### PR TITLE
[urgent][cxxmodules] We are not yet ready to enable the module for R.

### DIFF
--- a/bindings/r/CMakeLists.txt
+++ b/bindings/r/CMakeLists.txt
@@ -30,6 +30,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RInterface
     Matrix
     RIO
     Thread
+  NO_CXXMODULE
 )
 
 ROOT_ADD_CXX_FLAG(_R_FLAGS -Wno-cast-function-type)


### PR DESCRIPTION
We need several adjustments to do. First pre-loading of RInterface.pcm in root-project/root@5096f5fffc causes some crashes. Second we seem to still have issues when trying to resolve symbols from the Rcpp library.

