### PR TITLE
[v620][RF] Cleanup `RooRealVar::_sharedPropList` in RooRealVar destructor

### DIFF
--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -126,6 +126,8 @@ public:
 
   void copyCacheFast(const RooRealVar& other, Bool_t setValDirty=kTRUE) { _value = other._value ; if (setValDirty) setValueDirty() ; }
 
+  static void cleanup() ;
+
   protected:
 
   static Bool_t _printScientific ;
@@ -156,7 +158,7 @@ public:
 
   virtual void setExpensiveObjectCache(RooExpensiveObjectCache&) { ; } // variables don't need caches 
   static RooRealVarSharedProperties& _nullProp(); // Null property
-  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>& _sharedPropList(); // List of properties shared among clones of a variable
+  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>* sharedPropList(); // List of properties shared among clones of a variable
   
   std::shared_ptr<RooRealVarSharedProperties> _sharedProp; //! Shared binnings associated with this instance
 

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -155,9 +155,9 @@ public:
   void installSharedProp(std::shared_ptr<RooRealVarSharedProperties>&& prop);
 
   virtual void setExpensiveObjectCache(RooExpensiveObjectCache&) { ; } // variables don't need caches 
+  static RooRealVarSharedProperties& _nullProp(); // Null property
+  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>& _sharedPropList(); // List of properties shared among clones of a variable
   
-  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>> _sharedPropList; // List of properties shared among clones of a variable
-  static const std::unique_ptr<RooRealVarSharedProperties> _nullProp ; // Null property
   std::shared_ptr<RooRealVarSharedProperties> _sharedProp; //! Shared binnings associated with this instance
 
   ClassDef(RooRealVar,6) // Real-valued variable

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -48,9 +48,20 @@ ClassImp(RooRealVar);
 
 Bool_t RooRealVar::_printScientific(kFALSE) ;
 Int_t  RooRealVar::_printSigDigits(5) ;
-std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>> RooRealVar::_sharedPropList;
-const std::unique_ptr<RooRealVarSharedProperties> RooRealVar::_nullProp(new RooRealVarSharedProperties("00000000-0000-0000-0000-000000000000"));
 
+/// Return a reference to a map of weak pointers to RooRealVarSharedProperties.
+std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>& RooRealVar::_sharedPropList() 
+{
+  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>> sharedPropList;
+  return sharedPropList; 
+}
+
+/// Return a dummy object to use when properties are not initialised.
+RooRealVarSharedProperties& RooRealVar::_nullProp()
+{
+  static const std::unique_ptr<RooRealVarSharedProperties> nullProp(new RooRealVarSharedProperties("00000000-0000-0000-0000-000000000000"));
+  return *nullProp; 
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
@@ -1241,7 +1252,7 @@ void RooRealVar::Streamer(TBuffer &R__b)
     if (_sharedProp) {
       _sharedProp->Streamer(R__b) ;
     } else {
-      _nullProp->Streamer(R__b) ;
+      _nullProp().Streamer(R__b) ;
     }
     R__b.SetByteCount(R__c, kTRUE);
 
@@ -1265,13 +1276,13 @@ std::shared_ptr<RooRealVarSharedProperties> RooRealVar::sharedProp() const {
 /// and share the existing.
 /// `nullptr` and properties equal to the RooRealVar::_nullProp will not be installed.
 void RooRealVar::installSharedProp(std::shared_ptr<RooRealVarSharedProperties>&& prop) {
-  if (prop == nullptr || (*prop == *_nullProp)) {
+  if (prop == nullptr || (*prop == _nullProp())) {
     _sharedProp = nullptr;
     return;
   }
 
 
-  auto& weakPtr = _sharedPropList[prop->asString().Data()];
+  auto& weakPtr = _sharedPropList()[prop->asString().Data()];
   std::shared_ptr<RooRealVarSharedProperties> existingProp;
   if ( (existingProp = weakPtr.lock()) ) {
     // Property exists, discard incoming
@@ -1292,9 +1303,9 @@ void RooRealVar::deleteSharedProperties()
 {
   _sharedProp.reset();
 
-  for (auto it = _sharedPropList.begin(); it != _sharedPropList.end();) {
+  for (auto it = _sharedPropList().begin(); it != _sharedPropList().end();) {
     if (it->second.expired()) {
-      it = _sharedPropList.erase(it);
+      it = _sharedPropList().erase(it);
     } else {
       ++it;
     }

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -38,6 +38,7 @@ optionally a series of alternate named ranges.
 #include "RooTrace.h"
 #include "RooRealVarSharedProperties.h"
 #include "RooUniformBinning.h"
+#include "RooSentinel.h"
 
 #include "TTree.h"
 
@@ -49,11 +50,30 @@ ClassImp(RooRealVar);
 Bool_t RooRealVar::_printScientific(kFALSE) ;
 Int_t  RooRealVar::_printSigDigits(5) ;
 
+static bool staticSharedPropListCleanedUp = false;
+
 /// Return a reference to a map of weak pointers to RooRealVarSharedProperties.
-std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>& RooRealVar::_sharedPropList() 
+std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>* RooRealVar::sharedPropList()
 {
-  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>> sharedPropList;
-  return sharedPropList; 
+  RooSentinel::activate();
+  if(!staticSharedPropListCleanedUp) {
+    static auto * staticSharedPropList = new std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>();
+    return staticSharedPropList;
+  }
+  return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Explicitely deletes the shared properties list on exit to avoid problems
+/// with the initialization order. Meant to be only used internally in RooFit
+/// by RooSentinel.
+
+void RooRealVar::cleanup()
+{
+  if(sharedPropList()) {
+    delete sharedPropList();
+    staticSharedPropListCleanedUp = true;
+  }
 }
 
 /// Return a dummy object to use when properties are not initialised.
@@ -212,6 +232,11 @@ RooRealVar& RooRealVar::operator=(const RooRealVar& other) {
 RooRealVar::~RooRealVar()
 {
   _altNonSharedBinning.Delete() ;
+
+  // We should not forget to explicitely call deleteSharedProperties() in the
+  // destructor, because this is where the expired weak_ptrs in the
+  // _sharedPropList get erased.
+  deleteSharedProperties();
 
   TRACE_DESTROY
 }
@@ -1282,7 +1307,7 @@ void RooRealVar::installSharedProp(std::shared_ptr<RooRealVarSharedProperties>&&
   }
 
 
-  auto& weakPtr = _sharedPropList()[prop->asString().Data()];
+  auto& weakPtr = (*sharedPropList())[prop->asString().Data()];
   std::shared_ptr<RooRealVarSharedProperties> existingProp;
   if ( (existingProp = weakPtr.lock()) ) {
     // Property exists, discard incoming
@@ -1301,14 +1326,26 @@ void RooRealVar::installSharedProp(std::shared_ptr<RooRealVarSharedProperties>&&
 /// Stop sharing properties.
 void RooRealVar::deleteSharedProperties()
 {
+  // Nothing to do if there were no shared properties to begin with.
+  if(!_sharedProp) return;
+
+  // Get the key for the _sharedPropList.
+  const std::string key = _sharedProp->asString().Data();
+
+  // Actually delete the shared properties object.
   _sharedProp.reset();
 
-  for (auto it = _sharedPropList().begin(); it != _sharedPropList().end();) {
-    if (it->second.expired()) {
-      it = _sharedPropList().erase(it);
-    } else {
-      ++it;
-    }
+  // If the _sharedPropList was already deleted, we can return now.
+  if(!sharedPropList()) return;
+
+  // Find the std::weak_ptr that the _sharedPropList holds to our
+  // _sharedProp.
+  auto iter = sharedPropList()->find(key);
+
+  // If no other RooRealVars shared the shared properties with us, the
+  // weak_ptr in _sharedPropList is expired and we can erase it from the map.
+  if(iter->second.expired()) {
+    sharedPropList()->erase(iter);
   }
 }
 

--- a/roofit/roofitcore/src/RooSentinel.cxx
+++ b/roofit/roofitcore/src/RooSentinel.cxx
@@ -46,6 +46,7 @@ static void CleanUpRooFitAtExit()
   RooMinuit::cleanup() ;
   RooArgSet::cleanup() ;
   RooDataSet::cleanup();
+  RooRealVar::cleanup();
 }
 
 


### PR DESCRIPTION
Backport of commit https://github.com/root-project/root/commit/f9eff417eea084261c3d27f4fb636f94db37138c from https://github.com/root-project/root/pull/9270.

Includes also commit https://github.com/root-project/root/commit/8b216dec994bb9a963ec2006add3d3fe6976e877 to avoid backporting conflicts.

