### PR TITLE
[DF] Avoid crash in tutorial due to reused canvas name

### DIFF
--- a/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
+++ b/tutorials/dataframe/df103_NanoAODHiggsAnalysis.py
@@ -193,7 +193,7 @@ def plot(sig, bkg, data, x_label, filename):
     # Canvas and general style options
     ROOT.gStyle.SetOptStat(0)
     ROOT.gStyle.SetTextFont(42)
-    d = ROOT.TCanvas("d", "", 800, 700)
+    d = ROOT.TCanvas("", "", 800, 700)
     # Make sure the canvas stays in the list of canvases after the macro execution
     ROOT.SetOwnership(d, False)
     d.SetLeftMargin(0.15)


### PR DESCRIPTION
This tutorial crashed with the following stacktrace when run
interactively. Avoiding to register a canvas with the same name
multiple times fixes the crash:

```
    #8  0x00007f5b7876967d in TCanvas::Resize(char const*) (this=0x55e768e126c0) at ../graf2d/gpad/src/TCanvas.cxx:1740
    #9  0x00007f5b3e90d668 in TRootCanvas::HandleContainerConfigure(Event_t*) (this=0x55e76852b460) at ../gui/gui/src/TRootCanvas.cxx:1789
    #10 0x00007f5b3e8464fd in TGFrame::HandleEvent(Event_t*) (this=0x55e767938e70, event=0x7f5b79adff40) at ../gui/gui/src/TGFrame.cxx:476
    #11 0x00007f5b3e7f4c9a in TGClient::HandleEvent(Event_t*) (this=0x55e768de2290, event=0x7f5b79adff40) at ../gui/gui/src/TGClient.cxx:846
    #12 0x00007f5b3e7f531d in TGClient::ProcessOneEvent() (this=0x55e768de2290) at ../gui/gui/src/TGClient.cxx:656
    #13 TGClient::ProcessOneEvent() (this=0x55e768de2290) at ../gui/gui/src/TGClient.cxx:648
    #14 0x00007f5b3e7f536b in TGClient::HandleInput() (this=0x55e768de2290) at ../gui/gui/src/TGClient.cxx:703
    #15 0x00007f5b8dcb0ff8 in TUnixSystem::DispatchOneEvent(bool) (this=0x55e75ccfd080, pendingOnly=<optimized out>) at ../core/unix/src/TUnixSystem.cxx:1067
    #16 0x00007f5b8dbd0dca in TSystem::ProcessEvents() (this=0x55e75ccfd080) at ../core/base/src/TSystem.cxx:424
    #17 0x00007f5b8130600d in  ()
    #18 0x00007f5b79ae0450 in  ()
    #19 0x00007f5b8de5215f in WrapperCall(Cppyy::TCppMethod_t, size_t, void*, void*, void*) (method=94452242807424, nargs=0, args_=0x7f5b79ae01d7, self=0x55e75ccfd080, result=0x7f5b79ae01d7) at ../bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:778
    #20 0x00007f5b8de527cf in CallT<unsigned char> (args=<optimized out>, nargs=<optimized out>, self=<optimized out>, method=<optimized out>) at ../bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:816
    #21 Cppyy::CallB(long, void*, unsigned long, void*) (method=<optimized out>, self=<optimized out>, nargs=<optimized out>, args=<optimized out>) at ../bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx:833
    #22 0x00007f5b8decdc0f in GILCallB (ctxt=0x7f5b79ae0430, self=<optimized out>, method=<optimized out>) at ../bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx:69
    #23 CPyCppyy::(anonymous namespace)::BoolExecutor::Execute(Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CPyCppyy::CallContext*) (this=<optimized out>, method=<optimized out>, self=<optimized out>, ctxt=0x7f5b79ae0430) at ../bindings/pyroot/cppyy/CPyCppyy/src/Executors.cxx:148
    #24 0x00007f5b8deba4c9 in CPyCppyy::CPPMethod::ExecuteFast(void*, long, CPyCppyy::CallContext*) (self=<optimized out>, offset=<optimized out>, ctxt=<optimized out>, this=<optimized out>, this=<optimized out>) at ../bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:74
    #25 0x00007f5b8debd3a8 in CPyCppyy::CPPMethod::ExecuteProtected(void*, long, CPyCppyy::CallContext*) (this=this entry=0x55e760617f50, self=0x55e75ccfd080, offset=0, ctxt=0x7f5b79ae0430) at ../bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:149
    #26 0x00007f5b8debb6fa in CPyCppyy::CPPMethod::Execute(void*, long, CPyCppyy::CallContext*) (this=this entry=0x55e760617f50, self=self entry=0x55e75ccfd080, offset=<optimized out>, ctxt=ctxt entry=0x7f5b79ae0430) at ../bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:728
    #27 0x00007f5b8debc46c in CPyCppyy::CPPMethod::Call(CPyCppyy::CPPInstance*&, _object*, _object*, CPyCppyy::CallContext*) (this=0x55e760617f50, self= 0x7f5b8080ef50: 0x7f5b808043c0, args=0x7f5b8e1ab040, kwds=<optimized out>, ctxt=0x7f5b79ae0430) at ../bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx:783
    #28 0x00007f5b8dec09fe in CPyCppyy::(anonymous namespace)::mp_call(CPyCppyy::CPPOverload*, PyObject*, PyObject*) (pymeth=0x7f5b8080ef40, args=0x7f5b8e1ab040, kwds=0x0) at ../bindings/pyroot/cppyy/CPyCppyy/src/CPPOverload.cxx:566
    #29 0x00007f5b8e941333 in _PyObject_MakeTpCall () at /usr/lib/libpython3.9.so.1.0
    #30 0x00007f5b8e93d218 in _PyEval_EvalFrameDefault () at /usr/lib/libpython3.9.so.1.0
    #31 0x00007f5b8e936fd9 in  () at /usr/lib/libpython3.9.so.1.0
    #32 0x00007f5b8e948b8e in _PyFunction_Vectorcall () at /usr/lib/libpython3.9.so.1.0
    #33 0x00007f5b8e93aec9 in _PyEval_EvalFrameDefault () at /usr/lib/libpython3.9.so.1.0
    #34 0x00007f5b8e94896b in _PyFunction_Vectorcall () at /usr/lib/libpython3.9.so.1.0
    #35 0x00007f5b8e93858e in _PyEval_EvalFrameDefault () at /usr/lib/libpython3.9.so.1.0
    #36 0x00007f5b8e94896b in _PyFunction_Vectorcall () at /usr/lib/libpython3.9.so.1.0
    #37 0x00007f5b8e93858e in _PyEval_EvalFrameDefault () at /usr/lib/libpython3.9.so.1.0
    #38 0x00007f5b8e94896b in _PyFunction_Vectorcall () at /usr/lib/libpython3.9.so.1.0
    #39 0x00007f5b8e95795b in  () at /usr/lib/libpython3.9.so.1.0
    #40 0x00007f5b8ea3cac6 in  () at /usr/lib/libpython3.9.so.1.0
    #41 0x00007f5b8ea17554 in  () at /usr/lib/libpython3.9.so.1.0
    #42 0x00007f5b8e62c259 in start_thread () at /usr/lib/libpthread.so.0
    #43 0x00007f5b8e7425e3 in clone () at /usr/lib/libc.so.6
```

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

