### PR TITLE
[hist] Fix pattern-matching bug in TFormula::HandleLinear()

### DIFF
--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -21,12 +21,14 @@
 #include "TInterpreterValue.h"
 #include "TFormula.h"
 #include "TRegexp.h"
+
 #include <array>
 #include <cassert>
 #include <iostream>
 #include <unordered_map>
 #include <functional>
 #include <set>
+#include <sstream>
 
 using namespace std;
 
@@ -1670,55 +1672,57 @@ void TFormula::HandleExponentiation(TString &formula)
    }
 }
 
+namespace {
+
+// Borrowed from RooHelpers.h, should this go to a central place?
+std::vector<std::string> tokenise(const std::string &str, const std::string &delims, bool returnEmptyToken) {
+  if (str.empty())
+    return std::vector<std::string>(returnEmptyToken ? 1 : 0);
+
+  std::vector<std::string> tokens;
+
+  auto beg = str.find_first_not_of(delims, 0);
+  auto end = str.find_first_of(delims, beg);
+  do {
+    tokens.emplace_back(str.substr(beg, end-beg));
+    beg = str.find_first_not_of(delims, end);
+    end = str.find_first_of(delims, beg);
+  } while (beg != std::string::npos);
+
+  return tokens;
+}
+
+} // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Handle linear functions defined with the operator ++.
 
 void TFormula::HandleLinear(TString &formula)
 {
+   auto terms = tokenise(formula.Data(), "@", false);
+   if(terms.size() <= 1) return; // function is not linear
    // Handle Linear functions identified with "@" operator
-   Int_t linPos = formula.Index("@");
-   if (linPos == kNPOS ) return;  // function is not linear
-   Int_t nofLinParts = formula.CountChar((int)'@');
-   assert(nofLinParts > 0);
-   fLinearParts.reserve(nofLinParts + 1);
-   Int_t Nlinear = 0;
-   bool first = true;
-   while (linPos != kNPOS && !IsAParameterName(formula, linPos)) {
+   fLinearParts.reserve(terms.size());
+   TString expandedFormula = "";
+   int delimeterPos = 0;
+   for(std::size_t iTerm = 0; iTerm < terms.size(); ++iTerm) {
+      // determine the position of the "@" operator in the formula
+      delimeterPos += terms[iTerm].size() + (iTerm == 0);
+      if(IsAParameterName(formula, delimeterPos)) {
+         // append the current term and the remaining formula unchanged to the expanded formula
+         expandedFormula += terms[iTerm];
+         expandedFormula += formula(delimeterPos, formula.Length() - (delimeterPos + 1));
+         break;
+      }
       SetBit(kLinear, 1);
-      // analyze left part only the first time
-      Int_t temp = 0;
-      TString left;
-      if (first) {
-         temp = linPos - 1;
-         while (temp >= 0 && formula[temp] != '@') {
-            temp--;
-         }
-         left = formula(temp + 1, linPos - (temp + 1));
-      }
-      temp = linPos + 1;
-      while (temp < formula.Length() && formula[temp] != '@') {
-         temp++;
-      }
-      TString right = formula(linPos + 1, temp - (linPos + 1));
-
-      TString pattern =
-         (first) ? TString::Format("%s@%s", left.Data(), right.Data()) : TString::Format("@%s", right.Data());
-      TString replacement =
-         (first) ? TString::Format("([%d]*(%s))+([%d]*(%s))", Nlinear, left.Data(), Nlinear + 1, right.Data())
-                 : TString::Format("+([%d]*(%s))", Nlinear, right.Data());
-      Nlinear += (first) ? 2 : 1;
-
-      formula.ReplaceAll(pattern, replacement);
-      if (first) {
-         TFormula *lin1 = new TFormula("__linear1", left, false);
-         fLinearParts.push_back(lin1);
-      }
-      TFormula *lin2 = new TFormula("__linear2", right, false);
-      fLinearParts.push_back(lin2);
-
-      linPos = formula.Index("@");
-      first = false;
+      auto termName = std::string("__linear") + std::to_string(iTerm+1);
+      fLinearParts.push_back(new TFormula(termName.c_str(), terms[iTerm].c_str(), false));
+      std::stringstream ss;
+      ss << "([" << iTerm << "]*(" << terms[iTerm] << "))";
+      expandedFormula += ss.str();
+      if(iTerm < terms.size() - 1) expandedFormula += "+";
    }
+   formula = expandedFormula;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/TFormulaParsingTests.h
+++ b/test/TFormulaParsingTests.h
@@ -1048,6 +1048,19 @@ bool test52() {
 }
 
 
+bool test53()
+{
+   // Test if a formula with linear terms in each parameter is correctly expanded,
+   // even if some earlier terms are substrings of later terms.
+   bool ok = true;
+
+   TF1 f1("f1", "1.0 ++ x ++ x*x ++ x*x*x", -1.0, 1.0);
+   ok &= f1.GetNpar() == 4;
+
+   return ok;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////////////
 
 void PrintError(int itest)  {
@@ -1119,6 +1132,7 @@ int runTests(bool debug = false) {
    IncrTest(itest); if (!test50() ) { PrintError(itest); }
    IncrTest(itest); if (!test51() ) { PrintError(itest); }
    IncrTest(itest); if (!test52() ) { PrintError(itest); }
+   IncrTest(itest); if (!test53() ) { PrintError(itest); }
 
    std::cout << ".\n";
 


### PR DESCRIPTION
Simple C++ code to demonstrate the problem:
```C++
TF1{"f1", "1.0++x++x*x++x*x*x", -1.0, 1.0}.Print();
```
Before this commit, running this line gave you:
```
Formula based function:     f1
        f1 : 1.0++x++x*x++x*x*x Ndim= 1, Npar= 3, Number= 0
 Formula expression:
        ([p0]*(1.0))+([p1]*(x))+([p2]*(x*x))+([p2]*(x*x))*x
```

The problem is that `TFormula::HandleLinear()` uses pattern-matching to
replace the strings representing the linear terms. This is problematic
if one of the strings is a substring of another one.