### PR TITLE
RooAddPdf: Avoid UB in checkObservables [v6.22]

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -900,7 +900,9 @@ Bool_t RooAddPdf::checkObservables(const RooArgSet* nset) const
 {
   Bool_t ret(kFALSE) ;
 
-  for (int i = 0; i < _pdfList.getSize(); ++i) {
+  // There may be fewer coefficients than PDFs.
+  int end = std::min(_pdfList.getSize(), _coefList.getSize());
+  for (int i = 0; i < end; ++i) {
     auto pdf  = static_cast<const RooAbsPdf *>(_pdfList.at(i));
     auto coef = static_cast<const RooAbsReal*>(_coefList.at(i));
     if (pdf->observableOverlaps(nset,*coef)) {


### PR DESCRIPTION
A RooAddPdf may have more PDFs than coefficients, in which case "the coefficient of the last PDF is calculated automatically from the condition that the sum of all coefficients has to be 1". In this case, the last call to `_coefList.at(i)` is supposed to return
a `nullptr` because the index is out of range, and dereferencing it is undefined behavior which Clang 13 optimizes away, leading to crashes.

Fixes #9547

(cherry picked from commit 1f3f0fdc0544087042e6289376094bf06b2d259f, backport of PR #9557)