### PR TITLE
[DF] Improve SaveGraph. Apply suggestions from #9556

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -317,7 +317,10 @@ public:
       return std::make_unique<RMergeableFill<Hist_t>>(*fResultHist);
    }
 
-   std::string GetActionName() { return "FillWithUnknownAxes"; }
+   std::string GetActionName()
+   {
+      return std::string(fResultHist->IsA()->GetName()) + "<BR/>" + std::string(fResultHist->GetName());
+   }
 };
 
 extern template void FillHelper::Exec(unsigned int, const std::vector<float> &);
@@ -501,7 +504,19 @@ public:
       return std::make_unique<RMergeableFill<HIST>>(*fObjects[0]);
    }
 
-   std::string GetActionName() { return "Fill"; }
+   // if the fObjects vector type is derived from TObject, return the name of the object
+   template <typename T = HIST, typename std::enable_if<std::is_base_of<TObject, T>::value>::type * = nullptr>
+   std::string GetActionName()
+   {
+      return std::string(fObjects[0]->IsA()->GetName()) + "<BR/>" + std::string(fObjects[0]->GetName());
+   }
+
+   // if fObjects is not derived from TObject, indicate it is some other object
+   template <typename T = HIST, typename std::enable_if<!std::is_base_of<TObject, T>::value>::type * = nullptr>
+   std::string GetActionName()
+   {
+      return "Fill custom object";
+   }
 };
 
 class FillTGraphHelper : public ROOT::Detail::RDF::RActionImpl<FillTGraphHelper> {

--- a/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/GraphNode.hxx
@@ -88,31 +88,31 @@ public:
    /// \brief Gives a different shape based on the node type
    void SetRoot()
    {
-      fColor = "#e8f8fc";
-      fShape = "oval";
+      fColor = "#f4b400";
+      fShape = "ellipse";
    }
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Gives a different shape based on the node type
    void SetFilter()
    {
-      fColor = "#c4cfd4";
-      fShape = "diamond";
+      fColor = "#0f9d58";
+      fShape = "hexagon";
    }
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Gives a different shape based on the node type
    void SetDefine()
    {
-      fColor = "#60aef3";
-      fShape = "oval";
+      fColor = "#4285f4";
+      fShape = "ellipse";
    }
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Gives a different shape based on the node type
    void SetRange()
    {
-      fColor = "#6F4D8F";
+      fColor = "#9574b4";
       fShape = "diamond";
    }
 
@@ -121,9 +121,10 @@ public:
    void SetAction(bool hasRun)
    {
       if (hasRun) {
-         fColor = "#baf1e5";
+         fName += "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>";
+         fColor = "#e6e5e6";
       } else {
-         fColor = "#9cbbe5";
+         fColor = "#e47c7e";
       }
       fShape = "box";
    }

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -27,7 +27,7 @@ std::string GraphCreatorHelper::FromGraphLeafToDot(std::shared_ptr<GraphNode> le
 
    // Explore the graph bottom-up and store its dot representation.
    while (leaf) {
-      dotStringLabels << "\t" << leaf->fCounter << " [label=\"" << leaf->fName << "\", style=\"filled\", fillcolor=\""
+      dotStringLabels << "\t" << leaf->fCounter << " [label=<" << leaf->fName << ">, style=\"filled\", fillcolor=\""
                       << leaf->fColor << "\", shape=\"" << leaf->fShape << "\"];\n";
       if (leaf->fPrevNode) {
          dotStringGraph << "\t" << leaf->fPrevNode->fCounter << " -> " << leaf->fCounter << ";\n";
@@ -47,9 +47,8 @@ std::string GraphCreatorHelper::FromGraphActionsToDot(std::vector<std::shared_pt
 
    for (auto leaf : leaves) {
       while (leaf && !leaf->fIsExplored) {
-         dotStringLabels << "\t" << leaf->fCounter << " [label=\"" << leaf->fName
-                         << "\", style=\"filled\", fillcolor=\"" << leaf->fColor << "\", shape=\"" << leaf->fShape
-                         << "\"];\n";
+         dotStringLabels << "\t" << leaf->fCounter << " [label=<" << leaf->fName << ">, style=\"filled\", fillcolor=\""
+                         << leaf->fColor << "\", shape=\"" << leaf->fShape << "\"];\n";
          if (leaf->fPrevNode) {
             dotStringGraph << "\t" << leaf->fPrevNode->fCounter << " -> " << leaf->fCounter << ";\n";
          }
@@ -96,7 +95,7 @@ std::shared_ptr<GraphNode> CreateDefineNode(const std::string &columnName,
    if (duplicateDefineIt != visitedMap.end())
       return duplicateDefineIt->second;
 
-   auto node = std::make_shared<GraphNode>("Define\n" + columnName);
+   auto node = std::make_shared<GraphNode>("Define<BR/>" + columnName);
    node->SetDefine();
    node->SetCounter(visitedMap.size());
    visitedMap[(void *)columnPtr] = node;

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -892,7 +892,7 @@ std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode> RLoopManager::GetG
    } else if (fTree) {
       name = fTree->GetName();
    } else {
-      name = std::to_string(fNEmptyEntries);
+      name = "Empty source<BR/>Entries: " + std::to_string(fNEmptyEntries);
    }
    auto thisNode = std::make_shared<ROOT::Internal::RDF::GraphDrawing::GraphNode>(name);
    thisNode->SetRoot();

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -56,7 +56,6 @@ TEST(RDFHelpers, PassAsVec)
    EXPECT_EQ(1u, *df.Filter(PassAsVec<2, int>(TwoOnesDeque), {"one", "_1"}).Count());
 }
 
-
 // this tests https://github.com/root-project/root/issues/8276
 TEST(RDFHelpers, ReturnPassAsVec)
 {
@@ -114,48 +113,40 @@ public:
       *branch2_2;
    }
 
-   std::string GetRepresentationFromRoot()
-   {
-      return SaveGraph(rd1);
-   }
+   std::string GetRepresentationFromRoot() { return SaveGraph(rd1); }
 
    std::string GetRealRepresentationFromRoot()
    {
-      return std::string("digraph {\n"
-                         "\t8 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
-             (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
+      return std::string("digraph {\n\t8 [label=<Mean") +
+             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
+             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
-             "\t6 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t7 [label=\"Define\n"
-             "Branch_1_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t3 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t4 [label=\"Define\n"
-             "Branch_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t5 [label=\"Define\n"
-             "Root_def2\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t2 [label=\"Define\n"
-             "Root_def1\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t0 [label=\"8\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n"
-             "\t11 [label=\"Count\", style=\"filled\", fillcolor=\"" +
-             (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
+             "\t6 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t7 [label=<Define<BR/>Branch_1_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t3 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t4 [label=<Define<BR/>Branch_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t5 [label=<Define<BR/>Root_def2>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t1 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t2 [label=<Define<BR/>Root_def1>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t0 [label=<Empty source<BR/>Entries: 8>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
+             "\t11 [label=<Count" +
+             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
+             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
-             "\t9 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t10 [label=\"Define\n"
-             "Branch_1_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t17 [label=\"Max\", style=\"filled\", fillcolor=\"" +
-             (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
+             "\t9 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t10 [label=<Define<BR/>Branch_1_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t17 [label=<Max" +
+             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
+             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
-             "\t14 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t15 [label=\"Define\n"
-             "Branch_2_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t16 [label=\"Define\n"
-             "Branch_2_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t12 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t13 [label=\"Define\n"
-             "Branch_2_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t18 [label=\"Count\", style=\"filled\", fillcolor=\"" +
-             (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
+             "\t14 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t15 [label=<Define<BR/>Branch_2_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t16 [label=<Define<BR/>Branch_2_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t12 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t13 [label=<Define<BR/>Branch_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t18 [label=<Count" +
+             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
+             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
              "\t6 -> 8;\n"
              "\t7 -> 6;\n"
@@ -174,33 +165,26 @@ public:
              "\t12 -> 16;\n"
              "\t13 -> 12;\n"
              "\t5 -> 13;\n"
-             "\t13 -> 18;\n"
-             "}";
+             "\t13 -> 18;\n}";
    }
 
-   std::string GetRepresentationFromAction()
-   {
-      return SaveGraph(branch1_1);
-   }
+   std::string GetRepresentationFromAction() { return SaveGraph(branch1_1); }
 
    std::string GetRealRepresentationFromAction()
    {
-      return std::string("digraph {\n"
-                         "\t8 [label=\"Mean\", style=\"filled\", fillcolor=\"") +
-             (hasLoopRun ? "#baf1e5" : "#9cbbe5") +
+      return std::string("digraph {\n\t8 [label=<Mean") +
+             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
+             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
-             "\t6 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t7 [label=\"Define\n"
-             "Branch_1_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t3 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t4 [label=\"Define\n"
-             "Branch_1_def\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t5 [label=\"Define\n"
-             "Root_def2\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n"
-             "\t2 [label=\"Define\n"
-             "Root_def1\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n"
-             "\t0 [label=\"8\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n"
+             "\t6 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", "
+             "shape=\"hexagon\"];\n"
+             "\t7 [label=<Define<BR/>Branch_1_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t3 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t4 [label=<Define<BR/>Branch_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t5 [label=<Define<BR/>Root_def2>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t1 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t2 [label=<Define<BR/>Root_def1>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t0 [label=<Empty source<BR/>Entries: 8>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
              "\t6 -> 8;\n"
              "\t7 -> 6;\n"
              "\t3 -> 7;\n"
@@ -208,8 +192,7 @@ public:
              "\t5 -> 4;\n"
              "\t1 -> 5;\n"
              "\t2 -> 1;\n"
-             "\t0 -> 2;\n"
-             "}";
+             "\t0 -> 2;\n}";
    }
 };
 
@@ -242,6 +225,129 @@ TEST(RDFHelpers, SaveGraphAfterEventLoop)
    EXPECT_EQ(helper.GetRepresentationFromAction(), helper.GetRealRepresentationFromAction());
 }
 
+TEST(RDFHelpers, SaveGraphHistograms)
+{
+   ROOT::RDataFrame df(10);
+   int x = 0;
+   auto d1 = df.Define("x", [&x]() { return x++; })
+                .Filter([](int n) { return n >= 2; }, {"x"}, "MyFilt")
+                .Range(3)
+                .Filter([](int n) { return n >= 2; }, {"x"}, "");
+   auto h0 = d1.Histo1D<int>({"h1", "h1", 10, 0, 10}, "x");
+   auto d2 = df.Define("v0",
+                       []() {
+                          std::vector<float> v({1, 2, 3});
+                          return v;
+                       })
+                .Define("v1",
+                        []() {
+                           std::vector<float> v({4, 5, 6});
+                           return v;
+                        })
+                .Define("v2",
+                        []() {
+                           std::vector<float> v({7, 8, 9});
+                           return v;
+                        })
+                .Define("w", []() { return 3; });
+   auto h1 = d2.Histo1D<std::vector<float>, int>("v0", "w");
+   auto h2 = d2.Histo2D<std::vector<float>, std::vector<float>, int>({"A", "B", 16, 0, 16, 16, 0, 16}, "v0", "v1", "w");
+   auto h3 = d2.Histo3D<std::vector<float>, std::vector<float>, std::vector<float>, int>(
+      {"C", "D", 16, 0, 16, 16, 0, 16, 16, 0, 16}, "v0", "v1", "v2", "w");
+
+   auto strOut = SaveGraph(df);
+
+   static const std::string expectedGraph(
+      "digraph {\n"
+      "\t5 [label=<TH1D<BR/>h1>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t4 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+      "\t3 [label=<Range>, style=\"filled\", fillcolor=\"#9574b4\", shape=\"diamond\"];\n"
+      "\t1 [label=<MyFilt>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+      "\t2 [label=<Define<BR/>x>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t0 [label=<Empty source<BR/>Entries: 10>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
+      "\t10 [label=<TH1D<BR/>v0_weighted_w>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t6 [label=<Define<BR/>w>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t7 [label=<Define<BR/>v2>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t8 [label=<Define<BR/>v1>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t9 [label=<Define<BR/>v0>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t11 [label=<TH2D<BR/>A>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t12 [label=<TH3D<BR/>C>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t4 -> 5;\n"
+      "\t3 -> 4;\n"
+      "\t1 -> 3;\n"
+      "\t2 -> 1;\n"
+      "\t0 -> 2;\n"
+      "\t6 -> 10;\n"
+      "\t7 -> 6;\n"
+      "\t8 -> 7;\n"
+      "\t9 -> 8;\n"
+      "\t0 -> 9;\n"
+      "\t6 -> 11;\n"
+      "\t6 -> 12;\n}");
+
+   EXPECT_EQ(expectedGraph, strOut);
+}
+
+struct Jet {
+   double a, b;
+};
+
+struct CustomFiller {
+
+   TH2D h{"", "", 10, 0, 10, 10, 0, 10};
+
+   void Fill(const Jet &j) { h.Fill(j.a, j.b); }
+
+   void Merge(const std::vector<CustomFiller *> &)
+   {
+      // unused, single-thread test
+   }
+};
+
+TEST(RDFHelpers, CustomObjects)
+{
+   auto df = ROOT::RDataFrame(10);
+   auto res = df.Define("Jet", [] { return Jet{1., 2.}; }).Fill<Jet>(CustomFiller{}, {"Jet"});
+
+   int x = 0;
+   auto d1 = df.Define("x", [&x]() { return x++; })
+                .Filter([](int n) { return n >= 2; }, {"x"}, "MyFilt")
+                .Range(3)
+                .Filter([](int n) { return n >= 2; }, {"x"}, "");
+   auto h0 = d1.Histo1D<int>({"h1", "h1", 10, 0, 10}, "x");
+
+   auto d2 = df.Define("v0", []() { return 1; }).Define("w", []() { return 2; });
+   auto h1 = d2.Histo1D<int, int>("v0", "w");
+
+   auto strOut = SaveGraph(df);
+
+   static const std::string expectedGraph(
+      "digraph {\n"
+      "\t2 [label=<Fill custom object>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t1 [label=<Define<BR/>Jet>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t0 [label=<Empty source<BR/>Entries: 10>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
+      "\t7 [label=<TH1D<BR/>h1>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t6 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+      "\t5 [label=<Range>, style=\"filled\", fillcolor=\"#9574b4\", shape=\"diamond\"];\n"
+      "\t3 [label=<MyFilt>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+      "\t4 [label=<Define<BR/>x>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t10 [label=<TH1D<BR/>v0_weighted_w>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n"
+      "\t8 [label=<Define<BR/>w>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t9 [label=<Define<BR/>v0>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+      "\t1 -> 2;\n"
+      "\t0 -> 1;\n"
+      "\t6 -> 7;\n"
+      "\t5 -> 6;\n"
+      "\t3 -> 5;\n"
+      "\t4 -> 3;\n"
+      "\t0 -> 4;\n"
+      "\t8 -> 10;\n"
+      "\t9 -> 8;\n"
+      "\t0 -> 9;\n}");
+
+   EXPECT_EQ(expectedGraph, strOut);
+}
+
 TEST(RDFHelpers, SaveGraphRootFromTree)
 {
    TFile f("savegraphrootfromtree.root", "recreate");
@@ -254,8 +360,8 @@ TEST(RDFHelpers, SaveGraphRootFromTree)
    f.Close();
 
    static const std::string expectedGraph(
-      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}");
+      "digraph {\n\t1 [label=<Count>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n\t0 [label=<t>, "
+      "style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n\t0 -> 1;\n}");
 
    ROOT::RDataFrame df("t", "savegraphrootfromtree.root");
    auto c = df.Count();
@@ -277,8 +383,8 @@ TEST(RDFHelpers, SaveGraphToFile)
    f.Close();
 
    static const std::string expectedGraph(
-      "digraph {\n\t1 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t0 [label=\"t\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}");
+      "digraph {\n\t1 [label=<Count>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n\t0 [label=<t>, "
+      "style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n\t0 -> 1;\n}");
 
    ROOT::RDataFrame df("t", "savegraphtofile.root");
    auto c = df.Count();
@@ -301,8 +407,8 @@ TEST(RDFHelpers, SaveGraphNoActions)
    auto df2 = df.Filter([] { return true; });
    const auto res = ROOT::RDF::SaveGraph(df);
    const std::string expected =
-      "digraph {\n\t1 [label=\"Filter\", style=\"filled\", fillcolor=\"#c4cfd4\", shape=\"diamond\"];\n\t0 "
-      "[label=\"1\", style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t0 -> 1;\n}";
+      "digraph {\n\t1 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n\t0 [label=<Empty "
+      "source<BR/>Entries: 1>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n\t0 -> 1;\n}";
    EXPECT_EQ(res, expected);
 }
 
@@ -315,12 +421,12 @@ TEST(RDFHelpers, SaveGraphSharedDefines)
    auto c2 = df2.Define("two", One).Count();
    std::string graph = ROOT::RDF::SaveGraph(df);
    const std::string expected =
-      "digraph {\n\t3 [label=\"Count\", style=\"filled\", fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t1 "
-      "[label=\"Define\none\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t2 "
-      "[label=\"Define\nshared\", style=\"filled\", fillcolor=\"#60aef3\", shape=\"oval\"];\n\t0 [label=\"1\", "
-      "style=\"filled\", fillcolor=\"#e8f8fc\", shape=\"oval\"];\n\t5 [label=\"Count\", style=\"filled\", "
-      "fillcolor=\"#9cbbe5\", shape=\"box\"];\n\t4 [label=\"Define\ntwo\", style=\"filled\", fillcolor=\"#60aef3\", "
-      "shape=\"oval\"];\n\t1 -> 3;\n\t2 -> 1;\n\t0 -> 2;\n\t4 -> 5;\n\t2 -> 4;\n}";
+      "digraph {\n\t3 [label=<Count>, style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n\t1 "
+      "[label=<Define<BR/>one>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n\t2 "
+      "[label=<Define<BR/>shared>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n\t0 [label=<Empty "
+      "source<BR/>Entries: 1>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n\t5 [label=<Count>, "
+      "style=\"filled\", fillcolor=\"#e47c7e\", shape=\"box\"];\n\t4 [label=<Define<BR/>two>, style=\"filled\", "
+      "fillcolor=\"#4285f4\", shape=\"ellipse\"];\n\t1 -> 3;\n\t2 -> 1;\n\t0 -> 2;\n\t4 -> 5;\n\t2 -> 4;\n}";
    EXPECT_EQ(graph, expected);
 }
 


### PR DESCRIPTION
# This Pull request:

* Histogram nodes now contain histogram name and number of entries (test included);
* Label nodes now use html, allowing for more custom fonts;
* Colors of different element types were changed to be easier to
  distinguish;
* Empty RLoopManager is more clearly indicated;
* Actions which has run are more clearly indicated;
* Tests adapted accordingly.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #9556

