### PR TITLE
RooFit::MultiProcess & TestStatistics part 7: MultiProcess based TestStatistics classes

### DIFF
--- a/builtins/zeromq/cppzmq/CMakeLists.txt
+++ b/builtins/zeromq/cppzmq/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(ExternalProject)
 
+set(cppzmq_HEADER_PATH ${CMAKE_CURRENT_BINARY_DIR}/BUILTIN_cppzmq-prefix/src/BUILTIN_cppzmq)
+
 ExternalProject_Add(BUILTIN_cppzmq
     URL https://github.com/zeromq/cppzmq/archive/refs/tags/v4.8.1.tar.gz
     URL_HASH SHA256=7a23639a45f3a0049e11a188e29aaedd10b2f4845f0000cf3e22d6774ebde0af
@@ -7,26 +9,14 @@ ExternalProject_Add(BUILTIN_cppzmq
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     DEPENDS libzmq
+    BUILD_BYPRODUCTS ${cppzmq_HEADER_PATH}/zmq.hpp
 )
-
-# manually copy header (inspired by nlohmann builtin)
-set(cppzmq_HEADER_PATH ${CMAKE_CURRENT_BINARY_DIR}/BUILTIN_cppzmq-prefix/src/BUILTIN_cppzmq)
-add_custom_command(
-        OUTPUT ${CMAKE_BINARY_DIR}/include/zmq.hpp
-        COMMAND ${CMAKE_COMMAND} -E copy ${cppzmq_HEADER_PATH}/zmq.hpp ${CMAKE_BINARY_DIR}/include/zmq.hpp
-        COMMENT "Copying zmq.hpp header to ${CMAKE_BINARY_DIR}/include"
-        DEPENDS BUILTIN_cppzmq)
-
-add_custom_target(builtin_cppzmq_incl
-        DEPENDS ${CMAKE_BINARY_DIR}/include/zmq.hpp)
-
-set_property(GLOBAL APPEND PROPERTY ROOT_HEADER_TARGETS builtin_cppzmq_incl)
 
 # find_package emulation
 set(cppzmq_FOUND TRUE CACHE BOOL "" FORCE)
-set(cppzmq_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include CACHE INTERNAL "" FORCE)
+set(cppzmq_INCLUDE_DIR ${cppzmq_HEADER_PATH} CACHE INTERNAL "" FORCE)
 set(cppzmq_INCLUDE_DIRS ${cppzmq_INCLUDE_DIR} CACHE INTERNAL "" FORCE)
 
 add_library(cppzmq INTERFACE IMPORTED GLOBAL)
 target_include_directories(cppzmq INTERFACE $<BUILD_INTERFACE:${cppzmq_INCLUDE_DIR}>)
-add_dependencies(cppzmq BUILTIN_cppzmq builtin_cppzmq_incl)
+add_dependencies(cppzmq BUILTIN_cppzmq)

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -316,6 +316,7 @@ endif()
 if(WIN32)
   set(davix_defvalue OFF)
   set(pyroot_legacy_defvalue OFF)
+  set(roofit_multiprocess_defvalue OFF)
   set(roottest_defvalue OFF)
   set(rpath_defvalue OFF)
   set(runtime_cxxmodules_defvalue OFF)
@@ -346,6 +347,11 @@ endif()
 # Disable RDataFrame on 32-bit UNIX platforms due to ROOT-9236
 if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(dataframe_defvalue OFF)
+endif()
+
+# MultiProcess is not possible on Windows, so fail if it is manually set:
+if(roofit_multiprocess AND WIN32)
+    message(FATAL_ERROR ">>> Option 'roofit_multiprocess' is not supported on Windows.")
 endif()
 
 #---Options depending of CMake Generator-------------------------------------------------------

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -162,7 +162,7 @@ ROOT_BUILD_OPTION(qt5web OFF "Enable support for Qt5 web-based display (requires
 ROOT_BUILD_OPTION(qt6web OFF "Enable support for Qt6 web-based display (requires Qt6::WebEngineCore and Qt6::WebEngineWidgets)")
 ROOT_BUILD_OPTION(r OFF "Enable support for R bindings (requires R, Rcpp, and RInside)")
 ROOT_BUILD_OPTION(roofit ON "Build the advanced fitting package RooFit, and RooStats for statistical tests. If xml is available, also build HistFactory.")
-ROOT_BUILD_OPTION(roofit_multiprocess ON "Build RooFit::MultiProcess and multi-process RooFit::TestStatistics classes (requires ZeroMQ with zmq_ppoll and cppzmq).")
+ROOT_BUILD_OPTION(roofit_multiprocess OFF "Build RooFit::MultiProcess and multi-process RooFit::TestStatistics classes (requires ZeroMQ with zmq_ppoll and cppzmq).")
 ROOT_BUILD_OPTION(roofit_hs3_ryml OFF "Try to find RapidYML on the system and use it for RooFit JSON/YAML convertes")
 ROOT_BUILD_OPTION(webgui ON "Build Web-based UI components of ROOT (requires C++17 standard or higher)")
 ROOT_BUILD_OPTION(root7 ON "Build ROOT 7 components of ROOT (requires C++17 standard or higher)")

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1864,7 +1864,7 @@ endif()
 
 #---Check for ZeroMQ when building RooFit::MultiProcess--------------------------------------------
 
-if (roofit_multiprocess AND NOT MSVC)
+if (roofit_multiprocess)
   if(NOT builtin_zeromq)
     message(STATUS "Looking for ZeroMQ (libzmq)")
     # Clear cache before calling find_package(ZeroMQ),
@@ -1929,7 +1929,7 @@ if (roofit_multiprocess AND NOT MSVC)
   target_compile_definitions(libzmq INTERFACE ZMQ_NO_EXPORT)
   target_compile_definitions(cppzmq INTERFACE ZMQ_BUILD_DRAFT_API)
   target_compile_definitions(cppzmq INTERFACE ZMQ_NO_EXPORT)
-endif (roofit_multiprocess AND NOT MSVC)
+endif (roofit_multiprocess)
 
 #---Download googletest--------------------------------------------------------------
 if (testing)

--- a/math/mathcore/inc/Math/Util.h
+++ b/math/mathcore/inc/Math/Util.h
@@ -129,6 +129,29 @@ namespace ROOT {
          std::fill(std::begin(fCarry), std::end(fCarry), 0.);
        }
 
+       /// Initialise with a sum value and a carry value.
+       /// \param[in] initialSumValue Initialise the sum with this value.
+       /// \param[in] initialCarryValue Initialise the carry with this value.
+       KahanSum(T initialSumValue, T initialCarryValue) {
+          fSum[0] = initialSumValue;
+          fCarry[0] = initialCarryValue;
+          std::fill(std::begin(fSum)+1, std::end(fSum), 0.);
+          std::fill(std::begin(fCarry)+1, std::end(fCarry), 0.);
+       }
+
+       /// Initialise the sum with a pre-existing state.
+       /// \param[in] sumBegin Begin of iterator range with values to initialise the sum with.
+       /// \param[in] sumEnd End of iterator range with values to initialise the sum with.
+       /// \param[in] carryBegin Begin of iterator range with values to initialise the carry with.
+       /// \param[in] carryEnd End of iterator range with values to initialise the carry with.
+       template<class Iterator>
+       KahanSum(Iterator sumBegin, Iterator sumEnd, Iterator carryBegin, Iterator carryEnd) {
+          assert(std::distance(sumBegin, sumEnd) == N);
+          assert(std::distance(carryBegin, carryEnd) == N);
+          std::copy(sumBegin, sumEnd, std::begin(fSum));
+          std::copy(carryBegin, carryEnd, std::begin(fCarry));
+       }
+
        /// Constructor to create a KahanSum from another KahanSum with a different number of accumulators
        template <unsigned int M>
        KahanSum(KahanSum<T,M> const& other) {

--- a/roofit/CMakeLists.txt
+++ b/roofit/CMakeLists.txt
@@ -5,10 +5,10 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
 add_subdirectory(batchcompute)
-if (roofit_multiprocess AND NOT MSVC)
+if (roofit_multiprocess)
   add_subdirectory(roofitZMQ)
   add_subdirectory(multiprocess)
-endif(roofit_multiprocess AND NOT MSVC)
+endif()
 add_subdirectory(roofitcore)
 add_subdirectory(roofit)
 if(mathmore)

--- a/roofit/multiprocess/CMakeLists.txt
+++ b/roofit/multiprocess/CMakeLists.txt
@@ -16,7 +16,9 @@ ROOT_LINKER_LIBRARY(RooFitMultiProcess
 )
 
 target_link_libraries(RooFitMultiProcess PUBLIC RooFitZMQ)
-set(RooFitMultiProcess_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/res ${RooFitZMQ_INCLUDE_DIRS})
-target_include_directories(RooFitMultiProcess PRIVATE ${RooFitMultiProcess_INCLUDE_DIRS})
+set(RooFitMultiProcess_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/res")
+target_include_directories(RooFitMultiProcess
+        PRIVATE ${RooFitMultiProcess_INCLUDE_DIR}
+        INTERFACE $<BUILD_INTERFACE:${RooFitMultiProcess_INCLUDE_DIR}>)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/multiprocess/res/RooFit/MultiProcess/Messenger_decl.h
+++ b/roofit/multiprocess/res/RooFit/MultiProcess/Messenger_decl.h
@@ -84,11 +84,12 @@ public:
 
    // -- MASTER - WORKER COMMUNICATION --
 
-   void publish_from_master_to_workers();
-   template <typename T, typename... Ts>
-   void publish_from_master_to_workers(T item, Ts... items);
+   template <typename T>
+   void publish_from_master_to_workers(T&& item);
+   template <typename T, typename T2, typename... Ts>
+   void publish_from_master_to_workers(T&& item, T2&& item2, Ts&&... items);
    template <typename value_t>
-   value_t receive_from_master_on_worker();
+   value_t receive_from_master_on_worker(bool *more = nullptr);
 
    void send_from_worker_to_master();
    template <typename T, typename... Ts>

--- a/roofit/multiprocess/test/CMakeLists.txt
+++ b/roofit/multiprocess/test/CMakeLists.txt
@@ -2,15 +2,11 @@
 
 add_library(RooFit_multiprocess_testing_utils INTERFACE)
 target_link_libraries(RooFit_multiprocess_testing_utils INTERFACE RooFitCore RooBatchCompute)
-target_include_directories(RooFit_multiprocess_testing_utils PRIVATE ${RooFitMultiProcess_INCLUDE_DIRS})
+target_include_directories(RooFit_multiprocess_testing_utils INTERFACE ${RooFitMultiProcess_INCLUDE_DIR})
 
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_Job test_Job.cxx LIBRARIES RooFitMultiProcess)
 # link to the INTERFACE library separately, ROOT_EXECUTABLE cannot handle INTERFACE library properties:
 target_link_libraries(test_RooFit_MultiProcess_Job RooFit_multiprocess_testing_utils)
-target_include_directories(test_RooFit_MultiProcess_Job PRIVATE ${RooFitMultiProcess_INCLUDE_DIRS})
 
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_ProcessManager test_ProcessManager.cxx LIBRARIES RooFitMultiProcess)
-target_include_directories(test_RooFit_MultiProcess_ProcessManager PRIVATE ${RooFitMultiProcess_INCLUDE_DIRS})
-
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_Messenger test_Messenger.cxx LIBRARIES RooFitMultiProcess)
-target_include_directories(test_RooFit_MultiProcess_Messenger PRIVATE ${RooFitMultiProcess_INCLUDE_DIRS})

--- a/roofit/roofitZMQ/CMakeLists.txt
+++ b/roofit/roofitZMQ/CMakeLists.txt
@@ -11,7 +11,9 @@ ROOT_LINKER_LIBRARY(RooFitZMQ
     )
 
 target_link_libraries(RooFitZMQ PUBLIC libzmq cppzmq)
-set(RooFitZMQ_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/res)
-target_include_directories(RooFitZMQ PRIVATE ${RooFitZMQ_INCLUDE_DIRS})
+set(RooFitZMQ_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/res)
+target_include_directories(RooFitZMQ
+        PRIVATE ${RooFitZMQ_INCLUDE_DIR}
+        INTERFACE $<BUILD_INTERFACE:${RooFitZMQ_INCLUDE_DIR}>)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/roofit/roofitZMQ/test/CMakeLists.txt
+++ b/roofit/roofitZMQ/test/CMakeLists.txt
@@ -1,14 +1,5 @@
 ROOT_ADD_GTEST(test_RooFitZMQ test_ZMQ.cpp LIBRARIES RooFitZMQ)
-target_include_directories(test_RooFitZMQ PRIVATE ${RooFitZMQ_INCLUDE_DIRS})
-
 ROOT_ADD_GTEST(test_RooFitZMQ_polling test_polling.cxx LIBRARIES RooFitZMQ)
-target_include_directories(test_RooFitZMQ_polling PRIVATE ${RooFitZMQ_INCLUDE_DIRS})
-
 ROOT_ADD_GTEST(test_RooFitZMQ_HWM test_HWM.cxx LIBRARIES RooFitZMQ)
-target_include_directories(test_RooFitZMQ_HWM PRIVATE ${RooFitZMQ_INCLUDE_DIRS})
-
 ROOT_ADD_GTEST(test_RooFitZMQ_load_balancing test_ZMQ_load_balancing.cxx LIBRARIES RooFitZMQ)
-target_include_directories(test_RooFitZMQ_load_balancing PRIVATE ${RooFitZMQ_INCLUDE_DIRS})
-
 ROOT_ADD_GTEST(test_RooFitZMQ_mkstemp test_mkstemp.cxx LIBRARIES RooFitZMQ)
-target_include_directories(test_RooFitZMQ_mkstemp PRIVATE ${RooFitZMQ_INCLUDE_DIRS})

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -9,6 +9,10 @@
 # @author Pere Mato, CERN
 ############################################################################
 
+if (roofit_multiprocess)
+  set(RooFitMPTestStatisticsSources src/TestStatistics/LikelihoodJob.cxx src/TestStatistics/LikelihoodGradientJob.cxx)
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   HEADERS
     Floats.h
@@ -473,6 +477,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/TestStatistics/RooUnbinnedL.cxx
     src/TestStatistics/optional_parameter_types.cxx
     src/TestStatistics/buildLikelihood.cxx
+    ${RooFitMPTestStatisticsSources}
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
   LIBRARIES
@@ -492,6 +497,13 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
   LINKDEF
     inc/LinkDef.h
 )
+
+if (roofit_multiprocess)
+  target_link_libraries(RooFitCore PRIVATE RooFitMultiProcess)
+  target_compile_definitions(RooFitCore PRIVATE -DBUILD_WITH_ROOFIT_MULTIPROCESS)
+  set(RooFitCore_MultiProcess_TestStatistics_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/res")
+  target_include_directories(RooFitCore PRIVATE ${RooFitCore_MultiProcess_TestStatistics_INCLUDE_DIR})
+endif()
 
 # For recent clang, this can facilitate auto-vectorisation.
 # In RooFit, the errno side effect is not needed, anyway:

--- a/roofit/roofitcore/inc/TestStatistics/LikelihoodGradientWrapper.h
+++ b/roofit/roofitcore/inc/TestStatistics/LikelihoodGradientWrapper.h
@@ -37,6 +37,8 @@ public:
    virtual LikelihoodGradientWrapper* clone() const = 0;
 
    virtual void fillGradient(double *grad) = 0;
+   virtual void
+   fillGradientWithPrevResult(double *grad, double *previous_grad, double *previous_g2, double *previous_gstep) = 0;
 
    /// Synchronize minimizer settings with calculators in child classes.
    virtual void synchronizeWithMinimizer(const ROOT::Math::MinimizerOptions &options);

--- a/roofit/roofitcore/res/TestStatistics/LikelihoodGradientJob.h
+++ b/roofit/roofitcore/res/TestStatistics/LikelihoodGradientJob.h
@@ -1,0 +1,91 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOT_ROOFIT_TESTSTATISTICS_LikelihoodGradientJob
+#define ROOT_ROOFIT_TESTSTATISTICS_LikelihoodGradientJob
+
+#include "RooFit/MultiProcess/Job.h"
+#include "TestStatistics/LikelihoodGradientWrapper.h"
+
+#include "Math/MinimizerOptions.h"
+#include "Minuit2/NumericalDerivator.h"
+#include "Minuit2/MnMatrix.h"
+
+#include <vector>
+
+namespace RooFit {
+namespace TestStatistics {
+
+class LikelihoodGradientJob : public MultiProcess::Job, public LikelihoodGradientWrapper {
+public:
+   LikelihoodGradientJob(std::shared_ptr<RooAbsL> likelihood,
+                         std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean, std::size_t N_dim,
+                         RooMinimizer *minimizer);
+   LikelihoodGradientJob *clone() const override;
+   LikelihoodGradientJob(const LikelihoodGradientJob &other);
+
+   void fillGradient(double *grad) override;
+   void fillGradientWithPrevResult(double *grad, double *previous_grad, double *previous_g2,
+                                   double *previous_gstep) override;
+
+   void update_state() override;
+
+   enum class GradientCalculatorMode { ExactlyMinuit2, AlmostMinuit2 };
+
+private:
+   void run_derivator(unsigned int i_component) const;
+
+   void synchronizeParameterSettings(ROOT::Math::IMultiGenFunction *function,
+                                     const std::vector<ROOT::Fit::ParameterSettings> &parameter_settings) override;
+   // this overload must also be overridden here so that the one above doesn't trigger a overloaded-virtual warning:
+   void synchronizeParameterSettings(const std::vector<ROOT::Fit::ParameterSettings> &parameter_settings) override;
+
+   void synchronizeWithMinimizer(const ROOT::Math::MinimizerOptions &options) override;
+   void setStrategy(int istrat);
+   void setStepTolerance(double step_tolerance) const;
+   void setGradTolerance(double grad_tolerance) const;
+   void setNCycles(unsigned int ncycles) const;
+   void setErrorLevel(double error_level) const;
+
+   void updateMinuitInternalParameterValues(const std::vector<double> &minuit_internal_x) override;
+
+   bool usesMinuitInternalValues() override;
+
+   // Job overrides:
+   void evaluate_task(std::size_t task) override;
+
+   struct task_result_t {
+      std::size_t job_id;
+      std::size_t task_id;
+      ROOT::Minuit2::DerivatorElement grad;
+   };
+   void send_back_task_result_from_worker(std::size_t task) override;
+   bool receive_task_result_on_master(const zmq::message_t &message) override;
+
+   void update_workers_state();
+   void calculate_all();
+
+   // members
+
+   // mutables below are because ROOT::Math::IMultiGradFunction::DoDerivative is const
+   mutable std::vector<ROOT::Minuit2::DerivatorElement> grad_;
+   mutable ROOT::Minuit2::NumericalDerivator gradf_;
+
+   std::size_t N_tasks_ = 0;
+   std::size_t N_tasks_at_workers_ = 0;
+   std::vector<double> minuit_internal_x_;
+};
+
+} // namespace TestStatistics
+} // namespace RooFit
+
+#endif // ROOT_ROOFIT_LikelihoodGradientJob

--- a/roofit/roofitcore/res/TestStatistics/LikelihoodJob.h
+++ b/roofit/roofitcore/res/TestStatistics/LikelihoodJob.h
@@ -1,0 +1,81 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOT_ROOFIT_TESTSTATISTICS_LikelihoodJob
+#define ROOT_ROOFIT_TESTSTATISTICS_LikelihoodJob
+
+#include "RooFit/MultiProcess/Job.h"
+#include "RooFit/MultiProcess/types.h"
+#include "TestStatistics/LikelihoodWrapper.h"
+#include "RooArgList.h"
+
+#include "Math/MinimizerOptions.h"
+
+#include <vector>
+
+namespace RooFit {
+namespace TestStatistics {
+
+class LikelihoodJob : public MultiProcess::Job, public LikelihoodWrapper {
+public:
+   LikelihoodJob(std::shared_ptr<RooAbsL> _likelihood,
+                 std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean /*, RooMinimizer *minimizer*/);
+   LikelihoodJob *clone() const override;
+
+   void init_vars();
+
+   void evaluate() override;
+   inline ROOT::Math::KahanSum<double> getResult() const override { return result_; }
+
+   void updateWorkersParameters(); // helper for evaluate
+   void updateWorkersOffsetting(); // helper for enableOffsetting
+
+   // Job overrides:
+   void evaluate_task(std::size_t task) override;
+   void update_state() override;
+
+   struct update_state_t {
+      std::size_t var_index;
+      double value;
+      bool is_constant;
+   };
+   enum class update_state_mode : int { parameters, offsetting };
+
+   // --- RESULT LOGISTICS ---
+   struct task_result_t {
+      std::size_t job_id; // job ID must always be the first part of any result message/type
+      double value;
+      double carry;
+   };
+
+   void send_back_task_result_from_worker(std::size_t task) override;
+   bool receive_task_result_on_master(const zmq::message_t &message) override;
+
+   void enableOffsetting(bool flag) override;
+
+private:
+   ROOT::Math::KahanSum<double> result_;
+   std::vector<ROOT::Math::KahanSum<double>> results_;
+
+   RooArgList vars_;      // Variables
+   RooArgList save_vars_; // Copy of variables
+
+   LikelihoodType likelihood_type_;
+   std::size_t N_tasks_at_workers_ = 0;
+};
+
+std::ostream &operator<<(std::ostream &out, const LikelihoodJob::update_state_mode value);
+
+} // namespace TestStatistics
+} // namespace RooFit
+
+#endif // ROOT_ROOFIT_LikelihoodJob

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -1,0 +1,238 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "TestStatistics/LikelihoodGradientJob.h"
+
+#include "RooFit/MultiProcess/JobManager.h"
+#include "RooFit/MultiProcess/Messenger.h"
+#include "RooFit/MultiProcess/Queue.h"
+#include "RooMsgService.h"
+#include "RooMinimizer.h"
+
+#include "Minuit2/MnStrategy.h"
+
+namespace RooFit {
+namespace TestStatistics {
+
+LikelihoodGradientJob::LikelihoodGradientJob(std::shared_ptr<RooAbsL> likelihood,
+                                             std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean,
+                                             std::size_t N_dim, RooMinimizer *minimizer)
+   : LikelihoodGradientWrapper(std::move(likelihood), std::move(calculation_is_clean), N_dim, minimizer), grad_(N_dim)
+{
+   // Note to future maintainers: take care when storing the minimizer_fcn pointer. The
+   // RooAbsMinimizerFcn subclasses may get cloned inside MINUIT, which means the pointer
+   // should also somehow be updated in this class.
+   N_tasks_ = N_dim;
+   minuit_internal_x_.reserve(N_dim);
+}
+
+LikelihoodGradientJob::LikelihoodGradientJob(const LikelihoodGradientJob &other)
+   : MultiProcess::Job(other), LikelihoodGradientWrapper(other), grad_(other.grad_), gradf_(other.gradf_),
+     N_tasks_(other.N_tasks_), minuit_internal_x_(other.minuit_internal_x_)
+{
+}
+
+LikelihoodGradientJob *LikelihoodGradientJob::clone() const
+{
+   return new LikelihoodGradientJob(*this);
+}
+
+void LikelihoodGradientJob::synchronizeParameterSettings(
+   const std::vector<ROOT::Fit::ParameterSettings> &parameter_settings)
+{
+   LikelihoodGradientWrapper::synchronizeParameterSettings(parameter_settings);
+}
+
+void LikelihoodGradientJob::synchronizeParameterSettings(
+   ROOT::Math::IMultiGenFunction *function, const std::vector<ROOT::Fit::ParameterSettings> &parameter_settings)
+{
+   gradf_.SetInitialGradient(function, parameter_settings, grad_);
+}
+
+void LikelihoodGradientJob::synchronizeWithMinimizer(const ROOT::Math::MinimizerOptions &options)
+{
+   setStrategy(options.Strategy());
+   setErrorLevel(options.ErrorDef());
+}
+
+void LikelihoodGradientJob::setStrategy(int istrat)
+{
+   assert(istrat >= 0);
+   ROOT::Minuit2::MnStrategy strategy(static_cast<unsigned int>(istrat));
+
+   setStepTolerance(strategy.GradientStepTolerance());
+   setGradTolerance(strategy.GradientTolerance());
+   setNCycles(strategy.GradientNCycles());
+}
+
+void LikelihoodGradientJob::setStepTolerance(double step_tolerance) const
+{
+   gradf_.SetStepTolerance(step_tolerance);
+}
+
+void LikelihoodGradientJob::setGradTolerance(double grad_tolerance) const
+{
+   gradf_.SetGradTolerance(grad_tolerance);
+}
+
+void LikelihoodGradientJob::setNCycles(unsigned int ncycles) const
+{
+   gradf_.SetNCycles(ncycles);
+}
+
+void LikelihoodGradientJob::setErrorLevel(double error_level) const
+{
+   gradf_.SetErrorLevel(error_level);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// Job overrides:
+
+void LikelihoodGradientJob::evaluate_task(std::size_t task)
+{
+   run_derivator(task);
+}
+
+// SYNCHRONIZATION FROM WORKERS TO MASTER
+
+void LikelihoodGradientJob::send_back_task_result_from_worker(std::size_t task)
+{
+   task_result_t task_result{id_, task, grad_[task]};
+   zmq::message_t message(sizeof(task_result_t));
+   memcpy(message.data(), &task_result, sizeof(task_result_t));
+   get_manager()->messenger().send_from_worker_to_master(std::move(message));
+}
+
+bool LikelihoodGradientJob::receive_task_result_on_master(const zmq::message_t &message)
+{
+   auto result = message.data<task_result_t>();
+   grad_[result->task_id] = result->grad;
+   --N_tasks_at_workers_;
+   bool job_completed = (N_tasks_at_workers_ == 0);
+   return job_completed;
+}
+
+// END SYNCHRONIZATION FROM WORKERS TO MASTER
+
+// SYNCHRONIZATION FROM MASTER TO WORKERS (STATE)
+
+void LikelihoodGradientJob::update_workers_state()
+{
+   // TODO optimization: only send changed parameters (now sending all)
+   zmq::message_t gradient_message(grad_.begin(), grad_.end());
+   zmq::message_t minuit_internal_x_message(minuit_internal_x_.begin(), minuit_internal_x_.end());
+   ++state_id_;
+   get_manager()->messenger().publish_from_master_to_workers(id_, state_id_, std::move(gradient_message),
+                                                             std::move(minuit_internal_x_message));
+}
+
+void LikelihoodGradientJob::update_state()
+{
+   bool more;
+
+   state_id_ = get_manager()->messenger().receive_from_master_on_worker<MultiProcess::State>(&more);
+
+   auto gradient_message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
+   assert(more);
+   auto gradient_message_begin = gradient_message.data<ROOT::Minuit2::DerivatorElement>();
+   auto gradient_message_end =
+      gradient_message_begin + gradient_message.size() / sizeof(ROOT::Minuit2::DerivatorElement);
+   std::copy(gradient_message_begin, gradient_message_end, grad_.begin());
+
+   auto minuit_internal_x_message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>(&more);
+   assert(!more);
+   auto minuit_internal_x_message_begin = minuit_internal_x_message.data<double>();
+   auto minuit_internal_x_message_end =
+      minuit_internal_x_message_begin + minuit_internal_x_message.size() / sizeof(double);
+   std::copy(minuit_internal_x_message_begin, minuit_internal_x_message_end, minuit_internal_x_.begin());
+
+   gradf_.SetupDifferentiate(minimizer_->getMultiGenFcn(), minuit_internal_x_.data(),
+                             minimizer_->fitter()->Config().ParamsSettings());
+}
+
+// END SYNCHRONIZATION FROM MASTER TO WORKERS (STATE)
+
+///////////////////////////////////////////////////////////////////////////////
+/// Calculation stuff (mostly duplicates of RooGradMinimizerFcn code):
+
+void LikelihoodGradientJob::run_derivator(unsigned int i_component) const
+{
+   // Calculate the derivative etc for these parameters
+   grad_[i_component] = gradf_.FastPartialDerivative(
+      minimizer_->getMultiGenFcn(), minimizer_->fitter()->Config().ParamsSettings(), i_component, grad_[i_component]);
+}
+
+void LikelihoodGradientJob::calculate_all()
+{
+   if (get_manager()->process_manager().is_master()) {
+      update_workers_state();
+
+      // master fills queue with tasks
+      for (std::size_t ix = 0; ix < N_tasks_; ++ix) {
+         MultiProcess::JobTask job_task{id_, state_id_, ix};
+         get_manager()->queue().add(job_task);
+      }
+      N_tasks_at_workers_ = N_tasks_;
+      // wait for task results back from workers to master (put into _grad)
+      gather_worker_results();
+
+      calculation_is_clean_->gradient = true;
+   }
+}
+
+void LikelihoodGradientJob::fillGradient(double *grad)
+{
+   if (get_manager()->process_manager().is_master()) {
+      if (!calculation_is_clean_->gradient) {
+         calculate_all();
+      }
+
+      // put the results from _grad into *grad
+      for (Int_t ix = 0; ix < minimizer_->getNPar(); ++ix) {
+         grad[ix] = grad_[ix].derivative;
+      }
+   }
+}
+
+void LikelihoodGradientJob::fillGradientWithPrevResult(double *grad, double *previous_grad, double *previous_g2,
+                                                       double *previous_gstep)
+{
+   if (get_manager()->process_manager().is_master()) {
+      for (std::size_t i_component = 0; i_component < N_tasks_; ++i_component) {
+         grad_[i_component] = {previous_grad[i_component], previous_g2[i_component], previous_gstep[i_component]};
+      }
+
+      if (!calculation_is_clean_->gradient) {
+         calculate_all();
+      }
+
+      // put the results from _grad into *grad
+      for (Int_t ix = 0; ix < minimizer_->getNPar(); ++ix) {
+         grad[ix] = grad_[ix].derivative;
+         previous_g2[ix] = grad_[ix].second_derivative;
+         previous_gstep[ix] = grad_[ix].step_size;
+      }
+   }
+}
+
+void LikelihoodGradientJob::updateMinuitInternalParameterValues(const std::vector<double> &minuit_internal_x)
+{
+   minuit_internal_x_ = minuit_internal_x;
+}
+
+bool LikelihoodGradientJob::usesMinuitInternalValues()
+{
+   return true;
+}
+
+} // namespace TestStatistics
+} // namespace RooFit

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
@@ -1,0 +1,247 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "TestStatistics/LikelihoodJob.h"
+
+#include "RooFit/MultiProcess/JobManager.h"
+#include "RooFit/MultiProcess/ProcessManager.h"
+#include "RooFit/MultiProcess/Queue.h"
+#include "RooFit/MultiProcess/Job.h"
+#include "RooFit/MultiProcess/types.h"
+#include "TestStatistics/RooAbsL.h"
+#include "TestStatistics/RooUnbinnedL.h"
+#include "TestStatistics/RooBinnedL.h"
+#include "TestStatistics/RooSubsidiaryL.h"
+#include "TestStatistics/RooSumL.h"
+#include "RooRealVar.h"
+
+namespace RooFit {
+namespace TestStatistics {
+
+LikelihoodJob::LikelihoodJob(
+   std::shared_ptr<RooAbsL> likelihood,
+   std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean /*, RooMinimizer *minimizer*/)
+   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean) /*, minimizer*/)
+{
+   init_vars();
+   // determine likelihood type
+   if (dynamic_cast<RooUnbinnedL *>(likelihood_.get()) != nullptr) {
+      likelihood_type_ = LikelihoodType::unbinned;
+   } else if (dynamic_cast<RooBinnedL *>(likelihood_.get()) != nullptr) {
+      likelihood_type_ = LikelihoodType::binned;
+   } else if (dynamic_cast<RooSumL *>(likelihood_.get()) != nullptr) {
+      likelihood_type_ = LikelihoodType::sum;
+   } else if (dynamic_cast<RooSubsidiaryL *>(likelihood_.get()) != nullptr) {
+      likelihood_type_ = LikelihoodType::subsidiary;
+   } else {
+      throw std::logic_error("in LikelihoodJob constructor: likelihood is not of a valid subclass!");
+   }
+   // Note to future maintainers: take care when storing the minimizer_fcn pointer. The
+   // RooAbsMinimizerFcn subclasses may get cloned inside MINUIT, which means the pointer
+   // should also somehow be updated in this class.
+}
+
+LikelihoodJob *LikelihoodJob::clone() const
+{
+   return new LikelihoodJob(*this);
+}
+
+// This is a separate function (instead of just in ctor) for historical reasons.
+// Its predecessor RooRealMPFE::initVars() was used from multiple ctors, but also
+// from RooRealMPFE::constOptimizeTestStatistic at the end, which makes sense,
+// because it might change the set of variables. We may at some point want to do
+// this here as well.
+void LikelihoodJob::init_vars()
+{
+   // Empty current lists
+   vars_.removeAll();
+   save_vars_.removeAll();
+
+   // Retrieve non-constant parameters
+   auto vars = std::make_unique<RooArgSet>(
+      *likelihood_->getParameters()); // TODO: make sure this is the right list of parameters, compare to original
+                                      // implementation in RooRealMPFE.cxx
+   RooArgList varList(*vars);
+
+   // Save in lists
+   vars_.add(varList);
+   save_vars_.addClone(varList);
+}
+
+void LikelihoodJob::update_state()
+{
+   if (get_manager()->process_manager().is_worker()) {
+      auto mode = get_manager()->messenger().receive_from_master_on_worker<update_state_mode>();
+      switch (mode) {
+      case update_state_mode::parameters: {
+         state_id_ = get_manager()->messenger().receive_from_master_on_worker<RooFit::MultiProcess::State>();
+         auto message = get_manager()->messenger().receive_from_master_on_worker<zmq::message_t>();
+         auto message_begin = message.data<update_state_t>();
+         auto message_end = message_begin + message.size() / sizeof(update_state_t);
+         std::vector<update_state_t> to_update(message_begin, message_end);
+         for (auto const &item : to_update) {
+            RooRealVar *rvar = (RooRealVar *)vars_.at(item.var_index);
+            rvar->setVal(static_cast<Double_t>(item.value));
+            if (rvar->isConstant() != item.is_constant) {
+               rvar->setConstant(static_cast<Bool_t>(item.is_constant));
+            }
+         }
+         break;
+      }
+      case update_state_mode::offsetting: {
+         LikelihoodWrapper::enableOffsetting(get_manager()->messenger().receive_from_master_on_worker<bool>());
+         break;
+      }
+      }
+   }
+}
+
+void LikelihoodJob::updateWorkersParameters()
+{
+   if (get_manager()->process_manager().is_master()) {
+      bool valChanged = false;
+      bool constChanged = false;
+      std::vector<update_state_t> to_update;
+      for (std::size_t ix = 0u; ix < static_cast<std::size_t>(vars_.getSize()); ++ix) {
+         valChanged = !vars_[ix].isIdentical(save_vars_[ix], kTRUE);
+         constChanged = (vars_[ix].isConstant() != save_vars_[ix].isConstant());
+
+         if (valChanged || constChanged) {
+            if (constChanged) {
+               ((RooRealVar *)&save_vars_[ix])->setConstant(vars_[ix].isConstant());
+            }
+            // TODO: Check with Wouter why he uses copyCache in MPFE; makes it very difficult to extend, because
+            // copyCache is protected (so must be friend). Moved setting value to if-block below.
+            //          _saveVars[ix].copyCache(&_vars[ix]);
+
+            // send message to queue (which will relay to workers)
+            RooAbsReal *rar_val = dynamic_cast<RooAbsReal *>(&vars_[ix]);
+            if (rar_val) {
+               Double_t val = rar_val->getVal();
+               dynamic_cast<RooRealVar *>(&save_vars_[ix])->setVal(val);
+               Bool_t isC = vars_[ix].isConstant();
+               to_update.push_back(update_state_t{ix, val, isC});
+            }
+         }
+      }
+      if (!to_update.empty()) {
+         ++state_id_;
+         zmq::message_t message(to_update.begin(), to_update.end());
+         // always send Job id first! This is used in worker_loop to route the
+         // update_state call to the correct Job.
+         get_manager()->messenger().publish_from_master_to_workers(id_, update_state_mode::parameters, state_id_);
+         // have to pass message separately to avoid copies from parameter pack to first parameter
+         get_manager()->messenger().publish_from_master_to_workers(std::move(message));
+      }
+   }
+}
+
+void LikelihoodJob::updateWorkersOffsetting()
+{
+   get_manager()->messenger().publish_from_master_to_workers(id_, update_state_mode::offsetting, isOffsetting());
+}
+
+void LikelihoodJob::evaluate()
+{
+   if (get_manager()->process_manager().is_master()) {
+      // update parameters that changed since last calculation (or creation if first time)
+      updateWorkersParameters();
+
+      // master fills queue with tasks
+      for (std::size_t ix = 0; ix < get_manager()->process_manager().N_workers(); ++ix) {
+         get_manager()->queue().add({id_, state_id_, ix});
+      }
+      N_tasks_at_workers_ = get_manager()->process_manager().N_workers();
+
+      // wait for task results back from workers to master
+      gather_worker_results();
+
+      for (auto const &item : results_) {
+         result_ += item;
+      }
+      result_ = applyOffsetting(result_);
+      results_.clear();
+   }
+}
+
+// --- RESULT LOGISTICS ---
+
+void LikelihoodJob::send_back_task_result_from_worker(std::size_t /*task*/)
+{
+   task_result_t task_result{id_, result_.Result(), result_.Carry()};
+   zmq::message_t message(sizeof(task_result_t));
+   memcpy(message.data(), &task_result, sizeof(task_result_t));
+   get_manager()->messenger().send_from_worker_to_master(std::move(message));
+}
+
+bool LikelihoodJob::receive_task_result_on_master(const zmq::message_t &message)
+{
+   auto task_result = message.data<task_result_t>();
+   results_.emplace_back(task_result->value, task_result->carry);
+   printf("result received: %f\n", task_result->value);
+   --N_tasks_at_workers_;
+   bool job_completed = (N_tasks_at_workers_ == 0);
+   return job_completed;
+}
+
+// --- END OF RESULT LOGISTICS ---
+
+void LikelihoodJob::evaluate_task(std::size_t task)
+{
+   assert(get_manager()->process_manager().is_worker());
+
+   std::size_t N_events = likelihood_->numDataEntries();
+
+   // used to have multiple modes here, but only kept "bulk" mode; dropped interleaved, single_event and all_events from
+   // old MultiProcess::NLLVar
+   std::size_t first = N_events * task / get_manager()->process_manager().N_workers();
+   std::size_t last = N_events * (task + 1) / get_manager()->process_manager().N_workers();
+
+   switch (likelihood_type_) {
+   case LikelihoodType::unbinned:
+   case LikelihoodType::binned: {
+      result_ = likelihood_->evaluatePartition(
+         {static_cast<double>(first) / N_events, static_cast<double>(last) / N_events}, 0, 0);
+      break;
+   }
+   default: {
+      throw std::logic_error(
+         "in LikelihoodJob::evaluate_task: likelihood types other than binned and unbinned not yet implemented!");
+      break;
+   }
+   }
+}
+
+void LikelihoodJob::enableOffsetting(bool flag)
+{
+   LikelihoodWrapper::enableOffsetting(flag);
+   updateWorkersOffsetting();
+}
+
+#define PROCESS_VAL(p) \
+   case (p): s = #p; break;
+
+std::ostream &operator<<(std::ostream &out, const LikelihoodJob::update_state_mode value)
+{
+   std::string s;
+   switch (value) {
+      PROCESS_VAL(LikelihoodJob::update_state_mode::offsetting);
+      PROCESS_VAL(LikelihoodJob::update_state_mode::parameters);
+   default: s = std::to_string(static_cast<int>(value));
+   }
+   return out << s;
+}
+
+#undef PROCESS_VAL
+
+} // namespace TestStatistics
+} // namespace RooFit

--- a/roofit/roofitcore/src/TestStatistics/README.md
+++ b/roofit/roofitcore/src/TestStatistics/README.md
@@ -1,0 +1,153 @@
+# `RooFit::TestStatistics` usage notes
+
+The `RooFit::TestStatistics` namespace contains a major refactoring of the `RooAbsTestStatistic`-`RooAbsOptTestStatistic`-`RooNLLVar` inheritance tree into:
+
+1. statistics-based classes on the one hand;
+2. calculation/evaluation/optimization based classes on the other hand.
+
+The motivation for this refactoring was also twofold:
+
+1. These test statistics classes make a cleaner separation of concerns than the existing `RooAbsTestStatistic` based tree and are hence more maintainable and future proof.
+2. They provided a place for us to try out new parallelized gradient calculation methods using the `RooFit::MultiProcess` module. See the usage example below on how to use this.
+
+## Statistics
+The likelihood is the central unit on the statistics side.
+The `RooAbsL` class is implemented for four kinds of likelihoods: binned, unbinned, "subsidiary" (an optimization for numerical stability that gathers components like global observables) and "sum" (over multiple components of the other types), in the correspondingly named classes `RooBinnedL`, `RooUnbinnedL`, `RooSubsidiaryL` and `RooSumL`.
+These classes provide a `evaluatePartition` function that allows for computing them in parallelizable chunks that can be used by the calculator classes as they see fit.
+
+On top of the likelihood classes, we also provide for convenience a likelihood builder `buildLikelihood`, as a free function in the namespace.
+This function analyzes the `pdf` and automatically constructs the proper likelihood, built
+up from the available `RooAbsL` subclasses.
+
+The new classes are not per se meant to be used outside of `RooMinimizer`, although they can be.
+The main reason is that they do not behave as regular `RooAbsReal` objects, but have their own interface which was kept to the minimum necessary for interacting with `RooMinimizer` as an object that encodes purely the statistics concepts.
+However, we do provide the `RooRealL` class, which holds a `RooAbsL` object, but does inherit from `RooAbsReal` as well, so that it can be used in contexts where you would normally use a `RooAbsReal` (like for plotting).
+
+### Usage example: Create an unbinned likelihood object
+It is possible to directly create `RooAbsL` based likelihood objects from a pdf and dataset, in this example a `RooUnbinnedL` type:
+```c++
+RooAbsPdf *pdf;
+RooDataSet *data;
+std::tie(pdf, data) = generate_some_unbinned_pdf_and_dataset(with, some, parameters);
+
+RooFit::TestStatistics::RooUnbinnedL likelihood(pdf, data);
+```
+
+However, most of the time, the user will not need **or want** such direct control over the type, but rather just let RooFit figure out what exact likelihood type (`RooAbsL` derived class) is best.
+For this situation, the `buildLikelihood` function was created that can be used (for instance) as:
+```c++
+std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood = RooFit::TestStatistics::buildLikelihood(pdf, data);
+```
+`buildLikelihood` actually returns a `unique_ptr`; storing the result in a `shared_ptr` as done here is just one possible use-case.
+
+### Usage example: Create a likelihood of a simultaneous PDF with constraint terms and global observables (and other optional arguments)
+The `RooAbsPdf::fitTo` or `RooAbsPdf::createNLL` interfaces could take in a set of optional parameters as `RooCmdArg` objects.
+In `TestStatistics::buildLikelihood`, we have implemented 4 of these options as separate types while an additional one is supported as a simple string:
+- `RooAbsL::Extended`: an enum class used to set extended term calculation `on`, `off` or use `Extended::Auto` to determine automatically based on the pdf whether to activate or not.
+- `ConstrainedParameters`: Initialized with a `RooArgSet` of parameters that are constrained. Pdf components dependent on these alone are added to a subsidiary likelihood term.
+- `ExternalConstraints`: Initialized with a `RooArgSet` of external constraint pdfs, i.e. constraints not necessarily in the pdf itself. These are always added to the subsidiary likelihood.
+- `GlobalObservables`: Initialized with a `RooArgSet` of observables that have a constant value, independent of the dataset events. Pdf components dependent on these alone are added to the subsidiary likelihood. \note This overrides all other likelihood parameters (like those in the `ConstrainedParameters` argument) if present.
+- Finally, a string argument `global_observables_tag` can be given, which should be set as attribute in any pdf component to indicate that it is a global observable. Can be used instead of or in addition to a `GlobalObservables` argument.
+
+Using these parameters, creating a likelihood of a simultaneous pdf (i.e. a `RooSimultaneous`) with constrained terms and global observables can be done with:
+
+```c++
+auto likelihood = RooFit::TestStatistics::buildLikelihood(
+  simultaneous_pdf, data,
+  RooFit::TestStatistics::ConstrainedParameters(RooArgSet(/*YOUR CONSTRAINED PARAMETERS*/)),
+  RooFit::TestStatistics::GlobalObservables(RooArgSet(/*YOUR GLOBAL OBSERVABLES*/)));
+```
+
+The resulting object will be a `RooSumL` containing a `RooSubsidiaryL` with the constrained parameters and `RooBinnedL` or `RooUnbinnedL` components for each simultaneous pdf component (depending on whether they are binned or unbinned pdfs).
+Note that, just like for `fitTo`, the order of the parameters is arbitrary.
+The difference is that `fitTo` has a step to analyze the `RooCmdArg` optional parameters for their content dynamically at runtime, while in `buildLikelihood` the arguments are statically typed and so no further runtime analysis is needed.
+
+As a side-note: one optional parameter of `RooNLLVar` that is not included in the `RooAbsL` tree is offsetting.
+Offsetting has instead been implemented in the calculators that we'll describe next.
+This is one of the consequences of the conceptual splitting of functionality into statistics and calculator classes.
+Offsetting is a feature of calculation in a fitting context; it enhances numerical precision by subtracting the initial likelihood value from the value that the minimizer sees, thus setting it to zero for the minimizer.
+Since this does not impact the derivative terms, it does not affect the fitting result, except for added numerical precision.
+
+
+## Calculators
+`RooFit::TestStatistics` provides two abstract base classes for likelihood calculation: `LikelihoodWrapper` and `LikelihoodGradientWrapper`.
+These are used by the `RooAbsMinimizerFcn` implementation `MinuitFcnGrad` which expects them to, respectively, provide likelihood and likelihood gradient values for use by `Minuit2` in fitting the pdf to the dataset.
+
+The `Wrapper`s can be implemented for different kinds of algorithms, or with different kinds of optimization "back-ends" in mind.
+One implementation of each is ready for use in `RooFit` currently:
+
+1. `LikelihoodSerial` is more or less simply a rewrite of the existing serial calculation of a `RooNLLVar`.
+2. `LikelihoodGradientJob` calculates the partial derivatives or the gradient in parallel on multiple CPUs/cores, based on `RooFit::MultiProcess`, which is a fork-based multi-processing task execution framework with dynamic load balancing.
+
+Other possible implementations could use the GPU or external tools like TensorFlow.
+
+The coupling of all these classes to `RooMinimizer` is made via the `MinuitFcnGrad` class, which owns the `Wrappers` that calculate the likelihood components.
+
+Note: a second `LikelihoodWrapper` class called `LikelihoodJob` is also available.
+This class emulates the existing `NumCPU(>1)` functionality of the `RooAbsTestStatistic` tree, which is implemented based on `RooRealMPFE`.
+This class is not yet thoroughly tested and should not be considered production ready.
+
+### Usage example: `MultiProcess` enabled parallel gradient calculator
+
+The main selling point of using `RooFit::TestStatistics` from a performance point of view is the implementation of the `RooFit::MultiProcess` based `LikelihoodGradientJob` calculator class.
+To use it, one should create a `RooMinimizer` using the new constructor that takes a `RooAbsL`-based likelihood instead of a `RooAbsReal`.
+
+Taking any of the above created `likelihood` objects (as long as they are in a `std::shared_ptr`), we can create a `RooMinimizer` with parallel gradient calculation using:
+```c++
+std::shared_ptr<RooAbsL> likelihood = /* see examples above */;
+RooMinimizer m(likelihood);
+```
+
+As noted above, offsetting is purely a function of the `RooMinimizer` when using `TestStatistics` classes.
+Whereas with `fitTo` we can pass in a `RooFit::Offset(kTRUE)` optional `RooCmdArg` argument to activate offsetting, here we must do it on the minimizer as follows:
+```c++
+m.setOffsetting(true);
+```
+
+All existing functionality of the `RooMinimizer` can be used on `TestStatistics` likelihoods as well.
+For instance, running a `migrad` fit:
+```c++
+m.migrad()
+```
+
+## Constant term optimization
+The `RooAbsTestStatistic` based classes not only combine statistics and calculation, but also constant term optimization routines.
+These can be run on PDFs and datasets before starting a fit.
+They search the calculation graph for parts that are independent of the fit parameters, precalculates them, and adds them to (a clone of) the dataset so that these values can be used during calculation.
+
+In `RooFit::TestStatistics`, we separated this functionality out into the `ConstantTermsOptimizer` class.
+In fact, it is not so much a class, as it is a collection of static functions that can be applied to any combination of pdf and dataset.
+This class does essentially the same as `constOptimizeTestStatistic` did on a `RooNLLVar`, except that it has been factored out into a separate class.
+
+### Usage example: apply constant term optimization on pdf and dataset inside a likelihood
+Applying the default `ConstantTermsOptimizer` optimization routines on the pdf and dataset inside a `RooAbsL` likelihood is as simple as:
+
+```c++
+likelihood.constOptimizeTestStatistic();
+```
+This applies constant term optimization to the cloned pdf and dataset inside the likelihood object.
+It will not modify anything outside of the likelihood.
+
+Optimization can also be activated through the minimizer, which may be more familiar to most users.
+Given the `RooMinimizer` object `m` as definied in the example above, we can do:
+```c++
+m.optimizeConst(2);
+```
+
+For the adventurous user, it is also possible to apply constant term optimization to a pdf and dataset directly without needing a likelihood object, e.g. given some `RooArgSet` set of observables `normSet`:
+```c++
+bool applyTrackingOpt = true;
+ConstantTermsOptimizer::enableConstantTermsOptimization(&pdf, &normSet, dataset, applyTrackingOpt);
+```
+We refer to RooFit documentation for more about "tracking optimization" which can be enabled or disabled using the final boolean parameter.
+
+## Caveats
+This package is still under development.
+Some functionality that users of `RooAbsPdf::fitTo` or `RooAbsPdf::createNLL` were used to has not yet been ported to this namespace.
+However, the functionality that is implemented has been tested thoroughly for a set of common usage patterns and should work as expected.
+
+The classes implemented here will give the exact same numerical results for most fits.
+One notable exception is fitting _simultaneous_ pdfs with a _constrained_ term _when using offsetting_.
+Because offsetting is handled differently in the `TestStatistics` classes compared to the way it was done in the object returned from `RooAbsPdf::createNLL` (a `RooAddition` of an offset `RooNLLVar` and a non-offset `RooConstraintSum`, whereas `RooSumL` applies the offset to the
+total sum of its binned, unbinned and constraint components), we cannot always expect exactly equal results for fits with likelihood offsetting enabled.
+

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -47,3 +47,7 @@ ROOT_ADD_GTEST(testRooGradMinimizerFcn testRooGradMinimizerFcn.cxx LIBRARIES Roo
 ROOT_ADD_GTEST(testLikelihoodSerial TestStatistics/testLikelihoodSerial.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooRealL TestStatistics/RooRealL.cpp LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFit)
+if (roofit_multiprocess)
+  ROOT_ADD_GTEST(testLikelihoodGradientJob TestStatistics/testLikelihoodGradientJob.cpp LIBRARIES RooFitMultiProcess RooFitCore RooFit RooStats m)
+  target_include_directories(testLikelihoodGradientJob PRIVATE ${RooFitCore_MultiProcess_TestStatistics_INCLUDE_DIR})
+endif()

--- a/roofit/roofitcore/test/TestStatistics/RooRealL.cpp
+++ b/roofit/roofitcore/test/TestStatistics/RooRealL.cpp
@@ -1,18 +1,16 @@
-// Author: Patrick Bos, Inti Pelupessy, Vince Croft, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *   IP, Inti Pelupessy, Netherlands eScience Center, i.pelupessy@esciencecenter.nl
+ *   VC, Vince Croft, DIANA / NYU, vincent.croft@cern.ch
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include "TestStatistics/RooRealL.h"
 #include "TestStatistics/RooUnbinnedL.h"

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
@@ -1,0 +1,445 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *   IP, Inti Pelupessy, Netherlands eScience Center, i.pelupessy@esciencecenter.nl
+ *   VC, Vince Croft, DIANA / NYU, vincent.croft@cern.ch
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "TestStatistics/LikelihoodGradientJob.h"
+
+#include "RooRandom.h"
+#include "RooWorkspace.h"
+#include "RooDataHist.h" // complete type in Binned test
+#include "RooCategory.h" // complete type in MultiBinnedConstraint test
+#include "RooMinimizer.h"
+#include "RooGradMinimizerFcn.h"
+#include "RooFitResult.h"
+#include "TestStatistics/LikelihoodSerial.h"
+#include "TestStatistics/RooUnbinnedL.h"
+#include "TestStatistics/buildLikelihood.h"
+#include "RooFit/MultiProcess/JobManager.h"
+#include "RooFit/MultiProcess/ProcessManager.h" // need to complete type for debugging
+#include "RooStats/ModelConfig.h"
+#include "RunContext.h" // complete RooBatchCompute::RunContext type used in RooUnbinnedL
+
+#include <TFile.h>
+
+#include <stdexcept> // runtime_error
+
+#include "gtest/gtest.h"
+#include "../test_lib.h" // generate_1D_gaussian_pdf_nll
+
+class Environment : public testing::Environment {
+public:
+   void SetUp() override { RooMsgService::instance().setGlobalKillBelow(RooFit::ERROR); }
+};
+
+// Previously, we just called AddGlobalTestEnvironment in global namespace, but this caused either a warning about an
+// unused declared variable (the return value of the call) or a parsing problem that the compiler can't handle if you
+// don't store the return value at all. The solution is to just define this manual main function. The default gtest
+// main function does InitGoogleTest and RUN_ALL_TESTS, we add the environment call in the middle.
+int main(int argc, char **argv)
+{
+   testing::InitGoogleTest(&argc, argv);
+   testing::AddGlobalTestEnvironment(new Environment);
+   return RUN_ALL_TESTS();
+}
+
+class LikelihoodGradientJob : public ::testing::TestWithParam<std::tuple<std::size_t, std::size_t>> {
+};
+
+TEST_P(LikelihoodGradientJob, Gaussian1D)
+{
+   // do a minimization, but now using GradMinimizer and its MP version
+
+   // parameters
+   std::size_t NWorkers = std::get<0>(GetParam());
+   std::size_t seed = std::get<1>(GetParam());
+
+   RooRandom::randomGenerator()->SetSeed(seed);
+
+   RooWorkspace w = RooWorkspace();
+
+   std::unique_ptr<RooAbsReal> nll;
+   std::unique_ptr<RooArgSet> values;
+   RooAbsPdf *pdf;
+   RooDataSet *data;
+   std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
+   RooRealVar *mu = w.var("mu");
+
+   RooArgSet *savedValues = dynamic_cast<RooArgSet *>(values->snapshot());
+   if (savedValues == nullptr) {
+      throw std::runtime_error("params->snapshot() cannot be casted to RooArgSet!");
+   }
+
+   // --------
+
+   std::unique_ptr<RooMinimizer> m0 = std::make_unique<RooMinimizer>(*nll, RooMinimizer::FcnMode::gradient);
+   m0->setMinimizerType("Minuit2");
+
+   m0->setStrategy(0);
+   m0->setPrintLevel(-1);
+
+   m0->migrad();
+
+   RooFitResult *m0result = m0->lastMinuitFit();
+   double minNll0 = m0result->minNll();
+   double edm0 = m0result->edm();
+   double mu0 = mu->getVal();
+   double muerr0 = mu->getError();
+
+   *values = *savedValues;
+
+   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
+   RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
+                   RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
+   m1.setMinimizerType("Minuit2");
+
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
+
+   m1.migrad();
+
+   RooFitResult *m1result = m1.lastMinuitFit();
+   double minNll1 = m1result->minNll();
+   double edm1 = m1result->edm();
+   double mu1 = mu->getVal();
+   double muerr1 = mu->getError();
+
+   EXPECT_EQ(minNll0, minNll1);
+   EXPECT_EQ(mu0, mu1);
+   EXPECT_EQ(muerr0, muerr1);
+   EXPECT_EQ(edm0, edm1);
+
+   m1.cleanup(); // necessary in tests to clean up global _theFitter
+}
+
+TEST(LikelihoodGradientJob, RepeatMigrad)
+{
+   // do multiple minimizations using MP::GradMinimizer, testing breakdown and rebuild
+
+   // parameters
+   std::size_t NWorkers = 2;
+   std::size_t seed = 5;
+
+   RooRandom::randomGenerator()->SetSeed(seed);
+
+   RooWorkspace w = RooWorkspace();
+
+   std::unique_ptr<RooAbsReal> nll;
+   std::unique_ptr<RooArgSet> values;
+   RooAbsPdf *pdf;
+   RooDataSet *data;
+   std::tie(nll, pdf, data, values) = generate_1D_gaussian_pdf_nll(w, 10000);
+
+   RooArgSet *savedValues = dynamic_cast<RooArgSet *>(values->snapshot());
+   if (savedValues == nullptr) {
+      throw std::runtime_error("params->snapshot() cannot be casted to RooArgSet!");
+   }
+
+   // --------
+
+   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
+   RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
+                   RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
+
+   m1.setMinimizerType("Minuit2");
+
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
+
+   std::cout << "... running migrad first time ..." << std::endl;
+   m1.migrad();
+
+   *values = *savedValues;
+
+   std::cout << "... running migrad second time ..." << std::endl;
+   m1.migrad();
+
+   std::cout << "... cleaning up minimizer ..." << std::endl;
+   m1.cleanup(); // necessary in tests to clean up global _theFitter
+}
+
+TEST_P(LikelihoodGradientJob, GaussianND)
+{
+   // do a minimization, but now using GradMinimizer and its MP version
+
+   // parameters
+   std::size_t NWorkers = std::get<0>(GetParam());
+   std::size_t seed = std::get<1>(GetParam());
+
+   unsigned int N = 4;
+
+   RooRandom::randomGenerator()->SetSeed(seed);
+
+   RooWorkspace w = RooWorkspace();
+
+   std::unique_ptr<RooAbsReal> nll;
+   std::unique_ptr<RooArgSet> values;
+   RooAbsPdf *pdf;
+   RooDataSet *data;
+   std::tie(nll, pdf, data, values) = generate_ND_gaussian_pdf_nll(w, N, 1000);
+
+   RooArgSet *savedValues = dynamic_cast<RooArgSet *>(values->snapshot());
+   if (savedValues == nullptr) {
+      throw std::runtime_error("params->snapshot() cannot be casted to RooArgSet!");
+   }
+
+   // --------
+
+   RooMinimizer m0(*nll, RooMinimizer::FcnMode::gradient);
+   m0.setMinimizerType("Minuit2");
+
+   m0.setStrategy(0);
+   m0.setPrintLevel(-1);
+
+   m0.migrad();
+
+   RooFitResult *m0result = m0.lastMinuitFit();
+   double minNll0 = m0result->minNll();
+   double edm0 = m0result->edm();
+   double mean0[N];
+   double std0[N];
+   for (unsigned ix = 0; ix < N; ++ix) {
+      {
+         std::ostringstream os;
+         os << "m" << ix;
+         mean0[ix] = dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->getVal();
+      }
+      {
+         std::ostringstream os;
+         os << "s" << ix;
+         std0[ix] = dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->getVal();
+      }
+   }
+
+   // --------
+
+   *values = *savedValues;
+
+   // --------
+
+   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
+   RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
+                   RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
+   m1.setMinimizerType("Minuit2");
+
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
+
+   m1.migrad();
+
+   RooFitResult *m1result = m1.lastMinuitFit();
+   double minNll1 = m1result->minNll();
+   double edm1 = m1result->edm();
+   double mean1[N];
+   double std1[N];
+   for (unsigned ix = 0; ix < N; ++ix) {
+      {
+         std::ostringstream os;
+         os << "m" << ix;
+         mean1[ix] = dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->getVal();
+      }
+      {
+         std::ostringstream os;
+         os << "s" << ix;
+         std1[ix] = dynamic_cast<RooRealVar *>(w.arg(os.str().c_str()))->getVal();
+      }
+   }
+
+   EXPECT_EQ(minNll0, minNll1);
+   EXPECT_EQ(edm0, edm1);
+
+   for (unsigned ix = 0; ix < N; ++ix) {
+      EXPECT_EQ(mean0[ix], mean1[ix]);
+      EXPECT_EQ(std0[ix], std1[ix]);
+   }
+
+   m1.cleanup(); // necessary in tests to clean up global _theFitter
+}
+
+INSTANTIATE_TEST_SUITE_P(NworkersSeed, LikelihoodGradientJob,
+                         ::testing::Combine(::testing::Values(1, 2, 3), // number of workers
+                                            ::testing::Values(2, 3)));  // random seed
+
+class BasicTest : public ::testing::Test {
+protected:
+   void SetUp() override
+   {
+      RooRandom::randomGenerator()->SetSeed(seed);
+      clean_flags = std::make_shared<RooFit::TestStatistics::WrapperCalculationCleanFlags>();
+   }
+
+   std::size_t seed = 23;
+   RooWorkspace w;
+   std::unique_ptr<RooAbsReal> nll;
+   RooAbsPdf *pdf;
+   RooAbsData *data;
+   std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood;
+   std::shared_ptr<RooFit::TestStatistics::WrapperCalculationCleanFlags> clean_flags;
+};
+
+class LikelihoodSimBinnedConstrainedTest : public BasicTest {
+protected:
+   void SetUp() override
+   {
+      BasicTest::SetUp();
+      // Unbinned pdfs that define template histograms
+
+      w.factory("Gaussian::gA(x[-10,10],-2,3)");
+      w.factory("Gaussian::gB(x[-10,10],2,1)");
+      w.factory("Uniform::u(x)");
+
+      // Generate template histograms
+
+      RooDataHist *h_sigA = w.pdf("gA")->generateBinned(*w.var("x"), 1000);
+      RooDataHist *h_sigB = w.pdf("gB")->generateBinned(*w.var("x"), 1000);
+      RooDataHist *h_bkg = w.pdf("u")->generateBinned(*w.var("x"), 1000);
+
+      w.import(*h_sigA, RooFit::Rename("h_sigA"));
+      w.import(*h_sigB, RooFit::Rename("h_sigB"));
+      w.import(*h_bkg, RooFit::Rename("h_bkg"));
+
+      // Construct binned pdf as sum of amplitudes
+      w.factory("HistFunc::hf_sigA(x,h_sigA)");
+      w.factory("HistFunc::hf_sigB(x,h_sigB)");
+      w.factory("HistFunc::hf_bkg(x,h_bkg)");
+
+      w.factory(
+         "ASUM::model_phys_A(mu_sig[1,-1,10]*hf_sigA,expr::mu_bkg_A('1+0.02*alpha_bkg_A',alpha_bkg_A[-5,5])*hf_bkg)");
+      w.factory("ASUM::model_phys_B(mu_sig*hf_sigB,expr::mu_bkg_B('1+0.05*alpha_bkg_B',alpha_bkg_B[-5,5])*hf_bkg)");
+
+      // Construct L_subs: Gaussian subsidiary measurement that constrains alpha_bkg
+      w.factory("Gaussian:model_subs_A(alpha_bkg_obs_A[0],alpha_bkg_A,1)");
+      w.factory("Gaussian:model_subs_B(alpha_bkg_obs_B[0],alpha_bkg_B,1)");
+
+      // Construct full pdfs for each component (A,B)
+      w.factory("PROD::model_A(model_phys_A,model_subs_A)");
+      w.factory("PROD::model_B(model_phys_B,model_subs_B)");
+
+      // Construct simulatenous pdf
+      w.factory("SIMUL::model(index[A,B],A=model_A,B=model_B)");
+
+      pdf = w.pdf("model");
+      // Construct dataset from physics pdf
+      data = pdf->generate(RooArgSet(*w.var("x"), *w.cat("index")), RooFit::AllBinned());
+   }
+};
+
+TEST_F(LikelihoodSimBinnedConstrainedTest, BasicParameters)
+{
+   // original test:
+   nll.reset(pdf->createNLL(
+      *data, RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")))));
+
+   // --------
+
+   auto nll0 = nll->getVal();
+
+   likelihood = RooFit::TestStatistics::buildLikelihood(
+      pdf, data, RooFit::TestStatistics::GlobalObservables({*w.var("alpha_bkg_obs_A"), *w.var("alpha_bkg_obs_B")}));
+   RooFit::TestStatistics::LikelihoodSerial nll_ts(likelihood, clean_flags /*, nullptr*/);
+
+   nll_ts.evaluate();
+   auto nll1 = nll_ts.getResult();
+
+   EXPECT_DOUBLE_EQ(nll0, nll1);
+}
+
+TEST_F(LikelihoodSimBinnedConstrainedTest, ConstrainedAndOffset)
+{
+   // do a minimization, but now using GradMinimizer and its MP version
+   nll.reset(pdf->createNLL(*data, RooFit::Constrain(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+                            RooFit::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))), RooFit::Offset(kTRUE)));
+
+   // parameters
+   std::size_t NWorkers = 2;
+
+   RooArgSet *values = pdf->getParameters(data);
+
+   values->add(*pdf);
+   values->add(*nll);
+
+   RooArgSet *savedValues = dynamic_cast<RooArgSet *>(values->snapshot());
+   if (savedValues == nullptr) {
+      throw std::runtime_error("params->snapshot() cannot be casted to RooArgSet!");
+   }
+
+   // --------
+
+   RooMinimizer m0(*nll, RooMinimizer::FcnMode::gradient);
+
+   m0.setMinimizerType("Minuit2");
+   m0.setStrategy(0);
+   m0.setPrintLevel(1);
+
+   m0.migrad();
+
+   RooFitResult *m0result = m0.lastMinuitFit();
+   double minNll_nominal = m0result->minNll();
+   double edm_nominal = m0result->edm();
+   double alpha_bkg_A_nominal = w.var("alpha_bkg_A")->getVal();
+   double alpha_bkg_A_error_nominal = w.var("alpha_bkg_A")->getError();
+   double alpha_bkg_B_nominal = w.var("alpha_bkg_B")->getVal();
+   double alpha_bkg_B_error_nominal = w.var("alpha_bkg_B")->getError();
+   double mu_sig_nominal = w.var("mu_sig")->getVal();
+   double mu_sig_error_nominal = w.var("mu_sig")->getError();
+
+   *values = *savedValues;
+
+   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+
+   likelihood = RooFit::TestStatistics::buildLikelihood(
+      pdf, data, RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
+      RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))));
+
+   RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
+                   RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
+   m1.setOffsetting(true);
+
+   m1.setMinimizerType("Minuit2");
+   m1.setStrategy(0);
+   m1.setPrintLevel(1);
+   m1.optimizeConst(2);
+
+   m1.migrad();
+
+   RooFitResult *m1result = m1.lastMinuitFit();
+   double minNll_GradientJob = m1result->minNll();
+   double edm_GradientJob = m1result->edm();
+   double alpha_bkg_A_GradientJob = w.var("alpha_bkg_A")->getVal();
+   double alpha_bkg_A_error_GradientJob = w.var("alpha_bkg_A")->getError();
+   double alpha_bkg_B_GradientJob = w.var("alpha_bkg_B")->getVal();
+   double alpha_bkg_B_error_GradientJob = w.var("alpha_bkg_B")->getError();
+   double mu_sig_GradientJob = w.var("mu_sig")->getVal();
+   double mu_sig_error_GradientJob = w.var("mu_sig")->getError();
+
+   // Because offsetting is handled differently in the TestStatistics classes
+   // compared to the way it was done in the object returned from
+   // RooAbsPdf::createNLL (a RooAddition of an offset RooNLLVar and a
+   // non-offset RooConstraintSum, whereas RooSumL applies the offset to the
+   // total sum of its binned, unbinned and constraint components),
+   // we cannot always expect exactly equal results for fits with likelihood
+   // offsetting enabled. See also the LikelihoodSerialSimBinnedConstrainedTest.
+   // ConstrainedAndOffset test case in testLikelihoodSerial.
+   EXPECT_FLOAT_EQ(minNll_nominal, minNll_GradientJob);
+   EXPECT_NEAR(edm_nominal, edm_GradientJob, 1e-5);
+   EXPECT_FLOAT_EQ(alpha_bkg_A_nominal, alpha_bkg_A_GradientJob);
+   EXPECT_FLOAT_EQ(alpha_bkg_A_error_nominal, alpha_bkg_A_error_GradientJob);
+   EXPECT_FLOAT_EQ(alpha_bkg_B_nominal, alpha_bkg_B_GradientJob);
+   EXPECT_FLOAT_EQ(alpha_bkg_B_error_nominal, alpha_bkg_B_error_GradientJob);
+   EXPECT_FLOAT_EQ(mu_sig_nominal, mu_sig_GradientJob);
+   EXPECT_FLOAT_EQ(mu_sig_error_nominal, mu_sig_error_GradientJob);
+
+   m1.cleanup(); // necessary in tests to clean up global _theFitter
+}

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodSerial.cxx
@@ -1,18 +1,14 @@
-// Author: Patrick Bos, Netherlands eScience Center / NIKHEF 2021
-
-/*****************************************************************************
- * RooFit
- * Authors:                                                                  *
- *   WV, Wouter Verkerke, UC Santa Barbara, verkerke@slac.stanford.edu       *
- *   DK, David Kirkby,    UC Irvine,         dkirkby@uci.edu                 *
- *                                                                           *
- * Copyright (c) 2000-2021, Regents of the University of California          *
- *                          and Stanford University. All rights reserved.    *
- *                                                                           *
- * Redistribution and use in source and binary forms,                        *
- * with or without modification, are permitted according to the terms        *
- * listed in LICENSE (http://roofit.sourceforge.net/license.txt)             *
- *****************************************************************************/
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
 
 #include <TestStatistics/LikelihoodSerial.h>
 

--- a/roofit/roofitcore/test/testRooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/test/testRooGradMinimizerFcn.cxx
@@ -72,15 +72,15 @@ TEST_P(GradMinimizerParSeed, Gaussian1D)
 
    *values = *savedValues;
 
-   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
-   m1->setMinimizerType("Minuit2");
+   RooMinimizer m1(*nll, RooMinimizer::FcnMode::gradient);
+   m1.setMinimizerType("Minuit2");
 
-   m1->setStrategy(0);
-   m1->setPrintLevel(-1);
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
 
-   m1->migrad();
+   m1.migrad();
 
-   RooFitResult *m1result = m1->lastMinuitFit();
+   RooFitResult *m1result = m1.lastMinuitFit();
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
    double mu1 = mu->getVal();
@@ -136,14 +136,14 @@ TEST(GradMinimizerDebugging, DISABLED_Gaussian1DGradMinimizer)
    // when c++17 support arrives, change to this:
    // auto [nll, _] = generate_1D_gaussian_pdf_nll(w, 10000);
 
-   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
-   m1->setMinimizerType("Minuit2");
+   RooMinimizer m1(*nll, RooMinimizer::FcnMode::gradient);
+   m1.setMinimizerType("Minuit2");
 
-   m1->setStrategy(0);
-   m1->setPrintLevel(100);
-   m1->setVerbose(kTRUE);
+   m1.setStrategy(0);
+   m1.setPrintLevel(100);
+   m1.setVerbose(kTRUE);
 
-   m1->migrad();
+   m1.migrad();
 }
 
 TEST(GradMinimizer, GaussianND)
@@ -207,15 +207,15 @@ TEST(GradMinimizer, GaussianND)
 
    // --------
 
-   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create(*(nll.get()), RooMinimizer::FcnMode::gradient);
-   m1->setMinimizerType("Minuit2");
+   RooMinimizer m1(*(nll.get()), RooMinimizer::FcnMode::gradient);
+   m1.setMinimizerType("Minuit2");
 
-   m1->setStrategy(0);
-   m1->setPrintLevel(-1);
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
 
-   m1->migrad();
+   m1.migrad();
 
-   RooFitResult *m1result = m1->lastMinuitFit();
+   RooFitResult *m1result = m1.lastMinuitFit();
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
    std::vector<double> mean1(N);
@@ -271,16 +271,16 @@ TEST(GradMinimizerReverse, GaussianND)
 
    // --------
 
-   std::unique_ptr<RooMinimizer> m0 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
+   RooMinimizer m0(*nll, RooMinimizer::FcnMode::gradient);
 
-   m0->setMinimizerType("Minuit2");
+   m0.setMinimizerType("Minuit2");
 
-   m0->setStrategy(0);
-   m0->setPrintLevel(-1);
+   m0.setStrategy(0);
+   m0.setPrintLevel(-1);
 
-   m0->migrad();
+   m0.migrad();
 
-   RooFitResult *m0result = m0->lastMinuitFit();
+   RooFitResult *m0result = m0.lastMinuitFit();
    double minNll0 = m0result->minNll();
    double edm0 = m0result->edm();
    std::vector<double> mean0(N);
@@ -451,15 +451,15 @@ TEST(GradMinimizer, BranchingPDF)
 
    // --------
 
-   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
-   m1->setMinimizerType("Minuit2");
+   RooMinimizer m1(*nll, RooMinimizer::FcnMode::gradient);
+   m1.setMinimizerType("Minuit2");
 
-   m1->setStrategy(0);
-   m1->setPrintLevel(-1);
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
 
-   m1->migrad();
+   m1.migrad();
 
-   RooFitResult *m1result = m1->lastMinuitFit();
+   RooFitResult *m1result = m1.lastMinuitFit();
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
 
@@ -569,15 +569,15 @@ TEST(GradMinimizerDebugging, DISABLED_BranchingPDFLoadFromWorkspace)
 
    all_values.Print("v");
 
-   std::unique_ptr<RooMinimizer> m1 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
-   m1->setMinimizerType("Minuit2");
+   RooMinimizer m1(*nll, RooMinimizer::FcnMode::gradient);
+   m1.setMinimizerType("Minuit2");
 
-   m1->setStrategy(0);
-   m1->setPrintLevel(-1);
+   m1.setStrategy(0);
+   m1.setPrintLevel(-1);
 
-   m1->migrad();
+   m1.migrad();
 
-   RooFitResult *m1result = m1->lastMinuitFit();
+   RooFitResult *m1result = m1.lastMinuitFit();
    double minNll1 = m1result->minNll();
    double edm1 = m1result->edm();
 
@@ -640,8 +640,8 @@ TEST(GradMinimizerDebugging, DISABLED_BranchingPDFLoadFromWorkspaceGradMinimizer
    RooDataSet *data = static_cast<RooDataSet *>(w.data(""));
    auto nll = sum.createNLL(*data);
 
-   std::unique_ptr<RooMinimizer> m0 = RooMinimizer::create(*nll, RooMinimizer::FcnMode::gradient);
-   m0->setMinimizerType("Minuit2");
-   m0->setStrategy(0);
-   m0->migrad();
+   RooMinimizer m0(*nll, RooMinimizer::FcnMode::gradient);
+   m0.setMinimizerType("Minuit2");
+   m0.setStrategy(0);
+   m0.migrad();
 }


### PR DESCRIPTION
In this PR, we introduce two new classes: `LikelihoodJob` and `LikelihoodGradientJob`. These are `RooFit::MultiProcess` based test-statistic calculators that parallelize likelihood and likelihood gradient calculation respectively over multiple processes. These classes can be used internally by `RooMinimizer` to speed up fitting with `migrad`. The way to use them is to use the new `RooMinimizer` constructor that takes a (pointer to a) `RooAbsL` likelihood class that was introduced in previous PR #8700.

This PR is the seventh and final part of a split and clean-up of #8294.

## Changes or fixes:
- Adds `LikelihoodJob` and `LikelihoodGradientJob` under the `RooFit::TestStatistics` namespace.
- Adds the `LikelihoodGradientJob` test case, which also covers the rest of the `TestStatistics` framework, as promised in https://github.com/root-project/root/pull/8700#issue-947741252.
- Adds two `KahanSum` constructors that allow for initialization of the full internal state. This is necessary for serializing and rematerializing `KahanSum`s so they can be sent over ZeroMQ sockets.
- `RooMinimizer` templated constructors and create factory functions were removed. These are replaced with enum class flags that allow the user to choose the type of `RooAbsMinimizerFcn` (this was already in place) and the `Likelihood(Gradient)Wrapper` implementations to use, i.e. the classes introduced in this PR. Similar changes were made in `MinuitFcnGrad`, which is now also template-free.
- `RooMinimizer`'s (now) two constructors use two helper functions now to avoid code duplication.
- There were some mistakes in the build setup of `RooFitZMQ` and `RooFit::MultiProcess` that only came to light now when building these classes that depend on `RooFit::MultiProcess`. These are fixed.
- A few functions had to be added to `LikelihoodGradientWrapper` and `MinuitFcnGrad` for passing along previous gradient, second derivative and step size information from Minuit2 to RooFit and back, i.e. using the functionality introduced in #8694.

## Checklist:

- [x] tested changes locally
- [x] update the docs (if necessary)
- [x] unify copyright/license headers with previous commits
- [x] includes: correct order (matching header, RooFit, ROOT, std) and ROOT includes in quotation marks
- [x] refactor member names: underscore suffix
- [x] remove commented out code and TODOs and other junk
- [x] clang-tidy up
- [ ] rebase into two commits (one for `KahanSum` and one for the rest)
- [x] make Readme.md for developers with some examples to run