### PR TITLE
allow emitting signal or not in TGNumberEntry

### DIFF
--- a/gui/gui/inc/TGNumberEntry.h
+++ b/gui/gui/inc/TGNumberEntry.h
@@ -174,24 +174,24 @@ public:
                  Double_t min = 0, Double_t max = 1);
    virtual ~TGNumberEntry();
 
-   virtual void SetNumber(Double_t val) {
+   virtual void SetNumber(Double_t val, Bool_t emit = kTRUE) {
       // Set the numeric value (floating point representation)
-      fNumericEntry->SetNumber(val); }
-   virtual void SetIntNumber(Long_t val) {
+      fNumericEntry->SetNumber(val, emit); }
+   virtual void SetIntNumber(Long_t val, Bool_t emit = kTRUE) {
       // Set the numeric value (integer representation)
-      fNumericEntry->SetIntNumber(val); }
-   virtual void SetTime(Int_t hour, Int_t min, Int_t sec) {
+      fNumericEntry->SetIntNumber(val, emit); }
+   virtual void SetTime(Int_t hour, Int_t min, Int_t sec, Bool_t emit = kTRUE) {
       // Set the numeric value (time format)
-      fNumericEntry->SetTime(hour, min, sec); }
-   virtual void SetDate(Int_t year, Int_t month, Int_t day) {
+      fNumericEntry->SetTime(hour, min, sec, emit); }
+   virtual void SetDate(Int_t year, Int_t month, Int_t day, Bool_t emit = kTRUE) {
       // Set the numeric value (date format)
-      fNumericEntry->SetDate(year, month, day); }
-   virtual void SetHexNumber(ULong_t val) {
+      fNumericEntry->SetDate(year, month, day, emit); }
+   virtual void SetHexNumber(ULong_t val, Bool_t emit = kTRUE) {
       // Set the numeric value (hex format)
-      fNumericEntry->SetHexNumber(val); }
-   virtual void SetText(const char* text) {
+      fNumericEntry->SetHexNumber(val, emit); }
+   virtual void SetText(const char* text, Bool_t emit = kTRUE) {
       // Set the value (text format)
-      fNumericEntry->SetText(text); }
+      fNumericEntry->SetText(text, emit); }
    virtual void SetState(Bool_t enable = kTRUE);
 
    virtual Double_t GetNumber() const {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Allows forwarding emit arg to TGNumberEntryField
It's a follow-up from https://github.com/root-project/root/pull/8656 which implemented emit for SetNumber-emit in TGNumberEntryField

## Checklist:

- [x] tested changes locally

