### PR TITLE
[ntuple] Add RRVecField for type-erased I/O of RVecs

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -401,9 +401,15 @@ public:
 
 /// The type-erased field for a RVec<Type>
 class RRVecField : public Detail::RFieldBase {
+private:
+   /// Evaluate the constant returned by GetValueSize.
+   // (we separate evaluation from the getter to avoid repeating the computation).
+   std::size_t EvalValueSize() const;
+
 protected:
    std::size_t fItemSize;
    ClusterSize_t fNWritten;
+   std::size_t fValueSize;
 
    std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const override;
    std::size_t AppendImpl(const Detail::RFieldValue &value) override;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -399,6 +399,45 @@ public:
    }
 };
 
+/// The type-erased field for a RVec<Type>
+class RRVecField : public Detail::RFieldBase {
+private:
+   std::size_t fItemSize;
+   ClusterSize_t fNWritten;
+
+protected:
+   std::unique_ptr<Detail::RFieldBase> CloneImpl(std::string_view newName) const final;
+   std::size_t AppendImpl(const Detail::RFieldValue &value) final;
+   void ReadGlobalImpl(NTupleSize_t globalIndex, Detail::RFieldValue *value) final;
+
+public:
+   RRVecField(std::string_view fieldName, std::unique_ptr<Detail::RFieldBase> itemField);
+   RRVecField(RRVecField &&) = default;
+   RRVecField &operator=(RRVecField &&) = default;
+   RRVecField(const RRVecField &) = delete;
+   RRVecField &operator=(RRVecField &) = delete;
+   ~RRVecField() = default;
+
+   void GenerateColumnsImpl() final;
+   void GenerateColumnsImpl(const RNTupleDescriptor &desc) final;
+   using Detail::RFieldBase::GenerateValue;
+   Detail::RFieldValue GenerateValue(void *where) final;
+   void DestroyValue(const Detail::RFieldValue &value, bool dtorOnly = false) final;
+   Detail::RFieldValue CaptureValue(void *where) final;
+   std::vector<Detail::RFieldValue> SplitValue(const Detail::RFieldValue &value) const final;
+   size_t GetValueSize() const final;
+   size_t GetAlignment() const final;
+   void CommitCluster() final;
+   void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
+   void GetCollectionInfo(NTupleSize_t globalIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   {
+      fPrincipalColumn->GetCollectionInfo(globalIndex, collectionStart, size);
+   }
+   void GetCollectionInfo(const RClusterIndex &clusterIndex, RClusterIndex *collectionStart, ClusterSize_t *size) const
+   {
+      fPrincipalColumn->GetCollectionInfo(clusterIndex, collectionStart, size);
+   }
+};
 
 /// The generic field for fixed size arrays, which do not need an offset column
 class RArrayField : public Detail::RFieldBase {

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -64,6 +64,7 @@ public:
    virtual void VisitUInt8Field(const RField<std::uint8_t> &field) { VisitField(field); }
    virtual void VisitVectorField(const RVectorField &field) { VisitField(field); }
    virtual void VisitVectorBoolField(const RField<std::vector<bool>> &field) { VisitField(field); }
+   virtual void VisitRVecField(const RRVecField &field) { VisitField(field); }
 }; // class RFieldVisitor
 
 } // namespace Detail

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -211,6 +211,7 @@ public:
    void VisitRecordField(const RRecordField &field) final;
    void VisitVectorField(const RVectorField &field) final;
    void VisitVectorBoolField(const RField<std::vector<bool>> &field) final;
+   void VisitRVecField(const RRVecField &field) final;
 };
 
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1148,10 +1148,9 @@ std::size_t ROOT::Experimental::RRVecField::AppendImpl(const Detail::RFieldValue
    auto [beginPtr, sizePtr, _] = GetRVecDataMembers(value.GetRawPtr());
 
    std::size_t nbytes = 0;
-   char *begin = reinterpret_cast<char*>(*beginPtr); // for pointer arithmetics
+   char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
    for (std::int32_t i = 0; i < *sizePtr; ++i) {
-      auto elementValue =
-         fSubFields[0]->CaptureValue(begin + i * fItemSize);
+      auto elementValue = fSubFields[0]->CaptureValue(begin + i * fItemSize);
       nbytes += fSubFields[0]->Append(elementValue);
    }
 
@@ -1186,7 +1185,7 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
    }
 
    // Create new elements
-   char *begin = reinterpret_cast<char*>(*beginPtr); // for pointer arithmetics
+   char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
    for (auto i = 0u; i < nItems; ++i) {
       // GenerateValue uses a placement new which starts the objects' lifetime
       auto itemValue = fSubFields[0]->GenerateValue(begin + (i * fItemSize));
@@ -1198,8 +1197,8 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl()
 {
    RColumnModel modelIndex(EColumnType::kIndex, true /* isSorted*/);
-   fColumns.emplace_back(std::unique_ptr<Detail::RColumn>(
-      Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
+   fColumns.emplace_back(
+      std::unique_ptr<Detail::RColumn>(Detail::RColumn::Create<ClusterSize_t, EColumnType::kIndex>(modelIndex, 0)));
 }
 
 void ROOT::Experimental::RRVecField::GenerateColumnsImpl(const RNTupleDescriptor &desc)
@@ -1208,22 +1207,22 @@ void ROOT::Experimental::RRVecField::GenerateColumnsImpl(const RNTupleDescriptor
    GenerateColumnsImpl();
 }
 
-ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RRVecField::GenerateValue(void* where)
+ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RRVecField::GenerateValue(void *where)
 {
    // initialize data members fBegin, fSize, fCapacity
    // currently the inline buffer is left uninitialized
-   void **beginPtr = new (where) (void *)(nullptr);
-   std::int32_t* sizePtr = new (reinterpret_cast<void*>(beginPtr + 1)) std::int32_t(0);
+   void **beginPtr = new (where)(void *)(nullptr);
+   std::int32_t *sizePtr = new (reinterpret_cast<void *>(beginPtr + 1)) std::int32_t(0);
    new (sizePtr + 1) std::int32_t(0);
 
-   return Detail::RFieldValue(/*captureTag*/true, this, where);
+   return Detail::RFieldValue(/*captureTag*/ true, this, where);
 }
 
-void ROOT::Experimental::RRVecField::DestroyValue(const Detail::RFieldValue& value, bool dtorOnly)
+void ROOT::Experimental::RRVecField::DestroyValue(const Detail::RFieldValue &value, bool dtorOnly)
 {
    auto [beginPtr, sizePtr, capacityPtr] = GetRVecDataMembers(value.GetRawPtr());
 
-   char *begin = reinterpret_cast<char*>(*beginPtr); // for pointer arithmetics
+   char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
    for (std::int32_t i = 0; i < *sizePtr; ++i) {
       auto elementValue = fSubFields[0]->CaptureValue(begin + i * fItemSize);
       fSubFields[0]->DestroyValue(elementValue, true /* dtorOnly */);
@@ -1236,7 +1235,7 @@ void ROOT::Experimental::RRVecField::DestroyValue(const Detail::RFieldValue& val
    auto paddingMiddle = dataMemberSz % alignOfT;
    if (paddingMiddle != 0)
       paddingMiddle = alignOfT - paddingMiddle;
-   const bool isSmall = (reinterpret_cast<void*>(begin) == (beginPtr + dataMemberSz + paddingMiddle));
+   const bool isSmall = (reinterpret_cast<void *>(begin) == (beginPtr + dataMemberSz + paddingMiddle));
 
    const bool owns = (*capacityPtr != -1);
    if (!isSmall && owns)
@@ -1246,7 +1245,7 @@ void ROOT::Experimental::RRVecField::DestroyValue(const Detail::RFieldValue& val
       free(beginPtr);
 }
 
-ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RRVecField::CaptureValue(void* where)
+ROOT::Experimental::Detail::RFieldValue ROOT::Experimental::RRVecField::CaptureValue(void *where)
 {
    return Detail::RFieldValue(true /* captureFlag */, this, where);
 }
@@ -1257,7 +1256,7 @@ ROOT::Experimental::RRVecField::SplitValue(const Detail::RFieldValue &value) con
    auto [beginPtr, sizePtr, _] = GetRVecDataMembers(value.GetRawPtr());
 
    std::vector<Detail::RFieldValue> result;
-   char *begin = reinterpret_cast<char*>(*beginPtr); // for pointer arithmetics
+   char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
    for (std::int32_t i = 0; i < *sizePtr; ++i) {
       auto elementValue = fSubFields[0]->CaptureValue(begin + i * fItemSize);
       result.emplace_back(std::move(elementValue));
@@ -1313,7 +1312,8 @@ size_t ROOT::Experimental::RRVecField::EvalValueSize() const
    return dataMemberSz + inlineStorageSz + paddingMiddle + paddingEnd;
 }
 
-size_t ROOT::Experimental::RRVecField::GetValueSize() const {
+size_t ROOT::Experimental::RRVecField::GetValueSize() const
+{
    return fValueSize;
 }
 
@@ -1323,7 +1323,6 @@ size_t ROOT::Experimental::RRVecField::GetAlignment() const
    // (including the inline buffer which has the same alignment as the RVec::value_type)
    return std::max({alignof(void *), alignof(std::int32_t), fSubFields[0]->GetAlignment()});
 }
-
 
 void ROOT::Experimental::RRVecField::CommitCluster()
 {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1119,6 +1119,7 @@ ROOT::Experimental::RRVecField::RRVecField(std::string_view fieldName, std::uniq
      fItemSize(itemField->GetValueSize()), fNWritten(0)
 {
    Attach(std::move(itemField));
+   fValueSize = EvalValueSize(); // requires fSubFields to be populated
 }
 
 std::unique_ptr<ROOT::Experimental::Detail::RFieldBase>
@@ -1278,7 +1279,7 @@ ROOT::Experimental::RRVecField::SplitValue(const Detail::RFieldValue &value) con
    return result;
 }
 
-size_t ROOT::Experimental::RRVecField::GetValueSize() const
+size_t ROOT::Experimental::RRVecField::EvalValueSize() const
 {
    // the size of an RVec<T> is the size of its 4 data-members + optional padding:
    //
@@ -1324,6 +1325,10 @@ size_t ROOT::Experimental::RRVecField::GetValueSize() const
       paddingEnd = alignOfRVecT - paddingEnd;
 
    return dataMemberSz + inlineStorageSz + paddingMiddle + paddingEnd;
+}
+
+size_t ROOT::Experimental::RRVecField::GetValueSize() const {
+   return fValueSize;
 }
 
 size_t ROOT::Experimental::RRVecField::GetAlignment() const

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -190,8 +190,6 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       std::string itemTypeName = normalizedType.substr(12, normalizedType.length() - 13);
       auto itemField = Create("_0", itemTypeName);
       result = std::make_unique<RVectorField>(fieldName, itemField.Unwrap());
-   } else if (normalizedType == "ROOT::VecOps::RVec<bool>") {
-      result = std::make_unique<RField<ROOT::VecOps::RVec<bool>>>(fieldName);
    } else if (normalizedType.substr(0, 19) == "ROOT::VecOps::RVec<") {
       std::string itemTypeName = normalizedType.substr(19, normalizedType.length() - 20);
       auto itemField = Create("_0", itemTypeName);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1164,13 +1164,6 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
    // int32_t fCapacity is the third data member (1 int32_t after fSize)
    std::int32_t *capacity = size + 1;
 
-   // Destroy current elements.
-   for (auto i = 0; i < *size; ++i) {
-      auto itemAddr = reinterpret_cast<void *>(begin + (i * fItemSize));
-      auto itemValue = fSubFields[0]->CaptureValue(itemAddr);
-      fSubFields[0]->DestroyValue(itemValue, /*dtorOnly=*/true);
-   }
-
    // Read collection info for this entry
    ClusterSize_t nItems;
    RClusterIndex collectionStart;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1286,7 +1286,7 @@ size_t ROOT::Experimental::RRVecField::EvalValueSize() const
    // - between fCapacity and the char[] buffer aligned like T
    // - after the char[] buffer
 
-   const auto dataMemberSz = sizeof(void *) + 2 * sizeof(std::int32_t);
+   constexpr auto dataMemberSz = sizeof(void *) + 2 * sizeof(std::int32_t);
    const auto alignOfT = fSubFields[0]->GetAlignment();
    const auto sizeOfT = fSubFields[0]->GetValueSize();
 
@@ -1299,7 +1299,7 @@ size_t ROOT::Experimental::RRVecField::EvalValueSize() const
       constexpr unsigned cacheLineSize = 64u;
 #endif
       const unsigned elementsPerCacheLine = (cacheLineSize - dataMemberSz) / sizeOfT;
-      const unsigned maxInlineByteSize = 1024;
+      constexpr unsigned maxInlineByteSize = 1024;
       const unsigned nElements =
          elementsPerCacheLine >= 8 ? elementsPerCacheLine : (sizeOfT * 8 > maxInlineByteSize ? 0 : 8);
       return nElements * sizeOfT;

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -332,6 +332,10 @@ void ROOT::Experimental::RPrintValueVisitor::VisitVectorBoolField(const RField<s
    PrintCollection(field);
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitRVecField(const RRVecField &field)
+{
+   PrintCollection(field);
+}
 
 //---------------------------- RNTupleFormatter --------------------------------
 

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -145,7 +145,6 @@ TEST(RNTuple, RVec)
    EXPECT_EQ(1.0, (*rdJetsAsStdVector)[0]);
 }
 
-
 TEST(RNTuple, RVecTypeErased)
 {
    FileRaii fileGuard("test_ntuple_rvec_typeerased.root");
@@ -185,7 +184,6 @@ TEST(RNTuple, RVecTypeErased)
    EXPECT_TRUE(v->empty());
 }
 
-
 TEST(RNTuple, ReadVectorAsRVec)
 {
    FileRaii fileGuard("test_ntuple_vectorrvecinterop.root");
@@ -214,7 +212,6 @@ TEST(RNTuple, ReadVectorAsRVec)
    r->LoadEntry(2);
    EXPECT_TRUE(rvec->empty());
 }
-
 
 TEST(RNTuple, BoolVector)
 {

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -165,6 +165,8 @@ TEST(RNTuple, RVecTypeErased)
       rvec.clear();
       rvec.push_back(42);
       w->Fill();
+      rvec.clear();
+      w->Fill();
    }
 
    // read back RVec with type-erased API
@@ -178,6 +180,9 @@ TEST(RNTuple, RVecTypeErased)
    r->LoadEntry(1);
    EXPECT_EQ(v->size(), 1);
    EXPECT_EQ(v->at(0), 42);
+
+   r->LoadEntry(2);
+   EXPECT_TRUE(v->empty());
 }
 
 
@@ -194,6 +199,8 @@ TEST(RNTuple, ReadVectorAsRVec)
       r->Fill();
       vec->push_back(4.f);
       r->Fill();
+      vec->clear();
+      r->Fill();
    }
 
    // read them back as the other type
@@ -204,6 +211,8 @@ TEST(RNTuple, ReadVectorAsRVec)
    EXPECT_TRUE(All(*rvec == ROOT::RVec<float>({1.f, 2.f, 3.f})));
    r->LoadEntry(1);
    EXPECT_TRUE(All(*rvec == ROOT::RVec<float>({1.f, 2.f, 3.f, 4.f})));
+   r->LoadEntry(2);
+   EXPECT_TRUE(rvec->empty());
 }
 
 


### PR DESCRIPTION
This PR:
- adds the RRVecField type for type-erased I/O of RVecs with RNTuple
- removes some special-casing of `RVec<bool>` which is unnecessary now that we have RVec 2.0
- adds RPrintValueVisitor support for RVecs
- adds tests for type-erased I/O of RVecs
- adds tests for `ntuple->Show` + RVecs
- adds tests for interop I/O of std::vectors and RVecs (i.e. writing one and reading the other)

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary): I don't think it's necessary

This PR fixes #6347 .