### PR TITLE
TGLAxisPainter silently modified the histogram's Z axis parameters

### DIFF
--- a/graf3d/gl/src/TGLAxisPainter.cxx
+++ b/graf3d/gl/src/TGLAxisPainter.cxx
@@ -571,7 +571,6 @@ void TGLAxisPainterBox::DrawAxis3D(TGLRnrCtx &rnrCtx)
    // Z axis
    //
    // tick-mark vector = 10 pixels left
-   fAxis[2]->SetTickLength(1.); // leave this relative factor neutral
    TGLVertex3 worldRef(fAxisTitlePos[2].X(), fAxisTitlePos[2].Y(), fAxisTitlePos[2].Z());
    RefTMOff(0) = rnrCtx.RefCamera().ViewportDeltaToWorld(worldRef, -10, 0, &mm);
    SetTMNDim(1);
@@ -621,9 +620,6 @@ void TGLAxisPainterBox::PlotStandard(      TGLRnrCtx      &rnrCtx,
    fAxis[0] = histo->GetXaxis();
    fAxis[1] = histo->GetYaxis();
    fAxis[2] = histo->GetZaxis();
-   // fAxis[2]->SetTitle("Z");
-   // fAxis[2]->SetLabelSize(0.04);
-   // fAxis[2]->SetTitleSize(0.05);
 
    Double_t sx = (bbox.XMax() - bbox.XMin()) / (fAxis[0]->GetXmax() - fAxis[0]->GetXmin());
    Double_t sy = (bbox.YMax() - bbox.YMin()) / (fAxis[1]->GetXmax() - fAxis[1]->GetXmin());


### PR DESCRIPTION
Tick length set to a fixed value 1.

The Z axis tick marks length was then wrong when drawn in a 2D canvas
This was discovered by: https://github.com/root-project/root/issues/8618

