### PR TITLE
Update the ref guide main page

### DIFF
--- a/documentation/doxygen/mainpage.md
+++ b/documentation/doxygen/mainpage.md
@@ -3,16 +3,24 @@
 ### Introduction
 Welcome to %ROOT!
 
-This is the reference manual of the ROOT software tooklit.
-You can find in the [reference documentation page](https://root.cern/reference/) pointers to reference manuals for all %ROOT versions.
+This is the Reference Guide of the ROOT software toolkit.
+You can find in the [reference documentation page](https://root.cern/reference/) pointers
+to Reference Guides for all %ROOT versions.
 
-### Other types of documentation:
+### Manuals
 
+- The [Manual](https://root.cern/manual/) provides a more in depth explanation of
+  concepts and functionality available in the %ROOT system. It is closely linked to the
+  Reference Guide.
+- A number of topical [User Guides and Manuals](https://root.cern/topical/) for various
+  components of the system.
+
+### Tutorials and courses
+
+- A rich set of %ROOT [tutorials and code examples](https://root.cern/doc/master/group__Tutorials.html) are offered to developers to exercise specific functionality.
 - [ROOT Primer](https://root.cern/primer/).
 - [ROOT Introductory Course](https://github.com/root-project/training/tree/master/BasicCourse).
-- A rich set of %ROOT [tutorials and code examples](https://root.cern/doc/master/group__Tutorials.html) are offered to developers to exercise specific functionality.
-- A general [Manual](https://root.cern/manual/) is provided for a more in depth explanation of concepts and functionality available in the %ROOT system.
-- A number of topical [User Guides and Manuals](https://root.cern/topical/) for various components of the system.
+
 
 ### Provide your feedback
 If you have suggestions about how to improve this documentation, you can let us know:


### PR DESCRIPTION
Reorganise the ref guide main page to highlight the Manual. The tutorial and course are listed in a separated paragraph. Fix for typo.
