### PR TITLE
Fix compilation warnings on Win64

### DIFF
--- a/graf2d/win32gdk/gdk/src/gdk/gdkrgb.c
+++ b/graf2d/win32gdk/gdk/src/gdk/gdkrgb.c
@@ -92,9 +92,9 @@ struct _GdkRgbInfo {
    GdkVisual *visual;
    GdkColormap *cmap;
 
-   gulong *color_pixels;
-   gulong *gray_pixels;
-   gulong *reserved_pixels;
+   unsigned long *color_pixels;
+   unsigned long *gray_pixels;
+   unsigned long *reserved_pixels;
 
    guint nred_shades;
    guint ngreen_shades;
@@ -148,9 +148,9 @@ static guchar *colorcube;
 static guchar *colorcube_d;
 
 static gint
-gdk_rgb_cmap_fail(const char *msg, GdkColormap * cmap, gulong * pixels)
+gdk_rgb_cmap_fail(const char *msg, GdkColormap * cmap, unsigned long * pixels)
 {
-   gulong free_pixels[256];
+   unsigned long free_pixels[256];
    gint n_free;
    gint i;
 
@@ -167,7 +167,7 @@ gdk_rgb_cmap_fail(const char *msg, GdkColormap * cmap, gulong * pixels)
 }
 
 static void
-gdk_rgb_make_colorcube(gulong * pixels, gint nr, gint ng, gint nb)
+gdk_rgb_make_colorcube(unsigned long * pixels, gint nr, gint ng, gint nb)
 {
    guchar rt[16], gt[16], bt[16];
    gint i;
@@ -191,7 +191,7 @@ gdk_rgb_make_colorcube(gulong * pixels, gint nr, gint ng, gint nb)
 
 /* this is the colorcube suitable for dithering */
 static void
-gdk_rgb_make_colorcube_d(gulong * pixels, gint nr, gint ng, gint nb)
+gdk_rgb_make_colorcube_d(unsigned long * pixels, gint nr, gint ng, gint nb)
 {
    gint r, g, b;
    gint i;
@@ -214,8 +214,8 @@ static gint gdk_rgb_try_colormap(gint nr, gint ng, gint nb)
    gint r0, g0, b0;
    GdkColormap *cmap;
    GdkColor color;
-   gulong pixels[256];
-   gulong junk[256];
+   unsigned long pixels[256];
+   unsigned long junk[256];
    gint i;
    gint d2;
    gint colors_needed;
@@ -488,7 +488,7 @@ static void gdk_rgb_set_gray_cmap(GdkColormap * cmap)
    gint i;
    GdkColor color;
    gint status;
-   gulong pixels[256];
+   unsigned long pixels[256];
    gint r, g, b, gray;
 
    for (i = 0; i < 256; i++) {
@@ -630,9 +630,9 @@ void gdk_rgb_init(void)
 }
 
 /* convert an rgb value into an X pixel code */
-gulong gdk_rgb_xpixel_from_rgb(guint32 rgb)
+unsigned long gdk_rgb_xpixel_from_rgb(guint32 rgb)
 {
-   gulong pixel = 0;
+   unsigned long pixel = 0;
 
    if (image_info->bitmap) {
       return ((rgb & 0xff0000) >> 16) +

--- a/graf2d/win32gdk/gdk/src/gdk/gdkrgb.h
+++ b/graf2d/win32gdk/gdk/src/gdk/gdkrgb.h
@@ -43,7 +43,7 @@ extern "C" {
    void
     gdk_rgb_init(void);
 
-    gulong gdk_rgb_xpixel_from_rgb(guint32 rgb);
+    unsigned long gdk_rgb_xpixel_from_rgb(guint32 rgb);
 
    void
     gdk_rgb_gc_set_foreground(GdkGC * gc, guint32 rgb);

--- a/graf2d/win32gdk/gdk/src/glib/giochannel.c
+++ b/graf2d/win32gdk/gdk/src/glib/giochannel.c
@@ -1722,7 +1722,7 @@ g_io_channel_read_chars (GIOChannel	*channel,
 
   if (!channel->use_buffer)
     {
-      gint tmp_bytes;
+      gsize tmp_bytes;
       
       g_assert (!channel->read_buf || channel->read_buf->len == 0);
 
@@ -1914,7 +1914,7 @@ g_io_channel_write_chars (GIOChannel	*channel,
 
   if (!channel->use_buffer)
     {
-      gint tmp_bytes;
+      gsize tmp_bytes;
       
       g_assert (!channel->write_buf || channel->write_buf->len == 0);
       g_assert (channel->partial_write_buf[0] == '\0');

--- a/graf2d/win32gdk/gdk/src/glib/glibconfig-bogus.h
+++ b/graf2d/win32gdk/gdk/src/glib/glibconfig-bogus.h
@@ -84,11 +84,11 @@ typedef unsigned long long guint64;
 #define G_GINT64_FORMAT "I64i"
 #define G_GUINT64_FORMAT "I64u"
 
-typedef gint32 gssize;
-typedef guint32 gsize;
+typedef intptr_t  gssize;
+typedef uintptr_t gsize;
 
-#define GPOINTER_TO_INT(p)	((gint)(p))
-#define GPOINTER_TO_UINT(p)	((guint)(p))
+#define GPOINTER_TO_INT(p)	((intptr_t)   (p))
+#define GPOINTER_TO_UINT(p)	((uintptr_t)  (p))
 
 #define GINT_TO_POINTER(i)	((gpointer)(i))
 #define GUINT_TO_POINTER(u)	((gpointer)(u))

--- a/graf2d/win32gdk/gdk/src/glib/glibconfig.h.win32
+++ b/graf2d/win32gdk/gdk/src/glib/glibconfig.h.win32
@@ -64,11 +64,11 @@ typedef unsigned __int64 guint64;
 #define GLIB_SIZEOF_LONG   4
 #define GLIB_SIZEOF_SIZE_T 4
 
-typedef gint32  gssize;
-typedef guint32 gsize;
+typedef intptr_t  gssize;
+typedef uintptr_t gsize;
 
-#define GPOINTER_TO_INT(p)	((gint)   (p))
-#define GPOINTER_TO_UINT(p)	((guint)  (p))
+#define GPOINTER_TO_INT(p)	((intptr_t)   (p))
+#define GPOINTER_TO_UINT(p)	((uintptr_t)  (p))
 
 #define GINT_TO_POINTER(i)	((gpointer)  (i))
 #define GUINT_TO_POINTER(u)	((gpointer)  (u))

--- a/graf2d/win32gdk/gdk/src/glib/gspawn-win32.c
+++ b/graf2d/win32gdk/gdk/src/glib/gspawn-win32.c
@@ -188,7 +188,7 @@ read_data (GString     *str,
            GError     **error)
 {
   GIOError gioerror;
-  gint bytes;
+  gsize bytes;
   gchar buf[4096];
 
  again:


### PR DESCRIPTION
Fix compilation warnings on Win64, as shown below, by using proper long types
```
  gcompletion.c(47): warning C4028: formal parameter 3 different from declaration [C:\Users\bellenot\build\x64\release\graf2d\win32gdk\glib.vcxproj]
  gconvert.c(105): warning C4133: 'function': incompatible types - from 'gsize *' to 'size_t *' [C:\Users\bellenot\build\x64\release\graf2d\win32gdk\glib.vcxproj]
  gconvert.c(460): warning C4133: 'function': incompatible types - from 'size_t *' to 'gsize *' [C:\Users\bellenot\build\x64\release\graf2d\win32gdk\glib.vcxproj]
  gdataset.c(552): warning C4311: 'type cast': pointer truncation from 'gpointer' to 'guint' [C:\Users\bellenot\build\x64\release\graf2d\win32gdk\glib.vcxproj]
  giochannel.c(1238): warning C4133: 'function': incompatible types - from 'size_t *' to 'gsize *' [C:\Users\bellenot\build\x64\release\graf2d\win32gdk\glib.vcxproj]
  gmem.c(662): warning C4311: 'type cast': pointer truncation from 'gpointer' to 'guint' [C:\Users\bellenot\build\x64\release\graf2d\win32gdk\glib.vcxproj]
  ...
```
