### PR TITLE
[TGMainFrame] grabbed keys stop working if TGTextButton with Alt hotkey

### DIFF
--- a/gui/gui/src/TGButton.cxx
+++ b/gui/gui/src/TGButton.cxx
@@ -814,6 +814,8 @@ void TGTextButton::DoRedraw()
 
 Bool_t TGTextButton::HandleKey(Event_t *event)
 {
+   if (fState == kButtonDisabled || !(event->fState & kKeyMod1Mask)) return kFALSE;
+   
    Bool_t click = kFALSE;
    Bool_t was = !IsDown();   // kTRUE if button was off
 
@@ -824,8 +826,6 @@ Bool_t TGTextButton::HandleKey(Event_t *event)
    }
 
    if (fTip && event->fType == kGKeyPress) fTip->Hide();
-
-   if (fState == kButtonDisabled) return kTRUE;
 
    // We don't need to check the key number as GrabKey will only
    // allow fHotchar events if Alt button is pressed (kKeyMod1Mask)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

TGMainFrame::HandleKey stops prematurely, see https://github.com/root-project/root/blob/master/gui/gui/src/TGFrame.cxx#L1593, if any TGTextButton with a hotkey shortcut (`"&Sort data"`) is used in a GUI, even if the actual Key is CTRL+S instead of Alt+S or even if button is disabled.

## Reproducer
Based on @bellenot from https://github.com/root-project/root/issues/8665

To try it, press CTRL+S, it should open a file dialog to save the frame. Instead, it thinks it is Alt+S and stops the function too early.
```
#include "KeySymbols.h"
#include "TGFrame.h"
#include <iostream>
#include "TVirtualX.h"
#include "TGButton.h"
//______________________________________________________________________________
//
//
//______________________________________________________________________________
class MyMainFrame : public TGMainFrame {
public:
   MyMainFrame(const TGWindow *p, UInt_t w, UInt_t h);
   virtual ~MyMainFrame() { Cleanup(); }
   void     CloseWindow() { delete this; }

   ClassDef(MyMainFrame, 0)
};

//______________________________________________________________________________
MyMainFrame::MyMainFrame(const TGWindow *p, UInt_t w, UInt_t h) : TGMainFrame(p, w, h)
{
   auto sortdata = new TGTextButton(this, "&Sort data");
   AddFrame(sortdata);

   MapSubwindows();
   Layout();
   MapWindow();
   Resize(150,100);
}

//______________________________________________________________________________
void test_grab_key()
{
    MyMainFrame *main = new MyMainFrame(gClient->GetRoot(), 150, 100);
}

```


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
