### PR TITLE
Fix roofit compilation errors with std:c++17 on Windows

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -54,7 +54,7 @@ struct RunContext;
 // `std::string_view`. This means one can still use a `TString` for the name or
 // title parameter. The condition in the following `#if` should be kept in
 // sync with the one in TString.h.
-#if (__cplusplus >= 201700L) && (!defined(__clang_major__) || __clang_major__ > 5)
+#if (__cplusplus >= 201700L) && !defined(_MSC_VER) && (!defined(__clang_major__) || __clang_major__ > 5)
 #define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t) // does nothing
 #else
 #define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t)                                             \


### PR DESCRIPTION
Fix the following compilation errors when using the /std:c++17 flag on Windows:
```
roofit\roofitcore\src\RooDataSet.cxx(2073,43): error C2664: 'RooDataSet::RooDataSet(std::string_view,std::string_view,RooDataSet *,const RooArgSet &,const RooFormulaVar *,const char *,size_t,size_t,Bool_t,const char *)': cannot convert argument 1 from 'TString' to 'std::string_view'
roofit\roofitcore\src\RooDataSet.cxx(2073,17): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
roofit\roofitcore\src\RooDataSet.cxx(625,13): message : see declaration of 'RooDataSet::RooDataSet'
roofit\roofitcore\src\RooDataSet.cxx(2074,43): error C2664: 'RooDataSet::RooDataSet(std::string_view,std::string_view,RooDataSet *,const RooArgSet &,const RooFormulaVar *,const char *,size_t,size_t,Bool_t,const char *)': cannot convert argument 1 from 'TString' to 'std::string_view'
roofit\roofitcore\src\RooDataSet.cxx(2074,17): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
roofit\roofitcore\src\RooDataSet.cxx(625,13): message : see declaration of 'RooDataSet::RooDataSet'
roofit\roofitcore\src\RooDataSet.cxx(2075,43): error C2664: 'RooDataSet::RooDataSet(std::string_view,std::string_view,RooDataSet *,const RooArgSet &,const RooFormulaVar *,const char *,size_t,size_t,Bool_t,const char *)': cannot convert argument 2 from 'TString' to 'std::string_view'
roofit\roofitcore\src\RooDataSet.cxx(2075,23): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
roofit\roofitcore\src\RooDataSet.cxx(625,13): message : see declaration of 'RooDataSet::RooDataSet'
```
