### PR TITLE
[RF] Add overloads for memory-safe `RooAbsCollection::addOwned` and `RooAbsArg::addOwnedComponents`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -545,7 +545,19 @@ public:
   void printCompactTree(std::ostream& os, const char* indent="", const char* namePat=0, RooAbsArg* client=0) ;
   virtual void printCompactTreeHook(std::ostream& os, const char *ind="") ;
 
-  Bool_t addOwnedComponents(const RooArgSet& comps) ;
+  // We want to support three cases here:
+  //   * passing a RooArgSet
+  //   * passing a RooArgList
+  //   * passing an initializer list
+  // Before, there was only an overload taking a RooArg set, which caused an
+  // implicit creation of a RooArgSet when a RooArgList was passed. This needs
+  // to be avoided, because if the passed RooArgList is owning the argumnets,
+  // this information will be lost with the copy. The solution is to have one
+  // overload that takes a general RooAbsCollection, and one overload for
+  // RooArgList that is invoked in the case of passing an initializer list.
+  bool addOwnedComponents(const RooAbsCollection& comps) ;
+  bool addOwnedComponents(RooAbsCollection&& comps) ;
+  bool addOwnedComponents(RooArgList&& comps) ;
 
   // Transfer the ownership of one or more other RooAbsArgs to this RooAbsArg
   // via a `std::unique_ptr`.

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -34,6 +34,7 @@
 #include <unordered_map>
 #include <vector>
 #include <type_traits>
+#include <memory>
 
 
 // To make ROOT::RangeStaticCast available under the name static_range_cast.
@@ -110,6 +111,7 @@ public:
   // List content management
   virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) ;
   virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE);
+  bool addOwned(std::unique_ptr<RooAbsArg> var, bool silent=false);
   virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) ;
   virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) ;
   virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
@@ -132,7 +134,8 @@ public:
   bool add(const RooAbsCollection& list, bool silent=kFALSE) {
     return add(list._list.begin(), list._list.end(), silent);
   }
-  virtual Bool_t addOwned(const RooAbsCollection& list, Bool_t silent=kFALSE);
+  virtual bool addOwned(const RooAbsCollection& list, bool silent=false);
+  bool addOwned(RooAbsCollection&& list, bool silent=false);
   virtual void   addClone(const RooAbsCollection& list, Bool_t silent=kFALSE);
   Bool_t replace(const RooAbsCollection &other);
   Bool_t remove(const RooAbsCollection& list, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;

--- a/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
+++ b/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
@@ -26,9 +26,10 @@ class RooArgSet;
 namespace RooFit {
 namespace BatchModeHelpers {
 
-RooAbsReal *createNLL(RooAbsPdf &pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &&constraints,
-                      std::string const &rangeName, std::string const &addCoefRangeName, RooArgSet const &projDeps,
-                      bool isExtended, double integrateOverBinsPrecision, RooFit::BatchModeOption batchMode);
+std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &&constraints,
+                                      std::string const &rangeName, std::string const &addCoefRangeName,
+                                      RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
+                                      RooFit::BatchModeOption batchMode);
 
 }
 } // namespace RooFit

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -129,9 +129,16 @@ public:
       bool _ownsDriver;
    };
 
-   std::unique_ptr<RooAbsReal> makeAbsRealWrapper(bool ownsDriver = false)
+   std::unique_ptr<RooAbsReal> makeAbsRealWrapper()
    {
-      return std::unique_ptr<RooAbsReal>{new RooAbsRealWrapper{*this, ownsDriver}};
+      return std::unique_ptr<RooAbsReal>{new RooAbsRealWrapper{*this, false}};
+   }
+
+   // Static method to create a RooAbsRealWrapper that owns a given
+   // RooFitDriver passed by smart pointer.
+   static std::unique_ptr<RooAbsReal> makeAbsRealWrapper(std::unique_ptr<RooFitDriver> driver)
+   {
+      return std::unique_ptr<RooAbsReal>{new RooAbsRealWrapper{*driver.release(), true}};
    }
 
 private:

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -63,10 +63,9 @@ std::unique_ptr<RooAbsArg> prepareSimultaneousModelForBatchMode(RooSimultaneous 
          arg->SetName(newName.c_str());
       }
       nll.recursiveRedirectServers(obsClones, false, true);
-      nll.addOwnedComponents(obsClones);
-      obsClones.releaseOwnership();
       newObservables.add(obsClones);
       static_cast<ROOT::Experimental::RooNLLVarNew &>(nll).setObservables(obsClones);
+      nll.addOwnedComponents(std::move(obsClones));
       ++iNLL;
    }
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -92,7 +92,7 @@ RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, 
    if (!rangeName.empty()) {
       auto term = createRangeNormTerm(pdf, observables, pdf.GetName(), rangeName);
       _rangeNormTerm = std::make_unique<RooTemplateProxy<RooAbsReal>>("_rangeNormTerm", "_rangeNormTerm", this, *term);
-      this->addOwnedComponents(*term.release());
+      this->addOwnedComponents(std::move(term));
    }
 }
 

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -1148,12 +1148,12 @@ void RooSimultaneous::wrapPdfsInBinSamplingPdfs(RooAbsData const &data, double p
       // RooBinSamplingPdf in the RooSimultaneous.
       newSamplingPdf->setAttribute(
           (std::string("ORIGNAME:") + pdf.GetName()).c_str());
-      newSamplingPdfs.add(*newSamplingPdf.release());
+      newSamplingPdfs.addOwned(std::move(newSamplingPdf));
     }
   }
 
   this->redirectServers(newSamplingPdfs, false, true);
-  this->addOwnedComponents(newSamplingPdfs);
+  this->addOwnedComponents(std::move(newSamplingPdfs));
 }
 
 
@@ -1195,10 +1195,10 @@ void RooSimultaneous::wrapPdfsInBinSamplingPdfs(RooAbsData const &data,
       // RooBinSamplingPdf in the RooSimultaneous.
       newSamplingPdf->setAttribute(
           (std::string("ORIGNAME:") + pdf.GetName()).c_str());
-      newSamplingPdfs.add(*newSamplingPdf.release());
+      newSamplingPdfs.addOwned(std::move(newSamplingPdf));
     }
   }
 
   this->redirectServers(newSamplingPdfs, false, true);
-  this->addOwnedComponents(newSamplingPdfs);
+  this->addOwnedComponents(std::move(newSamplingPdfs));
 }

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -216,27 +216,16 @@ public:
 
     // compare pdfs
     assert(pMC_API->GetPdf() && pMC_XML->GetPdf());
-    RooArgSet* pObservables = (RooArgSet*)(pMC_API->GetObservables()->snapshot());
-    RooArgSet* pGlobalObservables = (RooArgSet*)(pMC_API->GetGlobalObservables()->snapshot());
-    if(pGlobalObservables)
-    {
-      pObservables->addOwned(*pGlobalObservables);
-    }
+    RooArgSet pObservables;
+    pMC_API->GetObservables()->snapshot(pObservables);
+    RooArgSet pGlobalObservables;
+    pMC_API->GetGlobalObservables()->snapshot(pGlobalObservables);
+    pObservables.addOwned(std::move(pGlobalObservables));
 
     if(_verb > 0)
       Info("testCode","comparing PDFs");
-    if(!ComparePDF(*pMC_API->GetPdf(),*pMC_XML->GetPdf(),*pObservables,*pWS_API->data("obsData")))
-    {
-      delete pObservables;
-      // delete pGlobalObservables;
-      return kFALSE;
-    }
 
-    // clean up
-    delete pObservables;
-    // delete pGlobalObservables;
-
-    return kTRUE;
+    return ComparePDF(*pMC_API->GetPdf(),*pMC_XML->GetPdf(),pObservables,*pWS_API->data("obsData"));
   }
 
 private:


### PR DESCRIPTION
More details in in the commit descriptions.

In particular, the memory management in JSONFactories_HistFactory is simplified in such a way that this PR should unblock https://github.com/root-project/root/pull/9683.
