### PR TITLE
[NFC] Add Jakob as owner of tree/ntuple/v7

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@
 /tree/ @pcanal
 /tutorials/ @couet
 /tree/dataframe @eguiraud
+/tree/ntuple/v7/ @jblomer
 
 # Projects that span over several code modules:
 /bindings/r/ @omazapa


### PR DESCRIPTION
Just noticed that opening a PR against these files added Philippe as a reviewer automatically but not Jakob.