### PR TITLE
[DF] Add DefinePerSample 

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -53,6 +53,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RAction.hxx
     ROOT/RDF/RBookedDefines.hxx
     ROOT/RDF/RDataBlockNotifier.hxx
+    ROOT/RDF/RDataBlockID.hxx
     ROOT/RDF/RDefineBase.hxx
     ROOT/RDF/RDefine.hxx
     ROOT/RDF/RDefineReader.hxx

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -52,8 +52,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RActionBase.hxx
     ROOT/RDF/RAction.hxx
     ROOT/RDF/RBookedDefines.hxx
-    ROOT/RDF/RDataBlockNotifier.hxx
-    ROOT/RDF/RDataBlockID.hxx
+    ROOT/RDF/RNewSampleNotifier.hxx
+    ROOT/RDF/RSampleInfo.hxx
     ROOT/RDF/RDefineBase.hxx
     ROOT/RDF/RDefine.hxx
     ROOT/RDF/RDefineReader.hxx

--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -57,7 +57,7 @@
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TStatistic>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile2D>+;
-#pragma link C++ class TNotifyLink<ROOT::Internal::RDF::RDataBlockFlag>;
+#pragma link C++ class TNotifyLink<ROOT::Internal::RDF::RNewSampleFlag>;
 #pragma link C++ class ROOT::RDF::RCutFlowReport;
 
 #endif

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -24,7 +24,7 @@
 #include "ROOT/RVec.hxx"
 #include "ROOT/TBufferMerger.hxx" // for SnapshotHelper
 #include "ROOT/RDF/RCutFlowReport.hxx"
-#include "ROOT/RDF/RDataBlockID.hxx"
+#include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RSnapshotOptions.hxx"
 #include "ROOT/TypeTraits.hxx"
@@ -81,7 +81,7 @@ public:
       throw std::logic_error("`GetMergeableValue` is not implemented for this type of action.");
    }
 
-   virtual ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() { return {}; }
+   virtual ROOT::RDF::SampleCallback_t GetSampleCallback() { return {}; }
 };
 
 } // namespace RDF
@@ -1455,9 +1455,9 @@ public:
 
    std::string GetActionName() { return "Snapshot"; }
 
-   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final
    {
-      return [this](unsigned int, const RDataBlockID &) mutable { fBranchAddressesNeedReset = true; };
+      return [this](unsigned int, const RSampleInfo &) mutable { fBranchAddressesNeedReset = true; };
    }
 };
 
@@ -1629,9 +1629,9 @@ public:
 
    std::string GetActionName() { return "Snapshot"; }
 
-   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final
    {
-      return [this](unsigned int slot, const RDataBlockID &) mutable { fBranchAddressesNeedReset[slot] = 1; };
+      return [this](unsigned int slot, const RSampleInfo &) mutable { fBranchAddressesNeedReset[slot] = 1; };
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -81,6 +81,10 @@ public:
       throw std::logic_error("`GetMergeableValue` is not implemented for this type of action.");
    }
 
+   virtual std::function<void(unsigned int)> GetDataBlockCallback() R__DEPRECATED(6, 28, "Use GetSampleCallback.")
+   {
+      return {};
+   }
    virtual ROOT::RDF::SampleCallback_t GetSampleCallback() { return {}; }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -24,6 +24,7 @@
 #include "ROOT/RVec.hxx"
 #include "ROOT/TBufferMerger.hxx" // for SnapshotHelper
 #include "ROOT/RDF/RCutFlowReport.hxx"
+#include "ROOT/RDF/RDataBlockID.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RSnapshotOptions.hxx"
 #include "ROOT/TypeTraits.hxx"
@@ -80,7 +81,7 @@ public:
       throw std::logic_error("`GetMergeableValue` is not implemented for this type of action.");
    }
 
-   virtual std::function<void(unsigned int)> GetDataBlockCallback() { return {}; }
+   virtual ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() { return {}; }
 };
 
 } // namespace RDF
@@ -1454,9 +1455,9 @@ public:
 
    std::string GetActionName() { return "Snapshot"; }
 
-   std::function<void(unsigned int)> GetDataBlockCallback() final
+   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final
    {
-      return [this](unsigned int) mutable { fBranchAddressesNeedReset = true; };
+      return [this](unsigned int, const RDataBlockID &) mutable { fBranchAddressesNeedReset = true; };
    }
 };
 
@@ -1628,9 +1629,9 @@ public:
 
    std::string GetActionName() { return "Snapshot"; }
 
-   std::function<void(unsigned int)> GetDataBlockCallback() final
+   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final
    {
-      return [this](unsigned int slot) mutable { fBranchAddressesNeedReset[slot] = 1; };
+      return [this](unsigned int slot, const RDataBlockID &) mutable { fBranchAddressesNeedReset[slot] = 1; };
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -498,7 +498,7 @@ void CallBuildAction(std::shared_ptr<PrevNodeType> *prevNodeOnHeap, const char *
 
    auto actionPtr =
       BuildAction<ColTypes...>(cols, std::move(*helperArgOnHeap), nSlots, std::move(prevNodePtr), ActionTag{}, *defines);
-   loopManager.AddDataBlockCallback(actionPtr->GetDataBlockCallback());
+   loopManager.AddSampleCallback(actionPtr->GetSampleCallback());
    jittedActionOnHeap->SetAction(std::move(actionPtr));
 
    // defines points to the columns structure in the heap, created before the jitted call so that the jitter can

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -165,7 +165,7 @@ private:
    // this one is always available but has lower precedence thanks to `...`
    void *PartialUpdateImpl(...) { throw std::runtime_error("This action does not support callbacks!"); }
 
-   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final { return fHelper.GetDataBlockCallback(); }
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final { return fHelper.GetSampleCallback(); }
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -165,7 +165,7 @@ private:
    // this one is always available but has lower precedence thanks to `...`
    void *PartialUpdateImpl(...) { throw std::runtime_error("This action does not support callbacks!"); }
 
-   std::function<void(unsigned int)> GetDataBlockCallback() final { return fHelper.GetDataBlockCallback(); }
+   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final { return fHelper.GetDataBlockCallback(); }
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -12,6 +12,7 @@
 #define ROOT_RACTIONBASE
 
 #include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RDataBlockID.hxx"
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t
 #include "RtypesCore.h"
 
@@ -81,7 +82,7 @@ public:
    */
    virtual std::unique_ptr<RMergeableValueBase> GetMergeableValue() const = 0;
 
-   virtual std::function<void(unsigned int)> GetDataBlockCallback() = 0;
+   virtual ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() = 0;
 };
 } // namespace RDF
 } // namespace Internal

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -12,7 +12,7 @@
 #define ROOT_RACTIONBASE
 
 #include "ROOT/RDF/RBookedDefines.hxx"
-#include "ROOT/RDF/RDataBlockID.hxx"
+#include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t
 #include "RtypesCore.h"
 
@@ -82,7 +82,7 @@ public:
    */
    virtual std::unique_ptr<RMergeableValueBase> GetMergeableValue() const = 0;
 
-   virtual ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() = 0;
+   virtual ROOT::RDF::SampleCallback_t GetSampleCallback() = 0;
 };
 } // namespace RDF
 } // namespace Internal

--- a/tree/dataframe/inc/ROOT/RDF/RDataBlockID.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDataBlockID.hxx
@@ -1,0 +1,64 @@
+// Author: Enrico Guiraud, 2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDATABLOCKID
+#define ROOT_RDF_RDATABLOCKID
+
+#include <ROOT/RStringView.hxx>
+
+#include <functional>
+#include <stdexcept>
+#include <string>
+
+namespace ROOT {
+namespace RDF {
+
+/// This type represents a data-block identifier, to be used in conjunction with RDataFrame features such as
+/// DefinePerSample() and data-block callbacks.
+class RDataBlockID {
+   // Currently backed by a simple string, might change in the future as we get usage experience.
+   std::string fID;
+
+public:
+   explicit RDataBlockID(std::string_view id) : fID(id) {}
+   RDataBlockID() = default;
+   RDataBlockID(const RDataBlockID &) = default;
+   RDataBlockID &operator=(const RDataBlockID &) = default;
+   RDataBlockID(RDataBlockID &&) = default;
+   RDataBlockID &operator=(RDataBlockID &&) = default;
+   ~RDataBlockID() = default;
+
+   bool Contains(std::string_view substr) const
+   {
+      // C++14 needs the conversion from std::string_view to std::string
+      return fID.find(std::string(substr)) != std::string::npos;
+   }
+
+   bool Empty() const {
+      return fID.empty();
+   }
+
+   const std::string &AsString() const
+   {
+      return fID;
+   }
+
+   bool operator==(const RDataBlockID &other) const { return fID == other.fID; }
+   bool operator!=(const RDataBlockID &other) const { return !(*this == other); }
+};
+
+/// The type of a data-block callback, registered with a RDataFrame computation graph via e.g.
+/// DefinePerSample() or by certain actions (e.g. Snapshot()).
+using DataBlockCallback_t = std::function<void(unsigned int, const ROOT::RDF::RDataBlockID &)>;
+
+} // namespace RDF
+} // namespace ROOT
+
+#endif

--- a/tree/dataframe/inc/ROOT/RDF/RDataBlockID.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDataBlockID.hxx
@@ -12,6 +12,7 @@
 #define ROOT_RDF_RDATABLOCKID
 
 #include <ROOT/RStringView.hxx>
+#include <Rtypes.h>
 
 #include <functional>
 #include <stdexcept>
@@ -25,9 +26,13 @@ namespace RDF {
 class RDataBlockID {
    // Currently backed by a simple string, might change in the future as we get usage experience.
    std::string fID;
+   std::pair<ULong64_t, ULong64_t> fEntryRange;
 
 public:
-   explicit RDataBlockID(std::string_view id) : fID(id) {}
+   explicit RDataBlockID(std::string_view id, std::pair<ULong64_t, ULong64_t> entryRange)
+      : fID(id), fEntryRange(entryRange)
+   {
+   }
    RDataBlockID() = default;
    RDataBlockID(const RDataBlockID &) = default;
    RDataBlockID &operator=(const RDataBlockID &) = default;
@@ -49,6 +54,10 @@ public:
    {
       return fID;
    }
+
+   std::pair<ULong64_t, ULong64_t> EntryRange() const { return fEntryRange; }
+
+   ULong64_t NEntries() const { return fEntryRange.second - fEntryRange.first; }
 
    bool operator==(const RDataBlockID &other) const { return fID == other.fID; }
    bool operator!=(const RDataBlockID &other) const { return !(*this == other); }

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -142,6 +142,8 @@ public:
       }
    }
 
+   void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo &/*id*/) final {}
+
    const std::type_info &GetTypeId() const { return typeid(ret_type); }
 
    /// Clean-up operations to be performed at the end of a task.

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -13,6 +13,7 @@
 
 #include "ROOT/RDF/GraphNode.hxx"
 #include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RSampleInfo.hxx"
 
 #include <deque>
 #include <map>
@@ -65,6 +66,8 @@ public:
    std::string GetTypeName() const;
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
    virtual void Update(unsigned int slot, Long64_t entry) = 0;
+   /// Update function to be called once per sample, used if the derived type is a RDefinePerSample
+   virtual void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo &/*id*/) {}
    /// Clean-up operations to be performed at the end of a task.
    virtual void FinaliseSlot(unsigned int slot) = 0;
    /// Return the unique identifier of this RDefineBase.

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -58,7 +58,7 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id)
+   void Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id) final
    {
       fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()] = fExpression(slot, id);
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -11,7 +11,7 @@
 #ifndef ROOT_RDF_RDEFINEPERSAMPLE
 #define ROOT_RDF_RDEFINEPERSAMPLE
 
-#include "ROOT/RDF/RDataBlockID.hxx"
+#include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include <ROOT/RDF/RDefineBase.hxx>
 #include <ROOT/TypeTraits.hxx>
@@ -58,7 +58,7 @@ public:
    }
 
    /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
-   void Update(unsigned int slot, const ROOT::RDF::RDataBlockID &id)
+   void Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id)
    {
       fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()] = fExpression(slot, id);
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -1,0 +1,76 @@
+// Author: Enrico Guiraud, CERN  08/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDEFINEPERSAMPLE
+#define ROOT_RDF_RDEFINEPERSAMPLE
+
+#include "ROOT/RDF/RDataBlockID.hxx"
+#include "ROOT/RDF/Utils.hxx"
+#include <ROOT/RDF/RDefineBase.hxx>
+#include <ROOT/TypeTraits.hxx>
+
+#include <deque>
+#include <vector>
+
+namespace ROOT {
+namespace Detail {
+namespace RDF {
+
+using namespace ROOT::TypeTraits;
+
+template <typename F>
+class R__CLING_PTRCHECK(off) RDefinePerSample final : public RDefineBase {
+   using RetType_t = typename CallableTraits<F>::ret_type;
+
+   // Avoid instantiating vector<bool> as `operator[]` returns temporaries in that case. Use std::deque instead.
+   using ValuesPerSlot_t =
+      std::conditional_t<std::is_same<RetType_t, bool>::value, std::deque<RetType_t>, std::vector<RetType_t>>;
+
+   F fExpression;
+   ValuesPerSlot_t fLastResults;
+
+public:
+   RDefinePerSample(std::string_view name, std::string_view type, F expression, unsigned int nSlots)
+      : RDefineBase(name, type, nSlots, /*defines*/ {}, /*DSValuePtrs*/ {}, /*ds*/ nullptr),
+        fExpression(std::move(expression)), fLastResults(fNSlots * RDFInternal::CacheLineStep<RetType_t>())
+   {
+   }
+
+   RDefinePerSample(const RDefinePerSample &) = delete;
+   RDefinePerSample &operator=(const RDefinePerSample &) = delete;
+
+   /// Return the (type-erased) address of the Define'd value for the given processing slot.
+   void *GetValuePtr(unsigned int slot) final
+   {
+      return static_cast<void *>(&fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()]);
+   }
+
+   void Update(unsigned int, Long64_t) final
+   {
+      // no-op
+   }
+
+   /// Update the value at the address returned by GetValuePtr with the content corresponding to the given entry
+   void Update(unsigned int slot, const ROOT::RDF::RDataBlockID &id)
+   {
+      fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()] = fExpression(slot, id);
+   }
+
+   const std::type_info &GetTypeId() const { return typeid(RetType_t); }
+
+   void InitSlot(TTreeReader *, unsigned int) final {}
+   void FinaliseSlot(unsigned int) final {}
+};
+
+} // namespace RDF
+} // namespace Detail
+} // namespace ROOT
+
+#endif // ROOT_RDF_RDEFINEPERSAMPLE

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -500,10 +500,10 @@ public:
       auto newColumn = std::make_shared<RDFDetail::RDefinePerSample<F>>(name, retTypeName, std::move(expression),
                                                                         fLoopManager->GetNSlots());
 
-      auto updateDefinePerSample = [newColumn](unsigned int slot, const ROOT::RDF::RDataBlockID &id) {
+      auto updateDefinePerSample = [newColumn](unsigned int slot, const ROOT::RDF::RSampleInfo &id) {
          newColumn->Update(slot, id);
       };
-      fLoopManager->AddDataBlockCallback(std::move(updateDefinePerSample));
+      fLoopManager->AddSampleCallback(std::move(updateDefinePerSample));
 
       RDFInternal::RBookedDefines newCols(fDefines);
       newCols.AddColumn(std::move(newColumn), name);
@@ -2630,7 +2630,7 @@ private:
       auto action =
          RDFInternal::BuildAction<ColTypes...>(validColumnNames, helperArg, nSlots, fProxiedPtr, ActionTag{}, fDefines);
       fLoopManager->Book(action.get());
-      fLoopManager->AddDataBlockCallback(action->GetDataBlockCallback());
+      fLoopManager->AddSampleCallback(action->GetSampleCallback());
       return MakeResultPtr(r, *fLoopManager, std::move(action));
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -479,8 +479,23 @@ public:
       return newInterface;
    }
 
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Creates a custom column that is updated when the input sample changes.
+   /// \param[in] name The name of the defined column.
+   /// \param[in] expression A C++ callable that computes the new value of the defined column.
+   /// \return the first node of the computation graph for which the new quantity is defined.
+   ///
+   /// The signature of the callable passed as second argument should be `T(unsigned int slot, ROOT::RDF::RSampleInfo &id)`
+   /// where `T` is the type of the defined column, `slot` is a number in the range [0, nThreads) that is different
+   /// for each processing thread that can simplify the definition of thread-safe callables, and `id` is an instance
+   /// of a ROOT::RDF::RSampleInfo object which contains information about the sample which is being processed (see the
+   /// relevant docs for more information).
+   ///
+   /// DefinePerSample() is useful to e.g. define a quantity that depends on which TTree in which TFile is being
+   /// processed or to inject a callback into the event loop that is only called when the processing of a new sample
+   /// starts rather than at every entry.
+   ///
    // TODO we could SFINAE on F's signature to provide friendlier compilation errors in case of signature mismatch
-   // FIXME add docs
    template <typename F, typename RetType_t = typename TTraits::CallableTraits<F>::ret_type>
    RInterface<Proxied, DS_t> DefinePerSample(std::string_view name, F expression)
    {
@@ -511,7 +526,17 @@ public:
       return newInterface;
    }
 
-   // FIXME add docs
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Creates a custom column that is updated when the input sample changes.
+   /// \param[in] name The name of the defined column.
+   /// \param[in] expression A valid C++ expression as a string, which will be used to compute the defined value.
+   /// \return the first node of the computation graph for which the new quantity is defined.
+   ///
+   /// The expression is just-in-time compiled and used to produce the column entries.
+   /// It must be valid C++ syntax and the usage of the special variable names `rdfslot_` and `rdfsampleinfo_` is
+   /// permitted, where these variables will take the same values as the `slot` and `id` parameters described at the
+   /// other DefinePerSample overload. See the documentation of that overload for more information.
+   ///
    RInterface<Proxied, DS_t> DefinePerSample(std::string_view name, std::string_view expression)
    {
       RDFInternal::CheckValidCppVarName(name, "DefinePerSample");

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -61,7 +61,7 @@ public:
    // Helper for RMergeableValue
    std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> GetMergeableValue() const final;
 
-   std::function<void(unsigned int)> GetDataBlockCallback() final;
+   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -61,7 +61,7 @@ public:
    // Helper for RMergeableValue
    std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> GetMergeableValue() const final;
 
-   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final;
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -12,6 +12,7 @@
 #define ROOT_RJITTEDCUSTOMCOLUMN
 
 #include "ROOT/RDF/RDefineBase.hxx"
+#include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RStringView.hxx"
 #include "RtypesCore.h"
 
@@ -44,6 +45,7 @@ public:
    void *GetValuePtr(unsigned int slot) final;
    const std::type_info &GetTypeId() const final;
    void Update(unsigned int slot, Long64_t entry) final;
+   void Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id) final;
    void FinaliseSlot(unsigned int slot) final;
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -13,6 +13,7 @@
 
 #include "ROOT/RDF/RNodeBase.hxx"
 #include "ROOT/RDF/RDataBlockNotifier.hxx"
+#include "ROOT/RDF/RDataBlockID.hxx"
 
 #include <functional>
 #include <map>
@@ -121,8 +122,9 @@ class RLoopManager : public RNodeBase {
    /// Registered callbacks to invoke just once before running the loop
    std::vector<RDFInternal::ROneTimeCallback> fCallbacksOnce;
    /// Registered callbacks to call at the beginning of each "data block"
-   std::vector<RDFInternal::Callback_t> fDataBlockCallbacks;
+   std::vector<ROOT::RDF::DataBlockCallback_t> fDataBlockCallbacks;
    RDFInternal::RDataBlockNotifier fDataBlockNotifier;
+   std::vector<ROOT::RDF::RDataBlockID> fDataBlockIDs;
    unsigned int fNRuns{0}; ///< Number of event loops run
 
    /// Registry of per-slot value pointers for booked data-source columns
@@ -202,7 +204,7 @@ public:
 
    const ColumnNames_t &GetBranchNames();
 
-   void AddDataBlockCallback(std::function<void(unsigned int)> &&callback);
+   void AddDataBlockCallback(ROOT::RDF::DataBlockCallback_t &&callback);
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -12,8 +12,8 @@
 #define ROOT_RLOOPMANAGER
 
 #include "ROOT/RDF/RNodeBase.hxx"
-#include "ROOT/RDF/RDataBlockNotifier.hxx"
-#include "ROOT/RDF/RDataBlockID.hxx"
+#include "ROOT/RDF/RNewSampleNotifier.hxx"
+#include "ROOT/RDF/RSampleInfo.hxx"
 
 #include <functional>
 #include <map>
@@ -122,9 +122,9 @@ class RLoopManager : public RNodeBase {
    /// Registered callbacks to invoke just once before running the loop
    std::vector<RDFInternal::ROneTimeCallback> fCallbacksOnce;
    /// Registered callbacks to call at the beginning of each "data block"
-   std::vector<ROOT::RDF::DataBlockCallback_t> fDataBlockCallbacks;
-   RDFInternal::RDataBlockNotifier fDataBlockNotifier;
-   std::vector<ROOT::RDF::RDataBlockID> fDataBlockIDs;
+   std::vector<ROOT::RDF::SampleCallback_t> fSampleCallbacks;
+   RDFInternal::RNewSampleNotifier fNewSampleNotifier;
+   std::vector<ROOT::RDF::RSampleInfo> fSampleInfos;
    unsigned int fNRuns{0}; ///< Number of event loops run
 
    /// Registry of per-slot value pointers for booked data-source columns
@@ -146,9 +146,9 @@ class RLoopManager : public RNodeBase {
    void CleanUpNodes();
    void CleanUpTask(TTreeReader *r, unsigned int slot);
    void EvalChildrenCounts();
-   void SetupDataBlockCallbacks(TTreeReader *r, unsigned int slot);
-   void UpdateDataBlockID(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range);
-   void UpdateDataBlockID(unsigned int slot, TTreeReader &r);
+   void SetupSampleCallbacks(TTreeReader *r, unsigned int slot);
+   void UpdateSampleInfo(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range);
+   void UpdateSampleInfo(unsigned int slot, TTreeReader &r);
 
 public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
@@ -206,7 +206,7 @@ public:
 
    const ColumnNames_t &GetBranchNames();
 
-   void AddDataBlockCallback(ROOT::RDF::DataBlockCallback_t &&callback);
+   void AddSampleCallback(ROOT::RDF::SampleCallback_t &&callback);
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -147,6 +147,8 @@ class RLoopManager : public RNodeBase {
    void CleanUpTask(TTreeReader *r, unsigned int slot);
    void EvalChildrenCounts();
    void SetupDataBlockCallbacks(TTreeReader *r, unsigned int slot);
+   void UpdateDataBlockID(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range);
+   void UpdateDataBlockID(unsigned int slot, TTreeReader &r);
 
 public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);

--- a/tree/dataframe/inc/ROOT/RDF/RNewSampleNotifier.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RNewSampleNotifier.hxx
@@ -8,8 +8,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_RDF_RDATABLOCKNOTIFIER
-#define ROOT_RDF_RDATABLOCKNOTIFIER
+#ifndef ROOT_RDF_RNEWSAMPLENOTIFIER
+#define ROOT_RDF_RNEWSAMPLENOTIFIER
 
 #include <TNotifyLink.h>
 
@@ -19,7 +19,7 @@ namespace ROOT {
 namespace Internal {
 namespace RDF {
 
-struct RDataBlockFlag {
+struct RNewSampleFlag {
    bool fFlag = false;
 
 public:
@@ -33,20 +33,20 @@ public:
    }
 };
 
-class RDataBlockNotifier {
-   // TNotifyLink and RDataBlockFlags per processing slot
-   std::vector<std::unique_ptr<TNotifyLink<RDataBlockFlag>>> fNotifyLink;
-   std::vector<RDataBlockFlag> fFlags;
+class RNewSampleNotifier {
+   // TNotifyLink and RNewSampleFlags per processing slot
+   std::vector<std::unique_ptr<TNotifyLink<RNewSampleFlag>>> fNotifyLink;
+   std::vector<RNewSampleFlag> fFlags;
 
 public:
-   RDataBlockNotifier(unsigned int nSlots) : fNotifyLink(nSlots), fFlags(nSlots) {}
+   RNewSampleNotifier(unsigned int nSlots) : fNotifyLink(nSlots), fFlags(nSlots) {}
    bool CheckFlag(unsigned int slot) const { return fFlags[slot].CheckFlag(); }
    void SetFlag(unsigned int slot) { fFlags[slot].SetFlag(); }
    void UnsetFlag(unsigned int slot) { fFlags[slot].UnsetFlag(); }
-   TNotifyLink<RDataBlockFlag> &GetChainNotifyLink(unsigned int slot)
+   TNotifyLink<RNewSampleFlag> &GetChainNotifyLink(unsigned int slot)
    {
       if (fNotifyLink[slot] == nullptr)
-         fNotifyLink[slot] = std::make_unique<TNotifyLink<RDataBlockFlag>>(&fFlags[slot]);
+         fNotifyLink[slot] = std::make_unique<TNotifyLink<RNewSampleFlag>>(&fFlags[slot]);
       return *fNotifyLink[slot];
    }
 };

--- a/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
@@ -8,8 +8,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_RDF_RDATABLOCKID
-#define ROOT_RDF_RDATABLOCKID
+#ifndef ROOT_RDF_RSAMPLEINFO
+#define ROOT_RDF_RSAMPLEINFO
 
 #include <ROOT/RStringView.hxx>
 #include <Rtypes.h>
@@ -23,22 +23,22 @@ namespace RDF {
 
 /// This type represents a data-block identifier, to be used in conjunction with RDataFrame features such as
 /// DefinePerSample() and data-block callbacks.
-class RDataBlockID {
+class RSampleInfo {
    // Currently backed by a simple string, might change in the future as we get usage experience.
    std::string fID;
    std::pair<ULong64_t, ULong64_t> fEntryRange;
 
 public:
-   explicit RDataBlockID(std::string_view id, std::pair<ULong64_t, ULong64_t> entryRange)
+   explicit RSampleInfo(std::string_view id, std::pair<ULong64_t, ULong64_t> entryRange)
       : fID(id), fEntryRange(entryRange)
    {
    }
-   RDataBlockID() = default;
-   RDataBlockID(const RDataBlockID &) = default;
-   RDataBlockID &operator=(const RDataBlockID &) = default;
-   RDataBlockID(RDataBlockID &&) = default;
-   RDataBlockID &operator=(RDataBlockID &&) = default;
-   ~RDataBlockID() = default;
+   RSampleInfo() = default;
+   RSampleInfo(const RSampleInfo &) = default;
+   RSampleInfo &operator=(const RSampleInfo &) = default;
+   RSampleInfo(RSampleInfo &&) = default;
+   RSampleInfo &operator=(RSampleInfo &&) = default;
+   ~RSampleInfo() = default;
 
    bool Contains(std::string_view substr) const
    {
@@ -59,13 +59,13 @@ public:
 
    ULong64_t NEntries() const { return fEntryRange.second - fEntryRange.first; }
 
-   bool operator==(const RDataBlockID &other) const { return fID == other.fID; }
-   bool operator!=(const RDataBlockID &other) const { return !(*this == other); }
+   bool operator==(const RSampleInfo &other) const { return fID == other.fID; }
+   bool operator!=(const RSampleInfo &other) const { return !(*this == other); }
 };
 
 /// The type of a data-block callback, registered with a RDataFrame computation graph via e.g.
 /// DefinePerSample() or by certain actions (e.g. Snapshot()).
-using DataBlockCallback_t = std::function<void(unsigned int, const ROOT::RDF::RDataBlockID &)>;
+using SampleCallback_t = std::function<void(unsigned int, const ROOT::RDF::RSampleInfo &)>;
 
 } // namespace RDF
 } // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
@@ -27,7 +27,7 @@ namespace RDF {
 /// When the input data comes from a TTree, the string representation of RSampleInfo (which is returned by AsString()
 /// and that can be queried e.g. with Contains()) is of the form "<filename>/<treename>".
 ///
-/// In multi-thread runs different tasks might process different entry ranges of the same sample,
+/// In multi-thread runs, different tasks might process different entry ranges of the same sample,
 /// so RSampleInfo also provides methods to inspect which part of a sample is being taken into consideration.
 class RSampleInfo {
    // Currently backed by a simple string, might change in the future as we get usage experience.

--- a/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RSampleInfo.hxx
@@ -21,8 +21,14 @@
 namespace ROOT {
 namespace RDF {
 
-/// This type represents a data-block identifier, to be used in conjunction with RDataFrame features such as
-/// DefinePerSample() and data-block callbacks.
+/// This type represents a sample identifier, to be used in conjunction with RDataFrame features such as
+/// DefinePerSample() and per-sample callbacks.
+///
+/// When the input data comes from a TTree, the string representation of RSampleInfo (which is returned by AsString()
+/// and that can be queried e.g. with Contains()) is of the form "<filename>/<treename>".
+///
+/// In multi-thread runs different tasks might process different entry ranges of the same sample,
+/// so RSampleInfo also provides methods to inspect which part of a sample is being taken into consideration.
 class RSampleInfo {
    // Currently backed by a simple string, might change in the future as we get usage experience.
    std::string fID;
@@ -40,23 +46,34 @@ public:
    RSampleInfo &operator=(RSampleInfo &&) = default;
    ~RSampleInfo() = default;
 
+   /// Check whether the sample name contains the given substring.
    bool Contains(std::string_view substr) const
    {
       // C++14 needs the conversion from std::string_view to std::string
       return fID.find(std::string(substr)) != std::string::npos;
    }
 
+   /// Check whether the sample name is empty.
+   ///
+   /// This is the case e.g. when using a RDataFrame with no input data, constructed as `RDataFrame(nEntries)`.
    bool Empty() const {
       return fID.empty();
    }
 
+   /// Return a string representation of the sample name.
+   ///
+   /// The representation is of the form "<filename>/<treename>" if the input data comes from a TTree or a TChain.
    const std::string &AsString() const
    {
       return fID;
    }
 
+   /// Return the entry range in this sample that is being taken into consideration.
+   ///
+   /// Multiple multi-threading tasks might process different entry ranges of the same sample.
    std::pair<ULong64_t, ULong64_t> EntryRange() const { return fEntryRange; }
 
+   /// Return the number of entries of this sample that is being taken into consideration.
    ULong64_t NEntries() const { return fEntryRange.second - fEntryRange.first; }
 
    bool operator==(const RSampleInfo &other) const { return fID == other.fID; }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -624,6 +624,7 @@ std::string PrettyPrintAddr(const void *const addr)
    return s.str();
 }
 
+// Book the jitting of a Filter call
 void BookFilterJit(const std::shared_ptr<RJittedFilter> &jittedFilter,
                    std::shared_ptr<RDFDetail::RNodeBase> *prevNodeOnHeap, std::string_view name,
                    std::string_view expression, const std::map<std::string, std::string> &aliasMap,
@@ -669,7 +670,7 @@ void BookFilterJit(const std::shared_ptr<RJittedFilter> &jittedFilter,
    lm->ToJitExec(filterInvocation.str());
 }
 
-// Jit a Define call
+// Book the jitting of a Define call
 std::shared_ptr<RJittedDefine> BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm,
                                              RDataSource *ds, const RBookedDefines &customCols,
                                              const ColumnNames_t &branches,

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -94,8 +94,8 @@ std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> RJittedAction::GetMergea
    return fConcreteAction->GetMergeableValue();
 }
 
-ROOT::RDF::DataBlockCallback_t RJittedAction::GetDataBlockCallback()
+ROOT::RDF::SampleCallback_t RJittedAction::GetSampleCallback()
 {
    R__ASSERT(fConcreteAction != nullptr);
-   return fConcreteAction->GetDataBlockCallback();
+   return fConcreteAction->GetSampleCallback();
 }

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -94,7 +94,7 @@ std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> RJittedAction::GetMergea
    return fConcreteAction->GetMergeableValue();
 }
 
-std::function<void(unsigned int)> RJittedAction::GetDataBlockCallback()
+ROOT::RDF::DataBlockCallback_t RJittedAction::GetDataBlockCallback()
 {
    R__ASSERT(fConcreteAction != nullptr);
    return fConcreteAction->GetDataBlockCallback();

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -37,6 +37,12 @@ void RJittedDefine::Update(unsigned int slot, Long64_t entry)
    fConcreteDefine->Update(slot, entry);
 }
 
+void RJittedDefine::Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id)
+{
+   R__ASSERT(fConcreteDefine != nullptr);
+   fConcreteDefine->Update(slot, id);
+}
+
 void RJittedDefine::FinaliseSlot(unsigned int slot)
 {
    R__ASSERT(fConcreteDefine != nullptr);

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -620,8 +620,8 @@ void RLoopManager::SetupDataBlockCallbacks(TTreeReader *r, unsigned int slot) {
 }
 
 void RLoopManager::UpdateDataBlockID(unsigned int slot, const std::pair<ULong64_t, ULong64_t> &range) {
-   fDataBlockIDs[slot] =
-      RDataBlockID("Empty source, range: {" + std::to_string(range.first) + ", " + std::to_string(range.second) + "}");
+   fDataBlockIDs[slot] = RDataBlockID(
+      "Empty source, range: {" + std::to_string(range.first) + ", " + std::to_string(range.second) + "}", range);
 }
 
 void RLoopManager::UpdateDataBlockID(unsigned int slot, TTreeReader &r) {
@@ -631,7 +631,15 @@ void RLoopManager::UpdateDataBlockID(unsigned int slot, TTreeReader &r) {
    const std::string treename = ROOT::Internal::TreeUtils::GetTreeFullPaths(*tree)[0];
    auto *file = tree->GetCurrentFile();
    const std::string fname = file != nullptr ? file->GetName() : "#inmemorytree#";
-   fDataBlockIDs[slot] = RDataBlockID(fname + "/" + treename);
+
+
+   std::pair<Long64_t, Long64_t> range = r.GetEntriesRange();
+   R__ASSERT(range.first >= 0);
+   if (range.second == -1) {
+      range.second = tree->GetEntries(); // convert '-1', i.e. 'until the end', to the actual entry number
+   }
+
+   fDataBlockIDs[slot] = RDataBlockID(fname + "/" + treename, range);
 }
 
 /// Initialize all nodes of the functional graph before running the event loop.

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -21,6 +21,7 @@ ROOT_ADD_GTEST(dataframe_splitcoll_arrayview dataframe_splitcoll_arrayview.cxx L
 target_include_directories(dataframe_splitcoll_arrayview PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 ROOT_GENERATE_DICTIONARY(TwoFloatsDict TwoFloats.h MODULE dataframe_splitcoll_arrayview LINKDEF TwoFloatsLinkDef.h OPTIONS -inlineInputHeader)
 ROOT_ADD_GTEST(dataframe_redefine dataframe_redefine.cxx LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_definepersample dataframe_definepersample.cxx LIBRARIES ROOTDataFrame)
 if(NOT MSVC OR win_broken_tests)
   ROOT_ADD_GTEST(dataframe_simple dataframe_simple.cxx LIBRARIES ROOTDataFrame)
   target_include_directories(dataframe_simple PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -40,7 +40,7 @@ ROOT_ADD_GTEST(dataframe_resptr dataframe_resptr.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_take dataframe_take.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_entrylist dataframe_entrylist.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_merge_results dataframe_merge_results.cxx LIBRARIES ROOTDataFrame)
-ROOT_ADD_GTEST(dataframe_datablockcallback dataframe_datablockcallback.cxx CounterHelper.h LIBRARIES ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_samplecallback dataframe_samplecallback.cxx CounterHelper.h LIBRARIES ROOTDataFrame)
 
 if (imt)
    ROOT_ADD_GTEST(dataframe_concurrency dataframe_concurrency.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/CounterHelper.h
+++ b/tree/dataframe/test/CounterHelper.h
@@ -22,9 +22,9 @@ public:
    void Exec(unsigned int) { ++(*fNCalls); }
 #else
    void Exec(unsigned int) {}
-   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final
+   ROOT::RDF::SampleCallback_t GetSampleCallback() final
    {
-      return [this](unsigned int, const ROOT::RDF::RDataBlockID &) mutable { ++(*this->fNCalls); };
+      return [this](unsigned int, const ROOT::RDF::RSampleInfo &) mutable { ++(*this->fNCalls); };
    }
 #endif
    void Finalize() {}

--- a/tree/dataframe/test/CounterHelper.h
+++ b/tree/dataframe/test/CounterHelper.h
@@ -22,9 +22,9 @@ public:
    void Exec(unsigned int) { ++(*fNCalls); }
 #else
    void Exec(unsigned int) {}
-   std::function<void(unsigned int)> GetDataBlockCallback() final
+   ROOT::RDF::DataBlockCallback_t GetDataBlockCallback() final
    {
-      return [this](unsigned int) mutable { ++(*this->fNCalls); };
+      return [this](unsigned int, const ROOT::RDF::RDataBlockID &) mutable { ++(*this->fNCalls); };
    }
 #endif
    void Finalize() {}

--- a/tree/dataframe/test/dataframe_datablockcallback.cxx
+++ b/tree/dataframe/test/dataframe_datablockcallback.cxx
@@ -19,7 +19,7 @@
 // fixture for all tests in this file
 struct RDFDataBlockCallback : ::testing::TestWithParam<bool> {
    unsigned int NSLOTS;
-   unsigned int NENTRIES = std::max(10u, std::thread::hardware_concurrency() * 2);
+   ULong64_t NENTRIES = std::max(10u, std::thread::hardware_concurrency() * 2);
 
    RDFDataBlockCallback() : NSLOTS(GetParam() ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
    {
@@ -62,7 +62,7 @@ TEST_P(RDFDataBlockCallback, EmptySource) {
    ROOT::RDataFrame df(NENTRIES);
    auto result = df.Book<>(CounterHelper(), {});
    // RDF with empty sources tries to produce 2 tasks per slot when MT is enabled
-   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, df.GetNSlots() * 2u) : 1u;
+   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, df.GetNSlots() * 2ull) : 1u;
    EXPECT_EQ(*result, expected);
 }
 
@@ -70,7 +70,7 @@ TEST_P(RDFDataBlockCallback, DataSource) {
    auto df = ROOT::RDF::MakeTrivialDataFrame(NENTRIES);
    auto result = df.Book<>(CounterHelper(), {});
    // RTrivialDS tries to produce NSLOTS tasks
-   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, df.GetNSlots()) : 1u;
+   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, ULong64_t(df.GetNSlots())) : 1ull;
    EXPECT_EQ(*result, expected);
 }
 
@@ -118,51 +118,68 @@ public:
    std::string GetActionName() { return "DataBlockHelper"; }
 };
 
-TEST_P(RDFDataBlockCallback, EmptySourceDataBlockNames) {
+TEST_P(RDFDataBlockCallback, EmptySourceDataBlockID) {
    ROOT::RDataFrame df(NENTRIES);
    auto result = df.Book<>(DataBlockHelper(), {});
    if (ROOT::IsImplicitMTEnabled()) {
       // RDF with empty sources tries to produce 2 tasks per slot when MT is enabled
-      const auto expectedSize = std::min(NENTRIES, df.GetNSlots() * 2u);
+      const auto expectedSize = std::min(NENTRIES, df.GetNSlots() * 2ull);
       ASSERT_EQ(result->size(), expectedSize);
       for (auto &id : *result) {
          // check that all entries start with the expected string
          EXPECT_TRUE(id.AsString().rfind("Empty source, range: {", 0) == 0);
+         EXPECT_EQ(id.NEntries(), NENTRIES / expectedSize);
       }
    } else {
+      ASSERT_EQ(result->size(), 1);
+      const auto &id = result->at(0);
       const std::string expectedStr = "Empty source, range: {0, " + std::to_string(NENTRIES) + "}";
-      EXPECT_EQ(result->at(0).AsString(), expectedStr);
+      EXPECT_EQ(id.AsString(), expectedStr);
+      EXPECT_EQ(id.NEntries(), NENTRIES);
+      EXPECT_EQ(id.EntryRange(), std::make_pair(0ull, NENTRIES));
    }
 }
 
-TEST_P(RDFDataBlockCallback, TTreeDataBlockNames) {
+TEST_P(RDFDataBlockCallback, TTreeDataBlockID) {
    const std::string prefix = "rdfdatablockcallback_ttreedbnames";
    InputFilesRAII file(1u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
    auto result = df.Book<>(DataBlockHelper(), {});
    ASSERT_EQ(result->size(), 1u);
-   EXPECT_TRUE(result->at(0).Contains(prefix));
-   EXPECT_TRUE(result->at(0).AsString().rfind("/t") == result->at(0).AsString().size() - 2);
+   const auto &id = result->at(0);
+   EXPECT_TRUE(id.Contains(prefix));
+   EXPECT_TRUE(id.AsString().rfind("/t") == id.AsString().size() - 2);
+   EXPECT_EQ(id.NEntries(), 1u);
+   EXPECT_EQ(id.EntryRange(), std::make_pair(0ull, 1ull));
 }
 
-TEST_P(RDFDataBlockCallback, TChainDataBlockNames) {
+TEST_P(RDFDataBlockCallback, TChainDataBlockID) {
    const std::string prefix = "rdfdatablockcallback_tchain";
    InputFilesRAII file(5u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
    auto result = df.Book<>(DataBlockHelper(), {});
    ASSERT_EQ(result->size(), 5u);
    std::vector<char> fileNumbers(5);
+   std::vector<std::pair<ULong64_t, ULong64_t>> entryRanges(5);
    for (auto i = 0u; i < 5u; ++i) {
       EXPECT_TRUE(result->at(i).Contains(prefix));
       const auto &id = result->at(i).AsString();
       EXPECT_TRUE(id.rfind("/t") == id.size() - 2);
       fileNumbers[i] = id[id.size() - 8];
+      entryRanges[i] = result->at(i).EntryRange();
    }
 
    std::sort(fileNumbers.begin(), fileNumbers.end());
-   for (int i = 0; i < 5; ++i)
+   std::sort(
+      entryRanges.begin(), entryRanges.end(),
+      [](std::pair<ULong64_t, ULong64_t> p1, std::pair<ULong64_t, ULong64_t> p2) { return p1.first < p2.first; });
+   for (int i = 0; i < 5; ++i) {
       // '0' == 48, '1' == 49, etc.
       EXPECT_EQ(fileNumbers[i], i + 48);
+      // local entry numbers are reported
+      EXPECT_EQ(entryRanges[i].first, 0ull);
+      EXPECT_EQ(entryRanges[i].second, 1ull);
+   }
 }
 
 /* TODO: data-block IDs for RDataSources are not supported yet

--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -1,0 +1,166 @@
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RTrivialDS.hxx>
+#include <TChain.h>
+#include <TSystem.h>
+#include <TTree.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <thread> // std::thread::hardware_concurrency
+
+// fixture for all tests in this file
+struct DefinePerSample : ::testing::TestWithParam<bool> {
+   unsigned int NSLOTS;
+   unsigned int NENTRIES = std::max(10u, std::thread::hardware_concurrency() * 2);
+
+   DefinePerSample() : NSLOTS(GetParam() ? std::min(4u, std::thread::hardware_concurrency()) : 1u)
+   {
+      if (GetParam())
+         ROOT::EnableImplicitMT();
+   }
+
+   ~DefinePerSample()
+   {
+      if (GetParam())
+         ROOT::DisableImplicitMT();
+   }
+};
+
+// A RAII object that ensures existence of nFiles root files named prefix0.root, prefix1.root, ...
+// Each file contains a TTree called "t" with one `int` branch called "x" with sequentially increasing values (0,1,2...)
+struct InputFilesRAII {
+   unsigned int fNFiles = 0;
+   std::string fPrefix;
+
+   InputFilesRAII(unsigned int nFiles, std::string prefix) : fNFiles(nFiles), fPrefix(std::move(prefix))
+   {
+      for (auto i = 0u; i < fNFiles; ++i) {
+         TFile f((fPrefix + std::to_string(i) + ".root").c_str(), "recreate");
+         TTree t("t", "t");
+         t.Branch("x", &i);
+         t.Fill();
+         t.Write();
+      }
+   }
+
+   ~InputFilesRAII()
+   {
+      for (auto i = 0u; i < fNFiles; ++i)
+         gSystem->Unlink((fPrefix + std::to_string(i) + ".root").c_str());
+   }
+};
+
+TEST_P(DefinePerSample, NoJitting)
+{
+   int counter = 0;
+   auto df = ROOT::RDataFrame(NENTRIES).DefinePerSample("x", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &) {
+      ++counter;
+      return 42;
+   });
+   auto xmin = df.Min<int>("x");
+   auto xmax = df.Max<int>("x");
+   EXPECT_EQ(*xmin, 42);
+   EXPECT_EQ(*xmax, 42);
+   // RDF with empty sources tries to produce 2 tasks per slot when MT is enabled
+   const auto expected = ROOT::IsImplicitMTEnabled() ? std::min(NENTRIES, df.GetNSlots() * 2u) : 1u;
+   EXPECT_EQ(counter, expected);
+}
+
+TEST_P(DefinePerSample, Tree)
+{
+   const std::string prefix = "rdfdatablockcallback_ttree";
+   InputFilesRAII file(1u, prefix);
+   ROOT::RDataFrame df("t", prefix + "*");
+
+   int counter = 0;
+   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &) {
+      ++counter;
+      return 42;
+   });
+   auto xmin = df2.Min<int>("y");
+   auto xmax = df2.Max<int>("y");
+   EXPECT_EQ(*xmin, 42);
+   EXPECT_EQ(*xmax, 42);
+   const auto expected = 1u; // as the TTree only contains one cluster, we only have one "data-block"
+   EXPECT_EQ(counter, expected);
+}
+
+TEST_P(DefinePerSample, TChain)
+{
+   const std::string prefix = "rdfdatablockcallback_tchain";
+   InputFilesRAII file(5u, prefix);
+   ROOT::RDataFrame df("t", prefix + "*");
+
+   int counter = 0;
+   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &) {
+      ++counter;
+      return 42;
+   });
+   auto xmin = df2.Min<int>("y");
+   auto xmax = df2.Max<int>("y");
+   EXPECT_EQ(*xmin, 42);
+   EXPECT_EQ(*xmax, 42);
+   const auto expected = 5u; // one "data-block" per tree (because each tree only has one cluster)
+   EXPECT_EQ(counter, expected);
+}
+
+TEST(DefinePerSampleMore, ThrowOnRedefinition)
+{
+   auto df = ROOT::RDataFrame(1)
+                .Define("x", [] { return 42; });
+   EXPECT_THROW(df.DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; }),
+                std::runtime_error);
+}
+
+TEST(DefinePerSampleMore, GetColumnType)
+{
+   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; });
+   EXPECT_EQ(df.GetColumnType("x"), "int");
+}
+
+TEST(DefinePerSampleMore, GetColumnNames)
+{
+   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; });
+   EXPECT_EQ(df.GetColumnNames(), std::vector<std::string>{"x"});
+}
+
+TEST(DefinePerSampleMore, GetDefinedColumnNames)
+{
+   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; });
+   EXPECT_EQ(df.GetDefinedColumnNames(), std::vector<std::string>{"x"});
+}
+
+// TODO
+/*
+
+// Not supported yet
+TEST(DefinePerSample, Jitting)
+{
+   auto df = ROOT::RDataFrame(1).Define("x", [] { return 1; }).Define("y", "1");
+   // Jitted redefine for a non-jitted Define
+   auto rx = df.DefinePerSample("x", "42").Max<int>("x");
+   // Jitted redefine for a jitted Define
+   auto ry = df.DefinePerSample("y", "42").Max<int>("y");
+
+   EXPECT_EQ(*rx, 42);
+   EXPECT_EQ(*ry, 42);
+}
+
+// Not supported yet
+TEST(DefinePerSample, DataSource)
+{
+   ROOT::RDataFrame df(std::make_unique<ROOT::RDF::RTrivialDS>(1));
+   auto r = df.DefinePerSample("col0", [] { return 42; }).Max<int>("col0");
+   EXPECT_EQ(*r, 42);
+}
+
+*/
+
+// instantiate single-thread tests
+INSTANTIATE_TEST_SUITE_P(Seq, DefinePerSample, ::testing::Values(false));
+
+#ifdef R__USE_IMT
+// instantiate multi-thread tests
+INSTANTIATE_TEST_SUITE_P(MT, DefinePerSample, ::testing::Values(true));
+#endif

--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -54,7 +54,7 @@ struct InputFilesRAII {
 TEST_P(DefinePerSample, NoJitting)
 {
    int counter = 0;
-   auto df = ROOT::RDataFrame(NENTRIES).DefinePerSample("x", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &) {
+   auto df = ROOT::RDataFrame(NENTRIES).DefinePerSample("x", [&counter](unsigned int, const ROOT::RDF::RSampleInfo &) {
       ++counter;
       return 42;
    });
@@ -74,7 +74,7 @@ TEST_P(DefinePerSample, Tree)
    ROOT::RDataFrame df("t", prefix + "*");
 
    int counter = 0;
-   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &db) {
+   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RSampleInfo &db) {
       EXPECT_EQ(db.EntryRange(), std::make_pair(0ull, 1ull));
       ++counter;
       return 42;
@@ -94,7 +94,7 @@ TEST_P(DefinePerSample, TChain)
    ROOT::RDataFrame df("t", prefix + "*");
 
    int counter = 0;
-   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &db) {
+   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RSampleInfo &db) {
       EXPECT_EQ(db.EntryRange(), std::make_pair(0ull, 1ull));
       ++counter;
       return 42;
@@ -111,25 +111,25 @@ TEST(DefinePerSampleMore, ThrowOnRedefinition)
 {
    auto df = ROOT::RDataFrame(1)
                 .Define("x", [] { return 42; });
-   EXPECT_THROW(df.DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; }),
+   EXPECT_THROW(df.DefinePerSample("x", [](unsigned, const ROOT::RDF::RSampleInfo &) { return 42; }),
                 std::runtime_error);
 }
 
 TEST(DefinePerSampleMore, GetColumnType)
 {
-   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; });
+   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RSampleInfo &) { return 42; });
    EXPECT_EQ(df.GetColumnType("x"), "int");
 }
 
 TEST(DefinePerSampleMore, GetColumnNames)
 {
-   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; });
+   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RSampleInfo &) { return 42; });
    EXPECT_EQ(df.GetColumnNames(), std::vector<std::string>{"x"});
 }
 
 TEST(DefinePerSampleMore, GetDefinedColumnNames)
 {
-   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RDataBlockID &) { return 42; });
+   auto df = ROOT::RDataFrame(1).DefinePerSample("x", [](unsigned, const ROOT::RDF::RSampleInfo &) { return 42; });
    EXPECT_EQ(df.GetDefinedColumnNames(), std::vector<std::string>{"x"});
 }
 

--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -74,7 +74,8 @@ TEST_P(DefinePerSample, Tree)
    ROOT::RDataFrame df("t", prefix + "*");
 
    int counter = 0;
-   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &) {
+   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &db) {
+      EXPECT_EQ(db.EntryRange(), std::make_pair(0ull, 1ull));
       ++counter;
       return 42;
    });
@@ -93,7 +94,8 @@ TEST_P(DefinePerSample, TChain)
    ROOT::RDataFrame df("t", prefix + "*");
 
    int counter = 0;
-   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &) {
+   auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RDataBlockID &db) {
+      EXPECT_EQ(db.EntryRange(), std::make_pair(0ull, 1ull));
       ++counter;
       return 42;
    });

--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <memory>
 #include <thread> // std::thread::hardware_concurrency
 
@@ -53,7 +54,7 @@ struct InputFilesRAII {
 
 TEST_P(DefinePerSample, NoJitting)
 {
-   int counter = 0;
+   std::atomic_int counter{0};
    auto df = ROOT::RDataFrame(NENTRIES).DefinePerSample("x", [&counter](unsigned int, const ROOT::RDF::RSampleInfo &) {
       ++counter;
       return 42;
@@ -73,7 +74,7 @@ TEST_P(DefinePerSample, Tree)
    InputFilesRAII file(1u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
 
-   int counter = 0;
+   std::atomic_int counter{0};
    auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RSampleInfo &db) {
       EXPECT_EQ(db.EntryRange(), std::make_pair(0ull, 1ull));
       ++counter;
@@ -93,7 +94,7 @@ TEST_P(DefinePerSample, TChain)
    InputFilesRAII file(5u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
 
-   int counter = 0;
+   std::atomic_int counter{0};
    auto df2 = df.DefinePerSample("y", [&counter](unsigned int, const ROOT::RDF::RSampleInfo &db) {
       EXPECT_EQ(db.EntryRange(), std::make_pair(0ull, 1ull));
       ++counter;


### PR DESCRIPTION
This patch adds `df.DefinePerSample`, a method that lets user define
new columns that are only updated per "data-block" rather than per
entry, where a "data-block" is made of several entries that have the
same data-block ID (e.g. that belong to the same TTree in a TChain).

The data-block ID is passed as an argument to the callback, so that
quantities can be defined based on the sample being processed.

Currently a jitted version is not available and RDataSources have
no way to hook into the mechanism (they get one data-block per task
with empty data-block ID). Support for these cases will be added by
later commits.

This resolves #6745.

This PR should make @stwunsch happy.

To do:

- [x] test `RDataBlockID` with entry ranges
- [x] naming: `RDataBlockID -> RDataBlockInfo`? `DefinePerSample -> DefinePerDataBlock`?
- [x] add support for jitted `df.DefinePerSample("myconstant", "rdfdatablock_.Contains(\"MC\") ? 42. : 8.")`
- [ ] add release notes