### PR TITLE
[DF] Fix RTrivialDS + Define

### DIFF
--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -18,6 +18,9 @@ namespace ROOT {
 
 namespace RDF {
 
+/// \brief A simple data-source implementation, for demo purposes.
+///
+/// Constructing an RDataFrame as `RDataFrame(nEntries)` is a superior alternative.
 class RTrivialDS final : public ROOT::RDF::RDataSource {
 private:
    unsigned int fNSlots = 0U;
@@ -47,9 +50,11 @@ public:
    std::string GetLabel();
 };
 
-// Make a RDF wrapping a RTrivialDS with the specified amount of entries
+/// \brief Make a RDF wrapping a RTrivialDS with the specified amount of entries.
+///
+/// Constructing an RDataFrame as `RDataFrame(nEntries)` is a superior alternative.
 RInterface<RDFDetail::RLoopManager> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries = false);
-// Make a RDF wrapping a RTrivialDS with infinite entries
+/// \brief Make a RDF wrapping a RTrivialDS with infinite entries, for demo purposes.
 RInterface<RDFDetail::RLoopManager> MakeTrivialDataFrame();
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -48,9 +48,9 @@ public:
 };
 
 // Make a RDF wrapping a RTrivialDS with the specified amount of entries
-RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries = false);
+RInterface<RDFDetail::RLoopManager> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries = false);
 // Make a RDF wrapping a RTrivialDS with infinite entries
-RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame();
+RInterface<RDFDetail::RLoopManager> MakeTrivialDataFrame();
 
 } // ns RDF
 

--- a/tree/dataframe/src/RTrivialDS.cxx
+++ b/tree/dataframe/src/RTrivialDS.cxx
@@ -121,17 +121,17 @@ std::string RTrivialDS::GetLabel()
    return "TrivialDS";
 }
 
-RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries)
+RInterface<RDFDetail::RLoopManager> MakeTrivialDataFrame(ULong64_t size, bool skipEvenEntries)
 {
    auto lm = std::make_unique<RDFDetail::RLoopManager>(std::make_unique<RTrivialDS>(size, skipEvenEntries),
                                                        RDFInternal::ColumnNames_t{});
-   return RInterface<RDFDetail::RLoopManager, RTrivialDS>(std::move(lm));
+   return RInterface<RDFDetail::RLoopManager>(std::move(lm));
 }
 
-RInterface<RDFDetail::RLoopManager, RTrivialDS> MakeTrivialDataFrame()
+RInterface<RDFDetail::RLoopManager> MakeTrivialDataFrame()
 {
    auto lm = std::make_unique<RDFDetail::RLoopManager>(std::make_unique<RTrivialDS>(), RDFInternal::ColumnNames_t{});
-   return RInterface<RDFDetail::RLoopManager, RTrivialDS>(std::move(lm));
+   return RInterface<RDFDetail::RLoopManager>(std::move(lm));
 }
 
 } // ns RDF

--- a/tutorials/dataframe/df010_trivialDataSource.C
+++ b/tutorials/dataframe/df010_trivialDataSource.C
@@ -11,6 +11,9 @@
 /// - https://github.com/root-project/root/blob/master/tree/dataframe/src/RTrivialDS.cxx
 /// - https://github.com/root-project/root/blob/master/tree/dataframe/inc/ROOT/RTrivialDS.hxx
 ///
+/// Note that RTrivialDS is only a demo data source implementation and superior alternatives
+/// typically exist for production use (e.g. constructing an empty RDataFrame as `RDataFrame(nEntries)`).
+///
 /// \macro_code
 ///
 /// \date September 2017
@@ -28,7 +31,7 @@ int df010_trivialDataSource()
    /// Now we redo the same with a RDF from scratch and we draw the two histograms
    ROOT::RDataFrame d(nEvents);
 
-   /// This lambda redoes what the TTrivialDS provides
+   /// This lambda redoes what the RTrivialDS provides
    auto g = []() {
       static ULong64_t i = 0;
       return i++;

--- a/tutorials/dataframe/df010_trivialDataSource.py
+++ b/tutorials/dataframe/df010_trivialDataSource.py
@@ -4,9 +4,12 @@
 ## Use the "trivial data source", an example data source implementation.
 ##
 ## This tutorial illustrates how use the RDataFrame in combination with a
-## RDataSource. In this case we use a TTrivialDS, which is nothing more
+## RDataSource. In this case we use a RTrivialDS, which is nothing more
 ## than a simple generator: it does not interface to any existing dataset.
-## The TTrivialDS has a single column, col0, which has value n for entry n.
+## The RTrivialDS has a single column, col0, which has value n for entry n.
+##
+## Note that RTrivialDS is only a demo data source implementation and superior alternatives
+## typically exist for production use (e.g. constructing an empty RDataFrame as `RDataFrame(nEntries)`).
 ##
 ## \macro_code
 ##


### PR DESCRIPTION
This PR fixes the problem reported at https://root-forum.cern.ch/t/rtrivialds-can-not-define-new-column-with-function/47038 and clarifies in our docs that RTrivialDS is only meant as a demonstrator RDataSource implementation and superior alternatives exist for common usecases.