### PR TITLE
[v626][RF] Backports of RooFit PRs to `v6-26-00-patches`: Part 5

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -17,6 +17,7 @@ The following people have contributed to this new version:
  Jakob Blomer, CERN/SFT,\
  Patrick Bos, Netherlands eScience Center,\
  Rene Brun, CERN/SFT,\
+ Carsten D. Burgard, DESY/ATLAS,\ 
  Will Buttinger, STFC/ATLAS,\
  Philippe Canal, FNAL,\
  Olivier Couet, CERN/SFT,\
@@ -232,6 +233,22 @@ Two new classes to help to provide this functionality:
 For example usage of the RooLagrangianMorphFunc class, please consult the tutorials for a single parameter case ([rf711_lagrangianmorph.C](https://root.cern.ch/doc/v626/rf711__lagrangianmorph_8C.html) / [.py](https://root.cern.ch/doc/v626/rf711__lagrangianmorph_8py.html)) and for a multi-parameter case ([rf712_lagrangianmorphfit.C](https://root.cern.ch/doc/v626/rf712__lagrangianmorphfit_8C.html) / [.py](https://root.cern.ch/doc/v626/rf712__lagrangianmorphfit_8py.html)).
 
 A `RooLagrangianMorphFunc` can also be created with the `RooWorkspace::factory` interface, showcased in [rf512_wsfactory_oper.C](https://root.cern.ch/doc/v626/rf512__wsfactory__oper_8C.html) / [.py](https://root.cern.ch/doc/master/rf512__wsfactory__oper_8py.html).
+
+### Exporting and importing `RooWorkspace` to and from JSON and YML
+
+The new component `RooFitHS3` implements serialization and
+deserialization of `RooWorkspace` objects to and from JSON and YML.
+The main class providing this functionality is
+[RooJSONFactoryWSTool](https://root.cern/doc/v626/classRooJSONFactoryWSTool.html).
+For now, this functionality is not feature complete with respect to
+all available functions and pdfs available in `RooFit`, but provides
+an interface that is easily extensible by users, which is documented
+in the corresponding
+[README](https://github.com/root-project/root/blob/master/roofit/hs3/README.md). It
+is hoped that, though user contributions, a sufficiently comprehensive
+library of serializers and deserializers will emerge over time.
+
+For more details, consult the tutorial [rf515_hfJSON](https://root.cern/doc/v626/rf515__hfJSON_8py.html).
 
 ### Creating RooFit datasets from RDataFrame
 RooFit now contains two RDataFrame action helpers, `RooDataSetHelper` and `RooDataHistHelper`, which allow for creating RooFit datasets by booking an action:

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/__init__.py
@@ -46,6 +46,7 @@ from ._rooglobalfunc import (
     FillStyle,
     MarkerStyle,
 )
+from ._roojsonfactorywstool import RooJSONFactoryWSTool
 from ._roomcstudy import RooMCStudy
 from ._roomsgservice import RooMsgService
 from ._roonllvar import RooNLLVar
@@ -76,6 +77,7 @@ python_classes = [
     RooDataSet,
     RooDecay,
     RooGenFitStudy,
+    RooJSONFactoryWSTool,
     RooMCStudy,
     RooMsgService,
     RooNLLVar,

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roojsonfactorywstool.py
@@ -1,0 +1,14 @@
+# Authors:
+# * Jonas Rembser 01/2022
+
+################################################################################
+# Copyright (C) 1995-2020, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+
+class RooJSONFactoryWSTool(object):
+    pass

--- a/roofit/hs3/README.md
+++ b/roofit/hs3/README.md
@@ -1,0 +1,206 @@
+## RooFitHS3 Library
+_Contains facilities to serialize and deserialize RooWorkspaces to and from JSON and YML._
+#### Note: This library is still at an experimental stage.
+
+### Purpose
+
+When using `RooFit`, statistical models can be conveniently handled and
+stored as a `RooWorkspace`. However, for the sake of interoperability
+with other statistical frameworks, and also ease of manipulation, it
+may be useful to store statistical models in text form. This library
+sets out to achieve exactly that, exporting to and importing from JSON
+and YML.
+
+### Backend
+
+The default backend for this is the `nlohmann` JSON implementation,
+which ships with ROOT as a builtin dependency and will import from and
+export to JSON. Alternatively, the RapidYAML (`RYML`) implementation
+can be used to also import from and export to YML. This implementation
+can be selected at compile time with the `cmake` flag
+`roofit_hs3_ryml`.
+
+### Usage
+
+The main class providing import from and export to JSON and YML is the
+`RooJSONFactoryWSTool`. For basic usage, please refer to the
+[class documentation](https://root.cern.ch/doc/master/RooJSONFactoryWSTool_8h.html).
+
+### Open-world philosophy
+
+One of the most challenging aspects of providing serialization and
+deserialization for `RooFit` is the fact that `RooFit` follows an
+"open-world" philosophy with respect to the functions and pdfs it can
+handle. Over the years, `RooFit` has also accumulated a significant
+number of different pre-implemented functions and pdfs. What is more,
+you can easily create your own `RooFit` function by inheriting from
+`RooAbsReal` or your own `RooFit` pdf by inheriting from
+`RooAbsPdf`. This means that feature-complete serialization and
+deserialization to and from JSON and YML will probably never be fully
+achieved. However, this may not impede your usage of this library, as
+it was written in such a way as to allow users (that is, people like
+you) to easily add missing importers and exporters for existing
+`RooFit` classes as well as custom implementations you might be using.
+
+### Native and proxy-based importers and exporters
+
+`RooFitHS3` allows to different types of importers and exporters:
+*Native* implementations, and *proxy-based* ones.  If for a certain
+class several implementations are provided, the native
+implementation(s) take precedence.
+
+### Writing your own importers and exporters: Proxy-based
+
+Proxy-based implementations can be added very easily and without
+actually writing any `C++` code -- you only need to add a short item
+to a list in a `JSON` file, namely the
+[export keys](https://github.com/root-project/root/blob/master/etc/RooFitHS3_wsexportkeys.json)
+for an exporter, or the
+[factory expressions](https://github.com/root-project/root/blob/master/etc/RooFitHS3_wsfactoryexpressions.json)
+for an importer.
+
+This works in the following way: Every `RooFit` class performs
+dependency tracking via proxies, which have names. This can be
+exploited to perform the mapping of proxy names to `json` keys upon
+export. In the other direction, the `RooWorkspace` has a factory
+interface that allows to call any constructor via a string
+interface. Hence:
+ - If a `RooFit` class has no other members aside from proxies, it can
+   be exported using a set of `export keys`.
+ - If all relevant members to a `RooFit` class are passed as
+   constructor arguments, it can be imported using a `factory
+   expression`.
+
+For the importer, an entry in the
+[factory expressions](https://github.com/root-project/root/blob/master/etc/RooFitHS3_wsfactoryexpressions.json)
+needs to be added as follows:
+
+    "<json-key>": {
+        "class": "<C++ class name>",
+        "arguments": [
+            "<json-key of constructor argument #1>",
+            "<json-key of constructor argument #2>",
+             ...
+        ]
+    }
+
+Similarly, for the exporter, an entry in the
+[export keys](https://github.com/root-project/root/blob/master/etc/RooFitHS3_wsexportkeys.json)
+needs to be added as follows:
+
+    "<C++ class name>": {
+        "type": "<json-key>",
+        "proxies": {
+            "<name of proxy>": "<json-key of this element>",
+            "<name of proxy>": "<json-key of this element>",
+            ...
+        }
+    }
+
+
+If you don't want to edit the central `json` files containing the
+factory expressions or export keys, you can also put your custom
+export keys or factory expressions into a different json file and load
+that using `RooJSONFactoryWSTool::loadExportKeys(const std::string
+&fname)` and `RooJSONFactoryWSTool::loadFactoryExpressions(const
+std::string &fname)`.
+
+If either the importer or the exporter cannot be created with factory
+expressions and export keys, you can instead write a custom `C++`
+class to perform the import and export for you.
+
+### Writing your own importers and exporters: Custom `C++` code
+
+In order to implement your own importer or exporter, you can inherit
+from the corresponding base classes `RooJSONFactoryWSTool::Importer`
+or `RooJSONFactoryWSTool::Exporter`, respectively. You can find
+[simple examples](https://github.com/root-project/root/blob/master/roofit/hs3/src/JSONFactories_RooFitCore.cxx)
+as well as
+[more complicated ones](https://github.com/root-project/root/blob/master/roofit/hs3/src/JSONFactories_HistFactory.cxx)
+in `ROOT`.
+
+Any importer should take the following form:
+
+    class MyClassFactory : public RooJSONFactoryWSTool::Importer {
+    public:
+       bool importFunction(RooJSONFactoryWSTool *tool, const JSONNode &p) const override
+       {
+          std::string name(RooJSONFactoryWSTool::name(p));
+
+          // check if the required keys are available in the JSON
+          if (!p.has_child("<class member key #1>")) {
+             RooJSONFactoryWSTool::error("missing key '<class member key #1>' of '" + name + "'");
+          }
+          if (!p.has_child("<class member key #2>")) {
+             RooJSONFactoryWSTool::error("missing key '<class member key #2>' of '" + name + "'");
+          }
+
+          std::string member1(p["<class member key #1>"].val());
+          int member2(p["<class member key #2>"].val_int());
+
+          MyClass theobj(name.c_str(), member1, member2);
+          tool->workspace()->import(theobj, RooFit::RecycleConflictNodes(true), RooFit::Silence(true));
+          return true;
+       }
+    };
+
+If the class you are trying to import inherits from `RooAbsPdf` rather
+than from `RooAbsReal`, you should define `importPdf` instead of
+`importFunction`, with the same signature.
+
+Once your importer implementation exists, you need to register it with the tool using a line like the following:
+
+    RooJSONFactoryWSTool::registerImporter("<json key>", new MyClassFactory(), true);
+
+As there can be several importers for the same `json` key, the last
+(boolean) argument determines whether your new importer should be
+added at the top of the priority list (`true`) or at the bottom
+(`false`). If the import fails, other importers are attempted.
+
+The implementation of an exporter works in a very similar fashion:
+
+    class MyClassStreamer : public RooJSONFactoryWSTool::Exporter {
+    public:
+       std::string const &key() const override
+       {
+          const static std::string keystring = "<json key>";
+          return keystring;
+       }
+       bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
+       {
+          const MyClass *theObj = static_cast<const MyClass *>(func);
+          elem["type"] << key();
+
+          auto &member1 = elem["<class member key #1>"];
+          member1 << theObj->getMember1();
+
+          auto &member2 = elem["<class member key #2>"];
+          member2 << theObj->getMember2();
+
+          return true;
+       }
+    };
+
+Also this needs to be registered with the tool
+
+    RooJSONFactoryWSTool::registerExporter(MyClass::Class(), new MyClassStreamer(), true);
+
+For more complicated cases where members are lists of elements, the
+methods `is_seq()`, `set_seq()`, `is_map()`, `set_map()` and
+ranged-based for-loops via `children()` might come in handy.
+
+### Contributing
+
+If you encounter a missing importer or exporter, please consider
+filing a feature request via the
+[issue tracker](https://github.com/root-project/root/issues/new?assignees=&labels=new+feature&template=feature_request.md).
+
+If you don't want to wait for one of the dev's to pick up your request
+an process it, you can use the above instructions to write your own.
+If you wrote an importer or exporter for a `RooFit` class that is part
+of `ROOT`, either via `export keys` and `factory expressions`, or via
+native `C++` classes, please consider contributing your implementation
+to `ROOT` such that it can help other users also missing this importer
+or exporter. You can fork `ROOT`, commit your changes, and file a pull
+request to `ROOT` for your work to be included in the next release!
+

--- a/roofit/hs3/inc/RooFitHS3/JSONInterface.h
+++ b/roofit/hs3/inc/RooFitHS3/JSONInterface.h
@@ -17,6 +17,7 @@ public:
    public:
       class Impl {
       public:
+         virtual ~Impl() = default;
          virtual std::unique_ptr<Impl> clone() const = 0;
          virtual void forward() = 0;
          virtual void backward() = 0;

--- a/roofit/hs3/src/JSONInterface.cxx
+++ b/roofit/hs3/src/JSONInterface.cxx
@@ -2,21 +2,21 @@
 
 namespace {
 template <class Nd>
-class childItImpl : public RooFit::Experimental::JSONNode::child_iterator_t<Nd>::Impl {
+class ChildItImpl final : public RooFit::Experimental::JSONNode::child_iterator_t<Nd>::Impl {
 public:
    using child_iterator = RooFit::Experimental::JSONNode::child_iterator_t<Nd>;
-   childItImpl(Nd &n, size_t p) : node(n), pos(p) {}
-   childItImpl(const childItImpl &other) : node(other.node), pos(other.pos) {}
+   ChildItImpl(Nd &n, size_t p) : node(n), pos(p) {}
+   ChildItImpl(const ChildItImpl &other) : node(other.node), pos(other.pos) {}
    virtual std::unique_ptr<typename child_iterator::Impl> clone() const override
    {
-      return std::make_unique<childItImpl>(node, pos);
+      return std::make_unique<ChildItImpl>(node, pos);
    }
    virtual void forward() override { ++pos; }
    virtual void backward() override { --pos; }
    virtual Nd &current() override { return node.child(pos); }
    virtual bool equal(const typename child_iterator::Impl &other) const override
    {
-      auto it = dynamic_cast<const childItImpl<Nd> *>(&other);
+      auto it = dynamic_cast<const ChildItImpl<Nd> *>(&other);
       return it && &(it->node) == &(this->node) && (it->pos) == this->pos;
    }
 
@@ -34,13 +34,13 @@ template class JSONNode::child_iterator_t<const JSONNode>;
 
 JSONNode::children_view JSONNode::children()
 {
-   return {child_iterator(std::make_unique<::childItImpl<JSONNode>>(*this, 0)),
-           child_iterator(std::make_unique<::childItImpl<JSONNode>>(*this, this->num_children()))};
+   return {child_iterator(std::make_unique<::ChildItImpl<JSONNode>>(*this, 0)),
+           child_iterator(std::make_unique<::ChildItImpl<JSONNode>>(*this, this->num_children()))};
 }
 JSONNode::const_children_view JSONNode::children() const
 {
-   return {const_child_iterator(std::make_unique<::childItImpl<const JSONNode>>(*this, 0)),
-           const_child_iterator(std::make_unique<::childItImpl<const JSONNode>>(*this, this->num_children()))};
+   return {const_child_iterator(std::make_unique<::ChildItImpl<const JSONNode>>(*this, 0)),
+           const_child_iterator(std::make_unique<::ChildItImpl<const JSONNode>>(*this, this->num_children()))};
 }
 
 std::ostream &operator<<(std::ostream &os, JSONNode const &s)

--- a/roofit/hs3/src/JSONParser.cxx
+++ b/roofit/hs3/src/JSONParser.cxx
@@ -325,17 +325,17 @@ using json_iterator = nlohmann::basic_json<>::iterator;
 using const_json_iterator = nlohmann::basic_json<>::const_iterator;
 
 template <class Nd, class NdType, class json_it>
-class TJSONTree::Node::childItImpl : public RooFit::Experimental::JSONNode::child_iterator_t<Nd>::Impl {
+class TJSONTree::Node::ChildItImpl final : public RooFit::Experimental::JSONNode::child_iterator_t<Nd>::Impl {
 public:
    enum class POS { BEGIN, END };
-   childItImpl(NdType &n, POS p)
+   ChildItImpl(NdType &n, POS p)
       : node(n), iter(p == POS::BEGIN ? n.get_node().get().begin() : n.get_node().get().end()){};
-   childItImpl(NdType &n, json_it it) : node(n), iter(it) {}
-   childItImpl(const childItImpl &other) : node(other.node), iter(other.iter) {}
+   ChildItImpl(NdType &n, json_it it) : node(n), iter(it) {}
+   ChildItImpl(const ChildItImpl &other) : node(other.node), iter(other.iter) {}
    using child_iterator = RooFit::Experimental::JSONNode::child_iterator_t<Nd>;
    virtual std::unique_ptr<typename child_iterator::Impl> clone() const override
    {
-      return std::make_unique<childItImpl>(node, iter);
+      return std::make_unique<ChildItImpl>(node, iter);
    }
    virtual void forward() override { ++iter; }
    virtual void backward() override { --iter; }
@@ -349,7 +349,7 @@ public:
    }
    virtual bool equal(const typename child_iterator::Impl &other) const override
    {
-      auto it = dynamic_cast<const childItImpl<Nd, NdType, json_it> *>(&other);
+      auto it = dynamic_cast<const ChildItImpl<Nd, NdType, json_it> *>(&other);
       return it && it->iter == this->iter;
    }
 
@@ -360,14 +360,14 @@ private:
 
 RooFit::Experimental::JSONNode::children_view TJSONTree::Node::children()
 {
-   using childIt = TJSONTree::Node::childItImpl<RooFit::Experimental::JSONNode, TJSONTree::Node, json_iterator>;
+   using childIt = TJSONTree::Node::ChildItImpl<RooFit::Experimental::JSONNode, TJSONTree::Node, json_iterator>;
    return {child_iterator(std::make_unique<childIt>(*this, childIt::POS::BEGIN)),
            child_iterator(std::make_unique<childIt>(*this, childIt::POS::END))};
 }
 RooFit::Experimental::JSONNode::const_children_view TJSONTree::Node::children() const
 {
    using childConstIt =
-      TJSONTree::Node::childItImpl<const RooFit::Experimental::JSONNode, const TJSONTree::Node, const_json_iterator>;
+      TJSONTree::Node::ChildItImpl<const RooFit::Experimental::JSONNode, const TJSONTree::Node, const_json_iterator>;
    return {const_child_iterator(std::make_unique<childConstIt>(*this, childConstIt::POS::BEGIN)),
            const_child_iterator(std::make_unique<childConstIt>(*this, childConstIt::POS::END))};
 }

--- a/roofit/hs3/src/JSONParser.h
+++ b/roofit/hs3/src/JSONParser.h
@@ -14,7 +14,7 @@ public:
       TJSONTree *tree;
       class Impl;
       template <class Nd, class NdType, class json_it>
-      class childItImpl;
+      class ChildItImpl;
       friend TJSONTree;
       std::unique_ptr<Impl> node;
 

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -30,6 +30,50 @@ typedef TJSONTree tree_t;
 #include <stack>
 #include <stdexcept>
 
+
+/** \class RooJSONFactoryWSTool
+\ingroup roofit
+
+When using `RooFit`, statistical models can be conveniently handled and
+stored as a `RooWorkspace`. However, for the sake of interoperability
+with other statistical frameworks, and also ease of manipulation, it
+may be useful to store statistical models in text form.
+
+The RooJSONFactoryWSTool is a helper class to achieve exactly this,
+exporting to and importing from JSON and YML.
+
+In order to import a workspace from a JSON file, you can do
+
+~~~ {.py}
+ws = ROOT.RooWorkspace("ws")
+tool = ROOT.RooJSONFactoryWSTool(ws)
+tool.importJSON("myjson.json")
+~~~
+
+Similarly, in order to export a workspace to a JSON file, you can do
+
+~~~ {.py}
+tool = ROOT.RooJSONFactoryWSTool(ws)
+tool.exportJSON("myjson.json")
+~~~
+
+For more details, consult the tutorial <a
+href="https://root.cern/doc/v626/rf515__hfJSON_8py.html">rf515_hfJSON</a>.
+
+In order to import and export YML files, `ROOT` needs to be compiled
+with the external dependency <a
+href="https://github.com/biojppm/rapidyaml">RapidYAML</a>, which needs
+to be installed on your system and enabled via the CMake option
+`roofit_hs3_ryml`.
+
+The RooJSONFactoryWSTool only knows about a limited set of classes for
+import and export. If import or export of a class you're interested in
+fails, you might need to add your own importer or exporter. Please
+consult the <a
+href="https://github.com/root-project/root/blob/master/roofit/hs3/README.md">README</a>
+to learn how to do that.  ~~~
+*/
+
 using RooFit::Experimental::JSONNode;
 
 namespace {
@@ -771,7 +815,7 @@ void RooJSONFactoryWSTool::exportObject(const RooAbsArg *func, JSONNode &n)
          std::cerr << " 3: you are reading a file with export keys - call RooJSONFactoryWSTool::printExportKeys() to "
                       "see what is available"
                    << std::endl;
-         std::cerr << " 2 & 1: you might need to write a serialization definition yourself. check INSERTLINKHERE to "
+         std::cerr << " 2 & 1: you might need to write a serialization definition yourself. check https://github.com/root-project/root/blob/master/roofit/hs3/README.md to "
                       "see how to do this!"
                    << std::endl;
          return;
@@ -905,7 +949,7 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool isPdf)
             }
          } else {
             std::stringstream ss;
-            ss << "RooJSONFactoryWSTool() no handling for functype '" << functype << "' implemented, skipping."
+            ss << "RooJSONFactoryWSTool() no handling for type '" << functype << "' implemented, skipping."
                << "\n"
                << "there are several possible reasons for this:\n"
                << " 1. " << functype << " is a custom type that is not available in RooFit.\n"
@@ -915,9 +959,9 @@ void RooJSONFactoryWSTool::importFunction(const JSONNode &p, bool isPdf)
                   "RooJSONFactoryWSTool::clearFactoryExpressions() and/or never successfully read a file defining "
                   "these expressions with RooJSONFactoryWSTool::loadFactoryExpressions(filename)\n"
                << "either way, please make sure that:\n"
-               << " 3: you are reading a file with export keys - call RooJSONFactoryWSTool::printFactoryExpressions() "
+               << " 3: you are reading a file with factory expressions - call RooJSONFactoryWSTool::printFactoryExpressions() "
                   "to see what is available\n"
-               << " 2 & 1: you might need to write a serialization definition yourself. check INSERTLINKHERE to see "
+               << " 2 & 1: you might need to write a deserialization definition yourself. check https://github.com/root-project/root/blob/master/roofit/hs3/README.md to see "
                   "how to do this!"
                << std::endl;
             logInputArgumentsError(std::move(ss));

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1493,6 +1493,16 @@ void RooJSONFactoryWSTool::exportAllObjects(JSONNode &n)
                }
             }
          }
+         if (mc->GetGlobalObservables()) {
+            for (auto *np : *mc->GetGlobalObservables()) {
+               if (auto *v = dynamic_cast<RooRealVar *>(np)) {
+                  exportVariable(v, vars);
+                  auto &tags = vars[v->GetName()]["tags"];
+                  tags.set_seq();
+                  RooJSONFactoryWSTool::append(tags, "glob");
+               }
+            }
+         }
          mcs.push_back(mc);
       }
    }

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -495,8 +495,8 @@ std::vector<std::vector<int>> RooJSONFactoryWSTool::generateBinIndices(const Roo
    std::vector<std::vector<int>> combinations;
    std::vector<int> vars_numbins;
    vars_numbins.reserve(vars.size());
-   for (auto &absv : vars) {
-      vars_numbins.push_back(((RooRealVar *)absv)->numBins());
+   for (const auto *absv : static_range_cast<RooRealVar *>(vars)) {
+      vars_numbins.push_back(absv->numBins());
    }
    std::vector<int> curr_comb(vars.size());
    ::genIndicesHelper(combinations, curr_comb, vars_numbins, 0);


### PR DESCRIPTION
This is a backport of all the RooFit PRs that were merged to `master` edit to `v6-26-00-patches` (if the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/9683
2. https://github.com/root-project/root/pull/9734

I would have liked to collect more PRs, but the second one is urgently needed to fix a compiler warning.