### PR TITLE
[v6.26] Use correct Longptr_t return type for Win64 (thanks Sergey) (#9817)

### DIFF
--- a/core/gui/inc/TBrowser.h
+++ b/core/gui/inc/TBrowser.h
@@ -105,7 +105,7 @@ public:
    void          SetDrawOption(Option_t *option="") { if (fImp) fImp->SetDrawOption(option); }
    Option_t     *GetDrawOption() const { return  (fImp) ? fImp->GetDrawOption() : 0; }
 
-   Long_t        ExecPlugin(const char *name = 0, const char *fname = 0,
+   Longptr_t     ExecPlugin(const char *name = 0, const char *fname = 0,
                             const char *cmd = 0, Int_t pos = 1, Int_t subpos = -1) {
                     return (fImp) ? fImp->ExecPlugin(name, fname, cmd, pos, subpos) : -1;
                  }

--- a/core/gui/inc/TBrowserImp.h
+++ b/core/gui/inc/TBrowserImp.h
@@ -56,7 +56,7 @@ public:
    virtual void      SetDrawOption(Option_t * = "") { }
    virtual Option_t *GetDrawOption() const { return nullptr; }
 
-   virtual Long_t    ExecPlugin(const char *, const char *, const char *, Int_t, Int_t) { return 0; }
+   virtual Longptr_t ExecPlugin(const char *, const char *, const char *, Int_t, Int_t) { return 0; }
    virtual void      SetStatusText(const char *, Int_t) { }
    virtual void      StartEmbedding(Int_t, Int_t) { }
    virtual void      StopEmbedding(const char *) { }

--- a/gui/gui/inc/TRootBrowser.h
+++ b/gui/gui/inc/TRootBrowser.h
@@ -165,7 +165,7 @@ public:
    Option_t         *GetDrawOption() const override;
    TGMainFrame      *GetMainFrame() const override { return (TGMainFrame *)this; }
 
-   Long_t            ExecPlugin(const char *name = nullptr, const char *fname = nullptr,
+   Longptr_t         ExecPlugin(const char *name = nullptr, const char *fname = nullptr,
                                 const char *cmd = nullptr, Int_t pos = kRight,
                                 Int_t subpos = -1) override;
    void              SetStatusText(const char *txt, Int_t col) override;

--- a/gui/gui/src/TRootBrowser.cxx
+++ b/gui/gui/src/TRootBrowser.cxx
@@ -552,10 +552,10 @@ void TRootBrowser::EventInfo(Int_t event, Int_t px, Int_t py, TObject *selected)
 /// Execute a macro and embed the created frame in the tab "pos"
 /// and tab element "subpos".
 
-Long_t TRootBrowser::ExecPlugin(const char *name, const char *fname,
-                                const char *cmd, Int_t pos, Int_t subpos)
+Longptr_t TRootBrowser::ExecPlugin(const char *name, const char *fname,
+                                   const char *cmd, Int_t pos, Int_t subpos)
 {
-   Long_t retval = 0;
+   Longptr_t retval = 0;
    TBrowserPlugin *p;
    TString command, pname;
    if (cmd && strlen(cmd)) {


### PR DESCRIPTION
* Use correct Longptr_t return type for Win64 (thanks Sergey)

* Add a forgotten Longptr_t change (thanks again Sergey!)
