### PR TITLE
[IO] Write title of TNamed-derived object in TKey constructor

### DIFF
--- a/io/io/src/TKey.cxx
+++ b/io/io/src/TKey.cxx
@@ -325,6 +325,12 @@ TKey::TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, T
       actualStart = obj;
    }
 
+   if (clActual->InheritsFrom("TNamed")){
+      // This object has its own title, overwrite default one
+      auto namedobj = static_cast<const TNamed *>(clActual->DynamicCast(TNamed::Class(), obj));
+      SetTitle(namedobj->GetTitle());
+   }
+
    Build(motherDir, clActual->GetName(), -1);
 
    fBufferRef = new TBufferFile(TBuffer::kWrite, bufsize);


### PR DESCRIPTION
The [TKey constructor that accepts a void pointer](https://github.com/root-project/root/blob/35b5aaef38b6635e131e7d93a0c96f69bb293b9d/io/io/src/TKey.cxx#L299-L300) calls the parent TNamed constructor with a default title, because in general there is no guarantee the object has the interface `GetTitle(),SetTitle()` and there is no extra "title" parameter to the constructor.

This leads though to some weird situations when using the [TDirectory::WriteObject](https://github.com/root-project/root/blob/35b5aaef38b6635e131e7d93a0c96f69bb293b9d/core/base/inc/TDirectory.h#L265-L268) method to write objects to files. If the written object actually has a title, this would be discarded because the function doesn't manage it as a TObject-derived instance on purpose. For example, the program below:

```cpp
#include <TFile.h>
#include <TH1F.h>

int main(){
    TFile f{"myfile.root","recreate"};
    TH1F h{"myhistoname","myhistotitle",100,0,100};
    f.WriteObject(&h, h.GetName());
    f.Close();
}
```

When executed creates a file where the object "h" gets the default title "object title":

```bash
$ rootls -l myfile.root
TH1F  Aug 21 10:41 2021 myhistoname;1 "object title"
```

This commit adds an extra check in the TKey constructor above. If the object is derived from TNamed, then we know that it has a title (either empty or provided by the user), so we should use that instead of "object title". It could be interesting to have a way to
generalise this to classes that have a `GetTitle(), SetTitle()` interface, but it would be more difficult. After this commit, the example
above outputs a file that contains the histogram object with the correct title:

```bash
$ rootls -l myfile.root
TH1F  Aug 21 11:00 2021 myhistoname;1 "myhistotitle"
```

## Note
This commit provides an idea of a fix, if there's a faster way to get to the object title that doesn't involve all those casts it would be great :smile: 
