### PR TITLE
Provide public access to `RAttrValue<T>` members

### DIFF
--- a/core/metacling/test/TClingDataMemberInfoTests.cxx
+++ b/core/metacling/test/TClingDataMemberInfoTests.cxx
@@ -234,7 +234,7 @@ TEST(TClingDataMemberInfo, issue8553)
    TClass *clBox = nullptr;
    ASSERT_TRUE(clBox = TClass::GetClass("ROOT::Experimental::RBox"));
    TDataMember *dmAttrBorder = nullptr;
-   ASSERT_TRUE(dmAttrBorder = clBox->GetDataMember("fAttrBorder"));
+   ASSERT_TRUE(dmAttrBorder = clBox->GetDataMember("border"));
    EXPECT_NE(dmAttrBorder->GetOffsetCint(), 0);
 }
 #endif

--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -31,6 +31,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RPalette.hxx
     ROOT/RPaletteDrawable.hxx
     ROOT/RDrawable.hxx
+    ROOT/ROnFrameDrawable.hxx
     ROOT/RDrawableRequest.hxx
     ROOT/RStyle.hxx
     ROOT/RPadDisplayItem.hxx

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -81,12 +81,14 @@
 
 #pragma link C++ class ROOT::Experimental::RAttrFill-;
 #pragma link C++ class ROOT::Experimental::RAttrLine-;
+#pragma link C++ class ROOT::Experimental::RAttrLineEnding-;
 #pragma link C++ class ROOT::Experimental::RAttrBorder-;
 #pragma link C++ class ROOT::Experimental::RAttrMarker-;
 #pragma link C++ class ROOT::Experimental::RAttrFont-;
 #pragma link C++ class ROOT::Experimental::RAttrText-;
 #pragma link C++ class ROOT::Experimental::RAttrAxisLabels-;
 #pragma link C++ class ROOT::Experimental::RAttrAxisTitle-;
+#pragma link C++ class ROOT::Experimental::RAttrAxisTicks-;
 #pragma link C++ class ROOT::Experimental::RAttrAxis-;
 #pragma link C++ class ROOT::Experimental::RAttrMargins-;
 

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -83,6 +83,7 @@
 #pragma link C++ class ROOT::Experimental::RAttrLine-;
 #pragma link C++ class ROOT::Experimental::RAttrBorder-;
 #pragma link C++ class ROOT::Experimental::RAttrMarker-;
+#pragma link C++ class ROOT::Experimental::RAttrFont-;
 #pragma link C++ class ROOT::Experimental::RAttrText-;
 #pragma link C++ class ROOT::Experimental::RAttrAxisLabels-;
 #pragma link C++ class ROOT::Experimental::RAttrAxisTitle-;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class ROOT::Experimental::RStyle::Block_t+;
 
 #pragma link C++ class ROOT::Experimental::RDrawable+;
+#pragma link C++ class ROOT::Experimental::ROnFrameDrawable+;
 #pragma link C++ class ROOT::Experimental::RDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RDrawableDisplayItem+;
 #pragma link C++ class ROOT::Experimental::RIndirectDisplayItem+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -92,10 +92,7 @@
 #pragma link C++ class ROOT::Experimental::RAttrAxis-;
 #pragma link C++ class ROOT::Experimental::RAttrMargins-;
 
-#pragma link C++ class ROOT::Experimental::RAxisDrawableBase+;
 #pragma link C++ class ROOT::Experimental::RAxisDrawable+;
-#pragma link C++ class ROOT::Experimental::RAxisLabelsDrawable+;
-
 #pragma link C++ class ROOT::Experimental::RPadBase+;
 #pragma link C++ class ROOT::Experimental::RPad+;
 #pragma link C++ class ROOT::Experimental::RCanvas+;

--- a/graf2d/gpadv7/inc/LinkDef.h
+++ b/graf2d/gpadv7/inc/LinkDef.h
@@ -84,6 +84,8 @@
 #pragma link C++ class ROOT::Experimental::RAttrBorder-;
 #pragma link C++ class ROOT::Experimental::RAttrMarker-;
 #pragma link C++ class ROOT::Experimental::RAttrText-;
+#pragma link C++ class ROOT::Experimental::RAttrAxisLabels-;
+#pragma link C++ class ROOT::Experimental::RAttrAxisTitle-;
 #pragma link C++ class ROOT::Experimental::RAttrAxis-;
 #pragma link C++ class ROOT::Experimental::RAttrMargins-;
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -19,6 +19,45 @@
 namespace ROOT {
 namespace Experimental {
 
+/** \class RAttrAxisLabels
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-02-20
+\brief Axis labels drawing attributes
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrAxisLabels : public RAttrText {
+   R__ATTR_CLASS_DERIVED(RAttrAxisLabels, "labels", RAttrText)
+
+   RAttrValue<RPadLength> offset{this, "offset", {}};      ///<! labels offset - relative to "default" position
+   RAttrValue<bool> center{this, "center", false};         ///<! center labels
+   RAttrValue<bool> hide{this, "hide", false};             ///<! hide labels
+};
+
+/** \class RAttrAxisTitle
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2020-02-20
+\brief Axis title and its drawing attributes
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrAxisTitle : public RAttrText {
+   R__ATTR_CLASS_DERIVED(RAttrAxisTitle, "title", RAttrText)
+
+   RAttrValue<std::string> value{this, "value", ""};            ///<! axis title value
+   RAttrValue<std::string> position{this, "position", "right"};   ///<! axis title position - left, right, center
+   RAttrValue<RPadLength> offset{this, "offset", {}};        ///<! axis title offset - relative to "default" position
+
+   RAttrAxisTitle& operator=(const std::string &_title) { value = _title; return *this; }
+
+   void SetLeft() { position = "left"; }
+   void SetCenter() { position = "center"; }
+   void SetRight() { position = "right"; }
+
+};
+
 /** \class RAttrAxis
 \ingroup GpadROOT7
 \author Sergey Linev <s.linev@gsi.de>
@@ -28,7 +67,6 @@ namespace Experimental {
 */
 
 class RAttrAxis : public RAttrAggregation {
-
    RAttrValue<double> fMin{this, "min", 0.};                             ///<! axis min
    RAttrValue<double> fMax{this, "max", 0.};                             ///<! axis max
    RAttrValue<double> fZoomMin{this, "zoommin", 0.};                     ///<! axis zoom min
@@ -45,18 +83,12 @@ class RAttrAxis : public RAttrAggregation {
    RAttrValue<RPadLength> fTicksSize{this, "ticks_size", 0.02_normal};   ///<! ticks size
    RAttrValue<RColor> fTicksColor{this, "ticks_color", RColor::kBlack};  ///<! ticks color
    RAttrValue<int> fTicksWidth{this, "ticks_width", 1};                  ///<! ticks width
-   RAttrValue<bool> fHideLabels{this, "hidelabels", false};              ///<! disable labels drawing
-   RAttrText fAttrLabels{this, "labels"};                                ///<! text attributes for labels
-   RAttrValue<RPadLength> fLabelsOffset{this, "labels_offset", {}};      ///<! axis labels offset - relative
-   RAttrValue<bool> fLabelsCenter{this, "labels_center", false};         ///<! center labels
-   RAttrText fAttrTitle{this, "title"};                                  ///<! axis title text attributes
-   RAttrValue<std::string> fTitle{this, "title", ""};                    ///<! axis title
-   RAttrValue<std::string> fTitlePos{this, "title_position", "right"};   ///<! axis title position - left, right, center
-   RAttrValue<RPadLength> fTitleOffset{this, "title_offset", {}};        ///<! axis title offset - relative
 
    R__ATTR_CLASS(RAttrAxis, "axis");
 
    RAttrLine line{this, "line"};                                    ///<! line attributes
+   RAttrAxisLabels labels{this, "labels"};                          ///<! labels attributes
+   RAttrAxisTitle title{this, "title"};                             ///<! title attributes
 
    RAttrAxis &SetMin(double min) { fMin = min; return *this; }
    RAttrAxis &SetMax(double max) { fMax = max; return *this; }
@@ -138,32 +170,8 @@ class RAttrAxis : public RAttrAggregation {
    RAttrAxis &SetTicksWidth(int width) { fTicksWidth = width; return *this; }
    int GetTicksWidth() const { return fTicksWidth; }
 
-   RAttrAxis &SetLabelsOffset(const RPadLength &len) { fLabelsOffset = len; return *this; }
-   RPadLength GetLabelsOffset() const { return fLabelsOffset; }
-
-   RAttrAxis &SetHideLabels(bool on = true) { fHideLabels = on; return *this; }
-   bool GetHideLabels() const { return fHideLabels; }
-
-   const RAttrText &AttrLabels() const { return fAttrLabels; }
-   RAttrText &AttrLabels() { return fAttrLabels; }
-
-   RAttrAxis &SetLabelsCenter(bool on = true) { fLabelsCenter = on; return *this; }
-   bool GetLabelsCenter() const { return fLabelsCenter; }
-
-   const RAttrText &AttrTitle() const { return fAttrTitle; }
-   RAttrText &AttrTitle() { return fAttrTitle; }
-
-   RAttrAxis &SetTitle(const std::string &title) { fTitle = title; return *this; }
-   std::string GetTitle() const { return fTitle; }
-
-   RAttrAxis &SetTitlePos(const std::string &pos) { fTitlePos = pos; return *this; }
-   RAttrAxis &SetTitleLeft() { return SetTitlePos("left"); }
-   RAttrAxis &SetTitleCenter() { return SetTitlePos("center"); }
-   RAttrAxis &SetTitleRight() { return SetTitlePos("right"); }
-   std::string GetTitlePos() const { return fTitlePos; }
-
-   RAttrAxis &SetTitleOffset(const RPadLength &len) { fTitleOffset = len; return *this; }
-   RPadLength GetTitleOffset() const { return fTitleOffset; }
+   RAttrAxis &SetTitle(const std::string &_title) { title.value = _title; return *this; }
+   std::string GetTitle() const { return title.value; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -28,7 +28,10 @@ namespace Experimental {
 */
 
 class RAttrAxisLabels : public RAttrText {
+
    R__ATTR_CLASS_DERIVED(RAttrAxisLabels, "labels", RAttrText)
+
+public:
 
    RAttrValue<RPadLength> offset{this, "offset", {}};      ///<! labels offset - relative to "default" position
    RAttrValue<bool> center{this, "center", false};         ///<! center labels
@@ -44,7 +47,10 @@ class RAttrAxisLabels : public RAttrText {
 */
 
 class RAttrAxisTitle : public RAttrText {
+
    R__ATTR_CLASS_DERIVED(RAttrAxisTitle, "title", RAttrText)
+
+public:
 
    RAttrValue<std::string> value{this, "value", ""};            ///<! axis title value
    RAttrValue<std::string> position{this, "position", "right"}; ///<! axis title position - left, right, center
@@ -66,7 +72,10 @@ class RAttrAxisTitle : public RAttrText {
 */
 
 class RAttrAxisTicks : public RAttrAggregation {
+
    R__ATTR_CLASS(RAttrAxisTicks, "ticks");
+
+public:
 
    RAttrValue<std::string> side{this, "side", "normal"};     ///<! ticks position - normal, invert, both
    RAttrValue<RPadLength> size{this, "size", 0.02_normal};   ///<! ticks size
@@ -88,7 +97,10 @@ class RAttrAxisTicks : public RAttrAggregation {
 */
 
 class RAttrAxis : public RAttrAggregation {
+
    R__ATTR_CLASS(RAttrAxis, "axis");
+
+public:
 
    RAttrLine line{this, "line"};                                    ///<! line attributes
    RAttrLineEnding ending{this, "ending"};                          ///<! ending attributes

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -109,20 +109,20 @@ public:
    RAttrAxisTicks ticks{this, "ticks"};                             ///<! ticks attributes
    RAttrValue<double> min{this, "min", 0.};                         ///<! axis min
    RAttrValue<double> max{this, "max", 0.};                         ///<! axis max
-   RAttrValue<double> zoommin{this, "zoommin", 0.};                 ///<! axis zoom min
-   RAttrValue<double> zoommax{this, "zoommax", 0.};                 ///<! axis zoom max
+   RAttrValue<double> zoomMin{this, "zoomMin", 0.};                 ///<! axis zoom min
+   RAttrValue<double> zoomMax{this, "zoomMax", 0.};                 ///<! axis zoom max
    RAttrValue<double> log{this, "log", 0};                          ///<! log scale, <1 off, 1 - base10, 2 - base 2, 2.71 - exp, 3, 4, ...
    RAttrValue<double> symlog{this, "symlog", 0};                    ///<! symlog scale constant, 0 - off
    RAttrValue<bool> reverse{this, "reverse", false};                ///<! reverse scale
    RAttrValue<bool> time{this, "time", false};                      ///<! time scale
-   RAttrValue<double> time_offset{this, "time_offset", 0};          ///<! time offset to display
-   RAttrValue<std::string> time_format{this, "time_format", ""};    ///<! time format
+   RAttrValue<double> timeOffset{this, "timeOffset", 0};            ///<! offset for time axis values
+   RAttrValue<std::string> timeFormat{this, "timeFormat", ""};      ///<! time format
 
    RAttrAxis &SetMinMax(double _min, double _max) { min = _min; max = _max; return *this; }
    RAttrAxis &ClearMinMax() { min.Clear(); max.Clear(); return *this; }
 
-   RAttrAxis &SetZoom(double _zoommin, double _zoommax) { zoommin = _zoommin; zoommax = _zoommax; return *this; }
-   RAttrAxis &ClearZoom() { zoommin.Clear(); zoommax.Clear(); return *this; }
+   RAttrAxis &SetZoom(double _zoomMin, double _zoomMax) { zoomMin = _zoomMin; zoomMax = _zoomMax; return *this; }
+   RAttrAxis &ClearZoom() { zoomMin.Clear(); zoomMax.Clear(); return *this; }
 
    bool IsLogScale() const { return this->log > 0.999999; }
    bool IsLog10() const { auto l = this->log; return (std::fabs(l-1.) < 1e-6) || (std::fabs(l-10.) < 1e-6); }
@@ -132,15 +132,22 @@ public:
    RAttrAxis &SetTimeDisplay(const std::string &fmt = "", double offset = -1)
    {
       this->time = true;
-      if (!fmt.empty()) time_format = fmt;
-      if (offset >= 0) time_offset = offset;
+      if (!fmt.empty())
+         timeFormat = fmt;
+      else
+         timeFormat.Clear();
+      if (offset >= 0)
+         timeOffset = offset;
+      else
+         timeOffset.Clear();
       return *this;
    }
+
    void ClearTimeDisplay()
    {
       this->time.Clear();
-      time_offset.Clear();
-      time_format.Clear();
+      timeOffset.Clear();
+      timeFormat.Clear();
    }
 
    RAttrAxis &SetTitle(const std::string &_title) { title.value = _title; return *this; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -39,7 +39,6 @@ class RAttrAxis : public RAttrAggregation {
    RAttrValue<bool> fTimeDisplay{this, "time", false};                   ///<! time display
    RAttrValue<double> fTimeOffset{this, "time_offset", 0};               ///<! time offset to display
    RAttrValue<std::string> fTimeFormat{this, "time_format", ""};         ///<! time format
-   RAttrLine fAttrLine{this, "line"};                                    ///<! line attributes
    RAttrValue<std::string> fEndingStyle{this, "ending_style", ""};       ///<! axis ending style - none, arrow, circle
    RAttrValue<RPadLength> fEndingSize{this, "ending_size", 0.02_normal}; ///<! axis ending size
    RAttrValue<std::string> fTicksSide{this, "ticks_side", "normal"};     ///<! ticks position - normal, invert, both
@@ -56,6 +55,8 @@ class RAttrAxis : public RAttrAggregation {
    RAttrValue<RPadLength> fTitleOffset{this, "title_offset", {}};        ///<! axis title offset - relative
 
    R__ATTR_CLASS(RAttrAxis, "axis");
+
+   RAttrLine line{this, "line"};                                    ///<! line attributes
 
    RAttrAxis &SetMin(double min) { fMin = min; return *this; }
    RAttrAxis &SetMax(double max) { fMax = max; return *this; }
@@ -113,9 +114,6 @@ class RAttrAxis : public RAttrAggregation {
       fTimeOffset.Clear();
       fTimeFormat.Clear();
    }
-
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
 
    RAttrAxis &SetEndingSize(const RPadLength &sz) { fEndingSize = sz; return *this; }
    RPadLength GetEndingSize() const { return fEndingSize; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -47,8 +47,8 @@ class RAttrAxisTitle : public RAttrText {
    R__ATTR_CLASS_DERIVED(RAttrAxisTitle, "title", RAttrText)
 
    RAttrValue<std::string> value{this, "value", ""};            ///<! axis title value
-   RAttrValue<std::string> position{this, "position", "right"};   ///<! axis title position - left, right, center
-   RAttrValue<RPadLength> offset{this, "offset", {}};        ///<! axis title offset - relative to "default" position
+   RAttrValue<std::string> position{this, "position", "right"}; ///<! axis title position - left, right, center
+   RAttrValue<RPadLength> offset{this, "offset", {}};           ///<! axis title offset - relative to "default" position
 
    RAttrAxisTitle& operator=(const std::string &_title) { value = _title; return *this; }
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx
@@ -22,7 +22,7 @@ namespace Experimental {
 /** \class RAttrAxisLabels
 \ingroup GpadROOT7
 \author Sergey Linev <s.linev@gsi.de>
-\date 2020-02-20
+\date 2021-06-28
 \brief Axis labels drawing attributes
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
@@ -38,7 +38,7 @@ class RAttrAxisLabels : public RAttrText {
 /** \class RAttrAxisTitle
 \ingroup GpadROOT7
 \author Sergey Linev <s.linev@gsi.de>
-\date 2020-02-20
+\date 2021-06-28
 \brief Axis title and its drawing attributes
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
@@ -55,6 +55,27 @@ class RAttrAxisTitle : public RAttrText {
    void SetLeft() { position = "left"; }
    void SetCenter() { position = "center"; }
    void SetRight() { position = "right"; }
+};
+
+/** \class RAttrAxisTicks
+\ingroup GpadROOT7
+\author Sergey Linev <s.linev@gsi.de>
+\date 2021-06-28
+\brief Axis ticks attributes
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrAxisTicks : public RAttrAggregation {
+   R__ATTR_CLASS(RAttrAxisTicks, "ticks");
+
+   RAttrValue<std::string> side{this, "side", "normal"};     ///<! ticks position - normal, invert, both
+   RAttrValue<RPadLength> size{this, "size", 0.02_normal};   ///<! ticks size
+   RAttrValue<RColor> color{this, "color", RColor::kBlack};  ///<! ticks color
+   RAttrValue<int> width{this, "width", 1};                  ///<! ticks width
+
+   void SetNormal() { side = "normal"; }
+   void SetInvert() { side = "invert"; }
+   void SetBoth() { side = "both"; }
 
 };
 
@@ -67,108 +88,48 @@ class RAttrAxisTitle : public RAttrText {
 */
 
 class RAttrAxis : public RAttrAggregation {
-   RAttrValue<double> fMin{this, "min", 0.};                             ///<! axis min
-   RAttrValue<double> fMax{this, "max", 0.};                             ///<! axis max
-   RAttrValue<double> fZoomMin{this, "zoommin", 0.};                     ///<! axis zoom min
-   RAttrValue<double> fZoomMax{this, "zoommax", 0.};                     ///<! axis zoom max
-   RAttrValue<double> fLog{this, "log", 0};                              ///<! log scale, <1 off, 1 - base10, 2 - base 2, 2.71 - exp, 3, 4, ...
-   RAttrValue<double> fSymlog{this, "symlog", 0};                        ///<! symlog scale constant, 0 - off
-   RAttrValue<bool> fReverse{this, "reverse", false};                    ///<! reverse scale
-   RAttrValue<bool> fTimeDisplay{this, "time", false};                   ///<! time display
-   RAttrValue<double> fTimeOffset{this, "time_offset", 0};               ///<! time offset to display
-   RAttrValue<std::string> fTimeFormat{this, "time_format", ""};         ///<! time format
-   RAttrValue<std::string> fEndingStyle{this, "ending_style", ""};       ///<! axis ending style - none, arrow, circle
-   RAttrValue<RPadLength> fEndingSize{this, "ending_size", 0.02_normal}; ///<! axis ending size
-   RAttrValue<std::string> fTicksSide{this, "ticks_side", "normal"};     ///<! ticks position - normal, invert, both
-   RAttrValue<RPadLength> fTicksSize{this, "ticks_size", 0.02_normal};   ///<! ticks size
-   RAttrValue<RColor> fTicksColor{this, "ticks_color", RColor::kBlack};  ///<! ticks color
-   RAttrValue<int> fTicksWidth{this, "ticks_width", 1};                  ///<! ticks width
-
    R__ATTR_CLASS(RAttrAxis, "axis");
 
    RAttrLine line{this, "line"};                                    ///<! line attributes
+   RAttrLineEnding ending{this, "ending"};                          ///<! ending attributes
    RAttrAxisLabels labels{this, "labels"};                          ///<! labels attributes
    RAttrAxisTitle title{this, "title"};                             ///<! title attributes
+   RAttrAxisTicks ticks{this, "ticks"};                             ///<! ticks attributes
+   RAttrValue<double> min{this, "min", 0.};                         ///<! axis min
+   RAttrValue<double> max{this, "max", 0.};                         ///<! axis max
+   RAttrValue<double> zoommin{this, "zoommin", 0.};                 ///<! axis zoom min
+   RAttrValue<double> zoommax{this, "zoommax", 0.};                 ///<! axis zoom max
+   RAttrValue<double> log{this, "log", 0};                          ///<! log scale, <1 off, 1 - base10, 2 - base 2, 2.71 - exp, 3, 4, ...
+   RAttrValue<double> symlog{this, "symlog", 0};                    ///<! symlog scale constant, 0 - off
+   RAttrValue<bool> reverse{this, "reverse", false};                ///<! reverse scale
+   RAttrValue<bool> time{this, "time", false};                      ///<! time scale
+   RAttrValue<double> time_offset{this, "time_offset", 0};          ///<! time offset to display
+   RAttrValue<std::string> time_format{this, "time_format", ""};    ///<! time format
 
-   RAttrAxis &SetMin(double min) { fMin = min; return *this; }
-   RAttrAxis &SetMax(double max) { fMax = max; return *this; }
-   double GetMin() const { return fMin; }
-   double GetMax() const { return fMax; }
-   bool HasMin() const { return fMin.Has(); }
-   bool HasMax() const { return fMax.Has(); }
+   RAttrAxis &SetMinMax(double _min, double _max) { min = _min; max = _max; return *this; }
+   RAttrAxis &ClearMinMax() { min.Clear(); max.Clear(); return *this; }
 
-   RAttrAxis &SetMinMax(double min, double max) { SetMin(min); SetMax(max); return *this; }
-   void ClearMinMax() { fMin.Clear(); fMax.Clear(); }
+   RAttrAxis &SetZoom(double _zoommin, double _zoommax) { zoommin = _zoommin; zoommax = _zoommax; return *this; }
+   RAttrAxis &ClearZoom() { zoommin.Clear(); zoommax.Clear(); return *this; }
 
-   RAttrAxis &SetZoomMin(double min) { fZoomMin = min; return *this; }
-   RAttrAxis &SetZoomMax(double max) { fZoomMax = max; return *this; }
-   double GetZoomMin() const { return fZoomMin; }
-   double GetZoomMax() const { return fZoomMax; }
-   bool HasZoomMin() const { return fZoomMin.Has(); }
-   bool HasZoomMax() const { return fZoomMax.Has(); }
-
-   RAttrAxis &SetZoom(double min, double max) { SetZoomMin(min); SetZoomMax(max); return *this; }
-   void ClearZoom() { fZoomMin.Clear(); fZoomMax.Clear(); }
-
-   RAttrAxis &SetLog(double base = 10) { fLog = (base < 1) ? 0 : base; return *this; }
-   double GetLog() const { return fLog; }
-   bool IsLogScale() const { return GetLog() > 0.999999; }
-   bool IsLog10() const { auto l = GetLog(); return (std::fabs(l-1.) < 1e-6) || (std::fabs(l-10.) < 1e-6); }
-   bool IsLog2() const { return std::fabs(GetLog() - 2.) < 1e-6; }
-   bool IsLn() const { return std::fabs(GetLog() - 2.71828) < 0.1; }
-
-   RAttrAxis &SetSymlog(double const_value = 0.01)
-   {
-      if (const_value <= 0.)
-         fSymlog.Clear();
-      else
-         fSymlog = const_value;
-      return *this;
-   }
-   double GetSymlog() const { return fSymlog; }
-   bool HasSymlog() const { return fSymlog.Has(); }
-   void ClearSymlog() { fSymlog.Clear(); }
-
-   RAttrAxis &SetReverse(bool on = true) { fReverse = on; return *this; }
-   bool GetReverse() const { return fReverse; }
+   bool IsLogScale() const { return this->log > 0.999999; }
+   bool IsLog10() const { auto l = this->log; return (std::fabs(l-1.) < 1e-6) || (std::fabs(l-10.) < 1e-6); }
+   bool IsLog2() const { return std::fabs(this->log - 2.) < 1e-6; }
+   bool IsLn() const { return std::fabs(this->log - 2.71828) < 0.1; }
 
    RAttrAxis &SetTimeDisplay(const std::string &fmt = "", double offset = -1)
    {
-      fTimeDisplay = true;
-      if (!fmt.empty()) fTimeFormat = fmt;
-      if (offset >= 0) fTimeOffset = offset;
+      this->time = true;
+      if (!fmt.empty()) time_format = fmt;
+      if (offset >= 0) time_offset = offset;
       return *this;
    }
-   bool GetTimeDisplay() const { return fTimeDisplay; }
    void ClearTimeDisplay()
    {
-      fTimeDisplay.Clear();
-      fTimeOffset.Clear();
-      fTimeFormat.Clear();
+      this->time.Clear();
+      time_offset.Clear();
+      time_format.Clear();
    }
-
-   RAttrAxis &SetEndingSize(const RPadLength &sz) { fEndingSize = sz; return *this; }
-   RPadLength GetEndingSize() const { return fEndingSize; }
-
-   RAttrAxis &SetEndingStyle(const std::string &st) { fEndingStyle = st; return *this; }
-   RAttrAxis &SetEndingArrow() { return SetEndingStyle("arrow"); }
-   RAttrAxis &SetEndingCircle() { return SetEndingStyle("cicrle"); }
-   std::string GetEndingStyle() const { return fEndingStyle; }
-
-   RAttrAxis &SetTicksSize(const RPadLength &sz) { fTicksSize = sz; return *this; }
-   RPadLength GetTicksSize() const { return fTicksSize; }
-
-   RAttrAxis &SetTicksSide(const std::string &side) { fTicksSide = side; return *this; }
-   RAttrAxis &SetTicksNormal() { return SetTicksSide("normal"); }
-   RAttrAxis &SetTicksInvert() { return SetTicksSide("invert"); }
-   RAttrAxis &SetTicksBoth() { return SetTicksSide("both"); }
-   std::string GetTicksSide() const { return fTicksSide; }
-
-   RAttrAxis &SetTicksColor(const RColor &color) { fTicksColor = color; return *this; }
-   RColor GetTicksColor() const { return fTicksColor; }
-
-   RAttrAxis &SetTicksWidth(int width) { fTicksWidth = width; return *this; }
-   int GetTicksWidth() const { return fTicksWidth; }
 
    RAttrAxis &SetTitle(const std::string &_title) { title.value = _title; return *this; }
    std::string GetTitle() const { return title.value; }

--- a/graf2d/gpadv7/inc/ROOT/RAttrBorder.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBorder.hxx
@@ -25,18 +25,11 @@ namespace Experimental {
 
 class RAttrBorder : public RAttrLine {
 
-   RAttrValue<int>     fRx{this, "rx", 0};              ///<! rounding on x coordinate, px
-   RAttrValue<int>     fRy{this, "ry", 0};              ///<! rounding on y coordinate, px
-
    R__ATTR_CLASS_DERIVED(RAttrBorder, "border", RAttrLine)
 
-   ///The rounding on x, px
-   RAttrBorder &SetRx(int rx) { fRx = rx; return *this; }
-   int GetRx() const { return fRx; }
+   RAttrValue<int>     rx{this, "rx", 0};              ///<! rounding on x coordinate, px
+   RAttrValue<int>     ry{this, "ry", 0};              ///<! rounding on y coordinate, px
 
-   ///The rounding on x, px
-   RAttrBorder &SetRy(int ry) { fRy = ry; return *this; }
-   int GetRy() const { return fRy; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrBorder.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrBorder.hxx
@@ -27,6 +27,8 @@ class RAttrBorder : public RAttrLine {
 
    R__ATTR_CLASS_DERIVED(RAttrBorder, "border", RAttrLine)
 
+public:
+
    RAttrValue<int>     rx{this, "rx", 0};              ///<! rounding on x coordinate, px
    RAttrValue<int>     ry{this, "ry", 0};              ///<! rounding on y coordinate, px
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -27,6 +27,8 @@ class RAttrFill : public RAttrAggregation {
 
    R__ATTR_CLASS(RAttrFill, "fill");
 
+public:
+
    RAttrValue<RColor>  color{this, "color", RColor::kBlack};  ///<! fill color
    RAttrValue<int>     style{this, "style", 1};               ///<! fill style
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -25,19 +25,16 @@ namespace Experimental {
 
 class RAttrFill : public RAttrAggregation {
 
-   RAttrValue<RColor> fColor{this, "color", RColor::kBlack};  ///<! fill color
-   RAttrValue<int>    fStyle{this, "style", 1};               ///<! fill style
-
    R__ATTR_CLASS(RAttrFill, "fill");
 
-   ///The fill style
-   RAttrFill &SetStyle(int style) { fStyle = style; return *this; }
-   int GetStyle() const { return fStyle; }
+   RAttrValue<RColor>  color{this, "color", RColor::kBlack};  ///<! fill color
+   RAttrValue<int>     style{this, "style", 1};               ///<! fill style
 
-   ///The fill color
-   RAttrFill &SetColor(const RColor &color) { fColor = color; return *this; }
-   RColor GetColor() const { return fColor; }
-
+   RAttrFill(RColor _color, int _style) : RAttrFill()
+   {
+      color = _color;
+      style = _style;
+   }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -40,6 +40,27 @@ class RAttrLine : public RAttrAggregation {
 
 };
 
+
+/** \class RAttrLineEnding
+\ingroup GpadROOT7
+\author  Sergey Linev <s.linev@gsi.de>
+\date 2021-06-28
+\brief Attributes for line ending
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrLineEnding : public RAttrAggregation {
+
+   R__ATTR_CLASS(RAttrLineEnding, "ending");
+
+   RAttrValue<std::string> style{this, "style", ""};       ///<! axis ending style - none, arrow, circle
+   RAttrValue<RPadLength> size{this, "size", 0.02_normal}; ///<! ending size
+
+   void SetArrow() { style = "arrow"; }
+   void SetCircle() { style = "cicrle"; }
+};
+
+
 } // namespace Experimental
 } // namespace ROOT
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -27,6 +27,8 @@ class RAttrLine : public RAttrAggregation {
 
    R__ATTR_CLASS(RAttrLine, "line");
 
+public:
+
    RAttrValue<RColor>  color{this, "color", RColor::kBlack}; ///<! line color
    RAttrValue<double>  width{this, "width", 1.};             ///<! line width
    RAttrValue<int>     style{this, "style", 1};              ///<! line style
@@ -52,6 +54,8 @@ class RAttrLine : public RAttrAggregation {
 class RAttrLineEnding : public RAttrAggregation {
 
    R__ATTR_CLASS(RAttrLineEnding, "ending");
+
+public:
 
    RAttrValue<std::string> style{this, "style", ""};       ///<! axis ending style - none, arrow, circle
    RAttrValue<RPadLength> size{this, "size", 0.02_normal}; ///<! ending size

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -17,7 +17,7 @@ namespace Experimental {
 
 /** \class RAttrLine
 \ingroup GpadROOT7
-\author Axel Naumann <axel@cern.ch>
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
 \date 2018-10-12
 \brief Drawing line attributes for different objects.
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
@@ -25,23 +25,18 @@ namespace Experimental {
 
 class RAttrLine : public RAttrAggregation {
 
-   RAttrValue<RColor>  fColor{this, "color", RColor::kBlack}; ///<! line color
-   RAttrValue<double>  fWidth{this, "width", 1.};             ///<! line width
-   RAttrValue<int>     fStyle{this, "style", 1};              ///<! line style
-
    R__ATTR_CLASS(RAttrLine, "line");
 
-   ///The width of the line.
-   RAttrLine &SetWidth(double width) { fWidth = width; return *this; }
-   double GetWidth() const { return fWidth; }
+   RAttrValue<RColor>  color{this, "color", RColor::kBlack}; ///<! line color
+   RAttrValue<double>  width{this, "width", 1.};             ///<! line width
+   RAttrValue<int>     style{this, "style", 1};              ///<! line style
 
-   ///The style of the line.
-   RAttrLine &SetStyle(int style) { fStyle = style; return *this; }
-   int GetStyle() const { return fStyle; }
-
-   ///The color of the line.
-   RAttrLine &SetColor(const RColor &color) { fColor = color; return *this; }
-   RColor GetColor() const { return fColor; }
+   RAttrLine(const RColor &_color, double _width, int _style) : RAttrLine()
+   {
+      color = _color;
+      width = _width;
+      style = _style;
+   }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -26,31 +26,21 @@ namespace Experimental {
 
 class RAttrMargins : public RAttrAggregation {
 
-   RAttrValue<RPadLength>   fLeft{this, "left", 0._normal};
-   RAttrValue<RPadLength>   fRight{this, "right", 0._normal};
-   RAttrValue<RPadLength>   fTop{this, "top", 0._normal};
-   RAttrValue<RPadLength>   fBottom{this, "bottom", 0._normal};
-   RAttrValue<RPadLength>   fAll{this, "all", 0._normal};
-
    R__ATTR_CLASS(RAttrMargins, "margins");
 
-public:
+   RAttrValue<RPadLength> left{this, "left", 0._normal};     ///<! left margin
+   RAttrValue<RPadLength> right{this, "right", 0._normal};   ///<! right margin
+   RAttrValue<RPadLength> top{this, "top", 0._normal};       ///<! top margin
+   RAttrValue<RPadLength> bottom{this, "bottom", 0._normal}; ///<! bottom margin
 
-   RAttrMargins &SetLeft(const RPadLength &len) { fLeft = len; return *this; }
-   RPadLength GetLeft() const { return fLeft; }
-
-   RAttrMargins &SetRight(const RPadLength &len) { fRight = len; return *this; }
-   RPadLength GetRight() const { return fRight; }
-
-   RAttrMargins &SetTop(const RPadLength &len) { fTop = len; return *this; }
-   RPadLength GetTop() const { return fTop; }
-
-   RAttrMargins &SetBottom(const RPadLength &len) { fBottom = len; return *this; }
-   RPadLength GetBottom() const { return fBottom; }
-
-   RAttrMargins &SetAll(const RPadLength &len) { fAll = len; return *this; }
-   RPadLength GetAll() const { return fAll; }
-
+   RAttrMargins &operator=(const RPadLength &len)
+   {
+      left = len;
+      right = len;
+      top = len;
+      bottom = len;
+      return *this;
+   }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMargins.hxx
@@ -28,6 +28,8 @@ class RAttrMargins : public RAttrAggregation {
 
    R__ATTR_CLASS(RAttrMargins, "margins");
 
+public:
+
    RAttrValue<RPadLength> left{this, "left", 0._normal};     ///<! left margin
    RAttrValue<RPadLength> right{this, "right", 0._normal};   ///<! right margin
    RAttrValue<RPadLength> top{this, "top", 0._normal};       ///<! top margin

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -68,6 +68,8 @@ class RAttrMarker : public RAttrAggregation {
       kFourSquaresPlus = 49
    };
 
+public:
+
    RAttrValue<RColor> color{this, "color", RColor::kBlack}; ///<! marker color
    RAttrValue<double> size{this, "size", 1.};               ///<! marker size
    RAttrValue<int> style{this, "style", 1};                 ///<! marker style

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -25,10 +25,6 @@ namespace Experimental {
 
 class RAttrMarker : public RAttrAggregation {
 
-   RAttrValue<RColor>   fColor{this, "color", RColor::kBlack};  ///<! marker color
-   RAttrValue<double>   fSize{this, "size", 1.};                ///<! marker size
-   RAttrValue<int>      fStyle{this, "style", 1};               ///<! marker style
-
    R__ATTR_CLASS(RAttrMarker, "marker");
 
    enum EStyle {
@@ -72,16 +68,16 @@ class RAttrMarker : public RAttrAggregation {
       kFourSquaresPlus = 49
    };
 
-   RAttrMarker &SetColor(const RColor &color) { fColor = color; return *this; }
-   RColor GetColor() const { return fColor; }
+   RAttrValue<RColor> color{this, "color", RColor::kBlack}; ///<! marker color
+   RAttrValue<double> size{this, "size", 1.};               ///<! marker size
+   RAttrValue<int> style{this, "style", 1};                 ///<! marker style
 
-   /// The size of the marker.
-   RAttrMarker &SetSize(double size) { fSize = size; return *this; }
-   double GetSize() const { return fSize; }
-
-   /// The style of the marker.
-   RAttrMarker &SetStyle(int style) { fStyle = style; return *this; }
-   int GetStyle() const { return fStyle; }
+   RAttrMarker(const RColor &_color, double _size, int _style) : RAttrMarker()
+   {
+      color = _color;
+      size = _size;
+      style = _style;
+   }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -28,6 +28,8 @@ class RAttrFont : public RAttrAggregation {
 
    R__ATTR_CLASS(RAttrFont, "font");
 
+public:
+
    RAttrValue<std::string> family{this, "family"};  ///<! font family, corresponds to css font-familty attribute
    RAttrValue<std::string> style{this, "style"};    ///<! font style, corresponds to css font-style attribute
    RAttrValue<std::string> weight{this, "weight"};  ///<! font weight, corresponds to css font-weight attribute
@@ -72,14 +74,14 @@ class RAttrText : public RAttrAggregation {
 
    R__ATTR_CLASS(RAttrText, "text");
 
+public:
+
    RAttrValue<RColor> color{this, "color", RColor::kBlack};  ///<! text color
    RAttrValue<double> size{this, "size", 12.};               ///<! text size
    RAttrValue<double> angle{this, "angle", 0.};              ///<! text angle
    RAttrValue<int> align{this, "align", 22};                 ///<! text align
    RAttrFont font{this, "font"};                             ///<! text font
 };
-
-
 
 } // namespace Experimental
 } // namespace ROOT

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -15,6 +15,51 @@
 namespace ROOT {
 namespace Experimental {
 
+
+/** \class RAttrFont
+\ingroup GpadROOT7
+\brief A font attributes, used together with text attributes
+\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
+\date 2021-06-28
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrFont : public RAttrAggregation {
+
+   R__ATTR_CLASS(RAttrFont, "font");
+
+   RAttrValue<std::string> family{this, "family"};  ///<! font family, corresponds to css font-familty attribute
+   RAttrValue<std::string> style{this, "style"};    ///<! font style, corresponds to css font-style attribute
+   RAttrValue<std::string> weight{this, "weight"};  ///<! font weight, corresponds to css font-weight attribute
+
+   ///Set text font by id as usually handled in the ROOT (without precision), number should be between 1 and 15
+   RAttrFont &SetFont(int font)
+   {
+      switch(font) {
+      case 1: family = "Times New Roman"; style = "italic"; break;
+      case 2: family = "Times New Roman"; weight = "bold"; break;
+      case 3: family = "Times New Roman"; style = "italic"; weight = "bold"; break;
+      case 4: family = "Arial"; break;
+      case 5: family = "Arial"; style = "oblique"; break;
+      case 6: family = "Arial"; weight = "bold"; break;
+      case 7: family = "Arial"; style = "oblique"; weight = "bold"; break;
+      case 8: family = "Courier New"; break;
+      case 9: family = "Courier New"; style = "oblique"; break;
+      case 10: family = "Courier New"; weight = "bold"; break;
+      case 11: family = "Courier New"; style = "oblique"; weight = "bold"; break;
+      case 12: family = "Symbol"; break;
+      case 13: family = "Times New Roman"; break;
+      case 14: family = "Wingdings"; break;
+      case 15: family = "Symbol"; style = "italic"; break;
+      }
+      return *this;
+   }
+
+   RAttrFont &operator=(int id) { SetFont(id); return *this; }
+
+};
+
+
 /** \class RAttrText
 \ingroup GpadROOT7
 \brief A text attributes.
@@ -31,33 +76,7 @@ class RAttrText : public RAttrAggregation {
    RAttrValue<double> size{this, "size", 12.};               ///<! text size
    RAttrValue<double> angle{this, "angle", 0.};              ///<! text angle
    RAttrValue<int> align{this, "align", 22};                 ///<! text align
-   RAttrValue<std::string> font_family{this, "font_family"};  ///<! font family, corresponds to css font-familty attribute
-   RAttrValue<std::string> font_style{this, "font_style"};    ///<! font style, corresponds to css font-style attribute
-   RAttrValue<std::string> font_weight{this, "font_weight"};  ///<! font weight, corresponds to css font-weight attribute
-
-   ///Set text font by id as usually handled in the ROOT (without precision), number should be between 1 and 15
-   RAttrText &SetFont(int font)
-   {
-      switch(font) {
-      case 1: font_family = "Times New Roman"; font_style = "italic"; break;
-      case 2: font_family = "Times New Roman"; font_weight = "bold"; break;
-      case 3: font_family = "Times New Roman"; font_style = "italic"; font_weight = "bold"; break;
-      case 4: font_family = "Arial"; break;
-      case 5: font_family = "Arial"; font_style = "oblique"; break;
-      case 6: font_family = "Arial"; font_weight = "bold"; break;
-      case 7: font_family = "Arial"; font_style = "oblique"; font_weight = "bold"; break;
-      case 8: font_family = "Courier New"; break;
-      case 9: font_family = "Courier New"; font_style = "oblique"; break;
-      case 10: font_family = "Courier New"; font_weight = "bold"; break;
-      case 11: font_family = "Courier New"; font_style = "oblique"; font_weight = "bold"; break;
-      case 12: font_family = "Symbol"; break;
-      case 13: font_family = "Times New Roman"; break;
-      case 14: font_family = "Wingdings"; break;
-      case 15: font_family = "Symbol"; font_style = "italic"; break;
-      }
-      return *this;
-   }
-
+   RAttrFont font{this, "font"};                             ///<! text font
 };
 
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -25,93 +25,38 @@ namespace Experimental {
 
 class RAttrText : public RAttrAggregation {
 
-   RAttrValue<RColor> fColor{this, "color", RColor::kBlack};  ///<! text color
-   RAttrValue<double> fSize{this, "size", 12.};               ///<! text size
-   RAttrValue<double> fAngle{this, "angle", 0.};              ///<! text angle
-   RAttrValue<int> fAlign{this, "align", 22};                 ///<! text align
-   RAttrValue<std::string> fFontFamily{this, "font_family"};  ///<! font family, corresponds to css font-familty attribute
-   RAttrValue<std::string> fFontStyle{this, "font_style"};    ///<! font style, corresponds to css font-style attribute
-   RAttrValue<std::string> fFontWeight{this, "font_weight"};  ///<! font weight, corresponds to css font-weight attribute
-
    R__ATTR_CLASS(RAttrText, "text");
 
-   ///The text size
-   RAttrText &SetSize(double sz) { fSize = sz; return *this; }
-   double GetSize() const { return fSize; }
+   RAttrValue<RColor> color{this, "color", RColor::kBlack};  ///<! text color
+   RAttrValue<double> size{this, "size", 12.};               ///<! text size
+   RAttrValue<double> angle{this, "angle", 0.};              ///<! text angle
+   RAttrValue<int> align{this, "align", 22};                 ///<! text align
+   RAttrValue<std::string> font_family{this, "font_family"};  ///<! font family, corresponds to css font-familty attribute
+   RAttrValue<std::string> font_style{this, "font_style"};    ///<! font style, corresponds to css font-style attribute
+   RAttrValue<std::string> font_weight{this, "font_weight"};  ///<! font weight, corresponds to css font-weight attribute
 
-   ///The text angle
-   RAttrText &SetAngle(double angle) { fAngle = angle; return *this; }
-   double GetAngle() const { return fAngle; }
-
-   ///The text alignment
-   RAttrText &SetAlign(int align) { fAlign = align; return *this; }
-   int GetAlign() const { return fAlign; }
-
-   ///The color of the text.
-   RAttrText &SetColor(const RColor &color) { fColor = color; return *this; }
-   RColor GetColor() const { return fColor; }
-
-   ///Set text font by id as usually handled in the ROOT, set number between 1 and 15
+   ///Set text font by id as usually handled in the ROOT (without precision), number should be between 1 and 15
    RAttrText &SetFont(int font)
    {
-      std::string family, style, weight;
       switch(font) {
-      case 1: family = "Times New Roman"; style = "italic"; break;
-      case 2: family = "Times New Roman"; weight = "bold"; break;
-      case 3: family = "Times New Roman"; style = "italic"; weight = "bold"; break;
-      case 4: family = "Arial"; break;
-      case 5: family = "Arial"; style = "oblique"; break;
-      case 6: family = "Arial"; weight = "bold"; break;
-      case 7: family = "Arial"; style = "oblique"; weight = "bold"; break;
-      case 8: family = "Courier New"; break;
-      case 9: family = "Courier New"; style = "oblique"; break;
-      case 10: family = "Courier New"; weight = "bold"; break;
-      case 11: family = "Courier New"; style = "oblique"; weight = "bold"; break;
-      case 12: family = "Symbol"; break;
-      case 13: family = "Times New Roman"; break;
-      case 14: family = "Wingdings"; break;
-      case 15: family = "Symbol"; style = "italic"; break;
+      case 1: font_family = "Times New Roman"; font_style = "italic"; break;
+      case 2: font_family = "Times New Roman"; font_weight = "bold"; break;
+      case 3: font_family = "Times New Roman"; font_style = "italic"; font_weight = "bold"; break;
+      case 4: font_family = "Arial"; break;
+      case 5: font_family = "Arial"; font_style = "oblique"; break;
+      case 6: font_family = "Arial"; font_weight = "bold"; break;
+      case 7: font_family = "Arial"; font_style = "oblique"; font_weight = "bold"; break;
+      case 8: font_family = "Courier New"; break;
+      case 9: font_family = "Courier New"; font_style = "oblique"; break;
+      case 10: font_family = "Courier New"; font_weight = "bold"; break;
+      case 11: font_family = "Courier New"; font_style = "oblique"; font_weight = "bold"; break;
+      case 12: font_family = "Symbol"; break;
+      case 13: font_family = "Times New Roman"; break;
+      case 14: font_family = "Wingdings"; break;
+      case 15: font_family = "Symbol"; font_style = "italic"; break;
       }
-
-      SetFontFamily(family);
-      SetFontWeight(weight);
-      SetFontStyle(style);
-
       return *this;
    }
-
-   ///The text font-family attribute
-   RAttrText &SetFontFamily(const std::string &family)
-   {
-      if (family.empty())
-         fFontFamily.Clear();
-      else
-         fFontFamily = family;
-      return *this;
-   }
-   std::string GetFontFamily() const { return fFontFamily; }
-
-   ///The text font-style attribute
-   RAttrText &SetFontStyle(const std::string &style)
-   {
-      if (style.empty())
-         fFontStyle.Clear();
-      else
-         fFontStyle = style;
-      return *this;
-   }
-   std::string GetFontStyle() const { return fFontStyle; }
-
-   ///The text font-weight attribute
-   RAttrText &SetFontWeight(const std::string &weight)
-   {
-      if (weight.empty())
-         fFontWeight.Clear();
-      else
-         fFontWeight = weight;
-      return *this;
-   }
-   std::string GetFontWeight() const { return fFontWeight; }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrValue.hxx
@@ -103,6 +103,9 @@ public:
    friend bool operator==(const RAttrValue& lhs, const RAttrValue& rhs) { return lhs.Get() == rhs.Get(); }
    friend bool operator!=(const RAttrValue& lhs, const RAttrValue& rhs) { return lhs.Get() != rhs.Get(); }
 
+   friend bool operator==(const RAttrValue& lhs, const T& rhs) { return lhs.Get() == rhs; }
+   friend bool operator!=(const RAttrValue& lhs, const T& rhs) { return lhs.Get() != rhs; }
+
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAxisDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAxisDrawable.hxx
@@ -21,91 +21,45 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class RAxisDrawableBase
+/** \class RAxisDrawable
 \ingroup GrafROOT7
-\brief Axis base drawing - only attributes and position.
+\brief Axis drawing
 \author Sergey Linev <S.Linev@gsi.de>
 \date 2020-11-03
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RAxisDrawableBase : public RDrawable {
+class RAxisDrawable : public RDrawable {
 
    RPadPos fPos;                          ///< axis start point
    bool fVertical{false};                 ///< is vertical axis
    RPadLength fLength;                    ///< axis length
+   std::vector<std::string> fLabels;      ///< axis labels
+
 public:
 
    RAttrAxis axis{this, "axis"};     ///<! axis attributes
 
-   RAxisDrawableBase() : RDrawable("axis") {}
+   RAxisDrawable() : RDrawable("axis") {}
 
-   RAxisDrawableBase(const RPadPos &pos, bool vertical, const RPadLength &len) : RAxisDrawableBase()
+   RAxisDrawable(const RPadPos &pos, bool vertical, const RPadLength &len) : RAxisDrawable()
    {
       SetPos(pos);
       SetVertical(vertical);
       SetLength(len);
    }
 
-   RAxisDrawableBase &SetPos(const RPadPos &pos) { fPos = pos; return *this; }
-   RAxisDrawableBase &SetVertical(bool vertical = true) { fVertical = vertical; return *this; }
-   RAxisDrawableBase &SetLength(const RPadLength &len) { fLength = len; return *this; }
+   RAxisDrawable &SetPos(const RPadPos &pos) { fPos = pos; return *this; }
+   RAxisDrawable &SetVertical(bool vertical = true) { fVertical = vertical; return *this; }
+   RAxisDrawable &SetLength(const RPadLength &len) { fLength = len; return *this; }
+   RAxisDrawable &SetLabels(const std::vector<std::string> &lbls) { fLabels = lbls; return *this; }
 
    bool IsVertical() const { return fVertical; }
    const RPadPos& GetPos() const { return fPos; }
    const RPadLength& GetLength() const { return fLength; }
-};
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/** \class RAxisDrawable
-\ingroup GrafROOT7
-\brief Plain axis drawing.
-\author Sergey Linev <S.Linev@gsi.de>
-\date 2020-11-03
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-class RAxisDrawable : public RAxisDrawableBase {
-
-   double fMin{0}, fMax{100};      ///< axis minimum and maximum
-
-public:
-
-   RAxisDrawable() = default;
-
-   RAxisDrawable(const RPadPos &pos, bool vertical, const RPadLength &len) : RAxisDrawableBase(pos, vertical, len) {}
-
-   RAxisDrawable &SetMinMax(double min, double max) { fMin = min; fMax = max; return *this; }
-   double GetMin() const { return fMin; }
-   double GetMax() const { return fMax; }
-};
-
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/** \class RAxisLabelsDrawable
-\ingroup GrafROOT7
-\brief Labels axis drawing.
-\author Sergey Linev <S.Linev@gsi.de>
-\date 2020-11-03
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-class RAxisLabelsDrawable : public RAxisDrawableBase {
-
-   std::vector<std::string> fLabels;      ///< axis labels
-
-public:
-
-   RAxisLabelsDrawable() = default;
-
-   RAxisLabelsDrawable(const RPadPos &pos, bool vertical, const RPadLength &len) : RAxisDrawableBase(pos, vertical, len) {}
-
-   RAxisLabelsDrawable &SetLabels(const std::vector<std::string> &lbls) { fLabels = lbls; return *this; }
    const std::vector<std::string> &GetLabels() const { return fLabels; }
 };
+
 
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RAxisDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAxisDrawable.hxx
@@ -34,9 +34,9 @@ class RAxisDrawableBase : public RDrawable {
    RPadPos fPos;                          ///< axis start point
    bool fVertical{false};                 ///< is vertical axis
    RPadLength fLength;                    ///< axis length
-   RAttrAxis fAttrAxis{this, "axis"};     ///<! axis attributes
-
 public:
+
+   RAttrAxis axis{this, "axis"};     ///<! axis attributes
 
    RAxisDrawableBase() : RDrawable("axis") {}
 
@@ -54,9 +54,6 @@ public:
    bool IsVertical() const { return fVertical; }
    const RPadPos& GetPos() const { return fPos; }
    const RPadLength& GetLength() const { return fLength; }
-
-   const RAttrAxis &AttrAxis() const { return fAttrAxis; }
-   RAttrAxis &AttrAxis() { return fAttrAxis; }
 };
 
 

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -100,8 +100,7 @@ public:
 /** \class RDrawable
 \ingroup GpadROOT7
 \brief Base class for drawable entities: objects that can be painted on a `RPad`.
-\author Axel Naumann <axel@cern.ch>
-\author Sergey Linev <s.linev@gsi.de>
+\authors Axel Naumann <axel@cern.ch>, Sergey Linev <s.linev@gsi.de>
 \date 2015-08-07
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -145,7 +145,6 @@ public:
 
 private:
    RAttrMargins fAttrMargins{this, "margins"};    ///<! frame margins relative to pad
-   RAttrBorder fAttrBorder{this, "border"};       ///<! frame border attributes
    RAttrFill fAttrFill{this, "fill"};             ///<! frame fill attributes
    RAttrAxis fAttrX{this, "x"};                   ///<! drawing attributes for X axis
    RAttrAxis fAttrY{this, "y"};                   ///<! drawing attributes for Y axis
@@ -192,6 +191,9 @@ public:
       }
    };
 
+
+   RAttrBorder border{this, "border"};       ///<! frame border attributes
+
    RFrame(TRootIOCtor*) : RFrame() {}
 
    bool GetDrawAxes() const { return fDrawAxes; }
@@ -199,9 +201,6 @@ public:
 
    const RAttrMargins &AttrMargins() const { return fAttrMargins; }
    RAttrMargins &AttrMargins() { return fAttrMargins; }
-
-   const RAttrBorder &AttrBorder() const { return fAttrBorder; }
-   RAttrBorder &AttrBorder() { return fAttrBorder; }
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -144,7 +144,6 @@ public:
    };
 
 private:
-   RAttrMargins fAttrMargins{this, "margins"};    ///<! frame margins relative to pad
    RAttrValue<bool> fDrawAxes{this, "drawaxes", false}; ///<! draw axes by frame
    RAttrValue<bool> fGridX{this, "gridx", false}; ///<! show grid for X axis
    RAttrValue<bool> fGridY{this, "gridy", false}; ///<! show grid for Y axis
@@ -186,6 +185,7 @@ public:
    };
 
 
+   RAttrMargins margins{this, "margins"};    ///<! frame margins relative to pad
    RAttrBorder border{this, "border"};       ///<! frame border attributes
    RAttrFill fill{this, "fill"};             ///<! frame fill attributes
    RAttrAxis x{this, "x"};                   ///<! drawing attributes for X axis
@@ -198,9 +198,6 @@ public:
 
    bool GetDrawAxes() const { return fDrawAxes; }
    RFrame &SetDrawAxes(bool on = true) { fDrawAxes = on; return *this; }
-
-   const RAttrMargins &AttrMargins() const { return fAttrMargins; }
-   RAttrMargins &AttrMargins() { return fAttrMargins; }
 
    RFrame &SetGridX(bool on = true) { fGridX = on; return *this; }
    bool GetGridX() const { return fGridX; }

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -185,13 +185,13 @@ public:
    RAttrAxis z{this, "z"};                             ///<! drawing attributes for Z axis
    RAttrAxis x2{this, "x2"};                           ///<! drawing attributes for X2 axis
    RAttrAxis y2{this, "y2"};                           ///<! drawing attributes for Y2 axis
-   RAttrValue<bool> drawaxes{this, "drawaxes", false}; ///<! draw axes by frame
-   RAttrValue<bool> gridx{this, "gridx", false};       ///<! show grid for X axis
-   RAttrValue<bool> gridy{this, "gridy", false};       ///<! show grid for Y axis
-   RAttrValue<bool> swapx{this, "swapx", false};       ///<! swap position of X axis
-   RAttrValue<bool> swapy{this, "swapy", false};       ///<! swap position of Y axis
-   RAttrValue<int> ticksx{this, "ticksx", 1};          ///<! X ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
-   RAttrValue<int> ticksy{this, "ticksy", 1};          ///<! Y ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
+   RAttrValue<bool> drawAxes{this, "drawAxes", false}; ///<! draw axes by frame
+   RAttrValue<bool> gridX{this, "gridX", false};       ///<! show grid for X axis
+   RAttrValue<bool> gridY{this, "gridY", false};       ///<! show grid for Y axis
+   RAttrValue<bool> swapX{this, "swapX", false};       ///<! swap position of X axis
+   RAttrValue<bool> swapY{this, "swapY", false};       ///<! swap position of Y axis
+   RAttrValue<int> ticksX{this, "ticksX", 1};          ///<! X ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
+   RAttrValue<int> ticksY{this, "ticksY", 1};          ///<! Y ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
 
    RFrame(TRootIOCtor*) : RFrame() {}
 

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -145,7 +145,6 @@ public:
 
 private:
    RAttrMargins fAttrMargins{this, "margins"};    ///<! frame margins relative to pad
-   RAttrFill fAttrFill{this, "fill"};             ///<! frame fill attributes
    RAttrAxis fAttrX{this, "x"};                   ///<! drawing attributes for X axis
    RAttrAxis fAttrY{this, "y"};                   ///<! drawing attributes for Y axis
    RAttrAxis fAttrZ{this, "z"};                   ///<! drawing attributes for Z axis
@@ -193,6 +192,7 @@ public:
 
 
    RAttrBorder border{this, "border"};       ///<! frame border attributes
+   RAttrFill fill{this, "fill"};             ///<! frame fill attributes
 
    RFrame(TRootIOCtor*) : RFrame() {}
 
@@ -201,9 +201,6 @@ public:
 
    const RAttrMargins &AttrMargins() const { return fAttrMargins; }
    RAttrMargins &AttrMargins() { return fAttrMargins; }
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 
    const RAttrAxis &AttrX() const { return fAttrX; }
    RAttrAxis &AttrX() { return fAttrX; }

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -145,11 +145,6 @@ public:
 
 private:
    RAttrMargins fAttrMargins{this, "margins"};    ///<! frame margins relative to pad
-   RAttrAxis fAttrX{this, "x"};                   ///<! drawing attributes for X axis
-   RAttrAxis fAttrY{this, "y"};                   ///<! drawing attributes for Y axis
-   RAttrAxis fAttrZ{this, "z"};                   ///<! drawing attributes for Z axis
-   RAttrAxis fAttrX2{this, "x2"};                 ///<! drawing attributes for X2 axis
-   RAttrAxis fAttrY2{this, "y2"};                 ///<! drawing attributes for Y2 axis
    RAttrValue<bool> fDrawAxes{this, "drawaxes", false}; ///<! draw axes by frame
    RAttrValue<bool> fGridX{this, "gridx", false}; ///<! show grid for X axis
    RAttrValue<bool> fGridY{this, "gridy", false}; ///<! show grid for Y axis
@@ -193,6 +188,11 @@ public:
 
    RAttrBorder border{this, "border"};       ///<! frame border attributes
    RAttrFill fill{this, "fill"};             ///<! frame fill attributes
+   RAttrAxis x{this, "x"};                   ///<! drawing attributes for X axis
+   RAttrAxis y{this, "y"};                   ///<! drawing attributes for Y axis
+   RAttrAxis z{this, "z"};                   ///<! drawing attributes for Z axis
+   RAttrAxis x2{this, "x2"};                 ///<! drawing attributes for X2 axis
+   RAttrAxis y2{this, "y2"};                 ///<! drawing attributes for Y2 axis
 
    RFrame(TRootIOCtor*) : RFrame() {}
 
@@ -201,21 +201,6 @@ public:
 
    const RAttrMargins &AttrMargins() const { return fAttrMargins; }
    RAttrMargins &AttrMargins() { return fAttrMargins; }
-
-   const RAttrAxis &AttrX() const { return fAttrX; }
-   RAttrAxis &AttrX() { return fAttrX; }
-
-   const RAttrAxis &AttrY() const { return fAttrY; }
-   RAttrAxis &AttrY() { return fAttrY; }
-
-   const RAttrAxis &AttrZ() const { return fAttrZ; }
-   RAttrAxis &AttrZ() { return fAttrZ; }
-
-   const RAttrAxis &AttrX2() const { return fAttrX2; }
-   RAttrAxis &AttrX2() { return fAttrX2; }
-
-   const RAttrAxis &AttrY2() const { return fAttrY2; }
-   RAttrAxis &AttrY2() { return fAttrY2; }
 
    RFrame &SetGridX(bool on = true) { fGridX = on; return *this; }
    bool GetGridX() const { return fGridX; }

--- a/graf2d/gpadv7/inc/ROOT/RFrame.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RFrame.hxx
@@ -144,13 +144,6 @@ public:
    };
 
 private:
-   RAttrValue<bool> fDrawAxes{this, "drawaxes", false}; ///<! draw axes by frame
-   RAttrValue<bool> fGridX{this, "gridx", false}; ///<! show grid for X axis
-   RAttrValue<bool> fGridY{this, "gridy", false}; ///<! show grid for Y axis
-   RAttrValue<bool> fSwapX{this, "swapx", false}; ///<! swap position of X axis
-   RAttrValue<bool> fSwapY{this, "swapy", false}; ///<! swap position of Y axis
-   RAttrValue<int> fTicksX{this, "ticksx", 1};    ///<! X ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
-   RAttrValue<int> fTicksY{this, "ticksy", 1};    ///<! Y ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
    std::map<unsigned, RUserRanges> fClientRanges; ///<! individual client ranges
 
    RFrame(const RFrame &) = delete;
@@ -184,40 +177,23 @@ public:
       }
    };
 
-
-   RAttrMargins margins{this, "margins"};    ///<! frame margins relative to pad
-   RAttrBorder border{this, "border"};       ///<! frame border attributes
-   RAttrFill fill{this, "fill"};             ///<! frame fill attributes
-   RAttrAxis x{this, "x"};                   ///<! drawing attributes for X axis
-   RAttrAxis y{this, "y"};                   ///<! drawing attributes for Y axis
-   RAttrAxis z{this, "z"};                   ///<! drawing attributes for Z axis
-   RAttrAxis x2{this, "x2"};                 ///<! drawing attributes for X2 axis
-   RAttrAxis y2{this, "y2"};                 ///<! drawing attributes for Y2 axis
+   RAttrMargins margins{this, "margins"};              ///<! frame margins relative to pad
+   RAttrBorder border{this, "border"};                 ///<! frame border attributes
+   RAttrFill fill{this, "fill"};                       ///<! frame fill attributes
+   RAttrAxis x{this, "x"};                             ///<! drawing attributes for X axis
+   RAttrAxis y{this, "y"};                             ///<! drawing attributes for Y axis
+   RAttrAxis z{this, "z"};                             ///<! drawing attributes for Z axis
+   RAttrAxis x2{this, "x2"};                           ///<! drawing attributes for X2 axis
+   RAttrAxis y2{this, "y2"};                           ///<! drawing attributes for Y2 axis
+   RAttrValue<bool> drawaxes{this, "drawaxes", false}; ///<! draw axes by frame
+   RAttrValue<bool> gridx{this, "gridx", false};       ///<! show grid for X axis
+   RAttrValue<bool> gridy{this, "gridy", false};       ///<! show grid for Y axis
+   RAttrValue<bool> swapx{this, "swapx", false};       ///<! swap position of X axis
+   RAttrValue<bool> swapy{this, "swapy", false};       ///<! swap position of Y axis
+   RAttrValue<int> ticksx{this, "ticksx", 1};          ///<! X ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
+   RAttrValue<int> ticksy{this, "ticksy", 1};          ///<! Y ticks drawing: 0 - off, 1 - normal, 2 - both sides, 3 - both sides with labels
 
    RFrame(TRootIOCtor*) : RFrame() {}
-
-   bool GetDrawAxes() const { return fDrawAxes; }
-   RFrame &SetDrawAxes(bool on = true) { fDrawAxes = on; return *this; }
-
-   RFrame &SetGridX(bool on = true) { fGridX = on; return *this; }
-   bool GetGridX() const { return fGridX; }
-
-   RFrame &SetGridY(bool on = true) { fGridY = on; return *this; }
-   bool GetGridY() const { return fGridY; }
-
-   RFrame &SetSwapX(bool on = true) { fSwapX = on; return *this; }
-   bool GetSwapX() const { return fSwapX; }
-
-   RFrame &SetSwapY(bool on = true) { fSwapY = on; return *this; }
-   bool GetSwapY() const { return fSwapY; }
-
-   /** Configure X ticks drawing 0 - off, 1 - as configured for axis, 2 - both sides, 3 - labels on both side */
-   RFrame &SetTicksX(int v = 1) { fTicksX = v; return *this; }
-   int GetTicksX() const { return fTicksX; }
-
-   /** Configure Y ticks drawing 0 - off, 1 - as configured for axis, 2 - both sides, 3 - labels on both side */
-   RFrame &SetTicksY(int v = 1) { fTicksY = v; return *this; }
-   int GetTicksY() const { return fTicksY; }
 
    void GetClientRanges(unsigned connid, RUserRanges &ranges);
 };

--- a/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
@@ -1,0 +1,44 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_ROnFrameDrawable
+#define ROOT7_ROnFrameDrawable
+
+#include <ROOT/RDrawable.hxx>
+#include <ROOT/RAttrValue.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class ROnFrameDrawable
+\ingroup GpadROOT7
+\brief Base class for drawable which can be drawn on frame or on pad. Introduces "onframe" and "clipping" attributes. If onframe = true, one can enable clipping of such drawables.
+Dedicated for classes like RLine, RText, RBox and similar
+\author Sergey Linev <s.linev@gsi.de>
+\date 2021-06-29
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class ROnFrameDrawable : public RDrawable {
+protected:
+   ROnFrameDrawable(const ROnFrameDrawable &) = delete;
+   ROnFrameDrawable &operator=(const ROnFrameDrawable &) = delete;
+
+   explicit ROnFrameDrawable(const std::string &type) : RDrawable(type) {}
+
+public:
+   virtual ~ROnFrameDrawable() = default;
+
+   RAttrValue<bool> onframe{this, "onframe", false};  ///<! is drawn on the frame or not
+   RAttrValue<bool> clipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
@@ -17,7 +17,7 @@ namespace Experimental {
 
 /** \class ROnFrameDrawable
 \ingroup GpadROOT7
-\brief Base class for drawable which can be drawn on frame or on pad. Introduces "onframe" and "clipping" attributes. If onframe = true, one can enable clipping of such drawables.
+\brief Base class for drawable which can be drawn on frame or on pad. Introduces "onFrame" and "clipping" attributes. If onFrame = true, one can enable clipping of such drawables.
 Dedicated for classes like RLine, RText, RBox and similar
 \author Sergey Linev <s.linev@gsi.de>
 \date 2021-06-29
@@ -34,7 +34,7 @@ protected:
 public:
    virtual ~ROnFrameDrawable() = default;
 
-   RAttrValue<bool> onframe{this, "onframe", false};  ///<! is drawn on the frame or not
+   RAttrValue<bool> onFrame{this, "onFrame", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> clipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RPad.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPad.hxx
@@ -32,8 +32,6 @@ class RPad: public RPadBase {
    RPadPos fPos;                           ///< pad position
    RPadExtent fSize;                       ///< pad size
 
-   RAttrLine fAttrLine{this, "border"};    ///<! border attributes
-
    /// Create default pad
    RPad() : RPadBase("pad") {}
 
@@ -53,6 +51,8 @@ protected:
 
 
 public:
+
+   RAttrBorder border{this, "border"};    ///<! border attributes
 
    /// Constructor must be used only for I/O
    RPad(TRootIOCtor*) : RPad() {}
@@ -83,9 +83,6 @@ public:
 
    /// Set position
    void SetPos(const RPadPos &p) { fPos = p; }
-
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPaletteDrawable.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -32,9 +32,6 @@ namespace Experimental {
 class RPaletteDrawable final : public RDrawable {
 
    RPalette                fPalette;                              ///<  color palette to draw
-   RAttrValue<bool>        fVisible{this, "visible", true};       ///<! visibility flag
-   RAttrValue<RPadLength>  fMargin{this, "margin", 0.02_normal};  ///<! margin
-   RAttrValue<RPadLength>  fSize{this, "size", 0.05_normal};      ///<! margin
 
 protected:
 
@@ -44,18 +41,13 @@ protected:
 
 public:
 
+   RAttrValue<bool>        visible{this, "visible", true};       ///<! visibility flag
+   RAttrValue<RPadLength>  margin{this, "margin", 0.02_normal};  ///<! horizontal margin to frame
+   RAttrValue<RPadLength>  width{this, "width", 0.05_normal};    ///<! width of palette
+
    RPaletteDrawable(const RPalette &palette) : RPaletteDrawable() { fPalette = palette; }
-   RPaletteDrawable(const RPalette &palette, bool visible) : RPaletteDrawable() { fPalette = palette; SetVisible(visible); }
+   RPaletteDrawable(const RPalette &palette, bool _visible) : RPaletteDrawable() { fPalette = palette; visible = _visible; }
    const RPalette &GetPalette() const { return fPalette; }
-
-   RPaletteDrawable &SetVisible(bool on = true) { fVisible = on; return *this; }
-   bool GetVisible() const { return fVisible; }
-
-   RPaletteDrawable &SetMargin(const RPadLength &pos) { fMargin = pos; return *this; }
-   RPadLength GetMargin() const { return fMargin; }
-
-   RPaletteDrawable &SetSize(const RPadLength &sz) { fSize = sz; return *this; }
-   RPadLength GetSize() const { return fSize; }
 };
 
 //inline auto GetDrawable(const RPalette &palette)

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -31,7 +31,6 @@ namespace Experimental {
 
 class RPave : public RDrawable {
 
-   RAttrText               fAttrText{this, "text"};          ///<! text attributes
    RAttrValue<RPadLength>  fCornerX{this, "cornerx", 0.02};  ///<! X corner
    RAttrValue<RPadLength>  fCornerY{this, "cornery", 0.02};  ///<! Y corner
    RAttrValue<RPadLength>  fWidth{this, "width", 0.4};       ///<! pave width
@@ -45,6 +44,7 @@ public:
 
    RAttrBorder             border{this, "border"};      ///<! border attributes
    RAttrFill               fill{this, "fill"};          ///<! fill attributes
+   RAttrText               text{this, "text"};          ///<! text attributes
 
    RPave() : RPave("pave") {}
 
@@ -59,9 +59,6 @@ public:
 
    RPave &SetHeight(const RPadLength &height) { fHeight = height; return *this; }
    RPadLength GetHeight() const { return fHeight; }
-
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -32,7 +32,6 @@ namespace Experimental {
 class RPave : public RDrawable {
 
    RAttrText               fAttrText{this, "text"};          ///<! text attributes
-   RAttrFill               fAttrFill{this, "fill"};          ///<! line attributes
    RAttrValue<RPadLength>  fCornerX{this, "cornerx", 0.02};  ///<! X corner
    RAttrValue<RPadLength>  fCornerY{this, "cornery", 0.02};  ///<! Y corner
    RAttrValue<RPadLength>  fWidth{this, "width", 0.4};       ///<! pave width
@@ -45,6 +44,7 @@ protected:
 public:
 
    RAttrBorder             border{this, "border"};      ///<! border attributes
+   RAttrFill               fill{this, "fill"};          ///<! fill attributes
 
    RPave() : RPave("pave") {}
 
@@ -62,9 +62,6 @@ public:
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -39,8 +39,8 @@ public:
    RAttrBorder border{this, "border"};                    ///<! border attributes
    RAttrFill fill{this, "fill"};                          ///<! fill attributes
    RAttrText text{this, "text"};                          ///<! text attributes
-   RAttrValue<RPadLength> cornerx{this, "cornerx", 0.02}; ///<! X corner
-   RAttrValue<RPadLength> cornery{this, "cornery", 0.02}; ///<! Y corner
+   RAttrValue<RPadLength> cornerX{this, "cornerX", 0.02}; ///<! X corner
+   RAttrValue<RPadLength> cornerY{this, "cornerY", 0.02}; ///<! Y corner
    RAttrValue<RPadLength> width{this, "width", 0.4};      ///<! pave width
    RAttrValue<RPadLength> height{this, "height", 0.2};    ///<! pave height
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -32,7 +32,6 @@ namespace Experimental {
 class RPave : public RDrawable {
 
    RAttrText               fAttrText{this, "text"};          ///<! text attributes
-   RAttrBorder             fAttrBorder{this, "border"};      ///<! border attributes
    RAttrFill               fAttrFill{this, "fill"};          ///<! line attributes
    RAttrValue<RPadLength>  fCornerX{this, "cornerx", 0.02};  ///<! X corner
    RAttrValue<RPadLength>  fCornerY{this, "cornery", 0.02};  ///<! Y corner
@@ -44,6 +43,8 @@ protected:
    RPave(const std::string &csstype) : RDrawable(csstype) {}
 
 public:
+
+   RAttrBorder             border{this, "border"};      ///<! border attributes
 
    RPave() : RPave("pave") {}
 
@@ -61,9 +62,6 @@ public:
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }
-
-   const RAttrBorder &AttrBorder() const { return fAttrBorder; }
-   RAttrBorder &AttrBorder() { return fAttrBorder; }
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -31,34 +31,21 @@ namespace Experimental {
 
 class RPave : public RDrawable {
 
-   RAttrValue<RPadLength>  fCornerX{this, "cornerx", 0.02};  ///<! X corner
-   RAttrValue<RPadLength>  fCornerY{this, "cornery", 0.02};  ///<! Y corner
-   RAttrValue<RPadLength>  fWidth{this, "width", 0.4};       ///<! pave width
-   RAttrValue<RPadLength>  fHeight{this, "height", 0.2};     ///<! pave height
-
 protected:
 
    RPave(const std::string &csstype) : RDrawable(csstype) {}
 
 public:
-
-   RAttrBorder             border{this, "border"};      ///<! border attributes
-   RAttrFill               fill{this, "fill"};          ///<! fill attributes
-   RAttrText               text{this, "text"};          ///<! text attributes
+   RAttrBorder border{this, "border"};                    ///<! border attributes
+   RAttrFill fill{this, "fill"};                          ///<! fill attributes
+   RAttrText text{this, "text"};                          ///<! text attributes
+   RAttrValue<RPadLength> cornerx{this, "cornerx", 0.02}; ///<! X corner
+   RAttrValue<RPadLength> cornery{this, "cornery", 0.02}; ///<! Y corner
+   RAttrValue<RPadLength> width{this, "width", 0.4};      ///<! pave width
+   RAttrValue<RPadLength> height{this, "height", 0.2};    ///<! pave height
 
    RPave() : RPave("pave") {}
 
-   RPave &SetCornerX(const RPadLength &pos) { fCornerX = pos; return *this; }
-   RPadLength GetCornerX() const { return fCornerX; }
-
-   RPave &SetCornerY(const RPadLength &pos) { fCornerY = pos; return *this; }
-   RPadLength GetCornerY() const { return fCornerY; }
-
-   RPave &SetWidth(const RPadLength &width) { fWidth = width; return *this; }
-   RPadLength GetWidth() const { return fWidth; }
-
-   RPave &SetHeight(const RPadLength &height) { fHeight = height; return *this; }
-   RPadLength GetHeight() const { return fHeight; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -47,7 +47,6 @@ private:
    const TObject *fExtObj{nullptr};            ///<! external object, managed outside of the drawable, not persistent
    RAttrValue<std::string> fOpt{this, "opt"};  ///<! object draw options
    RAttrText fAttrText{this, "text"};          ///<! object text attributes
-   RAttrMarker fMarkerAttr{this, "marker"};    ///<! object marker attributes
 
    static std::string GetColorCode(TColor *col);
 
@@ -79,6 +78,7 @@ public:
 
    RAttrLine line{this, "line"};          ///<! object line attributes
    RAttrFill fill{this, "fill"};          ///<! object fill attributes
+   RAttrMarker marker{this, "marker"};    ///<! object marker attributes
 
    TObjectDrawable();
    TObjectDrawable(TObject *obj, bool isowner = false);
@@ -100,9 +100,6 @@ public:
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }
-
-   const RAttrMarker &AttrMarker() const { return fMarkerAttr; }
-   RAttrMarker &AttrMarker() { return fMarkerAttr; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -46,7 +46,6 @@ private:
    Internal::RIOShared<TObject> fObj;          ///< The object to be painted, owned by the drawable
    const TObject *fExtObj{nullptr};            ///<! external object, managed outside of the drawable, not persistent
    RAttrValue<std::string> fOpt{this, "opt"};  ///<! object draw options
-   RAttrText fAttrText{this, "text"};          ///<! object text attributes
 
    static std::string GetColorCode(TColor *col);
 
@@ -79,6 +78,7 @@ public:
    RAttrLine line{this, "line"};          ///<! object line attributes
    RAttrFill fill{this, "fill"};          ///<! object fill attributes
    RAttrMarker marker{this, "marker"};    ///<! object marker attributes
+   RAttrText text{this, "text"};          ///<! object text attributes
 
    TObjectDrawable();
    TObjectDrawable(TObject *obj, bool isowner = false);
@@ -98,8 +98,6 @@ public:
    void SetOpt(const std::string &opt) { fOpt = opt; }
    std::string GetOpt() const { return fOpt; }
 
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -46,7 +46,6 @@ private:
    Internal::RIOShared<TObject> fObj;          ///< The object to be painted, owned by the drawable
    const TObject *fExtObj{nullptr};            ///<! external object, managed outside of the drawable, not persistent
    RAttrValue<std::string> fOpt{this, "opt"};  ///<! object draw options
-   RAttrLine fAttrLine{this, "line"};          ///<! object line attributes
    RAttrFill fAttrFill{this, "fill"};          ///<! object fill attributes
    RAttrText fAttrText{this, "text"};          ///<! object text attributes
    RAttrMarker fMarkerAttr{this, "marker"};    ///<! object marker attributes
@@ -79,6 +78,8 @@ public:
       kPalette = 6   ///< list of colors from palette
    };
 
+   RAttrLine line{this, "line"};          ///<! object line attributes
+
    TObjectDrawable();
    TObjectDrawable(TObject *obj, bool isowner = false);
    TObjectDrawable(TObject *obj, const std::string &opt, bool isowner = false);
@@ -96,9 +97,6 @@ public:
 
    void SetOpt(const std::string &opt) { fOpt = opt; }
    std::string GetOpt() const { return fOpt; }
-
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -78,7 +78,7 @@ public:
    RAttrFill fill{this, "fill"};          ///<! object fill attributes
    RAttrMarker marker{this, "marker"};    ///<! object marker attributes
    RAttrText text{this, "text"};          ///<! object text attributes
-   RAttrValue<std::string> drawopt{this, "drawopt"};  ///<! object draw options
+   RAttrValue<std::string> options{this, "options"};  ///<! object draw options
 
    TObjectDrawable();
    TObjectDrawable(TObject *obj, bool isowner = false);

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -46,7 +46,6 @@ private:
    Internal::RIOShared<TObject> fObj;          ///< The object to be painted, owned by the drawable
    const TObject *fExtObj{nullptr};            ///<! external object, managed outside of the drawable, not persistent
    RAttrValue<std::string> fOpt{this, "opt"};  ///<! object draw options
-   RAttrFill fAttrFill{this, "fill"};          ///<! object fill attributes
    RAttrText fAttrText{this, "text"};          ///<! object text attributes
    RAttrMarker fMarkerAttr{this, "marker"};    ///<! object marker attributes
 
@@ -79,6 +78,7 @@ public:
    };
 
    RAttrLine line{this, "line"};          ///<! object line attributes
+   RAttrFill fill{this, "fill"};          ///<! object fill attributes
 
    TObjectDrawable();
    TObjectDrawable(TObject *obj, bool isowner = false);
@@ -97,9 +97,6 @@ public:
 
    void SetOpt(const std::string &opt) { fOpt = opt; }
    std::string GetOpt() const { return fOpt; }
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -45,7 +45,6 @@ private:
    int fKind{kNone};                           ///< object kind
    Internal::RIOShared<TObject> fObj;          ///< The object to be painted, owned by the drawable
    const TObject *fExtObj{nullptr};            ///<! external object, managed outside of the drawable, not persistent
-   RAttrValue<std::string> fOpt{this, "opt"};  ///<! object draw options
 
    static std::string GetColorCode(TColor *col);
 
@@ -79,6 +78,7 @@ public:
    RAttrFill fill{this, "fill"};          ///<! object fill attributes
    RAttrMarker marker{this, "marker"};    ///<! object marker attributes
    RAttrText text{this, "text"};          ///<! object text attributes
+   RAttrValue<std::string> drawopt{this, "drawopt"};  ///<! object draw options
 
    TObjectDrawable();
    TObjectDrawable(TObject *obj, bool isowner = false);
@@ -94,10 +94,6 @@ public:
    void Set(TObject *obj, const std::string &opt, bool isowner = false);
 
    const TObject *Get();
-
-   void SetOpt(const std::string &opt) { fOpt = opt; }
-   std::string GetOpt() const { return fOpt; }
-
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/src/RFrame.cxx
+++ b/graf2d/gpadv7/src/RFrame.cxx
@@ -23,11 +23,11 @@ using namespace ROOT::Experimental;
 
 void RFrame::GetAxisRanges(unsigned ndim, const RAttrAxis &axis, RUserRanges &ranges) const
 {
-   if (axis.zoommin.Has())
-      ranges.AssignMin(ndim, axis.zoommin);
+   if (axis.zoomMin.Has())
+      ranges.AssignMin(ndim, axis.zoomMin);
 
-   if (axis.zoommax.Has())
-      ranges.AssignMax(ndim, axis.zoommax);
+   if (axis.zoomMax.Has())
+      ranges.AssignMax(ndim, axis.zoomMax);
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -36,13 +36,13 @@ void RFrame::GetAxisRanges(unsigned ndim, const RAttrAxis &axis, RUserRanges &ra
 void RFrame::AssignZoomRange(unsigned ndim, RAttrAxis &axis, const RUserRanges &ranges)
 {
    if (ranges.IsUnzoom(ndim)) {
-      axis.zoommin.Clear();
-      axis.zoommax.Clear();
+      axis.zoomMin.Clear();
+      axis.zoomMax.Clear();
    } else {
       if (ranges.HasMin(ndim))
-         axis.zoommin = ranges.GetMin(ndim);
+         axis.zoomMin = ranges.GetMin(ndim);
       if (ranges.HasMax(ndim))
-         axis.zoommax = ranges.GetMax(ndim);
+         axis.zoomMax = ranges.GetMax(ndim);
    }
 }
 

--- a/graf2d/gpadv7/src/RFrame.cxx
+++ b/graf2d/gpadv7/src/RFrame.cxx
@@ -23,11 +23,11 @@ using namespace ROOT::Experimental;
 
 void RFrame::GetAxisRanges(unsigned ndim, const RAttrAxis &axis, RUserRanges &ranges) const
 {
-   if (axis.HasZoomMin())
-      ranges.AssignMin(ndim, axis.GetZoomMin());
+   if (axis.zoommin.Has())
+      ranges.AssignMin(ndim, axis.zoommin);
 
-   if (axis.HasZoomMax())
-      ranges.AssignMax(ndim, axis.GetZoomMax());
+   if (axis.zoommax.Has())
+      ranges.AssignMax(ndim, axis.zoommax);
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -36,12 +36,13 @@ void RFrame::GetAxisRanges(unsigned ndim, const RAttrAxis &axis, RUserRanges &ra
 void RFrame::AssignZoomRange(unsigned ndim, RAttrAxis &axis, const RUserRanges &ranges)
 {
    if (ranges.IsUnzoom(ndim)) {
-      axis.ClearZoom();
+      axis.zoommin.Clear();
+      axis.zoommax.Clear();
    } else {
       if (ranges.HasMin(ndim))
-         axis.SetZoomMin(ranges.GetMin(ndim));
+         axis.zoommin = ranges.GetMin(ndim);
       if (ranges.HasMax(ndim))
-         axis.SetZoomMax(ranges.GetMax(ndim));
+         axis.zoommax = ranges.GetMax(ndim);
    }
 }
 
@@ -55,12 +56,12 @@ void RFrame::PopulateMenu(RMenuItems & /* items */)
    auto is_y = items.GetSpecifier() == "y";
 
    if (is_x || is_y) {
-      RAttrAxis &attr = is_x ? AttrX() : AttrY();
-      std::string name = is_x ? "AttrX()" : "AttrY()";
+      RAttrAxis &attr = is_x ? x : y;
+      std::string name = is_x ? "x" : "y";
       auto cl = TClass::GetClass<RAttrAxis>();
       auto log = attr.GetLog();
-      items.AddChkMenuItem("Linear scale", "Set linear scale", !log, name + ".SetLog(0)", cl);
-      items.AddChkMenuItem("Log scale", "Logarithmic scale", !log, name + ".SetLog(10)", cl);
+      items.AddChkMenuItem("Linear scale", "Set linear scale", !log, name + ".log = 0", cl);
+      items.AddChkMenuItem("Log scale", "Logarithmic scale", !log, name + ".log = 10", cl);
    }
 */
 }
@@ -71,11 +72,11 @@ void RFrame::PopulateMenu(RMenuItems & /* items */)
 void RFrame::SetClientRanges(unsigned connid, const RUserRanges &ranges, bool ismainconn)
 {
    if (ismainconn) {
-      AssignZoomRange(0, AttrX(), ranges);
-      AssignZoomRange(1, AttrY(), ranges);
-      AssignZoomRange(2, AttrZ(), ranges);
-      AssignZoomRange(3, AttrX2(), ranges);
-      AssignZoomRange(4, AttrY2(), ranges);
+      AssignZoomRange(0, x, ranges);
+      AssignZoomRange(1, y, ranges);
+      AssignZoomRange(2, z, ranges);
+      AssignZoomRange(3, x2, ranges);
+      AssignZoomRange(4, y2, ranges);
    }
 
    if (fClientRanges.find(connid) == fClientRanges.end()) {
@@ -97,9 +98,9 @@ void RFrame::GetClientRanges(unsigned connid, RUserRanges &ranges)
    if (iter != fClientRanges.end()) {
       ranges = iter->second;
    } else {
-      GetAxisRanges(0, AttrX(), ranges);
-      GetAxisRanges(1, AttrY(), ranges);
-      GetAxisRanges(2, AttrZ(), ranges);
+      GetAxisRanges(0, x, ranges);
+      GetAxisRanges(1, y, ranges);
+      GetAxisRanges(2, z, ranges);
    }
 }
 

--- a/graf2d/gpadv7/src/RStyle.cxx
+++ b/graf2d/gpadv7/src/RStyle.cxx
@@ -12,6 +12,8 @@
 #include <ROOT/RDrawable.hxx>
 #include <ROOT/RLogger.hxx>
 
+#include <algorithm>
+
 using namespace std::string_literals;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -19,9 +21,13 @@ using namespace std::string_literals;
 
 const ROOT::Experimental::RAttrMap::Value_t *ROOT::Experimental::RStyle::Eval(const std::string &field, const RDrawable &drawable) const
 {
+   std::string name;
+   for(auto &c : field)
+      name += std::tolower(c);
+
    for (const auto &block : fBlocks) {
       if (drawable.MatchSelector(block.selector)) {
-         auto res = block.map.Find(field);
+         auto res = block.map.Find(name);
          if (res)
             return res;
       }
@@ -35,9 +41,13 @@ const ROOT::Experimental::RAttrMap::Value_t *ROOT::Experimental::RStyle::Eval(co
 
 const ROOT::Experimental::RAttrMap::Value_t *ROOT::Experimental::RStyle::Eval(const std::string &field, const std::string &selector) const
 {
+   std::string name;
+   for(auto &c : field)
+      name += std::tolower(c);
+
    for (const auto &block : fBlocks) {
       if (block.selector == selector) {
-         auto res = block.map.Find(field);
+         auto res = block.map.Find(name);
          if (res)
             return res;
       }
@@ -154,7 +164,11 @@ bool ROOT::Experimental::RStyle::ParseString(const std::string &css_code)
 
          while ((pos < len) && check_symbol(is_first)) { shift(); is_first = false; }
 
-         return css_code.substr(pos0, pos-pos0);
+         std::string s = css_code.substr(pos0, pos-pos0);
+         if (!selector)
+            std::transform(s.begin(), s.end(), s.begin(),
+                              [](unsigned char c){ return std::tolower(c); });
+         return s;
       }
 
       std::string scan_value()

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -86,7 +86,7 @@ TObjectDrawable::TObjectDrawable(TObject *obj, bool isowner) : RDrawable(DetectC
 
 TObjectDrawable::TObjectDrawable(TObject *obj, const std::string &opt, bool isowner) : TObjectDrawable(obj, isowner)
 {
-   drawopt = opt;
+   options = opt;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -105,7 +105,7 @@ TObjectDrawable::TObjectDrawable(const std::shared_ptr<TObject> &obj) : RDrawabl
 
 TObjectDrawable::TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : TObjectDrawable(obj)
 {
-   drawopt = opt;
+   options = opt;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -176,7 +176,7 @@ void TObjectDrawable::Set(TObject *obj, bool isowner)
 void TObjectDrawable::Set(TObject *obj, const std::string &opt, bool isowner)
 {
    Set(obj, isowner);
-   drawopt = opt;
+   options = opt;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -86,7 +86,7 @@ TObjectDrawable::TObjectDrawable(TObject *obj, bool isowner) : RDrawable(DetectC
 
 TObjectDrawable::TObjectDrawable(TObject *obj, const std::string &opt, bool isowner) : TObjectDrawable(obj, isowner)
 {
-   SetOpt(opt);
+   drawopt = opt;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -105,7 +105,7 @@ TObjectDrawable::TObjectDrawable(const std::shared_ptr<TObject> &obj) : RDrawabl
 
 TObjectDrawable::TObjectDrawable(const std::shared_ptr<TObject> &obj, const std::string &opt) : TObjectDrawable(obj)
 {
-   SetOpt(opt);
+   drawopt = opt;
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -176,7 +176,7 @@ void TObjectDrawable::Set(TObject *obj, bool isowner)
 void TObjectDrawable::Set(TObject *obj, const std::string &opt, bool isowner)
 {
    Set(obj, isowner);
-   SetOpt(opt);
+   drawopt = opt;
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -37,12 +37,12 @@ TEST(RAttrTest, AttribDirect) {
 
    {
       auto val = attrs.GetDirect("line_width");
-      EXPECT_FLOAT_EQ(val, 42.f);
+      EXPECT_DOUBLE_EQ(val, 42.);
    }
 
    {
       auto val = attrs.GetDirect("text_size");
-      EXPECT_FLOAT_EQ(val, 1.7f);
+      EXPECT_DOUBLE_EQ(val, 1.7);
    }
 }
 
@@ -52,7 +52,7 @@ TEST(RAttrTest, AttribVals) {
    attrs.text.color = RColor::kBlue;
    attrs.line.width = 42.f;
 
-   EXPECT_FLOAT_EQ(attrs.line.width, 42.f);
+   EXPECT_DOUBLE_EQ(attrs.line.width, 42.f);
    EXPECT_EQ(attrs.text.color, RColor::kBlue);
 
 }
@@ -123,19 +123,19 @@ TEST(RAttrTest, AttribAssign) {
    EXPECT_NE(attrs1.line, attrLine1);
    EXPECT_NE(attrs2.line, attrLine2);
 
-   EXPECT_FLOAT_EQ(attrLine1.width, 42.);
-   EXPECT_FLOAT_EQ(attrLine2.width, 42.);
+   EXPECT_DOUBLE_EQ(attrLine1.width, 42.);
+   EXPECT_DOUBLE_EQ(attrLine2.width, 42.);
    // default width return 1
-   EXPECT_FLOAT_EQ(attrs1.line.width, 1.f);
-   EXPECT_FLOAT_EQ(attrs2.line.width, 1.f);
+   EXPECT_DOUBLE_EQ(attrs1.line.width, 1.);
+   EXPECT_DOUBLE_EQ(attrs2.line.width, 1.);
 
    // Are the two attributes disconnected?
    attrLine2.width = 3.;
    EXPECT_EQ(attrs1.line, attrs2.line);
-   EXPECT_FLOAT_EQ(attrLine1.width, 42.f);
-   EXPECT_FLOAT_EQ(attrLine2.width, 3.f);
-   EXPECT_FLOAT_EQ(attrs1.line.width, 1.f);
-   EXPECT_FLOAT_EQ(attrs2.line.width, 1.f);
+   EXPECT_DOUBLE_EQ(attrLine1.width, 42.);
+   EXPECT_DOUBLE_EQ(attrLine2.width, 3.);
+   EXPECT_DOUBLE_EQ(attrs1.line.width, 1.);
+   EXPECT_DOUBLE_EQ(attrs2.line.width, 1.);
 }
 
 TEST(RAttrTest, AttribValue) {

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -9,18 +9,16 @@
 using namespace ROOT::Experimental;
 
 class CustomAttrs : public RAttrAggregation {
-   RAttrLine    fAttrLine{this, "line"};    ///<! line attributes
    RAttrFill    fAttrFill{this, "fill"};    ///<! fill attributes
    RAttrText    fAttrText{this, "text"};    ///<! text attributes
 
 protected:
    // required here while dictionary for CustomAttrs not created
-   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(fAttrLine).AddDefaults(fAttrFill).AddDefaults(fAttrText); }
+   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(line).AddDefaults(fAttrFill).AddDefaults(fAttrText); }
 
    R__ATTR_CLASS(CustomAttrs, "custom");
 
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
+   RAttrLine    line{this, "line"};    ///<! line attributes
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }
@@ -37,10 +35,10 @@ protected:
 };
 
 
-TEST(RAttrTest, AttribStrings) {
+TEST(RAttrTest, AttribDirect) {
    CustomAttrs attrs;
 
-   attrs.AttrLine().SetWidth(42.);
+   attrs.line.width = 42.;
    attrs.AttrText().SetSize(1.7);
 
    {
@@ -58,13 +56,13 @@ TEST(RAttrTest, AttribVals) {
    CustomAttrs attrs;
 
    attrs.AttrText().SetColor(RColor::kBlue);
-   auto &line = attrs.AttrLine();
-   line.SetWidth(42.);
+   auto &line = attrs.line;
+   line.width = 42.f;
 
    {
       // Value was set on this attr, not coming from style:
-      EXPECT_FLOAT_EQ(attrs.AttrLine().GetWidth(), 42.f);
-      EXPECT_FLOAT_EQ(line.GetWidth(), 42.f);
+      EXPECT_FLOAT_EQ(attrs.line.width, 42.f);
+      EXPECT_FLOAT_EQ(line.width, 42.f);
    }
 
    {
@@ -84,12 +82,12 @@ TEST(RAttrTest, NullAttribCompare) {
 TEST(RAttrTest, AttribEqual) {
    CustomAttrs attrs;
 
-   auto &al1 = attrs.AttrLine();
-   auto &al2 = attrs.AttrLine();
+   auto &al1 = attrs.line;
+   auto &al2 = attrs.line;
    EXPECT_EQ(al1, al2);
    EXPECT_EQ(al2, al1);
 
-   al1.SetColor(RColor::kRed);
+   al1.color = RColor::kRed;
 
    EXPECT_EQ(al1, al2);
    EXPECT_EQ(al2, al1);
@@ -102,13 +100,13 @@ TEST(RAttrTest, AttribDiffer) {
 
    // RLogScopedVerbosity debugThis(GPadLog(), ELogLevel::kDebug);
 
-   attrs1.AttrLine().SetWidth(7.);
+   attrs1.line.width = 7.f;
    EXPECT_NE(attrs1, attrs2);
    EXPECT_NE(attrs2, attrs1);
    EXPECT_EQ(attrs2, attrs3);
    EXPECT_EQ(attrs3, attrs2);
 
-   attrs2.AttrLine().SetColor(RColor::kRed);
+   attrs2.line.color = RColor::kRed;
    EXPECT_NE(attrs1, attrs2);
    EXPECT_NE(attrs2, attrs1);
    EXPECT_NE(attrs1, attrs3);
@@ -123,13 +121,13 @@ TEST(RAttrTest, AttribAssign) {
    CustomAttrs attrs2;
 
    // deep copy - independent from origin
-   auto attrLine1 = attrs1.AttrLine();
-   auto attrLine2 = attrs2.AttrLine();
+   auto attrLine1 = attrs1.line;
+   auto attrLine2 = attrs2.line;
 
    EXPECT_EQ(attrLine2, attrLine1);
    EXPECT_EQ(attrLine1, attrLine2);
 
-   attrLine1.SetWidth(42.);
+   attrLine1.width = 42.;
    EXPECT_NE(attrLine2, attrLine1);
 
    attrLine2 = attrLine1;
@@ -137,22 +135,22 @@ TEST(RAttrTest, AttribAssign) {
    EXPECT_EQ(attrLine1, attrLine2);
 
    // But original attributes now differ
-   EXPECT_NE(attrs1.AttrLine(), attrLine1);
-   EXPECT_NE(attrs2.AttrLine(), attrLine2);
+   EXPECT_NE(attrs1.line, attrLine1);
+   EXPECT_NE(attrs2.line, attrLine2);
 
-   EXPECT_FLOAT_EQ(attrLine1.GetWidth(), 42.);
-   EXPECT_FLOAT_EQ(attrLine2.GetWidth(), 42.);
+   EXPECT_FLOAT_EQ(attrLine1.width, 42.);
+   EXPECT_FLOAT_EQ(attrLine2.width, 42.);
    // default width return 1
-   EXPECT_FLOAT_EQ(attrs1.AttrLine().GetWidth(), 1.);
-   EXPECT_FLOAT_EQ(attrs2.AttrLine().GetWidth(), 1.);
+   EXPECT_FLOAT_EQ(attrs1.line.width, 1.f);
+   EXPECT_FLOAT_EQ(attrs2.line.width, 1.f);
 
    // Are the two attributes disconnected?
-   attrLine2.SetWidth(3.);
-   EXPECT_EQ(attrs1.AttrLine(), attrs2.AttrLine());
-   EXPECT_FLOAT_EQ(attrLine1.GetWidth(), 42.);
-   EXPECT_FLOAT_EQ(attrLine2.GetWidth(), 3.);
-   EXPECT_FLOAT_EQ(attrs1.AttrLine().GetWidth(), 1.);
-   EXPECT_FLOAT_EQ(attrs2.AttrLine().GetWidth(), 1.);
+   attrLine2.width = 3.;
+   EXPECT_EQ(attrs1.line, attrs2.line);
+   EXPECT_FLOAT_EQ(attrLine1.width, 42.f);
+   EXPECT_FLOAT_EQ(attrLine2.width, 3.f);
+   EXPECT_FLOAT_EQ(attrs1.line.width, 1.f);
+   EXPECT_FLOAT_EQ(attrs2.line.width, 1.f);
 }
 
 TEST(RAttrTest, AttribValue) {

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -9,19 +9,16 @@
 using namespace ROOT::Experimental;
 
 class CustomAttrs : public RAttrAggregation {
-   RAttrText    fAttrText{this, "text"};    ///<! text attributes
 
 protected:
    // required here while dictionary for CustomAttrs not created
-   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(line).AddDefaults(fill).AddDefaults(fAttrText); }
+   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(line).AddDefaults(fill).AddDefaults(text); }
 
    R__ATTR_CLASS(CustomAttrs, "custom");
 
    RAttrLine    line{this, "line"};    ///<! line attributes
    RAttrFill    fill{this, "fill"};    ///<! fill attributes
-
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
+   RAttrText    text{this, "text"};    ///<! text attributes
 
    double GetDirect(const std::string &name)
    {
@@ -36,7 +33,7 @@ TEST(RAttrTest, AttribDirect) {
    CustomAttrs attrs;
 
    attrs.line.width = 42.;
-   attrs.AttrText().SetSize(1.7);
+   attrs.text.size = 1.7;
 
    {
       auto val = attrs.GetDirect("line_width");
@@ -52,20 +49,11 @@ TEST(RAttrTest, AttribDirect) {
 TEST(RAttrTest, AttribVals) {
    CustomAttrs attrs;
 
-   attrs.AttrText().SetColor(RColor::kBlue);
-   auto &line = attrs.line;
-   line.width = 42.f;
+   attrs.text.color = RColor::kBlue;
+   attrs.line.width = 42.f;
 
-   {
-      // Value was set on this attr, not coming from style:
-      EXPECT_FLOAT_EQ(attrs.line.width, 42.f);
-      EXPECT_FLOAT_EQ(line.width, 42.f);
-   }
-
-   {
-      // Value was set on this attr, not coming from style:
-      EXPECT_EQ(attrs.AttrText().GetColor(), RColor::kBlue);
-   }
+   EXPECT_FLOAT_EQ(attrs.line.width, 42.f);
+   EXPECT_EQ(attrs.text.color, RColor::kBlue);
 
 }
 

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -9,19 +9,16 @@
 using namespace ROOT::Experimental;
 
 class CustomAttrs : public RAttrAggregation {
-   RAttrFill    fAttrFill{this, "fill"};    ///<! fill attributes
    RAttrText    fAttrText{this, "text"};    ///<! text attributes
 
 protected:
    // required here while dictionary for CustomAttrs not created
-   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(line).AddDefaults(fAttrFill).AddDefaults(fAttrText); }
+   RAttrMap CollectDefaults() const override { return RAttrMap().AddDefaults(line).AddDefaults(fill).AddDefaults(fAttrText); }
 
    R__ATTR_CLASS(CustomAttrs, "custom");
 
    RAttrLine    line{this, "line"};    ///<! line attributes
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
+   RAttrFill    fill{this, "fill"};    ///<! fill attributes
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }

--- a/graf2d/gpadv7/test/attribute.cxx
+++ b/graf2d/gpadv7/test/attribute.cxx
@@ -16,6 +16,8 @@ protected:
 
    R__ATTR_CLASS(CustomAttrs, "custom");
 
+public:
+
    RAttrLine    line{this, "line"};    ///<! line attributes
    RAttrFill    fill{this, "fill"};    ///<! fill attributes
    RAttrText    text{this, "text"};    ///<! text attributes

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -21,10 +21,10 @@ TEST(Primitives, RPave)
    pave->border.width = 3.f;
    pave->fill.color = RColor::kBlue;
    pave->fill.style = 3003;
-   pave->SetCornerX(0.03_normal);
-   pave->SetWidth(0.4_normal);
-   pave->SetCornerY(-0.03_normal);
-   pave->SetHeight(0.2_normal);
+   pave->cornerx = 0.03_normal;
+   pave->width = 0.4_normal;
+   pave->cornery = -0.03_normal;
+   pave->height = 0.2_normal;
 
    // when adding pave, RFrame is automatically created
    EXPECT_EQ(canv.NumPrimitives(), 2u);
@@ -35,9 +35,9 @@ TEST(Primitives, RPave)
    EXPECT_EQ(pave->fill.color, RColor::kBlue);
    EXPECT_EQ(pave->fill.style, 3003);
 
-   EXPECT_EQ(pave->GetCornerX(), 0.03_normal);
-   EXPECT_EQ(pave->GetWidth(), 0.4_normal);
-   EXPECT_EQ(pave->GetCornerY(), -0.03_normal);
-   EXPECT_EQ(pave->GetHeight(), 0.2_normal);
+   EXPECT_EQ(pave->cornerx, 0.03_normal);
+   EXPECT_EQ(pave->width, 0.4_normal);
+   EXPECT_EQ(pave->cornery, -0.03_normal);
+   EXPECT_EQ(pave->height, 0.2_normal);
 }
 

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -18,7 +18,7 @@ TEST(Primitives, RPave)
 
    auto pave = canv.Add<RPave>();
    pave->border.color = RColor::kRed;
-   pave->border.width = 3.f;
+   pave->border.width = 3.;
    pave->fill.color = RColor::kBlue;
    pave->fill.style = 3003;
    pave->cornerx = 0.03_normal;
@@ -30,7 +30,7 @@ TEST(Primitives, RPave)
    EXPECT_EQ(canv.NumPrimitives(), 2u);
 
    EXPECT_EQ(pave->border.color, RColor::kRed);
-   EXPECT_EQ(pave->border.width, 3.f);
+   EXPECT_DOUBLE_EQ(pave->border.width, 3.);
 
    EXPECT_EQ(pave->fill.color, RColor::kBlue);
    EXPECT_EQ(pave->fill.style, 3003);

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -21,9 +21,9 @@ TEST(Primitives, RPave)
    pave->border.width = 3.;
    pave->fill.color = RColor::kBlue;
    pave->fill.style = 3003;
-   pave->cornerx = 0.03_normal;
+   pave->cornerX = 0.03_normal;
    pave->width = 0.4_normal;
-   pave->cornery = -0.03_normal;
+   pave->cornerY = -0.03_normal;
    pave->height = 0.2_normal;
 
    // when adding pave, RFrame is automatically created
@@ -35,9 +35,9 @@ TEST(Primitives, RPave)
    EXPECT_EQ(pave->fill.color, RColor::kBlue);
    EXPECT_EQ(pave->fill.style, 3003);
 
-   EXPECT_EQ(pave->cornerx, 0.03_normal);
+   EXPECT_EQ(pave->cornerX, 0.03_normal);
    EXPECT_EQ(pave->width, 0.4_normal);
-   EXPECT_EQ(pave->cornery, -0.03_normal);
+   EXPECT_EQ(pave->cornerY, -0.03_normal);
    EXPECT_EQ(pave->height, 0.2_normal);
 }
 

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -19,7 +19,8 @@ TEST(Primitives, RPave)
    auto pave = canv.Add<RPave>();
    pave->border.color = RColor::kRed;
    pave->border.width = 3.f;
-   pave->AttrFill().SetColor(RColor::kBlue).SetStyle(3003);
+   pave->fill.color = RColor::kBlue;
+   pave->fill.style = 3003;
    pave->SetCornerX(0.03_normal);
    pave->SetWidth(0.4_normal);
    pave->SetCornerY(-0.03_normal);
@@ -31,8 +32,8 @@ TEST(Primitives, RPave)
    EXPECT_EQ(pave->border.color, RColor::kRed);
    EXPECT_EQ(pave->border.width, 3.f);
 
-   EXPECT_EQ(pave->AttrFill().GetColor(), RColor::kBlue);
-   EXPECT_EQ(pave->AttrFill().GetStyle(), 3003);
+   EXPECT_EQ(pave->fill.color, RColor::kBlue);
+   EXPECT_EQ(pave->fill.style, 3003);
 
    EXPECT_EQ(pave->GetCornerX(), 0.03_normal);
    EXPECT_EQ(pave->GetWidth(), 0.4_normal);

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -16,8 +16,9 @@ TEST(Primitives, RPave)
 
    auto frame = canv.AddFrame();
 
-   auto pave = canv.Draw<RPave>();
-   pave->AttrBorder().SetColor(RColor::kRed).SetWidth(3);
+   auto pave = canv.Add<RPave>();
+   pave->border.color = RColor::kRed;
+   pave->border.width = 3.f;
    pave->AttrFill().SetColor(RColor::kBlue).SetStyle(3003);
    pave->SetCornerX(0.03_normal);
    pave->SetWidth(0.4_normal);
@@ -27,8 +28,8 @@ TEST(Primitives, RPave)
    // when adding pave, RFrame is automatically created
    EXPECT_EQ(canv.NumPrimitives(), 2u);
 
-   EXPECT_EQ(pave->AttrBorder().GetColor(), RColor::kRed);
-   EXPECT_EQ(pave->AttrBorder().GetWidth(), 3);
+   EXPECT_EQ(pave->border.color, RColor::kRed);
+   EXPECT_EQ(pave->border.width, 3.f);
 
    EXPECT_EQ(pave->AttrFill().GetColor(), RColor::kBlue);
    EXPECT_EQ(pave->AttrFill().GetStyle(), 3003);

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -16,16 +16,14 @@
 using namespace ROOT::Experimental;
 
 class CustomDrawable : public RDrawable {
-   RAttrLine  fAttrLine{this, "line"};         ///<! line attributes
    RAttrFill  fAttrFill{this, "fill"};         ///<! fill attributes
    RAttrText  fAttrText{this, "text"};         ///<! text attributes
    RAttrMargins fAttrMargins{this, "margins"}; ///<! margin attributes
 
 public:
-   CustomDrawable() : RDrawable("custom") {}
+   RAttrLine  line{this, "line"};         ///<! line attributes
 
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
+   CustomDrawable() : RDrawable("custom") {}
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }
@@ -55,7 +53,7 @@ TEST(RStyleTest, CreateStyle)
 
    drawable.UseStyle(style);
 
-   EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 2.);
+   EXPECT_DOUBLE_EQ(drawable.line.width, 2.f);
 
    EXPECT_EQ(drawable.AttrFill().GetStyle(), 5);
 
@@ -77,9 +75,9 @@ TEST(RStyleTest, CreateCss)
 
    drawable.UseStyle(style);
 
-   EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 2.);
+   EXPECT_DOUBLE_EQ(drawable.line.width, 2.f);
 
-   EXPECT_EQ(drawable.AttrLine().GetColor(), RColor::kRed);
+   EXPECT_EQ(drawable.line.color, RColor::kRed);
 
    EXPECT_EQ(drawable.AttrFill().GetStyle(), 5);
 
@@ -116,10 +114,10 @@ TEST(RStyleTest, LostStyle)
       // here weak_ptr will be set, therefore after style is deleted drawable will loose it
       drawable.UseStyle(style);
 
-      EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 2.);
+      EXPECT_DOUBLE_EQ(drawable.line.width, 2.f);
    }
 
    // here style no longer exists
-   EXPECT_DOUBLE_EQ(drawable.AttrLine().GetWidth(), 1.);
+   EXPECT_DOUBLE_EQ(drawable.line.width, 1.f);
 }
 

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -16,17 +16,14 @@
 using namespace ROOT::Experimental;
 
 class CustomDrawable : public RDrawable {
-   RAttrText  fAttrText{this, "text"};         ///<! text attributes
    RAttrMargins fAttrMargins{this, "margins"}; ///<! margin attributes
 
 public:
    RAttrLine  line{this, "line"};         ///<! line attributes
    RAttrFill  fill{this, "fill"};         ///<! fill attributes
+   RAttrText  text{this, "text"};         ///<! text attributes
 
    CustomDrawable() : RDrawable("custom") {}
-
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
 
    const RAttrMargins &AttrMargins() const { return fAttrMargins; }
    RAttrMargins &AttrMargins() { return fAttrMargins; }
@@ -53,7 +50,7 @@ TEST(RStyleTest, CreateStyle)
 
    EXPECT_EQ(drawable.fill.style, 5);
 
-   EXPECT_DOUBLE_EQ(drawable.AttrText().GetSize(), 3.);
+   EXPECT_DOUBLE_EQ(drawable.text.size, 3.);
 }
 
 
@@ -77,7 +74,7 @@ TEST(RStyleTest, CreateCss)
 
    EXPECT_EQ(drawable.fill.style, 5);
 
-   EXPECT_DOUBLE_EQ(drawable.AttrText().GetSize(), 3.);
+   EXPECT_DOUBLE_EQ(drawable.text.size, 3.);
 }
 
 

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -74,6 +74,32 @@ TEST(RStyleTest, CreateCss)
    EXPECT_DOUBLE_EQ(drawable.text.size, 3.);
 }
 
+TEST(RStyleTest, CaseInsensitive)
+{
+   auto style = RStyle::Parse(" custom { line_Width: 2; Line_coloR: red; }"
+                              " #customID { fill_style: 5; }"
+                              " .custom_Cclass { text_size: 3; }");
+
+   ASSERT_NE(style, nullptr);
+
+   CustomDrawable drawable;
+   drawable.SetId("customid");
+   drawable.SetCssClass("custom_class");
+
+   drawable.UseStyle(style);
+
+   // attribute names should be case insensetive
+   EXPECT_DOUBLE_EQ(drawable.line.width, 2.f);
+
+   EXPECT_EQ(drawable.line.color, RColor::kRed);
+
+   // but id should have exact match
+   EXPECT_NE(drawable.fill.style, 5);
+
+   // and class name should have exact match
+   EXPECT_NE(drawable.text.size, 3.);
+}
+
 
 TEST(RStyleTest, TestMargins)
 {

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -16,17 +16,14 @@
 using namespace ROOT::Experimental;
 
 class CustomDrawable : public RDrawable {
-   RAttrMargins fAttrMargins{this, "margins"}; ///<! margin attributes
 
 public:
    RAttrLine  line{this, "line"};         ///<! line attributes
    RAttrFill  fill{this, "fill"};         ///<! fill attributes
    RAttrText  text{this, "text"};         ///<! text attributes
+   RAttrMargins margins{this, "margins"}; ///<! margins attributes
 
    CustomDrawable() : RDrawable("custom") {}
-
-   const RAttrMargins &AttrMargins() const { return fAttrMargins; }
-   RAttrMargins &AttrMargins() { return fAttrMargins; }
 };
 
 
@@ -80,18 +77,16 @@ TEST(RStyleTest, CreateCss)
 
 TEST(RStyleTest, TestMargins)
 {
-   auto style = RStyle::Parse(" custom { margins_all: 0.3; margins_left: 0.2; margins_right: 0.4; }");
+   auto style = RStyle::Parse(" custom { margins_top: 0.3; margins_left: 0.2; margins_right: 0.4; }");
 
    ASSERT_NE(style, nullptr);
 
    CustomDrawable drawable;
    drawable.UseStyle(style);
 
-   auto &margins = drawable.AttrMargins();
-
-   EXPECT_EQ(margins.GetLeft(), 0.2);
-   EXPECT_EQ(margins.GetRight(), 0.4_normal);
-   EXPECT_EQ(margins.GetAll(), 0.3_normal);
+   EXPECT_EQ(drawable.margins.left, 0.2);
+   EXPECT_EQ(drawable.margins.right, 0.4_normal);
+   EXPECT_EQ(drawable.margins.top, 0.3_normal);
 }
 
 

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -16,24 +16,20 @@
 using namespace ROOT::Experimental;
 
 class CustomDrawable : public RDrawable {
-   RAttrFill  fAttrFill{this, "fill"};         ///<! fill attributes
    RAttrText  fAttrText{this, "text"};         ///<! text attributes
    RAttrMargins fAttrMargins{this, "margins"}; ///<! margin attributes
 
 public:
    RAttrLine  line{this, "line"};         ///<! line attributes
+   RAttrFill  fill{this, "fill"};         ///<! fill attributes
 
    CustomDrawable() : RDrawable("custom") {}
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }
 
    const RAttrMargins &AttrMargins() const { return fAttrMargins; }
    RAttrMargins &AttrMargins() { return fAttrMargins; }
-
 };
 
 
@@ -55,7 +51,7 @@ TEST(RStyleTest, CreateStyle)
 
    EXPECT_DOUBLE_EQ(drawable.line.width, 2.f);
 
-   EXPECT_EQ(drawable.AttrFill().GetStyle(), 5);
+   EXPECT_EQ(drawable.fill.style, 5);
 
    EXPECT_DOUBLE_EQ(drawable.AttrText().GetSize(), 3.);
 }
@@ -79,7 +75,7 @@ TEST(RStyleTest, CreateCss)
 
    EXPECT_EQ(drawable.line.color, RColor::kRed);
 
-   EXPECT_EQ(drawable.AttrFill().GetStyle(), 5);
+   EXPECT_EQ(drawable.fill.style, 5);
 
    EXPECT_DOUBLE_EQ(drawable.AttrText().GetSize(), 3.);
 }

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -31,7 +31,6 @@ namespace Experimental {
 class RBox : public RDrawable {
 
    RPadPos fP1, fP2;                                   ///< box corners coordinates
-   RAttrFill fAttrFill{this, "fill"};                  ///<! box fill attributes
    RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 
@@ -42,6 +41,7 @@ protected:
 public:
 
    RAttrBorder border{this, "border"};            ///<! box border attributes
+   RAttrFill fill{this, "fill"};                  ///<! box fill attributes
 
    RBox() : RDrawable("box") {}
 
@@ -56,9 +56,6 @@ public:
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 
    RBox &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -9,13 +9,12 @@
 #ifndef ROOT7_RBox
 #define ROOT7_RBox
 
-#include <ROOT/RDrawable.hxx>
+#include <ROOT/ROnFrameDrawable.hxx>
 #include <ROOT/RAttrFill.hxx>
 #include <ROOT/RAttrBorder.hxx>
 #include <ROOT/RPadPos.hxx>
 
 #include <initializer_list>
-
 
 namespace ROOT {
 namespace Experimental {
@@ -28,22 +27,20 @@ namespace Experimental {
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RBox : public RDrawable {
+class RBox : public ROnFrameDrawable {
 
    RPadPos fP1, fP2;                                   ///< box corners coordinates
-   RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
-   RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 
 protected:
    // constructor for derived classes
-   RBox(const std::string &subtype) : RDrawable(subtype) {}
+   RBox(const std::string &subtype) : ROnFrameDrawable(subtype) {}
 
 public:
 
    RAttrBorder border{this, "border"};            ///<! box border attributes
    RAttrFill fill{this, "fill"};                  ///<! box fill attributes
 
-   RBox() : RDrawable("box") {}
+   RBox() : RBox("box") {}
 
    RBox(const RPadPos &p1, const RPadPos &p2) : RBox()
    {
@@ -56,12 +53,6 @@ public:
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
-
-   RBox &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
-   bool GetOnFrame() const { return fOnFrame; }
-
-   RBox &SetClipping(bool on = true) { fClipping = on; return *this; }
-   bool GetClipping() const { return fClipping; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -31,7 +31,6 @@ namespace Experimental {
 class RBox : public RDrawable {
 
    RPadPos fP1, fP2;                                   ///< box corners coordinates
-   RAttrBorder fAttrBorder{this, "border"};            ///<! box border attributes
    RAttrFill fAttrFill{this, "fill"};                  ///<! box fill attributes
    RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
@@ -41,6 +40,9 @@ protected:
    RBox(const std::string &subtype) : RDrawable(subtype) {}
 
 public:
+
+   RAttrBorder border{this, "border"};            ///<! box border attributes
+
    RBox() : RDrawable("box") {}
 
    RBox(const RPadPos &p1, const RPadPos &p2) : RBox()
@@ -54,9 +56,6 @@ public:
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
-
-   const RAttrBorder &AttrBorder() const { return fAttrBorder; }
-   RAttrBorder &AttrBorder() { return fAttrBorder; }
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -37,6 +37,7 @@ protected:
    bool IsFrameRequired() const final { return true; }
 
 public:
+
    RAttrText text{this, "text"};                               ///<! title text attributes
    RAttrValue<RPadLength> margin{this, "margin", 0.02_normal}; ///<! title margin to frame
    RAttrValue<RPadLength> height{this, "height", 0.05_normal}; ///<! title height

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -31,7 +31,6 @@ welcome!
 class RFrameTitle final : public RDrawable {
 
    std::string fText;                                           ///< title to display
-   RAttrText fAttrText{this, "text"};                           ///<! title text attributes
    RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! title margin
    RAttrValue<RPadLength> fHeight{this, "height", 0.05_normal}; ///<! title height
 
@@ -39,6 +38,8 @@ protected:
    bool IsFrameRequired() const final { return true; }
 
 public:
+   RAttrText text{this, "text"};                           ///<! title text attributes
+
    RFrameTitle() : RDrawable("title") {}
 
    RFrameTitle(const std::string &txt) : RFrameTitle() { fText = txt; }
@@ -63,9 +64,6 @@ public:
       return *this;
    }
    RPadLength GetHeight() const { return fHeight; }
-
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -19,7 +19,7 @@
 namespace ROOT {
 namespace Experimental {
 
-/** \class ROOT::Experimental::RFrameTitle
+/** \class RFrameTitle
 \ingroup GrafROOT7
 \brief A title for the RFrame.
 \author Sergey Linev <s.linev@gsi.de>
@@ -31,14 +31,15 @@ welcome!
 class RFrameTitle final : public RDrawable {
 
    std::string fText;                                           ///< title to display
-   RAttrValue<RPadLength> fMargin{this, "margin", 0.02_normal}; ///<! title margin
-   RAttrValue<RPadLength> fHeight{this, "height", 0.05_normal}; ///<! title height
 
 protected:
+
    bool IsFrameRequired() const final { return true; }
 
 public:
-   RAttrText text{this, "text"};                           ///<! title text attributes
+   RAttrText text{this, "text"};                               ///<! title text attributes
+   RAttrValue<RPadLength> margin{this, "margin", 0.02_normal}; ///<! title margin to frame
+   RAttrValue<RPadLength> height{this, "height", 0.05_normal}; ///<! title height
 
    RFrameTitle() : RDrawable("title") {}
 
@@ -50,20 +51,6 @@ public:
       return *this;
    }
    const std::string &GetText() const { return fText; }
-
-   RFrameTitle &SetMargin(const RPadLength &pos)
-   {
-      fMargin = pos;
-      return *this;
-   }
-   RPadLength GetMargin() const { return fMargin; }
-
-   RFrameTitle &SetHeight(const RPadLength &pos)
-   {
-      fHeight = pos;
-      return *this;
-   }
-   RPadLength GetHeight() const { return fHeight; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -195,8 +195,8 @@ public:
 
    RLegend(const RPadPos &corner, const RPadExtent &size) : RLegend()
    {
-      cornerx = corner.Horiz();
-      cornery = corner.Vert();
+      cornerX = corner.Horiz();
+      cornerY = corner.Vert();
       width = size.Horiz();
       height = size.Vert();
    }

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -195,10 +195,10 @@ public:
 
    RLegend(const RPadPos &corner, const RPadExtent &size) : RLegend()
    {
-      SetCornerX(corner.Horiz());
-      SetCornerY(corner.Vert());
-      SetWidth(size.Horiz());
-      SetHeight(size.Vert());
+      cornerx = corner.Horiz();
+      cornery = corner.Vert();
+      width = size.Horiz();
+      height = size.Vert();
    }
 
    RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }

--- a/graf2d/primitivesv7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLine.hxx
@@ -9,9 +9,11 @@
 #ifndef ROOT7_RLine
 #define ROOT7_RLine
 
-#include <ROOT/RDrawable.hxx>
+#include <ROOT/ROnFrameDrawable.hxx>
 #include <ROOT/RAttrLine.hxx>
 #include <ROOT/RPadPos.hxx>
+
+#include <initializer_list>
 
 namespace ROOT {
 namespace Experimental {
@@ -19,22 +21,18 @@ namespace Experimental {
 /** \class RLine
 \ingroup GrafROOT7
 \brief A simple line.
-\author Olivier Couet <Olivier.Couet@cern.ch>
-\author Sergey Linev <S.Linev@gsi.de>
+\authors Olivier Couet <Olivier.Couet@cern.ch>, Sergey Linev <S.Linev@gsi.de>
 \date 2017-10-16
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RLine : public RDrawable {
+class RLine : public ROnFrameDrawable {
 
-   RPadPos fP1, fP2;                                   ///< line begin/end
-   RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
-   RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
+   RPadPos fP1, fP2; ///< line begin/end
 public:
+   RAttrLine line{this, "line"}; ///<! line attributes
 
-   RAttrLine line{this, "line"};                  ///<! line attributes
-
-   RLine() : RDrawable("line") {}
+   RLine() : ROnFrameDrawable("line") {}
 
    RLine(const RPadPos &p1, const RPadPos &p2) : RLine()
    {
@@ -42,17 +40,20 @@ public:
       fP2 = p2;
    }
 
-   RLine &SetP1(const RPadPos &p1) { fP1 = p1; return *this; }
-   RLine &SetP2(const RPadPos &p2) { fP2 = p2; return *this; }
+   RLine &SetP1(const RPadPos &p1)
+   {
+      fP1 = p1;
+      return *this;
+   }
+
+   RLine &SetP2(const RPadPos &p2)
+   {
+      fP2 = p2;
+      return *this;
+   }
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
-
-   RLine &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
-   bool GetOnFrame() const { return fOnFrame; }
-
-   RLine &SetClipping(bool on = true) { fClipping = on; return *this; }
-   bool GetClipping() const { return fClipping; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RLine.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLine.hxx
@@ -28,10 +28,12 @@ namespace Experimental {
 class RLine : public RDrawable {
 
    RPadPos fP1, fP2;                                   ///< line begin/end
-   RAttrLine fAttrLine{this, "line"};                  ///<! line attributes
    RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 public:
+
+   RAttrLine line{this, "line"};                  ///<! line attributes
+
    RLine() : RDrawable("line") {}
 
    RLine(const RPadPos &p1, const RPadPos &p2) : RLine()
@@ -45,9 +47,6 @@ public:
 
    const RPadPos &GetP1() const { return fP1; }
    const RPadPos &GetP2() const { return fP2; }
-
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
 
    RLine &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }

--- a/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
@@ -29,20 +29,18 @@ namespace Experimental {
 class RMarker : public RDrawable {
 
    RPadPos fP;                                         ///< position
-   RAttrMarker fAttrMarker{this, "marker"};            ///<! marker attributes
    RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 
 public:
+   RAttrMarker marker{this, "marker"};            ///<! marker attributes
+
    RMarker() : RDrawable("marker") {}
 
    RMarker(const RPadPos &p) : RMarker() { fP = p; }
 
    RMarker &SetP(const RPadPos &p) { fP = p; return *this; }
    const RPadPos &GetP() const { return fP; }
-
-   const RAttrMarker &AttrMarker() const { return fAttrMarker; }
-   RAttrMarker &AttrMarker() { return fAttrMarker; }
 
    RMarker &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }

--- a/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RMarker.hxx
@@ -9,7 +9,7 @@
 #ifndef ROOT7_RMarker
 #define ROOT7_RMarker
 
-#include <ROOT/RDrawable.hxx>
+#include <ROOT/ROnFrameDrawable.hxx>
 #include <ROOT/RAttrMarker.hxx>
 #include <ROOT/RPadPos.hxx>
 
@@ -26,28 +26,19 @@ namespace Experimental {
 \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
 */
 
-class RMarker : public RDrawable {
+class RMarker : public ROnFrameDrawable {
 
    RPadPos fP;                                         ///< position
-   RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
-   RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 
 public:
    RAttrMarker marker{this, "marker"};            ///<! marker attributes
 
-   RMarker() : RDrawable("marker") {}
+   RMarker() : ROnFrameDrawable("marker") {}
 
    RMarker(const RPadPos &p) : RMarker() { fP = p; }
 
    RMarker &SetP(const RPadPos &p) { fP = p; return *this; }
    const RPadPos &GetP() const { return fP; }
-
-   RMarker &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
-   bool GetOnFrame() const { return fOnFrame; }
-
-   RMarker &SetClipping(bool on = true) { fClipping = on; return *this; }
-   bool GetClipping() const { return fClipping; }
-
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RPaveText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RPaveText.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/graf2d/primitivesv7/inc/ROOT/RText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RText.hxx
@@ -31,11 +31,12 @@ class RText : public RDrawable {
 
    std::string fText;                                  ///< text to display
    RPadPos fPos;                                       ///< position
-   RAttrText fAttrText{this, "text"};                  ///<! text attributes
    RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
    RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 
 public:
+   RAttrText text{this, "text"};                  ///<! text attributes
+
    RText() : RDrawable("text") {}
 
    RText(const std::string &txt) : RText() { fText = txt; }
@@ -51,9 +52,6 @@ public:
 
    RText &SetPos(const RPadPos &p) { fPos = p; return *this; }
    const RPadPos &GetPos() const { return fPos; }
-
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
 
    RText &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
    bool GetOnFrame() const { return fOnFrame; }

--- a/graf2d/primitivesv7/inc/ROOT/RText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RText.hxx
@@ -9,10 +9,11 @@
 #ifndef ROOT7_RText
 #define ROOT7_RText
 
-#include <ROOT/RDrawable.hxx>
+#include <ROOT/ROnFrameDrawable.hxx>
 #include <ROOT/RAttrText.hxx>
 #include <ROOT/RPadPos.hxx>
 
+#include <initializer_list>
 #include <string>
 
 namespace ROOT {
@@ -27,17 +28,15 @@ namespace Experimental {
 welcome!
 */
 
-class RText : public RDrawable {
+class RText : public ROnFrameDrawable {
 
    std::string fText;                                  ///< text to display
    RPadPos fPos;                                       ///< position
-   RAttrValue<bool> fOnFrame{this, "onframe", false};  ///<! is drawn on the frame or not
-   RAttrValue<bool> fClipping{this, "clipping", false}; ///<! is clipping on when drawn on the frame
 
 public:
    RAttrText text{this, "text"};                  ///<! text attributes
 
-   RText() : RDrawable("text") {}
+   RText() : ROnFrameDrawable("text") {}
 
    RText(const std::string &txt) : RText() { fText = txt; }
 
@@ -52,12 +51,6 @@ public:
 
    RText &SetPos(const RPadPos &p) { fPos = p; return *this; }
    const RPadPos &GetPos() const { return fPos; }
-
-   RText &SetOnFrame(bool on = true) { fOnFrame = on; return *this; }
-   bool GetOnFrame() const { return fOnFrame; }
-
-   RText &SetClipping(bool on = true) { fClipping = on; return *this; }
-   bool GetClipping() const { return fClipping; }
 };
 
 } // namespace Experimental

--- a/graf2d/primitivesv7/inc/ROOT/RText.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RText.hxx
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 1995-2017, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -19,16 +19,17 @@ TEST(Primitives, RBox)
    box->border.color = RColor::kRed;
    box->border.width = 5.f;
    box->border.style = 7;
-   box->AttrFill().SetColor(RColor::kBlue).SetStyle(6);
+   box->fill.color = RColor::kBlue;
+   box->fill.style = 6;
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(box->border.color, RColor::kRed);
-   EXPECT_DOUBLE_EQ(box->border.width, 5.f);
+   EXPECT_FLOAT_EQ(box->border.width, 5.f);
    EXPECT_EQ(box->border.style, 7);
 
-   EXPECT_EQ(box->AttrFill().GetColor(), RColor::kBlue);
-   EXPECT_EQ(box->AttrFill().GetStyle(), 6);
+   EXPECT_EQ(box->fill.color, RColor::kBlue);
+   EXPECT_EQ(box->fill.style, 6);
 }
 
 // Test RLine API
@@ -95,7 +96,8 @@ TEST(Primitives, RLegend)
    line3->line.color = RColor::kBlue;
 
    auto legend = canv.Draw<RLegend>("Legend title");
-   legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->fill.style = 5;
+   legend->fill.color = RColor::kWhite;
    legend->border.width = 2;
    legend->border.color = RColor::kRed;
    legend->AddEntry(line1, "RLine 1");
@@ -106,9 +108,10 @@ TEST(Primitives, RLegend)
 
    EXPECT_EQ(legend->NumEntries(), 3u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
+   EXPECT_EQ(legend->fill.style, 5);
+   EXPECT_EQ(legend->fill.color, RColor::kWhite);
    EXPECT_EQ(legend->border.width, 2);
    EXPECT_EQ(legend->border.color, RColor::kRed);
-   EXPECT_EQ(legend->AttrFill().GetColor(), RColor::kWhite);
 }
 
 // Test RPaveText API
@@ -121,7 +124,8 @@ TEST(Primitives, RPaveText)
    text->AttrText().SetColor(RColor::kBlack).SetSize(12).SetAlign(13).SetFontFamily("Times New Roman");
    text->border.color = RColor::kRed;
    text->border.width = 3;
-   text->AttrFill().SetColor(RColor::kBlue).SetStyle(3003);
+   text->fill.color = RColor::kBlue;
+   text->fill.style = 3003;
 
    text->AddLine("First line");
    text->AddLine("Second line");
@@ -142,7 +146,7 @@ TEST(Primitives, RPaveText)
    EXPECT_EQ(text->border.color, RColor::kRed);
    EXPECT_EQ(text->border.width, 3);
 
-   EXPECT_EQ(text->AttrFill().GetColor(), RColor::kBlue);
-   EXPECT_EQ(text->AttrFill().GetStyle(), 3003);
+   EXPECT_EQ(text->fill.color, RColor::kBlue);
+   EXPECT_EQ(text->fill.style, 3003);
 }
 

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -41,7 +41,7 @@ TEST(Primitives, RLine)
    line->line.color = RColor::kRed;
    line->line.width = 5.;
    line->line.style = 7;
-   line->onframe = true;
+   line->onFrame = true;
    line->clipping = false;
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
@@ -49,7 +49,7 @@ TEST(Primitives, RLine)
    EXPECT_EQ(line->line.color, RColor::kRed);
    EXPECT_DOUBLE_EQ(line->line.width, 5.);
    EXPECT_EQ(line->line.style, 7);
-   EXPECT_EQ(line->onframe, true);
+   EXPECT_EQ(line->onFrame, true);
    EXPECT_EQ(line->clipping, false);
 }
 

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -75,7 +75,7 @@ TEST(Primitives, RText)
    text->text.size = 12.5;
    text->text.angle = 90.;
    text->text.align = 13;
-   text->text.font_family = "Arial";
+   text->text.font.family = "Arial";
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
@@ -84,7 +84,7 @@ TEST(Primitives, RText)
    EXPECT_DOUBLE_EQ(text->text.size, 12.5);
    EXPECT_DOUBLE_EQ(text->text.angle, 90.);
    EXPECT_EQ(text->text.align, 13);
-   EXPECT_EQ(text->text.font_family, "Arial");
+   EXPECT_EQ(text->text.font.family, "Arial");
 }
 
 // Test RLegend API
@@ -128,7 +128,7 @@ TEST(Primitives, RPaveText)
    text->text.color = RColor::kBlack;
    text->text.size = 12;
    text->text.align = 13;
-   text->text.font_family = "Times New Roman";
+   text->text.font.family = "Times New Roman";
    text->border.color = RColor::kRed;
    text->border.width = 3;
    text->fill.color = RColor::kBlue;
@@ -148,7 +148,7 @@ TEST(Primitives, RPaveText)
    EXPECT_EQ(text->text.color, RColor::kBlack);
    EXPECT_DOUBLE_EQ(text->text.size, 12);
    EXPECT_EQ(text->text.align, 13);
-   EXPECT_EQ(text->text.font_family, "Times New Roman");
+   EXPECT_EQ(text->text.font.family, "Times New Roman");
 
    EXPECT_EQ(text->border.color, RColor::kRed);
    EXPECT_EQ(text->border.width, 3);

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -16,14 +16,16 @@ TEST(Primitives, RBox)
    RCanvas canv;
    auto box = canv.Draw<RBox>(RPadPos(0.1_normal, 0.3_normal), RPadPos(0.3_normal,0.6_normal));
 
-   box->AttrBorder().SetColor(RColor::kRed).SetWidth(5.).SetStyle(7);
+   box->border.color = RColor::kRed;
+   box->border.width = 5.f;
+   box->border.style = 7;
    box->AttrFill().SetColor(RColor::kBlue).SetStyle(6);
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(box->AttrBorder().GetColor(), RColor::kRed);
-   EXPECT_DOUBLE_EQ(box->AttrBorder().GetWidth(), 5.);
-   EXPECT_EQ(box->AttrBorder().GetStyle(), 7);
+   EXPECT_EQ(box->border.color, RColor::kRed);
+   EXPECT_DOUBLE_EQ(box->border.width, 5.f);
+   EXPECT_EQ(box->border.style, 7);
 
    EXPECT_EQ(box->AttrFill().GetColor(), RColor::kBlue);
    EXPECT_EQ(box->AttrFill().GetStyle(), 6);
@@ -35,13 +37,15 @@ TEST(Primitives, RLine)
    RCanvas canv;
    auto line = canv.Draw<RLine>(RPadPos(0.1_normal, 0.1_normal), RPadPos(0.9_normal,0.9_normal));
 
-   line->AttrLine().SetColor(RColor::kRed).SetWidth(5.).SetStyle(7);
+   line->line.color = RColor::kRed;
+   line->line.width = 5.;
+   line->line.style = 7;
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(line->AttrLine().GetColor(), RColor::kRed);
-   EXPECT_DOUBLE_EQ(line->AttrLine().GetWidth(), 5.);
-   EXPECT_EQ(line->AttrLine().GetStyle(), 7);
+   EXPECT_EQ(line->line.color, RColor::kRed);
+   EXPECT_DOUBLE_EQ(line->line.width, 5.f);
+   EXPECT_EQ(line->line.style, 7);
 }
 
 // Test RMarker API
@@ -86,13 +90,14 @@ TEST(Primitives, RLegend)
    auto line2 = canv.Draw<RLine>(RPadPos(0.1_normal, 0.9_normal), RPadPos(0.9_normal,0.1_normal));
    auto line3 = canv.Draw<RLine>(RPadPos(0.9_normal, 0.1_normal), RPadPos(0.1_normal,0.9_normal));
 
-   line1->AttrLine().SetColor(RColor::kRed);
-   line2->AttrLine().SetColor(RColor::kGreen);
-   line3->AttrLine().SetColor(RColor::kBlue);
+   line1->line.color = RColor::kRed;
+   line2->line.color = RColor::kGreen;
+   line3->line.color = RColor::kBlue;
 
    auto legend = canv.Draw<RLegend>("Legend title");
    legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
-   legend->AttrBorder().SetWidth(2).SetColor(RColor::kRed);
+   legend->border.width = 2;
+   legend->border.color = RColor::kRed;
    legend->AddEntry(line1, "RLine 1");
    legend->AddEntry(line2, "RLine 2");
    legend->AddEntry(line3, "RLine 3");
@@ -101,6 +106,8 @@ TEST(Primitives, RLegend)
 
    EXPECT_EQ(legend->NumEntries(), 3u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
+   EXPECT_EQ(legend->border.width, 2);
+   EXPECT_EQ(legend->border.color, RColor::kRed);
    EXPECT_EQ(legend->AttrFill().GetColor(), RColor::kWhite);
 }
 
@@ -109,10 +116,11 @@ TEST(Primitives, RPaveText)
 {
    RCanvas canv;
 
-   auto text = canv.Draw<RPaveText>();
+   auto text = canv.Add<RPaveText>();
 
    text->AttrText().SetColor(RColor::kBlack).SetSize(12).SetAlign(13).SetFontFamily("Times New Roman");
-   text->AttrBorder().SetColor(RColor::kRed).SetWidth(3);
+   text->border.color = RColor::kRed;
+   text->border.width = 3;
    text->AttrFill().SetColor(RColor::kBlue).SetStyle(3003);
 
    text->AddLine("First line");
@@ -131,8 +139,8 @@ TEST(Primitives, RPaveText)
    EXPECT_EQ(text->AttrText().GetAlign(), 13);
    EXPECT_EQ(text->AttrText().GetFontFamily(), "Times New Roman");
 
-   EXPECT_EQ(text->AttrBorder().GetColor(), RColor::kRed);
-   EXPECT_EQ(text->AttrBorder().GetWidth(), 3);
+   EXPECT_EQ(text->border.color, RColor::kRed);
+   EXPECT_EQ(text->border.width, 3);
 
    EXPECT_EQ(text->AttrFill().GetColor(), RColor::kBlue);
    EXPECT_EQ(text->AttrFill().GetStyle(), 3003);

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -55,13 +55,13 @@ TEST(Primitives, RMarker)
    RCanvas canv;
    auto marker = canv.Draw<RMarker>(RPadPos(0.5_normal, 0.5_normal));
 
-   marker->AttrMarker().SetStyle(RAttrMarker::kStar).SetSize(2.5).SetColor(RColor::kGreen);
+   marker->marker = RAttrMarker(RColor::kGreen, 2.5, RAttrMarker::kStar);
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
-   EXPECT_EQ(marker->AttrMarker().GetColor(), RColor::kGreen);
-   EXPECT_DOUBLE_EQ(marker->AttrMarker().GetSize(), 2.5);
-   EXPECT_EQ(marker->AttrMarker().GetStyle(), RAttrMarker::kStar);
+   EXPECT_EQ(marker->marker.color, RColor::kGreen);
+   EXPECT_DOUBLE_EQ(marker->marker.size, 2.5);
+   EXPECT_EQ(marker->marker.style, RAttrMarker::kStar);
 }
 
 // Test RText API

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -41,12 +41,16 @@ TEST(Primitives, RLine)
    line->line.color = RColor::kRed;
    line->line.width = 5.;
    line->line.style = 7;
+   line->onframe = true;
+   line->clipping = false;
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(line->line.color, RColor::kRed);
    EXPECT_DOUBLE_EQ(line->line.width, 5.f);
    EXPECT_EQ(line->line.style, 7);
+   EXPECT_EQ(line->onframe, true);
+   EXPECT_EQ(line->clipping, false);
 }
 
 // Test RMarker API

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -17,7 +17,7 @@ TEST(Primitives, RBox)
    auto box = canv.Draw<RBox>(RPadPos(0.1_normal, 0.3_normal), RPadPos(0.3_normal,0.6_normal));
 
    box->border.color = RColor::kRed;
-   box->border.width = 5.f;
+   box->border.width = 5.;
    box->border.style = 7;
    box->fill.color = RColor::kBlue;
    box->fill.style = 6;
@@ -25,7 +25,7 @@ TEST(Primitives, RBox)
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(box->border.color, RColor::kRed);
-   EXPECT_FLOAT_EQ(box->border.width, 5.f);
+   EXPECT_DOUBLE_EQ(box->border.width, 5.);
    EXPECT_EQ(box->border.style, 7);
 
    EXPECT_EQ(box->fill.color, RColor::kBlue);
@@ -47,7 +47,7 @@ TEST(Primitives, RLine)
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(line->line.color, RColor::kRed);
-   EXPECT_DOUBLE_EQ(line->line.width, 5.f);
+   EXPECT_DOUBLE_EQ(line->line.width, 5.);
    EXPECT_EQ(line->line.style, 7);
    EXPECT_EQ(line->onframe, true);
    EXPECT_EQ(line->clipping, false);
@@ -106,7 +106,7 @@ TEST(Primitives, RLegend)
    auto legend = canv.Draw<RLegend>("Legend title");
    legend->fill.style = 5;
    legend->fill.color = RColor::kWhite;
-   legend->border.width = 2;
+   legend->border.width = 2.;
    legend->border.color = RColor::kRed;
    legend->AddEntry(line1, "RLine 1");
    legend->AddEntry(line2, "RLine 2");
@@ -118,7 +118,7 @@ TEST(Primitives, RLegend)
    EXPECT_EQ(legend->GetTitle(), "Legend title");
    EXPECT_EQ(legend->fill.style, 5);
    EXPECT_EQ(legend->fill.color, RColor::kWhite);
-   EXPECT_EQ(legend->border.width, 2);
+   EXPECT_EQ(legend->border.width, 2.);
    EXPECT_EQ(legend->border.color, RColor::kRed);
 }
 
@@ -134,7 +134,7 @@ TEST(Primitives, RPaveText)
    text->text.align = 13;
    text->text.font.family = "Times New Roman";
    text->border.color = RColor::kRed;
-   text->border.width = 3;
+   text->border.width = 3.;
    text->fill.color = RColor::kBlue;
    text->fill.style = 3003;
 
@@ -155,9 +155,8 @@ TEST(Primitives, RPaveText)
    EXPECT_EQ(text->text.font.family, "Times New Roman");
 
    EXPECT_EQ(text->border.color, RColor::kRed);
-   EXPECT_EQ(text->border.width, 3);
+   EXPECT_DOUBLE_EQ(text->border.width, 3.);
 
    EXPECT_EQ(text->fill.color, RColor::kBlue);
    EXPECT_EQ(text->fill.style, 3003);
 }
-

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -71,16 +71,20 @@ TEST(Primitives, RText)
 
    auto text = canv.Draw<RText>(RPadPos(0.5_normal, 0.5_normal), "Hello World");
 
-   text->AttrText().SetColor(RColor::kBlack).SetSize(12.5).SetAngle(90.).SetAlign(13).SetFontFamily("Arial");
+   text->text.color = RColor::kBlack;
+   text->text.size = 12.5;
+   text->text.angle = 90.;
+   text->text.align = 13;
+   text->text.font_family = "Arial";
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(text->GetText(), "Hello World");
-   EXPECT_EQ(text->AttrText().GetColor(), RColor::kBlack);
-   EXPECT_DOUBLE_EQ(text->AttrText().GetSize(), 12.5);
-   EXPECT_DOUBLE_EQ(text->AttrText().GetAngle(), 90.);
-   EXPECT_EQ(text->AttrText().GetAlign(), 13);
-   EXPECT_EQ(text->AttrText().GetFontFamily(), "Arial");
+   EXPECT_EQ(text->text.color, RColor::kBlack);
+   EXPECT_DOUBLE_EQ(text->text.size, 12.5);
+   EXPECT_DOUBLE_EQ(text->text.angle, 90.);
+   EXPECT_EQ(text->text.align, 13);
+   EXPECT_EQ(text->text.font_family, "Arial");
 }
 
 // Test RLegend API
@@ -121,7 +125,10 @@ TEST(Primitives, RPaveText)
 
    auto text = canv.Add<RPaveText>();
 
-   text->AttrText().SetColor(RColor::kBlack).SetSize(12).SetAlign(13).SetFontFamily("Times New Roman");
+   text->text.color = RColor::kBlack;
+   text->text.size = 12;
+   text->text.align = 13;
+   text->text.font_family = "Times New Roman";
    text->border.color = RColor::kRed;
    text->border.width = 3;
    text->fill.color = RColor::kBlue;
@@ -138,10 +145,10 @@ TEST(Primitives, RPaveText)
    EXPECT_EQ(text->GetLine(1), "Second line");
    EXPECT_EQ(text->GetLine(2), "Third line");
 
-   EXPECT_EQ(text->AttrText().GetColor(), RColor::kBlack);
-   EXPECT_DOUBLE_EQ(text->AttrText().GetSize(), 12);
-   EXPECT_EQ(text->AttrText().GetAlign(), 13);
-   EXPECT_EQ(text->AttrText().GetFontFamily(), "Times New Roman");
+   EXPECT_EQ(text->text.color, RColor::kBlack);
+   EXPECT_DOUBLE_EQ(text->text.size, 12);
+   EXPECT_EQ(text->text.align, 13);
+   EXPECT_EQ(text->text.font_family, "Times New Roman");
 
    EXPECT_EQ(text->border.color, RColor::kRed);
    EXPECT_EQ(text->border.width, 3);

--- a/graf2d/primitivesv7/test/rline.cxx
+++ b/graf2d/primitivesv7/test/rline.cxx
@@ -35,7 +35,7 @@ TEST(RCanvas, SimpleIO)
          line->SetP1({0.0_normal, 0.0_normal});
          line->SetP2({1.0_normal, 1.0_normal});
 
-         line->AttrLine().SetColor(col);
+         line->line.color = col;
 
          line->SetId("line"s + std::to_string(n));
       }
@@ -58,7 +58,7 @@ TEST(RCanvas, SimpleIO)
 
       RColor col( 10 + n*10, 50 + n*5, 90 + n);
 
-      EXPECT_EQ(line->AttrLine().GetColor(), col);
+      EXPECT_EQ(line->line.color, col);
    }
 
 }

--- a/graf2d/primitivesv7/test/rline.cxx
+++ b/graf2d/primitivesv7/test/rline.cxx
@@ -56,7 +56,7 @@ TEST(RCanvas, SimpleIO)
 
       ASSERT_NE(line, nullptr);
 
-      RColor col( 10 + n*10, 50 + n*5, 90 + n);
+      RColor col(10 + n*10, 50 + n*5, 90 + n);
 
       EXPECT_EQ(line->line.color, col);
    }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -37,7 +37,6 @@ namespace Experimental {
 class RHistDrawableBase : public RDrawable {
    RAttrValue<std::string> fKind{this, "kind", ""};     ///<! hist draw kind
    RAttrValue<int> fSub{this, "sub", -1};               ///<! hist draw sub kind
-   RAttrValue<bool> fOptimize{this, "optimize", false}; ///<! optimize drawing
 
 protected:
 
@@ -62,7 +61,7 @@ protected:
 
    std::unique_ptr<RDisplayItem> Display(const RDisplayContext &ctxt) override
    {
-      if (fOptimize)
+      if (optimize)
          return CreateHistDisplay(ctxt);
 
       return RDrawable::Display(ctxt);
@@ -93,10 +92,9 @@ public:
    RAttrFill fill{this, "fill"};                   ///<! hist fill attributes
    RAttrMarker marker{this, "marker"};             ///<! hist marker attributes
    RAttrText text{this, "text"};                   ///<! hist text attributes
+   RAttrValue<bool> optimize{this, "optimize", false}; ///<! optimize drawing
 
    RHistDrawableBase() : RDrawable("hist") {}
-
-   RHistDrawableBase &Optimize(bool on = true) { fOptimize = on; return *this; }
 };
 
 
@@ -126,34 +124,32 @@ public:
 
 
 class RHist1Drawable final : public RHistDrawable<1> {
-   RAttrValue<double> fBarOffset{this, "bar_offset", 0.}; ///<!  bar offset
-   RAttrValue<double> fBarWidth{this, "bar_width", 1.};   ///<!  bar width
-   RAttrValue<bool> fText{this, "text", false};           ///<! draw text
-   RAttrValue<bool> fSecondX{this, "secondx", false};     ///<! is draw second x axis for histogram
-   RAttrValue<bool> fSecondY{this, "secondy", false};     ///<! is draw second y axis for histogram
-
 protected:
    std::unique_ptr<RDisplayItem> CreateHistDisplay(const RDisplayContext &) override;
 
    bool Is3D() const final { return GetDrawKind() == "lego"; }
 
 public:
+   RAttrValue<bool> drawtext{this, "drawtext", false}; ///<! draw text
+   RAttrValue<bool> secondx{this, "secondx", false};   ///<! is draw second x axis for histogram
+   RAttrValue<bool> secondy{this, "secondy", false};   ///<! is draw second y axis for histogram
+   RAttrValue<double> baroffset{this, "baroffset", 0.}; ///<!  bar offset
+   RAttrValue<double> barwidth{this, "barwidth", 1.};   ///<!  bar width
+
    RHist1Drawable() = default;
 
    template <class HIST>
    RHist1Drawable(const std::shared_ptr<HIST> &hist) : RHistDrawable<1>(hist) {}
 
-   RHist1Drawable &Bar() { SetDrawKind("bar", 0); fBarOffset.Clear(); fBarWidth.Clear(); return *this; }
-   RHist1Drawable &Bar(double offset, double width, bool mode3d = false) { SetDrawKind("bar", mode3d ? 1 : 0); fBarOffset = offset; fBarWidth = width; return *this; }
+   RHist1Drawable &Bar() { SetDrawKind("bar", 0); return *this; }
+   RHist1Drawable &Bar(double _offset, double _width, bool mode3d = false) { SetDrawKind("bar", mode3d ? 1 : 0); baroffset = _offset; barwidth = _width; return *this; }
    RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
    RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
    RHist1Drawable &Star() { marker.style = RAttrMarker::kStar; return Marker(); }
    RHist1Drawable &Hist() { SetDrawKind("hist"); return *this; }
    RHist1Drawable &Line() { SetDrawKind("l"); return *this; }
    RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }
-   RHist1Drawable &Text(bool on = true) { fText = on; return *this; }
-   RHist1Drawable &SecondX(bool on = true) { fSecondX = on; return *this; }
-   RHist1Drawable &SecondY(bool on = true) { fSecondY = on; return *this; }
+   RHist1Drawable &Text() { drawtext = true; return *this; }
 
    bool IsBar() const { return GetDrawKind() == "bar"; }
    bool IsError() const { return GetDrawKind() == "err"; }
@@ -161,18 +157,11 @@ public:
    bool IsHist() const { return GetDrawKind() == "hist"; }
    bool IsLine() const { return GetDrawKind() == "l"; }
    bool IsLego() const { return GetDrawKind() == "lego"; }
-   bool IsText() const { return fText; }
-   bool IsSecondX() const { return fSecondX; }
-   bool IsSecondY() const { return fSecondY; }
-
-   double GetBarOffset() const { return fBarOffset; }
-   double GetBarWidth() const { return fBarWidth; }
+   bool IsText() const { return drawtext; }
 };
 
 
 class RHist2Drawable final : public RHistDrawable<2> {
-   RAttrValue<bool> fText{this, "text", false};               ///<! draw text
-
 protected:
 
    std::unique_ptr<RDisplayItem> CreateHistDisplay(const RDisplayContext &) override;
@@ -180,6 +169,8 @@ protected:
    bool Is3D() const final { return (GetDrawKind() == "lego") || (GetDrawKind() == "surf") || (GetDrawKind() == "err"); }
 
 public:
+   RAttrValue<bool> drawtext{this, "drawtext", false};               ///<! draw text
+
    RHist2Drawable() = default;
 
    template <class HIST>
@@ -193,7 +184,17 @@ public:
    RHist2Drawable &Contour(int kind = 0) { SetDrawKind("cont", kind); return *this; }
    RHist2Drawable &Scatter() { SetDrawKind("scat"); return *this; }
    RHist2Drawable &Arrow() { SetDrawKind("arr"); return *this; }
-   RHist2Drawable &Text(bool on = true) { fText = on; return *this; }
+   RHist2Drawable &Text() { drawtext = true; return *this; }
+
+   bool IsColor() const { return GetDrawKind() == "col"; }
+   bool IsBox() const { return GetDrawKind() == "box"; }
+   bool IsLego() const { return GetDrawKind() == "lego"; }
+   bool IsSurf() const { return GetDrawKind() == "surf"; }
+   bool IsError() const { return GetDrawKind() == "err"; }
+   bool IsContour() const { return GetDrawKind() == "cont"; }
+   bool IsScatter() const { return GetDrawKind() == "scat"; }
+   bool IsArrow() const { return GetDrawKind() == "arr"; }
+   bool IsText() const { return drawtext; }
 };
 
 

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -37,7 +37,6 @@ namespace Experimental {
 class RHistDrawableBase : public RDrawable {
    RAttrValue<std::string> fKind{this, "kind", ""};     ///<! hist draw kind
    RAttrValue<int> fSub{this, "sub", -1};               ///<! hist draw sub kind
-   RAttrFill fAttrFill{this, "fill"};                   ///<! hist fill attributes
    RAttrText fAttrText{this, "text"};                   ///<! hist text attributes
    RAttrMarker fMarkerAttr{this, "marker"};             ///<! hist marker attributes
    RAttrValue<bool> fOptimize{this, "optimize", false}; ///<! optimize drawing
@@ -93,11 +92,9 @@ public:
    friend class RRequest;
 
    RAttrLine line{this, "line"};                   ///<! hist line attributes
+   RAttrFill fill{this, "fill"};                   ///<! hist fill attributes
 
    RHistDrawableBase() : RDrawable("hist") {}
-
-   const RAttrFill &AttrFill() const { return fAttrFill; }
-   RAttrFill &AttrFill() { return fAttrFill; }
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -38,7 +38,6 @@ class RHistDrawableBase : public RDrawable {
    RAttrValue<std::string> fKind{this, "kind", ""};     ///<! hist draw kind
    RAttrValue<int> fSub{this, "sub", -1};               ///<! hist draw sub kind
    RAttrText fAttrText{this, "text"};                   ///<! hist text attributes
-   RAttrMarker fMarkerAttr{this, "marker"};             ///<! hist marker attributes
    RAttrValue<bool> fOptimize{this, "optimize", false}; ///<! optimize drawing
 
 protected:
@@ -93,14 +92,12 @@ public:
 
    RAttrLine line{this, "line"};                   ///<! hist line attributes
    RAttrFill fill{this, "fill"};                   ///<! hist fill attributes
+   RAttrMarker marker{this, "marker"};             ///<! hist marker attributes
 
    RHistDrawableBase() : RDrawable("hist") {}
 
    const RAttrText &AttrText() const { return fAttrText; }
    RAttrText &AttrText() { return fAttrText; }
-
-   const RAttrMarker &AttrMarker() const { return fMarkerAttr; }
-   RAttrMarker &AttrMarker() { return fMarkerAttr; }
 
    RHistDrawableBase &Optimize(bool on = true) { fOptimize = on; return *this; }
 };
@@ -153,7 +150,7 @@ public:
    RHist1Drawable &Bar(double offset, double width, bool mode3d = false) { SetDrawKind("bar", mode3d ? 1 : 0); fBarOffset = offset; fBarWidth = width; return *this; }
    RHist1Drawable &Error(int kind = 0) { SetDrawKind("err", kind); return *this; }
    RHist1Drawable &Marker() { SetDrawKind("p"); return *this; }
-   RHist1Drawable &Star() { AttrMarker().SetStyle(RAttrMarker::kStar); return Marker(); }
+   RHist1Drawable &Star() { marker.style = RAttrMarker::kStar; return Marker(); }
    RHist1Drawable &Hist() { SetDrawKind("hist"); return *this; }
    RHist1Drawable &Line() { SetDrawKind("l"); return *this; }
    RHist1Drawable &Lego(int kind = 0) { SetDrawKind("lego", kind); return *this; }

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -37,7 +37,6 @@ namespace Experimental {
 class RHistDrawableBase : public RDrawable {
    RAttrValue<std::string> fKind{this, "kind", ""};     ///<! hist draw kind
    RAttrValue<int> fSub{this, "sub", -1};               ///<! hist draw sub kind
-   RAttrText fAttrText{this, "text"};                   ///<! hist text attributes
    RAttrValue<bool> fOptimize{this, "optimize", false}; ///<! optimize drawing
 
 protected:
@@ -93,11 +92,9 @@ public:
    RAttrLine line{this, "line"};                   ///<! hist line attributes
    RAttrFill fill{this, "fill"};                   ///<! hist fill attributes
    RAttrMarker marker{this, "marker"};             ///<! hist marker attributes
+   RAttrText text{this, "text"};                   ///<! hist text attributes
 
    RHistDrawableBase() : RDrawable("hist") {}
-
-   const RAttrText &AttrText() const { return fAttrText; }
-   RAttrText &AttrText() { return fAttrText; }
 
    RHistDrawableBase &Optimize(bool on = true) { fOptimize = on; return *this; }
 };

--- a/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistDrawable.hxx
@@ -37,7 +37,6 @@ namespace Experimental {
 class RHistDrawableBase : public RDrawable {
    RAttrValue<std::string> fKind{this, "kind", ""};     ///<! hist draw kind
    RAttrValue<int> fSub{this, "sub", -1};               ///<! hist draw sub kind
-   RAttrLine fAttrLine{this, "line"};                   ///<! hist line attributes
    RAttrFill fAttrFill{this, "fill"};                   ///<! hist fill attributes
    RAttrText fAttrText{this, "text"};                   ///<! hist text attributes
    RAttrMarker fMarkerAttr{this, "marker"};             ///<! hist marker attributes
@@ -93,10 +92,9 @@ public:
 
    friend class RRequest;
 
-   RHistDrawableBase() : RDrawable("hist") {}
+   RAttrLine line{this, "line"};                   ///<! hist line attributes
 
-   const RAttrLine &AttrLine() const { return fAttrLine; }
-   RAttrLine &AttrLine() { return fAttrLine; }
+   RHistDrawableBase() : RDrawable("hist") {}
 
    const RAttrFill &AttrFill() const { return fAttrFill; }
    RAttrFill &AttrFill() { return fAttrFill; }

--- a/hist/histdrawv7/test/draw.cxx
+++ b/hist/histdrawv7/test/draw.cxx
@@ -48,7 +48,7 @@ TEST(DrawOptTest, OneD)
    auto h = std::make_shared<RH1D>(xaxis);
    RCanvas canv;
    auto drawable = canv.Draw(h);
-   drawable->AttrLine().SetColor(RColor::kRed);
-   RColor shouldBeRed = drawable->AttrLine().GetColor();
+   drawable->line.color = RColor::kRed;
+   RColor shouldBeRed = drawable->line.color;
    EXPECT_EQ(shouldBeRed, RColor::kRed);
 }

--- a/hist/histdrawv7/test/io.cxx
+++ b/hist/histdrawv7/test/io.cxx
@@ -55,9 +55,9 @@ TEST(IOTest, OneDOpts)
       auto h = std::make_shared<RH1D>(xaxis);
       RCanvas canv;
       auto drawable1 = canv.Draw(h);
-      drawable1->AttrLine().SetColor(RColor::kRed);
+      drawable1->line.color = RColor::kRed;
       auto drawable2 = canv.Draw(h);
-      drawable2->AttrLine().SetColor(RColor::kBlue);
+      drawable2->line.color = RColor::kBlue;
 
       EXPECT_EQ(canv.NumPrimitives(), 3u);
       EXPECT_NE(canv.GetPrimitive(0).get(), canv.GetPrimitive(1).get());
@@ -85,8 +85,8 @@ TEST(IOTest, OneDOpts)
    ASSERT_NE(dr1, nullptr);
    ASSERT_NE(dr2, nullptr);
 
-   EXPECT_EQ(dr1->AttrLine().GetColor(), RColor::kRed);
-   EXPECT_EQ(dr2->AttrLine().GetColor(), RColor::kBlue);
+   EXPECT_EQ(dr1->line.color, RColor::kRed);
+   EXPECT_EQ(dr2->line.color, RColor::kBlue);
 
    EXPECT_NE(dr1->GetHist(), nullptr);
    EXPECT_NE(dr2->GetHist(), nullptr);

--- a/js/changes.md
+++ b/js/changes.md
@@ -8,6 +8,14 @@
 5. Upgrade d3.js to 6.7.0
 6. Implement "nozoomx" and "nozoomy" draw options for TPad
 7. Implement "frame" draw option for TGaxis - fix position of axis relative to the frame
+8. Preserve position of TPaletteAxis, if provided with histogram. Make default position like in ROOT.
+9. Support basic TLatex symbols in lego plos axis title
+10. Use frame margins when create 3D lego drawings
+11. Implement "nomargins" draw option for pad/canvas
+12. Support custom mouse click/dblcklick handlers for lego plots
+
+## Changes in 6.1.1
+1. Fix bug in TFrame drawing, some interactive features was not properly working
 
 
 ## Changes in 6.1.0

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "30/06/2021";
+   JSROOT.version_date = "2/07/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -883,7 +883,7 @@
                case "Float64": arr = new Float64Array(value.len); break;
                default: arr = new Array(value.len); break;
             }
-            for (let k=0;k<value.len;++k) arr[k] = dflt;
+            for (let k = 0; k < value.len; ++k) arr[k] = dflt;
 
             if (value.b !== undefined) {
                // base64 coding
@@ -895,7 +895,7 @@
                if (arr.buffer) {
                   let dv = new DataView(arr.buffer, value.o || 0),
                       len = Math.min(buf.length, dv.byteLength);
-                  for (let k=0; k<len; ++k)
+                  for (let k = 0; k < len; ++k)
                      dv.setUint8(k, buf.charCodeAt(k));
                } else {
                   throw new Error('base64 coding supported only for native arrays with binary data');
@@ -1016,7 +1016,7 @@
       if (!json) return null;
       let arr = JSON.parse(json);
       if (arr && arr.length)
-         for (let i=0;i<arr.length;++i)
+         for (let i = 0; i < arr.length; ++i)
             arr[i] = JSROOT.parse(arr[i]);
       return arr;
    }
@@ -1351,7 +1351,7 @@
 
       return new Promise((resolve, reject) => {
          element.onload = () => resolve(true);
-         element.onerror = () => reject(Error(`Fail to load ${url}`));
+         element.onerror = () => { element.remove(); reject(Error(`Fail to load ${url}`)); };
          document.getElementsByTagName("head")[0].appendChild(element);
       });
    }
@@ -1755,7 +1755,7 @@
    JSROOT.createTGraph = (npoints, xpts, ypts) => {
       let graph = extend(create("TGraph"), { fBits: 0x408, fName: "graph", fTitle: "title" });
 
-      if (npoints>0) {
+      if (npoints > 0) {
          graph.fMaxSize = graph.fNpoints = npoints;
 
          const usex = (typeof xpts == 'object') && (xpts.length === npoints);
@@ -1780,7 +1780,7 @@
      * let stack = JSROOT.createTHStack(h1, h2, h3); */
    JSROOT.createTHStack = function() {
       let stack = create("THStack");
-      for(let i=0; i<arguments.length; ++i)
+      for (let i = 0; i < arguments.length; ++i)
          stack.fHists.Add(arguments[i], "");
       return stack;
    }
@@ -1794,7 +1794,7 @@
      * let mgr = JSROOT.createTMultiGraph(gr1, gr2, gr3); */
    JSROOT.createTMultiGraph = function() {
       let mgraph = create("TMultiGraph");
-      for(let i=0; i<arguments.length; ++i)
+      for (let i = 0; i < arguments.length; ++i)
           mgraph.fGraphs.Add(arguments[i], "");
       return mgraph;
    }

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "23/06/2021";
+   JSROOT.version_date = "29/06/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -651,7 +651,7 @@
 
          if (!m.jsroot || m.extract)
             element.onload = () => finish_loading(m, m.extract ? globalThis[m.extract] : 1); // mark script loaded
-         element.onerror = () => { m.failure = true; req.failed(); }
+         element.onerror = () => { element.remove(); m.failure = true; req.failed(); }
       }
 
       function after_depend_load(req,d,m) {
@@ -1453,7 +1453,7 @@
             create("TNamed", obj);
             create("TAttAxis", obj);
             extend(obj, { fNbins: 1, fXmin: 0, fXmax: 1, fXbins : [], fFirst: 0, fLast: 0,
-                                 fBits2: 0, fTimeDisplay: false, fTimeFormat: "", fLabels: null, fModLabs: null });
+                          fBits2: 0, fTimeDisplay: false, fTimeFormat: "", fLabels: null, fModLabs: null });
             break;
          case 'TAttLine':
             extend(obj, { fLineColor: 1, fLineStyle: 1, fLineWidth: 1 });
@@ -1478,8 +1478,8 @@
          case 'TPave':
             create("TBox", obj);
             extend(obj, { fX1NDC : 0., fY1NDC: 0, fX2NDC: 1, fY2NDC: 1,
-                                 fBorderSize: 0, fInit: 1, fShadowColor: 1,
-                                 fCornerRadius: 0, fOption: "blNDC", fName: "title" });
+                          fBorderSize: 0, fInit: 1, fShadowColor: 1,
+                          fCornerRadius: 0, fOption: "blNDC", fName: "title" });
             break;
          case 'TAttText':
             extend(obj, { fTextAngle: 0, fTextSize: 0, fTextAlign: 22, fTextColor: 1, fTextFont: 42});
@@ -1525,19 +1525,13 @@
             create("TAttLine", obj);
             create("TAttFill", obj);
             create("TAttMarker", obj);
-
-            extend(obj, {
-               fBits: 8,
-               fNcells: 0,
-               fXaxis: create("TAxis"),
-               fYaxis: create("TAxis"),
-               fZaxis: create("TAxis"),
-               fBarOffset: 0, fBarWidth: 1000, fEntries: 0.,
-               fTsumw: 0., fTsumw2: 0., fTsumwx: 0., fTsumwx2: 0.,
-               fMaximum: -1111., fMinimum: -1111, fNormFactor: 0., fContour: [],
-               fSumw2: [], fOption: "",
-               fFunctions: create("TList"),
-               fBufferSize: 0, fBuffer: [], fBinStatErrOpt: 0, fStatOverflows: 2 });
+            extend(obj, { fBits: 8, fNcells: 0,
+                          fXaxis: create("TAxis"), fYaxis: create("TAxis"), fZaxis: create("TAxis"),
+                          fBarOffset: 0, fBarWidth: 1000, fEntries: 0.,
+                          fTsumw: 0., fTsumw2: 0., fTsumwx: 0., fTsumwx2: 0.,
+                          fMaximum: -1111., fMinimum: -1111, fNormFactor: 0., fContour: [],
+                          fSumw2: [], fOption: "", fFunctions: create("TList"),
+                          fBufferSize: 0, fBuffer: [], fBinStatErrOpt: 0, fStatOverflows: 2 });
             break;
          case 'TH1I':
          case 'TH1F':
@@ -1581,7 +1575,7 @@
             create("TAttFill", obj);
             create("TAttMarker", obj);
             extend(obj, { fFunctions: create("TList"), fHistogram: null,
-                                 fMaxSize: 0, fMaximum: -1111, fMinimum: -1111, fNpoints: 0, fX: [], fY: [] });
+                          fMaxSize: 0, fMaximum: -1111, fMinimum: -1111, fNpoints: 0, fX: [], fY: [] });
             break;
          case 'TGraphAsymmErrors':
             create("TGraph", obj);
@@ -1590,16 +1584,16 @@
          case 'TMultiGraph':
             create("TNamed", obj);
             extend(obj, { fFunctions: create("TList"), fGraphs: create("TList"),
-                                 fHistogram: null, fMaximum: -1111, fMinimum: -1111 });
+                          fHistogram: null, fMaximum: -1111, fMinimum: -1111 });
             break;
          case 'TGraphPolargram':
             create("TNamed", obj);
             create("TAttText", obj);
             create("TAttLine", obj);
             extend(obj, { fRadian: true, fDegree: false, fGrad: false, fPolarLabelColor: 1, fRadialLabelColor: 1,
-                                 fAxisAngle: 0, fPolarOffset: 0.04, fPolarTextSize: 0.04, fRadialOffset: 0.025, fRadialTextSize: 0.035,
-                                 fRwrmin: 0, fRwrmax: 1, fRwtmin: 0, fRwtmax: 2*Math.PI, fTickpolarSize: 0.02,
-                                 fPolarLabelFont: 62, fRadialLabelFont: 62, fCutRadial: 0, fNdivRad: 508, fNdivPol: 508 });
+                          fAxisAngle: 0, fPolarOffset: 0.04, fPolarTextSize: 0.04, fRadialOffset: 0.025, fRadialTextSize: 0.035,
+                          fRwrmin: 0, fRwrmax: 1, fRwtmin: 0, fRwtmax: 2*Math.PI, fTickpolarSize: 0.02,
+                          fPolarLabelFont: 62, fRadialLabelFont: 62, fCutRadial: 0, fNdivRad: 508, fNdivPol: 508 });
             break;
          case 'TPolyLine':
             create("TObject", obj);
@@ -1611,24 +1605,24 @@
             create("TLine", obj);
             create("TAttText", obj);
             extend(obj, { fChopt: "", fFunctionName: "", fGridLength: 0,
-                                 fLabelColor: 1, fLabelFont: 42, fLabelOffset: 0.005, fLabelSize: 0.035,
-                                 fName: "", fNdiv: 12, fTickSize: 0.02, fTimeFormat: "",
-                                 fTitle: "", fTitleOffset: 1, fTitleSize: 0.035,
-                                 fWmax: 100, fWmin: 0 });
+                          fLabelColor: 1, fLabelFont: 42, fLabelOffset: 0.005, fLabelSize: 0.035,
+                          fName: "", fNdiv: 12, fTickSize: 0.02, fTimeFormat: "",
+                          fTitle: "", fTitleOffset: 1, fTitleSize: 0.035,
+                          fWmax: 100, fWmin: 0 });
             break;
          case 'TAttPad':
             extend(obj, { fLeftMargin: gStyle.fPadLeftMargin,
-                                 fRightMargin: gStyle.fPadRightMargin,
-                                 fBottomMargin: gStyle.fPadBottomMargin,
-                                 fTopMargin: gStyle.fPadTopMargin,
-                                 fXfile: 2, fYfile: 2, fAfile: 1, fXstat: 0.99, fYstat: 0.99, fAstat: 2,
-                                 fFrameFillColor: gStyle.fFrameFillColor,
-                                 fFrameFillStyle: gStyle.fFrameFillStyle,
-                                 fFrameLineColor: gStyle.fFrameLineColor,
-                                 fFrameLineWidth: gStyle.fFrameLineWidth,
-                                 fFrameLineStyle: gStyle.fFrameLineStyle,
-                                 fFrameBorderSize: gStyle.fFrameBorderSize,
-                                 fFrameBorderMode: gStyle.fFrameBorderMode });
+                          fRightMargin: gStyle.fPadRightMargin,
+                          fBottomMargin: gStyle.fPadBottomMargin,
+                          fTopMargin: gStyle.fPadTopMargin,
+                          fXfile: 2, fYfile: 2, fAfile: 1, fXstat: 0.99, fYstat: 0.99, fAstat: 2,
+                          fFrameFillColor: gStyle.fFrameFillColor,
+                          fFrameFillStyle: gStyle.fFrameFillStyle,
+                          fFrameLineColor: gStyle.fFrameLineColor,
+                          fFrameLineWidth: gStyle.fFrameLineWidth,
+                          fFrameLineStyle: gStyle.fFrameLineStyle,
+                          fFrameBorderSize: gStyle.fFrameBorderSize,
+                          fFrameBorderMode: gStyle.fFrameBorderMode });
             break;
          case 'TPad':
             create("TObject", obj);
@@ -1636,38 +1630,38 @@
             create("TAttFill", obj);
             create("TAttPad", obj);
             extend(obj, { fX1: 0, fY1: 0, fX2: 1, fY2: 1, fXtoAbsPixelk: 1, fXtoPixelk: 1,
-                                 fXtoPixel: 1, fYtoAbsPixelk: 1, fYtoPixelk: 1, fYtoPixel: 1,
-                                 fUtoAbsPixelk: 1, fUtoPixelk: 1, fUtoPixel: 1, fVtoAbsPixelk: 1,
-                                 fVtoPixelk: 1, fVtoPixel: 1, fAbsPixeltoXk: 1, fPixeltoXk: 1,
-                                 fPixeltoX: 1, fAbsPixeltoYk: 1, fPixeltoYk: 1, fPixeltoY: 1,
-                                 fXlowNDC: 0, fYlowNDC: 0, fXUpNDC: 0, fYUpNDC: 0, fWNDC: 1, fHNDC: 1,
-                                 fAbsXlowNDC: 0, fAbsYlowNDC: 0, fAbsWNDC: 1, fAbsHNDC: 1,
-                                 fUxmin: 0, fUymin: 0, fUxmax: 0, fUymax: 0, fTheta: 30, fPhi: 30, fAspectRatio: 0,
-                                 fNumber: 0, fLogx: gStyle.fOptLogx, fLogy: gStyle.fOptLogy, fLogz: gStyle.fOptLogz,
-                                 fTickx: gStyle.fPadTickX,
-                                 fTicky: gStyle.fPadTickY,
-                                 fPadPaint: 0, fCrosshair: 0, fCrosshairPos: 0, fBorderSize: 2,
-                                 fBorderMode: 0, fModified: false,
-                                 fGridx: gStyle.fPadGridX,
-                                 fGridy: gStyle.fPadGridY,
-                                 fAbsCoord: false, fEditable: true, fFixedAspectRatio: false,
-                                 fPrimitives: create("TList"), fExecs: null,
-                                 fName: "pad", fTitle: "canvas" });
+                          fXtoPixel: 1, fYtoAbsPixelk: 1, fYtoPixelk: 1, fYtoPixel: 1,
+                          fUtoAbsPixelk: 1, fUtoPixelk: 1, fUtoPixel: 1, fVtoAbsPixelk: 1,
+                          fVtoPixelk: 1, fVtoPixel: 1, fAbsPixeltoXk: 1, fPixeltoXk: 1,
+                          fPixeltoX: 1, fAbsPixeltoYk: 1, fPixeltoYk: 1, fPixeltoY: 1,
+                          fXlowNDC: 0, fYlowNDC: 0, fXUpNDC: 0, fYUpNDC: 0, fWNDC: 1, fHNDC: 1,
+                          fAbsXlowNDC: 0, fAbsYlowNDC: 0, fAbsWNDC: 1, fAbsHNDC: 1,
+                          fUxmin: 0, fUymin: 0, fUxmax: 0, fUymax: 0, fTheta: 30, fPhi: 30, fAspectRatio: 0,
+                          fNumber: 0, fLogx: gStyle.fOptLogx, fLogy: gStyle.fOptLogy, fLogz: gStyle.fOptLogz,
+                          fTickx: gStyle.fPadTickX,
+                          fTicky: gStyle.fPadTickY,
+                          fPadPaint: 0, fCrosshair: 0, fCrosshairPos: 0, fBorderSize: 2,
+                          fBorderMode: 0, fModified: false,
+                          fGridx: gStyle.fPadGridX,
+                          fGridy: gStyle.fPadGridY,
+                          fAbsCoord: false, fEditable: true, fFixedAspectRatio: false,
+                          fPrimitives: create("TList"), fExecs: null,
+                          fName: "pad", fTitle: "canvas" });
 
             break;
          case 'TAttCanvas':
             extend(obj, { fXBetween: 2, fYBetween: 2, fTitleFromTop: 1.2,
-                                 fXdate: 0.2, fYdate: 0.3, fAdate: 1 });
+                          fXdate: 0.2, fYdate: 0.3, fAdate: 1 });
             break;
          case 'TCanvas':
             create("TPad", obj);
             extend(obj, { fNumPaletteColor: 0, fNextPaletteColor: 0, fDISPLAY: "$DISPLAY",
-                                 fDoubleBuffer: 0, fRetained: true, fXsizeUser: 0,
-                                 fYsizeUser: 0, fXsizeReal: 20, fYsizeReal: 10,
-                                 fWindowTopX: 0, fWindowTopY: 0, fWindowWidth: 0, fWindowHeight: 0,
-                                 fCw: 500, fCh: 300, fCatt: create("TAttCanvas"),
-                                 kMoveOpaque: true, kResizeOpaque: true, fHighLightColor: 5,
-                                 fBatch: true, kShowEventStatus: false, kAutoExec: true, kMenuBar: true });
+                          fDoubleBuffer: 0, fRetained: true, fXsizeUser: 0,
+                          fYsizeUser: 0, fXsizeReal: 20, fYsizeReal: 10,
+                          fWindowTopX: 0, fWindowTopY: 0, fWindowWidth: 0, fWindowHeight: 0,
+                          fCw: 500, fCh: 300, fCatt: create("TAttCanvas"),
+                          kMoveOpaque: true, kResizeOpaque: true, fHighLightColor: 5,
+                          fBatch: true, kShowEventStatus: false, kAutoExec: true, kMenuBar: true });
             break;
          case 'TGeoVolume':
             create("TNamed", obj);

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "29/06/2021";
+   JSROOT.version_date = "30/06/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -2854,6 +2854,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    /** @summary Try to find painter for specified object
      * @desc can be used to find painter for some special objects, registered as
      * histogram functions
+     * @param {object} selobj - object to which painter should be search, set null to ignore parameter
+     * @param {string} [selname] - object name, set to null to ignore
+     * @param {string} [seltype] - object type, set to null to ignore
+     * @returns {object} - painter for specified object (if any)
      * @private */
    TPadPainter.prototype.findPainterFor = function(selobj, selname, seltype) {
       for (let n = 0; n < this.painters.length; ++n) {

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -829,23 +829,23 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       }).then(() => {
 
-         if (!title_g) return true;
+         if (title_g) {
+            // fine-tuning of title position when possible
+            if (axis_rect) {
+               let title_rect = title_g.node().getBoundingClientRect();
+               if ((axis_rect.left != axis_rect.right) && (title_rect.left != title_rect.right))
+                  title_shift_x = (side > 0) ? Math.round(axis_rect.left - title_rect.right - title_fontsize*0.3) :
+                                               Math.round(axis_rect.right - title_rect.left + title_fontsize*0.3);
+               else
+                  title_shift_x = -1 * Math.round(((side > 0) ? (labeloffset + labelMaxWidth) : 0) + title_fontsize*0.7);
+            }
 
-         // fine-tuning of title position when possible
-         if (axis_rect) {
-            let title_rect = title_g.node().getBoundingClientRect();
-            if ((axis_rect.left != axis_rect.right) && (title_rect.left != title_rect.right))
-               title_shift_x = (side > 0) ? Math.round(axis_rect.left - title_rect.right - title_fontsize*0.3) :
-                                            Math.round(axis_rect.right - title_rect.left + title_fontsize*0.3);
-            else
-               title_shift_x = -1 * Math.round(((side > 0) ? (labeloffset + labelMaxWidth) : 0) + title_fontsize*0.7);
+            title_g.attr('transform', 'translate(' + title_shift_x + ',' + title_shift_y + ')')
+                   .property('shift_x', title_shift_x)
+                   .property('shift_y', title_shift_y);
          }
 
-         title_g.attr('transform', 'translate(' + title_shift_x + ',' + title_shift_y + ')')
-                .property('shift_x', title_shift_x)
-                .property('shift_y', title_shift_y);
-
-         return true;
+         return this;
       });
    }
 
@@ -922,7 +922,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       painter.disable_zooming = true;
 
       return jsrp.ensureTCanvas(painter, false)
-             .then(() => { if (opt) painter.convertTo(opt); return painter.redraw(); }).then(() => painter);
+             .then(() => { if (opt) painter.convertTo(opt); return painter.redraw(); });
    }
 
    // ===============================================
@@ -2288,11 +2288,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    let drawFrame = (divid, obj, opt) => {
-      let p = new TFramePainter(divid, obj);
-      return jsrp.ensureTCanvas(p, false).then(() => {
-         if (opt == "3d") p.mode3d = true;
-         p.redraw();
-         return p;
+      let fp = new TFramePainter(divid, obj);
+      return jsrp.ensureTCanvas(fp, false).then(() => {
+         if (opt == "3d") fp.mode3d = true;
+         fp.redraw();
+         return fp;
       })
    }
 
@@ -2353,9 +2353,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary cleanup pad and all primitives inside */
    TPadPainter.prototype.cleanup = function() {
+      if (this._doing_draw)
+         console.error('pad drawing is not completed when cleanup is called');
 
-      for (let k = 0; k < this.painters.length; ++k)
-         this.painters[k].cleanup();
+      this.painters.forEach(p => p.cleanup());
 
       let svg_p = this.svg_this_pad();
       if (!svg_p.empty()) {
@@ -2371,6 +2372,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       delete this._pad_y;
       delete this._pad_width;
       delete this._pad_height;
+      delete this._doing_draw;
 
       this.painters = [];
       this.pad = null;
@@ -2839,16 +2841,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    /** @summary try to find object by name in list of pad primitives
      * @desc used to find title drawing
      * @private */
-   TPadPainter.prototype.findInPrimitives = function(objname) {
+   TPadPainter.prototype.findInPrimitives = function(objname, objtype) {
       let arr = this.pad && this.pad.fPrimitives ? this.pad.fPrimitives.arr : null;
 
-      if (arr && arr.length && objname)
-         for (let n = 0; n < arr.length; ++n) {
-            let prim = arr[n];
-            if (prim.fName === objname) return prim;
-         }
-
-      return null;
+      return arr ? arr.find(obj => (obj.fName == objname) && (objtype ? (obj.typename == objtype) : true)) : null;
    }
 
    /** @summary Try to find painter for specified object
@@ -2860,45 +2856,40 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
      * @returns {object} - painter for specified object (if any)
      * @private */
    TPadPainter.prototype.findPainterFor = function(selobj, selname, seltype) {
-      for (let n = 0; n < this.painters.length; ++n) {
-         let pobj = this.painters[n].getObject();
-         if (!pobj) continue;
+      return this.painters.find(p => {
+         let pobj = p.getObject();
+         if (!pobj) return;
 
-         if (selobj && (pobj === selobj)) return this.painters[n];
-         if (!selname && !seltype) continue;
-         if (selname && (pobj.fName !== selname)) continue;
-         if (seltype && (pobj._typename !== seltype)) continue;
-         return this.painters[n];
-      }
-      return null;
+         if (selobj && (pobj === selobj)) return true;
+         if (!selname && !seltype) return;
+         if (selname && (pobj.fName !== selname)) return;
+         if (seltype && (pobj._typename !== seltype)) return;
+         return true;
+      });
    }
 
    /** @summary Return true if any objects beside sub-pads exists in the pad */
    TPadPainter.prototype.hasObjectsToDraw = function() {
-
-      if (!this.pad || !this.pad.fPrimitives) return false;
-
-      for (let n=0;n<this.pad.fPrimitives.arr.length;++n)
-         if (this.pad.fPrimitives.arr[n] && this.pad.fPrimitives.arr[n]._typename != "TPad") return true;
-
-      return false;
+      let arr = this.pad && this.pad.fPrimitives ? this.pad.fPrimitives.arr : null;
+      return arr && arr.find(obj => obj._typename != "TPad") ? true : false;
    }
 
    /** @summary sync drawing/redrawing/resize of the pad
-     * @returns {Promise} when pad is ready to toperation or false if operation already queued
+     * @param {string} kind - kind of draw operation, if true - always queued
+     * @returns {Promise} when pad is ready for draw operation or false if operation already queued
      * @private */
    TPadPainter.prototype.syncDraw = function(kind) {
+      let entry = { kind : kind || "redraw" };
       if (this._doing_draw === undefined) {
-         this._doing_draw = [];
-         this._doing_drawf = [];
+         this._doing_draw = [ entry ];
          return Promise.resolve(true);
       }
-      if (!kind) kind = "redraw";
-      // if operation registered, ignore next calls
-      if ((kind !== true) && (this._doing_draw.indexOf(kind) >= 0)) return false;
-      this._doing_draw.push(kind);
+      // if queued operation registered, ignore next calls, indx == 0 is running operation
+      if ((entry.kind !== true) && (this._doing_draw.findIndex((e,i) => (i > 0) && (e.kind == entry.kind)) > 0))
+         return false;
+      this._doing_draw.push(entry);
       return new Promise(resolveFunc => {
-         this._doing_drawf.push(resolveFunc);
+         entry.func = resolveFunc;
       });
    }
 
@@ -2907,13 +2898,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    TPadPainter.prototype.confirmDraw = function() {
       if (this._doing_draw === undefined)
          return console.warn("failure, should not happen");
+      this._doing_draw.shift();
       if (this._doing_draw.length == 0) {
          delete this._doing_draw;
-         delete this._doing_drawf;
       } else {
-         this._doing_draw.shift();
-         let func = this._doing_drawf.shift();
-         func(); // activate next action
+         let entry = this._doing_draw[0];
+         if(entry.func) { entry.func(); delete entry.func; }
       }
    }
 
@@ -2924,13 +2914,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (indx === undefined) {
          if (this.iscan)
-            this._start_tm = this._lasttm_tm = new Date().getTime();
+            this._start_tm = new Date().getTime();
 
          // set number of primitves
          this._num_primitives = this.pad && this.pad.fPrimitives ? this.pad.fPrimitives.arr.length : 0;
 
          // sync to prevent immediate pad redraw during normal drawing sequence
-         return this.syncDraw("draw").then(() => this.drawPrimitives(0));
+         return this.syncDraw(true).then(() => this.drawPrimitives(0));
       }
 
       if (indx >= this._num_primitives) {
@@ -2938,7 +2928,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             let spenttm = new Date().getTime() - this._start_tm;
             if (spenttm > 1000) console.log("Canvas drawing took " + (spenttm*1e-3).toFixed(2) + "s");
             delete this._start_tm;
-            delete this._lasttm_tm;
          }
 
          this.confirmDraw();
@@ -2946,12 +2935,11 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
 
       // use of Promise should avoid large call-stack depth when many primitives are drawn
-      return JSROOT.draw(this.getDom(), this.pad.fPrimitives.arr[indx], this.pad.fPrimitives.opt[indx]).then(ppainter=> {
-         if (ppainter && (typeof ppainter == 'object'))
-            ppainter._primitive = true; // mark painter as belonging to primitives
+      return JSROOT.draw(this.getDom(), this.pad.fPrimitives.arr[indx], this.pad.fPrimitives.opt[indx]).then(op => {
+         if (op && (typeof op == 'object'))
+            op._primitive = true; // mark painter as belonging to primitives
 
          return this.drawPrimitives(indx+1);
-
       });
    }
 
@@ -3108,11 +3096,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       let elem = this.svg_this_pad();
       if (!elem.empty() && elem.property('can3d') === JSROOT.constants.Embed3D.Overlay) return true;
 
-      for (let i = 0; i < this.painters.length; ++i)
-         if (typeof this.painters[i].needRedrawByResize === 'function')
-            if (this.painters[i].needRedrawByResize()) return true;
-
-      return false;
+      return this.painters.findIndex(objp => {
+         if (typeof objp.needRedrawByResize === 'function')
+            return objp.needRedrawByResize();
+      }) >= 0;
    }
 
    /** @summary Check resize of canvas
@@ -3259,7 +3246,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       // first appropriate painter for the object
       // if same object drawn twice, two painters will exists
-      for (let k=0; k<this.painters.length; ++k) {
+      for (let k = 0;  k < this.painters.length; ++k) {
          if (this.painters[k].snapid === snapid)
             if (--cnt === 0) { objpainter = this.painters[k]; break; }
       }
@@ -3358,7 +3345,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       return this.drawNextSnap(lst, indx);
    }
 
-
    /** @summary Return painter with specified id
      * @private */
    TPadPainter.prototype.findSnap = function(snapid) {
@@ -3367,7 +3353,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (!this.painters) return null;
 
-      for (let k=0;k<this.painters.length;++k) {
+      for (let k = 0; k < this.painters.length; ++k) {
          let sub = this.painters[k];
 
          if (typeof sub.findSnap === 'function')
@@ -3456,47 +3442,43 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          this.createPadSvg(true);
       }
 
-      let isanyfound = false, isanyremove = false;
-
-      // check if frame or title was recreated, we could reassign handlers for them directly
-
-      function MatchPrimitive(painters, primitives, class_name, obj_name) {
-         let painter, primitive;
-         for (let k = 0; k < painters.length; ++k) {
-            if (painters[k].snapid === undefined) continue;
-            if (!painters[k].matchObjectType(class_name)) continue;
-            if (obj_name && (!painters[k].getObject() || (painters[k].getObject().fName !== obj_name))) continue;
-            painter = painters[k];
-            break;
-         }
+      let MatchPrimitive = (painters, primitives, class_name, obj_name) => {
+         let painter = painters.find(p => {
+            if (p.snapid === undefined) return;
+            if (!p.matchObjectType(class_name)) return;
+            if (obj_name && (!p.getObject() || (p.getObject().fName !== obj_name))) return;
+            return true;
+         });
          if (!painter) return;
-         for (let k = 0;k < primitives.length; ++k) {
-            if ((primitives[k].fKind !== 1) || !primitives[k].fSnapshot || (primitives[k].fSnapshot._typename !== class_name)) continue;
-            if (obj_name && (primitives[k].fSnapshot.fName !== obj_name)) continue;
-            primitive = primitives[k];
-            break;
-         }
+         let primitive = primitives.find(pr => {
+            if ((pr.fKind !== 1) || !pr.fSnapshot || (pr.fSnapshot._typename !== class_name)) return;
+            if (obj_name && (pr.fSnapshot.fName !== obj_name)) return;
+            return true;
+         });
          if (!primitive) return;
 
          // force painter to use new object id
          if (painter.snapid !== primitive.fObjectID)
             painter.snapid = primitive.fObjectID;
-      }
+      };
 
+      // check if frame or title was recreated, we could reassign handlers for them directly
       // while this is temporary objects, which can be recreated very often, try to catch such situation ourselfs
       MatchPrimitive(this.painters, snap.fPrimitives, "TFrame");
       MatchPrimitive(this.painters, snap.fPrimitives, "TPaveText", "title");
+
+      let isanyfound = false, isanyremove = false;
 
       // find and remove painters which no longer exists in the list
       for (let k = 0; k < this.painters.length; ++k) {
          let sub = this.painters[k];
          if ((sub.snapid===undefined) || sub.$secondary) continue; // look only for painters with snapid
 
-         for (let i=0;i<snap.fPrimitives.length;++i)
+         for (let i = 0; i < snap.fPrimitives.length; ++i)
             if (snap.fPrimitives[i].fObjectID === sub.snapid) { sub = null; isanyfound = true; break; }
 
          if (sub) {
-            console.log('Remove painter' + k + ' from ' + this.painters.length + ' ' + sub.getObject()._typename);
+            console.log(`Remove painter ${k} from ${this.painters.length} class ${sub.getClassName()}`);
             // remove painter which does not found in the list of snaps
             this.painters.splice(k--,1);
             sub.cleanup(); // cleanup such painter
@@ -3511,9 +3493,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (!isanyfound) {
          // TODO: maybe just remove frame painter?
          let fp = this.getFramePainter();
-         for (let k = 0;k < this.painters.length; ++k)
-            if (fp !== this.painters[k])
-               this.painters[k].cleanup();
+         this.painters.forEach(objp => {
+            if (fp !== objp) objp.cleanup();
+         });
          delete this.main_painter_ref;
          this.painters = [];
          if (fp) {
@@ -3529,12 +3511,15 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       return this.drawNextSnap(snap.fPrimitives).then(() => {
          // redraw secondaries like stat box
-         for (let k = 0; k < this.painters.length; ++k) {
-            let sub = this.painters[k];
-            if ((sub.snapid===undefined) || sub.$secondary)
-               sub.redraw();
-         }
-
+         let promises = [];
+         this.painters.forEach(sub => {
+            if ((sub.snapid===undefined) || sub.$secondary) {
+               let res = sub.redraw();
+               if (jsrp.isPromise(res)) promises.push(res);
+            }
+         });
+         return Promise.all(promises);
+      }).then(() => {
          this.selectCurrentPad(prev_name);
          if (jsrp.getActivePad() === this) {
             let canp = this.getCanvPainter();
@@ -3592,8 +3577,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             console.log('fail to get ranges for pad ' +  this.pad.fName);
       }
 
-      for (let k=0; k<this.painters.length; ++k) {
-         let sub = this.painters[k];
+      this.painters.forEach(sub => {
          if (typeof sub.getWebPadOptions == "function") {
             if (scan_subpads) sub.getWebPadOptions(arg);
          } else if (sub.snapid) {
@@ -3602,7 +3586,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                opt = sub.fillWebObjectOptions(opt);
             elem.primitives.push(opt);
          }
-      }
+      });
 
       if (is_top) return JSROOT.toJSON(arg);
    }
@@ -3915,15 +3899,14 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             if (this.painters && (this.painters.length > 0)) {
                menu.add("separator");
                let shown = [];
-               for (let n = 0; n < this.painters.length; ++n) {
-                  let pp = this.painters[n];
+               this.painters.forEach(pp => {
                   let obj = pp ? pp.getObject() : null;
-                  if (!obj || (shown.indexOf(obj) >= 0)) continue;
+                  if (!obj || (shown.indexOf(obj) >= 0)) return;
                   let name = ('_typename' in obj) ? (obj._typename + "::") : "";
                   if ('fName' in obj) name += obj.fName;
                   if (!name.length) name = "item" + n;
                   menu.add(name, n, this.itemContextMenu);
-               }
+               });
             }
 
             menu.show();
@@ -3936,15 +3919,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       // if any painter indicates that processing completed, it returns true
       let done = false;
 
-      for (let i = 0; i < this.painters.length; ++i) {
-         let pp = this.painters[i];
-
+      this.painters.forEach(pp => {
          if (typeof pp.clickPadButton == 'function')
             pp.clickPadButton(funcname);
 
          if (!done && (typeof pp.clickButton == 'function'))
             done = pp.clickButton(funcname);
-      }
+      });
    }
 
    /** @summary Add button to the pad

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -2400,13 +2400,11 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       let histo = this.getHisto(), st = JSROOT.gStyle,
           pp = this.getPadPainter(),
           tpainter = pp ? pp.findPainterFor(null, "title") : null,
-          pt = tpainter ? tpainter.getObject() : null;
+          pt = tpainter ? tpainter.getObject() : null,
+          draw_title = !histo.TestBit(TH1StatusBits.kNoTitle) && (st.fOptTitle > 0);
 
-      if (!pt && pp && pp.findInPrimitives)
-         pt = pp.findInPrimitives("title");
-      if (pt && (pt._typename !== "TPaveText")) pt = null;
-
-      let draw_title = !histo.TestBit(TH1StatusBits.kNoTitle) && (st.fOptTitle > 0);
+      if (!pt && pp && typeof pp.findInPrimitives == "function")
+         pt = pp.findInPrimitives("title", "TPaveText");
 
       // histo.fTitle = "#strike{testing} #overline{Title:} #overline{Title:_{X}} #underline{test}  #underline{test^{X}}";
       // histo.fTitle = "X-Y-#overline{V}_{#Phi}";
@@ -2475,7 +2473,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
    THistPainter.prototype.findStat = function() {
       if (this.options.PadStats) {
          let pp = this.getPadPainter(),
-             p = pp ? pp.findPainterFor(null,"stats", "TPaveStats") : null;
+             p = pp ? pp.findPainterFor(null, "stats", "TPaveStats") : null;
          return p ? p.getObject() : null;
       }
 
@@ -2652,7 +2650,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
       // no need to do something if painter for object was already done
       // object will be redraw automatically
-      if ((func_painter === null) && func)
+      if (!func_painter && func)
          do_draw = this.needDrawFunc(histo, func);
 
       if (!do_draw)

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -2395,7 +2395,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
       // case when histogram drawn over other histogram (same option)
       if (!this.isMainPainter() || this.options.Same)
-         return Promise.resolve(true);
+         return Promise.resolve(this);
 
       let histo = this.getHisto(), st = JSROOT.gStyle,
           pp = this.getPadPainter(),
@@ -2414,7 +2414,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       if (pt) {
          pt.Clear();
          if (draw_title) pt.AddText(histo.fTitle);
-         if (tpainter) tpainter.redraw();
+         if (tpainter) return tpainter.redraw().then(() => this);
       } else if (draw_title && !tpainter && histo.fTitle && !this.options.PadTitle) {
          pt = JSROOT.create("TPaveText");
          pt.fName = "title";
@@ -2427,8 +2427,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          pt.fBorderSize = st.fTitleBorderSize;
 
          pt.AddText(histo.fTitle);
-         return drawPave(this.getDom(), pt, "postitle").then(tpainter => {
-            if (tpainter) tpainter.$secondary = true;
+         return drawPave(this.getDom(), pt, "postitle").then(tp => {
+            if (tp) tp.$secondary = true;
             return this;
          });
       }
@@ -6619,9 +6619,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
             // redraw palette till the end when contours are available
             return pp.drawPave();
          });
-      }).then(() => {
-         return this.drawHistTitle();
-      }).then(() => {
+      }).then(() => this.drawHistTitle()).then(() => {
 
          this.updateStatWebCanvas();
 

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -853,7 +853,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
          // collect tooltips from pad painter - it has list of all drawn objects
          let hints = pp.processPadTooltipEvent(pnt), exact = null;
-         for (let k=0; (k<hints.length) && !exact; ++k)
+         for (let k = 0; (k <hints.length) && !exact; ++k)
             if (hints[k] && hints[k].exact) exact = hints[k];
          //if (exact) console.log('Click exact', pnt, exact.painter.getObjectHint());
          //      else console.log('Click frame', pnt);

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -2915,7 +2915,6 @@ JSROOT.define(['d3'], (d3) => {
          fp.configureUserDblclickHandler(handler);
    }
 
-
    /** @summary Check if user-defined tooltip function was configured
      * @returns {boolean} flag is user tooltip handler was configured */
    ObjectPainter.prototype.hasUserTooltip = function() {

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -43,7 +43,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                         (obj.fCssClass && (block.selector == ("." + obj.fCssClass)));
 
             if (match && block.map && block.map.m) {
-               let value = block.map.m[name];
+               let value = block.map.m[name.toLowerCase()];
                if (value) return type_check(value.v);
             }
          }
@@ -399,7 +399,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (this.v7EvalAttr("time")) {
          this.kind = 'time';
          this.timeoffset = 0;
-         let toffset = this.v7EvalAttr("time_offset");
+         let toffset = this.v7EvalAttr("timeOffset");
          if (toffset !== undefined) {
             toffset = parseFloat(toffset);
             if (Number.isFinite(toffset)) this.timeoffset = toffset*1000;
@@ -470,7 +470,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          if (this.nticks > 8) this.nticks = 8;
 
          let scale_range = this.scale_max - this.scale_min,
-             tf1 = this.v7EvalAttr("time_format", ""),
+             tf1 = this.v7EvalAttr("timeFormat", ""),
              tf2 = jsrp.chooseTimeFormat(scale_range / gr_range, false);
 
          if (!tf1 || (scale_range < 0.1 * (this.full_max - this.full_min)))
@@ -1247,7 +1247,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary Change zooming in standalone mode */
    RAxisPainter.prototype.zoomStandalone = function(min,max) {
-      this.changeAxisAttr(1, "zoommin", min, "zoommax", max);
+      this.changeAxisAttr(1, "zoomMin", min, "zoomMax", max);
    }
 
    /** @summary Redraw axis, used in standalone mode for RAxisDrawable */
@@ -1265,8 +1265,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       // in vertical direction axis drawn in negative direction
       if (drawable.fVertical) len -= pp.getPadHeight();
 
-      let smin = this.v7EvalAttr("zoommin"),
-          smax = this.v7EvalAttr("zoommax");
+      let smin = this.v7EvalAttr("zoomMin"),
+          smax = this.v7EvalAttr("zoomMax");
       if (smin === smax) {
          smin = min; smax = max;
       }
@@ -1592,8 +1592,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       let h = this.getFrameHeight(),
           w = this.getFrameWidth(),
-          gridx = this.v7EvalAttr("gridx", false),
-          gridy = this.v7EvalAttr("gridy", false),
+          gridx = this.v7EvalAttr("gridX", false),
+          gridy = this.v7EvalAttr("gridY", false),
           grid_style = JSROOT.gStyle.fGridStyle,
           grid_color = (JSROOT.gStyle.fGridColor > 0) ? this.getColor(JSROOT.gStyle.fGridColor) : "black";
 
@@ -1668,8 +1668,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       let nzmin = "zoom_" + prefix + "min", nzmax = "zoom_" + prefix + "max";
 
       if ((this[nzmin] == this[nzmax]) && !this.zoomChangedInteractive(prefix)) {
-         min = this.v7EvalAttr(prefix + "_zoommin");
-         max = this.v7EvalAttr(prefix + "_zoommax");
+         min = this.v7EvalAttr(prefix + "_zoomMin");
+         max = this.v7EvalAttr(prefix + "_zoomMax");
 
          if ((min !== undefined) || (max !== undefined)) {
             this[nzmin] = (min === undefined) ? this[nmin] : min;
@@ -1736,9 +1736,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             this.scale_ymax += (this.scale_ymax - this.scale_ymin)*0.1;
       }
 
-      if (opts.check_pad_range) {
+      // if (opts.check_pad_range) {
          // take zooming out of pad or axis attributes - skip!
-      }
+      // }
 
       if ((this.zoom_ymin == this.zoom_ymax) && (opts.zoom_ymin != opts.zoom_ymax) && !this.zoomChangedInteractive("y")) {
          this.zoom_ymin = opts.zoom_ymin;
@@ -1800,12 +1800,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (this.axes_drawn || (this.xmin == this.xmax) || (this.ymin == this.ymax))
          return Promise.resolve(this.axes_drawn);
 
-      let ticksx = this.v7EvalAttr("ticksx", 1),
-          ticksy = this.v7EvalAttr("ticksy", 1),
+      let ticksx = this.v7EvalAttr("ticksX", 1),
+          ticksy = this.v7EvalAttr("ticksY", 1),
           sidex = 1, sidey = 1;
 
-      if (this.v7EvalAttr("swapx", false)) sidex = -1;
-      if (this.v7EvalAttr("swapy", false)) sidey = -1;
+      if (this.v7EvalAttr("swapX", false)) sidex = -1;
+      if (this.v7EvalAttr("swapY", false)) sidey = -1;
 
       let w = this.getFrameWidth(), h = this.getFrameHeight();
 
@@ -2199,7 +2199,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       let promise = Promise.resolve(true);
 
-      if (this.v7EvalAttr("drawaxes")) {
+      if (this.v7EvalAttr("drawAxes")) {
          this.self_drawaxes = true;
          this.setAxesRanges();
          promise = this.drawAxes().then(() => this.addInteractivity());
@@ -2544,27 +2544,27 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       menu.addchk(this.isTooltipAllowed(), "Show tooltips", () => this.setTooltipAllowed("toggle"));
 
       if (this.x_handle)
-         menu.addchk(this.x_handle.draw_grid, "Grid x", flag => this.changeFrameAttr("gridx", flag));
+         menu.addchk(this.x_handle.draw_grid, "Grid x", flag => this.changeFrameAttr("gridX", flag));
       if (this.y_handle)
-         menu.addchk(this.y_handle.draw_grid, "Grid y", flag => this.changeFrameAttr("gridy", flag));
+         menu.addchk(this.y_handle.draw_grid, "Grid y", flag => this.changeFrameAttr("gridY", flag));
       if (this.x_handle && !this.x2_handle)
-         menu.addchk(this.x_handle.draw_swapside, "Swap x", flag => this.changeFrameAttr("swapx", flag));
+         menu.addchk(this.x_handle.draw_swapside, "Swap x", flag => this.changeFrameAttr("swapX", flag));
       if (this.y_handle && !this.y2_handle)
-         menu.addchk(this.y_handle.draw_swapside, "Swap y", flag => this.changeFrameAttr("swapy", flag));
+         menu.addchk(this.y_handle.draw_swapside, "Swap y", flag => this.changeFrameAttr("swapY", flag));
       if (this.x_handle && !this.x2_handle) {
          menu.add("sub:Ticks x");
-         menu.addchk(this.x_handle.draw_ticks == 0, "off", () => this.changeFrameAttr("ticksx", 0));
-         menu.addchk(this.x_handle.draw_ticks == 1, "normal", () => this.changeFrameAttr("ticksx", 1));
-         menu.addchk(this.x_handle.draw_ticks == 2, "ticks on both sides", () => this.changeFrameAttr("ticksx", 2));
-         menu.addchk(this.x_handle.draw_ticks == 3, "labels on both sides", () => this.changeFrameAttr("ticksx", 3));
+         menu.addchk(this.x_handle.draw_ticks == 0, "off", () => this.changeFrameAttr("ticksX", 0));
+         menu.addchk(this.x_handle.draw_ticks == 1, "normal", () => this.changeFrameAttr("ticksX", 1));
+         menu.addchk(this.x_handle.draw_ticks == 2, "ticks on both sides", () => this.changeFrameAttr("ticksX", 2));
+         menu.addchk(this.x_handle.draw_ticks == 3, "labels on both sides", () => this.changeFrameAttr("ticksX", 3));
          menu.add("endsub:");
        }
       if (this.y_handle && !this.y2_handle) {
          menu.add("sub:Ticks y");
-         menu.addchk(this.y_handle.draw_ticks == 0, "off", () => this.changeFrameAttr("ticksy", 0));
-         menu.addchk(this.y_handle.draw_ticks == 1, "normal", () => this.changeFrameAttr("ticksy", 1));
-         menu.addchk(this.y_handle.draw_ticks == 2, "ticks on both sides", () => this.changeFrameAttr("ticksy", 2));
-         menu.addchk(this.y_handle.draw_ticks == 3, "labels on both sides", () => this.changeFrameAttr("ticksy", 3));
+         menu.addchk(this.y_handle.draw_ticks == 0, "off", () => this.changeFrameAttr("ticksY", 0));
+         menu.addchk(this.y_handle.draw_ticks == 1, "normal", () => this.changeFrameAttr("ticksY", 1));
+         menu.addchk(this.y_handle.draw_ticks == 2, "ticks on both sides", () => this.changeFrameAttr("ticksY", 2));
+         menu.addchk(this.y_handle.draw_ticks == 3, "labels on both sides", () => this.changeFrameAttr("ticksY", 3));
          menu.add("endsub:");
        }
 
@@ -2685,20 +2685,26 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       return this.getPadSvg(this.this_pad_name);
    }
 
+   /** @summary Returns main painter on the pad
+     * @desc Typically main painter is TH1/TH2 object which is drawing axes
+    * @private */
    RPadPainter.prototype.getMainPainter = function() {
       return this.main_painter_ref || null;
    }
 
+   /** @summary Assign main painter on the pad
+    * @private */
    RPadPainter.prototype.setMainPainter = function(painter, force) {
       if (!this.main_painter_ref || force)
          this.main_painter_ref = painter;
    }
 
-   /** @summary cleanup only pad itself, all child elements will be collected and cleanup separately */
+   /** @summary cleanup pad and all primitives inside */
    RPadPainter.prototype.cleanup = function() {
+      if (this._doing_draw)
+         console.error('pad drawing is not completed when cleanup is called');
 
-      for (let k = 0; k < this.painters.length; ++k)
-         this.painters[k].cleanup();
+      this.painters.forEach(p => p.cleanup());
 
       let svg_p = this.svg_this_pad();
       if (!svg_p.empty()) {
@@ -2713,6 +2719,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       delete this._pad_y;
       delete this._pad_width;
       delete this._pad_height;
+      delete this._doing_draw;
+
       this.painters = [];
       this.pad = null;
       this.draw_object = null;
@@ -2767,17 +2775,16 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
      * histogram functions
      * @private */
    RPadPainter.prototype.findPainterFor = function(selobj, selname, seltype) {
-      for (let n = 0; n < this.painters.length; ++n) {
-         let pobj = this.painters[n].getObject();
-         if (!pobj) continue;
+      return this.painters.find(p => {
+         let pobj = p.getObject();
+         if (!pobj) return;
 
-         if (selobj && (pobj === selobj)) return this.painters[n];
-         if (!selname && !seltype) continue;
-         if (selname && (pobj.fName !== selname)) continue;
-         if (seltype && (pobj._typename !== seltype)) continue;
-         return this.painters[n];
-      }
-      return null;
+         if (selobj && (pobj === selobj)) return true;
+         if (!selname && !seltype) return;
+         if (selname && (pobj.fName !== selname)) return;
+         if (seltype && (pobj._typename !== seltype)) return;
+         return true;
+      });
    }
 
    /** @summary Returns palette associated with pad.
@@ -3127,31 +3134,26 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary returns true if any objects beside sub-pads exists in the pad */
    RPadPainter.prototype.hasObjectsToDraw = function() {
-
       let arr = this.pad ? this.pad.fPrimitives : null;
-
-      if (arr)
-         for (let n=0;n<arr.length;++n)
-            if (arr[n] && arr[n]._typename != "ROOT::Experimental::RPadDisplayItem") return true;
-
-      return false;
+      return arr && arr.find(obj => obj._typename != "ROOT::Experimental::RPadDisplayItem") ? true : false;
    }
 
-      /** @summary sync drawing/redrawing/resize of the pad
-     * @returns {Promise} when pad is ready to toperation or false if operation already queued
+   /** @summary sync drawing/redrawing/resize of the pad
+     * @param {string} kind - kind of draw operation, if true - always queued
+     * @returns {Promise} when pad is ready for draw operation or false if operation already queued
      * @private */
    RPadPainter.prototype.syncDraw = function(kind) {
+      let entry = { kind : kind || "redraw" };
       if (this._doing_draw === undefined) {
-         this._doing_draw = [];
-         this._doing_drawf = [];
+         this._doing_draw = [ entry ];
          return Promise.resolve(true);
       }
-      if (!kind) kind = "redraw";
-      // if operation registered, ignore next calls
-      if ((kind !== true) && (this._doing_draw.indexOf(kind) >= 0)) return false;
-      this._doing_draw.push(kind);
+      // if queued operation registered, ignore next calls, indx == 0 is running operation
+      if ((entry.kind !== true) && (this._doing_draw.findIndex((e,i) => (i > 0) && (e.kind == entry.kind)) > 0))
+         return false;
+      this._doing_draw.push(entry);
       return new Promise(resolveFunc => {
-         this._doing_drawf.push(resolveFunc);
+         entry.func = resolveFunc;
       });
    }
 
@@ -3160,13 +3162,12 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    RPadPainter.prototype.confirmDraw = function() {
       if (this._doing_draw === undefined)
          return console.warn("failure, should not happen");
+      this._doing_draw.shift();
       if (this._doing_draw.length == 0) {
          delete this._doing_draw;
-         delete this._doing_drawf;
       } else {
-         this._doing_draw.shift();
-         let func = this._doing_drawf.shift();
-         func(); // activate next action
+         let entry = this._doing_draw[0];
+         if(entry.func) { entry.func(); delete entry.func; }
       }
    }
 
@@ -3181,7 +3182,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          // set number of primitves
          this._num_primitives = this.pad && this.pad.fPrimitives ? this.pad.fPrimitives.length : 0;
 
-         return this.syncDraw("draw").then(() => this.drawPrimitives(0));
+         return this.syncDraw(true).then(() => this.drawPrimitives(0));
       }
 
       if (!this.pad || (indx >= this._num_primitives)) {
@@ -3192,7 +3193,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             let spenttm = new Date().getTime() - this._start_tm;
             if (spenttm > 3000) console.log("Canvas drawing took " + (spenttm*1e-3).toFixed(2) + "s");
             delete this._start_tm;
-            delete this._lasttm_tm;
          }
 
          return Promise.resolve();
@@ -3322,7 +3322,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             let canp = this.getCanvPainter();
             if (canp) canp.producePadEvent("padredraw", this);
          }
-         this.confirmRedraw();
+         this.confirmDraw();
          return true;
       });
    }
@@ -3428,7 +3428,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       pattr.csstype = snap.fCssType;
       pattr.rstyle = snap.fStyle;
 
-      snap.fOption = pattr.v7EvalAttr("drawopt", "");
+      snap.fOption = pattr.v7EvalAttr("options", "");
 
       let extract_color = (member_name, attr_name) => {
          let col = pattr.v7EvalColor(attr_name, "");
@@ -4878,8 +4878,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
 
       let visible      = this.v7EvalAttr("visible", true),
-          pave_cornerx = this.v7EvalLength("cornerx", rect.width, 0.02),
-          pave_cornery = this.v7EvalLength("cornery", rect.height, -0.02),
+          pave_cornerx = this.v7EvalLength("cornerX", rect.width, 0.02),
+          pave_cornery = this.v7EvalLength("cornerY", rect.height, -0.02),
           pave_width   = this.v7EvalLength("width", rect.width, 0.3),
           pave_height  = this.v7EvalLength("height", rect.height, 0.3),
           line_width   = this.v7EvalAttr("border_width", 1),
@@ -4965,8 +4965,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
 
       let changes = {};
-      this.v7AttrChange(changes, "cornerx", (pave_x + this.pave_width - fx - fw) / rect.width);
-      this.v7AttrChange(changes, "cornery", (pave_y - fy) / rect.height);
+      this.v7AttrChange(changes, "cornerX", (pave_x + this.pave_width - fx - fw) / rect.width);
+      this.v7AttrChange(changes, "cornerY", (pave_y - fy) / rect.height);
       this.v7AttrChange(changes, "width", this.pave_width / rect.width);
       this.v7AttrChange(changes, "height", this.pave_height / rect.height);
       this.v7SendAttrChanges(changes, false); // do not invoke canvas update on the server

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -64,13 +64,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    /** @summary Decode pad length from string, return pixel value
      * @private */
-   JSROOT.ObjectPainter.prototype.v7EvalLength = function(name, sizepx, dflt, name2) {
+   JSROOT.ObjectPainter.prototype.v7EvalLength = function(name, sizepx, dflt) {
       if (sizepx <= 0) sizepx = 1;
 
       let value = this.v7EvalAttr(name);
-
-      if ((value === undefined) && name2)
-         value = this.v7EvalAttr(name2);
 
       if (value === undefined)
          return Math.round(dflt*sizepx);
@@ -523,7 +520,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          }
       } else {
          let labels = this.getObject().fLabels;
-         if (labels && (indx>=0) && (indx < labels.length))
+         if (labels && (indx >= 0) && (indx < labels.length))
             return labels[indx];
       }
       return null;
@@ -1133,9 +1130,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       this.ticksColor = this.v7EvalColor("ticks_color", "");
       this.ticksWidth = this.v7EvalAttr("ticks_width", 1);
       this.labelsOffset = this.v7EvalLength("labels_offset", this.scaling_size, 0);
-      this.optionUnlab = this.v7EvalAttr("hidelabels", false);
+      this.optionUnlab = this.v7EvalAttr("labels_hide", false);
 
-      this.fTitle = this.v7EvalAttr("title", "");
+      this.fTitle = this.v7EvalAttr("title_value", "");
 
       if (this.max_tick_size && (this.ticksSize > this.max_tick_size)) this.ticksSize = this.max_tick_size;
    }
@@ -1261,8 +1258,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
           pos  = pp.getCoordinate(drawable.fPos),
           len  = pp.getPadLength(drawable.fVertical, drawable.fLength),
           reverse = this.v7EvalAttr("reverse", false),
-          min = drawable.fLabels ? 0 : drawable.fMin,
-          max = drawable.fLabels ? drawable.fLabels.length : drawable.fMax;
+          labels_len = drawable.fLabels.length,
+          min = (labels_len > 0) ? 0 : this.v7EvalAttr("min", 0),
+          max = (labels_len > 0) ? labels_len : this.v7EvalAttr("max", 100);
 
       // in vertical direction axis drawn in negative direction
       if (drawable.fVertical) len -= pp.getPadHeight();
@@ -1273,7 +1271,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          smin = min; smax = max;
       }
 
-      this.configureAxis("axis", min, max, smin, smax, drawable.fVertical, undefined, len, { reverse: reverse, labels: !!drawable.fLabels });
+      this.configureAxis("axis", min, max, smin, smax, drawable.fVertical, undefined, len, { reverse: reverse, labels: labels_len > 0 });
 
       this.createG();
 
@@ -1520,10 +1518,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if ((this.fX1NDC === undefined) || (force && !this.modified_NDC)) {
 
          let rect = this.getPadPainter().getPadRect();
-         this.fX1NDC = this.v7EvalLength("margins_left", rect.width, JSROOT.settings.FrameNDC.fX1NDC, "margins_all") / rect.width;
-         this.fY1NDC = this.v7EvalLength("margins_bottom", rect.height, JSROOT.settings.FrameNDC.fY1NDC, "margins_all") / rect.height;
-         this.fX2NDC = 1 - this.v7EvalLength("margins_right", rect.width, 1-JSROOT.settings.FrameNDC.fX2NDC, "margins_all") / rect.width;
-         this.fY2NDC = 1 - this.v7EvalLength("margins_top", rect.height, 1-JSROOT.settings.FrameNDC.fY2NDC, "margins_all") / rect.height;
+         this.fX1NDC = this.v7EvalLength("margins_left", rect.width, JSROOT.settings.FrameNDC.fX1NDC) / rect.width;
+         this.fY1NDC = this.v7EvalLength("margins_bottom", rect.height, JSROOT.settings.FrameNDC.fY1NDC) / rect.height;
+         this.fX2NDC = 1 - this.v7EvalLength("margins_right", rect.width, 1-JSROOT.settings.FrameNDC.fX2NDC) / rect.width;
+         this.fY2NDC = 1 - this.v7EvalLength("margins_top", rect.height, 1-JSROOT.settings.FrameNDC.fY2NDC) / rect.height;
       }
 
       if (!this.fillatt)
@@ -1763,7 +1761,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       this.x_handle = new JSROOT.TAxisPainter(this.getDom(), xaxis, true);
       this.x_handle.setPadName(this.getPadName());
-      this.x_handle.optionUnlab = this.v7EvalAttr("x_hidelabels", false);
+      this.x_handle.optionUnlab = this.v7EvalAttr("x_labels_hide", false);
 
       this.x_handle.configureAxis("xaxis", this.xmin, this.xmax, this.scale_xmin, this.scale_xmax, this.swap_xy, this.swap_xy ? [0,h] : [0,w],
                                       { reverse: this.reverse_x,
@@ -1776,7 +1774,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       this.y_handle = new JSROOT.TAxisPainter(this.getDom(), yaxis, true);
       this.y_handle.setPadName(this.getPadName());
-      this.y_handle.optionUnlab = this.v7EvalAttr("y_hidelabels", false);
+      this.y_handle.optionUnlab = this.v7EvalAttr("y_labels_hide", false);
 
       this.y_handle.configureAxis("yaxis", this.ymin, this.ymax, this.scale_ymin, this.scale_ymax, !this.swap_xy, this.swap_xy ? [0,w] : [0,h],
                                       { reverse: this.reverse_y,
@@ -3382,7 +3380,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       pattr.csstype = snap.fCssType;
       pattr.rstyle = snap.fStyle;
 
-      snap.fOption = pattr.v7EvalAttr("opt", "");
+      snap.fOption = pattr.v7EvalAttr("drawopt", "");
 
       let extract_color = (member_name, attr_name) => {
          let col = pattr.v7EvalColor(attr_name, "");
@@ -5215,7 +5213,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
               palette_x = Math.round(fx + fw + palette_margin),
               palette_y = fy;
 
-          palette_width = this.v7EvalLength("size", pw, 0.05);
+          palette_width = this.v7EvalLength("width", pw, 0.05);
           palette_height = fh;
 
           // x,y,width,height attributes used for drag functionality
@@ -5423,7 +5421,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    jsrp.addDrawFunc({ name: "ROOT::Experimental::RPaveText", icon: "img_pavetext", prereq: "v7more", func: "JSROOT.v7.drawPaveText", opt: "" });
    jsrp.addDrawFunc({ name: "ROOT::Experimental::RFrame", icon: "img_frame", func: drawRFrame, opt: "" });
    jsrp.addDrawFunc({ name: "ROOT::Experimental::RAxisDrawable", icon: "img_frame", func: drawRAxis, opt: "" });
-   jsrp.addDrawFunc({ name: "ROOT::Experimental::RAxisLabelsDrawable", icon: "img_frame", func: drawRAxis, opt: "" });
 
    JSROOT.v7.RAxisPainter = RAxisPainter;
    JSROOT.v7.RFramePainter = RFramePainter;

--- a/js/scripts/JSRoot.v7hist.js
+++ b/js/scripts/JSRoot.v7hist.js
@@ -1921,9 +1921,9 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
              has_main = !!painter.getMainPainter(),
              o = painter.options;
 
-         o.Text = painter.v7EvalAttr("text", false);
-         o.BarOffset = painter.v7EvalAttr("bar_offset", 0.);
-         o.BarWidth = painter.v7EvalAttr("bar_width", 1.);
+         o.Text = painter.v7EvalAttr("drawtext", false);
+         o.BarOffset = painter.v7EvalAttr("baroffset", 0.);
+         o.BarWidth = painter.v7EvalAttr("barwidth", 1.);
          o.second_x = has_main && painter.v7EvalAttr("secondx", false);
          o.second_y = has_main && painter.v7EvalAttr("secondy", false);
 
@@ -3742,7 +3742,7 @@ JSROOT.define(['d3', 'painter', 'v7gpad'], (d3, jsrp) => {
              sub = painter.v7EvalAttr("sub", 0),
              o = painter.options;
 
-         o.Text = painter.v7EvalAttr("text", false);
+         o.Text = painter.v7EvalAttr("drawtext", false);
 
          switch(kind) {
             case "lego": o.Lego = sub > 0 ? 10+sub : 12; o.Mode3D = true; break;

--- a/js/scripts/JSRoot.v7more.js
+++ b/js/scripts/JSRoot.v7more.js
@@ -8,7 +8,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
    function drawText() {
       let text      = this.getObject(),
           pp        = this.getPadPainter(),
-          onframe   = this.v7EvalAttr("onframe", false) ? pp.getFramePainter() : null,
+          onframe   = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
           clipping  = onframe ? this.v7EvalAttr("clipping", false) : false,
           p         = pp.getCoordinate(text.fPos, onframe),
           textFont  = this.v7EvalFont("text", { size: 12, color: "black", align: 22 });
@@ -28,7 +28,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
 
        let line         = this.getObject(),
            pp           = this.getPadPainter(),
-           onframe      = this.v7EvalAttr("onframe", false) ? pp.getFramePainter() : null,
+           onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
            clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
            p1           = pp.getCoordinate(line.fP1, onframe),
            p2           = pp.getCoordinate(line.fP2, onframe),
@@ -56,7 +56,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
 
        let box          = this.getObject(),
            pp           = this.getPadPainter(),
-           onframe      = this.v7EvalAttr("onframe", false) ? pp.getFramePainter() : null,
+           onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
            clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
            p1           = pp.getCoordinate(box.fP1, onframe),
            p2           = pp.getCoordinate(box.fP2, onframe),
@@ -91,7 +91,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
    function drawMarker() {
        let marker       = this.getObject(),
            pp           = this.getPadPainter(),
-           onframe      = this.v7EvalAttr("onframe", false) ? pp.getFramePainter() : null,
+           onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
            clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
            p            = pp.getCoordinate(marker.fP, onframe),
            marker_size  = this.v7EvalAttr( "marker_size", 1),

--- a/tutorials/v7/box.cxx
+++ b/tutorials/v7/box.cxx
@@ -28,17 +28,17 @@ void box()
    auto box1 = canvas->Draw<RBox>(RPadPos(0.1_normal, 0.3_normal), RPadPos(0.3_normal,0.6_normal));
    box1->border.color = RColor::kBlue;
    box1->border.width = 5;
-   box1->AttrFill().SetColor(RColor(0, 255, 0, 127)); // 50% opaque
+   box1->fill.color = RColor(0, 255, 0, 127); // 50% opaque
 
    auto box2 = canvas->Draw<RBox>(RPadPos(0.4_normal, 0.2_normal), RPadPos(0.6_normal,0.7_normal));
    box2->border.color = RColor::kRed;
    box2->border.width = 10.f;
    box2->border.style = 2;
-   box2->AttrFill().SetColor(RColor(0, 0, 255, 179)); // 70% opaque
+   box2->fill.color = RColor(0, 0, 255, 179); // 70% opaque
 
    auto box3 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.4_normal), RPadPos(0.9_normal,0.6_normal));
    box3->border.width = 3;
-   box3->AttrFill().SetColor(RColor::kBlue);
+   box3->fill.color = RColor::kBlue;
 
    auto box4 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.7_normal), RPadPos(0.9_normal,0.9_normal));
    box4->border.width = 4;

--- a/tutorials/v7/box.cxx
+++ b/tutorials/v7/box.cxx
@@ -26,22 +26,27 @@ void box()
    auto canvas = RCanvas::Create("RBox drawing");
 
    auto box1 = canvas->Draw<RBox>(RPadPos(0.1_normal, 0.3_normal), RPadPos(0.3_normal,0.6_normal));
-   box1->AttrBorder().SetColor(RColor::kBlue).SetWidth(5);
+   box1->border.color = RColor::kBlue;
+   box1->border.width = 5;
    box1->AttrFill().SetColor(RColor(0, 255, 0, 127)); // 50% opaque
 
    auto box2 = canvas->Draw<RBox>(RPadPos(0.4_normal, 0.2_normal), RPadPos(0.6_normal,0.7_normal));
-   box2->AttrBorder().SetColor(RColor::kRed).SetStyle(2).SetWidth(10);
+   box2->border.color = RColor::kRed;
+   box2->border.width = 10.f;
+   box2->border.style = 2;
    box2->AttrFill().SetColor(RColor(0, 0, 255, 179)); // 70% opaque
 
    auto box3 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.4_normal), RPadPos(0.9_normal,0.6_normal));
-   box3->AttrBorder().SetWidth(3);
+   box3->border.width = 3;
    box3->AttrFill().SetColor(RColor::kBlue);
 
    auto box4 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.7_normal), RPadPos(0.9_normal,0.9_normal));
-   box4->AttrBorder().SetWidth(4);
+   box4->border.width = 4;
 
    auto box5 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.1_normal), RPadPos(0.9_normal,0.3_normal));
-   box5->AttrBorder().SetRx(10).SetRy(10).SetWidth(2);
+   box5->border.rx = 10;
+   box5->border.ry = 10;
+   box5->border.width = 2;
 
    canvas->Show();
 }

--- a/tutorials/v7/box.py
+++ b/tutorials/v7/box.py
@@ -21,21 +21,26 @@ from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor
 canvas = RCanvas.Create("RBox drawing")
 
 box1 = canvas.Draw[RBox](RPadPos(0.1, 0.1), RPadPos(0.3, 0.6))
-box1.AttrBorder().SetColor(RColor.kBlue).SetWidth(5)
+box1.border.color.Set(RColor.kBlue)
+box1.border.width.Set(5)
 box1.AttrFill().SetColor(RColor(0, 255, 0, 127)) # 50% opaque
 
 box2 = canvas.Draw[RBox](RPadPos(0.4, 0.2), RPadPos(0.6, 0.7))
-box2.AttrBorder().SetColor(RColor.kRed).SetStyle(2).SetWidth(10)
+box2.border.color = RColor.kRed
+box2.border.width = 10
+box2.border.style = 2
 box2.AttrFill().SetColor(RColor(0, 0, 255, 179)) # 70% opaque
 
 box3 = canvas.Draw[RBox](RPadPos(0.7, 0.4), RPadPos(0.9, 0.6))
-box3.AttrBorder().SetWidth(3)
+box3.border.width = 3
 box3.AttrFill().SetColor(RColor.kBlue)
 
 box4 = canvas.Draw[RBox](RPadPos(0.7, 0.7), RPadPos(0.9, 0.9))
-box4.AttrBorder().SetWidth(4)
+box4.border.width = 4
 
 box5 = canvas.Draw[RBox](RPadPos(0.7, 0.1), RPadPos(0.9, 0.3))
-box5.AttrBorder().SetRx(10).SetRy(10).SetWidth(2)
+box5.border.rx = 10
+box5.border.ry = 10
+box5.border.width = 2
 
 canvas.Show()

--- a/tutorials/v7/box.py
+++ b/tutorials/v7/box.py
@@ -21,8 +21,8 @@ from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor
 canvas = RCanvas.Create("RBox drawing")
 
 box1 = canvas.Draw[RBox](RPadPos(0.1, 0.1), RPadPos(0.3, 0.6))
-box1.border.color.Set(RColor.kBlue)
-box1.border.width.Set(5)
+box1.border.color = RColor.kBlue
+box1.border.width = 5
 box1.fill.color = RColor(0, 255, 0, 127) # 50% opaque
 
 box2 = canvas.Draw[RBox](RPadPos(0.4, 0.2), RPadPos(0.6, 0.7))

--- a/tutorials/v7/box.py
+++ b/tutorials/v7/box.py
@@ -23,17 +23,17 @@ canvas = RCanvas.Create("RBox drawing")
 box1 = canvas.Draw[RBox](RPadPos(0.1, 0.1), RPadPos(0.3, 0.6))
 box1.border.color.Set(RColor.kBlue)
 box1.border.width.Set(5)
-box1.AttrFill().SetColor(RColor(0, 255, 0, 127)) # 50% opaque
+box1.fill.color = RColor(0, 255, 0, 127) # 50% opaque
 
 box2 = canvas.Draw[RBox](RPadPos(0.4, 0.2), RPadPos(0.6, 0.7))
 box2.border.color = RColor.kRed
 box2.border.width = 10
 box2.border.style = 2
-box2.AttrFill().SetColor(RColor(0, 0, 255, 179)) # 70% opaque
+box2.fill.color = RColor(0, 0, 255, 179) # 70% opaque
 
 box3 = canvas.Draw[RBox](RPadPos(0.7, 0.4), RPadPos(0.9, 0.6))
 box3.border.width = 3
-box3.AttrFill().SetColor(RColor.kBlue)
+box3.fill.color = RColor.kBlue
 
 box4 = canvas.Draw[RBox](RPadPos(0.7, 0.7), RPadPos(0.9, 0.9))
 box4.border.width = 4

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -105,7 +105,7 @@ upper_pad = c.AddPad(RPadPos(0,0), RPadExtent(1, 0.65))
 
 upper_frame = upper_pad.AddFrame()
 upper_frame.AttrMargins().SetBottom(0).SetLeft(0.14).SetRight(0.05)
-upper_frame.AttrX().labels.hide = True
+upper_frame.x.labels.hide = True
 
 lower_frame = lower_pad.AddFrame()
 lower_frame.AttrMargins().SetTop(0).SetLeft(0.14).SetRight(0.05).SetBottom(0.3)

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -104,11 +104,16 @@ lower_pad = c.AddPad(RPadPos(0,0.65), RPadExtent(1, 0.35))
 upper_pad = c.AddPad(RPadPos(0,0), RPadExtent(1, 0.65))
 
 upper_frame = upper_pad.AddFrame()
-upper_frame.AttrMargins().SetBottom(0).SetLeft(0.14).SetRight(0.05)
+upper_frame.margins.bottom = 0
+upper_frame.margins.left = 0.14
+upper_frame.margins.right = 0.05
 upper_frame.x.labels.hide = True
 
 lower_frame = lower_pad.AddFrame()
-lower_frame.AttrMargins().SetTop(0).SetLeft(0.14).SetRight(0.05).SetBottom(0.3)
+lower_frame.margins.top = 0
+lower_frame.margins.left = 0.14
+lower_frame.margins.right = 0.05
+lower_frame.margins.bottom = 0.3
 
 # Fit signal + background model to data
 fit = ROOT.TF1("fit", "([0]+[1]*x+[2]*x^2+[3]*x^3)+[4]*exp(-0.5*((x-[5])/[6])^2)", 105, 160)

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -217,17 +217,17 @@ legend.AddEntry(higgs_drawable, "Signal")
 
 # Add ATLAS labels
 lbl1 = upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS")
-lbl1.onframe = True
+lbl1.onFrame = True
 lbl1.text.font = 7
 lbl1.text.size = 0.05
 lbl1.text.align = 11
 lbl2 = upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data")
-lbl2.onframe = True
+lbl2.onFrame = True
 lbl2.text.font = 4
 lbl2.text.size = 0.05
 lbl2.text.align = 11
 lbl3 = upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}")
-lbl3.onframe = True
+lbl3.onFrame = True
 lbl3.text.font = 4
 lbl3.text.size = 0.04
 lbl3.text.align = 11

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -105,7 +105,7 @@ upper_pad = c.AddPad(RPadPos(0,0), RPadExtent(1, 0.65))
 
 upper_frame = upper_pad.AddFrame()
 upper_frame.AttrMargins().SetBottom(0).SetLeft(0.14).SetRight(0.05)
-upper_frame.AttrX().SetHideLabels()
+upper_frame.AttrX().labels.hide = True
 
 lower_frame = lower_pad.AddFrame()
 lower_frame.AttrMargins().SetTop(0).SetLeft(0.14).SetRight(0.05).SetBottom(0.3)
@@ -198,7 +198,9 @@ lower_pad.Add[TObjectDrawable]().Set(ratiodata, "E SAME")
 
 # Add RLegend
 legend = upper_pad.Draw[RLegend](RPadPos(-0.05, 0.05), RPadExtent(0.3, 0.4))
-legend.AttrText().SetFont(4).SetSize(0.05).SetAlign(32)
+legend.text.size = 0.05
+legend.text.align = 32
+legend.text.SetFont(4)
 legend.border.style = 0
 legend.border.width = 0
 legend.fill.style = 0
@@ -209,9 +211,21 @@ legend.AddEntry(fit_drawable, "Signal + Bkg.")
 legend.AddEntry(higgs_drawable, "Signal")
 
 # Add ATLAS labels
-upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS").SetOnFrame().AttrText().SetFont(7).SetSize(0.05).SetAlign(11)
-upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data").SetOnFrame().AttrText().SetFont(4).SetSize(0.05).SetAlign(11)
-upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}").SetOnFrame().AttrText().SetFont(4).SetSize(0.04).SetAlign(11)
+lbl1 = upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS")
+lbl1.SetOnFrame()
+lbl1.text.SetFont(7)
+lbl1.text.size = 0.05
+lbl1.text.align = 11
+lbl2 = upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data")
+lbl2.SetOnFrame()
+lbl2.text.SetFont(4)
+lbl2.text.size = 0.05
+lbl2.text.align = 11
+lbl3 = upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}")
+lbl3.SetOnFrame()
+lbl3.text.SetFont(4)
+lbl3.text.size = 0.04
+lbl3.text.align = 11
 
 # show canvas finally
 c.SetSize(700, 780)

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -217,17 +217,17 @@ legend.AddEntry(higgs_drawable, "Signal")
 
 # Add ATLAS labels
 lbl1 = upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS")
-lbl1.SetOnFrame()
+lbl1.onframe = True
 lbl1.text.font = 7
 lbl1.text.size = 0.05
 lbl1.text.align = 11
 lbl2 = upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data")
-lbl2.SetOnFrame()
+lbl2.onframe = True
 lbl2.text.font = 4
 lbl2.text.size = 0.05
 lbl2.text.align = 11
 lbl3 = upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}")
-lbl3.SetOnFrame()
+lbl3.onframe = True
 lbl3.text.font = 4
 lbl3.text.size = 0.04
 lbl3.text.align = 11

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -201,7 +201,7 @@ legend = upper_pad.Draw[RLegend](RPadPos(-0.05, 0.05), RPadExtent(0.3, 0.4))
 legend.AttrText().SetFont(4).SetSize(0.05).SetAlign(32)
 legend.border.style = 0
 legend.border.width = 0
-legend.AttrFill().SetStyle(0)
+legend.fill.style = 0
 
 legend.AddEntry(data_drawable, "Data")
 legend.AddEntry(bkg_drawable, "Background")

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -200,7 +200,7 @@ lower_pad.Add[TObjectDrawable]().Set(ratiodata, "E SAME")
 legend = upper_pad.Draw[RLegend](RPadPos(-0.05, 0.05), RPadExtent(0.3, 0.4))
 legend.text.size = 0.05
 legend.text.align = 32
-legend.text.SetFont(4)
+legend.text.font = 4
 legend.border.style = 0
 legend.border.width = 0
 legend.fill.style = 0
@@ -213,17 +213,17 @@ legend.AddEntry(higgs_drawable, "Signal")
 # Add ATLAS labels
 lbl1 = upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS")
 lbl1.SetOnFrame()
-lbl1.text.SetFont(7)
+lbl1.text.font = 7
 lbl1.text.size = 0.05
 lbl1.text.align = 11
 lbl2 = upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data")
 lbl2.SetOnFrame()
-lbl2.text.SetFont(4)
+lbl2.text.font = 4
 lbl2.text.size = 0.05
 lbl2.text.align = 11
 lbl3 = upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}")
 lbl3.SetOnFrame()
-lbl3.text.SetFont(4)
+lbl3.text.font = 4
 lbl3.text.size = 0.04
 lbl3.text.align = 11
 

--- a/tutorials/v7/df104.py
+++ b/tutorials/v7/df104.py
@@ -199,7 +199,8 @@ lower_pad.Add[TObjectDrawable]().Set(ratiodata, "E SAME")
 # Add RLegend
 legend = upper_pad.Draw[RLegend](RPadPos(-0.05, 0.05), RPadExtent(0.3, 0.4))
 legend.AttrText().SetFont(4).SetSize(0.05).SetAlign(32)
-legend.AttrBorder().SetStyle(0).SetWidth(0)
+legend.border.style = 0
+legend.border.width = 0
 legend.AttrFill().SetStyle(0)
 
 legend.AddEntry(data_drawable, "Data")

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -180,7 +180,7 @@ frame.y.title.size = 0.045
 frame.y.labels.size = 0.04
 
 # instruct RFrame to draw axes
-frame.drawaxes = True
+frame.drawAxes = True
 
 # Draw stack with MC contributions
 stack = ROOT.THStack()

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -217,17 +217,17 @@ c.Add[TObjectDrawable]().Set(legend)
 
 # Add ATLAS label
 lbl1 = c.Add[RText](RPadPos(0.05, 0.88), "ATLAS")
-lbl1.onframe = True
+lbl1.onFrame = True
 lbl1.text.font = 7
 lbl1.text.size = 0.05
 lbl1.text.align = 11
 lbl2 = c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data")
-lbl2.onframe = True
+lbl2.onFrame = True
 lbl2.text.font = 4
 lbl2.text.size = 0.05
 lbl2.text.align = 11
 lbl3 = c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0))
-lbl3.onframe = True
+lbl3.onFrame = True
 lbl3.text.font = 4
 lbl3.text.size = 0.04
 lbl3.text.align = 11

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -162,17 +162,19 @@ frame.AttrMargins().SetTop(0.05).SetLeft(0.16).SetRight(0.05).SetBottom(0.16)
 # c.SetTickx(0)
 # c.SetTicky(0)
 
-frame.AttrX().SetMinMax(60,180)
-frame.AttrX().title.value = "m_{T}^{W#rightarrow l#nu} [GeV]"
-frame.AttrX().title.size = 0.045
-frame.AttrX().title.offset = 0.01
-frame.AttrX().labels.size = 0.04
+frame.x.min = 60
+frame.x.max = 180
+frame.x.title.value = "m_{T}^{W#rightarrow l#nu} [GeV]"
+frame.x.title.size = 0.045
+frame.x.title.offset = 0.01
+frame.x.labels.size = 0.04
 
-frame.AttrY().SetMinMax(1, 1e10*args.lumi_scale)
-frame.AttrY().SetLog()
-frame.AttrY().title.value = "Events"
-frame.AttrY().title.size = 0.045
-frame.AttrY().labels.size = 0.04
+frame.y.min = 1
+frame.y.max = 1e10*args.lumi_scale
+frame.y.log = 10
+frame.y.title.value = "Events"
+frame.y.title.size = 0.045
+frame.y.labels.size = 0.04
 
 # instruct RFrame to draw axes
 frame.SetDrawAxes(True)

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -163,16 +163,16 @@ frame.AttrMargins().SetTop(0.05).SetLeft(0.16).SetRight(0.05).SetBottom(0.16)
 # c.SetTicky(0)
 
 frame.AttrX().SetMinMax(60,180)
-frame.AttrX().SetTitle("m_{T}^{W#rightarrow l#nu} [GeV]")
-frame.AttrX().AttrTitle().SetSize(0.045)
-frame.AttrX().SetTitleOffset(0.01)
-frame.AttrX().AttrLabels().SetSize(0.04)
+frame.AttrX().title.value = "m_{T}^{W#rightarrow l#nu} [GeV]"
+frame.AttrX().title.size = 0.045
+frame.AttrX().title.offset = 0.01
+frame.AttrX().labels.size = 0.04
 
 frame.AttrY().SetMinMax(1, 1e10*args.lumi_scale)
 frame.AttrY().SetLog()
-frame.AttrY().SetTitle("Events")
-frame.AttrY().AttrTitle().SetSize(0.045)
-frame.AttrY().AttrLabels().SetSize(0.04)
+frame.AttrY().title.value = "Events"
+frame.AttrY().title.size = 0.045
+frame.AttrY().labels.size = 0.04
 
 # instruct RFrame to draw axes
 frame.SetDrawAxes(True)
@@ -211,9 +211,21 @@ legend.AddEntry(singletop, "Single top", "f")
 c.Add[TObjectDrawable]().Set(legend)
 
 # Add ATLAS label
-c.Add[RText](RPadPos(0.05, 0.88), "ATLAS").SetOnFrame().AttrText().SetFont(7).SetSize(0.04).SetAlign(11)
-c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data").SetOnFrame().AttrText().SetFont(4).SetSize(0.04).SetAlign(11)
-c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0)).SetOnFrame().AttrText().SetFont(4).SetSize(0.035).SetAlign(11)
+lbl1 = c.Add[RText](RPadPos(0.05, 0.88), "ATLAS")
+lbl1.SetOnFrame()
+lbl1.text.SetFont(7)
+lbl1.text.size = 0.05
+lbl1.text.align = 11
+lbl2 = c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data")
+lbl2.SetOnFrame()
+lbl2.text.SetFont(4)
+lbl2.text.size = 0.05
+lbl2.text.align = 11
+lbl3 = c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0))
+lbl3.SetOnFrame()
+lbl3.text.SetFont(4)
+lbl3.text.size = 0.04
+lbl3.text.align = 11
 
 # show canvas finally
 c.SetSize(600, 600)

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -158,7 +158,10 @@ ROOT.gROOT.SetStyle("ATLAS")
 # Create canvas and configure frame with axis attributes
 c = RCanvas.Create("df105_WBosonAnalysis")
 frame = c.AddFrame()
-frame.AttrMargins().SetTop(0.05).SetLeft(0.16).SetRight(0.05).SetBottom(0.16)
+frame.margins.top = 0.05
+frame.margins.right = 0.05
+frame.margins.left = 0.16
+frame.margins.bottom = 0.16
 # c.SetTickx(0)
 # c.SetTicky(0)
 

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -213,17 +213,17 @@ c.Add[TObjectDrawable]().Set(legend)
 # Add ATLAS label
 lbl1 = c.Add[RText](RPadPos(0.05, 0.88), "ATLAS")
 lbl1.SetOnFrame()
-lbl1.text.SetFont(7)
+lbl1.text.font = 7
 lbl1.text.size = 0.05
 lbl1.text.align = 11
 lbl2 = c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data")
 lbl2.SetOnFrame()
-lbl2.text.SetFont(4)
+lbl2.text.font = 4
 lbl2.text.size = 0.05
 lbl2.text.align = 11
 lbl3 = c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0))
 lbl3.SetOnFrame()
-lbl3.text.SetFont(4)
+lbl3.text.font = 4
 lbl3.text.size = 0.04
 lbl3.text.align = 11
 

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -217,17 +217,17 @@ c.Add[TObjectDrawable]().Set(legend)
 
 # Add ATLAS label
 lbl1 = c.Add[RText](RPadPos(0.05, 0.88), "ATLAS")
-lbl1.SetOnFrame()
+lbl1.onframe = True
 lbl1.text.font = 7
 lbl1.text.size = 0.05
 lbl1.text.align = 11
 lbl2 = c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data")
-lbl2.SetOnFrame()
+lbl2.onframe = True
 lbl2.text.font = 4
 lbl2.text.size = 0.05
 lbl2.text.align = 11
 lbl3 = c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0))
-lbl3.SetOnFrame()
+lbl3.onframe = True
 lbl3.text.font = 4
 lbl3.text.size = 0.04
 lbl3.text.align = 11

--- a/tutorials/v7/df105.py
+++ b/tutorials/v7/df105.py
@@ -180,7 +180,7 @@ frame.y.title.size = 0.045
 frame.y.labels.size = 0.04
 
 # instruct RFrame to draw axes
-frame.SetDrawAxes(True)
+frame.drawaxes = True
 
 # Draw stack with MC contributions
 stack = ROOT.THStack()

--- a/tutorials/v7/draw.cxx
+++ b/tutorials/v7/draw.cxx
@@ -46,11 +46,12 @@ void draw()
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("Canvas Title");
    auto draw1 = canvas->Draw(pHist);
-   // draw1->AttrLine().SetColor(RColor::kRed);
+   // draw1->line.color = RColor::kRed;
 
    auto other = std::make_shared<RH2D>(*pHist);
    auto draw2 = canvas->Draw(other);
-   // draw2->AttrLine().SetColor(RColor::kBlue).SetWidth(12);
+   // draw2->line.color = RColor::kBlue;
+   // draw2->line.width = 12;
 
    canvas->Show();
 }

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -32,72 +32,83 @@ void draw_axes()
    auto x1 = 0.08_normal, w1 = 0.36_normal, x2 = 0.57_normal, w2 = 0.36_normal;
 
    auto draw0 = canvas->Draw<RAxisDrawable>(RPadPos(0.03_normal,0.1_normal), true, 0.8_normal);
-   draw0->AttrAxis().SetTicksInvert().SetTicksSize(0.02_normal);
-   draw0->AttrAxis().title = "vertical";
+   draw0->axis.ticks.SetInvert();
+   draw0->axis.ticks.size = 0.02_normal;
+   draw0->axis.title = "vertical";
 
    auto draw1 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.9_normal), false, w1);
-   draw1->AttrAxis().title = "horizontal";
-   draw1->AttrAxis().title.SetCenter();
+   draw1->axis.title = "horizontal";
+   draw1->axis.title.SetCenter();
 
    auto draw2 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.7_normal), false, w1);
-   draw2->AttrAxis().SetTicksBoth().SetTicksSize(0.02_normal);
-   draw2->AttrAxis().title = "both side ticks";
-   draw2->AttrAxis().title.SetCenter();
+   draw2->axis.ticks.SetBoth();
+   draw2->axis.ticks.size = 0.02_normal;
+   draw2->axis.title = "both side ticks";
+   draw2->axis.title.SetCenter();
 
    auto draw3 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.5_normal), false, w1);
-   draw3->AttrAxis().title = "center labels";
-   draw3->AttrAxis().labels.center = true;
+   draw3->axis.title = "center labels";
+   draw3->axis.labels.center = true;
 
    auto draw4 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.3_normal), false, w1);
-   draw4->SetMinMax(TDatime(2020,11,12,9,0,0).Convert(), TDatime(2020,11,12,12,0,0).Convert())
-          .AttrAxis().SetTimeDisplay("%d/%m/%y %H:%M");
-   draw4->AttrAxis().title = "time display";
-   draw4->AttrAxis().labels.size = 0.01;
-   draw4->AttrAxis().labels.color = RColor::kRed;
+   draw4->SetMinMax(TDatime(2020,11,12,9,0,0).Convert(), TDatime(2020,11,12,12,0,0).Convert());
+   draw4->axis.SetTimeDisplay("%d/%m/%y %H:%M");
+   draw4->axis.title = "time display";
+   draw4->axis.labels.size = 0.01;
+   draw4->axis.labels.color = RColor::kRed;
 
    std::vector<std::string> labels = {"first", "second", "third", "forth", "fifth"};
    auto draw5 = canvas->Draw<RAxisLabelsDrawable>(RPadPos(x1, 0.1_normal), false, w1);
    draw5->SetLabels(labels);
-   draw5->AttrAxis().SetTicksInvert();
-   draw5->AttrAxis().title = "labels, swap ticks side";
-   draw5->AttrAxis().title.SetLeft();
+   draw5->axis.ticks.SetInvert();
+   draw5->axis.title = "labels, swap ticks side";
+   draw5->axis.title.SetLeft();
 
    auto draw6 = canvas->Draw<RAxisDrawable>(RPadPos(0.5_normal,0.9_normal), true, -0.8_normal);
-   draw6->SetMinMax(0, 10).AttrAxis().SetEndingArrow();
-   draw6->AttrAxis().title = "vertical negative length";
+   draw6->SetMinMax(0, 10);
+   draw6->axis.ending.SetArrow();
+   draw6->axis.title = "vertical negative length";
 
    auto draw7 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.9_normal), false, w2);
-   draw7->SetMinMax(1, 100).AttrAxis().SetLog(10);
-   draw7->AttrAxis().title = "log10 scale";
-   draw7->AttrAxis().title.SetCenter();
-   draw7->AttrAxis().title.font = 12;
-   draw7->AttrAxis().title.color = RColor::kGreen;
+   draw7->SetMinMax(1, 100);
+   draw7->axis.log = 10;
+   draw7->axis.title = "log10 scale";
+   draw7->axis.title.SetCenter();
+   draw7->axis.title.font = 12;
+   draw7->axis.title.color = RColor::kGreen;
+   draw7->axis.ending.SetCircle();
 
    auto draw8 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.7_normal), false, w2);
-   draw8->SetMinMax(0.125, 128).AttrAxis().SetLog(2);
-   draw8->AttrAxis().title = "log2 scale";
-   draw8->AttrAxis().title.SetCenter();
+   draw8->SetMinMax(0.125, 128);
+   draw8->axis.log = 2;
+   draw8->axis.title = "log2 scale";
+   draw8->axis.title.SetCenter();
 
    auto draw9 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.5_normal), false, w2);
-   draw9->SetMinMax(1, 100).AttrAxis().SetLog(2.7182);
-   draw9->AttrAxis().title = "ln scale";
-   draw9->AttrAxis().title.SetCenter();
+   draw9->SetMinMax(1, 100);
+   draw9->axis.log = 2.7182;
+   draw9->axis.title = "ln scale";
+   draw9->axis.title.SetCenter();
 
    auto draw10 = canvas->Draw<RAxisDrawable>(RPadPos(x2+w2, 0.3_normal), false, -w2);
-   draw10->AttrAxis().SetEndingArrow();
-   draw10->AttrAxis().title = "horizontal negative length";
-   draw10->AttrAxis().title.SetCenter();
+   draw10->axis.ending.SetArrow();
+   draw10->axis.title = "horizontal negative length";
+   draw10->axis.title.SetCenter();
 
    auto draw11 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.1_normal), false, w2);
-   draw11->AttrAxis().SetReverse().SetEndingArrow();
-   draw11->AttrAxis().title = "horizontal reverse";
-   draw11->AttrAxis().title.SetCenter();
+   draw11->axis.ending.SetArrow();
+   draw11->axis.reverse = true;
+   draw11->axis.title = "horizontal reverse";
+   draw11->axis.title.SetCenter();
 
    auto draw12 = canvas->Draw<RAxisDrawable>(RPadPos(0.97_normal, 0.1_normal), true, 0.8_normal);
-   draw12->AttrAxis().SetTicksBoth().SetTicksSize(0.01_normal).SetTicksColor(RColor::kBlue)
-                     .SetEndingArrow().SetEndingSize(0.01_normal);
-   draw12->AttrAxis().title = "vertical axis with arrow";
-   draw12->AttrAxis().title.SetCenter();
+   draw12->axis.ending.SetArrow();
+   draw12->axis.ending.size = 0.01_normal;
+   draw12->axis.ticks.SetBoth();
+   draw12->axis.ticks.color = RColor::kBlue;
+   draw12->axis.ticks.size = 0.01_normal;
+   draw12->axis.title = "vertical axis with arrow";
+   draw12->axis.title.SetCenter();
 
    canvas->SetSize(1000, 800);
 

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -32,48 +32,72 @@ void draw_axes()
    auto x1 = 0.08_normal, w1 = 0.36_normal, x2 = 0.57_normal, w2 = 0.36_normal;
 
    auto draw0 = canvas->Draw<RAxisDrawable>(RPadPos(0.03_normal,0.1_normal), true, 0.8_normal);
-   draw0->AttrAxis().SetTitle("vertical").SetTicksInvert().SetTicksSize(0.02_normal);
+   draw0->AttrAxis().SetTicksInvert().SetTicksSize(0.02_normal);
+   draw0->AttrAxis().title = "vertical";
 
    auto draw1 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.9_normal), false, w1);
-   draw1->AttrAxis().SetTitle("horizontal").SetTitleCenter();
+   draw1->AttrAxis().title = "horizontal";
+   draw1->AttrAxis().title.SetCenter();
 
    auto draw2 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.7_normal), false, w1);
-   draw2->AttrAxis().SetTicksBoth().SetTicksSize(0.02_normal)
-                    .SetTitle("both side ticks").SetTitleCenter();
+   draw2->AttrAxis().SetTicksBoth().SetTicksSize(0.02_normal);
+   draw2->AttrAxis().title = "both side ticks";
+   draw2->AttrAxis().title.SetCenter();
 
    auto draw3 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.5_normal), false, w1);
-   draw3->AttrAxis().SetTitle("center labels").SetLabelsCenter();
+   draw3->AttrAxis().title = "center labels";
+   draw3->AttrAxis().labels.center = true;
 
    auto draw4 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.3_normal), false, w1);
    draw4->SetMinMax(TDatime(2020,11,12,9,0,0).Convert(), TDatime(2020,11,12,12,0,0).Convert())
-          .AttrAxis().SetTimeDisplay("%d/%m/%y %H:%M").SetTitle("time display").AttrLabels().SetSize(0.01).SetColor(RColor::kRed);
+          .AttrAxis().SetTimeDisplay("%d/%m/%y %H:%M");
+   draw4->AttrAxis().title = "time display";
+   draw4->AttrAxis().labels.size = 0.01;
+   draw4->AttrAxis().labels.color = RColor::kRed;
 
    std::vector<std::string> labels = {"first", "second", "third", "forth", "fifth"};
    auto draw5 = canvas->Draw<RAxisLabelsDrawable>(RPadPos(x1, 0.1_normal), false, w1);
-   draw5->SetLabels(labels).AttrAxis().SetTitle("labels, swap ticks side").SetTitleLeft().SetTicksInvert();
+   draw5->SetLabels(labels);
+   draw5->AttrAxis().SetTicksInvert();
+   draw5->AttrAxis().title = "labels, swap ticks side";
+   draw5->AttrAxis().title.SetLeft();
 
    auto draw6 = canvas->Draw<RAxisDrawable>(RPadPos(0.5_normal,0.9_normal), true, -0.8_normal);
-   draw6->SetMinMax(0, 10).AttrAxis().SetTitle("vertical negative length").SetEndingArrow();
+   draw6->SetMinMax(0, 10).AttrAxis().SetEndingArrow();
+   draw6->AttrAxis().title = "vertical negative length";
 
    auto draw7 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.9_normal), false, w2);
-   draw7->SetMinMax(1, 100).AttrAxis().SetLog(10).SetTitle("log10 scale").SetTitleCenter().AttrTitle().SetFont(12).SetColor(RColor::kGreen);
+   draw7->SetMinMax(1, 100).AttrAxis().SetLog(10);
+   draw7->AttrAxis().title = "log10 scale";
+   draw7->AttrAxis().title.SetCenter();
+   draw7->AttrAxis().title.SetFont(12);
+   draw7->AttrAxis().title.color = RColor::kGreen;
 
    auto draw8 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.7_normal), false, w2);
-   draw8->SetMinMax(0.125, 128).AttrAxis().SetLog(2).SetTitle("log2 scale").SetTitleCenter();
+   draw8->SetMinMax(0.125, 128).AttrAxis().SetLog(2);
+   draw8->AttrAxis().title = "log2 scale";
+   draw8->AttrAxis().title.SetCenter();
 
    auto draw9 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.5_normal), false, w2);
-   draw9->SetMinMax(1, 100).AttrAxis().SetLog(2.7182).SetTitle("ln scale").SetTitleCenter();
+   draw9->SetMinMax(1, 100).AttrAxis().SetLog(2.7182);
+   draw9->AttrAxis().title = "ln scale";
+   draw9->AttrAxis().title.SetCenter();
 
    auto draw10 = canvas->Draw<RAxisDrawable>(RPadPos(x2+w2, 0.3_normal), false, -w2);
-   draw10->AttrAxis().SetTitle("horizontal negative length").SetTitleCenter().SetEndingArrow();
+   draw10->AttrAxis().SetEndingArrow();
+   draw10->AttrAxis().title = "horizontal negative length";
+   draw10->AttrAxis().title.SetCenter();
 
    auto draw11 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.1_normal), false, w2);
-   draw11->AttrAxis().SetReverse().SetTitle("horizontal reverse").SetTitleCenter().SetEndingArrow();
+   draw11->AttrAxis().SetReverse().SetEndingArrow();
+   draw11->AttrAxis().title = "horizontal reverse";
+   draw11->AttrAxis().title.SetCenter();
 
    auto draw12 = canvas->Draw<RAxisDrawable>(RPadPos(0.97_normal, 0.1_normal), true, 0.8_normal);
-   draw12->AttrAxis().SetTitle("vertical axis with arrow").SetTitleCenter()
-                     .SetTicksBoth().SetTicksSize(0.01_normal).SetTicksColor(RColor::kBlue)
+   draw12->AttrAxis().SetTicksBoth().SetTicksSize(0.01_normal).SetTicksColor(RColor::kBlue)
                      .SetEndingArrow().SetEndingSize(0.01_normal);
+   draw12->AttrAxis().title = "vertical axis with arrow";
+   draw12->AttrAxis().title.SetCenter();
 
    canvas->SetSize(1000, 800);
 

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -51,26 +51,29 @@ void draw_axes()
    draw3->axis.labels.center = true;
 
    auto draw4 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.3_normal), false, w1);
-   draw4->SetMinMax(TDatime(2020,11,12,9,0,0).Convert(), TDatime(2020,11,12,12,0,0).Convert());
+   draw4->axis.min = TDatime(2020,11,12,9,0,0).Convert();
+   draw4->axis.max = TDatime(2020,11,12,12,0,0).Convert();
    draw4->axis.SetTimeDisplay("%d/%m/%y %H:%M");
    draw4->axis.title = "time display";
    draw4->axis.labels.size = 0.01;
    draw4->axis.labels.color = RColor::kRed;
 
    std::vector<std::string> labels = {"first", "second", "third", "forth", "fifth"};
-   auto draw5 = canvas->Draw<RAxisLabelsDrawable>(RPadPos(x1, 0.1_normal), false, w1);
+   auto draw5 = canvas->Draw<RAxisDrawable>(RPadPos(x1, 0.1_normal), false, w1);
    draw5->SetLabels(labels);
    draw5->axis.ticks.SetInvert();
    draw5->axis.title = "labels, swap ticks side";
    draw5->axis.title.SetLeft();
 
    auto draw6 = canvas->Draw<RAxisDrawable>(RPadPos(0.5_normal,0.9_normal), true, -0.8_normal);
-   draw6->SetMinMax(0, 10);
+   draw6->axis.min = 0;
+   draw6->axis.max = 10;
    draw6->axis.ending.SetArrow();
    draw6->axis.title = "vertical negative length";
 
    auto draw7 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.9_normal), false, w2);
-   draw7->SetMinMax(1, 100);
+   draw7->axis.min = 1;
+   draw7->axis.max = 100;
    draw7->axis.log = 10;
    draw7->axis.title = "log10 scale";
    draw7->axis.title.SetCenter();
@@ -79,13 +82,15 @@ void draw_axes()
    draw7->axis.ending.SetCircle();
 
    auto draw8 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.7_normal), false, w2);
-   draw8->SetMinMax(0.125, 128);
+   draw8->axis.min = 0.125;
+   draw8->axis.max = 128;
    draw8->axis.log = 2;
    draw8->axis.title = "log2 scale";
    draw8->axis.title.SetCenter();
 
    auto draw9 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.5_normal), false, w2);
-   draw9->SetMinMax(1, 100);
+   draw9->axis.min = 1;
+   draw9->axis.max = 100;
    draw9->axis.log = 2.7182;
    draw9->axis.title = "ln scale";
    draw9->axis.title.SetCenter();

--- a/tutorials/v7/draw_axes.cxx
+++ b/tutorials/v7/draw_axes.cxx
@@ -70,7 +70,7 @@ void draw_axes()
    draw7->SetMinMax(1, 100).AttrAxis().SetLog(10);
    draw7->AttrAxis().title = "log10 scale";
    draw7->AttrAxis().title.SetCenter();
-   draw7->AttrAxis().title.SetFont(12);
+   draw7->AttrAxis().title.font = 12;
    draw7->AttrAxis().title.color = RColor::kGreen;
 
    auto draw8 = canvas->Draw<RAxisDrawable>(RPadPos(x2, 0.7_normal), false, w2);

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -77,49 +77,49 @@ void draw_frame()
 
    // draw on left size of frame, but bound to frame, moved with frame
    auto line2 = canvas->Draw<RLine>(RPadPos(-.2_normal, -.1_normal), RPadPos(-.2_normal , 1.1_normal));
-   line2->SetOnFrame(true); // or via CSS "onframe: true;"
+   line2->onframe = true; // or via CSS "onframe: true;"
    line2->line.color = RColor::kRed;
 
    auto text2 = canvas->Draw<RText>(RPadPos(-.2_normal - 5_px, -.1_normal), "Line drawn on frame, normalized coordinates");
-   text2->SetOnFrame(true); // or via CSS "onframe: true;"
+   text2->onframe = true; // or via CSS "onframe: true;"
    text2->text.angle = 90;
    text2->text.align = 11;
 
    // draw on right size of frame, user coordiante, moved and zoomed with frame
    auto line3 = canvas->Draw<RLine>(RPadPos(110_user, -.1_normal), RPadPos(110_user, 1.1_normal));
-   line3->SetOnFrame(true); // or via CSS "onframe: true;"
+   line3->onframe = true; // or via CSS "onframe: true;"
    line3->line.color = RColor::kRed;
 
    auto text3 = canvas->Draw<RText>(RPadPos(110_user, -.1_normal), "Line drawn on frame, user coordinates");
-   text3->SetOnFrame(true); // or via CSS "onframe: true;"
+   text3->onframe = true; // or via CSS "onframe: true;"
    text3->text.angle = 90;
 
    // draw box before line at same position as line ending with 40x40 px size and clipping on
    auto box4 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 80_user - 20_px), RPadPos(80_user + 20_px, 80_user + 20_px));
    box4->fill.color = RColor::kBlue;
-   box4->SetClipping(true); // or via CSS "clipping: true;"
-   box4->SetOnFrame(true); // or via CSS "onframe: true;"
+   box4->clipping = true; // or via CSS "clipping: true;"
+   box4->onframe = true; // or via CSS "onframe: true;"
 
    // draw line in the frame, allowed to set user coordinate
    auto line4 = canvas->Draw<RLine>(RPadPos(20_user, 20_user), RPadPos(80_user, 80_user));
-   line4->SetClipping(true); // or via CSS "clipping: true;"
-   line4->SetOnFrame(true); // or via CSS "onframe: true;"
+   line4->clipping = true; // or via CSS "clipping: true;"
+   line4->onframe = true; // or via CSS "onframe: true;"
 
    auto text4 = canvas->Draw<RText>(RPadPos(20_user, 20_user), "clipping on");
-   text4->SetOnFrame(true); // or via CSS "onframe: true;"
-   text4->SetClipping(true); // or via CSS "clipping: true;"
+   text4->onframe = true; // or via CSS "onframe: true;"
+   text4->clipping = true; // or via CSS "clipping: true;"
 
    // draw box before line at same position as line ending with 40x40 px size
    auto box5 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 20_user - 20_px), RPadPos(80_user + 20_px, 20_user + 20_px));
    box5->fill.color = RColor::kYellow;
-   box5->SetOnFrame(true); // or via CSS "onframe: true;"
+   box5->onframe = true; // or via CSS "onframe: true;"
 
    // draw line in the frame, but disable default cutting by the frame borders
    auto line5 = canvas->Draw<RLine>(RPadPos(20_user, 80_user), RPadPos(80_user, 20_user));
-   line5->SetOnFrame(true); // or via CSS "onframe: true;"
+   line5->onframe = true; // or via CSS "onframe: true;"
 
    auto text5 = canvas->Draw<RText>(RPadPos(20_user, 80_user), "clipping off");
-   text5->SetOnFrame(true); // or via CSS "onframe: true;"
+   text5->onframe = true; // or via CSS "onframe: true;"
    text5->text.align = 11;
 
    canvas->UseStyle(frame_style);

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -49,7 +49,7 @@ void draw_frame()
    frame->margins.top = 0.25_normal;
 
    // let frame draw axes without need of any histogram
-   frame->drawaxes = true;
+   frame->drawAxes = true;
 
    frame->x.min = 0;
    frame->x.max = 100;

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -64,7 +64,9 @@ void draw_frame()
    frame->y.zoommax = 95;
    frame->y.line.color = RColor::kBlue; // or in CSS "y_line_color: blue;"
 
-   canvas->Draw<RFrameTitle>("Frame title")->SetMargin(0.01_normal).SetHeight(0.1_normal);
+   auto title = canvas->Draw<RFrameTitle>("Frame title");
+   title->margin = 0.01_normal;
+   title->height = 0.1_normal;
 
    // draw line over the frame
    auto line0 = canvas->Draw<RLine>(RPadPos(100_px, .9_normal), RPadPos(900_px , .9_normal));

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -45,8 +45,8 @@ void draw_frame()
    // frame->fill.color = RColor::kBlue;
    frame->border.color = RColor::kBlue;
    frame->border.width = 3;
-   frame->AttrMargins().SetTop(0.25_normal);
-   frame->AttrMargins().SetAll(0.2_normal);
+   frame->margins = 0.2_normal; // set all mergins first
+   frame->margins.top = 0.25_normal;
 
    // let frame draw axes without need of any histogram
    frame->SetDrawAxes(true);

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -51,14 +51,18 @@ void draw_frame()
    // let frame draw axes without need of any histogram
    frame->SetDrawAxes(true);
 
-   frame->AttrX().SetMinMax(0,100);
-   // frame->AttrX().SetLog(2.);
-   frame->AttrX().SetZoom(5.,95.);
-   frame->AttrX().line.color = RColor::kGreen; // or in CSS "x_line_color: green;"
+   frame->x.min = 0;
+   frame->x.max = 100;
+   // frame->x.log = 2.;
+   frame->x.zoommin = 5.;
+   frame->x.zoommax = 95.;
+   frame->x.line.color = RColor::kGreen; // or in CSS "x_line_color: green;"
 
-   frame->AttrY().SetMinMax(0,100);
-   frame->AttrY().SetZoom(5,95);
-   frame->AttrY().line.color = RColor::kBlue; // or in CSS "y_line_color: blue;"
+   frame->y.min = 0;
+   frame->y.max = 100;
+   frame->y.zoommin = 5;
+   frame->y.zoommax = 95;
+   frame->y.line.color = RColor::kBlue; // or in CSS "y_line_color: blue;"
 
    canvas->Draw<RFrameTitle>("Frame title")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -65,7 +65,7 @@ void draw_frame()
    // draw line over the frame
    auto line0 = canvas->Draw<RLine>(RPadPos(100_px, .9_normal), RPadPos(900_px , .9_normal));
    auto text0 = canvas->Draw<RText>(RPadPos(100_px, .9_normal + 5_px), "Line drawn on pad, fix pixel length");
-   text0->AttrText().SetAlign(11);
+   text0->text.align = 11;
 
    // draw line under the frame
    auto line1 = canvas->Draw<RLine>(RPadPos(.1_normal, .1_normal), RPadPos(.9_normal, .1_normal));
@@ -78,7 +78,8 @@ void draw_frame()
 
    auto text2 = canvas->Draw<RText>(RPadPos(-.2_normal - 5_px, -.1_normal), "Line drawn on frame, normalized coordinates");
    text2->SetOnFrame(true); // or via CSS "onframe: true;"
-   text2->AttrText().SetAngle(90).SetAlign(11);
+   text2->text.angle = 90;
+   text2->text.align = 11;
 
    // draw on right size of frame, user coordiante, moved and zoomed with frame
    auto line3 = canvas->Draw<RLine>(RPadPos(110_user, -.1_normal), RPadPos(110_user, 1.1_normal));
@@ -87,7 +88,7 @@ void draw_frame()
 
    auto text3 = canvas->Draw<RText>(RPadPos(110_user, -.1_normal), "Line drawn on frame, user coordinates");
    text3->SetOnFrame(true); // or via CSS "onframe: true;"
-   text3->AttrText().SetAngle(90);
+   text3->text.angle = 90;
 
    // draw box before line at same position as line ending with 40x40 px size and clipping on
    auto box4 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 80_user - 20_px), RPadPos(80_user + 20_px, 80_user + 20_px));
@@ -115,7 +116,7 @@ void draw_frame()
 
    auto text5 = canvas->Draw<RText>(RPadPos(20_user, 80_user), "clipping off");
    text5->SetOnFrame(true); // or via CSS "onframe: true;"
-   text5->AttrText().SetAlign(11);
+   text5->text.align = 11;
 
    canvas->UseStyle(frame_style);
 

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -49,7 +49,7 @@ void draw_frame()
    frame->margins.top = 0.25_normal;
 
    // let frame draw axes without need of any histogram
-   frame->SetDrawAxes(true);
+   frame->drawaxes = true;
 
    frame->x.min = 0;
    frame->x.max = 100;

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -42,7 +42,7 @@ void draw_frame()
 
    // configure RFrame with direct API calls
    auto frame = canvas->AddFrame();
-   // frame->AttrFill().SetColor(RColor::kBlue);
+   // frame->fill.color = RColor::kBlue;
    frame->border.color = RColor::kBlue;
    frame->border.width = 3;
    frame->AttrMargins().SetTop(0.25_normal);
@@ -91,7 +91,7 @@ void draw_frame()
 
    // draw box before line at same position as line ending with 40x40 px size and clipping on
    auto box4 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 80_user - 20_px), RPadPos(80_user + 20_px, 80_user + 20_px));
-   box4->AttrFill().SetColor(RColor::kBlue);
+   box4->fill.color = RColor::kBlue;
    box4->SetClipping(true); // or via CSS "clipping: true;"
    box4->SetOnFrame(true); // or via CSS "onframe: true;"
 
@@ -106,7 +106,7 @@ void draw_frame()
 
    // draw box before line at same position as line ending with 40x40 px size
    auto box5 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 20_user - 20_px), RPadPos(80_user + 20_px, 20_user + 20_px));
-   box5->AttrFill().SetColor(RColor::kYellow);
+   box5->fill.color = RColor::kYellow;
    box5->SetOnFrame(true); // or via CSS "onframe: true;"
 
    // draw line in the frame, but disable default cutting by the frame borders

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -43,8 +43,8 @@ void draw_frame()
    // configure RFrame with direct API calls
    auto frame = canvas->AddFrame();
    // frame->AttrFill().SetColor(RColor::kBlue);
-   frame->AttrBorder().SetColor(RColor::kBlue);
-   frame->AttrBorder().SetWidth(3);
+   frame->border.color = RColor::kBlue;
+   frame->border.width = 3;
    frame->AttrMargins().SetTop(0.25_normal);
    frame->AttrMargins().SetAll(0.2_normal);
 
@@ -54,11 +54,11 @@ void draw_frame()
    frame->AttrX().SetMinMax(0,100);
    // frame->AttrX().SetLog(2.);
    frame->AttrX().SetZoom(5.,95.);
-   frame->AttrX().AttrLine().SetColor(RColor::kGreen); // or in CSS "x_line_color: green;"
+   frame->AttrX().line.color = RColor::kGreen; // or in CSS "x_line_color: green;"
 
    frame->AttrY().SetMinMax(0,100);
    frame->AttrY().SetZoom(5,95);
-   frame->AttrY().AttrLine().SetColor(RColor::kGreen); // or in CSS "x_line_color: blue;"
+   frame->AttrY().line.color = RColor::kBlue; // or in CSS "y_line_color: blue;"
 
    canvas->Draw<RFrameTitle>("Frame title")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
@@ -74,7 +74,7 @@ void draw_frame()
    // draw on left size of frame, but bound to frame, moved with frame
    auto line2 = canvas->Draw<RLine>(RPadPos(-.2_normal, -.1_normal), RPadPos(-.2_normal , 1.1_normal));
    line2->SetOnFrame(true); // or via CSS "onframe: true;"
-   line2->AttrLine().SetColor(RColor::kRed);
+   line2->line.color = RColor::kRed;
 
    auto text2 = canvas->Draw<RText>(RPadPos(-.2_normal - 5_px, -.1_normal), "Line drawn on frame, normalized coordinates");
    text2->SetOnFrame(true); // or via CSS "onframe: true;"
@@ -83,7 +83,7 @@ void draw_frame()
    // draw on right size of frame, user coordiante, moved and zoomed with frame
    auto line3 = canvas->Draw<RLine>(RPadPos(110_user, -.1_normal), RPadPos(110_user, 1.1_normal));
    line3->SetOnFrame(true); // or via CSS "onframe: true;"
-   line3->AttrLine().SetColor(RColor::kRed);
+   line3->line.color = RColor::kRed;
 
    auto text3 = canvas->Draw<RText>(RPadPos(110_user, -.1_normal), "Line drawn on frame, user coordinates");
    text3->SetOnFrame(true); // or via CSS "onframe: true;"

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -54,14 +54,14 @@ void draw_frame()
    frame->x.min = 0;
    frame->x.max = 100;
    // frame->x.log = 2.;
-   frame->x.zoommin = 5.;
-   frame->x.zoommax = 95.;
+   frame->x.zoomMin = 5.;
+   frame->x.zoomMax = 95.;
    frame->x.line.color = RColor::kGreen; // or in CSS "x_line_color: green;"
 
    frame->y.min = 0;
    frame->y.max = 100;
-   frame->y.zoommin = 5;
-   frame->y.zoommax = 95;
+   frame->y.zoomMin = 5;
+   frame->y.zoomMax = 95;
    frame->y.line.color = RColor::kBlue; // or in CSS "y_line_color: blue;"
 
    auto title = canvas->Draw<RFrameTitle>("Frame title");

--- a/tutorials/v7/draw_frame.cxx
+++ b/tutorials/v7/draw_frame.cxx
@@ -79,49 +79,49 @@ void draw_frame()
 
    // draw on left size of frame, but bound to frame, moved with frame
    auto line2 = canvas->Draw<RLine>(RPadPos(-.2_normal, -.1_normal), RPadPos(-.2_normal , 1.1_normal));
-   line2->onframe = true; // or via CSS "onframe: true;"
+   line2->onFrame = true; // or via CSS "onFrame: true;"
    line2->line.color = RColor::kRed;
 
    auto text2 = canvas->Draw<RText>(RPadPos(-.2_normal - 5_px, -.1_normal), "Line drawn on frame, normalized coordinates");
-   text2->onframe = true; // or via CSS "onframe: true;"
+   text2->onFrame = true; // or via CSS "onFrame: true;"
    text2->text.angle = 90;
    text2->text.align = 11;
 
    // draw on right size of frame, user coordiante, moved and zoomed with frame
    auto line3 = canvas->Draw<RLine>(RPadPos(110_user, -.1_normal), RPadPos(110_user, 1.1_normal));
-   line3->onframe = true; // or via CSS "onframe: true;"
+   line3->onFrame = true; // or via CSS "onFrame: true;"
    line3->line.color = RColor::kRed;
 
    auto text3 = canvas->Draw<RText>(RPadPos(110_user, -.1_normal), "Line drawn on frame, user coordinates");
-   text3->onframe = true; // or via CSS "onframe: true;"
+   text3->onFrame = true; // or via CSS "onFrame: true;"
    text3->text.angle = 90;
 
    // draw box before line at same position as line ending with 40x40 px size and clipping on
    auto box4 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 80_user - 20_px), RPadPos(80_user + 20_px, 80_user + 20_px));
    box4->fill.color = RColor::kBlue;
    box4->clipping = true; // or via CSS "clipping: true;"
-   box4->onframe = true; // or via CSS "onframe: true;"
+   box4->onFrame = true; // or via CSS "onFrame: true;"
 
    // draw line in the frame, allowed to set user coordinate
    auto line4 = canvas->Draw<RLine>(RPadPos(20_user, 20_user), RPadPos(80_user, 80_user));
    line4->clipping = true; // or via CSS "clipping: true;"
-   line4->onframe = true; // or via CSS "onframe: true;"
+   line4->onFrame = true; // or via CSS "onFrame: true;"
 
    auto text4 = canvas->Draw<RText>(RPadPos(20_user, 20_user), "clipping on");
-   text4->onframe = true; // or via CSS "onframe: true;"
+   text4->onFrame = true; // or via CSS "onFrame: true;"
    text4->clipping = true; // or via CSS "clipping: true;"
 
    // draw box before line at same position as line ending with 40x40 px size
    auto box5 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 20_user - 20_px), RPadPos(80_user + 20_px, 20_user + 20_px));
    box5->fill.color = RColor::kYellow;
-   box5->onframe = true; // or via CSS "onframe: true;"
+   box5->onFrame = true; // or via CSS "onFrame: true;"
 
    // draw line in the frame, but disable default cutting by the frame borders
    auto line5 = canvas->Draw<RLine>(RPadPos(20_user, 80_user), RPadPos(80_user, 20_user));
-   line5->onframe = true; // or via CSS "onframe: true;"
+   line5->onFrame = true; // or via CSS "onFrame: true;"
 
    auto text5 = canvas->Draw<RText>(RPadPos(20_user, 80_user), "clipping off");
-   text5->onframe = true; // or via CSS "onframe: true;"
+   text5->onFrame = true; // or via CSS "onFrame: true;"
    text5->text.align = 11;
 
    canvas->UseStyle(frame_style);

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -52,19 +52,22 @@ void draw_legend()
 
    // draw first histogram
    auto draw1 = canvas->Draw(pHist);
-   draw1->AttrLine().SetWidth(2).SetColor(0.3); // should be red color
+   draw1->line.width = 2.f;
+   draw1->line.color = .3f; // should be red color
 
    // draw second histogram
    auto draw2 = canvas->Draw(pHist2);
-   draw2->AttrLine().SetWidth(4).SetColor(0.7); // should be blue color
+   draw2->line.width = 4.f;
+   draw2->line.color = .7f; // should be blue color
 
    auto legend = canvas->Draw<RLegend>("Legend title");
    legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
-   legend->AttrBorder().SetWidth(2).SetColor(RColor::kRed);
+   legend->border.color = RColor::kRed;
+   legend->border.width = 2;
    legend->AddEntry(draw1, "histo1");
    legend->AddEntry(draw2, "histo2");
 
-   legend->AddEntry("test").SetAttrLine(RAttrLine().SetColor(RColor::kGreen).SetWidth(5))
+   legend->AddEntry("test").SetAttrLine(RAttrLine(RColor::kGreen, 5., 1))
                            .SetAttrFill(RAttrFill().SetColor(RColor::kBlue).SetStyle(3004))
                            .SetAttrMarker(RAttrMarker().SetColor(RColor::kRed).SetSize(3).SetStyle(RAttrMarker::kOpenCross));
 

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -61,14 +61,15 @@ void draw_legend()
    draw2->line.color = .7f; // should be blue color
 
    auto legend = canvas->Draw<RLegend>("Legend title");
-   legend->AttrFill().SetStyle(5).SetColor(RColor::kWhite);
+   legend->fill.style = 5;
+   legend->fill.color = RColor::kWhite;
    legend->border.color = RColor::kRed;
    legend->border.width = 2;
    legend->AddEntry(draw1, "histo1");
    legend->AddEntry(draw2, "histo2");
 
    legend->AddEntry("test").SetAttrLine(RAttrLine(RColor::kGreen, 5., 1))
-                           .SetAttrFill(RAttrFill().SetColor(RColor::kBlue).SetStyle(3004))
+                           .SetAttrFill(RAttrFill(RColor::kBlue,3004))
                            .SetAttrMarker(RAttrMarker().SetColor(RColor::kRed).SetSize(3).SetStyle(RAttrMarker::kOpenCross));
 
    canvas->SetSize(1000, 700);

--- a/tutorials/v7/draw_legend.cxx
+++ b/tutorials/v7/draw_legend.cxx
@@ -69,8 +69,8 @@ void draw_legend()
    legend->AddEntry(draw2, "histo2");
 
    legend->AddEntry("test").SetAttrLine(RAttrLine(RColor::kGreen, 5., 1))
-                           .SetAttrFill(RAttrFill(RColor::kBlue,3004))
-                           .SetAttrMarker(RAttrMarker().SetColor(RColor::kRed).SetSize(3).SetStyle(RAttrMarker::kOpenCross));
+                           .SetAttrFill(RAttrFill(RColor::kBlue, 3004))
+                           .SetAttrMarker(RAttrMarker(RColor::kRed, 3., RAttrMarker::kOpenCross));
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_mt.cxx
+++ b/tutorials/v7/draw_mt.cxx
@@ -59,8 +59,8 @@ void draw_canvas(const std::string &title, RColor col)
    auto canvas = RCanvas::Create(title);
 
    canvas->Draw<RFrameTitle>(title);
-   canvas->Draw(pHist)->AttrLine().SetColor(col);
-   canvas->Draw(pHist2)->AttrLine().SetColor(RColor::kBlue);
+   canvas->Draw(pHist)->line.color = col;
+   canvas->Draw(pHist2)->line.color = RColor::kBlue;
 
    int maxloop = 100;
 

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -39,16 +39,16 @@ void draw_pave()
    pave->fill.color = RColor::kBlue;
    pave->border.color = RColor::kGreen;
    pave->border.width = 3;
-   pave->SetCornerY(-0.03_normal);
-   pave->SetHeight(0.2_normal);
+   pave->cornery = -0.03_normal;
+   pave->height = 0.2_normal;
 
    auto text = canvas->Draw<RPaveText>();
    text->AddLine("This is RTextPave");
    text->AddLine("It can have several lines");
    text->AddLine("It should be positioned below RPave");
    text->fill.color = RColor::kYellow;
-   text->SetCornerY(0.25_normal);
-   text->SetHeight(0.3_normal);
+   text->cornery = 0.25_normal;
+   text->height = 0.3_normal;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -36,7 +36,7 @@ void draw_pave()
 
    // RFrame will be automatically created as well
    auto pave = canvas->Draw<RPave>();
-   pave->AttrFill().SetColor(RColor::kBlue);
+   pave->fill.color = RColor::kBlue;
    pave->border.color = RColor::kGreen;
    pave->border.width = 3;
    pave->SetCornerY(-0.03_normal);
@@ -46,7 +46,7 @@ void draw_pave()
    text->AddLine("This is RTextPave");
    text->AddLine("It can have several lines");
    text->AddLine("It should be positioned below RPave");
-   text->AttrFill().SetColor(RColor::kYellow);
+   text->fill.color = RColor::kYellow;
    text->SetCornerY(0.25_normal);
    text->SetHeight(0.3_normal);
 

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -39,7 +39,7 @@ void draw_pave()
    pave->fill.color = RColor::kBlue;
    pave->border.color = RColor::kGreen;
    pave->border.width = 3;
-   pave->cornery = -0.03_normal;
+   pave->cornerY = -0.03_normal;
    pave->height = 0.2_normal;
 
    auto text = canvas->Draw<RPaveText>();
@@ -47,7 +47,7 @@ void draw_pave()
    text->AddLine("It can have several lines");
    text->AddLine("It should be positioned below RPave");
    text->fill.color = RColor::kYellow;
-   text->cornery = 0.25_normal;
+   text->cornerY = 0.25_normal;
    text->height = 0.3_normal;
 
    canvas->SetSize(1000, 700);

--- a/tutorials/v7/draw_pave.cxx
+++ b/tutorials/v7/draw_pave.cxx
@@ -37,7 +37,8 @@ void draw_pave()
    // RFrame will be automatically created as well
    auto pave = canvas->Draw<RPave>();
    pave->AttrFill().SetColor(RColor::kBlue);
-   pave->AttrBorder().SetColor(RColor::kGreen).SetWidth(3);
+   pave->border.color = RColor::kGreen;
+   pave->border.width = 3;
    pave->SetCornerY(-0.03_normal);
    pave->SetHeight(0.2_normal);
 

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -69,7 +69,7 @@ void draw_rh1()
 
    // text and marker draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
-   subpads[0][1]->Draw(pHist1)->Text(true).AttrText().SetColor(col1);
+   subpads[0][1]->Draw(pHist1)->Text(true).text.color = col1;
    subpads[0][1]->Draw(pHist2)->Marker().marker = RAttrMarker(col2, 1.5, RAttrMarker::kOpenStar);
 
    // bar draw options

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -55,12 +55,16 @@ void draw_rh1()
 
    // default draw option
    subpads[0][0]->Draw<RFrameTitle>("Default RH1 drawing");
-   subpads[0][0]->Draw(pHist1)->AttrLine().SetColor(col1).SetWidth(2);
-   subpads[0][0]->Draw(pHist2)->AttrLine().SetColor(col2).SetWidth(4);
+   auto draw001 = subpads[0][0]->Draw(pHist1);
+   draw001->line.color = col1;
+   draw001->line.width = 2;
+   auto draw002 = subpads[0][0]->Draw(pHist2);
+   draw002->line.color = col2;
+   draw002->line.width = 4;
 
    // errors draw options
    subpads[1][0]->Draw<RFrameTitle>("Error() draw options");
-   subpads[1][0]->Draw(pHist1)->Error(1).AttrLine().SetColor(col1);
+   subpads[1][0]->Draw(pHist1)->Error(1).line.color = col1;
    subpads[1][0]->Draw(pHist2)->Error(4).AttrFill().SetColor(col2).SetStyle(3003);
 
    // text and marker draw options
@@ -75,8 +79,12 @@ void draw_rh1()
 
    // line draw option
    subpads[0][2]->Draw<RFrameTitle>("Line() draw option");
-   subpads[0][2]->Draw(pHist1)->Line().AttrLine().SetColor(col1);
-   subpads[0][2]->Draw(pHist2)->Line().AttrLine().SetColor(col2);
+   auto draw021 = subpads[0][2]->Draw(pHist1);
+   draw021->Line();
+   draw021->line.color = col1;
+   auto draw022 = subpads[0][2]->Draw(pHist2);
+   draw022->Line();
+   draw022->line.color = col2;
 
    // lego draw option
    subpads[1][2]->Draw<RFrameTitle>("Lego() draw option");

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -65,7 +65,7 @@ void draw_rh1()
    // errors draw options
    subpads[1][0]->Draw<RFrameTitle>("Error() draw options");
    subpads[1][0]->Draw(pHist1)->Error(1).line.color = col1;
-   subpads[1][0]->Draw(pHist2)->Error(4).AttrFill().SetColor(col2).SetStyle(3003);
+   subpads[1][0]->Draw(pHist2)->Error(4).fill = RAttrFill(col2, 3003);
 
    // text and marker draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
@@ -74,21 +74,17 @@ void draw_rh1()
 
    // bar draw options
    subpads[1][1]->Draw<RFrameTitle>("Bar() draw options");
-   subpads[1][1]->Draw(pHist1)->Bar(0,0.5).AttrFill().SetColor(col1);
-   subpads[1][1]->Draw(pHist2)->Bar(0.5,0.5,true).AttrFill().SetColor(col2);
+   subpads[1][1]->Draw(pHist1)->Bar(0,0.5).fill.color = col1;
+   subpads[1][1]->Draw(pHist2)->Bar(0.5,0.5,true).fill.color = col2;
 
    // line draw option
    subpads[0][2]->Draw<RFrameTitle>("Line() draw option");
-   auto draw021 = subpads[0][2]->Draw(pHist1);
-   draw021->Line();
-   draw021->line.color = col1;
-   auto draw022 = subpads[0][2]->Draw(pHist2);
-   draw022->Line();
-   draw022->line.color = col2;
+   subpads[0][2]->Draw(pHist1)->Line().line.color = col1;
+   subpads[0][2]->Draw(pHist2)->Line().line.color = col2;
 
    // lego draw option
    subpads[1][2]->Draw<RFrameTitle>("Lego() draw option");
-   subpads[1][2]->Draw(pHist1)->Lego().AttrFill().SetColor(col1);
+   subpads[1][2]->Draw(pHist1)->Lego().fill.color = col1;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -70,7 +70,7 @@ void draw_rh1()
    // text and marker draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
    subpads[0][1]->Draw(pHist1)->Text(true).AttrText().SetColor(col1);
-   subpads[0][1]->Draw(pHist2)->Marker().AttrMarker().SetColor(col2).SetStyle(RAttrMarker::kOpenStar).SetSize(1.5);
+   subpads[0][1]->Draw(pHist2)->Marker().marker = RAttrMarker(col2, 1.5, RAttrMarker::kOpenStar);
 
    // bar draw options
    subpads[1][1]->Draw<RFrameTitle>("Bar() draw options");

--- a/tutorials/v7/draw_rh1.cxx
+++ b/tutorials/v7/draw_rh1.cxx
@@ -69,7 +69,7 @@ void draw_rh1()
 
    // text and marker draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
-   subpads[0][1]->Draw(pHist1)->Text(true).text.color = col1;
+   subpads[0][1]->Draw(pHist1)->Text().text.color = col1;
    subpads[0][1]->Draw(pHist2)->Marker().marker = RAttrMarker(col2, 1.5, RAttrMarker::kOpenStar);
 
    // bar draw options

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -50,7 +50,8 @@ void draw_rh1_large()
    auto frame = canvas->AddFrame();
 
    frame->SetGridX(true).SetGridY(true);
-   frame->AttrX().SetZoom(nbins*0.2, nbins*0.8);
+   frame->x.zoommin = nbins*0.2;
+   frame->x.zoommax = nbins*0.8;
 
    canvas->Draw<RFrameTitle>(TString::Format("Large RH1D histogram with %d bins",nbins).Data());
 

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -49,8 +49,8 @@ void draw_rh1_large()
 
    auto frame = canvas->AddFrame();
 
-   frame->gridx = true;
-   frame->gridy = true;
+   frame->gridX = true;
+   frame->gridY = true;
    frame->x.zoomMin = nbins*0.2;
    frame->x.zoomMax = nbins*0.8;
 

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -49,7 +49,8 @@ void draw_rh1_large()
 
    auto frame = canvas->AddFrame();
 
-   frame->SetGridX(true).SetGridY(true);
+   frame->gridx = true;
+   frame->gridy = true;
    frame->x.zoommin = nbins*0.2;
    frame->x.zoommax = nbins*0.8;
 

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -65,7 +65,7 @@ void draw_rh1_large()
    // draw->Error(3); // configure error drawing
    draw->Hist();  // configure hist draw option, default
 
-   draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
+   draw->optimize = true; // enable draw optimization, reduced data set will be send to clients
 
    auto stat = canvas->Draw<RHist1StatBox>(pHist, "hist");
    stat->fill.color = RColor::kBlue;

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -51,8 +51,8 @@ void draw_rh1_large()
 
    frame->gridx = true;
    frame->gridy = true;
-   frame->x.zoommin = nbins*0.2;
-   frame->x.zoommax = nbins*0.8;
+   frame->x.zoomMin = nbins*0.2;
+   frame->x.zoomMax = nbins*0.8;
 
    canvas->Draw<RFrameTitle>(TString::Format("Large RH1D histogram with %d bins",nbins).Data());
 

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -57,7 +57,7 @@ void draw_rh1_large()
    auto draw = canvas->Draw(pHist);
 
    draw->line.color = RColor::kLime;
-   // draw->AttrFill().SetColor(RColor::kLime);
+   // draw->fill.color = RColor::kLime;
    // draw->Line(); // configure line draw option
    // draw->Bar(); // configure bar draw option
    // draw->Error(3); // configure error drawing
@@ -66,7 +66,7 @@ void draw_rh1_large()
    draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
 
    auto stat = canvas->Draw<RHist1StatBox>(pHist, "hist");
-   stat->AttrFill().SetColor(RColor::kBlue);
+   stat->fill.color = RColor::kBlue;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh1_large.cxx
+++ b/tutorials/v7/draw_rh1_large.cxx
@@ -56,7 +56,7 @@ void draw_rh1_large()
 
    auto draw = canvas->Draw(pHist);
 
-   draw->AttrLine().SetColor(RColor::kLime);
+   draw->line.color = RColor::kLime;
    // draw->AttrFill().SetColor(RColor::kLime);
    // draw->Line(); // configure line draw option
    // draw->Bar(); // configure bar draw option

--- a/tutorials/v7/draw_rh1_twoaxes.cxx
+++ b/tutorials/v7/draw_rh1_twoaxes.cxx
@@ -53,8 +53,13 @@ void draw_rh1_twoaxes()
 
    // default draw option
    canvas->Draw<RFrameTitle>("Two independent Y axes for histograms");
-   canvas->Draw(pHist1)->AttrLine().SetColor(col1).SetWidth(2);
-   canvas->Draw(pHist2)->SecondY().AttrLine().SetColor(col2).SetWidth(4);
+   auto draw1 = canvas->Draw(pHist1);
+   draw1->line.color = col1;
+   draw1->line.width = 2;
+   auto draw2 = canvas->Draw(pHist2);
+   draw2->SecondY(true);
+   draw2->line.color = col2;
+   draw2->line.width = 4;
 
    canvas->GetFrame()->AttrY().SetTicksColor(col1);
    canvas->GetFrame()->AttrY2().SetTicksColor(col2);

--- a/tutorials/v7/draw_rh1_twoaxes.cxx
+++ b/tutorials/v7/draw_rh1_twoaxes.cxx
@@ -2,7 +2,7 @@
 /// \ingroup tutorial_v7
 ///
 /// This macro generates two RH1D, fills them and draw in RCanvas.
-/// Second histogram uses enables SecondY() draw option to draw separate Y axis on right side
+/// Second histogram uses enables "secondy" attribute to draw separate Y axis on right side
 ///
 /// \macro_image (rcanvas_js)
 /// \macro_code
@@ -57,7 +57,7 @@ void draw_rh1_twoaxes()
    draw1->line.color = col1;
    draw1->line.width = 2;
    auto draw2 = canvas->Draw(pHist2);
-   draw2->SecondY(true);
+   draw2->secondy = true;
    draw2->line.color = col2;
    draw2->line.width = 4;
 

--- a/tutorials/v7/draw_rh1_twoaxes.cxx
+++ b/tutorials/v7/draw_rh1_twoaxes.cxx
@@ -61,8 +61,8 @@ void draw_rh1_twoaxes()
    draw2->line.color = col2;
    draw2->line.width = 4;
 
-   canvas->GetFrame()->AttrY().SetTicksColor(col1);
-   canvas->GetFrame()->AttrY2().SetTicksColor(col2);
+   canvas->GetFrame()->y.ticks.color = col1;
+   canvas->GetFrame()->y2.ticks.color = col2;
 
    canvas->SetSize(800, 600);
    canvas->Show();

--- a/tutorials/v7/draw_rh2.cxx
+++ b/tutorials/v7/draw_rh2.cxx
@@ -57,7 +57,7 @@ void draw_rh2()
 
    // text draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() draw option");
-   subpads[0][1]->Draw(pHist)->Text(true).AttrText().SetColor(RColor::kBlue);
+   subpads[0][1]->Draw(pHist)->Text(true).text.color = RColor::kBlue;
 
    // arrow draw options
    subpads[1][1]->Draw<RFrameTitle>("Arrow() draw option");

--- a/tutorials/v7/draw_rh2.cxx
+++ b/tutorials/v7/draw_rh2.cxx
@@ -57,7 +57,7 @@ void draw_rh2()
 
    // text draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() draw option");
-   subpads[0][1]->Draw(pHist)->Text(true).text.color = RColor::kBlue;
+   subpads[0][1]->Draw(pHist)->Text().text.color = RColor::kBlue;
 
    // arrow draw options
    subpads[1][1]->Draw<RFrameTitle>("Arrow() draw option");

--- a/tutorials/v7/draw_rh2.cxx
+++ b/tutorials/v7/draw_rh2.cxx
@@ -61,7 +61,9 @@ void draw_rh2()
 
    // arrow draw options
    subpads[1][1]->Draw<RFrameTitle>("Arrow() draw option");
-   subpads[1][1]->Draw(pHist)->Arrow().AttrLine().SetColor(RColor::kRed);
+   auto draw11 = subpads[1][1]->Draw(pHist);
+   draw11->Arrow();
+   draw11->line.color = RColor::kRed;
 
    // lego draw options
    subpads[0][2]->Draw<RFrameTitle>("Lego() draw option");

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -78,7 +78,7 @@ void draw_rh2_colz()
    draw->Text(true); // configure text drawing (can be enabled with most 2d options)
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
-   stat->AttrFill().SetColor(RColor::kRed);
+   stat->fill.color = RColor::kRed;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -51,16 +51,16 @@ void draw_rh2_colz()
    // should we made special style for frame with palette?
    frame->margins.right = 0.2_normal;
 
-   frame->gridx = false;
-   frame->gridy = false;
+   frame->gridX = false;
+   frame->gridY = false;
 
    // draw ticks on both sides
-   frame->ticksx = 2;
-   frame->ticksy = 2;
+   frame->ticksX = 2;
+   frame->ticksY = 2;
 
    // swap frame side where axes are drawn
-   // frame->swapx = true;
-   // frame->swapy = true;
+   // frame->swapX = true;
+   // frame->swapY = true;
 
    frame->x.zoomMin = 2;
    frame->x.zoomMax = 8;

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -62,10 +62,10 @@ void draw_rh2_colz()
    // frame->swapx = true;
    // frame->swapy = true;
 
-   frame->x.zoommin = 2;
-   frame->x.zoommax = 8;
-   frame->y.zoommin = 2;
-   frame->y.zoommax = 8;
+   frame->x.zoomMin = 2;
+   frame->x.zoomMax = 8;
+   frame->y.zoomMin = 2;
+   frame->y.zoomMax = 8;
 
    auto title = canvas->Draw<RFrameTitle>("2D histogram with color palette");
    title->margin = 0.01_normal;

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -81,7 +81,7 @@ void draw_rh2_colz()
    // draw->Scatter(); // configure color draw option (default)
    // draw->Arrow(); // configure arrow draw option
    draw->Color(); // configure color draw option (default)
-   draw->Text(true); // configure text drawing (can be enabled with most 2d options)
+   draw->Text(); // configure text drawing (can be enabled with most 2d options)
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
    stat->fill.color = RColor::kRed;

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -68,7 +68,7 @@ void draw_rh2_colz()
    canvas->Draw<RPaletteDrawable>(RPalette::GetPalette(), true);
 
    auto draw = canvas->Draw(pHist);
-   // draw->AttrLine().SetColor(RColor::kLime);
+   // draw->line.color = RColor::kLime;
    // draw->Surf(2); // configure surf4 draw option
    // draw->Lego(2); // configure lego2 draw option
    // draw->Contour(); // configure cont draw option

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -51,13 +51,16 @@ void draw_rh2_colz()
    // should we made special style for frame with palette?
    frame->margins.right = 0.2_normal;
 
-   frame->SetGridX(false).SetGridY(false);
+   frame->gridx = false;
+   frame->gridy = false;
 
    // draw ticks on both sides
-   frame->SetTicksX(2).SetTicksY(2);
+   frame->ticksx = 2;
+   frame->ticksy = 2;
 
    // swap frame side where axes are drawn
-   // frame->SetSwapX(true).SetSwapY(true);
+   // frame->swapx = true;
+   // frame->swapy = true;
 
    frame->x.zoommin = 2;
    frame->x.zoommax = 8;

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -67,7 +67,9 @@ void draw_rh2_colz()
    frame->y.zoommin = 2;
    frame->y.zoommax = 8;
 
-   canvas->Draw<RFrameTitle>("2D histogram with color palette")->SetMargin(0.01_normal).SetHeight(0.09_normal);
+   auto title = canvas->Draw<RFrameTitle>("2D histogram with color palette");
+   title->margin = 0.01_normal;
+   title->height = 0.09_normal;
 
    canvas->Draw<RPaletteDrawable>(RPalette::GetPalette(), true);
 

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -49,7 +49,7 @@ void draw_rh2_colz()
    auto frame = canvas->AddFrame();
 
    // should we made special style for frame with palette?
-   frame->AttrMargins().SetRight(0.2_normal);
+   frame->margins.right = 0.2_normal;
 
    frame->SetGridX(false).SetGridY(false);
 

--- a/tutorials/v7/draw_rh2_colz.cxx
+++ b/tutorials/v7/draw_rh2_colz.cxx
@@ -59,9 +59,10 @@ void draw_rh2_colz()
    // swap frame side where axes are drawn
    // frame->SetSwapX(true).SetSwapY(true);
 
-   frame->AttrX().SetZoom(2.,8.);
-
-   frame->AttrY().SetZoom(2.,8.);
+   frame->x.zoommin = 2;
+   frame->x.zoommax = 8;
+   frame->y.zoommin = 2;
+   frame->y.zoommax = 8;
 
    canvas->Draw<RFrameTitle>("2D histogram with color palette")->SetMargin(0.01_normal).SetHeight(0.09_normal);
 

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -53,7 +53,8 @@ void draw_rh2_large()
    // should we made special style for frame with palette?
    // frame->margins.right = 0.2_normal;
 
-   frame->SetGridX(false).SetGridY(false);
+   frame->gridx = false;
+   frame->gridy = false;
    frame->x.zoommin = nbins*0.2;
    frame->x.zoommax = nbins*0.8;
    frame->y.zoommin = nbins*0.2;

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -75,7 +75,7 @@ void draw_rh2_large()
    // draw->Lego(2); // configure lego2 draw option, 3d
    // draw->Error(); // configure error drawing, 3d
 
-   draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
+   draw->optimize = true; // enable draw optimization, reduced data set will be send to clients
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
    stat->fill.color = RColor::kBlue;

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -75,7 +75,7 @@ void draw_rh2_large()
    draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
-   stat->AttrFill().SetColor(RColor::kBlue);
+   stat->fill.color = RColor::kBlue;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -53,8 +53,8 @@ void draw_rh2_large()
    // should we made special style for frame with palette?
    // frame->margins.right = 0.2_normal;
 
-   frame->gridx = false;
-   frame->gridy = false;
+   frame->gridX = false;
+   frame->gridY = false;
    frame->x.zoomMin = nbins*0.2;
    frame->x.zoomMax = nbins*0.8;
    frame->y.zoomMin = nbins*0.2;

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -61,7 +61,7 @@ void draw_rh2_large()
 
    auto draw = canvas->Draw(pHist);
 
-   draw->AttrLine().SetColor(RColor::kLime);
+   draw->line.color = RColor::kLime;
    // draw->Contour(); // configure cont draw option
    // draw->Scatter(); // configure scatter draw option
    // draw->Arrow(); // configure arrow draw option

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -51,7 +51,7 @@ void draw_rh2_large()
    auto frame = canvas->AddFrame();
 
    // should we made special style for frame with palette?
-   // frame->AttrMargins().SetRight(0.2_normal);
+   // frame->margins.right = 0.2_normal;
 
    frame->SetGridX(false).SetGridY(false);
    frame->x.zoommin = nbins*0.2;

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -55,10 +55,10 @@ void draw_rh2_large()
 
    frame->gridx = false;
    frame->gridy = false;
-   frame->x.zoommin = nbins*0.2;
-   frame->x.zoommax = nbins*0.8;
-   frame->y.zoommin = nbins*0.2;
-   frame->y.zoommax = nbins*0.8;
+   frame->x.zoomMin = nbins*0.2;
+   frame->x.zoomMax = nbins*0.8;
+   frame->y.zoomMin = nbins*0.2;
+   frame->y.zoomMax = nbins*0.8;
 
    canvas->Draw<RFrameTitle>(TString::Format("Large RH2D histogram with %d x %d bins",nbins,nbins).Data());
 

--- a/tutorials/v7/draw_rh2_large.cxx
+++ b/tutorials/v7/draw_rh2_large.cxx
@@ -54,8 +54,10 @@ void draw_rh2_large()
    // frame->AttrMargins().SetRight(0.2_normal);
 
    frame->SetGridX(false).SetGridY(false);
-   frame->AttrX().SetZoom(nbins*0.2, nbins*0.8);
-   frame->AttrY().SetZoom(nbins*0.2, nbins*0.8);
+   frame->x.zoommin = nbins*0.2;
+   frame->x.zoommax = nbins*0.8;
+   frame->y.zoommin = nbins*0.2;
+   frame->y.zoommax = nbins*0.8;
 
    canvas->Draw<RFrameTitle>(TString::Format("Large RH2D histogram with %d x %d bins",nbins,nbins).Data());
 

--- a/tutorials/v7/draw_rh3.cxx
+++ b/tutorials/v7/draw_rh3.cxx
@@ -51,7 +51,7 @@ void draw_rh3()
 
    // default draw option
    subpads[0][0]->Draw<RFrameTitle>("Box(0) default draw option");
-   subpads[0][0]->Draw(pHist)->Box(0).AttrFill().SetColor(RColor::kBlue);
+   subpads[0][0]->Draw(pHist)->Box(0).fill.color = RColor::kBlue;
 
    // sphere draw options
    subpads[1][0]->Draw<RFrameTitle>("Sphere(1) draw option");
@@ -63,7 +63,7 @@ void draw_rh3()
 
    // arrow draw options
    subpads[1][1]->Draw<RFrameTitle>("Scatter() draw option");
-   subpads[1][1]->Draw(pHist)->Scatter().AttrFill().SetColor(RColor::kBlack);
+   subpads[1][1]->Draw(pHist)->Scatter().fill.color = RColor::kBlack;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -53,7 +53,7 @@ void draw_rh3_large()
    auto frame = canvas->AddFrame();
 
    // should we made special style for frame with palette?
-   // frame->AttrMargins().SetRight(0.2_normal);
+   // frame->margins.right = 0.2_normal;
 
    frame->x.zoommin = nbins*0.1;
    frame->x.zoommax = nbins*0.9;

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -72,7 +72,7 @@ void draw_rh3_large()
    draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
 
    //auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
-   //stat->AttrFill().SetColor(RColor::kBlue);
+   //stat->fill.color = RColor::kBlue;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -55,12 +55,12 @@ void draw_rh3_large()
    // should we made special style for frame with palette?
    // frame->margins.right = 0.2_normal;
 
-   frame->x.zoommin = nbins*0.1;
-   frame->x.zoommax = nbins*0.9;
-   frame->y.zoommin = nbins*0.1;
-   frame->y.zoommax = nbins*0.9;
-   frame->z.zoommin = nbins*0.1;
-   frame->z.zoommax = nbins*0.9;
+   frame->x.zoomMin = nbins*0.1;
+   frame->x.zoomMax = nbins*0.9;
+   frame->y.zoomMin = nbins*0.1;
+   frame->y.zoomMax = nbins*0.9;
+   frame->z.zoomMin = nbins*0.1;
+   frame->z.zoomMax = nbins*0.9;
 
    canvas->Draw<RFrameTitle>(TString::Format("Large RH3D histogram with %d x %d x %d bins",nbins,nbins,nbins).Data());
 

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -72,7 +72,7 @@ void draw_rh3_large()
    draw->Scatter(); // configure scatter draw option
    // draw->Color(); // configure color draw option
 
-   draw->Optimize(true); // enable draw optimization, reduced data set will be send to clients
+   draw->optimize = true; // enable draw optimization, reduced data set will be send to clients
 
    //auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
    //stat->fill.color = RColor::kBlue;

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -63,7 +63,7 @@ void draw_rh3_large()
 
    auto draw = canvas->Draw(pHist);
 
-   draw->AttrLine().SetColor(RColor::kLime);
+   draw->line.color = RColor::kLime;
    // draw->Box(); // configure box draw option (default)
    // draw->Sphere(); // configure sphere draw option
    draw->Scatter(); // configure scatter draw option

--- a/tutorials/v7/draw_rh3_large.cxx
+++ b/tutorials/v7/draw_rh3_large.cxx
@@ -55,9 +55,12 @@ void draw_rh3_large()
    // should we made special style for frame with palette?
    // frame->AttrMargins().SetRight(0.2_normal);
 
-   frame->AttrX().SetZoom(nbins*0.1, nbins*0.9);
-   frame->AttrY().SetZoom(nbins*0.1, nbins*0.9);
-   frame->AttrZ().SetZoom(nbins*0.1, nbins*0.9);
+   frame->x.zoommin = nbins*0.1;
+   frame->x.zoommax = nbins*0.9;
+   frame->y.zoommin = nbins*0.1;
+   frame->y.zoommax = nbins*0.9;
+   frame->z.zoommin = nbins*0.1;
+   frame->z.zoommax = nbins*0.9;
 
    canvas->Draw<RFrameTitle>(TString::Format("Large RH3D histogram with %d x %d x %d bins",nbins,nbins,nbins).Data());
 

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -54,16 +54,16 @@ void draw_subpads()
 
   auto subpads = canvas->Divide(2,2);
 
-  subpads[0][0]->Draw(pHist1)->AttrLine().SetColor(RColor::kRed);
-  subpads[1][0]->Draw(pHist2)->AttrLine().SetColor(RColor::kBlue);
-  subpads[0][1]->Draw(pHist3)->AttrLine().SetColor(RColor::kGreen);
+  subpads[0][0]->Draw(pHist1)->line.color = RColor::kRed;
+  subpads[1][0]->Draw(pHist2)->line.color = RColor::kBlue;
+  subpads[0][1]->Draw(pHist3)->line.color = RColor::kGreen;
 
-  // Divide pad on sub-sub-pads
+  // Divide sub-pad on sub-sub-pads
   auto subsubpads = subpads[1][1]->Divide(2,2);
 
-  subsubpads[0][0]->Draw(pHist1)->AttrLine().SetColor(RColor::kBlue);
-  subsubpads[1][0]->Draw(pHist2)->AttrLine().SetColor(RColor::kGreen);
-  subsubpads[0][1]->Draw(pHist3)->AttrLine().SetColor(RColor::kRed);
+  subsubpads[0][0]->Draw(pHist1)->line.color = RColor::kBlue;
+  subsubpads[1][0]->Draw(pHist2)->line.color = RColor::kGreen;
+  subsubpads[0][1]->Draw(pHist3)->line.color = RColor::kRed;
 
    auto style = RStyle::Parse(
         "frame {"              // select type frame for RFrame

--- a/tutorials/v7/draw_subpads.cxx
+++ b/tutorials/v7/draw_subpads.cxx
@@ -67,10 +67,10 @@ void draw_subpads()
 
    auto style = RStyle::Parse(
         "frame {"              // select type frame for RFrame
-        "   gridx: true;"      // enable grid drawing
-        "   gridy: true;"
-        "   ticksx: 2;"        // enable ticks drawing on both sides
-        "   ticksy: 2;"
+        "   gridX: true;"      // enable grid drawing
+        "   gridY: true;"
+        "   ticksX: 2;"        // enable ticks drawing on both sides
+        "   ticksY: 2;"
         "   x_labels_size: 0.05;" // below 1 is scaling factor for pad height
         "   y_labels_size: 20;"   // just a font size in pixel
         "   y_labels_color: green;"  // and name labels color

--- a/tutorials/v7/draw_symlog.cxx
+++ b/tutorials/v7/draw_symlog.cxx
@@ -28,6 +28,7 @@
 using namespace ROOT::Experimental;
 
 auto symlog_style = RStyle::Parse("frame { margins_left: 0.1; }"
+                                  "title { margin: 0.01; height: 0.1; }"
                                   "marker { onframe: true; clipping: true; }"
                                   ".group1 { marker_style: 8; marker_color: blue; }"
                                   ".group2 { marker_style: 8; marker_color: orange; }");
@@ -51,7 +52,7 @@ void draw_symlog()
    frame1->y.max = 1e4;
    frame1->y.title = "y log";
    frame1->y.title.SetCenter();
-   pads[0][0]->Draw<RFrameTitle>("linear scale")->SetMargin(0.01_normal).SetHeight(0.1_normal);
+   pads[0][0]->Draw<RFrameTitle>("linear scale");
 
    // second pad with log scales, negative values missing
    auto frame2 = pads[0][1]->AddFrame();
@@ -66,7 +67,7 @@ void draw_symlog()
    frame2->y.max = 1e4;
    frame2->y.title = "y log";
    frame2->y.title.SetCenter();
-   pads[0][1]->Draw<RFrameTitle>("log scale, missing points")->SetMargin(0.01_normal).SetHeight(0.1_normal);
+   pads[0][1]->Draw<RFrameTitle>("log scale, missing points");
 
    // third pad with symlog scales
    auto frame3 = pads[0][2]->AddFrame();
@@ -82,7 +83,7 @@ void draw_symlog()
    frame3->y.max = 1e4;
    frame3->y.title = "y log";
    frame3->y.title.SetCenter();
-   pads[0][2]->Draw<RFrameTitle>("symlog scale")->SetMargin(0.01_normal).SetHeight(0.1_normal);
+   pads[0][2]->Draw<RFrameTitle>("symlog scale");
 
    for (int n=0;n<100;n++) {
       auto x1 = TMath::Power(10, gRandom->Uniform(1, 2.9));

--- a/tutorials/v7/draw_symlog.cxx
+++ b/tutorials/v7/draw_symlog.cxx
@@ -42,23 +42,35 @@ void draw_symlog()
    // first pad with linear scales
    auto frame1 = pads[0][0]->AddFrame();
    frame1->SetDrawAxes(true);
-   frame1->AttrX().SetMinMax(-40, 1040).SetTitle("x linear").SetTitleCenter();
-   frame1->AttrY().SetMinMax(1,1e4).SetLog().SetTitle("y log").SetTitleCenter();
+   frame1->AttrX().SetMinMax(-40, 1040);
+   frame1->AttrX().title = "x linear";
+   frame1->AttrX().title.SetCenter();
+   frame1->AttrY().SetMinMax(1,1e4).SetLog();
+   frame1->AttrY().title = "y log";
+   frame1->AttrY().title.SetCenter();
    pads[0][0]->Draw<RFrameTitle>("linear scale")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
    // second pad with log scales, negative values missing
    auto frame2 = pads[0][1]->AddFrame();
    frame2->SetDrawAxes(true);
-   frame2->AttrX().SetMinMax(0.05,1.2e3).SetLog().SetTitle("x log").SetTitleCenter();
-   frame2->AttrY().SetMinMax(1,1e4).SetLog().SetTitle("y log").SetTitleCenter();
+   frame2->AttrX().SetMinMax(0.05,1.2e3).SetLog();
+   frame2->AttrX().title = "x log";
+   frame2->AttrX().title.SetCenter();
+   frame2->AttrY().SetMinMax(1,1e4).SetLog();
+   frame2->AttrY().title = "y log";
+   frame2->AttrY().title.SetCenter();
    pads[0][1]->Draw<RFrameTitle>("log scale, missing points")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
    // third pad with symlog scales
    auto frame3 = pads[0][2]->AddFrame();
    frame3->SetDrawAxes(true);
    // configure synlog scale with 10 for linear range, rest will be logarithmic, including negative
-   frame3->AttrX().SetMinMax(-10,1.2e3).SetSymlog(10).SetTitle("x symlog").SetTitleCenter();
-   frame3->AttrY().SetMinMax(1,1e4).SetLog().SetTitle("y log").SetTitleCenter();
+   frame3->AttrX().SetMinMax(-10,1.2e3).SetSymlog(10);
+   frame3->AttrX().title = "x symlog";
+   frame3->AttrX().title.SetCenter();
+   frame3->AttrY().SetMinMax(1,1e4).SetLog();
+   frame3->AttrY().title = "y log";
+   frame3->AttrY().title.SetCenter();
    pads[0][2]->Draw<RFrameTitle>("symlog scale")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
    for (int n=0;n<100;n++) {

--- a/tutorials/v7/draw_symlog.cxx
+++ b/tutorials/v7/draw_symlog.cxx
@@ -42,7 +42,7 @@ void draw_symlog()
 
    // first pad with linear scales
    auto frame1 = pads[0][0]->AddFrame();
-   frame1->drawaxes = true;
+   frame1->drawAxes = true;
    frame1->x.min = -40;
    frame1->x.max = 1040;
    frame1->x.title = "x linear";
@@ -56,7 +56,7 @@ void draw_symlog()
 
    // second pad with log scales, negative values missing
    auto frame2 = pads[0][1]->AddFrame();
-   frame2->drawaxes = true;
+   frame2->drawAxes = true;
    frame2->x.log = 10.;
    frame2->x.min = 0.05;
    frame2->x.max = 1.2e3;
@@ -71,7 +71,7 @@ void draw_symlog()
 
    // third pad with symlog scales
    auto frame3 = pads[0][2]->AddFrame();
-   frame3->drawaxes = true;
+   frame3->drawAxes = true;
    // configure symlog scale with 10 for linear range, rest will be logarithmic, including negative
    frame3->x.symlog = 10.; // boundary inside which linear scale will be used
    frame3->x.min = -10;

--- a/tutorials/v7/draw_symlog.cxx
+++ b/tutorials/v7/draw_symlog.cxx
@@ -41,7 +41,7 @@ void draw_symlog()
 
    // first pad with linear scales
    auto frame1 = pads[0][0]->AddFrame();
-   frame1->SetDrawAxes(true);
+   frame1->drawaxes = true;
    frame1->x.min = -40;
    frame1->x.max = 1040;
    frame1->x.title = "x linear";
@@ -55,7 +55,7 @@ void draw_symlog()
 
    // second pad with log scales, negative values missing
    auto frame2 = pads[0][1]->AddFrame();
-   frame2->SetDrawAxes(true);
+   frame2->drawaxes = true;
    frame2->x.log = 10.;
    frame2->x.min = 0.05;
    frame2->x.max = 1.2e3;
@@ -70,8 +70,8 @@ void draw_symlog()
 
    // third pad with symlog scales
    auto frame3 = pads[0][2]->AddFrame();
-   frame3->SetDrawAxes(true);
-   // configure synlog scale with 10 for linear range, rest will be logarithmic, including negative
+   frame3->drawaxes = true;
+   // configure symlog scale with 10 for linear range, rest will be logarithmic, including negative
    frame3->x.symlog = 10.; // boundary inside which linear scale will be used
    frame3->x.min = -10;
    frame3->x.max = 1.2e3;

--- a/tutorials/v7/draw_symlog.cxx
+++ b/tutorials/v7/draw_symlog.cxx
@@ -42,35 +42,46 @@ void draw_symlog()
    // first pad with linear scales
    auto frame1 = pads[0][0]->AddFrame();
    frame1->SetDrawAxes(true);
-   frame1->AttrX().SetMinMax(-40, 1040);
-   frame1->AttrX().title = "x linear";
-   frame1->AttrX().title.SetCenter();
-   frame1->AttrY().SetMinMax(1,1e4).SetLog();
-   frame1->AttrY().title = "y log";
-   frame1->AttrY().title.SetCenter();
+   frame1->x.min = -40;
+   frame1->x.max = 1040;
+   frame1->x.title = "x linear";
+   frame1->x.title.SetCenter();
+   frame1->y.log = 10.;
+   frame1->y.min = 1;
+   frame1->y.max = 1e4;
+   frame1->y.title = "y log";
+   frame1->y.title.SetCenter();
    pads[0][0]->Draw<RFrameTitle>("linear scale")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
    // second pad with log scales, negative values missing
    auto frame2 = pads[0][1]->AddFrame();
    frame2->SetDrawAxes(true);
-   frame2->AttrX().SetMinMax(0.05,1.2e3).SetLog();
-   frame2->AttrX().title = "x log";
-   frame2->AttrX().title.SetCenter();
-   frame2->AttrY().SetMinMax(1,1e4).SetLog();
-   frame2->AttrY().title = "y log";
-   frame2->AttrY().title.SetCenter();
+   frame2->x.log = 10.;
+   frame2->x.min = 0.05;
+   frame2->x.max = 1.2e3;
+   frame2->x.title = "x log";
+   frame2->x.title.SetCenter();
+   frame2->y.log = 10.;
+   frame2->y.min = 1;
+   frame2->y.max = 1e4;
+   frame2->y.title = "y log";
+   frame2->y.title.SetCenter();
    pads[0][1]->Draw<RFrameTitle>("log scale, missing points")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
    // third pad with symlog scales
    auto frame3 = pads[0][2]->AddFrame();
    frame3->SetDrawAxes(true);
    // configure synlog scale with 10 for linear range, rest will be logarithmic, including negative
-   frame3->AttrX().SetMinMax(-10,1.2e3).SetSymlog(10);
-   frame3->AttrX().title = "x symlog";
-   frame3->AttrX().title.SetCenter();
-   frame3->AttrY().SetMinMax(1,1e4).SetLog();
-   frame3->AttrY().title = "y log";
-   frame3->AttrY().title.SetCenter();
+   frame3->x.symlog = 10.; // boundary inside which linear scale will be used
+   frame3->x.min = -10;
+   frame3->x.max = 1.2e3;
+   frame3->x.title = "x symlog";
+   frame3->x.title.SetCenter();
+   frame3->y.log = 10.;
+   frame3->y.min = 1;
+   frame3->y.max = 1e4;
+   frame3->y.title = "y log";
+   frame3->y.title.SetCenter();
    pads[0][2]->Draw<RFrameTitle>("symlog scale")->SetMargin(0.01_normal).SetHeight(0.1_normal);
 
    for (int n=0;n<100;n++) {

--- a/tutorials/v7/draw_text.cxx
+++ b/tutorials/v7/draw_text.cxx
@@ -40,7 +40,7 @@ void draw_text()
       draw->text.size = 10+i/10;
       draw->text.angle = i;
       draw->text.align = 13;
-      draw->text.SetFont(4);
+      draw->text.font = 4;
    }
 
    canvas->Show();

--- a/tutorials/v7/draw_text.cxx
+++ b/tutorials/v7/draw_text.cxx
@@ -35,8 +35,7 @@ void draw_text()
    for (int i=0; i<=360; i+=10) {
       auto draw = canvas->Draw<RText>(RPadPos(0.5_normal, 0.6_normal), "____  Hello World");
 
-      RColor col((int) (0.38*i), (int) (0.64*i), (int) (0.76*i));
-      draw->text.color = col;
+      draw->text.color = RColor((int) (0.38*i), (int) (0.64*i), (int) (0.76*i));
       draw->text.size = 10+i/10;
       draw->text.angle = i;
       draw->text.align = 13;

--- a/tutorials/v7/draw_text.cxx
+++ b/tutorials/v7/draw_text.cxx
@@ -33,10 +33,14 @@ void draw_text()
    auto canvas = RCanvas::Create("Canvas Title");
 
    for (int i=0; i<=360; i+=10) {
-      auto text = canvas->Draw<RText>(RPadPos(0.5_normal, 0.6_normal), "____  Hello World");
+      auto draw = canvas->Draw<RText>(RPadPos(0.5_normal, 0.6_normal), "____  Hello World");
 
       RColor col((int) (0.38*i), (int) (0.64*i), (int) (0.76*i));
-      text->AttrText().SetColor(col).SetSize(10+i/10).SetAngle(i).SetAlign(13).SetFont(42);
+      draw->text.color = col;
+      draw->text.size = 10+i/10;
+      draw->text.angle = i;
+      draw->text.align = 13;
+      draw->text.SetFont(4);
    }
 
    canvas->Show();

--- a/tutorials/v7/draw_v6.cxx
+++ b/tutorials/v7/draw_v6.cxx
@@ -84,7 +84,8 @@ void draw_v6()
    subpads[0][0]->Draw<TObjectDrawable>(gr, "AL");
 
    // one can change basic attributes via v7 classes, value will be replaced on client side
-   subpads[0][1]->Draw<TObjectDrawable>(th1)->AttrLine().SetColor(RColor::kBlue).SetWidth(3).SetStyle(2);
+   auto drawth1 = subpads[0][1]->Draw<TObjectDrawable>(th1);
+   drawth1->line = RAttrLine(RColor::kBlue, 3., 2);
 
    subpads[1][0]->Draw<TObjectDrawable>(th2, "colz");
 

--- a/tutorials/v7/line.cxx
+++ b/tutorials/v7/line.cxx
@@ -29,8 +29,10 @@ void line()
    for (double i = 0; i < 360; i+=1) {
       double angle = i * TMath::Pi() / 180;
       RColor col( 50  + (int) i/360*200, 0, 0);
-      canvas->Draw<RLine>()->SetP1({0.5_normal, 0.5_normal})
-                            .SetP2({0.5_normal + 0.3_normal*TMath::Cos(angle), 0.5_normal + 0.3_normal*TMath::Sin(angle)}).AttrLine().SetColor(col);
+      auto draw = canvas->Draw<RLine>();
+      draw->SetP1({0.5_normal, 0.5_normal});
+      draw->SetP2({0.5_normal + 0.3_normal*TMath::Cos(angle), 0.5_normal + 0.3_normal*TMath::Sin(angle)});
+      draw->line.color = col;
     }
 
    canvas->Draw<RLine>()->SetP1({0.0_normal, 0.0_normal}).SetP2({1.0_normal,1.0_normal});

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -28,10 +28,12 @@ void lineRStyle()
    for (int i=10; i>0; i--){
       num = num + 0.05;
 
-      canvas->Draw<RText>(std::to_string(i))->SetPos({.3_normal, 1_normal*num}).AttrText().SetSize(13).SetAlign(32).SetFont(52);
+      auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
+      text->text.size = 13;
+      text->text.align = 32;
+      text->text.SetFont(5);
 
-      auto line = canvas->Draw<RLine>(RPadPos(.32_normal,1_normal*num), RPadPos(.8_normal, 1_normal*num));
-
+      auto line = canvas->Add<RLine>(RPadPos(.32_normal,1_normal*num), RPadPos(.8_normal, 1_normal*num));
       line->SetId(std::string("obj") + std::to_string(i));
       line->SetCssClass(std::string("user_class_") + std::to_string(i % 3));
 

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -50,5 +50,5 @@ void lineRStyle()
    canvas->Show();
 
    // after leaving function scope style will be destroyed, one has to preserve it
-   RDirectory::Heap().Add("line_style", style);
+   RDirectory::Heap().Add("lineRStyle", style);
 }

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -31,7 +31,7 @@ void lineRStyle()
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
       text->text.size = 13;
       text->text.align = 32;
-      text->text.SetFont(5);
+      text->text.font = 5;
 
       auto line = canvas->Add<RLine>(RPadPos(.32_normal,1_normal*num), RPadPos(.8_normal, 1_normal*num));
       line->SetId(std::string("obj") + std::to_string(i));

--- a/tutorials/v7/lineRStyle.cxx
+++ b/tutorials/v7/lineRStyle.cxx
@@ -25,7 +25,7 @@ void lineRStyle()
    auto canvas = RCanvas::Create("Canvas Title");
    double num = 0.3;
 
-   for (int i=10; i>0; i--){
+   for (int i = 10; i > 0; i--){
       num = num + 0.05;
 
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
@@ -36,7 +36,6 @@ void lineRStyle()
       auto line = canvas->Add<RLine>(RPadPos(.32_normal,1_normal*num), RPadPos(.8_normal, 1_normal*num));
       line->SetId(std::string("obj") + std::to_string(i));
       line->SetCssClass(std::string("user_class_") + std::to_string(i % 3));
-
    }
 
    auto style = std::make_shared<RStyle>();

--- a/tutorials/v7/lineStyle.cxx
+++ b/tutorials/v7/lineStyle.cxx
@@ -25,11 +25,12 @@ void lineStyle()
    for (int i=10; i>0; i--){
       num = num + 0.05;
 
-      canvas->Draw<RText>(std::to_string(i))->SetPos({.3_normal, 1_normal*num}).AttrText().SetSize(13).SetAlign(32).SetFont(52);
+      auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
+      text->text.size = 13;
+      text->text.align = 32;
+      text->text.SetFont(5);
 
-      auto draw = canvas->Draw<RLine>();
-      draw->SetP1({.32_normal,1_normal*num});
-      draw->SetP2({.8_normal, 1_normal*num});
+      auto draw = canvas->Add<RLine>(RPadPos{.32_normal,1_normal*num}, RPadPos{.8_normal, 1_normal*num});
       draw->line.style = i;
    }
 

--- a/tutorials/v7/lineStyle.cxx
+++ b/tutorials/v7/lineStyle.cxx
@@ -28,7 +28,7 @@ void lineStyle()
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
       text->text.size = 13;
       text->text.align = 32;
-      text->text.SetFont(5);
+      text->text.font = 5;
 
       auto draw = canvas->Add<RLine>(RPadPos{.32_normal,1_normal*num}, RPadPos{.8_normal, 1_normal*num});
       draw->line.style = i;

--- a/tutorials/v7/lineStyle.cxx
+++ b/tutorials/v7/lineStyle.cxx
@@ -27,7 +27,10 @@ void lineStyle()
 
       canvas->Draw<RText>(std::to_string(i))->SetPos({.3_normal, 1_normal*num}).AttrText().SetSize(13).SetAlign(32).SetFont(52);
 
-      canvas->Draw<RLine>()->SetP1({.32_normal,1_normal*num}).SetP2({.8_normal, 1_normal*num}).AttrLine().SetStyle(i);
+      auto draw = canvas->Draw<RLine>();
+      draw->SetP1({.32_normal,1_normal*num});
+      draw->SetP2({.8_normal, 1_normal*num});
+      draw->line.style = i;
    }
 
    canvas->Show();

--- a/tutorials/v7/lineWidth.cxx
+++ b/tutorials/v7/lineWidth.cxx
@@ -9,7 +9,7 @@
 /// \date 2018-03-18
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
-/// \author Iliana Betsou
+/// \authors Iliana Betsou, Sergey Linev
 
 #include "ROOT/RCanvas.hxx"
 #include "ROOT/RText.hxx"
@@ -22,17 +22,15 @@ void lineWidth()
    auto canvas = RCanvas::Create("Canvas Title");
    double num = 0.3;
 
-   for (int i=10; i>0; i--){
+   for (int i = 10; i > 0; i--){
       num = num + 0.05;
 
-      // one can create object ourself
       auto text = canvas->Add<RText>(RPadPos(.3_normal, 1_normal*num), std::to_string(i));
       text->text.size = 13;
       text->text.align = 32;
-      text->text.SetFont(5);
+      text->text.font = 5;
 
-      // or let it create by templated Draw<T> method
-      auto draw = canvas->Add<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal , 1_normal*num));
+      auto draw = canvas->Add<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal, 1_normal*num));
       draw->line.width = i;
    }
 

--- a/tutorials/v7/lineWidth.cxx
+++ b/tutorials/v7/lineWidth.cxx
@@ -29,7 +29,8 @@ void lineWidth()
       canvas->Draw(std::make_shared<RText>(RPadPos(.3_normal, 1_normal*num), std::to_string(i)))->AttrText().SetSize(13).SetAlign(32).SetFont(52);
 
       // or let it create by templated Draw<T> method
-      canvas->Draw<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal , 1_normal*num))->AttrLine().SetWidth(i);
+      auto draw = canvas->Draw<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal , 1_normal*num));
+      draw->line.width = i;
    }
 
    canvas->Show();

--- a/tutorials/v7/lineWidth.cxx
+++ b/tutorials/v7/lineWidth.cxx
@@ -26,10 +26,13 @@ void lineWidth()
       num = num + 0.05;
 
       // one can create object ourself
-      canvas->Draw(std::make_shared<RText>(RPadPos(.3_normal, 1_normal*num), std::to_string(i)))->AttrText().SetSize(13).SetAlign(32).SetFont(52);
+      auto text = canvas->Add<RText>(RPadPos(.3_normal, 1_normal*num), std::to_string(i));
+      text->text.size = 13;
+      text->text.align = 32;
+      text->text.SetFont(5);
 
       // or let it create by templated Draw<T> method
-      auto draw = canvas->Draw<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal , 1_normal*num));
+      auto draw = canvas->Add<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal , 1_normal*num));
       draw->line.width = i;
    }
 

--- a/tutorials/v7/markerStyle.cxx
+++ b/tutorials/v7/markerStyle.cxx
@@ -36,7 +36,9 @@ void markerStyle()
          canvas->Draw<RText>(pt, std::to_string(style));
 
          RPadPos pm(RPadLength::Normal(x), .25_normal + 0.3_normal*row);
-         canvas->Draw<RMarker>(pm)->AttrMarker().SetStyle(style).SetSize(2.5);
+         auto draw = canvas->Draw<RMarker>(pm);
+         draw->marker.style = style;
+         draw->marker.size = 2.5;
       }
    }
 

--- a/tutorials/v7/pad.cxx
+++ b/tutorials/v7/pad.cxx
@@ -28,7 +28,7 @@ void pad()
 {
    using namespace ROOT::Experimental;
 
-   auto canvas = RCanvas::Create("what to do with a pad!");
+   auto canvas = RCanvas::Create("RCanvas::Divide example");
    auto pads   = canvas->Divide(3, 3);
 
    for (int i = 0; i < 3; ++i)


### PR DESCRIPTION
In most drawables and aggregations  provide public access to the attributes.
One can directly assign value to such member like:
```cpp
line->line.style = 12;
text->text.font.face = "Arial";
```
And one always can check if attribute `Has()` value or `Clear()` it like:
```cpp
if (!line->line.style.Has()) // do somthing;
text->text.font.face.Clear();
```
Introduce several new aggregations like `RAttrAxisTitle`, `RAttrAxisLabels`, `RAttrAxisTicks`, `RAttrFont` to let provide syntax:
```
frame->x.labels.font.size = 12;
frame->y.ticks.color = RColor::kRed;
```
Sometime assign operator defined in aggregation to let assign value to whole aggregation like:
```
frame->x.labels.font = 11;
```
This will assign ROOT font type 11 to `RAttrFont` which is `face = "Courier New"; style = "oblique"; weight = "bold";`

Adjust all tests and tutorials.

Waiting for fixing cling error https://github.com/root-project/root/issues/8547 - all python tests should fail now
