### PR TITLE
Eve-7: Add XZ,YZ, ZX, and ZY projection types. Zeroth version of Lego view type

### DIFF
--- a/graf3d/eve/inc/LinkDef1.h
+++ b/graf3d/eve/inc/LinkDef1.h
@@ -199,6 +199,9 @@
 #pragma link C++ class TEveRhoZProjection+;
 #pragma link C++ class TEveRPhiProjection+;
 #pragma link C++ class TEveXZProjection+;
+#pragma link C++ class TEveYZProjection+;
+#pragma link C++ class TEveZXProjection+;
+#pragma link C++ class TEveZYProjection+;
 #pragma link C++ class TEve3DProjection+;
 
 #pragma link C++ class TEveProjectionManager+;

--- a/graf3d/eve/inc/TEveProjections.h
+++ b/graf3d/eve/inc/TEveProjections.h
@@ -26,7 +26,8 @@ class TEveTrans;
 class TEveProjection
 {
 public:
-   enum EPType_e   { kPT_Unknown, kPT_RPhi, kPT_XZ, kPT_RhoZ, kPT_3D, kPT_End }; // projection type
+   enum EPType_e   { kPT_Unknown, kPT_RhoZ, kPT_RPhi, 
+                     kPT_XZ, kPT_YZ, kPT_ZX, kPT_ZY, kPT_3D, kPT_End };  // projection type
    enum EPProc_e   { kPP_Plane, kPP_Distort, kPP_Full };                 // projection procedure
    enum EGeoMode_e { kGM_Unknown, kGM_Polygons, kGM_Segments };          // strategy for geometry projections
 
@@ -227,6 +228,88 @@ public:
 
    ClassDef(TEveXZProjection, 0); // XZ non-linear projection.
 };
+
+
+//==============================================================================
+// TEveYZProjection
+//==============================================================================
+
+class TEveYZProjection : public TEveProjection
+{
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   TEveYZProjection();
+   virtual ~TEveYZProjection() {}
+
+   virtual Bool_t Is2D() const { return kTRUE;  }
+   virtual Bool_t Is3D() const { return kFALSE; }
+
+   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+
+   ClassDef(TEveYZProjection, 0); // XY non-linear projection.
+};
+
+
+//==============================================================================
+// TEveZXProjection
+//==============================================================================
+
+class TEveZXProjection : public TEveProjection
+{
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   TEveZXProjection();
+   virtual ~TEveZXProjection() {}
+
+   virtual Bool_t Is2D() const { return kTRUE;  }
+   virtual Bool_t Is3D() const { return kFALSE; }
+
+   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+
+   ClassDef(TEveZXProjection, 0); // XZ non-linear projection.
+};
+
+
+//==============================================================================
+// TEveZYProjection
+//==============================================================================
+
+class TEveZYProjection : public TEveProjection
+{
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   TEveZYProjection();
+   virtual ~TEveZYProjection() {}
+
+   virtual Bool_t Is2D() const { return kTRUE;  }
+   virtual Bool_t Is3D() const { return kFALSE; }
+
+   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+
+   ClassDef(TEveZYProjection, 0); // XY non-linear projection.
+};
+
 
 //==============================================================================
 // TEve3DProjection

--- a/graf3d/eve/src/TEveProjectionManager.cxx
+++ b/graf3d/eve/src/TEveProjectionManager.cxx
@@ -104,6 +104,11 @@ void TEveProjectionManager::SetProjection(TEveProjection::EPType_e type)
    {
       switch (type)
       {
+         case TEveProjection::kPT_RhoZ:
+         {
+            fProjections[type] = new TEveRhoZProjection();
+            break;
+         }
          case TEveProjection::kPT_RPhi:
          {
             fProjections[type] = new TEveRPhiProjection();
@@ -114,9 +119,19 @@ void TEveProjectionManager::SetProjection(TEveProjection::EPType_e type)
             fProjections[type] = new TEveXZProjection();
             break;
          }
-         case TEveProjection::kPT_RhoZ:
+         case TEveProjection::kPT_YZ:
          {
-            fProjections[type] = new TEveRhoZProjection();
+            fProjections[type] = new TEveYZProjection();
+            break;
+         }
+         case TEveProjection::kPT_ZX:
+         {
+            fProjections[type] = new TEveZXProjection();
+            break;
+         }
+         case TEveProjection::kPT_ZY:
+         {
+            fProjections[type] = new TEveZYProjection();
             break;
          }
          case TEveProjection::kPT_3D:

--- a/graf3d/eve/src/TEveProjectionManagerEditor.cxx
+++ b/graf3d/eve/src/TEveProjectionManagerEditor.cxx
@@ -49,9 +49,12 @@ TEveProjectionManagerEditor::TEveProjectionManagerEditor(const TGWindow *p,
       TGLabel* lab = new TGLabel(f, "Type");
       f->AddFrame(lab, new TGLayoutHints(kLHintsLeft|kLHintsBottom, 1, 31, 1, 2));
       fType = new TGComboBox(f);
+      fType->AddEntry("RhoZ", TEveProjection::kPT_RhoZ);
       fType->AddEntry("RPhi", TEveProjection::kPT_RPhi);
       fType->AddEntry("XZ",   TEveProjection::kPT_XZ);
-      fType->AddEntry("RhoZ", TEveProjection::kPT_RhoZ);
+      fType->AddEntry("YZ",   TEveProjection::kPT_YZ);
+      fType->AddEntry("ZX",   TEveProjection::kPT_ZX);
+      fType->AddEntry("ZY",   TEveProjection::kPT_ZY);
       fType->AddEntry("3D",   TEveProjection::kPT_3D);
       TGListBox* lb = fType->GetListBox();
       lb->Resize(lb->GetWidth(), 2*18);

--- a/graf3d/eve/src/TEveProjections.cxx
+++ b/graf3d/eve/src/TEveProjections.cxx
@@ -790,7 +790,7 @@ void TEveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
                                     Float_t d, EPProc_e proc)
 {
    using namespace TMath;
-   
+
    if (fDisplaceOrigin)
    {
       x  -= fCenter.fX;
@@ -873,6 +873,341 @@ void TEveXZProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
       vec.Set(1.0f, 0.0f, 0.0f);
    else if (screenAxis == 1)
       vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+
+/** \class TEveYZProjection
+\ingroup TEve
+YZ projection with distortion around given center.
+*/
+
+ClassImp(TEveYZProjection);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+TEveYZProjection::TEveYZProjection() :
+   TEveProjection()
+{
+   fType    = kPT_YZ;
+   fGeoMode = kGM_Polygons;
+   fName    = "YZ";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void TEveYZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = y;
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveYZProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fY;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveYZProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 1.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+
+/** \class TEveZXProjection
+\ingroup TEve
+ZX projection with distortion around given center.
+*/
+
+ClassImp(TEveZXProjection);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+TEveZXProjection::TEveZXProjection() :
+   TEveProjection()
+{
+   fType    = kPT_ZX;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZX";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void TEveZXProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = x;
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveZXProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fX;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveZXProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(1.0f, 0.0f, 0.0f);
+}
+
+
+/** \class TEveZYProjection
+\ingroup TEve
+ZY projection with distortion around given center.
+*/
+
+ClassImp(TEveZYProjection);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+TEveZYProjection::TEveZYProjection() :
+   TEveProjection()
+{
+   fType    = kPT_ZY;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZY";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void TEveZYProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveZYProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fY;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveZYProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 1.0f, 0.0f);
 }
 
 

--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -158,6 +158,10 @@
 #pragma link C++ typedef ROOT::Experimental::REveProjection::vPreScale_t;
 #pragma link C++ class ROOT::Experimental::REveRhoZProjection+;
 #pragma link C++ class ROOT::Experimental::REveRPhiProjection+;
+#pragma link C++ class ROOT::Experimental::REveXZProjection+;
+#pragma link C++ class ROOT::Experimental::REveYZProjection+;
+#pragma link C++ class ROOT::Experimental::REveZXProjection+;
+#pragma link C++ class ROOT::Experimental::REveZYProjection+;
 #pragma link C++ class ROOT::Experimental::REve3DProjection+;
 
 #pragma link C++ class ROOT::Experimental::REveProjectionManager+;

--- a/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
@@ -73,7 +73,7 @@ private:
    ItemsChangeFunc_t fHandlerItemsChange;
    FillImpliedSelectedFunc_t fHandlerFillImplied;
 
-   std::vector<TTip> fTooltipExpressions;
+   std::vector< std::unique_ptr<TTip> > fTooltipExpressions;
 
 public:
    REveDataItemList(const std::string& n = "Items", const std::string& t = "");
@@ -92,7 +92,7 @@ public:
 
    void ProcessSelection(ElementId_t id, bool multi, bool secondary, const std::set<int>& in_secondary_idcs);
 
-   void AddTooltipExpression(const std::string &title, const std::string &expr);
+   void AddTooltipExpression(const std::string &title, const std::string &expr, bool init = true);
 
    using REveElement::GetHighlightTooltip;
    std::string GetHighlightTooltip(const std::set<int>& secondary_idcs) const override;
@@ -102,6 +102,8 @@ public:
 
    static void DummyItemsChange(REveDataItemList*, const std::vector<int>&);
    static void DummyFillImpliedSelected(REveDataItemList*, Set_t& impSelSet);
+
+   std::vector< std::unique_ptr<TTip> >& RefToolTipExpressions() {return fTooltipExpressions;}
 };
 
 //==============================================================================

--- a/graf3d/eve7/inc/ROOT/REveDataProxyBuilderBase.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataProxyBuilderBase.hxx
@@ -60,6 +60,8 @@ public:
    void ModelChanges(const REveDataCollection::Ids_t&);
    void CollectionChanged(const REveDataCollection*);
 
+   virtual void ScaleChanged();
+
    void SetupElement(REveElement* el, bool color = true);
    void SetupAddElement(REveElement* el, REveElement* parent,  bool set_color = true);
 
@@ -80,6 +82,8 @@ protected:
    virtual void ModelChanges(const REveDataCollection::Ids_t&, Product*) = 0;
    virtual void FillImpliedSelected( REveElement::Set_t& /*impSet*/, Product*) {};
    virtual void LocalModelChanges(int idx, REveElement* el, const REveViewContext* ctx);
+
+   virtual void ScaleProduct(REveElement*, const std::string&) {};
 
    virtual void Clean();
    virtual void CleanLocal();

--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
@@ -43,7 +43,7 @@ public:
 
    struct SPBProduct {
       std::map<int, REveCollectionCompound*> map;
-      std::list<REveCollectionCompound*> cache;
+      int lastChildIdx{0};
    }; 
    
    typedef  std::map<REveElement*, std::unique_ptr<SPBProduct*> > EProductMap_t;
@@ -64,16 +64,15 @@ protected:
    REveCollectionCompound* CreateCompound(bool set_color=true, bool propagate_color_to_all_children=false);
 
    //int GetItemIdxForCompound() const;
+   bool VisibilityModelChanges(int idx, REveElement*, const std::string& viewType, const REveViewContext*) override;
+
+   std::map<REveElement*, SPBProduct*> fProductMap;
+   REveCompound* GetHolder(REveElement *product, int idx);
+
 private:
    REveDataSimpleProxyBuilder(const REveDataSimpleProxyBuilder&); // stop default
 
    const REveDataSimpleProxyBuilder& operator=(const REveDataSimpleProxyBuilder&); // stop default
-
-   bool VisibilityModelChanges(int idx, REveElement*, const std::string& viewType, const REveViewContext*) override;
-
- std::map<REveElement*, SPBProduct*> fProductMap;
-   REveCompound* GetHolder(REveElement *product, int idx);
-
 };
 //==============================================================================
 

--- a/graf3d/eve7/inc/ROOT/REveProjections.hxx
+++ b/graf3d/eve7/inc/ROOT/REveProjections.hxx
@@ -29,7 +29,8 @@ class REveTrans;
 
 class REveProjection {
 public:
-   enum EPType_e { kPT_Unknown, kPT_RPhi, kPT_RhoZ, kPT_3D, kPT_End }; // projection type
+   enum EPType_e { kPT_Unknown, kPT_RhoZ, kPT_RPhi,
+                   kPT_XZ, kPT_YZ, kPT_ZX, kPT_ZY, kPT_3D, kPT_End };  // projection type
    enum EPProc_e { kPP_Plane, kPP_Distort, kPP_Full };                 // projection procedure
    enum EGeoMode_e { kGM_Unknown, kGM_Polygons, kGM_Segments };        // strategy for geometry projections
 
@@ -189,6 +190,102 @@ public:
    Bool_t Is3D() const override { return kFALSE; }
 
    void ProjectPoint(Float_t &x, Float_t &y, Float_t &z, Float_t d, EPProc_e proc = kPP_Full) override;
+};
+
+//==============================================================================
+// REveXZProjection
+// XZ non-linear projection.
+//==============================================================================
+
+class REveXZProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveXZProjection();
+   virtual ~REveXZProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
+};
+
+//==============================================================================
+// REveYZProjection
+// YZ non-linear projection.
+//==============================================================================
+
+class REveYZProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveYZProjection();
+   virtual ~REveYZProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
+};
+
+//==============================================================================
+// REveZXProjection
+// ZX non-linear projection.
+//==============================================================================
+
+class REveZXProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveZXProjection();
+   virtual ~REveZXProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
+};
+
+//==============================================================================
+// REveZYProjection
+// ZY non-linear projection.
+//==============================================================================
+
+class REveZYProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveZYProjection();
+   virtual ~REveZYProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
 };
 
 //==============================================================================

--- a/graf3d/eve7/inc/ROOT/REveViewer.hxx
+++ b/graf3d/eve7/inc/ROOT/REveViewer.hxx
@@ -26,9 +26,14 @@ class REveScene;
 
 class REveViewer : public REveElement
 {
+public:
+   enum ECameraType { kCameraPerspXOZ, kCameraOrthoXOY };
+
 private:
    REveViewer(const REveViewer&) = delete;
    REveViewer& operator=(const REveViewer&) = delete;
+
+   ECameraType fCameraType{kCameraPerspXOZ};
 
 public:
    REveViewer(const std::string &n="REveViewer", const std::string &t="");
@@ -39,8 +44,12 @@ public:
    virtual void AddScene(REveScene* scene);
    // XXX Missing RemoveScene() ????
 
+   void SetCameraType(ECameraType t) { fCameraType = t; }
+   ECameraType GetCameraType() const { return fCameraType; }
+
    void RemoveElementLocal(REveElement *el) override;
    void RemoveElementsLocal() override;
+   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
 };
 
 

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -174,10 +174,10 @@ std::string REveDataItemList::GetHighlightTooltip(const std::set<int>& secondary
    {
       idx = z;
       data = col->GetDataPtr(idx);
-      res +=  TString::Format("%s %d",  name.c_str(), idx);
+      res +=  std::string(TString::Format("%s %d",  name.c_str(), idx));
       for (auto &t : fTooltipExpressions) {
          std::string eval = t->fTooltipFunction.EvalExpr(data);
-         res +=  TString::Format("\n  %s = %s", t->fTooltipTitle.c_str(), eval.c_str());
+         res +=  std::string(TString::Format("\n  %s = %s", t->fTooltipTitle.c_str(), eval.c_str()));
       }
       res += "\n";
    }
@@ -346,7 +346,7 @@ void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
                ms += " ";
                ms += ma->GetName();
             }
-            char* entry = TString::Format("i.%s(%s)",meth->GetName(),ms.Data());
+            std::string entry(TString::Format("i.%s(%s)",meth->GetName(),ms.Data()).Data());
             nlohmann::json jm ;
             jm["f"] = entry;
             jm["r"] = meth->GetReturnTypeName();

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -174,10 +174,10 @@ std::string REveDataItemList::GetHighlightTooltip(const std::set<int>& secondary
    {
       idx = z;
       data = col->GetDataPtr(idx);
-      res +=  Form("%s %d",  name.c_str(), idx);
+      res +=  TString::Format("%s %d",  name.c_str(), idx);
       for (auto &t : fTooltipExpressions) {
          std::string eval = t->fTooltipFunction.EvalExpr(data);
-         res +=  Form("\n  %s = %s", t->fTooltipTitle.c_str(), eval.c_str());
+         res +=  TString::Format("\n  %s = %s", t->fTooltipTitle.c_str(), eval.c_str());
       }
       res += "\n";
    }
@@ -346,7 +346,7 @@ void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
                ms += " ";
                ms += ma->GetName();
             }
-            char* entry = Form("i.%s(%s)",meth->GetName(),ms.Data());
+            char* entry = TString::Format("i.%s(%s)",meth->GetName(),ms.Data());
             nlohmann::json jm ;
             jm["f"] = entry;
             jm["r"] = meth->GetReturnTypeName();

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -176,8 +176,8 @@ std::string REveDataItemList::GetHighlightTooltip(const std::set<int>& secondary
       data = col->GetDataPtr(idx);
       res +=  Form("%s %d",  name.c_str(), idx);
       for (auto &t : fTooltipExpressions) {
-         std::string eval = t.fTooltipFunction.EvalExpr(data);
-         res +=  Form("\n  %s = %s", t.fTooltipTitle.c_str(), eval.c_str());
+         std::string eval = t->fTooltipFunction.EvalExpr(data);
+         res +=  Form("\n  %s = %s", t->fTooltipTitle.c_str(), eval.c_str());
       }
       res += "\n";
    }
@@ -185,15 +185,21 @@ std::string REveDataItemList::GetHighlightTooltip(const std::set<int>& secondary
 }
 
 //______________________________________________________________________________
-void REveDataItemList::AddTooltipExpression(const std::string &title, const std::string &expr)
+void REveDataItemList::AddTooltipExpression(const std::string &title, const std::string &expr, bool init)
 {
-   TTip tt;
-   tt.fTooltipTitle = title;
-   tt.fTooltipFunction.SetPrecision(2);
-   auto col = dynamic_cast<REveDataCollection*>(fMother);
+   fTooltipExpressions.push_back(std::unique_ptr<TTip>(new TTip()));
+   TTip *tt = fTooltipExpressions.back().get();
+
+   tt->fTooltipTitle = title;
+   tt->fTooltipFunction.SetPrecision(2);
+   auto col = dynamic_cast<REveDataCollection *>(fMother);
    auto icls = col->GetItemClass();
-   tt.fTooltipFunction.SetExpressionAndType(expr, REveDataColumn::FT_Double, icls);
-   fTooltipExpressions.push_back(tt);
+   tt->fTooltipFunction.SetExpressionAndType(expr, REveDataColumn::FT_Double, icls);
+
+   if (init) {
+      auto re = tt->fTooltipFunction.GetFunctionExpressionString();
+      gROOT->ProcessLine(re.c_str());
+   }
 }
 
 //______________________________________________________________________________

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -113,29 +113,21 @@ void REveDataProxyBuilderBase::Build()
                   auto parentIt = projectedAsElement->RefChildren().begin();
                   for (auto &prod: elms->RefChildren())
                   {
-                      // reused projected holder
-                     if (cnt < oldSize)
-                     {
-                        /*
-                        // AMT no use case for this at the moment
+                     // reused projected holder
+                     if (cnt < oldSize) {
                         if ((*parentIt)->NumChildren()) {
-                            // update projected (mislleading name)
-                           for ( REveElement::List_i pci = (*parentIt)->BeginChildren(); pci != (*parentIt)->EndChildren(); pci++)
-                               pmgr->ProjectChildrenRecurse(*pci);
+                           // update projected (mislleading name)
+                            for (auto &projHolder: (*parentIt)->RefChildren())
+                              pmgr->ProjectChildrenRecurse(projHolder);
+                        } else {
+                           // import projectable
+                           pmgr->SubImportChildren(prod, *parentIt);
                         }
-                        */
-                        // import projectable
-                        pmgr->SubImportChildren(prod, *parentIt);
-
                         ++parentIt;
-                     }
-                     else if (cnt < itemSize)
-                     {
+                     } else if (cnt < itemSize) {
                         // new product holder
                         pmgr->SubImportElements(prod, projectedAsElement);
-                     }
-                     else
-                     {
+                     } else {
                         break;
                      }
                      ++cnt;

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -181,7 +181,7 @@ REveDataProxyBuilderBase::CreateProduct( const std::string& viewType, const REve
    if (m_collection)
    {
       // debug info in eve browser
-      product->m_elements->SetName(Form("product %s viewtype %s", m_collection->GetCName(), viewType.c_str()));
+      product->m_elements->SetName(TString::Format("product %s viewtype %s", m_collection->GetCName(), viewType.c_str()));
    }
    return product->m_elements;
 }

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -181,7 +181,7 @@ REveDataProxyBuilderBase::CreateProduct( const std::string& viewType, const REve
    if (m_collection)
    {
       // debug info in eve browser
-      product->m_elements->SetName(TString::Format("product %s viewtype %s", m_collection->GetCName(), viewType.c_str()));
+      product->m_elements->SetName(TString::Format("product %s viewtype %s", m_collection->GetCName(), viewType.c_str()).Data());
    }
    return product->m_elements;
 }

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -265,8 +265,7 @@ REveDataProxyBuilderBase::SetupElement(REveElement* el, bool color)
 void REveDataProxyBuilderBase::ScaleChanged()
 {
    for (auto &prod : m_products) {
-      if (!HaveSingleProduct())
-         ScaleProduct(prod->m_elements, prod->m_viewType);
+      ScaleProduct(prod->m_elements, prod->m_viewType);
    }
 }
 //------------------------------------------------------------------------------

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -284,7 +284,15 @@ REveDataProxyBuilderBase::SetupElement(REveElement* el, bool color)
    }
 }
 
+//------------------------------------------------------------------------------
 
+void REveDataProxyBuilderBase::ScaleChanged()
+{
+   for (auto &prod : m_products) {
+      if (!HaveSingleProduct())
+         ScaleProduct(prod->m_elements, prod->m_viewType);
+   }
+}
 //------------------------------------------------------------------------------
 
 void REveDataProxyBuilderBase::Clean()

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -15,6 +15,7 @@
 #include <ROOT/REveViewContext.hxx>
 #include <ROOT/REveCompound.hxx>
 #include <ROOT/RLogger.hxx>
+#include <ROOT/REveScene.hxx>
 
 #include <cassert>
 
@@ -70,7 +71,7 @@ void REveDataProxyBuilderBase::Build()
 {
    if (m_collection)
    {
-      // printf("Base %p %s %s\n", m_collection, m_collection->GetCName(), m_type.c_str());
+      // printf("REveDataProxyBuilderBase::Build %p %s products %lu\n", m_collection, m_collection->GetCName(), m_products.size());
       try
       {
          auto itemSize = m_collection->GetNItems(); //cashed
@@ -82,52 +83,47 @@ void REveDataProxyBuilderBase::Build()
 
          for (auto &pp: m_products)
          {
-            // printf("build() %s \n", m_collection->GetCName());
-            REveElement* elms = pp->m_elements;
-            auto oldSize = elms->NumChildren();
-
+            REveElement* product = pp->m_elements;
+            auto oldSize = product->NumChildren();
             if (HaveSingleProduct())
             {
-               Build(m_collection, elms, pp->m_viewContext);
+               Build(m_collection, product, pp->m_viewContext);
             }
             else
             {
-               BuildViewType(m_collection, elms, pp->m_viewType, pp->m_viewContext);
+               BuildViewType(m_collection, product, pp->m_viewType, pp->m_viewContext);
             }
 
             // Project all children of current product.
             // If product is not registered into any projection-manager,
             // this does nothing.
-            REveProjectable* pable = dynamic_cast<REveProjectable*>(elms);
-            if (pable->HasProjecteds())
+            REveProjectable* pableProduct = dynamic_cast<REveProjectable*>(product);
+            if (pableProduct->HasProjecteds())
             {
                // loop projected holders
-               for (auto &prj: pable->RefProjecteds())
+               for (auto &projectedProduct: pableProduct->RefProjecteds())
                {
-                  REveProjectionManager *pmgr = prj->GetManager();
+                  REveProjectionManager *pmgr = projectedProduct->GetManager();
                   Float_t oldDepth = pmgr->GetCurrentDepth();
                   pmgr->SetCurrentDepth(m_layer);
                   Int_t cnt = 0;
-
-                  REveElement *projectedAsElement = prj->GetProjectedAsElement();
-                  auto parentIt = projectedAsElement->RefChildren().begin();
-                  for (auto &prod: elms->RefChildren())
+                  REveElement *projectedProductAsElement = projectedProduct->GetProjectedAsElement();
+                  // printf("projectedProduct children %d, product children %d\n", projectedProductAsElement->NumChildren(), product->NumChildren());
+                  auto parentIt = projectedProductAsElement->RefChildren().begin();
+                  for (auto &holder: product->RefChildren())
                   {
                      // reused projected holder
-                     if (cnt < oldSize) {
-                        if ((*parentIt)->NumChildren()) {
-                           // update projected (mislleading name)
-                            for (auto &projHolder: (*parentIt)->RefChildren())
-                              pmgr->ProjectChildrenRecurse(projHolder);
-                        } else {
-                           // import projectable
-                           pmgr->SubImportChildren(prod, *parentIt);
-                        }
+                     if (cnt < oldSize) 
+                     {
+                        pmgr->SubImportChildren(holder, *parentIt);
                         ++parentIt;
-                     } else if (cnt < itemSize) {
+                     }
+                     else if (cnt < itemSize)
+                     {
                         // new product holder
-                        pmgr->SubImportElements(prod, projectedAsElement);
-                     } else {
+                        pmgr->SubImportElements(holder, projectedProductAsElement);
+                     }
+                     else {
                         break;
                      }
                      ++cnt;
@@ -135,18 +131,6 @@ void REveDataProxyBuilderBase::Build()
                   pmgr->SetCurrentDepth(oldDepth);
                }
             }
-
-            /*
-            if (m_interactionList && itemSize > oldSize)
-            {
-               auto elIt = elms->RefChildren().begin();
-               for (size_t cnt = 0; cnt < itemSize; ++cnt, ++elIt)
-               {
-                  if (cnt >= oldSize )
-                       m_interactionList->Added(*elIt, cnt);
-               }
-            }
-            */
          }
       }
       catch (const std::runtime_error &iException) {
@@ -197,7 +181,7 @@ REveDataProxyBuilderBase::CreateProduct( const std::string& viewType, const REve
    if (m_collection)
    {
       // debug info in eve browser
-      product->m_elements->SetName(Form("product %s", m_collection->GetCName()));
+      product->m_elements->SetName(Form("product %s viewtype %s", m_collection->GetCName(), viewType.c_str()));
    }
    return product->m_elements;
 }

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -110,7 +110,7 @@ REveCompound *REveDataSimpleProxyBuilder::GetHolder(REveElement *product, int id
       spb->lastChildIdx = idx;
       spb->map.emplace(idx, itemHolder);
       itemHolder->SetMainColor(Collection()->GetDataItem(idx)->GetMainColor());
-      std::string name = TString::Format("%s %d", Collection()->GetCName(), idx);
+      std::string name(TString::Format("%s %d", Collection()->GetCName(), idx));
       itemHolder->SetName(name);
    }
 

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -40,8 +40,9 @@ void REveDataSimpleProxyBuilder::Clean()
          for (auto &compound : product->RefChildren()) {
             REveCollectionCompound *collComp = dynamic_cast<REveCollectionCompound *>(compound);
             collComp->DestroyElements();
-            (spbIt)->second->cache.push_back(collComp);
          }
+         (spbIt)->second->lastChildIdx=0;
+         (spbIt)->second->map.clear();
       }
    }
 
@@ -91,23 +92,22 @@ REveCompound *REveDataSimpleProxyBuilder::GetHolder(REveElement *product, int id
 
    REveCollectionCompound *itemHolder = nullptr;
 
-   auto hit = spb->map.find(idx);
-   if (hit != spb->map.end()) {
-      itemHolder = hit->second;
+   auto pmIt = spb->map.find(idx);
+   if (pmIt != spb->map.end()) {
+      itemHolder = pmIt->second;
       // printf("GetHolder already in map %d \n", idx);
    } else {
-
-      if (!spb->cache.empty()) {
-         itemHolder = spb->cache.front();
-         spb->cache.pop_front();
+      if (product->NumChildren() > idx) {
+         auto cIt = std::next(product->RefChildren().begin(), idx);
+         itemHolder = dynamic_cast<REveCollectionCompound *>(*cIt);
+         // printf("GetHolder isreused %d \n", idx);
       }
-
       if (!itemHolder) {
          itemHolder = CreateCompound(true, true);
          product->AddElement(itemHolder);
          // printf("Creating new holder\n");
       }
-
+      spb->lastChildIdx = idx;
       spb->map.emplace(idx, itemHolder);
       itemHolder->SetMainColor(Collection()->GetDataItem(idx)->GetMainColor());
       std::string name = Form("%s %d", Collection()->GetCName(), idx);
@@ -148,6 +148,7 @@ REveDataSimpleProxyBuilder::BuildViewType(const REveDataCollection* collection,
          BuildViewType(collection->GetDataPtr(index), index, itemHolder, viewType, vc);
       }
    }
+   //      printf("END Build view type [%s] product size %d\n",viewType.c_str(), product->NumChildren());
 }
 
 //______________________________________________________________________________

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -110,7 +110,7 @@ REveCompound *REveDataSimpleProxyBuilder::GetHolder(REveElement *product, int id
       spb->lastChildIdx = idx;
       spb->map.emplace(idx, itemHolder);
       itemHolder->SetMainColor(Collection()->GetDataItem(idx)->GetMainColor());
-      std::string name = Form("%s %d", Collection()->GetCName(), idx);
+      std::string name = TString::Format("%s %d", Collection()->GetCName(), idx);
       itemHolder->SetName(name);
    }
 

--- a/graf3d/eve7/src/REveProjectionManager.cxx
+++ b/graf3d/eve7/src/REveProjectionManager.cxx
@@ -98,14 +98,34 @@ void REveProjectionManager::SetProjection(REveProjection::EPType_e type)
    {
       switch (type)
       {
+         case REveProjection::kPT_RhoZ:
+         {
+            fProjections[type] = new REveRhoZProjection();
+            break;
+         }
          case REveProjection::kPT_RPhi:
          {
             fProjections[type] = new REveRPhiProjection();
             break;
          }
-         case REveProjection::kPT_RhoZ:
+         case REveProjection::kPT_XZ:
          {
-            fProjections[type] = new REveRhoZProjection();
+            fProjections[type] = new REveXZProjection();
+            break;
+         }
+         case REveProjection::kPT_YZ:
+         {
+            fProjections[type] = new REveYZProjection();
+            break;
+         }
+         case REveProjection::kPT_ZX:
+         {
+            fProjections[type] = new REveZXProjection();
+            break;
+         }
+         case REveProjection::kPT_ZY:
+         {
+            fProjections[type] = new REveZYProjection();
             break;
          }
          case REveProjection::kPT_3D:

--- a/graf3d/eve7/src/REveProjections.cxx
+++ b/graf3d/eve7/src/REveProjections.cxx
@@ -751,6 +751,442 @@ void REveRPhiProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
    z = d;
 }
 
+/** \class REveXZProjection
+\ingroup REve
+XZ projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveXZProjection::REveXZProjection() :
+   REveProjection()
+{
+   fType    = kPT_XZ;
+   fGeoMode = kGM_Polygons;
+   fName    = "XZ";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveXZProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fX;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveXZProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(1.0f, 0.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+
+/** \class REveYZProjection
+\ingroup REve
+YZ projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveYZProjection::REveYZProjection() :
+   REveProjection()
+{
+   fType    = kPT_YZ;
+   fGeoMode = kGM_Polygons;
+   fName    = "YZ";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveYZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = y;
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveYZProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fY;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveYZProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 1.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+/** \class REveZXProjection
+\ingroup REve
+ZX projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveZXProjection::REveZXProjection() :
+   REveProjection()
+{
+   fType    = kPT_ZX;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZX";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveZXProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = x;
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveZXProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fX;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveZXProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(1.0f, 0.0f, 0.0f);
+}
+
+
+/** \class REveZYProjection
+\ingroup REve
+ZY projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveZYProjection::REveZYProjection() :
+   REveProjection()
+{
+   fType    = kPT_ZY;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZY";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveZYProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveZYProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fY;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveZYProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 1.0f, 0.0f);
+}
+
 /** \class REve3DProjection
 \ingroup REve
 3D scaling projection. One has to use pre-scaling to make any ise of this.

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -46,7 +46,7 @@ REveException REX::operator+(const REveException &s1, ElementId_t x)
 
 REX::RLogChannel &REX::REveLog()
 {
-   thread_local RLogChannel sLog("ROOT.Eve");
+   static RLogChannel sLog("ROOT.Eve");
    return sLog;
 }
 

--- a/graf3d/eve7/src/REveTypes.cxx
+++ b/graf3d/eve7/src/REveTypes.cxx
@@ -16,6 +16,7 @@
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
 
+
 /** \class REveException
 \ingroup REve
 Exception class thrown by Eve classes and macros.
@@ -45,7 +46,7 @@ REveException REX::operator+(const REveException &s1, ElementId_t x)
 
 REX::RLogChannel &REX::REveLog()
 {
-   static RLogChannel sLog("ROOT.Eve");
+   thread_local RLogChannel sLog("ROOT.Eve");
    return sLog;
 }
 

--- a/graf3d/eve7/src/REveViewer.cxx
+++ b/graf3d/eve7/src/REveViewer.cxx
@@ -100,6 +100,21 @@ List of Viewers providing common operations on REveViewer collections.
 */
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Stream Camera Info.
+/// Virtual from REveElement.
+int REveViewer::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+{
+   std::string ct;
+   switch (fCameraType)
+   {
+      case kCameraPerspXOZ: ct = "PerspXOZ"; break;
+      case kCameraOrthoXOY: ct = "OrthoXOY"; break;
+   }
+   j["CameraType"] = ct;
+   return REveElement::WriteCoreJson(j, rnr_offset);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 REveViewerList::REveViewerList(const std::string &n, const std::string &t) :
    REveElement  (n, t),

--- a/tutorials/eve7/calorimeters.C
+++ b/tutorials/eve7/calorimeters.C
@@ -38,6 +38,7 @@ void makeCalo2D(REveCalo3D* calo3d, const char* pname, REveProjection::EPType_e 
    REveElement* geo2d =  mng->ImportElements(eveMng->GetGlobalScene()->FirstChild(), geomScene);
 
    auto view = eveMng->SpawnNewViewer("RPhi View", "");
+   view->SetCameraType(REveViewer::kCameraOrthoXOY);
    view->AddScene(geomScene);
    view->AddScene(eventScene);
 }

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -803,6 +803,7 @@ void collection_proxies(bool proj=true)
    g_projMng->SetImportEmpty(true);
 
    auto rhoZView = eveMng->SpawnNewViewer("RhoZ View");
+   rhoZView->SetCameraType(REveViewer::kCameraOrthoXOY);
    rhoZView->AddScene(rhoZEventScene);
    auto pgeoScene = eveMng->SpawnNewScene("Geometry projected");
    rhoZView->AddScene(pgeoScene);

--- a/tutorials/eve7/error_ellipse.C
+++ b/tutorials/eve7/error_ellipse.C
@@ -41,6 +41,7 @@ void makeProjected(REveElement* el, const char* pname, REveProjection::EPType_e 
    mng->SetProjection(t);
    mng->ImportElements(el, eventScene);
    auto view = eveMng->SpawnNewViewer(pname);
+   view->SetCameraType(REveViewer::kCameraOrthoXOY);
    view->AddScene(eventScene);
 }
 

--- a/tutorials/eve7/event_demo.C
+++ b/tutorials/eve7/event_demo.C
@@ -32,7 +32,6 @@
 #include <ROOT/REvePointSet.hxx>
 #include <ROOT/REveJetCone.hxx>
 #include <ROOT/REveTrans.hxx>
-
 #include <ROOT/REveTrack.hxx>
 #include <ROOT/REveTrackPropagator.hxx>
 
@@ -177,6 +176,7 @@ void createProjectionStuff()
    mngRhoPhi = new REX::REveProjectionManager(REX::REveProjection::kPT_RPhi);
 
    rphiView = eveMng->SpawnNewViewer("RPhi View", "");
+   rphiView->SetCameraType(REX::REveViewer::kCameraOrthoXOY);
    rphiView->AddScene(rPhiGeomScene);
    rphiView->AddScene(rPhiEventScene);
 
@@ -188,6 +188,7 @@ void createProjectionStuff()
    mngRhoZ = new REX::REveProjectionManager(REX::REveProjection::kPT_RhoZ);
 
    rhoZView = eveMng->SpawnNewViewer("RhoZ View", "");
+   rhoZView->SetCameraType(REX::REveViewer::kCameraOrthoXOY);
    rhoZView->AddScene(rhoZGeomScene);
    rhoZView->AddScene(rhoZEventScene);
 }

--- a/tutorials/eve7/lego.C
+++ b/tutorials/eve7/lego.C
@@ -38,9 +38,58 @@ void lego()
    auto scene = eveMng->SpawnNewScene("Lego", "LegoView");
    auto view = eveMng->SpawnNewViewer("Lego", "");
    view->AddScene(scene);
-   
+
    auto ps = createPointSet(100);
    scene->AddElement(ps);
+
+   {
+      // gROOT->SetBatch();
+
+      // TPad *p = new TPad("LegoPad", "Lego Pad Tit", 0, 0, 1, 1);
+      TPad *p = new TCanvas("LegoPad", "Lego Pad Tit", 800,400);
+
+      // *** Simple TH2
+      /*
+      TH2F* h = new TH2F("Booboo","exampul",128,-5,5,64,-2.5,2.5);
+      TRandom r;
+      for(int i=0;i<1000000;++i) {
+         h->Fill(r.Gaus() - 2, r.Gaus());
+         h->Fill(r.Gaus() + 2, r.Gaus());
+      }
+      for(int i=0;i<6000;++i) {
+         h->Fill(0.1*r.Gaus() - 2, 0.1*r.Gaus());
+         h->Fill(0.1*r.Gaus() + 2, 0.1*r.Gaus());
+      }
+      // h->Draw("LEGO2");
+      p->GetListOfPrimitives()->Add(h, "LEGO2");
+      p->Modified(kTRUE);
+      */
+
+      // *** Load std CMS calo demo
+      const char* histFile = "http://amraktad.web.cern.ch/amraktad/cms_calo_hist.root";
+      TFile::SetCacheFileDir(".");
+      auto hf = TFile::Open(histFile, "CACHEREAD");
+      auto ecalHist = (TH2F*)hf->Get("ecalLego");
+      auto hcalHist = (TH2F*)hf->Get("hcalLego");
+
+      THStack *s = new THStack("LegoStack", "ECal undt HCal");
+      ecalHist->SetFillColor(kRed);
+      ecalHist->GetXaxis()->SetLabelSize(1);
+      ecalHist->GetYaxis()->SetLabelSize(1);
+      ecalHist->GetZaxis()->SetLabelSize(1);
+      s->Add(ecalHist);
+      hcalHist->SetFillColor(kBlue);
+      s->Add(hcalHist);
+      p->GetListOfPrimitives()->Add(s);
+
+      p->Modified(kTRUE);
+
+      TString json( TBufferJSON::ToJSON(p) );
+
+      ps->SetTitle(TBase64::Encode(json).Data());
+
+      s->Draw();
+   }
 
    eveMng->Show();
 }

--- a/tutorials/eve7/lego.C
+++ b/tutorials/eve7/lego.C
@@ -1,0 +1,46 @@
+/// \file
+/// \ingroup tutorial_eve7
+///  This example display only points in web browser
+///
+/// \macro_code
+///
+
+#include "TRandom.h"
+#include <ROOT/REveElement.hxx>
+#include <ROOT/REveScene.hxx>
+#include <ROOT/REveManager.hxx>
+#include <ROOT/REvePointSet.hxx>
+
+namespace REX = ROOT::Experimental;
+
+REX::REvePointSet *createPointSet(int npoints = 2, float s = 2, int color = 28)
+{
+   TRandom &r = *gRandom;
+
+   REX::REvePointSet *ps = new REX::REvePointSet("MyTestPoints", "list of eve points", npoints);
+
+   for (Int_t i=0; i < npoints; ++i)
+      ps->SetNextPoint(r.Uniform(-s,s), r.Uniform(-s,s), r.Uniform(-s,s));
+
+   ps->SetMarkerColor(color);
+   ps->SetMarkerSize(3+r.Uniform(1, 2));
+   ps->SetMarkerStyle(4);
+   return ps;
+}
+
+void lego()
+{
+   auto eveMng = REX::REveManager::Create();
+
+   // disable default view
+   eveMng->GetViewers()->FirstChild()->SetRnrSelf(false);
+
+   auto scene = eveMng->SpawnNewScene("Lego", "LegoView");
+   auto view = eveMng->SpawnNewViewer("Lego", "");
+   view->AddScene(scene);
+   
+   auto ps = createPointSet(100);
+   scene->AddElement(ps);
+
+   eveMng->Show();
+}

--- a/tutorials/eve7/lego.C
+++ b/tutorials/eve7/lego.C
@@ -76,9 +76,11 @@ void lego()
       THStack *s = new THStack("LegoStack", ""); // "ECal undt HCal");
       ecalHist->SetFillColor(kRed);
       ecalHist->GetXaxis()->SetLabelSize(1);
-      ecalHist->GetXaxis()->SetTitle(reinterpret_cast<const char *>(u8"\u03B7")); // "#eta");
+      // ecalHist->GetXaxis()->SetTitle(reinterpret_cast<const char *>(u8"\u03B7"));
+      ecalHist->GetXaxis()->SetTitle("#eta");
       ecalHist->GetYaxis()->SetLabelSize(1);
-      ecalHist->GetYaxis()->SetTitle(reinterpret_cast<const char *>(u8"\u03C6")); // "#varphi");
+      // ecalHist->GetYaxis()->SetTitle(reinterpret_cast<const char *>(u8"\u03C6"));
+      ecalHist->GetYaxis()->SetTitle("#varphi");
       ecalHist->GetZaxis()->SetLabelSize(1);
       s->Add(ecalHist);
       hcalHist->SetFillColor(kBlue);

--- a/tutorials/eve7/lego.C
+++ b/tutorials/eve7/lego.C
@@ -47,6 +47,7 @@ void lego()
 
       // TPad *p = new TPad("LegoPad", "Lego Pad Tit", 0, 0, 1, 1);
       TPad *p = new TCanvas("LegoPad", "Lego Pad Tit", 800,400);
+      p->SetMargin(0, 0, 0, 0);
 
       // *** Simple TH2
       /*
@@ -75,14 +76,21 @@ void lego()
       THStack *s = new THStack("LegoStack", ""); // "ECal undt HCal");
       ecalHist->SetFillColor(kRed);
       ecalHist->GetXaxis()->SetLabelSize(1);
-      ecalHist->GetXaxis()->SetTitle("#eta");
+      ecalHist->GetXaxis()->SetTitle(reinterpret_cast<const char *>(u8"\u03B7")); // "#eta");
       ecalHist->GetYaxis()->SetLabelSize(1);
-      ecalHist->GetYaxis()->SetTitle("#varphi");
+      ecalHist->GetYaxis()->SetTitle(reinterpret_cast<const char *>(u8"\u03C6")); // "#varphi");
       ecalHist->GetZaxis()->SetLabelSize(1);
       s->Add(ecalHist);
       hcalHist->SetFillColor(kBlue);
       s->Add(hcalHist);
       p->GetListOfPrimitives()->Add(s);
+
+      TGraph2D *line = new TGraph2D(200);
+      for (int i = 0; i < 200; ++i)
+         line->SetPoint(i, std::cos(i*0.1), std::sin(i*0.1), i*0.25);
+      line->SetLineWidth(5);
+      line->SetLineColor(kCyan - 2);
+      p->GetListOfPrimitives()->Add(line, "LINE");
 
       p->Modified(kTRUE);
 

--- a/tutorials/eve7/lego.C
+++ b/tutorials/eve7/lego.C
@@ -72,10 +72,12 @@ void lego()
       auto ecalHist = (TH2F*)hf->Get("ecalLego");
       auto hcalHist = (TH2F*)hf->Get("hcalLego");
 
-      THStack *s = new THStack("LegoStack", "ECal undt HCal");
+      THStack *s = new THStack("LegoStack", ""); // "ECal undt HCal");
       ecalHist->SetFillColor(kRed);
       ecalHist->GetXaxis()->SetLabelSize(1);
+      ecalHist->GetXaxis()->SetTitle("#eta");
       ecalHist->GetYaxis()->SetLabelSize(1);
+      ecalHist->GetYaxis()->SetTitle("#varphi");
       ecalHist->GetZaxis()->SetLabelSize(1);
       s->Add(ecalHist);
       hcalHist->SetFillColor(kBlue);

--- a/tutorials/eve7/projection_prescale.C
+++ b/tutorials/eve7/projection_prescale.C
@@ -63,6 +63,7 @@ void makeProjectedViewsAndScene(REX::REveProjection::EPType_e type, bool scale)
    auto rphiView = eveMng->SpawnNewViewer("Projected View", "");
    rphiView->AddScene(rPhiGeomScene);
    rphiView->AddScene(rPhiEventScene);
+   rphiView->SetCameraType(REveViewer::kCameraOrthoXOY);
 
    for (auto &ie : eveMng->GetGlobalScene()->RefChildren())
       mngRhoPhi->ImportElements(ie, rPhiGeomScene);

--- a/ui5/eve7/controller/EveTable.controller.js
+++ b/ui5/eve7/controller/EveTable.controller.js
@@ -25,7 +25,7 @@ sap.ui.define([
       onInit: function () {
          var viewData = this.getView().getViewData();
          if (viewData) {
-            this.setupManagerAndViewType(viewData.eveViewerId, viewData.kind, viewData.mgr);
+            this.setupManagerAndViewType(viewData.eveViewerId, viewData.mgr);
          }
          else {
              UIComponent.getRouterFor(this).getRoute("Table").attachPatternMatched(this.onTableObjectMatched, this);
@@ -33,19 +33,18 @@ sap.ui.define([
       },
       onTableObjectMatched: function (oEvent) {
          let args = oEvent.getParameter("arguments");
-         this.setupManagerAndViewType(JSROOT.$eve7tmp.eveViewerId, JSROOT.$eve7tmp.view_kind, JSROOT.$eve7tmp.mgr );
+         this.setupManagerAndViewType(JSROOT.$eve7tmp.eveViewerId, JSROOT.$eve7tmp.mgr );
          delete JSROOT.$eve7tmp;
 
          this.checkViewReady();
       },
-      setupManagerAndViewType: function(eveViewerId, kind, mgr)
+      setupManagerAndViewType: function(eveViewerId, mgr)
       {
          this._load_scripts = true;
          this._render_html = false;
 
          this.mgr = mgr;
          this.eveViewerId = eveViewerId;
-         this.kind = kind;
 
          var rh = this.mgr.handle.getUserArgs("TableRowHeight");
          if (rh && (rh > 0))

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -74,7 +74,6 @@ sap.ui.define([
          if (viewName)
          {
             data.standalone = viewName;
-            data.kind       = viewName;
          }
 
          // console.log("VIEW DATA", data);
@@ -83,7 +82,6 @@ sap.ui.define([
          {
             this.mgr        = moredata.mgr;
             this.eveViewerId  = moredata.eveViewerId;
-            this.kind       = moredata.kind;
             this.standalone = viewName;
             this.checkViewReady();
          }
@@ -97,7 +95,6 @@ sap.ui.define([
          {
             this.mgr       = data.mgr;
             this.eveViewerId = data.eveViewerId;
-            this.kind      = data.kind;
          }
 
          this.mgr.RegisterController(this);
@@ -135,7 +132,6 @@ sap.ui.define([
          if (!found) return;
 
          this.eveViewerId = found.fElementId;
-         this.kind      = (found.fName == "Default Viewer") ? "3D" : "2D";
 
          this.checkViewReady();
       },

--- a/ui5/eve7/controller/GL.controller.js
+++ b/ui5/eve7/controller/GL.controller.js
@@ -251,6 +251,18 @@ sap.ui.define([
       /** Called from JSROOT context menu when object selected for browsing */
       invokeBrowseOf: function(obj_id) {
          this.mgr.SendMIR("BrowseElement(" + obj_id + ")", 0, "ROOT::Experimental::REveManager");
+      },
+
+      getEveCameraType : function(){
+          let vo = this.mgr.GetElement(this.eveViewerId);
+          return vo.CameraType;
+      },
+
+      isEveCameraPerspective: function() {
+         let vo = this.mgr.GetElement(this.eveViewerId);
+         console.log("compare ", vo.CameraType,"PerspXOZ" );
+         return vo.CameraType.startsWith("PerspXOZ");
+
       }
 
    });

--- a/ui5/eve7/controller/Lego.controller.js
+++ b/ui5/eve7/controller/Lego.controller.js
@@ -1,0 +1,74 @@
+sap.ui.define([
+    'sap/ui/core/mvc/Controller',
+    'sap/ui/core/Component',
+    'sap/ui/core/UIComponent',
+    'sap/ui/model/json/JSONModel',
+    'sap/ui/model/Sorter',
+    'sap/m/Column',
+    'sap/m/ColumnListItem',
+    'sap/m/Input',
+    'sap/m/Label',
+    'sap/m/Button',
+    "sap/m/FormattedText",
+    "sap/ui/layout/VerticalLayout",
+    "sap/ui/layout/HorizontalLayout",
+    "sap/ui/table/Column",
+    "sap/m/MessageBox"
+], function (Controller, Component, UIComponent, JSONModel, Sorter,
+    mColumn, mColumnListItem, mInput, mLabel, mButton,
+    FormattedText, VerticalLayout, HorizontalLayout, tableColumn, MessageBox) {
+
+    "use strict";
+
+    return Controller.extend("rootui5.eve7.controller.Lego", {
+
+        onInit: function () {
+            let data = this.getView().getViewData();
+
+            console.log("LEGO onInit ", data);
+
+            this.mgr       = data.mgr;
+            this.eveViewerId = data.eveViewerId;
+
+            let eviewer = this.mgr.GetElement(this.eveViewerId);
+            console.log("viewer", eviewer);
+            let sceneInfo = eviewer.childs[0];
+            let sceneId = sceneInfo.fSceneId;
+            
+            this.mgr.RegisterController(this);
+            this.mgr.RegisterSceneReceiver(sceneId, this);
+
+            let scene = this.mgr.GetElement(sceneId);
+            console.log("Lego scene 2", scene);
+
+            let dump = JSON.stringify(scene.childs[0]);
+            var element = this.byId("legoX");
+            element.setHtmlText(dump);
+
+        },
+
+
+
+        onSceneCreate: function (element, id) {
+            console.log("LEGO onSceneCreate", id);
+        },
+
+        sceneElementChange: function (el) {
+            console.log("LEGO element changed");
+        },
+
+        endChanges: function (oEvent) {
+        },
+
+        elementRemoved: function (elId) {
+        },
+
+        SelectElement: function (selection_obj, element_id, sec_idcs) {
+            console.log("LEGO element selected", element_id);
+        },
+
+
+        UnselectElement: function (selection_obj, element_id) {
+        }
+    });
+});

--- a/ui5/eve7/controller/Lego.controller.js
+++ b/ui5/eve7/controller/Lego.controller.js
@@ -34,20 +34,35 @@ sap.ui.define([
             console.log("viewer", eviewer);
             let sceneInfo = eviewer.childs[0];
             let sceneId = sceneInfo.fSceneId;
-            
+
             this.mgr.RegisterController(this);
             this.mgr.RegisterSceneReceiver(sceneId, this);
 
             let scene = this.mgr.GetElement(sceneId);
             console.log("Lego scene 2", scene);
 
-            let dump = JSON.stringify(scene.childs[0]);
-            var element = this.byId("legoX");
-            element.setHtmlText(dump);
+            let chld = scene.childs[0];
+            // let dump = JSON.stringify();
+            let element = this.byId("legoX");
+            element.setHtmlText("Pointset infected by TCanvas / Lego Stack");
 
+            this.canvas_json = JSROOT.parse( atob(chld.fTitle) );
         },
 
+        // Called when HTML parent/container rendering is complete.
+        onAfterRendering: function()
+        {
+            console.log("onAfterRendering", "view", this.getView(), "dom", this.byId("legoPlotPlace").getDomRef());
 
+            if ( ! this.jst_ptr)
+            {
+                // this.jst_ptr = new JSROOT.ObjectPainter(this.getView().getDomRef(), this.canvas_json);
+
+                console.log(this.canvas_json);
+                this.jst_ptr = 1;
+                JSROOT.draw(this.byId("legoPlotPlace").getDomRef(), this.canvas_json);
+            }
+        },
 
         onSceneCreate: function (element, id) {
             console.log("LEGO onSceneCreate", id);

--- a/ui5/eve7/controller/Lego.controller.js
+++ b/ui5/eve7/controller/Lego.controller.js
@@ -1,6 +1,7 @@
 sap.ui.define([
     'sap/ui/core/mvc/Controller',
     'sap/ui/core/Component',
+    "sap/ui/core/ResizeHandler",
     'sap/ui/core/UIComponent',
     'sap/ui/model/json/JSONModel',
     'sap/ui/model/Sorter',
@@ -14,7 +15,7 @@ sap.ui.define([
     "sap/ui/layout/HorizontalLayout",
     "sap/ui/table/Column",
     "sap/m/MessageBox"
-], function (Controller, Component, UIComponent, JSONModel, Sorter,
+], function (Controller, Component, ResizeHandler, UIComponent, JSONModel, Sorter,
     mColumn, mColumnListItem, mInput, mLabel, mButton,
     FormattedText, VerticalLayout, HorizontalLayout, tableColumn, MessageBox) {
 
@@ -46,21 +47,24 @@ sap.ui.define([
             let element = this.byId("legoX");
             element.setHtmlText("Pointset infected by TCanvas / Lego Stack");
 
+            ResizeHandler.register(this.getView(), this.onResize.bind(this));
+
             this.canvas_json = JSROOT.parse( atob(chld.fTitle) );
         },
 
-        // Called when HTML parent/container rendering is complete.
-        onAfterRendering: function()
+        onResize()
         {
-            console.log("onAfterRendering", "view", this.getView(), "dom", this.byId("legoPlotPlace").getDomRef());
+            let domref = this.byId("legoPlotPlace").getDomRef();
 
             if ( ! this.jst_ptr)
             {
-                // this.jst_ptr = new JSROOT.ObjectPainter(this.getView().getDomRef(), this.canvas_json);
-
-                console.log(this.canvas_json);
                 this.jst_ptr = 1;
-                JSROOT.draw(this.byId("legoPlotPlace").getDomRef(), this.canvas_json);
+                JSROOT.draw(domref, this.canvas_json);
+            }
+            else
+            {
+                // if completely different, call JSROOT.cleanup(dom) first.
+                JSROOT.redraw(domref, this.canvas_json);
             }
         },
 
@@ -81,7 +85,6 @@ sap.ui.define([
         SelectElement: function (selection_obj, element_id, sec_idcs) {
             console.log("LEGO element selected", element_id);
         },
-
 
         UnselectElement: function (selection_obj, element_id) {
         }

--- a/ui5/eve7/controller/Lego.controller.js
+++ b/ui5/eve7/controller/Lego.controller.js
@@ -43,13 +43,13 @@ sap.ui.define([
             console.log("Lego scene 2", scene);
 
             let chld = scene.childs[0];
-            // let dump = JSON.stringify();
             let element = this.byId("legoX");
             element.setHtmlText("Pointset infected by TCanvas / Lego Stack");
 
             ResizeHandler.register(this.getView(), this.onResize.bind(this));
 
             this.canvas_json = JSROOT.parse( atob(chld.fTitle) );
+            // console.log(JSON.stringify(this.canvas_json));
         },
 
         onResize()

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -64,7 +64,7 @@ sap.ui.define(['sap/ui/core/Component',
          var name = item.getText();
          if (name.indexOf(" ") > 0) name = name.substr(0, name.indexOf(" "));
          // FIXME: one need better way to deliver parameters to the selected view
-         JSROOT.$eve7tmp = { mgr: this.mgr, eveViewerId: elem.fElementId, kind: elem.view_kind };
+         JSROOT.$eve7tmp = { mgr: this.mgr, eveViewerId: elem.fElementId};
 
          var oRouter = UIComponent.getRouterFor(this);
          if (name == "Table")
@@ -113,16 +113,13 @@ sap.ui.define(['sap/ui/core/Component',
                vtype = "rootui5.eve7.view.EveTable"; // AMT temporary solution
             else if (elem.fName === "Lego")
                vtype = "rootui5.eve7.view.Lego"; // AMT temporary solution
-            else
-               elem.view_kind = (n == 0) ? "3D" : "2D"; // FIXME: should be property of GL view
-
 
             var oOwnerComponent = Component.getOwnerComponentFor(this.getView());
             var view = oOwnerComponent.runAsOwner(function() {
                return new sap.ui.xmlview({
                   id: viewid,
                   viewName: vtype,
-                  viewData: { mgr: main.mgr, eveViewerId: elem.fElementId, kind: elem.view_kind },
+                  viewData: { mgr: main.mgr, eveViewerId: elem.fElementId },
                   layoutData: oLd
                });
             });

--- a/ui5/eve7/controller/Main.controller.js
+++ b/ui5/eve7/controller/Main.controller.js
@@ -111,8 +111,10 @@ sap.ui.define(['sap/ui/core/Component',
             var vtype = "rootui5.eve7.view.GL";
             if (elem.fName === "Table")
                vtype = "rootui5.eve7.view.EveTable"; // AMT temporary solution
+            else if (elem.fName === "Lego")
+               vtype = "rootui5.eve7.view.Lego"; // AMT temporary solution
             else
-               elem.view_kind = (n==0) ? "3D" : "2D"; // FIXME: should be property of GL view
+               elem.view_kind = (n == 0) ? "3D" : "2D"; // FIXME: should be property of GL view
 
 
             var oOwnerComponent = Component.getOwnerComponentFor(this.getView());

--- a/ui5/eve7/lib/GlViewerJSRoot.js
+++ b/ui5/eve7/lib/GlViewerJSRoot.js
@@ -55,7 +55,7 @@ sap.ui.define([
          let options = "outline";
          options += ", mouse_click"; // process mouse click events
          // options += " black, ";
-         if (this.controller.kind != "3D") options += ", ortho_camera";
+         if (!this.controller.isEveCameraPerspective()) options += ", ortho_camera";
 
          // TODO: should be specified somehow in XML file
          // MT-RCORE - why have I removed this ???

--- a/ui5/eve7/lib/GlViewerRCore.js
+++ b/ui5/eve7/lib/GlViewerRCore.js
@@ -139,7 +139,7 @@ sap.ui.define([
          let light_class_3d = RC.PointLight; // RC.DirectionalLight; // RC.PointLight;
          let light_class_2d = RC.DirectionalLight;
 
-         if (this.controller.kind === "3D")
+         if (this.controller.isEveCameraPerspective())
          {
             this.camera = new RC.PerspectiveCamera(75, w / h, 1, 5000);
             this.camera.position = new RC.Vector3(-500, 0, 0);

--- a/ui5/eve7/lib/GlViewerRCore.js
+++ b/ui5/eve7/lib/GlViewerRCore.js
@@ -266,7 +266,7 @@ sap.ui.define([
             {
                this.removeEventListener('mouseup', glc.mouseup_listener);
 
-               if (event.buttons == 1) // Selection on mouseup without move
+               if (event2.buttons == 1) // Selection on mouseup without move
                {
                   glc.handleMouseSelect(event2);
                }
@@ -274,8 +274,7 @@ sap.ui.define([
                {
                   // Was needed for "on press with timeout"
                   // glc.controls.resetMouseDown(event);
-
-                  JSROOT.Painter.createMenu(glc, glc.showContextMenu.bind(glc, event2));
+                  JSROOT.Painter.createMenu(event2, glc).then(menu => { glc.showContextMenu(event2, menu) });
                }
             }
 

--- a/ui5/eve7/lib/GlViewerThree.js
+++ b/ui5/eve7/lib/GlViewerThree.js
@@ -83,7 +83,7 @@ sap.ui.define([
          this.scene = new THREE.Scene();
          // this.scene.fog = new THREE.FogExp2( 0xaaaaaa, 0.05 );
 
-         if (this.controller.kind === "3D") {
+         if (this.controller.isEveCameraPerspective()) {
             this.camera = new THREE.PerspectiveCamera(75, w / h, 1, 5000);
          }
          else {

--- a/ui5/eve7/view/Lego.view.xml
+++ b/ui5/eve7/view/Lego.view.xml
@@ -1,13 +1,13 @@
 <mvc:View
    class="sapUiSizeCompact"
-   height="100%"
+   height="100%" width="100%"
    controllerName="rootui5.eve7.controller.Lego"
    xmlns:mvc="sap.ui.core.mvc"
    xmlns:l="sap.ui.layout"
    xmlns="sap.m"
    xmlns:html="http://www.w3.org/1999/xhtml"
    >
-    <Panel id="legoPanel" >
+    <Panel id="legoPanel" width="100%" height="100%">
         <headerToolbar>
             <OverflowToolbar>
                <Title text="HELLO"/>
@@ -15,10 +15,8 @@
             </OverflowToolbar>
         </headerToolbar>
         <content>
-           <l:VerticalLayout>
            <FormattedText id="legoX"/>
-           <html:div id="legoPlotPlace"/>
-           </l:VerticalLayout>
+           <html:div id="legoPlotPlace" style="position:relative;left:0;right:0;top:0;bottom:0;height:100%;width:100%"/>
         </content>
     </Panel>
 </mvc:View>

--- a/ui5/eve7/view/Lego.view.xml
+++ b/ui5/eve7/view/Lego.view.xml
@@ -1,0 +1,21 @@
+<mvc:View
+   class="sapUiSizeCompact"
+   height="100%"
+   controllerName="rootui5.eve7.controller.Lego"
+   xmlns:mvc="sap.ui.core.mvc"
+   xmlns:l="sap.ui.layout"
+   xmlns="sap.m">
+    <Panel id="legoPanel" >
+        <headerToolbar>
+            <OverflowToolbar>
+               <Title text="HELLO"/>
+               <Button text="LEGO" />
+            </OverflowToolbar>
+        </headerToolbar>
+        <content>
+           <l:VerticalLayout width="100%">
+           <FormattedText id="legoX"/>
+           </l:VerticalLayout>
+        </content>
+    </Panel>
+</mvc:View>

--- a/ui5/eve7/view/Lego.view.xml
+++ b/ui5/eve7/view/Lego.view.xml
@@ -4,17 +4,20 @@
    controllerName="rootui5.eve7.controller.Lego"
    xmlns:mvc="sap.ui.core.mvc"
    xmlns:l="sap.ui.layout"
-   xmlns="sap.m">
+   xmlns="sap.m"
+   xmlns:html="http://www.w3.org/1999/xhtml"
+   >
     <Panel id="legoPanel" >
         <headerToolbar>
             <OverflowToolbar>
                <Title text="HELLO"/>
-               <Button text="LEGO" />
+               <Button text="LEGO"/>
             </OverflowToolbar>
         </headerToolbar>
         <content>
-           <l:VerticalLayout width="100%">
+           <l:VerticalLayout>
            <FormattedText id="legoX"/>
+           <html:div id="legoPlotPlace"/>
            </l:VerticalLayout>
         </content>
     </Panel>


### PR DESCRIPTION

## Changes or fixes:
* Add XZ,YZ, ZX, and ZY projection types
* Zero version of Lego view type
* Add energy scaling in REveDataProxyBuilderBase
* Ability to set camera type through REveViewer
* Corrections in reuse of compounds in REveDataSimpleProxyBuilder
* Fix selection/highlight in REveStraightLineSet

## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)


