### PR TITLE
Cling llvm module inlines

### DIFF
--- a/interpreter/cling/lib/Interpreter/BackendPasses.h
+++ b/interpreter/cling/lib/Interpreter/BackendPasses.h
@@ -35,6 +35,8 @@ namespace clang {
 }
 
 namespace cling {
+  class IncrementalJIT;
+
   ///\brief Runs passes on IR. Remove once we can migrate from ModuleBuilder to
   /// what's in clang's CodeGen/BackendUtil.
   class BackendPasses {
@@ -45,6 +47,7 @@ namespace cling {
     const clang::CodeGenOptions &m_CGOpts;
     //const clang::TargetOptions &m_TOpts;
     //const clang::LangOptions &m_LOpts;
+    IncrementalJIT &m_JIT;
 
     void CreatePasses(llvm::Module& M, int OptLevel);
 
@@ -52,7 +55,8 @@ namespace cling {
     BackendPasses(const clang::CodeGenOptions &CGOpts,
                   const clang::TargetOptions & /*TOpts*/,
                   const clang::LangOptions & /*LOpts*/,
-                  llvm::TargetMachine& TM);
+                  llvm::TargetMachine& TM,
+                  cling::IncrementalJIT& JIT);
     ~BackendPasses();
 
     void runOnModule(llvm::Module& M, int OptLevel);

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -285,8 +285,6 @@ IncrementalJIT::IncrementalJIT(IncrementalExecutor& exe,
           if (!Sym.getAddress())
             llvm_unreachable("Handle the error case");
           ret.erase(I);
-        } else if (m_ExeMM->findSymbol(symName)) {
-          ret.erase(I);
         }
       }
       return ret;

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.cpp
@@ -295,15 +295,6 @@ IncrementalJIT::IncrementalJIT(IncrementalExecutor& exe,
         llvm::orc::SymbolNameSet Symbols) {
       return llvm::orc::lookupWithLegacyFn(m_ES, *Q, Symbols,
         [&](const std::string& Name) {
-          if (auto Sym = getInjectedSymbols(Name)) {
-            if (auto AddrOrErr = Sym.getAddress())
-              return JITSymbol((uint64_t)*AddrOrErr, Sym.getFlags());
-            else
-              llvm_unreachable("Handle the error case");
-          }
-          if (auto Sym = m_ExeMM->findSymbol(Name))
-            return Sym;
-
           if (auto Sym = getSymbolAddressWithoutMangling(Name, true)) {
             if (auto AddrOrErr = Sym.getAddress())
               return JITSymbol(*AddrOrErr, Sym.getFlags());


### PR DESCRIPTION
Remove definitions for weak symbols that can be referenced from the process. Idea by @hahnjo !

Should fix relocation issues on M1 as reported by @FonsRademakers 

For hsimple.C, this reduces the amount of emitted symbols from 57 to 43.