### PR TITLE
Fix for TRatioPlot axes sync

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -181,6 +181,7 @@ public:
    virtual void     Print(const char *filename, Option_t *option) = 0;
    virtual void     Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2) = 0;
    virtual void     RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) = 0;
+   virtual void     RangeAxis() = 0;
            void     RecursiveRemove(TObject *obj) override = 0;
    virtual void     RedrawAxis(Option_t *option="") = 0;
    virtual void     ResetView3D(TObject *view=0) = 0;

--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -181,7 +181,7 @@ public:
    virtual void     Print(const char *filename, Option_t *option) = 0;
    virtual void     Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2) = 0;
    virtual void     RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) = 0;
-   virtual void     RangeAxis() = 0;
+   virtual void     RangeAxisChanged() { Emit("RangeAxisChanged()"); } // *SIGNAL*
            void     RecursiveRemove(TObject *obj) override = 0;
    virtual void     RedrawAxis(Option_t *option="") = 0;
    virtual void     ResetView3D(TObject *view=0) = 0;

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -307,8 +307,7 @@ public:
    void              Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override; // *MENU* *ARGS={x1=>fX1,y1=>fY1,x2=>fX2,y2=>fY2}
    virtual void      RangeChanged() { Emit("RangeChanged()"); } // *SIGNAL*
    void              RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) override;
-   void              RangeAxis() override;
-   virtual void      RangeAxisChanged() { Emit("RangeAxisChanged()"); } // *SIGNAL*
+   virtual void      RangeAxisChanged() override { Emit("RangeAxisChanged()"); } // *SIGNAL*
    void              RecursiveRemove(TObject *obj) override;
    void              RedrawAxis(Option_t *option="") override;
    void              ResetView3D(TObject *view=nullptr) override { fPadView3D=view; }

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -307,6 +307,7 @@ public:
    void              Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override; // *MENU* *ARGS={x1=>fX1,y1=>fY1,x2=>fX2,y2=>fY2}
    virtual void      RangeChanged() { Emit("RangeChanged()"); } // *SIGNAL*
    void              RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) override;
+   void              RangeAxis() override;
    virtual void      RangeAxisChanged() { Emit("RangeAxisChanged()"); } // *SIGNAL*
    void              RecursiveRemove(TObject *obj) override;
    void              RedrawAxis(Option_t *option="") override;

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -307,7 +307,6 @@ public:
    void              Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2) override; // *MENU* *ARGS={x1=>fX1,y1=>fY1,x2=>fX2,y2=>fY2}
    virtual void      RangeChanged() { Emit("RangeChanged()"); } // *SIGNAL*
    void              RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) override;
-   virtual void      RangeAxisChanged() override { Emit("RangeAxisChanged()"); } // *SIGNAL*
    void              RecursiveRemove(TObject *obj) override;
    void              RedrawAxis(Option_t *option="") override;
    void              ResetView3D(TObject *view=nullptr) override { fPadView3D=view; }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5234,7 +5234,7 @@ void TPad::RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax)
    RangeAxisChanged();
 }
 
-void TPad::RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax)
+void TPad::RangeAxis()
 {
    // emit signal
    RangeAxisChanged();

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5234,6 +5234,12 @@ void TPad::RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax)
    RangeAxisChanged();
 }
 
+void TPad::RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax)
+{
+   // emit signal
+   RangeAxisChanged();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Recursively remove object from a pad and its sub-pads.
 

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -5234,12 +5234,6 @@ void TPad::RangeAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax)
    RangeAxisChanged();
 }
 
-void TPad::RangeAxis()
-{
-   // emit signal
-   RangeAxisChanged();
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Recursively remove object from a pad and its sub-pads.
 

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -4569,6 +4569,7 @@ void THistPainter::Paint(Option_t *option)
       return;
    }
 
+   gPad->RangeAxis(); //emit RangeAxisChanged() signal to sync axes
    // fill Hparam structure with histo parameters
    if (!PaintInit()) {
       delete [] fXbuf; delete [] fYbuf;

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -4569,7 +4569,7 @@ void THistPainter::Paint(Option_t *option)
       return;
    }
 
-   gPad->RangeAxis(); //emit RangeAxisChanged() signal to sync axes
+   gPad->RangeAxisChanged(); //emit RangeAxisChanged() signal to sync axes
    // fill Hparam structure with histo parameters
    if (!PaintInit()) {
       delete [] fXbuf; delete [] fYbuf;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Fix for TRatioPlot axes sync:
   - Added TPad::RangeAxis() which only emits the RangeAxisChanged() signal
   - Call this before PaintInit() in THistPainter::Paint()
   - This correctly syncs the histogram axes before the upper histogram is drawn

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #9263 