### PR TITLE
[DF] Make sure the Dask scheduler has information about the workers

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/Backend.py
@@ -42,10 +42,12 @@ class DaskBackend(Base.BaseBackend):
         execution. Currently, we try to get the total number of worker logical
         cores in the cluster.
         """
-        try:
-            return sum(worker['nthreads'] for worker in self.client.scheduler_info()['workers'].values())
-        except KeyError:
-            # If the scheduler doesn't have some information about the workers
+        workers_dict = self.client.scheduler_info().get("workers")
+        if workers_dict:
+            # The 'workers' key exists in the dictionary and it is non-empty
+            return sum(worker['nthreads'] for worker in workers_dict.values())
+        else:
+            # The scheduler doesn't have information about the workers
             return self.MIN_NPARTITIONS
 
     def ProcessAndMerge(self, ranges, mapper, reducer):


### PR DESCRIPTION
The current implementation of `optimize_npartitions` of the Dask backend
queries information about the workers from the Dask client object. The
information is stored in the `client.scheduler_info()` return value
which is a dictionary that can have the key `workers`.

Supposedly, when this key exists it means the Dask client has the needed
information. This is not always true. In certain scenarios, for example
when waiting for a batch system to return the available workers to the
dask client, the `workers` key will be present but its value will be an
empty dictionary. This is because the scheduler doesn't already know
which nodes of the cluster will become workers (this can be mitigated by
calling the `client.wait_for_workers` function beforehand).

This commit makes the check a bit stronger, getting the value of the
dictionary key `workers` and then checking if that value actually
contains something.

fixes #9429 

