### PR TITLE
RooFit::MultiProcess & TestStatistics part 5b: test RooGradMinimizerFcn

### DIFF
--- a/math/mathcore/inc/Fit/Chi2FCN.h
+++ b/math/mathcore/inc/Fit/Chi2FCN.h
@@ -126,6 +126,14 @@ public:
       FitUtil::Evaluate<T>::EvalChi2Gradient(BaseFCN::ModelFunction(), BaseFCN::Data(), x, g, fNEffPoints,
                                              fExecutionPolicy);
    }
+   /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
    /// get type of fit method function
    virtual  typename BaseObjFunction::Type_t Type() const { return BaseObjFunction::kLeastSquare; }
@@ -153,6 +161,15 @@ private:
    virtual double  DoDerivative(const double * x, unsigned int icoord ) const {
       Gradient(x, fGrad.data());
       return fGrad[icoord];
+   }
+   /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                               double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
 

--- a/math/mathcore/inc/Fit/LogLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/LogLikelihoodFCN.h
@@ -129,6 +129,14 @@ public:
       FitUtil::Evaluate<typename BaseFCN::T>::EvalLogLGradient(BaseFCN::ModelFunction(), BaseFCN::Data(), x, g,
                                                                fNEffPoints, fExecutionPolicy);
    }
+   /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This overload just calls the two-parameter version.
+   virtual void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
    /// get type of fit method function
    virtual  typename BaseObjFunction::Type_t Type() const { return BaseObjFunction::kLogLikelihood; }
@@ -161,6 +169,14 @@ private:
    virtual double  DoDerivative(const double * x, unsigned int icoord ) const {
       Gradient(x, &fGrad[0]);
       return fGrad[icoord];
+   }
+   /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   virtual double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                               double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
 

--- a/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
@@ -130,6 +130,14 @@ public:
       FitUtil::Evaluate<typename BaseFCN::T>::EvalPoissonLogLGradient(BaseFCN::ModelFunction(), BaseFCN::Data(), x, g,
                                                                       fNEffPoints, fExecutionPolicy);
    }
+   /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
    /// get type of fit method function
    virtual  typename BaseObjFunction::Type_t Type() const { return BaseObjFunction::kLogLikelihood; }
@@ -169,6 +177,15 @@ private:
    virtual double  DoDerivative(const double * x, unsigned int icoord ) const {
       Gradient(x, &fGrad[0]);
       return fGrad[icoord];
+   }
+   /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                               double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
 

--- a/math/mathcore/inc/Math/Functor.h
+++ b/math/mathcore/inc/Math/Functor.h
@@ -128,6 +128,14 @@ private :
       return fFunc.Derivative(x,icoord);
    }
 
+   // TODO: implementing this will require extending with another function signature in GradFunctor
+   /// \warning This overload just calls the two-parameter version.
+   inline double DoDerivative(const double *x, unsigned int icoord, double */*previous_grad*/, double */*previous_g2*/,
+                              double */*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
+   }
+
 
    unsigned int fDim;
    mutable Func fFunc;  // should here be a reference and pass a non-const ref in ctor
@@ -211,6 +219,13 @@ private :
       return fGradFunc(x, icoord);
    }
 
+   // TODO: implementing this will require extending with another function signature in GradFunctor
+   /// \warning This overload just calls the two-parameter version.
+   inline double DoDerivative(const double *x, unsigned int icoord, double */*previous_grad*/, double */*previous_g2*/,
+                              double */*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
+   }
 
    unsigned int fDim;
    mutable Func fFunc;
@@ -346,6 +361,14 @@ private :
 
    inline double DoDerivative (const double * x, unsigned int icoord ) const {
       return ((*fObj).*fGradMemFn)(x,icoord);
+   }
+
+   // TODO: implementing this will require extending with another function signature in GradFunctor
+   /// \warning This overload just calls the two-parameter version.
+   inline double DoDerivative(const double *x, unsigned int icoord, double */*previous_grad*/, double */*previous_g2*/,
+                              double */*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
    unsigned int fDim;
@@ -700,6 +723,14 @@ private :
 
    inline double DoDerivative (const double * x, unsigned int icoord  ) const {
       return fImpl->Derivative(x,icoord);
+   }
+
+   // TODO: implementing this will require extending with another function signature in GradFunctor
+   /// \warning This overload just calls the two-parameter version.
+   inline double DoDerivative(const double *x, unsigned int icoord, double */*previous_grad*/, double */*previous_g2*/,
+                              double */*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
    std::unique_ptr<Impl> fImpl;    // pointer to base grad functor handler

--- a/math/mathcore/inc/Math/IFunction.h
+++ b/math/mathcore/inc/Math/IFunction.h
@@ -215,6 +215,14 @@ namespace ROOT {
             Return the partial derivative with respect to the passed coordinate
          */
          T Derivative(const T *x, unsigned int icoord = 0) const { return DoDerivative(x, icoord); }
+         /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+         /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+         /// so that these can be passed forward again as well at the call site, if necessary.
+         T Derivative(const T *x, unsigned int icoord, T *previous_grad, T *previous_g2,
+                      T *previous_gstep) const
+         {
+            return DoDerivative(x, icoord, previous_grad, previous_g2, previous_gstep);
+         }
 
          /**
              Optimized method to evaluate at the same time the function value and derivative at a point x.
@@ -232,6 +240,14 @@ namespace ROOT {
             function to evaluate the derivative with respect each coordinate. To be implemented by the derived class
          */
          virtual T DoDerivative(const T *x, unsigned int icoord) const = 0;
+         /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+         /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+         /// so that these can be passed forward again as well at the call site, if necessary.
+         virtual T DoDerivative(const T *x, unsigned int icoord, T * /*previous_grad*/, T * /*previous_g2*/,
+                                T * /*previous_gstep*/) const
+         {
+            return DoDerivative(x, icoord);
+         };
       };
 
 //___________________________________________________________________________________
@@ -344,6 +360,16 @@ namespace ROOT {
             unsigned int ndim = NDim();
             for (unsigned int icoord  = 0; icoord < ndim; ++icoord)
                grad[icoord] = BaseGrad::Derivative(x, icoord);
+         }
+
+         /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
+         /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+         /// so that these can be passed forward again as well at the call site, if necessary.
+         virtual void Gradient(const T *x, T *grad, T *previous_grad, T *previous_g2, T *previous_gstep) const
+         {
+            unsigned int ndim = NDim();
+            for (unsigned int icoord  = 0; icoord < ndim; ++icoord)
+               grad[icoord] = BaseGrad::Derivative(x, icoord, previous_grad, previous_g2, previous_gstep);
          }
 
          using  BaseFunc::NDim;

--- a/math/mathcore/inc/Math/MinimTransformFunction.h
+++ b/math/mathcore/inc/Math/MinimTransformFunction.h
@@ -123,6 +123,14 @@ private:
       //std::cout << "Derivative icoord (ext)" << fIndex[icoord] << "   dtrafo " << dExtdInt << "  " << deriv << std::endl;
       return deriv * dExtdInt;
    }
+   /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   virtual double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                               double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
+   }
 
    // copy constructor for this class (disable by having it private)
    MinimTransformFunction( const MinimTransformFunction & ) :

--- a/math/mathcore/test/fit/testMinim.cxx
+++ b/math/mathcore/test/fit/testMinim.cxx
@@ -188,6 +188,10 @@ public :
       }
 
    }
+   void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
 #ifdef USE_FDF
    void FdF (const double * x, double & f, double * g) const {
@@ -239,6 +243,11 @@ public :
       std::vector<double> g(fDim);
       Gradient(x,&g[0]);
       return  g[i];
+   }
+   double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                       double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
 private:
@@ -322,6 +331,10 @@ public :
 
 
    }
+   void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
    private:
 
@@ -341,6 +354,11 @@ public :
       std::vector<double> g(fDim);
       Gradient(x,&g[0]);
       return  g[i];
+   }
+   double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                       double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
    void DoCalculatefi(const double * x) const {

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -102,6 +102,14 @@ public:
       double f0 = 0;
       FdF(x,f0,g);
    }
+   /// In some cases, the gradient algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
    void FdF (const double * x, double & f, double * g) const {
       unsigned int n = NDim();
@@ -128,6 +136,15 @@ private:
       const double kEps = 1.0E-4;
       fX2[icoord] += kEps;
       return ( DoEval(&fX2.front()) - DoEval(x) )/kEps;
+   }
+   /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                               double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
    unsigned int fIndex;

--- a/math/mathmore/inc/Math/MultiNumGradFunction.h
+++ b/math/mathmore/inc/Math/MultiNumGradFunction.h
@@ -122,6 +122,15 @@ private:
 
    // calculate derivative using mathcore derivator
    double DoDerivative (const double * x, unsigned int icoord  ) const;
+   /// In some cases, the derivative algorithm will use information from the previous step, these can be passed
+   /// in with this overload. The `previous_*` arrays can also be used to return second derivative and step size
+   /// so that these can be passed forward again as well at the call site, if necessary.
+   /// \warning This implementation just calls the two-parameter overload.
+   virtual double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                               double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
+   }
 
    // adapat internal function type to IMultiGenFunction needed by derivative calculation
    const IMultiGenFunction * fFunc;

--- a/math/minuit2/inc/Minuit2/FCNGradAdapter.h
+++ b/math/minuit2/inc/Minuit2/FCNGradAdapter.h
@@ -54,6 +54,18 @@ public:
       });
       return fGrad;
    }
+   std::vector<double> Gradient(const std::vector<double> &v, double *previous_grad, double *previous_g2,
+                                double *previous_gstep) const override
+   {
+      fFunc.Gradient(&v[0], &fGrad[0], previous_grad, previous_g2, previous_gstep);
+
+      MnPrint("FCNGradAdapter").Debug([&](std::ostream &os) {
+         os << "gradient in FCNAdapter = {";
+         for (unsigned int i = 0; i < fGrad.size(); ++i)
+            os << fGrad[i] << (i == fGrad.size() - 1 ? '}' : '\t');
+      });
+      return fGrad;
+   }
    // forward interface
    // virtual double operator()(int npar, double* params,int iflag = 4) const;
    bool CheckGradient() const override { return false; }

--- a/math/minuit2/inc/Minuit2/FCNGradientBase.h
+++ b/math/minuit2/inc/Minuit2/FCNGradientBase.h
@@ -41,6 +41,8 @@ public:
    virtual ~FCNGradientBase() {}
 
    virtual std::vector<double> Gradient(const std::vector<double> &) const = 0;
+   virtual std::vector<double> Gradient(const std::vector<double> &parameters, double */*previous_grad*/, double */*previous_g2*/,
+                                        double */*previous_gstep*/) const { return Gradient(parameters); };
 
    virtual bool CheckGradient() const { return true; }
 

--- a/math/minuit2/inc/Minuit2/NumericalDerivator.h
+++ b/math/minuit2/inc/Minuit2/NumericalDerivator.h
@@ -70,8 +70,7 @@ public:
    double Ext2int(const ROOT::Fit::ParameterSettings &parameter, double val) const;
    double DInt2Ext(const ROOT::Fit::ParameterSettings &parameter, double val) const;
 
-   void SetInitialGradient(const ROOT::Math::IBaseFunctionMultiDim *function,
-                           const std::vector<ROOT::Fit::ParameterSettings> &parameters,
+   void SetInitialGradient(const std::vector<ROOT::Fit::ParameterSettings> &parameters,
                            std::vector<DerivatorElement> &gradient);
 
    inline bool AlwaysExactlyMimicMinuit2() const { return fAlwaysExactlyMimicMinuit2; }

--- a/math/minuit2/src/ExternalInternalGradientCalculator.cxx
+++ b/math/minuit2/src/ExternalInternalGradientCalculator.cxx
@@ -13,13 +13,13 @@
 #include "Minuit2/MnUserTransformation.h"
 #include "Minuit2/FunctionGradient.h"
 #include "Minuit2/MinimumParameters.h"
+#include "Minuit2/MnPrint.h"
 
 namespace ROOT {
 namespace Minuit2 {
 
 FunctionGradient ExternalInternalGradientCalculator::operator()(const MinimumParameters &par) const
 {
-   // evaluate analytical gradient. take care of parameter transformations
    std::vector<double> par_vec;
    par_vec.resize(par.Vec().size());
    for (std::size_t ix = 0; ix < par.Vec().size(); ++ix) {
@@ -35,18 +35,42 @@ FunctionGradient ExternalInternalGradientCalculator::operator()(const MinimumPar
       v(i) = grad[ext];
    }
 
-#ifdef DEBUG
-   std::cout << "User given gradient in Minuit2" << v << std::endl;
-#endif
+   MnPrint print("ExternalInternalGradientCalculator");
+   print.Debug("User given gradient in Minuit2", v);
 
    return FunctionGradient(v);
 }
 
 FunctionGradient
-ExternalInternalGradientCalculator::operator()(const MinimumParameters &par, const FunctionGradient &) const
+ExternalInternalGradientCalculator::operator()(const MinimumParameters &par, const FunctionGradient &functionGradient) const
 {
-   // needed from base class
-   return (*this)(par);
+   std::vector<double> par_vec;
+   par_vec.resize(par.Vec().size());
+   for (std::size_t ix = 0; ix < par.Vec().size(); ++ix) {
+      par_vec[ix] = par.Vec()(ix);
+   }
+
+   std::vector<double> previous_grad(functionGradient.Grad().Data(), functionGradient.Grad().Data() + functionGradient.Grad().size());
+   std::vector<double> previous_g2(functionGradient.G2().Data(), functionGradient.G2().Data() + functionGradient.G2().size());
+   std::vector<double> previous_gstep(functionGradient.Gstep().Data(), functionGradient.Gstep().Data() + functionGradient.Gstep().size());
+
+   std::vector<double> grad = fGradCalc.Gradient(par_vec, previous_grad.data(), previous_g2.data(), previous_gstep.data());
+   assert(grad.size() == fTransformation.Parameters().size());
+
+   MnAlgebraicVector v(par.Vec().size());
+   MnAlgebraicVector v_g2(par.Vec().size());
+   MnAlgebraicVector v_gstep(par.Vec().size());
+   for (unsigned int i = 0; i < par.Vec().size(); i++) {
+      unsigned int ext = fTransformation.ExtOfInt(i);
+      v(i) = grad[ext];
+      v_g2(i) = previous_g2[ext];
+      v_gstep(i) = previous_gstep[ext];
+   }
+
+   MnPrint print("ExternalInternalGradientCalculator");
+   print.Debug("User given gradient in Minuit2", v, "g2", v_g2, "step size", v_gstep);
+
+   return FunctionGradient(v, v_g2, v_gstep);
 }
 
 } // namespace Minuit2

--- a/math/minuit2/src/NumericalDerivator.cxx
+++ b/math/minuit2/src/NumericalDerivator.cxx
@@ -221,8 +221,7 @@ double NumericalDerivator::DInt2Ext(const ROOT::Fit::ParameterSettings &paramete
 // MODIFIED:
 /// This function was not implemented as in Minuit2. Now it copies the behavior
 /// of InitialGradientCalculator. See https://github.com/roofit-dev/root/issues/10
-void NumericalDerivator::SetInitialGradient(const ROOT::Math::IBaseFunctionMultiDim *,
-                                            const std::vector<ROOT::Fit::ParameterSettings> &parameters,
+void NumericalDerivator::SetInitialGradient(const std::vector<ROOT::Fit::ParameterSettings> &parameters,
                                             std::vector<DerivatorElement> &gradient)
 {
    // set an initial gradient using some given steps

--- a/math/minuit2/test/MnTutorial/Quad1F.h
+++ b/math/minuit2/test/MnTutorial/Quad1F.h
@@ -37,6 +37,8 @@ public:
 
       return (std::vector<double>(1, 2. * x));
    }
+   virtual std::vector<double> Gradient(const std::vector<double> &parameters, double */*previous_grad*/, double */*previous_g2*/,
+                                        double */*previous_gstep*/) const { return Gradient(parameters); };
 
    void SetErrorDef(double up) { fErrorDef = up; }
 

--- a/math/minuit2/test/MnTutorial/Quad4F.h
+++ b/math/minuit2/test/MnTutorial/Quad4F.h
@@ -72,6 +72,8 @@ public:
       g[3] = 2. * w;
       return g;
    }
+   virtual std::vector<double> Gradient(const std::vector<double> &parameters, double */*previous_grad*/, double */*previous_g2*/,
+                                        double */*previous_gstep*/) const { return Gradient(parameters); };
 
    double Up() const { return 1.; }
 

--- a/math/minuit2/test/testMinimizer.cxx
+++ b/math/minuit2/test/testMinimizer.cxx
@@ -169,6 +169,10 @@ public:
          }
       }
    }
+   void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
 #ifdef USE_FDF
    void FdF(const double *x, double &f, double *g) const
@@ -219,6 +223,11 @@ private:
       std::vector<double> g(fDim);
       Gradient(x, &g[0]);
       return g[i];
+   }
+   double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                       double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
 private:
@@ -286,6 +295,10 @@ public:
          g[j] = 2. * g[j] / double(n);
       }
    }
+   void Gradient(const double *x, double *g, double */*previous_grad*/, double */*previous_g2*/, double */*previous_gstep*/) const
+   {
+      Gradient(x, g);
+   }
 
 private:
    double DoEval(const double *x) const
@@ -305,6 +318,11 @@ private:
       std::vector<double> g(fDim);
       Gradient(x, &g[0]);
       return g[i];
+   }
+   double DoDerivative(const double *x, unsigned int icoord, double * /*previous_grad*/, double * /*previous_g2*/,
+                       double * /*previous_gstep*/) const
+   {
+      return DoDerivative(x, icoord);
    }
 
    void DoCalculatefi(const double *x) const

--- a/roofit/roofitcore/inc/RooGradMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooGradMinimizerFcn.h
@@ -70,6 +70,8 @@ private:
    // IMultiGradFunction overrides
    double DoEval(const double *x) const override;
    double DoDerivative(const double *x, unsigned int icoord) const override;
+   double DoDerivative(const double *x, unsigned int i_component, double *previous_grad,
+                       double *previous_g2, double *previous_gstep) const override;
 
    // members
    // mutable because ROOT::Math::IMultiGradFunction::DoDerivative is const

--- a/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
@@ -64,7 +64,7 @@ ROOT::Math::IMultiGradFunction *RooGradMinimizerFcn::Clone() const
 void RooGradMinimizerFcn::synchronizeGradientParameterSettings(
    std::vector<ROOT::Fit::ParameterSettings> &parameter_settings) const
 {
-   _gradf.SetInitialGradient(_context->getMultiGenFcn(), parameter_settings, _grad);
+   _gradf.SetInitialGradient(parameter_settings, _grad);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
@@ -215,6 +215,18 @@ double RooGradMinimizerFcn::DoDerivative(const double *x, unsigned int i_compone
    return _grad[i_component].derivative;
 }
 
+double RooGradMinimizerFcn::DoDerivative(const double *x, unsigned int i_component, double *previous_grad,
+                                         double *previous_g2, double *previous_gstep) const
+{
+   syncParameters(x);
+   _grad[i_component] = {previous_grad[i_component], previous_g2[i_component], previous_gstep[i_component]};
+   runDerivator(i_component);
+   previous_grad[i_component] = _grad[i_component].derivative;
+   previous_g2[i_component] = _grad[i_component].second_derivative;
+   previous_gstep[i_component] = _grad[i_component].step_size;
+   return _grad[i_component].derivative;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void RooGradMinimizerFcn::setStrategy(int istrat)

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -42,6 +42,5 @@ if(NOT MSVC OR win_broken_tests)
 endif()
 ROOT_ADD_GTEST(testRooProductPdf testRooProductPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore)
-#ROOT_ADD_GTEST(testRooGradMinimizerFcn testRooGradMinimizerFcn.cxx LIBRARIES RooFitCore)
-
+ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooGradMinimizerFcn testRooGradMinimizerFcn.cxx LIBRARIES RooFitCore)

--- a/roofit/roofitcore/test/testRooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/test/testRooGradMinimizerFcn.cxx
@@ -72,7 +72,7 @@ TEST_P(GradMinimizerParSeed, Gaussian1D)
 
    *values = *savedValues;
 
-   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create<RooGradMinimizerFcn>(*nll);
+   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
    m1->setMinimizerType("Minuit2");
 
    m1->setStrategy(0);
@@ -186,8 +186,8 @@ TEST(GradMinimizer, GaussianND)
    RooFitResult *m0result = m0.lastMinuitFit();
    double minNll0 = m0result->minNll();
    double edm0 = m0result->edm();
-   double mean0[N];
-   double std0[N];
+   std::vector<double> mean0(N);
+   std::vector<double> std0(N);
    for (unsigned ix = 0; ix < N; ++ix) {
       {
          std::ostringstream os;
@@ -218,8 +218,8 @@ TEST(GradMinimizer, GaussianND)
    RooFitResult *m1result = m1->lastMinuitFit();
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
-   double mean1[N];
-   double std1[N];
+   std::vector<double> mean1(N);
+   std::vector<double> std1(N);
    for (unsigned ix = 0; ix < N; ++ix) {
       {
          std::ostringstream os;
@@ -283,8 +283,8 @@ TEST(GradMinimizerReverse, GaussianND)
    RooFitResult *m0result = m0->lastMinuitFit();
    double minNll0 = m0result->minNll();
    double edm0 = m0result->edm();
-   double mean0[N];
-   double std0[N];
+   std::vector<double> mean0(N);
+   std::vector<double> std0(N);
    for (unsigned ix = 0; ix < N; ++ix) {
       {
          std::ostringstream os;
@@ -315,8 +315,8 @@ TEST(GradMinimizerReverse, GaussianND)
    RooFitResult *m1result = m1.lastMinuitFit();
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
-   double mean1[N];
-   double std1[N];
+   std::vector<double> mean1(N);
+   std::vector<double> std1(N);
    for (unsigned ix = 0; ix < N; ++ix) {
       {
          std::ostringstream os;

--- a/roofit/roofitcore/test/test_lib.h
+++ b/roofit/roofitcore/test/test_lib.h
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <memory>  // make_unique
+#include <vector>
 
 RooAbsPdf * generate_1D_gaussian_pdf(RooWorkspace &w)
 {
@@ -61,7 +62,7 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &w, unsigned int n, unsigned long N_ev
   RooArgSet obs_set;
 
   // create gaussian parameters
-  double mean[n], sigma[n];
+  std::vector<double> mean(n), sigma(n);
   for (unsigned ix = 0; ix < n; ++ix) {
     mean[ix] = RooRandom::randomGenerator()->Gaus(0, 2);
     sigma[ix] = 0.1 + abs(RooRandom::randomGenerator()->Gaus(0, 2));


### PR DESCRIPTION
This PR reactivates and fixes the test for RooGradMinimizerFcn (introduced in #8596).

The first commit provides a way for external gradient calculators to use previous gradient information (gradient itself, second derivatives, step size) to calculate the next gradient values. Simultaneously, it allows the external calculator to pass back (via the same arrays to keep the redesign as minimal as possible, in anticipation of planned dedicated Hessian support) the second derivative and step sizes, so they can also be reused in the next gradient calculation. All of this reuse was already going on in Numerical2PGradientCalculator, but external gradient calculators had no access to this data, because the FCNGradAdaptor and IMultiGradFunction had no support for passing it back and forth. The commit also implements use of this mechanism in ExternalInternalGradientCalculator and in RooGradMinimizerFcn.

The second commit reactivates the (already existing) test, and fixes it, because it turned out it had a small remaining bug. The bug was fixed by removing an unused parameter from `NumericalGradient::SetInitialGradient`, so that was two birds with one stone.