### PR TITLE
[clad] Bump clad version to v0.9.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1400,6 +1400,9 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       // Add include path to etc/cling.
       clingArgsStorage.push_back("-I" + interpInclude + "/cling");
 
+      // Add include path to etc/cling.
+      clingArgsStorage.push_back("-I" + interpInclude + "/cling/plugins/include");
+
       // Add the root include directory and etc/ to list searched by default.
       clingArgsStorage.push_back(std::string(("-I" + TROOT::GetIncludeDir()).Data()));
 

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -124,7 +124,7 @@ private:
    void ReInitializeEvalMethod();
    std::string GetGradientFuncName() const {
       assert(fClingName.Length() && "TFormula is not initialized yet!");
-      return std::string(fClingName.Data()) + "_grad";
+      return std::string(fClingName.Data()) + "_grad_1";
    }
    bool HasGradientGenerationFailed() const {
       return !fGradMethod && !fGradGenerationInput.empty();

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -769,8 +769,10 @@ prepareMethod(bool HasParameters, bool HasVariables, const char* FuncName,
       AddDoublePtrParam();
 
    // We need an extra Double_t* for the gradient return result.
-   if (IsGradient)
-      AddDoublePtrParam();
+   if (IsGradient) {
+      prototypeArguments.Append(",");
+      prototypeArguments.Append("clad::array_ref<Double_t>");
+   }
 
    // Initialize the method call using real function name (cling name) defined
    // by ProcessFormula
@@ -3143,10 +3145,11 @@ bool TFormula::GenerateGradientPar()
          std::string GradReqFuncName = GetGradientFuncName() + "_req";
          // We want to call clad::differentiate(TFormula_id);
          fGradGenerationInput = std::string("#pragma cling optimize(2)\n") +
-            "#pragma clad ON\n" +
-            "void " + GradReqFuncName + "() {\n" +
-            "clad::gradient(" + std::string(fClingName.Data()) + ");\n }\n" +
-            "#pragma clad OFF";
+             "#pragma clad ON\n" +
+             "void " + GradReqFuncName + "() {\n" +
+             "clad::gradient(" + std::string(fClingName.Data())
+             + ", \"p\");\n }\n" +
+             "#pragma clad OFF";
 
          if (!gInterpreter->Declare(fGradGenerationInput.c_str()))
             return false;
@@ -3211,13 +3214,24 @@ void TFormula::GradientPar(const Double_t *x, Double_t *result)
       // __attribute__((used)) extern "C" void __cf_0(void* obj, int nargs, void** args, void* ret)
       // {
       //    ((void (&)(double*, double*,
-      //               double*))TFormula____id_grad)(*(double**)args[0], *(double**)args[1],
-      //                                                                 *(double**)args[2]);
+      //               clad::array_ref<double>))TFormula____id_grad_1)(*(double**)args[0],
+      //                                                             *(double**)args[1],
+      //                                                             *(clad::array_ref<double> *)args[2]);
       //    return;
       // }
       const double *pars = fClingParameters.data();
       args[1] = &pars;
-      args[2] = &result;
+
+      // Using the interpreter to obtain the pointer to clad::array_ref is too
+      // slow and we do not want to expose clad::array_ref to the interpreter
+      // so this struct acts as a lightweight implementation of it
+      struct array_ref_interface {
+        Double_t *arr;
+        std::size_t size;
+      };
+
+      array_ref_interface ari{result, static_cast<size_t>(fNpar)};
+      args[2] = &ari;
       (*fGradFuncPtr)(0, 3, args, /*ret*/nullptr); // We do not use ret in a return-void func.
    }
 }
@@ -3537,7 +3551,9 @@ TString TFormula::GetExpFormula(Option_t *option) const
 
 TString TFormula::GetGradientFormula() const {
    std::unique_ptr<TInterpreterValue> v = gInterpreter->MakeInterpreterValue();
-   gInterpreter->Evaluate(GetGradientFuncName().c_str(), *v);
+   std::string s("(void (&)(Double_t *, Double_t *, clad::array_ref<Double_t>)) ");
+   s += GetGradientFuncName();
+   gInterpreter->Evaluate(s.c_str(), *v);
    return v->ToString();
 }
 

--- a/interpreter/cling/tools/plugins/clad/CMakeLists.txt
+++ b/interpreter/cling/tools/plugins/clad/CMakeLists.txt
@@ -66,7 +66,7 @@ list(APPEND _clad_cmake_logging_settings LOG_OUTPUT_ON_FAILURE ON)
 ExternalProject_Add(
   clad
   GIT_REPOSITORY https://github.com/vgvassilev/clad.git
-  GIT_TAG v0.8
+  GIT_TAG v0.9
   UPDATE_COMMAND ""
   CMAKE_ARGS -G ${CMAKE_GENERATOR}
              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}


### PR DESCRIPTION
This new release includes some improvements:
* Extended array support
* Add cmake variables to control the locations where find_package discovers LLVM and Clang: `LLVM_CONFIG_EXTRA_PATH_HINTS` and `Clang_CONFIG_EXTRA_PATH_HINTS` respectively.

See more at: https://github.com/vgvassilev/clad/blob/v0.9/docs/ReleaseNotes.md