### PR TITLE
[gui] Fix typo in `TRootGuiBuilder`

### DIFF
--- a/gui/guibuilder/src/TRootGuiBuilder.cxx
+++ b/gui/guibuilder/src/TRootGuiBuilder.cxx
@@ -1992,7 +1992,7 @@ void TRootGuiBuilder::EraseStatusBar()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Keyborad key binding.
+/// Keyboard key binding.
 
 void TRootGuiBuilder::BindKeys()
 {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
typo in trootguibuilder docu
