### PR TITLE
Emulated Collection Proxy always need the VectorLooper for the StreamerInfoActions

### DIFF
--- a/io/io/src/TStreamerInfoActions.cxx
+++ b/io/io/src/TStreamerInfoActions.cxx
@@ -1693,7 +1693,9 @@ namespace TStreamerInfoActions
 
    ESelectLooper SelectLooper(TVirtualCollectionProxy &proxy)
    {
-      if ( (proxy.GetCollectionType() == ROOT::kSTLvector) || (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated) ) {
+      if ( (proxy.GetProperties() & TVirtualCollectionProxy::kIsEmulated) ) {
+         return kVectorLooper;
+      } else if ( (proxy.GetCollectionType() == ROOT::kSTLvector)) {
          if (proxy.GetProperties() & TVirtualCollectionProxy::kCustomAlloc)
             return kGenericLooper;
          else
@@ -2647,6 +2649,8 @@ namespace TStreamerInfoActions
       template <typename T>
       static INLINE_TEMPLATE_ARGS Int_t ReadCollectionBasicType(TBuffer &buf, void *addr, const TConfiguration *conf)
       {
+         //TODO:  Check whether we can implement this without loading the data in
+         // a temporary variable and whether this is noticeably faster.
          return ReadNumericalCollection<ConvertBasicType<T,T,Numeric > >(buf,addr,conf);
       }
 


### PR DESCRIPTION
This fixes #9136.

Without this commit, SelectLooper would select the 'GenericLooper'
in the case of an emulated proxy for STL collection with (in the
name) a custom allocator.  However the GenericLooper only usable
for collection with a compiled collection proxy.

In particular, GenericLooper is calling the 'Next' function which
is not defined for vector ... and emulated collection.  Using
it lead to an assert complaining (right fully so) that an
'undefined' function is being called.

