### PR TITLE
[TMVA][SOFIE] Parsing models not only from current working directory

### DIFF
--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -162,9 +162,9 @@ RModel RModelParser_ONNX::Parse(std::string filename){
       sep = '\\';
    #endif
    size_t i = filename.rfind(sep, filename.length());
-   std::string modelname;
+   std::string filename_nodir = filename;
    if (i != std::string::npos){
-      filename = (filename.substr(i+1, filename.length() - i));
+      filename_nodir = (filename.substr(i+1, filename.length() - i));
    }
 
 
@@ -179,7 +179,7 @@ RModel RModelParser_ONNX::Parse(std::string filename){
    GOOGLE_PROTOBUF_VERIFY_VERSION;
    //model I/O
    onnx::ModelProto model;
-   RModel rmodel(filename, parsetime);
+   RModel rmodel(filename_nodir, parsetime);
 
    std::unordered_map<std::string, ETensorType> tensor_type;
 


### PR DESCRIPTION

# This Pull request:
This is for not losing the path of the input filename after getting its filename without its path. This allows the parser to read files in any directory (previously, only models in the current working directory could be parsed).

## Changed files:
- /tmva/sofie_parsers/src/RModelParser_ONNX.cxx

## Checklist:

- [x] tested changes locally



