### PR TITLE
[webgui] disbale gpu and audio in headless chrome

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -380,8 +380,8 @@ RWebDisplayHandle::ChromeCreator::ChromeCreator() : BrowserCreator(true)
    fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "$prog --headless --disable-gpu $geometry $url &");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --app=$url &"); // & in windows mean usage of spawn
 #else
-   fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless --incognito --no-sandbox --no-zygote --disable-extensions --single-process $geometry $url");
-   fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "fork: --headless --incognito --no-sandbox --no-zygote --disable-extensions --single-process $geometry $url");
+   fBatchExec = gEnv->GetValue("WebGui.ChromeBatch", "$prog --headless --incognito --no-sandbox --no-zygote --disable-extensions --disable-gpu --disable-audio-output $geometry $url");
+   fHeadlessExec = gEnv->GetValue("WebGui.ChromeHeadless", "fork: --headless --incognito --no-sandbox --no-zygote --disable-extensions --disable-gpu --disable-audio-output $geometry $url");
    fExec = gEnv->GetValue("WebGui.ChromeInteractive", "$prog $geometry --no-first-run --incognito --app=\'$url\' &");
 #endif
 }


### PR DESCRIPTION
Remove --single-process which may fail on some special platforms

Trying to resolve `webgui-ping` problem on some platforms while this should be basic test for batch / headless functionality of
web-based gui