### PR TITLE
Fix compilation errors with the `/permissive-` compiler flag on Windo…

### DIFF
--- a/graf2d/win32gdk/src/TGWin32.cxx
+++ b/graf2d/win32gdk/src/TGWin32.cxx
@@ -2687,7 +2687,7 @@ void TGWin32::RescaleWindow(int wid, unsigned int w, unsigned int h)
                                        w, h, gdk_visual_get_best_depth());
       }
       for (i = 0; i < kMAXGC; i++) {
-         gdk_gc_set_clip_mask(gGClist[i], None);
+         gdk_gc_set_clip_mask(gGClist[i], (GdkBitmap *)None);
       }
       SetColor(gGCpxmp, 0);
       gdk_win32_draw_rectangle(gTws->buffer, gGCpxmp, 1, 0, 0, w, h);
@@ -3052,7 +3052,7 @@ void TGWin32::SetDoubleBufferON()
       SetColor(gGCpxmp, 1);
    }
    for (int i = 0; i < kMAXGC; i++) {
-      gdk_gc_set_clip_mask(gGClist[i], None);
+      gdk_gc_set_clip_mask(gGClist[i], (GdkBitmap *)None);
    }
    gTws->double_buffer = 1;
    gTws->drawing = gTws->buffer;

--- a/gui/gui/src/TGFileDialog.cxx
+++ b/gui/gui/src/TGFileDialog.cxx
@@ -387,7 +387,7 @@ TGFileDialog::TGFileDialog(const TGWindow *p, const TGWindow *main,
 TGFileDialog::~TGFileDialog()
 {
    if (IsZombie()) return;
-   TString str = fCheckB ? fCheckB->GetString() : "";
+   TString str = fCheckB ? fCheckB->GetString() : (TString)"";
    if (str.Contains("Multiple") && fCheckB)
       fCheckB->Disconnect("Toggled(Bool_t)");
    fClient->FreePicture(fPcdup);

--- a/gui/gui/src/TGFileDialog.cxx
+++ b/gui/gui/src/TGFileDialog.cxx
@@ -387,7 +387,7 @@ TGFileDialog::TGFileDialog(const TGWindow *p, const TGWindow *main,
 TGFileDialog::~TGFileDialog()
 {
    if (IsZombie()) return;
-   TString str = fCheckB ? fCheckB->GetString() : (TString)"";
+   TString str = fCheckB ? fCheckB->GetString() : TString();
    if (str.Contains("Multiple") && fCheckB)
       fCheckB->Disconnect("Toggled(Bool_t)");
    fClient->FreePicture(fPcdup);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -465,7 +465,7 @@ public:
    }
    virtual TString  GetExpFormula(Option_t *option = "") const
    {
-      return (fFormula) ? fFormula->GetExpFormula(option) : (TString)"";
+      return (fFormula) ? fFormula->GetExpFormula(option) : TString();
    }
    virtual const TObject *GetLinearPart(Int_t i) const
    {

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -465,7 +465,7 @@ public:
    }
    virtual TString  GetExpFormula(Option_t *option = "") const
    {
-      return (fFormula) ? fFormula->GetExpFormula(option) : "";
+      return (fFormula) ? fFormula->GetExpFormula(option) : (TString)"";
    }
    virtual const TObject *GetLinearPart(Int_t i) const
    {

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3125,7 +3125,7 @@ TH1 *TH1::DrawCopy(Option_t *option, const char * name_postfix) const
    TString opt = option;
    opt.ToLower();
    if (gPad && !opt.Contains("same")) gPad->Clear();
-   TString newName = (name_postfix) ? TString::Format("%s%s",GetName(),name_postfix) : TString();
+   TString newName = (name_postfix) ? TString::Format("%s%s", GetName(), name_postfix) : TString();
    TH1 *newth1 = (TH1 *)Clone(newName);
    newth1->SetDirectory(0);
    newth1->SetBit(kCanDelete);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3125,7 +3125,7 @@ TH1 *TH1::DrawCopy(Option_t *option, const char * name_postfix) const
    TString opt = option;
    opt.ToLower();
    if (gPad && !opt.Contains("same")) gPad->Clear();
-   TString newName = (name_postfix) ?  TString::Format("%s%s",GetName(),name_postfix) : TString();
+   TString newName = (name_postfix) ? TString::Format("%s%s",GetName(),name_postfix) : TString();
    TH1 *newth1 = (TH1 *)Clone(newName);
    newth1->SetDirectory(0);
    newth1->SetBit(kCanDelete);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3125,7 +3125,7 @@ TH1 *TH1::DrawCopy(Option_t *option, const char * name_postfix) const
    TString opt = option;
    opt.ToLower();
    if (gPad && !opt.Contains("same")) gPad->Clear();
-   TString newName = (name_postfix) ?  TString::Format("%s%s",GetName(),name_postfix) : (TString)"";
+   TString newName = (name_postfix) ?  TString::Format("%s%s",GetName(),name_postfix) : TString();
    TH1 *newth1 = (TH1 *)Clone(newName);
    newth1->SetDirectory(0);
    newth1->SetBit(kCanDelete);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -3125,7 +3125,7 @@ TH1 *TH1::DrawCopy(Option_t *option, const char * name_postfix) const
    TString opt = option;
    opt.ToLower();
    if (gPad && !opt.Contains("same")) gPad->Clear();
-   TString newName = (name_postfix) ?  TString::Format("%s%s",GetName(),name_postfix) : "";
+   TString newName = (name_postfix) ?  TString::Format("%s%s",GetName(),name_postfix) : (TString)"";
    TH1 *newth1 = (TH1 *)Clone(newName);
    newth1->SetDirectory(0);
    newth1->SetBit(kCanDelete);


### PR DESCRIPTION
…ws. Resolves #9607

Fix the following compilation errors when using the `/permissive-` compiler flag:
```
  hist\hist\inc\TF1.h(463,1): error C2445: result type of conditional expression is ambiguous: types 'TString' and 'const char [1]' can be converted to multiple common types
      hist\hist\inc\TF1.h(463,1): message : could be 'TString'
      hist\hist\inc\TF1.h(463,1): message : or       'const char *'

  hist\hist\src\TH1.cxx(3128,91): error C2445: result type of conditional expression is ambiguous: types 'TString' and 'const char [1]' can be converted to multiple common types
      hist\hist\src\TH1.cxx(3128,91): message : could be 'TString'
      hist\hist\src\TH1.cxx(3128,91): message : or       'const char *'

  gui\gui\src\TGFileDialog.cxx(390,53): error C2445: result type of conditional expression is ambiguous: types 'TString' and 'const char [1]' can be converted to multiple common types
      gui\gui\src\TGFileDialog.cxx(390,53): message : could be 'TString'
      gui\gui\src\TGFileDialog.cxx(390,53): message : or       'const char *'

  graf2d\win32gdk\src\TGWin32.cxx(2690,47): error C2664: 'void gdk_gc_set_clip_mask(GdkGC *,GdkBitmap *)': cannot convert argument 2 from 'const unsigned long' to 'GdkBitmap *'
  graf2d\win32gdk\src\TGWin32.cxx(3055,44): error C2664: 'void gdk_gc_set_clip_mask(GdkGC *,GdkBitmap *)': cannot convert argument 2 from 'const unsigned long' to 'GdkBitmap *'
```
