### PR TITLE
Retrieve all base classes of the inheritance chain

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -1192,7 +1192,7 @@ bool Cppyy::HasComplexHierarchy(TCppType_t klass)
     size_t nbases = 0;
 
     TClassRef& cr = type_from_handle(klass);
-    if (cr.GetClass() && cr->GetListOfBases() != 0)
+    if (cr.GetClass() && cr->GetListOfAllBases() != 0)
         nbases = GetNumBases(klass);
 
     if (1 < nbases)
@@ -1200,7 +1200,7 @@ bool Cppyy::HasComplexHierarchy(TCppType_t klass)
     else if (nbases == 0)
         is_complex = 0;
     else {         // one base class only
-        TBaseClass* base = (TBaseClass*)cr->GetListOfBases()->At(0);
+        TBaseClass* base = (TBaseClass*)cr->GetListOfAllBases()->At(0);
         if (base->Property() & kIsVirtualBase)
             is_complex = 1;       // TODO: verify; can be complex, need not be.
         else
@@ -1214,15 +1214,15 @@ Cppyy::TCppIndex_t Cppyy::GetNumBases(TCppType_t klass)
 {
 // Get the total number of base classes that this class has.
     TClassRef& cr = type_from_handle(klass);
-    if (cr.GetClass() && cr->GetListOfBases() != 0)
-        return (TCppIndex_t)cr->GetListOfBases()->GetSize();
+    if (cr.GetClass() && cr->GetListOfAllBases() != 0)
+        return (TCppIndex_t)cr->GetListOfAllBases()->GetSize();
     return (TCppIndex_t)0;
 }
 
 std::string Cppyy::GetBaseName(TCppType_t klass, TCppIndex_t ibase)
 {
     TClassRef& cr = type_from_handle(klass);
-    return ((TBaseClass*)cr->GetListOfBases()->At((int)ibase))->GetName();
+    return ((TBaseClass*)cr->GetListOfAllBases()->At((int)ibase))->GetName();
 }
 
 bool Cppyy::IsSubtype(TCppType_t derived, TCppType_t base)

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -445,6 +445,7 @@ public:
    TList             *GetListOfEnums(Bool_t load = kTRUE);
    TList             *GetListOfFunctionTemplates(Bool_t load = kTRUE);
    TList             *GetListOfBases();
+   TList             *GetListOfAllBases();
    TList             *GetListOfMethods(Bool_t load = kTRUE);
    TCollection       *GetListOfMethodOverloads(const char* name) const;
    TList             *GetListOfRealData() const { return fRealData; }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3624,7 +3624,9 @@ const char *TClass::GetSharedLibs()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return list containing the TBaseClass(es) of a class.
+/// Return list containing the \b direct TBaseClass(es) of a class. This
+/// function does not include all base classes in the inheritance chain of the
+/// class. For that behaviour, see TClass::GetListOfAllBases .
 
 TList *TClass::GetListOfBases()
 {
@@ -3657,6 +3659,23 @@ TList *TClass::GetListOfBases()
       }
    }
    return fBase;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Return list containing all base classes of this class, considering the full
+/// inheritance chain.
+
+TList *TClass::GetListOfAllBases()
+{
+   TList *allbases = new TList;
+   for (TObject *baseclass_tobject: *GetListOfBases()){
+      auto baseclass_tbaseclass = static_cast<TBaseClass *>(baseclass_tobject);
+      allbases->Add(baseclass_tbaseclass);
+      TClass *baseclass_tclass = baseclass_tbaseclass->GetClassPointer();
+      allbases->AddAll(baseclass_tclass->GetListOfAllBases());
+   }
+
+   return allbases;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Add a new method TClass::GetListOfAllBases to retrieve all the base classes in the full inheritance chain of a class. Use the new function to correctly retrieve information about the hierarchy of a class type in cppyy. Related to #8817 , not a final solution but I'd like to see if it brings hell in the CI
