### PR TITLE
[RF] New RooArgList/Set constructors for use in pyROOT

### DIFF
--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -56,6 +56,18 @@ public:
     }
   }
 
+  /// Construct a non-owning RooArgList from a vector of RooAbsArg pointers.
+  /// This constructor is mainly intended for pyROOT. With cppyy, a Python list
+  /// or tuple can be implicitly converted to an std::vector, and by enabling
+  /// implicit construction of a RooArgList from a std::vector, we indirectly
+  /// enable implicit conversion from a Python list/tuple to RooArgLists.
+  /// \param vec A vector with pointers to the arguments.
+  RooArgList(std::vector<RooAbsArg*> const& vec) {
+    for(auto const& arg : vec) {
+      add(*arg);
+    }
+  }
+
   virtual ~RooArgList();
   // Create a copy of an existing list. New variables cannot be added
   // to a copied list. The variables in the copied list are independent

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -73,6 +73,18 @@ public:
     }
   }
 
+  /// Construct a non-owning RooArgSet from a vector of RooAbsArg pointers.
+  /// This constructor is mainly intended for pyROOT. With cppyy, a Python list
+  /// or tuple can be implicitly converted to an std::vector, and by enabling
+  /// implicit construction of a RooArgSet from a std::vector, we indirectly
+  /// enable implicit conversion from a Python list/tuple to RooArgSets.
+  /// \param vec A vector with pointers to the arguments.
+  RooArgSet(std::vector<RooAbsArg*> const& vec) {
+    for(auto const& arg : vec) {
+      add(*arg);
+    }
+  }
+
   RooArgSet(const RooArgSet& other, const char *name="");
   /// Move constructor.
   RooArgSet(RooArgSet && other) : RooAbsCollection(std::move(other)) {}


### PR DESCRIPTION
Adding constructors that create a non-owning RooArgLists/Sets from a
vector of RooAbsArg pointers.

This is mainly intended for pyROOT. With cppyy, a Python list or tuple
can be implicitly converted to an `std::vector`, and by enabling implicit
construction of a RooArgList/Set from a `std::vector`, we indirectly
enable implicit conversion from a Python list/tuple to RooArgLists/Sets.