### PR TITLE
[DF] Add RCutFlowReport to LinkDef

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -58,6 +58,7 @@
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile2D>+;
 #pragma link C++ class TNotifyLink<ROOT::Internal::RDF::RDataBlockFlag>;
+#pragma link C++ class ROOT::RDF::RCutFlowReport;
 
 #endif
 


### PR DESCRIPTION
This should fix some sporadic failures in cling's symbol resolution
in builds without runtime cxx modules.