### PR TITLE
[metcling] Disable optimized register allocation

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -3526,8 +3526,9 @@ gOptModuleByproducts("mByproduct", llvm::cl::ZeroOrMore,
                      llvm::cl::Hidden,
                      llvm::cl::desc("The list of the expected implicit modules build as part of building the current module."),
                      llvm::cl::cat(gRootclingOptions));
+// Really llvm::cl::Required, will be changed in RootClingMain below.
 static llvm::cl::opt<std::string>
-gOptDictionaryFileName(llvm::cl::Positional, llvm::cl::Required,
+gOptDictionaryFileName(llvm::cl::Positional,
                       llvm::cl::desc("<output dictionary file>"),
                       llvm::cl::cat(gRootclingOptions));
 
@@ -3820,8 +3821,9 @@ static llvm::cl::list<std::string>
 gOptWDiags("W", llvm::cl::Prefix, llvm::cl::ZeroOrMore,
           llvm::cl::desc("Specify compiler diagnostics options."),
           llvm::cl::cat(gRootclingOptions));
+// Really OneOrMore, will be changed in RootClingMain below.
 static llvm::cl::list<std::string>
-gOptDictionaryHeaderFiles(llvm::cl::Positional, llvm::cl::OneOrMore,
+gOptDictionaryHeaderFiles(llvm::cl::Positional, llvm::cl::ZeroOrMore,
                          llvm::cl::desc("<list of dictionary header files> <LinkDef file>"),
                          llvm::cl::cat(gRootclingOptions));
 static llvm::cl::list<std::string>
@@ -3960,6 +3962,11 @@ int RootClingMain(int argc,
    llvm::cl::alias optHelpAlias2("?",
                       llvm::cl::desc("Alias for -help"),
                       llvm::cl::aliasopt(optHelp));
+
+   // Set number of required arguments. We cannot do this globally since it
+   // would interfere with LLVM's option parsing.
+   gOptDictionaryFileName.setNumOccurrencesFlag(llvm::cl::Required);
+   gOptDictionaryHeaderFiles.setNumOccurrencesFlag(llvm::cl::OneOrMore);
 
    // Copied from cling driver.
    // FIXME: Uncomment once we fix ROOT's teardown order.

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1425,6 +1425,10 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
       clingArgsStorage.push_back("-Wno-undefined-inline");
       clingArgsStorage.push_back("-fsigned-char");
       clingArgsStorage.push_back("-O1");
+      // Disable optimized register allocation which is turned on automatically
+      // by -O1, but seems to require -O2 to not explode in run time.
+      clingArgsStorage.push_back("-mllvm");
+      clingArgsStorage.push_back("-optimize-regalloc=0");
    }
 
    // Process externally passed arguments if present.

--- a/interpreter/cling/include/cling/Interpreter/InvocationOptions.h
+++ b/interpreter/cling/include/cling/Interpreter/InvocationOptions.h
@@ -70,9 +70,6 @@ namespace cling {
     /// \brief Architecture level of the CUDA gpu. Necessary for the
     /// NVIDIA fatbinary tool.
     std::string CUDAGpuArch;
-    /// \brief Contains arguments, which will passed to the nvidia tool
-    /// fatbinary.
-    std::vector<std::string> CUDAFatbinaryArgs;
 
     ///\brief The remaining arguments to pass to clang.
     ///

--- a/interpreter/cling/lib/Interpreter/InvocationOptions.cpp
+++ b/interpreter/cling/lib/Interpreter/InvocationOptions.cpp
@@ -146,9 +146,6 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
       case options::OPT_fmodules_cache_path: CachePath = arg->getValue(); break;
       case options::OPT_cuda_path_EQ: CUDAPath = arg->getValue(); break;
       case options::OPT_cuda_gpu_arch_EQ: CUDAGpuArch = arg->getValue(); break;
-      case options::OPT_Xcuda_fatbinary:
-        CUDAFatbinaryArgs.push_back(arg->getValue());
-        break;
       case options::OPT_cuda_device_only:
         Language = true;
         CUDADevice = true;


### PR DESCRIPTION
This brings RDF jitting times of large computation graphs almost back to the level it was with `-O0`.

@eguiraud can you confirm this works / helps for other RDF examples as well?