### PR TITLE
[cling] Revert "[cling] Enable `-Wredundant-parens`"

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1315,9 +1315,6 @@ namespace {
         default: llvm_unreachable("Unrecognized C++ version");
       }
     }
-    // Warn on redundant parentheses surrounding declarator, e.g. `bool(i)`,
-    // whose parsing might not match the user intent.
-    argvCompile.push_back("-Wredundant-parens");
 
     // This argument starts the cling instance with the x86 target. Otherwise,
     // the first job in the joblist starts the cling instance with the nvptx


### PR DESCRIPTION
This reverts commit eb52895d22aaad0a88d47b8e7bb18c7f47ff35be.

As discussed, we should try to make clang parse input containing solely a function-style cast (e.g. `bool(i)`) as an expression instead of a declaration.

In the interim, this patch is reverted to silence unwanted warnings in third-party code.
The PR https://github.com/root-project/root/pull/9695 will also be closed.

## Checklist:
- [X] tested changes locally

This PR fixes [SPI-2064](https://sft.its.cern.ch/jira/browse/SPI-2064) and reopens issue #8304.