### PR TITLE
Complete fhistogram limits computations

### DIFF
--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1095,8 +1095,15 @@ TH1F *TMultiGraph::GetHistogram()
    double dy = 0.05*(rwymax-rwymin);
    rwxmin = rwxmin - dx;
    rwxmax = rwxmax + dx;
-   rwymin = rwymin - dy;
-   rwymax = rwymax + dy;
+   if (gPad->GetLogy()) {
+      if (rwymin <= 0) rwymin = 0.001*rwymax;
+      double r = rwymax/rwymin;
+      rwymin = rwymin/(1+0.5*TMath::Log10(r));
+      rwymax = rwymax*(1+0.2*TMath::Log10(r));
+   } else {
+      rwymin = rwymin - dy;
+      rwymax = rwymax + dy;
+   }
    fHistogram = new TH1F(GetName(),GetTitle(),npt,rwxmin,rwxmax);
    if (!fHistogram) return 0;
    fHistogram->SetMinimum(rwymin);

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1095,7 +1095,7 @@ TH1F *TMultiGraph::GetHistogram()
    double dy = 0.05*(rwymax-rwymin);
    rwxmin = rwxmin - dx;
    rwxmax = rwxmax + dx;
-   if (gPad->GetLogy()) {
+   if (gPad && gPad->GetLogy()) {
       if (rwymin <= 0) rwymin = 0.001*rwymax;
       double r = rwymax/rwymin;
       rwymin = rwymin/(1+0.5*TMath::Log10(r));

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -16,6 +16,7 @@ ROOT_ADD_GTEST(test_TEfficiency test_TEfficiency.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(TGraphMultiErrorsTests TGraphMultiErrorsTests.cxx LIBRARIES Hist RIO)
 ROOT_ADD_GTEST(test_TF123_Moments test_TF123_Moments.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(test_THBinIterator test_THBinIterator.cxx LIBRARIES Hist)
+ROOT_ADD_GTEST(testTMultiGraphGetHistogram test_TMultiGraph_GetHistogram.cxx LIBRARIES Hist)
 
 if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)

--- a/hist/hist/test/CMakeLists.txt
+++ b/hist/hist/test/CMakeLists.txt
@@ -16,7 +16,7 @@ ROOT_ADD_GTEST(test_TEfficiency test_TEfficiency.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(TGraphMultiErrorsTests TGraphMultiErrorsTests.cxx LIBRARIES Hist RIO)
 ROOT_ADD_GTEST(test_TF123_Moments test_TF123_Moments.cxx LIBRARIES Hist)
 ROOT_ADD_GTEST(test_THBinIterator test_THBinIterator.cxx LIBRARIES Hist)
-ROOT_ADD_GTEST(testTMultiGraphGetHistogram test_TMultiGraph_GetHistogram.cxx LIBRARIES Hist)
+ROOT_ADD_GTEST(testTMultiGraphGetHistogram test_TMultiGraph_GetHistogram.cxx LIBRARIES Hist Gpad)
 
 if(fftw3)
   ROOT_ADD_GTEST(testTF1 test_tf1.cxx LIBRARIES Hist)

--- a/hist/hist/test/test_TMultiGraph_GetHistogram.cxx
+++ b/hist/hist/test/test_TMultiGraph_GetHistogram.cxx
@@ -1,0 +1,32 @@
+// test TMultiGraph::GetHistogram in log scale
+
+#include "gtest/gtest.h"
+
+#include "TCanvas.h"
+#include "TMultiGraph.h"
+#include "TGraph.h"
+#include "TH1.h"
+
+TEST(TMultiGraph, GetHistogram)
+{
+   gROOT->SetBatch(1);
+   auto c = new TCanvas();
+    c->SetLogy();
+
+   std::vector<double> x1;
+   std::vector<double> sig1;
+   std::vector<double> sig2;
+   for (double E=1e-4;E<2e7;E*=1.1) {
+      x1.push_back(E);
+      sig1.push_back(10*pow(E,-0.1));
+      sig2.push_back(15*pow(E,-0.15));
+   }
+
+   auto mg = new TMultiGraph();
+   auto g1 = new TGraph(x1.size(), x1.data(), sig1.data()); mg->Add(g1);
+   auto g2 = new TGraph(x1.size(), x1.data(), sig2.data()); mg->Add(g2);
+   auto h  = mg->GetHistogram();
+
+   EXPECT_DOUBLE_EQ(h->GetMinimum(), 0.652338);
+   EXPECT_DOUBLE_EQ(h->GetMaximum(), 79.9602);
+}

--- a/hist/hist/test/test_TMultiGraph_GetHistogram.cxx
+++ b/hist/hist/test/test_TMultiGraph_GetHistogram.cxx
@@ -2,6 +2,7 @@
 
 #include "gtest/gtest.h"
 
+#include "TROOT.h"
 #include "TCanvas.h"
 #include "TMultiGraph.h"
 #include "TGraph.h"
@@ -11,7 +12,7 @@ TEST(TMultiGraph, GetHistogram)
 {
    gROOT->SetBatch(1);
    auto c = new TCanvas();
-    c->SetLogy();
+   c->SetLogy();
 
    std::vector<double> x1;
    std::vector<double> sig1;
@@ -27,6 +28,7 @@ TEST(TMultiGraph, GetHistogram)
    auto g2 = new TGraph(x1.size(), x1.data(), sig2.data()); mg->Add(g2);
    auto h  = mg->GetHistogram();
 
-   EXPECT_DOUBLE_EQ(h->GetMinimum(), 0.652338);
-   EXPECT_DOUBLE_EQ(h->GetMaximum(), 79.9602);
+   double delta = 1.E-3;
+   EXPECT_NEAR(h->GetMinimum(), 0.65234, delta);
+   EXPECT_NEAR(h->GetMaximum(), 79.9602, delta);
 }


### PR DESCRIPTION
# This Pull request:

Complete https://github.com/osschar/root/commit/d087f000322c7958f02c8e9ddce2a302502c8604 in case of log scale on Y. The coded imported in that PR from "Paint" missed the log part. It was seen in https://github.com/root-project/root/issues/9011#event-5529694431

 

