### PR TITLE
[RF] Remove entry masking feature from RooDataHist

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -44,10 +44,15 @@ Please use their non-experimental counterparts `ROOT::TBufferMerger` and `ROOT::
 - The deprecated function `ROOT::Detail::RDF::RActionImpl<Helper>::GetDataBlockCallback()` is removed; please use `GetSampleCallback()` instead.
 - The deprecated RooFit containers `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList` are removed. Please use STL container classes instead, like `std::unordered_map`, `std::set`, and `std::vector`.
 - The `RooFit::FitOptions(const char*)` command to steer [RooAbsPdf::fitTo()](https://root.cern.ch/doc/v628/classRooAbsPdf.html) with an option string was removed. This way of configuring the fit was deprecated since at least since ROOT 5.02.
-  Subsequently, the `RooMinimizer::fit(const char*)` function and the [RooMCStudy](https://root.cern.ch/doc/v628/classRooMCStudy.html) constructor that takes an option string was removed as well.
+  Subsequently, the `RooMinimizer::fit(const char*)` function and the [RooMCStudy](https://root.cern.ch/doc/v628/classRooMCStudy.html) constructor that takes an option string were removed as well.
 - The overload of `RooAbsData::createHistogram` that takes integer parameters for the bin numbers is now deprecated and will be removed in ROOT 6.30.
   This was done to avoid confusion with inconsistent behavior when compared to other `createHistogram` overloads.
   Please use the verson of `createHistogram` that takes RooFit command arguments.
+- The `RooAbsData::valid()` method to cache valid entries in the variable range
+  was removed. It was not implemented in RooDataSet, so it never worked as
+  intended. Related to it was the `RooDataHist::cacheValidEntries()` function, which is removed as well.
+  The preferred way to reduce RooFit datasets to subranges is [RooAbsData::reduce()](https://root.cern.ch/doc/v628/classRooAbsData.html#acfa7b31e5cd751eec1bc4e95d2796390).
+
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -108,7 +108,6 @@ public:
   }
   virtual double weight() const = 0 ; // DERIVED
   virtual double weightSquared() const = 0 ; // DERIVED
-  virtual bool valid() const { return true ; }
 
   enum ErrorType { Poisson, SumW2, None, Auto, Expected } ;
   /// Return the symmetric error on the current weight.

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -115,8 +115,6 @@ public:
   /// Return bin volume of i-th bin. \see getIndex()
   double binVolume(std::size_t i) const { return _binv[i]; }
   double binVolume(const RooArgSet& bin) const;
-  /// Return true if bin `i` is considered valid within the current range definitions of all observables. \see getIndex()
-  bool valid(std::size_t i) const { return i <= static_cast<std::size_t>(_arrSize) && (_maskedWeights.empty() || _maskedWeights[i] != 0.);}
 
   TIterator* sliceIterator(RooAbsArg& sliceArg, const RooArgSet& otherArgs) ;
 
@@ -162,9 +160,6 @@ public:
 
   void removeSelfFromDir() { removeFromDir(this) ; }
 
-  // A shortcut function only for RooAbsOptTestStatistic.
-  void cacheValidEntries();
-
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////
   /// @name Deprecated functions
@@ -199,13 +194,6 @@ public:
   /// Write `weight` into current bin. \deprecated Use set(std::size_t,double,double)
   void set(double wgt, double wgtErr=-1)
   R__SUGGEST_ALTERNATIVE("Use set(std::size_t,double,double).");
-
-  /// Return true if currently loaded coordinate is considered valid within
-  /// the current range definitions of all observables.
-  /// \deprecated Use the safer valid(std::size_t) const.
-  bool valid() const override
-  R__SUGGEST_ALTERNATIVE("Use valid(std::size_t).")
-  { return _curIndex <= static_cast<std::size_t>(_arrSize) && (_maskedWeights.empty() || _maskedWeights[_curIndex] != 0.);}
 
   void dump2();
 
@@ -278,9 +266,6 @@ protected:
   mutable double* _errHi{nullptr}; ///<[_arrSize] High-side error on weight array
   mutable double* _sumw2{nullptr}; ///<[_arrSize] Sum of weights^2
   double*         _binv {nullptr}; ///<[_arrSize] Bin volume array
-
-  mutable std::vector<double> _maskedWeights; ///<! Copy of _wgt, but masked events have a weight of zero.
-  mutable std::vector<double> _maskedSumw2;   ///<! Copy of _sumW2, but masked events have a weight of zero.
 
   mutable ULong64_t _curIndex{std::numeric_limits<ULong64_t>::max()}; ///< Current index
 

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -353,13 +353,6 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
   // *** PART 3.2 *** Binned fits                                     *
   // ******************************************************************
 
-  // If dataset is binned, activate caching of bins that are invalid because the're outside the
-  // updated range definition (WVE need to add virtual interface here)
-  RooDataHist* tmph = dynamic_cast<RooDataHist*>(_dataClone) ;
-  if (tmph) {
-    tmph->cacheValidEntries() ;
-  }
-
   setUpBinSampling();
 
 

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -298,8 +298,6 @@ double RooChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastEve
     // get the data values for this event
     hdata->get(i);
 
-    if (!hdata->valid()) continue;
-
     const double nData = hdata->weight() ;
 
     const double nPdf = _funcClone->getVal(_normSet) * normFactor * hdata->binVolume() ;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -248,8 +248,6 @@ double RooNLLVar::evaluatePartition(std::size_t firstEvent, std::size_t lastEven
 
       _dataClone->get(i) ;
 
-      if (!_dataClone->valid()) continue;
-
       double eventWeight = _dataClone->weight();
 
 
@@ -392,7 +390,6 @@ RooNLLVar::ComputeResult RooNLLVar::computeBatchedFunc(const RooAbsPdf *pdfClone
     if (dataClone->weight() == 0.) // 0-weight events are not cached, so cannot compare against them.
       continue;
 
-    assert(dataClone->valid());
     try {
       // Cross check results with strict tolerance and complain
       BatchInterfaceAccessor::checkBatchComputation(*pdfClone, *evalData, evtNo-firstEvent, normSet, 1.E-13);
@@ -482,8 +479,6 @@ RooNLLVar::ComputeResult RooNLLVar::computeScalarFunc(const RooAbsPdf *pdfClone,
 
   for (auto i=firstEvent; i<lastEvent; i+=stepSize) {
     dataClone->get(i) ;
-
-    if (!dataClone->valid()) continue;
 
     double eventWeight = dataClone->weight(); //FIXME
     if (0. == eventWeight * eventWeight) continue ;

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -408,14 +408,6 @@ double RooXYChi2Var::evaluatePartition(std::size_t firstEvent, std::size_t lastE
     // get the data values for this event
     xydata->get(i);
 
-    if (!xydata->valid()) {
-      continue ;
-    }
-
-//     cout << "xydata = " << endl ;
-//     xydata->get()->Print("v") ;
-    //xydata->store()->dump() ;
-
     // Get function value
     double yfunc = fy() ;
 

--- a/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
@@ -179,12 +179,18 @@ void RooAbsL::initClones(RooAbsPdf &inpdf, RooAbsData &indata)
 
    // TODO
 
-   // If dataset is binned, activate caching of bins that are invalid because they're outside the
-   // updated range definition (WVE need to add virtual interface here)
-   RooDataHist *tmph = dynamic_cast<RooDataHist *>(data_.get());
-   if (tmph) {
-      tmph->cacheValidEntries();
-   }
+   // Jonas R.: The following code is commented out, because the functionality
+   // to mask out-ot-range entries with `RooDataHist::cacheValidEntries` has
+   // been removed from the RooDataHist. If you want to implement ranged fits
+   // properly, please create a RooDataHist for the requested range with
+   // `RooDataHist::reduce`.
+
+   //// If dataset is binned, activate caching of bins that are invalid because they're outside the
+   //// updated range definition (WVE need to add virtual interface here)
+   //RooDataHist *tmph = dynamic_cast<RooDataHist *>(data_.get());
+   //if (tmph) {
+      //tmph->cacheValidEntries();
+   //}
 
    // This is deferred from part 2 - but must happen after part 3 - otherwise invalid bins cannot be properly marked in
    // cacheValidEntries

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -97,9 +97,6 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
 
       data_->get(i);
 
-      if (!data_->valid())
-         continue;
-
       double eventWeight = data_->weight();
 
       // Calculate log(Poisson(N|mu) for this bin


### PR DESCRIPTION
This commit removes some functions from the RooFit data classes:

  * `RooAbsData::valid()` (virtual method that was overridden in
     RooDataHist but not RooDataSet)

  * `RooDataHist::valid(std::size_t i)` and `RooDataHist::valid()`

  * `RooDataHist::cacheValidEntries()`

The `cacheValidEntries` method was originally intended to be used in
`RooAbsOptTestStatistic` to mask histogram entries out of the variable
range in case of a subrange fit. The reasons why `cacheValidEntries` and
the related `valid()` methods should be removed are:

  1. It is redundant. In a subrange fit, the `RooAbsOptTestStatistic` is
     creating a clone of the dataset with the subrange only using
     `RooAbsData::reduce()`. So all entries are valid by definition.

  2. RooDataHist and RooDataSet have inconistent implementations. For
     the RooDataHist, `valid()` tells you "if bin `i` is considered
     valid within the current range definitions of all observables"
     (according to the documentation). For the RooDataSet, it always
     returns `true`. This inconsistency leaves plenty of room for error.

  3. The masking of out-of-range entries unnessecarily increases the
     `mutable` state of the RooDataHist, which can cause trouble if one
     updates the observable range but then forgets to call
     `cacheValidEntries()`.

  4. Even the documentation said that `RooDataHist::cacheValidEntries()`
     was a "shortcut function only for RooAbsOptTestStatistic". Why keep
     it if `RooAbsOptTestStatistic` doesn't even use it in a meaningful
     way anymore?