### PR TITLE
[DF] Use different file names in different tests

### DIFF
--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -88,7 +88,7 @@ TEST(DefinePerSample, Jitted)
 
 TEST_P(DefinePerSample, Tree)
 {
-   const std::string prefix = "rdfdatablockcallback_ttree";
+   const std::string prefix = "rdfdefinepersample_tree";
    InputFilesRAII file(1u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
 
@@ -108,7 +108,7 @@ TEST_P(DefinePerSample, Tree)
 
 TEST_P(DefinePerSample, TChain)
 {
-   const std::string prefix = "rdfdatablockcallback_tchain";
+   const std::string prefix = "rdfdefinepersample_chain";
    InputFilesRAII file(5u, prefix);
    ROOT::RDataFrame df("t", prefix + "*");
 


### PR DESCRIPTION
These names collided with those in
tree/dataframe/test/dataframe_samplecallback.cxx.