### PR TITLE
[skip-ci] Disable a couple of failing roofit tests on Windows

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -123,8 +123,10 @@ else()
                     roofit/rf316_llratioplot.py
                     roofit/rf401_importttreethx.C
                     roofit/rf401_importttreethx.py
+                    roofit/rf408_RDataFrameToRooFit.py
                     roofit/rf512_wsfactory_oper.C
                     roofit/rf512_wsfactory_oper.py
+                    roofit/rf708_bphysics.py
     )
   endif()
 endif()


### PR DESCRIPTION
Disable the failing `rf408_RDataFrameToRooFit.py` and `rf708_bphysics.py` tests on Windows