### PR TITLE
[RF] Use RooAbsCollection::assign() in RooFit code

### DIFF
--- a/roofit/roofit/src/RooIntegralMorph.cxx
+++ b/roofit/roofit/src/RooIntegralMorph.cxx
@@ -197,7 +197,7 @@ void RooIntegralMorph::fillCacheObject(PdfCacheElem& cache) const
     RooArgSet alphaSet(alpha.arg()) ;
     coutP(Eval) << "RooIntegralMorph::fillCacheObject(" << GetName() << ") filling multi-dimensional cache" ;
     while(slIter->Next()) {
-      alphaSet = (*cache.hist()->get()) ;
+      alphaSet.assign(*cache.hist()->get()) ;
       TIterator* dIter = cache.hist()->sliceIterator((RooAbsArg&)x.arg(),RooArgSet(alpha.arg())) ;
       mcache.calculate(dIter) ;
       ccoutP(Eval) << "." << flush;

--- a/roofit/roofit/src/RooJeffreysPrior.cxx
+++ b/roofit/roofit/src/RooJeffreysPrior.cxx
@@ -125,7 +125,7 @@ Double_t RooJeffreysPrior::evaluate() const
 
   auto& cachedPdf = *cacheElm->_pdf;
   auto& pdfVars = *cacheElm->_pdfVariables;
-  pdfVars = _paramSet;
+  pdfVars.assign(_paramSet);
 
   std::unique_ptr<RooDataHist> data( cachedPdf.generateBinned(_obsSet,ExpectedData()) );
   std::unique_ptr<RooFitResult> res( cachedPdf.fitTo(*data, Save(),PrintLevel(-1),Minos(false),SumW2Error(false)) );

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -52,9 +52,9 @@ public:
   RooAbsCollection(const RooAbsCollection& other, const char *name="");
   RooAbsCollection& operator=(const RooAbsCollection& other);
 
-  void assign(const RooAbsCollection& other);
+  void assign(const RooAbsCollection& other) const;
   RooAbsCollection &assignValueOnly(const RooAbsCollection& other, bool forceIfSizeOne=false);
-  void assignFast(const RooAbsCollection& other, bool setValDirty=true) ;
+  void assignFast(const RooAbsCollection& other, bool setValDirty=true) const;
 
   // Move constructor
   RooAbsCollection(RooAbsCollection && other);

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -332,7 +332,7 @@ RooAbsCollection &RooAbsCollection::operator=(const RooAbsCollection& other)
 /// Sets the value, cache and constant attribute of any argument in our set
 /// that also appears in the other set.
 
-void RooAbsCollection::assign(const RooAbsCollection& other)
+void RooAbsCollection::assign(const RooAbsCollection& other) const
 {
   if (&other==this) return ;
 
@@ -380,7 +380,7 @@ RooAbsCollection &RooAbsCollection::assignValueOnly(const RooAbsCollection& othe
 /// Functional equivalent of assign() but assumes this and other collection
 /// have same layout. Also no attributes are copied
 
-void RooAbsCollection::assignFast(const RooAbsCollection& other, bool setValDirty)
+void RooAbsCollection::assignFast(const RooAbsCollection& other, bool setValDirty) const
 {
   if (&other==this) return ;
   assert(hasSameLayout(other));

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -235,7 +235,7 @@ RooDataSet *RooAbsGenContext::generate(Double_t nEvents, Bool_t skipInit, Bool_t
       const RooArgSet *subEvent= _prototype->get(actualProtoIdx);
       _nextProtoIndex++;
       if(0 != subEvent) {
-	*_theEvent= *subEvent;
+        _theEvent->assign(*subEvent);
       }
       else {
 	coutE(Generation) << ClassName() << "::" << GetName() << ":generate: cannot load event "

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1184,7 +1184,7 @@ int RooAbsPdf::calculateAsymptoticCorrectedCovMatrix(RooMinimizer &minimizer, Ro
    // Loop over data
    for (int j = 0; j < data.numEntries(); j++) {
       // Sets obs to current data point, this is where the pdf will be evaluated
-      obs = *data.get(j);
+      obs.assign(*data.get(j));
       // Determine first derivatives
       std::vector<double> diffs(floated.getSize(), 0.0);
       for (int k = 0; k < floated.getSize(); k++) {

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -2868,7 +2868,7 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
     RooDataSet* d = paramPdf->generate(errorParams,n) ;
     vector<RooCurve*> cvec ;
     for (int i=0 ; i<d->numEntries() ; i++) {
-      cloneParams = (*d->get(i)) ;
+      cloneParams.assign(*d->get(i)) ;
       RooLinkedList tmp2(plotArgList) ;
       cloneFunc->plotOn(frame,tmp2) ;
       cvec.push_back(frame->getCurve()) ;

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -205,7 +205,7 @@ const RooArgSet* RooCompositeDataStore::get(Int_t idx) const
       offset += iter->second->numEntries() ;
       continue ;
     }    
-    const_cast<RooCompositeDataStore*>(this)->_vars = (*iter->second->get(idx-offset)) ;
+    _vars.assign(*iter->second->get(idx-offset)) ;
 
     _indexCat->setIndex(iter->first) ;
     _curStore = iter->second ;
@@ -359,7 +359,7 @@ void RooCompositeDataStore::append(RooAbsDataStore& other)
 {
   Int_t nevt = other.numEntries() ;
   for (int i=0 ; i<nevt ; i++) {  
-    _vars = *other.get(i) ;
+    _vars.assign(*other.get(i)) ;
     fill() ;
   }
 }

--- a/roofit/roofitcore/src/RooConvGenContext.cxx
+++ b/roofit/roofitcore/src/RooConvGenContext.cxx
@@ -301,8 +301,8 @@ void RooConvGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
     Double_t convValSmeared = _cvPdf->getVal() + _cvModel->getVal() ;
     if (_cvOut->isValidReal(convValSmeared)) {
       // Smeared value in acceptance range, transfer values to output set
-      theEvent = *_modelVars ;
-      theEvent = *_pdfVars ;
+      theEvent.assign(*_modelVars) ;
+      theEvent.assign(*_pdfVars) ;
       _cvOut->setVal(convValSmeared) ;
       return ;
     }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -578,7 +578,7 @@ void RooDataHist::importDHistSet(const RooArgList& /*vars*/, RooCategory& indexC
 
     // Transfer contents
     for (Int_t i=0 ; i<dhist->numEntries() ; i++) {
-      _vars = *dhist->get(i) ;
+      _vars.assign(*dhist->get(i)) ;
       add(_vars,dhist->weight()*initWgt, pow(dhist->weightError(SumW2),2) ) ;
     }
 
@@ -1581,7 +1581,7 @@ Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, bo
   RooArgSet sliceOnlySet(sliceSet);
   sliceOnlySet.remove(sumSet,true,true) ;
 
-  _vars = sliceOnlySet;
+  _vars.assign(sliceOnlySet);
   std::vector<double> const * pbinv = nullptr;
 
   if(correctForBinSize && inverseBinCor) {
@@ -1627,7 +1627,7 @@ Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, bo
     }
   }
 
-  _vars = varSave ;
+  _vars.assign(varSave) ;
 
   return total;
 }
@@ -1660,7 +1660,7 @@ Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
   {
     RooArgSet sliceOnlySet(sliceSet);
     sliceOnlySet.remove(sumSet, true, true);
-    _vars = sliceOnlySet;
+    _vars.assign(sliceOnlySet);
   }
 
   // Calculate mask and reference plot bins for non-iterating variables,
@@ -1736,7 +1736,7 @@ Double_t RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
     total += getBinScale(ibin)*(get_wgt(ibin) * corr * corrPartial);
   }
 
-  _vars = varSave;
+  _vars.assign(varSave);
 
   return total;
 }
@@ -1930,7 +1930,7 @@ void RooDataHist::setAllWeights(Double_t value)
 TIterator* RooDataHist::sliceIterator(RooAbsArg& sliceArg, const RooArgSet& otherArgs) 
 {
   // Update to current position
-  _vars = otherArgs ;
+  _vars.assign(otherArgs) ;
   _curIndex = calcTreeIndex(_vars, true);
   
   RooAbsArg* intArg = _vars.find(sliceArg) ;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1158,7 +1158,7 @@ void RooDataSet::add(const RooArgSet& data, Double_t wgt, Double_t wgtError)
 
   const double oldW = _wgtVar ? _wgtVar->getVal() : 0.;
 
-  _varsNoWgt = data;
+  _varsNoWgt.assign(data);
 
   if (_wgtVar) {
     _wgtVar->setVal(wgt) ;
@@ -1210,7 +1210,7 @@ void RooDataSet::add(const RooArgSet& indata, Double_t inweight, Double_t weight
 
   const double oldW = _wgtVar ? _wgtVar->getVal() : 0.;
 
-  _varsNoWgt = indata;
+  _varsNoWgt.assign(indata);
   if (_wgtVar) {
     _wgtVar->setVal(inweight) ;
     _wgtVar->setAsymError(weightErrorLo,weightErrorHi) ;
@@ -1831,7 +1831,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
       } else {
         // Read single line
         Bool_t readError = variables.readFromStream(file,kTRUE,verbose) ;
-        data->_vars = variables ;
+        data->_vars.assign(variables) ;
 
         // Stop on read error
         if(!file.good()) {

--- a/roofit/roofitcore/src/RooFitLegacy/RooMinuit.cxx
+++ b/roofit/roofitcore/src/RooFitLegacy/RooMinuit.cxx
@@ -662,7 +662,7 @@ Bool_t RooMinuit::synchronize(Bool_t verbose)
   }
 
   // Update reference list
-  *_initConstParamList = *_constParamList ;
+  _initConstParamList->assign(*_constParamList) ;
 
 
   // Synchronize MINUIT with function state
@@ -995,7 +995,7 @@ RooPlot* RooMinuit::contour(RooRealVar& var1, RooRealVar& var2, Double_t n1, Dou
   gMinuit->SetErrorDef(errdef);
 
   // restore parameter values
-  *_floatParamList = *paramSave ;
+  _floatParamList->assign(*paramSave) ;
   delete paramSave ;
 
 

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -375,7 +375,7 @@ const RooArgList& RooFitResult::randomizePars() const
   }
   else {
     // reset to the final fit values
-    *_randomPars= *_finalPars;
+    _randomPars->assign(*_finalPars);
   }
 
   // create a vector of unit Gaussian variables

--- a/roofit/roofitcore/src/RooGenContext.cxx
+++ b/roofit/roofitcore/src/RooGenContext.cxx
@@ -427,7 +427,7 @@ void RooGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
       }
       arglv->randomize() ;
     }
-    theEvent = _uniformVars ;
+    theEvent.assign(_uniformVars) ;
   }
 
 }

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -197,7 +197,7 @@ Bool_t RooGenFitStudy::initialize()
 
 Bool_t RooGenFitStudy::execute() 
 { 
-  *_params = *_initParams ;
+  _params->assign(*_initParams) ;
   RooDataSet* data = _genPdf->generate(*_genSpec) ;
   RooFitResult* fr  = _fitPdf->fitTo(*data,RooFit::Save(kTRUE),(RooCmdArg&)*_fitOpts.At(0),(RooCmdArg&)*_fitOpts.At(1),(RooCmdArg&)*_fitOpts.At(2)) ;
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -495,12 +495,12 @@ Bool_t RooMCStudy::run(Bool_t doGenerate, Bool_t DoFit, Int_t nSamples, Int_t nE
       Int_t nEvt(nEvtPerSample) ;
 
       // Reset generator parameters to initial values
-      *_genParams = *_genInitParams ;
+      _genParams->assign(*_genInitParams) ;
 
       // If constraints are present, sample generator values from constraints
       if (_constrPdf) {
 	RooDataSet* tmp = _constrGenContext->generate(1) ;
-	*_genParams = *tmp->get() ;
+	_genParams->assign(*tmp->get()) ;
 	delete tmp ;
       }
 
@@ -737,7 +737,7 @@ Bool_t RooMCStudy::fit(Int_t nSamples, TList& dataSetList)
 
 void RooMCStudy::resetFitParams()
 {
-  *_fitParams = *_fitInitParams ;
+  _fitParams->assign(*_fitInitParams) ;
 }
 
 
@@ -885,7 +885,7 @@ Bool_t RooMCStudy::addFitResult(const RooFitResult& fr)
   }
   
   // Transfer contents of fit result to fitParams ;
-  *_fitParams = RooArgSet(fr.floatParsFinal()) ;
+  _fitParams->assign(RooArgSet(fr.floatParsFinal())) ;
   
   // If fit converged, store parameters and NLL
   Bool_t ok = (fr.status()==0) ;

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -819,7 +819,7 @@ RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
   _theFitter->Config().MinimizerOptions().SetErrorDef(errdef);
 
   // restore parameter values
-  *params = *paramSave ;
+  params->assign(*paramSave) ;
   delete paramSave ;
 
   return frame ;

--- a/roofit/roofitcore/src/RooProdGenContext.cxx
+++ b/roofit/roofitcore/src/RooProdGenContext.cxx
@@ -369,7 +369,7 @@ void RooProdGenContext::generateEvent(RooArgSet &theEvent, Int_t remaining)
 	arglv->randomize() ;
       }
     }
-    theEvent = _uniObs ;
+    theEvent.assign(_uniObs) ;
   }  
 
 }

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -170,7 +170,7 @@ Double_t RooProfileLL::evaluate() const
 
   // If requested set initial parameters to those corresponding to absolute minimum
   if (_startFromMin) {
-    const_cast<RooProfileLL&>(*this)._par = _paramAbsMin ;
+    _par.assign(_paramAbsMin) ;
   }
 
   _minimizer->zeroEvalCount() ;
@@ -279,7 +279,7 @@ void RooProfileLL::validateAbsMin() const
     }
 
     // Restore original parameter values
-    const_cast<RooSetProxy&>(_obs) = obsStart ;
+    _obs.assign(obsStart) ;
 
   }
 }

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -857,8 +857,8 @@ Double_t RooRealIntegral::evaluate() const
         }
         
         // Save current integral dependent values 
-        _saveInt = _intList ;
-        _saveSum = _sumList ;
+        _saveInt.assign(_intList) ;
+        _saveSum.assign(_sumList) ;
         
         // Evaluate sum/integral
         retVal = sum() ;
@@ -868,8 +868,8 @@ Double_t RooRealIntegral::evaluate() const
         setDirtyInhibit(origState) ;
         
         // Restore integral dependent values
-        _intList=_saveInt ;
-        _sumList=_saveSum ;
+        _intList.assign(_saveInt) ;
+        _sumList.assign(_saveSum) ;
         
         // Cache numeric integrals in >1d expensive object cache
         if ((_cacheNum && _intList.getSize()>0) || _intList.getSize()>=_cacheAllNDim) {

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1114,7 +1114,7 @@ RooDataSet* RooSimultaneous::generateSimGlobal(const RooArgSet& whatVars, Int_t 
       RooDataSet* tmp = pdftmp->generate(*globtmp,1) ;
 
       // Transfer values to output placeholder
-      *globClone = *tmp->get(0) ;
+      globClone->assign(*tmp->get(0)) ;
 
       // Cleanup
       delete globtmp ;

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -603,7 +603,7 @@ void RooTreeDataStore::loadValues(const RooAbsDataStore *ads, const RooFormulaVa
       continue ;
     }
 
-    _cachedVars = ((RooTreeDataStore*)ads)->_cachedVars ;
+    _cachedVars.assign(((RooTreeDataStore*)ads)->_cachedVars) ;
     fill() ;
   }
 
@@ -1012,12 +1012,12 @@ RooAbsDataStore* RooTreeDataStore::merge(const RooArgSet& allVars, list<RooAbsDa
   for (int i=0 ; i<nevt ; i++) {
 
     // Cope data from self
-    mergedStore->_vars = *get(i) ;
+    mergedStore->_vars.assign(*get(i)) ;
 
     // Copy variables from merge sets
     for (list<RooAbsDataStore*>::iterator iter = dstoreList.begin() ; iter!=dstoreList.end() ; ++iter) {
       const RooArgSet* partSet = (*iter)->get(i) ;
-      mergedStore->_vars = *partSet ;
+      mergedStore->_vars.assign(*partSet) ;
     }
 
     mergedStore->fill() ;
@@ -1035,7 +1035,7 @@ void RooTreeDataStore::append(RooAbsDataStore& other)
 {
   Int_t nevt = other.numEntries() ;
   for (int i=0 ; i<nevt ; i++) {
-    _vars = *other.get(i) ;
+    _vars.assign(*other.get(i)) ;
     if (_wgtVar) {
       _wgtVar->setVal(other.weight()) ;
     }

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -216,7 +216,7 @@ RooVectorDataStore::RooVectorDataStore(const RooTreeDataStore& other, const RooA
   reserve(other.numEntries());
   for (Int_t i=0 ; i<other.numEntries() ; i++) {
     other.get(i) ;
-    _varsww = other._varsww ;
+    _varsww.assign(other._varsww) ;
     fill() ;
   }
   TRACE_CREATE
@@ -833,12 +833,12 @@ RooAbsDataStore* RooVectorDataStore::merge(const RooArgSet& allVars, list<RooAbs
   for (int i=0 ; i<nevt ; i++) {
 
     // Copy data from self
-    mergedStore->_vars = *get(i) ;
+    mergedStore->_vars.assign(*get(i)) ;
       
     // Copy variables from merge sets
     for (list<RooAbsDataStore*>::iterator iter = dstoreList.begin() ; iter!=dstoreList.end() ; ++iter) {
       const RooArgSet* partSet = (*iter)->get(i) ;
-      mergedStore->_vars = *partSet ;
+      mergedStore->_vars.assign(*partSet) ;
     }
 
     mergedStore->fill() ;
@@ -870,7 +870,7 @@ void RooVectorDataStore::append(RooAbsDataStore& other)
   Int_t nevt = other.numEntries() ;
   reserve(nevt + numEntries());
   for (int i=0 ; i<nevt ; i++) {  
-    _vars = *other.get(i) ;
+    _vars.assign(*other.get(i)) ;
     if (_wgtVar) {
       _wgtVar->setVal(other.weight()) ;
     }

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1183,7 +1183,7 @@ Bool_t RooWorkspace::saveSnapshot(const char* name, const RooArgSet& params, Boo
   snapshot->setName(name) ;
 
   if (importValues) {
-    *snapshot = params ;
+    snapshot->assign(params) ;
   }
 
   RooArgSet* oldSnap = (RooArgSet*) _snapshots.FindObject(name) ;
@@ -1214,7 +1214,7 @@ Bool_t RooWorkspace::loadSnapshot(const char* name)
   }
 
   RooArgSet* actualParams = (RooArgSet*) _allOwnedNodes.selectCommon(*snap) ;
-  *actualParams = *snap ;
+  actualParams->assign(*snap) ;
   delete actualParams ;
 
   return kTRUE ;

--- a/roofit/roofitcore/test/testNaNPacker.cxx
+++ b/roofit/roofitcore/test/testNaNPacker.cxx
@@ -139,7 +139,7 @@ TEST(RooNaNPacker, FitParabola) {
   for (bool batchMode : std::initializer_list<bool>{true, false}) {
     SCOPED_TRACE(batchMode ? "in batch mode" : "in single-value mode");
 
-    params = evilValues;
+    params.assign(evilValues);
     std::unique_ptr<RooFitResult> fitResultOld( pdf.fitTo(*data,
         RooFit::RecoverFromUndefinedRegions(0.),
         RooFit::Save(),
@@ -148,7 +148,7 @@ TEST(RooNaNPacker, FitParabola) {
         RooFit::BatchMode(batchMode),
         RooFit::Minos()));
 
-    params = evilValues;
+    params.assign(evilValues);
     std::unique_ptr<RooFitResult> fitResultNew( pdf.fitTo(*data,
         RooFit::Save(),
         RooFit::PrintLevel(-1),
@@ -200,11 +200,11 @@ TEST(RooNaNPacker, FitAddPdf_DegenerateCoeff) {
   a2.setVal(0.7);
   params.snapshot(evilValues);
 
-  params = evilValues;
+  params.assign(evilValues);
 
   RooFitResult *fitResult1 = nullptr, *fitResult2 = nullptr;
   for (auto tryRecover : std::initializer_list<double>{0., 10.}) {
-    params = evilValues;
+    params.assign(evilValues);
 
     RooMinimizer::cleanup();
     RooMinimizer minim(*nll);
@@ -265,11 +265,11 @@ TEST(RooNaNPacker, Interface_RooAbsPdf_fitTo_RooRealSumPdf_DegenerateCoeff) {
   a2.setVal(0.7);
   params.snapshot(evilValues);
 
-  params = evilValues;
+  params.assign(evilValues);
 
   RooFitResult *fitResult1 = nullptr, *fitResult2 = nullptr;
   for (auto tryRecover : std::initializer_list<double>{0., 10.}) {
-    params = evilValues;
+    params.assign(evilValues);
 
     auto fitResult = pdf.fitTo(*data, RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1), RooFit::Save(), RooFit::RecoverFromUndefinedRegions(tryRecover));
     (tryRecover != 0. ? fitResult1 : fitResult2) = fitResult;

--- a/roofit/roostats/inc/RooStats/RooStatsUtils.h
+++ b/roofit/roostats/inc/RooStats/RooStatsUtils.h
@@ -63,7 +63,7 @@ namespace RooStats {
    Double_t AsimovSignificance(Double_t s, Double_t b, Double_t sigma_b = 0.0 ); 
 
    inline void SetParameters(const RooArgSet* desiredVals, RooArgSet* paramsToChange){
-      *paramsToChange=*desiredVals ;
+      paramsToChange->assign(*desiredVals) ;
    }
 
    inline void RemoveConstantParameters(RooArgSet* set){

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -241,7 +241,7 @@ bool AsymptoticCalculator::Initialize() const {
       // assume use current value of nuisance as nominal ones
       if (verbose >= 0)
          oocoutI((TObject*)0,InputArguments) << "AsymptoticCalculator: Asimovdata set will be generated using nominal (current) nuisance parameter values" << endl;
-      nominalParams = poiAlt; // set poi to alt value but keep nuisance at the nominal one
+      nominalParams.assign(poiAlt); // set poi to alt value but keep nuisance at the nominal one
       fAsimovData = MakeAsimovData( *GetNullModel(), nominalParams, fAsimovGlobObs);
    }
 
@@ -258,7 +258,7 @@ bool AsymptoticCalculator::Initialize() const {
       assert(globObs.getSize() == fAsimovGlobObs.getSize() );
       // store previous snapshot value
       globObs.snapshot(globObsSnapshot);
-      globObs = fAsimovGlobObs;
+      globObs.assign(fAsimovGlobObs);
    }
 
 
@@ -277,7 +277,7 @@ bool AsymptoticCalculator::Initialize() const {
    //poi->Print("v");
 
    // restore previous value
-   globObs = globObsSnapshot;
+   globObs.assign(globObsSnapshot);
 
    // restore number of bins
    if (prevBins > 0 && xobs) xobs->setBins(prevBins);
@@ -509,7 +509,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    }
 
    RooArgSet * allParams = nullPdf->getParameters(*GetData() );
-   *allParams = fBestFitParams;
+   allParams->assign(fBestFitParams);
    delete allParams;
 
    // set the one-side condition
@@ -606,7 +606,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       globObs.add(*GetNullModel()->GetGlobalObservables());
       // store previous snapshot value
       globObs.snapshot(globObsSnapshot);
-      globObs = fAsimovGlobObs;
+      globObs.assign(fAsimovGlobObs);
    }
 
 
@@ -664,7 +664,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
 
 
    // restore previous value of global observables
-   globObs = globObsSnapshot;
+   globObs.assign(globObsSnapshot);
 
    // now we compute p-values using the asymptotic formulae
    // described in the paper
@@ -1227,7 +1227,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
 
 
    RooArgSet  poi(*model.GetParametersOfInterest());
-   poi = paramValues;
+   poi.assign(paramValues);
    //RooRealVar *r = dynamic_cast<RooRealVar *>(poi.first());
    // set poi constant for conditional MLE
    // need to fit nuisance parameters at their conditional MLE value
@@ -1321,7 +1321,9 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
    RooStats::RemoveConstantParameters( allParams );
 
    // if a RooArgSet of poi is passed , different poi will be used for generating the Asimov data set
-   if (genPoiValues) *allParams = *genPoiValues;
+   if (genPoiValues) {
+    allParams->assign(*genPoiValues);
+   }
 
    // now do the actual generation of the AsimovData Set
    // no need to pass parameters values since we have set them before
@@ -1353,7 +1355,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
    // the nuisance parameter values could be set at their fitted value (the MLE)
    if (allParamValues.getSize() > 0) {
       RooArgSet *  allVars = model.GetPdf()->getVariables();
-      *allVars = allParamValues;
+      allVars->assign(allParamValues);
       delete allVars;
    }
 
@@ -1407,7 +1409,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       if (nuis.getSize() == 0) {
             oocoutW((TObject*)0,Generation) << "AsymptoticCalculator::MakeAsimovData: model does not have nuisance parameters but has global observables"
                                             << " set global observables to model values " << endl;
-            asimovGlobObs = gobs;
+            asimovGlobObs.assign(gobs);
             return asimov;
       }
 
@@ -1559,7 +1561,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       gobs.snapshot(asimovGlobObs);
 
       // revert global observables to the data value
-      gobs = snapGlobalObsData;
+      gobs.assign(snapGlobalObsData);
 
       if (verbose>0) {
          std::cout << "Generated Asimov data for global observables ";

--- a/roofit/roostats/src/DetailedOutputAggregator.cxx
+++ b/roofit/roostats/src/DetailedOutputAggregator.cxx
@@ -101,7 +101,7 @@ namespace RooStats {
             // we never committed, so by default all columns are expected to not exist
             RooAbsArg* var = v->createFundamental();
             assert(var != NULL);
-            (RooArgSet(*var)) = RooArgSet(*v);
+            RooArgSet(*var).assign(RooArgSet(*v));
             var->SetName(renamed);
             if (RooRealVar* rvar= dynamic_cast<RooRealVar*>(var)) {
                if (v->getAttribute("StoreError"))     var->setAttribute("StoreError");
@@ -114,7 +114,7 @@ namespace RooStats {
          if (RooAbsArg* var = fBuiltSet->find(renamed)) {
             // we already committed an argset once, so we expect all columns to already be in the set
             var->SetName(v->GetName());
-            (RooArgSet(*var)) = RooArgSet(*v); // copy values and errors
+            RooArgSet(*var).assign(RooArgSet(*v)); // copy values and errors
             var->SetName(renamed);
          }
       }

--- a/roofit/roostats/src/FeldmanCousins.cxx
+++ b/roofit/roostats/src/FeldmanCousins.cxx
@@ -183,7 +183,7 @@ void FeldmanCousins::CreateParameterPoints() const{
 
     for(Int_t i=0; i<parameterScan->numEntries(); ++i){
       // here's where we figure out the profiled value of nuisance parameters
-      *parameters = *parameterScan->get(i);
+      parameters->assign(*parameterScan->get(i));
       profile->getVal();
       profileConstructionPoints->add(*parameters);
     }

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -71,7 +71,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       allButNuisance.remove(*fNullModel->GetNuisanceParameters());
       if( fConditionalMLEsNull ) {
          oocoutI((TObject*)0,InputArguments) << "Using given conditional MLEs for Null." << endl;
-         *allParams = *fConditionalMLEsNull;
+         allParams->assign(*fConditionalMLEsNull);
          // LM: fConditionalMLEsNull must be nuisance parameters otherwise an error message will be printed
          allButNuisance.add( *fConditionalMLEsNull );
          if (fNullModel->GetNuisanceParameters()) {
@@ -183,7 +183,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       allButNuisance.remove(*fAltModel->GetNuisanceParameters());
       if( fConditionalMLEsAlt ) {
          oocoutI((TObject*)0,InputArguments) << "Using given conditional MLEs for Alt." << endl;
-         *allParams = *fConditionalMLEsAlt;
+         allParams->assign(*fConditionalMLEsAlt);
          // LM: fConditionalMLEsAlt must be nuisance parameters otherwise an error message will be printed
          allButNuisance.add( *fConditionalMLEsAlt );
          if (fAltModel->GetNuisanceParameters()) {

--- a/roofit/roostats/src/HybridCalculatorOriginal.cxx
+++ b/roofit/roostats/src/HybridCalculatorOriginal.cxx
@@ -514,13 +514,13 @@ void HybridCalculatorOriginal::RunToys(std::vector<double>& bVals, std::vector<d
          RooArgSet * sbparams = fSbModel->getParameters(*fObservables);
          if (sbparams) {
             assert(originalSbParams.getSize() == sbparams->getSize());
-            *sbparams = originalSbParams;
+            sbparams->assign(originalSbParams);
             delete sbparams;
          }
          RooArgSet * bparams = fBModel->getParameters(*fObservables);
          if (bparams) {
             assert(originalBParams.getSize() == bparams->getSize());
-            *bparams = originalBParams;
+            bparams->assign(originalBParams);
             delete bparams;
          }
       }

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -163,7 +163,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    // set parameters back ... in case the evaluation of the test statistic
    // modified something (e.g. a nuisance parameter that is not randomized
    // must be set here)
-   *bothParams = *saveAll;
+   bothParams->assign(*saveAll);
 
 
 
@@ -187,7 +187,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    }else samp_null = fTestStatSampler->GetSamplingDistribution(paramPointNull);
 
    // set parameters back
-   *bothParams = *saveAll;
+   bothParams->assign(*saveAll);
 
    // Generate sampling distribution for alternate
    SetupSampler(*fAltModel);
@@ -242,7 +242,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
       res->SetFitInfo( dset );
    }
 
-   *bothParams = *saveAll;
+   bothParams->assign(*saveAll);
    delete allTS;
    delete bothParams;
    delete saveAll;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -698,7 +698,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    const ModelConfig * sbModel = fCalculator0->GetNullModel();
    RooArgSet poi; poi.add(*sbModel->GetParametersOfInterest());
    // set poi to right values
-   poi = RooArgSet(*fScannedVariable);
+   poi.assign(RooArgSet(*fScannedVariable));
    const_cast<ModelConfig*>(sbModel)->SetSnapshot(poi);
 
    if (fVerbose > 0)
@@ -1096,10 +1096,10 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RebuildDistribution - background snapshot not existing"
                                           << " assume is for POI = 0" << std::endl;
       fScannedVariable->setVal(0);
-      paramPoint = RooArgSet(*fScannedVariable);
+      paramPoint.assign(RooArgSet(*fScannedVariable));
    }
    else
-      paramPoint = *poibkg;
+      paramPoint.assign(*poibkg);
    // generate data at bkg parameter point
 
    ToyMCSampler * toymcSampler = dynamic_cast<ToyMCSampler *>(fCalculator0->GetTestStatSampler() );
@@ -1205,7 +1205,9 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       sbModel->GetSnapshot()->Print("v");
 
       // reset parameters to initial values to be sure in case they are not reset
-      if (itoy> 0) *allParams = saveParams;
+      if (itoy> 0) {
+        allParams->assign(saveParams);
+      }
 
       // need to set th epdf to clear the cache in ToyMCSampler
       // pdf we must use is background pdf

--- a/roofit/roostats/src/LikelihoodIntervalPlot.cxx
+++ b/roofit/roostats/src/LikelihoodIntervalPlot.cxx
@@ -208,7 +208,7 @@ void LikelihoodIntervalPlot::Draw(const Option_t *options)
 
    // do a dummy evaluation around minimum to be sure profile has right minimum
    if (fInterval->GetBestFitParameters() ) {
-      *fParamsPlot = *fInterval->GetBestFitParameters();
+      fParamsPlot->assign(*fInterval->GetBestFitParameters());
       newProfile->getVal();
    }
 

--- a/roofit/roostats/src/NeymanConstruction.cxx
+++ b/roofit/roostats/src/NeymanConstruction.cxx
@@ -134,7 +134,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
     point = (RooArgSet*) fPointsToTest->get(i);//->clone("temp");
 
     // set parameters of interest to current point
-    *fPOI = *point;
+    fPOI->assign(*point);
 
     // set test stat sampler to use this point
     fTestStatSampler->SetParametersForTestStat(*fPOI);

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -112,7 +112,7 @@ Double_t RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type
        // make sure we set the variables attached to this nll
        RooArgSet* attachedSet = fNll->getVariables();
 
-       *attachedSet = paramsOfInterest;
+       attachedSet->assign(paramsOfInterest);
        RooArgSet* origAttachedSet = (RooArgSet*) attachedSet->snapshot();
 
        ///////////////////////////////////////////////////////////////////////
@@ -182,7 +182,7 @@ Double_t RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type
 
 
           //       cout <<" reestablish snapshot"<<endl;
-          *attachedSet = *snap;
+          attachedSet->assign(*snap);
 
 
           // set the POI to constant
@@ -273,7 +273,7 @@ Double_t RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type
 
 
        // need to restore the values ?
-       *attachedSet = *origAttachedSet;
+       attachedSet->assign(*origAttachedSet);
 
        delete attachedSet;
        delete origAttachedSet;

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -132,7 +132,7 @@ SPlot::SPlot():
 {
   RooArgList Args;
 
-  fSWeightVars = Args;
+  fSWeightVars.assign(Args);
 
   fSData = NULL;
 
@@ -145,7 +145,7 @@ SPlot::SPlot(const char* name, const char* title):
 {
   RooArgList Args;
 
-  fSWeightVars = Args;
+  fSWeightVars.assign(Args);
 
   fSData = NULL;
 
@@ -160,7 +160,7 @@ SPlot::SPlot(const char* name, const char* title, const RooDataSet &data):
 {
   RooArgList Args;
 
-  fSWeightVars = Args;
+  fSWeightVars.assign(Args);
 
   fSData = (RooDataSet*) &data;
 }

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -61,8 +61,8 @@ Double_t RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, Roo
 
    // make sure we set the variables attached to this nll
    RooArgSet* attachedSet = fNllNull->getVariables();
-   *attachedSet = *fNullParameters;
-   *attachedSet = nullPOI;
+   attachedSet->assign(*fNullParameters);
+   attachedSet->assign(nullPOI);
    double nullNLL = fNllNull->getVal();
 
    //std::cout << std::endl << "SLRTS: null params:" << std::endl;
@@ -86,7 +86,7 @@ Double_t RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, Roo
    }
    // make sure we set the variables attached to this nll
    attachedSet = fNllAlt->getVariables();
-   *attachedSet = *fAltParameters;
+   attachedSet->assign(*fAltParameters);
    double altNLL = fNllAlt->getVal();
 
    //std::cout << std::endl << "SLRTS: alt params:" << std::endl;

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -288,7 +288,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
    // assign input paramPoint
    RooArgSet* allVars = fPdf->getVariables();
-   *allVars = paramPoint;
+   allVars->assign(paramPoint);
 
 
    // create nuisance parameter points
@@ -334,13 +334,15 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    RooAbsData* data = NULL;
    if( fGenerateFromNull ) {
       //cout << "gen from null" << endl;
-      *allVars = *fNullSnapshots[fIndexGenDensity];
+      allVars->assign(*fNullSnapshots[fIndexGenDensity]);
       data = Generate(*fNullDensities[fIndexGenDensity], observables);
    }else{
       // need to be careful here not to overwrite the current state of the
       // nuisance parameters, ie they must not be part of the snapshot
       //cout << "gen from imp" << endl;
-      if(fImportanceSnapshots[fIndexGenDensity]) *allVars = *fImportanceSnapshots[fIndexGenDensity];
+      if(fImportanceSnapshots[fIndexGenDensity]) {
+        allVars->assign(*fImportanceSnapshots[fIndexGenDensity]);
+      }
       data = Generate(*fImportanceDensities[fIndexGenDensity], observables);
    }
    //cout << "data generated: " << data << endl;
@@ -360,7 +362,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       //oocoutI((TObject*)0,InputArguments) << "Setting variables to nullSnapshot["<<i<<"]"<<endl;
       //fNullSnapshots[i]->Print("v");
 
-      *allVars = *fNullSnapshots[i];
+      allVars->assign(*fNullSnapshots[i]);
       if( !fNullNLLs[i] ) {
          RooArgSet* allParams = fNullDensities[i]->getParameters(*data);
          fNullNLLs[i] = fNullDensities[i]->createNLL(*data, RooFit::CloneData(kFALSE), RooFit::Constrain(*allParams),
@@ -384,7 +386,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       //oocoutI((TObject*)0,InputArguments) << "Setting variables to impSnapshot["<<i<<"]"<<endl;
       //fImportanceSnapshots[i]->Print("v");
 
-      if( fImportanceSnapshots[i] ) *allVars = *fImportanceSnapshots[i];
+      if( fImportanceSnapshots[i] ) {
+        allVars->assign(*fImportanceSnapshots[i]);
+      }
       if( !fImpNLLs[i] ) {
          RooArgSet* allParams = fImportanceDensities[i]->getParameters(*data);
          fImpNLLs[i] = fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(kFALSE), RooFit::Constrain(*allParams),
@@ -421,7 +425,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
 
-   *allVars = *saveVars;
+   allVars->assign(*saveVars);
    delete allVars;
    delete saveVars;
 

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -73,7 +73,7 @@ void NuisanceParametersSampler::NextPoint(RooArgSet& nuisPoint, Double_t& weight
    }
 
    // get value
-   nuisPoint =  *fPoints->get(fIndex++);
+   nuisPoint.assign(*fPoints->get(fIndex++));
    weight = fPoints->weight();
 
    // check whether result will have any influence
@@ -275,7 +275,10 @@ const RooArgList* ToyMCSampler::EvaluateAllTestStatistics(RooAbsData& data, cons
         name.Append("_");
         detOutAgg.AppendArgSet(detOut, name);
       }
-      if (saveAll) *allVars = *saveAll;  // restore values, perhaps modified by fTestStatistics[i]->Evaluate()
+      if (saveAll) {
+        // restore values, perhaps modified by fTestStatistics[i]->Evaluate()
+        allVars->assign(*saveAll);
+      }
    }
    delete saveAll;
    delete allVars;
@@ -406,7 +409,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
       Double_t valueFirst = -999.0, weight = 1.0;
 
       // set variables to requested parameter point
-      *allVars = *saveAll; // important for example for SimpleLikelihoodRatioTestStat
+      allVars->assign(*saveAll); // important for example for SimpleLikelihoodRatioTestStat
 
       RooAbsData* toydata = GenerateToyData(*paramPoint, weight);
       if (i == 0 && !fPdf->canBeExtended() && dynamic_cast<RooSimultaneous*>(fPdf)) {
@@ -419,7 +422,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
             " extended. Otherwise, the number of events to generate per component cannot be determined." << std::endl;
       }
 
-      *allVars = *fParametersForTestStat;
+      allVars->assign(*fParametersForTestStat);
 
       const RooArgList* allTS = EvaluateAllTestStatistics(*toydata, *fParametersForTestStat, detOutAgg);
       if (allTS->getSize() > Int_t(fTestStatistics.size()))
@@ -445,7 +448,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
    }
 
    // clean up
-   *allVars = *saveAll;
+   allVars->assign(*saveAll);
    delete saveAll;
    delete allVars;
    delete paramPoint;
@@ -476,7 +479,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
          if (!_allVars) {
             _allVars.reset(pdf.getVariables());
          }
-         *_allVars = *values;
+         _allVars->assign(*values);
          delete one;
 
       } else {
@@ -499,7 +502,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
          // Assign generated values to the observables in _obsList
          for (unsigned int i = 0; i < _pdfList.size(); ++i) {
            std::unique_ptr<RooDataSet> tmp( _pdfList[i]->generate(*_gsList[i]) );
-           *_obsList[i] = *tmp->get(0);
+           _obsList[i]->assign(*tmp->get(0));
          }
       }
 
@@ -510,7 +513,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
       RooDataSet* one = pdf.generateSimGlobal( *fGlobalObservables, 1 );
       const RooArgSet *values = one->get(0);
       RooArgSet* allVars = pdf.getVariables();
-      *allVars = *values;
+      allVars->assign(*values);
       delete allVars;
       delete one;
 
@@ -533,7 +536,7 @@ RooAbsData* ToyMCSampler::GenerateToyData(RooArgSet& paramPoint, double& weight,
 
    // assign input paramPoint
    RooArgSet* allVars = fPdf->getVariables();
-   *allVars = paramPoint;
+   allVars->assign(paramPoint);
 
 
    // create nuisance parameter points
@@ -578,7 +581,7 @@ RooAbsData* ToyMCSampler::GenerateToyData(RooArgSet& paramPoint, double& weight,
 
    // We generated the data with the randomized nuisance parameter (if hybrid)
    // but now we are setting the nuisance parameters back to where they were.
-   *allVars = *saveVars;
+   allVars->assign(*saveVars);
    delete allVars;
    delete saveVars;
 

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -409,8 +409,8 @@ private:
     float fPDF1value, fPDF2value;
     for(Int_t i = 0; i < pSamplingPoints->numEntries(); ++i)
     {
-      *pVars1 = *pSamplingPoints->get(i);
-      *pVars2 = *pSamplingPoints->get(i);
+      pVars1->assign(*pSamplingPoints->get(i));
+      pVars2->assign(*pSamplingPoints->get(i));
 
       fPDF1value = rPDF1.getVal();
       fPDF2value = rPDF2.getVal();
@@ -444,7 +444,7 @@ private:
       return kFALSE;
 
     // check fit result to test data
-    *pVars1 = *pVars2;
+    pVars1->assign(*pVars2);
 
     // do the fit
     std::string minimizerType = "Minuit2";


### PR DESCRIPTION
After the `RooAbsCollection::assign()` function was introduced as a
better alternative to `RooAbsCollection::operator=()` in commit
4fff188, this commit now makes use of it in all the RooFit code.

