### PR TITLE
Remove some remaining underscores in friend_info attributes

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -184,8 +184,8 @@ class BaseBackend(ABC):
 
                 # Gather information about friend trees. Check that we got an
                 # RFriendInfo struct and that it's not empty
-                if (current_range.friend_info is not None and
-                    not current_range.friend_info.fFriendNames.empty()):
+                if (current_range.friendinfo is not None and
+                    not current_range.friendinfo.fFriendNames.empty()):
                     # Zip together the information about friend trees. Each
                     # element of the iterator represents a single friend tree.
                     # If the friend is a TChain, the zipped information looks like:
@@ -194,12 +194,12 @@ class BaseBackend(ABC):
                     # only one filename and the list of names of the sub trees
                     # is empty, so the zipped information looks like:
                     # (name, alias), (filename.root, ), ()
-                    zipped_friend_info = zip(
-                        current_range.friend_info.fFriendNames,
-                        current_range.friend_info.fFriendFileNames,
-                        current_range.friend_info.fFriendChainSubNames
+                    zipped_friendinfo = zip(
+                        current_range.friendinfo.fFriendNames,
+                        current_range.friendinfo.fFriendFileNames,
+                        current_range.friendinfo.fFriendChainSubNames
                     )
-                    for (friend_name, friend_alias), friend_filenames, friend_chainsubnames in zipped_friend_info:
+                    for (friend_name, friend_alias), friend_filenames, friend_chainsubnames in zipped_friendinfo:
                         # Start a TChain with the current friend treename
                         friend_chain = ROOT.TChain(str(friend_name))
                         # Add each corresponding file to the TChain

--- a/bindings/experimental/distrdf/python/DistRDF/Ranges.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Ranges.py
@@ -62,12 +62,12 @@ class TreeRange(object):
     treesnentries (list[int]): List of total number of entries relative to each
         single file in this range.
 
-    friend_info (ROOT.Internal.TreeUtils.RFriendInfo, None): Information about
+    friendinfo (ROOT.Internal.TreeUtils.RFriendInfo, None): Information about
         friend trees of the chain built for this range. Not None if the user
         provided a TTree or TChain in the distributed RDataFrame constructor.
     """
 
-    def __init__(self, rangeid, globalstart, globalend, localstarts, localends, filelist, treesnentries, friend_info):
+    def __init__(self, rangeid, globalstart, globalend, localstarts, localends, filelist, treesnentries, friendinfo):
         """set attributes"""
         self.id = rangeid
         self.globalstart = globalstart
@@ -76,7 +76,7 @@ class TreeRange(object):
         self.localends = localends
         self.filelist = filelist
         self.treesnentries = treesnentries
-        self.friend_info = friend_info
+        self.friendinfo = friendinfo
 
 
 @total_ordering
@@ -329,7 +329,7 @@ def get_clustered_ranges(clustersinfiles, npartitions, friendinfo):
                     localends=[50, 100],
                     filelist=['file1.root', 'file2.root'],
                     treesnentries=[50, 200],
-                    friend_info=None),
+                    friendinfo=None),
                 TreeRange(id=1,
                     globalstart=150,
                     globalend=300,
@@ -337,7 +337,7 @@ def get_clustered_ranges(clustersinfiles, npartitions, friendinfo):
                     localends=[200, 50],
                     filelist=['file2.root', 'file3.root'],
                     treesnentries=[200, 50],
-                    friend_info=None),
+                    friendinfo=None),
             ]
 
     """
@@ -413,7 +413,7 @@ def get_clustered_ranges(clustersinfiles, npartitions, friendinfo):
         #                 filelist=['tree10000entries10clusters.root',
         #                           'tree20000entries10clusters.root'],
         #                 treesnentries=[10000, 20000],
-        #                 friend_info=None)
+        #                 friendinfo=None)
         #       TreeRange(id=1,
         #                 globalstart=10000,
         #                 globalend=50000,
@@ -422,7 +422,7 @@ def get_clustered_ranges(clustersinfiles, npartitions, friendinfo):
         #                 filelist=['tree20000entries10clusters.root',
         #                           'tree30000entries10clusters.root'],
         #                 treesnentries=[20000,30000],
-        #                 friend_info=None)
+        #                 friendinfo=None)
         #   The first `TreeRange` will read the first 10000 entries from the
         #   first file, then switch to the second file and read the first 10000
         #   entries. The second `TreeRange` will start from entry number 10000

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -46,7 +46,7 @@ class FriendInfoTest(unittest.TestCase):
         ff.Write()
         ff.Close()
 
-    def test_friend_info_with_ttree(self):
+    def test_friendinfo_with_ttree(self):
         """
         Check that RFriendInfo correctly stores information about the friend
         trees
@@ -73,12 +73,12 @@ class FriendInfoTest(unittest.TestCase):
         headnode = create_dummy_headnode(maintree)
 
         # Retrieve information about friends
-        friend_info = headnode.friendinfo
+        friendinfo = headnode.friendinfo
 
         # Convert to Python collections
-        friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friend_info.fFriendNames]
-        friendfilenames = [[str(filename) for filename in filenames] for filenames in friend_info.fFriendFileNames]
-        friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friend_info.fFriendChainSubNames]
+        friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friendinfo.fFriendNames]
+        friendfilenames = [[str(filename) for filename in filenames] for filenames in friendinfo.fFriendFileNames]
+        friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friendinfo.fFriendChainSubNames]
 
         # Check that the three lists with treenames, filenames and subnames are populated
         # as expected.
@@ -91,7 +91,7 @@ class FriendInfoTest(unittest.TestCase):
         os.remove(friend_tree_filename)
 
 
-    def test_friend_info_chain_with_subnames(self):
+    def test_friendinfo_chain_with_subnames(self):
         """
         Check that RFriendInfo correctly stores information about the friend
         trees
@@ -123,12 +123,12 @@ class FriendInfoTest(unittest.TestCase):
         headnode = create_dummy_headnode(maintree)
 
         # Retrieve information about friends
-        friend_info = headnode.friendinfo
+        friendinfo = headnode.friendinfo
 
         # Convert to Python collections
-        friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friend_info.fFriendNames]
-        friendfilenames = [[str(filename) for filename in filenames] for filenames in friend_info.fFriendFileNames]
-        friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friend_info.fFriendChainSubNames]
+        friendnamesalias = [(str(pair.first), str(pair.second)) for pair in friendinfo.fFriendNames]
+        friendfilenames = [[str(filename) for filename in filenames] for filenames in friendinfo.fFriendFileNames]
+        friendchainsubnames = [[str(chainsubname) for chainsubname in chainsubnames] for chainsubnames in friendinfo.fFriendChainSubNames]
 
         # Check that the three lists with treenames, filenames and subnames are populated
         # as expected.


### PR DESCRIPTION
Finish up with changing naming of `friend_info` to `friendinfo` which is more consistent with other variable naming in various classes and functions in DistRDF