### PR TITLE
[http] do not list object members when object scanned as container

### DIFF
--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "19/11/2021"*/
-   JSROOT.version_date = "17/12/2021";
+   JSROOT.version_date = "20/12/2021";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.jq2d.js
+++ b/js/scripts/JSRoot.jq2d.js
@@ -820,7 +820,8 @@ JSROOT.define(['d3', 'jquery', 'painter', 'hierarchy', 'jquery-ui', 'jqueryui-mo
 
       if (!place || (place=="")) place = "item";
 
-      let sett = jsrp.getDrawSettings(hitem._kind), handle = sett.handle;
+      let selector = (hitem._kind == "ROOT.TKey" && hitem._more) ? "noinspect" : "",
+          sett = jsrp.getDrawSettings(hitem._kind, selector), handle = sett.handle;
 
       if (place == "icon") {
          let func = null;

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -761,8 +761,7 @@ void TRootSniffer::ScanObjectChilds(TRootSnifferScanRec &rec, TObject *obj)
    } else if (obj->InheritsFrom(TDirectory::Class())) {
       TDirectory *dir = (TDirectory *)obj;
       ScanCollection(rec, dir->GetList(), nullptr, dir->GetListOfKeys());
-   }
-   if (rec.CanExpandItem()) {
+   } else if (rec.CanExpandItem()) {
       ScanObjectMembers(rec, obj->IsA(), (char *)obj);
    }
 }


### PR DESCRIPTION
When scanning sub-elements with sniffer, it is allowed to get list
of object members. But this should not be performed for container
objects like TFolder or TDirectory

Let correctly browse `TFile` with sub-directories via `THttpServer`.