### PR TITLE
Make sure the temporary file is closed before renaming it. Fixes #9730

### DIFF
--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2941,12 +2941,14 @@ public:
          std::ifstream ifile(tmpName);
          if (!ifile)
             ROOT::TMetaUtils::Error(nullptr, "Cannot find %s!\n", tmpName);
+         // make sure the file is closed, mostly for Windows FS, also when
+         // accesing it from a Linux VM via a shared folder
+         if (ifile.is_open())
+            ifile.close();
 #ifdef WIN32
          // Sometimes files cannot be renamed on Windows if they don't have
          // been released by the system. So just copy them and try to delete
          // the old one afterwards.
-         if (ifile.is_open())
-            ifile.close();
          if (0 != std::rename(tmpName , name)) {
             if (llvm::sys::fs::copy_file(tmpName , name)) {
                llvm::sys::fs::remove(tmpName);

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2943,8 +2943,8 @@ public:
          std::ifstream ifile(tmpName);
          if (!ifile)
             ROOT::TMetaUtils::Error(nullptr, "Cannot find %s!\n", tmpName);
-         // make sure the file is closed, mostly for Windows FS, also when
-         // accesing it from a Linux VM via a shared folder
+         // Make sure the file is closed, mostly for Windows FS, also when
+         // accessing it from a Linux VM via a shared folder
          if (ifile.is_open())
             ifile.close();
 #ifdef WIN32

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2920,7 +2920,9 @@ public:
          std::ifstream ifile(tmpName);
          if (!ifile)
             ROOT::TMetaUtils::Error(nullptr, "Cannot find %s!\n", tmpName);
-
+         // make sure the file is closed
+         if (ifile.is_open())
+            ifile.close();
          if (0 != std::remove(tmpName)) {
             ROOT::TMetaUtils::Error(nullptr, "Removing %s!\n", tmpName);
             retval++;

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2920,7 +2920,8 @@ public:
          std::ifstream ifile(tmpName);
          if (!ifile)
             ROOT::TMetaUtils::Error(nullptr, "Cannot find %s!\n", tmpName);
-         // make sure the file is closed
+         // Make sure the file is closed, mostly for Windows FS, also when
+         // accessing it from a Linux VM via a shared folder
          if (ifile.is_open())
             ifile.close();
          if (0 != std::remove(tmpName)) {


### PR DESCRIPTION
As reported [on the forun](https://root-forum.cern.ch/t/rootcint-cannot-create-dictionary-in-a-vm/48580), make sure the temporary file is closed before renaming it. Should fix #9730
