### PR TITLE
[DF] Change the signature of RInterface::Describe (Fix #8893)

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -12,6 +12,7 @@ if(dataframe)
     list(APPEND PYROOT_EXTRA_PYSOURCE
         ROOT/_pythonization/_rdf_utils.py
         ROOT/_pythonization/_rdataframe.py
+        ROOT/_pythonization/_rdfdescription.py
         ROOT/_pythonization/_rtensor.py)
     list(APPEND PYROOT_EXTRA_SOURCE
         src/RDataFramePyz.cxx

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdfdescription.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdfdescription.py
@@ -1,0 +1,19 @@
+# Author: Ivan Kabadzhov, Vincenzo Eduardo Padulano CERN  01/2022
+
+################################################################################
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+from . import pythonization
+
+@pythonization("RDFDescription", ns="ROOT::RDF")
+def pythonize_rdfdescription(klass):
+    """
+    Parameters:
+    klass: class to be pythonized
+    """
+    klass.__repr__ = klass.AsString

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -108,6 +108,11 @@ if (dataframe)
     endif()
 endif()
 
+# RDFDescription pythonization
+if (dataframe)
+    ROOT_ADD_PYUNITTEST(pyroot_rdfdescription rdfdescription.py)
+endif()
+
 # RTensor pythonizations
 if (dataframe AND tmva)
     ROOT_ADD_PYUNITTEST(pyroot_pyz_rtensor rtensor.py PYTHON_DEPS numpy)

--- a/bindings/pyroot/pythonizations/test/rdfdescription.py
+++ b/bindings/pyroot/pythonizations/test/rdfdescription.py
@@ -1,0 +1,17 @@
+import unittest
+import ROOT
+
+class RDFDescriptionTest(unittest.TestCase):
+    """
+    Testing of RDFDescription pythonization
+    """
+    def test_repr(self):
+        """
+        Test supported __repr__
+        """
+        df1 = ROOT.RDataFrame(1);
+        self.assertEqual(df1.Describe().__repr__(), df1.Describe().AsString());
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -77,6 +77,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RTreeColumnReader.hxx
     ROOT/RDF/Utils.hxx
     ROOT/RDF/PyROOTHelpers.hxx
+    ROOT/RDF/RDFDescription.hxx
     ${RDATAFRAME_EXTRA_HEADERS}
   SOURCES
     src/RActionBase.cxx
@@ -101,6 +102,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RRootDS.cxx
     src/RSlotStack.cxx
     src/RTrivialDS.cxx
+    src/RDFDescription.cxx
   DICTIONARY_OPTIONS
     -writeEmptyRootPCM
     ${RDATAFRAME_EXTRA_INCLUDES}

--- a/tree/dataframe/inc/ROOT/RDF/RDFDescription.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDFDescription.hxx
@@ -1,0 +1,50 @@
+// Author: Ivan Kabadzhov, Enrico Guiraud CERN  01/2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDFDescription
+#define ROOT_RDFDescription
+
+#include <string>
+
+namespace ROOT {
+namespace RDF {
+
+/**
+\class ROOT::RDF::RDFDescription
+\ingroup dataframe
+\brief A DFDescription contains useful information about a given RDataFrame computation graph.
+
+ A DFDescription is returned by the Describe() RDataFrame method.
+ Each DFDescription object can output either a brief or full description.
+*/
+class RDFDescription {
+
+   std::string fBriefDescription;
+   std::string fFullDescription;
+
+public:
+   RDFDescription(const std::string &briefDescription, const std::string &fullDescription);
+
+   std::string AsString(bool shortFormat = false) const;
+
+   void Print(bool shortFormat = false) const;
+
+   friend std::ostream &operator<<(std::ostream &os, const RDFDescription &description);
+};
+
+} // namespace RDF
+} // namespace ROOT
+
+/// Print an RDFDescription at the prompt
+namespace cling {
+std::string printValue(ROOT::RDF::RDFDescription *td);
+} // namespace cling
+
+#endif

--- a/tree/dataframe/src/RDFDescription.cxx
+++ b/tree/dataframe/src/RDFDescription.cxx
@@ -1,0 +1,50 @@
+// Author: Ivan Kabadzhov, Enrico Guiraud CERN  01/2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RDF/RDFDescription.hxx"
+#include <iostream>
+
+namespace ROOT {
+namespace RDF {
+
+RDFDescription::RDFDescription(const std::string &briefDescription, const std::string &fullDescription)
+   : fBriefDescription(briefDescription), fFullDescription(fullDescription){};
+
+std::string RDFDescription::AsString(bool shortFormat /*= false*/) const
+{
+   if (shortFormat)
+      return fBriefDescription;
+   else
+      return fBriefDescription + "\n\n" + fFullDescription;
+}
+
+void RDFDescription::Print(bool shortFormat /*= false*/) const
+{
+   std::cout << AsString(shortFormat);
+}
+
+std::ostream &operator<<(std::ostream &os, const RDFDescription &description)
+{
+   os << description.AsString();
+   return os;
+}
+
+} // namespace RDF
+} // namespace ROOT
+
+namespace cling {
+//////////////////////////////////////////////////////////////////////////
+/// Print an RDFDescription at the prompt
+std::string printValue(ROOT::RDF::RDFDescription *td)
+{
+   return td->AsString();
+}
+
+} // namespace cling

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -619,7 +619,18 @@ TEST(RDataFrameInterface, Describe)
                      "\n"
                      "Column  Type    Origin\n"
                      "------  ----    ------\n";
-   EXPECT_EQ(df1.Describe(), ref1);
+   EXPECT_EQ(df1.Describe().AsString(), ref1);
+
+   // Testing the std output printing
+   std::cout << std::flush;
+   // Redirect cout.
+   std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
+   std::ostringstream strCout;
+   std::cout.rdbuf(strCout.rdbuf());
+   std::cout << df1.Describe();
+   // Restore old cout.
+   std::cout.rdbuf(oldCoutStreamBuf);
+   EXPECT_EQ(strCout.str(), ref1);
 
    // create in-memory tree
    TTree tree("tree", "tree");
@@ -649,7 +660,7 @@ TEST(RDataFrameInterface, Describe)
                      "myLongColumnName        unsigned int                    Define\n"
                      "myInt                   Int_t                           Dataset\n"
                      "myFloat                 Float_t                         Dataset";
-   EXPECT_EQ(df3.Describe(), ref2);
+   EXPECT_EQ(df3.Describe().AsString(), ref2);
 }
 
 TEST(RDFSimpleTests, LeafWithDifferentNameThanBranch)
@@ -663,20 +674,31 @@ TEST(RDFSimpleTests, LeafWithDifferentNameThanBranch)
    EXPECT_EQ(*m, 42);
 }
 
-TEST(RDataFrameInterface, DescribeDataset)
+TEST(RDataFrameInterface, DescribeShortFormat)
 {
    // trivial/empty datasource
    ROOT::RDataFrame df1a(1);
-   EXPECT_EQ(df1a.DescribeDataset(), "Empty dataframe filling 1 row");
+   EXPECT_EQ(df1a.Describe().AsString(/*shortFormat =*/true), "Empty dataframe filling 1 row");
+
+   // Testing the std output printing
+   std::cout << std::flush;
+   // Redirect cout.
+   std::streambuf *oldCoutStreamBuf = std::cout.rdbuf();
+   std::ostringstream strCout;
+   std::cout.rdbuf(strCout.rdbuf());
+   df1a.Describe().Print(/*shortFormat =*/true);
+   // Restore old cout.
+   std::cout.rdbuf(oldCoutStreamBuf);
+   EXPECT_EQ(strCout.str(), "Empty dataframe filling 1 row");
 
    ROOT::RDataFrame df1b(2);
-   EXPECT_EQ(df1b.DescribeDataset(), "Empty dataframe filling 2 rows");
+   EXPECT_EQ(df1b.Describe().AsString(/*shortFormat =*/true), "Empty dataframe filling 2 rows");
 
    // ttree/tchain
    // case: in-memory tree
    TTree tree("someName", "someTitle");
    ROOT::RDataFrame df2a(tree);
-   EXPECT_EQ(df2a.DescribeDataset(), "Dataframe from TTree someName (in-memory)");
+   EXPECT_EQ(df2a.Describe().AsString(/*shortFormat =*/true), "Dataframe from TTree someName (in-memory)");
 
    // case: ctor from a single file
    // NOTE: using the RDataFrame("tree", "file.root") ctor, it's always a TChain
@@ -687,7 +709,7 @@ TEST(RDataFrameInterface, DescribeDataset)
    ROOT::RDataFrame df2b("myTree", "testDescribeDataset1.root");
    std::stringstream ss1;
    ss1 << "Dataframe from TChain myTree in file testDescribeDataset1.root";
-   EXPECT_EQ(df2b.DescribeDataset(), ss1.str());
+   EXPECT_EQ(df2b.Describe().AsString(/*shortFormat =*/true), ss1.str());
 
    // case: ctor with multiple files
    TFile f2("testDescribeDataset2.root", "recreate");
@@ -699,7 +721,7 @@ TEST(RDataFrameInterface, DescribeDataset)
    ss2 << "Dataframe from TChain myTree in files\n"
        << "  testDescribeDataset1.root\n"
        << "  testDescribeDataset2.root";
-   EXPECT_EQ(df2d.DescribeDataset(), ss2.str());
+   EXPECT_EQ(df2d.Describe().AsString(/*shortFormat =*/true), ss2.str());
 
    // case: ttree/tchain with friends
    TFile f3("testDescribeDataset3.root", "recreate");
@@ -727,13 +749,13 @@ TEST(RDataFrameInterface, DescribeDataset)
        << "  myTree (myAlias2)\n"
        << "    myTree testDescribeDataset2.root\n"
        << "    myTree testDescribeDataset3.root";
-   EXPECT_EQ(df2e.DescribeDataset(), ss3.str());
+   EXPECT_EQ(df2e.Describe().AsString(/*shortFormat =*/true), ss3.str());
    f3.Close();
    f4.Close();
 
    // others with an actual fDataSource, like csv
    auto df3 = ROOT::RDF::MakeCsvDataFrame("RCsvDS_test_headers.csv");
-   EXPECT_EQ(df3.DescribeDataset(), "Dataframe from datasource RCsv");
+   EXPECT_EQ(df3.Describe().AsString(/*shortFormat =*/true), "Dataframe from datasource RCsv");
 }
 
 // #var is a convenience alias for R_rdf_sizeof_var.

--- a/tutorials/dataframe/df033_Describe.py
+++ b/tutorials/dataframe/df033_Describe.py
@@ -17,7 +17,8 @@ df = ROOT.RDataFrame('Events', path)
 
 # Describe the state of the dataframe.
 # Note that this operation is not running the event loop.
-print(df.Describe())
+# Describe returns a DFDescription object, which has e.g. a Print method. See its docs for more information.
+df.Describe().Print()
 
 # Build a small analysis studying the invariant mass of dimuon systems.
 # See tutorial df102_NanoAODDimuonAnalysis for more information.
@@ -31,5 +32,5 @@ df = df.Filter('nMuon == 2')\
 print('\nApproximate mass of the Z boson: {:.2f} GeV\n'.format(
     df.Mean('Dimuon_mass').GetValue()))
 
-# Describe again the state of the dataframe.
-print(df.Describe())
+# This time we ask for the `shortFormat`, which only prints a brief description of the dataset:
+df.Describe().Print(shortFormat=True)


### PR DESCRIPTION
A new class DFDescription is introduced.
It has 2 member strings, corresponding to the brief and the full description.
It allows more interactive output of these strings.

RInterface::Describe now returns a DFDescription object.
As brief description is the output from RInterface::DescribeDataset.
As full description is the remaining code from RInterface::Describe.
Moreover, RInterface::DescribeDataset is now a private method.

RDFDescription has the following methods:
* AsString(bool) -> returning brief/full description as a string
* Print(bool) -> printing the content of AsString(bool)
* overloaded<< -> returns ostream corresponding to AsString(shortFormat=false)
* printValue -> returns string corresponding to AsString(shortFomat=false)
* __repr__ pythonization -> assigning __repr__ to AsString(shortFormat=false)

Tests and Tutorials were adapted correspondingly.

This PR fixes #8893

