### PR TITLE
[RF][PyROOT] New functions for conversion between RooDataSet and NumPy arrays or Pandas dataframes

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -154,6 +154,18 @@ Other notable additions and improvements include:
 
 
 ## RooFit Libraries
+### New PyROOT functions for interoperability with NumPy and Pandas
+
+New member functions of RooFit classes were introduced exclusively to PyROOT for better interoperability between RooFit and Numpy and Pandas:
+
+- `RooDataSet.from_numpy`: Import a RooDataSet from a dictionary of numpy arrays (static method)
+- `RooDataSet.to_numpy`: Export a RooDataSet to a dictionary of numpy arrays
+- `RooDataSet.from_pandas`: Import a RooDataSet from a Pandas dataframe (static method)
+- `RooDataSet.to_pandas`: Export a RooDataSet to a Pandas dataframe
+- `RooRealVar.bins`: Get bin boundaries for a `RooRealVar` as a NumPy array
+
+For more details, consult the tutorial [rf409_NumPyPandasToRooFit.py](https://root.cern/doc/v626/rf409__NumPyPandasToRooFit_8C.html).
+
 ### Creating RooFit datasets from RDataFrame
 RooFit now contains two RDataFrame action helpers, `RooDataSetHelper` and `RooDataHistHelper`, which allow for creating RooFit datasets by booking an action:
 ```c++

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
@@ -140,17 +140,33 @@ def get_defined_attributes(klass, consider_base_classes=False):
     return sorted([attr for attr in dir(klass) if is_defined(attr)])
 
 
+def is_staticmethod(klass, func_name):
+    """Check if the function with name `func_name` of a class is a static method.
+    """
+
+    import sys
+
+    if sys.version_info >= (3, 0):
+        func = getattr(klass(), func_name)
+    else:
+        func = getattr(klass, func_name)
+
+    return type(func).__name__ == "function"
+
+
 def rebind_instancemethod(to_class, from_class, func_name):
     """
     Bind the instance method `from_class.func_name` also to class `to_class`.
     """
 
-    from_method = getattr(from_class, func_name)
-
     import sys
+
+    from_method = getattr(from_class, func_name)
 
     if sys.version_info >= (3, 0):
         to_method = from_method
+    elif is_staticmethod(from_class, func_name):
+        to_method = staticmethod(from_method)
     else:
         import new
 

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
@@ -53,6 +53,7 @@ from ._rooprodpdf import RooProdPdf
 from ._roosimultaneous import RooSimultaneous
 from ._roosimwstool import RooSimWSTool
 from ._rooworkspace import RooWorkspace
+from ._roovectordatastore import RooVectorDataStore
 
 
 # list of python classes that are used to pythonize RooFit classes
@@ -81,6 +82,7 @@ python_classes = [
     RooSimultaneous,
     RooSimWSTool,
     RooWorkspace,
+    RooVectorDataStore,
 ]
 
 # list of python functions that are used to pythonize RooGlobalFunc function in RooFit
@@ -141,8 +143,7 @@ def get_defined_attributes(klass, consider_base_classes=False):
 
 
 def is_staticmethod(klass, func_name):
-    """Check if the function with name `func_name` of a class is a static method.
-    """
+    """Check if the function with name `func_name` of a class is a static method."""
 
     import sys
 

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/__init__.py
@@ -50,6 +50,7 @@ from ._roomcstudy import RooMCStudy
 from ._roomsgservice import RooMsgService
 from ._roonllvar import RooNLLVar
 from ._rooprodpdf import RooProdPdf
+from ._roorealvar import RooRealVar
 from ._roosimultaneous import RooSimultaneous
 from ._roosimwstool import RooSimWSTool
 from ._rooworkspace import RooWorkspace
@@ -79,6 +80,7 @@ python_classes = [
     RooMsgService,
     RooNLLVar,
     RooProdPdf,
+    RooRealVar,
     RooSimultaneous,
     RooSimWSTool,
     RooWorkspace,

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roodataset.py
@@ -54,3 +54,200 @@ class RooDataSet(object):
         # Redefinition of `RooDataSet.plotOnXY` for keyword arguments.
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         return self._plotOnXY(*args, **kwargs)
+
+    @staticmethod
+    def from_numpy(data, variables, name=None, title=None, weight_name=None, clip_to_limits=True):
+        """Create a RooDataSet from a dictionary of numpy arrays.
+        Args:
+            data (dict): Dictionary with strings as keys and numpy arrays as
+                         values, to be imported into the RooDataSet.
+            variables (RooArgSet, or list/tuple of RooAbsArgs):
+                Specification of the variables in the RooDataSet, will be
+                forwarded to the RooDataSet constructor. Both real values and
+                categories are supported.
+            name (str): Name of the RooDataSet, `None` is equivalent to an
+                        empty string.
+            title (str): Title of the RooDataSet, `None` is equivalent to an
+                         empty string.
+            weight_name (str): Key of the array in `data` that will be used for
+                               the dataset weights.
+            clip_to_limits (bool): When entries are added to a RooDataSet, the
+                                   standard RooFit behavior is to clip the
+                                   values to the limits specified by the
+                                   binning of the RooFit variables. To save
+                                   computational cost, you can disable this
+                                   clipping if not necessary in your workflow.
+
+        Returns:
+            RooDataSet
+        """
+        import ROOT
+        import numpy as np
+        import ctypes
+
+        name = "" if name is None else name
+        title = "" if title is None else title
+
+        if weight_name is None:
+            dataset = ROOT.RooDataSet(name, title, variables)
+        else:
+            dataset = ROOT.RooDataSet(name, title, variables, weight_name)
+
+        for real in dataset.store().realStoreList():
+            vec = real.data()
+            arg = real.bufArg()
+            arr = data[arg.GetName()]
+
+            if clip_to_limits:
+                arr = np.clip(arr, a_min=arg.getMin(), a_max=arg.getMax())
+
+            arr = arr if arr.dtype == np.float64 else np.array(arr, dtype=np.float64)
+            vec.resize(len(arr))
+
+            beg = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+            void_p = ctypes.cast(beg, ctypes.c_voidp).value + 8 * len(arr)
+            end = ctypes.cast(void_p, ctypes.POINTER(ctypes.c_double))
+            ROOT.std.copy(beg, end, vec.begin())
+
+        for cat in dataset.store().catStoreList():
+            vec = cat.data()
+            arr = data[cat.bufArg().GetName()]
+            arr = arr if arr.dtype == np.int32 else np.array(arr, dtype=np.int32)
+            vec.resize(len(arr))
+
+            beg = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int))
+            void_p = ctypes.cast(beg, ctypes.c_voidp).value + 4 * len(arr)
+            end = ctypes.cast(void_p, ctypes.POINTER(ctypes.c_int))
+            ROOT.std.copy(beg, end, vec.begin())
+
+        dataset.store().recomputeSumWeight()
+
+        n_entries = None
+
+        for real in dataset.store().realStoreList():
+            if n_entries is None:
+                n_entries = real.size()
+            assert n_entries == real.size()
+
+        for cat in dataset.store().catStoreList():
+            assert n_entries == cat.size()
+
+        return dataset
+
+    def to_numpy(self, copy=True, compute_derived_weight=False):
+        """Export a RooDataSet to a dictinary of numpy arrays.
+
+        Args:
+            copy (bool): If False, the data will not be copied. Use with
+                         caution, as the numpy arrays and the RooAbsData now
+                         own the same memory. If the dataset uses a
+                         RooTreeDataStore, there will always be a copy and the
+                         copy argument is ignored.
+            compute_derived_weight (bool): Sometimes, the weight variable is
+                not stored in the dataset, but it is a derived variable like a
+                RooFormulaVar. If the compute_derived_weight is True, the
+                weights will be computed in this case and also stored in the
+                output. Switched off by default because the computation is
+                relatively expensive.
+
+        Returns:
+            dict: A dictionary with the variable or weight names as keys and
+                  the numpy arrays as values.
+        """
+        import ROOT
+        import numpy as np
+
+        data = {}
+
+        if isinstance(self.store(), ROOT.RooVectorDataStore):
+            for name, array in self.store().to_numpy(copy=copy).items():
+                data[name] = array
+        elif isinstance(self.store(), ROOT.RooTreeDataStore):
+            # first create a VectorDataStore so we can read arrays
+            store = self.store()
+            variables = store.get()
+            store_name = store.GetName()
+            tmp_store = ROOT.RooVectorDataStore(store, variables, store_name)
+            for name, array in tmp_store.to_numpy(copy=copy).items():
+                data[name] = array
+        else:
+            raise RuntimeError(
+                "Exporting RooDataSet to numpy arrays failed. The data store type "
+                + self.store().__class__.__name__
+                + " is not supported."
+            )
+
+        # Special case where the weight is a derived variable (e.g. a RooFormulaVar).
+        # We don't want to miss putting the weight in the output arrays, so we
+        # are forced to iterate over the dataset to compute the weight.
+        if compute_derived_weight:
+            try:
+                wgt_var_name = self.weightVar().GetName()
+                if not wgt_var_name in data:
+                    weight_array = np.zeros(self.numEntries(), dtype=np.float64)
+                    for i in range(self.numEntries()):
+                        self.get(i)
+                        weight_array[i] = self.weight()
+                    data[wgt_var_name] = weight_array
+            except ReferenceError:
+                # self.weightVar() is a nullptr
+                pass
+
+        return data
+
+    @staticmethod
+    def from_pandas(df, variables, name=None, title=None, weight_name=None, clip_to_limits=True):
+        """Create a RooDataSet from a pandas DataFrame.
+        Args:
+            df (pandas.DataFrame): Pandas DataFrame to import.
+            variables (RooArgSet, or list/tuple of RooAbsArgs):
+                Specification of the variables in the RooDataSet, will be
+                forwarded to the RooDataSet constructor. Both real values and
+                categories are supported.
+            name (str): Name of the RooDataSet, `None` is equivalent to an
+                        empty string.
+            title (str): Title of the RooDataSet, `None` is equivalent to an
+                         empty string.
+            weight_name (str): Key of the array in `data` that will be used for
+                               the dataset weights.
+            clip_to_limits (bool): When entries are added to a RooDataSet, the
+                                   standard RooFit behavior is to clip the
+                                   values to the limits specified by the
+                                   binning of the RooFit variables. To save
+                                   computational cost, you can disable this
+                                   clipping if not necessary in your workflow.
+
+        Returns:
+            RooDataSet
+        """
+        import ROOT
+
+        data = {}
+        for column in df:
+            data[column] = df[column].values
+        return ROOT.RooDataSet.from_numpy(data, variables=variables, name=name, title=title, weight_name=weight_name, clip_to_limits=clip_to_limits)
+
+    def to_pandas(self, compute_derived_weight=False):
+        """Export a RooDataSet to a pandas DataFrame.
+
+        Args:
+            compute_derived_weight (bool): Sometimes, the weight variable is
+                not stored in the dataset, but it is a derived variable like a
+                RooFormulaVar. If the compute_derived_weight is True, the
+                weights will be computed in this case and also stored in the
+                output. Switched off by default because the computation is
+                relatively expensive.
+
+        Note:
+            Pandas copies the data from the numpy arrays when creating a
+            DataFrame. That's why we can disable copying in the to_numpy call.
+
+        Returns:
+            pandas.DataFrame: A dataframe with the variable or weight names as
+                              column names and the a row for each variable or
+                              weight in the dataset.
+        """
+        import ROOT
+        import pandas as pd
+
+        return pd.DataFrame(self.to_numpy(copy=False))

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roorealvar.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roorealvar.py
@@ -1,0 +1,39 @@
+# Authors:
+# * Jonas Rembser 11/2021
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+
+class RooRealVar(object):
+    def bins(self, range_name=None):
+        """Return the binning of this RooRealVar as a numpy array."""
+
+        import numpy as np
+
+        if range_name:
+            binning = self.getBinning(range_name)
+        else:
+            binning = self.getBinning()
+
+        num_bins = binning.numBins()
+        bin_array = np.zeros(num_bins + 1)
+        if num_bins == 0:
+            return bin_array
+
+        bin_array[0] = binning.binLow(0)
+        bin_array[1] = binning.binHigh(0)
+        for i in range(1, num_bins):
+            a_min, a_max = binning.binLow(i), binning.binHigh(i)
+            try:
+                np.testing.assert_almost_equal(a_min, bin_array[i])
+            except AssertionError:
+                raise ValueError("Binnings with gaps in between can't be exported to numpy.")
+            bin_array[i + 1] = a_max
+
+        return bin_array

--- a/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roovectordatastore.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/pythonization/_roofit/_roovectordatastore.py
@@ -1,0 +1,36 @@
+# Authors:
+# * Jonas Rembser 07/2021
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+
+class RooVectorDataStore(object):
+    def to_numpy(self, copy=True):
+        import numpy as np
+
+        data = {}
+
+        def check_for_duplicate_name(name):
+            if name in data:
+                raise RuntimeError("Attempt to add " + name + " twice to the numpy arrays!")
+
+        array_info = self.getArrays()
+        n = array_info.size
+
+        for x in array_info.reals:
+            check_for_duplicate_name(x.name)
+            data[x.name] = np.frombuffer(x.data, dtype=np.float64, count=n)
+        for x in array_info.cats:
+            check_for_duplicate_name(x.name)
+            data[x.name] = np.frombuffer(x.data, dtype=np.int32, count=n)
+        if copy:
+            for name in data.keys():
+                data[name] = np.copy(data[name])
+
+        return data

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -127,6 +127,12 @@ if(roofit)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabsreal_ploton roofit/rooabsreal_ploton.py)
 
   ROOT_ADD_PYUNITTEST(pyroot_roofit_roolinkedlist roofit/roolinkedlist.py)
+
+  # NumPy compatibility
+  if(NOT MSVC OR win_broken_tests)
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py)
+  endif()
+
 endif()
 
 if (dataframe)

--- a/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
@@ -1,0 +1,105 @@
+import unittest
+
+import ROOT
+
+import numpy as np
+
+
+class TestRooDataSetNumpy(unittest.TestCase):
+    def _create_dataset(self):
+        x = ROOT.RooRealVar("x", "x", 0, 10)
+        cat = ROOT.RooCategory("cat", "cat")
+        cat.defineType("minus", -1)
+        cat.defineType("plus", +1)
+        mean = ROOT.RooRealVar("mean", "mean of gaussian", 5, 0, 10)
+        sigma = ROOT.RooRealVar("sigma", "width of gaussian", 2, 0.1, 10)
+        gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
+        data = gauss.generate((x, cat), 100)
+        return data, x, cat
+
+    def test_to_numpy_basic(self):
+        """Basic test with a real value and a category."""
+        data, _, _ = self._create_dataset()
+        self.assertEqual(set(data.to_numpy().keys()), {"x", "cat"})
+
+    def test_to_numpy_weighted(self):
+        """Test with a weighted dataset."""
+        import numpy as np
+
+        x = ROOT.RooRealVar("x", "x", -10, 10)
+        myweight = ROOT.RooRealVar("myweight", "myweight", 0, 400)
+
+        columns = (x, myweight)
+
+        data = ROOT.RooDataSet("data", "data", columns, WeightVar=myweight)
+        for j in range(100):
+            x.setVal(np.random.normal())
+            myweight.setVal(10 + np.random.normal())
+            data.add(columns, myweight.getVal())
+
+        self.assertEqual(set(data.to_numpy().keys()), {"x", "myweight"})
+
+    def test_to_numpy_derived_weight(self):
+        """Test if the optional computation of derived weights works."""
+
+        data, x, _ = self._create_dataset()
+
+        # Create a data set with a derived weight
+        wFunc = ROOT.RooFormulaVar("w", "event weight", "(x*x+10)", [x])
+        w = data.addColumn(wFunc)
+        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
+
+        self.assertEqual(set(wdata.to_numpy().keys()), {"x", "cat"})
+        self.assertEqual(set(wdata.to_numpy(compute_derived_weight=True).keys()), {"x", "cat", "w"})
+
+    def test_to_numpy_and_from_numpy(self):
+        """Test exporting to numpy and then importing back a non-weighted dataset."""
+
+        data, x, cat = self._create_dataset()
+
+        np_data = data.to_numpy()
+
+        data_2 = ROOT.RooDataSet.from_numpy(np_data, (x, cat), name="data_2", title="data_2")
+
+        np_data_2 = data_2.to_numpy()
+
+        np.testing.assert_almost_equal(data_2.sumEntries(), data.sumEntries(), decimal=10)
+        self.assertEqual(set(np_data.keys()), set(np_data_2.keys()))
+
+        for key in np_data.keys():
+            self.assertEqual(len(np_data[key]), len(np_data_2[key]))
+            self.assertEqual(np_data[key][0], np_data_2[key][0])
+            self.assertEqual(np_data[key][-1], np_data_2[key][-1])
+
+    def test_to_numpy_and_from_numpy_weighted(self):
+        """Test exporting to numpy and then importing back a weighted dataset."""
+
+        data, x, cat = self._create_dataset()
+        wvar = ROOT.RooRealVar("w", "w", 0, 110)
+
+        # Construct formula to calculate (fake) weight for events
+        wFunc = ROOT.RooFormulaVar("w", "event weight", "(x*x+10)", [x])
+
+        # Add column with variable w to previously generated dataset
+        w = data.addColumn(wFunc)
+
+        # Instruct dataset wdata to use w as event weight and not observable
+        wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
+
+        np_data = wdata.to_numpy(compute_derived_weight=True)
+
+        wdata_2 = ROOT.RooDataSet.from_numpy(np_data, (x, cat, wvar), name="wdata_2", title="wdata_2", weight_name="w")
+
+        np_data_2 = wdata_2.to_numpy()
+
+        np.testing.assert_almost_equal(wdata_2.sumEntries(), wdata.sumEntries(), decimal=10)
+        self.assertEqual(set(np_data.keys()), set(np_data_2.keys()))
+
+        for key in np_data.keys():
+            self.assertEqual(len(np_data[key]), len(np_data_2[key]))
+            self.assertEqual(np_data[key][0], np_data_2[key][0])
+            self.assertEqual(np_data[key][-1], np_data_2[key][-1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/documentation/doxygen/print_roofit_pyz_doctrings.py
+++ b/documentation/doxygen/print_roofit_pyz_doctrings.py
@@ -113,18 +113,23 @@ def print_roofit_pythonization_page():
     """Prints the doxygen code for the RooFit pythonization page."""
     from ROOT.pythonization import _roofit
 
+    def member_funcs_have_doc(python_class):
+        funcs_have_doc = False
+        for func_name in _roofit.get_defined_attributes(python_klass):
+            if not getattr(python_class, func_name).__doc__ is None:
+                funcs_have_doc = True
+        return funcs_have_doc
+
     # Fill separate RooFit pythonization page, starting with the introduction and table of contents...
     print("\defgroup RoofitPythonizations Roofit pythonizations")
     print("\ingroup Roofitmain")
     for python_klass in _roofit.python_classes:
-        if python_klass.__doc__ is None:
+        if python_klass.__doc__ is None and not member_funcs_have_doc(python_klass):
             continue
         class_name = python_klass.__name__
         print("- [" + class_name + "](\\ref _" + class_name.lower() + ")")
 
-        func_names = _roofit.get_defined_attributes(python_klass)
-
-        for func_name in func_names:
+        for func_name in _roofit.get_defined_attributes(python_klass):
             func = getattr(python_klass, func_name)
             if func.__doc__ is None:
                 continue
@@ -134,19 +139,19 @@ def print_roofit_pythonization_page():
 
     # ...and then iterating over all pythonized classes and functions
     for python_klass in _roofit.python_classes:
-        if python_klass.__doc__ is None:
+
+        if python_klass.__doc__ is None and not member_funcs_have_doc(python_klass):
             continue
 
         print("\\anchor _" + python_klass.__name__.lower())
         print("## " + python_klass.__name__)
         print("\see " + python_klass.__name__)
-        print("")
-        print(inspect.cleandoc(python_klass.__doc__))
+        if not python_klass.__doc__ is None:
+            print("")
+            print(inspect.cleandoc(python_klass.__doc__))
         print("")
 
-        func_names = _roofit.get_defined_attributes(python_klass)
-
-        for func_name in func_names:
+        for func_name in _roofit.get_defined_attributes(python_klass):
             func = getattr(python_klass, func_name)
             if func.__doc__ is None:
                 continue

--- a/roofit/roofitcore/inc/RooAbsCategoryLValue.h
+++ b/roofit/roofitcore/inc/RooAbsCategoryLValue.h
@@ -77,11 +77,11 @@ public:
 
   // Binned fit interface
   virtual void setBin(Int_t ibin, const char* rangeName=0) ;
-  /// Get index of plot bin for current value this category.
-  virtual Int_t getBin(const char* /*rangeName*/) const {
+  /// Get the index of the plot bin for the current value of this category.
+  virtual Int_t getBin(const char* /*rangeName*/=nullptr) const {
     return getCurrentOrdinalNumber();
   }
-  virtual Int_t numBins(const char* rangeName) const ;
+  virtual Int_t numBins(const char* rangeName=nullptr) const ;
   virtual Double_t getBinWidth(Int_t /*i*/, const char* /*rangeName*/=0) const { 
     // Return volume of i-th bin (according to binning named rangeName if rangeName!=0)
     return 1.0 ; 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -60,6 +60,33 @@ public:
 
   virtual ~RooVectorDataStore() ;
 
+  /// \class ArraysStruct
+  /// Output struct for the RooVectorDataStore::getArrays() helper function.
+  /// Meant to be used for RooFit internal use and might change without warning.
+  struct ArraysStruct {
+
+    template<class T>
+    struct ArrayInfo {
+        ArrayInfo(std::string_view n, T const* d) : name{n}, data{d} {}
+        std::string name;
+        T const* data;
+    };
+
+    std::vector<ArrayInfo<double>> reals;
+    std::vector<ArrayInfo<RooAbsCategory::value_type>> cats;
+
+    std::size_t size;
+  };
+
+  /// \name Internal RooFit interface.
+  /// The classes and functions in the internal RooFit interface are
+  /// implementaion details and not part of the public user interface.
+  /// Everything in this group might change without warning.
+  /// @{
+  ArraysStruct getArrays() const;
+  void recomputeSumWeight();
+  /// @}
+
 private:
   RooArgSet varsNoWeight(const RooArgSet& allVars, const char* wgtName);
   RooRealVar* weightVar(const RooArgSet& allVars, const char* wgtName);
@@ -608,8 +635,6 @@ public:
   std::vector<RealVector*>& realStoreList() { return _realStoreList ; }
   std::vector<RealFullVector*>& realfStoreList() { return _realfStoreList ; }
   std::vector<CatVector*>& catStoreList() { return _catStoreList ; }
-
-  void recomputeSumWeight();
 
  protected:
 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -295,6 +295,8 @@ public:
       return _vec;
     }
 
+    std::vector<double>& data() { return _vec; }
+
   protected:
     std::vector<double> _vec;
 
@@ -480,6 +482,10 @@ public:
       if (_vecEH) _vecEH->reserve(siz);
     }
 
+    std::vector<double>* dataE() { return _vecE; }
+    std::vector<double>* dataEL() { return _vecEL; }
+    std::vector<double>* dataEH() { return _vecEH; }
+
   private:
     friend class RooVectorDataStore ;
     Double_t *_bufE ; //!
@@ -588,6 +594,8 @@ public:
     void setBufArg(RooAbsCategory* arg) { _cat = arg; }
     const RooAbsCategory* bufArg() const { return _cat; }
 
+    std::vector<RooAbsCategory::value_type>& data() { return _vec; }
+
   private:
     friend class RooVectorDataStore ;
     RooAbsCategory* _cat;
@@ -597,15 +605,17 @@ public:
     ClassDef(CatVector,2) // STL-vector-based Data Storage class
   } ;
   
+  std::vector<RealVector*>& realStoreList() { return _realStoreList ; }
+  std::vector<RealFullVector*>& realfStoreList() { return _realfStoreList ; }
+  std::vector<CatVector*>& catStoreList() { return _catStoreList ; }
+
+  void recomputeSumWeight();
 
  protected:
 
   friend class RooAbsReal ;
   friend class RooAbsCategory ;
   friend class RooRealVar ;
-  std::vector<RealVector*>& realStoreList() { return _realStoreList ; }
-  std::vector<RealFullVector*>& realfStoreList() { return _realfStoreList ; }
-  std::vector<CatVector*>& catStoreList() { return _catStoreList ; }
 
   CatVector* addCategory(RooAbsCategory* cat);
 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -630,7 +630,6 @@ public:
   std::vector<RealVector*> _realStoreList ;
   std::vector<RealFullVector*> _realfStoreList ;
   std::vector<CatVector*> _catStoreList ;
-  std::vector<double> _weights;
 
   void setAllBuffersNative() ;
 
@@ -649,7 +648,7 @@ public:
 
   Bool_t _forcedUpdate ; //! Request for forced cache update 
 
-  ClassDefOverride(RooVectorDataStore, 5) // STL-vector-based Data Storage class
+  ClassDefOverride(RooVectorDataStore, 6) // STL-vector-based Data Storage class
 };
 
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -1491,8 +1491,7 @@ RooVectorDataStore::RealFullVector* RooVectorDataStore::addRealFull(RooAbsReal* 
 
 /// Trigger a recomputation of the cached weight sums. Meant for use by RooFit
 /// dataset converter functions such as the NumPy converter functions
-/// implemented as pythonizations. Not meant to be part of the public user
-/// interface, so the interface might change without warning.
+/// implemented as pythonizations.
 void RooVectorDataStore::recomputeSumWeight() {
   double const* arr = nullptr;
   if (_extWgtArray) {
@@ -1516,4 +1515,33 @@ void RooVectorDataStore::recomputeSumWeight() {
   auto result = ROOT::Math::KahanSum<double, 4>::Accumulate(arr, arr + size(), 0.0);
   _sumWeight = result.Sum();
   _sumWeightCarry = result.Carry();
+}
+
+
+/// Exports all arrays in this RooVectorDataStore into a simple datastructure
+/// to be used by RooFit internal export functions.
+RooVectorDataStore::ArraysStruct  RooVectorDataStore::getArrays() const {
+  ArraysStruct out;
+  out.size = size();
+
+  for(auto const* real : _realStoreList) {
+    out.reals.emplace_back(real->_nativeReal->GetName(), real->_vec.data());
+  }
+  for(auto const* realf : _realfStoreList) {
+    std::string name = realf->_nativeReal->GetName();
+    out.reals.emplace_back(name, realf->_vec.data());
+    if(realf->_vecE) out.reals.emplace_back(name + "Err", realf->_vecE->data());
+    if(realf->_vecEL) out.reals.emplace_back(name + "ErrLo", realf->_vecEL->data());
+    if(realf->_vecEH) out.reals.emplace_back(name + "ErrHi", realf->_vecEH->data());
+  }
+  for(auto const* cat : _catStoreList) {
+    out.cats.emplace_back(cat->_cat->GetName(), cat->_vec.data());
+  }
+
+  if(_extWgtArray) out.reals.emplace_back("weight", _extWgtArray);
+  if(_extWgtErrLoArray) out.reals.emplace_back("wgtErrLo", _extWgtErrLoArray);
+  if(_extWgtErrHiArray) out.reals.emplace_back("wgtErrHi", _extWgtErrHiArray);
+  if(_extSumW2Array) out.reals.emplace_back("sumW2",_extSumW2Array);
+
+  return out;
 }

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -124,6 +124,7 @@ else()
                     roofit/rf401_importttreethx.C
                     roofit/rf401_importttreethx.py
                     roofit/rf408_RDataFrameToRooFit.py
+                    roofit/rf409_NumPyPandasToRooFit.py
                     roofit/rf512_wsfactory_oper.C
                     roofit/rf512_wsfactory_oper.py
                     roofit/rf708_bphysics.py

--- a/tutorials/roofit/rf409_NumPyPandasToRooFit.py
+++ b/tutorials/roofit/rf409_NumPyPandasToRooFit.py
@@ -1,0 +1,89 @@
+## \file
+## \ingroup tutorial_roofit
+## \notebook
+## Convert between NumPy arrays or Pandas DataFrames and RooDataSets.
+##
+## This totorial first how to export a RooDataSet to NumPy arrays or a Pandas
+## DataFrame, and then it shows you how to create a RooDataSet from a Pandas
+## DataFrame.
+##
+## \macro_code
+## \macro_output
+##
+## \date November 2021
+## \author Jonas Rembser
+
+import ROOT
+
+import numpy as np
+
+
+# The number of events that we use for the datasets created in this tutorial.
+n_events = 10000
+
+
+# Creating a RooDataSet and exporting it to the Python ecosystem
+# --------------------------------------------------------------
+
+# Define the observable.
+x = ROOT.RooRealVar("x", "x", -10, 10)
+
+# Define a Gaussian model with its parameters.
+mean = ROOT.RooRealVar("mean", "mean of gaussian", 1, -10, 10)
+sigma = ROOT.RooRealVar("sigma", "width of gaussian", 1, 0.1, 10)
+gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
+
+# Create a RooDataSet.
+data = gauss.generate(ROOT.RooArgSet(x), 10000)
+
+# Use RooDataSet.to_numpy() to export dataset to a dictionary of NumPy arrays.
+# Real values will be of type `double`, categorical values of type `int`.
+arrays = data.to_numpy()
+
+# We can verify that the mean and standard deviation matches our model specification.
+print("Mean of numpy array:", np.mean(arrays["x"]))
+print("Standard deviation of numpy array:", np.std(arrays["x"]))
+
+# It is also possible to create a Pandas DataFrame directly from the numpy arrays:
+df = data.to_pandas()
+
+# Now you can use the DataFrame e.g. for plotting. You can even combine this
+# with the RooAbsReal.bins PyROOT function, which returns the binning from
+# RooFit as a numpy array!
+try:
+    import matplotlib.pyplot as plt
+
+    df.hist(column="x", bins=x.bins())
+except ImportError:
+    print('Skipping `df.hist(column="x", bins=x.bins())` because matplotlib could not be imported.')
+
+del data
+del arrays
+del df
+
+
+# Creating a dataset with NumPy and importing it to a RooDataSet
+# --------------------------------------------------------------
+
+# Now we create some Gaussian toy data with numpy, this time with a different
+# mean.
+x_arr = np.random.normal(-1.0, 1.0, (n_events,))
+
+# Import the data to a RooDataSet, passing a dictionary of arrays and the
+# corresponding RooRealVars just like you would pass to the RooDataSet
+# constructor.
+data = ROOT.RooDataSet.from_numpy({"x" : x_arr}, ROOT.RooArgSet(x))
+
+# Let's fit the Gaussian to the data. The mean is updated accordingly.
+fit_result = gauss.fitTo(data, PrintLevel=-1, Save=True)
+fit_result.Print()
+
+# We can now plot the model and the dataset with RooFit.
+xframe = x.frame(Title="Gaussian pdf")
+data.plotOn(xframe)
+gauss.plotOn(xframe)
+
+# Draw RooFit plot on a canvas.
+c = ROOT.TCanvas("rf409_NumPyPandasToRooFit", "rf409_NumPyPandasToRooFit", 800, 400)
+xframe.Draw()
+c.SaveAs("rf409_NumPyPandasToRooFit.png")


### PR DESCRIPTION
New member functions of RooFit classes were introduced exclusively to PyROOT for better interoperability between RooFit and Numpy and Pandas:

1. `RooDataSet.from_numpy`: Import a RooDataSet from a dictionary of numpy arrays (static method)
2. `RooDataSet.to_numpy`: Export a RooDataSet to a dictionary of numpy arrays
3. `RooDataSet.from_pandas`: Import a RooDataSet from a Pandas dataframe (static method)
4. `RooDataSet.to_pandas`: Export a RooDataSet to a Pandas dataframe
5. `RooRealVar.bins`: Get bin boundaries for a `RooRealVar` as a NumPy array


- Unit tests were implemented that make closure tests for weighted and unweighted datasets, and also test if the support for `RooAbsCategory` works
- Besides implementing these functions as pythonizations, this PR makes some changes to the `RooVectorDataStore` interface to enable this data import/export functionality
- Some changes were made to the RooFit pythonization infrastructure to support static methods in the Python mirror classes
- A new tutorial was written to showcase these features
- Release notes were added
- Windows tests are disabled for now because they fail for reasons that I don't understand (see draft PR #8784)

This is part of the feature set presented at ACAT 2021 and promised for the next ROOT release. The equivalent import/export functions for `RooDataHist` will follow later.