### PR TITLE
[TTreeProcessorMT] Reduce the number of tasks generated 

### DIFF
--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -85,7 +85,6 @@ private:
    ROOT::TThreadedObject<ROOT::Internal::TTreeView> fTreeView{TNumSlots{ROOT::GetThreadPoolSize()}};
 
    std::vector<std::string> FindTreeNames();
-   static unsigned int fgMaxTasksPerFilePerWorker;
    static unsigned int fgTasksPerWorkerHint;
 
 public:

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -272,8 +272,6 @@ static std::vector<std::vector<Long64_t>> GetFriendEntries(const Internal::TreeU
 
 namespace ROOT {
 
-unsigned int TTreeProcessorMT::fgMaxTasksPerFilePerWorker = 24U;
-
 unsigned int TTreeProcessorMT::fgTasksPerWorkerHint = 24U;
 
 namespace Internal {

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -272,7 +272,7 @@ static std::vector<std::vector<Long64_t>> GetFriendEntries(const Internal::TreeU
 
 namespace ROOT {
 
-unsigned int TTreeProcessorMT::fgTasksPerWorkerHint = 24U;
+unsigned int TTreeProcessorMT::fgTasksPerWorkerHint = 10U;
 
 namespace Internal {
 

--- a/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
+++ b/tree/treeplayer/test/treeprocmt/treeprocessormt.cxx
@@ -294,26 +294,27 @@ TEST(TreeProcessorMT, LimitNTasks_CheckEntries)
       }
    };
 
-   const unsigned int nslots = std::min(4U, std::thread::hardware_concurrency());
+   //const unsigned int nslots = std::min(4U, std::thread::hardware_concurrency());
+   const unsigned int nslots = 1U;
    ROOT::EnableImplicitMT(nslots);
 
    ROOT::TTreeProcessorMT p(filename, treename);
    p.Process(f);
 
    if (nslots == 4) {
-      EXPECT_EQ(nTasks, 96U) << "Wrong number of tasks generated!\n";
-      EXPECT_EQ(nEntriesCountsMap[10], 65U) << "Wrong number of tasks with 10 clusters each!\n";
-      EXPECT_EQ(nEntriesCountsMap[11], 31U) << "Wrong number of tasks with 11 clusters each!\n";
+      EXPECT_EQ(nTasks, 40U) << "Wrong number of tasks generated!\n";
+      EXPECT_EQ(nEntriesCountsMap[24], 9U) << "Wrong number of tasks with 24 clusters each!\n";
+      EXPECT_EQ(nEntriesCountsMap[25], 31U) << "Wrong number of tasks with 25 clusters each!\n";
    }
    else if (nslots == 2) {
-      EXPECT_EQ(nTasks, 48U) << "Wrong number of tasks generated!\n";
-      EXPECT_EQ(nEntriesCountsMap[20], 17U) << "Wrong number of tasks with 20 clusters each!\n";
-      EXPECT_EQ(nEntriesCountsMap[21], 31U) << "Wrong number of tasks with 21 clusters each!\n";
+      EXPECT_EQ(nTasks, 20U) << "Wrong number of tasks generated!\n";
+      EXPECT_EQ(nEntriesCountsMap[49], 9U) << "Wrong number of tasks with 49 clusters each!\n";
+      EXPECT_EQ(nEntriesCountsMap[50], 11U) << "Wrong number of tasks with 50 clusters each!\n";
    }
    else if (nslots == 1) {
-      EXPECT_EQ(nTasks, 24U) << "Wrong number of tasks generated!\n";
-      EXPECT_EQ(nEntriesCountsMap[41], 17U) << "Wrong number of tasks with 41 clusters each!\n";
-      EXPECT_EQ(nEntriesCountsMap[42], 7U) << "Wrong number of tasks with 42 clusters each!\n";
+      EXPECT_EQ(nTasks, 10U) << "Wrong number of tasks generated!\n";
+      EXPECT_EQ(nEntriesCountsMap[99], 9U) << "Wrong number of tasks with 99 clusters each!\n";
+      EXPECT_EQ(nEntriesCountsMap[100], 1U) << "Wrong number of tasks with 100 clusters each!\n";
    }
 
    gSystem->Unlink(filename);


### PR DESCRIPTION
When performing multi-thread reads of ROOT files, we need to pick the number
of TBB tasks among which we will divide the dataset.

Our heuristic is "try to produce around `T = N/ntrees` tasks per tree per
worker thread": we don't know the number of clusters in each tree before
we open the files, so we don't know the total number of clusters upfront.
Instead we set a "desired value" of T tasks per tree and per thread, and
then when each thread opens a file it tries to make T tasks out of it (if
the file turns out to be too small, it might end up producing _less_ tasks than
desired. If we are processing `M > N` small files, we might end up producing
_more_ tasks per worker than N).

N is a free parameter, and it represents the desired total number of
tasks per worker. If N is too low, parallelism will be too coarse-grained
and we might get imbalance/tails with bad parallelization.
The higher N is, the more CPU time we spend in task setup/teardown.

Empirically, I believe we have set N too high (before this patch we set
it to 24). We often see runtime improvements in benchmarks by setting it
to a lower value, e.g. 10.
Again from experience, N == 10 should be a high-enough value to avoid
load imbalance between threads while it significantly reduces the amount
of tasks spawned (and the overhead that comes with it).
Therefore this patch sets N to 10.

More discussion:
- https://mattermost.web.cern.ch/root/pl/8ay6my4pwbru7kzqs97f8xcdre
- https://docs.oneapi.com/versions/latest/onetbb/tbb_userguide/Task-Based_Programming.html