### PR TITLE
Fix issue with Redefine, expand test coverage

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -119,6 +119,8 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
       if (!fIsInitialized[slot]) {
+         for (auto &define : fDefines.GetColumns())
+            define.second->InitSlot(r, slot);
          fIsInitialized[slot] = true;
          RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fDSValuePtrs, fDataSource};
          fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);

--- a/tree/dataframe/test/dataframe_redefine.cxx
+++ b/tree/dataframe/test/dataframe_redefine.cxx
@@ -139,7 +139,7 @@ TEST(Redefine, OriginalDefineAsInputJitted)
 {
    auto r = ROOT::RDataFrame(1)
                .Define("x", [] { return 1; })
-               .Redefine("x", [](int x) { return x * 42; }, {"x"})
+               .Redefine("x", "x*42")
                .Max<int>("x");
    EXPECT_EQ(*r, 42);
 }

--- a/tree/dataframe/test/dataframe_redefine.cxx
+++ b/tree/dataframe/test/dataframe_redefine.cxx
@@ -129,7 +129,7 @@ TEST(Redefine, OriginalBranchAsInputJitted)
 TEST(Redefine, OriginalDefineAsInput)
 {
    auto r = ROOT::RDataFrame(1)
-               .Define("x", [] { return 1; })
+               .Define("x", [] (ULong64_t e) { return int(e + 1); }, {"rdfentry_"})
                .Redefine("x", [](int x) { return x * 42; }, {"x"})
                .Max<int>("x");
    EXPECT_EQ(*r, 42);


### PR DESCRIPTION
Before the introduction of `Redefine`, `RDefine::InitSlot` did not
recursively call `InitSlot` on its table of defined columns because
it was guaranteed that some other action of filter would do it if
that defined column was ever to be used.

With the introduction of `Redefine`, the only user of a `RDefine`
might be another `RDefine` (`RDefine` serves as the workhorse of both
`Define`s and `Redefine`s), so we have to trigger the recursive call
to `InitSlot` from `RDefine` as well.

This PR fixes #8857 .

