### PR TITLE
Fix compilation error with the `/permissive-` flag on Windows

### DIFF
--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -285,7 +285,7 @@ RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
 
       // use UnixPathName to simplify handling of backslashes
       exec = "wmic process call create '"s + gSystem->UnixPathName(fProg.c_str()) + exec + "' | find \"ProcessId\" "s;
-      std::string process_id = gSystem->GetFromPipe(exec.c_str());
+      std::string process_id = gSystem->GetFromPipe(exec.c_str()).Data();
       std::stringstream ss(process_id);
       std::string tmp;
       char c;


### PR DESCRIPTION
Fix the following error with the `/permissive-` compiler flag on Windows
```
   gui\webdisplay\src\RWebDisplayHandle.cxx(288,66): error C2440: 'initializing': cannot convert from 'TString' to 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>'
```
