### PR TITLE
[cling,v6-26] Make enumerators in a scopeless enum visible in the enclosing scope

### DIFF
--- a/interpreter/cling/lib/Interpreter/DeclExtractor.cpp
+++ b/interpreter/cling/lib/Interpreter/DeclExtractor.cpp
@@ -182,19 +182,9 @@ namespace cling {
     bool hasNoErrors = !CheckForClashingNames(TouchedDecls, WrapperDC);
     if (hasNoErrors) {
       for (size_t i = 0; i < TouchedDecls.size(); ++i) {
-        // We should skip the checks for annonymous decls and we should not
-        // register them in the lookup.
-        if (!TouchedDecls[i]->getDeclName())
-          continue;
-
-        Sema::ContextRAII RAII(*m_Sema, TouchedDecls[i]->getDeclContext());
-        m_Sema->PushOnScopeChains(TouchedDecls[i],
-                                  TUScope,
-                    /*AddCurContext*/!isa<UsingDirectiveDecl>(TouchedDecls[i]));
-
         // The transparent DeclContexts (eg. scopeless enum) doesn't have
         // scopes. While extracting their contents we need to update the
-        // lookup tables and telling them to pick up the new possitions
+        // lookup tables and telling them to pick up the new positions
         // in the AST.
         if (DeclContext* InnerDC = dyn_cast<DeclContext>(TouchedDecls[i])) {
           if (InnerDC->isTransparentContext()) {
@@ -208,6 +198,16 @@ namespace cling {
             }
           }
         }
+
+        // We should skip the checks for anonymous decls and we should not
+        // register them in the lookup. Their inner decls have been added above.
+        if (!TouchedDecls[i]->getDeclName())
+          continue;
+
+        Sema::ContextRAII RAII(*m_Sema, TouchedDecls[i]->getDeclContext());
+        m_Sema->PushOnScopeChains(TouchedDecls[i],
+                                  TUScope,
+                    /*AddCurContext*/!isa<UsingDirectiveDecl>(TouchedDecls[i]));
       }
     }
 

--- a/interpreter/cling/test/Lookup/named.C
+++ b/interpreter/cling/test/Lookup/named.C
@@ -39,6 +39,14 @@ class Inside_AnotherNext {};
 
 .rawInput 0
 
+// ROOT-6095: names introduced in a scopeless enum should be available in the
+// parent context.
+typedef enum { k0, k1 } E;
+E foo = k1
+//CHECK: (E) (k1) : (unsigned int) 1
+struct X { enum { k0, k1 = 2 }; } bar
+X::k1
+//CHECK: (X::(anonymous)) (X::k1) : (unsigned int) 2
 
 clang::Sema& S = gCling->getSema();
 const LookupHelper& lookup = gCling->getLookupHelper();
@@ -61,6 +69,10 @@ decl
 //CHECK: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
 decl->getQualifiedNameAsString().c_str()
 //CHECK-NEXT: ({{[^)]+}}) "AnotherNext::Inside_AnotherNext"
+
+decl = utils::Lookup::Named(&S, "k1", nullptr);
+decl
+//CHECK: (const clang::NamedDecl *) 0x{{[1-9a-f][0-9a-f]*$}}
 
 // Now test the ambiguities.
 


### PR DESCRIPTION
This pull-request is a backport of PR #9781; see details there.  A bug in DeclExtractor was preventing names introduced by an anonymous scopeless enum to become available in the parent scope.

## Checklist:
- [X] tested changes locally

This PR fixes ROOT-6095.