### PR TITLE
Fix some warnings when using an older version of protobuf

### DIFF
--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -37,8 +37,8 @@ target_include_directories(emitFromONNX PRIVATE
 )
 
 target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie)
-set_target_properties(emitFromONNX PROPERTIES
-  POSITION_INDEPENDENT_CODE TRUE)
+set_target_properties(emitFromONNX PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+target_compile_options(emitFromONNX PRIVATE "-Wno-unused-parameter -Wno-array-bounds")
 
 # Automatic compilation of headers from onnx files
 add_custom_target(SofieCompileModels_ONNX)

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(emitFromONNX PRIVATE
 
 target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie)
 set_target_properties(emitFromONNX PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-target_compile_options(emitFromONNX PRIVATE "-Wno-unused-parameter -Wno-array-bounds")
+target_compile_options(emitFromONNX PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from onnx files
 add_custom_target(SofieCompileModels_ONNX)
@@ -85,8 +85,8 @@ target_include_directories(emitFromROOT PRIVATE
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie)
-set_target_properties(emitFromROOT PROPERTIES
-  POSITION_INDEPENDENT_CODE TRUE)
+set_target_properties(emitFromROOT PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+target_compile_options(emitFromROOT PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from root files
 add_custom_target(SofieCompileModels_ROOT)

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(emitFromONNX PRIVATE
 
 target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie)
 set_target_properties(emitFromONNX PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromONNX PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from onnx files
@@ -86,6 +87,7 @@ target_include_directories(emitFromROOT PRIVATE
 )
 target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie)
 set_target_properties(emitFromROOT PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromROOT PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from root files

--- a/tmva/sofie_parsers/CMakeLists.txt
+++ b/tmva/sofie_parsers/CMakeLists.txt
@@ -14,6 +14,7 @@
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "onnx_proto3")
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
 set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS -Wno-array-bounds)
+set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS -Wno-unused-parameter)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofieParser
   HEADERS

--- a/tmva/sofie_parsers/CMakeLists.txt
+++ b/tmva/sofie_parsers/CMakeLists.txt
@@ -13,6 +13,7 @@
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "onnx_proto3")
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
+set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS -Wno-array-bounds)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofieParser
   HEADERS

--- a/tmva/sofie_parsers/CMakeLists.txt
+++ b/tmva/sofie_parsers/CMakeLists.txt
@@ -13,7 +13,9 @@
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "onnx_proto3")
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
+## silence protobuf warnings for version 3.6. Not needed from protobuf version 3.17
 set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS -Wno-array-bounds)
+## silence protobuf warnings for version 3.0. Not needed from protobuf version 3.6
 set_source_files_properties(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS -Wno-unused-parameter)
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTTMVASofieParser


### PR DESCRIPTION
Fix protobuf warnings as suggested in https://github.com/protocolbuffers/protobuf/issues/7140#issuecomment-599467033

The warnings should however be fixed in the latest protobuf version, 3.17