### PR TITLE
Fix dependency of pymva on sofie

### DIFF
--- a/tmva/CMakeLists.txt
+++ b/tmva/CMakeLists.txt
@@ -17,7 +17,9 @@ if(r OR tmva-rmva)
    add_subdirectory(rmva)
 endif()
 
+add_subdirectory(sofie)
+#parser depends on protobuf 
+#found if flag tmva-sofie is on
 if (tmva-sofie)
-   add_subdirectory(sofie)
    add_subdirectory(sofie_parsers)
 endif()

--- a/tmva/pymva/inc/TMVA/PyMethodBase.h
+++ b/tmva/pymva/inc/TMVA/PyMethodBase.h
@@ -131,7 +131,7 @@ namespace TMVA {
       PyObject *fLocalNS; // local namesapace
 
    public:
-      static void PyRunString(TString code, PyObject *fGlobalNS, PyObject* fLocalNS); // Overloaded static Python utlity function for running Python code
+      static void PyRunString(TString code, PyObject *globalNS, PyObject* localNS); // Overloaded static Python utlity function for running Python code
       static const char* PyStringAsString(PyObject *string); // Python Utility function for converting a Python String object to const char*
 
       ClassDef(PyMethodBase, 0) // Virtual base class for all TMVA method

--- a/tmva/pymva/inc/TMVA/RModelParser_Keras.h
+++ b/tmva/pymva/inc/TMVA/RModelParser_Keras.h
@@ -42,51 +42,6 @@ namespace SOFIE{
 namespace PyKeras{
 
 
-// Referencing Python utility functions present in PyMethodBase
-static void(& PyRunString)(TString, PyObject*, PyObject*) = PyMethodBase::PyRunString;
-static const char*(& PyStringAsString)(PyObject*) = PyMethodBase::PyStringAsString;
-
-
-namespace INTERNAL{
-   // For adding Keras layer into RModel object
-   void AddKerasLayer(RModel& rmodel, PyObject* fLayer);
-
-
-   // Declaring Internal Functions for Keras layers which don't have activation as an additional attribute
-   std::unique_ptr<ROperator> MakeKerasActivation(PyObject* fLayer);  // For instantiating ROperator for Keras Activation Layer
-   std::unique_ptr<ROperator> MakeKerasReLU(PyObject* fLayer);       // For instantiating ROperator for Keras ReLU layer
-   std::unique_ptr<ROperator> MakeKerasPermute(PyObject* fLayer);   // For instantiating ROperator for Keras Permute Layer
-
-
-   // Declaring Internal function for Keras layers which have additional activation attribute
-   std::unique_ptr<ROperator> MakeKerasDense(PyObject* fLayer);   // For instantiating ROperator for Keras Dense Layer
-
-   // For mapping Keras layer with the preparatory functions for ROperators
-   using KerasMethodMap = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(PyObject* fLayer)>;
-   using KerasMethodMapWithActivation = std::unordered_map<std::string, std::unique_ptr<ROperator>(*)(PyObject* fLayer)>;
-
-   const KerasMethodMap mapKerasLayer =
-    {
-        {"Activation", &MakeKerasActivation},
-        {"Permute", &MakeKerasPermute},
-
-        //For activation layers
-        {"ReLU", &MakeKerasReLU},
-
-        //For layers with activation attributes
-        {"relu", &MakeKerasReLU}
-    };
-
-    const KerasMethodMapWithActivation mapKerasLayerWithActivation =
-    {
-        {"Dense", &MakeKerasDense},
-    };
-
-    // Function which returns values from a Python Tuple object in vector of size_t
-    std::vector<size_t> GetShapeFromTuple(PyObject* shapeTuple);
-
-}//INTERNAL
-
 /// Parser function for translatng Keras .h5 model into a RModel object.
 /// Accepts the file location of a Keras model and returns the
 /// equivalent RModel object.

--- a/tmva/pymva/inc/TMVA/RModelParser_Keras.h
+++ b/tmva/pymva/inc/TMVA/RModelParser_Keras.h
@@ -25,10 +25,8 @@
 #ifndef TMVA_SOFIE_RMODELPARSER_KERAS
 #define TMVA_SOFIE_RMODELPARSER_KERAS
 
-#include <Python.h>
-
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include <numpy/arrayobject.h>
+//#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+//#include <numpy/arrayobject.h>
 
 #include "TMVA/RModel.hxx"
 #include "TMVA/SOFIE_common.hxx"

--- a/tmva/pymva/inc/TMVA/RModelParser_Keras.h
+++ b/tmva/pymva/inc/TMVA/RModelParser_Keras.h
@@ -25,9 +25,6 @@
 #ifndef TMVA_SOFIE_RMODELPARSER_KERAS
 #define TMVA_SOFIE_RMODELPARSER_KERAS
 
-//#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-//#include <numpy/arrayobject.h>
-
 #include "TMVA/RModel.hxx"
 #include "TMVA/SOFIE_common.hxx"
 #include "TMVA/Types.h"

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -335,8 +335,8 @@ void PyMethodBase::PyRunString(TString code, TString errorMessage, int start) {
 /// from string and throw runtime error if the Python session
 /// is unable to execute the code
 
-void PyMethodBase::PyRunString(TString code, PyObject *fGlobalNS, PyObject *fLocalNS){
-   PyObject *fPyReturn = PyRun_String(code, Py_single_input, fGlobalNS, fLocalNS);
+void PyMethodBase::PyRunString(TString code, PyObject *globalNS, PyObject *localNS){
+   PyObject *fPyReturn = PyRun_String(code, Py_single_input, globalNS, localNS);
    if (!fPyReturn) {
       std::cout<<"\nPython error message:\n";
       PyErr_Print();

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -19,6 +19,10 @@
 
 #include "TMVA/RModelParser_Keras.h"
 
+#include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
 
 namespace TMVA{
 namespace Experimental{

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -29,7 +29,43 @@ namespace Experimental{
 namespace SOFIE{
 namespace PyKeras{
 
+   // Referencing Python utility functions present in PyMethodBase
+static void(& PyRunString)(TString, PyObject*, PyObject*) = PyMethodBase::PyRunString;
+static const char*(& PyStringAsString)(PyObject*) = PyMethodBase::PyStringAsString;
+
 namespace INTERNAL{
+
+// For adding Keras layer into RModel object
+void AddKerasLayer(RModel &rmodel, PyObject *fLayer);
+
+// Declaring Internal Functions for Keras layers which don't have activation as an additional attribute
+std::unique_ptr<ROperator>
+MakeKerasActivation(PyObject *fLayer);                         // For instantiating ROperator for Keras Activation Layer
+std::unique_ptr<ROperator> MakeKerasReLU(PyObject *fLayer);    // For instantiating ROperator for Keras ReLU layer
+std::unique_ptr<ROperator> MakeKerasPermute(PyObject *fLayer); // For instantiating ROperator for Keras Permute Layer
+
+// Declaring Internal function for Keras layers which have additional activation attribute
+std::unique_ptr<ROperator> MakeKerasDense(PyObject *fLayer); // For instantiating ROperator for Keras Dense Layer
+
+// For mapping Keras layer with the preparatory functions for ROperators
+using KerasMethodMap = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(PyObject *fLayer)>;
+using KerasMethodMapWithActivation = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(PyObject *fLayer)>;
+
+const KerasMethodMap mapKerasLayer = {{"Activation", &MakeKerasActivation},
+                                      {"Permute", &MakeKerasPermute},
+
+                                      // For activation layers
+                                      {"ReLU", &MakeKerasReLU},
+
+                                      // For layers with activation attributes
+                                      {"relu", &MakeKerasReLU}};
+
+const KerasMethodMapWithActivation mapKerasLayerWithActivation = {
+   {"Dense", &MakeKerasDense},
+};
+
+// Function which returns values from a Python Tuple object in vector of size_t
+std::vector<size_t> GetShapeFromTuple(PyObject *shapeTuple);
 
 //////////////////////////////////////////////////////////////////////////////////
 /// \brief Adds equivalent ROperator with respect to Keras model layer

--- a/tmva/pymva/test/EmitFromKeras.cxx
+++ b/tmva/pymva/test/EmitFromKeras.cxx
@@ -1,8 +1,8 @@
 // Author: Sanjiban Sengupta, 2021
 // Description:
-//           This is to test the RModelParser_PyTorch.
-//           The program is run when the target 'TestRModelParserPyTorch' is built.
-//           The program generates the required .hxx file after parsing a PyTorch .pt file into a RModel object.
+//           This is to test the RModelParser_Keras.
+//           The program is run when the target 'TestRModelParserKeras' is built.
+//           The program generates the required .hxx file after parsing a Keras .h5 file into a RModel object.
 
 
 #include "TMVA/RModel.hxx"

--- a/tmva/pymva/test/EmitFromKeras.cxx
+++ b/tmva/pymva/test/EmitFromKeras.cxx
@@ -8,6 +8,8 @@
 #include "TMVA/RModel.hxx"
 #include "TMVA/RModelParser_Keras.h"
 
+#include <Python.h>
+
 using namespace TMVA::Experimental::SOFIE;
 
 int main(){

--- a/tmva/sofie/CMakeLists.txt
+++ b/tmva/sofie/CMakeLists.txt
@@ -33,4 +33,7 @@ target_include_directories(ROOTTMVASofie PUBLIC
 set_target_properties(ROOTTMVASofie PROPERTIES
   POSITION_INDEPENDENT_CODE TRUE)
 
-ROOT_ADD_TEST_SUBDIRECTORY(test)
+# tests requires protobuf
+if (tmva-sofie)
+   ROOT_ADD_TEST_SUBDIRECTORY(test)
+endif()

--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -82,7 +82,7 @@ struct InitializedTensor{
 };
 
 template <typename T>
-ETensorType GetTemplatedType(T obj){
+ETensorType GetTemplatedType(T /*obj*/ ){
    if (std::is_same<T, float>::value) return ETensorType::FLOAT;
    if (std::is_same<T, uint8_t>::value) return ETensorType::UNINT8;
    if (std::is_same<T, int8_t>::value) return ETensorType::INT8;

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -148,7 +148,7 @@ namespace SOFIE{
 
    void RModel::UpdateInitializedTensor(std::string tensor_name, ETensorType type, std::vector<std::size_t> shape, std::shared_ptr<void> data){
       tensor_name = UTILITY::Clean_name(tensor_name);
-      if (not CheckIfTensorAlreadyExist(tensor_name)){
+      if (!CheckIfTensorAlreadyExist(tensor_name)){
          throw std::runtime_error("TMVA-SOFIE: tensor " + tensor_name + " not found when trying to update it");
       }
       InitializedTensor new_tensor {type, shape, data};


### PR DESCRIPTION
The core part of  tmva/sofie does not depend on protobuffer and it is used in pymva to parse a model from Keras to Tmva::Sofie format.  
It is now always built as tmva, while only sofie_parser is built when protobuf is found.
This PR fixes the problem seed when building pymva  when protobuf is not found