### PR TITLE
[RF] Fix memory leaks in RooFitHS3 by completely avoiding manual memory management

### DIFF
--- a/roofit/hs3/src/JSONParser.cxx
+++ b/roofit/hs3/src/JSONParser.cxx
@@ -74,11 +74,14 @@ TJSONTree::Node &TJSONTree::Node::Impl::mkNode(TJSONTree *t, const std::string &
    return t->incache(Node(t, ref));
 }
 
-TJSONTree::Node::Node(TJSONTree *t, std::istream &is) : tree(t), node(new Impl::BaseNode(is)) {}
+TJSONTree::Node::Node(TJSONTree *t, std::istream &is) : tree(t), node(std::make_unique<Impl::BaseNode>(is)) {}
 
-TJSONTree::Node::Node(TJSONTree *t) : tree(t), node(new Impl::BaseNode()) {}
+TJSONTree::Node::Node(TJSONTree *t) : tree(t), node(std::make_unique<Impl::BaseNode>()) {}
 
-TJSONTree::Node::Node(TJSONTree *t, Impl &other) : tree(t), node(new Impl::NodeRef(other.key(), other.get())) {}
+TJSONTree::Node::Node(TJSONTree *t, Impl &other)
+   : tree(t), node(std::make_unique<Impl::NodeRef>(other.key(), other.get()))
+{
+}
 
 TJSONTree::Node::Node(const Node &other) : Node(other.tree, *other.node) {}
 

--- a/roofit/hs3/src/RYMLParser.cxx
+++ b/roofit/hs3/src/RYMLParser.cxx
@@ -110,12 +110,12 @@ void TRYMLTree::Node::set_seq()
 }
 
 TRYMLTree::TRYMLTree(std::istream &is)
-   : tree(new Impl(is)){
+   : tree(std::make_unique<Impl>(is)){
         // constructor taking an istream (for reading)
      };
 
 TRYMLTree::TRYMLTree()
-   : tree(new Impl()){
+   : tree(std::make_unique<Impl>()){
         // default constructor (for writing)
      };
 
@@ -127,7 +127,7 @@ TRYMLTree::~TRYMLTree()
 
 // JSONNode interface implementation
 
-TRYMLTree::Node::Node(TRYMLTree *t, const TRYMLTree::Node::Impl &imp) : tree(t), node(new Impl(imp))
+TRYMLTree::Node::Node(TRYMLTree *t, const TRYMLTree::Node::Impl &imp) : tree(t), node(std::make_unique<Impl>(imp))
 {
    // construct a new node from scratch
 }

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -545,6 +545,13 @@ public:
   virtual void printCompactTreeHook(std::ostream& os, const char *ind="") ;
 
   Bool_t addOwnedComponents(const RooArgSet& comps) ;
+
+  // Transfer the ownership of one or more other RooAbsArgs to this RooAbsArg
+  // via a `std::unique_ptr`.
+  template<typename... Args_t>
+  bool addOwnedComponents(std::unique_ptr<Args_t>... comps) {
+    return addOwnedComponents({*comps.release() ...});
+  }
   const RooArgSet* ownedComponents() const { return _ownedComponents ; }
 
   void setProhibitServerRedirect(Bool_t flag) { _prohibitServerRedirect = flag ; }

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -26,12 +26,13 @@
 #include "RooLinkedListIter.h"
 #include <RooBatchCompute/DataKey.h>
 
-#include <map>
-#include <set>
 #include <deque>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
 #include <stack>
 #include <string>
-#include <iostream>
 
 #ifndef R__LESS_INCLUDES
 #include "TClass.h"


### PR DESCRIPTION
This PR fixes tons of memory leaks in RooFitHS3 by never using manual memory allocation in RooFitHS3.

To facilitate this, an overload of `RooAbsArg::addOwnedComponents` was added that takes transfers the ownership via smart pointers (otherwise one would have to use raw owning pointers or `std::unique_ptr<T>::release()` which I want to avoid).

If the CI passes, I'll squash the second and third commit and add commit messages.
