### PR TITLE
[dictgen] Also forward declare namespaces, typedefs, enums:

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3192,8 +3192,9 @@ static std::string GenerateFwdDeclString(const RScanner &scan,
                    selectedDecls.begin(),
                    [](const ROOT::TMetaUtils::AnnotatedRecordDecl& rcd){return rcd.GetRecordDecl();});
 
-   for (auto* TD: scan.fSelectedTypedefs)
-      selectedDecls.push_back(TD);
+   selectedDecls.insert(selectedDecls.begin(), scan.fSelectedNamespaces.begin(), scan.fSelectedNamespaces.end());
+   selectedDecls.insert(selectedDecls.begin(), scan.fSelectedTypedefs.begin(), scan.fSelectedTypedefs.end());
+   selectedDecls.insert(selectedDecls.begin(), scan.fSelectedEnums.begin(), scan.fSelectedEnums.end());
 
 //    for (auto* VAR: scan.fSelectedVariables)
 //       selectedDecls.push_back(VAR);


### PR DESCRIPTION
They were picked up as side effects of classes, but not forward declared as
and by themselves. This fixes namespaces and enums not being available / known at the ROOT prompt despite their dictionary being loaded:
https://root-forum.cern.ch/t/enum-in-namespace-not-available-after-loading-dictionary/45757
