### PR TITLE
Simplify PgSQL plugin

### DIFF
--- a/sql/pgsql/CMakeLists.txt
+++ b/sql/pgsql/CMakeLists.txt
@@ -15,10 +15,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(PgSQL
     TPgSQLServer.h
     TPgSQLStatement.h
   SOURCES
-    src/TPgSQLResult.cxx
-    src/TPgSQLRow.cxx
-    src/TPgSQLServer.cxx
-    src/TPgSQLStatement.cxx
+    TPgSQLResult.cxx
+    TPgSQLRow.cxx
+    TPgSQLServer.cxx
+    TPgSQLStatement.cxx
   DEPENDENCIES
     Core
     Net
@@ -26,5 +26,5 @@ ROOT_STANDARD_LIBRARY_PACKAGE(PgSQL
     MathCore
 )
 
-target_include_directories(PgSQL PUBLIC ${PostgreSQL_INCLUDE_DIRS})
-target_link_libraries(PgSQL PUBLIC ${PostgreSQL_LIBRARIES})
+target_include_directories(PgSQL PRIVATE ${PostgreSQL_INCLUDE_DIRS})
+target_link_libraries(PgSQL PRIVATE ${PostgreSQL_LIBRARIES})

--- a/sql/pgsql/inc/TPgSQLResult.h
+++ b/sql/pgsql/inc/TPgSQLResult.h
@@ -26,7 +26,7 @@ private:
    Bool_t  IsValid(Int_t field);
 
 public:
-   TPgSQLResult(void *result);
+   TPgSQLResult(PGresult *result);
    ~TPgSQLResult();
 
    void        Close(Option_t *opt="") final;

--- a/sql/pgsql/inc/TPgSQLResult.h
+++ b/sql/pgsql/inc/TPgSQLResult.h
@@ -14,7 +14,8 @@
 
 #include "TSQLResult.h"
 
-#include <libpq-fe.h>
+struct pg_result;
+typedef struct pg_result PGresult;
 
 class TPgSQLResult : public TSQLResult {
 

--- a/sql/pgsql/inc/TPgSQLRow.h
+++ b/sql/pgsql/inc/TPgSQLRow.h
@@ -26,7 +26,7 @@ private:
    Bool_t  IsValid(Int_t field);
 
 public:
-   TPgSQLRow(void *result, ULong_t rowHandle);
+   TPgSQLRow(PGresult *result, ULong_t rowHandle);
    ~TPgSQLRow();
 
    void        Close(Option_t *opt="") final;

--- a/sql/pgsql/inc/TPgSQLRow.h
+++ b/sql/pgsql/inc/TPgSQLRow.h
@@ -14,7 +14,8 @@
 
 #include "TSQLRow.h"
 
-#include <libpq-fe.h>
+struct pg_result;
+typedef struct pg_result PGresult;
 
 class TPgSQLRow : public TSQLRow {
 

--- a/sql/pgsql/inc/TPgSQLServer.h
+++ b/sql/pgsql/inc/TPgSQLServer.h
@@ -17,7 +17,8 @@
 #include <map>
 #include <string>
 
-#include <libpq-fe.h>
+struct pg_conn;
+typedef struct pg_conn PGconn;
 
 class TPgSQLServer : public TSQLServer {
 

--- a/sql/pgsql/inc/TPgSQLStatement.h
+++ b/sql/pgsql/inc/TPgSQLStatement.h
@@ -14,7 +14,12 @@
 
 #include "TSQLStatement.h"
 
-#include <libpq-fe.h>
+struct pg_conn;
+typedef struct pg_conn PGconn;
+
+struct pg_result;
+typedef struct pg_result PGresult;
+
 
 struct PgSQL_Stmt_t {
    PGconn   *fConn;
@@ -24,7 +29,6 @@ struct PgSQL_Stmt_t {
 class TPgSQLStatement : public TSQLStatement {
 
 private:
-
 
    PgSQL_Stmt_t         *fStmt{nullptr};          //! executed statement
    Int_t                 fNumBuffers{0};          //! number of statement parameters

--- a/sql/pgsql/src/TPgSQLResult.cxx
+++ b/sql/pgsql/src/TPgSQLResult.cxx
@@ -12,6 +12,7 @@
 #include "TPgSQLResult.h"
 #include "TPgSQLRow.h"
 
+#include <libpq-fe.h>
 
 ClassImp(TPgSQLResult);
 

--- a/sql/pgsql/src/TPgSQLResult.cxx
+++ b/sql/pgsql/src/TPgSQLResult.cxx
@@ -19,7 +19,7 @@ ClassImp(TPgSQLResult);
 ////////////////////////////////////////////////////////////////////////////////
 /// PgSQL query result.
 
-TPgSQLResult::TPgSQLResult(void *result)
+TPgSQLResult::TPgSQLResult(PGresult *result)
 {
    fResult     = (PGresult *) result;
    fRowCount   = fResult ? PQntuples(fResult) : 0;
@@ -44,7 +44,7 @@ void TPgSQLResult::Close(Option_t *)
       return;
 
    PQclear(fResult);
-   fResult     = 0;
+   fResult     = nullptr;
    fRowCount   = 0;
    fCurrentRow = 0;
 }
@@ -84,7 +84,7 @@ const char *TPgSQLResult::GetFieldName(Int_t field)
 {
    if (!fResult) {
       Error("GetFieldName", "result set closed");
-      return 0;
+      return nullptr;
    }
    return PQfname(fResult, field);
 }
@@ -95,15 +95,13 @@ const char *TPgSQLResult::GetFieldName(Int_t field)
 
 TSQLRow *TPgSQLResult::Next()
 {
-   Int_t row;
-
    if (!fResult) {
       Error("Next", "result set closed");
-      return 0;
+      return nullptr;
    }
-   row = fCurrentRow++;
-   if (row >= fRowCount)
-      return 0;
-   else
-      return new TPgSQLRow((void *) fResult, (ULong_t) row);
+   ULong_t row = fCurrentRow++;
+   if ((Int_t) row >= fRowCount)
+      return nullptr;
+
+   return new TPgSQLRow(fResult, row);
 }

--- a/sql/pgsql/src/TPgSQLRow.cxx
+++ b/sql/pgsql/src/TPgSQLRow.cxx
@@ -19,10 +19,10 @@ ClassImp(TPgSQLRow);
 ////////////////////////////////////////////////////////////////////////////////
 /// Single row of query result.
 
-TPgSQLRow::TPgSQLRow(void *res, ULong_t rowHandle)
+TPgSQLRow::TPgSQLRow(PGresult *res, ULong_t rowHandle)
 {
-   fResult = (PGresult *) res;
-   fRowNum = (ULong_t) rowHandle;
+   fResult = res;
+   fRowNum = rowHandle;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -42,7 +42,7 @@ void TPgSQLRow::Close(Option_t *)
    if (!fRowNum)
       return;
 
-   fResult = 0;
+   fResult = nullptr;
    fRowNum = 0;
 }
 
@@ -82,7 +82,7 @@ ULong_t TPgSQLRow::GetFieldLength(Int_t field)
 const char *TPgSQLRow::GetField(Int_t field)
 {
    if (!IsValid(field))
-      return 0;
+      return nullptr;
 
    return PQgetvalue(fResult, fRowNum, field);
 }

--- a/sql/pgsql/src/TPgSQLRow.cxx
+++ b/sql/pgsql/src/TPgSQLRow.cxx
@@ -11,6 +11,8 @@
 
 #include "TPgSQLRow.h"
 
+#include <libpq-fe.h>
+
 
 ClassImp(TPgSQLRow);
 

--- a/sql/pgsql/src/TPgSQLServer.cxx
+++ b/sql/pgsql/src/TPgSQLServer.cxx
@@ -25,6 +25,7 @@
                         || ((x) == PGRES_COMMAND_OK) \
                         || ((x) == PGRES_TUPLES_OK))
 
+#include <libpq-fe.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// PluginManager generator function

--- a/sql/pgsql/src/TPgSQLServer.cxx
+++ b/sql/pgsql/src/TPgSQLServer.cxx
@@ -45,8 +45,8 @@ ClassImp(TPgSQLServer);
 
 TPgSQLServer::TPgSQLServer(const char *db, const char *uid, const char *pw)
 {
-   fPgSQL = 0;
-   fSrvInfo="";
+   fPgSQL = nullptr;
+   fSrvInfo = "";
 
    TUrl url(db);
 

--- a/sql/pgsql/src/TPgSQLStatement.cxx
+++ b/sql/pgsql/src/TPgSQLStatement.cxx
@@ -111,7 +111,7 @@ void TPgSQLStatement::Close(Option_t *)
 #define CheckStmt(method, res)                          \
    {                                                    \
       ClearError();                                     \
-      if (fStmt==0) {                                   \
+      if (!fStmt) {                                     \
          SetError(-1,"Statement handle is 0",method);   \
          return res;                                    \
       }                                                 \
@@ -261,13 +261,13 @@ const char* TPgSQLStatement::GetFieldName(Int_t nfield)
 
 Bool_t TPgSQLStatement::NextResultRow()
 {
-   if ((fStmt==0) || !IsResultSetMode()) return kFALSE;
+   if (!fStmt || !IsResultSetMode()) return kFALSE;
 
-   Bool_t res=kTRUE;
+   Bool_t res = kTRUE;
 
    fIterationCount++;
    if (fIterationCount>=fNumResultRows)
-     res=kFALSE;
+     res = kFALSE;
    return res;
 }
 

--- a/sql/pgsql/src/TPgSQLStatement.cxx
+++ b/sql/pgsql/src/TPgSQLStatement.cxx
@@ -33,6 +33,7 @@
                         || ((x) == PGRES_COMMAND_OK) \
                         || ((x) == PGRES_TUPLES_OK))
 
+#include <libpq-fe.h>
 
 ClassImp(TPgSQLStatement);
 


### PR DESCRIPTION
Replace real PgSQL includes in header files by forward declarations

No need to present them to cling.
Make PgSQL include private in cmake
More use of `nullptr` for pointers