### PR TITLE
[skip-ci] the geometry and graphpainter anchors clashed

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -54,22 +54,22 @@ ClassImp(TGraphPainter);
     \ingroup Histpainter
     \brief The graph painter class. Implements all graphs' drawing's options.
 
-- [Introduction](\ref GP00)
-- [Graphs' plotting options](\ref GP01)
-- [Exclusion graphs](\ref GP02)
-- [Graphs with error bars](\ref GP03)
-   - [TGraphErrors](\ref GP03a)
-   - [TGraphAsymmErrors](\ref GP03b)
-   - [TGraphBentErrors](\ref GP03c)
-   - [TGraphMultiErrors](\ref GP03d)
-- [TGraphPolar options](\ref GP04)
-- [Colors automatically picked in palette](\ref GP05)
-- [Reverse graphs' axis](\ref GP06)
-- [Graphs in logarithmic scale](\ref GP07)
-- [Highlight mode for graph](\ref GP08)
+- [Introduction](\ref GrP0)
+- [Graphs' plotting options](\ref GrP1)
+- [Exclusion graphs](\ref GrP2)
+- [Graphs with error bars](\ref GrP3)
+   - [TGraphErrors](\ref GrP3a)
+   - [TGraphAsymmErrors](\ref GrP3b)
+   - [TGraphBentErrors](\ref GrP3c)
+   - [TGraphMultiErrors](\ref GrP3d)
+- [TGraphPolar options](\ref GrP4)
+- [Colors automatically picked in palette](\ref GrP5)
+- [Reverse graphs' axis](\ref GrP6)
+- [Graphs in logarithmic scale](\ref GrP7)
+- [Highlight mode for graph](\ref GrP8)
 
 
-\anchor GP00
+\anchor GrP0
 ### Introduction
 
 Graphs are drawn via the painter `TGraphPainter` class. This class
@@ -102,7 +102,7 @@ after one of these three actions:
 2.  a click inside the pad,
 3.  a call to `TPad::Update`.
 
-\anchor GP01
+\anchor GrP1
 ### Graphs' plotting options
 Graphs can be drawn with the following options:
 
@@ -181,7 +181,7 @@ Begin_Macro(source)
 }
 End_Macro
 
-\anchor GP02
+\anchor GrP2
 ### Exclusion graphs
 
 When a graph is painted with the option `C` or `L` it is
@@ -204,7 +204,7 @@ Begin_Macro(source)
 ../../../tutorials/graphs/exclusiongraph.C
 End_Macro
 
-\anchor GP03
+\anchor GrP3
 ### Graphs with error bars
 Three classes are available to handle graphs with error bars:
 `TGraphErrors`, `TGraphAsymmErrors` and `TGraphBentErrors`.
@@ -232,7 +232,7 @@ The following drawing options are specific to graphs with error bars:
 at the end of the error bars (when option 1 is used).
 By default `np=1`. (np represents the number of pixels).
 
-\anchor GP03a
+\anchor GrP3a
 #### TGraphErrors
 
 A `TGraphErrors` is a `TGraph` with error bars. The errors are
@@ -350,7 +350,7 @@ Begin_Macro(source)
 }
 End_Macro
 
-\anchor GP03b
+\anchor GrP3b
 #### TGraphAsymmErrors
 A `TGraphAsymmErrors` is like a `TGraphErrors` but the errors
 defined along X and Y are not symmetric: The left and right errors are
@@ -374,7 +374,7 @@ Begin_Macro(source)
 End_Macro
 
 
-\anchor GP03c
+\anchor GrP3c
 #### TGraphBentErrors
 A `TGraphBentErrors` is like a `TGraphAsymmErrors`.
 An extra parameter allows to bend the error bars to better see them
@@ -403,7 +403,7 @@ Begin_Macro(source)
 End_Macro
 
 
-\anchor GP03d
+\anchor GrP3d
 #### TGraphMultiErrors
 A `TGraphMultiErrors` works basically the same way like a `TGraphAsymmErrors`.
 It has the possibility to define more than one type / dimension of y-Errors.
@@ -455,7 +455,7 @@ Begin_Macro(source)
 End_Macro
 
 
-\anchor GP04
+\anchor GrP4
 ### TGraphPolar options
 
 The drawing options for the polar graphs are the following:
@@ -497,7 +497,7 @@ Begin_Macro(source)
 }
 End_Macro
 
-\anchor GP05
+\anchor GrP5
 ### Colors automatically picked in palette
 
 \since **ROOT version 6.09/01**
@@ -520,7 +520,7 @@ Begin_Macro(source)
 ../../../tutorials/graphs/multigraphpalettecolor.C
 End_Macro
 
-\anchor GP06
+\anchor GrP6
 ### Reverse graphs' axis
 
 \since **ROOT version 6.09/03**
@@ -561,7 +561,7 @@ Begin_Macro(source)
 }
 End_Macro
 
-\anchor GP07
+\anchor GrP7
 ### Graphs in logarithmic scale
 
 Like histograms, graphs can be drawn in logarithmic scale along X and Y. When
@@ -603,7 +603,7 @@ Begin_Macro(source)
 
 End_Macro
 
-\anchor GP08
+\anchor GrP8
 #### Highlight mode for graph
 
 \since **ROOT version 6.15/01**
@@ -1275,7 +1275,7 @@ void TGraphPainter::PaintHelper(TGraph *theGraph, Option_t *option)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a graph.]($GP01)
+/// [Control function to draw a graph.](\ref GrP1)
 
 void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt)
 {
@@ -2406,7 +2406,7 @@ do_cleanup:
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Paint this TGraphAsymmErrors with its current attributes.](#GP03)
+/// [Paint this TGraphAsymmErrors with its current attributes.](\ref GrP3)
 
 void TGraphPainter::PaintGraphAsymmErrors(TGraph *theGraph, Option_t *option)
 {
@@ -2652,7 +2652,7 @@ void TGraphPainter::PaintGraphAsymmErrors(TGraph *theGraph, Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Paint this TGraphMultiErrors with its current attributes.]($GP03)
+/// [Paint this TGraphMultiErrors with its current attributes.](\ref GrP3)
 
 void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
 {
@@ -3123,7 +3123,7 @@ void TGraphPainter::PaintGraphMultiErrors(TGraph *theGraph, Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Paint this TGraphBentErrors with its current attributes.]($GP03)
+/// [Paint this TGraphBentErrors with its current attributes.](\ref GrP3)
 
 void TGraphPainter::PaintGraphBentErrors(TGraph *theGraph, Option_t *option)
 {
@@ -3379,7 +3379,7 @@ void TGraphPainter::PaintGraphBentErrors(TGraph *theGraph, Option_t *option)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Paint this TGraphErrors with its current attributes.]($GP03)
+/// [Paint this TGraphErrors with its current attributes.](\ref GrP3)
 
 void TGraphPainter::PaintGraphErrors(TGraph *theGraph, Option_t *option)
 {
@@ -3626,7 +3626,7 @@ void TGraphPainter::PaintGraphErrors(TGraph *theGraph, Option_t *option)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Paint this TGraphPolar with its current attributes.]($GP04)
+/// [Paint this TGraphPolar with its current attributes.](\ref GrP4)
 
 void TGraphPainter::PaintGraphPolar(TGraph *theGraph, Option_t* options)
 {

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -436,7 +436,7 @@ some combinations must be use with care.
 - It does not work when combined with the `LEGO` and `SURF` options unless the
   histogram plotted with the option `SAME` has exactly the same
   ranges on the X, Y and Z axis as the currently drawn histogram. To superimpose
-  lego plots [histograms' stacks](#HP26) should be used.
+  lego plots [histograms' stacks](\ref HP26) should be used.
 
 
 \anchor HP061
@@ -1132,7 +1132,7 @@ End_Macro
 When the option SAME (or "SAMES") is used with the option COL, the boxes' color
 are computing taking the previous plots into account. The range along the Z axis
 is imposed by the first plot (the one without option SAME); therefore the order
-in which the plots are done is relevant. Same as [in the `BOX` option](#HP13), one can use
+in which the plots are done is relevant. Same as [in the `BOX` option](\ref HP13), one can use
 `SAME0` (or `SAMES0`) to opt out of this imposition.
 
 Begin_Macro(source)
@@ -1915,7 +1915,7 @@ following options:
 | "0"      | When used with any LEGO option, the empty bins are not drawn.|
 
 
-See the limitations with [the option "SAME"](#HP060a).
+See the limitations with [the option "SAME"](\ref HP060a).
 
 Line attributes can be used in lego plots to change the edges' style.
 
@@ -2021,7 +2021,7 @@ The height of the mesh is proportional to the cell content.
 
 
 
-See the limitations with [the option "SAME"](#HP060a).
+See the limitations with [the option "SAME"](\ref HP060a).
 
 The following example shows a 2D histogram plotted with the option
 `SURF`. The option `SURF` draws a lego plot using the hidden
@@ -2286,7 +2286,7 @@ Begin_Macro(source)
 End_Macro
 
 This option also works for horizontal plots. The example given in the section
-["The bar chart option"](#HP100) appears as follow:
+["The bar chart option"](\ref HP100) appears as follow:
 
 Begin_Macro(source)
 {
@@ -4462,7 +4462,7 @@ Int_t THistPainter::MakeCuts(char *choptin)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control routine to paint any kind of histograms](#HP00)
+/// [Control routine to paint any kind of histograms](\ref HP00)
 
 void THistPainter::Paint(Option_t *option)
 {
@@ -4656,7 +4656,7 @@ paintstat:
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a table as an arrow plot](#HP12)
+/// [Control function to draw a table as an arrow plot](\ref HP12)
 
 void THistPainter::PaintArrows(Option_t *)
 {
@@ -5031,7 +5031,7 @@ void THistPainter::PaintAxis(Bool_t drawGridOnly)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Draw a bar-chart in a normal pad.](#HP10)
+/// [Draw a bar-chart in a normal pad.](\ref HP10)
 
 void THistPainter::PaintBar(Option_t *)
 {
@@ -5080,7 +5080,7 @@ void THistPainter::PaintBar(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Draw a bar char in a rotated pad (X vertical, Y horizontal)](#HP10)
+/// [Draw a bar char in a rotated pad (X vertical, Y horizontal)](\ref HP10)
 
 void THistPainter::PaintBarH(Option_t *)
 {
@@ -5157,7 +5157,7 @@ void THistPainter::PaintBarH(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a box plot](#HP13)
+/// [Control function to draw a 2D histogram as a box plot](\ref HP13)
 
 void THistPainter::PaintBoxes(Option_t *)
 {
@@ -5342,7 +5342,7 @@ void THistPainter::PaintBoxes(Option_t *)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a candle (box) plot or violin plot](#HP14)
+/// [Control function to draw a 2D histogram as a candle (box) plot or violin plot](\ref HP14)
 
 void THistPainter::PaintCandlePlot(Option_t *)
 {
@@ -5556,7 +5556,7 @@ THistPainter::ComputeRenderingRegions(TAxis* pAxis, Int_t nPixels, Bool_t isLog)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Rendering scheme for the COL2 and COLZ2 options] (#HP14)
+/// [Rendering scheme for the COL2 and COLZ2 options] (\ref HP14)
 
 void THistPainter::PaintColorLevelsFast(Option_t*)
 {
@@ -5745,7 +5745,7 @@ void THistPainter::PaintColorLevelsFast(Option_t*)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a color plot.](#HP14)
+/// [Control function to draw a 2D histogram as a color plot.](\ref HP14)
 
 void THistPainter::PaintColorLevels(Option_t*)
 {
@@ -5908,7 +5908,7 @@ void THistPainter::PaintColorLevels(Option_t*)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a contour plot.](#HP16)
+/// [Control function to draw a 2D histogram as a contour plot.](\ref HP16)
 
 void THistPainter::PaintContour(Option_t *option)
 {
@@ -6306,7 +6306,7 @@ Int_t THistPainter::PaintContourLine(Double_t elev1, Int_t icont1, Double_t x1, 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Draw 1D histograms error bars.](#HP09)
+/// [Draw 1D histograms error bars.](\ref HP09)
 
 void THistPainter::PaintErrors(Option_t *)
 {
@@ -6796,7 +6796,7 @@ void THistPainter::PaintFrame()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  [Paint functions associated to an histogram.](#HP28")
+///  [Paint functions associated to an histogram.](\ref HP28")
 
 void THistPainter::PaintFunction(Option_t *)
 {
@@ -6836,7 +6836,7 @@ void THistPainter::PaintFunction(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control routine to draw 1D histograms](#HP01b)
+/// [Control routine to draw 1D histograms](\ref HP01b)
 
 void THistPainter::PaintHist(Option_t *)
 {
@@ -6978,7 +6978,7 @@ void THistPainter::PaintHist(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 3D histograms.](#HP01d)
+/// [Control function to draw a 3D histograms.](\ref HP01d)
 
 void THistPainter::PaintH3(Option_t *option)
 {
@@ -7470,7 +7470,7 @@ Int_t THistPainter::PaintInitH()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 3D histogram with boxes.](#HP25)
+/// [Control function to draw a 3D histogram with boxes.](\ref HP25)
 
 void THistPainter::PaintH3Box(Int_t iopt)
 {
@@ -7645,7 +7645,7 @@ void THistPainter::PaintH3Box(Int_t iopt)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 3D histogram with boxes.](#HP25)
+/// [Control function to draw a 3D histogram with boxes.](\ref HP25)
 
 void THistPainter::PaintH3BoxRaster()
 {
@@ -7831,7 +7831,7 @@ void THistPainter::PaintH3BoxRaster()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 3D histogram with Iso Surfaces.](#HP25)
+/// [Control function to draw a 3D histogram with Iso Surfaces.](\ref HP25)
 
 void THistPainter::PaintH3Iso()
 {
@@ -7949,7 +7949,7 @@ void THistPainter::PaintH3Iso()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a lego plot.](#HP17)
+/// [Control function to draw a 2D histogram as a lego plot.](\ref HP17)
 
 void THistPainter::PaintLego(Option_t *)
 {
@@ -8350,7 +8350,7 @@ void THistPainter::PaintLegoAxis(TGaxis *axis, Double_t ang)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Paint the color palette on the right side of the pad.](#HP22)
+/// [Paint the color palette on the right side of the pad.](\ref HP22)
 
 void THistPainter::PaintPalette()
 {
@@ -8389,7 +8389,7 @@ void THistPainter::PaintPalette()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a scatter plot.](#HP11)
+/// [Control function to draw a 2D histogram as a scatter plot.](\ref HP11)
 
 void THistPainter::PaintScatterPlot(Option_t *option)
 {
@@ -8543,7 +8543,7 @@ void THistPainter::PaintSpecialObjects(const TObject *obj, Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Draw the statistics box for 1D and profile histograms.](#HP07)
+/// [Draw the statistics box for 1D and profile histograms.](\ref HP07)
 
 void THistPainter::PaintStat(Int_t dostat, TF1 *fit)
 {
@@ -8760,7 +8760,7 @@ void THistPainter::PaintStat(Int_t dostat, TF1 *fit)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Draw the statistics box for 2D histograms.](#HP07)
+/// [Draw the statistics box for 2D histograms.](\ref HP07)
 
 void THistPainter::PaintStat2(Int_t dostat, TF1 *fit)
 {
@@ -8977,7 +8977,7 @@ void THistPainter::PaintStat2(Int_t dostat, TF1 *fit)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Draw the statistics box for 3D histograms.](#HP07)
+/// [Draw the statistics box for 3D histograms.](\ref HP07)
 
 void THistPainter::PaintStat3(Int_t dostat, TF1 *fit)
 {
@@ -9192,7 +9192,7 @@ void THistPainter::PaintStat3(Int_t dostat, TF1 *fit)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 2D histogram as a surface plot.](#HP18)
+/// [Control function to draw a 2D histogram as a surface plot.](\ref HP18)
 
 void THistPainter::PaintSurface(Option_t *)
 {
@@ -9569,7 +9569,7 @@ void THistPainter::DefineColorLevels(Int_t ndivz)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw 2D/3D histograms (tables).](#HP01c)
+/// [Control function to draw 2D/3D histograms (tables).](\ref HP01c)
 
 void THistPainter::PaintTable(Option_t *option)
 {
@@ -9732,7 +9732,7 @@ void THistPainter::PaintTH2PolyBins(Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a TH2Poly as a color plot.](#HP20a)
+/// [Control function to draw a TH2Poly as a color plot.](\ref HP20a)
 
 void THistPainter::PaintTH2PolyColorLevels(Option_t *)
 {
@@ -9829,7 +9829,7 @@ void THistPainter::PaintTH2PolyColorLevels(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a TH2Poly as a scatter plot.](#HP20a)
+/// [Control function to draw a TH2Poly as a scatter plot.](\ref HP20a)
 
 void THistPainter::PaintTH2PolyScatterPlot(Option_t *)
 {
@@ -9942,7 +9942,7 @@ void THistPainter::PaintTH2PolyScatterPlot(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a TH2Poly as a text plot.](#HP20a)
+/// [Control function to draw a TH2Poly as a text plot.](\ref HP20a)
 
 void THistPainter::PaintTH2PolyText(Option_t *)
 {
@@ -10000,7 +10000,7 @@ void THistPainter::PaintTH2PolyText(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 1D/2D histograms with the bin values.](#HP15)
+/// [Control function to draw a 1D/2D histograms with the bin values.](\ref HP15)
 
 void THistPainter::PaintText(Option_t *)
 {
@@ -10096,7 +10096,7 @@ void THistPainter::PaintText(Option_t *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// [Control function to draw a 3D implicit functions.](#HP27)
+/// [Control function to draw a 3D implicit functions.](\ref HP27)
 
 void THistPainter::PaintTF3()
 {


### PR DESCRIPTION
reported here: 
https://root-forum.cern.ch/t/wrong-links-in-tgraphpainter-documentation-page/47231/2
