### PR TITLE
Fix drag and drop on Windows

### DIFF
--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -384,38 +384,6 @@ static Int_t _lookup_string(Event_t * event, char *buf, Int_t buflen)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-inline void SplitLong(Longptr_t ll, Longptr_t & i1, Longptr_t & i2)
-{
-   union {
-      Longptr_t l;
-      Int_t i[2];
-   } conv;
-
-   conv.l    = 0L;
-   conv.i[0] = 0;
-   conv.i[1] = 0;
-
-   conv.l = ll;
-   i1 = conv.i[0];
-   i2 = conv.i[1];
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-inline void AsmLong(Longptr_t i1, Longptr_t i2, Longptr_t & ll)
-{
-   union {
-      Longptr_t l;
-      Int_t i[2];
-   } conv;
-
-   conv.i[0] = (Int_t) i1;
-   conv.i[1] = (Int_t) i2;
-   ll = conv.l;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Make sure the child window is visible.
 
 static BOOL CALLBACK EnumChildProc(HWND hwndChild, LPARAM lParam)
@@ -6032,17 +6000,10 @@ void TGWin32::MapEvent(Event_t & ev, GdkEvent & xev, Bool_t tox)
             xev.client.message_type = (GdkAtom) ev.fHandle;
             xev.client.data_format = ev.fFormat;
             xev.client.data.l[0] = ev.fUser[0];
-            if (sizeof(ev.fUser[0]) > 4) {
-               SplitLong(ev.fUser[1], xev.client.data.l[1],
-                         xev.client.data.l[3]);
-               SplitLong(ev.fUser[2], xev.client.data.l[2],
-                         xev.client.data.l[4]);
-            } else {
-               xev.client.data.l[1] = ev.fUser[1];
-               xev.client.data.l[2] = ev.fUser[2];
-               xev.client.data.l[3] = ev.fUser[3];
-               xev.client.data.l[4] = ev.fUser[4];
-            }
+            xev.client.data.l[1] = ev.fUser[1];
+            xev.client.data.l[2] = ev.fUser[2];
+            xev.client.data.l[3] = ev.fUser[3];
+            xev.client.data.l[4] = ev.fUser[4];
          }
       }
       if (ev.fType == kMotionNotify) {
@@ -6144,17 +6105,10 @@ void TGWin32::MapEvent(Event_t & ev, GdkEvent & xev, Bool_t tox)
          ev.fFormat = 32;
          ev.fHandle = gWM_DELETE_WINDOW;
          ev.fUser[0] = (Longptr_t) gWM_DELETE_WINDOW;
-         if (sizeof(ev.fUser[0]) > 4) {
-            AsmLong(xev.client.data.l[1], xev.client.data.l[3],
-                    ev.fUser[1]);
-            AsmLong(xev.client.data.l[2], xev.client.data.l[4],
-                    ev.fUser[2]);
-         } else {
-            ev.fUser[1] = 0; //xev.client.data.l[1];
-            ev.fUser[2] = 0; //xev.client.data.l[2];
-            ev.fUser[3] = 0; //xev.client.data.l[3];
-            ev.fUser[4] = 0; //xev.client.data.l[4];
-         }
+         ev.fUser[1] = 0; //xev.client.data.l[1];
+         ev.fUser[2] = 0; //xev.client.data.l[2];
+         ev.fUser[3] = 0; //xev.client.data.l[3];
+         ev.fUser[4] = 0; //xev.client.data.l[4];
       }
       if (xev.type == GDK_DESTROY) {
          ev.fType = kDestroyNotify;
@@ -6252,17 +6206,10 @@ void TGWin32::MapEvent(Event_t & ev, GdkEvent & xev, Bool_t tox)
          ev.fHandle = xev.client.message_type;
          ev.fFormat = xev.client.data_format;
          ev.fUser[0] = xev.client.data.l[0];
-         if (sizeof(ev.fUser[0]) > 4) {
-            AsmLong(xev.client.data.l[1], xev.client.data.l[3],
-                    ev.fUser[1]);
-            AsmLong(xev.client.data.l[2], xev.client.data.l[4],
-                    ev.fUser[2]);
-         } else {
-            ev.fUser[1] = xev.client.data.l[1];
-            ev.fUser[2] = xev.client.data.l[2];
-            ev.fUser[3] = xev.client.data.l[3];
-            ev.fUser[4] = xev.client.data.l[4];
-         }
+         ev.fUser[1] = xev.client.data.l[1];
+         ev.fUser[2] = xev.client.data.l[2];
+         ev.fUser[3] = xev.client.data.l[3];
+         ev.fUser[4] = xev.client.data.l[4];
       }
       if (ev.fType == kSelectionClear) {
          ev.fWindow = (Window_t) xev.selection.window;

--- a/gui/gui/src/TGDNDManager.cxx
+++ b/gui/gui/src/TGDNDManager.cxx
@@ -826,7 +826,7 @@ Bool_t TGDNDManager::HandleSelectionRequest(Event_t *event)
       gVirtualX->ChangeProperties(event->fUser[0], event->fUser[3],
                                   event->fUser[2], 8,
                                   (unsigned char *) data, len);
-
+#ifndef R__WIN32
       xevent.fType    = kSelectionNotify;
       xevent.fTime    = event->fTime;
       xevent.fUser[0] = event->fUser[0]; // requestor
@@ -834,7 +834,7 @@ Bool_t TGDNDManager::HandleSelectionRequest(Event_t *event)
       xevent.fUser[2] = event->fUser[2]; // target;
       xevent.fUser[3] = event->fUser[3]; // property;
       gVirtualX->SendEvent(event->fUser[0], &xevent);
-
+#endif
       return kTRUE;
    } else {
       return kFALSE;  // not for us...


### PR DESCRIPTION
Fix the following side effect with the `drag_and_drop.C` tutorial on Windows: When starting to drag an item from the list tree, the item gets copied inside the list tree, like if it was dropped in the folder of the tree.
