### PR TITLE
[DF] Use assert, not R__ASSERT when checks are unnecessary in releases

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -21,6 +21,7 @@
 #include "RtypesCore.h"
 
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <string>
 #include <utility> // std::index_sequence
@@ -138,7 +139,7 @@ public:
 
    void TriggerChildrenCount() final
    {
-      R__ASSERT(!fName.empty()); // this method is to only be called on named filters
+      assert(!fName.empty()); // this method is to only be called on named filters
       fPrevData.IncrChildrenCount();
    }
 

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -15,6 +15,8 @@
 #include "ROOT/RDF/RMergeableValue.hxx"
 #include "TError.h"
 
+#include <cassert>
+
 using ROOT::Internal::RDF::RJittedAction;
 using ROOT::Detail::RDF::RLoopManager;
 
@@ -22,43 +24,43 @@ RJittedAction::RJittedAction(RLoopManager &lm) : RActionBase(&lm, {}, ROOT::Inte
 
 void RJittedAction::Run(unsigned int slot, Long64_t entry)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    fConcreteAction->Run(slot, entry);
 }
 
 void RJittedAction::Initialize()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    fConcreteAction->Initialize();
 }
 
 void RJittedAction::InitSlot(TTreeReader *r, unsigned int slot)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    fConcreteAction->InitSlot(r, slot);
 }
 
 void RJittedAction::TriggerChildrenCount()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    fConcreteAction->TriggerChildrenCount();
 }
 
 void RJittedAction::FinalizeSlot(unsigned int slot)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    fConcreteAction->FinalizeSlot(slot);
 }
 
 void RJittedAction::Finalize()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    fConcreteAction->Finalize();
 }
 
 void *RJittedAction::PartialUpdate(unsigned int slot)
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    return fConcreteAction->PartialUpdate(slot);
 }
 
@@ -74,13 +76,13 @@ bool RJittedAction::HasRun() const
 
 void RJittedAction::SetHasRun()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    return fConcreteAction->SetHasRun();
 }
 
 std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    return fConcreteAction->GetGraph();
 }
 
@@ -90,12 +92,12 @@ std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::Get
 */
 std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> RJittedAction::GetMergeableValue() const
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    return fConcreteAction->GetMergeableValue();
 }
 
 ROOT::RDF::SampleCallback_t RJittedAction::GetSampleCallback()
 {
-   R__ASSERT(fConcreteAction != nullptr);
+   assert(fConcreteAction != nullptr);
    return fConcreteAction->GetSampleCallback();
 }

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -9,42 +9,44 @@
  *************************************************************************/
 
 #include <ROOT/RDF/RJittedDefine.hxx>
-#include <TError.h> // R__ASSERT
+#include <TError.h> // assert
+
+#include <cassert>
 
 using namespace ROOT::Detail::RDF;
 
 void RJittedDefine::InitSlot(TTreeReader *r, unsigned int slot)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   assert(fConcreteDefine != nullptr);
    fConcreteDefine->InitSlot(r, slot);
 }
 
 void *RJittedDefine::GetValuePtr(unsigned int slot)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   assert(fConcreteDefine != nullptr);
    return fConcreteDefine->GetValuePtr(slot);
 }
 
 const std::type_info &RJittedDefine::GetTypeId() const
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   assert(fConcreteDefine != nullptr);
    return fConcreteDefine->GetTypeId();
 }
 
 void RJittedDefine::Update(unsigned int slot, Long64_t entry)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   assert(fConcreteDefine != nullptr);
    fConcreteDefine->Update(slot, entry);
 }
 
 void RJittedDefine::Update(unsigned int slot, const ROOT::RDF::RSampleInfo &id)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   assert(fConcreteDefine != nullptr);
    fConcreteDefine->Update(slot, id);
 }
 
 void RJittedDefine::FinaliseSlot(unsigned int slot)
 {
-   R__ASSERT(fConcreteDefine != nullptr);
+   assert(fConcreteDefine != nullptr);
    fConcreteDefine->FinaliseSlot(slot);
 }

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -13,6 +13,8 @@
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RJittedFilter.hxx"
 
+#include <cassert>
+
 using namespace ROOT::Detail::RDF;
 
 RJittedFilter::RJittedFilter(RLoopManager *lm, std::string_view name)
@@ -25,73 +27,73 @@ void RJittedFilter::SetFilter(std::unique_ptr<RFilterBase> f)
 
 void RJittedFilter::InitSlot(TTreeReader *r, unsigned int slot)
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->InitSlot(r, slot);
 }
 
 bool RJittedFilter::CheckFilters(unsigned int slot, Long64_t entry)
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    return fConcreteFilter->CheckFilters(slot, entry);
 }
 
 void RJittedFilter::Report(ROOT::RDF::RCutFlowReport &cr) const
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->Report(cr);
 }
 
 void RJittedFilter::PartialReport(ROOT::RDF::RCutFlowReport &cr) const
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->PartialReport(cr);
 }
 
 void RJittedFilter::FillReport(ROOT::RDF::RCutFlowReport &cr) const
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->FillReport(cr);
 }
 
 void RJittedFilter::IncrChildrenCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->IncrChildrenCount();
 }
 
 void RJittedFilter::StopProcessing()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->StopProcessing();
 }
 
 void RJittedFilter::ResetChildrenCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->ResetChildrenCount();
 }
 
 void RJittedFilter::TriggerChildrenCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->TriggerChildrenCount();
 }
 
 void RJittedFilter::ResetReportCount()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->ResetReportCount();
 }
 
 void RJittedFilter::FinaliseSlot(unsigned int slot)
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->FinaliseSlot(slot);
 }
 
 void RJittedFilter::InitNode()
 {
-   R__ASSERT(fConcreteFilter != nullptr);
+   assert(fConcreteFilter != nullptr);
    fConcreteFilter->InitNode();
 }
 


### PR DESCRIPTION
In particular, `RJitted{Action,Filter,Define}::Run` and similar functions
can be performance hotspots. Avoid the nullptr check there.

Many thanks to Josh Bendavid for reporting the problem.