### PR TITLE
[v624][RF] Reset cached normalization sets if servers are redirected

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -260,7 +260,25 @@ public:
   // Server redirection interface
   Bool_t redirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t isRecursionStep=kFALSE) ;
   Bool_t recursiveRedirectServers(const RooAbsCollection& newServerList, Bool_t mustReplaceAll=kFALSE, Bool_t nameChange=kFALSE, Bool_t recurseInNewSet=kTRUE) ;
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) { return kFALSE ; } ;
+
+  /// Function that is called at the end of redirectServers(). Can be overloaded
+  /// to inject some class-dependent behavior after server redirection, e.g.
+  /// resetting of caches. The return value is meant to be an error flag, so in
+  /// case something goes wrong the function should return `true`.
+  ///
+  /// \see redirectServers() For a detailed explanation of the function parameters.
+  ///
+  /// \param[in] newServerList One of the original parameters passed to redirectServers().
+  /// \param[in] mustReplaceAll One of the original parameters passed to redirectServers().
+  /// \param[in] nameChange  One of the original parameters passed to redirectServers().
+  /// \param[in] isRecursiveStep  One of the original parameters passed to redirectServers().
+  virtual bool redirectServersHook(const RooAbsCollection & /*newServerList*/, bool /*mustReplaceAll*/,
+                                   bool /*nameChange*/, bool /*isRecursiveStep*/)
+  {
+    return false;
+  }
+
+
   virtual void serverNameChangeHook(const RooAbsArg* /*oldServer*/, const RooAbsArg* /*newServer*/) { } ;
 
   void addServer(RooAbsArg& server, Bool_t valueProp=kTRUE, Bool_t shapeProp=kFALSE, std::size_t refCount = 1);

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -318,8 +318,8 @@ protected:
 
   friend class RooAbsAnaConvPdf ;
   mutable Double_t _rawValue ;
-  mutable RooAbsReal* _norm   ;      //! Normalization integral (owned by _normMgr)
-  mutable RooArgSet* _normSet ;      //! Normalization set with for above integral
+  mutable RooAbsReal* _norm = nullptr; //! Normalization integral (owned by _normMgr)
+  mutable RooArgSet const* _normSet = nullptr; //! Normalization set with for above integral
 
   class CacheElem : public RooAbsCacheElement {
   public:
@@ -339,8 +339,13 @@ protected:
 
     // Object is own by _normCacheManager that will delete object as soon as cache
     // is sterilized by server redirect
-    _norm = 0 ;
-    return kFALSE ; 
+    _norm = nullptr ;
+
+    // Similar to the situation with the normalization integral above: if a
+    // server is redirected, the cached normalization set might not point to
+    // the right observables anymore. We need to reset it.
+    _normSet = nullptr ;
+    return false ;
   } ;
 
   

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -146,6 +146,13 @@ protected:
 
   mutable Int_t _coefErrCount ; //! Coefficient error counter
 
+  bool redirectServersHook(const RooAbsCollection&, bool, bool, bool) {
+    // If a server is redirected, the cached normalization set might not point
+    // to the right observables anymore. We need to reset it.
+    _copyOfLastNormSet.reset();
+    return false;
+  }
+
 private:
   std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* defaultNorm = nullptr) const;
   mutable RooArgSet const* _pointerToLastUsedNormSet = nullptr; //!

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -200,7 +200,7 @@ TString RooAbsPdf::_normRangeOverride;
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor
 
-RooAbsPdf::RooAbsPdf() : _norm(0), _normSet(0), _specGeneratorConfig(0)
+RooAbsPdf::RooAbsPdf() : _specGeneratorConfig(0)
 {
   _errorCount = 0 ;
   _negCount = 0 ;
@@ -215,7 +215,7 @@ RooAbsPdf::RooAbsPdf() : _norm(0), _normSet(0), _specGeneratorConfig(0)
 /// Constructor with name and title only
 
 RooAbsPdf::RooAbsPdf(const char *name, const char *title) :
-  RooAbsReal(name,title), _norm(0), _normSet(0), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
+  RooAbsReal(name,title), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
 {
   resetErrorCounters() ;
   setTraceCounter(0) ;
@@ -228,7 +228,7 @@ RooAbsPdf::RooAbsPdf(const char *name, const char *title) :
 
 RooAbsPdf::RooAbsPdf(const char *name, const char *title,
 		     Double_t plotMin, Double_t plotMax) :
-  RooAbsReal(name,title,plotMin,plotMax), _norm(0), _normSet(0), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
+  RooAbsReal(name,title,plotMin,plotMax), _normMgr(this,10), _selectComp(kTRUE), _specGeneratorConfig(0)
 {
   resetErrorCounters() ;
   setTraceCounter(0) ;
@@ -240,7 +240,7 @@ RooAbsPdf::RooAbsPdf(const char *name, const char *title,
 /// Copy constructor
 
 RooAbsPdf::RooAbsPdf(const RooAbsPdf& other, const char* name) :
-  RooAbsReal(other,name), _norm(0), _normSet(0),
+  RooAbsReal(other,name),
   _normMgr(other._normMgr,this), _selectComp(other._selectComp), _normRange(other._normRange)
 {
   resetErrorCounters() ;
@@ -281,8 +281,8 @@ Double_t RooAbsPdf::getValV(const RooArgSet* nset) const
 
   // Special handling of case without normalization set (used in numeric integration of pdfs)
   if (!nset) {
-    RooArgSet* tmp = _normSet ;
-    _normSet = 0 ;
+    RooArgSet const* tmp = _normSet ;
+    _normSet = nullptr ;
     Double_t val = evaluate() ;
     _normSet = tmp ;
 
@@ -522,10 +522,7 @@ const RooAbsReal* RooAbsPdf::getNormObj(const RooArgSet* nset, const RooArgSet* 
 
 Bool_t RooAbsPdf::syncNormalization(const RooArgSet* nset, Bool_t adjustProxies) const
 {
-
-//   cout << IsA()->GetName() << "::syncNormalization(" << GetName() << ") nset = " << nset << " = " << (nset?*nset:RooArgSet()) << endl ;
-
-  _normSet = (RooArgSet*) nset ;
+  _normSet = nset;
 
   // Check if data sets are identical
   CacheElem* cache = (CacheElem*) _normMgr.getObj(nset) ;

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -1,20 +1,27 @@
 // Tests for RooAbsPdf
 // Author: Stephan Hageboeck, CERN 04/2020
 
-#include "RooRealVar.h"
-#include "RooGenericPdf.h"
-#include "RooFormulaVar.h"
-#include "RooDataSet.h"
-#include "RooFitResult.h"
-#include "RooProduct.h"
-#include "RooHelpers.h"
-#include "RooGaussian.h"
-#include "RooPoisson.h"
+#include <RooAddPdf.h>                                                                               
+#include <RooCategory.h>                                                                             
+#include <RooConstVar.h>                                                                             
+#include <RooDataSet.h>
+#include <RooFitResult.h>  
+#include <RooFormulaVar.h>
+#include <RooGaussian.h>
+#include <RooGenericPdf.h>
+#include <RooHelpers.h>
+#include <RooPoisson.h>
+#include <RooProdPdf.h>                                                                              
+#include <RooProduct.h>
+#include <RooRealVar.h>
+#include <RooSimultaneous.h>
+#include <RooUniform.h>
 
-#include "TRandom.h"
+#include <TClass.h>
+#include <TRandom.h>
 #include <ROOT/RMakeUnique.hxx>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <memory>
 
@@ -122,4 +129,50 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
     ++iMean;
   }
 
+}
+
+// This test will crash if the cached normalization sets are not reset
+// correctly after servers are redirected. This is a reduced version of a code
+// provided in the ROOT forum that originally unveiled this problem:
+// https://root-forum.cern.ch/t/problems-with-2d-simultaneous-fit/48249/4
+TEST(RooAbsPdf, ProblemsWith2DSimultaneousFit)
+{
+   using namespace RooFit;
+
+   RooRealVar x("x", "y", 1.0, 2.);
+   RooRealVar y("y", "y", 1.0, 2.);
+
+   RooRealVar mu1("mu1", "mu1", 2., 0, 5);
+
+   RooUniform uniform1("uniform1", "uniform1", {x, y});
+   RooUniform uniform2("uniform2", "uniform2", {x, y});
+
+   RooGaussian gauss1("gauss1", "gauss1", x, mu1, RooConst(0.1));
+   RooGaussian gauss2("gauss2", "gauss2", x, mu1, RooConst(0.1));
+   RooGaussian gauss3("gauss3", "gauss3", x, mu1, RooConst(0.1));
+
+   RooAddPdf gauss12("gauss12", "gauss12", gauss1, gauss2, RooConst(0.1));
+
+   RooAddPdf sig_x("sig_x", "sig_x", gauss3, gauss12, RooConst(0.1));
+
+   RooUniform sig_y("sig_y", "sig_y", y);
+   RooProdPdf sig("sig", "sig", sig_y, sig_x);
+
+   RooRealVar yield{"yield", "yield", 100};
+
+   // Complete model
+   RooAddPdf model("model", "model", {sig, sig_y, uniform2, uniform1}, {yield, yield, yield, yield});
+
+   // Define category to distinguish d0 and d0bar samples events
+   RooCategory sample("sample", "sample", {{"cat0", 0}, {"cat1", 1}});
+
+   // Construct a dummy dataset
+   RooDataSet data("data", "data", RooArgSet(sample, x, y));
+
+   // Construct a simultaneous pdf using category sample as index
+   RooSimultaneous simPdf("simPdf", "simultaneous pdf", sample);
+   simPdf.addPdf(model, "cat0");
+   simPdf.addPdf(model, "cat1");
+
+   simPdf.fitTo(data, PrintLevel(-1));
 }


### PR DESCRIPTION
If a server is redirected, the cached normalization sets in `RooAbsPdf`
and `RooAddPdf` might not point to the right observables anymore. We
need to reset them.

A unit test based on the code that originally unveiled this issue is
also implemented.

This is a backport of https://github.com/root-project/root/pull/9552.