### PR TITLE
[tree] Enable TTreeCache even if fAutoFlush == 0

### DIFF
--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -176,7 +176,7 @@ protected:
    Int_t    SetBranchAddressImp(TBranch *branch, void* addr, TBranch** ptr);
    virtual TLeaf   *GetLeafImpl(const char* branchname, const char* leafname);
 
-   Long64_t         GetCacheAutoSize(Bool_t withDefault = kFALSE) const;
+   Long64_t         GetCacheAutoSize(Bool_t withDefault = kFALSE);
    char             GetNewlineValue(std::istream &inputStream);
    void             ImportClusterRanges(TTree *fromtree);
    void             MoveReadCache(TFile *src, TDirectory *dir);

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -161,6 +161,7 @@ private:
    void             SortBranchesByTime();
    Int_t            FlushBasketsImpl() const;
    void             MarkEventCluster();
+   Long64_t         GetMedianClusterSize();
 
 protected:
    virtual void     KeepCircular();

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5379,7 +5379,10 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
       cacheSize = Long64_t(-cacheFactor * fAutoFlush);
    } else if (fAutoFlush == 0) {
       const auto medianClusterSize = GetMedianClusterSize();
-      cacheSize = Long64_t(cacheFactor * 1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
+      if (medianClusterSize > 0)
+         cacheSize = Long64_t(cacheFactor * 1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
+      else
+         cacheSize = Long64_t(cacheFactor * 1.5 * 30000000); // use the default value of fAutoFlush
    } else {
       cacheSize = Long64_t(cacheFactor * 1.5 * fAutoFlush * GetZipBytes() / (fEntries + 1));
    }
@@ -5397,7 +5400,10 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
          cacheSize = -fAutoFlush;
       } else if (fAutoFlush == 0) {
          const auto medianClusterSize = GetMedianClusterSize();
-         cacheSize = Long64_t(1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
+         if (medianClusterSize > 0)
+            cacheSize = Long64_t(1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
+         else
+            cacheSize = Long64_t(cacheFactor * 1.5 * 30000000); // use the default value of fAutoFlush
       } else {
          cacheSize = Long64_t(1.5 * fAutoFlush * GetZipBytes() / (fEntries + 1));
       }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -5358,7 +5358,7 @@ Int_t TTree::GetBranchStyle()
 /// A cache sizing factor is taken from the configuration. If this yields zero
 /// and withDefault is true the historical algorithm for default size is used.
 
-Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ ) const
+Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ )
 {
    const char *stcs;
    Double_t cacheFactor = 0.0;
@@ -5375,9 +5375,14 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ ) const
 
    Long64_t cacheSize = 0;
 
-   if (fAutoFlush < 0) cacheSize = Long64_t(-cacheFactor*fAutoFlush);
-   else if (fAutoFlush == 0) cacheSize = 0;
-   else cacheSize = Long64_t(cacheFactor*1.5*fAutoFlush*GetZipBytes()/(fEntries+1));
+   if (fAutoFlush < 0) {
+      cacheSize = Long64_t(-cacheFactor * fAutoFlush);
+   } else if (fAutoFlush == 0) {
+      const auto medianClusterSize = GetMedianClusterSize();
+      cacheSize = Long64_t(cacheFactor * 1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
+   } else {
+      cacheSize = Long64_t(cacheFactor * 1.5 * fAutoFlush * GetZipBytes() / (fEntries + 1));
+   }
 
    if (cacheSize >= (INT_MAX / 4)) {
       cacheSize = INT_MAX / 4;
@@ -5388,9 +5393,14 @@ Long64_t TTree::GetCacheAutoSize(Bool_t withDefault /* = kFALSE */ ) const
    }
 
    if (cacheSize == 0 && withDefault) {
-      if (fAutoFlush < 0) cacheSize = -fAutoFlush;
-      else if (fAutoFlush == 0) cacheSize = 0;
-      else cacheSize = Long64_t(1.5*fAutoFlush*GetZipBytes()/(fEntries+1));
+      if (fAutoFlush < 0) {
+         cacheSize = -fAutoFlush;
+      } else if (fAutoFlush == 0) {
+         const auto medianClusterSize = GetMedianClusterSize();
+         cacheSize = Long64_t(1.5 * medianClusterSize * GetZipBytes() / (fEntries + 1));
+      } else {
+         cacheSize = Long64_t(1.5 * fAutoFlush * GetZipBytes() / (fEntries + 1));
+      }
    }
 
    return cacheSize;

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -8220,6 +8220,40 @@ void TTree::MarkEventCluster()
     ++fNClusterRange;
 }
 
+/// Estimate the median cluster size for the TTree.
+/// This value provides e.g. a reasonable cache size default if other heuristics fail.
+/// Clusters with size 0 and the very last cluster range, that might not have been committed to fClusterSize yet,
+/// are ignored for the purposes of the calculation.
+Long64_t TTree::GetMedianClusterSize()
+{
+   std::vector<Long64_t> clusterSizesPerRange;
+   clusterSizesPerRange.reserve(fNClusterRange);
+
+   // We ignore cluster sizes of 0 for the purposes of this function.
+   // We also ignore the very last cluster range which might not have been committed to fClusterSize.
+   std::copy_if(fClusterSize, fClusterSize + fNClusterRange, std::back_inserter(clusterSizesPerRange),
+                [](Long64_t size) { return size != 0; });
+
+   std::vector<double> nClustersInRange; // we need to store doubles because of the signature of TMath::Median
+   nClustersInRange.reserve(clusterSizesPerRange.size());
+
+   auto clusterRangeStart = 0ll;
+   for (int i = 0; i < fNClusterRange; ++i) {
+      const auto size = fClusterSize[i];
+      R__ASSERT(size >= 0);
+      if (fClusterSize[i] == 0)
+         continue;
+      const auto nClusters = (1 + fClusterRangeEnd[i] - clusterRangeStart) / fClusterSize[i];
+      nClustersInRange.emplace_back(nClusters);
+      clusterRangeStart = fClusterRangeEnd[i] + 1;
+   }
+
+   R__ASSERT(nClustersInRange.size() == clusterSizesPerRange.size());
+   const auto medianClusterSize =
+      TMath::Median(nClustersInRange.size(), clusterSizesPerRange.data(), nClustersInRange.data());
+   return medianClusterSize;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// This function may be called at the start of a program to change
 /// the default value for fAutoSave (and for SetAutoSave) is -300000000, ie 300 MBytes.


### PR DESCRIPTION
With the current logic, if for some reason fAutoFlush is set to 0
for the TTree, the TTreeCache is disabled.
That is undesirable: we still can and want to do pre-fetching even
if auto-flushing was turned off when writing the TTree.

Other more direct methods to turn off the TTreeCache still work,
e.g. tree->SetCacheSize(0).

## Checklist:

- [x] tested changes locally (complicated because of https://github.com/root-project/root/issues/7366 , but seems mostly ok) 
- [ ] updated the docs (@pcanal let me know if there are docs to update)
- [x] could we set the cachesize to a better value than the autoflush default of ~30MB?

This PR fixes #8713 .
