### PR TITLE
[DF] Suppress spurious ResourceWarning in distrdf-pyspark tests

### DIFF
--- a/bindings/experimental/distrdf/test/backend/test_spark.py
+++ b/bindings/experimental/distrdf/test/backend/test_spark.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+import warnings
 
 import DistRDF
 import pyspark
@@ -18,23 +19,32 @@ class SparkBackendInitTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
+        Set up test environment for this class. Currently this includes:
 
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
+        - Synchronize PYSPARK_PYTHON variable to the current Python executable.
+          Needed to avoid mismatch between python versions on driver and on the
+          fake executor on the same machine.
+        - Ignore `ResourceWarning: unclosed socket` warning triggered by Spark.
+          this is ignored by default in any application, but Python's unittest
+          library overrides the default warning filters thus exposing this
+          warning
         """
         os.environ["PYSPARK_PYTHON"] = sys.executable
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("ignore", ResourceWarning)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset test environment."""
+        os.environ["PYSPARK_PYTHON"] = ""
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("default", ResourceWarning)
 
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_set_spark_context_default(self):
         """
@@ -82,23 +92,32 @@ class OperationSupportTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
+        Set up test environment for this class. Currently this includes:
 
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
+        - Synchronize PYSPARK_PYTHON variable to the current Python executable.
+          Needed to avoid mismatch between python versions on driver and on the
+          fake executor on the same machine.
+        - Ignore `ResourceWarning: unclosed socket` warning triggered by Spark.
+          this is ignored by default in any application, but Python's unittest
+          library overrides the default warning filters thus exposing this
+          warning
         """
         os.environ["PYSPARK_PYTHON"] = sys.executable
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("ignore", ResourceWarning)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset test environment."""
+        os.environ["PYSPARK_PYTHON"] = ""
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("default", ResourceWarning)
 
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_action(self):
         """Check that action nodes are classified accurately."""
@@ -144,23 +163,32 @@ class InitializationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
+        Set up test environment for this class. Currently this includes:
 
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
+        - Synchronize PYSPARK_PYTHON variable to the current Python executable.
+          Needed to avoid mismatch between python versions on driver and on the
+          fake executor on the same machine.
+        - Ignore `ResourceWarning: unclosed socket` warning triggered by Spark.
+          this is ignored by default in any application, but Python's unittest
+          library overrides the default warning filters thus exposing this
+          warning
         """
         os.environ["PYSPARK_PYTHON"] = sys.executable
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("ignore", ResourceWarning)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset test environment."""
+        os.environ["PYSPARK_PYTHON"] = ""
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("default", ResourceWarning)
 
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_initialization(self):
         """
@@ -219,23 +247,32 @@ class EmptyTreeErrorTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
+        Set up test environment for this class. Currently this includes:
 
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
+        - Synchronize PYSPARK_PYTHON variable to the current Python executable.
+          Needed to avoid mismatch between python versions on driver and on the
+          fake executor on the same machine.
+        - Ignore `ResourceWarning: unclosed socket` warning triggered by Spark.
+          this is ignored by default in any application, but Python's unittest
+          library overrides the default warning filters thus exposing this
+          warning
         """
         os.environ["PYSPARK_PYTHON"] = sys.executable
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("ignore", ResourceWarning)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset test environment."""
+        os.environ["PYSPARK_PYTHON"] = ""
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("default", ResourceWarning)
 
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_histo_from_empty_root_file(self):
         """
@@ -259,23 +296,32 @@ class ChangeAttributeTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
+        Set up test environment for this class. Currently this includes:
 
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
+        - Synchronize PYSPARK_PYTHON variable to the current Python executable.
+          Needed to avoid mismatch between python versions on driver and on the
+          fake executor on the same machine.
+        - Ignore `ResourceWarning: unclosed socket` warning triggered by Spark.
+          this is ignored by default in any application, but Python's unittest
+          library overrides the default warning filters thus exposing this
+          warning
         """
         os.environ["PYSPARK_PYTHON"] = sys.executable
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("ignore", ResourceWarning)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset test environment."""
+        os.environ["PYSPARK_PYTHON"] = ""
+
+        if sys.version_info.major >= 3:
+            warnings.simplefilter("default", ResourceWarning)
 
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_change_attribute_when_npartitions_greater_than_clusters(self):
         """


### PR DESCRIPTION
distributed RDataFrame tests that use `pyspark` will report `ResourceWarning`s like the ones seen here
https://lcgapp-services.cern.ch/root-jenkins/job/root-nightly-master/LABEL=ROOT-ubuntu18.04,SPEC=nortcxxmod,V=master/2956/testReport/projectroot.roottest.python/distrdf/roottest_python_distrdf_spark_test_reducer_merge/

This kind of warning is apparently common in Python unittests that use socket, both with [pyspark](https://stackoverflow.com/questions/49361286/unittesting-with-pyspark-unclosed-socket-warnings) and [others](https://stackoverflow.com/questions/14938716/socket-resourcewarning-using-urllib-in-python-3).

The reason they are shown is that in Python3 the unittest module has been updated to use the "default" level of warnings filters, as mentioned [in the docs](https://docs.python.org/3.5/library/warnings.html#updating-code-for-new-versions-of-python).

For the particular case of `pyspark`, these warnings are actually present in any application that uses the same "default" level:
```py
$: cat sparktest.py 
import pyspark
import warnings

warnings.simplefilter("default", ResourceWarning)

sc = pyspark.SparkContext.getOrCreate()

sc.parallelize([1,2,3,4,5]).map(lambda x: 1).reduce(lambda x,y: x+y)
```

```bash
$: python sparktest.py 
21/08/30 11:04:59 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
/usr/lib64/python3.8/socket.py:740: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 35374), raddr=('127.0.0.1', 36167)>
  self._sock = None
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This commit adds an extra call in the setup part of unittests that use pyspark, to ignore these warnings. The default level for the warnings is restored after the tests.