### PR TITLE
v6-26: [cling] Do not ACLiC-link against (non-existent) libssl:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3401,6 +3401,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        || strstr(filename, "/usr/lib/libRosetta")
        || strstr(filename, "/usr/lib/libCoreEntitlements")
        || strstr(filename, "/usr/lib/libssl.")
+       || strstr(filename, "/usr/lib/libcrypto.")
        // These are candidates for suppression, too:
        //   -lfakelink -lapple_nghttp2 -lnetwork -lsqlite3 -lenergytrace -lCoreEntitlements
        //   -lMobileGestalt -lcoretls -lcoretls_cfhelpers -lxar.1 -lcompression -larchive.2

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3400,6 +3400,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        || strstr(filename, "/usr/lib/liboah")
        || strstr(filename, "/usr/lib/libRosetta")
        || strstr(filename, "/usr/lib/libCoreEntitlements")
+       || strstr(filename, "/usr/lib/libssl.")
        // These are candidates for suppression, too:
        //   -lfakelink -lapple_nghttp2 -lnetwork -lsqlite3 -lenergytrace -lCoreEntitlements
        //   -lMobileGestalt -lcoretls -lcoretls_cfhelpers -lxar.1 -lcompression -larchive.2


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/9803
