### PR TITLE
[RF] Avoid heap allocation of `RooArgSet` in `Roo(Abs)GenContext`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsGenContext.h
+++ b/roofit/roofitcore/inc/RooAbsGenContext.h
@@ -75,7 +75,7 @@ protected:
   void resampleData(Double_t& ratio) ;
 
   const RooDataSet *_prototype; // Pointer to prototype dataset
-  RooArgSet *_theEvent;         // Pointer to observable event being generated
+  RooArgSet _theEvent;          // Pointer to observable event being generated
   Bool_t _isValid;              // Is context in valid state?
   Bool_t _verbose;              // Verbose messaging?
   UInt_t _expectedEvents;       // Number of expected events from extended p.d.f

--- a/roofit/roofitcore/inc/RooGenContext.h
+++ b/roofit/roofitcore/inc/RooGenContext.h
@@ -42,7 +42,7 @@ protected:
   virtual void initGenerator(const RooArgSet &theEvent);
   virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
 
-  RooArgSet *_cloneSet;   // Clone of all nodes of input p.d.f
+  RooArgSet _cloneSet;    // Clone of all nodes of input p.d.f
   RooAbsPdf *_pdfClone;   // Clone of input p.d.f
   RooArgSet _directVars,_uniformVars,_otherVars; // List of observables generated internally, randomly, and by accept/reject sampling
   Int_t _code;                        // Internal generation code

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -54,7 +54,6 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
 				   const RooDataSet *prototype, const RooArgSet* auxProto, Bool_t verbose) :
   TNamed(model), 
   _prototype(prototype), 
-  _theEvent(0), 
   _isValid(kTRUE),
   _verbose(verbose),
   _protoOrder(0),
@@ -68,7 +67,7 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
   }
 
   // Make a snapshot of the generated variables that we can overwrite.
-  _theEvent= (RooArgSet*)vars.snapshot(kFALSE);
+  vars.snapshot(_theEvent, false);
 
   // Analyze the prototype dataset, if one is specified
   _nextProtoIndex= 0;
@@ -77,9 +76,9 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
     const RooAbsArg *proto = 0;
     while((proto= (const RooAbsArg*)protoIterator->Next())) {
       // is this variable being generated or taken from the prototype?
-      if(!_theEvent->contains(*proto)) {
+      if(!_theEvent.contains(*proto)) {
 	_protoVars.add(*proto);
-	_theEvent->addClone(*proto);
+	_theEvent.addClone(*proto);
       }
     }
     delete protoIterator;
@@ -88,13 +87,13 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
   // Add auxiliary protovars to _protoVars, if provided
   if (auxProto) {
     _protoVars.add(*auxProto) ;
-    _theEvent->addClone(*auxProto) ; 
+    _theEvent.addClone(*auxProto);
   }
 
   // Remember the default number of events to generate when no prototype dataset is provided.
   _extendMode = model.extendMode() ;
   if (model.canBeExtended()) {
-    _expectedEvents= (Int_t)(model.expectedEvents(_theEvent) + 0.5);
+    _expectedEvents= (Int_t)(model.expectedEvents(&_theEvent) + 0.5);
   } else {
     _expectedEvents= 0 ;
   }
@@ -112,7 +111,6 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
 
 RooAbsGenContext::~RooAbsGenContext()
 {
-  if(0 != _theEvent) delete _theEvent;
   if (_protoOrder) delete[] _protoOrder ;
 }
 
@@ -214,12 +212,12 @@ RooDataSet *RooAbsGenContext::generate(Double_t nEvents, Bool_t skipInit, Bool_t
   title.Prepend("Generated From ");
 
   // WVE need specialization here for simultaneous pdfs
-  _genData = createDataSet(name.Data(),title.Data(),*_theEvent) ; 
+  _genData = createDataSet(name.Data(), title.Data(), _theEvent);
 
   // Perform any subclass implementation-specific initialization
   // Can be skipped if this is a rerun with an identical configuration
   if (!skipInit) {
-    initGenerator(*_theEvent);
+    initGenerator(_theEvent);
   }
   
   // Loop over the events to generate
@@ -235,7 +233,7 @@ RooDataSet *RooAbsGenContext::generate(Double_t nEvents, Bool_t skipInit, Bool_t
       const RooArgSet *subEvent= _prototype->get(actualProtoIdx);
       _nextProtoIndex++;
       if(0 != subEvent) {
-        _theEvent->assign(*subEvent);
+        _theEvent.assign(*subEvent);
       }
       else {
 	coutE(Generation) << ClassName() << "::" << GetName() << ":generate: cannot load event "
@@ -245,15 +243,15 @@ RooDataSet *RooAbsGenContext::generate(Double_t nEvents, Bool_t skipInit, Bool_t
     }
 
     // delegate the generation of the rest of this event to our subclass implementation
-    generateEvent(*_theEvent, (Int_t)(nEvents - _genData->numEntries()));
+    generateEvent(_theEvent, (Int_t)(nEvents - _genData->numEntries()));
 
 
     // WVE add check that event is in normRange
-    if (_normRange.Length()>0 && !_theEvent->isInRange(_normRange.Data())) {
+    if (_normRange.Length()>0 && !_theEvent.isInRange(_normRange.Data())) {
       continue ;
     }      
 
-    _genData->addFast(*_theEvent);
+    _genData->addFast(_theEvent);
     evt++ ;
   }
 
@@ -312,7 +310,7 @@ void RooAbsGenContext::printClassName(ostream& os) const
 void RooAbsGenContext::printArgs(ostream& os) const 
 {
   os << "[ " ;    
-  TIterator* iter = _theEvent->createIterator() ;
+  TIterator* iter = _theEvent.createIterator() ;
   RooAbsArg* arg ;
   Bool_t first(kTRUE) ;
   while((arg=(RooAbsArg*)iter->Next())) {

--- a/roofit/roofitcore/src/RooAddGenContext.cxx
+++ b/roofit/roofitcore/src/RooAddGenContext.cxx
@@ -90,7 +90,7 @@ RooAddGenContext::RooAddGenContext(const RooAddPdf &model, const RooArgSet &vars
   }  
 
   ((RooAddPdf*)_pdf)->getProjCache(_vars) ;
-  _pdf->recursiveRedirectServers(*_theEvent) ;
+  _pdf->recursiveRedirectServers(_theEvent) ;
 
   _mcache = 0 ;
   _pcache = 0 ;
@@ -127,7 +127,7 @@ RooAddGenContext::RooAddGenContext(const RooAddModel &model, const RooArgSet &va
   }  
 
   ((RooAddModel*)_pdf)->getProjCache(_vars) ;
-  _pdf->recursiveRedirectServers(*_theEvent) ;
+  _pdf->recursiveRedirectServers(_theEvent) ;
 
   _mcache = 0 ;
   _pcache = 0 ;

--- a/roofit/roofitcore/src/RooBinnedGenContext.cxx
+++ b/roofit/roofitcore/src/RooBinnedGenContext.cxx
@@ -70,7 +70,7 @@ RooBinnedGenContext::RooBinnedGenContext(const RooAbsPdf &model, const RooArgSet
       _pdf->fixAddCoefNormalization(coefNSet) ;
     }
 
-  _pdf->recursiveRedirectServers(*_theEvent) ;
+  _pdf->recursiveRedirectServers(_theEvent) ;
   _vars = _pdf->getObservables(vars) ;
 
   // If pdf has boundary definitions, follow those for the binning 

--- a/roofit/roofitcore/src/RooGenContext.cxx
+++ b/roofit/roofitcore/src/RooGenContext.cxx
@@ -70,7 +70,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
 			     const RooDataSet *prototype, const RooArgSet* auxProto,
 			     Bool_t verbose, const RooArgSet* forceDirect) :  
   RooAbsGenContext(model,vars,prototype,auxProto,verbose),
-  _cloneSet(0), _pdfClone(0), _acceptRejectFunc(0), _generator(0),
+  _pdfClone(0), _acceptRejectFunc(0), _generator(0),
   _maxVar(0), _uniIter(0), _updateFMaxPerEvent(0) 
 {
   cxcoutI(Generation) << "RooGenContext::ctor() setting up event generator context for p.d.f. " << model.GetName() 
@@ -84,14 +84,13 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   // Clone the model and all nodes that it depends on so that this context
   // is independent of any existing objects.
   RooArgSet nodes(model,model.GetName());
-  _cloneSet= (RooArgSet*) nodes.snapshot(kTRUE);
-  if (!_cloneSet) {
+  if (nodes.snapshot(_cloneSet, true)) {
     coutE(Generation) << "RooGenContext::RooGenContext(" << GetName() << ") Couldn't deep-clone PDF, abort," << endl ;
     RooErrorHandler::softAbort() ;
   }
 
   // Find the clone in the snapshot list
-  _pdfClone = (RooAbsPdf*)_cloneSet->find(model.GetName());
+  _pdfClone = static_cast<RooAbsPdf*>(_cloneSet.find(model.GetName()));
   _pdfClone->setOperMode(RooAbsArg::ADirty,kTRUE) ;
 
   // Optionally fix RooAddPdf normalizations
@@ -115,7 +114,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
       continue;
     }
     // lookup this argument in the cloned set of PDF dependents
-    arg= (const RooAbsArg*)_cloneSet->find(tmp->GetName());
+    arg= static_cast<RooAbsArg const*>(_cloneSet.find(tmp->GetName()));
     if(0 == arg) {
       coutI(Generation) << "RooGenContext::ctor() WARNING model does not depend on \"" << tmp->GetName() 
 			  << "\" which will have uniform distribution" << endl;
@@ -192,8 +191,9 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   ccxcoutI(Generation) << endl ;
 
   // initialize the accept-reject generator
-  RooArgSet *depList= _pdfClone->getObservables(_theEvent);
-  depList->remove(_otherVars);
+  RooArgSet depList;
+  _pdfClone->getObservables(&_theEvent, depList);
+  depList.remove(_otherVars);
 
   TString nname(_pdfClone->GetName()) ;
   nname.Append("_AccRej") ;
@@ -201,14 +201,15 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   ntitle.Append(" (Accept/Reject)") ;
   
 
-  RooArgSet* protoDeps = model.getObservables(_protoVars) ;
+  RooArgSet protoDeps;
+  model.getObservables(&_protoVars, protoDeps);
   
 
   if (_protoVars.getSize()==0) {
 
     // No prototype variables
     
-    if(depList->getSize()==0) {
+    if(depList.empty()) {
       // All variable are generated with accept-reject
       
       // Check if PDF supports maximum finding
@@ -216,7 +217,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
       if (maxFindCode != 0) {
 	coutI(Generation) << "RooGenContext::ctor() no prototype data provided, all observables are generated with numerically and "
 			      << "model supports analytical maximum findin:, can provide analytical pdf maximum to numeric generator" << endl ;
-	Double_t maxVal = _pdfClone->maxVal(maxFindCode) / _pdfClone->getNorm(_theEvent) ;
+	Double_t maxVal = _pdfClone->maxVal(maxFindCode) / _pdfClone->getNorm(&_theEvent) ;
 	_maxVar = new RooRealVar("funcMax","function maximum",maxVal) ;
 	cxcoutD(Generation) << "RooGenContext::ctor() maximum value returned by RooAbsPdf::maxVal() is " << maxVal << endl ;
       }
@@ -224,7 +225,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
 
     if (_otherVars.getSize()>0) {
       _pdfClone->getVal(&vars) ; // WVE debug
-      _acceptRejectFunc= new RooRealIntegral(nname,ntitle,*_pdfClone,*depList,&vars);
+      _acceptRejectFunc= new RooRealIntegral(nname,ntitle,*_pdfClone,depList,&vars);
       cxcoutI(Generation) << "RooGenContext::ctor() accept/reject sampling function is " << _acceptRejectFunc->GetName() << endl ;
     } else {
       _acceptRejectFunc = 0 ;
@@ -233,8 +234,8 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
   } else {
 
     // Generation _with_ prototype variable
-    depList->remove(_protoVars,kTRUE,kTRUE) ;
-    _acceptRejectFunc= (RooRealIntegral*) _pdfClone->createIntegral(*depList,vars) ;
+    depList.remove(_protoVars,true,true);
+    _acceptRejectFunc= (RooRealIntegral*) _pdfClone->createIntegral(depList,vars) ;
     cxcoutI(Generation) << "RooGenContext::ctor() accept/reject sampling function is " << _acceptRejectFunc->GetName() << endl ;
     
     // Check if PDF supports maximum finding for the entire phase space
@@ -266,7 +267,7 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
       // Regular case: First find maximum in other+proto space
       RooArgSet otherAndProto(_otherVars) ;
 
-      otherAndProto.add(*protoDeps) ;
+      otherAndProto.add(protoDeps) ;
       
       if (_otherVars.getSize()>0) {      
 
@@ -304,8 +305,6 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
     _generator = 0 ;
   }
 
-  delete protoDeps ;
-  delete depList;
   _otherVars.add(_uniformVars);
 }
 
@@ -315,9 +314,6 @@ RooGenContext::RooGenContext(const RooAbsPdf &model, const RooArgSet &vars,
 
 RooGenContext::~RooGenContext() 
 {
-  // Clean up the cloned objects used in this context.
-  delete _cloneSet;
-
   // Clean up our accept/reject generator
   if (_generator) delete _generator;
   if (_acceptRejectFunc) delete _acceptRejectFunc;

--- a/roofit/roofitcore/src/RooSimSplitGenContext.cxx
+++ b/roofit/roofitcore/src/RooSimSplitGenContext.cxx
@@ -228,7 +228,7 @@ RooDataSet* RooSimSplitGenContext::generate(Double_t nEvents, Bool_t skipInit, B
   // Perform any subclass implementation-specific initialization
   // Can be skipped if this is a rerun with an identical configuration
   if (!skipInit) {
-    initGenerator(*_theEvent);
+    initGenerator(_theEvent);
   }
 
   // Generate lookup table from expected event counts


### PR DESCRIPTION
This change is done to avoid using the memory pool for `RooArgSets` in
toy dataset generation workflows.
