### PR TITLE
[Rint] Correctly handle line continuation after '\'

### DIFF
--- a/core/rint/inc/TRint.h
+++ b/core/rint/inc/TRint.h
@@ -38,6 +38,7 @@ private:
    Bool_t        fInterrupt;          // if true macro execution will be stopped
    Int_t         fCaughtSignal;       // TRint just caught a signal
    TFileHandler *fInputHandler;       // terminal input handler
+   Bool_t        fBackslashContinue{};// whether the last line ended with '\'
 
    TRint(const TRint&) = delete;
    TRint& operator=(const TRint&) = delete;

--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -747,8 +747,11 @@ Longptr_t  TRint::ProcessLineNr(const char* filestem, const char *line, Int_t *e
    if (!error)
       error = &err;
    if (line && line[0] != '.') {
-      TString lineWithNr = TString::Format("#line 1 \"%s%d\"\n", filestem, fNcmd - 1);
-      int res = ProcessLine(lineWithNr + line, kFALSE, error);
+      TString input;
+      if (!fBackslashContinue)
+         input += TString::Format("#line 1 \"%s%d\"\n", filestem, fNcmd - 1);
+      input += line;
+      int res = ProcessLine(input, kFALSE, error);
       if (*error == TInterpreter::kProcessing) {
          if (!fNonContinuePrompt.Length())
             fNonContinuePrompt = fDefaultPrompt;
@@ -757,6 +760,10 @@ Longptr_t  TRint::ProcessLineNr(const char* filestem, const char *line, Int_t *e
          SetPrompt(fNonContinuePrompt);
          fNonContinuePrompt.Clear();
       }
+      std::string_view sv(line);
+      auto lastNonSpace = sv.find_last_not_of(" \t");
+      fBackslashContinue = (lastNonSpace != std::string_view::npos
+                            && sv[lastNonSpace] == '\\');
       return res;
    }
    if (line && line[0] == '.' && line[1] == '@') {


### PR DESCRIPTION
To have better diagnostics, `TRint::ProcessLineNr()` prepends a `#line 1 "ROOT_prompt_xxx"` PP directive to each input line.  However, this causes problems if the previous line is continued with '\\', e.g.
```
root [0] #define m(x) printf("%s", \
root (cont'ed, cancel with .@) [1]x);
ROOT_prompt_0:2:2: error; '#' is not followed by a macro parameter
 ^
ROOT_prompt_0:3:1: error; use of undeclared identifier 'x'
x);
^
```

This PR fixes issue #8762.

## Checklist:
- [X] tested changes locally