### PR TITLE
[DF] Throw from MT loops if TTreeReader had a problem 

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -451,6 +451,13 @@ void RLoopManager::RunTreeProcessorMT()
          std::cerr << "RDataFrame::Run: event loop was interrupted\n";
          throw;
       }
+      // fNStopsReceived < fNChildren is always true at the moment as we don't support event loop early quitting in
+      // multi-thread runs, but it costs nothing to be safe and future-proof in case we add support for that later.
+      if (r.GetEntryStatus() != TTreeReader::kEntryBeyondEnd && fNStopsReceived < fNChildren) {
+         // something went wrong in the TTreeReader event loop
+         throw std::runtime_error("An error was encountered while processing the data. TTreeReader status code is: " +
+                                  std::to_string(r.GetEntryStatus()));
+      }
    });
 #endif // no-op otherwise (will not be called)
 }


### PR DESCRIPTION
Before this commit, in single-thread event loops RDF was throwing
in case TTreeReader had an error flag at the end of the loop.
Now multi-thread loops perform the same check at the end of each task.

