### PR TITLE
[DF]  Remove SaveGraph static members; Add SaveGraph tutorials

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
@@ -52,23 +52,10 @@ private:
    bool fIsNew = true; ///< A just created node. This means that in no other exploration the node was already created
    ///< (this is needed because branches may share some common node).
 
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Returns a static variable to allow each node to retrieve its counter
-   static unsigned int &GetStaticGlobalCounter()
-   {
-      static unsigned int sGlobalCounter = 1;
-      return sGlobalCounter;
-   }
-
 public:
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Creates a node with a name and a counter
-   GraphNode(const std::string_view &name) : fName(name) { fCounter = GetStaticGlobalCounter()++; }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Resets the counter.
-   /// This is not strictly needed but guarantees that two consecutive request to the graph return the same result.
-   static void ClearCounter() { GraphNode::GetStaticGlobalCounter() = 1; }
+   /// \brief Creates a node with a name
+   GraphNode(const std::string_view &name) : fName(name) {}
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Appends a node on the head of the current node

--- a/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphUtils.hxx
@@ -35,20 +35,17 @@ class RRangeBase;
 namespace Internal {
 namespace RDF {
 class RColumnRegister;
-
 namespace GraphDrawing {
-std::shared_ptr<GraphNode>
-CreateDefineNode(const std::string &columnName, const ROOT::Detail::RDF::RDefineBase *columnPtr);
 
-std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr);
+std::shared_ptr<GraphNode> CreateDefineNode(const std::string &columnName,
+                                            const ROOT::Detail::RDF::RDefineBase *columnPtr,
+                                            std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
 
-std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr);
+std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr,
+                                            std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
 
-
-/// Add the Defines that have been added between this node and the previous to the graph.
-/// Return the new "upmost" node, i.e. the last of the Defines added if any, otherwise the node itself
-std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRegister &colRegister,
-                                             const std::vector<std::string> &prevNodeDefines);
+std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr,
+                                           std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
 
 // clang-format off
 /**
@@ -63,46 +60,9 @@ std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, co
 // clang-format on
 class GraphCreatorHelper {
 private:
-   using DefinesNodesMap_t = std::map<const ROOT::Detail::RDF::RDefineBase *, std::weak_ptr<GraphNode>>;
-   using FiltersNodesMap_t = std::map<const ROOT::Detail::RDF::RFilterBase *, std::weak_ptr<GraphNode>>;
-   using RangesNodesMap_t = std::map<const ROOT::Detail::RDF::RRangeBase *, std::weak_ptr<GraphNode>>;
-
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Stores the columns defined and which node in the graph defined them.
-   static DefinesNodesMap_t &GetStaticColumnsMap()
-   {
-      static DefinesNodesMap_t sMap;
-      return sMap;
-   };
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Stores the filters defined and which node in the graph defined them.
-   static FiltersNodesMap_t &GetStaticFiltersMap()
-   {
-      static FiltersNodesMap_t sMap;
-      return sMap;
-   }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Stores the ranges defined and which node in the graph defined them.
-   static RangesNodesMap_t &GetStaticRangesMap()
-   {
-      static RangesNodesMap_t sMap;
-      return sMap;
-   }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Invoked by the RNodes to create a define graph node.
-   friend std::shared_ptr<GraphNode>
-   CreateDefineNode(const std::string &columnName, const ROOT::Detail::RDF::RDefineBase *columnPtr);
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Invoked by the RNodes to create a Filter graph node.
-   friend std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr);
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Invoked by the RNodes to create a Range graph node.
-   friend std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr);
+   /// \brief Map to keep track of visited nodes when constructing the computation graph (SaveGraph)
+   std::unordered_map<void *, std::shared_ptr<GraphNode>> fVisitedMap;
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Starting from any leaf (Action, Filter, Range) it draws the dot representation of the branch.
@@ -112,6 +72,7 @@ private:
    /// \brief Starting by an array of leaves, it draws the entire graph.
    std::string FromGraphActionsToDot(std::vector<std::shared_ptr<GraphNode>> leaves);
 
+public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Starting from the root node, prints the entire graph.
    std::string RepresentGraph(ROOT::RDataFrame &rDataFrame);
@@ -128,7 +89,7 @@ private:
       auto loopManager = rInterface.GetLoopManager();
       loopManager->Jit();
 
-      return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph());
+      return FromGraphLeafToDot(rInterface.GetProxiedPtr()->GetGraph(fVisitedMap));
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -141,24 +102,7 @@ private:
       loopManager->Jit();
 
       auto actionPtr = resultPtr.fActionPtr;
-      return FromGraphLeafToDot(actionPtr->GetGraph());
-   }
-
-public:
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Functor. Initializes the static members and delegates the work to the right override.
-   /// \tparam NodeType the RNode from which the graph has to be drawn
-   template <typename NodeType>
-   std::string operator()(NodeType &node)
-   {
-      // First all static data structures are cleaned, to avoid undefined behaviours if more than one Represent is
-      // called
-      GetStaticFiltersMap() = FiltersNodesMap_t();
-      GetStaticColumnsMap() = DefinesNodesMap_t();
-      GetStaticRangesMap() = RangesNodesMap_t();
-      GraphNode::ClearCounter();
-      // The Represent can now start on a clean environment
-      return RepresentGraph(node);
+      return FromGraphLeafToDot(actionPtr->GetGraph(fVisitedMap));
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RActionBase.hxx
@@ -74,7 +74,8 @@ public:
    virtual bool HasRun() const { return fHasRun; }
    virtual void SetHasRun() { fHasRun = true; }
 
-   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph() = 0;
+   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap) = 0;
 
    /**
       Retrieve a wrapper to the result of the action that knows how to merge

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -56,7 +56,8 @@ public:
    bool HasRun() const final;
    void SetHasRun() final;
 
-   std::shared_ptr<GraphDrawing::GraphNode> GetGraph();
+   std::shared_ptr<GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<GraphDrawing::GraphNode>> &visitedMap);
 
    // Helper for RMergeableValue
    std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> GetMergeableValue() const final;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -58,7 +58,8 @@ public:
    void InitNode() final;
    void AddFilterName(std::vector<std::string> &filters) final;
    void FinalizeSlot(unsigned int slot) final;
-   std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph();
+   std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap);
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -202,7 +202,8 @@ public:
    /// Return all actions, either booked or already run
    std::vector<RDFInternal::RActionBase *> GetAllActions() const;
 
-   std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph();
+   std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap);
 
    const ColumnNames_t &GetBranchNames();
 

--- a/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
@@ -16,6 +16,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 namespace ROOT {
 namespace RDF {
@@ -54,7 +55,8 @@ public:
    virtual void StopProcessing() = 0;
    virtual void AddFilterName(std::vector<std::string> &filters) = 0;
    // Helper function for SaveGraph
-   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> GetGraph() = 0;
+   virtual std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap) = 0;
 
    virtual void ResetChildrenCount()
    {

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -23,7 +23,8 @@ namespace ROOT {
 namespace Internal {
 namespace RDF {
 namespace GraphDrawing {
-std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr);
+std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr,
+                                           std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap);
 } // ns GraphDrawing
 } // ns RDF
 } // ns Internal
@@ -98,14 +99,15 @@ public:
 
    /// This function must be defined by all nodes, but only the filters will add their name
    void AddFilterName(std::vector<std::string> &filters) { fPrevData.AddFilterName(filters); }
-   std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph()
+   std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
    {
       // TODO: Ranges node have no information about custom columns, hence it is not possible now
       // if defines have been used before.
-      auto prevNode = fPrevData.GetGraph();
+      auto prevNode = fPrevData.GetGraph(visitedMap);
       auto prevColumns = prevNode->GetDefinedColumns();
 
-      auto thisNode = RDFGraphDrawing::CreateRangeNode(this);
+      auto thisNode = RDFGraphDrawing::CreateRangeNode(this, visitedMap);
 
       /* If the returned node is not new, there is no need to perform any other operation.
        * This is a likely scenario when building the entire graph in which branches share

--- a/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
@@ -50,7 +50,8 @@ public:
    virtual ~RRangeBase();
 
    void InitNode() { ResetCounters(); }
-   virtual std::shared_ptr<RDFGraphDrawing::GraphNode> GetGraph() = 0;
+   virtual std::shared_ptr<RDFGraphDrawing::GraphNode>
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) = 0;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -118,7 +118,7 @@ template <typename NodeType>
 std::string SaveGraph(NodeType node)
 {
    ROOT::Internal::RDF::GraphDrawing::GraphCreatorHelper helper;
-   return helper(node);
+   return helper.RepresentGraph(node);
 }
 
 // clang-format off
@@ -137,7 +137,7 @@ template <typename NodeType>
 void SaveGraph(NodeType node, const std::string &outputFile)
 {
    ROOT::Internal::RDF::GraphDrawing::GraphCreatorHelper helper;
-   std::string dotGraph = helper(node);
+   std::string dotGraph = helper.RepresentGraph(node);
 
    std::ofstream out(outputFile);
    if (!out.is_open()) {

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -79,69 +79,67 @@ std::string GraphCreatorHelper::RepresentGraph(RLoopManager *loopManager)
    nodes.reserve(actions.size() + edges.size());
 
    for (auto *action : actions)
-      nodes.emplace_back(action->GetGraph());
+      nodes.emplace_back(action->GetGraph(fVisitedMap));
    for (auto *edge : edges)
-      nodes.emplace_back(edge->GetGraph());
+      nodes.emplace_back(edge->GetGraph(fVisitedMap));
 
    return FromGraphActionsToDot(nodes);
 }
 
-std::shared_ptr<GraphNode>
-CreateDefineNode(const std::string &columnName, const ROOT::Detail::RDF::RDefineBase *columnPtr)
+std::shared_ptr<GraphNode> CreateDefineNode(const std::string &columnName,
+                                            const ROOT::Detail::RDF::RDefineBase *columnPtr,
+                                            std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap)
 {
    // If there is already a node for this define (recognized by the custom column it is defining) return it. If there is
    // not, return a new one.
-   auto &sColumnsMap = GraphCreatorHelper::GetStaticColumnsMap();
-   auto duplicateDefineIt = sColumnsMap.find(columnPtr);
-   if (duplicateDefineIt != sColumnsMap.end()) {
-      auto duplicateDefine = duplicateDefineIt->second.lock();
-      return duplicateDefine;
-   }
+   auto duplicateDefineIt = visitedMap.find((void *)columnPtr);
+   if (duplicateDefineIt != visitedMap.end())
+      return duplicateDefineIt->second;
 
    auto node = std::make_shared<GraphNode>("Define\n" + columnName);
    node->SetDefine();
-
-   sColumnsMap[columnPtr] = node;
+   node->SetCounter(visitedMap.size());
+   visitedMap[(void *)columnPtr] = node;
    return node;
 }
 
-std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr)
+std::shared_ptr<GraphNode> CreateFilterNode(const ROOT::Detail::RDF::RFilterBase *filterPtr,
+                                            std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap)
 {
    // If there is already a node for this filter return it. If there is not, return a new one.
-   auto &sFiltersMap = GraphCreatorHelper::GetStaticFiltersMap();
-   auto duplicateFilterIt = sFiltersMap.find(filterPtr);
-   if (duplicateFilterIt != sFiltersMap.end()) {
-      auto duplicateFilter = duplicateFilterIt->second.lock();
-      duplicateFilter->SetIsNew(false);
-      return duplicateFilter;
+   auto duplicateFilterIt = visitedMap.find((void *)filterPtr);
+   if (duplicateFilterIt != visitedMap.end()) {
+      duplicateFilterIt->second->SetIsNew(false);
+      return duplicateFilterIt->second;
    }
-   auto filterName = (filterPtr->HasName() ? filterPtr->GetName() : "Filter");
-   auto node = std::make_shared<GraphNode>(filterName);
 
-   sFiltersMap[filterPtr] = node;
+   auto node = std::make_shared<GraphNode>((filterPtr->HasName() ? filterPtr->GetName() : "Filter"));
    node->SetFilter();
+   node->SetCounter(visitedMap.size());
+   visitedMap[(void *)filterPtr] = node;
    return node;
 }
 
-std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr)
+std::shared_ptr<GraphNode> CreateRangeNode(const ROOT::Detail::RDF::RRangeBase *rangePtr,
+                                           std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap)
 {
    // If there is already a node for this range return it. If there is not, return a new one.
-   auto &sRangesMap = GraphCreatorHelper::GetStaticRangesMap();
-   auto duplicateRangeIt = sRangesMap.find(rangePtr);
-   if (duplicateRangeIt != sRangesMap.end()) {
-      auto duplicateRange = duplicateRangeIt->second.lock();
-      duplicateRange->SetIsNew(false);
-      return duplicateRange;
+   auto duplicateRangeIt = visitedMap.find((void *)rangePtr);
+   if (duplicateRangeIt != visitedMap.end()) {
+      duplicateRangeIt->second->SetIsNew(false);
+      return duplicateRangeIt->second;
    }
+
    auto node = std::make_shared<GraphNode>("Range");
    node->SetRange();
-
-   sRangesMap[rangePtr] = node;
+   node->SetCounter(visitedMap.size());
+   visitedMap[(void *)rangePtr] = node;
    return node;
 }
 
 std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRegister &colRegister,
-                                             const std::vector<std::string> &prevNodeDefines)
+                                             const std::vector<std::string> &prevNodeDefines,
+                                             std::unordered_map<void *, std::shared_ptr<GraphNode>> &visitedMap)
 {
    auto upmostNode = node;
    const auto &defineNames = colRegister.GetNames();
@@ -157,7 +155,7 @@ std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node, co
          break; // we walked back through all new defines, the rest is stuff that was already in the graph
 
       // create a node for this new Define
-      auto defineNode = RDFGraphDrawing::CreateDefineNode(colName, defineMap.at(colName).get());
+      auto defineNode = RDFGraphDrawing::CreateDefineNode(colName, defineMap.at(colName).get(), visitedMap);
       upmostNode->SetPrevNode(defineNode);
       upmostNode = defineNode;
    }

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -80,10 +80,11 @@ void RJittedAction::SetHasRun()
    return fConcreteAction->SetHasRun();
 }
 
-std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph()
+std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RJittedAction::GetGraph(
+   std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap)
 {
    assert(fConcreteAction != nullptr);
-   return fConcreteAction->GetGraph();
+   return fConcreteAction->GetGraph(visitedMap);
 }
 
 /**

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -108,11 +108,12 @@ void RJittedFilter::AddFilterName(std::vector<std::string> &filters)
    fConcreteFilter->AddFilterName(filters);
 }
 
-std::shared_ptr<RDFGraphDrawing::GraphNode> RJittedFilter::GetGraph()
+std::shared_ptr<RDFGraphDrawing::GraphNode>
+RJittedFilter::GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
 {
    if (fConcreteFilter != nullptr) {
       // Here the filter exists, so it can be served
-      return fConcreteFilter->GetGraph();
+      return fConcreteFilter->GetGraph(visitedMap);
    }
    throw std::runtime_error("The Jitting should have been invoked before this method.");
 }

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -878,8 +878,14 @@ std::vector<RDFInternal::RActionBase *> RLoopManager::GetAllActions() const
    return actions;
 }
 
-std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetGraph()
+std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetGraph(
+   std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap)
 {
+   // If there is already a node for the RLoopManager return it. If there is not, return a new one.
+   auto duplicateRLoopManagerIt = visitedMap.find((void *)this);
+   if (duplicateRLoopManagerIt != visitedMap.end())
+      return duplicateRLoopManagerIt->second;
+
    std::string name;
    if (fDataSource) {
       name = fDataSource->GetLabel();
@@ -888,10 +894,10 @@ std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetG
    } else {
       name = std::to_string(fNEmptyEntries);
    }
-
    auto thisNode = std::make_shared<ROOT::Internal::RDF::GraphDrawing::GraphNode>(name);
    thisNode->SetRoot();
-   thisNode->SetCounter(0);
+   thisNode->SetCounter(visitedMap.size());
+   visitedMap[(void *)this] = thisNode;
    return thisNode;
 }
 

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -122,59 +122,59 @@ public:
    std::string GetRealRepresentationFromRoot()
    {
       return std::string("digraph {\n"
-                         "\t9 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
+                         "\t8 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t7 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t8 [label=\"Define\n"
+             "\t6 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t7 [label=\"Define\n"
              "Branch_1_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t4 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t5 [label=\"Define\n"
+             "\t3 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t4 [label=\"Define\n"
              "Branch_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t6 [label=\"Define\n"
+             "\t5 [label=\"Define\n"
              "Root_def2\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t2 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t3 [label=\"Define\n"
+             "\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t2 [label=\"Define\n"
              "Root_def1\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
              "\t0 [label=\"8\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n"
-             "\t13 [label=\"Count\", style=\"filled\", fillcolor=\"" +
+             "\t11 [label=\"Count\", style=\"filled\", fillcolor=\"" +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t11 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t12 [label=\"Define\n"
+             "\t9 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t10 [label=\"Define\n"
              "Branch_1_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t20 [label=\"Max\", style=\"filled\", fillcolor=\"" +
+             "\t17 [label=\"Max\", style=\"filled\", fillcolor=\"" +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t17 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t18 [label=\"Define\n"
+             "\t14 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t15 [label=\"Define\n"
              "Branch_2_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t19 [label=\"Define\n"
-             "Branch_2_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t15 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
              "\t16 [label=\"Define\n"
+             "Branch_2_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
+             "\t12 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t13 [label=\"Define\n"
              "Branch_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t22 [label=\"Count\", style=\"filled\", fillcolor=\"" +
+             "\t18 [label=\"Count\", style=\"filled\", fillcolor=\"" +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t7 -> 9;\n"
-             "\t8 -> 7;\n"
-             "\t4 -> 8;\n"
+             "\t6 -> 8;\n"
+             "\t7 -> 6;\n"
+             "\t3 -> 7;\n"
+             "\t4 -> 3;\n"
              "\t5 -> 4;\n"
-             "\t6 -> 5;\n"
-             "\t2 -> 6;\n"
-             "\t3 -> 2;\n"
-             "\t0 -> 3;\n"
-             "\t11 -> 13;\n"
-             "\t12 -> 11;\n"
-             "\t5 -> 12;\n"
-             "\t17 -> 20;\n"
-             "\t18 -> 17;\n"
-             "\t19 -> 18;\n"
-             "\t15 -> 19;\n"
+             "\t1 -> 5;\n"
+             "\t2 -> 1;\n"
+             "\t0 -> 2;\n"
+             "\t9 -> 11;\n"
+             "\t10 -> 9;\n"
+             "\t4 -> 10;\n"
+             "\t14 -> 17;\n"
+             "\t15 -> 14;\n"
              "\t16 -> 15;\n"
-             "\t6 -> 16;\n"
-             "\t16 -> 22;\n"
+             "\t12 -> 16;\n"
+             "\t13 -> 12;\n"
+             "\t5 -> 13;\n"
+             "\t13 -> 18;\n"
              "}";
    }
 
@@ -186,29 +186,29 @@ public:
    std::string GetRealRepresentationFromAction()
    {
       return std::string("digraph {\n"
-                         "\t9 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
+                         "\t8 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
              (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
              "\", shape=\"box\"];\n"
-             "\t7 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t8 [label=\"Define\n"
+             "\t6 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t7 [label=\"Define\n"
              "Branch_1_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t4 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t5 [label=\"Define\n"
+             "\t3 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t4 [label=\"Define\n"
              "Branch_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t6 [label=\"Define\n"
+             "\t5 [label=\"Define\n"
              "Root_def2\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t2 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t3 [label=\"Define\n"
+             "\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
+             "\t2 [label=\"Define\n"
              "Root_def1\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
              "\t0 [label=\"8\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n"
-             "\t7 -> 9;\n"
-             "\t8 -> 7;\n"
-             "\t4 -> 8;\n"
+             "\t6 -> 8;\n"
+             "\t7 -> 6;\n"
+             "\t3 -> 7;\n"
+             "\t4 -> 3;\n"
              "\t5 -> 4;\n"
-             "\t6 -> 5;\n"
-             "\t2 -> 6;\n"
-             "\t3 -> 2;\n"
-             "\t0 -> 3;\n"
+             "\t1 -> 5;\n"
+             "\t2 -> 1;\n"
+             "\t0 -> 2;\n"
              "}";
    }
 };
@@ -254,8 +254,8 @@ TEST(RDFHelpers, SaveGraphRootFromTree)
    f.Close();
 
    static const std::string expectedGraph(
-      "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}");
+      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
+      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}");
 
    ROOT::RDataFrame df("t", "savegraphrootfromtree.root");
    auto c = df.Count();
@@ -277,8 +277,8 @@ TEST(RDFHelpers, SaveGraphToFile)
    f.Close();
 
    static const std::string expectedGraph(
-      "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}");
+      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
+      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}");
 
    ROOT::RDataFrame df("t", "savegraphtofile.root");
    auto c = df.Count();
@@ -301,8 +301,8 @@ TEST(RDFHelpers, SaveGraphNoActions)
    auto df2 = df.Filter([] { return true; });
    const auto res = ROOT::RDF::SaveGraph(df);
    const std::string expected =
-      "digraph {\n\t2 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n\t0 "
-      "[label=\"1\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 2;\n}";
+      "digraph {\n\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n\t0 "
+      "[label=\"1\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}";
    EXPECT_EQ(res, expected);
 }
 
@@ -315,12 +315,12 @@ TEST(RDFHelpers, SaveGraphSharedDefines)
    auto c2 = df2.Define("two", One).Count();
    std::string graph = ROOT::RDF::SaveGraph(df);
    const std::string expected =
-      "digraph {\n\t2 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t3 "
-      "[label=\"Define\none\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t4 "
+      "digraph {\n\t3 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t1 "
+      "[label=\"Define\none\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t2 "
       "[label=\"Define\nshared\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t0 [label=\"1\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t6 [label=\"Count\", style=\"filled\", "
-      "fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t7 [label=\"Define\ntwo\", style=\"filled\", fillcolor=\"#60aef3\", "
-      "shape=\"oval\"];\n\t3 -> 2;\n\t4 -> 3;\n\t0 -> 4;\n\t7 -> 6;\n\t4 -> 7;\n}";
+      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t5 [label=\"Count\", style=\"filled\", "
+      "fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t4 [label=\"Define\ntwo\", style=\"filled\", fillcolor=\"#60aef3\", "
+      "shape=\"oval\"];\n\t1 -> 3;\n\t2 -> 1;\n\t0 -> 2;\n\t4 -> 5;\n\t2 -> 4;\n}";
    EXPECT_EQ(graph, expected);
 }
 

--- a/tutorials/dataframe/df034_SaveGraph.C
+++ b/tutorials/dataframe/df034_SaveGraph.C
@@ -1,0 +1,51 @@
+/// \file
+/// \ingroup tutorial_dataframe
+/// \notebook -nodraw
+/// Basic SaveGraph usage.
+///
+/// This tutorial shows how to use the SaveGraph action.
+/// SaveGraph inspects the sequence of RDataFrame actions.
+///
+/// \macro_code
+/// \macro_output
+///
+/// \date January 2022
+/// \author Ivan Kabadzhov (CERN)
+
+// First, an RDataFrame computation graph is created with Defines, Filters and methods such as Mean, Count, etc.
+// After that, SaveGraph can be called either on the root RDataFrame object or on a specific node of the computation
+// graph: in the first case, the graph returned will span the full computation graph, in the second case it will show
+// only the branch of the computation graph that the node belongs to.
+// If a filename is passed as second argument, the graph is saved to that file, otherwise it is returned as a string.
+
+void df034_SaveGraph()
+{
+   ROOT::RDataFrame rd1(1);
+   auto rd2 = rd1.Define("Root_def1", "1").Filter("Root_def1 < 2", "Main_Filter").Define("Root_def2", "1");
+
+   auto branch1 = rd2.Define("Branch_1_def", "1");
+   auto branch2 = rd2.Define("Branch_2_def", "1");
+
+   ROOT::RDF::RResultPtr<double> branch1_1 = branch1.Filter("Branch_1_def < 2", "Filter_1")
+                                                .Define("Branch_1_1_def", "1")
+                                                .Filter("1 == Branch_1_1_def % 2", "Filter_1_1")
+                                                .Mean("Branch_1_1_def");
+
+   ROOT::RDF::RResultPtr<unsigned long long> branch1_2 =
+      branch1.Define("Branch_1_2_def", "1").Filter("Branch_1_2_def < 2", "Filter_1_2").Count();
+
+   ROOT::RDF::RResultPtr<double> branch2_1 = branch2.Filter("Branch_2_def < 2", "Filter_2")
+                                                .Define("Branch_2_1_def", "1")
+                                                .Define("Branch_2_2_def", "1")
+                                                .Filter("1 == Branch_2_1_def % 2", "Filter_2_1")
+                                                .Max("Branch_2_1_def");
+
+   ROOT::RDF::RResultPtr<unsigned long long> branch2_2 = branch2.Count();
+
+   std::cout << ROOT::RDF::SaveGraph(branch1_1);
+   ROOT::RDF::SaveGraph(rd1, /*output_file=*/"rdf_savegraph_tutorial.dot");
+   // SaveGraph produces content in the standard DOT file format
+   // (https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29): it can be converted to e.g. an image file
+   // using standard tools such as the `dot` CLI program.
+   gSystem->Exec("dot -Tpng rdf_savegraph_tutorial.dot -o rdf_savegraph_tutorial.png");
+}

--- a/tutorials/dataframe/df034_SaveGraph.py
+++ b/tutorials/dataframe/df034_SaveGraph.py
@@ -1,0 +1,50 @@
+## \file
+## \ingroup tutorial_dataframe
+## \notebook -nodraw
+## Basic SaveGraph usage.
+##
+## This tutorial shows how to use the SaveGraph action.
+## SaveGraph inspects the sequence of RDataFrame actions.
+##
+## \macro_code
+## \macro_output
+##
+## \date January 2022
+## \author Ivan Kabadzhov (CERN)
+
+# First, an RDataFrame computation graph is created with Defines, Filters and methods such as Mean, Count, etc.
+# After that, SaveGraph can be called either on the root RDataFrame object or on a specific node of the computation
+# graph: in the first case, the graph returned will span the full computation graph, in the second case it will show
+# only the branch of the computation graph that the node belongs to.
+# If a filename is passed as second argument, the graph is saved to that file, otherwise it is returned as a string.
+
+import ROOT
+
+rd1 = ROOT.RDataFrame(2)
+
+rd2 = rd1.Define("Root_def1", "1") \
+         .Filter("Root_def1 < 2", "Main_Filter") \
+         .Define("Root_def2", "1")
+
+branch1 = rd2.Define("Branch_1_def", "1")
+branch2 = rd2.Define("Branch_2_def", "1")
+
+branch1_1 = branch1.Filter("Branch_1_def < 2", "Filter_1") \
+                   .Define("Branch_1_1_def", "1") \
+                   .Filter("1 == Branch_1_1_def % 2", "Filter_1_1") \
+                   .Mean("Branch_1_1_def");
+
+branch1_2 = branch1.Define("Branch_1_2_def", "1") \
+                   .Filter("Branch_1_2_def < 2", "Filter_1_2") \
+                   .Count()
+
+branch2_1 = branch2.Filter("Branch_2_def < 2", "Filter_2") \
+                   .Define("Branch_2_1_def", "1") \
+                   .Define("Branch_2_2_def", "1") \
+                   .Filter("1 == Branch_2_1_def % 2", "Filter_2_1") \
+                   .Max("Branch_2_1_def")
+
+branch2_2 = branch2.Count()
+
+print(ROOT.RDF.SaveGraph(branch1_1))
+ROOT.RDF.SaveGraph(rd1, "exampleGraph.dot")


### PR DESCRIPTION
# This Pull request:
[DF] Added SaveGraph Tutorials
[DF] Remove static members from SaveGraph (Apply improvements from #9145)

## Changes or fixes:

Removed the static GraphNode id initializer (relevant for SaveGraph).

Removed static maps, which were used to check if a define/filter/range node were already on the computation graph.
Solution is to pass a (non-static) map, which is created at each call of SaveGraph. The visited map is now only one and has signature `std::unordered_map<void *, std::shared_ptr<GraphNode>>` - in this manner, different type of nodes can use the same map.

The size of the map of visited nodes is used to assign unique ids. Now, also the action nodes are in the visited map.

Moreover, some friend methods are now redundant.

Tests were adapted accordingly.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #9145

