### PR TITLE
[tcling] Suppress `-Wunused-result` diagnostics in wrappers generated by TClingCallFunc

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -982,7 +982,7 @@ void TClingCallFunc::make_narg_call_with_return(const unsigned N, const string &
    //    new (ret) (return_type) ((class_name*)obj)->func(args...);
    // }
    // else {
-   //    ((class_name*)obj)->func(args...);
+   //    (void)(((class_name*)obj)->func(args...));
    // }
    //
    const FunctionDecl *FD = GetDecl();
@@ -1085,8 +1085,9 @@ void TClingCallFunc::make_narg_call_with_return(const unsigned N, const string &
          for (int i = 0; i < indent_level; ++i) {
             callbuf << kIndentString;
          }
+         callbuf << "(void)(";
          make_narg_call(type_name, N, typedefbuf, callbuf, class_name, indent_level);
-         callbuf << ";\n";
+         callbuf << ");\n";
          for (int i = 0; i < indent_level; ++i) {
             callbuf << kIndentString;
          }

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -1,4 +1,4 @@
-#include "TError.h"
+#include "ROOTUnitTestSupport.h"
 #include "TInterpreter.h"
 
 #include "gtest/gtest.h"
@@ -14,19 +14,6 @@
 // of C++ code, so if these tests fail because this interface was replaced by another
 // system, feel free to delete them as these tests here don't represent things the user
 // should do in his code.
-
-class FilterDiagsRAII {
-   ErrorHandlerFunc_t fPrevHandler;
-public:
-   FilterDiagsRAII(ErrorHandlerFunc_t fn) : fPrevHandler(::GetErrorHandler()) {
-      ::SetErrorHandler(fn);
-      gInterpreter->ReportDiagnosticsToErrorHandler();
-   }
-   ~FilterDiagsRAII() {
-      gInterpreter->ReportDiagnosticsToErrorHandler(/*enable=*/false);
-      ::SetErrorHandler(fPrevHandler);
-   }
-};
 
 TEST(TClingCallFunc, FunctionWrapper)
 {

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -1,3 +1,4 @@
+#include "TError.h"
 #include "TInterpreter.h"
 
 #include "gtest/gtest.h"
@@ -13,6 +14,19 @@
 // of C++ code, so if these tests fail because this interface was replaced by another
 // system, feel free to delete them as these tests here don't represent things the user
 // should do in his code.
+
+class FilterDiagsRAII {
+   ErrorHandlerFunc_t fPrevHandler;
+public:
+   FilterDiagsRAII(ErrorHandlerFunc_t fn) : fPrevHandler(::GetErrorHandler()) {
+      ::SetErrorHandler(fn);
+      gInterpreter->ReportDiagnosticsToErrorHandler();
+   }
+   ~FilterDiagsRAII() {
+      gInterpreter->ReportDiagnosticsToErrorHandler(/*enable=*/false);
+      ::SetErrorHandler(fPrevHandler);
+   }
+};
 
 TEST(TClingCallFunc, FunctionWrapper)
 {
@@ -258,4 +272,37 @@ TEST(TClingCallFunc, DISABLED_OverloadedTemplate)
                              bool k2 = ((bool(&)(X,bool))::operator==<bool>)(x, true);
                            }
                            )cpp");
+}
+
+TEST(TClingCallFunc, FunctionWrapperNodiscard)
+{
+   gInterpreter->Declare(R"cpp(
+                           struct TClingCallFunc_Nodiscard1 {
+                           #if __cplusplus >= 201703L
+                           [[nodiscard]]
+                           #endif
+                             bool foo(int) { return false; }
+                           };
+                           )cpp");
+
+   ClassInfo_t *FooNamespace = gInterpreter->ClassInfo_Factory("TClingCallFunc_Nodiscard1");
+   CallFunc_t *mc = gInterpreter->CallFunc_Factory();
+   Longptr_t offset = 0;
+
+   gInterpreter->CallFunc_SetFuncProto(mc, FooNamespace, "foo", "int", &offset);
+   std::string wrapper = gInterpreter->CallFunc_GetWrapperCode(mc);
+
+   {
+      using ::testing::Not;
+      using ::testing::HasSubstr;
+      FilterDiagsRAII RAII([] (int /*level*/, Bool_t /*abort*/,
+                               const char * /*location*/, const char *msg) {
+         EXPECT_THAT(msg, Not(HasSubstr("-Wunused-result")));
+      });
+      ASSERT_TRUE(gInterpreter->Declare(wrapper.c_str()));
+   }
+
+   // Cleanup
+   gInterpreter->CallFunc_Delete(mc);
+   gInterpreter->ClassInfo_Delete(FooNamespace);
 }


### PR DESCRIPTION
This pull-request suppresses `-Wunused-result` diagnostics for wrapper functions generated by TClingCallFunc (see below).

A TClingCallFunc wrapper function might look as the excerpt below, where the function denoted by `func` may have been annotated as `[[nodiscard]]`. Note that if `ret == nullptr` the result of the call is unused.
```c++
extern "C" void __cf_0(void* obj, int nargs, void** args, void* ret) {
   if (ret) {
      new (ret) (return_type) ((class_name*)obj)->func(args...);
   }
   else {
      ((class_name*)obj)->func(args...);
   }
}
```

In turn, this triggers warnings when used by cppyy/PyROOT, e.g.
```python
>>> import ROOT
>>> v = ROOT.std.vector(int)()
>>> v.empty()
input_line_34:10:7: warning; ignoring return value of function declared with 'nodiscard' attribute
      [-Wunused-result]
      ((const vector<int>*)obj)->empty();
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
True
>>>
```

## Changes or fixes:
- Given the above situation, this commit supresses `-Wunused-result` diagnostics only for TClingCallFunc wrapper functions.

## Checklist:
- [X] tested changes locally

This PR fixes #8622.

Sibling PR in roottest: https://github.com/root-project/roottest/pull/791