### PR TITLE
[urgent] [cxxmodules] Exclude the RInterface from the global module index.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1233,9 +1233,14 @@ static void RegisterCxxModules(cling::Interpreter &clingInterp)
       // FIXME: Hist is not a core module but is very entangled to MathCore and
       // causes issues.
       std::vector<std::string> FIXMEModules = {"Hist"};
+      clang::CompilerInstance &CI = *clingInterp.getCI();
+      clang::Preprocessor &PP = CI.getPreprocessor();
+      ModuleMap &MMap = PP.getHeaderSearchInfo().getModuleMap();
+      if (MMap.findModule("RInterface"))
+         FIXMEModules.push_back("RInterface");
+
       LoadModules(FIXMEModules, clingInterp);
 
-      clang::CompilerInstance &CI = *clingInterp.getCI();
       GlobalModuleIndex *GlobalIndex = nullptr;
       // Conservatively enable platform by platform.
       bool supportedPlatform =
@@ -1274,10 +1279,8 @@ static void RegisterCxxModules(cling::Interpreter &clingInterp)
       if (GlobalIndex)
          GlobalIndex->getKnownModuleFileNames(KnownModuleFileNames);
 
-      clang::Preprocessor &PP = CI.getPreprocessor();
       std::vector<std::string> PendingModules;
       PendingModules.reserve(256);
-      ModuleMap &MMap = PP.getHeaderSearchInfo().getModuleMap();
       for (auto I = MMap.module_begin(), E = MMap.module_end(); I != E; ++I) {
          clang::Module *M = I->second;
          assert(M);


### PR DESCRIPTION
PR root-project/root#6969 allowed ROOT to build pcm files for the R package via the RInterface.pcm. However, various headers of R define macros which are defined by math.h and others (ERROR in RooFit).

When the global module index is enabled, ROOT loads RInterface on a lookup for (Range). Then the exported macros "shadow" the ones which are still in the index and we do not load the correct corresponding module. This obscure problem seems to be coming from a current deficiency in the implementation/interaction
between clang and the index.

Pre-loading the RInterface, if enabled, seems to resolve the issue at a reasonable compromise rather than trying to disable the module altogether or undefine the fragile macros.
