### PR TITLE
[RF] Use range-based loops for RooLinkedList

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -48,8 +48,8 @@
 #pragma link C++ class RooAbsCollection+ ;
 #pragma read sourceClass="RooAbsCollection" targetClass="RooAbsCollection" version="[1]" source="" target="_allRRV" code="{ _allRRV=kFALSE ; }"
 #pragma read sourceClass="RooAbsCollection" targetClass="RooAbsCollection" version="[2]"\
-    source="RooLinkedList _list" target="_list" code="{ RooFIter iter = onfile._list.fwdIterator(); RooAbsArg * theArg;\
-    while ((theArg = iter.next())) {_list.push_back(theArg);} }"
+    source="RooLinkedList _list" target="_list" code="{ \
+    for (RooAbsArg * theArg : static_range_cast<RooAbsArg*>(onfile._list)) {_list.push_back(theArg);} }"
 #pragma link C++ class RooAbsData- ;
 #pragma link C++ class RooAbsFunc+ ;
 #pragma link C++ class RooAbsGenContext+ ;
@@ -202,8 +202,8 @@
 #pragma read sourceClass="RooRealVarSharedProperties" targetClass="RooRealVarSharedProperties" version="[1]" \
   include="RooLinkedList.h" \
   source="RooLinkedList _altBinning" target="_altBinning" \
-  code="{ RooFIter iter = onfile._altBinning.fwdIterator(); TObject* binning;\
-    while ( (binning = iter.next()) ) { _altBinning[binning->GetName()] = static_cast<RooAbsBinning*>(binning); } \
+  code="{ \
+    for (TObject * binning : onfile._altBinning) { _altBinning[binning->GetName()] = static_cast<RooAbsBinning*>(binning); } \
   }"
 #pragma link C++ class RooRefCountList+ ;
 #pragma link C++ class RooScaledFunc+ ;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1360,18 +1360,15 @@ void RooAbsCollection::printLatex(ostream& ofs, Int_t ncol, const char* option, 
   // Make list of lists ;
   RooLinkedList listList ;
   listList.Add((RooAbsArg*)this) ;
-  RooFIter sIter = siblingList.fwdIterator() ;
-  RooAbsCollection* col ;
-  while((col=(RooAbsCollection*)sIter.next())) {
+  for(auto * col : static_range_cast<RooAbsCollection*>(siblingList)) {
     listList.Add(col) ;
   }
 
   RooLinkedList listListRRV ;
 
   // Make list of RRV-only components
-  RooFIter lIter = listList.fwdIterator() ;
   RooArgList* prevList = 0 ;
-  while((col=(RooAbsCollection*)lIter.next())) {
+  for(auto * col : static_range_cast<RooAbsCollection*>(listList)) {
     RooArgList* list = new RooArgList ;
     RooFIter iter = col->fwdIterator() ;
     RooAbsArg* arg ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -1852,15 +1852,15 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
 
     // Loop over all categories provided by (multiple) Slice() arguments
     auto catTokens = ROOT::Split(sliceCatState, ",");
-    std::unique_ptr<TIterator> iter( sliceCatList.MakeIterator() );
+    auto iter = sliceCatList.begin();
     for (unsigned int i=0; i < catTokens.size(); ++i) {
-      auto scat = static_cast<RooCategory*>(iter->Next());
-      if (scat) {
+      if (auto scat = static_cast<RooCategory*>(*iter)) {
         // Set the slice position to the value indicate by slabel
         scat->setLabel(catTokens[i]) ;
         // Add the slice category to the master slice set
         sliceSet->add(*scat,kFALSE) ;
       }
+      ++iter;
     }
   }
 
@@ -2823,9 +2823,7 @@ RooPlot* RooAbsReal::plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, 
 
   // Strip any 'internal normalization' arguments from list
   RooLinkedList plotArgList ;
-  RooFIter iter = plotArgListTmp.fwdIterator() ;
-  RooCmdArg* cmd ;
-  while ((cmd=(RooCmdArg*)iter.next())) {
+  for (auto * cmd : static_range_cast<RooCmdArg*>(plotArgListTmp)) {
     if (std::string("Normalization")==cmd->GetName()) {
       if (((RooCmdArg*)cmd)->getInt(1)!=0) {
       } else {

--- a/roofit/roofitcore/src/RooAbsStudy.cxx
+++ b/roofit/roofitcore/src/RooAbsStudy.cxx
@@ -148,15 +148,9 @@ void RooAbsStudy::aggregateSummaryOutput(TList* chunkList)
       }
     }
 
-    RooLinkedList* dlist = dynamic_cast<RooLinkedList*>(obj) ;
-    if (dlist) {
+    if (auto dlist = dynamic_cast<RooLinkedList*>(obj)) {
       if (TString(dlist->GetName()).BeginsWith(Form("%s_detailed_data",GetName()))) {
-	//cout << "RooAbsStudy::aggregateSummaryOutput(" << GetName() << ") found detail block " <<dlist->GetName() << " with " << dlist->GetSize() << " entries" << endl ;
-	TIter diter = dlist->MakeIterator() ;
-	TNamed* dobj ;
-	while((dobj=(TNamed*)diter.Next())) {	  
-	  storeDetailedOutput(*dobj) ;
-	}
+        for(auto * dobj : static_range_cast<TNamed*>(*dlist)) storeDetailedOutput(*dobj) ;
       }
     }
   }

--- a/roofit/roofitcore/src/RooCategory.cxx
+++ b/roofit/roofitcore/src/RooCategory.cxx
@@ -492,8 +492,7 @@ void RooCategory::installLegacySharedProp(const RooCategorySharedProperties* pro
     auto& rangesMap = *_ranges;
 
     // Copy the data:
-    std::unique_ptr<TIterator> iter(props->_altRanges.MakeIterator());
-    while (TList* olist = (TList*)iter->Next()) {
+    for (auto * olist : static_range_cast<TList*>(props->_altRanges)) {
       std::vector<value_type>& vec = rangesMap[olist->GetName()];
 
 

--- a/roofit/roofitcore/src/RooErrorVar.cxx
+++ b/roofit/roofitcore/src/RooErrorVar.cxx
@@ -61,13 +61,7 @@ RooErrorVar::RooErrorVar(const RooErrorVar& other, const char* name) :
   _binning = other._binning->clone() ;
 
   // Copy constructor
-
-  TIterator* iter = other._altBinning.MakeIterator() ;
-  RooAbsBinning* binning ;
-  while((binning=(RooAbsBinning*)iter->Next())) {
-    _altBinning.Add(binning->clone()) ;
-  }
-  delete iter ;
+  for(auto * binning : static_range_cast<RooAbsBinning*>(other._altBinning)) _altBinning.Add(binning->clone());
 }
 
 
@@ -153,9 +147,7 @@ std::list<std::string> RooErrorVar::getBinningNames() const
 {
   std::list<std::string> binningNames(1, "");
 
-  RooFIter iter = _altBinning.fwdIterator();
-  const RooAbsArg* binning = 0;
-  while((binning = iter.next())) {
+  for(auto * binning : static_range_cast<RooAbsArg*>(_altBinning)) {
     const char* name = binning->GetName();
     binningNames.push_back(name);
   }

--- a/roofit/roofitcore/src/RooNumGenConfig.cxx
+++ b/roofit/roofitcore/src/RooNumGenConfig.cxx
@@ -119,14 +119,11 @@ RooNumGenConfig::RooNumGenConfig(const RooNumGenConfig& other) :
   _methodNDCondCat(other._methodNDCondCat)
 {
   // Clone all configuration dat
-  TIterator* iter = other._configSets.MakeIterator() ;
-  RooArgSet* set ;
-  while((set=(RooArgSet*)iter->Next())) {
+  for (auto * set : static_range_cast<RooArgSet*>(other._configSets)) {
     RooArgSet* setCopy = (RooArgSet*) set->snapshot() ;
     setCopy->setName(set->GetName()) ;
    _configSets.Add(setCopy);
   }
-  delete iter ;
 }
 
 
@@ -160,14 +157,11 @@ RooNumGenConfig& RooNumGenConfig::operator=(const RooNumGenConfig& other)
   _configSets.Delete() ;
 
   // Copy new integrator-specific data
-  TIterator* iter = other._configSets.MakeIterator() ;
-  RooArgSet* set ;
-  while((set=(RooArgSet*)iter->Next())) {
+  for(auto * set : static_range_cast<RooArgSet*>(other._configSets)) {
     RooArgSet* setCopy = (RooArgSet*) set->snapshot() ;
     setCopy->setName(set->GetName()) ;
    _configSets.Add(setCopy);
   }
-  delete iter ;
 
   return *this ;
 }
@@ -368,9 +362,7 @@ void RooNumGenConfig::printMultiline(ostream &os, Int_t /*content*/, Bool_t verb
   if (verbose) {
 
     os << endl << "Available sampling methods:" << endl << endl ;
-    TIterator* cIter = _configSets.MakeIterator() ;
-    RooArgSet* configSet ;
-    while ((configSet=(RooArgSet*)cIter->Next())) {
+    for(auto * configSet : static_range_cast<RooArgSet*>(_configSets)) {
 
       os << indent << "*** " << configSet->GetName() << " ***" << endl ;
       os << indent << "Capabilities: " ;
@@ -384,7 +376,5 @@ void RooNumGenConfig::printMultiline(ostream &os, Int_t /*content*/, Bool_t verb
       os << endl ;
 
     }
-
-    delete cIter ;
   }
 }

--- a/roofit/roofitcore/src/RooNumIntConfig.cxx
+++ b/roofit/roofitcore/src/RooNumIntConfig.cxx
@@ -117,14 +117,11 @@ RooNumIntConfig::RooNumIntConfig(const RooNumIntConfig& other) :
   _methodNDOpen(other._methodNDOpen)
 {
   // Clone all configuration dat
-  TIterator* iter = other._configSets.MakeIterator() ;
-  RooArgSet* set ;
-  while((set=(RooArgSet*)iter->Next())) {
+  for(auto * set : static_range_cast<RooArgSet*>(other._configSets)) {
     RooArgSet* setCopy = (RooArgSet*) set->snapshot() ;
     setCopy->setName(set->GetName()) ;
    _configSets.Add(setCopy);
   }
-  delete iter ;
 }
 
 
@@ -152,14 +149,11 @@ RooNumIntConfig& RooNumIntConfig::operator=(const RooNumIntConfig& other)
   _configSets.Delete() ;
 
   // Copy new integrator-specific data
-  TIterator* iter = other._configSets.MakeIterator() ;
-  RooArgSet* set ;
-  while((set=(RooArgSet*)iter->Next())) {
+  for(auto * set : static_range_cast<RooArgSet*>(other._configSets)) {
     RooArgSet* setCopy = (RooArgSet*) set->snapshot() ;
     setCopy->setName(set->GetName()) ;
    _configSets.Add(setCopy);
   }
-  delete iter ;
 
   return *this ;
 }
@@ -308,9 +302,7 @@ void RooNumIntConfig::printMultiline(ostream &os, Int_t /*content*/, Bool_t verb
   if (verbose) {
 
     os << endl << "Available integration methods:" << endl << endl ;
-    TIterator* cIter = _configSets.MakeIterator() ;
-    RooArgSet* configSet ;
-    while ((configSet=(RooArgSet*)cIter->Next())) {
+    for(auto * configSet : static_range_cast<RooArgSet*>(_configSets)) {
 
       os << indent << "*** " << configSet->GetName() << " ***" << endl ;
       os << indent << "Capabilities: " ;
@@ -332,7 +324,5 @@ void RooNumIntConfig::printMultiline(ostream &os, Int_t /*content*/, Bool_t verb
       os << endl ;
 
     }
-
-    delete cIter ;
   }
 }

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -640,10 +640,8 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
     auto catTokens = ROOT::Split(sliceCatState, ",");
 
     // Loop over all categories provided by (multiple) Slice() arguments
-    TIterator* iter = sliceCatList.MakeIterator() ;
-    RooCategory* scat ;
     unsigned int tokenIndex = 0;
-    while((scat=(RooCategory*)iter->Next())) {
+    for(auto * scat : static_range_cast<RooCategory*>(sliceCatList)) {
       const char* slabel = tokenIndex >= catTokens.size() ? nullptr : catTokens[tokenIndex++].c_str();
 
       if (slabel) {
@@ -653,7 +651,6 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
         sliceSet->add(*scat,kFALSE) ;
       }
     }
-    delete iter ;
   }
 
   // Check if we have a projection dataset

--- a/roofit/roostats/src/ToyMCStudy.cxx
+++ b/roofit/roostats/src/ToyMCStudy.cxx
@@ -107,10 +107,8 @@ RooDataSet* ToyMCStudy::merge() {
       return NULL;
    }
 
-   RooLinkedListIter iter = detailedData()->iterator();
-   TObject *o = NULL;
    int i = 0;
-   while((o = iter.Next())) {
+   for (auto * o : static_range_cast<TObject*>(*detailedData())) {
       ToyMCPayload *oneWorker = dynamic_cast< ToyMCPayload* >(o);
       if(!oneWorker) {
          coutW(Generation) << "Merging Results problem: not correct type" << endl;


### PR DESCRIPTION
This is a followup to commit 2f7936a, using range-based loops or at
least the `begin()` and `end()` member functions for RooLinkedLists
everywhere in RooFit/RooStats.

This is not an important update but just a small technical change, which I found in some of my older development branches but forgot to open a PR so far.