### PR TITLE
[RF] Remove safeDeleteList functionality of RooAbsCollection

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -356,7 +356,7 @@ protected:
   TString _name;    // Our name.
   Bool_t _allRRV ; // All contents are RRV
 
-  void safeDeleteList() ;
+  void deleteList() ;
 
   // Support for snapshot method 
   Bool_t addServerClonesToList(const RooAbsArg& var) ;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -198,17 +198,18 @@ RooAbsCollection::~RooAbsCollection()
 {
   // Delete all variables in our list if we own them
   if(_ownCont){
-    safeDeleteList() ;
+    deleteList() ;
   }
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Examine client server dependencies in list and
-/// delete contents in safe order: any client
-/// is deleted before a server is deleted
+/// Delete contents of the list.
+/// The RooAbsArg destructor ensures clients and servers can be deleted in any
+/// order.
+/// Also cleans the hash-map for fast lookups if present.
 
-void RooAbsCollection::safeDeleteList()
+void RooAbsCollection::deleteList()
 {
   _hashAssistedFind = nullptr;
 
@@ -725,7 +726,7 @@ void RooAbsCollection::removeAll()
   _hashAssistedFind = nullptr;
 
   if(_ownCont) {
-    safeDeleteList() ;
+    deleteList() ;
     _ownCont= kFALSE;
   }
   else {

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -212,38 +212,6 @@ void RooAbsCollection::safeDeleteList()
 {
   _hashAssistedFind = nullptr;
 
-  // Handle trivial case here
-  if (_list.size() > 1) {
-    std::vector<RooAbsArg*> tmp;
-    tmp.reserve(_list.size());
-    do {
-      tmp.clear();
-      for (auto arg : _list) {
-        // Check if arg depends on remainder of list
-        if (!arg->dependsOn(*this, arg)) tmp.push_back(arg);
-      }
-
-      // sort and uniquify, in case some elements occur more than once
-      std::sort(tmp.begin(), tmp.end());
-
-      tmp.erase(std::unique(tmp.begin(), tmp.end()), tmp.end());
-      // okay, can remove and delete what's in tmp
-      auto newEnd = _list.end();
-      for (auto item : tmp) {
-        newEnd = std::remove(_list.begin(), newEnd, item);
-        delete item;
-      }
-      _list.erase(newEnd, _list.end());
-    } while (!tmp.empty() && _list.size() > 1);
-
-    // Check if there are any remaining elements
-    if (_list.size() > 1) {
-      coutW(ObjectHandling) << "RooAbsCollection::safeDeleteList(" << GetName()
-	    << ") WARNING: unable to delete following elements in client-server order " ;
-      Print("1") ;
-    }
-  }
-
   // Built-in delete remaining elements
   for (auto item : _list) {
     delete item;


### PR DESCRIPTION
This is presumbaly a bit controversial.

safeDeleteList remove elements in order in a RooAbsCollection,
starting with the ones that only have clients and no servers.

This is a slow process, and takes 25% of CPU time on large workspace
manipulation workflows, as it takes place at each workspace::import
call. It can also lead to slow ~RooWorkspace.

The point is, I don't think this logic is needed at all.
~RooAbsArg takes care of properly breaking all the client-server links,
both uplinks and downlinks, for every object. I couldn't find a logical
case where a crash would occur if the safeDeleteList logic were to be
removed.

All RooFit tests pass after this patch. No problem for my heavy
workspace manipulation worflows either.