### PR TITLE
Translate some `ROOT::Fit` tutorials referenced in the manual to Python

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -682,6 +682,7 @@ if(ROOT_pyroot_FOUND)
   # and add it to the list "fixtureLists" below.
   file(GLOB requires_numpy   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
       dataframe/df026_AsNumpyArrays.py
+      fit/combinedFit.py
       fit/multifit.py
       roofit/rf409_NumPyPandasToRooFit.py)
   file(GLOB requires_numba   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} pyroot/pyroot004_NumbaDeclare.py)

--- a/tutorials/fit/FitHistoInFile.C
+++ b/tutorials/fit/FitHistoInFile.C
@@ -90,7 +90,7 @@ void FitRoutine(TCanvas* c1, TH1* histo, float fitxmin, float fitxmax, TString f
 
    const double binwidth = histo->GetXaxis()->GetBinWidth(1);
    const double integral = signalFcn.Integral(0.,3.);
-   cout << "number of signal events = " << integral/binwidth << " " << binwidth<< endl;
+   std::cout << "number of signal events = " << integral/binwidth << " " << binwidth<< std::endl;
 
    // draw the legend
    TLegend legend(0.15,0.7,0.28,0.85);
@@ -138,7 +138,7 @@ void FitHistoInFile() {
    TH1D* histo= nullptr;
    f->GetObject("histo",histo);
    if (!histo){
-      cout << "histo not found"<<endl;
+      std::cout << "histo not found" << std::endl;
       return;
    }
    histo->SetMarkerStyle(21);

--- a/tutorials/fit/TestBinomial.C
+++ b/tutorials/fit/TestBinomial.C
@@ -35,17 +35,22 @@
 ///
 /// \author Rene Brun
 
-#include "TBinomialEfficiencyFitter.h"
-#include "TVirtualFitter.h"
-#include "TH1.h"
-#include "TRandom3.h"
-#include "TF1.h"
-#include "TFitResult.h"
-#include "TStyle.h"
-#include "TCanvas.h"
-#include "TLegend.h"
-#include "TPaveStats.h"
-#include "Math/IntegratorOptions.h"
+#include <TBinomialEfficiencyFitter.h>
+#include <TVirtualFitter.h>
+#include <TH1.h>
+#include <TRandom3.h>
+#include <TF1.h>
+#include <TFitResult.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <TPaveStats.h>
+#include <TGraphErrors.h>
+#include <TObjArray.h>
+#include <HFitInterface.h>
+#include <Fit/BinData.h>
+#include <Math/IntegratorOptions.h>
+
 #include <cassert>
 #include <iostream>
 

--- a/tutorials/fit/combinedFit.C
+++ b/tutorials/fit/combinedFit.C
@@ -15,86 +15,88 @@
 ///
 /// \author Lorenzo Moneta
 
-#include "Fit/Fitter.h"
-#include "Fit/BinData.h"
-#include "Fit/Chi2FCN.h"
-#include "TH1.h"
-#include "TList.h"
-#include "Math/WrappedMultiTF1.h"
-#include "HFitInterface.h"
-#include "TCanvas.h"
-#include "TStyle.h"
-
+#include <Fit/Fitter.h>
+#include <Fit/BinData.h>
+#include <Fit/Chi2FCN.h>
+#include <TH1.h>
+#include <Math/WrappedMultiTF1.h>
+#include <HFitInterface.h>
+#include <TCanvas.h>
+#include <TStyle.h>
 
 // definition of shared parameter
 // background function
-int iparB[2] = { 0,      // exp amplitude in B histo
-                 2    // exp common parameter
+int iparB[2] = {
+   0, // exp amplitude in B histo
+   2  // exp common parameter
 };
 
 // signal + background function
-int iparSB[5] = { 1, // exp amplitude in S+B histo
-                  2, // exp common parameter
-                  3, // Gaussian amplitude
-                  4, // Gaussian mean
-                  5  // Gaussian sigma
+int iparSB[5] = {
+   1, // exp amplitude in S+B histo
+   2, // exp common parameter
+   3, // Gaussian amplitude
+   4, // Gaussian mean
+   5  // Gaussian sigma
 };
 
 // Create the GlobalCHi2 structure
 
 struct GlobalChi2 {
-   GlobalChi2(  ROOT::Math::IMultiGenFunction & f1,
-                ROOT::Math::IMultiGenFunction & f2) :
-      fChi2_1(&f1), fChi2_2(&f2) {}
+   GlobalChi2(ROOT::Math::IMultiGenFunction &f1, ROOT::Math::IMultiGenFunction &f2) : fChi2_1(&f1), fChi2_2(&f2) {}
 
    // parameter vector is first background (in common 1 and 2)
    // and then is signal (only in 2)
-   double operator() (const double *par) const {
+   double operator()(const double *par) const
+   {
       double p1[2];
-      for (int i = 0; i < 2; ++i) p1[i] = par[iparB[i] ];
+      for (int i = 0; i < 2; ++i)
+         p1[i] = par[iparB[i]];
 
       double p2[5];
-      for (int i = 0; i < 5; ++i) p2[i] = par[iparSB[i] ];
+      for (int i = 0; i < 5; ++i)
+         p2[i] = par[iparSB[i]];
 
       return (*fChi2_1)(p1) + (*fChi2_2)(p2);
    }
 
-   const  ROOT::Math::IMultiGenFunction * fChi2_1;
-   const  ROOT::Math::IMultiGenFunction * fChi2_2;
+   const ROOT::Math::IMultiGenFunction *fChi2_1;
+   const ROOT::Math::IMultiGenFunction *fChi2_2;
 };
 
-void combinedFit() {
+void combinedFit()
+{
 
-   TH1D * hB = new TH1D("hB","histo B",100,0,100);
-   TH1D * hSB = new TH1D("hSB","histo S+B",100, 0,100);
+   TH1D *hB = new TH1D("hB", "histo B", 100, 0, 100);
+   TH1D *hSB = new TH1D("hSB", "histo S+B", 100, 0, 100);
 
-   TF1 * fB = new TF1("fB","expo",0,100);
-   fB->SetParameters(1,-0.05);
+   TF1 *fB = new TF1("fB", "expo", 0, 100);
+   fB->SetParameters(1, -0.05);
    hB->FillRandom("fB");
 
-   TF1 * fS = new TF1("fS","gaus",0,100);
-   fS->SetParameters(1,30,5);
+   TF1 *fS = new TF1("fS", "gaus", 0, 100);
+   fS->SetParameters(1, 30, 5);
 
-   hSB->FillRandom("fB",2000);
-   hSB->FillRandom("fS",1000);
+   hSB->FillRandom("fB", 2000);
+   hSB->FillRandom("fS", 1000);
 
    // perform now global fit
 
-   TF1 * fSB = new TF1("fSB","expo + gaus(2)",0,100);
+   TF1 *fSB = new TF1("fSB", "expo + gaus(2)", 0, 100);
 
-   ROOT::Math::WrappedMultiTF1 wfB(*fB,1);
-   ROOT::Math::WrappedMultiTF1 wfSB(*fSB,1);
+   ROOT::Math::WrappedMultiTF1 wfB(*fB, 1);
+   ROOT::Math::WrappedMultiTF1 wfSB(*fSB, 1);
 
    ROOT::Fit::DataOptions opt;
    ROOT::Fit::DataRange rangeB;
    // set the data range
-   rangeB.SetRange(10,90);
-   ROOT::Fit::BinData dataB(opt,rangeB);
+   rangeB.SetRange(10, 90);
+   ROOT::Fit::BinData dataB(opt, rangeB);
    ROOT::Fit::FillData(dataB, hB);
 
    ROOT::Fit::DataRange rangeSB;
-   rangeSB.SetRange(10,50);
-   ROOT::Fit::BinData dataSB(opt,rangeSB);
+   rangeSB.SetRange(10, 50);
+   ROOT::Fit::BinData dataSB(opt, rangeSB);
    ROOT::Fit::FillData(dataSB, hSB);
 
    ROOT::Fit::Chi2Function chi2_B(dataB, wfB);
@@ -105,44 +107,41 @@ void combinedFit() {
    ROOT::Fit::Fitter fitter;
 
    const int Npar = 6;
-   double par0[Npar] = { 5,5,-0.1,100, 30,10};
+   double par0[Npar] = {5, 5, -0.1, 100, 30, 10};
 
    // create before the parameter settings in order to fix or set range on them
-   fitter.Config().SetParamsSettings(6,par0);
+   fitter.Config().SetParamsSettings(6, par0);
    // fix 5-th parameter
    fitter.Config().ParSettings(4).Fix();
    // set limits on the third and 4-th parameter
-   fitter.Config().ParSettings(2).SetLimits(-10,-1.E-4);
-   fitter.Config().ParSettings(3).SetLimits(0,10000);
+   fitter.Config().ParSettings(2).SetLimits(-10, -1.E-4);
+   fitter.Config().ParSettings(3).SetLimits(0, 10000);
    fitter.Config().ParSettings(3).SetStepSize(5);
 
    fitter.Config().MinimizerOptions().SetPrintLevel(0);
-   fitter.Config().SetMinimizer("Minuit2","Migrad");
+   fitter.Config().SetMinimizer("Minuit2", "Migrad");
 
    // fit FCN function directly
    // (specify optionally data size and flag to indicate that is a chi2 fit)
-   fitter.FitFCN(6,globalChi2,0,dataB.Size()+dataSB.Size(),true);
+   fitter.FitFCN(6, globalChi2, 0, dataB.Size() + dataSB.Size(), true);
    ROOT::Fit::FitResult result = fitter.Result();
    result.Print(std::cout);
 
-   TCanvas * c1 = new TCanvas("Simfit","Simultaneous fit of two histograms",
-                              10,10,700,700);
-   c1->Divide(1,2);
+   TCanvas *c1 = new TCanvas("Simfit", "Simultaneous fit of two histograms", 10, 10, 700, 700);
+   c1->Divide(1, 2);
    c1->cd(1);
    gStyle->SetOptFit(1111);
 
-   fB->SetFitResult( result, iparB);
+   fB->SetFitResult(result, iparB);
    fB->SetRange(rangeB().first, rangeB().second);
    fB->SetLineColor(kBlue);
    hB->GetListOfFunctions()->Add(fB);
    hB->Draw();
 
    c1->cd(2);
-   fSB->SetFitResult( result, iparSB);
+   fSB->SetFitResult(result, iparSB);
    fSB->SetRange(rangeSB().first, rangeSB().second);
    fSB->SetLineColor(kRed);
    hSB->GetListOfFunctions()->Add(fSB);
    hSB->Draw();
-
-
 }

--- a/tutorials/fit/combinedFit.py
+++ b/tutorials/fit/combinedFit.py
@@ -1,0 +1,135 @@
+## \file
+## \ingroup tutorial_fit
+## \notebook
+## Combined (simultaneous) fit of two histogram with separate functions
+## and some common parameters
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \author Jonas Rembser, Lorenzo Moneta (C++ version)
+
+
+import ROOT
+import numpy as np
+
+
+# definition of shared parameter background function
+iparB = np.array([0, 2], dtype=np.int32)  # exp amplitude in B histo and exp common parameter
+
+# signal + background function
+iparSB = np.array(
+    [
+        1,  # exp amplitude in S+B histo
+        2,  # exp common parameter
+        3,  # Gaussian amplitude
+        4,  # Gaussian mean
+        5,  # Gaussian sigma
+    ],
+    dtype=np.int32,
+)
+
+# Create the GlobalCHi2 structure
+
+class GlobalChi2(object):
+    def __init__(self, f1, f2):
+        self._f1 = f1
+        self._f2 = f2
+
+    def __call__(self, par):
+        # parameter vector is first background (in common 1 and 2) and then is
+        # signal (only in 2)
+
+        # the zero-copy way to get a numpy array from a double *
+        par_arr = np.frombuffer(par, dtype=np.float64, count=6)
+
+        p1 = par_arr[iparB]
+        p2 = par_arr[iparSB]
+
+        return self._f1(p1) + self._f2(p2)
+
+
+hB = ROOT.TH1D("hB", "histo B", 100, 0, 100)
+hSB = ROOT.TH1D("hSB", "histo S+B", 100, 0, 100)
+
+fB = ROOT.TF1("fB", "expo", 0, 100)
+fB.SetParameters(1, -0.05)
+hB.FillRandom("fB")
+
+fS = ROOT.TF1("fS", "gaus", 0, 100)
+fS.SetParameters(1, 30, 5)
+
+hSB.FillRandom("fB", 2000)
+hSB.FillRandom("fS", 1000)
+
+# perform now global fit
+
+fSB = ROOT.TF1("fSB", "expo + gaus(2)", 0, 100)
+
+wfB = ROOT.Math.WrappedMultiTF1(fB, 1)
+wfSB = ROOT.Math.WrappedMultiTF1(fSB, 1)
+
+opt = ROOT.Fit.DataOptions()
+rangeB = ROOT.Fit.DataRange()
+# set the data range
+rangeB.SetRange(10, 90)
+dataB = ROOT.Fit.BinData(opt, rangeB)
+ROOT.Fit.FillData(dataB, hB)
+
+rangeSB = ROOT.Fit.DataRange()
+rangeSB.SetRange(10, 50)
+dataSB = ROOT.Fit.BinData(opt, rangeSB)
+ROOT.Fit.FillData(dataSB, hSB)
+
+chi2_B = ROOT.Fit.Chi2Function(dataB, wfB)
+chi2_SB = ROOT.Fit.Chi2Function(dataSB, wfSB)
+
+globalChi2 = GlobalChi2(chi2_B, chi2_SB)
+
+fitter = ROOT.Fit.Fitter()
+
+Npar = 6
+par0 = np.array([5, 5, -0.1, 100, 30, 10])
+
+# create before the parameter settings in order to fix or set range on them
+fitter.Config().SetParamsSettings(6, par0)
+# fix 5-th parameter
+fitter.Config().ParSettings(4).Fix()
+# set limits on the third and 4-th parameter
+fitter.Config().ParSettings(2).SetLimits(-10, -1.0e-4)
+fitter.Config().ParSettings(3).SetLimits(0, 10000)
+fitter.Config().ParSettings(3).SetStepSize(5)
+
+fitter.Config().MinimizerOptions().SetPrintLevel(0)
+fitter.Config().SetMinimizer("Minuit2", "Migrad")
+
+# we can't pass the Python object globalChi2 directly to FitFCN.
+# It needs to be wrapped in a ROOT::Math::Functor.
+globalChi2Functor = ROOT.Math.Functor(globalChi2, 6)
+
+# fit FCN function
+# (specify optionally data size and flag to indicate that is a chi2 fit)
+fitter.FitFCN(globalChi2Functor, 0, dataB.Size() + dataSB.Size(), True)
+result = fitter.Result()
+result.Print(ROOT.std.cout)
+
+c1 = ROOT.TCanvas("Simfit", "Simultaneous fit of two histograms", 10, 10, 700, 700)
+c1.Divide(1, 2)
+c1.cd(1)
+ROOT.gStyle.SetOptFit(1111)
+
+fB.SetFitResult(result, iparB)
+fB.SetRange(rangeB().first, rangeB().second)
+fB.SetLineColor(ROOT.kBlue)
+hB.GetListOfFunctions().Add(fB)
+hB.Draw()
+
+c1.cd(2)
+fSB.SetFitResult(result, iparSB)
+fSB.SetRange(rangeSB().first, rangeSB().second)
+fSB.SetLineColor(ROOT.kRed)
+hSB.GetListOfFunctions().Add(fSB)
+hSB.Draw()
+
+c1.SaveAs("combinedFit.png")

--- a/tutorials/fit/fit2d.C
+++ b/tutorials/fit/fit2d.C
@@ -9,6 +9,12 @@
 ///
 /// \author Rene Brun
 
+#include <TCanvas.h>
+#include <TCutG.h>
+#include <TH2F.h>
+#include <TProfile.h>
+#include <TRandom.h>
+
 void fit2d()
 {
    // generate a 2-d histogram using a TCutG

--- a/tutorials/fit/fitExclude.C
+++ b/tutorials/fit/fitExclude.C
@@ -9,9 +9,9 @@
 ///
 /// \author Rene Brun
 
-#include "TH1.h"
-#include "TF1.h"
-#include "TList.h"
+#include <TH1.h>
+#include <TF1.h>
+#include <TROOT.h>
 
 bool reject;
 double fline(double *x, double *par)

--- a/tutorials/fit/fitNormSum.C
+++ b/tutorials/fit/fitNormSum.C
@@ -20,83 +20,82 @@
 ///
 /// \author Lorenzo Moneta
 
-#include <TMath.h>
+#include <Math/MinimizerOptions.h>
 #include <TCanvas.h>
-#include <TF1NormSum.h>
 #include <TF1.h>
+#include <TF1NormSum.h>
+#include <TFitResult.h>
 #include <TH1.h>
-
-
-using namespace std;
-
+#include <TLatex.h>
+#include <TMath.h>
+#include <TStopwatch.h>
+#include <TStyle.h>
 
 void fitNormSum()
 {
    const int nsig = 5.E4;
    const int nbkg = 1.e6;
-   int NEvents = nsig+nbkg;
-   int NBins   = 1e3;
+   int nEvents = nsig + nbkg;
+   int nBins = 1e3;
 
    double signal_mean = 3;
-   TF1 *f_cb    = new TF1("MyCrystalBall","crystalball",-5.,5.);
-   TF1 *f_exp   = new TF1("MyExponential","expo",-5.,5.);
+   TF1 *f_cb = new TF1("MyCrystalBall", "crystalball", -5., 5.);
+   TF1 *f_exp = new TF1("MyExponential", "expo", -5., 5.);
 
    // I.:
-   f_exp-> SetParameters(1.,-0.3);
-   f_cb -> SetParameters(1,signal_mean,0.3,2,1.5);
+   f_exp->SetParameters(1., -0.3);
+   f_cb->SetParameters(1, signal_mean, 0.3, 2, 1.5);
 
    // CONSTRUCTION OF THE TF1NORMSUM OBJECT ........................................
    // 1) :
-   TF1NormSum *fnorm_exp_cb = new TF1NormSum(f_cb,f_exp,nsig,nbkg);
+   TF1NormSum *fnorm_exp_cb = new TF1NormSum(f_cb, f_exp, nsig, nbkg);
    // 4) :
 
-   TF1   * f_sum = new TF1("fsum", *fnorm_exp_cb, -5., 5., fnorm_exp_cb->GetNpar());
-   f_sum->Draw();
+   TF1 *f_sum = new TF1("fsum", *fnorm_exp_cb, -5., 5., fnorm_exp_cb->GetNpar());
 
    // III.:
-   f_sum->SetParameters( fnorm_exp_cb->GetParameters().data() );
-   f_sum->SetParName(1,"NBackground");
-   f_sum->SetParName(0,"NSignal");
+   f_sum->SetParameters(fnorm_exp_cb->GetParameters().data());
+   f_sum->SetParName(1, "NBackground");
+   f_sum->SetParName(0, "NSignal");
    for (int i = 2; i < f_sum->GetNpar(); ++i)
-      f_sum->SetParName(i,fnorm_exp_cb->GetParName(i) );
+      f_sum->SetParName(i, fnorm_exp_cb->GetParName(i));
 
    // GENERATE HISTOGRAM TO FIT ..............................................................
    TStopwatch w;
    w.Start();
-   TH1D *h_sum = new TH1D("h_ExpCB", "Exponential Bkg + CrystalBall function", NBins, -5., 5.);
-   for (int i=0; i<NEvents; i++)
-   {
-      h_sum -> Fill(f_sum -> GetRandom());
-   }
-   printf("Time to generate %d events:  ",NEvents);
+   TH1D *h_sum = new TH1D("h_ExpCB", "Exponential Bkg + CrystalBall function", nBins, -5., 5.);
+   h_sum->FillRandom("fsum", nEvents);
+   printf("Time to generate %d events:  ", nEvents);
    w.Print();
-   //TH1F *h_orig = new TH1F(*h_sum);
 
    // need to scale histogram with width since we are fitting a density
-   h_sum -> Sumw2();
-   h_sum -> Scale(1., "width");
+   h_sum->Sumw2();
+   h_sum->Scale(1., "width");
 
-   //fit - use Minuit2 if available
+   // fit - use Minuit2 if available
    ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2");
-   new TCanvas("Fit","Fit",800,1000);
+   new TCanvas("Fit", "Fit", 800, 1000);
    // do a least-square fit of the spectrum
-   auto result = h_sum -> Fit("fsum","SQ");
+   auto result = h_sum->Fit("fsum", "SQ");
    result->Print();
-   h_sum -> Draw();
+   h_sum->Draw();
    printf("Time to fit using ROOT TF1Normsum: ");
    w.Print();
 
    // test if parameters are fine
-   std::vector<double>  pref = {nsig, nbkg, signal_mean};
-   for (unsigned int i = 0; i< pref.size(); ++i)  {
-      if (!TMath::AreEqualAbs(pref[i], f_sum->GetParameter(i), f_sum->GetParError(i)*10.) )
-         Error("testFitNormSum","Difference found in fitted %s - difference is %g sigma",f_sum->GetParName(i), (f_sum->GetParameter(i)-pref[i])/f_sum->GetParError(i));
+   std::vector<double> pref = {nsig, nbkg, signal_mean};
+   for (unsigned int i = 0; i < pref.size(); ++i) {
+      if (!TMath::AreEqualAbs(pref[i], f_sum->GetParameter(i), f_sum->GetParError(i) * 10.))
+         Error("testFitNormSum", "Difference found in fitted %s - difference is %g sigma", f_sum->GetParName(i),
+               (f_sum->GetParameter(i) - pref[i]) / f_sum->GetParError(i));
    }
 
    gStyle->SetOptStat(0);
    // add parameters
-   auto t1 = new TLatex(-2.5, 300000, TString::Format("%s = %8.0f #pm %4.0f", "NSignal",f_sum->GetParameter(0), f_sum->GetParError(0) ) );
-   auto t2 = new TLatex(-2.5, 270000, TString::Format("%s = %8.0f #pm %4.0f", "Nbackgr",f_sum->GetParameter(1), f_sum->GetParError(1) ) );
+   auto t1 = new TLatex(
+      -2.5, 300000, TString::Format("%s = %8.0f #pm %4.0f", "NSignal", f_sum->GetParameter(0), f_sum->GetParError(0)));
+   auto t2 = new TLatex(
+      -2.5, 270000, TString::Format("%s = %8.0f #pm %4.0f", "Nbackgr", f_sum->GetParameter(1), f_sum->GetParError(1)));
    t1->Draw();
    t2->Draw();
 }

--- a/tutorials/fit/fitNormSum.py
+++ b/tutorials/fit/fitNormSum.py
@@ -1,0 +1,100 @@
+## \file
+## \ingroup tutorial_fit
+## \notebook
+## Tutorial for normalized sum of two functions
+## Here: a background exponential and a crystalball function
+## Parameters can be set:
+##  1.   with the TF1 object before adding the function (for 3) and 4))
+##  2.  with the TF1NormSum object (first two are the coefficients, then the non constant parameters)
+##  3. with the TF1 object after adding the function
+##
+## Sum can be constructed by:
+##  1. by a string containing the names of the functions and/or the coefficient in front
+##  2. by a string containg formulas like expo, gaus...
+##  3. by the list of functions and coefficients (which are 1 by default)
+##  4. by a std::vector for functions and coefficients
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \author Jonas Rembser, Lorenzo Moneta (C++ version)
+
+import ROOT
+
+nsig = 50000
+nbkg = 1000000
+nEvents = nsig + nbkg
+nBins = 1000
+
+signal_mean = 3.0
+f_cb = ROOT.TF1("MyCrystalBall", "crystalball", -5.0, 5.0)
+f_exp = ROOT.TF1("MyExponential", "expo", -5.0, 5.0)
+
+# I.:
+f_exp.SetParameters(1.0, -0.3)
+f_cb.SetParameters(1, signal_mean, 0.3, 2, 1.5)
+
+# CONSTRUCTION OF THE TF1NORMSUM OBJECT ........................................
+# 1) :
+fnorm_exp_cb = ROOT.TF1NormSum(f_cb, f_exp, nsig, nbkg)
+# 4) :
+
+f_sum = ROOT.TF1("fsum", fnorm_exp_cb, -5.0, 5.0, fnorm_exp_cb.GetNpar())
+
+# III.:
+parameter_values = fnorm_exp_cb.GetParameters()
+f_sum.SetParameters(parameter_values.data())
+# Note: in the C++ tutorial, the parameter value sync is done in one line with:
+# ```C++
+#     f_sum->SetParameters(fnorm_exp_cb->GetParameters().data());
+# ```
+# However, TF1NormSum::GetParameters() returns an std::vector by value, which
+# doesn't survive long enough in Python. That's why we have to explicitly
+# assign it to a variable first and can't use a temporary.
+
+f_sum.SetParName(1, "NBackground")
+f_sum.SetParName(0, "NSignal")
+for i in range(2, f_sum.GetNpar()):
+    f_sum.SetParName(i, fnorm_exp_cb.GetParName(i))
+
+# GENERATE HISTOGRAM TO FIT ..............................................................
+w = ROOT.TStopwatch()
+w.Start()
+h_sum = ROOT.TH1D("h_ExpCB", "Exponential Bkg + CrystalBall function", nBins, -5.0, 5.0)
+h_sum.FillRandom("fsum", nEvents)
+print("Time to generate {0} events:  ".format(nEvents))
+w.Print()
+
+# need to scale histogram with width since we are fitting a density
+h_sum.Sumw2()
+h_sum.Scale(1.0, "width")
+
+# fit - use Minuit2 if available
+ROOT.Math.MinimizerOptions.SetDefaultMinimizer("Minuit2")
+c1 = ROOT.TCanvas("Fit", "Fit", 800, 1000)
+# do a least-square fit of the spectrum
+result = h_sum.Fit("fsum", "SQ")
+result.Print()
+h_sum.Draw()
+print("Time to fit using ROOT TF1Normsum: ")
+w.Print()
+
+# test if parameters are fine
+for i, pref in enumerate([nsig, nbkg, signal_mean]):
+    if not ROOT.TMath.AreEqualAbs(pref, f_sum.GetParameter(i), f_sum.GetParError(i) * 10.0):
+        ROOT.Error(
+            "testFitNormSum",
+            "Difference found in fitted {0} - difference is {1:.2f} sigma".format(
+                f_sum.GetParName(i), (f_sum.GetParameter(i) - pref) / f_sum.GetParError(i)
+            ),
+        )
+
+ROOT.gStyle.SetOptStat(0)
+# add parameters
+t1 = ROOT.TLatex(-2.5, 300000, "NSignal = {0:g} #pm {1:g}".format(f_sum.GetParameter(0), f_sum.GetParError(0)))
+t2 = ROOT.TLatex(-2.5, 270000, "Nbackgr = {0:g} #pm {1:g}".format(f_sum.GetParameter(1), f_sum.GetParError(1)))
+t1.Draw()
+t2.Draw()
+
+c1.SaveAs("fitNormSum.png")

--- a/tutorials/fit/fitcont.C
+++ b/tutorials/fit/fitcont.C
@@ -16,7 +16,11 @@
 ///
 /// \author Rene Brun
 
-#include "TMinuit.h"
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TH1F.h>
+#include <TMinuit.h>
+#include <TVirtualFitter.h>
 
 void fitcont()
 {

--- a/tutorials/fit/fithist.C
+++ b/tutorials/fit/fithist.C
@@ -9,6 +9,10 @@
 ///
 /// \author Rene Brun
 
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1F.h>
+
 TH1F *background;
 void histgen() {
    //generate the histogram background and save it to a file

--- a/tutorials/fit/fitpanel_playback.C
+++ b/tutorials/fit/fitpanel_playback.C
@@ -19,7 +19,7 @@
 #include "TRecorder.h"
 #include "Riostream.h"
 
-int file_size(char *filename)
+int file_size(const char *filename)
 {
    FileStat_t fs;
    gSystem->GetPathInfo(filename, fs);
@@ -28,7 +28,7 @@ int file_size(char *filename)
 
 void fitpanel_playback()
 {
-   r = new TRecorder();
+   auto * r = new TRecorder();
    r->Replay("http://root.cern.ch/files/fitpanel_playback.root");
 
    // wait for the recorder to finish the replay
@@ -51,39 +51,39 @@ void fitpanel_playback()
    int Step5_Size   =  file_size("Step5.png");
 
 
-   cout << "**********************************************************************" <<endl;
-   cout << "*  Report of fitpanel_playback.C                                     *" <<endl;
-   cout << "**********************************************************************" <<endl;
+   std::cout << "**********************************************************************" << std::endl;
+   std::cout << "*  Report of fitpanel_playback.C                                     *" << std::endl;
+   std::cout << "**********************************************************************" << std::endl;
 
    if (TMath::Abs(Step1_Ref-Step1_Size) <= Step_Err) {
-      cout << "Step1: ............................................................ OK" <<endl;
+      std::cout << "Step1: ............................................................ OK" << std::endl;
    } else {
-      cout << "Step1: ........................................................ FAILED" <<endl;
+      std::cout << "Step1: ........................................................ FAILED" << std::endl;
    }
 
    if (TMath::Abs(Step2_Ref-Step2_Size) <= Step_Err) {
-      cout << "Step2: ............................................................ OK" <<endl;
+      std::cout << "Step2: ............................................................ OK" << std::endl;
    } else {
-      cout << "Step2: ........................................................ FAILED" <<endl;
+      std::cout << "Step2: ........................................................ FAILED" << std::endl;
    }
 
    if (TMath::Abs(Step3_Ref-Step3_Size) <= Step_Err) {
-      cout << "Step3: ............................................................ OK" <<endl;
+      std::cout << "Step3: ............................................................ OK" << std::endl;
    } else {
-      cout << "Step3: ........................................................ FAILED" <<endl;
+      std::cout << "Step3: ........................................................ FAILED" << std::endl;
    }
 
    if (TMath::Abs(Step4_Ref-Step4_Size) <= Step_Err) {
-      cout << "Step4: ............................................................ OK" <<endl;
+      std::cout << "Step4: ............................................................ OK" << std::endl;
    } else {
-      cout << "Step4: ........................................................ FAILED" <<endl;
+      std::cout << "Step4: ........................................................ FAILED" << std::endl;
    }
 
    if (TMath::Abs(Step5_Ref-Step5_Size) <= Step_Err) {
-      cout << "Step5: ............................................................ OK" <<endl;
+      std::cout << "Step5: ............................................................ OK" << std::endl;
    } else {
-      cout << "Step5: ........................................................ FAILED" <<endl;
+      std::cout << "Step5: ........................................................ FAILED" << std::endl;
    }
-   cout << "**********************************************************************" <<endl;
+   std::cout << "**********************************************************************" << std::endl;
 
 }

--- a/tutorials/fit/fitslicesy.C
+++ b/tutorials/fit/fitslicesy.C
@@ -14,6 +14,12 @@
 ///
 /// \author Rene Brun
 
+#include <TCanvas.h>
+#include <TFile.h>
+#include <TH2F.h>
+#include <TROOT.h>
+#include <TStyle.h>
+
 void fitslicesy() {
 // Change some default parameters in the current style
    gStyle->SetLabelSize(0.06,"x");

--- a/tutorials/fit/line3Dfit.C
+++ b/tutorials/fit/line3Dfit.C
@@ -174,7 +174,3 @@ int line3Dfit()
    l0->Draw("same");
    return 0;
 }
-
-int main() {
-   return line3Dfit();
-}

--- a/tutorials/fit/minuit2GausFit.C
+++ b/tutorials/fit/minuit2GausFit.C
@@ -54,19 +54,19 @@ void testGausFit( std::string type = "Minuit2", int n = 1000) {
    c1->Divide(2,2);
 
    c1->cd(1);
-   cout << "\nDo Fit 1\n";
+   std::cout << "\nDo Fit 1\n";
    h1->Fit("gaus","Q");
    h1->Draw();
    c1->cd(2);
-   cout << "\nDo Fit 2\n";
+   std::cout << "\nDo Fit 2\n";
    h2->Fit("gaus","VE");
    h2->Draw();
    c1->cd(3);
-   cout << "\nDo Fit 3\n";
+   std::cout << "\nDo Fit 3\n";
    h3->Fit("gaus","IE");
    h3->Draw();
    c1->cd(4);
-   cout << "\nDo Fit 4\n";
+   std::cout << "\nDo Fit 4\n";
    h4->Fit("gaus","VLE");
    h4->Draw();
 

--- a/tutorials/fit/multidimfit.C
+++ b/tutorials/fit/multidimfit.C
@@ -156,12 +156,12 @@ int CompareResults(TMultiDimFit *fit, bool doFit)
 int multidimfit(bool doFit = true)
 {
 
-   cout << "*************************************************" << endl;
-   cout << "*             Multidimensional Fit              *" << endl;
-   cout << "*                                               *" << endl;
-   cout << "* By Christian Holm <cholm@nbi.dk> 14/10/00     *" << endl;
-   cout << "*************************************************" << endl;
-   cout << endl;
+   std::cout << "*************************************************" << std::endl;
+   std::cout << "*             Multidimensional Fit              *" << std::endl;
+   std::cout << "*                                               *" << std::endl;
+   std::cout << "* By Christian Holm <cholm@nbi.dk> 14/10/00     *" << std::endl;
+   std::cout << "*************************************************" << std::endl;
+   std::cout << std::endl;
 
    // Initialize global TRannom object.
    gRandom = new TRandom();

--- a/tutorials/fit/myfit.C
+++ b/tutorials/fit/myfit.C
@@ -15,12 +15,21 @@
 ///
 /// \author Rene Brun
 
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TInterpreter.h>
+#include <TROOT.h>
+
+#include <cmath>
+
 double fitf(double *x, double *par)
 {
    double arg = 0;
    if (par[2] != 0) arg = (x[0] - par[1])/par[2];
 
-   double fitval = par[0]*TMath::Exp(-0.5*arg*arg);
+   double fitval = par[0]*std::exp(-0.5*arg*arg);
    return fitval;
 }
 void myfit()

--- a/tutorials/fit/qa2.C
+++ b/tutorials/fit/qa2.C
@@ -9,6 +9,13 @@
 ///
 /// \author Rene Brun
 
+#include <TBenchmark.h>
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFormula.h>
+#include <TH1F.h>
+#include <TPaveLabel.h>
+
 void qa2() {
    //Fill a 1-D histogram from a parametric function
    TCanvas *c1 = new TCanvas("c1","The FillRandom example",0,0,700,500);

--- a/tutorials/fit/vectorizedFit.C
+++ b/tutorials/fit/vectorizedFit.C
@@ -13,6 +13,15 @@
 ///
 /// \author Lorenzo Moneta
 
+#include <Math/MinimizerOptions.h>
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TH1D.h>
+#include <TStopwatch.h>
+#include <TStyle.h>
+
+#include <iostream>
+
 void vectorizedFit() {
 
    gStyle->SetOptFit(111111);


### PR DESCRIPTION
The combinedFit.C tutorial is a good example for the `ROOT::Fitter` functionality, so we also want to have it in Python. The fitNormSum.C tutorial explains a feature that is often asked about in the forum.