### PR TITLE
[dyld] Do not resolve symbols from executables compiled with -fPIE. 

### DIFF
--- a/interpreter/cling/test/DynamicLibraryManager/cached_realpath.C
+++ b/interpreter/cling/test/DynamicLibraryManager/cached_realpath.C
@@ -8,6 +8,7 @@
 
 // REQUIRES: not_system-windows
 
+// RUN: %mkdir %t-dir
 // RUN: cd %t-dir
 
 // RUN: %mkdir %t-dir/dir1/dir11/dir111

--- a/interpreter/cling/test/DynamicLibraryManager/call_pie.c
+++ b/interpreter/cling/test/DynamicLibraryManager/call_pie.c
@@ -1,0 +1,17 @@
+/*------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//----------------------------------------------------------------------------*/
+
+// RUN: true
+// Used as executable/library source by pie.C, etc.
+CLING_EXPORT int cling_testlibrary_function() {
+  return 42;
+}
+
+int main() {
+  return 0;
+}

--- a/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_order1.C
+++ b/interpreter/cling/test/DynamicLibraryManager/callable_lib_L_AB_order1.C
@@ -26,6 +26,5 @@ cling_testlibrary_function()
 .L libcall_lib_L_AB
 cling_testlibrary_function()
 // CHECK: (int) 91749
-357
 
 .q

--- a/interpreter/cling/test/DynamicLibraryManager/pie.C
+++ b/interpreter/cling/test/DynamicLibraryManager/pie.C
@@ -1,0 +1,39 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// REQUIRES: not_system-windows
+
+// RUN: mkdir -p %t-dir/lib
+// RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_A.c -o%t-dir/lib/libcall_lib_A%shlibext
+// RUN: %clang -shared -DCLING_EXPORT=%dllexport %S/call_lib_B.c -o%t-dir/lib/libcall_lib_B%shlibext
+// RUN: %clang %fPIC -fpie -pie -DCLING_EXPORT=%dllexport %S/call_pie.c -o%t-dir/lib/call_pie_so%shlibext
+// RUN: %clang %fPIC -fpie -pie -DCLING_EXPORT=%dllexport %S/call_pie.c -o%t-dir/lib/call_pie
+// RUN: cat %s | LD_LIBRARY_PATH="%t-dir/lib" %cling 2>&1 | FileCheck %s
+
+// Test: Cling pragma for loading libraries. Lookup and load library Lib_L_AB
+//       that depends on two libraries Lib_A and Lib_B via file names.
+//       Lib_A and Lib_B are in LD_LIBRARY_PATH. Call_pie is "PIE" compiled excutable.
+//       Lookup functions from libraries and use them to print result value.
+//       We are expecting an error for the symbol from the PIE executable, which is
+//       expected not to be loaded by dynamic linker.
+
+#pragma cling load("libcall_lib_A")
+extern "C" int cling_testlibrary_function_A();
+cling_testlibrary_function_A()
+// CHECK: (int) 170
+
+#pragma cling load("libcall_lib_B")
+extern "C" int cling_testlibrary_function_B();
+cling_testlibrary_function_B()
+// CHECK: (int) 187
+
+extern "C" int cling_testlibrary_function();
+cling_testlibrary_function()
+// expected-error {{symbol 'cling_testlibrary_function' unresolved while linking}}
+
+//.q

--- a/interpreter/llvm/src/include/llvm/BinaryFormat/ELF.h
+++ b/interpreter/llvm/src/include/llvm/BinaryFormat/ELF.h
@@ -1289,7 +1289,8 @@ enum {
   DF_1_NORELOC = 0x00400000,
   DF_1_SYMINTPOSE = 0x00800000, // Object has individual interposers.
   DF_1_GLOBAUDIT = 0x01000000,  // Global auditing required.
-  DF_1_SINGLETON = 0x02000000   // Singleton symbols are used.
+  DF_1_SINGLETON = 0x02000000,  // Singleton symbols are used.
+  DF_1_PIE = 0x08000000,        // Object is a position-independent executable.
 };
 
 // DT_MIPS_FLAGS values.


### PR DESCRIPTION
Executables that are compiled with fPIE means they are compiled in a position independent manner and are almost indistinguishable from the shared objects. A reasonably reliable way to find if this was a `pie executable` is to check the `DF_1_PIE` in the dynamic section of ELF.

The pseudo-code is:
```
    if DT_FLAGS_1 dynamic section entry is present
      if DF_1_PIE is set in DT_FLAGS_1:
        print pie executable
      else
        print shared object
```
    
    See https://stackoverflow.com/questions/34519521/why-does-gcc-create-a-shared-object-instead-of-an-executable-binary-according-to/34522357#34522357


Fixes #7366

Patch by Alexander Penev (@alexander-penev)