### PR TITLE
Silence compilation warnings on Windows 64 bit

### DIFF
--- a/cmake/modules/SetUpWindows.cmake
+++ b/cmake/modules/SetUpWindows.cmake
@@ -19,7 +19,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 
 elseif(MSVC)
   if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")
-    set(ARCH -D_WIN64)
+    set(ARCH "-wd4267 -D_WIN64")
     set(ROOT_ARCHITECTURE win64)
   else()
     set(ROOT_ARCHITECTURE win32)


### PR DESCRIPTION
Silence a zillion of compilation warnings like:
```
warning C4267: 'initializing': conversion from 'size_t' to 'UInt_t', possible loss of data
```
From Microsoft:
Compiler Warning (level 3) C4267
'var' : conversion from 'size_t' to 'type', possible loss of data
The compiler detected a conversion from size_t to a smaller type.
To fix this warning, use size_t instead of type. Alternatively, use an integral type that is at least as large as size_t.
(size_t is unsigned __int64 or unsigned integer, depending on the target platform)
