### PR TITLE
[win] Fix a couple of failing tests on Windows with VS 2022

### DIFF
--- a/test/stressMathMore.cxx
+++ b/test/stressMathMore.cxx
@@ -436,7 +436,7 @@ int testGammaFunction(int n = 100) {
    dist.SetScaleInv(10000); // few tests fail here
    // vary shape of gamma parameter
    for (int i =1; i <= 5; ++i) {
-      double k = std::pow(2.,double(i-1));
+      double k = std::pow(2.,i-1);
       double theta = 2./double(i);
       dist.SetParameters(k,theta);
       if (k <=1 )

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -65,7 +65,7 @@ TEST(RNTuple, UnsupportedStdTypes)
       auto field = RFieldBase::Create("pair_field", "std::pair<int, float>").Unwrap();
       FAIL() << "should not be able to make a std::pair field";
    } catch (const RException& err) {
-      EXPECT_THAT(err.what(), testing::HasSubstr("std::pair<int,float> is not supported"));
+      EXPECT_THAT(err.what(), testing::HasSubstr("pair<int,float> is not supported"));
    }
    try {
       auto field = RField<std::pair<int, float>>("pair_field");


### PR DESCRIPTION
Fix a crash with `test-stressmathmore-interpreted` and fix the following `gtest-tree-ntuple-v7-test-ntuple-types` error on Windows with VS 2022:
```
361: [ RUN      ] RNTuple.UnsupportedStdTypes
361: C:\Users\sftnight\git\master\tree\ntuple\v7\test\ntuple_types.cxx(68): error: Value of: err.what()
361: Expected: has substring "std::pair<int,float> is not supported"
361:   Actual: 0E870D50 pointing to "pair<int,float> is not supported\nAt:\n  __thiscall ROOT::Experimental::RClassField::RClassField(class std::basic_string_view<char,struct std::char_traits<char> >,class std::basic_string_view<char,struct std::char_traits<char> >,class TClass *) [C:\\Users\\sftnight\\git\\master\\tree\\ntuple\\v7\\src\\RField.cxx:773]\n" (of type char const *)
361: [  FAILED  ] RNTuple.UnsupportedStdTypes (3 ms)
```
