### PR TITLE
[RF] Always mark RooAbsCache and child classes as transient

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -99,6 +99,10 @@ The `RooMinuit` class was the old interface between RooFit and minuit. With ROOT
 
 Before 6.26, it was possible to still use the `RooMinuit` by passing the `Minimizer("OldMinuit", "minimizer")` command argument to `RooAbsPdf::fitTo()`. This option is now removed.
 
+### Increase of the `RooAbsArg` class version
+
+The class version of `RooAbsArg` was incremented from 7 to 8 in this release. In some circumstances, this can cause warnings in `TStreamerInfo` for classes inheriting from `RooAbsArg` when reading older RooFit models from a file. These warnings are harmless and can be avoided by incrementing also the class version of the inheriting class.
+
 ## 2D Graphics Libraries
 
 - Implement the option `X+` and `Y+` for reverse axis on TGraph.

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -80,7 +80,7 @@ protected:
     RooArgList _highIntList ;
     // will want std::vector<RooRealVar*> for low and high also
   } ;
-  mutable RooObjCacheManager _normIntMgr ; // The integration cache manager
+  mutable RooObjCacheManager _normIntMgr ; //! The integration cache manager
 
   RooListProxy _dataVars;       // The RooRealVars
   RooListProxy _paramSet ;            // interpolation parameters
@@ -110,7 +110,7 @@ protected:
 private:
   static NumBins getNumBinsPerDim(RooArgSet const& vars);
 
-  ClassDefOverride(ParamHistFunc, 6)
+  ClassDefOverride(ParamHistFunc, 7)
 };
 
 #endif

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -83,7 +83,7 @@ protected:
     RooArgList _highIntList ;
     // will want std::vector<RooRealVar*> for low and high also
   } ;
-  mutable RooObjCacheManager _normIntMgr ; // The integration cache manager
+  mutable RooObjCacheManager _normIntMgr ; ///<! The integration cache manager
 
   RooRealProxy _nominal;           // The nominal value
   RooArgList   _ownedList ;       // List of owned components
@@ -98,7 +98,7 @@ protected:
   Double_t evaluate() const;
   RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
 
-  ClassDef(PiecewiseInterpolation,3) // Sum of RooAbsReal objects
+  ClassDef(PiecewiseInterpolation,4) // Sum of RooAbsReal objects
 };
 
 #endif

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -58,7 +58,8 @@ ClassImp(ParamHistFunc);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ParamHistFunc::ParamHistFunc() : _numBins(0)
+ParamHistFunc::ParamHistFunc()
+  : _normIntMgr(this), _numBins(0)
 {
   _dataSet.removeSelfFromDir(); // files must not delete _dataSet.
 }
@@ -79,6 +80,7 @@ ParamHistFunc::ParamHistFunc() : _numBins(0)
 ParamHistFunc::ParamHistFunc(const char* name, const char* title, 
 			     const RooArgList& vars, const RooArgList& paramSet) :
   RooAbsReal(name, title),
+  _normIntMgr(this),
   _dataVars("!dataVars","data Vars",       this),
   _paramSet("!paramSet","bin parameters",  this),
   _numBins(0),
@@ -123,6 +125,7 @@ ParamHistFunc::ParamHistFunc(const char* name, const char* title,
 			     const RooArgList& vars, const RooArgList& paramSet,
 			     const TH1* Hist ) :
   RooAbsReal(name, title),
+  _normIntMgr(this),
   //  _dataVar("!dataVar","data Var", this, (RooRealVar&) var),
   _dataVars("!dataVars","data Vars",       this),
   _paramSet("!paramSet","bin parameters",  this),
@@ -170,6 +173,7 @@ Int_t ParamHistFunc::GetNumBins( const RooArgSet& vars ) {
 
 ParamHistFunc::ParamHistFunc(const ParamHistFunc& other, const char* name) :
   RooAbsReal(other, name), 
+  _normIntMgr(other._normIntMgr, this),
   _dataVars("!dataVars", this, other._dataVars ),
   _paramSet("!paramSet", this, other._paramSet),
   _numBins( other._numBins ),

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -47,7 +47,7 @@ ClassImp(PiecewiseInterpolation);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-PiecewiseInterpolation::PiecewiseInterpolation()
+PiecewiseInterpolation::PiecewiseInterpolation() : _normIntMgr(this)
 {
   _positiveDefinite=false;
   TRACE_CREATE
@@ -73,6 +73,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
 					       const RooArgList& paramSet,
 					       Bool_t takeOwnership) :
   RooAbsReal(name, title),
+  _normIntMgr(this),
   _nominal("!nominal","nominal value", this, (RooAbsReal&)nominal),
   _lowSet("!lowSet","low-side variation",this),
   _highSet("!highSet","high-side variation",this),
@@ -142,6 +143,7 @@ PiecewiseInterpolation::PiecewiseInterpolation(const char* name, const char* tit
 
 PiecewiseInterpolation::PiecewiseInterpolation(const PiecewiseInterpolation& other, const char* name) :
   RooAbsReal(other, name), 
+  _normIntMgr(other._normIntMgr, this),
   _nominal("!nominal",this,other._nominal),
   _lowSet("!lowSet",this,other._lowSet),
   _highSet("!highSet",this,other._highSet),

--- a/roofit/roofit/inc/RooJeffreysPrior.h
+++ b/roofit/roofit/inc/RooJeffreysPrior.h
@@ -17,7 +17,7 @@ class RooArgList ;
 class RooJeffreysPrior : public RooAbsPdf {
 public:
 
-  RooJeffreysPrior() { };
+  RooJeffreysPrior() : _cacheMgr(this, 1, true, false) {}
   RooJeffreysPrior(const char *name, const char *title, RooAbsPdf& nominal, const RooArgList& paramSet, const RooArgList& obsSet) ;
   virtual ~RooJeffreysPrior() ;
 

--- a/roofit/roofit/inc/RooMomentMorphFuncND.h
+++ b/roofit/roofit/inc/RooMomentMorphFuncND.h
@@ -134,7 +134,7 @@ protected:
    friend class CacheElem;
    friend class Grid2;
 
-   mutable RooObjCacheManager _cacheMgr;
+   mutable RooObjCacheManager _cacheMgr; ///<! Transient cache manager
    mutable RooArgSet *_curNormSet;
 
    RooListProxy _parList;
@@ -155,7 +155,7 @@ protected:
 
    inline int sij(const int &i, const int &j) const { return (i * _obsList.getSize() + j); }
 
-   ClassDef(RooMomentMorphFuncND, 1)
+   ClassDef(RooMomentMorphFuncND, 2)
 };
 
 #endif

--- a/roofit/roofit/inc/RooMomentMorphND.h
+++ b/roofit/roofit/inc/RooMomentMorphND.h
@@ -121,7 +121,7 @@ protected:
    friend class CacheElem;
    friend class Grid;
 
-   mutable RooObjCacheManager _cacheMgr;
+   mutable RooObjCacheManager _cacheMgr; ///<! Transient cache manager
    mutable RooArgSet *_curNormSet;
 
    RooListProxy _parList;
@@ -142,7 +142,7 @@ protected:
 
    inline int sij(const int &i, const int &j) const { return (i * _obsList.getSize() + j); }
 
-   ClassDef(RooMomentMorphND, 1)
+   ClassDef(RooMomentMorphND, 2)
 };
 
 #endif

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -2329,7 +2329,8 @@ double RooLagrangianMorphFunc::getScale() { return this->_scale; }
 // default constructor
 
 RooLagrangianMorphFunc::RooLagrangianMorphFunc()
-    : _operators("operators", "set of operators", this, kTRUE, kFALSE),
+    : _cacheMgr(this, 10, true, true),
+      _operators("operators", "set of operators", this, kTRUE, kFALSE),
       _observables("observable", "morphing observable", this, kTRUE, kFALSE),
       _binWidths("binWidths", "set of bin width objects", this, kTRUE, kFALSE) {
   static int counter(0);

--- a/roofit/roofit/src/RooMomentMorph.cxx
+++ b/roofit/roofit/src/RooMomentMorph.cxx
@@ -34,7 +34,8 @@ ClassImp(RooMomentMorph);
 ////////////////////////////////////////////////////////////////////////////////
 /// coverity[UNINIT_CTOR]
 
-RooMomentMorph::RooMomentMorph() : _curNormSet(0), _mref(0), _M(0), _useHorizMorph(true)
+RooMomentMorph::RooMomentMorph()
+  : _cacheMgr(this,10,true,true), _curNormSet(0), _mref(0), _M(0), _useHorizMorph(true)
 {
   _varItr    = _varList.createIterator() ;
   _pdfItr    = _pdfList.createIterator() ;

--- a/roofit/roofit/src/RooMomentMorphFunc.cxx
+++ b/roofit/roofit/src/RooMomentMorphFunc.cxx
@@ -28,9 +28,9 @@ using namespace std;
 
 ClassImp(RooMomentMorphFunc)
 
-   //_____________________________________________________________________________
-   RooMomentMorphFunc::RooMomentMorphFunc()
-   : _curNormSet(0), _mref(0), _M(0), _useHorizMorph(true)
+//_____________________________________________________________________________
+RooMomentMorphFunc::RooMomentMorphFunc()
+   : _cacheMgr(this, 10, true, true), _curNormSet(0), _mref(0), _M(0), _useHorizMorph(true)
 {
    // coverity[UNINIT_CTOR]
    _varItr = _varList.createIterator();

--- a/roofit/roofit/src/RooMomentMorphFuncND.cxx
+++ b/roofit/roofit/src/RooMomentMorphFuncND.cxx
@@ -39,7 +39,7 @@ ClassImp(RooMomentMorphFuncND)
 
    //_____________________________________________________________________________
    RooMomentMorphFuncND::RooMomentMorphFuncND()
-   : _curNormSet(0), _M(0), _MSqr(0), _setting(RooMomentMorphFuncND::Linear), _useHorizMorph(true)
+   : _cacheMgr(this, 10, true, true), _curNormSet(0), _M(0), _MSqr(0), _setting(RooMomentMorphFuncND::Linear), _useHorizMorph(true)
 {
    _parItr = _parList.createIterator();
    _obsItr = _obsList.createIterator();

--- a/roofit/roofit/src/RooMomentMorphND.cxx
+++ b/roofit/roofit/src/RooMomentMorphND.cxx
@@ -33,9 +33,9 @@ using namespace std;
 
 ClassImp(RooMomentMorphND)
 
-   //_____________________________________________________________________________
-   RooMomentMorphND::RooMomentMorphND()
-   : _curNormSet(0), _M(0), _MSqr(0), _setting(RooMomentMorphND::Linear), _useHorizMorph(true)
+//_____________________________________________________________________________
+RooMomentMorphND::RooMomentMorphND()
+   : _cacheMgr(this, 10, true, true), _curNormSet(0), _M(0), _MSqr(0), _setting(RooMomentMorphND::Linear), _useHorizMorph(true)
 {
    _parItr = _parList.createIterator();
    _obsItr = _obsList.createIterator();

--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -115,11 +115,11 @@ protected:
     RooArgList _coefVarList ;
     RooArgList _normList ;
   } ;
-  mutable RooObjCacheManager _coefNormMgr ; // Coefficient normalization manager
+  mutable RooObjCacheManager _coefNormMgr ; //! Coefficient normalization manager
 
   mutable RooAICRegistry _codeReg ;   //! Registry of analytical integration codes
 
-  ClassDef(RooAbsAnaConvPdf,2) // Abstract Composite Convoluted PDF
+  ClassDef(RooAbsAnaConvPdf,3) // Abstract Composite Convoluted PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -611,7 +611,8 @@ private:
   RefCountList_t _clientListValue; // subset of clients that requested value dirty flag propagation
 
   RooRefArray _proxyList        ; // list of proxies
-  std::deque<RooAbsCache*> _cacheList ; // list of caches
+
+  std::vector<RooAbsCache*> _cacheList ; //! list of caches
 
 
   // Proxy management
@@ -707,7 +708,7 @@ private:
   static std::stack<RooAbsArg*> _ioReadStack ; // reading stack
   /// \endcond
 
-  ClassDef(RooAbsArg,7) // Abstract variable
+  ClassDef(RooAbsArg,8) // Abstract variable
 };
 
 std::ostream& operator<<(std::ostream& os, const RooAbsArg &arg);

--- a/roofit/roofitcore/inc/RooAbsCache.h
+++ b/roofit/roofitcore/inc/RooAbsCache.h
@@ -29,15 +29,32 @@ class RooAbsCache {
 public:
 
   RooAbsCache(RooAbsArg* owner=0) ;
+
   RooAbsCache(const RooAbsCache&, RooAbsArg* owner=0 ) ;
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) ;
-  virtual void operModeHook() ;
-  virtual void optimizeCacheMode(const RooArgSet&, RooArgSet&, RooLinkedList& ) ;
-  virtual void findConstantNodes(const RooArgSet&, RooArgSet& , RooLinkedList&) ;
-  virtual void printCompactTreeHook(std::ostream&, const char *) ;
-  virtual void wireCache() {} ;
-  
+
   virtual ~RooAbsCache() ;
+
+  void setOwner(RooAbsArg* owner);
+
+  /// Interface for server redirect calls.
+  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/,
+                                     bool /*mustReplaceAll*/,
+                                     bool /*nameChange*/,
+                                     bool /*isRecursive*/) { return false; }
+
+  /// Interface for operation mode changes.
+  virtual void operModeHook() {}
+
+  /// Interface for processing of cache mode optimization calls.
+  virtual void optimizeCacheMode(const RooArgSet&, RooArgSet&, RooLinkedList& ) {}
+
+  /// Interface for constant term node finding calls.
+  virtual void findConstantNodes(const RooArgSet&, RooArgSet& , RooLinkedList&) {}
+
+  /// Interface for printing of cache guts in tree mode printing.
+  virtual void printCompactTreeHook(std::ostream&, const char *) {}
+
+  virtual void wireCache() {}
    
 protected:
 

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -25,9 +25,8 @@ class RooChangeTracker ;
 class RooAbsCachedPdf : public RooAbsPdf {
 public:
 
-  RooAbsCachedPdf() {
-    // Default constructor
-  } ;
+  // Default constructor
+  RooAbsCachedPdf() : _cacheMgr(this,10) {}
   RooAbsCachedPdf(const char *name, const char *title, Int_t ipOrder=0);
   RooAbsCachedPdf(const RooAbsCachedPdf& other, const char* name=0) ;
   virtual ~RooAbsCachedPdf() ;
@@ -106,7 +105,7 @@ public:
   virtual RooAbsArg& pdfObservable(RooAbsArg& histObservable) const { return histObservable ; }
   virtual void fillCacheObject(PdfCacheElem& cache) const = 0 ;
 
-  mutable RooObjCacheManager _cacheMgr ; // The cache manager  
+  mutable RooObjCacheManager _cacheMgr ; //! The cache manager  
   Int_t _ipOrder ; // Interpolation order for cache histograms 
  
   TString cacheNameSuffix(const RooArgSet& nset) const ;
@@ -132,7 +131,7 @@ private:
 
   Bool_t _disableCache ; // Flag to run object in passthrough (= non-caching mode)
 
-  ClassDef(RooAbsCachedPdf,1) // Abstract base class for cached p.d.f.s
+  ClassDef(RooAbsCachedPdf,2) // Abstract base class for cached p.d.f.s
 };
  
 #endif

--- a/roofit/roofitcore/inc/RooAbsCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsCachedReal.h
@@ -24,7 +24,7 @@ class RooArgSet ;
 class RooAbsCachedReal : public RooAbsReal {
 public:
 
-  RooAbsCachedReal() {} ;
+  RooAbsCachedReal() : _cacheMgr(this,10) {}
   RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder=0);
   RooAbsCachedReal(const RooAbsCachedReal& other, const char* name=0) ;
   virtual ~RooAbsCachedReal() ;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -332,7 +332,7 @@ protected:
     virtual RooArgList containedArgs(Action) { return RooArgList(*_norm) ; }
     RooAbsReal* _norm ;
   } ;
-  mutable RooObjCacheManager _normMgr ; // The cache manager
+  mutable RooObjCacheManager _normMgr ; //! The cache manager
 
   friend class CacheElem ; // Cache needs to be able to clear _norm pointer
   
@@ -362,7 +362,7 @@ private:
   int calculateAsymptoticCorrectedCovMatrix(RooMinimizer& minimizer, RooAbsData const& data);
   int calculateSumW2CorrectedCovMatrix(RooMinimizer& minimizer, RooAbsReal const& nll) const;
   
-  ClassDef(RooAbsPdf,4) // Abstract PDF with normalization support
+  ClassDef(RooAbsPdf,5) // Abstract PDF with normalization support
 };
 
 

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -108,7 +108,7 @@ protected:
     virtual RooArgList containedArgs(Action) ;
 
   } ;
-  mutable RooObjCacheManager _projCacheMgr ;  // Manager of cache with coefficient projections and transformations
+  mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations
   CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=0, const char* rangeName=0) const ;
   void updateCoefficients(CacheElem& cache, const RooArgSet* nset) const ;
 
@@ -121,7 +121,7 @@ protected:
     virtual RooArgList containedArgs(Action) ;
   } ;
   
-  mutable RooObjCacheManager _intCacheMgr ; // Manager of cache with integrals
+  mutable RooObjCacheManager _intCacheMgr ; //! Manager of cache with integrals
  
   mutable RooAICRegistry _codeReg ;  //! Registry of component analytical integration codes
 
@@ -138,7 +138,7 @@ protected:
 
 private:
 
-  ClassDef(RooAddModel,1) // Resolution model representing a sum of resolution models
+  ClassDef(RooAddModel,2) // Resolution model representing a sum of resolution models
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -32,7 +32,7 @@
 class RooAddPdf : public RooAbsPdf {
 public:
 
-  RooAddPdf() { TRACE_CREATE }
+  RooAddPdf() : _projCacheMgr(this,10) { TRACE_CREATE }
   RooAddPdf(const char *name, const char *title=0);
   RooAddPdf(const char *name, const char *title,
             RooAbsPdf& pdf1, RooAbsPdf& pdf2, RooAbsReal& coef1) ;
@@ -117,7 +117,7 @@ protected:
     virtual RooArgList containedArgs(Action) ;
 
   } ;
-  mutable RooObjCacheManager _projCacheMgr ;  // Manager of cache with coefficient projections and transformations
+  mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations
   CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=0, const char* rangeName=0) const ;
   void updateCoefficients(CacheElem& cache, const RooArgSet* nset) const ;
 
@@ -150,7 +150,7 @@ private:
 
   void finalizeConstruction();
 
-  ClassDefOverride(RooAddPdf,3) // PDF representing a sum of PDFs
+  ClassDefOverride(RooAddPdf,4) // PDF representing a sum of PDFs
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -69,11 +69,11 @@ protected:
       RooArgList _I ;
       virtual RooArgList containedArgs(Action) ;
   };
-  mutable RooObjCacheManager _cacheMgr ; // The cache manager
+  mutable RooObjCacheManager _cacheMgr ; //! The cache manager
 
   Double_t evaluate() const;
 
-  ClassDef(RooAddition,2) // Sum of RooAbsReal objects
+  ClassDef(RooAddition,3) // Sum of RooAbsReal objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooEffProd.h
+++ b/roofit/roofitcore/inc/RooEffProd.h
@@ -20,7 +20,7 @@
 class RooEffProd: public RooAbsPdf {
 public:
   // Constructors, assignment etc
-  inline RooEffProd() : _nset(0), _fixedNset(0) { };
+  inline RooEffProd() : _cacheMgr(this,10), _nset(0), _fixedNset(0) { };
   virtual ~RooEffProd();
   RooEffProd(const char *name, const char *title, RooAbsPdf& pdf, RooAbsReal& efficiency);
   RooEffProd(const RooEffProd& other, const char* name=0);

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -152,7 +152,7 @@ private:
     void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) override ;
     void writeToStream(std::ostream& os) const ;
   } ;
-  mutable RooObjCacheManager _cacheMgr ; // The cache manager
+  mutable RooObjCacheManager _cacheMgr ; //! The cache manager
 
   CacheElem* getCacheElem(RooArgSet const* nset) const ;
   void rearrangeProduct(CacheElem&) const;
@@ -183,7 +183,7 @@ private:
   
 private:
 
-  ClassDef(RooProdPdf,4) // PDF representing a product of PDFs
+  ClassDef(RooProdPdf,5) // PDF representing a product of PDFs
 };
 
 

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -72,7 +72,7 @@ protected:
       RooArgList _ownedList ;
       virtual RooArgList containedArgs(Action) ;
   };
-  mutable RooObjCacheManager _cacheMgr ; // The cache manager
+  mutable RooObjCacheManager _cacheMgr ; //! The cache manager
                                                                                                                                                              
 
   Double_t calculate(const RooArgList& partIntList) const;
@@ -86,7 +86,7 @@ protected:
 
 
 
-  ClassDef(RooProduct,2) // Product of RooAbsReal and/or RooAbsCategory terms
+  ClassDef(RooProduct,3) // Product of RooAbsReal and/or RooAbsCategory terms
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -71,7 +71,7 @@ protected:
       RooArgList _funcIntList;
       RooArgList _funcNormList;
    };
-   mutable RooObjCacheManager _normIntMgr; // The integration cache manager
+   mutable RooObjCacheManager _normIntMgr; //! The integration cache manager
 
    Bool_t _haveLastCoef;
 
@@ -84,7 +84,7 @@ protected:
    static Bool_t _doFloorGlobal; // Global flag for introducing floor at zero in pdf
 
 private:
-   ClassDef(RooRealSumFunc, 3) // PDF constructed from a sum of (non-pdf) functions
+   ClassDef(RooRealSumFunc, 4) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -77,7 +77,7 @@ protected:
     RooArgList _funcIntList ;
     RooArgList _funcNormList ;
   } ;
-  mutable RooObjCacheManager _normIntMgr ; // The integration cache manager
+  mutable RooObjCacheManager _normIntMgr ; //! The integration cache manager
 
 
   RooListProxy _funcList ;   //  List of component FUNCs
@@ -94,7 +94,7 @@ private:
     return _funcList.size() == _coefList.size();
   }
 
-  ClassDef(RooRealSumPdf, 4) // PDF constructed from a sum of (non-pdf) functions
+  ClassDef(RooRealSumPdf, 5) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -164,7 +164,7 @@ public:
   
   std::shared_ptr<RooRealVarSharedProperties> _sharedProp; //! Shared binnings associated with this instance
 
-  ClassDef(RooRealVar,7) // Real-valued variable
+  ClassDef(RooRealVar,8) // Real-valued variable
 };
 
 

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -38,7 +38,7 @@ class RooSimultaneous : public RooAbsPdf {
 public:
 
   // Constructors, assignment etc
-  inline RooSimultaneous() : _plotCoefNormRange(0) { }
+  inline RooSimultaneous() : _plotCoefNormRange(0), _partIntMgr(this,10) {}
   RooSimultaneous(const char *name, const char *title, RooAbsCategoryLValue& indexCat) ;
   RooSimultaneous(const char *name, const char *title, std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;
   RooSimultaneous(const char *name, const char *title, const RooArgList& pdfList, RooAbsCategoryLValue& indexCat) ;
@@ -99,7 +99,7 @@ protected:
     RooArgList containedArgs(Action) { return RooArgList(_partIntList) ; }
     RooArgList _partIntList ;
   } ;
-  mutable RooObjCacheManager _partIntMgr ; // Component normalization manager
+  mutable RooObjCacheManager _partIntMgr ; //! Component normalization manager
 
 
   friend class RooSimGenContext ;
@@ -113,7 +113,7 @@ protected:
   TList    _pdfProxyList ;     // List of PDF proxies (named after applicable category state)
   Int_t    _numPdf ;           // Number of registered PDFs
 
-  ClassDef(RooSimultaneous,2)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
+  ClassDef(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -83,7 +83,8 @@ ClassImp(RooAbsAnaConvPdf);
 /// Default constructor, required for persistence
 
 RooAbsAnaConvPdf::RooAbsAnaConvPdf() :
-  _isCopy(kFALSE)
+  _isCopy(false),
+  _coefNormMgr(this,10)
 {
 }
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2310,12 +2310,9 @@ void RooAbsArg::wireAllCaches()
 {
   RooArgSet branches ;
   branchNodeServerList(&branches) ;
-  RooFIter iter = branches.fwdIterator() ;
-  RooAbsArg* arg ;
-  while((arg=iter.next())) {
-//     cout << "wiring caches on node " << arg->GetName() << endl ;
-    for (deque<RooAbsCache*>::iterator iter2 = arg->_cacheList.begin() ; iter2 != arg->_cacheList.end() ; ++iter2) {
-      (*iter2)->wireCache() ;
+  for(auto const& arg : branches) {
+    for (auto const& arg2 : arg->_cacheList) {
+      arg2->wireCache() ;
     }
   }
 }

--- a/roofit/roofitcore/src/RooAbsCache.cxx
+++ b/roofit/roofitcore/src/RooAbsCache.cxx
@@ -39,7 +39,7 @@ ClassImp(RooAbsCache);
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor. Takes owner as argument and register cache with owner
+/// Constructor. Takes owner as argument and register cache with owner.
 
 RooAbsCache::RooAbsCache(RooAbsArg* owner) : _owner(owner) 
 { 
@@ -49,9 +49,8 @@ RooAbsCache::RooAbsCache(RooAbsArg* owner) : _owner(owner)
 } 
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor. Takes owner as argument and registers cache with owne
+/// Copy constructor. Takes owner as argument and registers cache with owne.
 
 RooAbsCache::RooAbsCache(const RooAbsCache&, RooAbsArg* owner ) : _owner(owner) 
 { 
@@ -61,9 +60,8 @@ RooAbsCache::RooAbsCache(const RooAbsCache&, RooAbsArg* owner ) : _owner(owner)
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Destructor. Unregisters cache with owner
+/// Destructor. Unregisters cache with owner.
 
 RooAbsCache::~RooAbsCache() 
 { 
@@ -73,48 +71,15 @@ RooAbsCache::~RooAbsCache()
 }
 
 
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Interface for processing of cache mode optimization calls
-
-void RooAbsCache::optimizeCacheMode(const RooArgSet& /*obs*/, RooArgSet&, RooLinkedList& ) 
+/// Reset the owner, triggering the owner to register this cache in its list of caches.
+void RooAbsCache::setOwner(RooAbsArg * owner)
 {
+  if (_owner) {
+    _owner->unRegisterCache(*this) ; 
+  }
+  _owner = owner;
+  if (_owner) {
+    owner->registerCache(*this) ; 
+  }
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface for server redirect calls
-
-Bool_t RooAbsCache::redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) 
-{ 
-  return kFALSE ; 
-} 
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface for operation mode changes
-
-void RooAbsCache::operModeHook() 
-{
-} 
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface for constant term node finding calls
-
-void RooAbsCache::findConstantNodes(const RooArgSet&, RooArgSet&, RooLinkedList& ) 
-{  
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Interface for printing of cache guts in tree mode printing
-
-void RooAbsCache::printCompactTreeHook(std::ostream&, const char *)
-{
-}
-

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -203,7 +203,7 @@ TString RooAbsPdf::_normRangeOverride;
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-RooAbsPdf::RooAbsPdf() : _norm(0), _normSet(0), _specGeneratorConfig(0)
+RooAbsPdf::RooAbsPdf() : _norm(0), _normSet(0), _normMgr(this,10), _specGeneratorConfig(0)
 {
   _errorCount = 0 ;
   _negCount = 0 ;

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -66,6 +66,8 @@ RooAddModel::RooAddModel() :
   _refCoefNorm("!refCoefNorm","Reference coefficient normalization set",this,kFALSE,kFALSE),
   _refCoefRangeName(0),
   _projectCoefs(false),
+  _projCacheMgr(this,10),
+  _intCacheMgr(this,10),
   _codeReg(10),
   _snormList(0),
   _haveLastCoef(false),

--- a/roofit/roofitcore/src/RooAddition.cxx
+++ b/roofit/roofitcore/src/RooAddition.cxx
@@ -49,7 +49,7 @@ ClassImp(RooAddition);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Empty constructor
-RooAddition::RooAddition()
+RooAddition::RooAddition() : _cacheMgr(this,10)
 {
 }
 

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -37,10 +37,10 @@
 
 class RooMappedCategoryCache : public RooAbsCache {
   public:
-    RooMappedCategoryCache(RooAbsArg* owner = 0) : RooAbsCache(owner)
+    RooMappedCategoryCache(RooAbsArg* owner) : RooAbsCache(owner)
   { initialise(); }
-    RooMappedCategoryCache(const RooAbsCache& other, RooAbsArg* owner = 0) :
-      RooAbsCache(other, owner)
+    RooMappedCategoryCache(const RooAbsCache& /*other*/, RooAbsArg* owner) :
+      RooAbsCache(owner)
     { initialise(); }
 
     // look up our parent's output based on our parent's input category index

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -79,6 +79,7 @@ ClassImp(RooProdPdf);
 /// Default constructor
 
 RooProdPdf::RooProdPdf() :
+  _cacheMgr(this,10),
   _cutOff(0),
   _extendedIndex(-1),
   _useDefaultGen(kFALSE),

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -54,7 +54,7 @@ namespace {
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-RooProduct::RooProduct()
+RooProduct::RooProduct() : _cacheMgr(this,10)
 {
   TRACE_CREATE
 }

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -45,7 +45,7 @@ using namespace std;
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-RooProjectedPdf::RooProjectedPdf()
+RooProjectedPdf::RooProjectedPdf() : _cacheMgr(this,10)
 {
 }
 

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -60,7 +60,7 @@ ClassImp(RooRealSumFunc);
 Bool_t RooRealSumFunc::_doFloorGlobal = kFALSE;
 
 //_____________________________________________________________________________
-RooRealSumFunc::RooRealSumFunc()
+RooRealSumFunc::RooRealSumFunc() : _normIntMgr(this, 10)
 {
    // Default constructor
    // coverity[UNINIT_CTOR]

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -69,7 +69,7 @@ Bool_t RooRealSumPdf::_doFloorGlobal = kFALSE ;
 /// Default constructor
 /// coverity[UNINIT_CTOR]
 
-RooRealSumPdf::RooRealSumPdf() 
+RooRealSumPdf::RooRealSumPdf() : _normIntMgr(this,10)
 {
   _extended = kFALSE ;
   _doFloor = kFALSE ;


### PR DESCRIPTION
The commit consistently marks the `RooAbsCache` class and the derived
`RooCacheManager` and `RooObjCacheManager` classes as transient
whereever they are used in RooFit, effectively excluding them from I/O.

This change was made primarily to fix a bug happening when models are
read back from a ROOT file (the pointes in `RooAbsArg::_cacheList` were
not correct anymore), but it also has the nice effect of reducing the
size of RooFit models.

The classes were almost de-facto removed from I/O already, because
almost all of their data members were excluded from I/O anyway. The only
exceptions are the following data members:

  * `RooObjCacheManager::_clearOnRedirect`

  * `RooObjCacheManager::_allowOptimize`

  * `RooAbsCache::_owner`

All of these values are set in the respective constructors and are never
changed. To make these values consistent even if a class that uses a
cache is read back from a ROOT file, the correct constructor for the
cache is now also called in the default I/O constructors of the classes.

A simple reproducer to see problem with `RooAbsArg::_cacheList` after reading back the model:

```C++
#define private public

#include "RooWorkspace.h"
#include "RooGaussian.h"

#include "TFile.h"

void reproducer() {

{
    RooWorkspace w("w","w");
    w.factory("RooGaussian::gaus(x[0,-10,10],mean[0,-10,10],sigma[1,0.1,10.0])");
    w.writeToFile("file.root");

    auto gaus = w.pdf("gaus");
    std::cout << &gaus->_normMgr << std::endl;
    std::cout << gaus->getCache(0) << std::endl;
    std::cout << gaus->numCaches() << std::endl;

    gaus->IsA()->GetListOfDataMembers()->Print();
}

{
    TFile f1("file.root");
    auto w =f1.Get<RooWorkspace>("w");

    auto gaus = w->pdf("gaus");
    std::cout << &gaus->_normMgr << std::endl;
    std::cout << gaus->getCache(0) << std::endl;
    std::cout << gaus->numCaches() << std::endl;

    delete w;
}

}
```

Here the nice report from @will-cern (thanks!!) that motivated this PR to give some more context:

>  have been recently working on a workflow that involved repeatedly writing and reading workspaces, and I wanted to understand why this was leaking a lot of memory. This is in 6.22/08 but I think the problems persist in master. Thankfully the biggest leak is easy to fix and I'll make a PR for that soon (workspace not cleaning up all its RooLinkedLists).  But the next biggest one has taken me a while to understand....
<br>Valgrind reported lots of leaking of RooObjCacheManager instances. I believe a way to evidence this is with a minimal reproducer (see above).
<br>If you track how many times a RooObjCacheManager is constructed with these lines, the first line constructs one of them (the `_normMgr` of the RooAbsPdf class). But when the file is read back in on the second line, I see two RooObjCacheManagers get constructed. The first one comes from the constructor of the RooAbsPdf (via the gaussian), but the second comes from streaming of the RooAbsArg base class which contains a `std::deque<RooAbsCache*> _cacheList`. 
<br>So what I'm seeing is that in the first line where the pdf is first created, the `_normMgr` (which is declared as `RooObjCacheManager _normMgr` in `RooAbsPdf`) is the same as the one in the `_cacheList`. But when you read back the pdf in the second line, the `_normMgr` no longer is the same as the one in the `_cacheList` -- both caches (the one in the `_cacheList` and the `_normMgr`) have the gaus as its owner, but they are distinct objects and when the gaus is deleted I assume the one in the `_cacheList` doesnt get destroyed, causing the leak. 
<br>If my diagnosis is correct, then I dunno what would be the correct way to fix this, the best way I can think of so far would be making `RooObjCacheManager` always be a pointer rather than an instance data member. Do others have thoughts?
<br>Worth acknowledging the problem probably isn't just a memory leak when we have an inconsistency between the list of caches in the `RooAbsArg` base class vs the actual caches the derived classes might be interacting with directly, but i havent studied that.
