### PR TITLE
Change naming scheme of distributed snapshot

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -218,8 +218,7 @@ class BaseBackend(ABC):
             # rdf_range = rdf.Range(current_range.start, current_range.end)
 
             # Output of the callable
-            resultptr_list = computation_graph_callable(
-                rdf, rdf_range=current_range)
+            resultptr_list = computation_graph_callable(rdf, current_range.id, rdf_range=current_range)
 
             mergeables = [
                 resultptr  # Here resultptr is already the result value

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -79,7 +79,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         generator = ComputationGraphGenerator.ComputationGraphGenerator(
             node.proxied_node)
         mapper_func = generator.get_callable()
-        values = mapper_func(t)
+        values = mapper_func(t, 0)
         nodes = generator.get_action_nodes()
 
         reqd_order = [1, 3, 2, 2, 3, 2]
@@ -116,7 +116,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         generator = ComputationGraphGenerator.ComputationGraphGenerator(
             node.proxied_node)
         mapper_func = generator.get_callable()
-        values = mapper_func(t)
+        values = mapper_func(t, 0)
         nodes = generator.get_action_nodes()
 
         reqd_order = [1, 2, 2, 2, 3, 2]


### PR DESCRIPTION
Change the naming scheme of distributed Snapshot in preparation of the removal of `Range` operation.