### PR TITLE
[ntuple] Use V1 serialization in DAOS backend

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -84,9 +84,9 @@ public:
       REnvelopeLink fPageListEnvelopeLink;
    };
 
-   /// The streamer context is used for the piecewise serialization of a descriptor.  During header serialization,
+   /// The serialization context is used for the piecewise serialization of a descriptor.  During header serialization,
    /// the mapping of in-memory field and column IDs to physical IDs is built so that it can be used for the
-   /// footer serialzation in a second step.
+   /// footer serialization in a second step.
    class RContext {
    private:
       std::uint32_t fHeaderSize = 0;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleZip.hxx
@@ -46,6 +46,10 @@ public:
    /// Data might be overwritten, if a zipped block in the middle of a large input data stream
    /// turns out to be uncompressible
    using Writer_t = std::function<void(const void *buffer, size_t nbytes, size_t offset)>;
+   static Writer_t MakeMemCopyWriter(unsigned char *dest)
+   {
+      return [=](const void *b, size_t n, size_t o) { memcpy(dest + o, b, n); };
+   }
    static constexpr size_t kMaxSingleBlock = kMAXZIPBUF;
 
    RNTupleCompressor() : fZipBuffer(std::unique_ptr<Buffer_t>(new Buffer_t())) {}

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -16,6 +16,7 @@
 #ifndef ROOT7_RPageStorageDaos
 #define ROOT7_RPageStorageDaos
 
+#include <ROOT/RError.hxx>
 #include <ROOT/RPageStorage.hxx>
 #include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleZip.hxx>
@@ -74,7 +75,7 @@ struct RDaosNTupleAnchor {
    }
 
    std::uint32_t Serialize(void *buffer) const;
-   std::uint32_t Deserialize(const void *buffer);
+   RResult<std::uint32_t> Deserialize(const void *buffer, std::uint32_t bufSize);
 
    static std::uint32_t GetSize();
 };

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -17,6 +17,7 @@
 #define ROOT7_RPageStorageDaos
 
 #include <ROOT/RPageStorage.hxx>
+#include <ROOT/RNTupleSerialize.hxx>
 #include <ROOT/RNTupleZip.hxx>
 #include <ROOT/RStringView.hxx>
 
@@ -102,6 +103,8 @@ private:
    std::string fURI;
    /// Tracks the number of bytes committed to the current cluster
    std::uint64_t fNBytesCurrentCluster{0};
+   /// Used to keeo the column and field IDs issued during header serialization for the footer serialization
+   Internal::RNTupleSerializer::RContext fSerializationContext;
 
    RDaosNTupleAnchor fNTupleAnchor;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -104,7 +104,7 @@ private:
    std::string fURI;
    /// Tracks the number of bytes committed to the current cluster
    std::uint64_t fNBytesCurrentCluster{0};
-   /// Used to keeo the column and field IDs issued during header serialization for the footer serialization
+   /// Used to keep the column and field IDs issued during header serialization for the footer serialization
    Internal::RNTupleSerializer::RContext fSerializationContext;
 
    RDaosNTupleAnchor fNTupleAnchor;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -65,7 +65,7 @@ private:
    std::uint64_t fClusterMaxOffset = 0;
    /// Number of bytes committed to storage in the current cluster
    std::uint64_t fNBytesCurrentCluster = 0;
-   /// Used to keeo the column and field IDs issued during header serialization for the footer serialization
+   /// Used to keep the column and field IDs issued during header serialization for the footer serialization
    Internal::RNTupleSerializer::RContext fSerializationContext;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -65,6 +65,7 @@ private:
    std::uint64_t fClusterMaxOffset = 0;
    /// Number of bytes committed to storage in the current cluster
    std::uint64_t fNBytesCurrentCluster = 0;
+   /// Used to keeo the column and field IDs issued during header serialization for the footer serialization
    Internal::RNTupleSerializer::RContext fSerializationContext;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -229,9 +229,8 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl()
                                                     fSerializationContext);
 
    auto bufPageListZip = std::make_unique<unsigned char[]>(szPageList);
-   auto szPageListZip = fCompressor->Zip(
-      bufPageList.get(), szPageList, GetWriteOptions().GetCompression(),
-      [&bufPageListZip](const void *b, size_t n, size_t o) { memcpy(bufPageListZip.get() + o, b, n); });
+   auto szPageListZip = fCompressor->Zip(bufPageList.get(), szPageList, GetWriteOptions().GetCompression(),
+                                         RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
    fDaosContainer->WriteSingleAkey(bufPageListZip.get(), szPageListZip, kOidPageList, kDistributionKey, kAttributeKey,
                                    kCidMetadata);
 
@@ -246,9 +245,8 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl()
    Internal::RNTupleSerializer::SerializeFooterV1(bufFooter.get(), descriptor, fSerializationContext);
 
    auto bufFooterZip = std::make_unique<unsigned char[]>(szFooter);
-   auto szFooterZip =
-      fCompressor->Zip(bufFooter.get(), szFooter, GetWriteOptions().GetCompression(),
-                       [&bufFooterZip](const void *b, size_t n, size_t o) { memcpy(bufFooterZip.get() + o, b, n); });
+   auto szFooterZip = fCompressor->Zip(bufFooter.get(), szFooter, GetWriteOptions().GetCompression(),
+                                       RNTupleCompressor::MakeMemCopyWriter(bufFooterZip.get()));
    WriteNTupleFooter(bufFooterZip.get(), szFooterZip, szFooter);
    WriteNTupleAnchor();
 }

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -7,6 +7,7 @@ TEST(RPageStorageDaos, Basics)
    ROOTUnitTestSupport::CheckDiagsRAII diags;
    diags.requiredDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
    diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos", "The DAOS backend is experimental and still under development.", false);
+   diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
 
    std::string daosUri("daos://" R__DAOS_TEST_POOL ":1/a947484e-e3bc-48cb-8f71-3292c19b59a4");
 


### PR DESCRIPTION
Switch from V0 to V1 binary format in the DAOS backend. This should remove the last traces of the V0 serialization code so that a follow-up PR can remove it.