### PR TITLE
[llvm] Fix valgrind report (operlapping memcpy):

### DIFF
--- a/interpreter/llvm/src/lib/Support/VirtualFileSystem.cpp
+++ b/interpreter/llvm/src/lib/Support/VirtualFileSystem.cpp
@@ -1305,10 +1305,9 @@ class llvm::vfs::RedirectingFileSystemParser {
 
         NameValueNode = I.getValue();
         if (FS->UseCanonicalizedPaths) {
-          SmallString<256> Path(Value);
           // Guarantee that old YAML files containing paths with ".." and "."
           // are properly canonicalized before read into the VFS.
-          Path = sys::path::remove_leading_dotslash(Path);
+          SmallString<256> Path = sys::path::remove_leading_dotslash(Value);
           sys::path::remove_dots(Path, /*remove_dot_dot=*/true);
           Name = Path.str();
         } else {
@@ -1369,7 +1368,8 @@ class llvm::vfs::RedirectingFileSystemParser {
         if (FS->UseCanonicalizedPaths) {
           // Guarantee that old YAML files containing paths with ".." and "."
           // are properly canonicalized before read into the VFS.
-          FullPath = sys::path::remove_leading_dotslash(FullPath);
+          SmallString<256> Path = sys::path::remove_leading_dotslash(FullPath);
+          FullPath = Path;
           sys::path::remove_dots(FullPath, /*remove_dot_dot=*/true);
         }
         ExternalContentsPath = FullPath.str();
@@ -1610,7 +1610,8 @@ RedirectingFileSystem::lookupPath(const Twine &Path_) const {
   // a VFS request, do bot bother about symlinks in the path components
   // but canonicalize in order to perform the correct entry search.
   if (UseCanonicalizedPaths) {
-    Path = sys::path::remove_leading_dotslash(Path);
+    SmallString<256> PathNoDotSlash = sys::path::remove_leading_dotslash(Path);
+    Path = PathNoDotSlash;
     sys::path::remove_dots(Path, /*remove_dot_dot=*/true);
   }
 


### PR DESCRIPTION
This is addressed by ecb00a77624c9/da45bd232165e in upstream llvm,
but with a much wider scope. Restrict the fix to what matters for llvm9.

Addresses:
==1932== Source and destination overlap in memcpy(0xbecac83c, 0xbecac83c, 100)
==1932==    at 0x4839989: memcpy (vg_replace_strmem.c:1035)
==1932==    by 0x62DD594: void llvm::SmallVectorTemplateBase<char, true>::uninitialized_copy<char const, char>(char const*, char const*, char*, std::enable_if<std::is_same<std::remove_const<char const>::type, char>::value, void>::type*) (SmallVector.h:294)
==1932==    by 0x62D5F67: void llvm::SmallVectorImpl<char>::append<char const*, void>(char const*, char const*) (SmallVector.h:392)
==1932==    by 0x9413D55: llvm::vfs::RedirectingFileSystemParser::parseEntry(llvm::yaml::Node*, llvm::vfs::RedirectingFileSystem*, bool) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x9413C4E: llvm::vfs::RedirectingFileSystemParser::parseEntry(llvm::yaml::Node*, llvm::vfs::RedirectingFileSystem*, bool) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x9414BA0: llvm::vfs::RedirectingFileSystemParser::parse(llvm::yaml::Node*, llvm::vfs::RedirectingFileSystem*) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x9414FDF: llvm::vfs::RedirectingFileSystem::create(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >, void (*)(llvm::SMDiagnostic const&, void*), llvm::StringRef, void*, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x9415176: llvm::vfs::getVFSFromYAML(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >, void (*)(llvm::SMDiagnostic const&, void*), llvm::StringRef, void*, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x64D7D9D: (anonymous namespace)::collectModuleMaps(clang::CompilerInstance&, llvm::SmallVectorImpl<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >&) [clone .constprop.575] (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x64D8CAA: (anonymous namespace)::setupCxxModules(clang::CompilerInstance&) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x64DB45A: (anonymous namespace)::createCIImpl(std::unique_ptr<llvm::MemoryBuffer, std::default_delete<llvm::MemoryBuffer> >, cling::CompilerOptions const&, char const*, std::unique_ptr<clang::ASTConsumer, std::default_delete<clang::ASTConsumer> >, std::vector<std::shared_ptr<clang::ModuleFileExtension>, std::allocator<std::shared_ptr<clang::ModuleFileExtension> > > const&, bool, bool) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)
==1932==    by 0x64DD0E9: cling::CIFactory::createCI(llvm::StringRef, cling::InvocationOptions const&, char const*, std::unique_ptr<clang::ASTConsumer, std::default_delete<clang::ASTConsumer> >, std::vector<std::shared_ptr<clang::ModuleFileExtension>, std::allocator<std::shared_ptr<clang::ModuleFileExtension> > > const&) (in /home/sftnight/build/wsincrmaster/LABEL/ROOT-debian10-i386/SPEC/cxx14/build/lib/libCling.so)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

