### PR TITLE
Update warning flag for bidi characters (6.26)

### DIFF
--- a/graf2d/mathtext/CMakeLists.txt
+++ b/graf2d/mathtext/CMakeLists.txt
@@ -19,8 +19,8 @@ ROOT_LINKER_LIBRARY(mathtext
   NOINSTALL
 )
 
-check_cxx_compiler_flag(-Wbidirectional=none GCC_HAS_BIDIRECTIONAL_FLAG)
-if(GCC_HAS_BIDIRECTIONAL_FLAG)
-    set_source_files_properties(src/fontembed.cxx COMPILE_FLAGS "-Wbidirectional=none")
+check_cxx_compiler_flag(-Wbidi-chars=none GCC_HAS_BIDI_CHARS_FLAG)
+if(GCC_HAS_BIDI_CHARS_FLAG)
+    set_source_files_properties(src/fontembed.cxx COMPILE_FLAGS "-Wbidi-chars=none")
 endif()
 set_property(TARGET mathtext PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/graf2d/postscript/CMakeLists.txt
+++ b/graf2d/postscript/CMakeLists.txt
@@ -31,7 +31,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Postscript
     Graf
 )
 
-check_cxx_compiler_flag(-Wbidirectional=none GCC_HAS_BIDIRECTIONAL_FLAG)
-if(GCC_HAS_BIDIRECTIONAL_FLAG)
-    set_source_files_properties(src/TPostScript.cxx COMPILE_FLAGS "-Wbidirectional=none")
+check_cxx_compiler_flag(-Wbidi-chars=none GCC_HAS_BIDI_CHARS_FLAG)
+if(GCC_HAS_BIDI_CHARS_FLAG)
+    set_source_files_properties(src/TPostScript.cxx COMPILE_FLAGS "-Wbidi-chars=none")
 endif()


### PR DESCRIPTION
Backport of #9532

-Wbidirectional= was RedHat's initial proposal that they also shipped
in gcc-8.5.0-4.el8 for CentOS 8. During review, the name was changed
to -Wbidi-chars= which will appear in GCC 12 and was backported to the
next gcc-8.5.0-5.el8. See the mailing list thread at
https://gcc.gnu.org/pipermail/gcc-patches/2021-November/thread.html#583031
for details.
