### PR TITLE
[ntuple] Add 'std::' qualifier to int32_t, uint32_t

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -876,7 +876,7 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::AddClustersFromFooter(void* f
 
          RClusterDescriptor::RPageRange pageRange;
          pageRange.fColumnId = columnId;
-         uint32_t nPages;
+         std::uint32_t nPages;
          pos += DeserializeUInt32(pos, &nPages);
          for (unsigned int k = 0; k < nPages; ++k) {
             RClusterDescriptor::RPageRange::RPageInfo pageInfo;

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -14,6 +14,7 @@
 #include <ROOT/RPageStorageFile.hxx>
 #include <ROOT/RStringView.hxx>
 
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -294,7 +295,7 @@ TEST(PageStorageFile, LoadCluster)
 
    auto modelWrite = ROOT::Experimental::RNTupleModel::Create();
    auto wrPt = modelWrite->MakeField<float>("pt", 42.0);
-   auto wrTag = modelWrite->MakeField<int32_t>("tag", 0);
+   auto wrTag = modelWrite->MakeField<std::int32_t>("tag", 0);
 
    {
       ROOT::Experimental::RNTupleWriter ntuple(


### PR DESCRIPTION
The patch is a side-effect of addressing your comments in https://github.com/root-project/root/pull/8770 
