### PR TITLE
[TGMainFrame] disengage SaveFrame code from GUI so that it can also run from script

### DIFF
--- a/gui/gui/inc/TGFrame.h
+++ b/gui/gui/inc/TGFrame.h
@@ -453,6 +453,7 @@ public:
    virtual Bool_t HandleButton(Event_t *event);
    virtual Bool_t HandleMotion(Event_t *event);
    virtual Bool_t SaveFrameAsCodeOrImage();
+   virtual Bool_t SaveFrameAsCodeOrImage(const TString fileName);
    virtual void   SendCloseMessage();
    virtual void   CloseWindow();   //*SIGNAL*
 

--- a/gui/gui/inc/TGFrame.h
+++ b/gui/gui/inc/TGFrame.h
@@ -453,7 +453,7 @@ public:
    virtual Bool_t HandleButton(Event_t *event);
    virtual Bool_t HandleMotion(Event_t *event);
    virtual Bool_t SaveFrameAsCodeOrImage();
-   virtual Bool_t SaveFrameAsCodeOrImage(const TString fileName);
+   virtual Bool_t SaveFrameAsCodeOrImage(const TString &fileName);
    virtual void   SendCloseMessage();
    virtual void   CloseWindow();   //*SIGNAL*
 

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1563,8 +1563,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage(const TString &fileName)
    if (fname.EndsWith(".C")) {
       TGMainFrame *main = (TGMainFrame*)GetMainFrame();
       main->SaveSource(fname.Data(), "");
-   }
-   else {
+   } else {
       TImage::EImageFileTypes gtype = TImage::kUnknown;
       if (fname.EndsWith("gif")) {
          gtype = TImage::kGif;

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1586,8 +1586,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage(const TString &fileName)
          img->WriteImage(fname, gtype);
          gErrorIgnoreLevel = saver;
          delete img;
-      }
-      else {
+      } else {
          Error("SaveFrameAsCodeOrImage", "File cannot be saved with this extension");
          return kFALSE;
       }

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1536,8 +1536,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage()
       dir = fi.fIniDir;
       overwr = fi.fOverwrite;
       const Bool_t res = SaveFrameAsCodeOrImage(fi.fFilename);
-      if(!res)
-      {
+      if (!res) {
          Int_t retval;
          new TGMsgBox(fClient->GetDefaultRoot(), this, "Error...",
                       TString::Format("file (%s) cannot be saved with this extension",

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1538,12 +1538,12 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage()
       const Bool_t res = SaveFrameAsCodeOrImage(fi.fFilename);
       if(!res)
       {
-            Int_t retval;
-            new TGMsgBox(fClient->GetDefaultRoot(), this, "Error...",
-                         TString::Format("file (%s) cannot be saved with this extension",
-                                         fi.fFilename), kMBIconExclamation,
-                         kMBRetry | kMBCancel, &retval);
-            repeat_save = (retval == kMBRetry);
+         Int_t retval;
+         new TGMsgBox(fClient->GetDefaultRoot(), this, "Error...",
+                      TString::Format("file (%s) cannot be saved with this extension",
+                                      fi.fFilename),
+                      kMBIconExclamation, kMBRetry | kMBCancel, &retval);
+         repeat_save = (retval == kMBRetry);
       }
    } while (repeat_save);
 
@@ -1562,7 +1562,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage(const TString fileName)
 
    const TString fname = gSystem->UnixPathName(fileName);
    if (fname.EndsWith(".C")) {
-	  TGMainFrame *main = (TGMainFrame*)GetMainFrame();
+      TGMainFrame *main = (TGMainFrame*)GetMainFrame();
       main->SaveSource(fname.Data(), "");
    }
    else {
@@ -1590,7 +1590,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage(const TString fileName)
       }
       else {
          Error("SaveFrameAsCodeOrImage", "File cannot be saved with this extension");
-		 return kFALSE;
+         return kFALSE;
       }
    }
 

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1556,7 +1556,7 @@ Bool_t TGMainFrame::SaveFrameAsCodeOrImage()
 /// If preexisting, the file is overwritten.
 /// Returns kTRUE if something was saved.
 
-Bool_t TGMainFrame::SaveFrameAsCodeOrImage(const TString fileName)
+Bool_t TGMainFrame::SaveFrameAsCodeOrImage(const TString &fileName)
 {
    static TString dir(".");
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Adds an option to call SaveFrame from batch script, without having to interact, giving the filename as argument.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
