### PR TITLE
[RF][PyROOT] Pythonize RooArgSet constructor to accept a Python `set`

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooargset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooargset.py
@@ -17,6 +17,20 @@ import operator
 
 
 class RooArgSet(RooAbsCollection):
+    def __init__(self, *args, **kwargs):
+        """Pythonization of RooArgSet constructor to support implicit
+        conversion from Python sets.
+        """
+        # Note: This simple Pythonization caused me days of headache.
+        # Initially, I was also checking of `len(kwargs) == 0`, but it just
+        # didn't work. Eventually, I understood that when cppy attempts
+        # implicit conversion, a magic `__cppyy_no_implicit=True` keyword
+        # argument is added, hence the `len(kwargs) == 0` check breaks the
+        # implicit conversion!
+        if len(args) == 1 and isinstance(args[0], set):
+            return self._init(*args[0], **kwargs)
+        return self._init(*args, **kwargs)
+
     def __getitem__(self, key):
 
         # other than the RooArgList, the RooArgSet also supports string keys

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_utils.py
@@ -12,47 +12,47 @@
 ################################################################################
 
 
-def _getter(k, v):
-    # helper function to get CmdArg attribute from `RooFit`
-    # Parameters:
-    # k: key of the kwarg
-    # v: value of the kwarg
-
-    # We have to use ROOT here and not cppy.gbl, because the RooFit namespace is pythonized itself.
-    import ROOT
-    import libcppyy
-
-    func = getattr(ROOT.RooFit, k)
-
-    if isinstance(func, libcppyy.CPPOverload):
-        # Pythonization for functions that don't pass any RooCmdArgs like ShiftToZero() and MoveToBack(). For Eg,
-        # Default bindings: pdf.plotOn(frame, ROOT.RooFit.MoveToBack())
-        # With pythonizations: pdf.plotOn(frame, MoveToBack=True)
-
-        if "()" in func.func_doc:
-            if not isinstance(v, bool):
-                raise TypeError("The keyword argument " + k + " can only take bool values.")
-            return func() if v else ROOT.RooCmdArg.none()
-
-    try:
-        # If the keyword argument value is a tuple, list, or dict, first
-        # try to unpack it as parameters to the RooCmdArg-generating
-        # function. If this doesn't succeed, the tuple, list, or dict,
-        # will be passed directly to the function as it's only argument.
-        if isinstance(v, (tuple, list)):
-            return func(*v)
-        elif isinstance(v, (dict,)):
-            return func(**v)
-    except:
-        pass
-
-    return func(v)
-
-
 def _kwargs_to_roocmdargs(*args, **kwargs):
-    """Helper function to check kwargs and pythonize the arguments using _getter"""
+    """Helper function to check kwargs with keys that correspond to a function that creates RooCmdArg."""
+
+    def getter(k, v):
+        # helper function to get CmdArg attribute from `RooFit`
+        # Parameters:
+        # k: key of the kwarg
+        # v: value of the kwarg
+
+        # We have to use ROOT here and not cppy.gbl, because the RooFit namespace is pythonized itself.
+        import ROOT
+        import libcppyy
+
+        func = getattr(ROOT.RooFit, k)
+
+        if isinstance(func, libcppyy.CPPOverload):
+            # Pythonization for functions that don't pass any RooCmdArgs like ShiftToZero() and MoveToBack(). For Eg,
+            # Default bindings: pdf.plotOn(frame, ROOT.RooFit.MoveToBack())
+            # With pythonizations: pdf.plotOn(frame, MoveToBack=True)
+
+            if "()" in func.func_doc:
+                if not isinstance(v, bool):
+                    raise TypeError("The keyword argument " + k + " can only take bool values.")
+                return func() if v else ROOT.RooCmdArg.none()
+
+        try:
+            # If the keyword argument value is a tuple, list, set, or dict, first
+            # try to unpack it as parameters to the RooCmdArg-generating
+            # function. If this doesn't succeed, the tuple, list, or dict,
+            # will be passed directly to the function as it's only argument.
+            if isinstance(v, (tuple, list, set)):
+                return func(*v)
+            elif isinstance(v, (dict,)):
+                return func(**v)
+        except:
+            pass
+
+        return func(v)
+
     if kwargs:
-        args = args + tuple((_getter(k, v) for k, v in kwargs.items()))
+        args = args + tuple((getter(k, v) for k, v in kwargs.items()))
     return args, {}
 
 

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -110,8 +110,11 @@ RooCmdArg ShowProgress() ;
 
 // RooAbsPdf::plotOn arguments
 RooCmdArg Normalization(Double_t scaleFactor, Int_t scaleType) ;
-RooCmdArg Components(const RooArgSet& compSet) ;
-RooCmdArg Components(RooArgSet && compSet) ;
+template<class... Args_t>
+RooCmdArg Components(Args_t &&... argsOrArgSet) {
+  return RooCmdArg("SelectCompSet",0,0,0,0,0,0,
+          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}), 0);
+}
 RooCmdArg Components(const char* compSpec) ;
 
 // RooAbsData::plotOn arguments
@@ -310,8 +313,11 @@ RooCmdArg Scaling(Bool_t flag) ;
 RooCmdArg IntrinsicBinning(Bool_t flag=kTRUE) ;
 
 // RooAbsReal::createIntegral arguments
-RooCmdArg NormSet(const RooArgSet& nset) ;
-RooCmdArg NormSet(RooArgSet && nset) ;
+template<class... Args_t>
+RooCmdArg NormSet(Args_t &&... argsOrArgSet) {
+  return RooCmdArg("NormSet",0,0,0,0,0,0,
+          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}), 0);
+}
 RooCmdArg NumIntConfig(const RooNumIntConfig& cfg) ;
 
 // RooMCStudy::ctor arguments

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -115,8 +115,6 @@ namespace RooFit {
   RooCmdArg ShowProgress()                         { return RooCmdArg("ShowProgress",1,0,0,0,0,0,0,0) ; }
   
   // RooAbsPdf::plotOn arguments
-  RooCmdArg Components(const RooArgSet& compSet) { return RooCmdArg("SelectCompSet",0,0,0,0,0,0,&compSet,0) ; }
-  RooCmdArg Components(RooArgSet && compSet) { return Components(RooCmdArg::take(std::move(compSet))); }
   RooCmdArg Components(const char* compSpec) { return RooCmdArg("SelectCompSpec",0,0,0,0,compSpec,0,0,0) ; }
   RooCmdArg Normalization(Double_t scaleFactor, Int_t scaleType) 
                                                    { return RooCmdArg("Normalization",scaleType,0,scaleFactor,0,0,0,0,0) ; }
@@ -301,8 +299,6 @@ namespace RooFit {
   RooCmdArg IntegratedObservables(RooArgSet && intObs) { return IntegratedObservables(RooCmdArg::take(std::move(intObs))); }
  
   // RooAbsReal::createIntegral arguments
-  RooCmdArg NormSet(const RooArgSet& nset)           { return RooCmdArg("NormSet",0,0,0,0,0,0,&nset,0) ; }
-  RooCmdArg NormSet(RooArgSet && nset) { return NormSet(RooCmdArg::take(std::move(nset))); }
   RooCmdArg NumIntConfig(const RooNumIntConfig& cfg) { return RooCmdArg("NumIntConfig",0,0,0,0,0,0,&cfg,0) ; }
 
   // RooMCStudy::ctor arguments

--- a/tutorials/roofit/rf101_basics.py
+++ b/tutorials/roofit/rf101_basics.py
@@ -38,7 +38,7 @@ gauss.plotOn(xframe, LineColor="r")
 # Generate events
 # -----------------------------
 # Generate a dataset of 1000 events in x from gauss
-data = gauss.generate(ROOT.RooArgSet(x), 10000)  # ROOT.RooDataSet
+data = gauss.generate({x}, 10000)  # ROOT.RooDataSet
 
 # Make a second plot frame in x and draw both the
 # data and the pdf in the frame

--- a/tutorials/roofit/rf102_dataimport.py
+++ b/tutorials/roofit/rf102_dataimport.py
@@ -103,7 +103,7 @@ y = ROOT.RooRealVar("y", "y", -10, 10)
 # and RRV y defines a range [-10,10] this means that the ROOT.RooDataSet
 # below will have less entries than the ROOT.TTree 'tree'
 
-ds = ROOT.RooDataSet("ds", "ds", ROOT.RooArgSet(x, y), ROOT.RooFit.Import(tree))
+ds = ROOT.RooDataSet("ds", "ds", {x, y}, ROOT.RooFit.Import(tree))
 
 # Use ascii import/export for datasets
 # ------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf103_interprfuncs.py
+++ b/tutorials/roofit/rf103_interprfuncs.py
@@ -29,7 +29,7 @@ genpdf = ROOT.RooGenericPdf("genpdf", "genpdf", "(1+0.1*abs(x)+sin(sqrt(abs(x*al
 # ---------------------------------------------------------------
 
 # Generate a toy dataset from the interpreted pdf
-data = genpdf.generate(ROOT.RooArgSet(x), 10000)
+data = genpdf.generate({x}, 10000)
 
 # Fit the interpreted pdf to the generated data
 genpdf.fitTo(data)
@@ -62,7 +62,7 @@ g2 = ROOT.RooGaussian("g2", "h2", x, mean, sigma)
 # Construct a separate gaussian g1(x,10,3) to generate a toy Gaussian
 # dataset with mean 10 and width 3
 g1 = ROOT.RooGaussian("g1", "g1", x, ROOT.RooFit.RooConst(10), ROOT.RooFit.RooConst(3))
-data2 = g1.generate(ROOT.RooArgSet(x), 1000)
+data2 = g1.generate({x}, 1000)
 
 # Fit and plot tailored standard pdf
 # -------------------------------------------------------------------

--- a/tutorials/roofit/rf104_classfactory.py
+++ b/tutorials/roofit/rf104_classfactory.py
@@ -65,7 +65,7 @@ pdf = ROOT.MyPdfV3("pdf", "pdf", y, a, b)
 
 # Generate toy data from pdf and plot data and pdf on frame
 frame1 = y.frame(Title="Compiled class MyPdfV3")
-data = pdf.generate(ROOT.RooArgSet(y), 1000)
+data = pdf.generate({y}, 1000)
 pdf.fitTo(data)
 data.plotOn(frame1)
 pdf.plotOn(frame1)
@@ -85,7 +85,7 @@ alpha = ROOT.RooRealVar("alpha", "alpha", 5, 0.1, 10)
 genpdf = ROOT.RooClassFactory.makePdfInstance("GenPdf", "(1+0.1*fabs(x)+sin(sqrt(fabs(x*alpha+0.1))))", [x, alpha])
 
 # Generate a toy dataset from the interpreted pdf
-data2 = genpdf.generate(ROOT.RooArgSet(x), 50000)
+data2 = genpdf.generate({x}, 50000)
 
 # Fit the interpreted pdf to the generated data
 genpdf.fitTo(data2)

--- a/tutorials/roofit/rf105_funcbinding.py
+++ b/tutorials/roofit/rf105_funcbinding.py
@@ -58,7 +58,7 @@ beta = ROOT.beta
 beta.Print()
 
 # Generate some events and fit
-data = beta.generate(ROOT.RooArgSet(x2), 10000)
+data = beta.generate({x2}, 10000)
 beta.fitTo(data)
 
 # Plot data and pdf on frame

--- a/tutorials/roofit/rf106_plotdecoration.py
+++ b/tutorials/roofit/rf106_plotdecoration.py
@@ -21,7 +21,7 @@ mean = ROOT.RooRealVar("mean", "mean", -3, -10, 10)
 gauss = ROOT.RooGaussian("gauss", "gauss", x, mean, sigma)
 
 # Generate a sample of 1000 events with sigma=3
-data = gauss.generate(ROOT.RooArgSet(x), 1000)
+data = gauss.generate({x}, 1000)
 
 # Fit pdf to data
 gauss.fitTo(data)

--- a/tutorials/roofit/rf107_plotstyles.py
+++ b/tutorials/roofit/rf107_plotstyles.py
@@ -23,7 +23,7 @@ mean = ROOT.RooRealVar("mean", "mean", -3, -10, 10)
 gauss = ROOT.RooGaussian("gauss", "gauss", x, mean, sigma)
 
 # Generate a sample of 100 events with sigma=3
-data = gauss.generate(ROOT.RooArgSet(x), 100)
+data = gauss.generate({x}, 100)
 
 # Fit pdf to data
 gauss.fitTo(data)

--- a/tutorials/roofit/rf108_plotbinning.py
+++ b/tutorials/roofit/rf108_plotbinning.py
@@ -36,7 +36,7 @@ bmix = ROOT.RooBMixDecay("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw,
 # --------------------------------------------
 
 # Sample 2000 events in (dt,mixState,tagFlav) from bmix
-data = bmix.generate(ROOT.RooArgSet(dt, mixState, tagFlav), 2000)
+data = bmix.generate({dt, mixState, tagFlav}, 2000)
 
 # Show dt distribution with custom binning
 # -------------------------------------------------------------------------------

--- a/tutorials/roofit/rf109_chi2residpull.py
+++ b/tutorials/roofit/rf109_chi2residpull.py
@@ -26,7 +26,7 @@ mean = ROOT.RooRealVar("mean", "mean", 0, -10, 10)
 gauss = ROOT.RooGaussian("gauss", "gauss", x, mean, sigma)
 
 # Generate a sample of 1000 events with sigma=3
-data = gauss.generate(ROOT.RooArgSet(x), 10000)
+data = gauss.generate({x}, 10000)
 
 # Change sigma to 3.15
 sigma.setVal(3.15)

--- a/tutorials/roofit/rf110_normintegration.py
+++ b/tutorials/roofit/rf110_normintegration.py
@@ -28,12 +28,12 @@ gx = ROOT.RooGaussian("gx", "gx", x, ROOT.RooFit.RooConst(-2), ROOT.RooFit.RooCo
 print("gx = ", gx.getVal())
 
 # Return value of gx normalized over x in range [-10,10]
-nset = ROOT.RooArgSet(x)
+nset = {x}
 print("gx_Norm[x] = ", gx.getVal(nset))
 
 # Create object representing integral over gx
 # which is used to calculate  gx_Norm[x] == gx / gx_Int[x]
-igx = gx.createIntegral(ROOT.RooArgSet(x))
+igx = gx.createIntegral({x})
 print("gx_Int[x] = ", igx.getVal())
 
 # Integrate normalized pdf over subrange
@@ -45,7 +45,7 @@ x.setRange("signal", -5, 5)
 # Create an integral of gx_Norm[x] over x in range "signal"
 # ROOT.This is the fraction of of pdf gx_Norm[x] which is in the
 # range named "signal"
-xset = ROOT.RooArgSet(x)
+xset = {x}
 igx_sig = gx.createIntegral(xset, NormSet=xset, Range="signal")
 print("gx_Int[x|signal]_Norm[x] = ", igx_sig.getVal())
 
@@ -54,7 +54,7 @@ print("gx_Int[x|signal]_Norm[x] = ", igx_sig.getVal())
 
 # Create the cumulative distribution function of gx
 # i.e. calculate Int[-10,x] gx(x') dx'
-gx_cdf = gx.createCdf(ROOT.RooArgSet(x))
+gx_cdf = gx.createCdf({x})
 
 # Plot cdf of gx versus x
 frame = x.frame(Title="cdf of Gaussian pdf")

--- a/tutorials/roofit/rf201_composite.py
+++ b/tutorials/roofit/rf201_composite.py
@@ -54,7 +54,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # ---------------------------------------------------
 
 # Generate a data sample of 1000 events in x from model
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Fit model to data
 model.fitTo(data)
@@ -65,12 +65,10 @@ data.plotOn(xframe)
 model.plotOn(xframe)
 
 # Overlay the background component of model with a dashed line
-ras_bkg = ROOT.RooArgSet(bkg)
-model.plotOn(xframe, Components=ras_bkg, LineStyle="--")
+model.plotOn(xframe, Components={bkg}, LineStyle="--")
 
 # Overlay the background+sig2 components of model with a dotted line
-ras_bkg_sig2 = ROOT.RooArgSet(bkg, sig2)
-model.plotOn(xframe, Components=ras_bkg_sig2, LineStyle=":")
+model.plotOn(xframe, Components={bkg, sig2}, LineStyle=":")
 
 # Print structure of composite pdf
 model.Print("t")
@@ -94,7 +92,7 @@ model2 = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig1, sig2], [bkgfrac, sig1fra
 # Plot recursive addition model
 # ---------------------------------------------------------
 model2.plotOn(xframe, LineColor="r", LineStyle="--")
-model2.plotOn(xframe, Components=ras_bkg_sig2, LineColor="r", LineStyle="--")
+model2.plotOn(xframe, Components={bkg, sig2}, LineColor="r", LineStyle="--")
 model2.Print("t")
 
 # Draw the frame on the canvas

--- a/tutorials/roofit/rf202_extendedmlfit.py
+++ b/tutorials/roofit/rf202_extendedmlfit.py
@@ -48,7 +48,7 @@ model = ROOT.RooAddPdf("model", "(g1+g2)+a", [bkg, sig], [nbkg, nsig])
 
 # Generate a data sample of expected number events in x from model
 # = model.expectedEvents() = nsig+nbkg
-data = model.generate(ROOT.RooArgSet(x))
+data = model.generate({x})
 
 # Fit model to data, ML term automatically included
 model.fitTo(data)
@@ -60,16 +60,15 @@ data.plotOn(xframe)
 model.plotOn(xframe, Normalization=dict(scaleFactor=1.0, scaleType=ROOT.RooAbsReal.RelativeExpected))
 
 # Overlay the background component of model with a dashed line
-ras_bkg = ROOT.RooArgSet(bkg)
 model.plotOn(
     xframe,
-    Components=ras_bkg,
+    Components={bkg},
     LineStyle=":",
     Normalization=dict(scaleFactor=1.0, scaleType=ROOT.RooAbsReal.RelativeExpected),
 )
 
 # Overlay the background+sig2 components of model with a dotted line
-ras_bkg_sig2 = ROOT.RooArgSet(bkg, sig2)
+ras_bkg_sig2 = {bkg, sig2}
 model.plotOn(
     xframe,
     Components=ras_bkg_sig2,

--- a/tutorials/roofit/rf203_ranges.py
+++ b/tutorials/roofit/rf203_ranges.py
@@ -29,7 +29,7 @@ f = ROOT.RooRealVar("f", "f", 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [gx, px], [f])
 
 # Generated 10000 events in (x,y) from pdf model
-modelData = model.generate(ROOT.RooArgSet(x), 10000)
+modelData = model.generate({x}, 10000)
 
 # Fit full range
 # ---------------------------

--- a/tutorials/roofit/rf204_extrangefit.py
+++ b/tutorials/roofit/rf204_extrangefit.py
@@ -59,7 +59,7 @@ model = ROOT.RooAddPdf("model", "(g1+g2)+a", [ebkg, esig])
 
 # Generate 1000 events from model so that nsig, come out to numbers <<500
 # in fit
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Perform unbinned extended ML fit to data
 r = model.fitTo(data, Extended=True, Save=True)

--- a/tutorials/roofit/rf204a_extendedLikelihood.py
+++ b/tutorials/roofit/rf204a_extendedLikelihood.py
@@ -28,7 +28,7 @@ sig2 = ROOT.RooGaussian("sig2", "Signal component 2", x, mean, sigma2)
 # Build Chebychev polynomial pdf
 a0 = ROOT.RooRealVar("a0", "a0", 0.5, 0.0, 1.0)
 a1 = ROOT.RooRealVar("a1", "a1", 0.2, 0.0, 1.0)
-bkg = ROOT.RooChebychev("bkg", "Background", x, ROOT.RooArgSet(a0, a1))
+bkg = ROOT.RooChebychev("bkg", "Background", x, [a0, a1])
 
 # Sum the signal components into a composite signal pdf
 sig1frac = ROOT.RooRealVar("sig1frac", "fraction of component 1 in signal", 0.8, 0.0, 1.0)

--- a/tutorials/roofit/rf205_compplot.py
+++ b/tutorials/roofit/rf205_compplot.py
@@ -49,7 +49,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # ------------------------------------------------------------------------------
 
 # Generate a data sample of 1000 events in x from model
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Plot data and complete PDF overlaid
 xframe = x.frame(Title="Component plotting of pdf=(sig1+sig2)+(bkg1+bkg2)")
@@ -63,17 +63,17 @@ xframe2 = xframe.Clone("xframe2")
 # --------------------------------------------------------------------
 
 # Plot single background component specified by object reference
-ras_bkg = ROOT.RooArgSet(bkg)
+ras_bkg = {bkg}
 model.plotOn(xframe, Components=ras_bkg, LineColor="r")
 
 # Plot single background component specified by object reference
-ras_bkg2 = ROOT.RooArgSet(bkg2)
+ras_bkg2 = {bkg2}
 model.plotOn(xframe, Components=ras_bkg2, LineStyle="--", LineColor="r")
 
 # Plot multiple background components specified by object reference
 # Note that specified components may occur at any level in object tree
 # (e.g bkg is component of 'model' and 'sig2' is component 'sig')
-ras_bkg_sig2 = ROOT.RooArgSet(bkg, sig2)
+ras_bkg_sig2 = {bkg, sig2}
 model.plotOn(xframe, Components=ras_bkg_sig2, LineStyle=":")
 
 # Make component by name/regexp

--- a/tutorials/roofit/rf207_comptools.py
+++ b/tutorials/roofit/rf207_comptools.py
@@ -43,7 +43,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 
 # Create dummy dataset that has more observables than the above pdf
 y = ROOT.RooRealVar("y", "y", -10, 10)
-data = ROOT.RooDataSet("data", "data", ROOT.RooArgSet(x, y))
+data = ROOT.RooDataSet("data", "data", {x, y})
 
 # Basic information requests
 # ---------------------------------------------
@@ -65,7 +65,7 @@ model_obs.Print("v")
 # -------------------------------------------
 
 # Get list of parameters, list of observables
-model_params = model.getParameters(ROOT.RooArgSet(x))
+model_params = model.getParameters({x})
 model_params.Print("v")
 
 # Get list of parameters, a dataset

--- a/tutorials/roofit/rf208_convolution.py
+++ b/tutorials/roofit/rf208_convolution.py
@@ -44,7 +44,7 @@ lxg = ROOT.RooFFTConvPdf("lxg", "landau (X) gauss", t, landau, gauss)
 # ----------------------------------------------------------------------
 
 # Sample 1000 events in x from gxlx
-data = lxg.generate(ROOT.RooArgSet(t), 10000)
+data = lxg.generate({t}, 10000)
 
 # Fit gxlx to data
 lxg.fitTo(data)

--- a/tutorials/roofit/rf210_angularconv.py
+++ b/tutorials/roofit/rf210_angularconv.py
@@ -54,7 +54,7 @@ Mpsi.setBufferFraction(0)
 # --------------------------------------------------------------------------------
 
 # Generate some events in observable psi
-data_psi = Mpsi.generate(ROOT.RooArgSet(psi), 10000)
+data_psi = Mpsi.generate({psi}, 10000)
 
 # Fit convoluted model as function of angle psi
 Mpsi.fitTo(data_psi)
@@ -84,7 +84,7 @@ Mcpsi.setBufferFraction(0)
 # --------------------------------------------------------------------------------
 
 # Generate some events
-data_cpsi = Mcpsi.generate(ROOT.RooArgSet(cpsi), 10000)
+data_cpsi = Mcpsi.generate({cpsi}, 10000)
 
 # set psi constant to exclude to be a parameter of the fit
 psi.setConstant(True)

--- a/tutorials/roofit/rf211_paramconv.py
+++ b/tutorials/roofit/rf211_paramconv.py
@@ -36,14 +36,14 @@ model = ROOT.RooFFTConvPdf("model", "model", mean, modelx, model_mean)
 # Configure convolution to construct a 2-D cache in (x,mean)
 # rather than a 1-d cache in mean that needs to be recalculated
 # for each value of x
-model.setCacheObservables(ROOT.RooArgSet(x))
+model.setCacheObservables({x})
 model.setBufferFraction(1.0)
 
 # Integrate model over projModel = Int model dmean
-projModel = model.createProjection(ROOT.RooArgSet(mean))
+projModel = model.createProjection({mean})
 
 # Generate 1000 toy events
-d = projModel.generateBinned(ROOT.RooArgSet(x), 1000)
+d = projModel.generateBinned({x}, 1000)
 
 # Fit p.d.f. to toy data
 projModel.fitTo(d, Verbose=True)
@@ -59,7 +59,7 @@ hh = model.createHistogram(
     x,
     Binning=50,
     YVar=dict(var=mean, Binning=50),
-    ConditionalObservables=ROOT.RooArgSet(mean),
+    ConditionalObservables={mean},
 )
 hh.SetTitle("histogram of model(x|mean)")
 hh.SetLineColor(ROOT.kBlue)

--- a/tutorials/roofit/rf301_composition.py
+++ b/tutorials/roofit/rf301_composition.py
@@ -33,7 +33,7 @@ model = ROOT.RooGaussian("model", "Gaussian with shifting mean", x, fy, sigma)
 # ---------------------------------------------------------------------------------
 
 # Generate 10000 events in x and y from model
-data = model.generate(ROOT.RooArgSet(x, y), 10000)
+data = model.generate({x, y}, 10000)
 
 # Plot x distribution of data and projection of model x = Int(dy)
 # model(x,y)

--- a/tutorials/roofit/rf303_conditional.py
+++ b/tutorials/roofit/rf303_conditional.py
@@ -18,7 +18,7 @@ import ROOT
 def makeFakeDataXY():
     x = ROOT.RooRealVar("x", "x", -10, 10)
     y = ROOT.RooRealVar("y", "y", -10, 10)
-    coord = ROOT.RooArgSet(x, y)
+    coord = {x, y}
 
     d = ROOT.RooDataSet("d", "d", coord)
 
@@ -56,17 +56,17 @@ expDataXY = makeFakeDataXY()
 # ---------------------------------------------------------------------------------------------
 
 # Make subset of experimental data with only y values
-expDataY = expDataXY.reduce(ROOT.RooArgSet(y))
+expDataY = expDataXY.reduce({y})
 
 # Generate 10000 events in x obtained from _conditional_ model(x|y) with y
 # values taken from experimental data
-data = model.generate(ROOT.RooArgSet(x), ProtoData=expDataY)
+data = model.generate({x}, ProtoData=expDataY)
 data.Print()
 
 # Fit conditional p.d.f model(x|y) to data
 # ---------------------------------------------------------------------------------------------
 
-model.fitTo(expDataXY, ConditionalObservables=ROOT.RooArgSet(y))
+model.fitTo(expDataXY, ConditionalObservables={y})
 
 # Project conditional p.d.f on x and y dimensions
 # ---------------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf304_uncorrprod.py
+++ b/tutorials/roofit/rf304_uncorrprod.py
@@ -39,7 +39,7 @@ gaussxy = ROOT.RooProdPdf("gaussxy", "gaussx*gaussy", [gaussx, gaussy])
 # ---------------------------------------------------------------------------
 
 # Generate 10000 events in x and y from gaussxy
-data = gaussxy.generate(ROOT.RooArgSet(x, y), 10000)
+data = gaussxy.generate({x, y}, 10000)
 
 # Plot x distribution of data and projection of gaussxy x = Int(dy)
 # gaussxy(x,y)

--- a/tutorials/roofit/rf305_condcorrprod.py
+++ b/tutorials/roofit/rf305_condcorrprod.py
@@ -38,15 +38,13 @@ gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, ROOT.RooFit.RooConst(0),
 # -------------------------------------------------------
 
 # Create gaussx(x,sx|y) * gaussy(y)
-model = ROOT.RooProdPdf(
-    "model", "gaussx(x|y)*gaussy(y)", ROOT.RooArgSet(gaussy), Conditional=(ROOT.RooArgSet(gaussx), ROOT.RooArgSet(x))
-)
+model = ROOT.RooProdPdf("model", "gaussx(x|y)*gaussy(y)", {gaussy}, Conditional=({gaussx}, {x}))
 
 # Sample, fit and plot product pdf
 # ---------------------------------------------------------------
 
 # Generate 1000 events in x and y from model
-data = model.generate(ROOT.RooArgSet(x, y), 10000)
+data = model.generate({x, y}, 10000)
 
 # Plot x distribution of data and projection of model x = Int(dy)
 # model(x,y)

--- a/tutorials/roofit/rf306_condpereventerrors.py
+++ b/tutorials/roofit/rf306_condpereventerrors.py
@@ -32,20 +32,20 @@ decay_gm = ROOT.RooDecay("decay_gm", "decay", dt, tau, gm, type="DoubleSided")
 
 # Use landau pdf to get somewhat realistic distribution with long tail
 pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, ROOT.RooFit.RooConst(1), ROOT.RooFit.RooConst(0.25))
-expDataDterr = pdfDtErr.generate(ROOT.RooArgSet(dterr), 10000)
+expDataDterr = pdfDtErr.generate({dterr}, 10000)
 
 # Sample data from conditional decay_gm(dt|dterr)
 # ---------------------------------------------------------------------------------------------
 
 # Specify external dataset with dterr values to use decay_dm as
 # conditional pdf
-data = decay_gm.generate(ROOT.RooArgSet(dt), ProtoData=expDataDterr)
+data = decay_gm.generate({dt}, ProtoData=expDataDterr)
 
 # Fit conditional decay_dm(dt|dterr)
 # ---------------------------------------------------------------------
 
 # Specify dterr as conditional observable
-decay_gm.fitTo(data, ConditionalObservables=ROOT.RooArgSet(dterr))
+decay_gm.fitTo(data, ConditionalObservables={dterr})
 
 # Plot conditional decay_dm(dt|dterr)
 # ---------------------------------------------------------------------

--- a/tutorials/roofit/rf307_fullpereventerrors.py
+++ b/tutorials/roofit/rf307_fullpereventerrors.py
@@ -32,20 +32,18 @@ decay_gm = ROOT.RooDecay("decay_gm", "decay", dt, tau, gm, type="DoubleSided")
 
 # Use landau pdf to get empirical distribution with long tail
 pdfDtErr = ROOT.RooLandau("pdfDtErr", "pdfDtErr", dterr, ROOT.RooFit.RooConst(1), ROOT.RooFit.RooConst(0.25))
-expDataDterr = pdfDtErr.generate(ROOT.RooArgSet(dterr), 10000)
+expDataDterr = pdfDtErr.generate({dterr}, 10000)
 
 # Construct a histogram pdf to describe the shape of the dtErr distribution
 expHistDterr = expDataDterr.binnedClone()
-pdfErr = ROOT.RooHistPdf("pdfErr", "pdfErr", ROOT.RooArgSet(dterr), expHistDterr)
+pdfErr = ROOT.RooHistPdf("pdfErr", "pdfErr", {dterr}, expHistDterr)
 
 # Construct conditional product decay_dm(dt|dterr)*pdf(dterr)
 # ----------------------------------------------------------------------------------------------------------------------
 
 # Construct production of conditional decay_dm(dt|dterr) with empirical
 # pdfErr(dterr)
-model = ROOT.RooProdPdf(
-    "model", "model", ROOT.RooArgSet(pdfErr), Conditional=(ROOT.RooArgSet(decay_gm), ROOT.RooArgSet(dt))
-)
+model = ROOT.RooProdPdf("model", "model", {pdfErr}, Conditional=({decay_gm}, {dt}))
 
 # (Alternatively you could also use the landau shape pdfDtErr)
 # ROOT.RooProdPdf model("model", "model",pdfDtErr,
@@ -56,7 +54,7 @@ model = ROOT.RooProdPdf(
 
 # Specify external dataset with dterr values to use model_dm as
 # conditional pdf
-data = model.generate(ROOT.RooArgSet(dt, dterr), 10000)
+data = model.generate({dt, dterr}, 10000)
 
 # Fit conditional decay_dm(dt|dterr)
 # ---------------------------------------------------------------------

--- a/tutorials/roofit/rf308_normintegration2d.py
+++ b/tutorials/roofit/rf308_normintegration2d.py
@@ -33,12 +33,12 @@ gxy = ROOT.RooProdPdf("gxy", "gxy", [gx, gy])
 print("gxy = ", gxy.getVal())
 
 # Return value of gxy normalized over x _and_ y in range [-10,10]
-nset_xy = ROOT.RooArgSet(x, y)
+nset_xy = {x, y}
 print("gx_Norm[x,y] = ", gxy.getVal(nset_xy))
 
 # Create object representing integral over gx
 # which is used to calculate  gx_Norm[x,y] == gx / gx_Int[x,y]
-x_and_y = ROOT.RooArgSet(x, y)
+x_and_y = {x, y}
 igxy = gxy.createIntegral(x_and_y)
 print("gx_Int[x,y] = ", igxy.getVal())
 
@@ -46,12 +46,12 @@ print("gx_Int[x,y] = ", igxy.getVal())
 
 # Return value of gxy normalized over x in range [-10,10] (i.e. treating y
 # as parameter)
-nset_x = ROOT.RooArgSet(x)
+nset_x = {x}
 print("gx_Norm[x] = ", gxy.getVal(nset_x))
 
 # Return value of gxy normalized over y in range [-10,10] (i.e. treating x
 # as parameter)
-nset_y = ROOT.RooArgSet(y)
+nset_y = {y}
 print("gx_Norm[y] = ", gxy.getVal(nset_y))
 
 # Integarte normalizes pdf over subrange
@@ -73,7 +73,7 @@ print("gx_Int[x,y|signal]_Norm[x,y] = ", igxy_sig.getVal())
 
 # Create the cumulative distribution function of gx
 # i.e. calculate Int[-10,x] gx(x') dx'
-gxy_cdf = gxy.createCdf(ROOT.RooArgSet(x, y))
+gxy_cdf = gxy.createCdf({x, y})
 
 # Plot cdf of gx versus x
 hh_cdf = gxy_cdf.createHistogram("hh_cdf", x, Binning=40, YVar=dict(var=y, Binning=40))

--- a/tutorials/roofit/rf309_ndimplot.py
+++ b/tutorials/roofit/rf309_ndimplot.py
@@ -29,7 +29,7 @@ fy = ROOT.RooFormulaVar("fy", "a0-a1*sqrt(10*abs(y))", [y, a0, a1])
 model = ROOT.RooGaussian("model", "Gaussian with shifting mean", x, fy, sigma)
 
 # Sample dataset from gauss(x,y)
-data = model.generate(ROOT.RooArgSet(x, y), 10000)
+data = model.generate({x, y}, 10000)
 
 # Make 2D plots of data and model
 # -------------------------------------------------------------
@@ -54,7 +54,7 @@ z = ROOT.RooRealVar("z", "z", -5, 5)
 gz = ROOT.RooGaussian("gz", "gz", z, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(2))
 model3 = ROOT.RooProdPdf("model3", "model3", [model, gz])
 
-data3 = model3.generate(ROOT.RooArgSet(x, y, z), 10000)
+data3 = model3.generate({x, y, z}, 10000)
 
 # Make 3D plots of data and model
 # -------------------------------------------------------------

--- a/tutorials/roofit/rf310_sliceplot.py
+++ b/tutorials/roofit/rf310_sliceplot.py
@@ -37,7 +37,7 @@ gm1 = ROOT.RooGaussModel("gm1", "gauss model 1", dt, bias1, sigma1)
 bmix_gm1 = ROOT.RooBMixDecay("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw, gm1, type="DoubleSided")
 
 # Generate BMixing data with above set of event errors
-data = bmix_gm1.generate(ROOT.RooArgSet(dt, tagFlav, mixState), 20000)
+data = bmix_gm1.generate({dt, tagFlav, mixState}, 20000)
 
 # Plot full decay distribution
 # ----------------------------------------------------------

--- a/tutorials/roofit/rf311_rangeplot.py
+++ b/tutorials/roofit/rf311_rangeplot.py
@@ -34,7 +34,7 @@ bkg = ROOT.RooProdPdf("bkg", "bkg", [px, py, pz])
 fsig = ROOT.RooRealVar("fsig", "signal fraction", 0.1, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
-data = model.generate(ROOT.RooArgSet(x, y, z), 20000)
+data = model.generate({x, y, z}, 20000)
 
 # Project pdf and data on x
 # -------------------------------------------------

--- a/tutorials/roofit/rf312_multirangefit.py
+++ b/tutorials/roofit/rf312_multirangefit.py
@@ -37,7 +37,7 @@ f = ROOT.RooRealVar("f", "f", 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [f])
 
 # Sample 10000 events in (x,y) from the model
-modelData = model.generate(ROOT.RooArgSet(x, y), 10000)
+modelData = model.generate({x, y}, 10000)
 
 # Define signal and sideband regions
 # -------------------------------------------------------------------

--- a/tutorials/roofit/rf313_paramranges.py
+++ b/tutorials/roofit/rf313_paramranges.py
@@ -48,7 +48,7 @@ z.setRange("R", zlo, zhi)
 # ----------------------------------------------------------------------------------
 
 # Create integral over normalized pdf model over x,y, in "R" region
-intPdf = pxyz.createIntegral(ROOT.RooArgSet(x, y, z), ROOT.RooArgSet(x, y, z), "R")
+intPdf = pxyz.createIntegral({x, y, z}, {x, y, z}, "R")
 
 # Plot value of integral as function of pdf parameter z0
 frame = z0.frame(Title="Integral of pxyz over x,y, in region R")

--- a/tutorials/roofit/rf314_paramfitrange.py
+++ b/tutorials/roofit/rf314_paramfitrange.py
@@ -34,15 +34,13 @@ model = ROOT.RooExponential("model", "model", t, tau)
 # ------------------------------------
 
 # Generate complete dataset without acceptance cuts (for reference)
-dall = model.generate(ROOT.RooArgSet(t), 10000)
+dall = model.generate({t}, 10000)
 
 # Generate a (fake) prototype dataset for acceptance limit values
-tmp = ROOT.RooGaussian("gmin", "gmin", tmin, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(0.5)).generate(
-    ROOT.RooArgSet(tmin), 5000
-)
+tmp = ROOT.RooGaussian("gmin", "gmin", tmin, ROOT.RooFit.RooConst(0), ROOT.RooFit.RooConst(0.5)).generate({tmin}, 5000)
 
 # Generate dataset with t values that observe (t>tmin)
-dacc = model.generate(ROOT.RooArgSet(t), ProtoData=tmp)
+dacc = model.generate({t}, ProtoData=tmp)
 
 # Fit pdf to data in acceptance region
 # -----------------------------------------------------------------------

--- a/tutorials/roofit/rf315_projectpdf.py
+++ b/tutorials/roofit/rf315_projectpdf.py
@@ -39,21 +39,21 @@ gaussy = ROOT.RooGaussian("gaussy", "Gaussian in y", y, ROOT.RooFit.RooConst(0),
 model = ROOT.RooProdPdf(
     "model",
     "gaussx(x|y)*gaussy(y)",
-    ROOT.RooArgSet(gaussy),
-    Conditional=(ROOT.RooArgSet(gaussx), ROOT.RooArgSet(x)),
+    {gaussy},
+    Conditional=({gaussx}, {x}),
 )
 
 # Marginalize m(x,y) to m(x)
 # ----------------------------------------------------
 
 # modelx(x) = Int model(x,y) dy
-modelx = model.createProjection(ROOT.RooArgSet(y))
+modelx = model.createProjection({y})
 
 # Use marginalized pdf as regular 1D pdf
 # -----------------------------------------------
 
 # Sample 1000 events from modelx
-data = modelx.generateBinned(ROOT.RooArgSet(x), 1000)
+data = modelx.generateBinned({x}, 1000)
 
 # Fit modelx to toy data
 modelx.fitTo(data, Verbose=True)

--- a/tutorials/roofit/rf316_llratioplot.py
+++ b/tutorials/roofit/rf316_llratioplot.py
@@ -36,7 +36,7 @@ bkg = ROOT.RooProdPdf("bkg", "bkg", [px, py, pz])
 fsig = ROOT.RooRealVar("fsig", "signal fraction", 0.1, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
-data = model.generate(ROOT.RooArgSet(x, y, z), 20000)
+data = model.generate({x, y, z}, 20000)
 
 # Project pdf and data on x
 # -------------------------------------------------
@@ -51,8 +51,8 @@ model.plotOn(frame)
 
 # Calculate projection of signal and total likelihood on (y,z) observables
 # i.e. integrate signal and composite model over x
-sigyz = sig.createProjection(ROOT.RooArgSet(x))
-totyz = model.createProjection(ROOT.RooArgSet(x))
+sigyz = sig.createProjection({x})
+totyz = model.createProjection({x})
 
 # Construct the log of the signal / signal+background probability
 llratio_func = ROOT.RooFormulaVar("llratio", "log10(@0)-log10(@1)", [sigyz, totyz])
@@ -76,7 +76,7 @@ dataSel.plotOn(frame2)
 # ---------------------------------------------------------------------------------------------
 
 # Generate large number of events for MC integration of pdf projection
-mcprojData = model.generate(ROOT.RooArgSet(x, y, z), 10000)
+mcprojData = model.generate({x, y, z}, 10000)
 
 # Calculate LL ratio for each generated event and select MC events with
 # llratio)0.7

--- a/tutorials/roofit/rf401_importttreethx.py
+++ b/tutorials/roofit/rf401_importttreethx.py
@@ -84,12 +84,12 @@ y = ROOT.RooRealVar("y", "y", -10, 10)
 z = ROOT.RooRealVar("z", "z", -10, 10)
 
 # Import only observables (y,z)
-ds = ROOT.RooDataSet("ds", "ds", ROOT.RooArgSet(x, y), Import=tree)
+ds = ROOT.RooDataSet("ds", "ds", {x, y}, Import=tree)
 ds.Print()
 
 # Import observables (x,y,z) but only event for which (y+z<0) is ROOT.True
 # Import observables (x,y,z) but only event for which (y+z<0) is ROOT.True
-ds2 = ROOT.RooDataSet("ds2", "ds2", ROOT.RooArgSet(x, y, z), Import=tree, Cut="y+z<0")
+ds2 = ROOT.RooDataSet("ds2", "ds2", {x, y, z}, Import=tree, Cut="y+z<0")
 ds2.Print()
 
 # Importing integer ROOT TTree branches
@@ -97,7 +97,7 @@ ds2.Print()
 
 # Import integer tree branch as ROOT.RooRealVar
 i = ROOT.RooRealVar("i", "i", 0, 5)
-ds3 = ROOT.RooDataSet("ds3", "ds3", ROOT.RooArgSet(i, x), Import=tree)
+ds3 = ROOT.RooDataSet("ds3", "ds3", {i, x}, Import=tree)
 ds3.Print()
 
 # Define category i
@@ -105,23 +105,23 @@ icat = ROOT.RooCategory("i", "i", {"State0": 0, "State1": 1})
 
 # Import integer tree branch as ROOT.RooCategory (only events with i==0 and i==1
 # will be imported as those are the only defined states)
-ds4 = ROOT.RooDataSet("ds4", "ds4", ROOT.RooArgSet(icat, x), Import=tree)
+ds4 = ROOT.RooDataSet("ds4", "ds4", {icat, x}, Import=tree)
 ds4.Print()
 
 # Import multiple RooDataSets into a RooDataSet
 # ----------------------------------------------------------------------------------------
 
 # Create three ROOT.RooDataSets in (y,z)
-dsA = ds2.reduce(ROOT.RooArgSet(x, y), "z<-5")
-dsB = ds2.reduce(ROOT.RooArgSet(x, y), "abs(z)<5")
-dsC = ds2.reduce(ROOT.RooArgSet(x, y), "z>5")
+dsA = ds2.reduce({x, y}, "z<-5")
+dsB = ds2.reduce({x, y}, "abs(z)<5")
+dsC = ds2.reduce({x, y}, "z>5")
 
 # Create a dataset that imports contents of all the above datasets mapped
 # by index category c
 dsABC = ROOT.RooDataSet(
     "dsABC",
     "dsABC",
-    ROOT.RooArgSet(x, y),
+    {x, y},
     ROOT.RooFit.Import("SampleA", dsA),
     ROOT.RooFit.Import("SampleB", dsB),
     Index=c,

--- a/tutorials/roofit/rf402_datahandling.py
+++ b/tutorials/roofit/rf402_datahandling.py
@@ -30,7 +30,7 @@ c.defineType("Minus", -1)
 
 # ROOT.RooDataSet is an unbinned dataset (a collection of points in
 # N-dimensional space)
-d = ROOT.RooDataSet("d", "d", ROOT.RooArgSet(x, y, c))
+d = ROOT.RooDataSet("d", "d", {x, y, c})
 
 # Unlike ROOT.RooAbsArgs (ROOT.RooAbsPdf, ROOT.RooFormulaVar,....) datasets are not attached to
 # the variables they are constructed from. Instead they are attached to an internal
@@ -50,7 +50,7 @@ for i in range(1000):
     if i < 3:
         print(x, y, c)
         print(type(x))
-    d.add(ROOT.RooArgSet(x, y, c))
+    d.add({x, y, c})
 
 d.Print("v")
 print("")
@@ -73,11 +73,11 @@ print("")
 # The reduce() function returns a dataset which is a subset of the
 # original
 print("\n >> d1 has only columns x,c")
-d1 = d.reduce(ROOT.RooArgSet(x, c))
+d1 = d.reduce({x, c})
 d1.Print("v")
 
 print("\n >> d2 has only column y")
-d2 = d.reduce(ROOT.RooArgSet(y))
+d2 = d.reduce({y})
 d2.Print("v")
 
 print("\n >> d3 has only the points with y>5.17")
@@ -85,7 +85,7 @@ d3 = d.reduce("y>5.17")
 d3.Print("v")
 
 print("\n >> d4 has only columns x, for data points with y>5.17")
-d4 = d.reduce(ROOT.RooArgSet(x, c), "y>5.17")
+d4 = d.reduce({x, c}, "y>5.17")
 d4.Print("v")
 
 # The merge() function adds two data set column-wise
@@ -113,7 +113,7 @@ print(">> the category 'c' will be projected in the filling process")
 # state
 x.setBins(10)
 y.setBins(10)
-dh = ROOT.RooDataHist("dh", "binned version of d", ROOT.RooArgSet(x, y), d)
+dh = ROOT.RooDataHist("dh", "binned version of d", {x, y}, d)
 dh.Print("v")
 
 yframe = y.frame(Bins=10, Title="Operations on binned datasets")
@@ -130,7 +130,7 @@ x.setVal(0.3)
 y.setVal(20.5)
 print(">> retrieving the properties of the bin enclosing coordinate (x,y) = (0.3,20.5) bin center:")
 # load bin center coordinates in internal buffer
-dh.get(ROOT.RooArgSet(x, y)).Print("v")
+dh.get({x, y}).Print("v")
 print(" weight = ", dh.weight())  # return weight of last loaded coordinates
 
 # Reduce the 2-dimensional binned dataset to a 1-dimensional binned dataset
@@ -139,7 +139,7 @@ print(" weight = ", dh.weight())  # return weight of last loaded coordinates
 # demonstrated on unbinned datasets can be applied to binned datasets as
 # well.
 print(">> Creating 1-dimensional projection on y of dh for bins with x>0")
-dh2 = dh.reduce(ROOT.RooArgSet(y), "x>0")
+dh2 = dh.reduce({y}, "x>0")
 dh2.Print("v")
 
 # Add dh2 to yframe and redraw

--- a/tutorials/roofit/rf403_weightedevts.py
+++ b/tutorials/roofit/rf403_weightedevts.py
@@ -27,7 +27,7 @@ x.setBins(40)
 p0 = ROOT.RooPolynomial("px", "px", x)
 
 # Sample 1000 events from pdf
-data = p0.generate(ROOT.RooArgSet(x), 1000)
+data = p0.generate({x}, 1000)
 
 # Calculate weight and make dataset weighted
 # --------------------------------------------------
@@ -101,10 +101,10 @@ p2.plotOn(frame)
 genPdf = ROOT.RooGenericPdf("genPdf", "x*x+10", [x])
 
 # Sample a dataset with the same number of events as data
-data2 = genPdf.generate(ROOT.RooArgSet(x), 1000)
+data2 = genPdf.generate({x}, 1000)
 
 # Sample a dataset with the same number of weights as data
-data3 = genPdf.generate(ROOT.RooArgSet(x), 43000)
+data3 = genPdf.generate({x}, 43000)
 
 # Fit the 2nd order polynomial to both unweighted datasets and save the
 # results for comparison

--- a/tutorials/roofit/rf404_categories.py
+++ b/tutorials/roofit/rf404_categories.py
@@ -35,7 +35,7 @@ b0flav.Print()
 
 # Generate a dummy dataset
 x = ROOT.RooRealVar("x", "x", 0, 10)
-data = ROOT.RooPolynomial("p", "p", x).generate(ROOT.RooArgSet(x, b0flav, tagCat), 10000)
+data = ROOT.RooPolynomial("p", "p", x).generate({x, b0flav, tagCat}, 10000)
 
 # Print tables of category contents of datasets
 # --------------------------------------------------
@@ -51,7 +51,7 @@ ttable.Print()
 ttable.Print("v")
 
 # Create table for all (tagCat x b0flav) state combinations
-bttable = data.table(ROOT.RooArgSet(tagCat, b0flav))
+bttable = data.table({tagCat, b0flav})
 bttable.Print("v")
 
 # Retrieve number of events from table

--- a/tutorials/roofit/rf405_realtocatfuncs.py
+++ b/tutorials/roofit/rf405_realtocatfuncs.py
@@ -19,7 +19,7 @@ x = ROOT.RooRealVar("x", "x", 0, 10)
 a = ROOT.RooArgusBG("a", "argus(x)", x, ROOT.RooFit.RooConst(10), ROOT.RooFit.RooConst(-1))
 
 # Generate a dummy dataset
-data = a.generate(ROOT.RooArgSet(x), 10000)
+data = a.generate({x}, 10000)
 
 # Create a threshold real -> cat function
 # --------------------------------------------------------------------------

--- a/tutorials/roofit/rf406_cattocatfuncs.py
+++ b/tutorials/roofit/rf406_cattocatfuncs.py
@@ -29,7 +29,7 @@ b0flav.Print()
 # Construct a dummy dataset with random values of tagCat and b0flav
 x = ROOT.RooRealVar("x", "x", 0, 10)
 p = ROOT.RooPolynomial("p", "p", x)
-data = p.generate(ROOT.RooArgSet(x, b0flav, tagCat), 10000)
+data = p.generate({x, b0flav, tagCat}, 10000)
 
 # Create a cat -> cat mapping category
 # ---------------------------------------------------------------------
@@ -55,7 +55,7 @@ mtable.Print("v")
 
 # A SUPER-category is 'product' of _lvalue_ categories. The state names of a super
 # category is a composite of the state labels of the input categories
-b0Xtcat = ROOT.RooSuperCategory("b0Xtcat", "b0flav X tagCat", ROOT.RooArgSet(b0flav, tagCat))
+b0Xtcat = ROOT.RooSuperCategory("b0Xtcat", "b0flav X tagCat", {b0flav, tagCat})
 
 # Make a table of the product category state multiplicity in data
 stable = data.table(b0Xtcat)
@@ -66,7 +66,7 @@ b0Xtcat.setLabel("{B0bar;Lepton}")
 
 # A MULTI-category is a 'product' of any category (function). The state names of a super
 # category is a composite of the state labels of the input categories
-b0Xttype = ROOT.RooMultiCategory("b0Xttype", "b0flav X tagType", ROOT.RooArgSet(b0flav, tcatType))
+b0Xttype = ROOT.RooMultiCategory("b0Xttype", "b0flav X tagType", {b0flav, tcatType})
 
 # Make a table of the product category state multiplicity in data
 xtable = data.table(b0Xttype)

--- a/tutorials/roofit/rf407_latextables.py
+++ b/tutorials/roofit/rf407_latextables.py
@@ -50,13 +50,13 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # ----------------------------------------------------------------------------------------
 
 # Make list of model parameters
-params = model.getParameters(ROOT.RooArgSet(x))
+params = model.getParameters({x})
 
 # Save snapshot of prefit parameters
 initParams = params.snapshot()
 
 # Do fit to data, obtain error estimates on parameters
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 model.fitTo(data)
 
 # Print LateX table of parameters of pdf

--- a/tutorials/roofit/rf501_simultaneouspdf.py
+++ b/tutorials/roofit/rf501_simultaneouspdf.py
@@ -53,8 +53,8 @@ model_ctl = ROOT.RooAddPdf("model_ctl", "model_ctl", [gx_ctl, px_ctl], [f_ctl])
 # ---------------------------------------------------------------
 
 # Generate 1000 events in x and y from model
-data = model.generate(ROOT.RooArgSet(x), 100)
-data_ctl = model_ctl.generate(ROOT.RooArgSet(x), 2000)
+data = model.generate({x}, 100)
+data_ctl = model_ctl.generate({x}, 2000)
 
 # Create index category and join samples
 # ---------------------------------------------------------------------------
@@ -68,7 +68,7 @@ sample.defineType("control")
 combData = ROOT.RooDataSet(
     "combData",
     "combined data",
-    ROOT.RooArgSet(x),
+    {x},
     ROOT.RooFit.Index(sample),
     ROOT.RooFit.Import("physics", data),
     ROOT.RooFit.Import("control", data_ctl),
@@ -106,7 +106,7 @@ combData.plotOn(frame1, Cut="sample==sample::physics")
 # and can thus not be integrated
 # NB2: The sampleSet *must* be named. It will not work to pass this as a temporary
 # because python will delete it. The same holds for fitTo() and plotOn() below.
-sampleSet = ROOT.RooArgSet(sample)
+sampleSet = {sample}
 simPdf.plotOn(frame1, Slice=(sample, "physics"), Components="px", ProjWData=(sampleSet, combData), LineStyle="--")
 
 # The same plot for the control sample slice

--- a/tutorials/roofit/rf502_wspacewrite.py
+++ b/tutorials/roofit/rf502_wspacewrite.py
@@ -40,7 +40,7 @@ bkgfrac = ROOT.RooRealVar("bkgfrac", "fraction of background", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 
 # Generate a data sample of 1000 events in x from model
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Create workspace, import data and model
 # -----------------------------------------------------------------------------

--- a/tutorials/roofit/rf504_simwstool.py
+++ b/tutorials/roofit/rf504_simwstool.py
@@ -46,7 +46,7 @@ d.defineType("bar")
 
 # Import ingredients in a workspace
 w = ROOT.RooWorkspace("w", "w")
-w.Import(ROOT.RooArgSet(model, c, d))
+w.Import({model, c, d})
 
 # Make Sim builder tool
 sct = ROOT.RooSimWSTool(w)

--- a/tutorials/roofit/rf505_asciicfg.py
+++ b/tutorials/roofit/rf505_asciicfg.py
@@ -32,14 +32,14 @@ model = ROOT.RooAddPdf("model", "model", [gauss, poly], [f])
 # Fit model to toy data
 # -----------------------------------------
 
-d = model.generate(ROOT.RooArgSet(x), 1000)
+d = model.generate({x}, 1000)
 model.fitTo(d)
 
 # Write parameters to ASCII file
 # -----------------------------------------------------------
 
 # Obtain set of parameters
-params = model.getParameters(ROOT.RooArgSet(x))
+params = model.getParameters({x})
 
 # Write parameters to file
 params.writeToFile("rf505_asciicfg_example.txt")

--- a/tutorials/roofit/rf506_msgservice.py
+++ b/tutorials/roofit/rf506_msgservice.py
@@ -27,7 +27,7 @@ poly = ROOT.RooPolynomial("p", "p", x, [p0])
 f = ROOT.RooRealVar("f", "f", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [gauss, poly], [f])
 
-data = model.generate(ROOT.RooArgSet(x), 10)
+data = model.generate({x}, 10)
 
 # Print configuration of message service
 # ------------------------------------------
@@ -45,7 +45,7 @@ ROOT.RooMsgService.instance().Print()
 ROOT.RooMsgService.instance().getStream(1).addTopic(ROOT.RooFit.Integration)
 
 # Construct integral over gauss to demonstrate message stream
-igauss = gauss.createIntegral(ROOT.RooArgSet(x))
+igauss = gauss.createIntegral({x})
 igauss.Print()
 
 # Print streams configuration in verbose, also shows inactive streams

--- a/tutorials/roofit/rf509_wsinteractive.py
+++ b/tutorials/roofit/rf509_wsinteractive.py
@@ -77,7 +77,7 @@ w.Print()
 model = w["model"]
 x = w["x"]
 
-d = model.generate(ROOT.RooArgSet(x), 1000)
+d = model.generate({x}, 1000)
 r = model.fitTo(d)
 
 # old syntax to access the variable x
@@ -97,8 +97,7 @@ d.plotOn(frame)
 # correct syntax
 bkg = w["bkg"]
 model.plotOn(frame)
-ras_bkg = ROOT.RooArgSet(bkg)
-model.plotOn(frame, Components=ras_bkg, LineStyle="--")
+model.plotOn(frame, Components=bkg, LineStyle="--")
 
 # Draw the frame on the canvas
 c = ROOT.TCanvas("rf509_wsinteractive", "rf509_wsinteractive", 600, 600)

--- a/tutorials/roofit/rf510_wsnamedsets.py
+++ b/tutorials/roofit/rf510_wsnamedsets.py
@@ -59,9 +59,9 @@ def fillWorkspace(w):
     # of defineSet must be set to import them on the fly. Named sets contain only references
     # to the original variables, the value of observables in named sets already
     # reflect their 'current' value
-    params = model.getParameters(ROOT.RooArgSet(x))
+    params = model.getParameters({x})
     w.defineSet("parameters", params)
-    w.defineSet("observables", ROOT.RooArgSet(x))
+    w.defineSet("observables", {x})
 
     # Encode reference value for parameters in workspace
     # ---------------------------------------------------------------------------------------------------
@@ -76,7 +76,7 @@ def fillWorkspace(w):
 
     # Do a dummy fit to a (supposedly) reference dataset here and store the results
     # of that fit into a snapshot
-    refData = model.generate(ROOT.RooArgSet(x), 10000)
+    refData = model.generate({x}, 10000)
     model.fitTo(refData, PrintLevel=-1)
 
     # The kTRUE flag imports the values of the objects in (*params) into the workspace

--- a/tutorials/roofit/rf511_wsfactory_basic.py
+++ b/tutorials/roofit/rf511_wsfactory_basic.py
@@ -56,7 +56,7 @@ else:
 # class
 
 # Make a dummy dataset pdf 'model' and import it in the workspace
-data = w["model"].generate(ROOT.RooArgSet(w["x"]), 1000)
+data = w["model"].generate({w["x"]}, 1000)
 # Cannot call 'import' directly because this is a python keyword:
 w.Import(data, Rename="data")
 

--- a/tutorials/roofit/rf601_intminuit.py
+++ b/tutorials/roofit/rf601_intminuit.py
@@ -34,7 +34,7 @@ frac = ROOT.RooRealVar("frac", "frac", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [g1, g2], [frac])
 
 # Generate 1000 events
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Construct unbinned likelihood of model w.r.t. data
 nll = model.createNLL(data)
@@ -53,7 +53,7 @@ m.migrad()
 
 # Print values of all parameters, reflect values (and error estimates)
 # that are back propagated from MINUIT
-model.getParameters(ROOT.RooArgSet(x)).Print("s")
+model.getParameters({x}).Print("s")
 
 # Disable verbose logging
 m.setVerbose(False)
@@ -66,7 +66,7 @@ m.hesse()
 sigma_g2.Print()
 
 # Run MINOS on sigma_g2 parameter only
-m.minos(ROOT.RooArgSet(sigma_g2))
+m.minos({sigma_g2})
 
 # Print value (and error) of sigma_g2 parameter, reflects
 # value and error back propagated from MINUIT

--- a/tutorials/roofit/rf602_chi2fit.py
+++ b/tutorials/roofit/rf602_chi2fit.py
@@ -47,7 +47,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 # Create biuned dataset
 # -----------------------------------------
 
-d = model.generate(ROOT.RooArgSet(x), 10000)
+d = model.generate({x}, 10000)
 dh = d.binnedClone()
 
 # Construct a chi^2 of the data and the model.

--- a/tutorials/roofit/rf603_multicpu.py
+++ b/tutorials/roofit/rf603_multicpu.py
@@ -36,7 +36,7 @@ fsig = ROOT.RooRealVar("fsig", "signal fraction", 0.1, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
 # Generate large dataset
-data = model.generate(ROOT.RooArgSet(x, y, z), 200000)
+data = model.generate({x, y, z}, 200000)
 
 # Parallel fitting
 # -------------------------------
@@ -53,8 +53,8 @@ model.fitTo(data, NumCPU=4, Timer=True)
 
 # Construct signal, likelihood projection on (y,z) observables and
 # likelihood ratio
-sigyz = sig.createProjection(ROOT.RooArgSet(x))
-totyz = model.createProjection(ROOT.RooArgSet(x))
+sigyz = sig.createProjection({x})
+totyz = model.createProjection({x})
 llratio_func = ROOT.RooFormulaVar("llratio", "log10(@0)-log10(@1)", [sigyz, totyz])
 
 # Calculate likelihood ratio for each event, subset of events with high

--- a/tutorials/roofit/rf604_constraints.py
+++ b/tutorials/roofit/rf604_constraints.py
@@ -30,7 +30,7 @@ f = ROOT.RooRealVar("f", "f", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [gauss, poly], [f])
 
 # Generate small dataset for use in fitting below
-d = model.generate(ROOT.RooArgSet(x), 50)
+d = model.generate({x}, 50)
 
 # Create constraint pdf
 # -----------------------------------------
@@ -53,7 +53,7 @@ modelc = ROOT.RooProdPdf("modelc", "model with constraint", [model, fconstraint]
 r1 = model.fitTo(d, Save=True)
 
 # Fit modelc with constraint term on parameter f
-r2 = modelc.fitTo(d, Constrain=ROOT.RooArgSet(f), Save=True)
+r2 = modelc.fitTo(d, Constrain={f}, Save=True)
 
 # Method 2 - specify external constraint when fitting
 # ------------------------------------------------------------------------------------------
@@ -63,7 +63,7 @@ r2 = modelc.fitTo(d, Constrain=ROOT.RooArgSet(f), Save=True)
 fconstext = ROOT.RooGaussian("fconstext", "fconstext", f, ROOT.RooFit.RooConst(0.2), ROOT.RooFit.RooConst(0.1))
 
 # Fit with external constraint
-r3 = model.fitTo(d, ExternalConstraints=ROOT.RooArgSet(fconstext), Save=True)
+r3 = model.fitTo(d, ExternalConstraints={fconstext}, Save=True)
 
 # Print the fit results
 print("fit result without constraint (data generated at f=0.5)")

--- a/tutorials/roofit/rf605_profilell.py
+++ b/tutorials/roofit/rf605_profilell.py
@@ -34,7 +34,7 @@ frac = ROOT.RooRealVar("frac", "frac", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [g1, g2], [frac])
 
 # Generate 1000 events
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Construct plain likelihood
 # ---------------------------------------------------
@@ -59,7 +59,7 @@ nll.plotOn(frame2, ShiftToZero=True)
 # The profile likelihood estimator on nll for frac will minimize nll w.r.t
 # all floating parameters except frac for each evaluation
 
-pll_frac = nll.createProfile(ROOT.RooArgSet(frac))
+pll_frac = nll.createProfile({frac})
 
 # Plot the profile likelihood in frac
 pll_frac.plotOn(frame1, LineColor="r")
@@ -73,7 +73,7 @@ frame1.SetMaximum(3)
 
 # The profile likelihood estimator on nll for sigma_g2 will minimize nll
 # w.r.t all floating parameters except sigma_g2 for each evaluation
-pll_sigmag2 = nll.createProfile(ROOT.RooArgSet(sigma_g2))
+pll_sigmag2 = nll.createProfile({sigma_g2})
 
 # Plot the profile likelihood in sigma_g2
 pll_sigmag2.plotOn(frame2, LineColor="r")

--- a/tutorials/roofit/rf606_nllerrorhandling.py
+++ b/tutorials/roofit/rf606_nllerrorhandling.py
@@ -30,7 +30,7 @@ k = ROOT.RooRealVar("k", "k", -30, -50, -10)
 argus = ROOT.RooArgusBG("argus", "argus", m, m0, k)
 
 # Sample 1000 events in m from argus
-data = argus.generate(ROOT.RooArgSet(m), 1000)
+data = argus.generate({m}, 1000)
 
 # Plot model and data
 # --------------------------------------

--- a/tutorials/roofit/rf607_fitresult.py
+++ b/tutorials/roofit/rf607_fitresult.py
@@ -41,7 +41,7 @@ bkgfrac = ROOT.RooRealVar("bkgfrac", "fraction of background", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [bkgfrac])
 
 # Generate 1000 events
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Fit pdf to data, save fit result
 # -------------------------------------------------------------

--- a/tutorials/roofit/rf608_fitresultaspdf.py
+++ b/tutorials/roofit/rf608_fitresultaspdf.py
@@ -30,7 +30,7 @@ frac = ROOT.RooRealVar("frac", "frac", 0.5, 0.0, 1.0)
 model = ROOT.RooAddPdf("model", "model", [g1, g2], [frac])
 
 # Generate 1000 events
-data = model.generate(ROOT.RooArgSet(x), 1000)
+data = model.generate({x}, 1000)
 
 # Fit model to data
 # ----------------------------------
@@ -40,13 +40,13 @@ r = model.fitTo(data, Save=True)
 # Create MV Gaussian pdf of fitted parameters
 # ------------------------------------------------------------------------------------
 
-parabPdf = r.createHessePdf(ROOT.RooArgSet(frac, mean, sigma_g2))
+parabPdf = r.createHessePdf({frac, mean, sigma_g2})
 
 # Some exercises with the parameter pdf
 # -----------------------------------------------------------------------------
 
 # Generate 100K points in the parameter space, from the MVGaussian pdf
-d = parabPdf.generate(ROOT.RooArgSet(mean, sigma_g2, frac), 100000)
+d = parabPdf.generate({mean, sigma_g2, frac}, 100000)
 
 # Sample a 3-D histogram of the pdf to be visualized as an error
 # ellipsoid using the GLISO draw option
@@ -56,9 +56,9 @@ hh_3d.SetFillColor(ROOT.kBlue)
 # Project 3D parameter pdf down to 3 permutations of two-dimensional pdfs
 # The integrations corresponding to these projections are performed analytically
 # by the MV Gaussian pdf
-pdf_sigmag2_frac = parabPdf.createProjection(ROOT.RooArgSet(mean))
-pdf_mean_frac = parabPdf.createProjection(ROOT.RooArgSet(sigma_g2))
-pdf_mean_sigmag2 = parabPdf.createProjection(ROOT.RooArgSet(frac))
+pdf_sigmag2_frac = parabPdf.createProjection({mean})
+pdf_mean_frac = parabPdf.createProjection({sigma_g2})
+pdf_mean_sigmag2 = parabPdf.createProjection({frac})
 
 # Make 2D plots of the 3 two-dimensional pdf projections
 hh_sigmag2_frac = pdf_sigmag2_frac.createHistogram("sigma_g2,frac", 50, 50)

--- a/tutorials/roofit/rf609_xychi2fit.py
+++ b/tutorials/roofit/rf609_xychi2fit.py
@@ -25,7 +25,7 @@ import math
 
 x = ROOT.RooRealVar("x", "x", -11, 11)
 y = ROOT.RooRealVar("y", "y", -10, 200)
-dxy = ROOT.RooDataSet("dxy", "dxy", ROOT.RooArgSet(x, y), StoreError=(ROOT.RooArgSet(x, y)))
+dxy = ROOT.RooDataSet("dxy", "dxy", {x, y}, StoreError={x, y})
 
 # Fill an example dataset with X,err(X),Y,err(Y) values
 for i in range(10):
@@ -36,7 +36,7 @@ for i in range(10):
     y.setVal(x.getVal() * x.getVal() + 4 * abs(ROOT.gRandom.Gaus()))
     y.setError(math.sqrt(y.getVal()))
 
-    dxy.add(ROOT.RooArgSet(x, y))
+    dxy.add({x, y})
 
 # Perform chi2 fit to X +/- dX and Y +/- dY values
 # ---------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf610_visualerror.py
+++ b/tutorials/roofit/rf610_visualerror.py
@@ -30,7 +30,7 @@ model = ROOT.RooAddPdf("model", "model", [sig, bkg], [fsig])
 
 # Create binned dataset
 x.setBins(25)
-d = model.generateBinned(ROOT.RooArgSet(x), 1000)
+d = model.generateBinned({x}, 1000)
 
 # Perform fit and save fit result
 r = model.fitTo(d, Save=True)
@@ -111,8 +111,8 @@ frame2 = x.frame(Bins=40, Title="Visualization of 2-sigma partial error from (m,
 
 # Propagate partial error due to shape parameters (m,m2) using linear and
 # sampling method
-model.plotOn(frame2, VisualizeError=(r, ROOT.RooArgSet(m, m2), 2), FillColor="c")
-model.plotOn(frame2, Components="bkg", VisualizeError=(r, ROOT.RooArgSet(m, m2), 2), FillColor="c")
+model.plotOn(frame2, VisualizeError=(r, {m, m2}, 2), FillColor="c")
+model.plotOn(frame2, Components="bkg", VisualizeError=(r, {m, m2}, 2), FillColor="c")
 
 model.plotOn(frame2)
 model.plotOn(frame2, Components="bkg", LineStyle="--")
@@ -123,8 +123,8 @@ frame3 = x.frame(Bins=40, Title="Visualization of 2-sigma partial error from (s,
 
 # Propagate partial error due to yield parameter using linear and sampling
 # method
-model.plotOn(frame3, VisualizeError=(r, ROOT.RooArgSet(s, s2), 2), FillColor="g")
-model.plotOn(frame3, Components="bkg", VisualizeError=(r, ROOT.RooArgSet(fsig), 2), FillColor="g")
+model.plotOn(frame3, VisualizeError=(r, {s, s2}, 2), FillColor="g")
+model.plotOn(frame3, Components="bkg", VisualizeError=(r, {fsig}, 2), FillColor="g")
 
 model.plotOn(frame3)
 model.plotOn(frame3, Components="bkg", LineStyle="--")
@@ -135,8 +135,8 @@ frame4 = x.frame(Bins=40, Title="Visualization of 2-sigma partial error from fsi
 
 # Propagate partial error due to yield parameter using linear and sampling
 # method
-model.plotOn(frame4, VisualizeError=(r, ROOT.RooArgSet(fsig), 2), FillColor="m")
-model.plotOn(frame4, Components="bkg", VisualizeError=(r, ROOT.RooArgSet(fsig), 2), FillColor="m")
+model.plotOn(frame4, VisualizeError=(r, {fsig}, 2), FillColor="m")
+model.plotOn(frame4, Components="bkg", VisualizeError=(r, {fsig}, 2), FillColor="m")
 
 model.plotOn(frame4)
 model.plotOn(frame4, Components="bkg", LineStyle="--")

--- a/tutorials/roofit/rf612_recoverFromInvalidParameters.py
+++ b/tutorials/roofit/rf612_recoverFromInvalidParameters.py
@@ -27,7 +27,7 @@ x = ROOT.RooRealVar("x", "x", -15, 15)
 a1 = ROOT.RooRealVar("a1", "a1", -0.5, -10.0, 20.0)
 a2 = ROOT.RooRealVar("a2", "a2", 0.2, -10.0, 20.0)
 a3 = ROOT.RooRealVar("a3", "a3", 0.01)
-pdf = ROOT.RooPolynomial("pol3", "c + a1 * x + a2 * x*x + 0.01 * x*x*x", x, ROOT.RooArgSet(a1, a2, a3))
+pdf = ROOT.RooPolynomial("pol3", "c + a1 * x + a2 * x*x + 0.01 * x*x*x", x, [a1, a2, a3])
 
 # Create toy data with all-positive coefficients:
 data = pdf.generate(x, 10000)

--- a/tutorials/roofit/rf701_efficiencyfit.py
+++ b/tutorials/roofit/rf701_efficiencyfit.py
@@ -41,18 +41,16 @@ effPdf = ROOT.RooEfficiency("effPdf", "effPdf", effFunc, cut, "accept")
 # Construct global shape pdf shape(x) and product model(x,cut) = eff(cut|x)*shape(x)
 # (These are _only_ needed to generate some toy MC here to be used later)
 shapePdf = ROOT.RooPolynomial("shapePdf", "shapePdf", x, [-0.095])
-model = ROOT.RooProdPdf(
-    "model", "model", ROOT.RooArgSet(shapePdf), Conditional=(ROOT.RooArgSet(effPdf), ROOT.RooArgSet(cut))
-)
+model = ROOT.RooProdPdf("model", "model", {shapePdf}, Conditional=({effPdf}, {cut}))
 
 # Generate some toy data from model
-data = model.generate(ROOT.RooArgSet(x, cut), 10000)
+data = model.generate({x, cut}, 10000)
 
 # Fit conditional efficiency pdf to data
 # --------------------------------------------------------------------------
 
 # Fit conditional efficiency pdf to data
-effPdf.fitTo(data, ConditionalObservables=ROOT.RooArgSet(x))
+effPdf.fitTo(data, ConditionalObservables={x})
 
 # Plot fitted, data efficiency
 # --------------------------------------------------------

--- a/tutorials/roofit/rf702_efficiencyfit_2D.py
+++ b/tutorials/roofit/rf702_efficiencyfit_2D.py
@@ -52,18 +52,16 @@ effPdf = ROOT.RooEfficiency("effPdf", "effPdf", effFunc, cut, "accept")
 shapePdfX = ROOT.RooPolynomial("shapePdfX", "shapePdfX", x, [0 if flat else -0.095])
 shapePdfY = ROOT.RooPolynomial("shapePdfY", "shapePdfY", y, [0 if flat else +0.095])
 shapePdf = ROOT.RooProdPdf("shapePdf", "shapePdf", [shapePdfX, shapePdfY])
-model = ROOT.RooProdPdf(
-    "model", "model", ROOT.RooArgSet(shapePdf), Conditional=(ROOT.RooArgSet(effPdf), ROOT.RooArgSet(cut))
-)
+model = ROOT.RooProdPdf("model", "model", {shapePdf}, Conditional=({effPdf}, {cut}))
 
 # Generate some toy data from model
-data = model.generate(ROOT.RooArgSet(x, y, cut), 10000)
+data = model.generate({x, y, cut}, 10000)
 
 # Fit conditional efficiency pdf to data
 # --------------------------------------------------------------------------
 
 # Fit conditional efficiency pdf to data
-effPdf.fitTo(data, ConditionalObservables=ROOT.RooArgSet(x, y))
+effPdf.fitTo(data, ConditionalObservables={x, y})
 
 # Plot fitted, data efficiency
 # --------------------------------------------------------

--- a/tutorials/roofit/rf703_effpdfprod.py
+++ b/tutorials/roofit/rf703_effpdfprod.py
@@ -49,7 +49,7 @@ modelEff.plotOn(frame2)
 
 # Generate events. If the input pdf has an internal generator, internal generator
 # is used and an accept/reject sampling on the efficiency is applied.
-data = modelEff.generate(ROOT.RooArgSet(t), 10000)
+data = modelEff.generate({t}, 10000)
 
 # Fit pdf. The normalization integral is calculated numerically.
 modelEff.fitTo(data)

--- a/tutorials/roofit/rf704_amplitudefit.py
+++ b/tutorials/roofit/rf704_amplitudefit.py
@@ -47,7 +47,7 @@ f2 = ROOT.RooRealVar("f2", "f2", 0.5, 0, 2)
 pdf = ROOT.RooRealSumPdf("pdf", "pdf", [ampl1, ampl2], [f1, f2])
 
 # Generate some toy data from pdf
-data = pdf.generate(ROOT.RooArgSet(t, cosa), 10000)
+data = pdf.generate({t, cosa}, 10000)
 
 # Fit pdf to toy data with only amplitude strength floating
 pdf.fitTo(data)
@@ -67,11 +67,8 @@ hh_sin.SetLineColor(ROOT.kRed)
 frame1 = t.frame()
 data.plotOn(frame1)
 pdf.plotOn(frame1)
-# workaround, see https://root.cern.ch/phpBB3/viewtopic.php?t=7764
-ras_ampl1 = ROOT.RooArgSet(ampl1)
-pdf.plotOn(frame1, Components=ras_ampl1, LineStyle="--")
-ras_ampl2 = ROOT.RooArgSet(ampl2)
-pdf.plotOn(frame1, Components=ras_ampl2, LineStyle="--", LineColor="r")
+pdf.plotOn(frame1, Components=ampl1, LineStyle="--")
+pdf.plotOn(frame1, Components=ampl2, LineStyle="--", LineColor="r")
 
 # Make projection on cosa, data, and its components
 # Note that components projection may be larger than sum because
@@ -79,8 +76,8 @@ pdf.plotOn(frame1, Components=ras_ampl2, LineStyle="--", LineColor="r")
 frame2 = cosa.frame()
 data.plotOn(frame2)
 pdf.plotOn(frame2)
-pdf.plotOn(frame2, Components=ras_ampl1, LineStyle="--")
-pdf.plotOn(frame2, Components=ras_ampl2, LineStyle="--", LineColor="r")
+pdf.plotOn(frame2, Components=ampl1, LineStyle="--")
+pdf.plotOn(frame2, Components=ampl2, LineStyle="--", LineColor="r")
 
 c = ROOT.TCanvas("rf704_amplitudefit", "rf704_amplitudefit", 800, 800)
 c.Divide(2, 2)

--- a/tutorials/roofit/rf705_linearmorph.py
+++ b/tutorials/roofit/rf705_linearmorph.py
@@ -81,7 +81,7 @@ hh.SetLineColor(ROOT.kBlue)
 
 # Generate a toy dataset alpha = 0.8
 alpha.setVal(0.8)
-data = lmorph.generate(ROOT.RooArgSet(x), 1000)
+data = lmorph.generate({x}, 1000)
 
 # Fit pdf to toy data
 lmorph.setCacheAlpha(True)

--- a/tutorials/roofit/rf706_histpdf.py
+++ b/tutorials/roofit/rf706_histpdf.py
@@ -22,13 +22,13 @@ p = ROOT.RooPolynomial("p", "p", x, [0.01, -0.01, 0.0004])
 
 # Sample 500 events from p
 x.setBins(20)
-data1 = p.generate(ROOT.RooArgSet(x), 500)
+data1 = p.generate({x}, 500)
 
 # Create a binned dataset with 20 bins and 500 events
 hist1 = data1.binnedClone()
 
 # Represent data in dh as pdf in x
-histpdf1 = ROOT.RooHistPdf("histpdf1", "histpdf1", ROOT.RooArgSet(x), hist1, 0)
+histpdf1 = ROOT.RooHistPdf("histpdf1", "histpdf1", {x}, hist1, 0)
 
 # Plot unbinned data and histogram pdf overlaid
 frame1 = x.frame(Title="Low statistics histogram pdf", Bins=100)
@@ -40,13 +40,13 @@ histpdf1.plotOn(frame1)
 
 # Sample 100000 events from p
 x.setBins(10)
-data2 = p.generate(ROOT.RooArgSet(x), 100000)
+data2 = p.generate({x}, 100000)
 
 # Create a binned dataset with 10 bins and 100K events
 hist2 = data2.binnedClone()
 
 # Represent data in dh as pdf in x, 2nd order interpolation
-histpdf2 = ROOT.RooHistPdf("histpdf2", "histpdf2", ROOT.RooArgSet(x), hist2, 2)
+histpdf2 = ROOT.RooHistPdf("histpdf2", "histpdf2", {x}, hist2, 2)
 
 # Plot unbinned data and histogram pdf overlaid
 frame2 = x.frame(Title="High stats histogram pdf with interpolation", Bins=100)

--- a/tutorials/roofit/rf707_kernelestimation.py
+++ b/tutorials/roofit/rf707_kernelestimation.py
@@ -19,7 +19,7 @@ x = ROOT.RooRealVar("x", "x", 0, 20)
 p = ROOT.RooPolynomial("p", "p", x, [0.01, -0.01, 0.0004])
 
 # Sample 500 events from p
-data1 = p.generate(ROOT.RooArgSet(x), 200)
+data1 = p.generate({x}, 200)
 
 # Create 1D kernel estimation pdf
 # ---------------------------------------------------------------
@@ -60,7 +60,7 @@ py = ROOT.RooPolynomial(
     [0.01, 0.01, -0.0004],
 )
 pxy = ROOT.RooProdPdf("pxy", "pxy", [p, py])
-data2 = pxy.generate(ROOT.RooArgSet(x, y), 1000)
+data2 = pxy.generate({x, y}, 1000)
 
 # Create 2D kernel estimation pdf
 # ---------------------------------------------------------------

--- a/tutorials/roofit/rf708_bphysics.py
+++ b/tutorials/roofit/rf708_bphysics.py
@@ -41,7 +41,7 @@ bmix = ROOT.RooBMixDecay("bmix", "decay", dt, mixState, tagFlav, tau, dm, w, dw,
 # ---------------------------------------------------
 
 # Generate some data
-data = bmix.generate(ROOT.RooArgSet(dt, mixState, tagFlav), 10000)
+data = bmix.generate({dt, mixState, tagFlav}, 10000)
 
 # Plot B0 and B0bar tagged data separately
 # For all plots below B0 and B0 tagged data will look somewhat differently
@@ -93,7 +93,7 @@ bcp = ROOT.RooBCPEffDecay(
 # ---------------------------------------------------------------------------
 
 # Generate some data
-data2 = bcp.generate(ROOT.RooArgSet(dt, tagFlav), 10000)
+data2 = bcp.generate({dt, tagFlav}, 10000)
 
 # Plot B0 and B0bar tagged data separately
 frame4 = dt.frame(Title="B decay distribution with CPV(|l|=1,Im(l)=0.7) (B0/B0bar)")
@@ -110,7 +110,7 @@ bcp.plotOn(frame4, Slice=(tagFlav, "B0bar"), LineColor="c")
 absLambda.setVal(0.7)
 
 # Generate some data
-data3 = bcp.generate(ROOT.RooArgSet(dt, tagFlav), 10000)
+data3 = bcp.generate({dt, tagFlav}, 10000)
 
 # Plot B0 and B0bar tagged data separately (sin2b = 0.7 plus direct CPV
 # |l|=0.5)
@@ -153,7 +153,7 @@ bcpg = ROOT.RooBDecay(
 # -------------------------------------------------------------------------------------
 
 # Generate some data
-data4 = bcpg.generate(ROOT.RooArgSet(dt, tagFlav), 10000)
+data4 = bcpg.generate({dt, tagFlav}, 10000)
 
 # Plot B0 and B0bar tagged data separately
 frame6 = dt.frame(Title="B decay distribution with CPV(Im(l)=0.7,Re(l)=0.7,|l|=1,dG/G=0.5) (B0/B0bar)")

--- a/tutorials/roofit/rf709_BarlowBeeston.py
+++ b/tutorials/roofit/rf709_BarlowBeeston.py
@@ -75,7 +75,7 @@ hc_sig = ROOT.RooHistConstraint("hc_sig", "hc_sig", p_ph_sig1)
 hc_bkg = ROOT.RooHistConstraint("hc_bkg", "hc_bkg", p_ph_bkg1)
 
 # Construct the joint model with template PDFs and constraints
-model1 = ROOT.RooProdPdf("model1", "model1", ROOT.RooArgSet(hc_sig, hc_bkg), Conditional=(model_tmp, x))
+model1 = ROOT.RooProdPdf("model1", "model1", {hc_sig, hc_bkg}, Conditional=(model_tmp, x))
 
 
 #  Case 2 - 'Barlow Beeston' light (one parameter per bin for all samples)
@@ -97,7 +97,7 @@ Abkg2 = ROOT.RooRealVar("Abkg", "Abkg", 1, 0.01, 5000)
 model2_tmp = ROOT.RooRealSumPdf("sp_ph", "sp_ph", [p_ph_sig2, p_ph_bkg2], [Asig2, Abkg2], True)
 
 # Construct the subsidiary poisson measurements constraining the statistical fluctuations
-hc_sigbkg = ROOT.RooHistConstraint("hc_sigbkg", "hc_sigbkg", ROOT.RooArgSet(p_ph_sig2, p_ph_bkg2))
+hc_sigbkg = ROOT.RooHistConstraint("hc_sigbkg", "hc_sigbkg", {p_ph_sig2, p_ph_bkg2})
 
 # Construct the joint model
 model2 = ROOT.RooProdPdf("model2", "model2", hc_sigbkg, Conditional=(model2_tmp, x))
@@ -127,8 +127,8 @@ model0.plotOn(frame, LineColor="b", VisualizeError=result0)
 sumData.plotOn(frame)
 # Plot model components
 model0.plotOn(frame, LineColor="b")
-p_ph_sig_set = ROOT.RooArgSet(p_h_sig)
-p_ph_bkg_set = ROOT.RooArgSet(p_h_bkg)
+p_ph_sig_set = {p_h_sig}
+p_ph_bkg_set = {p_h_bkg}
 model0.plotOn(frame, Components=p_ph_sig_set, LineColor="kAzure")
 model0.plotOn(frame, Components=p_ph_bkg_set, LineColor="r")
 model0.paramOn(frame)
@@ -157,11 +157,11 @@ model1.plotOn(frame, LineColor="b", VisualizeError=result1)
 # Plot data again to show it on top of error bands:
 sumData.plotOn(frame)
 model1.plotOn(frame, LineColor="b")
-p_ph_sig1_set = ROOT.RooArgSet(p_ph_sig1)
-p_ph_bkg1_set = ROOT.RooArgSet(p_ph_bkg1)
+p_ph_sig1_set = {p_ph_sig1}
+p_ph_bkg1_set = {p_ph_bkg1}
 model1.plotOn(frame, Components=p_ph_sig1_set, LineColor="kAzure")
 model1.plotOn(frame, Components=p_ph_bkg1_set, LineColor="r")
-model1.paramOn(frame, Parameters=ROOT.RooArgSet(Asig1, Abkg1))
+model1.paramOn(frame, Parameters={Asig1, Abkg1})
 
 sigData.plotOn(frame, MarkerColor="b")
 frame.Draw()
@@ -189,11 +189,11 @@ model2.plotOn(frame, LineColor="b", VisualizeError=result2)
 # Plot data again to show it on top of model0 error bands:
 sumData.plotOn(frame)
 model2.plotOn(frame, LineColor="b")
-p_ph_sig2_set = ROOT.RooArgSet(p_ph_sig2)
-p_ph_bkg2_set = ROOT.RooArgSet(p_ph_bkg2)
+p_ph_sig2_set = {p_ph_sig2}
+p_ph_bkg2_set = {p_ph_bkg2}
 model2.plotOn(frame, Components=p_ph_sig2_set, LineColor="kAzure")
 model2.plotOn(frame, Components=p_ph_bkg2_set, LineColor="r")
-model2.paramOn(frame, Parameters=ROOT.RooArgSet(Asig2, Abkg2))
+model2.paramOn(frame, Parameters={Asig2, Abkg2})
 
 sigData.plotOn(frame, MarkerColor="b")
 frame.Draw()

--- a/tutorials/roofit/rf801_mcstudy.py
+++ b/tutorials/roofit/rf801_mcstudy.py
@@ -61,7 +61,7 @@ model = ROOT.RooAddPdf("model", "g1+g2+a", [bkg, sig], [nbkg, nsig])
 
 mcstudy = ROOT.RooMCStudy(
     model,
-    ROOT.RooArgSet(x),
+    {x},
     Binned=True,
     Silence=True,
     Extended=True,

--- a/tutorials/roofit/rf802_mcstudy_addons.py
+++ b/tutorials/roofit/rf802_mcstudy_addons.py
@@ -31,7 +31,7 @@ gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
 
 # Create study manager for binned likelihood fits of a Gaussian pdf in 10
 # bins
-mcs = ROOT.RooMCStudy(gauss, ROOT.RooArgSet(x), ROOT.RooFit.Silence(), ROOT.RooFit.Binned())
+mcs = ROOT.RooMCStudy(gauss, {x}, ROOT.RooFit.Silence(), ROOT.RooFit.Binned())
 
 # Add chi^2 calculator module to mcs
 chi2mod = ROOT.RooChi2MCSModule()
@@ -55,9 +55,7 @@ gauss2 = ROOT.RooGaussian("gauss2", "gaussian PDF2", x, mean2, sigma)
 # Create study manager with separate generation and fit model. ROOT.This configuration
 # is set up to generate bad fits as the fit and generator model have different means
 # and the mean parameter is not floating in the fit
-mcs2 = ROOT.RooMCStudy(
-    gauss2, ROOT.RooArgSet(x), ROOT.RooFit.FitModel(gauss), ROOT.RooFit.Silence(), ROOT.RooFit.Binned()
-)
+mcs2 = ROOT.RooMCStudy(gauss2, {x}, ROOT.RooFit.FitModel(gauss), ROOT.RooFit.Silence(), ROOT.RooFit.Binned())
 
 # Add chi^2 calculator module to mcs
 chi2mod2 = ROOT.RooChi2MCSModule()

--- a/tutorials/roofit/rf803_mcstudy_addons2.py
+++ b/tutorials/roofit/rf803_mcstudy_addons2.py
@@ -46,7 +46,7 @@ model = ROOT.RooAddPdf("model", "model", [sig, bkg], [nsig, nbkg])
 # with a Poisson fluctuation on Nobs (Extended())
 mcs = ROOT.RooMCStudy(
     model,
-    ROOT.RooArgSet(mjjj),
+    {mjjj},
     ROOT.RooFit.Binned(),
     ROOT.RooFit.Silence(),
     ROOT.RooFit.Extended(ROOT.kTRUE),
@@ -65,7 +65,7 @@ mcs = ROOT.RooMCStudy(
 # by a single randomizer module
 
 randModule = ROOT.RooRandomizeParamMCSModule()
-randModule.sampleSumUniform(ROOT.RooArgSet(nsig, nbkg), 50, 500)
+randModule.sampleSumUniform({nsig, nbkg}, 50, 500)
 mcs.addModule(randModule)
 
 # Add profile likelihood calculation of significance. Redo each

--- a/tutorials/roofit/rf804_mcstudy_constr.py
+++ b/tutorials/roofit/rf804_mcstudy_constr.py
@@ -44,8 +44,8 @@ sumc = ROOT.RooProdPdf("sumc", "sum with constraint", [sum, fconstraint])
 # Perform toy study with internal constraint on f
 mcs = ROOT.RooMCStudy(
     sumc,
-    ROOT.RooArgSet(x),
-    ROOT.RooFit.Constrain(ROOT.RooArgSet(f)),
+    {x},
+    ROOT.RooFit.Constrain({f}),
     ROOT.RooFit.Silence(),
     ROOT.RooFit.Binned(),
     ROOT.RooFit.FitOptions(ROOT.RooFit.PrintLevel(-1)),

--- a/tutorials/roofit/rf901_numintconfig.py
+++ b/tutorials/roofit/rf901_numintconfig.py
@@ -46,7 +46,7 @@ landau = ROOT.RooLandau("landau", "landau", x, ROOT.RooFit.RooConst(0), ROOT.Roo
 ROOT.RooMsgService.instance().addStream(ROOT.RooFit.DEBUG, Topic=ROOT.RooFit.Integration)
 
 # Calculate integral over landau with default choice of numeric integrator
-intLandau = landau.createIntegral(ROOT.RooArgSet(x))
+intLandau = landau.createIntegral({x})
 val = intLandau.getVal()
 print(" [1] int_dx landau(x) = ", val)  # setprecision(15)
 
@@ -61,7 +61,7 @@ if integratorGKNotExisting:
     print("WARNING: RooAdaptiveGaussKronrodIntegrator is not existing because ROOT is built without Mathmore support")
 
 # Calculate integral over landau with custom integral specification
-intLandau2 = landau.createIntegral(ROOT.RooArgSet(x), NumIntConfig=customConfig)
+intLandau2 = landau.createIntegral({x}, NumIntConfig=customConfig)
 val2 = intLandau2.getVal()
 print(" [2] int_dx landau(x) = ", val2)
 
@@ -74,7 +74,7 @@ landau.setIntegratorConfig(customConfig)
 
 # Calculate integral over landau custom numeric integrator specified as
 # object default
-intLandau3 = landau.createIntegral(ROOT.RooArgSet(x))
+intLandau3 = landau.createIntegral({x})
 val3 = intLandau3.getVal()
 print(" [3] int_dx landau(x) = ", val3)
 

--- a/tutorials/roofit/rf902_numgenconfig.py
+++ b/tutorials/roofit/rf902_numgenconfig.py
@@ -27,7 +27,7 @@ model = ROOT.RooChebychev("model", "model", x, [0.0, 0.5, -0.1])
 ROOT.RooAbsPdf.defaultGeneratorConfig().method1D(False, False).setLabel("RooAcceptReject")
 
 # Generate 10Kevt using ROOT.RooAcceptReject
-data_ar = model.generate(ROOT.RooArgSet(x), 10000, Verbose=True)
+data_ar = model.generate({x}, 10000, Verbose=True)
 data_ar.Print()
 
 # Adjusting default config for a specific pdf
@@ -52,5 +52,5 @@ model.specialGeneratorConfig().getConfigSection("RooFoamGenerator").setRealValue
 
 # Generate 10Kevt using ROOT.RooFoamGenerator (FOAM verbosity increased
 # with above chatLevel adjustment for illustration purposes)
-data_foam = model.generate(ROOT.RooArgSet(x), 10000, ROOT.RooFit.Verbose())
+data_foam = model.generate({x}, 10000, ROOT.RooFit.Verbose())
 data_foam.Print()

--- a/tutorials/roofit/rf903_numintcache.py
+++ b/tutorials/roofit/rf903_numintcache.py
@@ -44,7 +44,7 @@ def getWorkspace(mode):
         model.setStringAttribute("CACHEPARMINT", "x:y:z")
 
         # Evaluate pdf once to trigger filling of cache
-        normSet = ROOT.RooArgSet(w["x"], w["y"], w["z"])
+        normSet = {w["x"], w["y"], w["z"]}
         model.getVal(normSet)
         w.writeToFile("rf903_numintcache.root")
 
@@ -87,7 +87,7 @@ if mode == 1:
 # ROOT.This is always slow (need to find maximum function value
 # empirically in 3D space)
 model = w["model"]
-d = model.generate(ROOT.RooArgSet(w["x"], w["y"], w["z"]), 1000)
+d = model.generate({w["x"], w["y"], w["z"]}, 1000)
 
 # ROOT.This is slow in mode 0, fast in mode 1
 model.fitTo(d, Verbose=True, Timer=True)


### PR DESCRIPTION
For the pyROOT interface, we wanted to support that the user can pass a
Python set whenever the interface expects a RooArgSet.

This is achieved by pythonizing the `__init__` function of the RooArgSet Python mirror class.

This PR also includes a complete migration of all RooFit tutorials.