### PR TITLE
[DF] Remove unused "unique ID" logic in RDefineBase

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -39,9 +39,6 @@ protected:
    const std::string fName; ///< The name of the custom column
    const std::string fType; ///< The type of the custom column as a text string
    std::vector<Long64_t> fLastCheckedEntry;
-   /// A unique ID that identifies this custom column.
-   /// Used e.g. to distinguish custom columns with the same name in different branches of the computation graph.
-   const unsigned int fID = GetNextID();
    RDFInternal::RBookedDefines fDefines;
    std::deque<bool> fIsInitialized; // because vector<bool> is not thread-safe
    const std::map<std::string, std::vector<void *>> &fDSValuePtrs; // reference to RLoopManager's data member
@@ -49,8 +46,6 @@ protected:
    const ROOT::RDF::ColumnNames_t fColumnNames;
    /// The nth flag signals whether the nth input column is a custom column or not.
    ROOT::RVecB fIsDefine;
-
-   static unsigned int GetNextID();
 
 public:
    RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
@@ -73,8 +68,6 @@ public:
    virtual void Update(unsigned int /*slot*/, const ROOT::RDF::RSampleInfo &/*id*/) {}
    /// Clean-up operations to be performed at the end of a task.
    virtual void FinaliseSlot(unsigned int slot) = 0;
-   /// Return the unique identifier of this RDefineBase.
-   unsigned int GetID() const { return fID; }
 };
 
 } // ns RDF

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -20,12 +20,6 @@
 using ROOT::Detail::RDF::RDefineBase;
 namespace RDFInternal = ROOT::Internal::RDF; // redundant (already present in the header), but Windows needs it
 
-unsigned int RDefineBase::GetNextID()
-{
-   static std::atomic_uint id(0U);
-   return ++id;
-}
-
 RDefineBase::RDefineBase(std::string_view name, std::string_view type, unsigned int nSlots,
                          const RDFInternal::RBookedDefines &defines,
                          const std::map<std::string, std::vector<void *>> &DSValuePtrs, ROOT::RDF::RDataSource *ds,


### PR DESCRIPTION
It became unused when we started tracking defines in each branch
of the computation graph separately. We have no need for IDs to
distinguish separate Defines of the same column anymore.