### PR TITLE
[webgui6] support HighlightConnect with TWebCanvas

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -74,6 +74,7 @@ protected:
    std::vector<std::string> fCustomClasses;  ///<! list of custom classes, which can be delivered as is to client
    Bool_t fCanCreateObjects{kTRUE}; ///<! indicates if canvas allowed to create extra objects for interactive painting
    Bool_t fLongerPolling{kFALSE};  ///<! when true, make longer polling in blocking operations
+   Bool_t fProcessingData{kFALSE}; ///<! flag used to prevent blocking methods when process data is invoked
 
    UpdatedSignal_t fUpdatedSignal; ///<! signal emitted when canvas updated or state is changed
    PadSignal_t fActivePadChangedSignal; ///<! signal emitted when active pad changed in the canvas

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -88,6 +88,7 @@ class TCanvasWebSnapshot : public TPadWebSnapshot {
 protected:
    Long64_t fVersion{0};           ///< actual canvas version
    std::string fScripts;           ///< custom scripts to load
+   bool fHighlightConnect{false};  ///< does HighlightConnect has connection
 public:
    TCanvasWebSnapshot() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
    TCanvasWebSnapshot(bool readonly, Long64_t v) : TPadWebSnapshot(readonly), fVersion(v) {}
@@ -95,8 +96,12 @@ public:
    Long64_t GetVersion() const { return fVersion; }
 
    void SetScripts(const std::string &src) { fScripts = src; }
+   const std::string &GetScripts() const { return fScripts; }
 
-   ClassDef(TCanvasWebSnapshot, 1) // Canvas painting snapshot, used for JSROOT
+   void SetHighlightConnect(bool on = true) { fHighlightConnect = on; }
+   bool GetHighlightConnect() const { return fHighlightConnect; }
+
+   ClassDef(TCanvasWebSnapshot, 2) // Canvas painting snapshot, used for JSROOT
 };
 
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -918,6 +918,20 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          AssignStatusBits(std::stoul(arg.substr(11)));
          if (fUpdatedSignal) fUpdatedSignal(); // invoke signal
       }
+   } else if (arg.compare(0, 10, "HIGHLIGHT:") == 0) {
+      auto arr = TBufferJSON::FromJSON<std::vector<std::string>>(arg.substr(10));
+      if (!arr || (arr->size() != 4)) {
+         Error("ProcessData", "Wrong arguments count %d in highlight message", (int) (arr ? arr->size() : -1));
+      } else {
+         auto pad = dynamic_cast<TVirtualPad*> (FindPrimitive(arr->at(0)));
+         auto obj = FindPrimitive(arr->at(1));
+         int argx = std::stoi(arr->at(2));
+         int argy = std::stoi(arr->at(3));
+         if (pad && obj) {
+            Canvas()->Highlighted(pad, obj, argx, argy);
+            CheckPadModified(Canvas());
+         }
+      }
 
    } else if (IsReadOnly()) {
 
@@ -1122,7 +1136,7 @@ Bool_t TWebCanvas::PerformUpdate()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-/// Increment canvas version and force sending data to client - do not wit for reply
+/// Increment canvas version and force sending data to client - do not wait for reply
 
 void TWebCanvas::ForceUpdate()
 {

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -564,6 +564,8 @@ void TWebCanvas::CheckDataToSend(unsigned connid)
          if (!conn.fSendVersion)
             holder.SetScripts(fCustomScripts);
 
+         holder.SetHighlightConnect(Canvas()->HasConnection("Highlighted(TVirtualPad*,TObject*,Int_t,Int_t)"));
+
          CreatePadSnapshot(holder, Canvas(), conn.fSendVersion, [&buf,this](TPadWebSnapshot *snap) {
             buf.append(TBufferJSON::ToJSON(snap, fJsonComp).Data());
          });

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -828,7 +828,6 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg)
    return kTRUE;
 }
 
-
 //////////////////////////////////////////////////////////////////////////////////////////
 /// Handle data from web browser
 /// Returns kFALSE if message was not processed
@@ -846,6 +845,14 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
    }
    if (indx >= fWebConn.size())
       return kTRUE;
+
+   struct FlagGuard {
+      Bool_t &flag;
+      FlagGuard(Bool_t &_flag) : flag(_flag) { flag = true; }
+      ~FlagGuard() { flag = false; }
+   };
+
+   FlagGuard guard(fProcessingData);
 
    const char *cdata = arg.c_str();
 
@@ -1130,7 +1137,8 @@ Bool_t TWebCanvas::PerformUpdate()
    CheckDataToSend();
 
    // block in canvas update, can it be optional?
-   WaitWhenCanvasPainted(fCanvVersion);
+   if (!fProcessingData)
+      WaitWhenCanvasPainted(fCanvVersion);
 
    return kTRUE;
 }

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -104,7 +104,7 @@
 
    /** @summary JSROOT version date
      * @desc Release date in format day/month/year like "19/11/2021"*/
-   JSROOT.version_date = "21/01/2022";
+   JSROOT.version_date = "26/01/2022";
 
    /** @summary JSROOT version id and date
      * @desc Produced by concatenation of {@link JSROOT.version_id} and {@link JSROOT.version_date}

--- a/js/scripts/JSRoot.interactive.js
+++ b/js/scripts/JSRoot.interactive.js
@@ -186,9 +186,10 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
              gapy = 10,  // y coordinate, taking into account all gaps
              gapminx = -1111, gapmaxx = -1111,
              minhinty = -frame_shift.y,
-             maxhinty = this.getCanvPainter().getPadHeight() - frame_rect.y - frame_shift.y;
+             cp = this.getCanvPainter(),
+             maxhinty = cp.getPadHeight() - frame_rect.y - frame_shift.y;
 
-         function FindPosInGap(y) {
+         const FindPosInGap = y => {
             for (let n = 0; (n < hints.length) && (y < maxhinty); ++n) {
                let hint = hints[n];
                if (!hint) continue;
@@ -198,7 +199,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                }
             }
             return y;
-         }
+         };
 
          for (let n = 0; n < hints.length; ++n) {
             let hint = hints[n],
@@ -321,6 +322,9 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
                .select('rect').attr("width", actualw);
 
          hintsg.property('startx', posx);
+
+         if (cp._highlight_connect && (typeof cp.processHighlightConnect == 'function'))
+            cp.processHighlightConnect(hints);
       },
 
       /** @summary Assigns tooltip methods */
@@ -334,7 +338,7 @@ JSROOT.define(['d3', 'painter'], (d3, jsrp) => {
 
    } // TooltipHandler
 
-   function setPainterTooltipEnabled(painter,on) {
+   function setPainterTooltipEnabled(painter, on) {
       if (!painter) return;
 
       let fp = painter.getFramePainter();

--- a/js/scripts/JSRoot.more.js
+++ b/js/scripts/JSRoot.more.js
@@ -1703,13 +1703,15 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
 
       if (findbin === null) return null;
 
-      let d = d3.select(findbin).datum();
-
-      let res = { name: this.getObject().fName, title: this.getObject().fTitle,
+      let d = d3.select(findbin).datum(),
+          gr = this.getObject(),
+          res = { name: gr.fName, title: gr.fTitle,
                   x: d.grx1, y: d.gry1,
                   color1: this.lineatt.color,
                   lines: this.getTooltips(d),
                   rect: best, d3bin: findbin  };
+
+       res.user_info = { obj: gr,  name: gr.fName, bin: d.indx, cont: d.y, grx: d.grx1, gry: d.gry1 };
 
       if (this.fillatt && this.fillatt.used && !this.fillatt.empty()) res.color2 = this.fillatt.getFillColor();
 
@@ -1882,6 +1884,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
                   lines: this.getTooltips(best.bin),
                   usepath: true };
 
+      res.user_info = { obj: gr,  name: gr.fName, bin: 0, cont: 0, grx: res.x, gry: res.y };
+
       res.ismark = ismark;
       res.islines = islines;
 
@@ -1899,6 +1903,8 @@ JSROOT.define(['d3', 'painter', 'gpad'], (d3, jsrp) => {
          res.binindx = best.indx;
          res.bin = best.bin;
          res.radius = best.radius;
+         res.user_info.bin = best.indx;
+         res.user_info.cont = best.bin.y;
 
          res.exact = (Math.abs(pnt.x - res.x) <= best.radius) &&
             ((Math.abs(pnt.y - res.gry1) <= best.radius) || (Math.abs(pnt.y - res.gry2) <= best.radius));

--- a/js/scripts/JSRoot.webwindow.js
+++ b/js/scripts/JSRoot.webwindow.js
@@ -493,7 +493,7 @@ JSROOT.define([], () => {
       this.close();
       if (!href && this.href) href = this.href;
 
-      let pthis = this, ntry = 0, args = (this.key ? ("key=" + this.key) : "");
+      let ntry = 0, args = (this.key ? ("key=" + this.key) : "");
       if (this.token) {
          if (args) args += "&";
          args += "token=" + this.token;
@@ -541,37 +541,37 @@ JSROOT.define([], () => {
 
          if (!this._websocket) return;
 
-         this._websocket.onopen = function() {
+         this._websocket.onopen = () => {
             if ((ntry > 2) && JSROOT.Painter) JSROOT.Painter.showProgress();
-            pthis.state = 1;
+            this.state = 1;
 
-            let key = pthis.key || "";
+            let key = this.key || "";
 
-            pthis.send("READY=" + key, 0); // need to confirm connection
-            pthis.invokeReceiver(false, "onWebsocketOpened");
-         }
+            this.send("READY=" + key, 0); // need to confirm connection
+            this.invokeReceiver(false, "onWebsocketOpened");
+         };
 
-         this._websocket.onmessage = function(e) {
+         this._websocket.onmessage = e => {
             let msg = e.data;
 
-            if (pthis.next_binary) {
+            if (this.next_binary) {
 
-               let binchid = pthis.next_binary;
-               delete pthis.next_binary;
+               let binchid = this.next_binary;
+               delete this.next_binary;
 
                if (msg instanceof Blob) {
                   // this is case of websocket
                   // console.log('Get Blob object - convert to buffer array');
-                  let reader = new FileReader, qitem = pthis.reserveQueueItem();
+                  let reader = new FileReader, qitem = this.reserveQueueItem();
                   reader.onload = function(event) {
                      // The file's text will be printed here
-                     pthis.markQueueItemDone(qitem, event.target.result, 0);
+                     this.markQueueItemDone(qitem, event.target.result, 0);
                   };
                   reader.readAsArrayBuffer(msg, e.offset || 0);
                } else {
                   // console.log('got array ' + (typeof msg) + ' len = ' + msg.byteLength);
                   // this is from CEF or LongPoll handler
-                  pthis.provideData(binchid, msg, e.offset || 0);
+                  this.provideData(binchid, msg, e.offset || 0);
                }
 
                return;
@@ -586,45 +586,45 @@ JSROOT.define([], () => {
                i3 = msg.indexOf(":", i2 + 1),
                chid = parseInt(msg.substr(i2 + 1, i3 - i2));
 
-            pthis.ackn++;            // count number of received packets,
-            pthis.cansend += credit; // how many packets client can send
+            this.ackn++;            // count number of received packets,
+            this.cansend += credit; // how many packets client can send
 
             msg = msg.substr(i3 + 1);
 
             if (chid == 0) {
                console.log('GET chid=0 message', msg);
                if (msg == "CLOSE") {
-                  pthis.close(true); // force closing of socket
-                  pthis.invokeReceiver(true, "onWebsocketClosed");
+                  this.close(true); // force closing of socket
+                  this.invokeReceiver(true, "onWebsocketClosed");
                }
             } else if (msg == "$$binary$$") {
-               pthis.next_binary = chid;
+               this.next_binary = chid;
             } else if (msg == "$$nullbinary$$") {
-               pthis.provideData(chid, new ArrayBuffer(0), 0);
+               this.provideData(chid, new ArrayBuffer(0), 0);
             } else {
-               pthis.provideData(chid, msg);
+               this.provideData(chid, msg);
             }
 
-            if (pthis.ackn > 7)
-               pthis.send('READY', 0); // send dummy message to server
-         }
+            if (this.ackn > 7)
+               this.send('READY', 0); // send dummy message to server
+         };
 
-         this._websocket.onclose = function(arg) {
-            delete pthis._websocket;
-            if ((pthis.state > 0) || (arg === "force_close")) {
+         this._websocket.onclose = arg => {
+            delete this._websocket;
+            if ((this.state > 0) || (arg === "force_close")) {
                console.log('websocket closed');
-               pthis.state = 0;
-               pthis.invokeReceiver(true, "onWebsocketClosed");
+               this.state = 0;
+               this.invokeReceiver(true, "onWebsocketClosed");
             }
-         }
+         };
 
-         this._websocket.onerror = function(err) {
-            console.log(`websocket error ${err} state ${pthis.state}`);
-            if (pthis.state > 0) {
-               pthis.invokeReceiver(true, "onWebsocketError", err);
-               pthis.state = 0;
+         this._websocket.onerror = err => {
+            console.log(`websocket error ${err} state ${this.state}`);
+            if (this.state > 0) {
+               this.invokeReceiver(true, "onWebsocketError", err);
+               this.state = 0;
             }
-         }
+         };
 
          // only in interactive mode try to reconnect
          if (!JSROOT.batch_mode)

--- a/js/style/JSRoot.painter.css
+++ b/js/style/JSRoot.painter.css
@@ -717,6 +717,7 @@
    background-position: left 2px top 2px;
    background-repeat: no-repeat;
    background-size: 24px 24px;
+   border-color: inherit;
 }
 
 .jsroot_browser_btns:hover {


### PR DESCRIPTION
When configured, tooltip is automatically enabled on web canvas
And client delivers correspondent events, which are used to invoke canvas signal.

Require some adjustment in examples or slight change in API that `TH1::SetHighlight()` works also without painter.