### PR TITLE
 [RDFD][Fix #7205] Print() now indicates non-fitting columns

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -69,7 +69,7 @@ private:
    using VecStr_t = std::vector<std::string>;
    using DElement_t = ROOT::Internal::RDF::RDisplayElement;
    static constexpr char fgSeparator = ' '; ///< Spacing used to align the table entries
-   static constexpr unsigned fgMaxWidth = 80;
+   static constexpr unsigned fgMaxWidth = 100; ///< Maximum width of the table that Print() displays
 
    VecStr_t fTypes; ///< This attribute stores the type of each column. It is needed by the interpreter to print it.
    std::vector<bool> fIsCollection; ///< True if the column contains a collection. Collections are treated differently

--- a/tree/dataframe/src/RDFDisplay.cxx
+++ b/tree/dataframe/src/RDFDisplay.cxx
@@ -201,11 +201,19 @@ size_t RDisplay::GetNColumnsToShorten() const
 
 void RDisplay::Print() const
 {
-   auto columnsToPrint =
-      fNColumns - GetNColumnsToShorten(); // Get the number of columns that fit in the characters limit
-
-   if (columnsToPrint < fNColumns)
+   size_t columnsToPrint = fNColumns;
+   const size_t columnsToShorten = GetNColumnsToShorten();
+   bool allColumnsFit = true;
+   if (fNColumns > 1u && columnsToShorten > 0u){
+      if (fNColumns > columnsToShorten) {
+         columnsToPrint = fNColumns - columnsToShorten;
+      } else { // table has many columns and the first column is very wide;
+               // thus, the first column is only printed
+         columnsToPrint = 1;
+      }
       Info("Print", "Only showing %lu columns out of %lu\n", columnsToPrint, fNColumns);
+      allColumnsFit = false;
+   }
 
    if (fNMaxCollectionElements < 1)
       Info("Print", "No collections shown since fNMaxCollectionElements is %lu\n", fNMaxCollectionElements);
@@ -238,6 +246,10 @@ void RDisplay::Print() const
                    << " | ";
       }
       if (!isRowEmpty) {
+         if (!allColumnsFit){ // If there are column(s), that do not fit, a single column of dots is displayed
+                              // in the right end of each (non-empty) row.
+            stringRow << " ... | ";
+         }
          std::cout << stringRow.str() << std::endl;
       }
    }

--- a/tree/dataframe/test/dataframe_display.cxx
+++ b/tree/dataframe/test/dataframe_display.cxx
@@ -368,3 +368,101 @@ TEST(RDFDisplayTests, CustomMaxWidth)
 
    EXPECT_EQ(strCout.str(), "S3  | \n0   | \n0   | \n... | \n");
 }
+
+TEST(RDFDisplayTests, PrintWideTables1)
+{
+  std::vector<std::string> v3(3);
+  v3[0] = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890";
+  v3[1] = v3[0];
+  v3[2] = v3[0];
+  std::vector<int> v0(10);
+  ROOT::RDataFrame vc(3);
+  auto dd = vc.Define("S3", [&v3] { return v3; })
+              .Display<std::vector<std::string>>({"S3"});
+
+   // Testing the std output printing
+   std::cout << std::flush;
+   // Redirect cout.
+   std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
+   std::ostringstream strCout;
+   std::cout.rdbuf(strCout.rdbuf());
+   dd->Print();
+   // Restore old cout.
+   std::cout.rdbuf(oldCoutStreamBuf);
+
+   EXPECT_EQ(strCout.str(), "S3                                                                                                     | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n");
+}
+
+TEST(RDFDisplayTests, PrintWideTables2)
+{
+  std::vector<std::string> v3(3);
+  v3[0] = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890";
+  v3[1] = v3[0];
+  v3[2] = v3[0];
+  std::vector<int> v10(10);
+  ROOT::RDataFrame vc(1);
+  auto dd = vc.Define("S10", [&v10] { return v10; })
+              .Define("S3", [&v3] { return v3; })
+              .Display<std::vector<int>, std::vector<std::string>>({"S10", "S3"});
+
+   // Testing the std output printing
+   std::cout << std::flush;
+   // Redirect cout.
+   std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
+   std::ostringstream strCout;
+   std::cout.rdbuf(strCout.rdbuf());
+   dd->Print();
+   // Restore old cout.
+   std::cout.rdbuf(oldCoutStreamBuf);
+
+   EXPECT_EQ(strCout.str(), "S10 |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n"
+   "0   |  ... | \n");
+}
+
+
+TEST(RDFDisplayTests, PrintWideTables3)
+{
+  std::vector<std::string> v3(3);
+  v3[0] = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890";
+  v3[1] = v3[0];
+  v3[2] = v3[0];
+  std::vector<int> v10(10);
+  ROOT::RDataFrame vc(1);
+  auto dd = vc.Define("S10", [&v10] { return v10; })
+              .Define("S3", [&v3] { return v3; })
+              .Display<std::vector<std::string>, std::vector<int>>({"S3", "S10"});
+
+   // Testing the std output printing
+   std::cout << std::flush;
+   // Redirect cout.
+   std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
+   std::ostringstream strCout;
+   std::cout.rdbuf(strCout.rdbuf());
+   dd->Print();
+   // Restore old cout.
+   std::cout.rdbuf(oldCoutStreamBuf);
+
+   EXPECT_EQ(strCout.str(), "S3                                                                                                     |  ... | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" |  ... | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" |  ... | \n"
+   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" |  ... | \n");
+}
+


### PR DESCRIPTION

# This Pull request: [RDFD][Fix #7205] Print() now indicates non-fitting columns

## Changes or fixes:

In case of tables of many columns, Print() now have a right-most
column of dots (...). Moreover, the user will be notified with an
info message as well.

Print() guarantees that at least 1 column of the table is displayed
(regardless the width of the first column).

The default maximum allowed width of the table is increased to 100
(from 80).

New tests written to check the behaviour of wide tables.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #7205 

