### PR TITLE
Fix ROOT for musl libc - part 2

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -148,17 +148,6 @@
 #   define UTMP_NO_ADDR
 #endif
 
-#if (defined(R__AIX) && !defined(_AIX43)) || \
-    (defined(R__SUNGCC3) && !defined(__arch64__))
-#   define USE_SIZE_T
-#elif defined(R__GLIBC) || defined(R__FBSD) || \
-      (defined(R__SUNGCC3) && defined(__arch64__)) || \
-      defined(R__OBSD) || defined(MAC_OS_X_VERSION_10_4) || \
-      (defined(R__AIX) && defined(_AIX43)) || \
-      (defined(R__SOLARIS) && defined(_SOCKLEN_T))
-#   define USE_SOCKLEN_T
-#endif
-
 #if defined(R__LYNXOS)
 extern "C" {
    extern int putenv(const char *);
@@ -3073,13 +3062,7 @@ TInetAddress TUnixSystem::GetHostByName(const char *hostname)
 TInetAddress TUnixSystem::GetSockName(int sock)
 {
    struct sockaddr addr;
-#if defined(USE_SIZE_T)
-   size_t len = sizeof(addr);
-#elif defined(USE_SOCKLEN_T)
    socklen_t len = sizeof(addr);
-#else
-   int len = sizeof(addr);
-#endif
 
    TInetAddress ia;
    if (getsockname(sock, &addr, &len) == -1) {
@@ -3109,13 +3092,7 @@ TInetAddress TUnixSystem::GetSockName(int sock)
 TInetAddress TUnixSystem::GetPeerName(int sock)
 {
    struct sockaddr addr;
-#if defined(USE_SIZE_T)
-   size_t len = sizeof(addr);
-#elif defined(USE_SOCKLEN_T)
    socklen_t len = sizeof(addr);
-#else
-   int len = sizeof(addr);
-#endif
 
    TInetAddress ia;
    if (getpeername(sock, &addr, &len) == -1) {
@@ -3482,13 +3459,7 @@ int TUnixSystem::GetSockOpt(int sock, int opt, int *val)
 {
    if (sock < 0) return -1;
 
-#if defined(USE_SOCKLEN_T) || defined(_AIX43)
    socklen_t optlen = sizeof(*val);
-#elif defined(USE_SIZE_T)
-   size_t optlen = sizeof(*val);
-#else
-   int optlen = sizeof(*val);
-#endif
 
    switch (opt) {
    case kSendBuffer:

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -453,7 +453,7 @@ namespace cling {
 
     // Intercept all atexit calls, as the Interpreter and functions will be long
     // gone when the -native- versions invoke them.
-#if defined(__linux__)
+#if defined(__GLIBC__)
     const char* LinkageCxx = "extern \"C++\"";
     const char* Attr = LangOpts.CPlusPlus ? " throw () " : "";
 #else

--- a/io/io/src/TMapFile.cxx
+++ b/io/io/src/TMapFile.cxx
@@ -107,9 +107,7 @@ robust Streamer mechanism I opted for 3).
 #include <sys/types.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
-#if defined(R__HPUX) || \
-    defined (R__SOLARIS) || defined(R__AIX) || defined(R__HIUX) || \
-    __GLIBC_MINOR__ > 0
+#ifndef WIN32
 union semun {
    int val;                      // value for SETVAL
    struct semid_ds *buf;         // buffer for IPC_STAT & IPC_SET

--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -577,62 +577,12 @@ struct Limits {
 // Trig and other functions
 
 #include <float.h>
+#include <math.h>
 
 #if defined(R__WIN32) && !defined(__CINT__)
 #   ifndef finite
 #      define finite _finite
 #   endif
-#endif
-#if defined(R__AIX) || defined(R__SOLARIS_CC50) || \
-    defined(R__HPUX11) || defined(R__GLIBC) || \
-    (defined(R__MACOSX) )
-// math functions are defined inline so we have to include them here
-#   include <math.h>
-#   ifdef R__SOLARIS_CC50
-       extern "C" { int finite(double); }
-#   endif
-// #   if defined(R__GLIBC) && defined(__STRICT_ANSI__)
-// #      ifndef finite
-// #         define finite __finite
-// #      endif
-// #      ifndef isnan
-// #         define isnan  __isnan
-// #      endif
-// #   endif
-#else
-// don't want to include complete <math.h>
-extern "C" {
-   extern double sin(double);
-   extern double cos(double);
-   extern double tan(double);
-   extern double sinh(double);
-   extern double cosh(double);
-   extern double tanh(double);
-   extern double asin(double);
-   extern double acos(double);
-   extern double atan(double);
-   extern double atan2(double, double);
-   extern double sqrt(double);
-   extern double exp(double);
-   extern double pow(double, double);
-   extern double log(double);
-   extern double log10(double);
-#ifndef R__WIN32
-#   if !defined(finite)
-       extern int finite(double);
-#   endif
-#   if !defined(isnan)
-       extern int isnan(double);
-#   endif
-   extern double ldexp(double, int);
-   extern double ceil(double);
-   extern double floor(double);
-#else
-   _CRTIMP double ldexp(double, int);
-   _CRTIMP double ceil(double);
-   _CRTIMP double floor(double);
-#endif
-}
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/net/rpdutils/src/daemon.cxx
+++ b/net/rpdutils/src/daemon.cxx
@@ -24,8 +24,7 @@
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/param.h>
-#if defined(__sun) || defined(__sgi)
-#  include <fcntl.h>
+#include <fcntl.h>
 #endif
 
 #if defined(__linux__) && !defined(linux)

--- a/net/rpdutils/src/daemon.cxx
+++ b/net/rpdutils/src/daemon.cxx
@@ -43,15 +43,6 @@
 #   define NOFILE 0
 #endif
 
-#if defined(__hpux)
-#define USE_SIGCHLD
-#endif
-
-#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-#define USE_SIGCHLD
-#define SIGCLD SIGCHLD
-#endif
-
 #if defined(linux) || defined(__hpux) || defined(__sun) || defined(__sgi) || \
     defined(_AIX) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
     defined(__APPLE__) || defined(__MACH__) || \
@@ -68,23 +59,16 @@ namespace ROOT {
 
 extern ErrorHandler_t gErrSys;
 
-#if defined(USE_SIGCHLD)
 ////////////////////////////////////////////////////////////////////////////////
 
 static void SigChild(int)
 {
-   int         pid;
-#if defined(__hpux) || defined(__FreeBSD__) || defined(__OpenBSD__) || \
-    defined(__APPLE__)
+   int pid;
    int status;
-#else
-   union wait  status;
-#endif
 
    while ((pid = wait3(&status, WNOHANG, 0)) > 0)
       ;
 }
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Detach a daemon process from login session context.
@@ -207,15 +191,7 @@ out:
    // and execute the wait3() system call.
 
    if (ignsigcld) {
-#ifdef USE_SIGCHLD
-      signal(SIGCLD, SigChild);
-#else
-#if defined(__sun)
-      sigignore(SIGCHLD);
-#else
-      signal(SIGCLD, SIG_IGN);
-#endif
-#endif
+      signal(SIGCHLD, SigChild);
    }
 }
 

--- a/net/rpdutils/src/daemon.cxx
+++ b/net/rpdutils/src/daemon.cxx
@@ -25,7 +25,6 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 #include <fcntl.h>
-#endif
 
 #if defined(__linux__) && !defined(linux)
 # define linux

--- a/net/rpdutils/src/net.cxx
+++ b/net/rpdutils/src/net.cxx
@@ -31,17 +31,6 @@
 #include <netdb.h>
 #include <errno.h>
 
-#if (defined(R__AIX) && !defined(_AIX43)) || \
-    (defined(R__SUNGCC3) && !defined(__arch64__))
-#   define USE_SIZE_T
-#elif defined(R__GLIBC) || defined(R__FBSD) || \
-     (defined(R__SUNGCC3) && defined(__arch64__)) || \
-     defined(R__OBSD) || defined(MAC_OS_X_VERSION_10_4) || \
-     (defined(R__AIX) && defined(_AIX43)) || \
-     (defined(R__SOLARIS) && defined(_SOCKLEN_T))
-#   define USE_SOCKLEN_T
-#endif
-
 #include "rpdp.h"
 #include "rpderr.h"
 
@@ -357,13 +346,7 @@ int NetRecv(char *msg, int max)
 
 int NetOpen(int inetdflag, EService service)
 {
-#if defined(USE_SIZE_T)
-   size_t clilen = sizeof(gTcpCliAddr);
-#elif defined(USE_SOCKLEN_T)
    socklen_t clilen = sizeof(gTcpCliAddr);
-#else
-   int clilen = sizeof(gTcpCliAddr);
-#endif
 
    if (inetdflag) {
 
@@ -588,13 +571,7 @@ void NetSetOptions(EService serv, int sock, int tcpwindowsize)
          ErrorInfo("NetSetOptions: set SO_RCVBUF %d", val);
 
    if (gDebug > 0) {
-#if defined(USE_SIZE_T)
-      size_t optlen = sizeof(val);
-#elif defined(USE_SOCKLEN_T)
       socklen_t optlen = sizeof(val);
-#else
-      int optlen = sizeof(val);
-#endif
       if (serv == kROOTD) {
          getsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char*)&val, &optlen);
          ErrorInfo("NetSetOptions: get TCP_NODELAY: %d", val);

--- a/net/rpdutils/src/netpar.cxx
+++ b/net/rpdutils/src/netpar.cxx
@@ -37,17 +37,6 @@
 #include <strings.h>
 #endif
 
-#if (defined(R__AIX) && !defined(_AIX43)) || \
-    (defined(R__SUNGCC3) && !defined(__arch64__))
-#   define USE_SIZE_T
-#elif defined(R__GLIBC) || defined(R__FBSD) || \
-      (defined(R__SUNGCC3) && defined(__arch64__)) || \
-      defined(R__OBSD) || defined(MAC_OS_X_VERSION_10_4) || \
-      (defined(R__AIX) && defined(_AIX43)) || \
-      (defined(R__SOLARIS) && defined(_SOCKLEN_T))
-#   define USE_SOCKLEN_T
-#endif
-
 #include "rpdp.h"
 
 extern int gDebug;
@@ -201,13 +190,7 @@ int NetParOpen(int port, int size)
    struct sockaddr_in remote_addr;
    memset(&remote_addr, 0, sizeof(remote_addr));
 
-#if defined(USE_SIZE_T)
-   size_t remlen = sizeof(remote_addr);
-#elif defined(USE_SOCKLEN_T)
    socklen_t remlen = sizeof(remote_addr);
-#else
-   int remlen = sizeof(remote_addr);
-#endif
 
    if (!getpeername(NetGetSockFd(), (struct sockaddr *)&remote_addr, &remlen)) {
       remote_addr.sin_family = AF_INET;


### PR DESCRIPTION
Continuation of #9260, closes #9253. Successfully compiles and launches with both musl and glibc, however the affected features were **not** specifically tested so please make sure to review carefully.

With musl, compilation only succeeds without builtin XRootD and TBB and without SSL support - the former need to be fixed in the respective projects, the latter would probably require a little more effort as the `ruserok` function used by `net/rpdutils/src/rpdutils.cxx` is not available in musl - this implies `-Dxrootd=OFF -Dimt=OFF -Dssl=OFF` `cmake` options.