### PR TITLE
Make FileAndIndex class ordered and hashable

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Ranges.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Ranges.py
@@ -49,6 +49,7 @@ class TreeRange(object):
         self.friend_info = friend_info
 
 
+@total_ordering
 class FileAndIndex(object):
     """
     This is a pair (filename, index) that represents the index of the current
@@ -65,6 +66,21 @@ class FileAndIndex(object):
         """set attributes"""
         self.filename = filename
         self.fileindex = fileindex
+
+    def __lt__(self, other):
+        """Total ordering is defined to be able to sort a set[FileAndIndex]."""
+        return self.fileindex < other.fileindex
+
+    def __eq__(self, other):
+        """Defined in compliance with total_ordering decorator"""
+        return self.fileindex == other.fileindex
+
+    def __hash__(self):
+        """
+        This type needs to be hashable to be part of a set in
+        get_clustered_ranges
+        """
+        return hash(self.filename)
 
 
 @total_ordering

--- a/bindings/experimental/distrdf/test/test_buildranges.py
+++ b/bindings/experimental/distrdf/test/test_buildranges.py
@@ -287,3 +287,23 @@ class BuildRangesTest(unittest.TestCase):
         ]
 
         self.assertListEqual(ranges, ranges_reqd)
+
+    def test_clustered_ranges_with_two_files(self):
+        """
+        Create two ranges from two files with a different number of clusters.
+        """
+
+        treename = "myTree"
+        filelist = ["backend/2clusters.root", "backend/4clusters.root"]
+        headnode = create_dummy_headnode(treename, filelist)
+        headnode.npartitions = 2
+
+        crs = headnode.build_ranges()
+        ranges = treeranges_to_tuples(crs)
+
+        ranges_reqd = [
+            (0, 1250, ["backend/2clusters.root", "backend/4clusters.root"]),
+            (250, 1000, ["backend/4clusters.root"]),
+        ]
+
+        self.assertListEqual(ranges, ranges_reqd)


### PR DESCRIPTION
The FileAndIndex class needs to be ordered and hashable because in `get_clustered_ranges` objects of this class are stored in a set and sorted to find, per each partition of the distributed RDataFrame, what files need to be considered.
Python classes get `__eq__` and `__hash__` methods by default, but not the ordering ones. Without this commit, `filelist` members of the `TreeRange` objects resulting from `get_clustered_ranges` would just be a 1:1 copy of the filenames that each cluster in the chain of that partition belongs to.
For example, given a tree with ten thousand entries and ten clusters split in two partitions, one would get:

Partition 0
Range of entries [0, 5000]
Filelist of the partition ['tree10000entries10clusters.root', 'tree10000entries10clusters.root', 'tree10000entries10clusters.root', 'tree10000entries10clusters.root', 'tree10000entries10clusters.root']

Partition 1
Range of entries [5000, 10000]
Filelist of the partition ['tree10000entries10clusters.root', 'tree10000entries10clusters.root', 'tree10000entries10clusters.root', 'tree10000entries10clusters.root', 'tree10000entries10clusters.root']

So effectively we would be sending ranges with one filename per cluster in the range, which would lead to wrong reads.

