### PR TITLE
[RF] Use RooFormula copy constructor in RooFormulaVar copy constructor

### DIFF
--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -120,7 +120,7 @@ RooFormulaVar::RooFormulaVar(const RooFormulaVar& other, const char* name) :
   _formExpr(other._formExpr)
 {
   if (other._formula && other._formula->ok()) {
-    _formula.reset(new RooFormula(GetName(), _formExpr, _actualVars, /*checkVariables=*/false));
+    _formula = std::make_unique<RooFormula>(*other._formula);
     _formExpr = _formula->formulaString().c_str();
   }
 }


### PR DESCRIPTION
This speeds up the likelihood creation for the ATLAS Higgs to GG
workspace by 20 %.