### PR TITLE
[RF] Make RooArgList and RooArgSet constructors also accept numbers

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -305,6 +305,17 @@ public:
 
   void useHashMapForFind(bool flag) const;
 
+  // For use in the RooArgList/Set(std::vector<RooAbsArgPtrOrDouble> const&) constructor.
+  // Can be replaced with std::variant when C++17 is the minimum supported standard.
+  struct RooAbsArgPtrOrDouble {
+    RooAbsArgPtrOrDouble(RooAbsArg * arg) : ptr{arg}, hasPtr{true} {}
+    RooAbsArgPtrOrDouble(double x) : val{x}, hasPtr{false} {}
+
+    RooAbsArg * ptr = nullptr;
+    double val = 0.0;
+    bool hasPtr = false;
+  };
+
 protected:
   Storage_t _list; // Actual object storage
   using LegacyIterator_t = TIteratorToSTLInterface<Storage_t>;

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -124,4 +124,15 @@ private:
   ClassDef(RooArgList,1) // Ordered list of RooAbsArg objects
 };
 
+
+namespace RooFitShortHand {
+
+template<class... Args_t>
+RooArgList L(Args_t&&... args) {
+  return {std::forward<Args_t>(args)...};
+}
+
+} // namespace RooFitShortHand
+
+
 #endif

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -68,10 +68,11 @@ public:
   /// or tuple can be implicitly converted to an std::vector, and by enabling
   /// implicit construction of a RooArgList from a std::vector, we indirectly
   /// enable implicit conversion from a Python list/tuple to RooArgLists.
-  /// \param vec A vector with pointers to the arguments.
-  RooArgList(std::vector<RooAbsArg*> const& vec) {
+  /// \param vec A vector with pointers to the arguments or doubles for RooFit::RooConst().
+  RooArgList(std::vector<RooAbsArgPtrOrDouble> const& vec) {
     for(auto const& arg : vec) {
-      add(*arg);
+      if(arg.hasPtr) processArg(arg.ptr);
+      else processArg(arg.val);
     }
   }
 

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -87,10 +87,11 @@ public:
   /// or tuple can be implicitly converted to an std::vector, and by enabling
   /// implicit construction of a RooArgSet from a std::vector, we indirectly
   /// enable implicit conversion from a Python list/tuple to RooArgSets.
-  /// \param vec A vector with pointers to the arguments.
-  RooArgSet(std::vector<RooAbsArg*> const& vec) {
+  /// \param vec A vector with pointers to the arguments or doubles for RooFit::RooConst().
+  RooArgSet(std::vector<RooAbsArgPtrOrDouble> const& vec) {
     for(auto const& arg : vec) {
-      add(*arg);
+      if(arg.hasPtr) processArg(arg.ptr);
+      else processArg(arg.val);
     }
   }
 

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -181,4 +181,15 @@ private:
   ClassDefOverride(RooArgSet,1) // Set of RooAbsArg objects
 };
 
+
+namespace RooFitShortHand {
+
+template<class... Args_t>
+RooArgSet S(Args_t&&... args) {
+  return {std::forward<Args_t>(args)...};
+}
+
+} // namespace RooFitShortHand
+
+
 #endif

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -379,38 +379,8 @@ RooConstVar& RooConst(Double_t val) ;
 
 namespace RooFitShortHand {
 
-RooArgSet S(const RooAbsArg& v1) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-            const RooAbsArg& v6) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-            const RooAbsArg& v6, const RooAbsArg& v7) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-            const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8) ;
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-            const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8, const RooAbsArg& v9) ;
+RooConstVar& C(Double_t value);
 
-RooArgList L(const RooAbsArg& v1) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-             const RooAbsArg& v6) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-             const RooAbsArg& v6, const RooAbsArg& v7) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-             const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8) ;
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5,
-             const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8, const RooAbsArg& v9) ;
-
-RooConstVar& C(Double_t value) ;
-
-} // End namespace ShortHand
-
-class RooGlobalFunc {};
+} // namespace RooFitShortHand
 
 #endif

--- a/roofit/roofitcore/src/RooArgList.cxx
+++ b/roofit/roofitcore/src/RooArgList.cxx
@@ -45,6 +45,7 @@
 #include "RooAbsCategoryLValue.h"
 #include "RooTrace.h"
 #include "RooMsgService.h"
+#include "RooConstVar.h"
 
 #include <stdexcept>
 
@@ -192,3 +193,5 @@ Bool_t RooArgList::readFromStream(istream& is, Bool_t compact, Bool_t verbose)
   return kFALSE ;  
 }
 
+
+void RooArgList::processArg(double value) { processArg(RooFit::RooConst(value)); }

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -51,6 +51,7 @@
 #include "RooArgList.h"
 #include "RooSentinel.h"
 #include "RooMsgService.h"
+#include "RooConstVar.h"
 #include "ROOT/RMakeUnique.hxx"
 #include "strlcpy.h"
 
@@ -653,3 +654,6 @@ Bool_t RooArgSet::isInRange(const char* rangeSpec)
   delete iter ;
   return kFALSE ;
 }
+
+
+void RooArgSet::processArg(double value) { processArg(RooFit::RooConst(value)); }

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -385,40 +385,9 @@ namespace RooFit {
  
 } // End namespace RooFit
 
+
 namespace RooFitShortHand {
-
-RooArgSet S(const RooAbsArg& v1) { return RooArgSet(v1) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2) { return RooArgSet(v1,v2) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3) { return RooArgSet(v1,v2,v3) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4) { return RooArgSet(v1,v2,v3,v4) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5) 
-          { return RooArgSet(v1,v2,v3,v4,v5) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-            const RooAbsArg& v6) { return RooArgSet(v1,v2,v3,v4,v5,v6) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-            const RooAbsArg& v6, const RooAbsArg& v7) { return RooArgSet(v1,v2,v3,v4,v5,v6,v7) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-            const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8) { return RooArgSet(v1,v2,v3,v4,v5,v6,v7,v8) ; }
-RooArgSet S(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-            const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8, const RooAbsArg& v9) 
-          { return RooArgSet(v1,v2,v3,v4,v5,v6,v7,v8,v9) ; }
-
-RooArgList L(const RooAbsArg& v1) { return RooArgList(v1) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2) { return RooArgList(v1,v2) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3) { return RooArgList(v1,v2,v3) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4) { return RooArgList(v1,v2,v3,v4) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5) 
-           { return RooArgList(v1,v2,v3,v4,v5) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-             const RooAbsArg& v6) { return RooArgList(v1,v2,v3,v4,v5,v6) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-             const RooAbsArg& v6, const RooAbsArg& v7) { return RooArgList(v1,v2,v3,v4,v5,v6,v7) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-             const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8) { return RooArgList(v1,v2,v3,v4,v5,v6,v7,v8) ; }
-RooArgList L(const RooAbsArg& v1, const RooAbsArg& v2, const RooAbsArg& v3, const RooAbsArg& v4, const RooAbsArg& v5, 
-             const RooAbsArg& v6, const RooAbsArg& v7, const RooAbsArg& v8, const RooAbsArg& v9) 
-           { return RooArgList(v1,v2,v3,v4,v5,v6,v7,v8,v9) ; }
 
 RooConstVar& C(Double_t value) { return RooFit::RooConst(value) ; }
 
-} // End namespace Shorthand
+} // namespace RooFitShortHand

--- a/tutorials/roofit/rf311_rangeplot.C
+++ b/tutorials/roofit/rf311_rangeplot.C
@@ -40,8 +40,8 @@ void rf311_rangeplot()
    RooProdPdf sig("sig", "sig", RooArgSet(gx, gy, gz));
 
    // Create background pdf poly(x)*poly(y)*poly(z)
-   RooPolynomial px("px", "px", x, RooArgSet(RooConst(-0.1), RooConst(0.004)));
-   RooPolynomial py("py", "py", y, RooArgSet(RooConst(0.1), RooConst(-0.004)));
+   RooPolynomial px("px", "px", x, RooArgSet(-0.1, 0.004));
+   RooPolynomial py("py", "py", y, RooArgSet(0.1, -0.004));
    RooPolynomial pz("pz", "pz", z);
    RooProdPdf bkg("bkg", "bkg", RooArgSet(px, py, pz));
 

--- a/tutorials/roofit/rf316_llratioplot.C
+++ b/tutorials/roofit/rf316_llratioplot.C
@@ -41,8 +41,8 @@ void rf316_llratioplot()
    RooProdPdf sig("sig", "sig", RooArgSet(gx, gy, gz));
 
    // Create background pdf poly(x)*poly(y)*poly(z)
-   RooPolynomial px("px", "px", x, RooArgSet(RooConst(-0.1), RooConst(0.004)));
-   RooPolynomial py("py", "py", y, RooArgSet(RooConst(0.1), RooConst(-0.004)));
+   RooPolynomial px("px", "px", x, RooArgSet(-0.1, 0.004));
+   RooPolynomial py("py", "py", y, RooArgSet(0.1, -0.004));
    RooPolynomial pz("pz", "pz", z);
    RooProdPdf bkg("bkg", "bkg", RooArgSet(px, py, pz));
 

--- a/tutorials/roofit/rf316_llratioplot.py
+++ b/tutorials/roofit/rf316_llratioplot.py
@@ -27,8 +27,8 @@ gz = ROOT.RooGaussian("gz", "gz", z, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooCon
 sig = ROOT.RooProdPdf("sig", "sig", ROOT.RooArgList(gx, gy, gz))
 
 # Create background pdf poly(x)*poly(y)*poly(z)
-px = ROOT.RooPolynomial("px", "px", x, ROOT.RooArgList(ROOT.RooFit.RooConst(-0.1), ROOT.RooFit.RooConst(0.004)))
-py = ROOT.RooPolynomial("py", "py", y, ROOT.RooArgList(ROOT.RooFit.RooConst(0.1), ROOT.RooFit.RooConst(-0.004)))
+px = ROOT.RooPolynomial("px", "px", x, [-0.1, 0.004])
+py = ROOT.RooPolynomial("py", "py", y, [0.1, -0.004])
 pz = ROOT.RooPolynomial("pz", "pz", z)
 bkg = ROOT.RooProdPdf("bkg", "bkg", ROOT.RooArgList(px, py, pz))
 

--- a/tutorials/roofit/rf401_importttreethx.C
+++ b/tutorials/roofit/rf401_importttreethx.C
@@ -16,7 +16,6 @@
 #include "RooDataHist.h"
 #include "RooCategory.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"

--- a/tutorials/roofit/rf402_datahandling.C
+++ b/tutorials/roofit/rf402_datahandling.C
@@ -14,7 +14,6 @@
 #include "RooDataSet.h"
 #include "RooDataHist.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooCategory.h"
 #include "TCanvas.h"
 #include "TAxis.h"

--- a/tutorials/roofit/rf403_weightedevts.C
+++ b/tutorials/roofit/rf403_weightedevts.C
@@ -14,7 +14,6 @@
 #include "RooDataSet.h"
 #include "RooDataHist.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooFormulaVar.h"
 #include "RooGenericPdf.h"
 #include "RooPolynomial.h"

--- a/tutorials/roofit/rf404_categories.C
+++ b/tutorials/roofit/rf404_categories.C
@@ -15,7 +15,6 @@
 #include "RooCategory.h"
 #include "Roo1DTable.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"

--- a/tutorials/roofit/rf407_latextables.C
+++ b/tutorials/roofit/rf407_latextables.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooExponential.h"

--- a/tutorials/roofit/rf501_simultaneouspdf.C
+++ b/tutorials/roofit/rf501_simultaneouspdf.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooSimultaneous.h"

--- a/tutorials/roofit/rf502_wspacewrite.C
+++ b/tutorials/roofit/rf502_wspacewrite.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooWorkspace.h"

--- a/tutorials/roofit/rf503_wspaceread.C
+++ b/tutorials/roofit/rf503_wspaceread.C
@@ -15,7 +15,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooWorkspace.h"

--- a/tutorials/roofit/rf504_simwstool.C
+++ b/tutorials/roofit/rf504_simwstool.C
@@ -14,7 +14,6 @@
 #include "RooCategory.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooSimultaneous.h"
 #include "RooAddPdf.h"

--- a/tutorials/roofit/rf505_asciicfg.C
+++ b/tutorials/roofit/rf505_asciicfg.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "TCanvas.h"

--- a/tutorials/roofit/rf506_msgservice.C
+++ b/tutorials/roofit/rf506_msgservice.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "TCanvas.h"

--- a/tutorials/roofit/rf507_debugtools.C
+++ b/tutorials/roofit/rf507_debugtools.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooAddPdf.h"
 #include "TCanvas.h"

--- a/tutorials/roofit/rf508_listsetmanip.C
+++ b/tutorials/roofit/rf508_listsetmanip.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"

--- a/tutorials/roofit/rf510_wsnamedsets.C
+++ b/tutorials/roofit/rf510_wsnamedsets.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooWorkspace.h"

--- a/tutorials/roofit/rf511_wsfactory_basic.C
+++ b/tutorials/roofit/rf511_wsfactory_basic.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooWorkspace.h"

--- a/tutorials/roofit/rf512_wsfactory_oper.C
+++ b/tutorials/roofit/rf512_wsfactory_oper.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooWorkspace.h"

--- a/tutorials/roofit/rf513_wsfactory_tools.C
+++ b/tutorials/roofit/rf513_wsfactory_tools.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooWorkspace.h"

--- a/tutorials/roofit/rf601_intminuit.C
+++ b/tutorials/roofit/rf601_intminuit.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooProdPdf.h"
 #include "RooAddPdf.h"
 #include "RooMinimizer.h"

--- a/tutorials/roofit/rf602_chi2fit.C
+++ b/tutorials/roofit/rf602_chi2fit.C
@@ -12,7 +12,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooChi2Var.h"

--- a/tutorials/roofit/rf603_multicpu.C
+++ b/tutorials/roofit/rf603_multicpu.C
@@ -40,8 +40,8 @@ void rf603_multicpu()
    RooProdPdf sig("sig", "sig", RooArgSet(gx, gy, gz));
 
    // Create background pdf poly(x)*poly(y)*poly(z)
-   RooPolynomial px("px", "px", x, RooArgSet(RooConst(-0.1), RooConst(0.004)));
-   RooPolynomial py("py", "py", y, RooArgSet(RooConst(0.1), RooConst(-0.004)));
+   RooPolynomial px("px", "px", x, RooArgSet(-0.1, 0.004));
+   RooPolynomial py("py", "py", y, RooArgSet(0.1, -0.004));
    RooPolynomial pz("pz", "pz", z);
    RooProdPdf bkg("bkg", "bkg", RooArgSet(px, py, pz));
 

--- a/tutorials/roofit/rf605_profilell.C
+++ b/tutorials/roofit/rf605_profilell.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooAddPdf.h"
 #include "RooMinimizer.h"
 #include "TCanvas.h"

--- a/tutorials/roofit/rf607_fitresult.C
+++ b/tutorials/roofit/rf607_fitresult.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooAddPdf.h"
 #include "RooChebychev.h"
 #include "RooFitResult.h"

--- a/tutorials/roofit/rf608_fitresultaspdf.C
+++ b/tutorials/roofit/rf608_fitresultaspdf.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooAddPdf.h"
 #include "RooChebychev.h"
 #include "RooFitResult.h"

--- a/tutorials/roofit/rf609_xychi2fit.C
+++ b/tutorials/roofit/rf609_xychi2fit.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooPolyVar.h"
-#include "RooConstVar.h"
 #include "RooChi2Var.h"
 #include "TCanvas.h"
 #include "TAxis.h"
@@ -59,7 +58,7 @@ void rf609_xychi2fit()
    // Make fit function
    RooRealVar a("a", "a", 0.0, -10, 10);
    RooRealVar b("b", "b", 0.0, -100, 100);
-   RooPolyVar f("f", "f", x, RooArgList(b, a, RooConst(1)));
+   RooPolyVar f("f", "f", x, RooArgList(b, a, 1.0));
 
    // Plot dataset in X-Y interpretation
    RooPlot *frame = x.frame(Title("Chi^2 fit of function set of (X#pmdX,Y#pmdY) values"));

--- a/tutorials/roofit/rf610_visualerror.C
+++ b/tutorials/roofit/rf610_visualerror.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataHist.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooAddPdf.h"
 #include "RooPlot.h"
 #include "TCanvas.h"

--- a/tutorials/roofit/rf704_amplitudefit.C
+++ b/tutorials/roofit/rf704_amplitudefit.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooTruthModel.h"
 #include "RooFormulaVar.h"
 #include "RooRealSumPdf.h"
@@ -44,8 +43,8 @@ void rf704_amplitudefit()
    RooAbsReal *sinhGConv = truthModel.convolution(&sinhGBasis, &t);
 
    // Construct polynomial amplitudes in cos(a)
-   RooPolyVar poly1("poly1", "poly1", cosa, RooArgList(RooConst(0.5), RooConst(0.2), RooConst(0.2)), 0);
-   RooPolyVar poly2("poly2", "poly2", cosa, RooArgList(RooConst(1), RooConst(-0.2), RooConst(3)), 0);
+   RooPolyVar poly1("poly1", "poly1", cosa, RooArgList(0.5, 0.2, 0.2), 0);
+   RooPolyVar poly2("poly2", "poly2", cosa, RooArgList(1.0, -0.2, 3.0), 0);
 
    // Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
    RooProduct ampl1("ampl1", "amplitude 1", RooArgSet(poly1, *coshGConv));

--- a/tutorials/roofit/rf705_linearmorph.C
+++ b/tutorials/roofit/rf705_linearmorph.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooIntegralMorph.h"
 #include "RooNLLVar.h"
@@ -36,7 +35,7 @@ void rf705_linearmorph()
    RooGaussian g1("g1", "g1", x, g1mean, RooConst(2));
 
    // Upper end point shape: a Polynomial
-   RooPolynomial g2("g2", "g2", x, RooArgSet(RooConst(-0.03), RooConst(-0.001)));
+   RooPolynomial g2("g2", "g2", x, RooArgSet(-0.03, -0.001));
 
    // C r e a t e   i n t e r p o l a t i n g   p d f
    // -----------------------------------------------

--- a/tutorials/roofit/rf706_histpdf.C
+++ b/tutorials/roofit/rf706_histpdf.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooHistPdf.h"
 #include "TCanvas.h"
@@ -27,7 +26,7 @@ void rf706_histpdf()
    // ---------------------------------------------
 
    RooRealVar x("x", "x", 0, 20);
-   RooPolynomial p("p", "p", x, RooArgList(RooConst(0.01), RooConst(-0.01), RooConst(0.0004)));
+   RooPolynomial p("p", "p", x, RooArgList(0.01, -0.01, 0.0004));
 
    // C r e a t e   l o w   s t a t s   h i s t o g r a m
    // ---------------------------------------------------

--- a/tutorials/roofit/rf707_kernelestimation.C
+++ b/tutorials/roofit/rf707_kernelestimation.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooPolynomial.h"
 #include "RooKeysPdf.h"
 #include "RooNDKeysPdf.h"
@@ -31,7 +30,7 @@ void rf707_kernelestimation()
 
    // Create a toy pdf for sampling
    RooRealVar x("x", "x", 0, 20);
-   RooPolynomial p("p", "p", x, RooArgList(RooConst(0.01), RooConst(-0.01), RooConst(0.0004)));
+   RooPolynomial p("p", "p", x, RooArgList(0.01, -0.01, 0.0004));
 
    // Sample 500 events from p
    RooDataSet *data1 = p.generate(x, 200);
@@ -68,7 +67,7 @@ void rf707_kernelestimation()
 
    // Construct a 2D toy pdf for sampling
    RooRealVar y("y", "y", 0, 20);
-   RooPolynomial py("py", "py", y, RooArgList(RooConst(0.01), RooConst(0.01), RooConst(-0.0004)));
+   RooPolynomial py("py", "py", y, RooArgList(0.01, 0.01, -0.0004));
    RooProdPdf pxy("pxy", "pxy", RooArgSet(p, py));
    RooDataSet *data2 = pxy.generate(RooArgSet(x, y), 1000);
 

--- a/tutorials/roofit/rf801_mcstudy.C
+++ b/tutorials/roofit/rf801_mcstudy.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooMCStudy.h"

--- a/tutorials/roofit/rf802_mcstudy_addons.C
+++ b/tutorials/roofit/rf802_mcstudy_addons.C
@@ -15,7 +15,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooMCStudy.h"

--- a/tutorials/roofit/rf803_mcstudy_addons2.C
+++ b/tutorials/roofit/rf803_mcstudy_addons2.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
 #include "RooMCStudy.h"

--- a/tutorials/roofit/rf902_numgenconfig.C
+++ b/tutorials/roofit/rf902_numgenconfig.C
@@ -12,7 +12,6 @@
 
 #include "RooRealVar.h"
 #include "RooDataSet.h"
-#include "RooConstVar.h"
 #include "RooChebychev.h"
 #include "TCanvas.h"
 #include "TAxis.h"
@@ -30,7 +29,7 @@ void rf902_numgenconfig()
 
    // Example pdf for use below
    RooRealVar x("x", "x", 0, 10);
-   RooChebychev model("model", "model", x, RooArgList(RooConst(0), RooConst(0.5), RooConst(-0.1)));
+   RooChebychev model("model", "model", x, RooArgList(0, 0.5, -0.1));
 
    // Change global strategy for 1D sampling problems without conditional observable
    // (1st kFALSE) and without discrete observable (2nd kFALSE) from RooFoamGenerator,

--- a/tutorials/roofit/rf903_numintcache.C
+++ b/tutorials/roofit/rf903_numintcache.C
@@ -14,7 +14,6 @@
 #include "RooDataSet.h"
 #include "RooDataHist.h"
 #include "RooGaussian.h"
-#include "RooConstVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"


### PR DESCRIPTION
This PR makes the necessary changes on the C++ side to be able to construct RooFit collections directly from numerical constants without the intermediate call to `RooFit::RooConst`. This works now both from C++ and Python and helps to make the Python code much more expressive and pythonic.

For example this:
```Python
px = ROOT.RooPolynomial("px", "px", x, ROOT.RooArgList(ROOT.RooFit.RooConst(-0.1), ROOT.RooFit.RooConst(0.004)))
```
becomes this:
```Python
px = ROOT.RooPolynomial("px", "px", x, [-0.1, 0.004])
```