### PR TITLE
[core/foundation] Add R__DEBUG_ASSERT macro

### DIFF
--- a/core/foundation/inc/TError.h
+++ b/core/foundation/inc/TError.h
@@ -115,10 +115,20 @@ extern void Obsolete(const char *function, const char *asOfVers, const char *rem
 R__EXTERN const char *kAssertMsg;
 R__EXTERN const char *kCheckMsg;
 
+/// Check for condition, emit a fatal error if false.
+/// \attention Unlike `assert`, this is *not* compiled away in release builds. Use R__DEBUG_ASSERT for that.
 #define R__ASSERT(e)                                                     \
    do {                                                                  \
       if (!(e)) ::Fatal("", kAssertMsg, _QUOTE_(e), __LINE__, __FILE__); \
    } while (false)
+
+/// A version of R__ASSERT that is only compiled in debug builds.
+#ifdef NDEBUG
+#define R__DEBUG_ASSERT(e) (void)0 // so that R__DEBUG_ASSERT can always be followed by a semi-colon
+#else
+#define R__DEBUG_ASSERT(e) R__ASSERT(e)
+#endif
+
 #define R__CHECK(e)                                                       \
    do {                                                                   \
       if (!(e)) ::Warning("", kCheckMsg, _QUOTE_(e), __LINE__, __FILE__); \

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1446,8 +1446,8 @@ public:
 
    void Finalize()
    {
-      R__ASSERT(fOutputTree != nullptr);
-      R__ASSERT(fOutputFile != nullptr);
+      R__DEBUG_ASSERT(fOutputTree != nullptr);
+      R__DEBUG_ASSERT(fOutputFile != nullptr);
 
       // use AutoSave to flush TTree contents because TTree::Write writes in gDirectory, not in fDirectory
       fOutputTree->AutoSave("flushbaskets");
@@ -1609,7 +1609,7 @@ public:
       const bool allNullFiles =
          std::all_of(fOutputFiles.begin(), fOutputFiles.end(),
                      [](const std::shared_ptr<ROOT::TBufferMergerFile> &ptr) { return ptr == nullptr; });
-      R__ASSERT(!allNullFiles);
+      R__DEBUG_ASSERT(!allNullFiles);
 
       auto fileWritten = false;
       for (auto &file : fOutputFiles) {

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -19,7 +19,7 @@
 
 #include <ROOT/RDataSource.hxx>
 #include <ROOT/TypeTraits.hxx>
-#include <TError.h> // R__ASSERT
+#include <TError.h> // R__DEBUG_ASSERT, R__ASSERT
 #include <TTreeReader.h>
 
 #include <array>
@@ -71,7 +71,7 @@ MakeColumnReadersHelper(unsigned int slot, RDFDetail::RDefineBase *define,
 {
    const auto DSValuePtrsIt = DSValuePtrsMap.find(colName);
    const std::vector<void *> *DSValuePtrsPtr = DSValuePtrsIt != DSValuePtrsMap.end() ? &DSValuePtrsIt->second : nullptr;
-   R__ASSERT(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr || ds != nullptr);
+   R__DEBUG_ASSERT(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr || ds != nullptr);
    return MakeColumnReader<T>(slot, define, r, ds, DSValuePtrsPtr, colName);
 }
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -143,7 +143,7 @@ public:
 
    void TriggerChildrenCount() final
    {
-      R__ASSERT(!fName.empty()); // this method is to only be called on named filters
+      R__DEBUG_ASSERT(!fName.empty()); // this method is to only be called on named filters
       fPrevData.IncrChildrenCount();
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -14,7 +14,7 @@
 #include "ROOT/RDF/RBookedDefines.hxx"
 #include "ROOT/RDF/RNodeBase.hxx"
 #include "RtypesCore.h"
-#include "TError.h" // R_ASSERT
+#include "TError.h" // R__ASSERT, R__DEBUG_ASSERT
 
 #include <string>
 #include <vector>
@@ -58,7 +58,7 @@ public:
    virtual void TriggerChildrenCount() = 0;
    virtual void ResetReportCount()
    {
-      R__ASSERT(!fName.empty()); // this method is to only be called on named filters
+      R__DEBUG_ASSERT(!fName.empty()); // this method is to only be called on named filters
       // fAccepted and fRejected could be different than 0 if this is not the first event-loop run using this filter
       std::fill(fAccepted.begin(), fAccepted.end(), 0);
       std::fill(fRejected.begin(), fRejected.end(), 0);

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -452,7 +452,7 @@ bool RCsvDS::SetEntry(unsigned int slot, ULong64_t entry)
 
 void RCsvDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
+   R__DEBUG_ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
 
    fNSlots = nSlots;
 

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -194,7 +194,7 @@ static std::unordered_map<std::string, std::string> &GetJittedExprs() {
 static std::string
 BuildLambdaString(const std::string &expr, const ColumnNames_t &vars, const ColumnNames_t &varTypes)
 {
-   R__ASSERT(vars.size() == varTypes.size());
+   R__DEBUG_ASSERT(vars.size() == varTypes.size());
 
    TPRegexp re(R"(\breturn\b)");
    const bool hasReturnStmt = re.MatchB(expr);

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -22,43 +22,43 @@ RJittedAction::RJittedAction(RLoopManager &lm) : RActionBase(&lm, {}, ROOT::Inte
 
 void RJittedAction::Run(unsigned int slot, Long64_t entry)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    fConcreteAction->Run(slot, entry);
 }
 
 void RJittedAction::Initialize()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    fConcreteAction->Initialize();
 }
 
 void RJittedAction::InitSlot(TTreeReader *r, unsigned int slot)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    fConcreteAction->InitSlot(r, slot);
 }
 
 void RJittedAction::TriggerChildrenCount()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    fConcreteAction->TriggerChildrenCount();
 }
 
 void RJittedAction::FinalizeSlot(unsigned int slot)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    fConcreteAction->FinalizeSlot(slot);
 }
 
 void RJittedAction::Finalize()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    fConcreteAction->Finalize();
 }
 
 void *RJittedAction::PartialUpdate(unsigned int slot)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->PartialUpdate(slot);
 }
 
@@ -74,13 +74,13 @@ bool RJittedAction::HasRun() const
 
 void RJittedAction::SetHasRun()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->SetHasRun();
 }
 
 std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->GetGraph();
 }
 
@@ -90,12 +90,12 @@ std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::Get
 */
 std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> RJittedAction::GetMergeableValue() const
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->GetMergeableValue();
 }
 
 std::function<void(unsigned int)> RJittedAction::GetDataBlockCallback()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   R__DEBUG_ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->GetDataBlockCallback();
 }

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -9,36 +9,36 @@
  *************************************************************************/
 
 #include <ROOT/RDF/RJittedDefine.hxx>
-#include <TError.h> // R__ASSERT
+#include <TError.h> // R__DEBUG_ASSERT
 
 using namespace ROOT::Detail::RDF;
 
 void RJittedDefine::InitSlot(TTreeReader *r, unsigned int slot)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   R__DEBUG_ASSERT(fConcreteDefine != nullptr);
    fConcreteDefine->InitSlot(r, slot);
 }
 
 void *RJittedDefine::GetValuePtr(unsigned int slot)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   R__DEBUG_ASSERT(fConcreteDefine != nullptr);
    return fConcreteDefine->GetValuePtr(slot);
 }
 
 const std::type_info &RJittedDefine::GetTypeId() const
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   R__DEBUG_ASSERT(fConcreteDefine != nullptr);
    return fConcreteDefine->GetTypeId();
 }
 
 void RJittedDefine::Update(unsigned int slot, Long64_t entry)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   R__DEBUG_ASSERT(fConcreteDefine != nullptr);
    fConcreteDefine->Update(slot, entry);
 }
 
 void RJittedDefine::FinaliseSlot(unsigned int slot)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   R__DEBUG_ASSERT(fConcreteDefine != nullptr);
    fConcreteDefine->FinaliseSlot(slot);
 }

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -25,73 +25,73 @@ void RJittedFilter::SetFilter(std::unique_ptr<RFilterBase> f)
 
 void RJittedFilter::InitSlot(TTreeReader *r, unsigned int slot)
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->InitSlot(r, slot);
 }
 
 bool RJittedFilter::CheckFilters(unsigned int slot, Long64_t entry)
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    return fConcreteFilter->CheckFilters(slot, entry);
 }
 
 void RJittedFilter::Report(ROOT::RDF::RCutFlowReport &cr) const
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->Report(cr);
 }
 
 void RJittedFilter::PartialReport(ROOT::RDF::RCutFlowReport &cr) const
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->PartialReport(cr);
 }
 
 void RJittedFilter::FillReport(ROOT::RDF::RCutFlowReport &cr) const
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->FillReport(cr);
 }
 
 void RJittedFilter::IncrChildrenCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->IncrChildrenCount();
 }
 
 void RJittedFilter::StopProcessing()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->StopProcessing();
 }
 
 void RJittedFilter::ResetChildrenCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->ResetChildrenCount();
 }
 
 void RJittedFilter::TriggerChildrenCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->TriggerChildrenCount();
 }
 
 void RJittedFilter::ResetReportCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->ResetReportCount();
 }
 
 void RJittedFilter::FinaliseSlot(unsigned int slot)
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->FinaliseSlot(slot);
 }
 
 void RJittedFilter::InitNode()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   R__DEBUG_ASSERT(fConcreteFilter != nullptr);
    fConcreteFilter->InitNode();
 }
 

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -483,7 +483,7 @@ void RLoopManager::RunTreeReader()
 /// Run event loop over data accessed through a DataSource, in sequence.
 void RLoopManager::RunDataSource()
 {
-   R__ASSERT(fDataSource != nullptr);
+   R__DEBUG_ASSERT(fDataSource != nullptr);
    fDataSource->Initialise();
    auto ranges = fDataSource->GetEntryRanges();
    while (!ranges.empty() && fNStopsReceived < fNChildren) {
@@ -515,7 +515,7 @@ void RLoopManager::RunDataSource()
 void RLoopManager::RunDataSourceMT()
 {
 #ifdef R__USE_IMT
-   R__ASSERT(fDataSource != nullptr);
+   R__DEBUG_ASSERT(fDataSource != nullptr);
    RSlotStack slotStack(fNSlots);
    ROOT::TThreadExecutor pool;
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -57,7 +57,7 @@ public:
    ~RRDFCardinalityField() = default;
 
    // Field is only used for reading
-   void GenerateColumnsImpl() final { R__ASSERT(false && "Cardinality fields must only be used for reading"); }
+   void GenerateColumnsImpl() final { R__DEBUG_ASSERT(false && "Cardinality fields must only be used for reading"); }
 
    void GenerateColumnsImpl(const RNTupleDescriptor &) final
    {
@@ -321,7 +321,7 @@ void RNTupleDS::SetNSlots(unsigned int nSlots)
 
    for (unsigned int i = 1; i < fNSlots; ++i) {
       fSources.emplace_back(fSources[0]->Clone());
-      R__ASSERT(i == (fSources.size() - 1));
+      R__DEBUG_ASSERT(i == (fSources.size() - 1));
       fSources[i]->Attach();
    }
 }

--- a/tree/dataframe/src/RRootDS.cxx
+++ b/tree/dataframe/src/RRootDS.cxx
@@ -137,7 +137,7 @@ bool RRootDS::SetEntry(unsigned int slot, ULong64_t entry)
 
 void RRootDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
+   R__DEBUG_ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
 
    fNSlots = nSlots;
 

--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -10,7 +10,7 @@
 
 #include <ROOT/TSeq.hxx>
 #include <ROOT/RDF/RSlotStack.hxx>
-#include <TError.h> // R__ASSERT
+#include <TError.h> // R__DEBUG_ASSERT
 
 #include <mutex> // std::lock_guard
 
@@ -23,14 +23,14 @@ ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size)
 void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slot)
 {
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
-   R__ASSERT(fStack.size() < fSize && "Trying to put back a slot to a full stack!");
+   R__DEBUG_ASSERT(fStack.size() < fSize && "Trying to put back a slot to a full stack!");
    fStack.push(slot);
 }
 
 unsigned int ROOT::Internal::RDF::RSlotStack::GetSlot()
 {
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
-   R__ASSERT(!fStack.empty() && "Trying to pop a slot from an empty stack!");
+   R__DEBUG_ASSERT(!fStack.empty() && "Trying to pop a slot from an empty stack!");
    const auto slot = fStack.top();
    fStack.pop();
    return slot;

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -545,7 +545,7 @@ RDataFrame MakeSqliteDataFrame(std::string_view fileName, std::string_view query
 /// Stores the result of the current active sqlite query row as a C++ value.
 bool RSqliteDS::SetEntry(unsigned int /* slot */, ULong64_t entry)
 {
-   R__ASSERT(entry + 1 == fNRow);
+   R__DEBUG_ASSERT(entry + 1 == fNRow);
    unsigned N = fValues.size();
    for (unsigned i = 0; i < N; ++i) {
       if (!fValues[i].fIsActive)

--- a/tree/dataframe/src/RTrivialDS.cxx
+++ b/tree/dataframe/src/RTrivialDS.cxx
@@ -88,7 +88,7 @@ bool RTrivialDS::SetEntry(unsigned int slot, ULong64_t entry)
 
 void RTrivialDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
+   R__DEBUG_ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
 
    fNSlots = nSlots;
    fCounter.resize(fNSlots);


### PR DESCRIPTION
This is a version of R__ASSERT that is only compiled in debug builds,
as it's too late to have R__ASSERT itself disappear from debug builds,
see e.g. the discussion at https://github.com/root-project/root/pull/8587.

