### PR TITLE
[TTreeProcessorMT] Use unambiguous syntax when building chains 

### DIFF
--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -83,7 +83,7 @@ ConvertToElistClusters(std::vector<std::vector<EntryCluster>> &&clusters, TEntry
       // we need `chain` to be able to convert local entry numbers to global entry numbers in `Next`
       chain.reset(new TChain());
       for (auto i = 0u; i < nFiles; ++i)
-         chain->Add((fileNames[i] + "/" + treeNames[i]).c_str(), entriesPerFile[i]);
+         chain->Add((fileNames[i] + "?query#" + treeNames[i]).c_str(), entriesPerFile[i]);
       Next = [](Long64_t &elEntry, TEntryList &elist, TChain *ch) {
          ++elEntry;
          int treenum = -1;
@@ -295,7 +295,7 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
    fChain.reset(new TChain());
    const auto nFiles = fileNames.size();
    for (auto i = 0u; i < nFiles; ++i) {
-      fChain->Add((fileNames[i] + "/" + treeNames[i]).c_str(), nEntries[i]);
+      fChain->Add((fileNames[i] + "?query#" + treeNames[i]).c_str(), nEntries[i]);
    }
    fChain->ResetBit(TObject::kMustCleanup);
 
@@ -322,7 +322,7 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
          // "filename/treename" as argument to `TChain::Add`
       } else {
          for (auto j = 0u; j < nFileNames; ++j) {
-            frChain->Add((thisFriendFiles[j] + "/" + thisFriendChainSubNames[j]).c_str(), thisFriendEntries[j]);
+            frChain->Add((thisFriendFiles[j] + "?query#" + thisFriendChainSubNames[j]).c_str(), thisFriendEntries[j]);
          }
       }
 


### PR DESCRIPTION
chain->Add("filename/treename") is ambiguous when filename does not
end in `.root`: in that case `TChain` interprets its argument
as the full path to the file, with no treename specified.

We now instead use the unambiguous syntax "filename?query#treename"
when building chains in TTreeProcessorMT.

This fixes #8739 (reading files with no `.root` extension in RDF's
multi-thread event loops).

Companion PR https://github.com/root-project/roottest/pull/758 adds a test.