### PR TITLE
[cling,tcling] Allow reporting cling diagnostics via the ROOT error handler

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -267,6 +267,8 @@ public:
            int    SetClassAutoloading(int a) const { return SetClassAutoLoading(a); }  // Deprecated
    virtual int    SetClassAutoparsing(int) {return 0;};
    virtual void   SetErrmsgcallback(void * /* p */) const {;}
+   /// \brief Report diagnostics to the ROOT error handler (see TError.h).
+   virtual void   ReportDiagnosticsToErrorHandler(bool /*enable*/ = true) {}
    virtual void   SetTempLevel(int /* val */) const {;}
    virtual int    UnloadFile(const char * /* path */) const {return 0;}
 

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -10,9 +10,11 @@
 
 if(MSVC)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -GR-)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingDiagnostics.cxx COMPILE_FLAGS -GR-)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingRdictModuleFileExtension.cxx COMPILE_FLAGS -GR-)
 else()
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -fno-rtti)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingDiagnostics.cxx COMPILE_FLAGS -fno-rtti)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingRdictModuleFileExtension.cxx COMPILE_FLAGS -fno-rtti)
 endif()
 
@@ -25,6 +27,7 @@ ROOT_OBJECT_LIBRARY(MetaCling
   TClingClassInfo.cxx
   TClingDataMemberInfo.cxx
   TClingDeclInfo.cxx
+  TClingDiagnostics.cxx
   TClingMemberIter.cxx
   TClingMethodArgInfo.cxx
   TClingMethodInfo.cxx

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -354,6 +354,7 @@ public: // Public Interface
    virtual int    SetClassAutoparsing(int) ;
            Bool_t IsAutoParsingSuspended() const { return fIsAutoParsingSuspended; }
    virtual void   SetErrmsgcallback(void* p) const;
+   virtual void   ReportDiagnosticsToErrorHandler(bool enable = true);
    virtual void   SetTempLevel(int val) const;
    virtual int    UnloadFile(const char* path) const;
 

--- a/core/metacling/src/TClingDiagnostics.cxx
+++ b/core/metacling/src/TClingDiagnostics.cxx
@@ -1,0 +1,29 @@
+// @(#)root/core/metacling:$Id$
+// Author: Javier Lopez-Gomez   16/07/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TClingDiagnostics.h"
+
+TClingDelegateDiagnosticPrinter::TClingDelegateDiagnosticPrinter
+(clang::DiagnosticOptions *DiagOpts, clang::LangOptions &LangOpts, handler_t fn)
+  : TextDiagnosticPrinter(fOS, DiagOpts), fOS(fOS_out), fHandler(fn)
+{
+   // Required to initialize the internal `clang::TextDiagnostic` instance.
+   TextDiagnosticPrinter::BeginSourceFile(LangOpts, nullptr);
+}
+
+void
+TClingDelegateDiagnosticPrinter::HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                                                  const clang::Diagnostic &Info)
+{
+   fOS_out.clear();
+   TextDiagnosticPrinter::HandleDiagnostic(Level, Info);
+   fHandler(Level, fOS.str());
+}

--- a/core/metacling/src/TClingDiagnostics.h
+++ b/core/metacling/src/TClingDiagnostics.h
@@ -1,0 +1,45 @@
+// @(#)root/core/metacling:$Id$
+// Author: Javier Lopez-Gomez   16/07/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TClingDiagnostics
+#define ROOT_TClingDiagnostics
+
+#include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+namespace clang {
+   class LangOptions;
+}
+
+/// \brief Uses `clang::TextDiagnosticPrinter` to format diagnostics, which
+///  are then passed to a user-specified function.
+///
+class TClingDelegateDiagnosticPrinter : public clang::TextDiagnosticPrinter {
+public:
+   typedef void (*handler_t)(clang::DiagnosticsEngine::Level Level,
+                             const std::string &Info);
+private:
+   std::string fOS_out;
+   llvm::raw_string_ostream fOS;
+   handler_t fHandler;
+
+public:
+   TClingDelegateDiagnosticPrinter(clang::DiagnosticOptions *DiagOpts,
+                                   clang::LangOptions &LangOpts, handler_t fn);
+   ~TClingDelegateDiagnosticPrinter() override = default;
+
+   void HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                         const clang::Diagnostic &Info) override;
+};
+
+#endif // ROOT_TClingDiagnostics

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -37,6 +37,7 @@ namespace clang {
   class CompilerInstance;
   class Decl;
   class DeclContext;
+  class DiagnosticConsumer;
   class DiagnosticsEngine;
   class FunctionDecl;
   class GlobalDecl;
@@ -338,6 +339,8 @@ namespace cling {
                       nullptr) {}
 
     ///\brief Constructor for child Interpreter.
+    /// If the parent Interpreter has a replacement DiagnosticConsumer, it is
+    /// inherited by the child (not owned).
     ///\param[in] parentInterpreter - the  parent interpreter of this interpreter
     ///\param[in] argc - no. of args.
     ///\param[in] argv - arguments passed when driver is invoked.
@@ -694,6 +697,13 @@ namespace cling {
     clang::CompilerInstance* getCIOrNull() const;
     clang::Sema& getSema() const;
     clang::DiagnosticsEngine& getDiagnostics() const;
+
+    /// \brief Replaces the default DiagnosticConsumer.
+    /// \param[in] Consumer - The replacement `clang::DiagnosticConsumer`
+    /// \param[in] Own - Whether the pointee is owned by this instance.
+    ///
+    void replaceDiagnosticConsumer(clang::DiagnosticConsumer* Consumer, bool Own = false);
+    bool hasReplacedDiagnosticConsumer() const;
 
     IncrementalCUDADeviceCompiler* getCUDACompiler() const {
       return m_CUDACompiler.get();

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -127,6 +127,9 @@ namespace cling {
     clang::CodeGenerator* getCodeGenerator() const { return m_CodeGen; }
     bool hasCodeGenerator() const { return m_CodeGen; }
 
+    void setDiagnosticConsumer(clang::DiagnosticConsumer* Consumer, bool Own);
+    clang::DiagnosticConsumer* getDiagnosticConsumer() const;
+
     /// Returns the next available unique source location. It is an offset into
     /// the limitless virtual file. Each time this interface is used it bumps
     /// an internal counter. This is very useful for using the various API in

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -371,6 +371,9 @@ namespace cling {
       // Give my IncrementalExecutor a pointer to the Incremental executor of the
       // parent Interpreter.
       m_Executor->setExternalIncrementalExecutor(parentInterpreter.m_Executor.get());
+
+      if (auto C = parentInterpreter.m_IncrParser->getDiagnosticConsumer())
+        m_IncrParser->setDiagnosticConsumer(C, /*Own=*/false);
     }
   }
 
@@ -747,6 +750,15 @@ namespace cling {
 
   DiagnosticsEngine& Interpreter::getDiagnostics() const {
     return getCI()->getDiagnostics();
+  }
+
+  void Interpreter::replaceDiagnosticConsumer(clang::DiagnosticConsumer* Consumer,
+					      bool Own) {
+    m_IncrParser->setDiagnosticConsumer(Consumer, Own);
+  }
+
+  bool Interpreter::hasReplacedDiagnosticConsumer() const {
+    return m_IncrParser->getDiagnosticConsumer() != nullptr;
   }
 
   CompilationOptions Interpreter::makeDefaultCompilationOpts() const {


### PR DESCRIPTION
This PR enables cling diagnostics to be reported via the ROOT error handler, as required by the experiments.  Independently, this error handler may be changed by the user (see `TError.h`), e.g.

```
root [0] int f() { return; }
ROOT_prompt_0:1:11: non-void function 'f' should return a value [-Wreturn-type]
int f() { return; }
          ^

root [1] gInterpreter->ReportDiagnosticsToErrorHandler();
root [2] int f() { return; }
Error in <cling>: ROOT_prompt_2:1:11: non-void function 'f' should return a value [-Wreturn-type]
int f() { return; }
          ^
root [3] // Note the previous error is reported through the default ROOT error handler.
```
## Changes in this PR
- Required changes to `FilteringDiagConsumer` (in IncrementalParser.cpp). 
- Two member functions have been added to the `Interpreter` class:
    - `void replaceDiagnosticConsumer(clang::DiagnosticConsumer* Consumer, bool Own)`: replaces the default CIFactory-provided diagnostic consumer.
    - `bool hasReplacedDiagnosticConsumer()`: returns whether the default diagnostic consumer has been replaced.
- Added `void TCling::ReportDiagnosticsToErrorHandler(bool enable)` member function.

This PR closes JIRA issue [ROOT-7587](https://sft.its.cern.ch/jira/browse/ROOT-7587).

Link to sibling PR in `roottest` repository: https://github.com/root-project/roottest/pull/761.