### PR TITLE
[DF] Make internal naming convention more uniform

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -44,18 +44,18 @@ std::shared_ptr<GraphNode> AddDefinesToGraph(std::shared_ptr<GraphNode> node,
  * \ingroup dataframe
  * \brief A RDataFrame node that produces a result
  * \tparam Helper The action helper type, which implements the concrete action logic (e.g. FillHelper, SnapshotHelper)
- * \tparam PrevDataFrame The type of the parent node in the computation graph
+ * \tparam PrevNode The type of the parent node in the computation graph
  * \tparam ColumnTypes_t A TypeList with the types of the input columns
  *
  */
 // clang-format on
-template <typename Helper, typename PrevDataFrame, typename ColumnTypes_t = typename Helper::ColumnTypes_t>
+template <typename Helper, typename PrevNode, typename ColumnTypes_t = typename Helper::ColumnTypes_t>
 class R__CLING_PTRCHECK(off) RAction : public RActionBase {
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
 
    Helper fHelper;
-   const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
-   PrevDataFrame &fPrevData;
+   const std::shared_ptr<PrevNode> fPrevNodePtr;
+   PrevNode &fPrevNode;
    /// Column readers per slot and per input column
    std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
@@ -63,10 +63,9 @@ class R__CLING_PTRCHECK(off) RAction : public RActionBase {
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
 
 public:
-   RAction(Helper &&h, const ColumnNames_t &columns, std::shared_ptr<PrevDataFrame> pd,
-           const RColumnRegister &colRegister)
+   RAction(Helper &&h, const ColumnNames_t &columns, std::shared_ptr<PrevNode> pd, const RColumnRegister &colRegister)
       : RActionBase(pd->GetLoopManagerUnchecked(), columns, colRegister), fHelper(std::forward<Helper>(h)),
-        fPrevDataPtr(std::move(pd)), fPrevData(*fPrevDataPtr), fValues(GetNSlots()), fIsDefine()
+        fPrevNodePtr(std::move(pd)), fPrevNode(*fPrevNodePtr), fValues(GetNSlots()), fIsDefine()
    {
       const auto nColumns = columns.size();
       const auto &customCols = GetColRegister();
@@ -78,8 +77,8 @@ public:
    RAction &operator=(const RAction &) = delete;
    ~RAction()
    {
-      // must Deregister objects from the RLoopManager here, before the fPrevDataFrame data member is destroyed:
-      // otherwise if fPrevDataFrame is the RLoopManager, it will be destroyed before the calls to Deregister happen.
+      // must Deregister objects from the RLoopManager here, before the fPrevNode data member is destroyed:
+      // otherwise if fPrevNode is the RLoopManager, it will be destroyed before the calls to Deregister happen.
       RActionBase::GetColRegister().Clear(); // triggers RDefine deregistration
       fLoopManager->Deregister(this);
    }
@@ -114,11 +113,11 @@ public:
    void Run(unsigned int slot, Long64_t entry) final
    {
       // check if entry passes all filters
-      if (fPrevData.CheckFilters(slot, entry))
+      if (fPrevNode.CheckFilters(slot, entry))
          CallExec(slot, entry, ColumnTypes_t{}, TypeInd_t{});
    }
 
-   void TriggerChildrenCount() final { fPrevData.IncrChildrenCount(); }
+   void TriggerChildrenCount() final { fPrevNode.IncrChildrenCount(); }
 
    /// Clean-up operations to be performed at the end of a task.
    void FinalizeSlot(unsigned int slot) final
@@ -139,7 +138,7 @@ public:
    std::shared_ptr<RDFGraphDrawing::GraphNode>
    GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) final
    {
-      auto prevNode = fPrevData.GetGraph(visitedMap);
+      auto prevNode = fPrevNode.GetGraph(visitedMap);
       auto prevColumns = prevNode->GetDefinedColumns();
 
       // Action nodes do not need to go through CreateFilterNode: they are never common nodes between multiple branches

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -52,7 +52,7 @@ namespace RDF {
 using namespace ROOT::TypeTraits;
 namespace RDFGraphDrawing = ROOT::Internal::RDF::GraphDrawing;
 
-template <typename FilterF, typename PrevDataFrame>
+template <typename FilterF, typename PrevNode>
 class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
    using ColumnTypes_t = typename CallableTraits<FilterF>::arg_types;
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
@@ -60,24 +60,24 @@ class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
    FilterF fFilter;
    /// Column readers per slot and per input column
    std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
-   const std::shared_ptr<PrevDataFrame> fPrevDataPtr;
-   PrevDataFrame &fPrevData;
+   const std::shared_ptr<PrevNode> fPrevNodePtr;
+   PrevNode &fPrevNode;
 
 public:
-   RFilter(FilterF f, const ROOT::RDF::ColumnNames_t &columns, std::shared_ptr<PrevDataFrame> pd,
+   RFilter(FilterF f, const ROOT::RDF::ColumnNames_t &columns, std::shared_ptr<PrevNode> pd,
            const RDFInternal::RColumnRegister &colRegister, std::string_view name = "")
       : RFilterBase(pd->GetLoopManagerUnchecked(), name, pd->GetLoopManagerUnchecked()->GetNSlots(), colRegister,
                     columns),
-        fFilter(std::move(f)), fValues(pd->GetLoopManagerUnchecked()->GetNSlots()), fPrevDataPtr(std::move(pd)),
-        fPrevData(*fPrevDataPtr)
+        fFilter(std::move(f)), fValues(pd->GetLoopManagerUnchecked()->GetNSlots()), fPrevNodePtr(std::move(pd)),
+        fPrevNode(*fPrevNodePtr)
    {
    }
 
    RFilter(const RFilter &) = delete;
    RFilter &operator=(const RFilter &) = delete;
    ~RFilter() {
-      // must Deregister objects from the RLoopManager here, before the fPrevDataFrame data member is destroyed:
-      // otherwise if fPrevDataFrame is the RLoopManager, it will be destroyed before the calls to Deregister happen.
+      // must Deregister objects from the RLoopManager here, before the fPrevNode data member is destroyed:
+      // otherwise if fPrevNode is the RLoopManager, it will be destroyed before the calls to Deregister happen.
       fColRegister.Clear(); // triggers RDefine deregistration
       fLoopManager->Deregister(this);
    }
@@ -85,7 +85,7 @@ public:
    bool CheckFilters(unsigned int slot, Long64_t entry) final
    {
       if (entry != fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()]) {
-         if (!fPrevData.CheckFilters(slot, entry)) {
+         if (!fPrevNode.CheckFilters(slot, entry)) {
             // a filter upstream returned false, cache the result
             fLastResult[slot * RDFInternal::CacheLineStep<int>()] = false;
          } else {
@@ -122,7 +122,7 @@ public:
 
    void PartialReport(ROOT::RDF::RCutFlowReport &rep) const final
    {
-      fPrevData.PartialReport(rep);
+      fPrevNode.PartialReport(rep);
       FillReport(rep);
    }
 
@@ -130,7 +130,7 @@ public:
    {
       ++fNStopsReceived;
       if (fNStopsReceived == fNChildren)
-         fPrevData.StopProcessing();
+         fPrevNode.StopProcessing();
    }
 
    void IncrChildrenCount() final
@@ -138,18 +138,18 @@ public:
       ++fNChildren;
       // propagate "children activation" upstream. named filters do the propagation via `TriggerChildrenCount`.
       if (fNChildren == 1 && fName.empty())
-         fPrevData.IncrChildrenCount();
+         fPrevNode.IncrChildrenCount();
    }
 
    void TriggerChildrenCount() final
    {
       assert(!fName.empty()); // this method is to only be called on named filters
-      fPrevData.IncrChildrenCount();
+      fPrevNode.IncrChildrenCount();
    }
 
    void AddFilterName(std::vector<std::string> &filters)
    {
-      fPrevData.AddFilterName(filters);
+      fPrevNode.AddFilterName(filters);
       auto name = (HasName() ? fName : "Unnamed Filter");
       filters.push_back(name);
    }
@@ -165,7 +165,7 @@ public:
    GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
    {
       // Recursively call for the previous node.
-      auto prevNode = fPrevData.GetGraph(visitedMap);
+      auto prevNode = fPrevNode.GetGraph(visitedMap);
       auto prevColumns = prevNode->GetDefinedColumns();
 
       auto thisNode = RDFGraphDrawing::CreateFilterNode(this, visitedMap);


### PR DESCRIPTION
Prefer calling the previous nodes of in the computation graph and
their types fPrevNode/PrevNode instead of fPrevData and PrevDataFrame.