### PR TITLE
[RF] Change types of persistent `unsigned long` and `std::size_t` data members in RooFit classes to platform independent definitions

### DIFF
--- a/roofit/roofitcore/inc/RooSTLRefCountList.h
+++ b/roofit/roofitcore/inc/RooSTLRefCountList.h
@@ -261,7 +261,7 @@ class RooSTLRefCountList {
     }
 
     Container_t _storage;
-    std::vector<unsigned long> _refCount;
+    std::vector<UInt_t> _refCount;
     mutable std::vector<T*> _orderedStorage; //!
     mutable unsigned long _renameCounterForLastSorting = 0; //!
 
@@ -270,7 +270,7 @@ class RooSTLRefCountList {
     // the counter.
     static std::size_t const* _renameCounter;
 
-    ClassDef(RooSTLRefCountList<T>,2);
+    ClassDef(RooSTLRefCountList<T>,3);
 };
 
 template<class T>

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -23,6 +23,7 @@
 #include "RooRealVar.h"
 
 #include "ROOT/RStringView.hxx"
+#include "Rtypes.h"
 
 #include <list>
 #include <vector>
@@ -685,14 +686,14 @@ public:
   const Double_t* _extWgtErrHiArray ;    //! External weight array - high error
   const Double_t* _extSumW2Array ;       //! External sum of weights array
 
-  mutable std::size_t _currentWeightIndex{0}; //
+  mutable ULong64_t _currentWeightIndex{0}; //
 
   RooVectorDataStore* _cache ; //! Optimization cache
   RooAbsArg* _cacheOwner ; //! Cache owner
 
   Bool_t _forcedUpdate ; //! Request for forced cache update 
 
-  ClassDefOverride(RooVectorDataStore, 6) // STL-vector-based Data Storage class
+  ClassDefOverride(RooVectorDataStore, 7) // STL-vector-based Data Storage class
 };
 
 


### PR DESCRIPTION
This is a follow up to https://github.com/root-project/root/pull/9475. See the commit messages for more info.

