### PR TITLE
[DF] Fix FillTGraphHelper Exec method

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -545,6 +545,7 @@ public:
    void Initialize() {}
    void InitTask(TTreeReader *, unsigned int) {}
 
+   // case: both types are container types
    template <typename X0, typename X1,
              std::enable_if_t<IsDataContainer<X0>::value && IsDataContainer<X1>::value, int> = 0>
    void Exec(unsigned int slot, const X0 &x0s, const X1 &x1s)
@@ -552,7 +553,7 @@ public:
       if (x0s.size() != x1s.size()) {
          throw std::runtime_error("Cannot fill Graph with values in containers of different sizes.");
       }
-      auto thisSlotG = fGraphs[slot];
+      auto *thisSlotG = fGraphs[slot];
       auto x0sIt = std::begin(x0s);
       const auto x0sEnd = std::end(x0s);
       auto x1sIt = std::begin(x1s);
@@ -561,11 +562,21 @@ public:
       }
    }
 
-   template <typename X0, typename X1>
+   // case: both types are non-container types, e.g. scalars
+   template <typename X0, typename X1,
+             std::enable_if_t<!IsDataContainer<X0>::value && !IsDataContainer<X1>::value, int> = 0>
    void Exec(unsigned int slot, X0 x0, X1 x1)
    {
       auto thisSlotG = fGraphs[slot];
       thisSlotG->SetPoint(thisSlotG->GetN(), x0, x1);
+   }
+
+   // case: types are combination of containers and non-containers
+   // this is not supported, error out
+   template <typename X0, typename X1, typename... ExtraArgsToLowerPriority>
+   void Exec(unsigned int, X0, X1, ExtraArgsToLowerPriority...)
+   {
+      throw std::runtime_error("Graph was applied to a mix of scalar values and collections. This is not supported.");
    }
 
    void Finalize()

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1654,18 +1654,18 @@ public:
    }
 
    ////////////////////////////////////////////////////////////////////////////
-   /// \brief Fill and return a graph (*lazy action*).
-   /// \tparam V1 The type of the column used to fill the x axis of the graph.
-   /// \tparam V2 The type of the column used to fill the y axis of the graph.
-   /// \param[in] v1Name The name of the column that will fill the x axis.
-   /// \param[in] v2Name The name of the column that will fill the y axis.
-   /// \return the graph wrapped in a RResultPtr.
+   /// \brief Fill and return a TGraph object (*lazy action*).
+   /// \tparam X The type of the column used to fill the x axis.
+   /// \tparam Y The type of the column used to fill the y axis.
+   /// \param[in] x The name of the column that will fill the x axis.
+   /// \param[in] y The name of the column that will fill the y axis.
+   /// \return the TGraph wrapped in a RResultPtr.
    ///
-   /// Columns can be of a container type (e.g. std::vector<double>), in which case the graph
+   /// Columns can be of a container type (e.g. std::vector<double>), in which case the TGraph
    /// is filled with each one of the elements of the container.
    /// If Multithreading is enabled, the order in which points are inserted is undefined.
    /// If the Graph has to be drawn, it is suggested to the user to sort it on the x before printing.
-   /// A name and a title to the graph is given based on the input column names.
+   /// A name and a title to the TGraph is given based on the input column names.
    ///
    /// This action is *lazy*: upon invocation of this method the calculation is
    /// booked but not executed. Also see RResultPtr.
@@ -1678,14 +1678,14 @@ public:
    /// auto myGraph2 = myDf.Graph<int, float>("xValues", "yValues");
    /// ~~~
    ///
-   /// \note Differently from other ROOT interfaces, the returned graph is not associated to gDirectory
+   /// \note Differently from other ROOT interfaces, the returned TGraph is not associated to gDirectory
    /// and the caller is responsible for its lifetime (in particular, a typical source of confusion is that
    /// if result histograms go out of scope before the end of the program, ROOT might display a blank canvas).
-   template <typename V1 = RDFDetail::RInferredType, typename V2 = RDFDetail::RInferredType>
-   RResultPtr<::TGraph> Graph(std::string_view v1Name = "", std::string_view v2Name = "")
+   template <typename X = RDFDetail::RInferredType, typename Y = RDFDetail::RInferredType>
+   RResultPtr<::TGraph> Graph(std::string_view x = "", std::string_view y = "")
    {
       auto graph = std::make_shared<::TGraph>();
-      const std::vector<std::string_view> columnViews = {v1Name, v2Name};
+      const std::vector<std::string_view> columnViews = {x, y};
       const auto userColumns = RDFInternal::AtLeastOneEmptyString(columnViews)
                                   ? ColumnNames_t()
                                   : ColumnNames_t(columnViews.begin(), columnViews.end());
@@ -1693,15 +1693,13 @@ public:
       const auto validatedColumns = GetValidatedColumnNames(2, userColumns);
 
       // We build a default name and title based on the input columns
-      if (!(validatedColumns[0].empty() && validatedColumns[1].empty())) {
-         const auto g_name = std::string(v1Name) + "_vs_" + std::string(v2Name);
-         const auto g_title = std::string(v1Name) + " vs " + std::string(v2Name);
-         graph->SetNameTitle(g_name.c_str(), g_title.c_str());
-         graph->GetXaxis()->SetTitle(std::string(v1Name).c_str());
-         graph->GetYaxis()->SetTitle(std::string(v2Name).c_str());
-      }
+      const auto g_name = validatedColumns[0] + "_vs_" + validatedColumns[1];
+      const auto g_title = validatedColumns[0] + " vs " + validatedColumns[1];
+      graph->SetNameTitle(g_name.c_str(), g_title.c_str());
+      graph->GetXaxis()->SetTitle(validatedColumns[0].c_str());
+      graph->GetYaxis()->SetTitle(validatedColumns[1].c_str());
 
-      return CreateAction<RDFInternal::ActionTags::Graph, V1, V2>(validatedColumns, graph, graph);
+      return CreateAction<RDFInternal::ActionTags::Graph, X, Y>(validatedColumns, graph, graph);
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -430,6 +430,49 @@ TEST(RDFHelpers, SaveGraphSharedDefines)
    EXPECT_EQ(graph, expected);
 }
 
+TEST(RDFHelpers, GraphContainers)
+{
+   const std::vector<double> xx = {-0.22, 0.05, 0.25, 0.35, 0.5, 0.61, 0.7, 0.85, 0.89, 0.95};
+   const std::vector<double> yy = {1., 2.9, 5.6, 7.4, 9, 9.6, 8.7, 6.3, 4.5, 1};
+
+   auto df = RDataFrame(1).Define("xx", [&] { return xx; }).Define("yy", [&] { return yy; });
+
+   auto gr1 = df.Graph<std::vector<double>, std::vector<double>>("xx", "yy");
+
+   for (size_t i = 0; i < xx.size(); ++i) {
+      EXPECT_DOUBLE_EQ(gr1->GetX()[i], xx[i]);
+      EXPECT_DOUBLE_EQ(gr1->GetY()[i], yy[i]);
+   }
+}
+
+TEST(RDFHelpers, GraphScalars)
+{
+   auto df =
+      RDataFrame(2).DefineSlotEntry("x", [](unsigned int, ULong64_t x) { return x; }).Define("y", [] { return .5; });
+
+   auto gr1 = df.Graph<ULong64_t, double>("x", "y");
+
+   for (size_t i = 0; i < 2; ++i) {
+      EXPECT_EQ(gr1->GetX()[i], i);
+      EXPECT_DOUBLE_EQ(gr1->GetY()[i], .5);
+   }
+}
+
+TEST(RDFHelpers, GraphRunTimeErrors)
+{
+   const std::vector<double> xx = {-0.22}; // smaller size
+   const std::vector<double> yy = {1., 2.9};
+
+   auto df =
+      RDataFrame(1).Define("xx", [&] { return xx; }).Define("yy", [&] { return yy; }).Define("x", [] { return .5; });
+
+   auto gr1 = df.Graph<std::vector<double>, std::vector<double>>("xx", "yy"); // still no error since lazy action
+   auto gr2 = df.Graph<double, std::vector<double>>("x", "yy");               // still no error since lazy action
+
+   EXPECT_THROW(gr1.GetValue(), std::runtime_error);
+   EXPECT_THROW(gr2.GetValue(), std::runtime_error);
+}
+
 TEST(RDFHelpers, GraphAsymmErrorsContainers)
 {
    const std::vector<double> xx = {-0.22, 0.05, 0.25, 0.35, 0.5, 0.61, 0.7, 0.85, 0.89, 0.95};


### PR DESCRIPTION
Previously, the Exec method of the FillTGraphHelper was ambiguous.
Currently, Exec properly handles container and non-container types.
Corresponding tests added.
Small adjustments of the variable names of Graph in RInterface.hxx.

- [x] tested changes locally
- [ ] updated the docs (if necessary)