### PR TITLE
[RF] RooFit speed improvements

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -611,12 +611,7 @@ private:
   RefCountList_t _clientListShape; // subset of clients that requested shape dirty flag propagation
   RefCountList_t _clientListValue; // subset of clients that requested value dirty flag propagation
 
-  struct ProxyListCache {
-    std::vector<RooAbsProxy*> cache;
-    bool isDirty = true;
-  };
   RooRefArray _proxyList        ; // list of proxies
-  ProxyListCache _proxyListCache; //! cache of the list of proxies
 
   std::vector<RooAbsCache*> _cacheList ; //! list of caches
 
@@ -666,6 +661,12 @@ private:
   friend std::ostream& operator<<(std::ostream& os, const RooAbsArg &arg);
   friend std::istream& operator>>(std::istream& is, RooAbsArg &arg) ;
   friend void RooRefArray::Streamer(TBuffer&);
+
+  struct ProxyListCache {
+    std::vector<RooAbsProxy*> cache;
+    bool isDirty = true;
+  };
+  ProxyListCache _proxyListCache; //! cache of the list of proxies. Avoids type casting.
 
   // Debug stuff
   static Bool_t _verboseDirty ; // Static flag controlling verbose messaging for dirty state changes

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -611,7 +611,12 @@ private:
   RefCountList_t _clientListShape; // subset of clients that requested shape dirty flag propagation
   RefCountList_t _clientListValue; // subset of clients that requested value dirty flag propagation
 
+  struct ProxyListCache {
+    std::vector<RooAbsProxy*> cache;
+    bool isDirty = true;
+  };
   RooRefArray _proxyList        ; // list of proxies
+  ProxyListCache _proxyListCache; //! cache of the list of proxies
 
   std::vector<RooAbsCache*> _cacheList ; //! list of caches
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -36,6 +36,7 @@ class RooAbsCategoryLValue;
 class Roo1DTable ;
 class RooPlot;
 class RooArgList;
+class RooSimultaneous;
 class TH1;
 class TH2F;
 class RooAbsBinning ;
@@ -220,6 +221,9 @@ public:
 	
   // Split a dataset by a category
   virtual TList* split(const RooAbsCategory& splitCat, Bool_t createEmptyDataSets=kFALSE) const ;
+
+  // Split a dataset by categories of a RooSimultaneous
+  virtual TList* split(const RooSimultaneous& simpdf, Bool_t createEmptyDataSets=kFALSE) const ;
 
   // Fast splitting for SimMaster setData
   Bool_t canSplitFast() const ; 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1229,6 +1229,7 @@ void RooAbsArg::registerProxy(RooArgProxy& proxy)
 
   // Register proxy itself
   _proxyList.Add(&proxy) ;
+  _proxyListCache.isDirty = true;
 }
 
 
@@ -1240,6 +1241,7 @@ void RooAbsArg::unRegisterProxy(RooArgProxy& proxy)
 {
   _proxyList.Remove(&proxy) ;
   _proxyList.Compress() ;
+  _proxyListCache.isDirty = true;
 }
 
 
@@ -1261,6 +1263,7 @@ void RooAbsArg::registerProxy(RooSetProxy& proxy)
 
   // Register proxy itself
   _proxyList.Add(&proxy) ;
+  _proxyListCache.isDirty = true;
 }
 
 
@@ -1273,6 +1276,7 @@ void RooAbsArg::unRegisterProxy(RooSetProxy& proxy)
 {
   _proxyList.Remove(&proxy) ;
   _proxyList.Compress() ;
+  _proxyListCache.isDirty = true;
 }
 
 
@@ -1295,6 +1299,7 @@ void RooAbsArg::registerProxy(RooListProxy& proxy)
   // Register proxy itself
   Int_t nProxyOld = _proxyList.GetEntries() ;
   _proxyList.Add(&proxy) ;
+  _proxyListCache.isDirty = true;
   if (_proxyList.GetEntries()!=nProxyOld+1) {
     cout << "RooAbsArg::registerProxy(" << GetName() << ") proxy registration failure! nold=" << nProxyOld << " nnew=" << _proxyList.GetEntries() << endl ;
   }
@@ -1310,6 +1315,7 @@ void RooAbsArg::unRegisterProxy(RooListProxy& proxy)
 {
   _proxyList.Remove(&proxy) ;
   _proxyList.Compress() ;
+  _proxyListCache.isDirty = true;
 }
 
 
@@ -1343,9 +1349,19 @@ Int_t RooAbsArg::numProxies() const
 
 void RooAbsArg::setProxyNormSet(const RooArgSet* nset)
 {
-  for (int i=0 ; i<numProxies() ; i++) {
-    RooAbsProxy* p = getProxy(i) ;
-    if (!p) continue ;
+  if (_proxyListCache.isDirty) {
+    // First time we loop over proxies: cache the results to avoid future
+    // costly dynamic_casts
+    _proxyListCache.cache.clear();
+    for (int i=0 ; i<numProxies() ; i++) {
+      RooAbsProxy* p = getProxy(i) ;
+      if (!p) continue ;
+      _proxyListCache.cache.push_back(p);
+    }
+    _proxyListCache.isDirty = false;
+  }
+
+  for ( auto& p : _proxyListCache.cache ) {
     p->changeNormSet(nset);
   }
 }

--- a/roofit/roofitcore/src/RooAbsProxy.cxx
+++ b/roofit/roofitcore/src/RooAbsProxy.cxx
@@ -63,7 +63,7 @@ RooAbsProxy::RooAbsProxy(const char* /*name*/, const RooAbsProxy& other) :
 
 void RooAbsProxy::changeNormSet(const RooArgSet* newNormSet) 
 {
-  _nset = (RooArgSet*) newNormSet ;
+  _nset = const_cast<RooArgSet*>(newNormSet) ;
 }
 
 

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -459,7 +459,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
   RooAbsCategoryLValue& simCat = const_cast<RooAbsCategoryLValue&>(simpdf->indexCat());
 
   TString simCatName(simCat.GetName());
-  TList* dsetList = const_cast<RooAbsData*>(data)->split(simCat,processEmptyDataSets());
+  TList* dsetList = const_cast<RooAbsData*>(data)->split(*simpdf,processEmptyDataSets());
   if (!dsetList) {
     coutE(Fitting) << "RooAbsTestStatistic::initSimMode(" << GetName() << ") ERROR: index category of simultaneous pdf is missing in dataset, aborting" << endl;
     throw std::runtime_error("RooAbsTestStatistic::initSimMode() ERROR, index category of simultaneous pdf is missing in dataset, aborting");


### PR DESCRIPTION
- Remove `dynamic_cast` for cross casts in a multiple inheritance setting
- Reduce the size of datasets by removing observables that are not in use.

