### PR TITLE
[math] Remove unused variables to fix build warnings on `mac12arm`

### DIFF
--- a/math/mathcore/src/VectorizedTMath.cxx
+++ b/math/mathcore/src/VectorizedTMath.cxx
@@ -94,7 +94,7 @@ namespace TMath {
 
    ::ROOT::Double_v v = vecCore::math::Abs(x) / w2;
 
-   ::ROOT::Double_v ap, aq, h, hc, y, result;
+   ::ROOT::Double_v result;
 
    vecCore::Mask<::ROOT::Double_v> mask1 = v < ::ROOT::Double_v(0.5);
    vecCore::Mask<::ROOT::Double_v> mask2 = !mask1 && v < ::ROOT::Double_v(4.0);


### PR DESCRIPTION
Title says it all, the build warnings can be found here:
https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=mac12arm,SPEC=default,V=master/lastBuild/parsed_console/