### PR TITLE
[cmake] Fix building ROOT with external llvm.

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -238,7 +238,7 @@ if(builtin_llvm)
 else()
   # Rely on llvm-config.
   set(CONFIG_OUTPUT)
-  find_program(LLVM_CONFIG NAMES "llvm-config" "llvm-config-9.0")
+  find_program(LLVM_CONFIG NAMES "llvm-config" "llvm-config-9")
   if(LLVM_CONFIG)
     message(STATUS "Found LLVM_CONFIG as ${LLVM_CONFIG}")
     set(CONFIG_COMMAND ${LLVM_CONFIG}
@@ -249,7 +249,8 @@ else()
       "--prefix"
       "--src-root"
       "--cmakedir"
-      "--build-mode")
+      "--build-mode"
+      "--version")
     execute_process(
       COMMAND ${CONFIG_COMMAND}
       RESULT_VARIABLE HAD_ERROR
@@ -276,6 +277,9 @@ else()
   list(GET CONFIG_OUTPUT 5 MAIN_SRC_DIR)
   list(GET CONFIG_OUTPUT 6 LLVM_CONFIG_CMAKE_PATH)
   list(GET CONFIG_OUTPUT 7 LLVM_BUILD_MODE)
+  list(GET CONFIG_OUTPUT 8 LLVM_VERSION_S)
+
+  set(LLVM_VERSION_SAVE "${LLVM_VERSION_S}")
 
   message(STATUS "External llvm built in ${LLVM_BUILD_MODE} mode.")
 
@@ -425,10 +429,18 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
   # We cannot include LLVMConfig.cmake here. We reply on builtin clang to discover the available
   # llvm version and set it in clang version.
   # FIXME: This is a very ugly workaround. Is there a better way to do this?
-  set(LLVM_VERSION ${CLANG_VERSION} PARENT_SCOPE)
+  if ($CLANG_VERSION)
+    set(LLVM_VERSION ${CLANG_VERSION} PARENT_SCOPE)
+  else()
+    set(LLVM_VERSION ${LLVM_VERSION_SAVE} PARENT_SCOPE)
+  endif()
 
   # We are in the case of NOT builtin_llvm
   if (builtin_clang)
+    # remove clang-cpp from CLANG_LINKS_TO_CREATE to avoid clashes with
+    # install-clang-cpp target defined by LLVM's cmake module
+    set(CLANG_LINKS_TO_CREATE clang++ clang-cl)
+
     add_subdirectory(llvm/src/tools/clang EXCLUDE_FROM_ALL)
   endif(builtin_clang)
 
@@ -437,8 +449,13 @@ Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
 endif(builtin_llvm)
 
 if (builtin_clang)
-  # For builtin LLVM this is set in interpreter/llvm/src/CMakeLists.txt
-  set(Clang_DIR "${LLVM_BINARY_DIR}/tools/clang/")
+  if (builtin_llvm)
+    # For builtin LLVM this is set in interpreter/llvm/src/CMakeLists.txt
+    set(Clang_DIR "${LLVM_BINARY_DIR}/tools/clang/")
+  else()
+    set(Clang_DIR "${CMAKE_BINARY_DIR}/interpreter/llvm/src/tools/clang/")
+    set(Clang_Config_ExtraPathHints "${Clang_DIR}cmake/modules/CMakeFiles")
+  endif()
   set(CLANG_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/interpreter/llvm/src/tools/clang/include
     ${CMAKE_BINARY_DIR}/interpreter/llvm/src/tools/clang/include
@@ -457,9 +474,11 @@ if (builtin_cling)
   # LLVM doesn't really give us a API to get this with an in-source build
   # so we just use the normal way of doing this and read the llvm directory
   # compilation properties.
-  get_directory_property(LLVM_DEFS DIRECTORY llvm/src COMPILE_DEFINITIONS)
-  # Turns DEFINE1;DEFINE2 to -DDEFINE1 -DDEFINE2
-  string (REPLACE ";" " -D" LLVM_DEFS ";${LLVM_DEFS}")
+  if (builtin_llvm)
+    get_directory_property(LLVM_DEFS DIRECTORY llvm/src COMPILE_DEFINITIONS)
+    # Turns DEFINE1;DEFINE2 to -DDEFINE1 -DDEFINE2
+    string (REPLACE ";" " -D" LLVM_DEFS ";${LLVM_DEFS}")
+  endif()
 
   # FIXME: Reduce the usage of CLING_CXXFLAGS by adding a cmake routine in
   # RootMacros.cmake for all cling-dependent libraries

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -344,3 +344,29 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
 
 add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
                       ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+
+# If LLVM is external, but Clang is builtin, we must use some files
+# from patched (builtin) version of LLVM
+if ((NOT builtin_llvm) AND builtin_clang)
+  set(FixInclude "${CMAKE_SOURCE_DIR}/interpreter/llvm/src/include")
+
+  get_property(P SOURCE IncrementalJIT.cpp PROPERTY INCLUDE_DIRECTORIES)
+  list(INSERT P 0 ${FixInclude})
+  set_property(SOURCE IncrementalJIT.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
+
+  get_property(P SOURCE IncrementalExecutor.cpp PROPERTY INCLUDE_DIRECTORIES)
+  list(INSERT P 0 ${FixInclude})
+  set_property(SOURCE IncrementalExecutor.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
+
+  get_property(P SOURCE Interpreter.cpp PROPERTY INCLUDE_DIRECTORIES)
+  list(INSERT P 0 ${FixInclude})
+  set_property(SOURCE Interpreter.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
+
+  get_property(P SOURCE Transaction.cpp PROPERTY INCLUDE_DIRECTORIES)
+  list(INSERT P 0 ${FixInclude})
+  set_property(SOURCE Transaction.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
+
+  get_property(P SOURCE TransactionUnloader.cpp PROPERTY INCLUDE_DIRECTORIES)
+  list(INSERT P 0 ${FixInclude})
+  set_property(SOURCE TransactionUnloader.cpp PROPERTY INCLUDE_DIRECTORIES "${P}")
+endif()

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -40,7 +40,7 @@ if (CMAKE_CXX_STANDARD)
 endif(CMAKE_CXX_STANDARD)
 
 if (Clang_DIR)
-  list(APPEND _clad_extra_cmake_args -DClang_DIR=${Clang_DIR})
+  list(APPEND _clad_extra_cmake_args -DClang_DIR=${Clang_DIR} -DClang_CONFIG_EXTRA_PATH_HINTS=${Clang_Config_ExtraPathHints})
 endif(Clang_DIR)
 
 if (LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN)

--- a/interpreter/llvm/src/tools/clang/lib/Basic/CMakeLists.txt
+++ b/interpreter/llvm/src/tools/clang/lib/Basic/CMakeLists.txt
@@ -99,3 +99,13 @@ add_clang_library(clangBasic
   ${version_inc}
   )
 
+# Some versions of Debian/Ubuntu have a buggy LLVM/Clang package.
+# We workaround this case by defining a preprocessor symbol.
+if (NOT builtin_llvm)
+  file(READ ${LLVM_DIR}/include/llvm/ADT/Triple.h TMPTXT)
+  string(FIND "${TMPTXT}" "KFreeBSD" matchres)
+  if(${matchres} EQUAL -1)
+    set_property(SOURCE Targets.cpp APPEND PROPERTY
+                 COMPILE_DEFINITIONS "KFreeBSD=kFreeBSD")
+  endif ()
+endif()


### PR DESCRIPTION
Fixes #8141.

This PR requires a new clad release v0.9. The clad master is incompatible with ROOT atm and the release of 0.9 depends on  #8371