### PR TITLE
[ntuple] RNTupleSerialize: do not use two's complement to encode feature flags

### DIFF
--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -713,7 +713,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeFeatureF
          if (i == (flags.size() - 1))
             SerializeInt64(flags[i], bytes);
          else
-            bytes += SerializeInt64(-flags[i], bytes);
+            bytes += SerializeInt64(flags[i] | 0x8000000000000000, bytes);
       }
    }
    return (flags.size() * sizeof(std::int64_t));
@@ -731,7 +731,7 @@ RResult<std::uint32_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
          return R__FAIL("feature flag buffer too short");
       bytes += DeserializeInt64(bytes, f);
       bufSize -= sizeof(std::int64_t);
-      flags.emplace_back((f < 0) ? -f : f);
+      flags.emplace_back(f & ~0x8000000000000000);
    } while (f < 0);
 
    return (flags.size() * sizeof(std::int64_t));

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -710,6 +710,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeFeatureF
          if (flags[i] < 0)
             throw RException(R__FAIL("feature flag out of bounds"));
 
+         // The MSb indicates that another Int64 follows; set this bit to 1 for all except the last element
          if (i == (flags.size() - 1))
             SerializeInt64(flags[i], bytes);
          else


### PR DESCRIPTION
The RNTuple binary format v1 states that feature flags bitmap is encoded as a sequence of 64-bit integers in which the MSb indicates that another 64-bit block follows.

If more than one 64-bit integer is serialized, the MSb of all but the last integer should be `1` and the rest of the bits should preserve their original meaning.
Therefore, this PR avoids the use of two's complement in this case in favour of manually setting the MSb.

According to my interpretation of the [RNTuple binary format v1](https://github.com/root-project/root/blob/master/tree/ntuple/v7/doc/specifications.md) specification, this is the only case in which this happens.  All the other uses of two's complement are correct, e.g. in frames or locators we specify that negative sizes have a different/specific meaning.

## Changes or fixes:
- Fix feature flags bitmap serialization.

## Checklist:
- [X] tested changes locally