### PR TITLE
TBranchElement: do not set fOnfileObject for collection parent (type 3 or 4).

### DIFF
--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2236,11 +2236,6 @@ void TBranchElement::InitInfo()
             Bool_t seenExisting = kFALSE;
 
             fOnfileObject = new TVirtualArray( info->GetElement(0)->GetClassPointer(), arrlen );
-            if (fType == 31 || fType == 41) {
-               TBranchElement *parent = (TBranchElement*)GetMother()->GetSubBranch(this);
-               if (parent && parent->fOnfileObject == nullptr)
-                  parent->fOnfileObject = fOnfileObject;
-            }
             // Propagate this to all the other branch belonging to the same object.
             TObjArray *branches = toplevel ? GetListOfBranches() : GetMother()->GetSubBranch(this)->GetListOfBranches();
             Int_t nbranches = branches->GetEntriesFast();


### PR DESCRIPTION

This assignment is both unnecessary and harmfull.

It is unnecessary because the pushd and popd of the onfile object address
for those cases is already handle by the usage of PushDataCache and PopDataCache
action for the branches of type 3 and 4 (via their configuration).

It is harmfull because the type of the used/seen in the sub-branches might
be completely different from the type of the collection content.

For example, this code was crashing some CMS jobs because the sub-branches
that had a "OnfileObject" corresponded to a nested sub-object (of type
reco::ParticleState) and then this was (unconditionally) associated with
the head node of the collection, which contained reco::PFCandidate objects
(One of PFCandidate base class contains a reco::ParticleState sub-object).

The assignment is triggered when visiting one of the child branch (type 31 or 41)
of the collection parent branch.

This is a fix for the main branch commit 875e8fb91418f9e520e5d9b22fb1d32f4a42faf0
which is fix for the issue #7754.


