### PR TITLE
[cxxmodules] Fix ROOT-11002 -- Vc plus GMI

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -106,8 +106,8 @@ if(runtime_cxxmodules)
   # FIXME: Revise after a llvm upgrade or reproduce it outside rootcling.
   list(REMOVE_ITEM HEADERS "Math/Math.h")
 
-  if(veccore)
-    set(dictoptions "-mByproduct" "Vc")
+  if(veccore OR vc)
+    set(dictoptions "-m" "Vc" "-mByproduct" "Vc")
   endif(veccore)
 endif()
 

--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -107,7 +107,11 @@ if(runtime_cxxmodules)
   list(REMOVE_ITEM HEADERS "Math/Math.h")
 
   if(veccore OR vc)
-    set(dictoptions "-m" "Vc" "-mByproduct" "Vc")
+    # We do not link against libVc.a thus it makes no sense to check for
+    # version compatibility between libraries and header files. This fixes
+    # ROOT-11002 where upon building the modules.idx we run the static ctor
+    # runLibraryAbiCheck which fails to find the corresponding symbol.
+    set(dictoptions "-m" "Vc" "-mByproduct" "Vc" "-D" "Vc_NO_VERSION_CHECK")
   endif(veccore)
 endif()
 


### PR DESCRIPTION
[cxxmodules] Do not perform version checks for Vc.

We do not link against libVc.a thus it makes no sense to check for version compatibility between libraries and header files. This fixes a bug where upon building the modules.idx we run the static ctor runLibraryAbiCheck which fails to find the corresponding symbol.