### PR TITLE
[DF] Remove wrong RepresentGraph logic

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -139,10 +139,6 @@ private:
    {
       auto loopManager = resultPtr.fLoopManager;
 
-      if (std::is_same<T, RInterface<RLoopManager, void>>::value) {
-         return RepresentGraph(loopManager);
-      }
-
       loopManager->Jit();
 
       auto actionPtr = resultPtr.fActionPtr;

--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -138,8 +138,6 @@ private:
    std::string RepresentGraph(const RResultPtr<T> &resultPtr)
    {
       auto loopManager = resultPtr.fLoopManager;
-      if (!loopManager)
-         throw std::runtime_error("Something went wrong");
 
       if (std::is_same<T, RInterface<RLoopManager, void>>::value) {
          return RepresentGraph(loopManager);


### PR DESCRIPTION
If a `RResultPtr<RInterface<RLoopManager, void>>` is passed to
`SaveGraph`, we used to switch to the graph-wide representation.
That's not intended, and it's most likely an oversight.

