### PR TITLE
Fix a streaming error in TRandom1

### DIFF
--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -37,7 +37,7 @@ protected:
   const Int_t     fIntModulus;
   static Int_t    fgNumEngines;
   static Int_t    fgMaxIndex;
-  const UInt_t   *fTheSeeds;
+  const UInt_t   *fTheSeeds;           //! Temporary array of seed values (transient)
   const Double_t  fMantissaBit24;
   const Double_t  fMantissaBit12;
 
@@ -65,7 +65,7 @@ public:
                      // array of seeds. Only the first seed is used.
    virtual  void     SetSeed(ULong_t seed);
 
-   ClassDef(TRandom1,1)  //Ranlux Random number generators with periodicity > 10**14
+   ClassDef(TRandom1,2)  //Ranlux Random number generators with periodicity > 10**14
 };
 
 R__EXTERN TRandom *gRandom;


### PR DESCRIPTION
As reported in https://root-forum.cern.ch/t/trandom1-streamer-bug/46608
the fTheSeeds data member cannot be stored.
It should be a transient one since is a temporary array used to stored an array of seed values



