### PR TITLE
Demoting change of TGeo units from Warning to Info.

### DIFF
--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -4030,10 +4030,10 @@ void TGeoManager::SetDefaultUnits(EDefaultUnits new_value)
 	      "Alternatively unlock the default units at own risk.");
    }
    else if ( new_value == kG4Units )   {
-      ::Warning("TGeoManager","Changing system of units to Geant4 units (mm, ns, MeV).");
+      ::Info("TGeoManager","Changing system of units to Geant4 units (mm, ns, MeV).");
    }
    else if ( new_value == kRootUnits )   {
-      ::Warning("TGeoManager","Changing system of units to ROOT units (cm, s, GeV).");
+      ::Info("TGeoManager","Changing system of units to ROOT units (cm, s, GeV).");
    }
    fgDefaultUnits = new_value;
 }


### PR DESCRIPTION
# This Pull request:
Demoted the exception level from Warning to Info when changing the default system of units for TGeo
## Changes or fixes:
CMSSW fails due to a necessary recent change of the default units not being the Geant4 ones

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 
https://github.com/cms-sw/cmsdist/issues/7274
