### PR TITLE
Add a warning

### DIFF
--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -639,6 +639,9 @@ void TTeXDump::NewPage()
 
    if(!fBoundingBox) {
       PrintStr("\\begin{tikzpicture}@");
+      PrintStr("\\def\\CheckTikzLibraryLoaded#1{ \\ifcsname tikz@library@#1@loaded\\endcsname \\else \\PackageWarning{tikz}{usetikzlibrary{#1} is missing in the preamble.} \\fi }@");
+      PrintStr("\\CheckTikzLibraryLoaded{patterns}@");
+      PrintStr("\\CheckTikzLibraryLoaded{plotmarks}@");
       DefineMarkers();
       fBoundingBox = kTRUE;
    }


### PR DESCRIPTION

Print a warning when:

```
\usetikzlibrary{patterns}
\usetikzlibrary{plotmarks}
```
are missing

as suggested here:
https://github.com/root-project/root/issues/9143
