### PR TITLE
[RF] Avoid RooFit depenency in some RooFitCore unit tests

### DIFF
--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -9,21 +9,21 @@
 
 ROOT_ADD_GTEST(simple simple.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooCacheManager testRooCacheManager.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooFit RooStats)
+ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooStats)
 if(NOT MSVC OR win_broken_tests)
   ROOT_ADD_GTEST(testRooDataHist testRooDataHist.cxx LIBRARIES RooFitCore
     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/dataHistv4_ref.root
                      ${CMAKE_CURRENT_SOURCE_DIR}/dataHistv5_ref.root
                      ${CMAKE_CURRENT_SOURCE_DIR}/dataHistv6_ref.root)
 endif()
-ROOT_ADD_GTEST(testRooSimPdfBuilder testRooSimPdfBuilder.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooSimPdfBuilder testRooSimPdfBuilder.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooProdPdf testRooProdPdf.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooProdPdf testRooProdPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testProxiesAndCategories testProxiesAndCategories.cxx
   LIBRARIES RooFitCore
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testProxiesAndCategories_1.root
@@ -39,6 +39,6 @@ if(NOT MSVC OR win_broken_tests)
 endif()
 ROOT_ADD_GTEST(testRooProductPdf testRooProductPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore)
 #ROOT_ADD_GTEST(testRooGradMinimizerFcn testRooGradMinimizerFcn.cxx LIBRARIES RooFitCore)
 

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -48,7 +48,7 @@ TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
   auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true), RooFit::PrintLevel(-1));
   const double aError = a.getError();
   a = 1.2;
-  auto result2 = pdf.fitTo(weightedData, RooFit::Save(), RooFit::PrintLevel(-1));
+  auto result2 = pdf.fitTo(weightedData, RooFit::Save(), RooFit::SumW2Error(false), RooFit::PrintLevel(-1));
 
   EXPECT_TRUE(result->isIdentical(*result2)) << "Fit results should be very similar.";
   EXPECT_GT(aError, a.getError()*2.) << "Asymptotically correct errors should be significantly larger.";

--- a/roofit/roofitcore/test/testRooProdPdf.cxx
+++ b/roofit/roofitcore/test/testRooProdPdf.cxx
@@ -3,7 +3,7 @@
 
 #include "RooArgList.h"
 #include "RooArgSet.h"
-#include "RooPoisson.h"
+#include "RooGenericPdf.h"
 #include "RooProdPdf.h"
 #include "RooRealVar.h"
 
@@ -69,13 +69,13 @@ TEST(RooProdPdf, TestGetPartIntList)
    RooRealVar m2{"m2", "m2", 1., 0, 10};
    RooRealVar m3{"m3", "m3", 1., 0, 10};
 
-   RooPoisson gauss1{"gauss1", "gauss1", x, m1};
-   RooPoisson gauss2{"gauss2", "gauss2", x, m2};
-   RooPoisson gauss3{"gauss3", "gauss3", y, m3};
-   RooPoisson gauss4{"gauss4", "gauss4", z, m1};
-   RooPoisson gauss5{"gauss5", "gauss5", x, m1};
+   RooGenericPdf gauss1{"gauss1", "gauss1", "x+m1", {x, m1}};
+   RooGenericPdf gauss2{"gauss2", "gauss2", "x+m2", {x, m2}};
+   RooGenericPdf gauss3{"gauss3", "gauss3", "y+m3", {y, m3}};
+   RooGenericPdf gauss4{"gauss4", "gauss4", "z+m1", {z, m1}};
+   RooGenericPdf gauss5{"gauss5", "gauss5", "x+m1", {x, m1}};
 
-   // Product of all the Gaussians.
+   // Product of all the pdfs.
    RooProdPdf prod{"prod", "prod", RooArgList{gauss1, gauss2, gauss3, gauss4, gauss5}};
 
    // We hash the string serializations of caches for all possible

--- a/roofit/roofitcore/test/testRooSimPdfBuilder.cxx
+++ b/roofit/roofitcore/test/testRooSimPdfBuilder.cxx
@@ -5,12 +5,13 @@
 #include "RooRealVar.h"
 #include "RooArgSet.h"
 #include "RooDataSet.h"
-#include "RooGaussian.h"
+#include "RooGenericPdf.h"
 #include "RooFitResult.h"
 #include "RooExtendPdf.h"
 #include "RooSimultaneous.h"
 #include "RooSimPdfBuilder.h"
 #include "RooStringVar.h"
+#include "RooMsgService.h"
 
 #include <memory>
 
@@ -19,6 +20,9 @@
 TEST(TestRooSimPdfBuilder, Example)
 {
    using namespace RooFit;
+
+   // silence log output
+   RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
 
    RooCategory C("C", "C");
    C.defineType("C1");
@@ -40,8 +44,8 @@ TEST(TestRooSimPdfBuilder, Example)
       RooRealVar m("m", "mean of gaussian", 0, -10, 10);
       RooRealVar s_C1("s_C1", "sigma of gaussian C1", 3, 0.1, 10);
       RooRealVar s_C2("s_C2", "sigma of gaussian C2", 5, 0.1, 10);
-      RooGaussian gauss_C1("gauss_C1", "gaussian C1", X, m, s_C1);
-      RooGaussian gauss_C2("gauss_C2", "gaussian C2", X, m, s_C2);
+      RooGenericPdf gauss_C1("gauss_C1", "gaussian C1", "std::exp(-0.5*(X - m)^2/s_C1^2)", {X, m, s_C1});
+      RooGenericPdf gauss_C2("gauss_C2", "gaussian C2", "std::exp(-0.5*(X - m)^2/s_C2^2)", {X, m, s_C2});
 
       RooRealVar N_C1("N_C1", "Extended term C1", 1., 0., 10.);
       RooRealVar N_C2("N_C2", "Extended term C2", 1., 0., 10.);
@@ -69,7 +73,7 @@ TEST(TestRooSimPdfBuilder, Example)
 
       RooRealVar m("m", "mean of gaussian", -10, 10);
       RooRealVar s("s", "sigma of gaussian", 0.1, 10);
-      RooGaussian gauss("gauss", "gaussian", X, m, s);
+      RooGenericPdf gauss("gauss", "gaussian", "std::exp(-0.5*(X - m)^2/s^2)", {X, m, s});
       RooRealVar N("N", "Extended term", 1., 0., 10.);
       RooExtendPdf pdf("pdf", "Extended model", gauss, N, "FULL");
 

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -5,7 +5,7 @@
 #include "RooConstVar.h"
 #include "RooCategory.h"
 #include "RooDataSet.h"
-#include "RooGaussian.h"
+#include "RooGenericPdf.h"
 #include "RooRealVar.h"
 #include "RooSimultaneous.h"
 #include "RooProdPdf.h"
@@ -21,13 +21,16 @@ TEST(RooSimultaneous, ImportFromTreeWithCut)
 {
    using namespace RooFit;
 
+   // silence log output
+   RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
+
    RooRealVar x("x", "x", 0, 10);
    RooRealVar mean("mean", "mean", 1., 0, 10);
    RooRealVar width("width", "width", 1, 0.1, 10);
    RooRealVar nsig("nsig", "nsig", 500, 100, 1000);
 
-   RooGaussian gauss1("gauss1", "gauss1", x, mean, width);
-   RooGaussian fconstraint("fconstraint", "fconstraint", mean, RooConst(2.0), RooConst(0.2));
+   RooGenericPdf gauss1("guass1", "gauss1", "std::exp(-0.5*(x - mean)^2/width^2)", {x, mean, width});
+   RooGenericPdf fconstraint("fconstraint", "fconstraint", "std::exp(-0.5*(mean - 2.0)^2/0.2^2)", {mean});
 
    RooAddPdf model("model", "model", RooArgList(gauss1), RooArgList(nsig));
    RooProdPdf modelConstrained("modelConstrained", "modelConstrained", RooArgSet(model, fconstraint));


### PR DESCRIPTION
* this is achieved by using RooGenericPdf instead of RooGaussian or
  RooPoisson

* some more changes were made to silence the tests