### PR TITLE
Give more unique filenames in entrylist tests

### DIFF
--- a/tree/tree/test/chain_setentrylist.cxx
+++ b/tree/tree/test/chain_setentrylist.cxx
@@ -29,9 +29,9 @@ TEST(TChain, SetEntryListSyncNoSubLists) {
 
    const auto start1{0};
    const auto end1{5};
-   auto treename1{"tree10entries"};
-   auto filename1{"tree10entries.root"};
-   auto fullpath1{"tree10entries.root/tree10entries"};
+   auto treename1{"syncnosublists_tree10entries"};
+   auto filename1{"syncnosublists_tree10entries.root"};
+   auto fullpath1{"syncnosublists_tree10entries.root/syncnosublists_tree10entries"};
    const auto nentries1{10};
 
    FillTree(filename1, treename1, nentries1);
@@ -62,15 +62,15 @@ TEST(TChain, SetEntryListSyncWrongFile) {
 
    const auto start_1{0};
    const auto end_1{20};
-   auto treename1{"tree10entries"};
-   auto filename1{"tree10entries.root"};
-   auto fullpath1{"tree10entries.root/tree10entries"};
+   auto treename1{"syncwrongfile_tree10entries"};
+   auto filename1{"syncwrongfile_tree10entries.root"};
+   auto fullpath1{"syncwrongfile_tree10entries.root/syncwrongfile_tree10entries"};
    const auto nentries1{10};
 
    const auto start_2{0};
    const auto end_2{10};
-   auto treename2{"tree20entries"};
-   auto filename2{"tree20entries.root"};
+   auto treename2{"syncwrongfile_tree20entries"};
+   auto filename2{"syncwrongfile_tree20entries.root"};
    const auto nentries2{20};
 
    FillTree(filename1, treename1, nentries1);
@@ -119,14 +119,14 @@ TEST(TChain, SetEntryListSyncWrongNumberOfSubLists) {
 
    const auto start_1{0};
    const auto end_1{20};
-   auto treename1{"tree10entries"};
-   auto filename1{"tree10entries.root"};
-   auto fullpath1{"tree10entries.root/tree10entries"};
+   auto treename1{"syncwrongnumberofsublists_tree10entries"};
+   auto filename1{"syncwrongnumberofsublists_tree10entries.root"};
+   auto fullpath1{"syncwrongnumberofsublists_tree10entries.root/syncwrongnumberofsublists_tree10entries"};
    const auto nentries1{10};
 
-   auto treename2{"tree20entries"};
-   auto filename2{"tree20entries.root"};
-   auto fullpath2{"tree20entries.root/tree20entries"};
+   auto treename2{"syncwrongnumberofsublists_tree20entries"};
+   auto filename2{"syncwrongnumberofsublists_tree20entries.root"};
+   auto fullpath2{"syncwrongnumberofsublists_tree20entries.root/syncwrongnumberofsublists_tree20entries"};
    const auto nentries2{20};
 
    FillTree(filename1, treename1, nentries1);

--- a/tree/tree/test/entrylist_addsublist.cxx
+++ b/tree/tree/test/entrylist_addsublist.cxx
@@ -27,14 +27,14 @@ TEST(TEntryList, addSubList) {
 
    const auto start1{0};
    const auto end1{20};
-   auto treename1{"tree10entries"};
-   auto filename1{"tree10entries.root"};
+   auto treename1{"entrylist_addsublist_tree10entries"};
+   auto filename1{"entrylist_addsublist_tree10entries.root"};
    const auto nentries1{10};
 
    const auto start2{0};
    const auto end2{10};
-   auto treename2{"tree20entries"};
-   auto filename2{"tree20entries.root"};
+   auto treename2{"entrylist_addsublist_tree20entries"};
+   auto filename2{"entrylist_addsublist_tree20entries.root"};
    const auto nentries2{20};
 
    FillTree(filename1, treename1, nentries1);


### PR DESCRIPTION
This should hopefully fix sporadic failures happening when deleting the files create in these tests

