### PR TITLE
[ntuple] RNTupleSerialize: do not use `abs()` in feature flags deserialization

### DIFF
--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -731,7 +731,7 @@ RResult<std::uint32_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
          return R__FAIL("feature flag buffer too short");
       bytes += DeserializeInt64(bytes, f);
       bufSize -= sizeof(std::int64_t);
-      flags.emplace_back(abs(f));
+      flags.emplace_back((f < 0) ? -f : f);
    } while (f < 0);
 
    return (flags.size() * sizeof(std::int64_t));


### PR DESCRIPTION
Follow-up from PR #8897.

It seems that system headers for Clang 10.0.1 in EL 8.3 x86_64 do not provide an overload for `abs(std::uint64_t)`, triggering the diagnostic below. Using `(f < 0) ? -f : f` instead.

```
RNTupleSerialize.cxx:734:26: warning: absolute value function 'abs' given an argument of type 'std::int64_t' (aka 'long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
      flags.emplace_back(abs(f));
```

## Checklist:
- [X] tested changes locally