### PR TITLE
[cmake] Remove warning about mismatched argument to if/endif

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -480,7 +480,7 @@ if (builtin_cling)
     # cmake: set_property(TARGET clingInterpreter PROPERTY POSITION_INDEPENDENT_CODE ON)?
     string(APPEND CMAKE_CXX_FLAGS " -fPIC")
     string(APPEND CMAKE_C_FLAGS " -fPIC")
-  endif(LLVM_ENABLE_PIC)
+  endif(LLVM_ENABLE_PIC AND NOT MSVC)
   # Avoid cling being installed under ROOTSYS/include.
   add_subdirectory(cling EXCLUDE_FROM_ALL)
   add_dependencies(CLING ${CLING_LIBRARIES})


### PR DESCRIPTION
The warning is visible e.g. with cmake 3.11:

CMake Warning (dev) in interpreter/CMakeLists.txt:
  A logical block opening on the line

    /data/ssdext4/rvec2/root/interpreter/CMakeLists.txt:477 (if)

  closes on the line

    /data/ssdext4/rvec2/root/interpreter/CMakeLists.txt:483 (endif)

  with mis-matching arguments.
