### PR TITLE
[ntuple] Remove warning `Warning: Unused class rule: PackedContainer`

### DIFF
--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -12,6 +12,6 @@
 
 #pragma link C++ class IAuxSetOption+;
 #pragma link C++ class PackedParameters+;
-#pragma link C++ class PackedContainer+;
+#pragma link C++ class PackedContainer<int>+;
 
 #endif


### PR DESCRIPTION
This pull-request fixes a typo in `CustomStructLinkDef.h` that generated a warning during build, i.e.
```
Warning: Unused class rule: PackedContainer
```

## Checklist:
- [X] tested changes locally