### PR TITLE
[RF] Add missing `override` specifiers in RooFit

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/EstimateSummary.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/EstimateSummary.h
@@ -50,8 +50,8 @@ struct  EstimateSummary : public TObject {
 
    // simple structure to hold necessary information about each channel
    EstimateSummary();
-   virtual ~EstimateSummary();
-   void Print(const char *opt = 0) const ;
+   ~EstimateSummary() override;
+   void Print(const char *opt = 0) const override ;
    void AddSyst( const std::string & sname, TH1* low, TH1* high);
    bool operator==(const EstimateSummary &other) const ;
    bool CompareHisto( const TH1 * one, const TH1 * two) const ;
@@ -80,7 +80,7 @@ struct  EstimateSummary : public TObject {
   std::string shapeFactorName; //
   std::vector<ShapeSys> shapeSysts; //
 
-   ClassDef(RooStats::HistFactory::EstimateSummary,1)
+   ClassDefOverride(RooStats::HistFactory::EstimateSummary,1)
 };
 
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/FlexibleInterpVar.h
@@ -50,10 +50,10 @@ namespace HistFactory{
 
     void printAllInterpCodes();
 
-    virtual TObject* clone(const char* newname) const { return new FlexibleInterpVar(*this, newname); }
-    virtual ~FlexibleInterpVar() ;
+    TObject* clone(const char* newname) const override { return new FlexibleInterpVar(*this, newname); }
+    ~FlexibleInterpVar() override ;
 
-    virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose = kFALSE, TString indent = "") const;
+    void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose = kFALSE, TString indent = "") const override;
     virtual void printFlexibleInterpVars(std::ostream& os) const;
 
     const RooListProxy& variables() const;
@@ -77,9 +77,9 @@ namespace HistFactory{
     mutable Bool_t         _logInit ;            ///<! flag used for caching polynomial coefficients
     mutable std::vector< double>  _polCoeff;     ///<! cached polynomial coefficients
 
-    Double_t evaluate() const;
+    Double_t evaluate() const override;
 
-    ClassDef(RooStats::HistFactory::FlexibleInterpVar,2) // flexible interpolation
+    ClassDefOverride(RooStats::HistFactory::FlexibleInterpVar,2) // flexible interpolation
   };
 }
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryException.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistFactoryException.h
@@ -24,7 +24,7 @@ namespace RooStats{
     public:
       hf_exc(std::string message = "") : _message("HistFactory - Exception " + message) { }
 
-      virtual const char* what() const noexcept
+      const char* what() const noexcept override
       {
         return _message.c_str();
       }

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistFactorySimultaneous.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistFactorySimultaneous.h
@@ -35,22 +35,22 @@ public:
   HistFactorySimultaneous(const char *name, const char *title, const RooArgList& pdfList, RooAbsCategoryLValue& indexCat) ;
   HistFactorySimultaneous(const HistFactorySimultaneous& other, const char* name=0);
   HistFactorySimultaneous(const RooSimultaneous& other, const char* name=0);
-  ~HistFactorySimultaneous();
+  ~HistFactorySimultaneous() override;
 
-  virtual TObject* clone(const char* newname) const { return new HistFactorySimultaneous(*this,newname) ; }
+  TObject* clone(const char* newname) const override { return new HistFactorySimultaneous(*this,newname) ; }
 
-  virtual RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList);
+  RooAbsReal* createNLL(RooAbsData& data, const RooLinkedList& cmdList) override;
 
-  virtual RooAbsReal* createNLL(RooAbsData& data,
+  RooAbsReal* createNLL(RooAbsData& data,
             const RooCmdArg& arg1 = RooCmdArg::none(), const RooCmdArg& arg2 = RooCmdArg::none(),
             const RooCmdArg& arg3 = RooCmdArg::none(), const RooCmdArg& arg4 = RooCmdArg::none(),
             const RooCmdArg& arg5 = RooCmdArg::none(), const RooCmdArg& arg6 = RooCmdArg::none(),
-            const RooCmdArg& arg7 = RooCmdArg::none(), const RooCmdArg& arg8 = RooCmdArg::none());
+            const RooCmdArg& arg7 = RooCmdArg::none(), const RooCmdArg& arg8 = RooCmdArg::none()) override;
 
 
 protected:
 
-  ClassDef(RooStats::HistFactory::HistFactorySimultaneous,2)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
+  ClassDefOverride(RooStats::HistFactory::HistFactorySimultaneous,2)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
 };
 
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactory.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactory.h
@@ -39,7 +39,7 @@ namespace HistFactory{
 
      HistoToWorkspaceFactory(  std::string, std::string , std::vector<std::string> , double =200, double =20, int =0, int =6, TFile * =0);
       HistoToWorkspaceFactory();
-      virtual ~HistoToWorkspaceFactory();
+      ~HistoToWorkspaceFactory() override;
 
       void AddEfficiencyTerms(RooWorkspace* proto, std::string prefix, std::string interpName,
             std::map<std::string,std::pair<double,double> > systMap,
@@ -95,7 +95,7 @@ namespace HistFactory{
       TFile * fOut_f;
       FILE * pFile;
 
-      ClassDef(RooStats::HistFactory::HistoToWorkspaceFactory,1)
+      ClassDefOverride(RooStats::HistFactory::HistoToWorkspaceFactory,1)
   };
 
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -48,7 +48,7 @@ namespace RooStats{
 
       HistoToWorkspaceFactoryFast();
       HistoToWorkspaceFactoryFast(  RooStats::HistFactory::Measurement& Meas );
-      virtual ~HistoToWorkspaceFactoryFast();
+      ~HistoToWorkspaceFactoryFast() override;
 
       static void ConfigureWorkspaceForMeasurement( const std::string& ModelName,
                       RooWorkspace* ws_single,
@@ -139,7 +139,7 @@ namespace RooStats{
 
       RooArgList createObservables(const TH1 *hist, RooWorkspace *proto) const;
 
-      ClassDef(RooStats::HistFactory::HistoToWorkspaceFactoryFast,3)
+      ClassDefOverride(RooStats::HistFactory::HistoToWorkspaceFactoryFast,3)
     };
 
   }

--- a/roofit/histfactory/inc/RooStats/HistFactory/LinInterpVar.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/LinInterpVar.h
@@ -32,8 +32,8 @@ namespace HistFactory{
     LinInterpVar(const char *name, const char *title);
     LinInterpVar(const LinInterpVar&, const char*);
 
-    virtual TObject* clone(const char* newname) const { return new LinInterpVar(*this, newname); }
-    virtual ~LinInterpVar() ;
+    TObject* clone(const char* newname) const override { return new LinInterpVar(*this, newname); }
+    ~LinInterpVar() override ;
 
 
   protected:
@@ -45,9 +45,9 @@ namespace HistFactory{
 
     TIterator* _paramIter ;  ///<! do not persist
 
-    Double_t evaluate() const;
+    Double_t evaluate() const override;
 
-    ClassDef(RooStats::HistFactory::LinInterpVar,1) // Piecewise linear interpolation
+    ClassDefOverride(RooStats::HistFactory::LinInterpVar,1) // Piecewise linear interpolation
   };
 }
 }

--- a/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
@@ -160,7 +160,7 @@ private:
 
   std::string GetDirPath( TDirectory* dir );
 
-  ClassDef(RooStats::HistFactory::Measurement, 3);
+  ClassDefOverride(RooStats::HistFactory::Measurement, 3);
 
 };
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -27,10 +27,10 @@ public:
   ParamHistFunc() ;
   ParamHistFunc(const char *name, const char *title, const RooArgList& vars, const RooArgList& paramSet );
   ParamHistFunc(const char *name, const char *title, const RooArgList& vars, const RooArgList& paramSet, const TH1* hist );
-  virtual ~ParamHistFunc() ;
+  ~ParamHistFunc() override ;
 
   ParamHistFunc(const ParamHistFunc& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const override { return new ParamHistFunc(*this, newname); }
+  TObject* clone(const char* newname) const override { return new ParamHistFunc(*this, newname); }
 
   const RooArgList& paramList() const { return _paramSet ; }
 
@@ -49,7 +49,7 @@ public:
 
   double binVolume() const { return _dataSet.binVolume(); }
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
+  Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
 
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override;
   Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override;
@@ -58,9 +58,9 @@ public:
   static RooArgList createParamSet(RooWorkspace& w, const std::string&, const RooArgList& Vars, Double_t, Double_t);
   static RooArgList createParamSet(const std::string&, Int_t, Double_t, Double_t);
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override;
-  virtual Bool_t isBinnedDistribution(const RooArgSet& /*obs*/) const override { return true; }
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override;
+  Bool_t isBinnedDistribution(const RooArgSet& /*obs*/) const override { return true; }
 
 
 protected:
@@ -68,8 +68,8 @@ protected:
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem()  {} ;
-    virtual ~CacheElem() {} ;
-    virtual RooArgList containedArgs(Action) {
+    ~CacheElem() override {} ;
+    RooArgList containedArgs(Action) override {
       RooArgList ret(_funcIntList) ;
       ret.add(_lowIntList);
       ret.add(_highIntList);

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -32,10 +32,10 @@ public:
 
   PiecewiseInterpolation() ;
   PiecewiseInterpolation(const char *name, const char *title, const RooAbsReal& nominal, const RooArgList& lowSet, const RooArgList& highSet, const RooArgList& paramSet, Bool_t takeOwnerShip=kFALSE) ;
-  virtual ~PiecewiseInterpolation() ;
+  ~PiecewiseInterpolation() override ;
 
   PiecewiseInterpolation(const PiecewiseInterpolation& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new PiecewiseInterpolation(*this, newname); }
+  TObject* clone(const char* newname) const override { return new PiecewiseInterpolation(*this, newname); }
 
   /// Return pointer to the nominal hist function.
   const RooAbsReal* nominalHist() const {
@@ -54,8 +54,8 @@ public:
   //virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const { return kTRUE ; }
   Bool_t setBinIntegrator(RooArgSet& allVars) ;
 
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   void setPositiveDefinite(bool flag=true){_positiveDefinite=flag;}
 
@@ -63,17 +63,17 @@ public:
   void setAllInterpCodes(int code);
   void printAllInterpCodes();
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ;
-  virtual Bool_t isBinnedDistribution(const RooArgSet& obs) const ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet& obs) const override ;
 
 protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem()  {} ;
-    virtual ~CacheElem() {} ;
-    virtual RooArgList containedArgs(Action) {
+    ~CacheElem() override {} ;
+    RooArgList containedArgs(Action) override {
       RooArgList ret(_funcIntList) ;
       ret.add(_lowIntList);
       ret.add(_highIntList);
@@ -96,10 +96,10 @@ protected:
 
   std::vector<int> _interpCode;
 
-  Double_t evaluate() const;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
+  Double_t evaluate() const override;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
 
-  ClassDef(PiecewiseInterpolation,4) // Sum of RooAbsReal objects
+  ClassDefOverride(PiecewiseInterpolation,4) // Sum of RooAbsReal objects
 };
 
 #endif

--- a/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
@@ -28,8 +28,8 @@ public:
   RooBarlowBeestonLL() ;
   RooBarlowBeestonLL(const char *name, const char *title, RooAbsReal& nll /*, const RooArgSet& observables*/);
   RooBarlowBeestonLL(const RooBarlowBeestonLL& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooBarlowBeestonLL(*this,newname); }
-  virtual ~RooBarlowBeestonLL() ;
+  TObject* clone(const char* newname) const override { return new RooBarlowBeestonLL(*this,newname); }
+  ~RooBarlowBeestonLL() override ;
 
   // A simple class to store the
   // necessary objects for a
@@ -49,12 +49,12 @@ public:
   };
 
   void initializeBarlowCache();
-  bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const;
+  bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const override;
   RooAbsReal& nll() { return const_cast<RooAbsReal&>(_nll.arg()) ; }
-  virtual bool redirectServersHook(const RooAbsCollection& /*newServerList*/,
+  bool redirectServersHook(const RooAbsCollection& /*newServerList*/,
                                    bool /*mustReplaceAll*/,
                                    bool /*nameChange*/,
-                                   bool /*isRecursive*/) ;
+                                   bool /*isRecursive*/) override ;
   void setPdf(RooAbsPdf* pdf) { _pdf = pdf; }
   void setDataset(RooAbsData* data) { _data = data; }
 
@@ -66,12 +66,12 @@ protected:
   mutable std::map< std::string, std::vector< BarlowCache > > _barlowCache;
   mutable std::set< std::string > _statUncertParams;
   mutable std::map<std::string,bool> _paramFixed ; ///< Parameter constant status at last time of use
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
   // Real-valued function representing a Barlow-Beeston minimized profile likelihood of external (likelihood) function
-  ClassDef(RooStats::HistFactory::RooBarlowBeestonLL,0)
+  ClassDefOverride(RooStats::HistFactory::RooBarlowBeestonLL,0)
 };
 
   }

--- a/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Systematics.h
@@ -204,8 +204,8 @@ namespace HistFactory {
  */
 class HistoSys final : public HistogramUncertaintyBase {
 public:
-  virtual ~HistoSys() {}
-  virtual void PrintXML(std::ostream&) const override;
+  ~HistoSys() override {}
+  void PrintXML(std::ostream&) const override;
 };
 
 /** \class HistoFactor
@@ -214,7 +214,7 @@ public:
  */
   class HistoFactor final : public HistogramUncertaintyBase {
   public:
-    virtual ~HistoFactor() {}
+    ~HistoFactor() override {}
     void PrintXML(std::ostream&) const override;
   };
 

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -116,7 +116,7 @@ protected:
 public:
    class MissingRootnodeError : public std::exception {
    public:
-      virtual const char *what() const noexcept override { return "no rootnode set"; }
+      const char *what() const noexcept override { return "no rootnode set"; }
    };
 
    class DependencyMissingError : public std::exception {
@@ -131,7 +131,7 @@ public:
       const std::string &parent() const { return _parent; }
       const std::string &child() const { return _child; }
       const std::string &classname() const { return _class; }
-      virtual const char *what() const noexcept override { return _message.c_str(); }
+      const char *what() const noexcept override { return _message.c_str(); }
    };
    friend DependencyMissingError;
 

--- a/roofit/hs3/src/JSONInterface.cxx
+++ b/roofit/hs3/src/JSONInterface.cxx
@@ -19,14 +19,14 @@ public:
    using child_iterator = RooFit::Experimental::JSONNode::child_iterator_t<Nd>;
    ChildItImpl(Nd &n, size_t p) : node(n), pos(p) {}
    ChildItImpl(const ChildItImpl &other) : node(other.node), pos(other.pos) {}
-   virtual std::unique_ptr<typename child_iterator::Impl> clone() const override
+   std::unique_ptr<typename child_iterator::Impl> clone() const override
    {
       return std::make_unique<ChildItImpl>(node, pos);
    }
-   virtual void forward() override { ++pos; }
-   virtual void backward() override { --pos; }
-   virtual Nd &current() override { return node.child(pos); }
-   virtual bool equal(const typename child_iterator::Impl &other) const override
+   void forward() override { ++pos; }
+   void backward() override { --pos; }
+   Nd &current() override { return node.child(pos); }
+   bool equal(const typename child_iterator::Impl &other) const override
    {
       auto it = dynamic_cast<const ChildItImpl<Nd> *>(&other);
       return it && &(it->node) == &(this->node) && (it->pos) == this->pos;

--- a/roofit/hs3/src/JSONParser.cxx
+++ b/roofit/hs3/src/JSONParser.cxx
@@ -85,8 +85,8 @@ class TJSONTree::Node::Impl::BaseNode : public TJSONTree::Node::Impl {
    nlohmann::json node;
 
 public:
-   virtual nlohmann::json &get() override { return node; }
-   virtual const nlohmann::json &get() const override { return node; }
+   nlohmann::json &get() override { return node; }
+   const nlohmann::json &get() const override { return node; }
    BaseNode(std::istream &is) : Impl(""), node(nlohmann::json::parse(is)) {}
    BaseNode() : Impl("") {}
 };
@@ -95,8 +95,8 @@ class TJSONTree::Node::Impl::NodeRef : public TJSONTree::Node::Impl {
    nlohmann::json &node;
 
 public:
-   virtual nlohmann::json &get() override { return node; }
-   virtual const nlohmann::json &get() const override { return node; }
+   nlohmann::json &get() override { return node; }
+   const nlohmann::json &get() const override { return node; }
    NodeRef(const std::string &k, nlohmann::json &n) : Impl(k), node(n) {}
    NodeRef(const NodeRef &other) : Impl(other.key()), node(other.node) {}
 };
@@ -345,13 +345,13 @@ public:
    ChildItImpl(NdType &n, json_it it) : node(n), iter(it) {}
    ChildItImpl(const ChildItImpl &other) : node(other.node), iter(other.iter) {}
    using child_iterator = RooFit::Experimental::JSONNode::child_iterator_t<Nd>;
-   virtual std::unique_ptr<typename child_iterator::Impl> clone() const override
+   std::unique_ptr<typename child_iterator::Impl> clone() const override
    {
       return std::make_unique<ChildItImpl>(node, iter);
    }
-   virtual void forward() override { ++iter; }
-   virtual void backward() override { --iter; }
-   virtual Nd &current() override
+   void forward() override { ++iter; }
+   void backward() override { --iter; }
+   Nd &current() override
    {
       if (node.is_seq()) {
          return TJSONTree::Node::Impl::mkNode(node.get_tree(), "", iter.value());
@@ -359,7 +359,7 @@ public:
          return TJSONTree::Node::Impl::mkNode(node.get_tree(), iter.key(), iter.value());
       }
    }
-   virtual bool equal(const typename child_iterator::Impl &other) const override
+   bool equal(const typename child_iterator::Impl &other) const override
    {
       auto it = dynamic_cast<const ChildItImpl<Nd, NdType, json_it> *>(&other);
       return it && it->iter == this->iter;

--- a/roofit/hs3/src/JSONParser.h
+++ b/roofit/hs3/src/JSONParser.h
@@ -36,38 +36,38 @@ public:
       Impl &get_node();
 
    public:
-      virtual void writeJSON(std::ostream &os) const override;
+      void writeJSON(std::ostream &os) const override;
 
       Node(TJSONTree *t, std::istream &is);
       Node(TJSONTree *t, Impl &other);
       Node(TJSONTree *t);
       Node(const Node &other);
       virtual ~Node();
-      virtual Node &operator<<(std::string const &s) override;
-      virtual Node &operator<<(int i) override;
-      virtual Node &operator<<(double d) override;
-      virtual const Node &operator>>(std::string &v) const override;
-      virtual Node &operator[](std::string const &k) override;
-      virtual Node &operator[](size_t pos) override;
-      virtual const Node &operator[](std::string const &k) const override;
-      virtual const Node &operator[](size_t pos) const override;
-      virtual bool is_container() const override;
-      virtual bool is_map() const override;
-      virtual bool is_seq() const override;
-      virtual void set_map() override;
-      virtual void set_seq() override;
-      virtual std::string key() const override;
-      virtual std::string val() const override;
-      virtual int val_int() const override;
-      virtual float val_float() const override;
-      virtual bool val_bool() const override;
-      virtual bool has_key() const override;
-      virtual bool has_val() const override;
-      virtual bool has_child(std::string const &) const override;
-      virtual Node &append_child() override;
-      virtual size_t num_children() const override;
-      virtual Node &child(size_t pos) override;
-      virtual const Node &child(size_t pos) const override;
+      Node &operator<<(std::string const &s) override;
+      Node &operator<<(int i) override;
+      Node &operator<<(double d) override;
+      const Node &operator>>(std::string &v) const override;
+      Node &operator[](std::string const &k) override;
+      Node &operator[](size_t pos) override;
+      const Node &operator[](std::string const &k) const override;
+      const Node &operator[](size_t pos) const override;
+      bool is_container() const override;
+      bool is_map() const override;
+      bool is_seq() const override;
+      void set_map() override;
+      void set_seq() override;
+      std::string key() const override;
+      std::string val() const override;
+      int val_int() const override;
+      float val_float() const override;
+      bool val_bool() const override;
+      bool has_key() const override;
+      bool has_val() const override;
+      bool has_child(std::string const &) const override;
+      Node &append_child() override;
+      size_t num_children() const override;
+      Node &child(size_t pos) override;
+      const Node &child(size_t pos) const override;
 
       children_view children() override;
       const_children_view children() const override;
@@ -84,6 +84,6 @@ public:
    TJSONTree(std::istream &is);
    TJSONTree::Node &incache(const TJSONTree::Node &n);
 
-   virtual Node &rootnode() override;
+   Node &rootnode() override;
 };
 #endif

--- a/roofit/roofit/inc/Roo2DKeysPdf.h
+++ b/roofit/roofit/inc/Roo2DKeysPdf.h
@@ -28,9 +28,9 @@ public:
   Roo2DKeysPdf(const char *name, const char *title,
              RooAbsReal& xx, RooAbsReal &yy, RooDataSet& data, TString options = "a", Double_t widthScaleFactor = 1.0);
   Roo2DKeysPdf(const Roo2DKeysPdf& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new Roo2DKeysPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new Roo2DKeysPdf(*this,newname); }
 
-  virtual ~Roo2DKeysPdf();
+  ~Roo2DKeysPdf() override;
 
 //load in a new dataset and re-calculate the PDF
 //return 0 if successful
@@ -78,7 +78,7 @@ public:
   RooRealProxy x;
   RooRealProxy y;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 protected:
 
@@ -118,7 +118,7 @@ private:
   Int_t      _verbosedebug;
   Int_t      _vverbosedebug;
 
-  ClassDef(Roo2DKeysPdf,0) // Two-dimensional kernel estimation p.d.f.
+  ClassDefOverride(Roo2DKeysPdf,0) // Two-dimensional kernel estimation p.d.f.
 };
 
 inline void  Roo2DKeysPdf::setWidthScaleFactor(Double_t widthScaleFactor) { _widthScaleFactor = widthScaleFactor; }

--- a/roofit/roofit/inc/RooArgusBG.h
+++ b/roofit/roofit/inc/RooArgusBG.h
@@ -27,11 +27,11 @@ public:
   RooArgusBG(const char *name, const char *title,
         RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c, RooAbsReal& _p);
   RooArgusBG(const RooArgusBG& other,const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooArgusBG(*this,newname); }
-  inline virtual ~RooArgusBG() { }
+  TObject* clone(const char* newname) const override { return new RooArgusBG(*this,newname); }
+  inline ~RooArgusBG() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
   RooRealProxy m ;
@@ -39,15 +39,15 @@ protected:
   RooRealProxy c ;
   RooRealProxy p ;
 
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 
 //   void initGenerator();
 
 private:
-  ClassDef(RooArgusBG,1) // Argus background shape PDF
+  ClassDefOverride(RooArgusBG,1) // Argus background shape PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooBCPEffDecay.h
+++ b/roofit/roofit/inc/RooBCPEffDecay.h
@@ -36,17 +36,17 @@ public:
        const RooResolutionModel& model, DecayType type=DoubleSided) ;
 
   RooBCPEffDecay(const RooBCPEffDecay& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooBCPEffDecay(*this,newname) ; }
-  virtual ~RooBCPEffDecay();
+  TObject* clone(const char* newname) const override { return new RooBCPEffDecay(*this,newname) ; }
+  ~RooBCPEffDecay() override;
 
-  virtual Double_t coefficient(Int_t basisIndex) const ;
+  Double_t coefficient(Int_t basisIndex) const override ;
 
-  virtual Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void initGenerator(Int_t code) ;
-  void generateEvent(Int_t code) ;
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void initGenerator(Int_t code) override ;
+  void generateEvent(Int_t code) override ;
 
 protected:
 
@@ -67,7 +67,7 @@ protected:
   Int_t _basisSin ;
   Int_t _basisCos ;
 
-  ClassDef(RooBCPEffDecay,1) // B Mixing decay PDF
+  ClassDefOverride(RooBCPEffDecay,1) // B Mixing decay PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooBCPGenDecay.h
+++ b/roofit/roofit/inc/RooBCPGenDecay.h
@@ -37,17 +37,17 @@ public:
        const RooResolutionModel& model, DecayType type=DoubleSided) ;
 
   RooBCPGenDecay(const RooBCPGenDecay& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooBCPGenDecay(*this,newname) ; }
-  virtual ~RooBCPGenDecay();
+  TObject* clone(const char* newname) const override { return new RooBCPGenDecay(*this,newname) ; }
+  ~RooBCPGenDecay() override;
 
-  virtual Double_t coefficient(Int_t basisIndex) const ;
+  Double_t coefficient(Int_t basisIndex) const override ;
 
-  virtual Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void initGenerator(Int_t code) ;
-  void generateEvent(Int_t code) ;
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void initGenerator(Int_t code) override ;
+  void generateEvent(Int_t code) override ;
 
 protected:
 
@@ -67,7 +67,7 @@ protected:
   Int_t _basisSin ;
   Int_t _basisCos ;
 
-  ClassDef(RooBCPGenDecay,1)  // B decay time distribution with CP violation
+  ClassDefOverride(RooBCPGenDecay,1)  // B decay time distribution with CP violation
 };
 
 #endif

--- a/roofit/roofit/inc/RooBDecay.h
+++ b/roofit/roofit/inc/RooBDecay.h
@@ -38,20 +38,20 @@ public:
          const RooResolutionModel& model,
          DecayType type);
   RooBDecay(const RooBDecay& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const
+  TObject* clone(const char* newname) const override
   {
     return new RooBDecay(*this,newname);
   }
-  virtual ~RooBDecay();
+  ~RooBDecay() override;
 
-  virtual Double_t coefficient(Int_t basisIndex) const;
-  RooArgSet* coefVars(Int_t coefIdx) const ;
+  Double_t coefficient(Int_t basisIndex) const override;
+  RooArgSet* coefVars(Int_t coefIdx) const override ;
 
-  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
 protected:
 
@@ -70,7 +70,7 @@ protected:
   Int_t _basisB;
   DecayType _type;
 
-  ClassDef(RooBDecay, 1) // P.d.f of general description of B decay time distribution
+  ClassDefOverride(RooBDecay, 1) // P.d.f of general description of B decay time distribution
     };
 
 #endif

--- a/roofit/roofit/inc/RooBMixDecay.h
+++ b/roofit/roofit/inc/RooBMixDecay.h
@@ -34,17 +34,17 @@ public:
           DecayType type=DoubleSided) ;
 
   RooBMixDecay(const RooBMixDecay& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooBMixDecay(*this,newname) ; }
-  virtual ~RooBMixDecay();
+  TObject* clone(const char* newname) const override { return new RooBMixDecay(*this,newname) ; }
+  ~RooBMixDecay() override;
 
-  virtual Double_t coefficient(Int_t basisIndex) const ;
+  Double_t coefficient(Int_t basisIndex) const override ;
 
-  virtual Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void initGenerator(Int_t code) ;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void initGenerator(Int_t code) override ;
+  void generateEvent(Int_t code) override;
 
 protected:
 
@@ -64,7 +64,7 @@ protected:
   Double_t _genFlavFracMix ;   //!
   Double_t _genFlavFracUnmix ; //!
 
-  ClassDef(RooBMixDecay,1) // B Mixing decay PDF
+  ClassDefOverride(RooBMixDecay,1) // B Mixing decay PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooBernstein.h
+++ b/roofit/roofit/inc/RooBernstein.h
@@ -31,12 +31,12 @@ public:
                RooAbsRealLValue& _x, const RooArgList& _coefList) ;
 
   RooBernstein(const RooBernstein& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooBernstein(*this, newname); }
-  inline virtual ~RooBernstein() { }
+  TObject* clone(const char* newname) const override { return new RooBernstein(*this, newname); }
+  inline ~RooBernstein() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
-  void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) override ;
 
 private:
   
@@ -44,11 +44,11 @@ private:
   RooListProxy _coefList ;
   std::string _refRangeName ;
 
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
-  ClassDef(RooBernstein,2) // Bernstein polynomial PDF
+  ClassDefOverride(RooBernstein,2) // Bernstein polynomial PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooBifurGauss.h
+++ b/roofit/roofit/inc/RooBifurGauss.h
@@ -28,11 +28,11 @@ public:
       RooAbsReal& _mean, RooAbsReal& _sigmaL, RooAbsReal& _sigmaR);
 
   RooBifurGauss(const RooBifurGauss& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooBifurGauss(*this,newname); }
-  inline virtual ~RooBifurGauss() { }
+  TObject* clone(const char* newname) const override { return new RooBifurGauss(*this,newname); }
+  inline ~RooBifurGauss() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 
 protected:
@@ -42,13 +42,13 @@ protected:
   RooRealProxy sigmaL;
   RooRealProxy sigmaR;
 
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
 
-  ClassDef(RooBifurGauss,1) // Bifurcated Gaussian PDF
+  ClassDefOverride(RooBifurGauss,1) // Bifurcated Gaussian PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooBreitWigner.h
+++ b/roofit/roofit/inc/RooBreitWigner.h
@@ -28,11 +28,11 @@ public:
   RooBreitWigner(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _width);
   RooBreitWigner(const RooBreitWigner& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooBreitWigner(*this,newname); }
-  inline virtual ~RooBreitWigner() { }
+  TObject* clone(const char* newname) const override { return new RooBreitWigner(*this,newname); }
+  inline ~RooBreitWigner() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -40,16 +40,16 @@ protected:
   RooRealProxy mean ;
   RooRealProxy width ;
 
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 //   void initGenerator();
 //   Int_t generateDependents();
 
 private:
 
-  ClassDef(RooBreitWigner,1) // Breit Wigner PDF
+  ClassDefOverride(RooBreitWigner,1) // Breit Wigner PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooBukinPdf.h
+++ b/roofit/roofit/inc/RooBukinPdf.h
@@ -37,8 +37,8 @@ public:
 
   RooBukinPdf(const RooBukinPdf& other,const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooBukinPdf(*this,newname);   }
-  inline virtual ~RooBukinPdf() { }
+  TObject* clone(const char* newname) const override { return new RooBukinPdf(*this,newname);   }
+  inline ~RooBukinPdf() override { }
 
 protected:
   RooRealProxy x;
@@ -47,13 +47,13 @@ protected:
   RooRealProxy xi;
   RooRealProxy rho1;
   RooRealProxy rho2;
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
 
-  ClassDef(RooBukinPdf,2) // Variation of Novosibirsk PDF
+  ClassDefOverride(RooBukinPdf,2) // Variation of Novosibirsk PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooCBShape.h
+++ b/roofit/roofit/inc/RooCBShape.h
@@ -29,16 +29,16 @@ public:
         RooAbsReal& _alpha, RooAbsReal& _n);
 
   RooCBShape(const RooCBShape& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooCBShape(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooCBShape(*this,newname); }
 
-  inline virtual ~RooCBShape() { }
+  inline ~RooCBShape() override { }
 
-  virtual Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=0 ) const;
-  virtual Double_t analyticalIntegral( Int_t code, const char* rangeName=0 ) const;
+  Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=0 ) const override;
+  Double_t analyticalIntegral( Int_t code, const char* rangeName=0 ) const override;
 
   // Optimized accept/reject generator support
-  virtual Int_t getMaxVal(const RooArgSet& vars) const ;
-  virtual Double_t maxVal(Int_t code) const ;
+  Int_t getMaxVal(const RooArgSet& vars) const override ;
+  Double_t maxVal(Int_t code) const override ;
 
 protected:
 
@@ -50,14 +50,14 @@ protected:
   RooRealProxy alpha;
   RooRealProxy n;
 
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 
 private:
 
-  ClassDef(RooCBShape,1) // Crystal Ball lineshape PDF
+  ClassDefOverride(RooCBShape,1) // Crystal Ball lineshape PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooCFunction1Binding.h
+++ b/roofit/roofit/inc/RooCFunction1Binding.h
@@ -93,7 +93,7 @@ class RooCFunction1Ref : public TObject {
   RooCFunction1Ref(VO (*ptr)(VI)=0) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
-  ~RooCFunction1Ref() {} ;
+  ~RooCFunction1Ref() override {} ;
 
   VO operator()(VI x) const {
     // Evaluate embedded function
@@ -137,7 +137,7 @@ class RooCFunction1Ref : public TObject {
 
   static RooCFunction1Map<VO,VI>* _fmap ; // Pointer to mapping service object
 
-  ClassDef(RooCFunction1Ref,1) // Persistable reference to C function pointer
+  ClassDefOverride(RooCFunction1Ref,1) // Persistable reference to C function pointer
 } ;
 
 // Define static member
@@ -224,10 +224,10 @@ public:
   } ;
   RooCFunction1Binding(const char *name, const char *title, VO (*_func)(VI), RooAbsReal& _x);
   RooCFunction1Binding(const RooCFunction1Binding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction1Binding(*this,newname); }
-  inline virtual ~RooCFunction1Binding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction1Binding(*this,newname); }
+  inline ~RooCFunction1Binding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -245,14 +245,14 @@ protected:
   RooCFunction1Ref<VO,VI> func ; // Function pointer reference
   RooRealProxy x ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x) ;
   }
 
 private:
 
-  ClassDef(RooCFunction1Binding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction1Binding,1) // RooAbsReal binding to external C functions
 };
 
 
@@ -288,10 +288,10 @@ public:
   } ;
   RooCFunction1PdfBinding(const char *name, const char *title, VO (*_func)(VI), RooAbsReal& _x);
   RooCFunction1PdfBinding(const RooCFunction1PdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction1PdfBinding(*this,newname); }
-  inline virtual ~RooCFunction1PdfBinding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction1PdfBinding(*this,newname); }
+  inline ~RooCFunction1PdfBinding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -309,14 +309,14 @@ protected:
   RooCFunction1Ref<VO,VI> func ; // Function pointer reference
   RooRealProxy x ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x) ;
   }
 
 private:
 
-  ClassDef(RooCFunction1PdfBinding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction1PdfBinding,1) // RooAbsReal binding to external C functions
 };
 
 

--- a/roofit/roofit/inc/RooCFunction2Binding.h
+++ b/roofit/roofit/inc/RooCFunction2Binding.h
@@ -102,7 +102,7 @@ class RooCFunction2Ref : public TObject {
   RooCFunction2Ref(VO (*ptr)(VI1,VI2)=0) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
-  ~RooCFunction2Ref() {} ;
+  ~RooCFunction2Ref() override {} ;
 
   VO operator()(VI1 x,VI2 y) const {
     // Evaluate embedded function
@@ -152,7 +152,7 @@ class RooCFunction2Ref : public TObject {
 
   static RooCFunction2Map<VO,VI1,VI2>* _fmap ; // Pointer to mapping service object
 
-  ClassDef(RooCFunction2Ref,1) // Persistable reference to C function pointer
+  ClassDefOverride(RooCFunction2Ref,1) // Persistable reference to C function pointer
 } ;
 
 // Define static member
@@ -234,10 +234,10 @@ public:
   } ;
   RooCFunction2Binding(const char *name, const char *title, VO (*_func)(VI1,VI2), RooAbsReal& _x, RooAbsReal& _y);
   RooCFunction2Binding(const RooCFunction2Binding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction2Binding(*this,newname); }
-  inline virtual ~RooCFunction2Binding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction2Binding(*this,newname); }
+  inline ~RooCFunction2Binding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -256,14 +256,14 @@ protected:
   RooRealProxy x ;              // Argument reference
   RooRealProxy y ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x,y) ;
   }
 
 private:
 
-  ClassDef(RooCFunction2Binding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction2Binding,1) // RooAbsReal binding to external C functions
 };
 
 template<class VO,class VI1, class VI2>
@@ -302,10 +302,10 @@ public:
   } ;
   RooCFunction2PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2), RooAbsReal& _x, RooAbsReal& _y);
   RooCFunction2PdfBinding(const RooCFunction2PdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction2PdfBinding(*this,newname); }
-  inline virtual ~RooCFunction2PdfBinding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction2PdfBinding(*this,newname); }
+  inline ~RooCFunction2PdfBinding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -324,14 +324,14 @@ protected:
   RooRealProxy x ;              // Argument reference
   RooRealProxy y ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x,y) ;
   }
 
 private:
 
-  ClassDef(RooCFunction2PdfBinding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction2PdfBinding,1) // RooAbsReal binding to external C functions
 };
 
 template<class VO,class VI1, class VI2>

--- a/roofit/roofit/inc/RooCFunction3Binding.h
+++ b/roofit/roofit/inc/RooCFunction3Binding.h
@@ -104,7 +104,7 @@ class RooCFunction3Ref : public TObject {
   RooCFunction3Ref(VO (*ptr)(VI1,VI2,VI3)=0) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
-  ~RooCFunction3Ref() {} ;
+  ~RooCFunction3Ref() override {} ;
 
   VO operator()(VI1 x,VI2 y, VI3 z) const {
     // Evaluate embedded function
@@ -155,7 +155,7 @@ class RooCFunction3Ref : public TObject {
 
   static RooCFunction3Map<VO,VI1,VI2,VI3>* _fmap ; // Pointer to mapping service object
 
-  ClassDef(RooCFunction3Ref,1) // Persistable reference to C function pointer
+  ClassDefOverride(RooCFunction3Ref,1) // Persistable reference to C function pointer
 } ;
 
 // Define static member
@@ -244,10 +244,10 @@ public:
   } ;
   RooCFunction3Binding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z);
   RooCFunction3Binding(const RooCFunction3Binding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction3Binding(*this,newname); }
-  inline virtual ~RooCFunction3Binding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction3Binding(*this,newname); }
+  inline ~RooCFunction3Binding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -267,14 +267,14 @@ protected:
   RooRealProxy y ;              // Argument reference
   RooRealProxy z ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x,y,z) ;
   }
 
 private:
 
-  ClassDef(RooCFunction3Binding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction3Binding,1) // RooAbsReal binding to external C functions
 };
 
 
@@ -315,10 +315,10 @@ public:
   } ;
   RooCFunction3PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z);
   RooCFunction3PdfBinding(const RooCFunction3PdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction3PdfBinding(*this,newname); }
-  inline virtual ~RooCFunction3PdfBinding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction3PdfBinding(*this,newname); }
+  inline ~RooCFunction3PdfBinding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -338,14 +338,14 @@ protected:
   RooRealProxy y ;              // Argument reference
   RooRealProxy z ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x,y,z) ;
   }
 
 private:
 
-  ClassDef(RooCFunction3PdfBinding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction3PdfBinding,1) // RooAbsReal binding to external C functions
 };
 
 

--- a/roofit/roofit/inc/RooCFunction4Binding.h
+++ b/roofit/roofit/inc/RooCFunction4Binding.h
@@ -100,7 +100,7 @@ class RooCFunction4Ref : public TObject {
   RooCFunction4Ref(VO (*ptr)(VI1,VI2,VI3,VI4)=0) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
-  ~RooCFunction4Ref() {} ;
+  ~RooCFunction4Ref() override {} ;
 
   VO operator()(VI1 x,VI2 y,VI3 z,VI4 w) const {
     // Evaluate embedded function
@@ -150,7 +150,7 @@ class RooCFunction4Ref : public TObject {
 
   static RooCFunction4Map<VO,VI1,VI2,VI3,VI4>* _fmap ; // Pointer to mapping service object
 
-  ClassDef(RooCFunction4Ref,1) // Persistable reference to C function pointer
+  ClassDefOverride(RooCFunction4Ref,1) // Persistable reference to C function pointer
 } ;
 
 // Define static member
@@ -231,10 +231,10 @@ public:
   } ;
   RooCFunction4Binding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3,VI4), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z, RooAbsReal& _w);
   RooCFunction4Binding(const RooCFunction4Binding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction4Binding(*this,newname); }
-  inline virtual ~RooCFunction4Binding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction4Binding(*this,newname); }
+  inline ~RooCFunction4Binding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -255,14 +255,14 @@ protected:
   RooRealProxy z ;              // Argument reference
   RooRealProxy w ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x,y,z,w) ;
   }
 
 private:
 
-  ClassDef(RooCFunction4Binding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction4Binding,1) // RooAbsReal binding to external C functions
 };
 
 
@@ -304,10 +304,10 @@ public:
   } ;
   RooCFunction4PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3,VI4), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z, RooAbsReal& _w);
   RooCFunction4PdfBinding(const RooCFunction4PdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCFunction4PdfBinding(*this,newname); }
-  inline virtual ~RooCFunction4PdfBinding() { }
+  TObject* clone(const char* newname) const override { return new RooCFunction4PdfBinding(*this,newname); }
+  inline ~RooCFunction4PdfBinding() override { }
 
-  void printArgs(std::ostream& os) const {
+  void printArgs(std::ostream& os) const override {
     // Print object arguments and name/address of function pointer
     os << "[ function=" << func.name() << " " ;
     for (Int_t i=0 ; i<numProxies() ; i++) {
@@ -328,14 +328,14 @@ protected:
   RooRealProxy z ;              // Argument reference
   RooRealProxy w ;              // Argument reference
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     // Return value of embedded function using value of referenced variable x
     return func(x,y,z,w) ;
   }
 
 private:
 
-  ClassDef(RooCFunction4PdfBinding,1) // RooAbsReal binding to external C functions
+  ClassDefOverride(RooCFunction4PdfBinding,1) // RooAbsReal binding to external C functions
 };
 
 

--- a/roofit/roofit/inc/RooChebychev.h
+++ b/roofit/roofit/inc/RooChebychev.h
@@ -30,13 +30,13 @@ public:
                RooAbsReal& _x, const RooArgList& _coefList) ;
 
   RooChebychev(const RooChebychev& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooChebychev(*this, newname); }
-  inline virtual ~RooChebychev() { }
+  TObject* clone(const char* newname) const override { return new RooChebychev(*this, newname); }
+  inline ~RooChebychev() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   
-  virtual void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) ;
+  void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) override ;
   
 private:
 
@@ -44,13 +44,13 @@ private:
   RooListProxy _coefList ;
   mutable TNamed* _refRangeName ; 
 
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
   
   Double_t evalAnaInt(const Double_t a, const Double_t b) const;
 
-  ClassDef(RooChebychev,2) // Chebychev polynomial PDF
+  ClassDefOverride(RooChebychev,2) // Chebychev polynomial PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooChi2MCSModule.h
+++ b/roofit/roofit/inc/RooChi2MCSModule.h
@@ -24,12 +24,12 @@ public:
 
   RooChi2MCSModule() ;
   RooChi2MCSModule(const RooChi2MCSModule& other) ;
-  virtual ~RooChi2MCSModule() ;
+  ~RooChi2MCSModule() override ;
 
-  Bool_t initializeInstance() ;
-  Bool_t initializeRun(Int_t /*numSamples*/) ;
-  RooDataSet* finalizeRun() ;
-  Bool_t processAfterFit(Int_t /*sampleNum*/)  ;
+  Bool_t initializeInstance() override ;
+  Bool_t initializeRun(Int_t /*numSamples*/) override ;
+  RooDataSet* finalizeRun() override ;
+  Bool_t processAfterFit(Int_t /*sampleNum*/) override  ;
 
 private:
 
@@ -39,7 +39,7 @@ private:
   RooRealVar* _chi2red ; // Reduced Chi^2 w.r.t data
   RooRealVar* _prob ;    // Probability of chi^2,nDOF combination
 
-  ClassDef(RooChi2MCSModule,0) // MCStudy module to calculate chi2 between binned data and fit
+  ClassDefOverride(RooChi2MCSModule,0) // MCStudy module to calculate chi2 between binned data and fit
 } ;
 
 

--- a/roofit/roofit/inc/RooChiSquarePdf.h
+++ b/roofit/roofit/inc/RooChiSquarePdf.h
@@ -27,12 +27,12 @@ public:
                RooAbsReal& x,  RooAbsReal& ndof) ;
 
   RooChiSquarePdf(const RooChiSquarePdf& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooChiSquarePdf(*this, newname); }
-  inline virtual ~RooChiSquarePdf() { }
+  TObject* clone(const char* newname) const override { return new RooChiSquarePdf(*this, newname); }
+  inline ~RooChiSquarePdf() override { }
 
   
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   
 
 private:
@@ -40,11 +40,11 @@ private:
   RooRealProxy _x;
   RooRealProxy _ndof;
 
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
-  ClassDef(RooChiSquarePdf,1) // Chi Square distribution (eg. the PDF )
+  ClassDefOverride(RooChiSquarePdf,1) // Chi Square distribution (eg. the PDF )
 };
 
 #endif

--- a/roofit/roofit/inc/RooCrystalBall.h
+++ b/roofit/roofit/inc/RooCrystalBall.h
@@ -23,19 +23,19 @@ public:
                   RooAbsReal &alpha, RooAbsReal &n, bool doubleSided = false);
 
    RooCrystalBall(const RooCrystalBall &other, const char *name = 0);
-   virtual TObject *clone(const char *newname) const { return new RooCrystalBall(*this, newname); }
+   TObject *clone(const char *newname) const override { return new RooCrystalBall(*this, newname); }
 
-   inline virtual ~RooCrystalBall() {}
+   inline ~RooCrystalBall() override {}
 
-   virtual Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char *rangeName = 0) const;
-   virtual Double_t analyticalIntegral(Int_t code, const char *rangeName = 0) const;
+   Int_t getAnalyticalIntegral(RooArgSet &allVars, RooArgSet &analVars, const char *rangeName = 0) const override;
+   Double_t analyticalIntegral(Int_t code, const char *rangeName = 0) const override;
 
    // Optimized accept/reject generator support
-   virtual Int_t getMaxVal(const RooArgSet &vars) const;
-   virtual Double_t maxVal(Int_t code) const;
+   Int_t getMaxVal(const RooArgSet &vars) const override;
+   Double_t maxVal(Int_t code) const override;
 
 protected:
-   Double_t evaluate() const;
+   Double_t evaluate() const override;
 
 private:
    RooRealProxy x_;
@@ -49,7 +49,7 @@ private:
    std::unique_ptr<RooRealProxy> alphaR_ = nullptr;
    std::unique_ptr<RooRealProxy> nR_ = nullptr;
 
-   ClassDef(RooCrystalBall, 1)
+   ClassDefOverride(RooCrystalBall, 1)
 };
 
 #endif

--- a/roofit/roofit/inc/RooDecay.h
+++ b/roofit/roofit/inc/RooDecay.h
@@ -29,13 +29,13 @@ public:
   RooDecay(const char *name, const char *title, RooRealVar& t,
       RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;
   RooDecay(const RooDecay& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooDecay(*this,newname) ; }
-  virtual ~RooDecay();
+  TObject* clone(const char* newname) const override { return new RooDecay(*this,newname) ; }
+  ~RooDecay() override;
 
-  virtual Double_t coefficient(Int_t basisIndex) const ;
+  Double_t coefficient(Int_t basisIndex) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
 protected:
 
@@ -44,7 +44,7 @@ protected:
   DecayType    _type ;
   Int_t        _basisExp ;
 
-  ClassDef(RooDecay,1) // General decay function p.d.f
+  ClassDefOverride(RooDecay,1) // General decay function p.d.f
 };
 
 #endif

--- a/roofit/roofit/inc/RooDstD0BG.h
+++ b/roofit/roofit/inc/RooDstD0BG.h
@@ -31,12 +31,12 @@ public:
         RooAbsReal& _a, RooAbsReal& _b);
 
   RooDstD0BG(const RooDstD0BG& other, const char *name=0) ;
-  virtual TObject *clone(const char *newname) const {
+  TObject *clone(const char *newname) const override {
     return new RooDstD0BG(*this,newname); }
-  inline virtual ~RooDstD0BG() { };
+  inline ~RooDstD0BG() override { };
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -44,13 +44,13 @@ protected:
   RooRealProxy dm0 ;
   RooRealProxy C,A,B ;
 
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
 
-  ClassDef(RooDstD0BG,1) // D*-D0 mass difference background PDF
+  ClassDefOverride(RooDstD0BG,1) // D*-D0 mass difference background PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -28,8 +28,8 @@ public:
   RooExponential(const char *name, const char *title,
        RooAbsReal& _x, RooAbsReal& _c);
   RooExponential(const RooExponential& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const override { return new RooExponential(*this,newname); }
-  inline virtual ~RooExponential() { }
+  TObject* clone(const char* newname) const override { return new RooExponential(*this,newname); }
+  inline ~RooExponential() override { }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;

--- a/roofit/roofit/inc/RooFunctor1DBinding.h
+++ b/roofit/roofit/inc/RooFunctor1DBinding.h
@@ -37,13 +37,13 @@ public:
   } ; 
   RooFunctor1DBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionOneDim& ftor, RooAbsReal& var);
   RooFunctor1DBinding(const RooFunctor1DBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooFunctor1DBinding(*this,newname); }
-  inline virtual ~RooFunctor1DBinding() {}
-  void printArgs(std::ostream& os) const ;
+  TObject* clone(const char* newname) const override { return new RooFunctor1DBinding(*this,newname); }
+  inline ~RooFunctor1DBinding() override {}
+  void printArgs(std::ostream& os) const override ;
 
 protected:
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   const ROOT::Math::IBaseFunctionOneDim* func ;    // Functor
   RooRealProxy                       var ;    // Argument reference
@@ -51,7 +51,7 @@ protected:
 
 private:
 
-  ClassDef(RooFunctor1DBinding,1) // RooAbsReal binding to a ROOT::Math::IBaseFunctionOneDim
+  ClassDefOverride(RooFunctor1DBinding,1) // RooAbsReal binding to a ROOT::Math::IBaseFunctionOneDim
 };
 
 
@@ -63,13 +63,13 @@ public:
   } ; 
   RooFunctor1DPdfBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionOneDim& ftor, RooAbsReal& vars);
   RooFunctor1DPdfBinding(const RooFunctor1DPdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooFunctor1DPdfBinding(*this,newname); }
-  inline virtual ~RooFunctor1DPdfBinding() {}
-  void printArgs(std::ostream& os) const ;
+  TObject* clone(const char* newname) const override { return new RooFunctor1DPdfBinding(*this,newname); }
+  inline ~RooFunctor1DPdfBinding() override {}
+  void printArgs(std::ostream& os) const override ;
 
 protected:
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   const ROOT::Math::IBaseFunctionOneDim* func ;    // Functor
   RooRealProxy                           var ;    // Argument reference
@@ -77,7 +77,7 @@ protected:
 
 private:
 
-  ClassDef(RooFunctor1DPdfBinding,1) // RooAbsPdf binding to a ROOT::Math::IBaseFunctionOneDim
+  ClassDefOverride(RooFunctor1DPdfBinding,1) // RooAbsPdf binding to a ROOT::Math::IBaseFunctionOneDim
 };
 
 

--- a/roofit/roofit/inc/RooFunctorBinding.h
+++ b/roofit/roofit/inc/RooFunctorBinding.h
@@ -35,13 +35,13 @@ public:
   } ;
   RooFunctorBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionMultiDim& ftor, const RooArgList& vars);
   RooFunctorBinding(const RooFunctorBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooFunctorBinding(*this,newname); }
-  inline virtual ~RooFunctorBinding() { delete[] x ; }
-  void printArgs(std::ostream& os) const ;
+  TObject* clone(const char* newname) const override { return new RooFunctorBinding(*this,newname); }
+  inline ~RooFunctorBinding() override { delete[] x ; }
+  void printArgs(std::ostream& os) const override ;
 
 protected:
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   const ROOT::Math::IBaseFunctionMultiDim* func ;    // Functor
   RooListProxy                       vars ;    // Argument reference
@@ -50,7 +50,7 @@ protected:
 
 private:
 
-  ClassDef(RooFunctorBinding,1) // RooAbsReal binding to a ROOT::Math::IBaseFunctionMultiDim
+  ClassDefOverride(RooFunctorBinding,1) // RooAbsReal binding to a ROOT::Math::IBaseFunctionMultiDim
 };
 
 
@@ -62,13 +62,13 @@ public:
   } ;
   RooFunctorPdfBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionMultiDim& ftor, const RooArgList& vars);
   RooFunctorPdfBinding(const RooFunctorPdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooFunctorPdfBinding(*this,newname); }
-  inline virtual ~RooFunctorPdfBinding() { delete[] x ; }
-  void printArgs(std::ostream& os) const ;
+  TObject* clone(const char* newname) const override { return new RooFunctorPdfBinding(*this,newname); }
+  inline ~RooFunctorPdfBinding() override { delete[] x ; }
+  void printArgs(std::ostream& os) const override ;
 
 protected:
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   const ROOT::Math::IBaseFunctionMultiDim* func ;    // Functor
   RooListProxy                       vars ;    // Argument reference
@@ -77,7 +77,7 @@ protected:
 
 private:
 
-  ClassDef(RooFunctorPdfBinding,1) // RooAbsPdf binding to a ROOT::Math::IBaseFunctionMultiDim
+  ClassDefOverride(RooFunctorPdfBinding,1) // RooAbsPdf binding to a ROOT::Math::IBaseFunctionMultiDim
 };
 
 

--- a/roofit/roofit/inc/RooGExpModel.h
+++ b/roofit/roofit/inc/RooGExpModel.h
@@ -64,22 +64,22 @@ public:
 
 
   RooGExpModel(const RooGExpModel& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooGExpModel(*this,newname) ; }
-  virtual ~RooGExpModel();
+  TObject* clone(const char* newname) const override { return new RooGExpModel(*this,newname) ; }
+  ~RooGExpModel() override;
 
-  virtual Int_t basisCode(const char* name) const ;
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t basisCode(const char* name) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
   void advertiseFlatScaleFactorIntegral(Bool_t flag) { _flatSFInt = flag ; }
 
   void advertiseAsymptoticIntegral(Bool_t flag) { _asympInt = flag ; }  // added FMV,07/24/03
 
 protected:
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
   //Double_t calcDecayConv(Double_t sign, Double_t tau, Double_t sig, Double_t rtau) const ;
@@ -113,7 +113,7 @@ private:
   Bool_t _flatSFInt ;
   Bool_t _asympInt ;  // added FMV,07/24/03
 
-  ClassDef(RooGExpModel,2) // Gauss (x) Exponential resolution model
+  ClassDefOverride(RooGExpModel,2) // Gauss (x) Exponential resolution model
 };
 
 #endif

--- a/roofit/roofit/inc/RooGamma.h
+++ b/roofit/roofit/inc/RooGamma.h
@@ -23,14 +23,14 @@ public:
   RooGamma(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _gamma, RooAbsReal& _beta, RooAbsReal& _mu);
   RooGamma(const RooGamma& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooGamma(*this,newname); }
-  inline virtual ~RooGamma() { }
+  TObject* clone(const char* newname) const override { return new RooGamma(*this,newname); }
+  inline ~RooGamma() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
 protected:
 
@@ -39,13 +39,13 @@ protected:
   RooRealProxy beta ;
   RooRealProxy mu ;
 
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
 
-  ClassDef(RooGamma,1) // Gaussian PDF
+  ClassDefOverride(RooGamma,1) // Gaussian PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -45,15 +45,15 @@ public:
   RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& meanSF, RooAbsReal& sigmaSF) ;
   RooGaussModel(const RooGaussModel& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooGaussModel(*this,newname) ; }
-  virtual ~RooGaussModel();
+  TObject* clone(const char* newname) const override { return new RooGaussModel(*this,newname) ; }
+  ~RooGaussModel() override;
 
-  virtual Int_t basisCode(const char* name) const ;
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName) const ;
+  Int_t basisCode(const char* name) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
   void advertiseFlatScaleFactorIntegral(Bool_t flag) { _flatSFInt = flag ; }
 
@@ -61,7 +61,7 @@ public:
 
 protected:
 
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   // Calculate common normalization factors
   std::complex<Double_t> evalCerfInt(Double_t sign, Double_t wt, Double_t tau, Double_t umin, Double_t umax, Double_t c) const;
@@ -75,7 +75,7 @@ protected:
   RooRealProxy msf ;
   RooRealProxy ssf ;
 
-  ClassDef(RooGaussModel,1) // Gaussian Resolution Model
+  ClassDefOverride(RooGaussModel,1) // Gaussian Resolution Model
 };
 
 #endif

--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -27,10 +27,10 @@ public:
   RooGaussian(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma);
   RooGaussian(const RooGaussian& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname) const override {
     return new RooGaussian(*this,newname);
   }
-  inline virtual ~RooGaussian() { }
+  inline ~RooGaussian() override { }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;

--- a/roofit/roofit/inc/RooHistConstraint.h
+++ b/roofit/roofit/inc/RooHistConstraint.h
@@ -21,10 +21,10 @@ public:
   RooHistConstraint() {} ;
   RooHistConstraint(const char *name, const char *title, const RooArgSet& phfSet, Int_t threshold=1000000);
   RooHistConstraint(const RooHistConstraint& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooHistConstraint(*this,newname); }
-  inline virtual ~RooHistConstraint() { }
+  TObject* clone(const char* newname) const override { return new RooHistConstraint(*this,newname); }
+  inline ~RooHistConstraint() override { }
 
-  Double_t getLogVal(const RooArgSet* set=0) const ;
+  Double_t getLogVal(const RooArgSet* set=0) const override ;
 
 protected:
 
@@ -32,11 +32,11 @@ protected:
   RooListProxy _nominal ;
   Bool_t _relParam ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooHistConstraint, 2)
+  ClassDefOverride(RooHistConstraint, 2)
 };
 
 #endif

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -34,10 +34,10 @@ public:
            RooAbsReal& _x,
          RooAbsReal& _alpha, Bool_t cacheAlpha=kFALSE);
   RooIntegralMorph(const RooIntegralMorph& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooIntegralMorph(*this,newname); }
-  inline virtual ~RooIntegralMorph() { }
+  TObject* clone(const char* newname) const override { return new RooIntegralMorph(*this,newname); }
+  inline ~RooIntegralMorph() override { }
 
-  Bool_t selfNormalized() const {
+  Bool_t selfNormalized() const override {
     // P.d.f is self normalized
     return kTRUE ;
   }
@@ -50,14 +50,14 @@ public:
     return _cacheAlpha ;
   }
 
-  virtual void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const ;
+  void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const override ;
 
   class MorphCacheElem : public RooAbsCachedPdf::PdfCacheElem {
   public:
     MorphCacheElem(RooIntegralMorph& self, const RooArgSet* nset) ;
-    ~MorphCacheElem() ;
+    ~MorphCacheElem() override ;
     void calculate(TIterator* iter) ;
-    virtual RooArgList containedArgs(Action) ;
+    RooArgList containedArgs(Action) override ;
 
   protected:
 
@@ -92,11 +92,11 @@ public:
 protected:
 
   friend class MorphCacheElem ;
-  virtual PdfCacheElem* createCache(const RooArgSet* nset) const ;
-  virtual const char* inputBaseName() const ;
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual void fillCacheObject(PdfCacheElem& cache) const ;
+  PdfCacheElem* createCache(const RooArgSet* nset) const override ;
+  const char* inputBaseName() const override ;
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  void fillCacheObject(PdfCacheElem& cache) const override ;
 
   RooRealProxy pdf1 ; // First input shape
   RooRealProxy pdf2 ; // Second input shape
@@ -106,11 +106,11 @@ protected:
   mutable MorphCacheElem* _cache ; // Current morph cache element in use
 
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooIntegralMorph,1) // Linear shape interpolation operator p.d.f
+  ClassDefOverride(RooIntegralMorph,1) // Linear shape interpolation operator p.d.f
 };
 
 #endif

--- a/roofit/roofit/inc/RooJeffreysPrior.h
+++ b/roofit/roofit/inc/RooJeffreysPrior.h
@@ -19,10 +19,10 @@ public:
 
   RooJeffreysPrior() : _cacheMgr(this, 1, true, false) {}
   RooJeffreysPrior(const char *name, const char *title, RooAbsPdf& nominal, const RooArgList& paramSet, const RooArgList& obsSet) ;
-  virtual ~RooJeffreysPrior() ;
+  ~RooJeffreysPrior() override ;
 
   RooJeffreysPrior(const RooJeffreysPrior& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooJeffreysPrior(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooJeffreysPrior(*this, newname); }
 
   const RooArgList& lowList() const { return _obsSet ; }
   const RooArgList& paramList() const { return _paramSet ; }
@@ -33,17 +33,17 @@ protected:
   RooListProxy _obsSet ;   // Observables of the PDF.
   RooListProxy _paramSet ; // Parameters of the PDF.
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
   struct CacheElem : public RooAbsCacheElement {
   public:
-      virtual ~CacheElem() = default;
+      ~CacheElem() override = default;
       // Payload
       std::unique_ptr<RooAbsPdf> _pdf;
       std::unique_ptr<RooArgSet> _pdfVariables;
 
-      virtual RooArgList containedArgs(Action) override {
+      RooArgList containedArgs(Action) override {
         RooArgList list(*_pdf);
         list.add(*_pdfVariables, true);
         return list;
@@ -51,7 +51,7 @@ private:
   };
   mutable RooObjCacheManager _cacheMgr; //!
 
-  ClassDef(RooJeffreysPrior,2) // Sum of RooAbsReal objects
+  ClassDefOverride(RooJeffreysPrior,2) // Sum of RooAbsReal objects
 };
 
 #endif

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -32,7 +32,7 @@ public:
 
   RooJohnson(const RooJohnson& other, const char* newName = nullptr);
 
-  virtual ~RooJohnson() = default;
+  ~RooJohnson() override = default;
 
   TObject* clone(const char* newname) const override {
     return new RooJohnson(*this,newname);

--- a/roofit/roofit/inc/RooKeysPdf.h
+++ b/roofit/roofit/inc/RooKeysPdf.h
@@ -36,21 +36,21 @@ public:
              RooAbsReal& x, RooRealVar& xdata, RooDataSet& data, Mirror mirror= NoMirror,
         Double_t rho=1);
   RooKeysPdf(const RooKeysPdf& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const {return new RooKeysPdf(*this,newname); }
-  virtual ~RooKeysPdf();
+  TObject* clone(const char* newname) const override {return new RooKeysPdf(*this,newname); }
+  ~RooKeysPdf() override;
 
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
-     const char* rangeName = 0) const;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const;
-  virtual Int_t getMaxVal(const RooArgSet& vars) const;
-  virtual Double_t maxVal(Int_t code) const;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars,
+     const char* rangeName = 0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName = 0) const override;
+  Int_t getMaxVal(const RooArgSet& vars) const override;
+  Double_t maxVal(Int_t code) const override;
 
   void LoadDataSet( RooDataSet& data);
 
 protected:
 
   RooRealProxy _x ;
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
 private:
   // how far you have to go out in a Gaussian until it is smaller than the
@@ -76,7 +76,7 @@ private:
   Double_t _lo, _hi, _binWidth;
   Double_t _rho;
 
-  ClassDef(RooKeysPdf,2) // One-dimensional non-parametric kernel estimation p.d.f.
+  ClassDefOverride(RooKeysPdf,2) // One-dimensional non-parametric kernel estimation p.d.f.
 };
 
 #endif

--- a/roofit/roofit/inc/RooLagrangianMorphFunc.h
+++ b/roofit/roofit/inc/RooLagrangianMorphFunc.h
@@ -106,26 +106,26 @@ public:
    RooLagrangianMorphFunc(const char *name, const char *title, const Config &config);
    RooLagrangianMorphFunc(const RooLagrangianMorphFunc &other, const char *newName);
 
-   virtual ~RooLagrangianMorphFunc();
+   ~RooLagrangianMorphFunc() override;
 
-   virtual std::list<Double_t> *
+   std::list<Double_t> *
    binBoundaries(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
-   virtual std::list<Double_t> *
+   std::list<Double_t> *
    plotSamplingHint(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
-   virtual Bool_t isBinnedDistribution(const RooArgSet &obs) const override;
-   virtual Double_t evaluate() const override;
-   virtual TObject *clone(const char *newname) const override;
-   virtual Double_t getValV(const RooArgSet *set = 0) const override;
+   Bool_t isBinnedDistribution(const RooArgSet &obs) const override;
+   Double_t evaluate() const override;
+   TObject *clone(const char *newname) const override;
+   Double_t getValV(const RooArgSet *set = 0) const override;
 
-   virtual Bool_t checkObservables(const RooArgSet *nset) const override;
-   virtual Bool_t forceAnalyticalInt(const RooAbsArg &arg) const override;
-   virtual Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &numVars, const RooArgSet *normSet,
+   Bool_t checkObservables(const RooArgSet *nset) const override;
+   Bool_t forceAnalyticalInt(const RooAbsArg &arg) const override;
+   Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &numVars, const RooArgSet *normSet,
                                          const char *rangeName = 0) const override;
-   virtual Double_t
+   Double_t
    analyticalIntegralWN(Int_t code, const RooArgSet *normSet, const char *rangeName = 0) const override;
-   virtual void printMetaArgs(std::ostream &os) const override;
-   virtual RooAbsArg::CacheMode canNodeBeCached() const override;
-   virtual void setCacheAndTrackHints(RooArgSet &) override;
+   void printMetaArgs(std::ostream &os) const override;
+   RooAbsArg::CacheMode canNodeBeCached() const override;
+   void setCacheAndTrackHints(RooArgSet &) override;
 
    void insert(RooWorkspace *ws);
 

--- a/roofit/roofit/inc/RooLandau.h
+++ b/roofit/roofit/inc/RooLandau.h
@@ -26,11 +26,11 @@ public:
   RooLandau() {} ;
   RooLandau(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma);
   RooLandau(const RooLandau& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooLandau(*this,newname); }
-  inline virtual ~RooLandau() { }
+  TObject* clone(const char* newname) const override { return new RooLandau(*this,newname); }
+  inline ~RooLandau() override { }
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
   
 protected:
   
@@ -38,13 +38,13 @@ protected:
   RooRealProxy mean ;
   RooRealProxy sigma ;
   
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
   
 private:
   
-  ClassDef(RooLandau,1) // Landau Distribution PDF
+  ClassDefOverride(RooLandau,1) // Landau Distribution PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -22,14 +22,14 @@ public:
   RooLognormal(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _m0, RooAbsReal& _k);
   RooLognormal(const RooLognormal& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooLognormal(*this,newname); }
-  inline virtual ~RooLognormal() { }
+  TObject* clone(const char* newname) const override { return new RooLognormal(*this,newname); }
+  inline ~RooLognormal() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
 protected:
 
@@ -37,13 +37,13 @@ protected:
   RooRealProxy m0 ;
   RooRealProxy k ;
 
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
   
 private:
 
-  ClassDef(RooLognormal,1) // log-normal PDF
+  ClassDefOverride(RooLognormal,1) // log-normal PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooMomentMorph.h
+++ b/roofit/roofit/inc/RooMomentMorph.h
@@ -33,14 +33,14 @@ public:
   RooMomentMorph(const char *name, const char *title, RooAbsReal& _m, const RooArgList& varList,
           const RooArgList& pdfList, const TVectorD& mrefpoints, Setting setting = NonLinearPosFractions );
   RooMomentMorph(const RooMomentMorph& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooMomentMorph(*this,newname); }
-  virtual ~RooMomentMorph();
+  TObject* clone(const char* newname) const override { return new RooMomentMorph(*this,newname); }
+  ~RooMomentMorph() override;
 
   void     setMode(const Setting& setting) { _setting = setting; }
 
   void useHorizontalMorphing(bool val) { _useHorizMorph = val; }
 
-  virtual Bool_t selfNormalized() const {
+  Bool_t selfNormalized() const override {
     // P.d.f is self normalized
     return kTRUE ;
   }
@@ -54,8 +54,8 @@ protected:
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem(RooAbsPdf& sumPdf, RooChangeTracker& tracker, const RooArgList& flist) : _sumPdf(&sumPdf), _tracker(&tracker) { _frac.add(flist) ; } ;
-    virtual ~CacheElem() ;
-    virtual RooArgList containedArgs(Action) ;
+    ~CacheElem() override ;
+    RooArgList containedArgs(Action) override ;
     RooAbsPdf* _sumPdf ;
     RooChangeTracker* _tracker ;
     RooArgList _frac ;
@@ -69,7 +69,7 @@ protected:
 
   friend class CacheElem ; // Cache needs to be able to clear _norm pointer
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   void     initialize();
   CacheElem* getCache(const RooArgSet* nset) const ;
@@ -91,7 +91,7 @@ protected:
 
   bool _useHorizMorph;
 
-  ClassDef(RooMomentMorph,3) // Your description goes here...
+  ClassDefOverride(RooMomentMorph,3) // Your description goes here...
 };
 
 #endif

--- a/roofit/roofit/inc/RooMomentMorphFunc.h
+++ b/roofit/roofit/inc/RooMomentMorphFunc.h
@@ -34,8 +34,8 @@ public:
    RooMomentMorphFunc(const char *name, const char *title, RooAbsReal &_m, const RooArgList &varList,
                       const RooArgList &pdfList, const TVectorD &mrefpoints, Setting setting = NonLinearPosFractions);
    RooMomentMorphFunc(const RooMomentMorphFunc &other, const char *name = 0);
-   virtual TObject *clone(const char *newname) const { return new RooMomentMorphFunc(*this, newname); }
-   virtual ~RooMomentMorphFunc();
+   TObject *clone(const char *newname) const override { return new RooMomentMorphFunc(*this, newname); }
+   ~RooMomentMorphFunc() override;
 
    void setMode(const Setting &setting) { _setting = setting; }
 
@@ -51,9 +51,9 @@ public:
    RooAbsReal *sumFunc(const RooArgSet *nset);
    const RooAbsReal *sumFunc(const RooArgSet *nset) const;
 
-   virtual std::list<Double_t> *plotSamplingHint(RooAbsRealLValue &obs, Double_t xlo, Double_t xhi) const;
-   virtual std::list<Double_t> *binBoundaries(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const;
-   Bool_t isBinnedDistribution(const RooArgSet &obs) const;
+   std::list<Double_t> *plotSamplingHint(RooAbsRealLValue &obs, Double_t xlo, Double_t xhi) const override;
+   std::list<Double_t> *binBoundaries(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
+   Bool_t isBinnedDistribution(const RooArgSet &obs) const override;
 
 protected:
    class CacheElem : public RooAbsCacheElement {
@@ -63,8 +63,8 @@ protected:
       {
          _frac.add(flist);
       };
-      virtual ~CacheElem();
-      virtual RooArgList containedArgs(Action);
+      ~CacheElem() override;
+      RooArgList containedArgs(Action) override;
       RooAbsReal *_sumFunc;
       RooChangeTracker *_tracker;
       RooArgList _frac;
@@ -78,7 +78,7 @@ protected:
 
    friend class CacheElem; // Cache needs to be able to clear _norm pointer
 
-   Double_t evaluate() const;
+   Double_t evaluate() const override;
 
    void initialize();
    CacheElem *getCache(const RooArgSet *nset) const;
@@ -100,7 +100,7 @@ protected:
 
    bool _useHorizMorph;
 
-   ClassDef(RooMomentMorphFunc, 3) // Your description goes here...
+   ClassDefOverride(RooMomentMorphFunc, 3) // Your description goes here...
 };
 
 #endif

--- a/roofit/roofit/inc/RooMomentMorphFuncND.h
+++ b/roofit/roofit/inc/RooMomentMorphFuncND.h
@@ -77,8 +77,8 @@ protected:
       {
          _frac.add(flist);
       };
-      virtual ~CacheElem();
-      virtual RooArgList containedArgs(Action);
+      ~CacheElem() override;
+      RooArgList containedArgs(Action) override;
       RooAbsReal *_sumFunc;
       RooChangeTracker *_tracker;
       RooArgList _frac;
@@ -99,15 +99,15 @@ public:
    RooMomentMorphFuncND(const RooMomentMorphFuncND &other, const char *name = 0);
    RooMomentMorphFuncND(const char *name, const char *title, RooAbsReal &_m, const RooArgList &varList,
                         const RooArgList &pdfList, const TVectorD &mrefpoints, Setting setting);
-   virtual ~RooMomentMorphFuncND();
-   virtual TObject *clone(const char *newname) const { return new RooMomentMorphFuncND(*this, newname); }
+   ~RooMomentMorphFuncND() override;
+   TObject *clone(const char *newname) const override { return new RooMomentMorphFuncND(*this, newname); }
 
    void setMode(const Setting &setting) { _setting = setting; }
    virtual Bool_t selfNormalized() const { return kTRUE; }
    Bool_t setBinIntegrator(RooArgSet &allVars);
    void useHorizontalMorphing(Bool_t val) { _useHorizMorph = val; }
 
-   Double_t evaluate() const;
+   Double_t evaluate() const override;
    virtual Double_t getVal(const RooArgSet *set = 0) const;
 
 protected:
@@ -155,7 +155,7 @@ protected:
 
    inline int sij(const int &i, const int &j) const { return (i * _obsList.getSize() + j); }
 
-   ClassDef(RooMomentMorphFuncND, 2)
+   ClassDefOverride(RooMomentMorphFuncND, 2)
 };
 
 #endif

--- a/roofit/roofit/inc/RooMomentMorphND.h
+++ b/roofit/roofit/inc/RooMomentMorphND.h
@@ -75,8 +75,8 @@ protected:
       {
          _frac.add(flist);
       };
-      virtual ~CacheElem();
-      virtual RooArgList containedArgs(Action);
+      ~CacheElem() override;
+      RooArgList containedArgs(Action) override;
       RooAbsPdf *_sumPdf;
       RooChangeTracker *_tracker;
       RooArgList _frac;
@@ -97,15 +97,15 @@ public:
    RooMomentMorphND(const RooMomentMorphND &other, const char *name = 0);
    RooMomentMorphND(const char *name, const char *title, RooAbsReal &_m, const RooArgList &varList,
                     const RooArgList &pdfList, const TVectorD &mrefpoints, Setting setting);
-   virtual ~RooMomentMorphND();
-   virtual TObject *clone(const char *newname) const { return new RooMomentMorphND(*this, newname); }
+   ~RooMomentMorphND() override;
+   TObject *clone(const char *newname) const override { return new RooMomentMorphND(*this, newname); }
 
    void setMode(const Setting &setting) { _setting = setting; }
-   virtual Bool_t selfNormalized() const { return kTRUE; }
+   Bool_t selfNormalized() const override { return kTRUE; }
    Bool_t setBinIntegrator(RooArgSet &allVars);
    void useHorizontalMorphing(Bool_t val) { _useHorizMorph = val; }
 
-   Double_t evaluate() const;
+   Double_t evaluate() const override;
    virtual Double_t getVal(const RooArgSet *set = 0) const;
 
 protected:
@@ -142,7 +142,7 @@ protected:
 
    inline int sij(const int &i, const int &j) const { return (i * _obsList.getSize() + j); }
 
-   ClassDef(RooMomentMorphND, 2)
+   ClassDefOverride(RooMomentMorphND, 2)
 };
 
 #endif

--- a/roofit/roofit/inc/RooMultiBinomial.h
+++ b/roofit/roofit/inc/RooMultiBinomial.h
@@ -29,13 +29,13 @@ class RooMultiBinomial : public RooAbsReal {
 
   RooMultiBinomial(const char *name, const char *title, const RooArgList& effFuncList, const RooArgList& catList, Bool_t ignoreNonVisible);
   RooMultiBinomial(const RooMultiBinomial& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooMultiBinomial(*this,newname); }
-  virtual ~RooMultiBinomial();
+  TObject* clone(const char* newname) const override { return new RooMultiBinomial(*this,newname); }
+  ~RooMultiBinomial() override;
 
  protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
  private:
 
@@ -43,7 +43,7 @@ class RooMultiBinomial : public RooAbsReal {
   RooListProxy _effFuncList ; // Efficiency functions per category
   Bool_t _ignoreNonVisible ; // Ignore combination of only rejects (since invisible)
 
-  ClassDef(RooMultiBinomial,1) // Simultaneous pdf of N Binomial distributions with associated efficiency functions
+  ClassDefOverride(RooMultiBinomial,1) // Simultaneous pdf of N Binomial distributions with associated efficiency functions
   };
 
 #endif

--- a/roofit/roofit/inc/RooNDKeysPdf.h
+++ b/roofit/roofit/inc/RooNDKeysPdf.h
@@ -83,12 +83,12 @@ public:
                Bool_t sortInput = kTRUE);
 
   RooNDKeysPdf(const RooNDKeysPdf& other, const char* name=0);
-  virtual ~RooNDKeysPdf();
+  ~RooNDKeysPdf() override;
 
-  virtual TObject* clone(const char* newname) const { return new RooNDKeysPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooNDKeysPdf(*this,newname); }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
   inline void fixShape(Bool_t fix) {
     createPdf(kFALSE);
@@ -115,7 +115,7 @@ protected:
   RooListProxy _varList ;
   RooListProxy _rhoList;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
   void createPdf(Bool_t firstCall = kTRUE);
   void setOptions();
@@ -207,7 +207,7 @@ protected:
 
   RooChangeTracker *_tracker{nullptr}; //
 
-  ClassDef(RooNDKeysPdf, 1) // General N-dimensional non-parametric kernel estimation p.d.f
+  ClassDefOverride(RooNDKeysPdf, 1) // General N-dimensional non-parametric kernel estimation p.d.f
 };
 
 #endif

--- a/roofit/roofit/inc/RooNonCPEigenDecay.h
+++ b/roofit/roofit/inc/RooNonCPEigenDecay.h
@@ -77,21 +77,21 @@ public:
             DecayType       type = DoubleSided );
 
   RooNonCPEigenDecay(const RooNonCPEigenDecay& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const {
+  TObject* clone(const char* newname) const override {
     return new RooNonCPEigenDecay(*this,newname);
   }
-  virtual ~RooNonCPEigenDecay( void );
+  ~RooNonCPEigenDecay( void ) override;
 
-  virtual Double_t coefficient( Int_t basisIndex ) const;
+  Double_t coefficient( Int_t basisIndex ) const override;
 
-  virtual Int_t getCoefAnalyticalIntegral( Int_t coef, RooArgSet& allVars,
-                    RooArgSet& analVars, const char* rangeName=0 ) const;
-  virtual Double_t coefAnalyticalIntegral( Int_t coef, Int_t code, const char* rangeName=0 ) const;
+  Int_t getCoefAnalyticalIntegral( Int_t coef, RooArgSet& allVars,
+                    RooArgSet& analVars, const char* rangeName=0 ) const override;
+  Double_t coefAnalyticalIntegral( Int_t coef, Int_t code, const char* rangeName=0 ) const override;
 
   Int_t getGenerator( const RooArgSet& directVars,
-            RooArgSet&       generateVars, Bool_t staticInitOK=kTRUE ) const;
-  void initGenerator( Int_t code );
-  void generateEvent( Int_t code );
+            RooArgSet&       generateVars, Bool_t staticInitOK=kTRUE ) const override;
+  void initGenerator( Int_t code ) override;
+  void generateEvent( Int_t code ) override;
 
 protected:
 
@@ -117,7 +117,7 @@ protected:
   Int_t            _basisSin;
   Int_t            _basisCos;
 
-  ClassDef(RooNonCPEigenDecay,1) // PDF to model CP-violating decays to final states which are not CP eigenstates
+  ClassDefOverride(RooNonCPEigenDecay,1) // PDF to model CP-violating decays to final states which are not CP eigenstates
 };
 
 #endif

--- a/roofit/roofit/inc/RooNovosibirsk.h
+++ b/roofit/roofit/inc/RooNovosibirsk.h
@@ -35,18 +35,18 @@ public:
 
   RooNovosibirsk(const RooNovosibirsk& other,const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooNovosibirsk(*this,newname);   }
+  TObject* clone(const char* newname) const override { return new RooNovosibirsk(*this,newname);   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
   // An empty constructor is usually ok
-  inline virtual ~RooNovosibirsk() { }
+  inline ~RooNovosibirsk() override { }
 
 protected:
-  Double_t evaluate() const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
   RooRealProxy x;
@@ -54,7 +54,7 @@ private:
   RooRealProxy peak;
   RooRealProxy tail;
 
-  ClassDef(RooNovosibirsk,1) // Novosibirsk PDF
+  ClassDefOverride(RooNovosibirsk,1) // Novosibirsk PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooParamHistFunc.h
+++ b/roofit/roofit/inc/RooParamHistFunc.h
@@ -24,17 +24,17 @@ public:
   RooParamHistFunc(const char *name, const char *title, const RooAbsArg& x, RooDataHist& dh, Bool_t paramRelative=kTRUE);
   RooParamHistFunc(const char *name, const char *title, RooDataHist& dh, const RooParamHistFunc& paramSource, Bool_t paramRelative=kTRUE) ;
   RooParamHistFunc(const RooParamHistFunc& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooParamHistFunc(*this,newname); }
-  inline virtual ~RooParamHistFunc() { }
+  TObject* clone(const char* newname) const override { return new RooParamHistFunc(*this,newname); }
+  inline ~RooParamHistFunc() override { }
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ;
-  virtual Bool_t isBinnedDistribution(const RooArgSet&) const { return kTRUE ; }
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet&) const override { return kTRUE ; }
 
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const { return kTRUE ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   Double_t getActual(Int_t ibin) ;
   void setActual(Int_t ibin, Double_t newVal) ;
@@ -52,11 +52,11 @@ public:
   RooDataHist _dh ;
   Bool_t _relParam ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooParamHistFunc,1) // Your description goes here...
+  ClassDefOverride(RooParamHistFunc,1) // Your description goes here...
 };
 
 #endif

--- a/roofit/roofit/inc/RooParametricStepFunction.h
+++ b/roofit/roofit/inc/RooParametricStepFunction.h
@@ -32,11 +32,11 @@ public:
       RooAbsReal& x, const RooArgList& coefList, TArrayD& limits, Int_t nBins=1) ;
 
   RooParametricStepFunction(const RooParametricStepFunction& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooParametricStepFunction(*this, newname); }
-  virtual ~RooParametricStepFunction() ;
+  TObject* clone(const char* newname) const override { return new RooParametricStepFunction(*this, newname); }
+  ~RooParametricStepFunction() override ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
   Int_t getnBins();
   Double_t* getLimits();
 
@@ -50,9 +50,9 @@ protected:
   Int_t _nBins ;
   TIterator* _coefIter ;  //! do not persist
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooParametricStepFunction,1) // Parametric Step Function Pdf
+  ClassDefOverride(RooParametricStepFunction,1) // Parametric Step Function Pdf
 };
 
 #endif

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -21,8 +21,8 @@ public:
   RooPoisson() { _noRounding = kFALSE ;   } ;
   RooPoisson(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, Bool_t noRounding=kFALSE);
   RooPoisson(const RooPoisson& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const override { return new RooPoisson(*this,newname); }
-  inline virtual ~RooPoisson() {  }
+  TObject* clone(const char* newname) const override { return new RooPoisson(*this,newname); }
+  inline ~RooPoisson() override {  }
 
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;

--- a/roofit/roofit/inc/RooPolynomial.h
+++ b/roofit/roofit/inc/RooPolynomial.h
@@ -34,11 +34,11 @@ public:
       RooAbsReal& _x, const RooArgList& _coefList, Int_t lowestOrder=1) ;
 
   RooPolynomial(const RooPolynomial& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooPolynomial(*this, newname); }
-  virtual ~RooPolynomial() ;
+  TObject* clone(const char* newname) const override { return new RooPolynomial(*this, newname); }
+  ~RooPolynomial() override ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -49,11 +49,11 @@ protected:
   mutable std::vector<Double_t> _wksp; //! do not persist
 
   /// Evaluation
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
   //void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
   //inline bool canComputeBatchWithCuda() const { return true; }
 
-  ClassDef(RooPolynomial,1) // Polynomial PDF
+  ClassDefOverride(RooPolynomial,1) // Polynomial PDF
 };
 
 #endif

--- a/roofit/roofit/inc/RooStepFunction.h
+++ b/roofit/roofit/inc/RooStepFunction.h
@@ -33,15 +33,15 @@ class RooStepFunction : public RooAbsReal {
         RooAbsReal& x, const RooArgList& coefList, const RooArgList& limits, Bool_t interpolate=kFALSE) ;
 
   RooStepFunction(const RooStepFunction& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooStepFunction(*this, newname); }
-  virtual ~RooStepFunction() ;
+  TObject* clone(const char* newname) const override { return new RooStepFunction(*this, newname); }
+  ~RooStepFunction() override ;
 
   const RooArgList& coefficients() { return _coefList; }
   const RooArgList& boundaries() { return _boundaryList; }
 
  protected:
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
  private:
 
@@ -52,7 +52,7 @@ class RooStepFunction : public RooAbsReal {
   TIterator* _coefIter ;  //! do not persist
   TIterator* _boundIter ;  //! do not persist
 
-  ClassDef(RooStepFunction,1) //  Step Function
+  ClassDefOverride(RooStepFunction,1) //  Step Function
 };
 
 #endif

--- a/roofit/roofit/inc/RooTFnBinding.h
+++ b/roofit/roofit/inc/RooTFnBinding.h
@@ -19,10 +19,10 @@ public:
   RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list);
   RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list, const RooArgList& plist);
   RooTFnBinding(const RooTFnBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooTFnBinding(*this,newname); }
-  inline virtual ~RooTFnBinding() { }
+  TObject* clone(const char* newname) const override { return new RooTFnBinding(*this,newname); }
+  inline ~RooTFnBinding() override { }
 
-  void printArgs(std::ostream& os) const ;
+  void printArgs(std::ostream& os) const override ;
 
 protected:
 
@@ -30,11 +30,11 @@ protected:
   RooListProxy _plist ;
   TF1* _func ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooTFnBinding,1) // RooAbsReal binding to ROOT TF[123] functions
+  ClassDefOverride(RooTFnBinding,1) // RooAbsReal binding to ROOT TF[123] functions
 };
 
 

--- a/roofit/roofit/inc/RooTFnPdfBinding.h
+++ b/roofit/roofit/inc/RooTFnPdfBinding.h
@@ -18,21 +18,21 @@ public:
   RooTFnPdfBinding() : _func(0) {} ;
   RooTFnPdfBinding(const char *name, const char *title, TF1* func, const RooArgList& list);
   RooTFnPdfBinding(const RooTFnPdfBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooTFnPdfBinding(*this,newname); }
-  inline virtual ~RooTFnPdfBinding() { }
+  TObject* clone(const char* newname) const override { return new RooTFnPdfBinding(*this,newname); }
+  inline ~RooTFnPdfBinding() override { }
 
-  void printArgs(std::ostream& os) const ;
+  void printArgs(std::ostream& os) const override ;
 
 protected:
 
   RooListProxy _list ;
   TF1* _func ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooTFnPdfBinding,1) // RooAbsPdf binding to ROOT TF[123] functions
+  ClassDefOverride(RooTFnPdfBinding,1) // RooAbsPdf binding to ROOT TF[123] functions
 };
 
 

--- a/roofit/roofit/inc/RooUnblindCPAsymVar.h
+++ b/roofit/roofit/inc/RooUnblindCPAsymVar.h
@@ -33,18 +33,18 @@ public:
   RooUnblindCPAsymVar(const char *name, const char *title,
             const char *blindString, RooAbsReal& cpasym, RooAbsCategory& blindState);
   RooUnblindCPAsymVar(const RooUnblindCPAsymVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooUnblindCPAsymVar(*this,newname); }
-  virtual ~RooUnblindCPAsymVar();
+  TObject* clone(const char* newname) const override { return new RooUnblindCPAsymVar(*this,newname); }
+  ~RooUnblindCPAsymVar() override;
 
 protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   RooRealProxy _asym ;
   RooBlindTools _blindEngine ;
 
-  ClassDef(RooUnblindCPAsymVar,1) // CP-Asymmetry unblinding transformation
+  ClassDefOverride(RooUnblindCPAsymVar,1) // CP-Asymmetry unblinding transformation
 };
 
 #endif

--- a/roofit/roofit/inc/RooUnblindOffset.h
+++ b/roofit/roofit/inc/RooUnblindOffset.h
@@ -30,18 +30,18 @@ public:
          const char *blindString, Double_t scale, RooAbsReal& blindValue,
          RooAbsCategory& blindState);
   RooUnblindOffset(const RooUnblindOffset& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooUnblindOffset(*this,newname); }
-  virtual ~RooUnblindOffset();
+  TObject* clone(const char* newname) const override { return new RooUnblindOffset(*this,newname); }
+  ~RooUnblindOffset() override;
 
 protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   RooRealProxy _value ;
   RooBlindTools _blindEngine ;
 
-  ClassDef(RooUnblindOffset,1) // Offset unblinding transformation
+  ClassDefOverride(RooUnblindOffset,1) // Offset unblinding transformation
 };
 
 #endif

--- a/roofit/roofit/inc/RooUnblindPrecision.h
+++ b/roofit/roofit/inc/RooUnblindPrecision.h
@@ -33,18 +33,18 @@ public:
             const char *blindString, Double_t centralValue, Double_t scale,
             RooAbsReal& blindValue, RooAbsCategory& blindState, Bool_t sin2betaMode=kFALSE);
   RooUnblindPrecision(const RooUnblindPrecision& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooUnblindPrecision(*this,newname); }
-  virtual ~RooUnblindPrecision();
+  TObject* clone(const char* newname) const override { return new RooUnblindPrecision(*this,newname); }
+  ~RooUnblindPrecision() override;
 
 protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   RooRealProxy _value ;          // Holder of the blind value
   RooBlindTools _blindEngine ;   // Blinding engine
 
-  ClassDef(RooUnblindPrecision,1) // Precision unblinding transformation
+  ClassDefOverride(RooUnblindPrecision,1) // Precision unblinding transformation
 };
 
 #endif

--- a/roofit/roofit/inc/RooUnblindUniform.h
+++ b/roofit/roofit/inc/RooUnblindUniform.h
@@ -27,18 +27,18 @@ public:
   RooUnblindUniform(const char *name, const char *title,
             const char *blindString, Double_t scale, RooAbsReal& blindValue);
   RooUnblindUniform(const RooUnblindUniform& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooUnblindUniform(*this,newname); }
-  virtual ~RooUnblindUniform();
+  TObject* clone(const char* newname) const override { return new RooUnblindUniform(*this,newname); }
+  ~RooUnblindUniform() override;
 
 protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   RooRealProxy _value ;
   RooBlindTools _blindEngine ;
 
-  ClassDef(RooUnblindUniform,1) // Uniform unblinding transformation
+  ClassDefOverride(RooUnblindUniform,1) // Uniform unblinding transformation
 };
 
 #endif

--- a/roofit/roofit/inc/RooUniform.h
+++ b/roofit/roofit/inc/RooUniform.h
@@ -26,26 +26,26 @@ public:
   RooUniform() {} ;
   RooUniform(const char *name, const char *title, const RooArgSet& _x);
   RooUniform(const RooUniform& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooUniform(*this,newname); }
-  inline virtual ~RooUniform() { }
+  TObject* clone(const char* newname) const override { return new RooUniform(*this,newname); }
+  inline ~RooUniform() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
 protected:
 
   RooListProxy x ;
 
-  Double_t evaluate() const ;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/ = nullptr) const;
+  Double_t evaluate() const override ;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/ = nullptr) const override;
 
 
 private:
 
-  ClassDef(RooUniform,1) // Flat PDF in N dimensions
+  ClassDefOverride(RooUniform,1) // Flat PDF in N dimensions
 };
 
 #endif

--- a/roofit/roofit/inc/RooVoigtian.h
+++ b/roofit/roofit/inc/RooVoigtian.h
@@ -29,8 +29,8 @@ public:
               RooAbsReal& _width, RooAbsReal& _sigma,
               Bool_t doFast = kFALSE);
   RooVoigtian(const RooVoigtian& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooVoigtian(*this,newname); }
-  inline virtual ~RooVoigtian() { }
+  TObject* clone(const char* newname) const override { return new RooVoigtian(*this,newname); }
+  inline ~RooVoigtian() override { }
 
 // These methods allow the user to select the fast evaluation
 // of the complex error function using look-up tables
@@ -46,14 +46,14 @@ protected:
   RooRealProxy width ;
   RooRealProxy sigma ;
 
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
 private:
 
   Bool_t _doFast;
-  ClassDef(RooVoigtian,2) // Voigtian PDF (Gauss (x) BreitWigner)
+  ClassDefOverride(RooVoigtian,2) // Voigtian PDF (Gauss (x) BreitWigner)
 };
 
 #endif

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -1360,12 +1360,12 @@ public:
    double _condition;
 
    CacheElem(){};
-   virtual void operModeHook(RooAbsArg::OperMode) override{};
+   void operModeHook(RooAbsArg::OperMode) override{};
 
    //////////////////////////////////////////////////////////////////////////////
    /// retrieve the list of contained args
 
-   virtual RooArgList containedArgs(Action) override
+   RooArgList containedArgs(Action) override
    {
       RooArgList args(*_sumFunc);
       args.add(_weights);
@@ -1379,7 +1379,7 @@ public:
    //////////////////////////////////////////////////////////////////////////////
    // default destructor
 
-   virtual ~CacheElem() {}
+   ~CacheElem() override {}
 
    //////////////////////////////////////////////////////////////////////////////
    /// create the basic objects required for the morphing

--- a/roofit/roofitcore/inc/Roo1DTable.h
+++ b/roofit/roofitcore/inc/Roo1DTable.h
@@ -28,11 +28,11 @@ public:
     // Default constructor
     // coverity[UNINIT_CTOR]
   } ;
-  virtual ~Roo1DTable();
+  ~Roo1DTable() override;
   Roo1DTable(const char *name, const char *title, const RooAbsCategory &cat);
   Roo1DTable(const Roo1DTable& other) ;
 
-  virtual void fill(RooAbsCategory& cat, Double_t weight=1.0) ;
+  void fill(RooAbsCategory& cat, Double_t weight=1.0) override ;
   Double_t get(const char* label, Bool_t silent=kFALSE) const ;
   Double_t getFrac(const char* label, Bool_t silent=kFALSE) const ;
   Double_t get(const int index, Bool_t silent=kFALSE) const ;
@@ -40,19 +40,19 @@ public:
   Double_t getOverflow() const ;
 
   // Printing interface (human readable)
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printValue(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface (human readable)
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  virtual Bool_t isIdentical(const RooTable& other, bool verbose) ;
+  Bool_t isIdentical(const RooTable& other, bool verbose) override ;
 
 protected:
 
@@ -62,7 +62,7 @@ protected:
   Double_t  _total ;             ///< Total number of entries
   Double_t  _nOverflow ;         ///< Number of overflow entries
 
-  ClassDef(Roo1DTable,1) // 1-dimensional table
+  ClassDefOverride(Roo1DTable,1) // 1-dimensional table
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -41,10 +41,10 @@ public:
          RooRealVar& convVar) ;
 
   RooAbsAnaConvPdf(const RooAbsAnaConvPdf& other, const char* name=0);
-  virtual ~RooAbsAnaConvPdf();
+  ~RooAbsAnaConvPdf() override;
 
   Int_t declareBasis(const char* expression, const RooArgList& params) ;
-  virtual void printMultiline(std::ostream& stream, Int_t contents, Bool_t verbose=kFALSE, TString indent= "") const ;
+  void printMultiline(std::ostream& stream, Int_t contents, Bool_t verbose=kFALSE, TString indent= "") const override ;
 
   // Coefficient normalization access
   inline Double_t getCoefNorm(Int_t coefIdx, const RooArgSet& nset, const char* rangeName) const {
@@ -56,23 +56,23 @@ public:
   }
 
   // Analytical integration support
-  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   // Coefficient Analytical integration support
   virtual Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
   virtual Double_t coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const ;
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& dep) const ;
+  Bool_t forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
   virtual Double_t coefficient(Int_t basisIndex) const = 0 ;
   virtual RooArgSet* coefVars(Int_t coefIdx) const ;
 
-  virtual Bool_t isDirectGenSafe(const RooAbsArg& arg) const ;
+  Bool_t isDirectGenSafe(const RooAbsArg& arg) const override ;
 
-  virtual void setCacheAndTrackHints(RooArgSet&) ;
+  void setCacheAndTrackHints(RooArgSet&) override ;
 
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
+                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const override ;
   virtual Bool_t changeModel(const RooResolutionModel& newModel) ;
 
   /// Retrieve the convolution variable.
@@ -87,7 +87,7 @@ protected:
 
   Bool_t _isCopy ;
 
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   void makeCoefVarList(RooArgList&) const ;
 
@@ -104,9 +104,9 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    virtual ~CacheElem() {} ;
+    ~CacheElem() override {} ;
 
-    RooArgList containedArgs(Action) {
+    RooArgList containedArgs(Action) override {
       RooArgList l(_coefVarList) ;
       l.add(_normList) ;
       return l ;
@@ -119,7 +119,7 @@ protected:
 
   mutable RooAICRegistry _codeReg ;         ///<! Registry of analytical integration codes
 
-  ClassDef(RooAbsAnaConvPdf,3) // Abstract Composite Convoluted PDF
+  ClassDefOverride(RooAbsAnaConvPdf,3) // Abstract Composite Convoluted PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -62,9 +62,9 @@ class RooRefArray : public TObjArray {
   RooRefArray(const RooRefArray& other) : TObjArray(other) {
   }
   RooRefArray& operator=(const RooRefArray& other) = default;
-  virtual ~RooRefArray() {} ;
+  ~RooRefArray() override {} ;
  protected:
-  ClassDef(RooRefArray,1) // Helper class for proxy lists
+  ClassDefOverride(RooRefArray,1) // Helper class for proxy lists
 } ;
 
 class RooAbsArg;
@@ -80,12 +80,12 @@ public:
 
   // Constructors, cloning and assignment
   RooAbsArg() ;
-  virtual ~RooAbsArg();
+  ~RooAbsArg() override;
   RooAbsArg(const char *name, const char *title);
   RooAbsArg(const RooAbsArg& other, const char* name=0) ;
   RooAbsArg& operator=(const RooAbsArg& other);
   virtual TObject* clone(const char* newname=0) const = 0 ;
-  virtual TObject* Clone(const char* newname = 0) const {
+  TObject* Clone(const char* newname = 0) const override {
     return clone(newname && newname[0] != '\0' ? newname : nullptr);
   }
   virtual RooAbsArg* cloneTree(const char* newname=0) const ;
@@ -341,21 +341,21 @@ public:
 
   /// Print the object to the defaultPrintStream().
   /// \param[in] options **V** print verbose. **T** print a tree structure with all children.
-  virtual void Print(Option_t *options= 0) const {
+  void Print(Option_t *options= 0) const override {
     // Printing interface (human readable)
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printAddress(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printAddress(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
   virtual void printMetaArgs(std::ostream& /*os*/) const {} ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const;
-  virtual void printTree(std::ostream& os, TString indent="") const ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override;
+  void printTree(std::ostream& os, TString indent="") const override ;
 
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
 
   // Accessors to attributes
   void setAttribute(const Text_t* name, Bool_t value=kTRUE) ;
@@ -387,8 +387,8 @@ public:
   RooLinkedList getCloningAncestors() const ;
 
   // Sorting
-  Int_t Compare(const TObject* other) const ;
-  virtual Bool_t IsSortable() const {
+  Int_t Compare(const TObject* other) const override ;
+  Bool_t IsSortable() const override {
     // Object is sortable in ROOT container class
     return kTRUE ;
   }
@@ -585,8 +585,8 @@ public:
     return _namePtr ;
   }
 
-  void SetName(const char* name) ;
-  void SetNameTitle(const char *name, const char *title) ;
+  void SetName(const char* name) override ;
+  void SetNameTitle(const char *name, const char *title) override ;
 
   virtual Bool_t importWorkspaceHook(RooWorkspace &ws)
   {
@@ -759,7 +759,7 @@ private:
   static std::stack<RooAbsArg*> _ioReadStack ; // reading stack
   /// \endcond
 
-  ClassDef(RooAbsArg,8) // Abstract variable
+  ClassDefOverride(RooAbsArg,8) // Abstract variable
 };
 
 std::ostream& operator<<(std::ostream& os, const RooAbsArg &arg);

--- a/roofit/roofitcore/inc/RooAbsBinning.h
+++ b/roofit/roofitcore/inc/RooAbsBinning.h
@@ -30,9 +30,9 @@ public:
   RooAbsBinning(const RooAbsBinning& other, const char* name=0) : TNamed(name,name), RooPrintable(other) {
     // Copy constructor
   }
-  virtual TObject* Clone(const char* newname=0) const { return clone(newname) ; }
+  TObject* Clone(const char* newname=0) const override { return clone(newname) ; }
   virtual RooAbsBinning* clone(const char* name=0) const = 0 ;
-  virtual ~RooAbsBinning() ;
+  ~RooAbsBinning() override ;
 
   /// Return number of bins.
   Int_t numBins() const { 
@@ -64,16 +64,16 @@ public:
 
   virtual Double_t* array() const = 0 ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
-  virtual void printValue(std::ostream& os) const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
+  void printValue(std::ostream& os) const override ;
   
   /// Interface function. If true, min/max of binning is parameterized by external RooAbsReals.
   /// Default to `false`, unless overridden by a sub class.
@@ -100,7 +100,7 @@ public:
 
 protected:  
 
-  ClassDef(RooAbsBinning,2) // Abstract base class for binning specification
+  ClassDefOverride(RooAbsBinning,2) // Abstract base class for binning specification
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -30,8 +30,8 @@ public:
   RooAbsCachedPdf(const char *name, const char *title, Int_t ipOrder=0);
   RooAbsCachedPdf(const RooAbsCachedPdf& other, const char* name=nullptr) ;
 
-  virtual double getValV(const RooArgSet* set=nullptr) const ;
-  virtual bool selfNormalized() const {
+  double getValV(const RooArgSet* set=nullptr) const override ;
+  bool selfNormalized() const override {
     // Declare p.d.f self normalized
     return true ;
   }
@@ -53,9 +53,9 @@ public:
     return _ipOrder ;
   }
 
-  virtual bool forceAnalyticalInt(const RooAbsArg& dep) const ;
-  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const ;
-  virtual double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const ;
+  bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
 
   class PdfCacheElem : public RooAbsCacheElement {
@@ -63,8 +63,8 @@ public:
     PdfCacheElem(const RooAbsCachedPdf& self, const RooArgSet* nset) ;
 
     // Cache management functions
-    virtual RooArgList containedArgs(Action) ;
-    virtual void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) ;
+    RooArgList containedArgs(Action) override ;
+    void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) override ;
 
     RooHistPdf* pdf() { return _pdf.get() ; }
     RooDataHist* hist() { return _hist.get() ; }
@@ -83,7 +83,7 @@ public:
 
   protected:
 
-  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
   PdfCacheElem* getCache(const RooArgSet* nset, bool recalculate=true) const ;
   void clearCacheObject(PdfCacheElem& cache) const ;
@@ -131,7 +131,7 @@ private:
 
   bool _disableCache = false; ///< Flag to run object in passthrough (= non-caching mode)
 
-  ClassDef(RooAbsCachedPdf,2) // Abstract base class for cached p.d.f.s
+  ClassDefOverride(RooAbsCachedPdf,2) // Abstract base class for cached p.d.f.s
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsCachedReal.h
@@ -27,9 +27,9 @@ public:
   RooAbsCachedReal() : _cacheMgr(this,10) {}
   RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder=0);
   RooAbsCachedReal(const RooAbsCachedReal& other, const char* name=0) ;
-  virtual ~RooAbsCachedReal() ;
+  ~RooAbsCachedReal() override ;
 
-  virtual Double_t getValV(const RooArgSet* set=0) const ;
+  Double_t getValV(const RooArgSet* set=0) const override ;
   virtual Bool_t selfNormalized() const {
     // Declares function self normalized
     return kTRUE ;
@@ -41,13 +41,13 @@ public:
     return _ipOrder ;
   }
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const {
+  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
     // Force all observables to be offered for internal integration
     return kTRUE ;
   }
 
-  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   void disableCache(Bool_t flag) {
     // Switch to disable caching mechanism
@@ -59,11 +59,11 @@ protected:
   class FuncCacheElem : public RooAbsCacheElement {
   public:
     FuncCacheElem(const RooAbsCachedReal& self, const RooArgSet* nset) ;
-    virtual ~FuncCacheElem() ;
+    ~FuncCacheElem() override ;
 
     // Cache management functions
-    virtual RooArgList containedArgs(Action) ;
-    virtual void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) ;
+    RooArgList containedArgs(Action) override ;
+    void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) override ;
 
     RooHistFunc* func() { return _func ; }
     RooDataHist* hist() { return _hist ; }
@@ -114,7 +114,7 @@ private:
 
   Bool_t _disableCache ; // Flag to run object in passthrough (= non-caching mode)
 
-  ClassDef(RooAbsCachedReal,1) // Abstract base class for cached p.d.f.s
+  ClassDefOverride(RooAbsCachedReal,1) // Abstract base class for cached p.d.f.s
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -43,7 +43,7 @@ public:
   RooAbsCategory() { };
   RooAbsCategory(const char *name, const char *title);
   RooAbsCategory(const RooAbsCategory& other, const char* name=0) ;
-  virtual ~RooAbsCategory();
+  ~RooAbsCategory() override;
 
   // Value accessors
   virtual value_type getCurrentIndex() const ;
@@ -56,9 +56,9 @@ public:
   Bool_t operator!=(value_type index) {  return !operator==(index);}
   Bool_t operator==(const char* label) const ;
   Bool_t operator!=(const char* label) { return !operator==(label);}
-  virtual Bool_t operator==(const RooAbsArg& other) const ;
+  Bool_t operator==(const RooAbsArg& other) const override ;
   Bool_t         operator!=(const RooAbsArg& other) { return !operator==(other);}
-  virtual Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) const;
+  Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) const override;
 
   /// Check if a state with name `label` exists.
   bool hasLabel(const std::string& label) const {
@@ -78,18 +78,18 @@ public:
   Roo1DTable *createTable(const char *label) const ;
 
   // I/O streaming interface
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printValue(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
   virtual Bool_t isIntegrationSafeLValue(const RooArgSet* /*set*/) const {
     // Is this l-value object safe for use as integration observable
     return kTRUE ;
   }
 
-  RooAbsArg *createFundamental(const char* newname=0) const;
+  RooAbsArg *createFundamental(const char* newname=0) const override;
 
   /// Iterator for category state names. Points to pairs of index and name.
   std::map<std::string, value_type>::const_iterator begin() const {
@@ -188,7 +188,7 @@ protected:
   void defineStateUnchecked(const std::string& label, value_type index);
   void clearTypes() ;
 
-  virtual bool isValid() const {
+  bool isValid() const override {
     return hasIndex(_currentIndex);
   }
 
@@ -200,13 +200,13 @@ protected:
   virtual void recomputeShape() = 0;
 
   friend class RooVectorDataStore ;
-  virtual void syncCache(const RooArgSet* set=0) ;
-  virtual void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValueDirty=kTRUE) ;
+  void syncCache(const RooArgSet* set=0) override ;
+  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValueDirty=kTRUE) override ;
   void setCachedValue(double value, bool notifyClients = true) final;
-  virtual void attachToTree(TTree& t, Int_t bufSize=32000) ;
-  virtual void attachToVStore(RooVectorDataStore& vstore) ;
-  virtual void setTreeBranchStatus(TTree& t, Bool_t active) ;
-  virtual void fillTreeBranch(TTree& t) ;
+  void attachToTree(TTree& t, Int_t bufSize=32000) override ;
+  void attachToVStore(RooVectorDataStore& vstore) override ;
+  void setTreeBranchStatus(TTree& t, Bool_t active) override ;
+  void fillTreeBranch(TTree& t) override ;
 
   RooCatType* retrieveLegacyState(value_type index) const;
   value_type nextAvailableStateIndex() const;
@@ -221,7 +221,7 @@ protected:
 
   static const decltype(_stateNames)::value_type& invalidCategory();
 
-  ClassDef(RooAbsCategory, 3) // Abstract discrete variable
+  ClassDefOverride(RooAbsCategory, 3) // Abstract discrete variable
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsCategoryLValue.h
+++ b/roofit/roofitcore/inc/RooAbsCategoryLValue.h
@@ -30,7 +30,7 @@ public:
   } ;
   RooAbsCategoryLValue(const char *name, const char *title);
   RooAbsCategoryLValue(const RooAbsCategoryLValue& other, const char* name=0) ;
-  virtual ~RooAbsCategoryLValue();
+  ~RooAbsCategoryLValue() override;
 
   // Value modifiers
   ////////////////////////////////////////////////////////////////////////////////
@@ -76,25 +76,25 @@ public:
   RooAbsArg& operator=(const RooAbsCategory& other) ;
 
   // Binned fit interface
-  virtual void setBin(Int_t ibin, const char* rangeName=0) ;
+  void setBin(Int_t ibin, const char* rangeName=0) override ;
   /// Get the index of the plot bin for the current value of this category.
-  virtual Int_t getBin(const char* /*rangeName*/=nullptr) const {
+  Int_t getBin(const char* /*rangeName*/=nullptr) const override {
     return getCurrentOrdinalNumber();
   }
-  virtual Int_t numBins(const char* rangeName=nullptr) const ;
-  virtual Double_t getBinWidth(Int_t /*i*/, const char* /*rangeName*/=0) const { 
+  Int_t numBins(const char* rangeName=nullptr) const override ;
+  Double_t getBinWidth(Int_t /*i*/, const char* /*rangeName*/=0) const override { 
     // Return volume of i-th bin (according to binning named rangeName if rangeName!=0)
     return 1.0 ; 
   }
-  virtual Double_t volume(const char* rangeName) const { 
+  Double_t volume(const char* rangeName) const override { 
     // Return span of range with given name (=number of states included in this range)
     return numTypes(rangeName) ; 
   }
-  virtual void randomize(const char* rangeName=0);
+  void randomize(const char* rangeName=0) override;
 
-  virtual const RooAbsBinning* getBinningPtr(const char* /*rangeName*/) const { return 0 ; }
-  virtual std::list<std::string> getBinningNames() const { return std::list<std::string>(1, "") ; }
-  virtual Int_t getBin(const RooAbsBinning* /*ptr*/) const { return getBin((const char*)0) ; }
+  const RooAbsBinning* getBinningPtr(const char* /*rangeName*/) const override { return 0 ; }
+  std::list<std::string> getBinningNames() const override { return std::list<std::string>(1, "") ; }
+  Int_t getBin(const RooAbsBinning* /*ptr*/) const override { return getBin((const char*)0) ; }
 
 
   inline void setConstant(Bool_t value= kTRUE) { 
@@ -102,7 +102,7 @@ public:
     setAttribute("Constant",value); 
   }
   
-  inline virtual Bool_t isLValue() const { 
+  inline Bool_t isLValue() const override { 
     // Object is an l-value
     return kTRUE; 
   }
@@ -118,9 +118,9 @@ protected:
   }
   /// \endcond
 
-  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) ;
+  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) override ;
 
-  ClassDef(RooAbsCategoryLValue,1) // Abstract modifiable index variable 
+  ClassDefOverride(RooAbsCategoryLValue,1) // Abstract modifiable index variable 
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -72,10 +72,10 @@ public:
   RooAbsCollection(const char *name);
   virtual TObject* clone(const char* newname) const = 0 ;
   virtual TObject* create(const char* newname) const = 0 ;
-  virtual TObject* Clone(const char* newname=0) const {
+  TObject* Clone(const char* newname=0) const override {
     return clone(newname?newname:GetName()) ;
   }
-  virtual ~RooAbsCollection();
+  ~RooAbsCollection() override;
 
   // Create a copy of an existing list. New variables cannot be added
   // to a copied list. The variables in the copied list are independent
@@ -168,10 +168,10 @@ public:
   RooAbsArg *find(const RooAbsArg&) const ;
 
   /// Find object by name in the collection
-  TObject* FindObject(const char* name) const { return find(name); }
+  TObject* FindObject(const char* name) const override { return find(name); }
 
   /// Find object in the collection, Note: matching by object name, like the find() method
-  TObject* FindObject(const TObject* obj) const { auto arg = dynamic_cast<const RooAbsArg*>(obj); return (arg) ? find(*arg) : nullptr; }
+  TObject* FindObject(const TObject* obj) const override { auto arg = dynamic_cast<const RooAbsArg*>(obj); return (arg) ? find(*arg) : nullptr; }
 
   /// Check if collection contains an argument with the same name as var.
   /// To check for a specific instance, use containsInstance().
@@ -291,20 +291,20 @@ public:
 
   Int_t index(const char* name) const;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface (human readable)
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
   std::string contentsString() const ;
 
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printValue(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
 
   // Latex printing methods
   void printLatex(const RooCmdArg& arg1=RooCmdArg(), const RooCmdArg& arg2=RooCmdArg(),
@@ -318,7 +318,7 @@ public:
     // Set name of collection
     _name= name;
   }
-  const char* GetName() const {
+  const char* GetName() const override {
     // Return namer of collection
     return _name.Data() ;
   }
@@ -336,7 +336,7 @@ public:
 
   void sort(Bool_t reverse = false);
 
-  virtual void RecursiveRemove(TObject *obj);
+  void RecursiveRemove(TObject *obj) override;
 
   void useHashMapForFind(bool flag) const;
 
@@ -396,7 +396,7 @@ private:
 
   void insert(RooAbsArg*);
 
-  ClassDef(RooAbsCollection,3) // Collection of RooAbsArg objects
+  ClassDefOverride(RooAbsCollection,3) // Collection of RooAbsArg objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -65,7 +65,7 @@ public:
   RooAbsData(const RooAbsData& other, const char* newname = 0) ;
 
   RooAbsData& operator=(const RooAbsData& other);
-  virtual ~RooAbsData() ;
+  ~RooAbsData() override ;
   virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const = 0 ;
 
   // Reduction methods
@@ -88,7 +88,7 @@ public:
   void resetBuffers() ;
 
 
-  virtual void Draw(Option_t* option = "") ;
+  void Draw(Option_t* option = "") override ;
 
   void checkInit() const ;
 
@@ -220,17 +220,17 @@ public:
   virtual TH1 *fillHistogram(TH1 *hist, const RooArgList &plotVars, const char *cuts= "", const char* cutRange=0) const;
 
   // Printing interface (human readable)
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Print contents on stdout
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
 
   void setDirtyProp(Bool_t flag) ;
 
@@ -267,7 +267,7 @@ public:
                           const char* cutSpec=0, const char* cutRange=0,
                           const RooCmdArg* formatCmd=0);
 
-  virtual void RecursiveRemove(TObject *obj);
+  void RecursiveRemove(TObject *obj) override;
 
   Bool_t hasFilledCache() const ;
 
@@ -298,8 +298,8 @@ public:
     return _namePtr ;
   }
 
-  void SetName(const char* name) ;
-  void SetNameTitle(const char *name, const char *title) ;
+  void SetName(const char* name) override ;
+  void SetNameTitle(const char *name, const char *title) override ;
 
 
 protected:
@@ -356,7 +356,7 @@ protected:
 private:
   void copyGlobalObservables(const RooAbsData& other);
 
-   ClassDef(RooAbsData, 6) // Abstract data collection
+   ClassDefOverride(RooAbsData, 6) // Abstract data collection
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -118,7 +118,7 @@ public:
   void printMultiline(std::ostream& os, Int_t content, Bool_t verbose, TString indent) const override;
 
   /// Define default print options, for a given print style
-  virtual int defaultPrintContents(Option_t* /*opt*/) const override { return kName|kClassName|kArgs|kValue ; }
+  int defaultPrintContents(Option_t* /*opt*/) const override { return kName|kClassName|kArgs|kValue ; }
 
 
   // Constant term  optimizer interface

--- a/roofit/roofitcore/inc/RooAbsGenContext.h
+++ b/roofit/roofitcore/inc/RooAbsGenContext.h
@@ -27,7 +27,7 @@ class RooAbsGenContext : public TNamed, public RooPrintable {
 public:
   RooAbsGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0, const RooArgSet* auxProto=0,
          Bool_t _verbose= kFALSE) ;
-  virtual ~RooAbsGenContext();
+  ~RooAbsGenContext() override;
 
   virtual RooDataSet *generate(Double_t nEvents= 0, Bool_t skipInit=kFALSE, Bool_t extendedMode=kFALSE);
 
@@ -47,21 +47,21 @@ public:
 
   virtual void setProtoDataOrder(Int_t* lut) ;
 
-   inline virtual void Print(Option_t *options= 0) const {
+   inline void Print(Option_t *options= 0) const override {
      // Print context information on stdout
      printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
   virtual void attach(const RooArgSet& params) ;
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override;
 
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
-  virtual StyleOption defaultPrintStyle(Option_t* opt) const ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
+  StyleOption defaultPrintStyle(Option_t* opt) const override ;
 
   virtual void setExpectedData(Bool_t) {} ;
 
@@ -87,7 +87,7 @@ protected:
 
   RooDataSet* _genData ;        ///<! Data being generated
 
-  ClassDef(RooAbsGenContext,0) // Abstract context for generating a dataset from a PDF
+  ClassDefOverride(RooAbsGenContext,0) // Abstract context for generating a dataset from a PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsHiddenReal.h
+++ b/roofit/roofitcore/inc/RooAbsHiddenReal.h
@@ -31,14 +31,14 @@ public:
   RooAbsHiddenReal(const char *name, const char *title, const char *unit= "") ;
   RooAbsHiddenReal(const char *name, const char *title, RooAbsCategory& blindState, const char *unit= "") ;
   RooAbsHiddenReal(const RooAbsHiddenReal& other, const char* name=0) ;
-  virtual ~RooAbsHiddenReal();
+  ~RooAbsHiddenReal() override;
   
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Printing interface (human readable)
-  virtual void printValue(std::ostream& stream) const ;
+  void printValue(std::ostream& stream) const override ;
   
   inline Bool_t isHidden() const { 
     // If true, hiding mode is active
@@ -55,7 +55,7 @@ protected:
   // This is dubious from a C++ point of view, but it blocks the interactive user
   // from accidentally calling getVal() without explicit cast, which is the whole
   // point of this class
-  virtual Double_t getValV(const RooArgSet* nset=0) const { 
+  Double_t getValV(const RooArgSet* nset=0) const override { 
     // Forward call to RooAbsReal
     return RooAbsReal::getValV(nset) ; 
   }
@@ -65,7 +65,7 @@ protected:
 
   RooCategoryProxy _state ; // Proxy to hiding state category
 
-  ClassDef(RooAbsHiddenReal,1) // Abstract hidden real-valued variable
+  ClassDefOverride(RooAbsHiddenReal,1) // Abstract hidden real-valued variable
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsIntegrator.h
+++ b/roofit/roofitcore/inc/RooAbsIntegrator.h
@@ -24,7 +24,7 @@ public:
   RooAbsIntegrator() ;
   RooAbsIntegrator(const RooAbsFunc& function, Bool_t printEvalCounter=kFALSE);
   /// Destructor
-  inline virtual ~RooAbsIntegrator() {
+  inline ~RooAbsIntegrator() override {
   }
   virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const = 0 ;
 
@@ -69,7 +69,7 @@ protected:
   Bool_t _valid;               ///< Is integrator in valid state?
   Bool_t _printEvalCounter ;   ///< If true print number of function evaluation required for integration
 
-  ClassDef(RooAbsIntegrator,0) // Abstract interface for real-valued function integrators
+  ClassDefOverride(RooAbsIntegrator,0) // Abstract interface for real-valued function integrators
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsMCStudyModule.h
+++ b/roofit/roofitcore/inc/RooAbsMCStudyModule.h
@@ -32,7 +32,7 @@ public:
 
   RooAbsMCStudyModule(const char* name, const char* title) ;
   RooAbsMCStudyModule(const RooAbsMCStudyModule& other) ;
-  virtual ~RooAbsMCStudyModule() {} ;
+  ~RooAbsMCStudyModule() override {} ;
 
   /// Initializer method called upon attachement to given RooMCStudy object
   Bool_t doInitializeInstance(RooMCStudy& /*study*/) ;
@@ -189,7 +189,7 @@ private:
 
   RooMCStudy* _mcs ; ///< Pointer to RooMCStudy object module is attached to
 
-  ClassDef(RooAbsMCStudyModule,0) // Monte Carlo study manager add-on module
+  ClassDefOverride(RooAbsMCStudyModule,0) // Monte Carlo study manager add-on module
 } ;
 
 

--- a/roofit/roofitcore/inc/RooAbsMoment.h
+++ b/roofit/roofitcore/inc/RooAbsMoment.h
@@ -30,7 +30,7 @@ public:
   RooAbsMoment() ;
   RooAbsMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, Int_t order=1, Bool_t takeRoot=kFALSE) ;
   RooAbsMoment(const RooAbsMoment& other, const char* name = 0);
-  virtual ~RooAbsMoment() ;
+  ~RooAbsMoment() override ;
 
   Int_t order() const { return _order ; }
   Bool_t central() const { return _mean.absArg() ? kTRUE : kFALSE ; }
@@ -46,7 +46,7 @@ protected:
   RooRealProxy _x     ;                  ///< Observable
   RooRealProxy _mean ;                   ///< Mean (if calculated for central moment)
 
-  ClassDef(RooAbsMoment,1) // Abstract representation of moment in a RooAbsReal in a given RooRealVar
+  ClassDefOverride(RooAbsMoment,1) // Abstract representation of moment in a RooAbsReal in a given RooRealVar
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsNumGenerator.h
+++ b/roofit/roofitcore/inc/RooAbsNumGenerator.h
@@ -38,7 +38,7 @@ public:
     // If true, generator is in a valid state
     return _isValid;
   }
-  virtual ~RooAbsNumGenerator();
+  ~RooAbsNumGenerator() override;
 
   inline void setVerbose(Bool_t verbose= kTRUE) {
     // If flag is true, verbose messaging will be active during generation
@@ -52,15 +52,15 @@ public:
   virtual const RooArgSet *generateEvent(UInt_t remaining, Double_t& resampleRatio) = 0;
   virtual Double_t getFuncMax() { return 0 ; }
 
-   inline virtual void Print(Option_t *options= 0) const {
+   inline void Print(Option_t *options= 0) const override {
      // ascii printing interface
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
 
   void attachParameters(const RooArgSet& vars) ;
 
@@ -79,7 +79,7 @@ protected:
 
   RooDataSet *_cache;                  ///< Dataset holding generared values of observables
 
-  ClassDef(RooAbsNumGenerator,0) // Abstract base class for numeric event generator algorithms
+  ClassDefOverride(RooAbsNumGenerator,0) // Abstract base class for numeric event generator algorithms
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -34,9 +34,9 @@ public:
                          const RooArgSet& projDeps,
                          RooAbsTestStatistic::Configuration const& cfg);
   RooAbsOptTestStatistic(const RooAbsOptTestStatistic& other, const char* name=0);
-  virtual ~RooAbsOptTestStatistic();
+  ~RooAbsOptTestStatistic() override;
 
-  virtual Double_t combinedValue(RooAbsReal** gofArray, Int_t nVal) const ;
+  Double_t combinedValue(RooAbsReal** gofArray, Int_t nVal) const override ;
 
   RooAbsReal& function() { return *_funcClone ; }
   const RooAbsReal& function() const { return *_funcClone ; }
@@ -45,10 +45,10 @@ public:
   const RooAbsData& data() const ;
 
 
-  virtual const char* cacheUniqueSuffix() const { return Form("_%zx", (size_t)_dataClone) ; }
+  const char* cacheUniqueSuffix() const override { return Form("_%zx", (size_t)_dataClone) ; }
 
   // Override this to be always true to force calculation of likelihood without parameters
-  virtual Bool_t isDerived() const { return kTRUE ; }
+  Bool_t isDerived() const override { return kTRUE ; }
 
   void seal(const char* notice="") { _sealed = kTRUE ; _sealNotice = notice ; }
   Bool_t isSealed() const { return _sealed ; }
@@ -59,7 +59,7 @@ private:
 
 protected:
 
-  Bool_t setDataSlave(RooAbsData& data, Bool_t cloneData=kTRUE, Bool_t ownNewDataAnyway=kFALSE) ;
+  Bool_t setDataSlave(RooAbsData& data, Bool_t cloneData=kTRUE, Bool_t ownNewDataAnyway=kFALSE) override ;
   void initSlave(RooAbsReal& real, RooAbsData& indata, const RooArgSet& projDeps, const char* rangeName,
        const char* addCoefRangeName)  ;
 
@@ -67,10 +67,10 @@ protected:
   friend class RooAbsTestStatistic ;
 
   virtual Bool_t allowFunctionCache() { return kTRUE ;  }
-  void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) ;
+  void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) override ;
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
-  virtual void printCompactTreeHook(std::ostream& os, const char* indent="") ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
+  void printCompactTreeHook(std::ostream& os, const char* indent="") override ;
   virtual RooArgSet requiredExtraObservables() const { return RooArgSet() ; }
   void optimizeCaching() ;
   void optimizeConstantTerms(Bool_t,Bool_t=kTRUE) ;
@@ -91,7 +91,7 @@ protected:
   Bool_t      _optimized ; ///<!
   double      _integrateBinsPrecision{-1.}; // Precision for finer sampling of bins.
 
-  ClassDef(RooAbsOptTestStatistic,5) // Abstract base class for optimized test statistics
+  ClassDefOverride(RooAbsOptTestStatistic,5) // Abstract base class for optimized test statistics
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -48,7 +48,7 @@ public:
   RooAbsPdf(const char *name, const char *title=0) ;
   RooAbsPdf(const char *name, const char *title, Double_t minVal, Double_t maxVal) ;
   // RooAbsPdf(const RooAbsPdf& other, const char* name=0);
-  virtual ~RooAbsPdf();
+  ~RooAbsPdf() override;
 
   // Toy MC generation
 
@@ -118,16 +118,16 @@ public:
   virtual RooDataSet* generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) ;
 
   ///Helper calling plotOn(RooPlot*, RooLinkedList&) const
-  virtual RooPlot* plotOn(RooPlot* frame,
+  RooPlot* plotOn(RooPlot* frame,
            const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
            const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(),
            const RooCmdArg& arg5=RooCmdArg::none(), const RooCmdArg& arg6=RooCmdArg::none(),
            const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),
            const RooCmdArg& arg9=RooCmdArg::none(), const RooCmdArg& arg10=RooCmdArg::none()
-              ) const {
+              ) const override {
     return RooAbsReal::plotOn(frame,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) ;
   }
-  virtual RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const ;
+  RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const override ;
 
   /// Add a box with parameter values (and errors) to the specified frame
   virtual RooPlot* paramOn(RooPlot* frame,
@@ -194,13 +194,13 @@ public:
   // Chi^2 fits to histograms
   using RooAbsReal::chi2FitTo ;
   using RooAbsReal::createChi2 ;
-  virtual RooFitResult* chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList) ;
-  virtual RooAbsReal* createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
+  RooFitResult* chi2FitTo(RooDataHist& data, const RooLinkedList& cmdList) override ;
+  RooAbsReal* createChi2(RooDataHist& data, const RooCmdArg& arg1=RooCmdArg::none(),  const RooCmdArg& arg2=RooCmdArg::none(),
              const RooCmdArg& arg3=RooCmdArg::none(),  const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
-             const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
+             const RooCmdArg& arg6=RooCmdArg::none(),  const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) override ;
 
   // Chi^2 fits to X-Y datasets
-  virtual RooAbsReal* createChi2(RooDataSet& data, const RooLinkedList& cmdList) ;
+  RooAbsReal* createChi2(RooDataSet& data, const RooLinkedList& cmdList) override ;
 
 
   // Constraint management
@@ -222,17 +222,17 @@ public:
   RooAbsReal* createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
   // Function evaluation support
-  virtual Double_t getValV(const RooArgSet* set=0) const ;
+  Double_t getValV(const RooArgSet* set=0) const override ;
   virtual Double_t getLogVal(const RooArgSet* set=0) const ;
 
-  RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
+  RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
   using RooAbsReal::getValues;
   RooSpan<const double> getLogValBatch(std::size_t begin, std::size_t batchSize,
       const RooArgSet* normSet = nullptr) const;
   RooSpan<const double> getLogProbabilities(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet = nullptr) const;
   void getLogProbabilities(RooSpan<const double> pdfValues, double * output) const;
 
-  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
   /// \copydoc getNorm(const RooArgSet*) const
   Double_t getNorm(const RooArgSet& nset) const {
@@ -253,7 +253,7 @@ public:
   virtual void resetErrorCounters(Int_t resetValue=10) ;
   void setTraceCounter(Int_t value, Bool_t allNodes=kFALSE) ;
 
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   /// Shows if a PDF is self-normalized, which means that no attempt is made to add a normalization term.
   /// Always returns false, unless a PDF overrides this function.
@@ -287,8 +287,8 @@ public:
   }
 
   // Printing interface (human readable)
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printValue(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
   static void verboseEval(Int_t stat) ;
   static int verboseEval() ;
@@ -332,7 +332,7 @@ private:
 protected:
   double normalizeWithNaNPacking(double rawVal, double normVal) const;
 
-  virtual RooPlot *plotOn(RooPlot *frame, PlotOpt o) const;
+  RooPlot *plotOn(RooPlot *frame, PlotOpt o) const override;
 
   friend class RooEffGenContext ;
   friend class RooAddGenContext ;
@@ -365,15 +365,15 @@ protected:
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem(RooAbsReal& norm) : _norm(&norm) {} ;
-    virtual ~CacheElem() ;
-    virtual RooArgList containedArgs(Action) { return RooArgList(*_norm) ; }
+    ~CacheElem() override ;
+    RooArgList containedArgs(Action) override { return RooArgList(*_norm) ; }
     RooAbsReal* _norm ;
   } ;
   mutable RooObjCacheManager _normMgr ; //! The cache manager
 
   friend class CacheElem ; // Cache needs to be able to clear _norm pointer
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection&, Bool_t, Bool_t, Bool_t) {
+  Bool_t redirectServersHook(const RooAbsCollection&, Bool_t, Bool_t, Bool_t) override {
     // Hook function intercepting redirectServer calls. Discard current normalization
     // object if any server is redirected
 
@@ -404,7 +404,7 @@ private:
   int calcAsymptoticCorrectedCovariance(RooMinimizer& minimizer, RooAbsData const& data);
   int calcSumW2CorrectedCovariance(RooMinimizer& minimizer, RooAbsReal const& nll) const;
 
-  ClassDef(RooAbsPdf,5) // Abstract PDF with normalization support
+  ClassDefOverride(RooAbsPdf,5) // Abstract PDF with normalization support
 };
 
 

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -71,7 +71,7 @@ public:
         const char *unit= "") ;
   RooAbsReal(const RooAbsReal& other, const char* name=0);
   RooAbsReal& operator=(const RooAbsReal& other);
-  virtual ~RooAbsReal();
+  ~RooAbsReal() override;
 
 
 
@@ -142,8 +142,8 @@ public:
   Double_t getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet()) const;
 
   Bool_t operator==(Double_t value) const ;
-  virtual Bool_t operator==(const RooAbsArg& other) const;
-  virtual Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) const;
+  Bool_t operator==(const RooAbsArg& other) const override;
+  Bool_t isIdentical(const RooAbsArg& other, Bool_t assumeSameType=kFALSE) const override;
 
 
   inline const Text_t *getUnit() const {
@@ -160,7 +160,7 @@ public:
   RooAbsFunc *bindVars(const RooArgSet &vars, const RooArgSet* nset=0, Bool_t clipInvalid=kFALSE) const;
 
   // Create a fundamental-type object that can hold our value.
-  RooAbsArg *createFundamental(const char* newname=0) const;
+  RooAbsArg *createFundamental(const char* newname=0) const override;
 
   // Analytical integration support
   virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const ;
@@ -305,12 +305,12 @@ public:
              Bool_t correctForBinVolume=kFALSE, Bool_t showProgress=kFALSE) const ;
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Printing interface (human readable)
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printValue(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
   inline void setCachedValue(double value, bool notifyClients = true) final;
 
@@ -426,7 +426,7 @@ protected:
 
   // Internal consistency checking (needed by RooDataSet)
   /// Check if current value is valid.
-  virtual bool isValid() const { return isValidReal(_value); }
+  bool isValid() const override { return isValidReal(_value); }
   /// Interface function to check if given value is a valid value for this object. Returns true unless overridden.
   virtual bool isValidReal(double /*value*/, bool printError = false) const { (void)printError; return true; }
 
@@ -469,12 +469,12 @@ protected:
   // Hooks for RooDataSet interface
   friend class RooRealIntegral ;
   friend class RooVectorDataStore ;
-  virtual void syncCache(const RooArgSet* set=0) { getVal(set) ; }
-  virtual void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) ;
-  virtual void attachToTree(TTree& t, Int_t bufSize=32000) ;
-  virtual void attachToVStore(RooVectorDataStore& vstore) ;
-  virtual void setTreeBranchStatus(TTree& t, Bool_t active) ;
-  virtual void fillTreeBranch(TTree& t) ;
+  void syncCache(const RooArgSet* set=0) override { getVal(set) ; }
+  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) override ;
+  void attachToTree(TTree& t, Int_t bufSize=32000) override ;
+  void attachToVStore(RooVectorDataStore& vstore) override ;
+  void setTreeBranchStatus(TTree& t, Bool_t active) override ;
+  void fillTreeBranch(TTree& t) override ;
 
   friend class RooRealBinding ;
   Double_t _plotMin ;       ///< Minimum of plot range
@@ -584,7 +584,7 @@ protected:
   mutable RooArgSet* _lastNSet ; ///<!
   static Bool_t _hideOffset ;    ///< Offset hiding flag
 
-  ClassDef(RooAbsReal,2) // Abstract real-valued variable
+  ClassDefOverride(RooAbsReal,2) // Abstract real-valued variable
 };
 
 

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -35,7 +35,7 @@ public:
   RooAbsRealLValue(const char *name, const char *title, const char *unit= "") ;
   RooAbsRealLValue(const RooAbsRealLValue& other, const char* name=0);
   RooAbsRealLValue& operator=(const RooAbsRealLValue&) = default;
-  virtual ~RooAbsRealLValue();
+  ~RooAbsRealLValue() override;
 
   // Parameter value and error accessors
   /// Set the current value of the object. Needs to be overridden by implementations.
@@ -49,15 +49,15 @@ public:
   virtual RooAbsArg& operator=(Double_t newValue);
 
   // Implementation of RooAbsLValue
-  virtual void setBin(Int_t ibin, const char* rangeName=0) ;
-  virtual Int_t getBin(const char* rangeName=0) const { return getBinning(rangeName).binNumber(getVal()) ; }
-  virtual Int_t numBins(const char* rangeName=0) const { return getBins(rangeName) ; }
-  virtual Double_t getBinWidth(Int_t i, const char* rangeName=0) const { return getBinning(rangeName).binWidth(i) ; }
-  virtual Double_t volume(const char* rangeName) const { return getMax(rangeName)-getMin(rangeName) ; }
-  virtual void randomize(const char* rangeName=0);
+  void setBin(Int_t ibin, const char* rangeName=0) override ;
+  Int_t getBin(const char* rangeName=0) const override { return getBinning(rangeName).binNumber(getVal()) ; }
+  Int_t numBins(const char* rangeName=0) const override { return getBins(rangeName) ; }
+  Double_t getBinWidth(Int_t i, const char* rangeName=0) const override { return getBinning(rangeName).binWidth(i) ; }
+  Double_t volume(const char* rangeName) const override { return getMax(rangeName)-getMin(rangeName) ; }
+  void randomize(const char* rangeName=0) override;
 
-  virtual const RooAbsBinning* getBinningPtr(const char* rangeName) const { return &getBinning(rangeName) ; }
-  virtual Int_t getBin(const RooAbsBinning* ptr) const { return ptr->binNumber(getVal()) ; }
+  const RooAbsBinning* getBinningPtr(const char* rangeName) const override { return &getBinning(rangeName) ; }
+  Int_t getBin(const RooAbsBinning* ptr) const override { return ptr->binNumber(getVal()) ; }
 
   virtual void setBin(Int_t ibin, const RooAbsBinning& binning) ;
   virtual Int_t getBin(const RooAbsBinning& binning) const { return binning.binNumber(getVal()) ; }
@@ -77,7 +77,7 @@ public:
   virtual RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) = 0 ;
   /// Check if binning with given name has been defined.
   virtual Bool_t hasBinning(const char* name) const = 0 ;
-  virtual Bool_t inRange(const char* name) const ;
+  Bool_t inRange(const char* name) const override ;
   /// Get number of bins of currently defined range.
   /// \param name Optionally, request number of bins for range with given name.
   virtual Int_t getBins(const char* name=0) const { return getBinning(name).numBins(); }
@@ -99,28 +99,28 @@ public:
   /// Check if variable has an upper bound.
   inline Bool_t hasMax(const char* name=0) const { return !RooNumber::isInfinite(getMax(name)); }
   /// Check if variable has a binning with given name.
-  virtual Bool_t hasRange(const char* name) const { return hasBinning(name) ; }
+  Bool_t hasRange(const char* name) const override { return hasBinning(name) ; }
 
   // Jacobian term management
   virtual Bool_t isJacobianOK(const RooArgSet& depList) const ;
   virtual Double_t jacobian() const { return 1 ; }
 
-  inline virtual Bool_t isLValue() const { return kTRUE; }
+  inline Bool_t isLValue() const override { return kTRUE; }
 
   // Test a value against our fit range
   Bool_t inRange(Double_t value, const char* rangeName, Double_t* clippedValue=0) const;
   void inRange(std::span<const double> values, std::string const& rangeName, std::vector<bool>& out) const;
-  virtual Bool_t isValidReal(Double_t value, Bool_t printError=kFALSE) const ;
+  Bool_t isValidReal(Double_t value, Bool_t printError=kFALSE) const override ;
 
   // Constant and Projected flags
   inline void setConstant(Bool_t value= kTRUE) { setAttribute("Constant",value); setValueDirty() ; setShapeDirty() ; }
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Printing interface (human readable)
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
 
   // Build 1-dimensional plots
@@ -162,9 +162,9 @@ protected:
   virtual void setValFast(Double_t value) { setVal(value) ; }
 
   Bool_t fitRangeOKForPlotting() const ;
-  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) ;
+  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) override ;
 
-  ClassDef(RooAbsRealLValue,1) // Abstract modifiable real-valued object
+  ClassDefOverride(RooAbsRealLValue,1) // Abstract modifiable real-valued object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
@@ -24,21 +24,21 @@ public:
   RooAbsSelfCachedPdf() {} ;
   RooAbsSelfCachedPdf(const char *name, const char *title, Int_t ipOrder=0);
   RooAbsSelfCachedPdf(const RooAbsSelfCachedPdf& other, const char* name=0) ;
-  virtual ~RooAbsSelfCachedPdf() ;
+  ~RooAbsSelfCachedPdf() override ;
 
 protected:
 
-  virtual const char* inputBaseName() const {
+  const char* inputBaseName() const override {
     // Use own name as base name for caches
     return GetName() ;
   }
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual void fillCacheObject(PdfCacheElem& cache) const ;
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  void fillCacheObject(PdfCacheElem& cache) const override ;
 
 private:
 
-  ClassDef(RooAbsSelfCachedPdf,0) // Abstract base class for self-caching p.d.f.s
+  ClassDefOverride(RooAbsSelfCachedPdf,0) // Abstract base class for self-caching p.d.f.s
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -24,21 +24,21 @@ public:
   RooAbsSelfCachedReal() {} ;
   RooAbsSelfCachedReal(const char *name, const char *title, Int_t ipOrder=0);
   RooAbsSelfCachedReal(const RooAbsSelfCachedReal& other, const char* name=0) ;
-  virtual ~RooAbsSelfCachedReal() ;
+  ~RooAbsSelfCachedReal() override ;
 
 protected:
 
-  virtual const char* inputBaseName() const {
+  const char* inputBaseName() const override {
     // Use own name as base name for caches
     return GetName() ;
   }
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual void fillCacheObject(FuncCacheElem& cache) const ;
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  void fillCacheObject(FuncCacheElem& cache) const override ;
 
 private:
 
-  ClassDef(RooAbsSelfCachedReal,0) // Abstract base class for self-caching functions
+  ClassDefOverride(RooAbsSelfCachedReal,0) // Abstract base class for self-caching functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsStudy.h
+++ b/roofit/roofitcore/inc/RooAbsStudy.h
@@ -37,8 +37,8 @@ public:
   RooAbsStudy(const char* name, const char* title) ;
   RooAbsStudy(const RooAbsStudy& other) ;
   virtual RooAbsStudy* clone(const char* newname="") const = 0 ;
-  TObject* Clone(const char* newname="") const { return clone(newname) ; }
-  virtual ~RooAbsStudy() ;
+  TObject* Clone(const char* newname="") const override { return clone(newname) ; }
+  ~RooAbsStudy() override ;
 
   virtual Bool_t attach(RooWorkspace& /*w*/) { return kFALSE ; } ;
   virtual Bool_t initialize() { return kFALSE ; } ;
@@ -69,7 +69,7 @@ public:
   RooLinkedList*  _detailData ;  ///<!
   Bool_t      _ownDetailData ;
 
-  ClassDef(RooAbsStudy,1) // Abstract base class for RooStudyManager modules
+  ClassDefOverride(RooAbsStudy,1) // Abstract base class for RooStudyManager modules
 } ;
 
 

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -59,11 +59,11 @@ public:
   RooAbsTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                       const RooArgSet& projDeps, Configuration const& cfg);
   RooAbsTestStatistic(const RooAbsTestStatistic& other, const char* name=0);
-  virtual ~RooAbsTestStatistic();
+  ~RooAbsTestStatistic() override;
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                                       const RooArgSet& projDeps, Configuration const& cfg) = 0;
 
-  virtual void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) ;
+  void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTrackingOpt=kTRUE) override ;
 
   virtual Double_t combinedValue(RooAbsReal** gofArray, Int_t nVal) const = 0 ;
   virtual Double_t globalNormalization() const {
@@ -71,19 +71,19 @@ public:
     return 1.0 ;
   }
 
-  Bool_t setData(RooAbsData& data, Bool_t cloneData=kTRUE) ;
+  Bool_t setData(RooAbsData& data, Bool_t cloneData=kTRUE) override ;
 
-  void enableOffsetting(Bool_t flag) ;
-  Bool_t isOffsetting() const { return _doOffset ; }
-  virtual Double_t offset() const { return _offset.Sum() ; }
+  void enableOffsetting(Bool_t flag) override ;
+  Bool_t isOffsetting() const override { return _doOffset ; }
+  Double_t offset() const override { return _offset.Sum() ; }
   virtual Double_t offsetCarry() const { return _offset.Carry(); }
 
 protected:
 
-  virtual void printCompactTreeHook(std::ostream& os, const char* indent="") ;
+  void printCompactTreeHook(std::ostream& os, const char* indent="") override ;
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
-  virtual Double_t evaluate() const ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
+  Double_t evaluate() const override ;
 
   virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const = 0 ;
   virtual Double_t getCarry() const;
@@ -160,7 +160,7 @@ protected:
   mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision
   mutable Double_t _evalCarry = 0.0;                  ///<! carry of Kahan sum in evaluatePartition
 
-  ClassDef(RooAbsTestStatistic,3) // Abstract base class for real-valued test statistics
+  ClassDefOverride(RooAbsTestStatistic,3) // Abstract base class for real-valued test statistics
 
 };
 

--- a/roofit/roofitcore/inc/RooAcceptReject.h
+++ b/roofit/roofitcore/inc/RooAcceptReject.h
@@ -33,18 +33,18 @@ public:
   } ;
   RooAcceptReject(const RooAbsReal &func, const RooArgSet &genVars, const RooNumGenConfig& config, Bool_t verbose=kFALSE, const RooAbsReal* maxFuncVal=0);
   RooAbsNumGenerator* clone(const RooAbsReal& func, const RooArgSet& genVars, const RooArgSet& /*condVars*/,
-             const RooNumGenConfig& config, Bool_t verbose=kFALSE, const RooAbsReal* maxFuncVal=0) const {
+             const RooNumGenConfig& config, Bool_t verbose=kFALSE, const RooAbsReal* maxFuncVal=0) const override {
     return new RooAcceptReject(func,genVars,config,verbose,maxFuncVal) ;
   }
-  virtual ~RooAcceptReject();
+  ~RooAcceptReject() override;
 
-  const RooArgSet *generateEvent(UInt_t remaining, Double_t& resampleRatio);
-  Double_t getFuncMax() ;
+  const RooArgSet *generateEvent(UInt_t remaining, Double_t& resampleRatio) override;
+  Double_t getFuncMax() override ;
 
 
   // Advertisement of capabilities
-  virtual Bool_t canSampleConditional() const { return kTRUE ; }
-  virtual Bool_t canSampleCategories() const { return kTRUE ; }
+  Bool_t canSampleConditional() const override { return kTRUE ; }
+  Bool_t canSampleCategories() const override { return kTRUE ; }
 
 
 protected:
@@ -65,7 +65,7 @@ protected:
 
   UInt_t _minTrialsArray[4];            ///< Minimum number of trials samples for 1,2,3 dimensional problems
 
-  ClassDef(RooAcceptReject,0) // Context for generating a dataset from a PDF
+  ClassDefOverride(RooAcceptReject,0) // Context for generating a dataset from a PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAdaptiveIntegratorND.h
+++ b/roofit/roofitcore/inc/RooAdaptiveIntegratorND.h
@@ -30,21 +30,21 @@ public:
   RooAdaptiveIntegratorND() ;
   RooAdaptiveIntegratorND(const RooAbsFunc& function, const RooNumIntConfig& config) ;
 
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooAdaptiveIntegratorND();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooAdaptiveIntegratorND() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t *yvec=0) ;
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t *yvec=0) override ;
 
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t* xmin, Double_t* xmax);
+  Bool_t setLimits(Double_t* xmin, Double_t* xmax) override;
 
-  virtual Bool_t canIntegrate1D() const { return kFALSE ; }
-  virtual Bool_t canIntegrate2D() const { return kTRUE ; }
-  virtual Bool_t canIntegrateND() const { return kTRUE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kFALSE ; }
+  Bool_t canIntegrate2D() const override { return kTRUE ; }
+  Bool_t canIntegrateND() const override { return kTRUE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) {_useIntegrandLimits = flag ; return kTRUE ; }
+  Bool_t setUseIntegrandLimits(Bool_t flag) override {_useIntegrandLimits = flag ; return kTRUE ; }
 
 protected:
 
@@ -66,7 +66,7 @@ protected:
   friend class RooNumIntFactory ;
   static void registerIntegrator(RooNumIntFactory& fact) ;
 
-  ClassDef(RooAdaptiveIntegratorND,0) // N-dimensional adaptive integration (interface to MathCore integrator)
+  ClassDefOverride(RooAdaptiveIntegratorND,0) // N-dimensional adaptive integration (interface to MathCore integrator)
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAddGenContext.h
+++ b/roofit/roofitcore/inc/RooAddGenContext.h
@@ -35,18 +35,18 @@ public:
                    const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
   RooAddGenContext(const RooAddModel &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
                    const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
-  virtual ~RooAddGenContext();
+  ~RooAddGenContext() override;
 
-  virtual void setProtoDataOrder(Int_t* lut) ;
+  void setProtoDataOrder(Int_t* lut) override ;
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
 protected:
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
   void updateThresholds() ;
 
   RooAddGenContext(const RooAddGenContext& other) ;
@@ -61,7 +61,7 @@ protected:
   RooAddModel::CacheElem* _mcache ; ///<! RooAddModel cache element
   RooAddPdf::CacheElem* _pcache ;   ///<! RooAddPdf cache element
 
-  ClassDef(RooAddGenContext,0) // Specialized context for generating a dataset from a RooAddPdf
+  ClassDefOverride(RooAddGenContext,0) // Specialized context for generating a dataset from a RooAddPdf
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -29,35 +29,35 @@ public:
   RooAddModel() ;
   RooAddModel(const char *name, const char *title, const RooArgList& pdfList, const RooArgList& coefList, Bool_t ownPdfList=kFALSE) ;
   RooAddModel(const RooAddModel& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooAddModel(*this,newname) ; }
-  virtual RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const ;
-  virtual ~RooAddModel() ;
+  TObject* clone(const char* newname) const override { return new RooAddModel(*this,newname) ; }
+  RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const override ;
+  ~RooAddModel() override ;
 
-  Double_t evaluate() const ;
-  virtual Bool_t checkObservables(const RooArgSet* nset) const ;
+  Double_t evaluate() const override ;
+  Bool_t checkObservables(const RooArgSet* nset) const override ;
 
-  virtual Int_t basisCode(const char* name) const ;
+  Int_t basisCode(const char* name) const override ;
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const {
+  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
     // Force RooRealIntegral to offer all observables for internal integration
     return kTRUE ;
   }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   /// Model is self normalized when used as p.d.f
-  virtual Bool_t selfNormalized() const {
+  Bool_t selfNormalized() const override {
     return _basisCode==0 ? kTRUE : kFALSE ;
   }
 
   /// Return extended mode capabilities
-  virtual ExtendMode extendMode() const {
+  ExtendMode extendMode() const override {
     return (_haveLastCoef || _allExtendable) ? MustBeExtended : CanNotBeExtended;
   }
 
   /// Return expected number of events for extended likelihood calculation, which
   /// is the sum of all coefficients.
-  virtual Double_t expectedEvents(const RooArgSet* nset) const ;
+  Double_t expectedEvents(const RooArgSet* nset) const override ;
 
   /// Return list of component p.d.fs
   const RooArgList& pdfList() const {
@@ -69,26 +69,26 @@ public:
     return _coefList ;
   }
 
-  Bool_t isDirectGenSafe(const RooAbsArg& arg) const ;
+  Bool_t isDirectGenSafe(const RooAbsArg& arg) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
 
   void fixCoefNormalization(const RooArgSet& refCoefNorm) ;
   void fixCoefRange(const char* rangeName) ;
-  virtual void resetErrorCounters(Int_t resetValue=10) ;
+  void resetErrorCounters(Int_t resetValue=10) override ;
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
 protected:
 
   friend class RooAddGenContext ;
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
+                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const override ;
 
-  virtual void selectNormalization(const RooArgSet* depSet=0, Bool_t force=kFALSE) ;
-  virtual void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) ;
+  void selectNormalization(const RooArgSet* depSet=0, Bool_t force=kFALSE) override ;
+  void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) override ;
 
   mutable RooSetProxy _refCoefNorm ;   ///<! Reference observable set for coefficient interpretation
   mutable TNamed* _refCoefRangeName ;  ///<! Reference range name for coefficient interpretation
@@ -99,7 +99,7 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    virtual ~CacheElem() {} ;
+    ~CacheElem() override {} ;
 
     RooArgList _suppNormList ;     ///< Supplemental normalization list
 
@@ -108,7 +108,7 @@ protected:
     RooArgList _refRangeProjList ; ///< Range integrals to be multiplied with coefficients (reference range)
     RooArgList _rangeProjList ;    ///< Range integrals to be multiplied with coefficients (target range)
 
-    virtual RooArgList containedArgs(Action) ;
+    RooArgList containedArgs(Action) override ;
 
   } ;
   mutable RooObjCacheManager _projCacheMgr ;  ///<! Manager of cache with coefficient projections and transformations
@@ -119,9 +119,9 @@ protected:
   void getCompIntList(const RooArgSet* nset, const RooArgSet* iset, pRooArgList& compIntList, Int_t& code, const char* isetRangeName) const ;
   class IntCacheElem : public RooAbsCacheElement {
   public:
-    virtual ~IntCacheElem() {} ;
+    ~IntCacheElem() override {} ;
     RooArgList _intList ; ///< List of component integrals
-    virtual RooArgList containedArgs(Action) ;
+    RooArgList containedArgs(Action) override ;
   } ;
 
   mutable RooObjCacheManager _intCacheMgr ; ///<! Manager of cache with integrals
@@ -141,7 +141,7 @@ protected:
 
 private:
 
-  ClassDef(RooAddModel,2) // Resolution model representing a sum of resolution models
+  ClassDefOverride(RooAddModel,2) // Resolution model representing a sum of resolution models
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -104,7 +104,7 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    virtual ~CacheElem() {} ;
+    ~CacheElem() override {} ;
 
     RooArgList _suppNormList ; ///< Supplemental normalization list
     bool    _needSupNorm ;     ///< Does the above list contain any non-unit entries?
@@ -114,7 +114,7 @@ protected:
     RooArgList _refRangeProjList ; ///< Range integrals to be multiplied with coefficients (reference range)
     RooArgList _rangeProjList ;    ///< Range integrals to be multiplied with coefficients (target range)
 
-    virtual RooArgList containedArgs(Action) ;
+    RooArgList containedArgs(Action) override ;
 
   } ;
   mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -30,32 +30,32 @@ public:
   RooAddition() ;
   RooAddition(const char *name, const char *title, const RooArgList& sumSet, Bool_t takeOwnerShip=kFALSE) ;
   RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2, Bool_t takeOwnerShip=kFALSE) ;
-  virtual ~RooAddition() ;
+  ~RooAddition() override ;
 
   RooAddition(const RooAddition& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooAddition(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooAddition(*this, newname); }
 
-  virtual Double_t defaultErrorLevel() const ;
+  Double_t defaultErrorLevel() const override ;
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
   const RooArgList& list1() const { return _set ; }
   const RooArgList& list() const { return _set ; }
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const {
+  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
       // Force RooRealIntegral to offer all observables for internal integration
       return kTRUE ;
   }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& numVars, const char* rangeName=0) const;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& numVars, const char* rangeName=0) const override;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  Bool_t setData(RooAbsData& data, Bool_t cloneData=kTRUE) ;
+  Bool_t setData(RooAbsData& data, Bool_t cloneData=kTRUE) override ;
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  Bool_t isBinnedDistribution(const RooArgSet& obs) const  ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet& obs) const override  ;
 
-  virtual void enableOffsetting(Bool_t) ;
+  void enableOffsetting(Bool_t) override ;
 
 protected:
 
@@ -64,16 +64,16 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-      virtual ~CacheElem();
+      ~CacheElem() override;
       // Payload
       RooArgList _I ;
-      virtual RooArgList containedArgs(Action) ;
+      RooArgList containedArgs(Action) override ;
   };
   mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooAddition,3) // Sum of RooAbsReal objects
+  ClassDefOverride(RooAddition,3) // Sum of RooAbsReal objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooArgList.h
+++ b/roofit/roofitcore/inc/RooArgList.h
@@ -94,15 +94,15 @@ public:
     }
   }
 
-  virtual ~RooArgList();
+  ~RooArgList() override;
   // Create a copy of an existing list. New variables cannot be added
   // to a copied list. The variables in the copied list are independent
   // of the original variables.
   RooArgList(const RooArgList& other, const char *name="");
   /// Move constructor.
   RooArgList(RooArgList && other) : RooAbsCollection(std::move(other)) {}
-  virtual TObject* clone(const char* newname) const { return new RooArgList(*this,newname); }
-  virtual TObject* create(const char* newname) const { return new RooArgList(newname); }
+  TObject* clone(const char* newname) const override { return new RooArgList(*this,newname); }
+  TObject* create(const char* newname) const override { return new RooArgList(newname); }
   RooArgList& operator=(const RooArgList& other) { RooAbsCollection::operator=(other) ; return *this ; }
 
 
@@ -126,7 +126,7 @@ public:
   }
 
 protected:
-  virtual bool canBeAdded(RooAbsArg const&, bool) const  { return true; }
+  bool canBeAdded(RooAbsArg const&, bool) const override  { return true; }
 
 private:
   template<typename... Args_t>
@@ -146,7 +146,7 @@ private:
   void processArg(const char* name) { _name = name; }
   void processArg(double value);
 
-  ClassDef(RooArgList,1) // Ordered list of RooAbsArg objects
+  ClassDefOverride(RooArgList,1) // Ordered list of RooAbsArg objects
 };
 
 

--- a/roofit/roofitcore/inc/RooArgProxy.h
+++ b/roofit/roofitcore/inc/RooArgProxy.h
@@ -34,7 +34,7 @@ public:
   RooArgProxy(const char* name, const char* desc, RooAbsArg* owner, RooAbsArg& arg,
          Bool_t valueServer, Bool_t shapeServer, Bool_t proxyOwnsArg=kFALSE) ;
   RooArgProxy(const char* name, RooAbsArg* owner, const RooArgProxy& other) ;
-  virtual ~RooArgProxy() ;
+  ~RooArgProxy() override ;
 
   /// Return pointer to contained argument
   inline RooAbsArg* absArg() const {
@@ -42,10 +42,10 @@ public:
   }
 
   /// Return name of proxy
-  virtual const char* name() const {
+  const char* name() const override {
     return GetName() ;
   }
-  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const ;
+  void print(std::ostream& os, Bool_t addContents=kFALSE) const override ;
 
 protected:
 
@@ -68,11 +68,11 @@ protected:
   inline Bool_t isShapeServer() const {
     return _shapeServer ;
   }
-  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) ;
+  Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override ;
 
   virtual void changeDataSet(const RooArgSet* newNormSet) ;
 
-  ClassDef(RooArgProxy,1) // Abstract proxy for RooAbsArg objects
+  ClassDefOverride(RooArgProxy,1) // Abstract proxy for RooAbsArg objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -172,7 +172,7 @@ public:
 
 protected:
   Bool_t checkForDup(const RooAbsArg& arg, Bool_t silent) const ;
-  virtual bool canBeAdded(const RooAbsArg& arg, bool silent) const override {
+  bool canBeAdded(const RooAbsArg& arg, bool silent) const override {
     return !checkForDup(arg, silent);
   }
 

--- a/roofit/roofitcore/inc/RooBinIntegrator.h
+++ b/roofit/roofitcore/inc/RooBinIntegrator.h
@@ -34,20 +34,20 @@ public:
   RooBinIntegrator(const RooAbsFunc& function) ;
   RooBinIntegrator(const RooAbsFunc& function, const RooNumIntConfig& config) ;
 
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooBinIntegrator();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooBinIntegrator() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t *yvec=0) ;
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t *yvec=0) override ;
 
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t* xmin, Double_t* xmax);
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) {_useIntegrandLimits = flag ; return kTRUE ; }
+  Bool_t setLimits(Double_t* xmin, Double_t* xmax) override;
+  Bool_t setUseIntegrandLimits(Bool_t flag) override {_useIntegrandLimits = flag ; return kTRUE ; }
 
-  virtual Bool_t canIntegrate1D() const { return kTRUE ; }
-  virtual Bool_t canIntegrate2D() const { return kTRUE ; }
-  virtual Bool_t canIntegrateND() const { return kTRUE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kTRUE ; }
+  Bool_t canIntegrate2D() const override { return kTRUE ; }
+  Bool_t canIntegrateND() const override { return kTRUE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
 protected:
 
@@ -72,7 +72,7 @@ protected:
 
   Double_t *_x ; ///<! do not persist
 
-  ClassDef(RooBinIntegrator,0) // 1-dimensional numerical integration engine
+  ClassDefOverride(RooBinIntegrator,0) // 1-dimensional numerical integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -31,11 +31,11 @@ public:
   RooBinSamplingPdf() { };
   RooBinSamplingPdf(const char *name, const char *title, RooAbsRealLValue& observable, RooAbsPdf& inputPdf,
       double epsilon = 1.E-4);
-  virtual ~RooBinSamplingPdf() {};
+  ~RooBinSamplingPdf() override {};
 
   RooBinSamplingPdf(const RooBinSamplingPdf& other, const char* name = 0);
 
-  virtual TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname) const override {
     return new RooBinSamplingPdf(*this, newname);
   }
 
@@ -66,7 +66,7 @@ public:
   bool selfNormalized() const override { return true; }
 
   ExtendMode extendMode() const override { return _pdf->extendMode(); }
-  virtual Double_t expectedEvents(const RooArgSet* nset) const override { return _pdf->expectedEvents(nset); }
+  Double_t expectedEvents(const RooArgSet* nset) const override { return _pdf->expectedEvents(nset); }
 
   /// Forwards to the PDF's implementation.
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet& generateVars, bool staticInitOK = true) const override {

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -47,10 +47,10 @@ public:
     _histFunc("HistFuncForBinWidth", this, other._histFunc),
     _divideByBinWidth(other._divideByBinWidth) { }
 
-  virtual ~RooBinWidthFunction() { }
+  ~RooBinWidthFunction() override { }
 
   /// Copy the object and return as TObject*.
-  virtual TObject* clone(const char* newname = nullptr) const override {
+  TObject* clone(const char* newname = nullptr) const override {
     return new RooBinWidthFunction(*this, newname);
   }
 

--- a/roofit/roofitcore/inc/RooBinnedGenContext.h
+++ b/roofit/roofitcore/inc/RooBinnedGenContext.h
@@ -31,22 +31,22 @@ class RooBinnedGenContext : public RooAbsGenContext {
 public:
   RooBinnedGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
                    const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
-  virtual ~RooBinnedGenContext();
+  ~RooBinnedGenContext() override;
 
-  RooDataSet* generate(Double_t nEvents=0, Bool_t skipInit=kFALSE, Bool_t extendedMode=kFALSE) ;
+  RooDataSet* generate(Double_t nEvents=0, Bool_t skipInit=kFALSE, Bool_t extendedMode=kFALSE) override ;
 
-  virtual void setProtoDataOrder(Int_t*)  {}
+  void setProtoDataOrder(Int_t*) override  {}
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual void setExpectedData(Bool_t) ;
+  void setExpectedData(Bool_t) override ;
 
 protected:
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
   RooBinnedGenContext(const RooBinnedGenContext& other) ;
 
@@ -56,7 +56,7 @@ protected:
   RooDataHist* _hist ;          ///< Histogram
   Bool_t _expectedData ;        ///< Asimov?
 
-  ClassDef(RooBinnedGenContext,0) // Specialized context for generating a dataset from a binned pdf
+  ClassDefOverride(RooBinnedGenContext,0) // Specialized context for generating a dataset from a binned pdf
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooBinning.h
+++ b/roofit/roofitcore/inc/RooBinning.h
@@ -32,39 +32,39 @@ public:
   RooBinning(Int_t nBins, Double_t xlo, Double_t xhi, const char* name = 0);
   RooBinning(Int_t nBins, const Double_t* boundaries, const char* name = 0);
   RooBinning(const RooBinning& other, const char* name = 0);
-  RooAbsBinning* clone(const char* name = 0) const { return new RooBinning(*this,name?name:GetName()); }
-  ~RooBinning();
+  RooAbsBinning* clone(const char* name = 0) const override { return new RooBinning(*this,name?name:GetName()); }
+  ~RooBinning() override;
 
   /// Return the number boundaries
-  virtual Int_t numBoundaries() const {
+  Int_t numBoundaries() const override {
     return _nbins+1;
   }
-  virtual Int_t binNumber(Double_t x) const;
-  virtual Int_t rawBinNumber(Double_t x) const;
+  Int_t binNumber(Double_t x) const override;
+  Int_t rawBinNumber(Double_t x) const override;
   virtual Double_t nearestBoundary(Double_t x) const;
 
-  virtual void setRange(Double_t xlo, Double_t xhi);
+  void setRange(Double_t xlo, Double_t xhi) override;
 
   /// Return the lower bound value
-  virtual Double_t lowBound() const {
+  Double_t lowBound() const override {
     return _xlo;
   }
 
   /// Return the upper bound value
-  virtual Double_t highBound() const {
+  Double_t highBound() const override {
     return _xhi;
   }
 
   /// Return the average bin width
-  virtual Double_t averageBinWidth() const {
+  Double_t averageBinWidth() const override {
     return (highBound() - lowBound()) / numBins();
   }
-  virtual Double_t* array() const;
+  Double_t* array() const override;
 
-  virtual Double_t binCenter(Int_t bin) const;
-  virtual Double_t binWidth(Int_t bin) const;
-  virtual Double_t binLow(Int_t bin) const;
-  virtual Double_t binHigh(Int_t bin) const;
+  Double_t binCenter(Int_t bin) const override;
+  Double_t binWidth(Int_t bin) const override;
+  Double_t binLow(Int_t bin) const override;
+  Double_t binHigh(Int_t bin) const override;
 
   Bool_t addBoundary(Double_t boundary);
   void addBoundaryPair(Double_t boundary, Double_t mirrorPoint = 0);
@@ -88,7 +88,7 @@ protected:
   mutable Double_t* _array;          ///<! Array of boundaries
   mutable Int_t _blo;                ///<! bin number for _xlo
 
-  ClassDef(RooBinning,3) // Generic binning specification
+  ClassDefOverride(RooBinning,3) // Generic binning specification
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooBinningCategory.h
+++ b/roofit/roofitcore/inc/RooBinningCategory.h
@@ -27,11 +27,11 @@ public:
   inline RooBinningCategory() { }
   RooBinningCategory(const char *name, const char *title, RooAbsRealLValue& inputVar, const char* binningName=0, const char* catTypeName=0);
   RooBinningCategory(const RooBinningCategory& other, const char *name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooBinningCategory(*this, newname); }
-  virtual ~RooBinningCategory();
+  TObject* clone(const char* newname) const override { return new RooBinningCategory(*this, newname); }
+  ~RooBinningCategory() override;
 
   /// Printing interface (human readable)
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
 protected:
 
@@ -40,11 +40,11 @@ protected:
   RooTemplateProxy<RooAbsRealLValue> _inputVar; ///< Input variable that is mapped
   TString _bname ;         ///< Name of the binning specification to be used to perform the mapping
 
-  virtual value_type evaluate() const;
+  value_type evaluate() const override;
   /// The shape of this category does not need to be recomputed, as it creates states on the fly.
-  void recomputeShape() { }
+  void recomputeShape() override { }
 
-  ClassDef(RooBinningCategory,1) // RealVar-to-Category function defined by bin boundaries on input var
+  ClassDefOverride(RooBinningCategory,1) // RealVar-to-Category function defined by bin boundaries on input var
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooBrentRootFinder.h
+++ b/roofit/roofitcore/inc/RooBrentRootFinder.h
@@ -21,9 +21,9 @@
 class RooBrentRootFinder : public RooAbsRootFinder {
 public:
   RooBrentRootFinder(const RooAbsFunc& function);
-  inline virtual ~RooBrentRootFinder() { }
+  inline ~RooBrentRootFinder() override { }
 
-  virtual Bool_t findRoot(Double_t &result, Double_t xlo, Double_t xhi, Double_t value= 0) const;
+  Bool_t findRoot(Double_t &result, Double_t xlo, Double_t xhi, Double_t value= 0) const override;
 
   /// Set convergence tolerance parameter
   void setTol(Double_t tol) {
@@ -35,7 +35,7 @@ protected:
 
   Double_t _tol ;
 
-  ClassDef(RooBrentRootFinder,0) // Abstract interface for 1-dim real-valued function root finders
+  ClassDefOverride(RooBrentRootFinder,0) // Abstract interface for 1-dim real-valued function root finders
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooCacheManager.h
+++ b/roofit/roofitcore/inc/RooCacheManager.h
@@ -38,7 +38,7 @@ public:
   RooCacheManager(Int_t maxSize=2) ;
   RooCacheManager(RooAbsArg* owner, Int_t maxSize=2) ;
   RooCacheManager(const RooCacheManager& other, RooAbsArg* owner=0) ;
-  virtual ~RooCacheManager() ;
+  ~RooCacheManager() override ;
 
   /// Getter function without integration set
   T* getObj(const RooArgSet* nset, Int_t* sterileIndex=0, const TNamed* isetRangeName=0) {
@@ -71,15 +71,15 @@ public:
   }
 
   /// Interface function to intercept server redirects
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/,
-                 Bool_t /*nameChange*/, Bool_t /*isRecursive*/) {
+  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/,
+                 Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override {
     return kFALSE ;
   }
   /// Interface function to intercept cache operation mode changes
-  virtual void operModeHook() {
+  void operModeHook() override {
   }
   /// Interface function to cache add contents to output in tree printing mode
-  virtual void printCompactTreeHook(std::ostream&, const char *) {
+  void printCompactTreeHook(std::ostream&, const char *) override {
   }
 
   T* getObjByIndex(Int_t index) const ;
@@ -90,7 +90,7 @@ public:
   virtual void insertObjectHook(T&) {
   }
 
-  void wireCache() {
+  void wireCache() override {
     if (_size==0) {
       oocoutI(_owner,Optimization) << "RooCacheManager::wireCache(" << _owner->GetName() << ") no cached elements!" << std::endl ;
     } else if (_size==1) {
@@ -111,7 +111,7 @@ protected:
   std::vector<T*> _object ;                 ///<! Payload
   Bool_t _wired ;               ///<! In wired mode, there is a single payload which is returned always
 
-  ClassDef(RooCacheManager,2) // Cache Manager class generic objects
+  ClassDefOverride(RooCacheManager,2) // Cache Manager class generic objects
 } ;
 
 

--- a/roofit/roofitcore/inc/RooCachedPdf.h
+++ b/roofit/roofitcore/inc/RooCachedPdf.h
@@ -23,33 +23,33 @@ public:
   RooCachedPdf(const char *name, const char *title, RooAbsPdf& _pdf, const RooArgSet& cacheObs);
   RooCachedPdf(const char *name, const char *title, RooAbsPdf& _pdf);
   RooCachedPdf(const RooCachedPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCachedPdf(*this,newname); }
-  virtual ~RooCachedPdf() ;
+  TObject* clone(const char* newname) const override { return new RooCachedPdf(*this,newname); }
+  ~RooCachedPdf() override ;
 
-  virtual void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const ;
+  void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const override ;
 
 protected:
 
   /// Return the base name for cache objects, in this case the name of the cached p.d.f
-  virtual const char* inputBaseName() const {
+  const char* inputBaseName() const override {
     return pdf.arg().GetName() ;
   } ;
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual void fillCacheObject(PdfCacheElem& cachePdf) const ;
-  virtual Double_t evaluate() const {
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  void fillCacheObject(PdfCacheElem& cachePdf) const override ;
+  Double_t evaluate() const override {
     // Dummy evaluate, it is never called
     return 0 ;
   }
 
-  virtual const char* payloadUniqueSuffix() const { return pdf.arg().aggregateCacheUniqueSuffix() ; }
+  const char* payloadUniqueSuffix() const override { return pdf.arg().aggregateCacheUniqueSuffix() ; }
 
   RooRealProxy pdf ;       ///< Proxy to p.d.f being cached
   RooSetProxy  _cacheObs ; ///< Observable to be cached
 
 private:
 
-  ClassDef(RooCachedPdf,1) // P.d.f class that wraps another p.d.f and caches its output
+  ClassDefOverride(RooCachedPdf,1) // P.d.f class that wraps another p.d.f and caches its output
 
 };
 

--- a/roofit/roofitcore/inc/RooCachedReal.h
+++ b/roofit/roofitcore/inc/RooCachedReal.h
@@ -25,8 +25,8 @@ public:
   RooCachedReal(const char *name, const char *title, RooAbsReal& _func, const RooArgSet& cacheObs);
   RooCachedReal(const char *name, const char *title, RooAbsReal& _func);
   RooCachedReal(const RooCachedReal& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooCachedReal(*this,newname); }
-  virtual ~RooCachedReal() ;
+  TObject* clone(const char* newname) const override { return new RooCachedReal(*this,newname); }
+  ~RooCachedReal() override ;
 
   /// If flag is true the RooHistFunc that represent the cache histogram
   /// will use special boundary conditions for use with cumulative distribution
@@ -46,22 +46,22 @@ public:
 protected:
 
   /// Return base name for caches, i.e. the name of the cached function
-  virtual const char* inputBaseName() const {
+  const char* inputBaseName() const override {
     return func.arg().GetName() ;
   } ;
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual void fillCacheObject(FuncCacheElem& cacheFunc) const ;
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
   /// Dummy evaluate, it is never called
-  virtual Double_t evaluate() const {
+  Double_t evaluate() const override {
     return func ;
   }
 
-  void operModeHook() ;
+  void operModeHook() override ;
 
-  virtual FuncCacheElem* createCache(const RooArgSet* nset) const ;
+  FuncCacheElem* createCache(const RooArgSet* nset) const override ;
 
-  virtual const char* payloadUniqueSuffix() const { return func.arg().aggregateCacheUniqueSuffix() ; }
+  const char* payloadUniqueSuffix() const override { return func.arg().aggregateCacheUniqueSuffix() ; }
 
   RooRealProxy func ;           ///< Proxy to function being cached
   RooSetProxy  _cacheObs ;      ///< Variables to be cached
@@ -70,7 +70,7 @@ protected:
 
 private:
 
-  ClassDef(RooCachedReal,2) // P.d.f class that wraps another p.d.f and caches its output
+  ClassDefOverride(RooCachedReal,2) // P.d.f class that wraps another p.d.f and caches its output
 
 };
 

--- a/roofit/roofitcore/inc/RooCategory.h
+++ b/roofit/roofitcore/inc/RooCategory.h
@@ -32,22 +32,22 @@ public:
   RooCategory(const char* name, const char* title, const std::map<std::string, int>& allowedStates);
   RooCategory(const RooCategory& other, const char* name=0) ;
   RooCategory& operator=(const RooCategory&) = delete;
-  virtual ~RooCategory();
-  virtual TObject* clone(const char* newname) const override { return new RooCategory(*this,newname); }
+  ~RooCategory() override;
+  TObject* clone(const char* newname) const override { return new RooCategory(*this,newname); }
 
   /// Return current index.
-  virtual value_type getCurrentIndex() const override final {
+  value_type getCurrentIndex() const final {
     return RooCategory::evaluate();
   }
 
-  virtual Bool_t setIndex(Int_t index, bool printError = true) override;
+  Bool_t setIndex(Int_t index, bool printError = true) override;
   using RooAbsCategoryLValue::setIndex;
-  virtual Bool_t setLabel(const char* label, bool printError = true) override;
+  Bool_t setLabel(const char* label, bool printError = true) override;
   using RooAbsCategoryLValue::setLabel;
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const override ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   bool defineType(const std::string& label);
   bool defineType(const std::string& label, Int_t index);
@@ -79,12 +79,12 @@ public:
   /// @{
 
   /// Tell whether we can be stored in a dataset. Always true for RooCategory.
-  inline virtual Bool_t isFundamental() const override {
+  inline Bool_t isFundamental() const override {
     return true;
   }
 
   /// Does our value or shape depend on any other arg? Always false for RooCategory.
-  virtual Bool_t isDerived() const override {
+  Bool_t isDerived() const override {
     return false;
   }
 
@@ -92,11 +92,11 @@ public:
   Bool_t isStateInRange(const char* rangeName, const char* stateName) const ;
   /// Check if the currently defined category state is in the range with the given name.
   /// If no ranges are defined, the state counts as being in range.
-  virtual Bool_t inRange(const char* rangeName) const override {
+  Bool_t inRange(const char* rangeName) const override {
     return isStateInRange(rangeName, RooCategory::evaluate());
   }
   /// Returns true if category has a range with given name defined.
-  virtual bool hasRange(const char* rangeName) const override {
+  bool hasRange(const char* rangeName) const override {
     return _ranges->find(rangeName) != _ranges->end();
   }
 
@@ -106,7 +106,7 @@ protected:
   /// \copydoc RooAbsCategory::evaluate() const
   /// Returns the currently set state index. If this is invalid,
   /// returns the first-set index.
-  virtual value_type evaluate() const override {
+  value_type evaluate() const override {
     if (hasIndex(_currentIndex))
       return _currentIndex;
 

--- a/roofit/roofitcore/inc/RooChangeTracker.h
+++ b/roofit/roofitcore/inc/RooChangeTracker.h
@@ -28,10 +28,10 @@ public:
 
   RooChangeTracker() ;
   RooChangeTracker(const char *name, const char *title, const RooArgSet& trackSet, Bool_t checkValues=kFALSE) ;
-  virtual ~RooChangeTracker() ;
+  ~RooChangeTracker() override ;
 
   RooChangeTracker(const RooChangeTracker& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooChangeTracker(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooChangeTracker(*this, newname); }
 
   Bool_t hasChanged(Bool_t clearState) ;
 
@@ -48,9 +48,9 @@ protected:
 
   Bool_t        _init ; //!
 
-  Double_t evaluate() const { return 1 ; }
+  Double_t evaluate() const override { return 1 ; }
 
-  ClassDef(RooChangeTracker,1) // Meta object that tracks changes in set of other arguments
+  ClassDefOverride(RooChangeTracker,1) // Meta object that tracks changes in set of other arguments
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -48,17 +48,17 @@ public:
              RooDataHist::ErrorType=RooDataHist::SumW2) ;
 
   RooChi2Var(const RooChi2Var& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooChi2Var(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooChi2Var(*this,newname); }
 
-  virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& dhist,
-                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) {
+  RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& dhist,
+                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) override {
     // Virtual constructor
     return new RooChi2Var(name,title,(RooAbsPdf&)pdf,(RooDataHist&)dhist,projDeps,_funcMode,cfg,_etype) ;
   }
 
-  virtual ~RooChi2Var();
+  ~RooChi2Var() override;
 
-  virtual Double_t defaultErrorLevel() const {
+  Double_t defaultErrorLevel() const override {
     // The default error level for MINUIT error analysis for a chi^2 is 1.0
     return 1.0 ;
   }
@@ -70,9 +70,9 @@ protected:
   RooDataHist::ErrorType _etype ;     ///< Error type store in associated RooDataHist
   FuncMode _funcMode ;                ///< Function, P.d.f. or extended p.d.f?
 
-  virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const ;
+  Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
-  ClassDef(RooChi2Var,1) // Chi^2 function of p.d.f w.r.t a binned dataset
+  ClassDefOverride(RooChi2Var,1) // Chi^2 function of p.d.f w.r.t a binned dataset
 };
 
 

--- a/roofit/roofitcore/inc/RooClassFactory.h
+++ b/roofit/roofitcore/inc/RooClassFactory.h
@@ -34,7 +34,7 @@ public:
 
   // Constructors, assignment etc
   RooClassFactory() ;
-  virtual ~RooClassFactory() ;
+  ~RooClassFactory() override ;
 
   static RooAbsReal* makeFunctionInstance(const char* className, const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
   static RooAbsReal* makeFunctionInstance(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
@@ -54,7 +54,7 @@ public:
 
   class ClassFacIFace : public RooFactoryWSTool::IFace {
   public:
-    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) ;
+    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) override ;
   } ;
 
 protected:
@@ -63,7 +63,7 @@ protected:
 
   RooClassFactory(const RooClassFactory&) ;
 
-  ClassDef(RooClassFactory,0) // RooFit class code and instance factory
+  ClassDefOverride(RooClassFactory,0) // RooFit class code and instance factory
 } ;
 
 #endif

--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -54,13 +54,13 @@ public:
   /// Return list of sub-arguments in this RooCmdArg
   RooLinkedList& subArgs() { return _argList ; }
 
-  virtual TObject* Clone(const char* newName=0) const {
+  TObject* Clone(const char* newName=0) const override {
     RooCmdArg* newarg = new RooCmdArg(*this) ;
     if (newName) { newarg->SetName(newName) ; }
     return newarg ;
   }
 
-  virtual ~RooCmdArg();
+  ~RooCmdArg() override;
 
   static const RooCmdArg& none() ;
 
@@ -102,7 +102,7 @@ public:
 
   const RooArgSet* getSet(Int_t idx) const ;
 
-  void Print(const char* = "") const;
+  void Print(const char* = "") const override;
 
   template<class T>
   static T const& take(T && obj) {
@@ -134,7 +134,7 @@ private:
   static DataCollection _nextSharedData;
   static DataCollection &getNextSharedData();
 
-  ClassDef(RooCmdArg,2) // Generic named argument container
+  ClassDefOverride(RooCmdArg,2) // Generic named argument container
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -115,7 +115,7 @@ protected:
   TList _yList ; ///< Dependency cmd list
   TList _pList ; ///< Processed cmd list
 
-  ClassDef(RooCmdConfig,0) // Configurable parse of RooCmdArg objects
+  ClassDefOverride(RooCmdConfig,0) // Configurable parse of RooCmdArg objects
 };
 
 

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -40,79 +40,79 @@ public:
   RooCompositeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> inputData) ;
 
   // Empty ctor
-  virtual RooAbsDataStore* clone(const char* newname=0) const { return new RooCompositeDataStore(*this,newname) ; }
-  virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const { return new RooCompositeDataStore(*this,vars,newname) ; }
+  RooAbsDataStore* clone(const char* newname=0) const override { return new RooCompositeDataStore(*this,newname) ; }
+  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooCompositeDataStore(*this,vars,newname) ; }
 
   RooCompositeDataStore(const RooCompositeDataStore& other, const char* newname=0) ;
   RooCompositeDataStore(const RooCompositeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
-  virtual ~RooCompositeDataStore() ;
+  ~RooCompositeDataStore() override ;
 
-  virtual void dump() ;
+  void dump() override ;
 
   // Write current row
-  virtual Int_t fill() ;
+  Int_t fill() override ;
 
-  virtual Double_t sumEntries() const ;
+  Double_t sumEntries() const override ;
 
   // Retrieve a row
   using RooAbsDataStore::get ;
-  virtual const RooArgSet* get(Int_t index) const ;
+  const RooArgSet* get(Int_t index) const override ;
   using RooAbsDataStore::weight ;
-  virtual Double_t weight() const ;
-  virtual Double_t weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const ;
-  virtual void weightError(Double_t& lo, Double_t& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const ;
-  virtual Bool_t isWeighted() const ;
+  Double_t weight() const override ;
+  Double_t weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const override ;
+  void weightError(Double_t& lo, Double_t& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const override ;
+  Bool_t isWeighted() const override ;
 
   // Change observable name
-  virtual Bool_t changeObservableName(const char* from, const char* to) ;
+  Bool_t changeObservableName(const char* from, const char* to) override ;
 
   // Add one or more columns
-  virtual RooAbsArg* addColumn(RooAbsArg& var, Bool_t adjustRange=kTRUE) ;
-  virtual RooArgSet* addColumns(const RooArgList& varList) ;
+  RooAbsArg* addColumn(RooAbsArg& var, Bool_t adjustRange=kTRUE) override ;
+  RooArgSet* addColumns(const RooArgList& varList) override ;
 
   // Merge column-wise
-  RooAbsDataStore* merge(const RooArgSet& allvars, std::list<RooAbsDataStore*> dstoreList) ;
+  RooAbsDataStore* merge(const RooArgSet& allvars, std::list<RooAbsDataStore*> dstoreList) override ;
 
   RooCategory* index() { return _indexCat ; }
 
   // Add rows
-  virtual void append(RooAbsDataStore& other) ;
+  void append(RooAbsDataStore& other) override ;
 
   // General & bookkeeping methods
-  virtual Int_t numEntries() const ;
-  virtual void reset() ;
+  Int_t numEntries() const override ;
+  void reset() override ;
 
   // Buffer redirection routines used in inside RooAbsOptTestStatistics
-  virtual void attachBuffers(const RooArgSet& extObs) ;
-  virtual void resetBuffers() ;
+  void attachBuffers(const RooArgSet& extObs) override ;
+  void resetBuffers() override ;
 
   // Constant term  optimizer interface
-  virtual void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, Bool_t skipZeroWeights=kFALSE) ;
-  virtual const RooAbsArg* cacheOwner() { return 0 ; }
-  virtual void setArgStatus(const RooArgSet& set, Bool_t active) ;
-  virtual void resetCache() ;
+  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, Bool_t skipZeroWeights=kFALSE) override ;
+  const RooAbsArg* cacheOwner() override { return 0 ; }
+  void setArgStatus(const RooArgSet& set, Bool_t active) override ;
+  void resetCache() override ;
 
-  virtual void recalculateCache(const RooArgSet* /*proj*/, Int_t /*firstEvent*/, Int_t /*lastEvent*/, Int_t /*stepSize*/, Bool_t /*skipZeroWeights*/) ;
-  virtual Bool_t hasFilledCache() const ;
+  void recalculateCache(const RooArgSet* /*proj*/, Int_t /*firstEvent*/, Int_t /*lastEvent*/, Int_t /*stepSize*/, Bool_t /*skipZeroWeights*/) override ;
+  Bool_t hasFilledCache() const override ;
 
   void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=0, const char* rangeName=0,
-      std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max());
+      std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
 
-  virtual void forceCacheUpdate() ;
+  void forceCacheUpdate() override ;
 
-  virtual RooBatchCompute::RunContext getBatches(std::size_t first, std::size_t len) const {
+  RooBatchCompute::RunContext getBatches(std::size_t first, std::size_t len) const override {
     //TODO
     std::cerr << "This functionality is not yet implemented for composite data stores." << std::endl;
     throw std::logic_error("getBatches() not implemented for RooCompositeDataStore.");
     (void)first; (void)len;
     return {};
   }
-  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
+  RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
 
 
  protected:
 
-  void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
+  void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override ;
 
   std::map<Int_t,RooAbsDataStore*> _dataMap ;
   RooCategory* _indexCat ;
@@ -121,7 +121,7 @@ public:
   mutable std::unique_ptr<std::vector<double>> _weightBuffer; ///<! Buffer for weights in case a batch of values is requested.
   Bool_t _ownComps ; ///<!
 
-  ClassDef(RooCompositeDataStore,1) // Composite Data Storage class
+  ClassDefOverride(RooCompositeDataStore,1) // Composite Data Storage class
 };
 
 

--- a/roofit/roofitcore/inc/RooConstVar.h
+++ b/roofit/roofitcore/inc/RooConstVar.h
@@ -29,20 +29,20 @@ public:
   RooConstVar() { }
   RooConstVar(const char *name, const char *title, Double_t value);
   RooConstVar(const RooConstVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooConstVar(*this,newname); }
-  virtual ~RooConstVar() = default;
+  TObject* clone(const char* newname) const override { return new RooConstVar(*this,newname); }
+  ~RooConstVar() override = default;
 
   /// Return (constant) value.
-  virtual Double_t getValV(const RooArgSet*) const {
+  Double_t getValV(const RooArgSet*) const override {
     return _value;
   }
 
-  RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet*) const;
+  RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet*) const override;
 
-  void writeToStream(std::ostream& os, Bool_t compact) const ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   /// Returns false, as the value of the constant doesn't depend on other objects.
-  virtual Bool_t isDerived() const { 
+  Bool_t isDerived() const override { 
     return false;
   }
 
@@ -56,11 +56,11 @@ public:
 
 protected:
 
-  Double_t evaluate() const {
+  Double_t evaluate() const override {
     return _value;
   }
 
-  ClassDef(RooConstVar,2) // Constant RooAbsReal value object
+  ClassDefOverride(RooConstVar,2) // Constant RooAbsReal value object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -31,7 +31,7 @@ public:
   RooConstraintSum(const char *name, const char *title, const RooArgSet& constraintSet, const RooArgSet& paramSet, bool takeGlobalObservablesFromData=false) ;
 
   RooConstraintSum(const RooConstraintSum& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const override { return new RooConstraintSum(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooConstraintSum(*this, newname); }
 
   const RooArgList& list() { return _set1 ; }
 

--- a/roofit/roofitcore/inc/RooConvCoefVar.h
+++ b/roofit/roofitcore/inc/RooConvCoefVar.h
@@ -33,16 +33,16 @@ public:
   }
   RooConvCoefVar(const char *name, const char *title, const RooAbsAnaConvPdf& input, Int_t coefIdx, const RooArgSet* varList=0) ;
   RooConvCoefVar(const RooConvCoefVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooConvCoefVar(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooConvCoefVar(*this,newname); }
   /// Destructor
-  virtual ~RooConvCoefVar() {
+  ~RooConvCoefVar() override {
   } ;
 
-  virtual Double_t getValV(const RooArgSet* nset=0) const ;
+  Double_t getValV(const RooArgSet* nset=0) const override ;
 
-  virtual Double_t evaluate() const ;
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Double_t evaluate() const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -50,7 +50,7 @@ protected:
   RooRealProxy _convPdf ; ///< RooAbsAnaConv object implementing our coefficient
   Int_t    _coefIdx  ;    ///< Index code of the coefficient
 
-  ClassDef(RooConvCoefVar,1) // Auxiliary class representing the coefficient of a RooAbsAnaConvPdf as a RooAbsReal
+  ClassDefOverride(RooConvCoefVar,1) // Auxiliary class representing the coefficient of a RooAbsAnaConvPdf as a RooAbsReal
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooConvGenContext.h
+++ b/roofit/roofitcore/inc/RooConvGenContext.h
@@ -36,16 +36,16 @@ public:
           const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
   RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
           const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
-  virtual ~RooConvGenContext();
+  ~RooConvGenContext() override;
 
-  virtual void setProtoDataOrder(Int_t* lut) ;
+  void setProtoDataOrder(Int_t* lut) override ;
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
 protected:
 
@@ -64,7 +64,7 @@ protected:
   RooRealVar* _cvPdf{nullptr};   ///< Convolution variable in PDFxTruth event
   RooRealVar* _cvOut{nullptr};   ///< Convolution variable in output event
 
-  ClassDef(RooConvGenContext,0) // Context for generating a dataset from a PDF
+  ClassDefOverride(RooConvGenContext,0) // Context for generating a dataset from a PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooConvIntegrandBinding.h
+++ b/roofit/roofitcore/inc/RooConvIntegrandBinding.h
@@ -27,11 +27,11 @@ public:
   RooConvIntegrandBinding(const RooAbsReal& func, const RooAbsReal& model,
 	             RooAbsReal& x, RooAbsReal& xprime,
                      const RooArgSet* nset=0, Bool_t clipInvalid=kFALSE);
-  virtual ~RooConvIntegrandBinding();
+  ~RooConvIntegrandBinding() override;
 
-  virtual Double_t operator()(const Double_t xvector[]) const;
-  virtual Double_t getMinLimit(UInt_t dimension) const;
-  virtual Double_t getMaxLimit(UInt_t dimension) const;
+  Double_t operator()(const Double_t xvector[]) const override;
+  Double_t getMinLimit(UInt_t dimension) const override;
+  Double_t getMaxLimit(UInt_t dimension) const override;
   inline void setNormalizationSet(const RooArgSet* nset) {
     // Use the supplied nset as normalization set for calls to func and model
     _nset = nset ;
@@ -48,7 +48,7 @@ protected:
   mutable Bool_t _xvecValid; ///< If true _xvec defines a valid point
   Bool_t _clipInvalid ;      ///< If true, invalid x values are clipped into their valid range
 
-  ClassDef(RooConvIntegrandBinding,0) // RooAbsFunc representation of convolution integrands
+  ClassDefOverride(RooConvIntegrandBinding,0) // RooAbsFunc representation of convolution integrands
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooCurve.h
+++ b/roofit/roofitcore/inc/RooCurve.h
@@ -40,23 +40,23 @@ public:
   RooCurve(const char *name, const char *title, const RooAbsFunc &func, Double_t xlo,
       Double_t xhi, UInt_t minPoints, Double_t prec= 1e-3, Double_t resolution= 1e-3,
       Bool_t shiftToZero=kFALSE, WingMode wmode=Extended, Int_t nEvalError=-1, Int_t doEEVal=kFALSE, Double_t eeVal=0);
-  virtual ~RooCurve();
+  ~RooCurve() override;
 
   RooCurve(const char* name, const char* title, const RooCurve& c1, const RooCurve& c2, Double_t scale1=1., Double_t scale2=1.) ;
 
   void addPoint(Double_t x, Double_t y);
 
-  Double_t getFitRangeBinW() const;
-  Double_t getFitRangeNEvt(Double_t xlo, Double_t xhi) const ;
-  Double_t getFitRangeNEvt() const;
+  Double_t getFitRangeBinW() const override;
+  Double_t getFitRangeNEvt(Double_t xlo, Double_t xhi) const override ;
+  Double_t getFitRangeNEvt() const override;
 
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
@@ -90,7 +90,7 @@ protected:
 
   Bool_t _showProgress ; ///<! Show progress indication when adding points
 
-  ClassDef(RooCurve,1) // 1-dimensional smooth curve for use in RooPlots
+  ClassDefOverride(RooCurve,1) // 1-dimensional smooth curve for use in RooPlots
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooCustomizer.h
+++ b/roofit/roofitcore/inc/RooCustomizer.h
@@ -39,7 +39,7 @@ public:
   // Constructors, assignment etc
   RooCustomizer(const RooAbsArg& pdf, const RooAbsCategoryLValue& masterCat, RooArgSet& splitLeafListOwned, RooArgSet* splitLeafListAll=0) ;
   RooCustomizer(const RooAbsArg& pdf, const char* name) ;
-  virtual ~RooCustomizer() ;
+  ~RooCustomizer() override ;
 
   /// If flag is true, make customizer own all created components
   void setOwning(Bool_t flag) {
@@ -62,14 +62,14 @@ public:
   }
 
   // Printing interface
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent= "") const;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent= "") const override;
 
   /// Printing interface
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
@@ -79,8 +79,8 @@ public:
   /// Factory interface
   class CustIFace : public RooFactoryWSTool::IFace {
   public:
-    virtual ~CustIFace() {} ;
-    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) ;
+    ~CustIFace() override {} ;
+    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) override ;
   } ;
 
 protected:
@@ -114,7 +114,7 @@ protected:
   RooArgSet* _cloneNodeListAll ;        ///< List of all cloned nodes
   RooArgSet* _cloneNodeListOwned ;      ///< List of owned cloned nodes
 
-  ClassDef(RooCustomizer,0) // Editing tool for RooAbsArg composite object expressions
+  ClassDefOverride(RooCustomizer,0) // Editing tool for RooAbsArg composite object expressions
 } ;
 
 #endif

--- a/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
+++ b/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
@@ -26,14 +26,14 @@ public:
   RooDLLSignificanceMCSModule(const RooRealVar& param, Double_t nullHypoValue=0) ;
   RooDLLSignificanceMCSModule(const char* parName, Double_t nullHypoValue=0) ;
   RooDLLSignificanceMCSModule(const RooDLLSignificanceMCSModule& other) ;
-  virtual ~RooDLLSignificanceMCSModule() ;
+  ~RooDLLSignificanceMCSModule() override ;
 
-  Bool_t initializeInstance() ;
+  Bool_t initializeInstance() override ;
 
-  Bool_t initializeRun(Int_t /*numSamples*/) ;
-  RooDataSet* finalizeRun() ;
+  Bool_t initializeRun(Int_t /*numSamples*/) override ;
+  RooDataSet* finalizeRun() override ;
 
-  Bool_t processAfterFit(Int_t /*sampleNum*/)  ;
+  Bool_t processAfterFit(Int_t /*sampleNum*/) override  ;
 
 private:
 
@@ -44,7 +44,7 @@ private:
   RooRealVar* _sig0h ;     ///< Container variable for NLL result with signal
   Double_t    _nullValue ; ///< Numeric value of Nsignal parameter representing the null hypothesis
 
-  ClassDef(RooDLLSignificanceMCSModule,0) // MCStudy module to calculate Delta(-logL) significance w.r.t given null hypothesis
+  ClassDefOverride(RooDLLSignificanceMCSModule,0) // MCStudy module to calculate Delta(-logL) significance w.r.t given null hypothesis
 } ;
 
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -134,9 +134,9 @@ public:
 
   void reset() override;
 
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override;
-  virtual void printArgs(std::ostream& os) const override;
-  virtual void printValue(std::ostream& os) const override;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override;
+  void printArgs(std::ostream& os) const override;
+  void printValue(std::ostream& os) const override;
   void printDataHistogram(std::ostream& os, RooRealVar* obs) const;
 
   void SetName(const char *name) override;

--- a/roofit/roofitcore/inc/RooDataHistSliceIter.h
+++ b/roofit/roofitcore/inc/RooDataHistSliceIter.h
@@ -27,14 +27,14 @@ class RooDataHistSliceIter : public TIterator {
 public:
   // Constructors, assignment etc.
   RooDataHistSliceIter(const RooDataHistSliceIter& other) ;
-  virtual ~RooDataHistSliceIter() ;
+  ~RooDataHistSliceIter() override ;
 
   // Iterator implementation
-  virtual const TCollection* GetCollection() const ;
-  virtual TObject* Next() ;
-  virtual void Reset() ;
-  virtual bool operator!=(const TIterator &aIter) const ;
-  virtual TObject *operator*() const ;
+  const TCollection* GetCollection() const override ;
+  TObject* Next() override ;
+  void Reset() override ;
+  bool operator!=(const TIterator &aIter) const override ;
+  TObject *operator*() const override ;
 protected:
 
   friend class RooDataHist ;
@@ -48,11 +48,11 @@ protected:
   Int_t      _curStep ;
 
   /// Prohibit iterator assignment
-  TIterator& operator=(const TIterator&) {
+  TIterator& operator=(const TIterator&) override {
     return *this ;
   }
 
-  ClassDef(RooDataHistSliceIter,0) // Iterator over a one-dimensional slice of a RooDataHist
+  ClassDefOverride(RooDataHistSliceIter,0) // Iterator over a one-dimensional slice of a RooDataHist
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooDataProjBinding.h
+++ b/roofit/roofitcore/inc/RooDataProjBinding.h
@@ -25,11 +25,11 @@ class Roo1DTable ;
 class RooDataProjBinding : public RooRealBinding {
 public:
   RooDataProjBinding(const RooAbsReal &real, const RooAbsData& data, const RooArgSet &vars, const RooArgSet* normSet=0) ;
-  virtual ~RooDataProjBinding() ;
+  ~RooDataProjBinding() override ;
 
-  virtual Double_t operator()(const Double_t xvector[]) const;
+  Double_t operator()(const Double_t xvector[]) const override;
 
-  RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const;
+  RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const override;
 
 protected:
 
@@ -42,7 +42,7 @@ protected:
   Roo1DTable* _catTable ;        ///< Supercategory table generated from _data
   mutable std::unique_ptr<std::vector<double>> _batchBuffer; ///<! Storage for handing out spans.
 
-  ClassDef(RooDataProjBinding,0) // RealFunc/Dataset binding for data projection of a real function
+  ClassDefOverride(RooDataProjBinding,0) // RealFunc/Dataset binding for data projection of a real function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -67,17 +67,17 @@ public:
              const RooFormulaVar& cutVar, const char* wgtVarName=0) ;
 
   RooDataSet(RooDataSet const & other, const char* newname=0) ;
-  virtual TObject* Clone(const char* newname = "") const override {
+  TObject* Clone(const char* newname = "") const override {
     return new RooDataSet(*this, newname && newname[0] != '\0' ? newname : GetName());
   }
-  virtual ~RooDataSet() ;
+  ~RooDataSet() override ;
 
-  virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const override;
+  RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const override;
 
   RooDataHist* binnedClone(const char* newName=0, const char* newTitle=0) const ;
 
-  virtual Double_t sumEntries() const override;
-  virtual Double_t sumEntries(const char* cutSpec, const char* cutRange=0) const override;
+  Double_t sumEntries() const override;
+  Double_t sumEntries(const char* cutSpec, const char* cutRange=0) const override;
 
   virtual RooPlot* plotOnXY(RooPlot* frame,
              const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
@@ -95,23 +95,23 @@ public:
   Bool_t write(std::ostream & ofs) const;
 
 
-  virtual Bool_t isWeighted() const override;
-  virtual Bool_t isNonPoissonWeighted() const override;
+  Bool_t isWeighted() const override;
+  Bool_t isNonPoissonWeighted() const override;
 
-  virtual Double_t weight() const override;
+  Double_t weight() const override;
   /// Returns a pointer to the weight variable (if set).
   RooRealVar* weightVar() const { return _wgtVar; }
-  virtual Double_t weightSquared() const override;
-  virtual void weightError(double& lo, double& hi,ErrorType etype=SumW2) const override;
+  Double_t weightSquared() const override;
+  void weightError(double& lo, double& hi,ErrorType etype=SumW2) const override;
   double weightError(ErrorType etype=SumW2) const override;
 
-  virtual const RooArgSet* get(Int_t index) const override;
-  virtual const RooArgSet* get() const override;
+  const RooArgSet* get(Int_t index) const override;
+  const RooArgSet* get() const override;
 
-  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len, bool sumW2) const override;
+  RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len, bool sumW2) const override;
 
   /// Add one ore more rows of data
-  virtual void add(const RooArgSet& row, Double_t weight=1.0, Double_t weightError=0) override;
+  void add(const RooArgSet& row, Double_t weight=1.0, Double_t weightError=0) override;
   virtual void add(const RooArgSet& row, Double_t weight, Double_t weightErrorLo, Double_t weightErrorHi);
 
   virtual void addFast(const RooArgSet& row, Double_t weight=1.0, Double_t weightError=0);
@@ -132,8 +132,8 @@ public:
                         const char* cuts="", const char *name="hist") const;
 
   void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override;
-  virtual void printArgs(std::ostream& os) const override;
-  virtual void printValue(std::ostream& os) const override;
+  void printArgs(std::ostream& os) const override;
+  void printValue(std::ostream& os) const override;
 
   void SetName(const char *name) override;
   void SetNameTitle(const char *name, const char* title) override;
@@ -144,7 +144,7 @@ public:
 
 protected:
 
-  virtual RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) override;
+  RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) override;
 
   friend class RooProdGenContext ;
 

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -31,27 +31,27 @@ public:
                          RooAbsTestStatistic::Configuration const& cfg, bool showProgress=false) ;
 
   RooDataWeightedAverage(const RooDataWeightedAverage& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooDataWeightedAverage(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooDataWeightedAverage(*this,newname); }
 
-  virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& adata,
+  RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& adata,
                                       const RooArgSet& projDeps,
-                                      RooAbsTestStatistic::Configuration const& cfg) {
+                                      RooAbsTestStatistic::Configuration const& cfg) override {
     // Virtual constructor
     return new RooDataWeightedAverage(name,title,real,adata,projDeps,cfg) ;
   }
 
-  virtual Double_t globalNormalization() const ;
+  Double_t globalNormalization() const override ;
 
-  virtual ~RooDataWeightedAverage();
+  ~RooDataWeightedAverage() override;
 
 
 protected:
 
   Double_t _sumWeight ;  ///< Global sum of weights needed for normalization
   Bool_t _showProgress ; ///< Show progress indication during evaluation if true
-  virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const ;
+  Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
-  ClassDef(RooDataWeightedAverage,1) // Optimized calculator of data weighted average of a RooAbsReal
+  ClassDefOverride(RooDataWeightedAverage,1) // Optimized calculator of data weighted average of a RooAbsReal
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooDerivative.h
+++ b/roofit/roofitcore/inc/RooDerivative.h
@@ -33,16 +33,16 @@ public:
   RooDerivative() ;
   RooDerivative(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, Int_t order=1, Double_t eps=0.001) ;
   RooDerivative(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, Int_t order=1, Double_t eps=0.001) ;
-  virtual ~RooDerivative() ;
+  ~RooDerivative() override ;
 
   RooDerivative(const RooDerivative& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooDerivative(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooDerivative(*this, newname); }
 
   Int_t order() const { return _order ; }
   Double_t eps() const { return _eps ; }
   void setEps(Double_t e) { _eps = e ; }
 
-  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) ;
+  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override ;
 
 protected:
 
@@ -54,9 +54,9 @@ protected:
   mutable RooFunctor*  _ftor ;                   ///<! Functor binding of RooAbsReal
   mutable ROOT::Math::RichardsonDerivator *_rd ; ///<! Derivator
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooDerivative,1) // Representation of derivative of any RooAbsReal
+  ClassDefOverride(RooDerivative,1) // Representation of derivative of any RooAbsReal
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooDouble.h
+++ b/roofit/roofitcore/inc/RooDouble.h
@@ -28,7 +28,7 @@ public:
   RooDouble(Double_t value) ;
   RooDouble(const RooDouble& other) : TNamed(other), _value(other._value) {}
   /// Destructor
-  virtual ~RooDouble() {
+  ~RooDouble() override {
   } ;
 
   // Double_t cast operator
@@ -42,16 +42,16 @@ public:
   }
 
   // Sorting interface ;
-  Int_t Compare(const TObject* other) const ;
+  Int_t Compare(const TObject* other) const override ;
   /// We are a sortable object
-  virtual Bool_t IsSortable() const {
+  Bool_t IsSortable() const override {
     return kTRUE ;
   }
 
 protected:
 
   Double_t _value ; ///< Value payload
-  ClassDef(RooDouble,1) // Container class for Double_t
+  ClassDefOverride(RooDouble,1) // Container class for Double_t
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooEffGenContext.h
+++ b/roofit/roofitcore/inc/RooEffGenContext.h
@@ -26,11 +26,11 @@ public:
                    const RooAbsPdf &pdf,const RooAbsReal& eff,
                    const RooArgSet &vars, const RooDataSet *prototype= 0,
                    const RooArgSet* auxProto=0, Bool_t verbose=kFALSE, const RooArgSet* forceDirect=0);
-  virtual ~RooEffGenContext();
+  ~RooEffGenContext() override;
 
 protected:
-  void initGenerator(const RooArgSet &theEvent);
-  void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
 private:
    RooArgSet* _cloneSet;           ///< Internal clone of p.d.f.
@@ -39,6 +39,6 @@ private:
    RooArgSet* _vars;               ///< Vars to generate
    double _maxEff;                 ///< Maximum of efficiency in vars
 
-   ClassDef(RooEffGenContext, 1) // Context for generating a dataset from a PDF
+   ClassDefOverride(RooEffGenContext, 1) // Context for generating a dataset from a PDF
 };
 #endif

--- a/roofit/roofitcore/inc/RooEffProd.h
+++ b/roofit/roofitcore/inc/RooEffProd.h
@@ -21,21 +21,21 @@ class RooEffProd: public RooAbsPdf {
 public:
   // Constructors, assignment etc
   inline RooEffProd() : _cacheMgr(this,10), _nset(0), _fixedNset(0) { };
-  virtual ~RooEffProd();
+  ~RooEffProd() override;
   RooEffProd(const char *name, const char *title, RooAbsPdf& pdf, RooAbsReal& efficiency);
   RooEffProd(const RooEffProd& other, const char* name=0);
 
-  virtual TObject* clone(const char* newname) const { return new RooEffProd(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooEffProd(*this,newname); }
 
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype,
-                                       const RooArgSet* auxProto, Bool_t verbose) const;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype,
+                                       const RooArgSet* auxProto, Bool_t verbose) const override;
 
   /// Return kTRUE to force RooRealIntegral to offer all observables for internal integration
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const {
+  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
     return kTRUE ;
   }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
 protected:
 
@@ -49,18 +49,18 @@ protected:
   }
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem() : _clone(0), _int(0) {}
-    virtual ~CacheElem() { delete _int ; delete _clone ; }
+    ~CacheElem() override { delete _int ; delete _clone ; }
     // Payload
     RooArgSet   _intObs ;
     RooEffProd* _clone ;
     RooAbsReal* _int ;
     // Cache management functions
-    virtual RooArgList containedArgs(Action) ;
+    RooArgList containedArgs(Action) override ;
   } ;
   mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager
 
@@ -72,7 +72,7 @@ protected:
 
   RooArgSet* _fixedNset ; ///<! Fixed normalization set overriding default normalization set (if provided)
 
-  ClassDef(RooEffProd,2) // Product operator p.d.f of (PDF x efficiency) implementing optimized generator context
+  ClassDefOverride(RooEffProd,2) // Product operator p.d.f of (PDF x efficiency) implementing optimized generator context
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooEfficiency.h
+++ b/roofit/roofitcore/inc/RooEfficiency.h
@@ -32,21 +32,21 @@ public:
   }
   RooEfficiency(const char *name, const char *title, const RooAbsReal& effFunc, const RooAbsCategory& cat, const char* sigCatName);
   RooEfficiency(const RooEfficiency& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooEfficiency(*this,newname); }
-  virtual ~RooEfficiency();
+  TObject* clone(const char* newname) const override { return new RooEfficiency(*this,newname); }
+  ~RooEfficiency() override;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   RooCategoryProxy _cat ; ///< Accept/reject categort
   RooRealProxy _effFunc ; ///< Efficiency modeling function
   TString _sigCatName ;   ///< Name of accept state of accept/reject category
 
-  ClassDef(RooEfficiency,1) // Generic PDF defined by string expression and list of variables
+  ClassDefOverride(RooEfficiency,1) // Generic PDF defined by string expression and list of variables
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooEllipse.h
+++ b/roofit/roofitcore/inc/RooEllipse.h
@@ -23,26 +23,26 @@ class RooEllipse : public TGraph, public RooPlotable {
 public:
   RooEllipse();
   RooEllipse(const char *name, Double_t x1, Double_t x2, Double_t s1, Double_t s2, Double_t rho= 0, Int_t points= 100);
-  virtual ~RooEllipse();
+  ~RooEllipse() override;
 
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override;
 
   /// Printing interface
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
   // These methods return zero to indicate that they do not support
   // this interface. See RooPlot::updateFitRangeNorm() for details.
-  inline virtual Double_t getFitRangeNEvt() const { return 0; }
-  inline virtual Double_t getFitRangeNEvt(Double_t, Double_t) const { return 0; }
-  inline virtual Double_t getFitRangeBinW() const { return 0; }
+  inline Double_t getFitRangeNEvt() const override { return 0; }
+  inline Double_t getFitRangeNEvt(Double_t, Double_t) const override { return 0; }
+  inline Double_t getFitRangeBinW() const override { return 0; }
 
-  ClassDef(RooEllipse,1) // 2-dimensional contour
+  ClassDefOverride(RooEllipse,1) // 2-dimensional contour
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooErrorVar.h
+++ b/roofit/roofitcore/inc/RooErrorVar.h
@@ -33,29 +33,29 @@ public:
   }
   RooErrorVar(const char *name, const char *title, const RooRealVar& input) ;
   RooErrorVar(const RooErrorVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooErrorVar(*this,newname); }
-  virtual ~RooErrorVar() ;
+  TObject* clone(const char* newname) const override { return new RooErrorVar(*this,newname); }
+  ~RooErrorVar() override ;
 
-  virtual Double_t getValV(const RooArgSet* set=0) const ;
+  Double_t getValV(const RooArgSet* set=0) const override ;
 
-  virtual Double_t evaluate() const {
+  Double_t evaluate() const override {
     // return error of input RooRealVar
     return ((RooRealVar&)_realVar.arg()).getError() ;
   }
 
-  virtual void setVal(Double_t value) {
+  void setVal(Double_t value) override {
     // Set error of input RooRealVar to value
     ((RooRealVar&)_realVar.arg()).setVal(value) ;
   }
 
-  inline virtual Bool_t isFundamental() const {
+  inline Bool_t isFundamental() const override {
     // Return kTRUE as we implement a fundamental type of AbsArg that can be stored in a dataset
     return kTRUE ;
   }
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Set/get finite fit range limits
   /// Set lower bound of default range to value
@@ -76,10 +76,10 @@ public:
 
   void setBins(Int_t nBins);
   void setBinning(const RooAbsBinning& binning, const char* name=0) ;
-  const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const ;
-  RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) ;
-  Bool_t hasBinning(const char* name) const ;
-  std::list<std::string> getBinningNames() const ;
+  const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const override ;
+  RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) override ;
+  Bool_t hasBinning(const char* name) const override ;
+  std::list<std::string> getBinningNames() const override ;
 
   // Set infinite fit range limits
   void removeMin(const char* name=0);
@@ -93,12 +93,12 @@ protected:
 
   RooLinkedList _altBinning ;  ///<! Optional alternative ranges and binnings
 
-  void syncCache(const RooArgSet* set=0) ;
+  void syncCache(const RooArgSet* set=0) override ;
 
   RooRealProxy _realVar ;   ///< RealVar with the original error
   RooAbsBinning* _binning ; ///<! Pointer to default binning definition
 
-  ClassDef(RooErrorVar,1) // RooAbsRealLValue representation of an error of a RooRealVar
+  ClassDefOverride(RooErrorVar,1) // RooAbsRealLValue representation of an error of a RooRealVar
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooExpensiveObjectCache.h
+++ b/roofit/roofitcore/inc/RooExpensiveObjectCache.h
@@ -26,7 +26,7 @@ public:
 
   RooExpensiveObjectCache() ;
   RooExpensiveObjectCache(const RooExpensiveObjectCache&) ;
-  virtual ~RooExpensiveObjectCache() ;
+  ~RooExpensiveObjectCache() override ;
 
   Bool_t registerObject(const char* ownerName, const char* objectName, TObject& cacheObject, TIterator* paramIter) ;
   Bool_t registerObject(const char* ownerName, const char* objectName, TObject& cacheObject, const RooArgSet& params) ;
@@ -80,7 +80,7 @@ protected:
   std::map<TString,ExpensiveObject*> _map ;
 
 
-  ClassDef(RooExpensiveObjectCache,2) // Singleton class that serves as session repository for expensive objects
+  ClassDefOverride(RooExpensiveObjectCache,2) // Singleton class that serves as session repository for expensive objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -26,24 +26,24 @@ public:
   RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
           RooAbsReal& norm, const char* rangeName=0) ;
   RooExtendPdf(const RooExtendPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooExtendPdf(*this,newname) ; }
-  virtual ~RooExtendPdf() ;
+  TObject* clone(const char* newname) const override { return new RooExtendPdf(*this,newname) ; }
+  ~RooExtendPdf() override ;
 
-  Double_t evaluate() const { return _pdf ; }
+  Double_t evaluate() const override { return _pdf ; }
 
-  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const { return kTRUE ; }
+  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const override { return kTRUE ; }
   /// Forward determination of analytical integration capabilities to input p.d.f
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const {
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override {
     return _pdf->getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName) ;
   }
   /// Forward calculation of analytical integrals to input p.d.f
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const {
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override {
     return _pdf->analyticalIntegralWN(code, normSet, rangeName) ;
   }
 
-  virtual Bool_t selfNormalized() const { return kTRUE ; }
-  virtual ExtendMode extendMode() const { return CanBeExtended ; }
-  virtual Double_t expectedEvents(const RooArgSet* nset) const ;
+  Bool_t selfNormalized() const override { return kTRUE ; }
+  ExtendMode extendMode() const override { return CanBeExtended ; }
+  Double_t expectedEvents(const RooArgSet* nset) const override ;
 
 protected:
 
@@ -52,7 +52,7 @@ protected:
   const TNamed* _rangeName ;         ///< Name of subset range
 
 
-  ClassDef(RooExtendPdf,2) // Wrapper p.d.f adding an extended likelihood term to an existing p.d.f
+  ClassDefOverride(RooExtendPdf,2) // Wrapper p.d.f adding an extended likelihood term to an existing p.d.f
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooExtendedBinding.h
+++ b/roofit/roofitcore/inc/RooExtendedBinding.h
@@ -18,18 +18,18 @@ public:
   RooExtendedBinding() {} ; 
   RooExtendedBinding(const char *name, const char *title, RooAbsPdf& _pdf);
   RooExtendedBinding(const RooExtendedBinding& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooExtendedBinding(*this,newname); }
-  inline virtual ~RooExtendedBinding() { }
+  TObject* clone(const char* newname) const override { return new RooExtendedBinding(*this,newname); }
+  inline ~RooExtendedBinding() override { }
 
 protected:
 
   RooRealProxy pdf ;
   
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooExtendedBinding,1) // Your description goes here...
+  ClassDefOverride(RooExtendedBinding,1) // Your description goes here...
 };
  
 #endif

--- a/roofit/roofitcore/inc/RooExtendedTerm.h
+++ b/roofit/roofitcore/inc/RooExtendedTerm.h
@@ -25,20 +25,20 @@ public:
   RooExtendedTerm() ;
   RooExtendedTerm(const char *name, const char *title, const RooAbsReal& n) ;
   RooExtendedTerm(const RooExtendedTerm& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooExtendedTerm(*this,newname) ; }
-  virtual ~RooExtendedTerm() ;
+  TObject* clone(const char* newname) const override { return new RooExtendedTerm(*this,newname) ; }
+  ~RooExtendedTerm() override ;
 
-  Double_t evaluate() const { return 1. ; }
+  Double_t evaluate() const override { return 1. ; }
 
-  virtual ExtendMode extendMode() const { return CanBeExtended ; }
+  ExtendMode extendMode() const override { return CanBeExtended ; }
   /// Return number of expected events, in other words the value of the associated n parameter.
-  virtual Double_t expectedEvents(const RooArgSet* nset) const ;
+  Double_t expectedEvents(const RooArgSet* nset) const override ;
 
 protected:
 
   RooRealProxy _n ;          ///< Number of expected events
 
-  ClassDef(RooExtendedTerm,1) // Meta-p.d.f flat in all observables introducing only extended ML term
+  ClassDefOverride(RooExtendedTerm,1) // Meta-p.d.f flat in all observables introducing only extended ML term
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -31,8 +31,8 @@ public:
   RooFFTConvPdf(const char *name, const char *title, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder=2);
   RooFFTConvPdf(const char *name, const char *title, RooAbsReal& pdfConvVar, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder=2);
   RooFFTConvPdf(const RooFFTConvPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooFFTConvPdf(*this,newname); }
-  virtual ~RooFFTConvPdf() ;
+  TObject* clone(const char* newname) const override { return new RooFFTConvPdf(*this,newname); }
+  ~RooFFTConvPdf() override ;
 
   void setShift(Double_t val1, Double_t val2) { _shift1 = val1 ; _shift2 = val2 ; }
   void setCacheObservables(const RooArgSet& obs) { _cacheObs.removeAll() ; _cacheObs.add(obs) ; }
@@ -55,11 +55,11 @@ public:
   void setBufferStrategy(BufStrat bs) ;
   void setBufferFraction(Double_t frac) ;
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
   // Propagate maximum value estimate of pdf1 as convolution can only result in lower max values
-  virtual Int_t getMaxVal(const RooArgSet& vars) const { return _pdf1.arg().getMaxVal(vars) ; }
-  virtual Double_t maxVal(Int_t code) const { return _pdf1.arg().maxVal(code) ; }
+  Int_t getMaxVal(const RooArgSet& vars) const override { return _pdf1.arg().getMaxVal(vars) ; }
+  Double_t maxVal(Int_t code) const override { return _pdf1.arg().maxVal(code) ; }
 
 
 protected:
@@ -71,7 +71,7 @@ protected:
   RooSetProxy _params ;  ///< Effective parameters of this p.d.f.
 
   void calcParams() ;
-  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
 
   std::vector<double>  scanPdf(RooRealVar& obs, RooAbsPdf& pdf, const RooDataHist& hist, const RooArgSet& slicePos, Int_t& N, Int_t& N2, Int_t& zeroBin, Double_t shift) const ;
 
@@ -79,7 +79,7 @@ protected:
   public:
     FFTCacheElem(const RooFFTConvPdf& self, const RooArgSet* nset) ;
 
-    virtual RooArgList containedArgs(Action) ;
+    RooArgList containedArgs(Action) override ;
 
     std::unique_ptr<TVirtualFFT> fftr2c1;
     std::unique_ptr<TVirtualFFT> fftr2c2;
@@ -94,16 +94,16 @@ protected:
 
   friend class FFTCacheElem ;
 
-  virtual Double_t evaluate() const { RooArgSet dummy(_x.arg()) ; return getVal(&dummy) ; } ; // dummy
-  virtual const char* inputBaseName() const ;
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual RooAbsArg& pdfObservable(RooAbsArg& histObservable) const ;
-  virtual void fillCacheObject(PdfCacheElem& cache) const ;
+  Double_t evaluate() const override { RooArgSet dummy(_x.arg()) ; return getVal(&dummy) ; } ; // dummy
+  const char* inputBaseName() const override ;
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  RooAbsArg& pdfObservable(RooAbsArg& histObservable) const override ;
+  void fillCacheObject(PdfCacheElem& cache) const override ;
   void fillCacheSlice(FFTCacheElem& cache, const RooArgSet& slicePosition) const ;
 
-  virtual PdfCacheElem* createCache(const RooArgSet* nset) const ;
-  virtual TString histNameSuffix() const ;
+  PdfCacheElem* createCache(const RooArgSet* nset) const override ;
+  TString histNameSuffix() const override ;
 
   // mutable std:: map<const RooHistPdf*,CacheAuxInfo*> _cacheAuxInfo ; //! Auxilary Cache information (do not persist)
   Double_t _bufFrac ; // Sampling buffer size as fraction of domain size
@@ -112,8 +112,8 @@ protected:
   Double_t  _shift1 ;
   Double_t  _shift2 ;
 
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
+                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const override ;
 
   friend class RooConvGenContext ;
   RooSetProxy  _cacheObs ; ///< Non-convolution observables that are also cached
@@ -122,7 +122,7 @@ private:
 
   void prepareFFTBinning(RooRealVar& convVar) const;
 
-  ClassDef(RooFFTConvPdf,1) // Convolution operator p.d.f based on numeric Fourier transforms
+  ClassDefOverride(RooFFTConvPdf,1) // Convolution operator p.d.f based on numeric Fourier transforms
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFactoryWSTool.h
+++ b/roofit/roofitcore/inc/RooFactoryWSTool.h
@@ -50,7 +50,7 @@ public:
 
   // Constructors, assignment etc
   RooFactoryWSTool(RooWorkspace& ws) ;
-  virtual ~RooFactoryWSTool() ;
+  ~RooFactoryWSTool() override ;
 
   // --- low level factory interface ---
 
@@ -144,8 +144,8 @@ public:
 
   class SpecialsIFace : public IFace {
   public:
-    virtual ~SpecialsIFace() {} ;
-    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) ;
+    ~SpecialsIFace() override {} ;
+    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) override ;
   } ;
 
   static void registerSpecial(const char* typeName, RooFactoryWSTool::IFace* iface) ;
@@ -198,7 +198,7 @@ protected:
 
   RooFactoryWSTool(const RooFactoryWSTool&) ;
 
-  ClassDef(RooFactoryWSTool,0) // RooFit class code and instance factory
+  ClassDefOverride(RooFactoryWSTool,0) // RooFit class code and instance factory
 
 } ;
 

--- a/roofit/roofitcore/inc/RooFirstMoment.h
+++ b/roofit/roofitcore/inc/RooFirstMoment.h
@@ -30,10 +30,10 @@ public:
   RooFirstMoment() ;
   RooFirstMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x) ;
   RooFirstMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, Bool_t intNSet=kFALSE) ;
-  virtual ~RooFirstMoment() ;
+  ~RooFirstMoment() override ;
 
   RooFirstMoment(const RooFirstMoment& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooFirstMoment(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooFirstMoment(*this, newname); }
 
   const RooAbsReal& xF() { return _xf.arg() ; }
   const RooAbsReal& ixF() { return _ixf.arg() ; }
@@ -44,9 +44,9 @@ protected:
   RooRealProxy _xf ;                     ///< X*F
   RooRealProxy _ixf ;                    ///< Int(X*F(X))dx ;
   RooRealProxy _if ;                     ///< Int(F(x))dx ;
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooFirstMoment,1) // Representation of moment in a RooAbsReal in a given RooRealVar
+  ClassDefOverride(RooFirstMoment,1) // Representation of moment in a RooAbsReal in a given RooRealVar
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFitLegacy/RooCatTypeLegacy.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooCatTypeLegacy.h
@@ -37,12 +37,12 @@ public:
     strlcpy(_label,other._label,256) ;
   } ;
 
-  virtual ~RooCatType() {
+  ~RooCatType() override {
     // Destructor
   } ;
-  virtual TObject* Clone(const char*) const { return new RooCatType(*this); }
+  TObject* Clone(const char*) const override { return new RooCatType(*this); }
 
-  virtual const Text_t* GetName() const {
+  const Text_t* GetName() const override {
     // Return state name
     return _label[0] ? _label : 0 ;
   }
@@ -86,12 +86,12 @@ public:
   _value = newValue ;
   }
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printValue(std::ostream& os) const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printValue(std::ostream& os) const override ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
@@ -103,7 +103,7 @@ protected:
   Int_t _value ;     ///< Index value
   char _label[256] ; ///< State name
 
-  ClassDef(RooCatType,1) // Category state, (name,index) pair
+  ClassDefOverride(RooCatType,1) // Category state, (name,index) pair
 } R__SUGGEST_ALTERNATIVE("Instead of RooCatType, directly use the category number returned by RooAbsCategory::getIndex().\n"
     "Convert it into a name using RooAbsCategory::lookupName(index).");
 

--- a/roofit/roofitcore/inc/RooFitLegacy/RooCategorySharedProperties.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooCategorySharedProperties.h
@@ -39,7 +39,7 @@ public:
   /// Constructor with unique-id string.
   RooCategorySharedProperties(const char* uuidstr) : RooSharedProperties(uuidstr) {}
   /// Destructor.
-  virtual ~RooCategorySharedProperties() {
+  ~RooCategorySharedProperties() override {
     _altRanges.Delete() ;
   }
 
@@ -49,7 +49,7 @@ protected:
 
   RooLinkedList _altRanges ;  ///< Optional alternative ranges
 
-  ClassDef(RooCategorySharedProperties,1) // Shared properties of a RooCategory clone set
+  ClassDefOverride(RooCategorySharedProperties,1) // Shared properties of a RooCategory clone set
 };
 
 

--- a/roofit/roofitcore/inc/RooFitLegacy/RooHashTable.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooHashTable.h
@@ -37,7 +37,7 @@ public:
   RooHashTable(const RooHashTable& other) ;
 
   // Destructor
-  virtual ~RooHashTable() ;
+  ~RooHashTable() override ;
 
   void add(TObject* arg, TObject* hashArg=0) ;
   Bool_t remove(TObject* arg, TObject* hashArg=0) ;
@@ -68,7 +68,7 @@ protected:
   Int_t _size ;            ///< Total number of slots
   RooLinkedList** _arr ;   ///<! Array of linked lists storing elements in each slot
 
-  ClassDef(RooHashTable,1) // Hash table
+  ClassDefOverride(RooHashTable,1) // Hash table
 } R__SUGGEST_ALTERNATIVE("Please use std::unordered_map, which is also a hash table.");
 
 #endif

--- a/roofit/roofitcore/inc/RooFitLegacy/RooMinuit.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooMinuit.h
@@ -42,7 +42,7 @@ class RooMinuit : public TObject {
 public:
 
   RooMinuit(RooAbsReal& function) ;
-  virtual ~RooMinuit() ;
+  ~RooMinuit() override ;
 
   enum Strategy { Speed=0, Balance=1, Robustness=2 } ;
   enum PrintLevel { None=-1, Reduced=0, Normal=1, ExtraForProblem=2, Maximum=3 } ;
@@ -145,7 +145,7 @@ private:
 
   RooMinuit(const RooMinuit&) ;
 
-  ClassDef(RooMinuit,0) // RooFit minimizer based on MINUIT
+  ClassDefOverride(RooMinuit,0) // RooFit minimizer based on MINUIT
 } R__SUGGEST_ALTERNATIVE("Please use RooMinimizer instead of RooMinuit");
 
 

--- a/roofit/roofitcore/inc/RooFitLegacy/RooNameSet.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooNameSet.h
@@ -30,8 +30,8 @@ public:
   RooNameSet();
   RooNameSet(const RooArgSet& argSet);
   RooNameSet(const RooNameSet& other) ;
-  virtual TObject* Clone(const char*) const { return new RooNameSet(*this) ; }
-  virtual ~RooNameSet() ;
+  TObject* Clone(const char*) const override { return new RooNameSet(*this) ; }
+  ~RooNameSet() override ;
 
   void refill(const RooArgSet& argSet) ;
   RooArgSet* select(const RooArgSet& list) const ;
@@ -39,12 +39,12 @@ public:
   RooNameSet& operator=(const RooNameSet&) ;
   Bool_t operator<(const RooNameSet& other) const ;
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printValue(std::ostream& os) const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printValue(std::ostream& os) const override ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
@@ -60,7 +60,7 @@ protected:
   void extendBuffer(Int_t inc) ;
   static void strdup(Int_t& dstlen, char* &dstbuf, const char* str);
 
-  ClassDef(RooNameSet,1) // A sterile version of RooArgSet, containing only the names of the contained RooAbsArgs
+  ClassDefOverride(RooNameSet,1) // A sterile version of RooArgSet, containing only the names of the contained RooAbsArgs
 } R__SUGGEST_ALTERNATIVE("Please use RooHelpers::getColonSeparatedNameString() and RooHelpers::selectFromArgSet().");
 
 #endif

--- a/roofit/roofitcore/inc/RooFitLegacy/RooSetPair.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooSetPair.h
@@ -32,12 +32,12 @@ public:
   }
 
   // Destructor
-  virtual ~RooSetPair();
+  ~RooSetPair() override;
 
   RooArgSet* _set1 ;
   RooArgSet* _set2 ;
 
-  virtual ULong_t Hash() const {
+  ULong_t Hash() const override {
     return TString::Hash((void*)&_set1,2*sizeof(void*)) ;  
   }
 
@@ -47,7 +47,7 @@ protected:
   // Forbidden
   RooSetPair(const RooSetPair&) ;
 
-  ClassDef(RooSetPair,0) // Utility class holding a pair of RooArgSet pointers
+  ClassDefOverride(RooSetPair,0) // Utility class holding a pair of RooArgSet pointers
 } R__SUGGEST_ALTERNATIVE("Please use std::pair<RooArgSet*,RooArgSet*>");
 
 

--- a/roofit/roofitcore/inc/RooFitLegacy/RooTreeData.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooTreeData.h
@@ -35,7 +35,7 @@ private:
   RooArgSet _truth;        ///< Truth variables
   TString _blindString ;   ///< Blinding string (optionally read from ASCII files)
 
-  ClassDef(RooTreeData,1) // Dummy class for legacy RooDataSet support
+  ClassDefOverride(RooTreeData,1) // Dummy class for legacy RooDataSet support
 };
 
 

--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -43,33 +43,33 @@ public:
   // Constructors, assignment etc.
   RooFitResult(const char* name=0, const char* title=0) ;
   RooFitResult(const RooFitResult& other) ;
-  virtual TObject* Clone(const char* newname = 0) const {
+  TObject* Clone(const char* newname = 0) const override {
     RooFitResult* r =  new RooFitResult(*this) ;
     if (newname && *newname) r->SetName(newname) ;
     return r ;
   }
   virtual TObject* clone() const { return new RooFitResult(*this); }
-  virtual ~RooFitResult() ;
+  ~RooFitResult() override ;
 
   static RooFitResult* lastMinuitFit(const RooArgList& varList=RooArgList()) ;
 
   static RooFitResult *prefitResult(const RooArgList &paramList);
 
   // Printing interface (human readable)
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
-  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printValue(std::ostream& os) const override ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
-  virtual StyleOption defaultPrintStyle(Option_t* opt) const ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
+  StyleOption defaultPrintStyle(Option_t* opt) const override ;
 
   RooAbsPdf* createHessePdf(const RooArgSet& params) const ;
 
@@ -154,8 +154,8 @@ public:
   bool isIdenticalNoCov(const RooFitResult& other, double tol=1e-6, bool verbose=true) const ;
   bool isIdentical(const RooFitResult& other, double tol=1e-6, double tolCorr=1e-4, bool verbose=true) const ;
 
-  void SetName(const char *name) ;
-  void SetNameTitle(const char *name, const char* title) ;
+  void SetName(const char *name) override ;
+  void SetNameTitle(const char *name, const char* title) override ;
 
 protected:
 
@@ -201,7 +201,7 @@ protected:
 
   std::vector<std::pair<std::string,int> > _statusHistory ; ///< History of status codes
 
-  ClassDef(RooFitResult,5) // Container class for fit result
+  ClassDefOverride(RooFitResult,5) // Container class for fit result
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFoamGenerator.h
+++ b/roofit/roofitcore/inc/RooFoamGenerator.h
@@ -33,17 +33,17 @@ public:
   RooFoamGenerator() : _binding(0), _tfoam(0), _xmin(0), _range(0), _vec(0) {} ;
   RooFoamGenerator(const RooAbsReal &func, const RooArgSet &genVars, const RooNumGenConfig& config, Bool_t verbose=kFALSE, const RooAbsReal* maxFuncVal=0);
   RooAbsNumGenerator* clone(const RooAbsReal& func, const RooArgSet& genVars, const RooArgSet& /*condVars*/,
-			    const RooNumGenConfig& config, Bool_t verbose=kFALSE, const RooAbsReal* maxFuncVal=0) const {
+			    const RooNumGenConfig& config, Bool_t verbose=kFALSE, const RooAbsReal* maxFuncVal=0) const override {
     return new RooFoamGenerator(func,genVars,config,verbose,maxFuncVal) ;
   }
-  virtual ~RooFoamGenerator();
+  ~RooFoamGenerator() override;
 
-  const RooArgSet *generateEvent(UInt_t remaining, Double_t& resampleRatio);
+  const RooArgSet *generateEvent(UInt_t remaining, Double_t& resampleRatio) override;
 
   TFoam& engine() { return *_tfoam; }
 
-  virtual Bool_t canSampleConditional() const { return kFALSE ; }
-  virtual Bool_t canSampleCategories() const { return kFALSE ; }
+  Bool_t canSampleConditional() const override { return kFALSE ; }
+  Bool_t canSampleCategories() const override { return kFALSE ; }
 
 protected:
 
@@ -57,7 +57,7 @@ protected:
   Double_t*        _vec ;     ///< Transfer array for FOAM output
 
 
-  ClassDef(RooFoamGenerator,0) // Context for generating a dataset from a PDF using the TFoam class
+  ClassDefOverride(RooFoamGenerator,0) // Context for generating a dataset from a PDF using the TFoam class
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -35,7 +35,7 @@ public:
   RooFormula() ;
   RooFormula(const char* name, const char* formula, const RooArgList& varList, bool checkVariables = true);
   RooFormula(const RooFormula& other, const char* name=0);
-  virtual TObject* Clone(const char* newName = nullptr) const {return new RooFormula(*this, newName);}
+  TObject* Clone(const char* newName = nullptr) const override {return new RooFormula(*this, newName);}
 
   ////////////////////////////////////////////////////////////////////////////////
   /// Return list of arguments which are used in the formula.
@@ -65,14 +65,14 @@ public:
   Bool_t reCompile(const char* newFormula) ;
 
 
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
-  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printValue(std::ostream& os) const override ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual void Print(Option_t *options= 0) const {
+  void Print(Option_t *options= 0) const override {
     // Printing interface (human readable)
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
@@ -92,7 +92,7 @@ private:
   std::vector<bool> _isCategory; ///<! Whether an element of the _origList is a category.
   std::unique_ptr<TFormula> _tFormula; ///<! The formula used to compute values
 
-  ClassDef(RooFormula,0)
+  ClassDefOverride(RooFormula,0)
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -34,7 +34,7 @@ public:
   RooFormulaVar(const char *name, const char *title, const char* formula, const RooArgList& dependents, bool checkVariables = true);
   RooFormulaVar(const char *name, const char *title, const RooArgList& dependents, bool checkVariables = true);
   RooFormulaVar(const RooFormulaVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooFormulaVar(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooFormulaVar(*this,newname); }
 
   inline Bool_t ok() const { return getFormula().ok() ; }
   const char* expression() const { return _formExpr.Data(); }
@@ -50,12 +50,12 @@ public:
   }
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Printing interface (human readable)
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent= "") const ;
-  void printMetaArgs(std::ostream& os) const ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent= "") const override ;
+  void printMetaArgs(std::ostream& os) const override ;
 
   // Debugging
   /// Dump the formula to stdout.
@@ -65,15 +65,15 @@ public:
     return getFormula();
   }
 
-  virtual Double_t defaultErrorLevel() const ;
+  Double_t defaultErrorLevel() const override ;
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
-  inline void computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
+  Double_t evaluate() const override ;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  inline void computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const override
   {
     formula().computeBatch(stream, output, nEvents, dataMap);
   }
@@ -81,9 +81,9 @@ public:
 
   protected:
   // Post-processing of server redirection
-  virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
 
-  virtual Bool_t isValidReal(Double_t /*value*/, Bool_t /*printError*/) const {return true;}
+  Bool_t isValidReal(Double_t /*value*/, Bool_t /*printError*/) const override {return true;}
 
   private:
   RooFormula& getFormula() const;
@@ -93,7 +93,7 @@ public:
   mutable RooArgSet* _nset{nullptr}; ///<! Normalization set to be passed along to contents
   TString _formExpr ;            ///< Formula expression string
 
-  ClassDef(RooFormulaVar,1) // Real-valued function of other RooAbsArgs calculated by a TFormula expression
+  ClassDefOverride(RooFormulaVar,1) // Real-valued function of other RooAbsArgs calculated by a TFormula expression
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooFracRemainder.h
+++ b/roofit/roofitcore/inc/RooFracRemainder.h
@@ -27,19 +27,19 @@ public:
 
   RooFracRemainder() ;
   RooFracRemainder(const char *name, const char *title, const RooArgSet& sumSet) ;
-  virtual ~RooFracRemainder() ;
+  ~RooFracRemainder() override ;
 
   RooFracRemainder(const RooFracRemainder& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooFracRemainder(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooFracRemainder(*this, newname); }
 
 protected:
 
   RooListProxy _set1 ;            ///< Set of input fractions
   mutable TIterator* _setIter1 ;  ///<! Iterator over set of input fractions
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooFracRemainder,1) // Utility function calculating remainder fraction, i.e. 1-sum_i(a_i)
+  ClassDefOverride(RooFracRemainder,1) // Utility function calculating remainder fraction, i.e. 1-sum_i(a_i)
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooGenContext.h
+++ b/roofit/roofitcore/inc/RooGenContext.h
@@ -31,16 +31,16 @@ class RooGenContext : public RooAbsGenContext {
 public:
   RooGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
 		const RooArgSet* auxProto=0, Bool_t verbose=kFALSE, const RooArgSet* forceDirect=0);
-  virtual ~RooGenContext();
+  ~RooGenContext() override;
 
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
 protected:
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
   RooArgSet _cloneSet;    ///< Clone of all nodes of input p.d.f
   RooAbsPdf *_pdfClone;   ///< Clone of input p.d.f
@@ -53,7 +53,7 @@ protected:
   TIterator *_uniIter ;               ///< Iterator over uniform observables
   Int_t _updateFMaxPerEvent ;         ///< If true, maximum p.d.f value needs to be recalculated for each event
 
-  ClassDef(RooGenContext,0) // Universal context for generating toy MC data from any p.d.f
+  ClassDefOverride(RooGenContext,0) // Universal context for generating toy MC data from any p.d.f
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -37,18 +37,18 @@ public:
 
   RooGenFitStudy(const char* name=0, const char* title=0) ;
   RooGenFitStudy(const RooGenFitStudy& other) ;
-  virtual ~RooGenFitStudy() ;
-  virtual RooAbsStudy* clone(const char* newname="") const { return new RooGenFitStudy(newname?newname:GetName(),GetTitle()) ; }
+  ~RooGenFitStudy() override ;
+  RooAbsStudy* clone(const char* newname="") const override { return new RooGenFitStudy(newname?newname:GetName(),GetTitle()) ; }
 
   void setGenConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg()) ;
   void setFitConfig(const char* pdfName, const char* obsName, const RooCmdArg& arg1=RooCmdArg(),const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg()) ;
 
-  virtual Bool_t attach(RooWorkspace& w) ;
-  virtual Bool_t initialize() ;
-  virtual Bool_t execute() ;
-  virtual Bool_t finalize() ;
+  Bool_t attach(RooWorkspace& w) override ;
+  Bool_t initialize() override ;
+  Bool_t execute() override ;
+  Bool_t finalize() override ;
 
-  void Print(Option_t *options= 0) const;
+  void Print(Option_t *options= 0) const override;
 
  protected:
 
@@ -71,7 +71,7 @@ public:
   RooArgSet* _params ; ///<!
   RooArgSet* _initParams; ///<!
 
-  ClassDef(RooGenFitStudy,1) // Generate-and-Fit study module
+  ClassDefOverride(RooGenFitStudy,1) // Generate-and-Fit study module
 } ;
 
 

--- a/roofit/roofitcore/inc/RooGenFunction.h
+++ b/roofit/roofitcore/inc/RooGenFunction.h
@@ -25,15 +25,15 @@ public:
   RooGenFunction(const RooAbsReal& func, const RooArgList& observables, const RooArgList& parameters) ;
   RooGenFunction(const RooAbsReal& func, const RooArgList& observables, const RooArgList& parameters, const RooArgSet& nset) ;
   RooGenFunction(const RooGenFunction& other) ;
-  virtual ~RooGenFunction() ;
+  ~RooGenFunction() override ;
 
-  virtual ROOT::Math::IBaseFunctionOneDim* Clone() const {
+  ROOT::Math::IBaseFunctionOneDim* Clone() const override {
     return new RooGenFunction(*this) ;
   }
 
 protected:
 
-  double DoEval(double) const ;
+  double DoEval(double) const override ;
 
   RooFunctor _ftor ;
 

--- a/roofit/roofitcore/inc/RooGenProdProj.h
+++ b/roofit/roofitcore/inc/RooGenProdProj.h
@@ -31,17 +31,17 @@ public:
        const RooArgSet& _normSet, const char* isetRangeName, const char* normRangeName=0, Bool_t doFactorize=kTRUE) ;
 
   RooGenProdProj(const RooGenProdProj& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooGenProdProj(*this, newname); }
-  virtual ~RooGenProdProj() ;
+  TObject* clone(const char* newname) const override { return new RooGenProdProj(*this, newname); }
+  ~RooGenProdProj() override ;
 
 protected:
 
   RooAbsReal* makeIntegral(const char* name, const RooArgSet& compSet, const RooArgSet& intSet,
             RooArgSet& saveSet, const char* isetRangeName, Bool_t doFactorize) ;
 
-  virtual void operModeHook() ;
+  void operModeHook() override ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
   RooArgSet* _compSetOwnedN ; ///< Owner of numerator components
   RooArgSet* _compSetOwnedD ; ///< Owner of denominator components
   RooSetProxy _compSetN ; ///< Set proxy for numerator components
@@ -49,7 +49,7 @@ protected:
   RooListProxy _intList ; ///< Master integrals representing numerator and denominator
   Bool_t _haveD ;         ///< Do we have a denominator term?
 
-  ClassDef(RooGenProdProj,1) // General form of projected integral of product of PDFs, utility class for RooProdPdf
+  ClassDefOverride(RooGenProdProj,1) // General form of projected integral of product of PDFs, utility class for RooProdPdf
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -29,15 +29,15 @@ public:
   RooGenericPdf(const char *name, const char *title, const char* formula, const RooArgList& dependents);
   RooGenericPdf(const char *name, const char *title, const RooArgList& dependents);
   RooGenericPdf(const RooGenericPdf& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooGenericPdf(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooGenericPdf(*this,newname); }
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Printing interface (human readable)
-  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
-  void printMetaArgs(std::ostream& os) const ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
+  void printMetaArgs(std::ostream& os) const override ;
 
   // Debugging
   void dumpFormula() { formula().dump() ; }
@@ -51,21 +51,21 @@ protected:
 
   // Function evaluation
   RooListProxy _actualVars ;
-  virtual Double_t evaluate() const ;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& inputData, const RooArgSet* normSet) const;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
+  Double_t evaluate() const override ;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& inputData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
 
   Bool_t setFormula(const char* formula) ;
 
   // Post-processing of server redirection
-  virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
 
-  virtual Bool_t isValidReal(Double_t value, Bool_t printError) const ;
+  Bool_t isValidReal(Double_t value, Bool_t printError) const override ;
 
   std::unique_ptr<RooFormula> _formula{nullptr}; ///<! Formula engine
   TString _formExpr ;            ///< Formula expression string
 
-  ClassDef(RooGenericPdf,1) // Generic PDF defined by string expression and list of variables
+  ClassDefOverride(RooGenericPdf,1) // Generic PDF defined by string expression and list of variables
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooGrid.h
+++ b/roofit/roofitcore/inc/RooGrid.h
@@ -25,15 +25,15 @@ class RooGrid : public TObject, public RooPrintable {
 public:
   RooGrid() ;
   RooGrid(const RooAbsFunc &function);
-  virtual ~RooGrid();
+  ~RooGrid() override;
 
   // Printing interface
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
@@ -83,7 +83,7 @@ protected:
   Double_t *_xin;    ///<! Internal workspace
   Double_t *_weight; ///<! Internal workspace
 
-  ClassDef(RooGrid,1) // Utility class for RooMCIntegrator holding a multi-dimensional grid
+  ClassDefOverride(RooGrid,1) // Utility class for RooMCIntegrator holding a multi-dimensional grid
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooHist.h
+++ b/roofit/roofitcore/inc/RooHist.h
@@ -35,7 +35,7 @@ public:
   RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1=1.0, Double_t wgt2=1.0,
      RooAbsData::ErrorType etype=RooAbsData::Poisson, Double_t xErrorFrac=1.0) ;
   RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0, const RooArgSet *normVars = 0, const RooFitResult* fr = 0);
-  virtual ~RooHist();
+  ~RooHist() override;
 
   // add a datapoint for a bin with n entries, using a Poisson error
   void addBin(Axis_t binCenter, Double_t n, Double_t binWidth= 0, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0);
@@ -55,19 +55,19 @@ public:
   // add a datapoint for the efficiency (n1)/(n1+n2), using a sum-of-weights error
   void addEfficiencyBinWithError(Axis_t binCenter, Double_t n1, Double_t n2, Double_t en1, Double_t en2, Double_t binWidth= 0, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0);
 
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent= "") const;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent= "") const override;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     // Printing interface
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
-  Double_t getFitRangeNEvt() const;
-  Double_t getFitRangeNEvt(Double_t xlo, Double_t xhi) const ;
-  Double_t getFitRangeBinW() const;
+  Double_t getFitRangeNEvt() const override;
+  Double_t getFitRangeNEvt(Double_t xlo, Double_t xhi) const override ;
+  Double_t getFitRangeBinW() const override;
   inline Double_t getNominalBinWidth() const { return _nominalBinWidth; }
   inline void setRawEntries(Double_t n) { _rawEntries = n ; }
 
@@ -91,7 +91,7 @@ private:
   Double_t _entries ;         ///< Number of entries in histogram
   Double_t _rawEntries;       ///< Number of entries in source dataset
 
-  ClassDef(RooHist,1) // 1-dimensional histogram with error bars
+  ClassDefOverride(RooHist,1) // 1-dimensional histogram with error bars
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooHistError.h
+++ b/roofit/roofitcore/inc/RooHistError.h
@@ -56,7 +56,7 @@ private:
   class PoissonSum : public RooAbsFunc {
   public:
     inline PoissonSum(Int_t n) : RooAbsFunc(1), _n(n) { }
-    inline Double_t operator()(const Double_t xvec[]) const {
+    inline Double_t operator()(const Double_t xvec[]) const override {
       Double_t mu(xvec[0]),result(1),factorial(1);
       for(Int_t k= 1; k <= _n; k++) {
    factorial*= k;
@@ -64,8 +64,8 @@ private:
       }
       return exp(-mu)*result;
     };
-    inline Double_t getMinLimit(UInt_t /*index*/) const { return 0; }
-    inline Double_t getMaxLimit(UInt_t /*index*/) const { return RooNumber::infinity() ; }
+    inline Double_t getMinLimit(UInt_t /*index*/) const override { return 0; }
+    inline Double_t getMaxLimit(UInt_t /*index*/) const override { return RooNumber::infinity() ; }
   private:
     Int_t _n;
   };
@@ -82,7 +82,7 @@ private:
   public:
     BinomialSumAsym(Int_t n, Int_t m) : RooAbsFunc(1), _n1(n), _N1(n+m) {
     }
-    inline Double_t operator()(const Double_t xvec[]) const
+    inline Double_t operator()(const Double_t xvec[]) const override
       {
    Double_t p1(0.5*(1+xvec[0])),p2(1-p1),result(0),fact1(1),fact2(1);
    for(Int_t k= 0; k <= _n1; k++) {
@@ -92,8 +92,8 @@ private:
    return result;
       };
 
-    inline Double_t getMinLimit(UInt_t /*index*/) const { return -1; }
-    inline Double_t getMaxLimit(UInt_t /*index*/) const { return +1; }
+    inline Double_t getMinLimit(UInt_t /*index*/) const override { return -1; }
+    inline Double_t getMaxLimit(UInt_t /*index*/) const override { return +1; }
 
   private:
     Int_t _n1 ; ///< WVE Solaris CC5 doesn't want _n or _N here (likely compiler bug)
@@ -113,7 +113,7 @@ private:
   public:
     BinomialSumEff(Int_t n, Int_t m) : RooAbsFunc(1), _n1(n), _N1(n+m) {
     }
-    inline Double_t operator()(const Double_t xvec[]) const
+    inline Double_t operator()(const Double_t xvec[]) const override
       {
    Double_t p1(xvec[0]),p2(1-p1),result(0),fact1(1),fact2(1);
    for(Int_t k= 0; k <= _n1; k++) {
@@ -123,8 +123,8 @@ private:
    return result;
       };
 
-    inline Double_t getMinLimit(UInt_t /*index*/) const { return  0; }
-    inline Double_t getMaxLimit(UInt_t /*index*/) const { return +1; }
+    inline Double_t getMinLimit(UInt_t /*index*/) const override { return  0; }
+    inline Double_t getMaxLimit(UInt_t /*index*/) const override { return +1; }
 
   private:
     Int_t _n1 ; ///< WVE Solaris CC5 doesn't want _n or _N here (likely compiler bug)

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -33,8 +33,8 @@ public:
   RooHistFunc(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistFunc(const char *name, const char *title, const RooArgList& funcObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistFunc(const RooHistFunc& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooHistFunc(*this,newname); }
-  virtual ~RooHistFunc() ;
+  TObject* clone(const char* newname) const override { return new RooHistFunc(*this,newname); }
+  ~RooHistFunc() override ;
 
   /// Return RooDataHist that is represented.
   RooDataHist& dataHist()  {
@@ -62,8 +62,8 @@ public:
     return _intOrder ;
   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
   /// Set use of special boundary conditions for c.d.f.s
   void setCdfBoundaries(Bool_t flag) {
@@ -76,12 +76,12 @@ public:
     return _cdfBoundaries ;
   }
 
-  virtual Int_t getMaxVal(const RooArgSet& vars) const;
-  virtual Double_t maxVal(Int_t code) const;
+  Int_t getMaxVal(const RooArgSet& vars) const override;
+  Double_t maxVal(Int_t code) const override;
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ;
-  virtual Bool_t isBinnedDistribution(const RooArgSet&) const { return _intOrder==0 ; }
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet&) const override { return _intOrder==0 ; }
   RooArgSet const& getHistObsList() const { return _histObsList; }
 
 
@@ -90,14 +90,14 @@ public:
 
 protected:
 
-  Bool_t importWorkspaceHook(RooWorkspace& ws) ;
+  Bool_t importWorkspaceHook(RooWorkspace& ws) override ;
   Bool_t areIdentical(const RooDataHist& dh1, const RooDataHist& dh2) ;
 
-  Double_t evaluate() const;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const;
+  Double_t evaluate() const override;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const override;
   friend class RooAbsCachedReal ;
 
-  virtual void ioStreamerPass2() ;
+  void ioStreamerPass2() override ;
 
   RooArgSet         _histObsList ;   ///< List of observables defining dimensions of histogram
   RooSetProxy       _depList ;       ///< List of observables mapped onto histogram observables
@@ -108,7 +108,7 @@ protected:
   mutable Double_t  _totVolume ;     ///<! Total volume of space (product of ranges of observables)
   Bool_t            _unitNorm  ;     ///<! Assume contents is unit normalized (for use as pdf cache)
 
-  ClassDef(RooHistFunc,2) // Histogram based function
+  ClassDefOverride(RooHistFunc,2) // Histogram based function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -32,8 +32,8 @@ public:
   RooHistPdf(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistPdf(const RooHistPdf& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooHistPdf(*this,newname); }
-  virtual ~RooHistPdf() ;
+  TObject* clone(const char* newname) const override { return new RooHistPdf(*this,newname); }
+  ~RooHistPdf() override ;
 
   RooDataHist& dataHist()  {
     // Return RooDataHist that is represented
@@ -67,8 +67,8 @@ public:
                                      RooDataHist& dataHist,
                                      bool histFuncMode) ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
   void setCdfBoundaries(Bool_t flag) {
     // Set use of special boundary conditions for c.d.f.s
@@ -88,23 +88,23 @@ public:
     return _unitNorm ;
   }
 
-  virtual Bool_t selfNormalized() const { return _unitNorm ; }
+  Bool_t selfNormalized() const override { return _unitNorm ; }
 
-  virtual Int_t getMaxVal(const RooArgSet& vars) const ;
-  virtual Double_t maxVal(Int_t code) const ;
+  Int_t getMaxVal(const RooArgSet& vars) const override ;
+  Double_t maxVal(Int_t code) const override ;
 
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ;
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual Bool_t isBinnedDistribution(const RooArgSet&) const { return _intOrder==0 ; }
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet&) const override { return _intOrder==0 ; }
 
 
 protected:
 
   Bool_t areIdentical(const RooDataHist& dh1, const RooDataHist& dh2) ;
 
-  Bool_t importWorkspaceHook(RooWorkspace& ws) ;
+  Bool_t importWorkspaceHook(RooWorkspace& ws) override ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
   Double_t totalVolume() const ;
   friend class RooAbsCachedPdf ;
   Double_t totVolume() const ;
@@ -118,7 +118,7 @@ protected:
   mutable Double_t  _totVolume ;     ///<! Total volume of space (product of ranges of observables)
   Bool_t            _unitNorm  ;     ///< Assume contents is unit normalized (for use as pdf cache)
 
-  ClassDef(RooHistPdf,4) // Histogram based PDF
+  ClassDefOverride(RooHistPdf,4) // Histogram based PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooImproperIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooImproperIntegrator1D.h
@@ -29,19 +29,19 @@ public:
   RooImproperIntegrator1D(const RooAbsFunc& function);
   RooImproperIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config);
   RooImproperIntegrator1D(const RooAbsFunc& function, Double_t xmin, Double_t xmax, const RooNumIntConfig& config);
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooImproperIntegrator1D();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooImproperIntegrator1D() override;
 
-  virtual Bool_t checkLimits() const;
+  Bool_t checkLimits() const override;
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t* xmin, Double_t* xmax);
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) {_useIntegrandLimits = flag ; return kTRUE ; }
-  virtual Double_t integral(const Double_t* yvec=0) ;
+  Bool_t setLimits(Double_t* xmin, Double_t* xmax) override;
+  Bool_t setUseIntegrandLimits(Bool_t flag) override {_useIntegrandLimits = flag ; return kTRUE ; }
+  Double_t integral(const Double_t* yvec=0) override ;
 
-  virtual Bool_t canIntegrate1D() const { return kTRUE ; }
-  virtual Bool_t canIntegrate2D() const { return kFALSE ; }
-  virtual Bool_t canIntegrateND() const { return kFALSE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kTRUE ; }
+  Bool_t canIntegrate1D() const override { return kTRUE ; }
+  Bool_t canIntegrate2D() const override { return kFALSE ; }
+  Bool_t canIntegrateND() const override { return kFALSE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kTRUE ; }
 
 protected:
 
@@ -62,7 +62,7 @@ protected:
   RooNumIntConfig  _config ;    ///< Configuration object
   mutable RooIntegrator1D *_integrator1,*_integrator2,*_integrator3; ///< Piece integrators
 
-  ClassDef(RooImproperIntegrator1D,0) // 1-dimensional improper integration engine
+  ClassDefOverride(RooImproperIntegrator1D,0) // 1-dimensional improper integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooInt.h
+++ b/roofit/roofitcore/inc/RooInt.h
@@ -25,20 +25,20 @@ public:
   RooInt() : _value(0) {} ;
   RooInt(Int_t value) : TNamed(), _value(value) {} ;
   RooInt(const RooInt& other) : TNamed(other), _value(other._value) {}
-  virtual ~RooInt() {} ;
+  ~RooInt() override {} ;
 
   // Double_t cast operator
   inline operator Int_t() const { return _value ; }
   RooInt& operator=(Int_t value) { _value = value ; return *this ; }
 
   // Sorting interface ;
-  Int_t Compare(const TObject* other) const ;
-  virtual Bool_t IsSortable() const { return kTRUE ; }
+  Int_t Compare(const TObject* other) const override ;
+  Bool_t IsSortable() const override { return kTRUE ; }
 
 protected:
 
   Int_t _value ; ///< Payload
-  ClassDef(RooInt,1) // Container class for Int_t
+  ClassDefOverride(RooInt,1) // Container class for Int_t
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooIntegrator1D.h
@@ -35,20 +35,20 @@ public:
   RooIntegrator1D(const RooAbsFunc& function, Double_t xmin, Double_t xmax,
         const RooNumIntConfig& config) ;
 
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooIntegrator1D();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooIntegrator1D() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t *yvec=0) ;
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t *yvec=0) override ;
 
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t* xmin, Double_t* xmax);
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) {_useIntegrandLimits = flag ; return kTRUE ; }
+  Bool_t setLimits(Double_t* xmin, Double_t* xmax) override;
+  Bool_t setUseIntegrandLimits(Bool_t flag) override {_useIntegrandLimits = flag ; return kTRUE ; }
 
-  virtual Bool_t canIntegrate1D() const { return kTRUE ; }
-  virtual Bool_t canIntegrate2D() const { return kFALSE ; }
-  virtual Bool_t canIntegrateND() const { return kFALSE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kTRUE ; }
+  Bool_t canIntegrate2D() const override { return kFALSE ; }
+  Bool_t canIntegrateND() const override { return kFALSE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
 protected:
 
@@ -90,7 +90,7 @@ protected:
 
   Double_t *_x ; //! do not persist
 
-  ClassDef(RooIntegrator1D,0) // 1-dimensional numerical integration engine
+  ClassDefOverride(RooIntegrator1D,0) // 1-dimensional numerical integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooIntegrator2D.h
+++ b/roofit/roofitcore/inc/RooIntegrator2D.h
@@ -33,15 +33,15 @@ public:
   RooIntegrator2D(const RooAbsFunc& function, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax,
         const RooNumIntConfig& config) ;
 
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooIntegrator2D() ;
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooIntegrator2D() override ;
 
-  virtual Bool_t checkLimits() const;
+  Bool_t checkLimits() const override;
 
-  virtual Bool_t canIntegrate1D() const { return kFALSE ; }
-  virtual Bool_t canIntegrate2D() const { return kTRUE ; }
-  virtual Bool_t canIntegrateND() const { return kFALSE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kFALSE ; }
+  Bool_t canIntegrate2D() const override { return kTRUE ; }
+  Bool_t canIntegrateND() const override { return kFALSE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
 protected:
 
@@ -51,7 +51,7 @@ protected:
   RooIntegrator1D* _xIntegrator ; ///< Integrator in first dimension
   RooAbsFunc* _xint ; ///< Function binding representing integral over first dimension
 
-  ClassDef(RooIntegrator2D,0) // 2-dimensional numerical integration engine
+  ClassDefOverride(RooIntegrator2D,0) // 2-dimensional numerical integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooIntegratorBinding.h
+++ b/roofit/roofitcore/inc/RooIntegratorBinding.h
@@ -23,17 +23,17 @@ class RooIntegratorBinding : public RooAbsFunc {
 public:
   RooIntegratorBinding(RooAbsIntegrator& integrator) :
     RooAbsFunc(integrator.integrand()->getDimension()-1), _integrator(&integrator) {} ;
-  virtual ~RooIntegratorBinding() {} ;
+  ~RooIntegratorBinding() override {} ;
 
-  inline virtual Double_t operator()(const Double_t xvector[]) const { _ncall++ ; return _integrator->integral(xvector) ; }
-  inline virtual Double_t getMinLimit(UInt_t index) const { return _integrator->integrand()->getMinLimit(index+1); }
-  inline virtual Double_t getMaxLimit(UInt_t index) const { return _integrator->integrand()->getMaxLimit(index+1); }
+  inline Double_t operator()(const Double_t xvector[]) const override { _ncall++ ; return _integrator->integral(xvector) ; }
+  inline Double_t getMinLimit(UInt_t index) const override { return _integrator->integrand()->getMinLimit(index+1); }
+  inline Double_t getMaxLimit(UInt_t index) const override { return _integrator->integrand()->getMaxLimit(index+1); }
 
 protected:
   RooAbsIntegrator* _integrator ;  ///< Numeric integrator
 
 
-  ClassDef(RooIntegratorBinding,0) // Function binding representing output of numeric integrator
+  ClassDefOverride(RooIntegratorBinding,0) // Function binding representing output of numeric integrator
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooInvTransform.h
+++ b/roofit/roofitcore/inc/RooInvTransform.h
@@ -21,19 +21,19 @@
 class RooInvTransform : public RooAbsFunc {
 public:
   RooInvTransform(const RooAbsFunc &func);
-  inline virtual ~RooInvTransform() { }
+  inline ~RooInvTransform() override { }
 
-  inline virtual Double_t operator()(const Double_t xvector[]) const {
+  inline Double_t operator()(const Double_t xvector[]) const override {
     Double_t xinv= 1./xvector[0];
     return (*_func)(&xinv)*xinv*xinv;
   }
-  inline virtual Double_t getMinLimit(UInt_t index) const { return 1/_func->getMaxLimit(index); }
-  inline virtual Double_t getMaxLimit(UInt_t index) const { return 1/_func->getMinLimit(index); }
+  inline Double_t getMinLimit(UInt_t index) const override { return 1/_func->getMaxLimit(index); }
+  inline Double_t getMaxLimit(UInt_t index) const override { return 1/_func->getMinLimit(index); }
 
 protected:
   const RooAbsFunc *_func; ///< Input function binding
 
-  ClassDef(RooInvTransform,0) // Function binding returning inverse of other function binding
+  ClassDefOverride(RooInvTransform,0) // Function binding returning inverse of other function binding
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooLinTransBinning.h
+++ b/roofit/roofitcore/inc/RooLinTransBinning.h
@@ -25,25 +25,25 @@ public:
   RooLinTransBinning(const char* name=0) : RooAbsBinning(name) { }
   RooLinTransBinning(const RooAbsBinning& input, Double_t slope=1.0, Double_t offset=0.0, const char* name=0);
   RooLinTransBinning(const RooLinTransBinning&, const char* name=0);
-  virtual RooAbsBinning* clone(const char* name=0) const { return new RooLinTransBinning(*this,name) ; }
-  virtual ~RooLinTransBinning() ;
+  RooAbsBinning* clone(const char* name=0) const override { return new RooLinTransBinning(*this,name) ; }
+  ~RooLinTransBinning() override ;
 
-  virtual Int_t numBoundaries() const { return _input->numBoundaries() ; }
-  virtual Int_t binNumber(Double_t x) const { return _input->binNumber(invTrans(x)) ; }
-  virtual Double_t binCenter(Int_t bin) const { return trans(_input->binCenter(binTrans(bin))) ; }
-  virtual Double_t binWidth(Int_t bin) const { return _slope*_input->binWidth(binTrans(bin)) ; }
-  virtual Double_t binLow(Int_t bin) const { if (_slope>0) return trans(_input->binLow(binTrans(bin))) ; else return trans(_input->binHigh(binTrans(bin))) ; }
-  virtual Double_t binHigh(Int_t bin) const { if (_slope>0) return trans(_input->binHigh(binTrans(bin))) ; else return trans(_input->binLow(binTrans(bin))) ; }
+  Int_t numBoundaries() const override { return _input->numBoundaries() ; }
+  Int_t binNumber(Double_t x) const override { return _input->binNumber(invTrans(x)) ; }
+  Double_t binCenter(Int_t bin) const override { return trans(_input->binCenter(binTrans(bin))) ; }
+  Double_t binWidth(Int_t bin) const override { return _slope*_input->binWidth(binTrans(bin)) ; }
+  Double_t binLow(Int_t bin) const override { if (_slope>0) return trans(_input->binLow(binTrans(bin))) ; else return trans(_input->binHigh(binTrans(bin))) ; }
+  Double_t binHigh(Int_t bin) const override { if (_slope>0) return trans(_input->binHigh(binTrans(bin))) ; else return trans(_input->binLow(binTrans(bin))) ; }
 
-  virtual void setRange(Double_t xlo, Double_t xhi) ;
-  virtual void setMin(Double_t xlo) { setRange(xlo,highBound()) ; }
-  virtual void setMax(Double_t xhi) { setRange(lowBound(),xhi) ; }
+  void setRange(Double_t xlo, Double_t xhi) override ;
+  void setMin(Double_t xlo) override { setRange(xlo,highBound()) ; }
+  void setMax(Double_t xhi) override { setRange(lowBound(),xhi) ; }
 
-  virtual Double_t lowBound() const { if (_slope>0) return trans(_input->lowBound()) ; else return trans(_input->highBound()) ; }
-  virtual Double_t highBound() const { if (_slope>0) return trans(_input->highBound()) ; else return trans(_input->lowBound()) ; }
-  virtual Double_t averageBinWidth() const { return _slope*_input->averageBinWidth() ; }
+  Double_t lowBound() const override { if (_slope>0) return trans(_input->lowBound()) ; else return trans(_input->highBound()) ; }
+  Double_t highBound() const override { if (_slope>0) return trans(_input->highBound()) ; else return trans(_input->lowBound()) ; }
+  Double_t averageBinWidth() const override { return _slope*_input->averageBinWidth() ; }
 
-  virtual Double_t* array() const ;
+  Double_t* array() const override ;
 
   void updateInput(const RooAbsBinning& input, Double_t slope=1.0, Double_t offset=0.0) ;
 
@@ -58,7 +58,7 @@ protected:
   RooAbsBinning* _input{nullptr};    ///< Input binning
   mutable Double_t *_array{nullptr}; ///<! Array of transformed bin boundaries
 
-  ClassDef(RooLinTransBinning,1) // Linear transformation of binning specification
+  ClassDefOverride(RooLinTransBinning,1) // Linear transformation of binning specification
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooLinearCombination.h
+++ b/roofit/roofitcore/inc/RooLinearCombination.h
@@ -36,17 +36,17 @@ public:
   RooLinearCombination();
   RooLinearCombination(const char *name);
   RooLinearCombination(const RooLinearCombination &other, const char *name);
-  virtual void printArgs(std::ostream &os) const override;
-  ~RooLinearCombination();
-  virtual TObject *clone(const char *newname) const override;
+  void printArgs(std::ostream &os) const override;
+  ~RooLinearCombination() override;
+  TObject *clone(const char *newname) const override;
   void add(RooFit::SuperFloat c, RooAbsReal *t);
   void setCoefficient(size_t idx, RooFit::SuperFloat c);
   RooFit::SuperFloat getCoefficient(size_t idx);
-  virtual Double_t evaluate() const override;
-  virtual std::list<Double_t> *binBoundaries(RooAbsRealLValue &obs,
+  Double_t evaluate() const override;
+  std::list<Double_t> *binBoundaries(RooAbsRealLValue &obs,
                                              Double_t xlo,
                                              Double_t xhi) const override;
-  virtual std::list<Double_t> *plotSamplingHint(RooAbsRealLValue &obs,
+  std::list<Double_t> *plotSamplingHint(RooAbsRealLValue &obs,
                                                 Double_t xlo,
                                                 Double_t xhi) const override;
 

--- a/roofit/roofitcore/inc/RooLinearVar.h
+++ b/roofit/roofitcore/inc/RooLinearVar.h
@@ -33,24 +33,24 @@ public:
   RooLinearVar() {} ;
   RooLinearVar(const char *name, const char *title, RooAbsRealLValue& variable, const RooAbsReal& slope, const RooAbsReal& offset, const char *unit= "") ;
   RooLinearVar(const RooLinearVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooLinearVar(*this,newname); }
-  virtual ~RooLinearVar() ;
+  TObject* clone(const char* newname) const override { return new RooLinearVar(*this,newname); }
+  ~RooLinearVar() override ;
 
   // Parameter value and error accessors
-  virtual void setVal(Double_t value) ;
+  void setVal(Double_t value) override ;
 
   // Jacobian and limits
-  virtual Bool_t hasBinning(const char* name) const ;
-  virtual const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const ;
-  virtual RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE)  ;
-  virtual std::list<std::string> getBinningNames() const;
+  Bool_t hasBinning(const char* name) const override ;
+  const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const override ;
+  RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) override  ;
+  std::list<std::string> getBinningNames() const override;
 
-  virtual Double_t jacobian() const ;
-  virtual Bool_t isJacobianOK(const RooArgSet& depList) const ;
+  Double_t jacobian() const override ;
+  Bool_t isJacobianOK(const RooArgSet& depList) const override ;
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // Printing interface (human readable)
 
@@ -59,7 +59,7 @@ public:
 
 protected:
 
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   mutable RooLinTransBinning _binning ;
   RooLinkedList _altBinning ; ///<!
@@ -67,7 +67,7 @@ protected:
   RooRealProxy _slope ;       ///< Slope of transformation
   RooRealProxy _offset ;      ///< Offset of transformation
 
-  ClassDef(RooLinearVar,1) // Lvalue linear transformation function
+  ClassDefOverride(RooLinearVar,1) // Lvalue linear transformation function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooLinkedList.h
+++ b/roofit/roofitcore/inc/RooLinkedList.h
@@ -43,7 +43,7 @@ public:
   // Copy constructor
   RooLinkedList(const RooLinkedList& other) ;
 
-  virtual TObject* Clone(const char* =0) const {
+  TObject* Clone(const char* =0) const override {
     return new RooLinkedList(*this) ;
   }
 
@@ -58,7 +58,7 @@ public:
   void setHashTableSize(Int_t size) ;
 
   // Destructor
-  virtual ~RooLinkedList() ;
+  ~RooLinkedList() override ;
 
   Int_t GetSize() const { return _size ; }
   std::size_t size() const { return _size ; }
@@ -76,32 +76,32 @@ public:
   RooLinkedListIterImpl rbegin() const;
   RooLinkedListIterImpl rend() const;
 
-  void Clear(Option_t *o=0) ;
-  void Delete(Option_t *o=0) ;
+  void Clear(Option_t *o=0) override ;
+  void Delete(Option_t *o=0) override ;
   TObject* find(const char* name) const ;
   RooAbsArg* findArg(const RooAbsArg*) const ;
-  TObject* FindObject(const char* name) const ;
-  TObject* FindObject(const TObject* obj) const ;
+  TObject* FindObject(const char* name) const override ;
+  TObject* FindObject(const TObject* obj) const override ;
   Int_t IndexOf(const char* name) const ;
   Int_t IndexOf(const TObject* arg) const ;
   TObject* First() const {
     return _first?_first->_arg:0 ;
   }
 
-  virtual void RecursiveRemove(TObject *obj);
+  void RecursiveRemove(TObject *obj) override;
 
-  void Print(const char* opt) const ;
+  void Print(const char* opt) const override ;
   void Sort(Bool_t ascend=kTRUE) ;
 
   // const char* GetName() const { return "" ; /*_name.Data() ; */ }
   // void SetName(const char* /*name*/) { /*_name = name ; */ }
-  const char* GetName() const { return _name.Data() ;  }
+  const char* GetName() const override { return _name.Data() ;  }
   void SetName(const char* name) { _name = name ;  }
 
    void useNptr(Bool_t flag) { _useNptr = flag ; }
    // needed for using it in THashList/THashTable
 
-   ULong_t  Hash() const { return _name.Hash(); }
+   ULong_t  Hash() const override { return _name.Hash(); }
 
 protected:
 
@@ -140,7 +140,7 @@ private:
 
   std::vector<RooLinkedListElem *> _at; ///<! index list for quick index through ::At
 
-  ClassDef(RooLinkedList,3) // Doubly linked list for storage of RooAbsArg objects
+  ClassDefOverride(RooLinkedList,3) // Doubly linked list for storage of RooAbsArg objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooLinkedListIter.h
+++ b/roofit/roofitcore/inc/RooLinkedListIter.h
@@ -248,7 +248,7 @@ public:
   RooLinkedListIterImpl(const RooLinkedList* list, bool forward) :
     RooLinkedListIterImpl(list, forward ? list->_first : list->_last, forward) {}
 
-  TIterator& operator=(const TIterator& other) {
+  TIterator& operator=(const TIterator& other) override {
 
     // Iterator assignment operator
 
@@ -262,12 +262,12 @@ public:
     return *this ;
   }
 
-  virtual const TCollection *GetCollection() const {
+  const TCollection *GetCollection() const override {
     // Dummy
     return 0 ;
   }
 
-  virtual TObject *Next() {
+  TObject *Next() override {
     // Return next element in collection
     return NextNV();
   }
@@ -280,12 +280,12 @@ public:
     return arg ;
   }
 
-  virtual void Reset() {
+  void Reset() override {
     // Return iterator to first element in collection
     _ptr = _forward ? _list->_first : _list->_last ;
   }
 
-  bool operator!=(const TIterator &aIter) const {
+  bool operator!=(const TIterator &aIter) const override {
     const RooLinkedListIterImpl *iter(dynamic_cast<const RooLinkedListIterImpl*>(&aIter));
     if (iter) return (_ptr != iter->_ptr);
     return false; // for base class we don't implement a comparison
@@ -295,7 +295,7 @@ public:
     return _ptr != aIter._ptr;
   }
 
-  virtual TObject *operator*() const {
+  TObject *operator*() const override {
     // Return element iterator points to
     return _ptr ? _ptr->_arg : nullptr;
   }

--- a/roofit/roofitcore/inc/RooList.h
+++ b/roofit/roofitcore/inc/RooList.h
@@ -21,12 +21,12 @@
 class RooList : public TList {
 public:
   inline RooList() : TList() { }
-  virtual ~RooList() {} ;
+  ~RooList() override {} ;
   TObjOptLink *findLink(const char *name, const char *caller= 0) const;
   Bool_t moveBefore(const char *before, const char *target, const char *caller= 0);
   Bool_t moveAfter(const char *after, const char *target, const char *caller= 0);
 protected:  
-  ClassDef(RooList,1) // TList with extra support for Option_t associations
+  ClassDefOverride(RooList,1) // TList with extra support for Option_t associations
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooListProxy.h
+++ b/roofit/roofitcore/inc/RooListProxy.h
@@ -29,24 +29,24 @@ public:
   RooListProxy(const char* name, const char* desc, RooAbsArg* owner,
 	      Bool_t defValueServer=kTRUE, Bool_t defShapeServer=kFALSE) ;
   RooListProxy(const char* name, RooAbsArg* owner, const RooListProxy& other) ;
-  virtual ~RooListProxy() ;
+  ~RooListProxy() override ;
 
-  virtual const char* name() const override { return GetName() ; }
+  const char* name() const override { return GetName() ; }
 
   // List content management (modified for server hooks)
   using RooAbsCollection::add;
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
+  Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
   virtual Bool_t add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent) ;
 
   using RooAbsCollection::addOwned;
-  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
-  virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) override;
-  virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) override;
-  virtual void removeAll() override;
+  Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
+  Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) override;
+  Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) override;
+  void removeAll() override;
 
   RooListProxy& operator=(const RooArgList& other) ;
 
-  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const override;
+  void print(std::ostream& os, Bool_t addContents=kFALSE) const override;
 
 protected:
 
@@ -54,7 +54,7 @@ protected:
   Bool_t _defValueServer ;  ///< Propagate value dirty flags?
   Bool_t _defShapeServer ;  ///< Propagate shape dirty flags?
 
-  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
+  Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
 
   ClassDefOverride(RooListProxy,1) // Proxy class for a RooArgList
 };

--- a/roofit/roofitcore/inc/RooMCIntegrator.h
+++ b/roofit/roofitcore/inc/RooMCIntegrator.h
@@ -31,11 +31,11 @@ public:
   RooMCIntegrator(const RooAbsFunc& function, SamplingMode mode= Importance,
         GeneratorType genType= QuasiRandom, Bool_t verbose= kFALSE);
   RooMCIntegrator(const RooAbsFunc& function, const RooNumIntConfig& config);
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooMCIntegrator();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooMCIntegrator() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t* yvec=0);
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t* yvec=0) override;
 
   enum Stage { AllStages, ReuseGrid, RefineGrid };
   Double_t vegas(Stage stage, UInt_t calls, UInt_t iterations, Double_t *absError= 0);
@@ -48,10 +48,10 @@ public:
 
   const RooGrid &grid() const { return _grid; }
 
-  virtual Bool_t canIntegrate1D() const { return kTRUE ; }
-  virtual Bool_t canIntegrate2D() const { return kTRUE ; }
-  virtual Bool_t canIntegrateND() const { return kTRUE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kTRUE ; }
+  Bool_t canIntegrate2D() const override { return kTRUE ; }
+  Bool_t canIntegrateND() const override { return kTRUE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
 protected:
 
@@ -74,7 +74,7 @@ protected:
   Double_t _jac,_wtd_int_sum,_sum_wgts,_chi_sum,_chisq,_result,_sigma; ///< Scratch variables preserved between calls to vegas1/2/2
   UInt_t _it_start,_it_num,_samples,_calls_per_box;                    ///< Scratch variables preserved between calls to vegas1/2/2
 
-  ClassDef(RooMCIntegrator,0) // VEGAS based multi-dimensional numerical integration engine
+  ClassDefOverride(RooMCIntegrator,0) // VEGAS based multi-dimensional numerical integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -41,7 +41,7 @@ public:
         const RooArgSet& dependents, const char* genOptions="",
         const char* fitOptions="", const RooDataSet* genProtoData=0,
         const RooArgSet& projDeps=RooArgSet()) ;
-  virtual ~RooMCStudy() ;
+  ~RooMCStudy() override ;
 
   // Method to add study modules
   void addModule(RooAbsMCStudyModule& module) ;
@@ -148,13 +148,13 @@ protected:
   // Utilities for modules ;
   RooFitResult* refit(RooAbsData* genSample=0) ;
   void resetFitParams() ;
-  virtual void RecursiveRemove(TObject *obj);
+  void RecursiveRemove(TObject *obj) override;
 
 private:
 
   RooMCStudy(const RooMCStudy&) ;
 
-  ClassDef(RooMCStudy,0) // A general purpose toy Monte Carlo study manager
+  ClassDefOverride(RooMCStudy,0) // A general purpose toy Monte Carlo study manager
 } ;
 
 

--- a/roofit/roofitcore/inc/RooMappedCategory.h
+++ b/roofit/roofitcore/inc/RooMappedCategory.h
@@ -32,19 +32,19 @@ public:
   inline RooMappedCategory() : _defCat(0), _mapcache(0) { }
   RooMappedCategory(const char *name, const char *title, RooAbsCategory& inputCat, const char* defCatName="NotMapped", Int_t defCatIdx=NoCatIdx);
   RooMappedCategory(const RooMappedCategory& other, const char *name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooMappedCategory(*this,newname); }
-  virtual ~RooMappedCategory();
+  TObject* clone(const char* newname) const override { return new RooMappedCategory(*this,newname); }
+  ~RooMappedCategory() override;
 
   // Mapping function
   Bool_t map(const char* inKeyRegExp, const char* outKeyName, Int_t outKeyNum=NoCatIdx) ;
 
   // Printing interface (human readable)
-  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
-  void printMetaArgs(std::ostream& os) const ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
+  void printMetaArgs(std::ostream& os) const override ;
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
 
   class Entry {
@@ -77,15 +77,15 @@ protected:
   std::map<std::string,RooMappedCategory::Entry> _mapArray ;  ///< List of mapping rules
   mutable RooMappedCategoryCache* _mapcache; ///<! transient member: cache the mapping
 
-  virtual value_type evaluate() const ;
+  value_type evaluate() const override ;
   const RooMappedCategoryCache* getOrCreateCache() const;
 
   /// When the input category changes states, the cached state mappings are invalidated
-  void recomputeShape();
+  void recomputeShape() override;
 
   friend class RooMappedCategoryCache;
 
-  ClassDef(RooMappedCategory, 2) // Index variable, derived from another index using pattern-matching based mapping
+  ClassDefOverride(RooMappedCategory, 2) // Index variable, derived from another index using pattern-matching based mapping
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooMinimizerFcn.h
+++ b/roofit/roofitcore/inc/RooMinimizerFcn.h
@@ -38,7 +38,7 @@ class RooMinimizerFcn : public RooAbsMinimizerFcn, public ROOT::Math::IBaseFunct
 public:
    RooMinimizerFcn(RooAbsReal *funct, RooMinimizer *context, bool verbose = false);
    RooMinimizerFcn(const RooMinimizerFcn &other);
-   virtual ~RooMinimizerFcn();
+   ~RooMinimizerFcn() override;
 
    ROOT::Math::IBaseFunctionMultiDim *Clone() const override;
    unsigned int NDim() const override { return getNDim(); }

--- a/roofit/roofitcore/inc/RooMoment.h
+++ b/roofit/roofitcore/inc/RooMoment.h
@@ -31,10 +31,10 @@ public:
   RooMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, Int_t order=1, Bool_t central=kFALSE, Bool_t takeRoot=kFALSE) ;
   RooMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, Int_t order=1, Bool_t central=kFALSE, Bool_t takeRoot=kFALSE,
 	    Bool_t intNSet=kFALSE) ;
-  virtual ~RooMoment() ;
+  ~RooMoment() override ;
 
   RooMoment(const RooMoment& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooMoment(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooMoment(*this, newname); }
 
   const RooAbsReal& xF() { return _xf.arg() ; }
   const RooAbsReal& ixF() { return _ixf.arg() ; }
@@ -45,9 +45,9 @@ protected:
   RooRealProxy _xf ;                     ///< X*F
   RooRealProxy _ixf ;                    ///< Int(X*F(X))dx ;
   RooRealProxy _if ;                     ///< Int(F(x))dx ;
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooMoment,1) // Representation of moment in a RooAbsReal in a given RooRealVar
+  ClassDefOverride(RooMoment,1) // Representation of moment in a RooAbsReal in a given RooRealVar
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooMsgService.h
+++ b/roofit/roofitcore/inc/RooMsgService.h
@@ -106,7 +106,7 @@ class RooWorkspace ;
 class RooMsgService : public TObject {
 public:
 
-  virtual ~RooMsgService() ;
+  ~RooMsgService() override ;
 
   struct StreamConfig {
     public:
@@ -160,7 +160,7 @@ public:
   void setGlobalKillBelow(RooFit::MsgLevel level) { _globMinLevel = level ; }
   RooFit::MsgLevel globalKillBelow() const { return _globMinLevel ; }
 
-  void Print(Option_t *options= 0) const ;
+  void Print(Option_t *options= 0) const override ;
   void showPid(Bool_t flag) { _showPid = flag ; }
 
   // Back end -- Send message or check if particular logging configuration is active
@@ -213,7 +213,7 @@ protected:
 
   Int_t _debugCode ;
   
-  ClassDef(RooMsgService,0) // RooFit Message Service Singleton class
+  ClassDefOverride(RooMsgService,0) // RooFit Message Service Singleton class
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooMultiCategory.h
+++ b/roofit/roofitcore/inc/RooMultiCategory.h
@@ -31,15 +31,15 @@ public:
   inline RooMultiCategory() { setShapeDirty(); }
   RooMultiCategory(const char *name, const char *title, const RooArgSet& inputCatList);
   RooMultiCategory(const RooMultiCategory& other, const char *name=0) ;
-  virtual TObject* clone(const char* newname) const override { return new RooMultiCategory(*this,newname); }
-  virtual ~RooMultiCategory();
+  TObject* clone(const char* newname) const override { return new RooMultiCategory(*this,newname); }
+  ~RooMultiCategory() override;
 
   // Printing interface (human readable)
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override;
 
   /// Multi categories cannot be read from streams.
-  virtual Bool_t readFromStream(std::istream& /*is*/, Bool_t /*compact*/, Bool_t /*verbose=kFALSE*/) override { return true; }
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const override;
+  Bool_t readFromStream(std::istream& /*is*/, Bool_t /*compact*/, Bool_t /*verbose=kFALSE*/) override { return true; }
+  void writeToStream(std::ostream& os, Bool_t compact) const override;
 
   const RooArgSet& inputCatList() const { return _catSet ; }
   const char* getCurrentLabel() const override;

--- a/roofit/roofitcore/inc/RooMultiGenFunction.h
+++ b/roofit/roofitcore/inc/RooMultiGenFunction.h
@@ -31,17 +31,17 @@ public:
   RooMultiGenFunction(const RooAbsReal& func, const RooArgList& observables, const RooArgList& parameters) ;
   RooMultiGenFunction(const RooAbsReal& func, const RooArgList& observables, const RooArgList& parameters, const RooArgSet& nset) ;
   RooMultiGenFunction(const RooMultiGenFunction& other) ;
-  virtual ~RooMultiGenFunction() ;
+  ~RooMultiGenFunction() override ;
 
-  virtual ROOT::Math::IBaseFunctionMultiDim* Clone() const {
+  ROOT::Math::IBaseFunctionMultiDim* Clone() const override {
     return new RooMultiGenFunction(*this) ;
   }
 
-  unsigned int NDim() const { return _ftor.nObs() ; }
+  unsigned int NDim() const override { return _ftor.nObs() ; }
 
 protected:
 
-  double DoEval(const double*) const ;
+  double DoEval(const double*) const override ;
 
   RooFunctor _ftor ;
 

--- a/roofit/roofitcore/inc/RooMultiVarGaussian.h
+++ b/roofit/roofitcore/inc/RooMultiVarGaussian.h
@@ -39,15 +39,15 @@ public:
   void setAnaIntZ(Double_t z) { _z = z ; }
 
   RooMultiVarGaussian(const RooMultiVarGaussian& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooMultiVarGaussian(*this,newname); }
-  inline virtual ~RooMultiVarGaussian() { }
+  TObject* clone(const char* newname) const override { return new RooMultiVarGaussian(*this,newname); }
+  inline ~RooMultiVarGaussian() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void initGenerator(Int_t code) ;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void initGenerator(Int_t code) override ;
+  void generateEvent(Int_t code) override;
 
   const TMatrixDSym& covarianceMatrix() const { return _cov ; }
 
@@ -106,11 +106,11 @@ protected:
   void syncMuVec() const ;
   mutable TVectorD _muVec ; //! Do not persist
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooMultiVarGaussian,1) // Multivariate Gaussian PDF with correlations
+  ClassDefOverride(RooMultiVarGaussian,1) // Multivariate Gaussian PDF with correlations
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -46,16 +46,16 @@ public:
             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{});
 
   RooNLLVar(const RooNLLVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooNLLVar(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooNLLVar(*this,newname); }
 
-  virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg);
+  RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
+                                      const RooArgSet& projDeps, RooAbsTestStatistic::Configuration const& cfg) override;
 
-  virtual ~RooNLLVar();
+  ~RooNLLVar() override;
 
   void applyWeightSquared(Bool_t flag) ;
 
-  virtual Double_t defaultErrorLevel() const { return 0.5 ; }
+  Double_t defaultErrorLevel() const override { return 0.5 ; }
 
   void batchMode(bool on = true) {
     _batchEvaluations = on;
@@ -73,8 +73,8 @@ public:
 
 protected:
 
-  virtual Bool_t processEmptyDataSets() const { return _extended ; }
-  virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const;
+  Bool_t processEmptyDataSets() const override { return _extended ; }
+  Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override;
 
   static RooArgSet _emptySet ; // Supports named argument constructor
 
@@ -92,7 +92,7 @@ private:
   mutable RooRealSumPdf* _binnedPdf{nullptr}; ///<!
   mutable std::unique_ptr<RooBatchCompute::RunContext> _evalData; ///<! Struct to store function evaluation workspaces.
 
-  ClassDef(RooNLLVar,3) // Function representing (extended) -log(L) of p.d.f and dataset
+  ClassDefOverride(RooNLLVar,3) // Function representing (extended) -log(L) of p.d.f and dataset
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNameReg.h
+++ b/roofit/roofitcore/inc/RooNameReg.h
@@ -26,7 +26,7 @@ class RooNameReg : public TNamed {
 public:
 
   static RooNameReg& instance() ;
-  virtual ~RooNameReg();
+  ~RooNameReg() override;
   const TNamed* constPtr(const char* stringPtr) ;
   const char* constStr(const TNamed* namePtr) ;
   static const TNamed* ptr(const char* stringPtr) ;
@@ -50,7 +50,7 @@ protected:
   std::unordered_map<std::string,std::unique_ptr<TNamed>> _map;
   std::size_t _renameCounter = 0;
 
-//  ClassDef(RooNameReg,1) // String name registry
+//  ClassDefOverride(RooNameReg,1) // String name registry
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumCdf.h
+++ b/roofit/roofitcore/inc/RooNumCdf.h
@@ -18,16 +18,16 @@ class RooNumCdf : public RooNumRunningInt {
 public:
   RooNumCdf(const char *name, const char *title, RooAbsPdf& _pdf, RooRealVar& _x, const char* binningName="cache");
   RooNumCdf(const RooNumCdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooNumCdf(*this,newname); }
-  virtual ~RooNumCdf() ;
+  TObject* clone(const char* newname) const override { return new RooNumCdf(*this,newname); }
+  ~RooNumCdf() override ;
 
 protected:
 
-  virtual void fillCacheObject(FuncCacheElem& cacheFunc) const ;
+  void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
 
 private:
 
-  ClassDef(RooNumCdf,1) // Numeric calculator for CDF for a given PDF
+  ClassDefOverride(RooNumCdf,1) // Numeric calculator for CDF for a given PDF
 
 };
  

--- a/roofit/roofitcore/inc/RooNumConvPdf.h
+++ b/roofit/roofitcore/inc/RooNumConvPdf.h
@@ -33,10 +33,10 @@ public:
 
   RooNumConvPdf(const RooNumConvPdf& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooNumConvPdf(*this,newname) ; }
-  virtual ~RooNumConvPdf() ;
+  TObject* clone(const char* newname) const override { return new RooNumConvPdf(*this,newname) ; }
+  ~RooNumConvPdf() override ;
 
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   // Calls forwarded to RooNumConvolution
   inline RooNumIntConfig& convIntConfig() { return conv().convIntConfig() ; }
@@ -53,7 +53,7 @@ public:
   RooAbsReal&  pdf() const { return const_cast<RooAbsReal&>(_origPdf.arg()) ; }
   RooAbsReal&  model() const { return const_cast<RooAbsReal&>(_origModel.arg()) ; }
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
 protected:
 
@@ -70,12 +70,12 @@ protected:
   RooRealProxy _origPdf ;         ///< Original input PDF
   RooRealProxy _origModel ;       ///< Original resolution model
 
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
+                                       const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const override ;
 
   friend class RooConvGenContext ;
 
-  ClassDef(RooNumConvPdf,1)     // Operator PDF implementing numeric convolution of 2 input PDFs
+  ClassDefOverride(RooNumConvPdf,1)     // Operator PDF implementing numeric convolution of 2 input PDFs
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumConvolution.h
+++ b/roofit/roofitcore/inc/RooNumConvolution.h
@@ -36,10 +36,10 @@ public:
 
   RooNumConvolution(const RooNumConvolution& other, const char* name=0) ;
 
-  virtual TObject* clone(const char* newname) const { return new RooNumConvolution(*this,newname) ; }
-  virtual ~RooNumConvolution() ;
+  TObject* clone(const char* newname) const override { return new RooNumConvolution(*this,newname) ; }
+  ~RooNumConvolution() override ;
 
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
   RooNumIntConfig& convIntConfig() { _init = kFALSE ; return _convIntConfig ; }
   const RooNumIntConfig& convIntConfig() const { _init = kFALSE ; return _convIntConfig ; }
@@ -62,9 +62,9 @@ protected:
 
   mutable Bool_t _init ;
   void initialize() const ;
-  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
 
-  virtual void printCompactTreeHook(std::ostream& os, const char* indent="") ;
+  void printCompactTreeHook(std::ostream& os, const char* indent="") override ;
 
   RooNumIntConfig _convIntConfig ; ///< Configuration of numeric convolution integral ;
   mutable RooConvIntegrandBinding* _integrand ; ///<! Binding of Convolution Integrand function
@@ -94,7 +94,7 @@ protected:
   Bool_t       _doProf   ;        ///< Switch to activate profiling option
   TH2*         _callHist ;        ///<! Histogram recording number of calls per convolution integral calculation
 
-  ClassDef(RooNumConvolution,1)   // Operator PDF implementing numeric convolution of 2 input functions
+  ClassDefOverride(RooNumConvolution,1)   // Operator PDF implementing numeric convolution of 2 input functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumGenConfig.h
+++ b/roofit/roofitcore/inc/RooNumGenConfig.h
@@ -28,7 +28,7 @@ public:
   RooNumGenConfig();
   RooNumGenConfig(const RooNumGenConfig& other) ;
   RooNumGenConfig& operator=(const RooNumGenConfig& other) ;
-  virtual ~RooNumGenConfig();
+  ~RooNumGenConfig() override;
 
   // Return selected integration techniques for 1,2,N dimensional integrals
   RooCategory& method1D(Bool_t cond, Bool_t cat) ;
@@ -45,12 +45,12 @@ public:
   const RooArgSet& getConfigSection(const char* name) const ;
   RooArgSet& getConfigSection(const char* name) ;
 
-  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose, TString indent= "") const;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose, TString indent= "") const override;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
-  virtual StyleOption defaultPrintStyle(Option_t* opt) const ;
+  StyleOption defaultPrintStyle(Option_t* opt) const override ;
 
 
 protected:
@@ -72,7 +72,7 @@ protected:
 
   RooLinkedList _configSets ; ///< List of configuration sets for individual integration methods
 
-  ClassDef(RooNumGenConfig,1) // Numeric (MC) Event generator configuration
+  ClassDefOverride(RooNumGenConfig,1) // Numeric (MC) Event generator configuration
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumGenFactory.h
+++ b/roofit/roofitcore/inc/RooNumGenFactory.h
@@ -31,7 +31,7 @@ class RooNumGenFactory : public TObject {
 public:
 
   static RooNumGenFactory& instance() ;
-  virtual ~RooNumGenFactory();
+  ~RooNumGenFactory() override;
 
   Bool_t storeProtoSampler(RooAbsNumGenerator* proto, const RooArgSet& defConfig) ;
   const RooAbsNumGenerator* getProtoSampler(const char* name) ;
@@ -50,7 +50,7 @@ protected:
   RooNumGenFactory(const RooNumGenFactory& other) ;
 
 
-  ClassDef(RooNumGenFactory,1) // Numeric Generator factory
+  ClassDefOverride(RooNumGenFactory,1) // Numeric Generator factory
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumIntConfig.h
+++ b/roofit/roofitcore/inc/RooNumIntConfig.h
@@ -28,7 +28,7 @@ public:
   RooNumIntConfig();
   RooNumIntConfig(const RooNumIntConfig& other) ;
   RooNumIntConfig& operator=(const RooNumIntConfig& other) ;
-  virtual ~RooNumIntConfig();
+  ~RooNumIntConfig() override;
 
   // Return selected integration techniques for 1,2,N dimensional integrals
   RooCategory& method1D() { return _method1D ; }
@@ -63,10 +63,10 @@ public:
   const RooArgSet& getConfigSection(const char* name) const ;
   RooArgSet& getConfigSection(const char* name) ;
 
-  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose, TString indent= "") const;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose, TString indent= "") const override;
 
-  virtual StyleOption defaultPrintStyle(Option_t* opt) const ;
-  inline virtual void Print(Option_t *options= 0) const {
+  StyleOption defaultPrintStyle(Option_t* opt) const override ;
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
@@ -83,7 +83,7 @@ protected:
   RooCategory _methodNDOpen ; ///< Selects integration method for open ended ND integrals
   RooLinkedList _configSets ; ///< List of configuration sets for individual integration methods
 
-  ClassDef(RooNumIntConfig,1) // Numeric Integrator configuration
+  ClassDefOverride(RooNumIntConfig,1) // Numeric Integrator configuration
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumIntFactory.h
+++ b/roofit/roofitcore/inc/RooNumIntFactory.h
@@ -31,7 +31,7 @@ class RooNumIntFactory : public TObject {
 public:
 
   static RooNumIntFactory& instance() ;
-  virtual ~RooNumIntFactory() = default;
+  ~RooNumIntFactory() override = default;
 
   Bool_t storeProtoIntegrator(RooAbsIntegrator* proto, const RooArgSet& defConfig, const char* depName="") ;
   const RooAbsIntegrator* getProtoIntegrator(const char* name) const;
@@ -52,7 +52,7 @@ private:
   void init();
 
 
-  ClassDef(RooNumIntFactory, 0) // Numeric Integrator factory
+  ClassDefOverride(RooNumIntFactory, 0) // Numeric Integrator factory
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -21,16 +21,16 @@ class RooNumRunningInt : public RooAbsCachedReal {
 public:
   RooNumRunningInt(const char *name, const char *title, RooAbsReal& _func, RooRealVar& _x, const char* binningName="cache");
   RooNumRunningInt(const RooNumRunningInt& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooNumRunningInt(*this,newname); }
-  virtual ~RooNumRunningInt() ;
+  TObject* clone(const char* newname) const override { return new RooNumRunningInt(*this,newname); }
+  ~RooNumRunningInt() override ;
 
 protected:
 
   class RICacheElem: public FuncCacheElem {
   public:
     RICacheElem(const RooNumRunningInt& ri, const RooArgSet* nset) ;
-    ~RICacheElem() ;
-    virtual RooArgList containedArgs(Action) ;
+    ~RICacheElem() override ;
+    RooArgList containedArgs(Action) override ;
     void calculate(Bool_t cdfmode) ;
     void addRange(Int_t ixlo, Int_t ixhi, Int_t nbins) ;
     void addPoint(Int_t ix) ;
@@ -43,15 +43,15 @@ protected:
   } ;
 
   friend class RICacheElem ;
-  virtual const char* binningName() const { return _binningName.c_str() ; }
-  virtual FuncCacheElem* createCache(const RooArgSet* nset) const ;
-  virtual const char* inputBaseName() const ;
-  virtual RooArgSet* actualObservables(const RooArgSet& nset) const ;
-  virtual RooArgSet* actualParameters(const RooArgSet& nset) const ;
-  virtual void fillCacheObject(FuncCacheElem& cacheFunc) const ;
-  virtual Double_t evaluate() const ;
+  const char* binningName() const override { return _binningName.c_str() ; }
+  FuncCacheElem* createCache(const RooArgSet* nset) const override ;
+  const char* inputBaseName() const override ;
+  RooArgSet* actualObservables(const RooArgSet& nset) const override ;
+  RooArgSet* actualParameters(const RooArgSet& nset) const override ;
+  void fillCacheObject(FuncCacheElem& cacheFunc) const override ;
+  Double_t evaluate() const override ;
 
-  virtual const char* payloadUniqueSuffix() const { return func.arg().aggregateCacheUniqueSuffix() ; }
+  const char* payloadUniqueSuffix() const override { return func.arg().aggregateCacheUniqueSuffix() ; }
 
   RooRealProxy func ; ///< Proxy to functions whose running integral is calculated
   RooRealProxy x   ; ///< Intergrated observable
@@ -59,7 +59,7 @@ protected:
 
 private:
 
-  ClassDef(RooNumRunningInt,1) // Numeric calculator for running integral of a given function
+  ClassDefOverride(RooNumRunningInt,1) // Numeric calculator for running integral of a given function
 
 };
 

--- a/roofit/roofitcore/inc/RooObjCacheManager.h
+++ b/roofit/roofitcore/inc/RooObjCacheManager.h
@@ -33,17 +33,17 @@ public:
 
   RooObjCacheManager(RooAbsArg* owner=0, Int_t maxSize=2, Bool_t clearCacheOnServerRedirect=kTRUE, Bool_t allowOptimize=kFALSE) ;
   RooObjCacheManager(const RooObjCacheManager& other, RooAbsArg* owner=0) ;
-  virtual ~RooObjCacheManager() ;
+  ~RooObjCacheManager() override ;
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) ;
-  virtual void operModeHook() ;
-  virtual void optimizeCacheMode(const RooArgSet& /*obs*/, RooArgSet& /*optSet*/, RooLinkedList& /*processedNodes*/) ;
-  virtual void printCompactTreeHook(std::ostream&, const char *) ;
-  virtual void findConstantNodes(const RooArgSet& /*obs*/, RooArgSet& /*cacheList*/, RooLinkedList& /*processedNodes*/) ;
+  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override ;
+  void operModeHook() override ;
+  void optimizeCacheMode(const RooArgSet& /*obs*/, RooArgSet& /*optSet*/, RooLinkedList& /*processedNodes*/) override ;
+  void printCompactTreeHook(std::ostream&, const char *) override ;
+  void findConstantNodes(const RooArgSet& /*obs*/, RooArgSet& /*cacheList*/, RooLinkedList& /*processedNodes*/) override ;
 
-  virtual void insertObjectHook(RooAbsCacheElement&) ;
+  void insertObjectHook(RooAbsCacheElement&) override ;
 
-  void sterilize() ;
+  void sterilize() override ;
 
   static void doClearObsList(Bool_t flag) { _clearObsList = flag ; }
   static Bool_t clearObsList() { return _clearObsList ; }
@@ -60,7 +60,7 @@ protected:
 
   static Bool_t _clearObsList ; ///< Clear obslist on sterilize?
 
-  ClassDef(RooObjCacheManager,3) ///< Cache manager for generic caches that contain RooAbsArg objects
+  ClassDefOverride(RooObjCacheManager,3) ///< Cache manager for generic caches that contain RooAbsArg objects
 } ;
 
 

--- a/roofit/roofitcore/inc/RooParamBinning.h
+++ b/roofit/roofitcore/inc/RooParamBinning.h
@@ -28,34 +28,34 @@ public:
   RooParamBinning(const char* name=0) ;
   RooParamBinning(RooAbsReal& xlo, RooAbsReal& xhi, Int_t nBins, const char* name=0) ;
   RooParamBinning(const RooParamBinning& other, const char* name=0) ;
-  RooAbsBinning* clone(const char* name=0) const { return new RooParamBinning(*this,name?name:GetName()) ; }
-  virtual ~RooParamBinning() ;
+  RooAbsBinning* clone(const char* name=0) const override { return new RooParamBinning(*this,name?name:GetName()) ; }
+  ~RooParamBinning() override ;
 
-  virtual void setRange(Double_t xlo, Double_t xhi) ;
+  void setRange(Double_t xlo, Double_t xhi) override ;
 
-  virtual Int_t numBoundaries() const { return _nbins + 1 ; }
-  virtual Int_t binNumber(Double_t x) const  ;
+  Int_t numBoundaries() const override { return _nbins + 1 ; }
+  Int_t binNumber(Double_t x) const override  ;
 
-  virtual Double_t lowBound() const { return xlo()->getVal() ; }
-  virtual Double_t highBound() const { return xhi()->getVal() ; }
+  Double_t lowBound() const override { return xlo()->getVal() ; }
+  Double_t highBound() const override { return xhi()->getVal() ; }
 
-  virtual Double_t binCenter(Int_t bin) const ;
-  virtual Double_t binWidth(Int_t bin) const ;
-  virtual Double_t binLow(Int_t bin) const ;
-  virtual Double_t binHigh(Int_t bin) const ;
+  Double_t binCenter(Int_t bin) const override ;
+  Double_t binWidth(Int_t bin) const override ;
+  Double_t binLow(Int_t bin) const override ;
+  Double_t binHigh(Int_t bin) const override ;
 
-  virtual Double_t averageBinWidth() const { return _binw ; }
-  virtual Double_t* array() const ;
+  Double_t averageBinWidth() const override { return _binw ; }
+  Double_t* array() const override ;
 
-  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual void insertHook(RooAbsRealLValue&) const  ;
-  virtual void removeHook(RooAbsRealLValue&) const  ;
+  void insertHook(RooAbsRealLValue&) const override  ;
+  void removeHook(RooAbsRealLValue&) const override  ;
 
-  virtual Bool_t isShareable() const { return kFALSE ; } // parameterized binning cannot be shared across instances
-  virtual Bool_t isParameterized() const { return kTRUE ; } // binning is parameterized, range will need special handling in integration
-  virtual RooAbsReal* lowBoundFunc() const { return xlo() ; }
-  virtual RooAbsReal* highBoundFunc() const { return xhi() ; }
+  Bool_t isShareable() const override { return kFALSE ; } // parameterized binning cannot be shared across instances
+  Bool_t isParameterized() const override { return kTRUE ; } // binning is parameterized, range will need special handling in integration
+  RooAbsReal* lowBoundFunc() const override { return xlo() ; }
+  RooAbsReal* highBoundFunc() const override { return xhi() ; }
 
 protected:
 
@@ -70,7 +70,7 @@ protected:
   RooAbsReal* xlo() const { return _lp ? ((RooAbsReal*)_lp->at(0)) : _xlo ; }
   RooAbsReal* xhi() const { return _lp ? ((RooAbsReal*)_lp->at(1)) : _xhi ; }
 
-  ClassDef(RooParamBinning,2) // Binning specification with ranges parameterized by external RooAbsReal functions
+  ClassDefOverride(RooParamBinning,2) // Binning specification with ranges parameterized by external RooAbsReal functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -51,7 +51,7 @@ public:
   RooPlot(const RooAbsRealLValue &var1, const RooAbsRealLValue &var2);
   RooPlot(const RooAbsRealLValue &var1, const RooAbsRealLValue &var2,
 	  Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax);
-  virtual ~RooPlot();
+  ~RooPlot() override;
 
   static RooPlot* frame(const RooAbsRealLValue &var, Double_t xmin, Double_t xmax, Int_t nBins);
   static RooPlot* frameWithLabels(const RooAbsRealLValue &var);
@@ -62,7 +62,7 @@ public:
   virtual Stat_t GetBinContent(Int_t) const;
   virtual Stat_t GetBinContent(Int_t, Int_t) const;
   virtual Stat_t GetBinContent(Int_t, Int_t, Int_t) const;
-  virtual void Draw(Option_t *options= 0);
+  void Draw(Option_t *options= 0) override;
 
   // forwarding of relevant TH1 interface
   TAxis* GetXaxis() const ;
@@ -78,7 +78,7 @@ public:
   void SetBarWidth(Float_t width = 0.5) ;
   void SetContour(Int_t nlevels, const Double_t* levels = 0) ;
   void SetContourLevel(Int_t level, Double_t value) ;
-  void SetDrawOption(Option_t* option = "") ;
+  void SetDrawOption(Option_t* option = "") override ;
   void SetFillAttributes() ;
   void SetFillColor(Color_t fcolor) ;
   void SetFillStyle(Style_t fstyle) ;
@@ -94,9 +94,9 @@ public:
   void SetMarkerColor(Color_t tcolor = 1) ;
   void SetMarkerSize(Size_t msize = 1) ;
   void SetMarkerStyle(Style_t mstyle = 1) ;
-  void SetName(const char *name) ;
-  void SetTitle(const char *name) ;
-  void SetNameTitle(const char *name, const char* title) ;
+  void SetName(const char *name) override ;
+  void SetTitle(const char *name) override ;
+  void SetNameTitle(const char *name, const char* title) override ;
   void SetNdivisions(Int_t n = 510, Option_t* axis = "X") ;
   void SetOption(Option_t* option = " ") ;
   void SetStats(Bool_t stats = kTRUE) ;
@@ -122,16 +122,16 @@ public:
   void remove(const char* name=0, Bool_t deleteToo=kTRUE) ;
 
   // ascii printing
-  virtual void printName(std::ostream& os) const ;
-  virtual void printTitle(std::ostream& os) const ;
-  virtual void printClassName(std::ostream& os) const ;
-  virtual void printArgs(std::ostream& os) const ;
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printName(std::ostream& os) const override ;
+  void printTitle(std::ostream& os) const override ;
+  void printClassName(std::ostream& os) const override ;
+  void printArgs(std::ostream& os) const override ;
+  void printValue(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
 
-  inline virtual void Print(Option_t *options= 0) const {
+  inline void Print(Option_t *options= 0) const override {
     printStream(defaultPrintStream(),defaultPrintContents(options),defaultPrintStyle(options));
   }
 
@@ -181,7 +181,7 @@ public:
   RooHist* pullHist(const char* histname=0, const char* pdfname=0, bool useAverage=true) const
     { return residHist(histname,pdfname,true,useAverage); }
 
-  void Browse(TBrowser *b) ;
+  void Browse(TBrowser *b) override ;
 
   /// \copydoc AddDirectoryStatus()
   static Bool_t addDirectoryStatus() ;
@@ -246,7 +246,7 @@ protected:
 
   static Bool_t _addDirStatus ; ///< static flag controlling AutoDirectoryAdd feature
 
-  ClassDef(RooPlot,2)        // Plot frame and container for graphics objects
+  ClassDefOverride(RooPlot,2)        // Plot frame and container for graphics objects
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooPlotable.h
+++ b/roofit/roofitcore/inc/RooPlotable.h
@@ -26,7 +26,7 @@ class RooArgSet;
 class RooPlotable : public RooPrintable {
 public:
   inline RooPlotable() : _ymin(0), _ymax(0), _normValue(0) { }
-  inline virtual ~RooPlotable() { }
+  inline ~RooPlotable() override { }
 
   inline const char* getYAxisLabel() const { return _yAxisLabel.Data(); }
   inline void setYAxisLabel(const char *label) { _yAxisLabel= label; }
@@ -47,13 +47,13 @@ public:
   virtual Double_t getFitRangeNEvt(Double_t xlo, Double_t xhi) const = 0;
   virtual Double_t getFitRangeBinW() const = 0;
 
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent= "") const;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent= "") const override;
 
   TObject *crossCast();
 protected:
   TString _yAxisLabel;
   Double_t _ymin, _ymax, _normValue;
-  ClassDef(RooPlotable,1) // Abstract interface for plotable objects in a RooPlot
+  ClassDefOverride(RooPlotable,1) // Abstract interface for plotable objects in a RooPlot
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooPolyFunc.h
+++ b/roofit/roofitcore/inc/RooPolyFunc.h
@@ -32,7 +32,7 @@ public:
    RooPolyFunc(const char *name, const char *title, const RooAbsCollection &vars);
    RooPolyFunc(const RooPolyFunc &other, const char *name = 0);
    RooPolyFunc &operator=(const RooPolyFunc &other);
-   virtual TObject *clone(const char *newname) const { return new RooPolyFunc(*this, newname); }
+   TObject *clone(const char *newname) const override { return new RooPolyFunc(*this, newname); }
 
    void addTerm(double coefficient);
    void addTerm(double coefficient, const RooAbsCollection &exponents);
@@ -52,9 +52,9 @@ protected:
    std::vector<std::unique_ptr<RooListProxy>> _terms;
 
    /// Evaluation
-   double evaluate() const;
+   double evaluate() const override;
 
-   ClassDef(RooPolyFunc, 1) // Polynomial Function
+   ClassDefOverride(RooPolyFunc, 1) // Polynomial Function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooPolyVar.h
+++ b/roofit/roofitcore/inc/RooPolyVar.h
@@ -34,11 +34,11 @@ public:
       RooAbsReal& _x, const RooArgList& _coefList, Int_t lowestOrder=0) ;
 
   RooPolyVar(const RooPolyVar& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooPolyVar(*this, newname); }
-  virtual ~RooPolyVar() ;
+  TObject* clone(const char* newname) const override { return new RooPolyVar(*this, newname); }
+  ~RooPolyVar() override ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -48,9 +48,9 @@ protected:
 
   mutable std::vector<Double_t> _wksp; ///<! do not persist
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooPolyVar,1) // Polynomial function
+  ClassDefOverride(RooPolyVar,1) // Polynomial function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooProdGenContext.h
+++ b/roofit/roofitcore/inc/RooProdGenContext.h
@@ -32,17 +32,17 @@ class RooProdGenContext : public RooAbsGenContext {
 public:
   RooProdGenContext(const RooProdPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
           const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
-  virtual ~RooProdGenContext();
+  ~RooProdGenContext() override;
 
-  virtual void setProtoDataOrder(Int_t* lut) ;
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void setProtoDataOrder(Int_t* lut) override ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
 protected:
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
   void updateCCDTable() ;
 
@@ -63,7 +63,7 @@ protected:
   std::list<RooAbsGenContext*>  _gcList ; ///<  List of component generator contexts
   RooArgSet _ownedMultiProds ;   ///<  Owned auxiliary multi-term product PDFs
 
-  ClassDef(RooProdGenContext,0) // Context for efficient generation of a a dataset from a RooProdPdf
+  ClassDefOverride(RooProdGenContext,0) // Context for efficient generation of a a dataset from a RooProdPdf
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -53,43 +53,43 @@ public:
              const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) ;
 
   RooProdPdf(const RooProdPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooProdPdf(*this,newname) ; }
-  virtual ~RooProdPdf() ;
+  TObject* clone(const char* newname) const override { return new RooProdPdf(*this,newname) ; }
+  ~RooProdPdf() override ;
 
-  virtual Bool_t checkObservables(const RooArgSet* nset) const ;
+  Bool_t checkObservables(const RooArgSet* nset) const override ;
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& dep) const ;
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual Bool_t selfNormalized() const { return _selfNorm ; }
+  Bool_t forceAnalyticalInt(const RooAbsArg& dep) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Bool_t selfNormalized() const override { return _selfNorm ; }
 
-  virtual ExtendMode extendMode() const ;
-  virtual Double_t expectedEvents(const RooArgSet* nset) const ;
+  ExtendMode extendMode() const override ;
+  Double_t expectedEvents(const RooArgSet* nset) const override ;
 
   const RooArgList& pdfList() const { return _pdfList ; }
 
-  virtual Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  virtual void initGenerator(Int_t code) ;
-  virtual void generateEvent(Int_t code);
-  virtual Bool_t isDirectGenSafe(const RooAbsArg& arg) const ;
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void initGenerator(Int_t code) override ;
+  void generateEvent(Int_t code) override;
+  Bool_t isDirectGenSafe(const RooAbsArg& arg) const override ;
 
   // Constraint management
-  virtual RooArgSet* getConstraints(const RooArgSet& observables, RooArgSet& constrainedParams, Bool_t stripDisconnected) const ;
+  RooArgSet* getConstraints(const RooArgSet& observables, RooArgSet& constrainedParams, Bool_t stripDisconnected) const override ;
 
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ;
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  Bool_t isBinnedDistribution(const RooArgSet& obs) const  ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet& obs) const override  ;
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
-  virtual void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) ;
+  void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) override ;
   void fixRefRange(const char* rangeName) ;
 
   void setSelfNormalized(Bool_t flag) { _selfNorm = flag ; }
   void setDefNormSet(const RooArgSet& nset) { _defNormSet.removeAll() ; _defNormSet.addClone(nset) ; }
 
 
-  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) ;
+  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override ;
 
   RooArgSet* getConnectedParameters(const RooArgSet& observables) const ;
 
@@ -99,13 +99,13 @@ public:
 
 private:
 
-  Double_t evaluate() const ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const;
-  inline bool canComputeBatchWithCuda() const { return true; }
+  Double_t evaluate() const override ;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
 
   RooAbsReal* makeCondPdfRatioCorr(RooAbsReal& term, const RooArgSet& termNset, const RooArgSet& termImpSet, const char* normRange, const char* refRange) const ;
 
-  virtual void getParametersHook(const RooArgSet* /*nset*/, RooArgSet* /*list*/, Bool_t stripDisconnected) const ;
+  void getParametersHook(const RooArgSet* /*nset*/, RooArgSet* /*list*/, Bool_t stripDisconnected) const override ;
 
   void initializeFromCmdArgList(const RooArgSet& fullPdfSet, const RooLinkedList& l) ;
 
@@ -127,8 +127,8 @@ private:
                      Bool_t& isOwned, Bool_t forceWrap=kFALSE) const ;
 
 
-  virtual CacheMode canNodeBeCached() const { return RooAbsArg::NotAdvised ; } ;
-  virtual void setCacheAndTrackHints(RooArgSet&) ;
+  CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;
+  void setCacheAndTrackHints(RooArgSet&) override ;
 
   // The cache object
   class CacheElem final : public RooAbsCacheElement {
@@ -159,8 +159,8 @@ private:
 
 
   friend class RooProdGenContext ;
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                  const RooArgSet *auxProto=0, Bool_t verbose= kFALSE) const ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
+                                  const RooArgSet *auxProto=0, Bool_t verbose= kFALSE) const override ;
 
 
   mutable RooAICRegistry _genCode ; ///<! Registry of composite direct generator codes
@@ -180,7 +180,7 @@ private:
 
 private:
 
-  ClassDef(RooProdPdf,6) // PDF representing a product of PDFs
+  ClassDefOverride(RooProdPdf,6) // PDF representing a product of PDFs
 };
 
 

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -36,28 +36,28 @@ public:
 
   void addTerm(RooAbsArg* term);
 
-  virtual TObject* clone(const char* newname) const { return new RooProduct(*this, newname); }
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& dep) const ;
-  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
+  TObject* clone(const char* newname) const override { return new RooProduct(*this, newname); }
+  Bool_t forceAnalyticalInt(const RooAbsArg& dep) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
                                                    const RooArgSet* normSet,
-                                                   const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const;
+                                                   const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override;
 
 
   RooArgList components() { RooArgList tmp(_compRSet) ; tmp.add(_compCSet) ; return tmp ; }
 
-  virtual ~RooProduct() ;
+  ~RooProduct() override ;
 
   class ProdMap ;
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual Bool_t isBinnedDistribution(const RooArgSet& obs) const ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet& obs) const override ;
 
-  virtual CacheMode canNodeBeCached() const { return RooAbsArg::NotAdvised ; } ;
-  virtual void setCacheAndTrackHints(RooArgSet&) ;
+  CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;
+  void setCacheAndTrackHints(RooArgSet&) override ;
 
 protected:
 
@@ -66,24 +66,24 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-      virtual ~CacheElem();
+      ~CacheElem() override;
       // Payload
       RooArgList _prodList ;
       RooArgList _ownedList ;
-      virtual RooArgList containedArgs(Action) ;
+      RooArgList containedArgs(Action) override ;
   };
   mutable RooObjCacheManager _cacheMgr ; //! The cache manager
 
 
   Double_t calculate(const RooArgList& partIntList) const;
-  Double_t evaluate() const;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
+  Double_t evaluate() const override;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
 
   const char* makeFPName(const char *pfx,const RooArgSet& terms) const ;
   ProdMap* groupProductTerms(const RooArgSet&) const;
   Int_t getPartIntList(const RooArgSet* iset, const char *rangeName=0) const;
 
-  ClassDef(RooProduct,3) // Product of RooAbsReal and/or RooAbsCategory terms
+  ClassDefOverride(RooProduct,3) // Product of RooAbsReal and/or RooAbsCategory terms
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooProfileLL.h
+++ b/roofit/roofitcore/inc/RooProfileLL.h
@@ -25,7 +25,7 @@ public:
   RooProfileLL() ;
   RooProfileLL(const char *name, const char *title, RooAbsReal& nll, const RooArgSet& observables);
   RooProfileLL(const RooProfileLL& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooProfileLL(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooProfileLL(*this,newname); }
 
   void setAlwaysStartFromMin(Bool_t flag) { _startFromMin = flag ; }
   Bool_t alwaysStartFromMin() const { return _startFromMin ; }
@@ -35,9 +35,9 @@ public:
   const RooArgSet& bestFitParams() const ;
   const RooArgSet& bestFitObs() const ;
 
-  virtual RooAbsReal* createProfile(const RooArgSet& paramsOfInterest) ;
+  RooAbsReal* createProfile(const RooArgSet& paramsOfInterest) override ;
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) ;
+  Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override ;
 
   void clearAbsMin() { _absMinValid = kFALSE ; }
 
@@ -65,12 +65,12 @@ protected:
   mutable RooArgSet _obsAbsMin ; ///< Observable values at absolute minimum
   mutable std::map<std::string,bool> _paramFixed ; ///< Parameter constant status at last time of use
   mutable Int_t _neval ; ///< Number evaluations used in last minimization
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 
 private:
 
-  ClassDef(RooProfileLL,0) // Real-valued function representing profile likelihood of external (likelihood) function
+  ClassDefOverride(RooProfileLL,0) // Real-valued function representing profile likelihood of external (likelihood) function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooProjectedPdf.h
+++ b/roofit/roofitcore/inc/RooProjectedPdf.h
@@ -24,24 +24,24 @@ public:
   RooProjectedPdf() ;
   RooProjectedPdf(const char *name, const char *title,  RooAbsReal& _intpdf, const RooArgSet& intObs);
   RooProjectedPdf(const RooProjectedPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooProjectedPdf(*this,newname); }
-  inline virtual ~RooProjectedPdf() { }
+  TObject* clone(const char* newname) const override { return new RooProjectedPdf(*this,newname); }
+  inline ~RooProjectedPdf() override { }
 
   // Analytical integration support
-  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& dep) const ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Bool_t forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void initGenerator(Int_t /*code*/) {} ; // optional pre-generation initialization
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void initGenerator(Int_t /*code*/) override {} ; // optional pre-generation initialization
+  void generateEvent(Int_t code) override;
 
-  virtual Bool_t selfNormalized() const { return kTRUE ; }
+  Bool_t selfNormalized() const override { return kTRUE ; }
 
   // Handle projection of projection explicitly
-  virtual RooAbsPdf* createProjection(const RooArgSet& iset) ;
+  RooAbsPdf* createProjection(const RooArgSet& iset) override ;
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
 
 protected:
@@ -52,23 +52,23 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    virtual ~CacheElem() { delete _projection ; } ;
+    ~CacheElem() override { delete _projection ; } ;
     // Payload
     RooAbsReal* _projection ;
     // Cache management functions
-    virtual RooArgList containedArgs(Action) ;
-    virtual void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) ;
+    RooArgList containedArgs(Action) override ;
+    void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) override ;
   } ;
   mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager
 
-  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override ;
 
   const RooAbsReal* getProjection(const RooArgSet* iset, const RooArgSet* nset, const char* rangeName, int& code) const ;
-  Double_t evaluate() const ;
+  Double_t evaluate() const override ;
 
 private:
 
-  ClassDef(RooProjectedPdf,1) // Operator p.d.f calculating projection of another p.d.f
+  ClassDefOverride(RooProjectedPdf,1) // Operator p.d.f calculating projection of another p.d.f
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooProofDriverSelector.h
+++ b/roofit/roofitcore/inc/RooProofDriverSelector.h
@@ -25,23 +25,23 @@ public :
    TBranch        *b_i;   ///<!
 
    RooProofDriverSelector(TTree * /*tree*/ =0) { b_i = 0 ; _pkg = 0 ; fChain = 0 ; }
-   virtual ~RooProofDriverSelector() { }
-   virtual Int_t   Version() const { return 2; }
-   virtual void    SlaveBegin(TTree *tree);
-   virtual void    Init(TTree* tree);
-   virtual Bool_t  Notify();
-   virtual Bool_t  Process(Long64_t entry);
-   virtual Int_t   GetEntry(Long64_t entry, Int_t getall = 0) { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }
-   virtual void    SetOption(const char *option) { fOption = option; }
-   virtual void    SetObject(TObject *obj) { fObject = obj; }
-   virtual void    SetInputList(TList *input) { fInput = input; }
-   virtual void    SlaveTerminate() ;
-   virtual TList  *GetOutputList() const { return fOutput; }
+   ~RooProofDriverSelector() override { }
+   Int_t   Version() const override { return 2; }
+   void    SlaveBegin(TTree *tree) override;
+   void    Init(TTree* tree) override;
+   Bool_t  Notify() override;
+   Bool_t  Process(Long64_t entry) override;
+   Int_t   GetEntry(Long64_t entry, Int_t getall = 0) override { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }
+   void    SetOption(const char *option) override { fOption = option; }
+   void    SetObject(TObject *obj) override { fObject = obj; }
+   void    SetInputList(TList *input) override { fInput = input; }
+   void    SlaveTerminate() override ;
+   TList  *GetOutputList() const override { return fOutput; }
 
    RooStudyPackage* _pkg ;
    Int_t      seed ;
 
-   ClassDef(RooProofDriverSelector,0);
+   ClassDefOverride(RooProofDriverSelector,0);
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooPullVar.h
+++ b/roofit/roofitcore/inc/RooPullVar.h
@@ -26,10 +26,10 @@ public:
 
   RooPullVar() ;
   RooPullVar(const char *name, const char *title, RooRealVar& measurement, RooAbsReal& truth) ;
-  virtual ~RooPullVar() ;
+  ~RooPullVar() override ;
 
   RooPullVar(const RooPullVar& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooPullVar(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooPullVar(*this, newname); }
 
 
 protected:
@@ -37,9 +37,9 @@ protected:
   RooTemplateProxy<RooRealVar> _meas ;
   RooRealProxy _true ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooPullVar,1) // Calculation of pull of measurement w.r.t a truth value
+  ClassDefOverride(RooPullVar,1) // Calculation of pull of measurement w.r.t a truth value
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRandomizeParamMCSModule.h
+++ b/roofit/roofitcore/inc/RooRandomizeParamMCSModule.h
@@ -26,7 +26,7 @@ public:
 
   RooRandomizeParamMCSModule() ;
   RooRandomizeParamMCSModule(const RooRandomizeParamMCSModule& other) ;
-  virtual ~RooRandomizeParamMCSModule() ;
+  ~RooRandomizeParamMCSModule() override ;
 
   void sampleUniform(RooRealVar& param, Double_t lo, Double_t hi) ;
   void sampleGaussian(RooRealVar& param, Double_t mean, Double_t sigma) ;
@@ -34,12 +34,12 @@ public:
   void sampleSumUniform(const RooArgSet& paramSet, Double_t lo, Double_t hi) ;
   void sampleSumGauss(const RooArgSet& paramSet, Double_t lo, Double_t hi) ;
 
-  Bool_t initializeInstance() ;
+  Bool_t initializeInstance() override ;
 
-  Bool_t initializeRun(Int_t /*numSamples*/) ;
-  RooDataSet* finalizeRun() ;
+  Bool_t initializeRun(Int_t /*numSamples*/) override ;
+  RooDataSet* finalizeRun() override ;
 
-  Bool_t processBeforeGen(Int_t /*sampleNum*/) ;
+  Bool_t processBeforeGen(Int_t /*sampleNum*/) override ;
 
 private:
 
@@ -91,7 +91,7 @@ private:
   RooArgSet _genParSet ;
   RooDataSet* _data ;
 
-  ClassDef(RooRandomizeParamMCSModule,0) // MCStudy module to vary one or more input parameters during fit/generation cycle
+  ClassDefOverride(RooRandomizeParamMCSModule,0) // MCStudy module to vary one or more input parameters during fit/generation cycle
 } ;
 
 

--- a/roofit/roofitcore/inc/RooRangeBinning.h
+++ b/roofit/roofitcore/inc/RooRangeBinning.h
@@ -24,31 +24,31 @@ public:
   RooRangeBinning(const char* name=0) ;
   RooRangeBinning(Double_t xmin, Double_t xmax, const char* name=0) ;
   RooRangeBinning(const RooRangeBinning&, const char* name=0) ;
-  virtual RooAbsBinning* clone(const char* name=0) const { return new RooRangeBinning(*this,name?name:GetName()) ; }
-  virtual ~RooRangeBinning() ;
+  RooAbsBinning* clone(const char* name=0) const override { return new RooRangeBinning(*this,name?name:GetName()) ; }
+  ~RooRangeBinning() override ;
 
-  virtual Int_t numBoundaries() const { return 2 ; }
-  virtual Int_t binNumber(Double_t) const { return 0 ; }
-  virtual Double_t binCenter(Int_t) const { return (_range[0] + _range[1]) / 2 ; }
-  virtual Double_t binWidth(Int_t) const { return (_range[1] - _range[0]) ; }
-  virtual Double_t binLow(Int_t) const { return _range[0] ; }
-  virtual Double_t binHigh(Int_t) const { return _range[1] ; }
+  Int_t numBoundaries() const override { return 2 ; }
+  Int_t binNumber(Double_t) const override { return 0 ; }
+  Double_t binCenter(Int_t) const override { return (_range[0] + _range[1]) / 2 ; }
+  Double_t binWidth(Int_t) const override { return (_range[1] - _range[0]) ; }
+  Double_t binLow(Int_t) const override { return _range[0] ; }
+  Double_t binHigh(Int_t) const override { return _range[1] ; }
 
-  virtual void setRange(Double_t xlo, Double_t xhi) ;
-  virtual void setMin(Double_t xlo) { setRange(xlo,highBound()) ; }
-  virtual void setMax(Double_t xhi) { setRange(lowBound(),xhi) ; }
+  void setRange(Double_t xlo, Double_t xhi) override ;
+  void setMin(Double_t xlo) override { setRange(xlo,highBound()) ; }
+  void setMax(Double_t xhi) override { setRange(lowBound(),xhi) ; }
 
-  virtual Double_t lowBound() const { return _range[0] ; }
-  virtual Double_t highBound() const { return _range[1] ; }
-  virtual Double_t averageBinWidth() const { return binWidth(0) ; }
+  Double_t lowBound() const override { return _range[0] ; }
+  Double_t highBound() const override { return _range[1] ; }
+  Double_t averageBinWidth() const override { return binWidth(0) ; }
 
-  virtual Double_t* array() const { return const_cast<Double_t*>(_range) ; }
+  Double_t* array() const override { return const_cast<Double_t*>(_range) ; }
 
 protected:
 
   Double_t _range[2] ;
     
-  ClassDef(RooRangeBinning,1) // Binning that only defines the total range
+  ClassDefOverride(RooRangeBinning,1) // Binning that only defines the total range
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRangeBoolean.h
+++ b/roofit/roofitcore/inc/RooRangeBoolean.h
@@ -30,20 +30,20 @@ public:
   RooRangeBoolean() ;
   RooRangeBoolean(const char* name, const char* title, RooAbsRealLValue& x, const char* rangeName) ;
   RooRangeBoolean(const RooRangeBoolean& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooRangeBoolean(*this, newname); }
-  virtual ~RooRangeBoolean() ;
+  TObject* clone(const char* newname) const override { return new RooRangeBoolean(*this, newname); }
+  ~RooRangeBoolean() override ;
 
 
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const ; 
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override ; 
 
 protected:
 
   RooRealProxy _x;
   TString _rangeName ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooRangeBoolean,1) // Polynomial function
+  ClassDefOverride(RooRangeBoolean,1) // Polynomial function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRatio.h
+++ b/roofit/roofitcore/inc/RooRatio.h
@@ -42,18 +42,18 @@ public:
            const RooArgList &num, const RooArgList &denom);
 
   RooRatio(const RooRatio &other, const char *name = 0);
-  virtual TObject *clone(const char *newname) const {
+  TObject *clone(const char *newname) const override {
     return new RooRatio(*this, newname);
   }
-  virtual ~RooRatio();
+  ~RooRatio() override;
 
 protected:
   RooRealProxy _numerator;
   RooRealProxy _denominator;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooRatio, 2) // Ratio of two RooAbsReal and/or numbers
+  ClassDefOverride(RooRatio, 2) // Ratio of two RooAbsReal and/or numbers
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealAnalytic.h
+++ b/roofit/roofitcore/inc/RooRealAnalytic.h
@@ -22,9 +22,9 @@ class RooRealAnalytic : public RooRealBinding {
 public:
   inline RooRealAnalytic(const RooAbsReal &func, const RooArgSet &vars, Int_t code, const RooArgSet* normSet=0, const TNamed* rangeName=0) :
     RooRealBinding(func,vars,normSet,rangeName), _code(code) { }
-  inline virtual ~RooRealAnalytic() { }
+  inline ~RooRealAnalytic() override { }
 
-  virtual Double_t operator()(const Double_t xvector[]) const override;
+  Double_t operator()(const Double_t xvector[]) const override;
   RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const override;
 
 protected:

--- a/roofit/roofitcore/inc/RooRealBinding.h
+++ b/roofit/roofitcore/inc/RooRealBinding.h
@@ -30,23 +30,23 @@ class RooRealBinding : public RooAbsFunc {
 public:
   RooRealBinding(const RooAbsReal& func, const RooArgSet &vars, const RooArgSet* nset=0, Bool_t clipInvalid=kFALSE, const TNamed* rangeName=0);
   RooRealBinding(const RooRealBinding& other, const RooArgSet* nset=0) ;
-  virtual ~RooRealBinding();
+  ~RooRealBinding() override;
 
-  virtual Double_t operator()(const Double_t xvector[]) const;
+  Double_t operator()(const Double_t xvector[]) const override;
   virtual RooSpan<const double> getValues(std::vector<RooSpan<const double>> coordinates) const;
   RooSpan<const double> getValuesOfBoundFunction(RooBatchCompute::RunContext& evalData) const;
-  virtual Double_t getMinLimit(UInt_t dimension) const;
-  virtual Double_t getMaxLimit(UInt_t dimension) const;
+  Double_t getMinLimit(UInt_t dimension) const override;
+  Double_t getMaxLimit(UInt_t dimension) const override;
 
-  virtual void saveXVec() const ;
-  virtual void restoreXVec() const ;
+  void saveXVec() const override ;
+  void restoreXVec() const override ;
 
-  virtual const char* getName() const ;
+  const char* getName() const override ;
 
-  virtual std::list<Double_t>* binBoundaries(Int_t) const ;
+  std::list<Double_t>* binBoundaries(Int_t) const override ;
   /// Return a pointer to the observable that defines the `i`-th dimension of the function.
   RooAbsRealLValue* observable(unsigned int i) const { return i < _vars.size() ? _vars[i] : nullptr; }
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
 
 protected:
 
@@ -64,7 +64,7 @@ protected:
   mutable Double_t _funcSave ; ///<!
   mutable std::unique_ptr<RooBatchCompute::RunContext> _evalData; ///< Memory for batch evaluations
 
-  ClassDef(RooRealBinding,0) // Function binding to RooAbsReal object
+  ClassDefOverride(RooRealBinding,0) // Function binding to RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealConstant.h
+++ b/roofit/roofitcore/inc/RooRealConstant.h
@@ -40,4 +40,3 @@ protected:
 
 
 #endif
-

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -39,15 +39,15 @@ public:
   RooRealIntegral(const char *name, const char *title, const RooAbsReal& function, const RooArgSet& depList,
         const RooArgSet* funcNormSet=0, const RooNumIntConfig* config=0, const char* rangeName=0) ;
   RooRealIntegral(const RooRealIntegral& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooRealIntegral(*this,newname); }
-  virtual ~RooRealIntegral();
+  TObject* clone(const char* newname) const override { return new RooRealIntegral(*this,newname); }
+  ~RooRealIntegral() override;
 
-  virtual Double_t getValV(const RooArgSet* set=0) const ;
+  Double_t getValV(const RooArgSet* set=0) const override ;
 
-  Bool_t isValid() const { return _valid; }
+  Bool_t isValid() const override { return _valid; }
 
-  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
-  void printMetaArgs(std::ostream& os) const ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
+  void printMetaArgs(std::ostream& os) const override ;
 
   const RooArgSet& numIntCatVars() const { return _sumList ; }
   const RooArgSet& numIntRealVars() const { return _intList ; }
@@ -71,12 +71,12 @@ public:
 
   static Int_t getCacheAllNumeric() ;
 
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const {
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override {
     // Forward plot sampling hint of integrand
     return _function.arg().plotSamplingHint(obs,xlo,xhi) ;
   }
 
-  virtual RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=0, const RooNumIntConfig* cfg=0, const char* rangeName=0) const ;
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=0, const RooNumIntConfig* cfg=0, const char* rangeName=0) const override ;
 
   void setAllowComponentSelection(Bool_t allow);
   Bool_t getAllowComponentSelection() const;
@@ -99,13 +99,13 @@ protected:
   virtual Double_t jacobianProduct() const ;
 
   // Evaluation and validation implementation
-  Double_t evaluate() const ;
-  virtual Bool_t isValidReal(Double_t value, Bool_t printError=kFALSE) const ;
+  Double_t evaluate() const override ;
+  Bool_t isValidReal(Double_t value, Bool_t printError=kFALSE) const override ;
   Bool_t servesExclusively(const RooAbsArg* server,const RooArgSet& exclLVBranches, const RooArgSet& allBranches) const ;
 
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList,
-                 Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList,
+                 Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
 
   // Function pointer and integrands list
   mutable RooSetProxy _sumList ; ///< Set of discrete observable over which is summed numerically
@@ -139,7 +139,7 @@ protected:
   Bool_t _cacheNum ;           ///< Cache integral if numeric
   static Int_t _cacheAllNDim ; ///<! Cache all integrals with given numeric dimension
 
-  ClassDef(RooRealIntegral,3) // Real-valued function representing an integral over a RooAbsReal object
+  ClassDefOverride(RooRealIntegral,3) // Real-valued function representing an integral over a RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealMPFE.h
+++ b/roofit/roofitcore/inc/RooRealMPFE.h
@@ -32,27 +32,27 @@ public:
   // Constructors, assignment etc
   RooRealMPFE(const char *name, const char *title, RooAbsReal& arg, Bool_t calcInline=kFALSE) ;
   RooRealMPFE(const RooRealMPFE& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooRealMPFE(*this,newname); }
-  virtual ~RooRealMPFE();
+  TObject* clone(const char* newname) const override { return new RooRealMPFE(*this,newname); }
+  ~RooRealMPFE() override;
 
   void calculate() const ;
-  virtual Double_t getValV(const RooArgSet* nset=0) const ;
+  Double_t getValV(const RooArgSet* nset=0) const override ;
   void standby() ;
 
   void setVerbose(Bool_t clientFlag=kTRUE, Bool_t serverFlag=kTRUE) ;
 
   void applyNLLWeightSquared(Bool_t flag) ;
 
-  void enableOffsetting(Bool_t flag) ;
+  void enableOffsetting(Bool_t flag) override ;
 
   void followAsSlave(RooRealMPFE& master) { _updateMaster = &master ; }
 
   protected:
 
   // Function evaluation
-  virtual Double_t evaluate() const ;
+  Double_t evaluate() const override ;
   friend class RooAbsTestStatistic ;
-  virtual void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTracking=kTRUE) ;
+  void constOptimizeTestStatistic(ConstOpCode opcode, Bool_t doAlsoTracking=kTRUE) override ;
   virtual Double_t getCarry() const;
 
   enum State { Initialize,Client,Server,Inline } ;
@@ -87,7 +87,7 @@ public:
 
   static RooMPSentinel _sentinel ;
 
-  ClassDef(RooRealMPFE,2) // Multi-process front-end for parallel calculation of a real valued function
+  ClassDefOverride(RooRealMPFE,2) // Multi-process front-end for parallel calculation of a real valued function
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -29,42 +29,42 @@ public:
    RooRealSumFunc(const char *name, const char *title, const RooArgList &funcList, const RooArgList &coefList);
    RooRealSumFunc(const char *name, const char *title, RooAbsReal &func1, RooAbsReal &func2, RooAbsReal &coef1);
    RooRealSumFunc(const RooRealSumFunc &other, const char *name = 0);
-   virtual TObject *clone(const char *newname) const { return new RooRealSumFunc(*this, newname); }
-   virtual ~RooRealSumFunc();
+   TObject *clone(const char *newname) const override { return new RooRealSumFunc(*this, newname); }
+   ~RooRealSumFunc() override;
 
-   Double_t evaluate() const;
-   virtual Bool_t checkObservables(const RooArgSet *nset) const;
+   Double_t evaluate() const override;
+   Bool_t checkObservables(const RooArgSet *nset) const override;
 
-   void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const;
+   void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
-   virtual Bool_t forceAnalyticalInt(const RooAbsArg &arg) const { return arg.isFundamental(); }
+   Bool_t forceAnalyticalInt(const RooAbsArg &arg) const override { return arg.isFundamental(); }
    Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &numVars, const RooArgSet *normSet,
-                                 const char *rangeName = 0) const;
-   Double_t analyticalIntegralWN(Int_t code, const RooArgSet *normSet, const char *rangeName = 0) const;
+                                 const char *rangeName = 0) const override;
+   Double_t analyticalIntegralWN(Int_t code, const RooArgSet *normSet, const char *rangeName = 0) const override;
 
    const RooArgList &funcList() const { return _funcList; }
    const RooArgList &coefList() const { return _coefList; }
 
-   void printMetaArgs(std::ostream &os) const;
+   void printMetaArgs(std::ostream &os) const override;
 
-   virtual std::list<Double_t> *binBoundaries(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const;
-   virtual std::list<Double_t> *plotSamplingHint(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const;
-   Bool_t isBinnedDistribution(const RooArgSet &obs) const;
+   std::list<Double_t> *binBoundaries(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
+   std::list<Double_t> *plotSamplingHint(RooAbsRealLValue & /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override;
+   Bool_t isBinnedDistribution(const RooArgSet &obs) const override;
 
    void setFloor(Bool_t flag) { _doFloor = flag; }
    Bool_t getFloor() const { return _doFloor; }
    static void setFloorGlobal(Bool_t flag) { _doFloorGlobal = flag; }
    static Bool_t getFloorGlobal() { return _doFloorGlobal; }
 
-   virtual CacheMode canNodeBeCached() const { return RooAbsArg::NotAdvised; };
-   virtual void setCacheAndTrackHints(RooArgSet &);
+   CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised; };
+   void setCacheAndTrackHints(RooArgSet &) override;
 
 protected:
    class CacheElem : public RooAbsCacheElement {
    public:
       CacheElem(){};
-      virtual ~CacheElem(){};
-      virtual RooArgList containedArgs(Action)
+      ~CacheElem() override{};
+      RooArgList containedArgs(Action) override
       {
          RooArgList ret(_funcIntList);
          ret.add(_funcNormList);
@@ -86,7 +86,7 @@ protected:
    static Bool_t _doFloorGlobal; ///< Global flag for introducing floor at zero in pdf
 
 private:
-   ClassDef(RooRealSumFunc, 4) // PDF constructed from a sum of (non-pdf) functions
+   ClassDefOverride(RooRealSumFunc, 4) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -30,52 +30,52 @@ public:
   RooRealSumPdf(const char *name, const char *title,
          RooAbsReal& func1, RooAbsReal& func2, RooAbsReal& coef1) ;
   RooRealSumPdf(const RooRealSumPdf& other, const char* name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooRealSumPdf(*this,newname) ; }
-  virtual ~RooRealSumPdf() ;
+  TObject* clone(const char* newname) const override { return new RooRealSumPdf(*this,newname) ; }
+  ~RooRealSumPdf() override ;
 
-  Double_t evaluate() const ;
-  virtual Bool_t checkObservables(const RooArgSet* nset) const ;
+  Double_t evaluate() const override ;
+  Bool_t checkObservables(const RooArgSet* nset) const override ;
 
-  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg& arg) const { return arg.isFundamental() ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Bool_t forceAnalyticalInt(const RooAbsArg& arg) const override { return arg.isFundamental() ; }
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }
 
-  virtual ExtendMode extendMode() const ;
+  ExtendMode extendMode() const override ;
 
   /// Return expected number of events for extended likelihood calculation, which
   /// is the sum of all coefficients.
-  virtual Double_t expectedEvents(const RooArgSet* nset) const ;
+  Double_t expectedEvents(const RooArgSet* nset) const override ;
 
-  virtual Bool_t selfNormalized() const { return getAttribute("BinnedLikelihoodActive") ; }
+  Bool_t selfNormalized() const override { return getAttribute("BinnedLikelihoodActive") ; }
 
-  void printMetaArgs(std::ostream& os) const ;
+  void printMetaArgs(std::ostream& os) const override ;
 
 
-  virtual std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const ;
-  Bool_t isBinnedDistribution(const RooArgSet& obs) const  ;
+  std::list<Double_t>* binBoundaries(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& /*obs*/, Double_t /*xlo*/, Double_t /*xhi*/) const override ;
+  Bool_t isBinnedDistribution(const RooArgSet& obs) const override  ;
 
   void setFloor(Bool_t flag) { _doFloor = flag ; }
   Bool_t getFloor() const { return _doFloor ; }
   static void setFloorGlobal(Bool_t flag) { _doFloorGlobal = flag ; }
   static Bool_t getFloorGlobal() { return _doFloorGlobal ; }
 
-  virtual CacheMode canNodeBeCached() const { return RooAbsArg::NotAdvised ; } ;
-  virtual void setCacheAndTrackHints(RooArgSet&) ;
+  CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;
+  void setCacheAndTrackHints(RooArgSet&) override ;
 
 protected:
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
 
   class CacheElem : public RooAbsCacheElement {
   public:
     CacheElem()  {} ;
-    virtual ~CacheElem() {} ;
-    virtual RooArgList containedArgs(Action) { RooArgList ret(_funcIntList) ; ret.add(_funcNormList) ; return ret ; }
+    ~CacheElem() override {} ;
+    RooArgList containedArgs(Action) override { RooArgList ret(_funcIntList) ; ret.add(_funcNormList) ; return ret ; }
     RooArgList _funcIntList ;
     RooArgList _funcNormList ;
   } ;
@@ -96,7 +96,7 @@ private:
     return _funcList.size() == _coefList.size();
   }
 
-  ClassDef(RooRealSumPdf, 5) // PDF constructed from a sum of (non-pdf) functions
+  ClassDefOverride(RooRealSumPdf, 5) // PDF constructed from a sum of (non-pdf) functions
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -48,15 +48,15 @@ public:
       Double_t minValue, Double_t maxValue, const char *unit= "") ;
   RooRealVar(const RooRealVar& other, const char* name=0);
   RooRealVar& operator=(const RooRealVar& other);
-  virtual TObject* clone(const char* newname) const { return new RooRealVar(*this,newname); }
-  virtual ~RooRealVar();
+  TObject* clone(const char* newname) const override { return new RooRealVar(*this,newname); }
+  ~RooRealVar() override;
 
   // Parameter value and error accessors
-  virtual Double_t getValV(const RooArgSet* nset=0) const ;
+  Double_t getValV(const RooArgSet* nset=0) const override ;
   RooSpan<const double> getValues(RooBatchCompute::RunContext& inputData, const RooArgSet* = nullptr) const final;
 
-  virtual void setVal(Double_t value);
-  virtual void setVal(Double_t value, const char* rangeName);
+  void setVal(Double_t value) override;
+  void setVal(Double_t value, const char* rangeName) override;
   inline Double_t getError() const { return _error>=0?_error:0. ; }
   inline Bool_t hasError(Bool_t allowZero=kTRUE) const { return allowZero ? (_error>=0) : (_error>0) ; }
   inline void setError(Double_t value) { _error= value ; }
@@ -87,10 +87,10 @@ public:
   void setBinning(const RooAbsBinning& binning, const char* name=0) ;
 
   // RooAbsRealLValue implementation
-  Bool_t hasBinning(const char* name) const ;
-  const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const ;
-  RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) ;
-  std::list<std::string> getBinningNames() const ;
+  Bool_t hasBinning(const char* name) const override ;
+  const RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) const override ;
+  RooAbsBinning& getBinning(const char* name=0, Bool_t verbose=kTRUE, Bool_t createOnTheFly=kFALSE) override ;
+  std::list<std::string> getBinningNames() const override ;
 
   // Set infinite fit range limits
   /// Remove lower range limit for binning with given name. Empty name means default range.
@@ -101,23 +101,23 @@ public:
   void removeRange(const char* name=0);
 
   // I/O streaming interface (machine readable)
-  virtual Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) ;
-  virtual void writeToStream(std::ostream& os, Bool_t compact) const ;
+  Bool_t readFromStream(std::istream& is, Bool_t compact, Bool_t verbose=kFALSE) override ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
   // We implement a fundamental type of AbsArg that can be stored in a dataset
-  inline virtual Bool_t isFundamental() const { return kTRUE; }
+  inline Bool_t isFundamental() const override { return kTRUE; }
 
   // Force to be a leaf-node of any expression tree, even if we have (shape) servers
-  virtual Bool_t isDerived() const {
+  Bool_t isDerived() const override {
     // Does value or shape of this arg depend on any other arg?
     return !_serverList.empty() || _proxyList.GetEntries()>0;
   }
 
   // Printing interface (human readable)
-  virtual void printValue(std::ostream& os) const ;
-  virtual void printExtras(std::ostream& os) const ;
-  virtual void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const ;
-  virtual Int_t defaultPrintContents(Option_t* opt) const ;
+  void printValue(std::ostream& os) const override ;
+  void printExtras(std::ostream& os) const override ;
+  void printMultiline(std::ostream& os, Int_t contents, Bool_t verbose=kFALSE, TString indent="") const override ;
+  Int_t defaultPrintContents(Option_t* opt) const override ;
 
 
   TString* format(const RooCmdArg& formatArg) const ;
@@ -140,14 +140,14 @@ public:
   static Int_t  _printSigDigits ;
 
   friend class RooAbsRealLValue ;
-  virtual void setValFast(Double_t value) { _value = value ; setValueDirty() ; }
+  void setValFast(Double_t value) override { _value = value ; setValueDirty() ; }
 
 
-  virtual Double_t evaluate() const { return _value ; } // dummy because we overloaded getVal()
-  virtual void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) ;
-  virtual void attachToTree(TTree& t, Int_t bufSize=32000) ;
-  virtual void attachToVStore(RooVectorDataStore& vstore) ;
-  virtual void fillTreeBranch(TTree& t) ;
+  Double_t evaluate() const override { return _value ; } // dummy because we overloaded getVal()
+  void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDirty=kTRUE) override ;
+  void attachToTree(TTree& t, Int_t bufSize=32000) override ;
+  void attachToVStore(RooVectorDataStore& vstore) override ;
+  void fillTreeBranch(TTree& t) override ;
 
   Double_t chopAt(Double_t what, Int_t where) const ;
 
@@ -160,13 +160,13 @@ public:
   std::shared_ptr<RooRealVarSharedProperties> sharedProp() const;
   void installSharedProp(std::shared_ptr<RooRealVarSharedProperties>&& prop);
 
-  virtual void setExpensiveObjectCache(RooExpensiveObjectCache&) { ; } ///< variables don't need caches
+  void setExpensiveObjectCache(RooExpensiveObjectCache&) override { ; } ///< variables don't need caches
   static RooRealVarSharedProperties& _nullProp(); ///< Null property
   static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>* sharedPropList(); ///< List of properties shared among clones of a variable
 
   std::shared_ptr<RooRealVarSharedProperties> _sharedProp; ///<! Shared binnings associated with this instance
 
-  ClassDef(RooRealVar,8) // Real-valued variable
+  ClassDefOverride(RooRealVar,8) // Real-valued variable
 };
 
 

--- a/roofit/roofitcore/inc/RooRealVarSharedProperties.h
+++ b/roofit/roofitcore/inc/RooRealVarSharedProperties.h
@@ -45,7 +45,7 @@ public:
   RooRealVarSharedProperties(const char* uuidstr) : RooSharedProperties(uuidstr) {}
 
   /// Destructor
-  virtual ~RooRealVarSharedProperties() {
+  ~RooRealVarSharedProperties() override {
     if (_ownBinnings) {
       for (auto& item : _altBinning) {
         delete item.second;
@@ -63,7 +63,7 @@ protected:
 
   std::unordered_map<std::string,RooAbsBinning*> _altBinning ;  ///< Optional alternative ranges and binnings
   bool _ownBinnings{true}; //!
-  ClassDef(RooRealVarSharedProperties,2) // Shared properties of a RooRealVar clone set
+  ClassDefOverride(RooRealVarSharedProperties,2) // Shared properties of a RooRealVar clone set
 };
 
 

--- a/roofit/roofitcore/inc/RooRecursiveFraction.h
+++ b/roofit/roofitcore/inc/RooRecursiveFraction.h
@@ -27,18 +27,18 @@ public:
 
   RooRecursiveFraction() ;
   RooRecursiveFraction(const char *name, const char *title, const RooArgList& fracSet) ;
-  virtual ~RooRecursiveFraction() ;
+  ~RooRecursiveFraction() override ;
 
   RooRecursiveFraction(const RooRecursiveFraction& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooRecursiveFraction(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooRecursiveFraction(*this, newname); }
 
 protected:
 
   RooListProxy _list ;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooRecursiveFraction,1) // Recursive fraction formula f1*(1-f2)*(1-f3) etc...
+  ClassDefOverride(RooRecursiveFraction,1) // Recursive fraction formula f1*(1-f2)*(1-f3) etc...
 } ;
 
 #endif

--- a/roofit/roofitcore/inc/RooRefCountList.h
+++ b/roofit/roofitcore/inc/RooRefCountList.h
@@ -21,16 +21,16 @@
 class RooRefCountList : public RooLinkedList {
 public:
   RooRefCountList() ; 
-  virtual ~RooRefCountList() {} ;
+  ~RooRefCountList() override {} ;
 
-  virtual void Add(TObject* arg) { Add(arg,1) ; }
-  virtual void Add(TObject* obj, Int_t count) ;
-  virtual Bool_t Remove(TObject* obj) ;
+  void Add(TObject* arg) override { Add(arg,1) ; }
+  void Add(TObject* obj, Int_t count) override ;
+  Bool_t Remove(TObject* obj) override ;
   virtual Bool_t RemoveAll(TObject* obj) ;
   Int_t refCount(TObject* obj) const;
   
 protected:  
-  ClassDef(RooRefCountList,1) // RooLinkedList with reference counting
+  ClassDefOverride(RooRefCountList,1) // RooLinkedList with reference counting
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -30,19 +30,19 @@ public:
   inline RooResolutionModel() : _basis(0) { }
   RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& x) ;
   RooResolutionModel(const RooResolutionModel& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const = 0 ;
-  virtual ~RooResolutionModel();
+  TObject* clone(const char* newname) const override = 0 ;
+  ~RooResolutionModel() override;
 
   virtual RooAbsGenContext* modelGenContext(const RooAbsAnaConvPdf&, const RooArgSet&,
                                             const RooDataSet*, const RooArgSet*,
                                             Bool_t) const { return 0; }
 
-  Double_t getValV(const RooArgSet* nset=0) const ;
+  Double_t getValV(const RooArgSet* nset=0) const override ;
 
   // If used as regular PDF, it also has to be normalized. If this resolution
   // model is used in a convolution, return unnormalized value regardless of
   // specified normalization set.
-  bool selfNormalized() const { return isConvolved() ; }
+  bool selfNormalized() const override { return isConvolved() ; }
 
   virtual RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const ;
   /// Return the convolution variable of the resolution model.
@@ -53,12 +53,12 @@ public:
   virtual Int_t basisCode(const char* name) const = 0 ;
 
   virtual void normLeafServerList(RooArgSet& list) const ;
-  Double_t getNorm(const RooArgSet* nset=0) const ;
+  Double_t getNorm(const RooArgSet* nset=0) const override ;
 
   inline const RooFormulaVar& basis() const { return _basis?*_basis:*identity() ; }
   Bool_t isConvolved() const { return _basis ? true : false ; }
 
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
   static RooFormulaVar* identity() ;
 
@@ -70,7 +70,7 @@ protected:
   friend class RooAddModel ;
   RooTemplateProxy<RooAbsRealLValue> x;                   ///< Dependent/convolution variable
 
-  virtual Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) ;
+  Bool_t redirectServersHook(const RooAbsCollection& newServerList, Bool_t mustReplaceAll, Bool_t nameChange, Bool_t isRecursive) override ;
 
   friend class RooAbsAnaConvPdf ;
 
@@ -78,7 +78,7 @@ protected:
   RooFormulaVar* _basis ;    ///< Basis function convolved with this resolution model
   Bool_t _ownBasis ;         ///< Flag indicating ownership of _basis
 
-  ClassDef(RooResolutionModel, 2) // Abstract Resolution Model
+  ClassDefOverride(RooResolutionModel, 2) // Abstract Resolution Model
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooScaledFunc.h
+++ b/roofit/roofitcore/inc/RooScaledFunc.h
@@ -23,15 +23,15 @@ class RooScaledFunc : public RooAbsFunc {
 public:
   inline RooScaledFunc(const RooAbsFunc &func, Double_t scaleFactor) :
     RooAbsFunc(func.getDimension()), _func(&func), _scaleFactor(scaleFactor) { }
-  inline virtual ~RooScaledFunc() { }
+  inline ~RooScaledFunc() override { }
 
-  inline virtual Double_t operator()(const Double_t xvector[]) const {
+  inline Double_t operator()(const Double_t xvector[]) const override {
     return _scaleFactor*(*_func)(xvector);
   }
-  inline virtual Double_t getMinLimit(UInt_t index) const { return _func->getMinLimit(index); }
-  inline virtual Double_t getMaxLimit(UInt_t index) const { return _func->getMaxLimit(index); }
+  inline Double_t getMinLimit(UInt_t index) const override { return _func->getMinLimit(index); }
+  inline Double_t getMaxLimit(UInt_t index) const override { return _func->getMaxLimit(index); }
 
-  virtual std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const {
+  std::list<Double_t>* plotSamplingHint(RooAbsRealLValue& obs, Double_t xlo, Double_t xhi) const override {
     return _func->plotSamplingHint(obs,xlo,xhi) ; 
   }
 
@@ -39,7 +39,7 @@ protected:
   const RooAbsFunc *_func;
   Double_t _scaleFactor;
 
-  ClassDef(RooScaledFunc,0) // Function binding applying scaling to another function binding
+  ClassDefOverride(RooScaledFunc,0) // Function binding applying scaling to another function binding
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSecondMoment.h
+++ b/roofit/roofitcore/inc/RooSecondMoment.h
@@ -30,10 +30,10 @@ public:
   RooSecondMoment() ;
   RooSecondMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, Bool_t central=kFALSE, Bool_t takeRoot=kFALSE) ;
   RooSecondMoment(const char *name, const char *title, RooAbsReal& func, RooRealVar& x, const RooArgSet& nset, Bool_t central=kFALSE, Bool_t takeRoot=kFALSE, Bool_t intNSet=kFALSE) ;
-  virtual ~RooSecondMoment() ;
+  ~RooSecondMoment() override ;
 
   RooSecondMoment(const RooSecondMoment& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooSecondMoment(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooSecondMoment(*this, newname); }
 
   const RooAbsReal& xF() { return _xf.arg() ; }
   const RooAbsReal& ixF() { return _ixf.arg() ; }
@@ -45,9 +45,9 @@ protected:
   RooRealProxy _ixf ;                    ///< Int((X-offset)*F(X))dx ;
   RooRealProxy _if ;                     ///< Int(F(x))dx ;
   Double_t _xfOffset ;                   ///< offset
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooSecondMoment,1) // Representation of moment in a RooAbsReal in a given RooRealVar
+  ClassDefOverride(RooSecondMoment,1) // Representation of moment in a RooAbsReal in a given RooRealVar
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSegmentedIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooSegmentedIntegrator1D.h
@@ -28,20 +28,20 @@ public:
   RooSegmentedIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooSegmentedIntegrator1D(const RooAbsFunc& function, Double_t xmin, Double_t xmax, const RooNumIntConfig& config) ;
 
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooSegmentedIntegrator1D();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooSegmentedIntegrator1D() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t *yvec=0) ;
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t *yvec=0) override ;
 
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t *xmin, Double_t *xmax);
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) { _useIntegrandLimits = flag ; return kTRUE ; }
+  Bool_t setLimits(Double_t *xmin, Double_t *xmax) override;
+  Bool_t setUseIntegrandLimits(Bool_t flag) override { _useIntegrandLimits = flag ; return kTRUE ; }
 
-  virtual Bool_t canIntegrate1D() const { return kTRUE ; }
-  virtual Bool_t canIntegrate2D() const { return kFALSE ; }
-  virtual Bool_t canIntegrateND() const { return kFALSE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kTRUE ; }
+  Bool_t canIntegrate2D() const override { return kFALSE ; }
+  Bool_t canIntegrateND() const override { return kFALSE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
 protected:
 
@@ -60,7 +60,7 @@ protected:
 
   Bool_t initialize();
 
-  ClassDef(RooSegmentedIntegrator1D,0) // 1-dimensional piece-wise numerical integration engine
+  ClassDefOverride(RooSegmentedIntegrator1D,0) // 1-dimensional piece-wise numerical integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSegmentedIntegrator2D.h
+++ b/roofit/roofitcore/inc/RooSegmentedIntegrator2D.h
@@ -29,15 +29,15 @@ public:
   RooSegmentedIntegrator2D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooSegmentedIntegrator2D(const RooAbsFunc& function, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax,
         const RooNumIntConfig& config) ;
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooSegmentedIntegrator2D() ;
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooSegmentedIntegrator2D() override ;
 
-  virtual Bool_t checkLimits() const;
+  Bool_t checkLimits() const override;
 
-  virtual Bool_t canIntegrate1D() const { return kFALSE ; }
-  virtual Bool_t canIntegrate2D() const { return kTRUE ; }
-  virtual Bool_t canIntegrateND() const { return kFALSE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kFALSE ; }
+  Bool_t canIntegrate1D() const override { return kFALSE ; }
+  Bool_t canIntegrate2D() const override { return kTRUE ; }
+  Bool_t canIntegrateND() const override { return kFALSE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kFALSE ; }
 
 protected:
 
@@ -47,7 +47,7 @@ protected:
   RooSegmentedIntegrator1D* _xIntegrator ;
   RooAbsFunc* _xint ;
 
-  ClassDef(RooSegmentedIntegrator2D,0) // 2-dimensional piece-wise numerical integration engine
+  ClassDefOverride(RooSegmentedIntegrator2D,0) // 2-dimensional piece-wise numerical integration engine
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSetProxy.h
+++ b/roofit/roofitcore/inc/RooSetProxy.h
@@ -37,27 +37,27 @@ public:
   RooSetProxy(const char* name, const char* desc, RooAbsArg* owner,
          Bool_t defValueServer=kTRUE, Bool_t defShapeServer=kFALSE) ;
   RooSetProxy(const char* name, RooAbsArg* owner, const RooSetProxy& other) ;
-  virtual ~RooSetProxy() ;
+  ~RooSetProxy() override ;
 
-  virtual const char* name() const override { return GetName() ; }
+  const char* name() const override { return GetName() ; }
 
   // List content management (modified for server hooks)
   using RooAbsCollection::add;
-  virtual Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
+  Bool_t add(const RooAbsArg& var, Bool_t silent=kFALSE) override;
   virtual Bool_t add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent) ;
 
   using RooAbsCollection::addOwned;
-  virtual Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
+  Bool_t addOwned(RooAbsArg& var, Bool_t silent=kFALSE) override;
 
   using RooAbsCollection::addClone;
-  virtual RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) override;
+  RooAbsArg *addClone(const RooAbsArg& var, Bool_t silent=kFALSE) override;
 
-  virtual Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) override;
-  virtual Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) override;
+  Bool_t replace(const RooAbsArg& var1, const RooAbsArg& var2) override;
+  Bool_t remove(const RooAbsArg& var, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) override;
   Bool_t remove(const RooAbsCollection& list, Bool_t silent=kFALSE, Bool_t matchByNameOnly=kFALSE) ;
-  virtual void removeAll() override;
+  void removeAll() override;
 
-  virtual void print(std::ostream& os, Bool_t addContents=kFALSE) const override;
+  void print(std::ostream& os, Bool_t addContents=kFALSE) const override;
 
   RooSetProxy& operator=(const RooArgSet& other) ;
 
@@ -67,7 +67,7 @@ protected:
   Bool_t _defValueServer ;
   Bool_t _defShapeServer ;
 
-  virtual Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
+  Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
 
   ClassDefOverride(RooSetProxy,1) // Proxy class for a RooArgSet
 };

--- a/roofit/roofitcore/inc/RooSharedProperties.h
+++ b/roofit/roofitcore/inc/RooSharedProperties.h
@@ -25,7 +25,7 @@ public:
 
   RooSharedProperties() ;
   RooSharedProperties(const char* uuidstr) ;
-  virtual ~RooSharedProperties() ;
+  ~RooSharedProperties() override ;
   Bool_t operator==(const RooSharedProperties& other) const ;
 
   // Copying and moving is disabled for RooSharedProperties and derived classes
@@ -36,7 +36,7 @@ public:
   RooSharedProperties(RooSharedProperties &&) = delete;
   RooSharedProperties& operator=(RooSharedProperties &&) = delete;
 
-  virtual void Print(Option_t* opts=0) const ;
+  void Print(Option_t* opts=0) const override ;
 
   void increaseRefCount() { _refCount++ ; }
   void decreaseRefCount() { if (_refCount>0) _refCount-- ; }
@@ -53,7 +53,7 @@ protected:
   Int_t _refCount ; ///<! Use count
   Int_t _inSharedList ; ///<! Is in shared list
 
-  ClassDef(RooSharedProperties,1) // Abstract interface for shared property implementations
+  ClassDefOverride(RooSharedProperties,1) // Abstract interface for shared property implementations
 };
 
 

--- a/roofit/roofitcore/inc/RooSimGenContext.h
+++ b/roofit/roofitcore/inc/RooSimGenContext.h
@@ -28,20 +28,20 @@ class RooSimGenContext : public RooAbsGenContext {
 public:
   RooSimGenContext(const RooSimultaneous &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
                    const RooArgSet* auxProto=0, Bool_t _verbose= kFALSE);
-  virtual ~RooSimGenContext();
-  virtual void setProtoDataOrder(Int_t* lut) ;
+  ~RooSimGenContext() override;
+  void setProtoDataOrder(Int_t* lut) override ;
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
 
 protected:
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
-  RooDataSet* createDataSet(const char* name, const char* title, const RooArgSet& obs) ;
+  RooDataSet* createDataSet(const char* name, const char* title, const RooArgSet& obs) override ;
   void updateFractions() ;
 
   RooSimGenContext(const RooSimGenContext& other) ;
@@ -61,7 +61,7 @@ protected:
   RooArgSet _allVarsPdf{};        ///< All pdf variables
   TIterator* _proxyIter{nullptr}; ///< Iterator over pdf proxies
 
-  ClassDef(RooSimGenContext,0) // Context for efficiently generating a dataset from a RooSimultaneous PDF
+  ClassDefOverride(RooSimGenContext,0) // Context for efficiently generating a dataset from a RooSimultaneous PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSimPdfBuilder.h
+++ b/roofit/roofitcore/inc/RooSimPdfBuilder.h
@@ -33,7 +33,7 @@ class RooSimPdfBuilder : public TObject {
 public:
 
   RooSimPdfBuilder(const RooArgSet& pdfProtoList) ;
-  ~RooSimPdfBuilder() ;
+  ~RooSimPdfBuilder() override ;
 
   RooArgSet* createProtoBuildConfig() ;
 
@@ -76,7 +76,7 @@ private:
   RooSimPdfBuilder(const RooSimPdfBuilder&) ; // No copying allowed
 
 protected:
-  ClassDef(RooSimPdfBuilder,0) // RooSimultaneous PDF Builder (obsolete)
+  ClassDefOverride(RooSimPdfBuilder,0) // RooSimultaneous PDF Builder (obsolete)
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSimSplitGenContext.h
+++ b/roofit/roofitcore/inc/RooSimSplitGenContext.h
@@ -27,23 +27,23 @@ class RooAbsCategoryLValue ;
 class RooSimSplitGenContext : public RooAbsGenContext {
 public:
   RooSimSplitGenContext(const RooSimultaneous &model, const RooArgSet &vars, Bool_t _verbose= kFALSE, Bool_t autoBinned=kTRUE, const char* binnedTag="");
-  virtual ~RooSimSplitGenContext();
-  virtual void setProtoDataOrder(Int_t* lut) ;
+  ~RooSimSplitGenContext() override;
+  void setProtoDataOrder(Int_t* lut) override ;
 
-  virtual void attach(const RooArgSet& params) ;
+  void attach(const RooArgSet& params) override ;
 
-  virtual void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream &os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  virtual RooDataSet *generate(Double_t nEvents= 0, Bool_t skipInit=kFALSE, Bool_t extendedMode=kFALSE);
+  RooDataSet *generate(Double_t nEvents= 0, Bool_t skipInit=kFALSE, Bool_t extendedMode=kFALSE) override;
 
-  virtual void setExpectedData(Bool_t) ;
+  void setExpectedData(Bool_t) override ;
 
 protected:
 
-  virtual void initGenerator(const RooArgSet &theEvent);
-  virtual void generateEvent(RooArgSet &theEvent, Int_t remaining);
+  void initGenerator(const RooArgSet &theEvent) override;
+  void generateEvent(RooArgSet &theEvent, Int_t remaining) override;
 
-  RooDataSet* createDataSet(const char* name, const char* title, const RooArgSet& obs) ;
+  RooDataSet* createDataSet(const char* name, const char* title, const RooArgSet& obs) override ;
 
   RooSimSplitGenContext(const RooSimSplitGenContext& other) ;
 
@@ -59,7 +59,7 @@ protected:
   RooArgSet _allVarsPdf ; ///< All pdf variables
   TIterator* _proxyIter ; ///< Iterator over pdf proxies
 
-  ClassDef(RooSimSplitGenContext,0) // Context for efficiently generating a dataset from a RooSimultaneous PDF
+  ClassDefOverride(RooSimSplitGenContext,0) // Context for efficiently generating a dataset from a RooSimultaneous PDF
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooSimWSTool.h
+++ b/roofit/roofitcore/inc/RooSimWSTool.h
@@ -40,7 +40,7 @@ public:
 
   // Constructors, assignment etc
   RooSimWSTool(RooWorkspace& ws) ;
-  virtual ~RooSimWSTool() ;
+  ~RooSimWSTool() override ;
 
   class BuildConfig ;
   class MultiBuildConfig ;
@@ -58,8 +58,8 @@ public:
 
   class SimWSIFace : public RooFactoryWSTool::IFace {
   public:
-    virtual ~SimWSIFace() {} ;
-    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) ;
+    ~SimWSIFace() override {} ;
+    std::string create(RooFactoryWSTool& ft, const char* typeName, const char* instanceName, std::vector<std::string> args) override ;
   } ;
 
 
@@ -73,14 +73,14 @@ protected:
 
   RooWorkspace* _ws ;
 
-  ClassDef(RooSimWSTool,0) // Workspace oriented tool for customized cloning of p.d.f. into a simultaneous p.d.f
+  ClassDefOverride(RooSimWSTool,0) // Workspace oriented tool for customized cloning of p.d.f. into a simultaneous p.d.f
 } ;
 
 
 class RooSimWSTool::SplitRule : public TNamed {
 public:
    SplitRule(const char* pdfName="") : TNamed(pdfName,pdfName) {} ;
-   virtual ~SplitRule() {} ;
+   ~SplitRule() override {} ;
    void splitParameter(const char* paramList, const char* categoryList) ;
    void splitParameterConstrained(const char* paramNameList, const char* categoryNameList, const char* remainderStateName) ;
 
@@ -95,7 +95,7 @@ protected:
 
    std::list<std::string>                                             _miStateNameList ;
    std::map<std::string, std::pair<std::list<std::string>,std::string> > _paramSplitMap  ; //<paramName,<std::list<splitCatSet>,remainderStateName>>
-   ClassDef(SplitRule,0) // Split rule specification for prototype p.d.f
+   ClassDefOverride(SplitRule,0) // Split rule specification for prototype p.d.f
 } ;
 
 
@@ -130,7 +130,7 @@ class RooSimWSTool::MultiBuildConfig : public RooSimWSTool::BuildConfig
 {
  public:
   MultiBuildConfig(const char* masterIndexCat)  ;
-  virtual ~MultiBuildConfig() {} ;
+  ~MultiBuildConfig() override {} ;
   void addPdf(const char* miStateList, const char* pdfName, SplitRule& sr) ;
   void addPdf(const char* miStateList, const char* pdfName,
          const RooCmdArg& arg1=RooCmdArg::none(),const RooCmdArg& arg2=RooCmdArg::none(),
@@ -140,7 +140,7 @@ class RooSimWSTool::MultiBuildConfig : public RooSimWSTool::BuildConfig
  protected:
   friend class RooSimWSTool ;
 
-  ClassDef(MultiBuildConfig,0) // Build configuration object for RooSimWSTool with multiple prototype p.d.f.
+  ClassDefOverride(MultiBuildConfig,0) // Build configuration object for RooSimWSTool with multiple prototype p.d.f.
  } ;
 
 

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -43,31 +43,31 @@ public:
   RooSimultaneous(const char *name, const char *title, std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;
   RooSimultaneous(const char *name, const char *title, const RooArgList& pdfList, RooAbsCategoryLValue& indexCat) ;
   RooSimultaneous(const RooSimultaneous& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooSimultaneous(*this,newname) ; }
-  virtual ~RooSimultaneous() ;
+  TObject* clone(const char* newname) const override { return new RooSimultaneous(*this,newname) ; }
+  ~RooSimultaneous() override ;
 
-  virtual Double_t evaluate() const ;
-  virtual Bool_t selfNormalized() const { return kTRUE ; }
+  Double_t evaluate() const override ;
+  Bool_t selfNormalized() const override { return kTRUE ; }
   Bool_t addPdf(const RooAbsPdf& pdf, const char* catLabel) ;
 
-  virtual ExtendMode extendMode() const ;
+  ExtendMode extendMode() const override ;
 
-  virtual Double_t expectedEvents(const RooArgSet* nset) const ;
+  Double_t expectedEvents(const RooArgSet* nset) const override ;
 
-  virtual Bool_t forceAnalyticalInt(const RooAbsArg&) const { return kTRUE ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
+  Bool_t forceAnalyticalInt(const RooAbsArg&) const override { return kTRUE ; }
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
 
   using RooAbsPdf::plotOn ;
-  virtual RooPlot* plotOn(RooPlot* frame,
+  RooPlot* plotOn(RooPlot* frame,
            const RooCmdArg& arg1            , const RooCmdArg& arg2=RooCmdArg(),
            const RooCmdArg& arg3=RooCmdArg(), const RooCmdArg& arg4=RooCmdArg(),
            const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
            const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg(),
-           const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const {
+           const RooCmdArg& arg9=RooCmdArg(), const RooCmdArg& arg10=RooCmdArg()) const override {
     return RooAbsReal::plotOn(frame,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9,arg10) ;
   }
-  virtual RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const ;
+  RooPlot* plotOn(RooPlot* frame, RooLinkedList& cmdList) const override ;
 
   // Backward compatibility function
   virtual RooPlot *plotOn(RooPlot *frame, Option_t* drawOptions, Double_t scaleFactor=1.0,
@@ -79,7 +79,7 @@ public:
   const RooAbsCategoryLValue& indexCat() const { return (RooAbsCategoryLValue&) _indexCat.arg() ; }
 
 
-  virtual RooDataSet* generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) ;
+  RooDataSet* generateSimGlobal(const RooArgSet& whatVars, Int_t nEvents) override ;
 
   virtual RooDataHist* fillDataHist(RooDataHist *hist, const RooArgSet* nset, Double_t scaleFactor,
                 Bool_t correctForBinVolume=kFALSE, Bool_t showProgress=kFALSE) const ;
@@ -93,15 +93,15 @@ protected:
 
   void initialize(RooAbsCategoryLValue& inIndexCat, std::map<std::string,RooAbsPdf*> pdfMap) ;
 
-  virtual void selectNormalization(const RooArgSet* depSet=0, Bool_t force=kFALSE) ;
-  virtual void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) ;
+  void selectNormalization(const RooArgSet* depSet=0, Bool_t force=kFALSE) override ;
+  void selectNormalizationRange(const char* rangeName=0, Bool_t force=kFALSE) override ;
   mutable RooSetProxy _plotCoefNormSet ;
   const TNamed* _plotCoefNormRange ;
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    virtual ~CacheElem() {} ;
-    RooArgList containedArgs(Action) { return RooArgList(_partIntList) ; }
+    ~CacheElem() override {} ;
+    RooArgList containedArgs(Action) override { return RooArgList(_partIntList) ; }
     RooArgList _partIntList ;
   } ;
   mutable RooObjCacheManager _partIntMgr ; ///<! Component normalization manager
@@ -109,16 +109,16 @@ protected:
 
   friend class RooSimGenContext ;
   friend class RooSimSplitGenContext ;
-  virtual RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0,
-                  Bool_t verbose=kFALSE, Bool_t autoBinned=kTRUE, const char* binnedTag="") const ;
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                  const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const ;
+  RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0,
+                  Bool_t verbose=kFALSE, Bool_t autoBinned=kTRUE, const char* binnedTag="") const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
+                                  const RooArgSet* auxProto=0, Bool_t verbose= kFALSE) const override ;
 
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)
   Int_t    _numPdf ;           ///< Number of registered PDFs
 
-  ClassDef(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
+  ClassDefOverride(RooSimultaneous,3)  // Simultaneous operator p.d.f, functions like C++  'switch()' on input p.d.fs operating on index category5A
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -26,8 +26,8 @@ public:
   RooStringVar() { }
   RooStringVar(const char *name, const char *title, const char* value, Int_t size=1024) ;
   RooStringVar(const RooStringVar& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const override { return new RooStringVar(*this,newname); }
-  virtual ~RooStringVar() = default;
+  TObject* clone(const char* newname) const override { return new RooStringVar(*this,newname); }
+  ~RooStringVar() override = default;
 
   // Parameter value and error accessors
   virtual operator TString() {return TString(_string.c_str()); }
@@ -51,7 +51,7 @@ public:
   bool isIdentical(const RooAbsArg& other, Bool_t /*assumeSameType*/) const override { return *this == other; }
 
   // Printing interface (human readable)
-  virtual void printValue(std::ostream& os) const override { os << _string; }
+  void printValue(std::ostream& os) const override { os << _string; }
 
 
   RooAbsArg *createFundamental(const char* newname=0) const override {
@@ -60,15 +60,15 @@ public:
 
 protected:
   // Internal consistency checking (needed by RooDataSet)
-  virtual Bool_t isValid() const override { return true; }
+  Bool_t isValid() const override { return true; }
   virtual Bool_t isValidString(const char*, Bool_t /*printError=kFALSE*/) const { return true; }
 
-  virtual void syncCache(const RooArgSet* /*nset*/ = nullptr) override { }
+  void syncCache(const RooArgSet* /*nset*/ = nullptr) override { }
   void copyCache(const RooAbsArg* source, Bool_t valueOnly=kFALSE, Bool_t setValDiry=kTRUE) override;
-  virtual void attachToTree(TTree& t, Int_t bufSize=32000) override;
-  virtual void attachToVStore(RooVectorDataStore&) override { }
-  virtual void fillTreeBranch(TTree& t) override;
-  virtual void setTreeBranchStatus(TTree& t, Bool_t active) override;
+  void attachToTree(TTree& t, Int_t bufSize=32000) override;
+  void attachToVStore(RooVectorDataStore&) override { }
+  void fillTreeBranch(TTree& t) override;
+  void setTreeBranchStatus(TTree& t, Bool_t active) override;
 
 private:
   std::string _string;

--- a/roofit/roofitcore/inc/RooStudyManager.h
+++ b/roofit/roofitcore/inc/RooStudyManager.h
@@ -61,7 +61,7 @@ protected:
 
   RooStudyManager(const RooStudyManager&) ;
 
-  ClassDef(RooStudyManager,1) // A general purpose workspace oriented parallelizing study manager
+  ClassDefOverride(RooStudyManager,1) // A general purpose workspace oriented parallelizing study manager
 } ;
 
 

--- a/roofit/roofitcore/inc/RooStudyPackage.h
+++ b/roofit/roofitcore/inc/RooStudyPackage.h
@@ -35,7 +35,7 @@ public:
   RooStudyPackage(RooWorkspace& w) ;
   RooStudyPackage(const RooStudyPackage&) ;
   void addStudy(RooAbsStudy& study) ;
-  TObject* Clone(const char* /*newname*/="") const { return new RooStudyPackage(*this) ; }
+  TObject* Clone(const char* /*newname*/="") const override { return new RooStudyPackage(*this) ; }
 
   RooWorkspace& wspace() { return *_ws ; }
   std::list<RooAbsStudy*>& studies() { return _studies ; }
@@ -58,7 +58,7 @@ protected:
   std::list<RooAbsStudy*> _studies ;
 
 
-  ClassDef(RooStudyPackage,1) // A general purpose workspace oriented parallelizing study manager
+  ClassDefOverride(RooStudyPackage,1) // A general purpose workspace oriented parallelizing study manager
 } ;
 
 

--- a/roofit/roofitcore/inc/RooSuperCategory.h
+++ b/roofit/roofitcore/inc/RooSuperCategory.h
@@ -30,23 +30,23 @@ public:
   RooSuperCategory();
   RooSuperCategory(const char *name, const char *title, const RooArgSet& inputCatList);
   RooSuperCategory(const RooSuperCategory& other, const char *name=0) ;
-  virtual TObject* clone(const char* newname) const override { return new RooSuperCategory(*this,newname); }
-  virtual ~RooSuperCategory() { };
+  TObject* clone(const char* newname) const override { return new RooSuperCategory(*this,newname); }
+  ~RooSuperCategory() override { };
 
-  virtual bool setIndex(value_type index, bool printError = true) override ;
+  bool setIndex(value_type index, bool printError = true) override ;
   using RooAbsCategoryLValue::setIndex;
-  virtual Bool_t setLabel(const char* label, Bool_t printError=kTRUE) override;
+  Bool_t setLabel(const char* label, Bool_t printError=kTRUE) override;
   using RooAbsCategoryLValue::setLabel;
 
   // Printing interface (human readable)
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override;
 
   /// \deprecated Use begin(), end() or range-based for loops to iterate through state names.
   TIterator* MakeIterator() const ;
   const RooArgSet& inputCatList() const { return _multiCat->inputCatList(); }
 
-  virtual Bool_t inRange(const char* rangeName) const override;
-  virtual Bool_t hasRange(const char* rangeName) const override;
+  Bool_t inRange(const char* rangeName) const override;
+  Bool_t hasRange(const char* rangeName) const override;
 
 protected:
   value_type evaluate() const override {

--- a/roofit/roofitcore/inc/RooTFoamBinding.h
+++ b/roofit/roofitcore/inc/RooTFoamBinding.h
@@ -24,9 +24,9 @@ class RooAbsPdf ;
 class RooTFoamBinding : public TFoamIntegrand {
 public:
   RooTFoamBinding(const RooAbsReal& pdf, const RooArgSet& observables) ;
-  virtual ~RooTFoamBinding();
+  ~RooTFoamBinding() override;
 
-  virtual Double_t Density(Int_t ndim, Double_t *) ;
+  Double_t Density(Int_t ndim, Double_t *) override ;
   
   RooRealBinding& binding() { return *_binding ; }
 
@@ -35,7 +35,7 @@ protected:
   RooArgSet       _nset ;
   RooRealBinding* _binding ;
 
-  ClassDef(RooTFoamBinding,0) // Function binding to RooAbsReal object
+  ClassDefOverride(RooTFoamBinding,0) // Function binding to RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooTObjWrap.h
+++ b/roofit/roofitcore/inc/RooTObjWrap.h
@@ -26,7 +26,7 @@ public:
   RooTObjWrap(Bool_t isArray=kFALSE) : _isArray(isArray), _owning(kFALSE) {} ;
   RooTObjWrap(TObject* inObj, Bool_t isArray=kFALSE) : TNamed(), _isArray(isArray), _owning(kFALSE) { if (inObj) _list.Add(inObj) ; } 
   RooTObjWrap(const RooTObjWrap& other) : TNamed(other),  _isArray(other._isArray), _owning(kFALSE), _list(other._list) {}
-  virtual ~RooTObjWrap() { if (_owning) _list.Delete() ; } ;
+  ~RooTObjWrap() override { if (_owning) _list.Delete() ; } ;
 
   void setOwning(Bool_t flag) { _owning = flag ; }
   TObject* obj() const { return _list.At(0) ; }
@@ -44,7 +44,7 @@ protected:
   Bool_t _isArray ;
   Bool_t _owning ;
   RooLinkedList _list ;
-  ClassDef(RooTObjWrap,2) // Container class for Int_t
+  ClassDefOverride(RooTObjWrap,2) // Container class for Int_t
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooTable.h
+++ b/roofit/roofitcore/inc/RooTable.h
@@ -25,7 +25,7 @@ public:
 
   // Constructors, cloning and assignment
   RooTable() {} ;
-  virtual ~RooTable() ;
+  ~RooTable() override ;
   RooTable(const char *name, const char *title);
   RooTable(const RooTable& other) ;
 
@@ -35,7 +35,7 @@ public:
 
 protected:
 
-  ClassDef(RooTable,1) // Abstract interface for tables
+  ClassDefOverride(RooTable,1) // Abstract interface for tables
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -71,7 +71,7 @@ and increment the class version of the owner.
 // In .h: Declare member
 RooRealProxy pdfProxy;
 
-ClassDef(MyPdf, 1)
+ClassDefOverride(MyPdf, 1)
 };
 
 // In .cxx: Initialise proxy in constructor
@@ -94,7 +94,7 @@ pdf->fitTo(...);
 // In .h: Declare member
 RooTemplateProxy<RooAbsPdf> pdfProxy;
 
-ClassDef(MyPdf, 2)
+ClassDefOverride(MyPdf, 2)
 };
 
 // In .cxx: Initialise proxy in constructor
@@ -201,7 +201,7 @@ public:
     }
   }
 
-  virtual TObject* Clone(const char* newName=0) const { return new RooTemplateProxy<T>(newName,_owner,*this); }
+  TObject* Clone(const char* newName=0) const override { return new RooTemplateProxy<T>(newName,_owner,*this); }
 
 
   /// Return reference to the proxied object.
@@ -369,7 +369,7 @@ private:
     return real.getVal(_nset);
   }
 
-  ClassDef(RooTemplateProxy,1) // Proxy for a RooAbsReal object
+  ClassDefOverride(RooTemplateProxy,1) // Proxy for a RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooThresholdCategory.h
+++ b/roofit/roofitcore/inc/RooThresholdCategory.h
@@ -31,15 +31,15 @@ public:
   RooThresholdCategory(const char *name, const char *title, RooAbsReal& inputVar,
       const char* defCatName="Default", Int_t defCatIdx=0);
   RooThresholdCategory(const RooThresholdCategory& other, const char *name=0) ;
-  virtual TObject* clone(const char* newname) const { return new RooThresholdCategory(*this, newname); }
+  TObject* clone(const char* newname) const override { return new RooThresholdCategory(*this, newname); }
 
   // Mapping function
   Bool_t addThreshold(Double_t upperLimit, const char* catName, Int_t catIdx=-99999) ;
 
   // Printing interface (human readable)
-  virtual void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const ;
+  void printMultiline(std::ostream& os, Int_t content, Bool_t verbose=kFALSE, TString indent="") const override ;
 
-  void writeToStream(std::ostream& os, Bool_t compact) const ;
+  void writeToStream(std::ostream& os, Bool_t compact) const override ;
 
 protected:
 
@@ -47,11 +47,11 @@ protected:
   const value_type _defIndex{std::numeric_limits<value_type>::min()};
   std::vector<std::pair<double,value_type>> _threshList;
 
-  virtual value_type evaluate() const ;
+  value_type evaluate() const override ;
   /// No shape recomputation is necessary. This category does not depend on other categories.
-  void recomputeShape() { }
+  void recomputeShape() override { }
 
-  ClassDef(RooThresholdCategory, 3) // Real-to-Category function defined by series of thresholds
+  ClassDefOverride(RooThresholdCategory, 3) // Real-to-Category function defined by series of thresholds
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -40,8 +40,8 @@ public:
 
   // Empty ctor
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
-  virtual RooAbsDataStore* clone(const char* newname=0) const { return new RooTreeDataStore(*this,newname) ; }
-  virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const { return new RooTreeDataStore(*this,vars,newname) ; }
+  RooAbsDataStore* clone(const char* newname=0) const override { return new RooTreeDataStore(*this,newname) ; }
+  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooTreeDataStore(*this,vars,newname) ; }
 
   // Ctors from TTree
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ;
@@ -57,56 +57,56 @@ public:
 
   RooTreeDataStore(const RooTreeDataStore& other, const char* newname=0) ;
   RooTreeDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
-  virtual ~RooTreeDataStore() ;
+  ~RooTreeDataStore() override ;
 
 
   // Write current row
-  virtual Int_t fill() ;
+  Int_t fill() override ;
 
   // Retrieve a row
   using RooAbsDataStore::get ;
-  virtual const RooArgSet* get(Int_t index) const ;
+  const RooArgSet* get(Int_t index) const override ;
   using RooAbsDataStore::weight ;
-  virtual Double_t weight() const ;
-  virtual Double_t weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const ;
-  virtual void weightError(Double_t& lo, Double_t& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const ;
-  virtual Bool_t isWeighted() const { return (_wgtVar!=0||_extWgtArray!=0) ; }
+  Double_t weight() const override ;
+  Double_t weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const override ;
+  void weightError(Double_t& lo, Double_t& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const override ;
+  Bool_t isWeighted() const override { return (_wgtVar!=0||_extWgtArray!=0) ; }
 
-  virtual RooBatchCompute::RunContext getBatches(std::size_t first, std::size_t len) const {
+  RooBatchCompute::RunContext getBatches(std::size_t first, std::size_t len) const override {
     //TODO
     std::cerr << "This functionality is not yet implemented for tree data stores." << std::endl;
     throw std::logic_error("getBatches() not implemented in RooTreeDataStore.");
     (void)first; (void)len;
     return {};
   }
-  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const;
+  RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
 
   // Change observable name
-  virtual Bool_t changeObservableName(const char* from, const char* to) ;
+  Bool_t changeObservableName(const char* from, const char* to) override ;
 
   // Add one or more columns
-  virtual RooAbsArg* addColumn(RooAbsArg& var, Bool_t adjustRange=kTRUE) ;
-  virtual RooArgSet* addColumns(const RooArgList& varList) ;
+  RooAbsArg* addColumn(RooAbsArg& var, Bool_t adjustRange=kTRUE) override ;
+  RooArgSet* addColumns(const RooArgList& varList) override ;
 
   // Merge column-wise
-  RooAbsDataStore* merge(const RooArgSet& allvars, std::list<RooAbsDataStore*> dstoreList) ;
+  RooAbsDataStore* merge(const RooArgSet& allvars, std::list<RooAbsDataStore*> dstoreList) override ;
 
   // Add rows
-  virtual void append(RooAbsDataStore& other) ;
+  void append(RooAbsDataStore& other) override ;
 
   // General & bookkeeping methods
-  virtual Double_t sumEntries() const ;
-  virtual Int_t numEntries() const ;
-  virtual void reset() ;
+  Double_t sumEntries() const override ;
+  Int_t numEntries() const override ;
+  void reset() override ;
 
   // Buffer redirection routines used in inside RooAbsOptTestStatistics
-  virtual void attachBuffers(const RooArgSet& extObs) ;
-  virtual void resetBuffers() ;
+  void attachBuffers(const RooArgSet& extObs) override ;
+  void resetBuffers() override ;
   void restoreAlternateBuffers() ;
 
   // Tree access
   TTree& tree() { return *_tree ; }
-  virtual const TTree* tree() const { return _tree ; }
+  const TTree* tree() const override { return _tree ; }
 
   // Forwarded from TTree
   Stat_t GetEntries() const;
@@ -114,22 +114,22 @@ public:
   Int_t Fill();
   Int_t GetEntry(Int_t entry = 0, Int_t getall = 0);
 
-  void   Draw(Option_t* option = "") ;
+  void   Draw(Option_t* option = "") override ;
 
   // Constant term  optimizer interface
-  virtual void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, Bool_t skipZeroWeights=kFALSE) ;
-  virtual const RooAbsArg* cacheOwner() { return _cacheOwner ; }
-  virtual void setArgStatus(const RooArgSet& set, Bool_t active) ;
-  virtual void resetCache() ;
+  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, Bool_t skipZeroWeights=kFALSE) override ;
+  const RooAbsArg* cacheOwner() override { return _cacheOwner ; }
+  void setArgStatus(const RooArgSet& set, Bool_t active) override ;
+  void resetCache() override ;
 
   void loadValues(const TTree *t, const RooFormulaVar* select=0, const char* rangeName=0, Int_t nStart=0, Int_t nStop=2000000000)  ;
   void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=0, const char* rangeName=0,
-      std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max());
+      std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
 
-  virtual void checkInit() const;
+  void checkInit() const override;
 
   void setExternalWeightArray(const Double_t* arrayWgt, const Double_t* arrayWgtErrLo,
-      const Double_t* arrayWgtErrHi, const Double_t* arraySumW2) {
+      const Double_t* arrayWgtErrHi, const Double_t* arraySumW2) override {
     _extWgtArray = arrayWgt ;
     _extWgtErrLoArray = arrayWgtErrLo ;
     _extWgtErrHiArray = arrayWgtErrHi ;
@@ -146,7 +146,7 @@ public:
   RooRealVar* weightVar(const RooArgSet& allVars, const char* wgtName=0) ;
 
   void initialize();
-  void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
+  void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override ;
 
   // TTree Branch buffer size control
   void setBranchBufferSize(Int_t size) { _defTreeBufSize = size ; }
@@ -178,7 +178,7 @@ public:
 
   RooArgSet _attachedBuffers ; ///<! Currently attached buffers (if different from _varsww)
 
-  ClassDef(RooTreeDataStore, 2) // TTree-based Data Storage class
+  ClassDefOverride(RooTreeDataStore, 2) // TTree-based Data Storage class
 };
 
 

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -38,26 +38,26 @@ public:
   inline RooTruthModel() { }
   RooTruthModel(const char *name, const char *title, RooAbsRealLValue& x) ;
   RooTruthModel(const RooTruthModel& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooTruthModel(*this,newname) ; }
-  virtual ~RooTruthModel();
+  TObject* clone(const char* newname) const override { return new RooTruthModel(*this,newname) ; }
+  ~RooTruthModel() override;
 
-  virtual Int_t basisCode(const char* name) const ;
+  Int_t basisCode(const char* name) const override ;
 
-  virtual RooAbsGenContext* modelGenContext(const RooAbsAnaConvPdf& convPdf, const RooArgSet &vars,
+  RooAbsGenContext* modelGenContext(const RooAbsAnaConvPdf& convPdf, const RooArgSet &vars,
                                             const RooDataSet *prototype=0, const RooArgSet* auxProto=0,
-                                            Bool_t verbose= kFALSE) const;
+                                            Bool_t verbose= kFALSE) const override;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const;
-  void generateEvent(Int_t code);
+  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, Bool_t staticInitOK=kTRUE) const override;
+  void generateEvent(Int_t code) override;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
-  virtual Double_t evaluate() const ;
-  virtual void changeBasis(RooFormulaVar* basis) ;
+  Double_t evaluate() const override ;
+  void changeBasis(RooFormulaVar* basis) override ;
 
-  ClassDef(RooTruthModel,1) // Truth resolution model (delta function)
+  ClassDefOverride(RooTruthModel,1) // Truth resolution model (delta function)
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooUniformBinning.h
+++ b/roofit/roofitcore/inc/RooUniformBinning.h
@@ -26,25 +26,25 @@ public:
   RooUniformBinning(const char* name=0) ;
   RooUniformBinning(Double_t xlo, Double_t xhi, Int_t nBins, const char* name=0) ;
   RooUniformBinning(const RooUniformBinning& other, const char* name=0) ;
-  RooAbsBinning* clone(const char* name=0) const { return new RooUniformBinning(*this,name?name:GetName()) ; }
-  virtual ~RooUniformBinning() ;
+  RooAbsBinning* clone(const char* name=0) const override { return new RooUniformBinning(*this,name?name:GetName()) ; }
+  ~RooUniformBinning() override ;
 
-  virtual void setRange(Double_t xlo, Double_t xhi) ;
+  void setRange(Double_t xlo, Double_t xhi) override ;
 
-  virtual Int_t numBoundaries() const { return _nbins + 1 ; }
-  virtual Int_t binNumber(Double_t x) const  ;
-  virtual Bool_t isUniform() const { return kTRUE ; }
+  Int_t numBoundaries() const override { return _nbins + 1 ; }
+  Int_t binNumber(Double_t x) const override  ;
+  Bool_t isUniform() const override { return kTRUE ; }
 
-  virtual Double_t lowBound() const { return _xlo ; }
-  virtual Double_t highBound() const { return _xhi ; }
+  Double_t lowBound() const override { return _xlo ; }
+  Double_t highBound() const override { return _xhi ; }
 
-  virtual Double_t binCenter(Int_t bin) const ;
-  virtual Double_t binWidth(Int_t bin) const ;
-  virtual Double_t binLow(Int_t bin) const ;
-  virtual Double_t binHigh(Int_t bin) const ;
+  Double_t binCenter(Int_t bin) const override ;
+  Double_t binWidth(Int_t bin) const override ;
+  Double_t binLow(Int_t bin) const override ;
+  Double_t binHigh(Int_t bin) const override ;
 
-  virtual Double_t averageBinWidth() const { return _binw ; }
-  virtual Double_t* array() const ;
+  Double_t averageBinWidth() const override { return _binw ; }
+  Double_t* array() const override ;
 
 protected:
 
@@ -55,7 +55,7 @@ protected:
   Double_t _binw ;
 
 
-  ClassDef(RooUniformBinning,1) // Uniform binning specification
+  ClassDefOverride(RooUniformBinning,1) // Uniform binning specification
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooUnitTest.h
+++ b/roofit/roofitcore/inc/RooUnitTest.h
@@ -37,7 +37,7 @@
 class RooUnitTest : public TNamed {
 public:
   RooUnitTest(const char* name, TFile* refFile, Bool_t writeRef, Int_t verbose, std::string const& batchMode="off") ;
-  ~RooUnitTest() ;
+  ~RooUnitTest() override ;
 
   void setDebug(Bool_t flag) { _debug = flag ; }
   void setSilentMode() ;
@@ -84,6 +84,6 @@ protected:
    std::list<std::pair<RooWorkspace*,std::string> > _regWS ;
    std::list<std::pair<TH1*,std::string> > _regTH ;
 
-  ClassDef(RooUnitTest,0) ; // Abstract base class for RooFit/RooStats unit regression tests
+  ClassDefOverride(RooUnitTest,0) ; // Abstract base class for RooFit/RooStats unit regression tests
 } ;
 #endif

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -45,8 +45,8 @@ public:
   // Empty ctor
   RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
 
-  virtual RooAbsDataStore* clone(const char* newname=0) const override { return new RooVectorDataStore(*this,newname) ; }
-  virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooVectorDataStore(*this,vars,newname) ; }
+  RooAbsDataStore* clone(const char* newname=0) const override { return new RooVectorDataStore(*this,newname) ; }
+  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooVectorDataStore(*this,vars,newname) ; }
 
   RooVectorDataStore(const RooVectorDataStore& other, const char* newname=0) ;
   RooVectorDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
@@ -57,7 +57,7 @@ public:
                      const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                      std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
 
-  virtual ~RooVectorDataStore() ;
+  ~RooVectorDataStore() override ;
 
   /// \class ArraysStruct
   /// Output struct for the RooVectorDataStore::getArrays() helper function.
@@ -95,11 +95,11 @@ private:
 
 public:
   // Write current row
-  virtual Int_t fill() override;
+  Int_t fill() override;
 
   // Retrieve a row
   using RooAbsDataStore::get;
-  virtual const RooArgSet* get(Int_t index) const override;
+  const RooArgSet* get(Int_t index) const override;
 
   virtual const RooArgSet* getNative(Int_t index) const;
 
@@ -114,30 +114,30 @@ public:
 
     return 1.0;
   }
-  virtual Double_t weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const override;
-  virtual void weightError(Double_t& lo, Double_t& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const override;
-  virtual Bool_t isWeighted() const override { return _wgtVar || _extWgtArray; }
+  Double_t weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const override;
+  void weightError(Double_t& lo, Double_t& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const override;
+  Bool_t isWeighted() const override { return _wgtVar || _extWgtArray; }
 
   RooBatchCompute::RunContext getBatches(std::size_t first, std::size_t len) const override;
   std::map<const std::string, RooSpan<const RooAbsCategory::value_type>> getCategoryBatches(std::size_t /*first*/, std::size_t len) const override;
-  virtual RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
+  RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len) const override;
 
   // Change observable name
-  virtual Bool_t changeObservableName(const char* from, const char* to) override;
+  Bool_t changeObservableName(const char* from, const char* to) override;
 
   // Add one or more columns
-  virtual RooAbsArg* addColumn(RooAbsArg& var, Bool_t adjustRange=kTRUE) override;
-  virtual RooArgSet* addColumns(const RooArgList& varList) override;
+  RooAbsArg* addColumn(RooAbsArg& var, Bool_t adjustRange=kTRUE) override;
+  RooArgSet* addColumns(const RooArgList& varList) override;
 
   // Merge column-wise
   RooAbsDataStore* merge(const RooArgSet& allvars, std::list<RooAbsDataStore*> dstoreList) override;
 
   // Add rows
-  virtual void append(RooAbsDataStore& other) override;
+  void append(RooAbsDataStore& other) override;
 
   // General & bookkeeping methods
-  virtual Int_t numEntries() const override { return static_cast<int>(size()); }
-  virtual Double_t sumEntries() const override { return _sumWeight ; }
+  Int_t numEntries() const override { return static_cast<int>(size()); }
+  Double_t sumEntries() const override { return _sumWeight ; }
   /// Get size of stored dataset.
   std::size_t size() const {
     if (!_realStoreList.empty()) {
@@ -150,21 +150,21 @@ public:
 
     return 0;
   }
-  virtual void reset() override;
+  void reset() override;
 
   // Buffer redirection routines used in inside RooAbsOptTestStatistics
-  virtual void attachBuffers(const RooArgSet& extObs) override;
-  virtual void resetBuffers() override;
+  void attachBuffers(const RooArgSet& extObs) override;
+  void resetBuffers() override;
 
 
   // Constant term  optimizer interface
-  virtual const RooAbsArg* cacheOwner() override { return _cacheOwner ; }
-  virtual void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, Bool_t skipZeroWeights=kTRUE) override;
-  virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override;
-  virtual void resetCache() override;
-  virtual void recalculateCache(const RooArgSet* /*proj*/, Int_t firstEvent, Int_t lastEvent, Int_t stepSize, Bool_t skipZeroWeights) override;
+  const RooAbsArg* cacheOwner() override { return _cacheOwner ; }
+  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, Bool_t skipZeroWeights=kTRUE) override;
+  void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override;
+  void resetCache() override;
+  void recalculateCache(const RooArgSet* /*proj*/, Int_t firstEvent, Int_t lastEvent, Int_t stepSize, Bool_t skipZeroWeights) override;
 
-  virtual void setArgStatus(const RooArgSet& set, Bool_t active) override;
+  void setArgStatus(const RooArgSet& set, Bool_t active) override;
 
   const RooVectorDataStore* cache() const { return _cache ; }
 
@@ -180,7 +180,7 @@ public:
     _extSumW2Array = arraySumW2 ;
   }
 
-  virtual void setDirtyProp(Bool_t flag) override {
+  void setDirtyProp(Bool_t flag) override {
     _doDirtyProp = flag ;
     if (_cache) {
       _cache->setDirtyProp(flag) ;
@@ -354,7 +354,7 @@ public:
       _vecE(0), _vecEL(0), _vecEH(0) {
     }
 
-    virtual ~RealFullVector() {
+    ~RealFullVector() override {
       if (_vecE) delete _vecE ;
       if (_vecEL) delete _vecEL ;
       if (_vecEH) delete _vecEH ;
@@ -522,7 +522,7 @@ public:
     Double_t *_nativeBufEL ; ///<!
     Double_t *_nativeBufEH ; ///<!
     std::vector<double> *_vecE, *_vecEL, *_vecEH ;
-    ClassDef(RealFullVector,1) // STL-vector-based Data Storage class
+    ClassDefOverride(RealFullVector,1) // STL-vector-based Data Storage class
   } ;
 
 
@@ -662,7 +662,7 @@ public:
 
   RealFullVector* addRealFull(RooAbsReal* real);
 
-  virtual Bool_t hasFilledCache() const override { return _cache ? kTRUE : kFALSE ; }
+  Bool_t hasFilledCache() const override { return _cache ? kTRUE : kFALSE ; }
 
   void forceCacheUpdate() override;
 

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -47,7 +47,7 @@ public:
   RooWorkspace(const char* name, Bool_t doCINTExport) ;
   RooWorkspace(const char* name, const char* title=0) ;
   RooWorkspace(const RooWorkspace& other) ;
-  ~RooWorkspace() ;
+  ~RooWorkspace() override ;
 
   void exportToCint(const char* namespaceName=0) ;
 
@@ -143,7 +143,7 @@ public:
     _allOwnedNodes.useHashMapForFind(flag);
   }
 
-  virtual void RecursiveRemove(TObject *obj);
+  void RecursiveRemove(TObject *obj) override;
 
   // Tools management
   RooFactoryWSTool& factory() ;
@@ -155,7 +155,7 @@ public:
   void clearStudies() ;
 
   // Print function
-  void Print(Option_t* opts=0) const ;
+  void Print(Option_t* opts=0) const override ;
 
   static void autoImportClassCode(Bool_t flag) ;
 
@@ -178,7 +178,7 @@ public:
           _ehmap(other._ehmap),
           _compiledOK(other._compiledOK) {} ;
 
-    virtual ~CodeRepo() {} ;
+    ~CodeRepo() override {} ;
 
     Bool_t autoImportClass(TClass* tc, Bool_t doReplace=kFALSE) ;
     Bool_t compileClasses() ;
@@ -218,7 +218,7 @@ public:
     std::map<TString,ExtraHeader> _ehmap ; // List of extra header files
     Bool_t _compiledOK ; //! Flag indicating that classes compiled OK
 
-    ClassDef(CodeRepo,2) ; // Code repository for RooWorkspace
+    ClassDefOverride(CodeRepo,2) ; // Code repository for RooWorkspace
   } ;
 
 
@@ -230,18 +230,18 @@ public:
       {
       }
 
-    virtual ~WSDir() { Clear("nodelete") ; } ;
+    ~WSDir() override { Clear("nodelete") ; } ;
 
 
-    virtual void Add(TObject*,Bool_t) ;
-    virtual void Append(TObject*,Bool_t) ;
+    void Add(TObject*,Bool_t) override ;
+    void Append(TObject*,Bool_t) override ;
 
   protected:
     friend class RooWorkspace ;
     void InternalAppend(TObject* obj) ;
     RooWorkspace* _wspace ; //! do not persist
 
-    ClassDef(WSDir,1) ; // TDirectory representation of RooWorkspace
+    ClassDefOverride(WSDir,1) ; // TDirectory representation of RooWorkspace
   } ;
 
 
@@ -287,7 +287,7 @@ public:
     Bool_t _openTrans;       ///<! Is there a transaction open?
     RooArgSet _sandboxNodes; ///<! Sandbox for incoming objects in a transaction
 
-    ClassDef(RooWorkspace, 8) // Persistable project container for (composite) pdfs, functions, variables and datasets
+    ClassDefOverride(RooWorkspace, 8) // Persistable project container for (composite) pdfs, functions, variables and datasets
 } ;
 
 #endif

--- a/roofit/roofitcore/inc/RooWrapperPdf.h
+++ b/roofit/roofitcore/inc/RooWrapperPdf.h
@@ -33,13 +33,13 @@ public:
   RooWrapperPdf(const char *name, const char *title, RooAbsReal& inputFunction) :
     RooAbsPdf(name, title),
     _func("inputFunction", "Function to be converted into a PDF", this, inputFunction) { }
-  virtual ~RooWrapperPdf() {};
+  ~RooWrapperPdf() override {};
 
   RooWrapperPdf(const RooWrapperPdf& other, const char* name = 0) :
     RooAbsPdf(other, name),
     _func("inputFunction", this, other._func) { }
 
-  virtual TObject* clone(const char* newname) const override {
+  TObject* clone(const char* newname) const override {
     return new RooWrapperPdf(*this, newname);
   }
 

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -37,17 +37,17 @@ public:
   RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& data, RooRealVar& yvar, Bool_t integrate=kFALSE) ;
 
   RooXYChi2Var(const RooXYChi2Var& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const { return new RooXYChi2Var(*this,newname); }
+  TObject* clone(const char* newname) const override { return new RooXYChi2Var(*this,newname); }
 
-  virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
-                                      const RooArgSet&, RooAbsTestStatistic::Configuration const&) {
+  RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,
+                                      const RooArgSet&, RooAbsTestStatistic::Configuration const&) override {
     // Virtual constructor
     return new RooXYChi2Var(name,title,pdf,(RooDataSet&)adata) ;
   }
 
-  virtual ~RooXYChi2Var();
+  ~RooXYChi2Var() override;
 
-  virtual Double_t defaultErrorLevel() const {
+  Double_t defaultErrorLevel() const override {
     // The default error level for MINUIT error analysis for a chi^2 is 1.0
     return 1.0 ;
   }
@@ -57,13 +57,13 @@ public:
 
 protected:
 
-  Bool_t allowFunctionCache() {
+  Bool_t allowFunctionCache() override {
     // Disable function (component) caching if integration is requested as the function
     // will be evaluated at coordinates other than the points in the dataset
     return !_integrate ;
   }
 
-  RooArgSet requiredExtraObservables() const ;
+  RooArgSet requiredExtraObservables() const override ;
 
   Double_t fy() const ;
 
@@ -78,13 +78,13 @@ protected:
   void initIntegrator() ;
   Double_t xErrorContribution(Double_t ydata) const ;
 
-  virtual Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const ;
+  Double_t evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
   RooNumIntConfig   _intConfig ; ///< Numeric integrator configuration for integration of function over bin
   RooAbsReal*       _funcInt ; ///<! Function integral
   std::list<RooAbsBinning*> _binList ; ///<! Bin ranges
 
-  ClassDef(RooXYChi2Var,1) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values
+  ClassDefOverride(RooXYChi2Var,1) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values
 };
 
 

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -102,7 +102,7 @@ public:
       {
       }
 
-      ~RooAbsRealWrapper()
+      ~RooAbsRealWrapper() override
       {
          if (_ownsDriver)
             delete _driver;

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -543,7 +543,7 @@ Bool_t RooClassFactory::makeClass(const char* baseName, const char* className, c
      << "" << endl
      << "private:" << endl
      << "" << endl
-     << "  ClassDef(" << className << ",1) // Your description goes here..." << endl
+     << "  ClassDefOverride(" << className << ",1) // Your description goes here..." << endl
      << "};" << endl
      << " " << endl
      << "#endif" << endl ;

--- a/roofit/roofitcore/src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
+++ b/roofit/roofitcore/src/RooFitLegacy/RooAbsCategoryLegacyIterator.h
@@ -35,7 +35,7 @@ class RooAbsCategoryLegacyIterator : public TIterator {
       populate();
     }
 
-    virtual const TCollection *GetCollection() const override { return nullptr; }
+    const TCollection *GetCollection() const override { return nullptr; }
 
     TObject* Next() override {
       ++index;

--- a/roofit/roofitcore/src/RooFitLegacy/RooMultiCatIter.h
+++ b/roofit/roofitcore/src/RooFitLegacy/RooMultiCatIter.h
@@ -31,18 +31,18 @@ public:
   // Constructors, assignment etc.
   RooMultiCatIter(const RooArgSet& catList, const char* rangeName=0) ;
   RooMultiCatIter(const RooMultiCatIter& other) ;
-  virtual ~RooMultiCatIter() ;
+  ~RooMultiCatIter() override ;
 
   // Iterator implementation
-  virtual const TCollection* GetCollection() const ;
-  virtual TObject* Next() ;
-  virtual void Reset() ;
-  virtual bool operator!=(const TIterator &aIter) const ;
-  virtual TObject *operator*() const ;
+  const TCollection* GetCollection() const override ;
+  TObject* Next() override ;
+  void Reset() override ;
+  bool operator!=(const TIterator &aIter) const override ;
+  TObject *operator*() const override ;
 
 protected:
   
-  TIterator& operator=(const TIterator&) { return *this ; } // forbidden for now
+  TIterator& operator=(const TIterator&) override { return *this ; } // forbidden for now
 
   void initialize(const RooArgSet& catList) ;
   TObjString* compositeLabel() ;
@@ -57,7 +57,7 @@ protected:
   TString _rangeName ;           // Range name (optional)
   TObject* _curItem;             // Current item returned by Next()
 
-//  ClassDef(RooMultiCatIter,0) // Iterator over all state permutations of a list of categories
+//  ClassDefOverride(RooMultiCatIter,0) // Iterator over all state permutations of a list of categories
 };
 
 #endif

--- a/roofit/roofitcore/src/RooMappedCategory.cxx
+++ b/roofit/roofitcore/src/RooMappedCategory.cxx
@@ -47,10 +47,10 @@ class RooMappedCategoryCache : public RooAbsCache {
     RooAbsCategory::value_type lookup(Int_t idx) const
     { return _map[idx]; }
 
-    virtual void wireCache()
+    void wireCache() override
     { _map.clear(); initialise(); }
 
-    virtual Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/)
+    Bool_t redirectServersHook(const RooAbsCollection& /*newServerList*/, Bool_t /*mustReplaceAll*/, Bool_t /*nameChange*/, Bool_t /*isRecursive*/) override
     { _map.clear(); initialise(); return kFALSE; }
 
   private:

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cpp
@@ -32,7 +32,7 @@ class TestRooRealLPlot : public RooUnitTest {
 public:
    TestRooRealLPlot(TFile &refFile, bool writeRef, int verbose, std::string const &batchMode)
       : RooUnitTest("Plotting and minimization with RooFit::TestStatistics", &refFile, writeRef, verbose, batchMode){};
-   Bool_t testCode()
+   Bool_t testCode() override
    {
 
       // C r e a t e   m o d e l  a n d  d a t a

--- a/roofit/roofitcore/test/testProxiesAndCategories.cxx
+++ b/roofit/roofitcore/test/testProxiesAndCategories.cxx
@@ -171,7 +171,7 @@ struct DummyClass : public RooAbsPdf {
       }
     }
 
-    double evaluate() const {
+    double evaluate() const override {
       return 1.;
     }
 
@@ -179,7 +179,7 @@ struct DummyClass : public RooAbsPdf {
       clearValueAndShapeDirty();
     }
 
-    TObject* clone(const char*) const {
+    TObject* clone(const char*) const override {
       return new TObject();
     }
 

--- a/roofit/roofitcore/test/testRooCacheManager.cxx
+++ b/roofit/roofitcore/test/testRooCacheManager.cxx
@@ -20,8 +20,8 @@ TEST(RooCacheManager, TestSelectFromArgSet)
    // the cached class doesn't matter for this test, it just has to be an object that the cache is going to own
    class CacheElem : public RooAbsCacheElement {
    public:
-      virtual ~CacheElem() {}
-      virtual RooArgList containedArgs(Action) { return {}; }
+      ~CacheElem() override {}
+      RooArgList containedArgs(Action) override { return {}; }
    };
 
    // RooObjCacheManager is a wrapper around RooCacheManager

--- a/roofit/roofitcore/test/testRooProductPdf.cxx
+++ b/roofit/roofitcore/test/testRooProductPdf.cxx
@@ -17,7 +17,7 @@ protected:
     a.setConstant(true);
   }
 
-  ~TestProdPdf() {
+  ~TestProdPdf() override {
 
   }
 

--- a/roofit/roofitcore/test/testWorkspace.cxx
+++ b/roofit/roofitcore/test/testWorkspace.cxx
@@ -98,7 +98,7 @@ protected:
     outfile.WriteObject(&w, "ws");
   }
 
-  ~TestRooWorkspaceWithGaussian() {
+  ~TestRooWorkspaceWithGaussian() override {
     gSystem->Unlink(_filename);
   }
 

--- a/roofit/roofitmore/inc/RooAdaptiveGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/inc/RooAdaptiveGaussKronrodIntegrator1D.h
@@ -29,32 +29,32 @@ public:
   RooAdaptiveGaussKronrodIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooAdaptiveGaussKronrodIntegrator1D(const RooAbsFunc& function, Double_t xmin, Double_t xmax, 
                                       const RooNumIntConfig& config) ;
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooAdaptiveGaussKronrodIntegrator1D();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooAdaptiveGaussKronrodIntegrator1D() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t *yvec=0) ;
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t *yvec=0) override ;
 
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t* xmin, Double_t* xmax);
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) {
+  Bool_t setLimits(Double_t* xmin, Double_t* xmax) override;
+  Bool_t setUseIntegrandLimits(Bool_t flag) override {
     // If flag is true, intergration limits are taken from definition in input function binding
     _useIntegrandLimits = flag ; return kTRUE ; 
   }
 
-  virtual Bool_t canIntegrate1D() const { 
+  Bool_t canIntegrate1D() const override { 
     // We can integrate 1-dimensional functions
     return kTRUE ; 
   }
-  virtual Bool_t canIntegrate2D() const { 
+  Bool_t canIntegrate2D() const override { 
     // We can not integrate 2-dimensional functions
     return kFALSE ; 
   }
-  virtual Bool_t canIntegrateND() const { 
+  Bool_t canIntegrateND() const override { 
     // We can not integrate >2-dimensional functions
     return kFALSE ; 
   }
-  virtual Bool_t canIntegrateOpenEnded() const { 
+  Bool_t canIntegrateOpenEnded() const override { 
     // We can integrate over open-ended domains
     return kTRUE ; 
   }
@@ -88,7 +88,7 @@ protected:
   mutable Double_t _xmin;              //! Lower integration bound
   mutable Double_t _xmax;              //! Upper integration bound
 
-  ClassDef(RooAdaptiveGaussKronrodIntegrator1D,0) // 1-dimensional adaptive Gauss-Kronrod numerical integration engine
+  ClassDefOverride(RooAdaptiveGaussKronrodIntegrator1D,0) // 1-dimensional adaptive Gauss-Kronrod numerical integration engine
 };
 
 #endif

--- a/roofit/roofitmore/inc/RooGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/inc/RooGaussKronrodIntegrator1D.h
@@ -28,20 +28,20 @@ public:
   RooGaussKronrodIntegrator1D() ;
   RooGaussKronrodIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooGaussKronrodIntegrator1D(const RooAbsFunc& function, Double_t xmin, Double_t xmax, const RooNumIntConfig& config) ;
-  virtual RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const ;
-  virtual ~RooGaussKronrodIntegrator1D();
+  RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
+  ~RooGaussKronrodIntegrator1D() override;
 
-  virtual Bool_t checkLimits() const;
-  virtual Double_t integral(const Double_t *yvec=0) ;
+  Bool_t checkLimits() const override;
+  Double_t integral(const Double_t *yvec=0) override ;
 
   using RooAbsIntegrator::setLimits ;
-  Bool_t setLimits(Double_t* xmin, Double_t* xmax);
-  virtual Bool_t setUseIntegrandLimits(Bool_t flag) {_useIntegrandLimits = flag ; return kTRUE ; }
+  Bool_t setLimits(Double_t* xmin, Double_t* xmax) override;
+  Bool_t setUseIntegrandLimits(Bool_t flag) override {_useIntegrandLimits = flag ; return kTRUE ; }
 
-  virtual Bool_t canIntegrate1D() const { return kTRUE ; }
-  virtual Bool_t canIntegrate2D() const { return kFALSE ; }
-  virtual Bool_t canIntegrateND() const { return kFALSE ; }
-  virtual Bool_t canIntegrateOpenEnded() const { return kTRUE ; }
+  Bool_t canIntegrate1D() const override { return kTRUE ; }
+  Bool_t canIntegrate2D() const override { return kFALSE ; }
+  Bool_t canIntegrateND() const override { return kFALSE ; }
+  Bool_t canIntegrateOpenEnded() const override { return kTRUE ; }
 
 protected:
 
@@ -63,7 +63,7 @@ protected:
   mutable Double_t _xmin;              //! Lower integration bound
   mutable Double_t _xmax;              //! Upper integration bound
 
-  ClassDef(RooGaussKronrodIntegrator1D,0) // 1-dimensional Gauss-Kronrod numerical integration engine
+  ClassDefOverride(RooGaussKronrodIntegrator1D,0) // 1-dimensional Gauss-Kronrod numerical integration engine
 };
 
 #endif

--- a/roofit/roofitmore/inc/RooHypatia2.h
+++ b/roofit/roofitmore/inc/RooHypatia2.h
@@ -29,8 +29,8 @@ public:
 	      RooAbsReal& x, RooAbsReal& lambda, RooAbsReal& zeta, RooAbsReal& beta,
 	      RooAbsReal& sigma, RooAbsReal& mu, RooAbsReal& a, RooAbsReal& n, RooAbsReal& a2, RooAbsReal& n2);
   RooHypatia2(const RooHypatia2& other, const char* name=0);
-  virtual TObject* clone(const char* newname) const override { return new RooHypatia2(*this,newname); }
-  inline virtual ~RooHypatia2() { }
+  TObject* clone(const char* newname) const override { return new RooHypatia2(*this,newname); }
+  inline ~RooHypatia2() override { }
 
   /* Analytical integrals need testing.
 

--- a/roofit/roofitmore/inc/RooLegendre.h
+++ b/roofit/roofitmore/inc/RooLegendre.h
@@ -27,24 +27,24 @@ public:
   RooLegendre(const char *name, const char *title, RooAbsReal& ctheta, int l1, int m1, int l2, int m2);
 
   RooLegendre(const RooLegendre& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooLegendre(*this, newname); }
-  inline virtual ~RooLegendre() { }
+  TObject* clone(const char* newname) const override { return new RooLegendre(*this, newname); }
+  inline ~RooLegendre() override { }
 
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  virtual Int_t getMaxVal( const RooArgSet& vars) const;
-  virtual Double_t maxVal( Int_t code) const;
+  Int_t getMaxVal( const RooArgSet& vars) const override;
+  Double_t maxVal( Int_t code) const override;
 
 protected: // allow RooSpHarmonic access...
   RooRealProxy _ctheta;
   int _l1,_m1;
   int _l2,_m2;
 
-  Double_t evaluate() const;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const;
+  Double_t evaluate() const override;
+  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
 
-  ClassDef(RooLegendre,1) // Legendre polynomial
+  ClassDefOverride(RooLegendre,1) // Legendre polynomial
 };
 
 #endif

--- a/roofit/roofitmore/inc/RooNonCentralChiSquare.h
+++ b/roofit/roofitmore/inc/RooNonCentralChiSquare.h
@@ -25,16 +25,16 @@ public:
                           RooAbsReal& _k,
                           RooAbsReal& _lambda);
    RooNonCentralChiSquare(const RooNonCentralChiSquare& other, const char* name=0) ;
-   virtual TObject* clone(const char* newname) const { return new RooNonCentralChiSquare(*this,newname); }
-   inline virtual ~RooNonCentralChiSquare() { }
+   TObject* clone(const char* newname) const override { return new RooNonCentralChiSquare(*this,newname); }
+   inline ~RooNonCentralChiSquare() override { }
 
    void SetErrorTolerance(Double_t t) {fErrorTol = t;}
    void SetMaxIters(Int_t mi) {fMaxIters = mi;}
    void SetForceSum(Bool_t flag);
 
 
-   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+   Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
 protected:
 
@@ -46,11 +46,11 @@ protected:
    Bool_t fForceSum;
    mutable Bool_t fHasIssuedConvWarning;
    mutable Bool_t fHasIssuedSumWarning;
-   Double_t evaluate() const ;
+   Double_t evaluate() const override ;
 
 private:
 
-   ClassDef(RooNonCentralChiSquare,1) // non-central chisquare pdf
+   ClassDefOverride(RooNonCentralChiSquare,1) // non-central chisquare pdf
 };
 
 #endif

--- a/roofit/roofitmore/inc/RooSpHarmonic.h
+++ b/roofit/roofitmore/inc/RooSpHarmonic.h
@@ -24,23 +24,23 @@ public:
   RooSpHarmonic(const char *name, const char *title, RooAbsReal& ctheta, RooAbsReal& phi, int l1, int m1, int l2, int m2);
 
   RooSpHarmonic(const RooSpHarmonic& other, const char* name = 0);
-  virtual TObject* clone(const char* newname) const { return new RooSpHarmonic(*this, newname); }
-  inline virtual ~RooSpHarmonic() { }
+  TObject* clone(const char* newname) const override { return new RooSpHarmonic(*this, newname); }
+  inline ~RooSpHarmonic() override { }
 
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Double_t analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
 
-  virtual Int_t getMaxVal( const RooArgSet& vars) const;
-  virtual Double_t maxVal( Int_t code) const;
+  Int_t getMaxVal( const RooArgSet& vars) const override;
+  Double_t maxVal( Int_t code) const override;
 
 private:
   RooRealProxy _phi;
   double _n;
   int _sgn1,_sgn2;
 
-  Double_t evaluate() const;
+  Double_t evaluate() const override;
 
-  ClassDef(RooSpHarmonic,1) // SpHarmonic polynomial
+  ClassDefOverride(RooSpHarmonic,1) // SpHarmonic polynomial
 };
 
 #endif

--- a/roofit/roostats/inc/RooStats/AsymptoticCalculator.h
+++ b/roofit/roostats/inc/RooStats/AsymptoticCalculator.h
@@ -34,14 +34,14 @@ namespace RooStats {
          bool nominalAsimov = false
          );
 
-      ~AsymptoticCalculator() {
+      ~AsymptoticCalculator() override {
       }
 
       /// initialize the calculator by performing a global fit and make the Asimov data set
       bool Initialize() const;
 
       /// re-implement HypoTest computation using the asymptotic
-      virtual HypoTestResult *GetHypoTest() const;
+      HypoTestResult *GetHypoTest() const override;
 
       /// Make Asimov data.
       static RooAbsData * MakeAsimovData( RooAbsData & data, const ModelConfig & model,  const RooArgSet & poiValues, RooArgSet & globObs, const RooArgSet * genPoiValues = 0);
@@ -68,15 +68,15 @@ namespace RooStats {
       void SetOneSidedDiscovery(bool on) { fOneSidedDiscovery = on; }
 
       /// re-implementation of  setters since they are needed to re-initialize the calculator
-      virtual void SetNullModel(const ModelConfig &nullModel) {
+      void SetNullModel(const ModelConfig &nullModel) override {
          HypoTestCalculatorGeneric::SetNullModel(nullModel);
          fIsInitialized = false;
       }
-      virtual void SetAlternateModel(const ModelConfig &altModel) {
+      void SetAlternateModel(const ModelConfig &altModel) override {
          HypoTestCalculatorGeneric::SetAlternateModel(altModel);
          fIsInitialized = false;
       }
-      virtual void SetData(RooAbsData &data) {
+      void SetData(RooAbsData &data) override {
          HypoTestCalculatorGeneric::SetData(data);
          fIsInitialized = false;
       }
@@ -122,7 +122,7 @@ namespace RooStats {
       static bool SetObsToExpected(RooProdPdf &prod, const RooArgSet &obs);
 
    protected:
-      ClassDef(AsymptoticCalculator,2)
+      ClassDefOverride(AsymptoticCalculator,2)
 
    private:
 

--- a/roofit/roostats/inc/RooStats/BayesianCalculator.h
+++ b/roofit/roostats/inc/RooStats/BayesianCalculator.h
@@ -51,7 +51,7 @@ namespace RooStats {
                           ModelConfig& model );
 
       /// destructor
-      virtual ~BayesianCalculator();
+      ~BayesianCalculator() override;
 
       /// get the plot with option to get it normalized
       RooPlot* GetPosteriorPlot(bool norm = false, double precision = 0.01) const;
@@ -67,16 +67,16 @@ namespace RooStats {
       /// compute the interval. By Default a central interval is computed
       /// By using SetLeftTileFraction can control if central/ upper/lower interval
       /// For shortest interval use SetShortestInterval(true)
-      virtual SimpleInterval* GetInterval() const ;
+      SimpleInterval* GetInterval() const override ;
 
-      virtual void SetData( RooAbsData & data ) {
+      void SetData( RooAbsData & data ) override {
          fData = &data;
          ClearAll();
       }
 
 
       /// set the model via the ModelConfig
-      virtual void SetModel( const ModelConfig& model );
+      void SetModel( const ModelConfig& model ) override;
 
       /// specify the parameters of interest in the interval
       virtual void SetParameters(const RooArgSet& set) { fPOI.removeAll(); fPOI.add(set); }
@@ -96,16 +96,16 @@ namespace RooStats {
       virtual void SetGlobalObservables(const RooArgSet& set) {fGlobalObs.removeAll(); fGlobalObs.add(set);}
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize( Double_t size ) {
+      void SetTestSize( Double_t size ) override {
          fSize = size;
          fValidInterval = false;
       }
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel( Double_t cl ) { SetTestSize(1.-cl); }
+      void SetConfidenceLevel( Double_t cl ) override { SetTestSize(1.-cl); }
       /// Get the size of the test (eg. rate of Type I error)
-      virtual Double_t Size() const { return fSize; }
+      Double_t Size() const override { return fSize; }
       /// Get the Confidence level for the test
-      virtual Double_t ConfidenceLevel() const { return 1.-fSize; }
+      Double_t ConfidenceLevel() const override { return 1.-fSize; }
 
       /// set the fraction of probability content on the left tail
       /// Central limits use 0.5 (default case)
@@ -191,7 +191,7 @@ namespace RooStats {
 
    protected:
 
-      ClassDef(BayesianCalculator,2)  // BayesianCalculator class
+      ClassDefOverride(BayesianCalculator,2)  // BayesianCalculator class
 
    };
 }

--- a/roofit/roostats/inc/RooStats/CombinedCalculator.h
+++ b/roofit/roostats/inc/RooStats/CombinedCalculator.h
@@ -93,29 +93,29 @@ in a common way for several concrete calculators.
       }
 
       /// destructor.
-      virtual ~CombinedCalculator() { }
+      ~CombinedCalculator() override { }
 
       /// Main interface to get a ConfInterval, pure virtual
-      virtual ConfInterval* GetInterval() const = 0;
+      ConfInterval* GetInterval() const override = 0;
       /// main interface to get a HypoTestResult, pure virtual
-      virtual HypoTestResult* GetHypoTest() const = 0;
+      HypoTestResult* GetHypoTest() const override = 0;
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize(Double_t size) {fSize = size;}
+      void SetTestSize(Double_t size) override {fSize = size;}
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;}
+      void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;}
       /// Get the size of the test (eg. rate of Type I error)
-      virtual Double_t Size() const {return fSize;}
+      Double_t Size() const override {return fSize;}
       /// Get the Confidence level for the test
-      virtual Double_t ConfidenceLevel()  const {return 1.-fSize;}
+      Double_t ConfidenceLevel()  const override {return 1.-fSize;}
 
       /// Set the DataSet, add to the the workspace if not already there
-      virtual void SetData(RooAbsData & data) {
+      void SetData(RooAbsData & data) override {
          fData = &data;
       }
 
       /// set the model (in this case can set only the parameters for the null hypothesis)
-      virtual void SetModel(const ModelConfig & model) {
+      void SetModel(const ModelConfig & model) override {
          fPdf = model.GetPdf();
          if (model.GetParametersOfInterest()) SetParameters(*model.GetParametersOfInterest());
          if (model.GetSnapshot()) SetNullParameters(*model.GetSnapshot());
@@ -124,9 +124,9 @@ in a common way for several concrete calculators.
          if (model.GetGlobalObservables()) SetGlobalObservables(*model.GetGlobalObservables());
       }
 
-      virtual void SetNullModel( const ModelConfig &) {  // to be understood what to do
+      void SetNullModel( const ModelConfig &) override {  // to be understood what to do
       }
-      virtual void SetAlternateModel(const ModelConfig &) {  // to be understood what to do
+      void SetAlternateModel(const ModelConfig &) override {  // to be understood what to do
       }
 
       /* specific setting - keep for convenience-  some of them could be removed */
@@ -170,7 +170,7 @@ in a common way for several concrete calculators.
       RooArgSet fGlobalObs;       ///< RooArgSet specifying the global observables
 
 
-      ClassDef(CombinedCalculator,2) // A base class that is for tools that can be both HypoTestCalculators and IntervalCalculators
+      ClassDefOverride(CombinedCalculator,2) // A base class that is for tools that can be both HypoTestCalculators and IntervalCalculators
 
    };
 }

--- a/roofit/roostats/inc/RooStats/ConfInterval.h
+++ b/roofit/roostats/inc/RooStats/ConfInterval.h
@@ -40,7 +40,7 @@ Note, one could use the same class for a Bayesian "credible interval".
       explicit ConfInterval(const char* name = 0) : TNamed(name,name) {}
 
       /// destructor
-      virtual ~ConfInterval() {}
+      ~ConfInterval() override {}
 
       /// operator=
       ConfInterval& operator=(const ConfInterval& other) {
@@ -67,7 +67,7 @@ Note, one could use the same class for a Bayesian "credible interval".
 
    protected:
 
-      ClassDef(ConfInterval,1) // Interface for Confidence Intervals
+      ClassDefOverride(ConfInterval,1) // Interface for Confidence Intervals
 
    };
 }

--- a/roofit/roostats/inc/RooStats/ConfidenceBelt.h
+++ b/roofit/roostats/inc/RooStats/ConfidenceBelt.h
@@ -34,7 +34,7 @@ namespace RooStats {
 
   public:
     SamplingSummaryLookup() {}
-    virtual ~SamplingSummaryLookup() {}
+    ~SamplingSummaryLookup() override {}
 
     void Add(Double_t cl, Double_t leftside){
       // add cl,leftside pair to lookup table
@@ -88,7 +88,7 @@ namespace RooStats {
     LookupTable fLookupTable; ///< map ( Index, ( CL, leftside tail prob) )
 
   protected:
-    ClassDef(SamplingSummaryLookup,1)  // A simple class used by ConfidenceBelt
+    ClassDefOverride(SamplingSummaryLookup,1)  // A simple class used by ConfidenceBelt
   };
 
 
@@ -96,7 +96,7 @@ namespace RooStats {
   class AcceptanceRegion : public TObject{
   public:
      AcceptanceRegion() : fLookupIndex(0), fLowerLimit(0), fUpperLimit(0) {}
-    virtual ~AcceptanceRegion() {}
+    ~AcceptanceRegion() override {}
 
     AcceptanceRegion(Int_t lu, Double_t ll, Double_t ul){
       fLookupIndex = lu;
@@ -113,7 +113,7 @@ namespace RooStats {
     Double_t fUpperLimit;  // upper limit on test statistic
 
   protected:
-    ClassDef(AcceptanceRegion,1)  // A simple class for acceptance regions used for ConfidenceBelt
+    ClassDefOverride(AcceptanceRegion,1)  // A simple class for acceptance regions used for ConfidenceBelt
 
   };
 
@@ -122,7 +122,7 @@ namespace RooStats {
   class SamplingSummary : public TObject {
   public:
      SamplingSummary() : fParameterPointIndex(0) {}
-    virtual ~SamplingSummary() {}
+    ~SamplingSummary() override {}
      SamplingSummary(AcceptanceRegion& ar) : fParameterPointIndex(0) {
       AddAcceptanceRegion(ar);
     }
@@ -147,7 +147,7 @@ namespace RooStats {
      std::map<Int_t, AcceptanceRegion> fAcceptanceRegions;
 
   protected:
-    ClassDef(SamplingSummary,1)  // A summary of acceptance regions for confidence belt
+    ClassDefOverride(SamplingSummary,1)  // A summary of acceptance regions for confidence belt
 
   };
 
@@ -168,7 +168,7 @@ namespace RooStats {
     ConfidenceBelt(const char* name, const char* title);
     ConfidenceBelt(const char* name, RooAbsData&);
     ConfidenceBelt(const char* name, const char* title, RooAbsData&);
-    virtual ~ConfidenceBelt();
+    ~ConfidenceBelt() override;
 
     /// add after creating a region
     void AddAcceptanceRegion(RooArgSet&, AcceptanceRegion region, Double_t cl=-1., Double_t leftside=-1.);
@@ -188,7 +188,7 @@ namespace RooStats {
     Bool_t CheckParameters(RooArgSet&) const ;
 
   protected:
-    ClassDef(ConfidenceBelt,1)  // A confidence belt for the Neyman Construction
+    ClassDefOverride(ConfidenceBelt,1)  // A confidence belt for the Neyman Construction
 
   };
 }

--- a/roofit/roostats/inc/RooStats/DebuggingSampler.h
+++ b/roofit/roostats/inc/RooStats/DebuggingSampler.h
@@ -39,13 +39,13 @@ namespace RooStats {
        fTestStatistic = new RooRealVar("UniformTestStatistic","UniformTestStatistic",0,0,1);
        fRand = new TRandom();
      }
-     virtual ~DebuggingSampler() {
+     ~DebuggingSampler() override {
        delete fRand;
        delete fTestStatistic;
      }
 
      /// Main interface to get a ConfInterval, pure virtual
-     virtual SamplingDistribution* GetSamplingDistribution(RooArgSet& paramsOfInterest)  {
+     SamplingDistribution* GetSamplingDistribution(RooArgSet& paramsOfInterest) override  {
        (void)paramsOfInterest; // avoid warning
        // normally this method would be complex, but here it is simple for debugging
        std::vector<Double_t> testStatVec;
@@ -56,45 +56,45 @@ namespace RooStats {
      }
 
      /// Main interface to evaluate the test statistic on a dataset
-     virtual Double_t EvaluateTestStatistic(RooAbsData& /*data*/, RooArgSet& /*paramsOfInterest*/)  {
+     Double_t EvaluateTestStatistic(RooAbsData& /*data*/, RooArgSet& /*paramsOfInterest*/) override  {
        //       data = data; // avoid warning
        //       paramsOfInterest = paramsOfInterest; // avoid warning
        return fRand->Uniform();
      }
 
       /// Get the TestStatistic
-      virtual TestStatistic* GetTestStatistic()  const {
+      TestStatistic* GetTestStatistic()  const override {
          std::cout << "GetTestStatistic() IS NOT IMPLEMENTED FOR THIS SAMPLER. Returning NULL." << std::endl;
          return NULL; /*fTestStatistic;*/
       }
 
       /// Get the Confidence level for the test
-      virtual Double_t ConfidenceLevel()  const {return 1.-fSize;}
+      Double_t ConfidenceLevel()  const override {return 1.-fSize;}
 
       /// Common Initialization
-      virtual void Initialize(RooAbsArg& /* testStatistic */, RooArgSet& /* paramsOfInterest */, RooArgSet& /* nuisanceParameters */ ) {
+      void Initialize(RooAbsArg& /* testStatistic */, RooArgSet& /* paramsOfInterest */, RooArgSet& /* nuisanceParameters */ ) override {
       }
 
       /// Set the Pdf, add to the the workspace if not already there
-      virtual void SetPdf(RooAbsPdf&) {}
+      void SetPdf(RooAbsPdf&) override {}
 
       /// specify the parameters of interest in the interval
       virtual void SetParameters(RooArgSet&) {}
       /// specify the nuisance parameters (eg. the rest of the parameters)
-      virtual void SetNuisanceParameters(const RooArgSet&) {}
+      void SetNuisanceParameters(const RooArgSet&) override {}
       /// specify the values of parameters used when evaluating test statistic
-      virtual void SetParametersForTestStat(const RooArgSet& ) {}
+      void SetParametersForTestStat(const RooArgSet& ) override {}
       /// specify the conditional observables
-      virtual void SetGlobalObservables(const RooArgSet& ) {}
+      void SetGlobalObservables(const RooArgSet& ) override {}
 
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize(Double_t size) {fSize = size;}
+      void SetTestSize(Double_t size) override {fSize = size;}
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;}
+      void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;}
 
       /// Set the TestStatistic (want the argument to be a function of the data & parameter points
-      virtual void SetTestStatistic(TestStatistic* /*testStatistic*/) {
+      void SetTestStatistic(TestStatistic* /*testStatistic*/) override {
          std::cout << "SetTestStatistic(...) IS NOT IMPLEMENTED FOR THIS SAMPLER" << std::endl;
       }
 
@@ -104,7 +104,7 @@ namespace RooStats {
       TRandom* fRand;
 
    protected:
-      ClassDef(DebuggingSampler,1)   // A simple implementation of the DistributionCreator interface
+      ClassDefOverride(DebuggingSampler,1)   // A simple implementation of the DistributionCreator interface
    };
 }
 

--- a/roofit/roostats/inc/RooStats/DebuggingTestStat.h
+++ b/roofit/roostats/inc/RooStats/DebuggingTestStat.h
@@ -42,13 +42,13 @@ namespace RooStats {
        fTestStatistic = new RooRealVar("UniformTestStatistic","UniformTestStatistic",0,0,1);
        fRand = new TRandom();
      }
-     virtual ~DebuggingTestStat() {
+     ~DebuggingTestStat() override {
        //       delete fRand;
        //       delete fTestStatistic;
      }
 
      /// Main interface to evaluate the test statistic on a dataset
-     virtual Double_t Evaluate(RooAbsData& /*data*/, RooArgSet& /*paramsOfInterest*/)  {
+     Double_t Evaluate(RooAbsData& /*data*/, RooArgSet& /*paramsOfInterest*/) override  {
        //data = data; // avoid warning
        //paramsOfInterest = paramsOfInterest; //avoid warning
        return fRand->Uniform();
@@ -63,7 +63,7 @@ namespace RooStats {
       TRandom* fRand;
 
    protected:
-      ClassDef(DebuggingTestStat,1)   // A concrete implementation of the TestStatistic interface, useful for debugging.
+      ClassDefOverride(DebuggingTestStat,1)   // A concrete implementation of the TestStatistic interface, useful for debugging.
    };
 
 }

--- a/roofit/roostats/inc/RooStats/FeldmanCousins.h
+++ b/roofit/roostats/inc/RooStats/FeldmanCousins.h
@@ -37,17 +37,17 @@ namespace RooStats {
      /// Common constructor
      FeldmanCousins(RooAbsData& data, ModelConfig& model);
 
-     virtual ~FeldmanCousins();
+     ~FeldmanCousins() override;
 
       /// Main interface to get a ConfInterval (will be a PointSetInterval)
-      virtual PointSetInterval* GetInterval() const;
+      PointSetInterval* GetInterval() const override;
 
       /// Get the size of the test (eg. rate of Type I error)
-      virtual Double_t Size() const {return fSize;}
+      Double_t Size() const override {return fSize;}
       /// Get the Confidence level for the test
-      virtual Double_t ConfidenceLevel()  const {return 1.-fSize;}
+      Double_t ConfidenceLevel()  const override {return 1.-fSize;}
       /// Set the DataSet
-      virtual void SetData(RooAbsData& /*data*/) {
+      void SetData(RooAbsData& /*data*/) override {
          std::cout << "DEPRECATED, set data in constructor" << std::endl;
       }
       /// Set the Pdf
@@ -76,11 +76,11 @@ namespace RooStats {
       }
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize(Double_t size) {fSize = size;}
+      void SetTestSize(Double_t size) override {fSize = size;}
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;}
+      void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;}
 
-      virtual void SetModel(const ModelConfig &);
+      void SetModel(const ModelConfig &) override;
 
       RooAbsData* GetPointsToScan() {
    if(!fPointsToTest) CreateParameterPoints();
@@ -134,7 +134,7 @@ namespace RooStats {
       Bool_t fCreateBelt;                     ///< controls use if ConfidenceBelt should be saved to a TFile
 
    protected:
-      ClassDef(FeldmanCousins,2)   // Interface for tools setting limits (producing confidence intervals)
+      ClassDefOverride(FeldmanCousins,2)   // Interface for tools setting limits (producing confidence intervals)
    };
 }
 

--- a/roofit/roostats/inc/RooStats/FrequentistCalculator.h
+++ b/roofit/roostats/inc/RooStats/FrequentistCalculator.h
@@ -43,7 +43,7 @@ namespace RooStats {
       {
       }
 
-      ~FrequentistCalculator() {
+      ~FrequentistCalculator() override {
          if( fConditionalMLEsNull ) delete fConditionalMLEsNull;
          if( fConditionalMLEsAlt ) delete fConditionalMLEsAlt;
          if( fFitInfo ) delete fFitInfo;
@@ -78,19 +78,19 @@ namespace RooStats {
          fStoreFitInfo = val;
       }
 
-      const RooArgSet* GetFitInfo() const {
+      const RooArgSet* GetFitInfo() const override {
          return fFitInfo;
       }
 
    protected:
       /// configure TestStatSampler for the Null run
-      int PreNullHook(RooArgSet *parameterPoint, double obsTestStat) const;
+      int PreNullHook(RooArgSet *parameterPoint, double obsTestStat) const override;
 
       /// configure TestStatSampler for the Alt run
-      int PreAltHook(RooArgSet *parameterPoint, double obsTestStat) const;
+      int PreAltHook(RooArgSet *parameterPoint, double obsTestStat) const override;
 
-      void PreHook() const;
-      void PostHook() const;
+      void PreHook() const override;
+      void PostHook() const override;
 
    protected:
       // MLE inputs
@@ -110,7 +110,7 @@ namespace RooStats {
       bool fStoreFitInfo;
 
    protected:
-      ClassDef(FrequentistCalculator,1)
+      ClassDefOverride(FrequentistCalculator,1)
    };
 }
 

--- a/roofit/roostats/inc/RooStats/HLFactory.h
+++ b/roofit/roostats/inc/RooStats/HLFactory.h
@@ -46,7 +46,7 @@ namespace RooStats {
     HLFactory();
 
     /// Default Destructor
-    ~HLFactory();
+    ~HLFactory() override;
 
     /// Add channel for the combination
     int AddChannel(const char* label,
@@ -130,7 +130,7 @@ namespace RooStats {
     int fParseLine(TString& line);
 
 
-  ClassDef(HLFactory,1)  // The high Level Model Factory to create models from datacards
+  ClassDefOverride(HLFactory,1)  // The high Level Model Factory to create models from datacards
 
   };
 }

--- a/roofit/roostats/inc/RooStats/Heaviside.h
+++ b/roofit/roostats/inc/RooStats/Heaviside.h
@@ -22,19 +22,19 @@ namespace RooStats {
             RooAbsReal& _x,
             RooAbsReal& _c);
       Heaviside(const Heaviside& other, const char* name=0) ;
-      virtual TObject* clone(const char* newname) const { return new Heaviside(*this,newname); }
-      inline virtual ~Heaviside() { }
+      TObject* clone(const char* newname) const override { return new Heaviside(*this,newname); }
+      inline ~Heaviside() override { }
 
    protected:
 
       RooRealProxy x ;
       RooRealProxy c ;
 
-      Double_t evaluate() const ;
+      Double_t evaluate() const override ;
 
    private:
 
-      ClassDef(Heaviside,1) // Your description goes here...
+      ClassDefOverride(Heaviside,1) // Your description goes here...
    };
 }
 

--- a/roofit/roostats/inc/RooStats/HybridCalculator.h
+++ b/roofit/roostats/inc/RooStats/HybridCalculator.h
@@ -40,7 +40,7 @@ namespace RooStats {
       {
       }
 
-      ~HybridCalculator() {
+      ~HybridCalculator() override {
          if(!fPriorNuisanceNullExternal) delete fPriorNuisanceNull;
          if(!fPriorNuisanceAltExternal) delete fPriorNuisanceAlt;
       }
@@ -58,14 +58,14 @@ namespace RooStats {
          fPriorNuisanceAltExternal = true;
       }
 
-      virtual void SetNullModel(const ModelConfig &nullModel) {
+      void SetNullModel(const ModelConfig &nullModel) override {
          fNullModel = &nullModel;
          if(!fPriorNuisanceNullExternal) delete fPriorNuisanceNull;
          fPriorNuisanceNull = MakeNuisancePdf(nullModel, "PriorNuisanceNull");
          fPriorNuisanceAltExternal = false;
       }
 
-      virtual void SetAlternateModel(const ModelConfig &altModel) {
+      void SetAlternateModel(const ModelConfig &altModel) override {
          fAltModel = &altModel;
          if(!fPriorNuisanceAltExternal) delete fPriorNuisanceAlt;
          fPriorNuisanceAlt = MakeNuisancePdf(altModel, "PriorNuisanceAlt");
@@ -80,13 +80,13 @@ namespace RooStats {
 
    protected:
       /// check whether all input is consistent
-      int CheckHook(void) const;
+      int CheckHook(void) const override;
 
       /// configure TestStatSampler for the Null run
-      int PreNullHook(RooArgSet* /*parameterPoint*/, double obsTestStat) const;
+      int PreNullHook(RooArgSet* /*parameterPoint*/, double obsTestStat) const override;
 
       /// configure TestStatSampler for the Alt run
-      int PreAltHook(RooArgSet* /*parameterPoint*/, double obsTestStat) const;
+      int PreAltHook(RooArgSet* /*parameterPoint*/, double obsTestStat) const override;
 
    protected:
       RooAbsPdf *fPriorNuisanceNull;
@@ -106,7 +106,7 @@ namespace RooStats {
       int fNToysAltTail;
 
    protected:
-      ClassDef(HybridCalculator,2)
+      ClassDefOverride(HybridCalculator,2)
    };
 }
 

--- a/roofit/roostats/inc/RooStats/HybridCalculatorOriginal.h
+++ b/roofit/roostats/inc/RooStats/HybridCalculatorOriginal.h
@@ -66,18 +66,18 @@ namespace RooStats {
    public:
 
       /// Destructor of HybridCalculator
-      virtual ~HybridCalculatorOriginal();
+      ~HybridCalculatorOriginal() override;
 
       /// inherited methods from HypoTestCalculator interface
-      virtual HybridResult* GetHypoTest() const;
+      HybridResult* GetHypoTest() const override;
 
       // inherited setter methods from HypoTestCalculator
 
 
       /// set the model for the null hypothesis (only B)
-      virtual void SetNullModel(const ModelConfig & );
+      void SetNullModel(const ModelConfig & ) override;
       /// set the model for the alternate hypothesis  (S+B)
-      virtual void SetAlternateModel(const ModelConfig & );
+      void SetAlternateModel(const ModelConfig & ) override;
 
 
       /// Set a common PDF for both the null and alternate
@@ -88,7 +88,7 @@ namespace RooStats {
       virtual void SetAlternatePdf(RooAbsPdf& pdf) { fSbModel = &pdf;  }
 
       /// Set the DataSet
-      virtual void SetData(RooAbsData& data) { fData = &data; }
+      void SetData(RooAbsData& data) override { fData = &data; }
 
       /// set parameter values for the null if using a common PDF
       virtual void SetNullParameters(const RooArgSet& ) { } // not needed
@@ -151,7 +151,7 @@ namespace RooStats {
       bool fTmpDoExtended;
 
    protected:
-      ClassDef(HybridCalculatorOriginal,1)  // Hypothesis test calculator using a Bayesian-frequentist hybrid method
+      ClassDefOverride(HybridCalculatorOriginal,1)  // Hypothesis test calculator using a Bayesian-frequentist hybrid method
    };
 
 }

--- a/roofit/roostats/inc/RooStats/HybridPlot.h
+++ b/roofit/roostats/inc/RooStats/HybridPlot.h
@@ -47,10 +47,10 @@ namespace RooStats {
                  bool verbosity=true);
 
       /// Destructor
-      ~HybridPlot();
+      ~HybridPlot() override;
 
       /// Draw on current pad
-      void Draw (const char* options="");
+      void Draw (const char* options="") override;
 
       /// All the objects are written to rootfile
       void DumpToFile (const char* RootFileName, const char* options);
@@ -118,7 +118,7 @@ namespace RooStats {
       TVirtualPad * fPad;         ///< The pad where it has been drawn
       bool fVerbose;              ///< verbosity flag
 
-      ClassDef(HybridPlot,1)   // Provides the plots for an HybridResult
+      ClassDefOverride(HybridPlot,1)   // Provides the plots for an HybridResult
    };
 }
 

--- a/roofit/roostats/inc/RooStats/HybridResult.h
+++ b/roofit/roostats/inc/RooStats/HybridResult.h
@@ -39,7 +39,7 @@ namespace RooStats {
 
 
       /// Destructor of HybridResult
-      virtual ~HybridResult();
+      ~HybridResult() override;
 
       void SetDataTestStatistics(double testStat_data_val);
 
@@ -59,10 +59,10 @@ namespace RooStats {
       double GetTestStat_data(){ return fTestStat_data;}
 
       // Return p-value for null hypothesis
-      Double_t NullPValue() const;
+      Double_t NullPValue() const override;
 
       // Return p-value for alternate hypothesis
-      Double_t AlternatePValue() const;
+      Double_t AlternatePValue() const override;
 
       /// The error on the "confidence level" of the null hypothesis
       Double_t CLbError() const;
@@ -85,7 +85,7 @@ namespace RooStats {
 
    protected:
 
-      ClassDef(HybridResult,1)  // Class containing the results of the HybridCalculator
+      ClassDefOverride(HybridResult,1)  // Class containing the results of the HybridCalculator
    };
 }
 

--- a/roofit/roostats/inc/RooStats/HypoTestCalculatorGeneric.h
+++ b/roofit/roostats/inc/RooStats/HypoTestCalculatorGeneric.h
@@ -42,24 +42,24 @@ namespace RooStats {
       );
 
 
-      ~HypoTestCalculatorGeneric();
+      ~HypoTestCalculatorGeneric() override;
 
 
    public:
 
       /// inherited methods from HypoTestCalculator interface
-      virtual HypoTestResult* GetHypoTest() const;
+      HypoTestResult* GetHypoTest() const override;
 
       /// set the model for the null hypothesis (only B)
-      virtual void SetNullModel(const ModelConfig &nullModel) { fNullModel = &nullModel; }
+      void SetNullModel(const ModelConfig &nullModel) override { fNullModel = &nullModel; }
       const RooAbsData * GetData(void) const { return fData; }
       const ModelConfig* GetNullModel(void) const { return fNullModel; }
       virtual const RooArgSet* GetFitInfo() const { return NULL; }
       /// Set the model for the alternate hypothesis  (S+B)
-      virtual void SetAlternateModel(const ModelConfig &altModel) { fAltModel = &altModel; }
+      void SetAlternateModel(const ModelConfig &altModel) override { fAltModel = &altModel; }
       const ModelConfig* GetAlternateModel(void) const { return fAltModel; }
       /// Set the DataSet
-      virtual void SetData(RooAbsData &data) { fData = &data; }
+      void SetData(RooAbsData &data) override { fData = &data; }
 
       /// Returns instance of TestStatSampler. Use to change properties of
       /// TestStatSampler, e.g. GetTestStatSampler.SetTestSize(Double_t size);
@@ -101,7 +101,7 @@ namespace RooStats {
 
 
    protected:
-   ClassDef(HypoTestCalculatorGeneric,2)
+   ClassDefOverride(HypoTestCalculatorGeneric,2)
 };
 }
 

--- a/roofit/roostats/inc/RooStats/HypoTestInverter.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverter.h
@@ -70,7 +70,7 @@ public:
            double size = 0.05) ;
 
 
-   virtual HypoTestInverterResult* GetInterval() const;
+   HypoTestInverterResult* GetInterval() const override;
 
    void Clear();
 
@@ -103,21 +103,21 @@ public:
 
    void UseCLs( bool on = true) { fUseCLs = on; if (fResults) fResults->UseCLs(on);   }
 
-   virtual void  SetData(RooAbsData &);
+   void  SetData(RooAbsData &) override;
 
-   virtual void SetModel(const ModelConfig &) { } // not needed
+   void SetModel(const ModelConfig &) override { } // not needed
 
    /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-   virtual void SetTestSize(Double_t size) {fSize = size; if (fResults) fResults->SetTestSize(size); }
+   void SetTestSize(Double_t size) override {fSize = size; if (fResults) fResults->SetTestSize(size); }
    /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-   virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;  if (fResults) fResults->SetConfidenceLevel(cl); }
+   void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;  if (fResults) fResults->SetConfidenceLevel(cl); }
    /// Get the size of the test (eg. rate of Type I error)
-   virtual Double_t Size() const {return fSize;}
+   Double_t Size() const override {return fSize;}
    /// Get the Confidence level for the test
-   virtual Double_t ConfidenceLevel()  const {return 1.-fSize;}
+   Double_t ConfidenceLevel()  const override {return 1.-fSize;}
 
    /// destructor
-   virtual ~HypoTestInverter() ;
+   ~HypoTestInverter() override ;
 
    /// retrieved a reference to the internally used HypoTestCalculator
    /// it might be invalid when the class is deleted
@@ -202,7 +202,7 @@ private:
 
 protected:
 
-   ClassDef(HypoTestInverter,4)  // HypoTestInverter class
+   ClassDefOverride(HypoTestInverter,4)  // HypoTestInverter class
 
 };
 

--- a/roofit/roostats/inc/RooStats/HypoTestInverterOriginal.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverterOriginal.h
@@ -39,7 +39,7 @@ namespace RooStats {
 
 
 
-    virtual HypoTestInverterResult* GetInterval() const { return fResults; } ;
+    HypoTestInverterResult* GetInterval() const override { return fResults; } ;
 
     bool RunAutoScan( double xMin, double xMax, double target, double epsilon=0.005, unsigned int numAlgorithm=0 );
 
@@ -49,21 +49,21 @@ namespace RooStats {
 
     void UseCLs( bool on = true) { fUseCLs = on; if (fResults) fResults->UseCLs(on);   }
 
-    virtual void  SetData(RooAbsData &) { } // not needed
+    void  SetData(RooAbsData &) override { } // not needed
 
-    virtual void SetModel(const ModelConfig &) { } // not needed
+    void SetModel(const ModelConfig &) override { } // not needed
 
     /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-     virtual void SetTestSize(Double_t size) {fSize = size; if (fResults) fResults->SetTestSize(size); }
+     void SetTestSize(Double_t size) override {fSize = size; if (fResults) fResults->SetTestSize(size); }
     /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-    virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;  if (fResults) fResults->SetConfidenceLevel(cl); }
+    void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;  if (fResults) fResults->SetConfidenceLevel(cl); }
     /// Get the size of the test (eg. rate of Type I error)
-    virtual Double_t Size() const {return fSize;}
+    Double_t Size() const override {return fSize;}
     /// Get the Confidence level for the test
-    virtual Double_t ConfidenceLevel()  const {return 1.-fSize;}
+    Double_t ConfidenceLevel()  const override {return 1.-fSize;}
 
     /// destructor
-    virtual ~HypoTestInverterOriginal() ;
+    ~HypoTestInverterOriginal() override ;
 
   private:
 
@@ -78,7 +78,7 @@ namespace RooStats {
 
   protected:
 
-    ClassDef(HypoTestInverterOriginal,1)  // HypoTestInverterOriginal class
+    ClassDefOverride(HypoTestInverterOriginal,1)  // HypoTestInverterOriginal class
 
   };
 }

--- a/roofit/roostats/inc/RooStats/HypoTestInverterPlot.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverterPlot.h
@@ -62,10 +62,10 @@ namespace RooStats {
       ///   EXP  :  draw only the expected plot
       ///   CLB  : draw also  CLb
       ///   2CL  : drow both  CLs+b and CLs
-      void Draw(Option_t *opt="");
+      void Draw(Option_t *opt="") override;
 
       /// destructor
-      ~HypoTestInverterPlot() ;
+      ~HypoTestInverterPlot() override ;
 
    private:
 
@@ -73,7 +73,7 @@ namespace RooStats {
 
    protected:
 
-      ClassDef(HypoTestInverterPlot,1)  // HypoTestInverterPlot class
+      ClassDefOverride(HypoTestInverterPlot,1)  // HypoTestInverterPlot class
 
    };
 }

--- a/roofit/roostats/inc/RooStats/HypoTestInverterResult.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverterResult.h
@@ -38,7 +38,7 @@ public:
    HypoTestInverterResult( const HypoTestInverterResult& other, const char* name );
 
    /// destructor
-   virtual ~HypoTestInverterResult();
+   ~HypoTestInverterResult() override;
 
    /// operator =
    HypoTestInverterResult& operator = (const HypoTestInverterResult& other);
@@ -99,7 +99,7 @@ public:
    virtual void SetTestSize( Double_t size ) { fConfidenceLevel = 1.-size; }
 
    /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-   virtual void SetConfidenceLevel( Double_t cl ) { fConfidenceLevel = cl; }
+   void SetConfidenceLevel( Double_t cl ) override { fConfidenceLevel = cl; }
 
    /// set CLs threshold for exclusion cleanup function
    inline void SetCLsCleanupThreshold( Double_t th ) { fCLsCleanupThreshold = th; }
@@ -113,8 +113,8 @@ public:
    bool IsTwoSided() const { return fIsTwoSided; }
 
    /// lower and upper bound of the confidence interval (to get upper/lower limits, multiply the size( = 1-confidence level ) by 2
-   Double_t LowerLimit();
-   Double_t UpperLimit();
+   Double_t LowerLimit() override;
+   Double_t UpperLimit() override;
 
    /// rough estimation of the error on the computed bound of the confidence interval
    /// Estimate of lower limit error
@@ -211,7 +211,7 @@ protected:
    friend class HypoTestInverterPlot;
    friend class HypoTestInverterOriginal;
 
-   ClassDef(HypoTestInverterResult,5)  // HypoTestInverterResult class
+   ClassDefOverride(HypoTestInverterResult,5)  // HypoTestInverterResult class
 };
 }
 

--- a/roofit/roostats/inc/RooStats/HypoTestPlot.h
+++ b/roofit/roostats/inc/RooStats/HypoTestPlot.h
@@ -25,7 +25,7 @@ class HypoTestPlot: public SamplingDistPlot {
    HypoTestPlot() : SamplingDistPlot() , fHypoTestResult(0) {}   // needed for IO
       HypoTestPlot(HypoTestResult& result, Int_t bins=100, Option_t* opt = "NORMALIZE HIST");
       HypoTestPlot(HypoTestResult& result, Int_t bins, Double_t min, Double_t max, Option_t* opt = "NORMALIZE HIST");
-      ~HypoTestPlot(void) {}
+      ~HypoTestPlot(void) override {}
 
       /// Applies a HypoTestResult.
       void ApplyResult(HypoTestResult& result, Option_t* opt = "NORMALIZE HIST");
@@ -36,7 +36,7 @@ class HypoTestPlot: public SamplingDistPlot {
       HypoTestResult *fHypoTestResult;
 
    protected:
-   ClassDef(HypoTestPlot,1)
+   ClassDefOverride(HypoTestPlot,1)
 };
 }
 

--- a/roofit/roostats/inc/RooStats/HypoTestResult.h
+++ b/roofit/roostats/inc/RooStats/HypoTestResult.h
@@ -33,7 +33,7 @@ namespace RooStats {
       HypoTestResult(const char* name, Double_t nullp, Double_t altp);
 
       /// destructor
-      virtual ~HypoTestResult();
+      ~HypoTestResult() override;
 
       /// assignment operator
       HypoTestResult & operator=(const HypoTestResult& other);
@@ -106,7 +106,7 @@ namespace RooStats {
       Double_t SignificanceError() const;
 
 
-      void Print(const Option_t* = "") const;
+      void Print(const Option_t* = "") const override;
 
    private:
       void UpdatePValue(const SamplingDistribution* distr, Double_t &pvalue, Double_t &perror,  Bool_t pIsRightTail);
@@ -128,7 +128,7 @@ namespace RooStats {
       Bool_t fPValueIsRightTail;
       Bool_t fBackgroundIsAlt;
 
-      ClassDef(HypoTestResult,4)  // Base class to represent results of a hypothesis test
+      ClassDefOverride(HypoTestResult,4)  // Base class to represent results of a hypothesis test
 
    };
 }

--- a/roofit/roostats/inc/RooStats/LikelihoodInterval.h
+++ b/roofit/roostats/inc/RooStats/LikelihoodInterval.h
@@ -43,22 +43,22 @@ namespace RooStats {
       LikelihoodInterval(const char* name, RooAbsReal*, const RooArgSet*,  RooArgSet * = 0);
 
       /// destructor
-      virtual ~LikelihoodInterval();
+      ~LikelihoodInterval() override;
 
       /// check if given point is in the interval
-      virtual Bool_t IsInInterval(const RooArgSet&) const;
+      Bool_t IsInInterval(const RooArgSet&) const override;
 
       /// set the confidence level for the interval (e.g 0.682 for a 1-sigma interval)
-      virtual void SetConfidenceLevel(Double_t cl) {fConfidenceLevel = cl; ResetLimits(); }
+      void SetConfidenceLevel(Double_t cl) override {fConfidenceLevel = cl; ResetLimits(); }
 
       /// return confidence level
-      virtual Double_t ConfidenceLevel() const {return fConfidenceLevel;}
+      Double_t ConfidenceLevel() const override {return fConfidenceLevel;}
 
       /// return a cloned list of parameters of interest.  User manages the return object
-      virtual  RooArgSet* GetParameters() const;
+       RooArgSet* GetParameters() const override;
 
       /// check if parameters are correct (i.e. they are the POI of this interval)
-      Bool_t CheckParameters(const RooArgSet&) const ;
+      Bool_t CheckParameters(const RooArgSet&) const override ;
 
 
       /// return the lower bound of the interval on a given parameter
@@ -106,7 +106,7 @@ namespace RooStats {
       std::shared_ptr<RooFunctor>           fFunctor;          ///<! transient pointer to functor class used by the minimizer
       std::shared_ptr<ROOT::Math::IMultiGenFunction> fMinFunc; ///<! transient pointer to the minimization function
 
-      ClassDef(LikelihoodInterval,1)  // Concrete implementation of a ConfInterval based on a likelihood ratio
+      ClassDefOverride(LikelihoodInterval,1)  // Concrete implementation of a ConfInterval based on a likelihood ratio
 
    };
 }

--- a/roofit/roostats/inc/RooStats/LikelihoodIntervalPlot.h
+++ b/roofit/roostats/inc/RooStats/LikelihoodIntervalPlot.h
@@ -35,7 +35,7 @@ namespace RooStats {
     LikelihoodIntervalPlot(LikelihoodInterval* theInterval);
 
     /// Destructor of SamplingDistribution
-    virtual ~LikelihoodIntervalPlot();
+    ~LikelihoodIntervalPlot() override;
 
 
     /// returned plotted object (RooPlot or histograms)
@@ -70,7 +70,7 @@ namespace RooStats {
     /// if option "TF1" is used the objects are drawn using a TF1 scanning the LL function in a
     /// grid of the set points (by default
     /// the TF1 can be costumized by setting maximum and the number of points to scan
-    void Draw(const Option_t *options=0);
+    void Draw(const Option_t *options=0) override;
 
   private:
 
@@ -96,7 +96,7 @@ namespace RooStats {
 
   protected:
 
-    ClassDef(LikelihoodIntervalPlot,2)  // Class containing the results of the IntervalCalculator
+    ClassDefOverride(LikelihoodIntervalPlot,2)  // Class containing the results of the IntervalCalculator
   };
 }
 

--- a/roofit/roostats/inc/RooStats/MCMCCalculator.h
+++ b/roofit/roostats/inc/RooStats/MCMCCalculator.h
@@ -41,20 +41,20 @@ namespace RooStats {
       /// be overridden by calling one of the Set...() methods.
       MCMCCalculator(RooAbsData& data, const ModelConfig& model);
 
-      virtual ~MCMCCalculator() {}
+      ~MCMCCalculator() override {}
 
       /// Main interface to get a ConfInterval
-      virtual MCMCInterval* GetInterval() const;
+      MCMCInterval* GetInterval() const override;
 
       /// Get the size of the test (eg. rate of Type I error)
-      virtual Double_t Size() const {return fSize;}
+      Double_t Size() const override {return fSize;}
       /// Get the Confidence level for the test
-      virtual Double_t ConfidenceLevel() const {return 1.-fSize;}
+      Double_t ConfidenceLevel() const override {return 1.-fSize;}
 
-      virtual void SetModel(const ModelConfig & model);
+      void SetModel(const ModelConfig & model) override;
 
       /// Set the DataSet if not already there
-      virtual void SetData(RooAbsData& data) { fData = &data; }
+      void SetData(RooAbsData& data) override { fData = &data; }
 
       /// Set the Pdf if not already there
       virtual void SetPdf(RooAbsPdf& pdf) { fPdf = &pdf; }
@@ -81,10 +81,10 @@ namespace RooStats {
       virtual void SetGlobalObservables(const RooArgSet& set) {fGlobalObs.removeAll(); fGlobalObs.add(set);}
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize(Double_t size) {fSize = size;}
+      void SetTestSize(Double_t size) override {fSize = size;}
 
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;}
+      void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;}
 
       /// set the proposal function for suggesting new points for the MCMC
       virtual void SetProposalFunction(ProposalFunction& proposalFunction)
@@ -203,7 +203,7 @@ namespace RooStats {
          delete it;
       }
 
-      ClassDef(MCMCCalculator,4) // Markov Chain Monte Carlo calculator for Bayesian credible intervals
+      ClassDefOverride(MCMCCalculator,4) // Markov Chain Monte Carlo calculator for Bayesian credible intervals
    };
 }
 

--- a/roofit/roostats/inc/RooStats/MCMCInterval.h
+++ b/roofit/roostats/inc/RooStats/MCMCInterval.h
@@ -45,10 +45,10 @@ namespace RooStats {
       enum {DEFAULT_NUM_BINS = 50};
       enum IntervalType {kShortest, kTailFraction};
 
-      virtual ~MCMCInterval();
+      ~MCMCInterval() override;
 
       /// determine whether this point is in the confidence interval
-      virtual Bool_t IsInInterval(const RooArgSet& point) const;
+      Bool_t IsInInterval(const RooArgSet& point) const override;
 
       /// set the desired confidence level (see GetActualConfidenceLevel())
       /// Note: calling this function triggers the algorithm that determines
@@ -56,14 +56,14 @@ namespace RooStats {
       /// of this IntervalCalculator
       /// Also, calling this function again with a different confidence level
       /// re-triggers the calculation of the interval
-      virtual void SetConfidenceLevel(Double_t cl);
+      void SetConfidenceLevel(Double_t cl) override;
 
       /// get the desired confidence level (see GetActualConfidenceLevel())
-      virtual Double_t ConfidenceLevel() const {return fConfidenceLevel;}
+      Double_t ConfidenceLevel() const override {return fConfidenceLevel;}
 
       /// return a set containing the parameters of this interval
       /// the caller owns the returned RooArgSet*
-      virtual RooArgSet* GetParameters() const;
+      RooArgSet* GetParameters() const override;
 
       /// get the cutoff bin height for being considered in the
       /// confidence interval
@@ -83,7 +83,7 @@ namespace RooStats {
       { fIsHistStrict = isHistStrict; }
 
       /// check if parameters are correct. (dummy implementation to start)
-      Bool_t CheckParameters(const RooArgSet& point) const;
+      Bool_t CheckParameters(const RooArgSet& point) const override;
 
       /// Set the parameters of interest for this interval
       /// and change other internal data members accordingly
@@ -341,7 +341,7 @@ namespace RooStats {
       virtual void CreateVector(RooRealVar* param);
       inline virtual Double_t CalcConfLevel(Double_t cutoff, Double_t full);
 
-      ClassDef(MCMCInterval,1)  // Concrete implementation of a ConfInterval based on MCMC calculation
+      ClassDefOverride(MCMCInterval,1)  // Concrete implementation of a ConfInterval based on MCMC calculation
 
    };
 }

--- a/roofit/roostats/inc/RooStats/MCMCIntervalPlot.h
+++ b/roofit/roostats/inc/RooStats/MCMCIntervalPlot.h
@@ -32,7 +32,7 @@ namespace RooStats {
       MCMCIntervalPlot(MCMCInterval& interval);
 
       /// Destructor of SamplingDistribution
-      virtual ~MCMCIntervalPlot();
+      ~MCMCIntervalPlot() override;
 
       void SetMCMCInterval(MCMCInterval& interval);
       void SetLineColor(Color_t color) {fLineColor = color;}
@@ -40,7 +40,7 @@ namespace RooStats {
       void SetShadeColor(Color_t color) {fShadeColor = color;}
       void SetShowBurnIn(Bool_t showBurnIn) { fShowBurnIn = showBurnIn; }
 
-      void Draw(const Option_t* options = NULL);
+      void Draw(const Option_t* options = NULL) override;
 
       void DrawChainScatter(RooRealVar& xVar, RooRealVar& yVar);
       void DrawParameterVsTime(RooRealVar& param);
@@ -83,7 +83,7 @@ namespace RooStats {
       void DrawKeysPdfInterval(const Option_t* options = NULL);
       void DrawTailFractionInterval(const Option_t* options = NULL);
 
-      ClassDef(MCMCIntervalPlot,1)  // Class containing the results of the MCMCCalculator
+      ClassDefOverride(MCMCIntervalPlot,1)  // Class containing the results of the MCMCCalculator
    };
 }
 

--- a/roofit/roostats/inc/RooStats/MarkovChain.h
+++ b/roofit/roostats/inc/RooStats/MarkovChain.h
@@ -104,7 +104,7 @@ namespace RooStats {
       virtual RooRealVar* GetWeightVar() const
       { return (RooRealVar*)fWeight->Clone(); }
 
-      virtual ~MarkovChain()
+      ~MarkovChain() override
       {
          delete fParameters;
          delete fDataEntry;
@@ -118,7 +118,7 @@ namespace RooStats {
       RooRealVar* fNLL;
       RooRealVar* fWeight;
 
-      ClassDef(MarkovChain,1);
+      ClassDefOverride(MarkovChain,1);
    };
 }
 

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -67,7 +67,7 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
    }
 
   //______________________________
-  virtual Double_t Evaluate(RooAbsData& data, RooArgSet& /*nullPOI*/) {
+  Double_t Evaluate(RooAbsData& data, RooArgSet& /*nullPOI*/) override {
 
 
     RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
@@ -135,18 +135,18 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
 
   }
 
-  virtual const TString GetVarName() const {
+  const TString GetVarName() const override {
     TString varName = Form("Maximum Likelihood Estimate of %s",fParameter->GetName());
     return varName;
   }
 
 
   virtual void PValueIsRightTail(bool isright) {  fUpperLimit = isright; }
-  virtual bool PValueIsRightTail(void) const { return fUpperLimit; }
+  bool PValueIsRightTail(void) const override { return fUpperLimit; }
 
    // set the conditional observables which will be used when creating the NLL
    // so the pdf's will not be normalized on the conditional observables when computing the NLL
-   virtual void SetConditionalObservables(const RooArgSet& set) {fConditionalObs.removeAll(); fConditionalObs.add(set);}
+   void SetConditionalObservables(const RooArgSet& set) override {fConditionalObs.removeAll(); fConditionalObs.add(set);}
 
 
    private:
@@ -161,7 +161,7 @@ class MaxLikelihoodEstimateTestStat: public TestStatistic {
 
 
    protected:
-   ClassDef(MaxLikelihoodEstimateTestStat,2)
+   ClassDefOverride(MaxLikelihoodEstimateTestStat,2)
 };
 
 }

--- a/roofit/roostats/inc/RooStats/MetropolisHastings.h
+++ b/roofit/roostats/inc/RooStats/MetropolisHastings.h
@@ -35,7 +35,7 @@ namespace RooStats {
       MetropolisHastings(RooAbsReal& function, const RooArgSet& paramsOfInterest,
             ProposalFunction& proposalFunction, Int_t numIters);
 
-      virtual ~MetropolisHastings() {}
+      ~MetropolisHastings() override {}
 
       /// main purpose of MetropolisHastings - run Metropolis-Hastings
       /// algorithm to generate Markov Chain of points in the parameter space
@@ -80,7 +80,7 @@ namespace RooStats {
       virtual Bool_t ShouldTakeStep(Double_t d);
       virtual Double_t CalcNLL(Double_t xL);
 
-      ClassDef(MetropolisHastings,2) // Markov Chain Monte Carlo calculator for Bayesian credible intervals
+      ClassDefOverride(MetropolisHastings,2) // Markov Chain Monte Carlo calculator for Bayesian credible intervals
    };
 }
 

--- a/roofit/roostats/inc/RooStats/MinNLLTestStat.h
+++ b/roofit/roostats/inc/RooStats/MinNLLTestStat.h
@@ -70,7 +70,7 @@ Internally it operates by delegating to a MinNLLTestStat object.
         return *this;
      }
 
-     virtual ~MinNLLTestStat() {
+     ~MinNLLTestStat() override {
    delete fProflts;
      }
 
@@ -84,13 +84,13 @@ Internally it operates by delegating to a MinNLLTestStat object.
      void SetLOffset(Bool_t flag=kTRUE) { fProflts->SetLOffset(flag) ; }
 
      // Main interface to evaluate the test statistic on a dataset
-     virtual Double_t Evaluate(RooAbsData& data, RooArgSet& paramsOfInterest) {
+     Double_t Evaluate(RooAbsData& data, RooArgSet& paramsOfInterest) override {
        return fProflts->EvaluateProfileLikelihood(1, data, paramsOfInterest); //find unconditional NLL minimum
      }
 
      virtual void EnableDetailedOutput( bool e=true ) { fProflts->EnableDetailedOutput(e); }
 
-     virtual const RooArgSet* GetDetailedOutput(void) const {
+     const RooArgSet* GetDetailedOutput(void) const override {
         // Returns detailed output. The value returned by this function is updated after each call to Evaluate().
         // The returned RooArgSet contains the following:
         //
@@ -101,13 +101,13 @@ Internally it operates by delegating to a MinNLLTestStat object.
 
      virtual void SetVarName(const char* name) { fProflts->SetVarName(name); }
 
-     virtual const TString GetVarName() const { return fProflts->GetVarName(); }
+     const TString GetVarName() const override { return fProflts->GetVarName(); }
 
    private:
      ProfileLikelihoodTestStat* fProflts;
 
    protected:
-      ClassDef(MinNLLTestStat,1)   // implements the minimum NLL as a test statistic to be used with several tools
+      ClassDefOverride(MinNLLTestStat,1)   // implements the minimum NLL as a test statistic to be used with several tools
    };
 }
 

--- a/roofit/roostats/inc/RooStats/ModelConfig.h
+++ b/roofit/roostats/inc/RooStats/ModelConfig.h
@@ -51,7 +51,7 @@ public:
 
 
    /// clone
-   virtual ModelConfig * Clone(const char * name = "") const override {
+   ModelConfig * Clone(const char * name = "") const override {
       ModelConfig * mc =  new ModelConfig(*this);
       if(strcmp(name,"")==0)
    mc->SetName(this->GetName());
@@ -61,12 +61,12 @@ public:
    }
 
    /// Set a workspace that owns all the necessary components for the analysis.
-   virtual void SetWS(RooWorkspace & ws) override;
+   void SetWS(RooWorkspace & ws) override;
    //// alias for SetWS(...)
    virtual void SetWorkspace(RooWorkspace & ws) { SetWS(ws); }
 
    /// Remove the existing reference to a workspace and replace it with this new one.
-   virtual void ReplaceWS(RooWorkspace *ws) override {
+   void ReplaceWS(RooWorkspace *ws) override {
      fRefWS = nullptr;
      SetWS(*ws);
    }
@@ -269,7 +269,7 @@ public:
    void GuessObsAndNuisance(const RooAbsData& data, bool printModelConfig = true);
 
    /// overload the print method
-   virtual void Print(Option_t* option = "") const override;
+   void Print(Option_t* option = "") const override;
 
 protected:
 

--- a/roofit/roostats/inc/RooStats/NeymanConstruction.h
+++ b/roofit/roostats/inc/RooStats/NeymanConstruction.h
@@ -40,10 +40,10 @@ namespace RooStats {
      ///     NeymanConstruction();
      NeymanConstruction(RooAbsData& data, ModelConfig& model);
 
-     virtual ~NeymanConstruction();
+     ~NeymanConstruction() override;
 
       /// Main interface to get a ConfInterval (will be a PointSetInterval)
-     virtual PointSetInterval* GetInterval() const;
+     PointSetInterval* GetInterval() const override;
 
       /// in addition to interface we also need:
       /// Set the TestStatSampler (eg. ToyMC or FFT, includes choice of TestStatistic)
@@ -66,16 +66,16 @@ namespace RooStats {
       ///      void SetNumSteps(std::map<RooAbsArg, Int_t>)
 
       /// Get the size of the test (eg. rate of Type I error)
-      virtual Double_t Size() const {return fSize;}
+      Double_t Size() const override {return fSize;}
 
       /// Get the Confidence level for the test
-      virtual Double_t ConfidenceLevel()  const {return 1.-fSize;}
+      Double_t ConfidenceLevel()  const override {return 1.-fSize;}
 
       /// Set ModelConfig
-      virtual void SetModel(const ModelConfig &model) {fModel = model;}
+      void SetModel(const ModelConfig &model) override {fModel = model;}
 
       /// Set the DataSet
-      virtual void SetData(RooAbsData& data) { fData = data; }
+      void SetData(RooAbsData& data) override { fData = data; }
 
       /// Set the Pdf, add to the the workspace if not already there
       virtual void SetPdf(RooAbsPdf& /*pdf*/) {
@@ -93,9 +93,9 @@ namespace RooStats {
       }
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize(Double_t size) {fSize = size;}
+      void SetTestSize(Double_t size) override {fSize = size;}
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel(Double_t cl) {fSize = 1.-cl;}
+      void SetConfidenceLevel(Double_t cl) override {fSize = 1.-cl;}
 
       /// Get confidence belt. This requires that CreateConfBelt() has been called.
       ConfidenceBelt* GetConfidenceBelt() {return fCreateBelt ? fConfBelt : nullptr;}
@@ -135,7 +135,7 @@ namespace RooStats {
       bool fCreateBelt;                ///< controls use if ConfidenceBelt should be saved to a TFile
 
    protected:
-      ClassDef(NeymanConstruction,1)   ///< Interface for tools setting limits (producing confidence intervals)
+      ClassDefOverride(NeymanConstruction,1)   ///< Interface for tools setting limits (producing confidence intervals)
    };
 }
 

--- a/roofit/roostats/inc/RooStats/NumEventsTestStat.h
+++ b/roofit/roostats/inc/RooStats/NumEventsTestStat.h
@@ -45,13 +45,13 @@ namespace RooStats {
      NumEventsTestStat(RooAbsPdf& pdf) {
        fPdf = &pdf;
      }
-     virtual ~NumEventsTestStat() {
+     ~NumEventsTestStat() override {
        //       delete fRand;
        //       delete fTestStatistic;
      }
     
      // Main interface to evaluate the test statistic on a dataset
-     virtual Double_t Evaluate(RooAbsData& data, RooArgSet& /*paramsOfInterest*/)  {       
+     Double_t Evaluate(RooAbsData& data, RooArgSet& /*paramsOfInterest*/) override  {       
       
          if(data.isWeighted()) {
             return data.sumEntries();
@@ -82,14 +82,14 @@ namespace RooStats {
       // Get the TestStatistic
       virtual const RooAbsArg* GetTestStatistic()  const {return fPdf;}  
 
-      virtual const TString GetVarName() const {return "Number of events";}
+      const TString GetVarName() const override {return "Number of events";}
     
       
    private:
       RooAbsPdf* fPdf;
 
    protected:
-      ClassDef(NumEventsTestStat,1)   
+      ClassDefOverride(NumEventsTestStat,1)   
    };
 
 }

--- a/roofit/roostats/inc/RooStats/PdfProposal.h
+++ b/roofit/roostats/inc/RooStats/PdfProposal.h
@@ -34,16 +34,16 @@ namespace RooStats {
       PdfProposal(RooAbsPdf& pdf);
 
       /// Populate xPrime with a new proposed point
-      virtual void Propose(RooArgSet& xPrime, RooArgSet& x);
+      void Propose(RooArgSet& xPrime, RooArgSet& x) override;
 
       /// Determine whether or not the proposal density is symmetric for
       /// points x1 and x2 - that is, whether the probability of reaching x2
       /// from x1 is equal to the probability of reaching x1 from x2
-      virtual Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2);
+      Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) override;
 
       /// Return the probability of proposing the point x1 given the starting
       /// point x2
-      virtual Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2);
+      Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2) override;
 
       /// Set the PDF to be the proposal density function
       virtual void SetPdf(RooAbsPdf& pdf) { fPdf = &pdf; }
@@ -93,7 +93,7 @@ namespace RooStats {
       //virtual void SetIsAlwaysSymmetric(Bool_t isAlwaysSymmetric)
       //{ fIsAlwaysSymmetric = isAlwaysSymmetric; }
 
-      virtual ~PdfProposal()
+      ~PdfProposal() override
       {
          delete fCache;
          if (fOwnsPdf)
@@ -116,7 +116,7 @@ namespace RooStats {
       virtual Bool_t Equals(RooArgSet& x1, RooArgSet& x2);
 
       /// Interface for tools setting limits (producing confidence intervals)
-      ClassDef(PdfProposal,1)
+      ClassDefOverride(PdfProposal,1)
    };
 }
 

--- a/roofit/roostats/inc/RooStats/PointSetInterval.h
+++ b/roofit/roostats/inc/RooStats/PointSetInterval.h
@@ -29,30 +29,30 @@ namespace RooStats {
     PointSetInterval(const char* name, RooAbsData&);
 
     /// destructor
-    virtual ~PointSetInterval();
+    ~PointSetInterval() override;
 
 
     /// check if parameter is in the interval
-    virtual Bool_t IsInInterval(const RooArgSet&) const;
+    Bool_t IsInInterval(const RooArgSet&) const override;
 
     /// set the confidence level for the interval
-    virtual void SetConfidenceLevel(Double_t cl) {fConfidenceLevel = cl;}
+    void SetConfidenceLevel(Double_t cl) override {fConfidenceLevel = cl;}
 
     /// return the confidence level for the interval
-    virtual Double_t ConfidenceLevel() const {return fConfidenceLevel;}
+    Double_t ConfidenceLevel() const override {return fConfidenceLevel;}
 
     /// Method to return lower limit on a given parameter
     ///  Double_t LowerLimit(RooRealVar& param) ; // could provide, but misleading?
     ///      Double_t UpperLimit(RooRealVar& param) ; // could provide, but misleading?
 
     /// return a cloned list with the parameter of interest
-    virtual RooArgSet* GetParameters() const;
+    RooArgSet* GetParameters() const override;
 
     /// return a copy of the data set (points) defining this interval
     RooAbsData* GetParameterPoints() const {return (RooAbsData*)fParameterPointsInInterval->Clone();}
 
     /// return a cloned list with the parameter of interest
-    Bool_t CheckParameters(const RooArgSet&) const ;
+    Bool_t CheckParameters(const RooArgSet&) const override ;
 
     /// return lower limit on a given parameter
     Double_t LowerLimit(RooRealVar& param) ;
@@ -63,7 +63,7 @@ namespace RooStats {
 
   protected:
 
-    ClassDef(PointSetInterval,1)  // Concrete implementation of ConfInterval for simple 1-D intervals in the form [a,b]
+    ClassDefOverride(PointSetInterval,1)  // Concrete implementation of ConfInterval for simple 1-D intervals in the form [a,b]
 
   private:
 

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodCalculator.h
@@ -42,16 +42,16 @@ namespace RooStats {
       ProfileLikelihoodCalculator(RooAbsData& data, ModelConfig & model, Double_t size = 0.05);
 
 
-      virtual ~ProfileLikelihoodCalculator();
+      ~ProfileLikelihoodCalculator() override;
 
       /// Return a likelihood interval. A global fit to the likelihood is performed and
       /// the interval is constructed using the profile likelihood ratio function of the POI.
-      virtual LikelihoodInterval* GetInterval() const ;
+      LikelihoodInterval* GetInterval() const override ;
 
       /// Return the hypothesis test result obtained from the likelihood ratio of the
       /// maximum likelihood value with the null parameters fixed to their values, with respect to keeping all parameters
       /// floating (global maximum likelihood value).
-      virtual HypoTestResult* GetHypoTest() const;
+      HypoTestResult* GetHypoTest() const override;
 
 
 
@@ -71,7 +71,7 @@ namespace RooStats {
     mutable bool fGlobalFitDone;        ///< flag to control if a global fit has been done
 
 
-    ClassDef(ProfileLikelihoodCalculator,2) // A concrete implementation of CombinedCalculator that uses the ProfileLikelihood ratio.
+    ClassDefOverride(ProfileLikelihoodCalculator,2) // A concrete implementation of CombinedCalculator that uses the ProfileLikelihood ratio.
 
    };
 }

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
@@ -76,7 +76,7 @@ namespace RooStats {
        fPrintLevel=::ROOT::Math::MinimizerOptions::DefaultPrintLevel();
      }
 
-     virtual ~ProfileLikelihoodTestStat() {
+     ~ProfileLikelihoodTestStat() override {
        if(fNll) delete fNll;
        if(fCachedBestFitParams) delete fCachedBestFitParams;
        if(fDetailedOutput) delete fDetailedOutput;
@@ -100,7 +100,7 @@ namespace RooStats {
      void SetPrintLevel(Int_t printlevel){fPrintLevel=printlevel;}
 
      /// Main interface to evaluate the test statistic on a dataset
-     virtual Double_t Evaluate(RooAbsData& data, RooArgSet& paramsOfInterest) {
+     Double_t Evaluate(RooAbsData& data, RooArgSet& paramsOfInterest) override {
         return EvaluateProfileLikelihood(0, data, paramsOfInterest);
      }
 
@@ -119,20 +119,20 @@ namespace RooStats {
      ///  - the minimum nll, fitstatus and convergence quality for each fit </li>
      ///  - for each fit and for each non-constant parameter, the value, error and pull of the parameter are stored </li>
      ///
-     virtual const RooArgSet* GetDetailedOutput(void) const {
+     const RooArgSet* GetDetailedOutput(void) const override {
       return fDetailedOutput;
      }
 
      /// set the conditional observables which will be used when creating the NLL
      /// so the pdf's will not be normalized on the conditional observables when computing the NLL
-     virtual void SetConditionalObservables(const RooArgSet& set) {fConditionalObs.removeAll(); fConditionalObs.add(set);}
+     void SetConditionalObservables(const RooArgSet& set) override {fConditionalObs.removeAll(); fConditionalObs.add(set);}
 
      /// set the global observables which will be used when creating the NLL
      /// so the constraint pdf's will be normalized correctly on the global observables when computing the NLL
-     virtual void SetGlobalObservables(const RooArgSet& set) {fGlobalObs.removeAll(); fGlobalObs.add(set);}
+     void SetGlobalObservables(const RooArgSet& set) override {fGlobalObs.removeAll(); fGlobalObs.add(set);}
 
      virtual void SetVarName(const char* name) { fVarName = name; }
-     virtual const TString GetVarName() const {return fVarName;}
+     const TString GetVarName() const override {return fVarName;}
 
      virtual RooAbsPdf * GetPdf() const { return fPdf; }
 
@@ -170,7 +170,7 @@ namespace RooStats {
 
    protected:
 
-      ClassDef(ProfileLikelihoodTestStat,10)   // implements the profile likelihood ratio as a test statistic to be used with several tools
+      ClassDefOverride(ProfileLikelihoodTestStat,10)   // implements the profile likelihood ratio as a test statistic to be used with several tools
    };
 }
 

--- a/roofit/roostats/inc/RooStats/ProposalFunction.h
+++ b/roofit/roostats/inc/RooStats/ProposalFunction.h
@@ -45,7 +45,7 @@ the proposal density to maintain detailed balance.
       ///Default constructor
       ProposalFunction() {}
 
-      virtual ~ProposalFunction() {}
+      ~ProposalFunction() override {}
 
       /// Populate xPrime with the new proposed point,
       /// possibly based on the current point x
@@ -83,7 +83,7 @@ the proposal density to maintain detailed balance.
       }
 
    protected:
-      ClassDef(ProposalFunction,1) /// Interface for the proposal function used with Markov Chain Monte Carlo
+      ClassDefOverride(ProposalFunction,1) /// Interface for the proposal function used with Markov Chain Monte Carlo
    };
 }
 

--- a/roofit/roostats/inc/RooStats/ProposalHelper.h
+++ b/roofit/roostats/inc/RooStats/ProposalHelper.h
@@ -88,7 +88,7 @@ namespace RooStats {
          fOwnsVars = kTRUE;
       }
 
-      virtual ~ProposalHelper()
+      ~ProposalHelper() override
       {
          if (fOwnsPdfProp)      delete fPdfProp;
          if (fOwnsPdf)          delete fPdf;
@@ -123,7 +123,7 @@ namespace RooStats {
       void CreateUniformPdf();
       void CreateCovMatrix(RooArgList& xVec);
 
-      ClassDef(ProposalHelper,1)
+      ClassDefOverride(ProposalHelper,1)
    };
 }
 #endif

--- a/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
+++ b/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
@@ -56,7 +56,7 @@ namespace RooStats {
       }
 
       //__________________________________________
-      ~RatioOfProfiledLikelihoodsTestStat(void) {
+      ~RatioOfProfiledLikelihoodsTestStat(void) override {
          if(fAltPOI) delete fAltPOI;
          if(fDetailedOutput) delete fDetailedOutput;
       }
@@ -69,7 +69,7 @@ namespace RooStats {
       Double_t ProfiledLikelihood(RooAbsData& data, RooArgSet& poi, RooAbsPdf& pdf);
 
       /// evaluate the ratio of profile likelihood
-      virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullParamsOfInterest);
+      Double_t Evaluate(RooAbsData& data, RooArgSet& nullParamsOfInterest) override;
 
       virtual void EnableDetailedOutput( bool e=true ) {
          fDetailedOutputEnabled = e;
@@ -103,14 +103,14 @@ namespace RooStats {
 
       /// set the conditional observables which will be used when creating the NLL
       /// so the pdf's will not be normalized on the conditional observables when computing the NLL
-      virtual void SetConditionalObservables(const RooArgSet& set) {
+      void SetConditionalObservables(const RooArgSet& set) override {
          fNullProfile.SetConditionalObservables(set);
          fAltProfile.SetConditionalObservables(set);
       }
 
       /// set the global observables which will be used when creating the NLL
       /// so the constraint pdf's will be normalized correctly on the global observables when computing the NLL
-      virtual void SetGlobalObservables(const RooArgSet& set) {
+      void SetGlobalObservables(const RooArgSet& set) override {
          fNullProfile.SetGlobalObservables(set);
          fAltProfile.SetGlobalObservables(set);
       }
@@ -119,14 +119,14 @@ namespace RooStats {
       /// The returned RooArgSet contains the following for the alternative and null hypotheses:
       ///  - the minimum nll, fitstatus and convergence quality for each fit
       ///  - for each fit and for each non-constant parameter, the value, error and pull of the parameter are stored
-      virtual const RooArgSet* GetDetailedOutput(void) const {
+      const RooArgSet* GetDetailedOutput(void) const override {
          return fDetailedOutput;
       }
 
 
 
 
-      virtual const TString GetVarName() const { return "log(L(#mu_{1},#hat{#nu}_{1}) / L(#mu_{0},#hat{#nu}_{0}))"; }
+      const TString GetVarName() const override { return "log(L(#mu_{1},#hat{#nu}_{1}) / L(#mu_{0},#hat{#nu}_{0}))"; }
 
       //    const bool PValueIsRightTail(void) { return false; } // overwrites default
 
@@ -146,7 +146,7 @@ namespace RooStats {
 
 
    protected:
-      ClassDef(RatioOfProfiledLikelihoodsTestStat,3)  // implements the ratio of profiled likelihood as test statistic
+      ClassDefOverride(RatioOfProfiledLikelihoodsTestStat,3)  // implements the ratio of profiled likelihood as test statistic
    };
 
 }

--- a/roofit/roostats/inc/RooStats/SPlot.h
+++ b/roofit/roostats/inc/RooStats/SPlot.h
@@ -33,7 +33,7 @@ namespace RooStats{
 
   public:
 
-    ~SPlot();
+    ~SPlot() override;
     SPlot();
     SPlot(const SPlot &other);
     SPlot(const char* name, const char* title);
@@ -81,7 +81,7 @@ namespace RooStats{
 
     RooDataSet* fSData;
 
-    ClassDef(SPlot,1)   // Class used for making sPlots
+    ClassDefOverride(SPlot,1)   // Class used for making sPlots
 
 
       };

--- a/roofit/roostats/inc/RooStats/SamplingDistPlot.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistPlot.h
@@ -37,7 +37,7 @@ namespace RooStats {
     SamplingDistPlot(Int_t nbins, Double_t min, Double_t max);
 
     /// Destructor of SamplingDistribution
-    virtual ~SamplingDistPlot();
+    ~SamplingDistPlot() override;
 
     /// adds the sampling distribution and returns the scale factor
     Double_t AddSamplingDistribution(const SamplingDistribution *samplingDist, Option_t *drawOptions="NORMALIZE HIST");
@@ -54,7 +54,7 @@ namespace RooStats {
     /// set legend
     void SetLegend(TLegend* l){ fLegend = l; }
 
-    void Draw(Option_t *options=0);
+    void Draw(Option_t *options=0) override;
 
     /// Applies a predefined style if fApplyStyle is kTRUE (default).
     void ApplyDefaultStyle(void);
@@ -134,7 +134,7 @@ namespace RooStats {
     void addOtherObject(TObject *obj, Option_t *drawOptions=0);
     void GetAbsoluteInterval(Double_t &theMin, Double_t &theMax, Double_t &theYMax) const;
 
-    ClassDef(SamplingDistPlot,1)  /// Class containing the results of the HybridCalculator
+    ClassDefOverride(SamplingDistPlot,1)  /// Class containing the results of the HybridCalculator
   };
 }
 

--- a/roofit/roostats/inc/RooStats/SamplingDistribution.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistribution.h
@@ -43,7 +43,7 @@ namespace RooStats {
     SamplingDistribution();
 
     /// Destructor of SamplingDistribution
-    virtual ~SamplingDistribution();
+    ~SamplingDistribution() override;
 
     /// get the inverse of the Cumulative distribution function
     Double_t InverseCDF(Double_t pvalue);
@@ -93,7 +93,7 @@ namespace RooStats {
     /// internal function to sort values
     void SortValues() const;
 
-    ClassDef(SamplingDistribution,2)  /// Class containing the results of the HybridCalculator
+    ClassDefOverride(SamplingDistribution,2)  /// Class containing the results of the HybridCalculator
   };
 }
 

--- a/roofit/roostats/inc/RooStats/SequentialProposal.h
+++ b/roofit/roostats/inc/RooStats/SequentialProposal.h
@@ -24,20 +24,20 @@ class SequentialProposal : public ProposalFunction {
       SequentialProposal(double divisor) ;
 
       /// Populate xPrime with a new proposed point
-      virtual void Propose(RooArgSet& xPrime, RooArgSet& x);
+      void Propose(RooArgSet& xPrime, RooArgSet& x) override;
 
       /// Determine whether or not the proposal density is symmetric for
       /// points x1 and x2 - that is, whether the probability of reaching x2
       /// from x1 is equal to the probability of reaching x1 from x2
-      virtual Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) ;
+      Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) override ;
 
       /// Return the probability of proposing the point x1 given the starting
       /// point x2
-      virtual Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2);
+      Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2) override;
 
-      virtual ~SequentialProposal() {}
+      ~SequentialProposal() override {}
 
-      ClassDef(SequentialProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
+      ClassDefOverride(SequentialProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
 
     private:
 

--- a/roofit/roostats/inc/RooStats/SimpleInterval.h
+++ b/roofit/roostats/inc/RooStats/SimpleInterval.h
@@ -33,17 +33,17 @@ namespace RooStats {
     SimpleInterval(const char* name, const RooRealVar & var, Double_t lower, Double_t upper, Double_t cl);
 
     /// destructor
-    virtual ~SimpleInterval();
+    ~SimpleInterval() override;
 
     /// check if parameter is in the interval
-    virtual Bool_t IsInInterval(const RooArgSet&) const;
+    Bool_t IsInInterval(const RooArgSet&) const override;
 
     /// set the confidence level for the interval. Simple interval is defined at construction time so this function
     /// has no effect
-    virtual void SetConfidenceLevel(Double_t ) {}
+    void SetConfidenceLevel(Double_t ) override {}
 
     /// return the confidence interval
-    virtual Double_t ConfidenceLevel() const {return fConfidenceLevel;}
+    Double_t ConfidenceLevel() const override {return fConfidenceLevel;}
 
     /// return the interval lower limit
     virtual Double_t LowerLimit() {return fLowerLimit;}
@@ -51,16 +51,16 @@ namespace RooStats {
     virtual Double_t UpperLimit() {return fUpperLimit;}
 
     /// return a cloned list with the parameter of interest
-    virtual RooArgSet* GetParameters() const;
+    RooArgSet* GetParameters() const override;
 
     /// check if parameters are correct (i.e. they are the POI of this interval)
-    Bool_t CheckParameters(const RooArgSet&) const ;
+    Bool_t CheckParameters(const RooArgSet&) const override ;
 
 
 
   protected:
 
-    ClassDef(SimpleInterval,1)  // Concrete implementation of ConfInterval for simple 1-D intervals in the form [a,b]
+    ClassDefOverride(SimpleInterval,1)  // Concrete implementation of ConfInterval for simple 1-D intervals in the form [a,b]
 
     RooArgSet fParameters;      ///< set containing the parameter of interest
     Double_t  fLowerLimit;      ///< lower interval limit

--- a/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
+++ b/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
@@ -89,7 +89,7 @@ namespace RooStats {
          fNllAlt=NULL ;
       }
 
-      virtual ~SimpleLikelihoodRatioTestStat() {
+      ~SimpleLikelihoodRatioTestStat() override {
          if (fNullParameters) delete fNullParameters;
          if (fAltParameters) delete fAltParameters;
          if (fNllNull) delete fNllNull ;
@@ -134,18 +134,18 @@ namespace RooStats {
 
       /// set the conditional observables which will be used when creating the NLL
       /// so the pdf's will not be normalized on the conditional observables when computing the NLL
-      virtual void SetConditionalObservables(const RooArgSet& set) {fConditionalObs.removeAll(); fConditionalObs.add(set);}
+      void SetConditionalObservables(const RooArgSet& set) override {fConditionalObs.removeAll(); fConditionalObs.add(set);}
 
       /// set the global observables which will be used when creating the NLL
       /// so the constraint pdf's will be normalized correctly on the global observables when computing the NLL
-      virtual void SetGlobalObservables(const RooArgSet& set) {fGlobalObs.removeAll(); fGlobalObs.add(set);}
+      void SetGlobalObservables(const RooArgSet& set) override {fGlobalObs.removeAll(); fGlobalObs.add(set);}
 
-      virtual Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI);
+      Double_t Evaluate(RooAbsData& data, RooArgSet& nullPOI) override;
 
       virtual void EnableDetailedOutput( bool e=true ) { fDetailedOutputEnabled = e; fDetailedOutput = NULL; }
-      virtual const RooArgSet* GetDetailedOutput(void) const { return fDetailedOutput; }
+      const RooArgSet* GetDetailedOutput(void) const override { return fDetailedOutput; }
 
-      virtual const TString GetVarName() const {
+      const TString GetVarName() const override {
          return "log(L(#mu_{1}) / L(#mu_{0}))";
       }
 
@@ -169,7 +169,7 @@ namespace RooStats {
 
 
    protected:
-   ClassDef(SimpleLikelihoodRatioTestStat,4)
+   ClassDefOverride(SimpleLikelihoodRatioTestStat,4)
 };
 
 }

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -43,15 +43,15 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          fToysStrategy = EQUALTOYSPERDENSITY;
       }
 
-      virtual ~ToyMCImportanceSampler();
+      ~ToyMCImportanceSampler() override;
 
       /// overwrite GetSamplingDistributionsSingleWorker(paramPoint) with a version that loops
       /// over nulls and importance densities, but calls the parent
       /// ToyMCSampler::GetSamplingDistributionsSingleWorker(paramPoint).
-      virtual RooDataSet* GetSamplingDistributionsSingleWorker(RooArgSet& paramPoint);
+      RooDataSet* GetSamplingDistributionsSingleWorker(RooArgSet& paramPoint) override;
 
       using ToyMCSampler::GenerateToyData;
-      virtual RooAbsData* GenerateToyData(RooArgSet& paramPoint, double& weight) const;
+      RooAbsData* GenerateToyData(RooArgSet& paramPoint, double& weight) const override;
       virtual RooAbsData* GenerateToyData(RooArgSet& paramPoint, double& weight, std::vector<double>& impNLLs, double& nullNLL) const;
       virtual RooAbsData* GenerateToyData(std::vector<double>& weights) const;
       virtual RooAbsData* GenerateToyData(std::vector<double>& weights, std::vector<double>& nullNLLs, std::vector<double>& impNLLs) const;
@@ -115,7 +115,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          ClearCache();
       }
       /// overwrite from ToyMCSampler
-      virtual void SetPdf(RooAbsPdf& pdf) {
+      void SetPdf(RooAbsPdf& pdf) override {
          ToyMCSampler::SetPdf(pdf);
 
          if( fNullDensities.size() == 1 ) { fNullDensities[0] = &pdf; }
@@ -125,7 +125,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          }
       }
       /// overwrite from ToyMCSampler
-      void SetParametersForTestStat(const RooArgSet& nullpoi) {
+      void SetParametersForTestStat(const RooArgSet& nullpoi) override {
          ToyMCSampler::SetParametersForTestStat(nullpoi);
          if( fNullSnapshots.size() == 0 ) AddNullDensity( NULL, &nullpoi );
          else if( fNullSnapshots.size() == 1 ) {
@@ -170,7 +170,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
    protected:
 
       /// helper method for clearing  the cache
-      virtual void ClearCache();
+      void ClearCache() override;
 
       unsigned int fIndexGenDensity;
       bool fGenerateFromNull;
@@ -194,7 +194,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
       mutable std::vector<RooAbsReal*> fImpNLLs;     ///<!
 
    protected:
-   ClassDef(ToyMCImportanceSampler,2) // An implementation of importance sampling
+   ClassDefOverride(ToyMCImportanceSampler,2) // An implementation of importance sampling
 };
 }
 

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -70,14 +70,14 @@ class ToyMCSampler: public TestStatSampler {
 
       ToyMCSampler();
       ToyMCSampler(TestStatistic &ts, Int_t ntoys);
-      virtual ~ToyMCSampler();
+      ~ToyMCSampler() override;
 
       static void SetAlwaysUseMultiGen(Bool_t flag);
 
       void SetUseMultiGen(Bool_t flag) { fUseMultiGen = flag ; }
 
       /// main interface
-      virtual SamplingDistribution* GetSamplingDistribution(RooArgSet& paramPoint);
+      SamplingDistribution* GetSamplingDistribution(RooArgSet& paramPoint) override;
       virtual RooDataSet* GetSamplingDistributions(RooArgSet& paramPoint);
       virtual RooDataSet* GetSamplingDistributionsSingleWorker(RooArgSet& paramPoint);
 
@@ -120,7 +120,7 @@ class ToyMCSampler: public TestStatSampler {
       virtual Double_t EvaluateTestStatistic(RooAbsData& data, RooArgSet& nullPOI, int i ) {
          return fTestStatistics[i]->Evaluate(data, nullPOI);
       }
-      virtual Double_t EvaluateTestStatistic(RooAbsData& data, RooArgSet& nullPOI) { return EvaluateTestStatistic( data,nullPOI, 0 ); }
+      Double_t EvaluateTestStatistic(RooAbsData& data, RooArgSet& nullPOI) override { return EvaluateTestStatistic( data,nullPOI, 0 ); }
       virtual RooArgList* EvaluateAllTestStatistics(RooAbsData& data, const RooArgSet& poi);
 
 
@@ -128,14 +128,14 @@ class ToyMCSampler: public TestStatSampler {
          if( fTestStatistics.size() <= i ) return NULL;
          return fTestStatistics[i];
       }
-      virtual TestStatistic* GetTestStatistic(void) const { return GetTestStatistic(0); }
+      TestStatistic* GetTestStatistic(void) const override { return GetTestStatistic(0); }
 
-      virtual Double_t ConfidenceLevel() const { return 1. - fSize; }
-      virtual void Initialize(
+      Double_t ConfidenceLevel() const override { return 1. - fSize; }
+      void Initialize(
          RooAbsArg& /*testStatistic*/,
          RooArgSet& /*paramsOfInterest*/,
          RooArgSet& /*nuisanceParameters*/
-      ) {}
+      ) override {}
 
       virtual Int_t GetNToys(void) { return fNToys; }
       virtual void SetNToys(const Int_t ntoy) { fNToys = ntoy; }
@@ -147,14 +147,14 @@ class ToyMCSampler: public TestStatSampler {
 
 
       /// Set the Pdf, add to the the workspace if not already there
-      virtual void SetParametersForTestStat(const RooArgSet& nullpoi) {
+      void SetParametersForTestStat(const RooArgSet& nullpoi) override {
          fParametersForTestStat.reset( nullpoi.snapshot() );
       }
 
-      virtual void SetPdf(RooAbsPdf& pdf) { fPdf = &pdf; ClearCache(); }
+      void SetPdf(RooAbsPdf& pdf) override { fPdf = &pdf; ClearCache(); }
 
       /// How to randomize the prior. Set to NULL to deactivate randomization.
-      virtual void SetPriorNuisance(RooAbsPdf* pdf) {
+      void SetPriorNuisance(RooAbsPdf* pdf) override {
          fPriorNuisance = pdf;
          if (fNuisanceParametersSampler) {
             delete fNuisanceParametersSampler;
@@ -162,17 +162,17 @@ class ToyMCSampler: public TestStatSampler {
          }
       }
       /// specify the nuisance parameters (eg. the rest of the parameters)
-      virtual void SetNuisanceParameters(const RooArgSet& np) { fNuisancePars = &np; }
+      void SetNuisanceParameters(const RooArgSet& np) override { fNuisancePars = &np; }
       /// specify the observables in the dataset (needed to evaluate the test statistic)
-      virtual void SetObservables(const RooArgSet& o) { fObservables = &o; }
+      void SetObservables(const RooArgSet& o) override { fObservables = &o; }
       /// specify the conditional observables
-      virtual void SetGlobalObservables(const RooArgSet& o) { fGlobalObservables = &o; }
+      void SetGlobalObservables(const RooArgSet& o) override { fGlobalObservables = &o; }
 
 
       /// set the size of the test (rate of Type I error) ( Eg. 0.05 for a 95% Confidence Interval)
-      virtual void SetTestSize(Double_t size) { fSize = size; }
+      void SetTestSize(Double_t size) override { fSize = size; }
       /// set the confidence level for the interval (eg. 0.95 for a 95% Confidence Interval)
-      virtual void SetConfidenceLevel(Double_t cl) { fSize = 1. - cl; }
+      void SetConfidenceLevel(Double_t cl) override { fSize = 1. - cl; }
 
       /// Set the TestStatistic (want the argument to be a function of the data & parameter points
       virtual void SetTestStatistic(TestStatistic *testStatistic, unsigned int i) {
@@ -185,7 +185,7 @@ class ToyMCSampler: public TestStatSampler {
          else
             fTestStatistics[i] = testStatistic;
       }
-      virtual void SetTestStatistic(TestStatistic *t) { return SetTestStatistic(t,0); }
+      void SetTestStatistic(TestStatistic *t) override { return SetTestStatistic(t,0); }
 
       virtual void SetExpectedNuisancePar(Bool_t i = kTRUE) { fExpectedNuisancePar = i; }
       virtual void SetAsimovNuisancePar(Bool_t i = kTRUE) { fExpectedNuisancePar = i; }
@@ -201,7 +201,7 @@ class ToyMCSampler: public TestStatSampler {
       void SetGenerateAutoBinned( Bool_t autoBinned = kTRUE ) { fGenerateAutoBinned = autoBinned; }
 
       /// Set the name of the sampling distribution used for plotting
-      void SetSamplingDistName(const char* name) { if(name) fSamplingDistName = name; }
+      void SetSamplingDistName(const char* name) override { if(name) fSamplingDistName = name; }
       std::string GetSamplingDistName(void) { return fSamplingDistName; }
 
       /// This option forces a maximum number of total toys.
@@ -288,7 +288,7 @@ class ToyMCSampler: public TestStatSampler {
       Bool_t fUseMultiGen ;                ///< Use PrepareMultiGen?
 
    protected:
-   ClassDef(ToyMCSampler, 4) // A simple implementation of the TestStatSampler interface
+   ClassDefOverride(ToyMCSampler, 4) // A simple implementation of the TestStatSampler interface
 };
 }
 

--- a/roofit/roostats/inc/RooStats/ToyMCStudy.h
+++ b/roofit/roostats/inc/RooStats/ToyMCStudy.h
@@ -41,14 +41,14 @@ class ToyMCStudy: public RooAbsStudy {
          storeDetailedOutput(kTRUE);
       }
 
-      RooAbsStudy* clone(const char* /*newname*/="") const { return new ToyMCStudy(*this) ; }
+      RooAbsStudy* clone(const char* /*newname*/="") const override { return new ToyMCStudy(*this) ; }
 
-      virtual ~ToyMCStudy() {}
+      ~ToyMCStudy() override {}
 
       // RooAbsStudy interfaces
-      virtual Bool_t initialize(void);
-      virtual Bool_t execute(void);
-      virtual Bool_t finalize(void);
+      Bool_t initialize(void) override;
+      Bool_t execute(void) override;
+      Bool_t finalize(void) override;
 
       RooDataSet* merge();
 
@@ -64,7 +64,7 @@ class ToyMCStudy: public RooAbsStudy {
       RooArgSet fParamPoint;
 
    protected:
-   ClassDef(ToyMCStudy,2); // toy MC study for parallel processing
+   ClassDefOverride(ToyMCStudy,2); // toy MC study for parallel processing
 
 };
 
@@ -83,7 +83,7 @@ class ToyMCPayload : public TNamed {
          fDataSet = sd;
       }
 
-      virtual ~ToyMCPayload() {
+      ~ToyMCPayload() override {
       }
 
 
@@ -96,7 +96,7 @@ class ToyMCPayload : public TNamed {
       RooDataSet* fDataSet;
 
    protected:
-   ClassDef(ToyMCPayload,1);
+   ClassDefOverride(ToyMCPayload,1);
 };
 
 

--- a/roofit/roostats/inc/RooStats/UniformProposal.h
+++ b/roofit/roostats/inc/RooStats/UniformProposal.h
@@ -29,20 +29,20 @@ namespace RooStats {
       UniformProposal() : ProposalFunction() {}
 
       /// Populate xPrime with a new proposed point
-      virtual void Propose(RooArgSet& xPrime, RooArgSet& x);
+      void Propose(RooArgSet& xPrime, RooArgSet& x) override;
 
       /// Determine whether or not the proposal density is symmetric for
       /// points x1 and x2 - that is, whether the probability of reaching x2
       /// from x1 is equal to the probability of reaching x1 from x2
-      virtual Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2);
+      Bool_t IsSymmetric(RooArgSet& x1, RooArgSet& x2) override;
 
       /// Return the probability of proposing the point x1 given the starting
       /// point x2
-      virtual Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2);
+      Double_t GetProposalDensity(RooArgSet& x1, RooArgSet& x2) override;
 
-      virtual ~UniformProposal() {}
+      ~UniformProposal() override {}
 
-      ClassDef(UniformProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
+      ClassDefOverride(UniformProposal,1) // A concrete implementation of ProposalFunction, that uniformly samples the parameter space.
    };
 }
 

--- a/roofit/roostats/inc/RooStats/UpperLimitMCSModule.h
+++ b/roofit/roostats/inc/RooStats/UpperLimitMCSModule.h
@@ -30,15 +30,15 @@ public:
 
    UpperLimitMCSModule(const RooArgSet* poi, Double_t CL=0.95) ;
    UpperLimitMCSModule(const UpperLimitMCSModule& other) ;
-   virtual ~UpperLimitMCSModule() ;
+   ~UpperLimitMCSModule() override ;
 
-   Bool_t initializeInstance() ;
+   Bool_t initializeInstance() override ;
 
-   Bool_t initializeRun(Int_t /*numSamples*/) ;
-   RooDataSet* finalizeRun() ;
+   Bool_t initializeRun(Int_t /*numSamples*/) override ;
+   RooDataSet* finalizeRun() override ;
 
    //Bool_t processAfterFit(Int_t /*sampleNum*/)  ;
-   Bool_t processBetweenGenAndFit(Int_t /*sampleNum*/) ;
+   Bool_t processBetweenGenAndFit(Int_t /*sampleNum*/) override ;
 
 private:
 
@@ -51,7 +51,7 @@ private:
    Double_t _cl;
    RooAbsPdf* _model;
 
-   ClassDef(UpperLimitMCSModule,0) // MCStudy module to calculate upper limit of a given poi
+   ClassDefOverride(UpperLimitMCSModule,0) // MCStudy module to calculate upper limit of a given poi
 };
 
 }

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -242,7 +242,7 @@ public:
    bool HasError() const { return fError; }
 
 
-   ROOT::Math::IGenFunction * Clone() const {
+   ROOT::Math::IGenFunction * Clone() const override {
       ooccoutD((TObject*)0,NumIntegration) << " cloning function .........." << std::endl;
       return new PosteriorCdfFunction(*this);
    }
@@ -257,7 +257,7 @@ private:
       return *this;
    }
 
-   double DoEval (double x) const {
+   double DoEval (double x) const override {
 
       // evaluate cdf at poi value x by integrating poi from [xmin,x] and all the nuisances
       fXmax[0] = x;
@@ -397,7 +397,7 @@ public:
    }
 
 
-   ROOT::Math::IGenFunction * Clone() const {
+   ROOT::Math::IGenFunction * Clone() const override {
       assert(1);
       return 0; // cannot clone this function for integrator
    }
@@ -406,7 +406,7 @@ public:
 
 
 private:
-   double DoEval (double x) const {
+   double DoEval (double x) const override {
 
       // evaluate posterior function at a poi value x by integrating all nuisance parameters
 
@@ -505,7 +505,7 @@ public:
       }
    }
 
-   virtual ~PosteriorFunctionFromToyMC() { if (fGenParams) delete fGenParams; }
+   ~PosteriorFunctionFromToyMC() override { if (fGenParams) delete fGenParams; }
 
    // generate first n-samples of the nuisance parameters
    void GenerateToys() const {
@@ -518,7 +518,7 @@ public:
 
    double Error() const { return fError;}
 
-   ROOT::Math::IGenFunction * Clone() const {
+   ROOT::Math::IGenFunction * Clone() const override {
       // use default copy constructor
       //return new PosteriorFunctionFromToyMC(*this);
       //  clone not implemented
@@ -528,7 +528,7 @@ public:
 
 private:
    // evaluate the posterior at the poi value x
-   double DoEval( double x) const {
+   double DoEval( double x) const override {
 
       int npar = fNuisParams.getSize();
       assert (npar > 0);


### PR DESCRIPTION
For RooFit developers, it is unconvenient that the `override` specifier
that flags member functions as overriding on first sight is not used so
much in RooFit.

Now that the v6.28 development cycle has just started and there are no
major developments in the pipeline yet, I think it is a good time to add
the missing `override` specifiers everywhere in RooFit.

This commit was generated more or less automatically with this Python
script that uses `clang-tidy`:

```Python
import os
import glob
import subprocess
import tqdm

"""
For clang-tidy to work, you have to copy the compile_commands.json from the
build directory back into the repo directory (just like in
.ci/copy_headers.sh).
"""

def get_sources(directory, extensions):

    files = []

    for ext in extensions:
        files += glob.glob(
            os.path.join(directory, "**/*" + ext), recursive=True
        )

    return files

"""
Recursively find extensions in directory, to figure out whic hextensions
should be globbed for.
   find . -type f -name '*.*' | sed 's|.*\.||' | sort -u
"""
extensions = [".h", ".hpp", ".cpp", ".cc", ".cxx"]

"""
Some extensions are recognized as C and not as C++ files by clang-tidy. We
need to rename them, and this dict specifies how file extensions should be
replaced.
"""
rename_dict = {".h": ".hpp"}

files = get_sources("roofit", extensions)

cflags = (
    subprocess.check_output(["root-config", "--cflags"]).strip().decode("utf-8")
)

for file in tqdm.tqdm(files):

    file_renamed = file
    for ext, ext_renamed in rename_dict.items():
        if file.endswith(ext):
            file_renamed = file.replace(ext, ext_renamed)

    if file_renamed != file:
        os.rename(file, file_renamed)

    cmd = [
        "clang-tidy",
        "-checks=modernize-use-override",
        "--fix",
        file_renamed,
        "--",
    ] + cflags.split(" ")
    subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

    if file_renamed != file:
        os.rename(file_renamed, file)

"""
Finally, replace the ClassDef with the ClassDefOverride macros.
  find roofit -type f -print | xargs sed -i 's/ClassDef(/ClassDefOverride(/'
...and change back the ClassDefOverride of non-overriding base classes.
"""
```