### PR TITLE
[netxng] Avoid XRootD warnings in generated source

### DIFF
--- a/net/netxng/CMakeLists.txt
+++ b/net/netxng/CMakeLists.txt
@@ -31,6 +31,12 @@ ROOT_STANDARD_LIBRARY_PACKAGE(NetxNG
 )
 
 target_include_directories(NetxNG SYSTEM PRIVATE ${XROOTD_INCLUDE_DIRS})
+# The generated dictionary source file G__NetxNG.cxx, compiled into the OBJECT
+# library G__NetxNG, depends on XRootD headers via our TNetXNGFile.h. To avoid
+# warnings, the XRootD include directories must be added as SYSTEM. We cannot do
+# this automatically in the macros as CMake has no target property to find out
+# SYSTEM include directories, so we must do it manually here.
+target_include_directories(G__NetxNG SYSTEM PRIVATE ${XROOTD_INCLUDE_DIRS})
 
 target_compile_options(NetxNG PRIVATE -Wno-shadow)
 


### PR DESCRIPTION
It pulls in XRootD headers via `TNetXNGFile.h`, so the include directories must be added as `SYSTEM`.

This should fix build warnings on CentOS 8 without the builtin XRootD, but rather the distribution version 5.4.0.