### PR TITLE
thread-safe gSystem list of timers

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -291,7 +291,7 @@ protected:
    Bool_t           fDone{kFALSE};              //True if eventloop should be finished
    Int_t            fLevel{0};                  //Level of nested eventloops
 
-   TSeqCollection  *fTimers{nullptr};           //List of timers
+   TList           *fTimers{nullptr};           //List of timers
    TSeqCollection  *fSignalHandler{nullptr};    //List of signal handlers
    TSeqCollection  *fFileHandler{nullptr};      //List of file handlers
    TSeqCollection  *fStdExceptionHandler{nullptr}; //List of std::exception handlers
@@ -389,7 +389,7 @@ public:
 
    //---- Time & Date
    virtual TTime           Now();
-   virtual TSeqCollection *GetListOfTimers() const { return fTimers; }
+   virtual TList          *GetListOfTimers() const { return fTimers; }
    virtual void            AddTimer(TTimer *t);
    virtual TTimer         *RemoveTimer(TTimer *t);
    virtual void            ResetTimer(TTimer *) { }

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -191,7 +191,8 @@ Bool_t TSystem::Init()
    fSignalHandler       = new TOrdCollection;
    fFileHandler         = new TOrdCollection;
    fStdExceptionHandler = new TOrdCollection;
-   fTimers              = new TOrdCollection;
+   fTimers              = new TList;
+   fTimers->UseRWLock();
 
    fBuildArch     = BUILD_ARCH;
    fBuildCompiler = COMPILER;
@@ -497,7 +498,7 @@ Long_t TSystem::NextTimeOut(Bool_t mode)
 {
    if (!fTimers) return -1;
 
-   TOrdCollectionIter it((TOrdCollection*)fTimers);
+   TListIter it(fTimers);
    TTimer *t, *to = nullptr;
    Long64_t tt, tnow = Now();
    Long_t   timeout = -1;

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -2945,7 +2945,7 @@ Bool_t TUnixSystem::DispatchTimers(Bool_t mode)
 
    fInsideNotify = kTRUE;
 
-   TOrdCollectionIter it((TOrdCollection*)fTimers);
+   TListIter it(fTimers);
    TTimer *t;
    Bool_t  timedout = kFALSE;
 

--- a/core/winnt/src/TWinNTSystem.cxx
+++ b/core/winnt/src/TWinNTSystem.cxx
@@ -4389,7 +4389,7 @@ Bool_t TWinNTSystem::DispatchTimers(Bool_t mode)
 
    fInsideNotify = kTRUE;
 
-   TOrdCollectionIter it((TOrdCollection*)fTimers);
+   TListIter it(fTimers);
    TTimer *t;
    Bool_t  timedout = kFALSE;
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Makes the list of timers thread-safe.
It attempts to fix some of the issues reported in https://github.com/root-project/root/issues/8365

This is a follow-up from: https://github.com/root-project/root/pull/8379#issuecomment-857765612

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

