### PR TITLE
Cleanup lists in workspace destruction

### DIFF
--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -247,6 +247,11 @@ RooWorkspace::~RooWorkspace()
   // WVE named sets too?
 
   _genObjects.Delete() ;
+
+   _embeddedDataList.Delete();
+   _views.Delete();
+   _studyMods.Delete();
+
 }
 
 


### PR DESCRIPTION
# This Pull request:

Some lists weren't being cleared when workspace is deleted, leaking lots of memory. (really only the embedded data list from all the RooHistFuncs)

Would be nice if this change be added to 6.24 and ideally 6.22 too?

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

