### PR TITLE
[RF] Fix memory leak in RooMinimizerFcn constructor

### DIFF
--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -37,9 +37,24 @@
 
 using namespace std;
 
+
+namespace {
+
+// Helper function that wraps RooAbsArg::getParameters and directly returns the
+// output RooArgSet. To be used in the initializer list of the RooMinimizerFcn
+// constructor.
+RooArgSet getParameters(RooAbsReal const& funct) {
+    RooArgSet out;
+    funct.getParameters(nullptr, out);
+    return out;
+}
+
+} // namespace
+
+
 RooMinimizerFcn::RooMinimizerFcn(RooAbsReal *funct, RooMinimizer* context,
 			   bool verbose) :
-  RooAbsMinimizerFcn(*funct->getParameters(RooArgSet()), context, verbose), _funct(funct)
+  RooAbsMinimizerFcn(getParameters(*funct), context, verbose), _funct(funct)
 {}
 
 


### PR DESCRIPTION
The RooMinimizerFcn constructor used the `RooAbsArg::getParameters`
function that returns an owning pointer, but missed to delete that
pointer afterwards, causing a memory leak until this commit.

This PR is another step in reducing the memory consumption increase reported in https://github.com/root-project/root/issues/9196.