### PR TITLE
grab CTRL+s in TGMainFrame also if NumLock active

### DIFF
--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1468,7 +1468,7 @@ TGMainFrame::TGMainFrame(const TGWindow *p, UInt_t w, UInt_t h,
    fWMInitState = (EInitialState) 0;
 
    gVirtualX->GrabKey(fId, gVirtualX->KeysymToKeycode(kKey_s),
-                      kKeyControlMask, kTRUE);
+                      kKeyControlMask | kKeyMod2Mask, kTRUE);//grab CTRL+s also if NumLock is active
    if (p == fClient->GetDefaultRoot()) {
       fMWMValue    = kMWMDecorAll;
       fMWMFuncs    = kMWMFuncAll;
@@ -1509,6 +1509,8 @@ TGMainFrame::~TGMainFrame()
       fBindList->Delete();
       delete fBindList;
    }
+   gVirtualX->GrabKey(fId, gVirtualX->KeysymToKeycode(kKey_s),
+                      kKeyControlMask | kKeyMod2Mask, kFALSE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1468,6 +1468,8 @@ TGMainFrame::TGMainFrame(const TGWindow *p, UInt_t w, UInt_t h,
    fWMInitState = (EInitialState) 0;
 
    gVirtualX->GrabKey(fId, gVirtualX->KeysymToKeycode(kKey_s),
+                      kKeyControlMask, kTRUE);//grab CTRL+s
+   gVirtualX->GrabKey(fId, gVirtualX->KeysymToKeycode(kKey_s),
                       kKeyControlMask | kKeyMod2Mask, kTRUE);//grab CTRL+s also if NumLock is active
    if (p == fClient->GetDefaultRoot()) {
       fMWMValue    = kMWMDecorAll;
@@ -1509,6 +1511,8 @@ TGMainFrame::~TGMainFrame()
       fBindList->Delete();
       delete fBindList;
    }
+   gVirtualX->GrabKey(fId, gVirtualX->KeysymToKeycode(kKey_s),
+                      kKeyControlMask, kFALSE);
    gVirtualX->GrabKey(fId, gVirtualX->KeysymToKeycode(kKey_s),
                       kKeyControlMask | kKeyMod2Mask, kFALSE);
 }

--- a/gui/guibuilder/src/TRootGuiBuilder.cxx
+++ b/gui/guibuilder/src/TRootGuiBuilder.cxx
@@ -70,6 +70,7 @@
 
   - Press Ctrl-Double-Click to start/stop edit mode
   - Press Double-Click to activate quick edit action (defined in root.mimes)
+  - Warning: some shortcuts might not work if NumLock is enabled
 
 ### Selection, grabbing, dropping
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
CTRL shortcuts X11Grab were not working if NumLock was enabled.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/8665

