### PR TITLE
Fix deprecation warning for new GitHub workflow [skip-ci]

### DIFF
--- a/.github/workflows/issues-nudge.yml
+++ b/.github/workflows/issues-nudge.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          version: 12
+          node-version: '16'
       - run: npm install octokit
       - run: node .github/actions/issues-nudge.js
         env:


### PR DESCRIPTION
The UI says:
> Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead.

Also bump to the latest NodeJS version 16.x which will become the next LTS version in October and be supported until 2024 (12.x will go EOL in April 2022, next year).