### PR TITLE
Optimize RooAbsCollection::containsInstance for RooArgSet

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -176,7 +176,7 @@ public:
     return find(var) != nullptr;
   }
   /// Check if this exact instance is in this collection.
-  Bool_t containsInstance(const RooAbsArg& var) const { 
+  virtual Bool_t containsInstance(const RooAbsArg& var) const { 
     return std::find(_list.begin(), _list.end(), &var) != _list.end();
   }
   RooAbsCollection* selectByAttrib(const char* name, Bool_t value) const ;

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -145,6 +145,10 @@ public:
   Bool_t readFromFile(const char* fileName, const char* flagReadAtt=0, const char* section=0, Bool_t verbose=kFALSE) ;
 
 
+  /// Check if this exact instance is in this collection.
+  Bool_t containsInstance(const RooAbsArg& var) const override { 
+    return find(var) == &var;
+  }
 
   static void cleanup() ;
 


### PR DESCRIPTION
Now that we have an efficient hash-assisted `find` mechanism to find by name, it can be used in `RooArgSet` to optimize `containsInstance` (as we are certain there is only one parameter with a given name).

This reduces the writing of large workspaces to file (such as ATLAS Higgs combination) by a significant factor (not precisely measured, but at least 5).