### PR TITLE
[VecOps] Re-add one namespace qualifier that was needed

### DIFF
--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -879,7 +879,7 @@ TEST(VecOps, UniqueCombinationsSingleVector)
 
 TEST(VecOps, PrintCollOfNonPrintable)
 {
-   auto code = "class A{};RVec<A> v(1);v";
+   auto code = "class A{};ROOT::RVec<A> v(1);v";
    auto ret = gInterpreter->ProcessLine(code);
    EXPECT_TRUE(0 != ret) << "Error in printing an RVec collection of non printable objects.";
 }


### PR DESCRIPTION
It fixes the failures in projectroot.math.vecops.test.gtest_math_vecops_test_vecops_rvec that are cropping up all over the place. Sorry, did not realize that the PR that introduced the change was not tested by jenkins because the title said `[N-F-C]` :disappointed: 