### PR TITLE
RooAddPdf: Avoid UB in checkObservables

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -826,7 +826,9 @@ bool RooAddPdf::checkObservables(const RooArgSet* nset) const
 {
   bool ret(false) ;
 
-  for (std::size_t i = 0; i < _pdfList.size(); ++i) {
+  // There may be fewer coefficients than PDFs.
+  std::size_t end = std::min(_pdfList.size(), _coefList.size());
+  for (std::size_t i = 0; i < end; ++i) {
     auto pdf  = static_cast<const RooAbsPdf *>(_pdfList.at(i));
     auto coef = static_cast<const RooAbsReal*>(_coefList.at(i));
     if (pdf->observableOverlaps(nset,*coef)) {


### PR DESCRIPTION
A RooAddPdf may have more PDFs than coefficients, in which case "the coefficient of the last PDF is calculated automatically from the condition that the sum of all coefficients has to be 1". In this case, the last call to `_coefList.at(i)` is supposed to return
a `nullptr` because the index is out of range, and dereferencing it is undefined behavior which Clang 13 optimizes away, leading to crashes.

Fixes #9547