### PR TITLE
[RF] Make RooProdPdf::_pdfNSetList a std::vector and not RooLinkedList

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -250,6 +250,12 @@
 #pragma link C++ class RooResolutionModel+ ;
 #pragma link C++ class RooTruthModel+ ;
 #pragma link C++ class RooProdPdf+ ;
+#pragma read sourceClass="RooProdPdf" targetClass="RooProdPdf" version="[-5]" \
+  source="RooLinkedList _pdfNSetList" target="_pdfNSetList"                  \
+  code="{for (auto * nset : static_range_cast<RooArgSet*>(onfile._pdfNSetList)) { \
+           _pdfNSetList.emplace_back(nset);                                       \
+         }                                                                        \
+         }";
 #pragma link C++ class RooSimPdfBuilder+ ;
 #pragma link C++ class RooMCStudy+ ;
 #pragma link C++ class RooMsgService+ ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -167,7 +167,7 @@ private:
 
   Double_t _cutOff ;       //  Cutoff parameter for running product
   RooListProxy _pdfList ;  //  List of PDF components
-  RooLinkedList _pdfNSetList ; // List of PDF component normalization sets
+  std::vector<std::unique_ptr<RooArgSet>> _pdfNSetList ; // List of PDF component normalization sets
   Int_t _extendedIndex ;   //  Index of extended PDF (if any) 
 
   void useDefaultGen(Bool_t flag=kTRUE) { _useDefaultGen = flag ; }
@@ -180,7 +180,7 @@ private:
   
 private:
 
-  ClassDef(RooProdPdf,5) // PDF representing a product of PDFs
+  ClassDef(RooProdPdf,6) // PDF representing a product of PDFs
 };
 
 


### PR DESCRIPTION
Part of the RooProdPdf modernization with the intention of eventually
deprecating the RooLinkedList.

This change reduces the size of a RooProdPdf from 1600 to 1496 bytes.

A manual schema evolution rule to test the reading of older RooProdPdfs
is implemented in the `LinkDef.h`. The schma evolution is tested by
the stressRooFit tests, which are reading some RooProdPdfs from the
reference files.
