### PR TITLE
[cmake] Fix build with builtin_llvm=off

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -235,6 +235,17 @@ if(builtin_llvm)
     endif()
   endforeach()
   set(LLVM_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}" PARENT_SCOPE)
+
+  #---Make LLVM compilation flags public---------------------------------------------------------------
+  # Extract the compilation flags from LLVM and make them public to the
+  # rest of ROOT so that we can compile against LLVM with matching flags.
+
+  # LLVM doesn't really give us a API to get this with an in-source build
+  # so we just use the normal way of doing this and read the llvm directory
+  # compilation properties.
+  get_directory_property(LLVM_DEFS DIRECTORY llvm/src COMPILE_DEFINITIONS)
+  # Turns DEFINE1;DEFINE2 to -DDEFINE1 -DDEFINE2
+  string (REPLACE ";" " -D" LLVM_DEFS ";${LLVM_DEFS}")
 else()
   # Rely on llvm-config.
   set(CONFIG_OUTPUT)
@@ -249,7 +260,8 @@ else()
       "--prefix"
       "--src-root"
       "--cmakedir"
-      "--build-mode")
+      "--build-mode"
+      "--cppflags")
     execute_process(
       COMMAND ${CONFIG_COMMAND}
       RESULT_VARIABLE HAD_ERROR
@@ -276,6 +288,7 @@ else()
   list(GET CONFIG_OUTPUT 5 MAIN_SRC_DIR)
   list(GET CONFIG_OUTPUT 6 LLVM_CONFIG_CMAKE_PATH)
   list(GET CONFIG_OUTPUT 7 LLVM_BUILD_MODE)
+  list(GET CONFIG_OUTPUT 8 LLVM_DEFS)
 
   message(STATUS "External llvm built in ${LLVM_BUILD_MODE} mode.")
 
@@ -450,16 +463,6 @@ endif()
 add_custom_target(CLING)
 set(CLING_LIBRARIES clingInterpreter;clingMetaProcessor;clingUtils CACHE STRING "")
 if (builtin_cling)
-
-  # Extract the compilation flags from LLVM and make them public to the
-  # rest of ROOT so that we can compile against LLVM with matching flags.
-
-  # LLVM doesn't really give us a API to get this with an in-source build
-  # so we just use the normal way of doing this and read the llvm directory
-  # compilation properties.
-  get_directory_property(LLVM_DEFS DIRECTORY llvm/src COMPILE_DEFINITIONS)
-  # Turns DEFINE1;DEFINE2 to -DDEFINE1 -DDEFINE2
-  string (REPLACE ";" " -D" LLVM_DEFS ";${LLVM_DEFS}")
 
   # FIXME: Reduce the usage of CLING_CXXFLAGS by adding a cmake routine in
   # RootMacros.cmake for all cling-dependent libraries

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -442,6 +442,10 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
 
   # We are in the case of NOT builtin_llvm
   if (builtin_clang)
+    # remove clang-cpp from CLANG_LINKS_TO_CREATE to avoid clashes with
+    # install-clang-cpp target defined by LLVM's cmake module
+    set(CLANG_LINKS_TO_CREATE clang++ clang-cl)
+
     add_subdirectory(llvm/src/tools/clang EXCLUDE_FROM_ALL)
   endif(builtin_clang)
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This fixes both of the errors seen when trying to build with builtin_llvm=off
https://root-forum.cern.ch/t/compiling-root-6-24-with-external-llvm-but-built-in-clang/45258

## Checklist:

- [x] tested changes locally
- updated the docs (if necessary)

This PR fixes #8141