### PR TITLE
Fix to TGeoMaterial::AddElement 

### DIFF
--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -18,6 +18,7 @@ Base class describing materials.
 */
 
 #include <iostream>
+#include <limits>
 #include "TMath.h"
 #include "TObjArray.h"
 #include "TGeoElement.h"
@@ -796,8 +797,17 @@ void TGeoMixture::AverageProperties()
 void TGeoMixture::AddElement(Double_t a, Double_t z, Double_t weight)
 {
    TGeoElementTable *table = gGeoManager->GetElementTable();
-   if (z<1 || z>table->GetNelements()-1)
+
+   // Check preconditions
+   if (weight < 0e0)    {
+      Fatal("AddElement", "Cannot add element with negative weight %g to mixture %s", weight, GetName());
+   }
+   else if ( weight < std::numeric_limits<Double_t>::epsilon() )   {
+      return;
+   }
+   else if (z<1 || z>table->GetNelements()-1)   {
       Fatal("AddElement", "Cannot add element having Z=%d to mixture %s", (Int_t)z, GetName());
+   }
    Int_t i;
    for (i=0; i<fNelements; i++) {
       if (!fElements && TMath::Abs(z-fZmixture[i])<1.e-6  && TMath::Abs(a-fAmixture[i])<1.e-6) {
@@ -849,6 +859,18 @@ void TGeoMixture::AddElement(TGeoMaterial *mat, Double_t weight)
 {
    TGeoElement *elnew, *elem;
    Double_t a,z;
+
+   // Check preconditions
+   if (!mat)   {
+      Fatal("AddElement", "Cannot add INVALID material to mixture %s", GetName());
+   }
+   else if (weight < 0e0)   {
+      Fatal("AddElement", "Cannot add material %s with negative weight %g to mixture %s",
+            mat->GetName(), weight, GetName());
+   }
+   else if ( weight < std::numeric_limits<Double_t>::epsilon() )   {
+      return;
+   }
    if (!mat->IsMixture()) {
       elem = mat->GetBaseElement();
       if (elem) {
@@ -873,7 +895,7 @@ void TGeoMixture::AddElement(TGeoMaterial *mat, Double_t weight)
       if (!elnew) continue;
       // check if we have the element already defined in the parent mixture
       for (j=0; j<fNelements; j++) {
-         if (fWeights[j]<=0) continue;
+         if ( fWeights[j] < 0e0 ) continue;
          elem = GetElement(j);
          if (elem == elnew) {
             // element found, compute new weight
@@ -898,13 +920,29 @@ void TGeoMixture::AddElement(TGeoElement *elem, Double_t weight)
    TGeoElementTable *table = gGeoManager->GetElementTable();
    if (!fElements) fElements = new TObjArray(128);
    Bool_t exist = kFALSE;
+
+   // Check preconditions
+   if (!elem)   {
+      Fatal("AddElement", "Cannot add INVALID element to mixture %s", GetName());
+   }
+   else if (weight < 0e0)   {
+      Fatal("AddElement", "Cannot add element %s with negative weight %g to mixture %s",
+            elem->GetName(), weight, GetName());
+   }
+   else if ( weight < std::numeric_limits<Double_t>::epsilon() )   {
+      return;
+   }
    // If previous elements were defined by A/Z, add corresponding TGeoElements
    for (Int_t i=0; i<fNelements; i++) {
       elemold = (TGeoElement*)fElements->At(i);
-      if (!elemold) fElements->AddAt(elemold = table->GetElement((Int_t)fZmixture[i]), i);
+      if (!elemold)  {
+        fElements->AddAt(elemold = table->GetElement((Int_t)fZmixture[i]), i);
+      }
       if (elemold == elem) exist = kTRUE;
    }
-   if (!exist) fElements->AddAtAndExpand(elem, fNelements);
+   if (!exist)   {
+     fElements->AddAtAndExpand(elem, fNelements);
+   }
    AddElement(elem->A(), elem->Z(), weight);
 }
 


### PR DESCRIPTION
# This Pull request:
Fix to TGeoMaterial::AddElement to allow to add elements/materials/mixtures with weight zero
## Changes or fixes:
Allow to add elements/materials/mixtures with weight zero. 
If weight is negative issue Fatal .
If weight is smaller than numeric_limits<Double_t>::epsilon(), ignore additional elements.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/8892
