### PR TITLE
Fix Swap overload of RVec-s

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -923,7 +923,7 @@ void RVecImpl<T>::swap(RVecImpl<T> &RHS)
    if (NumShared > RHS.size())
       NumShared = RHS.size();
    for (size_type i = 0; i != NumShared; ++i)
-      std::swap((*this)[i], RHS[i]);
+      std::iter_swap(this->begin() + i, RHS.begin() + i);
 
    // Copy over the extra elts.
    if (this->size() > RHS.size()) {

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -982,6 +982,31 @@ TEST(VecOps, Concatenate)
    CheckEqual(res, ref);
 }
 
+TEST(VecOps, SwapDifferentSizes)
+{
+   RVec<int> fixed_vempty{};
+   RVec<int> fixed_vshort1{1, 2, 3};
+   RVec<int> fixed_vshort2{4, 5, 6};
+   RVec<int> fixed_vlong{7, 8, 9, 10, 11, 12, 13, 14};
+
+   RVec<int> vempty{};
+   RVec<int> vshort1{1, 2, 3};
+   RVec<int> vshort2{4, 5, 6};
+   RVec<int> vlong{7, 8, 9, 10, 11, 12, 13, 14};
+
+   swap(vshort1, vshort2);
+   CheckEqual(vshort1, fixed_vshort2);
+   CheckEqual(vshort2, fixed_vshort1);
+
+   swap(vempty, vshort2);
+   CheckEqual(vempty, fixed_vshort1);
+   CheckEqual(vshort2, fixed_vempty);
+
+   swap(vshort1, vlong);
+   CheckEqual(vshort1, fixed_vlong);
+   CheckEqual(vlong, fixed_vshort2);
+}
+
 TEST(VecOps, DeltaPhi)
 {
    // Two scalars (radians)


### PR DESCRIPTION


# This Pull request: Fix Swap overload of RVec-s

## Changes or fixes:

Iterators are used to swap elements of RVecs.

Previously swap was trying to access element by indexing.
That was not a valid operation.

Test cases were added to verify the swap.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes swap overload of RVec.

