### PR TITLE
[cmake] Require CMake >= 3.19 on macOS:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@
 # For the licensing terms see $ROOTSYS/LICENSE.
 # For the list of contributors see $ROOTSYS/README/CREDITS.
 
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+if(APPLE)
+  cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+endif()
 
 if(WIN32)
   # Set CMP0091 (MSVC runtime library flags are selected by an abstraction) to OLD


### PR DESCRIPTION
Fixes framework python linking, https://gitlab.kitware.com/cmake/cmake/-/issues/21947
