### PR TITLE
Llvm conflict fix

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -495,9 +495,18 @@ if (builtin_cling)
     set(CLING_CXXFLAGS " ${LLVM_DEFS} -fno-strict-aliasing -Wwrite-strings -Wno-shadow -Wno-unused-parameter -Wno-deprecated-declarations")
   endif()
 
+  # Requires the linker to resolve the symbol internally and prevents
+  # conflicts when linked with another software using also LLVM like in
+  # the problem reported for Julia in
+  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
+  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
+  endif() 
+
   # Set the flags in the parent scope for the rest of the cling-based libraries in ROOT.
   set(CLING_CXXFLAGS ${CLING_CXXFLAGS} PARENT_SCOPE)
-
+  
   string(APPEND CMAKE_CXX_FLAGS ${CLING_CXXFLAGS})
   if (LLVM_ENABLE_PIC AND NOT MSVC)
     # FIXME: LLVM_ENABLE_PIC is ON by default, however not propagated to cling.

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -489,9 +489,18 @@ if (builtin_cling)
     set(CLING_CXXFLAGS " ${LLVM_DEFS} -fno-strict-aliasing -Wwrite-strings -Wno-shadow -Wno-unused-parameter -Wno-deprecated-declarations")
   endif()
 
+  # Requires the linker to resolve the symbol internally and prevents
+  # conflicts when linked with another software using also LLVM like in
+  # the problem reported for Julia in
+  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
+  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
+  endif() 
+
   # Set the flags in the parent scope for the rest of the cling-based libraries in ROOT.
   set(CLING_CXXFLAGS ${CLING_CXXFLAGS} PARENT_SCOPE)
-
+  
   string(APPEND CMAKE_CXX_FLAGS ${CLING_CXXFLAGS})
   if (LLVM_ENABLE_PIC AND NOT MSVC)
     # FIXME: LLVM_ENABLE_PIC is ON by default, however not propagated to cling.

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -497,7 +497,6 @@ if (builtin_cling)
 
   # Set the flags in the parent scope for the rest of the cling-based libraries in ROOT.
   set(CLING_CXXFLAGS ${CLING_CXXFLAGS} PARENT_SCOPE)
-
   string(APPEND CMAKE_CXX_FLAGS ${CLING_CXXFLAGS})
   if (LLVM_ENABLE_PIC AND NOT MSVC)
     # FIXME: LLVM_ENABLE_PIC is ON by default, however not propagated to cling.

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -497,6 +497,7 @@ if (builtin_cling)
 
   # Set the flags in the parent scope for the rest of the cling-based libraries in ROOT.
   set(CLING_CXXFLAGS ${CLING_CXXFLAGS} PARENT_SCOPE)
+
   string(APPEND CMAKE_CXX_FLAGS ${CLING_CXXFLAGS})
   if (LLVM_ENABLE_PIC AND NOT MSVC)
     # FIXME: LLVM_ENABLE_PIC is ON by default, however not propagated to cling.

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -132,6 +132,12 @@ else()
   set(CMAKE_C_VISIBILITY_PRESET hidden)
 endif()
 if (NOT MSVC AND NOT APPLE)
+  # Requires the linker to resolve the symbol internally and prevents
+  # conflicts when linked with another software using also LLVM like in
+  # the problem reported for Julia in
+  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
+  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
+  string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
   ROOT_ADD_CXX_FLAG(CMAKE_CXX_FLAGS "-fno-semantic-interposition")
 endif()
 set(CMAKE_VISIBILITY_INLINES_HIDDEN "ON")
@@ -489,18 +495,9 @@ if (builtin_cling)
     set(CLING_CXXFLAGS " ${LLVM_DEFS} -fno-strict-aliasing -Wwrite-strings -Wno-shadow -Wno-unused-parameter -Wno-deprecated-declarations")
   endif()
 
-  # Requires the linker to resolve the symbol internally and prevents
-  # conflicts when linked with another software using also LLVM like in
-  # the problem reported for Julia in
-  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
-  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
-  endif() 
-
   # Set the flags in the parent scope for the rest of the cling-based libraries in ROOT.
   set(CLING_CXXFLAGS ${CLING_CXXFLAGS} PARENT_SCOPE)
-  
+
   string(APPEND CMAKE_CXX_FLAGS ${CLING_CXXFLAGS})
   if (LLVM_ENABLE_PIC AND NOT MSVC)
     # FIXME: LLVM_ENABLE_PIC is ON by default, however not propagated to cling.

--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -495,18 +495,9 @@ if (builtin_cling)
     set(CLING_CXXFLAGS " ${LLVM_DEFS} -fno-strict-aliasing -Wwrite-strings -Wno-shadow -Wno-unused-parameter -Wno-deprecated-declarations")
   endif()
 
-  # Requires the linker to resolve the symbol internally and prevents
-  # conflicts when linked with another software using also LLVM like in
-  # the problem reported for Julia in
-  # https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292
-  # Only needed for Linux: Mac uses linker namespaces and  Windows explicit export/import
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-Bsymbolic")
-  endif() 
-
   # Set the flags in the parent scope for the rest of the cling-based libraries in ROOT.
   set(CLING_CXXFLAGS ${CLING_CXXFLAGS} PARENT_SCOPE)
-  
+
   string(APPEND CMAKE_CXX_FLAGS ${CLING_CXXFLAGS})
   if (LLVM_ENABLE_PIC AND NOT MSVC)
     # FIXME: LLVM_ENABLE_PIC is ON by default, however not propagated to cling.


### PR DESCRIPTION
@vgvassilev, here is the PR so solve the LLVM library conflicts when interfacing ROOT with Julia. I've limited the change to the interpreter package.

I have 25 out of the 2140 tests that fail. It's likely to be due to my local environment. If it can easily be tested with the jenkins system, it will be faster that me trying to investigate the test failures. 

Note. The parallel compilation is not working properly, independently of my changes: it fails many times and need to be restarted or build some package in single process mode. Is it a know problem ?

# This Pull request:

## Changes or fixes:

Adds -Bsymbolic linker option for libCling.so in order get the symbols resolved internally
    
    This is expected to solve conflicts when interfacing with other software using LLVM, like Julia. See https://github.com/JuliaHEP/ROOT.jl/issues/17#issuecomment-882719292

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


