### PR TITLE
Do not use gif

### DIFF
--- a/tutorials/graphics/latex4.C
+++ b/tutorials/graphics/latex4.C
@@ -20,7 +20,7 @@
 /// \author Rene Brun
 
 void latex4() {
-   TCanvas *c1 = new TCanvas("greek","greek",600,700);
+   auto c1 = new TCanvas("greek","greek",600,700);
 
    TLatex l;
    l.SetTextSize(0.03);
@@ -98,7 +98,7 @@ void latex4() {
 
    // Save the picture in various formats
    c1->Print("greek.ps");
-   c1->Print("greek.gif");
+   c1->Print("greek.png");
    c1->Print("greek.pdf");
    c1->Print("greek.svg");
 }

--- a/tutorials/graphics/latex5.C
+++ b/tutorials/graphics/latex5.C
@@ -16,7 +16,7 @@
 /// \author Rene Brun
 
 void latex5() {
-   TCanvas *c1 = new TCanvas("mathsymb","Mathematical Symbols",600,600);
+   auto c1 = new TCanvas("mathsymb","Mathematical Symbols",600,600);
 
    TLatex l;
    l.SetTextSize(0.03);
@@ -119,7 +119,7 @@ void latex5() {
 
    // Save the picture in various formats
    c1->Print("mathsymb.ps");
-   c1->Print("mathsymb.gif");
+   c1->Print("mathsymb.png");
    c1->Print("mathsymb.pdf");
    c1->Print("mathsymb.svg");
 }

--- a/tutorials/graphics/tmathtext.C
+++ b/tutorials/graphics/tmathtext.C
@@ -9,7 +9,7 @@
 /// \author Yue Shi Lai
 
 {
-   TCanvas *c1 = new TCanvas("c1");
+   auto c1 = new TCanvas("c1");
 
    TMathText l;
    l.SetTextAlign(23);
@@ -23,11 +23,6 @@
    l.DrawMathText(0.27, 0.110, "\\mathbb{N} \\subset \\mathbb{R}");
    l.DrawMathText(0.63, 0.100, "\\hbox{RHIC スピン物理 Нью-Йорк}");
 
-   c1->Print("c1.gif");
-   c1->Print("c1.jpg");
    c1->Print("c1.png");
    c1->Print("c1.ps");
-   c1->Print("c1.eps");
-
-   return c1;
 }

--- a/tutorials/image/hsumanim.C
+++ b/tutorials/image/hsumanim.C
@@ -2,7 +2,10 @@
 /// \ingroup tutorial_image
 /// \notebook
 /// This script is a slightly modified version of hsum.C.
-/// When run in batch mode, it produces an animated gif file.
+///
+/// At the end of this macro, after `c1->Modified();` calling `c1->Print("hsumanim.gif++");`
+/// will produce an animated gif file. The option "++" makes an infinite animation.
+/// The animated file `hsumanim.gif` can be visualized within a web browser
 ///
 /// \macro_image
 /// \macro_code
@@ -69,10 +72,6 @@ void hsumanim() {
    slider->SetRange(0,1);
    total->Draw("sameaxis"); // to redraw axis hidden by the fill area
    c1->Modified();
-   // make infinite animation by adding "++" to the file name
-   if (gROOT->IsBatch()) c1->Print("hsumanim.gif++");
-
-   // you can view the animated file hsumanim.gif with a web browser
 
    gBenchmark->Show("hsum");
 }

--- a/tutorials/tree/parallelcoordtrans.C
+++ b/tutorials/tree/parallelcoordtrans.C
@@ -49,10 +49,10 @@ void parallelcoordtrans() {
    Double_t s3x, s3y, s3z;
    r = new TRandom();;
 
-   TCanvas *c1 = new TCanvas("c1", "c1",0,0,900,1000);
+   auto c1 = new TCanvas("c1", "c1",0,0,900,1000);
    c1->Divide(1,2);
 
-   TNtuple *nt = new TNtuple("nt","Demo ntuple","x:y:z:u:v:w:a:b:c");
+   auto nt = new TNtuple("nt","Demo ntuple","x:y:z:u:v:w:a:b:c");
 
    int n=0;
    for (Int_t i=0; i<1500; i++) {
@@ -129,7 +129,6 @@ void parallelcoordtrans() {
    c1->Print("parallelcoordtrans.svg");
 
    // Produce transparent lines in batch mode only
-   c1->Print("parallelcoordtrans.gif");
    c1->Print("parallelcoordtrans.jpg");
    c1->Print("parallelcoordtrans.png");
 }


### PR DESCRIPTION
- Do not use gif output in tutorials. On machine where gif is not available is generated error when build the doxygen manual .
- use `auto`
