### PR TITLE
6-24: [core] TDirectory::RegisterGDirectory must not update other TDirectory without lock:

### DIFF
--- a/core/base/src/TDirectory.cxx
+++ b/core/base/src/TDirectory.cxx
@@ -1310,23 +1310,16 @@ void TDirectory::RegisterContext(TContext *ctxt) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Register a std::atomic<TDirectory*> pointing to this TDirectory object
+/// Register a std::atomic<TDirectory*> that will soon be pointing to this TDirectory object
 
 void TDirectory::RegisterGDirectory(std::atomic<TDirectory*> *globalptr)
 {
    ROOT::Internal::TSpinLockGuard slg(fSpinLock);
 
-   auto oldvalue = globalptr->load();
-
-   auto iter = std::find(fGDirectories.begin(), fGDirectories.end(), globalptr);
-   if (iter != fGDirectories.begin())
+   if (std::find(fGDirectories.begin(), fGDirectories.end(), globalptr) != fGDirectories.end())
       fGDirectories.push_back(globalptr);
-
-   if (oldvalue && oldvalue != this) {
-      iter = std::find(oldvalue->fGDirectories.begin(), oldvalue->fGDirectories.end(), globalptr);
-      if (iter != oldvalue->fGDirectories.begin())
-         oldvalue->fGDirectories.erase(iter);
-   }
+   // globalptr->load()->fGDirectories will still contain globalptr, but we cannot
+   // know whether globalptr->load() has been deleted by another thread in the meantime.
 }
 
 


### PR DESCRIPTION
As we cannot even know whether the other TDirectory has been deleted in the meantime, we have to
skip the optimization of erasing globalptr from the list of the oldvalue.

This is expected to fix MT crashes observed by Alice.

(cherry picked from commit 79a669bb1cd0ccd8bcaeb6c8f6b09c5ced761ac7)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

