### PR TITLE
Backport windows build fixes to 6.26 branch

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -14,6 +14,7 @@ if(WIN32)
     win/bindexplib/bindexplib.cxx
   )
   file(COPY win/w32pragma.h DESTINATION ${CMAKE_BINARY_DIR}/include/)
+  file(COPY win/sehmap.h DESTINATION ${CMAKE_BINARY_DIR}/include/)
 endif()
 
 ROOT_EXECUTABLE(rmkdepend

--- a/build/win/w32pragma.h
+++ b/build/win/w32pragma.h
@@ -29,8 +29,6 @@
 #pragma warning (disable: 4661)
 /* "deprecated, use ISO C++ conformant name" */
 #pragma warning (disable: 4996)
-/* "new behavior: elements default initialized" */
-#pragma warning (disable: 4351)
 /* local static not thread safe */
 #pragma warning (disable: 4640)
 /*forcing int to bool (performance warning) */
@@ -45,10 +43,6 @@
 #pragma warning (disable: 4554)
 /* qualifier applied to reference type; ignored */
 #pragma warning (disable: 4181)
-/* /GS can not buffer overrun protect parameters and locals: function not optimized */
-#pragma warning (disable: 4748)
-/* function(): resolved overload was found by argument-dependent lookup */
-#pragma warning (disable: 4675)
 /* X needs to have dll-interface to be used by clients of class Y */
 #pragma warning (disable: 4251)
 /* decorated name length exceeded, name was truncated */
@@ -62,9 +56,9 @@
 #define WIN32 1
 #define _WINDOWS 1
 #define WINVER 0x0500
-#define CRTAPI1 _cdecl 
+#define CRTAPI1 _cdecl
 #define CRTAPI2 _cdecl
-// #define _DLL  - used to be explicitly defined, 
+// #define _DLL  - used to be explicitly defined,
 // but it's implicitely defined via /MD(d)
 #define G__REDIRECTIO 1
 #define G__SHAREDLIB 1

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -704,6 +704,11 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/ROOTConfig-version.cmake.in
 string(REGEX REPLACE "(^|[ ]*)-W[^ ]*" "" __cxxflags "${CMAKE_CXX_FLAGS}")
 string(REGEX REPLACE "(^|[ ]*)-W[^ ]*" "" __cflags "${CMAKE_C_FLAGS}")
 
+if(MSVC)
+  string(REPLACE "-I${CMAKE_SOURCE_DIR}/build/win" "" __cxxflags "${__cxxflags}")
+  string(REPLACE "-I${CMAKE_SOURCE_DIR}/build/win" "" __cflags "${__cflags}")
+endif()
+
 if (cxxmodules)
   # Re-add the -Wno-module-import-in-extern-c which we just filtered out.
   # We want it because it changes the module cache hash and causes modules to be


### PR DESCRIPTION
* copy `sehmap.h` file into build directory
* remove no longer existing warnings codes
* exclude source directory from exported cxx flags