### PR TITLE
Eve7 Correction in handling of removed elements ids on the client 

### DIFF
--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -331,7 +331,7 @@ sap.ui.define([], function() {
 
       // notify scenes for beginning of changes and
       // notify for element removal
-      let removedIds = msg.header["removedElements"]; // AMT empty set should not be sent at the first place
+      let removedIds = msg.header["removedElements"];
       if (removedIds.length) {
          this.callSceneReceivers(scene, "elementsRemoved", removedIds);
          this.removeElements(removedIds);


### PR DESCRIPTION
# This Pull request:
In EveManager::ImportSceneChangeJson remove REveElements objects which indices have been marked as deleted on the server. 

## Changes or fixes:
Error messages in delete of server elements on  importSceneChangeJson.

## Checklist:

- [x ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

