### PR TITLE
[Math] Disable a warning when compiling unuran code on Fedora

### DIFF
--- a/math/unuran/CMakeLists.txt
+++ b/math/unuran/CMakeLists.txt
@@ -64,6 +64,8 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
 endif()
 if(${CMAKE_CXX_COMPILER_ID} MATCHES GNU)
   ROOT_ADD_C_FLAG(CMAKE_C_FLAGS -Wno-maybe-uninitialized)
+  ROOT_ADD_C_FLAG(CMAKE_C_FLAGS -Wno-alloc-size-larger-than)
+
 endif()
 
 set(unrsources ${UNR_UNTARDIR}/src/utils/*.c


### PR DESCRIPTION
The warning was observed on fedora32 with gcc 10.3.1
Warning:
```
root/src/methods/mvtdr_init.ch:886:17: warning: argument 1 value ‘18446744073709551608’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
  886 |   GEN->etable = malloc( size * sizeof(E_TABLE*) );
```

It can  be fixed by casting to an int the input to malloc or checking if it is not larger than 2^63-1

Since it is not critical, it is enough to disable it by passing the corresponding compiler flag
: `-Wno-alloc-size-larger-than`



