### PR TITLE
[RF] New RooStringView class for passing std::strings to functions

### DIFF
--- a/roofit/histfactory/src/Asimov.cxx
+++ b/roofit/histfactory/src/Asimov.cxx
@@ -58,7 +58,7 @@ void RooStats::HistFactory::Asimov::ConfigureWorkspace(RooWorkspace* wspace) {
     double val  = itr->second;
 
     // Try to get the variable in the workspace
-    RooRealVar* var = wspace->var(param.c_str());
+    RooRealVar* var = wspace->var(param);
     if( !var ) {
       std::cout << "Error: Trying to set variable: " << var
 		<< " to a specific value in creation of asimov dataset: " << fName
@@ -96,7 +96,7 @@ void RooStats::HistFactory::Asimov::ConfigureWorkspace(RooWorkspace* wspace) {
     bool isConstant  = itr->second;
 
     // Try to get the variable in the workspace
-    RooRealVar* var = wspace->var(param.c_str());
+    RooRealVar* var = wspace->var(param);
     if( !var ) {
       std::cout << "Error: Trying to set variable: " << var
 		<< " constant in creation of asimov dataset: " << fName

--- a/roofit/histfactory/src/HistFactoryNavigation.cxx
+++ b/roofit/histfactory/src/HistFactoryNavigation.cxx
@@ -96,7 +96,7 @@ namespace RooStats {
       }
 
       // Get the ModelConfig
-      ModelConfig* mc = (ModelConfig*) wspace->obj(ModelConfigName.c_str());
+      ModelConfig* mc = (ModelConfig*) wspace->obj(ModelConfigName);
       if( !mc ) {
 	std::cout << "Error: Failed to find ModelConfig: " << ModelConfigName
 		  << " from workspace: " << WorkspaceName

--- a/roofit/histfactory/src/HistoToWorkspaceFactory.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactory.cxx
@@ -159,7 +159,7 @@ namespace HistFactory{
     for(Int_t i=lowBin; i<highBin; ++i){
       std::stringstream str;
       str<<"_"<<i;
-      RooRealVar* temp = proto->var((prefix+str.str()).c_str());
+      RooRealVar* temp = proto->var(prefix+str.str());
       mean(i) = temp->getVal();
     }
 
@@ -198,7 +198,7 @@ namespace HistFactory{
       std::stringstream str;
       str<<"_"<<j;
 
-      RooRealVar* temp = (RooRealVar*) proto->var(("alpha_"+sourceName.at(j)).c_str());
+      RooRealVar* temp = (RooRealVar*) proto->var("alpha_"+sourceName.at(j));
       if(!temp){
         temp = (RooRealVar*) proto->factory(("alpha_"+sourceName.at(j)+range).c_str());
 
@@ -206,8 +206,8 @@ namespace HistFactory{
         string command=("Gaussian::alpha_"+sourceName.at(j)+"Constraint(alpha_"+sourceName.at(j)+",nom_"+sourceName.at(j)+"[0.,-10,10],1.)");
         cout << command << endl;
         likelihoodTermNames.push_back(  proto->factory( command.c_str() )->GetName() );
-	proto->var(("nom_"+sourceName.at(j)).c_str())->setConstant();
-	const_cast<RooArgSet*>(proto->set("globalObservables"))->add(*proto->var(("nom_"+sourceName.at(j)).c_str()));
+	proto->var("nom_"+sourceName.at(j))->setConstant();
+	const_cast<RooArgSet*>(proto->set("globalObservables"))->add(*proto->var("nom_"+sourceName.at(j)));
 
       } 
 
@@ -391,9 +391,9 @@ namespace HistFactory{
      for(Int_t i=lowBin; i<highBin; ++i){
        std::stringstream str;
        str<<"_"<<i;
-       RooRealVar* obs = (RooRealVar*) proto->var((obsPrefix+str.str()).c_str());
+       RooRealVar* obs = (RooRealVar*) proto->var(obsPrefix+str.str());
        cout << "expected number of events called: " << expPrefix << endl;
-       RooAbsReal* exp = proto->function((expPrefix+str.str()).c_str());
+       RooAbsReal* exp = proto->function(expPrefix+str.str());
        if(obs && exp){
          
          //proto->Print();
@@ -490,12 +490,12 @@ namespace HistFactory{
       proto->factory(Form("PolyVar::alphaOfBeta_%s(beta_%s,{%f,%f})",it->first.c_str(),it->first.c_str(),-1./scale,1./scale));
 	
       // set beta const status to be same as alpha
-      if(proto->var(Form("alpha_%s",it->first.c_str()))->isConstant())
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(true);
+      if(proto->var("alpha_" + it->first)->isConstant())
+	proto->var("beta_" + it->first)->setConstant(true);
       else
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(false);
+	proto->var("beta_" + it->first)->setConstant(false);
       // set alpha const status to true
-      //      proto->var(Form("alpha_%s",it->first.c_str()))->setConstant(true);
+      //      proto->var("alpha_" + it->first)->setConstant(true);
 
       // replace alphas with alphaOfBeta and replace constraints
       //cout <<         "alpha_"+it->first+"Constraint=beta_" + it->first+ "Constraint" << endl;
@@ -505,8 +505,8 @@ namespace HistFactory{
       editList+=precede + "alpha_"+it->first+"=alphaOfBeta_"+ it->first;
 
       /*
-      if( proto->pdf(("alpha_"+it->first+"Constraint").c_str()) && proto->var(("alpha_"+it->first).c_str()) )
-      cout << " checked they are there" << proto->pdf(("alpha_"+it->first+"Constraint").c_str()) << " " << proto->var(("alpha_"+it->first).c_str()) << endl;
+      if( proto->pdf("alpha_"+it->first+"Constraint") && proto->var("alpha_"+it->first) )
+      cout << " checked they are there" << proto->pdf("alpha_"+it->first+"Constraint") << " " << proto->var("alpha_"+it->first) << endl;
       else
 	cout << "NOT THERE" << endl;
       */
@@ -519,7 +519,7 @@ namespace HistFactory{
 	precede="";
 	cout << "Going to issue this edit command\n" << edit<< endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne)
 	  cout << "\n\n ---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	
@@ -529,7 +529,7 @@ namespace HistFactory{
     // add uniform terms and their constraints
     for(it=uniformSyst.begin(); it!=uniformSyst.end(); ++it) {
       cout << "edit for " << it->first << "with rel uncert = " << it->second << endl;
-      if(! proto->var(("alpha_"+it->first).c_str())){
+      if(! proto->var("alpha_"+it->first)){
 	cout << "systematic not there" << endl;
 	nskipped++; 
 	continue;
@@ -542,12 +542,12 @@ namespace HistFactory{
       proto->factory(Form("PolyVar::alphaOfBeta_%s(beta_%s,{-1,1})",it->first.c_str(),it->first.c_str()));
       
       // set beta const status to be same as alpha
-      if(proto->var(Form("alpha_%s",it->first.c_str()))->isConstant())
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(true);
+      if(proto->var("alpha_" + it->first)->isConstant())
+	proto->var("beta_" + it->first)->setConstant(true);
       else
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(false);
+	proto->var("beta_" + it->first)->setConstant(false);
       // set alpha const status to true
-      //      proto->var(Form("alpha_%s",it->first.c_str()))->setConstant(true);
+      //      proto->var("alpha_" + it->first)->setConstant(true);
 
       // replace alphas with alphaOfBeta and replace constraints
       cout <<         "alpha_"+it->first+"Constraint=beta_" + it->first+ "Constraint" << endl;
@@ -556,8 +556,8 @@ namespace HistFactory{
       cout <<         "alpha_"+it->first+"=alphaOfBeta_"+ it->first << endl;
       editList+=precede + "alpha_"+it->first+"=alphaOfBeta_"+ it->first;
 
-      if( proto->pdf(("alpha_"+it->first+"Constraint").c_str()) && proto->var(("alpha_"+it->first).c_str()) )
-	cout << " checked they are there" << proto->pdf(("alpha_"+it->first+"Constraint").c_str()) << " " << proto->var(("alpha_"+it->first).c_str()) << endl;
+      if( proto->pdf("alpha_"+it->first+"Constraint") && proto->var("alpha_"+it->first) )
+	cout << " checked they are there" << proto->pdf("alpha_"+it->first+"Constraint") << " " << proto->var("alpha_"+it->first) << endl;
       else
 	cout << "NOT THERE" << endl;
 
@@ -569,7 +569,7 @@ namespace HistFactory{
 	precede="";
 	cout << edit<< endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne)
 	  cout << "\n\n ---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	
@@ -583,7 +583,7 @@ namespace HistFactory{
     // add lognormal terms and their constraints
     for(it=logNormSyst.begin(); it!=logNormSyst.end(); ++it) {
       cout << "edit for " << it->first << "with rel uncert = " << it->second << endl;
-      if(! proto->var(("alpha_"+it->first).c_str())){
+      if(! proto->var("alpha_"+it->first)){
 	cout << "systematic not there" << endl;
 	nskipped++; 
 	continue;
@@ -609,12 +609,12 @@ namespace HistFactory{
       //      proto->factory(Form("PolyVar::alphaOfBeta_%s(beta_%s,{%f,%f})",it->first.c_str(),it->first.c_str(),-1.,1./scale));
       
       // set beta const status to be same as alpha
-      if(proto->var(Form("alpha_%s",it->first.c_str()))->isConstant())
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(true);
+      if(proto->var("alpha_" + it->first)->isConstant())
+	proto->var("beta_" + it->first)->setConstant(true);
       else
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(false);
+	proto->var("beta_" + it->first)->setConstant(false);
       // set alpha const status to true
-      //      proto->var(Form("alpha_%s",it->first.c_str()))->setConstant(true);
+      //      proto->var("alpha_" + it->first)->setConstant(true);
 
       // replace alphas with alphaOfBeta and replace constraints
       cout <<         "alpha_"+it->first+"Constraint=beta_" + it->first+ "Constraint" << endl;
@@ -623,8 +623,8 @@ namespace HistFactory{
       cout <<         "alpha_"+it->first+"=alphaOfBeta_"+ it->first << endl;
       editList+=precede + "alpha_"+it->first+"=alphaOfBeta_"+ it->first;
 
-      if( proto->pdf(("alpha_"+it->first+"Constraint").c_str()) && proto->var(("alpha_"+it->first).c_str()) )
-	cout << " checked they are there" << proto->pdf(("alpha_"+it->first+"Constraint").c_str()) << " " << proto->var(("alpha_"+it->first).c_str()) << endl;
+      if( proto->pdf("alpha_"+it->first+"Constraint") && proto->var("alpha_"+it->first) )
+	cout << " checked they are there" << proto->pdf("alpha_"+it->first+"Constraint") << " " << proto->var("alpha_"+it->first) << endl;
       else
 	cout << "NOT THERE" << endl;
 
@@ -636,7 +636,7 @@ namespace HistFactory{
 	precede="";
 	cout << edit<< endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne)
 	  cout << "\n\n ---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	
@@ -817,7 +817,7 @@ namespace HistFactory{
     //////////////////////////////////////
     // fix specified parameters
     for(unsigned int i=0; i<systToFix.size(); ++i){
-      RooRealVar* temp = proto->var((systToFix.at(i)).c_str());
+      RooRealVar* temp = proto->var(systToFix.at(i));
       if(temp) temp->setConstant();
       else cout << "could not find variable " << systToFix.at(i) << " could not set it to constant" << endl;
     }
@@ -887,7 +887,7 @@ namespace HistFactory{
       else ss << ',' << channel_name ;
       RooWorkspace * ch=chs[i];
       
-      RooAbsPdf* model = ch->pdf(("model_"+channel_name).c_str());
+      RooAbsPdf* model = ch->pdf("model_"+channel_name);
       models.push_back(model);
       globalObs.add(*ch->set("globalObservables"));
 
@@ -934,7 +934,7 @@ namespace HistFactory{
 
     for(unsigned int i=0; i<fSystToFix.size(); ++i){
       // make sure they are fixed
-      RooRealVar* temp = combined->var((fSystToFix.at(i)).c_str());
+      RooRealVar* temp = combined->var(fSystToFix.at(i));
       if(temp) {
         temp->setConstant();
         cout <<"setting " << fSystToFix.at(i) << " constant" << endl;
@@ -961,7 +961,7 @@ namespace HistFactory{
   {
 
     ModelConfig * combined_config = (ModelConfig *) combined->obj("ModelConfig");
-    RooDataSet * simData = (RooDataSet *) combined->obj(data_name.c_str());
+    RooDataSet * simData = (RooDataSet *) combined->obj(data_name);
     //    const RooArgSet * constrainedParams=combined_config->GetNuisanceParameters();
     const RooArgSet * POIs=combined_config->GetParametersOfInterest();
 
@@ -979,7 +979,7 @@ namespace HistFactory{
           combined->defineSet("constrainedParams", *constrainedParams);
     */
 
-    //RooAbsPdf* model=combined->pdf(model_name.c_str()); 
+    //RooAbsPdf* model=combined->pdf(model_name); 
     RooAbsPdf* model=combined_config->GetPdf();
     //    RooArgSet* allParams = model->getParameters(*simData);
 

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -143,7 +143,7 @@ namespace HistFactory{
     RooArgSet params;
     for( unsigned int i = 0; i < poi_list.size(); ++i ) {
       std::string poi_name = poi_list.at(i);
-      RooRealVar* poi = (RooRealVar*) ws_single->var( poi_name.c_str() );
+      RooRealVar* poi = (RooRealVar*) ws_single->var(poi_name);
       if(poi){
         params.add(*poi);
       }
@@ -192,8 +192,8 @@ namespace HistFactory{
     // Notice that we get the "new" pdf, this is the one that is
     // used in the creation of these asimov datasets since they
     // are fitted (or may be, at least).
-    RooAbsPdf* pdf = ws_single->pdf(NewModelName.c_str());
-    if( !pdf ) pdf = ws_single->pdf( ModelName.c_str() );
+    RooAbsPdf* pdf = ws_single->pdf(NewModelName);
+    if( !pdf ) pdf = ws_single->pdf( ModelName );
     const RooArgSet* observables = ws_single->set("observables");
 
     // Create a SnapShot of the nominal values 
@@ -325,7 +325,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
   RooArgList observables;
 
   for (unsigned int idx=0; idx < fObsNameVec.size(); ++idx) {
-    if (!proto->var(fObsNameVec[idx].c_str())) {
+    if (!proto->var(fObsNameVec[idx])) {
       const TAxis *axis = (idx == 0) ? hist->GetXaxis() : (idx == 1 ? hist->GetYaxis() : hist->GetZaxis());
       Int_t nbins = axis->GetNbins();
       Double_t xmin = axis->GetXmin();
@@ -340,7 +340,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       }
     }
 
-    observables.add(*proto->var(fObsNameVec[idx].c_str()));
+    observables.add(*proto->var(fObsNameVec[idx]));
   }
 
   return observables;
@@ -385,7 +385,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     for(Int_t i=lowBin; i<highBin; ++i){
       std::stringstream str;
       str<<"_"<<i;
-      RooRealVar* temp = proto->var((prefix+str.str()).c_str());
+      RooRealVar* temp = proto->var(prefix+str.str());
       mean(i) = temp->getVal();
     }
 
@@ -430,7 +430,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       const HistoSys& histoSys = histoSysList.at(j);
       string histoSysName = histoSys.GetName();
 
-      RooRealVar* temp = (RooRealVar*) proto->var(("alpha_" + histoSysName).c_str());
+      RooRealVar* temp = (RooRealVar*) proto->var("alpha_" + histoSysName);
       if(!temp){
 
         temp = (RooRealVar*) proto->factory(("alpha_" + histoSysName + range).c_str());
@@ -439,8 +439,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         string command=("Gaussian::alpha_"+histoSysName+"Constraint(alpha_"+histoSysName+",nom_alpha_"+histoSysName+"[0.,-10,10],1.)");
         cxcoutI(HistFactory) << command << endl;
         constraintTermNames.push_back(  proto->factory( command.c_str() )->GetName() );
-        proto->var(("nom_alpha_"+histoSysName).c_str())->setConstant();
-        const_cast<RooArgSet*>(proto->set("globalObservables"))->add(*proto->var(("nom_alpha_"+histoSysName).c_str()));
+        proto->var("nom_alpha_"+histoSysName)->setConstant();
+        const_cast<RooArgSet*>(proto->set("globalObservables"))->add(*proto->var("nom_alpha_"+histoSysName));
       } 
       params.add(* temp );
     }
@@ -514,14 +514,14 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         std::stringstream range;
         range << "[" << norm.GetVal() << "," << norm.GetLow() << "," << norm.GetHigh() << "]";
 
-        if( proto->obj(varname.c_str()) == NULL) {
+        if( proto->obj(varname) == NULL) {
           cxcoutI(HistFactory) << "making normFactor: " << norm.GetName() << endl;
           // remove "doRatio" and name can be changed when ws gets imported to the combined model.
           proto->factory((varname + range.str()).c_str());
         }
 
         if(norm.GetConst()) {
-          //	  proto->var(varname.c_str())->setConstant();
+          //	  proto->var(varname)->setConstant();
           //	  cout <<"setting " << varname << " constant"<<endl;
           cxcoutW(HistFactory) << "Const attribute to <NormFactor> tag is deprecated, will ignore." <<
               " Instead, add \n\t<ParamSetting Const=\"True\"> " << varname << " </ParamSetting>\n" <<
@@ -631,7 +631,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
          }
          
          // add Gaussian constraint terms (normal + log-normal case) 
-         RooRealVar* alpha = (RooRealVar*) proto->var((prefix + sys.GetName()).c_str());
+         RooRealVar* alpha = (RooRealVar*) proto->var(prefix + sys.GetName());
          if(!alpha) {
             
             alpha = (RooRealVar*) proto->factory((prefix + sys.GetName() + range).c_str());
@@ -639,7 +639,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
             RooAbsArg * gausConstraint =  proto->factory(TString::Format("Gaussian::%sConstraint(%s,%s,%f)",alpha->GetName(),alpha->GetName(), nomAlpha->GetName(), gaussSigma) );             
              //cout << command << endl;
             constraintTermNames.push_back( gausConstraint->GetName() );
-            proto->var(("nom_" + prefix + sys.GetName()).c_str())->setConstant();
+            proto->var("nom_" + prefix + sys.GetName())->setConstant();
             const_cast<RooArgSet*>(proto->set("globalObservables"))->add(*nomAlpha);	
          } 
          
@@ -807,7 +807,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
      for(Int_t i=lowBin; i<highBin; ++i){
        std::stringstream str;
        str<<"_"<<i;
-       RooRealVar* obs = (RooRealVar*) proto->var((obsPrefix+str.str()).c_str());
+       RooRealVar* obs = (RooRealVar*) proto->var(obsPrefix+str.str());
        cout << "expected number of events called: " << expPrefix << endl;
        RooAbsReal* exp = proto->function((expPrefix+str.str()).c_str());
        if(obs && exp){
@@ -865,7 +865,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     // add gamma terms and their constraints
     for(it=gammaSyst.begin(); it!=gammaSyst.end(); ++it) {
       //cout << "edit for " << it->first << "with rel uncert = " << it->second << endl;
-      if(! proto->var(("alpha_"+it->first).c_str())){
+      if(! proto->var("alpha_"+it->first)){
 	//cout << "systematic not there" << endl;
 	nskipped++; 
 	continue;
@@ -903,14 +903,14 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       proto->factory(Form("PolyVar::alphaOfBeta_%s(beta_%s,{%f,%f})",it->first.c_str(),it->first.c_str(),-1./scale,1./scale));
 	
       // set beta const status to be same as alpha
-      if(proto->var(Form("alpha_%s",it->first.c_str()))->isConstant()) {
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(true);
+      if(proto->var("alpha_" + it->first)->isConstant()) {
+	proto->var("beta_" + it->first)->setConstant(true);
       }
       else {
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(false);
+	proto->var("beta_" + it->first)->setConstant(false);
       }
       // set alpha const status to true
-      //      proto->var(Form("alpha_%s",it->first.c_str()))->setConstant(true);
+      //      proto->var("alpha_" + it->first)->setConstant(true);
 
       // replace alphas with alphaOfBeta and replace constraints
       editList+=precede + "alpha_"+it->first+"Constraint=beta_" + it->first+ "Constraint";
@@ -918,8 +918,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       editList+=precede + "alpha_"+it->first+"=alphaOfBeta_"+ it->first;
 
       /*
-      if( proto->pdf(("alpha_"+it->first+"Constraint").c_str()) && proto->var(("alpha_"+it->first).c_str()) )
-      cout << " checked they are there" << proto->pdf(("alpha_"+it->first+"Constraint").c_str()) << " " << proto->var(("alpha_"+it->first).c_str()) << endl;
+      if( proto->pdf("alpha_"+it->first+"Constraint") && proto->var("alpha_"+it->first)
+      cout << " checked they are there" << proto->pdf("alpha_"+it->first+"Constraint") << " " << proto->var("alpha_"+it->first) << endl;
       else
 	cout << "NOT THERE" << endl;
       */
@@ -932,7 +932,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 	precede="";
 	cout << "Going to issue this edit command\n" << edit<< endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne)
 	  cxcoutWHF << "---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	
@@ -942,7 +942,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     // add uniform terms and their constraints
     for(it=uniformSyst.begin(); it!=uniformSyst.end(); ++it) {
       cout << "edit for " << it->first << "with rel uncert = " << it->second << endl;
-      if(! proto->var(("alpha_"+it->first).c_str())){
+      if(! proto->var("alpha_"+it->first)){
 	cout << "systematic not there" << endl;
 	nskipped++; 
 	continue;
@@ -955,12 +955,12 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       proto->factory(Form("PolyVar::alphaOfBeta_%s(beta_%s,{-1,1})",it->first.c_str(),it->first.c_str()));
       
       // set beta const status to be same as alpha
-      if(proto->var(Form("alpha_%s",it->first.c_str()))->isConstant())
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(true);
+      if(proto->var("alpha_" + it->first)->isConstant())
+	proto->var("beta_" + it->first)->setConstant(true);
       else
-	proto->var(Form("beta_%s",it->first.c_str()))->setConstant(false);
+	proto->var("beta_" + it->first)->setConstant(false);
       // set alpha const status to true
-      //      proto->var(Form("alpha_%s",it->first.c_str()))->setConstant(true);
+      //      proto->var("alpha_" + it->first)->setConstant(true);
 
       // replace alphas with alphaOfBeta and replace constraints
       cout <<         "alpha_"+it->first+"Constraint=beta_" + it->first+ "Constraint" << endl;
@@ -969,8 +969,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       cout <<         "alpha_"+it->first+"=alphaOfBeta_"+ it->first << endl;
       editList+=precede + "alpha_"+it->first+"=alphaOfBeta_"+ it->first;
 
-      if( proto->pdf(("alpha_"+it->first+"Constraint").c_str()) && proto->var(("alpha_"+it->first).c_str()) )
-	cout << " checked they are there" << proto->pdf(("alpha_"+it->first+"Constraint").c_str()) << " " << proto->var(("alpha_"+it->first).c_str()) << endl;
+      if( proto->pdf("alpha_"+it->first+"Constraint") && proto->var("alpha_"+it->first))
+	cout << " checked they are there" << proto->pdf("alpha_"+it->first+"Constraint") << " " << proto->var("alpha_"+it->first) << endl;
       else
 	cout << "NOT THERE" << endl;
 
@@ -982,7 +982,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 	precede="";
 	cout << edit<< endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne)
 	  cxcoutWHF <<  "---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	
@@ -996,7 +996,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     // add lognormal terms and their constraints
     for(it=logNormSyst.begin(); it!=logNormSyst.end(); ++it) {
       cout << "edit for " << it->first << "with rel uncert = " << it->second << endl;
-      if(! proto->var(("alpha_"+it->first).c_str())){
+      if(! proto->var("alpha_"+it->first)){
 	cout << "systematic not there" << endl;
 	nskipped++; 
 	continue;
@@ -1037,8 +1037,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       cout <<         "alpha_"+it->first+"=alphaOfBeta_"+ it->first << endl;
       editList+=precede + "alpha_"+it->first+"=alphaOfBeta_"+ it->first;
 
-      if( proto->pdf(("alpha_"+it->first+"Constraint").c_str()) && proto->var(("alpha_"+it->first).c_str()) )
-	cout << " checked they are there" << proto->pdf(("alpha_"+it->first+"Constraint").c_str()) << " " << proto->var(("alpha_"+it->first).c_str()) << endl;
+      if( proto->pdf("alpha_"+it->first+"Constraint") && proto->var("alpha_"+it->first) )
+	cout << " checked they are there" << proto->pdf("alpha_"+it->first+"Constraint") << " " << proto->var("alpha_"+it->first) << endl;
       else
 	cout << "NOT THERE" << endl;
 
@@ -1050,7 +1050,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 	precede="";
 	cout << edit<< endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne)
 	  cxcoutWHF << "\n\n ---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	
@@ -1071,7 +1071,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     for(it=noSyst.begin(); it!=noSyst.end(); ++it) {
 
       cout << "remove constraint for parameter" << it->first << endl;
-      if(! proto->var(("alpha_"+it->first).c_str()) || ! proto->pdf(("alpha_"+it->first+"Constraint").c_str()) ) {
+      if(! proto->var("alpha_"+it->first) || ! proto->pdf("alpha_"+it->first+"Constraint") ) {
 	cout << "systematic not there" << endl;
 	nskipped++; 
 	continue;
@@ -1095,7 +1095,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 	precede="";
 	cout << edit << endl;
 	proto->factory( edit.c_str() );
-	RooAbsPdf* newOne = proto->pdf(lastPdf.c_str());
+	RooAbsPdf* newOne = proto->pdf(lastPdf);
 	if(!newOne) {
 	  cxcoutWHF << "---------------------\n WARNING: failed to make EDIT\n\n" << endl;
 	}
@@ -1401,7 +1401,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
             RooArgList theObservables;
             std::vector<std::string>::iterator itr = fObsNameVec.begin();
             for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
-              theObservables.add( *proto->var(itr->c_str()) );
+              theObservables.add( *proto->var(*itr) );
             }
 
             // Create the list of terms to
@@ -1457,7 +1457,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
               RooArgList theObservables;
               std::vector<std::string>::iterator itr = fObsNameVec.begin();
               for (int idx=0; itr!=fObsNameVec.end(); ++itr, ++idx ) {
-                theObservables.add( *proto->var(itr->c_str()) );
+                theObservables.add( *proto->var(*itr) );
               }
 
               // Create the Parameters
@@ -1557,7 +1557,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
               RooArgList theObservables;
               std::vector<std::string>::iterator itr = fObsNameVec.begin();
               for(; itr!=fObsNameVec.end(); ++itr ) {
-                theObservables.add( *proto->var(itr->c_str()) );
+                theObservables.add( *proto->var(*itr) );
               }
 
               // Create the Parameters
@@ -1702,7 +1702,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     //////////////////////////////////////
     // fix specified parameters
     for(unsigned int i=0; i<systToFix.size(); ++i){
-      RooRealVar* temp = proto->var((systToFix.at(i)).c_str());
+      RooRealVar* temp = proto->var(systToFix.at(i));
       if(temp) {
         // set the parameter constant
         temp->setConstant();
@@ -1712,7 +1712,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
         if(systToFix.at(i)=="Lumi"){
           auxMeas = proto->var("nominalLumi");
         } else {
-          auxMeas = proto->var(TString::Format("nom_%s",temp->GetName()));
+          auxMeas = proto->var(std::string("nom_") + temp->GetName());
         }
 
         if(auxMeas){
@@ -1757,7 +1757,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     std::vector<std::string>::iterator itr = fObsNameVec.begin();
     for(; itr!=fObsNameVec.end(); ++itr ) {
-      observables.add( *proto->var(itr->c_str()) );
+      observables.add( *proto->var(*itr) );
       if (!observablesStr.empty()) { observablesStr += ","; }
       observablesStr += *itr;
     }
@@ -1879,7 +1879,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     for (int i=1; i<=ax->GetNbins(); ++i) { // 1 or more dimension
 
       Double_t xval = ax->GetBinCenter(i);
-      proto->var( ObsNameVec[0].c_str() )->setVal( xval );
+      proto->var( ObsNameVec[0] )->setVal( xval );
 
       if(ObsNameVec.size()==1) {
 	Double_t fval = mnominal->GetBinContent(i);
@@ -1888,7 +1888,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
 	for(int j=1; j<=ay->GetNbins(); ++j) {
 	  Double_t yval = ay->GetBinCenter(j);
-	  proto->var( ObsNameVec[1].c_str() )->setVal( yval );
+	  proto->var( ObsNameVec[1] )->setVal( yval );
 
 	  if(ObsNameVec.size()==2) { 
 	    Double_t fval = mnominal->GetBinContent(i,j);
@@ -1897,7 +1897,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
 	    for(int k=1; k<=az->GetNbins(); ++k) {
 	      Double_t zval = az->GetBinCenter(k);
-	      proto->var( ObsNameVec[2].c_str() )->setVal( zval );
+	      proto->var( ObsNameVec[2] )->setVal( zval );
 	      Double_t fval = mnominal->GetBinContent(i,j,k);
 	      obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
 	    }
@@ -1970,7 +1970,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       else channelString << ',' << channel_name ;
       RooWorkspace * ch=chs[i].get();
       
-      RooAbsPdf* model = ch->pdf(("model_"+channel_name).c_str());
+      RooAbsPdf* model = ch->pdf("model_"+channel_name);
       if(!model) cout <<"failed to find model for channel"<<endl;
       //      cout << "int = " << model->createIntegral(*obsN)->getVal() << endl;;
       models.push_back(model);
@@ -2113,7 +2113,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       std::string paramName = param_itr->first;
       double paramVal = param_itr->second;
       
-      RooRealVar* temp = combined->var( paramName.c_str() );
+      RooRealVar* temp = combined->var( paramName );
       if(temp) {
         temp->setVal( paramVal );
         cxcoutI(HistFactory) <<"setting " << paramName << " to the value: " << paramVal <<  endl;
@@ -2124,7 +2124,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     for(unsigned int i=0; i<fSystToFix.size(); ++i){
       // make sure they are fixed
-      RooRealVar* temp = combined->var((fSystToFix.at(i)).c_str());
+      RooRealVar* temp = combined->var(fSystToFix[i]);
       if(temp) {
         temp->setConstant();
         cxcoutI(HistFactory) <<"setting " << fSystToFix.at(i) << " constant" << endl;
@@ -2548,13 +2548,13 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     }
   
     constraintTermNames.push_back( constrName );    
-    ConstraintTerms.add( *proto->pdf(constrName.c_str()) );
+    ConstraintTerms.add( *proto->pdf(constrName) );
 
     // Add the "observed" value to the 
     // list of global observables:
     RooArgSet* globalSet = const_cast<RooArgSet*>(proto->set("globalObservables"));
   
-    RooRealVar* nomVarInWorkspace = proto->var(nomName.c_str());
+    RooRealVar* nomVarInWorkspace = proto->var(nomName);
     if( ! globalSet->contains(*nomVarInWorkspace) ) {
       globalSet->add( *nomVarInWorkspace );	
     }

--- a/roofit/histfactory/src/MakeModelAndMeasurements.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurements.cxx
@@ -239,7 +239,7 @@ void topDriver( string input ) {
       ModelConfig* proto_config = (ModelConfig *) ws->obj("ModelConfig");
 
       std::cout << "Setting Parameter of Interest as :" << measurement.GetPOI() << endl;
-      RooRealVar* poi = (RooRealVar*) ws->var( (measurement.GetPOI()).c_str() );
+      RooRealVar* poi = (RooRealVar*) ws->var(measurement.GetPOI());
       RooArgSet * params= new RooArgSet;
       if(poi){
 	params->add(*poi);
@@ -298,8 +298,8 @@ void topDriver( string input ) {
     //
     ModelConfig * combined_config = (ModelConfig *) ws->obj("ModelConfig");
     cout << "Setting Parameter of Interest as :" << measurement.GetPOI() << endl;
-    RooRealVar* poi = (RooRealVar*) ws->var( (measurement.GetPOI()).c_str() );
-    //RooRealVar* poi = (RooRealVar*) ws->var((POI+"_comb").c_str());
+    RooRealVar* poi = (RooRealVar*) ws->var(measurement.GetPOI());
+    //RooRealVar* poi = (RooRealVar*) ws->var(POI+"_comb");
     RooArgSet * params= new RooArgSet;
     cout << poi << endl;
     if(poi){
@@ -524,7 +524,7 @@ void topDriver(string input ){
           // set poi in ModelConfig
           ModelConfig * proto_config = (ModelConfig *) ws->obj("ModelConfig");
           cout << "Setting Parameter of Interest as :" << POI << endl;
-          RooRealVar* poi = (RooRealVar*) ws->var(POI.c_str());
+          RooRealVar* poi = (RooRealVar*) ws->var(POI);
           RooArgSet * params= new RooArgSet;
 	  if(poi){
 	    params->add(*poi);
@@ -577,8 +577,8 @@ void topDriver(string input ){
           //
           ModelConfig * combined_config = (ModelConfig *) ws->obj("ModelConfig");
           cout << "Setting Parameter of Interest as :" << POI << endl;
-          RooRealVar* poi = (RooRealVar*) ws->var((POI).c_str());
-          //RooRealVar* poi = (RooRealVar*) ws->var((POI+"_comb").c_str());
+          RooRealVar* poi = (RooRealVar*) ws->var(POI);
+          //RooRealVar* poi = (RooRealVar*) ws->var(POI+"_comb");
           RooArgSet * params= new RooArgSet;
           cout << poi << endl;
 	  if(poi){

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -212,7 +212,7 @@ RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::Hist
       chanFile->Close();
 
       // Get the Paramater of Interest as a RooRealVar
-      RooRealVar* poi = dynamic_cast<RooRealVar*>( ws_single->var( (measurement.GetPOI()).c_str() ) );
+      RooRealVar* poi = dynamic_cast<RooRealVar*>( ws_single->var(measurement.GetPOI()));
 
       // do fit unless exportOnly requested
       if(! measurement.GetExportOnly()){
@@ -246,7 +246,7 @@ RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::Hist
     HistoToWorkspaceFactoryFast::ConfigureWorkspaceForMeasurement( "simPdf", ws, measurement );
 
     // Get the Parameter of interest as a RooRealVar
-    RooRealVar* poi = dynamic_cast<RooRealVar*>( ws->var( (measurement.GetPOI()).c_str() ) );
+    RooRealVar* poi = dynamic_cast<RooRealVar*>( ws->var(measurement.GetPOI()));
     
     std::string CombinedFileName = measurement.GetOutputFilePrefix() + "_combined_"
       + rowTitle + "_model.root";

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -313,7 +313,7 @@ RooArgList ParamHistFunc::createParamSet(RooWorkspace& w, const std::string& Pre
       gamma.setConstant( false );
 
       w.import( gamma, RooFit::RecycleConflictNodes() );
-      RooRealVar* gamma_wspace = (RooRealVar*) w.var( VarName.c_str() );
+      RooRealVar* gamma_wspace = (RooRealVar*) w.var( VarName );
 
       paramSet.add( *gamma_wspace );
 
@@ -347,7 +347,7 @@ RooArgList ParamHistFunc::createParamSet(RooWorkspace& w, const std::string& Pre
         gamma.setConstant( false );
 
         w.import( gamma, RooFit::RecycleConflictNodes() );
-        RooRealVar* gamma_wspace = (RooRealVar*) w.var( VarName.c_str() );
+        RooRealVar* gamma_wspace = (RooRealVar*) w.var( VarName );
 
         paramSet.add( *gamma_wspace );
 
@@ -384,7 +384,7 @@ RooArgList ParamHistFunc::createParamSet(RooWorkspace& w, const std::string& Pre
           gamma.setConstant( false );
 
           w.import( gamma, RooFit::RecycleConflictNodes() );
-          RooRealVar* gamma_wspace = (RooRealVar*) w.var( VarName.c_str() );
+          RooRealVar* gamma_wspace = (RooRealVar*) w.var( VarName );
 
           paramSet.add( *gamma_wspace );
 

--- a/roofit/histfactory/test/testHistFactory.cxx
+++ b/roofit/histfactory/test/testHistFactory.cxx
@@ -313,7 +313,7 @@ TEST_P(HFFixture, ModelProperties) {
 
   // Check that parameters are in the model
   for (const auto& systName : _systNames) {
-    auto& var = *ws->var(systName.c_str());
+    auto& var = *ws->var(systName);
 
     EXPECT_TRUE(channelPdf->dependsOnValue(var)) << "Expect channel pdf to depend on " << systName;
     if (!var.isConstant()) {
@@ -323,7 +323,7 @@ TEST_P(HFFixture, ModelProperties) {
 
   // Check that sub models depend on their systematic uncertainties.
   for (auto& subModelName : std::initializer_list<std::string>{"signal_channel1_shapes", "background1_channel1_shapes", "background2_channel1_shapes"}) {
-    auto subModel = ws->function(subModelName.c_str());
+    auto subModel = ws->function(subModelName);
     ASSERT_NE(subModel, nullptr) << "Unable to retrieve sub model with name " << subModelName;
     if (subModelName.find("signal") != std::string::npos) {
       EXPECT_FALSE(subModel->dependsOn(*ws->var("gamma_stat_channel1_bin_0")));

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -165,7 +165,7 @@ public:
          auto varlist = tool->getObservables(p["data"], prefix);
 
          auto getBinnedData = [&tool, &p, &varlist](std::string const &binnedDataName) -> RooDataHist & {
-            auto *dh = dynamic_cast<RooDataHist *>(tool->workspace()->embeddedData(binnedDataName.c_str()));
+            auto *dh = dynamic_cast<RooDataHist *>(tool->workspace()->embeddedData(binnedDataName));
             if (!dh) {
                auto dhForImport = tool->readBinnedData(p["data"], binnedDataName, varlist);
                tool->workspace()->import(*dhForImport, RooFit::Silence(true), RooFit::Embedded());
@@ -195,7 +195,7 @@ public:
          if (p.has_child("normFactors")) {
             for (const auto &nf : p["normFactors"].children()) {
                std::string nfname(RooJSONFactoryWSTool::name(nf));
-               RooAbsReal *r = tool->workspace()->var(nfname.c_str());
+               RooAbsReal *r = tool->workspace()->var(nfname);
                if (r) {
                   normElems.add(*r);
                } else {

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -29,7 +29,7 @@ public:
       RooArgList dependents;
       for (const auto &d : p["dependents"].children()) {
          std::string objname(RooJSONFactoryWSTool::name(d));
-         TObject *obj = tool->workspace()->obj(objname.c_str());
+         TObject *obj = tool->workspace()->obj(objname);
          if (obj->InheritsFrom(RooAbsArg::Class())) {
             dependents.add(*static_cast<RooAbsArg *>(obj));
          }
@@ -59,7 +59,7 @@ public:
       RooArgList dependents;
       for (const auto &d : p["dependents"].children()) {
          std::string objname(RooJSONFactoryWSTool::name(d));
-         TObject *obj = tool->workspace()->obj(objname.c_str());
+         TObject *obj = tool->workspace()->obj(objname);
          if (obj->InheritsFrom(RooAbsArg::Class())) {
             dependents.add(*static_cast<RooAbsArg *>(obj));
          }
@@ -361,7 +361,7 @@ public:
          RooJSONFactoryWSTool::error("function '" + name + "' is of histogram type, but does not define a 'data' key");
       }
       auto varlist = tool->getObservables(p["data"], name);
-      RooDataHist *dh = dynamic_cast<RooDataHist *>(tool->workspace()->embeddedData(name.c_str()));
+      RooDataHist *dh = dynamic_cast<RooDataHist *>(tool->workspace()->embeddedData(name));
       if (!dh) {
          auto dhForImport = tool->readBinnedData(p["data"], name, varlist);
          tool->workspace()->import(*dhForImport, RooFit::Silence(true), RooFit::Embedded());

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -61,14 +61,14 @@ const RooFit::Experimental::JSONNode &RooJSONFactoryWSTool::irootnode() const
 template <>
 RooRealVar *RooJSONFactoryWSTool::request<RooRealVar>(const std::string &objname, const std::string &requestAuthor)
 {
-   RooRealVar *retval = this->workspace()->var(objname.c_str());
+   RooRealVar *retval = this->workspace()->var(objname);
    if (retval)
       return retval;
    if (irootnode().has_child("variables")) {
       const JSONNode &vars = irootnode()["variables"];
       if (vars.has_child(objname)) {
          this->importVariable(vars[objname]);
-         retval = this->workspace()->var(objname.c_str());
+         retval = this->workspace()->var(objname);
          if (retval)
             return retval;
       }
@@ -79,14 +79,14 @@ RooRealVar *RooJSONFactoryWSTool::request<RooRealVar>(const std::string &objname
 template <>
 RooAbsPdf *RooJSONFactoryWSTool::request<RooAbsPdf>(const std::string &objname, const std::string &requestAuthor)
 {
-   RooAbsPdf *retval = this->workspace()->pdf(objname.c_str());
+   RooAbsPdf *retval = this->workspace()->pdf(objname);
    if (retval)
       return retval;
    if (irootnode().has_child("pdfs")) {
       const JSONNode &pdfs = irootnode()["pdfs"];
       if (pdfs.has_child(objname)) {
          this->importFunction(pdfs[objname], true);
-         retval = this->workspace()->pdf(objname.c_str());
+         retval = this->workspace()->pdf(objname);
          if (retval)
             return retval;
       }
@@ -98,13 +98,13 @@ template <>
 RooAbsReal *RooJSONFactoryWSTool::request<RooAbsReal>(const std::string &objname, const std::string &requestAuthor)
 {
    RooAbsReal *retval = nullptr;
-   retval = this->workspace()->pdf(objname.c_str());
+   retval = this->workspace()->pdf(objname);
    if (retval)
       return retval;
-   retval = this->workspace()->function(objname.c_str());
+   retval = this->workspace()->function(objname);
    if (retval)
       return retval;
-   retval = this->workspace()->var(objname.c_str());
+   retval = this->workspace()->var(objname);
    if (retval)
       return retval;
    if (isNumber(objname))
@@ -122,7 +122,7 @@ RooAbsReal *RooJSONFactoryWSTool::request<RooAbsReal>(const std::string &objname
       const JSONNode &vars = irootnode()["variables"];
       if (vars.has_child(objname)) {
          this->importVariable(vars[objname]);
-         retval = this->workspace()->var(objname.c_str());
+         retval = this->workspace()->var(objname);
          if (retval)
             return retval;
       }
@@ -131,7 +131,7 @@ RooAbsReal *RooJSONFactoryWSTool::request<RooAbsReal>(const std::string &objname
       const JSONNode &funcs = irootnode()["functions"];
       if (funcs.has_child(objname)) {
          this->importFunction(funcs[objname], false);
-         retval = this->workspace()->function(objname.c_str());
+         retval = this->workspace()->function(objname);
          if (retval)
             return retval;
       }
@@ -853,7 +853,7 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool isPdf)
       if (this->_workspace->pdf(name.c_str()))
          return;
    } else {
-      if (this->_workspace->function(name.c_str()))
+      if (this->_workspace->function(name))
          return;
    }
    // if the key we found is not a map, it's an error
@@ -924,7 +924,7 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool isPdf)
             return;
          }
       }
-      RooAbsReal *func = this->_workspace->function(name.c_str());
+      RooAbsReal *func = this->_workspace->function(name);
       if (!func) {
          std::stringstream err;
          err << "something went wrong importing function '" << name << "'.";
@@ -1029,7 +1029,7 @@ std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadDat
          // combined measurement
          auto subMap = loadData(p);
          auto catname = p["index"].val();
-         RooCategory *channelCat = _workspace->cat(catname.c_str());
+         RooCategory *channelCat = _workspace->cat(catname);
          if (!channelCat) {
             std::stringstream ss;
             ss << "RooJSONFactoryWSTool() failed to retrieve channel category " << catname << std::endl;
@@ -1170,8 +1170,8 @@ RooArgSet RooJSONFactoryWSTool::getObservables(const JSONNode &n, const std::str
    RooArgList varlist;
    for (auto v : vars) {
       std::string name(v.first);
-      if (_workspace->var(name.c_str())) {
-         varlist.add(*(_workspace->var(name.c_str())));
+      if (_workspace->var(name)) {
+         varlist.add(*(_workspace->var(name)));
       } else {
          varlist.add(*RooJSONFactoryWSTool::createObservable(name, v.second));
       }
@@ -1202,7 +1202,7 @@ void RooJSONFactoryWSTool::clearScope()
 RooRealVar *RooJSONFactoryWSTool::createObservable(const std::string &name, const RooJSONFactoryWSTool::Var &var)
 {
    this->_workspace->factory(TString::Format("%s[%f]", name.c_str(), var.min));
-   RooRealVar *rrv = this->_workspace->var(name.c_str());
+   RooRealVar *rrv = this->_workspace->var(name);
    rrv->setMin(var.min);
    rrv->setMax(var.max);
    rrv->setConstant(true);
@@ -1306,7 +1306,7 @@ void RooJSONFactoryWSTool::configureToplevelPdf(const JSONNode &p, RooAbsPdf &pd
       RooStats::ModelConfig mc{mcname.c_str(), pdf.GetName()};
       this->_workspace->import(mc);
    }
-   RooStats::ModelConfig *inwsmc = dynamic_cast<RooStats::ModelConfig *>(this->_workspace->obj(mcname.c_str()));
+   RooStats::ModelConfig *inwsmc = dynamic_cast<RooStats::ModelConfig *>(this->_workspace->obj(mcname));
    if (inwsmc) {
       inwsmc->SetWS(*(this->_workspace));
       inwsmc->SetPdf(pdf);
@@ -1361,7 +1361,7 @@ void RooJSONFactoryWSTool::importVariable(const JSONNode &p)
 {
    // import a RooRealVar object
    std::string name(RooJSONFactoryWSTool::name(p));
-   if (this->_workspace->var(name.c_str()))
+   if (this->_workspace->var(name))
       return;
    if (!p.is_map()) {
       std::stringstream ss;
@@ -1653,7 +1653,7 @@ void RooJSONFactoryWSTool::importAllNodes(const RooFit::Experimental::JSONNode &
             continue;
          for (const auto &var : snsh.children()) {
             std::string vname = RooJSONFactoryWSTool::name(var);
-            RooRealVar *rrv = this->_workspace->var(vname.c_str());
+            RooRealVar *rrv = this->_workspace->var(vname);
             if (!rrv)
                continue;
             this->configureVariable(var, *rrv);

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -833,7 +833,7 @@ void collectHistograms(const char *name, TDirectory *file, std::map<std::string,
          RooArgSet vars;
          vars.add(var);
 
-         RooDataHist *dh = new RooDataHist(histname.View(), histname.View(), vars, hist);
+         RooDataHist *dh = new RooDataHist(histname, histname, vars, hist);
          // add it to the list
          RooHistFunc *hf = new RooHistFunc(funcname, funcname, var, *dh);
          int idx = physics.getSize();

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -209,6 +209,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     RooSimWSTool.h
     RooStreamParser.h
     RooStringVar.h
+    RooStringView.h
     RooStudyManager.h
     RooStudyPackage.h
     RooSuperCategory.h

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -25,6 +25,7 @@
 #include "RooNameReg.h"
 #include "RooLinkedListIter.h"
 #include <RooBatchCompute/DataKey.h>
+#include <RooStringView.h>
 
 #include <deque>
 #include <iostream>

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -23,7 +23,6 @@
 #include "RooSpan.h"
 #include "RooNameReg.h"
 
-#include "ROOT/RStringView.hxx"
 #include "TNamed.h"
 
 #include <map>
@@ -57,36 +56,13 @@ struct ConstantTermsOptimizer;
 }
 
 
-// Writes a templated constructor for compatibility with ROOT builds using the
-// C++14 standard or earlier, taking `ROOT::Internal::TStringView` instead of
-// `std::string_view`. This means one can still use a `TString` for the name or
-// title parameter. The condition in the following `#if` should be kept in
-// sync with the one in TString.h.
-#if (__cplusplus >= 201700L) && !defined(_MSC_VER) && (!defined(__clang_major__) || __clang_major__ > 5)
-#define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t) // does nothing
-#else
-#define WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(Class_t)                                             \
-  template<typename ...Args_t>                                                                    \
-  Class_t(ROOT::Internal::TStringView name, ROOT::Internal::TStringView title, Args_t &&... args) \
-    : Class_t(std::string_view(name), std::string_view(title), std::forward<Args_t>(args)...) {}  \
-  template<typename ...Args_t>                                                                    \
-  Class_t(ROOT::Internal::TStringView name, std::string_view title, Args_t &&... args)            \
-    : Class_t(std::string_view(name), title, std::forward<Args_t>(args)...) {}                    \
-  template<typename ...Args_t>                                                                    \
-  Class_t(std::string_view name, ROOT::Internal::TStringView title, Args_t &&... args)            \
-    : Class_t(name, std::string_view(title), std::forward<Args_t>(args)...) {}
-#endif
-
-
 class RooAbsData : public TNamed, public RooPrintable {
 public:
 
   // Constructors, factory methods etc.
   RooAbsData() ; 
-  RooAbsData(std::string_view name, std::string_view title, const RooArgSet& vars, RooAbsDataStore* store=0) ;
+  RooAbsData(RooStringView name, RooStringView title, const RooArgSet& vars, RooAbsDataStore* store=0) ;
   RooAbsData(const RooAbsData& other, const char* newname = 0) ;
-
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooAbsData)
 
   RooAbsData& operator=(const RooAbsData& other);
   virtual ~RooAbsData() ;

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -38,8 +38,8 @@ class RooAbsDataStore : public TNamed, public RooPrintable {
 public:
 
   RooAbsDataStore() {}
-  RooAbsDataStore(std::string_view name, std::string_view title, const RooArgSet& vars)
-    : TNamed(TString{name},TString{title}), _vars{vars} {}
+  RooAbsDataStore(RooStringView name, RooStringView title, const RooArgSet& vars)
+    : TNamed(name,title), _vars{vars} {}
   RooAbsDataStore(const RooAbsDataStore& other, const char* newname=0)
     : RooAbsDataStore(other, other._vars, newname) {}
   RooAbsDataStore(const RooAbsDataStore& other, const RooArgSet& vars, const char* newname=0)
@@ -47,8 +47,6 @@ public:
   {
     if(newname) SetName(newname);
   }
-
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooAbsDataStore)
 
   virtual RooAbsDataStore* clone(const char* newname=0) const = 0 ;
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const = 0 ;

--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -27,8 +27,14 @@ class RooCmdArg final : public TNamed {
 public:
 
   RooCmdArg();
+  /// Constructor from payload parameters. Note that the first payload
+  /// parameter has no default value, because otherwise the implicit creation
+  /// of a RooCmdArg from `const char*` would be possible. This would cause
+  /// ambiguity problems in RooFit code. It is not a problem that the first
+  /// parameter always has to be given, because creating a RooCmdArg with only
+  /// a name and no payload doesn't make sense anyway.
   RooCmdArg(const char* name, 
-	    Int_t i1=0, Int_t i2=0, 
+	    Int_t i1, Int_t i2=0,
 	    Double_t d1=0, Double_t d2=0, 
 	    const char* s1=0, const char* s2=0, 
 	    const TObject* o1=0, const TObject* o2=0, const RooCmdArg* ca=0, const char* s3=0,

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -37,9 +37,7 @@ public:
   RooCompositeDataStore() ; 
 
   // Ctors from DataStore
-  RooCompositeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> inputData) ;
-
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooCompositeDataStore)
+  RooCompositeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> inputData) ;
 
   // Empty ctor
   virtual RooAbsDataStore* clone(const char* newname=0) const { return new RooCompositeDataStore(*this,newname) ; }

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -47,17 +47,15 @@ public:
 
   // Constructors, factory methods etc.
   RooDataHist() ; 
-  RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const char* binningName=0) ;
-  RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsData& data, Double_t initWgt=1.0) ;
-  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const TH1* hist, Double_t initWgt=1.0) ;
-  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, Double_t initWgt=1.0) ;
-  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dhistMap, Double_t wgt=1.0) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const char* binningName=0) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsData& data, Double_t initWgt=1.0) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const TH1* hist, Double_t initWgt=1.0) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, Double_t initWgt=1.0) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dhistMap, Double_t wgt=1.0) ;
   //RooDataHist(const char *name, const char *title, const RooArgList& vars, Double_t initWgt=1.0) ;
-  RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
+  RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), const RooCmdArg& arg3=RooCmdArg(),
         const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
   RooDataHist& operator=(const RooDataHist&) = delete;
-
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooDataHist)
 
   RooDataHist(const RooDataHist& other, const char* newname = 0) ;
   TObject* Clone(const char* newname="") const override {
@@ -246,7 +244,7 @@ protected:
   void setAllWeights(Double_t value) ;
  
   void initialize(const char* binningName=0,Bool_t fillTree=kTRUE) ;
-  RooDataHist(std::string_view name, std::string_view title, RooDataHist* h, const RooArgSet& varSubset, 
+  RooDataHist(RooStringView name, RooStringView title, RooDataHist* h, const RooArgSet& varSubset,
         const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) ;
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0, 
                   std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) override;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -46,27 +46,25 @@ public:
   RooDataSet() ; 
 
   // Empty constructor 
-  RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
 
   // Universal constructor
-  RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(), 
+  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(),
 	     const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),const RooCmdArg& arg5=RooCmdArg(),
 	     const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ; 
 
     // Constructor for subset of existing dataset
-  RooDataSet(std::string_view name, std::string_view title, RooDataSet *data, const RooArgSet& vars, 
+  RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
              const char *cuts=0, const char* wgtVarName=0);
-  RooDataSet(std::string_view name, std::string_view title, RooDataSet *data, const RooArgSet& vars,  
+  RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
 	     const RooFormulaVar& cutVar, const char* wgtVarName=0) ;  
 
 
   // Constructor importing data from external ROOT Tree
-  RooDataSet(std::string_view name, std::string_view title, TTree *tree, const RooArgSet& vars,
+  RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
 	     const char *cuts=0, const char* wgtVarName=0); 
-  RooDataSet(std::string_view name, std::string_view title, TTree *tree, const RooArgSet& vars,
+  RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
 	     const RooFormulaVar& cutVar, const char* wgtVarName=0) ;  
-
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooDataSet)
 
   RooDataSet(RooDataSet const & other, const char* newname=0) ;  
   virtual TObject* Clone(const char* newname = "") const override {
@@ -159,7 +157,7 @@ protected:
   // Cache copy feature is not publicly accessible
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0, 
 	                std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) override;
-  RooDataSet(std::string_view name, std::string_view title, RooDataSet *ntuple, 
+  RooDataSet(RooStringView name, RooStringView title, RooDataSet *ntuple,
 	     const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange, std::size_t nStart, std::size_t nStop, Bool_t copyCache, const char* wgtVarName=0);
   
   RooArgSet addWgtVar(const RooArgSet& origVars, const RooAbsArg* wgtVar) ; 

--- a/roofit/roofitcore/inc/RooStringView.h
+++ b/roofit/roofitcore/inc/RooStringView.h
@@ -1,0 +1,39 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN, Jan 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef roofit_roofitcore_RooStringView_h
+#define roofit_roofitcore_RooStringView_h
+
+#include <ROOT/RStringView.hxx>
+#include <TString.h>
+
+#include <string>
+
+/// The RooStringView is a wrapper around a C-syle string that can also be
+/// constructed from a `std::string` or a Tstring. As such, it serves as a
+/// drop-in replacement for `const char*` in public RooFit interfaces, keeping
+/// the possibility to pass a C-style string without copying but also accepting
+/// a `std::string`.
+
+class RooStringView {
+public:
+   RooStringView(const char *str) : _cstr{str} {}
+   RooStringView(TString const &str) : _cstr{str} {}
+   RooStringView(std::string const &str) : _cstr{str.c_str()} {}
+   operator const char *() { return _cstr; }
+   operator std::string_view() { return _cstr; }
+
+private:
+   const char *_cstr;
+};
+
+#endif

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -38,22 +38,20 @@ public:
   RooTreeDataStore() ; 
   RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* wgtVarName=0) ; 
 
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooTreeDataStore)
-
   // Empty ctor
-  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
   virtual RooAbsDataStore* clone(const char* newname=0) const { return new RooTreeDataStore(*this,newname) ; }
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const { return new RooTreeDataStore(*this,vars,newname) ; }
 
   // Ctors from TTree
-  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ; 
-  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ; 
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ;
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ;
 
   // Ctors from DataStore
-  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName=0) ;
-  RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=0, const char* wgtVarName=0) ;
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName=0) ;
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=0, const char* wgtVarName=0) ;
 
-  RooTreeDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds, 
+  RooTreeDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
 		   const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 		   Int_t nStart, Int_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
 
@@ -158,7 +156,7 @@ public:
 
   static Int_t _defTreeBufSize ;  
 
-  void createTree(std::string_view name, std::string_view title) ; 
+  void createTree(RooStringView name, RooStringView title) ;
   TTree *_tree ;           // TTree holding the data points
   TTree *_cacheTree ;      //! TTree holding the cached function values
   const RooAbsArg* _cacheOwner ; //! Object owning cache contents

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -43,9 +43,7 @@ public:
   RooVectorDataStore() ; 
 
   // Empty ctor
-  RooVectorDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName=0) ;
-
-  WRITE_TSTRING_COMPATIBLE_CONSTRUCTOR(RooVectorDataStore)
+  RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
 
   virtual RooAbsDataStore* clone(const char* newname=0) const override { return new RooVectorDataStore(*this,newname) ; }
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooVectorDataStore(*this,vars,newname) ; }
@@ -55,7 +53,7 @@ public:
   RooVectorDataStore(const RooVectorDataStore& other, const RooArgSet& vars, const char* newname=0) ;
 
 
-  RooVectorDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds, 
+  RooVectorDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
 		     const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 		     std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
 
@@ -68,7 +66,7 @@ public:
 
     template<class T>
     struct ArrayInfo {
-        ArrayInfo(std::string_view n, T const* d) : name{n}, data{d} {}
+        ArrayInfo(RooStringView n, T const* d) : name{n}, data{d} {}
         std::string name;
         T const* data;
     };

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -103,20 +103,20 @@ public:
   //   RooAbsData* joinData(const char* jointDataName, const char* indexName, const char* inputMapping) ; 
 
   // Accessor functions 
-  RooAbsPdf* pdf(const char* name) const ;
-  RooAbsReal* function(const char* name) const ;
-  RooRealVar* var(const char* name) const ;
-  RooCategory* cat(const char* name) const ;
-  RooAbsCategory* catfunc(const char* name) const ;
-  RooAbsData* data(const char* name) const ;
-  RooAbsData* embeddedData(const char* name) const ;
-  RooAbsArg* arg(const char* name) const ;
-  RooAbsArg* fundArg(const char* name) const ;
-  RooArgSet argSet(const char* nameList) const ;
+  RooAbsPdf* pdf(RooStringView name) const ;
+  RooAbsReal* function(RooStringView name) const ;
+  RooRealVar* var(RooStringView name) const ;
+  RooCategory* cat(RooStringView name) const ;
+  RooAbsCategory* catfunc(RooStringView name) const ;
+  RooAbsData* data(RooStringView name) const ;
+  RooAbsData* embeddedData(RooStringView name) const ;
+  RooAbsArg* arg(RooStringView name) const ;
+  RooAbsArg* fundArg(RooStringView name) const ;
+  RooArgSet argSet(RooStringView nameList) const ;
   TIterator* componentIterator() const { return _allOwnedNodes.createIterator() ; }
   const RooArgSet& components() const { return _allOwnedNodes ; }
-  TObject* genobj(const char* name) const ;
-  TObject* obj(const char* name) const ;
+  TObject* genobj(RooStringView name) const ;
+  TObject* obj(RooStringView name) const ;
 
   // Group accessors
   RooArgSet allVars() const;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -183,8 +183,8 @@ RooAbsData::RooAbsData()
 /// Constructor from a set of variables. Only fundamental elements of vars
 /// (RooRealVar,RooCategory etc) are stored as part of the dataset
 
-RooAbsData::RooAbsData(std::string_view name, std::string_view title, const RooArgSet& vars, RooAbsDataStore* dstore) :
-  TNamed(TString{name},TString{title}),
+RooAbsData::RooAbsData(RooStringView name, RooStringView title, const RooArgSet& vars, RooAbsDataStore* dstore) :
+  TNamed(name,title),
   _vars("Dataset Variables"),
   _cachedVars("Cached Variables"),
   _dstore(dstore),

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -61,7 +61,7 @@ RooCompositeDataStore::RooCompositeDataStore() : _indexCat(0), _curStore(0), _cu
 /// Convert map by label to map by index for more efficient internal use
 
 RooCompositeDataStore::RooCompositeDataStore(
-        std::string_view name, std::string_view title,
+        RooStringView name, RooStringView title,
         const RooArgSet& vars, RooCategory& indexCat,map<std::string,RooAbsDataStore*> inputData) :
   RooAbsDataStore(name,title,RooArgSet(vars,indexCat)), _indexCat(&indexCat), _curStore(0), _curIndex(0), _ownComps(kFALSE)
 {

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -106,7 +106,7 @@ RooDataHist::RooDataHist()
 /// construct a RooThresholdCategory of the real dimension to be binned variably.
 /// Set the thresholds at the desired bin boundaries, and construct the
 /// data hist as a function of the threshold category instead of the real variable.
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const char* binningName) : 
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const char* binningName) :
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
@@ -143,7 +143,7 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
 /// If the constructed data hist has less dimensions that in source data collection,
 /// all missing dimensions will be projected.
 
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsData& data, Double_t wgt) :
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsData& data, Double_t wgt) :
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
@@ -169,7 +169,7 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
 /// The RooArgList 'vars' defines the dimensions of the histogram. 
 /// The ranges and number of bins are taken from the input histogram and must be the same in all histograms
 
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, 
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat,
 			 map<string,TH1*> histMap, Double_t wgt) :
   RooAbsData(name,title,RooArgSet(vars,&indexCat))
 {
@@ -194,7 +194,7 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
 /// The RooArgList 'vars' defines the dimensions of the histogram. 
 /// The ranges and number of bins are taken from the input histogram and must be the same in all histograms
 
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, RooCategory& indexCat, 
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat,
 			 map<string,RooDataHist*> dhistMap, Double_t wgt) :
   RooAbsData(name,title,RooArgSet(vars,&indexCat))
 {
@@ -216,7 +216,7 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
 /// and number of bins are taken from the input histogram, and the corresponding
 /// values are set accordingly on the arguments in 'vars'
 
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const TH1* hist, Double_t wgt) :
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const TH1* hist, Double_t wgt) :
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
@@ -275,7 +275,7 @@ RooDataHist::RooDataHist(std::string_view name, std::string_view title, const Ro
 /// </table>
 ///                              
 
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 			 const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8) :
   RooAbsData(name,title,RooArgSet(vars,(RooAbsArg*)RooCmdConfig::decodeObjOnTheFly("RooDataHist::RooDataHist", "IndexCat",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)))
 {
@@ -846,7 +846,7 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
 /// For most uses the RooAbsData::reduce() wrapper function, which uses this constructor, 
 /// is the most convenient way to create a subset of an existing data  
 
-RooDataHist::RooDataHist(std::string_view name, std::string_view title, RooDataHist* h, const RooArgSet& varSubset, 
+RooDataHist::RooDataHist(RooStringView name, RooStringView title, RooDataHist* h, const RooArgSet& varSubset,
 			 const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) :
   RooAbsData(name,title,varSubset)
 {

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -220,7 +220,7 @@ RooDataSet::RooDataSet() : _wgtVar(0)
 /// </table>
 ///
 
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2, const RooCmdArg& arg3,
 		       const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,const RooCmdArg& arg7,const RooCmdArg& arg8)  :
   RooAbsData(name,title,RooArgSet(vars,(RooAbsArg*)RooCmdConfig::decodeObjOnTheFly("RooDataSet::RooDataSet", "IndexCat",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)))
 {
@@ -628,7 +628,7 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooA
 /// Constructor of an empty data set from a RooArgSet defining the dimensions
 /// of the data space.
 
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName) :
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
 //   cout << "RooDataSet::ctor(" << this << ") storageType = " << ((defaultStorageType==Tree)?"Tree":"Vector") << endl ;
@@ -660,7 +660,7 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, const RooA
 /// subset of an existing data
 ///
 
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet *dset, 
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset,
 		       const RooArgSet& vars, const char *cuts, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -701,7 +701,7 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet
 /// uses this constructor, is the most convenient way to create a
 /// subset of an existing data
 
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet *dset, 
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset,
 		       const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -741,7 +741,7 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet
 /// operating exclusively and directly on the data set dimensions, the equivalent
 /// constructor with a string based cut expression is recommended.
 
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, TTree *theTree,
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, TTree *theTree,
     const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -789,7 +789,7 @@ RooDataSet::RooDataSet(std::string_view name, std::string_view title, TTree *the
 /// If other expressions are needed, such as intermediate formula objects, use
 /// RooDataSet::RooDataSet(const char*,const char*,TTree*,const RooArgSet&,const RooFormulaVar&,const char*)
 /// \param[in] wgtVarName Name of the variable in `vars` that represents an event weight.
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, TTree* theTree,
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, TTree* theTree,
     const RooArgSet& vars, const char* cuts, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
@@ -830,7 +830,7 @@ RooDataSet::RooDataSet(RooDataSet const & other, const char* newname) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Protected constructor for internal use only
 
-RooDataSet::RooDataSet(std::string_view name, std::string_view title, RooDataSet *dset, 
+RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset,
 		       const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 		       std::size_t nStart, std::size_t nStop, Bool_t copyCache, const char* wgtVarName) :
   RooAbsData(name,title,vars)

--- a/roofit/roofitcore/src/RooGenFitStudy.cxx
+++ b/roofit/roofitcore/src/RooGenFitStudy.cxx
@@ -108,7 +108,7 @@ Bool_t RooGenFitStudy::attach(RooWorkspace& w)
     ret = kTRUE ;
   }
 
-  _genObs.add(w.argSet(_genObsName.c_str())) ;
+  _genObs.add(w.argSet(_genObsName)) ;
   if (_genObs.getSize()==0) {
     coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: no generator observables defined" << endl ;
     ret = kTRUE ;
@@ -122,7 +122,7 @@ Bool_t RooGenFitStudy::attach(RooWorkspace& w)
     ret = kTRUE ;
   }
 
-  _fitObs.add(w.argSet(_fitObsName.c_str())) ;
+  _fitObs.add(w.argSet(_fitObsName)) ;
   if (_fitObs.getSize()==0) {
     coutE(InputArguments) << "RooGenFitStudy(" << GetName() << ") ERROR: no fitting observables defined" << endl ;
     ret = kTRUE ;

--- a/roofit/roofitcore/src/RooSimWSTool.cxx
+++ b/roofit/roofitcore/src/RooSimWSTool.cxx
@@ -214,7 +214,7 @@ RooSimWSTool::ObjBuildConfig* RooSimWSTool::validateConfig(BuildConfig& bc)
   ObjBuildConfig* obc = new ObjBuildConfig ;
 
   if (bc._masterCatName.length()>0) {
-    obc->_masterCat = _ws->cat(bc._masterCatName.c_str()) ;
+    obc->_masterCat = _ws->cat(bc._masterCatName) ;
     if (!obc->_masterCat) {
       coutE(ObjectHandling) << "RooSimWSTool::build(" << GetName() << ") ERROR: associated workspace " << _ws->GetName() 
 			    << " does not contain a category named " << bc._masterCatName 
@@ -249,7 +249,7 @@ RooSimWSTool::ObjBuildConfig* RooSimWSTool::validateConfig(BuildConfig& bc)
     for (pariter=sr._paramSplitMap.begin() ; pariter!=sr._paramSplitMap.end() ; ++pariter) {
       
       // Check that variable with given name exists in workspace
-      RooAbsArg* farg = _ws->fundArg(pariter->first.c_str()) ;
+      RooAbsArg* farg = _ws->fundArg(pariter->first) ;
       if (!farg) {
 	coutE(ObjectHandling) << "RooSimWSTool::build(" << GetName() << ") ERROR: associated workspace " << _ws->GetName() 
 			      << " does not contain a variable named " << pariter->first.c_str() 
@@ -357,7 +357,7 @@ RooSimWSTool::ObjBuildConfig* RooSimWSTool::validateConfig(BuildConfig& bc)
   // Check validity of build restriction specifications, if any
   map<string,string>::iterator riter ;
   for (riter=bc._restr.begin() ; riter!=bc._restr.end() ; ++riter) {
-    RooCategory* cat = _ws->cat(riter->first.c_str()) ;
+    RooCategory* cat = _ws->cat(riter->first) ;
     if (!cat) {
       coutE(ObjectHandling) << "RooSimWSTool::build(" << GetName() << ") ERROR: associated workspace " << _ws->GetName() 
 			    << " does not contain a category named " << riter->first

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -107,7 +107,7 @@ RooTreeDataStore::RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -128,7 +128,7 @@ RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -149,7 +149,7 @@ RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, TTree& t, const char* selExpr, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -177,7 +177,7 @@ RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -198,7 +198,7 @@ RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const RooAbsDataStore& ads, const char* selExpr, const char* wgtVarName) :
+RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& ads, const char* selExpr, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _tree(0),
   _cacheTree(0),
@@ -227,7 +227,7 @@ RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds,
+RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
 			 const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 			 Int_t nStart, Int_t nStop, Bool_t /*copyCache*/, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)), _defCtor(kFALSE),
@@ -412,10 +412,10 @@ void RooTreeDataStore::initialize()
 /// Create TTree object that lives in memory, independent of current
 /// location of gDirectory
 
-void RooTreeDataStore::createTree(std::string_view name, std::string_view title)
+void RooTreeDataStore::createTree(RooStringView name, RooStringView title)
 {
   if (!_tree) {
-    _tree = new TTree(TString{name},TString{title});
+    _tree = new TTree(name,title);
     _tree->ResetBit(kCanDelete);
     _tree->ResetBit(kMustCleanup);
     _tree->SetDirectory(nullptr);
@@ -433,7 +433,7 @@ void RooTreeDataStore::createTree(std::string_view name, std::string_view title)
   }
 
   if (!_cacheTree) {
-    _cacheTree = new TTree(TString{name} + "_cacheTree", TString{title});
+    _cacheTree = new TTree(TString{static_cast<const char*>(name)} + "_cacheTree", TString{static_cast<const char*>(title)});
     _cacheTree->SetDirectory(0) ;
     gDirectory->RecursiveRemove(_cacheTree) ;
   }

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -77,7 +77,7 @@ RooVectorDataStore::RooVectorDataStore() :
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooVectorDataStore::RooVectorDataStore(std::string_view name, std::string_view title, const RooArgSet& vars, const char* wgtVarName) :
+RooVectorDataStore::RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _varsww(vars),
   _wgtVar(weightVar(vars,wgtVarName)),
@@ -287,7 +287,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const Ro
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooVectorDataStore::RooVectorDataStore(std::string_view name, std::string_view title, RooAbsDataStore& tds, 
+RooVectorDataStore::RooVectorDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
 			 const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
 			 std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName) :
 

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1264,7 +1264,7 @@ const RooArgSet* RooWorkspace::getSnapshot(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve p.d.f (RooAbsPdf) with given name. A null pointer is returned if not found
 
-RooAbsPdf* RooWorkspace::pdf(const char* name) const
+RooAbsPdf* RooWorkspace::pdf(RooStringView name) const
 {
   return dynamic_cast<RooAbsPdf*>(_allOwnedNodes.find(name)) ;
 }
@@ -1273,7 +1273,7 @@ RooAbsPdf* RooWorkspace::pdf(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve function (RooAbsReal) with given name. Note that all RooAbsPdfs are also RooAbsReals. A null pointer is returned if not found.
 
-RooAbsReal* RooWorkspace::function(const char* name) const
+RooAbsReal* RooWorkspace::function(RooStringView name) const
 {
   return dynamic_cast<RooAbsReal*>(_allOwnedNodes.find(name)) ;
 }
@@ -1282,7 +1282,7 @@ RooAbsReal* RooWorkspace::function(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve real-valued variable (RooRealVar) with given name. A null pointer is returned if not found
 
-RooRealVar* RooWorkspace::var(const char* name) const
+RooRealVar* RooWorkspace::var(RooStringView name) const
 {
   return dynamic_cast<RooRealVar*>(_allOwnedNodes.find(name)) ;
 }
@@ -1291,7 +1291,7 @@ RooRealVar* RooWorkspace::var(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve discrete variable (RooCategory) with given name. A null pointer is returned if not found
 
-RooCategory* RooWorkspace::cat(const char* name) const
+RooCategory* RooWorkspace::cat(RooStringView name) const
 {
   return dynamic_cast<RooCategory*>(_allOwnedNodes.find(name)) ;
 }
@@ -1300,7 +1300,7 @@ RooCategory* RooWorkspace::cat(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve discrete function (RooAbsCategory) with given name. A null pointer is returned if not found
 
-RooAbsCategory* RooWorkspace::catfunc(const char* name) const
+RooAbsCategory* RooWorkspace::catfunc(RooStringView name) const
 {
   return dynamic_cast<RooAbsCategory*>(_allOwnedNodes.find(name)) ;
 }
@@ -1310,7 +1310,7 @@ RooAbsCategory* RooWorkspace::catfunc(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return RooAbsArg with given name. A null pointer is returned if none is found.
 
-RooAbsArg* RooWorkspace::arg(const char* name) const
+RooAbsArg* RooWorkspace::arg(RooStringView name) const
 {
   return _allOwnedNodes.find(name) ;
 }
@@ -1320,7 +1320,7 @@ RooAbsArg* RooWorkspace::arg(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return set of RooAbsArgs matching to given list of names
 
-RooArgSet RooWorkspace::argSet(const char* nameList) const
+RooArgSet RooWorkspace::argSet(RooStringView nameList) const
 {
   RooArgSet ret ;
 
@@ -1341,7 +1341,7 @@ RooArgSet RooWorkspace::argSet(const char* nameList) const
 /// Return fundamental (i.e. non-derived) RooAbsArg with given name. Fundamental types
 /// are e.g. RooRealVar, RooCategory. A null pointer is returned if none is found.
 
-RooAbsArg* RooWorkspace::fundArg(const char* name) const
+RooAbsArg* RooWorkspace::fundArg(RooStringView name) const
 {
   RooAbsArg* tmp = arg(name) ;
   if (!tmp) {
@@ -1355,7 +1355,7 @@ RooAbsArg* RooWorkspace::fundArg(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve dataset (binned or unbinned) with given name. A null pointer is returned if not found
 
-RooAbsData* RooWorkspace::data(const char* name) const
+RooAbsData* RooWorkspace::data(RooStringView name) const
 {
   return (RooAbsData*)_dataList.FindObject(name) ;
 }
@@ -1364,7 +1364,7 @@ RooAbsData* RooWorkspace::data(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieve dataset (binned or unbinned) with given name. A null pointer is returned if not found
 
-RooAbsData* RooWorkspace::embeddedData(const char* name) const
+RooAbsData* RooWorkspace::embeddedData(RooStringView name) const
 {
   return (RooAbsData*)_embeddedDataList.FindObject(name) ;
 }
@@ -2093,7 +2093,7 @@ void RooWorkspace::clearStudies()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return any type of object (RooAbsArg, RooAbsData or generic object) with given name)
 
-TObject* RooWorkspace::obj(const char* name) const
+TObject* RooWorkspace::obj(RooStringView name) const
 {
   // Try RooAbsArg first
   TObject* ret = arg(name) ;
@@ -2112,7 +2112,7 @@ TObject* RooWorkspace::obj(const char* name) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Return generic object with given name
 
-TObject* RooWorkspace::genobj(const char* name)  const
+TObject* RooWorkspace::genobj(RooStringView name)  const
 {
   // Find object by name
   TObject* gobj = _genObjects.FindObject(name) ;

--- a/roofit/roofitcore/test/testGlobalObservables.cxx
+++ b/roofit/roofitcore/test/testGlobalObservables.cxx
@@ -103,7 +103,7 @@ public:
       std::vector<std::string> names{"x", "m", "s", "gm", "gs"};
       std::vector<double> values{0.0, 10.0, 2.0, 11.0, 1.0};
       for (std::size_t i = 0; i < names.size(); ++i) {
-         auto *var = _workspace->var(names[i].c_str());
+         auto *var = _workspace->var(names[i]);
          var->setVal(values[i]);
          var->setError(0.0);
       }

--- a/roofit/roostats/src/NumberCountingPdfFactory.cxx
+++ b/roofit/roostats/src/NumberCountingPdfFactory.cxx
@@ -272,8 +272,8 @@ void NumberCountingPdfFactory::AddData(Double_t* mainMeas,
       tree->Branch(("x"+str.str()).c_str(), &xForTree[i] ,("x"+str.str()+"/D").c_str());
       tree->Branch(("y"+str.str()).c_str(), &yForTree[i] ,("y"+str.str()+"/D").c_str());
 
-      ws->var(("b"+str.str()).c_str())->setMax( 1.2*back[i]+MaxSigma*(sqrt(back[i])+back[i]*back_syst[i]) );
-      ws->var(("b"+str.str()).c_str())->setVal( back[i] );
+      ws->var("b"+str.str())->setMax( 1.2*back[i]+MaxSigma*(sqrt(back[i])+back[i]*back_syst[i]) );
+      ws->var("b"+str.str())->setVal( back[i] );
 
    }
    tree->Fill();
@@ -355,8 +355,8 @@ void NumberCountingPdfFactory::AddDataWithSideband(Double_t* mainMeas,
       tree->Branch(("x"+str.str()).c_str(), &xForTree[i] ,("x"+str.str()+"/D").c_str());
       tree->Branch(("y"+str.str()).c_str(), &yForTree[i] ,("y"+str.str()+"/D").c_str());
 
-      ws->var(("b"+str.str()).c_str())->setMax(  1.2*back+MaxSigma*(sqrt(back)+back*back_syst) );
-      ws->var(("b"+str.str()).c_str())->setVal( back );
+      ws->var("b"+str.str())->setMax(  1.2*back+MaxSigma*(sqrt(back)+back*back_syst) );
+      ws->var("b"+str.str())->setVal( back );
 
    }
    tree->Fill();


### PR DESCRIPTION
A new `RooStringView` is introduced as a copy-free drop-in replacement for `const char*` in public RooFit interfaces, which also accepts a `std::string`.

So far, this new `RooStringView` is used in the RooWorkspace accessors,  and also in the dataset classes as it's a superior solution over using `std::string` view, which is not guaranteed to be null-terminated and needs specific preprocessor macros for the C++ case.