### PR TITLE
[ntuple] Add support for writing multiple cluster groups

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -373,6 +373,9 @@ private:
    /// Estimator of uncompressed cluster size, taking into account the estimated compression ratio
    NTupleSize_t fUnzippedClusterSizeEst;
 
+   // Helper function that is called from CommitCluster() when necessary
+   void CommitClusterGroup();
+
 public:
    /// Throws an exception if the model is null.
    static std::unique_ptr<RNTupleWriter> Recreate(std::unique_ptr<RNTupleModel> model,

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -359,6 +359,7 @@ private:
    std::unique_ptr<RNTupleModel> fModel;
    Detail::RNTupleMetrics fMetrics;
    NTupleSize_t fLastCommitted = 0;
+   NTupleSize_t fLastCommittedClusterGroup = 0;
    NTupleSize_t fNEntries = 0;
    /// Keeps track of the number of bytes written into the current cluster
    std::size_t fUnzippedClusterSize = 0;
@@ -405,7 +406,7 @@ public:
          CommitCluster();
    }
    /// Ensure that the data from the so far seen Fill calls has been written to storage
-   void CommitCluster();
+   void CommitCluster(bool commitClusterGroup = false);
 
    std::unique_ptr<REntry> CreateEntry() { return fModel->CreateEntry(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -353,6 +353,7 @@ public:
    {
       return std::find(fClusterIds.begin(), fClusterIds.end(), clusterId) != fClusterIds.end();
    }
+   const std::vector<DescriptorId_t> &GetClusterIds() const { return fClusterIds; }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleSerialize.hxx
@@ -91,24 +91,20 @@ public:
    private:
       std::uint32_t fHeaderSize = 0;
       std::uint32_t fHeaderCrc32 = 0;
-      std::vector<RClusterGroup> fClusterGroups;
       std::map<DescriptorId_t, DescriptorId_t> fMem2PhysFieldIDs;
       std::map<DescriptorId_t, DescriptorId_t> fMem2PhysColumnIDs;
       std::map<DescriptorId_t, DescriptorId_t> fMem2PhysClusterIDs;
+      std::map<DescriptorId_t, DescriptorId_t> fMem2PhysClusterGroupIDs;
       std::vector<DescriptorId_t> fPhys2MemFieldIDs;
       std::vector<DescriptorId_t> fPhys2MemColumnIDs;
       std::vector<DescriptorId_t> fPhys2MemClusterIDs;
+      std::vector<DescriptorId_t> fPhys2MemClusterGroupIDs;
+
    public:
       void SetHeaderSize(std::uint32_t size) { fHeaderSize = size; }
       std::uint32_t GetHeaderSize() const { return fHeaderSize; }
       void SetHeaderCRC32(std::uint32_t crc32) { fHeaderCrc32 = crc32; }
       std::uint32_t GetHeaderCRC32() const { return fHeaderCrc32; }
-      void AddClusterGroup(std::uint32_t nClusters, const REnvelopeLink &pageListEnvelope) {
-         fClusterGroups.push_back({nClusters, pageListEnvelope});
-      }
-      const std::vector<RClusterGroup> &GetClusterGroups() const {
-         return fClusterGroups;
-      }
       DescriptorId_t MapFieldId(DescriptorId_t memId) {
          auto physId = fPhys2MemFieldIDs.size();
          fMem2PhysFieldIDs[memId] = physId;
@@ -127,12 +123,21 @@ public:
          fPhys2MemClusterIDs.push_back(memId);
          return physId;
       }
+      DescriptorId_t MapClusterGroupId(DescriptorId_t memId)
+      {
+         auto physId = fPhys2MemClusterGroupIDs.size();
+         fMem2PhysClusterGroupIDs[memId] = physId;
+         fPhys2MemClusterGroupIDs.push_back(memId);
+         return physId;
+      }
       DescriptorId_t GetPhysFieldId(DescriptorId_t memId) const { return fMem2PhysFieldIDs.at(memId); }
       DescriptorId_t GetPhysColumnId(DescriptorId_t memId) const { return fMem2PhysColumnIDs.at(memId); }
       DescriptorId_t GetPhysClusterId(DescriptorId_t memId) const { return fMem2PhysClusterIDs.at(memId); }
+      DescriptorId_t GetPhysClusterGroupId(DescriptorId_t memId) const { return fMem2PhysClusterGroupIDs.at(memId); }
       DescriptorId_t GetMemFieldId(DescriptorId_t physId) const { return fPhys2MemFieldIDs[physId]; }
       DescriptorId_t GetMemColumnId(DescriptorId_t physId) const { return fPhys2MemColumnIDs[physId]; }
       DescriptorId_t GetMemClusterId(DescriptorId_t physId) const { return fPhys2MemClusterIDs[physId]; }
+      DescriptorId_t GetMemClusterGroupId(DescriptorId_t physId) const { return fPhys2MemClusterGroupIDs[physId]; }
    };
 
    /// Writes a CRC32 checksum of the byte range given by data and length.

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -113,7 +113,7 @@ protected:
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
-   void CommitDatasetImpl() final;
+   void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
 
 public:
    explicit RPageSinkBuf(std::unique_ptr<RPageSink> inner);

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -108,7 +108,7 @@ private:
    std::vector<RColumnBuf> fBufferedColumns;
 
 protected:
-   void CreateImpl(const RNTupleModel &model) final;
+   void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -33,6 +33,9 @@ namespace Detail {
 \class ROOT::Experimental::Detail::RPageSinkBuf
 \ingroup NTuple
 \brief Wrapper sink that coalesces cluster column page writes
+*
+* TODO(jblomer): The interplay of derived class and RPageSink is not yet optimally designed for page storage wrapper
+* classes like this one. Header and footer serialization, e.g., are done twice.  To be revised.
 */
 // clang-format on
 class RPageSinkBuf : public RPageSink {

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -112,6 +112,7 @@ protected:
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
+   RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl() final;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -191,6 +191,9 @@ protected:
                                                const RPageStorage::RSealedPage &sealedPage) = 0;
    /// Returns the number of bytes written to storage (excluding metadata)
    virtual std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) = 0;
+   /// Returns the locator of the page list envelope of the given buffer that contains the serialized page list.
+   /// Typically, the implementation takes care of compressing and writing the provided buffer.
+   virtual RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) = 0;
    virtual void CommitDatasetImpl() = 0;
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
@@ -246,6 +249,9 @@ public:
    /// Finalize the current cluster and create a new one for the following data.
    /// Returns the number of bytes written to storage (excluding meta-data).
    std::uint64_t CommitCluster(NTupleSize_t nEntries);
+   /// Write out the page locations (page list envelope) for all the committed clusters since the last call of
+   /// CommitClusterGroup (or the beginning of writing).
+   void CommitClusterGroup();
    /// Finalize the current cluster and the entrire data set.
    void CommitDataset() { CommitDatasetImpl(); }
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -173,9 +173,6 @@ protected:
    /// with the page source, we leave it up to the derived class whether or not the compressor gets constructed.
    std::unique_ptr<RNTupleCompressor> fCompressor;
 
-   /// Building the ntuple descriptor while writing is done in the same way for all the storage sink implementations.
-   /// Field, column, cluster ids and page indexes per cluster are issued sequentially starting with 0
-   DescriptorId_t fLastFieldId = 0;
    /// Used to calculate the number of entries in the current cluster
    NTupleSize_t fPrevClusterNEntries = 0;
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -152,6 +152,10 @@ up to the given entry number are committed.
 */
 // clang-format on
 class RPageSink : public RPageStorage {
+private:
+   /// Used to map the IDs of the descriptor to the physical IDs issued during header/footer serialization
+   Internal::RNTupleSerializer::RContext fSerializationContext;
+
 protected:
    /// Default I/O performance counters that get registered in fMetrics
    struct RCounters {
@@ -180,9 +184,6 @@ protected:
    /// Keeps track of the written pages in the currently open cluster. Indexed by column id.
    std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
    RNTupleDescriptorBuilder fDescriptorBuilder;
-
-   /// Used to map the IDs of the descriptor to the physical IDs issued during header/footer serialization
-   Internal::RNTupleSerializer::RContext fSerializationContext;
 
    virtual void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) = 0;
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -177,6 +177,8 @@ protected:
    /// with the page source, we leave it up to the derived class whether or not the compressor gets constructed.
    std::unique_ptr<RNTupleCompressor> fCompressor;
 
+   /// Remembers the starting cluster id for the next cluster group
+   std::uint64_t fNextClusterInGroup = 0;
    /// Used to calculate the number of entries in the current cluster
    NTupleSize_t fPrevClusterNEntries = 0;
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -177,7 +177,7 @@ protected:
    /// Field, column, cluster ids and page indexes per cluster are issued sequentially starting with 0
    DescriptorId_t fLastFieldId = 0;
    DescriptorId_t fLastColumnId = 0;
-   DescriptorId_t fLastClusterId = 0;
+   /// Used to calculate the number of entries in the current cluster
    NTupleSize_t fPrevClusterNEntries = 0;
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.
    std::vector<RClusterDescriptor::RColumnRange> fOpenColumnRanges;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -181,6 +181,9 @@ protected:
    std::vector<RClusterDescriptor::RPageRange> fOpenPageRanges;
    RNTupleDescriptorBuilder fDescriptorBuilder;
 
+   /// Used to map the IDs of the descriptor to the physical IDs issued during header/footer serialization
+   Internal::RNTupleSerializer::RContext fSerializationContext;
+
    virtual void CreateImpl(const RNTupleModel &model) = 0;
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId,

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -176,7 +176,6 @@ protected:
    /// Building the ntuple descriptor while writing is done in the same way for all the storage sink implementations.
    /// Field, column, cluster ids and page indexes per cluster are issued sequentially starting with 0
    DescriptorId_t fLastFieldId = 0;
-   DescriptorId_t fLastColumnId = 0;
    /// Used to calculate the number of entries in the current cluster
    NTupleSize_t fPrevClusterNEntries = 0;
    /// Keeps track of the number of elements in the currently open cluster. Indexed by column id.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -193,7 +193,7 @@ protected:
    /// Returns the locator of the page list envelope of the given buffer that contains the serialized page list.
    /// Typically, the implementation takes care of compressing and writing the provided buffer.
    virtual RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) = 0;
-   virtual void CommitDatasetImpl() = 0;
+   virtual void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) = 0;
 
    /// Helper for streaming a page. This is commonly used in derived, concrete page sinks. Note that if
    /// compressionSetting is 0 (uncompressed) and the page is mappable, the returned sealed page will
@@ -252,7 +252,7 @@ public:
    /// CommitClusterGroup (or the beginning of writing).
    void CommitClusterGroup();
    /// Finalize the current cluster and the entrire data set.
-   void CommitDataset() { CommitDatasetImpl(); }
+   void CommitDataset();
 
    /// Get a new, empty page for the given column that can be filled with up to nElements.  If nElements is zero,
    /// the page sink picks an appropriate size.

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -184,7 +184,7 @@ protected:
    /// Used to map the IDs of the descriptor to the physical IDs issued during header/footer serialization
    Internal::RNTupleSerializer::RContext fSerializationContext;
 
-   virtual void CreateImpl(const RNTupleModel &model) = 0;
+   virtual void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) = 0;
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId,
                                                const RPageStorage::RSealedPage &sealedPage) = 0;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -114,6 +114,7 @@ protected:
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
+   RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl() final;
    void WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);
    void WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -113,7 +113,7 @@ protected:
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
-   void CommitDatasetImpl() final;
+   void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
    void WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader);
    void WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter);
    void WriteNTupleAnchor();

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -104,8 +104,6 @@ private:
    std::string fURI;
    /// Tracks the number of bytes committed to the current cluster
    std::uint64_t fNBytesCurrentCluster{0};
-   /// Used to keep the column and field IDs issued during header serialization for the footer serialization
-   Internal::RNTupleSerializer::RContext fSerializationContext;
 
    RDaosNTupleAnchor fNTupleAnchor;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -108,7 +108,7 @@ private:
    RDaosNTupleAnchor fNTupleAnchor;
 
 protected:
-   void CreateImpl(const RNTupleModel &model) final;
+   void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -77,6 +77,7 @@ protected:
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
+   RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl() final;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -59,10 +59,6 @@ private:
    std::unique_ptr<RPageAllocatorHeap> fPageAllocator;
 
    std::unique_ptr<Internal::RNTupleFileWriter> fWriter;
-   /// Byte offset of the first page of the current cluster
-   std::uint64_t fClusterMinOffset = std::uint64_t(-1);
-   /// Byte offset of the end of the last page of the current cluster
-   std::uint64_t fClusterMaxOffset = 0;
    /// Number of bytes committed to storage in the current cluster
    std::uint64_t fNBytesCurrentCluster = 0;
    /// Used to keep the column and field IDs issued during header serialization for the footer serialization

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -72,7 +72,7 @@ protected:
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
-   void CommitDatasetImpl() final;
+   void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;
 
 public:
    RPageSinkFile(std::string_view ntupleName, std::string_view path, const RNTupleWriteOptions &options);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -67,7 +67,7 @@ private:
                                                 std::size_t bytesPacked);
 
 protected:
-   void CreateImpl(const RNTupleModel &model) final;
+   void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -61,8 +61,6 @@ private:
    std::unique_ptr<Internal::RNTupleFileWriter> fWriter;
    /// Number of bytes committed to storage in the current cluster
    std::uint64_t fNBytesCurrentCluster = 0;
-   /// Used to keep the column and field IDs issued during header serialization for the footer serialization
-   Internal::RNTupleSerializer::RContext fSerializationContext;
    RPageSinkFile(std::string_view ntupleName, const RNTupleWriteOptions &options);
 
    RNTupleLocator WriteSealedPage(const RPageStorage::RSealedPage &sealedPage,

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -331,13 +331,19 @@ std::unique_ptr<ROOT::Experimental::RNTupleWriter> ROOT::Experimental::RNTupleWr
    return std::make_unique<RNTupleWriter>(std::move(model), std::move(sink));
 }
 
+void ROOT::Experimental::RNTupleWriter::CommitClusterGroup()
+{
+   if (fNEntries == fLastCommittedClusterGroup)
+      return;
+   fSink->CommitClusterGroup();
+   fLastCommittedClusterGroup = fNEntries;
+}
+
 void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
 {
    if (fNEntries == fLastCommitted) {
-      if (commitClusterGroup && fNEntries > fLastCommittedClusterGroup) {
-         fSink->CommitClusterGroup();
-         fLastCommittedClusterGroup = fNEntries;
-      }
+      if (commitClusterGroup)
+         CommitClusterGroup();
       return;
    }
    for (auto& field : *fModel->GetFieldZero()) {
@@ -356,10 +362,8 @@ void ROOT::Experimental::RNTupleWriter::CommitCluster(bool commitClusterGroup)
    fLastCommitted = fNEntries;
    fUnzippedClusterSize = 0;
 
-   if (commitClusterGroup) {
-      fSink->CommitClusterGroup();
-      fLastCommittedClusterGroup = fNEntries;
-   }
+   if (commitClusterGroup)
+      CommitClusterGroup();
 }
 
 

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -305,6 +305,7 @@ ROOT::Experimental::RNTupleWriter::RNTupleWriter(
 ROOT::Experimental::RNTupleWriter::~RNTupleWriter()
 {
    CommitCluster();
+   fSink->CommitClusterGroup();
    fSink->CommitDataset();
 }
 

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1048,8 +1048,9 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooterV1
    for (unsigned int i = 0; i < nClusterGroups; ++i) {
       const auto &cgDesc = desc.GetClusterGroupDescriptor(context.GetMemClusterGroupId(i));
       const auto nClustersInGroup = cgDesc.GetNClusters();
+      const auto &clusterIds = cgDesc.GetClusterIds();
       for (unsigned int j = 0; j < nClustersInGroup; ++j) {
-         const auto &clusterDesc = desc.GetClusterDescriptor(cgDesc.GetClusterIds()[j]);
+         const auto &clusterDesc = desc.GetClusterDescriptor(clusterIds[j]);
          RClusterSummary summary{clusterDesc.GetFirstEntryIndex(), clusterDesc.GetNEntries(), -1};
          pos += SerializeClusterSummary(summary, *where);
       }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1039,18 +1039,24 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooterV1
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
    // Cluster summaries
-   const auto nClusters = desc.GetNClusters();
+   const auto nClusterGroups = desc.GetNClusterGroups();
+   unsigned int nClusters = 0;
+   for (const auto &cgDesc : desc.GetClusterGroupIterable())
+      nClusters += cgDesc.GetNClusters();
    frame = pos;
    pos += SerializeListFramePreamble(nClusters, *where);
-   for (unsigned int i = 0; i < nClusters; ++i) {
-      const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(i));
-      RClusterSummary summary{clusterDesc.GetFirstEntryIndex(), clusterDesc.GetNEntries(), -1};
-      pos += SerializeClusterSummary(summary, *where);
+   for (unsigned int i = 0; i < nClusterGroups; ++i) {
+      const auto &cgDesc = desc.GetClusterGroupDescriptor(context.GetMemClusterGroupId(i));
+      const auto nClustersInGroup = cgDesc.GetNClusters();
+      for (unsigned int j = 0; j < nClustersInGroup; ++j) {
+         const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(j));
+         RClusterSummary summary{clusterDesc.GetFirstEntryIndex(), clusterDesc.GetNEntries(), -1};
+         pos += SerializeClusterSummary(summary, *where);
+      }
    }
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
    // Cluster groups
-   const auto nClusterGroups = desc.GetNClusterGroups();
    frame = pos;
    pos += SerializeListFramePreamble(nClusterGroups, *where);
    for (unsigned int i = 0; i < nClusterGroups; ++i) {

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1049,7 +1049,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooterV1
       const auto &cgDesc = desc.GetClusterGroupDescriptor(context.GetMemClusterGroupId(i));
       const auto nClustersInGroup = cgDesc.GetNClusters();
       for (unsigned int j = 0; j < nClustersInGroup; ++j) {
-         const auto &clusterDesc = desc.GetClusterDescriptor(context.GetMemClusterId(j));
+         const auto &clusterDesc = desc.GetClusterDescriptor(cgDesc.GetClusterIds()[j]);
          RClusterSummary summary{clusterDesc.GetFirstEntryIndex(), clusterDesc.GetNEntries(), -1};
          pos += SerializeClusterSummary(summary, *where);
       }

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -1050,12 +1050,16 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeFooterV1
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 
    // Cluster groups
-   const auto &clusterGroups = context.GetClusterGroups();
-   const auto nClusterGroups = clusterGroups.size();
+   const auto nClusterGroups = desc.GetNClusterGroups();
    frame = pos;
    pos += SerializeListFramePreamble(nClusterGroups, *where);
    for (unsigned int i = 0; i < nClusterGroups; ++i) {
-      pos += SerializeClusterGroup(clusterGroups[i], *where);
+      const auto &cgDesc = desc.GetClusterGroupDescriptor(context.GetMemClusterGroupId(i));
+      RClusterGroup clusterGroup;
+      clusterGroup.fNClusters = cgDesc.GetNClusters();
+      clusterGroup.fPageListEnvelopeLink.fUnzippedSize = cgDesc.GetPageListLength();
+      clusterGroup.fPageListEnvelopeLink.fLocator = cgDesc.GetPageListLocator();
+      pos += SerializeClusterGroup(clusterGroup, *where);
    }
    pos += SerializeFramePostscript(buffer ? frame : nullptr, pos - frame);
 

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -103,6 +103,15 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::
    return fInnerSink->CommitCluster(nEntries);
 }
 
+ROOT::Experimental::RNTupleLocator
+ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterGroupImpl(unsigned char * /* serializedPageList */,
+                                                                 std::uint32_t /* length */)
+{
+   fInnerSink->CommitClusterGroup();
+   // We're not using that locator any further, so it is safe to return a dummy one
+   return RNTupleLocator{};
+}
+
 void ROOT::Experimental::Detail::RPageSinkBuf::CommitDatasetImpl()
 {
    fInnerSink->CommitDataset();

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -31,7 +31,9 @@ ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink
    fMetrics.ObserveMetrics(fInnerSink->GetMetrics());
 }
 
-void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &model)
+void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &model,
+                                                          unsigned char * /* serializedHeader */,
+                                                          std::uint32_t /* length */)
 {
    fBufferedColumns.resize(fDescriptorBuilder.GetDescriptor().GetNColumns());
    fInnerModel = model.Clone();

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -114,7 +114,8 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterGroupImpl(unsigned char *
    return RNTupleLocator{};
 }
 
-void ROOT::Experimental::Detail::RPageSinkBuf::CommitDatasetImpl()
+void ROOT::Experimental::Detail::RPageSinkBuf::CommitDatasetImpl(unsigned char * /* serializedFooter */,
+                                                                 std::uint32_t /* length */)
 {
    fInnerSink->CommitDataset();
 }

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -33,7 +33,7 @@ ROOT::Experimental::Detail::RPageSinkBuf::RPageSinkBuf(std::unique_ptr<RPageSink
 
 void ROOT::Experimental::Detail::RPageSinkBuf::CreateImpl(const RNTupleModel &model)
 {
-   fBufferedColumns.resize(fLastColumnId);
+   fBufferedColumns.resize(fDescriptorBuilder.GetDescriptor().GetNColumns());
    fInnerModel = model.Clone();
    fInnerSink->Create(*fInnerModel);
 }

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -364,10 +364,12 @@ void ROOT::Experimental::Detail::RPageSink::CommitClusterGroup()
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
+   const auto nClusters = descriptor.GetNClusters();
    std::vector<DescriptorId_t> physClusterIDs;
-   for (const auto &c : descriptor.GetClusterIterable()) {
-      physClusterIDs.emplace_back(fSerializationContext.MapClusterId(c.GetId()));
+   for (auto i = fNextClusterInGroup; i < nClusters; ++i) {
+      physClusterIDs.emplace_back(fSerializationContext.MapClusterId(i));
    }
+   fNextClusterInGroup = nClusters;
 
    auto szPageList =
       Internal::RNTupleSerializer::SerializePageListV1(nullptr, descriptor, physClusterIDs, fSerializationContext);

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -271,7 +271,7 @@ std::unique_ptr<ROOT::Experimental::Detail::RPageSink> ROOT::Experimental::Detai
 ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSink::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
-   auto columnId = fLastColumnId++;
+   auto columnId = fDescriptorBuilder.GetDescriptor().GetNColumns();
    fDescriptorBuilder.AddColumn(columnId, fieldId, column.GetModel(), column.GetIndex());
    return ColumnHandle_t{columnId, &column};
 }
@@ -302,7 +302,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
       f.ConnectPageSink(*this); // issues in turn one or several calls to AddColumn()
    }
 
-   auto nColumns = fLastColumnId;
+   auto nColumns = fDescriptorBuilder.GetDescriptor().GetNColumns();
    for (DescriptorId_t i = 0; i < nColumns; ++i) {
       RClusterDescriptor::RColumnRange columnRange;
       columnRange.fColumnId = i;

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -282,23 +282,13 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    fDescriptorBuilder.SetNTuple(fNTupleName, model.GetDescription());
 
    auto &fieldZero = *model.GetFieldZero();
-   fDescriptorBuilder.AddField(
-      RFieldDescriptorBuilder::FromField(fieldZero)
-         .FieldId(fLastFieldId)
-         .MakeDescriptor()
-         .Unwrap()
-   );
-   fieldZero.SetOnDiskId(fLastFieldId);
+   fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
+   fieldZero.SetOnDiskId(0);
    for (auto& f : *model.GetFieldZero()) {
-      fLastFieldId++;
-      fDescriptorBuilder.AddField(
-         RFieldDescriptorBuilder::FromField(f)
-            .FieldId(fLastFieldId)
-            .MakeDescriptor()
-            .Unwrap()
-      );
-      fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fLastFieldId);
-      f.SetOnDiskId(fLastFieldId);
+      auto fieldId = fDescriptorBuilder.GetDescriptor().GetNFields();
+      fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
+      fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);
+      f.SetOnDiskId(fieldId);
       f.ConnectPageSink(*this); // issues in turn one or several calls to AddColumn()
    }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -365,6 +365,11 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
    return nbytes;
 }
 
+void ROOT::Experimental::Detail::RPageSink::CommitClusterGroup()
+{
+   // TODO
+}
+
 ROOT::Experimental::Detail::RPageStorage::RSealedPage
 ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page,
    const RColumnElementBase &element, int compressionSetting, void *buf)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -381,6 +381,17 @@ void ROOT::Experimental::Detail::RPageSink::CommitClusterGroup()
    fSerializationContext.AddClusterGroup(physClusterIDs.size(), pageListEnvelope);
 }
 
+void ROOT::Experimental::Detail::RPageSink::CommitDataset()
+{
+   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
+
+   auto szFooter = Internal::RNTupleSerializer::SerializeFooterV1(nullptr, descriptor, fSerializationContext);
+   auto bufFooter = std::make_unique<unsigned char[]>(szFooter);
+   Internal::RNTupleSerializer::SerializeFooterV1(bufFooter.get(), descriptor, fSerializationContext);
+
+   CommitDatasetImpl(bufFooter.get(), szFooter);
+}
+
 ROOT::Experimental::Detail::RPageStorage::RSealedPage
 ROOT::Experimental::Detail::RPageSink::SealPage(const RPage &page,
    const RColumnElementBase &element, int compressionSetting, void *buf)

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -349,7 +349,8 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
 
    R__ASSERT((nEntries - fPrevClusterNEntries) < ClusterSize_t(-1));
    auto nEntriesInCluster = ClusterSize_t(nEntries - fPrevClusterNEntries);
-   RClusterDescriptorBuilder clusterBuilder(fLastClusterId, fPrevClusterNEntries, nEntriesInCluster);
+   RClusterDescriptorBuilder clusterBuilder(fDescriptorBuilder.GetDescriptor().GetNClusters(), fPrevClusterNEntries,
+                                            nEntriesInCluster);
    for (unsigned int i = 0; i < fOpenColumnRanges.size(); ++i) {
       RClusterDescriptor::RPageRange fullRange;
       fullRange.fColumnId = i;
@@ -361,7 +362,6 @@ std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experim
    }
    fDescriptorBuilder.AddClusterWithDetails(clusterBuilder.MoveDescriptor().Unwrap());
    fPrevClusterNEntries = nEntries;
-   ++fLastClusterId;
    return nbytes;
 }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -285,7 +285,7 @@ void ROOT::Experimental::Detail::RPageSink::Create(RNTupleModel &model)
    auto &fieldZero = *model.GetFieldZero();
    fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(fieldZero).FieldId(0).MakeDescriptor().Unwrap());
    fieldZero.SetOnDiskId(0);
-   for (auto& f : *model.GetFieldZero()) {
+   for (auto &f : fieldZero) {
       auto fieldId = descriptor.GetNFields();
       fDescriptorBuilder.AddField(RFieldDescriptorBuilder::FromField(f).FieldId(fieldId).MakeDescriptor().Unwrap());
       fDescriptorBuilder.AddFieldLink(f.GetParent()->GetOnDiskId(), fieldId);

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -359,7 +359,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
       fDecompressor->Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
                            buffer.get());
 
-      auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, 0);
+      auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, cgDesc.GetId());
       Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), cgDesc.GetPageListLength(), clusters);
       for (std::size_t i = 0; i < clusters.size(); ++i) {
          ntplDesc.AddClusterDetails(clusters[i].MoveDescriptor().Unwrap());

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -69,11 +69,6 @@ static constexpr std::uint64_t kAttributeKey = 0x4243544b5344422d;
 static constexpr daos_obj_id_t kOidAnchor{std::uint64_t(-1), 0};
 static constexpr daos_obj_id_t kOidHeader{std::uint64_t(-2), 0};
 static constexpr daos_obj_id_t kOidFooter{std::uint64_t(-3), 0};
-// The page list offset needs to be a positive 64bit integer because we currently use
-// the object ID for the offset in the locator
-// TODO(jblomer): use object store locators
-// TODO(jblomer): add support for multiple page list envelopes from multiple cluster groups
-static constexpr daos_obj_id_t kOidPageList{std::numeric_limits<int64_t>::max(), 0};
 
 static constexpr daos_oclass_id_t kCidMetadata = OC_SX;
 } // namespace

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -228,29 +228,6 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl()
 {
    const auto &descriptor = fDescriptorBuilder.GetDescriptor();
 
-   std::vector<DescriptorId_t> physClusterIDs;
-   for (const auto &c : descriptor.GetClusterIterable()) {
-      physClusterIDs.emplace_back(fSerializationContext.MapClusterId(c.GetId()));
-   }
-
-   auto szPageList =
-      Internal::RNTupleSerializer::SerializePageListV1(nullptr, descriptor, physClusterIDs, fSerializationContext);
-   auto bufPageList = std::make_unique<unsigned char[]>(szPageList);
-   Internal::RNTupleSerializer::SerializePageListV1(bufPageList.get(), descriptor, physClusterIDs,
-                                                    fSerializationContext);
-
-   auto bufPageListZip = std::make_unique<unsigned char[]>(szPageList);
-   auto szPageListZip = fCompressor->Zip(bufPageList.get(), szPageList, GetWriteOptions().GetCompression(),
-                                         RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
-   fDaosContainer->WriteSingleAkey(bufPageListZip.get(), szPageListZip, kOidPageList, kDistributionKey, kAttributeKey,
-                                   kCidMetadata);
-
-   Internal::RNTupleSerializer::REnvelopeLink pageListEnvelope;
-   pageListEnvelope.fUnzippedSize = szPageList;
-   pageListEnvelope.fLocator.fPosition = kOidPageList.lo;
-   pageListEnvelope.fLocator.fBytesOnStorage = szPageListZip;
-   fSerializationContext.AddClusterGroup(physClusterIDs.size(), pageListEnvelope);
-
    auto szFooter = Internal::RNTupleSerializer::SerializeFooterV1(nullptr, descriptor, fSerializationContext);
    auto bufFooter = std::make_unique<unsigned char[]>(szFooter);
    Internal::RNTupleSerializer::SerializeFooterV1(bufFooter.get(), descriptor, fSerializationContext);

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -212,6 +212,13 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental:
    return std::exchange(fNBytesCurrentCluster, 0);
 }
 
+ROOT::Experimental::RNTupleLocator
+ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterGroupImpl(unsigned char * /* serializedPageList */,
+                                                                  std::uint32_t /* length */)
+{
+   // TODO
+   return RNTupleLocator{};
+}
 
 void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl()
 {

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -224,21 +224,14 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterGroupImpl(unsigned char 
    return result;
 }
 
-void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl()
+void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length)
 {
-   const auto &descriptor = fDescriptorBuilder.GetDescriptor();
-
-   auto szFooter = Internal::RNTupleSerializer::SerializeFooterV1(nullptr, descriptor, fSerializationContext);
-   auto bufFooter = std::make_unique<unsigned char[]>(szFooter);
-   Internal::RNTupleSerializer::SerializeFooterV1(bufFooter.get(), descriptor, fSerializationContext);
-
-   auto bufFooterZip = std::make_unique<unsigned char[]>(szFooter);
-   auto szFooterZip = fCompressor->Zip(bufFooter.get(), szFooter, GetWriteOptions().GetCompression(),
+   auto bufFooterZip = std::make_unique<unsigned char[]>(length);
+   auto szFooterZip = fCompressor->Zip(serializedFooter, length, GetWriteOptions().GetCompression(),
                                        RNTupleCompressor::MakeMemCopyWriter(bufFooterZip.get()));
-   WriteNTupleFooter(bufFooterZip.get(), szFooterZip, szFooter);
+   WriteNTupleFooter(bufFooterZip.get(), szFooterZip, length);
    WriteNTupleAnchor();
 }
-
 
 void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleHeader(
 		const void *data, size_t nbytes, size_t lenHeader)

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -158,6 +158,13 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitClusterImpl(ROOT::Experimental:
    return result;
 }
 
+ROOT::Experimental::RNTupleLocator
+ROOT::Experimental::Detail::RPageSinkFile::CommitClusterGroupImpl(unsigned char * /* serializedPageList */,
+                                                                  std::uint32_t /* length */)
+{
+   // TODO
+   return RNTupleLocator{};
+}
 
 void ROOT::Experimental::Detail::RPageSinkFile::CommitDatasetImpl()
 {

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -264,7 +264,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
       fDecompressor->Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
                            buffer.get());
 
-      auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, 0);
+      auto clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(ntplDesc, cgDesc.GetId());
       Internal::RNTupleSerializer::DeserializePageListV1(buffer.get(), cgDesc.GetPageListLength(), clusters);
       for (std::size_t i = 0; i < clusters.size(); ++i) {
          ntplDesc.AddClusterDetails(clusters[i].MoveDescriptor().Unwrap());

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -157,11 +157,17 @@ ROOT::Experimental::Detail::RPageSinkFile::CommitClusterImpl(ROOT::Experimental:
 }
 
 ROOT::Experimental::RNTupleLocator
-ROOT::Experimental::Detail::RPageSinkFile::CommitClusterGroupImpl(unsigned char * /* serializedPageList */,
-                                                                  std::uint32_t /* length */)
+ROOT::Experimental::Detail::RPageSinkFile::CommitClusterGroupImpl(unsigned char *serializedPageList,
+                                                                  std::uint32_t length)
 {
-   // TODO
-   return RNTupleLocator{};
+   auto bufPageListZip = std::make_unique<unsigned char[]>(length);
+   auto szPageListZip = fCompressor->Zip(serializedPageList, length, GetWriteOptions().GetCompression(),
+                                         RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
+
+   RNTupleLocator result;
+   result.fBytesOnStorage = szPageListZip;
+   result.fPosition = fWriter->WriteBlob(bufPageListZip.get(), szPageListZip, length);
+   return result;
 }
 
 void ROOT::Experimental::Detail::RPageSinkFile::CommitDatasetImpl()

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -110,8 +110,6 @@ ROOT::Experimental::Detail::RPageSinkFile::WriteSealedPage(
       RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
       offsetData = fWriter->WriteBlob(sealedPage.fBuffer, sealedPage.fSize, bytesPacked);
    }
-   fClusterMinOffset = std::min(offsetData, fClusterMinOffset);
-   fClusterMaxOffset = std::max(offsetData + sealedPage.fSize, fClusterMaxOffset);
 
    RNTupleLocator result;
    result.fPosition = offsetData;

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -13,6 +13,7 @@ TEST(RNTuple, ReconstructModel)
    {
       RPageSinkFile sink("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions());
       sink.Create(*model.get());
+      sink.CommitClusterGroup();
       sink.CommitDataset();
       model = nullptr;
    }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -551,12 +551,12 @@ TEST(RNTuple, SerializeFooter)
       physClusterIDs.emplace_back(context.MapClusterId(c.GetId()));
    }
    EXPECT_EQ(desc.GetNClusters(), physClusterIDs.size());
+   context.MapClusterGroupId(256);
 
    auto sizePageList = RNTupleSerializer::SerializePageListV1(nullptr, desc, physClusterIDs, context);
    EXPECT_GT(sizePageList, 0);
    auto bufPageList = std::make_unique<unsigned char []>(sizePageList);
    EXPECT_EQ(sizePageList, RNTupleSerializer::SerializePageListV1(bufPageList.get(), desc, physClusterIDs, context));
-   context.MapClusterGroupId(256);
 
    auto sizeFooter = RNTupleSerializer::SerializeFooterV1(nullptr, desc, context);
    EXPECT_GT(sizeFooter, 0);

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -532,6 +532,13 @@ TEST(RNTuple, SerializeFooter)
    pageRange.fPageInfos.emplace_back(pageInfo);
    clusterBuilder.CommitColumnRange(17, 0, 100, pageRange);
    builder.AddClusterWithDetails(clusterBuilder.MoveDescriptor().Unwrap());
+   RClusterGroupDescriptorBuilder cgBuilder;
+   RNTupleLocator cgLocator;
+   cgLocator.fPosition = 1337;
+   cgLocator.fBytesOnStorage = 42;
+   cgBuilder.ClusterGroupId(256).PageListLength(137).PageListLocator(cgLocator);
+   cgBuilder.AddCluster(84);
+   builder.AddClusterGroup(std::move(cgBuilder));
 
    auto desc = builder.MoveDescriptor();
    auto context = RNTupleSerializer::SerializeHeaderV1(nullptr, desc);
@@ -549,12 +556,7 @@ TEST(RNTuple, SerializeFooter)
    EXPECT_GT(sizePageList, 0);
    auto bufPageList = std::make_unique<unsigned char []>(sizePageList);
    EXPECT_EQ(sizePageList, RNTupleSerializer::SerializePageListV1(bufPageList.get(), desc, physClusterIDs, context));
-
-   RNTupleSerializer::REnvelopeLink pageListEnvelope;
-   pageListEnvelope.fUnzippedSize = 137;
-   pageListEnvelope.fLocator.fPosition = 1337;
-   pageListEnvelope.fLocator.fBytesOnStorage = 42;
-   context.AddClusterGroup(physClusterIDs.size(), pageListEnvelope);
+   context.MapClusterGroupId(256);
 
    auto sizeFooter = RNTupleSerializer::SerializeFooterV1(nullptr, desc, context);
    EXPECT_GT(sizeFooter, 0);


### PR DESCRIPTION
Adds a boolean parameter to `RNTupleWriter::Commit(bool commitClusterGroup)` that, if set to `true`, writes a new page list envelope with page locations corresponding to the bunch of clusters since the last cluster group commit.  This allows to split the page location meta-data into several blocks during writing.  Along the way, this PR also factors out some duplicated code in the page sink implementations (file, daos).

The goal is to make use of the cluster groups during _reading_, such that not all of the page locations need to be in memory all the time but only the locations of the cluster group corresponding to the currently processed event range. This will be subject to a follow-up PR.

Another PR should also take care of automatically committing cluster groups when a reasonable amount of page location meta-data has been accumulated.