### PR TITLE
Add rootcling support for `-isystem`

### DIFF
--- a/builtins/davix/CMakeLists.txt
+++ b/builtins/davix/CMakeLists.txt
@@ -79,7 +79,7 @@ set(DAVIX_LIBRARY ${DAVIX_PREFIX}/lib/${DAVIX_LIBNAME} CACHE INTERNAL "" FORCE)
 set(DAVIX_LIBRARIES ${DAVIX_LIBRARIES} CACHE INTERNAL "" FORCE)
 
 add_library(davix INTERFACE)
-target_include_directories(davix INTERFACE $<BUILD_INTERFACE:${DAVIX_INCLUDE_DIR}>)
+target_include_directories(davix SYSTEM INTERFACE $<BUILD_INTERFACE:${DAVIX_INCLUDE_DIR}>)
 target_link_libraries(davix INTERFACE $<BUILD_INTERFACE:${DAVIX_LIBRARIES}>)
 add_dependencies(davix DAVIX)
 

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -286,8 +286,8 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     set(libprefix "")
   endif()
 
-   # list of include directories for dictionary generation
-   set(incdirs)
+  # list of include directories for dictionary generation
+  set(incdirs)
 
   if((CMAKE_PROJECT_NAME STREQUAL ROOT) AND (TARGET ${ARG_MODULE}))
     set(headerdirs)

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3801,6 +3801,10 @@ gOptIncludePaths("I", llvm::cl::Prefix, llvm::cl::ZeroOrMore,
                 llvm::cl::desc("Specify an include path."),
                 llvm::cl::cat(gRootclingOptions));
 static llvm::cl::list<std::string>
+gOptSysIncludePaths("isystem", llvm::cl::ZeroOrMore,
+                    llvm::cl::desc("Specify a system include path."),
+                    llvm::cl::cat(gRootclingOptions));
+static llvm::cl::list<std::string>
 gOptPPDefines("D", llvm::cl::Prefix, llvm::cl::ZeroOrMore,
              llvm::cl::desc("Specify defined macros."),
              llvm::cl::cat(gRootclingOptions));
@@ -4111,6 +4115,11 @@ int RootClingMain(int argc,
 
    for (const std::string &IncludePath : gOptIncludePaths)
       clingArgs.push_back(std::string("-I") + llvm::sys::path::convert_to_slash(IncludePath));
+
+   for (const std::string &IncludePath : gOptSysIncludePaths) {
+      clingArgs.push_back("-isystem");
+      clingArgs.push_back(llvm::sys::path::convert_to_slash(IncludePath));
+   }
 
    for (const std::string &WDiag : gOptWDiags) {
       const std::string FullWDiag = std::string("-W") + WDiag;

--- a/net/http/CMakeLists.txt
+++ b/net/http/CMakeLists.txt
@@ -55,7 +55,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RHTTP
 )
 
 if(ssl)
-  target_include_directories(RHTTP PRIVATE ${OPENSSL_INCLUDE_DIR})
+  target_include_directories(RHTTP SYSTEM PRIVATE ${OPENSSL_INCLUDE_DIR})
 endif()
 
 if(FASTCGI_FOUND)

--- a/sql/sqlite/CMakeLists.txt
+++ b/sql/sqlite/CMakeLists.txt
@@ -25,5 +25,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RSQLite
     RIO
 )
 
-target_include_directories(RSQLite PUBLIC ${SQLITE_INCLUDE_DIR})
+target_include_directories(RSQLite SYSTEM PUBLIC ${SQLITE_INCLUDE_DIR})
 target_link_libraries(RSQLite PUBLIC ${SQLITE_LIBRARIES})


### PR DESCRIPTION
This fixes warnings emitted by rootcling stemming from external libraries.

The difficult part is that `-isystem /usr/include` causes havoc and needs to be removed.
