### PR TITLE
[DF] Avoid calling InitSlot/FinaliseSlot multiple times on RDefines

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -432,20 +432,18 @@ struct RDefinePerSampleTag {};
 
 template <typename F>
 auto MakeDefineNode(DefineTypes::RDefineTag, std::string_view name, std::string_view dummyType, F &&f,
-                    const ColumnNames_t &cols, unsigned int nSlots, RBookedDefines &defines,
-                    const std::map<std::string, std::vector<void *>> &dsValuePtrs, RDataSource *ds)
+                    const ColumnNames_t &cols, RBookedDefines &defines, RLoopManager &lm)
 {
-   return std::unique_ptr<RDefineBase>(new RDefine<std::decay_t<F>, CustomColExtraArgs::None>(
-      name, dummyType, std::forward<F>(f), cols, nSlots, defines, dsValuePtrs, ds));
+   return std::unique_ptr<RDefineBase>(
+      new RDefine<std::decay_t<F>, CustomColExtraArgs::None>(name, dummyType, std::forward<F>(f), cols, defines, lm));
 }
 
 template <typename F>
 auto MakeDefineNode(DefineTypes::RDefinePerSampleTag, std::string_view name, std::string_view dummyType, F &&f,
-                    const ColumnNames_t &, unsigned int nSlots, RBookedDefines &,
-                    const std::map<std::string, std::vector<void *>> &, RDataSource *)
+                    const ColumnNames_t &, RBookedDefines &, RLoopManager &lm)
 {
    return std::unique_ptr<RDefineBase>(
-      new RDefinePerSample<std::decay_t<F>>(name, dummyType, std::forward<F>(f), nSlots));
+      new RDefinePerSample<std::decay_t<F>>(name, dummyType, std::forward<F>(f), lm));
 }
 
 // Build a RDefine or a RDefinePerSample object and attach it to an existing RJittedDefine
@@ -483,8 +481,8 @@ void JitDefineHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::str
    // to help devs debugging
    const auto dummyType = "jittedCol_t";
    // use unique_ptr<RDefineBase> instead of make_unique<NewCol_t> to reduce jit/compile-times
-   std::unique_ptr<RDefineBase> newCol{MakeDefineNode(RDefineTypeTag{}, name, dummyType, std::forward<F>(f), cols,
-                                                      lm->GetNSlots(), *defines, lm->GetDSValuePtrs(), ds)};
+   std::unique_ptr<RDefineBase> newCol{
+      MakeDefineNode(RDefineTypeTag{}, name, dummyType, std::forward<F>(f), cols, *defines, *lm)};
    jittedDefine->SetDefine(std::move(newCol));
 
    // defines points to the columns structure in the heap, created before the jitted call so that the jitter can

--- a/tree/dataframe/inc/ROOT/RDF/RBookedDefines.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RBookedDefines.hxx
@@ -100,6 +100,11 @@ public:
    /// in each branch of the computation graph.
    /// Internally it recreates the vector with the new name, and swaps it with the old one.
    void AddName(std::string_view name);
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Empty the contents of this ledger.
+   /// The only allowed operation on a RBookedDefines object after a call to Clear is its destruction.
+   void Clear();
 };
 
 } // Namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -110,15 +110,10 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      if (!fIsInitialized[slot]) {
-         for (auto &define : fDefines.GetColumns())
-            define.second->InitSlot(r, slot);
-         fIsInitialized[slot] = true;
-         RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
-                                              fLoopManager->GetDataSource()};
-         fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
-         fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
-      }
+      RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
+                                           fLoopManager->GetDataSource()};
+      fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
+      fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
    }
 
    /// Return the (type-erased) address of the Define'd value for the given processing slot.
@@ -144,11 +139,8 @@ public:
    /// Clean-up operations to be performed at the end of a task.
    void FinaliseSlot(unsigned int slot) final
    {
-      if (fIsInitialized[slot]) {
-         for (auto &v : fValues[slot])
-            v.reset();
-         fIsInitialized[slot] = false;
-      }
+      for (auto &v : fValues[slot])
+         v.reset();
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -42,7 +42,6 @@ protected:
    const std::string fType; ///< The type of the custom column as a text string
    std::vector<Long64_t> fLastCheckedEntry;
    RDFInternal::RBookedDefines fDefines;
-   std::deque<bool> fIsInitialized; // because vector<bool> is not thread-safe
    RLoopManager *fLoopManager; // non-owning pointer to the RLoopManager
    const ROOT::RDF::ColumnNames_t fColumnNames;
    /// The nth flag signals whether the nth input column is a custom column or not.

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -32,6 +32,8 @@ class RDataSource;
 namespace Detail {
 namespace RDF {
 
+class RLoopManager;
+
 namespace RDFInternal = ROOT::Internal::RDF;
 
 class RDefineBase {
@@ -41,17 +43,14 @@ protected:
    std::vector<Long64_t> fLastCheckedEntry;
    RDFInternal::RBookedDefines fDefines;
    std::deque<bool> fIsInitialized; // because vector<bool> is not thread-safe
-   const std::map<std::string, std::vector<void *>> &fDSValuePtrs; // reference to RLoopManager's data member
-   ROOT::RDF::RDataSource *fDataSource; ///< non-owning ptr to the RDataSource, if any. Used to retrieve column readers.
+   RLoopManager *fLoopManager; // non-owning pointer to the RLoopManager
    const ROOT::RDF::ColumnNames_t fColumnNames;
    /// The nth flag signals whether the nth input column is a custom column or not.
    ROOT::RVecB fIsDefine;
 
 public:
-   RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
-               const RDFInternal::RBookedDefines &defines,
-               const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds,
-               const ColumnNames_t &columnNames);
+   RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RBookedDefines &defines,
+               RLoopManager &lm, const ColumnNames_t &columnNames);
 
    RDefineBase &operator=(const RDefineBase &) = delete;
    RDefineBase &operator=(RDefineBase &&) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -11,6 +11,7 @@
 #ifndef ROOT_RDF_RDEFINEPERSAMPLE
 #define ROOT_RDF_RDEFINEPERSAMPLE
 
+#include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include <ROOT/RDF/RDefineBase.hxx>
@@ -37,9 +38,9 @@ class R__CLING_PTRCHECK(off) RDefinePerSample final : public RDefineBase {
    ValuesPerSlot_t fLastResults;
 
 public:
-   RDefinePerSample(std::string_view name, std::string_view type, F expression, unsigned int nSlots)
-      : RDefineBase(name, type, nSlots, /*defines*/ {}, /*DSValuePtrs*/ {}, /*ds*/ nullptr, /*columnNames*/ {}),
-        fExpression(std::move(expression)), fLastResults(nSlots * RDFInternal::CacheLineStep<RetType_t>())
+   RDefinePerSample(std::string_view name, std::string_view type, F expression, RLoopManager &lm)
+      : RDefineBase(name, type, /*defines*/ {}, lm, /*columnNames*/ {}), fExpression(std::move(expression)),
+        fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<RetType_t>())
    {
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -389,6 +389,7 @@ public:
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fDefines,
                                                      fLoopManager->GetBranchNames(), upcastNodeOnHeap);
+      fLoopManager->Book(jittedDefine.get());
 
       RDFInternal::RBookedDefines newCols(fDefines);
       newCols.AddColumn(jittedDefine, name);
@@ -479,6 +480,7 @@ public:
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fDefines,
                                                      fLoopManager->GetBranchNames(), upcastNodeOnHeap);
+      fLoopManager->Book(jittedDefine.get());
 
       RDFInternal::RBookedDefines newCols(fDefines);
       newCols.AddColumn(jittedDefine, name);
@@ -2809,9 +2811,9 @@ private:
       }
 
       using NewCol_t = RDFDetail::RDefine<F, DefineType>;
-      auto newColumn =
-         std::make_shared<NewCol_t>(name, retTypeName, std::forward<F>(expression), validColumnNames,
-                                    fDefines, *fLoopManager);
+      auto newColumn = std::make_shared<NewCol_t>(name, retTypeName, std::forward<F>(expression), validColumnNames,
+                                                  fDefines, *fLoopManager);
+      fLoopManager->Book(newColumn.get());
 
       RDFInternal::RBookedDefines newCols(fDefines);
       newCols.AddColumn(newColumn, name);

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -530,8 +530,8 @@ public:
          retTypeName = "CLING_UNKNOWN_TYPE_" + demangledType;
       }
 
-      auto newColumn = std::make_shared<RDFDetail::RDefinePerSample<F>>(name, retTypeName, std::move(expression),
-                                                                        fLoopManager->GetNSlots());
+      auto newColumn =
+         std::make_shared<RDFDetail::RDefinePerSample<F>>(name, retTypeName, std::move(expression), *fLoopManager);
 
       auto updateDefinePerSample = [newColumn](unsigned int slot, const ROOT::RDF::RSampleInfo &id) {
          newColumn->Update(slot, id);
@@ -2674,8 +2674,7 @@ private:
       using NewColEntry_t = RDFDetail::RDefine<decltype(entryColGen), RDFDetail::CustomColExtraArgs::SlotAndEntry>;
 
       auto entryColumn = std::make_shared<NewColEntry_t>(entryColName, entryColType, std::move(entryColGen),
-                                                         ColumnNames_t{}, fLoopManager->GetNSlots(), newCols,
-                                                         fLoopManager->GetDSValuePtrs(), fDataSource);
+                                                         ColumnNames_t{}, newCols, *fLoopManager);
       newCols.AddColumn(entryColumn, entryColName);
 
       // Slot number column
@@ -2685,8 +2684,7 @@ private:
       using NewColSlot_t = RDFDetail::RDefine<decltype(slotColGen), RDFDetail::CustomColExtraArgs::Slot>;
 
       auto slotColumn = std::make_shared<NewColSlot_t>(slotColName, slotColType, std::move(slotColGen), ColumnNames_t{},
-                                                       fLoopManager->GetNSlots(), newCols,
-                                                       fLoopManager->GetDSValuePtrs(), fDataSource);
+                                                       newCols, *fLoopManager);
       newCols.AddColumn(slotColumn, slotColName);
 
       fDefines = std::move(newCols);
@@ -2813,7 +2811,7 @@ private:
       using NewCol_t = RDFDetail::RDefine<F, DefineType>;
       auto newColumn =
          std::make_shared<NewCol_t>(name, retTypeName, std::forward<F>(expression), validColumnNames,
-                                    fLoopManager->GetNSlots(), fDefines, fLoopManager->GetDSValuePtrs(), fDataSource);
+                                    fDefines, *fLoopManager);
 
       RDFInternal::RBookedDefines newCols(fDefines);
       newCols.AddColumn(newColumn, name);

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -37,6 +37,7 @@ public:
       : RDefineBase(name, type, RDFInternal::RBookedDefines(), lm, /* columnNames */ {})
    {
    }
+   ~RJittedDefine();
 
    void SetDefine(std::unique_ptr<RDefineBase> c) { fConcreteDefine = std::move(c); }
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -33,9 +33,8 @@ class RJittedDefine : public RDefineBase {
    std::unique_ptr<RDefineBase> fConcreteDefine = nullptr;
 
 public:
-   RJittedDefine(std::string_view name, std::string_view type, unsigned int nSlots,
-                       const std::map<std::string, std::vector<void *>> &DSValuePtrs)
-      : RDefineBase(name, type, nSlots, RDFInternal::RBookedDefines(), DSValuePtrs, nullptr, /* columnNames */ {})
+   RJittedDefine(std::string_view name, std::string_view type, RLoopManager &lm)
+      : RDefineBase(name, type, RDFInternal::RBookedDefines(), lm, /* columnNames */ {})
    {
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -92,6 +92,7 @@ namespace RDFInternal = ROOT::Internal::RDF;
 
 class RFilterBase;
 class RRangeBase;
+class RDefineBase;
 using ROOT::RDF::RDataSource;
 
 /// The head node of a RDF computation graph.
@@ -107,6 +108,7 @@ class RLoopManager : public RNodeBase {
    std::vector<RFilterBase *> fBookedFilters;
    std::vector<RFilterBase *> fBookedNamedFilters; ///< Contains a subset of fBookedFilters, i.e. only the named filters
    std::vector<RRangeBase *> fBookedRanges;
+   std::vector<RDefineBase *> fBookedDefines;
 
    /// Shared pointer to the input TTree. It does not delete the pointee if the TTree/TChain was passed directly as an
    /// argument to RDataFrame's ctor (in which case we let users retain ownership).
@@ -172,6 +174,8 @@ public:
    void Deregister(RFilterBase *filterPtr);
    void Book(RRangeBase *rangePtr);
    void Deregister(RRangeBase *rangePtr);
+   void Book(RDefineBase *definePtr);
+   void Deregister(RDefineBase *definePtr);
    bool CheckFilters(unsigned int, Long64_t) final;
    unsigned int GetNSlots() const { return fNSlots; }
    void Report(ROOT::RDF::RCutFlowReport &rep) const final;

--- a/tree/dataframe/src/RDFBookedDefines.cxx
+++ b/tree/dataframe/src/RDFBookedDefines.cxx
@@ -38,6 +38,11 @@ void RBookedDefines::AddName(std::string_view name)
    fDefinesNames = newColsNames;
 }
 
+void RBookedDefines::Clear() {
+   fDefines.reset();
+   fDefinesNames.reset();
+}
+
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -685,7 +685,7 @@ std::shared_ptr<RJittedDefine> BookDefineJit(std::string_view name, std::string_
 
    auto definesCopy = new RBookedDefines(customCols);
    auto definesAddr = PrettyPrintAddr(definesCopy);
-   auto jittedDefine = std::make_shared<RDFDetail::RJittedDefine>(name, type, lm.GetNSlots(), lm.GetDSValuePtrs());
+   auto jittedDefine = std::make_shared<RDFDetail::RJittedDefine>(name, type, lm);
 
    std::stringstream defineInvocation;
    defineInvocation << "ROOT::Internal::RDF::JitDefineHelper<ROOT::Internal::RDF::DefineTypes::RDefineTag>("
@@ -722,7 +722,7 @@ std::shared_ptr<RJittedDefine> BookDefinePerSampleJit(std::string_view name, std
 
    auto definesCopy = new RBookedDefines(customCols);
    auto definesAddr = PrettyPrintAddr(definesCopy);
-   auto jittedDefine = std::make_shared<RDFDetail::RJittedDefine>(name, retType, lm.GetNSlots(), lm.GetDSValuePtrs());
+   auto jittedDefine = std::make_shared<RDFDetail::RJittedDefine>(name, retType, lm);
 
    std::stringstream defineInvocation;
    defineInvocation << "ROOT::Internal::RDF::JitDefineHelper<ROOT::Internal::RDF::DefineTypes::RDefinePerSampleTag>("

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -22,7 +22,7 @@ using ROOT::Detail::RDF::RDefineBase;
 namespace RDFInternal = ROOT::Internal::RDF; // redundant (already present in the header), but Windows needs it
 
 RDefineBase::RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RBookedDefines &defines,
-                         RLoopManager &lm, const ROOT::RDF::ColumnNames_t &columnNames)
+                         ROOT::Detail::RDF::RLoopManager &lm, const ROOT::RDF::ColumnNames_t &columnNames)
    : fName(name), fType(type), fLastCheckedEntry(lm.GetNSlots() * RDFInternal::CacheLineStep<Long64_t>(), -1),
      fDefines(defines), fLoopManager(&lm), fColumnNames(columnNames), fIsDefine(columnNames.size())
 {

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -21,12 +21,10 @@
 using ROOT::Detail::RDF::RDefineBase;
 namespace RDFInternal = ROOT::Internal::RDF; // redundant (already present in the header), but Windows needs it
 
-RDefineBase::RDefineBase(std::string_view name, std::string_view type,
-                         const RDFInternal::RBookedDefines &defines, RLoopManager &lm,
-                         const ROOT::RDF::ColumnNames_t &columnNames)
+RDefineBase::RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RBookedDefines &defines,
+                         RLoopManager &lm, const ROOT::RDF::ColumnNames_t &columnNames)
    : fName(name), fType(type), fLastCheckedEntry(lm.GetNSlots() * RDFInternal::CacheLineStep<Long64_t>(), -1),
-     fDefines(defines), fIsInitialized(lm.GetNSlots(), false), fLoopManager(&lm), fColumnNames(columnNames),
-     fIsDefine(columnNames.size())
+     fDefines(defines), fLoopManager(&lm), fColumnNames(columnNames), fIsDefine(columnNames.size())
 {
    const auto nColumns = fColumnNames.size();
    for (auto i = 0u; i < nColumns; ++i)
@@ -34,7 +32,7 @@ RDefineBase::RDefineBase(std::string_view name, std::string_view type,
 }
 
 // pin vtable. Work around cling JIT issue.
-RDefineBase::~RDefineBase() {}
+RDefineBase::~RDefineBase() { fLoopManager->Deregister(this); }
 
 std::string RDefineBase::GetName() const
 {

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -9,6 +9,7 @@
  *************************************************************************/
 
 #include "ROOT/RDF/RDefineBase.hxx"
+#include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RStringView.hxx"
 #include "RtypesCore.h" // Long64_t
@@ -20,13 +21,12 @@
 using ROOT::Detail::RDF::RDefineBase;
 namespace RDFInternal = ROOT::Internal::RDF; // redundant (already present in the header), but Windows needs it
 
-RDefineBase::RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
-                         const RDFInternal::RBookedDefines &defines,
-                         const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds,
+RDefineBase::RDefineBase(std::string_view name, std::string_view type,
+                         const RDFInternal::RBookedDefines &defines, RLoopManager &lm,
                          const ROOT::RDF::ColumnNames_t &columnNames)
-   : fName(name), fType(type), fLastCheckedEntry(nSlots * RDFInternal::CacheLineStep<Long64_t>(), -1),
-     fDefines(defines), fIsInitialized(nSlots, false), fDSValuePtrs(DSValuePtrs), fDataSource(ds),
-     fColumnNames(columnNames), fIsDefine(columnNames.size())
+   : fName(name), fType(type), fLastCheckedEntry(lm.GetNSlots() * RDFInternal::CacheLineStep<Long64_t>(), -1),
+     fDefines(defines), fIsInitialized(lm.GetNSlots(), false), fLoopManager(&lm), fColumnNames(columnNames),
+     fIsDefine(columnNames.size())
 {
    const auto nColumns = fColumnNames.size();
    for (auto i = 0u; i < nColumns; ++i)

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -9,10 +9,16 @@
  *************************************************************************/
 
 #include <ROOT/RDF/RJittedDefine.hxx>
+#include <ROOT/RDF/RLoopManager.hxx>
 
 #include <cassert>
 
 using namespace ROOT::Detail::RDF;
+
+RJittedDefine::~RJittedDefine()
+{
+   fLoopManager->Deregister(this);
+}
 
 void RJittedDefine::InitSlot(TTreeReader *r, unsigned int slot)
 {

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -11,6 +11,7 @@
 #include "ROOT/RDF/GraphNode.hxx"
 #include "ROOT/InternalTreeUtils.hxx" // GetTreeFullPaths
 #include "ROOT/RDF/RActionBase.hxx"
+#include "ROOT/RDF/RDefineBase.hxx"
 #include "ROOT/RDF/RFilterBase.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RRangeBase.hxx"
@@ -601,6 +602,8 @@ void RLoopManager::InitNodeSlots(TTreeReader *r, unsigned int slot)
       ptr->InitSlot(r, slot);
    for (auto &ptr : fBookedFilters)
       ptr->InitSlot(r, slot);
+   for (auto &ptr : fBookedDefines)
+      ptr->InitSlot(r, slot);
    for (auto &callback : fCallbacksOnce)
       callback(slot);
 }
@@ -690,6 +693,8 @@ void RLoopManager::CleanUpTask(TTreeReader *r, unsigned int slot)
    for (auto &ptr : fBookedActions)
       ptr->FinalizeSlot(slot);
    for (auto &ptr : fBookedFilters)
+      ptr->FinaliseSlot(slot);
+   for (auto &ptr : fBookedDefines)
       ptr->FinaliseSlot(slot);
 }
 
@@ -808,6 +813,16 @@ void RLoopManager::Book(RRangeBase *rangePtr)
 void RLoopManager::Deregister(RRangeBase *rangePtr)
 {
    RDFInternal::Erase(rangePtr, fBookedRanges);
+}
+
+void RLoopManager::Book(RDefineBase *ptr)
+{
+   fBookedDefines.emplace_back(ptr);
+}
+
+void RLoopManager::Deregister(RDefineBase *ptr)
+{
+   RDFInternal::Erase(ptr, fBookedDefines);
 }
 
 // dummy call, end of recursive chain of calls


### PR DESCRIPTION
Before this commit, each action and filter was calling InitSlot on all
the defines it knew about. As a consequence, RDefine had to keep track
of whether InitSlot was already called on it for a given task and a
given slot.

We can avoid the multiple InitSlot calls on the same objects and the
book-keeping of whether the call already happened or not by having
RLoopManager call InitSlot on every defined column once per task and per
slot. To this end, we need to register RDefine objects with the
RLoopManager when they are created and deregister them when they are
destroyed.

This makes treatment of Define's `InitSlot` calls uniform with those of Filters and Actions. Systematic variations will look a lot like Defines and we want to treat everything uniformly.
