### PR TITLE
[RF] Fix rf408_RDataFrameToRooFit.py crash by adding missing std::move

### DIFF
--- a/tutorials/roofit/rf408_RDataFrameToRooFit.py
+++ b/tutorials/roofit/rf408_RDataFrameToRooFit.py
@@ -45,7 +45,7 @@ y.setBins(20)
 # - the column names that RDataFrame should fill into the dataset
 #
 # NOTE: RDataFrame columns are matched to RooFit variables by position, *not by name*!
-rooDataSet = dd.Book(ROOT.RooDataSetHelper("dataset", "Title of dataset", ROOT.RooArgSet(x, y)), ("x", "y"))
+rooDataSet = dd.Book(ROOT.std.move(ROOT.RooDataSetHelper("dataset", "Title of dataset", ROOT.RooArgSet(x, y))), ("x", "y"))
 
 
 # Method 2:


### PR DESCRIPTION
This hotfixes the crashes seen in the recent PR builds.

However, having to use `std::move` in pyROOT is quite unpythonic and we
should think about an improved interface for creating RooFit datasets
from RDataFrame in the future.