### PR TITLE
[core] Solve Streamer function warning in Doxygen and partly expose ClassDef documentation

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -361,8 +361,8 @@ public:                                                                         
    class _NAME2_(name,_c) { public: _NAME2_(name,_c)() { if (name) { } } }
 
 
-#define ClassImpUnique(name,key) \
-   namespace ROOT { \
+#define ClassImpUnique(name,key)                                                                        \
+   namespace ROOT {                                                                                     \
       /** \cond HIDDEN_SYMBOLS */ TGenericClassInfo *GenerateInitInstance(const name*); /** \endcond */ \
       namespace {                                                                                       \
          /** \cond HIDDEN_SYMBOLS */                                                                    \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -263,9 +263,9 @@ class ClassDefGenerateInitInstanceLocalInjector:
 }} // namespace ROOT::Internal
 
 
-// Common part of ClassDef definition, used both by ClassDef and ClassDefInline.
-// DeclFileLine() is not part of it since CINT uses that as trigger for
-// the class comment string.
+// Common part being called both by _ClassDefOutline_ and _ClassDefInline_.
+// DeclFileLine() is not part of it, since Cling uses that as trigger for
+// associating as class title the comment string found right after the macro.
 #define _ClassDefBase_(name, id, virtual_keyword, overrd)                                                       \
 private:                                                                                                        \
    static_assert(std::is_integral<decltype(id)>::value,                                                         \
@@ -296,7 +296,7 @@ public:                                                                         
       ::ROOT::Class_ShowMembers(name::Class(), this, insp);                                                     \
    } /** \endcond */                                                                                            \
    void StreamerNVirtual(TBuffer &ClassDef_StreamerNVirtual_b) { name::Streamer(ClassDef_StreamerNVirtual_b); } \
-   /** \return Name the file containing the class declaration */ static const char *DeclFileName() { return __FILE__; }
+   /** \return Name of the file containing the class declaration */ static const char *DeclFileName() { return __FILE__; }
 
 #define _ClassDefOutline_(name,id, virtual_keyword, overrd)                                                     \
    _ClassDefBase_(name,id, virtual_keyword, overrd)                                                             \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -381,7 +381,7 @@ public:                                                                         
          /** \cond HIDDEN_SYMBOLS */                                        \
          ::ROOT::TGenericClassInfo *GenerateInitInstance(); /** \endcond */ \
          namespace {                                                        \
-            /** \cond HIDDEN_SYMBOLS */
+            /** \cond HIDDEN_SYMBOLS */                                     \
             static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) =              \
                GenerateInitInstance()->SetImplFile(__FILE__, __LINE__);     \
             /** \endcond */                                                 \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -296,7 +296,7 @@ public:                                                                         
       ::ROOT::Class_ShowMembers(name::Class(), this, insp);                                                     \
    } /** \endcond */                                                                                            \
    void StreamerNVirtual(TBuffer &ClassDef_StreamerNVirtual_b) { name::Streamer(ClassDef_StreamerNVirtual_b); } \
-   /** \return Name of the current file */ static const char *DeclFileName() { return __FILE__; }
+   /** \return Name the file containing the class declaration */ static const char *DeclFileName() { return __FILE__; }
 
 #define _ClassDefOutline_(name,id, virtual_keyword, overrd)                                                     \
    _ClassDefBase_(name,id, virtual_keyword, overrd)                                                             \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -263,7 +263,7 @@ class ClassDefGenerateInitInstanceLocalInjector:
 }} // namespace ROOT::Internal
 
 
-/// Common part being called both by _ClassDefOutline_ and _ClassDefInline_.
+/// Common part being called both by \_ClassDefOutline\_ and \_ClassDefInline\_.
 /// \note DeclFileLine() is not part of it, since Cling uses that as trigger for
 /// associating as class title the comment string found right after the macro.
 #define _ClassDefBase_(name, id, virtual_keyword, overrd)                                                       \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -269,7 +269,7 @@ class ClassDefGenerateInitInstanceLocalInjector:
 #define _ClassDefBase_(name, id, virtual_keyword, overrd)                                                       \
 private:          \
    static_assert(std::is_integral<decltype(id)>::value, "ClassDef(Inline) macro: the specified class version number is not an integer.");                                                        \
-   virtual_keyword Bool_t CheckTObjectHashConsistency() const overrd                                            \
+   /** \cond HIDDEN_SYMBOLS */ virtual_keyword Bool_t CheckTObjectHashConsistency() const overrd                \
    {                                                                                                            \
       static std::atomic<UChar_t> recurseBlocker(0);                                                            \
       if (R__likely(recurseBlocker >= 2)) {                                                                     \
@@ -284,67 +284,68 @@ private:          \
          return ::ROOT::Internal::THashConsistencyHolder<decltype(*this)>::fgHashConsistency;                   \
       }                                                                                                         \
       return false; /* unreacheable */                                                                          \
-   }                                                                                                            \
+   } /** \endcond */                                                                                            \
                                                                                                                 \
 public:                                                                                                         \
-   static Version_t Class_Version() { return id; }                                                              \
-   virtual_keyword TClass *IsA() const overrd { return name::Class(); }                                         \
-   virtual_keyword void ShowMembers(TMemberInspector &insp) const overrd                                        \
+   /** \return Version of this class */ static Version_t Class_Version() { return id; }                         \
+   /** \cond HIDDEN_SYMBOLS */ virtual_keyword TClass *IsA() const overrd { return name::Class(); } /** \endcond */ \
+   /** \cond HIDDEN_SYMBOLS */ virtual_keyword void ShowMembers(TMemberInspector &insp) const overrd            \
    {                                                                                                            \
       ::ROOT::Class_ShowMembers(name::Class(), this, insp);                                                     \
-   }                                                                                                            \
-   void StreamerNVirtual(TBuffer &ClassDef_StreamerNVirtual_b) { name::Streamer(ClassDef_StreamerNVirtual_b); } \
-   static const char *DeclFileName() { return __FILE__; }
+   } /** \endcond */                                                                                            \
+   /** \cond HIDDEN_SYMBOLS */ void StreamerNVirtual(TBuffer &ClassDef_StreamerNVirtual_b)                      \
+   { name::Streamer(ClassDef_StreamerNVirtual_b); } /** \endcond */                                             \
+   /** \cond HIDDEN_SYMBOLS */ static const char *DeclFileName() { return __FILE__; } /** \endcond */
 
-#define _ClassDefOutline_(name,id, virtual_keyword, overrd) \
-   _ClassDefBase_(name,id, virtual_keyword, overrd)       \
-private: \
-   static atomic_TClass_ptr fgIsA; \
-public: \
-   static int ImplFileLine(); \
-   static const char *ImplFileName(); \
-   static const char *Class_Name(); \
-   static TClass *Dictionary(); \
-   static TClass *Class(); \
+#define _ClassDefOutline_(name,id, virtual_keyword, overrd)                                                     \
+   _ClassDefBase_(name,id, virtual_keyword, overrd)                                                             \
+private:                                                                                                        \
+   static atomic_TClass_ptr fgIsA;                                                                              \
+public:                                                                                                         \
+   /** \cond HIDDEN_SYMBOLS */ static int ImplFileLine();  /** \endcond */                                      \
+   /** \cond HIDDEN_SYMBOLS */ static const char *ImplFileName();  /** \endcond */                              \
+   /** \return Name of this class */ static const char *Class_Name();                                           \
+   /** \cond HIDDEN_SYMBOLS */ static TClass *Dictionary(); /** \endcond */                                     \
+   /** \cond HIDDEN_SYMBOLS */ static TClass *Class(); /** \endcond */                                          \
    virtual_keyword void Streamer(TBuffer&) overrd;
 
-#define _ClassDefInline_(name, id, virtual_keyword, overrd)                                                      \
-   _ClassDefBase_(name, id, virtual_keyword, overrd) public : static int ImplFileLine() { return -1; }           \
-   static const char *ImplFileName() { return 0; }                                                               \
-   static const char *Class_Name()                                                                               \
-   {                                                                                                             \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Name();                          \
-   }                                                                                                             \
-   static TClass *Dictionary()                                                                                   \
-   {                                                                                                             \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                    \
-   }                                                                                                             \
-   static TClass *Class() { return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class(); } \
+#define _ClassDefInline_(name, id, virtual_keyword, overrd)                                                     \
+   _ClassDefBase_(name, id, virtual_keyword, overrd) public : static int ImplFileLine() { return -1; }          \
+   static const char *ImplFileName() { return 0; }                                                              \
+   /** \return Name of this class */ static const char *Class_Name()                                            \
+   {                                                                                                            \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Name();                         \
+   }                                                                                                            \
+   /** \cond HIDDEN_SYMBOLS */ static TClass *Dictionary()                                                      \
+   {                                                                                                            \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                   \
+   } /** \endcond */                                                                                            \
+   /** \cond HIDDEN_SYMBOLS */ static TClass *Class() { return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class(); } /** \endcond */ \
    virtual_keyword void Streamer(TBuffer &R__b) overrd { ::ROOT::Internal::DefaultStreamer(R__b, name::Class(), this); }
 
 #define ClassDef(name,id)                            \
    _ClassDefOutline_(name,id,virtual,)               \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 #define ClassDefOverride(name,id)                    \
    _ClassDefOutline_(name,id,,override)              \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 #define ClassDefNV(name,id)                          \
    _ClassDefOutline_(name,id,,)                      \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 #define ClassDefInline(name,id)                      \
    _ClassDefInline_(name,id,virtual,)                \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 #define ClassDefInlineOverride(name,id)              \
    _ClassDefInline_(name,id,,override)               \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 #define ClassDefInlineNV(name,id)                    \
    _ClassDefInline_(name,id,,)                       \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 //#define _ClassDefInterp_(name,id) ClassDefInline(name,id)
 
@@ -390,11 +391,11 @@ public: \
 
 #define ClassDefT(name,id)                          \
    _ClassDefOutline_(name,id,virtual,)              \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 #define ClassDefTNV(name,id)                        \
    _ClassDefOutline_(name,id,virtual,)              \
-   static int DeclFileLine() { return __LINE__; }
+   /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */
 
 
 #define ClassDefT2(name,Tmpl)

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -307,7 +307,7 @@ public:                                                                         
    /** \cond HIDDEN_SYMBOLS \deprecated */ static const char *ImplFileName(); /** \endcond */                   \
    /** \return Name of this class */ static const char *Class_Name();                                           \
    /** \cond HIDDEN_SYMBOLS */ static TClass *Dictionary(); /** \endcond */                                     \
-   /** \return TClass describing this class  */ static TClass *Class();                                 \
+   /** \return TClass describing this class */ static TClass *Class();                                          \
    virtual_keyword void Streamer(TBuffer&) overrd;
 
 #define _ClassDefInline_(name, id, virtual_keyword, overrd)                                                     \
@@ -322,7 +322,7 @@ public:                                                                         
    {                                                                                                            \
       return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                   \
    } /** \endcond */                                                                                            \
-   /** \return TClass describing this class */ static TClass *Class()                                  \
+   /** \return TClass describing this class */ static TClass *Class()                                           \
    {                                                                                                            \
       return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class();                        \
    }                                                                                                            \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -301,7 +301,8 @@ public:                                                                         
 #define _ClassDefOutline_(name,id, virtual_keyword, overrd)                                                     \
    _ClassDefBase_(name,id, virtual_keyword, overrd)                                                             \
 private:                                                                                                        \
-   static atomic_TClass_ptr fgIsA;                                                                              \
+   /** \cond HIDDEN_SYMBOLS \brief Pointer holding the address of the TClass describing this class */           \
+   static atomic_TClass_ptr fgIsA; /** \endcond */                                                              \
 public:                                                                                                         \
    /** \cond HIDDEN_SYMBOLS \deprecated */ static int ImplFileLine(); /** \endcond */                           \
    /** \cond HIDDEN_SYMBOLS \deprecated */ static const char *ImplFileName(); /** \endcond */                   \
@@ -364,9 +365,8 @@ public:                                                                         
    namespace ROOT {                                                                                     \
       /** \cond HIDDEN_SYMBOLS */ TGenericClassInfo *GenerateInitInstance(const name*); /** \endcond */ \
       namespace {                                                                                       \
-         /** \cond HIDDEN_SYMBOLS */                                                                    \
          static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) __attribute__((unused)) =                     \
-            GenerateInitInstance((name*)0x0)->SetImplFile(__FILE__, __LINE__);  /** \endcond */         \
+            GenerateInitInstance((name*)0x0)->SetImplFile(__FILE__, __LINE__);                          \
          R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key)));                                            \
       }                                                                                                 \
    }
@@ -381,10 +381,8 @@ public:                                                                         
          /** \cond HIDDEN_SYMBOLS */                                        \
          ::ROOT::TGenericClassInfo *GenerateInitInstance(); /** \endcond */ \
          namespace {                                                        \
-            /** \cond HIDDEN_SYMBOLS */                                     \
             static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) =              \
                GenerateInitInstance()->SetImplFile(__FILE__, __LINE__);     \
-            /** \endcond */                                                 \
             R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key)));             \
          }                                                                  \
       }                                                                     \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -268,7 +268,8 @@ class ClassDefGenerateInitInstanceLocalInjector:
 // the class comment string.
 #define _ClassDefBase_(name, id, virtual_keyword, overrd)                                                       \
 private:                                                                                                        \
-   static_assert(std::is_integral<decltype(id)>::value, "ClassDef(Inline) macro: the specified class version number is not an integer.");                                                        \
+   static_assert(std::is_integral<decltype(id)>::value,                                                         \
+   "ClassDef(Inline) macro: the specified class version number is not an integer.");                            \
    /** \cond HIDDEN_SYMBOLS */ virtual_keyword Bool_t CheckTObjectHashConsistency() const overrd                \
    {                                                                                                            \
       static std::atomic<UChar_t> recurseBlocker(0);                                                            \
@@ -288,7 +289,8 @@ private:                                                                        
                                                                                                                 \
 public:                                                                                                         \
    /** \return Version of this class */ static Version_t Class_Version() { return id; }                         \
-   /** \Return TClass describing current object */ virtual_keyword TClass *IsA() const overrd { return name::Class(); }                   \
+   /** \return TClass describing current object */ virtual_keyword TClass *IsA() const overrd                   \
+   { return name::Class(); }                                                                                    \
    /** \cond HIDDEN_SYMBOLS */ virtual_keyword void ShowMembers(TMemberInspector &insp) const overrd            \
    {                                                                                                            \
       ::ROOT::Class_ShowMembers(name::Class(), this, insp);                                                     \
@@ -305,7 +307,7 @@ public:                                                                         
    /** \cond HIDDEN_SYMBOLS \deprecated */ static const char *ImplFileName(); /** \endcond */                   \
    /** \return Name of this class */ static const char *Class_Name();                                           \
    /** \cond HIDDEN_SYMBOLS */ static TClass *Dictionary(); /** \endcond */                                     \
-   /** \return Pointer to injected TClass */ static TClass *Class();                                            \
+   /** \return Pointer to statically injected TClass */ static TClass *Class();                                 \
    virtual_keyword void Streamer(TBuffer&) overrd;
 
 #define _ClassDefInline_(name, id, virtual_keyword, overrd)                                                     \
@@ -320,7 +322,7 @@ public:                                                                         
    {                                                                                                            \
       return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                   \
    } /** \endcond */                                                                                            \
-   /** \return Pointer to injected TClass */ static TClass *Class()                                             \
+   /** \return Pointer to statically injected TClass */ static TClass *Class()                                  \
    {                                                                                                            \
       return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class(); }                      \
    }                                                                                                            \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -362,28 +362,34 @@ public:                                                                         
 
 #define ClassImpUnique(name,key) \
    namespace ROOT { \
-      TGenericClassInfo *GenerateInitInstance(const name*); \
-      namespace { \
-         static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) __attribute__((unused)) = \
-            GenerateInitInstance((name*)0x0)->SetImplFile(__FILE__, __LINE__); \
-         R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key))); \
-      } \
+      /** \cond HIDDEN_SYMBOLS */ TGenericClassInfo *GenerateInitInstance(const name*); /** \endcond */ \
+      namespace {                                                                                       \
+         /** \cond HIDDEN_SYMBOLS */                                                                    \
+         static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) __attribute__((unused)) =                     \
+            GenerateInitInstance((name*)0x0)->SetImplFile(__FILE__, __LINE__);  /** \endcond */         \
+         R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key)));                                            \
+      }                                                                                                 \
    }
+   
 #define ClassImp(name) ClassImpUnique(name,default)
 
 // Macro for Namespace
 
-#define NamespaceImpUnique(name,key) \
-   namespace name { \
-      namespace ROOTDict { \
-         ::ROOT::TGenericClassInfo *GenerateInitInstance(); \
-         namespace { \
-            static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) = \
-               GenerateInitInstance()->SetImplFile(__FILE__, __LINE__); \
-            R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key))); \
-         } \
-      } \
+#define NamespaceImpUnique(name,key)                                        \
+   namespace name {                                                         \
+      namespace ROOTDict {                                                  \
+         /** \cond HIDDEN_SYMBOLS */                                        \
+         ::ROOT::TGenericClassInfo *GenerateInitInstance(); /** \endcond */ \
+         namespace {                                                        \
+            /** \cond HIDDEN_SYMBOLS */
+            static int _R__UNIQUE_(_NAME2_(R__dummyint,key)) =              \
+               GenerateInitInstance()->SetImplFile(__FILE__, __LINE__);     \
+            /** \endcond */                                                 \
+            R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key)));             \
+         }                                                                  \
+      }                                                                     \
    }
+   
 #define NamespaceImp(name) NamespaceImpUnique(name,default)
 
 //---- ClassDefT macros for templates with one template argument ---------------
@@ -409,8 +415,9 @@ public:                                                                         
 
 #define templateClassImpUnique(name, key)                                                                           \
    namespace ROOT {                                                                                                 \
-   static TNamed *                                                                                                  \
+   /** \cond HIDDEN_SYMBOLS */ static TNamed *                                                                      \
       _R__UNIQUE_(_NAME2_(R__dummyholder, key)) = ::ROOT::RegisterClassTemplate(_QUOTE_(name), __FILE__, __LINE__); \
+   /** \endcond */                                                                                                  \
    R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyholder, key)));                                                          \
    }
 #define templateClassImp(name) templateClassImpUnique(name,default)
@@ -437,20 +444,25 @@ public:                                                                         
 
 //---- Macro to set the class version of non instrumented classes --------------
 
-#define RootClassVersion(name,VersionNumber) \
-namespace ROOT { \
-   TGenericClassInfo *GenerateInitInstance(const name*); \
-   static Short_t _R__UNIQUE_(R__dummyVersionNumber) = \
-           GenerateInitInstance((name*)0x0)->SetVersion(VersionNumber); \
-   R__UseDummy(_R__UNIQUE_(R__dummyVersionNumber)); \
+#define RootClassVersion(name,VersionNumber)                             \
+namespace ROOT { /** \cond HIDDEN_SYMBOLS */                             \
+   TGenericClassInfo *GenerateInitInstance(const name*); /** \endcond */ \
+   /** \cond HIDDEN_SYMBOLS */                                           \
+   static Short_t _R__UNIQUE_(R__dummyVersionNumber) =                   \
+           GenerateInitInstance((name*)0x0)->SetVersion(VersionNumber);  \
+   /** \endcond */                                                       \
+   R__UseDummy(_R__UNIQUE_(R__dummyVersionNumber));                      \
 }
 
-#define RootStreamer(name,STREAMER)                                  \
-namespace ROOT {                                                     \
-   TGenericClassInfo *GenerateInitInstance(const name*);             \
-   static Short_t _R__UNIQUE_(R__dummyStreamer) =                    \
-           GenerateInitInstance((name*)0x0)->SetStreamer(STREAMER);  \
-   R__UseDummy(_R__UNIQUE_(R__dummyStreamer));                       \
+#define RootStreamer(name,STREAMER)                                      \
+namespace ROOT {                                                         \
+   /** \cond HIDDEN_SYMBOLS */                                           \
+   TGenericClassInfo *GenerateInitInstance(const name*); /** \endcond */ \
+   /** \cond HIDDEN_SYMBOLS */                                           \
+   static Short_t _R__UNIQUE_(R__dummyStreamer) =                        \
+           GenerateInitInstance((name*)0x0)->SetStreamer(STREAMER);      \
+   /** \endcond */                                                       \
+   R__UseDummy(_R__UNIQUE_(R__dummyStreamer));                           \
 }
 
 //---- Macro to load a library into the interpreter --------------

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -288,7 +288,7 @@ private:                                                                        
                                                                                                                 \
 public:                                                                                                         \
    /** \return Version of this class */ static Version_t Class_Version() { return id; }                         \
-   /** \see ::Class() */ virtual_keyword TClass *IsA() const overrd { return name::Class(); }                   \
+   /** \Return TClass describing current object */ virtual_keyword TClass *IsA() const overrd { return name::Class(); }                   \
    /** \cond HIDDEN_SYMBOLS */ virtual_keyword void ShowMembers(TMemberInspector &insp) const overrd            \
    {                                                                                                            \
       ::ROOT::Class_ShowMembers(name::Class(), this, insp);                                                     \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -307,7 +307,7 @@ public:                                                                         
    /** \cond HIDDEN_SYMBOLS \deprecated */ static const char *ImplFileName(); /** \endcond */                   \
    /** \return Name of this class */ static const char *Class_Name();                                           \
    /** \cond HIDDEN_SYMBOLS */ static TClass *Dictionary(); /** \endcond */                                     \
-   /** \return Pointer to statically injected TClass */ static TClass *Class();                                 \
+   /** \return TClass describing this class  */ static TClass *Class();                                 \
    virtual_keyword void Streamer(TBuffer&) overrd;
 
 #define _ClassDefInline_(name, id, virtual_keyword, overrd)                                                     \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -324,7 +324,7 @@ public:                                                                         
    } /** \endcond */                                                                                            \
    /** \return Pointer to statically injected TClass */ static TClass *Class()                                  \
    {                                                                                                            \
-      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class(); }                      \
+      return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class();                        \
    }                                                                                                            \
    virtual_keyword void Streamer(TBuffer &R__b) overrd                                                          \
    {                                                                                                            \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -293,8 +293,7 @@ public:                                                                         
    {                                                                                                            \
       ::ROOT::Class_ShowMembers(name::Class(), this, insp);                                                     \
    } /** \endcond */                                                                                            \
-   /** \cond HIDDEN_SYMBOLS */ void StreamerNVirtual(TBuffer &ClassDef_StreamerNVirtual_b)                      \
-   { name::Streamer(ClassDef_StreamerNVirtual_b); } /** \endcond */                                             \
+   void StreamerNVirtual(TBuffer &ClassDef_StreamerNVirtual_b) { name::Streamer(ClassDef_StreamerNVirtual_b); } \
    /** \return Name of the current file */ static const char *DeclFileName() { return __FILE__; }
 
 #define _ClassDefOutline_(name,id, virtual_keyword, overrd)                                                     \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -322,7 +322,7 @@ public:                                                                         
    {                                                                                                            \
       return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Dictionary();                   \
    } /** \endcond */                                                                                            \
-   /** \return Pointer to statically injected TClass */ static TClass *Class()                                  \
+   /** \return TClass describing this class */ static TClass *Class()                                  \
    {                                                                                                            \
       return ::ROOT::Internal::ClassDefGenerateInitInstanceLocalInjector<name>::Class();                        \
    }                                                                                                            \

--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -263,9 +263,9 @@ class ClassDefGenerateInitInstanceLocalInjector:
 }} // namespace ROOT::Internal
 
 
-// Common part being called both by _ClassDefOutline_ and _ClassDefInline_.
-// DeclFileLine() is not part of it, since Cling uses that as trigger for
-// associating as class title the comment string found right after the macro.
+/// Common part being called both by _ClassDefOutline_ and _ClassDefInline_.
+/// \note DeclFileLine() is not part of it, since Cling uses that as trigger for
+/// associating as class title the comment string found right after the macro.
 #define _ClassDefBase_(name, id, virtual_keyword, overrd)                                                       \
 private:                                                                                                        \
    static_assert(std::is_integral<decltype(id)>::value,                                                         \
@@ -360,7 +360,6 @@ public:                                                                         
 #define R__UseDummy(name) \
    class _NAME2_(name,_c) { public: _NAME2_(name,_c)() { if (name) { } } }
 
-
 #define ClassImpUnique(name,key)                                                                        \
    namespace ROOT {                                                                                     \
       /** \cond HIDDEN_SYMBOLS */ TGenericClassInfo *GenerateInitInstance(const name*); /** \endcond */ \
@@ -371,11 +370,11 @@ public:                                                                         
          R__UseDummy(_R__UNIQUE_(_NAME2_(R__dummyint,key)));                                            \
       }                                                                                                 \
    }
-   
+
+/// \deprecated
 #define ClassImp(name) ClassImpUnique(name,default)
 
-// Macro for Namespace
-
+/// Macro for Namespace
 #define NamespaceImpUnique(name,key)                                        \
    namespace name {                                                         \
       namespace ROOTDict {                                                  \
@@ -400,9 +399,8 @@ public:                                                                         
 // ClassImpT  corresponds to ClassImp
 
 
-// This ClassDefT is stricly redundant and is kept only for
-// backward compatibility.
-
+/// This ClassDefT is stricly redundant and is kept only for
+/// backward compatibility. \deprecated
 #define ClassDefT(name,id)                          \
    _ClassDefOutline_(name,id,virtual,)              \
    /** \cond HIDDEN_SYMBOLS */ static int DeclFileLine() { return __LINE__; } /** \endcond */

--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -2222,21 +2222,21 @@ MACRO_EXPANSION        = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = YES
+EXPAND_ONLY_PREDEF     = NO
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SEARCH_INCLUDES        = NO
+SEARCH_INCLUDES        = YES
 
 # The INCLUDE_PATH tag can be used to specify one or more directories that
 # contain include files that are not input files but should be processed by the
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           =
+INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2254,12 +2254,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = "ClassDef(x,y)=//" \
-                         ClassImp(x)=// \
-                         ClassImpQ(x)=// \
-                         templateClassImp(x)=// \
-                         NamespaceImp(x)=// \
-                         R__CLING_PTRCHECK \
+PREDEFINED             = R__CLING_PTRCHECK \
                          R__USE_IMT \
                          R__SUGGEST_ALTERNATIVE(x)=
 
@@ -2280,7 +2275,7 @@ EXPAND_AS_DEFINED      =
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SKIP_FUNCTION_MACROS   = YES
+SKIP_FUNCTION_MACROS   = NO
 
 #---------------------------------------------------------------------------
 # Configuration options related to external references


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Prevents 181 warnings in https://lcgapp-services.cern.ch/root-jenkins/view/ROOT/job/root-makedoc-v624/96/consoleFull when running Doxygen concerning the ::Streamer functions.

And 4 or 5 warnings are solved also in Bindings/R documentation.

It also exposes some parts of ClassDef macro that were not included in doxygen before.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/9596

