### PR TITLE
Revert "[cxxmodules] Enable a module if json is present."

### DIFF
--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -107,9 +107,7 @@ set(clinginclude ${CMAKE_SOURCE_DIR}/interpreter/cling/include)
 
 set(custom_modulemaps)
 if (runtime_cxxmodules)
-  set(custom_modulemaps boost.modulemap tinyxml2.modulemap cuda.modulemap
-                        module.modulemap.build
-                        json.modulemap)
+  set(custom_modulemaps boost.modulemap tinyxml2.modulemap cuda.modulemap module.modulemap.build)
   # FIXME: We should install vc.modulemap only when Vc is found (Vc_FOUND) but
   # some systems install it under /usr/include/Vc/Vc which allows rootcling to
   # discover it and assert that the modulemap is not found.

--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -136,23 +136,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
 
 if(builtin_nlohmannjson)
    target_include_directories(ROOTEve PRIVATE ${CMAKE_SOURCE_DIR}/builtins)
-   target_compile_definitions(ROOTEve INTERFACE NLOHMANN_JSON_PROVIDES_FWD_HPP)
 else()
    target_link_libraries(ROOTEve PUBLIC nlohmann_json::nlohmann_json)
-
-   get_target_property(inc_dirs nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
-   foreach(dir ${inc_dirs})
-      if(EXISTS "${dir}/nlohmann/json_fwd.hpp")
-         set(found_fwd true)
-      endif()
-   endforeach()
-
-   if(found_fwd)
-      target_compile_definitions(ROOTEve INTERFACE NLOHMANN_JSON_PROVIDES_FWD_HPP)
-   else()
-      message("-- missing nlohmann/json_fwd.hpp required by eve7")
-   endif()
-
 endif()
 
 # this is required for glew

--- a/graf3d/eve7/CMakeLists.txt
+++ b/graf3d/eve7/CMakeLists.txt
@@ -123,8 +123,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTEve
     src/REveViewer.cxx
     src/REveVSD.cxx
     src/REveVSDStructs.cxx
-  DICTIONARY_OPTIONS
-    -mByproduct Json
   DEPENDENCIES
     Core
     Geom

--- a/graf3d/eve7/inc/ROOT/REveElement.hxx
+++ b/graf3d/eve7/inc/ROOT/REveElement.hxx
@@ -18,11 +18,7 @@
 
 #include <memory>
 
-#ifdef NLOHMANN_JSON_PROVIDES_FWD_HPP
 #include <nlohmann/json_fwd.hpp>
-#else
-#include <nlohmann/json.hpp>
-#endif
 
 class TGeoMatrix;
 

--- a/graf3d/eve7/src/REveViewer.cxx
+++ b/graf3d/eve7/src/REveViewer.cxx
@@ -17,6 +17,8 @@
 #include <ROOT/REveManager.hxx>
 #include <ROOT/REveSelection.hxx>
 
+#include <nlohmann/json.hpp>
+
 using namespace ROOT::Experimental;
 namespace REX = ROOT::Experimental;
 

--- a/interpreter/cling/include/cling/json.modulemap
+++ b/interpreter/cling/include/cling/json.modulemap
@@ -1,4 +1,0 @@
-module Json {
-  header "nlohmann/json.hpp"
-  export *
-}

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -580,7 +580,6 @@ namespace {
     llvm::SmallString<256> tinyxml2IncLoc(getIncludePathForHeader(HS, "tinyxml2.h"));
     llvm::SmallString<256> cudaIncLoc(getIncludePathForHeader(HS, "cuda.h"));
     llvm::SmallString<256> vcVcIncLoc(getIncludePathForHeader(HS, "Vc/Vc"));
-    llvm::SmallString<256> jsonIncLoc(getIncludePathForHeader(HS, "nlohmann/json.hpp"));
     llvm::SmallString<256> clingIncLoc(getIncludePathForHeader(HS,
                                         "cling/Interpreter/RuntimeUniverse.h"));
 
@@ -703,11 +702,6 @@ namespace {
                               /*AllowModulemapOverride=*/ false);
     if (!vcVcIncLoc.empty())
       maybeAppendOverlayEntry(vcVcIncLoc.str(), "vc.modulemap",
-                              clingIncLoc.str(), MOverlay,
-                              /*RegisterModuleMap=*/ true,
-                              /*AllowModulemapOverride=*/ false);
-    if (!jsonIncLoc.empty())
-      maybeAppendOverlayEntry(jsonIncLoc.str(), "json.modulemap",
                               clingIncLoc.str(), MOverlay,
                               /*RegisterModuleMap=*/ true,
                               /*AllowModulemapOverride=*/ false);


### PR DESCRIPTION
Reverts root-project/root#9251 due to failures in LCG.

In 1c38aa0 we made it possible to use installed json versions which do not have `json_fwd.h` to forward declare the json classes. However in this case, that brings the entire json package in the dictionaries. In turn, then we will need to build Json.pcm to avoid content duplication. This in turn requires LCG to provide ROOT_INCLUDE_PATH=/path/to/json at runtime.

Is this all worth it?