### PR TITLE
SaveAs png failed in batch mode with two canvases, one divided.

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1996,7 +1996,10 @@ void TCanvas::SetCanvasSize(UInt_t ww, UInt_t wh)
       fCanvasImp->SetCanvasSize(ww, wh);
       fCw = ww;
       fCh = wh;
+      TPad *padsav = (TPad*)gPad;
+      cd();
       ResizePad();
+      if (padsav) padsav->cd();
    }
 }
 


### PR DESCRIPTION
This PR fixes this Jira report:
https://sft.its.cern.ch/jira/browse/ROOT-7969

In `TCanvas::SetCanvasSize`, `ResizePad();` acts on `gPad`. This PR makes sure 
`gPad` is properly defined before calling `ResizePad();`.
