### PR TITLE
[RF] Minor RooFit interface updates

### DIFF
--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -35,6 +35,12 @@ public:
   /// Switch on or off protection against negative means.
   void protectNegativeMean(bool flag = kTRUE) {_protectNegative = flag;}
 
+  /// Get the x variable.
+  RooAbsReal const& getX() const { return x.arg(); }
+
+  /// Get the mean parameter.
+  RooAbsReal const& getMean() const { return mean.arg(); }
+
 protected:
 
   RooRealProxy x ;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -105,6 +105,8 @@ public:
   virtual Bool_t isNonPoissonWeighted() const override;
 
   virtual Double_t weight() const override;
+  /// Returns a pointer to the weight variable (if set).
+  RooRealVar* weightVar() { return _wgtVar; }
   virtual Double_t weightSquared() const override;
   virtual void weightError(double& lo, double& hi,ErrorType etype=SumW2) const override;
   double weightError(ErrorType etype=SumW2) const override;


### PR DESCRIPTION
The interfaces of `RooPoisson` and `RooDataSet` are extended to support some of the new developments in other PRs:

* getters for `x` and `mean` of RooPoisson (needed by https://github.com/root-project/root/pull/8944)
* `RooDataSet::weightVar()` to access weight variable if set (needed by https://github.com/root-project/root/pull/8944, https://github.com/root-project/root/pull/9004)