### PR TITLE
[RF] Fix imt and VDT dependency for roofit BatchCompute library

### DIFF
--- a/roofit/batchcompute/CMakeLists.txt
+++ b/roofit/batchcompute/CMakeLists.txt
@@ -6,10 +6,11 @@ ROOT_LINKER_LIBRARY(RooBatchCompute
   DEPENDENCIES
     Core
     MathCore
+    Imt
 )
 
-if(vdt AND NOT builtin_vdt)
-  target_include_directories(RooBatchCompute PUBLIC ${VDT_INCLUDE_DIR})
+if(vdt OR builtin_vdt)
+  target_include_directories(RooBatchCompute PRIVATE ${VDT_INCLUDE_DIRS} INTERFACE $<BUILD_INTERFACE:${VDT_INCLUDE_DIRS}>)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -15,7 +15,6 @@
 
 #include "RooSpan.h"
 #include "RunContext.h"
-#include "RooVDTHeaders.h"
 
 #include "DllImport.h" //for R__EXTERN, needed for windows
 #include "TError.h"

--- a/roofit/batchcompute/inc/RooVDTHeaders.h
+++ b/roofit/batchcompute/inc/RooVDTHeaders.h
@@ -22,6 +22,8 @@
  * this layer can be used to switch between different implementations.
  */
 
+#include "RConfigure.h"
+
 #if defined(R__HAS_VDT) && !defined(__CUDACC__)
 #include "vdt/exp.h"
 #include "vdt/log.h"

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -19,6 +19,7 @@ This file contains the code for cpu computations using the RooBatchCompute libra
 **/
 
 #include "RooBatchCompute.h"
+#include "RooVDTHeaders.h"
 #include "Batches.h"
 
 #include "ROOT/RConfig.h"

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -173,6 +173,7 @@ called for each data event.
 #include "RooFormulaVar.h"
 #include "RooDerivative.h"
 #include "RooFit/BatchModeHelpers.h"
+#include "RooVDTHeaders.h"
 
 #include "ROOT/StringUtils.hxx"
 #include "TClass.h"


### PR DESCRIPTION
- When imt is off one needs to have still the imt dependency for using  TExecutor
- Fix correct definition for variable defining location of vdt headers.
It should be VDT_INCLUDE_DIRS and not VDT_INCLUDE_DIR

