### PR TITLE
[RF] Avoid uninitialized RooListProxies in RooLagrangianMorphFunc

### DIFF
--- a/roofit/roofit/inc/RooLagrangianMorphFunc.h
+++ b/roofit/roofit/inc/RooLagrangianMorphFunc.h
@@ -262,7 +262,10 @@ protected:
    RooListProxy _flags;
    Config _config;
    std::vector<std::vector<RooListProxy *>> _diagrams;
-   mutable const RooArgSet *_curNormSet; //!
+   mutable const RooArgSet *_curNormSet = nullptr; //!
+
+   // TODO: the _nonInterfering is not filled anywhere and also not considered
+   // correctly in the copy constructor. Can it be removed?
    std::vector<RooListProxy *> _nonInterfering;
 
    ClassDefOverride(RooLagrangianMorphFunc, 1)

--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -451,19 +451,19 @@ void readValues(std::map<const std::string, T> &myMap, TH1 *h_pc)
 ///////////////////////////////////////////////////////////////////////////////
 /// Set up folder ownership over its children, and treat likewise any subfolders.
 /// @param theFolder: folder to update. Assumed to be a valid pointer
-void setOwnerRecursive(TFolder* theFolder){
+void setOwnerRecursive(TFolder *theFolder)
+{
    theFolder->SetOwner();
    // And also need to set up ownership for nested folders
    auto subdirs = theFolder->GetListOfFolders();
-   for (auto* subdir : *subdirs){
-      auto thisfolder = dynamic_cast<TFolder*>(subdir);
-      if (thisfolder){
+   for (auto *subdir : *subdirs) {
+      auto thisfolder = dynamic_cast<TFolder *>(subdir);
+      if (thisfolder) {
          // no explicit deletion here, will be handled by parent
          setOwnerRecursive(thisfolder);
       }
    }
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Load a TFolder from a file while ensuring it owns its content.
@@ -473,10 +473,12 @@ void setOwnerRecursive(TFolder* theFolder){
 /// @param inFile: Input file to read - assumed to be a valid pointer
 /// @param folderName: Name of the folder to read from the file
 /// @return a unique_ptr to the folder. Nullptr if not found.
-std::unique_ptr<TFolder> readOwningFolderFromFile(TDirectory* inFile, const std::string & folderName){
+std::unique_ptr<TFolder> readOwningFolderFromFile(TDirectory *inFile, const std::string &folderName)
+{
    std::unique_ptr<TFolder> theFolder(inFile->Get<TFolder>(folderName.c_str()));
    if (!theFolder) {
-      std::cerr << "Error: unable to access data from folder '" << folderName << "' from file '"<<inFile->GetName()<<"'!" << std::endl;
+      std::cerr << "Error: unable to access data from folder '" << folderName << "' from file '" << inFile->GetName()
+                << "'!" << std::endl;
       return nullptr;
    }
    setOwnerRecursive(theFolder.get());
@@ -492,10 +494,9 @@ std::unique_ptr<TFolder> readOwningFolderFromFile(TDirectory* inFile, const std:
 /// @param objName Name of the object to load
 /// @param notFoundError If set, print a detailed error if we didn't find something
 /// @return Returns a pointer to a clone of the loaded object. Ownership assigned to the caller.
-template <class AObjType> AObjType* loadFromFileResidentFolder(TDirectory* inFile,
-                                                            const std::string & folderName,
-                                                            const std::string & objName,
-                                                            bool notFoundError = true)
+template <class AObjType>
+AObjType *loadFromFileResidentFolder(TDirectory *inFile, const std::string &folderName, const std::string &objName,
+                                     bool notFoundError = true)
 {
    auto folder = readOwningFolderFromFile(inFile, folderName);
    if (!folder) {
@@ -503,10 +504,10 @@ template <class AObjType> AObjType* loadFromFileResidentFolder(TDirectory* inFil
    }
    AObjType *loadedObject = dynamic_cast<AObjType *>(folder->FindObject(objName.c_str()));
    if (!loadedObject) {
-      if (notFoundError){
+      if (notFoundError) {
          std::stringstream errstr;
          errstr << "Error: unable to retrieve object '" << objName << "' from folder '" << folderName
-                  << "'. contents are:";
+                << "'. contents are:";
          TIter next(folder->GetListOfFolders()->begin());
          TFolder *f;
          while ((f = (TFolder *)next())) {
@@ -517,9 +518,9 @@ template <class AObjType> AObjType* loadFromFileResidentFolder(TDirectory* inFil
       return nullptr;
    }
    // replace the loaded object by a clone, as the loaded folder will delete the original
-   return static_cast<AObjType *>(loadedObject->Clone()); // can use a static_cast - confirmed validity by initial cast above.
+   return static_cast<AObjType *>(
+      loadedObject->Clone()); // can use a static_cast - confirmed validity by initial cast above.
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 /// retrieve a ParamSet from a certain subfolder 'name' of the file
@@ -803,8 +804,9 @@ void collectHistograms(const char *name, TDirectory *file, std::map<std::string,
    bool binningOK = false;
    for (auto sampleit : inputParameters) {
       const std::string sample(sampleit.first);
-      TH1* hist = loadFromFileResidentFolder<TH1>(file, sample, varname, true);
-      if (!hist) return;
+      TH1 *hist = loadFromFileResidentFolder<TH1>(file, sample, varname, true);
+      if (!hist)
+         return;
 
       auto it = list_hf.find(sample);
       if (it != list_hf.end()) {
@@ -855,8 +857,9 @@ void collectRooAbsReal(const char * /*name*/, TDirectory *file, std::map<std::st
 {
    for (auto sampleit : inputParameters) {
       const std::string sample(sampleit.first);
-      RooAbsReal* obj = loadFromFileResidentFolder<RooAbsReal>(file,sample,varname,true);
-      if (!obj) return;
+      RooAbsReal *obj = loadFromFileResidentFolder<RooAbsReal>(file, sample, varname, true);
+      if (!obj)
+         return;
       auto it = list_hf.find(sample);
       if (it == list_hf.end()) {
          int idx = physics.getSize();
@@ -877,7 +880,7 @@ void collectCrosssections(const char *name, TDirectory *file, std::map<std::stri
 {
    for (auto sampleit : inputParameters) {
       const std::string sample(sampleit.first);
-      TObject* obj = loadFromFileResidentFolder<TObject>(file, sample, varname,false);
+      TObject *obj = loadFromFileResidentFolder<TObject>(file, sample, varname, false);
       TParameter<T> *xsection = nullptr;
       TParameter<T> *error = nullptr;
       TParameter<T> *p = dynamic_cast<TParameter<T> *>(obj);
@@ -922,8 +925,9 @@ void collectCrosssectionsTPair(const char *name, TDirectory *file, std::map<std:
                                RooArgList &physics, const std::string &varname, const std::string &basefolder,
                                const RooLagrangianMorphFunc::ParamMap &inputParameters)
 {
-   TPair* pair = loadFromFileResidentFolder<TPair>(file,basefolder,varname,false);
-   if (!pair) return;
+   TPair *pair = loadFromFileResidentFolder<TPair>(file, basefolder, varname, false);
+   if (!pair)
+      return;
    TParameter<double> *xsec_double = dynamic_cast<TParameter<double> *>(pair->Key());
    if (xsec_double) {
       collectCrosssections<double>(name, file, list_xs, physics, varname, inputParameters);
@@ -1277,7 +1281,7 @@ createFormulas(const char *name, const RooLagrangianMorphFunc::ParamMap &inputs,
       errorMsgStream
          << "no formulas are non-zero, check if any if your couplings is floating and missing from your param_cards!"
          << std::endl;
-   const auto errorMsg = errorMsgStream.str();
+      const auto errorMsg = errorMsgStream.str();
       throw std::runtime_error(errorMsg);
    }
    checkMatrix(inputs, retval);
@@ -1681,7 +1685,7 @@ RooRealVar *RooLagrangianMorphFunc::setupObservable(const char *obsname, TClass 
    } else {
       if (strcmp(obsname, obs->GetName()) != 0) {
          coutW(ObjectHandling) << " name of existing observable " << this->_observables.at(0)->GetName()
-                               << " does not match expected name " << obsname << std::endl ;
+                               << " does not match expected name " << obsname << std::endl;
       }
    }
 
@@ -1714,8 +1718,8 @@ inline void RooLagrangianMorphFunc::updateSampleWeights()
       // build the formula with the correct normalization
       RooLinearCombination *sampleformula = dynamic_cast<RooLinearCombination *>(this->getSampleWeight(sample.c_str()));
       if (!sampleformula) {
-       coutE(ObjectHandling) << Form("unable to access formula for sample '%s'!",sample.c_str()) << std::endl;
-      return;
+         coutE(ObjectHandling) << Form("unable to access formula for sample '%s'!", sample.c_str()) << std::endl;
+         return;
       }
       cxcoutP(ObjectHandling) << "updating formula for sample '" << sample << "'" << std::endl;
       for (size_t formulaidx = 0; formulaidx < n; ++formulaidx) {
@@ -1761,9 +1765,10 @@ void RooLagrangianMorphFunc::collectInputs(TDirectory *file)
    cxcoutP(InputArguments) << "initializing physics inputs from file " << file->GetName() << " with object name(s) '"
                            << obsName << "'" << std::endl;
    auto folderNames = this->_config.folderNames;
-   TObject* obj = loadFromFileResidentFolder<TObject>(file, folderNames.front(), obsName, true);
+   TObject *obj = loadFromFileResidentFolder<TObject>(file, folderNames.front(), obsName, true);
    if (!obj) {
-      std::cerr << "unable to locate object '" << obsName << "' in folder '" << folderNames.front() << "'!" << std::endl;
+      std::cerr << "unable to locate object '" << obsName << "' in folder '" << folderNames.front() << "'!"
+                << std::endl;
       return;
    }
    std::string classname = obj->ClassName();
@@ -1808,7 +1813,7 @@ void RooLagrangianMorphFunc::addFolders(const RooArgList &folders)
    TIter next(file->GetList());
    TObject *obj = nullptr;
    while ((obj = (TObject *)next())) {
-      auto f = readOwningFolderFromFile(file,obj->GetName());
+      auto f = readOwningFolderFromFile(file, obj->GetName());
       if (!f)
          continue;
       std::string name(f->GetName());
@@ -2562,7 +2567,7 @@ void RooLagrangianMorphFunc::setParameters(const char *foldername)
 {
    std::string filename = this->_config.fileName;
    TDirectory *file = openFile(filename.c_str());
-   TH1 *paramhist = loadFromFileResidentFolder<TH1>(file, foldername,"param_card");
+   TH1 *paramhist = loadFromFileResidentFolder<TH1>(file, foldername, "param_card");
    setParams(paramhist, this->_operators, false);
    closeFile(file);
 }

--- a/roofit/roofitcore/inc/RooListProxy.h
+++ b/roofit/roofitcore/inc/RooListProxy.h
@@ -55,6 +55,7 @@ protected:
   Bool_t _defShapeServer ;  ///< Propagate shape dirty flags?
 
   Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
+  void checkValid() const;
 
   ClassDefOverride(RooListProxy,1) // Proxy class for a RooArgList
 };

--- a/roofit/roofitcore/inc/RooSetProxy.h
+++ b/roofit/roofitcore/inc/RooSetProxy.h
@@ -68,6 +68,7 @@ protected:
   Bool_t _defShapeServer ;
 
   Bool_t changePointer(const RooAbsCollection& newServerSet, Bool_t nameChange=kFALSE, Bool_t factoryInitMode=kFALSE) override;
+  void checkValid() const;
 
   ClassDefOverride(RooSetProxy,1) // Proxy class for a RooArgSet
 };

--- a/roofit/roofitcore/src/RooListProxy.cxx
+++ b/roofit/roofitcore/src/RooListProxy.cxx
@@ -35,6 +35,8 @@ are clone and client-server links need to be redirected.
 #include "RooArgList.h"
 #include "RooAbsArg.h"
 
+#include <exception>
+
 using namespace std;
 
 ClassImp(RooListProxy);
@@ -89,8 +91,9 @@ RooListProxy::~RooListProxy()
 
 Bool_t RooListProxy::add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent)
 {
+  checkValid();
   Bool_t ret=RooArgList::add(var,silent) ;
-  if (ret && _owner) {
+  if (ret) {
     _owner->addServer((RooAbsArg&)var,valueServer,shapeServer) ;
   }
   return ret ;
@@ -113,6 +116,7 @@ Bool_t RooListProxy::add(const RooAbsArg& var, Bool_t silent)
 
 Bool_t RooListProxy::addOwned(RooAbsArg& var, Bool_t silent)
 {
+  checkValid();
   Bool_t ret=RooArgList::addOwned(var,silent) ;
   if (ret) {
     _owner->addServer((RooAbsArg&)var,_defValueServer,_defShapeServer) ;
@@ -235,5 +239,13 @@ void RooListProxy::print(ostream& os, Bool_t addContents) const
       arg->printStream(os,kValue|kName,kInline) ;
     }
     os << ")" ;
+  }
+}
+
+
+void RooListProxy::checkValid() const {
+  if(!_owner) {
+    throw std::runtime_error("Attempt to add elements to a RooListProxy without owner!"
+            " Please avoid using the RooListProxy default constructor, which should only be used by IO.");
   }
 }

--- a/roofit/roofitcore/src/RooSetProxy.cxx
+++ b/roofit/roofitcore/src/RooSetProxy.cxx
@@ -38,6 +38,8 @@ the serverRedirect changes.
 #include "RooArgSet.h"
 #include "RooAbsArg.h"
 
+#include <exception>
+
 using namespace std;
 
 ClassImp(RooSetProxy);
@@ -116,6 +118,7 @@ RooSetProxy::~RooSetProxy()
 
 Bool_t RooSetProxy::add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeServer, Bool_t silent)
 {
+  checkValid();
   Bool_t ret=RooArgSet::add(var,silent) ;
   if (ret) {
     _owner->addServer((RooAbsArg&)var,valueServer,shapeServer) ;
@@ -132,6 +135,7 @@ Bool_t RooSetProxy::add(const RooAbsArg& var, Bool_t valueServer, Bool_t shapeSe
 
 Bool_t RooSetProxy::addOwned(RooAbsArg& var, Bool_t silent)
 {
+  checkValid();
   Bool_t ret=RooArgSet::addOwned(var,silent) ;
   if (ret) {
     _owner->addServer((RooAbsArg&)var,_defValueServer,_defShapeServer) ;
@@ -148,6 +152,7 @@ Bool_t RooSetProxy::addOwned(RooAbsArg& var, Bool_t silent)
 
 RooAbsArg* RooSetProxy::addClone(const RooAbsArg& var, Bool_t silent)
 {
+  checkValid();
   RooAbsArg* ret=RooArgSet::addClone(var,silent) ;
   if (ret) {
     _owner->addServer((RooAbsArg&)var,_defValueServer,_defShapeServer) ;
@@ -308,5 +313,13 @@ void RooSetProxy::print(ostream& os, Bool_t addContents) const
     }
     os << ")" ;
     delete iter ;
+  }
+}
+
+
+void RooSetProxy::checkValid() const {
+  if(!_owner) {
+    throw std::runtime_error("Attempt to add elements to a RooSetProxy without owner!"
+            " Please avoid using the RooListProxy default constructor, which should only be used by IO.");
   }
 }


### PR DESCRIPTION
A `RooListProxy` should always be constructed with the constructor that
takes the owner as an argument. The default constructor is only meant
for I/O, and any object created with it is invalid because a RooAbsProxy
is meaningless without an owner.

With this commit, the RooListProxy member functions of
RooLagrangianMorphFunc are correctly initialized. The commit also avoids
templated helper functions where the type should always be the same, and
adds some TODOs to suspicious parts of the RooLagrangianMorphFunc code
that were spotted when this commit was created.

FYI, @rahulgrit 

This bug was uncovered now because it caused a nullpointer dereferencing in another PR: https://github.com/root-project/root/pull/8728.

I also opened an issue with more **RooLagrangianMorphFunc** problems that I spotted while creating this PR: https://github.com/root-project/root/issues/9845