### PR TITLE
[RF] Bring back `RooAbsMinimizerFcn::NDim()` for backwards compatibility

### DIFF
--- a/roofit/roofitcore/inc/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooAbsMinimizerFcn.h
@@ -84,6 +84,12 @@ public:
 
    unsigned int getNDim() const { return _nDim; }
 
+   // In the past, the `getNDim` function was called just `NDim`. The funciton
+   // was renamed to match the code convention (lower case for funciton names),
+   // but we have to keep an overload with the old name to not break existing
+   // user code.
+   inline unsigned int NDim() const { return getNDim(); }
+
    void setOptimizeConst(Int_t flag);
 
    bool getOptConst();


### PR DESCRIPTION
In the past, the `getNDim` function was called just `NDim`. The funciton
was renamed to match the code convention (lower case for funciton
names), but we have to keep an overload with the old name to not break
existing user code.

Here you can see where the old `RooAbsMinimizerFcn::NDim()` function was defined:
https://github.com/root-project/root/blob/v6-24-00-patches/roofit/roofitcore/inc/RooMinimizerFcn.h#L43
(it was in `RooMinimizerFcn` before, but after @egpbos refactoring it can be in `RooAbsMinimizerFcn`)

FYI @cburgard 