### PR TITLE
[VecOps] Allow implicit conversions in Where

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2503,7 +2503,7 @@ RVec<T> Where(const RVec<int>& c, const RVec<T>& v1, const RVec<T>& v2)
 /// // (ROOT::VecOps::RVec<double>) { 4.0000000, 2.0000000, 3.0000000 }
 /// ~~~
 template <typename T>
-RVec<T> Where(const RVec<int>& c, const RVec<T>& v1, T v2)
+RVec<T> Where(const RVec<int> &c, const RVec<T> &v1, typename RVec<T>::value_type v2)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = c.size();
@@ -2531,7 +2531,7 @@ RVec<T> Where(const RVec<int>& c, const RVec<T>& v1, T v2)
 /// // (ROOT::VecOps::RVec<double>) { 1.0000000, 4.0000000, 4.0000000 }
 /// ~~~
 template <typename T>
-RVec<T> Where(const RVec<int>& c, T v1, const RVec<T>& v2)
+RVec<T> Where(const RVec<int>& c, typename RVec<T>::value_type v1, const RVec<T>& v2)
 {
    using size_type = typename RVec<T>::size_type;
    const size_type size = c.size();

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <cmath>
 
+using namespace ROOT;
 using namespace ROOT::VecOps;
 
 void CheckEqual(const ROOT::RVecF &a, const ROOT::RVecF &b, std::string_view msg = "")
@@ -953,6 +954,17 @@ TEST(VecOps, Where)
    auto v6 = Where(v0 == 2 || v0 == 4, -1.0f, 1.0f);
    RVec<float> ref4{1, -1, 1, -1};
    CheckEqual(v6, ref4);
+
+   // Two temporary vectors as arguments
+   auto v7 = Where(v0 > 1 && v0 < 4, RVecF{1, 2, 3, 4}, RVecF{-1, -2, -3, -4});
+   RVecF ref5{-1, 2, 3, -4};
+   CheckEqual(v3, ref1);
+
+   // Scalar value of a different type
+   auto v8 = Where(v0 > 1, v0, -1);
+   CheckEqual(v8, RVecF{-1, 2, 3, 4});
+   auto v9 = Where(v0 > 1, -1, v0);
+   CheckEqual(v9, RVecF{1, -1, -1, -1});
 }
 
 TEST(VecOps, AtWithFallback)


### PR DESCRIPTION
Before this commit, something like this would fail:

    Where(arr1 > 2, 10, ROOT::RVecF{arr1.size(), 1.f})

Because 10 is not exactly `float`.
We now allow the scalar arguments to be of a different type from the
value_type of the RVec arguments if they can be implicitly coverted
to the value_type.