### PR TITLE
[TRint] Properly update the prompt after incomplete input on a nested call to `TROOT::ProcessLine()`

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -153,6 +153,8 @@ public:
    virtual TClass  *GetClass(const std::type_info& typeinfo, Bool_t load) const = 0;
    virtual Int_t    GetExitCode() const = 0;
    virtual TEnv    *GetMapfile() const { return 0; }
+   ///\brief Returns whether the interpreter is waiting for more input, i.e.
+   /// the collected input is incomplete.
    virtual Int_t    GetMore() const = 0;
    virtual TClass  *GenerateTClass(const char *classname, Bool_t emulation, Bool_t silent = kFALSE) = 0;
    virtual TClass  *GenerateTClass(ClassInfo_t *classinfo, Bool_t silent = kFALSE) = 0;

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1370,7 +1370,7 @@ static void RegisterPreIncludedHeaders(cling::Interpreter &clingInterp)
 ///               e.g. `-DFOO=bar`. The last element of the array must be `nullptr`.
 
 TCling::TCling(const char *name, const char *title, const char* const argv[])
-: TInterpreter(name, title), fMore(0), fGlobalsListSerial(-1), fMapfile(nullptr),
+: TInterpreter(name, title), fGlobalsListSerial(-1), fMapfile(nullptr),
   fRootmapFiles(nullptr), fLockProcessLine(true), fNormalizedCtxt(0),
   fPrevLoadedDynLibInfo(0), fClingCallbacks(0), fAutoLoadCallBack(0),
   fTransactionCount(0), fHeaderParsingOnDemand(true), fIsAutoParsingSuspended(kFALSE)
@@ -4448,6 +4448,14 @@ void TCling::CreateListOfMethodArgs(TFunction* m) const
    m->fMethodArgs = arglist;
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Return whether we are waiting for more input either because the collected
+/// input contains unbalanced braces or last seen token was a `\` (backslash-newline)
+
+Int_t TCling::GetMore() const
+{
+   return fMetaProcessor->awaitingMoreInput();
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Generate a TClass for the given class.

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -106,7 +106,6 @@ private: // Static Data Members
 
 private: // Data Members
 
-   Int_t           fMore;             // The brace indent level for the cint command line processor.
    Int_t           fExitCode;         // Value passed to exit() in interpreter.
    char            fPrompt[64];       // Command line prompt string.
    //cling::DictPosition fDictPos;          // dictionary context after initialization is complete.
@@ -212,7 +211,7 @@ public: // Public Interface
    TClass *GetClass(const std::type_info& typeinfo, Bool_t load) const;
    Int_t   GetExitCode() const { return fExitCode; }
    TEnv*   GetMapfile() const { return fMapfile; }
-   Int_t   GetMore() const { return fMore; }
+   Int_t   GetMore() const;
    TClass *GenerateTClass(const char *classname, Bool_t emulation, Bool_t silent = kFALSE);
    TClass *GenerateTClass(ClassInfo_t *classinfo, Bool_t silent = kFALSE);
    Int_t   GenerateDictionary(const char* classes, const char* includes = "", const char* options = 0);

--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -786,7 +786,7 @@ Longptr_t  TRint::ProcessLineNr(const char* filestem, const char *line, Int_t *e
          input += TString::Format("#line 1 \"%s%d\"\n", filestem, fNcmd - 1);
       input += line;
       int res = ProcessLine(input, kFALSE, error);
-      if (*error == TInterpreter::kProcessing) {
+      if (gCling->GetMore()) {
          if (!fNonContinuePrompt.Length())
             fNonContinuePrompt = fDefaultPrompt;
          SetPrompt("root (cont'ed, cancel with .@) [%d]");

--- a/interpreter/cling/include/cling/MetaProcessor/InputValidator.h
+++ b/interpreter/cling/include/cling/MetaProcessor/InputValidator.h
@@ -26,6 +26,15 @@ namespace cling {
   /// are balanced.
   ///
   class InputValidator {
+  public:
+    ///\brief Brace balance validation could encounter.
+    ///
+    enum ValidationResult {
+      kIncomplete, ///< There is dangling brace.
+      kComplete,   ///< All braces are in balance.
+      kMismatch    ///< Closing brace doesn't match to opening. Eg: void f(};
+    };
+
   private:
     ///\brief The input being collected.
     ///
@@ -35,17 +44,13 @@ namespace cling {
     ///
     std::deque<int> m_ParenStack;
 
+    ///\brief Last validation result from `validate()`.
+    ///
+    ValidationResult m_LastResult = kComplete;
+
   public:
     InputValidator() {}
     ~InputValidator() {}
-
-    ///\brief Brace balance validation could encounter.
-    ///
-    enum ValidationResult {
-      kIncomplete, ///< There is dangling brace.
-      kComplete, ///< All braces are in balance.
-      kMismatch ///< Closing brace doesn't match to opening. Eg: void f(};
-    };
 
     ///\brief Checks whether the input contains balanced number of braces
     ///
@@ -54,10 +59,15 @@ namespace cling {
     ///
     ValidationResult validate(llvm::StringRef line);
 
+    ///\brief Get the last validation result returned by a `validate()` call,
+    /// which indicates the current state of the collected input.
+    ///
+    ValidationResult getLastResult() const { return m_LastResult; }
+
     ///\brief Retrieves the number of spaces that the next input line should be
     /// indented.
     ///
-    int getExpectedIndent() { return m_ParenStack.size(); }
+    int getExpectedIndent() const { return m_ParenStack.size(); }
 
     ///\brief Resets the collected input and its corresponding brace stack.
     ///

--- a/interpreter/cling/include/cling/MetaProcessor/MetaProcessor.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaProcessor.h
@@ -123,6 +123,11 @@ namespace cling {
     /// input, resetting the continuation to a new line.
     void cancelContinuation() const;
 
+    ///\brief Returns whether we are waiting for more input, either because the
+    /// input contains imbalanced braces or a backslash-newline was seen (i.e.,
+    /// the last token was a `\`).
+    bool awaitingMoreInput() const;
+
     ///\brief Returns the number of imbalanced tokens seen in the current input.
     ///
     int getExpectedIndent() const;

--- a/interpreter/cling/lib/MetaProcessor/InputValidator.cpp
+++ b/interpreter/cling/lib/MetaProcessor/InputValidator.cpp
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 #include "cling/MetaProcessor/InputValidator.h"
-
 #include "cling/MetaProcessor/MetaLexer.h"
 
 #include <algorithm>
@@ -106,6 +105,7 @@ namespace cling {
       m_Input.append("\n");
     }
     m_Input.append(line);
+    m_LastResult = Res;
     return Res;
   }
 
@@ -117,5 +117,6 @@ namespace cling {
       std::string().swap(m_Input);
 
     std::deque<int>().swap(m_ParenStack);
+    m_LastResult = kComplete;
   }
 } // end namespace cling

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -348,6 +348,11 @@ namespace cling {
     m_InputValidator->reset();
   }
 
+  bool MetaProcessor::awaitingMoreInput() const {
+    return m_InputValidator->getLastResult() ==
+           InputValidator::ValidationResult::kIncomplete;
+  }
+
   int MetaProcessor::getExpectedIndent() const {
     return m_InputValidator->getExpectedIndent();
   }


### PR DESCRIPTION
This pull-request fixes an issue ([ROOT-5219](https://sft.its.cern.ch/jira/browse/ROOT-5219)) updating the TRint prompt after incomplete input on a nested call to `TROOT::ProcessLine()`.

Specifically, `TRint::ProcessLineNr()` used the output parameter `error` to tell if the collected input was incomplete (i.e., it contains unbalanced braces or the last line was terminated by a `\` character).

While this works most of the time, it fails if there is a nested call to `ProcessLine()` that provides incomplete input, e.g.:
```c++
$ root -l -b
root [0] gROOT->ProcessLine("fprintf(stdout,\"the inner is printing\"\n")
(long) 0
root [1] 12
root (cont'ed, cancel with .@) [2].@
root [3] .q
```

In this case, there are two nested `ProcessLine()` calls; the inner-most has incomplete input (missing a `)`), but the `error` output parameter is ignored.  The outer-most call, however, has complete input, which is what was seen by TRint.

This created inconsistency between the collected input in cling's InputValidator (which was incomplete) and the ROOT prompt string, that was not showing `root (cont'ed, cancel with .@) []`.  Thus, the correct behavior would have been:
```c++
root [0] gROOT->ProcessLine("fprintf(stdout,\"the inner is printing\"\n");
root (cont'ed, cancel with .@) [0]);
the inner is printing
```

## Changes or fixes:
- Add `InputValidator::getLastResult()` and `MetaProcessor::waitingMoreInput()` which allow to query whether the collected input is incomplete, either because it contains unbalanced braces or we found a backslash-newline (the last seen token is a `\`).
- Properly implement the `TInterpreter::GetMore()` function based on `MetaProcessor::waitingMoreInput()`.  Get rid of the `fMore` member (which was not even updated correctly).
- Use `gCling->GetMore()` in `TRint::ProcessLineNr()` to tell if we are waiting for more input, and thus we should show the continuation prompt.

## Checklist:
- [X] tested changes locally

This PR fixes [ROOT-5219](https://sft.its.cern.ch/jira/browse/ROOT-5219).