### PR TITLE
Add missing include for strlcpy()

### DIFF
--- a/montecarlo/pythia6/src/TPythia6.cxx
+++ b/montecarlo/pythia6/src/TPythia6.cxx
@@ -68,6 +68,7 @@ For the details about these generators look at Pythia/Jetset manual:
 #include "TMCParticle.h"
 #include "TParticle.h"
 #include "snprintf.h"
+#include "strlcpy.h"
 
 TPythia6*  TPythia6::fgInstance = nullptr;
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

With `dev=1`, `asserts=1`, `pythia6=1`, `CMAKE_BUILD_TYPE=Debug`, `LLVM_BUILD_TYPE=Debug`, and `LLVM_ENABLE_ASSERTIONS=1`, a missing `#include "strlcpy.h" is exposed in `TPythia6.cxx` which is fixed by this PR.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
