### PR TITLE
[ROOT5] cint: implement a stat() call cache for G__matchfilename()

### DIFF
--- a/cint/cint/src/loadfile.cxx
+++ b/cint/cint/src/loadfile.cxx
@@ -577,10 +577,11 @@ struct G__StatCacheEntry {
 int G__cachingstat(const char *path, struct stat *buf) {
   static std::map<std::string, struct G__StatCacheEntry> stat_cache;
 
-  if (   stat_cache.count(path)
-      && (stat_cache[path].ctime > (time(NULL) - R__STAT_CACHING_TIME))
+  std::map<std::string, struct G__StatCacheEntry>::const_iterator it = stat_cache.find(path);
+  if (   (it != stat_cache.end())
+      && (it->second.ctime > (time(NULL) - R__STAT_CACHING_TIME))
      ) {
-    const struct G__StatCacheEntry &e = stat_cache[path];
+    const struct G__StatCacheEntry &e = it->second;
     if (e.retcode < 0) {
       errno = e._errno;
     }


### PR DESCRIPTION
The G__matchfilename() implements a file comparison check used
specifically for loading/unloading of the libraries and the source code.
On UNIX-like systems the basic filename comparison is supplemented an
additional file match condition is based on comparing file attributes
returned by the stat() syscall.  On a typical load/unload call, the
G__matchfilename() is iterated over items of G__srcfile, which produces
a number of stat() calls that is quadratic in number of loaded files.

In our specific case we observe an occasional poor performance on AFS
network filesystem. The suggested change introduces a cache for the
stat() calls that should allow to reduce the number of calls to scale
linearly.

# This Pull request:

## Changes or fixes:

Fixes downstream issue star-bnl/star-sw#115

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)