### PR TITLE
[RF] Avoid including `RooMath.h` in RooFit headers and stress tests

### DIFF
--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -18,7 +18,6 @@
 
 #include "RooResolutionModel.h"
 #include "RooRealProxy.h"
-#include "RooMath.h"
 
 #include <cmath>
 #include <complex>
@@ -63,14 +62,6 @@ public:
 protected:
 
   virtual Double_t evaluate() const ;
-  static std::complex<Double_t> evalCerfApprox(Double_t swt, Double_t u, Double_t c);
-
-  // Calculate exp(-u^2) cwerf(swt*c + i(u+c)), taking care of numerical instabilities
-  static inline std::complex<Double_t> evalCerf(Double_t swt, Double_t u, Double_t c)
-  {
-    std::complex<Double_t> z(swt*c,u+c);
-    return (z.imag()>-4.0) ? (std::exp(-u*u)*RooMath::faddeeva_fast(z)) : evalCerfApprox(swt,u,c);
-  }
 
   // Calculate common normalization factors
   std::complex<Double_t> evalCerfInt(Double_t sign, Double_t wt, Double_t tau, Double_t umin, Double_t umax, Double_t c) const;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -246,6 +246,12 @@ if(ROOT_roofit_FOUND)
   ROOT_ADD_TEST(test-stressroofit-interpreted COMMAND ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/stressRooFit.cxx
                 FAILREGEX "FAILED|Error in" DEPENDS test-stressroofit )
 
+  # Test that the user can still include RooMath.h themselves from the
+  # interpreter. We test this case explicitely, because RooMath.h was moved
+  # from roofit/roofitcore to roofit/batchcompute, which can cause redefinition
+  # problems.
+  ROOT_ADD_TEST(test-roofit-includingRooMath COMMAND ${ROOT_root_CMD} -b -q -l -e "#include\ <RooMath.h>")
+
   add_subdirectory(fit)
 endif()
 

--- a/test/stressHistFactory.cxx
+++ b/test/stressHistFactory.cxx
@@ -19,7 +19,6 @@
 #include "RooResolutionModel.h"
 #include "RooAbsData.h"
 #include "RooTrace.h"
-#include "RooMath.h"
 #include "RooUnitTest.h"
 
 // Tests file

--- a/test/stressRooFit.cxx
+++ b/test/stressRooFit.cxx
@@ -21,7 +21,7 @@
 #include "RooHist.h"
 #include "RooRandom.h"
 #include "RooTrace.h"
-#include "RooMath.h"
+
 #include <string>
 #include <list>
 #include <iostream>

--- a/test/stressRooStats.cxx
+++ b/test/stressRooStats.cxx
@@ -34,7 +34,6 @@
 #include "RooHist.h"
 #include "RooRandom.h"
 #include "RooTrace.h"
-#include "RooMath.h"
 
 // Tests file
 #include "stressRooStats_tests.h"


### PR DESCRIPTION
This change is introduced to fix a problem with redefinition of RooMath
when running stressRooFit in interpreted mode on some CI nodes.

You can see the errors here for example:
https://github.com/root-project/root/pull/9004#issuecomment-954950871

Copy paste from the log:
```
Processing /home/sftnight/build/workspace/root-pullrequests-build/root/test/stressRooFit.cxx...
In file included from input_line_8:1:
In file included from /home/sftnight/build/workspace/root-pullrequests-build/root/test/stressRooFit.cxx:15:
/home/sftnight/build/workspace/root-pullrequests-build/build/include/RooMath.h:25:7: error: redefinition of 'RooMath'
class RooMath {
      ^
/home/sftnight/build/workspace/root-pullrequests-build/build/include/RooGaussModel.h:21:10: note: '/home/sftnight/build/workspace/root-pullrequests-build/build/include/RooMath.h' included multiple times, additional include site in header from module 'RooFit.RooGaussModel.h'
#include "RooMath.h"
         ^
/home/sftnight/build/workspace/root-pullrequests-build/build/include/module.modulemap:2717:10: note: RooFit.RooGaussModel.h defined here
  module "RooGaussModel.h" { header "RooGaussModel.h" export * }
         ^
/home/sftnight/build/workspace/root-pullrequests-build/root/test/stressRooFit.cxx:15:10: note: '/home/sftnight/build/workspace/root-pullrequests-build/build/include/RooMath.h' included multiple times, additional include site here
#include "RooMath.h"
         ^
CMake Error at /home/sftnight/build/workspace/root-pullrequests-build/build/RootTestDriver.cmake:227 (message):
  error code: 1
```