### PR TITLE
Allow specifying pthread CPU affinity

### DIFF
--- a/core/thread/inc/TPosixThread.h
+++ b/core/thread/inc/TPosixThread.h
@@ -40,7 +40,7 @@ public:
 
    virtual Int_t  Join(TThread *th, void **ret);
    virtual Long_t SelfId();
-   virtual Int_t  Run(TThread *th);
+   virtual Int_t  Run(TThread *th, const int affinity = -1);
 
    virtual Int_t  Kill(TThread *th);
    virtual Int_t  SetCancelOff();

--- a/core/thread/inc/TThread.h
+++ b/core/thread/inc/TThread.h
@@ -122,7 +122,7 @@ public:
    virtual ~TThread();
 
    Int_t            Kill();
-   Int_t            Run(void *arg = nullptr);
+   Int_t            Run(void *arg = nullptr, const int affinity = -1);
    void             SetPriority(EPriority pri);
    void             Delete(Option_t *option="") { TObject::Delete(option); }
    EPriority        GetPriority() const { return fPriority; }

--- a/core/thread/inc/TThreadImp.h
+++ b/core/thread/inc/TThreadImp.h
@@ -35,7 +35,7 @@ public:
 
    virtual Int_t  Join(TThread *th, void **ret) = 0;
    virtual Long_t SelfId() = 0;
-   virtual Int_t  Run(TThread *th) = 0;
+   virtual Int_t  Run(TThread *th, const int affinity = -1) = 0;
 
    virtual Int_t  Kill(TThread *th) = 0;
    virtual Int_t  SetCancelOff() = 0;

--- a/core/thread/inc/TWin32Thread.h
+++ b/core/thread/inc/TWin32Thread.h
@@ -35,7 +35,7 @@ public:
 
    virtual Int_t  Join(TThread *th, void **ret);
    virtual Long_t SelfId();
-   virtual Int_t  Run(TThread *th);
+   virtual Int_t  Run(TThread *th, const int affinity = -1);
 
    virtual Int_t  Kill(TThread *th);
 

--- a/core/thread/src/TPosixThread.cxx
+++ b/core/thread/src/TPosixThread.cxx
@@ -39,7 +39,7 @@ Int_t TPosixThread::Run(TThread *th, const int affinity)
    if (affinity >= 0) {
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
-      CPU_SET(affinity,&cpuset);
+      CPU_SET(affinity, &cpuset);
       pthread_attr_setaffinity_np(attr, sizeof(cpu_set_t), &cpuset);
    }
 

--- a/core/thread/src/TPosixThread.cxx
+++ b/core/thread/src/TPosixThread.cxx
@@ -28,13 +28,20 @@ ClassImp(TPosixThread);
 /// Create a pthread. Returns 0 on success, otherwise an error number will
 /// be returned.
 
-Int_t TPosixThread::Run(TThread *th)
+Int_t TPosixThread::Run(TThread *th, const int affinity)
 {
    int det;
    pthread_t id;
    pthread_attr_t *attr = new pthread_attr_t;
 
    pthread_attr_init(attr);
+   
+   if (affinity >= 0) {
+      cpu_set_t cpuset;
+      CPU_ZERO(&cpuset);
+      CPU_SET(affinity,&cpuset);
+      pthread_attr_setaffinity_np(attr, sizeof(cpu_set_t), &cpuset);
+   }
 
    // Set detach state
    det = (th->fDetached) ? PTHREAD_CREATE_DETACHED : PTHREAD_CREATE_JOINABLE;

--- a/core/thread/src/TPosixThread.cxx
+++ b/core/thread/src/TPosixThread.cxx
@@ -20,6 +20,7 @@
 #include "TPosixThread.h"
 
 #include "TThread.h"
+#include <sched.h>
 
 ClassImp(TPosixThread);
 

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -562,7 +562,10 @@ Long_t TThread::SelfId()
 ////////////////////////////////////////////////////////////////////////////////
 /// Start the thread. This starts the static method TThread::Function()
 /// which calls the user function specified in the TThread ctor with
-/// the arg argument. Returns 0 on success, otherwise an error number will
+/// the arg argument. 
+/// If affinity is specified (>=0), a CPU affinity will be associated
+/// with the current thread.
+/// Returns 0 on success, otherwise an error number will
 /// be returned.
 
 Int_t TThread::Run(void *arg, const int affinity)

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -565,7 +565,7 @@ Long_t TThread::SelfId()
 /// the arg argument. Returns 0 on success, otherwise an error number will
 /// be returned.
 
-Int_t TThread::Run(void *arg)
+Int_t TThread::Run(void *arg, const int affinity)
 {
    if (arg) fThreadArg = arg;
 
@@ -573,7 +573,7 @@ Int_t TThread::Run(void *arg)
    ThreadInternalLock();
    SetComment("Run: MainMutex locked");
 
-   int iret = fgThreadImp->Run(this);
+   int iret = fgThreadImp->Run(this, affinity);
 
    fState = iret ? kInvalidState : kRunningState;
 

--- a/core/thread/src/TWin32Thread.cxx
+++ b/core/thread/src/TWin32Thread.cxx
@@ -30,7 +30,7 @@ ClassImp(TWin32Thread);
 /// Win32 threads -- spawn new thread (like pthread_create).
 /// Win32 has a thread handle in addition to the thread ID.
 
-Int_t TWin32Thread::Run(TThread *th)
+Int_t TWin32Thread::Run(TThread *th, const int affinity)
 {
    DWORD  dwThreadId;
    HANDLE hHandle = CreateThread(0, 0,

--- a/core/thread/src/TWin32Thread.cxx
+++ b/core/thread/src/TWin32Thread.cxx
@@ -36,6 +36,8 @@ Int_t TWin32Thread::Run(TThread *th, const int affinity)
    HANDLE hHandle = CreateThread(0, 0,
                                  (LPTHREAD_START_ROUTINE)&TThread::Function,
                                  th, 0, (DWORD*)&dwThreadId);
+   if (affinity >= 0)
+      Warning("Run", "Affinity setting not yet implemented on Win32");
    if (th->fDetached) {
       ::CloseHandle(hHandle);
       th->fHandle = 0L;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Allows associating a TThread run with a specific CPU on Linux

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)