### PR TITLE
[cmake] Clone the corresponding `roottest` branch, if `latest-stable` has been checked out for `root`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,13 @@ if(testing)
         set(GIT_BRANCH v${ROOT_MAJOR_VERSION}-${ROOT_MINOR_VERSION}-${ROOT_PATCH_VERSION})
       endif()
 
+      # Resolve the `latest-stable` branch to the latest merged head/tag
+      if("${GIT_BRANCH}" STREQUAL "latest-stable")
+        execute_process(COMMAND ${GIT_EXECUTABLE} for-each-ref --points-at=latest-stable^2 --format=%\(refname:short\)
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+      endif()
+
       execute_process(COMMAND
         ${GIT_EXECUTABLE} ls-remote --heads
         https://github.com/root-project/roottest.git ${GIT_BRANCH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,7 +619,7 @@ if(testing)
       find_package(Git REQUIRED)
 
       if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/.git)
-        execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+        execute_process(COMMAND ${GIT_EXECUTABLE} for-each-ref --points-at=HEAD --count=1 --format=%\(refname:short\)
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         OUTPUT_VARIABLE GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE)
       else()
@@ -634,7 +634,7 @@ if(testing)
       endif()
 
       execute_process(COMMAND
-        ${GIT_EXECUTABLE} ls-remote --heads
+        ${GIT_EXECUTABLE} ls-remote --heads --tags
         https://github.com/root-project/roottest.git ${GIT_BRANCH}
         OUTPUT_VARIABLE ROOTTEST_GIT_BRANCH)
 


### PR DESCRIPTION
This pull-request fixes a couple of issues related to `roottest` branch sync'ing.  See issue #8783 for more information.

## Changes or fixes:
- Checkout the correct `roottest` head/tag if root is at `latest-stable`.  If the current checked out branch is `latest-stable`, resolve it to the latest merged head/tag (i.e. second parent of latest-stable), and use that to clone `roottest`.  These two commands illustrate the proposed behavior:
```bash
$ git for-each-ref --points-at=latest-stable^2 --format=%(refname:short)
v6-24-06
$ git clone -b v6-24-06 https://github.com/root-project/roottest.git
```

- If the checked out ref in `root` is a tag (e.g. as a result of `$ git checkout v6-24-06`), `roottest` is not cloned at the expected revision.  The previous implementation relied on `git rev-parse --abbrev-ref HEAD` to get the name of the checked out branch.  While this works for branch heads, it fails for tags, i.e.
```bash
$ git checkout v6-24-06
HEAD is now at 3b796f86a3 "Update ROOT version files to v6.24/06."
$ git rev-parse --abbrev-ref HEAD
HEAD
```
The proposed solution in this case is to use `git for-each-ref` (or alternatively `git describe`), i.e.
```bash
$ git for-each-ref --points-at=HEAD --format='%(refname:short)'
v6-24-06
```

## Checklist:
- [X] tested changes locally

This PR fixes #8783.