### PR TITLE
Reduce precision errors for Mean and StdDev #7395

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -948,7 +948,7 @@ public:
 class MeanHelper : public RActionImpl<MeanHelper> {
    const std::shared_ptr<double> fResultMean;
    std::vector<ULong64_t> fCounts;
-   std::vector<double> fSums;
+   double kahanSum(vector< double > &fsums);
    std::vector<double> fPartialMeans;
 
 public:


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #7395 Reduce precision errors for Mean and StdDev 

I have tried to create a vector of Kahan sums using the already existing Kahan summation class: