### PR TITLE
Add the _MSC_VER value for Visual Studio 2022

### DIFF
--- a/interpreter/cling/lib/Utils/PlatformWin.cpp
+++ b/interpreter/cling/lib/Utils/PlatformWin.cpp
@@ -384,6 +384,8 @@ static int GetVisualStudioVersionCompiledWith() {
   return 15;
 #elif (_MSC_VER < 1930)
   return 16;
+#elif (_MSC_VER < 1940)
+  return 17;
 #else
   #error "Unsupported/Untested _MSC_VER"
   // As of now this is what is should be...have fun!


### PR DESCRIPTION
Add the `_MSC_VER` value (between 1930 and 1940) for the coming soon `Visual Studio 2022`
