### PR TITLE
[RF] Reset cached normalization sets if servers are redirected

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -261,7 +261,25 @@ public:
   // Server redirection interface
   Bool_t redirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t isRecursionStep=kFALSE) ;
   Bool_t recursiveRedirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t recurseInNewSet=kTRUE) ;
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) { return kFALSE ; } ;
+
+  /// Function that is called at the end of redirectServers(). Can be overloaded
+  /// to inject some class-dependent behavior after server redirection, e.g.
+  /// resetting of caches. The return value is meant to be an error flag, so in
+  /// case something goes wrong the function should return `true`.
+  ///
+  /// \see redirectServers() For a detailed explanation of the function parameters.
+  ///
+  /// \param[in] newServerList One of the original parameters passed to redirectServers().
+  /// \param[in] mustReplaceAll One of the original parameters passed to redirectServers().
+  /// \param[in] nameChange  One of the original parameters passed to redirectServers().
+  /// \param[in] isRecursiveStep  One of the original parameters passed to redirectServers().
+  virtual bool redirectServersHook(const RooAbsCollection & /*newServerList*/, bool /*mustReplaceAll*/,
+                                   bool /*nameChange*/, bool /*isRecursiveStep*/)
+  {
+    return false;
+  }
+
+
   virtual void serverNameChangeHook(const RooAbsArg* /*oldServer*/, const RooAbsArg* /*newServer*/) { } ;
 
   void addServer(RooAbsArg& server, Bool_t valueProp=kTRUE, Bool_t shapeProp=kFALSE, std::size_t refCount = 1);

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -361,8 +361,8 @@ protected:
 
   friend class RooAbsAnaConvPdf ;
   mutable Double_t _rawValue ;
-  mutable RooAbsReal* _norm   ;      //! Normalization integral (owned by _normMgr)
-  mutable RooArgSet* _normSet ;      //! Normalization set with for above integral
+  mutable RooAbsReal* _norm = nullptr; //! Normalization integral (owned by _normMgr)
+  mutable RooArgSet const* _normSet = nullptr; //! Normalization set with for above integral
   inline const RooArgSet* getNormSet() { return _normSet; }
 
   class CacheElem : public RooAbsCacheElement {
@@ -382,8 +382,13 @@ protected:
 
     // Object is own by _normCacheManager that will delete object as soon as cache
     // is sterilized by server redirect
-    _norm = 0 ;
-    return kFALSE ; 
+    _norm = nullptr ;
+
+    // Similar to the situation with the normalization integral above: if a
+    // server is redirected, the cached normalization set might not point to
+    // the right observables anymore. We need to reset it.
+    _normSet = nullptr ;
+    return false ;
   } ;
 
   

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -144,6 +144,13 @@ protected:
 
   mutable Int_t _coefErrCount ; //! Coefficient error counter
 
+  bool redirectServersHook(const RooAbsCollection&, bool, bool, bool) override {
+    // If a server is redirected, the cached normalization set might not point
+    // to the right observables anymore. We need to reset it.
+    _copyOfLastNormSet.reset();
+    return false;
+  }
+
 private:
   std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* defaultNorm = nullptr) const;
   mutable RooFit::UniqueId<RooArgSet>::Value_t _idOfLastUsedNormSet = RooFit::UniqueId<RooArgSet>::nullval; //!

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -223,7 +223,7 @@ TString RooAbsPdf::_normRangeOverride;
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-RooAbsPdf::RooAbsPdf() : _norm(0), _normSet(0), _normMgr(this,10), _specGeneratorConfig(0)
+RooAbsPdf::RooAbsPdf() :_normMgr(this,10), _specGeneratorConfig(0)
 {
   _errorCount = 0 ;
   _negCount = 0 ;
@@ -238,7 +238,7 @@ RooAbsPdf::RooAbsPdf() : _norm(0), _normSet(0), _normMgr(this,10), _specGenerato
 /// Constructor with name and title only
 
 RooAbsPdf::RooAbsPdf(const char *name, const char *title) :
-  RooAbsReal(name,title), _norm(0), _normSet(0), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
+  RooAbsReal(name,title), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
 {
   resetErrorCounters() ;
   setTraceCounter(0) ;
@@ -251,7 +251,7 @@ RooAbsPdf::RooAbsPdf(const char *name, const char *title) :
 
 RooAbsPdf::RooAbsPdf(const char *name, const char *title,
 		     Double_t plotMin, Double_t plotMax) :
-  RooAbsReal(name,title,plotMin,plotMax), _norm(0), _normSet(0), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
+  RooAbsReal(name,title,plotMin,plotMax), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
 {
   resetErrorCounters() ;
   setTraceCounter(0) ;
@@ -263,7 +263,7 @@ RooAbsPdf::RooAbsPdf(const char *name, const char *title,
 /// Copy constructor
 
 RooAbsPdf::RooAbsPdf(const RooAbsPdf& other, const char* name) :
-  RooAbsReal(other,name), _norm(0), _normSet(0),
+  RooAbsReal(other,name),
   _normMgr(other._normMgr,this), _selectComp(other._selectComp), _normRange(other._normRange)
 {
   resetErrorCounters() ;
@@ -329,8 +329,8 @@ Double_t RooAbsPdf::getValV(const RooArgSet* nset) const
 
   // Special handling of case without normalization set (used in numeric integration of pdfs)
   if (!nset) {
-    RooArgSet* tmp = _normSet ;
-    _normSet = 0 ;
+    RooArgSet const* tmp = _normSet ;
+    _normSet = nullptr ;
     Double_t val = evaluate() ;
     _normSet = tmp ;
 
@@ -550,10 +550,7 @@ const RooAbsReal* RooAbsPdf::getNormObj(const RooArgSet* nset, const RooArgSet* 
 
 Bool_t RooAbsPdf::syncNormalization(const RooArgSet* nset, Bool_t adjustProxies) const
 {
-
-//   cout << IsA()->GetName() << "::syncNormalization(" << GetName() << ") nset = " << nset << " = " << (nset?*nset:RooArgSet()) << endl ;
-
-  _normSet = (RooArgSet*) nset ;
+  _normSet = nset;
 
   // Check if data sets are identical
   CacheElem* cache = (CacheElem*) _normMgr.getObj(nset) ;


### PR DESCRIPTION
If a server is redirected, the cached normalization sets in `RooAbsPdf`
and `RooAddPdf` might not point to the right observables anymore. We
need to reset them.

This bug was discovered thanks to a [forum post](https://root-forum.cern.ch/t/problems-with-2d-simultaneous-fit/48249/4) that provided a code snippet that crashed in ROOT master and 6.24 because the cached normalization sets were used after the servers were redirected.

Needs to be backported to 6.24.

