### PR TITLE
ROOT-R: fixed RExport.h

### DIFF
--- a/bindings/r/inc/RExports.h
+++ b/bindings/r/inc/RExports.h
@@ -50,12 +50,6 @@
 //Some useful typedefs
 typedef std::vector<TString> TVectorString;
 
-
-//added to fix bug in last version of Rcpp on mac
-#if !defined(R_Version)
-#define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
-#endif
-
 #include<RcppCommon.h>
 namespace ROOT {
    namespace R {
@@ -128,6 +122,12 @@ namespace Rcpp {
       } ;
    }
 }
+
+//added to fix bug in last version of Rcpp on mac
+#if !defined(R_Version)
+#define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
+#endif
+
 #include<Rcpp.h>//this headers should be called after templates definitions
 #include<Rcpp/Named.h>
 #undef HAVE_UINTPTR_T


### PR DESCRIPTION

# This Pull request:
fixed https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/2946/LABEL=ROOT-performance-centos8-multicore,SPEC=default,V=master/console

## Changes or fixes:
reverted header RExport.h changed in  https://github.com/root-project/root/commit/4809ef48e9d3cc48bfe5f81f971a5c535b593b39


## Checklist:

- [ X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

 https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/2946/LABEL=ROOT-performance-centos8-multicore,SPEC=default,V=master/console