### PR TITLE
Fix unresolved external statics on Windows

### DIFF
--- a/tree/ntuple/v7/test/CustomStruct.cxx
+++ b/tree/ntuple/v7/test/CustomStruct.cxx
@@ -2,3 +2,33 @@
 
 int ComplexStruct::gNCallConstructor = 0;
 int ComplexStruct::gNCallDestructor = 0;
+
+ComplexStruct::ComplexStruct()
+{
+    gNCallConstructor++;
+}
+
+ComplexStruct::~ComplexStruct()
+{
+    gNCallDestructor++;
+}
+
+int ComplexStruct::GetNCallConstructor()
+{
+    return gNCallConstructor;
+}
+
+int ComplexStruct::GetNCallDestructor()
+{
+    return gNCallDestructor;
+}
+
+void ComplexStruct::SetNCallConstructor(int n)
+{
+    gNCallConstructor = n;
+}
+
+void ComplexStruct::SetNCallDestructor(int n)
+{
+    gNCallDestructor = n;
+}

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -51,8 +51,13 @@ struct ComplexStruct {
    static int gNCallConstructor;
    static int gNCallDestructor;
 
-   ComplexStruct() { gNCallConstructor++; }
-   ~ComplexStruct() { gNCallDestructor++; }
+   static int GetNCallConstructor();
+   static int GetNCallDestructor();
+   static void SetNCallConstructor(int);
+   static void SetNCallDestructor(int);
+
+   ComplexStruct();
+   ~ComplexStruct();
 
    int a = 0;
 };

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -205,40 +205,40 @@ TEST(RNTuple, ComplexVector)
       ntuple->Fill();
    }
 
-   ComplexStruct::gNCallConstructor = 0;
-   ComplexStruct::gNCallDestructor = 0;
+   ComplexStruct::SetNCallConstructor(0);
+   ComplexStruct::SetNCallDestructor(0);
    {
       auto ntuple = RNTupleReader::Open("T", fileGuard.GetPath());
       auto rdV = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<ComplexStruct>>("v");
 
       ntuple->LoadEntry(0);
-      EXPECT_EQ(0, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(0, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(0, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(0, ComplexStruct::GetNCallDestructor());
       EXPECT_TRUE(rdV->empty());
       ntuple->LoadEntry(1);
-      EXPECT_EQ(10, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(0, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(0, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(10u, rdV->size());
       ntuple->LoadEntry(2);
-      EXPECT_EQ(10000, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(0, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10000, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(0, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(10000u, rdV->size());
       ntuple->LoadEntry(3);
-      EXPECT_EQ(10000, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(9900, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10000, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(9900, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(100u, rdV->size());
       ntuple->LoadEntry(4);
-      EXPECT_EQ(10100, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(9900, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10100, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(9900, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(200u, rdV->size());
       ntuple->LoadEntry(5);
-      EXPECT_EQ(10100, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(10100, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10100, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(10100, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(0u, rdV->size());
       ntuple->LoadEntry(6);
-      EXPECT_EQ(10101, ComplexStruct::gNCallConstructor);
-      EXPECT_EQ(10100, ComplexStruct::gNCallDestructor);
+      EXPECT_EQ(10101, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(10100, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(1u, rdV->size());
    }
-   EXPECT_EQ(10101u, ComplexStruct::gNCallDestructor);
+   EXPECT_EQ(10101u, ComplexStruct::GetNCallDestructor());
 }


### PR DESCRIPTION
Fix the following compilation errors on Windows:
```
rfield_vector.obj : error LNK2019: unresolved external symbol "public: static int ComplexStruct::gNCallConstructor" (?gNCallConstructor@ComplexStruct@@2HA) referenced in function "private: virtual void __thiscall RNTuple_ComplexVector_Test::TestBody(void)" (?TestBody@RNTuple_ComplexVector_Test@@EAEXXZ)
rfield_vector.obj : error LNK2019: unresolved external symbol "public: static int ComplexStruct::gNCallDestructor" (?gNCallDestructor@ComplexStruct@@2HA) referenced in function "private: virtual void __thiscall RNTuple_ComplexVector_Test::TestBody(void)" (?TestBody@RNTuple_ComplexVector_Test@@EAEXXZ)
```
