### PR TITLE
Try fixing the LCG builds.

### DIFF
--- a/math/mathcore/CMakeLists.txt
+++ b/math/mathcore/CMakeLists.txt
@@ -106,13 +106,9 @@ if(runtime_cxxmodules)
   # FIXME: Revise after a llvm upgrade or reproduce it outside rootcling.
   list(REMOVE_ITEM HEADERS "Math/Math.h")
 
-  if(vc)
-    # We do not link against libVc.a thus it makes no sense to check for
-    # version compatibility between libraries and header files. This fixes
-    # ROOT-11002 where upon building the modules.idx we run the static ctor
-    # runLibraryAbiCheck which fails to find the corresponding symbol.
-    set(dictoptions "-m" "Vc" "-mByproduct" "Vc" "-D" "Vc_NO_VERSION_CHECK")
-  endif(vc)
+  if(veccore)
+    set(dictoptions "-mByproduct" "Vc")
+  endif(veccore)
 endif()
 
 ROOT_ADD_C_FLAG(_flags -Wno-strict-overflow)  # Avoid what it seems a compiler false positive warning


### PR DESCRIPTION
This commit reverts:
"[cxxmodules] Disentangle Vc and VecCore" root-project/root@fa4c3f5e722cc96e1a5a6fc0ef2d1ea331b22b19.
"[cxxmodules] Do not perform version checks for Vc." root-project/root@a4e70032b2a89d3f8306b0a5b328cf28326a1275.
