### PR TITLE
[Build System] Workaround MacOS 10.13+ and XCode Python 3.8+ fork issue

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -631,6 +631,17 @@ if(ROOT_pyroot_FOUND)
   # Use main Python executable to run in PySpark driver and executors
   if(test_distrdf_pyspark)
     list(APPEND ROOT_environ PYSPARK_PYTHON=${PYTHON_EXECUTABLE_Development_Main})
+    if(MACOSX_VERSION VERSION_GREATER_EQUAL 10.13)
+      # MacOS has changed rules about forking processes after 10.13
+      # Running pyspark tests with XCode Python3 throws crashes with errors like:
+      # `objc[17271]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.`
+      # This issue should have been fixed after Python 3.8 (see https://bugs.python.org/issue33725)
+      # Indeed, any other Python 3.8+ executable does not show this crash. It is
+      # specifically the XCode Python executable that triggers this.
+      # For now, there seems no other way than this workaround,
+      # which effectively sets the behaviour of `fork` back to MacOS 10.12
+      list(APPEND ROOT_environ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES)
+    endif()
   endif()
 
   find_python_module(xgboost QUIET)


### PR DESCRIPTION
Backport of #9811 