### PR TITLE
[ntuple] Remove `Warning: Unused class rule: SG::sgkey_t` in builds with `-Dtesting=ON`

### DIFF
--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -16,6 +16,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(CustomStruct
                               SOURCES CustomStruct.cxx
                               LINKDEF CustomStructLinkDef.h
                               DEPENDENCIES RIO)
+configure_file(CustomStruct.hxx . COPYONLY)
 if(MSVC)
   add_custom_command(TARGET CustomStruct POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libCustomStruct.dll

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -1,3 +1,6 @@
+#ifndef ROOT7_RNTuple_Test_CustomStruct
+#define ROOT7_RNTuple_Test_CustomStruct
+
 #include <string>
 #include <vector>
 
@@ -67,3 +70,5 @@ struct ComplexStruct {
 
    int a = 0;
 };
+
+#endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -11,7 +11,6 @@
 #pragma link C++ class DerivedC+;
 
 #pragma link C++ class IAuxSetOption+;
-#pragma link C++ typedef SG::sgkey_t+;
 #pragma link C++ class PackedParameters+;
 #pragma link C++ class PackedContainer<int>+;
 

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1,4 +1,5 @@
 #include "ntuple_test.hxx"
+#include "TInterpreter.h"
 
 TEST(RNTuple, TypeName) {
    EXPECT_STREQ("float", ROOT::Experimental::RField<float>::TypeName().c_str());
@@ -214,6 +215,9 @@ TEST(RNTuple, TClassMultipleInheritance)
 
 TEST(RNTuple, TClassTemplatedBase)
 {
+   // For non-cxxmodules builds, cling needs to parse the header for the `SG::sgkey_t` type to be known
+   gInterpreter->ProcessLine("#include \"CustomStruct.hxx\"");
+
    FileRaii fileGuard("test_ntuple_tclass.ntuple");
    {
       auto model = RNTupleModel::Create();


### PR DESCRIPTION
In one of the RNTuple tests that exercises user-defined types, `SG::sgkey_t` is a typedef for a fundamental type, which causes rootcling to print a warning:
```
Warning: Unused class rule: SG::sgkey_t
```

This is because `#pragma link C++ typedef foo` is only used by rootcling to generate a dictionary for `foo` if it is a typedef for a class/struct.
For other typedefs, either _(1)_ cxxmodules have to be enabled, or _(2)_ cling has to parse the header.

## Changes or fixes:
- Remove the no-op `#pragma link C++ typedef ...`
- We do not rely on cxxmodules to be enabled for this test; make cling parse `CustomStruct.hxx` instead

## Checklist:
- [X] tested changes locally