### PR TITLE
[DF] Minor non-functional changes

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -153,7 +153,7 @@ public:
    }
 
    /// Clean-up operations to be performed at the end of a task.
-   virtual void FinaliseSlot(unsigned int slot) final
+   void FinaliseSlot(unsigned int slot) final
    {
       for (auto &v : fValues[slot])
          v.reset();

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -69,7 +69,6 @@ public:
    /// Clean-up operations to be performed at the end of a task.
    virtual void FinaliseSlot(unsigned int slot) = 0;
    virtual void InitNode();
-   virtual void AddFilterName(std::vector<std::string> &filters) = 0;
 };
 
 } // ns RDF


### PR DESCRIPTION
- [NFC][DF] Remove redundant virtual keyword: `final` implies `virtual`.
- [NFC][DF] Remove unnecessary pure virtual method: the line just re-declared a method from the RNodeBase base class.