### PR TITLE
[Eve] Backport: Add projection types requested by Mu2e (XZ, YZ, ZX, ZY) to TEve and R…

### DIFF
--- a/graf3d/eve/inc/LinkDef1.h
+++ b/graf3d/eve/inc/LinkDef1.h
@@ -199,6 +199,9 @@
 #pragma link C++ class TEveRhoZProjection+;
 #pragma link C++ class TEveRPhiProjection+;
 #pragma link C++ class TEveXZProjection+;
+#pragma link C++ class TEveYZProjection+;
+#pragma link C++ class TEveZXProjection+;
+#pragma link C++ class TEveZYProjection+;
 #pragma link C++ class TEve3DProjection+;
 
 #pragma link C++ class TEveProjectionManager+;

--- a/graf3d/eve/inc/TEveProjections.h
+++ b/graf3d/eve/inc/TEveProjections.h
@@ -26,7 +26,8 @@ class TEveTrans;
 class TEveProjection
 {
 public:
-   enum EPType_e   { kPT_Unknown, kPT_RPhi, kPT_XZ, kPT_RhoZ, kPT_3D, kPT_End }; // projection type
+   enum EPType_e   { kPT_Unknown, kPT_RhoZ, kPT_RPhi, 
+                     kPT_XZ, kPT_YZ, kPT_ZX, kPT_ZY, kPT_3D, kPT_End };  // projection type
    enum EPProc_e   { kPP_Plane, kPP_Distort, kPP_Full };                 // projection procedure
    enum EGeoMode_e { kGM_Unknown, kGM_Polygons, kGM_Segments };          // strategy for geometry projections
 
@@ -227,6 +228,88 @@ public:
 
    ClassDef(TEveXZProjection, 0); // XZ non-linear projection.
 };
+
+
+//==============================================================================
+// TEveYZProjection
+//==============================================================================
+
+class TEveYZProjection : public TEveProjection
+{
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   TEveYZProjection();
+   virtual ~TEveYZProjection() {}
+
+   virtual Bool_t Is2D() const { return kTRUE;  }
+   virtual Bool_t Is3D() const { return kFALSE; }
+
+   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+
+   ClassDef(TEveYZProjection, 0); // XY non-linear projection.
+};
+
+
+//==============================================================================
+// TEveZXProjection
+//==============================================================================
+
+class TEveZXProjection : public TEveProjection
+{
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   TEveZXProjection();
+   virtual ~TEveZXProjection() {}
+
+   virtual Bool_t Is2D() const { return kTRUE;  }
+   virtual Bool_t Is3D() const { return kFALSE; }
+
+   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+
+   ClassDef(TEveZXProjection, 0); // XZ non-linear projection.
+};
+
+
+//==============================================================================
+// TEveZYProjection
+//==============================================================================
+
+class TEveZYProjection : public TEveProjection
+{
+private:
+   TEveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   TEveZYProjection();
+   virtual ~TEveZYProjection() {}
+
+   virtual Bool_t Is2D() const { return kTRUE;  }
+   virtual Bool_t Is3D() const { return kFALSE; }
+
+   virtual void   ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full);
+
+   virtual void     SetCenter(TEveVector& v);
+   virtual Float_t* GetProjectedCenter() { return fProjectedCenter.Arr(); }
+
+   virtual void     SetDirectionalVector(Int_t screenAxis, TEveVector& vec);
+
+   ClassDef(TEveZYProjection, 0); // XY non-linear projection.
+};
+
 
 //==============================================================================
 // TEve3DProjection

--- a/graf3d/eve/src/TEveProjectionManager.cxx
+++ b/graf3d/eve/src/TEveProjectionManager.cxx
@@ -104,6 +104,11 @@ void TEveProjectionManager::SetProjection(TEveProjection::EPType_e type)
    {
       switch (type)
       {
+         case TEveProjection::kPT_RhoZ:
+         {
+            fProjections[type] = new TEveRhoZProjection();
+            break;
+         }
          case TEveProjection::kPT_RPhi:
          {
             fProjections[type] = new TEveRPhiProjection();
@@ -114,9 +119,19 @@ void TEveProjectionManager::SetProjection(TEveProjection::EPType_e type)
             fProjections[type] = new TEveXZProjection();
             break;
          }
-         case TEveProjection::kPT_RhoZ:
+         case TEveProjection::kPT_YZ:
          {
-            fProjections[type] = new TEveRhoZProjection();
+            fProjections[type] = new TEveYZProjection();
+            break;
+         }
+         case TEveProjection::kPT_ZX:
+         {
+            fProjections[type] = new TEveZXProjection();
+            break;
+         }
+         case TEveProjection::kPT_ZY:
+         {
+            fProjections[type] = new TEveZYProjection();
             break;
          }
          case TEveProjection::kPT_3D:

--- a/graf3d/eve/src/TEveProjectionManagerEditor.cxx
+++ b/graf3d/eve/src/TEveProjectionManagerEditor.cxx
@@ -49,9 +49,12 @@ TEveProjectionManagerEditor::TEveProjectionManagerEditor(const TGWindow *p,
       TGLabel* lab = new TGLabel(f, "Type");
       f->AddFrame(lab, new TGLayoutHints(kLHintsLeft|kLHintsBottom, 1, 31, 1, 2));
       fType = new TGComboBox(f);
+      fType->AddEntry("RhoZ", TEveProjection::kPT_RhoZ);
       fType->AddEntry("RPhi", TEveProjection::kPT_RPhi);
       fType->AddEntry("XZ",   TEveProjection::kPT_XZ);
-      fType->AddEntry("RhoZ", TEveProjection::kPT_RhoZ);
+      fType->AddEntry("YZ",   TEveProjection::kPT_YZ);
+      fType->AddEntry("ZX",   TEveProjection::kPT_ZX);
+      fType->AddEntry("ZY",   TEveProjection::kPT_ZY);
       fType->AddEntry("3D",   TEveProjection::kPT_3D);
       TGListBox* lb = fType->GetListBox();
       lb->Resize(lb->GetWidth(), 2*18);

--- a/graf3d/eve/src/TEveProjections.cxx
+++ b/graf3d/eve/src/TEveProjections.cxx
@@ -790,7 +790,7 @@ void TEveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
                                     Float_t d, EPProc_e proc)
 {
    using namespace TMath;
-   
+
    if (fDisplaceOrigin)
    {
       x  -= fCenter.fX;
@@ -873,6 +873,341 @@ void TEveXZProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
       vec.Set(1.0f, 0.0f, 0.0f);
    else if (screenAxis == 1)
       vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+
+/** \class TEveYZProjection
+\ingroup TEve
+YZ projection with distortion around given center.
+*/
+
+ClassImp(TEveYZProjection);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+TEveYZProjection::TEveYZProjection() :
+   TEveProjection()
+{
+   fType    = kPT_YZ;
+   fGeoMode = kGM_Polygons;
+   fName    = "YZ";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void TEveYZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = y;
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveYZProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fY;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveYZProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 1.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+
+/** \class TEveZXProjection
+\ingroup TEve
+ZX projection with distortion around given center.
+*/
+
+ClassImp(TEveZXProjection);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+TEveZXProjection::TEveZXProjection() :
+   TEveProjection()
+{
+   fType    = kPT_ZX;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZX";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void TEveZXProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = x;
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveZXProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fX;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveZXProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(1.0f, 0.0f, 0.0f);
+}
+
+
+/** \class TEveZYProjection
+\ingroup TEve
+ZY projection with distortion around given center.
+*/
+
+ClassImp(TEveZYProjection);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+TEveZYProjection::TEveZYProjection() :
+   TEveProjection()
+{
+   fType    = kPT_ZY;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZY";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void TEveZYProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void TEveZYProjection::SetCenter(TEveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fY;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class TEveProjection.
+
+void TEveZYProjection::SetDirectionalVector(Int_t screenAxis, TEveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 1.0f, 0.0f);
 }
 
 

--- a/graf3d/eve7/inc/LinkDef.h
+++ b/graf3d/eve7/inc/LinkDef.h
@@ -158,6 +158,10 @@
 #pragma link C++ typedef ROOT::Experimental::REveProjection::vPreScale_t;
 #pragma link C++ class ROOT::Experimental::REveRhoZProjection+;
 #pragma link C++ class ROOT::Experimental::REveRPhiProjection+;
+#pragma link C++ class ROOT::Experimental::REveXZProjection+;
+#pragma link C++ class ROOT::Experimental::REveYZProjection+;
+#pragma link C++ class ROOT::Experimental::REveZXProjection+;
+#pragma link C++ class ROOT::Experimental::REveZYProjection+;
 #pragma link C++ class ROOT::Experimental::REve3DProjection+;
 
 #pragma link C++ class ROOT::Experimental::REveProjectionManager+;

--- a/graf3d/eve7/inc/ROOT/REveProjections.hxx
+++ b/graf3d/eve7/inc/ROOT/REveProjections.hxx
@@ -29,7 +29,8 @@ class REveTrans;
 
 class REveProjection {
 public:
-   enum EPType_e { kPT_Unknown, kPT_RPhi, kPT_RhoZ, kPT_3D, kPT_End }; // projection type
+   enum EPType_e { kPT_Unknown, kPT_RhoZ, kPT_RPhi,
+                   kPT_XZ, kPT_YZ, kPT_ZX, kPT_ZY, kPT_3D, kPT_End };  // projection type
    enum EPProc_e { kPP_Plane, kPP_Distort, kPP_Full };                 // projection procedure
    enum EGeoMode_e { kGM_Unknown, kGM_Polygons, kGM_Segments };        // strategy for geometry projections
 
@@ -189,6 +190,102 @@ public:
    Bool_t Is3D() const override { return kFALSE; }
 
    void ProjectPoint(Float_t &x, Float_t &y, Float_t &z, Float_t d, EPProc_e proc = kPP_Full) override;
+};
+
+//==============================================================================
+// REveXZProjection
+// XZ non-linear projection.
+//==============================================================================
+
+class REveXZProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveXZProjection();
+   virtual ~REveXZProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
+};
+
+//==============================================================================
+// REveYZProjection
+// YZ non-linear projection.
+//==============================================================================
+
+class REveYZProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveYZProjection();
+   virtual ~REveYZProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
+};
+
+//==============================================================================
+// REveZXProjection
+// ZX non-linear projection.
+//==============================================================================
+
+class REveZXProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveZXProjection();
+   virtual ~REveZXProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
+};
+
+//==============================================================================
+// REveZYProjection
+// ZY non-linear projection.
+//==============================================================================
+
+class REveZYProjection : public REveProjection {
+private:
+   REveVector   fProjectedCenter; // projected center of distortion.
+
+public:
+   REveZYProjection();
+   virtual ~REveZYProjection() {}
+
+   Bool_t Is2D() const override { return kTRUE;  }
+   Bool_t Is3D() const override { return kFALSE; }
+
+   void ProjectPoint(Float_t& x, Float_t& y, Float_t& z, Float_t d, EPProc_e proc = kPP_Full) override;
+
+   void     SetCenter(REveVector& v) override;
+   Float_t* GetProjectedCenter() override { return fProjectedCenter.Arr(); }
+
+   void SetDirectionalVector(Int_t screenAxis, REveVector& vec) override;
 };
 
 //==============================================================================

--- a/graf3d/eve7/src/REveProjections.cxx
+++ b/graf3d/eve7/src/REveProjections.cxx
@@ -751,6 +751,442 @@ void REveRPhiProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
    z = d;
 }
 
+/** \class REveXZProjection
+\ingroup REve
+XZ projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveXZProjection::REveXZProjection() :
+   REveProjection()
+{
+   fType    = kPT_XZ;
+   fGeoMode = kGM_Polygons;
+   fName    = "XZ";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveXZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveXZProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fX;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveXZProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(1.0f, 0.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+
+/** \class REveYZProjection
+\ingroup REve
+YZ projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveYZProjection::REveYZProjection() :
+   REveProjection()
+{
+   fType    = kPT_YZ;
+   fGeoMode = kGM_Polygons;
+   fName    = "YZ";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveYZProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = y;
+      y = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveYZProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fY;
+      fProjectedCenter.fY = fCenter.fZ;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveYZProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 1.0f, 0.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 0.0f, 1.0f);
+}
+
+/** \class REveZXProjection
+\ingroup REve
+ZX projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveZXProjection::REveZXProjection() :
+   REveProjection()
+{
+   fType    = kPT_ZX;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZX";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveZXProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      y = x;
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveZXProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fX;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveZXProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(1.0f, 0.0f, 0.0f);
+}
+
+
+/** \class REveZYProjection
+\ingroup REve
+ZY projection with distortion around given center.
+*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor.
+
+REveZYProjection::REveZYProjection() :
+   REveProjection()
+{
+   fType    = kPT_ZY;
+   fGeoMode = kGM_Polygons;
+   fName    = "ZY";
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Project point.
+
+void REveZYProjection::ProjectPoint(Float_t& x, Float_t& y, Float_t& z,
+                                    Float_t d, EPProc_e proc)
+{
+   using namespace TMath;
+
+   if (fDisplaceOrigin)
+   {
+      x  -= fCenter.fX;
+      y  -= fCenter.fY;
+      z  -= fCenter.fZ;
+   }
+
+   // projection
+   if (proc == kPP_Plane || proc == kPP_Full)
+   {
+      x = z;
+      z = d;
+   }
+   if (proc != kPP_Distort || proc == kPP_Full)
+   {
+      Float_t r, phi;
+      if (fUsePreScale)
+      {
+         r   = Sqrt(x*x + y*y);
+         phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+         PreScalePoint(r, phi);
+         x = r*Cos(phi);
+         y = r*Sin(phi);
+      }
+
+      if (!fDisplaceOrigin)
+      {
+         x -= fProjectedCenter.fX;
+         y -= fProjectedCenter.fY;
+      }
+
+      r   = Sqrt(x*x + y*y);
+      phi = (x == 0.0f && y == 0.0f) ? 0.0f : ATan2(y, x);
+
+      if (r > fFixR)
+         r =  fFixR + fPastFixRScale*(r - fFixR);
+      else if (r < -fFixR)
+         r = -fFixR + fPastFixRScale*(r + fFixR);
+      else
+         r =  r * fScaleR / (1.0f + r*fDistortion);
+
+      x = r*Cos(phi);
+      y = r*Sin(phi);
+
+      if (!fDisplaceOrigin)
+      {
+         x += fProjectedCenter.fX;
+         y += fProjectedCenter.fY;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Set center of distortion (virtual method).
+
+void REveZYProjection::SetCenter(REveVector& v)
+{
+   fCenter = v;
+
+   if (fDisplaceOrigin)
+   {
+      fProjectedCenter.Set(0.f, 0.f, 0.f);
+   }
+   else
+   {
+      fProjectedCenter.fX = fCenter.fZ;
+      fProjectedCenter.fY = fCenter.fY;
+      fProjectedCenter.fZ = 0;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Get direction in the unprojected space for axis index in the
+/// projected space.
+/// This is virtual method from base-class REveProjection.
+
+void REveZYProjection::SetDirectionalVector(Int_t screenAxis, REveVector& vec)
+{
+   if (screenAxis == 0)
+      vec.Set(0.0f, 0.0f, 1.0f);
+   else if (screenAxis == 1)
+      vec.Set(0.0f, 1.0f, 0.0f);
+}
+
 /** \class REve3DProjection
 \ingroup REve
 3D scaling projection. One has to use pre-scaling to make any ise of this.


### PR DESCRIPTION
This is a backport to v6-24-00 from master branch.
The original change was in #8676