### PR TITLE
[win] Fix window position & add missing dependencies

### DIFF
--- a/graf2d/win32gdk/CMakeLists.txt
+++ b/graf2d/win32gdk/CMakeLists.txt
@@ -30,6 +30,10 @@ set(gdkdll   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/gdk-1.3.dll)
 set(gdkliba  ${CMAKE_CURRENT_BINARY_DIR}/gdk/src/gdk/gdk-1.3.lib)
 set(gdkdlla  ${CMAKE_CURRENT_BINARY_DIR}/gdk/src/gdk/gdk-1.3.dll)
 
+file(GLOB iconvfiles "gdk/src/iconv/*.*")
+file(GLOB_RECURSE glibfiles "gdk/src/glib/*.*")
+file(GLOB_RECURSE gdkfiles "gdk/src/gdk/*.*")
+
 if(winrtdebug)
   set(nmcxxflags "${CMAKE_CXX_FLAGS_DEBUG}" DEBUG=1)
 else()
@@ -46,13 +50,12 @@ add_custom_command( OUTPUT ${iconvliba} ${iconvdlla}
 					COMMAND echo "*** Building ${iconvliba}"
 					COMMAND ${CMAKE_COMMAND} -E chdir gdk/src/iconv
 							nmake -nologo -f makefile.msc NMCXXFLAGS=${nmcxxflags} VC_MAJOR=${VC_MAJOR}
-				  )
+					DEPENDS ${iconvfiles} ${glibfiles} ${gdkfiles} )
 
 add_custom_command( OUTPUT ${iconvlib} ${iconvdll}
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${iconvliba} ${iconvlib}
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${iconvdlla} ${iconvdll}
-					DEPENDS ${iconvliba} ${iconvdlla}
-				  )
+					DEPENDS ${iconvliba} ${iconvdlla} )
 
 add_custom_target(iconv DEPENDS ${iconvlib})
 set_target_properties(iconv PROPERTIES FOLDER Builtins)
@@ -63,8 +66,7 @@ add_custom_command( OUTPUT ${glibliba} ${glibdlla}
 					COMMAND echo "*** Building ${glibliba}"
 					COMMAND ${CMAKE_COMMAND} -E chdir gdk/src/glib
 							nmake -nologo -f makefile.msc NMCXXFLAGS=${nmcxxflags} VC_MAJOR=${VC_MAJOR}
-					DEPENDS iconv
-				  )
+					DEPENDS iconv ${glibfiles} )
 
 add_custom_command( OUTPUT ${gliblib} ${glibdll}
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${glibliba} ${gliblib}
@@ -82,8 +84,7 @@ add_custom_command( OUTPUT ${gdkliba}
 							nmake -nologo -f makefile.msc NMCXXFLAGS=${nmcxxflags} VC_MAJOR=${VC_MAJOR}
 					COMMAND ${CMAKE_COMMAND} -E chdir gdk/src/gdk
 							nmake -nologo -f makefile.msc NMCXXFLAGS=${nmcxxflags} VC_MAJOR=${VC_MAJOR}
-					DEPENDS glib
-				  )
+					DEPENDS glib ${gdkfiles} )
 
 add_custom_command( OUTPUT ${gdklib} ${gdkdll}
 					COMMAND ${CMAKE_COMMAND} -E copy_if_different ${gdkliba} ${gdklib}

--- a/graf2d/win32gdk/gdk/src/gdk/win32/gdkwindow-win32.c
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/gdkwindow-win32.c
@@ -46,6 +46,7 @@ BOOL
 SafeAdjustWindowRectEx(RECT * lpRect,
                        DWORD dwStyle, BOOL bMenu, DWORD dwExStyle)
 {
+   LONG top = lpRect->top;
    if (!AdjustWindowRectEx(lpRect, dwStyle, bMenu, dwExStyle)) {
       WIN32_API_FAILED("AdjustWindowRectEx");
       return FALSE;
@@ -55,11 +56,11 @@ SafeAdjustWindowRectEx(RECT * lpRect,
       lpRect->right -= lpRect->left;
       lpRect->left = 0;
    }
-   if (lpRect->top < 0) {
-      lpRect->bottom -= lpRect->top;
-      lpRect->top = 0;
-   }
 #endif
+   if (top > 0 && lpRect->top < 0) {
+      lpRect->bottom += top;
+      lpRect->top = top;
+   }
    return TRUE;
 }
 

--- a/graf2d/win32gdk/gdk/src/gdk/win32/makefile.msc
+++ b/graf2d/win32gdk/gdk/src/gdk/win32/makefile.msc
@@ -26,7 +26,7 @@ CC = cl -GR $(OPTIMIZE) -W3 -nologo
 CC = cl -nologo $(NMCXXFLAGS)
 !endif
 
-LDFLAGS = /link /machine:ix86 $(LINKDEBUG)
+LDFLAGS = /link $(LINKDEBUG)
 
 GLIB_VER=1.3
 GTK_VER=1.3


### PR DESCRIPTION
Make sure the y position of a window is not negative (hiding the title bar) and add missing dependencies on the `iconv`, `glib`, and `gdk` source code