### PR TITLE
Enable `RCanvas` in `jupyter lab`

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -426,10 +426,7 @@ def GetGeometryDrawer():
         return NotebookDrawer(vol)
 
 def GetDrawers():
-    drawers = GetCanvasDrawers()
-    rdrawers = GetRCanvasDrawers()
-    for drawer in rdrawers:
-        drawers.append(drawer)
+    drawers = GetCanvasDrawers() + GetRCanvasDrawers()
     geometryDrawer = GetGeometryDrawer()
     if geometryDrawer: drawers.append(geometryDrawer)
     return drawers
@@ -527,7 +524,6 @@ class NotebookDrawer(object):
 
     def _getJsCode(self):
         # produce JSON for the canvas
-        json = ""
         if self.isRCanvas:
             json = self.drawableObject.CreateJSON()
         else:
@@ -546,8 +542,8 @@ class NotebookDrawer(object):
             options = ""
 
         if self.isRCanvas:
-            # height = self.drawableObject.GetSize()[0]
-            # width = self.drawableObject.GetSize()[1]
+            # width = self.drawableObject.GetSize()[0]
+            # height = self.drawableObject.GetSize()[1]
             options = ""
 
         thisJsCode = _jsCode.format(jsCanvasWidth = height,

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -63,6 +63,9 @@ private:
    /// a painter.
    std::unique_ptr<Internal::RVirtualCanvasPainter> fPainter; ///<!
 
+   /// indicate if Show() method was called before
+   bool fShown{false}; ///<!
+
    /// Disable copy construction for now.
    RCanvas(const RCanvas &) = delete;
 
@@ -106,6 +109,9 @@ public:
    /// Display the canvas.
    void Show(const std::string &where = "");
 
+   bool IsShown() const { return fShown; }
+   void ClearShown() { fShown = false; }
+
    /// Returns window name used to display canvas
    std::string GetWindowAddr() const;
 
@@ -148,6 +154,9 @@ public:
 
    /// Save canvas in image file
    bool SaveAs(const std::string &filename);
+
+   /// Provide JSON which can be used for offline display
+   std::string CreateJSON();
 
    /// Get the canvas's title.
    const std::string &GetTitle() const { return fTitle; }

--- a/graf2d/gpadv7/inc/ROOT/RVirtualCanvasPainter.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RVirtualCanvasPainter.hxx
@@ -60,6 +60,9 @@ public:
    /// produce file output in batch mode like png, jpeg, svg or pdf
    virtual bool ProduceBatchOutput(const std::string &, int, int) = 0;
 
+   /// produce canvas JSON
+   virtual std::string ProduceJSON() = 0;
+
    virtual void NewDisplay(const std::string &where) = 0;
 
    virtual int NumDisplays() const = 0;

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -135,6 +135,11 @@ std::shared_ptr<ROOT::Experimental::RCanvas> ROOT::Experimental::RCanvas::Create
 
 void ROOT::Experimental::RCanvas::Show(const std::string &where)
 {
+   fShown = true;
+
+   // workaround - in jupyter do not create any painters yet
+   if (gROOT->GetWebDisplay() == "jupyter") return;
+
    if (fPainter) {
       bool isany = (fPainter->NumDisplays() > 0);
 
@@ -179,7 +184,7 @@ void ROOT::Experimental::RCanvas::Hide()
 
 //////////////////////////////////////////////////////////////////////////
 /// Create image file for the canvas
-/// Supported SVG (extension .svg), JPEG (extension .jpg or .jpeg) and PNG (extension .png)
+/// Supported SVG (extension .svg), JPEG (extension .jpg or .jpeg), PNG (extension .png) or JSON (extension .json)
 
 bool ROOT::Experimental::RCanvas::SaveAs(const std::string &filename)
 {
@@ -193,6 +198,21 @@ bool ROOT::Experimental::RCanvas::SaveAs(const std::string &filename)
    auto height = fSize[1].fVal;
 
    return fPainter->ProduceBatchOutput(filename, width > 1 ? (int) width : 800, height > 1 ? (int) height : 600);
+}
+
+//////////////////////////////////////////////////////////////////////////
+/// Create JSON data for the canvas
+/// Can be used of offline display with JSROOT
+
+std::string ROOT::Experimental::RCanvas::CreateJSON()
+{
+   if (!fPainter)
+      fPainter = Internal::RVirtualCanvasPainter::Create(*this);
+
+   if (!fPainter)
+      return "";
+
+   return fPainter->ProduceJSON();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -157,6 +157,8 @@ public:
 
    bool ProduceBatchOutput(const std::string &fname, int width, int height) final;
 
+   std::string ProduceJSON() final;
+
    void NewDisplay(const std::string &where) final;
 
    int NumDisplays() const final;
@@ -471,6 +473,17 @@ bool RCanvasPainter::ProduceBatchOutput(const std::string &fname, int width, int
    }
 
    return RWebDisplayHandle::ProduceImage(fname, snapshot, width, height);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Produce JSON for the canvas
+
+std::string RCanvasPainter::ProduceJSON()
+{
+   RDrawable::RDisplayContext ctxt(&fCanvas, &fCanvas, 0);
+   ctxt.SetConnection(1, true);
+
+   return CreateSnapshot(ctxt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add several methods to RCanvas like `IsShown`, `ClearShown`, `CreateJSON`

In python part:
 * set special "jupyter" kind of web display
 * detect if RCanvas compiled
 * like with TCanvas, extract list of RCanvas after each cell
 * use RCanvas methods to create JSON and then display it

This enables offline functionality of `RCanvas` like for `TCanvas`.

As next step, one could try real  __online__ mode - `jupyter` provides communication channel between cells and server.
But lets do first step