### PR TITLE
[TMVA] Fix compilation warnings on Win64

### DIFF
--- a/tmva/tmva/src/BinarySearchTreeNode.cxx
+++ b/tmva/tmva/src/BinarySearchTreeNode.cxx
@@ -158,10 +158,10 @@ void TMVA::BinarySearchTreeNode::Print( std::ostream& os ) const
    os << std::setw(10) << "Class: " << GetClass() << std::endl;
 
    os << "Selector: " <<  this->GetSelector() <<std::endl;
-   os << "My address is " << long(this) << ", ";
-   if (this->GetParent() != NULL) os << " parent at addr: " << long(this->GetParent()) ;
-   if (this->GetLeft() != NULL) os << " left daughter at addr: " << long(this->GetLeft());
-   if (this->GetRight() != NULL) os << " right daughter at addr: " << long(this->GetRight()) ;
+   os << "My address is " << (Longptr_t)this << ", ";
+   if (this->GetParent() != NULL) os << " parent at addr: " << (Longptr_t)this->GetParent();
+   if (this->GetLeft() != NULL) os << " left daughter at addr: " << (Longptr_t)this->GetLeft();
+   if (this->GetRight() != NULL) os << " right daughter at addr: " << (Longptr_t)this->GetRight();
 
    os << " **** > "<< std::endl;
 }

--- a/tmva/tmva/src/DecisionTreeNode.cxx
+++ b/tmva/tmva/src/DecisionTreeNode.cxx
@@ -227,10 +227,10 @@ void TMVA::DecisionTreeNode::Print(std::ostream& os) const
       << " nType: " << this->GetNodeType()
       << std::endl;
 
-   os << "My address is " << long(this) << ", ";
-   if (this->GetParent() != NULL) os << " parent at addr: "         << long(this->GetParent()) ;
-   if (this->GetLeft()   != NULL) os << " left daughter at addr: "  << long(this->GetLeft());
-   if (this->GetRight()  != NULL) os << " right daughter at addr: " << long(this->GetRight()) ;
+   os << "My address is " << (Longptr_t)this << ", ";
+   if (this->GetParent() != NULL) os << " parent at addr: "         << (Longptr_t)this->GetParent();
+   if (this->GetLeft()   != NULL) os << " left daughter at addr: "  << (Longptr_t)this->GetLeft();
+   if (this->GetRight()  != NULL) os << " right daughter at addr: " << (Longptr_t)this->GetRight();
 
    os << " **** > " << std::endl;
 }


### PR DESCRIPTION
Fix the following compilation warnings on Win64:
```
  BinarySearchTreeNode.cxx(161,39): warning C4311: '<function-style-cast>': pointer truncation from 'const TMVA::BinarySearchTreeNode *' to 'long'
  BinarySearchTreeNode.cxx(161,39): warning C4302: '<function-style-cast>': truncation from 'const TMVA::BinarySearchTreeNode *' to 'long'
  BinarySearchTreeNode.cxx(162,86): warning C4311: '<function-style-cast>': pointer truncation from 'TMVA::Node *' to 'long'
  BinarySearchTreeNode.cxx(162,86): warning C4302: '<function-style-cast>': truncation from 'TMVA::Node *' to 'long'
  BinarySearchTreeNode.cxx(163,89): warning C4311: '<function-style-cast>': pointer truncation from 'TMVA::Node *' to 'long'
  BinarySearchTreeNode.cxx(163,89): warning C4302: '<function-style-cast>': truncation from 'TMVA::Node *' to 'long'
  BinarySearchTreeNode.cxx(164,92): warning C4311: '<function-style-cast>': pointer truncation from 'TMVA::Node *' to 'long'
  BinarySearchTreeNode.cxx(164,92): warning C4302: '<function-style-cast>': truncation from 'TMVA::Node *' to 'long'
  DecisionTreeNode.cxx(230,39): warning C4311: '<function-style-cast>': pointer truncation from 'const TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(230,39): warning C4302: '<function-style-cast>': truncation from 'const TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(231,94): warning C4311: '<function-style-cast>': pointer truncation from 'TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(231,94): warning C4302: '<function-style-cast>': truncation from 'TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(232,92): warning C4311: '<function-style-cast>': pointer truncation from 'TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(232,92): warning C4302: '<function-style-cast>': truncation from 'TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(233,93): warning C4311: '<function-style-cast>': pointer truncation from 'TMVA::DecisionTreeNode *' to 'long'
  DecisionTreeNode.cxx(233,93): warning C4302: '<function-style-cast>': truncation from 'TMVA::DecisionTreeNode *' to 'long'
```
