### PR TITLE
[RF] Make `roobatchcompute` header files safer

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -13,25 +13,12 @@
 #ifndef ROOFIT_BATCHCOMPUTE_ROOBATCHCOMPUTE_H
 #define ROOFIT_BATCHCOMPUTE_ROOBATCHCOMPUTE_H
 
-#include "RooSpan.h"
-#include "RunContext.h"
+#include "RooBatchComputeTypes.h"
 
 #include "DllImport.h" //for R__EXTERN, needed for windows
 #include "TError.h"
 
 #include <functional>
-#include <map>
-#include <vector>
-
-#ifndef __CUDACC__
-#define __device__
-#define __global__
-#define __host__
-struct cudaEvent_t;
-struct cudaStream_t;
-#endif // #ifndef __CUDACC__
-
-class RooAbsArg;
 
 /**
  * Namespace for dispatching RooFit computations to various backends.
@@ -48,15 +35,6 @@ class RooAbsArg;
 namespace RooBatchCompute {
 
 enum class Architecture { AVX512, AVX2, AVX, SSE4, GENERIC, CUDA };
-
-struct RunContext;
-// We have to use map instead of unordered_map because the unordered_maps from
-// nvcc and gcc are not compatible sometimes.
-typedef std::map<const RooAbsArg *, RooSpan<const double>> DataMap;
-typedef std::vector<const RooAbsArg *> VarVector;
-typedef std::vector<double> ArgVector;
-typedef double *__restrict RestrictArr;
-typedef const double *__restrict InputArr;
 
 enum Computer{AddPdf, ArgusBG, Bernstein, BifurGauss, BreitWigner, Bukin, CBShape, Chebychev,
               ChiSquare, DstD0BG, Exponential, Gamma, Gaussian, Johnson, Landau, Lognormal,

--- a/roofit/batchcompute/inc/RooBatchComputeTypes.h
+++ b/roofit/batchcompute/inc/RooBatchComputeTypes.h
@@ -1,0 +1,50 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Emmanouil Michalainas, CERN 6 January 2021
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOFIT_BATCHCOMPUTE_ROOBATCHCOMPUTETYPES_H
+#define ROOFIT_BATCHCOMPUTE_ROOBATCHCOMPUTETYPES_H
+
+#include <RooSpan.h>
+
+#include <map>
+#include <vector>
+
+
+#ifdef __CUDACC__
+#define __roodevice__ __device__
+#define __roohost__ __host__
+#define __rooglobal__ __global__
+#else
+#define __roodevice__
+#define __roohost__
+#define __rooglobal__
+struct cudaEvent_t;
+struct cudaStream_t;
+#endif // #indef __CUDACC__
+
+class RooAbsArg;
+
+namespace RooBatchCompute {
+
+struct RunContext;
+
+// We have to use map instead of unordered_map because the unordered_maps from
+// nvcc and gcc are not compatible sometimes.
+typedef std::map<const RooAbsArg *, RooSpan<const double>> DataMap;
+typedef std::vector<const RooAbsArg *> VarVector;
+typedef std::vector<double> ArgVector;
+typedef double *__restrict RestrictArr;
+typedef const double *__restrict InputArr;
+
+}
+
+#endif

--- a/roofit/batchcompute/inc/RooMath.h
+++ b/roofit/batchcompute/inc/RooMath.h
@@ -16,8 +16,10 @@
 #ifndef ROO_MATH
 #define ROO_MATH
 
-#include "RooBatchCompute.h"
-#include "TMath.h"
+#include <RooBatchComputeTypes.h>
+
+#include <TMath.h>
+
 #include <complex>
 
 typedef Double_t* pDouble_t;
@@ -95,7 +97,7 @@ public:
    * @f$Im(z)<0@f$, the symmetry property @f$w(x-iy)=2e^{-(x+iy)^2-w(x+iy)}@f$
    * is used.
    */
-  __device__ __host__ static std::complex<double> faddeeva(std::complex<double> z);
+  __roodevice__ __roohost__ static std::complex<double> faddeeva(std::complex<double> z);
   /** @brief evaluate Faddeeva function for complex argument (fast version)
    *
    * @author Manuel Schiller <manuel.schiller@nikhef.nl>

--- a/roofit/batchcompute/inc/RooVDTHeaders.h
+++ b/roofit/batchcompute/inc/RooVDTHeaders.h
@@ -47,27 +47,23 @@ inline double fast_isqrt(double x) {
 
 #else
 #include <cmath>
-#ifndef __CUDACC__
-  #define __device__
-#endif
 
 namespace RooBatchCompute{
 
-__device__ inline double fast_exp(double x) {
+__roodevice__ inline double fast_exp(double x) {
   return std::exp(x);
 }
 
-__device__ inline double fast_log(double x) {
+__roodevice__ inline double fast_log(double x) {
   return std::log(x);
 }
 
-__device__ inline double fast_isqrt(double x) {
+__roodevice__ inline double fast_isqrt(double x) {
   return 1/std::sqrt(x);
 }
 
 }
 
 #endif // defined(R__HAS_VDT) && !defined(__CUDACC__)
-
 
 #endif // ROOFIT_BATCHCOMPUTE_ROOVDTHEADERS_H_

--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -23,7 +23,7 @@ so that they can contain data for every kind of compute function.
 #ifndef ROOFIT_BATCHCOMPUTE_BATCHES_H
 #define ROOFIT_BATCHCOMPUTE_BATCHES_H
 
-#include "RooBatchCompute.h"
+#include <RooBatchComputeTypes.h>
 
 #include <stdint.h>
 
@@ -45,7 +45,7 @@ public:
    Batch() = default;
    inline Batch(InputArr array, bool isVector) : _scalar{array[0]}, _array{array}, _isVector{isVector} {}
 
-   __device__ constexpr bool isItVector() const { return _isVector; }
+   __roodevice__ constexpr bool isItVector() const { return _isVector; }
    inline void set(double scalar, InputArr array, bool isVector)
    {
       _scalar = scalar;
@@ -54,7 +54,7 @@ public:
    }
    inline void advance(size_t _nEvents) { _array += _isVector * _nEvents; }
 #ifdef __CUDACC__
-   __device__ constexpr double operator[](size_t i) const noexcept { return _isVector ? _array[i] : _scalar; }
+   __roodevice__ constexpr double operator[](size_t i) const noexcept { return _isVector ? _array[i] : _scalar; }
 #else
    constexpr double operator[](size_t i) const noexcept { return _array[i]; }
 #endif // #ifdef __CUDACC__
@@ -75,10 +75,10 @@ public:
 
    Batches(RestrictArr output, size_t nEvents, const DataMap &varData, const VarVector &vars,
            const ArgVector &extraArgs = {}, double stackArr[maxParams][bufferSize] = nullptr);
-   __device__ size_t getNEvents() const { return _nEvents; }
-   __device__ uint8_t getNExtraArgs() const { return _nExtraArgs; }
-   __device__ double extraArg(uint8_t i) const { return _extraArgs[i]; }
-   __device__ Batch operator[](int batchIdx) const { return _arrays[batchIdx]; }
+   __roodevice__ size_t getNEvents() const { return _nEvents; }
+   __roodevice__ uint8_t getNExtraArgs() const { return _nExtraArgs; }
+   __roodevice__ double extraArg(uint8_t i) const { return _extraArgs[i]; }
+   __roodevice__ Batch operator[](int batchIdx) const { return _arrays[batchIdx]; }
    inline void setNEvents(size_t n = bufferSize) { _nEvents = n; }
    inline void advance(size_t nEvents)
    {

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -24,8 +24,8 @@ https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-strid
 **/
 
 #include "RooBatchCompute.h"
-#include "Batches.h"
 #include "RooVDTHeaders.h"
+#include "Batches.h"
 
 #include <complex>
 
@@ -43,7 +43,7 @@ https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-strid
 namespace RooBatchCompute {
 namespace RF_ARCH {
 
-__global__ void computeAddPdf(Batches batches)
+__rooglobal__ void computeAddPdf(Batches batches)
 {
    const int nPdfs = batches.getNExtraArgs();
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
@@ -53,7 +53,7 @@ __global__ void computeAddPdf(Batches batches)
          batches._output[i] += batches.extraArg(pdf) * batches[pdf][i];
 }
 
-__global__ void computeArgusBG(Batches batches)
+__rooglobal__ void computeArgusBG(Batches batches)
 {
    Batch m = batches[0], m0 = batches[1], c = batches[2], p = batches[3], normVal = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -69,7 +69,7 @@ __global__ void computeArgusBG(Batches batches)
    }
 }
 
-__global__ void computeBernstein(Batches batches)
+__rooglobal__ void computeBernstein(Batches batches)
 {
    const int nCoef = batches.getNExtraArgs() - 2;
    const int degree = nCoef - 1;
@@ -130,7 +130,7 @@ __global__ void computeBernstein(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__global__ void computeBifurGauss(Batches batches)
+__rooglobal__ void computeBifurGauss(Batches batches)
 {
    Batch X = batches[0], M = batches[1], SL = batches[2], SR = batches[3], normVal = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -143,7 +143,7 @@ __global__ void computeBifurGauss(Batches batches)
    }
 }
 
-__global__ void computeBreitWigner(Batches batches)
+__rooglobal__ void computeBreitWigner(Batches batches)
 {
    Batch X = batches[0], M = batches[1], W = batches[2], normVal = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -152,7 +152,7 @@ __global__ void computeBreitWigner(Batches batches)
    }
 }
 
-__global__ void computeBukin(Batches batches)
+__rooglobal__ void computeBukin(Batches batches)
 {
    Batch X = batches[0], XP = batches[1], SP = batches[2], XI = batches[3], R1 = batches[4], R2 = batches[5],
          normVal = batches[6];
@@ -193,7 +193,7 @@ __global__ void computeBukin(Batches batches)
       batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
 }
 
-__global__ void computeCBShape(Batches batches)
+__rooglobal__ void computeCBShape(Batches batches)
 {
    Batch M = batches[0], M0 = batches[1], S = batches[2], A = batches[3], N = batches[4], normVal = batches[5];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -211,7 +211,7 @@ __global__ void computeCBShape(Batches batches)
       batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
 }
 
-__global__ void computeChebychev(Batches batches)
+__rooglobal__ void computeChebychev(Batches batches)
 {
    Batch xData = batches[0], normVal = batches[1];
    const int nCoef = batches.getNExtraArgs() - 2;
@@ -254,7 +254,7 @@ __global__ void computeChebychev(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__global__ void computeChiSquare(Batches batches)
+__rooglobal__ void computeChiSquare(Batches batches)
 {
    Batch X = batches[0], normVal = batches[1];
    const double ndof = batches.extraArg(0);
@@ -269,7 +269,7 @@ __global__ void computeChiSquare(Batches batches)
    }
 }
 
-__global__ void computeDstD0BG(Batches batches)
+__rooglobal__ void computeDstD0BG(Batches batches)
 {
    Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4], normVal = batches[5];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -286,14 +286,14 @@ __global__ void computeDstD0BG(Batches batches)
          batches._output[i] /= normVal[i];
 }
 
-__global__ void computeExponential(Batches batches)
+__rooglobal__ void computeExponential(Batches batches)
 {
    Batch x = batches[0], c = batches[1], normVal = batches[2];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = fast_exp(x[i] * c[i]) / normVal[i];
 }
 
-__global__ void computeGamma(Batches batches)
+__rooglobal__ void computeGamma(Batches batches)
 {
    Batch X = batches[0], G = batches[1], B = batches[2], M = batches[3], normVal = batches[4];
    double gamma = -std::lgamma(G[0]);
@@ -320,7 +320,7 @@ __global__ void computeGamma(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__global__ void computeGaussian(Batches batches)
+__rooglobal__ void computeGaussian(Batches batches)
 {
    auto x = batches[0], mean = batches[1], sigma = batches[2], normVal = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -330,7 +330,7 @@ __global__ void computeGaussian(Batches batches)
    }
 }
 
-__global__ void computeNegativeLogarithms(Batches batches)
+__rooglobal__ void computeNegativeLogarithms(Batches batches)
 {
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = -fast_log(batches[0][i]);
@@ -340,7 +340,7 @@ __global__ void computeNegativeLogarithms(Batches batches)
          batches._output[i] *= batches[1][i];
 }
 
-__global__ void computeJohnson(Batches batches)
+__rooglobal__ void computeJohnson(Batches batches)
 {
    Batch mass = batches[0], mu = batches[1], lambda = batches[2], gamma = batches[3], delta = batches[4],
          normVal = batches[5];
@@ -367,7 +367,7 @@ __global__ void computeJohnson(Batches batches)
  * Code copied from function landau_pdf (math/mathcore/src/PdfFuncMathCore.cxx)
  * and rewritten to enable vectorization.
  */
-__global__ void computeLandau(Batches batches)
+__rooglobal__ void computeLandau(Batches batches)
 {
    auto case0 = [](double x) {
       const double a1[3] = {0.04166666667, -0.01996527778, 0.02709538966};
@@ -449,7 +449,7 @@ __global__ void computeLandau(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__global__ void computeLognormal(Batches batches)
+__rooglobal__ void computeLognormal(Batches batches)
 {
    Batch X = batches[0], M0 = batches[1], K = batches[2], normVal = batches[3];
    const double rootOf2pi = 2.506628274631000502415765284811;
@@ -472,7 +472,7 @@ __global__ void computeLognormal(Batches batches)
  * ln is the logarithm that was solely present in the initial
  * formula, that is before the asinh replacement
  */
-__global__ void computeNovosibirsk(Batches batches)
+__rooglobal__ void computeNovosibirsk(Batches batches)
 {
    Batch X = batches[0], P = batches[1], W = batches[2], T = batches[3], normVal = batches[4];
    constexpr double xi = 2.3548200450309494; // 2 Sqrt( Ln(4) )
@@ -493,7 +493,7 @@ __global__ void computeNovosibirsk(Batches batches)
       batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
 }
 
-__global__ void computePoisson(Batches batches)
+__rooglobal__ void computePoisson(Batches batches)
 {
    Batch x = batches[0], mean = batches[1], normVal = batches[2];
    bool protectNegative = batches.extraArg(0);
@@ -523,7 +523,7 @@ __global__ void computePoisson(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__global__ void computePolynomial(Batches batches)
+__rooglobal__ void computePolynomial(Batches batches)
 {
    Batch X = batches[0], normVal = batches[1];
    const int nCoef = batches.getNExtraArgs() - 1;
@@ -568,7 +568,7 @@ finale:
       batches._output[i] /= normVal[i];
 }
 
-__global__ void computeProdPdf(Batches batches)
+__rooglobal__ void computeProdPdf(Batches batches)
 {
    const int nPdfs = batches.extraArg(0);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
@@ -578,7 +578,7 @@ __global__ void computeProdPdf(Batches batches)
          batches._output[i] *= batches[pdf][i];
 }
 
-__global__ void computeVoigtian(Batches batches)
+__rooglobal__ void computeVoigtian(Batches batches)
 {
    Batch X = batches[0], M = batches[1], W = batches[2], S = batches[3], normVal = batches[4];
    const double invSqrt2 = 0.707106781186547524400844362105;

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -19,6 +19,7 @@ This file contains the code for cpu computations using the RooBatchCompute libra
 **/
 
 #include "RooBatchCompute.h"
+#include "RunContext.h"
 #include "RooVDTHeaders.h"
 #include "Batches.h"
 

--- a/roofit/batchcompute/src/RooMath.cxx
+++ b/roofit/batchcompute/src/RooMath.cxx
@@ -28,7 +28,7 @@
 #include <iostream>
 
 namespace faddeeva_impl {
-__device__ __host__ static inline void cexp(double& re, double& im)
+__roodevice__ __roohost__ static inline void cexp(double& re, double& im)
     {
 	// with gcc on unix machines and on x86_64, we can gain by hand-coding
 	// exp(z) for the x87 coprocessor; other platforms have the default
@@ -111,7 +111,7 @@ __device__ __host__ static inline void cexp(double& re, double& im)
     }
 
     template <class T, unsigned N, unsigned NTAYLOR, unsigned NCF>
-__device__ __host__ static inline std::complex<T> faddeeva_smabmq_impl(
+__roodevice__ __roohost__ static inline std::complex<T> faddeeva_smabmq_impl(
 	    T zre, T zim, const T tm,
 	    const T (&a)[N], const T (&npi)[N],
 	    const T (&taylorarr)[N * NTAYLOR * 2])
@@ -281,7 +281,7 @@ __device__ __host__ static inline std::complex<T> faddeeva_smabmq_impl(
 	}
     }
 
-__device__ static const double npi24[24] = { // precomputed values n * pi
+__roodevice__ static const double npi24[24] = { // precomputed values n * pi
 	0.00000000000000000e+00, 3.14159265358979324e+00, 6.28318530717958648e+00,
 	9.42477796076937972e+00, 1.25663706143591730e+01, 1.57079632679489662e+01,
 	1.88495559215387594e+01, 2.19911485751285527e+01, 2.51327412287183459e+01,
@@ -291,7 +291,7 @@ __device__ static const double npi24[24] = { // precomputed values n * pi
 	5.65486677646162783e+01, 5.96902604182060715e+01, 6.28318530717958648e+01,
 	6.59734457253856580e+01, 6.91150383789754512e+01, 7.22566310325652445e+01,
     };
-__device__ static const double a24[24] = { // precomputed Fourier coefficient prefactors
+__roodevice__ static const double a24[24] = { // precomputed Fourier coefficient prefactors
 	2.95408975150919338e-01, 2.75840233292177084e-01, 2.24573955224615866e-01,
 	1.59414938273911723e-01, 9.86657664154541891e-02, 5.32441407876394120e-02,
 	2.50521500053936484e-02, 1.02774656705395362e-02, 3.67616433284484706e-03,
@@ -301,7 +301,7 @@ __device__ static const double a24[24] = { // precomputed Fourier coefficient pr
 	6.70217160600200763e-11, 5.30726516347079017e-12, 3.66432411346763916e-13,
 	2.20589494494103134e-14, 1.15782686262855879e-15, 5.29871142946730482e-17,
     };
-__device__ static const double taylorarr24[24 * 12] = {
+__roodevice__ static const double taylorarr24[24 * 12] = {
 	// real part imaginary part, low order coefficients last
 	// nsing = 0
 	 0.00000000000000000e-00,  3.00901111225470020e-01,
@@ -534,7 +534,7 @@ __device__ static const double taylorarr24[24 * 12] = {
     };
 }
 
-__device__ __host__ std::complex<double> RooMath::faddeeva(std::complex<double> z)
+__roodevice__ __roohost__ std::complex<double> RooMath::faddeeva(std::complex<double> z)
 {
     return faddeeva_impl::faddeeva_smabmq_impl<double, 24, 6, 9>(
 	    z.real(), z.imag(), 12., faddeeva_impl::a24,

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -23,7 +23,7 @@
 #include "RooArgList.h"
 #include "RooGlobalFunc.h"
 #include "RooSpan.h"
-#include "RooBatchCompute.h"
+#include "RooBatchComputeTypes.h"
 
 class RooArgList ;
 class RooDataSet ;

--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -20,16 +20,13 @@
 #include "RooArgList.h"
 #include "RooArgSet.h"
 
-#include "RooBatchCompute.h"
+#include "RooBatchComputeTypes.h"
 #include "TFormula.h"
 
 #include <memory>
 #include <vector>
 #include <string>
 
-namespace RooBatchCompute {
-  struct RunContext;
-}
 class RooAbsReal;
 
 class RooFormula : public TNamed, public RooPrintable {

--- a/roofit/roofitcore/res/RooFit/Detail/Buffers.h
+++ b/roofit/roofitcore/res/RooFit/Detail/Buffers.h
@@ -13,7 +13,7 @@
 #ifndef RooFit_Detail_Buffers_h
 #define RooFit_Detail_Buffers_h
 
-#include "RooBatchCompute.h"
+#include <RooBatchComputeTypes.h>
 
 #include <memory>
 

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -18,7 +18,7 @@
 #include "RooAbsReal.h"
 #include "RooTemplateProxy.h"
 
-#include "RooBatchCompute.h"
+#include "RooBatchComputeTypes.h"
 
 namespace ROOT {
 namespace Experimental {
@@ -59,8 +59,6 @@ protected:
    double getValV(const RooArgSet *normalisationSet = nullptr) const override;
 
    double evaluate() const override;
-
-   RooSpan<double> evaluateSpan(RooBatchCompute::RunContext &evalData, const RooArgSet *normSet) const override;
 
    RooSpan<const double>
    getValues(RooBatchCompute::RunContext &evalData, const RooArgSet *normSet = nullptr) const override;

--- a/roofit/roofitcore/src/Buffers.cxx
+++ b/roofit/roofitcore/src/Buffers.cxx
@@ -10,8 +10,11 @@
  * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
  */
 
-#include "RooFit/Detail/Buffers.h"
+#include <RooFit/Detail/Buffers.h>
 
+#include <RooBatchCompute.h>
+
+#include <functional>
 #include <queue>
 #include <unordered_map>
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -174,6 +174,7 @@ called for each data event.
 #include "RooDerivative.h"
 #include "RooFit/BatchModeHelpers.h"
 #include "RooVDTHeaders.h"
+#include "RunContext.h"
 
 #include "ROOT/StringUtils.hxx"
 #include "TClass.h"

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -211,11 +211,6 @@ double RooNLLVarNew::evaluate() const
    throw std::runtime_error("RooNLLVarNew::evaluate was called directly which should not happen!");
 }
 
-RooSpan<double> RooNLLVarNew::evaluateSpan(RooBatchCompute::RunContext &, const RooArgSet *) const
-{
-   throw std::runtime_error("RooNLLVarNew::evaluatSpan was called directly which should not happen!");
-}
-
 RooSpan<const double> RooNLLVarNew::getValues(RooBatchCompute::RunContext &, const RooArgSet *) const
 {
    throw std::runtime_error("RooNLLVarNew::getValues was called directly which should not happen!");


### PR DESCRIPTION
The changes in this commit achieve two things:

1. Reduce set of indirectly included headers in other RooFit libraries
   by including new `RooBatchComputeTypes.h` instead of
   `RooBatchCompute.h` if only the typedefs in the RooBatchCompute
   namespace are used.

2. Make sure that no dummy definitions of `__device__` or `__host__` in
   case no NVidia compiler is used can leak to user code via
   `roobatchcompute` header files.
