### PR TITLE
[llvm] Restore the ppc64le support that we lost in llvm8.

### DIFF
--- a/interpreter/llvm/src/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/interpreter/llvm/src/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -4463,7 +4463,15 @@ callsShareTOCBase(const Function *Caller, SDValue Callee,
    if (!G)
      return false;
 
-   const GlobalValue *GV = G->getGlobal();
+  const GlobalValue *GV = G->getGlobal();
+
+  // If the GV is not a strong definition then we need to assume it can be
+  // replaced by another function at link time. The function that replaces
+  // it may not share the same TOC as the caller since the callee may be
+  // replaced by a PC Relative version of the same function.
+  if (!GV->isStrongDefinitionForLinker())
+    return false;
+
   // The medium and large code models are expected to provide a sufficiently
   // large TOC to provide all data addressing needs of a module with a
   // single TOC. Since each module will be addressed with a single TOC then we
@@ -4471,13 +4479,6 @@ callsShareTOCBase(const Function *Caller, SDValue Callee,
   if (CodeModel::Medium == TM.getCodeModel() ||
       CodeModel::Large == TM.getCodeModel())
     return TM.shouldAssumeDSOLocal(*Caller->getParent(), GV);
-
-  // Otherwise we need to ensure callee and caller are in the same section,
-  // since the linker may allocate multiple TOCs, and we don't know which
-  // sections will belong to the same TOC base.
-
-  if (!GV->isStrongDefinitionForLinker())
-    return false;
 
   // Any explicitly-specified sections and section prefixes must also match.
   // Also, if we're using -ffunction-sections, then each function is always in


### PR DESCRIPTION
This patch is backported from https://reviews.llvm.org/D91983
also in https://reviews.llvm.org/D94183

For more discussion see https://github.com/numba/numba/issues/4026

Fixes root-project/root#8072 and root-project/root#9297

