### PR TITLE
[roofit] add missing include

### DIFF
--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -38,6 +38,7 @@ parallelized calculation of test statistics.
 #include "RooFit.h"
 
 #include "Riostream.h"
+#include "TClass.h"
 #include <string.h>
 
 


### PR DESCRIPTION
Appears with -Ddev=On compile options
