### PR TITLE
[TMVA][SOFIE] Include ROperator_Conv in sofie/CMakeLists.txt

### DIFF
--- a/tmva/sofie/CMakeLists.txt
+++ b/tmva/sofie/CMakeLists.txt
@@ -19,6 +19,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofie
    TMVA/ROperator_Gemm.hxx
    TMVA/ROperator_Relu.hxx
    TMVA/ROperator_Transpose.hxx
+   TMVA/ROperator_Conv.hxx
    TMVA/SOFIE_common.hxx
   SOURCES
     src/RModel.cxx


### PR DESCRIPTION
This Pull request modifies `tmva/sofie/CMakeLists.txt`  by adding `ROperator_Conv.hxx` in the INCLUDE files.

## Checklist:
- [x] tested changes locally