### PR TITLE
Some classes do not inherit form TNamed

### DIFF
--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -641,11 +641,11 @@ def copyRootObjectRecursive(sourceFile,sourcePathSplit,destFile,destPathSplit,re
                         retcode += retcodeTemp
                         continue
                     else:
-                        if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(setName)
+                        if isinstance(obj, ROOT.TNamed): obj.SetName(setName)
                         changeDirectory(destFile,destPathSplit)
                         obj.Write()
                 else:
-                    if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(setName)
+                    if isinstance(obj, ROOT.TNamed): obj.SetName(setName)
                     changeDirectory(destFile,destPathSplit)
                     obj.Write()
             elif issubclass(obj.__class__, ROOT.TCollection):
@@ -654,9 +654,9 @@ def copyRootObjectRecursive(sourceFile,sourcePathSplit,destFile,destPathSplit,re
                 obj.Write(setName, ROOT.TObject.kSingleKey)
             else:
                 if setName != "":
-                    if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(setName)
+                    if isinstance(obj, ROOT.TNamed): obj.SetName(setName)
                 else:
-                    if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(objectName)
+                    if isinstance(obj, ROOT.TNamed): obj.SetName(objectName)
                 changeDirectory(destFile,destPathSplit)
                 obj.Write()
             obj.Delete()

--- a/main/python/cmdLineUtils.py
+++ b/main/python/cmdLineUtils.py
@@ -641,11 +641,11 @@ def copyRootObjectRecursive(sourceFile,sourcePathSplit,destFile,destPathSplit,re
                         retcode += retcodeTemp
                         continue
                     else:
-                        obj.SetName(setName)
+                        if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(setName)
                         changeDirectory(destFile,destPathSplit)
                         obj.Write()
                 else:
-                    obj.SetName(setName)
+                    if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(setName)
                     changeDirectory(destFile,destPathSplit)
                     obj.Write()
             elif issubclass(obj.__class__, ROOT.TCollection):
@@ -654,9 +654,9 @@ def copyRootObjectRecursive(sourceFile,sourcePathSplit,destFile,destPathSplit,re
                 obj.Write(setName, ROOT.TObject.kSingleKey)
             else:
                 if setName != "":
-                    obj.SetName(setName)
+                    if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(setName)
                 else:
-                    obj.SetName(objectName)
+                    if obj.InheritsFrom(ROOT.TNamed.Class()): obj.SetName(objectName)
                 changeDirectory(destFile,destPathSplit)
                 obj.Write()
             obj.Delete()


### PR DESCRIPTION
Some classes like TObjString do not inherit form TNamed and therefor do not have the
SetName method. This produces in the command line tools  errors when such objects are
stored in ROOT files. This problem was seen in the forum post in the case of `rootcp`.
https://root-forum.cern.ch/t/remove-directory/47733/31