### PR TITLE
[ntuple] Fix RNTupleModel::GetField in case of empty argument

### DIFF
--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -79,6 +79,9 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
 
 ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RNTupleModel::GetField(std::string_view fieldName)
 {
+   if (fieldName.empty())
+      return nullptr;
+
    auto split_on_dot = [](std::string_view in) {
       std::vector<std::string_view> splits;
       for (std::size_t pos = in.find('.'); pos != std::string_view::npos; pos = in.find('.')) {

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -369,6 +369,7 @@ TEST(RNTupleModel, GetField)
    EXPECT_EQ(m->GetField("cs.v1")->GetName(), "v1");
    EXPECT_EQ(m->GetField("cs.v1")->GetType(), "std::vector<float>");
    EXPECT_EQ(m->GetField("nonexistent"), nullptr);
+   EXPECT_EQ(m->GetField(""), nullptr);
 }
 
 TEST(RNTuple, EmptyString)


### PR DESCRIPTION
Wrong logic ended up returning fFieldZero instead of nullptr.
