### PR TITLE
[RF][cmake] check the minimum required version for cppzmq

### DIFF
--- a/cmake/modules/Findcppzmq.cmake
+++ b/cmake/modules/Findcppzmq.cmake
@@ -8,8 +8,25 @@ find_path(cppzmq_INCLUDE_DIRS "zmq.hpp"
         )
 mark_as_advanced(cppzmq_INCLUDE_DIRS)
 
+# check for required minimum version for RooFitZMQ
+if(cppzmq_INCLUDE_DIRS)
+    SET(SAVE_CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES}")
+    SET(CMAKE_REQUIRED_INCLUDES ${cppzmq_INCLUDE_DIRS} ${ZeroMQ_INCLUDE_DIRS})
+    SET(SAVE_CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+    SET(CMAKE_REQUIRED_LIBRARIES libzmq)
+    check_cxx_source_runs("#include <zmq.hpp> \n int main () {if (CPPZMQ_VERSION_MAJOR > 4 || (CPPZMQ_VERSION_MAJOR == 4 && CPPZMQ_VERSION_MINOR >= 8)) {return 0;} else {return 1;} }" cppzmq_VERSION_COMPATIBLE)
+    SET(CMAKE_REQUIRED_INCLUDES "${SAVE_CMAKE_REQUIRED_INCLUDES}")
+    SET(CMAKE_REQUIRED_LIBRARIES "${SAVE_CMAKE_REQUIRED_LIBRARIES}")
+
+    if (NOT QUIET AND NOT cppzmq_VERSION_COMPATIBLE)
+        message("-- Version of zmq.hpp at ${cppzmq_INCLUDE_DIRS} too old, need at least 4.8.0.")
+    endif()
+endif()
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args (cppzmq DEFAULT_MSG cppzmq_INCLUDE_DIRS)
+# handle the QUIET and REQUIRED arguments and set cppzmq_FOUND to TRUE
+# if all listed variables are truthy
+find_package_handle_standard_args (cppzmq DEFAULT_MSG cppzmq_INCLUDE_DIRS cppzmq_VERSION_COMPATIBLE)
 
 if(cppzmq_FOUND)
     add_library(cppzmq INTERFACE IMPORTED)

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1907,6 +1907,10 @@ if (roofit_multiprocess)
     add_subdirectory(builtins/zeromq/libzmq)
   endif()
 
+  # zmq_ppoll is still in the draft API, so enable that transitively
+  target_compile_definitions(libzmq INTERFACE ZMQ_BUILD_DRAFT_API)
+  target_compile_definitions(libzmq INTERFACE ZMQ_NO_EXPORT)
+
   if(NOT builtin_cppzmq)
     message(STATUS "Looking for ZeroMQ C++ bindings (cppzmq)")
     # Clear cache before calling find_package(cppzmq),
@@ -1916,9 +1920,10 @@ if (roofit_multiprocess)
       unset(cppzmq_${suffix} CACHE)
     endforeach()
     if(fail-on-missing)
-      find_package(cppzmq REQUIRED)
+      # we only support MODULE mode fow now to handle version checking ourselves
+      find_package(cppzmq MODULE REQUIRED)
     else()
-      find_package(cppzmq QUIET)
+      find_package(cppzmq MODULE)
       if(NOT cppzmq_FOUND)
         message(STATUS "ZeroMQ C++ bindings not found. Switching on builtin_cppzmq option")
         set(builtin_cppzmq ON CACHE BOOL "Enabled because ZeroMQ C++ bindings not found (${builtin_cppzmq_description})" FORCE)
@@ -1932,8 +1937,6 @@ if (roofit_multiprocess)
   endif()
 
   # zmq_ppoll is still in the draft API, so enable that transitively
-  target_compile_definitions(libzmq INTERFACE ZMQ_BUILD_DRAFT_API)
-  target_compile_definitions(libzmq INTERFACE ZMQ_NO_EXPORT)
   target_compile_definitions(cppzmq INTERFACE ZMQ_BUILD_DRAFT_API)
   target_compile_definitions(cppzmq INTERFACE ZMQ_NO_EXPORT)
 endif (roofit_multiprocess)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Makes `Findcppzmq.cmake` check for the version of the zmq.hpp header that it may find installed on the system. If it is too old (below 4.8.0) then the module will consider cppzmq not found.

In `SearchInstalledSoftware.cmake`, then, configuration will either fall back to the cppzmq built-in or it will fail if `fail-on-missing` is on.

Thanks to @Axel-Naumann for the bug report.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)