### PR TITLE
[Eve-7] Correction in client selection : handle case when eve elements are removed (e.g. loop events)

### DIFF
--- a/ui5/eve7/lib/EveManager.js
+++ b/ui5/eve7/lib/EveManager.js
@@ -606,11 +606,14 @@ sap.ui.define([], function() {
 
          for (let imp of value.implied)
          {
-            if (JSROOT.EVE.DebugSelection)
-               console.log("UnSel impl", imp, this.GetElement(imp), this.GetElement(imp).fSceneId);
+            let impEl = this.GetElement(imp);
+            if (impEl) {
+               if (JSROOT.EVE.DebugSelection)
+                  console.log("UnSel impl", imp, impEl, impEl.fSceneId);
 
-            this.UnselectElement(sel, imp);
-            changedSet.add(this.GetElement(imp).fSceneId);
+               this.UnselectElement(sel, imp);
+               changedSet.add(impEl.fSceneId);
+            }
          }
       }
 


### PR DESCRIPTION
Fix client error if event is switched while elements were previously selected.