### PR TITLE
THStack::GetXaxis->SetRange did not auto-zoom Yaxis range

### DIFF
--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -525,11 +525,16 @@ Double_t THStack::GetMaximum(Option_t *option)
    if (!opt.Contains("nostack")) {
       BuildStack();
       h = (TH1*)fStack->At(nhists-1);
+      if (fHistogram) h->GetXaxis()->SetRange(fHistogram->GetXaxis()->GetFirst(),
+                                              fHistogram->GetXaxis()->GetLast());
       themax = h->GetMaximum();
    } else {
       for (Int_t i=0;i<nhists;i++) {
          h = (TH1*)fHists->At(i);
+         if (fHistogram) h->GetXaxis()->SetRange(fHistogram->GetXaxis()->GetFirst(),
+                                                 fHistogram->GetXaxis()->GetLast());
          them = h->GetMaximum();
+         if (fHistogram) h->GetXaxis()->SetRange(0,0);
          if (them > themax) themax = them;
       }
    }


### PR DESCRIPTION
This was reported here:
https://github.com/root-project/root/issues/6991


