### PR TITLE
Disable the failing rcanvas/rbox.py test on Windows

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -313,6 +313,7 @@ if(root7)
     #---EOS is not supported on Windows
     list(APPEND root7_veto rcanvas/df104.py)
     list(APPEND root7_veto rcanvas/df105.py)
+    list(APPEND root7_veto rcanvas/rbox.py)
   endif()
 else()
   file(GLOB v7_veto_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/ v7/*.py v7/*.cxx v7/*/*.cxx v7/*.C v7/*/*.C rcanvas/*.py rcanvas/*.cxx)


### PR DESCRIPTION
Disable the rcanvas/rbox.py test which is failing with the following errors:
```
    Start 993: tutorial-rcanvas-rbox-py

993: Test command: "C:\Program Files\CMake\bin\cmake.exe" "-DCMD=C:/Python39-32/python.exe^C:/Users/bellenot/git/master/tutorials/launcher.py^C:/Users/bellenot/git/master/tutorials/rcanvas/rbox.py" "-DSYS=C:/Users/bellenot/build/release" "-DENV=ROOTSYS=C:/Users/bellenot/build/release#PYTHONPATH=C:/Users/bellenot/build/release/bin#PYTHIA8DATA=C:/Users/bellenot/libs/pythia8/8.3.03/share/Pythia8/xmldoc" "-P" "C:/Users/bellenot/build/release/RootTestDriver.cmake"
993: Environment variables:
993:  ROOT_HIST=0
993: Test timeout computed to be: 1500
993: input_line_35:10:7: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
993:       ((const shared_ptr<ROOT::Experimental::RCanvas>*)obj)->operator-><ROOT::Experimental::RCanvas, 0>();
993:       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
993: input_line_39:10:7: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
993:       ((const shared_ptr<ROOT::Experimental::RBox>*)obj)->operator-><ROOT::Experimental::RBox, 0>();
993:       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
993: Traceback (most recent call last):
993:   File "C:\Users\bellenot\git\master\tutorials\launcher.py", line 34, in <module>
993:     spec.loader.exec_module(module)
993:   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
993:   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
993:   File "C:/Users/bellenot/git/master/tutorials/rcanvas/rbox.py", line 24, in <module>
993:     box1.border.color = RColor.kBlue
993: AttributeError: <class cppyy.gbl.ROOT.Experimental.RColor at 0x12092B98> has no attribute 'kBlue'. Full details:
993:   attribute access requires an instance
993:   'ROOT::Experimental::RColor::kBlue' is not a known C++ class
993:   'kBlue' is not a known C++ template
993:   'kBlue' is not a known C++ enum
993: CMake Error at C:/Users/bellenot/build/release/RootTestDriver.cmake:227 (message):
993:   error code: 1
993:
993:
1/1 Test #993: tutorial-rcanvas-rbox-py .........***Failed    3.69 sec

0% tests passed, 1 tests failed out of 1

Label Time Summary:
tutorial    =   3.69 sec*proc (1 test)

Total Test time (real) =   6.60 sec

The following tests FAILED:
        993 - tutorial-rcanvas-rbox-py (Failed)
Errors while running CTest
```
