### PR TITLE
[ntuple,daos] `RNTupleWriter::Recreate()` now overwrites old ntuple

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
+++ b/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
@@ -164,7 +164,8 @@ enum {
 };
 
 enum {
-	DAOS_COND_DKEY_INSERT	= (1 << 1),
+	DAOS_COND_DKEY_FETCH	= (1 << 3),
+	DAOS_COND_AKEY_FETCH	= (1 << 6),
 };
 
 /** Object open modes */

--- a/tree/ntuple/v7/src/RDaos.cxx
+++ b/tree/ntuple/v7/src/RDaos.cxx
@@ -98,13 +98,14 @@ ROOT::Experimental::Detail::RDaosObject::~RDaosObject()
 int ROOT::Experimental::Detail::RDaosObject::Fetch(FetchUpdateArgs &args)
 {
    args.fIods[0].iod_size = (daos_size_t)DAOS_REC_ANY;
-   return daos_obj_fetch(fObjectHandle, DAOS_TX_NONE, 0, &args.fDistributionKey, 1,
-                         args.fIods, args.fSgls, nullptr, args.fEv);
+   return daos_obj_fetch(fObjectHandle, DAOS_TX_NONE,
+                         DAOS_COND_DKEY_FETCH | DAOS_COND_AKEY_FETCH,
+                         &args.fDistributionKey, 1, args.fIods, args.fSgls, nullptr, args.fEv);
 }
 
 int ROOT::Experimental::Detail::RDaosObject::Update(FetchUpdateArgs &args)
 {
-   return daos_obj_update(fObjectHandle, DAOS_TX_NONE, DAOS_COND_DKEY_INSERT, &args.fDistributionKey, 1,
+   return daos_obj_update(fObjectHandle, DAOS_TX_NONE, 0, &args.fDistributionKey, 1,
                           args.fIods, args.fSgls, args.fEv);
 }
 


### PR DESCRIPTION
This pull-request fixes `RNTupleWriter::Recreate()` in DAOS 1.2, where the old ntuple was not overwritten (see issue #9032).

## Changes or fixes:
- `DAOS_COND_DKEY_INSERT` was inappropriately used in `daos_obj_update()` calls, which causes `RNTupleWriter::Recreate()` to not overwrite old data.  This has been fixed.

- Additionally, `DAOS_COND_{D,A}KEY_FETCH` has been added to flags in `daos_obj_fetch()` call (fail if dkey/akey does not exist).

## Checklist:
- [X] tested changes locally

This PR fixes #9032.