### PR TITLE
Add GitHub workflow with daily check of closed issues [skip-ci]

### DIFF
--- a/.github/actions/issues-nudge.js
+++ b/.github/actions/issues-nudge.js
@@ -1,0 +1,63 @@
+const { Octokit } = require("octokit");
+const { graphql } = require("@octokit/graphql");
+
+const token = process.env.GITHUB_TOKEN;
+const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+const octokit = new Octokit({ auth: token });
+
+async function nudge(issue_number) {
+  const { data: issue_details } = await octokit.rest.issues.get({
+    owner: owner,
+    repo: repo,
+    issue_number: issue_number,
+  });
+  const closed_by = issue_details.closed_by.login;
+  const assignees = issue_details.assignees.map(user => user.login);
+
+  // Put the person who closed the issue first, then all assignees (excluding
+  // the person who closed, for obvious reasons).
+  const ping_logins = [ closed_by ].concat(assignees.filter(user => user != closed_by));
+  const ping = ping_logins.map(login => "@" + login).join(", ");
+
+  console.log("Posting comment to issue #" + issue_number + "; pinging [ " + ping + " ]");
+
+  let body = "Hi " + ping + ",\n\n";
+  body += "It appears this issue is closed, but wasn't yet added to a project. ";
+  body += "Please add upcoming versions that will include the fix, or 'not applicable' otherwise.";
+  body += "\n\nSincerly,\n:robot:\n";
+
+  octokit.rest.issues.createComment({
+    owner: owner,
+    repo: repo,
+    issue_number: issue_number,
+    body: body,
+  });
+}
+
+async function iterate_issues() {
+  const { search: { nodes: issues } } = await graphql(
+    `
+      {
+        search(query: "repo:root-project/root is:issue is:closed no:project", type: ISSUE, first: 100) {
+          nodes {
+            ... on Issue {
+              number
+            }
+          }
+        }
+      }
+    `,
+    {
+      headers: {
+        authorization: "token " + token,
+      },
+    }
+  );
+
+  for (const issue of issues) {
+    nudge(issue.number);
+  }
+}
+
+iterate_issues();

--- a/.github/workflows/issues-nudge.yml
+++ b/.github/workflows/issues-nudge.yml
@@ -1,0 +1,19 @@
+name: Daily nudge about closed issues without a project
+on:
+  schedule:
+    # Run every weekday at 6:00 UTC (7:00 or 8:00 CERN)
+    - cron: '0 6 * * MON-FRI'
+
+jobs:
+  issues-nudge:
+    if: ${{ github.repository == 'root-project/root' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          version: 12
+      - run: npm install octokit
+      - run: node .github/actions/issues-nudge.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Nudge about those issues without a project, pinging the person who closed and all assignees.

(new version of #8654 which runs daily instead of immediately after closing an issue)