### PR TITLE
[cling] Remove unneed `assert()` in DynamicLookup.cpp

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLookup.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLookup.cpp
@@ -761,7 +761,6 @@ namespace cling {
                                                            TSI,
                                                            m_NoELoc,
                                                            ILE).get();
-    assert (ExprAddresses && "Could not build the void* array");
     if (!ExprAddresses)
        return SubTree;
 


### PR DESCRIPTION
The case of `ExprAddresses == nullptr` seems to be naturally handled in the lines below this assertion, which suggests that it is okay if the asserted predicate does not hold.

Therefore, removing this assertion -as discussed with @vgvassilev in the linked issue- [see here](https://github.com/root-project/root/issues/8389#issuecomment-958105156).

## Changes or fixes:
- Remove unneded `assert()`, as discussed above.

## Checklist:
- [X] tested changes locally

This PR fixes #8389.