### PR TITLE
Fix computation of radiation lengh in TGeoMaterial

### DIFF
--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -467,7 +467,7 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
    TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
    // compute radlen systematically with G3 formula for a valid material
    if ( typ == TGeoManager::kRootUnits && radlen>=0 ) {
-      //taken from Geant3 routine GSMATE
+      // taken from Geant3 routine GSMATE
       constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
@@ -475,7 +475,7 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
       fRadLen *= TGeoUnit::cm;
    }
    else if ( typ == TGeoManager::kG4Units && radlen>=0 ) {
-      //taken from Geant3 routine GSMATE
+      // taken from Geant3 routine GSMATE
       constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*

--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -467,16 +467,16 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
    TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
    // compute radlen systematically with G3 formula for a valid material
    if ( typ == TGeoManager::kRootUnits && radlen>=0 ) {
-      //taken grom Geant3 routine GSMATE
-      constexpr Double_t alr2av = 1.39621E-03*TGeoUnit::cm2;
+      //taken from Geant3 routine GSMATE
+      constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
                    (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
       fRadLen *= TGeoUnit::cm;
    }
    else if ( typ == TGeoManager::kG4Units && radlen>=0 ) {
-      //taken grom Geant3 routine GSMATE
-      constexpr Double_t alr2av = 1.39621E-03*TGeant4Unit::cm2;
+      //taken from Geant3 routine GSMATE
+      constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
                    (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

When default units (TGeoManager::kG4Units) are used, the computed radiation length in TGeoMaterial is smaller by factor 100 than the value computed in Geant3.
The problem was found in the ALICE O2 project.

Test code:
```c++
auto matLead = new TGeoMaterial("Lead", a = 207.19, z = 82., density = 11.35);
cout << "matLead->GetRadLen(): " << matLead->GetRadLen() << endl;

``` 
Output:
```
matLead->GetRadLen(): 0.561683   # cm, agrees with value computed by G3
matLead->GetRadLen(): 0.0561683  # mm, before this fix
matLead->GetRadLen(): 5.61683    # mm, after this fix
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

