### PR TITLE
[DF] Provide a definition of ColumnNames_t in ROOT::RDF

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -350,8 +350,6 @@ std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, con
 
 std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, const ColumnNames_t &definedDSCols);
 
-using ROOT::Detail::RDF::ColumnNames_t;
-
 template <typename T>
 void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSource &ds, RBookedDefines &defines)
 {

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -60,7 +60,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
       std::conditional_t<std::is_same<ret_type, bool>::value, std::deque<ret_type>, std::vector<ret_type>>;
 
    F fExpression;
-   const ColumnNames_t fColumnNames;
+   const ROOT::RDF::ColumnNames_t fColumnNames;
    ValuesPerSlot_t fLastResults;
 
    /// Column readers per slot and per input column
@@ -101,7 +101,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    }
 
 public:
-   RDefine(std::string_view name, std::string_view type, F expression, const ColumnNames_t &columns,
+   RDefine(std::string_view name, std::string_view type, F expression, const ROOT::RDF::ColumnNames_t &columns,
            unsigned int nSlots, const RDFInternal::RBookedDefines &defines,
            const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds)
       : RDefineBase(name, type, nSlots, defines, DSValuePtrs, ds), fExpression(std::move(expression)),

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -55,7 +55,7 @@ class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
 
    FilterF fFilter;
-   const ColumnNames_t fColumnNames;
+   const ROOT::RDF::ColumnNames_t fColumnNames;
    const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
    PrevDataFrame &fPrevData;
    /// Column readers per slot and per input column
@@ -64,7 +64,7 @@ class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
 
 public:
-   RFilter(FilterF f, const ColumnNames_t &columns, std::shared_ptr<PrevDataFrame> pd,
+   RFilter(FilterF f, const ROOT::RDF::ColumnNames_t &columns, std::shared_ptr<PrevDataFrame> pd,
            const RDFInternal::RBookedDefines &defines, std::string_view name = "")
       : RFilterBase(pd->GetLoopManagerUnchecked(), name, pd->GetLoopManagerUnchecked()->GetNSlots(), defines),
         fFilter(std::move(f)), fColumnNames(columns), fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr),

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -93,7 +93,6 @@ using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
 template <typename Proxied, typename DataSource = void>
 class RInterface {
    using DS_t = DataSource;
-   using ColumnNames_t = RDFDetail::ColumnNames_t;
    using RFilterBase = RDFDetail::RFilterBase;
    using RRangeBase = RDFDetail::RRangeBase;
    using RLoopManager = RDFDetail::RLoopManager;

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -51,11 +51,11 @@ namespace RDFInternal = ROOT::Internal::RDF;
 class RFilterBase;
 class RRangeBase;
 using ROOT::RDF::RDataSource;
-using ColumnNames_t = std::vector<std::string>;
 
 /// The head node of a RDF computation graph.
 /// This class is responsible of running the event loop.
 class RLoopManager : public RNodeBase {
+   using ColumnNames_t = std::vector<std::string>;
    enum class ELoopType { kROOTFiles, kROOTFilesMT, kNoFiles, kNoFilesMT, kDataSource, kDataSourceMT };
    using Callback_t = std::function<void(unsigned int)>;
    class TCallback {

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -29,8 +29,13 @@
 class TTree;
 class TTreeReader;
 
-/// \cond HIDDEN_SYMBOLS
+
 namespace ROOT {
+namespace RDF {
+using ColumnNames_t = std::vector<std::string>;
+}
+
+/// \cond HIDDEN_SYMBOLS
 namespace Experimental {
 class RLogChannel;
 }
@@ -41,7 +46,8 @@ class RDataSource;
 
 namespace Detail {
 namespace RDF {
-using ColumnNames_t = std::vector<std::string>;
+
+using ROOT::RDF::ColumnNames_t;
 
 ROOT::Experimental::RLogChannel &RDFLogChannel();
 

--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -41,7 +41,7 @@ namespace TTraits = ROOT::TypeTraits;
 
 class RDataFrame : public ROOT::RDF::RInterface<RDFDetail::RLoopManager> {
 public:
-   using ColumnNames_t = RDFDetail::ColumnNames_t;
+   using ColumnNames_t = ROOT::RDF::ColumnNames_t;
    RDataFrame(std::string_view treeName, std::string_view filenameglob, const ColumnNames_t &defaultBranches = {});
    RDataFrame(std::string_view treename, const std::vector<std::string> &filenames,
               const ColumnNames_t &defaultBranches = {});

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -60,7 +60,7 @@ class RDataSource;
 } // namespace ROOT
 
 namespace {
-using ROOT::Detail::RDF::ColumnNames_t;
+using ROOT::RDF::ColumnNames_t;
 
 /// A string expression such as those passed to Filter and Define, digested to a standardized form
 struct ParsedExpression {

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -1111,7 +1111,7 @@ ROOT::RDF::SaveGraph(rd1);
 
 namespace ROOT {
 
-using ROOT::Detail::RDF::ColumnNames_t;
+using ROOT::RDF::ColumnNames_t;
 using ColumnNamesPtr_t = std::shared_ptr<const ColumnNames_t>;
 
 namespace RDFInternal = ROOT::Internal::RDF;


### PR DESCRIPTION
ColumnNames_t is very user-visible, it's not an implementation
detail, so let's move it from ROOT::Detail::RDF to ROOT::RDF.

These changes are also useful for documentation purposes: we now
have one definition that users can look up via Doxygen, and (fewer)
others in less public namespaces or at class scope.