### PR TITLE
[foundation] Rename `std::Detail` to `std::__ROOT` (issue #9089):

### DIFF
--- a/core/foundation/inc/ROOT/RNotFn.hxx
+++ b/core/foundation/inc/ROOT/RNotFn.hxx
@@ -28,7 +28,7 @@
 
 namespace std {
 
-namespace Detail {
+namespace __ROOT_noinline {
 template <typename F>
 class not_fn_t {
    std::decay_t<F> fFun;
@@ -55,9 +55,9 @@ public:
 
 
 template <typename F>
-Detail::not_fn_t<F> not_fn(F &&f)
+__ROOT_noinline::not_fn_t<F> not_fn(F &&f)
 {
-   return Detail::not_fn_t<F>(std::forward<F>(f));
+   return __ROOT_noinline::not_fn_t<F>(std::forward<F>(f));
 }
 }
 


### PR DESCRIPTION
ROOT "swallows" `std::`, and we need to figure out how to handle the namespaces
`std::foo` vs `::foo`. Until we do that, avoid the issue by renaming the only
known "clash", using `std::__ROOT` as in several other backport cases.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

