### PR TITLE
Fix in THStack drawing option "pads"

### DIFF
--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -787,18 +787,19 @@ void THStack::Paint(Option_t *choptin)
          Int_t ny = nx;
          if (((nx*ny)-nx) >= npads) ny--;
          padsav->Divide(nx,ny);
+
+         TH1 *h;
+         Int_t i = 0;
+         TObjOptLink *lnk = (TObjOptLink*)fHists->FirstLink();
+         while (lnk) {
+            i++;
+            padsav->cd(i);
+            h = (TH1*)lnk->GetObject();
+            h->Draw(lnk->GetOption());
+            lnk = (TObjOptLink*)lnk->Next();
+         }
+         padsav->cd();
       }
-      TH1 *h;
-      Int_t i = 0;
-      TObjOptLink *lnk = (TObjOptLink*)fHists->FirstLink();
-      while (lnk) {
-         i++;
-         padsav->cd(i);
-         h = (TH1*)lnk->GetObject();
-         h->Draw(lnk->GetOption());
-         lnk = (TObjOptLink*)lnk->Next();
-      }
-      padsav->cd();
       return;
    }
 


### PR DESCRIPTION
The Paint method of THStack always redrew the histograms in the sub-pads defined by the THStack drawing option "pads". Like the "pad dividing" the "histograms' drawing" should be done only the first time the THStack is painted otherwise any additional graphics objects added in one of the pads (created by the "pads" option) will be removed as seen in the forum report:

https://root-forum.cern.ch/t/tline-not-shown/48028