### PR TITLE
[GSoC][TMVA][SOFIE] Fix protobuf

### DIFF
--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -20,19 +20,20 @@ protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "${SOFIE_PARSERS_DIR}/onnx_proto3")
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
 
 add_executable(emitFromONNX
-	EmitFromONNX.cxx
-	../src/SOFIE_common.cxx
-	../src/RModel.cxx
-	${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
-	${PROTO_SRCS}
+   EmitFromONNX.cxx
+   ../src/SOFIE_common.cxx
+   ../src/RModel.cxx
+   ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
+   ${PROTO_SRCS}
 )
 target_include_directories(emitFromONNX PRIVATE
-  ../inc
-  ${SOFIE_PARSERS_DIR}/inc
-  ../../tmva/inc
-  ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
-  ../../../core/foundation/inc
-  ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
+   ../inc
+   ${SOFIE_PARSERS_DIR}/inc
+   ../../tmva/inc
+   ${Protobuf_INCLUDE_DIRS}
+   ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
+   ../../../core/foundation/inc
+   ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 
 target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie)
@@ -68,19 +69,20 @@ add_dependencies(TestCustomModelsFromONNX SofieCompileModels_ONNX)
 
 #For testing serialisation of RModel object
 add_executable(emitFromROOT
-	EmitFromRoot.cxx
-	../src/SOFIE_common.cxx
-	../src/RModel.cxx
-	${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
-	${PROTO_SRCS}
+   EmitFromRoot.cxx
+   ../src/SOFIE_common.cxx
+   ../src/RModel.cxx
+   ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
+   ${PROTO_SRCS}
 )
 target_include_directories(emitFromROOT PRIVATE
-  ../inc
-  ${SOFIE_PARSERS_DIR}/inc
-  ../../tmva/inc
-  ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
-  ../../../core/foundation/inc
-  ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
+   ../inc
+   ${SOFIE_PARSERS_DIR}/inc
+   ../../tmva/inc
+   ${Protobuf_INCLUDE_DIRS}
+   ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
+   ../../../core/foundation/inc
+   ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie)
 set_target_properties(emitFromROOT PROPERTIES

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -10,7 +10,7 @@
 ############################################################################
 
 
-set(SOFIE_PARSERS_DIR ../../sofie_parsers)
+set(SOFIE_PARSERS_DIR ${CMAKE_SOURCE_DIR}/tmva/sofie_parsers)
 
 if (NOT ONNX_MODELS_DIR)
   set(ONNX_MODELS_DIR input_models)
@@ -21,18 +21,18 @@ set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRU
 
 add_executable(emitFromONNX
    EmitFromONNX.cxx
-   ../src/SOFIE_common.cxx
-   ../src/RModel.cxx
+   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
+   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
    ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
    ${PROTO_SRCS}
 )
 target_include_directories(emitFromONNX PRIVATE
-   ../inc
+   ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
    ${SOFIE_PARSERS_DIR}/inc
-   ../../tmva/inc
+   ${CMAKE_SOURCE_DIR}/tmva/inc
    ${Protobuf_INCLUDE_DIRS}
    ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
-   ../../../core/foundation/inc
+   ${CMAKE_SOURCE_DIR}/core/foundation/inc
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 
@@ -70,18 +70,18 @@ add_dependencies(TestCustomModelsFromONNX SofieCompileModels_ONNX)
 #For testing serialisation of RModel object
 add_executable(emitFromROOT
    EmitFromRoot.cxx
-   ../src/SOFIE_common.cxx
-   ../src/RModel.cxx
+   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
+   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
    ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
    ${PROTO_SRCS}
 )
 target_include_directories(emitFromROOT PRIVATE
-   ../inc
+   ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
    ${SOFIE_PARSERS_DIR}/inc
-   ../../tmva/inc
+   ${CMAKE_SOURCE_DIR}/tmva/inc
    ${Protobuf_INCLUDE_DIRS}
    ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
-   ../../../core/foundation/inc
+   ${CMAKE_SOURCE_DIR}/core/foundation/inc
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie)


### PR DESCRIPTION
# This Pull request:
Fixes `fatal error: 'google/protobuf/port_def.inc' file not found` error when building the tests of TMVA-Sofie with protobuf v3.17.3.

## Checklist:

- [ x] tested changes locally