### PR TITLE
use proper bitmap_pad in XCreateImage

### DIFF
--- a/graf2d/x11ttf/src/TGX11TTF.cxx
+++ b/graf2d/x11ttf/src/TGX11TTF.cxx
@@ -481,7 +481,8 @@ void TGX11TTF::RenderString(Int_t x, Int_t y, ETextMode mode)
    XImage *xim  = 0;
    xim = XCreateImage((Display*)fDisplay, fVisual,
                       depth, ZPixmap, 0, 0, w, h,
-                      depth == 24 ? 32 : (depth==15?16:depth), 0);
+                      depth <= 8 ? 8 : depth <= 16 ? 16 : 32, 0);
+   //bitmap_pad should be 8, 16 or 32 https://www.x.org/releases/X11R7.5/doc/man/man3/XPutPixel.3.html
    if (!xim) return;
 
    // use malloc since Xlib will use free() in XDestroyImage


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
XCreateImage bitmap_pad argument was not being set properly. It caused problems with depths of e.g. 30.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/8086

