### PR TITLE
Fix compilation, improve Oracle documentation

### DIFF
--- a/graf3d/ftgl/inc/FTFont.h
+++ b/graf3d/ftgl/inc/FTFont.h
@@ -122,7 +122,7 @@ class FTGL_EXPORT FTFont
          *
          * @param depth  The extrusion distance.
          */
-        virtual void Depth( float depth){}
+        virtual void Depth(float /* depth */){}
 
         /**
          * Enable or disable the use of Display Lists inside FTGL

--- a/sql/oracle/src/TOracleResult.cxx
+++ b/sql/oracle/src/TOracleResult.cxx
@@ -19,33 +19,31 @@
 
 #include <occi.h>
 
-using namespace oracle::occi;
-
 ClassImp(TOracleResult);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Oracle query result.
 
-void TOracleResult::initResultSet(Statement *stmt)
+void TOracleResult::initResultSet(oracle::occi::Statement *stmt)
 {
    if (!stmt) {
       Error("initResultSet", "construction: empty statement");
    } else {
       try {
          fStmt = stmt;
-         if (stmt->status() == Statement::RESULT_SET_AVAILABLE) {
+         if (stmt->status() == oracle::occi::Statement::RESULT_SET_AVAILABLE) {
             fResultType  = 1;
             fResult      = stmt->getResultSet();
-            fFieldInfo   = fResult ? new std::vector<MetaData>(fResult->getColumnListMetaData()) : nullptr;
+            fFieldInfo   = fResult ? new std::vector<oracle::occi::MetaData>(fResult->getColumnListMetaData()) : nullptr;
             fFieldCount  = fFieldInfo ? fFieldInfo->size() : 0;
-         } else if (stmt->status() == Statement::UPDATE_COUNT_AVAILABLE) {
+         } else if (stmt->status() == oracle::occi::Statement::UPDATE_COUNT_AVAILABLE) {
             fResultType  = 3; // this is update_count_available
             fResult      = nullptr;
             fFieldInfo   = nullptr;
             fFieldCount  = 0;
             fUpdateCount = stmt->getUpdateCount();
          }
-      } catch (SQLException &oraex) {
+      } catch (oracle::occi::SQLException &oraex) {
          Error("initResultSet", "%s", (oraex.getMessage()).c_str());
          MakeZombie();
       }
@@ -88,8 +86,8 @@ TOracleResult::TOracleResult(oracle::occi::Connection *conn, const char *tableNa
    if (!tableName || !conn) {
       Error("TOracleResult", "construction: empty input parameter");
    } else {
-      MetaData connMD = conn->getMetaData(tableName, MetaData::PTYPE_TABLE);
-      fFieldInfo   = new std::vector<MetaData>(connMD.getVector(MetaData::ATTR_LIST_COLUMNS));
+      oracle::occi::MetaData connMD = conn->getMetaData(tableName, oracle::occi::MetaData::PTYPE_TABLE);
+      fFieldInfo   = new std::vector<oracle::occi::MetaData>(connMD.getVector(oracle::occi::MetaData::ATTR_LIST_COLUMNS));
       fFieldCount  = fFieldInfo->size();
       fResultType  = 2; // indicates that this is just an table metainfo
    }
@@ -156,7 +154,7 @@ const char *TOracleResult::GetFieldName(Int_t field)
 {
    if (!IsValid(field))
       return nullptr;
-   fNameBuffer = (*fFieldInfo)[field].getString(MetaData::ATTR_NAME);
+   fNameBuffer = (*fFieldInfo)[field].getString(oracle::occi::MetaData::ATTR_NAME);
    return fNameBuffer.c_str();
 }
 
@@ -181,7 +179,7 @@ TSQLRow *TOracleResult::Next()
          return new TOracleRow(fResult, fFieldInfo);
       } else
          return 0;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       Error("Next", "%s", (oraex.getMessage()).c_str());
       MakeZombie();
    }

--- a/sql/oracle/src/TOracleRow.cxx
+++ b/sql/oracle/src/TOracleRow.cxx
@@ -19,8 +19,6 @@
 
 ClassImp(TOracleRow);
 
-using namespace oracle::occi;
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Single row of query result.
 
@@ -85,9 +83,9 @@ ULong_t TOracleRow::GetFieldLength(Int_t field)
    if (!IsValid(field) || fFieldInfo->size() <= 0)
       return 0;
 
-   MetaData fieldMD = (*fFieldInfo)[field];
+   oracle::occi::MetaData fieldMD = (*fFieldInfo)[field];
 
-   return fieldMD.getInt(MetaData::ATTR_DATA_SIZE);
+   return fieldMD.getInt(oracle::occi::MetaData::ATTR_DATA_SIZE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,12 +122,12 @@ void TOracleRow::GetRowData()
    for (int field=0;field<fFieldCount;field++) {
       if (fResult->isNull(field+1)) continue;
 
-      fDataType = (*fFieldInfo)[field].getInt(MetaData::ATTR_DATA_TYPE);
+      fDataType = (*fFieldInfo)[field].getInt(oracle::occi::MetaData::ATTR_DATA_TYPE);
 
       switch (fDataType) {
         case SQLT_NUM: //NUMBER
-           fPrecision = (*fFieldInfo)[field].getInt(MetaData::ATTR_PRECISION);
-           fScale = (*fFieldInfo)[field].getInt(MetaData::ATTR_SCALE);
+           fPrecision = (*fFieldInfo)[field].getInt(oracle::occi::MetaData::ATTR_PRECISION);
+           fScale = (*fFieldInfo)[field].getInt(oracle::occi::MetaData::ATTR_SCALE);
 
            if ((fScale == 0) || (fPrecision == 0)) {
               res = fResult->getString(field+1);
@@ -170,7 +168,7 @@ void TOracleRow::GetRowData()
       }
    }
 
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       Error("GetRowData", "%s", (oraex.getMessage()).c_str());
    }
 }

--- a/sql/oracle/src/TOracleServer.cxx
+++ b/sql/oracle/src/TOracleServer.cxx
@@ -63,8 +63,6 @@
 
 ClassImp(TOracleServer);
 
-using namespace oracle::occi;
-
 const char *TOracleServer::fgDatimeFormat = "MM/DD/YYYY, HH24:MI:SS";
 
 
@@ -78,7 +76,7 @@ const char *TOracleServer::fgDatimeFormat = "MM/DD/YYYY, HH24:MI:SS";
 
 // catch Oracle exception after try block
 #define CatchError(method)                           \
-   catch (SQLException &oraex) {                     \
+   catch (oracle::occi::SQLException &oraex) {                     \
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), method); \
    }
 
@@ -125,9 +123,9 @@ TOracleServer::TOracleServer(const char *db, const char *uid, const char *pw)
       Int_t pos = options.Index("ObjectMode");
       // create environment accordingly
       if (pos != kNPOS) {
-        fEnv = Environment::createEnvironment(Environment::OBJECT);
+        fEnv = oracle::occi::Environment::createEnvironment(oracle::occi::Environment::OBJECT);
       } else {
-        fEnv = Environment::createEnvironment();
+        fEnv = oracle::occi::Environment::createEnvironment();
       }
       fConn = fEnv->createConnection(uid, pw, conn_str ? conn_str : "");
 
@@ -152,7 +150,6 @@ TOracleServer::~TOracleServer()
       Close();
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Close connection to Oracle DB server.
 
@@ -164,7 +161,7 @@ void TOracleServer::Close(Option_t *)
       if (fConn)
          fEnv->terminateConnection(fConn);
       if (fEnv)
-         Environment::terminateEnvironment(fEnv);
+         oracle::occi::Environment::terminateEnvironment(fEnv);
    } CatchError("Close")
 
    fPort = -1;
@@ -184,7 +181,7 @@ TSQLStatement *TOracleServer::Statement(const char *sql, Int_t niter)
    try {
       oracle::occi::Statement *stmt = fConn->createStatement(sql);
 
-      Blob parblob(fConn);
+      oracle::occi::Blob parblob(fConn);
 
       return new TOracleStatement(fEnv, fConn, stmt, niter, fErrorOut);
 
@@ -604,12 +601,12 @@ Bool_t TOracleServer::Rollback()
 
 void TOracleServer::SetDatimeFormat(const char* fmt)
 {
-   if (fmt==0) fmt = "MM/DD/YYYY, HH24:MI:SS";
+   if (!fmt) fmt = "MM/DD/YYYY, HH24:MI:SS";
    fgDatimeFormat = fmt;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// return value of actul convertion format from timestamps or date to string
+/// return value of actual conversion format from timestamps or date to string
 
 const char* TOracleServer::GetDatimeFormat()
 {

--- a/sql/oracle/src/TOracleStatement.cxx
+++ b/sql/oracle/src/TOracleStatement.cxx
@@ -28,8 +28,6 @@
 
 ClassImp(TOracleStatement);
 
-using namespace oracle::occi;
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Normal constructor of TOracleStatement class
@@ -88,7 +86,7 @@ void TOracleStatement::Close(Option_t *)
 #define CheckStatement(method, res)                     \
    {                                                    \
       ClearError();                                     \
-      if (fStmt==0) {                                   \
+      if (!fStmt) {                                   \
          SetError(-1,"Statement is not correctly initialized",method); \
          return res;                                    \
       }                                                 \
@@ -175,7 +173,7 @@ Bool_t TOracleStatement::Process()
       }
 
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "Process");
    }
 
@@ -192,7 +190,7 @@ Int_t TOracleStatement::GetNumAffectedRows()
 
    try {
       return fStmt->getUpdateCount();
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetNumAffectedRows");
    }
    return -1;
@@ -220,10 +218,10 @@ Bool_t TOracleStatement::SetNull(Int_t npar)
    CheckSetPar("SetNull");
 
    try {
-      fStmt->setNull(npar+1, OCCIINT);
+      fStmt->setNull(npar+1, oracle::occi::OCCIINT);
 
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetNull");
    }
 
@@ -242,7 +240,7 @@ Bool_t TOracleStatement::SetInt(Int_t npar, Int_t value)
       fStmt->setInt(npar+1, value);
 
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetInt");
    }
 
@@ -259,7 +257,7 @@ Bool_t TOracleStatement::SetUInt(Int_t npar, UInt_t value)
    try {
       fStmt->setUInt(npar+1, value);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetUInt");
    }
 
@@ -274,9 +272,9 @@ Bool_t TOracleStatement::SetLong(Int_t npar, Long_t value)
    CheckSetPar("SetLong");
 
    try {
-      fStmt->setNumber(npar+1, Number(value));
+      fStmt->setNumber(npar+1, oracle::occi::Number(value));
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetLong");
    }
    return kFALSE;
@@ -290,9 +288,9 @@ Bool_t TOracleStatement::SetLong64(Int_t npar, Long64_t value)
    CheckSetPar("SetLong64");
 
    try {
-      fStmt->setNumber(npar+1, Number((long double)value));
+      fStmt->setNumber(npar+1, oracle::occi::Number((long double)value));
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetLong64");
    }
    return kFALSE;
@@ -306,9 +304,9 @@ Bool_t TOracleStatement::SetULong64(Int_t npar, ULong64_t value)
    CheckSetPar("SetULong64");
 
    try {
-      fStmt->setNumber(npar+1, Number((long double)value));
+      fStmt->setNumber(npar+1, oracle::occi::Number((long double)value));
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetULong64");
    }
    return kFALSE;
@@ -324,7 +322,7 @@ Bool_t TOracleStatement::SetDouble(Int_t npar, Double_t value)
    try {
       fStmt->setDouble(npar+1, value);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetDouble");
    }
    return kFALSE;
@@ -347,7 +345,7 @@ Bool_t TOracleStatement::SetString(Int_t npar, const char* value, Int_t maxsize)
 
       fStmt->setString(npar+1, value);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetString");
    }
    return kFALSE;
@@ -366,13 +364,13 @@ Bool_t TOracleStatement::SetBinary(Int_t npar, void* mem, Long_t size, Long_t ma
       if (fIterCounter==1)
          fStmt->setMaxParamSize(npar+1, maxsize);
 
-      Bytes buf((unsigned char*) mem, size);
+      oracle::occi::Bytes buf((unsigned char*) mem, size);
 
       fStmt->setBytes(npar+1, buf);
 
       return kTRUE;
 
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetBinary");
    }
    return kFALSE;
@@ -386,14 +384,14 @@ Bool_t TOracleStatement::SetDate(Int_t npar, Int_t year, Int_t month, Int_t day)
    CheckSetPar("SetDate");
 
    try {
-      Date tm = fStmt->getDate(npar+1);
+      oracle::occi::Date tm = fStmt->getDate(npar+1);
       int o_year;
       unsigned int o_month, o_day, o_hour, o_minute, o_second;
       tm.getDate(o_year, o_month, o_day, o_hour, o_minute, o_second);
       tm.setDate(year, month, day, o_hour, o_minute, o_second);
       fStmt->setDate(npar+1, tm);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetDate");
    }
 
@@ -408,14 +406,14 @@ Bool_t TOracleStatement::SetTime(Int_t npar, Int_t hour, Int_t min, Int_t sec)
    CheckSetPar("SetTime");
 
    try {
-      Date tm = fStmt->getDate(npar+1);
+      oracle::occi::Date tm = fStmt->getDate(npar+1);
       int o_year;
       unsigned int o_month, o_day, o_hour, o_minute, o_second;
       tm.getDate(o_year, o_month, o_day, o_hour, o_minute, o_second);
       tm.setDate(o_year, o_month, o_day, hour, min, sec);
       fStmt->setDate(npar+1, tm);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetTime");
    }
 
@@ -430,10 +428,10 @@ Bool_t TOracleStatement::SetDatime(Int_t npar, Int_t year, Int_t month, Int_t da
    CheckSetPar("SetDatime");
 
    try {
-      Date tm(fEnv, year, month, day, hour, min, sec);
+      oracle::occi::Date tm(fEnv, year, month, day, hour, min, sec);
       fStmt->setDate(npar+1, tm);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetDatime");
    }
 
@@ -448,10 +446,10 @@ Bool_t TOracleStatement::SetTimestamp(Int_t npar, Int_t year, Int_t month, Int_t
    CheckSetPar("SetTimestamp");
 
    try {
-      Timestamp tm(fEnv, year, month, day, hour, min, sec, frac);
+      oracle::occi::Timestamp tm(fEnv, year, month, day, hour, min, sec, frac);
       fStmt->setTimestamp(npar+1, tm);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetTimestamp");
    }
 
@@ -468,7 +466,7 @@ Bool_t TOracleStatement::SetVInt(Int_t npar, const std::vector<Int_t> value, con
    try {
       setVector(fStmt, npar+1, value, schemaName, typeName);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetVInt");
    }
 
@@ -485,7 +483,7 @@ Bool_t TOracleStatement::SetVUInt(Int_t npar, const std::vector<UInt_t> value, c
    try {
       setVector(fStmt, npar+1, value, schemaName, typeName);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetVUInt");
    }
 
@@ -500,15 +498,15 @@ Bool_t TOracleStatement::SetVLong(Int_t npar, const std::vector<Long_t> value, c
    CheckSetPar("SetVLong");
 
    try {
-      std::vector<Number> nvec;
+      std::vector<oracle::occi::Number> nvec;
       for (std::vector<Long_t>::const_iterator it = value.begin();
            it != value.end();
            ++it) {
-         nvec.push_back(Number(*it));
+         nvec.push_back(oracle::occi::Number(*it));
       }
       setVector(fStmt, npar+1, nvec, schemaName, typeName);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetVLong");
    }
    return kFALSE;
@@ -522,15 +520,15 @@ Bool_t TOracleStatement::SetVLong64(Int_t npar, const std::vector<Long64_t> valu
    CheckSetPar("SetVLong64");
 
    try {
-      std::vector<Number> nvec;
+      std::vector<oracle::occi::Number> nvec;
       for (std::vector<Long64_t>::const_iterator it = value.begin();
            it != value.end();
            ++it) {
-        nvec.push_back(Number((long double)*it));
+        nvec.push_back(oracle::occi::Number((long double)*it));
       }
       setVector(fStmt, npar+1, nvec, schemaName, typeName);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetVLong64");
    }
    return kFALSE;
@@ -544,15 +542,15 @@ Bool_t TOracleStatement::SetVULong64(Int_t npar, std::vector<ULong64_t> value, c
    CheckSetPar("SetVULong64");
 
    try {
-      std::vector<Number> nvec;
+      std::vector<oracle::occi::Number> nvec;
       for (std::vector<ULong64_t>::const_iterator it = value.begin();
            it != value.end();
            ++it) {
-        nvec.push_back(Number((long double)*it));
+        nvec.push_back(oracle::occi::Number((long double)*it));
       }
       setVector(fStmt, npar+1, nvec, schemaName, typeName);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetVULong64");
    }
    return kFALSE;
@@ -568,7 +566,7 @@ Bool_t TOracleStatement::SetVDouble(Int_t npar, const std::vector<Double_t> valu
    try {
       setVector(fStmt, npar+1, value, schemaName, typeName);
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetVDouble");
    }
    return kFALSE;
@@ -583,7 +581,7 @@ Bool_t TOracleStatement::NextIteration()
 
    try {
       fWorkingMode=1;
-      // if number of iterations achievs limit, execute it and continue to fill
+      // if number of iterations achieves limit, execute it and continue to fill
       if ((fIterCounter % fNumIterations == 0) && (fIterCounter>0)) {
          fStmt->executeUpdate();
       }
@@ -595,7 +593,7 @@ Bool_t TOracleStatement::NextIteration()
       fIterCounter++;
 
       return kTRUE;
-   } catch (SQLException &oraex)  {
+   } catch (oracle::occi::SQLException &oraex)  {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "NextIteration");
    }
    return kFALSE;
@@ -610,16 +608,16 @@ Bool_t TOracleStatement::StoreResult()
    CheckStatement("StoreResult", kFALSE);
 
    try {
-      if (fStmt->status() == Statement::RESULT_SET_AVAILABLE) {
+      if (fStmt->status() == oracle::occi::Statement::RESULT_SET_AVAILABLE) {
          fResult      = fStmt->getResultSet();
-         fFieldInfo   = (fResult==0) ? 0 : new std::vector<MetaData>(fResult->getColumnListMetaData());
+         fFieldInfo   = (fResult==0) ? 0 : new std::vector<oracle::occi::MetaData>(fResult->getColumnListMetaData());
          Int_t count  = (fFieldInfo==0) ? 0 : fFieldInfo->size();
          SetBufferSize(count);
          if ((fResult!=0) && (count>0)) fWorkingMode = 2;
 
          return IsResultSet();
       }
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "StoreResult");
    }
    return kFALSE;
@@ -627,7 +625,7 @@ Bool_t TOracleStatement::StoreResult()
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Defines maximum size for field which must be used for read or write operation
-/// Some Oracle types as LONG (long binary continer) requires this call
+/// Some Oracle types as LONG (long binary container) requires this call
 /// before any data can be read from database. Call it once before first call to NextResultRow()
 
 Bool_t TOracleStatement::SetMaxFieldSize(Int_t nfield, Long_t maxsize)
@@ -640,7 +638,7 @@ Bool_t TOracleStatement::SetMaxFieldSize(Int_t nfield, Long_t maxsize)
       else
          fStmt->setMaxParamSize(nfield+1, maxsize);
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "SetMaxFieldSize");
    }
 
@@ -665,7 +663,7 @@ const char* TOracleStatement::GetFieldName(Int_t npar)
    if (!IsResultSet() || (npar<0) || (npar>=fBufferSize)) return nullptr;
 
    if (fBuffer[npar].namebuf.empty())
-      fBuffer[npar].namebuf = (*fFieldInfo)[npar].getString(MetaData::ATTR_NAME);
+      fBuffer[npar].namebuf = (*fFieldInfo)[npar].getString(oracle::occi::MetaData::ATTR_NAME);
 
    return fBuffer[npar].namebuf.empty() ? nullptr : fBuffer[npar].namebuf.c_str();
 }
@@ -699,7 +697,7 @@ Bool_t TOracleStatement::NextResultRow()
          return kFALSE;
       }
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "NextResultRow");
 
       if (oraex.getErrorCode()==32108)
@@ -719,7 +717,7 @@ Bool_t TOracleStatement::IsNull(Int_t npar)
 
    try {
       return fResult->isNull(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "IsNull");
    }
 
@@ -738,7 +736,7 @@ Int_t TOracleStatement::GetInt(Int_t npar)
    try {
       if (!fResult->isNull(npar+1))
         res = fResult->getInt(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetInt");
    }
 
@@ -757,7 +755,7 @@ UInt_t TOracleStatement::GetUInt(Int_t npar)
    try {
       if (!fResult->isNull(npar+1))
         res = fResult->getUInt(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetUInt");
    }
 
@@ -777,7 +775,7 @@ Long_t TOracleStatement::GetLong(Int_t npar)
    try {
       if (!fResult->isNull(npar+1))
         res = (Long_t) fResult->getNumber(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetLong");
    }
 
@@ -796,7 +794,7 @@ Long64_t TOracleStatement::GetLong64(Int_t npar)
    try {
       if (!fResult->isNull(npar+1))
         res = (Long64_t) (long double) fResult->getNumber(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetLong64");
    }
 
@@ -815,7 +813,7 @@ ULong64_t TOracleStatement::GetULong64(Int_t npar)
    try {
       if (!fResult->isNull(npar+1))
         res = (ULong64_t) (long double) fResult->getNumber(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetULong64");
    }
 
@@ -834,7 +832,7 @@ Double_t TOracleStatement::GetDouble(Int_t npar)
    try {
       if (!fResult->isNull(npar+1))
         res = fResult->getDouble(npar+1);
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetDouble");
    }
 
@@ -854,14 +852,14 @@ const char* TOracleStatement::GetString(Int_t npar)
    try {
       if (fResult->isNull(npar+1)) return 0;
 
-      int datatype = (*fFieldInfo)[npar].getInt(MetaData::ATTR_DATA_TYPE);
+      int datatype = (*fFieldInfo)[npar].getInt(oracle::occi::MetaData::ATTR_DATA_TYPE);
 
       std::string res;
 
       switch (datatype) {
         case SQLT_NUM: { // oracle numeric NUMBER
-           int prec = (*fFieldInfo)[npar].getInt(MetaData::ATTR_PRECISION);
-           int scale = (*fFieldInfo)[npar].getInt(MetaData::ATTR_SCALE);
+           int prec = (*fFieldInfo)[npar].getInt(oracle::occi::MetaData::ATTR_PRECISION);
+           int scale = (*fFieldInfo)[npar].getInt(oracle::occi::MetaData::ATTR_SCALE);
 
            if ((scale == 0) || (prec == 0)) {
               res = fResult->getString(npar+1);
@@ -902,7 +900,7 @@ const char* TOracleStatement::GetString(Int_t npar)
 
       return (const char *)fBuffer[npar].membuf;
 
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetString");
    }
 
@@ -931,11 +929,11 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
    try {
       if (fResult->isNull(npar+1)) return kTRUE;
 
-      int datatype = (*fFieldInfo)[npar].getInt(MetaData::ATTR_DATA_TYPE);
+      int datatype = (*fFieldInfo)[npar].getInt(oracle::occi::MetaData::ATTR_DATA_TYPE);
 
       switch (datatype) {
          case SQLT_LNG: {
-            Bytes parbytes = fResult->getBytes(npar+1);
+            oracle::occi::Bytes parbytes = fResult->getBytes(npar+1);
 
             size = parbytes.length();
 
@@ -953,7 +951,7 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
          }
 
          case SQLT_BLOB: {
-            Blob parblob = fResult->getBlob(npar+1);
+            oracle::occi::Blob parblob = fResult->getBlob(npar+1);
 
             size = parblob.length();
 
@@ -971,7 +969,7 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
          }
 
          case SQLT_CLOB: {
-            Clob parclob = fResult->getClob(npar+1);
+            oracle::occi::Clob parclob = fResult->getClob(npar+1);
 
             size = parclob.length();
 
@@ -991,7 +989,7 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
          case SQLT_BFILEE:
          case SQLT_CFILEE: {
 
-            Bfile parbfile = fResult->getBfile(npar+1);
+            oracle::occi::Bfile parbfile = fResult->getBfile(npar+1);
 
             size = parbfile.length();
 
@@ -1016,7 +1014,7 @@ Bool_t TOracleStatement::GetBinary(Int_t npar, void* &mem, Long_t& size)
 
       return kTRUE;
 
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetBinary");
    }
 
@@ -1053,11 +1051,11 @@ Bool_t TOracleStatement::GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t&
 
    try {
       if (!fResult->isNull(npar+1)) {
-         int datatype = (*fFieldInfo)[npar].getInt(MetaData::ATTR_DATA_TYPE);
+         int datatype = (*fFieldInfo)[npar].getInt(oracle::occi::MetaData::ATTR_DATA_TYPE);
 
          if (datatype!=SQLT_DAT) return kFALSE;
 
-         Date tm = fResult->getDate(npar+1);
+         oracle::occi::Date tm = fResult->getDate(npar+1);
          int o_year;
          unsigned int o_month, o_day, o_hour, o_minute, o_second;
          tm.getDate(o_year, o_month, o_day, o_hour, o_minute, o_second);
@@ -1069,7 +1067,7 @@ Bool_t TOracleStatement::GetDatime(Int_t npar, Int_t& year, Int_t& month, Int_t&
          sec = (Int_t) o_second;
          return kTRUE;
       }
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetDatime");
    }
 
@@ -1085,13 +1083,13 @@ Bool_t TOracleStatement::GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int
 
    try {
       if (!fResult->isNull(npar+1)) {
-         int datatype = (*fFieldInfo)[npar].getInt(MetaData::ATTR_DATA_TYPE);
+         int datatype = (*fFieldInfo)[npar].getInt(oracle::occi::MetaData::ATTR_DATA_TYPE);
 
          if ((datatype!=SQLT_TIMESTAMP) &&
              (datatype!=SQLT_TIMESTAMP_TZ) &&
              (datatype!=SQLT_TIMESTAMP_LTZ)) return kFALSE;
 
-         Timestamp tm = fResult->getTimestamp(npar+1);
+         oracle::occi::Timestamp tm = fResult->getTimestamp(npar+1);
          int o_year;
          unsigned int o_month, o_day, o_hour, o_minute, o_second, o_frac;
          tm.getDate(o_year, o_month, o_day);
@@ -1105,7 +1103,7 @@ Bool_t TOracleStatement::GetTimestamp(Int_t npar, Int_t& year, Int_t& month, Int
          frac = (Int_t) o_frac;
          return kTRUE;
       }
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetTimestamp");
    }
 
@@ -1122,7 +1120,7 @@ Bool_t TOracleStatement::GetVInt(Int_t npar, std::vector<Int_t> &value)
       if (!fResult->isNull(npar+1))
          getVector(fResult, npar+1, value);
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetVInt");
    }
    return kFALSE;
@@ -1138,7 +1136,7 @@ Bool_t TOracleStatement::GetVUInt(Int_t npar, std::vector<UInt_t> &value)
       if (!fResult->isNull(npar+1))
          getVector(fResult, npar+1, value);
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetVUInt");
    }
    return kFALSE;
@@ -1152,16 +1150,16 @@ Bool_t TOracleStatement::GetVLong(Int_t npar, std::vector<Long_t> &value)
 {
    CheckGetField("GetVLong", kFALSE);
    try {
-      std::vector<Number> res;
+      std::vector<oracle::occi::Number> res;
       if (!fResult->isNull(npar+1))
          getVector(fResult, npar+1, res);
-      for (std::vector<Number>::const_iterator it = res.begin();
+      for (std::vector<oracle::occi::Number>::const_iterator it = res.begin();
            it != res.end();
            ++it ) {
          value.push_back((Long_t)*it);
       }
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetVLong");
    }
    return kFALSE;
@@ -1174,16 +1172,16 @@ Bool_t TOracleStatement::GetVLong64(Int_t npar, std::vector<Long64_t> &value)
 {
    CheckGetField("GetVLong64", kFALSE);
    try {
-      std::vector<Number> res;
+      std::vector<oracle::occi::Number> res;
       if (!fResult->isNull(npar+1))
          getVector(fResult, npar+1, res);
-      for (std::vector<Number>::const_iterator it = res.begin();
+      for (std::vector<oracle::occi::Number>::const_iterator it = res.begin();
            it != res.end();
            ++it ) {
          value.push_back((Long_t)*it);
       }
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetVLong64");
    }
    return kFALSE;
@@ -1196,16 +1194,16 @@ Bool_t TOracleStatement::GetVULong64(Int_t npar, std::vector<ULong64_t> &value)
 {
    CheckGetField("GetVULong64", kFALSE);
    try {
-      std::vector<Number> res;
+      std::vector<oracle::occi::Number> res;
       if (!fResult->isNull(npar+1))
          getVector(fResult, npar+1, res);
-      for (std::vector<Number>::const_iterator it = res.begin();
+      for (std::vector<oracle::occi::Number>::const_iterator it = res.begin();
            it != res.end();
            ++it ) {
         value.push_back((Long_t)(long double)*it);
       }
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetVULong64");
    }
    return kFALSE;
@@ -1221,7 +1219,7 @@ Bool_t TOracleStatement::GetVDouble(Int_t npar, std::vector<Double_t> &value)
       if (!fResult->isNull(npar+1))
          getVector(fResult, npar+1, value);
       return kTRUE;
-   } catch (SQLException &oraex) {
+   } catch (oracle::occi::SQLException &oraex) {
       SetError(oraex.getErrorCode(), oraex.getMessage().c_str(), "GetVDouble");
    }
    return kFALSE;

--- a/sql/oracle/src/TOracleStatement.cxx
+++ b/sql/oracle/src/TOracleStatement.cxx
@@ -610,10 +610,10 @@ Bool_t TOracleStatement::StoreResult()
    try {
       if (fStmt->status() == oracle::occi::Statement::RESULT_SET_AVAILABLE) {
          fResult      = fStmt->getResultSet();
-         fFieldInfo   = (fResult==0) ? 0 : new std::vector<oracle::occi::MetaData>(fResult->getColumnListMetaData());
-         Int_t count  = (fFieldInfo==0) ? 0 : fFieldInfo->size();
+         fFieldInfo   = !fResult ? nullptr : new std::vector<oracle::occi::MetaData>(fResult->getColumnListMetaData());
+         Int_t count  = !fFieldInfo ? 0 : fFieldInfo->size();
          SetBufferSize(count);
-         if ((fResult!=0) && (count>0)) fWorkingMode = 2;
+         if (fResult && (count > 0)) fWorkingMode = 2;
 
          return IsResultSet();
       }
@@ -676,12 +676,10 @@ Bool_t TOracleStatement::NextResultRow()
 {
    ClearError();
 
-   if (fResult==0) {
+   if (!fResult) {
       SetError(-1,"There is no result set for statement", "NextResultRow");
       return kFALSE;
    }
-
-   if (fResult==0) return kFALSE;
 
    try {
       for (int n=0;n<fBufferSize;n++) {


### PR DESCRIPTION
After #9673 compilation in `dev` mode is broken - warnings are converted to errors.

Plus update Oracle code to use namespace clearly - should help for Doxygen documentation