### PR TITLE
Improve the FindArrow warning workaround

### DIFF
--- a/cmake/modules/FindArrow.cmake
+++ b/cmake/modules/FindArrow.cmake
@@ -203,7 +203,9 @@ endmacro()
 #
 # Find package by CMake package configuration.
 macro(arrow_find_package_cmake_package_configuration)
-  find_package(${cmake_package_name} CONFIG)
+  # the QUIET option is a workaround to silence some cmake warnings coming from FindArrow.cmake when it
+  # looks for transitive dependencies, see also https://issues.apache.org/jira/browse/ARROW-11890
+  find_package(${cmake_package_name} CONFIG QUIET)
   if(${cmake_package_name}_FOUND)
     set(${prefix}_USE_CMAKE_PACKAGE_CONFIG TRUE PARENT_SCOPE)
     if(TARGET ${target_shared})

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -14,13 +14,7 @@ string(REPLACE "-Werror " "" ROOT_EXTERNAL_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 
 macro(find_package)
   if(NOT "${ARGV0}" IN_LIST ROOT_BUILTINS)
-    # this is a workaround to silence some cmake warnings coming from FindArrow.cmake when it
-    # looks for transitive dependencies, see also https://issues.apache.org/jira/browse/ARROW-11890
-    if("${ARGV0}" MATCHES "c-ares" OR "${ARGV0}" MATCHES "re2")
-      _find_package(${ARGV} QUIET)
-    else()
-      _find_package(${ARGV})
-    endif()
+    _find_package(${ARGV})
   endif()
 endmacro()
 


### PR DESCRIPTION
Move the `QUIET` option in `find_package` from `SearchInstalledSoftware.cmake` to `FindArrow.cmake`. Thanks to Guilherme Amadio for the suggestion.