### PR TITLE
Minimize use of global write lock in typical event loops

### DIFF
--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -205,7 +205,7 @@ public:
    void               SetCurrentCollection();
    void               SetName(const char *name) { fName = name; }
    virtual void       SetOwner(Bool_t enable = kTRUE);
-   virtual bool       UseRWLock();
+   virtual bool       UseRWLock(Bool_t enable = true);
    virtual Int_t      Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
    virtual Int_t      Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
 

--- a/core/cont/inc/THashList.h
+++ b/core/cont/inc/THashList.h
@@ -67,7 +67,7 @@ public:
    void       Rehash(Int_t newCapacity);
    TObject   *Remove(TObject *obj);
    TObject   *Remove(TObjLink *lnk);
-   bool       UseRWLock();
+   bool       UseRWLock(Bool_t enable = true);
 
    ClassDef(THashList,0)  //Doubly linked list with hashtable for lookup
 };

--- a/core/cont/src/TCollection.cxx
+++ b/core/cont/src/TCollection.cxx
@@ -758,10 +758,14 @@ void TCollection::SetOwner(Bool_t enable)
 /// Note: To test whether the usage is enabled do:
 ///    collection->TestBit(TCollection::kUseRWLock);
 
-bool TCollection::UseRWLock()
+bool TCollection::UseRWLock(Bool_t enable)
 {
    bool prev = TestBit(TCollection::kUseRWLock);
-   SetBit(TCollection::kUseRWLock);
+   if (enable) {
+      SetBit(TCollection::kUseRWLock);
+   } else {
+      ResetBit(TCollection::kUseRWLock);
+   }
    return prev;
 }
 

--- a/core/cont/src/THashList.cxx
+++ b/core/cont/src/THashList.cxx
@@ -406,8 +406,8 @@ TObject *THashList::Remove(TObjLink *lnk)
 /// Note: To test whether the usage is enabled do:
 ///    collection->TestBit(TCollection::kUseRWLock);
 
-bool THashList::UseRWLock()
+bool THashList::UseRWLock(Bool_t enable)
 {
-   fTable->UseRWLock();
-   return TCollection::UseRWLock();
+   fTable->UseRWLock(enable);
+   return TCollection::UseRWLock(enable);
 }

--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -113,6 +113,8 @@ protected:
    TList           *fInfoCache{nullptr};      ///<!Cached list of the streamer infos in this file
    TList           *fOpenPhases{nullptr};     ///<!Time info about open phases
 
+   bool             fGlobalRegistration = true; ///<! if true, bypass use of global lists
+
 #ifdef R__USE_IMT
    std::mutex                                 fWriteMutex;  ///<!Lock for writing baskets / keys into the file.
    static ROOT::Internal::RConcurrentHashColl fgTsSIHashes; ///<!TS Set of hashes built from read streamer infos

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1324,7 +1324,9 @@ TFile::InfoListRet TFile::GetStreamerInfoListImpl(bool lookupSICache)
 
 #ifdef R__USE_IMT
       if (lookupSICache) {
-         hash = fgTsSIHashes.Hash(buf, fNbytesInfo);
+         // key data must be excluded from the hash, otherwise the timestamp will
+         // always lead to unique hashes for each file
+         hash = fgTsSIHashes.Hash(buf + key->GetKeylen(), fNbytesInfo - key->GetKeylen());
          if (fgTsSIHashes.Find(hash)) {
             if (gDebug > 0) Info("GetStreamerInfo", "The streamer info record for file %s has already been treated, skipping it.", GetName());
             return {nullptr, 0, hash};

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -203,12 +203,13 @@ TFile::TFile() : TDirectoryFile(), fCompress(ROOT::RCompressionSetting::EAlgorit
 ///
 /// Option | Description
 /// -------|------------
-/// NEW or CREATE | Create a new file and open it for writing, if the file already exists the file is not opened.
-/// RECREATE      | Create a new file, if the file already exists it will be overwritten.
-/// UPDATE        | Open an existing file for writing. If no file exists, it is created.
-/// READ          | Open an existing file for reading (default).
-/// NET           | Used by derived remote file access classes, not a user callable option.
-/// WEB           | Used by derived remote http access class, not a user callable option.
+/// NEW or CREATE                     | Create a new file and open it for writing, if the file already exists the file is not opened.
+/// RECREATE                          | Create a new file, if the file already exists it will be overwritten.
+/// UPDATE                            | Open an existing file for writing. If no file exists, it is created.
+/// READ                              | Open an existing file for reading (default).
+/// NET                               | Used by derived remote file access classes, not a user callable option.
+/// WEB                               | Used by derived remote http access class, not a user callable option.
+/// READ_WITHOUT_GLOBALREGISTRATION   | Used by TTreeProcessorMT, not a user callable option.
 ///
 /// If option = "" (default), READ is assumed.
 /// The file can be specified as a URL of the form:
@@ -383,6 +384,14 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
    if (fOption == "NEW")
       fOption = "CREATE";
 
+   if (fOption == "READ_WITHOUT_GLOBALREGISTRATION") {
+      fOption = "READ";
+      fGlobalRegistration = false;
+      if (fList) {
+         fList->UseRWLock(false);
+      }
+   }
+
    Bool_t create   = (fOption == "CREATE") ? kTRUE : kFALSE;
    Bool_t recreate = (fOption == "RECREATE") ? kTRUE : kFALSE;
    Bool_t update   = (fOption == "UPDATE") ? kTRUE : kFALSE;
@@ -502,7 +511,7 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
 
 zombie:
    // error in file opening occurred, make this object a zombie
-   {
+   if (fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfClosedObjects()->Add(this);
    }
@@ -540,7 +549,9 @@ TFile::~TFile()
 
    {
       R__LOCKGUARD(gROOTMutex);
-      gROOT->GetListOfClosedObjects()->Remove(this);
+      if (fGlobalRegistration) {
+         gROOT->GetListOfClosedObjects()->Remove(this);
+      }
       gROOT->GetUUIDs()->RemoveUUID(GetUniqueID());
    }
 
@@ -825,8 +836,10 @@ void TFile::Init(Bool_t create)
 
    {
       R__LOCKGUARD(gROOTMutex);
-      gROOT->GetListOfFiles()->Add(this);
-      gROOT->GetUUIDs()->AddUUID(fUUID,this);
+      if (fGlobalRegistration) {
+         gROOT->GetListOfFiles()->Add(this);
+      }
+      gROOT->GetUUIDs()->AddUUID(fUUID, this);
    }
 
    // Create StreamerInfo index
@@ -862,10 +875,11 @@ void TFile::Init(Bool_t create)
       }
       fProcessIDs = new TObjArray(fNProcessIDs+1);
    }
+
    return;
 
 zombie:
-   {
+   if (fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfClosedObjects()->Add(this);
    }
@@ -971,7 +985,7 @@ void TFile::Close(Option_t *option)
    }
    pidDeleted.Delete();
 
-   if (!IsZombie()) {
+   if (!IsZombie() && fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfFiles()->Remove(this);
       gROOT->GetListOfBrowsers()->RecursiveRemove(this);

--- a/tree/tree/inc/TChain.h
+++ b/tree/tree/inc/TChain.h
@@ -43,6 +43,7 @@ protected:
    TObjArray   *fFiles;            ///< -> List of file names containing the trees (TChainElement, owned)
    TList       *fStatus;           ///< -> List of active/inactive branches (TChainElement, owned)
    TChain      *fProofChain;       ///<! chain proxy when going to be processed by PROOF
+   bool         fGlobalRegistration;  ///<! if true, bypass use of global lists
 
 private:
    TChain(const TChain&);            // not implemented
@@ -66,8 +67,10 @@ public:
    static constexpr auto kBigNumber = TTree::kMaxEntries;
 
 public:
-   TChain();
-   TChain(const char* name, const char* title = "");
+   enum Mode { kWithoutGlobalRegistration, kWithGlobalRegistration };
+
+   TChain(Mode mode = kWithGlobalRegistration);
+   TChain(const char *name, const char *title = "", Mode mode = kWithGlobalRegistration);
    virtual ~TChain();
 
    virtual Int_t     Add(TChain* chain);

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -85,7 +85,6 @@ TChain::TChain()
    fFiles = new TObjArray(fTreeOffsetLen);
    fStatus = new TList();
    fTreeOffset[0]  = 0;
-   if (gDirectory) gDirectory->Remove(this);
    gROOT->GetListOfSpecials()->Add(this);
    fFile = 0;
    fDirectory = 0;

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -68,24 +68,17 @@ ClassImp(TChain);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
-TChain::TChain()
-: TTree()
-, fTreeOffsetLen(100)
-, fNtrees(0)
-, fTreeNumber(-1)
-, fTreeOffset(0)
-, fCanDeleteRefs(kFALSE)
-, fTree(0)
-, fFile(0)
-, fFiles(0)
-, fStatus(0)
-, fProofChain(0)
+TChain::TChain(Mode mode)
+   : TTree(), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(0), fCanDeleteRefs(kFALSE), fTree(0),
+     fFile(0), fFiles(0), fStatus(0), fProofChain(0), fGlobalRegistration(mode == kWithGlobalRegistration)
 {
    fTreeOffset = new Long64_t[fTreeOffsetLen];
    fFiles = new TObjArray(fTreeOffsetLen);
    fStatus = new TList();
    fTreeOffset[0]  = 0;
-   gROOT->GetListOfSpecials()->Add(this);
+   if (fGlobalRegistration) {
+      gROOT->GetListOfSpecials()->Add(this);
+   }
    fFile = 0;
    fDirectory = 0;
 
@@ -93,12 +86,14 @@ TChain::TChain()
    ResetBit(kProofUptodate);
    ResetBit(kProofLite);
 
-   // Add to the global list
-   gROOT->GetListOfDataSets()->Add(this);
+   if (fGlobalRegistration) {
+      // Add to the global list
+      gROOT->GetListOfDataSets()->Add(this);
 
-   // Make sure we are informed if the TFile is deleted.
-   R__LOCKGUARD(gROOTMutex);
-   gROOT->GetListOfCleanups()->Add(this);
+      // Make sure we are informed if the TFile is deleted.
+      R__LOCKGUARD(gROOTMutex);
+      gROOT->GetListOfCleanups()->Add(this);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,18 +136,10 @@ TChain::TChain()
 ///     }
 /// ~~~
 
-TChain::TChain(const char* name, const char* title)
-:TTree(name, title, /*splitlevel*/ 99, nullptr)
-, fTreeOffsetLen(100)
-, fNtrees(0)
-, fTreeNumber(-1)
-, fTreeOffset(0)
-, fCanDeleteRefs(kFALSE)
-, fTree(0)
-, fFile(0)
-, fFiles(0)
-, fStatus(0)
-, fProofChain(0)
+TChain::TChain(const char *name, const char *title, Mode mode)
+   : TTree(name, title, /*splitlevel*/ 99, nullptr), fTreeOffsetLen(100), fNtrees(0), fTreeNumber(-1), fTreeOffset(0),
+     fCanDeleteRefs(kFALSE), fTree(0), fFile(0), fFiles(0), fStatus(0), fProofChain(0),
+     fGlobalRegistration(mode == kWithGlobalRegistration)
 {
    //
    //*-*
@@ -167,14 +154,16 @@ TChain::TChain(const char* name, const char* title)
    ResetBit(kProofUptodate);
    ResetBit(kProofLite);
 
-   R__LOCKGUARD(gROOTMutex);
+   if (fGlobalRegistration) {
+      R__LOCKGUARD(gROOTMutex);
 
-   // Add to the global lists
-   gROOT->GetListOfSpecials()->Add(this);
-   gROOT->GetListOfDataSets()->Add(this);
+      // Add to the global lists
+      gROOT->GetListOfSpecials()->Add(this);
+      gROOT->GetListOfDataSets()->Add(this);
 
-   // Make sure we are informed if the TFile is deleted.
-   gROOT->GetListOfCleanups()->Add(this);
+      // Make sure we are informed if the TFile is deleted.
+      gROOT->GetListOfCleanups()->Add(this);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,7 +173,7 @@ TChain::~TChain()
 {
    bool rootAlive = gROOT && !gROOT->TestBit(TObject::kInvalidObject);
 
-   if (rootAlive) {
+   if (rootAlive && fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfCleanups()->Remove(this);
    }
@@ -212,7 +201,7 @@ TChain::~TChain()
    fTreeOffset = 0;
 
    // Remove from the global lists
-   if (rootAlive) {
+   if (rootAlive && fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
       gROOT->GetListOfSpecials()->Remove(this);
       gROOT->GetListOfDataSets()->Remove(this);
@@ -519,7 +508,8 @@ Int_t TChain::AddFile(const char* name, Long64_t nentries /* = TTree::kMaxEntrie
       TFile* file;
       {
          TDirectory::TContext ctxt;
-         file = TFile::Open(filename);
+         const char *option = fGlobalRegistration ? "READ" : "READ_WITHOUT_GLOBALREGISTRATION";
+         file = TFile::Open(filename, option);
       }
       if (!file || file->IsZombie()) {
          delete file;
@@ -1506,8 +1496,10 @@ Long64_t TChain::LoadTree(Long64_t entry)
    //        if we did not delete it above.
    {
       TDirectory::TContext ctxt;
-      fFile = TFile::Open(element->GetTitle());
-      if (fFile) fFile->SetBit(kMustCleanup);
+      const char *option = fGlobalRegistration ? "READ" : "READ_WITHOUT_GLOBALREGISTRATION";
+      fFile = TFile::Open(element->GetTitle(), option);
+      if (fFile && fGlobalRegistration)
+         fFile->SetBit(kMustCleanup);
    }
 
    // ----- Begin of modifications by MvL
@@ -1534,6 +1526,8 @@ Long64_t TChain::LoadTree(Long64_t entry)
          // We do not return yet so that 'fEntries' can be updated with the
          // sum of the entries of all the other trees.
          returnCode = -4;
+      } else if (!fGlobalRegistration) {
+         fTree->ResetBit(kMustCleanup);
       }
    }
 
@@ -2955,7 +2949,7 @@ void TChain::SetEventList(TEventList *evlist)
 
 void TChain::SetName(const char* name)
 {
-   {
+   if (fGlobalRegistration) {
       // Should this be extended to include the call to TTree::SetName?
       R__WRITE_LOCKGUARD(ROOT::gCoreMutex); // Take the lock once rather than 3 times.
       gROOT->GetListOfCleanups()->Remove(this);
@@ -2963,14 +2957,13 @@ void TChain::SetName(const char* name)
       gROOT->GetListOfDataSets()->Remove(this);
    }
    TTree::SetName(name);
-   {
+   if (fGlobalRegistration) {
       // Should this be extended to include the call to TTree::SetName?
       R__WRITE_LOCKGUARD(ROOT::gCoreMutex); // Take the lock once rather than 3 times.
       gROOT->GetListOfCleanups()->Add(this);
       gROOT->GetListOfSpecials()->Add(this);
       gROOT->GetListOfDataSets()->Add(this);
    }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -68,6 +68,7 @@ public:
                                               const std::vector<std::string> &fileNames, const TreeUtils::RFriendInfo &friendInfo,
                                               const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
                                               const std::vector<std::vector<Long64_t>> &friendEntries);
+   void Reset();
 };
 } // End of namespace Internal
 

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -81,7 +81,7 @@ ConvertToElistClusters(std::vector<std::vector<EntryCluster>> &&clusters, TEntry
       };
    } else {
       // we need `chain` to be able to convert local entry numbers to global entry numbers in `Next`
-      chain.reset(new TChain());
+      chain.reset(new TChain(TChain::kWithoutGlobalRegistration));
       for (auto i = 0u; i < nFiles; ++i)
          chain->Add((fileNames[i] + "?#" + treeNames[i]).c_str(), entriesPerFile[i]);
       Next = [](Long64_t &elEntry, TEntryList &elist, TChain *ch) {
@@ -143,12 +143,14 @@ static ClustersAndEntries MakeClusters(const std::vector<std::string> &treeNames
       const auto &fileName = fileNames[i];
       const auto &treeName = treeNames[i];
 
-      std::unique_ptr<TFile> f(TFile::Open(fileName.c_str())); // need TFile::Open to load plugins if need be
+      std::unique_ptr<TFile> f(TFile::Open(
+         fileName.c_str(), "READ_WITHOUT_GLOBALREGISTRATION")); // need TFile::Open to load plugins if need be
       if (!f || f->IsZombie()) {
          const auto msg = "TTreeProcessorMT::Process: an error occurred while opening file \"" + fileName + "\"";
          throw std::runtime_error(msg);
       }
       auto *t = f->Get<TTree>(treeName.c_str()); // t will be deleted by f
+      t->ResetBit(kMustCleanup);
 
       if (!t) {
          const auto msg = "TTreeProcessorMT::Process: an error occurred while getting tree \"" + treeName +
@@ -243,7 +245,8 @@ static std::vector<std::vector<Long64_t>> GetFriendEntries(const Internal::TreeU
       if (!thisFriendChainSubNames.empty()) {
          // Traverse together filenames and respective treenames
          for (auto fileidx = 0u; fileidx < thisFriendFiles.size(); ++fileidx) {
-            std::unique_ptr<TFile> curfile(TFile::Open(thisFriendFiles[fileidx].c_str()));
+            std::unique_ptr<TFile> curfile(
+               TFile::Open(thisFriendFiles[fileidx].c_str(), "READ_WITHOUT_GLOBALREGISTRATION"));
             if (!curfile || curfile->IsZombie())
                throw std::runtime_error("TTreeProcessorMT::GetFriendEntries: Could not open file \"" +
                                         thisFriendFiles[fileidx] + "\"");
@@ -261,7 +264,7 @@ static std::vector<std::vector<Long64_t>> GetFriendEntries(const Internal::TreeU
          // to retrieve from the file in `thisFriendFiles`
       } else {
          for (const auto &fname : thisFriendFiles) {
-            std::unique_ptr<TFile> f(TFile::Open(fname.c_str()));
+            std::unique_ptr<TFile> f(TFile::Open(fname.c_str(), "READ_WITHOUT_GLOBALREGISTRATION"));
             if (!f || f->IsZombie())
                throw std::runtime_error("TTreeProcessorMT::GetFriendEntries: Could not open file \"" + fname + "\"");
             TTree *t = f->Get<TTree>(thisFriendName.c_str());
@@ -302,7 +305,7 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
    const auto &friendFileNames = friendInfo.fFriendFileNames;
    const auto &friendChainSubNames = friendInfo.fFriendChainSubNames;
 
-   fChain.reset(new TChain());
+   fChain.reset(new TChain(TChain::kWithoutGlobalRegistration));
    const auto nFiles = fileNames.size();
    for (auto i = 0u; i < nFiles; ++i) {
       fChain->Add((fileNames[i] + "?#" + treeNames[i]).c_str(), nEntries[i]);
@@ -320,7 +323,7 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
       const auto &thisFriendEntries = friendEntries[i];
 
       // Build a friend chain
-      auto frChain = std::make_unique<TChain>(thisFriendName.c_str());
+      auto frChain = std::make_unique<TChain>(thisFriendName.c_str(), "", TChain::kWithoutGlobalRegistration);
       const auto nFileNames = friendFileNames[i].size();
       if (thisFriendChainSubNames.empty()) {
          // If there are no chain subnames, the friend was a TTree. It's safe
@@ -370,6 +373,15 @@ TTreeView::GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::st
    auto reader = std::make_unique<TTreeReader>(fChain.get(), fEntryList.get());
    reader->SetEntriesRange(start, end);
    return reader;
+}
+
+////////////////////////////////////////////////////////////////////////
+/// Clear the resources
+void TTreeView::Reset()
+{
+   fChain.reset();
+   fEntryList.reset();
+   fFriends.clear();
 }
 
 } // namespace Internal
@@ -549,6 +561,14 @@ void TTreeProcessorMT::Process(std::function<void(TTreeReader &)> func)
    std::iota(fileIdxs.begin(), fileIdxs.end(), 0u);
 
    fPool.Foreach(processFile, fileIdxs);
+
+   // make sure TChains and TFiles are cleaned up since they are not globally tracked
+   for (unsigned int islot = 0; islot < fTreeView.GetNSlots(); ++islot) {
+      ROOT::Internal::TTreeView *view = fTreeView.GetAtSlotRaw(islot);
+      if (view != nullptr) {
+         view->Reset();
+      }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This avoids the remaining uses of the global write lock in typical RDataFrame event loops.

There are two parts to this

1) A bug fix in the hashing of streamer info when opening files.  (The hash was including the TKey timestamp and therefore ended up being unique even for files with identical streamer info).

2) Since TTreeProcessorMT can carefully manage its TChains and corresponding TFile and TTree objects, global lists/cleanup and thread safety features can be bypassed or disabled.

Together these changes are enough to almost completely eliminate the use of the global write lock in typical event loops.  The only remaining using is the calls from ```TFile``` to ```TProcessUUID::AddUUID``` and ```TProcessUUID::RemoveUUID```  There are still several remaining places where the global read lock is taken, and these still have some cost in light of the remaining global write lock usage.


These changes have the biggest impact when analyzing a large number of files.  A test case is below.

Produce the test dataset:
```cpp
#include "TFile.h"
#include "TTree.h"
#include "TString.h"
#include <thread>

void testwrite() {

  const unsigned int nfiles = 4000;
  const unsigned int nentries = 1000*1000;

  float outval = 1.;

  for (unsigned int ifile = 0; ifile < nfiles; ++ifile) {
    TFile *fout = TFile::Open(TString::Format("test_%i.root", ifile), "RECREATE");
    TTree *tree = new TTree("tree", "");
    tree->Branch("outval", &outval);
    for (unsigned int ientry = 0; ientry < nentries; ++ientry) {
      tree->Fill();
    }
    tree->Write();
    fout->Close();

    // make sure that each key has a distinct timestamp to maximally
    // provoke different hashes for streamer info in each file
    std::this_thread::sleep_for(1100ms);
  }

}
```

Test event loop:
```python
import ROOT
ROOT.gInterpreter.ProcessLine(".O3")
ROOT.ROOT.EnableImplicitMT()


chain = ROOT.TChain("tree")
chain.Add("test_*.root")

d = ROOT.ROOT.RDataFrame(chain)
res = d.Sum("outval")

resval = res.GetValue()
print(resval)
```

With 256 threads:

+ Baseline:
        Percent of CPU this job got: 391%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 5:17.52

+ +hashing fix
        Percent of CPU this job got: 453%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 3:15.25

+ +hashing fix and reduction of remaining global write locks (this PR):
        Percent of CPU this job got: 1639%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:38.98

+ +hashing fix and reduction of remaining global write locks + remove TFile UUID registration (not in this PR anymore):
        Percent of CPU this job got: 19861%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:17.52
