### PR TITLE
[cling] Diagnose shadowing of decls in the `std` namespace

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -141,6 +141,26 @@ namespace cling {
       kNumExeResults
     };
 
+    ///\brief Flags that provide additional information about the context in
+    /// which parsing occurs. These flags can be bitwise-OR'ed together.
+    enum InputFlags {
+      ///\brief Input comes from an external file
+      kInputFromFile = 0x01,
+      ///\brief If `kInputFromFile == 1`, whether `Interpreter::process()` is
+      /// called once per line
+      kIFFLineByLine = 0x02
+    };
+
+    ///\brief A RAII object that temporarily sets `Interpreter::m_InputFlags`
+    /// and restores it on destruction.
+    struct InputFlagsRAII {
+      Interpreter &m_Interp;
+      unsigned m_OldFlags;
+      InputFlagsRAII(Interpreter &I, unsigned F)
+        : m_Interp(I), m_OldFlags(I.m_InputFlags) { I.m_InputFlags = F; }
+      ~InputFlagsRAII() { m_Interp.m_InputFlags = m_OldFlags; }
+    };
+
   public:
     using ModuleFileExtensions =
         std::vector<std::shared_ptr<clang::ModuleFileExtension>>;
@@ -189,6 +209,10 @@ namespace cling {
     ///\brief Flag toggling the raw input on or off.
     ///
     bool m_RawInputEnabled;
+
+    ///\brief Flags that provide additional information about the context in
+    /// which parsing occurs (see `InputFlags`).
+    unsigned m_InputFlags{};
 
     ///\brief Configuration bits that can be changed at runtime. This allows the
     /// user to enable/disable specific interpreter extensions.
@@ -689,6 +713,9 @@ namespace cling {
 
     bool isRawInputEnabled() const { return m_RawInputEnabled; }
     void enableRawInput(bool raw = true) { m_RawInputEnabled = raw; }
+
+    unsigned getInputFlags() const { return m_InputFlags; }
+    void setInputFlags(unsigned value) { m_InputFlags = value; }
 
     int getDefaultOptLevel() const { return m_OptLevel; }
     void setDefaultOptLevel(int optLevel) { m_OptLevel = optLevel; }

--- a/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
+++ b/interpreter/cling/lib/Interpreter/DefinitionShadower.cpp
@@ -66,7 +66,7 @@ namespace cling {
             m_ShadowsDeclInStdDiagID(S.getDiagnostics().getCustomDiagID(
                 DiagnosticsEngine::Warning,
                 "'%0' shadows a declaration with the same name in the 'std' "
-                "namespace; consider using '::%0' to reference this declaration"))
+                "namespace; use '::%0' to reference this declaration"))
   {}
 
   bool DefinitionShadower::isClingShadowNamespace(const DeclContext *DC) {
@@ -103,7 +103,7 @@ namespace cling {
                    Sema::LookupOrdinaryName, Sema::NotForRedeclaration);
     Previous.suppressDiagnostics();
     m_Sema->LookupQualifiedName(Previous, m_TU);
-    bool shadowsDeclInStd{};
+    bool shadowsDeclInStd = false;
 
     for (auto Prev : Previous) {
       if (Prev == D)

--- a/interpreter/cling/lib/Interpreter/DefinitionShadower.h
+++ b/interpreter/cling/lib/Interpreter/DefinitionShadower.h
@@ -53,6 +53,7 @@ namespace cling {
     clang::ASTContext          &m_Context;
     Interpreter                &m_Interp;
     clang::TranslationUnitDecl *m_TU;
+    unsigned                    m_ShadowsDeclInStdDiagID;
 
     unsigned long long m_UniqueNameCounter = 0;
 

--- a/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaProcessor.cpp
@@ -493,6 +493,8 @@ namespace cling {
     if (content.back() != ';')
       content.append(";");
 
+    Interpreter::InputFlagsRAII RAII(m_Interp, Interpreter::kInputFromFile |
+                                               (lineByLine ? Interpreter::kIFFLineByLine : 0));
     Interpreter::CompilationResult ret = Interpreter::kSuccess;
     if (lineByLine) {
       int rslt = 0;


### PR DESCRIPTION
Related to the discussion in [ROOT-5971](https://sft.its.cern.ch/jira/browse/ROOT-5971), this commit improves the situation by diagnosing the shadowing of declarations in the `std` namespace.

In summary, given that ROOT issues an implicit `using namespace std;` and due to the way `SemaLookup` works, decls that shadow something in the `std` namespace cannot be referenced without using their fully-qualified name, i.e. `::xxx`.
See discussion in ROOT-5971 for the details.  This pull-request improves the situation by emitting a warning for that case.

## Changes or fixes:
- Add `Interpreter::m_InputFlags`, which provides additional information about the context in which parsing occurs.  In particular, the `kInputFromFile` and `kIFFLineByLine` flags allow to tell whether a sequence of calls to `Interpreter::process()` is issued from `MetaProcessor::readInputFromFile()` for the contents of an external file.
- Update cling's DefinitionShadower to emit a warning if a new declaration shadows a name in the `std` namespace (that became available via the implicit `using namespace std`).  This diagnostic is disabled for unnamed macros, as input is typically ingested in a single `process()` call, which makes all the variables local to the generated wrapper. 

This requires to change the lookup redeclaration kind to `NotForRedeclaration`, which has a performance penalty, given that the lookup will follow using directives, etc.  This is approximately one order of magnitude slower than `ForVisibleRedeclaration` (see table below).  The overhead seems acceptable given that this kind of lookup already occurs when a declaration is referenced and that definition is rare w.r.t. use.
```
+-------------------------+-------------------------------+
| Redeclaration kind      | Time (us) for 1000000 lookups |
+-------------------------+-------------------------------+
| ForVisibleRedeclaration |                         27617 |
| NotForRedeclaration     |                        717458 |
+-------------------------+-------------------------------+
```

## Checklist:
- [X] tested changes locally

This PR improves the situation for [ROOT-5971](https://sft.its.cern.ch/jira/browse/ROOT-5971).