### PR TITLE
Fix Mac compilation error

### DIFF
--- a/core/thread/src/TPosixThread.cxx
+++ b/core/thread/src/TPosixThread.cxx
@@ -20,7 +20,6 @@
 #include "TPosixThread.h"
 
 #include "TThread.h"
-#include <sched.h>
 
 ClassImp(TPosixThread);
 
@@ -38,10 +37,14 @@ Int_t TPosixThread::Run(TThread *th, const int affinity)
    pthread_attr_init(attr);
    
    if (affinity >= 0) {
+   #ifdef R__MACOSX
+      Warning("Run", "Affinity setting not yet implemented on MacOS");
+   #else
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
       CPU_SET(affinity, &cpuset);
       pthread_attr_setaffinity_np(attr, sizeof(cpu_set_t), &cpuset);
+   #endif
    }
 
    // Set detach state


### PR DESCRIPTION
cpu_set_t is not available on MacOS, only linux

# This Pull request:

## Changes or fixes:
compilation error introduced in https://github.com/root-project/root/pull/8557