### PR TITLE
[DF] Use `assert`, not `R__ASSERT` when we are checking for bugs

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1348,8 +1348,8 @@ public:
 
    void Finalize()
    {
-      R__ASSERT(fOutputTree != nullptr);
-      R__ASSERT(fOutputFile != nullptr);
+      assert(fOutputTree != nullptr);
+      assert(fOutputFile != nullptr);
 
       // use AutoSave to flush TTree contents because TTree::Write writes in gDirectory, not in fDirectory
       fOutputTree->AutoSave("flushbaskets");
@@ -1500,7 +1500,7 @@ public:
       const bool allNullFiles =
          std::all_of(fOutputFiles.begin(), fOutputFiles.end(),
                      [](const std::shared_ptr<ROOT::TBufferMergerFile> &ptr) { return ptr == nullptr; });
-      R__ASSERT(!allNullFiles);
+      assert(!allNullFiles);
 
       auto fileWritten = false;
       for (auto &file : fOutputFiles) {

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -19,7 +19,6 @@
 
 #include <ROOT/RDataSource.hxx>
 #include <ROOT/TypeTraits.hxx>
-#include <TError.h> // R__ASSERT
 #include <TTreeReader.h>
 
 #include <array>
@@ -71,7 +70,7 @@ MakeColumnReadersHelper(unsigned int slot, RDFDetail::RDefineBase *define,
 {
    const auto DSValuePtrsIt = DSValuePtrsMap.find(colName);
    const std::vector<void *> *DSValuePtrsPtr = DSValuePtrsIt != DSValuePtrsMap.end() ? &DSValuePtrsIt->second : nullptr;
-   R__ASSERT(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr || ds != nullptr);
+   assert(define != nullptr || r != nullptr || DSValuePtrsPtr != nullptr || ds != nullptr);
    return MakeColumnReader<T>(slot, define, r, ds, DSValuePtrsPtr, colName);
 }
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -16,8 +16,8 @@
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t
 #include "ROOT/RVec.hxx"
 #include "RtypesCore.h"
-#include "TError.h" // R_ASSERT
 
+#include <cassert>
 #include <string>
 #include <vector>
 
@@ -61,7 +61,7 @@ public:
    virtual void TriggerChildrenCount() = 0;
    virtual void ResetReportCount()
    {
-      R__ASSERT(!fName.empty()); // this method is to only be called on named filters
+      assert(!fName.empty()); // this method is to only be called on named filters
       // fAccepted and fRejected could be different than 0 if this is not the first event-loop run using this filter
       std::fill(fAccepted.begin(), fAccepted.end(), 0);
       std::fill(fRejected.begin(), fRejected.end(), 0);

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -452,7 +452,7 @@ bool RCsvDS::SetEntry(unsigned int slot, ULong64_t entry)
 
 void RCsvDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
+   assert(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
 
    fNSlots = nSlots;
 

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -194,7 +194,7 @@ static std::unordered_map<std::string, std::string> &GetJittedExprs() {
 static std::string
 BuildLambdaString(const std::string &expr, const ColumnNames_t &vars, const ColumnNames_t &varTypes)
 {
-   R__ASSERT(vars.size() == varTypes.size());
+   assert(vars.size() == varTypes.size());
 
    TPRegexp re(R"(\breturn\b)");
    const bool hasReturnStmt = re.MatchB(expr);

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -9,7 +9,6 @@
  *************************************************************************/
 
 #include <ROOT/RDF/RJittedDefine.hxx>
-#include <TError.h> // assert
 
 #include <cassert>
 

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -502,7 +502,7 @@ void RLoopManager::RunTreeReader()
 /// Run event loop over data accessed through a DataSource, in sequence.
 void RLoopManager::RunDataSource()
 {
-   R__ASSERT(fDataSource != nullptr);
+   assert(fDataSource != nullptr);
    fDataSource->Initialise();
    auto ranges = fDataSource->GetEntryRanges();
    while (!ranges.empty() && fNStopsReceived < fNChildren) {
@@ -534,7 +534,7 @@ void RLoopManager::RunDataSource()
 void RLoopManager::RunDataSourceMT()
 {
 #ifdef R__USE_IMT
-   R__ASSERT(fDataSource != nullptr);
+   assert(fDataSource != nullptr);
    RSlotStack slotStack(fNSlots);
    ROOT::TThreadExecutor pool;
 

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -57,7 +57,7 @@ public:
    ~RRDFCardinalityField() = default;
 
    // Field is only used for reading
-   void GenerateColumnsImpl() final { R__ASSERT(false && "Cardinality fields must only be used for reading"); }
+   void GenerateColumnsImpl() final { assert(false && "Cardinality fields must only be used for reading"); }
 
    void GenerateColumnsImpl(const RNTupleDescriptor &) final
    {
@@ -335,7 +335,7 @@ void RNTupleDS::SetNSlots(unsigned int nSlots)
 
    for (unsigned int i = 1; i < fNSlots; ++i) {
       fSources.emplace_back(fSources[0]->Clone());
-      R__ASSERT(i == (fSources.size() - 1));
+      assert(i == (fSources.size() - 1));
       fSources[i]->Attach();
    }
 }

--- a/tree/dataframe/src/RRootDS.cxx
+++ b/tree/dataframe/src/RRootDS.cxx
@@ -136,7 +136,7 @@ bool RRootDS::SetEntry(unsigned int slot, ULong64_t entry)
 
 void RRootDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
+   assert(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
 
    fNSlots = nSlots;
 

--- a/tree/dataframe/src/RSlotStack.cxx
+++ b/tree/dataframe/src/RSlotStack.cxx
@@ -10,8 +10,8 @@
 
 #include <ROOT/TSeq.hxx>
 #include <ROOT/RDF/RSlotStack.hxx>
-#include <TError.h> // R__ASSERT
 
+#include <cassert>
 #include <mutex> // std::lock_guard
 
 ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size)
@@ -23,14 +23,14 @@ ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size)
 void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slot)
 {
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
-   R__ASSERT(fStack.size() < fSize && "Trying to put back a slot to a full stack!");
+   assert(fStack.size() < fSize && "Trying to put back a slot to a full stack!");
    fStack.push(slot);
 }
 
 unsigned int ROOT::Internal::RDF::RSlotStack::GetSlot()
 {
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
-   R__ASSERT(!fStack.empty() && "Trying to pop a slot from an empty stack!");
+   assert(!fStack.empty() && "Trying to pop a slot from an empty stack!");
    const auto slot = fStack.top();
    fStack.pop();
    return slot;

--- a/tree/dataframe/src/RSqliteDS.cxx
+++ b/tree/dataframe/src/RSqliteDS.cxx
@@ -553,7 +553,7 @@ RDataFrame MakeSqliteDataFrame(std::string_view fileName, std::string_view query
 /// Stores the result of the current active sqlite query row as a C++ value.
 bool RSqliteDS::SetEntry(unsigned int /* slot */, ULong64_t entry)
 {
-   R__ASSERT(entry + 1 == fNRow);
+   assert(entry + 1 == fNRow);
    unsigned N = fValues.size();
    for (unsigned i = 0; i < N; ++i) {
       if (!fValues[i].fIsActive)

--- a/tree/dataframe/src/RTrivialDS.cxx
+++ b/tree/dataframe/src/RTrivialDS.cxx
@@ -88,7 +88,7 @@ bool RTrivialDS::SetEntry(unsigned int slot, ULong64_t entry)
 
 void RTrivialDS::SetNSlots(unsigned int nSlots)
 {
-   R__ASSERT(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
+   assert(0U == fNSlots && "Setting the number of slots even if the number of slots is different from zero.");
 
    fNSlots = nSlots;
    fCounter.resize(fNSlots);


### PR DESCRIPTION
These usages of `R__ASSERT` were meant to check preconditions
that are guaranteed by the program's logic, i.e. are only
relevant for catching bugs in our code. Let's disable them
in production code.