### PR TITLE
Fix copy/assign methods in TPolyLine3D and TPolyMarker3D

### DIFF
--- a/graf3d/g3d/inc/TPolyLine3D.h
+++ b/graf3d/g3d/inc/TPolyLine3D.h
@@ -32,10 +32,10 @@ class TList;
 class TPolyLine3D : public TObject, public TAttLine, public TAtt3D
 {
 protected:
-   Int_t        fN;            ///< Number of points
-   Float_t     *fP;            ///< [3*fN] Array of 3-D coordinates  (x,y,z)
-   TString      fOption;       ///< options
-   Int_t        fLastPoint;    ///< The index of the last filled point
+   Int_t        fN{0};             ///< Number of points
+   Float_t     *fP{nullptr};       ///< [3*fN] Array of 3-D coordinates  (x,y,z)
+   TString      fOption;           ///< options
+   Int_t        fLastPoint{-1};    ///< The index of the last filled point
 
 public:
    TPolyLine3D();
@@ -48,20 +48,20 @@ public:
    TPolyLine3D& operator=(const TPolyLine3D &polylin);
    virtual ~TPolyLine3D();
 
-   virtual void      Copy(TObject &polyline) const;
-   virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void      Draw(Option_t *option="");
+   void              Copy(TObject &polyline) const override;
+   Int_t             DistancetoPrimitive(Int_t px, Int_t py) override;
+   void              Draw(Option_t *option="") override;
    virtual void      DrawPolyLine(Int_t n, Float_t *p, Option_t *option="");
-   virtual void      ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void              ExecuteEvent(Int_t event, Int_t px, Int_t py)  override;
    Int_t             GetLastPoint() const {return fLastPoint;}
    Int_t             GetN() const {return fN;}
    Float_t          *GetP() const {return fP;}
-   Option_t         *GetOption() const {return fOption.Data();}
-   virtual void      ls(Option_t *option="") const;
+   Option_t         *GetOption() const  override { return fOption.Data(); }
+   void              ls(Option_t *option="") const  override;
    virtual Int_t     Merge(TCollection *list);
-   virtual void      Paint(Option_t *option="");
-   virtual void      Print(Option_t *option="") const;
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
+   void              Paint(Option_t *option="")  override;
+   void              Print(Option_t *option="") const  override;
+   void              SavePrimitive(std::ostream &out, Option_t *option = "")  override;
    virtual Int_t     SetNextPoint(Double_t x, Double_t y, Double_t z); // *MENU*
    virtual void      SetOption(Option_t *option="") {fOption = option;}
    virtual void      SetPoint(Int_t point, Double_t x, Double_t y, Double_t z); // *MENU*
@@ -72,7 +72,7 @@ public:
 
    static  void      DrawOutlineCube(TList *outline, Double_t *rmin, Double_t *rmax);
 
-   ClassDef(TPolyLine3D,1)  //A 3-D polyline
+   ClassDefOverride(TPolyLine3D,1)  //A 3-D polyline
 };
 
 #endif

--- a/graf3d/g3d/inc/TPolyMarker3D.h
+++ b/graf3d/g3d/inc/TPolyMarker3D.h
@@ -32,13 +32,11 @@ class TCollection;
 class TPolyMarker3D : public TObject, public TAttMarker, public TAtt3D
 {
 protected:
-   Int_t            fN;            //Number of allocated points
-   Float_t         *fP;            //[3*fN] Array of X,Y,Z coordinates
-   TString          fOption;       //Options
-   Int_t            fLastPoint;    //The index of the last filled point
-   TString          fName;         //Name of polymarker
-
-   TPolyMarker3D& operator=(const TPolyMarker3D&);
+   Int_t            fN{0};            //Number of allocated points
+   Float_t         *fP{nullptr};      //[3*fN] Array of X,Y,Z coordinates
+   TString          fOption;          //Options
+   Int_t            fLastPoint{-1};   //The index of the last filled point
+   TString          fName;            //Name of polymarker
 
 public:
    TPolyMarker3D();
@@ -46,25 +44,26 @@ public:
    TPolyMarker3D(Int_t n, Float_t *p, Marker_t marker=1, Option_t *option="");
    TPolyMarker3D(Int_t n, Double_t *p, Marker_t marker=1, Option_t *option="");
    TPolyMarker3D(const TPolyMarker3D &p);
+   TPolyMarker3D& operator=(const TPolyMarker3D&);
    virtual ~TPolyMarker3D();
 
-   virtual void      Copy(TObject &polymarker) const;
-   Int_t             DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void      Draw(Option_t *option="");
+   void              Copy(TObject &polymarker) const override;
+   Int_t             DistancetoPrimitive(Int_t px, Int_t py)  override;
+   void              Draw(Option_t *option="") override;
    virtual void      DrawPolyMarker(Int_t n, Float_t *p, Marker_t marker, Option_t *option="");
-   virtual void      ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void              ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Int_t     GetLastPoint() const { return fLastPoint;}
-   virtual const char  *GetName() const {return fName.Data();}
+   const char       *GetName() const override { return fName.Data(); }
    virtual Int_t     GetN() const { return fN;}
    virtual Float_t  *GetP() const { return fP;}
    virtual void      GetPoint(Int_t n, Float_t &x, Float_t &y, Float_t &z) const;
    virtual void      GetPoint(Int_t n, Double_t &x, Double_t &y, Double_t &z) const;
-   Option_t         *GetOption() const {return fOption.Data();}
-   virtual void      ls(Option_t *option="") const;
+   Option_t         *GetOption() const  override { return fOption.Data(); }
+   void              ls(Option_t *option="") const override;
    virtual Int_t     Merge(TCollection *list);
-   virtual void      Paint(Option_t *option="");
-   virtual void      Print(Option_t *option="") const;
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
+   void              Paint(Option_t *option="") override;
+   void              Print(Option_t *option="") const override;
+   void              SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void      SetName(const char *name); // *MENU*
    void              SetPoint(Int_t n, Double_t x, Double_t y, Double_t z); // *MENU*
    virtual void      SetPolyMarker(Int_t n, Float_t *p, Marker_t marker, Option_t *option="");
@@ -74,7 +73,7 @@ public:
 
    static  void      PaintH3(TH1 *h, Option_t *option);
 
-   ClassDef(TPolyMarker3D,3);  //An array of 3-D points with the same marker
+   ClassDefOverride(TPolyMarker3D,3);  //An array of 3-D points with the same marker
 };
 
 #endif

--- a/graf3d/g3d/src/TPolyLine3D.cxx
+++ b/graf3d/g3d/src/TPolyLine3D.cxx
@@ -230,15 +230,8 @@ TPolyLine3D::TPolyLine3D(Int_t n, Double_t const* x, Double_t const* y, Double_t
 
 TPolyLine3D& TPolyLine3D::operator=(const TPolyLine3D& pl)
 {
-   if(this!=&pl) {
-      TObject::operator=(pl);
-      TAttLine::operator=(pl);
-      TAtt3D::operator=(pl);
-      fN=pl.fN;
-      fP=pl.fP;
-      fOption=pl.fOption;
-      fLastPoint=pl.fLastPoint;
-   }
+   if(this != &pl)
+      pl.TPolyLine3D::Copy(*this);
    return *this;
 }
 
@@ -258,7 +251,7 @@ TPolyLine3D::TPolyLine3D(const TPolyLine3D &polyline) : TObject(polyline), TAttL
    fP         = 0;
    fLastPoint = 0;
    fN         = 0;
-   ((TPolyLine3D&)polyline).TPolyLine3D::Copy(*this);
+   polyline.TPolyLine3D::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -266,19 +259,21 @@ TPolyLine3D::TPolyLine3D(const TPolyLine3D &polyline) : TObject(polyline), TAttL
 
 void TPolyLine3D::Copy(TObject &obj) const
 {
+   auto &tgt = static_cast<TPolyLine3D &>(obj);
    TObject::Copy(obj);
-   TAttLine::Copy(((TPolyLine3D&)obj));
-   ((TPolyLine3D&)obj).fN = fN;
-   if (((TPolyLine3D&)obj).fP)
-      delete [] ((TPolyLine3D&)obj).fP;
+   TAttLine::Copy(tgt);
+   tgt.fN = fN;
+   if (tgt.fP)
+      delete [] tgt.fP;
    if (fN > 0) {
-      ((TPolyLine3D&)obj).fP = new Float_t[3*fN];
-      for (Int_t i=0; i<3*fN;i++)  {((TPolyLine3D&)obj).fP[i] = fP[i];}
+      tgt.fP = new Float_t[3*fN];
+      for (Int_t i=0; i<3*fN;i++)
+         tgt.fP[i] = fP[i];
    } else {
-      ((TPolyLine3D&)obj).fP = 0;
+      tgt.fP = nullptr;
    }
-   ((TPolyLine3D&)obj).fOption = fOption;
-   ((TPolyLine3D&)obj).fLastPoint = fLastPoint;
+   tgt.fOption = fOption;
+   tgt.fLastPoint = fLastPoint;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/TPolyLine3D.cxx
+++ b/graf3d/g3d/src/TPolyLine3D.cxx
@@ -99,9 +99,6 @@ option `L`.
 
 TPolyLine3D::TPolyLine3D()
 {
-   fN = 0;
-   fP = 0;
-   fLastPoint = -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -112,12 +109,8 @@ TPolyLine3D::TPolyLine3D(Int_t n, Option_t *option)
 {
    fOption = option;
    SetBit(kCanDelete);
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t[3*fN];
@@ -132,12 +125,8 @@ TPolyLine3D::TPolyLine3D(Int_t n, Float_t const* p, Option_t *option)
 {
    fOption = option;
    SetBit(kCanDelete);
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t[3*fN];
@@ -155,12 +144,8 @@ TPolyLine3D::TPolyLine3D(Int_t n, Double_t const* p, Option_t *option)
 {
    fOption = option;
    SetBit(kCanDelete);
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t[3*fN];
@@ -178,12 +163,8 @@ TPolyLine3D::TPolyLine3D(Int_t n, Float_t const* x, Float_t const* y, Float_t co
 {
    fOption = option;
    SetBit(kCanDelete);
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t[3*fN];
@@ -206,12 +187,8 @@ TPolyLine3D::TPolyLine3D(Int_t n, Double_t const* x, Double_t const* y, Double_t
 {
    fOption = option;
    SetBit(kCanDelete);
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t[3*fN];
@@ -248,9 +225,6 @@ TPolyLine3D::~TPolyLine3D()
 
 TPolyLine3D::TPolyLine3D(const TPolyLine3D &polyline) : TObject(polyline), TAttLine(polyline), TAtt3D(polyline)
 {
-   fP         = 0;
-   fLastPoint = 0;
-   fN         = 0;
    polyline.TPolyLine3D::Copy(*this);
 }
 
@@ -650,7 +624,7 @@ void TPolyLine3D::SetPolyLine(Int_t n, Option_t *option)
       fN = 0;
       fLastPoint = -1;
       delete [] fP;
-      fP = 0;
+      fP = nullptr;
       return;
    }
    fN = n;
@@ -671,7 +645,7 @@ void TPolyLine3D::SetPolyLine(Int_t n, Float_t *p, Option_t *option)
       fN = 0;
       fLastPoint = -1;
       delete [] fP;
-      fP = 0;
+      fP = nullptr;
       return;
    }
    fN = n;
@@ -700,7 +674,7 @@ void TPolyLine3D::SetPolyLine(Int_t n, Double_t *p, Option_t *option)
       fN = 0;
       fLastPoint = -1;
       delete [] fP;
-      fP = 0;
+      fP = nullptr;
       return;
    }
    fN = n;

--- a/graf3d/g3d/src/TPolyMarker3D.cxx
+++ b/graf3d/g3d/src/TPolyMarker3D.cxx
@@ -161,16 +161,8 @@ TPolyMarker3D::TPolyMarker3D(Int_t n, Double_t *p, Marker_t marker,
 
 TPolyMarker3D& TPolyMarker3D::operator=(const TPolyMarker3D& tp3)
 {
-   if(this!=&tp3) {
-      TObject::operator=(tp3);
-      TAttMarker::operator=(tp3);
-      TAtt3D::operator=(tp3);
-      fN=tp3.fN;
-      fP=tp3.fP;
-      fOption=tp3.fOption;
-      fLastPoint=tp3.fLastPoint;
-      fName=tp3.fName;
-   }
+   if(this != &tp3)
+      tp3.TPolyMarker3D::Copy(*this);
    return *this;
 }
 
@@ -193,7 +185,7 @@ TPolyMarker3D::TPolyMarker3D(const TPolyMarker3D &p) :
    fN = 0;
    fP = 0;
    fLastPoint = -1;
-   p.Copy(*this);
+   p.TPolyMarker3D::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,18 +193,22 @@ TPolyMarker3D::TPolyMarker3D(const TPolyMarker3D &p) :
 
 void TPolyMarker3D::Copy(TObject &obj) const
 {
+   auto &tgt = static_cast<TPolyMarker3D &>(obj);
    TObject::Copy(obj);
-   ((TPolyMarker3D&)obj).fN = fN;
+   TAttMarker::Copy(tgt);
+   tgt.fN = fN;
+   if (tgt.fP)
+      delete [] tgt.fP;
    if (fN > 0) {
-      ((TPolyMarker3D&)obj).fP = new Float_t [kDimension*fN];
-      for (Int_t i = 0; i < kDimension*fN; i++)  ((TPolyMarker3D&)obj).fP[i] = fP[i];
+      tgt.fP = new Float_t [kDimension*fN];
+      for (Int_t i = 0; i < kDimension*fN; i++)
+         tgt.fP[i] = fP[i];
    } else {
-      ((TPolyMarker3D&)obj).fP = 0;
+      tgt.fP = nullptr;
    }
-   ((TPolyMarker3D&)obj).SetMarkerStyle(GetMarkerStyle());
-   ((TPolyMarker3D&)obj).fOption = fOption;
-   ((TPolyMarker3D&)obj).fLastPoint = fLastPoint;
-   ((TPolyMarker3D&)obj).fName   = fName;
+   tgt.fOption = fOption;
+   tgt.fLastPoint = fLastPoint;
+   tgt.fName   = fName;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/TPolyMarker3D.cxx
+++ b/graf3d/g3d/src/TPolyMarker3D.cxx
@@ -74,9 +74,6 @@ Example:
 
 TPolyMarker3D::TPolyMarker3D()
 {
-   fN = 0;
-   fP = 0;
-   fLastPoint = -1;
    fName = "TPolyMarker3D";
 }
 
@@ -89,12 +86,8 @@ TPolyMarker3D::TPolyMarker3D(Int_t n, Marker_t marker, Option_t *option)
    fOption = option;
    SetMarkerStyle(marker);
    SetBit(kCanDelete);
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t [kDimension*fN];
@@ -111,12 +104,8 @@ TPolyMarker3D::TPolyMarker3D(Int_t n, Float_t *p, Marker_t marker,
    SetMarkerStyle(marker);
    SetBit(kCanDelete);
    fOption = option;
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t [kDimension*fN];
@@ -139,12 +128,8 @@ TPolyMarker3D::TPolyMarker3D(Int_t n, Double_t *p, Marker_t marker,
    SetMarkerStyle(marker);
    SetBit(kCanDelete);
    fOption = option;
-   fLastPoint = -1;
-   if (n <= 0) {
-      fN = 0;
-      fP = 0;
+   if (n <= 0)
       return;
-   }
 
    fN = n;
    fP = new Float_t [kDimension*fN];
@@ -179,12 +164,8 @@ TPolyMarker3D::~TPolyMarker3D()
 ////////////////////////////////////////////////////////////////////////////////
 /// 3-D polymarker copy ctor.
 
-TPolyMarker3D::TPolyMarker3D(const TPolyMarker3D &p) :
-   TObject(p), TAttMarker(p), TAtt3D(p)
+TPolyMarker3D::TPolyMarker3D(const TPolyMarker3D &p) : TObject(p), TAttMarker(p), TAtt3D(p)
 {
-   fN = 0;
-   fP = 0;
-   fLastPoint = -1;
    p.TPolyMarker3D::Copy(*this);
 }
 
@@ -584,7 +565,7 @@ void TPolyMarker3D::SetPolyMarker(Int_t n, Float_t *p, Marker_t marker, Option_t
       fN = 0;
       fLastPoint = -1;
       delete [] fP;
-      fP = 0;
+      fP = nullptr;
       return;
    }
    fN = n;
@@ -614,7 +595,7 @@ void TPolyMarker3D::SetPolyMarker(Int_t n, Double_t *p, Marker_t marker, Option_
       fN = 0;
       fLastPoint = -1;
       delete [] fP;
-      fP = 0;
+      fP = nullptr;
       return;
    }
    fN = n;


### PR DESCRIPTION
In both plain pointer was copied from source to target,
which should be deleted with objects destructor

Apply c++11 syntax, including override, nullptr, inline initializer

First commit (bug fix) can be applied to 6.26 branch