### PR TITLE
Add several improvements to use Unuran with the DistSampler interface

### DIFF
--- a/math/mathcore/inc/Math/DistSampler.h
+++ b/math/mathcore/inc/Math/DistSampler.h
@@ -92,26 +92,26 @@ public:
 
 
    /**
-      initialize the generators with the given algorithm
-      Implemented by derived classes who needs it
-      (like UnuranSampler)
+      Initialize the sampling generator with the given algorithm.
+      Implemented by the derived classes who needs it
+      (like UnuranSampler).
       If nothing is specified use default algorithm
       from DistSamplerOptions::SetDefaultAlgorithm
    */
    virtual bool Init(const char * =""/* algorithm */) { return true;}
 
    /**
-      initialize the generators with the given option
-      which my include the algorithm but also more if
-      the method is re-impelmented by derived class
-      The default implementation calls the above method
+      Initialize the generators with the given DistSamplerOption object.
+      The string will include the algorithm and in case additional options
+      which can be interpreted by a re-implemented method in the derived class.
+      The default implementation just calls the above method
       passing just the algorithm name
    */
    virtual bool Init(const DistSamplerOptions & opt );
 
 
    /**
-       Set the random engine to be used
+       Set the random engine to be used.
        To be implemented by the derived classes who provides
        random sampling
    */
@@ -119,44 +119,67 @@ public:
 
    /**
        Set the random seed for the TRandom instances used by the sampler
-       classes
+       classes.
        To be implemented by the derived classes who provides random sampling
    */
    virtual void SetSeed(unsigned int /*seed*/ ) {}
 
    /**
-      Get the random engine used by the sampler
+      Get the random engine used by the sampler.
       To be implemented by the derived classes who needs it
       Returns zero by default
     */
    virtual TRandom * GetRandom() { return 0; }
 
-   /// set range in a given dimension
+   /// Set the range in a given dimension.
    void SetRange(double xmin, double xmax, int icoord = 0);
 
-   /// set range for all dimensions
+   /// Set the range for all dimensions.
    void SetRange(const double * xmin, const double * xmax);
+   /// Set the range for all dimensions (use std::vector)
+   void SetRange(const std::vector<double> & xmin, const std::vector<double> & xmax){ 
+      assert(xmin.size() >= NDim() && xmax.size() >= NDim());
+      SetRange(xmin.data(),xmax.data());
+   }
 
-   /// set range using DataRange class
+   /// Set the range using the ROOT::Fit::DataRange class.
    void SetRange(const ROOT::Fit::DataRange & range);
 
-   /// set the mode of the distribution (could be useful to some methods)
-   /// implemented by derived classes if needed
+   /// Set the mode of the distribution (1D case).
+   /// It could be useful or needed by some sampling methods.
+   /// It is implemented by derived classes if needed (e.g. TUnuranSampler)
    virtual void SetMode(double  ) {}
 
-   /// set the normalization area of distribution
-   /// implemented by derived classes if needed
+   /// Set the mode of the distribution (Multi-dim case).
+   virtual void SetMode(const std::vector<double> &) {}
+
+   /// Set the normalization area of distribution.
+   /// Implemented by derived classes if needed
    virtual void SetArea(double) {}
 
-   /// get the parent distribution function (must be called after setting the function)
+   /// Use the log of the provided pdf.
+   /// Implemented by the derived classes 
+   virtual void SetUseLogPdf(bool = true) {}
+
+   /// Set usage of Derivative of PDF. 
+   /// Can be implemented by derived class 
+   virtual void SetDPdf(const ROOT::Math::IGenFunction & ) {}
+
+   /// Set usage of Cumulative of PDF.
+   /// Can be implemented by derived class
+   virtual void SetCdf(const ROOT::Math::IGenFunction &) {}
+
+   /// Get the parent distribution function (must be called after setting the function).
    const ROOT::Math::IMultiGenFunction & ParentPdf() const {
       return *fFunc;
    }
 
+   /// Check if there is a parent distribution defined.
+   bool HasParentPdf() const { return fFunc != nullptr; }
 
    /**
-      sample one event in one dimension
-      better implementation could be provided by the derived classes
+      Sample one event in one dimension.
+      Specialized implementation could be provided by the derived classes
    */
    virtual double Sample1D() {
       Sample(&fData[0]);
@@ -164,7 +187,8 @@ public:
    }
 
    /**
-      sample one event and rerturning array x with coordinates
+      Sample one event and return an array x with 
+      sample coordinates values.
     */
    const double *  Sample() {
       Sample(&fData[0]);
@@ -172,13 +196,14 @@ public:
    }
 
    /**
-      sample one event in multi-dimension by filling the given array
-      return false if sampling failed
+      Sample one event in multi-dimension by filling the given array.
+      Return false if the sampling failed.
+      Abstract method to be re-implmented by the derived classes
    */
    virtual bool Sample(double * x) = 0;
 
    /**
-      sample one bin given an estimated of the pdf in the bin
+      Sample one bin given an estimated of the pdf in the bin.
       (this can be function value at the center or its integral in the bin
       divided by the bin width)
       By default do not do random sample, just return the function values
@@ -190,27 +215,34 @@ public:
       return true;
    }
    /**
-      sample a set of bins given a vector of probabilities
+      Sample a set of bins given a vector of probabilities
       Typically multinomial statistics will be used and the sum of the probabilities
       will be equal to the total number of events to be generated
       For sampling the bins indipendently, SampleBin should be used
     */
    virtual bool SampleBins(unsigned int n, const double * prob, double * values, double * errors  = 0)  {
-      std::copy(prob,prob+n, values);
+      std::copy(prob,prob+n, values); // default impl returns prob values (Asimov data)
       if (errors) std::fill(errors,errors+n,0);
       return true;
    }
 
 
    /**
-      generate a un-binned data sets (fill the given data set)
-      if dataset has already data append to it
+      Generate a un-binned data sets by fill the given data set.
+      If dataset is not empty, append the new data.
    */
    virtual bool Generate(unsigned int nevt, ROOT::Fit::UnBinData & data);
-
+   /**
+      Generate a vector of events by fillling the passed data vector.
+      The flag eventRow indicates how the events are arrenged in the multi-dim case. 
+      The can be arranged in rows or in columns.  
+      With eventRow=false events are the columns in data: {x1,x2,.....,xn},{y1,....yn} 
+      With eventRow=true  events are rows in data: {x1,y1},{x2,y2},.....{xn,yn} 
+   */
+   virtual bool Generate(unsigned int nevt, double * data, bool eventRow = false);
 
    /**
-      generate a bin data set .
+      Generate a binned data set.
       A range must have been set before (otherwise inf is returned)
       and the bins are equidinstant in the previously defined range
       bin center values must be present in given data set
@@ -220,14 +252,14 @@ public:
       accordingly. The expected value/bin nexp  = f(x_i) * binArea/ nevt
       Extend control if use a fixed (i.e. multinomial statistics) or floating total number of events
    */
-   virtual bool Generate(unsigned int nevt, const  int * nbins, ROOT::Fit::BinData & data, bool extend = true);
+   virtual bool Generate(unsigned int nevt, const  int * nbins, ROOT::Fit::BinData & data, bool extend = true, bool expErr = true);
    /**
-      same as before but passing the range in case of 1 dim data
+      Same as before but passing the range in case of 1 dim data.
     */
-   bool Generate(unsigned int nevt, int nbins, double xmin, double xmax, ROOT::Fit::BinData & data, bool extend = true) {
+   bool Generate(unsigned int nevt, int nbins, double xmin, double xmax, ROOT::Fit::BinData & data, bool extend = true, bool expErr = true ) {
       SetRange(xmin,xmax);
       int nbs[1]; nbs[0] = nbins;
-      return Generate(nevt, nbs, data, extend);
+      return Generate(nevt, nbs, data, extend, expErr);
    }
 
 
@@ -235,6 +267,8 @@ protected:
 
    // internal method to set the function
    virtual void DoSetFunction(const ROOT::Math::IMultiGenFunction & func, bool copy);
+   // internal method to set the dimension
+   virtual void DoSetDimension(unsigned int ndim);
    // check if generator have been initialized correctly and one can start generating
    bool IsInitialized() ;
    /// return the data range of the Pdf . Must be called after setting the function
@@ -243,17 +277,14 @@ protected:
       return *fRange;
    }
 
-
-
-
 private:
 
    // private methods
 
-   bool fOwnFunc;                         // flag to indicate if the function is owned
-   mutable std::vector<double> fData;     // internal array used to cached the sample data
-   ROOT::Fit::DataRange    *   fRange;    // data range
-   const ROOT::Math::IMultiGenFunction * fFunc; // internal function (ND)
+   bool fOwnFunc;                         /// flag to indicate if the function is owned
+   mutable std::vector<double> fData;     ///! internal array used to cached the sample data
+   ROOT::Fit::DataRange    *   fRange;    /// data range
+   const ROOT::Math::IMultiGenFunction * fFunc; /// internal function (ND)
 
 
 };

--- a/math/mathcore/inc/Math/DistSampler.h
+++ b/math/mathcore/inc/Math/DistSampler.h
@@ -203,7 +203,7 @@ public:
    virtual bool Sample(double * x) = 0;
 
    /**
-      Sample one bin given an estimated of the pdf in the bin.
+      Sample one bin given an estimate of the pdf in the bin.
       (this can be function value at the center or its integral in the bin
       divided by the bin width)
       By default do not do random sample, just return the function values
@@ -228,8 +228,9 @@ public:
 
 
    /**
-      Generate a un-binned data sets by fill the given data set.
-      If dataset is not empty, append the new data.
+      Generate a un-binned data set by filling the given data set object.
+      If the data set object is not empty, the new generated data will be appended to the 
+      existing one. 
    */
    virtual bool Generate(unsigned int nevt, ROOT::Fit::UnBinData & data);
    /**

--- a/math/mathcore/inc/Math/DistSamplerOptions.h
+++ b/math/mathcore/inc/Math/DistSamplerOptions.h
@@ -14,14 +14,13 @@
 #include <string>
 
 #include <iostream>
+#include "Math/IOptions.h"
 
 namespace ROOT {
 
 
 namespace Math {
 
-
-class IOptions;
 
 //_______________________________________________________________________________
 /**
@@ -84,7 +83,7 @@ public:
    /// type of minimizer
    const std::string & Sampler() const { return fSamplerType; }
 
-   /// type of algorithm
+   /// type of algorithm (method)
    const std::string & Algorithm() const { return fAlgoType; }
 
    /// print all the options
@@ -104,6 +103,16 @@ public:
    /// set extra options (in this case pointer is cloned)
    void  SetExtraOptions(const IOptions & opt);
 
+   /// set a specific algorithm option
+   template <class T>
+   void SetAlgoOption(const char * name, T value) {
+      if (!fExtraOptions) CreateExtraOptions();
+      fExtraOptions->SetValue(name, value);
+   }
+
+protected:
+
+   void CreateExtraOptions();
 
 private:
 

--- a/math/mathcore/inc/Math/GenAlgoOptions.h
+++ b/math/mathcore/inc/Math/GenAlgoOptions.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <iomanip>
 #include <string>
+#include <vector>
 
 namespace ROOT {
       namespace Math {
@@ -84,6 +85,27 @@ public:
       InsertValue(name, fNamOpts, std::string(val));
    }
 
+   std::vector<std::string>  GetAllNamedKeys() {
+      std::vector<std::string> names;
+      // start by named options
+      for (auto & e : fNamOpts) 
+         names.push_back(e.first.c_str());
+      return names;
+   }
+   std::vector<std::string>  GetAllRealKeys() {
+      std::vector<std::string> names;
+      // start by named options
+      for (auto & e : fRealOpts) 
+         names.push_back(e.first.c_str());
+      return names;
+   }
+   std::vector<std::string>  GetAllIntKeys() {
+      std::vector<std::string> names;
+      // start by named options
+      for (auto & e : fIntOpts) 
+         names.push_back(e.first.c_str());
+      return names;
+   }
 
    /// print options
    virtual void Print(std::ostream & os = std::cout ) const {
@@ -142,9 +164,8 @@ private:
          os << std::setw(25) << pos->first << " : " << std::setw(15) << pos->second << std::endl;
    }
 
-
-   std::map<std::string, double>      fRealOpts;   // map of the real options
    std::map<std::string, int>         fIntOpts;    // map of the integer options
+   std::map<std::string, double>      fRealOpts;   // map of the real options
    std::map<std::string, std::string> fNamOpts;    // map of the named options
 
 };

--- a/math/mathcore/inc/Math/GenAlgoOptions.h
+++ b/math/mathcore/inc/Math/GenAlgoOptions.h
@@ -87,23 +87,26 @@ public:
 
    std::vector<std::string>  GetAllNamedKeys() {
       std::vector<std::string> names;
+      names.reserve(fNamOpts.size());
       // start by named options
-      for (auto & e : fNamOpts) 
-         names.push_back(e.first.c_str());
+      for (auto const & e : fNamOpts) 
+         names.push_back(e.first);
       return names;
    }
    std::vector<std::string>  GetAllRealKeys() {
       std::vector<std::string> names;
+      names.reserve(fRealOpts.size());
       // start by named options
-      for (auto & e : fRealOpts) 
-         names.push_back(e.first.c_str());
+      for (auto const & e : fRealOpts) 
+         names.push_back(e.first);
       return names;
    }
    std::vector<std::string>  GetAllIntKeys() {
       std::vector<std::string> names;
+      names.reserve(fIntOpts.size());
       // start by named options
-      for (auto & e : fIntOpts) 
-         names.push_back(e.first.c_str());
+      for (auto const & e : fIntOpts) 
+         names.push_back(e.first);
       return names;
    }
 

--- a/math/mathcore/src/DistSampler.cxx
+++ b/math/mathcore/src/DistSampler.cxx
@@ -72,21 +72,25 @@ void DistSampler::DoSetFunction(const ROOT::Math::IMultiGenFunction & func, bool
       fOwnFunc = false;
       fFunc = &func;
    }
-   fData = std::vector<double>(func.NDim());
+   DoSetDimension(func.NDim() );
+}
+
+void DistSampler::DoSetDimension(unsigned int ndim) {
+   // set function dimension (might be needed to initialize correctly the sampler)
+   fData = std::vector<double>(ndim);
    // delete a range if exists and it is not compatible
-   if (fRange && fRange->NDim() != fData.size() ) {
+   if (fRange && fRange->NDim() != ndim ) {
       delete fRange;
-      fRange = 0;
+      fRange = nullptr;
    }
-   if (!fRange) fRange = new ROOT::Fit::DataRange(func.NDim() );
+   if (!fRange) fRange = new ROOT::Fit::DataRange(ndim);
 }
 
 bool DistSampler::IsInitialized()  {
    // test if sampler is initialized
-   // tryying to generate one event (for this cannot be const)
+   // trying to generate one event (for this cannot be const)
    if (NDim() == 0) return false;
-   if (fFunc == 0) return false;
-   if (fFunc->NDim() != NDim() ) return false;
+   if (fFunc && fFunc->NDim() != NDim() ) return false;
    // test one event
    if (!Sample(&fData[0]) ) return false;
    return true;
@@ -108,16 +112,33 @@ bool DistSampler::Generate(unsigned int nevt, ROOT::Fit::UnBinData & data) {
    return true;
 }
 
+bool DistSampler::Generate(unsigned int nevt, double * data, bool eventRow) {
+   if (!IsInitialized()) {
+         MATH_WARN_MSG("DistSampler::Generate","sampler has not been initialized correctly");
+         return false;
+   }
+   unsigned int ndim = NDim();
+   for (unsigned int i = 0; i < nevt; ++i) {
+      const double * x = Sample();
+      assert(x != nullptr);
+      if (eventRow)
+         std::copy(x,x+ndim,data+i*ndim);
+      else {
+         for (unsigned int j = 0; j < ndim; ++j) {
+            data[j*nevt+i] = x[j];
+         }
+      }
+   }
+   return true;
+}
 
-   bool DistSampler::Generate(unsigned int nevt, const  int * nbins, ROOT::Fit::BinData & data, bool extend) {
+bool DistSampler::Generate(unsigned int nevt, const  int * nbins, ROOT::Fit::BinData & data, bool extend, bool expErr) {
    // generate a bin data set from given bin center values
    // bin center values must be present in given data set
-   //if (!IsInitialized()) {
-   if (NDim() == 0 || fFunc == 0 ) {
+   if (!IsInitialized()) {
       MATH_WARN_MSG("DistSampler::Generate","sampler has not been initialized correctly");
       return false;
    }
-
 
    int ntotbins = 1;
    for (unsigned int j = 0; j < NDim(); ++j) {
@@ -150,10 +171,10 @@ bool DistSampler::Generate(unsigned int nevt, ROOT::Fit::UnBinData & data) {
          for (int i = 0; i < nbins[j]; ++i) {
             //const double * v = Sample();
             double val = 0;
-            double eval = 0;
             double yval = (ParentPdf())(&x.front());
             double nexp = yval * nnorm;
-            ret &= SampleBin(nexp,val,&eval);
+            ret &= SampleBin(nexp,val,nullptr);
+            double eval = (expErr) ? std::sqrt(nexp) : std::sqrt(val);  
             data.Add(&x.front(), val, eval);
             x[j] += dx[j]; // increment x bin the bin
          }

--- a/math/mathcore/src/DistSamplerOptions.cxx
+++ b/math/mathcore/src/DistSamplerOptions.cxx
@@ -111,6 +111,11 @@ void DistSamplerOptions::SetExtraOptions(const IOptions & opt) {
    fExtraOptions = opt.Clone();
 }
 
+void DistSamplerOptions::CreateExtraOptions() { 
+   if (fExtraOptions) return;
+   fExtraOptions = new ROOT::Math::GenAlgoOptions();
+}
+
 void DistSamplerOptions::Print(std::ostream & os) const {
    //print all the options
    os << std::setw(25) << "DistSampler Type"        << " : " << std::setw(15) << fSamplerType << std::endl;

--- a/math/unuran/inc/TUnuran.h
+++ b/math/unuran/inc/TUnuran.h
@@ -105,10 +105,18 @@ private:
    TUnuran & operator = (const TUnuran & rhs);
 
 public:
-
-
    /**
-      initialize with Unuran string interface
+      Initialize with Unuran string API interface.
+      See  https://statmath.wu.ac.at/unuran/doc/unuran.html#StringAPI
+
+      @param distr   : UNU.RAN distribution string
+      @param  method : UNU.RAN  method string
+
+      Here is an example using the string API:
+      ```
+      Tunuran unr;
+      unr.Init("normal(3.,0.75); domain = (0,inf)", "method = tdr; c = 0");
+      ```
    */
    bool Init(const std::string & distr, const std::string  & method);
 
@@ -119,6 +127,9 @@ public:
       For the list of available method for 1D cont. distribution see the
       <A href="http://statmath.wu-wien.ac.at/unuran/doc/unuran.html#Methods_005ffor_005fCONT">UnuRan doc</A>.
       A re-initialization is needed whenever distribution parameters have been changed.
+      Note that the method string can contain in addition to the method name all the specific method 
+      parameters specified using the UNURAN methiod string API. 
+      For example a valid string can be `"method=arou; max_segments=1000; max_sqhratio = 0.9"`
    */
    bool Init(const TUnuranContDist & distr, const std::string & method = "auto");
 
@@ -157,7 +168,7 @@ public:
 
 
    /**
-      Initialize method for the Poisson distribution
+      Initialize method for the Poisson distribution.
       Used to generate poisson numbers for a constant parameter mu of the Poisson distribution.
       Use after the method TUnuran::SampleDiscr to generate the numbers.
       The flag reinit perform a fast re-initialization when only the distribution parameters
@@ -167,7 +178,7 @@ public:
    bool InitPoisson(double mu, const std::string & method = "dstd");
 
    /**
-      Initialize method for the Binomial distribution
+      Initialize method for the Binomial distribution.
       Used to generate poisson numbers for a constant parameters (n,p) of the Binomial distribution.
       Use after the method TUnuran::SampleDiscr to generate the numbers.
       The flag reinit perform a fast re-initialization when only the distribution parameters
@@ -177,31 +188,31 @@ public:
    bool InitBinomial(unsigned int ntot, double prob, const std::string & method = "dstd");
 
    /**
-      Reinitialize UNURAN by changing the distribution parameters but mantaining same distribution and method
+      Reinitialize UNURAN by changing the distribution parameters but mantaining same distribution and method.
       It is implemented now only for predefined discrete distributions like the poisson or the binomial
    */
    bool ReInitDiscrDist(unsigned int npar, double * params);
 
    /**
-      Sample 1D distribution
+      Sample 1D distribution.
       User is responsible for having previously correctly initialized with TUnuran::Init
    */
    double Sample();
 
    /**
-      Sample multidimensional distributions
+      Sample multidimensional distributions.
       User is responsible for having previously correctly initialized with TUnuran::Init
    */
    bool SampleMulti(double * x);
 
    /**
-      Sample discrete distributions
+      Sample discrete distributions.
       User is responsible for having previously correctly initialized with TUnuran::Init
    */
    int SampleDiscr();
 
    /**
-      set the random engine.
+      Set the random engine.
       Must be called before init to have effect
     */
    void SetRandom(TRandom * r) {
@@ -209,11 +220,46 @@ public:
    }
 
    /**
-      return instance of the random engine used
+      Return instance of the random engine used.
     */
    TRandom * GetRandom() {
       return fRng;
    }
+
+   /**
+      Return an information string about used unuran generator method.
+      @param extended : if true return some help about the possible options for the the method.
+   */
+   std::string GetInfo(bool extended = false);
+
+   /**
+      Return an ID string about the unuran generator method.
+   */
+   std::string GetGenId() const;
+
+   /**
+      Return the dimension of unuran generator method.
+      For 1D method returns 1 and for the multi-dimensional case 
+      must be equal to the distribution dimension.
+   */
+   int GetDimension() const;
+
+   /**
+      Return the type of the distribution.
+      See documentation of `unuran_distr_get_type` for the possible
+      types of distributions.
+   */
+   int GetDistType() const; 
+
+   /// Return true for a univariate continous distribution.
+   bool IsDistCont() const; 
+   /// Return true for a multivariate continous distribution.
+   bool IsDistMultiCont() const;  
+    /// Return true for a discrete distribution.
+   bool IsDistDiscrete() const; 
+    /// Return true for an empirical distribution.
+   bool IsDistEmpirical() const; 
+   
 
 
    /**

--- a/math/unuran/inc/TUnuran.h
+++ b/math/unuran/inc/TUnuran.h
@@ -128,7 +128,7 @@ public:
       <A href="http://statmath.wu-wien.ac.at/unuran/doc/unuran.html#Methods_005ffor_005fCONT">UnuRan doc</A>.
       A re-initialization is needed whenever distribution parameters have been changed.
       Note that the method string can contain in addition to the method name all the specific method 
-      parameters specified using the UNURAN methiod string API. 
+      parameters specified using the UNURAN method string API. 
       For example a valid string can be `"method=arou; max_segments=1000; max_sqhratio = 0.9"`
    */
    bool Init(const TUnuranContDist & distr, const std::string & method = "auto");
@@ -227,8 +227,8 @@ public:
    }
 
    /**
-      Return an information string about used unuran generator method.
-      @param extended : if true return some help about the possible options for the the method.
+      Return an information string about the used Unuran generator method.
+      @param extended : if true return some helper information about the existing options of the method.
    */
    std::string GetInfo(bool extended = false);
 

--- a/math/unuran/inc/TUnuranSampler.h
+++ b/math/unuran/inc/TUnuranSampler.h
@@ -15,6 +15,8 @@
 
 #include "Math/DistSampler.h"
 
+// needed by the ClassDef
+#include "Rtypes.h"
 
 namespace ROOT {
 
@@ -60,15 +62,20 @@ public:
 
    using DistSampler::SetFunction;
 
-   /// set the parent function distribution to use for random sampling (one dim case)
+   /// Set the parent function distribution to use for random sampling (one dim case).
    void SetFunction(const ROOT::Math::IGenFunction & func)  {
       fFunc1D = &func;
       SetFunction<const ROOT::Math::IGenFunction>(func, 1);
    }
 
-   /// set the Function using a TF1 pointer
+   /// Set the Function using a TF1 pointer.
    void SetFunction(TF1 * pdf);
 
+   /// set the cumulative distribution function of the PDF used for random sampling (one dim case)
+   void SetCdf(const ROOT::Math::IGenFunction &cdf);
+
+   /// set the Derivative of the PDF used for random sampling (one dim continous case)
+   void SetDPdf(const ROOT::Math::IGenFunction &dpdf);
 
    /**
       initialize the generators with the given algorithm
@@ -103,12 +110,18 @@ public:
    void SetPrintLevel(int level) {fLevel = level;}
 
    /*
-      set the mode
+      set the mode (1D distribution)
     */
    void SetMode(double mode) {
       fMode = mode;
       fHasMode = true;
    }
+
+   /*
+      set the mode (Multidim distribution)
+   */
+   void SetMode(const std::vector<double> &modes);
+
 
    /*
      set the area
@@ -117,6 +130,9 @@ public:
       fArea = area;
       fHasArea = true;
    }
+
+   /// Set using of logarithm of PDF (only for 1D continous case)
+   void SetUseLogPdf(bool on = true) { fUseLogPdf = on; }
 
    /**
       Get the random engine used by the sampler
@@ -154,29 +170,32 @@ public:
 
 protected:
 
-   //initialization for 1D distributions
+   /// Initialization for 1D distributions.
    bool DoInit1D(const char * algo);
-   //initialization for 1D discrete distributions
+   /// Initialization for 1D discrete distributions.
    bool DoInitDiscrete1D(const char * algo);
-   //initialization for multi-dim distributions
+   /// Initialization for multi-dim distributions.
    bool DoInitND(const char * algo);
 
 
 private:
 
    // private member
-   bool                              fOneDim;      // flag to indicate if the function is 1 dimension
-   bool                              fDiscrete;    // flag to indicate if the function is discrete
-   bool                              fHasMode;     // flag to indicate if a mode is set
-   bool                              fHasArea;     // flag to indicate if a area is set
-   int                               fLevel;       // debug level
-   double                            fMode;        // mode of dist
-   double                            fArea;        // area of dist
-   const ROOT::Math::IGenFunction *  fFunc1D;      // 1D function pointer
-   TUnuran *                         fUnuran;      // unuran engine class
+   bool                              fOneDim = false;      /// flag to indicate if the function is 1 dimension
+   bool                              fDiscrete = false;    /// flag to indicate if the function is discrete
+   bool                              fHasMode = false;     /// flag to indicate if a mode is set
+   bool                              fHasArea = false;     /// flag to indicate if a area is set
+   bool                              fUseLogPdf = false;   /// flag to indicate if we use the log of the PDF 
+   int fLevel;                                     /// debug level
+   double                            fMode;        /// mode of dist (1D)
+   double                            fArea;        /// area of dist
+   std::vector<double>               fNDMode;      /// mode of the multi-dim distribution
+   const ROOT::Math::IGenFunction *  fFunc1D = nullptr;      /// 1D function pointer (pdf)
+   const ROOT::Math::IGenFunction *  fCDF    = nullptr;      /// CDF function pointer
+   const ROOT::Math::IGenFunction *  fDPDF   = nullptr;        /// 1D Derivative function pointer
+   TUnuran *                         fUnuran = nullptr;      /// unuran engine class
 
-   //ClassDef(TUnuranSampler,1)  //Distribution sampler class based on UNU.RAN
-
+   ClassDef(TUnuranSampler, 2);                    /// Distribution sampler class based on UNU.RAN
 };
 
 

--- a/math/unuran/src/TUnuran.cxx
+++ b/math/unuran/src/TUnuran.cxx
@@ -374,6 +374,50 @@ bool TUnuran::SetMethodAndInit() {
    return true;
  }
 
+std::string TUnuran::GetInfo(bool extended) 
+{
+   // get information string about Unuran generator
+   if (!fGen) return std::string();
+   return std::string(unur_gen_info(fGen, extended)); 
+}
+
+std::string TUnuran::GetGenId() const
+{
+   // get Unuran generator ID
+   if (!fGen) return std::string();
+   return std::string(unur_get_genid(fGen)); 
+}
+
+int TUnuran::GetDimension() const
+{
+   // get dimension of the UNURAN generator
+   if (!fGen) return 0;
+   return unur_get_dimension(fGen); 
+}
+
+int TUnuran::GetDistType() const
+{
+   // get type of distribution
+   if (!fGen) return -1;
+   return unur_distr_get_type (unur_get_distr(fGen));
+}
+
+bool TUnuran::IsDistCont() const { 
+   if (!fGen) return false;
+   return unur_distr_is_cont (unur_get_distr(fGen));
+}
+bool TUnuran::IsDistMultiCont() const { 
+   if (!fGen) return false;
+   return unur_distr_is_cvec (unur_get_distr(fGen));
+}
+bool TUnuran::IsDistDiscrete() const { 
+   if (!fGen) return false;
+   return unur_distr_is_discr (unur_get_distr(fGen));
+}
+bool TUnuran::IsDistEmpirical() const { 
+   if (!fGen) return false;
+   return unur_distr_is_cemp (unur_get_distr(fGen));
+}
 
 int TUnuran::SampleDiscr()
 {
@@ -429,7 +473,6 @@ bool TUnuran::InitPoisson(double mu, const std::string & method) {
    if (! SetRandomGenerator() ) return false;
    return true;
 }
-
 
 bool TUnuran::InitBinomial(unsigned int ntot, double prob, const std::string & method ) {
    // initializaton for a Binomial

--- a/math/unuran/src/TUnuranContDist.cxx
+++ b/math/unuran/src/TUnuranContDist.cxx
@@ -30,7 +30,8 @@ TUnuranContDist::TUnuranContDist(const ROOT::Math::IGenFunction *pdf, const ROOT
    // Constructor from generic function interfaces
    // manage the functions and clone them if flag copyFunc is true
    if (fOwnFunc) {
-      fPdf = fPdf->Clone();
+      if (fPdf) 
+         fPdf = fPdf->Clone();
       if (fDPdf)
          fDPdf = fDPdf->Clone();
       if (fCdf)

--- a/math/unuran/src/TUnuranSampler.cxx
+++ b/math/unuran/src/TUnuranSampler.cxx
@@ -17,6 +17,7 @@
 #include "TUnuran.h"
 #include "Math/OneDimFunctionAdapter.h"
 #include "Math/DistSamplerOptions.h"
+#include "Math/GenAlgoOptions.h"
 #include "Fit/DataRange.h"
 //#include "Math/WrappedTF1.h"
 
@@ -34,7 +35,6 @@ TUnuranSampler::TUnuranSampler() : ROOT::Math::DistSampler(),
    fDiscrete(false),
    fHasMode(false), fHasArea(false),
    fMode(0), fArea(0),
-   fFunc1D(0),
    fUnuran(new TUnuran()  )
 {
    fLevel = ROOT::Math::DistSamplerOptions::DefaultPrintLevel();
@@ -48,9 +48,23 @@ TUnuranSampler::~TUnuranSampler() {
 bool TUnuranSampler::Init(const char * algo) {
    // initialize unuran classes using the given algorithm
    assert (fUnuran != 0 );
+   bool ret = false;
+   //case distribution has not been set
+   // Maybe we are using the Unuran string API which contains also distribution string
+   // try to initialize Unuran
    if (NDim() == 0)  {
-      Error("TUnuranSampler::Init","Distribution function has not been set ! Need to call SetFunction first.");
-      return false;
+      ret = fUnuran->Init(algo,"");
+      if (!ret) { 
+         Error("TUnuranSampler::Init",
+         "Unuran initialization string is invalid or the Distribution function has not been set and one needs to call SetFunction first.");
+         return false;
+      }
+      int ndim = fUnuran->GetDimension();
+      assert(ndim > 0);
+      fOneDim = (ndim == 1);
+      fDiscrete = fUnuran->IsDistDiscrete(); 
+      DoSetDimension(ndim);
+      return true;
    }
 
    if (fLevel < 0) fLevel =  ROOT::Math::DistSamplerOptions::DefaultPrintLevel();
@@ -62,7 +76,6 @@ bool TUnuranSampler::Init(const char * algo) {
    }
    method.ToUpper();
 
-   bool ret = false;
    if (NDim() == 1) {
        // check if distribution is discrete by
       // using first string in the method name is "D"
@@ -84,7 +97,7 @@ bool TUnuranSampler::Init(const char * algo) {
       //fUnuran->SetLogLevel(fLevel); ( seems not to work  disable for the time being)
       if (ret) Info("TUnuranSampler::Init","Successfully initailized Unuran with method %s",method.Data() );
       else Error("TUnuranSampler::Init","Failed to  initailize Unuran with method %s",method.Data() );
-      // seems not to work in UNURAN (cll only when level > 0 )
+      // seems not to work in UNURAN (call only when level > 0 )
    }
    return ret;
 }
@@ -93,22 +106,62 @@ bool TUnuranSampler::Init(const char * algo) {
 bool TUnuranSampler::Init(const ROOT::Math::DistSamplerOptions & opt ) {
    // default initialization with algorithm name
    SetPrintLevel(opt.PrintLevel() );
-   return Init(opt.Algorithm().c_str() );
+   // check if there are extra options
+   std::string optionStr = opt.Algorithm();
+   auto extraOpts = opt.ExtraOptions();
+   if (extraOpts) {
+      ROOT::Math::GenAlgoOptions * opts = dynamic_cast<ROOT::Math::GenAlgoOptions*>(extraOpts);
+      auto appendOption = [&](const std::string & key, const std::string & val) {
+         optionStr += "; ";
+         optionStr += key;
+         if (!val.empty()) {
+            optionStr += "=";
+            optionStr += val;
+         }
+      };
+      auto names = opts->GetAllNamedKeys();
+      for ( auto & name : names) {
+         std::string value = opts->NamedValue(name.c_str());
+         appendOption(name,value);
+      } 
+      names = opts->GetAllIntKeys();
+      for ( auto & name : names) {
+         std::string value = ROOT::Math::Util::ToString(opts->IValue(name.c_str()));
+         appendOption(name,value);
+      } 
+      names = opts->GetAllRealKeys();
+      for ( auto & name : names) {
+         std::string value = ROOT::Math::Util::ToString(opts->RValue(name.c_str()));
+         appendOption(name,value);
+      } 
+   }
+   Info("Init","Initialize UNU.RAN with Method option string: %s",optionStr.c_str());
+   return Init(optionStr.c_str() );
 }
 
 
 bool TUnuranSampler::DoInit1D(const char * method) {
-   // initilize for 1D sampling
+   // initialize for 1D sampling
    // need to create 1D interface from Multidim one
    // (to do: use directly 1D functions ??)
+   // to do : add possibility for String API of UNURAN
    fOneDim = true;
    TUnuranContDist * dist = 0;
    if (fFunc1D == 0) {
-      ROOT::Math::OneDimMultiFunctionAdapter<> function(ParentPdf() );
-      dist = new TUnuranContDist(function,0,false,true);
+      if (HasParentPdf()) {
+         ROOT::Math::OneDimMultiFunctionAdapter<> function(ParentPdf() );
+         dist = new TUnuranContDist(&function,fDPDF,fCDF,fUseLogPdf,true);
+      }
+      else {
+         if (!fDPDF && !fCDF) {
+            Error("DoInit1D", "No PDF, CDF or DPDF function has been set");
+            return false;
+         }
+         dist = new TUnuranContDist(nullptr, fDPDF, fCDF, fUseLogPdf, true);
+      }
    }
    else {
-      dist = new TUnuranContDist(*fFunc1D); // no need to copy the function
+      dist = new TUnuranContDist(fFunc1D, fDPDF, fCDF, fUseLogPdf, true); // no need to copy the function
    }
    // set range in distribution (support only one range)
    const ROOT::Fit::DataRange & range = PdfRange();
@@ -128,11 +181,15 @@ bool TUnuranSampler::DoInit1D(const char * method) {
 }
 
 bool TUnuranSampler::DoInitDiscrete1D(const char * method) {
-   // initilize for 1D sampling of discrete distributions
+   // initialize for 1D sampling of discrete distributions
    fOneDim = true;
    fDiscrete = true;
    TUnuranDiscrDist * dist = 0;
    if (fFunc1D == 0) {
+      if (!HasParentPdf()) {
+         Error("DoInitDiscrete1D", "No PMF has been defined");
+         return false;
+      }
       // need to copy the passed function pointer in this case
       ROOT::Math::OneDimMultiFunctionAdapter<> function(ParentPdf() );
       dist = new TUnuranDiscrDist(function,true);
@@ -141,6 +198,8 @@ bool TUnuranSampler::DoInitDiscrete1D(const char * method) {
       // no need to copy the function since fFunc1D is managed outside
       dist = new TUnuranDiscrDist(*fFunc1D, false);
    }
+   // set CDF if available
+   if (fCDF) dist->SetCdf(*fCDF);
    // set range in distribution (support only one range)
    // otherwise 0, inf is assumed
    const ROOT::Fit::DataRange & range = PdfRange();
@@ -163,7 +222,11 @@ bool TUnuranSampler::DoInitDiscrete1D(const char * method) {
 
 
 bool TUnuranSampler::DoInitND(const char * method) {
-   // initilize for 1D sampling
+   // initialize for ND sampling
+   if (!HasParentPdf()) {
+      Error("DoInitND", "No PDF has been defined");
+      return false;
+   }
    TUnuranMultiContDist dist(ParentPdf());
    // set range in distribution (support only one range)
    const ROOT::Fit::DataRange & range = PdfRange();
@@ -179,6 +242,9 @@ bool TUnuranSampler::DoInitND(const char * method) {
 //       std::cout << std::endl;
    }
    fOneDim = false;
+   if (fHasMode && fNDMode.size() == dist.NDim())
+      dist.SetMode(fNDMode.data());
+
    if (method) return fUnuran->Init(dist, method);
    return fUnuran->Init(dist);
 }
@@ -218,10 +284,39 @@ bool TUnuranSampler::Sample(double * x) {
 
 bool TUnuranSampler::SampleBin(double prob, double & value, double *error) {
    // sample a bin according to Poisson statistics
-
    TRandom * r = fUnuran->GetRandom();
    if (!r) return false;
    value = r->Poisson(prob);
-   if (error) *error = std::sqrt(value);
+   if (error) *error = std::sqrt(prob);
    return true;
+}
+
+void TUnuranSampler::SetMode(const std::vector<double> &mode)
+{
+   // set modes for multidim distribution
+   if (mode.size() == ParentPdf().NDim()) {
+      if (mode.size() == 1)
+         fMode = mode[0];
+      else 
+         fNDMode = mode;
+
+      fHasMode = true;
+   }
+   else {
+      Error("SetMode", "modes vector is not compatible with function dimension of %d", (int)ParentPdf().NDim());
+      fHasMode = false;
+      fNDMode.clear();
+   }
+}
+
+void TUnuranSampler::SetCdf(const ROOT::Math::IGenFunction &cdf) {
+   fCDF = &cdf;
+   // in case dimension has not been defined ( a pdf is not provided)
+   if (NDim() == 0) DoSetDimension(1);
+}
+
+void TUnuranSampler::SetDPdf(const ROOT::Math::IGenFunction &dpdf) { 
+   fDPDF = &dpdf;
+   // in case dimension has not been defined ( a pdf is not provided)
+   if (NDim() == 0) DoSetDimension(1);
 }

--- a/math/unuran/test/CMakeLists.txt
+++ b/math/unuran/test/CMakeLists.txt
@@ -29,3 +29,6 @@ foreach(file ${TestUnuranSource})
   ROOT_EXECUTABLE(${testname} ${file} LIBRARIES ${Libraries})
   ROOT_ADD_TEST(unuran-${testname} COMMAND ${testname} LABELS ${${testname}_LABELS})
 endforeach()
+
+# google tests
+ROOT_ADD_GTEST(testUnuranSampler unuranSampler.cxx LIBRARIES ${Libraries} )

--- a/math/unuran/test/unuranSampler.cxx
+++ b/math/unuran/test/unuranSampler.cxx
@@ -1,0 +1,232 @@
+// test TUnuran Sampler class using t he DistSampler interface 
+#include "gtest/gtest.h"
+
+#include "Math/DistSampler.h"
+#include "Math/DistSamplerOptions.h"
+#include "Math/Factory.h"
+#include "Math/DistFunc.h"
+#include "Math/Functor.h"
+#include "TH1.h"
+#include "TH2.h"
+
+using namespace ROOT::Math; 
+
+std::unique_ptr<TH1D> FillHisto1D( DistSampler & s) {
+    // create histogram using automatic binning
+    auto h1 = std::make_unique<TH1D>("h1","h1",100, 1, 0);  
+    const int nevt = 10000; 
+    for (int i = 0; i < nevt; i++) {
+        h1->Fill( s.Sample1D());
+    }
+    return h1;
+}
+
+// test using Unuran string API
+TEST(OneDim, StringAPI)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    bool ret = sampler->Init("distr = normal(3.,0.75); domain = (0,6) & method = tdr; c = 0");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    sampler->SetMode(0.75);
+  
+    auto h1 = FillHisto1D(*sampler);
+    EXPECT_NEAR(h1->GetMean(), 3., 5 * h1->GetMeanError());
+    EXPECT_NEAR(h1->GetRMS(), 0.75, 5*h1->GetRMSError());
+}
+
+// test passing a PDF distribution object
+TEST(OneDim, DistPdfAPI)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    auto pdf = [](double x){ return ROOT::Math::normal_pdf(x,0.75,3);};
+    Functor1D pdfDist(pdf);
+    sampler->SetFunction(pdfDist);
+
+    bool ret = sampler->Init("tdr");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    sampler->SetRange(0,6.);
+  
+    auto h1 = FillHisto1D(*sampler);
+    EXPECT_NEAR(h1->GetMean(), 3., 5 * h1->GetMeanError());
+    EXPECT_NEAR(h1->GetRMS(), 0.75, 5*h1->GetRMSError());
+}
+
+// test passing a CDF distribution object
+TEST(OneDim, DistCdfAPI)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+    auto cdf = [](double x){ return ROOT::Math::normal_cdf(x,0.75,3);};
+    Functor1D cdfDist(cdf);
+    sampler->SetCdf(cdfDist);
+
+    bool ret = sampler->Init("ninv");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    sampler->SetRange(0,6.);
+  
+    auto h1 = FillHisto1D(*sampler);
+    EXPECT_NEAR(h1->GetMean(), 3., 5 * h1->GetMeanError());
+    EXPECT_NEAR(h1->GetRMS(), 0.75, 5*h1->GetRMSError());
+}
+
+// test using DistSampler options
+TEST(OneDim, DistSamplerOptAPI){
+
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    auto pdf = [](double x){ return ROOT::Math::normal_pdf(x,0.75,3);};
+    Functor1D pdfDist(pdf);
+    sampler->SetFunction(pdfDist);
+    DistSamplerOptions opt; 
+    opt.SetAlgorithm("tdr");
+    // set specific options for the tdr method
+    opt.SetAlgoOption("c",0.);
+    opt.SetAlgoOption("cpoints",50);
+    opt.SetAlgoOption("usedars","true");
+    opt.SetAlgoOption("variant_gw","");
+    //opt.Print();
+    
+    bool ret = sampler->Init(opt);
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    sampler->SetRange(0,6.);
+  
+    auto h1 = FillHisto1D(*sampler);
+    EXPECT_NEAR(h1->GetMean(), 3., 5 * h1->GetMeanError());
+    EXPECT_NEAR(h1->GetRMS(), 0.75, 5*h1->GetRMSError());
+}
+// test using a discreate PDF
+TEST(Discrete, DistAPI)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    auto pdf = [](double x){ return ROOT::Math::poisson_pdf(x,10);};
+    Functor1D pdfDist(pdf);
+    sampler->SetFunction(pdfDist);
+    sampler->SetMode(10);
+    sampler->SetArea(1.);
+
+    bool ret = sampler->Init("dari");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+  
+    auto h1 = FillHisto1D(*sampler);
+    EXPECT_NEAR(h1->GetMean(), 10, 5 * h1->GetMeanError());
+    EXPECT_NEAR(h1->GetRMS(), sqrt(10), 5*h1->GetRMSError());
+}
+
+TEST(Discrete, StringAPI)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    // test using string API from a probability vector
+    bool ret = sampler->Init("distr = discr; pv = (0.5,0.2,0.3) & method = dau");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+  
+    TH1D h1("h1","h1",3,0,3);
+    const int nevt = 10000;
+    for (int i = 0; i < nevt; i++) { h1.Fill(sampler->Sample1D());}
+
+    double prob[] = {0.5,0.2,0.3};
+    for (int ibin = 1; ibin <=3; ibin++) {
+        EXPECT_NEAR(h1.GetBinContent(ibin), prob[ibin-1]*nevt, 5*h1.GetBinError(ibin));
+    }
+}
+
+std::unique_ptr<TH2D> FillHisto2D( DistSampler & s) {
+    // create histogram using automatic binning
+    auto h2 = std::make_unique<TH2D>("h2","h2",100, 1, 0, 100, 1, 0);  
+    const int nevt = 100000;
+    for (int i = 0; i < nevt; i++) {
+        auto x = s.Sample();
+        h2->Fill(x[0],x[1]);
+    }
+    return h2;
+}
+
+// test using a Multidim pdf
+TEST(MultiDim, DistAPI)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    auto pdf = [](const double * x){ return ROOT::Math::bigaussian_pdf(x[0],x[1],1.,2.,0.7,0.,5.);};
+    Functor pdfDist(pdf,2);
+    sampler->SetFunction(pdfDist);
+
+    bool ret = sampler->Init("vnrou");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    auto h1 = FillHisto2D(*sampler); 
+
+    EXPECT_NEAR(h1->GetMean(1), 0, 5 * h1->GetMeanError(1));
+    EXPECT_NEAR(h1->GetRMS(1), 1, 5*h1->GetRMSError(1));
+    EXPECT_NEAR(h1->GetMean(2), 5, 5 * h1->GetMeanError(2));
+    EXPECT_NEAR(h1->GetRMS(2), 2, 5*h1->GetRMSError(2));
+    EXPECT_NEAR(h1->GetCorrelationFactor(1,2), 0.7, 0.05);
+    
+}
+
+// test using a Multidim pdf using also mode
+TEST(MultiDim, DistAPIWithOpt)
+{
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    auto pdf = [](const double * x){ return ROOT::Math::bigaussian_pdf(x[0],x[1],1.,2.,0.7,0.,5.);};
+    Functor pdfDist(pdf,2);
+    sampler->SetFunction(pdfDist);
+    sampler->SetMode({0,5});
+    sampler->SetRange({-5,-5},{5,15});
+
+    bool ret = sampler->Init("hitro");
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    auto h1 = FillHisto2D(*sampler);
+    // relax test tolelrance. Method is Markov-Chain method
+    EXPECT_NEAR(h1->GetMean(1), 0, 10 * h1->GetMeanError(1));
+    EXPECT_NEAR(h1->GetRMS(1), 1, 10*h1->GetRMSError(1));
+    EXPECT_NEAR(h1->GetMean(2), 5, 10 * h1->GetMeanError(2));
+    EXPECT_NEAR(h1->GetRMS(2), 2, 10*h1->GetRMSError(2));
+    EXPECT_NEAR(h1->GetCorrelationFactor(1,2), 0.7, 0.1);
+}
+// test using DistSampler options
+TEST(MultiDim, DistSamplerOptAPI){
+
+    std::unique_ptr<DistSampler> sampler(Factory::CreateDistSampler("Unuran"));
+
+    auto pdf = [](const double * x){ return ROOT::Math::bigaussian_pdf(x[0],x[1],1.,2.,0.7,0.,5.);};
+    Functor pdfDist(pdf,2);
+    sampler->SetFunction(pdfDist);
+    sampler->SetMode({0,5});
+    sampler->SetRange({-5,-5},{5,15});
+
+    DistSamplerOptions opt; 
+    opt.SetAlgorithm("hitro");
+    // set specific options for the tdr method
+    opt.SetAlgoOption("burnin",200);
+    //opt.SetAlgoOption("startingpoint","(0,5)");
+    //opt.Print();
+
+    bool ret = sampler->Init(opt);
+    EXPECT_EQ(ret, true);
+    if (!ret) return;
+
+    auto h1 = FillHisto2D(*sampler);
+    // relax test tolelrance. Method is Markov-Chain method
+    EXPECT_NEAR(h1->GetMean(1), 0, 10 * h1->GetMeanError(1));
+    EXPECT_NEAR(h1->GetRMS(1), 1, 10*h1->GetRMSError(1));
+    EXPECT_NEAR(h1->GetMean(2), 5, 10 * h1->GetMeanError(2));
+    EXPECT_NEAR(h1->GetRMS(2), 2, 10*h1->GetRMSError(2));
+    EXPECT_NEAR(h1->GetCorrelationFactor(1,2), 0.7, 0.1);
+    
+}

--- a/math/unuran/test/unuranSampler.cxx
+++ b/math/unuran/test/unuranSampler.cxx
@@ -30,7 +30,7 @@ TEST(OneDim, StringAPI)
     EXPECT_EQ(ret, true);
     if (!ret) return;
 
-    sampler->SetMode(0.75);
+    sampler->SetMode(3.0);
   
     auto h1 = FillHisto1D(*sampler);
     EXPECT_NEAR(h1->GetMean(), 3., 5 * h1->GetMeanError());


### PR DESCRIPTION
This Pull request adds several improvements to use UNU.RAN using the DistSampler interface
(through the TUnuranSampler class).    This is to fix issue #7332 adding functionality as requested. 
 
   The major improvements are:
    - Improvements in using directly the string API from `DistSampler`
    - Better support for setting method and method options using the `DistSamplerOptions` class
    - Support for setting dpdf, cdf and multi-sim mode in the DistSampler interface
    - Add test program for all the new DistSampler functionality


This PR fixes #7332 

