### PR TITLE
[clang] Do not assume uniqueness of ODRHash:

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/AST/DeclTemplate.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/AST/DeclTemplate.cpp
@@ -207,6 +207,7 @@ Decl *RedeclarableTemplateDecl::loadLazySpecializationImpl(
   uint32_t ID = LazySpecInfo.DeclID;
   assert(ID && "Loading already loaded specialization!");
   // Note that we loaded the specialization.
+  // FIXME: consider removing entry from Specs.
   LazySpecInfo.DeclID = LazySpecInfo.ODRHash = LazySpecInfo.IsPartial = 0;
   return getASTContext().getExternalSource()->GetExternalDecl(ID);
 }
@@ -247,15 +248,16 @@ void RedeclarableTemplateDecl::addSpecializationImpl(
   using SETraits = SpecEntryTraits<EntryType>;
 
   if (InsertPos) {
-#ifndef NDEBUG
-    auto Args = SETraits::getTemplateArgs(Entry);
-    assert(!loadLazySpecializationsImpl(Args) &&
-           "Specialization is already registered as lazy");
-    void *CorrectInsertPos;
-    assert(!findSpecializationImpl(Specializations, Args, CorrectInsertPos) &&
-           InsertPos == CorrectInsertPos &&
-           "given incorrect InsertPos for specialization");
-#endif
+// This won't work as ODRHash isn't unique.
+//#ifndef NDEBUG
+//    auto Args = SETraits::getTemplateArgs(Entry);
+//    assert(!loadLazySpecializationsImpl(Args) &&
+//           "Specialization is already registered as lazy");
+//    void *CorrectInsertPos;
+//    assert(!findSpecializationImpl(Specializations, Args, CorrectInsertPos) &&
+//           InsertPos == CorrectInsertPos &&
+//           "given incorrect InsertPos for specialization");
+//#endif
     Specializations.InsertNode(Entry, InsertPos);
   } else {
     EntryType *Existing = Specializations.GetOrInsertNode(Entry);


### PR DESCRIPTION
When registering a new specialization, we cannot assert that the
specialization is new, as in: has not been registered as a loadable
specialization before, at least not based on the ODRHash.

The ODRHash is not unique for different types (hash collision), i.e.
different specialization template arguments might map to the same
ODRHash value. loadLazySpecializationsImpl() will thus load something,
and claim that the "Specialization is already registered as lazy",
but it will in fact be an unrelated specialization.

Give up on asserting any of this.

NOTE: it is unclear whether the ambiguity in which specialization will
be loaded is causing problems down the road; so far we have not observed
such problems in the wild. If so, the ODRHash must not be the lookup key,
but a mere lookup hint into a multimap or similar, where the search compares
the actual template arguments to identify which lazy specialization to load.

Based on discussion with Vassil (and in turn Richard Smith).

This fixes e.g.
```
roottest/cling/threading/clinglock.C...
Assertion failed: (!loadLazySpecializationsImpl(Args) && "Specialization is already registered as lazy"), function addSpecializationImpl, file /Users/sftnight/build/workspace/root-pullrequests-build/root/interpreter/llvm/src/tools/clang/lib/AST/DeclTemplate.cpp, line 253.
```
on macOS 11.
