### PR TITLE
[ntuple] Fix memory management on read of std::vector elements

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1031,9 +1031,18 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
+   auto oldNItems = typedValue->size() / fItemSize;
+   for (std::size_t i = nItems; i < oldNItems; ++i) {
+      auto itemValue = fSubFields[0]->CaptureValue(typedValue->data() + (i * fItemSize));
+      fSubFields[0]->DestroyValue(itemValue, true /* dtorOnly */);
+   }
    typedValue->resize(nItems * fItemSize);
-   for (unsigned i = 0; i < nItems; ++i) {
-      auto itemValue = fSubFields[0]->GenerateValue(typedValue->data() + (i * fItemSize));
+   for (std::size_t i = oldNItems; i < nItems; ++i) {
+      fSubFields[0]->GenerateValue(typedValue->data() + (i * fItemSize));
+   }
+
+   for (std::size_t i = 0; i < nItems; ++i) {
+      auto itemValue = fSubFields[0]->CaptureValue(typedValue->data() + (i * fItemSize));
       fSubFields[0]->Read(collectionStart + i, &itemValue);
    }
 }

--- a/tree/ntuple/v7/test/CustomStruct.cxx
+++ b/tree/ntuple/v7/test/CustomStruct.cxx
@@ -1,1 +1,4 @@
 #include "CustomStruct.hxx"
+
+int ComplexStruct::gNCallConstructor = 0;
+int ComplexStruct::gNCallDestructor = 0;

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -45,3 +45,14 @@ template <class T>
 struct PackedContainer : public std::vector<T>, public IAuxSetOption {
    PackedParameters m_params;
 };
+
+/// class with non-trivial constructor and destructor
+struct ComplexStruct {
+   static int gNCallConstructor;
+   static int gNCallDestructor;
+
+   ComplexStruct() { gNCallConstructor++; }
+   ~ComplexStruct() { gNCallDestructor++; }
+
+   int a = 0;
+};

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -14,4 +14,6 @@
 #pragma link C++ class PackedParameters+;
 #pragma link C++ class PackedContainer<int>+;
 
+#pragma link C++ class ComplexStruct+;
+
 #endif

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -173,3 +173,72 @@ TEST(RNTuple, BoolVector)
    EXPECT_TRUE((*rdBoolRVec)[2]);
    EXPECT_FALSE((*rdBoolRVec)[3]);
 }
+
+
+TEST(RNTuple, ComplexVector)
+{
+   FileRaii fileGuard("test_ntuple_vec_complex.root");
+
+   auto model = RNTupleModel::Create();
+   auto wrV = model->MakeField<std::vector<ComplexStruct>>("v");
+
+   {
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "T", fileGuard.GetPath());
+      ntuple->Fill();
+      for (unsigned i = 0; i < 10; ++i)
+         wrV->push_back(ComplexStruct());
+      ntuple->Fill();
+      wrV->clear();
+      for (unsigned i = 0; i < 10000; ++i)
+         wrV->push_back(ComplexStruct());
+      ntuple->Fill();
+      wrV->clear();
+      for (unsigned i = 0; i < 100; ++i)
+         wrV->push_back(ComplexStruct());
+      ntuple->Fill();
+      for (unsigned i = 0; i < 100; ++i)
+         wrV->push_back(ComplexStruct());
+      ntuple->Fill();
+      wrV->clear();
+      ntuple->Fill();
+      wrV->push_back(ComplexStruct());
+      ntuple->Fill();
+   }
+
+   ComplexStruct::gNCallConstructor = 0;
+   ComplexStruct::gNCallDestructor = 0;
+   {
+      auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
+      auto rdV = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<ComplexStruct>>("v");
+
+      ntuple->LoadEntry(0);
+      EXPECT_EQ(0, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(0, ComplexStruct::gNCallDestructor);
+      EXPECT_TRUE(rdV->empty());
+      ntuple->LoadEntry(1);
+      EXPECT_EQ(10, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(0, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10u, rdV->size());
+      ntuple->LoadEntry(2);
+      EXPECT_EQ(10000, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(0, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10000u, rdV->size());
+      ntuple->LoadEntry(3);
+      EXPECT_EQ(10000, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(9900, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(100u, rdV->size());
+      ntuple->LoadEntry(4);
+      EXPECT_EQ(10100, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(9900, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(200u, rdV->size());
+      ntuple->LoadEntry(5);
+      EXPECT_EQ(10100, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(10100, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(0u, rdV->size());
+      ntuple->LoadEntry(6);
+      EXPECT_EQ(10101, ComplexStruct::gNCallConstructor);
+      EXPECT_EQ(10100, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(1u, rdV->size());
+   }
+   EXPECT_EQ(10101u, ComplexStruct::gNCallDestructor);
+}


### PR DESCRIPTION
The problem of constructor and destructor calls when reading std::vector of non-trivial types has come up in #8770. This fixes #9133.

To me it looks like we would benefit from storing information about trivially constructable/destructable types in the `RField` class. @jalopezg-r00t @eguiraud @pcanal Let me know what you think.