### PR TITLE
Prevent Access of deleted object during hadd tear down

### DIFF
--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -939,6 +939,12 @@ TTree::~TTree()
       TFile *file = fDirectory->GetFile();
       MoveReadCache(file,0);
    }
+
+   // Remove the TTree from any list (linked to to the list of Cleanups) to avoid the unnecessary call to
+   // this RecursiveRemove while we delete our content.
+   ROOT::CallRecursiveRemoveIfNeeded(*this);
+   ResetBit(kMustCleanup); // Don't redo it.
+
    // We don't own the leaves in fLeaves, the branches do.
    fLeaves.Clear();
    // I'm ready to destroy any objects allocated by

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -961,6 +961,11 @@ TTree::~TTree()
    // Get rid of our branches, note that this will also release
    // any memory allocated by TBranchElement::SetAddress().
    fBranches.Delete();
+
+   // The TBranch destructor is using fDirectory to detect whether it
+   // owns the TFile that contains its data (See TBranch::~TBranch)
+   fDirectory = nullptr;
+
    // FIXME: We must consider what to do with the reset of these if we are a clone.
    delete fPlayer;
    fPlayer = 0;
@@ -1013,9 +1018,6 @@ TTree::~TTree()
    fClusterRangeEnd = 0;
    delete [] fClusterSize;
    fClusterSize = 0;
-   // Must be done after the destruction of friends.
-   // Note: We do *not* own our directory.
-   fDirectory = 0;
 
    if (fTransientBuffer) {
       delete fTransientBuffer;


### PR DESCRIPTION
    Prevent a TTree from calling its won RecursiveRemove.

    Call RecursiveRemove early in the TTree destructor (rather than last thing), to remove the tree
    from any list (like another TTree's list of clones) to avoid that the destructor's deletion of
    item (eg. the list of friends), provoke a call to this same TTree's RecursiveRemove which
    will try to call the RecursiveRemove on the item being deleted.  An alternative would be
    to replace the pattern.  `delete fFriends; fFriends = nullptr;`
    with `auto tmp = fFriends; fFriends = nullptr; delete tmp;`

    This fixes issue #9017 where we had a tear down crash because:

       ~TTree call delete fFriends which call RecursiveRemove which reach another TTree's list of clone
       where its find the (original) TTree and call its RecursiveRemove which tries (and fail) to call
       RecursiveRemove on fFriends
