### PR TITLE
[jsroot] bugfix version 6.3.2 [skip-ci]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,5 +1,9 @@
 # JSROOT changelog
 
+## Changes in 6.3.2
+1. Fix bug in TH1 drawing when minimum or/and maximum was configured for histogram
+
+
 ## Changes in 6.3.1
 1. Fix bug with col draw option in TH2/RH2
 

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -100,11 +100,11 @@
    /** @summary JSROOT version id
      * @desc For the JSROOT release the string in format "major.minor.patch" like "6.3.0"
      * For the ROOT release string is "ROOT major.minor.patch" like "ROOT 6.26.00" */
-   JSROOT.version_id = "6.3.1";
+   JSROOT.version_id = "6.3.2";
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "19/11/2021"*/
-   JSROOT.version_date = "25/11/2021";
+   JSROOT.version_date = "13/12/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -3533,7 +3533,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
       }
 
       if (!when_axis_changed) {
-         if (set_zoom && (this.draw_content || set_zoom2)) {
+         if (set_zoom && this.draw_content) {
             this.zoom_ymin = (hmin == -1111) ? this.ymin : hmin;
             this.zoom_ymax = (hmax == -1111) ? this.ymax : hmax;
          } else {


### PR DESCRIPTION
Fix bug in TH1 drawing when minimum or/and maximum was configured for histogram

