### PR TITLE
Reset to highest possible value when setting more than max-z-divisions

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -9550,8 +9550,8 @@ void THistPainter::DefineColorLevels(Int_t ndivz)
 
    // Initialize the color levels
    if (ndivz >= 100) {
-      Warning("PaintSurface", "too many color levels, %d, reset to 8", ndivz);
-      ndivz = 8;
+      Warning("PaintSurface", "too many color levels, %d >= 100, reset to 99", ndivz);
+      ndivz = 99;
    }
    Double_t *funlevel = new Double_t[ndivz+1];
    Int_t *colorlevel = new Int_t[ndivz+1];


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
When there is an overflow, go to closest value, not a very small one.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

