### PR TITLE
[cxxmodules] The top-level decl must be annotated as a part of a dictionary.

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -7049,6 +7049,13 @@ static std::string GetClassSharedLibsForModule(const char *cls, cling::LookupHel
          }
       };
 
+      // The top-level declaration must have a LinkLibraries which means it was
+      // produced by rootcling and has a dictionary. If that is not the case, we
+      // should not bother visiting anything else.
+      if (D->hasOwningModule() &&
+          !D->getOwningModule()->getTopLevelModule()->LinkLibraries.size())
+         return {};
+
       llvm::DenseSet<Module *> TopLevelModules;
       ModuleCollector m(TopLevelModules);
       m.Collect(D);


### PR DESCRIPTION
We should not descend into sub-declarations when the top-level declaration was not processed by rootcling.

This patch should fix a recent regression in cmssw where we ask for a dictionary for tbb::detail::d1::concurrent_unordered_base<...>

cc: @davidlange6 