### PR TITLE
[PyROOT] Disable RooFit PyROOT documentation

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -41,7 +41,7 @@ images:
 
 pyzdoc:
 	$(PYTHON_EXECUTABLE) extract_docstrings.py $(PYZ_DIR)
-	$(PYTHON_EXECUTABLE) print_roofit_pyz_doctrings.py > $(PYZ_DIR)/_roofit.pyzdoc
+	#$(PYTHON_EXECUTABLE) print_roofit_pyz_doctrings.py > $(PYZ_DIR)/_roofit.pyzdoc
 
 doxygen: filter pyzdoc
 	$(call MkDir,$(DOXYGEN_OUTPUT_DIRECTORY))


### PR DESCRIPTION
The generation of the doxygen code for the RooFit PyROOT documentation
is disabled until a solution is found to get acceess to the
RooFit pythonization mirror classes to extract the docstring.