### PR TITLE
[TMVA][SOFIE] Remove: RModelParser_ONNX+ from sofie/inc/LinkDef.h

### DIFF
--- a/tmva/sofie/inc/LinkDef.h
+++ b/tmva/sofie/inc/LinkDef.h
@@ -7,11 +7,7 @@
 
 #pragma link C++ nestedclass;
 
-
-// the classifiers
-
 #pragma link C++ class TMVA::Experimental::SOFIE::RModel-;
-#pragma link C++ class TMVA::Experimental::SOFIE::RModelParser_ONNX+;
 #pragma link C++ class TMVA::Experimental::SOFIE::ROperator+;
 #pragma link C++ struct TMVA::Experimental::SOFIE::InitializedTensor+;
 #pragma link C++ struct TMVA::Experimental::SOFIE::TensorInfo+;


### PR DESCRIPTION
 This Pull request modifies the LinkDef.h file present in `tmva/sofie/inc/LinkDef.h` by removing the #pragma link to class RModelParser_ONNX as the mentioned class is present in tmva/sofie_parsers directory.

## Changes or fixes:
- [x] Removed #pragma link to RModelParser_ONNX from sofie/inc/LinkDef.h