### PR TITLE
In FirstParse, text size was wrong.

### DIFF
--- a/core/base/inc/TAttText.h
+++ b/core/base/inc/TAttText.h
@@ -34,6 +34,7 @@ public:
    virtual Color_t  GetTextColor() const {return fTextColor;} ///< Return the text color
    virtual Font_t   GetTextFont()  const {return fTextFont;}  ///< Return the text font
    virtual Float_t  GetTextSize()  const {return fTextSize;}  ///< Return the text size
+   virtual Float_t  GetTextSizePercent(Float_t size);         ///< Return the text in percent of the pad size
    virtual void     Modify();
    virtual void     ResetAttText(Option_t *toption="");
    virtual void     SaveTextAttributes(std::ostream &out, const char *name, Int_t alidef=12, Float_t angdef=0, Int_t coldef=1, Int_t fondef=61, Float_t sizdef=1);
@@ -44,7 +45,7 @@ public:
    virtual void     SetTextColorAlpha(Color_t tcolor, Float_t talpha);
    virtual void     SetTextFont(Font_t tfont=62) { fTextFont = tfont;}     ///< Set the text font
    virtual void     SetTextSize(Float_t tsize=1) { fTextSize = tsize;}     ///< Set the text size
-   virtual void     SetTextSizePixels(Int_t npixels);
+   virtual void     SetTextSizePixels(Int_t npixels);                      ///< Set the text size in pixel
 
    ClassDef(TAttText,2)  //Text attributes
 };

--- a/core/base/src/TAttText.cxx
+++ b/core/base/src/TAttText.cxx
@@ -307,6 +307,29 @@ void TAttText::Copy(TAttText &atttext) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Return the text in percent of the pad size.
+///
+/// If the font precision is greater than 2, the text size returned is the size in pixel
+/// converted into percent of the pad size, otherwise the size returned is the same as the
+/// size given as input parameter.
+
+Float_t TAttText::GetTextSizePercent(Float_t size)
+{
+   Float_t rsize = size;
+   if (fTextFont%10 > 2 && gPad) {
+      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
+                            gPad->XtoAbsPixel(gPad->GetX1()));
+      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
+                            gPad->YtoAbsPixel(gPad->GetY1()));
+      if (w < h)
+         rsize = rsize/w;
+      else
+         rsize = rsize/h;
+   }
+   return rsize;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Change current text attributes if necessary.
 
 void TAttText::Modify()

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -2539,7 +2539,8 @@ Double_t TLatex::GetHeight() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return size of the formula along X in pad coordinates
+/// Return size of the formula along X in pad coordinates when the text precision
+/// is smaller than 3.
 
 Double_t TLatex::GetXsize()
 {
@@ -2626,7 +2627,8 @@ void TLatex::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return size of the formula along Y in pad coordinates
+/// Return size of the formula along Y in pad coordinates when the text precision
+/// is smaller than 3.
 
 Double_t TLatex::GetYsize()
 {

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -2204,14 +2204,7 @@ Int_t TLatex::PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size,
    Double_t saveSize = size;
    Int_t saveFont = fTextFont;
    if (fTextFont%10 > 2) {
-      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
-                            gPad->XtoAbsPixel(gPad->GetX1()));
-      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
-                            gPad->YtoAbsPixel(gPad->GetY1()));
-      if (w < h)
-         size = size/w;
-      else
-         size = size/h;
+      size = GetTextSizePercent(size);
       SetTextFont(10*(saveFont/10) + 2);
    }
 
@@ -2496,18 +2489,7 @@ TLatex::TLatexFormSize TLatex::FirstParse(Double_t angle, Double_t size, const C
 
    TextSpec_t spec;
    spec.fAngle = angle;
-   if (fTextFont%10 == 3) {
-      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
-                            gPad->XtoAbsPixel(gPad->GetX1()));
-      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
-                            gPad->YtoAbsPixel(gPad->GetY1()));
-      if (w < h)
-         spec.fSize = size/w;
-      else
-         spec.fSize = size/h;
-   } else {
-      spec.fSize  = size;
-   }
+   spec.fSize  = GetTextSizePercent(size);
    spec.fColor = GetTextColor();
    spec.fFont  = GetTextFont();
    Short_t halign = fTextAlign/10;

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -2497,9 +2497,14 @@ TLatex::TLatexFormSize TLatex::FirstParse(Double_t angle, Double_t size, const C
    TextSpec_t spec;
    spec.fAngle = angle;
    if (fTextFont%10 == 3) {
-      Double_t hw = TMath::Max((Double_t)gPad->XtoPixel(gPad->GetX2()),
-                               (Double_t)gPad->YtoPixel(gPad->GetY1()));
-      spec.fSize = size/hw;
+      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
+                            gPad->XtoAbsPixel(gPad->GetX1()));
+      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
+                            gPad->YtoAbsPixel(gPad->GetY1()));
+      if (w < h)
+         spec.fSize = size/w;
+      else
+         spec.fSize = size/h;
    } else {
       spec.fSize  = size;
    }

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -494,18 +494,7 @@ void TMathText::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t /*angle*/)
    Double_t y0;
    Double_t x1;
    Double_t y1;
-
-   Double_t size = GetTextSize();
-   if (fTextFont%10 == 3) {
-      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
-                            gPad->XtoAbsPixel(gPad->GetX1()));
-      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
-                            gPad->YtoAbsPixel(gPad->GetY1()));
-      if (w < h)
-         size = size/w;
-      else
-         size = size/h;
-   }
+   Double_t size = GetTextSizePercent(GetTextSize());
 
    GetSize(x0, y0, x1, y1, size, 0, text, length);
    w = (UInt_t)(TMath::Abs(gPad->XtoAbsPixel(x1) - gPad->XtoAbsPixel(x0)));

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -489,12 +489,23 @@ void TMathText::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t /*angle*/)
    const TString newText = GetTitle();
    const Int_t length = newText.Length();
    const Char_t *text = newText.Data();
-   const Double_t size = GetTextSize();
 
    Double_t x0;
    Double_t y0;
    Double_t x1;
    Double_t y1;
+
+   Double_t size = GetTextSize();
+   if (fTextFont%10 == 3) {
+      UInt_t w = TMath::Abs(gPad->XtoAbsPixel(gPad->GetX2()) -
+                            gPad->XtoAbsPixel(gPad->GetX1()));
+      UInt_t h = TMath::Abs(gPad->YtoAbsPixel(gPad->GetY2()) -
+                            gPad->YtoAbsPixel(gPad->GetY1()));
+      if (w < h)
+         size = size/w;
+      else
+         size = size/h;
+   }
 
    GetSize(x0, y0, x1, y1, size, 0, text, length);
    w = (UInt_t)(TMath::Abs(gPad->XtoAbsPixel(x1) - gPad->XtoAbsPixel(x0)));


### PR DESCRIPTION
The text size computed in TLatex:: FirstParse was not correct in case th text precision was 3. This was found in this forum post.

Fix https://root-forum.cern.ch/t/root-ttext-tlatex-size-bug-with-precision-3-fonts/48063/7

