### PR TITLE
[DF] Remove useless data member from RFilter, avoid (rare) reallocations

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -56,19 +56,19 @@ class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
 
    FilterF fFilter;
    const ROOT::RDF::ColumnNames_t fColumnNames;
-   const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
-   PrevDataFrame &fPrevData;
    /// Column readers per slot and per input column
    std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
+   const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
+   PrevDataFrame &fPrevData;
 
 public:
    RFilter(FilterF f, const ROOT::RDF::ColumnNames_t &columns, std::shared_ptr<PrevDataFrame> pd,
            const RDFInternal::RBookedDefines &defines, std::string_view name = "")
       : RFilterBase(pd->GetLoopManagerUnchecked(), name, pd->GetLoopManagerUnchecked()->GetNSlots(), defines),
-        fFilter(std::move(f)), fColumnNames(columns), fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr),
-        fValues(fNSlots), fIsDefine()
+        fFilter(std::move(f)), fColumnNames(columns), fValues(pd->GetLoopManagerUnchecked()->GetNSlots()), fIsDefine(),
+        fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr)
    {
       const auto nColumns = fColumnNames.size();
       for (auto i = 0u; i < nColumns; ++i)
@@ -115,6 +115,7 @@ public:
       RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
                                            fLoopManager->GetDataSource()};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
+      fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
    }
 
    // recursive chain of `Report`s

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -40,7 +40,6 @@ protected:
    std::vector<ULong64_t> fAccepted = {0};
    std::vector<ULong64_t> fRejected = {0};
    const std::string fName;
-   const unsigned int fNSlots; ///< Number of thread slots used by this node, inherited from parent node.
 
    RDFInternal::RBookedDefines fDefines;
 

--- a/tree/dataframe/src/RFilterBase.cxx
+++ b/tree/dataframe/src/RFilterBase.cxx
@@ -17,9 +17,10 @@ using namespace ROOT::Detail::RDF;
 
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots,
                          const RDFInternal::RBookedDefines &defines)
-   : RNodeBase(implPtr), fLastResult(nSlots * RDFInternal::CacheLineStep<int>()),
+   : RNodeBase(implPtr), fLastCheckedEntry(std::vector<Long64_t>(nSlots * RDFInternal::CacheLineStep<Long64_t>(), -1)),
+     fLastResult(nSlots * RDFInternal::CacheLineStep<int>()),
      fAccepted(nSlots * RDFInternal::CacheLineStep<ULong64_t>()),
-     fRejected(nSlots * RDFInternal::CacheLineStep<ULong64_t>()), fName(name), fNSlots(nSlots), fDefines(defines)
+     fRejected(nSlots * RDFInternal::CacheLineStep<ULong64_t>()), fName(name), fDefines(defines)
 {
 }
 
@@ -47,7 +48,6 @@ void RFilterBase::FillReport(ROOT::RDF::RCutFlowReport &rep) const
 
 void RFilterBase::InitNode()
 {
-   fLastCheckedEntry = std::vector<Long64_t>(fNSlots * RDFInternal::CacheLineStep<Long64_t>(), -1);
    if (!fName.empty()) // if this is a named filter we care about its report count
       ResetReportCount();
 }


### PR DESCRIPTION
This PR is a refactoring.

RFilter does not need to keep fNSlots stored, it only requires the value
at construction time. fLastCheckedEntry can be reset per-slot in
InitSlot rather than being reallocated whenever InitNode is called.

This also uniforms the logic of RFilter and RDefine w.r.t. the
treatment of fLastCheckedEntry.