### PR TITLE
[core] TDirectory::RegisterGDirectory must not update other TDirectoy without lock

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1306,23 +1306,16 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Register a std::atomic<TDirectory*> pointing to this TDirectory object
+/// Register a std::atomic<TDirectory*> that will soon be pointing to this TDirectory object
 
 void TDirectory::RegisterGDirectory(std::atomic<TDirectory*> *globalptr)
 {
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 
-   auto oldvalue = globalptr->load();
-
-   auto iter = std::find(fGDirectories.begin(), fGDirectories.end(), globalptr);
-   if (iter != fGDirectories.begin())
+   if (std::find(fGDirectories.begin(), fGDirectories.end(), globalptr) != fGDirectories.end())
       fGDirectories.push_back(globalptr);
-
-   if (oldvalue && oldvalue != this) {
-      iter = std::find(oldvalue->fGDirectories.begin(), oldvalue->fGDirectories.end(), globalptr);
-      if (iter != oldvalue->fGDirectories.begin())
-         oldvalue->fGDirectories.erase(iter);
-   }
+   // globalptr->load()->fGDirectories will still contain globalptr, but we cannot
+   // know whether globalptr->load() has been deleted by another thread in the meantime.
 }
 
 


### PR DESCRIPTION
As we cannot even know whether the other TDirectory has been deleted in the meantime, we have to
skip the optimization of erasing globalptr from the list of the oldvalue.

This is expected to fix MT crashes observed by Alice.
