### PR TITLE
TStreamerInfo::New needs to use the CollectionProxy::New

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -4804,7 +4804,10 @@ void* TStreamerInfo::New(void *obj)
                // missing information, avoid infinite loop
                // by doing nothing ....
             } else {
-               cle->New(eaddr);
+               if (cle->GetCollectionProxy())
+                  cle->GetCollectionProxy()->New(eaddr);
+               else
+                  cle->New(eaddr);
             }
          }
          break;


### PR DESCRIPTION
This fixes issue #9543

In the issue #9543, the unusual situation is the combination of:

* there is (intentionally) no dictionary for `std::map<int,std::vector<int>>`
* consequently we use an "emulated collection proxy" for that collection
* there is (unintentional due to external config) interpreter information/ClassInfo for `std::map<int,std::vector<int>>`

The crux of the issue #9543 is:

* TClass::fSizeof info prefers the information from the CollectionProxy
* TStreamerInfo::fSize is set to the value of TClass::fSizeOf
* TClass:New prefers the constructor from the interpreter
* TStreamerInfo::New was using TClass::New for that case
* On the failing platform, the `sizeof(std::map<int,std::vector<int>>)` is larger than the size of the emulated collection.

Since the I/O and TStreamerInfo uses the TCollection proxy and all of TStreamerInfo needs to prefer the information from the collection proxy (including the 'sizeof').  To fix #9543 the solution is for
* TStremearInfo::New to prefer/use TCollectionProxy::New over TClass::New (i.e. the interpreted constructor in this particular case).
