### PR TITLE
[jsroot] Several fixes in 6.3.2 version [skip-ci]

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,5 +1,10 @@
 # JSROOT changelog
 
+## Change in 6.3.x
+1. Fix TEfficiency drawing
+2. Provide TPadPainter.divide method 
+
+
 ## Changes in 6.3.2
 1. Fix bug in TH1 drawing when minimum or/and maximum was configured for histogram
 

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -100,11 +100,11 @@
    /** @summary JSROOT version id
      * @desc For the JSROOT release the string in format "major.minor.patch" like "6.3.0"
      * For the ROOT release string is "ROOT major.minor.patch" like "ROOT 6.26.00" */
-   JSROOT.version_id = "6.3.2";
+   JSROOT.version_id = "6.3.x";
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "19/11/2021"*/
-   JSROOT.version_date = "13/12/2021";
+   JSROOT.version_date = "17/12/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.gpad.js
+++ b/js/scripts/JSRoot.gpad.js
@@ -2974,6 +2974,69 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
          return this.drawPrimitives(indx+1);
       });
    }
+   
+   /** @summary Divide pad on subpads
+     * @returns {Promise} when finished
+     * @private */
+   TPadPainter.prototype.divide = function(nx, ny) {
+      if (!ny) {
+         let ndiv = nx;
+         if (ndiv < 2) return Promise.resolve(this); 
+         nx = ny = Math.round(Math.sqrt(ndiv));
+         if (nx*ny < ndiv) nx += 1;
+      }
+      
+      if (nx*ny < 2) return Promise.resolve(this);
+      
+      let xmargin = 0.01, ymargin = 0.01, 
+          dy = 1/ny, dx = 1/nx, n = 0, subpads = [];
+      for (let iy = 0; iy < ny; iy++) {
+         let y2 = 1 - iy*dy - ymargin,
+             y1 = y2 - dy + 2*ymargin;
+         if (y1 < 0) y1 = 0;
+         if (y1 > y2) continue;
+         for (let ix = 0; ix < nx; ix++) {
+            let x1 = ix*dx + xmargin,
+                x2 = x1 +dx -2*xmargin;
+            if (x1 > x2) continue;
+            n++;
+            let pad = JSROOT.create("TPad");
+            pad.fName = pad.fTitle = this.pad.fName + "_" + n;
+            pad.fNumber = n;
+            if (!this.iscan) {
+               pad.fAbsWNDC = (x2-x1) * this.pad.fAbsWNDC;
+               pad.fAbsHNDC = (y2-y1) * this.pad.fAbsHNDC;
+               pad.fAbsXlowNDC = this.pad.fAbsXlowNDC + x1 * this.pad.fAbsWNDC;
+               pad.fAbsYlowNDC = this.pad.fAbsYlowNDC + y1 * this.pad.fAbsWNDC;
+            } else {
+               pad.fAbsWNDC = x2 - x1;
+               pad.fAbsHNDC = y2 - y1;
+               pad.fAbsXlowNDC = x1;
+               pad.fAbsYlowNDC = y1;
+            }
+            
+            subpads.push(pad);
+         }
+      }
+      
+      const drawNext = () => {
+         if (subpads.length == 0) 
+            return Promise.resolve(this);
+         return JSROOT.draw(this.getDom(), subpads.shift()).then(drawNext); 
+      };
+
+      return drawNext();
+   }
+
+   /** @summary Return sub-pads painter, only direct childs are checked
+     * @private */
+   TPadPainter.prototype.getSubPadPainter = function(n) {
+      for (let k = 0; k < this.painters.length; ++k) {
+         let sub = this.painters[k];
+         if (sub.pad && (typeof sub.forEachPainterInPad === 'function') && (sub.pad.fNumber === n)) return sub;
+      }
+      return null;
+   }
 
    /** @summary Process tooltip event in the pad
      * @private */

--- a/js/scripts/JSRoot.more.js
+++ b/js/scripts/JSRoot.more.js
@@ -3309,15 +3309,24 @@ JSROOT.define(['d3', 'painter', 'math', 'gpad'], (d3, jsrp) => {
       let painter = new TEfficiencyPainter(divid, eff);
       painter.options = opt;
 
-      let gr = JSROOT.create('TGraphAsymmErrors');
-      gr.fName = "eff_graph";
-      painter.fillGraph(gr, opt);
-
-      return JSROOT.draw(divid, gr, opt)
-                   .then(() => {
-                       painter.addToPadPrimitives();
-                       return painter;
-                    });
+      return JSROOT.require('math').then(() => {
+         let gr = JSROOT.create('TGraphAsymmErrors');
+         gr.fName = "eff_graph";
+         gr.fTitle = eff.fTitle;
+         gr.fLineColor = eff.fLineColor;
+         gr.fLineStyle = eff.fLineStyle;
+         gr.fLineWidth = eff.fLineWidth;
+         gr.fFillColor = eff.fFillColor;
+         gr.fFillStyle = eff.fFillStyle;
+         gr.fMarkerColor = eff.fMarkerColor;
+         gr.fMarkerStyle = eff.fMarkerStyle;
+         gr.fMarkerSize = eff.fMarkerSize;
+         painter.fillGraph(gr, opt);
+         return JSROOT.draw(divid, gr, opt); 
+      }).then(() => {
+         painter.addToPadPrimitives();
+         return painter;
+      });
    }
 
    // =============================================================


### PR DESCRIPTION
`TEfficiency` fix
Provide `TPadPainter.divide` method

Enables handling of pad divisions like: https://jsroot.gsi.de/dev/api.htm#go4examplesimple_draw_picture 