### PR TITLE
[RF][PyROOT] Use raw strings for docstrings in RooFit pythonization mirror classes and avoid mutating the docstring of an instancemethod in Python 2

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
@@ -149,7 +149,7 @@ def rebind_instancemethod(to_class, from_class, func_name):
 
     import sys
 
-    if sys.version_info > (3, 0):
+    if sys.version_info >= (3, 0):
         to_method = from_method
     else:
         import new
@@ -197,6 +197,10 @@ def pythonize_roofit_class(klass, name):
             func_new = getattr(python_klass, func_name)
 
             import inspect
+            import sys
+
+            if sys.version_info < (3, 0):
+                func_new = func_new.__func__
 
             if func_new.__doc__ is None:
                 func_new.__doc__ = func_orig.__doc__

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabscollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabscollection.py
@@ -16,7 +16,7 @@ from libcppyy import SetOwnership
 
 
 class RooAbsCollection(object):
-    """Some member functions of RooAbsCollection that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooAbsCollection that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooAbsCollection::printLatex. For example, the following code is equivalent in PyROOT:
     \code{.py}
     # Directly passing a RooCmdArg:
@@ -29,7 +29,7 @@ class RooAbsCollection(object):
 
     @cpp_signature("RooAbsArg *RooAbsCollection::addClone(const RooAbsArg& var, Bool_t silent=kFALSE) ;")
     def addClone(self, arg, silent=False):
-        """The RooAbsCollection::addClone() function is pythonized with the command argument pythonization.
+        r"""The RooAbsCollection::addClone() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         clonedArg = self._addClone(arg, silent)
@@ -37,7 +37,7 @@ class RooAbsCollection(object):
 
     @cpp_signature("Bool_t RooAbsCollection::addOwned(RooAbsArg& var, Bool_t silent=kFALSE);")
     def addOwned(self, arg, silent=False):
-        """The RooAbsCollection::addOwned() function is pythonized with the command argument pythonization.
+        r"""The RooAbsCollection::addOwned() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function."""
         self._addOwned(arg, silent)
         SetOwnership(arg, False)
@@ -46,10 +46,10 @@ class RooAbsCollection(object):
         "RooAbsCollection::printLatex(const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),"
         "                        const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),"
         "                        const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),"
-        "	                    const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) const ;"
+        "                        const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) const ;"
     )
     def printLatex(self, *args, **kwargs):
-        """The RooAbsCollection::printLatex() function is pythonized with the command argument pythonization.
+        r"""The RooAbsCollection::printLatex() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsCollection.printLatex` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabsdata.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabsdata.py
@@ -16,7 +16,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooAbsData(object):
-    """Some member functions of RooAbsData that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooAbsData that take a RooCmdArg as argument also support keyword arguments.
     This applies to RooAbsData::plotOn, RooAbsData::createHistogram, RooAbsData::reduce, RooAbsData::statOn.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -36,7 +36,7 @@ class RooAbsData(object):
         "			  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def plotOn(self, *args, **kwargs):
-        """The RooAbsData::plotOn() function is pythonized with the command argument pythonization.
+        r"""The RooAbsData::plotOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsData.plotOn` for keyword arguments.
@@ -51,7 +51,7 @@ class RooAbsData(object):
         "                       const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def createHistogram(self, *args, **kwargs):
-        """The RooAbsData::createHistogram() function is pythonized with the command argument pythonization.
+        r"""The RooAbsData::createHistogram() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsData.createHistogram` for keyword arguments.
@@ -65,7 +65,7 @@ class RooAbsData(object):
         "                   const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;"
     )
     def reduce(self, *args, **kwargs):
-        """The RooAbsData::reduce() function is pythonized with the command argument pythonization.
+        r"""The RooAbsData::reduce() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsData.reduce` for keyword arguments.
@@ -80,7 +80,7 @@ class RooAbsData(object):
         "                          const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def statOn(self, *args, **kwargs):
-        """The RooAbsData::statOn() function is pythonized with the command argument pythonization.
+        r"""The RooAbsData::statOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsData.statOn` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabspdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabspdf.py
@@ -16,7 +16,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooAbsPdf(RooAbsReal):
-    """Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooAbsPdf that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooAbsPdf::fitTo, RooAbsPdf::plotOn, RooAbsPdf::generate, RooAbsPdf::paramOn, RooAbsPdf::createCdf,
     RooAbsPdf::generateBinned, RooAbsPdf::createChi2, RooAbsPdf::prepareMultiGen and RooAbsPdf::createNLL.
     For example, the following code is equivalent in PyROOT:
@@ -32,7 +32,7 @@ class RooAbsPdf(RooAbsReal):
         "RooAbsPdf::fitTo(RooAbsData&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)"
     )
     def fitTo(self, *args, **kwargs):
-        """The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::fitTo() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.fitTo` for keyword arguments.
@@ -49,7 +49,7 @@ class RooAbsPdf(RooAbsReal):
         ") const;"
     )
     def plotOn(self, *args, **kwargs):
-        """The RooAbsPdf::plotOn() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::plotOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.plotOn` for keyword arguments.
@@ -63,7 +63,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
     )
     def generate(self, *args, **kwargs):
-        """The RooAbsPdf::generate() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::generate() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.generate` for keyword arguments.
@@ -78,7 +78,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def paramOn(self, *args, **kwargs):
-        """The RooAbsPdf::paramOn() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::paramOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.paramOn` for keyword arguments.
@@ -91,7 +91,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def createNLL(self, *args, **kwargs):
-        """The RooAbsPdf::createNLL() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::createNLL() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.createNLL` for keyword arguments.
@@ -104,7 +104,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def createChi2(self, *args, **kwargs):
-        """The RooAbsPdf::createChi2() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::createChi2() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.createChi2` for keyword arguments.
@@ -118,7 +118,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def createCdf(self, *args, **kwargs):
-        """The RooAbsPdf::createCdf() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::createCdf() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.createCdf` for keyword arguments.
@@ -132,7 +132,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) const;"
     )
     def generateBinned(self, *args, **kwargs):
-        """The RooAbsPdf::generateBinned() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::generateBinned() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.generateBinned` for keyword arguments.
@@ -146,7 +146,7 @@ class RooAbsPdf(RooAbsReal):
         "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
     )
     def prepareMultiGen(self, *args, **kwargs):
-        """The RooAbsPdf::prepareMultiGen() function is pythonized with the command argument pythonization.
+        r"""The RooAbsPdf::prepareMultiGen() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsPdf.prepareMultiGen` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabsreal.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabsreal.py
@@ -16,7 +16,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooAbsReal(object):
-    """Some member functions of RooAbsReal that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooAbsReal that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooAbsReal::plotOn, RooAbsReal::createHistogram, RooAbsReal::chi2FitTo,
     RooAbsReal::createChi2, RooAbsReal::createRunningIntegral and RooAbsReal::createIntegral
     For example, the following code is equivalent in PyROOT:
@@ -38,7 +38,7 @@ class RooAbsReal(object):
         "    const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const ;"
     )
     def plotOn(self, *args, **kwargs):
-        """The RooAbsReal::plotOn() function is pythonized with the command argument pythonization.
+        r"""The RooAbsReal::plotOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsReal.plotOn` for keyword arguments.
@@ -53,7 +53,7 @@ class RooAbsReal(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def createHistogram(self, *args, **kwargs):
-        """The RooAbsReal::createHistogram() function is pythonized with the command argument pythonization.
+        r"""The RooAbsReal::createHistogram() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsReal.createHistogram` for keyword arguments.
@@ -67,7 +67,7 @@ class RooAbsReal(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def createIntegral(self, *args, **kwargs):
-        """The RooAbsReal::createIntegral() function is pythonized with the command argument pythonization.
+        r"""The RooAbsReal::createIntegral() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsReal.createIntegral` for keyword arguments.
@@ -81,7 +81,7 @@ class RooAbsReal(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def createRunningIntegral(self, *args, **kwargs):
-        """The RooAbsReal::createRunningIntegral() function is pythonized with the command argument pythonization.
+        r"""The RooAbsReal::createRunningIntegral() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsReal.createRunningIntegral` for keyword arguments.
@@ -94,7 +94,7 @@ class RooAbsReal(object):
         "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def createChi2(self, *args, **kwargs):
-        """The RooAbsReal::createChi2() function is pythonized with the command argument pythonization.
+        r"""The RooAbsReal::createChi2() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsReal.createChi2` for keyword arguments.
@@ -107,7 +107,7 @@ class RooAbsReal(object):
         "    const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def chi2FitTo(self, *args, **kwargs):
-        """The RooAbsReal::chi2FitTo() function is pythonized with the command argument pythonization.
+        r"""The RooAbsReal::chi2FitTo() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsReal.chi2FitTo` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabsreallvalue.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooabsreallvalue.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooAbsRealLValue(object):
-    """Some member functions of RooAbsRealLValue that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooAbsRealLValue that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooAbsRealLValue::createHistogram and RooAbsRealLValue::frame.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -35,7 +35,7 @@ class RooAbsRealLValue(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def createHistogram(self, *args, **kwargs):
-        """The RooAbsRealLValue::createHistogram() function is pythonized with the command argument pythonization.
+        r"""The RooAbsRealLValue::createHistogram() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsRealLValue.createHistogram` for keyword arguments.
@@ -48,7 +48,7 @@ class RooAbsRealLValue(object):
         "    const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def frame(self, *args, **kwargs):
-        """The RooAbsRealLValue::frame() function is pythonized with the command argument pythonization.
+        r"""The RooAbsRealLValue::frame() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooAbsRealLValue.frame` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roocategory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roocategory.py
@@ -15,7 +15,7 @@ from ._utils import _dict_to_std_map, cpp_signature
 
 
 class RooCategory(object):
-    """Constructor of RooCategory takes a map as an argument also supports python dictionaries.
+    r"""Constructor of RooCategory takes a map as an argument also supports python dictionaries.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
     # Default bindings :
@@ -30,7 +30,7 @@ class RooCategory(object):
 
     @cpp_signature("RooCategory(const char* name, const char* title, const std::map<std::string, int>& allowedStates);")
     def __init__(self, *args, **kwargs):
-        """The RooCategory constructor is pythonized for converting python dict to std::map.
+        r"""The RooCategory constructor is pythonized for converting python dict to std::map.
         The instances in the dict must correspond to the template argument in std::map of the constructor.
         """
         # Redefinition of `RooCategory` constructor for converting python dict to std::map.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roochi2var.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roochi2var.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooChi2Var(object):
-    """Constructor of RooChi2Var takes a RooCmdArg as argument also supports keyword arguments."""
+    r"""Constructor of RooChi2Var takes a RooCmdArg as argument also supports keyword arguments."""
 
     @cpp_signature(
         [
@@ -30,7 +30,7 @@ class RooChi2Var(object):
         ]
     )
     def __init__(self, *args, **kwargs):
-        """The RooCategory constructor is pythonized for converting python dict to std::map.
+        r"""The RooCategory constructor is pythonized for converting python dict to std::map.
         The keywords must correspond to the CmdArg of the constructor function.
         """
         # Redefinition of `RooChi2Var` constructor for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodatahist.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodatahist.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, _dict_to_std_map, cpp_signature
 
 
 class RooDataHist(object):
-    """Constructor of RooDataHist takes a RooCmdArg as argument also supports keyword arguments.
+    r"""Constructor of RooDataHist takes a RooCmdArg as argument also supports keyword arguments.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
     # Directly passing a RooCmdArg:
@@ -33,7 +33,7 @@ class RooDataHist(object):
         ]
     )
     def __init__(self, *args, **kwargs):
-        """The RooDataHist constructor is pythonized with the command argument pythonization and for converting python dict to std::map.
+        r"""The RooDataHist constructor is pythonized with the command argument pythonization and for converting python dict to std::map.
         The keywords must correspond to the CmdArg of the constructor function.
         The instances in dict must correspond to the template argument in std::map of the constructor.
         """

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodataset.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooDataSet(object):
-    """Some member functions of RooDataSet that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooDataSet that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooDataSet() constructor and RooDataSet::plotOnXY.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -33,7 +33,7 @@ class RooDataSet(object):
         "    const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooDataSet constructor is pythonized with the command argument pythonization.
+        r"""The RooDataSet constructor is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the constructor.
         """
         # Redefinition of `RooDataSet` constructor for keyword arguments.
@@ -48,7 +48,7 @@ class RooDataSet(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;"
     )
     def plotOnXY(self, *args, **kwargs):
-        """The RooDataSet::plotOnXY() function is pythonized with the command argument pythonization.
+        r"""The RooDataSet::plotOnXY() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooDataSet.plotOnXY` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodecays.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodecays.py
@@ -15,7 +15,7 @@ from ._utils import _decaytype_string_to_enum, cpp_signature
 
 
 class RooDecay(object):
-    """Some constructors of classes like RooDecay, RooBDecay, RooBCPGenDecay, RooBCPEffDecay and RooBMixDecay that take an enum
+    r"""Some constructors of classes like RooDecay, RooBDecay, RooBCPGenDecay, RooBCPEffDecay and RooBMixDecay that take an enum
     DecayType as argument also support keyword arguments.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -31,7 +31,7 @@ class RooDecay(object):
         "RooDecay(const char *name, const char *title, RooRealVar& t, RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooDecay constructor is pythonized with enum values."""
+        r"""The RooDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
 
@@ -44,7 +44,7 @@ class RooBDecay(object):
         "    const RooResolutionModel& model,   DecayType type);"
     )
     def __init__(self, *args, **kwargs):
-        """The RooBDecay constructor is pythonized with enum values."""
+        r"""The RooBDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
 
@@ -56,7 +56,7 @@ class RooBCPGenDecay(object):
         "    RooAbsReal& delMistag, RooAbsReal& mu, const RooResolutionModel& model, DecayType type=DoubleSided) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooBCPGenDecay constructor is pythonized with enum values."""
+        r"""The RooBCPGenDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
 
@@ -69,7 +69,7 @@ class RooBCPEffDecay(object):
         "    const RooResolutionModel& model, DecayType type=DoubleSided) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooBCPEffDecay constructor is pythonized with enum values."""
+        r"""The RooBCPEffDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)
 
@@ -81,6 +81,6 @@ class RooBMixDecay(object):
         "    RooAbsReal& delMistag, const RooResolutionModel& model, DecayType type=DoubleSided) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooBMixDecay constructor is pythonized with enum values."""
+        r"""The RooBMixDecay constructor is pythonized with enum values."""
         kwargs = _decaytype_string_to_enum(self, kwargs)
         self._init(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roogenfitstudy.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roogenfitstudy.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooGenFitStudy(object):
-    """Some member functions of RooGenFitStudy that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooGenFitStudy that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooGenFitStudy::setGenConfig.
     """
 
@@ -26,7 +26,7 @@ class RooGenFitStudy(object):
         ]
     )
     def setGenConfig(self, *args, **kwargs):
-        """The RooGenFitStudy::setGenConfig() function is pythonized with the command argument pythonization.
+        r"""The RooGenFitStudy::setGenConfig() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function.
         """
         # Redefinition of `RooGenFitStudy.setGenConfig` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooglobalfunc.py
@@ -60,7 +60,7 @@ _style_map = {"-": "kSolid", "--": "kDashed", ":": "kDotted", "-.": "kDashDotted
     "const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
 )
 def FitOptions(*args, **kwargs):
-    """The FitOptions() function is pythonized with the command argument pythonization.
+    r"""The FitOptions() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
     """
     # Redefinition of `FitOptions` for keyword arguments.
@@ -77,7 +77,7 @@ def FitOptions(*args, **kwargs):
     "const RooCmdArg& arg7=RooCmdArg::none(),const RooCmdArg& arg8=RooCmdArg::none()) ;"
 )
 def Format(*args, **kwargs):
-    """The Format() function is pythonized with the command argument pythonization.
+    r"""The Format() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
     """
     # Redefinition of `Format` for keyword arguments.
@@ -96,7 +96,7 @@ def Format(*args, **kwargs):
     "const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none()) ;"
 )
 def Frame(*args, **kwargs):
-    """The Frame() function is pythonized with the command argument pythonization.
+    r"""The Frame() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
     """
     # Redefinition of `Frame` for keyword arguments.
@@ -113,7 +113,7 @@ def Frame(*args, **kwargs):
     "const RooCmdArg& arg7=RooCmdArg::none(),const RooCmdArg& arg8=RooCmdArg::none()) ;"
 )
 def MultiArg(*args, **kwargs):
-    """The MultiArg() function is pythonized with the command argument pythonization.
+    r"""The MultiArg() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
     """
     # Redefinition of `MultiArg` for keyword arguments.
@@ -125,7 +125,7 @@ def MultiArg(*args, **kwargs):
 
 @cpp_signature("YVar(const RooAbsRealLValue& var, const RooCmdArg& arg=RooCmdArg::none()) ;")
 def YVar(*args, **kwargs):
-    """The YVar() function is pythonized with the command argument pythonization.
+    r"""The YVar() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
     """
     # Redefinition of `YVar` for keyword arguments.
@@ -140,7 +140,7 @@ def YVar(*args, **kwargs):
 
 @cpp_signature("ZVar(const RooAbsRealLValue& var, const RooCmdArg& arg=RooCmdArg::none()) ;")
 def ZVar(*args, **kwargs):
-    """The ZVar() function is pythonized with the command argument pythonization.
+    r"""The ZVar() function is pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the function.
     """
     # Redefinition of `ZVar` for keyword arguments.
@@ -155,7 +155,7 @@ def ZVar(*args, **kwargs):
 
 @cpp_signature("Slice(std::map<RooCategory*, std::string> const&) ;")
 def Slice(*args, **kwargs):
-    """The Slice function is pythonized for converting python dict to std::map.
+    r"""The Slice function is pythonized for converting python dict to std::map.
     The keywords must correspond to the CmdArg of the function.
     The instances in the dict must correspond to the template argument in std::map of the function.
     """
@@ -178,7 +178,7 @@ def Slice(*args, **kwargs):
     ]
 )
 def Import(*args, **kwargs):
-    """The Import function is pythonized for converting python dict to std::map.
+    r"""The Import function is pythonized for converting python dict to std::map.
     The keywords must correspond to the CmdArg of the function.
     The instances in the dict must correspond to the template argument in std::map of the function.
     """
@@ -195,7 +195,7 @@ def Import(*args, **kwargs):
 
 @cpp_signature("Link(const std::map<std::string,RooAbsData*>&) ;")
 def Link(*args, **kwargs):
-    """The Link function is pythonized for converting python dict to std::map.
+    r"""The Link function is pythonized for converting python dict to std::map.
     The keywords must correspond to the CmdArg of the function.
     The instances in the dict must correspond to the template argument in std::map of the function.
     """

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roomcstudy.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roomcstudy.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooMCStudy(object):
-    """Some member functions of RooMCStudy that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooMCStudy that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to constructor RooMCStudy(), RooMCStudy::plotParamOn, RooMCStudy::plotParam, RooMCStudy::plotNLL, RooMCStudy::plotError and RooMCStudy::plotPull.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -34,7 +34,7 @@ class RooMCStudy(object):
         "    const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooMCStudy constructor is pythonized with the command argument pythonization.
+        r"""The RooMCStudy constructor is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the constructor function.
         """
         # Redefinition of `RooMCStudy` constructor for keyword arguments.
@@ -48,7 +48,7 @@ class RooMCStudy(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def plotParamOn(self, *args, **kwargs):
-        """The RooMCStudy::plotParamOn() function is pythonized with the command argument pythonization.
+        r"""The RooMCStudy::plotParamOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function."""
         # Redefinition of `RooMCStudy.plotParamOn` for keyword arguments.
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
@@ -66,7 +66,7 @@ class RooMCStudy(object):
         ]
     )
     def plotParam(self, *args, **kwargs):
-        """The RooMCStudy::plotParam() function is pythonized with the command argument pythonization.
+        r"""The RooMCStudy::plotParam() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function.
         """
         # Redefinition of `RooMCStudy.plotParam` for keyword arguments.
@@ -80,7 +80,7 @@ class RooMCStudy(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def plotNLL(self, *args, **kwargs):
-        """The RooMCStudy::plotNLL() function is pythonized with the command argument pythonization.
+        r"""The RooMCStudy::plotNLL() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function.
         """
         # Redefinition of `RooMCStudy.plotNLL` for keyword arguments.
@@ -94,7 +94,7 @@ class RooMCStudy(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def plotError(self, *args, **kwargs):
-        """The RooMCStudy::plotError() function is pythonized with the command argument pythonization.
+        r"""The RooMCStudy::plotError() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function.
         """
         # Redefinition of `RooMCStudy.plotError` for keyword arguments.
@@ -108,7 +108,7 @@ class RooMCStudy(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;"
     )
     def plotPull(self, *args, **kwargs):
-        """The RooMCStudy::plotError() function is pythonized with the command argument pythonization.
+        r"""The RooMCStudy::plotError() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function.
         """
         # Redefinition of `RooMCStudy.plotPull` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roomsgservice.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roomsgservice.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooMsgService(object):
-    """Some member functions of RooMsgService that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooMsgService that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooMsgService::addStream.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -31,7 +31,7 @@ class RooMsgService(object):
         "    const RooCmdArg& arg4=RooCmdArg(), const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg());"
     )
     def addStream(self, *args, **kwargs):
-        """The RooMsgService::addStream() function is pythonized with the command argument pythonization.
+        r"""The RooMsgService::addStream() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the function.
         """
         # Redefinition of `RooMsgService.addStream` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roonllvar.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roonllvar.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooNLLVar(object):
-    """RooNLLVar() constructor takes a RooCmdArg as argument also supports keyword arguments."""
+    r"""RooNLLVar() constructor takes a RooCmdArg as argument also supports keyword arguments."""
 
     @cpp_signature(
         "RooNLLVar(const char* name, const char* title, RooAbsPdf& pdf, RooAbsData& data,"
@@ -24,7 +24,7 @@ class RooNLLVar(object):
         "    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooNLLVar constructor is pythonized with the command argument pythonization.
+        r"""The RooNLLVar constructor is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArg of the constructor function.
         """
         # Redefinition of `RooNLLVar` constructor for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooprodpdf.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooprodpdf.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooProdPdf(object):
-    """RooProdPdf() constructor takes a RooCmdArg as argument also supports keyword arguments.
+    r"""RooProdPdf() constructor takes a RooCmdArg as argument also supports keyword arguments.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
     # Directly passing a RooCmdArg:
@@ -38,7 +38,7 @@ class RooProdPdf(object):
         "    const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooProdPdf constructor is pythonized with the command argument pythonization.
+        r"""The RooProdPdf constructor is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the constructor.
         """
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roosimultaneous.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooSimultaneous(object):
-    """Some member functions of RooSimultaneous that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooSimultaneous that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooSimultaneous::plotOn.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -36,7 +36,7 @@ class RooSimultaneous(object):
         "    const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const;"
     )
     def plotOn(self, *args, **kwargs):
-        """The RooSimultaneous::plotOn() function is pythonized with the command argument pythonization.
+        r"""The RooSimultaneous::plotOn() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooSimultaneous.plotOn` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roosimwstool.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roosimwstool.py
@@ -15,7 +15,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooSimWSTool(object):
-    """Some member functions of RooSimWSTool that take a RooCmdArg as argument also support keyword arguments.
+    r"""Some member functions of RooSimWSTool that take a RooCmdArg as argument also support keyword arguments.
     So far, this applies to RooSimWSTool::build.
     For example, the following code is equivalent in PyROOT:
     \code{.py}
@@ -34,7 +34,7 @@ class RooSimWSTool(object):
         "    const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none()) ;"
     )
     def build(self, *args, **kwargs):
-        """The RooSimWSTool::build() function is pythonized with the command argument pythonization.
+        r"""The RooSimWSTool::build() function is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the function.
         """
         # Redefinition of `RooSimWSTool.build` for keyword arguments.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_rooworkspace.py
@@ -13,7 +13,7 @@ from ._utils import _kwargs_to_roocmdargs, cpp_signature
 
 
 class RooWorkspace(object):
-    """The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.
+    r"""The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.
     For this reason, an alternative with a capitalized name is provided:
     \code{.py}
     workspace.Import(x)
@@ -27,7 +27,7 @@ class RooWorkspace(object):
         "    const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg(),const RooCmdArg& arg9=RooCmdArg()) ;"
     )
     def __init__(self, *args, **kwargs):
-        """The RooWorkspace constructor is pythonized with the command argument pythonization.
+        r"""The RooWorkspace constructor is pythonized with the command argument pythonization.
         The keywords must correspond to the CmdArgs of the constructor.
         """
         # Redefinition of `RooWorkspace` constructor for keyword arguments.
@@ -56,14 +56,14 @@ class RooWorkspace(object):
         ]
     )
     def Import(self, *args, **kwargs):
-        """
+        r"""
         Support the C++ `import()` as `Import()` in python
         """
         return getattr(self, "import")(*args, **kwargs)
 
 
 def RooWorkspace_import(self, *args, **kwargs):
-    """The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.
+    r"""The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.
     So, Import() is used and pythonized with the command argument pythonization.
     The keywords must correspond to the CmdArg of the `import()` function.
     """


### PR DESCRIPTION
This PR fixes two bugs that can arise in the RooFit pythonizations.

** [RF] Turn docstrings in RooFit pythonizations into raw strings **

Fixes the `SyntaxError: invalid escape sequence \c` that arises when the
`\code` command is used in the doxygen code.

Closes GitHub issue #8902.

** RF] Fix in pythonize_roofit_class for use with Python 2 **

The docstring of an instancemethod can't be mutated in Python 2, so the
underlying function has to be obtained first via the `__func__`
attribute.

The original warning:
```
AttributeError: attribute '__doc__' of 'instancemethod' objects is not writable
```

