### PR TITLE
Added description field to RNTupleDescriptor::PrintInfo output

### DIFF
--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -181,7 +181,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
       std::string id = std::string("{id:") + std::to_string(col.fColumnId) + "}";
       output << nameAndType << std::setw(60 - nameAndType.length()) << id << std::endl;
       if(col.fFieldDescription != "")
-         output << "    Description          " << col.fFieldDescription << std::endl;
+         output << "    Description:         " << col.fFieldDescription << std::endl;
       output << "    # Elements:          " << col.fNElements << std::endl;
       output << "    # Pages:             " << col.fNPages << std::endl;
       output << "    Avg elements / page: " << avgElementsPerPage << std::endl;

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <iomanip>
 #include <ostream>
-#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptorFmt.cxx
@@ -180,7 +180,7 @@ void ROOT::Experimental::RNTupleDescriptor::PrintInfo(std::ostream &output) cons
          + "  --  " + Detail::RColumnElementBase::GetTypeName(col.fType);
       std::string id = std::string("{id:") + std::to_string(col.fColumnId) + "}";
       output << nameAndType << std::setw(60 - nameAndType.length()) << id << std::endl;
-      if(col.fFieldDescription != "")
+      if (!col.fFieldDescription.empty())
          output << "    Description:         " << col.fFieldDescription << std::endl;
       output << "    # Elements:          " << col.fNElements << std::endl;
       output << "    # Pages:             " << col.fNPages << std::endl;


### PR DESCRIPTION
# This Pull request:
Added description field to the output of `RNTupleDescriptor::PrintInfo`  by passing `ENTupleInfo::kStorageDetails`.  
Here is an example output in which `Vx` is description is set to `velocity in x direction`.  `Vy` description is not set. The result is as follows:
```
............................................................
  Vx[#0]  --  Int32                            {id:0}
    Description:         velocity in x direction 
    # Elements:          3354
    # Pages:             1
    Avg elements / page: 3354
    Avg page size:       5773 B
    Size on storage:     5773 B
    Compression:         2.32
............................................................
  Vy [#0]  --  Int32                            {id:1}
    # Elements:          3354
    # Pages:             1
    Avg elements / page: 3354
    Avg page size:       3132 B
    Size on storage:     3132 B
    Compression:         4.28
............................................................
```
## Changes or fixes:
Changes `RNTupleDescriptor::PrintInfo`

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR closes #8377 