### PR TITLE
[TMVA][Pymva] Fix handling PyObject's returned references

### DIFF
--- a/tmva/pymva/src/PyMethodBase.cxx
+++ b/tmva/pymva/src/PyMethodBase.cxx
@@ -94,6 +94,7 @@ PyMethodBase::PyMethodBase(Types::EMVA methodType,
 
 PyMethodBase::~PyMethodBase()
 {
+   // should we delete here fLocalNS ?
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -149,7 +150,7 @@ void PyMethodBase::PyInitialize()
       Log << kFATAL << "Can't init global namespace" << Endl;
       Log << Endl;
    }
-   // no need to increase reference for fGlobalNS, since it is linked to fMain?
+   Py_INCREF(fGlobalNS);
 
    #if PY_MAJOR_VERSION < 3
    //preparing objects for eval
@@ -213,6 +214,7 @@ void PyMethodBase::PyFinalize()
    if (fPickleDumps) Py_DECREF(fPickleDumps);
    if (fPickleLoads) Py_DECREF(fPickleLoads);
    if(fMain) Py_DECREF(fMain);//objects fGlobalNS and fLocalNS will be free here
+   if (fGlobalNS) Py_DECREF(fGlobalNS);
    Py_Finalize();
 }
 


### PR DESCRIPTION
This PR fixes the way the returned reference to PyObject are used in PyMethodBase.

When returned objects are borrowed and they need to be reused we increase the reference count,
but we make sure we don't decrease the count if it was not increased.
This should fix an issue observed in the Conda builds.
See https://root-forum.cern.ch/t/pymva-crashes-with-conda-root/46945

When the return objects are created ,we decrease the count if they are not used anymore.


