### PR TITLE
[netxng] Delete XrdFile already at Close():

### DIFF
--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -230,7 +230,6 @@ TNetXNGFile::~TNetXNGFile()
 {
    if (IsOpen())
       Close();
-   delete fFile;
    delete fUrl;
    delete fInitCondVar;
 }
@@ -303,7 +302,7 @@ Long64_t TNetXNGFile::GetSize() const
 
 Bool_t TNetXNGFile::IsOpen() const
 {
-   return fFile->IsOpen();
+   return fFile && fFile->IsOpen();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -331,6 +330,8 @@ void TNetXNGFile::Close(const Option_t */*option*/)
       Error("Close", "%s", status.ToStr().c_str());
       MakeZombie();
    }
+   delete fFile;
+   fFile = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This prevents the deletion of the TNetXNGFile triggered by static
destruction (TROOT::~TROOT() deleting open files) at a point where
the Xrootd client library had its static destruction already run,
and thus the call to XrdCl::File::~File() fails.

Fixes #8767.

(cherry picked from commit 3845be7063f4b45b63be6e7641601e7b28ea3652)
