### PR TITLE
[cxxmodules] Disentangle Vc and VecCore

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -106,13 +106,13 @@ if(runtime_cxxmodules)
   # FIXME: Revise after a llvm upgrade or reproduce it outside rootcling.
   list(REMOVE_ITEM HEADERS "Math/Math.h")
 
-  if(veccore OR vc)
+  if(vc)
     # We do not link against libVc.a thus it makes no sense to check for
     # version compatibility between libraries and header files. This fixes
     # ROOT-11002 where upon building the modules.idx we run the static ctor
     # runLibraryAbiCheck which fails to find the corresponding symbol.
     set(dictoptions "-m" "Vc" "-mByproduct" "Vc" "-D" "Vc_NO_VERSION_CHECK")
-  endif(veccore)
+  endif(vc)
 endif()
 
 ROOT_ADD_C_FLAG(_flags -Wno-strict-overflow)  # Avoid what it seems a compiler false positive warning


### PR DESCRIPTION
It seems that VecCore is a wrapper over Vc, however ROOT uses Vc in the context
of VecCore but also standalone.

Adapt CMake to only try to load the Vc module when the Vc option is on as VecCore
might have not exposed Vc...

This change improves root-project/root@f2ac9b349f

