### PR TITLE
[PyROOT] Implement @pythonization decorator for user and ROOT classes

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/ProxyWrappers.cxx
@@ -644,6 +644,11 @@ PyObject* CPyCppyy::CreateScopeProxy(const std::string& name, PyObject* parent)
             }
         }
 
+        if (!parent && name.size() > 0) {
+        // Didn't find any scope in the name, so must be global
+	    parent = CreateScopeProxy(Cppyy::gGlobalScope);
+        }
+
         if (parent && !CPPScope_Check(parent)) {
         // Special case: parent found is not one of ours (it's e.g. a pure Python module), so
         // continuing would fail badly. One final lookup, then out of here ...

--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -33,40 +33,9 @@ importlib.import_module(librootpyz_mod_name)
 # ensure 'import libROOTPythonizations' will find the versioned module
 sys.modules['libROOTPythonizations'] = sys.modules[librootpyz_mod_name]
 
-import ROOT.pythonization as pyz
-
-import functools
-import pkgutil
-
-def pythonization(lazy = True):
-    """
-    Pythonizor decorator to be used in pythonization modules for pythonizations.
-    These pythonizations functions are invoked upon usage of the class.
-    Parameters
-    ----------
-    lazy : boolean
-        If lazy is true, the class is pythonized upon first usage, otherwise
-        upon import of the ROOT module.
-    """
-    def pythonization_impl(fn):
-        """
-        The real decorator. This structure is adopted to deal with parameters
-        fn : function
-            Function that implements some pythonization.
-            The function must accept two parameters: the class
-            to be pythonized and the name of that class.
-        """
-        if lazy:
-            cppyy.py.add_pythonization(fn)
-        else:
-            fn()
-    return pythonization_impl
-
 # Trigger the addition of the pythonizations
-exclude = [ '_rdf_utils' ]
-for _, module_name, _ in  pkgutil.walk_packages(pyz.__path__):
-    if module_name not in exclude:
-        module = importlib.import_module(pyz.__name__ + '.' + module_name)
+from .pythonization import _register_pythonizations
+_register_pythonizations()
 
 # Check if we are in the IPython shell
 if major == 3:

--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -15,6 +15,8 @@ if sys.version_info[:3] > _numba_pyversion:
     # Python <= 2.7.5 cannot use exec in an inner function
     from ._numbadeclare import _NumbaDeclareDecorator
 
+from .pythonization import pythonization
+
 
 class PyROOTConfiguration(object):
     """Class for configuring PyROOT"""
@@ -117,6 +119,9 @@ class ROOTFacade(types.ModuleType):
 
         # Initialize configuration
         self.PyConfig = PyROOTConfiguration()
+
+        # @pythonization decorator
+        self.pythonization = pythonization
 
         self._is_ipython = is_ipython
 

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/__init__.py
@@ -7,3 +7,254 @@
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
+
+import importlib
+import pkgutil
+import re
+import sys
+
+import cppyy
+
+from ._generic import pythonize_generic
+
+
+def pythonization(target, is_prefix=False):
+    '''
+    Decorator that allows to pythonize C++ classes. To pythonize means to add
+    some extra behaviour to a C++ class that is used from Python via PyROOT,
+    so that such a class can be used in an easier / more "pythonic" way.
+    The injection of the pythonization behaviour in the C++ class is done
+    lazily, i.e. only when the class is first accessed from the application.
+
+    Args:
+        target (string/iterable[string]): specifies either a single string or
+            multiple strings, where each string can be either (i) the
+            fully-qualified name of a C++ class to be pythonized, or (ii) a
+            prefix to match all classes whose fully-qualified name starts with
+            that prefix.
+
+            These are examples of prefixes and what they match:
+            - "" : all classes in the global namespace
+            - "C" : all classes in the global namespace whose name starts with
+              "C"
+            - "NS1::NS2::" : all classes in namespace "NS1::NS2"
+            - "NS1::NS2::C" : all classes in namespace "NS1::NS2" whose name
+              starts with "C"
+
+        is_prefix (boolean): if True, `target` contains one or multiple
+            prefixes, each prefix potentially matching multiple classes.
+            Default is False.
+
+    Returns:
+        function: function that receives the user-defined function and
+            decorates it.
+    '''
+
+    # Type check and parsing of target argument.
+    # Retrieve the scope(s) of the class(es)/prefix(es) to register the
+    # pythonizor in the right scope(s)
+    scopes, scope_to_targets = _parse_target(target)
+
+    # Create a filter lambda for the target class(es)/prefix(es)
+    if is_prefix:
+        def passes_filter(class_name, scope):
+            prefixes = scope_to_targets.get(scope)
+            if prefixes is None:
+                return False # no prefix registered for this scope
+            else:
+                return any(class_name.startswith(prefix)
+                           for prefix in prefixes)
+    else:
+        def passes_filter(class_name, scope):
+            classes = scope_to_targets.get(scope)
+            if classes is None:
+                return False # no class registered for this scope
+            else:
+                return class_name in classes
+
+    def pythonization_impl(user_pythonizor):
+        '''
+        The real decorator. Accepts a user-provided function and decorates it.
+        An inner function - a wrapper of the user function - is registered in
+        cppyy as a pythonizor.
+
+        Args:
+            user_pythonizor (function): user-provided function to be decorated.
+                It implements some pythonization. It must accept two
+                parameters: the class to be pythonized, i.e. the Python proxy
+                of the class in which new behaviour can be injected, and the
+                name of that class (can be used e.g. to do some more complex
+                filtering).
+        '''
+
+        def cppyy_pythonizor(klass, name):
+            '''
+            Wrapper function with the parameters that cppyy requires for a
+            pythonizor function (class proxy and class name). It invokes the
+            user function only if the current class - a candidate for being
+            pythonized - matches the `target` argument of the decorator.
+
+            Args:
+                klass (class type): cppyy proxy of the class that is the
+                    current candidate to be pythonized.
+                name (string): name of the class that is the current candidate
+                    to be pythonized.
+            '''
+
+            fqn = klass.__cpp_name__
+
+            # Add pretty printing (done on all classes)
+            pythonize_generic(klass, fqn)
+
+            if passes_filter(name, _get_scope(fqn)):
+                user_pythonizor(klass, fqn)
+
+        # Register pythonizor in all the scopes of the requested classes
+        for scope in scopes:
+            cppyy.py.add_pythonization(cppyy_pythonizor, scope)
+
+        return cppyy_pythonizor
+
+    return pythonization_impl
+
+def _parse_target(target):
+    '''
+    Helper function to check the type of the `target` argument specified by the
+    user in a @pythonization decorator.
+    It also returns the received fully-qualified class name(s)/prefix(es) and
+    the corresponding scope(s), removing any repetition.
+
+    Args:
+        target (string/iterable[string]): fully-qualified class name(s)/
+            prefix(es).
+
+    Returns:
+        tuple[set,set]: fully-qualified class name(s)/prefix(es) and scope(s)
+            in `target`, with no repetitions.
+    '''
+
+    scopes = set()
+    scope_to_targets = {}
+
+    if _is_string(target):
+        _register_target(target, scopes, scope_to_targets)
+    else:
+        try:
+            for name in target:
+                if _is_string(name):
+                    _register_target(name, scopes, scope_to_targets)
+                else:
+                    raise TypeError()
+        except TypeError:
+            raise TypeError('Invalid type of "target" argument in @pythonization: '
+                            'must be string or iterable of strings')
+
+    return scopes, scope_to_targets
+
+def _is_string(o):
+    '''
+    Checks if object is a string.
+
+    Args:
+        o (any type): object to be checked.
+
+    Returns:
+        True if object is a string, False otherwise.
+    '''
+
+    if sys.version_info >= (3, 0):
+        return isinstance(o, str)
+    else:
+        return isinstance(o, basestring)
+
+def _register_target(target, scopes, scope_to_targets):
+    '''
+    Registers all the targets of a pythonizor per scope.
+
+    Args:
+        target (string): fully-qualified class name/prefix.
+        scopes (list): list of scopes to add the scope of `target` to.
+        scope_to_targets (dict): map from scope to list of targets that have
+            been registered for that scope.
+    '''
+
+    scope, class_name = _split_scope_and_class(target)
+    scopes.add(scope)
+    targets = scope_to_targets.get(scope)
+    if targets is None:
+        targets = []
+        scope_to_targets[scope] = targets
+    targets.append(class_name)
+
+def _get_scope(fqn):
+    '''
+    Parses and returns the scope in `fqn`.
+    Example: if `fqn` is "NS1::NS2::C", "NS1::NS2" is returned.
+
+    Args:
+        fqn (string): fully-qualified class name.
+
+    Returns:
+        string: scope of `fqn`.
+    '''
+
+    pos = _find_namespace_end(fqn)
+    if pos < 0: # global namespace
+        return ''
+    else:
+        return fqn[:pos]
+
+def _split_scope_and_class(fqn):
+    '''
+    Parses and returns the scope and class name in `fqn`.
+    Example: if `fqn` is "NS1::NS2::C", "NS1::NS2" and "C" are returned.
+
+    Args:
+        fqn (string): fully-qualified class name.
+
+    Returns:
+        tuple[string,string]: tuple with the scope of and class name of `fqn`.
+    '''
+
+    pos = _find_namespace_end(fqn)
+    if pos < 0: # global namespace
+        return '', fqn
+    else:
+        return fqn[:pos], fqn[pos+2:]
+
+def _find_namespace_end(fqn):
+    '''
+    Find the position where the namespace in `fqn` ends.
+
+    Args:
+        fqn (string): fully-qualified class name.
+
+    Returns:
+        integer: position where the namespace in `fqn` ends, i.e. the position
+            of the last '::', or -1 if there is no '::' in `fqn`.
+    '''
+
+    last_found = -1
+    prev_c = ''
+    pos = 0
+    for c in fqn:
+        if c == ':' and prev_c == ':':
+            last_found = pos - 1
+        elif c == '<':
+            # If we found a template, this is already the class name,
+            # so we're done!
+            break
+        prev_c = c
+        pos += 1
+
+    return last_found
+
+def _register_pythonizations():
+    '''
+    Registers the ROOT pythonizations with cppyy for lazy injection.
+    '''
+
+    exclude = [ '_rdf_utils' ]
+    for _, module_name, _ in  pkgutil.walk_packages(__path__):
+        if module_name not in exclude:
+            module = importlib.import_module(__name__ + '.' + module_name)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/__init__.py
@@ -287,4 +287,4 @@ def _register_pythonizations():
     exclude = [ '_rdf_utils' ]
     for _, module_name, _ in  pkgutil.walk_packages(__path__):
         if module_name not in exclude:
-            module = importlib.import_module(__name__ + '.' + module_name)
+            importlib.import_module(__name__ + '.' + module_name)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_cppinstance.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_cppinstance.py
@@ -8,15 +8,16 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
 import cppyy
 import libcppyy
 from libROOTPythonizations import AddCPPInstancePickling
 
-@pythonization(lazy = False)
 def pythonize_cppinstance():
     klass = libcppyy.CPPInstance
 
     AddCPPInstancePickling(klass)
 
-    return True
+# Instant pythonization (executed at `import ROOT` time), no need of a
+# decorator. CPPInstance is the base for cppyy instance proxies and thus needs
+# to be always pythonized.
+pythonize_cppinstance()

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_drawables.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_drawables.py
@@ -55,17 +55,17 @@ def _init(self, *args):
 
 @pythonization([ 'TPad', 'TButton', 'TColorWheel',
                  'TPolyLine3D', 'TPolyMarker', 'TPolyMarker3D' ])
-def pythonize_drawables(klass, name):
+def pythonize_drawables(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
+
     klass._OriginalDraw = klass.Draw
     klass.Draw = _Draw
 
 @pythonization('TSlider')
-def pythonize_tslider(klass, name):
+def pythonize_tslider(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
+
     klass._original__init__ = klass.__init__
     klass.__init__ = _init

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_drawables.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_drawables.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 from cppyy.gbl import kCanDelete
 from libcppyy import SetOwnership
 
@@ -53,20 +53,19 @@ def _init(self, *args):
         # do it again in case it is executed.
         self.Draw = self._OriginalDraw
 
-@pythonization()
+@pythonization([ 'TPad', 'TButton', 'TColorWheel',
+                 'TPolyLine3D', 'TPolyMarker', 'TPolyMarker3D' ])
 def pythonize_drawables(klass, name):
     # Parameters:
     # klass: class to be pythonized
-    # name: name of the class
+    # name: string containing the name of the class
+    klass._OriginalDraw = klass.Draw
+    klass.Draw = _Draw
 
-    if name in {'TPad', 'TButton', 'TColorWheel',
-                'TPolyLine3D', 'TPolyMarker', 'TPolyMarker3D'}:
-        # Draw
-        klass._OriginalDraw = klass.Draw
-        klass.Draw = _Draw
-    elif name == 'TSlider':
-        # __init__
-        klass._original__init__ = klass.__init__
-        klass.__init__ = _init
-
-    return True
+@pythonization('TSlider')
+def pythonize_tslider(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+    klass._original__init__ = klass.__init__
+    klass.__init__ = _init

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_generic.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_generic.py
@@ -9,7 +9,6 @@
 ################################################################################
 
 from libROOTPythonizations import AddPrettyPrintingPyz
-from ROOT import pythonization
 
 def _add_getitem_checked(klass):
     # Parameters:
@@ -33,9 +32,8 @@ def _add_getitem_checked(klass):
     klass._getitem__unchecked = klass.__getitem__
     klass.__getitem__ = getitem_checked
 
-
-@pythonization()
-def pythonizegeneric(klass, name):
+# Generic pythonizor for pretty printing that is applied to (almost) all classes
+def pythonize_generic(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
@@ -51,5 +49,3 @@ def pythonizegeneric(klass, name):
 
     if name not in exclude and not has_cpp_str:
         AddPrettyPrintingPyz(klass)
-
-    return True

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rbdt.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rbdt.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 from cppyy import gbl as gbl_namespace
 
 
@@ -36,14 +36,10 @@ def Compute(self, x):
     return self._OriginalCompute(x)
 
 
-@pythonization()
+@pythonization("TMVA::Experimental::RBDT", is_prefix=True)
 def pythonize_rbdt(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: name of the class
-
-    if name.startswith("TMVA::Experimental::RBDT"):
-        klass._OriginalCompute = klass.Compute
-        klass.Compute = Compute
-
-    return True
+    klass._OriginalCompute = klass.Compute
+    klass.Compute = Compute

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rbdt.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rbdt.py
@@ -37,9 +37,9 @@ def Compute(self, x):
 
 
 @pythonization("TMVA::Experimental::RBDT", is_prefix=True)
-def pythonize_rbdt(klass, name):
+def pythonize_rbdt(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: name of the class
+
     klass._OriginalCompute = klass.Compute
     klass.Compute = Compute

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rbdt.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rbdt.py
@@ -36,7 +36,7 @@ def Compute(self, x):
     return self._OriginalCompute(x)
 
 
-@pythonization("TMVA::Experimental::RBDT", is_prefix=True)
+@pythonization("RBDT", ns="TMVA::Experimental", is_prefix=True)
 def pythonize_rbdt(klass):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
@@ -229,7 +229,7 @@ def _histo_profile(self, fixed_args, *args):
     return res
 
 
-@pythonization([ "ROOT::RDataFrame<", "ROOT::RDF::RInterface<" ], is_prefix=True)
+@pythonization("RInterface<", ns="ROOT::RDF", is_prefix=True)
 def pythonize_rdataframe(klass):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rdataframe.py
@@ -230,10 +230,9 @@ def _histo_profile(self, fixed_args, *args):
 
 
 @pythonization([ "ROOT::RDataFrame<", "ROOT::RDF::RInterface<" ], is_prefix=True)
-def pythonize_rdataframe(klass, name):
+def pythonize_rdataframe(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     from cppyy.gbl.ROOT import RDF
 

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
@@ -14,7 +14,7 @@
 import sys
 import cppyy
 
-from ROOT import pythonization
+from .. import pythonization
 
 from ._rooabscollection import RooAbsCollection
 from ._rooabsdata import RooAbsData
@@ -168,14 +168,11 @@ def make_func_name_orig(func_name):
     return "_" + func_name
 
 
-@pythonization()
+@pythonization("Roo", is_prefix=True)
 def pythonize_roofit_class(klass, name):
     # Parameters:
     # klass: class to pythonize
     # name: string containing the name of the class
-
-    if not name.startswith("Roo"):
-        return
 
     if not name in python_classes_dict:
         return

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rtensor.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rtensor.py
@@ -8,9 +8,9 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
+from ._rvec import _array_interface_dtype_map
 from libROOTPythonizations import GetEndianess, GetDataPointer, GetSizeOfType
-from ROOT.pythonization._rvec import _array_interface_dtype_map
 import cppyy
 
 
@@ -117,16 +117,13 @@ def RTensorGetitem(self, idx):
     return self(idxVec)
 
 
-@pythonization()
+@pythonization("TMVA::Experimental::RTensor<", is_prefix=True)
 def pythonize_rtensor(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name.startswith("TMVA::Experimental::RTensor<"):
-        # Add numpy array interface
-        add_array_interface_property(klass, name)
-        # Get elements, including slices
-        klass.__getitem__ = RTensorGetitem
-
-    return True
+    # Add numpy array interface
+    add_array_interface_property(klass, name)
+    # Get elements, including slices
+    klass.__getitem__ = RTensorGetitem

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rtensor.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rtensor.py
@@ -117,7 +117,7 @@ def RTensorGetitem(self, idx):
     return self(idxVec)
 
 
-@pythonization("TMVA::Experimental::RTensor<", is_prefix=True)
+@pythonization("RTensor<", ns="TMVA::Experimental", is_prefix=True)
 def pythonize_rtensor(klass, name):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rvec.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rvec.py
@@ -65,7 +65,7 @@ print(rvec) # { 42.000000, 2.0000000, 3.0000000 }
 */
 '''
 
-from ROOT import pythonization
+from . import pythonization
 from libROOTPythonizations import GetEndianess, GetDataPointer, GetSizeOfType
 
 
@@ -110,14 +110,11 @@ def add_array_interface_property(klass, name):
         klass.__array_interface__ = property(get_array_interface)
 
 
-@pythonization()
+@pythonization("ROOT::VecOps::RVec<", is_prefix=True)
 def pythonize_rvec(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name.startswith("ROOT::VecOps::RVec<"):
-        # Add numpy array interface
-        add_array_interface_property(klass, name)
-
-    return True
+    # Add numpy array interface
+    add_array_interface_property(klass, name)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rvec.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_rvec.py
@@ -110,7 +110,7 @@ def add_array_interface_property(klass, name):
         klass.__array_interface__ = property(get_array_interface)
 
 
-@pythonization("ROOT::VecOps::RVec<", is_prefix=True)
+@pythonization("RVec<", ns="ROOT::VecOps", is_prefix=True)
 def pythonize_rvec(klass, name):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_stl_vector.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_stl_vector.py
@@ -12,7 +12,7 @@ from . import pythonization
 from ._rvec import add_array_interface_property
 
 
-@pythonization("std::vector<", is_prefix=True)
+@pythonization("vector<", ns="std", is_prefix=True)
 def pythonize_stl_vector(klass, name):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_stl_vector.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_stl_vector.py
@@ -8,19 +8,16 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
-from ROOT.pythonization._rvec import add_array_interface_property
+from . import pythonization
+from ._rvec import add_array_interface_property
 
 
-@pythonization()
+@pythonization("std::vector<", is_prefix=True)
 def pythonize_stl_vector(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name.startswith("std::vector<"):
-        # Add numpy array interface
-        # NOTE: The pythonization is reused from ROOT::VecOps::RVec
-        add_array_interface_property(klass, name)
-
-    return True
+    # Add numpy array interface
+    # NOTE: The pythonization is reused from ROOT::VecOps::RVec
+    add_array_interface_property(klass, name)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tarray.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tarray.py
@@ -45,12 +45,12 @@ for elem in a:
 */
 '''
 
-from ROOT import pythonization
+from . import pythonization
 
 from ._generic import _add_getitem_checked
 
 
-@pythonization()
+@pythonization("TArray", is_prefix=True)
 def pythonize_tarray(klass, name):
     # Parameters:
     # klass: class to be pythonized
@@ -59,12 +59,9 @@ def pythonize_tarray(klass, name):
     if name == 'TArray':
         # Support `len(a)` as `a.GetSize()`
         klass.__len__ = klass.GetSize
-
-    elif name.startswith('TArray'):
+    else:
         # Add checked __getitem__. It has to be directly added to the TArray
         # subclasses, which have a default __getitem__.
         # The new __getitem__ allows to throw pythonic IndexError when index
         # is out of range and to iterate over the array.
         _add_getitem_checked(klass)
-
-    return True

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tclass.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tclass.py
@@ -8,16 +8,17 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
 import cppyy
 from libROOTPythonizations import AddTClassDynamicCastPyz
 
 
-@pythonization(lazy = False)
 def pythonize_tclass():
     klass = cppyy.gbl.TClass
 
     # DynamicCast
     AddTClassDynamicCastPyz(klass)
 
-    return True
+# Instant pythonization (executed at `import ROOT` time), no need of a
+# decorator. This is a core class that is instantiated before cppyy's
+# pythonization machinery is in place.
+pythonize_tclass()

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tclonesarray.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tclonesarray.py
@@ -8,18 +8,15 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 from libROOTPythonizations import AddSetItemTCAPyz
 
 
-@pythonization()
+@pythonization('TClonesArray')
 def pythonize_tclonesarray(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name == 'TClonesArray':
-        # Add item setter method
-        AddSetItemTCAPyz(klass)
-
-    return True
+    # Add item setter method
+    AddSetItemTCAPyz(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tclonesarray.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tclonesarray.py
@@ -13,10 +13,9 @@ from libROOTPythonizations import AddSetItemTCAPyz
 
 
 @pythonization('TClonesArray')
-def pythonize_tclonesarray(klass, name):
+def pythonize_tclonesarray(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # Add item setter method
     AddSetItemTCAPyz(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcollection.py
@@ -94,10 +94,9 @@ def _iter_pyz(self):
 
 
 @pythonization('TCollection')
-def pythonize_tcollection(klass, name):
+def pythonize_tcollection(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # Support `len(c)` as `c.GetEntries()`
     klass.__len__ = klass.GetEntries

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcollection.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 import cppyy
 
 
@@ -93,29 +93,26 @@ def _iter_pyz(self):
         yield o
 
 
-@pythonization()
+@pythonization('TCollection')
 def pythonize_tcollection(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name == 'TCollection':
-        # Support `len(c)` as `c.GetEntries()`
-        klass.__len__ = klass.GetEntries
+    # Support `len(c)` as `c.GetEntries()`
+    klass.__len__ = klass.GetEntries
 
-        # Add Python lists methods
-        klass.append = klass.Add
-        klass.remove = _remove_pyz
-        klass.extend = _extend_pyz
-        klass.count = _count_pyz
+    # Add Python lists methods
+    klass.append = klass.Add
+    klass.remove = _remove_pyz
+    klass.extend = _extend_pyz
+    klass.count = _count_pyz
 
-        # Define Python operators
-        klass.__add__ = _add_pyz
-        klass.__mul__ = _mul_pyz
-        klass.__rmul__ = _mul_pyz
-        klass.__imul__ = _imul_pyz
+    # Define Python operators
+    klass.__add__ = _add_pyz
+    klass.__mul__ = _mul_pyz
+    klass.__rmul__ = _mul_pyz
+    klass.__imul__ = _imul_pyz
 
-        # Make TCollections iterable
-        klass.__iter__ = _iter_pyz
-
-    return True
+    # Make TCollections iterable
+    klass.__iter__ = _iter_pyz

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcomplex.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcomplex.py
@@ -44,10 +44,9 @@ def _rtruediv(self, other):
         return NotImplemented
 
 @pythonization('TComplex')
-def pythonize_tcomplex(klass, name):
+def pythonize_tcomplex(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # implements __radd__ as equal to __add__
     klass.__radd__ = klass.__add__

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcomplex.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tcomplex.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 import cppyy
 
 def _rsub(self, other):
@@ -43,29 +43,25 @@ def _rtruediv(self, other):
     else:
         return NotImplemented
 
-@pythonization()
+@pythonization('TComplex')
 def pythonize_tcomplex(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
-    if name == 'TComplex':
 
-        # implements __radd__ as equal to __add__
-        klass.__radd__ = klass.__add__
+    # implements __radd__ as equal to __add__
+    klass.__radd__ = klass.__add__
 
-        # implements __rsub__ by assigning the function previously defined
-        klass.__rsub__ = _rsub
+    # implements __rsub__ by assigning the function previously defined
+    klass.__rsub__ = _rsub
 
-        # implements __rmul__ as equal to __mul__
-        klass.__rmul__ = klass.__mul__
+    # implements __rmul__ as equal to __mul__
+    klass.__rmul__ = klass.__mul__
 
-        # implements __rtruediv__ by assigning the function previously defined
-        # necessary for Python3
-        klass.__rtruediv__ = _rtruediv
+    # implements __rtruediv__ by assigning the function previously defined
+    # necessary for Python3
+    klass.__rtruediv__ = _rtruediv
 
-        # implements __rtruediv__ by assigning the function previously defined
-        # necessary for Python2
-        klass.__rdiv__ = _rdiv
-
-    return True
-
+    # implements __rtruediv__ by assigning the function previously defined
+    # necessary for Python2
+    klass.__rdiv__ = _rdiv

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tdirectory.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tdirectory.py
@@ -51,16 +51,14 @@ for more information.
 '''
 
 from libROOTPythonizations import AddDirectoryGetAttrPyz, AddDirectoryWritePyz
-from ROOT import pythonization
 import cppyy
 
-# This pythonization must be set as not lazy, otherwise the mechanism cppyy uses
-# to pythonize classes will not be able to be triggered on this very core class.
-# The pythonization does not have arguments since it is not fired by cppyy but
-# manually upon import of the ROOT module.
-@pythonization(lazy = False)
 def pythonize_tdirectory():
     klass = cppyy.gbl.TDirectory
     AddDirectoryGetAttrPyz(klass)
     AddDirectoryWritePyz(klass)
-    return True
+
+# Instant pythonization (executed at `import ROOT` time), no need of a
+# decorator. This is a core class that is instantiated before cppyy's
+# pythonization machinery is in place.
+pythonize_tdirectory()

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tdirectoryfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tdirectoryfile.py
@@ -56,10 +56,10 @@ d.WriteObject(obj, 'keyName')
 '''
 
 from libROOTPythonizations import AddTDirectoryFileGetPyz
-from ROOT import pythonization
+from . import pythonization
 
 # Pythonizor function
-@pythonization()
+@pythonization('TDirectoryFile')
 def pythonize_tdirectoryfile(klass, name):
     """
     TDirectoryFile inherits from TDirectory the pythonized attr syntax (__getattr__)
@@ -76,7 +76,4 @@ def pythonize_tdirectoryfile(klass, name):
         2.2 returns nullptr if object not found
     """
 
-    if name == 'TDirectoryFile':
-        AddTDirectoryFileGetPyz(klass)
-
-    return True
+    AddTDirectoryFileGetPyz(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tdirectoryfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tdirectoryfile.py
@@ -60,7 +60,7 @@ from . import pythonization
 
 # Pythonizor function
 @pythonization('TDirectoryFile')
-def pythonize_tdirectoryfile(klass, name):
+def pythonize_tdirectoryfile(klass):
     """
     TDirectoryFile inherits from TDirectory the pythonized attr syntax (__getattr__)
     and WriteObject method.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tfile.py
@@ -39,7 +39,7 @@ file (e.g. non-existent or corrupted file).
 '''
 
 from libROOTPythonizations import AddFileOpenPyz
-from ROOT import pythonization
+from . import pythonization
 from libcppyy import bind_object
 
 def _TFileConstructor(self, *args):
@@ -68,7 +68,7 @@ def _TFileOpen(klass, *args):
     return f
 
 # Pythonizor function
-@pythonization()
+@pythonization('TFile')
 def pythonize_tfile(klass, name):
     """
     TFile inherits from
@@ -76,14 +76,11 @@ def pythonize_tfile(klass, name):
     - TDirectoryFile the pythonized Get method (pythonized only in Python)
     """
 
-    if name == 'TFile':
-        # Pythonizations for TFile::Open
-        AddFileOpenPyz(klass)
-        klass._OriginalOpen = klass.Open
-        klass.Open = classmethod(_TFileOpen)
+    # Pythonizations for TFile::Open
+    AddFileOpenPyz(klass)
+    klass._OriginalOpen = klass.Open
+    klass.Open = classmethod(_TFileOpen)
 
-        # Pythonization for TFile constructor
-        klass._OriginalConstructor = klass.__init__
-        klass.__init__ = _TFileConstructor
-
-    return True
+    # Pythonization for TFile constructor
+    klass._OriginalConstructor = klass.__init__
+    klass.__init__ = _TFileConstructor

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tfile.py
@@ -69,7 +69,7 @@ def _TFileOpen(klass, *args):
 
 # Pythonizor function
 @pythonization('TFile')
-def pythonize_tfile(klass, name):
+def pythonize_tfile(klass):
     """
     TFile inherits from
     - TDirectory the pythonized attr syntax (__getattr__) and WriteObject method.

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tgraph.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tgraph.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
 import cppyy
 
 def set_size(self, buf):
@@ -39,5 +38,5 @@ comp = cppyy.py.compose_method('^TGraph(2D)?$|^TGraph.*Errors$', # class to matc
                                'GetE?[XYZ]$',                    # method to match
                                set_size)                         # post-process function
 
-# Invoke the decorator with the composite as argument to add it to the list of pythonizors
-pythonization()(comp)
+# Add the composite to the list of pythonizors
+cppyy.py.add_pythonization(comp)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_th1.py
@@ -24,10 +24,9 @@ def _imul(self, c):
 
 
 @pythonization('TH1')
-def pythonize_th1(klass, name):
+def pythonize_th1(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: name of the class
 
     # Support hist *= scalar
     klass.__imul__ = _imul

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_th1.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_th1.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 
 
 # Multiplication by constant
@@ -23,14 +23,11 @@ def _imul(self, c):
     return self
 
 
-@pythonization()
+@pythonization('TH1')
 def pythonize_th1(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: name of the class
 
-    if name == 'TH1':
-        # Support hist *= scalar
-        klass.__imul__ = _imul
-
-    return True
+    # Support hist *= scalar
+    klass.__imul__ = _imul

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_titer.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_titer.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
 import cppyy
 
 def _next_pyz(self):
@@ -23,7 +22,6 @@ def _next_pyz(self):
 		raise StopIteration()
 
 
-@pythonization(lazy = False)
 def pythonize_titer():
     klass = cppyy.gbl.TIter
 
@@ -34,4 +32,7 @@ def pythonize_titer():
     klass.__next__ = _next_pyz  # Py3
     klass.next     = _next_pyz  # Py2
 
-    return True
+# Instant pythonization (executed at `import ROOT` time), no need of a
+# decorator. This is a core class that is instantiated before cppyy's
+# pythonization machinery is in place.
+pythonize_titer()

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tobject.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tobject.py
@@ -8,7 +8,6 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
 from libROOTPythonizations import AddTObjectEqNePyz
 import cppyy
 
@@ -50,7 +49,6 @@ def _ge(self, o):
         return NotImplemented
 
 
-@pythonization(lazy = False)
 def pythonize_tobject():
     klass = cppyy.gbl.TObject
 
@@ -64,4 +62,7 @@ def pythonize_tobject():
     klass.__gt__ = _gt
     klass.__ge__ = _ge
 
-    return True
+# Instant pythonization (executed at `import ROOT` time), no need of a
+# decorator. This is a core class that is instantiated before cppyy's
+# pythonization machinery is in place.
+pythonize_tobject()

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tobjstring.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tobjstring.py
@@ -12,10 +12,9 @@ from . import pythonization
 
 
 @pythonization('TObjString')
-def pythonize_tobjstring(klass, name):
+def pythonize_tobjstring(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: name of the class
 
     # `len(s)` is the length of string representation
     klass.__len__ = lambda self: len(str(self))

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tobjstring.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tobjstring.py
@@ -8,29 +8,26 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 
 
-@pythonization()
+@pythonization('TObjString')
 def pythonize_tobjstring(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: name of the class
 
-    if name == 'TObjString':
-        # `len(s)` is the length of string representation
-        klass.__len__ = lambda self: len(str(self))
+    # `len(s)` is the length of string representation
+    klass.__len__ = lambda self: len(str(self))
 
-        # Add string representation
-        klass.__str__  = klass.GetName
-        klass.__repr__ = lambda self: "'{}'".format(self)
+    # Add string representation
+    klass.__str__  = klass.GetName
+    klass.__repr__ = lambda self: "'{}'".format(self)
 
-        # Add comparison operators
-        klass.__eq__ = lambda self, o: str(self) == o
-        klass.__ne__ = lambda self, o: str(self) != o
-        klass.__lt__ = lambda self, o: str(self) <  o
-        klass.__le__ = lambda self, o: str(self) <= o
-        klass.__gt__ = lambda self, o: str(self) >  o
-        klass.__ge__ = lambda self, o: str(self) >= o
-
-    return True
+    # Add comparison operators
+    klass.__eq__ = lambda self, o: str(self) == o
+    klass.__ne__ = lambda self, o: str(self) != o
+    klass.__lt__ = lambda self, o: str(self) <  o
+    klass.__le__ = lambda self, o: str(self) <= o
+    klass.__gt__ = lambda self, o: str(self) >  o
+    klass.__ge__ = lambda self, o: str(self) >= o

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tree_inference.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tree_inference.py
@@ -122,9 +122,8 @@ def SaveXGBoost(self, xgb_model, key_name, output_path,
 
 
 @pythonization("TMVA::Experimental::SaveXGBoost")
-def pythonize_tree_inference(klass, name):
+def pythonize_tree_inference(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     klass.__init__ = SaveXGBoost

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tree_inference.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tree_inference.py
@@ -121,7 +121,7 @@ def SaveXGBoost(self, xgb_model, key_name, output_path,
     f.Close()
 
 
-@pythonization("TMVA::Experimental::SaveXGBoost")
+@pythonization("SaveXGBoost", ns="TMVA::Experimental")
 def pythonize_tree_inference(klass):
     # Parameters:
     # klass: class to be pythonized

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tree_inference.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tree_inference.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 import cppyy
 
 
@@ -121,13 +121,10 @@ def SaveXGBoost(self, xgb_model, key_name, output_path,
     f.Close()
 
 
-@pythonization()
+@pythonization("TMVA::Experimental::SaveXGBoost")
 def pythonize_tree_inference(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name == "TMVA::Experimental::SaveXGBoost":
-        klass.__init__ = SaveXGBoost
-
-    return True
+    klass.__init__ = SaveXGBoost

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tseqcollection.py
@@ -247,10 +247,9 @@ def _index_pyz(self, val):
 
 
 @pythonization('TSeqCollection')
-def pythonize_tseqcollection(klass, name):
+def pythonize_tseqcollection(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # Item access methods
     klass.__getitem__ = _getitem_pyz

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tseqcollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tseqcollection.py
@@ -8,7 +8,7 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 from libcppyy import SetOwnership
 
 import sys
@@ -246,23 +246,20 @@ def _index_pyz(self, val):
     return idx
 
 
-@pythonization()
+@pythonization('TSeqCollection')
 def pythonize_tseqcollection(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name == 'TSeqCollection':
-        # Item access methods
-        klass.__getitem__ = _getitem_pyz
-        klass.__setitem__ = _setitem_pyz
-        klass.__delitem__ = _delitem_pyz
+    # Item access methods
+    klass.__getitem__ = _getitem_pyz
+    klass.__setitem__ = _setitem_pyz
+    klass.__delitem__ = _delitem_pyz
 
-        # Python lists methods
-        klass.insert  = _insert_pyz
-        klass.pop     = _pop_pyz
-        klass.reverse = _reverse_pyz
-        klass.sort    = _sort_pyz
-        klass.index   = _index_pyz
-
-    return True
+    # Python lists methods
+    klass.insert  = _insert_pyz
+    klass.pop     = _pop_pyz
+    klass.reverse = _reverse_pyz
+    klass.sort    = _sort_pyz
+    klass.index   = _index_pyz

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tstring.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tstring.py
@@ -12,10 +12,9 @@ from . import pythonization
 
 
 @pythonization('TString')
-def pythonize_tstring(klass, name):
+def pythonize_tstring(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: name of the class
 
     # Support `len(s)` as `s.Length()`
     klass.__len__ = klass.Length

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tstring.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tstring.py
@@ -8,29 +8,26 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 
 
-@pythonization()
+@pythonization('TString')
 def pythonize_tstring(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: name of the class
 
-    if name == 'TString':
-        # Support `len(s)` as `s.Length()`
-        klass.__len__ = klass.Length
+    # Support `len(s)` as `s.Length()`
+    klass.__len__ = klass.Length
 
-        # Add string representation
-        klass.__str__  = klass.Data
-        klass.__repr__ = lambda self: "'{}'".format(self)
+    # Add string representation
+    klass.__str__  = klass.Data
+    klass.__repr__ = lambda self: "'{}'".format(self)
 
-        # Add comparison operators
-        klass.__eq__ = lambda self, o: str(self) == o
-        klass.__ne__ = lambda self, o: str(self) != o
-        klass.__lt__ = lambda self, o: str(self) <  o
-        klass.__le__ = lambda self, o: str(self) <= o
-        klass.__gt__ = lambda self, o: str(self) >  o
-        klass.__ge__ = lambda self, o: str(self) >= o
-
-    return True
+    # Add comparison operators
+    klass.__eq__ = lambda self, o: str(self) == o
+    klass.__ne__ = lambda self, o: str(self) != o
+    klass.__lt__ = lambda self, o: str(self) <  o
+    klass.__le__ = lambda self, o: str(self) <= o
+    klass.__gt__ = lambda self, o: str(self) >  o
+    klass.__ge__ = lambda self, o: str(self) >= o

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttree.py
@@ -194,10 +194,9 @@ def pythonize_ttree(klass, name):
     klass.Branch = _Branch
 
 @pythonization('TChain')
-def pythonize_tchain(klass, name):
+def pythonize_tchain(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # TChain needs to be explicitly pythonized because it redefines
     # SetBranchAddress in C++. As a consequence, TChain does not

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttree.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_ttree.py
@@ -131,8 +131,7 @@ ds.SetBranchAddress('structb', ms)
 '''
 
 from libROOTPythonizations import AddBranchAttrSyntax, SetBranchAddressPyz, BranchPyz
-
-from ROOT import pythonization
+from . import pythonization
 
 # TTree iterator
 def _TTree__iter__(self):
@@ -169,37 +168,44 @@ def _Branch(self, *args):
 
     return res
 
-@pythonization()
+@pythonization('TTree')
 def pythonize_ttree(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    to_pythonize = [ 'TTree', 'TChain' ]
-    if name in to_pythonize:
-        # Pythonizations that are common to TTree and its subclasses.
-        # To avoid duplicating the same logic in the pythonizors of
-        # the subclasses, inject the pythonizations for all the target
-        # classes here.
-        # TChain needs to be explicitly pythonized because it redefines
-        # SetBranchAddress in C++. As a consequence, TChain does not
-        # inherit TTree's pythonization for SetBranchAddress, which
-        # needs to be injected to TChain too. This is not the case for
-        # other classes like TNtuple, which will inherit all the
-        # pythonizations added here for TTree.
+    # Pythonizations that are common to TTree and its subclasses.
+    # To avoid duplicating the same logic in the pythonizors of
+    # the subclasses, inject the pythonizations for all the target
+    # classes here.
 
-        # Pythonic iterator
-        klass.__iter__ = _TTree__iter__
+    # Pythonic iterator
+    klass.__iter__ = _TTree__iter__
 
-        # tree.branch syntax
-        AddBranchAttrSyntax(klass)
+    # tree.branch syntax
+    AddBranchAttrSyntax(klass)
 
-        # SetBranchAddress
-        klass._OriginalSetBranchAddress = klass.SetBranchAddress
-        klass.SetBranchAddress = _SetBranchAddress
+    # SetBranchAddress
+    klass._OriginalSetBranchAddress = klass.SetBranchAddress
+    klass.SetBranchAddress = _SetBranchAddress
 
-        # Branch
-        klass._OriginalBranch = klass.Branch
-        klass.Branch = _Branch
+    # Branch
+    klass._OriginalBranch = klass.Branch
+    klass.Branch = _Branch
 
-    return True
+@pythonization('TChain')
+def pythonize_tchain(klass, name):
+    # Parameters:
+    # klass: class to be pythonized
+    # name: string containing the name of the class
+
+    # TChain needs to be explicitly pythonized because it redefines
+    # SetBranchAddress in C++. As a consequence, TChain does not
+    # inherit TTree's pythonization for SetBranchAddress, which
+    # needs to be injected to TChain too. This is not the case for
+    # other classes like TNtuple, which will inherit all the
+    # pythonizations added here for TTree.
+
+    # SetBranchAddress
+    klass._OriginalSetBranchAddress = klass.SetBranchAddress
+    klass.SetBranchAddress = _SetBranchAddress

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvector3.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvector3.py
@@ -8,24 +8,21 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 
 from ._generic import _add_getitem_checked
 
 
-@pythonization()
+@pythonization('TVector3')
 def pythonize_tvector3(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name == 'TVector3':
-        # `len(v)` is always 3
-        klass.__len__ = lambda _: 3
+    # `len(v)` is always 3
+    klass.__len__ = lambda _: 3
 
-        # Add checked __getitem__.
-        # Allows to throw pythonic IndexError when index is out of range
-        # and to iterate over the vector.
-        _add_getitem_checked(klass)
-
-    return True
+    # Add checked __getitem__.
+    # Allows to throw pythonic IndexError when index is out of range
+    # and to iterate over the vector.
+    _add_getitem_checked(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvector3.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvector3.py
@@ -14,10 +14,9 @@ from ._generic import _add_getitem_checked
 
 
 @pythonization('TVector3')
-def pythonize_tvector3(klass, name):
+def pythonize_tvector3(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # `len(v)` is always 3
     klass.__len__ = lambda _: 3

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvectort.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvectort.py
@@ -8,24 +8,21 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from ROOT import pythonization
+from . import pythonization
 
 from ._generic import _add_getitem_checked
 
 
-@pythonization()
+@pythonization('TVectorT', is_prefix=True)
 def pythonize_tvectort(klass, name):
     # Parameters:
     # klass: class to be pythonized
     # name: string containing the name of the class
 
-    if name.startswith('TVectorT'):
-        # Support `len(v)` as `v.GetNoElements()`
-        klass.__len__ = klass.GetNoElements
+    # Support `len(v)` as `v.GetNoElements()`
+    klass.__len__ = klass.GetNoElements
 
-        # Add checked __getitem__.
-        # Allows to throw pythonic IndexError when index is out of range
-        # and to iterate over the vector.
-        _add_getitem_checked(klass)
-
-    return True
+    # Add checked __getitem__.
+    # Allows to throw pythonic IndexError when index is out of range
+    # and to iterate over the vector.
+    _add_getitem_checked(klass)

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvectort.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_tvectort.py
@@ -14,10 +14,9 @@ from ._generic import _add_getitem_checked
 
 
 @pythonization('TVectorT', is_prefix=True)
-def pythonize_tvectort(klass, name):
+def pythonize_tvectort(klass):
     # Parameters:
     # klass: class to be pythonized
-    # name: string containing the name of the class
 
     # Support `len(v)` as `v.GetNoElements()`
     klass.__len__ = klass.GetNoElements

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -19,6 +19,9 @@ if(NOT MSVC)
     ROOT_ADD_PYUNITTEST(pyroot_dependency_versions dependency_versions.py)
 endif()
 
+# @pythonization decorator
+ROOT_ADD_PYUNITTEST(pyroot_pyz_decorator pythonization_decorator.py)
+
 # General pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_pretty_printing pretty_printing.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_array_interface array_interface.py PYTHON_DEPS numpy)

--- a/bindings/pyroot/pythonizations/test/pythonization_decorator.py
+++ b/bindings/pyroot/pythonizations/test/pythonization_decorator.py
@@ -1,0 +1,310 @@
+import unittest
+
+import ROOT
+from ROOT import pythonization
+
+
+class PythonizationDecorator(unittest.TestCase):
+    """
+    Test the @pythonization decorator for user-defined classes.
+    """
+
+    # Helpers
+    def _define_class(self, class_name, namespace=None):
+        if namespace is None:
+            ROOT.gInterpreter.ProcessLine('class {cn} {{ }};'.format(cn=class_name))
+        else:
+            ROOT.gInterpreter.ProcessLine('''
+            namespace {ns} {{
+            class {cn} {{}};
+            }}'''.format(ns=namespace, cn=class_name))
+
+    # Test @pythonization('MyClass')
+    def test_single_class_global(self):
+        # Define test class
+        class_name = 'MyClass'
+        self._define_class(class_name)
+
+        executed = []
+
+        # Define pythonizor function for class
+        @pythonization(class_name)
+        def my_func(klass, name):
+            self.assertEqual(klass.__cpp_name__, class_name)
+            self.assertEqual(name, class_name)
+            executed.append(name)
+
+        # Trigger execution of pythonizor
+        getattr(ROOT, class_name)
+
+        self.assertEqual(executed.pop(), class_name)
+        self.assertTrue(not executed)
+
+    # Test @pythonization('NS::MyClass')
+    def test_single_class_in_ns(self):
+        # Define test class
+        ns = 'NS'
+        class_name = 'MyClass1'
+        fqn = ns + '::' + class_name
+        self._define_class(class_name, ns)
+ 
+        executed = []
+
+        # Define pythonizor function for class
+        @pythonization(fqn)
+        def my_func(klass, name):
+            self.assertEqual(klass.__cpp_name__, fqn)
+            self.assertEqual(name, fqn)
+            executed.append(name)
+
+        # Trigger execution of pythonizor
+        getattr(getattr(ROOT, ns), class_name)
+
+        self.assertEqual(executed.pop(), fqn)
+        self.assertTrue(not executed)
+
+    # Test @pythonization('Prefix', is_prefix=True)
+    def test_single_prefix_global(self):
+        # Define test classes
+        prefix = 'Prefix'
+        class1 = prefix + 'Class1'
+        class2 = prefix + 'Class2'
+        for class_name in class1, class2:
+            self._define_class(class_name)
+
+        executed = []
+
+        # Define pythonizor function for prefix
+        @pythonization(prefix, is_prefix=True)
+        def my_func(klass, name):
+            self.assertTrue(klass.__cpp_name__.startswith(prefix))
+            self.assertTrue(name.startswith(prefix))
+            executed.append(name)
+
+        # Trigger execution of pythonizors
+        getattr(ROOT, class1)
+        getattr(ROOT, class2)
+
+        self.assertEqual(executed.pop(0), class1)
+        self.assertEqual(executed.pop(0), class2)
+        self.assertTrue(not executed)
+
+    # Test @pythonization('NS::Prefix', is_prefix=True)
+    def test_single_prefix_in_ns(self):
+        # Define test classes
+        ns = 'NS'
+        prefix = 'Prefix'
+        class1 = prefix + 'Class1'
+        fqn1 = ns + '::' + class1
+        class2 = prefix + 'Class2'
+        fqn2 = ns + '::' + class2
+        ns_prefix = ns + '::' + prefix
+        for class_name in class1, class2:
+            self._define_class(class_name, ns)
+
+        executed = []
+
+        # Define pythonizor function for prefix
+        @pythonization(ns_prefix, is_prefix=True)
+        def my_func(klass, name):
+            self.assertTrue(klass.__cpp_name__.startswith(ns_prefix))
+            self.assertTrue(name.startswith(ns_prefix))
+            executed.append(name)
+
+        # Trigger execution of pythonizors
+        getattr(getattr(ROOT, ns), class1)
+        getattr(getattr(ROOT, ns), class2)
+
+        self.assertEqual(executed.pop(0), fqn1)
+        self.assertEqual(executed.pop(0), fqn2)
+        self.assertTrue(not executed)
+
+    # Test @pythonization(['MyClass', 'NS::MyClass'])
+    def test_multiple_classes(self):
+        # Define test classes
+        class_name = 'MyClass2'
+        ns = 'NS'
+        fqn = ns + '::' + class_name
+        self._define_class(class_name)
+        self._define_class(class_name, ns)
+
+        executed = []
+        target_classes = [ class_name, fqn ]
+
+        # Define pythonizor function for classes
+        @pythonization(target_classes)
+        def my_func(klass, name):
+            self.assertTrue(klass.__cpp_name__ in target_classes)
+            self.assertTrue(name in target_classes)
+            executed.append(name)
+
+        # Trigger execution of pythonizor
+        getattr(ROOT, class_name)
+        getattr(getattr(ROOT, ns), class_name)
+
+        self.assertEqual(executed.pop(0), class_name)
+        self.assertEqual(executed.pop(0), fqn)
+        self.assertTrue(not executed)
+
+    # Test @pythonization(['Prefix', 'NS::Prefix'], is_prefix=True)
+    def test_multiple_prefixes(self):
+        # Define test classes
+        ns = 'NS'
+        prefix = 'Prefix'
+        ns_prefix = ns + '::' + prefix
+        class1 = prefix + 'Class11'
+        class2 = prefix + 'Class22'
+        for class_name in class1, class2:
+            self._define_class(class_name)
+            self._define_class(class_name, ns)
+
+        executed = []
+        target_prefixes = [ prefix, ns_prefix ]
+
+        # Define pythonizor function for prefixes
+        @pythonization(target_prefixes, is_prefix=True)
+        def my_func(klass, name):
+            self.assertTrue(any(klass.__cpp_name__.startswith(p) for p in target_prefixes))
+            self.assertTrue(any(name.startswith(p) for p in target_prefixes))
+            executed.append(name)
+
+        # Trigger execution of pythonizors
+        for class_name in class1, class2:
+            getattr(ROOT, class_name)
+            getattr(getattr(ROOT, ns), class_name)
+
+        for class_name in class1, class2:
+           self.assertEqual(executed.pop(0), class_name)
+           self.assertEqual(executed.pop(0), ns + '::' + class_name)
+        self.assertTrue(not executed)
+
+    # Test @pythonization(['', 'NS::'], is_prefix=True)
+    def test_all_classes_in_ns_prefixes(self):
+        # Define test classes
+        ns = 'NS'
+        class1 = 'Foo'
+        class2 = 'Bar'
+        for class_name in class1, class2:
+            self._define_class(class_name)
+            self._define_class(class_name, ns)
+
+        executed = []
+        target_prefixes = [ '',       # matches all classes in global namespace
+                            ns + '::' # matches all classes in `ns` namespace
+                          ]
+
+        # Define pythonizor function for prefixes
+        @pythonization(target_prefixes, is_prefix=True)
+        def my_func(klass, name):
+            self.assertTrue(any(klass.__cpp_name__.startswith(p) for p in target_prefixes))
+            self.assertTrue(any(name.startswith(p) for p in target_prefixes))
+            executed.append(name)
+
+        # Trigger execution of pythonizors
+        for class_name in class1, class2:
+            getattr(ROOT, class_name)
+            getattr(getattr(ROOT, ns), class_name)
+
+        for class_name in class1, class2:
+           self.assertEqual(executed.pop(0), class_name)
+           self.assertEqual(executed.pop(0), ns + '::' + class_name)
+        self.assertTrue(not executed)
+
+    # Test @pythonization(['MyClass', 'MyClass', 'NS::MyClass', 'NS::MyClass'])
+    def test_repeated_targets(self):
+        # Define test classes
+        class_name = 'MyClass3'
+        ns = 'NS'
+        fqn = ns + '::' + class_name
+        self._define_class(class_name)
+        self._define_class(class_name, ns)
+
+        executed = []
+        target_classes = [ class_name, class_name, fqn, fqn ]
+
+        # Define pythonizor function for classes
+        @pythonization(target_classes)
+        def my_func(klass, name):
+            self.assertTrue(klass.__cpp_name__ in target_classes)
+            self.assertTrue(name in target_classes)
+            executed.append(name)
+
+        # Trigger execution of pythonizor
+        getattr(ROOT, class_name)
+        getattr(getattr(ROOT, ns), class_name)
+
+        self.assertEqual(executed.pop(0), class_name)
+        self.assertEqual(executed.pop(0), fqn)
+        # The following should be true since @pythonization removes repetitions
+        self.assertTrue(not executed)
+
+    # Test that @pythonization filters out non-matching classes
+    def test_non_pythonized_classes(self):
+        ns1 = 'NS1'
+        ns2 = 'NS2'
+        prefix = 'Mat'
+        class1 = 'Matches'
+        class2 = 'DoesNotMatch'
+
+        for class_name,ns in (class1,ns1), (class2,ns2):
+            self._define_class(class_name)
+            self._define_class(class_name, ns)
+
+        executed = []
+        target_classes = [ class1, ns1 + '::' + class1 ]
+        target_prefixes = [ prefix, ns1 + '::' + prefix ]
+
+        @pythonization(target_classes)
+        def my_func1(klass, name):
+            self.assertTrue(klass.__cpp_name__ in target_classes)
+            self.assertTrue(name in target_classes)
+            executed.append(name)
+
+        @pythonization(target_prefixes, is_prefix=True)
+        def my_func2(klass, name):
+            self.assertTrue(any(klass.__cpp_name__.startswith(p) for p in target_prefixes))
+            self.assertTrue(any(name.startswith(p) for p in target_prefixes))
+            executed.append(name)
+
+        # Trigger execution of pythonizors.
+        # Non-matching classes should be filtered out
+        for class_name, ns in (class1,ns1), (class2,ns2):
+            getattr(ROOT, class_name)
+            getattr(getattr(ROOT, ns), class_name)
+
+        # Each first class access triggers the execution of the two pythonizors
+        for _ in range(2):
+            self.assertEqual(executed.pop(0), class1)
+        for _ in range(2):
+            self.assertEqual(executed.pop(0), ns1 + '::' + class1)
+        self.assertTrue(not executed)
+
+    # Test passing as target an iterable that is not a list
+    def test_iterable(self):
+        # Define test classes
+        class1 = 'MyClass4'
+        class2 = 'MyClass5'
+        for class_name in class1, class2:
+            self._define_class(class_name)
+
+        executed = []
+        target_classes_tuple = ( class1, class2 )
+
+        # Define pythonizor function for classes
+        @pythonization(target_classes_tuple)
+        def my_func(klass, name):
+            self.assertTrue(klass.__cpp_name__ in target_classes_tuple)
+            self.assertTrue(name in target_classes_tuple)
+            executed.append(name)
+
+        # Trigger execution of pythonizor
+        for class_name in class1, class2:
+            getattr(ROOT, class_name)
+
+        for class_name in class1, class2:
+            self.assertEqual(executed.pop(0), class_name)
+        self.assertTrue(not executed)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bindings/pyroot/pythonizations/test/pythonization_decorator.py
+++ b/bindings/pyroot/pythonizations/test/pythonization_decorator.py
@@ -305,6 +305,39 @@ class PythonizationDecorator(unittest.TestCase):
             self.assertEqual(executed.pop(0), class_name)
         self.assertTrue(not executed)
 
+    # Test pythonizor with a single parameter (the class proxy)
+    def test_single_parameter_pythonizor(self):
+        # Define test class
+        class_name = 'MyClass6'
+        self._define_class(class_name)
+
+        executed = []
+
+        # Define pythonizor function for class
+        @pythonization(class_name)
+        def my_func(klass):
+            self.assertEqual(klass.__cpp_name__, class_name)
+            executed.append(class_name)
+
+        # Trigger execution of pythonizor
+        getattr(ROOT, class_name)
+
+        self.assertEqual(executed.pop(0), class_name)
+        self.assertTrue(not executed)
+
+    # Test pythonizor with wrong number of parameters
+    def test_wrong_pars_pythonizor(self):
+        # Define test class
+        class_name = 'MyClass7'
+        self._define_class(class_name)
+
+        # Define pythonizor function for class.
+        # Registration of pythonizor should fail
+        with self.assertRaises(TypeError):
+            @pythonization(class_name)
+            def my_func(klass, name, wrong_par):
+                pass
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tutorials/pyroot/pyroot002_pythonizationDecorator.py
+++ b/tutorials/pyroot/pyroot002_pythonizationDecorator.py
@@ -35,8 +35,8 @@ class MyClass {};
 # namespace (if the latter is not specified, it defaults to the global
 # namespace, i.e. '::').
 #
-# On the other hand, the decorated function - the pythonizor - must accept
-# either one or two parameters:
+# The decorated function - the pythonizor - must accept either one or two
+# parameters:
 # 1. The class to be pythonized (proxy object where new behaviour can be
 # injected)
 # 2. The fully-qualified name of that class (optional).
@@ -145,8 +145,8 @@ def pair_pythonizor(klass, name):
 # can see this with the print we did inside the pythonizor.
 # Note that we could use the `name` parameter to e.g. further filter which
 # particular instantiations we would like to pythonize.
-p1 = ROOT.std.pair['int','int'](1,2) # prints 'Pythonizing class std::pair<int, int>' 
-p2 = ROOT.std.pair['int','double'](1,2.) # prints 'Pythonizing class std::pair<int, double>'
+p1 = ROOT.std.pair['int','int'](1,2) # prints 'Pythonizing class std::pair<int,int>'
+p2 = ROOT.std.pair['int','double'](1,2.) # prints 'Pythonizing class std::pair<int,double>'
 
 # Note that, to pythonize multiple classes in different namespaces, we can
 # stack multiple @pythonization decorators. For example, if we define these

--- a/tutorials/pyroot/pyroot002_pythonizationDecorator.py
+++ b/tutorials/pyroot/pyroot002_pythonizationDecorator.py
@@ -1,0 +1,141 @@
+## \file
+## \ingroup tutorial_pyroot
+## \notebook -nodraw
+## This tutorial shows how to use the @pythonization decorator to add extra
+## behaviour to C++ user classes that are used from Python via PyROOT.
+##
+## \macro_code
+## \macro_output
+##
+## \date November 2021
+## \author Enric Tejedor
+
+import ROOT
+from ROOT import pythonization
+
+# Let's first define a new C++ class. In this tutorial, we will see how we can
+# "pythonize" this class, i.e. how we can add some extra behaviour to it to
+# make it more pythonic or easier to use from Python.
+#
+# Note: In this example, the class is defined dynamically for demonstration
+# purposes, but it could also be a C++ class defined in some library or header.
+# For more information about loading C++ user code to be used from Python with
+# PyROOT, please see:
+# https://root.cern.ch/manual/python/#loading-user-libraries-and-just-in-time-compilation-jitting
+ROOT.gInterpreter.Declare('''
+class MyClass {};
+''')
+
+# Next, we define a pythonizor function: the function that will be responsible
+# for injecting new behaviour in our C++ class `MyClass`.
+#
+# To convert a given Python function into a pythonizor, we need to decorate it
+# with the @pythonization decorator. Such decorator allows us to define which
+# is our target class, i.e. which class we want to pythonize.
+#
+# On the other hand, the decorated function - the pythonizor - must accept
+# either one or two parameters:
+# 1. The class to be pythonized (proxy object where new behaviour can be
+# injected)
+# 2. The fully-qualified name of that class (optional).
+#
+# Let's see all this with a simple example. Suppose I would like to define how
+# `MyClass` objects are represented as a string in Python (i.e. what would be
+# shown when I print that object). For that purpose, I can define the following
+# pythonizor function. There are two important things to be noted here:
+# - The @pythonization decorator has one argument that specifies our target
+# class is `MyClass`.
+# - The pythonizor function `pythonizor_of_myclass` provides and injects a new
+# implementation for `__str__`, the mechanism that Python provides to define
+# how to represent objects of a class as a string. This new implementation
+# always returns the string "This is a MyClass object".
+@pythonization('MyClass')
+def pythonizor_of_myclass(klass):
+    klass.__str__ = lambda o : 'This is a MyClass object'
+
+# Once we have defined our pythonizor function, let's see it in action.
+# We will now use the `MyClass` class for the first time from Python: we will
+# create a new object of that class. At this moment, the pythonizor will
+# execute and modify the class - pythonizors are always lazily run when a given
+# class is used for the first time from a Python script.
+my_object = ROOT.MyClass()
+
+# Since the pythonizor already executed, we should now see the new behaviour.
+# For that purpose, let's print `my_object` (should show "This is a MyClass
+# object").
+print(my_object)
+
+# The previous example is just a simple one, but there are many ways in which a
+# class can be pythonized. Typical examples are the redefinition of dunder
+# methods (e.g. `__iter__` and `__next__` to make your objects iterable from
+# Python). If you need some inspiration, many ROOT classes are pythonized in
+# way we just saw; their pythonizations can be seen at:
+# https://github.com/root-project/root/tree/master/bindings/pyroot/pythonizations/python/ROOT/pythonization
+
+# The @pythonization decorator offers a few more options when it comes to
+# matching classes that you want to pythonize. We saw that we can match a
+# single class, but we can also specify a list of classes to pythonize.
+#
+# The following code defines a couple of new classes:
+ROOT.gInterpreter.Declare('''
+class Class1 {};
+
+namespace NS {
+    class Class2 {};
+}
+''')
+
+# A pythonizor that matches both classes would look like this:
+@pythonization(['Class1', 'NS::Class2'])
+def pythonize_two_classes(klass):
+    klass.new_attribute = 1
+
+# Both classes will have the new attribute:
+o1 = ROOT.Class1()
+o2 = ROOT.NS.Class2()
+print("Printing new attribute")
+for o in o1, o2:
+    print(o.new_attribute)
+
+# In addition, @pythonization also accepts prefixes of classes in a certain
+# namespace in order to match multiple classes in that namespace. In order to
+# signal that what we provide to @pythonization is a prefix, we need to set the
+# `is_prefix` argument to `True` (default is `False`).
+#
+# A common case where matching prefixes is useful is when we have a templated
+# class and we want to pythonize all possible instantiations of that template.
+# For example, we can pythonize the `std::vector` (templated) class like so:
+@pythonization('std::vector<', is_prefix=True)
+def vector_pythonizor(klass):
+    # first_elem returns the first element of the vector if it exists
+    klass.first_elem = lambda v : v[0] if v else None
+
+# Since we defined a prefix to do the match, the pythonization will be applied
+# both if we instantiate e.g. a vector of integers and a vector of doubles.
+v_int = ROOT.std.vector['int']([1,2,3])
+v_double = ROOT.std.vector['double']([4.,5.,6.])
+print("First element of integer vector: {}".format(v_int.first_elem()))
+print("First element of double vector: {}".format(v_double.first_elem()))
+
+# It is important to note that prefixes are applied to a certain namespace.
+# These are examples of prefixes and the corresponding classes they match:
+# - '' : all classes in the global namespace.
+# - 'NS1::NS2::' : all classes in the `NS1::NS2` namespace.
+# - 'Prefix' : classes whose name starts with `Prefix` in the global namespace.
+# - 'NS::Prefix' : classes whose name starts with `Prefix` in the `NS`
+# namespace.
+
+# Finally, a pythonizor function can have a second optional parameter that
+# contains the fully-qualified name of the class being pythonized. This can be
+# useful e.g. if we would like to do some more complex filtering of classes in
+# our pythonizor, for instance using regular expressions.
+@pythonization('std::pair<', is_prefix=True)
+def pair_pythonizor(klass, name):
+    print('Pythonizing class ' + name)
+
+# The pythonizor above will be applied to any instantiation of `std::pair` - we
+# can see this with the print we did inside the pythonizor.
+# Note that we could use the `name` parameter to e.g. further filter which
+# particular instantiations we would like to pythonize.
+p1 = ROOT.std.pair['int','int'](1,2)
+p2 = ROOT.std.pair['int','double'](1,2.)

--- a/tutorials/pyroot/pyroot002_pythonizationDecorator.py
+++ b/tutorials/pyroot/pyroot002_pythonizationDecorator.py
@@ -167,3 +167,34 @@ def pythonizor_for_first_and_second(klass, name):
 # If we now access both classes, we should see that the pythonizor runs twice.
 f = ROOT.FirstClass()
 s = ROOT.NS.SecondClass()
+
+# So far we have seen how pythonizations can be registered for classes that
+# have not been used yet. We have discussed how, in that case, the pythonizor
+# functions are executed lazily when their target class/es are used for the
+# first time in the application.
+# However, it can also happen that our target class/es have already been
+# accessed by the time we register a pythonization. In such a scenario, the
+# pythonizor is applied immediately (at registration time) to the target
+# class/es.
+
+# Let's see an example of what was just explained. We will define a new class
+# and immediately create an object of that class. We can check how the object
+# still does not have a new attribute `pythonized` that we are going to inject
+# in the next step.
+ROOT.gInterpreter.Declare('''
+class MyClass2 {};
+''')
+o = ROOT.MyClass2()
+try:
+    print(o.pythonized)
+except AttributeError:
+    print("Object has not been pythonized yet!")
+
+# After that, we will register a pythonization for `MyClass2`. Since the class
+# has already been used, the pythonization will happen right away.
+@pythonization('MyClass2')
+def pythonizor_for_myclass2(klass):
+    klass.pythonized = True
+
+# Now our object does have the `pythonized` attribute:
+print(o.pythonized) # prints True

--- a/tutorials/pyroot/pyroot002_pythonizationDecorator.py
+++ b/tutorials/pyroot/pyroot002_pythonizationDecorator.py
@@ -31,7 +31,7 @@ class MyClass {};
 #
 # To convert a given Python function into a pythonizor, we need to decorate it
 # with the @pythonization decorator. Such decorator allows us to define which
-# is our target class, i.e. which class we want to pythonize.
+# class is our target, i.e. which class we want to pythonize.
 #
 # On the other hand, the decorated function - the pythonizor - must accept
 # either one or two parameters:
@@ -47,7 +47,7 @@ class MyClass {};
 # class is `MyClass`.
 # - The pythonizor function `pythonizor_of_myclass` provides and injects a new
 # implementation for `__str__`, the mechanism that Python provides to define
-# how to represent objects of a class as a string. This new implementation
+# how to represent objects as strings. This new implementation
 # always returns the string "This is a MyClass object".
 @pythonization('MyClass')
 def pythonizor_of_myclass(klass):
@@ -55,7 +55,7 @@ def pythonizor_of_myclass(klass):
 
 # Once we have defined our pythonizor function, let's see it in action.
 # We will now use the `MyClass` class for the first time from Python: we will
-# create a new object of that class. At this moment, the pythonizor will
+# create a new instance of that class. At this moment, the pythonizor will
 # execute and modify the class - pythonizors are always lazily run when a given
 # class is used for the first time from a Python script.
 my_object = ROOT.MyClass()
@@ -69,7 +69,7 @@ print(my_object)
 # class can be pythonized. Typical examples are the redefinition of dunder
 # methods (e.g. `__iter__` and `__next__` to make your objects iterable from
 # Python). If you need some inspiration, many ROOT classes are pythonized in
-# way we just saw; their pythonizations can be seen at:
+# the way we just saw; their pythonizations can be seen at:
 # https://github.com/root-project/root/tree/master/bindings/pyroot/pythonizations/python/ROOT/pythonization
 
 # The @pythonization decorator offers a few more options when it comes to
@@ -137,5 +137,5 @@ def pair_pythonizor(klass, name):
 # can see this with the print we did inside the pythonizor.
 # Note that we could use the `name` parameter to e.g. further filter which
 # particular instantiations we would like to pythonize.
-p1 = ROOT.std.pair['int','int'](1,2)
-p2 = ROOT.std.pair['int','double'](1,2.)
+p1 = ROOT.std.pair['int','int'](1,2) # prints 'Pythonizing class std::pair<int, int>' 
+p2 = ROOT.std.pair['int','double'](1,2.) # prints 'Pythonizing class std::pair<int, double>'


### PR DESCRIPTION
A `@pythonization` decorator was already being used internally in ROOT to register pythonizor functions for ROOT classes. Such decorator has been redesigned and made available to users via the ROOT module to pythonize their classes.

The decorator accepts two parameters: the target of the pythonization (a string or an iterable of strings) and - optionally - a boolean that says if the string(s) are full class names or prefixes. Let's see this better with examples.

If I want to pythonize class `C`, I can define a pythonizor function like this:
```python
from ROOT import pythonization

@pythonization("C")
def pythonizor_C(klass, name):
    ...
```
where `klass` is the Python proxy class for `C` and `name` is the name of the class (i.e. "C"). The reason I kept `name` as parameter is for convenience for the user, since she might want to do some more complex filtering than what the decorator offers (this will be more useful in the examples for prefixes below).

If I want to apply the same pythonizor to more than one class, e.g. `C` and `B`, I can do:
```python
@pythonization([ "C", "B" ])
def pythonizor_C_B(klass, name):
    ...
```
Note that classes in namespaces also work, e.g. `@pythonization("NS1::C")` or `@pythonization(["NS1::C", "NS1::NS2::B"])` are also valid.

Regarding prefixes, I wanted to provide an option to match multiple classes without specifying their names one by one. This can be useful, for instance, for templated classes, since we might want to apply the same pythonizor to any instantiation of the templated class no matter with what type it was instantiated (note that pythonizors are not applied to templates but to classes).

So it is also possible to do (this time picking a real example from ROOT):
```python
@pythonization("ROOT::VecOps::RVec<", is_prefix=True)
def pythonizor_RVec(klass, name):
    ...
```
The `is_prefix` argument (`False` by default) tells that I want to match anything that starts with `ROOT::VecOps::RVec<`, e.g. `ROOT::VecOps::RVec<float>`. The same thing can be done with an iterable too:
```python
@pythonization([ "ROOT::VecOps::RVec<", "std::vector<" ], is_prefix=True)
def pythonizor_RVec_stdvec(klass, name):
    ...
```

Alternatively, I could have allowed regular expressions. I discarded that because of two reasons:
- They are more costly that simple string comparison.
- They complicate the registration of pythonizors per scope. In this new `@pythonization` decorator, the scope of the class is parsed (e.g. `NS1::NS2` for `NS1::NS2::C`) and the pythonizor is _registered for that scope_. This allows for more efficient lookup of the pythonizors to apply, because when a class is accessed for the first time, only the pythonizors registered for its scope will be attempted. This is nice for user classes, because if a user class belongs to `UserNamespace`, when the user script first accesses the class only the pythonizors for classes in `UserNamespace` will be tried, and not every single registered pythonizor (in particular, not all the pythonizors ROOT registers for its classes in the global namespace). So I prefer to have a clean static prefix that unambiguously tells me what the target scope is than something like `NS1::(.+)::C`. And if the user wants to do an additional complex matching with regular expressions, they can still do so in their pythonizor code via the `name` parameter.

I'd like to hear the opinion of @pikacic and @daritter about this since we've discussed about this decorator in the past (no need to review the whole PR, giving your opinion on the programming examples is already more than enough!).

EDIT: I have received some feedback from @eguiraud on the `name` parameter: he thinks it could be removed since some users won't need it (they won't do any further filtering inside the pythonizor). As an alternative, `name` could be injected in `klass` before the user pythonizor runs (so users would access it as `klass.name`), but that could cause a clash if `name` is already a static member of the class. There is also `klass.__cpp_name__` that is provided by cppyy with the fully qualified name of the class, so we could rely on that too. @vepadulano would rather keep `name` as a parameter. I'd like to hear more opinions :)