### PR TITLE
[DF] Avoid duplicates in list of columns returned by GetColumnNames

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2247,14 +2247,12 @@ public:
 
       auto tree = fLoopManager->GetTree();
       if (tree) {
-         auto branchNames = RDFInternal::GetBranchNames(*tree, /*allowDuplicates=*/false);
-         for (const auto &bName : branchNames)
+         for (const auto &bName : RDFInternal::GetBranchNames(*tree, /*allowDuplicates=*/false))
             allColumns.emplace(bName);
       }
 
       if (fDataSource) {
-         const auto &dsColNames = fDataSource->GetColumnNames();
-         for (const auto &s : dsColNames) {
+         for (const auto &s : fDataSource->GetColumnNames()) {
             if (s.rfind("R_rdf_sizeof", 0) != 0)
                allColumns.emplace(s);
          }

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2261,6 +2261,7 @@ public:
       }
 
       ColumnNames_t ret(allColumns.begin(), allColumns.end());
+      std::sort(ret.begin(), ret.end());
       return ret;
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2239,9 +2239,9 @@ public:
             allColumns.emplace_back(colName);
       };
 
-      auto columnNames = fColRegister.GetNames();
+      auto definedColumns = fColRegister.GetNames();
 
-      std::for_each(columnNames.begin(), columnNames.end(), addIfNotInternal);
+      std::for_each(definedColumns.begin(), definedColumns.end(), addIfNotInternal);
 
       auto tree = fLoopManager->GetTree();
       if (tree) {

--- a/tree/dataframe/test/dataframe_cache.cxx
+++ b/tree/dataframe/test/dataframe_cache.cxx
@@ -253,46 +253,40 @@ TEST(Cache, Regex)
    ROOT::RDataFrame df(1);
    ROOT::RDF::RNode n(df);
    std::string base("col_");
-   std::vector<std::string> defColNames; defColNames.reserve(128);
-   auto addCol = [base, &defColNames](ROOT::RDF::RNode &node, int i) {
-      auto colName = base+std::to_string(i);
-      defColNames.emplace_back(colName);
-      return ROOT::RDF::RNode(node.Define(colName, [](){return 0;}));
-   };
    for (auto i : ROOT::TSeqI(128)) {
-      n = addCol(n, i);
+      auto colName = base + std::to_string(i);
+      n = n.Define(colName, [](){return 0;});
    }
-   int cursor = 0;
    const auto df_even_cols = n.Cache(".*[02468]$").GetColumnNames();
+
+   std::vector<std::string> evenColNames;
+   for (auto i : ROOT::TSeqI(0, 128, 2))
+      evenColNames.emplace_back(base + std::to_string(i));
+   std::sort(evenColNames.begin(), evenColNames.end());
+
+   std::size_t cursor = 0u;
    for (auto &&col : df_even_cols) {
-      EXPECT_TRUE(col == defColNames[cursor]) << "Checking even columns. An error was encountered: expecting "
-                                              << defColNames[cursor] << " but found " << col;
-      cursor+=2;
+      EXPECT_TRUE(col == evenColNames[cursor]) << "Checking even columns. An error was encountered: expecting "
+                                              << evenColNames[cursor] << " but found " << col;
+      ++cursor;
    }
 
-   cursor = 1;
-   const auto df_odd_cols = n.Cache(".*[13579]$").GetColumnNames();
-   for (auto &&col : df_odd_cols) {
-      EXPECT_TRUE(col == defColNames[cursor]) << "Checking odd columns. An error was encountered: expecting "
-                                              << defColNames[cursor] << " but found " << col;
-      cursor+=2;
+   std::vector<std::string> colNamesWith2And5;
+   for (auto i : ROOT::TSeqI(128)) {
+      const auto s = std::to_string(i);
+      if (s.back() == '2' || s.back() == '5') {
+         colNamesWith2And5.emplace_back(base + s);
+      }
    }
-
-   cursor = 1;
+   std::sort(colNamesWith2And5.begin(), colNamesWith2And5.end());
+   cursor = 0u;
    const auto df_or_cols = n.Cache("(col_.*[2]$|col_.*[5]$)").GetColumnNames();
    for (auto &&col : df_or_cols) {
-      cursor++;
-      auto cursorAsString = std::to_string(cursor);
-      auto last = cursorAsString.back();
-      while (last != '2' && last != '5') {
-        cursor++;
-        cursorAsString = std::to_string(cursor);
-        last = cursorAsString.back();
-      }
-      EXPECT_TRUE(col == defColNames[cursor]) << "Checking columns chosen with an or. An error was encountered!: expecting "
-                                              << defColNames[cursor] << " but found " << col;
+      EXPECT_TRUE(col == colNamesWith2And5[cursor])
+         << "Checking columns chosen with an or. An error was encountered!: expecting " << colNamesWith2And5[cursor]
+         << " but found " << col;
+      ++cursor;
    }
-
 }
 
 TEST(Cache, Carrays)

--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -135,9 +135,8 @@ TEST(RDataFrameInterface, GetColumnNamesFromOrdering)
    RDataFrame tdf(t);
    auto names = tdf.GetColumnNames();
    EXPECT_EQ(2U, names.size());
-   EXPECT_STREQ("zzz", names[0].c_str());
-   EXPECT_STREQ("aaa", names[1].c_str());
-
+   EXPECT_STREQ("aaa", names[0].c_str());
+   EXPECT_STREQ("zzz", names[1].c_str());
 }
 
 TEST(RDataFrameInterface, GetColumnNamesFromSource)
@@ -472,7 +471,7 @@ TEST(RDataFrameInterface, ColumnWithSimpleStruct)
    EXPECT_NE(t.GetLeaf("c.b"),nullptr);
 
    ROOT::RDataFrame df(t);
-   const std::vector<std::string> expected({ "c.a", "a", "c.b", "b", "c" });
+   const std::vector<std::string> expected({ "a",  "b", "c", "c.a", "c.b" });
    EXPECT_EQ(df.GetColumnNames(), expected);
    for (std::string_view col : {"c.a", "a"}) {
       EXPECT_DOUBLE_EQ(df.Mean<int>(col).GetValue(), 42.); // compiled
@@ -656,10 +655,10 @@ TEST(RDataFrameInterface, Describe)
                      "\n"
                      "Column                  Type                            Origin\n"
                      "------                  ----                            ------\n"
-                     "myVec                   ROOT::VecOps::RVec<float>       Define\n"
-                     "myLongColumnName        unsigned int                    Define\n"
+                     "myFloat                 Float_t                         Dataset\n"
                      "myInt                   Int_t                           Dataset\n"
-                     "myFloat                 Float_t                         Dataset";
+                     "myLongColumnName        unsigned int                    Define\n"
+                     "myVec                   ROOT::VecOps::RVec<float>       Define";
    EXPECT_EQ(df3.Describe().AsString(), ref2);
 }
 


### PR DESCRIPTION
The same column name can appear as a Redefine'd column and as the
original column in the data source.

This fixes the "repeated column names" part of #9240.