### PR TITLE
 A new warning, -Wbidirectional, appeared on centos

### DIFF
--- a/graf2d/mathtext/CMakeLists.txt
+++ b/graf2d/mathtext/CMakeLists.txt
@@ -19,4 +19,8 @@ ROOT_LINKER_LIBRARY(mathtext
   NOINSTALL
 )
 
+check_cxx_compiler_flag(-Wbidirectional=none GCC_HAS_BIDIRECTIONAL_FLAG)
+if(GCC_HAS_BIDIRECTIONAL_FLAG)
+    set_source_files_properties(src/fontembed.cxx COMPILE_FLAGS "-Wbidirectional=none")
+endif()
 set_property(TARGET mathtext PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/graf2d/postscript/CMakeLists.txt
+++ b/graf2d/postscript/CMakeLists.txt
@@ -30,3 +30,8 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Postscript
   DEPENDENCIES
     Graf
 )
+
+check_cxx_compiler_flag(-Wbidirectional=none GCC_HAS_BIDIRECTIONAL_FLAG)
+if(GCC_HAS_BIDIRECTIONAL_FLAG)
+    set_source_files_properties(src/TPostScript.cxx COMPILE_FLAGS "-Wbidirectional=none")
+endif()


### PR DESCRIPTION
With the latest version of the `centos` C++ compiler a new warning appeared in 20 years old code.
The way to fix/deactivate it is to compile the files producing this warning with the option `-Wbidirectional=none` (found by @couet) . @bellenot found the way to set this option in the `CMakeLists.txt` files for the compilers having this option.
Fix warning:
```
warning: unpaired UTF-8 bidirectional character detected [-Wbidirectional=]
```

