### PR TITLE
Fix compilation in Debug mode on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@
 
 cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
+if(WIN32)
+  # Set CMP0091 (MSVC runtime library flags are selected by an abstraction) to OLD
+  # to keep the old way of selecting the runtime library with the -MD/-MDd compiler flag
+  cmake_policy(SET CMP0091 OLD)
+endif()
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
   message(FATAL_ERROR
     " ROOT must be built out-of-source.\n"

--- a/graf2d/asimage/src/libAfterImage/CMakeLists.txt
+++ b/graf2d/asimage/src/libAfterImage/CMakeLists.txt
@@ -1,12 +1,15 @@
 # libAferImage CMakeLists.txt
 
 PROJECT(AFTERIMAGE)
-if(MSVC)
+if(WIN32)
   # required for the following feature & bug fix:
   # 3.15: Added $<REMOVE_DUPLICATES:list> generator expression
   # 3.16: Bug fix with CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS: the auto-generated exports
   #       are now updated only when the object files providing the symbols are updated
   cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+  # Set CMP0091 (MSVC runtime library flags are selected by an abstraction) to OLD
+  # to keep the old way of selecting the runtime library with the -MD/-MDd compiler flag
+  cmake_policy(SET CMP0091 OLD)
 else()
   cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 endif()


### PR DESCRIPTION
Set the CMake policy `CMP0091 (MSVC runtime library flags are selected by an abstraction)` to `OLD` to keep the old way of selecting the runtime library with the `-MD`/`-MDd` compiler flag. This fixes several compilation errors like:
```
RStl.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in rootcling_stage1.obj
RStl.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MD_DynamicRelease' doesn't match value 'MDd_DynamicDebug' in rootcling_stage1.obj
```
