### PR TITLE
Support TChain with different subtrees in distributed RDF

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -121,11 +121,11 @@ class BaseBackend(ABC):
         computation_graph_callable = generator.get_callable()
 
         if isinstance(headnode, TreeHeadNode):
-            treename = headnode.treename
+            maintreename = headnode.maintreename
             defaultbranches = headnode.defaultbranches
         else:
             # Only other head node type is EmptySourceHeadNode at the moment
-            treename = None
+            maintreename = None
             nentries = headnode.nentries
 
         # Avoid having references to the instance inside the mapper
@@ -157,24 +157,24 @@ class BaseBackend(ABC):
             # environment
             initialization()
 
-            if treename is not None:
+            if maintreename is not None:
                 # Build TEntryList for this range:
                 elists = ROOT.TEntryList()
 
                 # Build TChain of files for this range:
-                chain = ROOT.TChain(treename)
-                for start, end, filename, treenentries in zip(current_range.localstarts, current_range.localends,
-                                                              current_range.filelist, current_range.treesnentries):
+                chain = ROOT.TChain(maintreename)
+                for start, end, filename, treenentries, subtreename in zip(current_range.localstarts, current_range.localends,
+                                                              current_range.filelist, current_range.treesnentries, current_range.treenames):
                     # Use default constructor of TEntryList rather than the
                     # constructor accepting treename and filename, otherwise
                     # the TEntryList would remove any url or protocol from the
                     # file name.
                     elist = ROOT.TEntryList()
-                    elist.SetTreeName(treename)
+                    elist.SetTreeName(subtreename)
                     elist.SetFileName(filename)
                     elist.EnterRange(start, end)
                     elists.AddSubList(elist)
-                    chain.Add(filename, treenentries)
+                    chain.Add(filename + "?#" + subtreename, treenentries)
 
                 # We assume 'end' is exclusive
                 chain.SetCacheEntryRange(current_range.globalstart, current_range.globalend)

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -174,11 +174,10 @@ class TreeHeadNode(Node.Node):
             if len(args) == 3:
                 self.defaultbranches = args[2]
 
-        # Retrieve treename and inputfiles to retrieve cluster list later
-        # TODO: We are still assuming that treename is unique for the whole
-        # dataset even when we're dealing with a TChain. This is wrong and needs
-        # to be fixed, see https://github.com/root-project/root/issues/8750
-        self.treename = ROOT.Internal.TreeUtils.GetTreeFullPaths(self.tree)[0]
+        # maintreename: name of the tree or main name of the chain
+        self.maintreename = self.tree.GetName()
+        # subtreenames: names of all subtrees in the chain or full path to the tree in the file it belongs to
+        self.subtreenames = [str(treename) for treename in ROOT.Internal.TreeUtils.GetTreeFullPaths(self.tree)]
         self.inputfiles = [str(filename) for filename in ROOT.Internal.TreeUtils.GetFileNamesFromTree(self.tree)]
 
     def build_ranges(self):
@@ -189,11 +188,13 @@ class TreeHeadNode(Node.Node):
                 ("Cannot build a distributed RDataFrame with zero entries. "
                  "Distributed computation will fail. "))
 
-        logger.debug("Building ranges for tree %s with the "
-                     "following input files:\n%s", self.treename, self.inputfiles)
+        logger.debug("Building ranges from dataset info:\n"
+                     "main treename: %s\n"
+                     "names of subtrees: %s\n"
+                     "input files: %s\n", self.maintreename, self.subtreenames, self.inputfiles)
 
         # Retrieve a tuple of clusters for all files of the tree
-        clustersinfiles = Ranges.get_clusters(self.treename, self.inputfiles)
+        clustersinfiles = Ranges.get_clusters(self.subtreenames, self.inputfiles)
         numclusters = len(clustersinfiles)
 
         # TODO: This shouldn't be triggered if len(clustersinfiles) == 1. The

--- a/bindings/experimental/distrdf/test/test_buildranges.py
+++ b/bindings/experimental/distrdf/test/test_buildranges.py
@@ -1,7 +1,8 @@
+import unittest
+import warnings
+
 from DistRDF.HeadNode import get_headnode
 from DistRDF import Ranges
-import warnings
-import unittest
 
 
 def emptysourceranges_to_tuples(ranges):
@@ -113,10 +114,10 @@ class BuildRangesTest(unittest.TestCase):
 
         """
 
-        treename = "TotemNtuple"
-        filelist = ["backend/Slimmed_ntuple.root"]
+        treenames = ["TotemNtuple"]
+        filenames = ["backend/Slimmed_ntuple.root"]
         npartitions = 1
-        clustersinfiles = Ranges.get_clusters(treename, filelist)
+        clustersinfiles = Ranges.get_clusters(treenames, filenames)
         friendinfo = None
 
         crs = Ranges.get_clustered_ranges(clustersinfiles, npartitions, friendinfo)

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -86,7 +86,7 @@ class DataFrameConstructorTests(unittest.TestCase):
         hn_3 = create_dummy_headnode("treename", reqd_vec)
 
         for hn in (hn_1, hn_2, hn_3):
-            self.assertEqual(hn.treename, "treename")
+            self.assertEqual(hn.maintreename, "treename")
 
         self.assertListEqual(hn_1.inputfiles, ["file.root"])
         self.assertListEqual(hn_2.inputfiles, rdf_2_files)
@@ -110,7 +110,7 @@ class DataFrameConstructorTests(unittest.TestCase):
         hn_2 = create_dummy_headnode("treename", "file.root", reqd_vec)
 
         for hn in (hn_1, hn_2):
-            self.assertEqual(hn.treename, "treename")
+            self.assertEqual(hn.maintreename, "treename")
             self.assertListEqual(hn.inputfiles, ["file.root"])
 
         self.assertListEqual(hn_1.defaultbranches, rdf_branches)
@@ -149,7 +149,7 @@ class DataFrameConstructorTests(unittest.TestCase):
         hn_4 = create_dummy_headnode("treename", reqd_files_vec, reqd_branches_vec)
 
         for hn in (hn_1, hn_2, hn_3, hn_4):
-            self.assertEqual(hn.treename, "treename")
+            self.assertEqual(hn.maintreename, "treename")
             self.assertListEqual(hn.inputfiles, rdf_files)
             self.assertListEqual(list(hn.defaultbranches), rdf_branches)
 


### PR DESCRIPTION
Fixes #8750 

To support this usecase we need to send the distributed workers also the names of the subtrees in the main chain. At this point we might want to think of a bit of a reworking of the data structures like  `ChainCluster` and `FileAndIndex`, plus I would like to make the function `get_clusters` return less redundant info (currently each cluster also reports the name of the file, the name of the tree and the number of entries which are all the same for clusters belonging to the same file). These improvements are left for the next PR.