### PR TITLE
[6.24] PySpark MacOs fork issue

### DIFF
--- a/bindings/experimental/distrdf/test/backend/CMakeLists.txt
+++ b/bindings/experimental/distrdf/test/backend/CMakeLists.txt
@@ -20,7 +20,10 @@ ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_dist test_dist.py)
 
 # pyspark is required to run this test
 if(test_distrdf_pyspark)
-    ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_spark test_spark.py)
+    # Define environment variables needed in all pyspark tests
+    set(PYSPARK_ENV_VARS PYSPARK_PYTHON=${PYTHON_EXECUTABLE_Development_Main})
+
+    ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_spark test_spark.py ENVIRONMENT ${PYSPARK_ENV_VARS})
 endif()
 
 endif()

--- a/bindings/experimental/distrdf/test/backend/CMakeLists.txt
+++ b/bindings/experimental/distrdf/test/backend/CMakeLists.txt
@@ -23,6 +23,18 @@ if(test_distrdf_pyspark)
     # Define environment variables needed in all pyspark tests
     set(PYSPARK_ENV_VARS PYSPARK_PYTHON=${PYTHON_EXECUTABLE_Development_Main})
 
+    if(MACOSX_VERSION VERSION_GREATER_EQUAL 10.13)
+        # MacOS has changed rules about forking processes after 10.13
+        # Running pyspark tests with XCode Python3 throws crashes with errors like:
+        # `objc[17271]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.`
+        # This issue should have been fixed after Python 3.8 (see https://bugs.python.org/issue33725)
+        # Indeed, any other Python 3.8+ executable does not show this crash. It is
+        # specifically the XCode Python executable that triggers this.
+        # For now, there seems no other way than this workaround,
+        # which effectively sets the behaviour of `fork` back to MacOS 10.12
+        list(APPEND PYSPARK_ENV_VARS OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES)
+    endif()
+
     ROOT_ADD_PYUNITTEST(distrdf_unit_backend_test_spark test_spark.py ENVIRONMENT ${PYSPARK_ENV_VARS})
 endif()
 

--- a/bindings/experimental/distrdf/test/backend/test_spark.py
+++ b/bindings/experimental/distrdf/test/backend/test_spark.py
@@ -15,26 +15,9 @@ class SparkBackendInitTest(unittest.TestCase):
     input `config` dict.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_set_spark_context_default(self):
         """
@@ -79,26 +62,9 @@ class OperationSupportTest(unittest.TestCase):
     environment.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_action(self):
         """Check that action nodes are classified accurately."""
@@ -141,26 +107,9 @@ class OperationSupportTest(unittest.TestCase):
 class InitializationTest(unittest.TestCase):
     """Check initialization method in the Spark backend"""
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_initialization(self):
         """
@@ -216,26 +165,9 @@ class EmptyTreeErrorTest(unittest.TestCase):
     Distributed execution fails when the tree has no entries.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_histo_from_empty_root_file(self):
         """
@@ -256,26 +188,9 @@ class EmptyTreeErrorTest(unittest.TestCase):
 class ChangeAttributeTest(unittest.TestCase):
     """Tests that check correct changes in the class attributes"""
 
-    @classmethod
-    def setUpClass(cls):
-        """
-        Synchronize PYSPARK_PYTHON variable to the current Python executable.
-
-        Needed to avoid mismatch between python versions on driver and on
-        the fake executor on the same machine.
-        """
-        os.environ["PYSPARK_PYTHON"] = sys.executable
-
     def tearDown(self):
         """Stop any created SparkContext"""
         pyspark.SparkContext.getOrCreate().stop()
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Stop the SparkContext and reset environment variable.
-        """
-        os.environ["PYSPARK_PYTHON"] = ""
 
     def test_change_attribute_when_npartitions_greater_than_clusters(self):
         """

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -590,6 +590,17 @@ if(ROOT_pyroot_FOUND)
   # Use main Python executable to run in PySpark driver and executors
   if(test_distrdf_pyspark)
     list(APPEND ROOT_environ PYSPARK_PYTHON=${PYTHON_EXECUTABLE_Development_Main})
+    if(MACOSX_VERSION VERSION_GREATER_EQUAL 10.13)
+      # MacOS has changed rules about forking processes after 10.13
+      # Running pyspark tests with XCode Python3 throws crashes with errors like:
+      # `objc[17271]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.`
+      # This issue should have been fixed after Python 3.8 (see https://bugs.python.org/issue33725)
+      # Indeed, any other Python 3.8+ executable does not show this crash. It is
+      # specifically the XCode Python executable that triggers this.
+      # For now, there seems no other way than this workaround,
+      # which effectively sets the behaviour of `fork` back to MacOS 10.12
+      list(APPEND ROOT_environ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES)
+    endif()
   endif()
 
   find_python_module(xgboost QUIET)


### PR DESCRIPTION
Logical backport of https://github.com/root-project/root/pull/9811 but adjusted to the status of the tests in 6.24