### PR TITLE
Veto fitConvolution.py without FFTW

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -208,7 +208,8 @@ if(NOT ROOT_fftw3_FOUND)
                  roofit/rf211_paramconv.py
                  roofit/rf512_wsfactory_oper.py
                  fft/FFT.C
-                 fit/fitConvolution.C)
+                 fit/fitConvolution.C
+                 fit/fitConvolution.py)
 endif()
 
 if(NOT ROOT_opengl_FOUND)


### PR DESCRIPTION
Commit 88665b9cde introduced a Python version of fitConvolution.C, but did not add it to the list of vetoed tests.