### PR TITLE
Disable Cling optimizations in TCanvas::SaveSource

### DIFF
--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1888,10 +1888,10 @@ void TCanvas::SaveSource(const char *filename, Option_t *option)
    }
 
    TString mname(fname);
-//    out <<"#ifdef __CLING__"<<std::endl;
-//    out <<"#pragma cling optimize(0)"<<std::endl;
-//    out <<"#endif"<<std::endl;
-//    out <<""<<std::endl;
+   out <<"#ifdef __CLING__"<<std::endl;
+   out <<"#pragma cling optimize(0)"<<std::endl;
+   out <<"#endif"<<std::endl;
+   out <<""<<std::endl;
    Int_t p = mname.Last('.');
    Int_t s = mname.Last('/')+1;
 

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -1888,10 +1888,10 @@ void TCanvas::SaveSource(const char *filename, Option_t *option)
    }
 
    TString mname(fname);
-   out <<"#ifdef __CLING__"<<std::endl;
-   out <<"#pragma cling optimize(0)"<<std::endl;
-   out <<"#endif"<<std::endl;
-   out <<""<<std::endl;
+   out << R"CODE(#ifdef __CLING__
+#pragma cling optimize(0)
+#endif
+)CODE";
    Int_t p = mname.Last('.');
    Int_t s = mname.Last('/')+1;
 


### PR DESCRIPTION
As discussed in https://github.com/root-project/root/issues/9312, long generated functions triggers edge cases in the optimizer passes and takes very long to compile for little to no gain in runtime.