### PR TITLE
[cling] Rewrite implementation of `InputValidator::validate()`; fixes ROOT-9202

### DIFF
--- a/interpreter/cling/include/cling/MetaProcessor/MetaLexer.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaLexer.h
@@ -118,8 +118,6 @@ namespace cling {
     void ReadToEndOfLine(Token& Tok, tok::TokenKind K = tok::unknown);
 
     static void LexPunctuator(const char* C, Token& Tok);
-    // TODO: Revise. We might not need that.
-    static bool LexPunctuatorAndAdvance(const char*& curPos, Token& Tok);
     static void LexQuotedStringAndAdvance(const char*& curPos, Token& Tok);
     void LexConstant(char C, Token& Tok);
     void LexIdentifier(char C, Token& Tok);

--- a/interpreter/cling/lib/MetaProcessor/MetaLexer.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaLexer.cpp
@@ -101,12 +101,10 @@ namespace cling {
 
   void MetaLexer::LexAnyString(Token& Tok) {
     Tok.startToken(curPos);
-
     // consume until we reach one of the "AnyString" delimiters or EOF.
     while(*curPos != ' ' && *curPos != '\t' && *curPos != '\0') {
       curPos++;
     }
-
     assert(Tok.getBufStart() != curPos && "It must consume at least on char");
 
     Tok.setKind(tok::raw_ident);
@@ -153,32 +151,9 @@ namespace cling {
     }
   }
 
-  bool MetaLexer::LexPunctuatorAndAdvance(const char*& curPos, Token& Tok) {
-    Tok.startToken(curPos);
-    bool nextWasPunct = true;
-    while (true) {
-      // On comment skip until the eof token.
-      if (curPos[0] == '/' && curPos[1] == '/') {
-        while (*curPos != '\0' && *curPos != '\r' && *curPos != '\n')
-          ++curPos;
-        if (*curPos == '\0') {
-          Tok.setBufStart(curPos);
-          Tok.setKind(tok::eof);
-          Tok.setLength(0);
-          return nextWasPunct;
-        }
-      }
-      MetaLexer::LexPunctuator(curPos++, Tok);
-      if (Tok.isNot(tok::unknown))
-        return nextWasPunct;
-      nextWasPunct = false;
-    }
-  }
-
   void MetaLexer::LexQuotedStringAndAdvance(const char*& curPos, Token& Tok) {
     // curPos must be right after the starting quote (single or double),
     // and we will lex until the next one or the end of the line.
-
     assert((curPos[-1] == '"' || curPos[-1] == '\'')
            && "Not a string / character literal!");
     if (curPos[-1] == '"')
@@ -195,7 +170,6 @@ namespace cling {
         curPos += 2;
         continue;
       }
-
       if (*curPos == '\0') {
         Tok.setBufStart(curPos);
         Tok.setKind(tok::eof);

--- a/interpreter/cling/test/Prompt/Continuation.C
+++ b/interpreter/cling/test/Prompt/Continuation.C
@@ -23,6 +23,13 @@ Bc
 Cc
 // CHECK-NEXT: (int) 35
 
+// Should not enter line continuation mode here (ROOT-9202) 
+unsigned u1 = 45, u2
+// CHECK-NEXT: (unsigned int) {{[[:digit:]]+}}
+u1
+// CHECK-NEXT: (unsigned int) 45
+int i1 \ i2 // expected-error {{expected ';' at end of declaration}}
+
 static void InvokeTest(int A,
                        int B) { printf("Invoke: %d, %d\n", A, B); }
 InvokeTest(Ac,


### PR DESCRIPTION
This pull request replaces the implementation of `InputValidator::validate()` by simpler, more maintainable code that also fixes JIRA issue [ROOT-9202](https://sft.its.cern.ch/jira/browse/ROOT-9202).

The previous implementation was unable to properly handle line continuation after ',' or '\\'.  Specifically, it skipped over non-punctuation tokens, entering continuation mode even if ',' or '\' were not the last tokens in the input, e.g.
```
int a, b
```
or
```
int a \      b
```
caused cling to request more input, where it shouldn't.

## Changes or fixes:
- MetaLexer:
  - Return `/*` and `*/` as independent tokens.
  - Added `ReadToEndOfLine()` function (consume input until '\r', '\n', or EOF).
  - Added `MetaLexer::RAII` that saves the current lexing position and restores it on destruction.
  - Remove unused `LexPunctuatorAndAdvance()`.
- Rewrite of `InputValidator::validate()`.

## Checklist:
- [X] tested changes locally

Fixes [ROOT-9202](https://sft.its.cern.ch/jira/browse/ROOT-9202).