### PR TITLE
[RF] Tweak RooAbsReal::evaluateSpan.

### DIFF
--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4826,7 +4826,7 @@ RooSpan<double> RooAbsReal::evaluateSpan(RooBatchCompute::RunContext& evalData, 
   std::size_t dataSize = 1;
 
   for (auto absArgServer : servers()) {
-    if (absArgServer->IsA()->InheritsFrom(RooAbsReal::Class())) {
+    if (absArgServer->IsA()->InheritsFrom(RooAbsReal::Class()) && absArgServer->isValueServer(*this)) {
       auto server = static_cast<RooAbsReal*>(absArgServer);
       ourServers.push_back({server,
           server->getValues(evalData, normSet),

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4814,81 +4814,64 @@ void RooAbsReal::setParameterizeIntegral(const RooArgSet& paramVars)
 /// \return     Span pointing to the results. The memory is owned by `evalData`.
 RooSpan<double> RooAbsReal::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
 
-  // Find leaves of the computation graph. Assign known data values to these.
-  //
-  // We can't use RooAbsArg::leafNodeServerList to find all leaves, sometimes a
-  // RooAbsReal sits on top of a leaf in the computation graph but it doesn't
-  // depend on it's values. The example here is a RooRealIntegral, which sets
-  // the leaf values itself to integrate over them. That's why we only add the
-  // parameters and observables here.
-  RooArgSet allLeafs;
-  RooArgSet parameters;
-  RooArgSet observables;
-  getParameters(normSet, parameters);
-  getObservables(normSet, observables);
-  allLeafs.add(parameters);
-  allLeafs.add(observables);
+  // Find all servers that are serving real numbers to us, retrieve their batch data,
+  // and switch them into "always clean" operating mode, so they return always the last-set value.
+  struct ServerData {
+    RooAbsReal* server;
+    RooSpan<const double> batch;
+    double oldValue;
+    RooAbsArg::OperMode oldOperMode;
+  };
+  std::vector<ServerData> ourServers;
+  std::size_t dataSize = 1;
 
-  std::vector<RooAbsRealLValue*> settableLeaves;
-  std::vector<RooSpan<const double>> leafValues;
-  std::vector<double> oldLeafValues;
-
-  for (auto item : allLeafs) {
-    if (!item->IsA()->InheritsFrom(RooAbsRealLValue::Class()))
-      continue;
-
-    auto leaf = static_cast<RooAbsRealLValue*>(item);
-
-    settableLeaves.push_back(leaf);
-    oldLeafValues.push_back(leaf->getVal());
-
-    auto knownLeaf = evalData.spans.find(leaf);
-    if (knownLeaf != evalData.spans.end()) {
-      // Data are already known
-      leafValues.push_back(knownLeaf->second);
-    } else {
-      auto result = leaf->getValues(evalData, normSet);
-      leafValues.push_back(result);
+  for (auto absArgServer : servers()) {
+    if (absArgServer->IsA()->InheritsFrom(RooAbsReal::Class())) {
+      auto server = static_cast<RooAbsReal*>(absArgServer);
+      ourServers.push_back({server,
+          server->getValues(evalData, normSet),
+          server->getVal(normSet),
+          server->operMode()});
+      // Prevent the server from evaluating; just return cached result, which we will side load:
+      server->setOperMode(RooAbsArg::AClean);
+      dataSize = std::max(dataSize, ourServers.back().batch.size());
     }
   }
 
-  size_t dataSize=1;
-  for (auto& i:leafValues) {
-    dataSize=std::max(dataSize, i.size());
-  }
+
+  // Make sure that we restore all state when we finish:
+  struct RestoreStateRAII {
+    RestoreStateRAII(std::vector<ServerData>& servers) :
+      _servers{servers} { }
+
+    ~RestoreStateRAII() {
+      for (auto& serverData : _servers) {
+        serverData.server->setCachedValue(serverData.oldValue, true);
+        serverData.server->setOperMode(serverData.oldOperMode);
+      }
+    }
+
+    std::vector<ServerData>& _servers;
+  } restoreState{ourServers};
+
 
   // Advising to implement the batch interface makes only sense if the batch was not a scalar.
   // Otherwise, there would be no speedup benefit.
-  if(dataSize > 1) {
-    if (RooMsgService::instance().isActive(this, RooFit::FastEvaluations, RooFit::INFO)) {
-      coutI(FastEvaluations) << "The class " << IsA()->GetName() << " does not implement the faster batch evaluation interface."
-          << " Consider requesting or implementing it to benefit from a speed up." << std::endl;
-    }
+  if(dataSize > 1 && RooMsgService::instance().isActive(this, RooFit::FastEvaluations, RooFit::INFO)) {
+    coutI(FastEvaluations) << "The class " << IsA()->GetName() << " does not implement the faster batch evaluation interface."
+        << " Consider requesting or implementing it to benefit from a speed up." << std::endl;
   }
 
+
+  // For each event, write temporary values into our servers' caches, and run a single-value computation.
   auto outputData = evalData.makeBatch(this, dataSize);
 
-  {
-    // Side track all caching that RooFit might think is necessary.
-    // When used with batch computations, we depend on computation
-    // graphs actually evaluating correctly, instead of having
-    // pre-calculated values side-loaded into nodes event-per-event.
-    RooHelpers::DisableCachingRAII disableCaching(inhibitDirty());
-
-    // For each event, assign values to the leaves, and run the single-value computation.
-    for (std::size_t i=0; i < outputData.size(); ++i) {
-      for (unsigned int j=0; j < settableLeaves.size(); ++j) {
-        if (leafValues[j].size() > i)
-          settableLeaves[j]->setVal(leafValues[j][i], evalData.rangeName);
-      }
-
-      outputData[i] = evaluate();
+  for (std::size_t i=0; i < outputData.size(); ++i) {
+    for (auto& serv : ourServers) {
+      serv.server->setCachedValue(serv.batch[std::min(i, serv.batch.size()-1)], /*notifyClients=*/ false);
     }
-  }
 
-  // Reset values
-  for (unsigned int j=0; j < settableLeaves.size(); ++j) {
-    settableLeaves[j]->setVal(oldLeafValues[j]);
+    outputData[i] = evaluate();
   }
 
   return outputData;

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -27,6 +27,9 @@
 // ROOT-10668: Asympt. correct errors don't work when title and name differ
 TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
 {
+  auto& msg = RooMsgService::instance();
+  msg.setGlobalKillBelow(RooFit::WARNING);
+
   RooRealVar x("x", "xxx", 0, 0, 10);
   RooRealVar a("a", "aaa", 2, 0, 10);
   // Cannot play with RooAbsPdf, since abstract.
@@ -44,10 +47,10 @@ TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
   ASSERT_NE(weightedData.weight(), 1);
 
   a = 1.2;
-  auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true));
+  auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true), RooFit::PrintLevel(-1));
   const double aError = a.getError();
   a = 1.2;
-  auto result2 = pdf.fitTo(weightedData, RooFit::Save());
+  auto result2 = pdf.fitTo(weightedData, RooFit::Save(), RooFit::PrintLevel(-1));
 
   EXPECT_TRUE(result->isIdentical(*result2)) << "Fit results should be very similar.";
   EXPECT_GT(aError, a.getError()*2.) << "Asymptotically correct errors should be significantly larger.";
@@ -70,6 +73,7 @@ TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
 TEST(RooAbsPdf, ConditionalFitBatchMode)
 {
   using namespace RooFit;
+  constexpr bool verbose = false;
 
   auto makeFakeDataXY = []() {
     RooRealVar x("x", "x", 0, 10);
@@ -121,7 +125,7 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
               PrintLevel(-1),
               BatchMode(batchMode)
          ));
-      fitResults.back()->Print();
+      if (verbose) fitResults.back()->Print();
     }
 
     EXPECT_TRUE(fitResults[1]->isIdentical(*fitResults[0]));
@@ -134,6 +138,8 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
 TEST(RooAbsPdf, MultiRangeFit)
 {
   using namespace RooFit;
+  auto& msg = RooMsgService::instance();
+  msg.setGlobalKillBelow(RooFit::WARNING);
 
   RooRealVar x("x","x",-10,10);
 

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -74,6 +74,8 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
 {
   using namespace RooFit;
   constexpr bool verbose = false;
+  auto& msg = RooMsgService::instance();
+  msg.getStream(1).removeTopic(RooFit::Minimization);
 
   auto makeFakeDataXY = []() {
     RooRealVar x("x", "x", 0, 10);

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -129,7 +129,7 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
     }
 
     EXPECT_TRUE(fitResults[1]->isIdentical(*fitResults[0]));
-    EXPECT_TRUE(hijack.str().empty() != expectFastEvaluationsWarnings[iMean]);
+    EXPECT_TRUE(hijack.str().empty() != expectFastEvaluationsWarnings[iMean]) << "Stream contents: " << hijack.str();
     ++iMean;
   }
 }


### PR DESCRIPTION
evaluateSpan() is a fallback for classes that don't implement an optimised
version of the batch computation function. It used to visit the entire
subtree in single-value mode to compute a batch of values.
Using RooAbsReal::writeToCache(), one should be able to get away with
visiting only the next level. This should speed up computations, because
less nodes are visited.

Also: Silence a test that was printing useless things.