### PR TITLE
[ntuple] Add RNTupleModel::GetField + test

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -166,6 +166,7 @@ public:
       std::unique_ptr<RNTupleModel> collectionModel);
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
+   Detail::RFieldBase *GetField(std::string_view fieldName);
    REntry *GetDefaultEntry() { return fDefaultEntry.get(); }
    std::unique_ptr<REntry> CreateEntry();
    RNTupleVersion GetVersion() const { return RNTupleVersion(); }

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -359,6 +359,18 @@ TEST(RNTupleModel, CollectionFieldDescriptions)
    EXPECT_EQ(std::string("muons after basic selection"), muon_desc.GetFieldDescription());
 }
 
+TEST(RNTupleModel, GetField)
+{
+   auto m = RNTupleModel::Create();
+   m->MakeField<int>("x");
+   m->MakeField<CustomStruct>("cs");
+   EXPECT_EQ(m->GetField("x")->GetName(), "x");
+   EXPECT_EQ(m->GetField("x")->GetType(), "std::int32_t");
+   EXPECT_EQ(m->GetField("cs.v1")->GetName(), "v1");
+   EXPECT_EQ(m->GetField("cs.v1")->GetType(), "std::vector<float>");
+   EXPECT_EQ(m->GetField("nonexistent"), nullptr);
+}
+
 TEST(RNTuple, EmptyString)
 {
    // empty storage string


### PR DESCRIPTION
Before this commit, in order to retrieve a given field from the
RNTupleModel it was required to walk the tree of fields starting
from fFieldZero.
This commit adds a convenience method that takes a field name and
returns a pointer to RFieldBase (null if the field could not be found).
