### PR TITLE
Fix testHistFactory compilation error on Windows

### DIFF
--- a/roofit/histfactory/test/CMakeLists.txt
+++ b/roofit/histfactory/test/CMakeLists.txt
@@ -7,5 +7,5 @@
 # @author Stephan Hageboeck CERN, 2019
 
 ROOT_ADD_GTEST(testHistFactory testHistFactory.cxx
-  LIBRARIES RooFitCore RooFit RooStats HistFactory RooBatchCompute
+  LIBRARIES RooFitCommon RooFitCore RooFit RooStats HistFactory RooBatchCompute
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/ref_6.16_example_UsingC_channel1_meas_model.root ${CMAKE_CURRENT_SOURCE_DIR}/ref_6.16_example_UsingC_combined_meas_model.root)


### PR DESCRIPTION
Fix the following compilation error on Windows:
```
testHistFactory.obj : error LNK2019: unresolved external symbol "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const & __cdecl RooFit::tmpPath(void)" (?tmpPath@RooFit@@YAAEBV?$basic_string@DU?$char_traits@D@std@@V$allocator@D@2@@std@@XZ) referenced in function "public: virtual void __cdecl HFFixture_ModelProperties_Test::TestBody(void)" (?TestBody@HFFixture_ModelProperties_Test@@UEAAXXZ)
testHistFactory.exe : fatal error LNK1120: 1 unresolved externals
```
