### PR TITLE
[RF][PyROOT] New mechanism for documentation of RooFit pythonizations

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
@@ -117,7 +117,7 @@ def get_defined_attributes(klass, consider_base_classes=False):
     blacklist = ["__dict__", "__doc__", "__hash__", "__module__", "__weakref__"]
 
     if not consider_base_classes:
-        return [attr for attr in klass.__dict__.keys() if attr not in blacklist]
+        return sorted([attr for attr in klass.__dict__.keys() if attr not in blacklist])
 
     # get a list of this class and all its base classes, excluding `object`
     method_resolution_order = klass.mro()
@@ -137,7 +137,7 @@ def get_defined_attributes(klass, consider_base_classes=False):
 
         return in_any_dict
 
-    return [attr for attr in dir(klass) if is_defined(attr)]
+    return sorted([attr for attr in dir(klass) if is_defined(attr)])
 
 
 def rebind_instancemethod(to_class, from_class, func_name):

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabspdf.py
@@ -10,44 +10,33 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-r"""
-/**
-\class RooAbsPdf
-\brief \parblock \endparblock
-\htmlonly
-<div class="pyrootbox">
-\endhtmlonly
-
-## PyROOT
-
-Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
-So far, this applies to RooAbsPdf::fitTo, RooAbsPdf::plotOn, RooAbsPdf::generate, RooAbsPdf::paramOn, RooAbsPdf::createCdf,
-RooAbsPdf::generateBinned, RooAbsPdf::createChi2, RooAbsPdf::prepareMultiGen and RooAbsPdf::createNLL.
-For example, the following code is equivalent in PyROOT:
-\code{.py}
-# Directly passing a RooCmdArg:
-pdf.fitTo(data, ROOT.RooFit.Range("r1"))
-
-# With keyword arguments:
-pdf.fitTo(data, Range="r1")
-\endcode
-
-\htmlonly
-</div>
-\endhtmlonly
-*/
-"""
 
 from ._rooabsreal import RooAbsReal
 from ._utils import _kwargs_to_roocmdargs
 
 
 class RooAbsPdf(RooAbsReal):
+
+    _doxygen = """Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
+    So far, this applies to RooAbsPdf::fitTo, RooAbsPdf::plotOn, RooAbsPdf::generate, RooAbsPdf::paramOn, RooAbsPdf::createCdf,
+    RooAbsPdf::generateBinned, RooAbsPdf::createChi2, RooAbsPdf::prepareMultiGen and RooAbsPdf::createNLL.
+    For example, the following code is equivalent in PyROOT:
+    \code{.py}
+    # Directly passing a RooCmdArg:
+    pdf.fitTo(data, ROOT.RooFit.Range("r1"))
+
+    # With keyword arguments:
+    pdf.fitTo(data, Range="r1")
+    \endcode"""
+
     def fitTo(self, *args, **kwargs):
         # Redefinition of `RooAbsPdf.fitTo` for keyword arguments.
         # The keywords must correspond to the CmdArg of the `fitTo` function.
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         return self._fitTo(*args, **kwargs)
+
+    fitTo._cpp_signature = "RooAbsPdf::fitTo(RooAbsData&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)"
+    fitTo._doxygen = """The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization."""
 
     def plotOn(self, *args, **kwargs):
         # Redefinition of `RooAbsPdf.plotOn` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabspdf.py
@@ -12,12 +12,11 @@
 
 
 from ._rooabsreal import RooAbsReal
-from ._utils import _kwargs_to_roocmdargs
+from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooAbsPdf(RooAbsReal):
-
-    _doxygen = """Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
+    """Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooAbsPdf::fitTo, RooAbsPdf::plotOn, RooAbsPdf::generate, RooAbsPdf::paramOn, RooAbsPdf::createCdf,
     RooAbsPdf::generateBinned, RooAbsPdf::createChi2, RooAbsPdf::prepareMultiGen and RooAbsPdf::createNLL.
     For example, the following code is equivalent in PyROOT:
@@ -29,14 +28,15 @@ class RooAbsPdf(RooAbsReal):
     pdf.fitTo(data, Range="r1")
     \endcode"""
 
+    @cpp_signature(
+        "RooAbsPdf::fitTo(RooAbsData&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)"
+    )
     def fitTo(self, *args, **kwargs):
-        # Redefinition of `RooAbsPdf.fitTo` for keyword arguments.
-        # The keywords must correspond to the CmdArg of the `fitTo` function.
+        """This function is pythonized with the command argument pythonization.
+        The keywords must correspond to the CmdArgs of the RooAbsPdf::fitTo() function.
+        """
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         return self._fitTo(*args, **kwargs)
-
-    fitTo._cpp_signature = "RooAbsPdf::fitTo(RooAbsData&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)"
-    fitTo._doxygen = """The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization."""
 
     def plotOn(self, *args, **kwargs):
         # Redefinition of `RooAbsPdf.plotOn` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_utils.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_utils.py
@@ -185,3 +185,15 @@ def _decaytype_string_to_enum(caller, kwargs):
                 raise exception
 
     return kwargs
+
+
+def cpp_signature(sig):
+    """Decorator to set the `_cpp_signature` attribute of a function.
+    This information can be used to generate the documentation.
+    """
+
+    def decorator(func):
+        func._cpp_signature = sig
+        return func
+
+    return decorator

--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -41,6 +41,7 @@ images:
 
 pyzdoc:
 	$(PYTHON_EXECUTABLE) extract_docstrings.py $(PYZ_DIR)
+	$(PYTHON_EXECUTABLE) print_roofit_pyz_doctrings.py > $(PYZ_DIR)/_roofit.pyzdoc
 
 doxygen: filter pyzdoc
 	$(call MkDir,$(DOXYGEN_OUTPUT_DIRECTORY))

--- a/documentation/doxygen/print_roofit_pyz_doctrings.py
+++ b/documentation/doxygen/print_roofit_pyz_doctrings.py
@@ -1,0 +1,124 @@
+# -------------------------------------------------------------------------------
+#  Author: Jonas Rembser <jonas.rembser@cern.ch> CERN
+# -------------------------------------------------------------------------------
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+# Creates the doxygen documentation for the RooFit pythonizations, which includes:
+#   - a PyROOT box for each pythonized class or member function
+#   - a separate page for the RoofitPythonizations group where all the RooFit
+#     pythonization documentation is aggregated
+
+import inspect
+
+
+def write_pyroot_block_for_class(klass):
+
+    if not hasattr(klass, "_doxygen"):
+        return
+
+    print("\class " + klass.__name__)
+    print("\\brief \parblock \endparblock")
+    print("\htmlonly")
+    print('<div class="pyrootbox">')
+    print("\endhtmlonly")
+    print("## PyROOT")
+
+    print(inspect.cleandoc(klass._doxygen))
+
+    print("\htmlonly")
+    print("</div>")
+    print("\endhtmlonly")
+    print("")
+
+
+def write_pyroot_block_for_member_func(func):
+
+    if not hasattr(func, "_doxygen") or not hasattr(func, "_cpp_signature"):
+        return
+
+    print("\\fn " + func._cpp_signature)
+    print("\\brief \parblock \endparblock")
+    print("\htmlonly")
+    print('<div class="pyrootbox">')
+    print("\endhtmlonly")
+    print("## PyROOT")
+
+    print(inspect.cleandoc(func._doxygen))
+
+    print("\htmlonly")
+    print("</div>")
+    print("\endhtmlonly")
+    print("")
+
+
+if __name__ == "__main__":
+
+    import ROOT.pythonization as pyz
+
+    # Fill separate RooFit pythonization page, starting with the introduction and table of contents...
+    print("/**")
+    print("\defgroup RoofitPythonizations")
+    print("\ingroup Roofitmain")
+    print("# RooFit pythonizations")
+    for python_klass in pyz._roofit.python_classes:
+        if not hasattr(python_klass, "_doxygen"):
+            continue
+        class_name = python_klass.__name__
+        print("- [" + class_name + "](\\ref _" + class_name.lower() + ")")
+
+        func_names = pyz._roofit.get_defined_attributes(python_klass)
+
+        for func_name in func_names:
+            func = getattr(python_klass, func_name)
+            if not hasattr(func, "_doxygen"):
+                continue
+            print("  - [" + func.__name__ + "](\\ref _" + (python_klass.__name__ + "_" + func.__name__).lower() + ")")
+
+    print("")
+
+    # ...and then iterating over all pythonized classes and functions
+    for python_klass in pyz._roofit.python_classes:
+        if not hasattr(python_klass, "_doxygen"):
+            continue
+
+        print("\\anchor _" + python_klass.__name__.lower())
+        print("## " + python_klass.__name__)
+        print("\see " + python_klass.__name__)
+        print("")
+        print(inspect.cleandoc(python_klass._doxygen))
+        print("")
+
+        func_names = pyz._roofit.get_defined_attributes(python_klass)
+
+        for func_name in func_names:
+            func = getattr(python_klass, func_name)
+            if not hasattr(func, "_doxygen"):
+                continue
+            print("\\anchor _" + (python_klass.__name__ + "_" + func.__name__).lower())
+            print("### " + python_klass.__name__ + "." + func.__name__)
+            print(inspect.cleandoc(func._doxygen))
+            print("")
+            if hasattr(func, "_cpp_signature"):
+                print("\see " + func._cpp_signature)
+            print("")
+    print("")
+
+    # Add PyROOT blocks to existing documentation
+    for python_klass in pyz._roofit.python_classes:
+
+        write_pyroot_block_for_class(python_klass)
+
+        func_names = pyz._roofit.get_defined_attributes(python_klass)
+
+        for func_name in func_names:
+            func = getattr(python_klass, func_name)
+            write_pyroot_block_for_member_func(func)
+
+    print("*/")


### PR DESCRIPTION
For the documentation of the RooFit pythonizations, we wanted to realize
two things:

  * A PyROOT block in the doxygen documentation of the C++ class,
    indicating the pythonizations for a given class or function

  * A new doxygen page with only the content of all the RooFit PyROOT
    blocks to have a one-stop place to learn everything about RooFit
    pythonizations

This commit proposes a new mechanism to do this, based on the existing
RooFit pythonization mirror class infrastructure:

  * Every class or member function that should get a PyROOT block gets
    an can be patched with an attribute `_doxygen`, containing the
    contents of the PyROOT block
  * Member functions can also be patched with the attribute
    `cpp_signature`, specifying the C++ overload where the PyROOT block
    should go
  * A new scipt `print_roofit_pyz_doctrings.py` extracts this
    information, and this script is used to create a file
    `_roofit.pyzdoc` with all the doxygen source to generate both the
    PyROOT blocks in the existing documentation, as well as the separate
    page about all the RooFit pythonizations

This is how the RooFit pythonization page would look like with this PR:

![Screenshot_2021-08-17_15-06-40](https://user-images.githubusercontent.com/6578603/129736827-e2aadfe5-2893-48c0-a7e9-2549a136cd68.png)

Writing all the documentation will be done in later PRs by @Harshalzzzzzzz , this PR is just to set up the infrastructure.