### PR TITLE
Fix adding isotopes for default elements

### DIFF
--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -1126,15 +1126,12 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       // We cannot use elements with Z = 0, so we expect a user definition
       if (ele && ele->Z() == 0)
          ele = nullptr;
-      if (!ele) {
+      if (!ele)
          ele = new TGeoElement(NameShort(name), NameShort(name), ncompo);
-         for (fractions f = fracmap.begin(); f != fracmap.end(); ++f) {
-            if (fisomap.find(f->first) != fisomap.end()) {
-               ele->AddIsotope((TGeoIsotope *)fisomap[f->first], f->second);
-            }
+      for (fractions f = fracmap.begin(); f != fracmap.end(); ++f) {
+         if (fisomap.find(f->first) != fisomap.end()) {
+            ele->AddIsotope((TGeoIsotope *)fisomap[f->first], f->second);
          }
-      } else if (gDebug >= 2) {
-         Info("TGDMLParse", "Re-use existing element: %s", ele->GetName());
       }
       felemap[name.Data()] = ele;
       return child;
@@ -1189,15 +1186,12 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       // We cannot use elements with Z = 0, so we expect a user definition
       if (ele && ele->Z() == 0)
          ele = nullptr;
-      if (!ele) {
+      if (!ele)
          ele = new TGeoElement(NameShort(name), NameShort(name), ncompo);
-         for (fractions f = fracmap.begin(); f != fracmap.end(); ++f) {
-            if (fisomap.find(f->first) != fisomap.end()) {
-               ele->AddIsotope((TGeoIsotope *)fisomap[f->first], f->second);
-            }
+      for (fractions f = fracmap.begin(); f != fracmap.end(); ++f) {
+         if (fisomap.find(f->first) != fisomap.end()) {
+            ele->AddIsotope((TGeoIsotope *)fisomap[f->first], f->second);
          }
-      } else if (gDebug >= 2) {
-         Info("TGDMLParse", "Re-use existing element: %s", ele->GetName());
       }
       felemap[name.Data()] = ele;
       return child;

--- a/geom/geom/src/TGeoElement.cxx
+++ b/geom/geom/src/TGeoElement.cxx
@@ -251,16 +251,21 @@ TGeoElementTable *TGeoElement::GetElementTable()
 void TGeoElement::AddIsotope(TGeoIsotope *isotope, Double_t relativeAbundance)
 {
    if (!fIsotopes) {
-      Fatal("AddIsotope", "Cannot add isotopes to normal elements. Use constructor with number of isotopes.");
-      return;
+      fNisotopes = 1;
+      fIsotopes = new TObjArray();
+      fAbundances = new Double_t[1];
    }
    Int_t ncurrent = 0;
    TGeoIsotope *isocrt;
    for (ncurrent=0; ncurrent<fNisotopes; ncurrent++)
       if (!fIsotopes->At(ncurrent)) break;
    if (ncurrent==fNisotopes) {
-      Error("AddIsotope", "All %d isotopes of element %s already defined", fNisotopes, GetName());
-      return;
+      // User requested overwriting a standard element - we need to extend dynamically the support arrays
+      Double_t *abundances = new Double_t[fNisotopes + 1];
+      memcpy(abundances, fAbundances, fNisotopes * sizeof(Double_t));
+      delete[] fAbundances;
+      fAbundances = abundances;
+      fNisotopes++;
    }
    // Check Z of the new isotope
    if ((fZ!=0) && (isotope->GetZ()!=fZ)) {


### PR DESCRIPTION
# This Pull request:
When the GDML file contains definitions of elements with isotopes and the element name matches one of the predefined standard elements, the pre-defined element is overwritten rather than being reused, since this is the expected behaviour.
## Changes or fixes:
Added support for modifying a pre-defined element (adding isotopes).


## Checklist:

- [x ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #9421  

