### PR TITLE
RooFit::MultiProcess & TestStatistics part 4: RooMinimizerFcn refactoring

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -31,6 +31,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooAbsIntegrator.h
     RooAbsLValue.h
     RooAbsMCStudyModule.h
+    RooAbsMinimizerFcn.h
     RooAbsMoment.h
     RooAbsNumGenerator.h
     RooAbsOptTestStatistic.h
@@ -253,6 +254,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooAbsIntegrator.cxx
     src/RooAbsLValue.cxx
     src/RooAbsMCStudyModule.cxx
+    src/RooAbsMinimizerFcn.cxx
     src/RooAbsMoment.cxx
     src/RooAbsNumGenerator.cxx
     src/RooAbsOptTestStatistic.cxx

--- a/roofit/roofitcore/inc/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooAbsMinimizerFcn.h
@@ -1,0 +1,131 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitCore                                                       *
+ * @(#)root/roofitcore:$Id$
+ * Authors:                                                                  *
+ *   AL, Alfio Lazzaro,   INFN Milan,        alfio.lazzaro@mi.infn.it        *
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl   *
+ *                                                                           *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#ifndef __ROOFIT_NOROOMINIMIZER
+
+#ifndef ROO_ABS_MINIMIZER_FCN
+#define ROO_ABS_MINIMIZER_FCN
+
+#include "Math/IFunction.h"
+#include "Fit/ParameterSettings.h"
+#include "Fit/FitResult.h"
+
+#include "TMatrixDSym.h"
+
+#include "RooAbsReal.h"
+#include "RooArgList.h"
+#include "RooRealVar.h"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+// forward declaration
+class RooMinimizer;
+
+class RooAbsMinimizerFcn {
+
+public:
+   RooAbsMinimizerFcn(RooArgList paramList, RooMinimizer *context, bool verbose = false);
+   RooAbsMinimizerFcn(const RooAbsMinimizerFcn &other);
+   virtual ~RooAbsMinimizerFcn();
+
+   // inform Minuit through its parameter_settings vector of RooFit parameter properties
+   Bool_t synchronize_parameter_settings(std::vector<ROOT::Fit::ParameterSettings> &parameters, Bool_t optConst, Bool_t verbose);
+   // same, but can be overridden to e.g. also include gradient strategy synchronization in subclasses:
+   virtual Bool_t Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters, Bool_t optConst, Bool_t verbose);
+
+   // used for export to RooFitResult from Minimizer:
+   RooArgList *GetFloatParamList();
+   RooArgList *GetConstParamList();
+   RooArgList *GetInitFloatParamList();
+   RooArgList *GetInitConstParamList();
+   Int_t GetNumInvalidNLL() const;
+
+   // need access from Minimizer:
+   void SetEvalErrorWall(Bool_t flag);
+   /// Try to recover from invalid function values. When invalid function values are encountered,
+   /// a penalty term is returned to the minimiser to make it back off. This sets the strength of this penalty.
+   /// \note A strength of zero is equivalent to a constant penalty (= the gradient vanishes, ROOT < 6.24).
+   /// Positive values lead to a gradient pointing away from the undefined regions. Use ~10 to force the minimiser
+   /// away from invalid function values.
+   void SetRecoverFromNaNStrength(double strength) { _recoverFromNaNStrength = strength; }
+   void SetPrintEvalErrors(Int_t numEvalErrors);
+   Double_t &GetMaxFCN();
+   Int_t evalCounter() const;
+   void zeroEvalCount();
+   /// Return a possible offset that's applied to the function to separate invalid function values from valid ones.
+   double getOffset() const { return _funcOffset; }
+   void SetVerbose(Bool_t flag = kTRUE);
+
+   // put Minuit results back into RooFit objects:
+   void BackProp(const ROOT::Fit::FitResult &results);
+
+   // used in several Minimizer functions:
+   virtual std::string getFunctionName() const = 0;
+   virtual std::string getFunctionTitle() const = 0;
+
+   // set different external covariance matrix
+   void ApplyCovarianceMatrix(TMatrixDSym &V);
+
+   Bool_t SetLogFile(const char *inLogfile);
+   std::ofstream *GetLogFile() { return _logfile; }
+
+   unsigned int get_nDim() const { return _nDim; }
+
+   virtual void setOptimizeConst(Int_t flag) = 0;
+
+   bool getOptConst();
+   std::vector<double> get_parameter_values() const;
+
+   Bool_t SetPdfParamVal(int index, double value) const;
+
+protected:
+   virtual void optimizeConstantTerms(bool constStatChange, bool constValChange) = 0;
+
+   // used in BackProp (Minuit results -> RooFit) and ApplyCovarianceMatrix
+   void SetPdfParamErr(Int_t index, Double_t value);
+   void ClearPdfParamAsymErr(Int_t index);
+   void SetPdfParamErr(Int_t index, Double_t loVal, Double_t hiVal);
+
+   void printEvalErrors() const;
+
+   // members
+   RooMinimizer *_context;
+
+   // the following four are mutable because DoEval is const (in child classes)
+   // Reset the *largest* negative log-likelihood value we have seen so far:
+   mutable double _maxFCN = -std::numeric_limits<double>::infinity();
+   mutable double _funcOffset{0.};
+   double _recoverFromNaNStrength{10.};
+   mutable int _numBadNLL = 0;
+   mutable int _printEvalErrors = 10;
+   mutable int _evalCounter{0};
+
+   unsigned int _nDim = 0;
+
+   Bool_t _optConst = kFALSE;
+
+   RooArgList *_floatParamList;
+   RooArgList *_constParamList;
+   RooArgList *_initFloatParamList;
+   RooArgList *_initConstParamList;
+
+   std::ofstream *_logfile = nullptr;
+   bool _doEvalErrorWall{true};
+   bool _verbose;
+};
+
+#endif
+#endif

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -77,7 +77,6 @@ public:
   void setProfile(Bool_t flag=kTRUE) { _profile = flag ; }
   Bool_t setLogFile(const char* logf=0) { return fitterFcn()->SetLogFile(logf); }
 
-  // necessary from RooAbsMinimizerFcn subclasses
   Int_t getPrintLevel() const;
 
   void setMinimizerType(const char* type) ;
@@ -112,9 +111,7 @@ private:
 
   Int_t       _printLevel ;
   Int_t       _status ;
-  Bool_t      _optConst ;
   Bool_t      _profile ;
-  RooAbsReal* _func ;
 
   Bool_t      _verbose ;
   TStopwatch  _timer ;
@@ -132,7 +129,7 @@ private:
 
   RooMinimizer(const RooMinimizer&) ;
 	
-  ClassDef(RooMinimizer,0) // RooFit interface to ROOT::Fit::Fitter
+  ClassDef(RooMinimizer,1) // RooFit interface to ROOT::Fit::Fitter
 } ;
 
 

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -77,6 +77,9 @@ public:
   void setProfile(Bool_t flag=kTRUE) { _profile = flag ; }
   Bool_t setLogFile(const char* logf=0) { return fitterFcn()->SetLogFile(logf); }
 
+  // necessary from RooAbsMinimizerFcn subclasses
+  Int_t getPrintLevel() const;
+
   void setMinimizerType(const char* type) ;
 
   static void cleanup() ;

--- a/roofit/roofitcore/inc/RooMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooMinimizerFcn.h
@@ -1,9 +1,10 @@
 /*****************************************************************************
  * Project: RooFit                                                           *
- * Package: RooFitCore                                                       * 
+ * Package: RooFitCore                                                       *
  * @(#)root/roofitcore:$Id$
  * Authors:                                                                  *
  *   AL, Alfio Lazzaro,   INFN Milan,        alfio.lazzaro@mi.infn.it        *
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl   *
  *                                                                           *
  *                                                                           *
  * Redistribution and use in source and binary forms,                        *
@@ -24,83 +25,34 @@
 #include <fstream>
 #include <vector>
 
-class RooMinimizer;
+#include <RooAbsMinimizerFcn.h>
+
 template<typename T> class TMatrixTSym;
 using TMatrixDSym = TMatrixTSym<double>;
 
-class RooMinimizerFcn : public ROOT::Math::IBaseFunctionMultiDim {
+// forward declaration
+class RooMinimizer;
 
- public:
+class RooMinimizerFcn : public RooAbsMinimizerFcn, public ROOT::Math::IBaseFunctionMultiDim {
 
-  RooMinimizerFcn(RooAbsReal *funct, RooMinimizer *context, 
-	       bool verbose = false);
-  RooMinimizerFcn(const RooMinimizerFcn& other);
-  virtual ~RooMinimizerFcn();
+public:
+   RooMinimizerFcn(RooAbsReal *funct, RooMinimizer *context, bool verbose = false);
+   RooMinimizerFcn(const RooMinimizerFcn &other);
+   virtual ~RooMinimizerFcn();
 
-  virtual ROOT::Math::IBaseFunctionMultiDim* Clone() const;
-  virtual unsigned int NDim() const { return _nDim; }
+   ROOT::Math::IBaseFunctionMultiDim *Clone() const override;
+   unsigned int NDim() const override { return get_nDim(); }
 
-  RooArgList* GetFloatParamList() { return _floatParamList; }
-  RooArgList* GetConstParamList() { return _constParamList; }
-  RooArgList* GetInitFloatParamList() { return _initFloatParamList; }
-  RooArgList* GetInitConstParamList() { return _initConstParamList; }
+   std::string getFunctionName() const override;
+   std::string getFunctionTitle() const override;
 
-  void SetEvalErrorWall(Bool_t flag) { _doEvalErrorWall = flag ; }
-  /// Try to recover from invalid function values. When invalid function values are encountered,
-  /// a penalty term is returned to the minimiser to make it back off. This sets the strength of this penalty.
-  /// \note A strength of zero is equivalent to a constant penalty (= the gradient vanishes, ROOT < 6.24).
-  /// Positive values lead to a gradient pointing away from the undefined regions. Use ~10 to force the minimiser
-  /// away from invalid function values.
-  void SetRecoverFromNaNStrength(double strength) { _recoverFromNaNStrength = strength; }
-  void SetPrintEvalErrors(Int_t numEvalErrors) { _printEvalErrors = numEvalErrors ; }
-  Bool_t SetLogFile(const char* inLogfile);
-  std::ofstream* GetLogFile() { return _logfile; }
-  void SetVerbose(Bool_t flag=kTRUE) { _verbose = flag ; }
+   void setOptimizeConst(Int_t flag) override;
 
-  Double_t& GetMaxFCN() { return _maxFCN; }
-  Int_t GetNumInvalidNLL() const { return _numBadNLL; }
+private:
+   double DoEval(const double *x) const override;
+   void optimizeConstantTerms(bool constStatChange, bool constValChange) override;
 
-  Bool_t Synchronize(std::vector<ROOT::Fit::ParameterSettings>& parameters, 
-		     Bool_t optConst, Bool_t verbose);
-  void BackProp(const ROOT::Fit::FitResult &results);  
-  void ApplyCovarianceMatrix(TMatrixDSym& V); 
-
-  Int_t evalCounter() const { return _evalCounter ; }
-  void zeroEvalCount() { _evalCounter = 0 ; }
-  /// Return a possible offset that's applied to the function to separate invalid function values from valid ones.
-  double getOffset() const { return _funcOffset; }
-
- private:
-  void SetPdfParamErr(Int_t index, Double_t value);
-  void ClearPdfParamAsymErr(Int_t index);
-  void SetPdfParamErr(Int_t index, Double_t loVal, Double_t hiVal);
-
-  Bool_t SetPdfParamVal(int index, double value) const;
-  void printEvalErrors() const;
-
-  virtual double DoEval(const double * x) const;  
-
-
-  RooAbsReal *_funct;
-  const RooMinimizer *_context;
-
-  mutable double _maxFCN;
-  mutable double _funcOffset{0.};
-  double _recoverFromNaNStrength{10.};
-  mutable int _numBadNLL;
-  mutable int _printEvalErrors;
-  mutable int _evalCounter{0};
-  int _nDim;
-
-  RooArgList* _floatParamList;
-  RooArgList* _constParamList;
-  RooArgList* _initFloatParamList;
-  RooArgList* _initConstParamList;
-
-  std::ofstream *_logfile;
-  bool _doEvalErrorWall{true};
-  bool _verbose;
-
+   RooAbsReal *_funct;
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooMinimizerFcn.h
@@ -41,16 +41,17 @@ public:
    virtual ~RooMinimizerFcn();
 
    ROOT::Math::IBaseFunctionMultiDim *Clone() const override;
-   unsigned int NDim() const override { return get_nDim(); }
+   unsigned int NDim() const override { return getNDim(); }
 
    std::string getFunctionName() const override;
    std::string getFunctionTitle() const override;
 
-   void setOptimizeConst(Int_t flag) override;
+   void setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, Bool_t doAlsoTrackingOpt) override;
+
+   void setOffsetting(Bool_t flag) override;
 
 private:
    double DoEval(const double *x) const override;
-   void optimizeConstantTerms(bool constStatChange, bool constValChange) override;
 
    RooAbsReal *_funct;
 };

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -1,0 +1,526 @@
+/*****************************************************************************
+ * Project: RooFit                                                           *
+ * Package: RooFitCore                                                       *
+ * @(#)root/roofitcore:$Id$
+ * Authors:                                                                  *
+ *   AL, Alfio Lazzaro,   INFN Milan,        alfio.lazzaro@mi.infn.it        *
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl   *
+ *                                                                           *
+ *                                                                           *
+ * Redistribution and use in source and binary forms,                        *
+ * with or without modification, are permitted according to the terms        *
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
+ *****************************************************************************/
+
+#ifndef __ROOFIT_NOROOMINIMIZER
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// RooAbsMinimizerFcn is an interface class to the ROOT::Math function
+// for minimization. It contains only the "logistics" of synchronizing
+// between Minuit and RooFit. Its subclasses implement actual interfacing
+// to Minuit by subclassing IMultiGenFunction or IMultiGradFunction.
+//
+
+#include "RooAbsMinimizerFcn.h"
+
+#include "RooAbsArg.h"
+#include "RooAbsPdf.h"
+#include "RooArgSet.h"
+#include "RooRealVar.h"
+#include "RooAbsRealLValue.h"
+#include "RooMsgService.h"
+#include "RooMinimizer.h"
+#include "RooNaNPacker.h"
+
+#include "TMatrixDSym.h"
+
+#include <fstream>
+#include <iomanip>
+
+using namespace std;
+
+RooAbsMinimizerFcn::RooAbsMinimizerFcn(RooArgList paramList, RooMinimizer *context, bool verbose)
+   : _context(context), _verbose(verbose)
+{
+   // Examine parameter list
+   _floatParamList = (RooArgList *)paramList.selectByAttrib("Constant", kFALSE);
+   if (_floatParamList->getSize() > 1) {
+      _floatParamList->sort();
+   }
+   _floatParamList->setName("floatParamList");
+
+   _constParamList = (RooArgList *)paramList.selectByAttrib("Constant", kTRUE);
+   if (_constParamList->getSize() > 1) {
+      _constParamList->sort();
+   }
+   _constParamList->setName("constParamList");
+
+  // Remove all non-RooRealVar parameters from list (MINUIT cannot handle them)
+  for (unsigned int i = 0; i < _floatParamList->size(); ) { // Note: Counting loop, since removing from collection!
+    const RooAbsArg* arg = (*_floatParamList).at(i);
+    if (!arg->IsA()->InheritsFrom(RooAbsRealLValue::Class())) {
+      oocoutW(_context,Minimization) << "RooMinimizerFcn::RooMinimizerFcn: removing parameter "
+				     << arg->GetName() << " from list because it is not of type RooRealVar" << endl;
+      _floatParamList->remove(*arg);
+    } else {
+      ++i;
+    }
+  }
+
+   _nDim = _floatParamList->getSize();
+
+   // Save snapshot of initial lists
+   _initFloatParamList = (RooArgList *)_floatParamList->snapshot(kFALSE);
+   _initConstParamList = (RooArgList *)_constParamList->snapshot(kFALSE);
+}
+
+RooAbsMinimizerFcn::RooAbsMinimizerFcn(const RooAbsMinimizerFcn &other)
+   : _context(other._context), _maxFCN(other._maxFCN),
+     _funcOffset(other._funcOffset),
+     _recoverFromNaNStrength(other._recoverFromNaNStrength),
+     _numBadNLL(other._numBadNLL),
+     _printEvalErrors(other._printEvalErrors), _evalCounter(other._evalCounter),
+     _nDim(other._nDim), _optConst(other._optConst), _logfile(other._logfile), _doEvalErrorWall(other._doEvalErrorWall), _verbose(other._verbose)
+{
+   _floatParamList = new RooArgList(*other._floatParamList);
+   _constParamList = new RooArgList(*other._constParamList);
+   _initFloatParamList = (RooArgList *)other._initFloatParamList->snapshot(kFALSE);
+   _initConstParamList = (RooArgList *)other._initConstParamList->snapshot(kFALSE);
+}
+
+RooAbsMinimizerFcn::~RooAbsMinimizerFcn()
+{
+   delete _floatParamList;
+   delete _initFloatParamList;
+   delete _constParamList;
+   delete _initConstParamList;
+}
+
+/// Internal function to synchronize TMinimizer with current
+/// information in RooAbsReal function parameters
+Bool_t RooAbsMinimizerFcn::synchronize_parameter_settings(std::vector<ROOT::Fit::ParameterSettings> &parameters, Bool_t optConst, Bool_t verbose)
+{
+   Bool_t constValChange(kFALSE);
+   Bool_t constStatChange(kFALSE);
+
+   Int_t index(0);
+
+   // Handle eventual migrations from constParamList -> floatParamList
+   for (index = 0; index < _constParamList->getSize(); index++) {
+
+      RooRealVar *par = dynamic_cast<RooRealVar *>(_constParamList->at(index));
+      if (!par)
+         continue;
+
+      RooRealVar *oldpar = dynamic_cast<RooRealVar *>(_initConstParamList->at(index));
+      if (!oldpar)
+         continue;
+
+      // Test if constness changed
+      if (!par->isConstant()) {
+
+         // Remove from constList, add to floatList
+         _constParamList->remove(*par);
+         _floatParamList->add(*par);
+         _initFloatParamList->addClone(*oldpar);
+         _initConstParamList->remove(*oldpar);
+         constStatChange = kTRUE;
+         _nDim++;
+
+         if (verbose) {
+            oocoutI(_context, Minimization)
+               << "RooAbsMinimizerFcn::synchronize: parameter " << par->GetName() << " is now floating." << endl;
+         }
+      }
+
+      // Test if value changed
+      if (par->getVal() != oldpar->getVal()) {
+         constValChange = kTRUE;
+         if (verbose) {
+            oocoutI(_context, Minimization)
+               << "RooAbsMinimizerFcn::synchronize: value of constant parameter " << par->GetName() << " changed from "
+               << oldpar->getVal() << " to " << par->getVal() << endl;
+         }
+      }
+   }
+
+   // Update reference list
+   *_initConstParamList = *_constParamList;
+
+   // Synchronize MINUIT with function state
+   // Handle floatParamList
+   for (index = 0; index < _floatParamList->getSize(); index++) {
+      RooRealVar *par = dynamic_cast<RooRealVar *>(_floatParamList->at(index));
+
+      if (!par)
+         continue;
+
+      Double_t pstep(0);
+      Double_t pmin(0);
+      Double_t pmax(0);
+
+      if (!par->isConstant()) {
+
+         // Verify that floating parameter is indeed of type RooRealVar
+         if (!par->IsA()->InheritsFrom(RooRealVar::Class())) {
+            oocoutW(_context, Minimization) << "RooAbsMinimizerFcn::fit: Error, non-constant parameter "
+                                            << par->GetName() << " is not of type RooRealVar, skipping" << endl;
+            _floatParamList->remove(*par);
+            index--;
+            _nDim--;
+            continue;
+         }
+         // make sure the parameter are in dirty state to enable
+         // a real NLL computation when the minimizer calls the function the first time
+         // (see issue #7659)
+         par->setValueDirty();
+
+         // Set the limits, if not infinite
+         if (par->hasMin())
+            pmin = par->getMin();
+         if (par->hasMax())
+            pmax = par->getMax();
+
+         // Calculate step size
+         pstep = par->getError();
+         if (pstep <= 0) {
+            // Floating parameter without error estitimate
+            if (par->hasMin() && par->hasMax()) {
+               pstep = 0.1 * (pmax - pmin);
+
+               // Trim default choice of error if within 2 sigma of limit
+               if (pmax - par->getVal() < 2 * pstep) {
+                  pstep = (pmax - par->getVal()) / 2;
+               } else if (par->getVal() - pmin < 2 * pstep) {
+                  pstep = (par->getVal() - pmin) / 2;
+               }
+
+               // If trimming results in zero error, restore default
+               if (pstep == 0) {
+                  pstep = 0.1 * (pmax - pmin);
+               }
+
+            } else {
+               pstep = 1;
+            }
+            if (verbose) {
+               oocoutW(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: WARNING: no initial error estimate available for "
+                  << par->GetName() << ": using " << pstep << endl;
+            }
+         }
+      } else {
+         pmin = par->getVal();
+         pmax = par->getVal();
+      }
+
+      // new parameter
+      if (index >= Int_t(parameters.size())) {
+
+         if (par->hasMin() && par->hasMax()) {
+            parameters.emplace_back(par->GetName(), par->getVal(), pstep, pmin, pmax);
+         } else {
+            parameters.emplace_back(par->GetName(), par->getVal(), pstep);
+            if (par->hasMin())
+               parameters.back().SetLowerLimit(pmin);
+            else if (par->hasMax())
+               parameters.back().SetUpperLimit(pmax);
+         }
+
+         continue;
+      }
+
+      Bool_t oldFixed = parameters[index].IsFixed();
+      Double_t oldVar = parameters[index].Value();
+      Double_t oldVerr = parameters[index].StepSize();
+      Double_t oldVlo = parameters[index].LowerLimit();
+      Double_t oldVhi = parameters[index].UpperLimit();
+
+      if (par->isConstant() && !oldFixed) {
+
+         // Parameter changes floating -> constant : update only value if necessary
+         if (oldVar != par->getVal()) {
+            parameters[index].SetValue(par->getVal());
+            if (verbose) {
+               oocoutI(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: value of parameter " << par->GetName() << " changed from "
+                  << oldVar << " to " << par->getVal() << endl;
+            }
+         }
+         parameters[index].Fix();
+         constStatChange = kTRUE;
+         if (verbose) {
+            oocoutI(_context, Minimization)
+               << "RooAbsMinimizerFcn::synchronize: parameter " << par->GetName() << " is now fixed." << endl;
+         }
+
+      } else if (par->isConstant() && oldFixed) {
+
+         // Parameter changes constant -> constant : update only value if necessary
+         if (oldVar != par->getVal()) {
+            parameters[index].SetValue(par->getVal());
+            constValChange = kTRUE;
+
+            if (verbose) {
+               oocoutI(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: value of fixed parameter " << par->GetName() << " changed from "
+                  << oldVar << " to " << par->getVal() << endl;
+            }
+         }
+
+      } else {
+         // Parameter changes constant -> floating
+         if (!par->isConstant() && oldFixed) {
+            parameters[index].Release();
+            constStatChange = kTRUE;
+
+            if (verbose) {
+               oocoutI(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: parameter " << par->GetName() << " is now floating." << endl;
+            }
+         }
+
+         // Parameter changes constant -> floating : update all if necessary
+         if (oldVar != par->getVal() || oldVlo != pmin || oldVhi != pmax || oldVerr != pstep) {
+            parameters[index].SetValue(par->getVal());
+            parameters[index].SetStepSize(pstep);
+            if (par->hasMin() && par->hasMax())
+               parameters[index].SetLimits(pmin, pmax);
+            else if (par->hasMin())
+               parameters[index].SetLowerLimit(pmin);
+            else if (par->hasMax())
+               parameters[index].SetUpperLimit(pmax);
+         }
+
+         // Inform user about changes in verbose mode
+         if (verbose) {
+            // if ierr<0, par was moved from the const list and a message was already printed
+
+            if (oldVar != par->getVal()) {
+               oocoutI(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: value of parameter " << par->GetName() << " changed from "
+                  << oldVar << " to " << par->getVal() << endl;
+            }
+            if (oldVlo != pmin || oldVhi != pmax) {
+               oocoutI(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: limits of parameter " << par->GetName() << " changed from ["
+                  << oldVlo << "," << oldVhi << "] to [" << pmin << "," << pmax << "]" << endl;
+            }
+
+            // If oldVerr=0, then parameter was previously fixed
+            if (oldVerr != pstep && oldVerr != 0) {
+               oocoutI(_context, Minimization)
+                  << "RooAbsMinimizerFcn::synchronize: error/step size of parameter " << par->GetName()
+                  << " changed from " << oldVerr << " to " << pstep << endl;
+            }
+         }
+      }
+   }
+
+   if (optConst) {
+      optimizeConstantTerms(constStatChange, constValChange);
+   }
+
+   return 0;
+}
+
+Bool_t
+RooAbsMinimizerFcn::Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters, Bool_t optConst, Bool_t verbose) {
+   return synchronize_parameter_settings(parameters, optConst, verbose);
+}
+
+/// Modify PDF parameter error by ordinal index (needed by MINUIT)
+void RooAbsMinimizerFcn::SetPdfParamErr(Int_t index, Double_t value)
+{
+   static_cast<RooRealVar*>(_floatParamList->at(index))->setError(value);
+}
+
+/// Modify PDF parameter error by ordinal index (needed by MINUIT)
+void RooAbsMinimizerFcn::ClearPdfParamAsymErr(Int_t index)
+{
+   static_cast<RooRealVar*>(_floatParamList->at(index))->removeAsymError();
+}
+
+/// Modify PDF parameter error by ordinal index (needed by MINUIT)
+void RooAbsMinimizerFcn::SetPdfParamErr(Int_t index, Double_t loVal, Double_t hiVal)
+{
+   static_cast<RooRealVar*>(_floatParamList->at(index))->setAsymError(loVal, hiVal);
+}
+
+/// Transfer MINUIT fit results back into RooFit objects.
+void RooAbsMinimizerFcn::BackProp(const ROOT::Fit::FitResult &results)
+{
+   for (unsigned int index = 0; index < _nDim; index++) {
+      Double_t value = results.Value(index);
+      SetPdfParamVal(index, value);
+
+      // Set the parabolic error
+      Double_t err = results.Error(index);
+      SetPdfParamErr(index, err);
+
+      Double_t eminus = results.LowerError(index);
+      Double_t eplus = results.UpperError(index);
+
+      if (eplus > 0 || eminus < 0) {
+         // Store the asymmetric error, if it is available
+         SetPdfParamErr(index, eminus, eplus);
+      } else {
+         // Clear the asymmetric error
+         ClearPdfParamAsymErr(index);
+      }
+   }
+}
+
+/// Change the file name for logging of a RooMinimizer of all MINUIT steppings
+/// through the parameter space. If inLogfile is null, the current log file
+/// is closed and logging is stopped.
+Bool_t RooAbsMinimizerFcn::SetLogFile(const char *inLogfile)
+{
+   if (_logfile) {
+      oocoutI(_context, Minimization) << "RooAbsMinimizerFcn::setLogFile: closing previous log file" << endl;
+      _logfile->close();
+      delete _logfile;
+      _logfile = 0;
+   }
+   _logfile = new ofstream(inLogfile);
+   if (!_logfile->good()) {
+      oocoutI(_context, Minimization) << "RooAbsMinimizerFcn::setLogFile: cannot open file " << inLogfile << endl;
+      _logfile->close();
+      delete _logfile;
+      _logfile = 0;
+   }
+
+   return kFALSE;
+}
+
+/// Apply results of given external covariance matrix. i.e. propagate its errors
+/// to all RRV parameter representations and give this matrix instead of the
+/// HESSE matrix at the next save() call
+void RooAbsMinimizerFcn::ApplyCovarianceMatrix(TMatrixDSym &V)
+{
+   for (unsigned int i = 0; i < _nDim; i++) {
+      // Skip fixed parameters
+      if (_floatParamList->at(i)->isConstant()) {
+         continue;
+      }
+      SetPdfParamErr(i, sqrt(V(i, i)));
+   }
+}
+
+/// Set value of parameter i.
+Bool_t RooAbsMinimizerFcn::SetPdfParamVal(int index, double value) const
+{
+  auto par = static_cast<RooRealVar*>(&(*_floatParamList)[index]);
+
+  if (par->getVal()!=value) {
+    if (_verbose) cout << par->GetName() << "=" << value << ", " ;
+    
+    par->setVal(value);
+    return kTRUE;
+  }
+
+  return kFALSE;
+}
+
+
+/// Print information about why evaluation failed.
+/// Using _printEvalErrors, the number of errors printed can be steered.
+/// Negative values disable printing.
+void RooAbsMinimizerFcn::printEvalErrors() const {
+  if (_printEvalErrors < 0)
+    return;
+
+  std::ostringstream msg;
+  if (_doEvalErrorWall) {
+    msg << "RooMinimizerFcn: Minimized function has error status." << endl
+        << "Returning maximum FCN so far (" << _maxFCN
+        << ") to force MIGRAD to back out of this region. Error log follows.\n";
+  } else {
+    msg << "RooMinimizerFcn: Minimized function has error status but is ignored.\n";
+  }
+
+  msg << "Parameter values: " ;
+  for (const auto par : *_floatParamList) {
+    auto var = static_cast<const RooRealVar*>(par);
+    msg << "\t" << var->GetName() << "=" << var->getVal() ;
+  }
+  msg << std::endl;
+
+  RooAbsReal::printEvalErrors(msg, _printEvalErrors);
+  ooccoutW(_context,Minimization) << msg.str() << endl;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Logistics
+
+RooArgList *RooAbsMinimizerFcn::GetFloatParamList()
+{
+   return _floatParamList;
+}
+RooArgList *RooAbsMinimizerFcn::GetConstParamList()
+{
+   return _constParamList;
+}
+RooArgList *RooAbsMinimizerFcn::GetInitFloatParamList()
+{
+   return _initFloatParamList;
+}
+RooArgList *RooAbsMinimizerFcn::GetInitConstParamList()
+{
+   return _initConstParamList;
+}
+
+void RooAbsMinimizerFcn::SetEvalErrorWall(Bool_t flag)
+{
+   _doEvalErrorWall = flag;
+}
+void RooAbsMinimizerFcn::SetPrintEvalErrors(Int_t numEvalErrors)
+{
+   _printEvalErrors = numEvalErrors;
+}
+
+Double_t &RooAbsMinimizerFcn::GetMaxFCN()
+{
+   return _maxFCN;
+}
+Int_t RooAbsMinimizerFcn::GetNumInvalidNLL() const
+{
+   return _numBadNLL;
+}
+
+Int_t RooAbsMinimizerFcn::evalCounter() const
+{
+   return _evalCounter;
+}
+void RooAbsMinimizerFcn::zeroEvalCount()
+{
+   _evalCounter = 0;
+}
+
+void RooAbsMinimizerFcn::SetVerbose(Bool_t flag)
+{
+   _verbose = flag;
+}
+
+bool RooAbsMinimizerFcn::getOptConst()
+{
+   return _optConst;
+}
+
+std::vector<double> RooAbsMinimizerFcn::get_parameter_values() const
+{
+   // TODO: make a cache for this somewhere so it doesn't have to be recreated on each call
+   std::vector<double> values;
+   values.reserve(_nDim);
+
+   for (std::size_t index = 0; index < _nDim; ++index) {
+      RooRealVar *par = (RooRealVar *)_floatParamList->at(index);
+      values.push_back(par->getVal());
+   }
+
+   return values;
+}
+
+#endif

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -957,3 +957,8 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
   return res;
 
 }
+
+Int_t RooMinimizer::getPrintLevel() const
+{
+   return _printLevel;
+}

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -12,7 +12,6 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
  *****************************************************************************/
 
-
 //////////////////////////////////////////////////////////////////////////////
 /// \class RooMinimizerFcn
 /// RooMinimizerFcn is an interface to the ROOT::Math::IBaseFunctionMultiDim,
@@ -59,46 +58,10 @@ ROOT::Math::IBaseFunctionMultiDim* RooMinimizerFcn::Clone() const
   return new RooMinimizerFcn(*this) ;
 }
 
-void RooMinimizerFcn::setOptimizeConst(Int_t flag)
+void RooMinimizerFcn::setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, Bool_t doAlsoTrackingOpt)
 {
-   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
-
-   if (_optConst && !flag) {
-      if (_context->getPrintLevel() > -1)
-         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: deactivating const optimization" << endl;
-      _funct->constOptimizeTestStatistic(RooAbsArg::DeActivate, true);
-      _optConst = flag;
-   } else if (!_optConst && flag) {
-      if (_context->getPrintLevel() > -1)
-         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: activating const optimization" << endl;
-      _funct->constOptimizeTestStatistic(RooAbsArg::Activate, flag > 1);
-      _optConst = flag;
-   } else if (_optConst && flag) {
-      if (_context->getPrintLevel() > -1)
-         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: const optimization already active" << endl;
-   } else {
-      if (_context->getPrintLevel() > -1)
-         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: const optimization wasn't active" << endl;
-   }
-
-   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors);
+   _funct->constOptimizeTestStatistic(opcode, doAlsoTrackingOpt);
 }
-
-void RooMinimizerFcn::optimizeConstantTerms(bool constStatChange, bool constValChange) {
-   if (constStatChange) {
-
-      RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
-
-      oocoutI(_context,Minimization) << "RooMinimizerFcn::optimizeConstantTerms: set of constant parameters changed, rerunning const optimizer" << endl ;
-      _funct->constOptimizeTestStatistic(RooAbsArg::ConfigChange, true) ;
-   } else if (constValChange) {
-      oocoutI(_context,Minimization) << "RooMinimizerFcn::optimizeConstantTerms: constant parameter values changed, rerunning const optimizer" << endl ;
-      _funct->constOptimizeTestStatistic(RooAbsArg::ValueChange, true) ;
-   }
-
-   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
-}
-
 
 /// Evaluate function given the parameters in `x`.
 double RooMinimizerFcn::DoEval(const double *x) const {
@@ -156,4 +119,9 @@ std::string RooMinimizerFcn::getFunctionName() const
 std::string RooMinimizerFcn::getFunctionTitle() const
 {
    return _funct->GetTitle();
+}
+
+void RooMinimizerFcn::setOffsetting(Bool_t flag)
+{
+   _funct->enableOffsetting(flag);
 }

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -4,6 +4,7 @@
  * @(#)root/roofitcore:$Id$
  * Authors:                                                                  *
  *   AL, Alfio Lazzaro,   INFN Milan,        alfio.lazzaro@mi.infn.it        *
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl   *
  *                                                                           *
  *                                                                           *
  * Redistribution and use in source and binary forms,                        *
@@ -39,81 +40,18 @@ using namespace std;
 
 RooMinimizerFcn::RooMinimizerFcn(RooAbsReal *funct, RooMinimizer* context,
 			   bool verbose) :
-  _funct(funct), _context(context),
-  // Reset the *largest* negative log-likelihood value we have seen so far
-  _maxFCN(-std::numeric_limits<double>::infinity()), _numBadNLL(0),
-  _printEvalErrors(10),
-  _nDim(0), _logfile(0),
-  _verbose(verbose)
-{
-
-  // Examine parameter list
-  RooArgSet* paramSet = _funct->getParameters(RooArgSet());
-  RooArgList paramList(*paramSet);
-  delete paramSet;
-
-  _floatParamList = (RooArgList*) paramList.selectByAttrib("Constant",kFALSE);
-  if (_floatParamList->getSize()>1) {
-    _floatParamList->sort();
-  }
-  _floatParamList->setName("floatParamList");
-
-  _constParamList = (RooArgList*) paramList.selectByAttrib("Constant",kTRUE);
-  if (_constParamList->getSize()>1) {
-    _constParamList->sort();
-  }
-  _constParamList->setName("constParamList");
-
-  // Remove all non-RooRealVar parameters from list (MINUIT cannot handle them)
-  for (unsigned int i = 0; i < _floatParamList->size(); ) { // Note: Counting loop, since removing from collection!
-    const RooAbsArg* arg = (*_floatParamList).at(i);
-    if (!arg->IsA()->InheritsFrom(RooAbsRealLValue::Class())) {
-      oocoutW(_context,Minimization) << "RooMinimizerFcn::RooMinimizerFcn: removing parameter "
-				     << arg->GetName() << " from list because it is not of type RooRealVar" << endl;
-      _floatParamList->remove(*arg);
-    } else {
-      ++i;
-    }
-  }
-
-  _nDim = _floatParamList->getSize();
-
-  // Save snapshot of initial lists
-  _initFloatParamList = (RooArgList*) _floatParamList->snapshot(kFALSE) ;
-  _initConstParamList = (RooArgList*) _constParamList->snapshot(kFALSE) ;
-
-}
+  RooAbsMinimizerFcn(*funct->getParameters(RooArgSet()), context, verbose), _funct(funct)
+{}
 
 
 
-RooMinimizerFcn::RooMinimizerFcn(const RooMinimizerFcn& other) : ROOT::Math::IBaseFunctionMultiDim(other),
-  _funct(other._funct),
-  _context(other._context),
-  _maxFCN(other._maxFCN),
-  _funcOffset(other._funcOffset),
-  _recoverFromNaNStrength(other._recoverFromNaNStrength),
-  _numBadNLL(other._numBadNLL),
-  _printEvalErrors(other._printEvalErrors),
-  _evalCounter(other._evalCounter),
-  _nDim(other._nDim),
-  _logfile(other._logfile),
-  _doEvalErrorWall(other._doEvalErrorWall),
-  _verbose(other._verbose)
-{
-  _floatParamList = new RooArgList(*other._floatParamList) ;
-  _constParamList = new RooArgList(*other._constParamList) ;
-  _initFloatParamList = (RooArgList*) other._initFloatParamList->snapshot(kFALSE) ;
-  _initConstParamList = (RooArgList*) other._initConstParamList->snapshot(kFALSE) ;
-}
+RooMinimizerFcn::RooMinimizerFcn(const RooMinimizerFcn& other) : RooAbsMinimizerFcn(other), ROOT::Math::IBaseFunctionMultiDim(other),
+  _funct(other._funct)
+{}
 
 
 RooMinimizerFcn::~RooMinimizerFcn()
-{
-  delete _floatParamList;
-  delete _initFloatParamList;
-  delete _constParamList;
-  delete _initConstParamList;
-}
+{}
 
 
 ROOT::Math::IBaseFunctionMultiDim* RooMinimizerFcn::Clone() const
@@ -121,374 +59,44 @@ ROOT::Math::IBaseFunctionMultiDim* RooMinimizerFcn::Clone() const
   return new RooMinimizerFcn(*this) ;
 }
 
-
-/// Internal function to synchronize TMinimizer with current
-/// information in RooAbsReal function parameters
-Bool_t RooMinimizerFcn::Synchronize(std::vector<ROOT::Fit::ParameterSettings>& parameters,
-				 Bool_t optConst, Bool_t verbose)
+void RooMinimizerFcn::setOptimizeConst(Int_t flag)
 {
-  Bool_t constValChange(kFALSE) ;
-  Bool_t constStatChange(kFALSE) ;
+   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
 
-  Int_t index(0) ;
+   if (_optConst && !flag) {
+      if (_context->getPrintLevel() > -1)
+         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: deactivating const optimization" << endl;
+      _funct->constOptimizeTestStatistic(RooAbsArg::DeActivate, true);
+      _optConst = flag;
+   } else if (!_optConst && flag) {
+      if (_context->getPrintLevel() > -1)
+         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: activating const optimization" << endl;
+      _funct->constOptimizeTestStatistic(RooAbsArg::Activate, flag > 1);
+      _optConst = flag;
+   } else if (_optConst && flag) {
+      if (_context->getPrintLevel() > -1)
+         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: const optimization already active" << endl;
+   } else {
+      if (_context->getPrintLevel() > -1)
+         oocoutI(_context, Minimization) << "RooMinimizerFcn::setOptimizeConst: const optimization wasn't active" << endl;
+   }
 
-  // Handle eventual migrations from constParamList -> floatParamList
-  for(index= 0; index < _constParamList->getSize() ; index++) {
+   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors);
+}
 
-    RooRealVar *par= dynamic_cast<RooRealVar*>(_constParamList->at(index)) ;
-    if (!par) continue ;
-
-    RooRealVar *oldpar= dynamic_cast<RooRealVar*>(_initConstParamList->at(index)) ;
-    if (!oldpar) continue ;
-
-    // Test if constness changed
-    if (!par->isConstant()) {
-
-      // Remove from constList, add to floatList
-      _constParamList->remove(*par) ;
-      _floatParamList->add(*par) ;
-      _initFloatParamList->addClone(*oldpar) ;
-      _initConstParamList->remove(*oldpar) ;
-      constStatChange=kTRUE ;
-      _nDim++ ;
-
-      if (verbose) {
-	oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: parameter "
-				     << par->GetName() << " is now floating." << endl ;
-      }
-    }
-
-    // Test if value changed
-    if (par->getVal()!= oldpar->getVal()) {
-      constValChange=kTRUE ;
-      if (verbose) {
-	oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: value of constant parameter "
-				       << par->GetName()
-				       << " changed from " << oldpar->getVal() << " to "
-				       << par->getVal() << endl ;
-      }
-    }
-
-  }
-
-  // Update reference list
-  *_initConstParamList = *_constParamList ;
-
-  // Synchronize MINUIT with function state
-  // Handle floatParamList
-  for(index= 0; index < _floatParamList->getSize(); index++) {
-    RooRealVar *par= dynamic_cast<RooRealVar*>(_floatParamList->at(index)) ;
-
-    if (!par) continue ;
-
-    Double_t pstep(0) ;
-    Double_t pmin(0) ;
-    Double_t pmax(0) ;
-
-    if(!par->isConstant()) {
-
-      // Verify that floating parameter is indeed of type RooRealVar
-      if (!par->IsA()->InheritsFrom(RooRealVar::Class())) {
-	oocoutW(_context,Minimization) << "RooMinimizerFcn::fit: Error, non-constant parameter "
-				       << par->GetName()
-				       << " is not of type RooRealVar, skipping" << endl ;
-	_floatParamList->remove(*par);
-	index--;
-	_nDim--;
-	continue ;
-      }
-      // make sure the parameter are in dirty state to enable
-      // a real NLL computation when the minimizer calls the function the first time
-      // (see issue #7659)
-      par->setValueDirty();
-
-      // Set the limits, if not infinite
-      if (par->hasMin() )
-	pmin = par->getMin();
-      if (par->hasMax() )
-	pmax = par->getMax();
-
-      // Calculate step size
-      pstep = par->getError();
-      if(pstep <= 0) {
-	// Floating parameter without error estitimate
-	if (par->hasMin() && par->hasMax()) {
-	  pstep= 0.1*(pmax-pmin);
-
-	  // Trim default choice of error if within 2 sigma of limit
-	  if (pmax - par->getVal() < 2*pstep) {
-	    pstep = (pmax - par->getVal())/2 ;
-	  } else if (par->getVal() - pmin < 2*pstep) {
-	    pstep = (par->getVal() - pmin )/2 ;
-	  }
-
-	  // If trimming results in zero error, restore default
-	  if (pstep==0) {
-	    pstep= 0.1*(pmax-pmin);
-	  }
-
-	} else {
-	  pstep=1 ;
-	}
-	if(verbose) {
-	  oocoutW(_context,Minimization) << "RooMinimizerFcn::synchronize: WARNING: no initial error estimate available for "
-					 << par->GetName() << ": using " << pstep << endl;
-	}
-      }
-    } else {
-      pmin = par->getVal() ;
-      pmax = par->getVal() ;
-    }
-
-    // new parameter
-    if (index>=Int_t(parameters.size())) {
-
-      if (par->hasMin() && par->hasMax()) {
-	parameters.push_back(ROOT::Fit::ParameterSettings(par->GetName(),
-							  par->getVal(),
-							  pstep,
-							  pmin,pmax));
-      }
-      else {
-	parameters.push_back(ROOT::Fit::ParameterSettings(par->GetName(),
-							  par->getVal(),
-							  pstep));
-        if (par->hasMin() )
-           parameters.back().SetLowerLimit(pmin);
-        else if (par->hasMax() )
-           parameters.back().SetUpperLimit(pmax);
-      }
-
-      continue;
-
-    }
-
-    Bool_t oldFixed = parameters[index].IsFixed();
-    Double_t oldVar = parameters[index].Value();
-    Double_t oldVerr = parameters[index].StepSize();
-    Double_t oldVlo = parameters[index].LowerLimit();
-    Double_t oldVhi = parameters[index].UpperLimit();
-
-    if (par->isConstant() && !oldFixed) {
-
-      // Parameter changes floating -> constant : update only value if necessary
-      if (oldVar!=par->getVal()) {
-	parameters[index].SetValue(par->getVal());
-	if (verbose) {
-	  oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: value of parameter "
-					 << par->GetName() << " changed from " << oldVar
-					 << " to " << par->getVal() << endl ;
-	}
-      }
-      parameters[index].Fix();
-      constStatChange=kTRUE ;
-      if (verbose) {
-	oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: parameter "
-				       << par->GetName() << " is now fixed." << endl ;
-      }
-
-    } else if (par->isConstant() && oldFixed) {
-
-      // Parameter changes constant -> constant : update only value if necessary
-      if (oldVar!=par->getVal()) {
-	parameters[index].SetValue(par->getVal());
-	constValChange=kTRUE ;
-
-	if (verbose) {
-	  oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: value of fixed parameter "
-					 << par->GetName() << " changed from " << oldVar
-					 << " to " << par->getVal() << endl ;
-	}
-      }
-
-    } else {
-      // Parameter changes constant -> floating
-      if (!par->isConstant() && oldFixed) {
-	parameters[index].Release();
-	constStatChange=kTRUE ;
-
-	if (verbose) {
-	  oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: parameter "
-					 << par->GetName() << " is now floating." << endl ;
-	}
-      }
-
-      // Parameter changes constant -> floating : update all if necessary
-      if (oldVar!=par->getVal() || oldVlo!=pmin || oldVhi != pmax || oldVerr!=pstep) {
-	parameters[index].SetValue(par->getVal());
-	parameters[index].SetStepSize(pstep);
-        if (par->hasMin() && par->hasMax() )
-           parameters[index].SetLimits(pmin,pmax);
-        else if (par->hasMin() )
-           parameters[index].SetLowerLimit(pmin);
-        else if (par->hasMax() )
-           parameters[index].SetUpperLimit(pmax);
-      }
-
-      // Inform user about changes in verbose mode
-      if (verbose) {
-	// if ierr<0, par was moved from the const list and a message was already printed
-
-	if (oldVar!=par->getVal()) {
-	  oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: value of parameter "
-					 << par->GetName() << " changed from " << oldVar << " to "
-					 << par->getVal() << endl ;
-	}
-	if (oldVlo!=pmin || oldVhi!=pmax) {
-	  oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: limits of parameter "
-					 << par->GetName() << " changed from [" << oldVlo << "," << oldVhi
-					 << "] to [" << pmin << "," << pmax << "]" << endl ;
-	}
-
-	// If oldVerr=0, then parameter was previously fixed
-	if (oldVerr!=pstep && oldVerr!=0) {
-	  oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: error/step size of parameter "
-					 << par->GetName() << " changed from " << oldVerr << " to " << pstep << endl ;
-	}
-      }
-    }
-  }
-
-  if (optConst) {
-    if (constStatChange) {
+void RooMinimizerFcn::optimizeConstantTerms(bool constStatChange, bool constValChange) {
+   if (constStatChange) {
 
       RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
 
-      oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: set of constant parameters changed, rerunning const optimizer" << endl ;
-      _funct->constOptimizeTestStatistic(RooAbsArg::ConfigChange) ;
-    } else if (constValChange) {
-      oocoutI(_context,Minimization) << "RooMinimizerFcn::synchronize: constant parameter values changed, rerunning const optimizer" << endl ;
-      _funct->constOptimizeTestStatistic(RooAbsArg::ValueChange) ;
-    }
+      oocoutI(_context,Minimization) << "RooMinimizerFcn::optimizeConstantTerms: set of constant parameters changed, rerunning const optimizer" << endl ;
+      _funct->constOptimizeTestStatistic(RooAbsArg::ConfigChange, true) ;
+   } else if (constValChange) {
+      oocoutI(_context,Minimization) << "RooMinimizerFcn::optimizeConstantTerms: constant parameter values changed, rerunning const optimizer" << endl ;
+      _funct->constOptimizeTestStatistic(RooAbsArg::ValueChange, true) ;
+   }
 
-    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
-
-  }
-
-  return 0 ;
-
-}
-
-/// Modify PDF parameter error by ordinal index (needed by MINUIT)
-void RooMinimizerFcn::SetPdfParamErr(Int_t index, Double_t value)
-{
-  static_cast<RooRealVar*>(_floatParamList->at(index))->setError(value);
-}
-
-/// Modify PDF parameter error by ordinal index (needed by MINUIT)
-void RooMinimizerFcn::ClearPdfParamAsymErr(Int_t index)
-{
-  static_cast<RooRealVar*>(_floatParamList->at(index))->removeAsymError();
-}
-
-/// Modify PDF parameter error by ordinal index (needed by MINUIT)
-void RooMinimizerFcn::SetPdfParamErr(Int_t index, Double_t loVal, Double_t hiVal)
-{
-  static_cast<RooRealVar*>(_floatParamList->at(index))->setAsymError(loVal,hiVal);
-}
-
-/// Transfer MINUIT fit results back into RooFit objects.
-void RooMinimizerFcn::BackProp(const ROOT::Fit::FitResult &results)
-{
-  for (Int_t index= 0; index < _nDim; index++) {
-    Double_t value = results.Value(index);
-    SetPdfParamVal(index, value);
-
-    // Set the parabolic error
-    Double_t err = results.Error(index);
-    SetPdfParamErr(index, err);
-
-    Double_t eminus = results.LowerError(index);
-    Double_t eplus = results.UpperError(index);
-
-    if(eplus > 0 || eminus < 0) {
-      // Store the asymmetric error, if it is available
-      SetPdfParamErr(index, eminus,eplus);
-    } else {
-      // Clear the asymmetric error
-      ClearPdfParamAsymErr(index) ;
-    }
-  }
-}
-
-/// Change the file name for logging of a RooMinimizer of all MINUIT steppings
-/// through the parameter space. If inLogfile is null, the current log file
-/// is closed and logging is stopped.
-Bool_t RooMinimizerFcn::SetLogFile(const char* inLogfile)
-{
-  if (_logfile) {
-    oocoutI(_context,Minimization) << "RooMinimizerFcn::setLogFile: closing previous log file" << endl ;
-    _logfile->close() ;
-    delete _logfile ;
-    _logfile = 0 ;
-  }
-  _logfile = new ofstream(inLogfile) ;
-  if (!_logfile->good()) {
-    oocoutI(_context,Minimization) << "RooMinimizerFcn::setLogFile: cannot open file " << inLogfile << endl ;
-    _logfile->close() ;
-    delete _logfile ;
-    _logfile= 0;
-  }
-
-  return kFALSE ;
-}
-
-/// Apply results of given external covariance matrix. i.e. propagate its errors
-/// to all RRV parameter representations and give this matrix instead of the
-/// HESSE matrix at the next save() call
-void RooMinimizerFcn::ApplyCovarianceMatrix(TMatrixDSym& V)
-{
-  for (Int_t i=0 ; i<_nDim ; i++) {
-    // Skip fixed parameters
-    if (_floatParamList->at(i)->isConstant()) {
-      continue ;
-    }
-    SetPdfParamErr(i, sqrt(V(i,i))) ;
-  }
-
-}
-
-/// Set value of parameter i.
-Bool_t RooMinimizerFcn::SetPdfParamVal(int index, double value) const
-{
-  auto par = static_cast<RooRealVar*>(&(*_floatParamList)[index]);
-
-  if (par->getVal()!=value) {
-    if (_verbose) cout << par->GetName() << "=" << value << ", " ;
-
-    par->setVal(value);
-    return kTRUE;
-  }
-
-  return kFALSE;
-}
-
-
-/// Print information about why evaluation failed.
-/// Using _printEvalErrors, the number of errors printed can be steered.
-/// Negative values disable printing.
-void RooMinimizerFcn::printEvalErrors() const {
-  if (_printEvalErrors < 0)
-    return;
-
-  std::ostringstream msg;
-  if (_doEvalErrorWall) {
-    msg << "RooMinimizerFcn: Minimized function has error status." << endl
-        << "Returning maximum FCN so far (" << _maxFCN
-        << ") to force MIGRAD to back out of this region. Error log follows.\n";
-  } else {
-    msg << "RooMinimizerFcn: Minimized function has error status but is ignored.\n";
-  }
-
-  msg << "Parameter values: " ;
-  for (const auto par : *_floatParamList) {
-    auto var = static_cast<const RooRealVar*>(par);
-    msg << "\t" << var->GetName() << "=" << var->getVal() ;
-  }
-  msg << std::endl;
-
-  RooAbsReal::printEvalErrors(msg, _printEvalErrors);
-  ooccoutW(_context,Minimization) << msg.str() << endl;
+   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
 }
 
 
@@ -496,7 +104,7 @@ void RooMinimizerFcn::printEvalErrors() const {
 double RooMinimizerFcn::DoEval(const double *x) const {
 
   // Set the parameter values for this iteration
-  for (int index = 0; index < _nDim; index++) {
+  for (unsigned index = 0; index < _nDim; index++) {
     if (_logfile) (*_logfile) << x[index] << " " ;
     SetPdfParamVal(index,x[index]);
   }
@@ -538,4 +146,14 @@ double RooMinimizerFcn::DoEval(const double *x) const {
   _evalCounter++ ;
 
   return fvalue;
+}
+
+std::string RooMinimizerFcn::getFunctionName() const
+{
+   return _funct->GetName();
+}
+
+std::string RooMinimizerFcn::getFunctionTitle() const
+{
+   return _funct->GetTitle();
 }


### PR DESCRIPTION
This PR refactors RooMinimizerFcn into two separate classes: RooAbsMinimizerFcn and a new RooMinimizerFcn derived from that. RooAbsMinimizerFcn contains all common synchronization "logistics" necessary between RooFit and Minuit function parameters. The implementations of this abstract base class are then expected to supply the actual function evaluation parts. This allows us to later implement classes that calculate the gradient outside of Minuit. We will provide both a serial implementation of this and later on a parallel one using the MultiProcess framework.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)