### PR TITLE
Fix R bindings for  MacOS

### DIFF
--- a/bindings/pyroot/pythonizations/src/PyzCppHelpers.hxx
+++ b/bindings/pyroot/pythonizations/src/PyzCppHelpers.hxx
@@ -14,7 +14,7 @@
 #include "CPyCppyy.h"
 #include "CPPInstance.h"
 #include "TClass.h"
-#include "RConfig.h"
+#include "ROOT/RConfig.hxx"
 
 #include <string>
 

--- a/bindings/pyroot/pythonizations/src/PyzPythonHelpers.cxx
+++ b/bindings/pyroot/pythonizations/src/PyzPythonHelpers.cxx
@@ -23,7 +23,7 @@ PyROOT extension module.
 
 #include "PyROOTPythonize.h"
 
-#include "RConfig.h"
+#include "ROOT/RConfig.hxx"
 #include "TInterpreter.h"
 
 #include <sstream>

--- a/bindings/pyroot/pythonizations/src/RDataFramePyz.cxx
+++ b/bindings/pyroot/pythonizations/src/RDataFramePyz.cxx
@@ -13,7 +13,7 @@
 #include "CPPInstance.h"
 #include "ProxyWrappers.h"
 #include "PyROOTPythonize.h"
-#include "RConfig.h"
+#include "ROOT/RConfig.hxx"
 #include "TInterpreter.h"
 #include "CPyCppyy/API.h"
 

--- a/bindings/r/inc/RExports.h
+++ b/bindings/r/inc/RExports.h
@@ -38,6 +38,7 @@
 //pragma to disable warnings on Rcpp which have
 //so many noise compiling
 #if defined(__GNUC__)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
@@ -45,11 +46,9 @@
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #pragma GCC diagnostic ignored "-Wextra"
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#endif
 // disable warning for macos
 #if defined(__APPLE__)
 #pragma GCC diagnostic ignored "-Wnonportable-include-path"
-#
 //This to fix conflict of RVersion.h from ROOT and Rversion.h from R 
 #if !defined(R_Version)
 #define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
@@ -58,6 +57,7 @@
 // but is defined as macro in RInternals.h
 #if defined(RAW)
 #undef RAW
+#endif
 #endif
 #endif
 
@@ -139,15 +139,18 @@ namespace Rcpp {
    }
 }
 
-
 #include<Rcpp.h>//this headers should be called after templates definitions
-#include<Rcpp/Named.h>
 #undef HAVE_UINTPTR_T
 #include<RInside.h>
 
 #ifdef Free
 // see https://sft.its.cern.ch/jira/browse/ROOT-9258
 # undef Free
+#endif
+
+// restore warning level of before
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #endif
 
 namespace ROOT {

--- a/bindings/r/inc/RExports.h
+++ b/bindings/r/inc/RExports.h
@@ -11,6 +11,22 @@
  *************************************************************************/
 #ifndef ROOT_R_RExports
 #define ROOT_R_RExports
+
+#if defined(__APPLE__) 
+//This to fix conflict of RVersion.h from ROOT and Rversion.h from R 
+#if !defined(R_Version)
+#define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
+#endif
+// RAW is defined in a MacOS system header
+// but is defined as macro in RInternals.h
+#if defined(RAW)
+#undef RAW
+#endif
+#endif
+
+#include<RcppCommon.h>
+
+
 //ROOT headers
 #include <Rtypes.h>
 
@@ -48,7 +64,6 @@
 //Some useful typedefs
 typedef std::vector<TString> TVectorString;
 
-#include<RcppCommon.h>
 namespace ROOT {
    namespace R {
       class TRFunctionExport;
@@ -121,10 +136,6 @@ namespace Rcpp {
    }
 }
 
-//added to fix bug in last version of Rcpp on mac
-#if !defined(R_Version)
-#define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
-#endif
 
 #include<Rcpp.h>//this headers should be called after templates definitions
 #include<Rcpp/Named.h>

--- a/bindings/r/inc/RExports.h
+++ b/bindings/r/inc/RExports.h
@@ -12,19 +12,6 @@
 #ifndef ROOT_R_RExports
 #define ROOT_R_RExports
 
-#if defined(__APPLE__) 
-//This to fix conflict of RVersion.h from ROOT and Rversion.h from R 
-#if !defined(R_Version)
-#define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
-#endif
-// RAW is defined in a MacOS system header
-// but is defined as macro in RInternals.h
-#if defined(RAW)
-#undef RAW
-#endif
-#endif
-
-#include<RcppCommon.h>
 
 
 //ROOT headers
@@ -59,6 +46,22 @@
 #pragma GCC diagnostic ignored "-Wextra"
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #endif
+// disable warning for macos
+#if defined(__APPLE__)
+#pragma GCC diagnostic ignored "-Wnonportable-include-path"
+#
+//This to fix conflict of RVersion.h from ROOT and Rversion.h from R 
+#if !defined(R_Version)
+#define R_Version(v,p,s) ((v * 65536) + (p * 256) + (s))
+#endif
+// RAW is defined in a MacOS system header
+// but is defined as macro in RInternals.h
+#if defined(RAW)
+#undef RAW
+#endif
+#endif
+
+#include<RcppCommon.h>
 
 
 //Some useful typedefs

--- a/bindings/r/inc/TRFunctionImport.h
+++ b/bindings/r/inc/TRFunctionImport.h
@@ -17,11 +17,6 @@
 
 #include <TRObject.h>
 
-#ifndef Rcpp_hpp
-#include <Rcpp.h>
-#endif
-
-
 namespace ROOT {
    namespace R {
 

--- a/bindings/r/inc/TRInterface.h
+++ b/bindings/r/inc/TRInterface.h
@@ -142,6 +142,10 @@ namespace ROOT {
          class Binding {
          public:
             Binding(TRInterface *rnt, TString name): fInterface(rnt), fName(name) {}
+            Binding(const Binding &obj) {
+               fInterface = obj.fInterface;
+               fName = obj.fName;
+            }
             Binding &operator=(const Binding &obj)
             {
                fInterface = obj.fInterface;

--- a/bindings/r/inc/TRInternalFunction.h
+++ b/bindings/r/inc/TRInternalFunction.h
@@ -14,10 +14,6 @@
 
 #include <RExports.h>
 
-#ifndef Rcpp_hpp
-#include <Rcpp.h>
-#endif
-
 //________________________________________________________________________________________________________
 /**
    This is a class to support deprecated method to pass function to R's Environment,

--- a/bindings/r/src/RExports.cxx
+++ b/bindings/r/src/RExports.cxx
@@ -11,7 +11,6 @@
 #include<TRFunctionExport.h>
 #include<TRObject.h>
 #include<TRDataFrame.h>
-#include<Rcpp/Vector.h>
 
 namespace ROOT {
    namespace R {

--- a/bindings/r/src/TRFunctionImport.cxx
+++ b/bindings/r/src/TRFunctionImport.cxx
@@ -10,8 +10,6 @@
 #include<TRFunctionImport.h>
 #include <TRObject.h>
 
-#include <Rcpp/Function.h>
-
 //______________________________________________________________________________
 /* Begin_Html
 End_Html

--- a/build/unix/module.modulemap
+++ b/build/unix/module.modulemap
@@ -14,8 +14,6 @@ module ROOT_Foundation_C  {
 module ROOT_Config  {
   // These headers are supposed to be only textually expanded for each TU.
   module "RVersion.h" { textual header "RVersion.h" export * }
-  module "RConfig.h" { header "RConfig.h" export * }
-  module "ROOT/RConfig.h" { header "ROOT/RConfig.h" export * }
   module "ROOT/RConfig.hxx" { textual header "ROOT/RConfig.hxx" export * }
   module "RConfigure.h" { textual header "RConfigure.h" export * }
   // FIXME: There is little benefit in keeping DllImport as a separate header.

--- a/build/unix/module.modulemap
+++ b/build/unix/module.modulemap
@@ -14,6 +14,8 @@ module ROOT_Foundation_C  {
 module ROOT_Config  {
   // These headers are supposed to be only textually expanded for each TU.
   module "RVersion.h" { textual header "RVersion.h" export * }
+  module "RConfig.h" { header "RConfig.h" export * }
+  module "ROOT/RConfig.h" { header "ROOT/RConfig.h" export * }
   module "ROOT/RConfig.hxx" { textual header "ROOT/RConfig.hxx" export * }
   module "RConfigure.h" { textual header "RConfigure.h" export * }
   // FIXME: There is little benefit in keeping DllImport as a separate header.

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2660,7 +2660,7 @@ static void R__WriteDependencyFile(const TString & build_loc, const TString &dep
    }
 #endif
    {
-     const char *dictHeaders[] = { "RVersion.h", "RConfig.h", "TClass.h",
+     const char *dictHeaders[] = { "RVersion.h", "ROOT/RConfig.hxx", "TClass.h",
        "TDictAttributeMap.h","TInterpreter.h","TROOT.h","TBuffer.h",
        "TMemberInspector.h","TError.h","RtypesImp.h","TIsAProxy.h",
        "TFileMergeInfo.h","TCollectionProxyInfo.h"};

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -2808,7 +2808,7 @@ void CreateDictHeader(std::ostream &dictStream, const std::string &main_dictname
                << "#include <string.h>\n"
                << "#include <assert.h>\n"
                << "#define G__DICTIONARY\n"
-               << "#include \"RConfig.h\"\n"
+               << "#include \"ROOT/RConfig.hxx\"\n"
                << "#include \"TClass.h\"\n"
                << "#include \"TDictAttributeMap.h\"\n"
                << "#include \"TInterpreter.h\"\n"

--- a/core/thread/test/testInterpreterLock.cxx
+++ b/core/thread/test/testInterpreterLock.cxx
@@ -1,4 +1,4 @@
-#include "RConfig.h"
+#include "ROOT/RConfig.hxx"
 #ifdef R__USE_IMT
 #include "ROOT/TThreadExecutor.hxx"
 #endif

--- a/roofit/batchcompute/src/RooBatchCompute.cu
+++ b/roofit/batchcompute/src/RooBatchCompute.cu
@@ -21,7 +21,7 @@ This file contains the code for cuda computations using the RooBatchCompute libr
 #include "RooBatchCompute.h"
 #include "Batches.h"
 
-#include "ROOT/RConfig.h"
+#include "ROOT/RConfig.hxx"
 #include "TError.h"
 
 #include <algorithm>

--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -23,7 +23,7 @@ This file contains the code for cpu computations using the RooBatchCompute libra
 #include "RooVDTHeaders.h"
 #include "Batches.h"
 
-#include "ROOT/RConfig.h"
+#include "ROOT/RConfig.hxx"
 #include "ROOT/TExecutor.hxx"
 
 #include <algorithm>


### PR DESCRIPTION
This PR fixes a problem found when building and using the R bindings on MacOS

- First we make sure that ROOT is not using the old RConfig.h but ROOT/RConfig.hxx
  This avoids a conflict with the R file Rconfig.h
  The first commit remove the usage of the old Rconfig.h when generating the dictionary for libCore 

- The second commit fixes a conflicting definition of a macro between system macOS and R headers. 