### PR TITLE
RCanvas - provide enums for different style attributes

### DIFF
--- a/graf2d/gpadv7/CMakeLists.txt
+++ b/graf2d/gpadv7/CMakeLists.txt
@@ -23,6 +23,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTGpadv7
     ROOT/RAttrBorder.hxx
     ROOT/RAttrLine.hxx
     ROOT/RAttrFill.hxx
+    ROOT/RAttrFont.hxx
     ROOT/RAttrMarker.hxx
     ROOT/RAttrMargins.hxx
     ROOT/RAttrText.hxx

--- a/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFill.hxx
@@ -29,10 +29,21 @@ class RAttrFill : public RAttrAggregation {
 
 public:
 
-   RAttrValue<RColor>  color{this, "color", RColor::kBlack};  ///<! fill color
-   RAttrValue<int>     style{this, "style", 1};               ///<! fill style
+   enum EStyle {
+      kHollow = 0,
+      kNone = 0,
+      kSolid = 1001,
+      k3001 = 3001, k3002 = 3002, k3003 = 3003, k3004 = 3004, k3005 = 3005,
+      k3006 = 3006, k3007 = 3007, k3008 = 3008, k3009 = 3009, k3010 = 3010,
+      k3011 = 3011, k3012 = 3012, k3013 = 3013, k3014 = 3014, k3015 = 3015,
+      k3016 = 3016, k3017 = 3017, k3018 = 3018, k3019 = 3019, k3020 = 3020,
+      k3021 = 3021, k3022 = 3022, k3023 = 3023, k3024 = 3024, k3025 = 3025
+   };
 
-   RAttrFill(RColor _color, int _style) : RAttrFill()
+   RAttrValue<RColor> color{this, "color", RColor::kBlack};  ///<! fill color
+   RAttrValue<EStyle> style{this, "style", kHollow};         ///<! fill style
+
+   RAttrFill(RColor _color, EStyle _style) : RAttrFill()
    {
       color = _color;
       style = _style;

--- a/graf2d/gpadv7/inc/ROOT/RAttrFont.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrFont.hxx
@@ -1,0 +1,110 @@
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_RAttrFont
+#define ROOT7_RAttrFont
+
+#include <ROOT/RAttrAggregation.hxx>
+#include <ROOT/RAttrValue.hxx>
+
+namespace ROOT {
+namespace Experimental {
+
+/** \class RAttrFont
+\ingroup GpadROOT7
+\brief A font attributes, used together with text attributes
+\author Sergey Linev <s.linev@gsi.de>
+\date 2021-06-28
+\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
+*/
+
+class RAttrFont : public RAttrAggregation {
+
+   R__ATTR_CLASS(RAttrFont, "font");
+
+public:
+
+   RAttrValue<std::string> family{this, "family"};  ///<! font family, corresponds to css font-familty attribute
+   RAttrValue<std::string> style{this, "style"};    ///<! font style, corresponds to css font-style attribute
+   RAttrValue<std::string> weight{this, "weight"};  ///<! font weight, corresponds to css font-weight attribute
+
+   enum EFont {
+      kTimesItalic = 1,
+      kTimesBold = 2,
+      kTimesBoldItalic = 3,
+      kArial = 4,
+      kArialOblique = 5,
+      kArialBold = 6,
+      kArialBoldOblique = 7,
+      kCourier = 8,
+      kCourierOblique = 9,
+      kCourierBold = 10,
+      kCourierBoldOblique = 11,
+      // kSymbol = 12, // not supported by web browsers
+      kTimes = 13,
+      // kWingdings = 14,
+      // kSymbolItalic = 15, // not supported by web browsers
+      kVerdana = 16,
+      kVerdanaItalic = 17,
+      kVerdanaBold = 18,
+      kVerdanaBoldItalic = 19
+   };
+
+   ///Set text font by id as usually handled in the ROOT (without precision), number should be between 1 and 15
+   RAttrFont &SetFont(EFont font)
+   {
+      switch(font) {
+      case kTimesItalic: family = "Times New Roman"; style = "italic"; break;
+      case kTimesBold: family = "Times New Roman"; weight = "bold"; break;
+      case kTimesBoldItalic: family = "Times New Roman"; style = "italic"; weight = "bold"; break;
+      case kArial: family = "Arial"; break;
+      case kArialOblique: family = "Arial"; style = "oblique"; break;
+      case kArialBold: family = "Arial"; weight = "bold"; break;
+      case kArialBoldOblique: family = "Arial"; style = "oblique"; weight = "bold"; break;
+      case kCourier: family = "Courier New"; break;
+      case kCourierOblique: family = "Courier New"; style = "oblique"; break;
+      case kCourierBold: family = "Courier New"; weight = "bold"; break;
+      case kCourierBoldOblique: family = "Courier New"; style = "oblique"; weight = "bold"; break;
+      // case kSymbol: family = "Symbol"; break;
+      case kTimes: family = "Times New Roman"; break;
+      // case kWingdings: family = "Wingdings"; break;
+      // case kSymbolItalic: family = "Symbol"; style = "italic"; break;
+      case kVerdana: family = "Verdana";  break;
+      case kVerdanaItalic: family = "Verdana";  style = "italic";  break;
+      case kVerdanaBold: family = "Verdana";  weight = "bold"; break;
+      case kVerdanaBoldItalic: family = "Verdana";  weight = "bold"; style = "italic"; break;
+      }
+      return *this;
+   }
+
+   /// assign font id, setting all necessary properties
+   RAttrFont &operator=(EFont id) { SetFont(id); return *this; }
+
+   friend bool operator==(const RAttrFont &font, EFont id) { RAttrFont font2; font2.SetFont(id); return font == font2; }
+
+   /// Returns full font name including weight and style
+   std::string GetFullName() const
+   {
+      std::string name = family, s = style, w = weight;
+      if (!w.empty()) {
+         name += " ";
+         name += w;
+      }
+      if (!s.empty()) {
+         name += " ";
+         name += s;
+      }
+      return name;
+   }
+
+};
+
+} // namespace Experimental
+} // namespace ROOT
+
+#endif

--- a/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrLine.hxx
@@ -29,11 +29,30 @@ class RAttrLine : public RAttrAggregation {
 
 public:
 
+   enum EStyle {
+      kNone = 0,
+      kSolid = 1,
+      kDashed = 2,
+      kDotted = 3,
+      kDashDotted = 4,
+      kStyle1 = 1,
+      kStyle2 = 2,
+      kStyle3 = 3,
+      kStyle4 = 4,
+      kStyle5 = 5,
+      kStyle6 = 6,
+      kStyle7 = 7,
+      kStyle8 = 8,
+      kStyle9 = 9,
+      kStyle10 = 10
+   };
+
    RAttrValue<RColor>  color{this, "color", RColor::kBlack}; ///<! line color
    RAttrValue<double>  width{this, "width", 1.};             ///<! line width
-   RAttrValue<int>     style{this, "style", 1};              ///<! line style
+   RAttrValue<EStyle>  style{this, "style", kSolid};         ///<! line style
+   RAttrValue<std::string> pattern{this, "pattern"};         ///<! line pattern like "3,2,3,1,5"
 
-   RAttrLine(const RColor &_color, double _width, int _style) : RAttrLine()
+   RAttrLine(const RColor &_color, double _width, EStyle _style) : RAttrLine()
    {
       color = _color;
       width = _width;

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -71,7 +71,7 @@ class RAttrMarker : public RAttrAggregation {
 public:
 
    RAttrValue<RColor> color{this, "color", RColor::kBlack}; ///<! marker color
-   RAttrValue<double> size{this, "size", 1.};               ///<! marker size
+   RAttrValue<double> size{this, "size", 0.01};             ///<! marker size >1 pixels, <1 relative to pad height
    RAttrValue<EStyle> style{this, "style", kDot};           ///<! marker style
 
    RAttrMarker(const RColor &_color, double _size, EStyle _style) : RAttrMarker()

--- a/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrMarker.hxx
@@ -72,9 +72,9 @@ public:
 
    RAttrValue<RColor> color{this, "color", RColor::kBlack}; ///<! marker color
    RAttrValue<double> size{this, "size", 1.};               ///<! marker size
-   RAttrValue<int> style{this, "style", 1};                 ///<! marker style
+   RAttrValue<EStyle> style{this, "style", kDot};           ///<! marker style
 
-   RAttrMarker(const RColor &_color, double _size, int _style) : RAttrMarker()
+   RAttrMarker(const RColor &_color, double _size, EStyle _style) : RAttrMarker()
    {
       color = _color;
       size = _size;

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -34,30 +34,74 @@ public:
    RAttrValue<std::string> style{this, "style"};    ///<! font style, corresponds to css font-style attribute
    RAttrValue<std::string> weight{this, "weight"};  ///<! font weight, corresponds to css font-weight attribute
 
+   enum EFont {
+      kTimesItalic = 1,
+      kTimesBold = 2,
+      kTimesBoldItalic = 3,
+      kArial = 4,
+      kArialOblique = 5,
+      kArialBold = 6,
+      kArialBoldOblique = 7,
+      kCourier = 8,
+      kCourierOblique = 9,
+      kCourierBold = 10,
+      kCourierBoldOblique = 11,
+      // kSymbol = 12, // not supported by web browsers
+      kTimes = 13,
+      // kWingdings = 14,
+      // kSymbolItalic = 15, // not supported by web browsers
+      kVerdana = 16,
+      kVerdanaItalic = 17,
+      kVerdanaBold = 18,
+      kVerdanaBoldItalic = 19
+   };
+
    ///Set text font by id as usually handled in the ROOT (without precision), number should be between 1 and 15
-   RAttrFont &SetFont(int font)
+   RAttrFont &SetFont(EFont font)
    {
       switch(font) {
-      case 1: family = "Times New Roman"; style = "italic"; break;
-      case 2: family = "Times New Roman"; weight = "bold"; break;
-      case 3: family = "Times New Roman"; style = "italic"; weight = "bold"; break;
-      case 4: family = "Arial"; break;
-      case 5: family = "Arial"; style = "oblique"; break;
-      case 6: family = "Arial"; weight = "bold"; break;
-      case 7: family = "Arial"; style = "oblique"; weight = "bold"; break;
-      case 8: family = "Courier New"; break;
-      case 9: family = "Courier New"; style = "oblique"; break;
-      case 10: family = "Courier New"; weight = "bold"; break;
-      case 11: family = "Courier New"; style = "oblique"; weight = "bold"; break;
-      case 12: family = "Symbol"; break;
-      case 13: family = "Times New Roman"; break;
-      case 14: family = "Wingdings"; break;
-      case 15: family = "Symbol"; style = "italic"; break;
+      case kTimesItalic: family = "Times New Roman"; style = "italic"; break;
+      case kTimesBold: family = "Times New Roman"; weight = "bold"; break;
+      case kTimesBoldItalic: family = "Times New Roman"; style = "italic"; weight = "bold"; break;
+      case kArial: family = "Arial"; break;
+      case kArialOblique: family = "Arial"; style = "oblique"; break;
+      case kArialBold: family = "Arial"; weight = "bold"; break;
+      case kArialBoldOblique: family = "Arial"; style = "oblique"; weight = "bold"; break;
+      case kCourier: family = "Courier New"; break;
+      case kCourierOblique: family = "Courier New"; style = "oblique"; break;
+      case kCourierBold: family = "Courier New"; weight = "bold"; break;
+      case kCourierBoldOblique: family = "Courier New"; style = "oblique"; weight = "bold"; break;
+      // case kSymbol: family = "Symbol"; break;
+      case kTimes: family = "Times New Roman"; break;
+      // case kWingdings: family = "Wingdings"; break;
+      // case kSymbolItalic: family = "Symbol"; style = "italic"; break;
+      case kVerdana: family = "Verdana";  break;
+      case kVerdanaItalic: family = "Verdana";  style = "italic";  break;
+      case kVerdanaBold: family = "Verdana";  weight = "bold"; break;
+      case kVerdanaBoldItalic: family = "Verdana";  weight = "bold"; style = "italic"; break;
       }
       return *this;
    }
 
-   RAttrFont &operator=(int id) { SetFont(id); return *this; }
+   /// assign font id, setting all necessary properties
+   RAttrFont &operator=(EFont id) { SetFont(id); return *this; }
+
+   friend bool operator==(const RAttrFont &font, EFont id) { RAttrFont font2; font2.SetFont(id); return font == font2; }
+
+   /// Returns full font name including weight and style
+   std::string GetFullName() const
+   {
+      std::string name = family, s = style, w = weight;
+      if (!w.empty()) {
+         name += " ";
+         name += w;
+      }
+      if (!s.empty()) {
+         name += " ";
+         name += s;
+      }
+      return name;
+   }
 
 };
 

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -76,10 +76,22 @@ class RAttrText : public RAttrAggregation {
 
 public:
 
+   enum EAlign {
+      kLeftBottom = 11,
+      kLeftCenter = 12,
+      kLeftTop = 13,
+      kCenterBottom = 21,
+      kCenter = 22,
+      kCenterTop = 23,
+      kRightBottom = 31,
+      kRightCenter = 32,
+      kRightTop = 33
+   };
+
    RAttrValue<RColor> color{this, "color", RColor::kBlack};  ///<! text color
    RAttrValue<double> size{this, "size", 12.};               ///<! text size
    RAttrValue<double> angle{this, "angle", 0.};              ///<! text angle
-   RAttrValue<int> align{this, "align", 22};                 ///<! text align
+   RAttrValue<EAlign> align{this, "align", kCenter};         ///<! text align
    RAttrFont font{this, "font"};                             ///<! text font
 
    RAttrText(RDrawable *drawable, const char *prefix, double _size) : RAttrAggregation(drawable, prefix), size(this, "size", _size) {}

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -11,100 +11,10 @@
 
 #include <ROOT/RAttrAggregation.hxx>
 #include <ROOT/RAttrValue.hxx>
+#include <ROOT/RAttrFont.hxx>
 
 namespace ROOT {
 namespace Experimental {
-
-
-/** \class RAttrFont
-\ingroup GpadROOT7
-\brief A font attributes, used together with text attributes
-\authors Axel Naumann <axel@cern.ch> Sergey Linev <s.linev@gsi.de>
-\date 2021-06-28
-\warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-*/
-
-class RAttrFont : public RAttrAggregation {
-
-   R__ATTR_CLASS(RAttrFont, "font");
-
-public:
-
-   RAttrValue<std::string> family{this, "family"};  ///<! font family, corresponds to css font-familty attribute
-   RAttrValue<std::string> style{this, "style"};    ///<! font style, corresponds to css font-style attribute
-   RAttrValue<std::string> weight{this, "weight"};  ///<! font weight, corresponds to css font-weight attribute
-
-   enum EFont {
-      kTimesItalic = 1,
-      kTimesBold = 2,
-      kTimesBoldItalic = 3,
-      kArial = 4,
-      kArialOblique = 5,
-      kArialBold = 6,
-      kArialBoldOblique = 7,
-      kCourier = 8,
-      kCourierOblique = 9,
-      kCourierBold = 10,
-      kCourierBoldOblique = 11,
-      // kSymbol = 12, // not supported by web browsers
-      kTimes = 13,
-      // kWingdings = 14,
-      // kSymbolItalic = 15, // not supported by web browsers
-      kVerdana = 16,
-      kVerdanaItalic = 17,
-      kVerdanaBold = 18,
-      kVerdanaBoldItalic = 19
-   };
-
-   ///Set text font by id as usually handled in the ROOT (without precision), number should be between 1 and 15
-   RAttrFont &SetFont(EFont font)
-   {
-      switch(font) {
-      case kTimesItalic: family = "Times New Roman"; style = "italic"; break;
-      case kTimesBold: family = "Times New Roman"; weight = "bold"; break;
-      case kTimesBoldItalic: family = "Times New Roman"; style = "italic"; weight = "bold"; break;
-      case kArial: family = "Arial"; break;
-      case kArialOblique: family = "Arial"; style = "oblique"; break;
-      case kArialBold: family = "Arial"; weight = "bold"; break;
-      case kArialBoldOblique: family = "Arial"; style = "oblique"; weight = "bold"; break;
-      case kCourier: family = "Courier New"; break;
-      case kCourierOblique: family = "Courier New"; style = "oblique"; break;
-      case kCourierBold: family = "Courier New"; weight = "bold"; break;
-      case kCourierBoldOblique: family = "Courier New"; style = "oblique"; weight = "bold"; break;
-      // case kSymbol: family = "Symbol"; break;
-      case kTimes: family = "Times New Roman"; break;
-      // case kWingdings: family = "Wingdings"; break;
-      // case kSymbolItalic: family = "Symbol"; style = "italic"; break;
-      case kVerdana: family = "Verdana";  break;
-      case kVerdanaItalic: family = "Verdana";  style = "italic";  break;
-      case kVerdanaBold: family = "Verdana";  weight = "bold"; break;
-      case kVerdanaBoldItalic: family = "Verdana";  weight = "bold"; style = "italic"; break;
-      }
-      return *this;
-   }
-
-   /// assign font id, setting all necessary properties
-   RAttrFont &operator=(EFont id) { SetFont(id); return *this; }
-
-   friend bool operator==(const RAttrFont &font, EFont id) { RAttrFont font2; font2.SetFont(id); return font == font2; }
-
-   /// Returns full font name including weight and style
-   std::string GetFullName() const
-   {
-      std::string name = family, s = style, w = weight;
-      if (!w.empty()) {
-         name += " ";
-         name += w;
-      }
-      if (!s.empty()) {
-         name += " ";
-         name += s;
-      }
-      return name;
-   }
-
-};
-
 
 /** \class RAttrText
 \ingroup GpadROOT7

--- a/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RAttrText.hxx
@@ -81,6 +81,8 @@ public:
    RAttrValue<double> angle{this, "angle", 0.};              ///<! text angle
    RAttrValue<int> align{this, "align", 22};                 ///<! text align
    RAttrFont font{this, "font"};                             ///<! text font
+
+   RAttrText(RDrawable *drawable, const char *prefix, double _size) : RAttrAggregation(drawable, prefix), size(this, "size", _size) {}
 };
 
 } // namespace Experimental

--- a/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RDrawable.hxx
@@ -169,12 +169,12 @@ public:
    };
 
 private:
-   RAttrMap fAttr;               ///< attributes values
-   std::weak_ptr<RStyle> fStyle; ///<! style applied for RDrawable, not stored when canvas is saved
-   std::string fCssType;         ///<! drawable type, not stored in the root file, must be initialized in constructor
-   std::string fCssClass;        ///< user defined drawable class, can later go inside map
-   std::string fId;              ///< optional object identifier, may be used in CSS as well
-   Version_t fVersion{1};        ///<! drawable version, changed from the canvas
+   RAttrMap fAttr;                ///< attributes values
+   std::weak_ptr<RStyle> fStyle;  ///<! style applied for RDrawable, not stored when canvas is saved
+   const char *fCssType{nullptr}; ///<! drawable type, not stored in the root file, must be initialized in constructor
+   std::string fCssClass;         ///< user-defined CSS class, used for RStyle
+   std::string fId;               ///< user-defined CSS id, used for RStyle
+   Version_t fVersion{1};         ///<! drawable version, changed from the canvas
 
 protected:
 
@@ -189,7 +189,7 @@ protected:
 
    virtual std::unique_ptr<RDisplayItem> Display(const RDisplayContext &);
 
-   void SetCssType(const std::string &csstype) { fCssType = csstype; }
+   void SetCssType(const char *csstype) { fCssType = csstype; }
 
    virtual void OnDisplayItemDestroyed(RDisplayItem *) const {}
 
@@ -205,20 +205,20 @@ protected:
 
 public:
 
-   explicit RDrawable(const std::string &type) : fCssType(type) {}
+   explicit RDrawable(const char *csstype) : fCssType(csstype) {}
 
    virtual ~RDrawable();
 
    virtual void UseStyle(const std::shared_ptr<RStyle> &style) { fStyle = style; }
    void ClearStyle() { UseStyle(nullptr); }
 
+   const char *GetCssType() const { return fCssType; }
+
    void SetCssClass(const std::string &cl) { fCssClass = cl; }
    const std::string &GetCssClass() const { return fCssClass; }
 
-   const std::string &GetCssType() const { return fCssType; }
-
-   const std::string &GetId() const { return fId; }
    void SetId(const std::string &id) { fId = id; }
+   const std::string &GetId() const { return fId; }
 };
 
 /// Central method to insert drawable in list of pad primitives

--- a/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/ROnFrameDrawable.hxx
@@ -29,7 +29,7 @@ protected:
    ROnFrameDrawable(const ROnFrameDrawable &) = delete;
    ROnFrameDrawable &operator=(const ROnFrameDrawable &) = delete;
 
-   explicit ROnFrameDrawable(const std::string &type) : RDrawable(type) {}
+   explicit ROnFrameDrawable(const char *type) : RDrawable(type) {}
 
 public:
    virtual ~ROnFrameDrawable() = default;

--- a/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadBase.hxx
@@ -58,7 +58,7 @@ private:
 
 protected:
    /// Allow derived classes to default construct a RPadBase.
-   explicit RPadBase(const std::string &csstype) : RDrawable(csstype) {}
+   explicit RPadBase(const char *csstype) : RDrawable(csstype) {}
 
    void CollectShared(Internal::RIOSharedVector_t &) override;
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -33,7 +33,7 @@ class RPave : public RDrawable {
 
 protected:
 
-   RPave(const std::string &csstype) : RDrawable(csstype) {}
+   RPave(const char *csstype) : RDrawable(csstype) {}
 
 public:
 

--- a/graf2d/gpadv7/inc/ROOT/RPave.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPave.hxx
@@ -36,13 +36,23 @@ protected:
    RPave(const std::string &csstype) : RDrawable(csstype) {}
 
 public:
-   RAttrBorder border{this, "border"};                    ///<! border attributes
-   RAttrFill fill{this, "fill"};                          ///<! fill attributes
-   RAttrText text{this, "text"};                          ///<! text attributes
-   RAttrValue<RPadLength> cornerX{this, "cornerX", 0.02}; ///<! X corner
-   RAttrValue<RPadLength> cornerY{this, "cornerY", 0.02}; ///<! Y corner
-   RAttrValue<RPadLength> width{this, "width", 0.4};      ///<! pave width
-   RAttrValue<RPadLength> height{this, "height", 0.2};    ///<! pave height
+
+   enum ECorner {
+      kTopLeft = 1,
+      kTopRight = 2,
+      kBottomLeft = 3,
+      kBottomRight = 4
+   };
+
+   RAttrBorder border{this, "border"};                     ///<! border attributes
+   RAttrFill fill{this, "fill"};                           ///<! fill attributes
+   RAttrText text{this, "text"};                           ///<! text attributes
+   RAttrValue<RPadLength> width{this, "width", 0.4};       ///<! pave width
+   RAttrValue<RPadLength> height{this, "height", 0.2};     ///<! pave height
+   RAttrValue<bool> onFrame{this, "onFrame", true};        ///<! is pave assigned to frame (true) or to pad corner (false)
+   RAttrValue<ECorner> corner{this, "corner", kTopRight};  ///<! frame/pad corner to which pave is bound
+   RAttrValue<RPadLength> offsetX{this, "offsetX", 0.02};  ///<! offset X relative to selected frame or pad corner
+   RAttrValue<RPadLength> offsetY{this, "offsetY", 0.02};  ///<! offset Y relative to selected frame or pad corner
 
    RPave() : RPave("pave") {}
 

--- a/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
+++ b/graf2d/gpadv7/inc/ROOT/TObjectDrawable.hxx
@@ -64,7 +64,7 @@ protected:
 
    static void CheckOwnership(TObject *obj);
 
-   static std::string DetectCssType(const TObject *obj);
+   static const char *DetectCssType(const TObject *obj);
 
 public:
    // special kinds, see TWebSnapshot enums

--- a/graf2d/gpadv7/src/TObjectDrawable.cxx
+++ b/graf2d/gpadv7/src/TObjectDrawable.cxx
@@ -46,7 +46,7 @@ void TObjectDrawable::CheckOwnership(TObject *obj)
 ////////////////////////////////////////////////////////////////////
 /// Provide css type
 
-std::string TObjectDrawable::DetectCssType(const TObject *obj)
+const char *TObjectDrawable::DetectCssType(const TObject *obj)
 {
    if (!obj) return "tobject";
 

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -20,7 +20,7 @@ TEST(Primitives, RPave)
    pave->border.color = RColor::kRed;
    pave->border.width = 3.;
    pave->fill.color = RColor::kBlue;
-   pave->fill.style = 3003;
+   pave->fill.style = RAttrFill::k3003;
    pave->corner = RPave::kBottomRight;
    pave->onFrame = false;
    pave->offsetX = 0.03_normal;
@@ -35,7 +35,7 @@ TEST(Primitives, RPave)
    EXPECT_DOUBLE_EQ(pave->border.width, 3.);
 
    EXPECT_EQ(pave->fill.color, RColor::kBlue);
-   EXPECT_EQ(pave->fill.style, 3003);
+   EXPECT_EQ(pave->fill.style, RAttrFill::k3003);
 
    EXPECT_EQ(pave->corner, RPave::kBottomRight);
    EXPECT_EQ(pave->onFrame, false);

--- a/graf2d/gpadv7/test/rpave.cxx
+++ b/graf2d/gpadv7/test/rpave.cxx
@@ -21,9 +21,11 @@ TEST(Primitives, RPave)
    pave->border.width = 3.;
    pave->fill.color = RColor::kBlue;
    pave->fill.style = 3003;
-   pave->cornerX = 0.03_normal;
+   pave->corner = RPave::kBottomRight;
+   pave->onFrame = false;
+   pave->offsetX = 0.03_normal;
+   pave->offsetY = -0.03_normal;
    pave->width = 0.4_normal;
-   pave->cornerY = -0.03_normal;
    pave->height = 0.2_normal;
 
    // when adding pave, RFrame is automatically created
@@ -35,9 +37,11 @@ TEST(Primitives, RPave)
    EXPECT_EQ(pave->fill.color, RColor::kBlue);
    EXPECT_EQ(pave->fill.style, 3003);
 
-   EXPECT_EQ(pave->cornerX, 0.03_normal);
+   EXPECT_EQ(pave->corner, RPave::kBottomRight);
+   EXPECT_EQ(pave->onFrame, false);
+   EXPECT_EQ(pave->offsetX, 0.03_normal);
    EXPECT_EQ(pave->width, 0.4_normal);
-   EXPECT_EQ(pave->cornerY, -0.03_normal);
+   EXPECT_EQ(pave->offsetY, -0.03_normal);
    EXPECT_EQ(pave->height, 0.2_normal);
 }
 

--- a/graf2d/gpadv7/test/rstyle.cxx
+++ b/graf2d/gpadv7/test/rstyle.cxx
@@ -33,7 +33,7 @@ TEST(RStyleTest, CreateStyle)
 
    style->AddBlock("custom").AddDouble("line_width", 2.);
 
-   style->AddBlock("#customid").AddInt("fill_style", 5);
+   style->AddBlock("#customid").AddInt("fill_style", RAttrFill::k3005);
 
    style->AddBlock(".custom_class").AddDouble("text_size", 3.);
 
@@ -45,7 +45,7 @@ TEST(RStyleTest, CreateStyle)
 
    EXPECT_DOUBLE_EQ(drawable.line.width, 2.f);
 
-   EXPECT_EQ(drawable.fill.style, 5);
+   EXPECT_EQ(drawable.fill.style, RAttrFill::k3005);
 
    EXPECT_DOUBLE_EQ(drawable.text.size, 3.);
 }
@@ -54,7 +54,7 @@ TEST(RStyleTest, CreateStyle)
 TEST(RStyleTest, CreateCss)
 {
    auto style = RStyle::Parse(" custom { line_width: 2; line_color: red; }"
-                              " #customid { fill_style: 5; }"
+                              " #customid { fill_style: 3005; }"
                               " .custom_class { text_size: 3; }");
 
    ASSERT_NE(style, nullptr);
@@ -69,7 +69,7 @@ TEST(RStyleTest, CreateCss)
 
    EXPECT_EQ(drawable.line.color, RColor::kRed);
 
-   EXPECT_EQ(drawable.fill.style, 5);
+   EXPECT_EQ(drawable.fill.style, RAttrFill::k3005);
 
    EXPECT_DOUBLE_EQ(drawable.text.size, 3.);
 }
@@ -77,7 +77,7 @@ TEST(RStyleTest, CreateCss)
 TEST(RStyleTest, CaseInsensitive)
 {
    auto style = RStyle::Parse(" custom { line_Width: 2; Line_coloR: red; }"
-                              " #customID { fill_style: 5; }"
+                              " #customID { fill_style: 3005; }"
                               " .custom_Cclass { text_size: 3; }");
 
    ASSERT_NE(style, nullptr);
@@ -94,7 +94,7 @@ TEST(RStyleTest, CaseInsensitive)
    EXPECT_EQ(drawable.line.color, RColor::kRed);
 
    // but id should have exact match
-   EXPECT_NE(drawable.fill.style, 5);
+   EXPECT_NE(drawable.fill.style, RAttrFill::k3005);
 
    // and class name should have exact match
    EXPECT_NE(drawable.text.size, 3.);

--- a/graf2d/primitivesv7/inc/LinkDef.h
+++ b/graf2d/primitivesv7/inc/LinkDef.h
@@ -18,6 +18,7 @@
 #pragma link C++ class ROOT::Experimental::RFont+;
 #pragma link C++ class ROOT::Experimental::RFrameTitle+;
 #pragma link C++ class ROOT::Experimental::RLegend+;
+#pragma link C++ class ROOT::Experimental::RLegend::RCustomDrawable+;
 #pragma link C++ class ROOT::Experimental::RLegend::REntry+;
 #pragma link C++ class ROOT::Experimental::RLine+;
 #pragma link C++ class ROOT::Experimental::RPaveText+;

--- a/graf2d/primitivesv7/inc/ROOT/RBox.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RBox.hxx
@@ -33,7 +33,7 @@ class RBox : public ROnFrameDrawable {
 
 protected:
    // constructor for derived classes
-   RBox(const std::string &subtype) : ROnFrameDrawable(subtype) {}
+   RBox(const char *csstype) : ROnFrameDrawable(csstype) {}
 
 public:
 

--- a/graf2d/primitivesv7/inc/ROOT/RFont.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFont.hxx
@@ -31,6 +31,7 @@ class RFont : public RDrawable  {
    std::string fStyle;    ///< font style, assigned as "font-style" attribute, normal by default
    std::string fWeight;   ///< font weight, assigned as "font-weight" attribute, normal by default
    std::string fSrc;      ///< font source, assigned as "src" attribute
+   bool fDefault{false};  ///< is font set as default for the pad
 
 public:
 
@@ -50,6 +51,9 @@ public:
 
    void SetWeight(const std::string &weight) { fWeight = weight; }
    const std::string &GetWeight() const { return fWeight; }
+
+   void SetDefault(bool dflt = true) { fDefault = dflt; }
+   bool GetDefault() const { return fDefault; }
 
    void SetUrl(const std::string &url, const std::string &fmt = "woff2");
    void SetFile(const std::string &fname, const std::string &fmt = "woff2");

--- a/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RFrameTitle.hxx
@@ -38,7 +38,7 @@ protected:
 
 public:
 
-   RAttrText text{this, "text"};                               ///<! title text attributes
+   RAttrText text{this, "text", 0.07};                         ///<! title text attributes
    RAttrValue<RPadLength> margin{this, "margin", 0.02_normal}; ///<! title margin to frame
    RAttrValue<RPadLength> height{this, "height", 0.05_normal}; ///<! title height
 

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -33,6 +33,25 @@ namespace Experimental {
 class RLegend : public RPave {
 
 public:
+
+   /** \class RCustomDrawable
+   \ingroup GrafROOT7
+   \brief Special drawable to let provide line, fill or marker attributes for legend
+   \author Sergey Linev <S.Linev@gsi.de>
+   \date 2021-07-06
+   \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+   is welcome!
+   */
+
+   class RCustomDrawable final : public RDrawable {
+   public:
+      RCustomDrawable() : RDrawable("lentry") {}
+
+      RAttrLine line{this, "line"};          ///<! line attributes
+      RAttrFill fill{this, "fill"};          ///<! fill attributes
+      RAttrMarker marker{this, "marker"};    ///<! marker attributes
+   };
+
    /** \class REntry
    \ingroup GrafROOT7
    \brief An entry in RLegend, references RDrawable and its attributes
@@ -54,34 +73,33 @@ public:
 
       std::string fDrawableId; ///< drawable id, used only when display item
 
-      bool IsCustomDrawable() const { return fDrawableId == "custom"; }
+      bool IsCustomDrawable() const { return dynamic_cast<const RCustomDrawable *>(fDrawable.get()) != nullptr; }
 
-      bool EnsureCustomDrawable()
+      void DecodeOptions(const std::string &opt)
       {
-         if (!IsCustomDrawable())
-            return false;
-
-         if (!fDrawable)
-            fDrawable = std::make_shared<RDrawable>("lentry");
-
-         return true;
+         if (opt.find('l') != std::string::npos) SetLine(true);
+         if (opt.find('f') != std::string::npos) SetFill(true);
+         if (opt.find('m') != std::string::npos) SetMarker(true);
+         if (opt.find('e') != std::string::npos) SetError(true);
       }
 
    public:
       REntry() = default;
 
       /** Create entry without reference to existing drawable object, can assign attributes */
-      REntry(const std::string &lbl)
+      REntry(const std::string &lbl, const std::string &opt)
       {
-         fLabel = lbl;
          fDrawableId = "custom";
+         fLabel = lbl;
+         DecodeOptions(opt);
       }
 
       /** Create entry with reference to existing drawable object */
-      REntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl)
+      REntry(std::shared_ptr<RDrawable> drawable, const std::string &lbl, const std::string &opt)
       {
          fDrawable = drawable;
          fLabel = lbl;
+         DecodeOptions(opt);
       }
 
       REntry &SetLabel(const std::string &lbl) { fLabel = lbl; return *this; }
@@ -90,62 +108,16 @@ public:
       REntry &SetLine(bool on = true) { fLine = on; return *this; }
       bool GetLine() const { return fLine; }
 
-      REntry &SetAttrLine(const RAttrLine &attr)
-      {
-         if (EnsureCustomDrawable()) {
-            RAttrLine(fDrawable.get()) = attr;
-            SetLine(true);
-         }
-         return *this;
-      }
-
-      RAttrLine GetAttrLine() const
-      {
-         if (IsCustomDrawable() && fDrawable)
-            return RAttrLine(const_cast<RDrawable *>(fDrawable.get()));
-         return {};
-      }
-
       REntry &SetFill(bool on = true) { fFill = on; return *this; }
       bool GetFill() const { return fFill; }
-
-      REntry &SetAttrFill(const RAttrFill &attr)
-      {
-         if (EnsureCustomDrawable()) {
-            RAttrFill(fDrawable.get()) = attr;
-            SetFill(true);
-         }
-         return *this;
-      }
-
-      RAttrFill GetAttrFill() const
-      {
-         if (IsCustomDrawable() && fDrawable)
-            return RAttrFill(const_cast<RDrawable *>(fDrawable.get()));
-         return {};
-      }
 
       REntry &SetMarker(bool on = true) { fMarker = on; return *this; }
       bool GetMarker() const { return fMarker; }
 
-      REntry &SetAttrMarker(const RAttrMarker &attr)
-      {
-         if (EnsureCustomDrawable()) {
-            RAttrMarker(fDrawable.get()) = attr;
-            SetMarker(true);
-         }
-         return *this;
-      }
-
-      RAttrMarker GetAttrMarker() const
-      {
-         if (IsCustomDrawable() && fDrawable)
-            return RAttrMarker(const_cast<RDrawable *>(fDrawable.get()));
-         return {};
-      }
-
       REntry &SetError(bool on = true) { fError = on; return *this; }
       bool GetError() const { return fError; }
+
+      std::shared_ptr<RDrawable> GetDrawable() const { return fDrawable.get_shared(); }
    };
 
 private:
@@ -204,18 +176,18 @@ public:
    RLegend &SetTitle(const std::string &title) { fTitle = title; return *this; }
    const std::string &GetTitle() const { return fTitle; }
 
-   REntry &AddEntry(const std::string &lbl)
+   std::shared_ptr<RCustomDrawable> AddEntry(const std::string &lbl, const std::string &opt = "")
    {
-      fEntries.emplace_back(lbl);
-      return fEntries.back();
+      fEntries.emplace_back(lbl, opt);
+      auto drawable = std::make_shared<RCustomDrawable>();
+      fEntries.back().fDrawable = drawable;
+      return drawable;
    }
 
-   REntry &AddEntry(const std::shared_ptr<RDrawable> &drawable, const std::string &lbl)
+   void AddEntry(const std::shared_ptr<RDrawable> &drawable, const std::string &lbl, const std::string &opt = "")
    {
-      fEntries.emplace_back(drawable, lbl);
-      return fEntries.back();
+      fEntries.emplace_back(drawable, lbl, opt);
    }
-
 
    auto NumEntries() const { return fEntries.size(); }
 

--- a/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
+++ b/graf2d/primitivesv7/inc/ROOT/RLegend.hxx
@@ -193,10 +193,10 @@ public:
 
    RLegend(const std::string &title) : RLegend() { SetTitle(title); }
 
-   RLegend(const RPadPos &corner, const RPadExtent &size) : RLegend()
+   RLegend(const RPadPos &offset, const RPadExtent &size) : RLegend()
    {
-      cornerX = corner.Horiz();
-      cornerY = corner.Vert();
+      offsetX = offset.Horiz();
+      offsetY = offset.Vert();
       width = size.Horiz();
       height = size.Vert();
    }

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -108,18 +108,43 @@ TEST(Primitives, RLegend)
    legend->fill.color = RColor::kWhite;
    legend->border.width = 2.;
    legend->border.color = RColor::kRed;
-   legend->AddEntry(line1, "RLine 1");
-   legend->AddEntry(line2, "RLine 2");
-   legend->AddEntry(line3, "RLine 3");
+   legend->AddEntry(line1, "RLine 1", "l");
+   legend->AddEntry(line2, "RLine 2", "l");
+   legend->AddEntry(line3, "RLine 3", "l");
+
+   auto custom = legend->AddEntry("test", "lfm");
+   custom->line.color = RColor::kGreen;
+   custom->line.width = 5.;
+   custom->line.style = 1;
+   custom->fill.color = RColor::kBlue;
+   custom->fill.style = 3004;
+   custom->marker.color = RColor::kRed;
+   custom->marker.size = 3.;
+   custom->marker.style = RAttrMarker::kOpenCross;
 
    EXPECT_EQ(canv.NumPrimitives(), 4u);
 
-   EXPECT_EQ(legend->NumEntries(), 3u);
+   EXPECT_EQ(legend->NumEntries(), 4u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
    EXPECT_EQ(legend->fill.style, 5);
    EXPECT_EQ(legend->fill.color, RColor::kWhite);
    EXPECT_EQ(legend->border.width, 2.);
    EXPECT_EQ(legend->border.color, RColor::kRed);
+
+   EXPECT_EQ(legend->GetEntry(0).GetLine(), true);
+   EXPECT_EQ(legend->GetEntry(1).GetFill(), false);
+   EXPECT_EQ(legend->GetEntry(2).GetMarker(), false);
+
+
+   EXPECT_EQ(legend->GetEntry(3).GetLine(), true);
+   EXPECT_EQ(legend->GetEntry(3).GetFill(), true);
+   EXPECT_EQ(legend->GetEntry(3).GetMarker(), true);
+   auto custom2 = std::dynamic_pointer_cast<RLegend::RCustomDrawable>(legend->GetEntry(3).GetDrawable());
+
+   EXPECT_NE(custom2, nullptr);
+   EXPECT_EQ(custom2->line.color, RColor::kGreen);
+   EXPECT_EQ(custom2->fill.color, RColor::kBlue);
+   EXPECT_EQ(custom2->marker.color, RColor::kRed);
 }
 
 // Test RPaveText API

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -18,7 +18,7 @@ TEST(Primitives, RBox)
 
    box->border.color = RColor::kRed;
    box->border.width = 5.;
-   box->border.style = 7;
+   box->border.style = RAttrLine::kDotted;
    box->fill.color = RColor::kBlue;
    box->fill.style = RAttrFill::k3006;
 
@@ -26,7 +26,7 @@ TEST(Primitives, RBox)
 
    EXPECT_EQ(box->border.color, RColor::kRed);
    EXPECT_DOUBLE_EQ(box->border.width, 5.);
-   EXPECT_EQ(box->border.style, 7);
+   EXPECT_EQ(box->border.style, RAttrLine::kDotted);
 
    EXPECT_EQ(box->fill.color, RColor::kBlue);
    EXPECT_EQ(box->fill.style, RAttrFill::k3006);
@@ -40,7 +40,7 @@ TEST(Primitives, RLine)
 
    line->line.color = RColor::kRed;
    line->line.width = 5.;
-   line->line.style = 7;
+   line->line.style = RAttrLine::kDashDotted;
    line->onFrame = true;
    line->clipping = false;
 
@@ -48,7 +48,7 @@ TEST(Primitives, RLine)
 
    EXPECT_EQ(line->line.color, RColor::kRed);
    EXPECT_DOUBLE_EQ(line->line.width, 5.);
-   EXPECT_EQ(line->line.style, 7);
+   EXPECT_EQ(line->line.style, RAttrLine::kDashDotted);
    EXPECT_EQ(line->onFrame, true);
    EXPECT_EQ(line->clipping, false);
 }
@@ -115,7 +115,7 @@ TEST(Primitives, RLegend)
    auto custom = legend->AddEntry("test", "lfm");
    custom->line.color = RColor::kGreen;
    custom->line.width = 5.;
-   custom->line.style = 1;
+   custom->line.style = RAttrLine::kDashed;
    custom->fill.color = RColor::kBlue;
    custom->fill.style = RAttrFill::k3004;
    custom->marker.color = RColor::kRed;
@@ -142,6 +142,7 @@ TEST(Primitives, RLegend)
 
    EXPECT_NE(custom2, nullptr);
    EXPECT_EQ(custom2->line.color, RColor::kGreen);
+   EXPECT_EQ(custom2->line.style, RAttrLine::kDashed);
    EXPECT_EQ(custom2->fill.color, RColor::kBlue);
    EXPECT_EQ(custom2->fill.style, RAttrFill::k3004);
    EXPECT_EQ(custom2->marker.color, RColor::kRed);

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -78,7 +78,7 @@ TEST(Primitives, RText)
    text->text.color = RColor::kBlack;
    text->text.size = 12.5;
    text->text.angle = 90.;
-   text->text.align = 13;
+   text->text.align = RAttrText::kLeftTop;
    text->text.font.family = "Arial";
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
@@ -87,7 +87,7 @@ TEST(Primitives, RText)
    EXPECT_EQ(text->text.color, RColor::kBlack);
    EXPECT_DOUBLE_EQ(text->text.size, 12.5);
    EXPECT_DOUBLE_EQ(text->text.angle, 90.);
-   EXPECT_EQ(text->text.align, 13);
+   EXPECT_EQ(text->text.align, RAttrText::kLeftTop);
    EXPECT_EQ(text->text.font.family, "Arial");
 }
 
@@ -156,7 +156,7 @@ TEST(Primitives, RPaveText)
 
    text->text.color = RColor::kBlack;
    text->text.size = 12;
-   text->text.align = 13;
+   text->text.align = RAttrText::kLeftTop;
    text->text.font.family = "Times New Roman";
    text->border.color = RColor::kRed;
    text->border.width = 3.;
@@ -176,7 +176,7 @@ TEST(Primitives, RPaveText)
 
    EXPECT_EQ(text->text.color, RColor::kBlack);
    EXPECT_DOUBLE_EQ(text->text.size, 12);
-   EXPECT_EQ(text->text.align, 13);
+   EXPECT_EQ(text->text.align, RAttrText::kLeftTop);
    EXPECT_EQ(text->text.font.family, "Times New Roman");
 
    EXPECT_EQ(text->border.color, RColor::kRed);

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -59,12 +59,12 @@ TEST(Primitives, RMarker)
    RCanvas canv;
    auto marker = canv.Draw<RMarker>(RPadPos(0.5_normal, 0.5_normal));
 
-   marker->marker = RAttrMarker(RColor::kGreen, 2.5, RAttrMarker::kStar);
+   marker->marker = RAttrMarker(RColor::kGreen, 0.05, RAttrMarker::kStar);
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
    EXPECT_EQ(marker->marker.color, RColor::kGreen);
-   EXPECT_DOUBLE_EQ(marker->marker.size, 2.5);
+   EXPECT_DOUBLE_EQ(marker->marker.size, 0.05);
    EXPECT_EQ(marker->marker.style, RAttrMarker::kStar);
 }
 
@@ -119,7 +119,7 @@ TEST(Primitives, RLegend)
    custom->fill.color = RColor::kBlue;
    custom->fill.style = RAttrFill::k3004;
    custom->marker.color = RColor::kRed;
-   custom->marker.size = 3.;
+   custom->marker.size = 0.01;
    custom->marker.style = RAttrMarker::kOpenCross;
 
    EXPECT_EQ(canv.NumPrimitives(), 4u);
@@ -147,6 +147,7 @@ TEST(Primitives, RLegend)
    EXPECT_EQ(custom2->fill.style, RAttrFill::k3004);
    EXPECT_EQ(custom2->marker.color, RColor::kRed);
    EXPECT_EQ(custom2->marker.style, RAttrMarker::kOpenCross);
+   EXPECT_DOUBLE_EQ(custom2->marker.size, 0.01);
 }
 
 // Test RPaveText API

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -20,7 +20,7 @@ TEST(Primitives, RBox)
    box->border.width = 5.;
    box->border.style = 7;
    box->fill.color = RColor::kBlue;
-   box->fill.style = 6;
+   box->fill.style = RAttrFill::k3006;
 
    EXPECT_EQ(canv.NumPrimitives(), 1u);
 
@@ -29,7 +29,7 @@ TEST(Primitives, RBox)
    EXPECT_EQ(box->border.style, 7);
 
    EXPECT_EQ(box->fill.color, RColor::kBlue);
-   EXPECT_EQ(box->fill.style, 6);
+   EXPECT_EQ(box->fill.style, RAttrFill::k3006);
 }
 
 // Test RLine API
@@ -104,7 +104,7 @@ TEST(Primitives, RLegend)
    line3->line.color = RColor::kBlue;
 
    auto legend = canv.Draw<RLegend>("Legend title");
-   legend->fill.style = 5;
+   legend->fill.style = RAttrFill::k3005;
    legend->fill.color = RColor::kWhite;
    legend->border.width = 2.;
    legend->border.color = RColor::kRed;
@@ -117,7 +117,7 @@ TEST(Primitives, RLegend)
    custom->line.width = 5.;
    custom->line.style = 1;
    custom->fill.color = RColor::kBlue;
-   custom->fill.style = 3004;
+   custom->fill.style = RAttrFill::k3004;
    custom->marker.color = RColor::kRed;
    custom->marker.size = 3.;
    custom->marker.style = RAttrMarker::kOpenCross;
@@ -126,7 +126,7 @@ TEST(Primitives, RLegend)
 
    EXPECT_EQ(legend->NumEntries(), 4u);
    EXPECT_EQ(legend->GetTitle(), "Legend title");
-   EXPECT_EQ(legend->fill.style, 5);
+   EXPECT_EQ(legend->fill.style, RAttrFill::k3005);
    EXPECT_EQ(legend->fill.color, RColor::kWhite);
    EXPECT_EQ(legend->border.width, 2.);
    EXPECT_EQ(legend->border.color, RColor::kRed);
@@ -134,7 +134,6 @@ TEST(Primitives, RLegend)
    EXPECT_EQ(legend->GetEntry(0).GetLine(), true);
    EXPECT_EQ(legend->GetEntry(1).GetFill(), false);
    EXPECT_EQ(legend->GetEntry(2).GetMarker(), false);
-
 
    EXPECT_EQ(legend->GetEntry(3).GetLine(), true);
    EXPECT_EQ(legend->GetEntry(3).GetFill(), true);
@@ -144,6 +143,7 @@ TEST(Primitives, RLegend)
    EXPECT_NE(custom2, nullptr);
    EXPECT_EQ(custom2->line.color, RColor::kGreen);
    EXPECT_EQ(custom2->fill.color, RColor::kBlue);
+   EXPECT_EQ(custom2->fill.style, RAttrFill::k3004);
    EXPECT_EQ(custom2->marker.color, RColor::kRed);
 }
 
@@ -161,7 +161,7 @@ TEST(Primitives, RPaveText)
    text->border.color = RColor::kRed;
    text->border.width = 3.;
    text->fill.color = RColor::kBlue;
-   text->fill.style = 3003;
+   text->fill.style = RAttrFill::k3003;
 
    text->AddLine("First line");
    text->AddLine("Second line");
@@ -183,5 +183,5 @@ TEST(Primitives, RPaveText)
    EXPECT_DOUBLE_EQ(text->border.width, 3.);
 
    EXPECT_EQ(text->fill.color, RColor::kBlue);
-   EXPECT_EQ(text->fill.style, 3003);
+   EXPECT_EQ(text->fill.style, RAttrFill::k3003);
 }

--- a/graf2d/primitivesv7/test/primitives.cxx
+++ b/graf2d/primitivesv7/test/primitives.cxx
@@ -146,6 +146,7 @@ TEST(Primitives, RLegend)
    EXPECT_EQ(custom2->fill.color, RColor::kBlue);
    EXPECT_EQ(custom2->fill.style, RAttrFill::k3004);
    EXPECT_EQ(custom2->marker.color, RColor::kRed);
+   EXPECT_EQ(custom2->marker.style, RAttrMarker::kOpenCross);
 }
 
 // Test RPaveText API

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "5/07/2021";
+   JSROOT.version_date = "6/07/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "6/07/2021";
+   JSROOT.version_date = "7/07/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "14/01/2021"*/
-   JSROOT.version_date = "7/07/2021";
+   JSROOT.version_date = "8/07/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -608,6 +608,7 @@ JSROOT.define(['d3'], (d3) => {
       this.color = (args.width === 0) ? 'none' : args.color;
       this.width = args.width;
       this.style = args.style;
+      this.pattern = args.pattern || jsrp.root_line_styles[this.style] || null;
 
       if (args.can_excl) {
          this.excl_side = this.excl_width = 0;
@@ -638,6 +639,13 @@ JSROOT.define(['d3'], (d3) => {
    /** @summary returns true if line attribute is empty and will not be applied. */
    TAttLineHandler.prototype.empty = function() { return this.color == 'none'; }
 
+   /** @summary set border parameters, used for rect drawing */
+   TAttLineHandler.prototype.setBorder = function(rx, ry) {
+      this.rx = rx;
+      this.ry = ry;
+      this.func = this.applyBorder.bind(this);
+   }
+
    /** @summary Applies line attribute to selection.
      * @param {object} selection - d3.js selection */
    TAttLineHandler.prototype.apply = function(selection) {
@@ -649,19 +657,33 @@ JSROOT.define(['d3'], (d3) => {
       else
          selection.style('stroke', this.color)
                   .style('stroke-width', this.width)
-                  .style('stroke-dasharray', jsrp.root_line_styles[this.style] || null);
-      if (this.rx !== undefined)
-         if (this.empty())
-            selection.attr("rx", null).attr("ry", null);
-         else
-            selection.attr("rx", this.rx || null).attr("ry", this.ry || null);
+                  .style('stroke-dasharray', this.pattern);
+   }
+
+   /** @summary Applies line and border attribute to selection.
+     * @param {object} selection - d3.js selection */
+   TAttLineHandler.prototype.applyBorder = function(selection) {
+      this.used = true;
+      if (this.empty())
+         selection.style('stroke', null)
+                  .style('stroke-width', null)
+                  .style('stroke-dasharray', null)
+                  .attr("rx", null).attr("ry", null);
+      else
+         selection.style('stroke', this.color)
+                  .style('stroke-width', this.width)
+                  .style('stroke-dasharray', this.pattern)
+                  .attr("rx", this.rx || null).attr("ry", this.ry || null);
    }
 
    /** @summary Change line attributes */
    TAttLineHandler.prototype.change = function(color, width, style) {
       if (color !== undefined) this.color = color;
       if (width !== undefined) this.width = width;
-      if (style !== undefined) this.style = style;
+      if (style !== undefined) {
+         this.style = style;
+         this.pattern = jsrp.root_line_styles[this.style] || null;
+      }
       this.changed = true;
    }
 

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -92,13 +92,15 @@ JSROOT.define(['d3'], (d3) => {
          'bTimes New Roman', 'biTimes New Roman', 'Arial',
          'oArial', 'bArial', 'boArial', 'Courier New',
          'oCourier New', 'bCourier New', 'boCourier New',
-         'Symbol', 'Times New Roman', 'Wingdings', 'iSymbol', 'Verdana'],
+         'Symbol', 'Times New Roman', 'Wingdings', 'iSymbol',
+         'Verdana', 'iVerdana', 'bVerdana', 'biVerdana'],
       // taken from https://www.math.utah.edu/~beebe/fonts/afm-widths.html
       root_fonts_aver_width: [0.537, 0.510,
          0.535, 0.520, 0.537,
          0.54, 0.556, 0.56, 0.6,
          0.6, 0.6, 0.6,
-         0.587, 0.514, 0.896, 0.587, 0.55]
+         0.587, 0.514, 0.896, 0.587,
+         0.55, 0.55, 0.55, 0.55 ]
    };
 
    jsrp.createMenu = function(evnt, handler, menuname) {

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -180,7 +180,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
        if (typeof text_size == "string") text_size = parseFloat(text_size);
        if (!Number.isFinite(text_size) || (text_size <= 0)) text_size = 12;
-       if (!fontScale) fontScale = pp.getPadHeight() || 10;
+       if (!fontScale) fontScale = pp.getPadHeight() || 100;
 
        let handler = new JSROOT.FontHandler(null, text_size, fontScale, font_family, font_style, font_weight);
 
@@ -224,10 +224,15 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (!prefix || (typeof prefix != "string")) prefix = "marker_";
 
       let marker_color = this.v7EvalColor(prefix + "color", "black"),
-          marker_size = this.v7EvalAttr(prefix + "size", 1),
-          marker_style = this.v7EvalAttr(prefix + "style", 1);
+          marker_size = this.v7EvalAttr(prefix + "size", 0.01),
+          marker_style = this.v7EvalAttr(prefix + "style", 1),
+          marker_refsize = 1;
+      if (marker_size < 1) {
+         let pp = this.getPadPainter();
+         marker_refsize = pp ? pp.getPadHeight() : 100;
+      }
 
-      this.createAttMarker({ color: marker_color, size: marker_size, style: marker_style });
+      this.createAttMarker({ color: marker_color, size: marker_size, style: marker_style, refsize: marker_refsize });
    }
 
    /** @summary Create RChangeAttr, which can be applied on the server side

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -168,17 +168,19 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (!dflts) dflts = {}; else
       if (typeof dflts == "number") dflts = { size: dflts };
 
-      let text_size   = this.v7EvalAttr(name + "_size", dflts.size || 12),
+      let pp = this.getPadPainter(),
+          rfont = pp._dfltRFont || { fFamily: "Arial", fStyle: "", fWeight: "" },
+          text_size   = this.v7EvalAttr(name + "_size", dflts.size || 12),
           text_angle  = this.v7EvalAttr(name + "_angle", 0),
           text_align  = this.v7EvalAttr(name + "_align", dflts.align || "none"),
           text_color  = this.v7EvalColor(name + "_color", dflts.color || "none"),
-          font_family = this.v7EvalAttr(name + "_font_family", "Arial"),
-          font_style  = this.v7EvalAttr(name + "_font_style", ""),
-          font_weight = this.v7EvalAttr(name + "_font_weight", "");
+          font_family = this.v7EvalAttr(name + "_font_family", rfont.fFamily || "Arial"),
+          font_style  = this.v7EvalAttr(name + "_font_style", rfont.fStyle || ""),
+          font_weight = this.v7EvalAttr(name + "_font_weight", rfont.fWeight || "");
 
        if (typeof text_size == "string") text_size = parseFloat(text_size);
        if (!Number.isFinite(text_size) || (text_size <= 0)) text_size = 12;
-       if (!fontScale) fontScale = this.getPadPainter().getPadHeight() || 10;
+       if (!fontScale) fontScale = pp.getPadHeight() || 10;
 
        let handler = new JSROOT.FontHandler(null, text_size, fontScale, font_family, font_style, font_weight);
 
@@ -2720,6 +2722,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       delete this._pad_width;
       delete this._pad_height;
       delete this._doing_draw;
+      delete this._dfltRFont;
 
       this.painters = [];
       this.pad = null;
@@ -5454,9 +5457,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
    }
 
    function drawRFont() {
-      let font      = this.getObject(),
-          svg       = this.getCanvSvg(),
-          defs      = svg.select('.canvas_defs'),
+      let font   = this.getObject(),
+          svg    = this.getCanvSvg(),
+          defs   = svg.select('.canvas_defs'),
           clname = "custom_font_" + font.fFamily+font.fWeight+font.fStyle;
 
       if (defs.empty())
@@ -5467,6 +5470,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          entry = defs.append("style").attr("type", "text/css").attr("class", clname);
 
       entry.text(`@font-face { font-family: "${font.fFamily}"; font-weight: ${font.fWeight ? font.fWeight : "normal"}; font-style: ${font.fStyle ? font.fStyle : "normal"}; src: ${font.fSrc}; }`);
+
+      if (font.fDefault)
+         this.getPadPainter()._dfltRFont = font;
 
       return true;
    }

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -5025,7 +5025,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
           title_margin = this.v7EvalLength("margin", ph, 0.02),
           title_width  = fw,
           title_height = this.v7EvalLength("height", ph, 0.05),
-          textFont     = this.v7EvalFont("text", { size: 24, color: "black", align: 22 });
+          textFont     = this.v7EvalFont("text", { size: 0.07, color: "black", align: 22 });
 
       this.createG();
 

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -209,14 +209,13 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       let line_color = this.v7EvalColor(prefix + "color", "black"),
           line_width = this.v7EvalAttr(prefix + "width", 1),
-          line_style = this.v7EvalAttr(prefix + "style", 1);
+          line_style = this.v7EvalAttr(prefix + "style", 1),
+          line_pattern = this.v7EvalAttr(prefix + "pattern");
 
-      this.createAttLine({ color: line_color, width: line_width, style: line_style });
+      this.createAttLine({ color: line_color, width: line_width, style: line_style, pattern: line_pattern });
 
-      if (prefix == "border_") {
-         this.lineatt.rx = this.v7EvalAttr(prefix + "rx", 0);
-         this.lineatt.ry = this.v7EvalAttr(prefix + "ry", 0);
-      }
+      if (prefix == "border_")
+         this.lineatt.setBorder(this.v7EvalAttr(prefix + "rx", 0), this.v7EvalAttr(prefix + "ry", 0));
    }
 
     /** @summary Create this.markeratt object based on v7 attributes
@@ -4915,8 +4914,6 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                  .attr("width", pave_width)
                  .attr("y", 0)
                  .attr("height", pave_height)
-                 .attr("rx", border_rx || null)
-                 .attr("ry", border_ry || null)
                  .call(this.lineatt.func)
                  .call(this.fillatt.func);
 

--- a/js/scripts/JSRoot.v7gpad.js
+++ b/js/scripts/JSRoot.v7gpad.js
@@ -197,11 +197,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       if (!prefix || (typeof prefix != "string")) prefix = "fill_";
 
       let fill_color = this.v7EvalColor(prefix + "color", ""),
-          fill_style = this.v7EvalAttr(prefix + "style", 1001);
+          fill_style = this.v7EvalAttr(prefix + "style", 0);
 
-      this.createAttFill({ pattern: fill_style, color: 0 });
-
-      this.fillatt.setSolidColor(fill_color || "none");
+      this.createAttFill({ pattern: fill_style, color: fill_color,  color_as_svg: true });
    }
 
    /** @summary Create this.lineatt object based on v7 line attributes
@@ -1527,7 +1525,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
       }
 
       if (!this.fillatt)
-         this.createv7AttFill("fill_");
+         this.createv7AttFill();
 
       this.createv7AttLine("border_");
    }
@@ -4874,14 +4872,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
           offsetx      = this.v7EvalLength("offsetX", rect.width, 0.02),
           offsety      = this.v7EvalLength("offsetY", rect.height, 0.02),
           pave_width   = this.v7EvalLength("width", rect.width, 0.3),
-          pave_height  = this.v7EvalLength("height", rect.height, 0.3),
-          line_width   = this.v7EvalAttr("border_width", 1),
-          line_style   = this.v7EvalAttr("border_style", 1),
-          line_color   = this.v7EvalColor("border_color", "black"),
-          border_rx    = this.v7EvalAttr("border_rx", 0),
-          border_ry    = this.v7EvalAttr("border_ry", 0),
-          fill_color   = this.v7EvalColor("fill_color", "white"),
-          fill_style   = this.v7EvalAttr("fill_style", 1);
+          pave_height  = this.v7EvalLength("height", rect.height, 0.3);
 
       this.createG();
 
@@ -4889,7 +4880,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
       if (!visible) return Promise.resolve(this);
 
-      if (fill_style == 0) fill_color = "none";
+      this.createv7AttLine("border_");
+
+      this.createv7AttFill();
 
       let pave_x = 0, pave_y = 0,
           fr = this.onFrame ? fp.getFrameRect() : rect;
@@ -4924,10 +4917,8 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                  .attr("height", pave_height)
                  .attr("rx", border_rx || null)
                  .attr("ry", border_ry || null)
-                 .style("stroke", line_color)
-                 .attr("stroke-width", line_width)
-                 .style("stroke-dasharray", jsrp.root_line_styles[line_style])
-                 .attr("fill", fill_color);
+                 .call(this.lineatt.func)
+                 .call(this.fillatt.func);
 
       this.pave_width = pave_width;
       this.pave_height = pave_height;

--- a/js/scripts/JSRoot.v7more.js
+++ b/js/scripts/JSRoot.v7more.js
@@ -59,18 +59,13 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
            onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
            clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
            p1           = pp.getCoordinate(box.fP1, onframe),
-           p2           = pp.getCoordinate(box.fP2, onframe),
-           line_width   = this.v7EvalAttr("border_width", 1),
-           line_style   = this.v7EvalAttr("border_style", 1),
-           line_color   = this.v7EvalColor("border_color", "black"),
-           fill_color   = this.v7EvalColor("fill_color", "white"),
-           fill_style   = this.v7EvalAttr("fill_style", 1),
-           border_rx    = this.v7EvalAttr("border_rx", 0),
-           border_ry    = this.v7EvalAttr("border_ry", 0);
+           p2           = pp.getCoordinate(box.fP2, onframe);
 
     this.createG(clipping ? "main_layer" : (onframe ? "upper_layer" : false));
 
-    if (fill_style == 0) fill_color = "none";
+    this.createv7AttLine("border_");
+
+    this.createv7AttFill();
 
     this.draw_g
         .append("svg:rect")
@@ -78,12 +73,8 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
         .attr("width", p2.x-p1.x)
         .attr("y", p2.y)
         .attr("height", p1.y-p2.y)
-        .attr("rx", border_rx || null)
-        .attr("ry", border_ry || null)
-        .style("stroke", line_color)
-        .attr("stroke-width", line_width)
-        .attr("fill", fill_color)
-        .style("stroke-dasharray", jsrp.root_line_styles[line_style]);
+        .call(this.lineatt.func)
+        .call(this.fillatt.func);
    }
 
    // =================================================================================

--- a/js/scripts/JSRoot.v7more.js
+++ b/js/scripts/JSRoot.v7more.js
@@ -80,19 +80,18 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
            pp           = this.getPadPainter(),
            onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
            clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
-           p            = pp.getCoordinate(marker.fP, onframe),
-           marker_size  = this.v7EvalAttr( "marker_size", 1),
-           marker_style = this.v7EvalAttr( "marker_style", 1),
-           marker_color = this.v7EvalColor( "marker_color", "black"),
-           att          = new JSROOT.TAttMarkerHandler({ style: marker_style, color: marker_color, size: marker_size }),
-           path         = att.create(p.x, p.y);
+           p            = pp.getCoordinate(marker.fP, onframe);
 
        this.createG(clipping ? "main_layer" : (onframe ? "upper_layer" : false));
+
+       this.createv7AttMarker();
+
+       let path = this.markeratt.create(p.x, p.y);
 
        if (path)
           this.draw_g.append("svg:path")
                      .attr("d", path)
-                     .call(att.func);
+                     .call(this.markeratt.func);
    }
 
    // =================================================================================

--- a/js/scripts/JSRoot.v7more.js
+++ b/js/scripts/JSRoot.v7more.js
@@ -31,12 +31,11 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
            onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
            clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
            p1           = pp.getCoordinate(line.fP1, onframe),
-           p2           = pp.getCoordinate(line.fP2, onframe),
-           line_width   = this.v7EvalAttr("line_width", 1),
-           line_style   = this.v7EvalAttr("line_style", 1),
-           line_color   = this.v7EvalColor("line_color", "black");
+           p2           = pp.getCoordinate(line.fP2, onframe);
 
        this.createG(clipping ? "main_layer" : (onframe ? "upper_layer" : false));
+
+       this.createv7AttLine();
 
        this.draw_g
            .append("svg:line")
@@ -44,10 +43,7 @@ JSROOT.define(['painter', 'v7gpad'], (jsrp) => {
            .attr("y1", p1.y)
            .attr("x2", p2.x)
            .attr("y2", p2.y)
-           .style("stroke", line_color)
-           .attr("stroke-width", line_width)
-//        .attr("stroke-opacity", line_opacity)
-           .style("stroke-dasharray", jsrp.root_line_styles[line_style]);
+           .call(this.lineatt.func);
    }
 
    // =================================================================================

--- a/tutorials/rcanvas/df104.py
+++ b/tutorials/rcanvas/df104.py
@@ -21,7 +21,7 @@
 
 import ROOT
 import os
-from ROOT.Experimental import RCanvas, RText, RAttrText, RLegend, RPadPos, RPadExtent, TObjectDrawable
+from ROOT.Experimental import RCanvas, RText, RAttrText, RAttrFont, RLegend, RPadPos, RPadExtent, TObjectDrawable
 
 # Enable multi-threading
 ROOT.ROOT.EnableImplicitMT()
@@ -204,7 +204,7 @@ lower_pad.Add[TObjectDrawable]().Set(ratiodata, "E SAME")
 legend = upper_pad.Draw[RLegend](RPadPos(0.01, 0.01), RPadExtent(0.3, 0.4))
 legend.text.size = 0.05
 legend.text.align = RAttrText.kRightCenter
-legend.text.font = 4
+legend.text.font = RAttrFont.kArial
 legend.border.style = 0
 legend.border.width = 0
 legend.fill.style = 0
@@ -217,17 +217,17 @@ legend.AddEntry(higgs_drawable, "Signal", "l")
 # Add ATLAS labels
 lbl1 = upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS")
 lbl1.onFrame = True
-lbl1.text.font = 7
+lbl1.text.font = RAttrFont.kArialBoldOblique
 lbl1.text.size = 0.04
 lbl1.text.align = RAttrText.kLeftBottom
 lbl2 = upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data")
 lbl2.onFrame = True
-lbl2.text.font = 4
+lbl2.text.font = RAttrFont.kArial
 lbl2.text.size = 0.04
 lbl2.text.align = RAttrText.kLeftBottom
 lbl3 = upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}")
 lbl3.onFrame = True
-lbl3.text.font = 4
+lbl3.text.font = RAttrFont.kArial
 lbl3.text.size = 0.03
 lbl3.text.align = RAttrText.kLeftBottom
 

--- a/tutorials/rcanvas/df104.py
+++ b/tutorials/rcanvas/df104.py
@@ -21,7 +21,7 @@
 
 import ROOT
 import os
-from ROOT.Experimental import RCanvas, RText, RAttrText, RAttrFont, RLegend, RPadPos, RPadExtent, TObjectDrawable
+from ROOT.Experimental import RCanvas, RText, RAttrText, RAttrFont, RAttrFill, RLegend, RPadPos, RPadExtent, TObjectDrawable
 
 # Enable multi-threading
 ROOT.ROOT.EnableImplicitMT()
@@ -207,7 +207,7 @@ legend.text.align = RAttrText.kRightCenter
 legend.text.font = RAttrFont.kArial
 legend.border.style = 0
 legend.border.width = 0
-legend.fill.style = 0
+legend.fill.style = RAttrFill.kHollow
 
 legend.AddEntry(data_drawable, "Data", "lme")
 legend.AddEntry(bkg_drawable, "Background", "l")

--- a/tutorials/rcanvas/df104.py
+++ b/tutorials/rcanvas/df104.py
@@ -21,7 +21,7 @@
 
 import ROOT
 import os
-from ROOT.Experimental import RCanvas, RText, RLegend, RPadPos, RPadExtent, TObjectDrawable
+from ROOT.Experimental import RCanvas, RText, RAttrText, RLegend, RPadPos, RPadExtent, TObjectDrawable
 
 # Enable multi-threading
 ROOT.ROOT.EnableImplicitMT()
@@ -180,7 +180,6 @@ ratiobkg.GetYaxis().SetLabelSize(0.08)
 ratiobkg.GetYaxis().SetTitleSize(0.09)
 ratiobkg.GetYaxis().SetTitle("Data - Bkg.")
 ratiobkg.GetYaxis().CenterTitle()
-ratiobkg.GetYaxis().SetTitleOffset(0.7)
 ratiobkg.GetYaxis().SetNdivisions(503, False)
 ratiobkg.GetYaxis().ChangeLabel(-1, -1, 0)
 ratiobkg.GetXaxis().SetTitle("m_{#gamma#gamma} [GeV]")
@@ -202,35 +201,35 @@ for i in range(1, data.GetNbinsX()):
 lower_pad.Add[TObjectDrawable]().Set(ratiodata, "E SAME")
 
 # Add RLegend
-legend = upper_pad.Draw[RLegend](RPadPos(-0.05, 0.05), RPadExtent(0.3, 0.4))
+legend = upper_pad.Draw[RLegend](RPadPos(0.01, 0.01), RPadExtent(0.3, 0.4))
 legend.text.size = 0.05
-legend.text.align = 32
+legend.text.align = RAttrText.kRightCenter
 legend.text.font = 4
 legend.border.style = 0
 legend.border.width = 0
 legend.fill.style = 0
 
-legend.AddEntry(data_drawable, "Data")
-legend.AddEntry(bkg_drawable, "Background")
-legend.AddEntry(fit_drawable, "Signal + Bkg.")
-legend.AddEntry(higgs_drawable, "Signal")
+legend.AddEntry(data_drawable, "Data", "lme")
+legend.AddEntry(bkg_drawable, "Background", "l")
+legend.AddEntry(fit_drawable, "Signal + Bkg.", "l")
+legend.AddEntry(higgs_drawable, "Signal", "l")
 
 # Add ATLAS labels
 lbl1 = upper_pad.Draw[RText](RPadPos(0.05, 0.88), "ATLAS")
 lbl1.onFrame = True
 lbl1.text.font = 7
-lbl1.text.size = 0.05
-lbl1.text.align = 11
+lbl1.text.size = 0.04
+lbl1.text.align = RAttrText.kLeftBottom
 lbl2 = upper_pad.Draw[RText](RPadPos(0.05 + 0.16, 0.88), "Open Data")
 lbl2.onFrame = True
 lbl2.text.font = 4
-lbl2.text.size = 0.05
-lbl2.text.align = 11
+lbl2.text.size = 0.04
+lbl2.text.align = RAttrText.kLeftBottom
 lbl3 = upper_pad.Draw[RText](RPadPos(0.05, 0.82), "#sqrt{s} = 13 TeV, 10 fb^{-1}")
 lbl3.onFrame = True
 lbl3.text.font = 4
-lbl3.text.size = 0.04
-lbl3.text.align = 11
+lbl3.text.size = 0.03
+lbl3.text.align = RAttrText.kLeftBottom
 
 # show canvas finally
 c.SetSize(700, 780)

--- a/tutorials/rcanvas/df104.py
+++ b/tutorials/rcanvas/df104.py
@@ -21,7 +21,7 @@
 
 import ROOT
 import os
-from ROOT.Experimental import RCanvas, RText, RAttrText, RAttrFont, RAttrFill, RLegend, RPadPos, RPadExtent, TObjectDrawable
+from ROOT.Experimental import RCanvas, RText, RAttrText, RAttrFont, RAttrFill, RAttrLine, RLegend, RPadPos, RPadExtent, TObjectDrawable
 
 # Enable multi-threading
 ROOT.ROOT.EnableImplicitMT()
@@ -205,7 +205,7 @@ legend = upper_pad.Draw[RLegend](RPadPos(0.01, 0.01), RPadExtent(0.3, 0.4))
 legend.text.size = 0.05
 legend.text.align = RAttrText.kRightCenter
 legend.text.font = RAttrFont.kArial
-legend.border.style = 0
+legend.border.style = RAttrLine.kNone
 legend.border.width = 0
 legend.fill.style = RAttrFill.kHollow
 

--- a/tutorials/rcanvas/df105.py
+++ b/tutorials/rcanvas/df105.py
@@ -24,7 +24,7 @@ import ROOT
 import json
 import argparse
 import os
-from ROOT.Experimental import RCanvas, RText, RAttrText, RPadPos, TObjectDrawable
+from ROOT.Experimental import RCanvas, RText, RAttrText, RAttrFont, RPadPos, TObjectDrawable
 
 # Argument parsing
 parser = argparse.ArgumentParser()
@@ -217,17 +217,17 @@ c.Add[TObjectDrawable]().Set(legend)
 # Add ATLAS label
 lbl1 = c.Add[RText](RPadPos(0.05, 0.88), "ATLAS")
 lbl1.onFrame = True
-lbl1.text.font = 7
+lbl1.text.font = RAttrFont.kArialBoldOblique
 lbl1.text.size = 0.04
 lbl1.text.align = RAttrText.kLeftBottom
 lbl2 = c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data")
 lbl2.onFrame = True
-lbl2.text.font = 4
+lbl2.text.font = RAttrFont.kArial
 lbl2.text.size = 0.04
 lbl2.text.align = RAttrText.kLeftBottom
 lbl3 = c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0))
 lbl3.onFrame = True
-lbl3.text.font = 4
+lbl3.text.font = RAttrFont.kArial
 lbl3.text.size = 0.03
 lbl3.text.align = RAttrText.kLeftBottom
 

--- a/tutorials/rcanvas/df105.py
+++ b/tutorials/rcanvas/df105.py
@@ -24,7 +24,7 @@ import ROOT
 import json
 import argparse
 import os
-from ROOT.Experimental import RCanvas, RText, RPadPos, TObjectDrawable
+from ROOT.Experimental import RCanvas, RText, RAttrText, RPadPos, TObjectDrawable
 
 # Argument parsing
 parser = argparse.ArgumentParser()
@@ -218,18 +218,18 @@ c.Add[TObjectDrawable]().Set(legend)
 lbl1 = c.Add[RText](RPadPos(0.05, 0.88), "ATLAS")
 lbl1.onFrame = True
 lbl1.text.font = 7
-lbl1.text.size = 0.05
-lbl1.text.align = 11
+lbl1.text.size = 0.04
+lbl1.text.align = RAttrText.kLeftBottom
 lbl2 = c.Add[RText](RPadPos(0.05 + 0.20, 0.88), "Open Data")
 lbl2.onFrame = True
 lbl2.text.font = 4
-lbl2.text.size = 0.05
-lbl2.text.align = 11
+lbl2.text.size = 0.04
+lbl2.text.align = RAttrText.kLeftBottom
 lbl3 = c.Add[RText](RPadPos(0.05, 0.82), "#sqrt{{s}} = 13 TeV, {:.2f} fb^{{-1}}".format(lumi * args.lumi_scale / 1000.0))
 lbl3.onFrame = True
 lbl3.text.font = 4
-lbl3.text.size = 0.04
-lbl3.text.align = 11
+lbl3.text.size = 0.03
+lbl3.text.align = RAttrText.kLeftBottom
 
 # show canvas finally
 c.SetSize(600, 600)

--- a/tutorials/rcanvas/raxis.cxx
+++ b/tutorials/rcanvas/raxis.cxx
@@ -77,7 +77,7 @@ void raxis()
    draw7->axis.log = 10;
    draw7->axis.title = "log10 scale";
    draw7->axis.title.SetCenter();
-   draw7->axis.title.font = 12;
+   draw7->axis.title.font = RAttrFont::kVerdana;
    draw7->axis.title.color = RColor::kGreen;
    draw7->axis.ending.SetCircle();
 

--- a/tutorials/rcanvas/rbox.cxx
+++ b/tutorials/rcanvas/rbox.cxx
@@ -29,16 +29,19 @@ void rbox()
    box1->border.color = RColor::kBlue;
    box1->border.width = 5;
    box1->fill.color = RColor(0, 255, 0, 127); // 50% opaque
+   box1->fill.style = RAttrFill::kSolid;
 
    auto box2 = canvas->Draw<RBox>(RPadPos(0.4_normal, 0.2_normal), RPadPos(0.6_normal,0.7_normal));
    box2->border.color = RColor::kRed;
    box2->border.width = 10.f;
    box2->border.style = 2;
    box2->fill.color = RColor(0, 0, 255, 179); // 70% opaque
+   box2->fill.style = RAttrFill::kSolid;
 
    auto box3 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.4_normal), RPadPos(0.9_normal,0.6_normal));
    box3->border.width = 3;
    box3->fill.color = RColor::kBlue;
+   box3->fill.style = RAttrFill::kSolid;
 
    auto box4 = canvas->Draw<RBox>(RPadPos(0.7_normal, 0.7_normal), RPadPos(0.9_normal,0.9_normal));
    box4->border.width = 4;

--- a/tutorials/rcanvas/rbox.cxx
+++ b/tutorials/rcanvas/rbox.cxx
@@ -34,7 +34,7 @@ void rbox()
    auto box2 = canvas->Draw<RBox>(RPadPos(0.4_normal, 0.2_normal), RPadPos(0.6_normal,0.7_normal));
    box2->border.color = RColor::kRed;
    box2->border.width = 10.f;
-   box2->border.style = 2;
+   box2->border.style = RAttrLine::kDashed;
    box2->fill.color = RColor(0, 0, 255, 179); // 70% opaque
    box2->fill.style = RAttrFill::kSolid;
 

--- a/tutorials/rcanvas/rbox.py
+++ b/tutorials/rcanvas/rbox.py
@@ -15,7 +15,7 @@
 ## \author Sergey Linev
 
 import ROOT
-from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor
+from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor, RAttrFill
 
 # Create a canvas to be displayed.
 canvas = RCanvas.Create("RBox drawing")
@@ -24,16 +24,19 @@ box1 = canvas.Draw[RBox](RPadPos(0.1, 0.1), RPadPos(0.3, 0.6))
 box1.border.color = RColor.kBlue
 box1.border.width = 5
 box1.fill.color = RColor(0, 255, 0, 127) # 50% opaque
+box1.fill.style = RAttrFill.kSolid
 
 box2 = canvas.Draw[RBox](RPadPos(0.4, 0.2), RPadPos(0.6, 0.7))
 box2.border.color = RColor.kRed
 box2.border.width = 10
 box2.border.style = 2
 box2.fill.color = RColor(0, 0, 255, 179) # 70% opaque
+box2.fill.style = RAttrFill.kSolid
 
 box3 = canvas.Draw[RBox](RPadPos(0.7, 0.4), RPadPos(0.9, 0.6))
 box3.border.width = 3
 box3.fill.color = RColor.kBlue
+box3.fill.style = RAttrFill.kSolid
 
 box4 = canvas.Draw[RBox](RPadPos(0.7, 0.7), RPadPos(0.9, 0.9))
 box4.border.width = 4

--- a/tutorials/rcanvas/rbox.py
+++ b/tutorials/rcanvas/rbox.py
@@ -15,7 +15,7 @@
 ## \author Sergey Linev
 
 import ROOT
-from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor, RAttrFill
+from ROOT.Experimental import RCanvas, RBox, RPadPos, RColor, RAttrFill, RAttrLine
 
 # Create a canvas to be displayed.
 canvas = RCanvas.Create("RBox drawing")
@@ -29,7 +29,7 @@ box1.fill.style = RAttrFill.kSolid
 box2 = canvas.Draw[RBox](RPadPos(0.4, 0.2), RPadPos(0.6, 0.7))
 box2.border.color = RColor.kRed
 box2.border.width = 10
-box2.border.style = 2
+box2.border.style = RAttrLine.kDashed
 box2.fill.color = RColor(0, 0, 255, 179) # 70% opaque
 box2.fill.style = RAttrFill.kSolid
 

--- a/tutorials/rcanvas/rframe.cxx
+++ b/tutorials/rcanvas/rframe.cxx
@@ -43,9 +43,10 @@ void rframe()
    // configure RFrame with direct API calls
    auto frame = canvas->AddFrame();
    // frame->fill.color = RColor::kBlue;
+   // frame->fill.style = RAttrFill::kSolid;
    frame->border.color = RColor::kBlue;
    frame->border.width = 3;
-   frame->margins = 0.2_normal; // set all mergins first
+   frame->margins = 0.2_normal; // set all margins first
    frame->margins.top = 0.25_normal;
 
    // let frame draw axes without need of any histogram
@@ -99,6 +100,7 @@ void rframe()
    // draw box before line at same position as line ending with 40x40 px size and clipping on
    auto box4 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 80_user - 20_px), RPadPos(80_user + 20_px, 80_user + 20_px));
    box4->fill.color = RColor::kBlue;
+   box4->fill.style = RAttrFill::kSolid;
    box4->clipping = true; // or via CSS "clipping: true;"
    box4->onFrame = true; // or via CSS "onFrame: true;"
 
@@ -114,6 +116,7 @@ void rframe()
    // draw box before line at same position as line ending with 40x40 px size
    auto box5 = canvas->Draw<RBox>(RPadPos(80_user - 20_px, 20_user - 20_px), RPadPos(80_user + 20_px, 20_user + 20_px));
    box5->fill.color = RColor::kYellow;
+   box5->fill.style = RAttrFill::kSolid;
    box5->onFrame = true; // or via CSS "onFrame: true;"
 
    // draw line in the frame, but disable default cutting by the frame borders

--- a/tutorials/rcanvas/rframe.cxx
+++ b/tutorials/rcanvas/rframe.cxx
@@ -71,7 +71,7 @@ void rframe()
    // draw line over the frame
    auto line0 = canvas->Draw<RLine>(RPadPos(100_px, .9_normal), RPadPos(900_px , .9_normal));
    auto text0 = canvas->Draw<RText>(RPadPos(100_px, .9_normal + 5_px), "Line drawn on pad, fix pixel length");
-   text0->text.align = 11;
+   text0->text.align = RAttrText::kLeftBottom;
 
    // draw line under the frame
    auto line1 = canvas->Draw<RLine>(RPadPos(.1_normal, .1_normal), RPadPos(.9_normal, .1_normal));
@@ -85,7 +85,7 @@ void rframe()
    auto text2 = canvas->Draw<RText>(RPadPos(-.2_normal - 5_px, -.1_normal), "Line drawn on frame, normalized coordinates");
    text2->onFrame = true; // or via CSS "onFrame: true;"
    text2->text.angle = 90;
-   text2->text.align = 11;
+   text2->text.align = RAttrText::kLeftBottom;
 
    // draw on right size of frame, user coordiante, moved and zoomed with frame
    auto line3 = canvas->Draw<RLine>(RPadPos(110_user, -.1_normal), RPadPos(110_user, 1.1_normal));
@@ -122,7 +122,7 @@ void rframe()
 
    auto text5 = canvas->Draw<RText>(RPadPos(20_user, 80_user), "clipping off");
    text5->onFrame = true; // or via CSS "onFrame: true;"
-   text5->text.align = 11;
+   text5->text.align = RAttrText::kLeftBottom;
 
    canvas->UseStyle(rframe_style);
 

--- a/tutorials/rcanvas/rh1.cxx
+++ b/tutorials/rcanvas/rh1.cxx
@@ -70,7 +70,7 @@ void rh1()
    // text and marker draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
    subpads[0][1]->Draw(pHist1)->Text().text.color = col1;
-   subpads[0][1]->Draw(pHist2)->Marker().marker = RAttrMarker(col2, 1.5, RAttrMarker::kOpenStar);
+   subpads[0][1]->Draw(pHist2)->Marker().marker = RAttrMarker(col2, 0.02, RAttrMarker::kOpenStar);
 
    // bar draw options
    subpads[1][1]->Draw<RFrameTitle>("Bar() draw options");

--- a/tutorials/rcanvas/rh1.cxx
+++ b/tutorials/rcanvas/rh1.cxx
@@ -65,7 +65,7 @@ void rh1()
    // errors draw options
    subpads[1][0]->Draw<RFrameTitle>("Error() draw options");
    subpads[1][0]->Draw(pHist1)->Error(1).line.color = col1;
-   subpads[1][0]->Draw(pHist2)->Error(4).fill = RAttrFill(col2, 3003);
+   subpads[1][0]->Draw(pHist2)->Error(4).fill = RAttrFill(col2, RAttrFill::k3003);
 
    // text and marker draw options
    subpads[0][1]->Draw<RFrameTitle>("Text() and Marker() draw options");
@@ -74,8 +74,8 @@ void rh1()
 
    // bar draw options
    subpads[1][1]->Draw<RFrameTitle>("Bar() draw options");
-   subpads[1][1]->Draw(pHist1)->Bar(0,0.5).fill.color = col1;
-   subpads[1][1]->Draw(pHist2)->Bar(0.5,0.5,true).fill.color = col2;
+   subpads[1][1]->Draw(pHist1)->Bar(0,0.5).fill = RAttrFill(col1, RAttrFill::kSolid);
+   subpads[1][1]->Draw(pHist2)->Bar(0.5,0.5,true).fill = RAttrFill(col2, RAttrFill::kSolid);
 
    // line draw option
    subpads[0][2]->Draw<RFrameTitle>("Line() draw option");
@@ -84,7 +84,7 @@ void rh1()
 
    // lego draw option
    subpads[1][2]->Draw<RFrameTitle>("Lego() draw option");
-   subpads[1][2]->Draw(pHist1)->Lego().fill.color = col1;
+   subpads[1][2]->Draw(pHist1)->Lego().fill = RAttrFill(col1, RAttrFill::kSolid);
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rh1_large.cxx
+++ b/tutorials/rcanvas/rh1_large.cxx
@@ -61,6 +61,7 @@ void rh1_large()
 
    draw->line.color = RColor::kLime;
    // draw->fill.color = RColor::kLime;
+   // draw->fill.style = RAttrFill::kSolid;
    // draw->Line(); // configure line draw option
    // draw->Bar(); // configure bar draw option
    // draw->Error(3); // configure error drawing
@@ -70,6 +71,7 @@ void rh1_large()
 
    auto stat = canvas->Draw<RHist1StatBox>(pHist, "hist");
    stat->fill.color = RColor::kBlue;
+   stat->fill.style = RAttrFill::kSolid;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rh2_colz.cxx
+++ b/tutorials/rcanvas/rh2_colz.cxx
@@ -85,6 +85,7 @@ void rh2_colz()
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist2");
    stat->fill.color = RColor::kRed;
+   stat->fill.style = RAttrFill::kSolid;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rh2_large.cxx
+++ b/tutorials/rcanvas/rh2_large.cxx
@@ -79,6 +79,7 @@ void rh2_large()
 
    auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
    stat->fill.color = RColor::kBlue;
+   stat->fill.style = RAttrFill::kSolid;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rh3.cxx
+++ b/tutorials/rcanvas/rh3.cxx
@@ -51,7 +51,7 @@ void rh3()
 
    // default draw option
    subpads[0][0]->Draw<RFrameTitle>("Box(0) default draw option");
-   subpads[0][0]->Draw(pHist)->Box(0).fill.color = RColor::kBlue;
+   subpads[0][0]->Draw(pHist)->Box(0).fill = RAttrFill(RColor::kBlue, RAttrFill::kSolid);
 
    // sphere draw options
    subpads[1][0]->Draw<RFrameTitle>("Sphere(1) draw option");
@@ -63,7 +63,7 @@ void rh3()
 
    // arrow draw options
    subpads[1][1]->Draw<RFrameTitle>("Scatter() draw option");
-   subpads[1][1]->Draw(pHist)->Scatter().fill.color = RColor::kBlack;
+   subpads[1][1]->Draw(pHist)->Scatter().fill = RAttrFill(RColor::kBlack, RAttrFill::kSolid);
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rh3_large.cxx
+++ b/tutorials/rcanvas/rh3_large.cxx
@@ -74,8 +74,9 @@ void rh3_large()
 
    draw->optimize = true; // enable draw optimization, reduced data set will be send to clients
 
-   //auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
-   //stat->fill.color = RColor::kBlue;
+   // auto stat = canvas->Draw<RHist2StatBox>(pHist, "hist");
+   // stat->fill.color = RColor::kBlue;
+   // stat->fill.style = RAttrFill::kSolid;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rlegend.cxx
+++ b/tutorials/rcanvas/rlegend.cxx
@@ -72,7 +72,7 @@ void rlegend()
    auto custom = legend->AddEntry("test", "lfm");
    custom->line.color = RColor::kGreen;
    custom->line.width = 5.;
-   custom->line.style = 1;
+   custom->line.style = RAttrLine::kSolid;
    custom->fill.color = RColor::kBlue;
    custom->fill.style = RAttrFill::k3004;
    custom->marker.color = RColor::kRed;

--- a/tutorials/rcanvas/rlegend.cxx
+++ b/tutorials/rcanvas/rlegend.cxx
@@ -65,12 +65,19 @@ void rlegend()
    legend->fill.color = RColor::kWhite;
    legend->border.color = RColor::kRed;
    legend->border.width = 2;
-   legend->AddEntry(draw1, "histo1");
-   legend->AddEntry(draw2, "histo2");
+   legend->AddEntry(draw1, "histo1", "l");
+   legend->AddEntry(draw2, "histo2", "l");
 
-   legend->AddEntry("test").SetAttrLine(RAttrLine(RColor::kGreen, 5., 1))
-                           .SetAttrFill(RAttrFill(RColor::kBlue, 3004))
-                           .SetAttrMarker(RAttrMarker(RColor::kRed, 3., RAttrMarker::kOpenCross));
+   // add custom entry, showing line, fill and marker attributes
+   auto custom = legend->AddEntry("test", "lfm");
+   custom->line.color = RColor::kGreen;
+   custom->line.width = 5.;
+   custom->line.style = 1;
+   custom->fill.color = RColor::kBlue;
+   custom->fill.style = 3004;
+   custom->marker.color = RColor::kRed;
+   custom->marker.size = 3.;
+   custom->marker.style = RAttrMarker::kOpenCross;
 
    canvas->SetSize(1000, 700);
    canvas->Show();

--- a/tutorials/rcanvas/rlegend.cxx
+++ b/tutorials/rcanvas/rlegend.cxx
@@ -76,7 +76,7 @@ void rlegend()
    custom->fill.color = RColor::kBlue;
    custom->fill.style = RAttrFill::k3004;
    custom->marker.color = RColor::kRed;
-   custom->marker.size = 3.;
+   custom->marker.size = 0.03;
    custom->marker.style = RAttrMarker::kOpenCross;
 
    canvas->SetSize(1000, 700);

--- a/tutorials/rcanvas/rlegend.cxx
+++ b/tutorials/rcanvas/rlegend.cxx
@@ -61,8 +61,8 @@ void rlegend()
    draw2->line.color = .7f; // should be blue color
 
    auto legend = canvas->Draw<RLegend>("Legend title");
-   legend->fill.style = 5;
-   legend->fill.color = RColor::kWhite;
+   legend->fill.color = RColor(0, 0, 120, 25);
+   legend->fill.style = RAttrFill::k3019;
    legend->border.color = RColor::kRed;
    legend->border.width = 2;
    legend->AddEntry(draw1, "histo1", "l");
@@ -74,7 +74,7 @@ void rlegend()
    custom->line.width = 5.;
    custom->line.style = 1;
    custom->fill.color = RColor::kBlue;
-   custom->fill.style = 3004;
+   custom->fill.style = RAttrFill::k3004;
    custom->marker.color = RColor::kRed;
    custom->marker.size = 3.;
    custom->marker.style = RAttrMarker::kOpenCross;

--- a/tutorials/rcanvas/rline_style.cxx
+++ b/tutorials/rcanvas/rline_style.cxx
@@ -22,12 +22,12 @@ void rline_style()
    auto canvas = RCanvas::Create("Different RLine styles");
    double num = 0.3;
 
-   for (int i=10; i>0; i--){
+   for (int i = 10; i > 0; i--){
       num = num + 0.05;
 
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
-      text->text.size = 13;
-      text->text.align = 32;
+      text->text.size = 0.04;
+      text->text.align = RAttrText::kRightCenter;
       text->text.font = 5;
 
       auto draw = canvas->Add<RLine>(RPadPos{.32_normal,1_normal*num}, RPadPos{.8_normal, 1_normal*num});

--- a/tutorials/rcanvas/rline_style.cxx
+++ b/tutorials/rcanvas/rline_style.cxx
@@ -28,7 +28,7 @@ void rline_style()
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
       text->text.size = 0.04;
       text->text.align = RAttrText::kRightCenter;
-      text->text.font = 5;
+      text->text.font = RAttrFont::kArialOblique;
 
       auto draw = canvas->Add<RLine>(RPadPos{.32_normal,1_normal*num}, RPadPos{.8_normal, 1_normal*num});
       draw->line.style = i;

--- a/tutorials/rcanvas/rline_style.cxx
+++ b/tutorials/rcanvas/rline_style.cxx
@@ -20,18 +20,27 @@ void rline_style()
    using namespace ROOT::Experimental;
 
    auto canvas = RCanvas::Create("Different RLine styles");
-   double num = 0.3;
+   auto posy = 0.9_normal;
 
-   for (int i = 10; i > 0; i--){
-      num = num + 0.05;
+   for (int i = 1; i <= 11; i++) {
+      std::string lbl;
+      if (i < 11)
+         lbl = std::to_string(i);
+      else
+         lbl = "Custom";
 
-      auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
+      auto text = canvas->Add<RText>(RPadPos{.3_normal, posy}, lbl);
       text->text.size = 0.04;
       text->text.align = RAttrText::kRightCenter;
       text->text.font = RAttrFont::kArialOblique;
 
-      auto draw = canvas->Add<RLine>(RPadPos{.32_normal,1_normal*num}, RPadPos{.8_normal, 1_normal*num});
-      draw->line.style = i;
+      auto draw = canvas->Add<RLine>(RPadPos{.32_normal, posy}, RPadPos{.8_normal, posy});
+      if (i < 11)
+         draw->line.style = (RAttrLine::EStyle) i;
+      else
+         draw->line.pattern = "10,2,8,2,10,6,1,6";
+
+      posy -= 0.05_normal;
    }
 
    canvas->Show();

--- a/tutorials/rcanvas/rline_width.cxx
+++ b/tutorials/rcanvas/rline_width.cxx
@@ -26,8 +26,8 @@ void rline_width()
       num = num + 0.05;
 
       auto text = canvas->Add<RText>(RPadPos(.3_normal, 1_normal*num), std::to_string(i));
-      text->text.size = 13;
-      text->text.align = 32;
+      text->text.size = 0.04;
+      text->text.align = RAttrText::kRightCenter;
       text->text.font = 5;
 
       auto draw = canvas->Add<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal, 1_normal*num));

--- a/tutorials/rcanvas/rline_width.cxx
+++ b/tutorials/rcanvas/rline_width.cxx
@@ -28,7 +28,7 @@ void rline_width()
       auto text = canvas->Add<RText>(RPadPos(.3_normal, 1_normal*num), std::to_string(i));
       text->text.size = 0.04;
       text->text.align = RAttrText::kRightCenter;
-      text->text.font = 5;
+      text->text.font = RAttrFont::kArialOblique;
 
       auto draw = canvas->Add<RLine>(RPadPos(.32_normal, 1_normal*num), RPadPos(.8_normal, 1_normal*num));
       draw->line.width = i;

--- a/tutorials/rcanvas/rmarker.cxx
+++ b/tutorials/rcanvas/rmarker.cxx
@@ -46,7 +46,7 @@ void rmarker()
          auto draw = canvas->Draw<RMarker>(pm);
          draw->marker.style = (RAttrMarker::EStyle) style;
          draw->marker.color = RColor::kBlue;
-         draw->marker.size = 2.5;
+         draw->marker.size = 0.1; // relative to pad height
       }
    }
 

--- a/tutorials/rcanvas/rmarker.cxx
+++ b/tutorials/rcanvas/rmarker.cxx
@@ -1,7 +1,7 @@
 /// \file
 /// \ingroup tutorial_rcanvas
 ///
-/// This ROOT 7 example shows the various marker style.
+/// This ROOT 7 example shows the various marker styles.
 ///
 /// \macro_image (rcanvas_js)
 /// \macro_code
@@ -25,7 +25,7 @@ void rmarker()
 
    double x = 0;
    double dx = 1/16.0;
-   for (int i=1;i<16;i++) {
+   for (int i = 1; i < 16; i++) {
       x += dx;
       for (int row=0;row<3;++row) {
          int style = i;
@@ -35,12 +35,17 @@ void rmarker()
          else if (row==2)
             style += 34;
 
-         RPadPos pt(RPadLength::Normal(x), .12_normal + 0.3_normal*row);
-         canvas->Draw<RText>(pt, std::to_string(style));
+         RPadPos pt(RPadLength::Normal(x), .17_normal + 0.3_normal*row);
+         auto text = canvas->Draw<RText>(pt, std::to_string(style));
+         text->text.font = RAttrFont::kVerdana;
+         text->text.size = 0.05;
+         text->text.align = RAttrText::kCenterTop;
+         text->text.color = RColor::kGreen;
 
          RPadPos pm(RPadLength::Normal(x), .25_normal + 0.3_normal*row);
          auto draw = canvas->Draw<RMarker>(pm);
-         draw->marker.style = style;
+         draw->marker.style = (RAttrMarker::EStyle) style;
+         draw->marker.color = RColor::kBlue;
          draw->marker.size = 2.5;
       }
    }

--- a/tutorials/rcanvas/rmarker.cxx
+++ b/tutorials/rcanvas/rmarker.cxx
@@ -30,7 +30,10 @@ void rmarker()
       for (int row=0;row<3;++row) {
          int style = i;
 
-         if (row==1) style+=19; else if (row==2) style+=34;
+         if (row == 1)
+            style += 19;
+         else if (row==2)
+            style += 34;
 
          RPadPos pt(RPadLength::Normal(x), .12_normal + 0.3_normal*row);
          canvas->Draw<RText>(pt, std::to_string(style));

--- a/tutorials/rcanvas/rpave.cxx
+++ b/tutorials/rcanvas/rpave.cxx
@@ -31,20 +31,32 @@ void rpave()
    // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("RPave example");
 
-   // RFrame will be automatically created as well
+   // this pave should be in top left corner
    auto pave = canvas->Draw<RPave>();
    pave->fill.color = RColor::kBlue;
    pave->border.color = RColor::kGreen;
    pave->border.width = 3;
-   pave->cornerY = -0.03_normal;
-   pave->height = 0.2_normal;
+   pave->corner = RPave::kTopLeft;
+   pave->offsetX = pave->offsetY = 0.05_normal;
+   pave->width = 0.3_normal;
+   pave->height = 0.3_normal;
+
+   // this second pave in the bottom left corner
+   auto pave2 = canvas->Draw<RPave>();
+   pave2->fill.color = RColor::kRed;
+   pave2->corner = RPave::kBottomLeft;
+   pave2->offsetX = pave2->offsetY = 0.05_normal;
+   pave2->width = 0.3_normal;
+   pave2->height = 0.3_normal;
 
    auto text = canvas->Draw<RPaveText>();
    text->AddLine("This is RPaveText");
    text->AddLine("It can have several lines");
-   text->AddLine("It should be positioned below RPave");
+   text->AddLine("It should be in top right corner");
    text->fill.color = RColor::kYellow;
-   text->cornerY = 0.25_normal;
+   text->corner = RPave::kTopRight;
+   text->offsetX = text->offsetY = 0.05_normal;
+   text->width = 0.4_normal;
    text->height = 0.3_normal;
 
    std::string fname = __FILE__;
@@ -54,13 +66,14 @@ void rpave()
    canvas->Draw<RFont>("CustomFont", fname);
 
    auto text2 = canvas->Draw<RPaveText>();
-   text2->AddLine("Example of custom font");
+   text2->AddLine("RPaveText with custom font");
    text2->AddLine("It loaded from comic.woff2 file");
    text2->AddLine("One also can provide valid URL");
    text2->fill.color = RColor::kGreen;
-   text2->cornerX = -0.4_normal;
-   text2->cornerY = -0.03_normal;
-   text2->height = 0.2_normal;
+   text2->corner = RPave::kBottomRight;
+   text2->offsetX = text2->offsetY = 0.05_normal;
+   text2->width = 0.4_normal;
+   text2->height = 0.3_normal;
    text2->text.font.family = "CustomFont";
 
    canvas->SetSize(1000, 700);

--- a/tutorials/rcanvas/rpave.cxx
+++ b/tutorials/rcanvas/rpave.cxx
@@ -34,6 +34,7 @@ void rpave()
    // this pave should be in top left corner
    auto pave = canvas->Draw<RPave>();
    pave->fill.color = RColor::kBlue;
+   pave->fill.style = RAttrFill::k3001;
    pave->border.color = RColor::kGreen;
    pave->border.width = 3;
    pave->corner = RPave::kTopLeft;
@@ -44,6 +45,7 @@ void rpave()
    // this second pave in the bottom left corner
    auto pave2 = canvas->Draw<RPave>();
    pave2->fill.color = RColor::kRed;
+   pave2->fill.style = RAttrFill::k3002;
    pave2->corner = RPave::kBottomLeft;
    pave2->offsetX = pave2->offsetY = 0.05_normal;
    pave2->width = 0.3_normal;
@@ -54,6 +56,7 @@ void rpave()
    text->AddLine("It can have several lines");
    text->AddLine("It should be in top right corner");
    text->fill.color = RColor::kYellow;
+   text->fill.style = RAttrFill::k3003;
    text->corner = RPave::kTopRight;
    text->offsetX = text->offsetY = 0.05_normal;
    text->width = 0.4_normal;
@@ -70,6 +73,7 @@ void rpave()
    text2->AddLine("It loaded from comic.woff2 file");
    text2->AddLine("One also can provide valid URL");
    text2->fill.color = RColor::kGreen;
+   text2->fill.style = RAttrFill::k3004;
    text2->corner = RPave::kBottomRight;
    text2->offsetX = text2->offsetY = 0.05_normal;
    text2->width = 0.4_normal;

--- a/tutorials/rcanvas/rstyle.cxx
+++ b/tutorials/rcanvas/rstyle.cxx
@@ -29,8 +29,8 @@ void rstyle()
       num = num + 0.05;
 
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
-      text->text.size = 13;
-      text->text.align = 32;
+      text->text.size = 0.04;
+      text->text.align = RAttrText::kRightCenter;
       text->text.font = 5;
 
       auto line = canvas->Add<RLine>(RPadPos(.32_normal,1_normal*num), RPadPos(.8_normal, 1_normal*num));

--- a/tutorials/rcanvas/rstyle.cxx
+++ b/tutorials/rcanvas/rstyle.cxx
@@ -31,7 +31,7 @@ void rstyle()
       auto text = canvas->Add<RText>(RPadPos{.3_normal, 1_normal*num}, std::to_string(i));
       text->text.size = 0.04;
       text->text.align = RAttrText::kRightCenter;
-      text->text.font = 5;
+      text->text.font = RAttrFont::kArialOblique;
 
       auto line = canvas->Add<RLine>(RPadPos(.32_normal,1_normal*num), RPadPos(.8_normal, 1_normal*num));
       line->SetId(std::string("obj") + std::to_string(i));

--- a/tutorials/rcanvas/rtext_align.cxx
+++ b/tutorials/rcanvas/rtext_align.cxx
@@ -32,7 +32,7 @@ void rtext_align()
    auto canvas = RCanvas::Create("RText align example");
 
    auto box = canvas->Add<RBox>(RPadPos(0.1_normal, 0.1_normal), RPadPos(0.9_normal, 0.9_normal));
-   box->border.style = 6;
+   box->border.style = RAttrLine::kStyle6;
 
    auto drawText = [&canvas](double x, double y, RAttrText::EAlign align, const std::string &lbl) {
       auto dbox = canvas->Add<RBox>(RPadPos(x-0.003, y-0.003), RPadPos(x+0.003, y+0.003));

--- a/tutorials/rcanvas/rtext_align.cxx
+++ b/tutorials/rcanvas/rtext_align.cxx
@@ -1,0 +1,67 @@
+/// \file
+/// \ingroup tutorial_rcanvas
+///
+/// This macro demonstrate the text attributes for RText. Angle, size and color are
+/// changed in a loop. The text alignment and the text font are fixed.
+///
+/// \macro_image (rcanvas_js)
+/// \macro_code
+///
+/// \date 2021-07-07
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RColor.hxx"
+#include "ROOT/RText.hxx"
+#include "ROOT/RBox.hxx"
+#include "ROOT/RPadPos.hxx"
+
+using namespace ROOT::Experimental;
+
+void rtext_align()
+{
+   // Create a canvas to be displayed.
+   auto canvas = RCanvas::Create("RText align example");
+
+   auto box = canvas->Add<RBox>(RPadPos(0.1_normal, 0.1_normal), RPadPos(0.9_normal, 0.9_normal));
+   box->border.style = 6;
+
+   auto drawText = [&canvas](double x, double y, RAttrText::EAlign align, const std::string &lbl) {
+      auto dbox = canvas->Add<RBox>(RPadPos(x-0.003, y-0.003), RPadPos(x+0.003, y+0.003));
+      dbox->fill.color = RColor::kRed;
+
+      auto text = canvas->Add<RText>(RPadPos(x, y), lbl);
+      text->text.size = 0.07;
+      text->text.align = align;
+   };
+
+   drawText(0.1, 0.9, RAttrText::kLeftTop, "kLeftTop");
+
+   drawText(0.1, 0.5, RAttrText::kLeftCenter, "kLeftCenter");
+
+   drawText(0.1, 0.1, RAttrText::kLeftBottom, "kLeftBottom");
+
+   drawText(0.9, 0.9, RAttrText::kRightTop, "kRightTop");
+
+   drawText(0.9, 0.5, RAttrText::kRightCenter, "kRightCenter");
+
+   drawText(0.9, 0.1, RAttrText::kRightBottom, "kRightBottom");
+
+   drawText(0.5, 0.5, RAttrText::kCenter, "kCenter");
+
+   drawText(0.5, 0.9, RAttrText::kCenterTop, "kCenterTop");
+
+   drawText(0.5, 0.1, RAttrText::kCenterBottom, "kCenterBottom");
+
+   canvas->Show();
+}

--- a/tutorials/rcanvas/rtext_align.cxx
+++ b/tutorials/rcanvas/rtext_align.cxx
@@ -1,8 +1,7 @@
 /// \file
 /// \ingroup tutorial_rcanvas
 ///
-/// This macro demonstrate the text attributes for RText. Angle, size and color are
-/// changed in a loop. The text alignment and the text font are fixed.
+/// This macro demonstrate the text align attribute for RText.
 ///
 /// \macro_image (rcanvas_js)
 /// \macro_code
@@ -30,7 +29,6 @@ using namespace ROOT::Experimental;
 
 void rtext_align()
 {
-   // Create a canvas to be displayed.
    auto canvas = RCanvas::Create("RText align example");
 
    auto box = canvas->Add<RBox>(RPadPos(0.1_normal, 0.1_normal), RPadPos(0.9_normal, 0.9_normal));

--- a/tutorials/rcanvas/rtext_align.cxx
+++ b/tutorials/rcanvas/rtext_align.cxx
@@ -37,6 +37,7 @@ void rtext_align()
    auto drawText = [&canvas](double x, double y, RAttrText::EAlign align, const std::string &lbl) {
       auto dbox = canvas->Add<RBox>(RPadPos(x-0.003, y-0.003), RPadPos(x+0.003, y+0.003));
       dbox->fill.color = RColor::kRed;
+      dbox->fill.style = RAttrFill::kSolid;
 
       auto text = canvas->Add<RText>(RPadPos(x, y), lbl);
       text->text.size = 0.07;

--- a/tutorials/rcanvas/rtext_angle.cxx
+++ b/tutorials/rcanvas/rtext_angle.cxx
@@ -25,20 +25,20 @@
 #include "ROOT/RText.hxx"
 #include "ROOT/RPadPos.hxx"
 
-void rtext()
+using namespace ROOT::Experimental;
+
+void rtext_angle()
 {
-   using namespace ROOT::Experimental;
-
    // Create a canvas to be displayed.
-   auto canvas = RCanvas::Create("RText example");
+   auto canvas = RCanvas::Create("RText angle example");
 
-   for (int i=0; i<=360; i+=10) {
+   for (double angle = 0; angle <= 360; angle += 10) {
       auto draw = canvas->Draw<RText>(RPadPos(0.5_normal, 0.6_normal), "____  Hello World");
 
-      draw->text.color = RColor((int) (0.38*i), (int) (0.64*i), (int) (0.76*i));
-      draw->text.size = 10+i/10;
-      draw->text.angle = i;
-      draw->text.align = 13;
+      draw->text.color = RColor((int) (0.38*angle), (int) (0.64*angle), (int) (0.76*angle));
+      draw->text.size = 0.01 + angle/5000.;
+      draw->text.angle = angle;
+      draw->text.align = RAttrText::kLeftTop;
       draw->text.font = 4;
    }
 

--- a/tutorials/rcanvas/rtext_angle.cxx
+++ b/tutorials/rcanvas/rtext_angle.cxx
@@ -39,7 +39,7 @@ void rtext_angle()
       draw->text.size = 0.01 + angle/5000.;
       draw->text.angle = angle;
       draw->text.align = RAttrText::kLeftTop;
-      draw->text.font = 4;
+      draw->text.font = RAttrFont::kArial;
    }
 
    canvas->Show();

--- a/tutorials/rcanvas/rtext_font.cxx
+++ b/tutorials/rcanvas/rtext_font.cxx
@@ -1,0 +1,82 @@
+/// \file
+/// \ingroup tutorial_rcanvas
+///
+/// This macro demonstrate usage of existing ROOT fonts for RText.
+/// Also load of custom font is shown
+///
+/// \macro_image (rcanvas_js)
+/// \macro_code
+///
+/// \date 2021-07-07
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+/// \author Sergey Linev <s.linev@gsi.de>
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RCanvas.hxx"
+#include "ROOT/RText.hxx"
+#include "ROOT/RPadPos.hxx"
+
+using namespace ROOT::Experimental;
+
+void rtext_font()
+{
+   auto canvas = RCanvas::Create("RText fonts example");
+
+   double posy = 0.93;
+
+   auto drawText = [&canvas, &posy](RAttrFont::EFont font, bool is_comic = false) {
+      auto text = canvas->Add<RText>(RPadPos(0.35, posy), "ABCDEFGH abcdefgh 0123456789 @#$");
+      text->text.size = 0.04;
+      text->text.align = RAttrText::kLeftCenter;
+      if (is_comic)
+         text->text.font.family = "Comic";
+      else
+         text->text.font = font;
+
+      auto name = canvas->Add<RText>(RPadPos(0.33, posy), text->text.font.GetFullName());
+      name->text.size = 0.03;
+      name->text.align = RAttrText::kRightCenter;
+
+      posy -= 0.05;
+   };
+
+   drawText(RAttrFont::kTimes);
+   drawText(RAttrFont::kTimesItalic);
+   drawText(RAttrFont::kTimesBold);
+   drawText(RAttrFont::kTimesBoldItalic);
+
+   drawText(RAttrFont::kArial);
+   drawText(RAttrFont::kArialOblique);
+   drawText(RAttrFont::kArialBold);
+   drawText(RAttrFont::kArialBoldOblique);
+
+   drawText(RAttrFont::kCourier);
+   drawText(RAttrFont::kCourierOblique);
+   drawText(RAttrFont::kCourierBold);
+   drawText(RAttrFont::kCourierBoldOblique);
+
+   drawText(RAttrFont::kVerdana);
+   drawText(RAttrFont::kVerdanaItalic);
+   drawText(RAttrFont::kVerdanaBold);
+   drawText(RAttrFont::kVerdanaBoldItalic);
+
+   // now draw text with custom font
+
+   posy -= 0.03;
+   std::string fname = __FILE__;
+   auto pos = fname.find("rtext_font.cxx");
+   if (pos > 0) { fname.resize(pos); fname.append("comic.woff2"); }
+           else fname = "comic.woff2";
+   canvas->Draw<RFont>("Comic", fname);
+   drawText(RAttrFont::kTimes, true);
+
+   canvas->Show();
+}

--- a/tutorials/rcanvas/tobject.cxx
+++ b/tutorials/rcanvas/tobject.cxx
@@ -84,7 +84,7 @@ void tobject()
 
    // one can change basic attributes via v7 classes, value will be replaced on client side
    auto drawth1 = subpads[0][1]->Draw<TObjectDrawable>(th1);
-   drawth1->line = RAttrLine(RColor::kBlue, 3., 2);
+   drawth1->line = RAttrLine(RColor::kBlue, 3., RAttrLine::kDashed);
 
    subpads[1][0]->Draw<TObjectDrawable>(th2, "colz");
 


### PR DESCRIPTION
- fill style in `RAttrFill`
- line style in `RAttrLine`
- font kind in `RAttrFont`
- text align in `RAttrText`

Provide possibility to configure custom line pattern directly in `RAttrLine`. Shown in `rline_style.cxx` macro.

Improve positioning of `RPave` and all derived classes. 
One can select any corner (default is `kTopRight`) and specify `offsetX` and `offsetY` relative to that corner.
By default frame corners are used, but if set `onFrame = false`, pad corners are used.

Let mark `RFont` instance as default for the pad - in this case font will be used as default for any text output on the pad if font was not configured for that text.
