### PR TITLE
[IO] Fix RooFit workspace I/O.

### DIFF
--- a/io/io/src/TGenCollectionStreamer.cxx
+++ b/io/io/src/TGenCollectionStreamer.cxx
@@ -30,6 +30,8 @@ size(), clear(), resize(). resize() may be a void operation.
 #include "TStreamerElement.h"
 #include "TVirtualCollectionIterators.h"
 
+#include <memory>
+
 TGenCollectionStreamer::TGenCollectionStreamer(const TGenCollectionStreamer& copy)
       : TGenCollectionProxy(copy), fReadBufferFunc(&TGenCollectionStreamer::ReadBufferDefault)
 {
@@ -367,8 +369,6 @@ void TGenCollectionStreamer::ReadObjects(int nElements, TBuffer &b, const TClass
    Bool_t vsn3 = b.GetInfo() && b.GetInfo()->GetOldVersion() <= 3;
    size_t len = fValDiff * nElements;
    StreamHelper* itm = 0;
-   char   buffer[8096];
-   void*  memory = 0;
 
    TClass* onFileValClass = (onFileClass ? onFileClass->GetCollectionProxy()->GetValueClass() : 0);
 
@@ -431,9 +431,10 @@ void TGenCollectionStreamer::ReadObjects(int nElements, TBuffer &b, const TClass
       case ROOT::kSTLmultiset:
       case ROOT::kSTLset:
       case ROOT::kSTLunorderedset:
-      case ROOT::kSTLunorderedmultiset:
+      case ROOT::kSTLunorderedmultiset: {
 #define DOLOOP(x) {int idx=0; while(idx<nElements) {StreamHelper* i=(StreamHelper*)(((char*)itm) + fValDiff*idx); { x ;} ++idx;}}
-         fEnv->fStart = itm = (StreamHelper*)(len < sizeof(buffer) ? buffer : memory =::operator new(len));
+         auto buffer = std::make_unique<char[]>(len);
+         fEnv->fStart = itm = reinterpret_cast<StreamHelper *>(buffer.get());
          fConstruct(itm,nElements);
          switch (fVal->fCase) {
             case kIsClass:
@@ -461,11 +462,9 @@ void TGenCollectionStreamer::ReadObjects(int nElements, TBuffer &b, const TClass
          }
 #undef DOLOOP
          break;
+      }
       default:
          break;
-   }
-   if (memory) {
-      ::operator delete(memory);
    }
 }
 
@@ -476,8 +475,6 @@ void TGenCollectionStreamer::ReadPairFromMap(int nElements, TBuffer &b)
    Bool_t vsn3 = b.GetInfo() && b.GetInfo()->GetOldVersion() <= 3;
    size_t len = fValDiff * nElements;
    StreamHelper* itm = 0;
-   char   buffer[8096];
-   void*  memory = 0;
 
    TStreamerInfo *pinfo = (TStreamerInfo*)fVal->fType->GetStreamerInfo();
    R__ASSERT(pinfo);
@@ -543,9 +540,10 @@ void TGenCollectionStreamer::ReadPairFromMap(int nElements, TBuffer &b)
       case ROOT::kSTLmultiset:
       case ROOT::kSTLset:
       case ROOT::kSTLunorderedset:
-      case ROOT::kSTLunorderedmultiset:
+      case ROOT::kSTLunorderedmultiset: {
 #define DOLOOP(x) {int idx=0; while(idx<nElements) {StreamHelper* i=(StreamHelper*)(((char*)itm) + fValDiff*idx); { x ;} ++idx;}}
-         fEnv->fStart = itm = (StreamHelper*)(len < sizeof(buffer) ? buffer : memory =::operator new(len));
+         auto buffer = std::make_unique<char[]>(len);
+         fEnv->fStart = itm = reinterpret_cast<StreamHelper *>(buffer.get());
          fConstruct(itm,nElements);
          switch (fVal->fCase) {
             case kIsClass:
@@ -559,11 +557,9 @@ void TGenCollectionStreamer::ReadPairFromMap(int nElements, TBuffer &b)
          }
 #undef DOLOOP
          break;
+      }
       default:
          break;
-   }
-   if (memory) {
-      ::operator delete(memory);
    }
 }
 


### PR DESCRIPTION
For a long time, users had to increase their maximum stack size in order
to read RooFit workspaces. Otherwise, the process would simply end
without any message.
The problem is an 8kB stack buffer for the I/O of stl sets, which is
always declared but rarely used. Here, the buffer is replaced with a
heap buffer.

This is an analysis of stack frames at -O2 in the moment of a crash:
```
tot. size     call count    frame size
5468960       665           8224      libRIO.so`TGenCollectionStreamer::ReadObjects(this nElements b
566576        2083           272      libRIO.so`int TStreamerInfo::ReadBuffer<char**>(TBuffer&, char**
307664        2747           112      libRIO.so`TBufferFile::ReadClassBuffer(this cl pointer
133248        2082            64      libRIO.so`TStreamerInfoActions::GenericReadAction(buf addr config
131856        2747            48      libRIO.so`TBufferFile::ApplySequence(this sequence obj
74480         665            112      libRIO.so`TBufferFile::ReadObjectAny(this clCast at
68064         1418            48      libCore.so`TStreamerBase::ReadBuffer(this b pointer
42560         665             64      libRIO.so`TGenCollectionStreamer::ReadBufferGeneric(this b obj
42560         665             64      libRIO.so`TBufferFile::ReadFastArray(this start cl
31920         665             48      libRIO.so`int TStreamerInfoActions::ReadSTL<&(TStreamerInfoActions::ReadSTLMemberWiseSameClass(TBuffer&, void*,
21280         665             32      libRooFitCore.so`RooAbsArg::Streamer(this R__b at
14592         152             96      libRooFitCore.so`RooRealVar::Streamer(this R__b at
1056          22              48      libRooFitCore.so`RooHistFunc::Streamer(this R__b at
720           15              48      libHistFactory.so`PiecewiseInterpolation::Streamer(this R__b at
```

and after this fix:
```
54400	200	272	 200 libRIO.so`int TStreamerInfo::ReadBuffer<char**>(this b 	272
29792	266	112	 266 libRIO.so`TBufferFile::ReadClassBuffer(this cl pointer 	112
12864	201	64	 201 libRIO.so`TStreamerInfoActions::GenericReadAction(buf addr config 	64
12768	266	48	 266 libRIO.so`TBufferFile::ApplySequence(this sequence obj 	48
8320	65	128	  65 libRIO.so`TGenCollectionStreamer::ReadObjects(this nElements b 	128
7280	65	112	  65 libRIO.so`TBufferFile::ReadObjectAny(this clCast at 	112
6480	135	48	 135 libCore.so`TStreamerBase::ReadBuffer(this b pointer 	48
4160	65	64	  65 libRIO.so`TGenCollectionStreamer::ReadBufferGeneric(this b obj 	64
4160	65	64	  65 libRIO.so`TBufferFile::ReadFastArray(this start cl 	64
3120	65	48	  65 libRIO.so`int TStreamerInfoActions::ReadSTL<&(TStreamerInfoActions::ReadSTLMemberWiseSameClass(TBuffer&, void*, 	48
2080	65	32	  65 libRooFitCore.so`RooAbsArg::Streamer(this R__b at 	32
960	10	96	  10 libRooFitCore.so`RooRealVar::Streamer(this R__b at 	96
96	2	48	   2 libRooFitCore.so`RooHistFunc::Streamer(this R__b at 	48
96	2	48	   2 libHistFactory.so`PiecewiseInterpolation::Streamer(this R__b at 	48
```
