### PR TITLE
Silent a couple of potential CMake Warnings

### DIFF
--- a/cmake/modules/FindArrow.cmake
+++ b/cmake/modules/FindArrow.cmake
@@ -203,7 +203,9 @@ endmacro()
 #
 # Find package by CMake package configuration.
 macro(arrow_find_package_cmake_package_configuration)
-  find_package(${cmake_package_name} CONFIG)
+  # the QUIET option is a workaround to silence some cmake warnings coming from FindArrow.cmake when it
+  # looks for transitive dependencies, see also https://issues.apache.org/jira/browse/ARROW-11890
+  find_package(${cmake_package_name} CONFIG QUIET)
   if(${cmake_package_name}_FOUND)
     set(${prefix}_USE_CMAKE_PACKAGE_CONFIG TRUE PARENT_SCOPE)
     if(TARGET ${target_shared})


### PR DESCRIPTION
Silent the following warnings when enabling arrow (`-Darrow=ON`) on Ubuntu:
```
CMake Warning at cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package):
  By not providing "Findre2.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "re2", but
  CMake did not find one.

  Could not find a package configuration file provided by "re2" with any of
  the following names:

    re2Config.cmake
    re2-config.cmake

  Add the installation prefix of "re2" to CMAKE_PREFIX_PATH or set "re2_DIR"
  to a directory containing one of the above files.  If "re2" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/arrow/Findre2Alt.cmake:25 (find_package)
  cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package)
  /usr/share/cmake-3.16/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/lib/x86_64-linux-gnu/cmake/arrow/ArrowConfig.cmake:96 (find_dependency)
  cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package)
  cmake/modules/FindArrow.cmake:206 (find_package)
  cmake/modules/FindArrow.cmake:313 (arrow_find_package_cmake_package_configuration)
  cmake/modules/FindArrow.cmake:350 (arrow_find_package)
  cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package)
  cmake/modules/SearchInstalledSoftware.cmake:1088 (find_package)
  CMakeLists.txt:245 (include)
```
and
```
CMake Warning at cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package):
  By not providing "Findc-ares.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "c-ares", but
  CMake did not find one.

  Could not find a package configuration file provided by "c-ares" with any
  of the following names:

    c-aresConfig.cmake
    c-ares-config.cmake

  Add the installation prefix of "c-ares" to CMAKE_PREFIX_PATH or set
  "c-ares_DIR" to a directory containing one of the above files.  If "c-ares"
  provides a separate development package or SDK, be sure it has been
  installed.
Call Stack (most recent call first):
  /usr/lib/x86_64-linux-gnu/cmake/arrow/Findc-aresAlt.cmake:25 (find_package)
  cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package)
  /usr/share/cmake-3.16/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/lib/x86_64-linux-gnu/cmake/arrow/ArrowConfig.cmake:96 (find_dependency)
  cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package)
  cmake/modules/FindArrow.cmake:206 (find_package)
  cmake/modules/FindArrow.cmake:313 (arrow_find_package_cmake_package_configuration)
  cmake/modules/FindArrow.cmake:350 (arrow_find_package)
  cmake/modules/SearchInstalledSoftware.cmake:20 (_find_package)
  cmake/modules/SearchInstalledSoftware.cmake:1088 (find_package)
  CMakeLists.txt:245 (include)
```
