### PR TITLE
[RF][PyROOT] New functions for conversion between RooDataHist and NumPy arrays

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -214,6 +214,8 @@ New member functions of RooFit classes were introduced exclusively to PyROOT for
 - `RooDataSet.to_numpy`: Export a RooDataSet to a dictionary of numpy arrays
 - `RooDataSet.from_pandas`: Import a RooDataSet from a Pandas dataframe (static method)
 - `RooDataSet.to_pandas`: Export a RooDataSet to a Pandas dataframe
+- `RooDataHist.from_numpy`: Import a RooDataHist from numpy arrays with histogram counts and bin edges (static method)
+- `RooDataHist.to_numpy`: Export a RooDataHist to numpy arrays with histogram counts and bin edges
 - `RooRealVar.bins`: Get bin boundaries for a `RooRealVar` as a NumPy array
 
 For more details, consult the tutorial [rf409_NumPyPandasToRooFit.py](https://root.cern/doc/v626/rf409__NumPyPandasToRooFit_8C.html).

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodatahist.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodatahist.py
@@ -50,3 +50,207 @@ class RooDataHist(object):
         # The keywords must correspond to the CmdArg of the `plotOn` function.
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         return self._plotOn(*args, **kwargs)
+
+    @property
+    def shape(self):
+        shape = []
+
+        for i_var, var in enumerate(self.get()):
+            shape.append(var.numBins())
+
+        def get_len_from_shape():
+            n_size_check = 1
+            for n in shape:
+                n_size_check = n_size_check * n
+            return n_size_check
+
+        # Cross check that the product of the shape values is equal to the full
+        # length.
+        assert get_len_from_shape() == len(self)
+
+        return tuple(shape)
+
+    def __len__(self):
+        return self.numEntries()
+
+    def _to_array(self, buffer):
+        # Helper to create a numpy array from a raw array pointer.
+        #
+        # Note: The data is copied.
+        #
+        # Args:
+        #     buffer (cppyy.LowLevelView):
+        #         The pointer to the beginning of the array data, usually
+        #         obtained from a C++ function that returns a `double *`.
+        #
+        # Returns:
+        #     numpy.ndarray
+        import numpy as np
+
+        # Check if buffer is a nullptr by using implicit conversion from
+        # `nullptr` to Bool (for some reason comparing with ROOT.nullptr
+        # doesn't work).
+        if not buffer:
+            return None
+        a = np.copy(np.frombuffer(buffer, dtype=np.float64, count=len(self)))
+        return a.reshape(self.shape)
+
+    def _var_is_category(self):
+        # Returns a list with a Bool for each dimension of the histogram that
+        # flags whether the variable in this dimension is a RooAbsCategory.
+        import ROOT
+
+        out = []
+
+        for i_var, var in enumerate(self.get()):
+            if isinstance(var, ROOT.RooAbsReal):
+                out.append(False)
+            elif isinstance(var, ROOT.RooAbsCategory):
+                out.append(True)
+            else:
+                raise TypeError("Vaiables in RooDataHist should either be RooAbsReal or RooAbsCategory.")
+
+        return out
+
+    def _weight_error_low(self):
+        # Returns the low weight errors as numpy arrays.
+        return self._to_array(self.wgtErrLoArray())
+
+    def _weight_error_high(self):
+        # Returns the high weight errors as numpy arrays.
+        return self._to_array(self.wgtErrHiArray())
+
+    def _weight_error(self):
+        # Returns the low and high weight errors as numpy arrays.
+        return self.weight_error_low(), self.weight_error_high()
+
+    def _weights_squared_sum(self):
+        # Returns the sum of squared weights that were used to fill each bin.
+        return self._to_array(self.sumW2Array())
+
+    @staticmethod
+    def from_numpy(hist_weights, variables, bins=None, ranges=None, weights_squared_sum=None, name=None, title=None):
+        r"""Create a RooDataHist from numpy arrays.
+
+        Note: The argument stucture was inspired by numpy.histogramdd.
+
+        Args:
+            hist_weights (numpy.ndarray): The multidimensional histogram bin
+                                          weights.
+            bins (list): The bin specification, where each element is either:
+                           * a numpy array describing the monotonically
+                             increasing bin edges along each dimension.
+                           * a scalar value for the number of bins (in this
+                             case, the corresponding item in the `ranges`
+                             argument must be filled)
+                           * `None` for a category dimension or if you want to
+                              use the default binning of the RooFit variable
+            variables (RooArgSet, or list/tuple of RooAbsArgs):
+                Specification of the variables in the RooDataHist, will be
+                forwarded to the RooDataHist constructor. Both real values and
+                categories are supported.
+            ranges (list): An optional list specifying the variable range
+                           limits. Each element is either:
+                             * `None` if a full bin edges array is given to
+                               `bins` or for a category dimension
+                             * a tuple with two values corresponding to the
+                               minimum and maximum values
+            weights_squared_sum (numpy.ndarray):
+                The sum of squared weights of the original samples that were
+                used to fill the histogram. If the input weights are from a
+                weighted histogram, this parameter is no longer optional.
+            name (str): Name of the RooDataSet, `None` is equivalent to an
+                        empty string.
+            title (str): Title of the RooDataSet, `None` is equivalent to an
+                         empty string.
+
+        Returns:
+            RooDataHist
+        """
+        import ROOT
+        import numpy as np
+
+        name = "" if name is None else name
+        title = "" if title is None else title
+
+        n_dim = len(variables)
+
+        if bins is None:
+            bins = [None] * n_dim
+
+        if ranges is None:
+            ranges = [None] * n_dim
+
+        # name for internal binning that is created for the RooDataHist to adapt
+        binning_name = "_roodataset_from_numpy_binning"
+
+        def set_binning(var, bins, ranges):
+            if bins is None:
+                binning = var.getBinning().clone()
+            elif np.isscalar(bins):
+                if ranges is None:
+                    raise ValueError("If a scalar number of bins is given, you must also provide an explicit range.")
+                binning = ROOT.RooUniformBinning(ranges[0], ranges[1], bins)
+            else:
+                binning = ROOT.RooBinning(len(bins) - 1, bins)
+
+            var.setBinning(binning, binning_name)
+
+        for i_var, var in enumerate(variables):
+            if isinstance(var, ROOT.RooAbsReal):
+                set_binning(var, bins[i_var], ranges[i_var])
+
+        datahist = ROOT.RooDataHist(name, title, variables, binning_name)
+
+        if len(datahist) != len(hist_weights):
+            raise ValueError("Length of hist_weights array doesn't match the size of the RooDataHist.")
+
+        if weights_squared_sum is None:
+            if not np.allclose(hist_weights, hist_weights.round()):
+                raise ValueError(
+                    "Your input histogram has non-integer weights! You must also provide weights_squared_sum to privide the complete information to RooDataHist.from_numpy()."
+                )
+        else:
+            if len(datahist) != len(weights_squared_sum):
+                raise ValueError("Length of weights_squared_sum array doesn't match the size of the RooDataHist.")
+
+        for i_bin in range(len(datahist)):
+            if not weights_squared_sum is None:
+                # some reverse-computation that can't be avoided with the current C++ RooDataHist interface
+                wgt_err = np.sqrt(weights_squared_sum[i_bin])
+            else:
+                wgt_err = -1
+
+            datahist.set(i_bin, hist_weights[i_bin], wgt_err)
+
+        return datahist
+
+    def to_numpy(self):
+        r"""Converts the weights and bin edges of a RooDataHist to numpy arrays.
+
+        Note: The output stucture was inspired by numpy.histogramdd.
+
+        Returns:
+            weight (numpy.ndarray): The weights for each histrogram bin.
+            bin_edges (list): A list of `n_dim` arrays describing the bin edges
+                              for each dimension. For dimensions of category
+                              types, the list element is `None`.
+        """
+        import ROOT
+        import numpy as np
+
+        bin_edges = []
+
+        var_is_category = self._var_is_category()
+
+        for i_var, var in enumerate(self.get()):
+
+            if var_is_category[i_var]:
+                bin_edges.append(None)
+            else:
+                binning = self.getBinnings()[i_var]
+                bin_edges.append(
+                    np.copy(np.frombuffer(binning.array(), dtype=np.float64, count=binning.numBoundaries()))
+                )
+
+        return self._to_array(self.weightArray()), bin_edges

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
@@ -181,7 +181,9 @@ class RooDataSet(object):
         # We don't want to miss putting the weight in the output arrays, so we
         # are forced to iterate over the dataset to compute the weight.
         if compute_derived_weight:
-            try:
+            # Check if self.weightVar() is not a nullptr by using implicit
+            # conversion from `nullptr` to Bool.
+            if self.weightVar():
                 wgt_var_name = self.weightVar().GetName()
                 if not wgt_var_name in data:
                     weight_array = np.zeros(self.numEntries(), dtype=np.float64)
@@ -189,9 +191,6 @@ class RooDataSet(object):
                         self.get(i)
                         weight_array[i] = self.weight()
                     data[wgt_var_name] = weight_array
-            except ReferenceError:
-                # self.weightVar() is a nullptr
-                pass
 
         return data
 
@@ -225,7 +224,9 @@ class RooDataSet(object):
         data = {}
         for column in df:
             data[column] = df[column].values
-        return ROOT.RooDataSet.from_numpy(data, variables=variables, name=name, title=title, weight_name=weight_name, clip_to_limits=clip_to_limits)
+        return ROOT.RooDataSet.from_numpy(
+            data, variables=variables, name=name, title=title, weight_name=weight_name, clip_to_limits=clip_to_limits
+        )
 
     def to_pandas(self, compute_derived_weight=False):
         """Export a RooDataSet to a pandas DataFrame.

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -133,7 +133,8 @@ if(roofit)
 
   # NumPy compatibility
   if(NOT MSVC OR win_broken_tests)
-    ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py)
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py PYTHON_DEPS numpy)
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_numpy roofit/roodatahist_numpy.py PYTHON_DEPS numpy)
   endif()
 
 endif()

--- a/bindings/pyroot/pythonizations/test/roofit/roodatahist_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodatahist_numpy.py
@@ -1,0 +1,49 @@
+import unittest
+
+import ROOT
+
+import numpy as np
+
+
+class TestRooDataHistNumpy(unittest.TestCase):
+
+    @staticmethod
+    def _make_root_histo():
+        # Create ROOT ROOT.TH1 filled with a Gaussian distribution
+        hh = ROOT.TH1D("hh", "hh", 25, -10, 10)
+        for i in range(100):
+            hh.Fill(ROOT.gRandom.Gaus(0, 3), 0.5)
+        return hh
+
+    def test_to_numpy_and_from_numpy(self):
+        """Test exporting to numpy and then importing back a RooDataHist."""
+
+        hh = self._make_root_histo()
+
+        # Declare observable x
+        x = ROOT.RooRealVar("x", "x", -10, 10)
+
+        datahist = ROOT.RooDataHist("data_hist", "data_hist", [x], Import=hh)
+
+        hist, bin_edges = datahist.to_numpy()
+        weights_squared_sum = datahist._weights_squared_sum()
+
+        # We try both ways to pass bin edges: either via a full array, or with
+        # the number of bins and the limits.
+        datahist_1 = ROOT.RooDataHist.from_numpy(hist, [x], bins=bin_edges, weights_squared_sum=weights_squared_sum)
+        datahist_2 = ROOT.RooDataHist.from_numpy(
+            hist, [x], bins=[25], ranges=[(-10, 10)], weights_squared_sum=weights_squared_sum
+        )
+
+        def compare_to_ref(dh):
+            hist_new, bin_edges_new = dh.to_numpy()
+            np.testing.assert_allclose(hist_new, hist)
+            np.testing.assert_allclose(bin_edges_new, bin_edges)
+            np.testing.assert_allclose(dh._weights_squared_sum(), weights_squared_sum)
+
+        compare_to_ref(datahist_1)
+        compare_to_ref(datahist_2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -223,6 +223,13 @@ public:
     bool initialized = false;
   };
 
+  std::vector<std::unique_ptr<const RooAbsBinning>> const& getBinnings() const { return _lvbins; }
+
+  double const* weightArray()   const { return _wgt; }
+  double const* wgtErrLoArray() const { return _errLo; }
+  double const* wgtErrHiArray() const { return _errHi; }
+  double const* sumW2Array()    const { return _sumw2; }
+
 protected:
 
   friend class RooAbsCachedPdf ;

--- a/tutorials/roofit/rf409_NumPyPandasToRooFit.py
+++ b/tutorials/roofit/rf409_NumPyPandasToRooFit.py
@@ -74,7 +74,7 @@ x_arr = np.random.normal(-1.0, 1.0, (n_events,))
 # Import the data to a RooDataSet, passing a dictionary of arrays and the
 # corresponding RooRealVars just like you would pass to the RooDataSet
 # constructor.
-data = ROOT.RooDataSet.from_numpy({"x": x_arr}, ROOT.RooArgSet(x))
+data = ROOT.RooDataSet.from_numpy({"x": x_arr}, [x])
 
 # Let's fit the Gaussian to the data. The mean is updated accordingly.
 fit_result = gauss.fitTo(data, PrintLevel=-1, Save=True)
@@ -89,3 +89,69 @@ gauss.plotOn(xframe)
 c = ROOT.TCanvas("rf409_NumPyPandasToRooFit", "rf409_NumPyPandasToRooFit", 800, 400)
 xframe.Draw()
 c.SaveAs("rf409_NumPyPandasToRooFit.png")
+
+
+# Exporting a RooDataHist to NumPy arrays for histogram counts and bin edges
+# --------------------------------------------------------------------------
+
+def print_histogram_output(histogram_output):
+    counts, bin_edges = histogram_output
+    print(np.array(counts, dtype=int))
+    print(bin_edges[0])
+
+
+# Create a binned clone of the dataset to show RooDataHist to NumPy export.
+datahist = data.binnedClone()
+
+# You can also export a RooDataHist to numpy arrays with
+# RooDataHist.to_numpy(). As output, you will get a multidimensional array with
+# the histogram counts and a list of arrays with bin edges. This is comparable
+# to the ouput of numpy.histogram (or numpy.histogramdd for the
+# multidimensional case).
+counts, bin_edges = datahist.to_numpy()
+
+print("Counts and bin edges from RooDataHist.to_numpy:")
+print_histogram_output((counts, bin_edges))
+
+# Let's compare the ouput to the counts and bin edges we get with
+# numpy.histogramdd when we pass it the original samples:
+print("Counts and bin edges from np.histogram:")
+print_histogram_output(np.histogramdd([x_arr], bins=[x.bins()]))
+
+# The array values should be the same!
+
+
+# Importing a RooDataHist from NumPy arrays with histogram counts and bin edges
+# -----------------------------------------------------------------------------
+
+# There is also a `RooDataHist.from_numpy` function, again with an interface
+# inspired by `numpy.histogramdd`. You need to pass at least the histogram
+# counts and the list of variables. The binning is optional: the default
+# binning of the RooRealVars is used if not explicitly specified.
+datahist_new_1 = ROOT.RooDataHist.from_numpy(counts, [x])
+
+print("RooDataHist imported with default binning and exported back to numpy:")
+print_histogram_output(datahist_new_1.to_numpy())
+
+
+# It's also possible to pass custom bin edges to `RooDataHist.from_numpy`, just
+# like you pass them to `numpy.histogramdd` when you get the counts to fill the
+# RooDataHist with:
+bins = [np.linspace(-10, 10, 21)]
+counts, _ = np.histogramdd([x_arr], bins=bins)
+datahist_new_2 = ROOT.RooDataHist.from_numpy(counts, [x], bins=bins)
+
+print("RooDataHist imported with linspace binning and exported back to numpy:")
+print_histogram_output(datahist_new_2.to_numpy())
+
+# Alternatively, you can specify only the number of bins and the range if your
+# binning is uniform. This is preferred over passing the full list of bin
+# edges, because RooFit will know that the binning is uniform and do some
+# optimizations.
+bins = [20]
+ranges = [(-10, 10)]
+counts, _ = np.histogramdd([x_arr], bins=bins, range=ranges)
+datahist_new_3 = ROOT.RooDataHist.from_numpy(counts, [x], bins=bins, ranges=ranges)
+
+print("RooDataHist imported with uniform binning and exported back to numpy:")
+print_histogram_output(datahist_new_3.to_numpy())


### PR DESCRIPTION
This PR introduces new PyROOT features that allow for conversion between the RooDataHist and the NumPy arrays, following up a PR that already introduced similar functionality for the RooDataSet:
https://github.com/root-project/root/pull/9346

The new methods are (with checkmarks if they are already implemented in this PR):

- [x] `RooDataHist.to_numpy()`
- [x] `RooDataHist.from_numpy()`

These new methods are also advertised in the release notes, and the existing `rf409_NumPyPandasToRooFit.py` tutorial is extended to also explain the functionality introduced in this PR.

Note that any new Python functions prefixed with an underscore are not meant to be part of the public stable user interface, which is why they are not advertised in the release notes and also don't have docstrings.
