### PR TITLE
[ntuple] Cache number of entries in RNTupleDescriptor

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -387,6 +387,8 @@ private:
    std::uint64_t fOnDiskHeaderSize = 0; ///< Set by the descriptor builder when deserialized
    std::uint64_t fOnDiskFooterSize = 0; ///< Like fOnDiskHeaderSize, contains both cluster summaries and page locations
 
+   std::uint64_t fNEntries = 0; ///< Updated by the descriptor builder when the cluster summaries are added
+
    std::unordered_map<DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
    std::unordered_map<DescriptorId_t, RColumnDescriptor> fColumnDescriptors;
    std::unordered_map<DescriptorId_t, RClusterGroupDescriptor> fClusterGroupDescriptors;
@@ -673,8 +675,8 @@ public:
    std::size_t GetNClusterGroups() const { return fClusterGroupDescriptors.size(); }
    std::size_t GetNClusters() const { return fClusterDescriptors.size(); }
 
-   // The number of entries as seen with the currently loaded cluster meta-data; there might be more
-   NTupleSize_t GetNEntries() const;
+   /// We know the number of entries from adding the cluster summaries
+   NTupleSize_t GetNEntries() const { return fNEntries; }
    NTupleSize_t GetNElements(DescriptorId_t columnId) const;
 
    /// Returns the logical parent of all top-level NTuple data fields.

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -191,15 +191,6 @@ bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &
 }
 
 
-ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNEntries() const
-{
-   NTupleSize_t result = 0;
-   for (const auto &cd : fClusterDescriptors) {
-      result = std::max(result, cd.second.GetFirstEntryIndex() + cd.second.GetNEntries());
-   }
-   return result;
-}
-
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::RNTupleDescriptor::GetNElements(DescriptorId_t columnId) const
 {
    NTupleSize_t result = 0;
@@ -601,6 +592,7 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterSummary(DescriptorId_t c
 {
    if (fDescriptor.fClusterDescriptors.count(clusterId) > 0)
       return R__FAIL("cluster id clash while adding cluster summary");
+   fDescriptor.fNEntries = std::max(fDescriptor.fNEntries, firstEntry + nEntries);
    fDescriptor.fClusterDescriptors.emplace(clusterId, RClusterDescriptor(clusterId, firstEntry, nEntries));
    return RResult<void>::Success();
 }
@@ -627,6 +619,8 @@ ROOT::Experimental::RNTupleDescriptorBuilder::AddClusterWithDetails(RClusterDesc
    auto clusterId = clusterDesc.GetId();
    if (fDescriptor.fClusterDescriptors.count(clusterId) > 0)
       return R__FAIL("cluster id clash");
+   fDescriptor.fNEntries =
+      std::max(fDescriptor.fNEntries, clusterDesc.GetFirstEntryIndex() + clusterDesc.GetNEntries());
    fDescriptor.fClusterDescriptors.emplace(clusterId, std::move(clusterDesc));
    return RResult<void>::Success();
 }


### PR DESCRIPTION
Optimization for `RNTupleDescriptor::GetNEntries()`: Once the cluster descriptor is constructed, all the cluster summaries must have been added. From the cluster summaries, we know the cluster event ranges. So we know the number of events of the ntuple and can cache it.