### PR TITLE
Adding the bin width in the TH1::ComputeIntegral method

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -2521,7 +2521,7 @@ void TH1::ClearUnderflowAndOverflow()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///  Compute integral (cumulative sum of bins)
+///  Compute integral (cumulative sum of bins areas)
 ///  The result stored in fIntegral is used by the GetRandom functions.
 ///  This function is automatically called by GetRandom when the fIntegral
 ///  array does not exist or when the number of entries in the histogram
@@ -2551,6 +2551,13 @@ Double_t TH1::ComputeIntegral(Bool_t onlyPositive)
          for (Int_t binx=1; binx <= nbinsx; ++binx) {
             ++ibin;
             Double_t y = RetrieveBinContent(GetBin(binx, biny, binz));
+
+	    Double_t xWidth=fXaxis.GetBinWidth(binx);
+	    Double_t yWidth=(fDimension > 1) ? fYaxis.GetBinWidth(biny) : 1;
+	    Double_t zWidth=(fDimension > 2) ? fZaxis.GetBinWidth(binz) : 1;
+	    y=y*xWidth*yWidth*zWidth;
+
+	    
             if (onlyPositive && y < 0) {
                  Error("ComputeIntegral","Bin content is negative - return a NaN value");
                  fIntegral[nbins] = TMath::QuietNaN();


### PR DESCRIPTION
Adding the bin width in the TH1::ComputeIntegral method, to handle histograms with non-uniform binning

# This Pull request:

## Changes or fixes:

Modified the TH1::ComputeIntegral method, used in the TH1::GetRandom method, by multiplying the "y" variable (bin content) by the bin width.


## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary). Not yet, since this has to be discussed with the ROOT developers. It has to be understood what a "random extraction from a histogram" should represent.

This PR fixes 9530

