### PR TITLE
Remove the source dir from compiler flags on Windows

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -704,6 +704,11 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/ROOTConfig-version.cmake.in
 string(REGEX REPLACE "(^|[ ]*)-W[^ ]*" "" __cxxflags "${CMAKE_CXX_FLAGS}")
 string(REGEX REPLACE "(^|[ ]*)-W[^ ]*" "" __cflags "${CMAKE_C_FLAGS}")
 
+if(MSVC)
+  string(REPLACE "-I${CMAKE_SOURCE_DIR}/build/win" "" __cxxflags "${__cxxflags}")
+  string(REPLACE "-I${CMAKE_SOURCE_DIR}/build/win" "" __cflags "${__cflags}")
+endif()
+
 if (cxxmodules)
   # Re-add the -Wno-module-import-in-extern-c which we just filtered out.
   # We want it because it changes the module cache hash and causes modules to be


### PR DESCRIPTION
Remove `-I${CMAKE_SOURCE_DIR}/build/win` from `ROOT_CXX_FLAGS`. To be merged after #9669
