### PR TITLE
[textinput] Enable Xterm-like movement between words, i.e. using Ctrl+{Left,Right}

### DIFF
--- a/core/textinput/src/textinput/KeyBinding.cpp
+++ b/core/textinput/src/textinput/KeyBinding.cpp
@@ -37,7 +37,8 @@ namespace textinput {
       return C(In.GetRaw());
     }
     // else
-    return ToCommandExtended(In.GetExtendedInput(), HadEscPending);
+    return ToCommandExtended(In.GetExtendedInput(), In.GetModifier(),
+                             HadEscPending);
   }
 
   Editor::Command
@@ -113,6 +114,7 @@ namespace textinput {
 
   Editor::Command
   KeyBinding::ToCommandExtended(InputData::EExtendedInput EI,
+                                unsigned char modifier,
                                 bool HadEscPending) {
     // Convert extended input into the corresponding Command.
     typedef Editor::Command C;
@@ -122,8 +124,12 @@ namespace textinput {
       case InputData::kEIEnd: return C(Editor::kMoveEnd);
       case InputData::kEIUp: return C(Editor::kCmdHistOlder);
       case InputData::kEIDown: return C(Editor::kCmdHistNewer);
-      case InputData::kEILeft: return C(Editor::kMoveLeft);
-      case InputData::kEIRight: return C(Editor::kMoveRight);
+      case InputData::kEILeft:
+        return (modifier & InputData::kModCtrl)
+               ? C(Editor::kMovePrevWord) : C(Editor::kMoveLeft);
+      case InputData::kEIRight:
+        return (modifier & InputData::kModCtrl)
+               ? C(Editor::kMoveNextWord) : C(Editor::kMoveRight);
       case InputData::kEIPgUp: return C(Editor::kCmdIgnore);
       case InputData::kEIPgDown: return C(Editor::kCmdIgnore);
       case InputData::kEIBackSpace:

--- a/core/textinput/src/textinput/KeyBinding.h
+++ b/core/textinput/src/textinput/KeyBinding.h
@@ -42,6 +42,7 @@ namespace textinput {
     Editor::Command ToCommandCtrl(char In, bool HadEscPending);
     Editor::Command ToCommandEsc(char In);
     Editor::Command ToCommandExtended(InputData::EExtendedInput EI,
+                                      unsigned char modifier,
                                       bool HadEscPending);
     bool fEscPending; // Dangling ESC is waiting to be processed
     bool fEscCmdEnabled; // Single ESC has a meaning


### PR DESCRIPTION
This pull-request enables fast word movement in the ROOT prompt à la Xterm (by using Ctrl+Left and Ctrl+Right).

Most users coming from a GUI (GTK+, Win32, etc.) will find this convenient, but also Archlinux users, given that the default `inputrc` file for GNU Readline provides these bindings (see https://wiki.archlinux.org/title/Readline#Fast_word_movement).

EDIT: it seems that `/etc/inputrc` in Fedora also provides this binding by default.  :-)

## Checklist:
- [X] tested changes locally