### PR TITLE
[skip-ci][DF] Improve DefinePerSample docs

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -81,6 +81,7 @@ Transformations are a way to manipulate the data.
 |------------------|--------------------|
 | Alias() | Introduce an alias for a particular column name. |
 | Define() | Creates a new column in the dataset. Example usages include adding a column that contains the invariant mass of a particle, or a selection of elements of an array (e.g. only the `pt`s of "good" muons). |
+| DefinePerSample() | Define a new column that is updated when the input sample changes, e.g. when switching tree being processed in a chain. |
 | DefineSlot() | Same as Define(), but the user-defined function must take an extra `unsigned int slot` as its first parameter. `slot` will take a different value, `0` to `nThreads - 1`, for each thread of execution. This is meant as a helper in writing thread-safe Define() transformation when using RDataFrame after ROOT::EnableImplicitMT(). DefineSlot() works just as well with single-thread execution: in that case `slot` will always be `0`.  |
 | DefineSlotEntry() | Same as DefineSlot(), but the entry number is passed in addition to the slot number. This is meant as a helper in case some dependency on the entry number needs to be honoured. |
 | Filter() | Filter rows based on user-defined conditions. |


### PR DESCRIPTION
- Link to DefinePerSample in the RDF cheat sheet
- correct signature of callable that must be given to DefinePerSample
- Add example usages in the docs


