### PR TITLE
[RF] Deprecate RooSetPair class by moving it to RooFitLegacy

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -196,7 +196,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooSegmentedIntegrator1D.h
     RooSegmentedIntegrator2D.h
     RooSentinel.h
-    RooSetPair.h
     RooSetProxy.h
     RooSharedProperties.h
     RooSimGenContext.h
@@ -232,6 +231,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooFitLegacy/RooHashTable.h
     RooFitLegacy/RooMinuit.h
     RooFitLegacy/RooNameSet.h
+    RooFitLegacy/RooSetPair.h
     RooFitLegacy/RooTreeData.h
   SOURCES
     src/BidirMMapPipe.cxx
@@ -414,7 +414,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooSegmentedIntegrator1D.cxx
     src/RooSegmentedIntegrator2D.cxx
     src/RooSentinel.cxx
-    src/RooSetPair.cxx
     src/RooSetProxy.cxx
     src/RooSharedProperties.cxx
     src/RooSimGenContext.cxx
@@ -449,6 +448,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooFitLegacy/RooMinuit.cxx
     src/RooFitLegacy/RooMultiCatIter.cxx
     src/RooFitLegacy/RooNameSet.cxx
+    src/RooFitLegacy/RooSetPair.cxx
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   LIBRARIES

--- a/roofit/roofitcore/inc/RooFitLegacy/RooSetPair.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooSetPair.h
@@ -16,12 +16,12 @@
 #ifndef ROO_SET_PAIR
 #define ROO_SET_PAIR
 
-#include <iostream>
 #include "TObject.h"
-#include "RooArgSet.h"
+#include "TString.h"
 
-class RooLinkedListElem ;
-class TBuffer ;
+#include <ROOT/RConfig.hxx>
+
+class RooArgSet;
 
 class RooSetPair : public TObject {
 public:
@@ -48,7 +48,7 @@ protected:
   RooSetPair(const RooSetPair&) ;
 
   ClassDef(RooSetPair,0) // Utility class holding a pair of RooArgSet pointers
-} ;
+} R__SUGGEST_ALTERNATIVE("Please use std::pair<RooArgSet*,RooArgSet*>");
 
 
 

--- a/roofit/roofitcore/src/RooFitLegacy/RooHashTable.cxx
+++ b/roofit/roofitcore/src/RooFitLegacy/RooHashTable.cxx
@@ -22,7 +22,7 @@
 #include "TCollection.h"
 #include "RooLinkedList.h"
 #include "RooAbsArg.h"
-#include "RooSetPair.h"
+#include "RooFitLegacy/RooSetPair.h"
 
 using namespace std;
 
@@ -32,7 +32,7 @@ ClassImp(RooHashTable);
 /**
 \file RooHashTable.cxx
 \class RooHashTable
-\ingroup Roofitcore
+\ingroup Roofitlegacy
 
 RooHashTable implements a hash table for TObjects. The hashing can be
 done on the object addresses, object names, or using the objects

--- a/roofit/roofitcore/src/RooFitLegacy/RooMinuit.cxx
+++ b/roofit/roofitcore/src/RooFitLegacy/RooMinuit.cxx
@@ -17,7 +17,7 @@
 /**
 \file RooMinuit.cxx
 \class RooMinuit
-\ingroup Roofitcore
+\ingroup Roofitlegacy
 
 RooMinuit is a wrapper class around TFitter/TMinuit that
 provides a seamless interface between the MINUIT functionality

--- a/roofit/roofitcore/src/RooFitLegacy/RooSetPair.cxx
+++ b/roofit/roofitcore/src/RooFitLegacy/RooSetPair.cxx
@@ -17,7 +17,7 @@
 /**
 \file RooSetPair.cxx
 \class RooSetPair
-\ingroup Roofitcore
+\ingroup Roofitlegacy
 
 RooSetPair is a utility class that stores a pair of RooArgSets
 **/
@@ -26,7 +26,7 @@ RooSetPair is a utility class that stores a pair of RooArgSets
 #include "TROOT.h"
 
 #define ROOSETPAIR_CXX
-#include "RooSetPair.h"
+#include "RooFitLegacy/RooSetPair.h"
 
 using namespace std;
 


### PR DESCRIPTION
The RooSetPair is not used in non-legacy RooFit code anymore, and it can easily be replaced by a `std::pair<RooArgSet*,RooArgSet*>`.

