### PR TITLE
[span] Fix span constructor for const vector

### DIFF
--- a/core/foundation/inc/ROOT/span.hxx
+++ b/core/foundation/inc/ROOT/span.hxx
@@ -196,8 +196,8 @@ public:
     static_assert(N > 0, "Zero-length array is not permitted in ISO C++.");
   }
 
-  /*implicit*/ span(std::vector<typename std::remove_cv<T>::type> const& v) noexcept
-     : length_(v.size()), data_(v.empty() ? nullptr : v.data())
+  /*implicit*/ span(std::vector<typename std::remove_cv<T>::type> const &v) noexcept
+     : length_(v.size()), data_(v.empty() ? nullptr : const_cast<T *>(v.data()))
   {}
 
   /*implicit*/ span(std::vector<typename std::remove_cv<T>::type> & v) noexcept

--- a/core/foundation/test/CMakeLists.txt
+++ b/core/foundation/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -6,6 +6,7 @@
 
 ROOT_ADD_GTEST(testMake_unique testMake_unique.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testTypeTraits testTypeTraits.cxx LIBRARIES Core)
+ROOT_ADD_GTEST(testSpan testspan.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testNotFn testNotFn.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testClassEdit testClassEdit.cxx LIBRARIES Core)
 ROOT_ADD_GTEST(testLogger testLogger.cxx LIBRARIES Core)

--- a/core/foundation/test/testspan.cxx
+++ b/core/foundation/test/testspan.cxx
@@ -1,0 +1,38 @@
+/// \file testspan.cxx
+///
+/// \brief The file contain unit tests which test the ROOT::RSpan
+///
+/// \author Ivan Kabadzhov
+///
+/// \date Feb, 2022
+///
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <ROOT/RSpan.hxx>
+
+#include "gtest/gtest.h"
+
+TEST(SpanConstructors, Vectors)
+{
+   std::vector<int> v = {1, 2, 3};
+   std::span<int> v_span = v;
+
+   const std::vector<int> const_v = {1, 2, 3};
+   std::span<int> const_v_span = const_v;
+
+   EXPECT_EQ(v_span, const_v_span);
+
+   std::vector<int> empty = {};
+   std::span<int> empty_span = empty;
+
+   const std::vector<int> const_empty = {};
+   std::span<int> const_empty_span = const_empty;
+
+   EXPECT_EQ(empty_span, const_empty_span);
+}


### PR DESCRIPTION
Change the cv qualification of the const vector passed to `span`.

Previously, the constructor `span(std::vector<typename
std::remove_cv<T>::type> const& v) noexcept` was producing an error for invalid conversion from `const long int*` to `std::__ROOT::span<long int>::pointer` {aka `long int*`} [-fpermissive].

Corresponding test added.