### PR TITLE
Avoid undefined behavior in RANLUX++ [v6.24]

### DIFF
--- a/math/mathcore/src/ranluxpp/mulmod.h
+++ b/math/mathcore/src/ranluxpp/mulmod.h
@@ -165,10 +165,14 @@ static void mod_m(const uint64_t *mul, uint64_t *out)
    // (The assembly implementation shifts by 63, which gives the same result.)
    int64_t t0 = c >> 1;
 
-   // c = 0 -> t2 = 0; c = 1 -> upper 16 bits set; c = -1 -> lower 48 bits set
-   int64_t t2 = t0 - (c << 48);
+   // Left shifting negative values is undefined behavior until C++20, cast to
+   // unsigned.
+   uint64_t c_unsigned = static_cast<uint64_t>(c);
 
-   // c = 0 -> t1 = 0; c = 1 -> all bits set; c = -1 -> t1 = 0
+   // c = 0 -> t2 = 0; c = 1 -> upper 16 bits set; c = -1 -> lower 48 bits set
+   int64_t t2 = t0 - (c_unsigned << 48);
+
+   // c = 0 -> t1 = 0; c = 1 -> all bits set (sign extension); c = -1 -> t1 = 0
    // (The assembly implementation shifts by 63, which gives the same result.)
    int64_t t1 = t2 >> 48;
 


### PR DESCRIPTION
Left shifting a negative base is undefined behavior until C++20, cast to unsigned where it becomes implementation defined already
in earlier standards and works in practice because hardware uses two's complement.

Fixes #8503, backport of #8522

(cherry picked from commit b7d0cb13f6544cbefadb26a99840fc41dba32891)