### PR TITLE
[TMVA][SOFIE] Add support for Conv Operator in Keras parser

### DIFF
--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -646,7 +646,7 @@ RModel Parse(std::string filename){
                "  weightProp={}\n"
                "  weightProp['name']=model.weights[idx].name\n"
                "  weightProp['dtype']=(model.get_weights())[idx].dtype.name\n"
-               "  weightProp['value']=(model.get_weights())[idx].transpose() if 'conv' in model.weights[idx].name else (model.get_weights())[idx]\n"
+               "  weightProp['value']=(model.get_weights())[idx].transpose((3,2,0,1)).copy() if ('conv' in model.weights[idx].name and model.weights[idx].shape.ndims == 4) else (model.get_weights())[idx]\n"
                "  weight.append(weightProp)",fGlobalNS,fLocalNS);
 
    PyObject *fWeightTensor, *fPWeight;

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -293,17 +293,14 @@ std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
          long outputHeight = std::ceil(float(inputHeight) / float(fAttrStrides[0]));
          long outputWidth  = std::ceil(float(inputWidth) / float(fAttrStrides[1]));
 
-         long x1 = (outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight;
-         long x2 = (outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth;
+         long padding_height = std::max(long((outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight),0L);
+         long padding_width = std::max(long((outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth),0L);
 
-         if(x1 < 0) x1 = 0;
-         if(x2 < 0) x2 = 0;
-
-         size_t x1_begin = std::floor(x1/2);
-         size_t x1_end   = x1 - x1_begin;
-         size_t x2_begin = std::floor(x2/2);
-         size_t x2_end   = x2 - x2_begin;
-         fAttrPads = {x1_begin,x2_begin,x1_end,x2_end};
+         size_t padding_top = std::floor(padding_height/2);
+         size_t padding_bottom   = padding_height - padding_top;
+         size_t padding_left = std::floor(padding_width/2);
+         size_t padding_right   = padding_width - padding_left;
+         fAttrPads = {padding_top,padding_bottom,padding_left,padding_right};
       }
       else{
          throw std::runtime_error("TMVA::SOFIE - RModel Keras Parser doesn't yet supports Convolution layer with padding " + fKerasPadding);
@@ -335,11 +332,7 @@ std::unique_ptr<ROperator> MakeKerasActivation(PyObject* fLayer){
       PyObject* fAttributes=PyDict_GetItemString(fLayer,"layerAttributes");
       PyObject* fPActivation = PyDict_GetItemString(fAttributes,"activation");
       std::string fLayerActivation = PyStringAsString(PyObject_GetAttrString(fPActivation,"__name__"));
-<<<<<<< HEAD
-      
-=======
 
->>>>>>> 4f8836d2f6 (feat: transpose op before and after conv for Keras NHWC)
       auto findLayer = mapKerasLayer.find(fLayerActivation);
       if(findLayer == mapKerasLayer.end()){
          throw std::runtime_error("TMVA::SOFIE - Parsing Keras Activation layer " + fLayerActivation + " is not yet supported");

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -149,11 +149,11 @@ void AddKerasLayer(RModel& rmodel, PyObject* fLayer){
 
          if(fLayerType == "Conv2D"){
             std::unique_ptr<ROperator> op_pre_transpose;
-            op_pre_transpose.reset(new ROperator_Transpose<float>({0,3,1,2}, PyStringAsString(PyList_GetItem(fInputs,0)), fLayerName+"_Trans"));
+            op_pre_transpose.reset(new ROperator_Transpose<float>({0,3,1,2}, PyStringAsString(PyList_GetItem(fInputs,0)), fLayerName+"PreTrans"));
             rmodel.AddOperator(std::move(op_pre_transpose));
 
-            PyList_SetItem(fInputs,0,PyUnicode_FromString((fLayerName+"_Trans").c_str()));
-            PyDict_SetItemString(fLayer,"layerInput",fOutputs);
+            PyList_SetItem(fInputs,0,PyUnicode_FromString((fLayerName+"PreTrans").c_str()));
+            PyDict_SetItemString(fLayer,"layerInput",fInputs);
          }
 
          // Making changes in the names of the input and output tensor names
@@ -164,9 +164,9 @@ void AddKerasLayer(RModel& rmodel, PyObject* fLayer){
          std::string fActivationLayerInput = fLayerName+fLayerType;   
          if(fLayerType == "Conv2D"){
             std::unique_ptr<ROperator> op_post_transpose;
-            op_post_transpose.reset(new ROperator_Transpose<float>({0,2,3,1}, fLayerName+fLayerType, fLayerName+"_Trans"));
+            op_post_transpose.reset(new ROperator_Transpose<float>({0,2,3,1}, fLayerName+fLayerType, fLayerName+"PostTrans"));
             rmodel.AddOperator(std::move(op_post_transpose));
-            fActivationLayerInput = fLayerName+"_Trans";
+            fActivationLayerInput = fLayerName+"PostTrans";
          }
 
          PyList_SetItem(fInputs,0,PyUnicode_FromString(fActivationLayerInput.c_str()));

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -147,12 +147,28 @@ void AddKerasLayer(RModel& rmodel, PyObject* fLayer){
          PyObject* fInputs = PyDict_GetItemString(fLayer,"layerInput");
          std::string fActivationLayerOutput = PyStringAsString(PyList_GetItem(fOutputs,0));
 
+         if(fLayerType == "Conv2D"){
+            std::unique_ptr<ROperator> op_pre_transpose;
+            op_pre_transpose.reset(new ROperator_Transpose<float>({0,3,1,2}, PyStringAsString(PyList_GetItem(fInputs,0)), fLayerName+"_Trans"));
+            rmodel.AddOperator(std::move(op_pre_transpose));
+
+            PyList_SetItem(fInputs,0,PyUnicode_FromString((fLayerName+"_Trans").c_str()));
+            PyDict_SetItemString(fLayer,"layerInput",fOutputs);
+         }
+
          // Making changes in the names of the input and output tensor names
          PyList_SetItem(fOutputs,0,PyUnicode_FromString((fLayerName+fLayerType).c_str()));
          PyDict_SetItemString(fLayer,"layerOutput",fOutputs);
          rmodel.AddOperator((findLayer->second)(fLayer));
 
-         std::string fActivationLayerInput = PyStringAsString(PyList_GetItem(fOutputs,0));
+         std::string fActivationLayerInput = fLayerName+fLayerType;   
+         if(fLayerType == "Conv2D"){
+            std::unique_ptr<ROperator> op_post_transpose;
+            op_post_transpose.reset(new ROperator_Transpose<float>({0,2,3,1}, fLayerName+fLayerType, fLayerName+"_Trans"));
+            rmodel.AddOperator(std::move(op_post_transpose));
+            fActivationLayerInput = fLayerName+"_Trans";
+         }
+
          PyList_SetItem(fInputs,0,PyUnicode_FromString(fActivationLayerInput.c_str()));
          PyList_SetItem(fOutputs,0,PyUnicode_FromString(fActivationLayerOutput.c_str()));
          PyDict_SetItemString(fLayer,"layerInput",fInputs);
@@ -163,6 +179,7 @@ void AddKerasLayer(RModel& rmodel, PyObject* fLayer){
             throw std::runtime_error("TMVA::SOFIE - Parsing Keras Activation layer " + fLayerActivation + " is not yet supported");
          }
          rmodel.AddOperator((findActivationLayer->second)(fLayer));
+
       }
       else{
          rmodel.AddOperator((findLayer->second)(fLayer));
@@ -228,13 +245,13 @@ std::unique_ptr<ROperator> MakeKerasDense(PyObject* fLayer){
 ///
 /// For Keras's Conv layer, the names of the input tensor, output tensor, and
 /// weight tensors are extracted, along with attributes like dilation_rate,
-/// groups, kernel size, padding, strides. Padding attribute for
-/// is then computed for ROperator depending on Keras' attribute parameter.
+/// groups, kernel size, padding, strides. Padding attribute is then 
+/// computed for ROperator depending on Keras' attribute parameter.
 std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
-      PyObject* fAttributes = PyDict_GetItemString(fLayer,"layerAttributes");
-      PyObject* fInputs  = PyDict_GetItemString(fLayer,"layerInput");
-      PyObject* fOutputs = PyDict_GetItemString(fLayer,"layerOutput");
-      std::string fLayerDType = PyStringAsString(PyDict_GetItemString(fLayer,"layerDType"));
+      PyObject* fAttributes = PyDict_GetItemWithError(fLayer,PyUnicode_FromString("layerAttributes"));
+      PyObject* fInputs  = PyDict_GetItemWithError(fLayer,PyUnicode_FromString("layerInput"));
+      PyObject* fOutputs = PyDict_GetItemWithError(fLayer,PyUnicode_FromString("layerOutput"));
+      std::string fLayerDType = PyStringAsString(PyDict_GetItemWithError(fLayer,PyUnicode_FromString("layerDType")));
 
       std::string fLayerInputName  = PyStringAsString(PyList_GetItem(fInputs,0));
       std::string fLayerOutputName = PyStringAsString(PyList_GetItem(fOutputs,0));
@@ -242,16 +259,16 @@ std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
       // Extracting names of weight tensors
       // The names of Kernel weights and bias weights are found in the list
       // of weight tensors from fLayer.
-      PyObject* fWeightNames  = PyDict_GetItemString(fLayer,"layerWeight");
+      PyObject* fWeightNames  = PyDict_GetItemWithError(fLayer,PyUnicode_FromString("layerWeight"));
       std::string fKernelName = PyStringAsString(PyList_GetItem(fWeightNames,0));
       std::string fBiasName   = PyStringAsString(PyList_GetItem(fWeightNames,1));
 
       // Extracting the Conv Node Attributes
-      PyObject* fDilations       = PyDict_GetItemString(fAttributes,"dilation_rate");
-      PyObject* fGroup           = PyDict_GetItemString(fAttributes,"groups");
-      PyObject* fKernelShape     = PyDict_GetItemString(fAttributes,"kernel_size");
-      PyObject* fPads            = PyDict_GetItemString(fAttributes,"padding");
-      PyObject* fStrides         = PyDict_GetItemString(fAttributes,"strides");
+      PyObject* fDilations       = PyDict_GetItemWithError(fAttributes,PyUnicode_FromString("dilation_rate"));
+      PyObject* fGroup           = PyDict_GetItemWithError(fAttributes,PyUnicode_FromString("groups"));
+      PyObject* fKernelShape     = PyDict_GetItemWithError(fAttributes,PyUnicode_FromString("kernel_size"));
+      PyObject* fPads            = PyDict_GetItemWithError(fAttributes,PyUnicode_FromString("padding"));
+      PyObject* fStrides         = PyDict_GetItemWithError(fAttributes,PyUnicode_FromString("strides"));
 
       std::vector<size_t> fAttrDilations = GetDataFromTuple(fDilations);
 
@@ -266,28 +283,27 @@ std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
       std::string fKerasPadding = PyStringAsString(fPads);
       if(fKerasPadding == "valid"){
          fAttrAutopad = "VALID";
-	      fAttrPads    = {0,0,0,0};
       }
       else if(fKerasPadding == "same"){
-         fAttrAutopad="NOTSET";
-         PyObject* fInputShape = PyDict_GetItemString(fAttributes,"batch_input_shape");
-         long inputHeight = PyLong_AsLong(PyTuple_GetItem(fInputShape,1));
-         long inputWidth = PyLong_AsLong(PyTuple_GetItem(fInputShape,2));
+         fAttrAutopad="SAME_UPPER";
+         // PyObject* fInputShape  = PyDict_GetItemString(fLayer,"layerInputShape");
+         // long inputHeight = PyLong_AsLong(PyTuple_GetItem(fInputShape,1));
+         // long inputWidth = PyLong_AsLong(PyTuple_GetItem(fInputShape,2));
 
-         long outputHeight = std::ceil(float(inputHeight) / float(fAttrStrides[0]));
-         long outputWidth  = std::ceil(float(inputWidth) / float(fAttrStrides[1]));
+         // long outputHeight = std::ceil(float(inputHeight) / float(fAttrStrides[0]));
+         // long outputWidth  = std::ceil(float(inputWidth) / float(fAttrStrides[1]));
 
-         long x1 = (outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight;
-         long x2 = (outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth;
+         // long x1 = (outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight;
+         // long x2 = (outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth;
 
-         if(x1 < 0) x1 = 0;
-         if(x2 < 0) x2 = 0;
+         // if(x1 < 0) x1 = 0;
+         // if(x2 < 0) x2 = 0;
 
-         size_t x1_begin = std::floor(x1/2);
-         size_t x1_end   = x1 - x1_begin;
-         size_t x2_begin = std::floor(x2/2);
-         size_t x2_end   = x2 - x2_begin;
-         fAttrPads = {x1_begin,x2_begin,x1_end,x2_end};
+         // size_t x1_begin = std::floor(x1/2);
+         // size_t x1_end   = x1 - x1_begin;
+         // size_t x2_begin = std::floor(x2/2);
+         // size_t x2_end   = x2 - x2_begin;
+         // fAttrPads = {x1_begin,x2_begin,x1_end,x2_end};
       }
       else{
          throw std::runtime_error("TMVA::SOFIE - RModel Keras Parser doesn't yet supports Convolution layer with padding " + fKerasPadding);
@@ -319,7 +335,11 @@ std::unique_ptr<ROperator> MakeKerasActivation(PyObject* fLayer){
       PyObject* fAttributes=PyDict_GetItemString(fLayer,"layerAttributes");
       PyObject* fPActivation = PyDict_GetItemString(fAttributes,"activation");
       std::string fLayerActivation = PyStringAsString(PyObject_GetAttrString(fPActivation,"__name__"));
+<<<<<<< HEAD
       
+=======
+
+>>>>>>> 4f8836d2f6 (feat: transpose op before and after conv for Keras NHWC)
       auto findLayer = mapKerasLayer.find(fLayerActivation);
       if(findLayer == mapKerasLayer.end()){
          throw std::runtime_error("TMVA::SOFIE - Parsing Keras Activation layer " + fLayerActivation + " is not yet supported");
@@ -580,7 +600,6 @@ RModel Parse(std::string filename){
    PyRunString("modelData=[]",fGlobalNS,fLocalNS);
    PyRunString("for idx in range(len(model.layers)):\n"
                "  layer=model.get_layer(index=idx)\n"
-               "  globals().update(locals())\n"
                "  layerData={}\n"
                "  layerData['layerType']=layer.__class__.__name__\n"
                "  layerData['layerAttributes']=layer.__dict__\n"
@@ -618,7 +637,7 @@ RModel Parse(std::string filename){
       INTERNAL::AddKerasLayer(rmodel,fLayer);
 
    }
-
+   
    //Extracting model's weights
    //For every initialized tensor, weightProp will have its name and dtype in string
    //and value in numpy array
@@ -742,6 +761,7 @@ RModel Parse(std::string filename){
          throw std::runtime_error("Type error: TMVA SOFIE does not yet support data type"+ConvertTypeToString(fInputDType));
 
       }
+   }
    }
 
 

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -646,7 +646,7 @@ RModel Parse(std::string filename){
                "  weightProp={}\n"
                "  weightProp['name']=model.weights[idx].name\n"
                "  weightProp['dtype']=(model.get_weights())[idx].dtype.name\n"
-               "  weightProp['value']=(model.get_weights())[idx].swapaxes(0,-1) if 'conv' in model.weights[idx].name else (model.get_weights())[idx]\n"
+               "  weightProp['value']=(model.get_weights())[idx].transpose() if 'conv' in model.weights[idx].name else (model.get_weights())[idx]\n"
                "  weight.append(weightProp)",fGlobalNS,fLocalNS);
 
    PyObject *fWeightTensor, *fPWeight;

--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -285,25 +285,25 @@ std::unique_ptr<ROperator> MakeKerasConv(PyObject* fLayer){
          fAttrAutopad = "VALID";
       }
       else if(fKerasPadding == "same"){
-         fAttrAutopad="SAME_UPPER";
-         // PyObject* fInputShape  = PyDict_GetItemString(fLayer,"layerInputShape");
-         // long inputHeight = PyLong_AsLong(PyTuple_GetItem(fInputShape,1));
-         // long inputWidth = PyLong_AsLong(PyTuple_GetItem(fInputShape,2));
+         fAttrAutopad="NOTSET";
+         PyObject* fInputShape  = PyDict_GetItemString(fAttributes,"_batch_input_shape");
+         long inputHeight = PyLong_AsLong(PyTuple_GetItem(fInputShape,1));
+         long inputWidth = PyLong_AsLong(PyTuple_GetItem(fInputShape,2));
 
-         // long outputHeight = std::ceil(float(inputHeight) / float(fAttrStrides[0]));
-         // long outputWidth  = std::ceil(float(inputWidth) / float(fAttrStrides[1]));
+         long outputHeight = std::ceil(float(inputHeight) / float(fAttrStrides[0]));
+         long outputWidth  = std::ceil(float(inputWidth) / float(fAttrStrides[1]));
 
-         // long x1 = (outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight;
-         // long x2 = (outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth;
+         long x1 = (outputHeight - 1) * fAttrStrides[0] + fAttrKernelShape[0] - inputHeight;
+         long x2 = (outputWidth - 1) * fAttrStrides[1] + fAttrKernelShape[1] - inputWidth;
 
-         // if(x1 < 0) x1 = 0;
-         // if(x2 < 0) x2 = 0;
+         if(x1 < 0) x1 = 0;
+         if(x2 < 0) x2 = 0;
 
-         // size_t x1_begin = std::floor(x1/2);
-         // size_t x1_end   = x1 - x1_begin;
-         // size_t x2_begin = std::floor(x2/2);
-         // size_t x2_end   = x2 - x2_begin;
-         // fAttrPads = {x1_begin,x2_begin,x1_end,x2_end};
+         size_t x1_begin = std::floor(x1/2);
+         size_t x1_end   = x1 - x1_begin;
+         size_t x2_begin = std::floor(x2/2);
+         size_t x2_end   = x2 - x2_begin;
+         fAttrPads = {x1_begin,x2_begin,x1_end,x2_end};
       }
       else{
          throw std::runtime_error("TMVA::SOFIE - RModel Keras Parser doesn't yet supports Convolution layer with padding " + fKerasPadding);

--- a/tmva/pymva/test/EmitFromKeras.cxx
+++ b/tmva/pymva/test/EmitFromKeras.cxx
@@ -36,5 +36,15 @@ int main(){
    modelBatchNorm.Generate();
    modelBatchNorm.OutputGenerated("KerasBatchNormModel.hxx");
 
+   //Emitting header file for Keras Conv2D Model with valid padding
+   RModel modelConv2D_Valid = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelConv2D_Valid.h5");
+   modelConv2D_Valid.Generate();
+   modelConv2D_Valid.OutputGenerated("KerasConv2D_Valid.hxx");
+
+   //Emitting header file for Keras Conv2D Model with valid padding
+   RModel modelConv2D_Same = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelConv2D_Same.h5");
+   modelConv2D_Same.Generate();
+   modelConv2D_Same.OutputGenerated("KerasConv2D_Same.hxx");
+
    return 0;
 }

--- a/tmva/pymva/test/TestRModelParserKeras.C
+++ b/tmva/pymva/test/TestRModelParserKeras.C
@@ -1,6 +1,8 @@
 #include "KerasFunctionalModel.hxx"
 #include "KerasSequentialModel.hxx"
 #include "KerasBatchNormModel.hxx"
+#include "KerasConv2D_Valid.hxx"
+#include "KerasConv2D_Same.hxx"
 
 #include <Python.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
@@ -144,5 +146,89 @@ TEST(RModelParser_Keras, BATCH_NORM)
     //Testing the actual and expected output tensor values
     for (size_t i = 0; i < outputBatchNorm.size(); ++i) {
       EXPECT_LE(std::abs(outputBatchNorm[i] - pOutputBatchNorm[i]), TOLERANCE);
+    }
+}
+
+TEST(RModelParser_Keras, CONV_VALID)
+{
+    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
+    float inputConv2D_Valid[]= {1,1,1,1,
+                                1,1,1,1,
+                                1,1,1,1,
+                                1,1,1,1};
+    TMVA_SOFIE_KerasModelConv2D_Valid::Session s("KerasConv2D_Valid.dat");
+    std::vector<float> outputConv2D_Valid = s.infer(inputConv2D_Valid);
+
+    Py_Initialize();
+    PyObject* main = PyImport_AddModule("__main__");
+    PyObject* fGlobalNS = PyModule_GetDict(main);
+    PyObject* fLocalNS = PyDict_New();
+    if (!fGlobalNS) {
+        throw std::runtime_error("Can't init global namespace for Python");
+        }
+    if (!fLocalNS) {
+        throw std::runtime_error("Can't init local namespace for Python");
+        }
+    PyRun_String("import os",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("from tensorflow.keras.models import load_model",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("import numpy",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("model=load_model('KerasModelConv2D_Valid.h5')",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("input=numpy.ones((1,4,4,1))",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("output=model(input).numpy()",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("outputSize=output.size",Py_single_input,fGlobalNS,fLocalNS);
+    std::size_t pOutputConv2DValidSize=(std::size_t)PyLong_AsLong(PyDict_GetItemString(fLocalNS,"outputSize"));
+
+    //Testing the actual and expected output tensor sizes
+    EXPECT_EQ(outputConv2D_Valid.size(), pOutputConv2DValidSize);
+
+    PyArrayObject* pConv2DValidValues=(PyArrayObject*)PyDict_GetItemString(fLocalNS,"output");
+    float* pOutputConv2DValid=(float*)PyArray_DATA(pConv2DValidValues);
+
+    //Testing the actual and expected output tensor values
+    for (size_t i = 0; i < outputConv2D_Valid.size(); ++i) {
+      EXPECT_LE(std::abs(outputConv2D_Valid[i] - pOutputConv2DValid[i]), TOLERANCE);
+    }
+}
+
+TEST(RModelParser_Keras, CONV_SAME)
+{
+    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
+    float inputConv2D_Same[]= {1,1,1,1,
+                                1,1,1,1,
+                                1,1,1,1,
+                                1,1,1,1};
+    TMVA_SOFIE_KerasModelConv2D_Same::Session s("KerasConv2D_Same.dat");
+    std::vector<float> outputConv2D_Same = s.infer(inputConv2D_Same);
+
+    Py_Initialize();
+    PyObject* main = PyImport_AddModule("__main__");
+    PyObject* fGlobalNS = PyModule_GetDict(main);
+    PyObject* fLocalNS = PyDict_New();
+    if (!fGlobalNS) {
+        throw std::runtime_error("Can't init global namespace for Python");
+        }
+    if (!fLocalNS) {
+        throw std::runtime_error("Can't init local namespace for Python");
+        }
+    PyRun_String("import os",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("from tensorflow.keras.models import load_model",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("import numpy",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("model=load_model('KerasModelConv2D_Same.h5')",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("input=numpy.ones((1,4,4,1))",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("output=model(input).numpy()",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("outputSize=output.size",Py_single_input,fGlobalNS,fLocalNS);
+    std::size_t pOutputConv2DSameSize=(std::size_t)PyLong_AsLong(PyDict_GetItemString(fLocalNS,"outputSize"));
+
+    //Testing the actual and expected output tensor sizes
+    EXPECT_EQ(outputConv2D_Same.size(), pOutputConv2DSameSize);
+
+    PyArrayObject* pConv2DSameValues=(PyArrayObject*)PyDict_GetItemString(fLocalNS,"output");
+    float* pOutputConv2DSame=(float*)PyArray_DATA(pConv2DSameValues);
+
+    //Testing the actual and expected output tensor values
+    for (size_t i = 0; i < outputConv2D_Same.size(); ++i) {
+      EXPECT_LE(std::abs(outputConv2D_Same[i] - pOutputConv2DSame[i]), TOLERANCE);
     }
 }

--- a/tmva/pymva/test/generateKerasModels.py
+++ b/tmva/pymva/test/generateKerasModels.py
@@ -3,7 +3,7 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 import numpy as np
 from tensorflow.keras.models import Model,Sequential
-from tensorflow.keras.layers import Input,Dense,Activation,ReLU,BatchNormalization
+from tensorflow.keras.layers import Input,Dense,Activation,ReLU,BatchNormalization,Conv2D
 from tensorflow.keras.optimizers import SGD
 
 def generateFunctionalModel():
@@ -52,6 +52,32 @@ def generateBatchNormModel():
     model.fit(x_train, y_train, epochs=10, batch_size=2)
     model.save('KerasModelBatchNorm.h5')
 
+def generateConv2DModel_ValidPadding():
+    model=Sequential()
+    model.add(Conv2D(8, kernel_size=3, activation="relu", input_shape=(4,4,1), padding="valid"))
+
+    randomGenerator=np.random.RandomState(0)
+    x_train=randomGenerator.rand(1,4,4,1)
+    y_train=randomGenerator.rand(1,2,2,8)
+
+    model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
+    model.fit(x_train, y_train, epochs=10, batch_size=2)
+    model.save('KerasModelConv2D_Valid.h5')
+
+def generateConv2DModel_SamePadding():
+    model=Sequential()
+    model.add(Conv2D(8, kernel_size=3, activation="relu", input_shape=(4,4,1), padding="same"))
+
+    randomGenerator=np.random.RandomState(0)
+    x_train=randomGenerator.rand(1,4,4,1)
+    y_train=randomGenerator.rand(1,4,4,8)
+
+    model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
+    model.fit(x_train, y_train, epochs=10, batch_size=2)
+    model.save('KerasModelConv2D_Same.h5')
+
 generateFunctionalModel()
 generateSequentialModel()
 generateBatchNormModel()
+generateConv2DModel_ValidPadding()
+generateConv2DModel_SamePadding()


### PR DESCRIPTION
This PR adds support for parsing Convolution layers from PyTorch and Keras models into an RModel object.

## Progress
- [x] Support for Keras Convolution Layers(Conv2D)          
  - [x] Support for `padding="valid"`
  - [x] Support for `padding="same"`
  - [x]  Tests

## Checklist:
- [x] tested changes locally