### PR TITLE
[v626] Fix drag and drop on Linux (#9768)

### DIFF
--- a/gui/gui/src/TGDNDManager.cxx
+++ b/gui/gui/src/TGDNDManager.cxx
@@ -424,11 +424,12 @@ Bool_t TGDNDManager::HandleClientMessage(Event_t *event)
       HandleDNDLeave((Window_t) event->fUser[0]);
 
    } else if (event->fHandle == fgDNDPosition) {
-      HandleDNDPosition((Window_t) event->fUser[0],
-                       (Int_t) (event->fUser[2] >> 16) & 0xFFFF,  // x_root
-                       (Int_t) (event->fUser[2] & 0xFFFF),        // y_root
-                       (Atom_t) event->fUser[4],                  // action
-                       (Time_t) event->fUser[3]);                 // timestamp
+      Atom_t action = (Atom_t)event->fUser[4] ? event->fUser[4] : 1;
+      HandleDNDPosition((Window_t)event->fUser[0],
+                        (Int_t)(event->fUser[2] >> 16) & 0xFFFF, // x_root
+                        (Int_t)(event->fUser[2] & 0xFFFF),       // y_root
+                        (Atom_t)action,                          // action
+                        (Time_t)event->fUser[3]);                // timestamp
 
    } else if (event->fHandle == fgDNDStatus) {
       Rectangle_t skip;


### PR DESCRIPTION
* Fix drag and drop on Linux

Add a work-around to make sure the action is no null in `HandleDNDPosition()`. This fixes an issue reported [on the forum](https://root-forum.cern.ch/t/drag-and-drop-in-root-6-24/47789)

* Make clang-format happy

* clang-format again
