### PR TITLE
[v624][RF] Fix size of output span from `RooUniform::evaluateSpan()`

### DIFF
--- a/roofit/roofit/src/RooUniform.cxx
+++ b/roofit/roofit/src/RooUniform.cxx
@@ -57,7 +57,14 @@ RooSpan<double> RooUniform::evaluateSpan(RooBatchCompute::RunContext& evalData, 
 {
   size_t nEvents = 1;
   for (auto elm : x) {
-    nEvents *= static_cast<const RooAbsReal*>(elm)->getValues(evalData).size();
+    size_t nEventsCurrent = static_cast<const RooAbsReal*>(elm)->getValues(evalData).size();
+    if(nEventsCurrent != 1 && nEvents != 1 && nEventsCurrent != nEvents) {
+      auto errorMsg = std::string("RooUniform::evaluateSpan(): number of entries for input variables does not match")
+                      + "in RooUniform with name \"" + GetName() + "\".";
+      coutE(FastEvaluations) << errorMsg << std::endl ;
+      throw std::runtime_error(errorMsg);
+    }
+    nEvents = std::max(nEvents, nEventsCurrent);
   }
   RooSpan<double> values = evalData.makeBatch(this, nEvents);
   for (size_t i=0; i<nEvents; i++) {


### PR DESCRIPTION
The size of the output span from the RooUniform in batch mode should be
the same as the size of the input spans, not the product of all sizes of
the input batches. This fixes a bug reported on the forum:

https://root-forum.cern.ch/t/rooaddpdf-evaluatespan-breaks-if-it-contains-a-roouniform

This is a backport of https://github.com/root-project/root/pull/8733.