### PR TITLE
[foundation] Skip R__ASSERT for NDEBUG:

### DIFF
--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -115,10 +115,15 @@ extern void Obsolete(const char *function, const char *asOfVers, const char *rem
 R__EXTERN const char *kAssertMsg;
 R__EXTERN const char *kCheckMsg;
 
-#define R__ASSERT(e)                                                     \
+#ifdef NDEBUG
+# define R__ASSERT(e) (void)0
+#else
+# define R__ASSERT(e)                                                    \
    do {                                                                  \
       if (!(e)) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
+#endif // NDEBUG
+
 #define R__CHECK(e)                                                       \
    do {                                                                   \
       if (!(e)) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \


### PR DESCRIPTION
Given the name, the expectation seems to be that `R__ASSERT(e)` will not
evaluate `e` if NDEBUG is defined, just like `assert()`.

Use `(void)0` such that `R__ASSERT` can be followed by a semicolon, yet
the compiler knows that there is no instruction to be emitted.

Even with this, `R__ASSERT` and `assert` provide different functionality,
with the former calling `::Fatal()`.
