### PR TITLE
[core] WriteObject overload for TObject-derived classes

### DIFF
--- a/core/base/inc/TDirectory.h
+++ b/core/base/inc/TDirectory.h
@@ -255,17 +255,38 @@ public:
    virtual Int_t       Write(const char * /*name*/=nullptr, Int_t /*opt*/=0, Int_t /*bufsize*/=0) const override {return 0;}
    virtual Int_t       WriteTObject(const TObject *obj, const char *name =nullptr, Option_t * /*option*/="", Int_t /*bufsize*/ =0);
 private:
+/// \cond HIDDEN_SYMBOLS
            Int_t       WriteObject(void *obj, const char* name, Option_t *option="", Int_t bufsize=0); // Intentionally not implemented.
+/// \endcond
 public:
-   /// Write an object with proper type checking.
+   /// \brief Write an object with proper type checking.
    /// \param[in] obj Pointer to an object to be written.
    /// \param[in] name Name of the object in the file.
-   /// \param[in] option Options. See TDirectory::WriteTObject() or TDirectoryWriteObjectAny().
-   /// \param[in] bufsize Buffer size. See TDirectory::WriteTObject().
-   template <class T> inline Int_t WriteObject(const T* obj, const char* name, Option_t *option="", Int_t bufsize=0)
-      {
-         return WriteObjectAny(obj, TClass::GetClass<T>(), name, option, bufsize);
-      }
+   /// \param[in] option Options. See TDirectory::WriteTObject.
+   /// \param[in] bufsize Buffer size. See TDirectory::WriteTObject.
+   ///
+   /// This overload takes care of instances of classes that are not derived
+   /// from TObject. The method redirects to TDirectory::WriteObjectAny.
+   template <typename T>
+   inline std::enable_if_t<!std::is_base_of<TObject, T>::value, Int_t>
+   WriteObject(const T *obj, const char *name, Option_t *option = "", Int_t bufsize = 0)
+   {
+      return WriteObjectAny(obj, TClass::GetClass<T>(), name, option, bufsize);
+   }
+   /// \brief Write an object with proper type checking.
+   /// \param[in] obj Pointer to an object to be written.
+   /// \param[in] name Name of the object in the file.
+   /// \param[in] option Options. See TDirectory::WriteTObject.
+   /// \param[in] bufsize Buffer size. See TDirectory::WriteTObject.
+   ///
+   /// This overload takes care of instances of classes that are derived from
+   /// TObject. The method redirects to TDirectory::WriteTObject.
+   template <typename T>
+   inline std::enable_if_t<std::is_base_of<TObject, T>::value, Int_t>
+   WriteObject(const T *obj, const char *name, Option_t *option = "", Int_t bufsize = 0)
+   {
+      return WriteTObject(obj, name, option, bufsize);
+   }
    virtual Int_t       WriteObjectAny(const void *, const char * /*classname*/, const char * /*name*/, Option_t * /*option*/="", Int_t /*bufsize*/ =0) {return 0;}
    virtual Int_t       WriteObjectAny(const void *, const TClass * /*cl*/, const char * /*name*/, Option_t * /*option*/="", Int_t /*bufsize*/ =0) {return 0;}
    virtual void        WriteDirHeader() {}

--- a/io/io/test/TFileTests.cxx
+++ b/io/io/test/TFileTests.cxx
@@ -1,6 +1,69 @@
-#include "TFile.h"
+#include <vector>
 
 #include "gtest/gtest.h"
+
+#include "TFile.h"
+#include "TKey.h"
+#include "TNamed.h"
+#include "TSystem.h"
+
+TEST(TFile, WriteObjectTObject)
+{
+    auto filename{"tfile_writeobject_tobject.root"};
+    auto tnamed_name{"mytnamed_name"};
+    auto tnamed_title{"mytnamed_title"};
+
+    {
+        TNamed mytnamed{tnamed_name, tnamed_title};
+        TFile f{filename, "recreate"};
+        f.WriteObject(&mytnamed, mytnamed.GetName());
+        f.Close();
+    }
+
+    TFile input{filename};
+    auto named = input.Get<TNamed>(tnamed_name);
+    auto keyptr = static_cast<TKey *>(input.GetListOfKeys()->At(0));
+
+    EXPECT_STREQ(named->GetName(), tnamed_name);
+    EXPECT_STREQ(named->GetTitle(), tnamed_title);
+    EXPECT_STREQ(keyptr->GetName(), tnamed_name);
+    EXPECT_STREQ(keyptr->GetTitle(), tnamed_title);
+
+    input.Close();
+    gSystem->Unlink(filename);
+}
+
+TEST(TFile, WriteObjectVector)
+{
+    auto filename{"tfile_writeobject_vector.root"};
+    auto vec_name{"object name"}; // Decided arbitrarily
+    auto vec_title{"object title"}; // Default title for non-TObject-derived instances
+
+    {
+        std::vector<int> myvec{1,2,3,4,5};
+        TFile f{filename, "recreate"};
+        f.WriteObject(&myvec, vec_name);
+        f.Close();
+    }
+
+    TFile input{filename};
+    auto retvecptr = input.Get<std::vector<int>>(vec_name);
+    const auto &retvec = *retvecptr;
+    auto retkey = static_cast<TKey *>(input.GetListOfKeys()->At(0));
+
+    std::vector<int> expected{1,2,3,4,5};
+
+    ASSERT_EQ(retvec.size(), expected.size());
+    for (std::size_t i = 0; i < retvec.size(); ++i) {
+        EXPECT_EQ(retvec[i], expected[i]);
+    }
+
+    EXPECT_STREQ(retkey->GetName(), vec_name);
+    EXPECT_STREQ(retkey->GetTitle(), vec_title);
+
+    input.Close();
+    gSystem->Unlink(filename);
+}
 
 // Tests ROOT-9857
 TEST(TFile, ReadFromSameFile)


### PR DESCRIPTION
The [TDirectory::WriteObject](https://github.com/root-project/root/blob/35b5aaef38b6635e131e7d93a0c96f69bb293b9d/core/base/inc/TDirectory.h#L265-L268) method allows writing objects to files. If the written object actually has a title, this  should be discarded because the function doesn't manage it as a TObject-derived instance on purpose. For example, the program below:

```cpp
int main(){
    TFile f{"myfile.root","recreate"};
    TH1F h{"myhistoname","myhistotitle",100,0,100};
    f.WriteObject(&h, h.GetName());
    f.Close();
}
```

When executed creates a file where the object "h" gets the default title "object title":

```bash
$ rootls -l myfile.root
TH1F  Aug 21 10:41 2021 myhistoname;1 "object title"
```

This is because The [TKey constructor that accepts a void pointer](https://github.com/root-project/root/blob/35b5aaef38b6635e131e7d93a0c96f69bb293b9d/io/io/src/TKey.cxx#L299-L300) calls the parent TNamed constructor with a default title, because in general there is no guarantee the object has the interface `GetTitle(),SetTitle()` and there is no extra "title" parameter to the constructor.

This commit provides a solution by creating a new overload for `TDirectory::WriteObject`, using SFINAE to make it available for types that are derived from TObject. The method redirects to `WriteTObject` instead of `WriteObjectAny`. This way, the correct TKey constructor is called that uses the actual object title. As a result, the example above will now output a file like this:

```
$ rootls -l myfile.root
TH1F  Aug 21 11:00 2021 myhistoname;1 "myhistotitle"
```

The already present method is modified with SFINAE as well, to only be available if the type T of the template is not derived from TObject.