### PR TITLE
Fix image artifact in X11 without alpha after zoom

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -2602,6 +2602,8 @@ void TPad::ExecuteEventAxis(Int_t event, Int_t px, Int_t py, TAxis *axis)
          if (zoombox) {
             zoombox->Delete();
             zoombox = 0;
+            gPad->Modified();
+            gPad->Update();
          }
       }
       break;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
There was an image artifact with the zoombox in X11 (Ubuntu) since ROOT 5.34.19, only appearing if c->SetFillStyle(0) and GL was disabled, and on Ubuntu only, apparently.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/9763

