### PR TITLE
[RF] Address memory leaks in RooLagrangianMorphFunc

### DIFF
--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -455,7 +455,8 @@ void readValues(std::map<const std::string, T> &myMap, TH1 *h_pc)
 /// @param folder TFolder to clean up 
 /// @param deleteIt if set, enable deletion of the folder after 
 ///                 setting ownership  
-void cleanUpFolder(TFolder* folder, bool deleteIt=true){
+void cleanUpFolder(TFolder* folder, bool deleteIt=true)
+{
   // start by assigning ownership to the folder itself
   folder->SetOwner();
   // And we need to do the same for all nested sub-folders.
@@ -474,20 +475,23 @@ void cleanUpFolder(TFolder* folder, bool deleteIt=true){
 ///////////////////////////////////////////////////////////////////////////////
 /// Helper to load a single object from a file-resident TFolder, while 
 /// avoiding memory leaks. 
-/// @tparam objType Type of object to load. 
+/// @tparam AObjType Type of object to load. 
 /// @param inFile input file to load from. Expected to be a valid pointer 
 /// @param folderName Name of the TFolder to load from the file 
 /// @param objName Name of the object to load 
 /// @param notFoundError If set, print a detailed error if we didn't find something
 /// @return Returns a pointer to a clone of the loaded object. Ownership assigned to the caller. 
-template <class objType> objType* loadFromFileResidentFolder(TDirectory* inFile, const std::string & folderName, const std::string & objName,
-                          bool notFoundError = true){
+template <class AObjType> AObjType* loadFromFileResidentFolder(TDirectory* inFile, 
+                                                            const std::string & folderName, 
+                                                            const std::string & objName,
+                                                            bool notFoundError = true)
+{
    auto folder = inFile->Get<TFolder>(folderName.c_str());
    if (!folder) {
       std::cerr << "Error: unable to access data from folder '" << folderName << "'!" << std::endl;
       return nullptr;
    }
-   objType *loadedObject = dynamic_cast<objType *>(folder->FindObject(objName.c_str()));
+   AObjType *loadedObject = dynamic_cast<AObjType *>(folder->FindObject(objName.c_str()));
    if (!loadedObject) {
       if (notFoundError){
          std::stringstream errstr;
@@ -504,7 +508,7 @@ template <class objType> objType* loadFromFileResidentFolder(TDirectory* inFile,
       return nullptr; 
    }
    // replace the loaded object by a clone to be able to clean the loaded folder 
-   objType* output = static_cast<objType *>(loadedObject->Clone()); // can use a static_cast - confirmed validity by initial cast above. 
+   AObjType* output = static_cast<AObjType *>(loadedObject->Clone()); // can use a static_cast - confirmed validity by initial cast above. 
    cleanUpFolder(folder); 
    return output;      
 }  

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -448,10 +448,10 @@ void readValues(std::map<const std::string, T> &myMap, TH1 *h_pc)
    }
 }
 
-
-/// Reading file-resident TFolders results in memory leakage, addressing this 
-/// by assigning ownership to the loaded folder over its content 
-/// and then deleting 
+///////////////////////////////////////////////////////////////////////////////
+/// Set up a TFolder loaded from a file to own its content. 
+/// Also recursively updates nested subfolders accordingly
+/// Optionally, delete the TFolder at the end
 /// @param folder TFolder to clean up 
 /// @param deleteIt if set, enable deletion of the folder after 
 ///                 setting ownership  
@@ -463,8 +463,7 @@ void cleanUpFolder(TFolder* folder, bool deleteIt=true){
   for (auto* subdir : *subdirs){
     auto thisfolder = dynamic_cast<TFolder*>(subdir);  
     if (thisfolder){
-      // recursively clean up the subfolders - no explicit deletion here, 
-      // will be handled by owning parent
+      // no explicit deletion here, will be handled by parent
       cleanUpFolder(thisfolder, false); 
     }
   }
@@ -472,7 +471,8 @@ void cleanUpFolder(TFolder* folder, bool deleteIt=true){
   if (deleteIt) delete folder; 
 }
 
-/// Helper to load an object from a file-resident TFolder, while 
+///////////////////////////////////////////////////////////////////////////////
+/// Helper to load a single object from a file-resident TFolder, while 
 /// avoiding memory leaks. 
 /// @tparam objType Type of object to load. 
 /// @param inFile input file to load from. Expected to be a valid pointer 

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -448,27 +448,67 @@ void readValues(std::map<const std::string, T> &myMap, TH1 *h_pc)
    }
 }
 
-///////////////////////////////////////////////////////////////////////////////
-/// retrieve a param_hist from a certain subfolder 'name' of the file
 
-inline TH1F *getParamHist(TDirectory *file, const std::string &name, const std::string &objkey = "param_card",
-                          bool notFoundError = true)
-{
-   auto f_tmp = file->Get<TFolder>(name.c_str());
-   if (!f_tmp) {
-      std::cerr << "unable to retrieve folder '" << name << "' from file '" << file->GetName() << "'!" << std::endl;
+/// Reading file-resident TFolders results in memory leakage, addressing this 
+/// by assigning ownership to the loaded folder over its content 
+/// and then deleting 
+/// @param folder TFolder to clean up 
+/// @param deleteIt if set, enable deletion of the folder after 
+///                 setting ownership  
+void cleanUpFolder(TFolder* folder, bool deleteIt=true){
+  // start by assigning ownership to the folder itself
+  folder->SetOwner();
+  // And we need to do the same for all nested sub-folders.
+  auto subdirs = folder->GetListOfFolders(); 
+  for (auto* subdir : *subdirs){
+    auto thisfolder = dynamic_cast<TFolder*>(subdir);  
+    if (thisfolder){
+      // recursively clean up the subfolders - no explicit deletion here, 
+      // will be handled by owning parent
+      cleanUpFolder(thisfolder, false); 
+    }
+  }
+  // now ownership is set up - can delete if requested. 
+  if (deleteIt) delete folder; 
+}
+
+/// Helper to load an object from a file-resident TFolder, while 
+/// avoiding memory leaks. 
+/// @tparam objType Type of object to load. 
+/// @param inFile input file to load from. Expected to be a valid pointer 
+/// @param folderName Name of the TFolder to load from the file 
+/// @param objName Name of the object to load 
+/// @param notFoundError If set, print a detailed error if we didn't find something
+/// @return Returns a pointer to a clone of the loaded object. Ownership assigned to the caller. 
+template <class objType> objType* loadFromFileResidentFolder(TDirectory* inFile, const std::string & folderName, const std::string & objName,
+                          bool notFoundError = true){
+   auto folder = inFile->Get<TFolder>(folderName.c_str());
+   if (!folder) {
+      std::cerr << "Error: unable to access data from folder '" << folderName << "'!" << std::endl;
       return nullptr;
    }
-   // retrieve the histogram param_card which should live directly in the folder
-   TH1F *h_pc = dynamic_cast<TH1F *>(f_tmp->FindObject(objkey.c_str()));
-   if (h_pc) {
-      return h_pc;
+   objType *loadedObject = dynamic_cast<objType *>(folder->FindObject(objName.c_str()));
+   if (!loadedObject) {
+      if (notFoundError){
+         std::stringstream errstr;
+         errstr << "Error: unable to retrieve object '" << objName << "' from folder '" << folderName
+                  << "'. contents are:";
+         TIter next(folder->GetListOfFolders()->begin());
+         TFolder *f;
+         while ((f = (TFolder *)next())) {
+            errstr << " " << f->GetName();
+         }
+         std::cerr << errstr.str() << std::endl;
+      } 
+      cleanUpFolder(folder); 
+      return nullptr; 
    }
-   if (notFoundError) {
-      std::cerr << "unable to retrieve " << objkey << " histogram from folder '" << name << "'" << std::endl;
-   }
-   return nullptr;
-}
+   // replace the loaded object by a clone to be able to clean the loaded folder 
+   objType* output = static_cast<objType *>(loadedObject->Clone()); // can use a static_cast - confirmed validity by initial cast above. 
+   cleanUpFolder(folder); 
+   return output;      
+}  
+
 
 ///////////////////////////////////////////////////////////////////////////////
 /// retrieve a ParamSet from a certain subfolder 'name' of the file
@@ -477,7 +517,7 @@ template <class T>
 void readValues(std::map<const std::string, T> &myMap, TDirectory *file, const std::string &name,
                 const std::string &key = "param_card", bool notFoundError = true)
 {
-   TH1F *h_pc = getParamHist(file, name, key, notFoundError);
+   TH1F *h_pc = loadFromFileResidentFolder<TH1F>(file, name, key, notFoundError);
    readValues(myMap, h_pc);
 }
 
@@ -752,24 +792,8 @@ void collectHistograms(const char *name, TDirectory *file, std::map<std::string,
    bool binningOK = false;
    for (auto sampleit : inputParameters) {
       const std::string sample(sampleit.first);
-      auto folder = file->Get<TFolder>(sample.c_str());
-      if (!folder) {
-         std::cerr << "Error: unable to access data from folder '" << sample << "'!" << std::endl;
-         continue;
-      }
-      TH1 *hist = dynamic_cast<TH1 *>(folder->FindObject(varname.c_str()));
-      if (!hist) {
-         std::stringstream errstr;
-         errstr << "Error: unable to retrieve histogram '" << varname << "' from folder '" << sample
-                << "'. contents are:";
-         TIter next(folder->GetListOfFolders()->begin());
-         TFolder *f;
-         while ((f = (TFolder *)next())) {
-            errstr << " " << f->GetName();
-         }
-         std::cerr << errstr.str() << std::endl;
-         return;
-      }
+      TH1* hist = loadFromFileResidentFolder<TH1>(file, sample, varname, true); 
+      if (!hist) return; 
 
       auto it = list_hf.find(sample);
       if (it != list_hf.end()) {
@@ -820,25 +844,8 @@ void collectRooAbsReal(const char * /*name*/, TDirectory *file, std::map<std::st
 {
    for (auto sampleit : inputParameters) {
       const std::string sample(sampleit.first);
-      auto folder = file->Get<TFolder>(sample.c_str());
-      if (!folder) {
-         std::cerr << "Error: unable to access data from folder '" << sample << "'!" << std::endl;
-         continue;
-      }
-
-      RooAbsReal *obj = dynamic_cast<RooAbsReal *>(folder->FindObject(varname.c_str()));
-      if (!obj) {
-         std::stringstream errstr;
-         std::cerr << "Error: unable to retrieve RooAbsArg '" << varname << "' from folder '" << sample
-                   << "'. contents are:" << std::endl;
-         TIter next(folder->GetListOfFolders()->begin());
-         TFolder *f;
-         while ((f = (TFolder *)next())) {
-            errstr << " " << f->GetName();
-         }
-         std::cerr << errstr.str() << std::endl;
-         return;
-      }
+      RooAbsReal* obj = loadFromFileResidentFolder<RooAbsReal>(file,sample,varname,true); 
+      if (!obj) return; 
       auto it = list_hf.find(sample);
       if (it == list_hf.end()) {
          int idx = physics.getSize();
@@ -859,12 +866,7 @@ void collectCrosssections(const char *name, TDirectory *file, std::map<std::stri
 {
    for (auto sampleit : inputParameters) {
       const std::string sample(sampleit.first);
-      auto folder = file->Get<TFolder>(sample.c_str());
-      if (!folder) {
-         std::cerr << "unable to access data from folder '" << sample << "'!" << std::endl;
-         return;
-      }
-      TObject *obj = folder->FindObject(varname.c_str());
+      TObject* obj = loadFromFileResidentFolder<TObject>(file, sample, varname,false);
       TParameter<T> *xsection = nullptr;
       TParameter<T> *error = nullptr;
       TParameter<T> *p = dynamic_cast<TParameter<T> *>(obj);
@@ -878,14 +880,7 @@ void collectCrosssections(const char *name, TDirectory *file, std::map<std::stri
       }
       if (!xsection) {
          std::stringstream errstr;
-         errstr << "Error: unable to retrieve cross section '" << varname << "' from folder '" << sample
-                << "'. contents are:";
-         TIter next(folder->GetListOfFolders()->begin());
-         TFolder *f;
-         while ((f = (TFolder *)next())) {
-            errstr << " " << f->GetName();
-         }
-         std::cerr << errstr.str() << std::endl;
+         errstr << "Error: unable to retrieve cross section '" << varname << "' from folder '" << sample;
          return;
       }
 
@@ -916,8 +911,8 @@ void collectCrosssectionsTPair(const char *name, TDirectory *file, std::map<std:
                                RooArgList &physics, const std::string &varname, const std::string &basefolder,
                                const RooLagrangianMorphFunc::ParamMap &inputParameters)
 {
-   auto folder = file->Get<TFolder>(basefolder.c_str());
-   TPair *pair = dynamic_cast<TPair *>(folder->FindObject(varname.c_str()));
+   TPair* pair = loadFromFileResidentFolder<TPair>(file,basefolder,varname,false); 
+   if (!pair) return; 
    TParameter<double> *xsec_double = dynamic_cast<TParameter<double> *>(pair->Key());
    if (xsec_double) {
       collectCrosssections<double>(name, file, list_xs, physics, varname, inputParameters);
@@ -1755,10 +1750,9 @@ void RooLagrangianMorphFunc::collectInputs(TDirectory *file)
    cxcoutP(InputArguments) << "initializing physics inputs from file " << file->GetName() << " with object name(s) '"
                            << obsName << "'" << std::endl;
    auto folderNames = this->_config.folderNames;
-   auto base = file->Get<TFolder>(folderNames[0].c_str());
-   TObject *obj = base->FindObject(obsName.c_str());
+   TObject* obj = loadFromFileResidentFolder<TObject>(file, folderNames.front(), obsName, true);
    if (!obj) {
-      std::cerr << "unable to locate object '" << obsName << "' in folder '" << base << "'!" << std::endl;
+      std::cerr << "unable to locate object '" << obsName << "' in folder '" << folderNames.front() << "'!" << std::endl;
       return;
    }
    std::string classname = obj->ClassName();
@@ -1807,6 +1801,7 @@ void RooLagrangianMorphFunc::addFolders(const RooArgList &folders)
       if (!f)
          continue;
       std::string name(f->GetName());
+      cleanUpFolder(f); 
       if (name.empty())
          continue;
       this->_config.folderNames.push_back(name);
@@ -2557,7 +2552,7 @@ void RooLagrangianMorphFunc::setParameters(const char *foldername)
 {
    std::string filename = this->_config.fileName;
    TDirectory *file = openFile(filename.c_str());
-   TH1 *paramhist = getParamHist(file, foldername);
+   TH1 *paramhist = loadFromFileResidentFolder<TH1>(file, foldername,"param_card");
    setParams(paramhist, this->_operators, false);
    closeFile(file);
 }


### PR DESCRIPTION
# This Pull request:
The `RooLagrangianMorphFunc` loads its input objects from a nested set of `TFolders` stored in a `TFile`.  
This MR adds protection (inspired by [ROOT-9275](https://sft.its.cern.ch/jira/browse/ROOT-9275) to avoid memory leaks in the initialisation of the `RooLagrangianMorphFunc`, which for large `RooFit` workspaces with many morphing functions can otherwise become unfeasible to use. 

## Changes or fixes:
- add a `cleanUpFolder` helper method to an existing anoymous namespace to `RooLagrangianMorphFunc.cxx`, which ensures ownership is enabled for `TFolder`s loaded from `TFile`s and optionally deletes the folders after setting them up 
- add a templated `loadFromFileResidentFolder` method to the same anonymous namespace in `RooLagrangianMorphFunc.cxx`, refactoring the procedure of loading an object from a nested `TFolder` structure that was previously performed in various locations in the class. The method exploits the `cleanUpFolder` method to prevent memory leaks in the access procedure. 

## Checklist:

- [ x ] tested changes locally - confirmed leak rate massively reduced in local testing. Draft test script (not yet merged) provided by @rahulgrit retains same output as before the changes
- [ ] updated the docs (if necessary) - no changes to user-accessible code. Inline doxygen documentation of new methods. 

Tagging @rahulgrit @guitargeek 
