### PR TITLE
[RF] Add utility function to reserve memory for addParameters

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -589,6 +589,7 @@ protected:
 
 private:
   void addParameters(RooAbsCollection& params, const RooArgSet* nset = nullptr, bool stripDisconnected = true) const;
+  std::size_t getParametersSizeEstimate(const RooArgSet* nset = nullptr) const;
 
   RefCountListLegacyIterator_t * makeLegacyIterator(const RefCountList_t& list) const;
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -618,6 +618,40 @@ void RooAbsArg::addParameters(RooAbsCollection& params, const RooArgSet* nset, b
   }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Obtain an estimate of the number of parameters of the function and its daughters.
+/// Calling `addParamters` for large functions (NLL) can cause many reallocations of
+/// `params` due to the recursive behaviour. This utility function aims to pre-compute
+/// the total number of parameters, so that enough memory is reserved.
+/// The estimate is not fully accurate (overestimate) as there is no equivalent to `getParametersHook`.
+/// \param[in] nset Normalisation set (optional). If a value depends on this set, it's not a parameter.
+
+std::size_t RooAbsArg::getParametersSizeEstimate(const RooArgSet* nset) const
+{
+
+  std::size_t res = 0;
+  std::vector<RooAbsArg*> branchList;
+  for (const auto server : _serverList) {
+    if (server->isValueServer(*this)) {
+      if (server->isFundamental()) {
+        if (!nset || !server->dependsOn(*nset)) {
+          res++;
+        }
+      } else {
+        branchList.push_back(server);
+      }
+    }
+  }
+
+  // Now recurse into branch servers
+  std::sort(branchList.begin(), branchList.end());
+  const auto last = std::unique(branchList.begin(), branchList.end());
+  for (auto serverIt = branchList.begin(); serverIt < last; ++serverIt) {
+    res += (*serverIt)->getParametersSizeEstimate(nset);
+  }
+
+  return res;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a list of leaf nodes in the arg tree starting with
@@ -660,6 +694,8 @@ bool RooAbsArg::getParameters(const RooArgSet* observables, RooArgSet& outputSet
    outputSet.setName("parameters");
 
    RooArgList tempList;
+   // reserve all memory needed in one go
+   tempList.reserve(getParametersSizeEstimate(observables));
 
    addParameters(tempList, observables, stripDisconnected);
 


### PR DESCRIPTION
Calling `addParamaters` for large functions (such as NLL creation or RooMinimizer creation for large workspaces) can cause many reallocations of `params` due to the recursive behaviour. This utility function aims to pre-compute the total number of parameters, so that enough memory is reserved. This is then used in `getParameters` so that the `params` passed to `addParameters` do not need to be resized.
