### PR TITLE
Fix drag and drop on Linux

### DIFF
--- a/gui/gui/src/TGDNDManager.cxx
+++ b/gui/gui/src/TGDNDManager.cxx
@@ -426,10 +426,10 @@ Bool_t TGDNDManager::HandleClientMessage(Event_t *event)
    } else if (event->fHandle == fgDNDPosition) {
       Atom_t action = (Atom_t) event->fUser[4] ? event->fUser[4] : 1;
       HandleDNDPosition((Window_t) event->fUser[0],
-                       (Int_t) (event->fUser[2] >> 16) & 0xFFFF,  // x_root
-                       (Int_t) (event->fUser[2] & 0xFFFF),        // y_root
-                       (Atom_t) action,                           // action
-                       (Time_t) event->fUser[3]);                 // timestamp
+                       (Int_t) (event->fUser[2] >> 16) & 0xFFFF, // x_root
+                       (Int_t) (event->fUser[2] & 0xFFFF),       // y_root
+                       (Atom_t) action,                          // action
+                       (Time_t) event->fUser[3]);                // timestamp
 
    } else if (event->fHandle == fgDNDStatus) {
       Rectangle_t skip;

--- a/gui/gui/src/TGDNDManager.cxx
+++ b/gui/gui/src/TGDNDManager.cxx
@@ -424,12 +424,12 @@ Bool_t TGDNDManager::HandleClientMessage(Event_t *event)
       HandleDNDLeave((Window_t) event->fUser[0]);
 
    } else if (event->fHandle == fgDNDPosition) {
-      Atom_t action = (Atom_t) event->fUser[4] ? event->fUser[4] : 1;
-      HandleDNDPosition((Window_t) event->fUser[0],
-                       (Int_t) (event->fUser[2] >> 16) & 0xFFFF, // x_root
-                       (Int_t) (event->fUser[2] & 0xFFFF),       // y_root
-                       (Atom_t) action,                          // action
-                       (Time_t) event->fUser[3]);                // timestamp
+      Atom_t action = (Atom_t)event->fUser[4] ? event->fUser[4] : 1;
+      HandleDNDPosition((Window_t)event->fUser[0],
+                        (Int_t)(event->fUser[2] >> 16) & 0xFFFF, // x_root
+                        (Int_t)(event->fUser[2] & 0xFFFF),       // y_root
+                        (Atom_t)action,                          // action
+                        (Time_t)event->fUser[3]);                // timestamp
 
    } else if (event->fHandle == fgDNDStatus) {
       Rectangle_t skip;

--- a/gui/gui/src/TGDNDManager.cxx
+++ b/gui/gui/src/TGDNDManager.cxx
@@ -424,10 +424,11 @@ Bool_t TGDNDManager::HandleClientMessage(Event_t *event)
       HandleDNDLeave((Window_t) event->fUser[0]);
 
    } else if (event->fHandle == fgDNDPosition) {
+      Atom_t action = (Atom_t) event->fUser[4] ? event->fUser[4] : 1;
       HandleDNDPosition((Window_t) event->fUser[0],
                        (Int_t) (event->fUser[2] >> 16) & 0xFFFF,  // x_root
                        (Int_t) (event->fUser[2] & 0xFFFF),        // y_root
-                       (Atom_t) event->fUser[4],                  // action
+                       (Atom_t) action,                           // action
                        (Time_t) event->fUser[3]);                 // timestamp
 
    } else if (event->fHandle == fgDNDStatus) {


### PR DESCRIPTION
Add a work-around to make sure the action is not null in `HandleDNDPosition()`. This fixes an issue reported [on the forum](https://root-forum.cern.ch/t/drag-and-drop-in-root-6-24/47789)
