### PR TITLE
[http] use proper conversion from string to unsigned long

### DIFF
--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1155,8 +1155,9 @@ Bool_t THttpServer::ExecuteWS(std::shared_ptr<THttpCallArg> &arg, Bool_t externa
          TUrl url;
          url.SetOptions(arg->fQuery);
          url.ParseOptions();
-         Int_t connid = url.GetIntValueFromOptions("connection");
-         arg->SetWSId((UInt_t)connid);
+         const char *connid = url.GetValueFromOptions("connection");
+         if (connid)
+            arg->SetWSId(std::stoul(connid));
          if (url.HasOption("close")) {
             arg->SetMethod("WS_CLOSE");
             arg->SetTextContent("OK");


### PR DESCRIPTION
Connection id can be arbitrary unsigned integer
Making problem with lonpoll engine, where id produced as hash value