### PR TITLE
[RF] Use `ULong64_t` for persistent data member `RooDataHist::_curIndex`

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -21,6 +21,7 @@
 #include "RooArgSet.h"
 
 #include "ROOT/RStringView.hxx"
+#include "Rtypes.h"
 
 #include <map>
 #include <vector>
@@ -278,7 +279,7 @@ protected:
   mutable std::vector<double> _maskedWeights; //! Copy of _wgt, but masked events have a weight of zero.
   mutable std::vector<double> _maskedSumw2; //! Copy of _sumW2, but masked events have a weight of zero.
  
-  mutable unsigned long _curIndex{std::numeric_limits<std::size_t>::max()}; // Current index
+  mutable ULong64_t _curIndex{std::numeric_limits<ULong64_t>::max()}; // Current index
 
   mutable std::unordered_map<int,std::vector<double>> _pbinvCache ; //! Cache for arrays of partial bin volumes
   std::vector<RooAbsLValue*> _lvvars ; //! List of observables casted as RooAbsLValue
@@ -298,7 +299,7 @@ private:
   VarInfo _varInfo; //!
   VarInfo const& getVarInfo();
 
-  ClassDefOverride(RooDataHist, 7) // Binned data set
+  ClassDefOverride(RooDataHist, 8) // Binned data set
 };
 
 #endif


### PR DESCRIPTION
Both `unsigned long` and `std::size_t` are not the right types for
getting a 64-bit unsigned integer on every platform. Following the
advice by @pcanal, `ULong64_t` is now used instead.