### PR TITLE
[skip-ci] this tutorial produced a wrong output

### DIFF
--- a/tutorials/hist/twoscales.py
+++ b/tutorials/hist/twoscales.py
@@ -28,6 +28,7 @@ for i in range(10000) :
     h1.Fill(ROOT.gRandom.Gaus(0,1))
 
 h1.Draw()
+c1.Update()
 
 hint1 = ROOT.TH1F("hint1","h1 bins integral",100,-3,3)
 
@@ -36,8 +37,8 @@ for i in range(1,101) :
    sum += h1.GetBinContent(i)
    hint1.SetBinContent(i,sum)
 
-rightmax = 1.1*hint1.GetMaximum();
-scale = ROOT.gPad.GetUymax()/rightmax;
+rightmax = 1.1*hint1.GetMaximum()
+scale = ROOT.gPad.GetUymax()/rightmax
 hint1.SetLineColor(ROOT.kRed)
 hint1.Scale(scale)
 hint1.Draw("same")


### PR DESCRIPTION
This tutorial didn't produce the same results as the C++ equivalent.
As mentioned here:
https://root-forum.cern.ch/t/error-in-pyroot-tutorial-twoscales-py/47215/2

