### PR TITLE
[cling] Remove unused variables to fix build warnings on `mac11arm`

### DIFF
--- a/interpreter/cling/lib/Interpreter/Exception.cpp
+++ b/interpreter/cling/lib/Interpreter/Exception.cpp
@@ -32,8 +32,6 @@ CLING_LIB_EXPORT
 void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
                                                    const void* Arg) {
 
-  const clang::Expr* const E = (const clang::Expr*)Expr;
-
 #if defined(__APPLE__) && defined(__arm64__)
   // See https://github.com/root-project/root/issues/7541 and
   // https://bugs.llvm.org/show_bug.cgi?id=49692 :
@@ -42,6 +40,8 @@ void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
   (void)Interp;
   (void)Expr;
 #else
+  const clang::Expr* const E = (const clang::Expr*)Expr;
+
   // The isValidAddress function return true even when the pointer is
   // null thus the checks have to be done before returning successfully from the
   // function in this specific order.


### PR DESCRIPTION
Title says it all, the build warnings can be found here:
https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=mac11arm,SPEC=noimt,V=master/lastBuild/parsed_console/
