### PR TITLE
[RF] Implement `RooResolutionModel::selfNormalized`

### DIFF
--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -38,6 +38,12 @@ public:
                                             Bool_t) const { return 0; }
 
   Double_t getValV(const RooArgSet* nset=0) const ;
+
+  // If used as regular PDF, it also has to be normalized. If this resolution
+  // model is used in a convolution, return unnormalized value regardless of
+  // specified normalization set.
+  bool selfNormalized() const { return isConvolved() ; }
+
   virtual RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const ;
   /// Return the convolution variable of the resolution model.
   RooAbsRealLValue& convVar() const {return *x;}
@@ -50,7 +56,7 @@ public:
   Double_t getNorm(const RooArgSet* nset=0) const ;
 
   inline const RooFormulaVar& basis() const { return _basis?*_basis:*identity() ; }
-  Bool_t isConvolved() { return _basis ? kTRUE : kFALSE ; }
+  Bool_t isConvolved() const { return _basis ? true : false ; }
 
   virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
 

--- a/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsAnaConvPdf.cxx
@@ -513,7 +513,7 @@ Double_t RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet* nor
       Double_t coef = getCoefNorm(index++,intCoefSet,_rangeName) ; 
       //cout << "coefInt[" << index << "] = " << coef << " " ; intCoefSet->Print("1") ; 
       if (coef!=0) {
-	integral += coef*(_rangeName ? conv->getNormObj(0,intConvSet,_rangeName)->getVal() :  conv->getNorm(intConvSet) ) ;       
+	integral += coef* conv->getNormObj(0,intConvSet,_rangeName)->getVal();
 	cxcoutD(Eval) << "RooAbsAnaConv::aiWN(" << GetName() << ") [" << index-1 << "] integral += " << conv->getNorm(intConvSet) << endl ;
       }
 
@@ -532,14 +532,14 @@ Double_t RooAbsAnaConvPdf::analyticalIntegralWN(Int_t code, const RooArgSet* nor
       Double_t coefInt = getCoefNorm(index,intCoefSet,_rangeName) ;
       //cout << "coefInt[" << index << "] = " << coefInt << "*" << term << " " << (intCoefSet?*intCoefSet:RooArgSet()) << endl ;
       if (coefInt!=0) {
-	Double_t term = (_rangeName ? conv->getNormObj(0,intConvSet,_rangeName)->getVal() : conv->getNorm(intConvSet) ) ;
+	Double_t term = conv->getNormObj(0,intConvSet,_rangeName)->getVal();
 	integral += coefInt*term ;
       }
 
       Double_t coefNorm = getCoefNorm(index,normCoefSet) ;
       //cout << "coefNorm[" << index << "] = " << coefNorm << "*" << term << " " << (normCoefSet?*normCoefSet:RooArgSet()) << endl ;
       if (coefNorm!=0) {
-	Double_t term = conv->getNorm(normConvSet) ;
+	Double_t term = conv->getNormObj(0,normConvSet)->getVal();
 	norm += coefNorm*term ;
       }
 


### PR DESCRIPTION
Even though the `RooResolutionModel` inherits from RooAbsPdf, it is
special because it has it's own overload of `getValV`. This is
problematic for the new RooFit batch mode, because it doesn't use
`getValV` but instead `RooAbsReal::evaluate()` directly. Then for pdfs
it does the normalization, and for non-pdfs it doesn't.

The `RooResolutionModel::getValV` is implemented such that the
resolution model behaves like a pdf when used on it's own (i.e., it will
be normalized), but when used for an analytical convolution via
`RooAbsAnaConvPdf`, it is not normalized.

In this commit, the function `RooResolutionMode::selfNormalized` is
implemented to return `true` if the resolution model is used in a
convolution. Like this, it's behavior as a pdf is consistent with the
`getValV` implementation and the batch mode had no problems using that
class anymore.

One complication after this change was the integral code in
`RooAbsAnaConvPdf`. In that code, the RooResolutionModel's integral
value is retrieved by getting it's normalization integral, but now that
the resolution model is proclaiming to be self-normalized the integral
is always trivially one. This problem is solved by getting the
normalization integral directly via `getNormObj` from the normalization
integral cache manager, in which case the check for self-normalization
is not done. In fact, this has already been done before in the case of
ranged fits, so the change in this commit is actually a simplification
of the code because it removes a code branch.