### PR TITLE
[ntuple] Represent v1 cluster groups in descriptor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -691,6 +691,10 @@ public:
    /// In case of invalid field ID, an empty string is returned.
    std::string GetQualifiedFieldName(DescriptorId_t fieldId) const;
 
+   /// Methods to load and drop cluster details
+   RResult<void> AddClusterDetails(RClusterDescriptor &&clusterDesc);
+   RResult<void> DropClusterDetails(DescriptorId_t clusterId);
+
    /// Re-create the C++ model from the stored meta-data
    std::unique_ptr<RNTupleModel> GenerateModel() const;
    void PrintInfo(std::ostream &output) const;
@@ -875,6 +879,10 @@ public:
 
    DescriptorId_t GetId() const { return fClusterGroup.GetId(); }
 
+   /// Used to preapre the cluster descriptor builders when loading the page locations for a certain cluster group
+   static std::vector<RClusterDescriptorBuilder>
+   GetClusterSummaries(const RNTupleDescriptor &ntplDesc, DescriptorId_t clusterGroupId);
+
    RResult<RClusterGroupDescriptor> MoveDescriptor();
 };
 
@@ -940,13 +948,13 @@ public:
    RResult<void> AddColumn(RColumnDescriptor &&columnDesc);
 
    RResult<void> AddClusterSummary(DescriptorId_t clusterId, std::uint64_t firstEntry, std::uint64_t nEntries);
+   void AddClusterGroup(RClusterGroupDescriptorBuilder &clusterGroup);
+
    // TODO(jblomer): get cluster summaries as function of the cluster group
    std::vector<RClusterDescriptorBuilder> GetClusterSummaries();
    void AddClusterGroup(Internal::RNTupleSerializer::RClusterGroup &clusterGroup);
    Internal::RNTupleSerializer::RClusterGroup GetClusterGroup(std::uint32_t id) const { return fClusterGroups.at(id); }
    RResult<void> AddCluster(RClusterDescriptor &&clusterDesc);
-
-   void AddClusterGroup(RClusterGroupDescriptorBuilder &clusterGroup);
 
    /// Clears so-far stored clusters, fields, and columns and return to a pristine ntuple descriptor
    void Reset();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -836,11 +836,6 @@ public:
       fCluster.fNEntries = nEntries;
       return *this;
    }
-   RClusterDescriptorBuilder &HasPageLocations()
-   {
-      fCluster.fHasPageLocations = true;
-      return *this;
-   }
 
    RResult<void> CommitColumnRange(DescriptorId_t columnId,
                                    std::uint64_t firstElementIndex,

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -939,7 +939,8 @@ public:
    std::uint32_t GetHeaderCRC32() const { return fHeaderCRC32; }
 
    void SetOnDiskHeaderSize(std::uint64_t size) { fDescriptor.fOnDiskHeaderSize = size; }
-   void SetOnDiskFooterSize(std::uint64_t size) { fDescriptor.fOnDiskFooterSize = size; }
+   /// The real footer size also include the page list envelopes
+   void AddToOnDiskFooterSize(std::uint64_t size) { fDescriptor.fOnDiskFooterSize += size; }
 
    void AddField(const RFieldDescriptor& fieldDesc);
    RResult<void> AddFieldLink(DescriptorId_t fieldId, DescriptorId_t linkId);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -951,7 +951,9 @@ public:
    RResult<void> AddClusterSummary(DescriptorId_t clusterId, std::uint64_t firstEntry, std::uint64_t nEntries);
    void AddClusterGroup(RClusterGroupDescriptorBuilder &&clusterGroup);
 
-   RResult<void> AddCluster(RClusterDescriptor &&clusterDesc);
+   /// Used during writing. For reading, cluster summaries are added in the builder and cluster details are added
+   /// on demand through the RNTupleDescriptor.
+   RResult<void> AddClusterWithDetails(RClusterDescriptor &&clusterDesc);
 
    /// Clears so-far stored clusters, fields, and columns and return to a pristine ntuple descriptor
    void Reset();

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -346,6 +346,7 @@ public:
    bool operator==(const RClusterGroupDescriptor &other) const;
 
    DescriptorId_t GetId() const { return fClusterGroupId; }
+   std::uint64_t GetNClusters() const { return fClusterIds.size(); }
    RNTupleLocator GetPageListLocator() const { return fPageListLocator; }
    std::uint32_t GetPageListLength() const { return fPageListLength; }
    bool Contains(DescriptorId_t clusterId) const
@@ -923,7 +924,6 @@ class RNTupleDescriptorBuilder {
 private:
    RNTupleDescriptor fDescriptor;
    std::uint32_t fHeaderCRC32 = 0;
-   std::vector<Internal::RNTupleSerializer::RClusterGroup> fClusterGroups;
 
    RResult<void> EnsureFieldExists(DescriptorId_t fieldId) const;
 public:
@@ -949,12 +949,8 @@ public:
    RResult<void> AddColumn(RColumnDescriptor &&columnDesc);
 
    RResult<void> AddClusterSummary(DescriptorId_t clusterId, std::uint64_t firstEntry, std::uint64_t nEntries);
-   void AddClusterGroup(RClusterGroupDescriptorBuilder &clusterGroup);
+   void AddClusterGroup(RClusterGroupDescriptorBuilder &&clusterGroup);
 
-   // TODO(jblomer): get cluster summaries as function of the cluster group
-   std::vector<RClusterDescriptorBuilder> GetClusterSummaries();
-   void AddClusterGroup(Internal::RNTupleSerializer::RClusterGroup &clusterGroup);
-   Internal::RNTupleSerializer::RClusterGroup GetClusterGroup(std::uint32_t id) const { return fClusterGroups.at(id); }
    RResult<void> AddCluster(RClusterDescriptor &&clusterDesc);
 
    /// Clears so-far stored clusters, fields, and columns and return to a pristine ntuple descriptor

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -156,6 +156,8 @@ is used to denote the column group of all the columns. Every ntuple has at least
 */
 // clang-format on
 class RColumnGroupDescriptor {
+   friend class RColumnGroupDescriptorBuilder;
+
 private:
    DescriptorId_t fColumnGroupId = kInvalidDescriptorId;
    std::unordered_set<DescriptorId_t> fColumnIds;
@@ -304,6 +306,8 @@ clusters is denoted by an empty fClusterIds set. Every ntuple has at least one c
 */
 // clang-format on
 class RClusterGroupDescriptor {
+   friend class RClusterGroupDescriptorBuilder;
+
 private:
    DescriptorId_t fClusterGroupId = kInvalidDescriptorId;
    std::unordered_set<DescriptorId_t> fClusterIds;
@@ -769,6 +773,63 @@ public:
    RResult<RClusterDescriptor> MoveDescriptor();
 };
 
+// clang-format off
+/**
+\class ROOT::Experimental::RClusterGroupDescriptorBuilder
+\ingroup NTuple
+\brief A helper class for piece-wise construction of an RClusterGroupDescriptor
+*/
+// clang-format on
+class RClusterGroupDescriptorBuilder {
+private:
+   RClusterGroupDescriptor fClusterGroup;
+
+public:
+   RClusterGroupDescriptorBuilder() = default;
+
+   RClusterGroupDescriptorBuilder &ClusterGroupId(DescriptorId_t clusterGroupId)
+   {
+      fClusterGroup.fClusterGroupId = clusterGroupId;
+      return *this;
+   }
+   RClusterGroupDescriptorBuilder &FirstEntryIndex(NTupleSize_t firstEntryIndex)
+   {
+      fClusterGroup.fFirstEntryIndex = firstEntryIndex;
+      return *this;
+   }
+   RClusterGroupDescriptorBuilder &NEntries(NTupleSize_t nEntries)
+   {
+      fClusterGroup.fNEntries = nEntries;
+      return *this;
+   }
+   void AddCluster(DescriptorId_t clusterId) { fClusterGroup.fClusterIds.insert(clusterId); }
+
+   RResult<RClusterGroupDescriptor> MoveDescriptor();
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::RColumnGroupDescriptorBuilder
+\ingroup NTuple
+\brief A helper class for piece-wise construction of an RColumnGroupDescriptor
+*/
+// clang-format on
+class RColumnGroupDescriptorBuilder {
+private:
+   RColumnGroupDescriptor fColumnGroup;
+
+public:
+   RColumnGroupDescriptorBuilder() = default;
+
+   RColumnGroupDescriptorBuilder &ColumnGroupId(DescriptorId_t columnGroupId)
+   {
+      fColumnGroup.fColumnGroupId = columnGroupId;
+      return *this;
+   }
+   void AddColumn(DescriptorId_t columnId) { fColumnGroup.fColumnIds.insert(columnId); }
+
+   RResult<RColumnGroupDescriptor> MoveDescriptor();
+};
 
 // clang-format off
 /**

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -145,6 +145,35 @@ public:
    DescriptorId_t GetFieldId() const { return fFieldId; }
 };
 
+// clang-format off
+/**
+\class ROOT::Experimental::RColumnGroupDescriptor
+\ingroup NTuple
+\brief Meta-data for a sets of columns; non-trivial column groups are used for sharded clusters
+
+Clusters can span a subset of columns. Such subsets are described as a column group. An empty column group
+is used to denote the column group of all the columns. Every ntuple has at least one column group.
+*/
+// clang-format on
+class RColumnGroupDescriptor {
+private:
+   DescriptorId_t fColumnGroupId = kInvalidDescriptorId;
+   std::unordered_set<DescriptorId_t> fColumnIds;
+
+public:
+   RColumnGroupDescriptor() = default;
+   RColumnGroupDescriptor(const RColumnGroupDescriptor &other) = delete;
+   RColumnGroupDescriptor &operator=(const RColumnGroupDescriptor &other) = delete;
+   RColumnGroupDescriptor(RColumnGroupDescriptor &&other) = default;
+   RColumnGroupDescriptor &operator=(RColumnGroupDescriptor &&other) = default;
+
+   bool operator==(const RColumnGroupDescriptor &other) const;
+
+   DescriptorId_t GetId() const { return fColumnGroupId; }
+   const std::unordered_set<DescriptorId_t> &GetColumnIds() const { return fColumnIds; }
+   bool Contains(DescriptorId_t columnId) const { return fColumnIds.empty() || fColumnIds.count(columnId) > 0; }
+   bool HasAllColumns() const { return fColumnIds.empty(); }
+};
 
 // clang-format off
 /**
@@ -262,6 +291,41 @@ public:
    std::uint64_t GetBytesOnStorage() const;
 };
 
+// clang-format off
+/**
+\class ROOT::Experimental::RClusterGroupDescriptor
+\ingroup NTuple
+\brief Clusters are stored in cluster groups. Cluster groups span all the columns of a certain event range.
+
+Very large ntuples or combined ntuples (chains, friends) contain multiple cluster groups. The cluster groups
+may contain shared clusters. However, a cluster group must contain the clusters spanning all the columns for the
+given event range. Cluster groups must partition the entry range of an ntuple. The cluster group spanning all
+clusters is denoted by an empty fClusterIds set. Every ntuple has at least one cluster group.
+*/
+// clang-format on
+class RClusterGroupDescriptor {
+private:
+   DescriptorId_t fClusterGroupId = kInvalidDescriptorId;
+   std::unordered_set<DescriptorId_t> fClusterIds;
+   NTupleSize_t fFirstEntryIndex = kInvalidNTupleIndex;
+   NTupleSize_t fNEntries = 0;
+
+public:
+   RClusterGroupDescriptor() = default;
+   RClusterGroupDescriptor(const RClusterGroupDescriptor &other) = delete;
+   RClusterGroupDescriptor &operator=(const RClusterGroupDescriptor &other) = delete;
+   RClusterGroupDescriptor(RClusterGroupDescriptor &&other) = default;
+   RClusterGroupDescriptor &operator=(RClusterGroupDescriptor &&other) = default;
+
+   bool operator==(const RClusterGroupDescriptor &other) const;
+
+   DescriptorId_t GetId() const { return fClusterGroupId; }
+   const std::unordered_set<DescriptorId_t> &GetClusterIds() const { return fClusterIds; }
+   NTupleSize_t GetFirstEntryIndex() const { return fFirstEntryIndex; }
+   NTupleSize_t GetNEntries() const { return fNEntries; }
+   bool Contains(DescriptorId_t clusterId) const { return fClusterIds.empty() && fClusterIds.count(clusterId) > 0; }
+   bool HasAllClusters() const { return fClusterIds.empty(); }
+};
 
 // clang-format off
 /**

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -511,7 +511,7 @@ public:
    \brief Used to loop over all the cluster groups of an ntuple (in unspecified order)
 
    Enumerate all cluster group IDs from the cluster group descriptor.  No specific order can be assumed, use
-   FindNextClusterGroupId and FindPrevClusterGroupId to travers clusters groups by entry number.
+   FindNextClusterGroupId and FindPrevClusterGroupId to traverse clusters groups by entry number.
    */
    // clang-format on
    class RClusterGroupDescriptorIterable {

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -311,8 +311,10 @@ class RClusterGroupDescriptor {
 private:
    DescriptorId_t fClusterGroupId = kInvalidDescriptorId;
    std::unordered_set<DescriptorId_t> fClusterIds;
-   NTupleSize_t fFirstEntryIndex = kInvalidNTupleIndex;
-   NTupleSize_t fNEntries = 0;
+   /// The page list that corresponds to the cluster group
+   RNTupleLocator fPageListLocator;
+   /// Uncompressed size of the page list
+   std::uint32_t fPageListLength = 0;
 
 public:
    RClusterGroupDescriptor() = default;
@@ -325,8 +327,8 @@ public:
 
    DescriptorId_t GetId() const { return fClusterGroupId; }
    const std::unordered_set<DescriptorId_t> &GetClusterIds() const { return fClusterIds; }
-   NTupleSize_t GetFirstEntryIndex() const { return fFirstEntryIndex; }
-   NTupleSize_t GetNEntries() const { return fNEntries; }
+   RNTupleLocator GetPageListLocator() const { return fPageListLocator; }
+   std::uint32_t GetPageListLength() const { return fPageListLength; }
    bool Contains(DescriptorId_t clusterId) const { return fClusterIds.empty() && fClusterIds.count(clusterId) > 0; }
    bool HasAllClusters() const { return fClusterIds.empty(); }
 };
@@ -792,14 +794,14 @@ public:
       fClusterGroup.fClusterGroupId = clusterGroupId;
       return *this;
    }
-   RClusterGroupDescriptorBuilder &FirstEntryIndex(NTupleSize_t firstEntryIndex)
+   RClusterGroupDescriptorBuilder &PageListLocator(const RNTupleLocator &pageListLocator)
    {
-      fClusterGroup.fFirstEntryIndex = firstEntryIndex;
+      fClusterGroup.fPageListLocator = pageListLocator;
       return *this;
    }
-   RClusterGroupDescriptorBuilder &NEntries(NTupleSize_t nEntries)
+   RClusterGroupDescriptorBuilder &PageListLength(std::uint32_t pageListLength)
    {
-      fClusterGroup.fNEntries = nEntries;
+      fClusterGroup.fPageListLength = pageListLength;
       return *this;
    }
    void AddCluster(DescriptorId_t clusterId) { fClusterGroup.fClusterIds.insert(clusterId); }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -880,7 +880,7 @@ public:
 
    DescriptorId_t GetId() const { return fClusterGroup.GetId(); }
 
-   /// Used to preapre the cluster descriptor builders when loading the page locations for a certain cluster group
+   /// Used to prepare the cluster descriptor builders when loading the page locations for a certain cluster group
    static std::vector<RClusterDescriptorBuilder>
    GetClusterSummaries(const RNTupleDescriptor &ntplDesc, DescriptorId_t clusterGroupId);
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -662,10 +662,7 @@ public:
    /// Searches for a top-level field
    DescriptorId_t FindFieldId(std::string_view fieldName) const;
    DescriptorId_t FindColumnId(DescriptorId_t fieldId, std::uint32_t columnIndex) const;
-   DescriptorId_t FindClusterGroupId(NTupleSize_t index) const;
    DescriptorId_t FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const;
-   DescriptorId_t FindNextClusterGroupId(DescriptorId_t clusterGroupId) const;
-   DescriptorId_t FindPrevClusterGroupId(DescriptorId_t clusterGroupId) const;
    DescriptorId_t FindNextClusterId(DescriptorId_t clusterId) const;
    DescriptorId_t FindPrevClusterId(DescriptorId_t clusterId) const;
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -319,7 +319,7 @@ public:
 \brief Clusters are stored in cluster groups. Cluster groups span all the columns of a certain event range.
 
 Very large ntuples or combined ntuples (chains, friends) contain multiple cluster groups. The cluster groups
-may contain shared clusters. However, a cluster group must contain the clusters spanning all the columns for the
+may contain sharded clusters. However, a cluster group must contain the clusters spanning all the columns for the
 given event range. Cluster groups must partition the entry range of an ntuple.
 Every ntuple has at least one cluster group.  The clusters in a cluster group are ordered corresponding to
 the order of page locations in the page list envelope that belongs to the cluster group (see format specification)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -215,6 +215,7 @@ public:
    static RResult<void> DeserializeFooterV1(const void *buffer,
                                             std::uint32_t bufSize,
                                             RNTupleDescriptorBuilder &descBuilder);
+   // The clusters vector must be initialized with the cluster summaries corresponding to the page list
    static RResult<void> DeserializePageListV1(const void *buffer,
                                               std::uint32_t bufSize,
                                               std::vector<RClusterDescriptorBuilder> &clusters);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -371,6 +371,7 @@ ROOT::Experimental::RClusterDescriptorBuilder::MoveDescriptor()
          return R__FAIL("missing column range");
       }
    }
+   fCluster.fHasPageLocations = true;
    RClusterDescriptor result;
    std::swap(result, fCluster);
    return result;
@@ -615,9 +616,8 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddCluster(
       return R__FAIL("cluster clash");
    const auto &summary = fClusterSummaries.at(clusterId);
    partialCluster.ClusterId(clusterId)
-      .FirstEntryIndex(summary.fFirstEntry)
-      .NEntries(summary.fNEntries)
-      .HasPageLocations();
+                 .FirstEntryIndex(summary.fFirstEntry)
+                 .NEntries(summary.fNEntries);
    auto cluster = partialCluster.MoveDescriptor();
    if (!cluster)
       return R__FORWARD_ERROR(cluster);

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -262,19 +262,6 @@ ROOT::Experimental::RNTupleDescriptor::FindColumnId(DescriptorId_t fieldId, std:
    return kInvalidDescriptorId;
 }
 
-ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterGroupId(NTupleSize_t index) const
-{
-   // TODO(jblomer): binary search?
-   for (const auto &cgd : fClusterGroupDescriptors) {
-      if (cgd.second.GetFirstEntryIndex() > index)
-         continue;
-      if (cgd.second.GetFirstEntryIndex() + cgd.second.GetNEntries() <= index)
-         continue;
-      return cgd.second.GetId();
-   }
-   return kInvalidDescriptorId;
-}
-
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const
 {
@@ -289,30 +276,6 @@ ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NT
    return kInvalidDescriptorId;
 }
 
-ROOT::Experimental::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindNextClusterGroupId(DescriptorId_t clusterGroupId) const
-{
-   const auto &clusterGroupDesc = GetClusterGroupDescriptor(clusterGroupId);
-   auto firstEntryInNextClusterGroup = clusterGroupDesc.GetFirstEntryIndex() + clusterGroupDesc.GetNEntries();
-   // TODO(jblomer): binary search?
-   for (const auto &cgd : fClusterGroupDescriptors) {
-      if (cgd.second.GetFirstEntryIndex() == firstEntryInNextClusterGroup)
-         return cgd.second.GetId();
-   }
-   return kInvalidDescriptorId;
-}
-
-ROOT::Experimental::DescriptorId_t
-ROOT::Experimental::RNTupleDescriptor::FindPrevClusterGroupId(DescriptorId_t clusterGroupId) const
-{
-   const auto &clusterGroupDesc = GetClusterGroupDescriptor(clusterGroupId);
-   // TODO(jblomer): binary search?
-   for (const auto &cgd : fClusterGroupDescriptors) {
-      if (cgd.second.GetFirstEntryIndex() + cgd.second.GetNEntries() == clusterGroupDesc.GetFirstEntryIndex())
-         return cgd.second.GetId();
-   }
-   return kInvalidDescriptorId;
-}
 
 // TODO(jblomer): fix for cases of sharded clasters
 ROOT::Experimental::DescriptorId_t

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -320,6 +320,20 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool ROOT::Experimental::RColumnGroupDescriptor::operator==(const RColumnGroupDescriptor &other) const
+{
+   return fColumnGroupId == other.fColumnGroupId && fColumnIds == other.fColumnIds;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool ROOT::Experimental::RClusterGroupDescriptor::operator==(const RClusterGroupDescriptor &other) const
+{
+   return fClusterGroupId == other.fClusterGroupId && fClusterIds == other.fClusterIds &&
+          fFirstEntryIndex == other.fFirstEntryIndex && fNEntries == other.fNEntries;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RClusterDescriptorBuilder::CommitColumnRange(

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -587,7 +587,8 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddColumn(RColumnDescriptor &&colu
          return R__FAIL("out of bounds column index");
    }
 
-   fDescriptor.fColumnDescriptors.emplace(columnDesc.GetId(), std::move(columnDesc));
+   auto columnId = columnDesc.GetId();
+   fDescriptor.fColumnDescriptors.emplace(columnId, std::move(columnDesc));
 
    return RResult<void>::Success();
 }
@@ -602,9 +603,10 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterSummary(DescriptorId_t c
    return RResult<void>::Success();
 }
 
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterGroup(RClusterGroupDescriptorBuilder &clusterGroup)
+void ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterGroup(RClusterGroupDescriptorBuilder &&clusterGroup)
 {
-   fDescriptor.fClusterGroupDescriptors.emplace(clusterGroup.GetId(), clusterGroup.MoveDescriptor().Unwrap());
+   auto id = clusterGroup.GetId();
+   fDescriptor.fClusterGroupDescriptors.emplace(id, clusterGroup.MoveDescriptor().Unwrap());
 }
 
 void ROOT::Experimental::RNTupleDescriptorBuilder::Reset()
@@ -614,23 +616,7 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::Reset()
    fDescriptor.fFieldDescriptors.clear();
    fDescriptor.fColumnDescriptors.clear();
    fDescriptor.fClusterDescriptors.clear();
-}
-
-std::vector<ROOT::Experimental::RClusterDescriptorBuilder>
-ROOT::Experimental::RNTupleDescriptorBuilder::GetClusterSummaries()
-{
-   std::vector<RClusterDescriptorBuilder> result;
-   for (unsigned i = 0; i < fDescriptor.GetNClusters(); ++i) {
-      const auto &cluster = fDescriptor.GetClusterDescriptor(i);
-      result.emplace_back(RClusterDescriptorBuilder(i, cluster.GetFirstEntryIndex(), cluster.GetNEntries()));
-   }
-   return result;
-}
-
-void ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterGroup(
-   Internal::RNTupleSerializer::RClusterGroup &clusterGroup)
-{
-   fClusterGroups.push_back(clusterGroup);
+   fDescriptor.fClusterGroupDescriptors.clear();
 }
 
 ROOT::Experimental::RResult<void>

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -262,6 +262,18 @@ ROOT::Experimental::RNTupleDescriptor::FindColumnId(DescriptorId_t fieldId, std:
    return kInvalidDescriptorId;
 }
 
+ROOT::Experimental::DescriptorId_t ROOT::Experimental::RNTupleDescriptor::FindClusterGroupId(NTupleSize_t index) const
+{
+   // TODO(jblomer): binary search?
+   for (const auto &cgd : fClusterGroupDescriptors) {
+      if (cgd.second.GetFirstEntryIndex() > index)
+         continue;
+      if (cgd.second.GetFirstEntryIndex() + cgd.second.GetNEntries() <= index)
+         continue;
+      return cgd.second.GetId();
+   }
+   return kInvalidDescriptorId;
+}
 
 ROOT::Experimental::DescriptorId_t
 ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NTupleSize_t index) const
@@ -277,6 +289,30 @@ ROOT::Experimental::RNTupleDescriptor::FindClusterId(DescriptorId_t columnId, NT
    return kInvalidDescriptorId;
 }
 
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::FindNextClusterGroupId(DescriptorId_t clusterGroupId) const
+{
+   const auto &clusterGroupDesc = GetClusterGroupDescriptor(clusterGroupId);
+   auto firstEntryInNextClusterGroup = clusterGroupDesc.GetFirstEntryIndex() + clusterGroupDesc.GetNEntries();
+   // TODO(jblomer): binary search?
+   for (const auto &cgd : fClusterGroupDescriptors) {
+      if (cgd.second.GetFirstEntryIndex() == firstEntryInNextClusterGroup)
+         return cgd.second.GetId();
+   }
+   return kInvalidDescriptorId;
+}
+
+ROOT::Experimental::DescriptorId_t
+ROOT::Experimental::RNTupleDescriptor::FindPrevClusterGroupId(DescriptorId_t clusterGroupId) const
+{
+   const auto &clusterGroupDesc = GetClusterGroupDescriptor(clusterGroupId);
+   // TODO(jblomer): binary search?
+   for (const auto &cgd : fClusterGroupDescriptors) {
+      if (cgd.second.GetFirstEntryIndex() + cgd.second.GetNEntries() == clusterGroupDesc.GetFirstEntryIndex())
+         return cgd.second.GetId();
+   }
+   return kInvalidDescriptorId;
+}
 
 // TODO(jblomer): fix for cases of sharded clasters
 ROOT::Experimental::DescriptorId_t

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -319,6 +319,8 @@ ROOT::Experimental::RNTupleDescriptor::AddClusterDetails(RClusterDescriptor &&cl
       return R__FAIL("invalid attempt to add cluster details without known cluster summary");
    if (iter->second.HasPageLocations())
       return R__FAIL("invalid attempt to re-populate page list");
+   if (!clusterDesc.HasPageLocations())
+      return R__FAIL("provided cluster descriptor does not contain page locations");
    iter->second = std::move(clusterDesc);
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -375,6 +375,29 @@ ROOT::Experimental::RClusterDescriptorBuilder::MoveDescriptor()
 
 ////////////////////////////////////////////////////////////////////////////////
 
+ROOT::Experimental::RResult<ROOT::Experimental::RClusterGroupDescriptor>
+ROOT::Experimental::RClusterGroupDescriptorBuilder::MoveDescriptor()
+{
+   if (fClusterGroup.fClusterGroupId == kInvalidDescriptorId)
+      return R__FAIL("unset cluster group ID");
+   RClusterGroupDescriptor result;
+   std::swap(result, fClusterGroup);
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+ROOT::Experimental::RResult<ROOT::Experimental::RColumnGroupDescriptor>
+ROOT::Experimental::RColumnGroupDescriptorBuilder::MoveDescriptor()
+{
+   if (fColumnGroup.fColumnGroupId == kInvalidDescriptorId)
+      return R__FAIL("unset column group ID");
+   RColumnGroupDescriptor result;
+   std::swap(result, fColumnGroup);
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::RResult<void>
 ROOT::Experimental::RNTupleDescriptorBuilder::EnsureFieldExists(DescriptorId_t fieldId) const {

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -329,8 +329,7 @@ bool ROOT::Experimental::RColumnGroupDescriptor::operator==(const RColumnGroupDe
 
 bool ROOT::Experimental::RClusterGroupDescriptor::operator==(const RClusterGroupDescriptor &other) const
 {
-   return fClusterGroupId == other.fClusterGroupId && fClusterIds == other.fClusterIds &&
-          fFirstEntryIndex == other.fFirstEntryIndex && fNEntries == other.fNEntries;
+   return fClusterGroupId == other.fClusterGroupId && fClusterIds == other.fClusterIds;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -620,13 +620,11 @@ void ROOT::Experimental::RNTupleDescriptorBuilder::Reset()
 }
 
 ROOT::Experimental::RResult<void>
-ROOT::Experimental::RNTupleDescriptorBuilder::AddCluster(RClusterDescriptor &&clusterDesc)
+ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterWithDetails(RClusterDescriptor &&clusterDesc)
 {
-   auto iter = fDescriptor.fClusterDescriptors.find(clusterDesc.GetId());
-   if (iter == fDescriptor.fClusterDescriptors.end())
-      return R__FAIL("invalid attempt to add cluster without known cluster summary");
-   if (iter->second.HasPageLocations())
-      return R__FAIL("invalid attempt to re-populate page list");
-   iter->second = std::move(clusterDesc);
+   auto clusterId = clusterDesc.GetId();
+   if (fDescriptor.fClusterDescriptors.count(clusterId) > 0)
+      return R__FAIL("cluster id clash");
+   fDescriptor.fClusterDescriptors.emplace(clusterId, std::move(clusterDesc));
    return RResult<void>::Success();
 }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1286,6 +1286,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::Internal::RNTupleSerialize
       if (!result)
          return R__FORWARD_ERROR(result);
       bytes += result.Unwrap();
+      descBuilder.AddToOnDiskFooterSize(clusterGroup.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
       descBuilder.AddClusterGroup(clusterGroup);
    }
    bytes = frame + frameSize;

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -92,7 +92,6 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFri
       AddVirtualField(i, desc.GetFieldZero(), 0, desc.GetName());
 
       for (const auto &c : desc.GetClusterIterable()) {
-         fBuilder.AddClusterSummary(fNextId, c.GetFirstEntryIndex(), c.GetNEntries());
          RClusterDescriptorBuilder clusterBuilder(fNextId, c.GetFirstEntryIndex(), c.GetNEntries());
          for (auto originColumnId : c.GetColumnIds()) {
             DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnId});
@@ -105,7 +104,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFri
 
             clusterBuilder.CommitColumnRange(virtualColumnId, firstElementIndex, compressionSettings, pageRange);
          }
-         fBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
+         fBuilder.AddClusterWithDetails(clusterBuilder.MoveDescriptor().Unwrap());
          fIdBiMap.Insert({i, c.GetId()}, fNextId);
          fNextId++;
       }

--- a/tree/ntuple/v7/src/RPageSourceFriends.cxx
+++ b/tree/ntuple/v7/src/RPageSourceFriends.cxx
@@ -92,18 +92,20 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFri
       AddVirtualField(i, desc.GetFieldZero(), 0, desc.GetName());
 
       for (const auto &c : desc.GetClusterIterable()) {
-         fBuilder.AddCluster(fNextId, c.GetFirstEntryIndex(), c.GetNEntries());
+         fBuilder.AddClusterSummary(fNextId, c.GetFirstEntryIndex(), c.GetNEntries());
+         RClusterDescriptorBuilder clusterBuilder(fNextId, c.GetFirstEntryIndex(), c.GetNEntries());
          for (auto originColumnId : c.GetColumnIds()) {
             DescriptorId_t virtualColumnId = fIdBiMap.GetVirtualId({i, originColumnId});
 
-            auto columnRange = c.GetColumnRange(originColumnId);
-            columnRange.fColumnId = virtualColumnId;
-            fBuilder.AddClusterColumnRange(fNextId, columnRange);
-
             auto pageRange = c.GetPageRange(originColumnId).Clone();
             pageRange.fColumnId = virtualColumnId;
-            fBuilder.AddClusterPageRange(fNextId, std::move(pageRange));
+
+            auto firstElementIndex = c.GetColumnRange(originColumnId).fFirstElementIndex;
+            auto compressionSettings = c.GetColumnRange(originColumnId).fCompressionSettings;
+
+            clusterBuilder.CommitColumnRange(virtualColumnId, firstElementIndex, compressionSettings, pageRange);
          }
+         fBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
          fIdBiMap.Insert({i, c.GetId()}, fNextId);
          fNextId++;
       }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -349,7 +349,6 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
 
    R__ASSERT((nEntries - fPrevClusterNEntries) < ClusterSize_t(-1));
    auto nEntriesInCluster = ClusterSize_t(nEntries - fPrevClusterNEntries);
-   fDescriptorBuilder.AddClusterSummary(fLastClusterId, fPrevClusterNEntries, nEntriesInCluster);
    RClusterDescriptorBuilder clusterBuilder(fLastClusterId, fPrevClusterNEntries, nEntriesInCluster);
    for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
       RClusterDescriptor::RPageRange fullRange;
@@ -360,7 +359,7 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
       fOpenColumnRanges[i].fFirstElementIndex += fOpenColumnRanges[i].fNElements;
       fOpenColumnRanges[i].fNElements = 0;
    }
-   fDescriptorBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
+   fDescriptorBuilder.AddClusterWithDetails(clusterBuilder.MoveDescriptor().Unwrap());
    fPrevClusterNEntries = nEntries;
    ++fLastClusterId;
    return nbytes;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -348,18 +348,19 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
    auto nbytes = CommitClusterImpl(nEntries);
 
    R__ASSERT((nEntries - fPrevClusterNEntries) < ClusterSize_t(-1));
-   fDescriptorBuilder.AddCluster(fLastClusterId, fPrevClusterNEntries, ClusterSize_t(nEntries - fPrevClusterNEntries));
-   for (auto &range : fOpenColumnRanges) {
-      fDescriptorBuilder.AddClusterColumnRange(fLastClusterId, range);
-      range.fFirstElementIndex += range.fNElements;
-      range.fNElements = 0;
-   }
-   for (auto &range : fOpenPageRanges) {
+   auto nEntriesInCluster = ClusterSize_t(nEntries - fPrevClusterNEntries);
+   fDescriptorBuilder.AddClusterSummary(fLastClusterId, fPrevClusterNEntries, nEntriesInCluster);
+   RClusterDescriptorBuilder clusterBuilder(fLastClusterId, fPrevClusterNEntries, nEntriesInCluster);
+   for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
       RClusterDescriptor::RPageRange fullRange;
-      std::swap(fullRange, range);
-      range.fColumnId = fullRange.fColumnId;
-      fDescriptorBuilder.AddClusterPageRange(fLastClusterId, std::move(fullRange));
+      fullRange.fColumnId = i;
+      std::swap(fullRange, fOpenPageRanges[i]);
+      clusterBuilder.CommitColumnRange(i, fOpenColumnRanges[i].fFirstElementIndex,
+                                       fOpenColumnRanges[i].fCompressionSettings, fullRange);
+      fOpenColumnRanges[i].fFirstElementIndex += fOpenColumnRanges[i].fNElements;
+      fOpenColumnRanges[i].fNElements = 0;
    }
+   fDescriptorBuilder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
    fPrevClusterNEntries = nEntries;
    ++fLastClusterId;
    return nbytes;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -376,10 +376,10 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    fDecompressor->Unzip(zipBuffer.get(), cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage,
                         cg.fPageListEnvelopeLink.fUnzippedSize, buffer.get());
 
-   std::vector<RClusterDescriptorBuilder> clusters;
+   std::vector<RClusterDescriptorBuilder> clusters = descBuilder.GetClusterSummaries();
    Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), cg.fPageListEnvelopeLink.fUnzippedSize, clusters);
    for (std::size_t i = 0; i < clusters.size(); ++i) {
-      descBuilder.AddCluster(i, std::move(clusters[i]));
+      descBuilder.AddCluster(clusters[i].MoveDescriptor().Unwrap());
    }
 
    return descBuilder.MoveDescriptor();

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -358,6 +358,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    fDecompressor->Unzip(zipBuffer.get(), ntpl.fNBytesHeader, ntpl.fLenHeader, buffer.get());
    Internal::RNTupleSerializer::DeserializeHeaderV1(buffer.get(), ntpl.fLenHeader, descBuilder);
 
+   descBuilder.AddToOnDiskFooterSize(ntpl.fNBytesFooter);
    buffer = std::make_unique<unsigned char[]>(ntpl.fLenFooter);
    zipBuffer = std::make_unique<unsigned char[]>(ntpl.fNBytesFooter);
    fDaosContainer->ReadSingleAkey(zipBuffer.get(), ntpl.fNBytesFooter, kOidFooter, kDistributionKey,
@@ -366,7 +367,6 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    Internal::RNTupleSerializer::DeserializeFooterV1(buffer.get(), ntpl.fLenFooter, descBuilder);
 
    auto cg = descBuilder.GetClusterGroup(0);
-   descBuilder.SetOnDiskFooterSize(ntpl.fNBytesFooter + cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
    buffer = std::make_unique<unsigned char[]>(cg.fPageListEnvelopeLink.fUnzippedSize);
    zipBuffer = std::make_unique<unsigned char[]>(cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
    fDaosContainer->ReadSingleAkey(

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -368,20 +368,21 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
 
    auto ntplDesc = descBuilder.MoveDescriptor();
 
-   const auto &clusterGroupDesc = ntplDesc.GetClusterGroupDescriptor(0);
-   buffer = std::make_unique<unsigned char[]>(clusterGroupDesc.GetPageListLength());
-   zipBuffer = std::make_unique<unsigned char[]>(clusterGroupDesc.GetPageListLocator().fBytesOnStorage);
-   fDaosContainer->ReadSingleAkey(
-      zipBuffer.get(), clusterGroupDesc.GetPageListLocator().fBytesOnStorage,
-      {static_cast<decltype(daos_obj_id_t::lo)>(clusterGroupDesc.GetPageListLocator().fPosition), 0}, kDistributionKey,
-      kAttributeKey, kCidMetadata);
-   fDecompressor->Unzip(zipBuffer.get(), clusterGroupDesc.GetPageListLocator().fBytesOnStorage,
-                        clusterGroupDesc.GetPageListLength(), buffer.get());
+   for (const auto &cgDesc : ntplDesc.GetClusterGroupIterable()) {
+      buffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLength());
+      zipBuffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLocator().fBytesOnStorage);
+      fDaosContainer->ReadSingleAkey(
+         zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage,
+         {static_cast<decltype(daos_obj_id_t::lo)>(cgDesc.GetPageListLocator().fPosition), 0}, kDistributionKey,
+         kAttributeKey, kCidMetadata);
+      fDecompressor->Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
+                           buffer.get());
 
-   auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, 0);
-   Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), clusterGroupDesc.GetPageListLength(), clusters);
-   for (std::size_t i = 0; i < clusters.size(); ++i) {
-      ntplDesc.AddClusterDetails(clusters[i].MoveDescriptor().Unwrap());
+      auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, 0);
+      Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), cgDesc.GetPageListLength(), clusters);
+      for (std::size_t i = 0; i < clusters.size(); ++i) {
+         ntplDesc.AddClusterDetails(clusters[i].MoveDescriptor().Unwrap());
+      }
    }
 
    return ntplDesc;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -271,6 +271,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
    fDecompressor->Unzip(zipBuffer.get(), ntpl.fNBytesHeader, ntpl.fLenHeader, buffer.get());
    Internal::RNTupleSerializer::DeserializeHeaderV1(buffer.get(), ntpl.fLenHeader, descBuilder);
 
+   descBuilder.AddToOnDiskFooterSize(ntpl.fNBytesFooter);
    buffer = std::make_unique<unsigned char[]>(ntpl.fLenFooter);
    zipBuffer = std::make_unique<unsigned char[]>(ntpl.fNBytesFooter);
    fReader.ReadBuffer(zipBuffer.get(), ntpl.fNBytesFooter, ntpl.fSeekFooter);
@@ -278,7 +279,6 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
    Internal::RNTupleSerializer::DeserializeFooterV1(buffer.get(), ntpl.fLenFooter, descBuilder);
 
    auto cg = descBuilder.GetClusterGroup(0);
-   descBuilder.SetOnDiskFooterSize(ntpl.fNBytesFooter + cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
    buffer = std::make_unique<unsigned char[]>(cg.fPageListEnvelopeLink.fUnzippedSize);
    zipBuffer = std::make_unique<unsigned char[]>(cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
    fReader.ReadBuffer(zipBuffer.get(),

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -278,24 +278,23 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
    fDecompressor->Unzip(zipBuffer.get(), ntpl.fNBytesFooter, ntpl.fLenFooter, buffer.get());
    Internal::RNTupleSerializer::DeserializeFooterV1(buffer.get(), ntpl.fLenFooter, descBuilder);
 
-   auto cg = descBuilder.GetClusterGroup(0);
-   buffer = std::make_unique<unsigned char[]>(cg.fPageListEnvelopeLink.fUnzippedSize);
-   zipBuffer = std::make_unique<unsigned char[]>(cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
-   fReader.ReadBuffer(zipBuffer.get(),
-                      cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage,
-                      cg.fPageListEnvelopeLink.fLocator.fPosition);
-   fDecompressor->Unzip(zipBuffer.get(),
-                        cg.fPageListEnvelopeLink.fLocator.fBytesOnStorage,
-                        cg.fPageListEnvelopeLink.fUnzippedSize,
-                        buffer.get());
+   auto ntplDesc = descBuilder.MoveDescriptor();
 
-   std::vector<RClusterDescriptorBuilder> clusters = descBuilder.GetClusterSummaries();
-   Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), cg.fPageListEnvelopeLink.fUnzippedSize, clusters);
+   const auto &clusterGroupDesc = ntplDesc.GetClusterGroupDescriptor(0);
+   buffer = std::make_unique<unsigned char[]>(clusterGroupDesc.GetPageListLength());
+   zipBuffer = std::make_unique<unsigned char[]>(clusterGroupDesc.GetPageListLocator().fBytesOnStorage);
+   fReader.ReadBuffer(zipBuffer.get(), clusterGroupDesc.GetPageListLocator().fBytesOnStorage,
+                      clusterGroupDesc.GetPageListLocator().fPosition);
+   fDecompressor->Unzip(zipBuffer.get(), clusterGroupDesc.GetPageListLocator().fBytesOnStorage,
+                        clusterGroupDesc.GetPageListLength(), buffer.get());
+
+   auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, 0);
+   Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), clusterGroupDesc.GetPageListLength(), clusters);
    for (std::size_t i = 0; i < clusters.size(); ++i) {
-      descBuilder.AddCluster(clusters[i].MoveDescriptor().Unwrap());
+      ntplDesc.AddClusterDetails(clusters[i].MoveDescriptor().Unwrap());
    }
 
-   return descBuilder.MoveDescriptor();
+   return ntplDesc;
 }
 
 

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -289,10 +289,10 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
                         cg.fPageListEnvelopeLink.fUnzippedSize,
                         buffer.get());
 
-   std::vector<RClusterDescriptorBuilder> clusters;
+   std::vector<RClusterDescriptorBuilder> clusters = descBuilder.GetClusterSummaries();
    Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), cg.fPageListEnvelopeLink.fUnzippedSize, clusters);
    for (std::size_t i = 0; i < clusters.size(); ++i) {
-      descBuilder.AddCluster(i, std::move(clusters[i]));
+      descBuilder.AddCluster(clusters[i].MoveDescriptor().Unwrap());
    }
 
    return descBuilder.MoveDescriptor();

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -60,9 +60,12 @@ public:
       ROOT::Experimental::RNTupleDescriptorBuilder descBuilder;
       for (unsigned i = 0; i <= 5; ++i) {
          descBuilder.AddClusterSummary(i, i, 1);
-         descBuilder.AddCluster(ROOT::Experimental::RClusterDescriptorBuilder(i, i, 1).MoveDescriptor().Unwrap());
       }
       fDescriptor = descBuilder.MoveDescriptor();
+      for (unsigned i = 0; i <= 5; ++i) {
+         fDescriptor.AddClusterDetails(
+            ROOT::Experimental::RClusterDescriptorBuilder(i, i, 1).MoveDescriptor().Unwrap());
+      }
    }
    std::unique_ptr<RPageSource> Clone() const final { return nullptr; }
    RPage PopulatePage(ColumnHandle_t, ROOT::Experimental::NTupleSize_t) final { return RPage(); }

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -58,12 +58,10 @@ public:
 
    RPageSourceMock() : RPageSource("test", ROOT::Experimental::RNTupleReadOptions()) {
       ROOT::Experimental::RNTupleDescriptorBuilder descBuilder;
-      descBuilder.AddCluster(0, 0, ClusterSize_t(1));
-      descBuilder.AddCluster(1, 1, ClusterSize_t(1));
-      descBuilder.AddCluster(2, 2, ClusterSize_t(1));
-      descBuilder.AddCluster(3, 3, ClusterSize_t(1));
-      descBuilder.AddCluster(4, 4, ClusterSize_t(1));
-      descBuilder.AddCluster(5, 5, ClusterSize_t(1));
+      for (unsigned i = 0; i <= 5; ++i) {
+         descBuilder.AddClusterSummary(i, i, 1);
+         descBuilder.AddCluster(ROOT::Experimental::RClusterDescriptorBuilder(i, i, 1).MoveDescriptor().Unwrap());
+      }
       fDescriptor = descBuilder.MoveDescriptor();
    }
    std::unique_ptr<RPageSource> Clone() const final { return nullptr; }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -524,7 +524,6 @@ TEST(RNTuple, SerializeFooter)
 
    ROOT::Experimental::RClusterDescriptor::RColumnRange columnRange;
    ROOT::Experimental::RClusterDescriptor::RPageRange::RPageInfo pageInfo;
-   builder.AddClusterSummary(84, 0, ROOT::Experimental::ClusterSize_t(100));
    RClusterDescriptorBuilder clusterBuilder(84, 0, 100);
    ROOT::Experimental::RClusterDescriptor::RPageRange pageRange;
    pageRange.fColumnId = 17;
@@ -532,7 +531,7 @@ TEST(RNTuple, SerializeFooter)
    pageInfo.fLocator.fPosition = 7000;
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(17, 0, 100, pageRange);
-   builder.AddCluster(clusterBuilder.MoveDescriptor().Unwrap());
+   builder.AddClusterWithDetails(clusterBuilder.MoveDescriptor().Unwrap());
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeaderV1(nullptr, desc);

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -60,6 +60,7 @@ using NTupleSize_t = ROOT::Experimental::NTupleSize_t;
 using RColumnModel = ROOT::Experimental::RColumnModel;
 using RClusterIndex = ROOT::Experimental::RClusterIndex;
 using RClusterDescriptorBuilder = ROOT::Experimental::RClusterDescriptorBuilder;
+using RClusterGroupDescriptorBuilder = ROOT::Experimental::RClusterGroupDescriptorBuilder;
 using RFieldDescriptorBuilder = ROOT::Experimental::RFieldDescriptorBuilder;
 using RException = ROOT::Experimental::RException;
 template <class T>


### PR DESCRIPTION
The v1 binary format knows cluster groups. Cluster groups correspond to page list envelopes in the binary format, i.e. to blocks of meta-data with page locations. As a result, cluster groups allow for incremental loading of page locations (page meta-data), which is useful for very large files and combined data sets (chains, friends).

This PR restructures the `RNTupleDescriptor` and `RClusterDescriptor` and their builder classes such that they can eventually make proper use of cluster groups.  To this end, the descriptor is first populated with cluster groups and cluster summaries only. Cluster summaries only contain the cluster's event range (plus, at a later point, the column group ID for sharded clusters). In a second step, page lists of cluster groups are loaded and used to populate the page locations of clusters.

At this point, ntuples still load all meta-data on open. Follow-up PRs should change it such that ntuples initially only know cluster summaries. The cluster details (i.e. page locations) will the be loaded and dropped during event iteration based on an actively set event range window, which needs to be controlled by the user of the page source (`RNTupleReader`, `RNTupleDS`).