### PR TITLE
[TMVA][SOFIE] Add Support for Conv Operator in RModelParsers for PyTorch & Keras

### DIFF
--- a/tmva/pymva/inc/TMVA/PyMethodBase.h
+++ b/tmva/pymva/inc/TMVA/PyMethodBase.h
@@ -133,6 +133,8 @@ namespace TMVA {
    public:
       static void PyRunString(TString code, PyObject *globalNS, PyObject* localNS); // Overloaded static Python utlity function for running Python code
       static const char* PyStringAsString(PyObject *string); // Python Utility function for converting a Python String object to const char*
+      static std::vector<size_t> GetDataFromTuple(PyObject *tupleObject);  // Function casts Python Tuple object into vector of size_t
+      static std::vector<size_t> GetDataFromList(PyObject *listObject);    // Function casts Python List object into vector of size_t
 
       ClassDef(PyMethodBase, 0) // Virtual base class for all TMVA method
 

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -381,7 +381,7 @@ std::vector<size_t> PyMethodBase::GetDataFromTuple(PyObject* tupleObject){
 std::vector<size_t> PyMethodBase::GetDataFromList(PyObject* listObject){
    std::vector<size_t>listVec;
    for(Py_ssize_t listIter=0; listIter<PyList_Size(listObject);++listIter){
-               listVec.push_back((size_t)PyLong_AsLong(PyTuple_GetItem(listObject,listIter)));
+               listVec.push_back((size_t)PyLong_AsLong(PyList_GetItem(listObject,listIter)));
          }
    return listVec;
 }

--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -355,3 +355,33 @@ const char* PyMethodBase::PyStringAsString(PyObject* string){
    const char* cstring = PyBytes_AsString(encodedString);
    return cstring;
 }
+
+//////////////////////////////////////////////////////////////////////////////////
+/// \brief Utility function which retrieves and returns the values of the Tuple
+///        object as a vector of size_t
+///
+/// \param[in] tupleObject Python Tuple object
+/// \return vector of tuple members
+
+std::vector<size_t> PyMethodBase::GetDataFromTuple(PyObject* tupleObject){
+   std::vector<size_t>tupleVec;
+   for(Py_ssize_t tupleIter=0;tupleIter<PyTuple_Size(tupleObject);++tupleIter){
+               tupleVec.push_back((size_t)PyLong_AsLong(PyTuple_GetItem(tupleObject,tupleIter)));
+         }
+   return tupleVec;
+}
+
+//////////////////////////////////////////////////////////////////////////////////
+/// \brief Utility function which retrieves and returns the values of the List
+///        object as a vector of size_t
+///
+/// \param[in] listObject Python List object
+/// \return vector of list members
+
+std::vector<size_t> PyMethodBase::GetDataFromList(PyObject* listObject){
+   std::vector<size_t>listVec;
+   for(Py_ssize_t listIter=0; listIter<PyList_Size(listObject);++listIter){
+               listVec.push_back((size_t)PyLong_AsLong(PyTuple_GetItem(listObject,listIter)));
+         }
+   return listVec;
+}

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -352,6 +352,7 @@ std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
       std::string fKerasPadding = PyStringAsString(fPads);
       if(fKerasPadding == "valid"){
          fAttrAutopad="VALID";
+	 fAttrPads    = {0,0,0,0};
       }
       else if(fKerasPadding == "same"){
          fAttrAutopad="NOTSET";
@@ -365,8 +366,8 @@ std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
          long x1 = (outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight;
          long x2 = (outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth;
 
-         (x1 < 0) ? x1 = 0 : x1 = x1;
-         (x2 < 0) ? x2 = 0 : x2 = x2;
+         if(x1 < 0) x1 = 0;
+         if(x2 < 0) x2 = 0;
 
          size_t x1_begin = std::floor(x1/2);
          size_t x1_end   = x1 - x1_begin;


### PR DESCRIPTION
This PR adds support for parsing Convolution layers from PyTorch and Keras models into an RModel object.

## Progress
- [x] Support for PyTorch Convolution Layers (Conv2D)  
- [x] Support for Keras Convolution Layers(Conv2D)          
  - [x] Support for `padding="valid"`
  - [x] Support for `padding="same"`

## Checklist:
- [ ] tested changes locally