### PR TITLE
Fix memory leak in candle plot

### DIFF
--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -588,6 +588,7 @@ void TCandle::Calculate() {
       if (fIsRaw) { //This is a raw-data candle
          if (!fProj) {
             fProj = new TH1D("hpa","hpa",100,min,max+0.0001*(max-min));
+            fProj->SetDirectory(nullptr);
             for (Long64_t i = 0; i < fNDatapoints; ++i) {
                fProj->Fill(fDatapoints[i]);
             }

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -41,8 +41,8 @@ directly to draw a candle.
 
 TCandle::TCandle()
 {
-   fIsCalculated  = 0;
-   fIsRaw         = 0;
+   fIsCalculated  = false;
+   fIsRaw         = false;
    fPosCandleAxis = 0.;
    fCandleWidth   = 1.0;
    fHistoWidth    = 1.0;
@@ -54,7 +54,7 @@ TCandle::TCandle()
    fWhiskerUp     = 0.;
    fWhiskerDown   = 0.;
    fNDatapoints   = 0;
-   fDismiss       = 0;
+   fDismiss       = false;
    fLogX          = 0;
    fLogY          = 0;
    fLogZ          = 0;
@@ -63,7 +63,7 @@ TCandle::TCandle()
    fAxisMin       = 0.;
    fAxisMax       = 0.;
    fOption        = kNoOption;
-   fProj          = NULL;
+   fProj          = nullptr;
    fDatapoints    = 0;
 
 }
@@ -73,8 +73,8 @@ TCandle::TCandle()
 
 TCandle::TCandle(const char *opt)
 {
-   fIsCalculated  = 0;
-   fIsRaw         = 0;
+   fIsCalculated  = false;
+   fIsRaw         = false;
    fPosCandleAxis = 0.;
    fCandleWidth   = 1.0;
    fHistoWidth    = 1.0;
@@ -86,7 +86,7 @@ TCandle::TCandle(const char *opt)
    fWhiskerUp     = 0.;
    fWhiskerDown   = 0.;
    fNDatapoints   = 0;
-   fDismiss = 0;
+   fDismiss       = false;
    fLogX          = 0;
    fLogY          = 0;
    fLogZ          = 0;
@@ -95,7 +95,7 @@ TCandle::TCandle(const char *opt)
    fAxisMin       = 0.;
    fAxisMax       = 0.;
    fOption        = kNoOption;
-   fProj          = NULL;
+   fProj          = nullptr;
    fDatapoints    = 0;
 
 
@@ -129,8 +129,8 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, Long64_t 
    fCandleWidth   = candleWidth;
    fHistoWidth    = candleWidth;
    fDatapoints    = points;
-   fProj          = NULL;
-   fDismiss       = 0;
+   fProj          = nullptr;
+   fDismiss       = false;
    fOption        = kNoOption;
    fLogX          = 0;
    fLogY          = 0;
@@ -157,14 +157,14 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, TH1D *pro
    fWhiskerUp     = 0;
    fWhiskerDown   = 0;
    fNDatapoints   = 0;
-   fIsCalculated  = 0;
-   fIsRaw         = 0;
+   fIsCalculated  = false;
+   fIsRaw         = false;
    fPosCandleAxis = candlePos;
    fCandleWidth   = candleWidth;
    fHistoWidth    = candleWidth;
    fDatapoints    = 0;
    fProj          = proj;
-   fDismiss       = 0;
+   fDismiss       = false;
    fOption        = kNoOption;
    fLogX          = 0;
    fLogY          = 0;

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -5347,7 +5347,7 @@ void THistPainter::PaintBoxes(Option_t *)
 
 void THistPainter::PaintCandlePlot(Option_t *)
 {
-   TH1D *hproj;
+   TH1D *hproj = nullptr;
    TH2D *h2 = (TH2D*)fH;
 
    TCandle myCandle;
@@ -5435,6 +5435,7 @@ void THistPainter::PaintCandlePlot(Option_t *)
          }
       }
    }
+   delete hproj;
 }
 
 


### PR DESCRIPTION
Projection histogram, which is created in candle plot, was not properly deleted.

Also prevent to add temporary histogram, created by TCandle, to gDirectory