### PR TITLE
[DF] Use `ROOT::Internal::TreeUtils` functions in `TreeHeadNode` class

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Ranges.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Ranges.py
@@ -38,7 +38,7 @@ class TreeRange(object):
 
     filelist (list[str]): List of files to be processed with this range.
 
-    friend_info (DistRDF.HeadNode.FriendInfo): Information about friend trees.
+    friend_info (ROOT.Internal.TreeUtils.RFriendInfo): Information about friend trees.
     """
 
     def __init__(self, start, end, filelist, friend_info):
@@ -263,7 +263,7 @@ def get_clustered_ranges(clustersinfiles, npartitions, treename, friend_info):
 
         treename (str): Name of the tree.
 
-        friend_info (DistRDF.HeadNode.FriendInfo): Information about friend
+        friend_info (ROOT.Internal.TreeUtils.RFriendInfo): Information about friend
             trees.
 
     Returns:
@@ -356,7 +356,7 @@ def get_clustered_ranges(clustersinfiles, npartitions, treename, friend_info):
                     cluster.filetuple for cluster in clusters
                 ]), key=lambda curtuple: curtuple.fileindex)
             ],  # type: list[str]
-            friend_info  # type: DistRDF.HeadNode.FriendInfo
+            friend_info  # type: ROOT.Internal.TreeUtils.RFriendInfo
         )  # type: DistRDF.Ranges.TreeRange
         for clusters in _n_even_chunks(clustersinfiles, npartitions)
     ]

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -3,7 +3,7 @@ import unittest
 from array import array
 
 import ROOT
-from DistRDF.HeadNode import FriendInfo, get_headnode
+from DistRDF.HeadNode import get_headnode
 
 
 class FriendInfoTest(unittest.TestCase):
@@ -45,24 +45,9 @@ class FriendInfoTest(unittest.TestCase):
         ff.Write()
         ff.Close()
 
-    def test_empty_friend_info(self):
-        """Check that FriendInfo is initialized with two empty lists"""
-
-        friend_info = FriendInfo()
-
-        friend_names = friend_info.friend_names
-        friend_file_names = friend_info.friend_file_names
-
-        # Check that both lists in FriendInfo are empty
-        self.assertTrue(len(friend_names) == 0)
-        self.assertTrue(len(friend_file_names) == 0)
-
-        # Check functioning of __bool__ method
-        self.assertFalse(friend_info)
-
     def test_friend_info_with_ttree(self):
         """
-        Check that FriendInfo correctly stores information about the friend
+        Check that RFriendInfo correctly stores information about the friend
         trees
         """
         self.create_parent_tree()
@@ -87,19 +72,19 @@ class FriendInfoTest(unittest.TestCase):
         # Passing None as `npartitions` since it is not required for the test
         headnode = get_headnode(None, basetree)
 
-        # Retrieve FriendInfo instance
+        # Retrieve RFriendInfo instance
         friend_info = headnode._get_friend_info()
 
-        # Check that FriendInfo has non-empty lists
-        self.assertTrue(friend_info)
+        # Convert to Python collections
+        friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friend_info.fFriendNames]
+        friendfilenames = [[str(filename) for filename in filenames] for filenames in friend_info.fFriendFileNames]
+        friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friend_info.fFriendChainSubNames]
 
         # Check that the two lists with treenames and filenames are populated
         # as expected.
-        self.assertListEqual(friend_info.friend_names, [friend_tree_name])
-        self.assertListEqual(
-            friend_info.friend_file_names,
-            [[friend_tree_filename]]
-        )
+        self.assertListEqual(friendnamesalias, [(friend_tree_name, friend_tree_name)])
+        self.assertListEqual(friendfilenames, [[friend_tree_filename]])
+        self.assertListEqual(friendchainsubnames, [[friend_tree_name]])
 
         # Remove unnecessary .root files
         os.remove(base_tree_filename)

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -5,41 +5,42 @@ from array import array
 import ROOT
 from DistRDF.HeadNode import get_headnode
 
+def create_dummy_headnode(*args):
+    """Create dummy head node instance needed in the test"""
+    # Pass None as `npartitions`. The tests will modify this member
+    # according to needs
+    return get_headnode(None, *args)
 
 class FriendInfoTest(unittest.TestCase):
     """Unit test for the FriendInfo class"""
 
-    def create_parent_tree(self):
+    def create_main_tree(self, treename, filename):
         """Creates a .root file with the parent TTree"""
-        f = ROOT.TFile("treeparent.root", "recreate")
-        t = ROOT.TTree("T", "test friend trees")
+        f = ROOT.TFile(filename, "recreate")
+        t = ROOT.TTree(treename, "parent tree")
 
-        x = array("f", [0])
-        t.Branch("x", x, "x/F")
+        x = array("i", [0])
+        t.Branch("x", x, "x/I")
 
-        r = ROOT.TRandom()
-        # The parent will have a gaussian distribution with mean 10 and
-        # standard deviation 1
-        for _ in range(10000):
-            x[0] = r.Gaus(10, 1)
+        for i in range(9):
+            x[0] = i
             t.Fill()
 
         f.Write()
         f.Close()
 
-    def create_friend_tree(self):
+    def create_friend_tree(self, treename, filename):
         """Creates a .root file with the friend TTree"""
-        ff = ROOT.TFile("treefriend.root", "recreate")
-        tf = ROOT.TTree("TF", "tree friend")
+        ff = ROOT.TFile(filename, "recreate")
+        tf = ROOT.TTree(treename, "friend tree")
 
-        x = array("f", [0])
-        tf.Branch("x", x, "x/F")
+        y = array("i", [0])
+        tf.Branch("y", y, "y/I")
 
-        r = ROOT.TRandom()
         # The friend will have a gaussian distribution with mean 20 and
         # standard deviation 1
-        for _ in range(10000):
-            x[0] = r.Gaus(20, 1)
+        for i in range(3):
+            y[0] = i
             tf.Fill()
 
         ff.Write()
@@ -50,29 +51,28 @@ class FriendInfoTest(unittest.TestCase):
         Check that RFriendInfo correctly stores information about the friend
         trees
         """
-        self.create_parent_tree()
-        self.create_friend_tree()
-
         # Parent Tree
-        base_tree_name = "T"
-        base_tree_filename = "treeparent.root"
-        basetree = ROOT.TChain(base_tree_name)
-        basetree.Add(base_tree_filename)
+        main_tree_name = "T"
+        main_tree_filename = "treeparent.root"
+        self.create_main_tree(main_tree_name, main_tree_filename)
+        maintree = ROOT.TChain(main_tree_name)
+        maintree.Add(main_tree_filename)
 
         # Friend Tree
         friend_tree_name = "TF"
+        friend_tree_alias = "TF"
         friend_tree_filename = "treefriend.root"
+        self.create_friend_tree(friend_tree_name, friend_tree_filename)
         friendtree = ROOT.TChain(friend_tree_name)
         friendtree.Add(friend_tree_filename)
 
         # Add friendTree to the parent
-        basetree.AddFriend(friendtree)
+        maintree.AddFriend(friendtree, friend_tree_alias)
 
         # Instantiate head node of the graph with the base TTree
-        # Passing None as `npartitions` since it is not required for the test
-        headnode = get_headnode(None, basetree)
+        headnode = create_dummy_headnode(maintree)
 
-        # Retrieve RFriendInfo instance
+        # Retrieve information about friends
         friend_info = headnode._get_friend_info()
 
         # Convert to Python collections
@@ -80,12 +80,63 @@ class FriendInfoTest(unittest.TestCase):
         friendfilenames = [[str(filename) for filename in filenames] for filenames in friend_info.fFriendFileNames]
         friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friend_info.fFriendChainSubNames]
 
-        # Check that the two lists with treenames and filenames are populated
+        # Check that the three lists with treenames, filenames and subnames are populated
         # as expected.
         self.assertListEqual(friendnamesalias, [(friend_tree_name, friend_tree_name)])
         self.assertListEqual(friendfilenames, [[friend_tree_filename]])
         self.assertListEqual(friendchainsubnames, [[friend_tree_name]])
 
         # Remove unnecessary .root files
-        os.remove(base_tree_filename)
+        os.remove(main_tree_filename)
         os.remove(friend_tree_filename)
+
+
+    def test_friend_info_chain_with_subnames(self):
+        """
+        Check that RFriendInfo correctly stores information about the friend
+        trees
+        """
+        # Parent Tree
+        main_tree_name = "treeparent"
+        main_tree_filename = "treeparent.root"
+        self.create_main_tree(main_tree_name, main_tree_filename)
+        maintree = ROOT.TChain(main_tree_name)
+        maintree.Add(main_tree_filename)
+
+        # Friend chain
+        friendchainname = "treefriend"
+        friendchain = ROOT.TChain(friendchainname)
+        actualfriendchainfilenames = []
+        actualfriendchainsubnames = []
+        for i in range(1,4):
+            friend_name = "treefriend" + str(i)
+            friend_filename = friend_name + ".root"
+            actualfriendchainfilenames.append(friend_filename)
+            actualfriendchainsubnames.append(friend_name)
+            self.create_friend_tree(friend_name, friend_filename)
+            friendchain.Add(friend_filename + "/" + friend_name)
+
+        # Add friendTree to the parent
+        maintree.AddFriend(friendchain)
+
+        # Instantiate head node of the graph with the base TTree
+        headnode = create_dummy_headnode(maintree)
+
+        # Retrieve information about friends
+        friend_info = headnode._get_friend_info()
+
+        # Convert to Python collections
+        friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friend_info.fFriendNames]
+        friendfilenames = [[str(filename) for filename in filenames] for filenames in friend_info.fFriendFileNames]
+        friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friend_info.fFriendChainSubNames]
+
+        # Check that the three lists with treenames, filenames and subnames are populated
+        # as expected.
+        self.assertListEqual(friendnamesalias, [(friendchainname, friendchainname)])
+        self.assertListEqual(friendfilenames, [actualfriendchainfilenames])
+        self.assertListEqual(friendchainsubnames, [actualfriendchainsubnames])
+
+        # Remove unnecessary .root files
+        os.remove(main_tree_filename)
+        for filename in actualfriendchainfilenames:
+            os.remove(filename)

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -39,7 +39,7 @@ class DataFrameConstructorTests(unittest.TestCase):
             tree.Fill()
 
         headnode = create_dummy_headnode(tree)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ROOT.std.runtime_error):
             # Trees with no associated files are not supported
             headnode.get_inputfiles()
 


### PR DESCRIPTION
fixes #7584

This PR addresses third step of #8391 
> Better support friends with the recently introduced ROOT::Internal::TreeUtils functions

