### PR TITLE
Enable Viewing HTML Reference Guide offline and in IDE

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -1471,14 +1471,14 @@ TOC_EXPAND             = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_QHP           = NO
+GENERATE_QHP           = YES
 
 # If the QHG_LOCATION tag is specified, the QCH_FILE tag can be used to specify
 # the file name of the resulting .qch file. The path specified is relative to
 # the HTML output folder.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QCH_FILE               =
+QCH_FILE               = ROOT.qch
 
 # The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
 # Project output. For more information please see Qt Help Project / Namespace
@@ -1487,7 +1487,7 @@ QCH_FILE               =
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHP_NAMESPACE          = org.doxygen.Project
+QHP_NAMESPACE          = cern.ch.ROOT
 
 # The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating Qt
 # Help Project output. For more information please see Qt Help Project / Virtual
@@ -1526,7 +1526,7 @@ QHP_SECT_FILTER_ATTRS  =
 # run qhelpgenerator on the generated .qhp file.
 # This tag requires that the tag GENERATE_QHP is set to YES.
 
-QHG_LOCATION           =
+QHG_LOCATION           = qhelpgenerator
 
 # If the GENERATE_ECLIPSEHELP tag is set to YES, additional index files will be
 # generated, together with the HTML files, they form an Eclipse help plugin. To


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Enables viewing the HTML reference guide directly embedded within the QtCreator IDE, by pressing F1 on each function, in the same Fashion as the Help functionality of MATLAB. It also allows searching the Reference Guide without needing to open a web browser or while being offline.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/8781
