### PR TITLE
[cmake] Quote cmake variable expansion

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -75,7 +75,7 @@ configure_file(python/cmdLineUtils.py ${localruntimedir}/cmdLineUtils.py @ONLY)
 
 
 set_source_files_properties(src/rootcling.cxx PROPERTIES
-  COMPILE_FLAGS ${CLING_CXXFLAGS}
+  COMPILE_FLAGS "${CLING_CXXFLAGS}"
   VISIBILITY_INLINES_HIDDEN "ON"
 )
 


### PR DESCRIPTION
Otherwise we get cmake errors when CLING_CXXFLAGS is empty.

