### PR TITLE
Disable tutorials/legacy/thread/threadsh1.C in v6.24

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -310,7 +310,9 @@ set(extra_veto
   tree/h1chain.C
   http/*.C
   eve7/*.C
-  r/rootlogon.C)
+  r/rootlogon.C
+  legacy/thread/threadsh1.C # disabled on 6.22 and 6.24 due to randomic failures on some platforms
+)
 
 set(all_veto hsimple.C
              geom/geometry.C


### PR DESCRIPTION
It causes randomic failures in our nightlies, and being in legacy
code we are happy with disabling the tutorial altogether.

