### PR TITLE
Fix ROOT for musl libc

### DIFF
--- a/core/base/inc/Varargs.h
+++ b/core/base/inc/Varargs.h
@@ -44,12 +44,10 @@
 #endif
 
 #if !defined(R__VA_COPY)
-#  if defined(__GNUC__) && !defined(__FreeBSD__)
-#     define R__VA_COPY(to, from) __va_copy((to), (from))
+#  if defined(va_copy)
+#     define R__VA_COPY(to, from) va_copy((to), (from))
 #  elif defined(__va_copy)
 #     define R__VA_COPY(to, from) __va_copy((to), (from))
-#  elif defined(va_copy)
-#     define R__VA_COPY(to, from) va_copy((to), (from))
 #  elif defined(_WIN32) && _MSC_VER < 1310
 #     define R__VA_COPY(to, from) (*(to) = *(from))
 #  else

--- a/core/clib/src/mmapsup.c
+++ b/core/clib/src/mmapsup.c
@@ -42,13 +42,6 @@ typedef char* caddr_t;
 #include <cygwin/version.h>
 #endif /* __CYGWIN__ */
 
-#if defined(R__LINUX) && !defined(R__GLIBC) && !defined(__CYGWIN__) \
-   || (defined(__CYGWIN__) && (CYGWIN_VERSION_API_MAJOR > 0 || CYGWIN_VERSION_API_MINOR < 213))
-extern size_t getpagesize PARAMS ((void));
-#else
-extern int getpagesize PARAMS ((void));
-#endif
-
 #ifndef SEEK_SET
 #define SEEK_SET 0
 #endif

--- a/core/clib/src/mvalloc.c
+++ b/core/clib/src/mvalloc.c
@@ -29,13 +29,6 @@ Boston, MA 02111-1307, USA.  */
 #include <cygwin/version.h>
 #endif /* __CYGWIN__ */
 
-#if defined(R__LINUX) && !defined(R__GLIBC) && !defined(__CYGWIN__) \
-   || (defined(__CYGWIN__) && (CYGWIN_VERSION_API_MAJOR > 0 || CYGWIN_VERSION_API_MINOR < 213))
-extern size_t getpagesize PARAMS ((void));
-#else
-extern int getpagesize PARAMS ((void));
-#endif
-
 #ifdef VMS
 #undef _SC_PAGE_SIZE
 #undef _SC_PAGESIZE

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -214,7 +214,6 @@ extern "C" {
 
 // FPE handling includes
 #if (defined(R__LINUX) && !defined(R__WINGCC))
-#include <fpu_control.h>
 #include <fenv.h>
 #include <sys/prctl.h>    // for prctl() function used in StackTrace()
 #endif

--- a/math/mathcore/src/triangle.c
+++ b/math/mathcore/src/triangle.c
@@ -324,7 +324,7 @@
 #include <float.h>
 #endif /* CPU86 */
 #ifdef LINUX
-#include <fpu_control.h>
+#include <fenv.h>
 #endif /* LINUX */
 #ifdef TRILIBRARY
 #include "triangle.h"
@@ -4867,7 +4867,7 @@ void exactinit()
   REAL check, lastcheck;
   int every_other;
 #ifdef LINUX
-  int cword;
+  fenv_t fenv;
 #endif /* LINUX */
 
 #ifdef CPU86
@@ -4879,13 +4879,13 @@ void exactinit()
 #endif /* CPU86 */
 #ifdef LINUX
 #ifdef SINGLE
-  /*  cword = 4223; */
-  cword = 4210;                 /* set FPU control word for single precision */
+  /*  fenv.__control_word = 4223; */
+  fenv.__control_word = 4210;  /* set FPU control word for single precision */
 #else /* not SINGLE */
-  /*  cword = 4735; */
-  cword = 4722;                 /* set FPU control word for double precision */
+  /*  fenv.__control_word = 4735; */
+  fenv.__control_word = 4722;  /* set FPU control word for double precision */
 #endif /* not SINGLE */
-  _FPU_SETCW(cword);
+  fesetenv(&fenv);
 #endif /* LINUX */
 
   every_other = 1;


### PR DESCRIPTION
It is not possible to compile ROOT with musl libc because in several places it relies on glibc and uses non-standard constructs. This PR aims to fix that, at least to such an extent so that compilation against musl does not fail.