### PR TITLE
[DF] Use different files for different test cases

### DIFF
--- a/tree/dataframe/test/dataframe_samplecallback.cxx
+++ b/tree/dataframe/test/dataframe_samplecallback.cxx
@@ -154,7 +154,7 @@ TEST_P(RDFSampleCallback, TTreeSampleID) {
 }
 
 TEST_P(RDFSampleCallback, TChainSampleID) {
-   const std::string prefix = "rdfdatablockcallback_tchain";
+   const std::string prefix = "rdfdatablockcallback_tchainsampleid";
    InputFilesRAII file(5u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
    auto result = df.Book<>(SampleHelper(), {});


### PR DESCRIPTION
This might or might not fix the failures at https://lcgapp-services.cern.ch/root-jenkins/job/root-incremental-master/LABEL=ROOT-ubuntu1804-clangHEAD,SPEC=noimt/10051/testReport/junit/projectroot.tree.dataframe/test/gtest_tree_dataframe_test_dataframe_samplecallback/ , but it's anyway an improvement