### PR TITLE
Disable the __CUDACC__ macro definition with latest Visual Studio

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -802,7 +802,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
-#if (_MSC_VER >= 1926)
+#if (_MSC_VER >= 1926 AND _MSC_VER <= 1928)
     // FIXME: Silly workaround for cling not being able to parse the STL
     //        headers anymore after the update of Visual Studio v16.7.0
     //        To be checked/removed after the upgrade of LLVM & Clang

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -802,7 +802,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
-#if (_MSC_VER >= 1926 AND _MSC_VER <= 1928)
+#if (_MSC_VER >= 1926 && _MSC_VER <= 1928)
     // FIXME: Silly workaround for cling not being able to parse the STL
     //        headers anymore after the update of Visual Studio v16.7.0
     //        To be checked/removed after the upgrade of LLVM & Clang

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -802,11 +802,11 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
-#if (_MSC_VER >= 1926 && _MSC_VER <= 1928)
+#if (_MSC_VER >= 1926)
     // FIXME: Silly workaround for cling not being able to parse the STL
     //        headers anymore after the update of Visual Studio v16.7.0
     //        To be checked/removed after the upgrade of LLVM & Clang
-    PPOpts.addMacroDef("__CUDACC__");
+    PPOpts.addMacroDef("_HAS_CONDITIONAL_EXPLICIT=0");
 #endif
 #endif
 

--- a/interpreter/llvm/src/tools/clang/include/clang/AST/ExprCXX.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/AST/ExprCXX.h
@@ -4741,6 +4741,8 @@ public:
       : ExplicitCastExpr(BuiltinBitCastExprClass, T, VK, CK, SrcExpr, 0,
                          DstType),
         KWLoc(KWLoc), RParenLoc(RParenLoc) {}
+  BuiltinBitCastExpr(EmptyShell Empty)
+      : ExplicitCastExpr(BuiltinBitCastExprClass, Empty, 0) {}
 
   SourceLocation getBeginLoc() const LLVM_READONLY { return KWLoc; }
   SourceLocation getEndLoc() const LLVM_READONLY { return RParenLoc; }

--- a/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/interpreter/llvm/src/tools/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1863,6 +1863,9 @@ namespace serialization {
       /// A CXXFunctionalCastExpr record.
       EXPR_CXX_FUNCTIONAL_CAST,
 
+      /// A BuiltinBitCastExpr record.
+      EXPR_BUILTIN_BIT_CAST,
+
       /// A UserDefinedLiteral record.
       EXPR_USER_DEFINED_LITERAL,
 

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -3223,6 +3223,11 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
                        /*PathSize*/ Record[ASTStmtReader::NumExprFields]);
       break;
 
+    case EXPR_BUILTIN_BIT_CAST:
+      assert(Record[ASTStmtReader::NumExprFields] == 0 && "Wrong PathSize!");
+      S = new (Context) BuiltinBitCastExpr(Empty);
+      break;
+
     case EXPR_USER_DEFINED_LITERAL:
       S = UserDefinedLiteral::CreateEmpty(
           Context, /*NumArgs=*/Record[ASTStmtReader::NumExprFields], Empty);

--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -1455,6 +1455,7 @@ void ASTStmtWriter::VisitBuiltinBitCastExpr(BuiltinBitCastExpr *E) {
   VisitExplicitCastExpr(E);
   Record.AddSourceLocation(E->getBeginLoc());
   Record.AddSourceLocation(E->getEndLoc());
+  Code = serialization::EXPR_BUILTIN_BIT_CAST;
 }
 
 void ASTStmtWriter::VisitUserDefinedLiteral(UserDefinedLiteral *E) {

--- a/interpreter/llvm/src/tools/clang/test/PCH/builtin-bit-cast.cpp
+++ b/interpreter/llvm/src/tools/clang/test/PCH/builtin-bit-cast.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -emit-pch -o %t %s
+// RUN: %clang_cc1 -include-pch %t -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+#ifndef HEADER
+#define HEADER
+
+template <class T, class U>
+constexpr T BuiltinBitCastWrapper(const U &Arg) {
+  return __builtin_bit_cast(T, Arg);
+}
+
+#else
+
+int main() {
+  return BuiltinBitCastWrapper<int>(0);
+}
+
+#endif


### PR DESCRIPTION
Disable the silly workaround for cling not being able to parse the STL headers anymore after the update of Visual Studio v16.7.0. Works now with the upgrade of LLVM and Visual Studio 16.10.3.
This workaround had side effects when trying to use code supporting CUDA (e.g. boost) inside the interpreter.
