### PR TITLE
[RF] Use std::string_view for name and title in RooFit data classes constructors

### DIFF
--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -775,7 +775,7 @@ void collectHistograms(
       RooArgSet vars;
       vars.add(var);
 
-      RooDataHist *dh = new RooDataHist(histname, histname, vars, hist);
+      RooDataHist *dh = new RooDataHist(histname.View(), histname.View(), vars, hist);
       // add it to the list
       RooHistFunc *hf = new RooHistFunc(funcname, funcname, var, *dh);
       int idx = physics.getSize();

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -16,11 +16,14 @@
 #ifndef ROO_ABS_DATA
 #define ROO_ABS_DATA
 
-#include "TNamed.h"
 #include "RooPrintable.h"
 #include "RooArgSet.h"
 #include "RooArgList.h"
 #include "RooSpan.h"
+
+#include "ROOT/RStringView.hxx"
+#include "TNamed.h"
+
 #include <map>
 #include <string>
 
@@ -46,13 +49,31 @@ struct RunContext;
 }
 
 
+// Writes a templated constructor for compatibility with ROOT builds using the
+// C++14 standard or earlier, taking `ROOT::Internal::TStringView` instead of
+// `std::string_view`. This means one can still use a `TString` for the name or
+// title parameter. The condition in the following `#if` should be kept in
+// sync with the one in TString.h.
+#if (__cplusplus >= 201700L) && (!defined(__clang_major__) || __clang_major__ > 5)
+#define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t) // does nothing
+#else
+#define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t)                                             \
+  template<typename ...Args_t>                                                                    \
+  Class_t(ROOT::Internal::TStringView name, ROOT::Internal::TStringView title, Args_t &&... args) \
+    : Class_t(std::string_view(name), std::string_view(title), std::forward<Args_t>(args)...) {}
+#endif
+
+
 class RooAbsData : public TNamed, public RooPrintable {
 public:
 
   // Constructors, factory methods etc.
   RooAbsData() ; 
-  RooAbsData(const char *name, const char *title, const RooArgSet& vars, RooAbsDataStore* store=0) ;
+  RooAbsData(std::string_view name, std::string_view title, const RooArgSet& vars, RooAbsDataStore* store=0) ;
   RooAbsData(const RooAbsData& other, const char* newname = 0) ;
+
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooAbsData)
+
   RooAbsData& operator=(const RooAbsData& other);
   virtual ~RooAbsData() ;
   virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const = 0 ;

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -19,7 +19,10 @@
 #include "Rtypes.h"
 #include "RooArgSet.h"
 #include "RooAbsData.h"
+
+#include "ROOT/RStringView.hxx"
 #include "TNamed.h"
+
 #include <list>
 #include <vector>
 
@@ -31,13 +34,17 @@ namespace RooBatchCompute {
 struct RunContext;
 }
 
+
 class RooAbsDataStore : public TNamed, public RooPrintable {
 public:
 
   RooAbsDataStore() ; 
-  RooAbsDataStore(const char* name, const char* title, const RooArgSet& vars) ; 
+  RooAbsDataStore(std::string_view name, std::string_view title, const RooArgSet& vars) ;
   RooAbsDataStore(const RooAbsDataStore& other, const char* newname=0) ; 
   RooAbsDataStore(const RooAbsDataStore& other, const RooArgSet& vars, const char* newname=0) ; 
+
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooAbsDataStore)
+
   virtual RooAbsDataStore* clone(const char* newname=0) const = 0 ;
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const = 0 ;
   virtual ~RooAbsDataStore() ;

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -37,7 +37,9 @@ public:
   RooCompositeDataStore() ; 
 
   // Ctors from DataStore
-  RooCompositeDataStore(const char* name, const char* title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> inputData) ;
+  RooCompositeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> inputData) ;
+
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooCompositeDataStore)
 
   // Empty ctor
   virtual RooAbsDataStore* clone(const char* newname=0) const { return new RooCompositeDataStore(*this,newname) ; }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -20,6 +20,8 @@
 #include "RooDirItem.h"
 #include "RooArgSet.h"
 
+#include "ROOT/RStringView.hxx"
+
 #include <map>
 #include <vector>
 #include <string>
@@ -39,15 +41,17 @@ public:
 
   // Constructors, factory methods etc.
   RooDataHist() ; 
-  RooDataHist(const char *name, const char *title, const RooArgSet& vars, const char* binningName=0) ;
-  RooDataHist(const char *name, const char *title, const RooArgSet& vars, const RooAbsData& data, Double_t initWgt=1.0) ;
-  RooDataHist(const char *name, const char *title, const RooArgList& vars, const TH1* hist, Double_t initWgt=1.0) ;
-  RooDataHist(const char *name, const char *title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, Double_t initWgt=1.0) ;
-  RooDataHist(const char *name, const char *title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dhistMap, Double_t wgt=1.0) ;
+  RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const char* binningName=0) ;
+  RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsData& data, Double_t initWgt=1.0) ;
+  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const TH1* hist, Double_t initWgt=1.0) ;
+  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, Double_t initWgt=1.0) ;
+  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dhistMap, Double_t wgt=1.0) ;
   //RooDataHist(const char *name, const char *title, const RooArgList& vars, Double_t initWgt=1.0) ;
-  RooDataHist(const char *name, const char *title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
+  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
         const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
   RooDataHist& operator=(const RooDataHist&) = delete;
+
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooDataHist)
 
   RooDataHist(const RooDataHist& other, const char* newname = 0) ;
   TObject* Clone(const char* newname="") const override {
@@ -227,7 +231,7 @@ protected:
   void setAllWeights(Double_t value) ;
  
   void initialize(const char* binningName=0,Bool_t fillTree=kTRUE) ;
-  RooDataHist(const char* name, const char* title, RooDataHist* h, const RooArgSet& varSubset, 
+  RooDataHist(std::string_view name, std::string_view title, RooDataHist* h, const RooArgSet& varSubset, 
         const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) ;
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0, 
                   std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) override;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -23,6 +23,9 @@ class RooDataHist;
 
 #include "RooAbsData.h"
 #include "RooDirItem.h"
+
+#include "ROOT/RStringView.hxx"
+
 #include <list>
 
 
@@ -43,26 +46,27 @@ public:
   RooDataSet() ; 
 
   // Empty constructor 
-  RooDataSet(const char *name, const char *title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName=0) ;
 
   // Universal constructor
-  RooDataSet(const char* name, const char* title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), 
+  RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), 
 	     const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),
 	     const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ; 
 
     // Constructor for subset of existing dataset
-  RooDataSet(const char *name, const char *title, RooDataSet *data, const RooArgSet& vars, 
+  RooDataSet(std::string_view name, std::string_view title, RooDataSet *data, const RooArgSet& vars, 
              const char *cuts=0, const char* wgtVarName=0);
-  RooDataSet(const char *name, const char *title, RooDataSet *data, const RooArgSet& vars,  
+  RooDataSet(std::string_view name, std::string_view title, RooDataSet *data, const RooArgSet& vars,  
 	     const RooFormulaVar& cutVar, const char* wgtVarName=0) ;  
 
 
   // Constructor importing data from external ROOT Tree
-  RooDataSet(const char *name, const char *title, TTree *tree, const RooArgSet& vars,
+  RooDataSet(std::string_view name, std::string_view title, TTree *tree, const RooArgSet& vars,
 	     const char *cuts=0, const char* wgtVarName=0); 
-  RooDataSet(const char *name, const char *title, TTree *tree, const RooArgSet& vars,
+  RooDataSet(std::string_view name, std::string_view title, TTree *tree, const RooArgSet& vars,
 	     const RooFormulaVar& cutVar, const char* wgtVarName=0) ;  
-  
+
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooDataSet)
 
   RooDataSet(RooDataSet const & other, const char* newname=0) ;  
   virtual TObject* Clone(const char* newname = "") const override {
@@ -155,7 +159,7 @@ protected:
   // Cache copy feature is not publicly accessible
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0, 
 	                std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) override;
-  RooDataSet(const char *name, const char *title, RooDataSet *ntuple, 
+  RooDataSet(std::string_view name, std::string_view title, RooDataSet *ntuple, 
 	     const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange, std::size_t nStart, std::size_t nStop, Bool_t copyCache, const char* wgtVarName=0);
   
   RooArgSet addWgtVar(const RooArgSet& origVars, const RooAbsArg* wgtVar) ; 

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -18,6 +18,9 @@
 
 #include "RooAbsDataStore.h"
 #include "RunContext.h"
+
+#include "ROOT/RStringView.hxx"
+
 #include <vector>
 #include <list>
 #include <string>
@@ -35,20 +38,22 @@ public:
   RooTreeDataStore() ; 
   RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* wgtVarName=0) ; 
 
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooTreeDataStore)
+
   // Empty ctor
-  RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName=0) ;
   virtual RooAbsDataStore* clone(const char* newname=0) const { return new RooTreeDataStore(*this,newname) ; }
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const { return new RooTreeDataStore(*this,vars,newname) ; }
 
   // Ctors from TTree
-  RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ; 
-  RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ; 
+  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ; 
+  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ; 
 
   // Ctors from DataStore
-  RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName=0) ;
-  RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=0, const char* wgtVarName=0) ;
+  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName=0) ;
+  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=0, const char* wgtVarName=0) ;
 
-  RooTreeDataStore(const char *name, const char *title, RooAbsDataStore& tds, 
+  RooTreeDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds, 
 		   const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 		   Int_t nStart, Int_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
 
@@ -154,7 +159,7 @@ public:
 
   static Int_t _defTreeBufSize ;  
 
-  void createTree(const char* name, const char* title) ; 
+  void createTree(std::string_view name, std::string_view title) ; 
   TTree *_tree ;           // TTree holding the data points
   TTree *_cacheTree ;      //! TTree holding the cached function values
   const RooAbsArg* _cacheOwner ; //! Object owning cache contents

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -22,6 +22,8 @@
 #include "RooChangeTracker.h"
 #include "RooRealVar.h"
 
+#include "ROOT/RStringView.hxx"
+
 #include <list>
 #include <vector>
 #include <algorithm>
@@ -40,7 +42,10 @@ public:
   RooVectorDataStore() ; 
 
   // Empty ctor
-  RooVectorDataStore(const char* name, const char* title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooVectorDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName=0) ;
+
+  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooVectorDataStore)
+
   virtual RooAbsDataStore* clone(const char* newname=0) const override { return new RooVectorDataStore(*this,newname) ; }
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooVectorDataStore(*this,vars,newname) ; }
 
@@ -49,7 +54,7 @@ public:
   RooVectorDataStore(const RooVectorDataStore& other, const RooArgSet& vars, const char* newname=0) ;
 
 
-  RooVectorDataStore(const char *name, const char *title, RooAbsDataStore& tds, 
+  RooVectorDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds, 
 		     const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 		     std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
 

--- a/roofit/roofitcore/src/RooAbsCachedPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedPdf.cxx
@@ -223,12 +223,8 @@ RooAbsCachedPdf::PdfCacheElem::PdfCacheElem(const RooAbsCachedPdf& self, const R
   }
 
   // Create RooDataHist
-  TString hname = self.GetName() ;
-  hname.Append("_") ;
-  hname.Append(self.inputBaseName()) ;
-  hname.Append("_CACHEHIST") ;
-  hname.Append(self.cacheNameSuffix(orderedObs)) ;
-  hname.Append(self.histNameSuffix()) ;
+  auto hname = std::string(self.GetName()) + "_" + self.inputBaseName() + "_CACHEHIST"
+               + self.cacheNameSuffix(orderedObs).Data() + self.histNameSuffix().Data();
   _hist = new RooDataHist(hname,hname,orderedObs,self.binningName()) ;
   _hist->removeSelfFromDir() ;
 

--- a/roofit/roofitcore/src/RooAbsCachedReal.cxx
+++ b/roofit/roofitcore/src/RooAbsCachedReal.cxx
@@ -203,9 +203,7 @@ RooAbsCachedReal::FuncCacheElem::FuncCacheElem(const RooAbsCachedReal& self, con
   self.preferredObservableScanOrder(*nset2,orderedObs) ;
 
   // Create RooDataHist
-  TString hname = self.inputBaseName() ;
-  hname.Append("_CACHEHIST") ;
-  hname.Append(self.cacheNameSuffix(*nset2)) ;
+  auto hname = std::string(self.inputBaseName()) + "_CACHEHIST" + self.cacheNameSuffix(*nset2).Data();
 
   _hist = new RooDataHist(hname,hname,*nset2,self.binningName()) ;
   _hist->removeSelfFromDir() ;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -129,8 +129,11 @@ RooAbsData::RooAbsData()
 /// Constructor from a set of variables. Only fundamental elements of vars
 /// (RooRealVar,RooCategory etc) are stored as part of the dataset
 
-RooAbsData::RooAbsData(const char *name, const char *title, const RooArgSet& vars, RooAbsDataStore* dstore) :
-  TNamed(name,title), _vars("Dataset Variables"), _cachedVars("Cached Variables"), _dstore(dstore)
+RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooArgSet& vars, RooAbsDataStore* dstore) :
+  TNamed(TString{name},TString{title}),
+  _vars("Dataset Variables"),
+  _cachedVars("Cached Variables"),
+  _dstore(dstore)
 {
    if (dynamic_cast<RooTreeDataStore *>(dstore)) {
       storageType = RooAbsData::Tree;

--- a/roofit/roofitcore/src/RooAbsDataStore.cxx
+++ b/roofit/roofitcore/src/RooAbsDataStore.cxx
@@ -51,8 +51,8 @@ RooAbsDataStore::RooAbsDataStore()
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-RooAbsDataStore::RooAbsDataStore(const char* name, const char* title, const RooArgSet& vars) : 
-  TNamed(name,title)
+RooAbsDataStore::RooAbsDataStore(std::string_view name, std::string_view title, const RooArgSet& vars) : 
+  TNamed(TString{name},TString{title})
 {
   // clone the fundamentals of the given data set into internal buffer
   _vars.add(vars) ;

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -60,7 +60,9 @@ RooCompositeDataStore::RooCompositeDataStore() : _indexCat(0), _curStore(0), _cu
 ////////////////////////////////////////////////////////////////////////////////
 /// Convert map by label to map by index for more efficient internal use
 
-RooCompositeDataStore::RooCompositeDataStore(const char* name, const char* title, const RooArgSet& vars, RooCategory& indexCat,map<std::string,RooAbsDataStore*> inputData) :
+RooCompositeDataStore::RooCompositeDataStore(
+        std::string_view name, std::string_view title,
+        const RooArgSet& vars, RooCategory& indexCat,map<std::string,RooAbsDataStore*> inputData) :
   RooAbsDataStore(name,title,RooArgSet(vars,indexCat)), _indexCat(&indexCat), _curStore(0), _curIndex(0), _ownComps(kFALSE)
 {
   for (const auto& iter : inputData) {

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -105,7 +105,7 @@ RooDataHist::RooDataHist()
 /// construct a RooThresholdCategory of the real dimension to be binned variably.
 /// Set the thresholds at the desired bin boundaries, and construct the
 /// data hist as a function of the threshold category instead of the real variable.
-RooDataHist::RooDataHist(const char *name, const char *title, const RooArgSet& vars, const char* binningName) : 
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const char* binningName) : 
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
@@ -142,7 +142,7 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgSet& v
 /// If the constructed data hist has less dimensions that in source data collection,
 /// all missing dimensions will be projected.
 
-RooDataHist::RooDataHist(const char *name, const char *title, const RooArgSet& vars, const RooAbsData& data, Double_t wgt) :
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsData& data, Double_t wgt) :
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
@@ -168,7 +168,7 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgSet& v
 /// The RooArgList 'vars' defines the dimensions of the histogram. 
 /// The ranges and number of bins are taken from the input histogram and must be the same in all histograms
 
-RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& vars, RooCategory& indexCat, 
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, 
 			 map<string,TH1*> histMap, Double_t wgt) :
   RooAbsData(name,title,RooArgSet(vars,&indexCat))
 {
@@ -193,7 +193,7 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& 
 /// The RooArgList 'vars' defines the dimensions of the histogram. 
 /// The ranges and number of bins are taken from the input histogram and must be the same in all histograms
 
-RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& vars, RooCategory& indexCat, 
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, 
 			 map<string,RooDataHist*> dhistMap, Double_t wgt) :
   RooAbsData(name,title,RooArgSet(vars,&indexCat))
 {
@@ -215,7 +215,7 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& 
 /// and number of bins are taken from the input histogram, and the corresponding
 /// values are set accordingly on the arguments in 'vars'
 
-RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& vars, const TH1* hist, Double_t wgt) :
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const TH1* hist, Double_t wgt) :
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
@@ -271,7 +271,7 @@ RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& 
 /// <tr><td> Import(map<string,TH1*>&) <td> As above, but allows specification of many imports in a single operation
 ///                              
 
-RooDataHist::RooDataHist(const char *name, const char *title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 			 const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8) :
   RooAbsData(name,title,RooArgSet(vars,(RooAbsArg*)RooCmdConfig::decodeObjOnTheFly("RooDataHist::RooDataHist", "IndexCat",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)))
 {
@@ -839,7 +839,7 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
 /// For most uses the RooAbsData::reduce() wrapper function, which uses this constructor, 
 /// is the most convenient way to create a subset of an existing data  
 
-RooDataHist::RooDataHist(const char* name, const char* title, RooDataHist* h, const RooArgSet& varSubset, 
+RooDataHist::RooDataHist(std::string_view name, std::string_view title, RooDataHist* h, const RooArgSet& varSubset, 
 			 const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) :
   RooAbsData(name,title,varSubset)
 {

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -217,7 +217,7 @@ RooDataSet::RooDataSet() : _wgtVar(0)
 /// </table>
 ///
 
-RooDataSet::RooDataSet(const char* name, const char* title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8)  :
   RooAbsData(name,title,RooArgSet(vars,(RooAbsArg*)RooCmdConfig::decodeObjOnTheFly("RooDataSet::RooDataSet", "IndexCat",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)))
 {
@@ -622,7 +622,7 @@ RooDataSet::RooDataSet(const char* name, const char* title, const RooArgSet& var
 /// Constructor of an empty data set from a RooArgSet defining the dimensions
 /// of the data space.
 
-RooDataSet::RooDataSet(const char *name, const char *title, const RooArgSet& vars, const char* wgtVarName) :
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
 //   cout << "RooDataSet::ctor(" << this << ") storageType = " << ((defaultStorageType==Tree)?"Tree":"Vector") << endl ;
@@ -654,7 +654,7 @@ RooDataSet::RooDataSet(const char *name, const char *title, const RooArgSet& var
 /// subset of an existing data
 ///
 
-RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset, 
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet *dset, 
 		       const RooArgSet& vars, const char *cuts, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -695,7 +695,7 @@ RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset,
 /// uses this constructor, is the most convenient way to create a
 /// subset of an existing data
 
-RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset, 
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet *dset, 
 		       const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -735,7 +735,7 @@ RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset,
 /// operating exclusively and directly on the data set dimensions, the equivalent
 /// constructor with a string based cut expression is recommended.
 
-RooDataSet::RooDataSet(const char *name, const char *title, TTree *theTree,
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, TTree *theTree,
     const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -783,7 +783,7 @@ RooDataSet::RooDataSet(const char *name, const char *title, TTree *theTree,
 /// If other expressions are needed, such as intermediate formula objects, use
 /// RooDataSet::RooDataSet(const char*,const char*,TTree*,const RooArgSet&,const RooFormulaVar&,const char*)
 /// \param[in] wgtVarName Name of the variable in `vars` that represents an event weight.
-RooDataSet::RooDataSet(const char* name, const char* title, TTree* theTree,
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, TTree* theTree,
     const RooArgSet& vars, const char* cuts, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -824,7 +824,7 @@ RooDataSet::RooDataSet(RooDataSet const & other, const char* newname) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Protected constructor for internal use only
 
-RooDataSet::RooDataSet(const char *name, const char *title, RooDataSet *dset, 
+RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet *dset, 
 		       const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 		       std::size_t nStart, std::size_t nStop, Bool_t copyCache, const char* wgtVarName) :
   RooAbsData(name,title,vars)
@@ -974,16 +974,17 @@ RooDataSet::~RooDataSet()
 
 RooDataHist* RooDataSet::binnedClone(const char* newName, const char* newTitle) const 
 {
-  TString title, name ;
+  std::string title;
+  std::string name;
   if (newName) {
     name = newName ;
   } else {
-    name = Form("%s_binned",GetName()) ;
+    name = std::string(GetName()) + "_binned" ;
   }
   if (newTitle) {
     title = newTitle ;
   } else {
-    title = Form("%s_binned",GetTitle()) ;
+    name = std::string(GetTitle()) + "_binned" ;
   }
 
   return new RooDataHist(name,title,*get(),*this) ;

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -106,7 +106,7 @@ RooTreeDataStore::RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -127,7 +127,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -148,7 +148,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, TTree& t, const char* selExpr, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const char* selExpr, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -176,7 +176,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -197,7 +197,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const RooArgSet& vars, const RooAbsDataStore& ads, const char* selExpr, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& ads, const char* selExpr, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -226,7 +226,7 @@ RooTreeDataStore::RooTreeDataStore(const char* name, const char* title, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(const char *name, const char *title, RooAbsDataStore& tds,
+RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds,
 			 const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 			 Int_t nStart, Int_t nStop, Bool_t /*copyCache*/, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)), _defCtor(kFALSE),
@@ -242,7 +242,7 @@ RooTreeDataStore::RooTreeDataStore(const char *name, const char *title, RooAbsDa
   // Protected constructor for internal use only
   _tree = 0 ;
   _cacheTree = 0 ;
-  createTree(makeTreeName().c_str(), title);
+  createTree(makeTreeName(), title);
 
   // Deep clone cutVar and attach clone to this dataset
   RooFormulaVar* cloneVar = 0;
@@ -395,7 +395,7 @@ RooTreeDataStore::~RooTreeDataStore()
 void RooTreeDataStore::initialize()
 {
   // Recreate (empty) cache tree
-  createTree(makeTreeName().c_str(), GetTitle());
+  createTree(makeTreeName(), GetTitle());
 
   // Attach each variable to the dataset
   for (auto var : _varsww) {
@@ -411,10 +411,10 @@ void RooTreeDataStore::initialize()
 /// Create TTree object that lives in memory, independent of current
 /// location of gDirectory
 
-void RooTreeDataStore::createTree(const char* name, const char* title)
+void RooTreeDataStore::createTree(std::string_view name, std::string_view title)
 {
   if (!_tree) {
-    _tree = new TTree(name,title);
+    _tree = new TTree(TString{name},TString{title});
     _tree->ResetBit(kCanDelete);
     _tree->ResetBit(kMustCleanup);
     _tree->SetDirectory(nullptr);
@@ -432,7 +432,7 @@ void RooTreeDataStore::createTree(const char* name, const char* title)
   }
 
   if (!_cacheTree) {
-    _cacheTree = new TTree((std::string(name) + "_cacheTree").c_str(), title);
+    _cacheTree = new TTree(TString{name} + "_cacheTree", TString{title});
     _cacheTree->SetDirectory(0) ;
     gDirectory->RecursiveRemove(_cacheTree) ;
   }

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -75,7 +75,7 @@ RooVectorDataStore::RooVectorDataStore() :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooVectorDataStore::RooVectorDataStore(const char* name, const char* title, const RooArgSet& vars, const char* wgtVarName) :
+RooVectorDataStore::RooVectorDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _varsww(vars),
   _wgtVar(weightVar(vars,wgtVarName)),
@@ -285,7 +285,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooVectorDataStore::RooVectorDataStore(const char *name, const char *title, RooAbsDataStore& tds, 
+RooVectorDataStore::RooVectorDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds, 
 			 const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 			 std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName) :
 

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -1040,7 +1040,8 @@ RooAbsData * AsymptoticCalculator::GenerateCountingAsimovData(RooAbsPdf & pdf, c
        icat = channelCat->getCurrentIndex();
     }
 
-    RooDataSet *ret = new RooDataSet(TString::Format("CountingAsimovData%d",icat),TString::Format("CountingAsimovData%d",icat), obs);
+    RooDataSet *ret = new RooDataSet(std::string("CountingAsimovData") + std::to_string(icat),
+                                     std::string("CountingAsimovData") + std::to_string(icat), obs);
     ret->add(obs);
     return ret;
 }
@@ -1068,7 +1069,8 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovDataSinglePdf(const RooAbsPdf &
    RooDataSet* asimovData = 0;
    if (channelCat) {
       int icat = channelCat->getCurrentIndex();
-      asimovData = new RooDataSet(TString::Format("AsimovData%d",icat),TString::Format("combAsimovData%d",icat),
+      asimovData = new RooDataSet(std::string("AsimovData") + std::to_string(icat),
+                                  std::string("combAsimovData") + std::to_string(icat),
                                   RooArgSet(obsAndWeight,*channelCat),RooFit::WeightVar(weightVar));
    }
    else

--- a/roofit/roostats/src/HybridCalculatorOriginal.cxx
+++ b/roofit/roostats/src/HybridCalculatorOriginal.cxx
@@ -256,7 +256,7 @@ HybridResult* HybridCalculatorOriginal::Calculate(TH1& data, unsigned int nToys,
 {
 
    /// convert data TH1 histogram to a RooDataHist
-   TString dataHistName = GetName(); dataHistName += "_roodatahist";
+   auto dataHistName = std::string(GetName()) + "_roodatahist";
    RooDataHist dataHist(dataHistName,"Data distribution as RooDataHist converted from TH1",*fObservables,&data);
 
    HybridResult* result = Calculate(dataHist,nToys,usePriors);

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -237,7 +237,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
 
    const RooArgSet *aset = GetFitInfo();
    if (aset != NULL) {
-      RooDataSet *dset = new RooDataSet(NULL, NULL, *aset);
+      RooDataSet *dset = new RooDataSet("", "", *aset);
       dset->add(*aset);
       res->SetFitInfo( dset );
    }


### PR DESCRIPTION
In modern C++, the `std::string_view` can be used instead of C-style
strings (`const char*`) to pass strings around.

The motivation to make this change now and for the data-related RooFit
classes only is pyROOT. With cppyy, Python strings get converted
to `std::strings` if you pass them to a templated function. This is
problematic if the templated function is forwarding the arguments to a
function that accepts a C-style string. In most cases, cppyy will just
tell you that the arguments don't match the function signature, but
there are corner cases in which an uninterpretable stack trace is
created. Here is a reproducer for that, inspired by the
RooAbsDataHelper that cannot be used from pyROOT without this commit:

```Python
import ROOT

ROOT.gInterpreter.ProcessLine("""

struct MyClass {

  std::shared_ptr<RooAbsData> _dataset;

  template<typename... Args_t>
  MyClass(Args_t&&... args)
  : _dataset{ new RooDataSet(std::forward<Args_t>(args)...) }
  {
    _dataset->Print();
  }

};

""")

x = ROOT.RooRealVar("x", "x", -5., 5.)
y = ROOT.RooRealVar("y", "y", -50., 50.)

argSet = ROOT.RooArgSet(x, y)
helper = ROOT.MyClass("dataset","Title of dataset", argSet)
```

This change should not break much user code, because a
`std::string_view` can also be implicitely constructed from a C-style
string or a TString.

There is one problem if one passed a `nullptr` before, a
`std::string_view` can't be constructed from a `nullptr`. But a
`nullptr` for name and title is a mistake anyway, so it can be expected
from the users the fix these error that are caught at compile-time.

The other backwards incompatibility is that for builds with the C++14
standard, the `TString` to `string_view` conversion does not work.
However, this problem is solved by templated constructors that take
`ROOT::Internal::TStringView` instead.

Here is some code to test that the `RooDataSetHelper` doesn't work without this PR, but works with the PR:
```Python
import ROOT

ROOT.ROOT.EnableImplicitMT()

d = ROOT.RDataFrame(2000000)
dd = d.Define("x", "gRandom->Uniform(-5.,  5.)") \
      .Define("y", "gRandom->Gaus(1., 3.)")

x = ROOT.RooRealVar("x", "x", -5., 5.)
y = ROOT.RooRealVar("y", "y", -50., 50.)
x.setBins(10)
y.setBins(20)

rdhMaker = ROOT.RooDataSetHelper("dataset","Title of dataset", ROOT.RooArgSet(x, y))
rooDataSet = dd.Book(ROOT.std.move(rdhMaker), ("x", "y"))
rooDataSet.GetPtr().Print()
```
