### PR TITLE
[ntuple] Fix race in RClusterPool destruction

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RClusterPool.hxx
@@ -155,6 +155,9 @@ public:
    /// of the returned cluster are already pushed into the page pool associated with the page source upon return.
    /// The cluster remains valid until the next call to GetCluster().
    RCluster *GetCluster(DescriptorId_t clusterId, const RCluster::ColumnSet_t &columns);
+
+   /// Used by the unit tests to drain the queue of clusters to be preloaded
+   void WaitForInFlightClusters();
 }; // class RClusterPool
 
 } // namespace Detail

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -417,3 +417,22 @@ ROOT::Experimental::Detail::RClusterPool::WaitFor(
       fInFlightClusters.erase(itr);
    }
 }
+
+
+void ROOT::Experimental::Detail::RClusterPool::WaitForInFlightClusters()
+{
+   while (true) {
+      decltype(fInFlightClusters)::iterator itr;
+      {
+         std::lock_guard<std::mutex> lockGuardInFlightClusters(fLockWorkQueue);
+         itr = fInFlightClusters.begin();
+         if (itr == fInFlightClusters.end())
+            return;
+      }
+
+      itr->fFuture.wait();
+
+      std::lock_guard<std::mutex> lockGuardInFlightClusters(fLockWorkQueue);
+      fInFlightClusters.erase(itr);
+   }
+}

--- a/tree/ntuple/v7/src/RClusterPool.cxx
+++ b/tree/ntuple/v7/src/RClusterPool.cxx
@@ -105,8 +105,7 @@ void ROOT::Experimental::Detail::RClusterPool::ExecUnzipClusters()
 
 void ROOT::Experimental::Detail::RClusterPool::ExecReadClusters()
 {
-   bool terminate = false;
-   while (!terminate) {
+   while (true) {
       std::vector<RReadItem> readItems;
       std::vector<RCluster::RKey> clusterKeys;
       std::int64_t bunchId = -1;
@@ -116,8 +115,7 @@ void ROOT::Experimental::Detail::RClusterPool::ExecReadClusters()
          while (!fReadQueue.empty()) {
             if (fReadQueue.front().fClusterKey.fClusterId == kInvalidDescriptorId) {
                fReadQueue.pop();
-               terminate = true;
-               break;
+               return;
             }
 
             if ((bunchId >= 0) && (fReadQueue.front().fBunchId != bunchId))
@@ -129,8 +127,6 @@ void ROOT::Experimental::Detail::RClusterPool::ExecReadClusters()
          }
       }
 
-      if (clusterKeys.empty())
-         break;
       auto clusters = fPageSource.LoadClusters(clusterKeys);
 
       for (std::size_t i = 0; i < clusters.size(); ++i) {
@@ -156,7 +152,7 @@ void ROOT::Experimental::Detail::RClusterPool::ExecReadClusters()
             fCvHasUnzipWork.notify_one();
          }
       }
-   } // while (!terminate)
+   } // while (true)
 }
 
 ROOT::Experimental::Detail::RCluster *

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -222,6 +222,7 @@ TEST(ClusterPool, GetClusterBasics)
    {
       RClusterPool c2(p2, 2);
       c2.GetCluster(0, {0});
+      c2.WaitForInFlightClusters();
    }
    ASSERT_EQ(4U, p2.fReqsClusterIds.size());
    EXPECT_EQ(0U, p2.fReqsClusterIds[0]);
@@ -238,6 +239,7 @@ TEST(ClusterPool, GetClusterBasics)
       RClusterPool c3(p3, 2);
       c3.GetCluster(0, {0});
       c3.GetCluster(1, {0});
+      c3.WaitForInFlightClusters();
    }
    ASSERT_EQ(4U, p3.fReqsClusterIds.size());
    EXPECT_EQ(0U, p3.fReqsClusterIds[0]);
@@ -249,6 +251,7 @@ TEST(ClusterPool, GetClusterBasics)
    {
       RClusterPool c4(p4, 3);
       c4.GetCluster(2, {0});
+      c4.WaitForInFlightClusters();
    }
    ASSERT_EQ(4U, p4.fReqsClusterIds.size());
    EXPECT_EQ(2U, p4.fReqsClusterIds[0]);


### PR DESCRIPTION
Ensures that the cluster prefetch thread flushes all queued requests before processing the termination signal.