### PR TITLE
[RF] Add `rf613` tutorial about global observables in RooFit and fixes to bugs discovered when writing the tutorial

### DIFF
--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -45,7 +45,7 @@ public:
         const char* globalObservablesTag,
         bool takeGlobalObservablesFromData,
         bool cloneConstraints,
-        RooWorkspace * workspace = nullptr);
+        RooWorkspace * workspace);
 
   bool setData(RooAbsData const& data, bool cloneData=true);
   /// \copydoc setData(RooAbsData const&, bool)

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -692,7 +692,10 @@ bool RooAbsArg::getParameters(const RooArgSet* observables, RooArgSet& outputSet
 
    addParameters(tempList, observables, stripDisconnected);
 
-   outputSet.add(tempList);
+   // The adding from the list to the set has to be silent to not complain
+   // about duplicate parameters. After all, it's normal that parameters can
+   // appear in sifferent components of the model.
+   outputSet.add(tempList, /*silent=*/true);
    outputSet.sort();
 
    // Cache parameter set

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1169,6 +1169,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
           pc.getSet("glObs"), // GlobalObservables RooCmdArg
           pc.getString("globstag",0,true), // GlobalObservablesTag RooCmdArg
           takeGlobalObservablesFromData, // From GlobalObservablesSource RooCmdArg
+          batchMode == RooFit::BatchModeOption::Off, // clone constraints?
           _myws // passing workspace to cache the set of constraints
   );
 

--- a/tutorials/roofit/rf604_constraints.C
+++ b/tutorials/roofit/rf604_constraints.C
@@ -50,7 +50,7 @@ void rf604_constraints()
    // -----------------------------------------
 
    // Construct Gaussian constraint pdf on parameter f at 0.8 with resolution of 0.1
-   RooGaussian fconstraint("fconstraint", "fconstraint", f, RooConst(0.8), RooConst(0.2));
+   RooGaussian fconstraint("fconstraint", "fconstraint", RooConst(0.8), f, RooConst(0.2));
 
    // M E T H O D   1   -   A d d   i n t e r n a l   c o n s t r a i n t   t o   m o d e l
    // -------------------------------------------------------------------------------------
@@ -62,19 +62,19 @@ void rf604_constraints()
    RooProdPdf modelc("modelc", "model with constraint", RooArgSet(model, fconstraint));
 
    // Fit model (without use of constraint term)
-   RooFitResult *r1 = model.fitTo(*d, Save());
+   RooFitResult *r1 = model.fitTo(*d, Save(), PrintLevel(-1));
 
    // Fit modelc with constraint term on parameter f
-   RooFitResult *r2 = modelc.fitTo(*d, Constrain(f), Save());
+   RooFitResult *r2 = modelc.fitTo(*d, Constrain(f), Save(), PrintLevel(-1));
 
    // M E T H O D   2   -     S p e c i f y   e x t e r n a l   c o n s t r a i n t   w h e n   f i t t i n g
    // -------------------------------------------------------------------------------------------------------
 
    // Construct another Gaussian constraint pdf on parameter f at 0.2 with resolution of 0.1
-   RooGaussian fconstext("fconstext", "fconstext", f, RooConst(0.2), RooConst(0.1));
+   RooGaussian fconstext("fconstext", "fconstext", RooConst(0.2), f, RooConst(0.1));
 
    // Fit with external constraint
-   RooFitResult *r3 = model.fitTo(*d, ExternalConstraints(fconstext), Save());
+   RooFitResult *r3 = model.fitTo(*d, ExternalConstraints(fconstext), Save(), PrintLevel(-1));
 
    // Print the fit results
    cout << "fit result without constraint (data generated at f=0.5)" << endl;

--- a/tutorials/roofit/rf604_constraints.py
+++ b/tutorials/roofit/rf604_constraints.py
@@ -37,33 +37,32 @@ d = model.generate({x}, 50)
 
 # Construct Gaussian constraint pdf on parameter f at 0.8 with
 # resolution of 0.1
-fconstraint = ROOT.RooGaussian("fconstraint", "fconstraint", f, ROOT.RooFit.RooConst(0.8), ROOT.RooFit.RooConst(0.1))
+fconstraint = ROOT.RooGaussian("fconstraint", "fconstraint", ROOT.RooFit.RooConst(0.8), f, ROOT.RooFit.RooConst(0.1))
 
 # Method 1 - add internal constraint to model
 # -------------------------------------------------------------------------------------
 
-# Multiply constraint term with regular pdf using ROOT.RooProdPdf
-# Specify in fitTo() that internal constraints on parameter f should be
-# used
+# Multiply constraint term with regular pdf using ROOT.RooProdPdf Specify in
+# fitTo() that internal constraints on parameter f should be used
 
 # Multiply constraint with pdf
 modelc = ROOT.RooProdPdf("modelc", "model with constraint", [model, fconstraint])
 
 # Fit model (without use of constraint term)
-r1 = model.fitTo(d, Save=True)
+r1 = model.fitTo(d, Save=True, PrintLevel=-1)
 
 # Fit modelc with constraint term on parameter f
-r2 = modelc.fitTo(d, Constrain={f}, Save=True)
+r2 = modelc.fitTo(d, Constrain={f}, Save=True, PrintLevel=-1)
 
 # Method 2 - specify external constraint when fitting
 # ------------------------------------------------------------------------------------------
 
 # Construct another Gaussian constraint pdf on parameter f at 0.8 with
 # resolution of 0.1
-fconstext = ROOT.RooGaussian("fconstext", "fconstext", f, ROOT.RooFit.RooConst(0.2), ROOT.RooFit.RooConst(0.1))
+fconstext = ROOT.RooGaussian("fconstext", "fconstext", ROOT.RooFit.RooConst(0.2), f, ROOT.RooFit.RooConst(0.1))
 
 # Fit with external constraint
-r3 = model.fitTo(d, ExternalConstraints={fconstext}, Save=True)
+r3 = model.fitTo(d, ExternalConstraints={fconstext}, Save=True, PrintLevel=-1)
 
 # Print the fit results
 print("fit result without constraint (data generated at f=0.5)")

--- a/tutorials/roofit/rf613_global_observables.C
+++ b/tutorials/roofit/rf613_global_observables.C
@@ -1,0 +1,166 @@
+/// \file
+/// \ingroup tutorial_roofit
+/// \notebook -js
+/// This tutorial explains the concept of global observables in RooFit, and
+/// showcases how their values can be stored either in the model or in the
+/// dataset.
+///
+/// ### Introduction
+///
+/// With RooFit, you usually optimize some model parameters `p` to maximize the
+/// likelihood `L` given the per-event or per-bin ## observations `x`:
+///
+/// \f[ L( x | p ) \f]
+///
+/// Often, the parameters are constrained with some prior likelihood `C`, which
+/// doesn't depend on the observables `x`:
+///
+/// \f[ L'( x | p ) = L( x | p ) * C( p ) \f]
+///
+/// Usually, these constraint terms depend on some auxiliary measurements of
+/// other observables `g`. The constraint term is then the likelihood of the
+/// so-called global observables:
+///
+/// \f[ L'( x | p ) = L( x | p ) * C( g | p ) \f]
+///
+/// For example, think of a model where the true luminosity `lumi` is a
+/// nuisance parameter that is constrained by an auxiliary measurement
+/// `lumi_obs` with uncertainty `lumi_obs_sigma`:
+///
+/// \f[ L'(data | mu, lumi) = L(data | mu, lumi) * Gauss(lumi_obs | lumi, lumi_obs_sigma) \f]
+///
+/// As a Gaussian is symmetric under exchange of the observable and the mean
+/// parameter, you can also sometimes find this equivalent but less conventional
+/// formulation for Gaussian constraints:
+///
+/// \f[ L'(data | mu, lumi) = L(data | mu, lumi) * Gauss(lumi | lumi_obs, lumi_obs_sigma) \f]
+///
+/// If you wanted to constrain a parameter that represents event counts, you
+/// would use a Poissonian constraint, e.g.:
+///
+/// \f[ L'(data | mu, count) = L(data | mu, count) * Poisson(count_obs | count) \f]
+///
+/// Note: unlike a Guassian, a Poissonian is not symmetric under exchange of the
+/// observable and the parameter, so here you need to be more careful to follow
+/// the global observable prescription correctly.
+///
+///
+/// \macro_code
+///
+/// \date January 2022
+/// \author Jonas Rembser
+
+#include <RooArgSet.h>
+#include <RooConstVar.h>
+#include <RooDataSet.h>
+#include <RooFitResult.h>
+#include <RooGaussian.h>
+#include <RooProdPdf.h>
+#include <RooRealVar.h>
+
+void rf613_global_observables()
+{
+   using namespace RooFit;
+
+   // Setting up the model and creating toy dataset
+   // ---------------------------------------------
+
+   // l'(x | mu, sigma) = l(x | mu, sigma) * Gauss(mu_obs | mu, 0.2)
+
+   // event observables
+   RooRealVar x("x", "x", -10, 10);
+
+   // parameters
+   RooRealVar mu("mu", "mu", 0.0, -10, 10);
+   RooRealVar sigma("sigma", "sigma", 1.0, 0.1, 2.0);
+
+   // Gaussian model for event observables
+   RooGaussian gauss("gauss", "gauss", x, mu, sigma);
+
+   // global observables (which are not parameters so they are constant)
+   RooRealVar mu_obs("mu_obs", "mu_obs", 1.0, -10, 10);
+   mu_obs.setConstant();
+   // note: alternatively, one can create a constant with default limits using `RooRealVar("mu_obs", "mu_obs", 1.0)`
+
+   // constraint pdf
+   RooGaussian constraint("constraint", "constraint", mu_obs, mu, RooConst(0.2));
+
+   // full pdf including constraint pdf
+   RooProdPdf model("model", "model", {gauss, constraint});
+
+   // Generating toy data with randomized global observables
+   // ------------------------------------------------------
+
+   // For most toy-based statistical procedures, it is necessary to also
+   // randomize the global observable when generating toy datasets.
+   //
+   // To that end, let's generate a single event from the model and take the
+   // global observable value (the same is done in the RooStats:ToyMCSampler
+   // class):
+
+   std::unique_ptr<RooDataSet> dataGlob{model.generate({mu_obs}, 1)};
+
+   // Next, we temporarily set the value of `mu_obs` to the randomized value for
+   // generating our toy dataset:
+   double mu_obs_orig_val = mu_obs.getVal();
+
+   RooArgSet{mu_obs}.assign(*dataGlob->get(0));
+
+   // actually generate the toy dataset
+   std::unique_ptr<RooDataSet> data{model.generate({x}, 1000)};
+
+   // When fitting the toy dataset, it is important to set the global
+   // observables in the fit to the values that were used to generate the toy
+   // dataset. To facilitate the bookkeeping of global observable values, you
+   // can attach a snapshot with the current global observable values to the
+   // dataset like this (new feature introduced in ROOT 6.26):
+
+   data->setGlobalObservables({mu_obs});
+
+   // reset original mu_obs value
+   mu_obs.setVal(mu_obs_orig_val);
+
+   // Fitting a model with global observables
+   // ---------------------------------------
+
+   // Create snapshot of original parameters to reset parameters after fitting
+   RooArgSet modelParameters;
+   model.getParameters(data->get(), modelParameters);
+   RooArgSet origParameters;
+   modelParameters.snapshot(origParameters);
+
+   using FitRes = std::unique_ptr<RooFitResult>;
+
+   // When you fit a model that includes global observables, you need to
+   // specify them in the call to RooAbsPdf::fitTo with the
+   // RooFit::GlobalObservables command argument. By default, the global
+   // observable values attached to the dataset will be prioritized over the
+   // values in the model, so the following fit correctly uses the randomized
+   // global observable values from the toy dataset:
+   std::cout << "1. model.fitTo(*data, GlobalObservables(mu_obs))\n";
+   std::cout << "------------------------------------------------\n\n";
+   FitRes res1{model.fitTo(*data, GlobalObservables(mu_obs), PrintLevel(-1), Save())};
+   res1->Print();
+   modelParameters.assign(origParameters);
+
+   // In our example, the set of global observables is attached to the toy
+   // dataset. In this case, you can actually drop the GlobalObservables()
+   // command argument, because the global observables are automatically
+   // figured out from the data set (this fit result should be identical to the
+   // previous one).
+   std::cout << "2. model.fitTo(*data)\n";
+   std::cout << "---------------------\n\n";
+   FitRes res2{model.fitTo(*data, PrintLevel(-1), Save())};
+   res2->Print();
+   modelParameters.assign(origParameters);
+
+   // If you want to explicitly ignore the global observables in the dataset,
+   // you can do that by specifying GlobalObservablesSource("model"). Keep in
+   // mind that now it's also again your responsability to define the set of
+   // global observables.
+   std::cout << "3. model.fitTo(*data, GlobalObservables(mu_obs), GlobalObservablesSource(\"model\"))\n";
+   std::cout << "------------------------------------------------\n\n";
+   FitRes res3{model.fitTo(*data, GlobalObservables(mu_obs), GlobalObservablesSource("model"), PrintLevel(-1), Save())};
+   res3->Print();
+   modelParameters.assign(origParameters);
+}

--- a/tutorials/roofit/rf613_global_observables.py
+++ b/tutorials/roofit/rf613_global_observables.py
@@ -1,0 +1,149 @@
+## \file
+## \ingroup tutorial_roofit
+## \notebook -js
+## This tutorial explains the concept of global observables in RooFit, and
+## showcases how their values can be stored either in the model or in the
+## dataset.
+##
+## ### Introduction
+##
+## With RooFit, you usually optimize some model parameters `p` to maximize the
+## likelihood `L` given the per-event or per-bin ## observations `x`:
+##
+## \f[ L( x | p ) \f]
+##
+## Often, the parameters are constrained with some prior likelihood `C`, which
+## doesn't depend on the observables `x`:
+##
+## \f[ L'( x | p ) = L( x | p ) * C( p ) \f]
+##
+## Usually, these constraint terms depend on some auxiliary measurements of
+## other observables `g`. The constraint term is then the likelihood of the
+## so-called global observables:
+##
+## \f[ L'( x | p ) = L( x | p ) * C( g | p ) \f]
+##
+## For example, think of a model where the true luminosity `lumi` is a
+## nuisance parameter that is constrained by an auxiliary measurement
+## `lumi_obs` with uncertainty `lumi_obs_sigma`:
+##
+## \f[ L'(data | mu, lumi) = L(data | mu, lumi) * Gauss(lumi_obs | lumi, lumi_obs_sigma) \f]
+##
+## As a Gaussian is symmetric under exchange of the observable and the mean
+## parameter, you can also sometimes find this equivalent but less conventional
+## formulation for Gaussian constraints:
+##
+## \f[ L'(data | mu, lumi) = L(data | mu, lumi) * Gauss(lumi | lumi_obs, lumi_obs_sigma) \f]
+##
+## If you wanted to constrain a parameter that represents event counts, you
+## would use a Poissonian constraint, e.g.:
+##
+## \f[ L'(data | mu, count) = L(data | mu, count) * Poisson(count_obs | count) \f]
+##
+## Note: unlike a Guassian, a Poissonian is not symmetric under exchange of the
+## observable and the parameter, so here you need to be more careful to follow
+## the global observable prescription correctly.
+##
+## \macro_code
+##
+## \date January 2022
+## \author Jonas Rembser
+
+
+import ROOT
+
+
+# Setting up the model and creating toy dataset
+# ---------------------------------------------
+
+# l'(x | mu, sigma) = l(x | mu, sigma) * Gauss(mu_obs | mu, 0.2)
+
+# event observables
+x = ROOT.RooRealVar("x", "x", -10, 10)
+
+# parameters
+mu = ROOT.RooRealVar("mu", "mu", 0.0, -10, 10)
+sigma = ROOT.RooRealVar("sigma", "sigma", 1.0, 0.1, 2.0)
+
+# Gaussian model for event observables
+gauss = ROOT.RooGaussian("gauss", "gauss", x, mu, sigma)
+
+# global observables (which are not parameters so they are constant)
+mu_obs = ROOT.RooRealVar("mu_obs", "mu_obs", 1.0, -10, 10)
+mu_obs.setConstant()
+# note: alternatively, one can create a constant with default limits using `RooRealVar("mu_obs", "mu_obs", 1.0)`
+
+# constraint pdf
+constraint = ROOT.RooGaussian("constraint", "constraint", mu_obs, mu, ROOT.RooFit.RooConst(0.2))
+
+# full pdf including constraint pdf
+model = ROOT.RooProdPdf("model", "model", [gauss, constraint])
+
+# Generating toy data with randomized global observables
+# ------------------------------------------------------
+
+# For most toy-based statistical procedures, it is necessary to also
+# randomize the global observable when generating toy datasets.
+#
+# To that end, let's generate a single event from the model and take the
+# global observable value (the same is done in the RooStats:ToyMCSampler
+# class):
+
+dataGlob = model.generate({mu_obs}, 1)
+
+# Next, we temporarily set the value of `mu_obs` to the randomized value for
+# generating our toy dataset:
+mu_obs_orig_val = mu_obs.getVal()
+
+ROOT.RooArgSet(mu_obs).assign(dataGlob.get(0))
+
+# actually generate the toy dataset
+data = model.generate({x}, 1000)
+
+# When fitting the toy dataset, it is important to set the global
+# observables in the fit to the values that were used to generate the toy
+# dataset. To facilitate the bookkeeping of global observable values, you
+# can attach a snapshot with the current global observable values to the
+# dataset like this (new feature introduced in ROOT 6.26):
+
+data.setGlobalObservables({mu_obs})
+
+# reset original mu_obs value
+mu_obs.setVal(mu_obs_orig_val)
+
+# Fitting a model with global observables
+# ---------------------------------------
+
+# Create snapshot of original parameters to reset parameters after fitting
+modelParameters = model.getParameters(data.get())
+origParameters = modelParameters.snapshot()
+
+# When you fit a model that includes global observables, you need to
+# specify them in the call to RooAbsPdf::fitTo with the
+# RooFit::GlobalObservables command argument. By default, the global
+# observable values attached to the dataset will be prioritized over the
+# values in the model, so the following fit correctly uses the randomized
+# global observable values from the toy dataset:
+print("1. model.fitTo(*data, GlobalObservables(mu_obs))")
+print("------------------------------------------------\n")
+model.fitTo(data, GlobalObservables=mu_obs, PrintLevel=-1, Save=True).Print()
+modelParameters.assign(origParameters)
+
+# In our example, the set of global observables is attached to the toy
+# dataset. In this case, you can actually drop the GlobalObservables()
+# command argument, because the global observables are automatically
+# figured out from the data set (this fit result should be identical to the
+# previous one).
+print("2. model.fitTo(*data)")
+print("---------------------\n")
+model.fitTo(data, PrintLevel=-1, Save=True).Print()
+modelParameters.assign(origParameters)
+
+# If you want to explicitly ignore the global observables in the dataset,
+# you can do that by specifying GlobalObservablesSource("model"). Keep in
+# mind that now it's also again your responsability to define the set of
+# global observables.
+print('3. model.fitTo(*data, GlobalObservables(mu_obs), GlobalObservablesSource("model"))')
+print("------------------------------------------------\n")
+model.fitTo(data, GlobalObservables=mu_obs, GlobalObservablesSource="model", PrintLevel=-1, Save=True).Print()
+modelParameters.assign(origParameters)


### PR DESCRIPTION
See more details in the commit messages.

This is a followup to https://github.com/root-project/root/pull/8878, and the first commit silences a harmless error message that appeared after https://github.com/root-project/root/commit/d5c3c5885726d11d14b59249e601e81ecfe8021d.
