### PR TITLE
[DF] Remove special treatment of RVec<bool> in Snapshot

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1204,7 +1204,7 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
                  "TClonesArray as a Snapshot template parameter to write out a TClonesArray instead.", inName.c_str());
       }
       if (outputBranch) {
-         branchAddress = GetData(*ab);
+         branchAddress = ab->data();
          outputBranch->SetAddress(&branchAddress);
       } else {
          auto *b = outputTree.Branch(outName.c_str(), ab);
@@ -1236,7 +1236,7 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
       outputBranch->SetTitle(inputBranch->GetTitle());
       outputBranches.Insert(outName, outputBranch);
       branch = outputBranch;
-      branchAddress = GetData(*ab);
+      branchAddress = ab->data();
    }
 }
 


### PR DESCRIPTION
We took special care of RVec<bool> columns when Snapshotting
because we did not have a handle to a proper `bool*`
(`std::vector<bool>::data` does not exist).

With the new implementation of RVec, `RVec<bool>` behaves just like
any other RVec and we can remove the special-casing.