### PR TITLE
Fix the tree/tree/test/testTOffsetGeneration on Windows

### DIFF
--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -9,6 +9,11 @@ ROOT_GENERATE_DICTIONARY(ElementStructDict ElementStruct.h LINKDEF ElementStruct
 ROOT_ADD_GTEST(testTOffsetGeneration TOffsetGeneration.cxx ElementStruct.cxx ElementStructDict.cxx
   LIBRARIES RIO Tree MathCore
 )
+if(MSVC)
+  add_custom_command(TARGET testTOffsetGeneration POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libElementStructDict_rdict.pcm
+                                     ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libElementStructDict_rdict.pcm)
+endif()
 target_include_directories(testTOffsetGeneration PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 ROOT_STANDARD_LIBRARY_PACKAGE(SillyStruct NO_INSTALL_HEADERS HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/SillyStruct.h SOURCES SillyStruct.cxx LINKDEF SillyStructLinkDef.h DEPENDENCIES RIO)
 ROOT_ADD_GTEST(testBulkApi BulkApi.cxx LIBRARIES RIO Tree TreePlayer)

--- a/tree/tree/test/TOffsetGeneration.cxx
+++ b/tree/tree/test/TOffsetGeneration.cxx
@@ -49,6 +49,8 @@ protected:
          tree->Fill();
       }
       file->Write();
+      file->Close();
+      delete file;
 
       file = new TFile("TOffsetGeneration3.root", "RECREATE");
       tree = new TTree("tree", "A test tree");


### PR DESCRIPTION
Fix the following errors on Windows:
```
362: Error in <TCling::LoadPCM>: ROOT PCM C:\Users\bellenot\build\release\tree\tree\test\Release\libElementStructDict_rdict.pcm file does not exist
362: [       OK ] TOffsetGeneration.offsetArrayValues (3014 ms)
362: [ RUN      ] TOffsetGeneration.primitiveTest
362: SysError in <TFile::TFile>: could not delete C:\Users\bellenot\build\release\tree\tree\test\TOffsetGeneration2.root (errno: 13) Permission denied
362: Warning in <TFile::Write>: file TOffsetGeneration2.root not opened in write mode
362: [       OK ] TOffsetGeneration.primitiveTest (142 ms)
362: [ RUN      ] TOffsetGeneration.elementsTest
362: SysError in <TFile::TFile>: could not delete C:\Users\bellenot\build\release\tree\tree\test\TOffsetGeneration2.root (errno: 13) Permission denied
362: Warning in <TFile::Write>: file TOffsetGeneration2.root not opened in write mode
362: [       OK ] TOffsetGeneration.elementsTest (136 ms)
362: [----------] 3 tests from TOffsetGeneration (3293 ms total)
```
