### PR TITLE
Revert "[cling] Enable `-Wredundant-parens`"

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -1315,9 +1315,6 @@ namespace {
         default: llvm_unreachable("Unrecognized C++ version");
       }
     }
-    // Warn on redundant parentheses surrounding declarator, e.g. `bool(i)`,
-    // whose parsing might not match the user intent.
-    argvCompile.push_back("-Wredundant-parens");
 
     // This argument starts the cling instance with the x86 target. Otherwise,
     // the first job in the joblist starts the cling instance with the nvptx


### PR DESCRIPTION
This PR is a backport of https://github.com/root-project/root/pull/9706 (see description there).

This PR fixes [SPI-2064](https://sft.its.cern.ch/jira/browse/SPI-2064) and reopens issue #8304.