### PR TITLE
[ntuple] Overhaul tuning and default settings when writing

### DIFF
--- a/tree/ntuple/CMakeLists.txt
+++ b/tree/ntuple/CMakeLists.txt
@@ -56,6 +56,7 @@ SOURCES
   v7/src/RNTupleMerger.cxx
   v7/src/RNTupleMetrics.cxx
   v7/src/RNTupleModel.cxx
+  v7/src/RNTupleOptions.cxx
   v7/src/RNTupleUtil.cxx
   v7/src/RPage.cxx
   v7/src/RPageAllocator.cxx

--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -43,4 +43,4 @@ If a column has enough elements to fill at least half a page, there is a mechani
 writing uses two page buffers in turns and flushes the previous buffer only once the next buffer is at least at 50%.
 If the cluster gets flushed with an undersized tail page,
 the small page is appended to the previous page before flushing.
-Therefore, tail pages sizes are between [0.5 * target size .. 1.5 * target size].
+Therefore, tail pages sizes are between `[0.5 * target size .. 1.5 * target size]`.

--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -10,7 +10,7 @@ The default can be changed by the `RNTupleWriteOptions`.
 The default should work well in the majority of cases.
 In general, larger clusters provide room for more and larger pages and should improve compression ratio and speed.
 However, clusters also need to be buffered during write and (partially) during read,
-so larger cluster increase the memory footprint.
+so larger clusters increase the memory footprint.
 
 A second option in `RNTupleWriteOptions` specifies the maximum uncompressed cluster size.
 The default is 512MiB.
@@ -20,7 +20,7 @@ Given the two settings, writing works as follows:
 when the current cluster is larger than the maximum uncompressed size, it will be flushed unconditionally.
 When the current cluster size reaches the estimate for the compressed cluster size, it will be flushed, too.
 The estimated compression ratio for the first cluster is 0.5 if compression is used, and 1 otherwise.
-The following clusters use the compression ratio of the last cluster as estimate.
+The following clusters use the average compression ratio of all so-far written clusters as an estimate.
 See the notes below on a discussion of this approximation.
 
 
@@ -53,8 +53,9 @@ Notes
 Approximation of the compressed cluster size
 --------------------------------------------
 
-The estimator for the compressed cluster size uses the compression factor of the previously written cluster.
-This has been choosen as a simple, yet (expectedly) accurate enough estimator.
+The estimator for the compressed cluster size uses the average compression factor
+of the so far written clusters.
+This has been choosen as a simple, yet expectedly accurate enough estimator (to be validated).
 The following alternative strategies were discussed:
 
   - The average compression factor of all so-far written pages.
@@ -64,8 +65,10 @@ The following alternative strategies were discussed:
     e.g. ones that are caused by changing experimental conditions during data taking
 
   - The average over a window of the last $k$ clusters, possibly with exponential smoothing.
-    More accurate than just the last cluster but also more code to implement.
-    Could be a viable option if cluster compression ratios turn out to change significantly.
+    More code compared to the average compression factor or all so-far written clusters.
+    It would be faster in adjusting to systematic changes in the data set,
+    e.g. ones that are caused by changing experimental conditions during data taking.
+    Could be a viable option if cluster compression ratios turn out to change significantly in a single file.
 
   - Calculate the cluster compression ratio from column-based individual estimators.
     More complex to implement and to recalculate the estimator on every fill,

--- a/tree/ntuple/v7/doc/tuning.md
+++ b/tree/ntuple/v7/doc/tuning.md
@@ -1,0 +1,46 @@
+Cluster Sizes
+=============
+
+A cluster contains all the data of a given event range.
+As clusters are usually compressed and tied to event boundaries, an exact size cannot be enforced.
+Instead, RNTuple uses a *target size* for the compressed data as a guideline for when to flush a cluster.
+
+The default cluster target size is 50MB of compressed data.
+The default can be changed by the `RNTupleWriteOptions`.
+The default should work well in the majority of cases.
+In general, larger clusters provide room for more and larger pages and should improve compression ratio and speed.
+However, clusters also need to be buffered during write and (partially) during read,
+so larger cluster increase the memory footprint.
+
+A second option in `RNTupleWriteOptions` specifies the maximum uncompressed cluster size.
+The default is 512MiB.
+This setting acts as an "emergency break" and should prevent very compressible clusters from growing too large.
+
+Given the two settings, writing works as follows:
+when the current cluster is larger than the maximum uncompressed size, it will be flushed unconditionally.
+When the current cluster size reaches the estimate for the compressed cluster size, it will be flushed, too.
+The estimated compression ratio for the first cluster is 0.5 if compression is used, and 1 otherwise.
+The following clusters use the compression ratio of the last cluster as estimate.
+
+
+Page Sizes
+==========
+
+Pages contain consecutive elements of a certain columns.
+They are the unit of compression and of addressability on storage.
+RNTuple uses a *target size* for the uncompressed data as a guideline for when to flush a page.
+
+The default page target size is 64KiB.
+The default can be changed by the `RNTupleWriteOptions`.
+In general, larger pages give better compression ratios; smaller pages reduce the memory footprint.
+When reading, every active column requires at least one page buffer.
+For the number of read requests, the page size does not matter
+because pages of the same column are written consecutively and therefore read in one go.
+
+Given the target size, writing works as follows:
+Pages are filled until the target size and then flushed.
+If a column has enough elements to fill at least half a page, there is a mechanism to prevent undersized tail pages:
+writing uses two page buffers in turns and flushes the previous buffer only once the next buffer is at least at 50%.
+If the cluster gets flushed with an undersized tail page,
+the small page is appended to the previous page before flushing.
+Therefore, tail pages sizes are between [0.5 * target size .. 1.5 * target size].

--- a/tree/ntuple/v7/doc/validation.md
+++ b/tree/ntuple/v7/doc/validation.md
@@ -1,0 +1,13 @@
+RNTuple Format and API Validation
+=================================
+
+This document is a stub.
+It is meant to be edited during the RNTuple development phase until its transition into production.
+The document should collect observables that need to be tested and verified
+during the large-scale validation of RNTuple (we foresee test with petabyte-scale of volume and >10^5 files).
+
+Checks
+------
+
+- Automatic sizing of cluster and page sizes:
+  check page size and cluster size histograms

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -89,8 +89,7 @@ public:
    void Connect(DescriptorId_t fieldId, RPageStorage *pageStorage);
 
    void Append(const RColumnElementBase &element) {
-      void *dst = fHeadPage[fHeadPageIdx].TryGrow(1);
-      R__ASSERT(dst != nullptr);
+      void *dst = fHeadPage[fHeadPageIdx].GrowUnchecked(1);
       if (fHeadPage[fHeadPageIdx].GetNElements() == fApproxNElementsPerPage / 2) {
          // Current page is at 50% fill level, we can now commit the previously used page
          auto otherIdx = 1 - fHeadPageIdx;
@@ -125,8 +124,7 @@ public:
             fPageSink->CommitPage(fHandleSink, fHeadPage[otherIdx]);
       }
 
-      void *dst = fHeadPage[fHeadPageIdx].TryGrow(count);
-      R__ASSERT(dst != nullptr);
+      void *dst = fHeadPage[fHeadPageIdx].GrowUnchecked(count);
       elemArray.WriteTo(dst, count);
       fNElements += count;
 

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -60,7 +60,9 @@ private:
    RPage fHeadPage[2];
    /// Index of the current head page
    int fHeadPageIdx = 0;
-   /// For writing, the targeted page size as given by the write options
+   /// For writing, the targeted page size as given by the write options.
+   /// We ensure this value to be >= 2 in Connect() so that we have meaningful
+   /// "page full" and "page half full" events when writing the page.
    std::uint32_t fApproxNElementsPerPage = 0;
    /// The number of elements written resp. available in the column
    NTupleSize_t fNElements = 0;

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -109,6 +109,7 @@ public:
 
    void AppendV(const RColumnElementBase &elemArray, std::size_t count) {
       if (fHeadPage[fHeadPageIdx].GetNElements() + count > fApproxNElementsPerPage) {
+         // TODO(jblomer): use (fewer) calls to AppendV to write the data page-by-page
          for (unsigned i = 0; i < count; ++i) {
             Append(RColumnElementBase(elemArray, i));
          }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -102,7 +102,7 @@ public:
 
       if (fHeadPage[fHeadPageIdx].GetNElements() == fApproxNElementsPerPage) {
          // We are at 100% fill level, switch to the other head page
-         fHeadPageIdx = (fHeadPageIdx + 1) % 2;
+         fHeadPageIdx = 1 - fHeadPageIdx;
          fHeadPage[fHeadPageIdx].Reset(fNElements);
       }
    }
@@ -120,7 +120,7 @@ public:
           (fHeadPage[fHeadPageIdx].GetNElements() + count >= fApproxNElementsPerPage / 2))
       {
          // Current page jumps over 50% fill level, we can now commit the previously used page
-         auto otherIdx = (fHeadPageIdx + 1) % 2;
+         auto otherIdx = 1 - fHeadPageIdx;
          if (fHeadPage[otherIdx].GetNElements())
             fPageSink->CommitPage(fHandleSink, fHeadPage[otherIdx]);
       }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -77,7 +77,7 @@ private:
 
    /// Used in Append() and AppendV() to switch pages when the main page reached the target size
    /// The other page has been flushed when the main page reached 50%.
-   void SwapHeadPages() {
+   void SwapWritePages() {
       fWritePageIdx = 1 - fWritePageIdx; // == (fWritePageIdx + 1) % 2
       R__ASSERT(fWritePage[fWritePageIdx].IsEmpty());
       fWritePage[fWritePageIdx].Reset(fNElements);
@@ -90,7 +90,7 @@ private:
          return;
       fPageSink->CommitPage(fHandleSink, fWritePage[otherIdx]);
       // Mark the page as flushed; the rangeFirst is zero for now but will be reset to
-      // fNElements in SwapHeadPages() when the pages swap
+      // fNElements in SwapWritePages() when the pages swap
       fWritePage[otherIdx].Reset(0);
    }
 
@@ -120,7 +120,7 @@ public:
       fNElements++;
 
       if (fWritePage[fWritePageIdx].GetNElements() == fApproxNElementsPerPage)
-         SwapHeadPages();
+         SwapWritePages();
    }
 
    void AppendV(const RColumnElementBase &elemArray, std::size_t count) {
@@ -149,7 +149,7 @@ public:
 
       // Note that by the very first check, we cannot have filled more than fApproxNElementsPerPage elements
       if (fWritePage[fWritePageIdx].GetNElements() == fApproxNElementsPerPage)
-         SwapHeadPages();
+         SwapWritePages();
    }
 
    void Read(const NTupleSize_t globalIndex, RColumnElementBase *element) {

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -78,7 +78,7 @@ private:
    /// Used in Append() and AppendV() to switch pages when the main page reached the target size
    /// The other page has been flushed when the main page reached 50%.
    void SwapHeadPages() {
-      fHeadPageIdx = 1 - fHeadPageIdx;
+      fHeadPageIdx = 1 - fHeadPageIdx; // == (fHeadPageIdx + 1) % 2
       R__ASSERT(fHeadPage[fHeadPageIdx].IsEmpty());
       fHeadPage[fHeadPageIdx].Reset(fNElements);
    }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -93,7 +93,7 @@ public:
       R__ASSERT(dst != nullptr);
       if (fHeadPage[fHeadPageIdx].GetNElements() == fApproxNElementsPerPage / 2) {
          // Current page is at 50% fill level, we can now commit the previously used page
-         auto otherIdx = (fHeadPageIdx + 1) % 2;
+         auto otherIdx = 1 - fHeadPageIdx;
          if (fHeadPage[otherIdx].GetNElements())
             fPageSink->CommitPage(fHandleSink, fHeadPage[otherIdx]);
       }

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -55,10 +55,10 @@ private:
    /// A set of open pages into which new elements are being written. The pages are used
    /// in rotation. They are 50% bigger than the target size given by the write options.
    /// The current page is filled until the target size, but it is only committed once the other
-   /// head page is filled at least 50%. If a flush occurs earlier, a slightly oversized, single
+   /// write page is filled at least 50%. If a flush occurs earlier, a slightly oversized, single
    /// page will be committed.
    RPage fWritePage[2];
-   /// Index of the current head page
+   /// Index of the current write page
    int fWritePageIdx = 0;
    /// For writing, the targeted number of elements, given by `fApproxNElementsPerPage` (in the write options) and the element size.
    /// We ensure this value to be >= 2 in Connect() so that we have meaningful
@@ -83,8 +83,8 @@ private:
       fWritePage[fWritePageIdx].Reset(fNElements);
    }
 
-   /// When the main head page surpasses the 50% fill level, the (full) shadow head page gets flushed
-   void FlushShadowHeadPage() {
+   /// When the main write page surpasses the 50% fill level, the (full) shadow write page gets flushed
+   void FlushShadowWritePage() {
       auto otherIdx = 1 - fWritePageIdx;
       if (fWritePage[otherIdx].IsEmpty())
          return;
@@ -113,7 +113,7 @@ public:
       void *dst = fWritePage[fWritePageIdx].GrowUnchecked(1);
 
       if (fWritePage[fWritePageIdx].GetNElements() == fApproxNElementsPerPage / 2) {
-         FlushShadowHeadPage();
+         FlushShadowWritePage();
       }
 
       element.WriteTo(dst, 1);
@@ -141,7 +141,7 @@ public:
       if ((fWritePage[fWritePageIdx].GetNElements() <= fApproxNElementsPerPage / 2) &&
           (fWritePage[fWritePageIdx].GetNElements() + count > fApproxNElementsPerPage / 2))
       {
-         FlushShadowHeadPage();
+         FlushShadowWritePage();
       }
 
       elemArray.WriteTo(dst, count);

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -60,7 +60,7 @@ private:
    RPage fHeadPage[2];
    /// Index of the current head page
    int fHeadPageIdx = 0;
-   /// For writing, the targeted page size as given by the write options.
+   /// For writing, the targeted number of elements, given by `fApproxNElementsPerPage` (in the write options) and the element size.
    /// We ensure this value to be >= 2 in Connect() so that we have meaningful
    /// "page full" and "page half full" events when writing the page.
    std::uint32_t fApproxNElementsPerPage = 0;

--- a/tree/ntuple/v7/inc/ROOT/RColumn.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RColumn.hxx
@@ -55,7 +55,7 @@ private:
    /// A set of open pages into which new elements are being written. The pages are used
    /// in rotation. They are 50% bigger than the target size given by the write options.
    /// The current page is filled until the target size, but it is only committed once the other
-   /// head page is filled at least 50%. If a flush occurs earlier, a slightly oversize, single
+   /// head page is filled at least 50%. If a flush occurs earlier, a slightly oversized, single
    /// page will be committed.
    RPage fHeadPage[2];
    /// Index of the current head page

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1375,7 +1375,7 @@ protected:
       Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
       fNWritten += count;
       fColumns[0]->Append(elemIndex);
-      return nbytes + sizeof(ClusterSize_t);
+      return nbytes + sizeof(elemIndex);
    }
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final {
       auto typedValue = value->Get<ContainerT>();
@@ -1469,7 +1469,7 @@ protected:
       Detail::RColumnElement<ClusterSize_t, EColumnType::kIndex> elemIndex(&fNWritten);
       fNWritten += count;
       fColumns[0]->Append(elemIndex);
-      return count + sizeof(ClusterSize_t);
+      return count + sizeof(elemIndex);
    }
    void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final {
       auto typedValue = value->Get<ContainerT>();

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -386,7 +386,8 @@ public:
          value.GetField()->Append(value);
       }
       fNEntries++;
-      if ((fNEntries % fSink->GetWriteOptions().GetNEntriesPerCluster()) == 0)
+      // FIXME(jblomer)
+      if ((fNEntries % 64000/* fSink->GetWriteOptions().GetNEntriesPerCluster() */) == 0)
          CommitCluster();
    }
    /// Ensure that the data from the so far seen Fill calls has been written to storage

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -361,6 +361,11 @@ private:
    NTupleSize_t fNEntries = 0;
    /// Keeps track of the number of bytes written into the current cluster
    std::size_t fUnzippedClusterSize = 0;
+   /// The total number of bytes written to storage (i.e., after compression)
+   std::uint64_t fNBytesCommitted = 0;
+   /// The total number of bytes filled into all the so far committed clusters,
+   /// i.e. the uncompressed size of the written clusters
+   std::uint64_t fNBytesFilled = 0;
    /// Limit for committing cluster no matter the other tunables
    std::size_t fMaxUnzippedClusterSize;
    /// Estimator of uncompressed cluster size, taking into account the estimated compression ratio

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -363,8 +363,8 @@ private:
    std::size_t fUnzippedClusterSize = 0;
    /// Limit for committing cluster no matter the other tunables
    std::size_t fMaxUnzippedClusterSize;
-   /// Estimator of minimum uncompressed cluster size, taking into account the estimated compression ratio
-   NTupleSize_t fMinUnzippedClusterSizeEst;
+   /// Estimator of uncompressed cluster size, taking into account the estimated compression ratio
+   NTupleSize_t fUnzippedClusterSizeEst;
 
 public:
    /// Throws an exception if the model is null.
@@ -392,7 +392,7 @@ public:
          fUnzippedClusterSize += value.GetField()->Append(value);
       }
       fNEntries++;
-      if ((fUnzippedClusterSize >= fMaxUnzippedClusterSize) || (fUnzippedClusterSize >= fMinUnzippedClusterSizeEst))
+      if ((fUnzippedClusterSize >= fMaxUnzippedClusterSize) || (fUnzippedClusterSize >= fUnzippedClusterSizeEst))
          CommitCluster();
    }
    /// Ensure that the data from the so far seen Fill calls has been written to storage

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -285,6 +285,7 @@ public:
    const RPageRange &GetPageRange(DescriptorId_t columnId) const { return fPageRanges.at(columnId); }
    bool ContainsColumn(DescriptorId_t columnId) const;
    std::unordered_set<DescriptorId_t> GetColumnIds() const;
+   std::uint64_t GetBytesOnStorage() const;
 };
 
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -52,6 +52,9 @@ class RNTupleWriteOptions {
    std::size_t fMinZippedClusterSize = 64 * 1000 * 1000;
    /// Approximation of the max compressed cluster size
    std::size_t fMaxZippedClusterSize = 128 * 1000 * 1000;
+   /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
+   /// on how large the I/O buffer can grow during writing.
+   std::size_t fMaxUnzippedClusterSize = 512 * 1000 * 1000;
    /// Should be just large enough so that the compression ratio does not benefit much more from larger pages
    std::size_t fMaxUnzippedPageSize = 64 * 1024;
    bool fUseBufferedWrite = true;
@@ -75,6 +78,9 @@ public:
 
    std::size_t GetMaxZippedClusterSize() const { return fMaxZippedClusterSize; }
    void SetMaxZippedClusterSize(std::size_t val) { fMaxZippedClusterSize = val; }
+
+   std::size_t GetMaxUnzippedClusterSize() const { return fMaxUnzippedClusterSize; }
+   void SetMaxUnzippedClusterSize(std::size_t val) { fMaxUnzippedClusterSize = val; }
 
    std::size_t GetMaxUnzippedPageSize() const { return fMaxUnzippedPageSize; }
    void SetMaxUnzippedPageSize(std::size_t val) {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -49,10 +49,10 @@ class RNTupleWriteOptions {
    int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
    ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
    /// Approximation of the target compressed cluster size
-   std::size_t fApproxZippedClusterSize = 64 * 1000 * 1000;
+   std::size_t fApproxZippedClusterSize = 50 * 1000 * 1000;
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
    /// on how large the I/O buffer can grow during writing.
-   std::size_t fMaxUnzippedClusterSize = 512 * 1000 * 1000;
+   std::size_t fMaxUnzippedClusterSize = 512 * 1024 * 1024;
    /// Should be just large enough so that the compression ratio does not benefit much more from larger pages
    std::size_t fMaxUnzippedPageSize = 64 * 1024;
    bool fUseBufferedWrite = true;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -20,6 +20,8 @@
 #include <ROOT/RError.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
+#include <memory>
+
 namespace ROOT {
 namespace Experimental {
 
@@ -62,30 +64,25 @@ class RNTupleWriteOptions {
 
 public:
    virtual ~RNTupleWriteOptions() = default;
-   virtual std::unique_ptr<RNTupleWriteOptions> Clone() const
-   { return std::make_unique<RNTupleWriteOptions>(*this); }
+   virtual std::unique_ptr<RNTupleWriteOptions> Clone() const;
 
    int GetCompression() const { return fCompression; }
    void SetCompression(int val) { fCompression = val; }
    void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {
-     fCompression = CompressionSettings(algorithm, compressionLevel);
+      fCompression = CompressionSettings(algorithm, compressionLevel);
    }
 
    ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
    void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }
 
    std::size_t GetApproxZippedClusterSize() const { return fApproxZippedClusterSize; }
-   void SetApproxZippedClusterSize(std::size_t val) { fApproxZippedClusterSize = val; }
+   void SetApproxZippedClusterSize(std::size_t val);
 
    std::size_t GetMaxUnzippedClusterSize() const { return fMaxUnzippedClusterSize; }
-   void SetMaxUnzippedClusterSize(std::size_t val) { fMaxUnzippedClusterSize = val; }
+   void SetMaxUnzippedClusterSize(std::size_t val);
 
    std::size_t GetApproxUnzippedPageSize() const { return fApproxUnzippedPageSize; }
-   void SetApproxUnzippedPageSize(std::size_t val) {
-      if (val < 64)
-         throw RException(R__FAIL("page size too small"));
-      fApproxUnzippedPageSize = val;
-   }
+   void SetApproxUnzippedPageSize(std::size_t val);
 
    bool GetUseBufferedWrite() const { return fUseBufferedWrite; }
    void SetUseBufferedWrite(bool val) { fUseBufferedWrite = val; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -57,7 +57,7 @@ class RNTupleWriteOptions {
    /// Should be just large enough so that the compression ratio does not benefit much more from larger pages.
    /// Unless the cluster is too small to contain a sufficiently large page, pages are
    /// fApproxUnzippedPageSize in size and tail pages (the last page in a cluster) is between
-   /// fApproxUnzippedPageSize/2 and fApproxUnzippedPageSize * 2 in size.
+   /// fApproxUnzippedPageSize/2 and fApproxUnzippedPageSize * 1.5 in size.
    std::size_t fApproxUnzippedPageSize = 64 * 1024;
    bool fUseBufferedWrite = true;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -48,10 +48,8 @@ All page sink classes need to support the common options.
 class RNTupleWriteOptions {
    int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
    ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
-   /// Approximation of the minimum compressed cluster size
-   std::size_t fMinZippedClusterSize = 64 * 1000 * 1000;
-   /// Approximation of the max compressed cluster size
-   std::size_t fMaxZippedClusterSize = 128 * 1000 * 1000;
+   /// Approximation of the target compressed cluster size
+   std::size_t fApproxZippedClusterSize = 64 * 1000 * 1000;
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
    /// on how large the I/O buffer can grow during writing.
    std::size_t fMaxUnzippedClusterSize = 512 * 1000 * 1000;
@@ -73,11 +71,8 @@ public:
    ENTupleContainerFormat GetContainerFormat() const { return fContainerFormat; }
    void SetContainerFormat(ENTupleContainerFormat val) { fContainerFormat = val; }
 
-   std::size_t GetMinZippedClusterSize() const { return fMinZippedClusterSize; }
-   void SetMinZippedClusterSize(std::size_t val) { fMinZippedClusterSize = val; }
-
-   std::size_t GetMaxZippedClusterSize() const { return fMaxZippedClusterSize; }
-   void SetMaxZippedClusterSize(std::size_t val) { fMaxZippedClusterSize = val; }
+   std::size_t GetApproxZippedClusterSize() const { return fApproxZippedClusterSize; }
+   void SetApproxZippedClusterSize(std::size_t val) { fApproxZippedClusterSize = val; }
 
    std::size_t GetMaxUnzippedClusterSize() const { return fMaxUnzippedClusterSize; }
    void SetMaxUnzippedClusterSize(std::size_t val) { fMaxUnzippedClusterSize = val; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -53,8 +53,11 @@ class RNTupleWriteOptions {
    /// Memory limit for committing a cluster: with very high compression ratio, we need a limit
    /// on how large the I/O buffer can grow during writing.
    std::size_t fMaxUnzippedClusterSize = 512 * 1024 * 1024;
-   /// Should be just large enough so that the compression ratio does not benefit much more from larger pages
-   std::size_t fMaxUnzippedPageSize = 64 * 1024;
+   /// Should be just large enough so that the compression ratio does not benefit much more from larger pages.
+   /// Unless the cluster is too small to contain a sufficiently large page, pages are
+   /// fApproxUnzippedPageSize in size and tail pages (the last page in a cluster) is between
+   /// fApproxUnzippedPageSize/2 and fApproxUnzippedPageSize * 2 in size.
+   std::size_t fApproxUnzippedPageSize = 64 * 1024;
    bool fUseBufferedWrite = true;
 
 public:
@@ -77,11 +80,11 @@ public:
    std::size_t GetMaxUnzippedClusterSize() const { return fMaxUnzippedClusterSize; }
    void SetMaxUnzippedClusterSize(std::size_t val) { fMaxUnzippedClusterSize = val; }
 
-   std::size_t GetMaxUnzippedPageSize() const { return fMaxUnzippedPageSize; }
-   void SetMaxUnzippedPageSize(std::size_t val) {
+   std::size_t GetApproxUnzippedPageSize() const { return fApproxUnzippedPageSize; }
+   void SetApproxUnzippedPageSize(std::size_t val) {
       if (val < 64)
          throw RException(R__FAIL("page size too small"));
-      fMaxUnzippedPageSize = val;
+      fApproxUnzippedPageSize = val;
    }
 
    bool GetUseBufferedWrite() const { return fUseBufferedWrite; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -17,7 +17,6 @@
 #define ROOT7_RNTupleOptions
 
 #include <Compression.h>
-#include <ROOT/RError.hxx>
 #include <ROOT/RNTupleUtil.hxx>
 
 #include <memory>

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -104,7 +104,7 @@ public:
 
    void* GetBuffer() const { return fBuffer; }
    /// Called during writing: returns a pointer after the last element and increases the element counter
-   /// in anticpation of the caller filling nElements in the page. It is the responsibility of the caller
+   /// in anticipation of the caller filling nElements in the page. It is the responsibility of the caller
    /// to prevent page overflows, i.e. that fNElements + nElements <= fMaxElements
    void* GrowUnchecked(ClusterSize_t::ValueType nElements) {
       auto offset = GetNBytes();

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -128,6 +128,7 @@ public:
    }
 
    bool IsNull() const { return fBuffer == nullptr; }
+   bool IsEmpty() const { return fNElements == 0; }
    bool operator ==(const RPage &other) const { return fBuffer == other.fBuffer; }
    bool operator !=(const RPage &other) const { return !(*this == other); }
 };

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -103,11 +103,10 @@ public:
     }
 
    void* GetBuffer() const { return fBuffer; }
-   /// Return a pointer after the last element that has space for nElements new elements. If there is not enough capacity,
-   /// return nullptr
-   void* TryGrow(ClusterSize_t::ValueType nElements) {
-      if (fNElements + nElements > fMaxElements)
-         return nullptr;
+   /// Called during writing: returns a pointer after the last element and increases the element counter
+   /// in anticpation of the caller filling nElements in the page. It is the responsibility of the caller
+   /// to prevent page overflows, i.e. that fNElements + nElements <= fMaxElements
+   void* GrowUnchecked(ClusterSize_t::ValueType nElements) {
       auto offset = GetNBytes();
       fNElements += nElements;
       return static_cast<unsigned char *>(fBuffer) + offset;

--- a/tree/ntuple/v7/inc/ROOT/RPage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPage.hxx
@@ -59,28 +59,29 @@ public:
 private:
    ColumnId_t fColumnId;
    void *fBuffer;
-   ClusterSize_t::ValueType fCapacity;
    ClusterSize_t::ValueType fElementSize;
    ClusterSize_t::ValueType fNElements;
+   /// The capacity of the page in number of elements
+   ClusterSize_t::ValueType fMaxElements;
    NTupleSize_t fRangeFirst;
    RClusterInfo fClusterInfo;
 
 public:
-   RPage() : fColumnId(kInvalidColumnId), fBuffer(nullptr), fCapacity(0), fElementSize(0), fNElements(0), fRangeFirst(0)
+   RPage()
+      : fColumnId(kInvalidColumnId), fBuffer(nullptr), fElementSize(0), fNElements(0), fMaxElements(0), fRangeFirst(0)
    {}
-   RPage(ColumnId_t columnId, void* buffer, ClusterSize_t::ValueType capacity, ClusterSize_t::ValueType elementSize)
-      : fColumnId(columnId), fBuffer(buffer), fCapacity(capacity), fElementSize(elementSize), fNElements(0),
+   RPage(ColumnId_t columnId, void* buffer, ClusterSize_t::ValueType elementSize, ClusterSize_t::ValueType maxElements)
+      : fColumnId(columnId), fBuffer(buffer), fElementSize(elementSize), fNElements(0), fMaxElements(maxElements),
         fRangeFirst(0)
    {}
    ~RPage() = default;
 
    ColumnId_t GetColumnId() const { return fColumnId; }
-   /// The total space available in the page
-   ClusterSize_t::ValueType GetCapacity() const { return fCapacity; }
    /// The space taken by column elements in the buffer
-   ClusterSize_t::ValueType GetSize() const { return fElementSize * fNElements; }
+   ClusterSize_t::ValueType GetNBytes() const { return fElementSize * fNElements; }
    ClusterSize_t::ValueType GetElementSize() const { return fElementSize; }
    ClusterSize_t::ValueType GetNElements() const { return fNElements; }
+   ClusterSize_t::ValueType GetMaxElements() const { return fMaxElements; }
    NTupleSize_t GetGlobalRangeFirst() const { return fRangeFirst; }
    NTupleSize_t GetGlobalRangeLast() const { return fRangeFirst + NTupleSize_t(fNElements) - 1; }
    ClusterSize_t::ValueType GetClusterRangeFirst() const { return fRangeFirst - fClusterInfo.GetIndexOffset(); }
@@ -105,11 +106,9 @@ public:
    /// Return a pointer after the last element that has space for nElements new elements. If there is not enough capacity,
    /// return nullptr
    void* TryGrow(ClusterSize_t::ValueType nElements) {
-      auto offset = GetSize();
-      auto nbyte = nElements * fElementSize;
-      if (offset + nbyte > fCapacity) {
-        return nullptr;
-      }
+      if (fNElements + nElements > fMaxElements)
+         return nullptr;
+      auto offset = GetNBytes();
       fNElements += nElements;
       return static_cast<unsigned char *>(fBuffer) + offset;
    }

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -52,7 +52,7 @@ private:
             return fSealedPage.fBuffer != nullptr;
          }
          void AllocateSealedPageBuf() {
-            fBuf = std::make_unique<unsigned char[]>(fPage.GetSize());
+            fBuf = std::make_unique<unsigned char[]>(fPage.GetNBytes());
          }
       };
    public:

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -111,7 +111,7 @@ protected:
    void CreateImpl(const RNTupleModel &model) final;
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RClusterDescriptor::RLocator CommitSealedPageImpl(DescriptorId_t columnId, const RSealedPage &sealedPage) final;
-   RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) final;
+   std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    void CommitDatasetImpl() final;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -122,7 +122,7 @@ public:
    RPageSinkBuf& operator=(RPageSinkBuf&&) = default;
    virtual ~RPageSinkBuf() = default;
 
-   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
+   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
    void ReleasePage(RPage &page) final;
 
    RNTupleMetrics &GetMetrics() final { return fMetrics; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -249,7 +249,7 @@ public:
 
    /// Get a new, empty page for the given column that can be filled with up to nElements.  If nElements is zero,
    /// the page sink picks an appropriate size.
-   virtual RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) = 0;
+   virtual RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) = 0;
 
    /// Returns the default metrics object.  Subclasses might alternatively provide their own metrics object by overriding this.
    virtual RNTupleMetrics &GetMetrics() override { return fMetrics; };

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -187,7 +187,8 @@ protected:
    virtual RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RClusterDescriptor::RLocator CommitSealedPageImpl(DescriptorId_t columnId,
                                                              const RPageStorage::RSealedPage &sealedPage) = 0;
-   virtual RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) = 0;
+   /// Returns the number of bytes written to storage (excluding metadata)
+   virtual std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) = 0;
    virtual void CommitDatasetImpl() = 0;
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
@@ -240,8 +241,9 @@ public:
    /// Write a preprocessed page to storage. The column must have been added before.
    /// TODO(jblomer): allow for vector commit of sealed pages
    void CommitSealedPage(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage);
-   /// Finalize the current cluster and create a new one for the following data. Returns the cluster ID.
-   DescriptorId_t CommitCluster(NTupleSize_t nEntries);
+   /// Finalize the current cluster and create a new one for the following data.
+   /// Returns the number of bytes written to storage (excluding meta-data).
+   std::uint64_t CommitCluster(NTupleSize_t nEntries);
    /// Finalize the current cluster and the entrire data set.
    void CommitDataset() { CommitDatasetImpl(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -240,8 +240,8 @@ public:
    /// Write a preprocessed page to storage. The column must have been added before.
    /// TODO(jblomer): allow for vector commit of sealed pages
    void CommitSealedPage(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage);
-   /// Finalize the current cluster and create a new one for the following data.
-   void CommitCluster(NTupleSize_t nEntries);
+   /// Finalize the current cluster and create a new one for the following data. Returns the cluster ID.
+   DescriptorId_t CommitCluster(NTupleSize_t nEntries);
    /// Finalize the current cluster and the entrire data set.
    void CommitDataset() { CommitDatasetImpl(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -100,6 +100,8 @@ private:
    std::atomic<std::uint64_t> fOid{0};
    /// \brief A URI to a DAOS pool of the form 'daos://pool-uuid:svc_replicas/container-uuid'
    std::string fURI;
+   /// Tracks the number of bytes committed to the current cluster
+   std::uint64_t fNBytesCurrentCluster{0};
 
    RDaosNTupleAnchor fNTupleAnchor;
 
@@ -108,7 +110,7 @@ protected:
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RClusterDescriptor::RLocator CommitSealedPageImpl(DescriptorId_t columnId,
                                                      const RPageStorage::RSealedPage &sealedPage) final;
-   RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) final;
+   std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    void CommitDatasetImpl() final;
    void WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);
    void WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -120,7 +120,7 @@ public:
    RPageSinkDaos(std::string_view ntupleName, std::string_view uri, const RNTupleWriteOptions &options);
    virtual ~RPageSinkDaos();
 
-   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
+   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
    void ReleasePage(RPage &page) final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -87,7 +87,7 @@ public:
    RPageSinkFile& operator=(RPageSinkFile&&) = default;
    virtual ~RPageSinkFile();
 
-   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements = 0) final;
+   RPage ReservePage(ColumnHandle_t columnHandle, std::size_t nElements) final;
    void ReleasePage(RPage &page) final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -61,6 +61,8 @@ private:
    std::uint64_t fClusterMinOffset = std::uint64_t(-1);
    /// Byte offset of the end of the last page of the current cluster
    std::uint64_t fClusterMaxOffset = 0;
+   /// Number of bytes committed to storage in the current cluster
+   std::uint64_t fNBytesCurrentCluster = 0;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
    RClusterDescriptor::RLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,
@@ -71,7 +73,7 @@ protected:
    RClusterDescriptor::RLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RClusterDescriptor::RLocator CommitSealedPageImpl(DescriptorId_t columnId,
                                                      const RPageStorage::RSealedPage &sealedPage) final;
-   RClusterDescriptor::RLocator CommitClusterImpl(NTupleSize_t nEntries) final;
+   std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    void CommitDatasetImpl() final;
 
 public:

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -64,7 +64,7 @@ void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageS
 void ROOT::Experimental::Detail::RColumn::Flush()
 {
    auto otherIdx = (fHeadPageIdx + 1) % 2;
-   if (fHeadPage[fHeadPageIdx].GetSize() == 0 && fHeadPage[otherIdx].GetSize() == 0)
+   if (fHeadPage[fHeadPageIdx].GetNBytes() == 0 && fHeadPage[otherIdx].GetNBytes() == 0)
       return;
 
    if ((fHeadPage[fHeadPageIdx].GetNElements() < fApproxNElementsPerPage / 2) &&

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -71,8 +71,7 @@ void ROOT::Experimental::Detail::RColumn::Flush()
        fHeadPage[otherIdx].GetNElements())
    {
       // Small tail page: merge with previously used page
-      void *dst = fHeadPage[otherIdx].TryGrow(fHeadPage[fHeadPageIdx].GetNElements());
-      R__ASSERT(dst != nullptr);
+      void *dst = fHeadPage[otherIdx].GrowUnchecked(fHeadPage[fHeadPageIdx].GetNElements());
       RColumnElementBase elem(fHeadPage[fHeadPageIdx].GetBuffer(), fHeadPage[fHeadPageIdx].GetElementSize());
       elem.WriteTo(dst, fHeadPage[fHeadPageIdx].GetNElements());
       fHeadPage[fHeadPageIdx].Reset(0);

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -48,7 +48,7 @@ void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageS
       fHandleSink = fPageSink->AddColumn(fieldId, *this);
       fApproxNElementsPerPage = fPageSink->GetWriteOptions().GetApproxUnzippedPageSize() / fElement->GetSize();
       if (fApproxNElementsPerPage < 2)
-         throw RException(R__FAIL("Page size too small for writing"));
+         throw RException(R__FAIL("page size too small for writing"));
       fHeadPage[0] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage + fApproxNElementsPerPage / 2);
       fHeadPage[1] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage + fApproxNElementsPerPage / 2);
       break;

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -32,8 +32,8 @@ ROOT::Experimental::Detail::RColumn::~RColumn()
       fPageSink->ReleasePage(fWritePage[0]);
    if (!fWritePage[1].IsNull())
       fPageSink->ReleasePage(fWritePage[1]);
-   if (!fCurrentPage.IsNull())
-      fPageSource->ReleasePage(fCurrentPage);
+   if (!fReadPage.IsNull())
+      fPageSource->ReleasePage(fReadPage);
    if (fHandleSink)
       fPageSink->DropColumn(fHandleSink);
    if (fHandleSource)
@@ -86,12 +86,12 @@ void ROOT::Experimental::Detail::RColumn::Flush()
 
 void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)
 {
-   fPageSource->ReleasePage(fCurrentPage);
-   fCurrentPage = fPageSource->PopulatePage(fHandleSource, index);
+   fPageSource->ReleasePage(fReadPage);
+   fReadPage = fPageSource->PopulatePage(fHandleSource, index);
 }
 
 void ROOT::Experimental::Detail::RColumn::MapPage(const RClusterIndex &clusterIndex)
 {
-   fPageSource->ReleasePage(fCurrentPage);
-   fCurrentPage = fPageSource->PopulatePage(fHandleSource, clusterIndex);
+   fPageSource->ReleasePage(fReadPage);
+   fReadPage = fPageSource->PopulatePage(fHandleSource, clusterIndex);
 }

--- a/tree/ntuple/v7/src/RColumn.cxx
+++ b/tree/ntuple/v7/src/RColumn.cxx
@@ -22,16 +22,16 @@
 #include <iostream>
 
 ROOT::Experimental::Detail::RColumn::RColumn(const RColumnModel& model, std::uint32_t index)
-   : fModel(model), fIndex(index), fPageSink(nullptr), fPageSource(nullptr), fHeadPage(), fNElements(0),
-     fCurrentPage(),
-     fColumnIdSource(kInvalidColumnId)
+   : fModel(model), fIndex(index)
 {
 }
 
 ROOT::Experimental::Detail::RColumn::~RColumn()
 {
-   if (!fHeadPage.IsNull())
-      fPageSink->ReleasePage(fHeadPage);
+   if (!fHeadPage[0].IsNull())
+      fPageSink->ReleasePage(fHeadPage[0]);
+   if (!fHeadPage[1].IsNull())
+      fPageSink->ReleasePage(fHeadPage[1]);
    if (!fCurrentPage.IsNull())
       fPageSource->ReleasePage(fCurrentPage);
    if (fHandleSink)
@@ -46,7 +46,9 @@ void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageS
    case EPageStorageType::kSink:
       fPageSink = static_cast<RPageSink*>(pageStorage); // the page sink initializes fHeadPage on AddColumn
       fHandleSink = fPageSink->AddColumn(fieldId, *this);
-      fHeadPage = fPageSink->ReservePage(fHandleSink);
+      fApproxNElementsPerPage = fPageSink->GetWriteOptions().GetApproxUnzippedPageSize() / fElement->GetSize();
+      fHeadPage[0] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage + fApproxNElementsPerPage / 2);
+      fHeadPage[1] = fPageSink->ReservePage(fHandleSink, fApproxNElementsPerPage + fApproxNElementsPerPage / 2);
       break;
    case EPageStorageType::kSource:
       fPageSource = static_cast<RPageSource*>(pageStorage);
@@ -61,10 +63,25 @@ void ROOT::Experimental::Detail::RColumn::Connect(DescriptorId_t fieldId, RPageS
 
 void ROOT::Experimental::Detail::RColumn::Flush()
 {
-   if (fHeadPage.GetSize() == 0) return;
+   auto otherIdx = (fHeadPageIdx + 1) % 2;
+   if (fHeadPage[fHeadPageIdx].GetSize() == 0 && fHeadPage[otherIdx].GetSize() == 0)
+      return;
 
-   fPageSink->CommitPage(fHandleSink, fHeadPage);
-   fHeadPage.Reset(fNElements);
+   if ((fHeadPage[fHeadPageIdx].GetNElements() < fApproxNElementsPerPage / 2) &&
+       fHeadPage[otherIdx].GetNElements())
+   {
+      // Small tail page: merge with previously used page
+      void *dst = fHeadPage[otherIdx].TryGrow(fHeadPage[fHeadPageIdx].GetNElements());
+      R__ASSERT(dst != nullptr);
+      RColumnElementBase elem(fHeadPage[fHeadPageIdx].GetBuffer(), fHeadPage[fHeadPageIdx].GetElementSize());
+      elem.WriteTo(dst, fHeadPage[fHeadPageIdx].GetNElements());
+      fHeadPage[fHeadPageIdx].Reset(0);
+      fHeadPageIdx = otherIdx;
+   } else {
+      fHeadPage[otherIdx].Reset(0);
+   }
+   fPageSink->CommitPage(fHandleSink, fHeadPage[fHeadPageIdx]);
+   fHeadPage[fHeadPageIdx].Reset(fNElements);
 }
 
 void ROOT::Experimental::Detail::RColumn::MapPage(const NTupleSize_t index)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -726,7 +726,7 @@ std::size_t ROOT::Experimental::RField<std::string>::AppendImpl(const ROOT::Expe
    fColumns[1]->AppendV(elemChars, length);
    fIndex += length;
    fColumns[0]->Append(fElemIndex);
-   return length + sizeof(ClusterSize_t);
+   return length + sizeof(fElemIndex);
 }
 
 void ROOT::Experimental::RField<std::string>::ReadGlobalImpl(
@@ -1011,7 +1011,7 @@ std::size_t ROOT::Experimental::RVectorField::AppendImpl(const Detail::RFieldVal
    Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
-   return nbytes + sizeof(ClusterSize_t);
+   return nbytes + sizeof(elemIndex);
 }
 
 void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value)
@@ -1111,7 +1111,7 @@ std::size_t ROOT::Experimental::RField<std::vector<bool>>::AppendImpl(const Deta
    Detail::RColumnElement<ClusterSize_t> elemIndex(&fNWritten);
    fNWritten += count;
    fColumns[0]->Append(elemIndex);
-   return count + sizeof(ClusterSize_t);
+   return count + sizeof(elemIndex);
 }
 
 void ROOT::Experimental::RField<std::vector<bool>>::ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue* value)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -243,7 +243,7 @@ ROOT::Experimental::Detail::RFieldBase::Clone(std::string_view newName) const
 
 std::size_t ROOT::Experimental::Detail::RFieldBase::AppendImpl(const ROOT::Experimental::Detail::RFieldValue& /*value*/)
 {
-   R__ASSERT(false);
+   R__ASSERT(false && "A non-simple RField must implement its own AppendImpl");
    return 0;
 }
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -337,7 +337,7 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster()
       field.Flush();
       field.CommitCluster();
    }
-   float nbytes = fSink->CommitCluster(fNEntries);
+   const float nbytes = fSink->CommitCluster(fNEntries);
    // Cap the compression factor at 1000 to prevent overflow of fMinUnzippedClusterSizeEst
    float compressionFactor = std::min(1000.f, static_cast<float>(fUnzippedClusterSize) / nbytes);
    fUnzippedClusterSizeEst =

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -295,8 +295,9 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
 
    fMaxUnzippedClusterSize = fSink->GetWriteOptions().GetMaxUnzippedClusterSize();
    // First estimate is a factor 2 compression if compression is used at all
-   fMinUnzippedClusterSizeEst = (fSink->GetWriteOptions().GetCompression() == 0) ?
-      fSink->GetWriteOptions().GetMinZippedClusterSize() : 2 * fSink->GetWriteOptions().GetMinZippedClusterSize();
+   fUnzippedClusterSizeEst = (fSink->GetWriteOptions().GetCompression() == 0)
+      ? fSink->GetWriteOptions().GetApproxZippedClusterSize()
+      : 2 * fSink->GetWriteOptions().GetApproxZippedClusterSize();
 }
 
 ROOT::Experimental::RNTupleWriter::~RNTupleWriter()
@@ -339,8 +340,8 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster()
    float nbytes = fSink->CommitCluster(fNEntries);
    // Cap the compression factor at 1000 to prevent overflow of fMinUnzippedClusterSizeEst
    float compressionFactor = std::min(1000.f, static_cast<float>(fUnzippedClusterSize) / nbytes);
-   fMinUnzippedClusterSizeEst =
-      compressionFactor * static_cast<float>(fSink->GetWriteOptions().GetMinZippedClusterSize());
+   fUnzippedClusterSizeEst =
+      compressionFactor * static_cast<float>(fSink->GetWriteOptions().GetApproxZippedClusterSize());
 
    fLastCommitted = fNEntries;
    fUnzippedClusterSize = 0;

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -295,9 +295,9 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
 
    fMaxUnzippedClusterSize = fSink->GetWriteOptions().GetMaxUnzippedClusterSize();
    // First estimate is a factor 2 compression if compression is used at all
-   fUnzippedClusterSizeEst = (fSink->GetWriteOptions().GetCompression() == 0)
-      ? fSink->GetWriteOptions().GetApproxZippedClusterSize()
-      : 2 * fSink->GetWriteOptions().GetApproxZippedClusterSize();
+   const auto &writeOpts = fSink->GetWriteOptions();
+   int scale = writeOpts.GetCompression() ? 1 : 2;
+   fUnzippedClusterSizeEst = scale * writeOpts.GetApproxZippedClusterSize();
 }
 
 ROOT::Experimental::RNTupleWriter::~RNTupleWriter()

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -337,9 +337,12 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster()
       field.Flush();
       field.CommitCluster();
    }
-   const float nbytes = fSink->CommitCluster(fNEntries);
-   // Cap the compression factor at 1000 to prevent overflow of fMinUnzippedClusterSizeEst
-   const float compressionFactor = std::min(1000.f, static_cast<float>(fUnzippedClusterSize) / nbytes);
+   fNBytesCommitted += fSink->CommitCluster(fNEntries);
+   fNBytesFilled += fUnzippedClusterSize;
+
+   // Cap the compression factor at 1000 to prevent overflow of fUnzippedClusterSizeEst
+   const float compressionFactor = std::min(1000.f,
+      static_cast<float>(fNBytesFilled) / static_cast<float>(fNBytesCommitted));
    fUnzippedClusterSizeEst =
       compressionFactor * static_cast<float>(fSink->GetWriteOptions().GetApproxZippedClusterSize());
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -339,7 +339,7 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster()
    }
    const float nbytes = fSink->CommitCluster(fNEntries);
    // Cap the compression factor at 1000 to prevent overflow of fMinUnzippedClusterSizeEst
-   float compressionFactor = std::min(1000.f, static_cast<float>(fUnzippedClusterSize) / nbytes);
+   const float compressionFactor = std::min(1000.f, static_cast<float>(fUnzippedClusterSize) / nbytes);
    fUnzippedClusterSizeEst =
       compressionFactor * static_cast<float>(fSink->GetWriteOptions().GetApproxZippedClusterSize());
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -293,10 +293,10 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    fSink->Create(*fModel.get());
    fMetrics.ObserveMetrics(fSink->GetMetrics());
 
-   fMaxUnzippedClusterSize = fSink->GetWriteOptions().GetMaxUnzippedClusterSize();
-   // First estimate is a factor 2 compression if compression is used at all
    const auto &writeOpts = fSink->GetWriteOptions();
-   int scale = writeOpts.GetCompression() ? 1 : 2;
+   fMaxUnzippedClusterSize = writeOpts.GetMaxUnzippedClusterSize();
+   // First estimate is a factor 2 compression if compression is used at all
+   int scale = writeOpts.GetCompression() ? 2 : 1;
    fUnzippedClusterSizeEst = scale * writeOpts.GetApproxZippedClusterSize();
 }
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -296,7 +296,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    const auto &writeOpts = fSink->GetWriteOptions();
    fMaxUnzippedClusterSize = writeOpts.GetMaxUnzippedClusterSize();
    // First estimate is a factor 2 compression if compression is used at all
-   int scale = writeOpts.GetCompression() ? 2 : 1;
+   const int scale = writeOpts.GetCompression() ? 2 : 1;
    fUnzippedClusterSizeEst = scale * writeOpts.GetApproxZippedClusterSize();
 }
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -483,6 +483,18 @@ bool ROOT::Experimental::RClusterDescriptor::ContainsColumn(DescriptorId_t colum
 }
 
 
+std::uint64_t ROOT::Experimental::RClusterDescriptor::GetBytesOnStorage() const
+{
+   std::uint64_t nbytes = 0;
+   for (const auto &pr : fPageRanges) {
+      for (const auto &pi : pr.second.fPageInfos) {
+         nbytes += pi.fLocator.fBytesOnStorage;
+      }
+   }
+   return nbytes;
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 
 

--- a/tree/ntuple/v7/src/RNTupleOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleOptions.cxx
@@ -31,7 +31,7 @@ void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClus
                                "maximum uncompressed cluster size"));
    }
    if (unzippedPageSize > unzippedClusterSize) {
-      throw RException(R__FAIL("compressed target page size must not be larger than "
+      throw RException(R__FAIL("target page size must not be larger than "
                                "maximum uncompressed cluster size"));
    }
    if (unzippedPageSize == 0) {

--- a/tree/ntuple/v7/src/RNTupleOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleOptions.cxx
@@ -26,6 +26,9 @@ void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClus
    if (zippedClusterSize == 0) {
       throw RException(R__FAIL("invalid target cluster size: 0"));
    }
+   if (unzippedPageSize == 0) {
+      throw RException(R__FAIL("invalid target page size: 0"));
+   }
    if (zippedClusterSize > unzippedClusterSize) {
       throw RException(R__FAIL("compressed target cluster size must not be larger than "
                                "maximum uncompressed cluster size"));
@@ -33,9 +36,6 @@ void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClus
    if (unzippedPageSize > unzippedClusterSize) {
       throw RException(R__FAIL("target page size must not be larger than "
                                "maximum uncompressed cluster size"));
-   }
-   if (unzippedPageSize == 0) {
-      throw RException(R__FAIL("invalid target page size: 0"));
    }
 }
 

--- a/tree/ntuple/v7/src/RNTupleOptions.cxx
+++ b/tree/ntuple/v7/src/RNTupleOptions.cxx
@@ -1,0 +1,66 @@
+/// \file RNTupleOptions.cxx
+/// \ingroup NTuple ROOT7
+/// \author Jakob Blomer <jblomer@cern.ch>
+/// \date 2021-07-28
+/// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
+/// is welcome!
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RError.hxx>
+#include <ROOT/RNTupleOptions.hxx>
+
+#include <utility>
+
+namespace {
+
+void EnsureValidTunables(std::size_t zippedClusterSize, std::size_t unzippedClusterSize, std::size_t unzippedPageSize)
+{
+   using RException = ROOT::Experimental::RException;
+   if (zippedClusterSize == 0) {
+      throw RException(R__FAIL("invalid target cluster size: 0"));
+   }
+   if (zippedClusterSize > unzippedClusterSize) {
+      throw RException(R__FAIL("compressed target cluster size must not be larger than "
+                               "maximum uncompressed cluster size"));
+   }
+   if (unzippedPageSize > unzippedClusterSize) {
+      throw RException(R__FAIL("compressed target page size must not be larger than "
+                               "maximum uncompressed cluster size"));
+   }
+   if (unzippedPageSize == 0) {
+      throw RException(R__FAIL("invalid target page size: 0"));
+   }
+}
+
+} // anonymous namespace
+
+std::unique_ptr<ROOT::Experimental::RNTupleWriteOptions>
+ROOT::Experimental::RNTupleWriteOptions::Clone() const
+{
+   return std::make_unique<RNTupleWriteOptions>(*this);
+}
+
+void ROOT::Experimental::RNTupleWriteOptions::SetApproxZippedClusterSize(std::size_t val)
+{
+   EnsureValidTunables(val, fMaxUnzippedClusterSize, fApproxUnzippedPageSize);
+   fApproxZippedClusterSize = val;
+}
+
+void ROOT::Experimental::RNTupleWriteOptions::SetMaxUnzippedClusterSize(std::size_t val)
+{
+   EnsureValidTunables(fApproxZippedClusterSize, val, fApproxUnzippedPageSize);
+   fMaxUnzippedClusterSize = val;
+}
+
+void ROOT::Experimental::RNTupleWriteOptions::SetApproxUnzippedPageSize(std::size_t val)
+{
+   EnsureValidTunables(fApproxZippedClusterSize, fMaxUnzippedClusterSize, val);
+   fApproxUnzippedPageSize = val;
+}

--- a/tree/ntuple/v7/src/RPageAllocator.cxx
+++ b/tree/ntuple/v7/src/RPageAllocator.cxx
@@ -24,7 +24,7 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorHeap
    R__ASSERT((elementSize > 0) && (nElements > 0));
    auto nbytes = elementSize * nElements;
    auto buffer = new unsigned char[nbytes];
-   return RPage(columnId, buffer, nbytes, elementSize);
+   return RPage(columnId, buffer, elementSize, nElements);
 }
 
 void ROOT::Experimental::Detail::RPageAllocatorHeap::DeletePage(const RPage& page)

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -44,7 +44,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHa
    // TODO avoid frequent (de)allocations by holding on to allocated buffers in RColumnBuf
    RPage bufPage = ReservePage(columnHandle, page.GetNElements());
    // make sure the page is aware of how many elements it will have
-   R__ASSERT(bufPage.TryGrow(page.GetNElements()));
+   bufPage.GrowUnchecked(page.GetNElements());
    memcpy(bufPage.GetBuffer(), page.GetBuffer(), page.GetNBytes());
    // Safety: RColumnBuf::iterators are guaranteed to be valid until the
    // element is destroyed. In other words, all buffered page iterators are

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -82,7 +82,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitSealedPageImpl(
    return RClusterDescriptor::RLocator{};
 }
 
-ROOT::Experimental::RClusterDescriptor::RLocator
+std::uint64_t
 ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::NTupleSize_t nEntries)
 {
    if (fTaskScheduler) {
@@ -100,10 +100,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::
          ReleasePage(bufPage.fPage);
       }
    }
-   fInnerSink->CommitCluster(nEntries);
-   // we're feeding bad locators to fOpenPageRanges but it should not matter
-   // because they never get written out
-   return RClusterDescriptor::RLocator{};
+   return fInnerSink->CommitCluster(nEntries);
 }
 
 void ROOT::Experimental::Detail::RPageSinkBuf::CommitDatasetImpl()

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -45,7 +45,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitPageImpl(ColumnHandle_t columnHa
    RPage bufPage = ReservePage(columnHandle, page.GetNElements());
    // make sure the page is aware of how many elements it will have
    R__ASSERT(bufPage.TryGrow(page.GetNElements()));
-   memcpy(bufPage.GetBuffer(), page.GetBuffer(), page.GetSize());
+   memcpy(bufPage.GetBuffer(), page.GetBuffer(), page.GetNBytes());
    // Safety: RColumnBuf::iterators are guaranteed to be valid until the
    // element is destroyed. In other words, all buffered page iterators are
    // valid until the return value of DrainBufferedPages() goes out of scope in

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -376,7 +376,7 @@ ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page,
 {
    unsigned char *pageBuf = reinterpret_cast<unsigned char *>(page.GetBuffer());
    bool isAdoptedBuffer = true;
-   auto packedBytes = page.GetSize();
+   auto packedBytes = page.GetNBytes();
 
    if (!element.IsMappable()) {
       packedBytes = element.GetPackedSize(page.GetNElements());

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -353,6 +353,7 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
                                  ClusterSize_t(nEntries - fPrevClusterNEntries));
    // TODO(jblomer): Remove me with the v1 Serialization
    // For now, we set a non-zero locator to make sure current reading code does not choke
+   R__ASSERT(RNTupleDescriptor::kFrameVersionCurrent < 1);
    fDescriptorBuilder.SetClusterLocator(fLastClusterId, RClusterDescriptor::RLocator({0, 1, ""}));
    for (auto &range : fOpenColumnRanges) {
       fDescriptorBuilder.AddClusterColumnRange(fLastClusterId, range);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -344,7 +344,8 @@ void ROOT::Experimental::Detail::RPageSink::CommitSealedPage(
 }
 
 
-void ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
 {
    auto locator = CommitClusterImpl(nEntries);
 
@@ -363,8 +364,8 @@ void ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experimental::NT
       range.fColumnId = fullRange.fColumnId;
       fDescriptorBuilder.AddClusterPageRange(fLastClusterId, std::move(fullRange));
    }
-   ++fLastClusterId;
    fPrevClusterNEntries = nEntries;
+   return fLastClusterId++;
 }
 
 ROOT::Experimental::Detail::RPageStorage::RSealedPage

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -352,7 +352,8 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
    fDescriptorBuilder.AddCluster(fLastClusterId, RNTupleVersion(), fPrevClusterNEntries,
                                  ClusterSize_t(nEntries - fPrevClusterNEntries));
    // TODO(jblomer): Remove me with the v1 Serialization
-   fDescriptorBuilder.SetClusterLocator(fLastClusterId, RClusterDescriptor::RLocator());
+   // For now, we set a non-zero locator to make sure current reading code does not choke
+   fDescriptorBuilder.SetClusterLocator(fLastClusterId, RClusterDescriptor::RLocator({0, 1, ""}));
    for (auto &range : fOpenColumnRanges) {
       fDescriptorBuilder.AddClusterColumnRange(fLastClusterId, range);
       range.fFirstElementIndex += range.fNElements;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -264,8 +264,8 @@ void ROOT::Experimental::Detail::RPageSinkDaos::ReleasePage(RPage &page)
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorDaos::NewPage(
    ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
 {
-   RPage newPage(columnId, mem, elementSize, elementSize * nElements);
-   newPage.TryGrow(nElements);
+   RPage newPage(columnId, mem, elementSize, nElements);
+   newPage.GrowUnchecked(nElements);
    return newPage;
 }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -188,17 +188,17 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageImpl(
    result.fBytesOnStorage = sealedPage.fSize;
    fCounters->fNPageCommitted.Inc();
    fCounters->fSzWritePayload.Add(sealedPage.fSize);
+   fNBytesCurrentCluster += sealedPage.fSize;
    return result;
 }
 
 
-// TODO(jalopezg): the current byte range arithmetic makes little sense for the
-// object store. We might find out, however, that there are native ways to group
-// clusters in DAOS.
-ROOT::Experimental::RClusterDescriptor::RLocator
+std::uint64_t
 ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
 {
-   return {};
+   auto result = fNBytesCurrentCluster;
+   fNBytesCurrentCluster = 0;
+   return result;
 }
 
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -196,9 +196,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageImpl(
 std::uint64_t
 ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
 {
-   auto result = fNBytesCurrentCluster;
-   fNBytesCurrentCluster = 0;
-   return result;
+   return std::exchange(fNBytesCurrentCluster, 0);
 }
 
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -246,9 +246,9 @@ void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleAnchor() {
 ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkDaos::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
-   auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    if (nElements == 0)
-      nElements = GetWriteOptions().GetMaxUnzippedPageSize() / elementSize;
+      throw RException(R__FAIL("invalid call: request empty page"));
+   auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -167,7 +167,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitPageImpl(ColumnHandle_t columnH
       sealedPage = SealPage(page, *element, GetWriteOptions().GetCompression());
    }
 
-   fCounters->fSzZip.Add(page.GetSize());
+   fCounters->fSzZip.Add(page.GetNBytes());
    return CommitSealedPageImpl(columnHandle.fId, sealedPage);
 }
 
@@ -264,7 +264,7 @@ void ROOT::Experimental::Detail::RPageSinkDaos::ReleasePage(RPage &page)
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorDaos::NewPage(
    ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
 {
-   RPage newPage(columnId, mem, elementSize * nElements, elementSize);
+   RPage newPage(columnId, mem, elementSize, elementSize * nElements);
    newPage.TryGrow(nElements);
    return newPage;
 }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -60,7 +60,7 @@ RDaosURI ParseDaosURI(std::string_view uri)
 }
 
 /// \brief Some random distribution/attribute key.  TODO: apply recommended schema, i.e.
-/// an OID for each cluster + a dkey for each page. 
+/// an OID for each cluster + a dkey for each page.
 static constexpr std::uint64_t kDistributionKey = 0x5a3c69f0cafe4a11;
 static constexpr std::uint64_t kAttributeKey = 0x4243544b5344422d;
 
@@ -246,9 +246,9 @@ void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleAnchor() {
 ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkDaos::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
-   if (nElements == 0)
-      nElements = GetWriteOptions().GetNElementsPerPage();
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
+   if (nElements == 0)
+      nElements = GetWriteOptions().GetMaxUnzippedPageSize() / elementSize;
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -175,9 +175,9 @@ void ROOT::Experimental::Detail::RPageSinkFile::CommitDatasetImpl()
 ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkFile::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
-   auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    if (nElements == 0)
-      nElements = GetWriteOptions().GetMaxUnzippedPageSize() / elementSize;
+      throw RException(R__FAIL("invalid call: request empty page"));
+   auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -177,9 +177,9 @@ void ROOT::Experimental::Detail::RPageSinkFile::CommitDatasetImpl()
 ROOT::Experimental::Detail::RPage
 ROOT::Experimental::Detail::RPageSinkFile::ReservePage(ColumnHandle_t columnHandle, std::size_t nElements)
 {
-   if (nElements == 0)
-      nElements = GetWriteOptions().GetNElementsPerPage();
    auto elementSize = columnHandle.fColumn->GetElement()->GetSize();
+   if (nElements == 0)
+      nElements = GetWriteOptions().GetMaxUnzippedPageSize() / elementSize;
    return fPageAllocator->NewPage(columnHandle.fId, elementSize, nElements);
 }
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -131,7 +131,7 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitPageImpl(ColumnHandle_t columnH
       sealedPage = SealPage(page, *element, GetWriteOptions().GetCompression());
    }
 
-   fCounters->fSzZip.Add(page.GetSize());
+   fCounters->fSzZip.Add(page.GetNBytes());
    return WriteSealedPage(sealedPage, element->GetPackedSize(page.GetNElements()));
 }
 
@@ -193,7 +193,7 @@ void ROOT::Experimental::Detail::RPageSinkFile::ReleasePage(RPage &page)
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorFile::NewPage(
    ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
 {
-   RPage newPage(columnId, mem, elementSize * nElements, elementSize);
+   RPage newPage(columnId, mem, elementSize, elementSize * nElements);
    newPage.TryGrow(nElements);
    return newPage;
 }

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -193,8 +193,8 @@ void ROOT::Experimental::Detail::RPageSinkFile::ReleasePage(RPage &page)
 ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorFile::NewPage(
    ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
 {
-   RPage newPage(columnId, mem, elementSize, elementSize * nElements);
-   newPage.TryGrow(nElements);
+   RPage newPage(columnId, mem, elementSize, nElements);
+   newPage.GrowUnchecked(nElements);
    return newPage;
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -220,7 +220,8 @@ TEST(RNTuple, ClusterEntries)
 
    {
       RNTupleWriteOptions opt;
-      opt.SetNEntriesPerCluster(5);
+      // FIXME(jblomer)
+      //opt.SetNEntriesPerCluster(5);
       auto ntuple = RNTupleWriter::Recreate(
          std::move(model), "ntuple", fileGuard.GetPath(), opt
       );
@@ -234,7 +235,7 @@ TEST(RNTuple, ClusterEntries)
    EXPECT_EQ(20, ntuple->GetDescriptor().GetNClusters());
 }
 
-TEST(RNTuple, ElementsPerPage)
+TEST(RNTuple, PageSize)
 {
    FileRaii fileGuard("test_ntuple_elements_per_page.root");
    auto model = RNTupleModel::Create();
@@ -242,7 +243,7 @@ TEST(RNTuple, ElementsPerPage)
 
    {
       RNTupleWriteOptions opt;
-      opt.SetNElementsPerPage(5);
+      opt.SetMaxUnzippedPageSize(20);
       auto ntuple = RNTupleWriter::Recreate(
          std::move(model), "ntuple", fileGuard.GetPath(), opt
       );

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -220,13 +220,11 @@ TEST(RNTuple, ClusterEntries)
 
    {
       RNTupleWriteOptions opt;
-      // FIXME(jblomer)
-      //opt.SetNEntriesPerCluster(5);
-      auto ntuple = RNTupleWriter::Recreate(
-         std::move(model), "ntuple", fileGuard.GetPath(), opt
-      );
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", fileGuard.GetPath(), opt);
       for (int i = 0; i < 100; i++) {
          ntuple->Fill();
+         if (i && ((i % 5) == 0))
+            ntuple->CommitCluster();
       }
    }
 
@@ -243,18 +241,18 @@ TEST(RNTuple, PageSize)
 
    {
       RNTupleWriteOptions opt;
-      opt.SetMaxUnzippedPageSize(20);
+      opt.SetMaxUnzippedPageSize(200);
       auto ntuple = RNTupleWriter::Recreate(
          std::move(model), "ntuple", fileGuard.GetPath(), opt
       );
-      for (int i = 0; i < 100; i++) {
+      for (int i = 0; i < 1000; i++) {
          ntuple->Fill();
       }
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    const auto &col0_pages = ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0);
-   // 100 column elements / 5 elements per page
+   // 1000 column elements / 50 elements per page
    EXPECT_EQ(20, col0_pages.fPageInfos.size());
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -241,7 +241,7 @@ TEST(RNTuple, PageSize)
 
    {
       RNTupleWriteOptions opt;
-      opt.SetMaxUnzippedPageSize(200);
+      opt.SetApproxUnzippedPageSize(200);
       auto ntuple = RNTupleWriter::Recreate(
          std::move(model), "ntuple", fileGuard.GetPath(), opt
       );

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -84,6 +84,7 @@ TEST(RNTuple, RandomAccess)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
+      options.SetMinZippedClusterSize(nEvents * sizeof(std::int32_t) / 10);
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath(), options);
       for (unsigned int i = 0; i < nEvents; ++i)
          ntuple->Fill();
@@ -92,7 +93,7 @@ TEST(RNTuple, RandomAccess)
    RNTupleReadOptions options;
    options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath(), options);
-   EXPECT_GT(ntuple->GetDescriptor().GetNClusters(), 10);
+   EXPECT_GE(ntuple->GetDescriptor().GetNClusters(), 10);
 
    auto viewValue = ntuple->GetView<std::int32_t>("value");
 

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -84,7 +84,7 @@ TEST(RNTuple, RandomAccess)
    {
       RNTupleWriteOptions options;
       options.SetCompression(0);
-      options.SetMinZippedClusterSize(nEvents * sizeof(std::int32_t) / 10);
+      options.SetApproxZippedClusterSize(nEvents * sizeof(std::int32_t) / 10);
       auto ntuple = RNTupleWriter::Recreate(std::move(modelWrite), "myNTuple", fileGuard.GetPath(), options);
       for (unsigned int i = 0; i < nEvents; ++i)
          ntuple->Fill();
@@ -93,7 +93,7 @@ TEST(RNTuple, RandomAccess)
    RNTupleReadOptions options;
    options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath(), options);
-   EXPECT_GE(ntuple->GetDescriptor().GetNClusters(), 10);
+   EXPECT_EQ(10, ntuple->GetDescriptor().GetNClusters());
 
    auto viewValue = ntuple->GetView<std::int32_t>("value");
 

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -6,9 +6,9 @@ TEST(Pages, Allocation)
 
    auto page = allocator.NewPage(42, 4, 16);
    EXPECT_FALSE(page.IsNull());
-   EXPECT_EQ(64U, page.GetCapacity());
+   EXPECT_EQ(16U, page.GetMaxElements());
    EXPECT_EQ(0U, page.GetNElements());
-   EXPECT_EQ(0U, page.GetSize());
+   EXPECT_EQ(0U, page.GetNBytes());
    allocator.DeletePage(page);
 }
 
@@ -21,7 +21,7 @@ TEST(Pages, Pool)
    pool.ReturnPage(page); // should not crash
 
    RPage::RClusterInfo clusterInfo(2, 40);
-   page = RPage(1, &page, 10, 1);
+   page = RPage(1, &page, 1, 10);
    EXPECT_NE(nullptr, page.TryGrow(10));
    page.SetWindow(50, clusterInfo);
    EXPECT_FALSE(page.IsNull());

--- a/tree/ntuple/v7/test/ntuple_pages.cxx
+++ b/tree/ntuple/v7/test/ntuple_pages.cxx
@@ -22,7 +22,8 @@ TEST(Pages, Pool)
 
    RPage::RClusterInfo clusterInfo(2, 40);
    page = RPage(1, &page, 1, 10);
-   EXPECT_NE(nullptr, page.TryGrow(10));
+   page.GrowUnchecked(10);
+   EXPECT_EQ(page.GetMaxElements(), page.GetNElements());
    page.SetWindow(50, clusterInfo);
    EXPECT_FALSE(page.IsNull());
    unsigned int nCallDeleter = 0;

--- a/tree/ntuple/v7/test/ntuple_view.cxx
+++ b/tree/ntuple/v7/test/ntuple_view.cxx
@@ -63,7 +63,7 @@ TEST(RNTuple, BulkView)
    auto eltsPerPage = 10'000;
    {
       RNTupleWriteOptions opt;
-      opt.SetMaxUnzippedPageSize(eltsPerPage * sizeof(float));
+      opt.SetApproxUnzippedPageSize(eltsPerPage * sizeof(float));
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple",
          fileGuard.GetPath(), opt);
       for (int i = 0; i < 100'000; i++) {
@@ -102,7 +102,7 @@ TEST(RNTuple, BulkViewCollection)
    auto pageSize = 80 * 1024;
    {
       RNTupleWriteOptions opt;
-      opt.SetMaxUnzippedPageSize(pageSize);
+      opt.SetApproxUnzippedPageSize(pageSize);
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "myNTuple",
          fileGuard.GetPath(), opt);
       for (int i = 0; i < 100'000; i++) {

--- a/tree/ntuple/v7/test/rfield_string.cxx
+++ b/tree/ntuple/v7/test/rfield_string.cxx
@@ -4,7 +4,7 @@
 TEST(RNTuple, ReadString)
 {
    const std::string_view ntupleName = "rs";
-   constexpr int numEntries = 2500;
+   constexpr int numEntries = 25000;
    const std::string contentString = "foooooo";
 
    FileRaii fileGuard("test_ntuple_readstring.root");


### PR DESCRIPTION
# This Pull request:
The PR sets new defaults for the cluster size and page size of RNTuple.  The default should work well in the majority of cases but can be adjusted if needed.  The idea is to give target sizes for clusters and pages (measured in bytes). RNTuple will try make good decisions and approximate the target sizes.  The PR replaces previous defaults for cluster size and page size given in number of entries and number of elements resp.

## Changes or fixes:
The PR sets three new defaults:
  - Target size for compressed clusters of 50MB. In general, larger clusters provide room for more and larger pages and should improve compression ratio and speed. However, clusters also need to be buffered during write and (partially) during read, so larger cluster increase the memory footprint.
  - Maximum size for uncompressed clusters of 512MiB. Prevents very compressible clusters from growing too large. That is mostly a problem for writing.
  - Target size for uncompressed pages of 64KiB. In general, larger pages give better compression ratios.  Smaller pages, however, reduce the memory footprint. When reading, every active column requires at least one page buffer. For the number of read requests, the page size does not matter because pages of the same column are written consecutively and therefore read in one go.

Given the three settings, writing works as follows: when the current cluster is larger than the maximum uncompressed size, it will be flushed unconditionally.  When the current cluster size reaches the estimate for the compressed cluster size, it will be flushed, too.  The estimated compression ratio for the first cluster is 0.5 if compression is used, and 1 otherwise.  The following clusters use the compression ratio of the last cluster as estimate.

Pages are filled until the target size and then flushed. If a column has enough elements to fill at least half a page, there is a mechanism to prevent undersized tail pages: writing uses two page buffers in turns and flushes the previous buffer only once the next buffer is at least at 50%. If the cluster gets flushed with an undersized tail page, the small page is appended to the previous page before flushing. Therefore, tail pages sizes are between `[0.5 * target size .. 1.5 * target size]`.
