### PR TITLE
[DF] Introduce distributed RunGraphs

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -428,3 +428,14 @@ class BaseBackend(ABC):
         Distributed backends have to take care of creating an RDataFrame object
         that can run distributedly.
         """
+
+    @staticmethod
+    def RunGraphs(proxies, concurrentruns=None):
+        """
+        By default, a distributed backend does not implement a way to submit
+        multiple jobs from the client at once. This raises a
+        `NotImplementedError` to allow us to default to submitting the jobs
+        sequentially.
+        """
+        raise NotImplementedError
+

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
@@ -199,8 +199,7 @@ class SparkBackend(Base.BaseBackend):
 
         # Create `numthreads` threads that will each submit a Spark job
         for _ in range(numthreads):
-            worker = threading.Thread(
-                target=trigger_loop, args=(q,), daemon=True)
+            worker = threading.Thread(group=None, target=trigger_loop, name=None, args=(q, ), kwargs=None)
             worker.start()
 
         # Start the execution and wait for all computations to finish

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -332,6 +332,16 @@ class ROOTFacade(types.ModuleType):
 
             # Inject Experimental.Distributed package into namespace RDF
             ns.Experimental = _create_rdf_experimental_distributed_module(ns)
+
+            # Add a dispatch function for RunGraphs to distinguish between
+            # local and distributed RDF cases.
+            from .pythonization._rdataframe import dispatch_rungraphs
+
+            api_name = "RunGraphs"
+            cpp_name = api_name + "_cpp"
+
+            setattr(ns, cpp_name, getattr(ns, api_name))
+            setattr(ns, api_name, dispatch_rungraphs)
         except:
             raise Exception('Failed to pythonize the namespace RDF')
         del type(self).RDF


### PR DESCRIPTION
This PR introduces the functionality offered by `ROOT::RDF::RunGraphs` in distributed RDataFrame. Some things may still need polishing or discussion.
- [x] Implement function for the Spark backend
- [x] Implement generic function available in the distributed module
- [x] Add test for the Spark backend
- [ ] Discuss whether we should keep the logic that all actions should be triggered by the same type of distributed backend (i.e. a user can submit N Spark jobs concurrently, but not N Spark jobs and M Dask jobs from the same call to RunGraphs)
- [ ] Discuss default value of `concurrent_runs` parameter, i.e. number of jobs submitted concurrently from the client to the scheduler.