### PR TITLE
[v618][RF] Fix missing initializer warnings in MemPoolForRooSets.h

### DIFF
--- a/roofit/roofitcore/src/MemPoolForRooSets.h
+++ b/roofit/roofitcore/src/MemPoolForRooSets.h
@@ -36,7 +36,8 @@ class MemPoolForRooSets {
     Arena()
       : ownedMemory{static_cast<RooSet_t *>(::operator new(2 * POOLSIZE * sizeof(RooSet_t)))},
         memBegin{ownedMemory}, nextItem{ownedMemory},
-        memEnd{memBegin + 2 * POOLSIZE}
+        memEnd{memBegin + 2 * POOLSIZE},
+        cycle{{}}
     {}
 
     Arena(const Arena &) = delete;
@@ -45,7 +46,8 @@ class MemPoolForRooSets {
         memBegin{other.memBegin}, nextItem{other.nextItem}, memEnd{other.memEnd},
         refCount{other.refCount},
         totCount{other.totCount},
-        assigned{other.assigned}
+        assigned{other.assigned},
+        cycle{{}}
     {
       // Needed for unique ownership
       other.ownedMemory = nullptr;
@@ -168,7 +170,7 @@ class MemPoolForRooSets {
     std::size_t totCount = 0;
 
     std::bitset<POOLSIZE> assigned = {};
-    std::array<int, POOLSIZE> cycle = {};
+    std::array<int, POOLSIZE> cycle = {{}};
   };
 
 


### PR DESCRIPTION
This PR should fix the build warnings in the v6.18 nightlies.

I have checked that the missing field initializer warnings go away with
this change by compiling the following example snippet under gcc48:

```C++
// compile with g++ -Wmissing-field-initializers -std=c++11 -o test test.cc

struct A{

   A()
     : arr_{{}}
   {}

   std::array<int, 10> arr_ = {{}};
};

int main() {
    A a{};
    std::cout << a.arr_[0] << std::endl;
    return 0;
}
```

The warnings are reproduced, and can successfully be suppressed by
replacing `{}` with `{{}}`.

This is a backport of 855fd44340e13161f88ca09a86e50abf5c1cd5a1.