### PR TITLE
[v624][RF] Fix `if` statement in HypoTestInverterResult::FindIndex()

### DIFF
--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -569,7 +569,7 @@ int HypoTestInverterResult::FindIndex(double xvalue) const
   for (int i=0; i<ArraySize(); i++) {
      double xpoint = fXValues[i];
      if ( (std::abs(xvalue) > 1 && TMath::AreEqualRel( xvalue, xpoint, tol) ) ||
-          (std::abs(xvalue) < 1 && TMath::AreEqualAbs( xvalue, xpoint, tol) ) )
+          (std::abs(xvalue) <= 1 && TMath::AreEqualAbs( xvalue, xpoint, tol) ) )
         return i;
   }
   return -1;


### PR DESCRIPTION
The `if` statement in `HypoTestInverterResult::FindIndex()` didn't
consider the `xvalue == 1` case, resulting in no index being found.

Backport of https://github.com/root-project/root/pull/8645.