### PR TITLE
[cling] Do not ACLiC-link against (non-existent) libssl:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3403,6 +3403,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        || strstr(filename, "/usr/lib/libRosetta")
        || strstr(filename, "/usr/lib/libCoreEntitlements")
        || strstr(filename, "/usr/lib/libssl.")
+       || strstr(filename, "/usr/lib/libcrypto.")
        // These are candidates for suppression, too:
        //   -lfakelink -lapple_nghttp2 -lnetwork -lsqlite3 -lenergytrace -lCoreEntitlements
        //   -lMobileGestalt -lcoretls -lcoretls_cfhelpers -lxar.1 -lcompression -larchive.2

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3402,6 +3402,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        || strstr(filename, "/usr/lib/liboah")
        || strstr(filename, "/usr/lib/libRosetta")
        || strstr(filename, "/usr/lib/libCoreEntitlements")
+       || strstr(filename, "/usr/lib/libssl.")
        // These are candidates for suppression, too:
        //   -lfakelink -lapple_nghttp2 -lnetwork -lsqlite3 -lenergytrace -lCoreEntitlements
        //   -lMobileGestalt -lcoretls -lcoretls_cfhelpers -lxar.1 -lcompression -larchive.2


### PR DESCRIPTION
macOS12 moves some libs into binary blobs, they cannot be linked
against. Instead, rely on whoever needs it to dlopen it, but do
not ask ACLiC to link against it.

Fixes ArgumentPassingCompiled_C.so on macOS 12.

