### PR TITLE
[webgui6] do not call blocking methods from ProcessData (6.24)

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -73,7 +73,7 @@ protected:
    std::string fCustomScripts;     ///<! custom JavaScript code or URL on JavaScript files to load before start drawing
    std::vector<std::string> fCustomClasses;  ///<! list of custom classes, which can be delivered as is to client
    Bool_t fCanCreateObjects{kTRUE}; ///<! indicates if canvas allowed to create extra objects for interactive painting
-
+   Bool_t fProcessingData{kFALSE}; ///<! flag used to prevent blocking methods when process data is invoked
    UpdatedSignal_t fUpdatedSignal; ///<! signal emitted when canvas updated or state is changed
    PadSignal_t fActivePadChangedSignal; ///<! signal emitted when active pad changed in the canvas
    PadClickedSignal_t fPadClickedSignal; ///<! signal emitted when simple mouse click performed on the pad

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -810,7 +810,6 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg)
    return kTRUE;
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Handle data from web browser
 /// Returns kFALSE if message was not processed
@@ -828,6 +827,14 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
    }
    if (indx >= fWebConn.size())
       return kTRUE;
+
+   struct FlagGuard {
+      Bool_t &flag;
+      FlagGuard(Bool_t &_flag) : flag(_flag) { flag = true; }
+      ~FlagGuard() { flag = false; }
+   };
+
+   FlagGuard guard(fProcessingData);
 
    const char *cdata = arg.c_str();
 
@@ -1098,7 +1105,8 @@ Bool_t TWebCanvas::PerformUpdate()
    CheckDataToSend();
 
    // block in canvas update, can it be optional?
-   WaitWhenCanvasPainted(fCanvVersion);
+   if (!fProcessingData)
+      WaitWhenCanvasPainted(fCanvVersion);
 
    return kTRUE;
 }


### PR DESCRIPTION
If during processing of incoming data TCanvas::Update() invoked,
do not block caller until actual update is done. Otherwise deadlock is
possible
