### PR TITLE
[RF] Speed improvements

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -588,7 +588,7 @@ protected:
 
 
 private:
-  void addParameters(RooArgSet& params, const RooArgSet* nset=0, Bool_t stripDisconnected=kTRUE) const;
+  void addParameters(RooAbsCollection& params, const RooArgSet* nset = nullptr, bool stripDisconnected = true) const;
 
   RefCountListLegacyIterator_t * makeLegacyIterator(const RefCountList_t& list) const;
 

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -54,6 +54,12 @@ ROOT::RRangeCast<T, true, Range_t> dynamic_range_cast(Range_t &&coll)
 
 class RooCmdArg;
 
+namespace RooFit {
+namespace Detail {
+struct HashAssistedFind;
+}
+}
+
 class RooAbsCollection : public TObject, public RooPrintable {
 public:
   using Storage_t = std::vector<RooAbsArg*>;
@@ -380,10 +386,12 @@ protected:
 
 private:
   std::unique_ptr<LegacyIterator_t> makeLegacyIterator (bool forward = true) const;
-  mutable std::unique_ptr<std::unordered_map<const TNamed*, Storage_t::value_type>> _nameToItemMap; //!
+
+  using HashAssistedFind = RooFit::Detail::HashAssistedFind;
+  mutable std::unique_ptr<HashAssistedFind> _hashAssistedFind; //!
   std::size_t _sizeThresholdForMapSearch; //!
+
   void insert(RooAbsArg*);
-  RooAbsArg* tryFastFind(const TNamed* namePtr) const;
 
   ClassDef(RooAbsCollection,3) // Collection of RooAbsArg objects
 };

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -80,11 +80,11 @@ protected:
   mutable RooObjCacheManager _normIntMgr ; //! The integration cache manager
 
 
-  RooListProxy _funcList ;   //  List of component FUNCs
+  RooListProxy _funcList ;  //  List of component FUNCs
   RooListProxy _coefList ;  //  List of coefficients
   Bool_t _extended ;        // Allow use as extended p.d.f.
 
-  Bool_t _doFloor ; // Introduce floor at zero in pdf
+  Bool_t _doFloor = false; // Introduce floor at zero in pdf
   mutable bool _haveWarned{false}; //!
   static Bool_t _doFloorGlobal ; // Global flag for introducing floor at zero in pdf
   

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1346,7 +1346,7 @@ void RooAbsArg::setProxyNormSet(const RooArgSet* nset)
   for (int i=0 ; i<numProxies() ; i++) {
     RooAbsProxy* p = getProxy(i) ;
     if (!p) continue ;
-    getProxy(i)->changeNormSet(nset) ;
+    p->changeNormSet(nset);
   }
 }
 

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -29,7 +29,6 @@ implemented using the container denoted by RooAbsCollection::Storage_t.
 #include "RooAbsCollection.h"
 
 #include "TClass.h"
-#include "TStopwatch.h"
 #include "TRegexp.h"
 #include "RooStreamParser.h"
 #include "RooFormula.h"

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -71,8 +71,7 @@ Bool_t RooRealSumPdf::_doFloorGlobal = kFALSE ;
 
 RooRealSumPdf::RooRealSumPdf() : _normIntMgr(this,10)
 {
-  _extended = kFALSE ;
-  _doFloor = kFALSE ;
+
 }
 
 
@@ -81,12 +80,12 @@ RooRealSumPdf::RooRealSumPdf() : _normIntMgr(this,10)
 /// Constructor with name and title
 
 RooRealSumPdf::RooRealSumPdf(const char *name, const char *title) :
-  RooAbsPdf(name,title), 
+  RooAbsPdf(name,title),
   _normIntMgr(this,10),
   _funcList("!funcList","List of functions",this),
   _coefList("!coefList","List of coefficients",this),
-  _extended(kFALSE),
-  _doFloor(kFALSE)
+  _extended(false),
+  _doFloor(false)
 {
 
 }
@@ -100,12 +99,7 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title) :
 
 RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
 		     RooAbsReal& func1, RooAbsReal& func2, RooAbsReal& coef1) : 
-  RooAbsPdf(name,title),
-  _normIntMgr(this,10),
-  _funcList("!funcList","List of functions",this),
-  _coefList("!coefList","List of coefficients",this),
-  _extended(kFALSE),
-  _doFloor(kFALSE)
+  RooRealSumPdf(name, title)
 {
   // Special constructor with two functions and one coefficient
 
@@ -143,13 +137,10 @@ RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
 
 RooRealSumPdf::RooRealSumPdf(const char *name, const char *title,
     const RooArgList& inFuncList, const RooArgList& inCoefList, Bool_t extended) :
-  RooAbsPdf(name,title),
-  _normIntMgr(this,10),
-  _funcList("!funcList","List of functions",this),
-  _coefList("!coefList","List of coefficients",this),
-  _extended(extended),
-  _doFloor(kFALSE)
-{ 
+  RooRealSumPdf(name, title)
+{
+  _extended = extended;
+
   if (!(inFuncList.getSize()==inCoefList.getSize()+1 || inFuncList.getSize()==inCoefList.getSize())) {
     coutE(InputArguments) << "RooRealSumPdf::RooRealSumPdf(" << GetName() 
 			  << ") number of pdfs and coefficients inconsistent, must have Nfunc=Ncoef or Nfunc=Ncoef+1" << endl ;

--- a/roofit/roofitcore/test/testRooAbsCollection.cxx
+++ b/roofit/roofitcore/test/testRooAbsCollection.cxx
@@ -74,3 +74,35 @@ TEST(RooArgSet, FromVector) {
   EXPECT_EQ(theSet.size(), 2);
   EXPECT_STREQ(theSet.GetName(), "Hallo");
 }
+
+TEST(RooArgSet, InsertAndDeduplicate) {
+  RooArgList list;
+  RooArgList list2;
+  for (unsigned int i = 0; i < 4; ++i) {
+    char name[] = {char('a'+i), '\0'};
+    list.addOwned(*(new RooRealVar(name, name, 0.)));
+  }
+  for (unsigned int i = 0; i < 5; ++i) {
+    char name[] = {char('a'+i), '\0'};
+    list2.addOwned(*(new RooRealVar(name, name, 0.)));
+    name[0] = char('a'+ 4 - i);
+    list2.addOwned(*(new RooRealVar(name, name, 0.)));
+  }
+
+  // Silence deduplication error messages
+  RooHelpers::HijackMessageStream hijack(RooFit::ERROR, RooFit::InputArguments);
+
+  RooArgSet set{list};
+  EXPECT_EQ(set.size(), list.size());
+
+  RooArgSet set2{list2};
+  EXPECT_EQ(set2.size(), list2.size()/2);
+
+  RooArgSet set3{list};
+  set3.add(list2);
+  EXPECT_EQ(set3.size(), set.size() + 1);
+  EXPECT_EQ(set3[set3.size()-1], & list2[1]);
+
+  RooArgSet set4{list, list2};
+  EXPECT_EQ(set4.size(), set.size() + 1);
+}


### PR DESCRIPTION
- Two important things: Dramatically speed up hash-assisted finds in `RooArgSet`
- Reduce `dynamic_cast` in RooAbsArg::setProxyNormSet

Here are some timings on a random machine with a dummy ATLAS Higgs->gamma gamma workspace:
|                                | Build | Fit  |
| ------------------------------ | ----- | ---- |
| HGam old                       | 3:33  | 3:30 |
| HGam new  | 0:40  | 2:12 |