### PR TITLE
[RF] Change RooNLLVar constructors to be backwards compatible

### DIFF
--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -38,11 +38,12 @@ public:
 	    const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
-            RooAbsTestStatistic::Configuration const& cfg, bool extended);
+            bool extended,
+            RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{});
   
   RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& data,
-            const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg,
-            bool extended = false) ;
+            const RooArgSet& projDeps, bool extended = false,
+            RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{});
 
   RooNLLVar(const RooNLLVar& other, const char* name=0);
   virtual TObject* clone(const char* newname) const { return new RooNLLVar(*this,newname); }

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1085,7 +1085,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     //cout<<"FK: Data test 1: "<<data.sumEntries()<<endl;
 
     cfg.rangeName = rangeName ? rangeName : "";
-    auto theNLL = new RooNLLVar(baseName.c_str(),"-log(likelihood)",*this,data,projDeps,cfg, ext);
+    auto theNLL = new RooNLLVar(baseName.c_str(),"-log(likelihood)",*this,data,projDeps, ext, cfg);
     theNLL->batchMode(pc.getInt("BatchMode"));
     nll = theNLL;
   } else {
@@ -1099,7 +1099,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
     for (const auto& token : tokens) {
       cfg.rangeName = token;
       auto nllComp = new RooNLLVar((baseName + "_" + token).c_str(),"-log(likelihood)",
-                                   *this,data,projDeps,cfg,ext);
+                                   *this,data,projDeps,ext,cfg);
       nllComp->batchMode(pc.getInt("BatchMode"));
       nllList.add(*nllComp) ;
     }

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -124,7 +124,7 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
 /// For internal use.
 
 RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& indata,
-                     RooAbsTestStatistic::Configuration const& cfg, bool extended) :
+                     bool extended, RooAbsTestStatistic::Configuration const& cfg) :
   RooAbsOptTestStatistic(name,title,pdf,indata,RooArgSet(),cfg),
   _extended(extended),
   _weightSq(kFALSE),
@@ -169,7 +169,7 @@ RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbs
 
 RooNLLVar::RooNLLVar(const char *name, const char *title, RooAbsPdf& pdf, RooAbsData& indata,
                      const RooArgSet& projDeps,
-                     RooAbsTestStatistic::Configuration const& cfg, bool extended) :
+                     bool extended, RooAbsTestStatistic::Configuration const& cfg) :
   RooAbsOptTestStatistic(name,title,pdf,indata,projDeps, cfg),
   _extended(extended),
   _weightSq(kFALSE),
@@ -229,7 +229,7 @@ RooAbsTestStatistic* RooNLLVar::create(const char *name, const char *title, RooA
   // check if pdf can be extended
   bool extendedPdf = _extended && thePdf.canBeExtended();
 
-  auto testStat = new RooNLLVar(name, title, thePdf, adata, projDeps, cfg, extendedPdf);
+  auto testStat = new RooNLLVar(name, title, thePdf, adata, projDeps, extendedPdf, cfg);
   testStat->batchMode(_batchEvaluations);
   return testStat;
 }

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -156,7 +156,7 @@ TEST_F(LikelihoodSerialBinnedDatasetTest, BinnedManualNLL)
    nll_config.cloneInputData = false;
    nll_config.binnedL = true;
    int extended = 2;
-   RooNLLVar nll_manual("nlletje", "-log(likelihood)", *pdf, *data, projDeps, nll_config, extended);
+   RooNLLVar nll_manual("nlletje", "-log(likelihood)", *pdf, *data, projDeps, extended, nll_config);
 
    likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
    RooFit::TestStatistics::LikelihoodSerial nll_ts(likelihood, clean_flags/*, nullptr*/);


### PR DESCRIPTION
In https://github.com/root-project/root/pull/7616, it was not taken care that the `RooNLLVar` constructor interface changes were backwards compatible, since the affected constructors were considered as internal.

However, this caused problems for users nonetheless, hence the interface was changed to be backwards compatible.

Closing https://github.com/root-project/root/issues/8976.