### PR TITLE
[DF] Use R_rdf instead of __rdf as the "secret RDF namespace"

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -636,10 +636,10 @@ public:
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
-      // Ignore __rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
+      // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;
       std::copy_if(dsColumns.begin(), dsColumns.end(), std::back_inserter(dsColumnsWithoutSizeColumns),
-                   [](const std::string &name) { return name.size() < 13 || name.substr(0, 13) != "__rdf_sizeof_"; });
+                   [](const std::string &name) { return name.size() < 13 || name.substr(0, 13) != "R_rdf_sizeof_"; });
       ColumnNames_t columnNames;
       columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumnsWithoutSizeColumns.size());
       columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
@@ -774,10 +774,10 @@ public:
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
-      // Ignore __rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
+      // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;
       std::copy_if(dsColumns.begin(), dsColumns.end(), std::back_inserter(dsColumnsWithoutSizeColumns),
-                   [](const std::string &name) { return name.size() < 13 || name.substr(0, 13) != "__rdf_sizeof_"; });
+                   [](const std::string &name) { return name.size() < 13 || name.substr(0, 13) != "R_rdf_sizeof_"; });
       ColumnNames_t columnNames;
       columnNames.reserve(definedColumns.size() + treeBranchNames.size() + dsColumns.size());
       columnNames.insert(columnNames.end(), definedColumns.begin(), definedColumns.end());
@@ -1971,9 +1971,9 @@ public:
 
       if (fDataSource) {
          const auto &dsColNames = fDataSource->GetColumnNames();
-         // ignore columns starting with __rdf_sizeof_
+         // ignore columns starting with R_rdf_sizeof_
          std::copy_if(dsColNames.begin(), dsColNames.end(), std::back_inserter(allColumns),
-                      [](const std::string &s) { return s.rfind("__rdf_sizeof", 0) != 0; });
+                      [](const std::string &s) { return s.rfind("R_rdf_sizeof", 0) != 0; });
       }
 
       return allColumns;

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -138,12 +138,12 @@ static ParsedExpression ParseRDFExpression(std::string_view expr, const ColumnNa
                                            const ColumnNames_t &customColNames, const ColumnNames_t &dataSourceColNames,
                                            const std::map<std::string, std::string> &aliasMap)
 {
-   // transform `#var` into `__rdf_sizeof_var`
+   // transform `#var` into `R_rdf_sizeof_var`
    TString preProcessedExpr(expr);
    // match #varname at beginning of the sentence or after not-a-word, but exclude preprocessor directives like #ifdef
    TPRegexp colSizeReplacer(
       "(^|\\W)#(?!(ifdef|ifndef|if|else|elif|endif|pragma|define|undef|include|line))([a-zA-Z_][a-zA-Z0-9_]*)");
-   colSizeReplacer.Substitute(preProcessedExpr, "$1__rdf_sizeof_$3", "g");
+   colSizeReplacer.Substitute(preProcessedExpr, "$1R_rdf_sizeof_$3", "g");
 
    const auto usedColsAndAliases =
       FindUsedColumns(std::string(preProcessedExpr), treeBranchNames, customColNames, dataSourceColNames, aliasMap);
@@ -259,7 +259,7 @@ BuildLambdaString(const std::string &expr, const ColumnNames_t &vars, const Colu
    return ss.str();
 }
 
-/// Declare a lambda expression to the interpreter in namespace __rdf, return the name of the jitted lambda.
+/// Declare a lambda expression to the interpreter in namespace R_rdf, return the name of the jitted lambda.
 /// If the lambda expression is already in GetJittedExprs, return the name for the lambda that has already been jitted.
 static std::string DeclareLambda(const std::string &expr, const ColumnNames_t &vars, const ColumnNames_t &varTypes)
 {
@@ -276,9 +276,9 @@ static std::string DeclareLambda(const std::string &expr, const ColumnNames_t &v
 
    // new expression
    const auto lambdaBaseName = "lambda" + std::to_string(exprMap.size());
-   const auto lambdaFullName = "__rdf::" + lambdaBaseName;
+   const auto lambdaFullName = "R_rdf::" + lambdaBaseName;
 
-   const auto toDeclare = "namespace __rdf {\nauto " + lambdaBaseName + " = " + lambdaExpr + ";\nusing " +
+   const auto toDeclare = "namespace R_rdf {\nauto " + lambdaBaseName + " = " + lambdaExpr + ";\nusing " +
                           lambdaBaseName + "_ret_t = typename ROOT::TypeTraits::CallableTraits<decltype(" +
                           lambdaBaseName + ")>::ret_type;\n}";
    ROOT::Internal::RDF::InterpreterDeclare(toDeclare.c_str());
@@ -376,9 +376,9 @@ std::string ResolveAlias(const std::string &col, const std::map<std::string, std
    if (it != aliasMap.end())
       return it->second;
 
-   // #var is an alias for __rdf_sizeof_var
+   // #var is an alias for R_rdf_sizeof_var
    if (col.size() > 1 && col[0] == '#')
-      return "__rdf_sizeof_" + col.substr(1);
+      return "R_rdf_sizeof_" + col.substr(1);
 
    return col;
 }
@@ -790,7 +790,7 @@ ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColu
 {
    auto selectedColumns = SelectColumns(nColumns, columns, lm.GetDefaultColumnNames());
 
-   // Resolve aliases and expand `#var` to `__rdf_sizeof_var`
+   // Resolve aliases and expand `#var` to `R_rdf_sizeof_var`
    const auto &aliasMap = lm.GetAliasMap();
 
    for (auto &col : selectedColumns) {

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -36,7 +36,7 @@ namespace Internal {
 
 /// An artificial field that transforms an RNTuple column that contains the offset of collections into
 /// collection sizes. It is used to provide the "number of" RDF columns for collections, e.g.
-/// `__rdf_sizeof_jets` for a collection named `jets`.
+/// `R_rdf_sizeof_jets` for a collection named `jets`.
 ///
 /// This field owns the collection offset field but instead of exposing the collection offsets it exposes
 /// the collection sizes (offset(N+1) - offset(N)).  For the time being, we offer this functionality only in RDataFrame.
@@ -169,13 +169,13 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    // "event"                             [Event]
    // "event.id"                          [int]
    // "event.tracks"                      [std::vector<Track>]
-   // "__rdf_sizeof_event.tracks"         [unsigned int]
+   // "R_rdf_sizeof_event.tracks"         [unsigned int]
    // "event.tracks.hits"                 [std::vector<std::vector<Hit>>]
-   // "__rdf_sizeof_event.tracks.hits"    [std::vector<unsigned int>]
+   // "R_rdf_sizeof_event.tracks.hits"    [std::vector<unsigned int>]
    // "event.tracks.hits.x"               [std::vector<std::vector<float>>]
-   // "__rdf_sizeof_event.tracks.hits.x"  [std::vector<unsigned int>]
+   // "R_rdf_sizeof_event.tracks.hits.x"  [std::vector<unsigned int>]
    // "event.tracks.hits.y"               [std::vector<std::vector<float>>]
-   // "__rdf_sizeof_event.tracks.hits.y"  [std::vector<unsigned int>]
+   // "R_rdf_sizeof_event.tracks.hits.y"  [std::vector<unsigned int>]
 
    const auto &fieldDesc = desc.GetFieldDescriptor(fieldId);
    if (fieldDesc.GetStructure() == ENTupleStructure::kCollection) {
@@ -209,7 +209,7 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    auto valueField = fieldOrException.Unwrap();
    valueField->SetOnDiskId(fieldId);
    std::unique_ptr<Detail::RFieldBase> cardinalityField;
-   // Collections get the additional "number of" RDF column (e.g. "__rdf_sizeof_tracks")
+   // Collections get the additional "number of" RDF column (e.g. "R_rdf_sizeof_tracks")
    if (!skeinIDs.empty()) {
       cardinalityField = std::make_unique<ROOT::Experimental::Internal::RRDFCardinalityField>();
       cardinalityField->SetOnDiskId(skeinIDs.back());
@@ -227,7 +227,7 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
    }
 
    if (cardinalityField) {
-      fColumnNames.emplace_back("__rdf_sizeof_" + std::string(colName));
+      fColumnNames.emplace_back("R_rdf_sizeof_" + std::string(colName));
       fColumnTypes.emplace_back(cardinalityField->GetType());
       auto cardColReader = std::make_unique<ROOT::Experimental::Internal::RNTupleColumnReader>(
          std::move(cardinalityField));

--- a/tree/dataframe/test/RArraysDS.hxx
+++ b/tree/dataframe/test/RArraysDS.hxx
@@ -34,10 +34,10 @@ public:
 /// A RDataSource to test the #var feature
 class RArraysDS : public ROOT::RDF::RDataSource {
    std::vector<int> fVar = {42};
-   std::vector<std::string> fColumnNames = {"__rdf_sizeof_var", "var"};
+   std::vector<std::string> fColumnNames = {"R_rdf_sizeof_var", "var"};
    std::vector<std::pair<ULong64_t, ULong64_t>> fRanges = {{0ull, 1ull}};
 
-   bool IsSizeColumn(std::string_view colName) const { return colName.substr(0, 13) == "__rdf_sizeof_"; }
+   bool IsSizeColumn(std::string_view colName) const { return colName.substr(0, 13) == "R_rdf_sizeof_"; }
 
 public:
    void SetNSlots(unsigned int) final { }
@@ -46,7 +46,7 @@ public:
 
    bool HasColumn(std::string_view name) const final
    {
-      return name == "var" || name == "__rdf_sizeof_var";
+      return name == "var" || name == "R_rdf_sizeof_var";
    }
 
    std::string GetTypeName(std::string_view name) const final

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -714,10 +714,10 @@ TEST(RDataFrameInterface, DescribeDataset)
    EXPECT_EQ(df3.DescribeDataset(), "Dataframe from datasource RCsv");
 }
 
-// #var is a convenience alias for __rdf_sizeof_var.
+// #var is a convenience alias for R_rdf_sizeof_var.
 TEST(RDataFrameInterface, ShortSyntaxForCollectionSizes)
 {
-   auto df = ROOT::RDataFrame(1).Define("__rdf_sizeof_x", [] { return 42; });
+   auto df = ROOT::RDataFrame(1).Define("R_rdf_sizeof_x", [] { return 42; });
    auto m1 = df.Max<int>("#x");
    auto m2 = df.Max("#x");
    auto m3 = df.Define("y", [] (int xs) { return xs; }, {"#x"}).Max<int>("y");
@@ -738,9 +738,9 @@ TEST(RDataFrameInterface, StressShortSyntaxForCollectionSizes)
 {
    gInterpreter->Declare("#define RDF_DO_FILTER 1");
    auto df = ROOT::RDF::RNode(ROOT::RDataFrame(42));
-   // Define __rdf_sizeof_var{1,2,...,100}
+   // Define R_rdf_sizeof_var{1,2,...,100}
    for (int i = 1; i <= 100; ++i)
-      df = df.Define("__rdf_sizeof_var" + std::to_string(i), [] { return 1; });
+      df = df.Define("R_rdf_sizeof_var" + std::to_string(i), [] { return 1; });
 
    // Filter expression is "#var1 + #var2 + ... + #var100 == 100"
    std::string expr = "#var1";

--- a/tree/dataframe/test/datasource_more.cxx
+++ b/tree/dataframe/test/datasource_more.cxx
@@ -40,7 +40,7 @@ TEST(RStreamingDS, MultipleEntryRanges)
 TEST(RArraysDS, ShortSyntaxForCollectionSizes)
 {
    ROOT::RDataFrame df(std::make_unique<RArraysDS>());
-   // GetColumnNames must hide column "__rdf_sizeof_var"...
+   // GetColumnNames must hide column "R_rdf_sizeof_var"...
    EXPECT_EQ(df.GetColumnNames(), std::vector<std::string>{"var"});
    // ...but it must nonetheless be a valid column
    EXPECT_EQ(df.GetColumnType("#var"), "std::size_t");

--- a/tree/dataframe/test/datasource_ntuple.cxx
+++ b/tree/dataframe/test/datasource_ntuple.cxx
@@ -51,12 +51,12 @@ TEST_F(RNTupleDSTest, ColTypeNames)
 
    EXPECT_TRUE(tds.HasColumn("pt"));
    EXPECT_TRUE(tds.HasColumn("energy"));
-   EXPECT_TRUE(tds.HasColumn("__rdf_sizeof_nnlo"));
+   EXPECT_TRUE(tds.HasColumn("R_rdf_sizeof_nnlo"));
    EXPECT_FALSE(tds.HasColumn("Address"));
 
    EXPECT_STREQ("std::string", tds.GetTypeName("tag").c_str());
    EXPECT_STREQ("float", tds.GetTypeName("energy").c_str());
-   EXPECT_STREQ("std::size_t", tds.GetTypeName("__rdf_sizeof_jets").c_str());
+   EXPECT_STREQ("std::size_t", tds.GetTypeName("R_rdf_sizeof_jets").c_str());
 }
 
 
@@ -66,13 +66,13 @@ TEST_F(RNTupleDSTest, CardinalityColumn)
 
    // Check that the special column #<collection> works without jitting...
    auto identity = [](std::size_t sz) { return sz; };
-   auto max_njets = df.Define("njets", identity, {"__rdf_sizeof_jets"}).Max<std::size_t>("njets");
+   auto max_njets = df.Define("njets", identity, {"R_rdf_sizeof_jets"}).Max<std::size_t>("njets");
    auto max_njets2 = df.Max<std::size_t>("#jets");
    EXPECT_EQ(*max_njets, *max_njets2);
    EXPECT_EQ(*max_njets, 2);
 
    // ...and with jitting
-   auto max_njets_jitted = df.Define("njets", "__rdf_sizeof_jets").Max<std::size_t>("njets");
+   auto max_njets_jitted = df.Define("njets", "R_rdf_sizeof_jets").Max<std::size_t>("njets");
    auto max_njets_jitted2 = df.Define("njets", "#jets").Max<std::size_t>("njets");
    auto max_njets_jitted3 = df.Max("#jets");
    EXPECT_EQ(*max_njets_jitted, *max_njets_jitted2);
@@ -86,9 +86,9 @@ void ReadTest(const std::string &name, const std::string &fname) {
    auto count = df.Count();
    auto sumpt = df.Sum<float>("pt");
    auto tag = df.Take<std::string>("tag");
-   auto njets = df.Take<ROOT::Experimental::ClusterSize_t::ValueType>("__rdf_sizeof_jets");
+   auto njets = df.Take<ROOT::Experimental::ClusterSize_t::ValueType>("R_rdf_sizeof_jets");
    auto sumjets = df.Sum<std::vector<float>>("jets");
-   auto sumnnlosize = df.Sum<std::vector<ROOT::Experimental::ClusterSize_t::ValueType>>("__rdf_sizeof_nnlo");
+   auto sumnnlosize = df.Sum<std::vector<ROOT::Experimental::ClusterSize_t::ValueType>>("R_rdf_sizeof_nnlo");
    auto sumvec = [](float red, const std::vector<std::vector<float>> &nnlo) {
       auto sum = 0.f;
       for (auto &v : nnlo)

--- a/tree/ntuple/v7/test/ntuple_rdf.cxx
+++ b/tree/ntuple/v7/test/ntuple_rdf.cxx
@@ -32,6 +32,6 @@ TEST(RNTuple, RDF)
    auto s = rdf.Take<std::string>("klass.s");
    EXPECT_EQ(1ull, s.GetValue().size());
    EXPECT_EQ(std::string("abc"), s.GetValue()[0]);
-   EXPECT_EQ(2U, *rdf.Min("__rdf_sizeof_jets"));
-   EXPECT_EQ(3U, *rdf.Min("__rdf_sizeof_klass.v1"));
+   EXPECT_EQ(2U, *rdf.Min("R_rdf_sizeof_jets"));
+   EXPECT_EQ(3U, *rdf.Min("R_rdf_sizeof_klass.v1"));
 }


### PR DESCRIPTION
Identifiers containing a double underscore are reserved in C++.

We have to do this now because we kind of expose `__rdf` to RDataSource
implementations via the (unreleased) `#var` aliasing mechanism.