### PR TITLE
[jsroot] dev 21/01/2022 with WebGL embeding in Chrome [skip-ci]

### DIFF
--- a/gui/cefdisplay/Readme.md
+++ b/gui/cefdisplay/Readme.md
@@ -2,9 +2,9 @@
 
 ## Compilation with CEF support
 
-See details about [Chromimum Embedded Framework](https://bitbucket.org/chromiumembedded/cef)
+See details about [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef)
 
-1. Current code tested with CEF3 branch 4638, Chromium 95 (October 2021)
+1. Current code tested with CEF3 branch 4692, Chromium 97 (January 2022)
    Older CEF versions are no longer supported.
 
 2. Download binary code from [https://cef-builds.spotifycdn.com/index.html](https://cef-builds.spotifycdn.com/index.html) and unpack it in directory without spaces and special symbols:
@@ -12,8 +12,8 @@ See details about [Chromimum Embedded Framework](https://bitbucket.org/chromiume
 ~~~
      $ mkdir /d/cef
      $ cd /d/cef/
-     $ wget https://cef-builds.spotifycdn.com/cef_binary_95.7.12%2Bg99c4ac0%2Bchromium-95.0.4638.54_linux64.tar.bz2
-     $ tar xjf cef_binary_95.7.12+g99c4ac0+chromium-95.0.4638.54_linux64.tar.bz2
+     $ wget https://cef-builds.spotifycdn.com/cef_binary_97.1.6%2Bg8961cdb%2Bchromium-97.0.4692.99_linux64_minimal.tar.bz2
+     $ tar xjf cef_binary_97.1.6+g8961cdb+chromium-97.0.4692.99_linux64_minimal.tar.bz2
 ~~~
 
 
@@ -23,7 +23,7 @@ See details about [Chromimum Embedded Framework](https://bitbucket.org/chromiume
 4. Compile CEF to produce `libcef_dll_wrapper`:
 
 ~~~
-     $ cd /d/cef/cef_binary_95.7.12+g99c4ac0+chromium-95.0.4638.54_linux64
+     $ cd /d/cef/cef_binary_97.1.6+g8961cdb+chromium-97.0.4692.99_linux64_minimal
      $ mkdir build
      $ cd build
      $ cmake ..
@@ -33,7 +33,7 @@ See details about [Chromimum Embedded Framework](https://bitbucket.org/chromiume
 5. Set CEF_ROOT variable to unpacked directory:
 
 ~~~
-     $ export CEF_ROOT=/d/cef/cef_binary_95.7.12+g99c4ac0+chromium-95.0.4638.54_linux64
+     $ export CEF_ROOT=/d/cef/cef_binary_97.1.6+g8961cdb+chromium-97.0.4692.99_linux64_minimal
 ~~~
 
 6. When configure ROOT compilation with `cmake -Dwebgui=ON -Dcefweb=ON ...`, CEF_ROOT shell variable should be set appropriately.
@@ -103,5 +103,4 @@ CEF with ozone support can be compiled with following commands:
 With little luck one get prepared tarballs in `/home/user/cef/chromium/src/cef/binary_distrib`.
 Just install it in the same way as described before in this document.
 ROOT will automatically detect that CEF build with `ozone` support and will use it for both interactive and headless modes.
-
 

--- a/js/changes.md
+++ b/js/changes.md
@@ -21,6 +21,7 @@
 18. Correctly display extra data from TGraphQQ
 19. Remove "collapsible" and "tabs" layouts which were implemented with jQuery - use "flex" instead
 20. Improve flexible layout, provide context menu with cascading, tiling, selecting frames
+21. Starting from Chrome 96, allow embedding WebGL into SVG - solving problem with lego plots in canvas
 
 
 ## Changes in 6.3.2

--- a/js/scripts/JSRoot.base3d.js
+++ b/js/scripts/JSRoot.base3d.js
@@ -53,6 +53,9 @@ JSROOT.define(['d3', 'three', 'painter'], (d3, THREE, jsrp) => {
             can3d = JSROOT.settings.Embed3D;
          else if (JSROOT.browser.isFirefox)
             can3d = JSROOT.constants.Embed3D.Embed;
+         else if (JSROOT.browser.chromeVersion > 95)
+         // version 96 works partially, 97 works fine
+            can3d = JSROOT.constants.Embed3D.Embed;
          else
             can3d = JSROOT.constants.Embed3D.Overlay;
       }

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "19/11/2021"*/
-   JSROOT.version_date = "20/01/2022";
+   JSROOT.version_date = "21/01/2022";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}
@@ -154,8 +154,9 @@
       browser.isFirefox = typeof InstallTrigger !== 'undefined';
       browser.isSafari = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0;
       browser.isChrome = !!window.chrome && !browser.isOpera;
-      browser.isWin = navigator.platform.indexOf('Win') >= 0;
       browser.isChromeHeadless = navigator.userAgent.indexOf('HeadlessChrome') >= 0;
+      browser.chromeVersion = (browser.isChrome || browser.isChromeHeadless) ? parseInt(navigator.userAgent.match(/Chrom(?:e|ium)\/([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)/)[1]) : 0;
+      browser.isWin = navigator.platform.indexOf('Win') >= 0;
       browser.touches = ('ontouchend' in document); // identify if touch events are supported
    }
 

--- a/js/scripts/JSRoot.hierarchy.js
+++ b/js/scripts/JSRoot.hierarchy.js
@@ -4483,8 +4483,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
              return;
          }
 
-         let pos = group.position;
-
+         let pos;
          if (action == "restore") {
              pos = group.position0;
          } else if (handle.vertical) {
@@ -4791,7 +4790,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
             return;
          }
 
-         let state = main.property("state"), newstate = state;
+         let state = main.property("state"), newstate;
          if (kind.t == "maximize")
             newstate = (state == "max") ? "normal" : "max";
          else

--- a/js/scripts/JSRoot.hist.js
+++ b/js/scripts/JSRoot.hist.js
@@ -6352,7 +6352,7 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          if (fWhiskerDown <= 0)
            if ((swapXY && funcs.logx) || (!swapXY && funcs.logy)) return;
 
-         let w = (grx_right - grx_left), candleWidth = w, histoWidth = w,
+         let w = (grx_right - grx_left), candleWidth, histoWidth,
              center = (grx_left + grx_right) / 2 + histo.fBarOffset/1000*w;
          if ((histo.fBarWidth > 0) && (histo.fBarWidth !== 1000)) {
             candleWidth = histoWidth = w * histo.fBarWidth / 1000;

--- a/js/scripts/JSRoot.painter.js
+++ b/js/scripts/JSRoot.painter.js
@@ -1293,8 +1293,8 @@ JSROOT.define(['d3'], (d3) => {
       if (ndig === undefined) ndig = smooth ? 2 : 0;
       if (height === undefined) height = 0;
 
-      const jsroot_d3_svg_lineSlope = (p0, p1) => (p1.gry - p0.gry) / (p1.grx - p0.grx);
-      const jsroot_d3_svg_lineFiniteDifferences = points => {
+      const jsroot_d3_svg_lineSlope = (p0, p1) => (p1.gry - p0.gry) / (p1.grx - p0.grx),
+            jsroot_d3_svg_lineFiniteDifferences = points => {
          let i = 0, j = points.length - 1, m = [], p0 = points[0], p1 = points[1], d = m[0] = jsroot_d3_svg_lineSlope(p0, p1);
          while (++i < j) {
             p0 = p1; p1 = points[i + 1];
@@ -1302,8 +1302,7 @@ JSROOT.define(['d3'], (d3) => {
          }
          m[i] = d;
          return m;
-      };
-      const jsroot_d3_svg_lineMonotoneTangents = points => {
+      }, jsroot_d3_svg_lineMonotoneTangents = points => {
          let d, a, b, s, m = jsroot_d3_svg_lineFiniteDifferences(points), i = -1, j = points.length - 1;
          while (++i < j) {
             d = jsroot_d3_svg_lineSlope(points[i], points[i + 1]);
@@ -1351,12 +1350,12 @@ JSROOT.define(['d3'], (d3) => {
 
       if (smooth) {
          // build smoothed curve
-         res.path += "C" + conv(bin.grx+bin.dgrx) + "," + conv(bin.gry+bin.dgry) + ",";
+         res.path += `C${conv(bin.grx+bin.dgrx)},${conv(bin.gry+bin.dgry)},`;
          for (let n = 1; n < npnts; ++n) {
             let prev = bin;
             bin = bins[n];
             if (n > 1) res.path += "S";
-            res.path += conv(bin.grx - bin.dgrx) + "," + conv(bin.gry - bin.dgry) + "," + conv(bin.grx) + "," + conv(bin.gry);
+            res.path += `${conv(bin.grx - bin.dgrx)},${conv(bin.gry - bin.dgry)},${conv(bin.grx)},${conv(bin.gry)}`;
             maxy = Math.max(maxy, prev.gry);
          }
       } else if (npnts < 10000) {
@@ -1375,7 +1374,7 @@ JSROOT.define(['d3'], (d3) => {
             dy = Math.round(bin.gry) - curry;
             if (dx && dy) {
                flush();
-               res.path += "l" + dx + "," + dy;
+               res.path += `l${dx},${dy}`;
             } else if (!dx && dy) {
                if ((acc_y === 0) || ((dy < 0) !== (acc_y < 0))) flush();
                acc_y += dy;
@@ -1414,7 +1413,7 @@ JSROOT.define(['d3'], (d3) => {
             }
             dy = lasty - curry;
             if (dy)
-               res.path += "l" + dx + "," + dy;
+               res.path += `l${dx},${dy}`;
             else
                res.path += "h" + dx;
             currx = lastx; curry = lasty;
@@ -1429,7 +1428,7 @@ JSROOT.define(['d3'], (d3) => {
       }
 
       if (height > 0)
-         res.close = "L" + conv(bin.grx) + "," + conv(maxy) + "h" + conv(bins[0].grx - bin.grx) + "Z";
+         res.close = `L${conv(bin.grx)},${conv(maxy)}h${conv(bins[0].grx - bin.grx)}Z`;
 
       return res;
    }
@@ -3036,7 +3035,7 @@ JSROOT.define(['d3'], (d3) => {
          });
       }
 
-      let DoFillMenu = (_menu, _reqid, _resolveFunc, reply) => {
+      const DoFillMenu = (_menu, _reqid, _resolveFunc, reply) => {
 
          // avoid multiple call of the callback after timeout
          if (this._got_menu) return;
@@ -3081,7 +3080,7 @@ JSROOT.define(['d3'], (d3) => {
          }
 
          _resolveFunc(_menu);
-      }
+      };
 
       let reqid = this.snapid;
       if (kind) reqid += "#" + kind; // use # to separate object id from member specifier like 'x' or 'z'
@@ -3207,18 +3206,15 @@ JSROOT.define(['d3'], (d3) => {
       let layer = frame.select(".main_layer");
       if (layer.empty()) return null;
 
-      let pos = d3.pointer(evnt, layer.node());
-      let pnt = { touch: false, x: pos[0], y: pos[1] };
+      let pos = d3.pointer(evnt, layer.node()),
+          pnt = { touch: false, x: pos[0], y: pos[1] };
 
       if (typeof this.extractToolTip == 'function')
          return this.extractToolTip(pnt);
 
       pnt.disabled = true;
 
-      let res = null;
-
-      if (typeof this.processTooltipEvent == 'function')
-         res = this.processTooltipEvent(pnt);
+      let res = (typeof this.processTooltipEvent == 'function') ? this.processTooltipEvent(pnt) : null;
 
       return res && res.user_info ? res.user_info : res;
    }
@@ -4134,9 +4130,8 @@ JSROOT.define(['d3'], (d3) => {
 
       function build(main) {
 
-         main.attr("width", args.width).attr("height", args.height);
-
-         main.style("width", args.width + "px").style("height", args.height + "px");
+         main.attr("width", args.width).attr("height", args.height)
+             .style("width", args.width + "px").style("height", args.height + "px");
 
          JSROOT._.svg_3ds = undefined;
 


### PR DESCRIPTION
CEF tested with 4692 branch (Chromium 97)

This version allows correct embeding of WebGL canvas into SVG
This solves long-standing problem with Chrome-based browsers
Starting from version 96 Chrome works as good as Firefox
in that respect. Checked that latest CEF works as well