### PR TITLE
[RF] Include RooAbsData objects in the RooNameReg

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -718,7 +718,7 @@ private:
 
   mutable RooExpensiveObjectCache* _eocache{nullptr}; // Pointer to global cache manager for any expensive components created by this object
 
-  mutable TNamed* _namePtr ; //! De-duplicated name pointer. This will be equal for all objects with the same name.
+  mutable const TNamed * _namePtr ; //! De-duplicated name pointer. This will be equal for all objects with the same name.
   Bool_t _isConstant ; //! Cached isConstant status
 
   mutable Bool_t _localNoInhibitDirty ; //! Prevent 'AlwaysDirty' mode for this node

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -375,7 +375,7 @@ protected:
 
   std::unique_ptr<RooArgSet> _globalObservables; // Snapshot of global observables
 
-  mutable TNamed* _namePtr ; //! De-duplicated name pointer. This will be equal for all objects with the same name.
+  mutable const TNamed * _namePtr ; //! De-duplicated name pointer. This will be equal for all objects with the same name.
 
 private:
   void copyGlobalObservables(const RooAbsData& other);

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -21,6 +21,7 @@
 #include "RooArgSet.h"
 #include "RooArgList.h"
 #include "RooSpan.h"
+#include "RooNameReg.h"
 
 #include "ROOT/RStringView.hxx"
 #include "TNamed.h"
@@ -311,6 +312,20 @@ public:
   RooArgSet const* getGlobalObservables() const { return _globalObservables.get(); }
   void setGlobalObservables(RooArgSet const& globalObservables);
 
+  /// De-duplicated pointer to this object's name.
+  /// This can be used for fast name comparisons.
+  /// like `if (namePtr() == other.namePtr())`.
+  /// \note TNamed::GetName() will return a pointer that's
+  /// different for each object, but namePtr() always points
+  /// to a unique instance.
+  inline const TNamed* namePtr() const {
+    return _namePtr ;
+  }
+
+  void SetName(const char* name) ;
+  void SetNameTitle(const char *name, const char *title) ;
+
+
 protected:
 
   static StorageType defaultStorageType ;
@@ -360,10 +375,12 @@ protected:
 
   std::unique_ptr<RooArgSet> _globalObservables; // Snapshot of global observables
 
+  mutable TNamed* _namePtr ; //! De-duplicated name pointer. This will be equal for all objects with the same name.
+
 private:
   void copyGlobalObservables(const RooAbsData& other);
 
-   ClassDef(RooAbsData, 6) // Abstract data collection
+   ClassDef(RooAbsData, 7) // Abstract data collection
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -380,7 +380,7 @@ protected:
 private:
   void copyGlobalObservables(const RooAbsData& other);
 
-   ClassDef(RooAbsData, 7) // Abstract data collection
+   ClassDef(RooAbsData, 6) // Abstract data collection
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNameReg.h
+++ b/roofit/roofitcore/inc/RooNameReg.h
@@ -44,6 +44,7 @@ protected:
   RooNameReg(const RooNameReg& other) = delete;
 
   friend class RooAbsArg;
+  friend class RooAbsData;
   static void incrementRenameCounter() ;
 
   std::unordered_map<std::string,std::unique_ptr<TNamed>> _map;

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -127,7 +127,7 @@ RooAbsArg::RooAbsArg()
      _prohibitServerRedirect(kFALSE), _namePtr(0), _isConstant(kFALSE), _localNoInhibitDirty(kFALSE),
      _myws(0)
 {
-  _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+  _namePtr = RooNameReg::instance().constPtr(GetName()) ;
 
 }
 
@@ -145,7 +145,7 @@ RooAbsArg::RooAbsArg(const char *name, const char *title)
     throw std::logic_error("Each RooFit object needs a name. "
         "Objects representing the same entity (e.g. an observable 'x') are identified using their name.");
   }
-  _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+  _namePtr = RooNameReg::instance().constPtr(GetName()) ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -161,7 +161,7 @@ RooAbsArg::RooAbsArg(const RooAbsArg &other, const char *name)
   // Use name in argument, if supplied
   if (name) {
     TNamed::SetName(name) ;
-    _namePtr = (TNamed*) RooNameReg::instance().constPtr(name) ;
+    _namePtr = RooNameReg::instance().constPtr(name) ;
   } else {
     // Same name, don't recalculate name pointer (expensive)
     TNamed::SetName(other.GetName()) ;
@@ -2310,7 +2310,7 @@ RooAbsArg* RooAbsArg::cloneTree(const char* newname) const
   // Adjust name of head node if requested
   if (newname) {
     head->TNamed::SetName(newname) ;
-    head->_namePtr = (TNamed*) RooNameReg::instance().constPtr(newname) ;
+    head->_namePtr = RooNameReg::instance().constPtr(newname) ;
   }
 
   // Return the head
@@ -2382,11 +2382,11 @@ void RooAbsArg::wireAllCaches()
 void RooAbsArg::SetName(const char* name)
 {
   TNamed::SetName(name) ;
-  TNamed* newPtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+  auto newPtr = RooNameReg::instance().constPtr(GetName()) ;
   if (newPtr != _namePtr) {
     //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
     _namePtr = newPtr;
-    _namePtr->SetBit(RooNameReg::kRenamedArg);
+    const_cast<TNamed*>(_namePtr)->SetBit(RooNameReg::kRenamedArg);
     RooNameReg::incrementRenameCounter();
   }
 }
@@ -2398,14 +2398,8 @@ void RooAbsArg::SetName(const char* name)
 
 void RooAbsArg::SetNameTitle(const char *name, const char *title)
 {
-  TNamed::SetNameTitle(name,title) ;
-  TNamed* newPtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
-  if (newPtr != _namePtr) {
-    //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
-    _namePtr = newPtr;
-    _namePtr->SetBit(RooNameReg::kRenamedArg);
-    RooNameReg::incrementRenameCounter();
-  }
+  TNamed::SetTitle(title) ;
+  SetName(name);
 }
 
 
@@ -2418,7 +2412,7 @@ void RooAbsArg::Streamer(TBuffer &R__b)
      _ioReadStack.push(this) ;
      R__b.ReadClassBuffer(RooAbsArg::Class(),this);
      _ioReadStack.pop() ;
-     _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+     _namePtr = RooNameReg::instance().constPtr(GetName()) ;
      _isConstant = getAttribute("Constant") ;
    } else {
      R__b.WriteClassBuffer(RooAbsArg::Class(),this);

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -153,20 +153,13 @@ RooAbsArg::RooAbsArg(const char *name, const char *title)
 /// object. Transient properties and client-server links are not copied
 
 RooAbsArg::RooAbsArg(const RooAbsArg &other, const char *name)
-   : TNamed(other.GetName(), other.GetTitle()), RooPrintable(other), _boolAttrib(other._boolAttrib),
+   : TNamed(name ? name : other.GetName(), other.GetTitle()), RooPrintable(other),
+     _boolAttrib(other._boolAttrib),
      _stringAttrib(other._stringAttrib), _deleteWatch(other._deleteWatch), _operMode(Auto), _fast(kFALSE),
-     _ownedComponents(0), _prohibitServerRedirect(kFALSE), _namePtr(other._namePtr),
+     _ownedComponents(0), _prohibitServerRedirect(kFALSE),
+     _namePtr(name ? RooNameReg::instance().constPtr(name) : other._namePtr),
      _isConstant(other._isConstant), _localNoInhibitDirty(other._localNoInhibitDirty), _myws(0)
 {
-  // Use name in argument, if supplied
-  if (name) {
-    TNamed::SetName(name) ;
-    _namePtr = RooNameReg::instance().constPtr(name) ;
-  } else {
-    // Same name, don't recalculate name pointer (expensive)
-    TNamed::SetName(other.GetName()) ;
-    _namePtr = other._namePtr ;
-  }
 
   // Copy server list by hand
   Bool_t valueProp, shapeProp ;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -217,7 +217,7 @@ RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooA
       var->attachArgs(_vars);
    }
 
-   _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+   _namePtr = RooNameReg::instance().constPtr(GetName()) ;
 
    RooTrace::create(this);
 }
@@ -268,7 +268,7 @@ RooAbsData::RooAbsData(const RooAbsData& other, const char* newname) :
   // Use name in argument, if supplied
   if (newname) {
     TNamed::SetName(newname) ;
-    _namePtr = (TNamed*) RooNameReg::instance().constPtr(newname) ;
+    _namePtr = RooNameReg::instance().constPtr(newname) ;
   } else {
     // Same name, don't recalculate name pointer (expensive)
     TNamed::SetName(other.GetName()) ;
@@ -2469,7 +2469,7 @@ void RooAbsData::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(RooAbsData::Class(),this);
-      _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+      _namePtr = RooNameReg::instance().constPtr(GetName()) ;
 
       // Convert on the fly to vector storage if that the current working default
       if (defaultStorageType==RooAbsData::Vector) {
@@ -2584,11 +2584,11 @@ void RooAbsData::setGlobalObservables(RooArgSet const& globalObservables) {
 void RooAbsData::SetName(const char* name)
 {
   TNamed::SetName(name) ;
-  TNamed* newPtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+  auto newPtr = RooNameReg::instance().constPtr(GetName()) ;
   if (newPtr != _namePtr) {
     //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
     _namePtr = newPtr;
-    _namePtr->SetBit(RooNameReg::kRenamedArg);
+    const_cast<TNamed*>(_namePtr)->SetBit(RooNameReg::kRenamedArg);
     RooNameReg::incrementRenameCounter();
   }
 }
@@ -2600,14 +2600,8 @@ void RooAbsData::SetName(const char* name)
 
 void RooAbsData::SetNameTitle(const char *name, const char *title)
 {
-  TNamed::SetNameTitle(name,title) ;
-  TNamed* newPtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
-  if (newPtr != _namePtr) {
-    //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
-    _namePtr = newPtr;
-    _namePtr->SetBit(RooNameReg::kRenamedArg);
-    RooNameReg::incrementRenameCounter();
-  }
+  TNamed::SetTitle(title) ;
+  SetName(name);
 }
 
 

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -226,10 +226,10 @@ RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooA
 /// Copy constructor
 
 RooAbsData::RooAbsData(const RooAbsData& other, const char* newname) :
-  TNamed(newname?newname:other.GetName(),other.GetTitle()),
+  TNamed(newname ? newname : other.GetName(),other.GetTitle()),
   RooPrintable(other), _vars(),
   _cachedVars("Cached Variables"),
-  _namePtr(other._namePtr)
+  _namePtr(newname ? RooNameReg::instance().constPtr(newname) : other._namePtr)
 {
   //cout << "created dataset " << this << endl ;
   claimVars(this) ;
@@ -264,16 +264,6 @@ RooAbsData::RooAbsData(const RooAbsData& other, const char* newname) :
   }
 
   copyGlobalObservables(other);
-
-  // Use name in argument, if supplied
-  if (newname) {
-    TNamed::SetName(newname) ;
-    _namePtr = RooNameReg::instance().constPtr(newname) ;
-  } else {
-    // Same name, don't recalculate name pointer (expensive)
-    TNamed::SetName(other.GetName()) ;
-    _namePtr = other._namePtr ;
-  }
 
   RooTrace::create(this) ;
 }

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -187,7 +187,8 @@ RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooA
   TNamed(TString{name},TString{title}),
   _vars("Dataset Variables"),
   _cachedVars("Cached Variables"),
-  _dstore(dstore)
+  _dstore(dstore),
+  _namePtr(nullptr)
 {
    if (dynamic_cast<RooTreeDataStore *>(dstore)) {
       storageType = RooAbsData::Tree;
@@ -216,6 +217,8 @@ RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooA
       var->attachArgs(_vars);
    }
 
+   _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+
    RooTrace::create(this);
 }
 
@@ -225,7 +228,8 @@ RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooA
 RooAbsData::RooAbsData(const RooAbsData& other, const char* newname) :
   TNamed(newname?newname:other.GetName(),other.GetTitle()),
   RooPrintable(other), _vars(),
-  _cachedVars("Cached Variables")
+  _cachedVars("Cached Variables"),
+  _namePtr(other._namePtr)
 {
   //cout << "created dataset " << this << endl ;
   claimVars(this) ;
@@ -261,6 +265,16 @@ RooAbsData::RooAbsData(const RooAbsData& other, const char* newname) :
 
   copyGlobalObservables(other);
 
+  // Use name in argument, if supplied
+  if (newname) {
+    TNamed::SetName(newname) ;
+    _namePtr = (TNamed*) RooNameReg::instance().constPtr(newname) ;
+  } else {
+    // Same name, don't recalculate name pointer (expensive)
+    TNamed::SetName(other.GetName()) ;
+    _namePtr = other._namePtr ;
+  }
+
   RooTrace::create(this) ;
 }
 
@@ -271,6 +285,7 @@ RooAbsData& RooAbsData::operator=(const RooAbsData& other) {
   claimVars(this);
   _vars.Clear();
   _vars.addClone(other._vars);
+  _namePtr = other._namePtr;
 
   // reconnect any parameterized ranges to internal dataset observables
   for (const auto var : _vars) {
@@ -2454,6 +2469,7 @@ void RooAbsData::Streamer(TBuffer &R__b)
 {
    if (R__b.IsReading()) {
       R__b.ReadClassBuffer(RooAbsData::Class(),this);
+      _namePtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
 
       // Convert on the fly to vector storage if that the current working default
       if (defaultStorageType==RooAbsData::Vector) {
@@ -2561,6 +2577,39 @@ void RooAbsData::setGlobalObservables(RooArgSet const& globalObservables) {
     if(auto lval = dynamic_cast<RooAbsCategoryLValue*>(arg)) lval->setConstant(true);
   }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+void RooAbsData::SetName(const char* name)
+{
+  TNamed::SetName(name) ;
+  TNamed* newPtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+  if (newPtr != _namePtr) {
+    //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
+    _namePtr = newPtr;
+    _namePtr->SetBit(RooNameReg::kRenamedArg);
+    RooNameReg::incrementRenameCounter();
+  }
+}
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+void RooAbsData::SetNameTitle(const char *name, const char *title)
+{
+  TNamed::SetNameTitle(name,title) ;
+  TNamed* newPtr = (TNamed*) RooNameReg::instance().constPtr(GetName()) ;
+  if (newPtr != _namePtr) {
+    //cout << "Rename '" << _namePtr->GetName() << "' to '" << name << "' (set flag in new name)" << endl;
+    _namePtr = newPtr;
+    _namePtr->SetBit(RooNameReg::kRenamedArg);
+    RooNameReg::incrementRenameCounter();
+  }
+}
+
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -616,8 +616,8 @@ TObject* RooLinkedList::find(const char* name) const
       if (nptr && nptr->TestBit(RooNameReg::kRenamedArg)) {
         RooLinkedListElem* ptr = _first ;
         while(ptr) {
-          if (static_cast<RooAbsArg*>(ptr->_arg)->namePtr() == nptr ||
-              static_cast<RooAbsData*>(ptr->_arg)->namePtr() == nptr) {
+          if ( (dynamic_cast<RooAbsArg*>(ptr->_arg) && static_cast<RooAbsArg*>(ptr->_arg)->namePtr() == nptr) ||
+               (dynamic_cast<RooAbsData*>(ptr->_arg) && static_cast<RooAbsData*>(ptr->_arg)->namePtr() == nptr)) {
             return ptr->_arg ;
           }
           ptr = ptr->_next ;
@@ -637,8 +637,8 @@ TObject* RooLinkedList::find(const char* name) const
     if (!nptr) return nullptr;
     
     while(ptr) {
-      if (static_cast<RooAbsArg*>(ptr->_arg)->namePtr() == nptr ||
-          static_cast<RooAbsData*>(ptr->_arg)->namePtr() == nptr) {
+      if ( (dynamic_cast<RooAbsArg*>(ptr->_arg) && static_cast<RooAbsArg*>(ptr->_arg)->namePtr() == nptr) ||
+           (dynamic_cast<RooAbsData*>(ptr->_arg) && static_cast<RooAbsData*>(ptr->_arg)->namePtr() == nptr)) {
         return ptr->_arg ;
       }
       ptr = ptr->_next ;

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -262,7 +262,7 @@ RooLinkedList::Pool* RooLinkedList::_pool = 0;
 ////////////////////////////////////////////////////////////////////////////////
 
 RooLinkedList::RooLinkedList(Int_t htsize) : 
-  _hashThresh(htsize), _size(0), _first(0), _last(0), _htableName(nullptr), _htableLink(nullptr), _useNptr(kTRUE)
+  _hashThresh(htsize), _size(0), _first(0), _last(0), _htableName(nullptr), _htableLink(nullptr), _useNptr(true)
 {
   if (!_pool) _pool = new Pool;
   _pool->acquire();
@@ -405,7 +405,7 @@ void RooLinkedList::Add(TObject* arg, Int_t refCount)
   if (!arg) return ;
 
   // Only use RooAbsArg::namePtr() in lookup-by-name if all elements have it
-  if (!dynamic_cast<RooAbsArg*>(arg) && !dynamic_cast<RooAbsData*>(arg)) _useNptr = kFALSE;
+  if (!dynamic_cast<RooAbsArg*>(arg) && !dynamic_cast<RooAbsData*>(arg)) _useNptr = false;
   
   // Add to hash table 
   if (_htableName) {
@@ -448,7 +448,7 @@ Bool_t RooLinkedList::Remove(TObject* arg)
 {
   // Find link element
   RooLinkedListElem* elem = findLink(arg) ;
-  if (!elem) return kFALSE ;
+  if (!elem) return false ;
   
   // Remove from hash table
   if (_htableName) {
@@ -469,7 +469,7 @@ Bool_t RooLinkedList::Remove(TObject* arg)
   // Delete and shrink
   _size-- ;
   deleteElement(elem) ;	
-  return kTRUE ;
+  return true ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -503,13 +503,13 @@ TObject* RooLinkedList::At(Int_t index) const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Replace object 'oldArg' in collection with new object 'newArg'.
-/// If 'oldArg' is not found in collection kFALSE is returned
+/// If 'oldArg' is not found in collection false is returned
 
 Bool_t RooLinkedList::Replace(const TObject* oldArg, const TObject* newArg) 
 {
   // Find existing element and replace arg
   RooLinkedListElem* elem = findLink(oldArg) ;
-  if (!elem) return kFALSE ;
+  if (!elem) return false ;
   
   if (_htableName) {
     _htableName->erase(oldArg->GetName());
@@ -522,7 +522,7 @@ Bool_t RooLinkedList::Replace(const TObject* oldArg, const TObject* newArg)
   }
 
   elem->_arg = (TObject*)newArg ;
-  return kTRUE ;
+  return true ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -32,6 +32,7 @@ Use RooAbsCollection derived objects for public use
 #include "RooFit.h"
 #include "RooLinkedListIter.h"
 #include "RooAbsArg.h"
+#include "RooAbsData.h"
 #include "RooMsgService.h"
 
 #include "Riostream.h"
@@ -404,7 +405,7 @@ void RooLinkedList::Add(TObject* arg, Int_t refCount)
   if (!arg) return ;
 
   // Only use RooAbsArg::namePtr() in lookup-by-name if all elements have it
-  if (!dynamic_cast<RooAbsArg*>(arg)) _useNptr = kFALSE;
+  if (!dynamic_cast<RooAbsArg*>(arg) && !dynamic_cast<RooAbsData*>(arg)) _useNptr = kFALSE;
   
   // Add to hash table 
   if (_htableName) {
@@ -604,7 +605,7 @@ TObject* RooLinkedList::find(const char* name) const
 {
   
   if (_htableName) {
-    RooAbsArg* a = (RooAbsArg*) (*_htableName)[name] ;
+    TObject *a = const_cast<TObject*>((*_htableName)[name]) ;
     // RooHashTable::find could return false negative if element was renamed to 'name'.
     // The list search means it won't return false positive, so can return here.
     if (a) return a;
@@ -616,6 +617,9 @@ TObject* RooLinkedList::find(const char* name) const
         RooLinkedListElem* ptr = _first ;
         while(ptr) {
           if ((((RooAbsArg*)ptr->_arg)->namePtr() == nptr)) {
+            return ptr->_arg ;
+          }
+          if ((((RooAbsData*)ptr->_arg)->namePtr() == nptr)) {
             return ptr->_arg ;
           }
           ptr = ptr->_next ;
@@ -636,6 +640,9 @@ TObject* RooLinkedList::find(const char* name) const
     
     while(ptr) {
       if ((((RooAbsArg*)ptr->_arg)->namePtr() == nptr)) {
+	return ptr->_arg ;
+      }
+      if ((((RooAbsData*)ptr->_arg)->namePtr() == nptr)) {
 	return ptr->_arg ;
       }
       ptr = ptr->_next ;

--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -616,16 +616,14 @@ TObject* RooLinkedList::find(const char* name) const
       if (nptr && nptr->TestBit(RooNameReg::kRenamedArg)) {
         RooLinkedListElem* ptr = _first ;
         while(ptr) {
-          if ((((RooAbsArg*)ptr->_arg)->namePtr() == nptr)) {
-            return ptr->_arg ;
-          }
-          if ((((RooAbsData*)ptr->_arg)->namePtr() == nptr)) {
+          if (static_cast<RooAbsArg*>(ptr->_arg)->namePtr() == nptr ||
+              static_cast<RooAbsData*>(ptr->_arg)->namePtr() == nptr) {
             return ptr->_arg ;
           }
           ptr = ptr->_next ;
         }
       }
-      return 0 ;
+      return nullptr ;
     }
     //cout << "RooLinkedList::find: possibly renamed '" << name << "'" << endl;
   }
@@ -636,18 +634,16 @@ TObject* RooLinkedList::find(const char* name) const
   // when the size list is longer than ~7, but let's be a bit conservative.
   if (_useNptr && _size>9) {
     const TNamed* nptr= RooNameReg::known(name);
-    if (!nptr) return 0;
+    if (!nptr) return nullptr;
     
     while(ptr) {
-      if ((((RooAbsArg*)ptr->_arg)->namePtr() == nptr)) {
-	return ptr->_arg ;
-      }
-      if ((((RooAbsData*)ptr->_arg)->namePtr() == nptr)) {
-	return ptr->_arg ;
+      if (static_cast<RooAbsArg*>(ptr->_arg)->namePtr() == nptr ||
+          static_cast<RooAbsData*>(ptr->_arg)->namePtr() == nptr) {
+        return ptr->_arg ;
       }
       ptr = ptr->_next ;
     }
-    return 0 ;
+    return nullptr ;
   }
   
   while(ptr) {
@@ -656,7 +652,7 @@ TObject* RooLinkedList::find(const char* name) const
     }
     ptr = ptr->_next ;
   }
-  return 0 ;
+  return nullptr ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The logic from RooAbsArg is copied into RooAbsData.

This allows to use the hash-map functionality of RooLinkedList
for RooAbsData objects, as the namePtr mechanism allows to track
renaming and therefore avoids false negatives that result in
linear scans of the collection.

In turn, this improves significantly the run-time of large workspace
imports (x2 to x4), which were dominated by embeddedData() calls.
This patch is based on the JSON tool use-case, but presumably will
significantly also improve other heavy uses of workspace import, such
as Higgs combination workspaces manipulation workflows.

The cost of one additional pointer per RooAbsData object seems a low
price to pay.