### PR TITLE
Fix Windows warning in RVec

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -2059,7 +2059,7 @@ template <typename T>
 auto Any(const RVec<T> &v) -> decltype(v[0] == true)
 {
    for (auto &&e : v)
-      if (e == true)
+      if ((bool) e == true)
          return true;
    return false;
 }
@@ -2078,7 +2078,7 @@ template <typename T>
 auto All(const RVec<T> &v) -> decltype(v[0] == false)
 {
    for (auto &&e : v)
-      if (e == false)
+      if ((bool) e == false)
          return false;
    return true;
 }


### PR DESCRIPTION
ROOT/RVec.hxx(2062,16):

     warning C4805: '==': unsafe mix of type 'const T' and type 'bool'
     in operation [C:\Soft\root_64\math\vecops\test\vecops_rvec.vcxproj]
    with
      [
          T=int
      ]
