### PR TITLE
[ntuple] (WIP) RNTuple page cache

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -89,18 +89,23 @@ public:
    void ReleasePage(RPage &page) final;
 };
 
+class RPageCache;
 
 // clang-format off
 /**
 \class ROOT::Experimental::Detail::RPageAllocatorFile
 \ingroup NTuple
-\brief Manages pages read from a the file
+\brief Manages pages read from the file
 */
 // clang-format on
 class RPageAllocatorFile {
+private:
+   std::unique_ptr<RPageCache> fPageCache;
 public:
+   RPageAllocatorFile();
    static RPage NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements);
-   static void DeletePage(const RPage& page);
+   RPage NewPage(ColumnId_t columnId, std::size_t elementSize, std::size_t nElements);
+   void DeletePage(const RPage& page);
 };
 
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -398,7 +398,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
       sealedPageBuffer = onDiskPage->GetAddress();
    }
 
-   auto nElts = pageInfo.fNElements;
+   const auto nElts = pageInfo.fNElements;
    auto newPage = fPageAllocator->NewPage(columnId, elementSize, nElts);
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
@@ -644,7 +644,6 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(RCluster *clu
 
                auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), element->GetSize(), nElements);
                newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
-
                fPagePool->PreloadPage(newPage,
                   // Thread safety (fPageAllocator->DeletePage):
                   // fPagePool operations are protected by a mutex.

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -33,6 +33,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <list>
 #include <utility>
 
 #include <atomic>
@@ -192,6 +193,83 @@ void ROOT::Experimental::Detail::RPageSinkFile::ReleasePage(RPage &page)
 ////////////////////////////////////////////////////////////////////////////////
 
 
+namespace ROOT {
+namespace Experimental {
+namespace Detail {
+
+class RPageCache {
+private:
+   // Doubly linked-list for random-access removal
+   std::list<RPage> fPages;
+public:
+   RPageCache() = default;
+   RPageCache(const RPageCache&) = delete;
+   RPageCache& operator=(const RPageCache&) = delete;
+   RPageCache(RPageCache&&) = default;
+   RPageCache& operator=(RPageCache&&) = default;
+
+   /// Deallocate the page's memory buffer.
+   void DeletePage(const RPage &page) {
+      delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
+   }
+
+   /// Return a page to the cache for reuse. Page memory ownership is passed to the cache.
+   /// If the cache is full, the smallest memory buffer is deallocated.
+   void ReturnPage(const RPage &page) {
+      if (fPages.size() < 32) {
+         fPages.push_back(RPage(
+            // Reset column id and element size and reuse buffer with known capacity
+            kInvalidColumnId, page.GetBuffer(), page.GetCapacity(), 0 /* elementSize */
+         ));
+         return;
+      }
+      // If the cache is getting too large, swap out the smallest page
+      auto min_elt = std::min_element(fPages.begin(), fPages.end(),
+         [](const auto &a, const auto &b) { return a.GetCapacity() < b.GetCapacity(); });
+      if (min_elt == fPages.end()) {
+         DeletePage(page);
+         return;
+      }
+      DeletePage(*min_elt);
+      *min_elt = page;
+   }
+
+   /// Request a page from the cache with at least the specified `capacity`. Ownership of the
+   /// page memory is passed to the caller. If there isn't a suitable page in the cache, a
+   /// new allocation is made.
+   RPage RequestPage(ColumnId_t columnId, std::size_t capacity, std::size_t elementSize) {
+      auto it = std::find_if(fPages.begin(), fPages.end(), [&](const auto &p) {
+         return p.GetCapacity() >= capacity;
+      });
+      // Cache miss, allocate a new page
+      if (it == fPages.end()) {
+         auto pageBuffer = std::make_unique<unsigned char[]>(capacity);
+         return RPage(columnId, pageBuffer.release(), capacity, elementSize);
+      }
+      // Cache hit, recycle a suitable page
+      auto page = *it;
+      fPages.erase(it);
+      return RPage(columnId, page.GetBuffer(), page.GetCapacity(), elementSize);
+   }
+
+   ~RPageCache() {
+      for (const auto &p : fPages) {
+         DeletePage(p);
+      }
+   }
+};
+
+} // namespace Detail
+} // namespace Experimental
+} // namespace ROOT
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+ROOT::Experimental::Detail::RPageAllocatorFile::RPageAllocatorFile()
+   : fPageCache(std::make_unique<RPageCache>()) {}
+
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorFile::NewPage(
    ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
 {
@@ -200,11 +278,19 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorFile
    return newPage;
 }
 
+ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorFile::NewPage(
+   ColumnId_t columnId, std::size_t elementSize, std::size_t nElements)
+{
+   RPage newPage = fPageCache->RequestPage(columnId, elementSize * nElements, elementSize);
+   newPage.TryGrow(nElements);
+   return newPage;
+}
+
 void ROOT::Experimental::Detail::RPageAllocatorFile::DeletePage(const RPage& page)
 {
    if (page.IsNull())
       return;
-   delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
+   fPageCache->ReturnPage(page);
 }
 
 
@@ -309,20 +395,38 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceFile::P
       sealedPageBuffer = onDiskPage->GetAddress();
    }
 
-   std::unique_ptr<unsigned char []> pageBuffer;
+   auto newPage = fPageAllocator->NewPage(columnId, elementSize, pageInfo.fNElements);
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
-      pageBuffer = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element);
+      // UnsealPage {
+      RSealedPage sealedPage(sealedPageBuffer, bytesOnStorage, pageInfo.fNElements);
+      const auto bytesPacked = element->GetPackedSize(sealedPage.fNElements);
+      //auto pageBuffer = std::make_unique<unsigned char[]>(bytesPacked);
+      if (sealedPage.fSize != bytesPacked) {
+         fDecompressor->Unzip(sealedPage.fBuffer, sealedPage.fSize, bytesPacked, newPage.GetBuffer());
+      } else {
+         // We cannot simply map the sealed page as we don't know its life time. Specialized page sources
+         // may decide to implement to not use UnsealPage but to custom mapping / decompression code.
+         // Note that usually pages are compressed.
+         memcpy(newPage.GetBuffer(), sealedPage.fBuffer, bytesPacked);
+      }
+      if (!element->IsMappable()) {
+         R__ASSERT(false && "implement mappable");
+         //element.Unpack(unpackedBuffer, pageBuffer.get(), sealedPage.fNElements);
+         //newPage = RPage(columnId
+         //pageBuffer = std::unique_ptr<unsigned char []>(unpackedBuffer);
+      }
+      // } end UnsealPage
       fCounters->fSzUnzip.Add(elementSize * pageInfo.fNElements);
    }
 
    const auto indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex;
-   auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), elementSize, pageInfo.fNElements);
    newPage.SetWindow(indexOffset + pageInfo.fFirstInPage, RPage::RClusterInfo(clusterId, indexOffset));
+   // Thread safety (fPageAllocator->DeletePage): fPagePool operations are protected by a mutex.
    fPagePool->RegisterPage(newPage,
-      RPageDeleter([](const RPage &page, void * /*userData*/)
+      RPageDeleter([&](const RPage &page, void * /*userData*/)
       {
-         RPageAllocatorFile::DeletePage(page);
+         fPageAllocator->DeletePage(page);
       }, nullptr));
    fCounters->fNPagePopulated.Inc();
    return newPage;
@@ -528,6 +632,7 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(RCluster *clu
          auto onDiskPage = cluster->GetOnDiskPage(key);
          R__ASSERT(onDiskPage && (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage));
 
+         // todo: use RPageCache guarded by mutex
          auto taskFunc =
             [this, columnId, clusterId, firstInPage, onDiskPage,
              element = allElements.back().get(),
@@ -539,10 +644,13 @@ void ROOT::Experimental::Detail::RPageSourceFile::UnzipClusterImpl(RCluster *clu
 
                auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), element->GetSize(), nElements);
                newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
+
                fPagePool->PreloadPage(newPage,
-                  RPageDeleter([](const RPage &page, void * /*userData*/)
+                  // Thread safety (fPageAllocator->DeletePage):
+                  // fPagePool operations are protected by a mutex.
+                  RPageDeleter([&](const RPage &page, void * /*userData*/)
                   {
-                     RPageAllocatorFile::DeletePage(page);
+                     fPageAllocator->DeletePage(page);
                   }, nullptr));
             };
 


### PR DESCRIPTION
Profiles of RNTuple benchmarks (`iotools/cms, lhcb`) showed ~10-20% of
total runtime is due to allocations in `RPageSource::UnsealPage`.

One typical RNTuple use case is an event loop over a fixed number of
columns. Columns are divided into pages with a fixed size, e.g.

```
Events | Column 0 | Column 1 | Column 2
-------+----------+----------+----------
  1-10   p0(40kB)   p1(80kB)   p2(80kB)
 11-20   p3(40kB)   p4(80kB)   p5(80kB)
  ...      ...        ...        ...
```

Before this change, page allocations were performed every time a page
is flushed from a column:

```
Events | Column 0 | Column 1 | Column 2
-------+----------+----------+----------
         [alloc]    [alloc]    [alloc]
  1-10   p0(40kB)   p1(80kB)   p2(80kB)
        [dealloc]  [dealloc]  [dealloc]
         [alloc]    [alloc]    [alloc]
 11-20   p3(40kB)   p4(80kB)   p5(80kB)
  ...      ...        ...        ...
        [dealloc]  [dealloc]  [dealloc]
```

After this change, allocations are held onto and reused if possible
(up to a certain limit, which for now is hard-coded to be 32 pages).

```
Events | Column 0 | Column 1 | Column 2
-------+----------+----------+----------
         [alloc]    [alloc]    [alloc]
  1-10   p0(40kB)   p1(80kB)   p2(80kB)
 11-20   p3(40kB)   p4(80kB)   p5(80kB)
  ...      ...        ...        ...
        [dealloc]  [dealloc]  [dealloc]
```

On SSD, the following serial results were obtained for the lhcb and cms
benchmarks (average of ten cold runs, 95% confidence interval):

```
cms

Before: 105145us +- 1338us
After:   93669us +- 2077us
%diff:  10.9%

lhcb

Before: 2111977us +-  8371us
After:  1770781us +- 11185us
%diff:  16.2%
```

Todo: 
- [x] Handle non-mappable case in `PopulatePage`
- [x] Investigate multi-threaded case

For multithreading, the current implementation just uses the existing `UnsealPage` mechanism and is unaffected by these changes -- deleted pages are returned to the cache which deallocates them properly. 

I tried adding an internal mutex to `RPageCache` and bumping the number of cached pages to 128 on the benchmark machine but the runtime was about the same as the existing cache-less implementation. Further cache size increases did not show improvements, but as expected only having 32 cached pages for 128 threads was much slower.

```
./lhcb -m (64-cores, 10 cold runs, 95% confidence interval)
no cache: 776188us +- 9918us
cache (128):    780214us +- 11888us
%diff: -0.5%
cache (32):    1369689us +- 33365us
%diff: -76.46%
```