### PR TITLE
[RF] Follow up on RooFit multiprocessing developments

### DIFF
--- a/.ci/copy_headers.sh
+++ b/.ci/copy_headers.sh
@@ -10,6 +10,6 @@ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -Dall=On -Dtesting=On -Dx11=Off -Dalien
 # We need to prebuild a minimal set of targets which are responsible for header copy
 # or generation.
 make -j4 move_headers intrinsics_gen clang-tablegen-targets ClangDriverOptions \
-         googletest Dictgen BaseTROOT BUILTIN_cppzmq
+         googletest Dictgen BaseTROOT
 ln -s $PWD/compile_commands.json $PWD/../root/
 

--- a/builtins/zeromq/cppzmq/CMakeLists.txt
+++ b/builtins/zeromq/cppzmq/CMakeLists.txt
@@ -22,9 +22,6 @@ add_custom_target(builtin_cppzmq_incl
 
 set_property(GLOBAL APPEND PROPERTY ROOT_HEADER_TARGETS builtin_cppzmq_incl)
 
-install(FILES ${cppzmq_HEADER_PATH}/zmq.hpp
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/)
-
 # find_package emulation
 set(cppzmq_FOUND TRUE CACHE BOOL "" FORCE)
 set(cppzmq_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include CACHE INTERNAL "" FORCE)

--- a/roofit/roofitZMQ/test/test_HWM.cxx
+++ b/roofit/roofitZMQ/test/test_HWM.cxx
@@ -27,15 +27,13 @@ protected:
       if (child_pid > 0) { // parent
          pusher.reset(zmqSvc().socket_ptr(zmq::socket_type::push));
          if (set_hwm) {
-            auto rc = zmq_setsockopt(*pusher, ZMQ_SNDHWM, &hwm, sizeof hwm);
-            assert(rc == 0);
+            EXPECT_EQ(zmq_setsockopt(*pusher, ZMQ_SNDHWM, &hwm, sizeof hwm), 0);
          }
          pusher->bind("ipc:///tmp/ZMQ_test_fork_polling_P2C.ipc");
       } else { // child
          puller.reset(zmqSvc().socket_ptr(zmq::socket_type::pull));
          if (set_hwm) {
-            auto rc = zmq_setsockopt(*puller, ZMQ_RCVHWM, &hwm, sizeof hwm);
-            assert(rc == 0);
+            EXPECT_EQ(zmq_setsockopt(*puller, ZMQ_RCVHWM, &hwm, sizeof hwm), 0);
          }
          puller->connect("ipc:///tmp/ZMQ_test_fork_polling_P2C.ipc");
       }

--- a/roofit/roofitcore/inc/TestStatistics/ConstantTermsOptimizer.h
+++ b/roofit/roofitcore/inc/TestStatistics/ConstantTermsOptimizer.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_ConstantTermsOptimizer
 #define ROOT_ROOFIT_TESTSTATISTICS_ConstantTermsOptimizer

--- a/roofit/roofitcore/inc/TestStatistics/LikelihoodGradientWrapper.h
+++ b/roofit/roofitcore/inc/TestStatistics/LikelihoodGradientWrapper.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_LikelihoodGradientWrapper
 #define ROOT_ROOFIT_TESTSTATISTICS_LikelihoodGradientWrapper

--- a/roofit/roofitcore/inc/TestStatistics/LikelihoodSerial.h
+++ b/roofit/roofitcore/inc/TestStatistics/LikelihoodSerial.h
@@ -1,18 +1,15 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
 
 #ifndef ROOT_ROOFIT_LikelihoodSerial
 #define ROOT_ROOFIT_LikelihoodSerial

--- a/roofit/roofitcore/inc/TestStatistics/LikelihoodWrapper.h
+++ b/roofit/roofitcore/inc/TestStatistics/LikelihoodWrapper.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_LikelihoodWrapper
 #define ROOT_ROOFIT_TESTSTATISTICS_LikelihoodWrapper

--- a/roofit/roofitcore/inc/TestStatistics/MinuitFcnGrad.h
+++ b/roofit/roofitcore/inc/TestStatistics/MinuitFcnGrad.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_MinuitFcnGrad
 #define ROOT_ROOFIT_TESTSTATISTICS_MinuitFcnGrad

--- a/roofit/roofitcore/inc/TestStatistics/RooAbsL.h
+++ b/roofit/roofitcore/inc/TestStatistics/RooAbsL.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_RooAbsL
 #define ROOT_ROOFIT_TESTSTATISTICS_RooAbsL

--- a/roofit/roofitcore/inc/TestStatistics/RooBinnedL.h
+++ b/roofit/roofitcore/inc/TestStatistics/RooBinnedL.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_RooBinnedL
 #define ROOT_ROOFIT_TESTSTATISTICS_RooBinnedL

--- a/roofit/roofitcore/inc/TestStatistics/RooRealL.h
+++ b/roofit/roofitcore/inc/TestStatistics/RooRealL.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_RooRealL
 #define ROOT_ROOFIT_TESTSTATISTICS_RooRealL

--- a/roofit/roofitcore/inc/TestStatistics/RooSubsidiaryL.h
+++ b/roofit/roofitcore/inc/TestStatistics/RooSubsidiaryL.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_RooSubsidiaryL
 #define ROOT_ROOFIT_TESTSTATISTICS_RooSubsidiaryL

--- a/roofit/roofitcore/inc/TestStatistics/RooSumL.h
+++ b/roofit/roofitcore/inc/TestStatistics/RooSumL.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_RooSumL
 #define ROOT_ROOFIT_TESTSTATISTICS_RooSumL

--- a/roofit/roofitcore/inc/TestStatistics/RooUnbinnedL.h
+++ b/roofit/roofitcore/inc/TestStatistics/RooUnbinnedL.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_RooUnbinnedL
 #define ROOT_ROOFIT_TESTSTATISTICS_RooUnbinnedL

--- a/roofit/roofitcore/inc/TestStatistics/buildLikelihood.h
+++ b/roofit/roofitcore/inc/TestStatistics/buildLikelihood.h
@@ -29,18 +29,18 @@ class RooAbsData;
 namespace RooFit {
 namespace TestStatistics {
 
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended extended = RooAbsL::Extended::Auto,
                 ConstrainedParameters constrained_parameters = {}, ExternalConstraints external_constraints = {},
                 GlobalObservables global_observables = {}, std::string global_observables_tag = {});
 
 // delegating builder calls, for more convenient "optional" parameter passing
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, ConstrainedParameters constrained_parameters);
-std::shared_ptr<RooAbsL> buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, ExternalConstraints external_constraints);
-std::shared_ptr<RooAbsL> buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, GlobalObservables global_observables);
-std::shared_ptr<RooAbsL> buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, std::string global_observables_tag);
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL> buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, ExternalConstraints external_constraints);
+std::unique_ptr<RooAbsL> buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, GlobalObservables global_observables);
+std::unique_ptr<RooAbsL> buildLikelihood(RooAbsPdf* pdf, RooAbsData* data, std::string global_observables_tag);
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, ConstrainedParameters constrained_parameters, GlobalObservables global_observables);
 
 }

--- a/roofit/roofitcore/inc/TestStatistics/buildLikelihood.h
+++ b/roofit/roofitcore/inc/TestStatistics/buildLikelihood.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_likelihood_builders
 #define ROOT_ROOFIT_TESTSTATISTICS_likelihood_builders

--- a/roofit/roofitcore/inc/TestStatistics/optional_parameter_types.h
+++ b/roofit/roofitcore/inc/TestStatistics/optional_parameter_types.h
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #ifndef ROOT_ROOFIT_TESTSTATISTICS_optional_parameter_types
 #define ROOT_ROOFIT_TESTSTATISTICS_optional_parameter_types

--- a/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
+++ b/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/ConstantTermsOptimizer.h>
 

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientWrapper.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientWrapper.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include "TestStatistics/LikelihoodGradientWrapper.h"
 #include "RooMinimizer.h"

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodSerial.cxx
@@ -1,19 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
-
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/LikelihoodSerial.h>
 #include <TestStatistics/RooAbsL.h>

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodWrapper.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodWrapper.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/LikelihoodWrapper.h>
 

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include "TestStatistics/MinuitFcnGrad.h"
 

--- a/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/RooAbsL.h>
 #include <TestStatistics/ConstantTermsOptimizer.h>

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 /**
 \file RooBinnedL.cxx

--- a/roofit/roofitcore/src/TestStatistics/RooRealL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooRealL.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/RooRealL.h>
 #include <TestStatistics/RooAbsL.h>

--- a/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 /**
 \file RooSubsidiaryL.cxx

--- a/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/RooSumL.h>
 #include <RooAbsData.h>

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 /**
 \file RooUnbinnedL.cxx

--- a/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
+++ b/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
@@ -351,7 +351,7 @@ getSimultaneousComponents(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended ex
  * \return A unique pointer to a RooSubsidiaryL that contains all terms in
  * the pdf that can be calculated separately from the other components in the full likelihood.
  */
-std::shared_ptr<RooAbsL> buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended extended,
+std::unique_ptr<RooAbsL> buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended extended,
                                          ConstrainedParameters constrained_parameters,
                                          ExternalConstraints external_constraints, GlobalObservables global_observables,
                                          std::string global_observables_tag)
@@ -381,27 +381,27 @@ std::shared_ptr<RooAbsL> buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, RooAb
 }
 
 // delegating convenience overloads
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, ConstrainedParameters constrained_parameters)
 {
    return buildLikelihood(pdf, data, RooAbsL::Extended::Auto, constrained_parameters);
 }
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, ExternalConstraints external_constraints)
 {
    return buildLikelihood(pdf, data, RooAbsL::Extended::Auto, {}, external_constraints);
 }
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, GlobalObservables global_observables)
 {
    return buildLikelihood(pdf, data, RooAbsL::Extended::Auto, {}, {}, global_observables);
 }
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, std::string global_observables_tag)
 {
    return buildLikelihood(pdf, data, RooAbsL::Extended::Auto, {}, {}, {}, global_observables_tag);
 }
-std::shared_ptr<RooAbsL>
+std::unique_ptr<RooAbsL>
 buildLikelihood(RooAbsPdf *pdf, RooAbsData *data, ConstrainedParameters constrained_parameters, GlobalObservables global_observables)
 {
    return buildLikelihood(pdf, data, RooAbsL::Extended::Auto, constrained_parameters, {}, global_observables);

--- a/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
+++ b/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/buildLikelihood.h>
 

--- a/roofit/roofitcore/src/TestStatistics/optional_parameter_types.cxx
+++ b/roofit/roofitcore/src/TestStatistics/optional_parameter_types.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/optional_parameter_types.h>
 


### PR DESCRIPTION
This PR contains some follow-up changes to https://github.com/root-project/root/pull/8700 and https://github.com/root-project/root/pull/9078:

* avoid using `std::shared_ptr` for return values
* change copyright of roofitcore/TestStatistics to `(c) CERN` (requested by @Axel-Naumann in https://github.com/root-project/root/pull/8700#discussion_r738407080)
  * I used now the same copyright headers from https://github.com/root-project/root/pull/9078 also for the  TestStatistics
* fix a build warning in non-debug mode
* don't install zmq.hpp header from builtins 
