### PR TITLE
[RDF] Remove static members from SaveGraph

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
@@ -52,23 +52,10 @@ private:
    bool fIsNew = true; ///< A just created node. This means that in no other exploration the node was already created
    ///< (this is needed because branches may share some common node).
 
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Returns a static variable to allow each node to retrieve its counter
-   static unsigned int &GetStaticGlobalCounter()
-   {
-      static unsigned int sGlobalCounter = 1;
-      return sGlobalCounter;
-   }
-
 public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Creates a node with a name and a counter
-   GraphNode(const std::string_view &name) : fName(name) { fCounter = GetStaticGlobalCounter()++; }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Resets the counter.
-   /// This is not strictly needed but guarantees that two consecutive request to the graph return the same result.
-   static void ClearCounter() { GraphNode::GetStaticGlobalCounter() = 1; }
+   GraphNode(const std::string_view &name) : fName(name) {}
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Appends a node on the head of the current node

--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -35,20 +35,7 @@ class RRangeBase;
 namespace Internal {
 namespace RDF {
 class RColumnRegister;
-
 namespace GraphDrawing {
-std::shared_ptr<GraphNode>
-CreateDefineNode(const std::string &columnName, const ROOT::Detail::RDF::RDefineBase *columnPtr);
-
-std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr);
-
-std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr);
-
-
-/// Add the Defines that have been added between this node and the previous to the graph.
-/// Return the new "upmost" node, i.e. the last of the Defines added if any, otherwise the node itself
-std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRegister &colRegister,
-                                             const std::vector<std::string> &prevNodeDefines);
 
 // clang-format off
 /**
@@ -63,46 +50,9 @@ std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, co
 // clang-format on
 class GraphCreatorHelper {
 private:
-   using DefinesNodesMap_t = std::map<const ROOT::Detail::RDF::RDefineBase *, std::weak_ptr<GraphNode>>;
-   using FiltersNodesMap_t = std::map<const ROOT::Detail::RDF::RFilterBase *, std::weak_ptr<GraphNode>>;
-   using RangesNodesMap_t = std::map<const ROOT::Detail::RDF::RRangeBase *, std::weak_ptr<GraphNode>>;
-
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Stores the columns defined and which node in the graph defined them.
-   static DefinesNodesMap_t &GetStaticColumnsMap()
-   {
-      static DefinesNodesMap_t sMap;
-      return sMap;
-   };
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Stores the filters defined and which node in the graph defined them.
-   static FiltersNodesMap_t &GetStaticFiltersMap()
-   {
-      static FiltersNodesMap_t sMap;
-      return sMap;
-   }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Stores the ranges defined and which node in the graph defined them.
-   static RangesNodesMap_t &GetStaticRangesMap()
-   {
-      static RangesNodesMap_t sMap;
-      return sMap;
-   }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Invoked by the RNodes to create a define graph node.
-   friend std::shared_ptr<GraphNode>
-   CreateDefineNode(const std::string &columnName, const ROOT::Detail::RDF::RDefineBase *columnPtr);
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Invoked by the RNodes to create a Filter graph node.
-   friend std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr);
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Invoked by the RNodes to create a Range graph node.
-   friend std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr);
+   /// \brief Map to keep track of visited nodes when constructing the computation graph (SaveGraph)
+   std::unordered_map<void *, std::shared_ptr<GraphNode>> fVisitedMap;
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Starting from any leaf (Action, Filter, Range) it draws the dot representation of the branch.
@@ -112,6 +62,7 @@ private:
    /// \brief Starting by an array of leaves, it draws the entire graph.
    std::string FromGraphActionsToDot(std::vector<std::shared_ptr<GraphNode>> leaves);
 
+public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Starting from the root node, prints the entire graph.
    std::string RepresentGraph(ROOT::RDataFrame &rDataFrame);
@@ -128,7 +79,7 @@ private:
       auto loopManager = rInterface.GetLoopManager();
       loopManager->Jit();
 
-      return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph());
+      return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph(fVisitedMap));
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -141,24 +92,7 @@ private:
       loopManager->Jit();
 
       auto actionPtr = resultPtr.fActionPtr;
-      return FromGraphLeafToDot(actionPtr->GetGraph());
-   }
-
-public:
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Functor. Initializes the static members and delegates the work to the right override.
-   /// \tparam NodeType the RNode from which the graph has to be drawn
-   template <typename NodeType>
-   std::string operator()(NodeType &node)
-   {
-      // First all static data structures are cleaned, to avoid undefined behaviours if more than one Represent is
-      // called
-      GetStaticFiltersMap() = FiltersNodesMap_t();
-      GetStaticColumnsMap() = DefinesNodesMap_t();
-      GetStaticRangesMap() = RangesNodesMap_t();
-      GraphNode::ClearCounter();
-      // The Represent can now start on a clean environment
-      return RepresentGraph(node);
+      return FromGraphLeafToDot(actionPtr->GetGraph(fVisitedMap));
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -34,7 +34,8 @@ namespace RDFGraphDrawing = ROOT::Internal::RDF::GraphDrawing;
 namespace GraphDrawing {
 std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node,
                                              const RDFInternal::RColumnRegister &colRegister,
-                                             const std::vector<std::string> &prevNodeDefines);
+                                             const std::vector<std::string> &prevNodeDefines,
+                                             std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
 } // namespace GraphDrawing
 
 // clang-format off
@@ -135,15 +136,18 @@ public:
       SetHasRun();
    }
 
-   std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph() final
+   std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) final
    {
-      auto prevNode = fPrevData.GetGraph();
+      auto prevNode = fPrevData.GetGraph(visitedMap);
       auto prevColumns = prevNode->GetDefinedColumns();
 
       // Action nodes do not need to go through CreateFilterNode: they are never common nodes between multiple branches
       auto thisNode = std::make_shared<RDFGraphDrawing::GraphNode>(fHelper.GetActionName());
+      visitedMap[(void *)this] = thisNode;
+      thisNode->SetCounter(visitedMap.size());
 
-      auto upmostNode = AddDefinesToGraph(thisNode, GetColRegister(), prevColumns);
+      auto upmostNode = AddDefinesToGraph(thisNode, GetColRegister(), prevColumns, visitedMap);
 
       thisNode->AddDefinedColumns(GetColRegister().GetNames());
       thisNode->SetAction(HasRun());

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -74,7 +74,8 @@ public:
    virtual bool HasRun() const { return fHasRun; }
    virtual void SetHasRun() { fHasRun = true; }
 
-   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph() = 0;
+   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap) = 0;
 
    /**
       Retrieve a wrapper to the result of the action that knows how to merge

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -56,7 +56,8 @@ public:
    bool HasRun() const final;
    void SetHasRun() final;
 
-   std::shared_ptr<GraphDrawing::GraphNode> GetGraph();
+   std::shared_ptr<GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<GraphDrawing::GraphNode>> &visitedMap);
 
    // Helper for RMergeableValue
    std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> GetMergeableValue() const final;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -58,7 +58,8 @@ public:
    void InitNode() final;
    void AddFilterName(std::vector<std::string> &filters) final;
    void FinaliseSlot(unsigned int slot) final;
-   std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph();
+   std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap);
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -205,7 +205,8 @@ public:
    /// Return all actions, either booked or already run
    std::vector<RDFInternal::RActionBase *> GetAllActions() const;
 
-   std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph();
+   std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> & /*visitedMap*/);
 
    const ColumnNames_t &GetBranchNames();
 

--- a/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace ROOT {
 namespace RDF {
@@ -54,7 +55,8 @@ public:
    virtual void StopProcessing() = 0;
    virtual void AddFilterName(std::vector<std::string> &filters) = 0;
    // Helper function for SaveGraph
-   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph() = 0;
+   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap) = 0;
 
    virtual void ResetChildrenCount()
    {

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -23,7 +23,8 @@ namespace ROOT {
 namespace Internal {
 namespace RDF {
 namespace GraphDrawing {
-std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr);
+std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr,
+                                           std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
 } // ns GraphDrawing
 } // ns RDF
 } // ns Internal
@@ -98,14 +99,15 @@ public:
 
    /// This function must be defined by all nodes, but only the filters will add their name
    void AddFilterName(std::vector<std::string> &filters) { fPrevData.AddFilterName(filters); }
-   std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph()
+   std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
    {
       // TODO: Ranges node have no information about custom columns, hence it is not possible now
       // if defines have been used before.
-      auto prevNode = fPrevData.GetGraph();
+      auto prevNode = fPrevData.GetGraph(visitedMap);
       auto prevColumns = prevNode->GetDefinedColumns();
 
-      auto thisNode = RDFGraphDrawing::CreateRangeNode(this);
+      auto thisNode = RDFGraphDrawing::CreateRangeNode(this, visitedMap);
 
       /* If the returned node is not new, there is no need to perform any other operation.
        * This is a likely scenario when building the entire graph in which branches share

--- a/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
@@ -50,7 +50,8 @@ public:
    virtual ~RRangeBase();
 
    void InitNode() { ResetCounters(); }
-   virtual std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph() = 0;
+   virtual std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) = 0;
 };
 
 } // ns RDF

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -80,10 +80,11 @@ void RJittedAction::SetHasRun()
    return fConcreteAction->SetHasRun();
 }
 
-std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph()
+std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph(
+   std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap)
 {
    assert(fConcreteAction != nullptr);
-   return fConcreteAction->GetGraph();
+   return fConcreteAction->GetGraph(visitedMap);
 }
 
 /**

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -108,11 +108,12 @@ void RJittedFilter::AddFilterName(std::vector<std::string> &filters)
    fConcreteFilter->AddFilterName(filters);
 }
 
-std::shared_ptr<RDFGraphDrawing::GraphNode> RJittedFilter::GetGraph()
+std::shared_ptr<RDFGraphDrawing::GraphNode>
+RJittedFilter::GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
 {
    if (fConcreteFilter != nullptr) {
       // Here the filter exists, so it can be served
-      return fConcreteFilter->GetGraph();
+      return fConcreteFilter->GetGraph(visitedMap);
    }
    throw std::runtime_error("The Jitting should have been invoked before this method.");
 }

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -878,7 +878,8 @@ std::vector<RDFInternal::RActionBase *> RLoopManager::GetAllActions() const
    return actions;
 }
 
-std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetGraph()
+std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetGraph(
+   std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> & /*visitedMap*/)
 {
    std::string name;
    if (fDataSource) {

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -122,59 +122,59 @@ public:
    std::string GetRealRepresentationFromRoot()
    {
       return std::string("digraph {\n"
-                         "\t9 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
+                         "\t8 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t7 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t8 [label=\"Define\n"
+             "\t6 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t7 [label=\"Define\n"
              "Branch_1_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t4 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t5 [label=\"Define\n"
+             "\t3 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t4 [label=\"Define\n"
              "Branch_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t6 [label=\"Define\n"
+             "\t5 [label=\"Define\n"
              "Root_def2\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t2 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t3 [label=\"Define\n"
+             "\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t2 [label=\"Define\n"
              "Root_def1\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
              "\t0 [label=\"8\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n"
-             "\t13 [label=\"Count\", style=\"filled\", fillcolor=\"" +
+             "\t11 [label=\"Count\", style=\"filled\", fillcolor=\"" +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t11 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t12 [label=\"Define\n"
+             "\t9 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t10 [label=\"Define\n"
              "Branch_1_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t20 [label=\"Max\", style=\"filled\", fillcolor=\"" +
+             "\t17 [label=\"Max\", style=\"filled\", fillcolor=\"" +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t17 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t18 [label=\"Define\n"
+             "\t14 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t15 [label=\"Define\n"
              "Branch_2_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t19 [label=\"Define\n"
-             "Branch_2_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t15 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
              "\t16 [label=\"Define\n"
+             "Branch_2_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
+             "\t12 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t13 [label=\"Define\n"
              "Branch_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t22 [label=\"Count\", style=\"filled\", fillcolor=\"" +
+             "\t18 [label=\"Count\", style=\"filled\", fillcolor=\"" +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t7 -> 9;\n"
-             "\t8 -> 7;\n"
-             "\t4 -> 8;\n"
+             "\t6 -> 8;\n"
+             "\t7 -> 6;\n"
+             "\t3 -> 7;\n"
+             "\t4 -> 3;\n"
              "\t5 -> 4;\n"
-             "\t6 -> 5;\n"
-             "\t2 -> 6;\n"
-             "\t3 -> 2;\n"
-             "\t0 -> 3;\n"
-             "\t11 -> 13;\n"
-             "\t12 -> 11;\n"
-             "\t5 -> 12;\n"
-             "\t17 -> 20;\n"
-             "\t18 -> 17;\n"
-             "\t19 -> 18;\n"
-             "\t15 -> 19;\n"
+             "\t1 -> 5;\n"
+             "\t2 -> 1;\n"
+             "\t0 -> 2;\n"
+             "\t9 -> 11;\n"
+             "\t10 -> 9;\n"
+             "\t4 -> 10;\n"
+             "\t14 -> 17;\n"
+             "\t15 -> 14;\n"
              "\t16 -> 15;\n"
-             "\t6 -> 16;\n"
-             "\t16 -> 22;\n"
+             "\t12 -> 16;\n"
+             "\t13 -> 12;\n"
+             "\t5 -> 13;\n"
+             "\t13 -> 18;\n"
              "}";
    }
 
@@ -186,29 +186,29 @@ public:
    std::string GetRealRepresentationFromAction()
    {
       return std::string("digraph {\n"
-                         "\t9 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
+                         "\t8 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t7 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t8 [label=\"Define\n"
+             "\t6 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t7 [label=\"Define\n"
              "Branch_1_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t4 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t5 [label=\"Define\n"
+             "\t3 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t4 [label=\"Define\n"
              "Branch_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t6 [label=\"Define\n"
+             "\t5 [label=\"Define\n"
              "Root_def2\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t2 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t3 [label=\"Define\n"
+             "\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t2 [label=\"Define\n"
              "Root_def1\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
              "\t0 [label=\"8\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n"
-             "\t7 -> 9;\n"
-             "\t8 -> 7;\n"
-             "\t4 -> 8;\n"
+             "\t6 -> 8;\n"
+             "\t7 -> 6;\n"
+             "\t3 -> 7;\n"
+             "\t4 -> 3;\n"
              "\t5 -> 4;\n"
-             "\t6 -> 5;\n"
-             "\t2 -> 6;\n"
-             "\t3 -> 2;\n"
-             "\t0 -> 3;\n"
+             "\t1 -> 5;\n"
+             "\t2 -> 1;\n"
+             "\t0 -> 2;\n"
              "}";
    }
 };
@@ -254,8 +254,8 @@ TEST(RDFHelpers, SaveGraphRootFromTree)
    f.Close();
 
    static const std::string expectedGraph(
-      "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}");
+      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
+      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}");
 
    ROOT::RDataFrame df("t", "savegraphrootfromtree.root");
    auto c = df.Count();
@@ -277,8 +277,8 @@ TEST(RDFHelpers, SaveGraphToFile)
    f.Close();
 
    static const std::string expectedGraph(
-      "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}");
+      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
+      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}");
 
    ROOT::RDataFrame df("t", "savegraphtofile.root");
    auto c = df.Count();
@@ -301,8 +301,8 @@ TEST(RDFHelpers, SaveGraphNoActions)
    auto df2 = df.Filter([] { return true; });
    const auto res = ROOT::RDF::SaveGraph(df);
    const std::string expected =
-      "digraph {\n\t2 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n\t0 "
-      "[label=\"1\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}";
+      "digraph {\n\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n\t0 "
+      "[label=\"1\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}";
    EXPECT_EQ(res, expected);
 }
 
@@ -315,12 +315,12 @@ TEST(RDFHelpers, SaveGraphSharedDefines)
    auto c2 = df2.Define("two", One).Count();
    std::string graph = ROOT::RDF::SaveGraph(df);
    const std::string expected =
-      "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t3 "
-      "[label=\"Define\none\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t4 "
+      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t2 "
+      "[label=\"Define\none\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t3 "
       "[label=\"Define\nshared\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t0 [label=\"1\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t6 [label=\"Count\", style=\"filled\", "
-      "fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t7 [label=\"Define\ntwo\", style=\"filled\", fillcolor=\"#60aef3\", "
-      "shape=\"oval\"];\n\t3 -> 2;\n\t4 -> 3;\n\t0 -> 4;\n\t7 -> 6;\n\t4 -> 7;\n}";
+      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t4 [label=\"Count\", style=\"filled\", "
+      "fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t5 [label=\"Define\ntwo\", style=\"filled\", fillcolor=\"#60aef3\", "
+      "shape=\"oval\"];\n\t2 -> 1;\n\t3 -> 2;\n\t0 -> 3;\n\t5 -> 4;\n\t3 -> 5;\n}";
    EXPECT_EQ(graph, expected);
 }
 


### PR DESCRIPTION
SaveGraph mainly relied on static structures.

Removed static maps, which were used to check if a define/filter/range node were already on the computation graph.
Solution is to pass a (non-static) map, which is created at each call of SaveGraph.

Get rid of the static id initializer.
The size of the map of visited nodes is used to assign unique ids.
Now, also the action nodes are in the visited map.
The visited map is now only one and has signature std::unordered_map<void *, std::shared_ptr<GraphNode>> - in this manner, different type of nodes can use the same map.

Tests were adapted accordingly.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

