### PR TITLE
[v624][RF] Store a copy of last-used normalization set in RooAddPdf

### DIFF
--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -82,8 +82,6 @@ public:
   const RooArgSet& getCoefNormalization() const { return _refCoefNorm ; }
   const char* getCoefRange() const { return _refCoefRangeName?RooNameReg::str(_refCoefRangeName):"" ; }
 
-  virtual Double_t getValV(const RooArgSet *set = 0) const;
-  
   virtual void resetErrorCounters(Int_t resetValue=10) ;
 
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 
@@ -150,6 +148,8 @@ protected:
 
 private:
   std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* defaultNorm = nullptr) const;
+  mutable RooArgSet const* _pointerToLastUsedNormSet = nullptr; //!
+  mutable std::unique_ptr<const RooArgSet> _copyOfLastNormSet = nullptr; //!
 
   ClassDef(RooAddPdf,3) // PDF representing a sum of PDFs
 };


### PR DESCRIPTION
Every RooFit pdf is evaluated with a set of variables to normalize over
(normalization set). A pointer to the last used normalization set is
stored in the pdf class. sometimes, pdfs are evaluated without a
normalization set in RooFit if the normalization doesn't matter. But for
a specific class the normalization always matters: the RooAddPdf Because
if the components are unnormalized, you get the wrong shape of the sum.

That's why commit f6d1543 added some lines to use the last-used
normalization set if you evaluate a RooAddPdf without a normalization
set. But since the pdf only has a *pointer* to the last-used
normalization set, it will have an invalid pointer if the actual
previous normalization set gets destroyed.

Because of RooFits memory pool for the RooArgSets that only recycles
memory every 6000 RooArgSets, the invalid `_normSet` problem only gets
visible in large models, but if the model is large enough it causes
reproducible crashes, as reported by the ATLAS Higgs combination group.

This commit fixes the issue by copying the last-used normalization set
into the RooAddPdf, instead of only storing a pointer. Furthermore, the
logic to override the empty normalization set with the last-stored
normalization set is moved to `RooAbsPdf::getNormAndCache()`, avoiding
the overload of `RooAbsPdf::getValV()`.

This is a backport of https://github.com/root-project/root/pull/8580, minus the safer uniqueId mechanism, which is probably too big of a change for a patch release.
