### PR TITLE
stop tgcommandplugin timer when remote check not needed

### DIFF
--- a/gui/gui/inc/TGCommandPlugin.h
+++ b/gui/gui/inc/TGCommandPlugin.h
@@ -51,7 +51,7 @@ public:
    void           SetHistAdd(Bool_t add = kTRUE);
 
    virtual Bool_t HandleTimer(TTimer *t);
-   void           StopTimer();
+   void           ToggleTimer(Bool_t on);
 
    ClassDef(TGCommandPlugin, 0) // Command (I/O redirection) plugin for the new ROOT Browser
 };

--- a/gui/gui/inc/TGCommandPlugin.h
+++ b/gui/gui/inc/TGCommandPlugin.h
@@ -51,6 +51,7 @@ public:
    void           SetHistAdd(Bool_t add = kTRUE);
 
    virtual Bool_t HandleTimer(TTimer *t);
+   void           StopTimer();
 
    ClassDef(TGCommandPlugin, 0) // Command (I/O redirection) plugin for the new ROOT Browser
 };

--- a/gui/gui/src/TGCommandPlugin.cxx
+++ b/gui/gui/src/TGCommandPlugin.cxx
@@ -277,6 +277,14 @@ Bool_t TGCommandPlugin::HandleTimer(TTimer *t)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Let user stop the internal timer when there is no need to check for remote.
+
+void TGCommandPlugin::StopTimer()
+{
+   fTimer->TurnOff();
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// The function SetHistAdd() is needed for a standalone TApplication to log the
 /// TGCommandPlugin commands into a ROOT history file.
 /// However, this function has no effect if the user does not explictly set on

--- a/gui/gui/src/TGCommandPlugin.cxx
+++ b/gui/gui/src/TGCommandPlugin.cxx
@@ -278,10 +278,14 @@ Bool_t TGCommandPlugin::HandleTimer(TTimer *t)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Let user stop the internal timer when there is no need to check for remote.
+/// or start it again later on if needed. (on=False to stop, on=True to start)
 
-void TGCommandPlugin::StopTimer()
+void TGCommandPlugin::ToggleTimer(Bool_t on)
 {
-   fTimer->TurnOff();
+   if (on)
+      fTimer->TurnOn();
+   else
+      fTimer->TurnOff();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Let user stop internal timer, for performance reasons, when there is a priori knowledge that there is no remote check needed.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/8269

