### PR TITLE
Add the "Standalone"option for tex output.

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4710,6 +4710,7 @@ static Bool_t ContainsTImage(TList *li)
 ///    - `EmbedFonts`:  a [PDF file with embedded fonts](\ref TPadPrintEmbedFonts) is generated.
 ///  -        `svg`:  a SVG file is produced
 ///  -        `tex`:  a TeX file is produced
+///    - `Standalone`:  a [standalone TeX file](\ref TPadPrintStandalone) is produced.
 ///  -        `gif`:  a GIF file is produced
 ///  -     `gif+NN`:  an animated GIF file is produced, where NN is delay in 10ms units NOTE: See other variants for looping animation in TASImage::WriteImage
 ///  -        `xpm`:  a XPM file is produced
@@ -4770,6 +4771,16 @@ static Bool_t ContainsTImage(TList *li)
 /// Example:
 /// ~~~ {.cpp}
 ///     canvas->Print("example.pdf","EmbedFonts");
+/// ~~~
+///
+/// \anchor TPadPrintStandalone
+/// ### The "Standalone" option
+/// The "Standalone" option allows to generate a TeX file ready to be processed by
+/// tools like `pdflatex`.
+///
+/// Example:
+/// ~~~ {.cpp}
+///     canvas->Print("example.tex","Standalone");
 /// ~~~
 ///
 /// \anchor TPadPrintPS
@@ -5009,7 +5020,7 @@ void TPad::Print(const char *filename, Option_t *option)
    }
 
    //==============Save pad/canvas as a TeX file================================
-   if (strstr(opt,"tex")) {
+   if (strstr(opt,"tex") || strstr(opt,"Standalone")) {
       gVirtualPS = (TVirtualPS*)gROOT->GetListOfSpecials()->FindObject(psname);
 
       Bool_t noScreen = kFALSE;
@@ -5031,9 +5042,13 @@ void TPad::Print(const char *filename, Option_t *option)
          }
       }
 
+      Bool_t standalone = kFALSE;
+      if (strstr(opt,"Standalone")) standalone = kTRUE;
+
       // Create a new TeX file
       if (gVirtualPS) {
          gVirtualPS->SetName(psname);
+         if (standalone) gVirtualPS->SetTitle("Standalone");
          gVirtualPS->Open(psname);
          gVirtualPS->SetBit(kPrintingPS);
          gVirtualPS->NewPage();
@@ -5041,7 +5056,13 @@ void TPad::Print(const char *filename, Option_t *option)
       Paint();
       if (noScreen)  GetCanvas()->SetBatch(kFALSE);
 
-      if (!gSystem->AccessPathName(psname)) Info("Print", "TeX file %s has been created", psname.Data());
+      if (!gSystem->AccessPathName(psname)) {
+         if (standalone) {
+            Info("Print", "Standalone TeX file %s has been created", psname.Data());
+         } else{
+            Info("Print", "TeX file %s has been created", psname.Data());
+         }
+      }
 
       delete gVirtualPS;
       gVirtualPS = 0;

--- a/graf2d/postscript/inc/TTeXDump.h
+++ b/graf2d/postscript/inc/TTeXDump.h
@@ -23,8 +23,9 @@ protected:
    Float_t      fXsize;           ///< Page size along X
    Float_t      fYsize;           ///< Page size along Y
    Int_t        fType;            ///< Workstation type used to know if the Tex is open
-   Bool_t       fBoundingBox;     ///< True when the Tex header is printed
+   Bool_t       fBoundingBox;     ///< True when the TeX header is printed
    Bool_t       fRange;           ///< True when a range has been defined
+   Bool_t       fStandalone;      ///< True when a TeX file should be standalone
    Float_t      fCurrentRed;      ///< Current Red component
    Float_t      fCurrentGreen;    ///< Current Green component
    Float_t      fCurrentBlue;     ///< Current Blue component

--- a/graf2d/postscript/src/TTeXDump.cxx
+++ b/graf2d/postscript/src/TTeXDump.cxx
@@ -167,9 +167,23 @@ void TTeXDump::Open(const char *fname, Int_t wtype)
 
    fBoundingBox = kFALSE;
    fRange       = kFALSE;
+   fStandalone  = kFALSE;
 
    // Set a default range
    Range(fXsize, fYsize);
+
+   if (strstr(GetTitle(),"Standalone")) fStandalone = kTRUE;
+   if (fStandalone) {
+      PrintStr("\\documentclass{standalone}@");
+      PrintStr("\\usepackage{tikz}@");
+      PrintStr("\\usetikzlibrary{patterns,plotmarks}@");
+      PrintStr("\\begin{document}@");
+   } else {
+      PrintStr("%\\documentclass{standalone}@");
+      PrintStr("%\\usepackage{tikz}@");
+      PrintStr("%\\usetikzlibrary{patterns,plotmarks}@");
+      PrintStr("%\\begin{document}@");
+   }
 
    NewPage();
 }
@@ -192,6 +206,11 @@ void TTeXDump::Close(Option_t *)
    if (gPad) gPad->Update();
    PrintStr("@");
    PrintStr("\\end{tikzpicture}@");
+   if (fStandalone) {
+      PrintStr("\\end{document}@");
+   } else {
+      PrintStr("%\\end{document}@");
+   }
 
    // Close file stream
    if (fStream) { fStream->close(); delete fStream; fStream = 0;}


### PR DESCRIPTION
The `.tex` produced when saving canvas as `.tex`, needed to be included in an existing LateX document to be visualized.
The new `Standalone` option allows to generate a `.tex` file which can be directly processed by LateX (for example with the `pdflatex` command) in order to visualise it. This is done via the command:

```
canvas->Print(".tex", "Standalone") 
```

The generated  `.tex` file has the form: 

```
\usepackage{tikz}
\usetikzlibrary{patterns,plotmarks}
\begin{document}
<----- here the graphics output
\end{document}
```
