### PR TITLE
[Math] Fix Kolmogorov-Smirnov 1 sample test (in ROOT::Math::GoFTest)

### DIFF
--- a/math/mathcore/inc/Math/GoFTest.h
+++ b/math/mathcore/inc/Math/GoFTest.h
@@ -63,7 +63,7 @@ public:
    GoFTest(UInt_t sample1Size, const Double_t* sample1, UInt_t sample2Size, const Double_t* sample2);
 
    /* Constructor for using only with 1-sample tests with a specified distribution */
-   GoFTest(UInt_t sampleSize, const Double_t* sample, EDistribution dist = kUndefined);
+   GoFTest(UInt_t sampleSize, const Double_t* sample, EDistribution dist = kUndefined, const std::vector<double>  & distParams = std::vector<double>());
 
    /* Templated constructor for using only with 1-sample tests with a user specified distribution */
    template<class Dist>
@@ -119,8 +119,8 @@ public:
    }
 
 
-   /* Sets the distribution for the predefined distribution types  */
-   void SetDistribution(EDistribution dist);
+   /* Sets the distribution for the predefined distribution types and optionally its parameters */
+   void SetDistribution(EDistribution dist, const std::vector<double>  & distParams = std::vector<double>());
 
 
    virtual ~GoFTest();
@@ -182,11 +182,9 @@ private:
    std::unique_ptr<IGenFunction> fCDF;
 
 
-   EDistribution fDist;
-
-   Double_t fMean;
-   Double_t fSigma;
-
+   EDistribution fDist;                /// Type of distribution 
+   std::vector<Double_t> fParams;      /// The distribution parameters (e.g. fParams[0] = mean, fParams[1] = sigma for a Gaussian)
+  
    std::vector<Double_t> fCombinedSamples;
 
    std::vector<std::vector<Double_t> > fSamples;
@@ -214,7 +212,7 @@ private:
 
    void SetSamples(std::vector<const Double_t*> samples, const std::vector<UInt_t> samplesSizes);
 
-   void SetParameters(); // Sets the estimated mean and standard-deviation from the samples
+   void SetParameters(const std::vector<double> & params); // Sets the distribution parameters
 }; // end GoFTest class
 
 

--- a/math/mathcore/inc/Math/GoFTest.h
+++ b/math/mathcore/inc/Math/GoFTest.h
@@ -27,150 +27,203 @@ namespace ROOT {
    }
 namespace Math {
 
-/////  @defgroup GoFClasses Goodness of Fit Statistical Tests Tools
 
-/*
-  Class for Goodness of Fit tests implementing the Anderson-Darling and Kolmogorov-Smirnov 1- and 2-Samples Goodness of Fit Tests.
+/**
+  @defgroup GoFClasses Goodness of Fit Tests
+  Classical one-dimensional goodness of git tests for unbinned data.
+  ROOT provides 1 sample goodness of fit test (comparison of data with a theoretical distribution) and
+  2-sample test (comparison of two data sets) through the class ROOT::Math::GoFTest
+  The algorithms provided are the Kolmogorov-Smirnov and Anderson-Darling.
+  These tests could be applied approximately also to binned data, assuming the bin size is much smaller than the intrinsic
+  data variations. It is assumed than a bin is like many data at the same bin center value.
+  For these binned version tests look at `TH1::KolmogorovTest` and `TH1::AndersonDarlingTest`
   @ingroup MathCore
+ */
 
+/**
+ * GoFTest class implementing the 1 sample and 2 sample goodness of fit tests
+ * for uni-variate distributions and data.
+ * The class implements the AndersonDarling and the KolmogorovSmirnov tests
+ *
+ * In the case of the 1-sample test the user needs to  provide:
+ *   - input data
+ *   - theoretical distribution. The distribution can be provided as a function object (functor) or an object implementing
+ *     the `ROOT::Math::IGenFunction` interface. One can provide either the PDF (default) of the CDF (cumulative distribution)
+ *     One can also provide a pre-defined function. In that case one needs to give also the distribution parameters otherwise the default values will be used.
+ *     The pre-defined distributions are:
+ *     - kGaussian  with default parameter mean=0, sigma=1
+ *     - kExponential with default parameter rate=1
+ *     - kLogNormal with default parameter meanlog=0, sigmalog=1
+ *
+ *     Note that one should not use data computed distribution parameters, otherwise the test will be biased.
+ *     The 1-sample KS test using data computed quantities is called Lilliefors test (see https://en.wikipedia.org/wiki/Lilliefors_test)
+ *
+ *  @ingroup GoFClasses
  */
 
 
 class GoFTest {
 public:
 
-   enum EDistribution { // H0 distributions for using only with 1-sample tests
-      kUndefined,       // Default value for non templated 1-sample test. Set with SetDistribution
-      kUserDefined,     // For internal use only within the class's template constructor
-      kGaussian,
-      kLogNormal,
-      kExponential
+   /// H0 distributions for using only with 1-sample tests.
+   /// One should provide the distribution parameters otherwise the default values will be used
+   enum EDistribution {
+      kUndefined,       /// Default value for non templated 1-sample test. Set with SetDistribution
+      kUserDefined,     /// For internal use only within the class's template constructor
+      kGaussian,        /// Gaussian distribution with default  mean=0, sigma=1
+      kLogNormal,       /// Lognormal distribution with default  meanlog=0, sigmalog=1
+      kExponential      /// Exponential distribution with default rate=1
    };
 
-   enum EUserDistribution { // User input distribution option
-      kCDF,
-      kPDF                  // Default value
+   /// User input distribution option
+   enum EUserDistribution {
+      kCDF,             /// Input distribution is a CDF : cumulative distribution function
+      kPDF              /// Input distribution is a PDF (Default value)
    };
 
-   enum ETestType { // Goodness of Fit test types for using with the class's unary functions as a shorthand for the in-built methods
-      kAD,   // Anderson-Darling Test. Default value
-      kAD2s, // Anderson-Darling 2-Samples Test
-      kKS,   // Kolmogorov-Smirnov Test
-      kKS2s  // Kolmogorov-Smirnov 2-Samples Test
+   /// Goodness of Fit test types for using with the class's unary functions as a shorthand for the in-built methods
+   enum ETestType {
+      kAD,   /// Anderson-Darling Test. Default value
+      kAD2s, /// Anderson-Darling 2-Samples Test
+      kKS,   /// Kolmogorov-Smirnov Test
+      kKS2s  /// Kolmogorov-Smirnov 2-Samples Test
    };
 
-   /* Constructor for using only with 2-samples tests */
-   GoFTest(UInt_t sample1Size, const Double_t* sample1, UInt_t sample2Size, const Double_t* sample2);
+   /// Constructor for  2-samples tests
+   GoFTest(size_t sample1Size, const Double_t* sample1, size_t sample2Size, const Double_t* sample2);
 
-   /* Constructor for using only with 1-sample tests with a specified distribution */
-   GoFTest(UInt_t sampleSize, const Double_t* sample, EDistribution dist = kUndefined, const std::vector<double>  & distParams = std::vector<double>());
+   /// Constructor for 1-sample tests with a specified distribution.
+   /// If a specific distribution is not specified it can be set later using SetDistribution.
+   GoFTest(size_t sampleSize, const Double_t* sample, EDistribution dist = kUndefined, const std::vector<double>  & distParams = {});
 
-   /* Templated constructor for using only with 1-sample tests with a user specified distribution */
+   /// Templated constructor for 1-sample tests with a user specified distribution as a functor object implementing `double operator()(double x)`.
    template<class Dist>
-   GoFTest(UInt_t sampleSize, const Double_t* sample, Dist& dist, EUserDistribution userDist = kPDF,
+   GoFTest(size_t sampleSize, const Double_t* sample, Dist& dist, EUserDistribution userDist = kPDF,
            Double_t xmin = 1, Double_t xmax = 0)
    {
       Instantiate(sample, sampleSize);
       SetUserDistribution<Dist>(dist, userDist, xmin, xmax);
    }
 
-   /* Specialization using IGenFunction interface */
-   GoFTest(UInt_t sampleSize, const Double_t* sample, const IGenFunction& dist, EUserDistribution userDist = kPDF,
+   /// Constructor for 1-sample tests with a user specified distribution implementing the ROOT::Math::IGenFunction interface.
+   GoFTest(size_t sampleSize, const Double_t* sample, const IGenFunction& dist, EUserDistribution userDist = kPDF,
            Double_t xmin = 1, Double_t xmax = 0)
    {
       Instantiate(sample, sampleSize);
       SetUserDistribution(dist, userDist, xmin, xmax);
    }
 
-   /* Sets the user input distribution function for 1-sample tests. */
+   /// Sets the user input distribution function for 1-sample test as a generic functor object.
    template<class Dist>
    void SetUserDistribution(Dist& dist, EUserDistribution userDist = kPDF, Double_t xmin = 1, Double_t xmax = 0) {
       WrappedFunction<Dist&> wdist(dist);
       SetDistributionFunction(wdist, userDist, xmin, xmax);
    }
 
-   /* Template specialization to set the user input distribution for 1-sample tests */
+   ///  Sets the user input distribution function for 1-sample test using the ROOT::Math::IGenFunction interface.
    void SetUserDistribution(const IGenFunction& dist, GoFTest::EUserDistribution userDist = kPDF, Double_t xmin = 1, Double_t xmax = 0) {
       SetDistributionFunction(dist, userDist, xmin, xmax);
    }
 
-   /* Sets the user input distribution as a probability density function for 1-sample tests */
+   /// Sets the user input distribution as a probability density function for 1-sample tests.
    template<class Dist>
    void SetUserPDF(Dist& pdf, Double_t xmin = 1, Double_t xmax = 0) {
       SetUserDistribution<Dist>(pdf, kPDF, xmin, xmax);
    }
 
-   /* Template specialization to set the user input distribution as a probability density function for 1-sample tests */
+   /// Specialization to set the user input distribution as a probability density function for 1-sample tests using the ROOT::Math::IGenFunction interface.
    void SetUserPDF(const IGenFunction& pdf, Double_t xmin = 1, Double_t xmax = 0) {
       SetUserDistribution(pdf, kPDF, xmin, xmax);
    }
 
-   /* Sets the user input distribution as a cumulative distribution function for 1-sample tests
-      The CDF must return zero
-    */
+   /// Sets the user input distribution as a cumulative distribution function for 1-sample tests.
+   /// The CDF must return zero for x=xmin and 1 for x=xmax.
    template<class Dist>
    void SetUserCDF(Dist& cdf, Double_t xmin = 1, Double_t xmax = 0) {
       SetUserDistribution<Dist>(cdf, kCDF, xmin, xmax);
    }
 
-   /* Template specialization to set the user input distribution as a cumulative distribution function for 1-sample tests */
+   /// Specialization to set the user input distribution as a cumulative distribution function for 1-sample tests.
    void SetUserCDF(const IGenFunction& cdf, Double_t xmin = 1, Double_t xmax = 0)  {
       SetUserDistribution(cdf, kCDF, xmin, xmax);
    }
 
 
-   /* Sets the distribution for the predefined distribution types and optionally its parameters */
-   void SetDistribution(EDistribution dist, const std::vector<double>  & distParams = std::vector<double>());
+   /// Sets the distribution for the predefined distribution types and optionally its parameters for 1-sample tests.
+   void SetDistribution(EDistribution dist, const std::vector<double>  & distParams = {});
 
 
    virtual ~GoFTest();
 
-/*
-  The Anderson-Darling K-Sample Test algorithm is described and taken from
-  http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/andeksam.htm
-  and described and taken from
-   (1) Scholz F.W., Stephens M.A. (1987), K-sample Anderson-Darling Tests, Journal of the American Statistical Association, 82, 918–924. (2-samples variant implemented)
-*/ void AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) const;
-   Double_t AndersonDarling2SamplesTest(const Char_t* option = "p") const; // Returns default p-value; option "t" returns the test statistic value "A2"
+   /// Performs the Anderson-Darling 2-Sample Test.
+   ///  The Anderson-Darling K-Sample Test algorithm is described and taken from
+   ///  http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/andeksam.htm
+   ///  and from
+   ///   (1) Scholz F.W., Stephens M.A. (1987), K-sample Anderson-Darling Tests, Journal of the American Statistical Association, 82, 918–924.
+   ///   (2-samples variant implemented).
+   void AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) const;
 
-/*
-  The Anderson-Darling 1-Sample Test algorithm for a specific distribution is described at
-  http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/andedarl.htm
-  and described and taken from (2)
-  Marsaglia J.C.W., Marsaglia G. (2004), Evaluating the Anderson-Darling Distribution, Journal of Statistical Software, Volume 09, Issue i02.
-  and described and taken from (3)
-  Lewis P.A.W. (1961), The Annals of Mathematical Statistics, Distribution of the Anderson-Darling Statistic, Volume 32, Number 4, 1118-1124.
-*/ void AndersonDarlingTest(Double_t& pvalue, Double_t& testStat) const;
-   Double_t AndersonDarlingTest(const Char_t* option = "p") const; // Returns default p-value; option "t" returns the test statistic value "A2"
+   ///  Anderson-Darling 2-Sample Test.
+   ///  Returns by default the p-value; when using option "t" returns the test statistic value "A2".
+   Double_t AndersonDarling2SamplesTest(const Char_t* option = "p") const;
 
-/*
-  The Kolmogorov-Smirnov 2-Samples Test algorithm is described at
-  http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/ks2samp.htm
-  and described and taken from
-  http://root.cern.ch/root/html/TMath.html#TMath:KolmogorovTest
-*/ void KolmogorovSmirnov2SamplesTest(Double_t& pvalue, Double_t& testStat) const;
-   Double_t KolmogorovSmirnov2SamplesTest(const Char_t* option = "p") const; // Returns default p-value; option "t" returns the test statistic value "Dn"
+   /**
+   Performs the Anderson-Darling 1-Sample Test.
+   The Anderson-Darling 1-Sample Test algorithm for a specific distribution is described at
+   http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/andedarl.htm
+   and described and taken from (2)
+   Marsaglia J.C.W., Marsaglia G. (2004), Evaluating the Anderson-Darling Distribution, Journal of Statistical Software, Volume 09, Issue i02.
+   and described and taken from (3)
+   Lewis P.A.W. (1961), The Annals of Mathematical Statistics, Distribution of the Anderson-Darling Statistic, Volume 32, Number 4, 1118-1124.
+   */
+   void AndersonDarlingTest(Double_t& pvalue, Double_t& testStat) const;
 
-/*
-  The Kolmogorov-Smirnov 1-Sample Test algorithm for a specific distribution is described at
-  http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/kstest.htm
-  and described and taken from (4)
-  Press W. H., Teukolsky S.A., Vetterling W.T., Flannery B.P. (2007), Numerical Recipes - The Art of Scientific Computing (Third Edition), Cambridge University Press
-*/ void KolmogorovSmirnovTest(Double_t& pvalue, Double_t& testStat) const;
-   Double_t KolmogorovSmirnovTest(const Char_t* option = "p") const; // Returns default p-value; option "t" returns the test statistic value "Dn"
+   /// Anderson-Darling 2-Sample Test.
+   /// Returns default p-value; option "t" returns the test statistic value "A2"
+   Double_t AndersonDarlingTest(const Char_t* option = "p") const;
 
-   // The class's unary functions
+   /**
+   * @brief Kolmogorov-Smirnov 2-Samples Test.
+   The Kolmogorov-Smirnov 2-Samples Test algorithm is described at
+   http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/ks2samp.htm
+   and described and taken from
+   http://root.cern.ch/root/html/TMath.html#TMath:KolmogorovTest
+   */
+   void KolmogorovSmirnov2SamplesTest(Double_t& pvalue, Double_t& testStat) const;
+
+   /// Kolmogorov-Smirnov 2-Samples Test.
+   /// Returns by default the p-value; option "t" returns the test statistic value "Dn".
+   Double_t KolmogorovSmirnov2SamplesTest(const Char_t* option = "p") const;
+
+  /**
+   * @brief  Kolmogorov-Smirnov 1-Sample Test.
+   *
+     The Kolmogorov-Smirnov 1-Sample Test algorithm for a specific distribution is described at
+     http://www.itl.nist.gov/div898/software/dataplot/refman1/auxillar/kstest.htm
+     and described and taken from (4)
+     Press W. H., Teukolsky S.A., Vetterling W.T., Flannery B.P. (2007), Numerical Recipes -
+     The Art of Scientific Computing (Third Edition), Cambridge University Press
+   */
+   void KolmogorovSmirnovTest(Double_t& pvalue, Double_t& testStat) const;
+
+   /// Kolmogorov-Smirnov 1-Sample Test.
+   /// Returns default p-value; option "t" returns the test statistic value "Dn".
+   Double_t KolmogorovSmirnovTest(const Char_t* option = "p") const;
+
+   /// The class's unary functions performing the gif test according to the ETestType provided.
    void operator()(ETestType test, Double_t& pvalue, Double_t& testStat) const;
 
-   // Returns default Anderson Darling 1-Sample Test and default p-value; option "t" returns the test statistic value
-   // specific to the test type
+   /// Returns default Anderson Darling 1-Sample Test and default p-value; option "t" returns the test statistic value
+   /// specific to the test type.
    Double_t operator()(ETestType test = kAD, const Char_t* option = "p") const;
 
-   // Computation of the K-Sample Anderson-Darling Test's p-value as described in (1)
-   // given a normalized test statistic. The first variant described in the paper is used
-   static Double_t PValueADKSamples(UInt_t nsamples, Double_t A2 );
+   /// Computation of the K-Sample Anderson-Darling Test's p-value as described in (1)
+   // given a normalized test statistic. The first variant described in the paper is used.
+   static Double_t PValueADKSamples(size_t nsamples, Double_t A2 );
 
-   // Compute The 2-Sample Anderson Darling test for binned data
+   /// Compute the 2-Sample Anderson Darling test for binned data
+   /// assuming equal data are present at the bin center values.
+   /// Used by `TH1::AndersonDarling`
    static void  AndersonDarling2SamplesTest(const ROOT::Fit::BinData & data1, const ROOT::Fit::BinData & data2, Double_t& pvalue, Double_t& testStat);
 
 private:
@@ -179,40 +232,46 @@ private:
    GoFTest(GoFTest& gof);           ///< Disallowed copy constructor
    GoFTest operator=(GoFTest& gof); ///< Disallowed assign operator
 
-   std::unique_ptr<IGenFunction> fCDF;
+   std::unique_ptr<IGenFunction> fCDF;  ///< Pointer to CDF used in 1-sample test
 
 
-   EDistribution fDist;                /// Type of distribution 
-   std::vector<Double_t> fParams;      /// The distribution parameters (e.g. fParams[0] = mean, fParams[1] = sigma for a Gaussian)
-  
-   std::vector<Double_t> fCombinedSamples;
+   EDistribution fDist;                ///< Type of distribution
+   std::vector<Double_t> fParams;      ///< The distribution parameters (e.g. fParams[0] = mean, fParams[1] = sigma for a Gaussian)
 
-   std::vector<std::vector<Double_t> > fSamples;
+   std::vector<Double_t> fCombinedSamples;       ///< The combined data
+
+   std::vector<std::vector<Double_t> > fSamples;  ///< The input data
 
    Bool_t fTestSampleFromH0;
 
    void SetCDF();
    void SetDistributionFunction(const IGenFunction& cdf, Bool_t isPDF, Double_t xmin, Double_t xmax);
 
-   void Instantiate(const Double_t* sample, UInt_t sampleSize);
+   void Instantiate(const Double_t* sample, size_t sampleSize);
 
 
    Double_t LogNormalCDF(Double_t x) const;
    Double_t GaussianCDF(Double_t x) const;
    Double_t ExponentialCDF(Double_t x) const;
 
-   static Double_t GetSigmaN(const std::vector<UInt_t> & ns, UInt_t N); // Computation of sigma_N as described in (1)
+   /// Computation of sigma_N as described in (1)
+   static Double_t GetSigmaN(const std::vector<size_t> & ns, size_t N);
 
-   static Double_t InterpolatePValues(int nsamples,Double_t A2); // Linear interpolation used in GoFTest::PValueAD2Samples
+   /// Linear interpolation used in GoFTest::PValueAD2Samples
+   static Double_t InterpolatePValues(int nsamples,Double_t A2);
 
+   /// Computation of the 1-Sample Anderson-Darling Test's p-value
+   Double_t PValueAD1Sample(Double_t A2) const;
 
-   Double_t PValueAD1Sample(Double_t A2) const; // Computation of the 1-Sample Anderson-Darling Test's p-value
+   /// Applies the logarithm to the sample when the specified distribution to test is LogNormal
+   void LogSample();
 
-   void LogSample(); // Applies the logarithm to the sample when the specified distribution to test is LogNormal
+   /// set a vector of samples
+   void SetSamples(std::vector<const Double_t*> samples, const std::vector<size_t> samplesSizes);
 
-   void SetSamples(std::vector<const Double_t*> samples, const std::vector<UInt_t> samplesSizes);
+   /// Sets the distribution parameters
+   void SetParameters(const std::vector<double> & params);
 
-   void SetParameters(const std::vector<double> & params); // Sets the distribution parameters
 }; // end GoFTest class
 
 

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -934,7 +934,7 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
       for (UInt_t i = 0; i < n; ++i) {
          Double_t Fn = (i + 1.0) / n;
          Double_t F = (*fCDF)(fSamples[0][i]);
-         Double_t result = std::max(TMath::Abs(Fn - F), TMath::Abs(Fo - Fn));
+         Double_t result = std::max(TMath::Abs(Fn - F), TMath::Abs(Fo - F));
          if (result > Dn) Dn = result;
          Fo = Fn;
       }

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -130,7 +130,7 @@ namespace Math {
       SetCDF();
    }
 
-   GoFTest::GoFTest( UInt_t sample1Size, const Double_t* sample1, UInt_t sample2Size, const Double_t* sample2 )
+   GoFTest::GoFTest( size_t sample1Size, const Double_t* sample1, size_t sample2Size, const Double_t* sample2 )
    : fDist(kUndefined),
      fSamples(std::vector<std::vector<Double_t> >(2)),
      fTestSampleFromH0(kFALSE) {
@@ -149,7 +149,7 @@ namespace Math {
          assert(!badSampleArg);
       }
       std::vector<const Double_t*> samples(2);
-      std::vector<UInt_t> samplesSizes(2);
+      std::vector<size_t> samplesSizes(2);
       samples[0] = sample1;
       samples[1] = sample2;
       samplesSizes[0] = sample1Size;
@@ -157,7 +157,7 @@ namespace Math {
       SetSamples(samples, samplesSizes);
    }
 
-   GoFTest::GoFTest(UInt_t sampleSize, const Double_t* sample, EDistribution dist, const std::vector<double> & distParams)
+   GoFTest::GoFTest(size_t sampleSize, const Double_t* sample, EDistribution dist, const std::vector<double> & distParams)
    : fDist(dist),
      fSamples(std::vector<std::vector<Double_t> >(1)),
      fTestSampleFromH0(kTRUE) {
@@ -169,7 +169,7 @@ namespace Math {
          assert(!badSampleArg);
       }
       std::vector<const Double_t*> samples(1, sample);
-      std::vector<UInt_t> samplesSizes(1, sampleSize);
+      std::vector<size_t> samplesSizes(1, sampleSize);
       SetSamples(samples, samplesSizes);
       SetParameters(distParams);
       SetCDF();
@@ -177,13 +177,13 @@ namespace Math {
 
    GoFTest::~GoFTest() {}
 
-   void GoFTest::SetSamples(std::vector<const Double_t*> samples, const std::vector<UInt_t> samplesSizes) {
+   void GoFTest::SetSamples(std::vector<const Double_t*> samples, const std::vector<size_t> samplesSizes) {
       fCombinedSamples.assign(std::accumulate(samplesSizes.begin(), samplesSizes.end(), 0u), 0.0);
-      UInt_t combinedSamplesSize = 0;
-      for (UInt_t i = 0; i < samples.size(); ++i) {
+      size_t combinedSamplesSize = 0;
+      for (size_t i = 0; i < samples.size(); ++i) {
          fSamples[i].assign(samples[i], samples[i] + samplesSizes[i]);
          std::sort(fSamples[i].begin(), fSamples[i].end());
-         for (UInt_t j = 0; j < samplesSizes[i]; ++j) {
+         for (size_t j = 0; j < samplesSizes[i]; ++j) {
             fCombinedSamples[combinedSamplesSize + j] = samples[i][j];
          }
          combinedSamplesSize += samplesSizes[i];
@@ -275,7 +275,7 @@ namespace Math {
          fCDF.reset(new CDFWrapper(f, xmin, xmax) );
    }
 
-   void GoFTest::Instantiate(const Double_t* sample, UInt_t sampleSize) {
+   void GoFTest::Instantiate(const Double_t* sample, size_t sampleSize) {
       // initialization function for the template constructors
       Bool_t badSampleArg = sample == 0 || sampleSize == 0;
       if (badSampleArg) {
@@ -288,7 +288,7 @@ namespace Math {
       fDist = kUserDefined;
       fSamples = std::vector<std::vector<Double_t> >(1);
       fTestSampleFromH0 = kTRUE;
-      SetSamples(std::vector<const Double_t*>(1, sample), std::vector<UInt_t>(1, sampleSize));
+      SetSamples(std::vector<const Double_t*>(1, sample), std::vector<size_t>(1, sampleSize));
    }
 
    Double_t GoFTest::GaussianCDF(Double_t x) const {
@@ -307,12 +307,12 @@ namespace Math {
 /* 
   Taken from (1)
 */ 
-   Double_t GoFTest::GetSigmaN(const std::vector<UInt_t> & ns, UInt_t N) {
+   Double_t GoFTest::GetSigmaN(const std::vector<size_t> & ns, size_t N) {
       // compute moments of AD distribution (from Scholz-Stephen paper, paragraph 3)
 
       Double_t sigmaN = 0.0, h = 0.0, H = 0.0, g = 0.0, a, b, c, d, k = ns.size();
 
-      for (UInt_t i = 0; i < ns.size(); ++i) {
+      for (size_t i = 0; i < ns.size(); ++i) {
          H += 1.0 /  double( ns[i] );
       }
 
@@ -320,13 +320,13 @@ namespace Math {
       // cache Sum( 1 / i)
       if (N < 2000) { 
          std::vector<double> invI(N); 
-         for (UInt_t i = 1; i <= N - 1; ++i) {
+         for (size_t i = 1; i <= N - 1; ++i) {
             invI[i] = 1.0 / i; 
             h += invI[i]; 
          }
-         for (UInt_t i = 1; i <= N - 2; ++i) {
+         for (size_t i = 1; i <= N - 2; ++i) {
             double tmp = invI[N-i];
-            for (UInt_t j = i + 1; j <= N - 1; ++j) {
+            for (size_t j = i + 1; j <= N - 1; ++j) {
                g += tmp * invI[j];
             }
          }
@@ -349,7 +349,7 @@ namespace Math {
    }
 
 
-   Double_t GoFTest::PValueADKSamples(UInt_t nsamples, Double_t tx)  {
+   Double_t GoFTest::PValueADKSamples(size_t nsamples, Double_t tx)  {
 
       /*
        Computation of p-values according to 
@@ -654,9 +654,9 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
       // for example unique of v={1,2,2,3,1,2,3,3} results in {1,2,3,1,2,3}  which is exactly what we wants 
       std::vector<Double_t>::iterator endUnique = std::unique(z.begin(), z.end()); //z_j's in (1)
       z.erase(endUnique, z.end() ); 
-      std::vector<UInt_t> h; // h_j's in (1)
+      std::vector<size_t> h; // h_j's in (1)
       std::vector<Double_t> H; // H_j's in (1)
-      UInt_t N = fCombinedSamples.size();
+      size_t N = fCombinedSamples.size();
       Double_t A2 = 0.0; // Anderson-Darling A^2 Test Statistic
 
 #ifdef USE_OLDIMPL      
@@ -667,7 +667,7 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
 
       // old implementation 
       for (std::vector<Double_t>::iterator data = z.begin(); data != endUnique; ++data) {
-         UInt_t n = std::count(fCombinedSamples.begin(), fCombinedSamples.end(), *data);
+         size_t n = std::count(fCombinedSamples.begin(), fCombinedSamples.end(), *data);
          h.push_back(n);
          H.push_back(std::count_if(fCombinedSamples.begin(), fCombinedSamples.end(),
                      std::bind(std::less<Double_t>(), std::placeholders::_1, *data)) + n / 2.);
@@ -676,18 +676,18 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
       w.Print();
       w.Reset(); w.Start();
       std::vector<std::vector<Double_t> > F(nSamples); // F_ij's in (1)
-      for (UInt_t i = 0; i < nSamples; ++i) {
+      for (size_t i = 0; i < nSamples; ++i) {
          for (std::vector<Double_t>::iterator data = z.begin(); data != endUnique; ++data) {
-            UInt_t n = std::count(fSamples[i].begin(), fSamples[i].end(), *data);
+            size_t n = std::count(fSamples[i].begin(), fSamples[i].end(), *data);
             F[i].push_back(std::count_if(fSamples[i].begin(), fSamples[i].end(),
                            std::bind(std::less<Double_t>(), std::placeholders::_1, *data)) + n / 2.);
          }
       }
       std::cout << "time for F";
       w.Print();
-      for (UInt_t i = 0; i < nSamples; ++i) {
+      for (size_t i = 0; i < nSamples; ++i) {
          Double_t sum_result = 0.0;
-         UInt_t j = 0;
+         size_t j = 0;
          w.Reset(); w.Start();      
          for (std::vector<Double_t>::iterator data = z.begin(); data != endUnique; ++data) {
             sum_result += h[j] *  TMath::Power(N * F[i][j]- fSamples[i].size() * H[j], 2) / (H[j] * (N - H[j]) - N * h[j] / 4.0);
@@ -727,7 +727,7 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
 
       // compute the normalized test statistic 
 
-      std::vector<UInt_t> ns(fSamples.size());
+      std::vector<size_t> ns(fSamples.size());
       for (unsigned int k = 0; k < ns.size(); ++k) ns[k] = fSamples[k].size();
       Double_t sigmaN = GetSigmaN(ns, N);
       A2 -= fSamples.size() - 1;
@@ -832,7 +832,7 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
       double A2 = adsum / nall; 
 
       // compute the normalized test statistic 
-      std::vector<unsigned int> ns(2); 
+      std::vector<size_t> ns(2); 
       ns[0] = ntot1; 
       ns[1] = ntot2;
       //std::cout << " ad2 = " << A2 << " nall " << nall;
@@ -899,8 +899,8 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
          MATH_ERROR_MSG("KolmogorovSmirnov2SamplesTest", "Only 1-sample tests can be issued with a 1-sample constructed GoFTest object!");
          return;
       }
-      const UInt_t na = fSamples[0].size();
-      const UInt_t nb = fSamples[1].size();
+      const size_t na = fSamples[0].size();
+      const size_t nb = fSamples[1].size();
       std::vector<Double_t> a(na);
       std::vector<Double_t> b(nb);
       std::copy(fSamples[0].begin(), fSamples[0].end(), a.begin());
@@ -929,8 +929,8 @@ void GoFTest::AndersonDarling2SamplesTest(Double_t& pvalue, Double_t& testStat) 
          return;
       }
       Double_t Fo = 0.0, Dn = 0.0;
-      UInt_t n = fSamples[0].size();
-      for (UInt_t i = 0; i < n; ++i) {
+      size_t n = fSamples[0].size();
+      for (size_t i = 0; i < n; ++i) {
          Double_t Fn = (i + 1.0) / n;
          Double_t F = (*fCDF)(fSamples[0][i]);
          Double_t result = std::max(TMath::Abs(Fn - F), TMath::Abs(Fo - F));

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -120,12 +120,13 @@ namespace Math {
       }
    };
 
-   void GoFTest::SetDistribution(EDistribution dist) {
+   void GoFTest::SetDistribution(EDistribution dist, const std::vector<double>  & distParams ) {
       if (!(kGaussian <= dist && dist <= kExponential)) {
-         MATH_ERROR_MSG("SetDistribution", "Cannot set distribution type! Distribution type option must be ennabled.");
+         MATH_ERROR_MSG("SetDistribution", "Cannot set distribution type! Distribution type option must be enabled.");
          return;
       }
       fDist = dist;
+      SetParameters(distParams);
       SetCDF();
    }
 
@@ -154,10 +155,9 @@ namespace Math {
       samplesSizes[0] = sample1Size;
       samplesSizes[1] = sample2Size;
       SetSamples(samples, samplesSizes);
-      SetParameters();
    }
 
-   GoFTest::GoFTest(UInt_t sampleSize, const Double_t* sample, EDistribution dist)
+   GoFTest::GoFTest(UInt_t sampleSize, const Double_t* sample, EDistribution dist, const std::vector<double> & distParams)
    : fDist(dist),
      fSamples(std::vector<std::vector<Double_t> >(1)),
      fTestSampleFromH0(kTRUE) {
@@ -171,7 +171,7 @@ namespace Math {
       std::vector<const Double_t*> samples(1, sample);
       std::vector<UInt_t> samplesSizes(1, sampleSize);
       SetSamples(samples, samplesSizes);
-      SetParameters();
+      SetParameters(distParams);
       SetCDF();
    }
 
@@ -200,9 +200,8 @@ namespace Math {
       }
    }
 
-   void GoFTest::SetParameters() {
-      fMean = std::accumulate(fSamples[0].begin(), fSamples[0].end(), 0.0) / fSamples[0].size();
-      fSigma = TMath::Sqrt(1. / (fSamples[0].size() - 1) * (std::inner_product(fSamples[0].begin(), fSamples[0].end(),     fSamples[0].begin(), 0.0) - fSamples[0].size() * TMath::Power(fMean, 2)));
+   void GoFTest::SetParameters(const std::vector<double> & distParams) {
+      fParams = distParams;
    }
 
    void GoFTest::operator()(ETestType test, Double_t& pvalue, Double_t& testStat) const {
@@ -246,12 +245,15 @@ namespace Math {
       switch (fDist) {
       case kLogNormal:
          LogSample();
+         if (fParams.empty()) fParams = {0,1};
          /* fall through */
       case kGaussian :
          cdf = new ROOT::Math::WrappedMemFunction<GoFTest, Double_t (GoFTest::*)(Double_t) const>(*this, &GoFTest::GaussianCDF);
+         if (fParams.empty()) fParams = {0,1};
          break;
       case kExponential:
          cdf = new ROOT::Math::WrappedMemFunction<GoFTest, Double_t (GoFTest::*)(Double_t) const>(*this, &GoFTest::ExponentialCDF);
+         if (fParams.empty()) fParams = {1};
          break;
       case kUserDefined:
       case kUndefined:
@@ -284,25 +286,22 @@ namespace Math {
       }
       fCDF.reset((IGenFunction*)0);
       fDist = kUserDefined;
-      fMean = 0;
-      fSigma = 0;
       fSamples = std::vector<std::vector<Double_t> >(1);
       fTestSampleFromH0 = kTRUE;
       SetSamples(std::vector<const Double_t*>(1, sample), std::vector<UInt_t>(1, sampleSize));
    }
 
    Double_t GoFTest::GaussianCDF(Double_t x) const {
-      return ROOT::Math::normal_cdf(x, fSigma, fMean);
+      return ROOT::Math::normal_cdf(x, fParams[1], fParams[0]);
    }
 
    Double_t GoFTest::ExponentialCDF(Double_t x) const {
-      return ROOT::Math::exponential_cdf(x, 1.0 / fMean);
+      return ROOT::Math::exponential_cdf(x, fParams[0]);
    }
 
    void GoFTest::LogSample() {
       transform(fSamples[0].begin(), fSamples[0].end(), fSamples[0].begin(),
                 std::function<Double_t(Double_t)>(TMath::Log));
-      SetParameters();
    }
 
 /* 

--- a/math/mathcore/test/CMakeLists.txt
+++ b/math/mathcore/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TestSource
     testTMath.cxx
     testBinarySearch.cxx
     testSortOrder.cxx
+    stressGoFTest.cxx
     stressTMath.cxx
     stressTF1.cxx
     testIntegration.cxx
@@ -40,7 +41,6 @@ set(TestSource
     fit/testLogLExecPolicy.cxx )
 
 if(mathmore)
-  list(APPEND TestSource stressGoFTest.cxx)
   list(APPEND Libraries MathMore)
 endif()
 
@@ -49,6 +49,10 @@ if(minuit2)
   list(APPEND Libraries Minuit2)
 endif()
 
+if(r)
+ add_definitions(-DROOT_HAS_R)
+ list(APPEND Libraries RInterface)
+endif()
 
 #---Build and add all the defined test in the list---------------
 foreach(file ${TestSource})


### PR DESCRIPTION
As reported in #9636 the line computing the distance between the model cdf and
the empirical distribution was not correct. It is now fixed as in the original implementation.



This PR fixes # 9636

