### PR TITLE
[DF] Add parameter `zero` in ROOT::VecOps::Sum and ROOT::VecOps::Mean

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -760,11 +760,24 @@ auto Dot(const RVec<T> &v0, const RVec<V> &v1) -> decltype(v0[0] * v1[0])
 /// auto v_sum = Sum(v);
 /// v_sum
 /// // (float) 6.f
+/// auto v_sum_d = Sum(v, 0.);
+/// v_sum_d
+/// // (double) 6.0000000
 /// ~~~
-template <typename T>
-T Sum(const RVec<T> &v)
+/// ~~~{.cpp}
+/// using namespace ROOT::VecOps;
+/// const ROOT::Math::PtEtaPhiMVector lv0 {15.5f, .3f, .1f, 105.65f},
+///   lv1 {34.32f, 2.2f, 3.02f, 105.65f},
+///   lv2 {12.95f, 1.32f, 2.2f, 105.65f};
+/// RVec<ROOT::Math::PtEtaPhiMVector> v {lv0, lv1, lv2};
+/// auto v_sum_lv = Sum(v, ROOT::Math::PtEtaPhiMVector());
+/// v_sum_lv
+/// // (ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > &) (30.8489,2.46534,2.58947,361.084)
+/// ~~~
+template <typename T, typename R = T>
+R Sum(const RVec<T> &v, const R zero = R(0))
 {
-   return std::accumulate(v.begin(), v.end(), T(0));
+   return std::accumulate(v.begin(), v.end(), zero);
 }
 
 /// Get the mean of the elements of an RVec
@@ -783,6 +796,37 @@ double Mean(const RVec<T> &v)
 {
    if (v.empty()) return 0.;
    return double(Sum(v)) / v.size();
+}
+
+/// Get the mean of the elements of an RVec with custom initial value
+///
+/// The return type will be deduced from the `zero` parameter
+/// Example code, at the ROOT prompt:
+/// ~~~{.cpp}
+/// using namespace ROOT::VecOps;
+/// RVec<float> v {1.f, 2.f, 4.f};
+/// auto v_mean_f = Mean(v, 0.f);
+/// v_mean_f
+/// // (float) 2.33333f
+/// auto v_mean_d = Mean(v, 0.);
+/// v_mean_d
+/// // (double) 2.3333333
+/// ~~~
+/// ~~~{.cpp}
+/// using namespace ROOT::VecOps;
+/// const ROOT::Math::PtEtaPhiMVector lv0 {15.5f, .3f, .1f, 105.65f},
+///   lv1 {34.32f, 2.2f, 3.02f, 105.65f},
+///   lv2 {12.95f, 1.32f, 2.2f, 105.65f};
+/// RVec<ROOT::Math::PtEtaPhiMVector> v {lv0, lv1, lv2};
+/// auto v_mean_lv = Mean(v, ROOT::Math::PtEtaPhiMVector());
+/// v_mean_lv
+/// // (ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > &) (10.283,2.46534,2.58947,120.361)
+/// ~~~
+template <typename T, typename R = T>
+R Mean(const RVec<T> &v, const R zero)
+{
+   if (v.empty()) return zero;
+   return Sum(v, zero) / v.size();
 }
 
 /// Get the greatest element of an RVec

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -35,6 +35,13 @@ void CheckEqual(const RVec<double> &a, const RVec<double> &b, std::string_view m
    }
 }
 
+void CheckEqual(const ROOT::Math::PtEtaPhiMVector &a, const ROOT::Math::PtEtaPhiMVector &b) {
+   EXPECT_DOUBLE_EQ(a.Pt(), b.Pt());
+   EXPECT_DOUBLE_EQ(a.Eta(), b.Eta());
+   EXPECT_DOUBLE_EQ(a.Phi(), b.Phi());
+   EXPECT_DOUBLE_EQ(a.M(), b.M());
+}
+
 template <typename T, typename V>
 void CheckEqual(const T &a, const V &b, std::string_view msg = "")
 {
@@ -741,6 +748,27 @@ TEST(VecOps, SimpleStatOps)
    ASSERT_DOUBLE_EQ(ArgMin(v4), 2);
    ASSERT_DOUBLE_EQ(Var(v4), 1.);
    ASSERT_DOUBLE_EQ(StdDev(v4), 1.);
+
+   ROOT::VecOps::RVec<int> v5 {2, 3, 1, 4};
+   ASSERT_DOUBLE_EQ(Sum(v5), 10);
+   ASSERT_DOUBLE_EQ(Mean(v5), 2.5);
+   ASSERT_DOUBLE_EQ(Max(v5), 4);
+   ASSERT_DOUBLE_EQ(Min(v5), 1);
+   ASSERT_DOUBLE_EQ(ArgMax(v5), 3);
+   ASSERT_DOUBLE_EQ(ArgMin(v5), 2);
+   ASSERT_DOUBLE_EQ(Var(v5), 5./3);
+   ASSERT_DOUBLE_EQ(StdDev(v5), std::sqrt(5./3));
+
+   const ROOT::Math::PtEtaPhiMVector lv0 {15.5f, .3f, .1f, 105.65f};
+   const ROOT::Math::PtEtaPhiMVector lv1 {34.32f, 2.2f, 3.02f, 105.65f};
+   const ROOT::Math::PtEtaPhiMVector lv2 {12.95f, 1.32f, 2.2f, 105.65f};
+   const ROOT::Math::PtEtaPhiMVector lv_sum_ref = lv0 + lv1 + lv2;
+   const ROOT::Math::PtEtaPhiMVector lv_mean_ref = lv_sum_ref / 3;
+   ROOT::VecOps::RVec<ROOT::Math::PtEtaPhiMVector> v6 {lv0, lv1, lv2};
+   const ROOT::Math::PtEtaPhiMVector lv_sum = ROOT::VecOps::Sum(v6, ROOT::Math::PtEtaPhiMVector());
+   const ROOT::Math::PtEtaPhiMVector lv_mean = ROOT::VecOps::Mean(v6, ROOT::Math::PtEtaPhiMVector());
+   CheckEqual(lv_sum, lv_sum_ref);
+   CheckEqual(lv_mean, lv_mean_ref);
 }
 
 TEST(VecOps, Any)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Add the `zero` parameter for `ROOT::VecOps::Sum()` and ROOT::VecOps::Mean()`` functions.
Used as `ROOT::VecOps::Sum(v, ROOT::Math::PtEtaPhiEVector())`
If applied, users will be able to get the sum of non-numeric `RVec`s easily.

This is my first PR here. Please tell me if there is something I missed.

## Checklist:

- [X] tested changes locally
- [X] updated the docs (if necessary)

<!-- This PR fixes # --> 

