### PR TITLE
[tcling] Gracefully handle namespace redeclarations

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -6634,9 +6634,9 @@ void TCling::RefreshClassInfo(TClass *cl, const clang::NamedDecl *def, bool alia
       if (!oldDef || (def && def != oldDef)) {
          cl->ResetCaches();
          TClass::RemoveClassDeclId(cci->GetDeclId());
-         if (def) {
+         if (const auto *type = cci->GetType()) {
             // It's a tag decl, not a namespace decl.
-            cci->Init(*cci->GetType());
+            cci->Init(*type);
             TClass::AddClassToDeclIdMap(cci->GetDeclId(), cl);
          }
       }

--- a/core/metacling/test/TClingTests.cxx
+++ b/core/metacling/test/TClingTests.cxx
@@ -241,3 +241,13 @@ TEST_F(TClingTests, ROOT10499) {
    EXPECT_EQ((void*)&errno, (void*)gInterpreter->Calc("&errno"));
 #endif
 }
+
+// Test issue #8828
+TEST_F(TClingTests, StdNamespaceRedefinition)
+{
+  gInterpreter->Declare("namespace std { namespace Detail { } }");
+  auto cl = TClass::GetClass("Detail");
+  EXPECT_TRUE(cl != nullptr);
+
+  gInterpreter->Declare("namespace Detail { }");
+}


### PR DESCRIPTION
The code in `TCling::RefreshClassInfo` assumed that, if there is a previous definition and it sees a new one, it must be a "tag decl". In fact, however, it is possible to be a namespace declaration with the same name as in `std::`, so explicitly check that `TClingClassInfo` has a type before attempting to dereference it.

Fixes #8828