### PR TITLE
[PyROOT] For MacOs12 with soversion, try to load libcppyy_backend wit…

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+++ b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
@@ -25,6 +25,14 @@ def _load_helper(bkname):
     except OSError:
          pass
 
+ # failed ... try absolute path
+ # needed on MacOS12 with soversion
+    try:
+        libpath = os.path.dirname(os.path.dirname(__file__))
+        return ctypes.CDLL(os.path.join(libpath, bkname), ctypes.RTLD_GLOBAL)
+    except OSError:
+        pass
+
  # failed ... load dependencies explicitly
     try:
         pkgpath = os.path.dirname(bkname)

--- a/bindings/pyroot/cppyy/patches/mac12soversion.patch
+++ b/bindings/pyroot/cppyy/patches/mac12soversion.patch
@@ -1,0 +1,32 @@
+From 646608f2daa3941d59d863bc9806da3f2f86b80e Mon Sep 17 00:00:00 2001
+From: Enric Tejedor Saavedra <enric.tejedor.saavedra@cern.ch>
+Date: Tue, 18 Jan 2022 15:10:22 +0100
+Subject: [PATCH] [PyROOT] For MacOs12 with soversion, try to load library with
+ absolute path
+
+---
+ .../cppyy-backend/cling/python/cppyy_backend/loader.py    | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+index 986f993ea1..4cce950c31 100644
+--- a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
++++ b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+@@ -25,6 +25,14 @@ def _load_helper(bkname):
+     except OSError:
+          pass
+ 
++ # failed ... try absolute path
++ # needed on MacOS12 with soversion
++    try:
++        libpath = os.path.dirname(os.path.dirname(__file__))
++        return ctypes.CDLL(os.path.join(libpath, bkname), ctypes.RTLD_GLOBAL)
++    except OSError:
++        pass
++
+  # failed ... load dependencies explicitly
+     try:
+         pkgpath = os.path.dirname(bkname)
+-- 
+2.17.1
+


### PR DESCRIPTION
…h absolute path

The reason for this fix is that, on MacOS12 with soversion enabled, loading e.g. libcppyy_backend3_8.so does not work even if LD_LIBRARY_PATH and PYTHONPATH are properly set.

An alternative that would also work would be to load the library with no path and its fully versioned name (e.g. libcppyy_backend3_8.6.27.so). The problem of that solution is that, at the moment of loading libcppyy_backend, cppyy is
not fully initialized and lookups can't be done yet, so we can't get the ROOT version via gROOT.GetVersion().

This fixes:
https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/3075/LABEL=mac12,SPEC=soversion,V=master/#showFailuresLink
