### PR TITLE
[cmake] simplify copies of misc files into build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ add_custom_command(OUTPUT ${stamp_file}
                    COMMAND ${CMAKE_COMMAND} -E touch ${stamp_file}
                    COMMENT "Copying directories such as etc, icons, fonts, js, ui5, etc. to build area")
 
-set(artifact_dirs)
+set(artifact_dirs "etc;test;icons;fonts;macros")
 if(http)
    list(APPEND artifact_dirs js)
 endif()
@@ -292,8 +292,8 @@ if(webgui)
 endif()
 
 #---Copy files to the build area, with dependency---------------------------------
-file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/* etc/* test/* icons/* fonts/* macros/*)
-set(artifact_files_builddir)
+file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/*)
+set(artifact_copydirs_targets)
 foreach(artifact_file ${artifact_files})
   # Filter out hsimple.root; someone might have created it in the src dir, and the hsimple.root
   # target below will interfere.
@@ -302,7 +302,7 @@ foreach(artifact_file ${artifact_files})
       COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${artifact_file} ${CMAKE_BINARY_DIR}/${artifact_file}
       COMMENT "Copying ${CMAKE_SOURCE_DIR}/${artifact_file}"
       DEPENDS ${CMAKE_SOURCE_DIR}/${artifact_file})
-    list(APPEND artifact_files_builddir ${CMAKE_BINARY_DIR}/${artifact_file})
+    list(APPEND artifact_copydirs_targets ${CMAKE_BINARY_DIR}/${artifact_file})
   endif()
 endforeach()
 
@@ -311,10 +311,10 @@ foreach(dir ${artifact_dirs})
    add_custom_target(${tgt}
                      COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/${dir} ${CMAKE_BINARY_DIR}/${dir}
                      COMMENT "Copy ${dir} directory")
-   list(APPEND artifact_files_builddir ${tgt})
+   list(APPEND artifact_copydirs_targets ${tgt})
 endforeach()
 
-add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_files_builddir})
+add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_copydirs_targets})
 
 add_subdirectory (interpreter)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,15 +283,16 @@ add_custom_command(OUTPUT ${stamp_file}
                    COMMAND ${CMAKE_COMMAND} -E touch ${stamp_file}
                    COMMENT "Copying directories such as etc, icons, fonts, js, ui5, etc. to build area")
 
+set(artifact_dirs)
 if(http)
-set(jsroot_files js/*)
+   list(APPEND artifact_dirs js)
 endif()
 if(webgui)
-set(openui5_files ui5/*)
+   list(APPEND artifact_dirs ui5)
 endif()
 
 #---Copy files to the build area, with dependency---------------------------------
-file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/* etc/* test/* icons/* fonts/* macros/* ${jsroot_files} ${openui5_files})
+file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/* etc/* test/* icons/* fonts/* macros/*)
 set(artifact_files_builddir)
 foreach(artifact_file ${artifact_files})
   # Filter out hsimple.root; someone might have created it in the src dir, and the hsimple.root
@@ -304,6 +305,15 @@ foreach(artifact_file ${artifact_files})
     list(APPEND artifact_files_builddir ${CMAKE_BINARY_DIR}/${artifact_file})
   endif()
 endforeach()
+
+foreach(dir ${artifact_dirs})
+   set(tgt copy_dir_${dir})
+   add_custom_target(${tgt}
+                     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/${dir} ${CMAKE_BINARY_DIR}/${dir}
+                     COMMENT "Copy ${dir} directory")
+   list(APPEND artifact_files_builddir ${tgt})
+endforeach()
+
 add_custom_target(move_artifacts DEPENDS ${stamp_file} ${artifact_files_builddir})
 
 add_subdirectory (interpreter)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,9 @@ add_custom_command(OUTPUT ${stamp_file}
                    COMMAND ${CMAKE_COMMAND} -E touch ${stamp_file}
                    COMMENT "Copying directories such as etc, icons, fonts, js, ui5, etc. to build area")
 
-set(artifact_dirs "etc;test;icons;fonts;macros")
+#---- List of directories which completely copied to target directory by each build
+set(artifact_dirs "etc;test;icons;fonts;macros;tutorials")
+
 if(http)
    list(APPEND artifact_dirs js)
 endif()
@@ -291,21 +293,7 @@ if(webgui)
    list(APPEND artifact_dirs ui5)
 endif()
 
-#---Copy files to the build area, with dependency---------------------------------
-file(GLOB_RECURSE artifact_files RELATIVE ${CMAKE_SOURCE_DIR} tutorials/*)
 set(artifact_copydirs_targets)
-foreach(artifact_file ${artifact_files})
-  # Filter out hsimple.root; someone might have created it in the src dir, and the hsimple.root
-  # target below will interfere.
-  if (NOT (artifact_file STREQUAL "tutorials/hsimple.root"))
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${artifact_file}
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_SOURCE_DIR}/${artifact_file} ${CMAKE_BINARY_DIR}/${artifact_file}
-      COMMENT "Copying ${CMAKE_SOURCE_DIR}/${artifact_file}"
-      DEPENDS ${CMAKE_SOURCE_DIR}/${artifact_file})
-    list(APPEND artifact_copydirs_targets ${CMAKE_BINARY_DIR}/${artifact_file})
-  endif()
-endforeach()
-
 foreach(dir ${artifact_dirs})
    set(tgt copy_dir_${dir})
    add_custom_target(${tgt}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,12 +279,11 @@ endforeach()
 set(stamp_file ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/move_artifacts.stamp)
 add_custom_command(OUTPUT ${stamp_file}
                    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE ${CMAKE_BINARY_DIR}/LICENSE
-                   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/README ${CMAKE_BINARY_DIR}/README
                    COMMAND ${CMAKE_COMMAND} -E touch ${stamp_file}
                    COMMENT "Copying directories such as etc, icons, fonts, js, ui5, etc. to build area")
 
-#---- List of directories which completely copied to target directory by each build
-set(artifact_dirs "etc;test;icons;fonts;macros;tutorials")
+#----  List of source directories which are copied verbatim into the build directory ---
+set(artifact_dirs "etc;test;icons;fonts;macros;tutorials;README")
 
 if(http)
    list(APPEND artifact_dirs js)


### PR DESCRIPTION
Instead of handling each individual file from `tutorials/` or `etc/` or `js/` subdirectory, 
just invoke `cmake -E copy_directory <src> <dst>` command. 
It ignores all files diffs and just copy them. 
Necessary to correctly handle incremental builds

Significantly reduce number of `cmake` invocations - compared with #9804.

