### PR TITLE
[webgui] support batch mode with Firefox

### DIFF
--- a/js/files/canv_batch.htm
+++ b/js/files/canv_batch.htm
@@ -36,6 +36,11 @@
                elem.html(res);
             else
                elem.html("").append("img").attr("src", res);
+            dump(`types ${typeof window} ${typeof window.dump}\n`);
+            if (JSROOT.browser.isFirefox && window && (typeof window.dump == 'function')) {
+                window.dump(d3.select("body").html());
+                window.close();
+           }
         });
    });
 </script>


### PR DESCRIPTION
Unfortunately, Firefox does not provide dump-dom command line argument
as chrome/chromium does. But one can use non-standard `window.dump()`
function which only exists in Firefox. For that one need to create
user.js file in profile directory with custom parameters.

Now one can create png, svg, jpeg files with Firefox, not PDF.
