### PR TITLE
[cling,v6-26] Only enable -Wredundant-parens for prompt input (fixes SPI-2064)

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/CompilationOptions.h
+++ b/interpreter/cling/include/cling/Interpreter/CompilationOptions.h
@@ -12,6 +12,22 @@
 
 namespace cling {
 
+  ///\brief Bits that can be set in `CompilationOptions::IgnoreDiagsMask` to
+  /// filter a group of diagnostics. These flags can be bitwise-OR'd together.
+  enum IgnoreDiags {
+    kNone = 0x00,
+
+    ///\brief Prompt input can look weird for the compiler, e.g.
+    /// void __cling_prompt() { sin(0.1); } // warning: unused function call
+    /// This flag suppresses these warnings; it should be set whenever input
+    /// is wrapped.
+    kPromptBasic = 0x01,
+
+    ///\brief Ignore additional (yet useful for prompt input) warnings, e.g.
+    /// `int (a); // warning: redundant parentheses surrounding declarator`.
+    kPromptExtended = 0x02
+  };
+
   ///\brief Options controlling the incremental compilation. Describe the set of
   /// custom AST consumers to be enabled/disabled.
   ///
@@ -57,11 +73,8 @@ namespace cling {
     /// describing code coming from an existing library.
     unsigned CodeGenerationForModule : 1;
 
-    ///\brief Prompt input can look weird for the compiler, e.g.
-    /// void __cling_prompt() { sin(0.1); } // warning: unused function call
-    /// This flag suppresses these warnings; it should be set whenever input
-    /// is wrapped.
-    unsigned IgnorePromptDiags : 1;
+    ///\brief Mask of ignored diagnostics (see `IgnoreDiags` enum above).
+    unsigned IgnoreDiagsMask : 2;
 
     ///\brief Pointer validity check can be enabled/disabled.
     ///
@@ -85,7 +98,7 @@ namespace cling {
       Debug = 0;
       CodeGeneration = 1;
       CodeGenerationForModule = 0;
-      IgnorePromptDiags = 0;
+      IgnoreDiagsMask = 0;
       OptLevel = 1;
       CheckPointerValidity = 1;
     }
@@ -100,7 +113,7 @@ namespace cling {
         Debug                 == Other.Debug &&
         CodeGeneration        == Other.CodeGeneration &&
         CodeGenerationForModule == Other.CodeGenerationForModule &&
-        IgnorePromptDiags     == Other.IgnorePromptDiags &&
+        IgnoreDiagsMask       == Other.IgnoreDiagsMask &&
         CheckPointerValidity  == Other.CheckPointerValidity &&
         OptLevel              == Other.OptLevel &&
         CodeCompletionOffset  == Other.CodeCompletionOffset;
@@ -116,7 +129,7 @@ namespace cling {
         Debug                 != Other.Debug ||
         CodeGeneration        != Other.CodeGeneration ||
         CodeGenerationForModule != Other.CodeGenerationForModule ||
-        IgnorePromptDiags     != Other.IgnorePromptDiags ||
+        IgnoreDiagsMask       != Other.IgnoreDiagsMask ||
         CheckPointerValidity  != Other.CheckPointerValidity ||
         OptLevel              != Other.OptLevel ||
         CodeCompletionOffset  != Other.CodeCompletionOffset;

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -10,6 +10,7 @@
 #ifndef CLING_INTERPRETER_H
 #define CLING_INTERPRETER_H
 
+#include "cling/Interpreter/CompilationOptions.h"
 #include "cling/Interpreter/InvocationOptions.h"
 #include "cling/Interpreter/RuntimeOptions.h"
 
@@ -66,7 +67,6 @@ namespace cling {
     }
   }
   class ClangInternalState;
-  class CompilationOptions;
   class DynamicLibraryManager;
   class IncrementalCUDADeviceCompiler;
   class IncrementalExecutor;
@@ -710,7 +710,7 @@ namespace cling {
     }
 
     ///\brief Create suitable default compilation options.
-    CompilationOptions makeDefaultCompilationOpts() const;
+    CompilationOptions makeDefaultCompilationOpts(unsigned ignoreDiags = IgnoreDiags::kPromptExtended) const;
 
     //FIXME: This must be in InterpreterCallbacks.
     void installLazyFunctionCreator(void* (*fp)(const std::string&));

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -761,7 +761,7 @@ namespace cling {
     return m_IncrParser->getDiagnosticConsumer() != nullptr;
   }
 
-  CompilationOptions Interpreter::makeDefaultCompilationOpts() const {
+  CompilationOptions Interpreter::makeDefaultCompilationOpts(unsigned ignoreDiags) const {
     CompilationOptions CO;
     CO.DeclarationExtraction = 0;
     CO.EnableShadowing = 0;
@@ -769,7 +769,8 @@ namespace cling {
     CO.CodeGeneration = m_IncrParser->hasCodeGenerator();
     CO.DynamicScoping = isDynamicLookupEnabled();
     CO.Debug = isPrintingDebug();
-    CO.IgnoreDiagsMask = (!isRawInputEnabled() ? IgnoreDiags::kPromptBasic : 0);
+    CO.IgnoreDiagsMask = ignoreDiags | (!isRawInputEnabled()
+                                        ? IgnoreDiags::kPromptBasic : 0);
     CO.CheckPointerValidity = !isRawInputEnabled();
     CO.OptLevel = getDefaultOptLevel();
     return CO;
@@ -821,7 +822,7 @@ namespace cling {
     if (!isRawInputEnabled())
       wrapPoint = utils::getWrapPoint(wrapReadySource, getCI()->getLangOpts());
 
-    CompilationOptions CO = makeDefaultCompilationOpts();
+    CompilationOptions CO = makeDefaultCompilationOpts(IgnoreDiags::kNone);
     CO.EnableShadowing = m_RuntimeOptions.AllowRedefinition && !isRawInputEnabled();
 
     if (isRawInputEnabled() || wrapPoint == std::string::npos) {

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -769,7 +769,7 @@ namespace cling {
     CO.CodeGeneration = m_IncrParser->hasCodeGenerator();
     CO.DynamicScoping = isDynamicLookupEnabled();
     CO.Debug = isPrintingDebug();
-    CO.IgnorePromptDiags = !isRawInputEnabled();
+    CO.IgnoreDiagsMask = (!isRawInputEnabled() ? IgnoreDiags::kPromptBasic : 0);
     CO.CheckPointerValidity = !isRawInputEnabled();
     CO.OptLevel = getDefaultOptLevel();
     return CO;
@@ -835,7 +835,7 @@ namespace cling {
     CO.ValuePrinting = disableValuePrinting ? CompilationOptions::VPDisabled
       : CompilationOptions::VPAuto;
     CO.ResultEvaluation = (bool)V;
-    // CO.IgnorePromptDiags = 1; done by EvaluateInternal().
+    // CO.IgnoreDiagsMask |= IgnoreDiags::kPromptBasic; done by EvaluateInternal().
     CO.CheckPointerValidity = 1;
     if (EvaluateInternal(wrapReadySource, CO, V, T, wrapPoint)
                                                      == Interpreter::kFailure) {
@@ -1373,7 +1373,7 @@ namespace cling {
 
     // We have wrapped and need to disable warnings that are caused by
     // non-default C++ at the prompt:
-    CO.IgnorePromptDiags = 1;
+    CO.IgnoreDiagsMask |= IgnoreDiags::kPromptBasic;
 
     IncrementalParser::ParseResultTransaction PRT
       = m_IncrParser->Compile(Wrapper, CO);

--- a/interpreter/cling/test/Prompt/IgnoreDiags.C
+++ b/interpreter/cling/test/Prompt/IgnoreDiags.C
@@ -1,0 +1,19 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+// Test diagnostics masking via `CompilationOptions::IgnoreDiagsMask`
+#include "cling/Interpreter/Interpreter.h"
+
+int (ii) = 0 // expected-warning {{redundant parentheses surrounding declarator}}
+// CHECK: (int) 0
+
+// [-Wredundant-parens] diagnostic should not be emitted in this case
+gCling->declare("int (jj);");
+
+.q


### PR DESCRIPTION
This pull-request is a backport of #9695 (see details there).

This PR fixes SPI-2064.