### PR TITLE
[DF] Upgrades to RBookedDefines in preparation for systematic variations

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -51,7 +51,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/InterfaceUtils.hxx
     ROOT/RDF/RActionBase.hxx
     ROOT/RDF/RAction.hxx
-    ROOT/RDF/RBookedDefines.hxx
+    ROOT/RDF/RColumnRegister.hxx
     ROOT/RDF/RNewSampleNotifier.hxx
     ROOT/RDF/RSampleInfo.hxx
     ROOT/RDF/RDefineBase.hxx
@@ -85,7 +85,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RCutFlowReport.cxx
     src/RDataFrame.cxx
     src/RDFActionHelpers.cxx
-    src/RDFBookedDefines.cxx
+    src/RDFColumnRegister.cxx
     src/RDFDisplay.cxx
     src/RDFGraphUtils.cxx
     src/RDFHistoModels.cxx

--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -41,7 +41,7 @@
 #pragma link C++ class ROOT::Internal::RDF::RRootDS-;
 #pragma link C++ class ROOT::RDF::RCsvDS-;
 #pragma link C++ class ROOT::Internal::RDF::MeanHelper-;
-#pragma link C++ class ROOT::Internal::RDF::RBookedDefines-;
+#pragma link C++ class ROOT::Internal::RDF::RColumnRegister-;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValueBase+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<int>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<unsigned int>+;

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -12,7 +12,7 @@
 #define ROOT_RDF_COLUMNREADERUTILS
 
 #include "RColumnReaderBase.hxx"
-#include "RBookedDefines.hxx"
+#include "RColumnRegister.hxx"
 #include "RDefineBase.hxx"
 #include "RDefineReader.hxx"
 #include "RDSColumnReader.hxx"
@@ -74,7 +74,7 @@ MakeColumnReader(unsigned int slot, RDefineBase *define,
 /// incorrectly from a compiled MakeColumnReaders symbols when invoked from a jitted symbol.
 struct RColumnReadersInfo {
    const std::vector<std::string> &fColNames;
-   const RBookedDefines &fCustomCols;
+   const RColumnRegister &fCustomCols;
    const bool *fIsDefine;
    const std::map<std::string, std::vector<void *>> &fDSValuePtrsMap;
    ROOT::RDF::RDataSource *fDataSource;

--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -34,7 +34,7 @@ class RRangeBase;
 
 namespace Internal {
 namespace RDF {
-class RBookedDefines;
+class RColumnRegister;
 
 namespace GraphDrawing {
 std::shared_ptr<GraphNode>
@@ -47,8 +47,7 @@ std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *
 
 /// Add the Defines that have been added between this node and the previous to the graph.
 /// Return the new "upmost" node, i.e. the last of the Defines added if any, otherwise the node itself
-std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node,
-                                             const RBookedDefines &defines,
+std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRegister &colRegister,
                                              const std::vector<std::string> &prevNodeDefines);
 
 // clang-format off

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -13,7 +13,7 @@
 
 #include <ROOT/RDF/RAction.hxx>
 #include <ROOT/RDF/ActionHelpers.hxx> // for BuildAction
-#include <ROOT/RDF/RBookedDefines.hxx>
+#include <ROOT/RDF/RColumnRegister.hxx>
 #include <ROOT/RDF/RDefine.hxx>
 #include <ROOT/RDF/RDefinePerSample.hxx>
 #include <ROOT/RDF/RFilter.hxx>
@@ -127,106 +127,106 @@ struct HistoUtils<T, false> {
 template <typename... ColTypes, typename ActionTag, typename ActionResultType, typename PrevNodeType>
 std::unique_ptr<RActionBase>
 BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &h, const unsigned int nSlots,
-            std::shared_ptr<PrevNodeType> prevNode, ActionTag, const RBookedDefines &defines)
+            std::shared_ptr<PrevNodeType> prevNode, ActionTag, const RColumnRegister &colRegister)
 {
    using Helper_t = FillParHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
 }
 
 // Histo1D filling (must handle the special case of distinguishing FillParHelper and FillHelper
 template <typename... ColTypes, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<::TH1D> &h,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Histo1D, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<::TH1D> &h, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Histo1D, const RColumnRegister &colRegister)
 {
    auto hasAxisLimits = HistoUtils<::TH1D>::HasAxisLimits(*h);
 
    if (hasAxisLimits) {
       using Helper_t = FillParHelper<::TH1D>;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), defines);
+      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
    } else {
       using Helper_t = FillHelper;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), defines);
+      return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
    }
 }
 
 template <typename... ColTypes, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<TGraph> &g,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Graph, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<TGraph> &g, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Graph, const RColumnRegister &colRegister)
 {
    using Helper_t = FillTGraphHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, std::move(prevNode), colRegister);
 }
 
 // Min action
 template <typename ColType, typename PrevNodeType, typename ActionResultType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &minV,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Min, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &minV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Min, const RColumnRegister &colRegister)
 {
    using Helper_t = MinHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColType>>;
-   return std::make_unique<Action_t>(Helper_t(minV, nSlots), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(minV, nSlots), bl, std::move(prevNode), colRegister);
 }
 
 // Max action
 template <typename ColType, typename PrevNodeType, typename ActionResultType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &maxV,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Max, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &maxV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Max, const RColumnRegister &colRegister)
 {
    using Helper_t = MaxHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColType>>;
-   return std::make_unique<Action_t>(Helper_t(maxV, nSlots), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(maxV, nSlots), bl, std::move(prevNode), colRegister);
 }
 
 // Sum action
 template <typename ColType, typename PrevNodeType, typename ActionResultType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &sumV,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Sum, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &sumV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Sum, const RColumnRegister &colRegister)
 {
    using Helper_t = SumHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColType>>;
-   return std::make_unique<Action_t>(Helper_t(sumV, nSlots), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(sumV, nSlots), bl, std::move(prevNode), colRegister);
 }
 
 // Mean action
 template <typename ColType, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &meanV,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Mean, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &meanV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Mean, const RColumnRegister &colRegister)
 {
    using Helper_t = MeanHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColType>>;
-   return std::make_unique<Action_t>(Helper_t(meanV, nSlots), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(meanV, nSlots), bl, std::move(prevNode), colRegister);
 }
 
 // Standard Deviation action
 template <typename ColType, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &stdDeviationV,
-                                         const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::StdDev, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &stdDeviationV, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::StdDev, const RColumnRegister &colRegister)
 {
    using Helper_t = StdDevHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColType>>;
-   return std::make_unique<Action_t>(Helper_t(stdDeviationV, nSlots), bl, prevNode, defines);
+   return std::make_unique<Action_t>(Helper_t(stdDeviationV, nSlots), bl, prevNode, colRegister);
 }
 
 // Display action
 template <typename... ColTypes, typename PrevNodeType>
 std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<RDisplay> &d,
                                          const unsigned int, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Display, const RDFInternal::RBookedDefines &defines)
+                                         ActionTags::Display, const RDFInternal::RColumnRegister &colRegister)
 {
    using Helper_t = DisplayHelper<PrevNodeType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(d, prevNode), bl, prevNode, defines);
+   return std::make_unique<Action_t>(Helper_t(d, prevNode), bl, prevNode, colRegister);
 }
 
 struct SnapshotHelperArgs {
@@ -242,7 +242,7 @@ template <typename... ColTypes, typename PrevNodeType>
 std::unique_ptr<RActionBase>
 BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperArgs> &snapHelperArgs,
             const unsigned int nSlots, std::shared_ptr<PrevNodeType> prevNode, ActionTags::Snapshot,
-            const RBookedDefines &defines)
+            const RColumnRegister &colRegister)
 {
    const auto &filename = snapHelperArgs->fFileName;
    const auto &dirname = snapHelperArgs->fDirName;
@@ -256,25 +256,25 @@ BuildAction(const ColumnNames_t &colNames, const std::shared_ptr<SnapshotHelperA
       using Helper_t = SnapshotHelper<ColTypes...>;
       using Action_t = RAction<Helper_t, PrevNodeType>;
       actionPtr.reset(new Action_t(Helper_t(filename, dirname, treename, colNames, outputColNames, options), colNames,
-                                   prevNode, defines));
+                                   prevNode, colRegister));
    } else {
       // multi-thread snapshot
       using Helper_t = SnapshotHelperMT<ColTypes...>;
       using Action_t = RAction<Helper_t, PrevNodeType>;
       actionPtr.reset(new Action_t(Helper_t(nSlots, filename, dirname, treename, colNames, outputColNames, options),
-                                   colNames, prevNode, defines));
+                                   colNames, prevNode, colRegister));
    }
    return actionPtr;
 }
 
 // Book with custom helper type
 template <typename... ColTypes, typename PrevNodeType, typename Helper_t>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<Helper_t> &h,
-                                         const unsigned int /*nSlots*/, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Book, const RBookedDefines &defines)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<Helper_t> &h, const unsigned int /*nSlots*/,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Book, const RColumnRegister &colRegister)
 {
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(std::move(*h)), bl, std::move(prevNode), defines);
+   return std::make_unique<Action_t>(Helper_t(std::move(*h)), bl, std::move(prevNode), colRegister);
 }
 
 /****** end BuildAndBook ******/
@@ -306,21 +306,20 @@ std::string PrettyPrintAddr(const void *const addr);
 void BookFilterJit(const std::shared_ptr<RJittedFilter> &jittedFilter, std::shared_ptr<RNodeBase> *prevNodeOnHeap,
                    std::string_view name, std::string_view expression,
                    const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
-                   const RBookedDefines &customCols, TTree *tree, RDataSource *ds);
+                   const RColumnRegister &customCols, TTree *tree, RDataSource *ds);
 
 std::shared_ptr<RJittedDefine> BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm,
-                                                   RDataSource *ds, const RBookedDefines &customCols,
-                                                   const ColumnNames_t &branches,
-                                                   std::shared_ptr<RNodeBase> *prevNodeOnHeap);
+                                             RDataSource *ds, const RColumnRegister &customCols,
+                                             const ColumnNames_t &branches, std::shared_ptr<RNodeBase> *prevNodeOnHeap);
 
 std::shared_ptr<RJittedDefine> BookDefinePerSampleJit(std::string_view name, std::string_view expression,
-                                                      RLoopManager &lm, const RBookedDefines &customCols,
+                                                      RLoopManager &lm, const RColumnRegister &customCols,
                                                       std::shared_ptr<RNodeBase> *upcastNodeOnHeap);
 
 std::string JitBuildAction(const ColumnNames_t &bl, std::shared_ptr<RDFDetail::RNodeBase> *prevNode,
                            const std::type_info &art, const std::type_info &at, void *rOnHeap, TTree *tree,
-                           const unsigned int nSlots, const RBookedDefines &defines,
-                           RDataSource *ds, std::weak_ptr<RJittedAction> *jittedActionOnHeap);
+                           const unsigned int nSlots, const RColumnRegister &colRegister, RDataSource *ds,
+                           std::weak_ptr<RJittedAction> *jittedActionOnHeap);
 
 // Allocate a weak_ptr on the heap, return a pointer to it. The user is responsible for deleting this weak_ptr.
 // This function is meant to be used by RInterface's methods that book code for jitting.
@@ -350,16 +349,16 @@ std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr);
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
                                       const ColumnNames_t &validDefines, RDataSource *ds);
 
-std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, const RBookedDefines &defines,
+std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, const RColumnRegister &colRegister,
                                               TTree *tree, RDataSource *ds, const std::string &context,
                                               bool vector2rvec);
 
 std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, const ColumnNames_t &definedDSCols);
 
 template <typename T>
-void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSource &ds, RBookedDefines &defines)
+void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSource &ds, RColumnRegister &colRegister)
 {
-   if (defines.HasName(colName) || !ds.HasColumn(colName) || lm.HasDSValuePtrs(colName))
+   if (colRegister.HasName(colName) || !ds.HasColumn(colName) || lm.HasDSValuePtrs(colName))
       return;
 
    const auto valuePtrs = ds.GetColumnReaders<T>(colName);
@@ -374,27 +373,27 @@ void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSourc
 /// and return a new map of custom columns (with the new datasource columns added to it)
 template <typename... ColumnTypes>
 void AddDSColumns(const std::vector<std::string> &requiredCols, RLoopManager &lm, RDataSource &ds,
-                  TTraits::TypeList<ColumnTypes...>, RBookedDefines &defines)
+                  TTraits::TypeList<ColumnTypes...>, RColumnRegister &colRegister)
 {
    // hack to expand a template parameter pack without c++17 fold expressions.
    using expander = int[];
    int i = 0;
-   (void)expander{(AddDSColumnsHelper<ColumnTypes>(requiredCols[i], lm, ds, defines), ++i)..., 0};
+   (void)expander{(AddDSColumnsHelper<ColumnTypes>(requiredCols[i], lm, ds, colRegister), ++i)..., 0};
 }
 
 // this function is meant to be called by the jitted code generated by BookFilterJit
 template <typename F, typename PrevNode>
 void JitFilterHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::string_view name,
                      std::weak_ptr<RJittedFilter> *wkJittedFilter, std::shared_ptr<PrevNode> *prevNodeOnHeap,
-                     RBookedDefines *defines) noexcept
+                     RColumnRegister *colRegister) noexcept
 {
    if (wkJittedFilter->expired()) {
       // The branch of the computation graph that needed this jitted code went out of scope between the type
       // jitting was booked and the time jitting actually happened. Nothing to do other than cleaning up.
       delete wkJittedFilter;
-      // defines must be deleted before prevNodeOnHeap because their dtor needs the RLoopManager to be alive
+      // colRegister must be deleted before prevNodeOnHeap because their dtor needs the RLoopManager to be alive
       // and prevNodeOnHeap is what keeps it alive if the rest of the computation graph is already out of scope
-      delete defines;
+      delete colRegister;
       delete prevNodeOnHeap;
       return;
    }
@@ -415,13 +414,13 @@ void JitFilterHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::str
    auto ds = lm.GetDataSource();
 
    if (ds != nullptr)
-      AddDSColumns(cols, lm, *ds, ColTypes_t(), *defines);
+      AddDSColumns(cols, lm, *ds, ColTypes_t(), *colRegister);
 
    jittedFilter->SetFilter(
-      std::unique_ptr<RFilterBase>(new F_t(std::forward<F>(f), cols, *prevNodeOnHeap, *defines, name)));
-   // defines points to the columns structure in the heap, created before the jitted call so that the jitter can
+      std::unique_ptr<RFilterBase>(new F_t(std::forward<F>(f), cols, *prevNodeOnHeap, *colRegister, name)));
+   // colRegister points to the columns structure in the heap, created before the jitted call so that the jitter can
    // share data after it has lazily compiled the code. Here the data has been used and the memory can be freed.
-   delete defines;
+   delete colRegister;
    delete prevNodeOnHeap;
    delete wkJittedFilter;
 }
@@ -433,15 +432,15 @@ struct RDefinePerSampleTag {};
 
 template <typename F>
 auto MakeDefineNode(DefineTypes::RDefineTag, std::string_view name, std::string_view dummyType, F &&f,
-                    const ColumnNames_t &cols, RBookedDefines &defines, RLoopManager &lm)
+                    const ColumnNames_t &cols, RColumnRegister &colRegister, RLoopManager &lm)
 {
-   return std::unique_ptr<RDefineBase>(
-      new RDefine<std::decay_t<F>, CustomColExtraArgs::None>(name, dummyType, std::forward<F>(f), cols, defines, lm));
+   return std::unique_ptr<RDefineBase>(new RDefine<std::decay_t<F>, CustomColExtraArgs::None>(
+      name, dummyType, std::forward<F>(f), cols, colRegister, lm));
 }
 
 template <typename F>
 auto MakeDefineNode(DefineTypes::RDefinePerSampleTag, std::string_view name, std::string_view dummyType, F &&f,
-                    const ColumnNames_t &, RBookedDefines &, RLoopManager &lm)
+                    const ColumnNames_t &, RColumnRegister &, RLoopManager &lm)
 {
    return std::unique_ptr<RDefineBase>(
       new RDefinePerSample<std::decay_t<F>>(name, dummyType, std::forward<F>(f), lm));
@@ -452,16 +451,16 @@ auto MakeDefineNode(DefineTypes::RDefinePerSampleTag, std::string_view name, std
 // If colsPtr is null, build a RDefinePerSample (it has no input columns), otherwise a RDefine.
 template <typename RDefineTypeTag, typename F>
 void JitDefineHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::string_view name, RLoopManager *lm,
-                     std::weak_ptr<RJittedDefine> *wkJittedDefine,
-                     RBookedDefines *defines, std::shared_ptr<RNodeBase> *prevNodeOnHeap) noexcept
+                     std::weak_ptr<RJittedDefine> *wkJittedDefine, RColumnRegister *colRegister,
+                     std::shared_ptr<RNodeBase> *prevNodeOnHeap) noexcept
 {
    if (wkJittedDefine->expired()) {
       // The branch of the computation graph that needed this jitted code went out of scope between the type
       // jitting was booked and the time jitting actually happened. Nothing to do other than cleaning up.
       delete wkJittedDefine;
-      // defines must be deleted before prevNodeOnHeap because their dtor needs the RLoopManager to be alive
+      // colRegister must be deleted before prevNodeOnHeap because their dtor needs the RLoopManager to be alive
       // and prevNodeOnHeap is what keeps it alive if the rest of the computation graph is already out of scope
-      delete defines;
+      delete colRegister;
       delete prevNodeOnHeap;
       return;
    }
@@ -476,21 +475,21 @@ void JitDefineHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::str
 
    auto ds = lm->GetDataSource();
    if (ds != nullptr)
-      AddDSColumns(cols, *lm, *ds, ColTypes_t(), *defines);
+      AddDSColumns(cols, *lm, *ds, ColTypes_t(), *colRegister);
 
    // will never actually be used (trumped by jittedDefine->GetTypeName()), but we set it to something meaningful
    // to help devs debugging
    const auto dummyType = "jittedCol_t";
    // use unique_ptr<RDefineBase> instead of make_unique<NewCol_t> to reduce jit/compile-times
    std::unique_ptr<RDefineBase> newCol{
-      MakeDefineNode(RDefineTypeTag{}, name, dummyType, std::forward<F>(f), cols, *defines, *lm)};
+      MakeDefineNode(RDefineTypeTag{}, name, dummyType, std::forward<F>(f), cols, *colRegister, *lm)};
    jittedDefine->SetDefine(std::move(newCol));
 
-   // defines points to the columns structure in the heap, created before the jitted call so that the jitter can
+   // colRegister points to the columns structure in the heap, created before the jitted call so that the jitter can
    // share data after it has lazily compiled the code. Here the data has been used and the memory can be freed.
-   delete defines;
+   delete colRegister;
    // prevNodeOnHeap only serves the purpose of keeping the RLoopManager alive so it can be accessed by
-   // defines' destructor in case the rest of the computation graph is gone. Can be safely deleted here.
+   // colRegister' destructor in case the rest of the computation graph is gone. Can be safely deleted here.
    delete prevNodeOnHeap;
    delete wkJittedDefine;
 }
@@ -499,14 +498,14 @@ void JitDefineHelper(F &&f, const char **colsPtr, std::size_t colsSize, std::str
 template <typename ActionTag, typename... ColTypes, typename PrevNodeType, typename HelperArgType>
 void CallBuildAction(std::shared_ptr<PrevNodeType> *prevNodeOnHeap, const char **colsPtr, std::size_t colsSize,
                      const unsigned int nSlots, std::shared_ptr<HelperArgType> *helperArgOnHeap,
-                     std::weak_ptr<RJittedAction> *wkJittedActionOnHeap, RBookedDefines *defines) noexcept
+                     std::weak_ptr<RJittedAction> *wkJittedActionOnHeap, RColumnRegister *colRegister) noexcept
 {
    if (wkJittedActionOnHeap->expired()) {
       delete helperArgOnHeap;
       delete wkJittedActionOnHeap;
-      // defines must be deleted before prevNodeOnHeap because their dtor needs the RLoopManager to be alive
+      // colRegister must be deleted before prevNodeOnHeap because their dtor needs the RLoopManager to be alive
       // and prevNodeOnHeap is what keeps it alive if the rest of the computation graph is already out of scope
-      delete defines;
+      delete colRegister;
       delete prevNodeOnHeap;
       return;
    }
@@ -523,16 +522,16 @@ void CallBuildAction(std::shared_ptr<PrevNodeType> *prevNodeOnHeap, const char *
    constexpr auto nColumns = ColTypes_t::list_size;
    auto ds = loopManager.GetDataSource();
    if (ds != nullptr)
-      AddDSColumns(cols, loopManager, *ds, ColTypes_t(), *defines);
+      AddDSColumns(cols, loopManager, *ds, ColTypes_t(), *colRegister);
 
-   auto actionPtr =
-      BuildAction<ColTypes...>(cols, std::move(*helperArgOnHeap), nSlots, std::move(prevNodePtr), ActionTag{}, *defines);
+   auto actionPtr = BuildAction<ColTypes...>(cols, std::move(*helperArgOnHeap), nSlots, std::move(prevNodePtr),
+                                             ActionTag{}, *colRegister);
    loopManager.AddSampleCallback(actionPtr->GetSampleCallback());
    jittedActionOnHeap->SetAction(std::move(actionPtr));
 
-   // defines points to the columns structure in the heap, created before the jitted call so that the jitter can
+   // colRegister points to the columns structure in the heap, created before the jitted call so that the jitter can
    // share data after it has lazily compiled the code. Here the data has been used and the memory can be freed.
-   delete defines;
+   delete colRegister;
 
    delete helperArgOnHeap;
    delete prevNodeOnHeap;

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -11,7 +11,7 @@
 #ifndef ROOT_RACTIONBASE
 #define ROOT_RACTIONBASE
 
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t
 #include "RtypesCore.h"
@@ -48,16 +48,16 @@ private:
    bool fHasRun = false;
    const ColumnNames_t fColumnNames;
 
-   RBookedDefines fDefines;
+   RColumnRegister fColRegister;
 
 public:
-   RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const RBookedDefines &defines);
+   RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const RColumnRegister &colRegister);
    RActionBase(const RActionBase &) = delete;
    RActionBase &operator=(const RActionBase &) = delete;
    virtual ~RActionBase();
 
    const ColumnNames_t &GetColumnNames() const { return fColumnNames; }
-   RBookedDefines &GetDefines() { return fDefines; }
+   RColumnRegister &GetColRegister() { return fColRegister; }
    RLoopManager *GetLoopManager() { return fLoopManager; }
    unsigned int GetNSlots() const { return fNSlots; }
    virtual void Run(unsigned int slot, Long64_t entry) = 0;

--- a/tree/dataframe/inc/ROOT/RDF/RBookedDefines.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RBookedDefines.hxx
@@ -11,12 +11,13 @@
 #ifndef ROOT_RDFBOOKEDCUSTOMCOLUMNS
 #define ROOT_RDFBOOKEDCUSTOMCOLUMNS
 
-#include <memory>
-#include <map>
-#include <vector>
-#include <string>
+#include <TString.h>
+
 #include <algorithm>
-#include "TString.h"
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace ROOT {
 namespace Detail {

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -8,8 +8,8 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#ifndef ROOT_RDFBOOKEDCUSTOMCOLUMNS
-#define ROOT_RDFBOOKEDCUSTOMCOLUMNS
+#ifndef ROOT_RDF_RCOLUMNREGISTER
+#define ROOT_RDF_RCOLUMNREGISTER
 
 #include <TString.h>
 
@@ -24,7 +24,7 @@ namespace Detail {
 namespace RDF {
 class RDefineBase;
 }
-}
+} // namespace Detail
 
 namespace Internal {
 namespace RDF {
@@ -32,16 +32,16 @@ namespace RDF {
 namespace RDFDetail = ROOT::Detail::RDF;
 
 /**
- * \class ROOT::Internal::RDF::RBookedDefines
+ * \class ROOT::Internal::RDF::RColumnRegister
  * \ingroup dataframe
  * \brief A binder for user-defined columns and aliases.
  * The storage is copy-on-write and shared between all instances of the class that have the same values.
  */
-class RBookedDefines {
+class RColumnRegister {
    using RDefineBasePtrMap_t = std::map<std::string, std::shared_ptr<RDFDetail::RDefineBase>>;
    using ColumnNames_t = std::vector<std::string>;
 
-   // Since RBookedDefines is meant to be an immutable, copy-on-write object, the actual values are set as const
+   // Since RColumnRegister is meant to be an immutable, copy-on-write object, the actual values are set as const
    using RDefineBasePtrMapPtr_t = std::shared_ptr<const RDefineBasePtrMap_t>;
    using ColumnNamesPtr_t = std::shared_ptr<const ColumnNames_t>;
 
@@ -50,21 +50,20 @@ private:
    /// When a new define is added (through a call to RInterface::Define or similar) a new map with the extra element is
    /// created.
    RDefineBasePtrMapPtr_t fDefines;
-   ColumnNamesPtr_t fColumnNames;  ///< Names of Defines and Aliases registered so far.
+   ColumnNamesPtr_t fColumnNames; ///< Names of Defines and Aliases registered so far.
 
 public:
-   RBookedDefines(const RBookedDefines &) = default;
-   RBookedDefines(RBookedDefines &&) = default;
-   RBookedDefines &operator=(const RBookedDefines &) = default;
+   RColumnRegister(const RColumnRegister &) = default;
+   RColumnRegister(RColumnRegister &&) = default;
+   RColumnRegister &operator=(const RColumnRegister &) = default;
 
-   RBookedDefines(RDefineBasePtrMapPtr_t defines, ColumnNamesPtr_t defineNames)
+   RColumnRegister(RDefineBasePtrMapPtr_t defines, ColumnNamesPtr_t defineNames)
       : fDefines(defines), fColumnNames(defineNames)
    {
    }
 
-   RBookedDefines()
-      : fDefines(std::make_shared<RDefineBasePtrMap_t>()),
-        fColumnNames(std::make_shared<ColumnNames_t>())
+   RColumnRegister()
+      : fDefines(std::make_shared<RDefineBasePtrMap_t>()), fColumnNames(std::make_shared<ColumnNames_t>())
    {
    }
 
@@ -95,7 +94,7 @@ public:
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Empty the contents of this ledger.
-   /// The only allowed operation on a RBookedDefines object after a call to Clear is its destruction.
+   /// The only allowed operation on a RColumnRegister object after a call to Clear is its destruction.
    void Clear();
 };
 
@@ -103,4 +102,4 @@ public:
 } // Namespace Internal
 } // Namespace ROOT
 
-#endif
+#endif // ROOT_RDF_RCOLUMNREGISTER

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -14,7 +14,7 @@
 #include <TString.h>
 
 #include <algorithm>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -38,7 +38,7 @@ namespace RDFDetail = ROOT::Detail::RDF;
  * The storage is copy-on-write and shared between all instances of the class that have the same values.
  */
 class RColumnRegister {
-   using RDefineBasePtrMap_t = std::map<std::string, std::shared_ptr<RDFDetail::RDefineBase>>;
+   using RDefineBasePtrMap_t = std::unordered_map<std::string, std::shared_ptr<RDFDetail::RDefineBase>>;
    using ColumnNames_t = std::vector<std::string>;
 
    // Since RColumnRegister is meant to be an immutable, copy-on-write object, the actual values are set as const

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -57,11 +57,6 @@ public:
    RColumnRegister(RColumnRegister &&) = default;
    RColumnRegister &operator=(const RColumnRegister &) = default;
 
-   RColumnRegister(RDefineBasePtrMapPtr_t defines, ColumnNamesPtr_t defineNames)
-      : fDefines(defines), fColumnNames(defineNames)
-   {
-   }
-
    RColumnRegister()
       : fDefines(std::make_shared<RDefineBasePtrMap_t>()), fColumnNames(std::make_shared<ColumnNames_t>())
    {

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -77,7 +77,7 @@ public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Add a new booked column.
    /// Internally it recreates the map with the new column, and swaps it with the old one.
-   void AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column, std::string_view name);
+   void AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column);
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Add a new name to the list returned by `GetNames` without booking a new column.

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -99,8 +99,8 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
 
 public:
    RDefine(std::string_view name, std::string_view type, F expression, const ROOT::RDF::ColumnNames_t &columns,
-           const RDFInternal::RBookedDefines &defines, RLoopManager &lm)
-      : RDefineBase(name, type, defines, lm, columns), fExpression(std::move(expression)),
+           const RDFInternal::RColumnRegister &colRegister, RLoopManager &lm)
+      : RDefineBase(name, type, colRegister, lm, columns), fExpression(std::move(expression)),
         fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<ret_type>()), fValues(lm.GetNSlots())
    {
    }
@@ -110,7 +110,7 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      RDFInternal::RColumnReadersInfo info{fColumnNames, fDefines, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
+      RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
                                            fLoopManager->GetDataSource()};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
       fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;

--- a/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineBase.hxx
@@ -12,7 +12,7 @@
 #define ROOT_RCUSTOMCOLUMNBASE
 
 #include "ROOT/RDF/GraphNode.hxx"
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/RSampleInfo.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RVec.hxx"
@@ -41,14 +41,14 @@ protected:
    const std::string fName; ///< The name of the custom column
    const std::string fType; ///< The type of the custom column as a text string
    std::vector<Long64_t> fLastCheckedEntry;
-   RDFInternal::RBookedDefines fDefines;
+   RDFInternal::RColumnRegister fColRegister;
    RLoopManager *fLoopManager; // non-owning pointer to the RLoopManager
    const ROOT::RDF::ColumnNames_t fColumnNames;
    /// The nth flag signals whether the nth input column is a custom column or not.
    ROOT::RVecB fIsDefine;
 
 public:
-   RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RBookedDefines &defines,
+   RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RColumnRegister &colRegister,
                RLoopManager &lm, const ColumnNames_t &columnNames);
 
    RDefineBase &operator=(const RDefineBase &) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -39,7 +39,7 @@ class R__CLING_PTRCHECK(off) RDefinePerSample final : public RDefineBase {
 
 public:
    RDefinePerSample(std::string_view name, std::string_view type, F expression, RLoopManager &lm)
-      : RDefineBase(name, type, /*defines*/ {}, lm, /*columnNames*/ {}), fExpression(std::move(expression)),
+      : RDefineBase(name, type, /*colRegister*/ {}, lm, /*columnNames*/ {}), fExpression(std::move(expression)),
         fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<RetType_t>())
    {
    }

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -11,7 +11,7 @@
 #ifndef ROOT_RFILTERBASE
 #define ROOT_RFILTERBASE
 
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/RNodeBase.hxx"
 #include "ROOT/RDF/Utils.hxx" // ColumnNames_t
 #include "ROOT/RVec.hxx"
@@ -43,13 +43,13 @@ protected:
    std::vector<ULong64_t> fRejected = {0};
    const std::string fName;
    const ROOT::RDF::ColumnNames_t fColumnNames;
-   RDFInternal::RBookedDefines fDefines;
+   RDFInternal::RColumnRegister fColRegister;
    /// The nth flag signals whether the nth input column is a custom column or not.
    ROOT::RVecB fIsDefine;
 
 public:
    RFilterBase(RLoopManager *df, std::string_view name, const unsigned int nSlots,
-               const RDFInternal::RBookedDefines &defines, const ColumnNames_t &columns);
+               const RDFInternal::RColumnRegister &colRegister, const ColumnNames_t &columns);
    RFilterBase &operator=(const RFilterBase &) = delete;
 
    virtual ~RFilterBase();

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -394,7 +394,7 @@ public:
       fLoopManager->Book(jittedDefine.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
-      newCols.AddColumn(jittedDefine, name);
+      newCols.AddColumn(jittedDefine);
 
       RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
@@ -485,7 +485,7 @@ public:
       fLoopManager->Book(jittedDefine.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
-      newCols.AddColumn(jittedDefine, name);
+      newCols.AddColumn(jittedDefine);
 
       RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
@@ -543,7 +543,7 @@ public:
       fLoopManager->AddSampleCallback(std::move(updateDefinePerSample));
 
       RDFInternal::RColumnRegister newCols(fColRegister);
-      newCols.AddColumn(std::move(newColumn), name);
+      newCols.AddColumn(std::move(newColumn));
       RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
       return newInterface;
    }
@@ -596,7 +596,7 @@ public:
       fLoopManager->AddSampleCallback(std::move(updateDefinePerSample));
 
       RDFInternal::RColumnRegister newCols(fColRegister);
-      newCols.AddColumn(jittedDefine, name);
+      newCols.AddColumn(jittedDefine);
 
       RInterface<Proxied, DS_t> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 
@@ -2753,7 +2753,7 @@ private:
 
       auto entryColumn = std::make_shared<NewColEntry_t>(entryColName, entryColType, std::move(entryColGen),
                                                          ColumnNames_t{}, newCols, *fLoopManager);
-      newCols.AddColumn(entryColumn, entryColName);
+      newCols.AddColumn(entryColumn);
 
       // Slot number column
       const std::string slotColName = "rdfslot_";
@@ -2763,7 +2763,7 @@ private:
 
       auto slotColumn = std::make_shared<NewColSlot_t>(slotColName, slotColType, std::move(slotColGen), ColumnNames_t{},
                                                        newCols, *fLoopManager);
-      newCols.AddColumn(slotColumn, slotColName);
+      newCols.AddColumn(slotColumn);
 
       fColRegister = std::move(newCols);
 
@@ -2892,7 +2892,7 @@ private:
       fLoopManager->Book(newColumn.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
-      newCols.AddColumn(newColumn, name);
+      newCols.AddColumn(newColumn);
 
       RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedDefine.hxx
@@ -34,7 +34,7 @@ class RJittedDefine : public RDefineBase {
 
 public:
    RJittedDefine(std::string_view name, std::string_view type, RLoopManager &lm)
-      : RDefineBase(name, type, RDFInternal::RBookedDefines(), lm, /* columnNames */ {})
+      : RDefineBase(name, type, RDFInternal::RColumnRegister(), lm, /* columnNames */ {})
    {
    }
    ~RJittedDefine();

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -116,7 +116,7 @@ public:
       thisNode->SetPrevNode(prevNode);
 
       // If there have been some defines between the last Filter and this Range node we won't detect them:
-      // Ranges don't keep track of Defines (they have no RBookedDefines data member).
+      // Ranges don't keep track of Defines (they have no RColumnRegister data member).
       // Let's pretend that the Defines of this node are the same as the node above, so that in the graph
       // the Defines will just appear below the Range instead (no functional change).
       thisNode->AddDefinedColumns(prevColumns);

--- a/tree/dataframe/src/RActionBase.cxx
+++ b/tree/dataframe/src/RActionBase.cxx
@@ -13,8 +13,10 @@
 
 using namespace ROOT::Internal::RDF;
 
-RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const RBookedDefines &defines)
-   : fLoopManager(lm), fNSlots(lm->GetNSlots()), fColumnNames(colNames), fDefines(defines) { }
+RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const RColumnRegister &colRegister)
+   : fLoopManager(lm), fNSlots(lm->GetNSlots()), fColumnNames(colNames), fColRegister(colRegister)
+{
+}
 
 // outlined to pin virtual table
 RActionBase::~RActionBase() {}

--- a/tree/dataframe/src/RDFBookedDefines.cxx
+++ b/tree/dataframe/src/RDFBookedDefines.cxx
@@ -14,8 +14,8 @@ namespace RDF {
 
 bool RBookedDefines::HasName(std::string_view name) const
 {
-   const auto ccolnamesEnd = fDefinesNames->end();
-   return ccolnamesEnd != std::find(fDefinesNames->begin(), ccolnamesEnd, name);
+   const auto ccolnamesEnd = fColumnNames->end();
+   return ccolnamesEnd != std::find(fColumnNames->begin(), ccolnamesEnd, name);
 }
 
 void RBookedDefines::AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column, std::string_view name)
@@ -35,7 +35,7 @@ void RBookedDefines::AddName(std::string_view name)
 
    auto newColsNames = std::make_shared<ColumnNames_t>(names);
    newColsNames->emplace_back(std::string(name));
-   fDefinesNames = newColsNames;
+   fColumnNames = newColsNames;
 }
 
 void RBookedDefines::Clear() {

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -23,7 +23,7 @@ void RColumnRegister::AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &c
    auto newDefines = std::make_shared<RDefineBasePtrMap_t>(GetColumns());
    const std::string colName(name);
    (*newDefines)[colName] = column;
-   fDefines = newDefines;
+   fDefines = std::move(newDefines);
    AddName(colName);
 }
 

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -6,28 +6,28 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 
 namespace ROOT {
 namespace Internal {
 namespace RDF {
 
-bool RBookedDefines::HasName(std::string_view name) const
+bool RColumnRegister::HasName(std::string_view name) const
 {
    const auto ccolnamesEnd = fColumnNames->end();
    return ccolnamesEnd != std::find(fColumnNames->begin(), ccolnamesEnd, name);
 }
 
-void RBookedDefines::AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column, std::string_view name)
+void RColumnRegister::AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column, std::string_view name)
 {
-   auto newCols = std::make_shared<RDefineBasePtrMap_t>(GetColumns());
+   auto newDefines = std::make_shared<RDefineBasePtrMap_t>(GetColumns());
    const std::string colName(name);
-   (*newCols)[colName] = column;
-   fDefines = newCols;
+   (*newDefines)[colName] = column;
+   fDefines = newDefines;
    AddName(colName);
 }
 
-void RBookedDefines::AddName(std::string_view name)
+void RColumnRegister::AddName(std::string_view name)
 {
    const auto &names = GetNames();
    if (std::find(names.begin(), names.end(), name) != names.end())
@@ -38,9 +38,10 @@ void RBookedDefines::AddName(std::string_view name)
    fColumnNames = newColsNames;
 }
 
-void RBookedDefines::Clear() {
+void RColumnRegister::Clear()
+{
    fDefines.reset();
-   fDefinesNames.reset();
+   fColumnNames.reset();
 }
 
 } // namespace RDF

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -7,6 +7,7 @@
  *************************************************************************/
 
 #include "ROOT/RDF/RColumnRegister.hxx"
+#include "ROOT/RDF/RDefineBase.hxx"
 
 namespace ROOT {
 namespace Internal {
@@ -18,10 +19,10 @@ bool RColumnRegister::HasName(std::string_view name) const
    return ccolnamesEnd != std::find(fColumnNames->begin(), ccolnamesEnd, name);
 }
 
-void RColumnRegister::AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column, std::string_view name)
+void RColumnRegister::AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column)
 {
    auto newDefines = std::make_shared<RDefineBasePtrMap_t>(GetColumns());
-   const std::string colName(name);
+   const std::string &colName = column->GetName();
    (*newDefines)[colName] = column;
    fDefines = std::move(newDefines);
    AddName(colName);

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -8,7 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/GraphUtils.hxx"
 
 #include <algorithm> // std::find
@@ -140,12 +140,12 @@ std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *
    return node;
 }
 
-std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RBookedDefines &defines,
+std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRegister &colRegister,
                                              const std::vector<std::string> &prevNodeDefines)
 {
    auto upmostNode = node;
-   const auto &defineNames = defines.GetNames();
-   const auto &defineMap = defines.GetColumns();
+   const auto &defineNames = colRegister.GetNames();
+   const auto &defineMap = colRegister.GetColumns();
    for (auto i = int(defineNames.size()) - 1; i >= 0; --i) { // walk backwards through the names of defined columns
       const auto colName = defineNames[i];
       const bool isAlias = defineMap.find(colName) == defineMap.end();

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -21,14 +21,14 @@
 using ROOT::Detail::RDF::RDefineBase;
 namespace RDFInternal = ROOT::Internal::RDF; // redundant (already present in the header), but Windows needs it
 
-RDefineBase::RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RBookedDefines &defines,
+RDefineBase::RDefineBase(std::string_view name, std::string_view type, const RDFInternal::RColumnRegister &colRegister,
                          ROOT::Detail::RDF::RLoopManager &lm, const ROOT::RDF::ColumnNames_t &columnNames)
    : fName(name), fType(type), fLastCheckedEntry(lm.GetNSlots() * RDFInternal::CacheLineStep<Long64_t>(), -1),
-     fDefines(defines), fLoopManager(&lm), fColumnNames(columnNames), fIsDefine(columnNames.size())
+     fColRegister(colRegister), fLoopManager(&lm), fColumnNames(columnNames), fIsDefine(columnNames.size())
 {
    const auto nColumns = fColumnNames.size();
    for (auto i = 0u; i < nColumns; ++i)
-      fIsDefine[i] = fDefines.HasName(fColumnNames[i]);
+      fIsDefine[i] = fColRegister.HasName(fColumnNames[i]);
 }
 
 // pin vtable. Work around cling JIT issue.

--- a/tree/dataframe/src/RFilterBase.cxx
+++ b/tree/dataframe/src/RFilterBase.cxx
@@ -16,16 +16,16 @@
 using namespace ROOT::Detail::RDF;
 
 RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const unsigned int nSlots,
-                         const RDFInternal::RBookedDefines &defines, const ColumnNames_t &columns)
+                         const RDFInternal::RColumnRegister &colRegister, const ColumnNames_t &columns)
    : RNodeBase(implPtr), fLastCheckedEntry(std::vector<Long64_t>(nSlots * RDFInternal::CacheLineStep<Long64_t>(), -1)),
      fLastResult(nSlots * RDFInternal::CacheLineStep<int>()),
      fAccepted(nSlots * RDFInternal::CacheLineStep<ULong64_t>()),
-     fRejected(nSlots * RDFInternal::CacheLineStep<ULong64_t>()), fName(name), fColumnNames(columns), fDefines(defines),
-     fIsDefine(columns.size())
+     fRejected(nSlots * RDFInternal::CacheLineStep<ULong64_t>()), fName(name), fColumnNames(columns),
+     fColRegister(colRegister), fIsDefine(columns.size())
 {
    const auto nColumns = fColumnNames.size();
    for (auto i = 0u; i < nColumns; ++i)
-      fIsDefine[i] = fDefines.HasName(fColumnNames[i]);
+      fIsDefine[i] = fColRegister.HasName(fColumnNames[i]);
 }
 
 // outlined to pin virtual table

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -8,7 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RJittedAction.hxx"
 // Avoid error: invalid application of ‘sizeof’ to incomplete type in RJittedAction::GetMergeableValue
@@ -20,7 +20,7 @@
 using ROOT::Internal::RDF::RJittedAction;
 using ROOT::Detail::RDF::RLoopManager;
 
-RJittedAction::RJittedAction(RLoopManager &lm) : RActionBase(&lm, {}, ROOT::Internal::RDF::RBookedDefines{}) {}
+RJittedAction::RJittedAction(RLoopManager &lm) : RActionBase(&lm, {}, ROOT::Internal::RDF::RColumnRegister{}) {}
 
 void RJittedAction::Run(unsigned int slot, Long64_t entry)
 {

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -9,7 +9,7 @@
  *************************************************************************/
 
 #include "ROOT/RDF/RCutFlowReport.hxx"
-#include "ROOT/RDF/RBookedDefines.hxx"
+#include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RJittedFilter.hxx"
 
@@ -18,7 +18,9 @@
 using namespace ROOT::Detail::RDF;
 
 RJittedFilter::RJittedFilter(RLoopManager *lm, std::string_view name)
-   : RFilterBase(lm, name, lm->GetNSlots(), RDFInternal::RBookedDefines(), /*columnNames*/{}) { }
+   : RFilterBase(lm, name, lm->GetNSlots(), RDFInternal::RColumnRegister(), /*columnNames*/ {})
+{
+}
 
 void RJittedFilter::SetFilter(std::unique_ptr<RFilterBase> f)
 {


### PR DESCRIPTION
The main change is the renaming from `RBookedDefines` to `RColumnRegister`:
we already abuse this class to also keep track of aliases.
Soon we will also keep track of defined systematic variations here.
With this patch we clarify the role of this class with a more appropriate name.