### PR TITLE
[RF] Store a copy of last-used normalization set in RooAddPdf and introduce RooArgSet::uniqueId()

### DIFF
--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -78,8 +78,6 @@ public:
   const RooArgSet& getCoefNormalization() const { return _refCoefNorm ; }
   const char* getCoefRange() const { return _refCoefRangeName?RooNameReg::str(_refCoefRangeName):"" ; }
 
-  virtual Double_t getValV(const RooArgSet *set = 0) const;
-  
   virtual void resetErrorCounters(Int_t resetValue=10) ;
 
   virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 
@@ -146,6 +144,8 @@ protected:
 
 private:
   std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* defaultNorm = nullptr) const;
+  mutable RooArgSet const* _pointerToLastUsedNormSet = nullptr; //!
+  mutable std::unique_ptr<const RooArgSet> _copyOfLastNormSet = nullptr; //!
 
   ClassDef(RooAddPdf,3) // PDF representing a sum of PDFs
 };

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -144,7 +144,7 @@ protected:
 
 private:
   std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* defaultNorm = nullptr) const;
-  mutable RooArgSet const* _pointerToLastUsedNormSet = nullptr; //!
+  mutable UniqueId<RooArgSet>::Value_t _idOfLastUsedNormSet = UniqueId<RooArgSet>::nullval; //!
   mutable std::unique_ptr<const RooArgSet> _copyOfLastNormSet = nullptr; //!
 
   ClassDef(RooAddPdf,3) // PDF representing a sum of PDFs

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -18,6 +18,7 @@
 
 #include "RooAbsCollection.h"
 #include "RooAbsArg.h"
+#include "UniqueId.h"
 
 class RooArgList ;
 
@@ -133,6 +134,12 @@ public:
     return RooAbsCollection::snapshot(output, deepCopy);
   }
 
+  /// Returns a unique ID that is different for every instantiated RooArgSet.
+  /// This ID can be used to check whether two RooAbsData are the same object,
+  /// which is safer than memory address comparisons that might result in false
+  /// positives when memory is recycled.
+  UniqueId<RooArgSet> const& uniqueId() const { return _uniqueId; }
+
 protected:
   Bool_t checkForDup(const RooAbsArg& arg, Bool_t silent) const ;
   virtual bool canBeAdded(const RooAbsArg& arg, bool silent) const override {
@@ -154,6 +161,7 @@ private:
   //to leak depending if RooArgSets are still alive. This depends on the order of destructions.
   static MemPool* memPool();
 #endif
+  const UniqueId<RooArgSet> _uniqueId; //!
   
   ClassDefOverride(RooArgSet,1) // Set of RooAbsArg objects
 };

--- a/roofit/roofitcore/inc/UniqueId.h
+++ b/roofit/roofitcore/inc/UniqueId.h
@@ -1,0 +1,72 @@
+// Author: Jonas Rembser, CERN, Jun 2021
+
+/// A UniqueId can be added as a class member to enhance any class with a
+/// unique identifier for each instantiated object.
+///
+/// Example:
+/// ~~~{.cpp}
+/// class MyClass {
+///
+/// public:
+///    /// Return unique ID by reference.
+///    /// Please always use the name `uniqueId` for the getter.
+///    UniqueId<MyClass> const& uniqueId() const { return _uniqueId; }
+///
+/// private:
+///    const UniqueId<MyClass> _uniqueId; //! should be non-persistent
+///
+/// };
+/// ~~~
+
+#ifndef roofit_roofitcore_UniqueId_h
+#define roofit_roofitcore_UniqueId_h
+
+#include <atomic>
+
+template <class Class>
+struct UniqueId {
+public:
+  using Value_t = unsigned long;
+
+  /// Create a new UniqueId with the next value from the static counter.
+  UniqueId() : _val{++counter} {}
+
+  // Disable all sorts of copying and moving to ensure uniqueness.
+  UniqueId(const UniqueId &) = delete;
+  UniqueId &operator=(const UniqueId &) = delete;
+  UniqueId(UniqueId &&) = delete;
+  UniqueId &operator=(UniqueId &&) = delete;
+
+  /// Return numerical value of ID.
+  /// Use only if necessary, as the UniqueId type information is lost and
+  /// copying/moving is not prohibited for the value type.
+  /// Please don't turn this into a cast operator, as a function with an
+  /// explicit name is easier to track in the codebase.
+  constexpr Value_t value() const { return _val; }
+
+  bool operator==(UniqueId const &other) const { return _val == other._val; }
+  bool operator<(UniqueId const &other) const { return _val < other._val; }
+
+  static const UniqueId nullid;  /// A value that is less than the ID of any object (similar to nullptr).
+
+private:
+  Value_t _val;  /// Numerical value of the ID.
+
+  static std::atomic<Value_t> counter;  /// The static object counter to get the next ID value.
+};
+
+template <class Class>
+std::atomic<typename UniqueId<Class>::Value_t> UniqueId<Class>::counter{0UL};
+
+template <class Class>
+const UniqueId<Class> UniqueId<Class>::nullid{0UL};
+
+/// A helper function to replace pointer comparisons with UniqueId comparisons.
+/// With pointer comparisons, we can also have `nullptr`. In the UniqueId case,
+/// this translates to the `nullid`.
+template <class Class>
+UniqueId<Class> getUniqueId(Class const *ptr) {
+  return ptr ? ptr->uniqueId() : UniqueId<Class>::nullid;
+}
+
+#endif

--- a/roofit/roofitcore/inc/UniqueId.h
+++ b/roofit/roofitcore/inc/UniqueId.h
@@ -37,6 +37,8 @@ public:
   UniqueId(UniqueId &&) = delete;
   UniqueId &operator=(UniqueId &&) = delete;
 
+  operator Value_t() const { return _val; }
+
   /// Return numerical value of ID.
   /// Use only if necessary, as the UniqueId type information is lost and
   /// copying/moving is not prohibited for the value type.
@@ -47,7 +49,8 @@ public:
   bool operator==(UniqueId const &other) const { return _val == other._val; }
   bool operator<(UniqueId const &other) const { return _val < other._val; }
 
-  static const UniqueId nullid;  /// A value that is less than the ID of any object (similar to nullptr).
+  static const UniqueId nullid;  /// An ID that is less than the ID of any object (similar to nullptr).
+  static constexpr Value_t nullval = 0UL; /// The value of the nullid.
 
 private:
   Value_t _val;  /// Numerical value of the ID.
@@ -56,10 +59,10 @@ private:
 };
 
 template <class Class>
-std::atomic<typename UniqueId<Class>::Value_t> UniqueId<Class>::counter{0UL};
+std::atomic<typename UniqueId<Class>::Value_t> UniqueId<Class>::counter{UniqueId<Class>::nullval};
 
 template <class Class>
-const UniqueId<Class> UniqueId<Class>::nullid{0UL};
+const UniqueId<Class> UniqueId<Class>::nullid{UniqueId<Class>::nullval};
 
 /// A helper function to replace pointer comparisons with UniqueId comparisons.
 /// With pointer comparisons, we can also have `nullptr`. In the UniqueId case,

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -810,9 +810,9 @@ std::pair<const RooArgSet*, RooAddPdf::CacheElem*> RooAddPdf::getNormAndCache(co
     // the last-used normalization set needs an update.
     if(nset == nullptr) {
       nset = _copyOfLastNormSet.get();
-    } else if(nset != _pointerToLastUsedNormSet) {
+    } else if(nset->uniqueId() != _idOfLastUsedNormSet) {
       _copyOfLastNormSet = std::make_unique<const RooArgSet>(*nset);
-      _pointerToLastUsedNormSet = nset;
+      _idOfLastUsedNormSet = nset->uniqueId();
     }
 
     // If nset is STILL nullptr, print a warning.


### PR DESCRIPTION
Every RooFit pdf is evaluated with a set of variables to normalize over
(normalization set). A pointer to the last used normalization set is
stored in the pdf class. sometimes, pdfs are evaluated without a
normalization set in RooFit if the normalization doesn't matter. But for
a specific class the normalization always matters: the RooAddPdf Because
if the components are unnormalized, you get the wrong shape of the sum.

That's why commit f6d1543 added some lines to use the last-used
normalization set if you evaluate a RooAddPdf without a normalization
set. But since the pdf only has a *pointer* to the last-used
normalization set, it will have an invalid pointer if the actual
previous normalization set gets destroyed.

Because of RooFits memory pool for the RooArgSets that only recycles
memory every 6000 RooArgSets, the invalid `_normSet` problem only gets
visible in large models, but if the model is large enough it causes
reproducible crashes, as reported by the ATLAS Higgs combination group.

This commit fixes the issue by copying the last-used normalization set
into the RooAddPdf, instead of only storing a pointer. Furthermore, the
logic to override the empty normalization set with the last-stored
normalization set is moved to `RooAbsPdf::getNormAndCache()`, avoiding
the overload of `RooAbsPdf::getValV()`.

Initially, the check where the copied normalization set needs to be updated was done based on the address of the normalization set. However, comparisons by address should be avoided because they can lead to false positives if memory is recycled. That's why this PR also contains the UniqueId mechanism already proposed and reviewed in https://github.com/root-project/root/pull/8324.

The backport of this PR to v624 is the PR https://github.com/root-project/root/pull/8579, which doesn't use the safer uniqueId mechanism, which is probably too big of a change for a patch release.
