### PR TITLE
[http] solve windows files problem, disable directory listing by default

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -80,6 +80,12 @@ The following lesser-used RooFit functions now return a `std::string` instead of
 
 ## Networking Libraries
 
+### THttpServer
+
+- upgrade civetweb code to version 1.15, supports SSL version 3.0
+- resolve problem with symbolic links usage on Windows
+- let disable/enable directory files listing via THttpServer (default is off)
+
 
 ## GUI Libraries
 

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -222,6 +222,10 @@ void RWebWindowsManager::AssignWindowThreadId(RWebWindow &win)
 ///
 ///      WebGui.HttpMaxAge: 3600
 ///
+/// Also one can provide extra URL options for, see TCivetweb::Create for list of supported options
+///
+///      WebGui.HttpExtraArgs: winsymlinks=no
+///
 /// One also can configure usage of FastCGI server for web windows:
 ///
 ///      WebGui.FastCgiPort: 4000
@@ -292,6 +296,7 @@ bool RWebWindowsManager::CreateServer(bool with_http)
    int http_thrds = gEnv->GetValue("WebGui.HttpThreads", 10);
    int http_wstmout = gEnv->GetValue("WebGui.HttpWSTmout", 10000);
    int http_maxage = gEnv->GetValue("WebGui.HttpMaxAge", -1);
+   const char *extra_args = gEnv->GetValue("WebGui.HttpExtraArgs", "");
    int fcgi_port = gEnv->GetValue("WebGui.FastCgiPort", 0);
    int fcgi_thrds = gEnv->GetValue("WebGui.FastCgiThreads", 10);
    const char *fcgi_serv = gEnv->GetValue("WebGui.FastCgiServer", "");
@@ -363,6 +368,11 @@ bool RWebWindowsManager::CreateServer(bool with_http)
          if (use_secure) {
             engine.Append("&ssl_cert=");
             engine.Append(ssl_cert);
+         }
+
+         if (extra_args && strlen(extra_args) > 0) {
+            engine.Append("&");
+            engine.Append(extra_args);
          }
 
          if (fServer->CreateEngine(engine)) {

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -28,12 +28,9 @@
 
 
 //////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TCivetwebWSEngine                                                    //
-//                                                                      //
-// Implementation of THttpWSEngine for Civetweb                         //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
+/// TCivetwebWSEngine
+///
+/// Implementation of THttpWSEngine for Civetweb
 
 class TCivetwebWSEngine : public THttpWSEngine {
 protected:
@@ -420,35 +417,36 @@ static int begin_request_handler(struct mg_connection *conn, void *)
 }
 
 //////////////////////////////////////////////////////////////////////////
-//                                                                      //
-// TCivetweb                                                            //
-//                                                                      //
-// http server implementation, based on civetweb embedded server        //
-// It is default kind of engine, created for THttpServer                //
-// Currently v1.8 from https://github.com/civetweb/civetweb is used     //
-//                                                                      //
-// Following additional options can be specified:                       //
-//    top=foldername - name of top folder, seen in the browser          //
-//    thrds=N - use N threads to run civetweb server (default 5)        //
-//    auth_file - global authentication file                            //
-//    auth_domain - domain name, used for authentication                //
-//                                                                      //
-// Example:                                                             //
-//    new THttpServer("http:8080?top=MyApp&thrds=3");                   //
-//                                                                      //
-// Authentication:                                                      //
-//    When auth_file and auth_domain parameters are specified, access   //
-//    to running http server will be possible only after user           //
-//    authentication, using so-call digest method. To generate          //
-//    authentication file, htdigest routine should be used:             //
-//                                                                      //
-//        [shell] htdigest -c .htdigest domain_name user                //
-//                                                                      //
-//    When creating server, parameters should be:                       //
-//                                                                      //
-//       new THttpServer("http:8080?auth_file=.htdigets&auth_domain=domain_name");  //
-//                                                                      //
-//////////////////////////////////////////////////////////////////////////
+///
+/// TCivetweb
+///
+/// http server implementation, based on civetweb embedded server
+/// It is default kind of engine, created for THttpServer
+/// Currently v1.15 from https://github.com/civetweb/civetweb is used
+///
+/// Additional options can be specified:
+///
+///     top=foldername - name of top folder, seen in the browser
+///     thrds=N - use N threads to run civetweb server (default 5)
+///     auth_file - global authentication file
+///     auth_domain - domain name, used for authentication
+///
+/// Example:
+///
+///     new THttpServer("http:8080?top=MyApp&thrds=3");
+///
+/// For the full list of supported options see TCivetweb::Create() documentation
+///
+/// When `auth_file` and `auth_domain` parameters are specified, access
+/// to running http server will be possible only after user
+/// authentication, using so-call digest method. To generate
+/// authentication file, htdigest routine should be used:
+///
+///     [shell] htdigest -c .htdigest domain_name user
+///
+/// When creating server, parameters should be:
+///
+///     new THttpServer("http:8080?auth_file=.htdigets&auth_domain=domain_name");
 
 ////////////////////////////////////////////////////////////////////////////////
 /// constructor
@@ -483,24 +481,31 @@ Int_t TCivetweb::ProcessLog(const char *message)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates embedded civetweb server
+///
+/// \param args string with civetweb server configuration
+///
 /// As main argument, http port should be specified like "8090".
 /// Or one can provide combination of ipaddress and portnumber like 127.0.0.1:8090
 /// Extra parameters like in URL string could be specified after '?' mark:
-///    thrds=N   - there N is number of threads used by the civetweb (default is 10)
-///    top=name  - configure top name, visible in the web browser
-///    ssl_certificate=filename - SSL certificate, see docs/OpenSSL.md from civetweb
-///    auth_file=filename  - authentication file name, created with htdigets utility
-///    auth_domain=domain   - authentication domain
-///    websocket_timeout=tm  - set web sockets timeout in seconds (default 300)
-///    websocket_disable - disable web sockets handling (default enabled)
-///    bind - ip address to bind server socket
-///    loopback  - bind specified port to loopback 127.0.0.1 address
-///    debug   - enable debug mode, server always returns html page with request info
-///    log=filename  - configure civetweb log file
-///    max_age=value - configures "Cache-Control: max_age=value" http header for all file-related requests, default 3600
-///    nocache - try to fully disable cache control for file requests
-///    winsymlinks=no - do not resolve symbolic links on file system (Windows only), default true
-///  Examples:
+///
+///     thrds=N   - there N is number of threads used by the civetweb (default is 10)
+///     top=name  - configure top name, visible in the web browser
+///     ssl_certificate=filename - SSL certificate, see docs/OpenSSL.md from civetweb
+///     auth_file=filename  - authentication file name, created with htdigets utility
+///     auth_domain=domain   - authentication domain
+///     websocket_timeout=tm  - set web sockets timeout in seconds (default 300)
+///     websocket_disable - disable web sockets handling (default enabled)
+///     bind - ip address to bind server socket
+///     loopback  - bind specified port to loopback 127.0.0.1 address
+///     debug   - enable debug mode, server always returns html page with request info
+///     log=filename  - configure civetweb log file
+///     max_age=value - configures "Cache-Control: max_age=value" http header for all file-related requests, default 3600
+///     nocache - try to fully disable cache control for file requests
+///     winsymlinks=no - do not resolve symbolic links on file system (Windows only), default true
+///     dirlisting=no - enable/disable directory listing for browsing filesystem (default no)
+///
+/// Examples of valid args values:
+///
 ///     http:8080?websocket_disable
 ///     http:7546?thrds=30&websocket_timeout=20
 
@@ -510,8 +515,15 @@ Bool_t TCivetweb::Create(const char *args)
    memset(fCallbacks, 0, sizeof(struct mg_callbacks));
    //((struct mg_callbacks *) fCallbacks)->begin_request = begin_request_handler;
    ((struct mg_callbacks *)fCallbacks)->log_message = log_message_handler;
-   TString sport = IsSecured() ? "8480s" : "8080", num_threads = "10", websocket_timeout = "300000";
-   TString auth_file, auth_domain, log_file, ssl_cert, max_age;
+   TString sport = IsSecured() ? "8480s" : "8080",
+           num_threads = "10",
+           websocket_timeout = "300000",
+           dir_listening = "no",
+           auth_file,
+           auth_domain,
+           log_file,
+           ssl_cert,
+           max_age;
    Bool_t use_ws = kTRUE;
 
    // extract arguments
@@ -573,6 +585,10 @@ Bool_t TCivetweb::Create(const char *args)
             if (winsymlinks)
                fWinSymLinks = strcmp(winsymlinks,"no") != 0;
 
+            const char *dls = url.GetValueFromOptions("dirlisting");
+            if (dls && (!strcmp(dls,"no") || !strcmp(dls,"yes")))
+               dir_listening = dls;
+
             if (url.HasOption("loopback") && (sport.Index(":") == kNPOS))
                sport = TString("127.0.0.1:") + sport;
 
@@ -598,7 +614,7 @@ Bool_t TCivetweb::Create(const char *args)
       }
    }
 
-   const char *options[20];
+   const char *options[25];
    int op(0);
 
    Info("Create", "Starting HTTP server on port %s", sport.Data());
@@ -639,6 +655,9 @@ Bool_t TCivetweb::Create(const char *args)
       options[op++] = "static_file_max_age";
       options[op++] = max_age.Data();
    }
+
+   options[op++] = "enable_directory_listing";
+   options[op++] = dir_listening.Data();
 
    options[op++] = nullptr;
 

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -24,6 +24,7 @@ protected:
    Bool_t fTerminating{kFALSE}; ///<! server doing shutdown and not react on requests
    Bool_t fOnlySecured{kFALSE}; ///<! if server should run only https protocol
    Int_t fMaxAge{3600};         ///<! max-age parameter
+   Bool_t fWinSymLinks{kTRUE};  ///<! resolve symbolic links on Windows
 
    void Terminate() override { fTerminating = kTRUE; }
 
@@ -40,6 +41,8 @@ public:
    Bool_t IsDebugMode() const { return fDebug; }
 
    Bool_t IsTerminating() const { return fTerminating; }
+
+   Bool_t IsWinSymLinks() const { return fWinSymLinks; }
 
    Int_t ProcessLog(const char *message);
 

--- a/net/http/src/TCivetweb.h
+++ b/net/http/src/TCivetweb.h
@@ -1,8 +1,7 @@
-// $Id$
 // Author: Sergey Linev   21/12/2013
 
 /*************************************************************************
- * Copyright (C) 1995-2013, Rene Brun and Fons Rademakers.               *
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
  * All rights reserved.                                                  *
  *                                                                       *
  * For the licensing terms see $ROOTSYS/LICENSE.                         *
@@ -15,10 +14,12 @@
 #include "THttpEngine.h"
 #include "TString.h"
 
+#include "../civetweb/civetweb.h"
+
 class TCivetweb : public THttpEngine {
 protected:
-   void *fCtx{nullptr};         ///<! civetweb context
-   void *fCallbacks{nullptr};   ///<! call-back table for civetweb webserver
+   struct mg_context *fCtx{nullptr}; ///<! civetweb context
+   struct mg_callbacks fCallbacks;  ///<! call-back table for civetweb webserver
    TString fTopName;            ///<! name of top item
    Bool_t fDebug{kFALSE};       ///<! debug mode
    Bool_t fTerminating{kFALSE}; ///<! server doing shutdown and not react on requests


### PR DESCRIPTION
With latest `civetweb` special windows files names not working
Also disable by default directory listing, can be enabled with URL arguments
Let change custom HTTP server settings for web widgets via special `gEnv` variable
Update documentation 