### PR TITLE
Use helper aliases from type_traits where possible

### DIFF
--- a/core/foundation/inc/ROOT/RNotFn.hxx
+++ b/core/foundation/inc/ROOT/RNotFn.hxx
@@ -31,7 +31,7 @@ namespace std {
 namespace Detail {
 template <typename F>
 class not_fn_t {
-   typename std::decay<F>::type fFun;
+   std::decay_t<F> fFun;
 
 public:
    explicit not_fn_t(F &&f) : fFun(std::forward<F>(f)) {}
@@ -40,13 +40,13 @@ public:
 
    template <class... Args>
    auto operator()(Args &&... args) & -> decltype(
-      !std::declval<typename std::result_of<typename std::decay<F>::type(Args...)>::type>())
+      !std::declval<std::result_of_t<std::decay_t<F>(Args...)>>())
    {
       return !fFun(std::forward<Args>(args)...);
    }
    template <class... Args>
    auto operator()(Args &&... args) const & -> decltype(
-      !std::declval<typename std::result_of<typename std::decay<F>::type const(Args...)>::type>())
+      !std::declval<std::result_of_t<std::decay_t<F> const(Args...)>>())
    {
       return !fFun(std::forward<Args>(args)...);
    }

--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -46,7 +46,7 @@ struct CallableTraitsImpl<T, true> {
 // lambdas, std::function, const member functions
 template <typename R, typename T, typename... Args>
 struct CallableTraitsImpl<R (T::*)(Args...) const, false> {
-   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types = ROOT::TypeTraits::TypeList<std::decay_t<Args>...>;
    using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
    using ret_type = R;
 };
@@ -54,7 +54,7 @@ struct CallableTraitsImpl<R (T::*)(Args...) const, false> {
 // mutable lambdas and functor classes, non-const member functions
 template <typename R, typename T, typename... Args>
 struct CallableTraitsImpl<R (T::*)(Args...), false> {
-   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types = ROOT::TypeTraits::TypeList<std::decay_t<Args>...>;
    using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
    using ret_type = R;
 };
@@ -62,7 +62,7 @@ struct CallableTraitsImpl<R (T::*)(Args...), false> {
 // function pointers
 template <typename R, typename... Args>
 struct CallableTraitsImpl<R (*)(Args...), false> {
-   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types = ROOT::TypeTraits::TypeList<std::decay_t<Args>...>;
    using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
    using ret_type = R;
 };
@@ -70,7 +70,7 @@ struct CallableTraitsImpl<R (*)(Args...), false> {
 // free functions
 template <typename R, typename... Args>
 struct CallableTraitsImpl<R(Args...), false> {
-   using arg_types = ROOT::TypeTraits::TypeList<typename std::decay<Args>::type...>;
+   using arg_types = ROOT::TypeTraits::TypeList<std::decay_t<Args>...>;
    using arg_types_nodecay = ROOT::TypeTraits::TypeList<Args...>;
    using ret_type = R;
 };

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -107,7 +107,7 @@ struct Book{};
 }
 // clang-format on
 
-template <typename T, bool ISV6HISTO = std::is_base_of<TH1, typename std::decay<T>::type>::value>
+template <typename T, bool ISV6HISTO = std::is_base_of<TH1, std::decay_t<T>>::value>
 struct HistoUtils {
    static void SetCanExtendAllAxes(T &h) { h.SetCanExtend(::TH1::kAllAxes); }
    static bool HasAxisLimits(T &h)
@@ -403,7 +403,7 @@ void JitFilterHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::str
    const auto jittedFilter = wkJittedFilter->lock();
 
    // mock Filter logic -- validity checks and Define-ition of RDataSource columns
-   using Callable_t = typename std::decay<F>::type;
+   using Callable_t = std::decay_t<F>;
    using F_t = RFilter<Callable_t, PrevNode>;
    using ColTypes_t = typename TTraits::CallableTraits<Callable_t>::arg_types;
    constexpr auto nColumns = ColTypes_t::list_size;
@@ -445,7 +445,7 @@ void JitDefineHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::str
 
    auto jittedDefine = wkJittedDefine->lock();
 
-   using Callable_t = typename std::decay<F>::type;
+   using Callable_t = std::decay_t<F>;
    using NewCol_t = RDefine<Callable_t, CustomColExtraArgs::None>;
    using ColTypes_t = typename TTraits::CallableTraits<Callable_t>::arg_types;
    constexpr auto nColumns = ColTypes_t::list_size;
@@ -571,7 +571,7 @@ struct RNeedJitting<> {
 /// Check preconditions for RInterface::Aggregate:
 /// - the aggregator callable must have signature `U(U,T)` or `void(U&,T)`.
 /// - the merge callable must have signature `U(U,U)` or `void(std::vector<U>&)`
-template <typename R, typename Merge, typename U, typename T, typename decayedU = typename std::decay<U>::type,
+template <typename R, typename Merge, typename U, typename T, typename decayedU = std::decay_t<U>,
           typename mergeArgsNoDecay_t = typename CallableTraits<Merge>::arg_types_nodecay,
           typename mergeArgs_t = typename CallableTraits<Merge>::arg_types,
           typename mergeRet_t = typename CallableTraits<Merge>::ret_type>

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -57,7 +57,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    using ret_type = typename CallableTraits<F>::ret_type;
    // Avoid instantiating vector<bool> as `operator[]` returns temporaries in that case. Use std::deque instead.
    using ValuesPerSlot_t =
-      typename std::conditional<std::is_same<ret_type, bool>::value, std::deque<ret_type>, std::vector<ret_type>>::type;
+      std::conditional_t<std::is_same<ret_type, bool>::value, std::deque<ret_type>, std::vector<ret_type>>;
 
    F fExpression;
    const ColumnNames_t fColumnNames;

--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -97,7 +97,7 @@ private:
    /// \param[in] element The event to convert to its string representation
    /// \param[in] index To which column the event belongs to
    /// \return false, the event is not a collection
-   template <typename T, typename std::enable_if<!ROOT::Internal::RDF::IsDataContainer<T>::value, int>::type = 0>
+   template <typename T, std::enable_if_t<!ROOT::Internal::RDF::IsDataContainer<T>::value, int> = 0>
    bool AddInterpreterString(std::stringstream &stream, T &element, const int &index)
    {
       stream << "*((std::string*)" << ROOT::Internal::RDF::PrettyPrintAddr(&(fRepresentations[index]))
@@ -113,7 +113,7 @@ private:
    /// \param[in] index To which column the event belongs to
    /// \return true, the event is a collection
    /// This function chains a sequence of call to cling::printValue, one for each element of the collection.
-   template <typename T, typename std::enable_if<ROOT::Internal::RDF::IsDataContainer<T>::value, int>::type = 0>
+   template <typename T, std::enable_if_t<ROOT::Internal::RDF::IsDataContainer<T>::value, int> = 0>
    bool AddInterpreterString(std::stringstream &stream, T &collection, const int &index)
    {
       size_t collectionSize = std::distance(std::begin(collection), std::end(collection));

--- a/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
@@ -235,7 +235,7 @@ class RMergeableFill final : public RMergeableValue<T> {
    // RDataFrame's generic Fill method supports two possible signatures for Merge.
    // Templated to create a dependent type to SFINAE on - in reality, `U` will always be `T`.
    // This overload handles Merge(TCollection*)...
-   template <typename U, typename = typename std::enable_if<std::is_base_of<TObject, U>::value, int>::type>
+   template <typename U, std::enable_if_t<std::is_base_of<TObject, U>::value, int> = 0>
    auto DoMerge(const RMergeableFill<U> &other, int /*toincreaseoverloadpriority*/)
       -> decltype(((U &)this->fValue).Merge((TCollection *)nullptr), void())
    {

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -70,7 +70,7 @@ using namespace ROOT::RDF;
 /// generic IsDataContainer<T>.
 template <typename T>
 struct IsDataContainer {
-   using Test_t = typename std::decay<T>::type;
+   using Test_t = std::decay_t<T>;
 
    template <typename A>
    static constexpr bool Test(A *pt, A const *cpt = nullptr, decltype(pt->begin()) * = nullptr,
@@ -166,7 +166,8 @@ struct IsRVec_t<ROOT::VecOps::RVec<T>> : public std::true_type {};
 
 // Check the value_type type of a type with a SFINAE to allow compilation in presence
 // fundamental types
-template <typename T, bool IsDataContainer = IsDataContainer<typename std::decay<T>::type>::value || std::is_same<std::string, T>::value>
+template <typename T,
+          bool IsDataContainer = IsDataContainer<std::decay_t<T>>::value || std::is_same<std::string, T>::value>
 struct ValueType {
    using value_type = typename T::value_type;
 };

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -49,7 +49,7 @@ template <std::size_t... N, typename T, typename F>
 class PassAsVecHelper<std::index_sequence<N...>, T, F> {
    template <std::size_t Idx>
    using AlwaysT = T;
-   typename std::decay<F>::type fFunc;
+   std::decay_t<F> fFunc;
 
 public:
    PassAsVecHelper(F &&f) : fFunc(std::forward<F>(f)) {}
@@ -76,8 +76,8 @@ namespace RDFInternal = ROOT::Internal::RDF;
 /// std::not_fn, required for interoperability with RDataFrame.
 // clang-format on
 template <typename F,
-          typename Args = typename ROOT::TypeTraits::CallableTraits<typename std::decay<F>::type>::arg_types_nodecay,
-          typename Ret = typename ROOT::TypeTraits::CallableTraits<typename std::decay<F>::type>::ret_type>
+          typename Args = typename ROOT::TypeTraits::CallableTraits<std::decay_t<F>>::arg_types_nodecay,
+          typename Ret = typename ROOT::TypeTraits::CallableTraits<std::decay_t<F>>::ret_type>
 auto Not(F &&f) -> decltype(RDFInternal::NotHelper(Args(), std::forward<F>(f)))
 {
    static_assert(std::is_same<Ret, bool>::value, "RDF::Not requires a callable that returns a bool.");

--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -191,8 +191,8 @@ public:
    ///
    /// Useful e.g. to store a number of RResultPtr<TH1D> and RResultPtr<TH2D> in a std::vector<RResultPtr<TH1>>.
    /// The requirements on T2 and T are the same as for conversion between std::shared_ptr<T2> and std::shared_ptr<T>.
-   template <typename T2, typename std::enable_if<std::is_constructible<std::shared_ptr<T>, std::shared_ptr<T2>>::value,
-                                                  int>::type = 0>
+   template <typename T2,
+             std::enable_if_t<std::is_constructible<std::shared_ptr<T>, std::shared_ptr<T2>>::value, int> = 0>
    RResultPtr(const RResultPtr<T2> &r) : fLoopManager(r.fLoopManager), fObjPtr(r.fObjPtr), fActionPtr(r.fActionPtr)
    {
    }

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -96,8 +96,10 @@ private:
    void SendResult();
 
    F  fProcFunc; ///< copy the function to be executed
-   typename std::result_of<F(std::reference_wrapper<TTreeReader>)>::type fReducedResult; ///< the results of the executions of fProcFunc merged together
-   bool fCanReduce; ///< true if fReducedResult can be reduced with a new result, false until we have produced one result
+   /// the results of the executions of fProcFunc merged together
+   std::result_of_t<F(std::reference_wrapper<TTreeReader>)> fReducedResult;
+   /// true if fReducedResult can be reduced with a new result, false until we have produced one result
+   bool fCanReduce;
 };
 
 class TMPWorkerTreeSel : public TMPWorkerTree {
@@ -131,8 +133,8 @@ private:
 /// object from the file we are reading the TTree from.
 /// Note: the only sane case in which this should happen is when a TH1F* is
 /// returned.
-template <class T, typename std::enable_if<std::is_pointer<T>::value && std::is_constructible<TObject *, T>::value &&
-                                           !std::is_constructible<TCollection *, T>::value>::type * = nullptr>
+template <class T, std::enable_if_t<std::is_pointer<T>::value && std::is_constructible<TObject *, T>::value &&
+                                    !std::is_constructible<TCollection *, T>::value> * = nullptr>
 void DetachRes(T res)
 {
    auto th1p = dynamic_cast<TH1*>(res);
@@ -159,8 +161,8 @@ void DetachRes(T res)
 }
 
 // Specialization for TCollections
-template <class T, typename std::enable_if<std::is_pointer<T>::value &&
-                                           std::is_constructible<TCollection *, T>::value>::type * = nullptr>
+template <class T,
+          std::enable_if_t<std::is_pointer<T>::value && std::is_constructible<TCollection *, T>::value> * = nullptr>
 void DetachRes(T res)
 {
    if (res) {

--- a/tree/treeplayer/inc/TTreeReaderArray.h
+++ b/tree/treeplayer/inc/TTreeReaderArray.h
@@ -85,8 +85,8 @@ public:
       using iterator_category = std::random_access_iterator_tag;
       using value_type = T;
       using difference_type = std::ptrdiff_t;
-      using pointer = typename std::conditional<std::is_const<ReaderArrayType>::value, const T *, T *>::type;
-      using reference = typename std::conditional<std::is_const<ReaderArrayType>::value, const T &, T &>::type;
+      using pointer = std::conditional_t<std::is_const<ReaderArrayType>::value, const T *, T *>;
+      using reference = std::conditional_t<std::is_const<ReaderArrayType>::value, const T &, T &>;
 
    private:
       TTreeReaderArray *fArray; ///< The array iterated over; nullptr if invalid/past-the-end.

--- a/tutorials/dataframe/df022_useKahan.C
+++ b/tutorials/dataframe/df022_useKahan.C
@@ -54,7 +54,7 @@ public:
       KahanAlgorithm(x, fPartialSums[slot], fCompensations[slot]);
    }
 
-   template <typename V=T, typename std::enable_if<ROOT::Internal::RDF::IsDataContainer<V>::value, int>::type = 0>
+   template <typename V=T, std::enable_if_t<ROOT::Internal::RDF::IsDataContainer<V>::value, int> = 0>
    void Exec(unsigned int slot, const T &vs)
    {
       for (auto &&v : vs) {


### PR DESCRIPTION
I only did a pass in `tree/dataframe` and `core/foundation`, which is code I wrote or maintain that I know contains a lot of TMP.
