### PR TITLE
[RF] Added `const` getter for `RooStats::HistFactory::Channel::fData`

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
@@ -57,6 +57,7 @@ public:
   void SetData( TH1* hData );
   /// get data object
   RooStats::HistFactory::Data& GetData() { return fData; }
+  const RooStats::HistFactory::Data& GetData() const { return fData; }  
 
   /// add additional data object
   void AddAdditionalData( const RooStats::HistFactory::Data& data ) { fAdditionalData.push_back(data); }


### PR DESCRIPTION
Add `const` getter for `RooStats::HistFactory::Channel::fData`, which is a requirement for the RooWorkspace to JSON/YAML conversion PR https://github.com/root-project/root/pull/8944..