### PR TITLE
[DF] Add GraphAsymmErrors member (apply #8363)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -38,6 +38,7 @@
 #include "TFile.h" // for SnapshotHelper
 #include "TH1.h"
 #include "TGraph.h"
+#include "TGraphAsymmErrors.h"
 #include "TLeaf.h"
 #include "TObject.h"
 #include "TTree.h"
@@ -573,6 +574,104 @@ public:
    std::string GetActionName() { return "Graph"; }
 
    Result_t &PartialUpdate(unsigned int slot) { return *fGraphs[slot]; }
+};
+
+class FillTGraphAsymmErrorsHelper : public ROOT::Detail::RDF::RActionImpl<FillTGraphAsymmErrorsHelper> {
+public:
+   using Result_t = ::TGraphAsymmErrors;
+
+private:
+   std::vector<::TGraphAsymmErrors *> fGraphAsymmErrors;
+
+public:
+   FillTGraphAsymmErrorsHelper(FillTGraphAsymmErrorsHelper &&) = default;
+   FillTGraphAsymmErrorsHelper(const FillTGraphAsymmErrorsHelper &) = delete;
+
+   FillTGraphAsymmErrorsHelper(const std::shared_ptr<::TGraphAsymmErrors> &g, const unsigned int nSlots)
+      : fGraphAsymmErrors(nSlots, nullptr)
+   {
+      fGraphAsymmErrors[0] = g.get();
+      // Initialize all other slots
+      for (unsigned int i = 1; i < nSlots; ++i) {
+         fGraphAsymmErrors[i] = new TGraphAsymmErrors(*fGraphAsymmErrors[0]);
+      }
+   }
+
+   void Initialize() {}
+   void InitTask(TTreeReader *, unsigned int) {}
+
+   // case: all types are container types
+   template <
+      typename X, typename Y, typename EXL, typename EXH, typename EYL, typename EYH,
+      std::enable_if_t<IsDataContainer<X>::value && IsDataContainer<Y>::value && IsDataContainer<EXL>::value &&
+                          IsDataContainer<EXH>::value && IsDataContainer<EYL>::value && IsDataContainer<EYH>::value,
+                       int> = 0>
+   void
+   Exec(unsigned int slot, const X &xs, const Y &ys, const EXL &exls, const EXH &exhs, const EYL &eyls, const EYH &eyhs)
+   {
+      if ((xs.size() != ys.size()) || (xs.size() != exls.size()) || (xs.size() != exhs.size()) ||
+          (xs.size() != eyls.size()) || (xs.size() != eyhs.size())) {
+         throw std::runtime_error("Cannot fill GraphAsymmErrors with values in containers of different sizes.");
+      }
+      auto *thisSlotG = fGraphAsymmErrors[slot];
+      auto xsIt = std::begin(xs);
+      auto ysIt = std::begin(ys);
+      auto exlsIt = std::begin(exls);
+      auto exhsIt = std::begin(exhs);
+      auto eylsIt = std::begin(eyls);
+      auto eyhsIt = std::begin(eyhs);
+      while (xsIt != std::end(xs)) {
+         const auto n = thisSlotG->GetN(); // must use the same `n` for SetPoint and SetPointError
+         thisSlotG->SetPoint(n, *xsIt++, *ysIt++);
+         thisSlotG->SetPointError(n, *exlsIt++, *exhsIt++, *eylsIt++, *eyhsIt++);
+      }
+   }
+
+   // case: all types are non-container types, e.g. scalars
+   template <
+      typename X, typename Y, typename EXL, typename EXH, typename EYL, typename EYH,
+      std::enable_if_t<!IsDataContainer<X>::value && !IsDataContainer<Y>::value && !IsDataContainer<EXL>::value &&
+                          !IsDataContainer<EXH>::value && !IsDataContainer<EYL>::value && !IsDataContainer<EYH>::value,
+                       int> = 0>
+   void Exec(unsigned int slot, X x, Y y, EXL exl, EXH exh, EYL eyl, EYH eyh)
+   {
+      auto thisSlotG = fGraphAsymmErrors[slot];
+      const auto n = thisSlotG->GetN();
+      thisSlotG->SetPoint(n, x, y);
+      thisSlotG->SetPointError(n, exl, exh, eyl, eyh);
+   }
+
+   // case: types are combination of containers and non-containers
+   // this is not supported, error out
+   template <typename X, typename Y, typename EXL, typename EXH, typename EYL, typename EYH,
+             typename... ExtraArgsToLowerPriority>
+   void Exec(unsigned int, X, Y, EXL, EXH, EYL, EYH, ExtraArgsToLowerPriority...)
+   {
+      throw std::runtime_error(
+         "GraphAsymmErrors was applied to a mix of scalar values and collections. This is not supported.");
+   }
+
+   void Finalize()
+   {
+      const auto nSlots = fGraphAsymmErrors.size();
+      auto resGraphAsymmErrors = fGraphAsymmErrors[0];
+      TList l;
+      l.SetOwner(); // The list will free the memory associated to its elements upon destruction
+      for (unsigned int slot = 1; slot < nSlots; ++slot) {
+         l.Add(fGraphAsymmErrors[slot]);
+      }
+      resGraphAsymmErrors->Merge(&l);
+   }
+
+   // Helper functions for RMergeableValue
+   std::unique_ptr<RMergeableValueBase> GetMergeableValue() const final
+   {
+      return std::make_unique<RMergeableFill<Result_t>>(*fGraphAsymmErrors[0]);
+   }
+
+   std::string GetActionName() { return "GraphAsymmErrors"; }
+
+   Result_t &PartialUpdate(unsigned int slot) { return *fGraphAsymmErrors[slot]; }
 };
 
 // In case of the take helper we have 4 cases:

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -94,6 +94,7 @@ struct Histo2D{};
 struct Histo3D{};
 struct HistoND{};
 struct Graph{};
+struct GraphAsymmErrors{};
 struct Profile1D{};
 struct Profile2D{};
 struct Min{};
@@ -160,6 +161,16 @@ BuildAction(const ColumnNames_t &bl, const std::shared_ptr<TGraph> &g, const uns
             std::shared_ptr<PrevNodeType> prevNode, ActionTags::Graph, const RColumnRegister &colRegister)
 {
    using Helper_t = FillTGraphHelper;
+   using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
+   return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, std::move(prevNode), colRegister);
+}
+
+template <typename... ColTypes, typename PrevNodeType>
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<TGraphAsymmErrors> &g, const unsigned int nSlots,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::GraphAsymmErrors, const RColumnRegister &colRegister)
+{
+   using Helper_t = FillTGraphAsymmErrorsHelper;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
    return std::make_unique<Action_t>(Helper_t(g, nSlots), bl, std::move(prevNode), colRegister);
 }


### PR DESCRIPTION
# This Pull request:

Introduce GraphAsymmErrors member in ActionHelpers.hxx similar to Graph.
GraphAsymmErrors creates a TGraphAsymmErrors, hence 6 arguments need to
be passed to it.
Appropriate structures in InterfaceUtils.hxx and RInterface.hxx are added.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

