### PR TITLE
[skip-ci] Use the JSRoot version corresponding to the ROOT version.

### DIFF
--- a/documentation/doxygen/MakeRCanvasJS.C
+++ b/documentation/doxygen/MakeRCanvasJS.C
@@ -39,7 +39,7 @@ void MakeRCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bo
    fprintf(fh,"      return new Promise(resolveFunc => {\n");
    fprintf(fh,"         if (typeof JSROOT != 'undefined') return resolveFunc(true);\n");
    fprintf(fh,"         let script = document.createElement('script');\n");
-   fprintf(fh,"         script.src = 'https://root.cern/js/dev/scripts/JSRoot.core.min.js';\n");
+   fprintf(fh,"         script.src = './js/scripts/JSRoot.core.js';\n");
    fprintf(fh,"         script.onload = resolveFunc;\n");
    fprintf(fh,"         document.head.appendChild(script);\n");
    fprintf(fh,"      });\n");

--- a/documentation/doxygen/MakeTCanvasJS.C
+++ b/documentation/doxygen/MakeTCanvasJS.C
@@ -40,7 +40,7 @@ void MakeTCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bo
    fprintf(fh,"      return new Promise(resolveFunc => {\n");
    fprintf(fh,"         if (typeof JSROOT != 'undefined') return resolveFunc(true);\n");
    fprintf(fh,"         let script = document.createElement('script');\n");
-   fprintf(fh,"         script.src = 'https://root.cern/js/dev/scripts/JSRoot.core.min.js';\n");
+   fprintf(fh,"         script.src = './js/scripts/JSRoot.core.js';\n");
    fprintf(fh,"         script.onload = resolveFunc;\n");
    fprintf(fh,"         document.head.appendChild(script);\n");
    fprintf(fh,"      });\n");

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: filter folders mathjax images doxygen
+.PHONY: filter folders mathjax js images doxygen
 
 PYTHON_EXECUTABLE ?= /usr/bin/python
 export PYTHON_EXECUTABLE
@@ -22,7 +22,7 @@ define MkDir
 	+@[ -d $1 ] || mkdir -p $1
 endef
 
-all: filter folders mathjax images doxygen
+all: filter folders mathjax js images doxygen
 
 filter:
 	`root-config --cxx` -o filter filter.cxx -std=c++11
@@ -30,6 +30,10 @@ filter:
 mathjax:
 	$(call MkDir,$(DOXYGEN_IMAGE_PATH))
 	tar xfz mathjax.tar.gz -C $(DOXYGEN_IMAGE_PATH)
+
+js:
+	$(call MkDir,$(DOXYGEN_IMAGE_PATH))
+	cp -r ../../js $(DOXYGEN_IMAGE_PATH)
 
 images:
 	$(call MkDir,$(DOXYGEN_IMAGE_PATH))


### PR DESCRIPTION
as requested here: https://github.com/root-project/root/issues/8599

