### PR TITLE
Directly store needed attributes in `TreeHeadNode`

### DIFF
--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -73,7 +73,7 @@ class FriendInfoTest(unittest.TestCase):
         headnode = create_dummy_headnode(maintree)
 
         # Retrieve information about friends
-        friend_info = headnode._get_friend_info()
+        friend_info = headnode.friendinfo
 
         # Convert to Python collections
         friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friend_info.fFriendNames]
@@ -123,7 +123,7 @@ class FriendInfoTest(unittest.TestCase):
         headnode = create_dummy_headnode(maintree)
 
         # Retrieve information about friends
-        friend_info = headnode._get_friend_info()
+        friend_info = headnode.friendinfo
 
         # Convert to Python collections
         friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friend_info.fFriendNames]


### PR DESCRIPTION
This PR addresses the TODO comments to remove the superfluous public getters / properties logic in `TreeHeadNode`. Currently, just parses the user arguments in the `__init__` method and stores the needed attributes. My idea is that in the end we'll only need to store `npartitions` and `tree` (which are always needed) plus `defaultbranches` and `friendinfo` as "optional" class attributes (meaning they are initialized to `None` and changed if some conditions apply). 

For simplicity, in this PR I still leave `treename` and `inputfiles` attributes which are needed in the `Ranges.get_clusters` function.

The next PRs will address:
* The assumption we only have one unique treename in the RDataFrame
* Change in `Ranges.get_clusters` to accept a `TTree` instance as argument, pairing it with new C++ functions in `ROOT::Internal::TreeUtils` to retrieve a vector of clusters (plus some other metadata) depending if it's a TTree or TChain

If the logic for this PR is approved I'll add more docs and commit messages