### PR TITLE
[ntuple] Improvements to the write API

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -40,7 +40,7 @@ that are associated to values are managed.
 */
 // clang-format on
 class REntry {
-   friend class REntryBuilder;
+   friend class RNTupleModel;
 
    std::vector<Detail::RFieldValue> fValues;
    /// The objects involed in serialization and deserialization might be used long after the entry is gone:
@@ -95,29 +95,6 @@ public:
 
    Iterator_t begin() { return fValues.begin(); }
    Iterator_t end() { return fValues.end(); }
-};
-
-class REntryBuilder {
-   REntry fEntry;
-
-public:
-   REntry MoveEntry();
-
-   /// Adds a value whose storage is managed by the entry
-   void AddValue(const Detail::RFieldValue &value);
-
-   /// Adds a value whose storage is _not_ managed by the entry
-   void CaptureValue(const Detail::RFieldValue &value);
-
-   /// While building the entry, adds a new value to the list and return the value's shared pointer
-   template <typename T, typename... ArgsT>
-   std::shared_ptr<T> AddValue(RField<T> *field, ArgsT &&...args)
-   {
-      auto ptr = std::make_shared<T>(std::forward<ArgsT>(args)...);
-      fEntry.fValues.emplace_back(Detail::RFieldValue(field->CaptureValue(ptr.get())));
-      fEntry.fValuePtrs.emplace_back(ptr);
-      return ptr;
-   }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -82,7 +82,10 @@ public:
    REntry &operator=(REntry &&other) = default;
    ~REntry();
 
-   Detail::RFieldValue GetValue(std::string_view fieldName) {
+   void CaptureValueUnsafe(std::string_view fieldName, void *where);
+
+   Detail::RFieldValue GetValue(std::string_view fieldName) const
+   {
       for (auto& v : fValues) {
          if (v.GetField()->GetName() == fieldName)
             return v;

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -40,6 +40,8 @@ that are associated to values are managed.
 */
 // clang-format on
 class REntry {
+   friend class REntryBuilder;
+
    std::vector<Detail::RFieldValue> fValues;
    /// The objects involed in serialization and deserialization might be used long after the entry is gone:
    /// hence the shared pointer
@@ -53,6 +55,8 @@ public:
    REntry() = default;
    REntry(const REntry& other) = delete;
    REntry& operator=(const REntry& other) = delete;
+   REntry(REntry &&other) = default;
+   REntry &operator=(REntry &&other) = default;
    ~REntry();
 
    /// Adds a value whose storage is managed by the entry
@@ -91,6 +95,29 @@ public:
 
    Iterator_t begin() { return fValues.begin(); }
    Iterator_t end() { return fValues.end(); }
+};
+
+class REntryBuilder {
+   REntry fEntry;
+
+public:
+   REntry MoveEntry();
+
+   /// Adds a value whose storage is managed by the entry
+   void AddValue(const Detail::RFieldValue &value);
+
+   /// Adds a value whose storage is _not_ managed by the entry
+   void CaptureValue(const Detail::RFieldValue &value);
+
+   /// While building the entry, adds a new value to the list and return the value's shared pointer
+   template <typename T, typename... ArgsT>
+   std::shared_ptr<T> AddValue(RField<T> *field, ArgsT &&...args)
+   {
+      auto ptr = std::make_shared<T>(std::forward<ArgsT>(args)...);
+      fEntry.fValues.emplace_back(Detail::RFieldValue(field->CaptureValue(ptr.get())));
+      fEntry.fValuePtrs.emplace_back(ptr);
+      return ptr;
+   }
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -16,6 +16,7 @@
 #ifndef ROOT7_REntry
 #define ROOT7_REntry
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RField.hxx>
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RStringView.hxx>
@@ -86,18 +87,19 @@ public:
          if (v.GetField()->GetName() == fieldName)
             return v;
       }
-      return Detail::RFieldValue();
+      throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
    }
 
-   template<typename T>
-   T* Get(std::string_view fieldName) {
+   template <typename T>
+   T *Get(std::string_view fieldName) const
+   {
       for (auto& v : fValues) {
          if (v.GetField()->GetName() == fieldName) {
             R__ASSERT(v.GetField()->GetType() == RField<T>::TypeName());
-            return static_cast<T*>(v.GetRawPtr());
+            return v.Get<T>();
          }
       }
-      return nullptr;
+      throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
    }
 
    std::uint64_t GetModelId() const { return fModelId; }

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -42,6 +42,9 @@ that are associated to values are managed.
 class REntry {
    friend class RNTupleModel;
 
+   /// The entry must be linked to a specific model, identified by a model ID
+   std::uint64_t fModelId = 0;
+   /// Corresponds to the top-level fields of the linked model
    std::vector<Detail::RFieldValue> fValues;
    /// The objects involed in serialization and deserialization might be used long after the entry is gone:
    /// hence the shared pointer
@@ -49,10 +52,12 @@ class REntry {
    /// Points into fValues and indicates the values that are owned by the entry and need to be destructed
    std::vector<std::size_t> fManagedValues;
 
+   REntry() = default;
+   explicit REntry(std::uint64_t modelId) : fModelId(modelId) {}
+
 public:
    using Iterator_t = decltype(fValues)::iterator;
 
-   REntry() = default;
    REntry(const REntry& other) = delete;
    REntry& operator=(const REntry& other) = delete;
    REntry(REntry &&other) = default;
@@ -92,6 +97,8 @@ public:
       }
       return nullptr;
    }
+
+   std::uint64_t GetModelId() const { return fModelId; }
 
    Iterator_t begin() { return fValues.begin(); }
    Iterator_t end() { return fValues.end(); }

--- a/tree/ntuple/v7/inc/ROOT/REntry.hxx
+++ b/tree/ntuple/v7/inc/ROOT/REntry.hxx
@@ -42,7 +42,7 @@ that are associated to values are managed.
 class REntry {
    friend class RNTupleModel;
 
-   /// The entry must be linked to a specific model, identified by a model ID
+   /// The entry must be linked to a specific model (or one if its clones), identified by a model ID
    std::uint64_t fModelId = 0;
    /// Corresponds to the top-level fields of the linked model
    std::vector<Detail::RFieldValue> fValues;
@@ -52,17 +52,10 @@ class REntry {
    /// Points into fValues and indicates the values that are owned by the entry and need to be destructed
    std::vector<std::size_t> fManagedValues;
 
+   // Creation of entries is done by the RNTupleModel class
+
    REntry() = default;
    explicit REntry(std::uint64_t modelId) : fModelId(modelId) {}
-
-public:
-   using Iterator_t = decltype(fValues)::iterator;
-
-   REntry(const REntry& other) = delete;
-   REntry& operator=(const REntry& other) = delete;
-   REntry(REntry &&other) = default;
-   REntry &operator=(REntry &&other) = default;
-   ~REntry();
 
    /// Adds a value whose storage is managed by the entry
    void AddValue(const Detail::RFieldValue& value);
@@ -78,6 +71,15 @@ public:
       fValuePtrs.emplace_back(ptr);
       return ptr;
    }
+
+public:
+   using Iterator_t = decltype(fValues)::iterator;
+
+   REntry(const REntry &other) = delete;
+   REntry &operator=(const REntry &other) = delete;
+   REntry(REntry &&other) = default;
+   REntry &operator=(REntry &&other) = default;
+   ~REntry();
 
    Detail::RFieldValue GetValue(std::string_view fieldName) {
       for (auto& v : fValues) {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -282,8 +282,6 @@ public:
    Detail::RFieldValue CaptureValue(void*) final { return Detail::RFieldValue(); }
    size_t GetValueSize() const final { return 0; }
 
-   /// Generates managed values for the top-level sub fields
-   std::unique_ptr<REntry> GenerateEntry() const;
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -411,6 +411,8 @@ public:
 
    void EnableMetrics() { fMetrics.Enable(); }
    const Detail::RNTupleMetrics &GetMetrics() const { return fMetrics; }
+
+   const RNTupleModel *GetModel() const { return fModel.get(); }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RNTuple
 
 #include <ROOT/RConfig.hxx> // for R__unlikely
+#include <ROOT/RError.hxx>
 #include <ROOT/RNTupleMetrics.hxx>
 #include <ROOT/RNTupleModel.hxx>
 #include <ROOT/RNTupleOptions.hxx>
@@ -393,6 +394,9 @@ public:
    /// Multiple entries can have been instantiated from the tnuple model.  This method will perform
    /// a light check whether the entry comes from the ntuple's own model
    void Fill(REntry &entry) {
+      if (R__unlikely(entry.GetModelId() != fModel->GetModelId()))
+         throw RException(R__FAIL("mismatch between entry and model"));
+
       for (auto& value : entry) {
          fUnzippedClusterSize += value.GetField()->Append(value);
       }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -50,24 +50,27 @@ class RNTupleModel {
    std::unique_ptr<REntry> fDefaultEntry;
    /// Keeps track of which field names are taken.
    std::unordered_set<std::string> fFieldNames;
-   ///
+   /// Free text set by the user
+   std::string fDescription;
+   /// Upon freezing, every model has a unique ID to distingusish it from other models.  Cloning preserves the ID.
+   /// Entries are linked to models via the ID.
    std::uint64_t fModelId = 0;
 
    /// Checks that user-provided field names are valid in the context
    /// of this NTuple model. Throws an RException for invalid names.
    void EnsureValidFieldName(std::string_view fieldName);
 
-   /// Free text set by the user
-   std::string fDescription;
+   RNTupleModel();
 
 public:
-   RNTupleModel();
    RNTupleModel(const RNTupleModel&) = delete;
    RNTupleModel& operator =(const RNTupleModel&) = delete;
    ~RNTupleModel() = default;
 
    std::unique_ptr<RNTupleModel> Clone() const;
-   static std::unique_ptr<RNTupleModel> Create() { return std::make_unique<RNTupleModel>(); }
+   static std::unique_ptr<RNTupleModel> Create();
+   /// A bare model has no default entry
+   static std::unique_ptr<RNTupleModel> CreateBare();
 
    /// Creates a new field and a corresponding tree value that is managed by a shared pointer.
    ///

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -161,7 +161,8 @@ public:
    }
 
    template <typename T>
-   T* Get(std::string_view fieldName) {
+   T *Get(std::string_view fieldName) const
+   {
       return fDefaultEntry->Get<T>(fieldName);
    }
 
@@ -176,10 +177,12 @@ public:
       std::string_view fieldName,
       std::unique_ptr<RNTupleModel> collectionModel);
 
+   std::unique_ptr<REntry> CreateEntry() const;
+   REntry *GetDefaultEntry() const;
+
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
-   Detail::RFieldBase *GetField(std::string_view fieldName);
-   REntry *GetDefaultEntry();
-   std::unique_ptr<REntry> CreateEntry();
+   const Detail::RFieldBase *GetField(std::string_view fieldName) const;
+
    std::string GetDescription() const { return fDescription; }
    void SetDescription(std::string_view description);
 };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -22,6 +22,7 @@
 #include <ROOT/RFieldValue.hxx>
 #include <ROOT/RStringView.hxx>
 
+#include <cstdint>
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -49,6 +50,8 @@ class RNTupleModel {
    std::unique_ptr<REntry> fDefaultEntry;
    /// Keeps track of which field names are taken.
    std::unordered_set<std::string> fFieldNames;
+   ///
+   std::uintptr_t fModelId = 0;
 
    /// Checks that user-provided field names are valid in the context
    /// of this NTuple model. Throws an RException for invalid names.
@@ -157,6 +160,10 @@ public:
    T* Get(std::string_view fieldName) {
       return fDefaultEntry->Get<T>(fieldName);
    }
+
+   void Freeze();
+   bool IsFrozen() const { return fModelId != 0; }
+   std::uintptr_t GetModelId() const { return fModelId; }
 
    /// Ingests a model for a sub collection and attaches it to the current model
    ///

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -51,7 +51,7 @@ class RNTupleModel {
    /// Keeps track of which field names are taken.
    std::unordered_set<std::string> fFieldNames;
    ///
-   std::uintptr_t fModelId = 0;
+   std::uint64_t fModelId = 0;
 
    /// Checks that user-provided field names are valid in the context
    /// of this NTuple model. Throws an RException for invalid names.
@@ -163,7 +163,7 @@ public:
 
    void Freeze();
    bool IsFrozen() const { return fModelId != 0; }
-   std::uintptr_t GetModelId() const { return fModelId; }
+   std::uint64_t GetModelId() const { return fModelId; }
 
    /// Ingests a model for a sub collection and attaches it to the current model
    ///

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -174,12 +174,10 @@ public:
 
    RFieldZero *GetFieldZero() const { return fFieldZero.get(); }
    Detail::RFieldBase *GetField(std::string_view fieldName);
-   REntry *GetDefaultEntry() { return fDefaultEntry.get(); }
+   REntry *GetDefaultEntry();
    std::unique_ptr<REntry> CreateEntry();
-   RNTupleVersion GetVersion() const { return RNTupleVersion(); }
    std::string GetDescription() const { return fDescription; }
-   void SetDescription(std::string_view description) { fDescription = std::string(description); }
-   RNTupleUuid GetUuid() const { return RNTupleUuid(); /* TODO */ }
+   void SetDescription(std::string_view description);
 };
 
 } // namespace Experimental

--- a/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleModel.hxx
@@ -124,6 +124,8 @@ public:
    std::shared_ptr<T> MakeField(std::pair<std::string_view, std::string_view> fieldNameDesc,
       ArgsT&&... args)
    {
+      if (IsFrozen())
+         throw RException(R__FAIL("invalid attempt to add field to frozen model"));
       EnsureValidFieldName(fieldNameDesc.first);
       auto field = std::make_unique<RField<T>>(fieldNameDesc.first);
       field->SetDescription(fieldNameDesc.second);
@@ -146,6 +148,8 @@ public:
    /// Throws an exception if fromWhere is null.
    template <typename T>
    void AddField(std::pair<std::string_view, std::string_view> fieldNameDesc, T* fromWhere) {
+      if (IsFrozen())
+         throw RException(R__FAIL("invalid attempt to add field to frozen model"));
       EnsureValidFieldName(fieldNameDesc.first);
       if (!fromWhere) {
          throw RException(R__FAIL("null field fromWhere"));

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -48,6 +48,7 @@ void ROOT::Experimental::REntry::CaptureValueUnsafe(std::string_view fieldName, 
          fManagedValues.erase(itr);
       }
       fValues[i] = fValues[i].GetField()->CaptureValue(where);
+      return;
    }
    throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
 }

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 #include <ROOT/REntry.hxx>
+#include <ROOT/RError.hxx>
 #include <ROOT/RFieldValue.hxx>
 
 #include <algorithm>
@@ -34,4 +35,19 @@ void ROOT::Experimental::REntry::AddValue(const Detail::RFieldValue& value)
 void ROOT::Experimental::REntry::CaptureValue(const Detail::RFieldValue& value)
 {
    fValues.push_back(value);
+}
+
+void ROOT::Experimental::REntry::CaptureValueUnsafe(std::string_view fieldName, void *where)
+{
+   for (std::size_t i = 0; i < fValues.size(); ++i) {
+      if (fValues[i].GetField()->GetName() != fieldName)
+         continue;
+      auto itr = std::find(fManagedValues.begin(), fManagedValues.end(), i);
+      if (itr != fManagedValues.end()) {
+         fValues[i].GetField()->DestroyValue(fValues[i]);
+         fManagedValues.erase(itr);
+      }
+      fValues[i] = fValues[i].GetField()->CaptureValue(where);
+   }
+   throw RException(R__FAIL("invalid field name: " + std::string(fieldName)));
 }

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -16,6 +16,8 @@
 #include <ROOT/REntry.hxx>
 #include <ROOT/RFieldValue.hxx>
 
+#include <algorithm>
+
 ROOT::Experimental::REntry::~REntry()
 {
    for (auto idx : fManagedValues) {
@@ -32,4 +34,24 @@ void ROOT::Experimental::REntry::AddValue(const Detail::RFieldValue& value)
 void ROOT::Experimental::REntry::CaptureValue(const Detail::RFieldValue& value)
 {
    fValues.push_back(value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+ROOT::Experimental::REntry ROOT::Experimental::REntryBuilder::MoveEntry()
+{
+   ROOT::Experimental::REntry result;
+   std::swap(result, fEntry);
+   return result;
+}
+
+void ROOT::Experimental::REntryBuilder::AddValue(const Detail::RFieldValue &value)
+{
+   fEntry.fManagedValues.emplace_back(fEntry.fValues.size());
+   fEntry.fValues.push_back(value);
+}
+
+void ROOT::Experimental::REntryBuilder::CaptureValue(const Detail::RFieldValue &value)
+{
+   fEntry.fValues.push_back(value);
 }

--- a/tree/ntuple/v7/src/REntry.cxx
+++ b/tree/ntuple/v7/src/REntry.cxx
@@ -35,23 +35,3 @@ void ROOT::Experimental::REntry::CaptureValue(const Detail::RFieldValue& value)
 {
    fValues.push_back(value);
 }
-
-////////////////////////////////////////////////////////////////////////////////
-
-ROOT::Experimental::REntry ROOT::Experimental::REntryBuilder::MoveEntry()
-{
-   ROOT::Experimental::REntry result;
-   std::swap(result, fEntry);
-   return result;
-}
-
-void ROOT::Experimental::REntryBuilder::AddValue(const Detail::RFieldValue &value)
-{
-   fEntry.fManagedValues.emplace_back(fEntry.fValues.size());
-   fEntry.fValues.push_back(value);
-}
-
-void ROOT::Experimental::REntryBuilder::CaptureValue(const Detail::RFieldValue &value)
-{
-   fEntry.fValues.push_back(value);
-}

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -419,15 +419,6 @@ ROOT::Experimental::RFieldZero::CloneImpl(std::string_view /*newName*/) const
 }
 
 
-std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RFieldZero::GenerateEntry() const
-{
-   auto entry = std::make_unique<REntry>();
-   for (auto& f : fSubFields) {
-      entry->AddValue(f->GenerateValue());
-   }
-   return entry;
-}
-
 void ROOT::Experimental::RFieldZero::AcceptVisitor(Detail::RFieldVisitor &visitor) const
 {
    visitor.VisitFieldZero(*this);

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -105,6 +105,7 @@ ROOT::Experimental::RNTupleReader::RNTupleReader(
    if (!fModel) {
       throw RException(R__FAIL("null model"));
    }
+   fModel->Freeze();
    InitPageSource();
    ConnectModel(*fModel);
 }
@@ -284,6 +285,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
    if (!fSink) {
       throw RException(R__FAIL("null sink"));
    }
+   fModel->Freeze();
 #ifdef R__USE_IMT
    if (IsImplicitMTEnabled()) {
       fZipTasks = std::make_unique<RNTupleImtTaskScheduler>();

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -747,7 +747,7 @@ ROOT::Experimental::RNTupleDescriptor::FindPrevClusterId(DescriptorId_t clusterI
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDescriptor::GenerateModel() const
 {
-   auto model = std::make_unique<RNTupleModel>();
+   auto model = RNTupleModel::Create();
    model->GetFieldZero()->SetOnDiskId(GetFieldZeroId());
    for (const auto &topDesc : GetTopLevelFields())
       model->AddField(topDesc.CreateField(*this));

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -751,6 +751,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
    model->GetFieldZero()->SetOnDiskId(GetFieldZeroId());
    for (const auto &topDesc : GetTopLevelFields())
       model->AddField(topDesc.CreateField(*this));
+   model->Freeze();
    return model;
 }
 

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -45,6 +45,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
 {
    auto cloneModel = std::make_unique<RNTupleModel>();
    auto cloneFieldZero = fFieldZero->Clone("");
+   cloneModel->fModelId = fModelId;
    cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(static_cast<RFieldZero *>(cloneFieldZero.release()));
    cloneModel->fDefaultEntry = cloneModel->fFieldZero->GenerateEntry();
    cloneModel->fFieldNames = fFieldNames;
@@ -108,4 +109,10 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
       entry->AddValue(f.GenerateValue());
    }
    return entry;
+}
+
+void ROOT::Experimental::RNTupleModel::Freeze()
+{
+   if (!IsFrozen())
+      fModelId = reinterpret_cast<uintptr_t>(this);
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -59,10 +59,12 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
 
 void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBase> field)
 {
-   if (!field) {
+   if (IsFrozen())
+      throw RException(R__FAIL("invalid attempt to add field to frozen model"));
+   if (!field)
       throw RException(R__FAIL("null field"));
-   }
    EnsureValidFieldName(field->GetName());
+
    fDefaultEntry->AddValue(field->GenerateValue());
    fFieldZero->Attach(std::move(field));
 }
@@ -71,6 +73,8 @@ void ROOT::Experimental::RNTupleModel::AddField(std::unique_ptr<Detail::RFieldBa
 std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental::RNTupleModel::MakeCollection(
    std::string_view fieldName, std::unique_ptr<RNTupleModel> collectionModel)
 {
+   if (IsFrozen())
+      throw RException(R__FAIL("invalid attempt to add collection to frozen model"));
    EnsureValidFieldName(fieldName);
    if (!collectionModel) {
       throw RException(R__FAIL("null collectionModel"));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -38,12 +38,24 @@ void ROOT::Experimental::RNTupleModel::EnsureValidFieldName(std::string_view fie
 }
 
 ROOT::Experimental::RNTupleModel::RNTupleModel()
-   : fFieldZero(std::make_unique<RFieldZero>()), fDefaultEntry(std::unique_ptr<REntry>(new REntry()))
+  : fFieldZero(std::make_unique<RFieldZero>())
 {}
+
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::Create()
+{
+   auto model = CreateBare();
+   model->fDefaultEntry = std::unique_ptr<REntry>(new REntry());
+   return model;
+}
+
+std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::CreateBare()
+{
+   return std::unique_ptr<RNTupleModel>(new RNTupleModel());
+}
 
 std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleModel::Clone() const
 {
-   auto cloneModel = std::make_unique<RNTupleModel>();
+   auto cloneModel = std::unique_ptr<RNTupleModel>(new RNTupleModel());
    auto cloneFieldZero = fFieldZero->Clone("");
    cloneModel->fModelId = fModelId;
    cloneModel->fFieldZero = std::unique_ptr<RFieldZero>(static_cast<RFieldZero *>(cloneFieldZero.release()));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -19,6 +19,7 @@
 #include <ROOT/RNTuple.hxx>
 #include <ROOT/StringUtils.hxx>
 
+#include <atomic>
 #include <cstdlib>
 #include <memory>
 #include <utility>
@@ -123,8 +124,11 @@ std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::Cr
 
 void ROOT::Experimental::RNTupleModel::Freeze()
 {
-   if (!IsFrozen())
-      fModelId = reinterpret_cast<uintptr_t>(this);
+   if (IsFrozen())
+      return;
+
+   static std::atomic<std::uint64_t> gLastModelId = 0;
+   fModelId = ++gLastModelId;
 }
 
 void ROOT::Experimental::RNTupleModel::SetDescription(std::string_view description)

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -100,8 +100,18 @@ ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RNTupleModel::GetFie
    return field;
 }
 
+ROOT::Experimental::REntry *ROOT::Experimental::RNTupleModel::GetDefaultEntry()
+{
+   if (!IsFrozen())
+      throw RException(R__FAIL("invalid attempt to get default entry of unfrozen model"));
+   return fDefaultEntry.get();
+}
+
 std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::CreateEntry()
 {
+   if (!IsFrozen())
+      throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));
+
    auto entry = std::make_unique<REntry>();
    for (auto& f : *fFieldZero) {
       if (f.GetParent() != GetFieldZero())
@@ -115,4 +125,11 @@ void ROOT::Experimental::RNTupleModel::Freeze()
 {
    if (!IsFrozen())
       fModelId = reinterpret_cast<uintptr_t>(this);
+}
+
+void ROOT::Experimental::RNTupleModel::SetDescription(std::string_view description)
+{
+   if (IsFrozen())
+      throw RException(R__FAIL("invalid attempt to set description of frozen model"));
+   fDescription = std::string(description);
 }

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -86,7 +86,8 @@ std::shared_ptr<ROOT::Experimental::RCollectionNTupleWriter> ROOT::Experimental:
    return collectionNTuple;
 }
 
-ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RNTupleModel::GetField(std::string_view fieldName)
+const ROOT::Experimental::Detail::RFieldBase *
+ROOT::Experimental::RNTupleModel::GetField(std::string_view fieldName) const
 {
    if (fieldName.empty())
       return nullptr;
@@ -107,14 +108,14 @@ ROOT::Experimental::Detail::RFieldBase *ROOT::Experimental::RNTupleModel::GetFie
    return field;
 }
 
-ROOT::Experimental::REntry *ROOT::Experimental::RNTupleModel::GetDefaultEntry()
+ROOT::Experimental::REntry *ROOT::Experimental::RNTupleModel::GetDefaultEntry() const
 {
    if (!IsFrozen())
       throw RException(R__FAIL("invalid attempt to get default entry of unfrozen model"));
    return fDefaultEntry.get();
 }
 
-std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::CreateEntry()
+std::unique_ptr<ROOT::Experimental::REntry> ROOT::Experimental::RNTupleModel::CreateEntry() const
 {
    if (!IsFrozen())
       throw RException(R__FAIL("invalid attempt to create entry of unfrozen model"));

--- a/tree/ntuple/v7/src/RNTupleModel.cxx
+++ b/tree/ntuple/v7/src/RNTupleModel.cxx
@@ -69,7 +69,7 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleMod
    cloneModel->fFieldNames = fFieldNames;
    cloneModel->fDescription = fDescription;
    if (fDefaultEntry) {
-      cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry());
+      cloneModel->fDefaultEntry = std::unique_ptr<REntry>(new REntry(fModelId));
       for (const auto &f : cloneModel->fFieldZero->GetSubFields()) {
          cloneModel->fDefaultEntry->AddValue(f->GenerateValue());
       }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -279,8 +279,8 @@ ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const R
 
 void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
 {
-   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription(), "undefined author",
-                                model.GetVersion(), model.GetUuid());
+   fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription(), "undefined author", RNTupleVersion(),
+                                RNTupleUuid());
 
    auto &fieldZero = *model.GetFieldZero();
    fDescriptorBuilder.AddField(

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -502,20 +502,20 @@ TEST(RNTuple, ModelId)
       m1->SetDescription("abc");
       FAIL() << "changing frozen model should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to set description"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to modify frozen model"));
    }
    try {
       m1->MakeField<float>("pt");
       FAIL() << "changing frozen model should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to add field"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to modify frozen model"));
    }
    try {
       float dummy;
       m1->AddField<float>("pt", &dummy);
       FAIL() << "changing frozen model should throw";
    } catch (const RException &err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to add field"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to modify frozen model"));
    }
 
    EXPECT_NE(m1->GetModelId(), m2->GetModelId());
@@ -574,13 +574,13 @@ TEST(RNTuple, BareEntry)
          model->GetDefaultEntry();
          FAIL() << "accessing default entry of bare model should throw";
       } catch (const RException &err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to get bare model's default entry"));
+         EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to use default entry of bare model"));
       }
       try {
          model->Get<float>("pt");
          FAIL() << "accessing default entry of bare model should throw";
       } catch (const RException &err) {
-         EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to get bare model's default entry"));
+         EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to use default entry of bare model"));
       }
 
       auto e1 = model->CreateEntry();

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -482,3 +482,34 @@ TEST(RNTuple, NullSafety)
       EXPECT_THAT(err.what(), testing::HasSubstr("null source"));
    }
 }
+
+TEST(RNTuple, ModelId)
+{
+   auto m1 = RNTupleModel::Create();
+   auto m2 = RNTupleModel::Create();
+   EXPECT_FALSE(m1->IsFrozen());
+   EXPECT_EQ(m1->GetModelId(), m2->GetModelId());
+
+   m1->Freeze();
+   EXPECT_TRUE(m1->IsFrozen());
+
+   try {
+      m1->SetDescription("abc");
+      FAIL() << "changing frozen model should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to set description"));
+   }
+
+   EXPECT_NE(m1->GetModelId(), m2->GetModelId());
+   // Freeze() should be idempotent call
+   auto id = m1->GetModelId();
+   m1->Freeze();
+   EXPECT_TRUE(m1->IsFrozen());
+   EXPECT_EQ(id, m1->GetModelId());
+
+   m2->Freeze();
+   EXPECT_NE(m1->GetModelId(), m2->GetModelId());
+
+   auto m2c = m2->Clone();
+   EXPECT_EQ(m2->GetModelId(), m2c->GetModelId());
+}

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -21,7 +21,12 @@ TEST(RNTuple, ReconstructModel)
    source.Attach();
 
    auto modelReconstructed = source.GetDescriptor().GenerateModel();
-   EXPECT_EQ(nullptr, modelReconstructed->GetDefaultEntry()->Get<float>("xyz"));
+   try {
+      modelReconstructed->GetDefaultEntry()->Get<float>("xyz");
+      FAIL() << "invalid field name should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid field name"));
+   }
    auto vecPtr = modelReconstructed->GetDefaultEntry()->Get<std::vector<std::vector<float>>>("nnlo");
    EXPECT_TRUE(vecPtr != nullptr);
    // Don't crash

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -499,6 +499,19 @@ TEST(RNTuple, ModelId)
    } catch (const RException &err) {
       EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to set description"));
    }
+   try {
+      m1->MakeField<float>("pt");
+      FAIL() << "changing frozen model should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to add field"));
+   }
+   try {
+      float dummy;
+      m1->AddField<float>("pt", &dummy);
+      FAIL() << "changing frozen model should throw";
+   } catch (const RException &err) {
+      EXPECT_THAT(err.what(), testing::HasSubstr("invalid attempt to add field"));
+   }
 
    EXPECT_NE(m1->GetModelId(), m2->GetModelId());
    // Freeze() should be idempotent call

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -52,8 +52,8 @@ void Convert() {
    std::unique_ptr<TFile> f(TFile::Open(kTreeFileName));
    assert(f && ! f->IsZombie());
 
-   // Get a unique pointer to an empty RNTuple model
-   auto model = RNTupleModel::Create();
+   // Get a unique pointer to an empty RNTuple model without a default entry
+   auto model = RNTupleModel::CreateBare();
 
    // We create RNTuple fields based on the types found in the TTree
    // This simple approach only works for trees with simple branches and only one leaf per branch
@@ -74,22 +74,23 @@ void Convert() {
       // to the model's default entry, that will be used to place the data supposed to be written
       model->AddField(std::move(field));
    }
-   model->Freeze();
-   for (auto b : TRangeDynCast<TBranch>(*tree->GetListOfBranches())) {
-      auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
-      // We connect the model's default entry's memory location for the new field to the branch, so that we can
-      // fill the ntuple with the data read from the TTree
-      void *fieldDataPtr = model->GetDefaultEntry()->GetValue(l->GetName()).GetRawPtr();
-      tree->SetBranchAddress(b->GetName(), fieldDataPtr);
-   }
 
    // The new ntuple takes ownership of the model
    auto ntuple = RNTupleWriter::Recreate(std::move(model), "DecayTree", kNTupleFileName);
 
+   auto entry = ntuple->GetModel()->CreateEntry();
+   for (auto b : TRangeDynCast<TBranch>(*tree->GetListOfBranches())) {
+      auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
+      // We connect the model's default entry's memory location for the new field to the branch, so that we can
+      // fill the ntuple with the data read from the TTree
+      void *fieldDataPtr = entry->GetValue(l->GetName()).GetRawPtr();
+      tree->SetBranchAddress(b->GetName(), fieldDataPtr);
+   }
+
    auto nEntries = tree->GetEntries();
    for (decltype(nEntries) i = 0; i < nEntries; ++i) {
       tree->GetEntry(i);
-      ntuple->Fill();
+      ntuple->Fill(*entry);
 
       if (i && i % 100000 == 0)
          std::cout << "Wrote " << i << " entries" << std::endl;

--- a/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
+++ b/tutorials/v7/ntuple/ntpl003_lhcbOpenData.C
@@ -73,7 +73,10 @@ void Convert() {
       // Hand over ownership of the field to the ntuple model.  This will also create a memory location attached
       // to the model's default entry, that will be used to place the data supposed to be written
       model->AddField(std::move(field));
-
+   }
+   model->Freeze();
+   for (auto b : TRangeDynCast<TBranch>(*tree->GetListOfBranches())) {
+      auto l = static_cast<TLeaf *>(b->GetListOfLeaves()->First());
       // We connect the model's default entry's memory location for the new field to the branch, so that we can
       // fill the ntuple with the data read from the TTree
       void *fieldDataPtr = model->GetDefaultEntry()->GetValue(l->GetName()).GetRawPtr();


### PR DESCRIPTION
Provides the following improvements to the write API:

  - Introduce the concept of freezing to ntuple models: Once all fields are added to a model, it must be frozen before it can be used with data sets.  That prevents model from being changed after they are linked to on-disk data
  - Links `REntry` instances to `RNTupleModel` instances through a new model ID, so that one cannot fill an ntuple with an entry of the wrong model
  - Introduce "bare models" and "bare entries": for use within frameworks, allows creation of models without a default entry. The model can then create bare entries, and those bare entries can use `CaptureValueUnsafe` to link the fields to `void *` addresses. See ntpl003 tutorial for an example how to use it.

Fixes #9069.  Almost finished patch set from last week.