### PR TITLE
[Jupyroot] Fix stdout/stderr capture on Windows

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -611,8 +611,7 @@ def loadMagicsAndCapturers():
     extMgr = ExtensionManager(ip)
     for extName in extNames:
         extMgr.load_extension(extName)
-    if not 'win32' in sys.platform:
-        captures.append(StreamCapture())
+    captures.append(StreamCapture())
     captures.append(CaptureDrawnPrimitives())
 
     for capture in captures: capture.register()

--- a/bindings/jupyroot/src/IOHandler.cxx
+++ b/bindings/jupyroot/src/IOHandler.cxx
@@ -74,12 +74,22 @@ static void PollImpl(FILE *stdStream, int *pipeHandle, std::string &pipeContent)
    int buf_read;
    char ch;
    fflush(stdStream);
+#ifdef _MSC_VER
+   char buffer[60000] = "";
+   struct _stat st;
+   _fstat(pipeHandle[0], &st);
+   if (st.st_size) {
+      _read(pipeHandle[0], buffer, 60000);
+      pipeContent += buffer;
+   }
+#else
    while (true) {
       buf_read = read(pipeHandle[0], &ch, 1);
       if (buf_read == 1) {
          pipeContent += ch;
       } else break;
    }
+#endif
 }
 
 void JupyROOTExecutorHandler::Poll()
@@ -94,10 +104,7 @@ static void InitCaptureImpl(int &savedStdStream, int *pipeHandle, int FILENO)
    if (pipe(pipeHandle) != 0) {
       return;
    }
-#ifdef _MSC_VER // Visual Studio
-   unsigned long mode = 1;
-   ioctlsocket(pipeHandle[0], FIONBIO, &mode);
-#else
+#ifndef _MSC_VER
    long flags_stdout = fcntl(pipeHandle[0], F_GETFL);
    if (flags_stdout == -1) return;
    flags_stdout |= O_NONBLOCK;

--- a/main/src/nbmain.cxx
+++ b/main/src/nbmain.cxx
@@ -132,13 +132,17 @@ static bool CreateJupyterConfig(string dest, string rootbin, string rootlib, str
    ofstream out(jupyconfig, ios::trunc);
    if (out.is_open()) {
       out << "import os" << endl;
+#ifdef WIN32
+      std::replace( rootbin.begin(), rootbin.end(), '\\', '/');
+      std::replace( rootdata.begin(), rootdata.end(), '\\', '/');
+      out << "rootbin = '" << rootbin << "'" << endl;
+      string jsrootsys = rootdata + "/js/";
+      out << "os.environ['PYTHONPATH']      = '%s' % rootbin + ';' + os.getenv('PYTHONPATH', '')" << endl;
+      out << "os.environ['PATH']            = '%s;%s/bin' % (rootbin,rootbin) + ';' + os.getenv('PATH', '')" << endl;
+      out << "c.NotebookApp.kernel_manager_class = 'notebook.services.kernels.kernelmanager.AsyncMappingKernelManager'" << endl;
+#else
       out << "rootbin = '" << rootbin << "'" << endl;
       out << "rootlib = '" << rootlib << "'" << endl;
-#ifdef WIN32
-      string jsrootsys = rootdata + "\\js\\";
-      out << "os.environ['PYTHONPATH']      = '%s' % rootlib + ':' + os.getenv('PYTHONPATH', '')" << endl;
-      out << "os.environ['PATH']            = '%s:%s\\bin' % (rootbin,rootbin) + ':' + '%s' % rootlib + ':' + os.getenv('PATH', '')" << endl;
-#else
       string jsrootsys = rootdata + "/js/";
       out << "os.environ['PYTHONPATH']      = '%s' % rootlib + ':' + os.getenv('PYTHONPATH', '')" << endl;
       out << "os.environ['PATH']            = '%s:%s/bin' % (rootbin,rootbin) + ':' + os.getenv('PATH', '')" << endl;


### PR DESCRIPTION
- add `_fstat(pipeHandle[0], &st)` to prevent blocking when there is nothing to read
- convert mixed forward slashes & backslashes into forward slashes only in the `jupyter_notebook_config.py` file
- add `c.NotebookApp.kernel_manager_class = 'notebook.services.kernels.kernelmanager.AsyncMappingKernelManager'` in the `jupyter_notebook_config.py` file
