### PR TITLE
[VecOps] Remove expensive asserts from RVec::operator[]

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -1179,16 +1179,11 @@ public:
 
    reference operator[](size_type idx)
    {
-#ifndef NDEBUG
-      R__ASSERT(idx < size());
-#endif
       return begin()[idx];
    }
+
    const_reference operator[](size_type idx) const
    {
-#ifndef NDEBUG
-      R__ASSERT(idx < size());
-#endif
       return begin()[idx];
    }
 


### PR DESCRIPTION
As RVec is a class template, even if ROOT is compiled with -DNDEBUG
these asserts might be compiled in user code depending on whether or
not they remember to include `-DNDEBUG` in their debug flags.
I think the performance penalty is too high w.r.t. the benefit.
