### PR TITLE
[gui][skip-ci] Fix typo in `TRootGuiBuilder::BindKeys()` documentation

### DIFF
--- a/gui/guibuilder/src/TRootGuiBuilder.cxx
+++ b/gui/guibuilder/src/TRootGuiBuilder.cxx
@@ -1992,7 +1992,7 @@ void TRootGuiBuilder::EraseStatusBar()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Keyborad key binding.
+/// Keyboard key binding.
 
 void TRootGuiBuilder::BindKeys()
 {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Typo in `TRootGuiBuilder::BindKeys` docu.

This PR supersedes https://github.com/root-project/root/pull/8663
