### PR TITLE
Update TLatex.cxx

### DIFF
--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -1944,6 +1944,7 @@ TLatex *TLatex::DrawLatex(Double_t x, Double_t y, const char *text)
 {
    TLatex *newtext = new TLatex(x, y, text);
    TAttText::Copy(*newtext);
+   TAttLine::Copy(*newtext);
    newtext->SetBit(kCanDelete);
    if (TestBit(kTextNDC)) newtext->SetNDC();
    newtext->AppendPad();


### PR DESCRIPTION
The function TLatex::DrawLatex() only copied the Text-Attributes, but not the Line-Attributes to the newly created TLatex-Object which does not seem logical to me. Please correct me if there was a purpose for not copying the Line-Attributes.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
