### PR TITLE
Added typedefs Float16_t and Double32_t to TDataType

### DIFF
--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -422,8 +422,10 @@ void TDataType::AddBuiltins(TCollection* types)
       fgBuiltins[kULong_t] = new TDataType("unsigned long");
       fgBuiltins[kLong64_t] = new TDataType("long long");
       fgBuiltins[kULong64_t] = new TDataType("unsigned long long");
-      fgBuiltins[kFloat_t] = fgBuiltins[kFloat16_t] = new TDataType("float");
-      fgBuiltins[kDouble_t] = fgBuiltins[kDouble32_t] = new TDataType("double");
+      fgBuiltins[kFloat_t] = new TDataType("float");
+      fgBuiltins[kDouble_t] = new TDataType("double");
+      fgBuiltins[kFloat16_t] = new TDataType("Float16_t");
+      fgBuiltins[kDouble32_t] = new TDataType("Double32_t");
       fgBuiltins[kVoid_t] = new TDataType("void");
       fgBuiltins[kBool_t] = new TDataType("bool");
       fgBuiltins[kCharStar] = new TDataType("char*");

--- a/core/meta/src/TDataType.cxx
+++ b/core/meta/src/TDataType.cxx
@@ -422,8 +422,8 @@ void TDataType::AddBuiltins(TCollection* types)
       fgBuiltins[kULong_t] = new TDataType("unsigned long");
       fgBuiltins[kLong64_t] = new TDataType("long long");
       fgBuiltins[kULong64_t] = new TDataType("unsigned long long");
-      fgBuiltins[kFloat_t] = new TDataType("float");
-      fgBuiltins[kDouble_t] = new TDataType("double");
+      fgBuiltins[kFloat_t] = fgBuiltins[kFloat16_t] = new TDataType("float");
+      fgBuiltins[kDouble_t] = fgBuiltins[kDouble32_t] = new TDataType("double");
       fgBuiltins[kVoid_t] = new TDataType("void");
       fgBuiltins[kBool_t] = new TDataType("bool");
       fgBuiltins[kCharStar] = new TDataType("char*");

--- a/tree/treeplayer/test/basic.cxx
+++ b/tree/treeplayer/test/basic.cxx
@@ -32,8 +32,8 @@ std::unique_ptr<TTree> MakeTree() {
    tree->Branch("two", &yData, "ny/i:y[ny]/I");
    tree->Branch("three", &z, "z");
    tree->Branch("str", &str);
-   tree->Branch("d32", &Double32);
-   tree->Branch("f16", &Float16);
+   tree->Branch("d32", &Double32, "d32/d");
+   tree->Branch("f16", &Float16, "f16/f");
    tree->Branch("0.2.0.energy", &z);
 
    x[1] = 42.;


### PR DESCRIPTION
# This Pull request: 
Adds the typedefs Float16_t and Double32_t to the builtin types in TDataType.
It is directly related to #9008 which adds the same changes to the patch-branch.

## Changes or fixes:
The change is required to read tree branches of those types using TTreeReader and TTreeReaderValue<Float16_t> / TTreeReaderValue<Double32_t>. Otherwise attempting to read such branches results in an error message that no dictonary for Float16_t / Double32_t exists.

## Checklist:
- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 