### PR TITLE
[GSoC][TMVA][SOFIE] Modified AddOutputTensorNameList in RModel

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -71,11 +71,7 @@ public:
          if ( i == libname) fNeededStdLib.insert(libname);
       }
    }
-   void AddOutputTensorNameList(std::vector<std::string> outputtensornames){
-      for(auto &it : outputtensornames){
-      fOutputTensorNames.push_back(UTILITY::Clean_name(it));
-      }
-   }
+   void AddOutputTensorNameList(std::vector<std::string> outputtensornames);
    void UpdateInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, std::shared_ptr<void> data);
    std::shared_ptr<void> GetInitializedTensorData(std::string tensor_name);
 

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -72,7 +72,9 @@ public:
       }
    }
    void AddOutputTensorNameList(std::vector<std::string> outputtensornames){
-      fOutputTensorNames = outputtensornames;
+      for(auto &it : outputtensornames){
+      fOutputTensorNames.push_back(UTILITY::Clean_name(it));
+      }
    }
    void UpdateInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, std::shared_ptr<void> data);
    std::shared_ptr<void> GetInitializedTensorData(std::string tensor_name);

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -133,6 +133,12 @@ namespace SOFIE{
       TensorInfo new_tensor {type, shape};
       fIntermediateTensorInfos[tensor_name] = new_tensor;
    }
+   
+   void RModel::AddOutputTensorNameList(std::vector<std::string> outputtensornames){
+      for(auto& it : outputtensornames){
+         fOutputTensorNames.push_back(UTILITY::Clean_name(it));
+      }
+   }
 
    void RModel::UpdateInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, std::shared_ptr<void> data){
       tensor_name = UTILITY::Clean_name(tensor_name);


### PR DESCRIPTION
## Description
This PR modifies the AddOutputTensorNameList() function present in RModel.hxx to use the UTILITY::Clean_name() function to process the strings before adding them into the RModel.


## Checklist:
- [x] tested changes locally


