### PR TITLE
[RF] Enable dirty flag propagation in `RooAbsReal::computeBatch` and speed up RooFitDriver by getting output sizes of nodes only once

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -242,7 +242,7 @@ public:
     return getNorm(&nset) ; 
   }
   virtual Double_t getNorm(const RooArgSet* set=0) const ;
-  inline const RooAbsReal* getIntegral(RooArgSet const& set) const {
+  inline RooAbsReal* getIntegral(RooArgSet const& set) const {
     syncNormalization(&set,true) ;
     getVal(set);
     assert(_norm != nullptr);

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -167,6 +167,7 @@ private:
       bool computeInScalarMode = false;
       bool computeInGPU = false;
       bool copyAfterEvaluation = false;
+      std::size_t outputSize = 1;
       ~NodeInfo()
       {
          if (event)
@@ -179,7 +180,6 @@ private:
    };
    void updateMyClients(const RooAbsArg *node);
    void updateMyServers(const RooAbsArg *node);
-   std::size_t getInputSize(RooAbsArg const &arg) const;
    void handleIntegral(const RooAbsArg *node);
    std::pair<std::chrono::microseconds, std::chrono::microseconds> memcpyBenchmark();
    std::chrono::microseconds simulateFit(std::chrono::microseconds h2dTime, std::chrono::microseconds d2hTime,
@@ -196,6 +196,8 @@ private:
          _changeOperModeRAIIs.emplace(arg, opMode);
       }
    }
+
+   void determineOutputSizes(RooArgSet const &serverSet);
 
    std::string _name;
    std::string _title;

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -56,12 +56,7 @@ protected:
    bool _isExtended;
    std::unique_ptr<RooTemplateProxy<RooAbsReal>> _rangeNormTerm;
 
-   double getValV(const RooArgSet *normalisationSet = nullptr) const override;
-
    double evaluate() const override;
-
-   RooSpan<const double>
-   getValues(RooBatchCompute::RunContext &evalData, const RooArgSet *normSet = nullptr) const override;
 
 }; // end class RooNLLVar
 

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4900,6 +4900,7 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
     RooSpan<const double> batch;
     double oldValue;
     RooAbsArg::OperMode oldOperMode;
+    bool hasOtherValueClients;
   };
   std::vector<ServerData> ourServers;
   std::size_t dataSize = 1;
@@ -4908,11 +4909,16 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
     if (server->isValueServer(*this)) {
       // maybe we are still missing inhibit dirty here
       auto oldOperMode = server->operMode();
-      server->setOperMode(RooAbsArg::AClean);
+      bool hasOtherValueClients = server->valueClients().size() > 1;
+      // See note at the bottom of this function to learn why we can only set
+      // the operation mode to "always clean" if there are no other value
+      // clients.
+      server->setOperMode(hasOtherValueClients ? RooAbsArg::Auto : RooAbsArg::AClean);
       ourServers.push_back({server,
           dataMap[server],
           dynamic_cast<RooAbsCategory const*>(server) ? static_cast<RooAbsCategory const*>(server)->getCurrentIndex() : static_cast<RooAbsReal const*>(server)->_value,
-          oldOperMode});
+          oldOperMode,
+          hasOtherValueClients});
       // Prevent the server from evaluating; just return cached result, which we will side load:
       dataSize = std::max(dataSize, ourServers.back().batch.size());
     }
@@ -4947,7 +4953,27 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
 
   for (std::size_t i=0; i < nEvents; ++i) {
     for (auto& serv : ourServers) {
-      serv.server->setCachedValue(serv.batch[std::min(i, serv.batch.size()-1)], /*notifyClients=*/ false);
+      // When we set the cached Value, we must be careful with the false
+      // conclusion that notifying the clients is not necessary even if we will
+      // forcibly call `evaluate()` a few lines below anyway! There are classes
+      // like the `RooAbsAnaConvPdf` that have an internal computation graph,
+      // and if we don't notify the clients these internal nodes don't get
+      // re-evaluated. Therefore, not notifying the clients is only safe if
+      // there are no other clients not evaluated in batch mode. One might
+      // thing that notifying the clients is expensive because the notification
+      // will recurse up through all the computation graph, but for this reason
+      // the RooFitDriver sets the operation mode of all nodes it evaluates to
+      // `ADirty` such that the propagation of the dirty flag is prevented.
+      //
+      // Possible optimization here: right now, we check if there are other
+      // clients besides us as a heuristic to tell if there are no other
+      // clients not evaluated in batch mode. The assumption that all other
+      // clients are not evaluated by the RooFitDriver is of course wrong. The
+      // computation graph can be analyzed more thoroughly to only enable the
+      // client notification is this case. This will require some interface
+      // extension of the RooFit batch mode functions, so it's only worth to
+      // implement it if this client notification turns out to be a bottleneck.
+      serv.server->setCachedValue(serv.batch[std::min(i, serv.batch.size()-1)], /*notifyClients=*/ serv.hasOtherValueClients);
     }
 
     output[i] = evaluate();

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -26,23 +26,22 @@ An instance of this class is created every time RooAbsPdf::fitTo() is called
 and gets destroyed when the fitting ends.
 **/
 
-#include "RooFitDriver.h"
-#include "RooAbsCategory.h"
-#include "RooAbsData.h"
-#include "RooAbsReal.h"
-#include "RooAbsPdf.h"
-#include "RooArgList.h"
-#include "RooBatchCompute.h"
-#include "RooMsgService.h"
-#include "RooRealVar.h"
-#include "RunContext.h"
-#include "RooDataSet.h"
-#include "RooSimultaneous.h"
-#include "RooNLLVarNew.h"
+#include <RooFitDriver.h>
 
-#include "RooBatchCompute.h"
+#include <RooAbsCategory.h>
+#include <RooAbsData.h>
+#include <RooAbsReal.h>
+#include <RooAbsPdf.h>
+#include <RooArgList.h>
+#include <RooBatchCompute.h>
+#include <RooDataSet.h>
+#include <RooMsgService.h>
+#include <RooNLLVarNew.h>
+#include <RooRealVar.h>
+#include <RooSimultaneous.h>
+#include <RunContext.h>
 
-#include "ROOT/StringUtils.hxx"
+#include <ROOT/StringUtils.hxx>
 
 #include <iomanip>
 #include <numeric>
@@ -52,18 +51,6 @@ namespace ROOT {
 namespace Experimental {
 
 using namespace Detail;
-
-namespace {
-
-bool absArgNeedsComputation(RooAbsArg const *arg)
-{
-   auto nodeAbsReal = dynamic_cast<RooAbsReal const *>(arg);
-   auto nodeAbsCategory = dynamic_cast<RooAbsCategory const *>(arg);
-   return nodeAbsReal || nodeAbsCategory;
-}
-
-} // namespace
-
 using namespace std::chrono;
 
 RooFitDriver::Dataset::Dataset(RooAbsData const &data, RooArgSet const &observables, std::string_view rangeName)
@@ -243,34 +230,45 @@ RooFitDriver::RooFitDriver(const RooAbsData &data, const RooAbsReal &topNode, Ro
       }
    }
 
-   for (RooAbsArg *arg : serverSet) {
+   for (std::size_t iNode = serverSet.size(); iNode > 0; --iNode) {
+      RooAbsArg *arg = serverSet[iNode - 1];
 
-      // We don't need dirty flag propagation for nodes evaluated by the
-      // RooFitDriver, because the driver takes care of deciding which node
-      // needs to be re-evaluated.
-      setOperMode(arg, RooAbsArg::ADirty);
+      auto &argInfo = _nodeInfos[arg];
+      if (_dataset.contains(arg)) {
+         _dataMapCPU[arg] = _dataset.span(arg);
+         argInfo.outputSize = _dataset.span(arg).size();
+      }
 
-      if (absArgNeedsComputation(arg)) {
-         if (_dataset.contains(arg)) {
-            _dataMapCPU[arg] = _dataset.span(arg);
-         }
+      for (auto *client : arg->clients()) {
+         // we use containsInstance instead of find to match by pointer and not name
+         if (!serverSet.containsInstance(*client))
+            continue;
 
-         // If the node doesn't depend on any observables, there is no need to
-         // loop over events and we don't need to use the batched evaluation.
-         RooArgSet observablesForNode;
-         arg->getObservables(data.get(), observablesForNode);
-         _nodeInfos[arg].computeInScalarMode = observablesForNode.empty() || !arg->isDerived();
+         auto &clientInfo = _nodeInfos[client];
 
-         for (auto *client : arg->clients()) {
-            // we use containsInstance instead of find to match by pointer and not name
-            if (!serverSet.containsInstance(*client))
-               continue;
-
-            ++_nodeInfos[client].nServers;
-            ++_nodeInfos[arg].nClients;
-         }
+         ++clientInfo.nServers;
+         ++argInfo.nClients;
       }
    }
+
+   determineOutputSizes(serverSet);
+
+   for (auto *arg : serverSet) {
+      auto& info = _nodeInfos[arg];
+
+      // If the node evaluation doesn't involve a loop over entries, we can
+      // always use the scalar mode.
+      info.computeInScalarMode = info.outputSize == 1 && !arg->isReducerNode();
+
+      // We don't need dirty flag propagation for nodes evaluated in batch
+      // mode, because the driver takes care of deciding which node needs to be
+      // re-evaluated. However, dirty flag propagation must be kept for reducer
+      // nodes, because their clients are evaluated in scalar mode.
+      if(!info.computeInScalarMode && !arg->isReducerNode()) {
+         setOperMode(arg, RooAbsArg::ADirty);
+      }
+   }
+
 
    // Extra steps for initializing in cuda mode
    if (_batchMode != RooFit::BatchModeOption::Cuda)
@@ -328,22 +326,16 @@ void RooFitDriver::computeCPUNode(const RooAbsArg *node, NodeInfo &info)
    auto nodeAbsCategory = dynamic_cast<RooAbsCategory const *>(node);
    assert(nodeAbsReal || nodeAbsCategory);
 
-   const std::size_t nOut = getInputSize(*node);
+   const std::size_t nOut = info.outputSize;
 
-   if (nOut == 1) {
+   if (info.computeInScalarMode) {
       // compute in scalar mode
-
-      // If a node is evaluated in scalar mode, we need the dirty flag propagation.
-      if (_getValInvocations == 1)
-         setOperMode(const_cast<RooAbsArg *>(node), RooAbsArg::Auto);
-
       _nonDerivedValues.push_back(nodeAbsCategory ? nodeAbsCategory->getIndex() : nodeAbsReal->getVal(&_normSet));
-
       _dataMapCPU[node] = _dataMapCUDA[node] = RooSpan<const double>(&_nonDerivedValues.back(), nOut);
-   } else if (node->isReducerNode()) {
+   } else if (nOut == 1) {
       _nonDerivedValues.push_back(0.0);
-      _dataMapCPU[node] = _dataMapCUDA[node] = RooSpan<const double>(&_nonDerivedValues.back(), 1);
-      nodeAbsReal->computeBatch(nullptr, &_nonDerivedValues.back(), 1, _dataMapCPU);
+      _dataMapCPU[node] = _dataMapCUDA[node] = RooSpan<const double>(&_nonDerivedValues.back(), nOut);
+      nodeAbsReal->computeBatch(nullptr, &_nonDerivedValues.back(), nOut, _dataMapCPU);
    } else {
       handleIntegral(node);
       info.buffer = info.copyAfterEvaluation ? makePinnedBuffer(nOut, info.stream) : makeCpuBuffer(nOut);
@@ -370,11 +362,9 @@ void RooFitDriver::computeCPUNode(const RooAbsArg *node, NodeInfo &info)
 /// Returns the value of the top node in the computation graph
 double RooFitDriver::getVal()
 {
-   ++_getValInvocations;
-
    // In a cuda fit, use first 3 fits to determine the execution times
    // and the hardware that computes each part of the graph
-   if (_batchMode == RooFit::BatchModeOption::Cuda && _getValInvocations <= 3)
+   if (_batchMode == RooFit::BatchModeOption::Cuda && ++_getValInvocations <= 3)
       markGPUNodes();
 
    for (auto &item : _nodeInfos) {
@@ -434,21 +424,6 @@ double RooFitDriver::getVal()
    return _dataMapCPU.at(&_topNode)[0];
 }
 
-std::size_t RooFitDriver::getInputSize(RooAbsArg const &arg) const
-{
-   RooArgSet valueServers;
-   arg.treeNodeServerList(&valueServers, nullptr, true, true, true);
-   std::size_t inputSize = 1;
-   for (auto *server : valueServers) {
-      if (_dataMapCUDA.find(server) != _dataMapCUDA.end()) {
-         inputSize = std::max(inputSize, _dataMapCUDA.at(server).size());
-      } else if (_dataMapCPU.find(server) != _dataMapCPU.end()) {
-         inputSize = std::max(inputSize, _dataMapCPU.at(server).size());
-      }
-   }
-   return inputSize;
-}
-
 /// Handles the computation of the integral of a PDF for normalization purposes,
 /// before the pdf is computed.
 void RooFitDriver::handleIntegral(const RooAbsArg *node)
@@ -457,19 +432,26 @@ void RooFitDriver::handleIntegral(const RooAbsArg *node)
    // For now, we just assume they are scalar and assign them some temporary memory
    if (auto pAbsPdf = dynamic_cast<const RooAbsPdf *>(node)) {
       auto integral = pAbsPdf->getIntegral(_normSet);
-      std::size_t inputSize = getInputSize(*integral);
 
       if (_integralInfos.count(integral) == 0) {
+         auto &info = _integralInfos[integral];
+         for (RooAbsArg *server : integral->servers()) {
+            if (server->isValueServer(*integral)) {
+               info.outputSize = std::max(info.outputSize, _nodeInfos.at(server).outputSize);
+            }
+         }
+
+         if (info.outputSize > 1 && _batchMode == RooFit::BatchModeOption::Cuda) {
+            info.copyAfterEvaluation = true;
+            info.stream = RooBatchCompute::dispatchCUDA->newCudaStream();
+         } else if (info.outputSize == 1) {
+            info.computeInScalarMode = true;
+         }
+
          // We don't need dirty flag propagation for nodes evaluated by the
          // RooFitDriver, because the driver takes care of deciding which node
          // needs to be re-evaluated.
-         setOperMode(integral, RooAbsArg::ADirty);
-
-         auto &info = _integralInfos[integral];
-         if (inputSize > 1 && _batchMode == RooFit::BatchModeOption::Cuda) {
-            info.copyAfterEvaluation = true;
-            info.stream = RooBatchCompute::dispatchCUDA->newCudaStream();
-         }
+         if(!info.computeInScalarMode) setOperMode(integral, RooAbsArg::ADirty);
       }
 
       computeCPUNode(integral, _integralInfos.at(integral));
@@ -483,9 +465,9 @@ void RooFitDriver::assignToGPU(RooAbsArg const *node)
    auto nodeAbsReal = dynamic_cast<RooAbsReal const *>(node);
    assert(nodeAbsReal || dynamic_cast<RooAbsCategory const *>(node));
 
-   const std::size_t nOut = getInputSize(*node);
-
    NodeInfo &info = _nodeInfos.at(node);
+   const std::size_t nOut = info.outputSize;
+
    info.remServers = -1;
    // wait for every server to finish
    for (auto *server : node->servers()) {
@@ -494,27 +476,6 @@ void RooFitDriver::assignToGPU(RooAbsArg const *node)
       const auto &infoServer = _nodeInfos.at(server);
       if (infoServer.event)
          RooBatchCompute::dispatchCUDA->cudaStreamWaitEvent(info.stream, infoServer.event);
-   }
-
-   if (node->isReducerNode()) {
-      _nonDerivedValues.push_back(0.0);
-      double *buffer = &_nonDerivedValues.back();
-      _dataMapCPU[node] = _dataMapCUDA[node] = RooSpan<const double>(buffer, 1);
-      nodeAbsReal->computeBatch(nullptr, buffer, 1, _dataMapCPU);
-
-      // measure launching overhead (add computation time later)
-      if (_getValInvocations == 2) {
-         using namespace std::chrono;
-         RooBatchCompute::dispatchCUDA->cudaEventRecord(info.eventStart, info.stream);
-         auto start = steady_clock::now();
-         nodeAbsReal->computeBatch(info.stream, buffer, 1, _dataMapCUDA);
-         info.cudaTime = duration_cast<microseconds>(steady_clock::now() - start);
-      } else
-         nodeAbsReal->computeBatch(info.stream, buffer, 1, _dataMapCUDA);
-      RooBatchCompute::dispatchCUDA->cudaEventRecord(info.event, info.stream);
-      updateMyClients(node);
-
-      return;
    }
 
    info.buffer = info.copyAfterEvaluation ? makePinnedBuffer(nOut, info.stream) : makeGpuBuffer(nOut);
@@ -762,6 +723,36 @@ void RooFitDriver::markGPUNodes()
             << std::setw(20) << item.first->GetName() << "\t" << item.first << "\t"
             << (item.second.computeInGPU ? "CUDA" : "CPU") << "\t" << item.second.cpuTime.count() << "us\t"
             << item.second.cudaTime.count() << "us\n";
+   }
+}
+
+void RooFitDriver::determineOutputSizes(RooArgSet const &serverSet)
+{
+   std::size_t totalSize = 1;
+   std::size_t prevTotalSize = 0;
+
+   // Usually, the serverSet is sorted by dependency and one or two passes in
+   // reverse order are enough the propagate through all clinet-server
+   // relationships and converge to the correct output sizes. Indeed, this
+   // function takes a negligible fraction of the time of the NLL creation for
+   // large ATLAS Higgs combination models.
+   while (totalSize != prevTotalSize) {
+      prevTotalSize = totalSize;
+      totalSize = 0;
+
+      for (std::size_t iNode = serverSet.size(); iNode > 0; --iNode) {
+         RooAbsArg const *arg = serverSet[iNode - 1];
+         auto &argInfo = _nodeInfos[arg];
+         for (auto *client : arg->valueClients()) {
+            if (serverSet.containsInstance(*client)) {
+               auto &clientInfo = _nodeInfos[client];
+               if (!client->isReducerNode()) {
+                  clientInfo.outputSize = std::max(clientInfo.outputSize, argInfo.outputSize);
+               }
+            }
+         }
+         totalSize += argInfo.outputSize;
+      }
    }
 }
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -198,22 +198,18 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
       nll += _sumCorrectionTerm;
    }
    output[0] = nll;
-}
 
-double RooNLLVarNew::getValV(const RooArgSet *) const
-{
-   // throw std::runtime_error("RooNLLVarNew::getValV was called directly which should not happen!");
-   return 0.0;
+   // Since the output of this node is always of size one, it is possible that it is
+   // evaluated in scalar mode. We need to set the cached value and clear
+   // the dirty flag.
+   const_cast<RooNLLVarNew *>(this)->setCachedValue(nll);
+   const_cast<RooNLLVarNew *>(this)->clearValueDirty();
 }
 
 double RooNLLVarNew::evaluate() const
 {
    throw std::runtime_error("RooNLLVarNew::evaluate was called directly which should not happen!");
-}
-
-RooSpan<const double> RooNLLVarNew::getValues(RooBatchCompute::RunContext &, const RooArgSet *) const
-{
-   throw std::runtime_error("RooNLLVarNew::getValues was called directly which should not happen!");
+   return _value;
 }
 
 void RooNLLVarNew::getParametersHook(const RooArgSet * /*nset*/, RooArgSet *params, Bool_t /*stripDisconnected*/) const


### PR DESCRIPTION
Dirty flag propagation appeared to be unnecessary in the batch mode
because the RooFitDriver manages the evaluation of nodes, but some nodes
have internal computation graphs that rely on the dirty flag
propagation, notably the integrals of a RooAbsAnaConvPdf.

This fixes some stressRooFit tests wit the RooFit batchmode:
```
Test 21 : Conditional use of per-event error p.d.f. F(t|dt)......OK
Test 28 : P.d.f. marginalization through integration.............OK
```

The only tests that still needs to be fixed now is:
```
Test 22 : Full per-event error p.d.f. F(t|dt)G(dt)...............FAILED
```