### PR TITLE
[skip-ci] Mark TGeoTrack as deprecated

### DIFF
--- a/geom/geompainter/src/TGeoTrack.cxx
+++ b/geom/geompainter/src/TGeoTrack.cxx
@@ -21,6 +21,11 @@
 /** \class TGeoTrack
 \ingroup Geometry_classes
 
+\deprecated
+TGeoTrack is one of the first attempts to make an event display in the pad early millennium,
+meanwhile people managed to implement similar functionality in much better ways in events
+displays applications. Although the class is still working, its usage was not encouraged.
+
 Class for user-defined tracks attached to a geometry.
 Tracks are 3D objects made of points and they store a
 pointer to a TParticle. The geometry manager holds a list


### PR DESCRIPTION
As requested here: 
https://root-forum.cern.ch/t/compiling-macro-with-tgeotrack/46600/3

