### PR TITLE
[skip-ci] Fix compilation error of constructors.cxx on Win64

### DIFF
--- a/hist/histv7/test/CMakeLists.txt
+++ b/hist/histv7/test/CMakeLists.txt
@@ -4,12 +4,17 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-if(MSVC AND MSVC_VERSION GREATER_EQUAL 1923)
-  # FIXME: using /O2 compiler flag prevent the following error when building in debug mode:
-  # axis.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT
-  # '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z'
-  # Try to remove those lines when upgrading Visual Studio
-  string(REPLACE "-Od -Z7" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+if(MSVC)
+  if(MSVC_VERSION GREATER_EQUAL 1923)
+    # FIXME: using /O2 compiler flag prevent the following error when building in debug mode:
+    # axis.obj : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT
+    # '??$?8DU?$char_traits@D@std@@@__ROOT@experimental@std@@YA_NV?$basic_string_view@DU?$char_traits@D@std@@@012@0@Z'
+    # Try to remove those lines when upgrading Visual Studio
+    string(REPLACE "-Od -Z7" "-O2" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+  endif()
+  if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")
+    set_source_files_properties(constructors.cxx COMPILE_FLAGS "/bigobj")
+  endif()
 endif()
 
 ROOT_ADD_UNITTEST_DIR(ROOTHist)


### PR DESCRIPTION
Fix the following compilation error on Windows 64 bit:
```
hist\histv7\test\constructors.cxx : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
```
