### PR TITLE
[Math] Fix a bug in creating the Default minimizer options 

### DIFF
--- a/math/mathcore/inc/Math/MinimizerOptions.h
+++ b/math/mathcore/inc/Math/MinimizerOptions.h
@@ -151,8 +151,8 @@ public:
    static ROOT::Math::IOptions * FindDefault(const char * name);
 
    /// Print all the default options including the extra one specific for a given minimizer name.
-   /// If no minimizer name is given, all the extra default options which have been set and configured will be printed
-   static void PrintDefault(const char * name, std::ostream & os = std::cout);
+   /// If no minimizer name is given, all the extra default options, which have been set and configured will be printed 
+   static void PrintDefault(const char * name = nullptr, std::ostream & os = std::cout);
 
 public:
 

--- a/math/mathcore/src/GenAlgoOptions.cxx
+++ b/math/mathcore/src/GenAlgoOptions.cxx
@@ -57,12 +57,10 @@ namespace GenAlgoOptUtil {
       std::string algoname(algo);
       OptionsMap & gOpts = GenAlgoOptUtil::gAlgoOptions;
       IOptions * opt = GenAlgoOptUtil::DoFindDefault(algoname, gOpts);
-      if (opt == 0) {
-         // create new extra options for the given type
-         std::pair<OptionsMap::iterator,bool> ret = gOpts.insert( OptionsMap::value_type(algoname, ROOT::Math::GenAlgoOptions()) );
-         assert(ret.second);
-         opt = &((ret.first)->second);
-      }
+      if (opt) return *opt;
+      // if not existing create new extra options for the given type
+      std::pair<OptionsMap::iterator,bool> ret = gOpts.insert( OptionsMap::value_type(algoname, ROOT::Math::GenAlgoOptions()) );
+      if (ret.second) return gOpts[algoname];
       return *opt;
    }
 

--- a/math/mathcore/src/MinimizerOptions.cxx
+++ b/math/mathcore/src/MinimizerOptions.cxx
@@ -242,9 +242,13 @@ void MinimizerOptions::PrintDefault(const char * name, std::ostream & os) {
    MinimizerOptions tmp;
    tmp.Print(os);
    if (!tmp.ExtraOptions() ) {
-      IOptions * opt = FindDefault(name);
-      os << "Specific options for "  << name << std::endl;
-      if (opt) opt->Print(os);
+      if (name) {
+         IOptions * opt = FindDefault(name);
+         os << "Specific options for "  << name << std::endl;
+         if (opt) opt->Print(os);
+      } else { 
+         GenAlgoOptions::PrintAllDefault(os);
+      }
    }
 }
 


### PR DESCRIPTION
Fix a bug when creating and setting default minimizer options for a Minimizer.
The bug was when using the function 
`ROOT::Math::MinimizerOptions::Default`

These code , to increase the parameter "Steps" of the Minimizer Genetic, before was causing a crash
```
auto & opt = ROOT::Math::MinimizerOptions::Default("Genetic")
opt.SetValue("Steps",1000)
ROOT::Math::MinimizerOptions::PrintDefault("Genetic")
```

The PR also add the possibility to print all default options for ll minimizer. Now this can be done:
```
ROOT::Math::MinimizerOptions::PrintDefault()
```

 
