### PR TITLE
Implement ChangeLabel with SetMoreLogLabels

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -283,7 +283,9 @@ The class version of `RooAbsArg` was incremented from 7 to 8 in this release. In
 ## 2D Graphics Libraries
 
 - Implement the option `X+` and `Y+` for reverse axis on TGraph.
+
 - Offsets for axis titles with absolute-sized fonts (size%10 == 3) are now relative only to the font size (i.e. no longer relative to pad dimensions).
+
 - In `TPaletteAxis` when the palette width is bigger than the palette height, the palette
   in automatically drawn horizontally.
 
@@ -302,6 +304,8 @@ canvas->Print(".tex", "Standalone");
 <----- here the graphics output
 \end{document}
 ```
+
+- Implement `ChangeLabel` in case `SetMoreLogLabels` is set.
 
 ## 3D Graphics Libraries
 

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -2305,9 +2305,14 @@ L160:
                      xi1 = gPad->XtoAbsPixel(u);
                      yi1 = gPad->YtoAbsPixel(v);
                      firstintlab = kFALSE;
+                     if (fNModLabs) {
+                        changelablogid++;
+                        ChangeLabelAttributes(changelablogid, 0, textaxis, chtemp);
+                     }
                      typolabel = chtemp;
                      typolabel.ReplaceAll("-", "#minus");
                      textaxis->PaintLatex(u,v,0,textaxis->GetTextSize(),typolabel.Data());
+                     if (fNModLabs) ResetLabelAttributes(textaxis);
                   } else {
                      xi2 = gPad->XtoAbsPixel(u);
                      yi2 = gPad->YtoAbsPixel(v);
@@ -2319,9 +2324,14 @@ L160:
                         xi1 = xi2;
                         yi1 = yi2;
                         textaxis->GetBoundingBox(wi, hi); wi=(UInt_t)(wi*1.3); hi=(UInt_t)(hi*1.3);
+                        if (fNModLabs) {
+                           changelablogid++;
+                           ChangeLabelAttributes(changelablogid, 0, textaxis, chtemp);
+                        }
                         typolabel = chtemp;
                         typolabel.ReplaceAll("-", "#minus");
                         textaxis->PaintLatex(u,v,0,textaxis->GetTextSize(),typolabel.Data());
+                        if (fNModLabs) ResetLabelAttributes(textaxis);
                      }
                   }
                }
@@ -2622,7 +2632,7 @@ void TGaxis::ChangeLabel(Int_t labNum, Double_t labAngle, Double_t labSize,
 /// Change the label attributes of label number i. If needed.
 ///
 /// \param[in] i        Current label number to be changed if needed
-/// \param[in] nlabels  Totals number of labels on for this axis (useful when i is counted from the end)
+/// \param[in] nlabels  Totals number of labels for this axis (useful when i is counted from the end)
 /// \param[in] t        Original TLatex string holding the label to be changed
 /// \param[in] c        Text string to be drawn
 
@@ -2646,7 +2656,13 @@ void TGaxis::ChangeLabelAttributes(Int_t i, Int_t nlabels, TLatex* t, char* c)
       SavedTextColor = t->GetTextColor();
       SavedTextFont  = t->GetTextFont();
       labNum = ml->GetLabNum();
-      if (labNum < 0) labNum = nlabels + labNum + 2;
+      if (labNum < 0) {
+         if (TestBit(TAxis::kMoreLogLabels)) {
+            Error("ChangeLabelAttributes", "reverse numbering in ChangeLabel doesn't work when more log labels are requested");
+            return;
+         }
+         labNum = nlabels + labNum + 2;
+      }
       if (i == labNum) {
          if (ml->GetAngle()>=0.) t->SetTextAngle(ml->GetAngle());
          if (ml->GetSize()>=0.)  t->SetTextSize(ml->GetSize());
@@ -2660,7 +2676,7 @@ void TGaxis::ChangeLabelAttributes(Int_t i, Int_t nlabels, TLatex* t, char* c)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Reset the label attributes to the value they have before the last call to
+/// Reset the labels' attributes to the values they had before the last call to
 /// ChangeLabelAttributes.
 
 void TGaxis::ResetLabelAttributes(TLatex* t)


### PR DESCRIPTION
In case "MoreLogLabels" was ON  `ChangeLabel` didn't work. This problem was reported by this forum post:
https://root-forum.cern.ch/t/setmoreloglabels-changelabel-not-working/47961

A easy small reproducer is:
```
{
   auto c = new TCanvas();
   c->SetLogx();
   auto h = new TH1F("h","h",100,1.,10);
   TAxis* a = h->GetXaxis();
   a->SetMoreLogLabels();
   a->ChangeLabel(1,-1,-1,-1,-1,-1,"#1 Changed");
   a->ChangeLabel(3,-1,-1,-1,-1,-1,"#3 Changed");
   a->ChangeLabel(10,-1,-1,-1,kRed,-1,"");
   h->Draw();
} 
```
