### PR TITLE
[dictgen] On macOS, use argv[0] to detect genreflex:

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -6125,6 +6125,12 @@ int ROOT_rootcling_Driver(int argc, char **argv, const ROOT::Internal::RootCling
    gBuildingROOT = config.fBuildingROOTStage1; // gets refined later
 
    std::string exeName = ExtractFileName(GetExePath());
+#ifdef __APPLE__
+   // _dyld_get_image_name() on macOS11 and later sometimes returns "rootcling" for "genreflex".
+   // Fix that (while still initializing the binary path, needed for ROOTSYS) by updating the
+   // exeName to argv[0]:
+   exeName = ExtractFileName(argv[0]);
+#endif
 
    // Select according to the name of the executable the procedure to follow:
    // 1) RootCling


### PR DESCRIPTION
_dyld_get_image_name() sporadically and only semi-reproducibly returns
"rootcling" when asked by the genreflex binary. Maybe because both binaries
are bitwise identical, and the image is shared - who knows.

To prevent the rootcling argument parsing being active mistakenly for genreflex:

genreflex: Not enough positional command line arguments specified!
Must specify at least 2 positional arguments: See: genreflex --help

make sure we get this right by not relying on _dyld_get_image_name() but on argv[0].
Call GetExePath() nonetheless, because we need it to set ROOTSYS.
