### PR TITLE
[RDF] Add progress bar + event statistics

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RResultMap.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RResultMap.hxx
@@ -85,6 +85,9 @@ class RResultMap {
    }
 
 public:
+   using iterator       = typename decltype(fMap)::iterator;
+   using const_iterator = typename decltype(fMap)::const_iterator;
+
    // TODO: can we use a std::string_view here without having to create a temporary std::string anyway?
    T &operator[](const std::string &key)
    {
@@ -96,6 +99,24 @@ public:
          fLoopManager->Run();
       return *it->second;
    }
+
+   /// Iterator to walk through key-value pairs of all variations for a given object.
+   /// Runs the event loop before returning if necessary.
+   iterator begin()
+   {
+      if (!fAction->HasRun())
+         fLoopManager->Run();
+      return fMap.begin();
+   }
+   const_iterator cbegin()
+   {
+      if (!fAction->HasRun())
+         fLoopManager->Run();
+      return fMap.cbegin();
+   }
+   iterator end() { return fMap.end(); }
+   const_iterator end() const { return fMap.cend(); }
+   const_iterator cend() const { return fMap.cend(); }
 
    const std::vector<std::string> &GetKeys() const { return fKeys; }
 };

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -17,6 +17,11 @@
 #endif // R__USE_IMT
 
 #include <set>
+#include <numeric>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+#include <stdio.h>
 
 using ROOT::RDF::RResultHandle;
 
@@ -210,6 +215,17 @@ void ProgressHelper::PrintProgressbar(std::ostream& stream, std::size_t currentE
   if (fUseShellColours) stream << "\e[33m";
   stream << '|' << std::setfill(' ') << std::setw(fBarWidth) << std::left << bars << "|   ";
   if (fUseShellColours) stream << "\e[0m";
+}
+
+std::size_t ROOT::RDF::RetrieveNEvents(const char* treename, const char* fileUrl) {
+  std::unique_ptr<TFile> file( TFile::Open(fileUrl, "READ") );
+  if (!file)
+    return 0u;
+
+  std::unique_ptr<TTree> tree( file->Get<TTree>(treename) );
+  if (tree) return tree->GetEntries();
+
+  return 0u;
 }
 
 } } // namespace ROOT::RDF

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -20,7 +20,10 @@
 
 using ROOT::RDF::RResultHandle;
 
-void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
+namespace ROOT {
+namespace RDF {
+
+void RunGraphs(std::vector<RResultHandle> handles)
 {
    if (handles.empty()) {
       Warning("RunGraphs", "Got an empty list of handles");
@@ -57,3 +60,156 @@ void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
    for (auto &h : uniqueLoops)
       run(h);
 }
+
+
+ProgressHelper::ProgressHelper(std::size_t increment,
+    unsigned int progressBarWidth,
+    unsigned int printInterval,
+    bool useShellColors) :
+fPrintInterval(printInterval),
+fIncrement{increment},
+fBarWidth{progressBarWidth},
+#ifdef _WIN32
+fIsTTY{_isatty(_fileno(stdout)) == 1},
+fUseShellColours{false && useShellColors}
+#else
+fIsTTY{isatty(fileno(stdout)) == 1},
+fUseShellColours{useShellColors && fIsTTY} // Control characters only with terminals.
+#endif
+{
+
+}
+
+/// Compute a running mean of events/s.
+double ProgressHelper::EvtPerSec() const {
+  if (fEventsPerSecondStatisticsIndex < fEventsPerSecondStatistics.size())
+    return std::accumulate(fEventsPerSecondStatistics.begin(), fEventsPerSecondStatistics.begin() + fEventsPerSecondStatisticsIndex, 0.) / fEventsPerSecondStatisticsIndex;
+  else
+    return std::accumulate(fEventsPerSecondStatistics.begin(), fEventsPerSecondStatistics.end(), 0.) / fEventsPerSecondStatistics.size();
+}
+
+/// Record current event counts and time stamp, populate evts/s statistics array.
+std::pair<std::size_t, std::chrono::seconds>
+ProgressHelper::RecordEvtCountAndTime() {
+  using namespace std::chrono;
+
+  const auto currentEventCount = fProcessedEvents.load();
+  const auto eventsPerTimeInterval = currentEventCount - fLastProcessedEvents;
+  fLastProcessedEvents = currentEventCount;
+
+  const auto oldPrintTime = fLastPrintTime;
+  const auto newPrintTime = system_clock::now();
+  fLastPrintTime = newPrintTime;
+
+  const duration<double> secondsCurrentInterval = newPrintTime - oldPrintTime;
+  fEventsPerSecondStatistics[fEventsPerSecondStatisticsIndex++ % fEventsPerSecondStatistics.size()] = eventsPerTimeInterval / secondsCurrentInterval.count();
+
+  return {currentEventCount, duration_cast<seconds>(newPrintTime - fBeginTime)};
+}
+
+namespace {
+  struct PacksOfThree {
+    std::array<unsigned int, 7> packsOfThree; // More not supported by std::size_t
+    int packCounter = 0;
+
+    PacksOfThree(std::size_t count) {
+      for (; count > 0; ++packCounter) {
+        assert(packCounter < static_cast<int>(packsOfThree.size()));
+        packsOfThree[packCounter] = count % 1000;
+        count /= 1000;
+      }
+      --packCounter;
+    }
+  };
+
+  /// Format event counts as `6.346.362k`.
+  std::ostream& operator<<(std::ostream& stream, const PacksOfThree& packs) {
+    for (int i = static_cast<int>(packs.packCounter); i >= 1; --i) {
+      if (i == packs.packCounter) stream << packs.packsOfThree[i];
+      else stream << std::setw(3) << std::setfill('0') << std::right << packs.packsOfThree[i];
+
+      stream << (i > 1 ? '.' : 'k');
+    }
+    return stream << std::setfill(' ');
+  }
+
+  /// Format std::chrono::seconds as `1:30m`.
+  std::ostream& operator<<(std::ostream& stream, std::chrono::seconds elapsedSeconds) {
+    const auto h = std::chrono::duration_cast<std::chrono::hours>(elapsedSeconds);
+    const auto m = std::chrono::duration_cast<std::chrono::minutes>(elapsedSeconds - h);
+    const auto s = (elapsedSeconds - h - m).count();
+    if (h.count() > 0) stream << h.count() << ':' << std::setw(2) << std::right << std::setfill('0');
+    stream << m.count() << ':' << std::setw(2) << std::right << std::setfill('0') << s;
+    return stream << (h.count() > 0 ? 'h' : 'm');
+  }
+
+  struct RestoreStreamState {
+    RestoreStreamState(std::ostream& stream) :
+      fStream(stream),
+      fFlags(stream.flags()),
+      fFillChar(stream.fill()) { }
+    ~RestoreStreamState() {
+      fStream.setf(fFlags);
+      fStream.fill(fFillChar);
+    }
+
+    std::ostream& fStream;
+    std::ios_base::fmtflags fFlags;
+    std::ostream::char_type fFillChar;
+  };
+}
+
+/// Print event and time statistics.
+void ProgressHelper::PrintStats(std::ostream& stream, std::size_t currentEventCount, std::chrono::seconds elapsedSeconds) const {
+  const auto evtpersec = EvtPerSec();
+  const auto maxEvents = ComputeMaxEvents();
+  RestoreStreamState restore(stream);
+
+  stream << "[" << elapsedSeconds << "  ";
+
+  // Event counts:
+  if (fUseShellColours) stream << "\e[32m";
+
+  stream << PacksOfThree(currentEventCount);
+  if (maxEvents != 0) {
+    stream << "/" << PacksOfThree(maxEvents);
+  }
+  stream << " evt  ";
+
+  if (fUseShellColours) stream << "\e[0m";
+
+
+  // events/s
+  stream << std::scientific << std::setprecision(2) << evtpersec << " evt/s";
+
+
+  // Time statistics:
+  if (maxEvents != 0) {
+    if (fUseShellColours) stream << "\e[35m";
+    const std::chrono::seconds remainingSeconds( static_cast<long long>((ComputeMaxEvents() - currentEventCount) / evtpersec) );
+    stream << " " << remainingSeconds << " remaining";
+    if (fUseShellColours) stream << "\e[0m";
+  }
+
+  stream << "]   ";
+}
+
+/// Print a progress bar of width `ProgressHelper::fBarWidth` if `fMaxEvents` is known.
+void ProgressHelper::PrintProgressbar(std::ostream& stream, std::size_t currentEventCount) const {
+  const auto maxEvents = ComputeMaxEvents();
+  if (maxEvents == 0)
+    return;
+  RestoreStreamState restore(stream);
+
+  const double completion = double(currentEventCount) / maxEvents;
+  const unsigned int nBar = std::min(completion, 1.) * fBarWidth;
+
+  std::string bars(std::max(nBar, 1u), '=');
+  bars.back() = (nBar == fBarWidth) ? '=' : '>';
+
+  if (fUseShellColours) stream << "\e[33m";
+  stream << '|' << std::setfill(' ') << std::setw(fBarWidth) << std::left << bars << "|   ";
+  if (fUseShellColours) stream << "\e[0m";
+}
+
+} } // namespace ROOT::RDF

--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -217,7 +217,7 @@ void ProgressHelper::PrintProgressbar(std::ostream& stream, std::size_t currentE
   if (fUseShellColours) stream << "\e[0m";
 }
 
-std::size_t ROOT::RDF::RetrieveNEvents(const char* treename, const char* fileUrl) {
+std::size_t RetrieveNEvents(const char* treename, const char* fileUrl) {
   std::unique_ptr<TFile> file( TFile::Open(fileUrl, "READ") );
   if (!file)
     return 0u;

--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -28,6 +28,8 @@
 #include "TLatex.h"
 #include "TStyle.h"
 
+#include "ROOT/RDFHelpers.hxx"
+
 using namespace ROOT::VecOps;
 
 void df102_NanoAODDimuonAnalysis()
@@ -37,6 +39,10 @@ void df102_NanoAODDimuonAnalysis()
 
    // Create dataframe from NanoAOD files
    ROOT::RDataFrame df("Events", "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root");
+   ROOT::RDF::ProgressHelper progress{1000};
+   df.DefinePerSample("_progressbar",
+           [&progress](unsigned int slot, const ROOT::RDF::RSampleInfo & id) -> std::size_t { progress.registerNewSample(slot, id); return progress.ComputeMaxEvents(); });
+   df.Count().OnPartialResultSlot(1000, [&](unsigned int slot, auto && arg){ progress(slot, arg); });
 
    // For simplicity, select only events with exactly two muons and require opposite charge
    auto df_2mu = df.Filter("nMuon == 2", "Events with exactly two muons");


### PR DESCRIPTION
# This Pull request:
ProgressHelper is a class that offers callback functions for RDataFrame,
and can compute and print event statistics and a progress bar.

With a change like this:
```diff
--- a/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
+++ b/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C
@@ -28,6 +28,7 @@
 #include "TLatex.h"
 #include "Math/Vector4D.h"
 #include "TStyle.h"
+#include "ROOT/RDFHelpers.hxx"
 
 using namespace ROOT::VecOps;
 
@@ -52,6 +53,9 @@ void df102_NanoAODDimuonAnalysis()
    // Request cut-flow report
    auto report = df_mass.Report();
 
+   ROOT::RDF::ProgressHelper progress(10000, ROOT::RDF::CountEvents("Events", "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root"));
+   h.OnPartialResultSlot(10000, [&progress](unsigned int slot, TH1D& histo){ progress(slot, histo); });
+
    // Produce plot
    gStyle->SetOptStat(0); gStyle->SetTextFont(42);
    auto c = new TCanvas("c", "", 800, 700);
```

one gets:
`bin/root -q ~/code/root-src/tutorials/dataframe/df102_NanoAODDimuonAnalysis.C+O`
![image](https://user-images.githubusercontent.com/16205615/125669114-03ebfeb1-96e4-4dcc-afd9-b6690aafb4a1.png)

## TODO
- [ ] Write helpers that integrate this into the head node of RDF, preferably with a single line of code.
- [ ] *Optional*: Finalise callbacks for RDF, since a carriage return is always missing.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
