### PR TITLE
[RF] add MultiProcess::Config for setting number of workers

### DIFF
--- a/roofit/multiprocess/CMakeLists.txt
+++ b/roofit/multiprocess/CMakeLists.txt
@@ -11,6 +11,7 @@ ROOT_LINKER_LIBRARY(RooFitMultiProcess
         src/Queue.cxx
         src/JobManager.cxx
         src/Job.cxx
+        src/Config.cxx
     DEPENDENCIES
         RooFitZMQ
 )
@@ -22,3 +23,5 @@ target_include_directories(RooFitMultiProcess
         INTERFACE $<BUILD_INTERFACE:${RooFitMultiProcess_INCLUDE_DIR}>)
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)
+
+ROOT_INSTALL_HEADERS()

--- a/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
@@ -1,0 +1,30 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOT_ROOFIT_MultiProcess_Config
+#define ROOT_ROOFIT_MultiProcess_Config
+
+namespace RooFit {
+namespace MultiProcess {
+
+class Config {
+public:
+   static void setDefaultNWorkers(unsigned int N_workers);
+   static unsigned int getDefaultNWorkers();
+private:
+   static unsigned int defaultNWorkers_;
+};
+
+} // namespace MultiProcess
+} // namespace RooFit
+
+#endif // ROOT_ROOFIT_MultiProcess_Config

--- a/roofit/multiprocess/res/RooFit/MultiProcess/JobManager.h
+++ b/roofit/multiprocess/res/RooFit/MultiProcess/JobManager.h
@@ -58,9 +58,6 @@ private:
    static std::map<std::size_t, Job *> job_objects_;
    static std::size_t job_counter_;
    static std::unique_ptr<JobManager> instance_;
-
-public:
-   static unsigned int default_N_workers; // no need for getters/setters, just public
 };
 
 } // namespace MultiProcess

--- a/roofit/multiprocess/src/Config.cxx
+++ b/roofit/multiprocess/src/Config.cxx
@@ -1,0 +1,58 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooFit/MultiProcess/Config.h"
+#include "RooFit/MultiProcess/JobManager.h"
+
+#include <thread> // std::thread::hardware_concurrency()
+
+namespace RooFit {
+namespace MultiProcess {
+
+/** \class Config
+ *
+ * \brief Configuration for MultiProcess infrastructure
+ *
+ * This class offers user-accessible configuration of the MultiProcess infrastructure.
+ * Since the rest of the MultiProcess classes are only accessible at compile time, a
+ * separate class is needed to set configuration. Currently, the only configurable
+ * part is the number of workers to be deployed.
+ *
+ * The default number of workers is set using 'std::thread::hardware_concurrency()'.
+ * To change it, use 'Config::setDefaultNWorkers()' to set it to a different value
+ * before creation of a new JobManager instance. Note that it cannot be set to zero
+ * and also cannot be changed after JobManager has been instantiated.
+ *
+ * Use Config::getDefaultNWorkers() to access the current value.
+ */
+
+void Config::setDefaultNWorkers(unsigned int N_workers)
+{
+   if (JobManager::is_instantiated()) {
+      printf("Warning: Config::setDefaultNWorkers cannot set number of workers after JobManager has been instantiated!\n");
+   } else if (N_workers == 0) {
+      printf("Warning: Config::setDefaultNWorkers cannot set number of workers to zero.\n");
+   } else {
+      defaultNWorkers_ = N_workers;
+   }
+}
+
+unsigned int Config::getDefaultNWorkers()
+{
+   return defaultNWorkers_;
+}
+
+// initialize static member
+unsigned int Config::defaultNWorkers_ = std::thread::hardware_concurrency();
+
+} // namespace MultiProcess
+} // namespace RooFit

--- a/roofit/multiprocess/src/JobManager.cxx
+++ b/roofit/multiprocess/src/JobManager.cxx
@@ -18,8 +18,7 @@
 #include "RooFit/MultiProcess/Queue.h" // complete type for JobManager::queue()
 #include "RooFit/MultiProcess/worker.h"
 #include "RooFit/MultiProcess/util.h"
-
-#include <thread> // std::thread::hardware_concurrency()
+#include "RooFit/MultiProcess/Config.h"
 
 namespace RooFit {
 namespace MultiProcess {
@@ -40,16 +39,15 @@ namespace MultiProcess {
  * This is the way the Job class uses this class, see 'Job::get_manager()'.
  *
  * The default number of processes is set using 'std::thread::hardware_concurrency()'.
- * To change it, simply set 'JobManager::default_N_workers' to a different value
- * before creation of a new instance.
+ * To change it, use 'Config::setDefaultNWorkers()' to set it to a different value
+ * before creation of a new JobManager instance.
  */
 
 // static function
 JobManager *JobManager::instance()
 {
    if (!JobManager::is_instantiated()) {
-      assert(default_N_workers != 0);
-      instance_.reset(new JobManager(default_N_workers)); // can't use make_unique, because ctor is private
+      instance_.reset(new JobManager(Config::getDefaultNWorkers())); // can't use make_unique, because ctor is private
       instance_->messenger().test_connections(instance_->process_manager());
       // set send to non blocking on all processes after checking the connections are working:
       instance_->messenger().set_send_flag(zmq::send_flags::dontwait);
@@ -212,7 +210,6 @@ bool JobManager::is_activated() const
 std::map<std::size_t, Job *> JobManager::job_objects_;
 std::size_t JobManager::job_counter_ = 0;
 std::unique_ptr<JobManager> JobManager::instance_{nullptr};
-unsigned int JobManager::default_N_workers = std::thread::hardware_concurrency();
 
 } // namespace MultiProcess
 } // namespace RooFit

--- a/roofit/multiprocess/test/test_Job.cxx
+++ b/roofit/multiprocess/test/test_Job.cxx
@@ -17,6 +17,7 @@
 
 #include "RooFit/MultiProcess/Job.h"
 #include "RooFit/MultiProcess/types.h" // JobTask
+#include "RooFit/MultiProcess/Config.h"
 // needed to complete type returned from...
 #include "RooFit/MultiProcess/JobManager.h"     // ... Job::get_manager()
 #include "RooFit/MultiProcess/ProcessManager.h" // ... JobManager::process_manager()
@@ -165,7 +166,7 @@ TEST_P(TestMPJob, singleJobGetResult)
    // start parallel test
 
    xSquaredPlusBVectorParallel x_sq_plus_b_parallel(&x_sq_plus_b);
-   RooFit::MultiProcess::JobManager::default_N_workers = NumCPU;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NumCPU);
 
    auto y_parallel = x_sq_plus_b_parallel.get_result();
 
@@ -192,7 +193,7 @@ TEST_P(TestMPJob, multiJobGetResult)
    xSquaredPlusBVectorSerial x_sq_plus_b2(b_initial + 1, x);
    xSquaredPlusBVectorParallel x_sq_plus_b_parallel(&x_sq_plus_b);
    xSquaredPlusBVectorParallel x_sq_plus_b_parallel2(&x_sq_plus_b2);
-   RooFit::MultiProcess::JobManager::default_N_workers = NumCPU;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NumCPU);
 
    // do stuff
    auto y_parallel = x_sq_plus_b_parallel.get_result();
@@ -225,7 +226,7 @@ TEST_P(TestMPJob, singleJobUpdateState)
    // start parallel test
    bool update_state = true;
    xSquaredPlusBVectorParallel x_sq_plus_b_parallel(&x_sq_plus_b, update_state);
-   RooFit::MultiProcess::JobManager::default_N_workers = NumCPU;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NumCPU);
 
    auto y_parallel_before_change = x_sq_plus_b_parallel.get_result();
 

--- a/roofit/roofitcore/src/TestStatistics/README.md
+++ b/roofit/roofitcore/src/TestStatistics/README.md
@@ -98,6 +98,9 @@ std::shared_ptr<RooAbsL> likelihood = /* see examples above */;
 RooMinimizer m(likelihood);
 ```
 
+By default, `RooFit::MultiProcess` spins up as many workers as there are cores in the system (as detected by `std::thread::hardware_concurrency()`).
+To change the number of workers, call `RooFit::MultiProcess::Config::setDefaultNWorkers(desired_N_workers)` **before** creating the `RooMinimizer`.
+
 As noted above, offsetting is purely a function of the `RooMinimizer` when using `TestStatistics` classes.
 Whereas with `fitTo` we can pass in a `RooFit::Offset(kTRUE)` optional `RooCmdArg` argument to activate offsetting, here we must do it on the minimizer as follows:
 ```c++

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
@@ -19,13 +19,12 @@
 #include "RooDataHist.h" // complete type in Binned test
 #include "RooCategory.h" // complete type in MultiBinnedConstraint test
 #include "RooMinimizer.h"
-#include "RooGradMinimizerFcn.h"
 #include "RooFitResult.h"
 #include "RooFit/TestStatistics/LikelihoodSerial.h"
 #include "RooFit/TestStatistics/RooUnbinnedL.h"
 #include "RooFit/TestStatistics/buildLikelihood.h"
 #include "RooFit/MultiProcess/JobManager.h"
-#include "RooFit/MultiProcess/ProcessManager.h" // need to complete type for debugging
+#include "RooFit/MultiProcess/Config.h"
 #include "RooStats/ModelConfig.h"
 #include "RunContext.h" // complete RooBatchCompute::RunContext type used in RooUnbinnedL
 
@@ -97,7 +96,7 @@ TEST_P(LikelihoodGradientJob, Gaussian1D)
 
    *values = *savedValues;
 
-   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
    RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
                    RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
@@ -147,7 +146,7 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
 
    // --------
 
-   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
    RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
                    RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
@@ -228,7 +227,7 @@ TEST_P(LikelihoodGradientJob, GaussianND)
 
    // --------
 
-   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
    RooMinimizer m1(likelihood, RooFit::TestStatistics::MinuitFcnGrad::LikelihoodMode::serial,
                    RooFit::TestStatistics::MinuitFcnGrad::LikelihoodGradientMode::multiprocess);
@@ -397,7 +396,7 @@ TEST_F(LikelihoodSimBinnedConstrainedTest, ConstrainedAndOffset)
 
    *values = *savedValues;
 
-   RooFit::MultiProcess::JobManager::default_N_workers = NWorkers;
+   RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
 
    likelihood = RooFit::TestStatistics::buildLikelihood(
       pdf, data, RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This commit adds the Config class to provide a user-accessible place set the desired number of workers. The number of workers was previously settable from a static public member of JobManager, but since we do not expose MultiProcess internals to users, it was unreachable from the ROOT interpreter and scripts.

Thanks to @Zeff020 for noticing this omission.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)