### PR TITLE
[RF] Add missing overloads to WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -60,7 +60,13 @@ struct RunContext;
 #define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t)                                             \
   template<typename ...Args_t>                                                                    \
   Class_t(ROOT::Internal::TStringView name, ROOT::Internal::TStringView title, Args_t &&... args) \
-    : Class_t(std::string_view(name), std::string_view(title), std::forward<Args_t>(args)...) {}
+    : Class_t(std::string_view(name), std::string_view(title), std::forward<Args_t>(args)...) {}  \
+  template<typename ...Args_t>                                                                    \
+  Class_t(ROOT::Internal::TStringView name, std::string_view title, Args_t &&... args)            \
+    : Class_t(std::string_view(name), title, std::forward<Args_t>(args)...) {}                    \
+  template<typename ...Args_t>                                                                    \
+  Class_t(std::string_view name, ROOT::Internal::TStringView title, Args_t &&... args)            \
+    : Class_t(name, std::string_view(title), std::forward<Args_t>(args)...) {}
 #endif
 
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -2062,3 +2062,15 @@ void RooDataSet::convertToTreeStore()
    }
 }
 
+
+// Compile-time test if we can still use TStrings for the constructors of
+// RooDataClasses, either for both name and title or for only one of them.
+namespace {
+  TString tstr = "tstr";
+  const char * cstr = "cstr";
+  RooRealVar x{"x", "x", 1.0};
+  RooArgSet vars{x};
+  RooDataSet d1(tstr, tstr, vars, nullptr);
+  RooDataSet d2(tstr, cstr, vars, nullptr);
+  RooDataSet d3(cstr, tstr, vars, nullptr);
+}


### PR DESCRIPTION
So far, the WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR only covered the cases
where a TString was passed both for the name and for the title.

This commit adds the overloads necessary to deal with the cases where
one of the two strings is not a TString.

This PR is a fixup to https://github.com/root-project/root/pull/8614.