### PR TITLE
[TREE] Utility to enter a range of entries in TEntryList

### DIFF
--- a/tree/tree/inc/TEntryList.h
+++ b/tree/tree/inc/TEntryList.h
@@ -66,6 +66,7 @@ class TEntryList: public TNamed
    virtual Int_t       Contains(Long64_t entry, TTree *tree = 0);
    virtual void        DirectoryAutoAdd(TDirectory *);
    virtual Bool_t      Enter(Long64_t entry, TTree *tree = 0);
+   void                EnterRange(Long64_t start, Long64_t end, TTree *tree = nullptr, UInt_t step = 1U);
    virtual TEntryList *GetCurrentList() const { return fCurrent; };
    virtual TEntryList *GetEntryList(const char *treename, const char *filename, Option_t *opt="");
    virtual Long64_t    GetEntry(Int_t index);

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -672,6 +672,24 @@ Bool_t TEntryList::Enter(Long64_t entry, TTree *tree)
 
 }
 
+/////////////////////////////////////////////////////////////////////////////
+/// \brief Enter all entries in a range in the TEntryList.
+/// \param[in] start starting entry to enter.
+/// \param[in] end ending entry to enter.
+/// \param[in] tree passed as is to TEntryList::Enter.
+/// \param[in] step step increase of the loop entering the entries.
+///
+/// This is a helper function that enters all entries between \p start
+/// (inclusive) and \p end (exclusive) to the TEntryList in a loop. It
+/// is useful also in PyROOT to avoid having to do the same in a Python loop.
+
+void TEntryList::EnterRange(Long64_t start, Long64_t end, TTree *tree, UInt_t step)
+{
+   for (auto entry = start; entry < end; entry += step) {
+      this->Enter(entry, tree);
+   }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Remove entry \#entry from the list
 /// - When tree = 0, removes from the current list

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -33,3 +33,4 @@ ROOT_ADD_GTEST(testTTreeTruncatedDatatypes TTreeTruncatedDatatypes.cxx LIBRARIES
 ROOT_ADD_GTEST(testTTreeRegressions TTreeRegressions.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(entrylist_addsublist entrylist_addsublist.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(chain_setentrylist chain_setentrylist.cxx LIBRARIES RIO Tree)
+ROOT_ADD_GTEST(entrylist_enterrange entrylist_enterrange.cxx LIBRARIES RIO Tree)

--- a/tree/tree/test/entrylist_enterrange.cxx
+++ b/tree/tree/test/entrylist_enterrange.cxx
@@ -1,0 +1,62 @@
+#include <memory>
+#include <string.h>
+
+#include "TEntryList.h"
+#include "TFile.h"
+#include "TSystem.h"
+#include "TTree.h"
+
+#include "gtest/gtest.h"
+
+void FillTree(const char *filename, const char *treeName, int nevents)
+{
+   TFile f{filename, "RECREATE"};
+   TTree t{treeName, treeName};
+
+   int b;
+   t.Branch("b1", &b);
+
+   for (int i = 0; i < nevents; ++i) {
+      b = i * 10;
+      t.Fill();
+   }
+
+   t.Write();
+   f.Close();
+}
+
+TEST(TEntryList, enterRange)
+{
+   const auto start1{10};
+   const auto end1{20};
+   auto treename1{"entrylist_enterrange_tree20entries"};
+   auto filename1{"entrylist_enterrange_tree20entries.root"};
+   const auto nentries1{20};
+
+   FillTree(filename1, treename1, nentries1);
+
+   TFile f{filename1};
+   std::unique_ptr<TTree> t{f.Get<TTree>(treename1)};
+   int b1;
+   t->SetBranchAddress("b1", &b1);
+
+   TEntryList elist{"", "", treename1, filename1};
+   elist.EnterRange(start1, end1);
+
+   t->SetEntryList(&elist);
+
+   EXPECT_EQ(elist.GetN(), 10);
+   EXPECT_EQ(t->GetEntries(), 20);
+   // The branch "b1" of the test tree holds integers in the range [0, 20)
+   // multiplied by 10. We traverse the tree with the entry numbers in the
+   // TEntryList and check that they have the expected value.
+   for (auto entry = 0; entry < elist.GetN(); entry++) {
+      t->GetEntry(elist.GetEntry(entry));
+      // We added the range of entries with values [10, 20) multiplied by 10 to
+      // the TEntryList
+      auto correct_value = (entry + 10) * 10;
+      EXPECT_EQ(b1, correct_value);
+   }
+
+   gSystem->Unlink(filename1);
+}


### PR DESCRIPTION
Add a utility function to call `TEntryList::Enter` with entries in a certain range, instead of having to do the loop manually. Especially useful in PyROOT to avoid doing the same in a Python loop
### Initial idea
```py
>>> import ROOT
>>> e = ROOT.TEntryList()
>>> e.GetN()
0
>>> ROOT.ROOT.Detail.EnterRange(e, 0, 10)
>>> e.GetN()
10
```

Not sure about the namespace and the naming, can be discussed

### Final interface

```py
>>> import ROOT
>>> e = ROOT.TEntryList()
>>> e.EnterRange(0,10)
>>> e.GetN()
10
```