### PR TITLE
Some tutorials did not show correctly in the ref guide.

### DIFF
--- a/tutorials/fit/ConfidenceIntervals.C
+++ b/tutorials/fit/ConfidenceIntervals.C
@@ -5,7 +5,6 @@
 /// This method computes confidence intervals for the fitted function
 ///
 /// \macro_image
-/// \macro_output
 /// \macro_code
 ///
 /// \author Rene Brun
@@ -21,7 +20,7 @@
 void ConfidenceIntervals()
 {
    TCanvas *myc = new TCanvas("myc",
-      "Confidence intervals on the fitted function",1200, 500);
+      "Confidence intervals on the fitted function",1000, 500);
    myc->Divide(3,1);
 
 //### 1. A graph

--- a/tutorials/fit/fit1.C
+++ b/tutorials/fit/fit1.C
@@ -33,13 +33,13 @@ void fit1() {
    gBenchmark->Start("fit1");
    //
    // We connect the ROOT file generated in a previous tutorial
-   // (see <a href="fillrandom.C.nbconvert.ipynb">Filling histograms with random numbers from a function</a>) 
+   // (see <a href="fillrandom.C.nbconvert.ipynb">Filling histograms with random numbers from a function</a>)
    //
    TString dir = gROOT->GetTutorialDir();
    dir.Append("/fit/");
    TFile *file = TFile::Open("fillrandom.root");
    if (!file) {
-      gROOT->ProcessLine(Form(".x %s../hist/fillrandom.C",dir.Data()));
+      gROOT->ProcessLine(Form(".x %s../hist/fillrandom.C(0)",dir.Data()));
       file = TFile::Open("fillrandom.root");
       if (!file) return;
    }

--- a/tutorials/hist/fillrandom.C
+++ b/tutorials/hist/fillrandom.C
@@ -8,52 +8,56 @@
 ///
 /// \author Rene Brun
 
-void fillrandom() {
-   TCanvas *c1 = new TCanvas("c1","The FillRandom example",200,10,700,900);
-
-   auto pad1 = new TPad("pad1","The pad with the function",0.05,0.50,0.95,0.95);
-   auto pad2 = new TPad("pad2","The pad with the histogram",0.05,0.05,0.95,0.45);
-   pad1->Draw();
-   pad2->Draw();
-   pad1->cd();
-
+void fillrandom(int plot=1) {
    gBenchmark->Start("fillrandom");
-   //
+
    // A function (any dimension) or a formula may reference
    // an already defined formula
-   //
    auto form1 = new TFormula("form1","abs(sin(x)/x)");
    auto sqroot = new TF1("sqroot","x*gaus(0) + [3]*form1",0,10);
-   sqroot->SetParameters(10,4,1,20);
-   pad1->SetGridx();
-   pad1->SetGridy();
-   pad1->GetFrame()->SetBorderMode(-1);
-   pad1->GetFrame()->SetBorderSize(5);
    sqroot->SetLineColor(4);
    sqroot->SetLineWidth(6);
-   sqroot->Draw();
-   auto lfunction = new TPaveLabel(5,39,9.8,46,"The sqroot function");
-   lfunction->Draw();
-   c1->Update();
+   sqroot->SetParameters(10,4,1,20);
 
-   //
    // Create a one dimensional histogram (one float per bin)
    // and fill it following the distribution in function sqroot.
-   //
-   pad2->cd();
-   pad2->GetFrame()->SetBorderMode(-1);
-   pad2->GetFrame()->SetBorderSize(5);
    auto h1f = new TH1F("h1f","Test random numbers",200,0,10);
-   h1f->SetFillColor(45);
    h1f->FillRandom("sqroot",10000);
-   h1f->Draw();
-   c1->Update();
-   //
+
    // Open a ROOT file and save the formula, function and histogram
-   //
    TFile myfile("fillrandom.root","RECREATE");
    form1->Write();
    sqroot->Write();
    h1f->Write();
+
+   // Produce a plot if requested
+   if (plot) {
+      TCanvas *c1 = new TCanvas("c1","The FillRandom example",200,10,700,900);
+
+      auto pad1 = new TPad("pad1","The pad with the function",0.05,0.50,0.95,0.95);
+      auto pad2 = new TPad("pad2","The pad with the histogram",0.05,0.05,0.95,0.45);
+      pad1->Draw();
+      pad2->Draw();
+      pad1->cd();
+
+      pad1->SetGridx();
+      pad1->SetGridy();
+      pad1->GetFrame()->SetBorderMode(-1);
+      pad1->GetFrame()->SetBorderSize(5);
+
+      sqroot->Draw();
+      auto lfunction = new TPaveLabel(5,39,9.8,46,"The sqroot function");
+      lfunction->Draw();
+      c1->Update();
+
+      pad2->cd();
+      pad2->GetFrame()->SetBorderMode(-1);
+      pad2->GetFrame()->SetBorderSize(5);
+
+      h1f->SetFillColor(45);
+      h1f->Draw();
+      c1->Update();
+   }
+
    gBenchmark->Show("fillrandom");
 }


### PR DESCRIPTION
 -  The `fit1.C` tutorial showed the picture of `fillrandom.C`. To fix that, In `fillrandom.C`, it is now possible to generate the data file without producing the plot. 
 - `ConfidenceIntervals.C` doesn't have text output.
