### PR TITLE
[RF] MultiProcess bugfix: close ZeroMQ context correctly

### DIFF
--- a/roofit/roofitcore/test/TestStatistics/RooRealL.cpp
+++ b/roofit/roofitcore/test/TestStatistics/RooRealL.cpp
@@ -326,7 +326,6 @@ TEST_P(RealLVsMPFE, minimize)
    EXPECT_EQ(muerr0, muerr1);
    EXPECT_EQ(edm0, edm1);
 
-   m1.cleanup(); // necessary in tests to clean up global _theFitter
    delete savedValues;
 }
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
@@ -118,8 +118,6 @@ TEST_P(LikelihoodGradientJob, Gaussian1D)
    EXPECT_EQ(mu0, mu1);
    EXPECT_EQ(muerr0, muerr1);
    EXPECT_EQ(edm0, edm1);
-
-   m1.cleanup(); // necessary in tests to clean up global _theFitter
 }
 
 TEST(LikelihoodGradientJob, RepeatMigrad)
@@ -164,9 +162,6 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
 
    std::cout << "... running migrad second time ..." << std::endl;
    m1.migrad();
-
-   std::cout << "... cleaning up minimizer ..." << std::endl;
-   m1.cleanup(); // necessary in tests to clean up global _theFitter
 }
 
 TEST_P(LikelihoodGradientJob, GaussianND)
@@ -264,8 +259,6 @@ TEST_P(LikelihoodGradientJob, GaussianND)
       EXPECT_EQ(mean0[ix], mean1[ix]);
       EXPECT_EQ(std0[ix], std1[ix]);
    }
-
-   m1.cleanup(); // necessary in tests to clean up global _theFitter
 }
 
 INSTANTIATE_TEST_SUITE_P(NworkersSeed, LikelihoodGradientJob,
@@ -440,6 +433,4 @@ TEST_F(LikelihoodSimBinnedConstrainedTest, ConstrainedAndOffset)
    EXPECT_FLOAT_EQ(alpha_bkg_B_error_nominal, alpha_bkg_B_error_GradientJob);
    EXPECT_FLOAT_EQ(mu_sig_nominal, mu_sig_GradientJob);
    EXPECT_FLOAT_EQ(mu_sig_error_nominal, mu_sig_error_GradientJob);
-
-   m1.cleanup(); // necessary in tests to clean up global _theFitter
 }


### PR DESCRIPTION
# This Pull request:
Fixes a bug that occurred spuriously when exiting the ROOT interpreter after using `MultiProcess::Job` objects, which left child processes alive.

## Changes or fixes:
As explained in the comments added in the code in the commit in this PR, the `zmqSvc().close_context()` was called at the wrong moment, namely in the `Messenger` destructor. When this was called at program exit, it caused dereferencing of a destroyed (and in the meantime randomly overwritten) singleton pointer, which caused a segfault on some systems.

This bug probably went unnoticed before because it is a case of "static destruction order fiasco", which makes it build command, OS and probably weather dependent.

This also makes the `RooMinimizer::cleanup()` calls after tests unnecessary; they were used as a workaround for the above problem, because by manually destroying all `Job`s (which were held alive inside `RooMinimizer::_theFitter`, which is deleted by `RooMinimizer::cleanup`), the `JobManager` was also destroyed (when all Jobs are destroyed, the JobManager self-destructs as well) before the `ZeroMQSvc` singleton is destroyed by the exiting of the program (in the phase of destroying static state), so the "random" destruction order problem mentioned above did not occur.

Thanks to @Zeff020 for discovering the bug.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)