### PR TITLE
Cc tgraph refactor

### DIFF
--- a/graf2d/graf/src/TCutG.cxx
+++ b/graf2d/graf/src/TCutG.cxx
@@ -274,7 +274,7 @@ Double_t TCutG::Area() const
    Double_t a = 0;
    Int_t n = GetN();
    for (Int_t i=0;i<n-1;i++) {
-      a += (fX[i]-fX[i+1])*(fY[i]+fY[i+1]);
+      a += (fX->at(i)-fX->at(i+1))*(fY[i]+fY[i+1]);
    }
    a *= 0.5;
    return a;
@@ -293,10 +293,10 @@ void TCutG::Center(Double_t &cx, Double_t &cy) const
    cx = cy = 0;
    Double_t t;
    for (Int_t i=0;i<n-1;i++) {
-      t   = 2*fX[i]*fY[i] + fY[i]*fX[i+1] + fX[i]*fY[i+1] + 2*fX[i+1]*fY[i+1];
-      cx += (fX[i]-fX[i+1])*t;
+      t   = 2*fX->at(i)*fY[i] + fY[i]*fX->at(i+1) + fX->at(i)*fY[i+1] + 2*fX->at(i+1)*fY[i+1];
+      cx += (fX->at(i)-fX->at(i+1))*t;
       cy += (-fY[i]+fY[i+1])*t;
-      a  += (fX[i]-fX[i+1])*(fY[i]+fY[i+1]);
+      a  += (fX->at(i)-fX->at(i+1))*(fY[i]+fY[i+1]);
    }
    a  *= 0.5;
    cx *= 1./(6*a);
@@ -317,8 +317,8 @@ Double_t TCutG::IntegralHist(TH2 *h, Option_t *option) const
    Double_t ymin = xmin;
    Double_t ymax = xmax;
    for (Int_t i=0;i<n;i++) {
-      if (fX[i] < xmin) xmin = fX[i];
-      if (fX[i] > xmax) xmax = fX[i];
+      if (fX->at(i) < xmin) xmin = fX->at(i);
+      if (fX->at(i) > xmax) xmax = fX->at(i);
       if (fY[i] < ymin) ymin = fY[i];
       if (fY[i] > ymax) ymax = fY[i];
    }
@@ -372,7 +372,7 @@ void TCutG::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    SaveMarkerAttributes(out,"cutg",1,1,1);
 
    for (Int_t i=0;i<fNpoints;i++) {
-      out<<"   cutg->SetPoint("<<i<<","<<fX[i]<<","<<fY[i]<<");"<<std::endl;
+      out<<"   cutg->SetPoint("<<i<<","<<fX->at(i)<<","<<fY[i]<<");"<<std::endl;
    }
    out<<"   cutg->Draw("
       <<quote<<option<<quote<<");"<<std::endl;

--- a/graf2d/graf/src/TCutG.cxx
+++ b/graf2d/graf/src/TCutG.cxx
@@ -274,7 +274,7 @@ Double_t TCutG::Area() const
    Double_t a = 0;
    Int_t n = GetN();
    for (Int_t i=0;i<n-1;i++) {
-      a += (fX->at(i)-fX->at(i+1))*(fY[i]+fY[i+1]);
+      a += (fX->at(i)-fX->at(i+1))*(fY->at(i)+fY->at(i+1));
    }
    a *= 0.5;
    return a;
@@ -293,10 +293,10 @@ void TCutG::Center(Double_t &cx, Double_t &cy) const
    cx = cy = 0;
    Double_t t;
    for (Int_t i=0;i<n-1;i++) {
-      t   = 2*fX->at(i)*fY[i] + fY[i]*fX->at(i+1) + fX->at(i)*fY[i+1] + 2*fX->at(i+1)*fY[i+1];
+      t   = 2*fX->at(i)*fY->at(i) + fY->at(i)*fX->at(i+1) + fX->at(i)*fY->at(i+1) + 2*fX->at(i+1)*fY->at(i+1);
       cx += (fX->at(i)-fX->at(i+1))*t;
-      cy += (-fY[i]+fY[i+1])*t;
-      a  += (fX->at(i)-fX->at(i+1))*(fY[i]+fY[i+1]);
+      cy += (-fY->at(i)+fY->at(i+1))*t;
+      a  += (fX->at(i)-fX->at(i+1))*(fY->at(i)+fY->at(i+1));
    }
    a  *= 0.5;
    cx *= 1./(6*a);
@@ -319,8 +319,8 @@ Double_t TCutG::IntegralHist(TH2 *h, Option_t *option) const
    for (Int_t i=0;i<n;i++) {
       if (fX->at(i) < xmin) xmin = fX->at(i);
       if (fX->at(i) > xmax) xmax = fX->at(i);
-      if (fY[i] < ymin) ymin = fY[i];
-      if (fY[i] > ymax) ymax = fY[i];
+      if (fY->at(i) < ymin) ymin = fY->at(i);
+      if (fY->at(i) > ymax) ymax = fY->at(i);
    }
    TAxis *xaxis = h->GetXaxis();
    TAxis *yaxis = h->GetYaxis();
@@ -372,7 +372,7 @@ void TCutG::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    SaveMarkerAttributes(out,"cutg",1,1,1);
 
    for (Int_t i=0;i<fNpoints;i++) {
-      out<<"   cutg->SetPoint("<<i<<","<<fX->at(i)<<","<<fY[i]<<");"<<std::endl;
+      out<<"   cutg->SetPoint("<<i<<","<<fX->at(i)<<","<<fY->at(i)<<");"<<std::endl;
    }
    out<<"   cutg->Draw("
       <<quote<<option<<quote<<");"<<std::endl;

--- a/graf2d/graf/src/TGraphQQ.cxx
+++ b/graf2d/graf/src/TGraphQQ.cxx
@@ -167,7 +167,7 @@ TGraphQQ::TGraphQQ(Int_t nx, Double_t *x, Int_t ny, Double_t *y)
       TMath::Sort(ny, y, index, kFALSE);
       if (nx==ny){
          for (Int_t i=0; i<fNpoints; i++)
-            fX[i] = y[index[i]];
+            fX->at(i) = y[index[i]];
          fY0 = 0;
          Quartiles();
       } else {
@@ -215,7 +215,7 @@ void TGraphQQ::MakeFunctionQuantiles()
       //use plotting positions optimal for normal distribution
       for (Int_t k=1; k<=fNpoints; k++){
          pk = (k-0.375)/(fNpoints+0.25);
-         fX[k-1]=TMath::NormQuantile(pk);
+         fX->at(k-1)=TMath::NormQuantile(pk);
       }
    } else {
       Double_t *prob = new Double_t[fNpoints];
@@ -227,7 +227,7 @@ void TGraphQQ::MakeFunctionQuantiles()
             prob[k-1] = (k-0.375)/(fNpoints+0.25);
       }
       //fF->GetQuantiles(fNpoints, prob, fX);
-      fF->GetQuantiles(fNpoints, fX, prob);
+      fF->GetQuantiles(fNpoints, &fX->at(0), prob);
       delete [] prob;
    }
 
@@ -250,9 +250,9 @@ void TGraphQQ::MakeQuantiles()
       pi = (fNy0-1)*Double_t(i)/Double_t(fNpoints-1);
       pint = TMath::FloorNint(pi);
       pfrac = pi - pint;
-      fX[i] = (1-pfrac)*fY0[pint]+pfrac*fY0[pint+1];
+      fX->at(i) = (1-pfrac)*fY0[pint]+pfrac*fY0[pint+1];
    }
-   fX[fNpoints-1]=fY0[fNy0-1];
+   fX->at(fNpoints-1)=fY0[fNy0-1];
 
    Quartiles();
 }
@@ -278,7 +278,7 @@ void TGraphQQ::Quartiles()
          fF->GetQuantiles(2, x, prob);
    }
    else
-      TMath::Quantiles(fNpoints, 2, fX, x, prob, kTRUE);
+      TMath::Quantiles(fNpoints, 2, &fX->at(0), x, prob, kTRUE);
 
    fXq1=x[0]; fXq2=x[1]; fYq1=y[0]; fYq2=y[1];
 }

--- a/graf2d/graf/src/TGraphQQ.cxx
+++ b/graf2d/graf/src/TGraphQQ.cxx
@@ -117,7 +117,7 @@ TGraphQQ::TGraphQQ(Int_t n, Double_t *x)
    Int_t *index = new Int_t[n];
    TMath::Sort(n, x, index, kFALSE);
    for (Int_t i=0; i<fNpoints; i++)
-      fY[i] = x[index[i]];
+      fY->at(i) = x[index[i]];
    fF=0;
    fY0=0;
    delete [] index;
@@ -134,7 +134,7 @@ TGraphQQ::TGraphQQ(Int_t n, Double_t *x, TF1 *f)
    Int_t *index = new Int_t[n];
    TMath::Sort(n, x, index, kFALSE);
    for (Int_t i=0; i<fNpoints; i++)
-      fY[i] = x[index[i]];
+      fY->at(i) = x[index[i]];
    delete [] index;
    fF = f;
    fY0=0;
@@ -163,7 +163,7 @@ TGraphQQ::TGraphQQ(Int_t nx, Double_t *x, Int_t ny, Double_t *y)
    TMath::Sort(nx, x, index, kFALSE);
    if (nx <=ny){
       for (Int_t i=0; i<fNpoints; i++)
-         fY[i] = x[index[i]];
+         fY->at(i) = x[index[i]];
       TMath::Sort(ny, y, index, kFALSE);
       if (nx==ny){
          for (Int_t i=0; i<fNpoints; i++)
@@ -184,7 +184,7 @@ TGraphQQ::TGraphQQ(Int_t nx, Double_t *x, Int_t ny, Double_t *y)
          fY0[i] = x[index[i]];
       TMath::Sort(ny, y, index, kFALSE);
       for (Int_t i=0; i<ny; i++)
-         fY[i] = y[index[i]];
+         fY->at(i) = y[index[i]];
       MakeQuantiles();
    }
 
@@ -266,7 +266,7 @@ void TGraphQQ::Quartiles()
    Double_t prob[]={0.25, 0.75};
    Double_t x[2];
    Double_t y[2];
-   TMath::Quantiles(fNpoints, 2, fY, y, prob, kTRUE);
+   TMath::Quantiles(fNpoints, 2, &fY->at(0), y, prob, kTRUE);
    if (fY0)
       TMath::Quantiles(fNy0, 2, fY0, x, prob, kTRUE);
    else if (fF) {

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -47,7 +47,7 @@ protected:
    Int_t              fMaxSize;   ///<!Current dimension of arrays fX and fY
    Int_t              fNpoints;   ///< Number of points <= fMaxSize
    std::shared_ptr<std::vector<Double_t>>          fX;         ///<[fNpoints] array of X points
-   Double_t          *fY;         ///<[fNpoints] array of Y points
+   std::shared_ptr<std::vector<Double_t>>          fY;         ///<[fNpoints] array of Y points
    TList             *fFunctions; ///< Pointer to list of functions (fits and user)
    TH1F              *fHistogram; ///< Pointer to histogram used for drawing axis
    Double_t           fMinimum;   ///< Minimum value for plotting along y
@@ -131,7 +131,7 @@ public:
    virtual Double_t      GetErrorYhigh(Int_t bin) const;
    virtual Double_t      GetErrorYlow(Int_t bin)  const;
    Double_t             *GetX()  const {return fX->data();}
-   Double_t             *GetY()  const {return fY;}
+   Double_t             *GetY()  const {return fY->data();}
    virtual Double_t     *GetEX() const {return nullptr;}
    virtual Double_t     *GetEY() const {return nullptr;}
    virtual Double_t     *GetEXhigh() const {return nullptr;}

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -29,6 +29,8 @@
 #include "TVectorDfwd.h"
 #include "TFitResultPtr.h"
 
+#include <memory>
+
 class TBrowser;
 class TAxis;
 class TH1;
@@ -44,7 +46,7 @@ protected:
 
    Int_t              fMaxSize;   ///<!Current dimension of arrays fX and fY
    Int_t              fNpoints;   ///< Number of points <= fMaxSize
-   Double_t          *fX;         ///<[fNpoints] array of X points
+   std::shared_ptr<std::vector<Double_t>>          fX;         ///<[fNpoints] array of X points
    Double_t          *fY;         ///<[fNpoints] array of Y points
    TList             *fFunctions; ///< Pointer to list of functions (fits and user)
    TH1F              *fHistogram; ///< Pointer to histogram used for drawing axis
@@ -128,7 +130,7 @@ public:
    virtual Double_t      GetErrorXlow(Int_t bin)  const;
    virtual Double_t      GetErrorYhigh(Int_t bin) const;
    virtual Double_t      GetErrorYlow(Int_t bin)  const;
-   Double_t             *GetX()  const {return fX;}
+   Double_t             *GetX()  const {return fX->data();}
    Double_t             *GetY()  const {return fY;}
    virtual Double_t     *GetEX() const {return nullptr;}
    virtual Double_t     *GetEY() const {return nullptr;}

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -116,7 +116,7 @@ TGraph::TGraph(Int_t n, const Int_t *x, const Int_t *y)
    if (!CtorAllocate()) return;
    for (Int_t i = 0; i < n; i++) {
       fX->at(i) = (Double_t)x[i];
-      fY[i] = (Double_t)y[i];
+      fY->at(i) = (Double_t)y[i];
    }
 }
 
@@ -134,7 +134,7 @@ TGraph::TGraph(Int_t n, const Float_t *x, const Float_t *y)
    if (!CtorAllocate()) return;
    for (Int_t i = 0; i < n; i++) {
       fX->at(i) = x[i];
-      fY[i] = y[i];
+      fY->at(i) = y[i];
    }
 }
 
@@ -152,7 +152,7 @@ TGraph::TGraph(Int_t n, const Double_t *x, const Double_t *y)
    if (!CtorAllocate()) return;
    n = fNpoints * sizeof(Double_t);
    //memcpy(fX, x, n);
-   memcpy(fY, y, n);
+   //memcpy(fY, y, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -178,12 +178,12 @@ TGraph::TGraph(const TGraph &gr)
       return;
    } else {
       //fX = new Double_t[fMaxSize];
-      fY = new Double_t[fMaxSize];
+      //fY = new Double_t[fMaxSize];
    }
 
    Int_t n = gr.GetN() * sizeof(Double_t);
    //memcpy(fX, gr.fX, n);
-   memcpy(fY, gr.fY, n);
+   //memcpy(fY, gr.fY, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -230,19 +230,19 @@ TGraph& TGraph::operator=(const TGraph &gr)
       fMinimum = gr.fMinimum;
       fMaximum = gr.fMaximum;
       //if (fX) delete [] fX;
-      if (fY) delete [] fY;
+      //if (fY) delete [] fY;
       if (!fMaxSize) {
          //fX = fY = nullptr;
          return *this;
       } else {
          //fX = new Double_t[fMaxSize];
-         fY = new Double_t[fMaxSize];
+         //fY = new Double_t[fMaxSize];
       }
 
       Int_t n = gr.GetN() * sizeof(Double_t);
       if (n > 0) {
          //memcpy(fX, gr.fX, n);
-         memcpy(fY, gr.fY, n);
+         //memcpy(fY, gr.fY, n);
       }
    }
    return *this;
@@ -263,7 +263,7 @@ TGraph::TGraph(const TVectorF &vx, const TVectorF &vy)
    Int_t ivylow  = vy.GetLwb();
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i)  = vx(i + ivxlow);
-      fY[i]  = vy(i + ivylow);
+      fY->at(i)  = vy(i + ivylow);
    }
 }
 
@@ -282,7 +282,7 @@ TGraph::TGraph(const TVectorD &vx, const TVectorD &vy)
    Int_t ivylow  = vy.GetLwb();
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i)  = vx(i + ivxlow);
-      fY[i]  = vy(i + ivylow);
+      fY->at(i)  = vy(i + ivylow);
    }
 }
 
@@ -309,7 +309,7 @@ TGraph::TGraph(const TH1 *h)
    TAxis *xaxis = ((TH1*)h)->GetXaxis();
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i) = xaxis->GetBinCenter(i + 1);
-      fY[i] = h->GetBinContent(i + 1);
+      fY->at(i) = h->GetBinContent(i + 1);
    }
    h->TAttLine::Copy(*this);
    h->TAttFill::Copy(*this);
@@ -353,19 +353,19 @@ TGraph::TGraph(const TF1 *f, Option_t *option)
    for (i = 0; i < fNpoints; i++) {
       if (coption == 'i' || coption == 'I') {
          fX->at(i) = xmin + i * dx;
-         if (i == 0) fY[i] = 0;
-         else        fY[i] = integ + ((TF1*)f)->Integral(fX->at(i) - dx, fX->at(i));
-         integ = fY[i];
+         if (i == 0) fY->at(i) = 0;
+         else        fY->at(i) = integ + ((TF1*)f)->Integral(fX->at(i) - dx, fX->at(i));
+         integ = fY->at(i);
       } else if (coption == 'd' || coption == 'D') {
          fX->at(i) = xmin + (i + 0.5) * dx;
-         fY[i] = ((TF1*)f)->Derivative(fX->at(i));
+         fY->at(i) = ((TF1*)f)->Derivative(fX->at(i));
       } else {
          fX->at(i) = xmin + (i + 0.5) * dx;
-         fY[i] = ((TF1*)f)->Eval(fX->at(i));
+         fY->at(i) = ((TF1*)f)->Eval(fX->at(i));
       }
    }
    if (integ != 0 && coption == 'I') {
-      for (i = 1; i < fNpoints; i++) fY[i] /= integ;
+      for (i = 1; i < fNpoints; i++) fY->at(i) /= integ;
    }
 
    f->TAttLine::Copy(*this);
@@ -521,7 +521,7 @@ TGraph::TGraph(const char *filename, const char *format, Option_t *option)
 TGraph::~TGraph()
 {
    //delete [] fX;
-   delete [] fY;
+   //delete [] fY;
    if (fFunctions) {
       fFunctions->SetBit(kInvalidObject);
       //special logic to support the case where the same object is
@@ -578,7 +578,7 @@ void TGraph::Apply(TF1 *f)
    if (fHistogram) SetBit(kResetHisto);
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      fY[i] = f->Eval(fX->at(i), fY[i]);
+      fY->at(i) = f->Eval(fX->at(i), fY->at(i));
    }
    if (gPad) gPad->Modified();
 }
@@ -646,11 +646,11 @@ Bool_t TGraph::CompareX(const TGraph* gr, Int_t left, Int_t right)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if fY[left] > fY[right]. Can be used by Sort.
+/// Return kTRUE if fY->at(left) > fY->at(right). Can be used by Sort.
 
 Bool_t TGraph::CompareY(const TGraph* gr, Int_t left, Int_t right)
 {
-   return gr->fY[left] > gr->fY[right];
+   return gr->fY->at(left) > gr->fY->at(right);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -659,8 +659,8 @@ Bool_t TGraph::CompareY(const TGraph* gr, Int_t left, Int_t right)
 
 Bool_t TGraph::CompareRadius(const TGraph* gr, Int_t left, Int_t right)
 {
-   return gr->fX->at(left) * gr->fX->at(left) + gr->fY[left] * gr->fY[left]
-          > gr->fX->at(right) * gr->fX->at(right) + gr->fY[right] * gr->fY[right];
+   return gr->fX->at(left) * gr->fX->at(left) + gr->fY->at(left) * gr->fY->at(left)
+          > gr->fX->at(right) * gr->fX->at(right) + gr->fY->at(right) * gr->fY->at(right);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -673,7 +673,7 @@ void TGraph::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double
       return;
    }
    xmin = xmax = fX->at(0);
-   ymin = ymax = fY[0];
+   ymin = ymax = fY->at(0);
 
    Double_t xminl = 0; // Positive minimum. Used in case of log scale along X axis.
    Double_t yminl = 0; // Positive minimum. Used in case of log scale along Y axis.
@@ -681,8 +681,8 @@ void TGraph::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double
    for (Int_t i = 1; i < fNpoints; i++) {
       if (fX->at(i) < xmin) xmin = fX->at(i);
       if (fX->at(i) > xmax) xmax = fX->at(i);
-      if (fY[i] < ymin) ymin = fY[i];
-      if (fY[i] > ymax) ymax = fY[i];
+      if (fY->at(i) < ymin) ymin = fY->at(i);
+      if (fY->at(i) > ymax) ymax = fY->at(i);
       if (ymin>0 && (yminl==0 || ymin<yminl)) yminl = ymin;
       if (xmin>0 && (xminl==0 || xmin<xminl)) xminl = xmin;
    }
@@ -704,8 +704,8 @@ void TGraph::CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t iend,
    if (newarrays) {
       //delete[] fX;
       //fX = newarrays[0];
-      delete[] fY;
-      fY = newarrays[1];
+      //delete[] fY;
+      //fY = newarrays[1];
       delete[] newarrays;
    }
 }
@@ -726,10 +726,10 @@ Bool_t TGraph::CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
    Int_t n = (iend - ibegin) * sizeof(Double_t);
    if (arrays) {
       memmove(&arrays[0][obegin], &fX->at(ibegin), n);
-      memmove(&arrays[1][obegin], &fY[ibegin], n);
+      memmove(&arrays[1][obegin], &fY->at(ibegin), n);
    } else {
       memmove(&fX->at(obegin), &fX->at(ibegin), n);
-      memmove(&fY[obegin], &fY[ibegin], n);
+      memmove(&fY->at(obegin), &fY->at(ibegin), n);
    }
    return kTRUE;
 }
@@ -756,7 +756,7 @@ Bool_t TGraph::CtorAllocate()
    } else {
       fMaxSize   = fNpoints;
       //fX = new Double_t[fMaxSize];
-      fY = new Double_t[fMaxSize];
+      //fY = new Double_t[fMaxSize];
    }
    return kTRUE;
 }
@@ -851,7 +851,7 @@ void TGraph::DrawGraph(Int_t n, const Double_t *x, const Double_t *y, Option_t *
    const Double_t *xx = x;
    const Double_t *yy = y;
    if (!xx) xx = &fX->at(0);
-   if (!yy) yy = fY;
+   if (!yy) yy = &fY->at(0);
    TGraph *newgraph = new TGraph(n, xx, yy);
    TAttLine::Copy(*newgraph);
    TAttFill::Copy(*newgraph);
@@ -893,7 +893,7 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
    }
 
    if (fNpoints == 0) return 0;
-   if (fNpoints == 1) return fY[0];
+   if (fNpoints == 1) return fY->at(0);
 
    if (option && *option) {
       TString opt = option;
@@ -908,7 +908,7 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
          TMath::Sort(fNpoints, &fX->at(0), &indxsort[0], false);
          for (Int_t i = 0; i < fNpoints; ++i) {
             xsort[i] = fX->at( indxsort[i] );
-            ysort[i] = fY[ indxsort[i] ];
+            ysort[i] = fY->at( indxsort[i] );
          }
 
          // spline interpolation creating a new spline
@@ -930,7 +930,7 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
          // use first two points for doing an extrapolation
          low = 0;
       }
-      if (fX->at(low) == x) return fY[low];
+      if (fX->at(low) == x) return fY->at(low);
       if (low == fNpoints-1) low--; // for extrapolating
       up = low+1;
    }
@@ -955,7 +955,7 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
                up = i;
             } else if (up2 == -1) up2 = i;
          } else // case x == fX->at(i)
-            return fY[i]; // no interpolation needed
+            return fY->at(i); // no interpolation needed
       }
 
       // treat cases when x is outside graph min max abscissa
@@ -971,8 +971,8 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
    // do now the linear interpolation
    assert(low != -1 && up != -1);
 
-   if (fX->at(low) == fX->at(up)) return fY[low];
-   Double_t yn = fY[up] + (x - fX->at(up)) * (fY[low] - fY[up]) / (fX->at(low) - fX->at(up));
+   if (fX->at(low) == fX->at(up)) return fY->at(low);
+   Double_t yn = fY->at(up) + (x - fX->at(up)) * (fY->at(low) - fY->at(up)) / (fX->at(low) - fX->at(up));
    return yn;
 }
 
@@ -1037,7 +1037,7 @@ Double_t **TGraph::ExpandAndCopy(Int_t size, Int_t iend)
 void TGraph::FillZero(Int_t begin, Int_t end, Bool_t)
 {
    //memset(&fX->at(0) + begin, 0, (end - begin)*sizeof(Double_t));
-   memset(fY + begin, 0, (end - begin)*sizeof(Double_t));
+   //memset(&fY->at(0) + begin, 0, (end - begin)*sizeof(Double_t));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1369,8 +1369,8 @@ Double_t TGraph::GetCovariance() const
 
    for (Int_t i = 0; i < fNpoints; i++) {
       sumx  += fX->at(i);
-      sumy  += fY[i];
-      sumxy += fX->at(i) * fY[i];
+      sumy  += fY->at(i);
+      sumxy += fX->at(i) * fY->at(i);
    }
    return sumxy / sum - sumx / sum * sumy / sum;
 }
@@ -1385,7 +1385,7 @@ Double_t TGraph::GetMean(Int_t axis) const
    Double_t sumx = 0;
    for (Int_t i = 0; i < fNpoints; i++) {
       if (axis == 1) sumx += fX->at(i);
-      else           sumx += fY[i];
+      else           sumx += fY->at(i);
    }
    return sumx / fNpoints;
 }
@@ -1403,8 +1403,8 @@ Double_t TGraph::GetRMS(Int_t axis) const
          sumx += fX->at(i);
          sumx2 += fX->at(i) * fX->at(i);
       } else           {
-         sumx += fY[i];
-         sumx2 += fY[i] * fY[i];
+         sumx += fY->at(i);
+         sumx2 += fY->at(i) * fY->at(i);
       }
    }
    Double_t x = sumx / fNpoints;
@@ -1608,7 +1608,7 @@ Int_t TGraph::GetPoint(Int_t i, Double_t &x, Double_t &y) const
 {
    if (i < 0 || i >= fNpoints || !fX || !fY) return -1;
    x = fX->at(i);
-   y = fY[i];
+   y = fY->at(i);
    return i;
 }
 
@@ -1631,7 +1631,7 @@ Double_t TGraph::GetPointY(Int_t i) const
    if (i < 0 || i >= fNpoints || !fY)
       return -1.;
 
-   return fY[i];
+   return fY->at(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1666,7 +1666,7 @@ char *TGraph::GetObjectInfo(Int_t px, Int_t py) const
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY->at(i)));
 
       if (dpx * dpx + dpy * dpy < 25) {
          ipoint = i;
@@ -1681,7 +1681,7 @@ char *TGraph::GetObjectInfo(Int_t px, Int_t py) const
       return Form("x=%g, y=%g", x, y);
 
    Double_t xval = fX->at(ipoint);
-   Double_t yval = fY[ipoint];
+   Double_t yval = fY->at(ipoint);
 
    return Form("x=%g, y=%g, point=%d, xval=%g, yval=%g", x, y, ipoint, xval, yval);
 }
@@ -1706,7 +1706,7 @@ void TGraph::InitGaus(Double_t xmin, Double_t xmax)
       x       = fX->at(bin);
       if (x < xmin || x > xmax) continue;
       np++;
-      val     = fY[bin];
+      val     = fY->at(bin);
       sumx   += val * x;
       sumx2  += val * x * x;
       allcha += val;
@@ -1778,7 +1778,7 @@ Int_t TGraph::InsertPoint()
    Int_t i, d = 0;
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints - 1; i++) {
-      d = DistancetoLine(px, py, gPad->XtoPad(fX->at(i)), gPad->YtoPad(fY[i]), gPad->XtoPad(fX->at(i+1)), gPad->YtoPad(fY[i+1]));
+      d = DistancetoLine(px, py, gPad->XtoPad(fX->at(i)), gPad->YtoPad(fY->at(i)), gPad->XtoPad(fX->at(i+1)), gPad->YtoPad(fY->at(i+1)));
       if (d < 5) {
          ipoint = i + 1;
          break;
@@ -1787,7 +1787,7 @@ Int_t TGraph::InsertPoint()
    if (ipoint == -2) {
       //may be we are far from one point, try again with a larger window
       for (i = 0; i < fNpoints - 1; i++) {
-         d = DistancetoLine(px, py, gPad->XtoPad(fX->at(i)), gPad->YtoPad(fY[i]), gPad->XtoPad(fX->at(i+1)), gPad->YtoPad(fY[i+1]));
+         d = DistancetoLine(px, py, gPad->XtoPad(fX->at(i)), gPad->YtoPad(fY->at(i)), gPad->XtoPad(fX->at(i+1)), gPad->YtoPad(fY->at(i+1)));
          if (d < 10) {
             ipoint = i + 1;
             break;
@@ -1797,7 +1797,7 @@ Int_t TGraph::InsertPoint()
    if (ipoint == -2) {
       //distinguish between first and last point
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(0)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->XtoPad(fY[0]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->XtoPad(fY->at(0)));
       if (dpx * dpx + dpy * dpy < 25) ipoint = 0;
       else                      ipoint = fNpoints;
    }
@@ -1837,7 +1837,7 @@ void TGraph::InsertPointBefore(Int_t ipoint, Double_t x, Double_t y)
    FillZero(ipoint, ipoint + 1);
 
    fX->at(ipoint) = x;
-   fY[ipoint] = y;
+   fY->at(ipoint) = y;
 }
 
 
@@ -1882,12 +1882,12 @@ Double_t TGraph::Integral(Int_t first, Int_t last) const
    Double_t sum = 0.0;
    //for(Int_t i=first;i<=last;i++) {
    //   Int_t j = first + (i-first+1)%np;
-   //   sum += TMath::Abs(fX->at(i)*fY[j]);
-   //   sum -= TMath::Abs(fY[i]*fX->at(j));
+   //   sum += TMath::Abs(fX->at(i)*fY->at(j));
+   //   sum -= TMath::Abs(fY->at(i)*fX->at(j));
    //}
    for (Int_t i = first; i <= last; i++) {
       Int_t j = first + (i - first + 1) % np;
-      sum += (fY[i] + fY[j]) * (fX->at(j) - fX->at(i));
+      sum += (fY->at(i) + fY->at(j)) * (fX->at(j) - fX->at(i));
    }
    return 0.5 * TMath::Abs(sum);
 }
@@ -1907,7 +1907,7 @@ Double_t TGraph::Integral(Int_t first, Int_t last) const
 
 Int_t TGraph::IsInside(Double_t x, Double_t y) const
 {
-   return (Int_t)TMath::IsInside(x, y, fNpoints, &fX->at(0), fY);
+   return (Int_t)TMath::IsInside(x, y, fNpoints, &fX->at(0), &fY->at(0));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1952,7 +1952,7 @@ void TGraph::LeastSquareFit(Int_t m, Double_t *a, Double_t xmin, Double_t xmax)
       xk     = fX->at(k);
       if (xk < xmin || xk > xmax) continue;
       np++;
-      yk     = fY[k];
+      yk     = fY->at(k);
       power  = one;
       da[0] += yk;
       for (l = 2; l <= m; ++l) {
@@ -1974,7 +1974,7 @@ void TGraph::LeastSquareFit(Int_t m, Double_t *a, Double_t xmin, Double_t xmax)
    H1LeastSquareSeqnd(m, b, idim, ifail, 1, da);
 
    if (ifail < 0) {
-      a[0] = fY[0];
+      a[0] = fY->at(0);
       for (i = 1; i < m; ++i) a[i] = 0;
       return;
    }
@@ -2014,7 +2014,7 @@ void TGraph::LeastSquareLinearFit(Int_t ndata, Double_t &a0, Double_t &a1, Int_t
       xk = fX->at(i);
       if (xk < xmin || xk > xmax) continue;
       np++;
-      yk = fY[i];
+      yk = fY->at(i);
       if (ndata < 0) {
          if (yk <= 0) yk = 1e-9;
          yk = TMath::Log(yk);
@@ -2080,7 +2080,7 @@ void TGraph::PaintStats(TF1 *fit)
 void TGraph::Print(Option_t *) const
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      printf("x[%d]=%g, y[%d]=%g\n", i, fX->at(i), i, fY[i]);
+      printf("x[%d]=%g, y[%d]=%g\n", i, fX->at(i), i, fY->at(i));
    }
 }
 
@@ -2110,7 +2110,7 @@ Int_t TGraph::RemovePoint()
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY->at(i)));
       if (dpx * dpx + dpy * dpy < 100) {
          ipoint = i;
          break;
@@ -2151,8 +2151,8 @@ void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
       out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
       out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-      for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-      out << "   " << fY[fNpoints-1] << "};" << std::endl;
+      for (i = 0; i < fNpoints-1; i++) out << "   " << fY->at(i) << "," << std::endl;
+      out << "   " << fY->at(fNpoints-1) << "};" << std::endl;
       if (gROOT->ClassSaved(TGraph::Class())) out << "   ";
       else out << "   TGraph *";
       out << "graph = new TGraph(" << fNpoints << "," << fXName << "," << fYName << ");" << std::endl;
@@ -2298,7 +2298,7 @@ void TGraph::SetPoint(Int_t i, Double_t x, Double_t y)
       fNpoints = i + 1;
    }
    fX->at(i) = x;
-   fY[i] = y;
+   fY->at(i) = y;
    if (gPad) gPad->Modified();
 }
 
@@ -2463,7 +2463,7 @@ void TGraph::Streamer(TBuffer &b)
       b >> fNpoints;
       fMaxSize = fNpoints;
       //fX = new Double_t[fNpoints];
-      fY = new Double_t[fNpoints];
+      //fY = new Double_t[fNpoints];
       if (R__v < 2) {
          Float_t *x = new Float_t[fNpoints];
          Float_t *y = new Float_t[fNpoints];
@@ -2471,13 +2471,13 @@ void TGraph::Streamer(TBuffer &b)
          b.ReadFastArray(y, fNpoints);
          for (Int_t i = 0; i < fNpoints; i++) {
             fX->at(i) = x[i];
-            fY[i] = y[i];
+            fY->at(i) = y[i];
          }
          delete [] y;
          delete [] x;
       } else {
          b.ReadFastArray(&fX->at(0), fNpoints);
-         b.ReadFastArray(fY, fNpoints);
+         b.ReadFastArray(&fY->at(0), fNpoints);
       }
       b >> fFunctions;
       b >> fHistogram;
@@ -2506,7 +2506,7 @@ void TGraph::Streamer(TBuffer &b)
 void TGraph::SwapPoints(Int_t pos1, Int_t pos2)
 {
    SwapValues(&fX->at(0), pos1, pos2);
-   SwapValues(fY, pos1, pos2);
+   SwapValues(&fY->at(0), pos1, pos2);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -115,7 +115,7 @@ TGraph::TGraph(Int_t n, const Int_t *x, const Int_t *y)
    }
    if (!CtorAllocate()) return;
    for (Int_t i = 0; i < n; i++) {
-      fX[i] = (Double_t)x[i];
+      fX->at(i) = (Double_t)x[i];
       fY[i] = (Double_t)y[i];
    }
 }
@@ -133,7 +133,7 @@ TGraph::TGraph(Int_t n, const Float_t *x, const Float_t *y)
    }
    if (!CtorAllocate()) return;
    for (Int_t i = 0; i < n; i++) {
-      fX[i] = x[i];
+      fX->at(i) = x[i];
       fY[i] = y[i];
    }
 }
@@ -151,7 +151,7 @@ TGraph::TGraph(Int_t n, const Double_t *x, const Double_t *y)
    }
    if (!CtorAllocate()) return;
    n = fNpoints * sizeof(Double_t);
-   memcpy(fX, x, n);
+   //memcpy(fX, x, n);
    memcpy(fY, y, n);
 }
 
@@ -174,15 +174,15 @@ TGraph::TGraph(const TGraph &gr)
    fMinimum = gr.fMinimum;
    fMaximum = gr.fMaximum;
    if (!fMaxSize) {
-      fX = fY = nullptr;
+      //fX = fY = nullptr;
       return;
    } else {
-      fX = new Double_t[fMaxSize];
+      //fX = new Double_t[fMaxSize];
       fY = new Double_t[fMaxSize];
    }
 
    Int_t n = gr.GetN() * sizeof(Double_t);
-   memcpy(fX, gr.fX, n);
+   //memcpy(fX, gr.fX, n);
    memcpy(fY, gr.fY, n);
 }
 
@@ -229,19 +229,19 @@ TGraph& TGraph::operator=(const TGraph &gr)
 
       fMinimum = gr.fMinimum;
       fMaximum = gr.fMaximum;
-      if (fX) delete [] fX;
+      //if (fX) delete [] fX;
       if (fY) delete [] fY;
       if (!fMaxSize) {
-         fX = fY = nullptr;
+         //fX = fY = nullptr;
          return *this;
       } else {
-         fX = new Double_t[fMaxSize];
+         //fX = new Double_t[fMaxSize];
          fY = new Double_t[fMaxSize];
       }
 
       Int_t n = gr.GetN() * sizeof(Double_t);
       if (n > 0) {
-         memcpy(fX, gr.fX, n);
+         //memcpy(fX, gr.fX, n);
          memcpy(fY, gr.fY, n);
       }
    }
@@ -262,7 +262,7 @@ TGraph::TGraph(const TVectorF &vx, const TVectorF &vy)
    Int_t ivxlow  = vx.GetLwb();
    Int_t ivylow  = vy.GetLwb();
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i]  = vx(i + ivxlow);
+      fX->at(i)  = vx(i + ivxlow);
       fY[i]  = vy(i + ivylow);
    }
 }
@@ -281,7 +281,7 @@ TGraph::TGraph(const TVectorD &vx, const TVectorD &vy)
    Int_t ivxlow  = vx.GetLwb();
    Int_t ivylow  = vy.GetLwb();
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i]  = vx(i + ivxlow);
+      fX->at(i)  = vx(i + ivxlow);
       fY[i]  = vy(i + ivylow);
    }
 }
@@ -308,7 +308,7 @@ TGraph::TGraph(const TH1 *h)
 
    TAxis *xaxis = ((TH1*)h)->GetXaxis();
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i] = xaxis->GetBinCenter(i + 1);
+      fX->at(i) = xaxis->GetBinCenter(i + 1);
       fY[i] = h->GetBinContent(i + 1);
    }
    h->TAttLine::Copy(*this);
@@ -352,16 +352,16 @@ TGraph::TGraph(const TF1 *f, Option_t *option)
    Int_t i;
    for (i = 0; i < fNpoints; i++) {
       if (coption == 'i' || coption == 'I') {
-         fX[i] = xmin + i * dx;
+         fX->at(i) = xmin + i * dx;
          if (i == 0) fY[i] = 0;
-         else        fY[i] = integ + ((TF1*)f)->Integral(fX[i] - dx, fX[i]);
+         else        fY[i] = integ + ((TF1*)f)->Integral(fX->at(i) - dx, fX->at(i));
          integ = fY[i];
       } else if (coption == 'd' || coption == 'D') {
-         fX[i] = xmin + (i + 0.5) * dx;
-         fY[i] = ((TF1*)f)->Derivative(fX[i]);
+         fX->at(i) = xmin + (i + 0.5) * dx;
+         fY[i] = ((TF1*)f)->Derivative(fX->at(i));
       } else {
-         fX[i] = xmin + (i + 0.5) * dx;
-         fY[i] = ((TF1*)f)->Eval(fX[i]);
+         fX->at(i) = xmin + (i + 0.5) * dx;
+         fY[i] = ((TF1*)f)->Eval(fX->at(i));
       }
    }
    if (integ != 0 && coption == 'I') {
@@ -520,7 +520,7 @@ TGraph::TGraph(const char *filename, const char *format, Option_t *option)
 
 TGraph::~TGraph()
 {
-   delete [] fX;
+   //delete [] fX;
    delete [] fY;
    if (fFunctions) {
       fFunctions->SetBit(kInvalidObject);
@@ -578,7 +578,7 @@ void TGraph::Apply(TF1 *f)
    if (fHistogram) SetBit(kResetHisto);
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      fY[i] = f->Eval(fX[i], fY[i]);
+      fY[i] = f->Eval(fX->at(i), fY[i]);
    }
    if (gPad) gPad->Modified();
 }
@@ -638,11 +638,11 @@ Bool_t TGraph::CompareArg(const TGraph* gr, Int_t left, Int_t right)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return kTRUE if fX[left] > fX[right]. Can be used by Sort.
+/// Return kTRUE if fX->at(left) > fX->at(right). Can be used by Sort.
 
 Bool_t TGraph::CompareX(const TGraph* gr, Int_t left, Int_t right)
 {
-   return gr->fX[left] > gr->fX[right];
+   return gr->fX->at(left) > gr->fX->at(right);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -659,8 +659,8 @@ Bool_t TGraph::CompareY(const TGraph* gr, Int_t left, Int_t right)
 
 Bool_t TGraph::CompareRadius(const TGraph* gr, Int_t left, Int_t right)
 {
-   return gr->fX[left] * gr->fX[left] + gr->fY[left] * gr->fY[left]
-          > gr->fX[right] * gr->fX[right] + gr->fY[right] * gr->fY[right];
+   return gr->fX->at(left) * gr->fX->at(left) + gr->fY[left] * gr->fY[left]
+          > gr->fX->at(right) * gr->fX->at(right) + gr->fY[right] * gr->fY[right];
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -672,15 +672,15 @@ void TGraph::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double
       xmin = xmax = ymin = ymax = 0;
       return;
    }
-   xmin = xmax = fX[0];
+   xmin = xmax = fX->at(0);
    ymin = ymax = fY[0];
 
    Double_t xminl = 0; // Positive minimum. Used in case of log scale along X axis.
    Double_t yminl = 0; // Positive minimum. Used in case of log scale along Y axis.
 
    for (Int_t i = 1; i < fNpoints; i++) {
-      if (fX[i] < xmin) xmin = fX[i];
-      if (fX[i] > xmax) xmax = fX[i];
+      if (fX->at(i) < xmin) xmin = fX->at(i);
+      if (fX->at(i) > xmax) xmax = fX->at(i);
       if (fY[i] < ymin) ymin = fY[i];
       if (fY[i] > ymax) ymax = fY[i];
       if (ymin>0 && (yminl==0 || ymin<yminl)) yminl = ymin;
@@ -702,8 +702,8 @@ void TGraph::CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t iend,
 {
    CopyPoints(newarrays, ibegin, iend, obegin);
    if (newarrays) {
-      delete[] fX;
-      fX = newarrays[0];
+      //delete[] fX;
+      //fX = newarrays[0];
       delete[] fY;
       fY = newarrays[1];
       delete[] newarrays;
@@ -725,10 +725,10 @@ Bool_t TGraph::CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
    }
    Int_t n = (iend - ibegin) * sizeof(Double_t);
    if (arrays) {
-      memmove(&arrays[0][obegin], &fX[ibegin], n);
+      memmove(&arrays[0][obegin], &fX->at(ibegin), n);
       memmove(&arrays[1][obegin], &fY[ibegin], n);
    } else {
-      memmove(&fX[obegin], &fX[ibegin], n);
+      memmove(&fX->at(obegin), &fX->at(ibegin), n);
       memmove(&fY[obegin], &fY[ibegin], n);
    }
    return kTRUE;
@@ -750,12 +750,12 @@ Bool_t TGraph::CtorAllocate()
    if (fNpoints <= 0) {
       fNpoints = 0;
       fMaxSize   = 0;
-      fX         = nullptr;
+      //fX         = nullptr;
       fY         = nullptr;
       return kFALSE;
    } else {
       fMaxSize   = fNpoints;
-      fX = new Double_t[fMaxSize];
+      //fX = new Double_t[fMaxSize];
       fY = new Double_t[fMaxSize];
    }
    return kTRUE;
@@ -850,7 +850,7 @@ void TGraph::DrawGraph(Int_t n, const Double_t *x, const Double_t *y, Option_t *
 {
    const Double_t *xx = x;
    const Double_t *yy = y;
-   if (!xx) xx = fX;
+   if (!xx) xx = &fX->at(0);
    if (!yy) yy = fY;
    TGraph *newgraph = new TGraph(n, xx, yy);
    TAttLine::Copy(*newgraph);
@@ -905,9 +905,9 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
          std::vector<Double_t> xsort(fNpoints);
          std::vector<Double_t> ysort(fNpoints);
          std::vector<Int_t> indxsort(fNpoints);
-         TMath::Sort(fNpoints, fX, &indxsort[0], false);
+         TMath::Sort(fNpoints, &fX->at(0), &indxsort[0], false);
          for (Int_t i = 0; i < fNpoints; ++i) {
-            xsort[i] = fX[ indxsort[i] ];
+            xsort[i] = fX->at( indxsort[i] );
             ysort[i] = fY[ indxsort[i] ];
          }
 
@@ -918,19 +918,19 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
       }
    }
    //linear interpolation
-   //In case x is < fX[0] or > fX[fNpoints-1] return the extrapolated point
+   //In case x is < fX->at(0) or > fX->at(fNpoints-1) return the extrapolated point
 
    //find points in graph around x assuming points are not sorted
    // (if point are sorted use a binary search)
    Int_t low  = -1;
    Int_t up  = -1;
    if (TestBit(TGraph::kIsSortedX) ) {
-      low = TMath::BinarySearch(fNpoints, fX, x);
+      low = TMath::BinarySearch(fNpoints, &fX->at(0), x);
       if (low == -1)  {
          // use first two points for doing an extrapolation
          low = 0;
       }
-      if (fX[low] == x) return fY[low];
+      if (fX->at(low) == x) return fY[low];
       if (low == fNpoints-1) low--; // for extrapolating
       up = low+1;
    }
@@ -944,17 +944,17 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
       Int_t up2 = -1;
 
       for (Int_t i = 0; i < fNpoints; ++i) {
-         if (fX[i] < x) {
-            if (low == -1 || fX[i] > fX[low])  {
+         if (fX->at(i) < x) {
+            if (low == -1 || fX->at(i) > fX->at(low))  {
                low2 = low;
                low = i;
             } else if (low2 == -1) low2 = i;
-         } else if (fX[i] > x) {
-            if (up  == -1 || fX[i] < fX[up])  {
+         } else if (fX->at(i) > x) {
+            if (up  == -1 || fX->at(i) < fX->at(up))  {
                up2 = up;
                up = i;
             } else if (up2 == -1) up2 = i;
-         } else // case x == fX[i]
+         } else // case x == fX->at(i)
             return fY[i]; // no interpolation needed
       }
 
@@ -971,8 +971,8 @@ Double_t TGraph::Eval(Double_t x, TSpline *spline, Option_t *option) const
    // do now the linear interpolation
    assert(low != -1 && up != -1);
 
-   if (fX[low] == fX[up]) return fY[low];
-   Double_t yn = fY[up] + (x - fX[up]) * (fY[low] - fY[up]) / (fX[low] - fX[up]);
+   if (fX->at(low) == fX->at(up)) return fY[low];
+   Double_t yn = fY[up] + (x - fX->at(up)) * (fY[low] - fY[up]) / (fX->at(low) - fX->at(up));
    return yn;
 }
 
@@ -1036,7 +1036,7 @@ Double_t **TGraph::ExpandAndCopy(Int_t size, Int_t iend)
 
 void TGraph::FillZero(Int_t begin, Int_t end, Bool_t)
 {
-   memset(fX + begin, 0, (end - begin)*sizeof(Double_t));
+   //memset(&fX->at(0) + begin, 0, (end - begin)*sizeof(Double_t));
    memset(fY + begin, 0, (end - begin)*sizeof(Double_t));
 }
 
@@ -1368,9 +1368,9 @@ Double_t TGraph::GetCovariance() const
    Double_t sum = fNpoints, sumx = 0, sumy = 0, sumxy = 0;
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      sumx  += fX[i];
+      sumx  += fX->at(i);
       sumy  += fY[i];
-      sumxy += fX[i] * fY[i];
+      sumxy += fX->at(i) * fY[i];
    }
    return sumxy / sum - sumx / sum * sumy / sum;
 }
@@ -1384,7 +1384,7 @@ Double_t TGraph::GetMean(Int_t axis) const
    if (fNpoints <= 0) return 0;
    Double_t sumx = 0;
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (axis == 1) sumx += fX[i];
+      if (axis == 1) sumx += fX->at(i);
       else           sumx += fY[i];
    }
    return sumx / fNpoints;
@@ -1400,8 +1400,8 @@ Double_t TGraph::GetRMS(Int_t axis) const
    Double_t sumx = 0, sumx2 = 0;
    for (Int_t i = 0; i < fNpoints; i++) {
       if (axis == 1) {
-         sumx += fX[i];
-         sumx2 += fX[i] * fX[i];
+         sumx += fX->at(i);
+         sumx2 += fX->at(i) * fX->at(i);
       } else           {
          sumx += fY[i];
          sumx2 += fY[i] * fY[i];
@@ -1607,7 +1607,7 @@ TH1F *TGraph::GetHistogram() const
 Int_t TGraph::GetPoint(Int_t i, Double_t &x, Double_t &y) const
 {
    if (i < 0 || i >= fNpoints || !fX || !fY) return -1;
-   x = fX[i];
+   x = fX->at(i);
    y = fY[i];
    return i;
 }
@@ -1620,7 +1620,7 @@ Double_t TGraph::GetPointX(Int_t i) const
    if (i < 0 || i >= fNpoints || !fX)
       return -1.;
 
-   return fX[i];
+   return fX->at(i);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1665,7 +1665,7 @@ char *TGraph::GetObjectInfo(Int_t px, Int_t py) const
    Int_t i;
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
 
       if (dpx * dpx + dpy * dpy < 25) {
@@ -1680,7 +1680,7 @@ char *TGraph::GetObjectInfo(Int_t px, Int_t py) const
    if (ipoint == -2)
       return Form("x=%g, y=%g", x, y);
 
-   Double_t xval = fX[ipoint];
+   Double_t xval = fX->at(ipoint);
    Double_t yval = fY[ipoint];
 
    return Form("x=%g, y=%g, point=%d, xval=%g, yval=%g", x, y, ipoint, xval, yval);
@@ -1697,13 +1697,13 @@ void TGraph::InitGaus(Double_t xmin, Double_t xmax)
 
    // Compute mean value and RMS of the graph in the given range
    if (xmax <= xmin) {
-      xmin = fX[0];
-      xmax = fX[fNpoints-1];
+      xmin = fX->at(0);
+      xmax = fX->at(fNpoints-1);
    }
    Int_t np = 0;
    allcha = sumx = sumx2 = 0;
    for (bin = 0; bin < fNpoints; bin++) {
-      x       = fX[bin];
+      x       = fX->at(bin);
       if (x < xmin || x > xmax) continue;
       np++;
       val     = fY[bin];
@@ -1732,8 +1732,8 @@ void TGraph::InitExpo(Double_t xmin, Double_t xmax)
    Double_t constant, slope;
    Int_t ifail;
    if (xmax <= xmin) {
-      xmin = fX[0];
-      xmax = fX[fNpoints-1];
+      xmin = fX->at(0);
+      xmax = fX->at(fNpoints-1);
    }
    Int_t nchanx = fNpoints;
 
@@ -1756,8 +1756,8 @@ void TGraph::InitPolynom(Double_t xmin, Double_t xmax)
    TF1 *f1 = (TF1*)grFitter->GetUserFunc();
    Int_t npar   = f1->GetNpar();
    if (xmax <= xmin) {
-      xmin = fX[0];
-      xmax = fX[fNpoints-1];
+      xmin = fX->at(0);
+      xmax = fX->at(fNpoints-1);
    }
 
    LeastSquareFit(npar, fitpar, xmin, xmax);
@@ -1778,7 +1778,7 @@ Int_t TGraph::InsertPoint()
    Int_t i, d = 0;
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints - 1; i++) {
-      d = DistancetoLine(px, py, gPad->XtoPad(fX[i]), gPad->YtoPad(fY[i]), gPad->XtoPad(fX[i+1]), gPad->YtoPad(fY[i+1]));
+      d = DistancetoLine(px, py, gPad->XtoPad(fX->at(i)), gPad->YtoPad(fY[i]), gPad->XtoPad(fX->at(i+1)), gPad->YtoPad(fY[i+1]));
       if (d < 5) {
          ipoint = i + 1;
          break;
@@ -1787,7 +1787,7 @@ Int_t TGraph::InsertPoint()
    if (ipoint == -2) {
       //may be we are far from one point, try again with a larger window
       for (i = 0; i < fNpoints - 1; i++) {
-         d = DistancetoLine(px, py, gPad->XtoPad(fX[i]), gPad->YtoPad(fY[i]), gPad->XtoPad(fX[i+1]), gPad->YtoPad(fY[i+1]));
+         d = DistancetoLine(px, py, gPad->XtoPad(fX->at(i)), gPad->YtoPad(fY[i]), gPad->XtoPad(fX->at(i+1)), gPad->YtoPad(fY[i+1]));
          if (d < 10) {
             ipoint = i + 1;
             break;
@@ -1796,7 +1796,7 @@ Int_t TGraph::InsertPoint()
    }
    if (ipoint == -2) {
       //distinguish between first and last point
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[0]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(0)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->XtoPad(fY[0]));
       if (dpx * dpx + dpy * dpy < 25) ipoint = 0;
       else                      ipoint = fNpoints;
@@ -1836,7 +1836,7 @@ void TGraph::InsertPointBefore(Int_t ipoint, Double_t x, Double_t y)
    // To avoid redefinitions in descendant classes
    FillZero(ipoint, ipoint + 1);
 
-   fX[ipoint] = x;
+   fX->at(ipoint) = x;
    fY[ipoint] = y;
 }
 
@@ -1882,12 +1882,12 @@ Double_t TGraph::Integral(Int_t first, Int_t last) const
    Double_t sum = 0.0;
    //for(Int_t i=first;i<=last;i++) {
    //   Int_t j = first + (i-first+1)%np;
-   //   sum += TMath::Abs(fX[i]*fY[j]);
-   //   sum -= TMath::Abs(fY[i]*fX[j]);
+   //   sum += TMath::Abs(fX->at(i)*fY[j]);
+   //   sum -= TMath::Abs(fY[i]*fX->at(j));
    //}
    for (Int_t i = first; i <= last; i++) {
       Int_t j = first + (i - first + 1) % np;
-      sum += (fY[i] + fY[j]) * (fX[j] - fX[i]);
+      sum += (fY[i] + fY[j]) * (fX->at(j) - fX->at(i));
    }
    return 0.5 * TMath::Abs(sum);
 }
@@ -1907,7 +1907,7 @@ Double_t TGraph::Integral(Int_t first, Int_t last) const
 
 Int_t TGraph::IsInside(Double_t x, Double_t y) const
 {
-   return (Int_t)TMath::IsInside(x, y, fNpoints, fX, fY);
+   return (Int_t)TMath::IsInside(x, y, fNpoints, &fX->at(0), fY);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1932,8 +1932,8 @@ void TGraph::LeastSquareFit(Int_t m, Double_t *a, Double_t xmin, Double_t xmax)
    Double_t da[20], xk, yk;
    Int_t n = fNpoints;
    if (xmax <= xmin) {
-      xmin = fX[0];
-      xmax = fX[fNpoints-1];
+      xmin = fX->at(0);
+      xmax = fX->at(fNpoints-1);
    }
 
    if (m <= 2) {
@@ -1949,7 +1949,7 @@ void TGraph::LeastSquareFit(Int_t m, Double_t *a, Double_t xmin, Double_t xmax)
    }
    Int_t np = 0;
    for (k = 0; k < fNpoints; ++k) {
-      xk     = fX[k];
+      xk     = fX->at(k);
       if (xk < xmin || xk > xmax) continue;
       np++;
       yk     = fY[k];
@@ -2003,15 +2003,15 @@ void TGraph::LeastSquareLinearFit(Int_t ndata, Double_t &a0, Double_t &a1, Int_t
    Double_t fn, xk, yk;
    Double_t det;
    if (xmax <= xmin) {
-      xmin = fX[0];
-      xmax = fX[fNpoints-1];
+      xmin = fX->at(0);
+      xmax = fX->at(fNpoints-1);
    }
 
    ifail = -2;
    xbar  = ybar = x2bar = xybar = 0;
    Int_t np = 0;
    for (i = 0; i < fNpoints; ++i) {
-      xk = fX[i];
+      xk = fX->at(i);
       if (xk < xmin || xk > xmax) continue;
       np++;
       yk = fY[i];
@@ -2080,7 +2080,7 @@ void TGraph::PaintStats(TF1 *fit)
 void TGraph::Print(Option_t *) const
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      printf("x[%d]=%g, y[%d]=%g\n", i, fX[i], i, fY[i]);
+      printf("x[%d]=%g, y[%d]=%g\n", i, fX->at(i), i, fY[i]);
    }
 }
 
@@ -2109,7 +2109,7 @@ Int_t TGraph::RemovePoint()
    Int_t i;
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
       if (dpx * dpx + dpy * dpy < 100) {
          ipoint = i;
@@ -2148,8 +2148,8 @@ void TGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
       TString fXName = TString(GetName()) + Form("_fx%d",frameNumber);
       TString fYName = TString(GetName()) + Form("_fy%d",frameNumber);
       out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-      for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-      out << "   " << fX[fNpoints-1] << "};" << std::endl;
+      for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
+      out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
       out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
       for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
       out << "   " << fY[fNpoints-1] << "};" << std::endl;
@@ -2297,7 +2297,7 @@ void TGraph::SetPoint(Int_t i, Double_t x, Double_t y)
       FillZero(fNpoints, i + 1);
       fNpoints = i + 1;
    }
-   fX[i] = x;
+   fX->at(i) = x;
    fY[i] = y;
    if (gPad) gPad->Modified();
 }
@@ -2462,7 +2462,7 @@ void TGraph::Streamer(TBuffer &b)
       TAttMarker::Streamer(b);
       b >> fNpoints;
       fMaxSize = fNpoints;
-      fX = new Double_t[fNpoints];
+      //fX = new Double_t[fNpoints];
       fY = new Double_t[fNpoints];
       if (R__v < 2) {
          Float_t *x = new Float_t[fNpoints];
@@ -2470,13 +2470,13 @@ void TGraph::Streamer(TBuffer &b)
          b.ReadFastArray(x, fNpoints);
          b.ReadFastArray(y, fNpoints);
          for (Int_t i = 0; i < fNpoints; i++) {
-            fX[i] = x[i];
+            fX->at(i) = x[i];
             fY[i] = y[i];
          }
          delete [] y;
          delete [] x;
       } else {
-         b.ReadFastArray(fX, fNpoints);
+         b.ReadFastArray(&fX->at(0), fNpoints);
          b.ReadFastArray(fY, fNpoints);
       }
       b >> fFunctions;
@@ -2505,7 +2505,7 @@ void TGraph::Streamer(TBuffer &b)
 
 void TGraph::SwapPoints(Int_t pos1, Int_t pos2)
 {
-   SwapValues(fX, pos1, pos2);
+   SwapValues(&fX->at(0), pos1, pos2);
    SwapValues(fY, pos1, pos2);
 }
 

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -195,7 +195,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const TVectorF  &vx, const TVectorF  &vy, c
    Int_t iveyllow = veyl.GetLwb();
    Int_t iveyhlow = veyh.GetLwb();
       for (Int_t i=0;i<fNpoints;i++) {
-      fX[i]      = vx(i+ivxlow);
+      fX->at(i)      = vx(i+ivxlow);
       fY[i]      = vy(i+ivylow);
       fEXlow[i]  = vexl(i+ivexllow);
       fEYlow[i]  = veyl(i+iveyllow);
@@ -225,7 +225,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const TVectorD &vx, const TVectorD &vy, con
    Int_t iveyllow = veyl.GetLwb();
    Int_t iveyhlow = veyh.GetLwb();
       for (Int_t i=0;i<fNpoints;i++) {
-      fX[i]      = vx(i+ivxlow);
+      fX->at(i)      = vx(i+ivxlow);
       fY[i]      = vy(i+ivylow);
       fEXlow[i]  = vexl(i+ivexllow);
       fEYlow[i]  = veyl(i+iveyllow);
@@ -972,15 +972,15 @@ void TGraphAsymmErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &x
    TGraph::ComputeRange(xmin,ymin,xmax,ymax);
 
    for (Int_t i=0;i<fNpoints;i++) {
-      if (fX[i] -fEXlow[i] < xmin) {
+      if (fX->at(i) -fEXlow[i] < xmin) {
          if (gPad && gPad->GetLogx()) {
-            if (fEXlow[i] < fX[i]) xmin = fX[i]-fEXlow[i];
-            else                   xmin = TMath::Min(xmin,fX[i]/3);
+            if (fEXlow[i] < fX->at(i)) xmin = fX->at(i)-fEXlow[i];
+            else                   xmin = TMath::Min(xmin,fX->at(i)/3);
          } else {
-            xmin = fX[i]-fEXlow[i];
+            xmin = fX->at(i)-fEXlow[i];
          }
       }
-      if (fX[i] +fEXhigh[i] > xmax) xmax = fX[i]+fEXhigh[i];
+      if (fX->at(i) +fEXhigh[i] > xmax) xmax = fX->at(i)+fEXhigh[i];
       if (fY[i] -fEYlow[i] < ymin) {
          if (gPad && gPad->GetLogy()) {
             if (fEYlow[i] < fY[i]) ymin = fY[i]-fEYlow[i];
@@ -1010,8 +1010,8 @@ void TGraphAsymmErrors::CopyAndRelease(Double_t **newarrays,
       fEYlow = newarrays[2];
       delete[] fEYhigh;
       fEYhigh = newarrays[3];
-      delete[] fX;
-      fX = newarrays[4];
+      //delete[] fX;
+      //fX = newarrays[4];
       delete[] fY;
       fY = newarrays[5];
       delete[] newarrays;
@@ -1223,7 +1223,7 @@ void TGraphAsymmErrors::Print(Option_t *) const
 {
    for (Int_t i=0;i<fNpoints;i++) {
       printf("x[%d]=%g, y[%d]=%g, exl[%d]=%g, exh[%d]=%g, eyl[%d]=%g, eyh[%d]=%g\n"
-         ,i,fX[i],i,fY[i],i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
+         ,i,fX->at(i),i,fY[i],i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
    }
 }
 
@@ -1246,8 +1246,8 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
    TString fEhXName = TString(GetName()) + Form("_fehx%d",frameNumber);
    TString fEhYName = TString(GetName()) + Form("_fehy%d",frameNumber);
    out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-   out << "   " << fX[fNpoints-1] << "};" << std::endl;
+   for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
+   out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
    out << "   " << fY[fNpoints-1] << "};" << std::endl;
@@ -1328,7 +1328,7 @@ void TGraphAsymmErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, 
    Int_t i;
    // start with a small window (in case the mouse is very close to one point)
    for (i=0;i<fNpoints;i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
       if (dpx*dpx+dpy*dpy < 25) {ipoint = i; break;}
    }

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -196,7 +196,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const TVectorF  &vx, const TVectorF  &vy, c
    Int_t iveyhlow = veyh.GetLwb();
       for (Int_t i=0;i<fNpoints;i++) {
       fX->at(i)      = vx(i+ivxlow);
-      fY[i]      = vy(i+ivylow);
+      fY->at(i)      = vy(i+ivylow);
       fEXlow[i]  = vexl(i+ivexllow);
       fEYlow[i]  = veyl(i+iveyllow);
       fEXhigh[i] = vexh(i+ivexhlow);
@@ -226,7 +226,7 @@ TGraphAsymmErrors::TGraphAsymmErrors(const TVectorD &vx, const TVectorD &vy, con
    Int_t iveyhlow = veyh.GetLwb();
       for (Int_t i=0;i<fNpoints;i++) {
       fX->at(i)      = vx(i+ivxlow);
-      fY[i]      = vy(i+ivylow);
+      fY->at(i)      = vy(i+ivylow);
       fEXlow[i]  = vexl(i+ivexllow);
       fEYlow[i]  = veyl(i+iveyllow);
       fEXhigh[i] = vexh(i+ivexhlow);
@@ -981,15 +981,15 @@ void TGraphAsymmErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &x
          }
       }
       if (fX->at(i) +fEXhigh[i] > xmax) xmax = fX->at(i)+fEXhigh[i];
-      if (fY[i] -fEYlow[i] < ymin) {
+      if (fY->at(i) -fEYlow[i] < ymin) {
          if (gPad && gPad->GetLogy()) {
-            if (fEYlow[i] < fY[i]) ymin = fY[i]-fEYlow[i];
-            else                   ymin = TMath::Min(ymin,fY[i]/3);
+            if (fEYlow[i] < fY->at(i)) ymin = fY->at(i)-fEYlow[i];
+            else                   ymin = TMath::Min(ymin,fY->at(i)/3);
          } else {
-            ymin = fY[i]-fEYlow[i];
+            ymin = fY->at(i)-fEYlow[i];
          }
       }
-      if (fY[i] +fEYhigh[i] > ymax) ymax = fY[i]+fEYhigh[i];
+      if (fY->at(i) +fEYhigh[i] > ymax) ymax = fY->at(i)+fEYhigh[i];
    }
 }
 
@@ -1012,8 +1012,8 @@ void TGraphAsymmErrors::CopyAndRelease(Double_t **newarrays,
       fEYhigh = newarrays[3];
       //delete[] fX;
       //fX = newarrays[4];
-      delete[] fY;
-      fY = newarrays[5];
+      //delete[] fY;
+      //fY = newarrays[5];
       delete[] newarrays;
    }
 }
@@ -1223,7 +1223,7 @@ void TGraphAsymmErrors::Print(Option_t *) const
 {
    for (Int_t i=0;i<fNpoints;i++) {
       printf("x[%d]=%g, y[%d]=%g, exl[%d]=%g, exh[%d]=%g, eyl[%d]=%g, eyh[%d]=%g\n"
-         ,i,fX->at(i),i,fY[i],i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
+         ,i,fX->at(i),i,fY->at(i),i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
    }
 }
 
@@ -1249,8 +1249,8 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
    for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
    out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-   out << "   " << fY[fNpoints-1] << "};" << std::endl;
+   for (i = 0; i < fNpoints-1; i++) out << "   " << fY->at(i) << "," << std::endl;
+   out << "   " << fY->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fElXName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fEXlow[i] << "," << std::endl;
    out << "   " << fEXlow[fNpoints-1] << "};" << std::endl;
@@ -1329,7 +1329,7 @@ void TGraphAsymmErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, 
    // start with a small window (in case the mouse is very close to one point)
    for (i=0;i<fNpoints;i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY->at(i)));
       if (dpx*dpx+dpy*dpy < 25) {ipoint = i; break;}
    }
    if (ipoint == -2) return;

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -242,15 +242,15 @@ void TGraphBentErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xm
    TGraph::ComputeRange(xmin,ymin,xmax,ymax);
 
    for (Int_t i=0;i<fNpoints;i++) {
-      if (fX[i] -fEXlow[i] < xmin) {
+      if (fX->at(i) -fEXlow[i] < xmin) {
          if (gPad && gPad->GetLogx()) {
-            if (fEXlow[i] < fX[i]) xmin = fX[i]-fEXlow[i];
-            else                   xmin = TMath::Min(xmin,fX[i]/3);
+            if (fEXlow[i] < fX->at(i)) xmin = fX->at(i)-fEXlow[i];
+            else                   xmin = TMath::Min(xmin,fX->at(i)/3);
          } else {
-            xmin = fX[i]-fEXlow[i];
+            xmin = fX->at(i)-fEXlow[i];
          }
       }
-      if (fX[i] +fEXhigh[i] > xmax) xmax = fX[i]+fEXhigh[i];
+      if (fX->at(i) +fEXhigh[i] > xmax) xmax = fX->at(i)+fEXhigh[i];
       if (fY[i] -fEYlow[i] < ymin) {
          if (gPad && gPad->GetLogy()) {
             if (fEYlow[i] < fY[i]) ymin = fY[i]-fEYlow[i];
@@ -288,8 +288,8 @@ void TGraphBentErrors::CopyAndRelease(Double_t **newarrays,
       fEYlowd = newarrays[6];
       delete[] fEYhighd;
       fEYhighd = newarrays[7];
-      delete[] fX;
-      fX = newarrays[8];
+      //delete[] fX;
+      //fX = newarrays[8];
       delete[] fY;
       fY = newarrays[9];
       delete[] newarrays;
@@ -490,7 +490,7 @@ void TGraphBentErrors::Print(Option_t *) const
 {
    for (Int_t i=0;i<fNpoints;i++) {
       printf("x[%d]=%g, y[%d]=%g, exl[%d]=%g, exh[%d]=%g, eyl[%d]=%g, eyh[%d]=%g\n"
-         ,i,fX[i],i,fY[i],i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
+         ,i,fX->at(i),i,fY[i],i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
    }
 }
 
@@ -517,8 +517,8 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
    TString fEhdXName = TString(GetName()) + Form("_fehdx%d",frameNumber);
    TString fEhdYName = TString(GetName()) + Form("_fehdy%d",frameNumber);
    out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-   out << "   " << fX[fNpoints-1] << "};" << std::endl;
+   for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
+   out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
    out << "   " << fY[fNpoints-1] << "};" << std::endl;
@@ -615,7 +615,7 @@ void TGraphBentErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, D
    Int_t i;
    // start with a small window (in case the mouse is very close to one point)
    for (i=0;i<fNpoints;i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
       if (dpx*dpx+dpy*dpy < 25) {ipoint = i; break;}
    }

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -251,15 +251,15 @@ void TGraphBentErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xm
          }
       }
       if (fX->at(i) +fEXhigh[i] > xmax) xmax = fX->at(i)+fEXhigh[i];
-      if (fY[i] -fEYlow[i] < ymin) {
+      if (fY->at(i) -fEYlow[i] < ymin) {
          if (gPad && gPad->GetLogy()) {
-            if (fEYlow[i] < fY[i]) ymin = fY[i]-fEYlow[i];
-            else                   ymin = TMath::Min(ymin,fY[i]/3);
+            if (fEYlow[i] < fY->at(i)) ymin = fY->at(i)-fEYlow[i];
+            else                   ymin = TMath::Min(ymin,fY->at(i)/3);
          } else {
-            ymin = fY[i]-fEYlow[i];
+            ymin = fY->at(i)-fEYlow[i];
          }
       }
-      if (fY[i] +fEYhigh[i] > ymax) ymax = fY[i]+fEYhigh[i];
+      if (fY->at(i) +fEYhigh[i] > ymax) ymax = fY->at(i)+fEYhigh[i];
    }
 }
 
@@ -290,8 +290,8 @@ void TGraphBentErrors::CopyAndRelease(Double_t **newarrays,
       fEYhighd = newarrays[7];
       //delete[] fX;
       //fX = newarrays[8];
-      delete[] fY;
-      fY = newarrays[9];
+      //delete[] fY;
+      //fY = newarrays[9];
       delete[] newarrays;
    }
 }
@@ -490,7 +490,7 @@ void TGraphBentErrors::Print(Option_t *) const
 {
    for (Int_t i=0;i<fNpoints;i++) {
       printf("x[%d]=%g, y[%d]=%g, exl[%d]=%g, exh[%d]=%g, eyl[%d]=%g, eyh[%d]=%g\n"
-         ,i,fX->at(i),i,fY[i],i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
+         ,i,fX->at(i),i,fY->at(i),i,fEXlow[i],i,fEXhigh[i],i,fEYlow[i],i,fEYhigh[i]);
    }
 }
 
@@ -520,8 +520,8 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
    for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
    out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-   out << "   " << fY[fNpoints-1] << "};" << std::endl;
+   for (i = 0; i < fNpoints-1; i++) out << "   " << fY->at(i) << "," << std::endl;
+   out << "   " << fY->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fElXName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fEXlow[i] << "," << std::endl;
    out << "   " << fEXlow[fNpoints-1] << "};" << std::endl;
@@ -616,7 +616,7 @@ void TGraphBentErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, D
    // start with a small window (in case the mouse is very close to one point)
    for (i=0;i<fNpoints;i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY->at(i)));
       if (dpx*dpx+dpy*dpy < 25) {ipoint = i; break;}
    }
    if (ipoint == -2) return;

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -481,15 +481,15 @@ void TGraphErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, 
          }
       }
       if (fX->at(i) + fEX[i] > xmax) xmax = fX->at(i) + fEX[i];
-      if (fY[i] - fEY[i] < ymin) {
+      if (fY->at(i) - fEY[i] < ymin) {
          if (gPad && gPad->GetLogy()) {
-            if (fEY[i] < fY[i]) ymin = fY[i] - fEY[i];
-            else                ymin = TMath::Min(ymin, fY[i] / 3);
+            if (fEY[i] < fY->at(i)) ymin = fY->at(i) - fEY[i];
+            else                ymin = TMath::Min(ymin, fY->at(i) / 3);
          } else {
-            ymin = fY[i] - fEY[i];
+            ymin = fY->at(i) - fEY[i];
          }
       }
-      if (fY[i] + fEY[i] > ymax) ymax = fY[i] + fEY[i];
+      if (fY->at(i) + fEY[i] > ymax) ymax = fY->at(i) + fEY[i];
    }
 }
 
@@ -504,8 +504,8 @@ void TGraphErrors::CopyAndRelease(Double_t **newarrays,
    if (newarrays) {
       //delete[] fX;
       //fX = newarrays[2];
-      delete[] fY;
-      fY = newarrays[3];
+      //delete[] fY;
+      //fY = newarrays[3];
       delete[] fEX;
       fEX = newarrays[0];
       delete[] fEY;
@@ -702,7 +702,7 @@ Int_t TGraphErrors::Merge(TCollection* li)
 void TGraphErrors::Print(Option_t *) const
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      printf("x[%d]=%g, y[%d]=%g, ex[%d]=%g, ey[%d]=%g\n", i, fX->at(i), i, fY[i], i, fEX[i], i, fEY[i]);
+      printf("x[%d]=%g, y[%d]=%g, ex[%d]=%g, ey[%d]=%g\n", i, fX->at(i), i, fY->at(i), i, fEX[i], i, fEY[i]);
    }
 }
 
@@ -726,8 +726,8 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
    out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-   out << "   " << fY[fNpoints-1] << "};" << std::endl;
+   for (i = 0; i < fNpoints-1; i++) out << "   " << fY->at(i) << "," << std::endl;
+   out << "   " << fY->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fEXName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fEX[i] << "," << std::endl;
    out << "   " << fEX[fNpoints-1] << "};" << std::endl;
@@ -800,7 +800,7 @@ void TGraphErrors::SetPointError(Double_t ex, Double_t ey)
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY->at(i)));
       if (dpx * dpx + dpy * dpy < 25) {
          ipoint = i;
          break;

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -472,15 +472,15 @@ void TGraphErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, 
    TGraph::ComputeRange(xmin, ymin, xmax, ymax);
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (fX[i] - fEX[i] < xmin) {
+      if (fX->at(i) - fEX[i] < xmin) {
          if (gPad && gPad->GetLogx()) {
-            if (fEX[i] < fX[i]) xmin = fX[i] - fEX[i];
-            else                xmin = TMath::Min(xmin, fX[i] / 3);
+            if (fEX[i] < fX->at(i)) xmin = fX->at(i) - fEX[i];
+            else                xmin = TMath::Min(xmin, fX->at(i) / 3);
          } else {
-            xmin = fX[i] - fEX[i];
+            xmin = fX->at(i) - fEX[i];
          }
       }
-      if (fX[i] + fEX[i] > xmax) xmax = fX[i] + fEX[i];
+      if (fX->at(i) + fEX[i] > xmax) xmax = fX->at(i) + fEX[i];
       if (fY[i] - fEY[i] < ymin) {
          if (gPad && gPad->GetLogy()) {
             if (fEY[i] < fY[i]) ymin = fY[i] - fEY[i];
@@ -502,8 +502,8 @@ void TGraphErrors::CopyAndRelease(Double_t **newarrays,
 {
    CopyPoints(newarrays, ibegin, iend, obegin);
    if (newarrays) {
-      delete[] fX;
-      fX = newarrays[2];
+      //delete[] fX;
+      //fX = newarrays[2];
       delete[] fY;
       fY = newarrays[3];
       delete[] fEX;
@@ -702,7 +702,7 @@ Int_t TGraphErrors::Merge(TCollection* li)
 void TGraphErrors::Print(Option_t *) const
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      printf("x[%d]=%g, y[%d]=%g, ex[%d]=%g, ey[%d]=%g\n", i, fX[i], i, fY[i], i, fEX[i], i, fEY[i]);
+      printf("x[%d]=%g, y[%d]=%g, ex[%d]=%g, ey[%d]=%g\n", i, fX->at(i), i, fY[i], i, fEX[i], i, fEY[i]);
    }
 }
 
@@ -723,8 +723,8 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    TString fEXName = TString(GetName()) + Form("_fex%d",frameNumber);
    TString fEYName = TString(GetName()) + Form("_fey%d",frameNumber);
    out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-   out << "   " << fX[fNpoints-1] << "};" << std::endl;
+   for (i = 0; i < fNpoints-1; i++) out << "   " << fX->at(i) << "," << std::endl;
+   out << "   " << fX->at(fNpoints-1) << "};" << std::endl;
    out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
    out << "   " << fY[fNpoints-1] << "};" << std::endl;
@@ -799,7 +799,7 @@ void TGraphErrors::SetPointError(Double_t ex, Double_t ey)
    Int_t i;
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
       if (dpx * dpx + dpy * dpy < 25) {
          ipoint = i;

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -441,7 +441,7 @@ TGraphMultiErrors::TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, c
 
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i) = tvX(itvXL + i);
-      fY[i] = tvY(itvYL + i);
+      fY->at(i) = tvY(itvYL + i);
       fExL[i] = tvExL(itvExLL + i);
       fExH[i] = tvExH(itvExHL + i);
       fEyL[0][i] = tvEyL(itvEyLL + i);
@@ -480,7 +480,7 @@ TGraphMultiErrors::TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, c
 
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i) = tvX(i + itvXL);
-      fY[i] = tvY(i + itvYL);
+      fY->at(i) = tvY(i + itvYL);
       fExL[i] = tvExL(i + itvExLL);
       fExH[i] = tvExH(i + itvExHL);
       fEyL[0][i] = tvEyL(i + itvEyLL);
@@ -516,7 +516,7 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVecto
 
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i) = tvX(i + itvXL);
-      fY[i] = tvY(i + itvYL);
+      fY->at(i) = tvY(i + itvYL);
       fExL[i] = tvExL(i + itvExLL);
       fExH[i] = tvExH(i + itvExHL);
 
@@ -555,7 +555,7 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVecto
 
    for (Int_t i = 0; i < fNpoints; i++) {
       fX->at(i) = tvX(i + itvXL);
-      fY[i] = tvY(i + itvYL);
+      fY->at(i) = tvY(i + itvYL);
       fExL[i] = tvExL(i + itvExLL);
       fExH[i] = tvExH(i + itvExHL);
 
@@ -751,8 +751,8 @@ void TGraphMultiErrors::CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t
    if (newarrays) {
       //delete[] fX;
       //fX = newarrays[0];
-      delete[] fY;
-      fY = newarrays[1];
+      //delete[] fY;
+      //fY = newarrays[1];
 
       delete[] fExL;
       fExL = newarrays[2];
@@ -1366,18 +1366,18 @@ void TGraphMultiErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &x
          eyHMax = TMath::Max(eyHMax, fEyH[j][i]);
       }
 
-      if (fY[i] - eyLMax < ymin) {
+      if (fY->at(i) - eyLMax < ymin) {
          if (gPad && gPad->GetLogy()) {
-            if (eyLMax < fY[i])
-               ymin = fY[i] - eyLMax;
+            if (eyLMax < fY->at(i))
+               ymin = fY->at(i) - eyLMax;
             else
-               ymin = TMath::Min(ymin, fY[i] / 3.);
+               ymin = TMath::Min(ymin, fY->at(i) / 3.);
          } else
-            ymin = fY[i] - eyLMax;
+            ymin = fY->at(i) - eyLMax;
       }
 
-      if (fY[i] + eyHMax > ymax)
-         ymax = fY[i] + eyHMax;
+      if (fY->at(i) + eyHMax > ymax)
+         ymax = fY->at(i) + eyHMax;
    }
 }
 
@@ -1674,7 +1674,7 @@ Width_t TGraphMultiErrors::GetLineWidth(Int_t e) const
 void TGraphMultiErrors::Print(Option_t *) const
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      printf("x[%d]=%g, y[%d]=%g", i, fX->at(i), i, fY[i]);
+      printf("x[%d]=%g, y[%d]=%g", i, fX->at(i), i, fY->at(i));
       if (fExL)
          printf(", exl[%d]=%g", i, fExL[i]);
       if (fExH)
@@ -1716,7 +1716,7 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
    }
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      out << "   tgme->SetPoint(" << i << ", " << fX->at(i) << ", " << fY[i] << ");" << std::endl;
+      out << "   tgme->SetPoint(" << i << ", " << fX->at(i) << ", " << fY->at(i) << ");" << std::endl;
       out << "   tgme->SetPointEX(" << i << ", " << fExL[i] << ", " << fExH[i] << ");" << std::endl;
 
       for (Int_t j = 0; j < fNYErrors; j++)
@@ -1771,7 +1771,7 @@ void TGraphMultiErrors::SetPointError(Double_t exL, Double_t exH, Double_t eyL1,
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
-      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
+      Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY->at(i)));
 
       if (dpx * dpx + dpy * dpy < 25) {
          ipoint = i;

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -440,7 +440,7 @@ TGraphMultiErrors::TGraphMultiErrors(const TVectorF &tvX, const TVectorF &tvY, c
    Int_t itvEyHL = tvEyH.GetLwb();
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i] = tvX(itvXL + i);
+      fX->at(i) = tvX(itvXL + i);
       fY[i] = tvY(itvYL + i);
       fExL[i] = tvExL(itvExLL + i);
       fExH[i] = tvExH(itvExHL + i);
@@ -479,7 +479,7 @@ TGraphMultiErrors::TGraphMultiErrors(const TVectorD &tvX, const TVectorD &tvY, c
    Int_t itvEyHL = tvEyH.GetLwb();
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i] = tvX(i + itvXL);
+      fX->at(i) = tvX(i + itvXL);
       fY[i] = tvY(i + itvYL);
       fExL[i] = tvExL(i + itvExLL);
       fExH[i] = tvExH(i + itvExHL);
@@ -515,7 +515,7 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorF &tvX, const TVecto
    Int_t itvExHL = tvExH.GetLwb();
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i] = tvX(i + itvXL);
+      fX->at(i) = tvX(i + itvXL);
       fY[i] = tvY(i + itvYL);
       fExL[i] = tvExL(i + itvExLL);
       fExH[i] = tvExH(i + itvExHL);
@@ -554,7 +554,7 @@ TGraphMultiErrors::TGraphMultiErrors(Int_t ne, const TVectorD &tvX, const TVecto
    Int_t itvExHL = tvExH.GetLwb();
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      fX[i] = tvX(i + itvXL);
+      fX->at(i) = tvX(i + itvXL);
       fY[i] = tvY(i + itvYL);
       fExL[i] = tvExL(i + itvExLL);
       fExH[i] = tvExH(i + itvExHL);
@@ -749,8 +749,8 @@ void TGraphMultiErrors::CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t
 {
    CopyPoints(newarrays, ibegin, iend, obegin);
    if (newarrays) {
-      delete[] fX;
-      fX = newarrays[0];
+      //delete[] fX;
+      //fX = newarrays[0];
       delete[] fY;
       fY = newarrays[1];
 
@@ -1347,18 +1347,18 @@ void TGraphMultiErrors::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &x
    TGraph::ComputeRange(xmin, ymin, xmax, ymax);
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      if (fX[i] - fExL[i] < xmin) {
+      if (fX->at(i) - fExL[i] < xmin) {
          if (gPad && gPad->GetLogx()) {
-            if (fExL[i] < fX[i])
-               xmin = fX[i] - fExL[i];
+            if (fExL[i] < fX->at(i))
+               xmin = fX->at(i) - fExL[i];
             else
-               xmin = TMath::Min(xmin, fX[i] / 3.);
+               xmin = TMath::Min(xmin, fX->at(i) / 3.);
          } else
-            xmin = fX[i] - fExL[i];
+            xmin = fX->at(i) - fExL[i];
       }
 
-      if (fX[i] + fExH[i] > xmax)
-         xmax = fX[i] + fExH[i];
+      if (fX->at(i) + fExH[i] > xmax)
+         xmax = fX->at(i) + fExH[i];
 
       Double_t eyLMax = 0., eyHMax = 0.;
       for (Int_t j = 0; j < fNYErrors; j++) {
@@ -1674,7 +1674,7 @@ Width_t TGraphMultiErrors::GetLineWidth(Int_t e) const
 void TGraphMultiErrors::Print(Option_t *) const
 {
    for (Int_t i = 0; i < fNpoints; i++) {
-      printf("x[%d]=%g, y[%d]=%g", i, fX[i], i, fY[i]);
+      printf("x[%d]=%g, y[%d]=%g", i, fX->at(i), i, fY[i]);
       if (fExL)
          printf(", exl[%d]=%g", i, fExL[i]);
       if (fExH)
@@ -1716,7 +1716,7 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
    }
 
    for (Int_t i = 0; i < fNpoints; i++) {
-      out << "   tgme->SetPoint(" << i << ", " << fX[i] << ", " << fY[i] << ");" << std::endl;
+      out << "   tgme->SetPoint(" << i << ", " << fX->at(i) << ", " << fY[i] << ");" << std::endl;
       out << "   tgme->SetPointEX(" << i << ", " << fExL[i] << ", " << fExH[i] << ");" << std::endl;
 
       for (Int_t j = 0; j < fNYErrors; j++)
@@ -1770,7 +1770,7 @@ void TGraphMultiErrors::SetPointError(Double_t exL, Double_t exH, Double_t eyL1,
    Int_t i;
    // start with a small window (in case the mouse is very close to one point)
    for (i = 0; i < fNpoints; i++) {
-      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
+      Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX->at(i)));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
 
       if (dpx * dpx + dpy * dpy < 25) {

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -543,7 +543,7 @@ void RooCurve::printMultiline(ostream& os, Int_t /*contents*/, Bool_t /*verbose*
   os << indent << "  Contains " << n << " points" << endl;
   os << indent << "  Graph points:" << endl;
   for(Int_t i= 0; i < n; i++) {
-    os << indent << setw(3) << i << ") x = " << fX[i] << " , y = " << fY[i] << endl;
+    os << indent << setw(3) << i << ") x = " << fX->at(i) << " , y = " << fY[i] << endl;
   }
 }
 
@@ -889,8 +889,8 @@ Bool_t RooCurve::isIdentical(const RooCurve& other, Double_t tol) const
   Int_t n= min(GetN(),other.GetN());
   Double_t xmin(1e30), xmax(-1e30), ymin(1e30), ymax(-1e30) ;
   for(Int_t i= 0; i < n; i++) {
-    if (fX[i]<xmin) xmin=fX[i] ;
-    if (fX[i]>xmax) xmax=fX[i] ;
+    if (fX->at(i)<xmin) xmin=fX->at(i) ;
+    if (fX->at(i)>xmax) xmax=fX->at(i) ;
     if (fY[i]<ymin) ymin=fY[i] ;
     if (fY[i]>ymax) ymax=fY[i] ;
   }
@@ -898,15 +898,15 @@ Bool_t RooCurve::isIdentical(const RooCurve& other, Double_t tol) const
 
   Bool_t ret(kTRUE) ;
   for(Int_t i= 2; i < n-2; i++) {
-    Double_t yTest = interpolate(other.fX[i],1e-10) ;
+    Double_t yTest = interpolate(other.fX->at(i),1e-10) ;
     Double_t rdy = fabs(yTest-other.fY[i])/Yrange ;
     if (rdy>tol) {
       ret = false;
       cout << "RooCurve::isIdentical[" << std::setw(3) << i << "] Y tolerance exceeded (" << std::setprecision(5) << std::setw(10) << rdy << ">" << tol << "),";
-      cout << "  x,y=(" << std::right << std::setw(10) << fX[i] << "," << std::setw(10) << fY[i] << ")\tref: y="
-          << std::setw(10) << other.interpolate(fX[i], 1.E-15) << ". [Nearest point from ref: ";
-      auto j = other.findPoint(fX[i], 1.E10);
-      std::cout << "j=" << j << "\tx,y=(" << std::setw(10) << other.fX[j] << "," << std::setw(10) << other.fY[j] << ") ]" << "\trange=" << Yrange << std::endl;
+      cout << "  x,y=(" << std::right << std::setw(10) << fX->at(i) << "," << std::setw(10) << fY[i] << ")\tref: y="
+          << std::setw(10) << other.interpolate(fX->at(i), 1.E-15) << ". [Nearest point from ref: ";
+      auto j = other.findPoint(fX->at(i), 1.E10);
+      std::cout << "j=" << j << "\tx,y=(" << std::setw(10) << other.fX->at(j) << "," << std::setw(10) << other.fY[j] << ") ]" << "\trange=" << Yrange << std::endl;
     }
   }
       

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -151,7 +151,7 @@ RooCurve::RooCurve(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xlo, Doubl
 
   // Adjust limits
   for (int i=0 ; i<GetN() ; i++) {
-    updateYAxisLimits(fY[i]);
+    updateYAxisLimits(fY->at(i));
   }
   this->Sort();
 }
@@ -179,7 +179,7 @@ RooCurve::RooCurve(const char *name, const char *title, const RooAbsFunc &func,
 
   // Adjust limits
   for (int i=0 ; i<GetN() ; i++) {
-    updateYAxisLimits(fY[i]);
+    updateYAxisLimits(fY->at(i));
   }
   this->Sort();
 }
@@ -543,7 +543,7 @@ void RooCurve::printMultiline(ostream& os, Int_t /*contents*/, Bool_t /*verbose*
   os << indent << "  Contains " << n << " points" << endl;
   os << indent << "  Graph points:" << endl;
   for(Int_t i= 0; i < n; i++) {
-    os << indent << setw(3) << i << ") x = " << fX->at(i) << " , y = " << fY[i] << endl;
+    os << indent << setw(3) << i << ") x = " << fX->at(i) << " , y = " << fY->at(i) << endl;
   }
 }
 
@@ -891,22 +891,22 @@ Bool_t RooCurve::isIdentical(const RooCurve& other, Double_t tol) const
   for(Int_t i= 0; i < n; i++) {
     if (fX->at(i)<xmin) xmin=fX->at(i) ;
     if (fX->at(i)>xmax) xmax=fX->at(i) ;
-    if (fY[i]<ymin) ymin=fY[i] ;
-    if (fY[i]>ymax) ymax=fY[i] ;
+    if (fY->at(i)<ymin) ymin=fY->at(i) ;
+    if (fY->at(i)>ymax) ymax=fY->at(i) ;
   }
   const double Yrange=ymax-ymin ;
 
   Bool_t ret(kTRUE) ;
   for(Int_t i= 2; i < n-2; i++) {
     Double_t yTest = interpolate(other.fX->at(i),1e-10) ;
-    Double_t rdy = fabs(yTest-other.fY[i])/Yrange ;
+    Double_t rdy = fabs(yTest-other.fY->at(i))/Yrange ;
     if (rdy>tol) {
       ret = false;
       cout << "RooCurve::isIdentical[" << std::setw(3) << i << "] Y tolerance exceeded (" << std::setprecision(5) << std::setw(10) << rdy << ">" << tol << "),";
-      cout << "  x,y=(" << std::right << std::setw(10) << fX->at(i) << "," << std::setw(10) << fY[i] << ")\tref: y="
+      cout << "  x,y=(" << std::right << std::setw(10) << fX->at(i) << "," << std::setw(10) << fY->at(i) << ")\tref: y="
           << std::setw(10) << other.interpolate(fX->at(i), 1.E-15) << ". [Nearest point from ref: ";
       auto j = other.findPoint(fX->at(i), 1.E10);
-      std::cout << "j=" << j << "\tx,y=(" << std::setw(10) << other.fX->at(j) << "," << std::setw(10) << other.fY[j] << ") ]" << "\trange=" << Yrange << std::endl;
+      std::cout << "j=" << j << "\tx,y=(" << std::setw(10) << other.fX->at(j) << "," << std::setw(10) << other.fY->at(j) << ") ]" << "\trange=" << Yrange << std::endl;
     }
   }
       

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -154,6 +154,6 @@ void RooEllipse::printMultiline(ostream& os, Int_t contents, Bool_t verbose, TSt
 {
   RooPlotable::printMultiline(os,contents,verbose,indent);
   for(Int_t index=0; index < fNpoints; index++) {
-    os << indent << "Point [" << index << "] is at (" << fX[index] << "," << fY[index] << ")" << endl;
+    os << indent << "Point [" << index << "] is at (" << fX->at(index) << "," << fY[index] << ")" << endl;
   }
 }

--- a/roofit/roofitcore/src/RooEllipse.cxx
+++ b/roofit/roofitcore/src/RooEllipse.cxx
@@ -154,6 +154,6 @@ void RooEllipse::printMultiline(ostream& os, Int_t contents, Bool_t verbose, TSt
 {
   RooPlotable::printMultiline(os,contents,verbose,indent);
   for(Int_t index=0; index < fNpoints; index++) {
-    os << indent << "Point [" << index << "] is at (" << fX->at(index) << "," << fY[index] << ")" << endl;
+    os << indent << "Point [" << index << "] is at (" << fX->at(index) << "," << fY->at(index) << ")" << endl;
   }
 }

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -701,7 +701,7 @@ void RooHist::printMultiline(ostream& os, Int_t contents, Bool_t verbose, TStrin
     os << indent << "  Errors calculated at" << _nSigma << "-sigma CL" << endl;
     os << indent << "  Bin Contents:" << endl;
     for(Int_t i= 0; i < n; i++) {
-      os << indent << setw(3) << i << ") x= " <<  fX[i];
+      os << indent << setw(3) << i << ") x= " <<  fX->at(i);
       if(fEXhigh[i] > 0 || fEXlow[i] > 0) {
    os << " +" << fEXhigh[i] << " -" << fEXlow[i];
       }

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -705,7 +705,7 @@ void RooHist::printMultiline(ostream& os, Int_t contents, Bool_t verbose, TStrin
       if(fEXhigh[i] > 0 || fEXlow[i] > 0) {
    os << " +" << fEXhigh[i] << " -" << fEXlow[i];
       }
-      os << " , y = " << fY[i] << " +" << fEYhigh[i] << " -" << fEYlow[i] << endl;
+      os << " , y = " << fY->at(i) << " +" << fEYhigh[i] << " -" << fEYlow[i] << endl;
     }
   }
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
This is a proof of concept to refactor the TGraph class to use C++ Standard Library smart pointers to user-provided arrays.

The main benefits are less memory usage because the data is not copied, and faster constructing of TGraph objects. Having this as an option does change the behaviour of the TGraph class a little; but that trade-off may be worth it for memory constrained local machines or time/memory constrained HPC jobs with large data sets.

At least a few more changes are necessary: 1) by default, TGraph constructors should still copy array data so that installed code is backwards-compatible, and 2) writing a TGraph to a ROOT file would need an updated dictionary.

## Checklist:

- [X ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

