### PR TITLE
[test] Fix several tests on Win64

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -394,7 +394,9 @@ TEST(RDataFrameInterface, UnusedJittedNodes)
    hasThrown = false;
 
 // ROOT-10458
-#ifdef _WIN32
+#if defined(_WIN64)
+const std::string symbol = "`private: virtual void __cdecl RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody(void) __ptr64'::`2'::SimpleType";
+#elif defined(_WIN32)
 const std::string symbol = "`private: virtual void __thiscall RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody(void)'::`2'::SimpleType";
 #else
 const std::string symbol = "RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody()::SimpleType";

--- a/tree/tree/test/BulkApiMultiple.cxx
+++ b/tree/tree/test/BulkApiMultiple.cxx
@@ -302,6 +302,7 @@ TEST_F(BulkApiMultipleTest, stdRead)
       increment(idx, idx_g);
       idx++;
    }
+   delete hfile;
    sw.Stop();
    printf("TTreeReader: Successful read of all events.\n");
    printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());

--- a/tree/tree/test/BulkApiSillyStruct.cxx
+++ b/tree/tree/test/BulkApiSillyStruct.cxx
@@ -77,6 +77,7 @@ TEST_F(BulkApiSillyStructTest, stdReadStruct)
       evF++;
       evD++;
    }
+   delete hfile;
 }
 
 TEST_F(BulkApiSillyStructTest, stdReadSplitBranch)
@@ -99,6 +100,7 @@ TEST_F(BulkApiSillyStructTest, stdReadSplitBranch)
       evF++;
       evD++;
    }
+   delete hfile;
 }
 
 TEST_F(BulkApiSillyStructTest, fastRead)

--- a/tree/tree/test/BulkApiVarLength.cxx
+++ b/tree/tree/test/BulkApiVarLength.cxx
@@ -127,6 +127,7 @@ TEST_F(BulkApiVariableTest, stdRead)
       ev++;
    }
    ASSERT_EQ(ev, events+1);
+   delete hfile;
 
    sw.Stop();
    printf("TTreeReader: Successful read of all events.\n");


### PR DESCRIPTION
 - Add the proper Win64 mangled symbol of `RDataFrameInterface_TypeUnknownToInterpreter_Test::TestBody(void)`
 - Add several explicit `delete hfile` to prevent the following kind of error:
   ```
     SysError in <TFile::TFile>: could not delete BulkApiSillyStruct.root (errno: 13) Permission denied
   ```
