### PR TITLE
Use integer pixels for RCanvas width and height

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -542,8 +542,8 @@ class NotebookDrawer(object):
             options = ""
 
         if self.isRCanvas:
-            # width = self.drawableObject.GetSize()[0]
-            # height = self.drawableObject.GetSize()[1]
+            if (self.drawableObject.GetWidth() > 0): width = self.drawableObject.GetWidth()
+            if (self.drawableObject.GetHeight() > 0): height = self.drawableObject.GetHeight()
             options = ""
 
         thisJsCode = _jsCode.format(jsCanvasWidth = height,

--- a/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RCanvas.hxx
@@ -52,8 +52,11 @@ private:
    /// Title of the canvas.
    std::string fTitle;
 
-   /// Size of the canvas in pixels,
-   std::array<RPadLength::Pixel, 2> fSize;
+   /// Width of the canvas in pixels
+   int fWidth{0};
+
+   /// Height of the canvas in pixels
+   int fHeight{0};
 
    /// Modify counter, incremented every time canvas is changed
    Version_t fModified{1}; ///<!
@@ -88,23 +91,24 @@ public:
    /// Access to the top-most canvas, if any (non-const version).
    RCanvas *GetCanvas() override { return this; }
 
-   /// Return canvas pixel size as array with two elements - width and height
-   const std::array<RPadLength::Pixel, 2> &GetSize() const { return fSize; }
-
-   /// Set canvas pixel size as array with two elements - width and height
-   RCanvas &SetSize(const std::array<RPadLength::Pixel, 2> &sz)
-   {
-      fSize = sz;
-      return *this;
-   }
-
    /// Set canvas pixel size - width and height
-   RCanvas &SetSize(const RPadLength::Pixel &width, const RPadLength::Pixel &height)
+   void SetSize(int width, int height)
    {
-      fSize[0] = width;
-      fSize[1] = height;
-      return *this;
+      fWidth = width;
+      fHeight = height;
    }
+
+   /// Set canvas width
+   void SetWidth(int width) { fWidth = width; }
+
+   /// Set canvas height
+   void SetHeight(int height) { fHeight = height; }
+
+   /// Get canvas width
+   int GetWidth() const { return fWidth; }
+
+   /// Get canvas height
+   int GetHeight() const { return fHeight; }
 
    /// Display the canvas.
    void Show(const std::string &where = "");

--- a/graf2d/gpadv7/inc/ROOT/RPadDisplayItem.hxx
+++ b/graf2d/gpadv7/inc/ROOT/RPadDisplayItem.hxx
@@ -102,7 +102,7 @@ public:
    RCanvasDisplayItem() = default;
    virtual ~RCanvasDisplayItem() = default;
    void SetTitle(const std::string &title) { fTitle = title; }
-   void SetWindowSize(const std::array<RPadLength::Pixel, 2> &win) { fWinSize[0] = (int) win[0].fVal; fWinSize[1] = (int) win[1].fVal; }
+   void SetWindowSize(int width, int height) { fWinSize[0] = width; fWinSize[1] = height; }
 
    void BuildFullId(const std::string &prefix) override
    {

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -194,10 +194,10 @@ bool ROOT::Experimental::RCanvas::SaveAs(const std::string &filename)
    if (!fPainter)
       return false;
 
-   auto width = fSize[0].fVal;
-   auto height = fSize[1].fVal;
+   int width = GetWidth();
+   int height = GetHeight();
 
-   return fPainter->ProduceBatchOutput(filename, width > 1 ? (int) width : 800, height > 1 ? (int) height : 600);
+   return fPainter->ProduceBatchOutput(filename, width > 1 ? width : 800, height > 1 ? height : 600);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/gui/canvaspainter/src/RCanvasPainter.cxx
+++ b/gui/canvaspainter/src/RCanvasPainter.cxx
@@ -626,14 +626,15 @@ void RCanvasPainter::NewDisplay(const std::string &where)
 {
    CreateWindow();
 
-   auto sz = fCanvas.GetSize();
+   int width = fCanvas.GetWidth();
+   int height = fCanvas.GetHeight();
 
    RWebDisplayArgs args(where);
 
-   if ((sz[0].fVal > 10) && (sz[1].fVal > 10)) {
+   if ((width > 10) && (height > 10)) {
       // extra size of browser window header + ui5 menu
-      args.SetWidth((int) sz[0].fVal + 1);
-      args.SetHeight((int) sz[1].fVal + 40);
+      args.SetWidth(width + 4);
+      args.SetHeight(height + 36);
    }
 
    fWindow->Show(args);
@@ -708,7 +709,7 @@ std::string RCanvasPainter::CreateSnapshot(RDrawable::RDisplayContext &ctxt)
    fCanvas.DisplayPrimitives(*canvitem, ctxt);
 
    canvitem->SetTitle(fCanvas.GetTitle());
-   canvitem->SetWindowSize(fCanvas.GetSize());
+   canvitem->SetWindowSize(fCanvas.GetWidth(), fCanvas.GetHeight());
 
    canvitem->BuildFullId(""); // create object id which unique identify it via pointer and position in subpads
    canvitem->SetObjectID("canvas"); // for canvas itself use special id


### PR DESCRIPTION
No any other dimension kinds are supported, therefore simplify API
Use canvas size in `jupyter` to configure output container