### PR TITLE
[PyROOT] Produce a more meaningful error message in addressof

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPyCppyyModule.cxx
@@ -431,15 +431,14 @@ static PyObject* addressof(PyObject* /* dummy */, PyObject* args, PyObject* kwds
 
 // error message if not already set
     if (!PyErr_Occurred()) {
-        PyErr_SetString(PyExc_TypeError, "aap");
-        /*if (PyTuple_CheckExact(args) && PyTuple_GET_SIZE(args)) {
+        if (PyTuple_CheckExact(args) && PyTuple_GET_SIZE(args)) {
             PyObject* str = PyObject_Str(PyTuple_GET_ITEM(args, 0));
             if (str && CPyCppyy_PyText_Check(str))
                 PyErr_Format(PyExc_TypeError, "unknown object %s", CPyCppyy_PyText_AsString(str));
             else
                 PyErr_Format(PyExc_TypeError, "unknown object at %p", (void*)PyTuple_GET_ITEM(args, 0));
             Py_XDECREF(str);
-        } */
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
To prevent `TypeError: aap` error in `addressof`.
