### PR TITLE
[DF][Fix root-project#9116] Display pretty Print and AsString

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -198,6 +198,10 @@ private:
    size_t GetNColumnsToShorten() const;
 
    ////////////////////////////////////////////////////////////////////////////
+   /// Generate dashes between entries in Print() and AsString() Methods
+   std::string DashesBetweenLines(size_t lastColToPrint, bool allColumnsFit) const;
+
+   ////////////////////////////////////////////////////////////////////////////
    /// Adds a row of events to the table
    template <typename... Columns>
    void AddRow(Columns &... columns)

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2594,11 +2594,12 @@ public:
    RResultPtr<RDisplay>
    Display(const ColumnNames_t &columnList, int nRows = 5, size_t nMaxCollectionElements = 10)
    {
-      CheckIMTDisabled("Display");
-
-      auto displayer = std::make_shared<RDFInternal::RDisplay>(columnList, GetColumnTypeNamesList(columnList), nRows,
-                                                               nMaxCollectionElements);
-      return CreateAction<RDFInternal::ActionTags::Display, ColumnTypes...>(columnList, displayer, displayer);
+      CheckIMTDisabled("Display");  
+      auto newCols = columnList;
+      newCols.insert(newCols.begin(), "rdfentry_"); // Artificially insert first column
+      auto displayer = std::make_shared<RDFInternal::RDisplay>(newCols, GetColumnTypeNamesList(newCols), nRows, nMaxCollectionElements);
+      // Need to add ULong64_t type corresponding to the first column rdfentry_
+      return CreateAction<RDFInternal::ActionTags::Display, ULong64_t, ColumnTypes...>(newCols, displayer, displayer);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -2610,14 +2611,17 @@ public:
    ///
    /// This overload automatically infers the column types.
    /// See the previous overloads for further details.
+   ///
+   /// Invoked when no types are specified to Display
    RResultPtr<RDisplay>
    Display(const ColumnNames_t &columnList, int nRows = 5, size_t nMaxCollectionElements = 10)
    {
       CheckIMTDisabled("Display");
-      auto displayer = std::make_shared<RDFInternal::RDisplay>(columnList, GetColumnTypeNamesList(columnList), nRows,
-                                                               nMaxCollectionElements);
-      return CreateAction<RDFInternal::ActionTags::Display, RDFDetail::RInferredType>(columnList, displayer, displayer,
-                                                                                      columnList.size());
+      auto newCols = columnList;
+      newCols.insert(newCols.begin(), "rdfentry_"); // Artificially insert first column
+      auto displayer = std::make_shared<RDFInternal::RDisplay>(newCols, GetColumnTypeNamesList(newCols), nRows, nMaxCollectionElements);
+      return CreateAction<RDFInternal::ActionTags::Display, RDFDetail::RInferredType>(newCols, displayer, displayer,
+                                                                                      newCols.size());
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/test/dataframe_display.cxx
+++ b/tree/dataframe/test/dataframe_display.cxx
@@ -9,17 +9,56 @@ using namespace ROOT;
 using namespace ROOT::RDF;
 using namespace ROOT::VecOps;
 
-static const std::string DisplayPrintDefaultRows(
-   "b1 | b2 | b3        | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | "
-   "2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n "
-   "  | 3  |           | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | "
-   "2.0000000 | \n   | 2  |           | \n   | 3  |           | \n");
+static const std::string DisplayPrintDefaultRows("+-----+----+----+-----------+\n"
+                                                 "| Row | b1 | b2 | b3        | \n"
+                                                 "+-----+----+----+-----------+\n"
+                                                 "| 0   | 0  | 1  | 2.0000000 | \n"
+                                                 "|     |    | 2  |           | \n"
+                                                 "|     |    | 3  |           | \n"
+                                                 "+-----+----+----+-----------+\n"
+                                                 "| 1   | 0  | 1  | 2.0000000 | \n"
+                                                 "|     |    | 2  |           | \n"
+                                                 "|     |    | 3  |           | \n"
+                                                 "+-----+----+----+-----------+\n"
+                                                 "| 2   | 0  | 1  | 2.0000000 | \n"
+                                                 "|     |    | 2  |           | \n"
+                                                 "|     |    | 3  |           | \n"
+                                                 "+-----+----+----+-----------+\n"
+                                                 "| 3   | 0  | 1  | 2.0000000 | \n"
+                                                 "|     |    | 2  |           | \n"
+                                                 "|     |    | 3  |           | \n"
+                                                 "+-----+----+----+-----------+\n"
+                                                 "| 4   | 0  | 1  | 2.0000000 | \n"
+                                                 "|     |    | 2  |           | \n"
+                                                 "|     |    | 3  |           | \n"
+                                                 "+-----+----+----+-----------+\n"
+);
 
-static const std::string DisplayAsStringDefaultRows(
-   "b1 | b2 | b3        | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | "
-   "2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n "
-   "  | 3  |           | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | "
-   "2.0000000 | \n   | 2  |           | \n   | 3  |           | \n   |    |           | \n");
+static const std::string DisplayAsStringDefaultRows("+-----+----+----+-----------+\n"
+                                                    "| Row | b1 | b2 | b3        | \n"
+                                                    "+-----+----+----+-----------+\n"
+                                                    "| 0   | 0  | 1  | 2.0000000 | \n"
+                                                    "|     |    | 2  |           | \n"
+                                                    "|     |    | 3  |           | \n"
+                                                    "+-----+----+----+-----------+\n"
+                                                    "| 1   | 0  | 1  | 2.0000000 | \n"
+                                                    "|     |    | 2  |           | \n"
+                                                    "|     |    | 3  |           | \n"
+                                                    "+-----+----+----+-----------+\n"
+                                                    "| 2   | 0  | 1  | 2.0000000 | \n"
+                                                    "|     |    | 2  |           | \n"
+                                                    "|     |    | 3  |           | \n"
+                                                    "+-----+----+----+-----------+\n"
+                                                    "| 3   | 0  | 1  | 2.0000000 | \n"
+                                                    "|     |    | 2  |           | \n"
+                                                    "|     |    | 3  |           | \n"
+                                                    "+-----+----+----+-----------+\n"
+                                                    "| 4   | 0  | 1  | 2.0000000 | \n"
+                                                    "|     |    | 2  |           | \n"
+                                                    "|     |    | 3  |           | \n"
+                                                    "|     |    |    |           | \n"
+                                                    "+-----+----+----+-----------+\n"
+);
 
 TEST(RDFDisplayTests, DisplayNoJitDefaultRows)
 {
@@ -102,13 +141,30 @@ TEST(RDFDisplayTests, DisplayRegexDefaultRows)
    EXPECT_EQ(dd->AsString(), DisplayAsStringDefaultRows);
 }
 
-static const std::string
-   DisplayPrintTwoRows("b1 | b2 | b3        | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |          "
-                       " | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |           | \n");
+static const std::string DisplayPrintTwoRows("+-----+----+----+-----------+\n"
+                                             "| Row | b1 | b2 | b3        | \n"
+                                             "+-----+----+----+-----------+\n"
+                                             "| 0   | 0  | 1  | 2.0000000 | \n"
+                                             "|     |    | 2  |           | \n"
+                                             "|     |    | 3  |           | \n"
+                                             "+-----+----+----+-----------+\n"
+                                             "| 1   | 0  | 1  | 2.0000000 | \n"
+                                             "|     |    | 2  |           | \n"
+                                             "|     |    | 3  |           | \n"
+                                             "+-----+----+----+-----------+\n");
 
-static const std::string DisplayAsStringTwoRows(
-   "b1 | b2 | b3        | \n0  | 1  | 2.0000000 | \n   | 2  |           | \n   | 3  |           | \n0  | 1  | "
-   "2.0000000 | \n   | 2  |           | \n   | 3  |           | \n   |    |           | \n");
+static const std::string DisplayAsStringTwoRows("+-----+----+----+-----------+\n"
+                                                "| Row | b1 | b2 | b3        | \n"
+                                                "+-----+----+----+-----------+\n"
+                                                "| 0   | 0  | 1  | 2.0000000 | \n"
+                                                "|     |    | 2  |           | \n"
+                                                "|     |    | 3  |           | \n"
+                                                "+-----+----+----+-----------+\n"
+                                                "| 1   | 0  | 1  | 2.0000000 | \n"
+                                                "|     |    | 2  |           | \n"
+                                                "|     |    | 3  |           | \n"
+                                                "|     |    |    |           | \n"
+                                                "+-----+----+----+-----------+\n");
 
 TEST(RDFDisplayTests, DisplayJitTwoRows)
 {
@@ -137,10 +193,44 @@ TEST(RDFDisplayTests, DisplayJitTwoRows)
    EXPECT_EQ(dd->AsString(), DisplayAsStringTwoRows);
 }
 
-static const std::string DisplayAsStringOneColumn("b1 | \n0  | \n0  | \n0  | \n0  | \n0  | \n   | \n");
-static const std::string DisplayAsStringTwoColumns(
-   "b1 | b2 | \n0  | 1  | \n   | 2  | \n   | 3  | \n0  | 1  | \n   | 2  | \n   | 3  | \n0  | 1  | \n   | 2  | "
-   "\n   | 3  | \n0  | 1  | \n   | 2  | \n   | 3  | \n0  | 1  | \n   | 2  | \n   | 3  | \n   |    | \n");
+static const std::string DisplayAsStringOneColumn("+-----+----+\n"
+                                                  "| Row | b1 | \n"
+                                                  "+-----+----+\n"
+                                                  "| 0   | 0  | \n"
+                                                  "+-----+----+\n"
+                                                  "| 1   | 0  | \n"
+                                                  "+-----+----+\n"
+                                                  "| 2   | 0  | \n"
+                                                  "+-----+----+\n"
+                                                  "| 3   | 0  | \n"
+                                                  "+-----+----+\n"
+                                                  "| 4   | 0  | \n"
+                                                  "|     |    | \n"
+                                                  "+-----+----+\n");
+static const std::string DisplayAsStringTwoColumns("+-----+----+----+\n"
+                                                   "| Row | b1 | b2 | \n"
+                                                   "+-----+----+----+\n"
+                                                   "| 0   | 0  | 1  | \n"
+                                                   "|     |    | 2  | \n"
+                                                   "|     |    | 3  | \n"
+                                                   "+-----+----+----+\n"
+                                                   "| 1   | 0  | 1  | \n"
+                                                   "|     |    | 2  | \n"
+                                                   "|     |    | 3  | \n"
+                                                   "+-----+----+----+\n"
+                                                   "| 2   | 0  | 1  | \n"
+                                                   "|     |    | 2  | \n"
+                                                   "|     |    | 3  | \n"
+                                                   "+-----+----+----+\n"
+                                                   "| 3   | 0  | 1  | \n"
+                                                   "|     |    | 2  | \n"
+                                                   "|     |    | 3  | \n"
+                                                   "+-----+----+----+\n"
+                                                   "| 4   | 0  | 1  | \n"
+                                                   "|     |    | 2  | \n"
+                                                   "|     |    | 3  | \n"
+                                                   "|     |    |    | \n"
+                                                   "+-----+----+----+\n");
 
 TEST(RDFDisplayTests, DisplayAmbiguity)
 {
@@ -156,7 +246,7 @@ TEST(RDFDisplayTests, DisplayAmbiguity)
    EXPECT_EQ(display_2->AsString(), DisplayAsStringTwoColumns);
 }
 
-static const std::string DisplayAsStringString("b1    | \n\"foo\" | \n\"foo\" | \n      | \n");
+static const std::string DisplayAsStringString("+-----+-------+\n| Row | b1    | \n+-----+-------+\n| 0   | \"foo\" | \n+-----+-------+\n| 1   | \"foo\" | \n|     |       | \n+-----+-------+\n");
 
 TEST(RDFDisplayTests, DisplayPrintString)
 {
@@ -193,7 +283,7 @@ TEST(RDFDisplayTests, CharArray)
    }
 
    const auto str = ROOT::RDataFrame("t", "chararray.root").Display()->AsString();
-   EXPECT_EQ(str, "str | \nasd | \nbar | \n    | \n");
+   EXPECT_EQ(str, "+-----+-----+\n| Row | str | \n+-----+-----+\n| 0   | asd | \n+-----+-----+\n| 1   | bar | \n|     |     | \n+-----+-----+\n");
 }
 
 TEST(RDFDisplayTests, BoolArray)
@@ -201,8 +291,25 @@ TEST(RDFDisplayTests, BoolArray)
    auto r = ROOT::RDataFrame(3)
       .Define("v", [] { return ROOT::RVec<bool>{true,false}; })
       .Display<ROOT::RVec<bool>>({"v"});
-   const auto expected = "v     | \ntrue  | \nfalse | \ntrue  | \nfalse | \ntrue  | \nfalse | \ntrue  | \nfalse | "
-                         "\ntrue  | \nfalse | \ntrue  | \nfalse | \n      | \n";
+   const auto expected = "+-----+-------+\n"
+                         "| Row | v     | \n"
+                         "+-----+-------+\n"
+                         "| 0   | true  | \n"
+                         "|     | false | \n"
+                         "+-----+-------+\n"
+                         "| 1   | true  | \n"
+                         "|     | false | \n"
+                         "|     | true  | \n"
+                         "|     | false | \n"
+                         "+-----+-------+\n"
+                         "| 2   | true  | \n"
+                         "|     | false | \n"
+                         "|     | true  | \n"
+                         "|     | false | \n"
+                         "|     | true  | \n"
+                         "|     | false | \n"
+                         "|     |       | \n"
+                         "+-----+-------+\n";
    EXPECT_EQ(r->AsString(), expected);
 }
 
@@ -211,8 +318,12 @@ TEST(RDFDisplayTests, UniquePtr)
    auto r = ROOT::RDataFrame(1)
                .Define("uptr", []() -> std::unique_ptr<int> { return nullptr; })
                .Display<std::unique_ptr<int>>({"uptr"});
-   const auto expected =
-      "uptr                       | \nstd::unique_ptr -> nullptr | \n                           | \n";
+   const auto expected = "+-----+----------------------------+\n"
+                         "| Row | uptr                       | \n"
+                         "+-----+----------------------------+\n"
+                         "| 0   | std::unique_ptr -> nullptr | \n"
+                         "|     |                            | \n"
+                         "+-----+----------------------------+\n";
    EXPECT_EQ(r->AsString(), expected);
 }
 
@@ -226,7 +337,7 @@ TEST(RDFDisplayTests, SubBranch)
    t.Fill();
    ROOT::RDataFrame df(t);
    const auto res = df.Display()->AsString();
-   const auto expected = "p.a | p.b | \n42  | 84  | \n    |     | \n";
+   const auto expected = "+-----+-----+-----+\n| Row | p.a | p.b | \n+-----+-----+-----+\n| 0   | 42  | 84  | \n|     |     |     | \n+-----+-----+-----+\n";
    EXPECT_EQ(res, expected);
 }
 
@@ -242,72 +353,117 @@ TEST(RDFDisplayTests, Friends)
   main.AddFriend(&fr);
 
   const auto res = ROOT::RDataFrame(main).Display()->AsString();
-  const auto expected = "friend.x | \n0        | \n         | \n";
+  const auto expected = "+-----+----------+\n| Row | friend.x | \n+-----+----------+\n| 0   | 0        | \n|     |          | \n+-----+----------+\n";
   EXPECT_EQ(res, expected);
 }
 
-static const std::string DisplayPrintVectors("S0 | S1 | S3 | S9 | S10 | S11 | S20 | S20_ | \n"
-                                             "   | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    |    | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    |    |     | ... | ... | ...  | \n"
-                                             "   | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    |    | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    |    |     | ... | ... | ...  | \n"
-                                             "   | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    | 0  | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    |    | 0   | 0   | 0   | 0    | \n"
-                                             "   |    |    |    |     | ... | ... | ...  | \n");
+static const std::string DisplayPrintVectors("+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                             "| Row | S0 | S1 | S3 | S9 | S10 | S11 | S20 | S20_ | \n"
+                                             "+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                             "| 0   |    | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    |    | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    |    |     | ... | ... | ...  | \n"
+                                             "+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                             "| 1   |    | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    |    | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    |    |     | ... | ... | ...  | \n"
+                                             "+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                             "| 2   |    | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    |    | 0   | 0   | 0   | 0    | \n"
+                                             "|     |    |    |    |    |     | ... | ... | ...  | \n"
+                                             "+-----+----+----+----+----+-----+-----+-----+------+\n");
 
-static const std::string DisplayAsStringVectors(
-   "S0 | S1 | S3 | S9 | S10 | S11 | S20 | S20_ | \n   | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n   |    | 0  | 0  | "
-   "0   | 0   | 0   | 0    | \n   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0  "
-   "  | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | "
-   "0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   "
-   "| 0    | \n   |    |    |    | 0   | 0   | 0   | 0    | \n   |    |    |    |     | 0   | 0   | 0    | \n   |    | "
-   "   |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     "
-   "| 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   "
-   "|    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     "
-   "|     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   | 0  | 0  | 0  | 0   | 0   | 0   | 0    | "
-   "\n   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  "
-   "| 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | "
-   "0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |   "
-   " | 0  | 0   | 0   | 0   | 0    | \n   |    |    |    | 0   | 0   | 0   | 0    | \n   |    |    |    |     | 0   | "
-   "0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |  "
-   "  |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |  "
-   "   | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n "
-   "  |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   | 0  | 0  | 0  | 0 "
-   "  | 0   | 0   | 0    | \n   |    | 0  | 0  | 0   | 0   | 0   | 0    | \n   |    | 0  | 0  | 0   | 0   | 0   | 0    "
-   "| \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0 "
-   " | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    | 0  | 0   | 0   | 0   | "
-   "0    | \n   |    |    | 0  | 0   | 0   | 0   | 0    | \n   |    |    |    | 0   | 0   | 0   | 0    | \n   |    |   "
-   " |    |     | 0   | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | "
-   "0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |  "
-   "  |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |  "
-   "   | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n   |    |    |    |     |     | 0   | 0    | \n "
-   "  |    |    |    |     |     |     |      | \n");
+static const std::string DisplayAsStringVectors("+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                                "| Row | S0 | S1 | S3 | S9 | S10 | S11 | S20 | S20_ | \n"
+                                                "+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                                "| 0   |    | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                                "| 1   |    | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "+-----+----+----+----+----+-----+-----+-----+------+\n"
+                                                "| 2   |    | 0  | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    | 0  | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    | 0  | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    | 0   | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     | 0   | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     | 0   | 0    | \n"
+                                                "|     |    |    |    |    |     |     |     |      | \n"
+                                                "+-----+----+----+----+----+-----+-----+-----+------+\n");
 
 TEST(RDFDisplayTests, Vectors)
 {
@@ -366,7 +522,7 @@ TEST(RDFDisplayTests, CustomMaxWidth)
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);
 
-   EXPECT_EQ(strCout.str(), "S3  | \n0   | \n0   | \n... | \n");
+   EXPECT_EQ(strCout.str(), "+-----+-----+\n| Row | S3  | \n+-----+-----+\n| 0   | 0   | \n|     | 0   | \n|     | ... | \n+-----+-----+\n");
 }
 
 TEST(RDFDisplayTests, PrintWideTables1)
@@ -390,16 +546,22 @@ TEST(RDFDisplayTests, PrintWideTables1)
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);
 
-   EXPECT_EQ(strCout.str(), "S3                                                                                                     | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n");
+   EXPECT_EQ(strCout.str(),
+   "+-----+--------------------------------------------------------------------------------------------------------+\n"
+   "| Row | S3                                                                                                     | \n"
+   "+-----+--------------------------------------------------------------------------------------------------------+\n"
+   "| 0   | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "+-----+--------------------------------------------------------------------------------------------------------+\n"
+   "| 1   | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "+-----+--------------------------------------------------------------------------------------------------------+\n"
+   "| 2   | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | \n"
+   "+-----+--------------------------------------------------------------------------------------------------------+\n");
 }
 
 TEST(RDFDisplayTests, PrintWideTables2)
@@ -424,17 +586,20 @@ TEST(RDFDisplayTests, PrintWideTables2)
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);
 
-   EXPECT_EQ(strCout.str(), "S10 |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n"
-   "0   |  ... | \n");
+   EXPECT_EQ(strCout.str(), "+-----+-----+-----+\n"
+                            "| Row | S10 | ... | \n"
+                            "+-----+-----+-----+\n"
+                            "| 0   | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "|     | 0   | ... | \n"
+                            "+-----+-----+-----+\n");
 }
 
 
@@ -460,9 +625,13 @@ TEST(RDFDisplayTests, PrintWideTables3)
    // Restore old cout.
    std::cout.rdbuf(oldCoutStreamBuf);
 
-   EXPECT_EQ(strCout.str(), "S3                                                                                                     |  ... | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" |  ... | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" |  ... | \n"
-   "\"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" |  ... | \n");
+   EXPECT_EQ(strCout.str(),
+   "+-----+--------------------------------------------------------------------------------------------------------+-----+\n"
+   "| Row | S3                                                                                                     | ... | \n"
+   "+-----+--------------------------------------------------------------------------------------------------------+-----+\n"
+   "| 0   | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | ... | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | ... | \n"
+   "|     | \"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 12345678901234567890\" | ... | \n"
+   "+-----+--------------------------------------------------------------------------------------------------------+-----+\n");
 }
 


### PR DESCRIPTION
# This Pull request:

Additional custom column "rdfentry_" added to the Display()

The RDisplay constructor is adjusted so that is prints the name of the
first column as "Row" (that is always "rdfentry_").

Function DashesBetweenLines added to display dashes in the beginning,
between entries and in the end of the Print() and AsString() methods.
To first column is used to check if there is a new entry in the table.

Moreover, the GetColumnsToShorten() method now considers spaces between
columns when counting the total width of the table.

All tests are adjusted accordingly.

## Changes or fixes:

More beatiful Display.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #9116 

