### PR TITLE
[skip-ci] a missing double quote screwed up some doc.

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -380,7 +380,7 @@ TGraph::TGraph(const TF1 *f, Option_t *option)
 /// Graph constructor reading input from filename.
 ///
 /// `filename` is assumed to contain at least two columns of numbers.
-/// the string format is by default `"%lg %lg"`.
+/// The string format is by default `"%lg %lg"`.
 /// This is a standard c formatting for `scanf()`.
 ///
 /// If columns of numbers should be skipped, a `"%*lg"` or `"%*s"` for each column

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -218,7 +218,7 @@ TGraphErrors::TGraphErrors(const TH1 *h)
 ///
 /// `filename` is assumed to contain at least 2 columns of numbers
 ///
-/// Convention for format (default="%lg %lg %lg %lg)
+/// Convention for format (default=`"%lg %lg %lg %lg"`)
 ///
 ///   - format = `%lg %lg`         read only 2 first columns into X,Y
 ///   - format = `%lg %lg %lg`     read only 3 first columns into X,Y and EY


### PR DESCRIPTION

Fix this: https://root.cern/doc/v624/classTGraphErrors.html#a5f6ab98471c9e48337cbbedbbfad07e1