### PR TITLE
[cmake] correctly copy misc files (like etc/, js/, ...) in incremental builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,17 +292,16 @@ endif()
 
 #---Copy files to the build area, with dependency---------------------------------
 file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/* etc/* test/* icons/* fonts/* macros/* ${jsroot_files} ${openui5_files})
+
+# Filter out hsimple.root
+list(REMOVE_ITEM artifact_files "tutorials/hsimple.root")
+
 set(artifact_files_builddir)
 foreach(artifact_file ${artifact_files})
-  # Filter out hsimple.root; someone might have created it in the src dir, and the hsimple.root
-  # target below will interfere.
-  if (NOT (artifact_file STREQUAL "tutorials/hsimple.root"))
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${artifact_file}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${artifact_file} ${CMAKE_BINARY_DIR}/${artifact_file}
-      COMMENT "Copying ${CMAKE_SOURCE_DIR}/${artifact_file}"
-      DEPENDS ${CMAKE_SOURCE_DIR}/${artifact_file})
-    list(APPEND artifact_files_builddir ${CMAKE_BINARY_DIR}/${artifact_file})
-  endif()
+  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${artifact_file}
+    COMMAND ${CMAKE_COMMAND} -DSRC="${CMAKE_SOURCE_DIR}/${artifact_file}" -DTGT="${CMAKE_BINARY_DIR}/${artifact_file}" -P ${CMAKE_SOURCE_DIR}/cmake/scripts/CopyFile.cmake
+    DEPENDS ${CMAKE_SOURCE_DIR}/${artifact_file})
+  list(APPEND artifact_files_builddir ${CMAKE_BINARY_DIR}/${artifact_file})
 endforeach()
 add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_files_builddir})
 

--- a/cmake/scripts/CopyFile.cmake
+++ b/cmake/scripts/CopyFile.cmake
@@ -1,0 +1,6 @@
+#arguments SRC - source file
+#          TGT - target file, use only directory
+
+get_filename_component(dir ${TGT} DIRECTORY)
+
+file(COPY ${SRC} DESTINATION ${dir})


### PR DESCRIPTION
Main problem of current approach is incremental builds.
Currently command is used: `cmake -E copy_if_different <source> <dest>`
It set current time when file is copied.
Fine if changing done locally - new file modification will trigger
file copy.

But problem appears when changes checkout from repository.
Git preserves time of last modification and this conflicts with logic
of incremental build.  Example: 

If one builds ROOT today, all files stamp will be from today in build directory.
If somebody commit changes already yesterday, all timestamps for that
changes will be from yesterday. If one checkout these commits, checked out 
files will get time stamps from yesterday.  And when running cmake - it will do nothing.

This is typical case with `js/` and `ui5/` folders with many files inside.
Very often changes in JSROOT and openui5 are missed by incremental builds.

The only way to preserve timestamp in cmake - use `file(COPY ...)` command.
This PR does exactly this. 

BUT!!! Drawback - cmake always run rule if source and target file stamps
matches. Incremental builds will be always filled with messages (even when nothing is changed).

I did not found way to convince cmake do nothing if time stamp matches.
Probably, there is somewhere the option. Maybe one can apply such brutal-force
approach for `ui5/` and `js/` folders, where main problems appears for me.

```
[ 56%] Generating tutorials/fit/graph2dfit.C
[ 56%] Generating tutorials/fit/langaus.C
[ 56%] Generating tutorials/fit/line3Dfit.C
[ 56%] Generating tutorials/fit/minuit2FitBench.C
[ 56%] Generating tutorials/fit/minuit2GausFit.C
[ 56%] Generating tutorials/fit/minuit2FitBench2D.C
[ 56%] Generating tutorials/fit/multifit.py
[ 56%] Generating tutorials/fit/myfit.C
[ 56%] Generating tutorials/fit/multifit.C
[ 56%] Generating tutorials/fit/multidimfit.C
[ 56%] Generating tutorials/fit/qa2.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial3.C
[ 56%] Generating tutorials/fit/vectorizedFit.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial1.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial2.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial5.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial4.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial6.C
[ 56%] Generating tutorials/fitsio/FITS_tutorial7.C
[ 56%] Generating tutorials/fitsio/rmf.fits
[ 56%] Generating tutorials/fitsio/FITS_tutorial8.C
[ 56%] Generating tutorials/fitsio/sample2.fits
[ 56%] Generating tutorials/fitsio/sample1.fits
[ 56%] Generating tutorials/fitsio/sample3.fits
[ 56%] Generating tutorials/fitsio/sample4.fits
[ 56%] Generating tutorials/fitsio/sample5.fits
[ 56%] Generating tutorials/foam/foam_demo.C
[ 56%] Generating tutorials/foam/foam_kanwa.C
```