### PR TITLE
[RF] Change signature of RooFit cross-collection constructors

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -119,6 +119,7 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tf_pycallables tf_pycallables.py)
 if(roofit)
   # RooAbsCollection and subclasses pythonizations
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabscollection roofit/rooabscollection.py)
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooarglist roofit/rooarglist.py)
 
   # RooDataHist pythonisations
   ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_ploton roofit/roodatahist_ploton.py)

--- a/bindings/pyroot/pythonizations/test/roofit/rooarglist.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooarglist.py
@@ -1,0 +1,30 @@
+import unittest
+
+import ROOT
+
+
+class TestRooArgList(unittest.TestCase):
+    """
+    Test for RooArgList pythonizations.
+    """
+
+    def test_conversion_from_python_collection(self):
+
+        # General check that the conversion from string or tuple works, using
+        # constants to get compact test code.
+        l1 = ROOT.RooArgList([1.0, 2.0, 3.0])
+        self.assertEqual(len(l1), 3)
+
+        l2 = ROOT.RooArgList((1.0, 2.0, 3.0))
+        self.assertEqual(len(l2), 3)
+
+        # Let's make sure that we can add two arguments with the same name to
+        # the RooArgList. Here, we try to add the same RooConst two times. The
+        # motivation for this test if the RooArgList is created via an
+        # intermediate RooArgSet, which should not happen.
+        l3 = ROOT.RooArgList([1.0, 2.0, 2.0])
+        self.assertEqual(len(l3), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -24,7 +24,7 @@ public:
 
   // Constructors, assignment etc.
   RooArgList();
-  RooArgList(const RooArgSet& set) ;
+  RooArgList(const RooAbsCollection& coll) ;
   explicit RooArgList(const TCollection& tcoll, const char* name="") ;
   explicit RooArgList(const char *name);
   /// Construct a (non-owning) RooArgList from one or more

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -119,7 +119,7 @@ public:
   RooArgSet(const RooArgSet& set1, const RooArgSet& set2,
             const char *name="");
 
-  RooArgSet(const RooArgList& list) ;
+  RooArgSet(const RooAbsCollection& coll) ;
   RooArgSet(const RooAbsCollection& collection, const RooAbsArg* var1);
   explicit RooArgSet(const TCollection& tcoll, const char* name="") ;
   explicit RooArgSet(const char *name);

--- a/roofit/roofitcore/src/RooArgList.cxx
+++ b/roofit/roofitcore/src/RooArgList.cxx
@@ -66,12 +66,12 @@ RooArgList::RooArgList() :
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor from a RooArgSet. 
+/// Constructor from another RooAbsCollection.
 
-RooArgList::RooArgList(const RooArgSet& set) :
-  RooAbsCollection(set.GetName())
+RooArgList::RooArgList(const RooAbsCollection& coll) :
+  RooAbsCollection(coll.GetName())
 {
-  add(set) ;
+  add(coll) ;
   TRACE_CREATE
 }
 

--- a/roofit/roofitcore/src/RooArgSet.cxx
+++ b/roofit/roofitcore/src/RooArgSet.cxx
@@ -154,10 +154,10 @@ RooArgSet::RooArgSet() :
 /// Constructor from a RooArgList. If the list contains multiple
 /// objects with the same name, only the first is store in the set.
 /// Warning messages will be printed for dropped items.
-RooArgSet::RooArgSet(const RooArgList& list) :
-  RooAbsCollection(list.GetName())
+RooArgSet::RooArgSet(const RooAbsCollection& coll) :
+  RooAbsCollection(coll.GetName())
 {
-  add(list,kTRUE) ; // verbose to catch duplicate errors
+  add(coll,true) ; // verbose to catch duplicate errors
   TRACE_CREATE
 }
 

--- a/tutorials/roofit/rf704_amplitudefit.py
+++ b/tutorials/roofit/rf704_amplitudefit.py
@@ -29,20 +29,8 @@ coshGConv = tm.convolution(coshGBasis, t)
 sinhGConv = tm.convolution(sinhGBasis, t)
 
 # Construct polynomial amplitudes in cos(a)
-poly1 = ROOT.RooPolyVar(
-    "poly1",
-    "poly1",
-    cosa,
-    ROOT.RooArgList(ROOT.RooFit.RooConst(0.5), ROOT.RooFit.RooConst(0.2), ROOT.RooFit.RooConst(0.2)),
-    0,
-)
-poly2 = ROOT.RooPolyVar(
-    "poly2",
-    "poly2",
-    cosa,
-    ROOT.RooArgList(ROOT.RooFit.RooConst(1), ROOT.RooFit.RooConst(-0.2), ROOT.RooFit.RooConst(3)),
-    0,
-)
+poly1 = ROOT.RooPolyVar("poly1", "poly1", cosa, [0.5, 0.2, 0.2], 0)
+poly2 = ROOT.RooPolyVar("poly2", "poly2", cosa, [1.0, -0.2, 3.0], 0)
 
 # Construct 2D amplitude as uncorrelated product of amp(t)*amp(cosa)
 ampl1 = ROOT.RooProduct("ampl1", "amplitude 1", [poly1, coshGConv])


### PR DESCRIPTION
In RooFit, there is a RooArgList constructor taking a RooArgSet and the
other way around. This is bad for pyROOT, because these constructors
might call each other, causing a RooArgList to be created via an
intermediate RooArgSet and vice versa.

To fix this, the signature of these constructors is changed to take a
general RooAbsCollection.
