### PR TITLE
Remove accidentally introduced I/O capabilities of RooMinimizer

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -129,7 +129,7 @@ private:
 
   RooMinimizer(const RooMinimizer&) ;
 	
-  ClassDef(RooMinimizer,1) // RooFit interface to ROOT::Fit::Fitter
+  ClassDef(RooMinimizer,0) // RooFit interface to ROOT::Fit::Fitter
 } ;
 
 


### PR DESCRIPTION
#8569 set the ClassDef version to 1, while it was zero before. Zero was a special value meaning "no I/O needed" (see https://root.cern.ch/root/html534/guides/users-guide/AddingaClass.html#motivation). This PR/commit resets it to zero.

Fixes #8652.