### PR TITLE
[RF] Fix memory leaks in RooFactoryWSTool

### DIFF
--- a/roofit/roofitcore/src/RooFactoryWSTool.cxx
+++ b/roofit/roofitcore/src/RooFactoryWSTool.cxx
@@ -531,13 +531,13 @@ RooAddPdf* RooFactoryWSTool::add(const char *objName, const char* specList, Bool
   } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooAddPdf: " << err << endl ;    
     logError() ;
-    return 0 ;
+    return nullptr;
   }
   
-  RooAddPdf* pdf =  new RooAddPdf(objName,objName,pdfList,coefList,recursiveCoefs) ;
-  pdf->setStringAttribute("factory_tag",Form("SUM::%s(%s)",objName,specList)) ;
-  if (_ws->import(*pdf,Silence())) logError() ;
-  return (RooAddPdf*) _ws->pdf(objName) ;
+  RooAddPdf pdf{objName,objName,pdfList,coefList,recursiveCoefs};
+  pdf.setStringAttribute("factory_tag",Form("SUM::%s(%s)",objName,specList)) ;
+  if (_ws->import(pdf,Silence())) logError() ;
+  return static_cast<RooAddPdf*>(_ws->pdf(objName));
 }
 
 
@@ -573,13 +573,13 @@ RooRealSumPdf* RooFactoryWSTool::amplAdd(const char *objName, const char* specLi
   } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::add(" << objName << ") ERROR creating RooRealSumPdf: " << err << endl ;    
     logError() ;
-    return 0 ;
+    return nullptr;
   }
   
-  RooRealSumPdf* pdf =  new RooRealSumPdf(objName,objName,amplList,coefList,(amplList.getSize()==coefList.getSize())) ;
-  pdf->setStringAttribute("factory_tag",Form("ASUM::%s(%s)",objName,specList)) ;
-  if (_ws->import(*pdf,Silence())) logError() ;
-  return (RooRealSumPdf*) _ws->pdf(objName) ;
+  RooRealSumPdf pdf(objName,objName,amplList,coefList,(amplList.getSize()==coefList.getSize())) ;
+  pdf.setStringAttribute("factory_tag",Form("ASUM::%s(%s)",objName,specList)) ;
+  if (_ws->import(pdf,Silence())) logError() ;
+  return static_cast<RooRealSumPdf*>(_ws->pdf(objName));
 }
 
 
@@ -629,23 +629,21 @@ RooProdPdf* RooFactoryWSTool::prod(const char *objName, const char* pdfList)
   }
   regPdfList += "}" ;
   
-  RooProdPdf* pdf = 0 ;
+  std::unique_ptr<RooProdPdf> pdf;
   try {
-    pdf = new RooProdPdf(objName,objName,asSET(regPdfList.c_str()),cmdList) ;
+    pdf = std::make_unique<RooProdPdf>(objName,objName,asSET(regPdfList.c_str()),cmdList);
   } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::prod(" << objName << ") ERROR creating RooProdPdf input set of regular p.d.f.s: " << err << endl ;
     logError() ;
-    pdf = 0 ;
   }
   cmdList.Delete() ;
   
   if (pdf) {
     pdf->setStringAttribute("factory_tag",Form("PROD::%s(%s)",objName,pdfList)) ;
     if (_ws->import(*pdf,Silence())) logError() ;
-    delete pdf ;
     return (RooProdPdf*) _ws->pdf(objName) ;
   } else {
-    return 0 ;
+    return nullptr;
   }
 }
 
@@ -683,12 +681,13 @@ RooSimultaneous* RooFactoryWSTool::simul(const char* objName, const char* indexC
 
 
   // Create simultaneous p.d.f.
-  RooSimultaneous* pdf(0) ;
+  std::unique_ptr<RooSimultaneous> pdf;
   try {
-    pdf = new RooSimultaneous(objName,objName,theMap,asCATLV(indexCat)) ;
+    pdf = std::make_unique<RooSimultaneous>(objName,objName,theMap,asCATLV(indexCat)) ;
   } catch (const string &err) {
     coutE(ObjectHandling) << "RooFactoryWSTool::simul(" << objName << ") ERROR creating RooSimultaneous::" << objName << " " << err << endl ;
     logError() ;
+    return nullptr;
   }
 
   // Import p.d.f into workspace
@@ -738,16 +737,11 @@ RooAddition* RooFactoryWSTool::addfunc(const char *objName, const char* specList
   }
 
 
-  RooAddition* sum ;
-  if (sumlist2.getSize()>0) {
-    sum = new RooAddition(objName,objName,sumlist1,sumlist2) ;
-  } else {
-    sum = new RooAddition(objName,objName,sumlist1) ;
-  }
+  auto sum = sumlist2.empty() ? std::make_unique<RooAddition>(objName,objName,sumlist1)
+                              : std::make_unique<RooAddition>(objName,objName,sumlist1,sumlist2);
 
   sum->setStringAttribute("factory_tag",Form("sum::%s(%s)",objName,specList)) ;
   if (_ws->import(*sum,Silence())) logError() ;
-  delete sum ;
   return (RooAddition*) _ws->pdf(objName) ;
   
 }
@@ -2108,18 +2102,18 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
     const char* range = R__STRTOK_R(0,"",&save) ;
     if (!range) range="" ;
 
-    RooAbsReal* integral = 0 ;
+    std::unique_ptr<RooAbsReal> integral;
     if (pargv.size()==2) {
       if (range && strlen(range)) {
-	integral = func.createIntegral(ft.asSET(intobs),Range(range)) ;
+        integral.reset(func.createIntegral(ft.asSET(intobs),Range(range)));
       } else {
-	integral = func.createIntegral(ft.asSET(intobs)) ;
+        integral.reset(func.createIntegral(ft.asSET(intobs)));
       }
     } else {
       if (range && strlen(range)) {
-	integral = func.createIntegral(ft.asSET(intobs),Range(range),NormSet(ft.asSET(pargv[2].c_str()))) ;
+        integral.reset(func.createIntegral(ft.asSET(intobs),Range(range),NormSet(ft.asSET(pargv[2].c_str()))));
       } else {
-	integral = func.createIntegral(ft.asSET(intobs),NormSet(ft.asSET(pargv[2].c_str()))) ;
+        integral.reset(func.createIntegral(ft.asSET(intobs),NormSet(ft.asSET(pargv[2].c_str()))));
       }
     }
 
@@ -2136,11 +2130,11 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
 
     RooAbsReal& func = ft.asFUNC(pargv[0].c_str()) ;
 
-    RooAbsReal* derivative(0) ;
+    std::unique_ptr<RooAbsReal> derivative;
     if (pargv.size()==2) {
-      derivative = func.derivative(ft.asVAR(pargv[1].c_str()),1) ;
+      derivative.reset(func.derivative(ft.asVAR(pargv[1].c_str()),1));
     } else {
-      derivative = func.derivative(ft.asVAR(pargv[1].c_str()),ft.asINT(pargv[2].c_str())) ;
+      derivative.reset(func.derivative(ft.asVAR(pargv[1].c_str()),ft.asINT(pargv[2].c_str())));
     }
 
     derivative->SetName(instName) ;
@@ -2156,11 +2150,11 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
 
     RooAbsPdf& pdf = ft.asPDF(pargv[0].c_str()) ;
 
-    RooAbsReal* cdf(0) ;
+    std::unique_ptr<RooAbsReal> cdf;
     if (pargv.size()==2) {
-      cdf = pdf.createCdf(ft.asSET(pargv[1].c_str())) ;
+      cdf.reset(pdf.createCdf(ft.asSET(pargv[1].c_str())));
     } else {
-      cdf = pdf.createCdf(ft.asSET(pargv[1].c_str()),ft.asSET(pargv[2].c_str())) ;
+      cdf.reset(pdf.createCdf(ft.asSET(pargv[1].c_str()),ft.asSET(pargv[2].c_str())));
     }
 
     cdf->SetName(instName) ;
@@ -2175,7 +2169,7 @@ std::string RooFactoryWSTool::SpecialsIFace::create(RooFactoryWSTool& ft, const 
     }
 
     RooAbsPdf& pdf = ft.asPDF(pargv[0].c_str()) ;
-    RooAbsPdf* projection = pdf.createProjection(ft.asSET(pargv[1].c_str())) ;
+    std::unique_ptr<RooAbsPdf> projection{pdf.createProjection(ft.asSET(pargv[1].c_str()))};
     projection->SetName(instName) ;
 
     if (ft.ws().import(*projection,Silence())) ft.logError() ;


### PR DESCRIPTION
In the special RooFit workspace functions implemented in
RooFactoryWSTool, the tool creates a given RooFit object that is then
imported in the workspace. For example, a RooAddPdf is created when you
use `SUM` in `RooWorkspace::factory()`.  When these objects are
imported, they are copied, so the original object is still owned by the
RooFactoryWSTool. In some cases, the original object is not deleted,
causing a memory leak and even worse duplicate client nodes in the
computation graph. This commit fixes that.

Simple reproducer for the problem with the duplicate client nodes that
this commit solves:

```C++
RooWorkspace w;
w.factory("Gaussian::g1(x[0,20],mx1[10,0,20],sx1[3,0,10])");
w.factory("Gaussian::g2(x,mx2[10,0,20],sx2[1,0,10])");
w.factory("Gaussian::g3(y[0,20],my[10,0,20],sy[2,0,10])");
w.factory("Polynomial::pol(y,a[-0.01,-0.05,0.1])");

w.factory("SUM::pdfx(fx[0.2,0,1]*g1,g2)");
w.factory("SUM::pdfy(fy[0.4,0.,1.]*g3,pol)");

w.pdf("g1")->Print("V");
w.pdf("g3")->Print("V");
```

You will see that `pdfx` appears twice as a client of `g1`, and `pdfy`
appears twice as a client of `g3`.