### PR TITLE
Introduce distributed RunGraphs

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -123,6 +123,7 @@ if __name__ == "__main__":
 
 Other notable additions and improvements include:
 
+- Enable triggering multiple distributed computation graphs through `RunGraphs`. This also allows sending both Spark and Dask jobs at the same time through a single function call.
 - Greatly reduce distributed tasks processing overhead. This involved:
     - Changing the distributed execution logic with the `TTree` data source to use `TEntryList` in order to select the range of entries that each task will read from the tree. This highly reduces the waiting time spent in retrieving the correct entries for processing, as it was previously done using the `Range` operation.
     - Refactoring the internal mechanism to store information about data sources and create ranges for the distributed tasks accordingly. This will also allow in the future to easily extend the supported data sources in distributed RDataFrame.

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -106,16 +106,10 @@ class ActionProxy(Proxy):
         self._cur_attr = attr  # Stores the name of operation call
         return self._call_action_result
 
-    def GetValue(self):
+    def execute_graph(self):
         """
-        Returns the result value of the current action
-        node if it was executed before, else triggers
-        the execution of the entire DistRDF graph before
-        returning the value.
-
-        Returns:
-            The value of the current action node, obtained after executing the
-            current action node in the computational graph.
+        Executes the distributed RDataFrame computation graph this proxy
+        belongs to. If the proxied node already has a value, this is a no-op.
         """
 
         # Creating a ROOT.TDirectory.TContext in a context manager so that
@@ -125,6 +119,15 @@ class ActionProxy(Proxy):
                 headnode = self.proxied_node.get_head()
                 generator = ComputationGraphGenerator(headnode)
                 headnode.backend.execute(generator)
+
+    def GetValue(self):
+        """
+        Returns the result value of the current action node if it was executed
+        before, else triggers the execution of the distributed graph before
+        returning the value.
+        """
+
+        self.execute_graph()
 
         return self.proxied_node.value
 

--- a/bindings/experimental/distrdf/python/DistRDF/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/__init__.py
@@ -14,6 +14,8 @@ import logging
 import sys
 import types
 
+import concurrent.futures
+
 from DistRDF.Backends import build_backends_submodules
 
 logger = logging.getLogger(__name__)
@@ -63,6 +65,55 @@ def create_logger(level="WARNING", log_path="./DistRDF.log"):
     return logger
 
 
+def RunGraphs(proxies):
+    """
+    Trigger the execution of multiple RDataFrame computation graphs on a certain
+    distributed backend. If the backend doesn't support multiple job
+    submissions concurrently, the distributed computation graphs will be
+    executed sequentially.
+
+    Args:
+        proxies(list): List of action proxies that should be triggered. Only
+            actions belonging to different RDataFrame graphs will be
+            triggered to avoid useless calls.
+
+    Example:
+
+        @code{.py}
+        import ROOT
+        RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
+        RunGraphs = ROOT.RDF.Experimental.Distributed.RunGraphs
+
+        # Create 3 different dataframes and book an histogram on each one
+        histoproxies = [
+            RDataFrame(100)
+                .Define("x", "rdfentry_")
+                .Histo1D(("name", "title", 10, 0, 100), "x")
+            for _ in range(4)
+        ]
+
+        # Execute the 3 computation graphs
+        RunGraphs(histoproxies)
+        # Retrieve all the histograms in one go
+        histos = [histoproxy.GetValue() for histoproxy in histoproxies]
+        @endcode
+
+
+    """
+
+    if not proxies:
+        raise ValueError("The list of result pointers passed to RunGraphs is empty.")
+
+    # Get proxies belonging to distinct computation graphs
+    uniqueproxies = list({proxy.proxied_node.get_head(): proxy for proxy in proxies}.values())
+
+    # Submit all computation graphs concurrently from multiple Python threads.
+    # The submission is not computationally intensive
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(uniqueproxies)) as executor:
+        futures = [executor.submit(proxy.execute_graph) for proxy in uniqueproxies]
+        concurrent.futures.wait(futures)
+
+
 def create_distributed_module(parentmodule):
     """
     Helper function to create the ROOT.RDF.Experimental.Distributed module.
@@ -84,6 +135,7 @@ def create_distributed_module(parentmodule):
     # Inject top-level functions
     distributed.initialize = initialize
     distributed.create_logger = create_logger
+    distributed.RunGraphs = RunGraphs
 
     # Set non-optimized default mode
     distributed.optimized = False

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -686,6 +686,34 @@ where `n` is the number of dataset partitions. As with local RDataFrame, the res
 RDataFrame is another distributed RDataFrame on which we can define a new computation graph and run more distributed
 computations.
 
+### Distributed RunGraphs
+
+Submitting multiple distributed RDataFrame executions is supported through the % RunGraphs function. Similarly to its
+local counterpart, the function expects an iterable of objects representing an RDataFrame action. Each action will be
+triggered concurrently to send multiple computation graphs to a distributed cluster at the same time:
+
+~~~{.py}
+import ROOT
+RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
+RunGraphs = ROOT.RDF.Experimental.Distributed.RunGraphs
+
+# Create 3 different dataframes and book an histogram on each one
+histoproxies = [
+   RDataFrame(100)
+         .Define("x", "rdfentry_")
+         .Histo1D(("name", "title", 10, 0, 100), "x")
+   for _ in range(4)
+]
+
+# Execute the 3 computation graphs
+RunGraphs(histoproxies)
+# Retrieve all the histograms in one go
+histos = [histoproxy.GetValue() for histoproxy in histoproxies]
+~~~
+
+Every distributed backend supports this feature and graphs belonging to different backends can be still triggered with
+a single call to % RunGraphs (e.g. it is possible to send a Spark job and a Dask job at the same time).
+
 \anchor transformations
 ## Transformations
 \anchor Filters


### PR DESCRIPTION
Second iteration of the distributed RunGraphs function. The logic is greatly simplified now.
* There is no need (at this moment) to provide separate implementations of RunGraphs for each distributed backend. Both Spark and Dask support submitting tasks from multiple Python threads. So a common ThreadPool is cleaner and also allows to use different backends at the same time in principle
* The `GetValue` method of the proxy has been split in two functions to separate its functionalities. The `execute_graph` method is called in `RunGraphs`