### PR TITLE
[RF] Make it possible to store global observables in `RooAbsData` and consider these global observables in `RooAbsPdf::fitTo`

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -96,6 +96,48 @@ RooFit now contains two RDataFrame action helpers, `RooDataSetHelper` and `RooDa
 ```
 For more details, consult the tutorial [rf408_RDataFrameToRooFit](https://root.cern/doc/v626/rf408__RDataFrameToRooFit_8C.html).
 
+### Storing global observables in RooFit datasets
+
+RooFit groups model variables into *observables* and *parameters*, depending on if their values are stored in the dataset.
+For fits with parameter constraints, there is a third kind of variables, called *global observables*.
+These represent the results of auxiliary measurements that constrain the nuisance parameters.
+In the RooFit implementation, a likelihood is generally the sum of two terms:
+  * the likelihood of the data given the parameters, where the normalization set is the set of observables (implemented by `RooNLLVar`)
+  * the constraint term, where the normalization set is the set of *global observables* (implemented by `RooConstraintSum`)
+
+Before this release, the global observable values were always taken from the model/pdf.
+With this release, a mechanism is added to store a snapshot of global observables in any `RooDataSet` or `RooDataHist`.
+For toy studies where the global observables assume a different values for each toy, the bookkeeping of the set of global observables and in particular their values is much easier with this change.
+
+Usage example for a model with global observables `g1` and `g2`:
+```C++
+auto data = model.generate(x, 1000); // data has only the single observables x
+data->setGlobalObservables(g1, g2); // now, data also stores a snapshot of g1 and g2
+
+// If you fit the model to the data, the global observables and their values
+// are taken from the dataset:
+model.fitTo(*data);
+
+// You can still define the set of global observables yourself, but the values
+// will be takes from the dataset if available:
+model.fitTo(*data, GlobalObservables(g1, g2));
+
+// To force `fitTo` to take the global observable values from the model even
+// though they are in the dataset, you can use the new `GlobalObservablesSource`
+// command argument:
+model.fitTo(*data, GlobalObservables(g1, g2), GlobalObservablesSource("model"));
+// The only other allowed value for `GlobalObservablesSource` is "data", which
+// corresponds to the new default behavior explained above.
+```
+
+In case you create a RooFit dataset directly by calling its constructor, you can also pass the global observables in a command argument instead of calling `setGlobalObservables()` later:
+```C++
+RooDataSet data{"dataset", "dataset", x, RooFit::GlobalObservables(g1, g2)};
+```
+
+To access the set of global observables stored in a `RooAbsData`, call `RooAbsData::getGlobalObservables()`.
+It returns a `nullptr` if no global observable snapshots are stored in the dataset.
+
 ### Changes in `RooAbsPdf::fitTo` behaviour for multi-range fits
 
 The `RooAbsPdf::fitTo` and `RooAbsPdf::createNLL` functions accept a command argument to specify the fit range.
@@ -106,7 +148,7 @@ From now on, the likelihoods are normalized by the sum of integrals in each rang
 
 ### Deprecation of the `RooMinuit` class
 
-The `RooMinuit` class was the old interface between RooFit and minuit. With ROOT version 5.24, a the more general `RooMinimizer` adapter was introduced, which became the default with ROOT 6.08. 
+The `RooMinuit` class was the old interface between RooFit and minuit. With ROOT version 5.24, a the more general `RooMinimizer` adapter was introduced, which became the default with ROOT 6.08.
 
 Before 6.26, it was possible to still use the `RooMinuit` by passing the `Minimizer("OldMinuit", "minimizer")` command argument to `RooAbsPdf::fitTo()`. This option is now removed.
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -303,6 +303,13 @@ public:
 
   static StorageType getDefaultStorageType();
 
+  /// Returns snapshot of global observables stored in this data.
+  /// \return Pointer to a RooArgSet with the snapshot of global observables
+  ///         stored in the data. Can be `nullptr` if no global observales are
+  ///         stored.
+  RooArgSet const* getGlobalObservables() const { return _globalObservables.get(); }
+  void setGlobalObservables(RooArgSet const& globalObservables);
+
 protected:
 
   static StorageType defaultStorageType ;
@@ -350,8 +357,12 @@ protected:
 
   std::map<std::string,RooAbsData*> _ownedComponents ; // Owned external components
 
+  std::unique_ptr<RooArgSet> _globalObservables; // Snapshot of global observables
+
 private:
-   ClassDef(RooAbsData, 5) // Abstract data collection
+  void copyGlobalObservables(const RooAbsData& other);
+
+   ClassDef(RooAbsData, 6) // Abstract data collection
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -159,6 +159,32 @@ public:
                               const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
   virtual RooFitResult* fitTo(RooAbsData& data, const RooLinkedList& cmdList) ;
 
+  /// Configuration struct for RooAbsPdf::minimizeNLL with all the default
+  //values that also should be taked as the default values for
+  //RooAbsPdf::fitTo.
+  struct MinimizerConfig {
+      double recoverFromNaN = 10.;
+      std::string fitOpt = "";
+      int optConst = 2;
+      int verbose = 0;
+      int doSave = 0;
+      int doTimer = 0;
+      int printLevel = 1;
+      int strat = 1;
+      int initHesse = 0;
+      int hesse = 1;
+      int minos = 0;
+      int numee = 10;
+      int doEEWall = 1;
+      int doWarn = 1;
+      int doSumW2 = -1;
+      int doAsymptotic = -1;
+      const RooArgSet* minosSet = nullptr;
+      std::string minType = "Minuit";
+      std::string minAlg = "minuit";
+  };
+  std::unique_ptr<RooFitResult> minimizeNLL(RooAbsReal & nll, RooAbsData const& data, MinimizerConfig const& cfg);
+
   virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) ;
   virtual RooAbsReal* createNLL(RooAbsData& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),  
 				const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),  
@@ -359,8 +385,8 @@ protected:
   static TString _normRangeOverride ; 
 
 private:
-  int calculateAsymptoticCorrectedCovMatrix(RooMinimizer& minimizer, RooAbsData const& data);
-  int calculateSumW2CorrectedCovMatrix(RooMinimizer& minimizer, RooAbsReal const& nll) const;
+  int calcAsymptoticCorrectedCovariance(RooMinimizer& minimizer, RooAbsData const& data);
+  int calcSumW2CorrectedCovariance(RooMinimizer& minimizer, RooAbsReal const& nll) const;
   
   ClassDef(RooAbsPdf,5) // Abstract PDF with normalization support
 };

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -51,6 +51,7 @@ public:
     bool cloneInputData = true;
     double integrateOverBinsPrecision = -1.;
     bool binnedL = false;
+    bool takeGlobalObservablesFromData = false;
   };
 
   // Constructors, assignment etc
@@ -155,10 +156,11 @@ protected:
 
   RooFit::MPSplit _mpinterl = RooFit::BulkPartition; // Use interleaving strategy rather than N-wise split for partioning of dataset for multiprocessor-split
   Bool_t         _doOffset = false; // Apply interval value offset to control numeric precision?
+  const bool  _takeGlobalObservablesFromData = false; // If the global observable values are taken from data
   mutable ROOT::Math::KahanSum<double> _offset = 0.0; //! Offset as KahanSum to avoid loss of precision
   mutable Double_t _evalCarry = 0.0; //! carry of Kahan sum in evaluatePartition
 
-  ClassDef(RooAbsTestStatistic,2) // Abstract base class for real-valued test statistics
+  ClassDef(RooAbsTestStatistic,3) // Abstract base class for real-valued test statistics
 
 };
 

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -31,7 +31,7 @@ public:
   RooConstraintSum(const char *name, const char *title, const RooArgSet& constraintSet, const RooArgSet& paramSet) ;
 
   RooConstraintSum(const RooConstraintSum& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooConstraintSum(*this, newname); }
+  virtual TObject* clone(const char* newname) const override { return new RooConstraintSum(*this, newname); }
 
   const RooArgList& list() { return _set1 ; }
 
@@ -45,14 +45,20 @@ public:
         const char* globalObservablesTag,
         RooWorkspace * workspace = nullptr);
 
+  bool setData(RooAbsData const& data, bool cloneData=true);
+  /// \copydoc setData(RooAbsData const&, bool)
+  bool setData(RooAbsData& data, bool cloneData=true) override {
+    return setData(static_cast<RooAbsData const&>(data), cloneData);
+  }
+
 protected:
 
   RooListProxy _set1 ;    // Set of constraint terms
   RooSetProxy _paramSet ; // Set of parameters to which constraints apply
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooConstraintSum,2) // sum of -log of set of RooAbsPdf representing parameter constraints
+  ClassDefOverride(RooConstraintSum,2) // sum of -log of set of RooAbsPdf representing parameter constraints
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -38,7 +38,7 @@ public:
   static std::unique_ptr<RooAbsReal> createConstraintTerm(
         std::string const& name,
         RooAbsPdf const& pdf,
-        RooArgSet const& observables,
+        RooAbsData const& data,
         RooArgSet const* constrainedParameters,
         RooArgSet const* externalConstraints,
         RooArgSet const* globalObservables,

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -28,7 +28,7 @@ class RooConstraintSum : public RooAbsReal {
 public:
 
   RooConstraintSum() {}
-  RooConstraintSum(const char *name, const char *title, const RooArgSet& constraintSet, const RooArgSet& paramSet) ;
+  RooConstraintSum(const char *name, const char *title, const RooArgSet& constraintSet, const RooArgSet& paramSet, bool takeGlobalObservablesFromData=false) ;
 
   RooConstraintSum(const RooConstraintSum& other, const char* name = 0);
   virtual TObject* clone(const char* newname) const override { return new RooConstraintSum(*this, newname); }
@@ -43,6 +43,7 @@ public:
         RooArgSet const* externalConstraints,
         RooArgSet const* globalObservables,
         const char* globalObservablesTag,
+        bool takeGlobalObservablesFromData,
         RooWorkspace * workspace = nullptr);
 
   bool setData(RooAbsData const& data, bool cloneData=true);
@@ -55,10 +56,11 @@ protected:
 
   RooListProxy _set1 ;    // Set of constraint terms
   RooSetProxy _paramSet ; // Set of parameters to which constraints apply
+  const bool _takeGlobalObservablesFromData = false; // If the global observable values are taken from data
 
   Double_t evaluate() const override;
 
-  ClassDefOverride(RooConstraintSum,2) // sum of -log of set of RooAbsPdf representing parameter constraints
+  ClassDefOverride(RooConstraintSum,3) // sum of -log of set of RooAbsPdf representing parameter constraints
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -239,10 +239,14 @@ RooCmdArg SplitRange(Bool_t flag=kTRUE) ;
 RooCmdArg SumCoefRange(const char* rangeName) ;
 RooCmdArg Constrain(const RooArgSet& params) ;
 RooCmdArg Constrain(RooArgSet && params) ;
-RooCmdArg GlobalObservables(const RooArgSet& globs) ;
-RooCmdArg GlobalObservables(RooArgSet && globs) ;
+
+template<class... Args_t>
+RooCmdArg GlobalObservables(Args_t &&... argsOrArgSet) {
+  return RooCmdArg("GlobalObservables",0,0,0,0,0,0,0,0,0,0,
+          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}));
+}
+RooCmdArg GlobalObservablesSource(const char* sourceName);
 RooCmdArg GlobalObservablesTag(const char* tagName) ;
-//RooCmdArg Constrained() ;
 RooCmdArg ExternalConstraints(const RooArgSet& constraintPdfs) ;
 RooCmdArg ExternalConstraints(RooArgSet && constraintPdfs) ;
 RooCmdArg PrintEvalErrors(Int_t numErrors) ;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -23,6 +23,58 @@ RooAbsData is the common abstract base class for binned and unbinned
 datasets. The abstract interface defines plotting and tabulating entry
 points for its contents and provides an iterator over its elements
 (bins for binned data sets, data points for unbinned datasets).
+
+### Storing global observables in RooFit datasets
+
+RooFit groups model variables into *observables* and *parameters*, depending on
+if their values are stored in the dataset. For fits with parameter
+constraints, there is a third kind of variables, called *global observables*.
+These represent the results of auxiliary measurements that constrain the
+nuisance parameters. In the RooFit implementation, a likelihood is generally
+the sum of two terms:
+- the likelihood of the data given the parameters, where the normalization set
+  is the set of observables (implemented by RooNLLVar)
+- the constraint term, where the normalization set is the set of *global
+observables* (implemented by RooConstraintSum)
+
+Before this release, the global observable values were always taken from the
+model/pdf. With this release, a mechanism is added to store a snapshot of
+global observables in any RooDataSet or RooDataHist. For toy studies where the
+global observables assume a different values for each toy, the bookkeeping of
+the set of global observables and in particular their values is much easier
+with this change.
+
+Usage example for a model with global observables `g1` and `g2`:
+```
+auto data = model.generate(x, 1000); // data has only the single observables x
+data->setGlobalObservables(g1, g2); // now, data also stores a snapshot of g1 and g2
+
+// If you fit the model to the data, the global observables and their values
+// are taken from the dataset:
+model.fitTo(*data);
+
+// You can still define the set of global observables yourself, but the values
+// will be takes from the dataset if available:
+model.fitTo(*data, GlobalObservables(g1, g2));
+
+// To force `fitTo` to take the global observable values from the model even
+// though they are in the dataset, you can use the new `GlobalObservablesSource`
+// command argument:
+model.fitTo(*data, GlobalObservables(g1, g2), GlobalObservablesSource("model"));
+// The only other allowed value for `GlobalObservablesSource` is "data", which
+// corresponds to the new default behavior explained above.
+```
+
+In case you create a RooFit dataset directly by calling its constructor, you
+can also pass the global observables in a command argument instead of calling
+RooAbsData::setGlobalObservables() later:
+```
+RooDataSet data{"dataset", "dataset", x, RooFit::GlobalObservables(g1, g2)};
+```
+
+To access the set of global observables stored in a RooAbsData, call
+RooAbsData::getGlobalObservables(). It returns a `nullptr` if no global
+observable snapshots are stored in the dataset.
 **/
 
 #include "RooAbsData.h"
@@ -206,6 +258,8 @@ RooAbsData::RooAbsData(const RooAbsData& other, const char* newname) :
     storageType = other.storageType;
   }
 
+  copyGlobalObservables(other);
+
   RooTrace::create(this) ;
 }
 
@@ -245,8 +299,22 @@ RooAbsData& RooAbsData::operator=(const RooAbsData& other) {
     storageType = other.storageType;
   }
 
+  copyGlobalObservables(other);
+
   return *this;
 }
+
+
+void RooAbsData::copyGlobalObservables(const RooAbsData& other) {
+  if (other._globalObservables) {
+    if(_globalObservables == nullptr) _globalObservables = std::make_unique<RooArgSet>();
+    else _globalObservables->clear();
+    other._globalObservables->snapshot(*_globalObservables);
+  } else {
+    _globalObservables.reset(nullptr);
+  }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor
@@ -397,8 +465,8 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
 
   // Process & check varargs
   pc.process(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8) ;
-  if (!pc.ok(kTRUE)) {
-    return 0 ;
+  if (!pc.ok(true)) {
+    return nullptr;
   }
 
   // Extract values from named arguments
@@ -442,15 +510,12 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
 
   }
 
-  if (!ret) return 0 ;
+  if (!ret) return nullptr;
 
-  if (name) {
-    ret->SetName(name) ;
-  }
-  if (title) {
-    ret->SetTitle(title) ;
-  }
+  if (name) ret->SetName(name) ;
+  if (title) ret->SetTitle(title) ;
 
+  ret->copyGlobalObservables(*this);
   return ret ;
 }
 
@@ -463,7 +528,9 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
 RooAbsData* RooAbsData::reduce(const char* cut)
 {
   RooFormulaVar cutVar(cut,cut,*get()) ;
-  return reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  ret->copyGlobalObservables(*this);
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -473,7 +540,9 @@ RooAbsData* RooAbsData::reduce(const char* cut)
 
 RooAbsData* RooAbsData::reduce(const RooFormulaVar& cutVar)
 {
-  return reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  ret->copyGlobalObservables(*this);
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -496,11 +565,15 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
     }
   }
 
+  RooAbsData* ret = nullptr;
   if (cut && strlen(cut)>0) {
     RooFormulaVar cutVar(cut, cut, *get(), false);
-    return reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+    ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max(),false);
+  } else {
+    ret = reduceEng(varSubset2,0,0,0,std::numeric_limits<std::size_t>::max(),false);
   }
-  return reduceEng(varSubset2,0,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  ret->copyGlobalObservables(*this);
+  return ret;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -514,18 +587,17 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& 
 {
   // Make sure varSubset doesn't contain any variable not in this dataset
   RooArgSet varSubset2(varSubset) ;
-  TIterator* iter = varSubset.createIterator() ;
-  RooAbsArg* arg ;
-  while((arg=(RooAbsArg*)iter->Next())) {
+  for(RooAbsArg * arg : varSubset) {
     if (!_vars.find(arg->GetName())) {
       coutW(InputArguments) << "RooAbsData::reduce(" << GetName() << ") WARNING: variable "
              << arg->GetName() << " not in dataset, ignored" << endl ;
       varSubset2.remove(*arg) ;
     }
   }
-  delete iter ;
 
-  return reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  RooAbsData* ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  ret->copyGlobalObservables(*this);
+  return ret;
 }
 
 
@@ -2355,5 +2427,22 @@ void RooAbsData::RecursiveRemove(TObject *obj)
     if (iter.second == obj) {
       iter.second = nullptr;
     }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Sets the global observables stored in this data. A snapshot of the
+/// observables will be saved.
+/// \param[in] globalObservables The set of global observables to take a snapshot of.
+
+void RooAbsData::setGlobalObservables(RooArgSet const& globalObservables) {
+  if(_globalObservables == nullptr) _globalObservables = std::make_unique<RooArgSet>();
+  else _globalObservables->clear();
+  globalObservables.snapshot(*_globalObservables);
+  for(auto * arg : *_globalObservables) {
+    arg->setAttribute("global",true);
+    // Global observables are also always constant in fits
+    if(auto lval = dynamic_cast<RooAbsRealLValue*>(arg)) lval->setConstant(true);
+    if(auto lval = dynamic_cast<RooAbsCategoryLValue*>(arg)) lval->setConstant(true);
   }
 }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1122,7 +1122,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
   auto constraintTerm = RooConstraintSum::createConstraintTerm(
           baseName + "_constr", // name
           *this, // pdf
-          *data.get(), // observables
+          data, // data
           pc.getSet("cPars"), // Constrain RooCmdArg
           pc.getSet("extCons"), // ExternalConstraints RooCmdArg
           pc.getSet("glObs"), // GlobalObservables RooCmdArg

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1078,6 +1078,14 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     projDeps.add(*tmp) ;
   }
 
+  const std::string globalObservablesSource = pc.getString("globssource","data",false);
+  if(globalObservablesSource != "data" && globalObservablesSource != "model") {
+    std::string errMsg = "RooAbsPdf::fitTo: GlobalObservablesSource can only be \"data\" or \"model\"!";
+    coutE(InputArguments) << errMsg << std::endl;
+    throw std::invalid_argument(errMsg);
+  }
+  const bool takeGlobalObservablesFromData = globalObservablesSource == "data";
+
   // Construct NLL
   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors) ;
   RooAbsReal* nll ;
@@ -1091,6 +1099,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
   cfg.cloneInputData = static_cast<bool>(cloneData);
   cfg.integrateOverBinsPrecision = pc.getDouble("IntegrateBins");
   cfg.binnedL = false;
+  cfg.takeGlobalObservablesFromData = takeGlobalObservablesFromData;
   if (!rangeName || strchr(rangeName,',')==0) {
     // Simple case: default range, or single restricted range
     //cout<<"FK: Data test 1: "<<data.sumEntries()<<endl;
@@ -1129,15 +1138,6 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     nll = new RooAddition(baseName.c_str(),"-log(likelihood)",nllList,true) ;
   }
   RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
-
-  const std::string globalObservablesSource = pc.getString("globssource","data",false);
-  if(globalObservablesSource != "data" && globalObservablesSource != "model") {
-    std::string errMsg = "RooAbsPdf::fitTo: GlobalObservablesSource can only be \"data\" or \"model\"!";
-    coutE(InputArguments) << errMsg << std::endl;
-    throw std::invalid_argument(errMsg);
-  }
-  const bool takeGlobsFromData = globalObservablesSource == "data";
-
 
   auto constraintTerm = RooConstraintSum::createConstraintTerm(
           baseName + "_constr", // name

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -270,6 +270,9 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
 ///                              category it will be added on the fly. The import command can be specified
 ///                              multiple times. 
 /// <tr><td> Import(map<string,TH1*>&) <td> As above, but allows specification of many imports in a single operation
+/// <tr><td> `GlobalObservables(const RooArgSet&)`      <td> Define the set of global observables to be stored in this RooDataHist.
+///                                                          A snapshot of the passed RooArgSet is stored, meaning the values wont't change unexpectedly.
+/// </table>
 ///                              
 
 RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
@@ -292,6 +295,7 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
   pc.defineDouble("weight","Weight",0,1) ; 
   pc.defineObject("dummy1","ImportDataHistSliceMany",0) ;
   pc.defineObject("dummy2","ImportHistoSliceMany",0) ;
+  pc.defineSet("glObs","GlobalObservables",0,0) ;
   pc.defineMutex("ImportHisto","ImportHistoSlice","ImportDataHistSlice") ;
   pc.defineDependency("ImportHistoSlice","IndexCat") ;
   pc.defineDependency("ImportDataHistSlice","IndexCat") ;
@@ -308,6 +312,8 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
     assert(0) ;
     return ;
   }
+
+  if(pc.getSet("glObs")) setGlobalObservables(*pc.getSet("glObs"));
 
   TH1* impHist = static_cast<TH1*>(pc.getObject("impHist")) ;
   Bool_t impDens = pc.getInt("impDens") ;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -215,6 +215,8 @@ RooDataSet::RooDataSet() : _wgtVar(0)
 ///     <td> Interpret the given variable as event weight rather than as observable
 /// <tr><td> StoreError(const RooArgSet&)     <td> Store symmetric error along with value for given subset of observables
 /// <tr><td> StoreAsymError(const RooArgSet&) <td> Store asymmetric error along with value for given subset of observables
+/// <tr><td> `GlobalObservables(const RooArgSet&)` <td> Define the set of global observables to be stored in this RooDataSet.
+///                                                     A snapshot of the passed RooArgSet is stored, meaning the values wont't change unexpectedly.
 /// </table>
 ///
 
@@ -245,6 +247,7 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooA
   pc.defineObject("dummy2","LinkDataSliceMany",0) ;
   pc.defineSet("errorSet","StoreError",0) ;
   pc.defineSet("asymErrSet","StoreAsymError",0) ;
+  pc.defineSet("glObs","GlobalObservables",0,0) ;
   pc.defineMutex("ImportTree","ImportData","ImportDataSlice","LinkDataSlice","ImportFromFile") ;
   pc.defineMutex("CutSpec","CutVar") ;
   pc.defineMutex("WeightVarName","WeightVar") ;
@@ -265,6 +268,8 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooA
     assert(0) ;
     return ;
   }
+
+  if(pc.getSet("glObs")) setGlobalObservables(*pc.getSet("glObs"));
 
   // Extract relevant objects
   TTree* impTree = static_cast<TTree*>(pc.getObject("impTree")) ;

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -222,10 +222,8 @@ namespace RooFit {
   RooCmdArg SumCoefRange(const char* rangeName)          { return RooCmdArg("SumCoefRange",0,0,0,0,rangeName,0,0,0) ; }
   RooCmdArg Constrain(const RooArgSet& params)           { return RooCmdArg("Constrain",0,0,0,0,0,0,0,0,0,0,&params) ; }
   RooCmdArg Constrain(RooArgSet && params) { return Constrain(RooCmdArg::take(std::move(params))); }
-  RooCmdArg GlobalObservables(const RooArgSet& globs)    { return RooCmdArg("GlobalObservables",0,0,0,0,0,0,0,0,0,0,&globs) ; }
-  RooCmdArg GlobalObservables(RooArgSet && globs) { return GlobalObservables(RooCmdArg::take(std::move(globs))); }
+  RooCmdArg GlobalObservablesSource(const char* sourceName) { return {"GlobalObservablesSource",0,0,0,0,sourceName,0,0,0}; }
   RooCmdArg GlobalObservablesTag(const char* tagName)    { return RooCmdArg("GlobalObservablesTag",0,0,0,0,tagName,0,0,0) ; }
-//  RooCmdArg Constrained()                                { return RooCmdArg("Constrained",kTRUE,0,0,0,0,0,0,0) ; }
   RooCmdArg ExternalConstraints(const RooArgSet& cpdfs)  { return RooCmdArg("ExternalConstraints",0,0,0,0,0,0,&cpdfs,0,0,0,&cpdfs) ; }
   RooCmdArg ExternalConstraints(RooArgSet && cpdfs)      { return ExternalConstraints(RooCmdArg::take(std::move(cpdfs))); }
   RooCmdArg PrintEvalErrors(Int_t numErrors)             { return RooCmdArg("PrintEvalErrors",numErrors,0,0,0,0,0,0,0) ; }

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -44,6 +44,6 @@ ROOT_ADD_GTEST(testRooProductPdf testRooProductPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooGradMinimizerFcn testRooGradMinimizerFcn.cxx LIBRARIES RooFitCore)
-
 ROOT_ADD_GTEST(testLikelihoodSerial TestStatistics/testLikelihoodSerial.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooRealL TestStatistics/RooRealL.cpp LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFit)

--- a/roofit/roofitcore/test/testGlobalObservables.cxx
+++ b/roofit/roofitcore/test/testGlobalObservables.cxx
@@ -1,0 +1,432 @@
+// Tests for global observables
+// Authors: Jonas Rembser, CERN  08/2021
+
+#include "RooRealVar.h"
+#include "RooMsgService.h"
+#include "RooGaussian.h"
+#include "RooPolynomial.h"
+#include "RooAddPdf.h"
+#include "RooDataSet.h"
+#include "RooProdPdf.h"
+#include "RooFitResult.h"
+#include "RooConstVar.h"
+#include "RooPoisson.h"
+#include "RooProduct.h"
+#include "RooWorkspace.h"
+
+#include "gtest/gtest.h"
+
+#include <memory>
+#include <functional>
+
+namespace {
+
+// Helper function to check if two RooFitResults are not identical.
+// We can't use RooFitResult::isIdentical() here, because it will print
+// something when the comparison fails even with verbose set to false.
+bool isNotIdentical(RooFitResult const &res1, RooFitResult const &res2)
+{
+   std::size_t n = res1.floatParsFinal().size();
+   if (n != res2.floatParsFinal().size())
+      return true;
+   for (std::size_t i = 0; i < n; ++i) {
+      if (static_cast<RooAbsRealLValue &>(res1.floatParsFinal()[i]).getVal() !=
+          static_cast<RooAbsRealLValue &>(res2.floatParsFinal()[i]).getVal())
+         return true;
+   }
+   return false;
+}
+
+} // namespace
+
+// Test environment to verify that if we use the feature of storing global
+// observables in a RooDataSet, we can reproduce the same fit results as when
+// we track the global observables separately.
+class TestGlobalObservables : public ::testing::Test {
+public:
+   void SetUp() override
+   {
+      // silence log output
+      RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
+
+      // observables
+      RooRealVar x("x", "x", 0.0, 0.0, 20.0);
+
+      // global observables, always constant in fits
+      RooRealVar gm("gm", "gm", 11.0, 0.0, 20.0);
+      RooRealVar gs("gs", "gs", 1.0, 0.1, 10.0);
+      gm.setConstant(true);
+      gs.setConstant(true);
+
+      // constrained parameters
+      RooRealVar f("f", "f", 0.5, 0.0, 1.0);
+
+      // other parameters
+      RooRealVar m("m", "m", 10.0, 0.0, 20.0);
+      RooRealVar s("s", "s", 2.0, 0.1, 10.0);
+
+      // We use the global observable also in the model for the event
+      // observables. It's unusual, but let's better do this to also cover the
+      // corner case where the global observable is not only part of the
+      // constraint term.
+      RooProduct sigma{"sigma", "sigma", {s, gs}};
+
+      // build the unconstrained model
+      RooGaussian model("model", "model", x, m, sigma);
+
+      // the constraint pdfs, they are RooPoisson so we can't have tests that accidentally
+      // pass because of the symmetry of normalizing over x or mu
+      RooPoisson mconstraint("mconstraint", "mconstraint", gm, m);
+      RooPoisson sconstraint("sconstraint", "sconstraint", gs, s);
+
+      // the model multiplied with the constraint term
+      RooProdPdf modelc("modelc", "modelc", RooArgSet(model, mconstraint, sconstraint));
+
+      // generate small dataset for use in fitting below, also cloned versions
+      // with one or two global observables attached
+      _data.reset(model.generate(x, 50));
+
+      _dataWithMeanSigmaGlobs.reset(
+         static_cast<RooDataSet *>(_data->Clone((std::string(_data->GetName()) + "_gm_gs").c_str())));
+      _dataWithMeanSigmaGlobs->setGlobalObservables({gm, gs});
+
+      _dataWithMeanGlob.reset(static_cast<RooDataSet *>(_data->Clone((std::string(_data->GetName()) + "_gm").c_str())));
+      _dataWithMeanGlob->setGlobalObservables(gm);
+
+      _workspace = std::make_unique<RooWorkspace>("workspace", "workspace");
+      _workspace->import(modelc);
+   }
+
+   // reset the parameter values to initial values before fits
+   void resetParameters()
+   {
+      std::vector<std::string> names{"x", "m", "s", "gm", "gs"};
+      std::vector<double> values{0.0, 10.0, 2.0, 11.0, 1.0};
+      for (std::size_t i = 0; i < names.size(); ++i) {
+         auto *var = _workspace->var(names[i].c_str());
+         var->setVal(values[i]);
+         var->setError(0.0);
+      }
+   }
+
+   RooWorkspace &ws() { return *_workspace; }
+   RooDataSet &data() { return *_data; }
+   RooDataSet &dataWithMeanSigmaGlobs() { return *_dataWithMeanSigmaGlobs; }
+   RooDataSet &dataWithMeanGlob() { return *_dataWithMeanGlob; }
+   RooAbsPdf &model() { return *ws().pdf("model"); }
+   RooAbsPdf &modelc() { return *ws().pdf("modelc"); }
+
+   std::unique_ptr<RooFitResult> doFit(RooAbsPdf &model, RooAbsData &data, RooCmdArg const &arg1 = RooCmdArg::none(),
+                                       RooCmdArg const &arg2 = RooCmdArg::none(),
+                                       RooCmdArg const &arg3 = RooCmdArg::none(),
+                                       RooCmdArg const &arg4 = RooCmdArg::none())
+   {
+      using namespace RooFit;
+      return std::unique_ptr<RooFitResult>(
+         model.fitTo(data, Save(), Verbose(false), PrintLevel(-1), arg1, arg2, arg3, arg4));
+   }
+
+   void TearDown() override
+   {
+      _workspace.reset();
+      _data.reset();
+      _dataWithMeanSigmaGlobs.reset();
+      _data.reset();
+   }
+
+private:
+   std::unique_ptr<RooWorkspace> _workspace;
+   std::unique_ptr<RooDataSet> _data;
+   std::unique_ptr<RooDataSet> _dataWithMeanSigmaGlobs;
+   std::unique_ptr<RooDataSet> _dataWithMeanGlob;
+};
+
+TEST_F(TestGlobalObservables, NoConstraints)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+
+   // fit with no constraints
+   resetParameters();
+   auto res1 = doFit(model(), data());
+   resetParameters();
+   // vary global observable to verify true value is picked up from the dataset
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   double gmVaryVal = gm.getVal();
+   double gsVaryVal = gs.getVal();
+   auto res2 = doFit(model(), dataWithMeanSigmaGlobs());
+   EXPECT_TRUE(res1->isIdentical(*res2)) << "fitting an unconstrained model "
+                                            "gave a different result when unrelated global observables were stored in "
+                                            "the dataset";
+
+   // verify that taking the global observable values from data has not changed
+   // the values in the model
+   {
+      const auto message = "taking the global observable values from data has changed the values in the model";
+      EXPECT_EQ(gmVaryVal, gm.getVal()) << message;
+      EXPECT_EQ(gsVaryVal, gs.getVal()) << message;
+   }
+}
+
+TEST_F(TestGlobalObservables, InternalConstrains)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+
+   // constrained fit with RooProdPdf
+   resetParameters();
+   auto res1 = doFit(modelc(), data(), GlobalObservables(gm, gs));
+   resetParameters();
+   // vary global observable to verify true value is picked up from the dataset
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   double gmVaryVal = gm.getVal();
+   double gsVaryVal = gs.getVal();
+   auto res2 = doFit(modelc(), dataWithMeanSigmaGlobs());
+   EXPECT_TRUE(res1->isIdentical(*res2)) << "fitting an model with internal "
+                                            "constraints in a RooPrdPdf gave a different result when global "
+                                            "observables were stored in the dataset";
+
+   // verify that taking the global observable values from data has not changed
+   // the values in the model
+   {
+      const auto message = "taking the global observable values from data has changed the values in the model";
+      EXPECT_EQ(gmVaryVal, gm.getVal()) << message;
+      EXPECT_EQ(gsVaryVal, gs.getVal()) << message;
+   }
+}
+
+TEST_F(TestGlobalObservables, ExternalConstraints)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+   auto &mconstraint = *ws().pdf("mconstraint");
+   auto &sconstraint = *ws().pdf("sconstraint");
+
+   // constrained fit with external constraints
+   resetParameters();
+   auto res1 = doFit(model(), data(), ExternalConstraints({mconstraint, sconstraint}), GlobalObservables(gm, gs));
+   resetParameters();
+   // vary global observable to verify true value is picked up from the dataset
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   double gmVaryVal = gm.getVal();
+   double gsVaryVal = gs.getVal();
+   auto res2 = doFit(model(), dataWithMeanSigmaGlobs(), ExternalConstraints({mconstraint, sconstraint}));
+   EXPECT_TRUE(res1->isIdentical(*res2))
+      << "fitting an model with external "
+         "constraints passed via ExternalConstraints() gave a different result when global "
+         "observables were stored in the dataset";
+
+   // verify that taking the global observable values from data has not changed
+   // the values in the model
+   {
+      const auto message = "taking the global observable values from data has changed the values in the model";
+      EXPECT_EQ(gmVaryVal, gm.getVal()) << message;
+      EXPECT_EQ(gsVaryVal, gs.getVal()) << message;
+   }
+}
+
+TEST_F(TestGlobalObservables, SubsetOfConstraintsFromData)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+
+   // check if only a subset of constraints it taken from data
+   resetParameters();
+   auto res1 = doFit(modelc(), data(), GlobalObservables(gm, gs));
+   resetParameters();
+   // Vary global observable to verify true value is picked up from the dataset.
+   // This time we only get gm from the dataset, so we don't vary gs for now.
+   gm.setVal(gm.getVal() + 0.5);
+   double gmVaryVal = gm.getVal();
+   double gsVaryVal = gs.getVal();
+   // if we take the global observables from the model, they have to be constant:
+   auto res2 = doFit(modelc(), dataWithMeanGlob(), GlobalObservables(gm, gs));
+   EXPECT_TRUE(res1->isIdentical(*res2)) << "fitting a constrained model "
+                                            "to a dataset that only stores a subset of the defined global observables "
+                                            "gave the wrong result";
+
+   // verify that taking the global observable values from data has not changed
+   // the values in the model
+   {
+      const auto message = "taking the global observable values from data has changed the values in the model";
+      EXPECT_EQ(gmVaryVal, gm.getVal()) << message;
+      EXPECT_EQ(gsVaryVal, gs.getVal()) << message;
+   }
+
+   resetParameters();
+   // Now that we also vary gs, the fit results should not be identical.
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   gmVaryVal = gm.getVal();
+   gsVaryVal = gs.getVal();
+   auto res3 = doFit(modelc(), dataWithMeanGlob(), GlobalObservables(gm, gs));
+   EXPECT_TRUE(isNotIdentical(*res1, *res3))
+      << "fitting a constrained model "
+         "to a dataset that only stores a subset of the defined global observables "
+         "gave the wrong result";
+
+   // verify that taking the global observable values from data has not changed
+   // the values in the model
+   {
+      const auto message = "taking the global observable values from data has changed the values in the model";
+      EXPECT_EQ(gmVaryVal, gm.getVal()) << message;
+      EXPECT_EQ(gsVaryVal, gs.getVal()) << message;
+   }
+}
+
+TEST_F(TestGlobalObservables, ResetDataToWrongData)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+   auto &model = modelc();
+
+   // constrained fit with RooProdPdf
+   resetParameters();
+   auto res1 = doFit(model, data(), GlobalObservables(gm, gs));
+
+   resetParameters();
+   // vary global observable to deliberately store "wrong" values in a cloned dataset
+   std::unique_ptr<RooDataSet> wrongData{static_cast<RooDataSet *>(data().Clone())};
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   wrongData->setGlobalObservables({gm, gs});
+
+   // check that the fit works when using the dataset with the correct values
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(dataWithMeanSigmaGlobs())};
+   RooAbsPdf::MinimizerConfig minimizerCfg;
+   minimizerCfg.doSave = true;
+   minimizerCfg.printLevel = -1;
+   auto res2 = model.minimizeNLL(*nll, dataWithMeanSigmaGlobs(), minimizerCfg);
+   EXPECT_TRUE(res1->isIdentical(*res2)) << "fitting an model with internal "
+                                            "constraints in a RooPrdPdf gave a different result when global "
+                                            "observables were stored in the dataset";
+
+   nll->setData(*wrongData);
+   resetParameters();
+   auto res3 = model.minimizeNLL(*nll, *wrongData, minimizerCfg);
+
+   // If resetting the dataset used for the nll worked correctly also for
+   // global observables, the fit will now give the wrong result.
+   EXPECT_TRUE(isNotIdentical(*res1, *res3))
+      << "resetting the dataset "
+         "underlying a RooNLLVar didn't change the global observable value, but it "
+         "should have";
+}
+
+TEST_F(TestGlobalObservables, ResetDataToCorrectData)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+   auto &model = modelc();
+
+   // constrained fit with RooProdPdf
+   resetParameters();
+   auto res1 = doFit(model, data(), GlobalObservables(gm, gs));
+
+   resetParameters();
+   // vary global observable to deliberately store "wrong" values in a cloned dataset
+   std::unique_ptr<RooDataSet> wrongData{static_cast<RooDataSet *>(data().Clone())};
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   wrongData->setGlobalObservables({gm, gs});
+   resetParameters();
+
+   // check that the fit doesn't work when using the dataset with the wrong values
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*wrongData)};
+   RooAbsPdf::MinimizerConfig minimizerCfg;
+   minimizerCfg.doSave = true;
+   minimizerCfg.printLevel = -1;
+   auto res2 = model.minimizeNLL(*nll, *wrongData, minimizerCfg);
+   EXPECT_TRUE(isNotIdentical(*res1, *res2)) << "fitting an model with internal "
+                                                "constraints in a RooPrdPdf ignored the global "
+                                                "observables stored in the dataset";
+
+   nll->setData(dataWithMeanSigmaGlobs());
+   resetParameters();
+   auto res3 = model.minimizeNLL(*nll, dataWithMeanSigmaGlobs(), minimizerCfg);
+   EXPECT_TRUE(res1->isIdentical(*res3)) << "resetting the dataset "
+                                            "underlying a RooNLLVar didn't change the global observable value, but it "
+                                            "should have";
+}
+
+TEST_F(TestGlobalObservables, GlobalObservablesSourceFromModel)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+
+   // constrained fit with RooProdPdf
+   resetParameters();
+   auto res1 = doFit(modelc(), data(), GlobalObservables(gm, gs));
+   resetParameters();
+   // vary global observable to verify true value is picked up from the dataset
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+
+   // verify that fit results are identical when global observable values are
+   // taken from data
+   auto res2 = doFit(modelc(), dataWithMeanSigmaGlobs());
+   EXPECT_TRUE(res1->isIdentical(*res2));
+
+   auto res3 = doFit(modelc(), dataWithMeanSigmaGlobs(), GlobalObservablesSource("model"));
+
+   // If the global observable values are indeed taken from the model and not
+   // from data, the comparison will fail now because we have changed the
+   // global observable values of the model after the first fit.
+   EXPECT_TRUE(isNotIdentical(*res2, *res3));
+}
+
+TEST_F(TestGlobalObservables, ResetDataButSourceFromModel)
+{
+   using namespace RooFit;
+
+   auto &gm = *ws().var("gm");
+   auto &gs = *ws().var("gs");
+   auto &model = modelc();
+
+   // constrained fit with RooProdPdf
+   resetParameters();
+   auto res1 = doFit(model, data(), GlobalObservables(gm, gs));
+
+   resetParameters();
+   // vary global observable to deliberately store "wrong" values in a cloned dataset
+   std::unique_ptr<RooDataSet> wrongData{static_cast<RooDataSet *>(data().Clone())};
+   gm.setVal(gm.getVal() + 0.5);
+   gs.setVal(gs.getVal() + 2.5);
+   wrongData->setGlobalObservables({gm, gs});
+
+   resetParameters();
+
+   // check that the fit works when using the dataset with the correct values
+   std::unique_ptr<RooAbsReal> nll{
+      model.createNLL(dataWithMeanSigmaGlobs(), GlobalObservablesSource("model"), GlobalObservables(gm, gs))};
+   RooAbsPdf::MinimizerConfig minimizerCfg;
+   minimizerCfg.doSave = true;
+   minimizerCfg.printLevel = -1;
+   auto res2 = model.minimizeNLL(*nll, dataWithMeanSigmaGlobs(), minimizerCfg);
+   EXPECT_TRUE(res1->isIdentical(*res2));
+
+   nll->setData(*wrongData);
+   resetParameters();
+   auto res3 = model.minimizeNLL(*nll, *wrongData, minimizerCfg);
+
+   // this time it should still be identical because even though we reset to
+   // the wrong data, we set the global observables source to "model"
+   EXPECT_TRUE(res1->isIdentical(*res3));
+}


### PR DESCRIPTION
This PR implements the possibility to store global observables in RooFit datasets, and makes the necessary changes in the `RooAbsPdf::fitTo` code path to consider the global observables in the data if available. If one wants to restore the old behavior of taking the global observable values from the model even if they are stored in the data, one can use the new `GlobalObservablesSource` command argument. 

Unit tests for all new functionality is also implemented.

Please find the more information in the commit messages.

Ideas for future developments in future PRs:
1. make it possible to specify the global observables when generating a dataset:
    `model.generate(x, 1000, GlobalObservables(g))`
2. make it possible to also sample global observable values when generating a toy dataset:
    `model.generate({x, g}, 1000, GlobalObservables(g))`
3. Add a tutorial to show all the new functionality related to global observables

Closes https://github.com/root-project/root/issues/8123.