### PR TITLE
[rootfit] fix compiler warnings in LikelihoodGradientWrapper.cxx (6.26)

### DIFF
--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientWrapper.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientWrapper.cxx
@@ -76,6 +76,10 @@ LikelihoodGradientWrapper::create(LikelihoodGradientMode likelihoodGradientMode,
       return std::make_unique<LikelihoodGradientJob>(std::move(likelihood), std::move(calculationIsClean), nDim,
                                                      minimizer);
 #else
+      (void) likelihood;
+      (void) calculationIsClean;
+      (void) nDim;
+      (void) minimizer;
       throw std::runtime_error("MinuitFcnGrad ctor with LikelihoodGradientMode::multiprocess is not available in this "
                                "build without RooFit::Multiprocess!");
 #endif


### PR DESCRIPTION
Blocks ROOT compilation with `-Ddev=ON`, 
Could be applied to master