### PR TITLE
[DF] Make Aliases specific to the computation graph branch

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -11,6 +11,7 @@
 #ifndef ROOT_RDF_TINTERFACE_UTILS
 #define ROOT_RDF_TINTERFACE_UTILS
 
+#include "RColumnRegister.hxx"
 #include <ROOT/RDF/RAction.hxx>
 #include <ROOT/RDF/ActionHelpers.hxx> // for BuildAction
 #include <ROOT/RDF/RColumnRegister.hxx>
@@ -289,23 +290,18 @@ void CheckFilter(Filter &)
 
 ColumnNames_t FilterArraySizeColNames(const ColumnNames_t &columnNames, const std::string &action);
 
-std::string ResolveAlias(const std::string &col, const std::map<std::string, std::string> &aliasMap);
-
 void CheckValidCppVarName(std::string_view var, const std::string &where);
 
-void CheckForRedefinition(const std::string &where, std::string_view definedCol, const ColumnNames_t &customCols,
-                          const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &treeColumns,
-                          const ColumnNames_t &dataSourceColumns);
+void CheckForRedefinition(const std::string &where, std::string_view definedCol, const RColumnRegister &customCols,
+                          const ColumnNames_t &treeColumns, const ColumnNames_t &dataSourceColumns);
 
-void CheckForDefinition(const std::string &where, std::string_view definedColView, const ColumnNames_t &customCols,
-                        const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &treeColumns,
-                        const ColumnNames_t &dataSourceColumns);
+void CheckForDefinition(const std::string &where, std::string_view definedColView, const RColumnRegister &customCols,
+                        const ColumnNames_t &treeColumns, const ColumnNames_t &dataSourceColumns);
 
 std::string PrettyPrintAddr(const void *const addr);
 
 void BookFilterJit(const std::shared_ptr<RJittedFilter> &jittedFilter, std::shared_ptr<RNodeBase> *prevNodeOnHeap,
-                   std::string_view name, std::string_view expression,
-                   const std::map<std::string, std::string> &aliasMap, const ColumnNames_t &branches,
+                   std::string_view name, std::string_view expression, const ColumnNames_t &branches,
                    const RColumnRegister &customCols, TTree *tree, RDataSource *ds);
 
 std::shared_ptr<RJittedDefine> BookDefineJit(std::string_view name, std::string_view expression, RLoopManager &lm,
@@ -347,7 +343,7 @@ bool AtLeastOneEmptyString(const std::vector<std::string_view> strings);
 std::shared_ptr<RNodeBase> UpcastNode(std::shared_ptr<RNodeBase> ptr);
 
 ColumnNames_t GetValidatedColumnNames(RLoopManager &lm, const unsigned int nColumns, const ColumnNames_t &columns,
-                                      const ColumnNames_t &validDefines, RDataSource *ds);
+                                      const RColumnRegister &validDefines, RDataSource *ds);
 
 std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, const RColumnRegister &colRegister,
                                               TTree *tree, RDataSource *ds, const std::string &context,
@@ -628,7 +624,7 @@ const ColumnNames_t SelectColumns(unsigned int nArgs, const ColumnNames_t &bl, c
 
 /// Check whether column names refer to a valid branch of a TTree or have been `Define`d. Return invalid column names.
 ColumnNames_t FindUnknownColumns(const ColumnNames_t &requiredCols, const ColumnNames_t &datasetColumns,
-                                 const ColumnNames_t &definedCols, const ColumnNames_t &dataSourceColumns);
+                                 const RColumnRegister &definedCols, const ColumnNames_t &dataSourceColumns);
 
 /// Returns the list of Filters defined in the whole graph
 std::vector<std::string> GetFilterNames(const std::shared_ptr<RLoopManager> &loopManager);

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -50,6 +50,8 @@ private:
    /// When a new define is added (through a call to RInterface::Define or similar) a new map with the extra element is
    /// created.
    RDefineBasePtrMapPtr_t fDefines;
+   /// Immutable map of Aliases, can be shared among several nodes.
+   std::shared_ptr<const std::unordered_map<std::string, std::string>> fAliases;
    ColumnNamesPtr_t fColumnNames; ///< Names of Defines and Aliases registered so far.
 
 public:
@@ -58,7 +60,9 @@ public:
    RColumnRegister &operator=(const RColumnRegister &) = default;
 
    RColumnRegister()
-      : fDefines(std::make_shared<RDefineBasePtrMap_t>()), fColumnNames(std::make_shared<ColumnNames_t>())
+      : fDefines(std::make_shared<RDefineBasePtrMap_t>()),
+        fAliases(std::make_shared<std::unordered_map<std::string, std::string>>()),
+        fColumnNames(std::make_shared<ColumnNames_t>())
    {
    }
 
@@ -86,6 +90,20 @@ public:
    /// in each branch of the computation graph.
    /// Internally it recreates the vector with the new name, and swaps it with the old one.
    void AddName(std::string_view name);
+
+   /// \brief Add a new alias to the ledger.
+   void AddAlias(std::string_view alias, std::string_view colName);
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Return true if the given column name is an existing alias.
+   bool IsAlias(const std::string &name) const;
+
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Return the actual column name that the alias resolves to.
+   /// Drills through multiple levels of aliasing if needed.
+   /// Returns the input in case it's not an alias.
+   /// Expands `#var` to `R_rdf_sizeof_var` (the #var columns are implicitly-defined aliases).
+   std::string ResolveAlias(std::string_view alias) const;
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Empty the contents of this ledger.

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -45,6 +45,14 @@ class RColumnRegister {
    using RDefineBasePtrMapPtr_t = std::shared_ptr<const RDefineBasePtrMap_t>;
    using ColumnNamesPtr_t = std::shared_ptr<const ColumnNames_t>;
 
+   ////////////////////////////////////////////////////////////////////////////
+   /// \brief Add a new name to the list returned by `GetNames` without booking a new column.
+   ///
+   /// This is needed because we abuse fColumnNames to also keep track of the aliases defined
+   /// in each branch of the computation graph.
+   /// Internally it recreates the vector with the new name, and swaps it with the old one.
+   void AddName(std::string_view name);
+
 private:
    /// Immutable map of Defines, can be shared among several nodes.
    /// When a new define is added (through a call to RInterface::Define or similar) a new map with the extra element is
@@ -82,14 +90,6 @@ public:
    /// \brief Add a new booked column.
    /// Internally it recreates the map with the new column, and swaps it with the old one.
    void AddColumn(const std::shared_ptr<RDFDetail::RDefineBase> &column);
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Add a new name to the list returned by `GetNames` without booking a new column.
-   ///
-   /// This is needed because we abuse fColumnNames to also keep track of the aliases defined
-   /// in each branch of the computation graph.
-   /// Internally it recreates the vector with the new name, and swaps it with the old one.
-   void AddName(std::string_view name);
 
    /// \brief Add a new alias to the ledger.
    void AddAlias(std::string_view alias, std::string_view colName);

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -119,7 +119,6 @@ class RLoopManager : public RNodeBase {
    bool fMustRunNamedFilters{true};
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
    const std::unique_ptr<RDataSource> fDataSource; ///< Owning pointer to a data-source object. Null if no data-source
-   std::map<std::string, std::string> fAliasColumnNameMap; ///< ColumnNameAlias-columnName pairs
    std::vector<RDFInternal::RCallback> fCallbacks;         ///< Registered callbacks
    /// Registered callbacks to invoke just once before running the loop
    std::vector<RDFInternal::ROneTimeCallback> fCallbacksOnce;
@@ -185,8 +184,6 @@ public:
    void IncrChildrenCount() final { ++fNChildren; }
    void StopProcessing() final { ++fNStopsReceived; }
    void ToJitExec(const std::string &) const;
-   void AddColumnAlias(const std::string &alias, const std::string &colName) { fAliasColumnNameMap[alias] = colName; }
-   const std::map<std::string, std::string> &GetAliasMap() const { return fAliasColumnNameMap; }
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);
    unsigned int GetNRuns() const { return fNRuns; }
    bool HasDSValuePtrs(const std::string &col) const;

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -74,7 +74,7 @@ TEST(RDataFrameInterface, CreateAliases)
 TEST(RDataFrameInterface, CheckAliasesPerChain)
 {
    RDataFrame tdf(1);
-   auto d = tdf.Define("c0", []() { return 0; });
+   auto d = tdf.Define("c0", []() { return 42; });
    // Now branch the graph
    auto ok = []() { return true; };
    auto f0 = d.Filter(ok);
@@ -82,6 +82,7 @@ TEST(RDataFrameInterface, CheckAliasesPerChain)
    auto f0a = f0.Alias("c1", "c0");
    // must work
    auto f0aa = f0a.Alias("c2", "c1");
+   EXPECT_EQ(f0aa.Max<int>("c2").GetValue(), 42);
    // must fail
    EXPECT_ANY_THROW(f1.Alias("c2", "c1")) << "No exception thrown when trying to alias a non-existing column.";
 }

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -388,9 +388,12 @@ TEST(RDataFrameInterface, GetNSlots)
 TEST(RDataFrameInterface, DefineAliasedColumn)
 {
    ROOT::RDataFrame rdf(1);
-   auto r0 = rdf.Define("myVar", [](){return 1;});
+   auto r0 = rdf.Define("myVar", [] { return 1; });
    auto r1 = r0.Alias("newVar", "myVar");
-   EXPECT_ANY_THROW(r0.Define("newVar", [](int i){return i;}, {"myVar"})) << "No exception thrown when defining a column with a name which is already an alias.";
+   auto mdefine = r0.Define("newVar", [] { return 42; }).Max<int>("newVar");
+   auto malias = r1.Max<int>("newVar");
+   EXPECT_EQ(*mdefine, 42);
+   EXPECT_EQ(*malias, 1);
 }
 
 // ROOT-10619

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -87,6 +87,22 @@ TEST(RDataFrameInterface, CheckAliasesPerChain)
    EXPECT_ANY_THROW(f1.Alias("c2", "c1")) << "No exception thrown when trying to alias a non-existing column.";
 }
 
+TEST(RDataFrameInterface, PerBranchAliases)
+{
+   // test that it's possible to register the same alias in different branches of the computation graph
+   auto df = ROOT::RDataFrame(1).Define("x", [] { return 42; }).Define("y", [] { return 0; });
+   auto dfzx = df.Alias("z", "x");
+   auto dfzy = df.Alias("z", "y");
+
+   EXPECT_ANY_THROW(df.Max<int>("z"))
+      << "No exception thrown when trying to access an alias that is not present at this point of the graph.";
+
+   auto max42 = dfzx.Max<int>("z");
+   auto max0 = dfzy.Max<int>("z");
+   EXPECT_EQ(*max42, 42);
+   EXPECT_EQ(*max0, 0);
+}
+
 TEST(RDataFrameInterface, GetColumnNamesFromScratch)
 {
    RDataFrame f(1);

--- a/tree/dataframe/test/dataframe_utils.cxx
+++ b/tree/dataframe/test/dataframe_utils.cxx
@@ -141,6 +141,7 @@ TEST(RDataFrameUtils, FindUnknownColumns)
    defs.AddAlias("b", "a");
 
    auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), defs, {});
+   EXPECT_EQ(ncols.size(), 2u);
    EXPECT_STREQ("c", ncols[0].c_str());
    EXPECT_STREQ("d", ncols[1].c_str());
 }

--- a/tree/dataframe/test/dataframe_utils.cxx
+++ b/tree/dataframe/test/dataframe_utils.cxx
@@ -137,7 +137,10 @@ TEST(RDataFrameUtils, FindUnknownColumns)
    TTree t("t", "t");
    t.Branch("a", &i);
 
-   auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), {"b"}, {});
+   RDFInt::RColumnRegister defs;
+   defs.AddAlias("b", "a");
+
+   auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), defs, {});
    EXPECT_STREQ("c", ncols[0].c_str());
    EXPECT_STREQ("d", ncols[1].c_str());
 }
@@ -148,7 +151,10 @@ TEST(RDataFrameUtils, FindUnknownColumnsWithDataSource)
    TTree t("t", "t");
    t.Branch("a", &i);
 
-   auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), {"b"}, {"c"});
+   RDFInt::RColumnRegister defs;
+   defs.AddAlias("b", "a");
+
+   auto ncols = RDFInt::FindUnknownColumns({"a", "b", "c", "d"}, RDFInt::GetBranchNames(t), defs, {"c"});
    EXPECT_EQ(ncols.size(), 1u);
    EXPECT_STREQ("d", ncols[0].c_str());
 }


### PR DESCRIPTION
As there is one RLoopManager per computation graph, when aliases
were managed by RLoopManager they were computation-graph-wide.
It is desirable to make Alias definitions behave coherently with
Defines instead, i.e. have Aliases be only accessible in the branch
of the computation graph in which they were defined, and only in
nodes that are downstream of the one where the alias is added.

This resolves #7381, "[DF] Let Aliases be defined per computation graph
branch, not globally".

In particular, in this commit:
- move alias management from RLoopManager to RBookedColumns
- remove alias-managing logic from RLoopManager
- refactor several functions so they only take RBookedColumns as input
  rather than a list of defined names plus a map of aliases
  (CheckForDefinition, CheckForRedefinition, FindUnknownColumns,
  GetValidatedColumnNames, BookFilterJit, FindUsedColumns,
  ParseRDFExpression)
- use RBookedColumns::ResolveAlias instead of ResolveAlias helper function
- adapt dataframe_utils test to the new signature of FindUnknownColumns

Note that this is a backward-incompatible change for user code that
relied on this global definition of Aliases. We expect this to be an
exceedingly rare usecase, and if such code exists it will produce a
clear error message.

