### PR TITLE
fix copy/move constructors/assignment for THnBase

### DIFF
--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -66,6 +66,14 @@ protected:
     THnBase(const char *name, const char *title, Int_t dim, const Int_t *nbins,
             const std::vector<std::vector<double>> &xbins);
 
+    THnBase(const THnBase &other);
+
+    THnBase &operator=(const THnBase &other);
+
+    THnBase(THnBase &&other);
+
+    THnBase &operator=(THnBase &&other);
+
     void UpdateXStat(const Double_t *x, Double_t w = 1.)
     {
        if (GetCalculateErrors()) {

--- a/hist/hist/src/THnBase.cxx
+++ b/hist/hist/src/THnBase.cxx
@@ -83,6 +83,82 @@ THnBase::THnBase(const char *name, const char *title, Int_t dim, const Int_t *nb
    fAxes.SetOwner();
 }
 
+THnBase::THnBase(const THnBase &other)
+   : TNamed(other), fNdimensions(other.fNdimensions), fAxes(fNdimensions), fBrowsables(fNdimensions),
+     fEntries(other.fEntries), fTsumw(other.fTsumw), fTsumw2(other.fTsumw2), fTsumwx(other.fTsumwx),
+     fTsumwx2(other.fTsumwx2), fIntegral(other.fIntegral), fIntegralStatus(other.fIntegralStatus)
+{
+
+   for (Int_t i = 0; i < fNdimensions; ++i) {
+      TAxis *axis = new TAxis(*static_cast<TAxis *>(other.fAxes[i]));
+      fAxes.AddAtAndExpand(axis, i);
+   }
+   fAxes.SetOwner();
+}
+
+THnBase &THnBase::operator=(const THnBase &other)
+{
+
+   if (this == &other)
+      return *this;
+
+   TNamed::operator=(other);
+   fNdimensions = other.fNdimensions;
+   fAxes = TObjArray(fNdimensions);
+   fBrowsables = TObjArray(fNdimensions);
+   fEntries = other.fEntries;
+   fTsumw = other.fTsumw;
+   fTsumw2 = other.fTsumw2;
+   fTsumwx = other.fTsumwx;
+   fTsumwx2 = other.fTsumwx2;
+   fIntegral = other.fIntegral;
+   fIntegralStatus = other.fIntegralStatus;
+
+   for (Int_t i = 0; i < fNdimensions; ++i) {
+      TAxis *axis = new TAxis(*static_cast<TAxis *>(other.fAxes[i]));
+      fAxes.AddAtAndExpand(axis, i);
+   }
+   fAxes.SetOwner();
+
+   return *this;
+}
+
+THnBase::THnBase(THnBase &&other)
+   : TNamed(std::move(other)), fNdimensions(other.fNdimensions), fAxes(other.fAxes), fBrowsables(fNdimensions),
+     fEntries(other.fEntries), fTsumw(other.fTsumw), fTsumw2(other.fTsumw2), fTsumwx(std::move(other.fTsumwx)),
+     fTsumwx2(std::move(other.fTsumwx2)), fIntegral(std::move(other.fIntegral)), fIntegralStatus(other.fIntegralStatus)
+{
+
+   other.fAxes.SetOwner(false);
+   other.fAxes.Clear();
+   fAxes.SetOwner();
+}
+
+THnBase &THnBase::operator=(THnBase &&other)
+{
+
+   if (this == &other)
+      return *this;
+
+   TNamed::operator=(std::move(other));
+   fNdimensions = other.fNdimensions;
+   fAxes = other.fAxes;
+   fBrowsables = TObjArray(fNdimensions);
+   fEntries = other.fEntries;
+   fTsumw = other.fTsumw;
+   fTsumw2 = other.fTsumw2;
+   fTsumwx = std::move(other.fTsumwx);
+   fTsumwx2 = std::move(other.fTsumwx2);
+   fIntegral = std::move(other.fIntegral);
+   fIntegralStatus = other.fIntegralStatus;
+
+   other.fAxes.SetOwner(false);
+   other.fAxes.Clear();
+   fAxes.SetOwner();
+
+   return *this;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Destruct a THnBase
 


### PR DESCRIPTION
Following https://github.com/root-project/root/pull/7499 THnBase and derived classes have auto-generated copy and move constructors and assignment operators, but these don't have fully the desired behaviour because of the TObjArray data members in THnBase.

In particular the axes objects end up being shared between the original histogram and the copy, such that deleting the original makes the copy unusable.  Fixed by implementing manual copy and move constructors and assignment operators for THnBase (all the other auto-generated ones should be ok)
