### PR TITLE
[DF][treereader] Use kEntryBeyondEnd, not kEntryNotFound if appropriate 

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -473,7 +473,7 @@ void RLoopManager::RunTreeReader()
       std::cerr << "RDataFrame::Run: event loop was interrupted\n";
       throw;
    }
-   if (r.GetEntryStatus() != TTreeReader::kEntryNotFound && fNStopsReceived < fNChildren) {
+   if (r.GetEntryStatus() != TTreeReader::kEntryBeyondEnd && fNStopsReceived < fNChildren) {
       // something went wrong in the TTreeReader event loop
       throw std::runtime_error("An error was encountered while processing the data. TTreeReader status code is: " +
                                std::to_string(r.GetEntryStatus()));

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -1280,7 +1280,6 @@ Int_t TChain::LoadBaskets(Long64_t /*maxmemory*/)
 /// In case of error, LoadTree returns a negative number:
 ///   * -1: The chain is empty.
 ///   * -2: The requested entry number is less than zero or too large for the chain.
-///       or too large for the large TTree.
 ///   * -3: The file corresponding to the entry could not be correctly open
 ///   * -4: The TChainElement corresponding to the entry is missing or
 ///       the TTree is missing from the file.

--- a/tree/treeplayer/src/TTreeReader.cxx
+++ b/tree/treeplayer/src/TTreeReader.cxx
@@ -521,7 +521,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
          // don't try to load entries anymore. Can happen in these cases:
          // while (tr.Next()) {something()};
          // while (tr.Next()) {somethingelse()}; // should not be calling somethingelse().
-         fEntryStatus = kEntryNotFound;
+         fEntryStatus = kEntryBeyondEnd;
          return fEntryStatus;
       }
       if (entry >= 0) {
@@ -574,7 +574,7 @@ TTreeReader::EEntryStatus TTreeReader::SetEntryBase(Long64_t entry, Bool_t local
                value->NotifyNewTree(fTree->GetTree());
             }
          }
-         fEntryStatus = kEntryNotFound;
+         fEntryStatus = kEntryBeyondEnd;
          return fEntryStatus;
       }
 

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -233,7 +233,7 @@ TEST(TTreeReaderBasic, ZeroEntryRange) {
    // Read beyond end:
    EXPECT_FALSE(tr.Next());
    // As the TTree only has up to entry 19, 20 is kEntryNotFound:
-   EXPECT_EQ(TTreeReader::kEntryNotFound, tr.GetEntryStatus());
+   EXPECT_EQ(TTreeReader::kEntryBeyondEnd, tr.GetEntryStatus());
    EXPECT_EQ(20, tr.GetCurrentEntry());
 }
 
@@ -255,7 +255,7 @@ TEST(TTreeReaderBasic, InvertedEntryRange) {
    // Read beyond end:
    EXPECT_FALSE(tr.Next());
    // As the TTree only has up to entry 19, 20 is kEntryNotFound:
-   EXPECT_EQ(TTreeReader::kEntryNotFound, tr.GetEntryStatus());
+   EXPECT_EQ(TTreeReader::kEntryBeyondEnd, tr.GetEntryStatus());
    EXPECT_EQ(20, tr.GetCurrentEntry());
 }
 
@@ -305,7 +305,7 @@ TEST(TTreeReaderBasic, EntryListBeyondEnd) {
 
    EXPECT_FALSE(aReader.Next());
    EXPECT_EQ(1, aReader.GetCurrentEntry());
-   EXPECT_EQ(TTreeReader::kEntryNotFound, aReader.GetEntryStatus());
+   EXPECT_EQ(TTreeReader::kEntryBeyondEnd, aReader.GetEntryStatus());
 }
 
 // two files treereader_entrylists{1,2}.root with branch "x" and values {0,1} and {2,3}


### PR DESCRIPTION
kEntryBeyondEnd is what is expected to be set at the end of a `while(r.Next())` event loop.

This change is not backward-compatible if anyone relied on `kEntryNotFound` being set even at the end of a well-behaved event loop.

On the other hand, the second usage example in TTreeReader's docs (https://root.cern/doc/master/classTTreeReader.html) as well as the names of the enum values seem to indicate that `kEntryNotFound` is an error state and `kEntryBeyondEnd` is what indicates a normal completion of the event loop.

P.S.
to be clear, the problem I'm trying to solve is that in the current state it's hard (maybe impossible) to distinguish between a TTreeReader event loop that ended well and one that ended because an entry that was supposed to be there was not found