### PR TITLE
[cling] Extracted decls should be unconditionally moved to the parent DeclContext

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclExtractor.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclExtractor.cpp
@@ -112,7 +112,7 @@ namespace cling {
     CompoundStmt* CS = dyn_cast<CompoundStmt>(FD->getBody());
     assert(CS && "Function body not a CompoundStmt?");
     assert(utils::Analyze::IsWrapper(FD) && "FD not a Cling wrapper?");
-    // DC is the internal `__cling_N5xxx' namespace or (if decl shadowing if off), the TU
+    // DC is the internal `__cling_N5xxx' namespace or (if decl shadowing is off), the TU
     DeclContext* WrapperDC = FD->getDeclContext();
     Scope* TUScope = m_Sema->TUScope;
     llvm::SmallVector<Stmt*, 4> Stmts;
@@ -156,14 +156,12 @@ namespace cling {
           // In the particular context this definition is inside a function
           // already, but clang thinks it as a lambda, so we need to ignore the
           // check decl context vs lexical decl context.
-          DeclContext *NewDC = isa<TagDecl>(ND) ? m_Context->getTranslationUnitDecl()
-		                                : WrapperDC;
           if (ND->getDeclContext() == ND->getLexicalDeclContext()
               || isa<FunctionDecl>(ND))
-            ND->setLexicalDeclContext(NewDC);
+            ND->setLexicalDeclContext(WrapperDC);
           else
             assert(0 && "Not implemented: Decl with different lexical context");
-          ND->setDeclContext(NewDC);
+          ND->setDeclContext(WrapperDC);
 
           if (VarDecl* VD = dyn_cast<VarDecl>(ND)) {
             if (!ValidateCXXRecord(VD))

--- a/interpreter/cling/test/CodeUnloading/DeclShadowing.C
+++ b/interpreter/cling/test/CodeUnloading/DeclShadowing.C
@@ -7,11 +7,21 @@
 //------------------------------------------------------------------------------
 
 // RUN: cat %s | %cling 2>&1 | FileCheck %s
+#include "cling/Interpreter/Interpreter.h"
+#include "cling/Utils/AST.h"
+#include "clang/AST/Decl.h"
+
 #include <type_traits>
 #include <cstdlib>
 #include <string>
 
+unsigned _i;
+struct _X {};
+int _g() { return 1; }
+
 cling::runtime::gClingOpts->AllowRedefinition = 1;
+
+void g() {}
 
 // ==== Test UsingDirectiveDecl/UsingDecl
 // These should not be nested into a `__cling_N5xxx' namespace (but placed at
@@ -87,5 +97,44 @@ f(33)
 //CHECK-NEXT: (int) 43605
 f(3.3f)
 //CHECK-NEXT: (int) 21930
+
+cling::runtime::gClingOpts->AllowRedefinition = 0;
+
+// ==== Check DeclContext
+// If DefinitionShadower is enabled, declaration context is an inline namespace;
+// otherwise it should be the TU.
+clang::Sema& _S = gCling->getSema();
+const clang::NamedDecl *_decl{nullptr};
+
+_decl = cling::utils::Lookup::Named(&_S, "_i", nullptr)
+//CHECK-NEXT: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
+_decl->getDeclContext()->isTranslationUnit()
+//CHECK-NEXT: (bool) true
+
+_decl = cling::utils::Lookup::Named(&_S, "_X", nullptr)
+//CHECK-NEXT: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
+_decl->getDeclContext()->isTranslationUnit()
+//CHECK-NEXT: (bool) true
+
+_decl = cling::utils::Lookup::Named(&_S, "_g", nullptr)
+//CHECK-NEXT: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
+_decl->getDeclContext()->isTranslationUnit()
+//CHECK-NEXT: (bool) true
+
+_decl = cling::utils::Lookup::Named(&_S, "bar", nullptr)
+//CHECK-NEXT: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
+_decl->getDeclContext()->isInlineNamespace()
+//CHECK-NEXT: (bool) true
+
+_decl = cling::utils::Lookup::Named(&_S, "MyStruct", nullptr)
+//CHECK-NEXT: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
+_decl->getDeclContext()->isInlineNamespace()
+//CHECK-NEXT: (bool) true
+
+_decl = cling::utils::Lookup::Named(&_S, "g", nullptr)
+//CHECK-NEXT: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
+_decl->getDeclContext()->isInlineNamespace()
+//CHECK-NEXT: (bool) true
+
 //expected-no-diagnostics
 .q


### PR DESCRIPTION
Declarations extracted by DeclExtractor, regardless of their type, should be moved to the parent declaration context (be it the `TranslationUnitDecl` or a `NamespaceDecl` if DefinitionShadower is enabled).

This prevents the following situation (i.e., the CXXRecordDecl becomes a child of the TranslationUnitDecl instead of the internal namespace used by the definition shadower):
```c++
root [] struct X {} foo
(struct X &) @0x7f545a5ff018
root [] .stats asttree
|-NamespaceDecl 0x5647ecc93780 <<invalid sloc>> <invalid sloc> __cling_N50 inline
| |-VarDecl 0x5647ecc89f10 <ROOT_prompt_0:1:1, col:13> col:13 used foo 'struct X':'X' callinit
| | `-CXXConstructExpr 0x5647ecc8a420 <col:13> 'struct X':'X' 'void () noexcept'
| `-FunctionDecl 0x5647ecc89bc8 <input_line_8:1:1, ROOT_prompt_0:3:1> input_line_8:1:6 __cling_Un1Qu30 'void (void *)'
...
|-CXXRecordDecl 0x5647ecc89c98 <line:1:1, col:11> col:8 struct X definition
```

Sibling PR in roottest: https://github.com/root-project/roottest/pull/819.

## Checklist:
- [X] tested changes locally