### PR TITLE
[roofit] Fix compilation error on Win64

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -279,7 +279,7 @@ protected:
   mutable std::vector<double> _maskedWeights; //! Copy of _wgt, but masked events have a weight of zero.
   mutable std::vector<double> _maskedSumw2; //! Copy of _sumW2, but masked events have a weight of zero.
  
-  mutable unsigned long _curIndex{std::numeric_limits<std::size_t>::max()}; // Current index
+  mutable unsigned long _curIndex{static_cast<unsigned long>(std::numeric_limits<std::size_t>::max())}; // Current index
 
   mutable std::unordered_map<int,std::vector<double>> _pbinvCache ; //! Cache for arrays of partial bin volumes
   std::vector<RooAbsLValue*> _lvvars ; //! List of observables casted as RooAbsLValue


### PR DESCRIPTION
Fix the following compilation error on Win64:
```
  Generating G__RooFitCore.cxx, ../../bin/libRooFitCore_rdict.pcm, ../../bin/libRooFitCore.rootmap
  In file included from input_line_9:58:
  In file included from C:/Users/bellenot/build/x64/release/include\RooChi2Var.h:22:
C:/Users/bellenot/build/x64/release/include/RooDataHist.h(282,35): error GE639D5E5: constant expression evaluates to 18446744073709551615 which cannot be narrowed to type 'unsigned long' [-Wc++11-narrowing] [C:\Users\bellenot\build\x64\release\roofit\roofitcore\G__RooFitCore.vcxproj]
    mutable unsigned long _curIndex{std::numeric_limits<std::size_t>::max()}; // Current index
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  C:/Users/bellenot/build/x64/release/include/RooDataHist.h:282:35: note: insert an explicit cast to silence
  this issue
    mutable unsigned long _curIndex{std::numeric_limits<std::size_t>::max()}; // Current index
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                    static_cast<unsigned long>(            )
CUSTOMBUILD : error : C:/Users/bellenot/build/x64/release/bin/rootcling.exe: compilation failure (C:/Users/bellenot/build/x64/release/bin/libRooFitCoreda5a37c58a_dictUmbrella.h) [C:\Users\bellenot\build\x64\release\roofit\roofitcore\G__RooFitCore.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(241,5): error MSB8066: Custom build for 'C:\Users\bellenot\build\x64\release\CMakeFiles\c53a70ca69b459bf8b1aa731202f2a45\G__RooFitCore.cxx.rule' exited with code 1. [C:\Users\bellenot\build\x64\release\roofit\roofitcore\G__RooFitCore.vcxproj]
```
