### PR TITLE
[hist] Add missing `override` specifiers in Hist

### DIFF
--- a/hist/hbook/inc/THbookBranch.h
+++ b/hist/hbook/inc/THbookBranch.h
@@ -32,15 +32,15 @@ public:
    THbookBranch() {;}
    THbookBranch(TTree *tree, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit);
    THbookBranch(TBranch *branch, const char *name, void *address, const char *leaflist, Int_t basketsize=32000, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit);
-   virtual ~THbookBranch();
-   virtual void     Browse(TBrowser *b);
-   virtual Int_t    GetEntry(Long64_t entry=0, Int_t getall=0);
+   ~THbookBranch() override;
+   void     Browse(TBrowser *b) override;
+   Int_t    GetEntry(Long64_t entry=0, Int_t getall=0) override;
    const char      *GetBlockName() const {return fBlockName.Data();}
-   virtual void     SetAddress(void *addobj);
+   void     SetAddress(void *addobj) override;
            void     SetBlockName(const char *name) {fBlockName=name;}
-   virtual void     SetEntries(Long64_t n) {fEntries=n;}
+   void     SetEntries(Long64_t n) override {fEntries=n;}
 
-   ClassDef(THbookBranch,1)  //A branch for a THbookTree
+   ClassDefOverride(THbookBranch,1)  //A branch for a THbookTree
 };
 
 #endif

--- a/hist/hbook/inc/THbookFile.h
+++ b/hist/hbook/inc/THbookFile.h
@@ -42,8 +42,8 @@ public:
 
    THbookFile();
    THbookFile(const char *fname, Int_t lrecl=1024);
-   virtual ~THbookFile();
-   virtual void      Browse(TBrowser *b);
+   ~THbookFile() override;
+   void      Browse(TBrowser *b) override;
    virtual Bool_t    cd(const char *dirname="");
    virtual void      Close(Option_t *option="");
    virtual TFile    *Convert2root(const char *rootname="", Int_t lrecl=0, Option_t *option=""); // *MENU*
@@ -53,8 +53,8 @@ public:
    virtual TObject  *Convert1D(Int_t id);
    virtual TObject  *Convert2D(Int_t id);
            void      DeleteID(Int_t id);
-   virtual TObject  *FindObject(const char *name) const;
-   virtual TObject  *FindObject(const TObject *obj) const;
+   TObject  *FindObject(const char *name) const override;
+   TObject  *FindObject(const TObject *obj) const override;
    TObject          *Get(Int_t id);
    const char       *GetCurDir() const {return fCurDir.Data();}
    Int_t             GetEntry(Int_t entry,Int_t id, Int_t atype, Float_t *x);
@@ -63,12 +63,12 @@ public:
    TList            *GetList() const {return fList;}
    TList            *GetListOfKeys() const { return fKeys; }
    void              InitLeaves(Int_t id, Int_t var, TTreeFormula *formula);
-   Bool_t            IsFolder() const { return kTRUE; }
+   Bool_t            IsFolder() const override { return kTRUE; }
    virtual Bool_t    IsOpen() const;
-   virtual void      ls(const char *path="") const;
+   void      ls(const char *path="") const override;
    virtual void      SetBranchAddress(Int_t id, const char *bname, void *add);
 
-   ClassDef(THbookFile,1)  //ROOT interface to Hbook/PAW files
+   ClassDefOverride(THbookFile,1)  //ROOT interface to Hbook/PAW files
 };
 
 #endif

--- a/hist/hbook/inc/THbookKey.h
+++ b/hist/hbook/inc/THbookKey.h
@@ -32,11 +32,11 @@ protected:
 public:
    THbookKey() : fDirectory(0),fID(0) {;}
    THbookKey(Int_t id, THbookFile *file);
-   virtual ~THbookKey();
-   virtual void      Browse(TBrowser *b);
-   Bool_t            IsFolder() const;
+   ~THbookKey() override;
+   void      Browse(TBrowser *b) override;
+   Bool_t            IsFolder() const override;
 
-   ClassDef(THbookKey,1)  //Hbook id descriptor
+   ClassDefOverride(THbookKey,1)  //Hbook id descriptor
 };
 
 #endif

--- a/hist/hbook/inc/THbookTree.h
+++ b/hist/hbook/inc/THbookTree.h
@@ -39,20 +39,20 @@ protected:
 public:
    THbookTree();
    THbookTree(const char *name, Int_t id);
-   virtual ~THbookTree();
-   virtual Int_t     GetEntry(Long64_t entry=0, Int_t getall=0);
+   ~THbookTree() override;
+   Int_t     GetEntry(Long64_t entry=0, Int_t getall=0) override;
    THbookFile       *GetHbookFile() {return fFile;}
    virtual Int_t     GetID() {return fID;}
    virtual Int_t     GetType() {return fType;}
            Float_t  *GetX() {return (Float_t*)fX;}
    virtual void      InitBranches(Long64_t entry);
            char     *MakeX(Int_t nvars) {fX = new char[nvars]; return fX;}
-   virtual void      Print(Option_t *option="") const;
-   virtual Long64_t  SetEntries(Long64_t n=-1);
+   void      Print(Option_t *option="") const override;
+   Long64_t  SetEntries(Long64_t n=-1) override;
    virtual void      SetHbookFile(THbookFile *file) {fFile = file;}
    virtual void      SetType(Int_t atype) {fType = atype;}
 
-   ClassDef(THbookTree,1)  //A wrapper class supporting Hbook ntuples (CWN and RWN)
+   ClassDefOverride(THbookTree,1)  //A wrapper class supporting Hbook ntuples (CWN and RWN)
 };
 
 #endif

--- a/hist/hist/inc/Math/WrappedMultiTF1.h
+++ b/hist/hist/inc/Math/WrappedMultiTF1.h
@@ -62,7 +62,7 @@ namespace ROOT {
          /**
             Destructor (no operations). Function pointer is not owned
          */
-         ~WrappedMultiTF1Templ()
+         ~WrappedMultiTF1Templ() override
          {
             if (fOwnFunc && fFunc) delete fFunc;
          }
@@ -82,7 +82,7 @@ namespace ROOT {
          /**
              Clone the wrapper but not the original function
          */
-         IMultiGenFunctionTempl<T> *Clone() const
+         IMultiGenFunctionTempl<T> *Clone() const override
          {
             return new WrappedMultiTF1Templ<T>(*this);
          }
@@ -90,39 +90,39 @@ namespace ROOT {
          /**
               Retrieve the dimension of the function
           */
-         unsigned int NDim() const
+         unsigned int NDim() const override
          {
             return fDim;
          }
 
          /// get the parameter values (return values from TF1)
-         const double *Parameters() const
+         const double *Parameters() const override
          {
             //return  (fParams.size() > 0) ? &fParams.front() : 0;
             return  fFunc->GetParameters();
          }
 
          /// set parameter values (only the cached one in this class,leave unchanges those of TF1)
-         void SetParameters(const double *p)
+         void SetParameters(const double *p) override
          {
             //std::copy(p,p+fParams.size(),fParams.begin());
             fFunc->SetParameters(p);
          }
 
          /// return number of parameters
-         unsigned int NPar() const
+         unsigned int NPar() const override
          {
             // return fParams.size();
             return fFunc->GetNpar();
          }
 
          /// return parameter name (from TF1)
-         std::string ParameterName(unsigned int i) const {
+         std::string ParameterName(unsigned int i) const override {
             return std::string(fFunc->GetParName(i));
          }
 
          // evaluate the derivative of the function with respect to the parameters
-         void ParameterGradient(const T *x, const double *par, T *grad) const;
+         void ParameterGradient(const T *x, const double *par, T *grad) const override;
 
          /// precision value used for calculating the derivative step-size
          /// h = eps * |x|. The default is 0.001, give a smaller in case function changes rapidly
@@ -143,7 +143,7 @@ namespace ROOT {
 
       private:
          /// evaluate function passing coordinates x and vector of parameters
-         T DoEvalPar(const T *x, const double *p) const
+         T DoEvalPar(const T *x, const double *p) const override
          {
             return fFunc->EvalPar(x, p);
          }
@@ -157,7 +157,7 @@ namespace ROOT {
 
          /// evaluate function using the cached parameter values (of TF1)
          /// re-implement for better efficiency
-         T DoEval(const T *x) const
+         T DoEval(const T *x) const override
          {
             // no need to call InitArg for interpreted functions (done in ctor)
 
@@ -166,7 +166,7 @@ namespace ROOT {
          }
 
          /// evaluate the partial derivative with respect to the parameter
-         T DoParameterDerivative(const T *x, const double *p, unsigned int ipar) const;
+         T DoParameterDerivative(const T *x, const double *p, unsigned int ipar) const override;
 
          bool fLinear;                 // flag for linear functions
          bool fPolynomial;             // flag for polynomial functions

--- a/hist/hist/inc/Math/WrappedTF1.h
+++ b/hist/hist/inc/Math/WrappedTF1.h
@@ -53,7 +53,7 @@ namespace ROOT {
          /**
             Destructor (no operations). TF1 Function pointer is not owned
          */
-         virtual ~WrappedTF1() {}
+         ~WrappedTF1() override {}
 
          /**
             Copy constructor
@@ -70,7 +70,7 @@ namespace ROOT {
          /**
              Clone the wrapper but not the original function
          */
-         ROOT::Math::IGenFunction *Clone() const
+         ROOT::Math::IGenFunction *Clone() const override
          {
             return  new WrappedTF1(*this);
          }
@@ -79,7 +79,7 @@ namespace ROOT {
          /** @name interface inherited from IParamFunction */
 
          /// get the parameter values (return values cachen inside, those inside TF1 might be different)
-         const double *Parameters() const
+         const double *Parameters() const override
          {
             //return  (fParams.size() > 0) ? &fParams.front() : 0;
             return fFunc->GetParameters();
@@ -87,21 +87,21 @@ namespace ROOT {
 
          /// set parameter values
          /// need to call also SetParameters in TF1 in ace some other operations (re-normalizations) are needed
-         void SetParameters(const double *p)
+         void SetParameters(const double *p) override
          {
             //std::copy(p,p+fParams.size(),fParams.begin());
             fFunc->SetParameters(p);
          }
 
          /// return number of parameters
-         unsigned int NPar() const
+         unsigned int NPar() const override
          {
             //return fParams.size();
             return fFunc->GetNpar();
          }
 
          /// return parameter name (this is stored in TF1)
-         std::string ParameterName(unsigned int i) const
+         std::string ParameterName(unsigned int i) const override
          {
             return std::string(fFunc->GetParName(i));
          }
@@ -110,10 +110,10 @@ namespace ROOT {
          using BaseGradFunc::operator();
 
          /// evaluate the derivative of the function with respect to the parameters
-         void  ParameterGradient(double x, const double *par, double *grad) const;
+         void  ParameterGradient(double x, const double *par, double *grad) const override;
 
          /// calculate function and derivative at same time (required by IGradient interface)
-         void FdF(double x, double &f, double &deriv) const
+         void FdF(double x, double &f, double &deriv) const override
          {
             f = DoEval(x);
             deriv = DoDerivative(x);
@@ -130,7 +130,7 @@ namespace ROOT {
 
 
          /// evaluate function passing coordinates x and vector of parameters
-         double DoEvalPar(double x, const double *p) const
+         double DoEvalPar(double x, const double *p) const override
          {
             fX[0] = x;
             if (fFunc->GetMethodCall()) fFunc->InitArgs(fX, p);  // needed for interpreted functions
@@ -139,7 +139,7 @@ namespace ROOT {
 
          /// evaluate function using the cached parameter values (of TF1)
          /// re-implement for better efficiency
-         double DoEval(double x) const
+         double DoEval(double x) const override
          {
             // no need to call InitArg for interpreted functions (done in ctor)
             // use EvalPar since it is much more efficient than Eval
@@ -149,10 +149,10 @@ namespace ROOT {
          }
 
          /// return the function derivatives w.r.t. x
-         double DoDerivative(double  x) const;
+         double DoDerivative(double  x) const override;
 
          /// evaluate the derivative of the function with respect to the parameters
-         double  DoParameterDerivative(double x, const double *p, unsigned int ipar) const;
+         double  DoParameterDerivative(double x, const double *p, unsigned int ipar) const override;
 
          bool fLinear;                 // flag for linear functions
          bool fPolynomial;             // flag for polynomial functions

--- a/hist/hist/inc/TAxis.h
+++ b/hist/hist/inc/TAxis.h
@@ -76,7 +76,7 @@ public:
    TAxis(Int_t nbins, Double_t xmin, Double_t xmax);
    TAxis(Int_t nbins, const Double_t *xbins);
    TAxis(const TAxis &axis);
-   virtual ~TAxis();
+   ~TAxis() override;
    TAxis& operator=(const TAxis&);
 
    Bool_t     CanExtend() const { return (fBits2 & kCanExtend);  }
@@ -94,11 +94,11 @@ public:
    void               CenterLabels(Bool_t center=kTRUE);
    void               CenterTitle(Bool_t center=kTRUE);
    const char        *ChooseTimeFormat(Double_t axislength=0);
-   virtual void       Copy(TObject &axis) const;
-   virtual void       Delete(Option_t * /*option*/ ="") { }
-   virtual Int_t      DistancetoPrimitive(Int_t px, Int_t py);
-   virtual TObject   *DrawClone(Option_t * /*option*/ ="") const {return 0;}
-   virtual void       ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void       Copy(TObject &axis) const override;
+   void       Delete(Option_t * /*option*/ ="") override { }
+   Int_t      DistancetoPrimitive(Int_t px, Int_t py) override;
+   TObject   *DrawClone(Option_t * /*option*/ ="") const override {return 0;}
+   void       ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Int_t      FindBin(Double_t x);
    virtual Int_t      FindBin(Double_t x) const { return FindFixBin(x); }
    virtual Int_t      FindBin(const char *label);
@@ -126,7 +126,7 @@ public:
    virtual Bool_t     GetTimeDisplay() const {return fTimeDisplay;}
    virtual const char *GetTimeFormat() const {return fTimeFormat.Data();}
    virtual const char *GetTimeFormatOnly() const;
-   const char        *GetTitle() const {return fTitle.Data();}
+   const char        *GetTitle() const override {return fTitle.Data();}
    const TArrayD     *GetXbins() const {return &fXbins;}
            Int_t      GetFirst() const;
            Int_t      GetLast() const;
@@ -139,14 +139,14 @@ public:
                       }
    virtual void       LabelsOption(Option_t *option="h");  // *MENU*
            void       RotateTitle(Bool_t rotate=kTRUE); // *TOGGLE* *GETTER=GetRotateTitle
-   virtual void       SaveAttributes(std::ostream &out, const char *name, const char *subname);
+   void       SaveAttributes(std::ostream &out, const char *name, const char *subname) override;
    virtual void       Set(Int_t nbins, Double_t xmin, Double_t xmax);
    virtual void       Set(Int_t nbins, const Float_t *xbins);
    virtual void       Set(Int_t nbins, const Double_t *xbins);
    virtual void       SetBinLabel(Int_t bin, const char *label);
            void       SetDecimals(Bool_t dot = kTRUE); // *TOGGLE* *GETTER=GetDecimals
    virtual void       SetDefaults();
-   virtual void       SetDrawOption(Option_t * /*option*/ ="") { }
+   void       SetDrawOption(Option_t * /*option*/ ="") override { }
    void               ChangeLabel(Int_t labNum=0, Double_t labAngle = -1.,
                                   Double_t labSize = -1., Int_t labAlign = -1,
                                   Int_t labColor = -1 , Int_t labFont = -1,
@@ -164,7 +164,7 @@ public:
    virtual void       UnZoom();  // *MENU*
    virtual void       ZoomOut(Double_t factor=0, Double_t offset=0);  // *MENU*
 
-   ClassDef(TAxis,10)  //Axis class
+   ClassDefOverride(TAxis,10)  //Axis class
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/inc/TAxisModLab.h
+++ b/hist/hist/inc/TAxisModLab.h
@@ -45,7 +45,7 @@ public:
    Int_t    GetFont()   {return fTextFont;}
    TString  GetText()   {return fLabText;}
 
-   ClassDef(TAxisModLab,3)  // Modified axis label
+   ClassDefOverride(TAxisModLab,3)  // Modified axis label
 };
 
 #endif

--- a/hist/hist/inc/TBackCompFitter.h
+++ b/hist/hist/inc/TBackCompFitter.h
@@ -45,7 +45,7 @@ public:
    //TBackCompFitter(ROOT::Fit::Fitter & fitter, ROOT::Fit::FitData * );
    TBackCompFitter( const std::shared_ptr<ROOT::Fit::Fitter> & fitter, const std::shared_ptr<ROOT::Fit::FitData> & data  );
 
-   virtual ~TBackCompFitter();
+   ~TBackCompFitter() override;
 
 public:
 
@@ -54,35 +54,35 @@ public:
    };
 
    // inherited interface
-   virtual Double_t  Chisquare(Int_t npar, Double_t *params) const;
-   virtual void      Clear(Option_t *option="");
-   virtual Int_t     ExecuteCommand(const char *command, Double_t *args, Int_t nargs);
-   virtual void      FixParameter(Int_t ipar);
+   Double_t  Chisquare(Int_t npar, Double_t *params) const override;
+   void      Clear(Option_t *option="") override;
+   Int_t     ExecuteCommand(const char *command, Double_t *args, Int_t nargs) override;
+   void      FixParameter(Int_t ipar) override;
 
-   virtual void      GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95);
-   virtual void      GetConfidenceIntervals(TObject *obj, Double_t cl=0.95);
+   void      GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95) override;
+   void      GetConfidenceIntervals(TObject *obj, Double_t cl=0.95) override;
 
-   virtual Double_t *GetCovarianceMatrix() const;
-   virtual Double_t  GetCovarianceMatrixElement(Int_t i, Int_t j) const;
-   virtual Int_t     GetErrors(Int_t ipar,Double_t &eplus, Double_t &eminus, Double_t &eparab, Double_t &globcc) const;
-   virtual Int_t     GetNumberTotalParameters() const;
-   virtual Int_t     GetNumberFreeParameters() const;
+   Double_t *GetCovarianceMatrix() const override;
+   Double_t  GetCovarianceMatrixElement(Int_t i, Int_t j) const override;
+   Int_t     GetErrors(Int_t ipar,Double_t &eplus, Double_t &eminus, Double_t &eparab, Double_t &globcc) const override;
+   Int_t     GetNumberTotalParameters() const override;
+   Int_t     GetNumberFreeParameters() const override;
 
-   virtual Double_t  GetParError(Int_t ipar) const;
-   virtual Double_t  GetParameter(Int_t ipar) const;
-   virtual Int_t     GetParameter(Int_t ipar,char *name,Double_t &value,Double_t &verr,Double_t &vlow, Double_t &vhigh) const;
-   virtual const char *GetParName(Int_t ipar) const;
-   virtual Int_t     GetStats(Double_t &amin, Double_t &edm, Double_t &errdef, Int_t &nvpar, Int_t &nparx) const;
-   virtual Double_t  GetSumLog(Int_t i);
+   Double_t  GetParError(Int_t ipar) const override;
+   Double_t  GetParameter(Int_t ipar) const override;
+   Int_t     GetParameter(Int_t ipar,char *name,Double_t &value,Double_t &verr,Double_t &vlow, Double_t &vhigh) const override;
+   const char *GetParName(Int_t ipar) const override;
+   Int_t     GetStats(Double_t &amin, Double_t &edm, Double_t &errdef, Int_t &nvpar, Int_t &nparx) const override;
+   Double_t  GetSumLog(Int_t i) override;
 
-   virtual Bool_t    IsFixed(Int_t ipar) const ;
+   Bool_t    IsFixed(Int_t ipar) const override ;
 
-   virtual void      PrintResults(Int_t level, Double_t amin) const;
-   virtual void      ReleaseParameter(Int_t ipar);
-   virtual void      SetFitMethod(const char *name);
-   virtual Int_t     SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh);
+   void      PrintResults(Int_t level, Double_t amin) const override;
+   void      ReleaseParameter(Int_t ipar) override;
+   void      SetFitMethod(const char *name) override;
+   Int_t     SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh) override;
 
-   virtual void      SetFCN(void (*fcn)(Int_t &, Double_t *, Double_t &f, Double_t *, Int_t) );
+   void      SetFCN(void (*fcn)(Int_t &, Double_t *, Double_t &f, Double_t *, Int_t) ) override;
 
    /// For using interpreted function passed by the user
    virtual void SetMethodCall(TMethodCall * m) { fMethodCall = m; }
@@ -140,7 +140,7 @@ private:
 
 
 
-   ClassDef(TBackCompFitter,1)  // Class providing backward compatibility for fitting by implementing the TVirtualFitter interface
+   ClassDefOverride(TBackCompFitter,1)  // Class providing backward compatibility for fitting by implementing the TVirtualFitter interface
 
 };
 

--- a/hist/hist/inc/TBinomialEfficiencyFitter.h
+++ b/hist/hist/inc/TBinomialEfficiencyFitter.h
@@ -58,7 +58,7 @@ private:
 public:
    TBinomialEfficiencyFitter();
    TBinomialEfficiencyFitter(const TH1 *numerator, const TH1 *denominator);
-   virtual ~TBinomialEfficiencyFitter();
+   ~TBinomialEfficiencyFitter() override;
 
    void   Set(const TH1 *numerator, const TH1 *denominator);
    void   SetPrecision(Double_t epsilon);
@@ -70,7 +70,7 @@ public:
       return f;
    }
 
-   ClassDef(TBinomialEfficiencyFitter, 1) //Binomial Fitter for the division of two histograms
+   ClassDefOverride(TBinomialEfficiencyFitter, 1) //Binomial Fitter for the division of two histograms
 
 
 };

--- a/hist/hist/inc/TConfidenceLevel.h
+++ b/hist/hist/inc/TConfidenceLevel.h
@@ -21,7 +21,7 @@ class TConfidenceLevel : public TObject {
  public:
    TConfidenceLevel();
    TConfidenceLevel(Int_t mc, bool onesided = kTRUE);
-   virtual ~TConfidenceLevel();
+   ~TConfidenceLevel() override;
    inline void SetTSD(Double_t in) { fTSD = in; }
    void SetTSB(Double_t * in);
    void SetTSS(Double_t * in);
@@ -31,7 +31,7 @@ class TConfidenceLevel : public TObject {
    inline void SetStot(Double_t in) { fStot = in; }
    inline void SetDtot(Int_t in) { fDtot = in; }
    inline Double_t GetStatistic() const { return -2 * (fTSD - fStot); }
-   void Draw(const Option_t *option="");
+   void Draw(const Option_t *option="") override;
    Double_t GetExpectedStatistic_b(Int_t sigma = 0) const;
    Double_t GetExpectedStatistic_sb(Int_t sigma = 0) const;
    Double_t CLb(bool use_sMC = kFALSE) const;
@@ -74,7 +74,7 @@ class TConfidenceLevel : public TObject {
    static const Double_t fgMCL5S1S;
    static const Double_t fgMCL3S2S;
    static const Double_t fgMCL5S2S;
-   ClassDef(TConfidenceLevel, 1) // output for TLimit functions
+   ClassDefOverride(TConfidenceLevel, 1) // output for TLimit functions
 };
 
 #endif

--- a/hist/hist/inc/TEfficiency.h
+++ b/hist/hist/inc/TEfficiency.h
@@ -89,15 +89,15 @@ public:
                   const Double_t* xbins,Int_t nbinsy,const Double_t* ybins,
                   Int_t nbinsz,const Double_t* zbins);
       TEfficiency(const TEfficiency& heff);
-      ~TEfficiency();
+      ~TEfficiency() override;
 
       void          Add(const TEfficiency& rEff) {*this += rEff;}
-      void          Browse(TBrowser*){Draw();}
+      void          Browse(TBrowser*) override{Draw();}
       TGraphAsymmErrors*   CreateGraph(Option_t * opt = "") const;
       TH2*          CreateHistogram(Option_t * opt = "") const;
-      virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
-      void          Draw(Option_t* opt = "");
-      virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
+      Int_t DistancetoPrimitive(Int_t px, Int_t py) override;
+      void          Draw(Option_t* opt = "") override;
+      void  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
       void          Fill(Bool_t bPassed,Double_t x,Double_t y=0,Double_t z=0);
       void          FillWeighted(Bool_t bPassed,Double_t weight,Double_t x,Double_t y=0,Double_t z=0);
       Int_t         FindFixBin(Double_t x,Double_t y=0,Double_t z=0) const;
@@ -124,14 +124,14 @@ public:
       Long64_t      Merge(TCollection* list);
       TEfficiency&  operator+=(const TEfficiency& rhs);
       TEfficiency&  operator=(const TEfficiency& rhs);
-      void          Paint(Option_t* opt);
-      void          SavePrimitive(std::ostream& out,Option_t* opt="");
+      void          Paint(Option_t* opt) override;
+      void          SavePrimitive(std::ostream& out,Option_t* opt="") override;
       void          SetBetaAlpha(Double_t alpha);
       void          SetBetaBeta(Double_t beta);
       void          SetBetaBinParameters(Int_t bin, Double_t alpha, Double_t beta);
       void          SetConfidenceLevel(Double_t level);
       void          SetDirectory(TDirectory* dir);
-      void          SetName(const char* name);
+      void          SetName(const char* name) override;
       Bool_t        SetPassedEvents(Int_t bin,Int_t events);
       Bool_t        SetPassedHistogram(const TH1& rPassed,Option_t* opt);
       void          SetPosteriorMode(Bool_t on = true) { SetBit(kPosteriorMode,on); SetShortestInterval(on); }
@@ -148,7 +148,7 @@ public:
       Bool_t        SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t * yBins, Int_t nz,
                             const Double_t *zBins);
 
-      void          SetTitle(const char* title);
+      void          SetTitle(const char* title) override;
       Bool_t        SetTotalEvents(Int_t bin,Int_t events);
       Bool_t        SetTotalHistogram(const TH1& rTotal,Option_t* opt);
       void          SetUseWeightedEvents(Bool_t on = kTRUE);
@@ -185,7 +185,7 @@ public:
       static Double_t BetaMean(Double_t alpha,Double_t beta);
       static Double_t BetaMode(Double_t alpha,Double_t beta);
 
-      ClassDef(TEfficiency,2)     //calculating efficiencies
+      ClassDefOverride(TEfficiency,2)     //calculating efficiencies
 };
 
 const TEfficiency operator+(const TEfficiency& lhs,const TEfficiency& rhs);

--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -293,8 +293,8 @@ protected:
    struct TF1FunctorPointerImpl: TF1FunctorPointer {
       TF1FunctorPointerImpl(const ROOT::Math::ParamFunctorTempl<T> &func): fImpl(func) {};
       TF1FunctorPointerImpl(const std::function<T(const T *f, const Double_t *param)> &func) : fImpl(func){};
-      virtual ~TF1FunctorPointerImpl() {}
-      virtual  TF1FunctorPointer * Clone() const { return new TF1FunctorPointerImpl<T>(fImpl); }
+      ~TF1FunctorPointerImpl() override {}
+       TF1FunctorPointer * Clone() const override { return new TF1FunctorPointerImpl<T>(fImpl); }
       ROOT::Math::ParamFunctorTempl<T> fImpl;
    };
 
@@ -411,7 +411,7 @@ public:
 
    TF1(const TF1 &f1);
    TF1 &operator=(const TF1 &rhs);
-   virtual   ~TF1();
+     ~TF1() override;
    virtual void     AddParameter(const TString &name, Double_t value)
    {
       if (fFormula) fFormula->AddParameter(name, value);
@@ -421,15 +421,15 @@ public:
    // virtual void     AddVariables(const TString *vars, Int_t size) { if (fFormula) fFormula->AddVariables(vars,size); }
    virtual Bool_t   AddToGlobalList(Bool_t on = kTRUE);
    static  Bool_t   DefaultAddToGlobalList(Bool_t on = kTRUE);
-   virtual void     Browse(TBrowser *b);
-   virtual void     Copy(TObject &f1) const;
-   TObject*         Clone(const char* newname=0) const;
+   void     Browse(TBrowser *b) override;
+   void     Copy(TObject &f1) const override;
+   TObject*         Clone(const char* newname=0) const override;
    virtual Double_t Derivative(Double_t x, Double_t *params = 0, Double_t epsilon = 0.001) const;
    virtual Double_t Derivative2(Double_t x, Double_t *params = 0, Double_t epsilon = 0.001) const;
    virtual Double_t Derivative3(Double_t x, Double_t *params = 0, Double_t epsilon = 0.001) const;
    static  Double_t DerivativeError();
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *option = "");
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     Draw(Option_t *option = "") override;
    virtual TF1     *DrawCopy(Option_t *option = "") const;
    virtual TObject *DrawDerivative(Option_t *option = "al"); // *MENU*
    virtual TObject *DrawIntegral(Option_t *option = "al"); // *MENU*
@@ -440,7 +440,7 @@ public:
    template <class T> T EvalPar(const T *x, const Double_t *params = 0);
    virtual Double_t operator()(Double_t x, Double_t y = 0, Double_t z = 0, Double_t t = 0) const;
    template <class T> T operator()(const T *x, const Double_t *params = nullptr);
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual void     FixParameter(Int_t ipar, Double_t value);
    bool      IsVectorized()
    {
@@ -509,7 +509,7 @@ public:
    {
       return fNpfits;
    }
-   virtual char    *GetObjectInfo(Int_t px, Int_t py) const;
+   char    *GetObjectInfo(Int_t px, Int_t py) const override;
    TObject    *GetParent() const
    {
       return fParent;
@@ -609,11 +609,11 @@ public:
       return (fFormula) ? fFormula->IsLinear() : false;
    }
    virtual Bool_t   IsValid() const;
-   virtual void     Print(Option_t *option = "") const;
-   virtual void     Paint(Option_t *option = "");
+   void     Print(Option_t *option = "") const override;
+   void     Paint(Option_t *option = "") override;
    virtual void     ReleaseParameter(Int_t ipar);
    virtual void     Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax);
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetChisquare(Double_t chi2)
    {
       fChisquare = chi2;
@@ -675,7 +675,7 @@ public:
    virtual void     SetRange(Double_t xmin, Double_t ymin,  Double_t xmax, Double_t ymax);
    virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin,  Double_t xmax, Double_t ymax, Double_t zmax);
    virtual void     SetSavedPoint(Int_t point, Double_t value);
-   virtual void     SetTitle(const char *title = ""); // *MENU*
+   void     SetTitle(const char *title = "") override; // *MENU*
    virtual void     SetVectorized(Bool_t vectorized)
    {
       if (fType == EFType::kFormula && fFormula)
@@ -716,7 +716,7 @@ private:
    inline double EvalParVec(const Double_t *data, const Double_t *params);
 #endif
 
-   ClassDef(TF1, 12) // The Parametric 1-D function
+   ClassDefOverride(TF1, 12) // The Parametric 1-D function
 };
 
 namespace ROOT {

--- a/hist/hist/inc/TF12.h
+++ b/hist/hist/inc/TF12.h
@@ -33,11 +33,11 @@ public:
    TF12();
    TF12(const char *name, TF2 *f2, Double_t xy, Option_t *option="x");
    TF12(const TF12 &f12);
-   virtual   ~TF12();
-   virtual void     Copy(TObject &f12) const;
-   virtual TF1     *DrawCopy(Option_t *option="") const;
-   virtual Double_t Eval(Double_t x, Double_t y=0, Double_t z=0, Double_t t=0) const;
-   virtual Double_t EvalPar(const Double_t *x, const Double_t *params=0);
+     ~TF12() override;
+   void     Copy(TObject &f12) const override;
+   TF1     *DrawCopy(Option_t *option="") const override;
+   Double_t Eval(Double_t x, Double_t y=0, Double_t z=0, Double_t t=0) const override;
+   Double_t EvalPar(const Double_t *x, const Double_t *params=0) override;
 
 #ifdef R__HAS_VECCORE
    using TF1::Eval;    // to not hide the vectorized version
@@ -45,10 +45,10 @@ public:
 #endif
 
    virtual Double_t GetXY() const {return fXY;}
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetXY(Double_t xy);  // *MENU*
 
-   ClassDef(TF12,1)  //Projection of a TF2 along x or y
+   ClassDefOverride(TF12,1)  //Projection of a TF2 along x or y
 };
 
 #endif

--- a/hist/hist/inc/TF1AbsComposition.h
+++ b/hist/hist/inc/TF1AbsComposition.h
@@ -16,16 +16,16 @@
 class TF1AbsComposition : public TObject {
 
 public:
-   virtual ~TF1AbsComposition() {}
+   ~TF1AbsComposition() override {}
 
    virtual double operator()(const Double_t *x, const Double_t *p) = 0; // for Eval
    virtual void SetRange(Double_t a, Double_t b) = 0;
    virtual void SetParameters(const Double_t *params) = 0;
    virtual void Update() = 0;
 
-   virtual void Copy(TObject &obj) const = 0;
+   void Copy(TObject &obj) const override = 0;
 
-   ClassDef(TF1AbsComposition, 1);
+   ClassDefOverride(TF1AbsComposition, 1);
 };
 
 #endif

--- a/hist/hist/inc/TF1Convolution.h
+++ b/hist/hist/inc/TF1Convolution.h
@@ -53,12 +53,12 @@ public:
    TF1Convolution(const TF1Convolution &conv);
 
    TF1Convolution &operator=(const TF1Convolution &rhs);
-   virtual ~TF1Convolution() {}
+   ~TF1Convolution() override {}
 
-   void SetParameters(const Double_t *params);
+   void SetParameters(const Double_t *params) override;
    void SetParameters(Double_t p0, Double_t p1, Double_t p2 = 0., Double_t p3 = 0., Double_t p4 = 0., Double_t p5 = 0.,
                       Double_t p6 = 0., Double_t p7 = 0.);
-   void SetRange(Double_t a, Double_t b);
+   void SetRange(Double_t a, Double_t b) override;
    void SetExtraRange(Double_t percentage);
    void SetNofPointsFFT(Int_t n);
    void SetNumConv(Bool_t flag = true) { fFlagFFT = !flag; }
@@ -71,13 +71,13 @@ public:
    const char *GetParName(Int_t ipar) const { return fParNames.at(ipar).Data(); }
    void GetRange(Double_t &a, Double_t &b) const;
 
-   void Update();
+   void Update() override;
 
-   Double_t operator()(const Double_t *x, const Double_t *p);
+   Double_t operator()(const Double_t *x, const Double_t *p) override;
 
-   void Copy(TObject &obj) const;
+   void Copy(TObject &obj) const override;
 
-   ClassDef(TF1Convolution, 1);
+   ClassDefOverride(TF1Convolution, 1);
 };
 
 

--- a/hist/hist/inc/TF1NormSum.h
+++ b/hist/hist/inc/TF1NormSum.h
@@ -44,20 +44,20 @@ public:
 
    TF1NormSum &operator=(const TF1NormSum &rhs);
 
-   virtual ~TF1NormSum() {}
+   ~TF1NormSum() override {}
 
-   double operator()(const Double_t *x, const Double_t *p);
+   double operator()(const Double_t *x, const Double_t *p) override;
 
    std::vector<double> GetParameters() const;
 
    void        SetScale(Double_t scale) { fScale = scale; };
 
-   void SetParameters(const Double_t *params);
+   void SetParameters(const Double_t *params) override;
 
    void        SetParameters(Double_t p0, Double_t p1, Double_t p2=0., Double_t p3=0., Double_t p4=0.,
                                    Double_t p5=0., Double_t p6=0., Double_t p7=0., Double_t p8=0., Double_t p9=0., Double_t p10=0.);
 
-   void SetRange(Double_t a, Double_t b);
+   void SetRange(Double_t a, Double_t b) override;
 
    Int_t       GetNpar() const;
 
@@ -71,10 +71,10 @@ public:
 
    void GetRange(Double_t &a, Double_t &b) const;
 
-   void Update();
+   void Update() override;
 
-   void Copy(TObject &obj) const;
+   void Copy(TObject &obj) const override;
 
-   ClassDef(TF1NormSum, 1);
+   ClassDefOverride(TF1NormSum, 1);
 };
 #endif /* defined(ROOT_TF1NormSum__) */

--- a/hist/hist/inc/TF2.h
+++ b/hist/hist/inc/TF2.h
@@ -84,26 +84,26 @@ public:
 
    TF2(const TF2 &f2);
    TF2 &operator=(const TF2& rhs);
-   virtual   ~TF2();
-   virtual void     Copy(TObject &f2) const;
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *option="");
-   virtual TF1     *DrawCopy(Option_t *option="") const;
-   virtual TObject *DrawDerivative(Option_t * ="al") {return 0;}
-   virtual TObject *DrawIntegral(Option_t * ="al")   {return 0;}
+     ~TF2() override;
+   void     Copy(TObject &f2) const override;
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     Draw(Option_t *option="") override;
+   TF1     *DrawCopy(Option_t *option="") const override;
+   TObject *DrawDerivative(Option_t * ="al") override {return 0;}
+   TObject *DrawIntegral(Option_t * ="al") override   {return 0;}
    //virtual void     DrawF2(const char *formula, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Option_t *option="");
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Int_t    GetContour(Double_t *levels=0);
    virtual Double_t GetContourLevel(Int_t level) const;
           Int_t     GetNpy() const {return fNpy;}
-   virtual char    *GetObjectInfo(Int_t px, Int_t py) const;
-   Double_t GetRandom(TRandom * rng = nullptr, Option_t * opt = nullptr);
-   Double_t GetRandom(Double_t xmin, Double_t xmax, TRandom * rng = nullptr, Option_t * opt = nullptr);
+   char    *GetObjectInfo(Int_t px, Int_t py) const override;
+   Double_t GetRandom(TRandom * rng = nullptr, Option_t * opt = nullptr) override;
+   Double_t GetRandom(Double_t xmin, Double_t xmax, TRandom * rng = nullptr, Option_t * opt = nullptr) override;
    virtual void     GetRandom2(Double_t &xrandom, Double_t &yrandom, TRandom * rng = nullptr);
    using TF1::GetRange;
-   virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
-   virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xmax, Double_t &ymax, Double_t &zmax) const;
-   virtual Double_t GetSave(const Double_t *x);
+   void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const override;
+   void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xmax, Double_t &ymax, Double_t &zmax) const override;
+   Double_t GetSave(const Double_t *x) override;
    virtual Double_t GetMinimumXY(Double_t &x, Double_t &y) const;
    virtual Double_t GetMaximumXY(Double_t &x, Double_t &y) const;
    using TF1::GetMinimum;
@@ -114,17 +114,17 @@ public:
    virtual Double_t GetYmax() const {return fYmax;}
    using TF1::Integral;
    virtual Double_t Integral(Double_t ax, Double_t bx, Double_t ay, Double_t by, Double_t epsrel=1.e-6);
-   virtual Bool_t   IsInside(const Double_t *x) const;
-   virtual TH1     *CreateHistogram();
-   virtual void     Paint(Option_t *option="");
-   virtual void     Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax);
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   Bool_t   IsInside(const Double_t *x) const override;
+   TH1     *CreateHistogram() override;
+   void     Paint(Option_t *option="") override;
+   void     Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax) override;
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetNpy(Int_t npy=100); // *MENU*
    virtual void     SetContour(Int_t nlevels=20, const Double_t *levels=0);
    virtual void     SetContourLevel(Int_t level, Double_t value);
-   virtual void     SetRange(Double_t xmin, Double_t xmax);
-   virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax); // *MENU*
-   virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin, Double_t xmax, Double_t ymax, Double_t zmax);
+   void     SetRange(Double_t xmin, Double_t xmax) override;
+   void     SetRange(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) override; // *MENU*
+   void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin, Double_t xmax, Double_t ymax, Double_t zmax) override;
 
    //Moments
    virtual Double_t Moment2(Double_t nx, Double_t ax, Double_t bx, Double_t ny, Double_t ay, Double_t by, Double_t epsilon=0.000001);
@@ -142,7 +142,7 @@ protected:
 
    virtual Double_t FindMinMax(Double_t* x, bool findmax) const;
 
-   ClassDef(TF2,4)  //The Parametric 2-D function
+   ClassDefOverride(TF2,4)  //The Parametric 2-D function
 };
 
 inline void TF2::SetRange(Double_t xmin, Double_t xmax)

--- a/hist/hist/inc/TF3.h
+++ b/hist/hist/inc/TF3.h
@@ -81,39 +81,39 @@ public:
 
    TF3(const TF3 &f3);
    TF3& operator=(const TF3 &rhs);
-   virtual   ~TF3();
-   virtual void     Copy(TObject &f3) const;
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *option="");
-   virtual TObject *DrawDerivative(Option_t * ="al") {return 0;}
-   virtual TObject *DrawIntegral(Option_t * ="al")   {return 0;}
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+     ~TF3() override;
+   void     Copy(TObject &f3) const override;
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     Draw(Option_t *option="") override;
+   TObject *DrawDerivative(Option_t * ="al") override {return 0;}
+   TObject *DrawIntegral(Option_t * ="al") override   {return 0;}
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Double_t GetMinimumXYZ(Double_t &x, Double_t &y, Double_t &z);
    virtual Double_t GetMaximumXYZ(Double_t &x, Double_t &y, Double_t &z);
           Int_t     GetNpz() const {return fNpz;}
    virtual void     GetRandom3(Double_t &xrandom, Double_t &yrandom, Double_t &zrandom, TRandom * rng = nullptr);
    using TF1::GetRange;
-   virtual void     GetRange(Double_t &xmin, Double_t &xmax) const;
-   virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const ;
-   virtual void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xmax, Double_t &ymax, Double_t &zmax) const;
-   virtual Double_t GetSave(const Double_t *x);
+   void     GetRange(Double_t &xmin, Double_t &xmax) const override;
+   void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const override ;
+   void     GetRange(Double_t &xmin, Double_t &ymin, Double_t &zmin, Double_t &xmax, Double_t &ymax, Double_t &zmax) const override;
+   Double_t GetSave(const Double_t *x) override;
    virtual Double_t GetZmin() const {return fZmin;}
    virtual Double_t GetZmax() const {return fZmax;}
    using TF2::Integral;
    virtual Double_t Integral(Double_t ax, Double_t bx, Double_t ay, Double_t by, Double_t az, Double_t bz, Double_t epsrel=1.e-6);
-   virtual Bool_t   IsInside(const Double_t *x) const;
-   virtual TH1     *CreateHistogram();
-   virtual void     Paint(Option_t *option="");
-   virtual void     Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax);
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   Bool_t   IsInside(const Double_t *x) const override;
+   TH1     *CreateHistogram() override;
+   void     Paint(Option_t *option="") override;
+   void     Save(Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax) override;
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetClippingBoxOff(); // *MENU*
    virtual Bool_t   GetClippingBoxOn() const { return fClipBoxOn; }
    virtual void     SetClippingBoxOn(Double_t xclip=0, Double_t yclip=0, Double_t zclip=0); // *MENU*
    virtual const Double_t *GetClippingBox() const { return fClipBoxOn ? fClipBox : nullptr; }
    virtual void     SetNpz(Int_t npz=30);
-   virtual void     SetRange(Double_t xmin, Double_t xmax);
-   virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax);
-   virtual void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin, Double_t xmax, Double_t ymax, Double_t zmax); // *MENU*
+   void     SetRange(Double_t xmin, Double_t xmax) override;
+   void     SetRange(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax) override;
+   void     SetRange(Double_t xmin, Double_t ymin, Double_t zmin, Double_t xmax, Double_t ymax, Double_t zmax) override; // *MENU*
 
    //Moments
    virtual Double_t Moment3(Double_t nx, Double_t ax, Double_t bx, Double_t ny, Double_t ay, Double_t by, Double_t nz, Double_t az, Double_t bz, Double_t epsilon=0.000001);
@@ -133,9 +133,9 @@ public:
 
 protected:
 
-   virtual Double_t FindMinMax(Double_t* x, bool findmax) const;
+   Double_t FindMinMax(Double_t* x, bool findmax) const override;
 
-   ClassDef(TF3,3)  //The Parametric 3-D function
+   ClassDefOverride(TF3,3)  //The Parametric 3-D function
 };
 
 inline void TF3::GetRange(Double_t &xmin, Double_t &xmax) const

--- a/hist/hist/inc/TFitResult.h
+++ b/hist/hist/inc/TFitResult.h
@@ -50,10 +50,10 @@ public:
    // constructor from an FitResult
    TFitResult(const ROOT::Fit::FitResult& f);
 
-   virtual ~TFitResult() {}
+   ~TFitResult() override {}
 
 
-   virtual void  Print(Option_t *option="") const;
+   void  Print(Option_t *option="") const override;
 
    TMatrixDSym GetCovarianceMatrix() const;
 
@@ -76,7 +76,7 @@ public:
    }
 
 private:
-   ClassDef(TFitResult, 0);  // Class holding the result of the fit
+   ClassDefOverride(TFitResult, 0);  // Class holding the result of the fit
 };
 
 namespace cling {

--- a/hist/hist/inc/TFormula.h
+++ b/hist/hist/inc/TFormula.h
@@ -184,7 +184,7 @@ public:
    using CladStorage = std::vector<Double_t>;
 
                   TFormula();
-   virtual        ~TFormula();
+          ~TFormula() override;
    TFormula&      operator=(const TFormula &rhs);
    TFormula(const char *name, const char * formula = "", bool addToGlobList = true, bool vectorize = false);
    TFormula(const char *name, const char * formula, int ndim, int npar, bool addToGlobList = true);
@@ -195,8 +195,8 @@ public:
    void           AddVariable(const TString &name, Double_t value = 0);
    void           AddVariables(const TString *vars, const Int_t size);
    Int_t          Compile(const char *expression="");
-   virtual void   Copy(TObject &f1) const;
-   virtual void   Clear(Option_t * option="");
+   void   Copy(TObject &f1) const override;
+   void   Clear(Option_t * option="") override;
    Double_t       Eval(Double_t x) const;
    Double_t       Eval(Double_t x, Double_t y) const;
    Double_t       Eval(Double_t x, Double_t y , Double_t z) const;
@@ -268,8 +268,8 @@ public:
    Bool_t         IsValid() const { return fReadyToExecute && fClingInitialized; }
    Bool_t IsVectorized() const { return fVectorized; }
    Bool_t         IsLinear() const { return TestBit(kLinear); }
-   void           Print(Option_t *option = "") const;
-   void           SetName(const char* name);
+   void           Print(Option_t *option = "") const override;
+   void           SetName(const char* name) override;
    void           SetParameter(const char* name, Double_t value);
    void           SetParameter(Int_t param, Double_t value);
    void           SetParameters(const Double_t *params);
@@ -286,6 +286,6 @@ public:
    void           SetVariables(const std::pair<TString,Double_t> *vars, const Int_t size);
    void SetVectorized(Bool_t vectorized);
 
-   ClassDef(TFormula,13)
+   ClassDefOverride(TFormula,13)
 };
 #endif

--- a/hist/hist/inc/TFractionFitter.h
+++ b/hist/hist/inc/TFractionFitter.h
@@ -28,7 +28,7 @@ class TFractionFitter: public TObject {
 public:
    TFractionFitter();
    TFractionFitter(TH1* data, TObjArray *MCs, Option_t *option="");
-   virtual ~TFractionFitter();
+   ~TFractionFitter() override;
 
    //TVirtualFitter* GetFitter() const;
    ROOT::Fit::Fitter* GetFitter() const;
@@ -109,7 +109,7 @@ protected:
 
    Int_t     fNpar;                     ///< number of fit parameters
 
-   ClassDef(TFractionFitter, 0); // Fits MC fractions to data histogram
+   ClassDefOverride(TFractionFitter, 0); // Fits MC fractions to data histogram
 };
 
 //

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -87,29 +87,29 @@ public:
    TGraph(const TH1 *h);
    TGraph(const TF1 *f, Option_t *option="");
    TGraph(const char *filename, const char *format="%lg %lg", Option_t *option="");
-   virtual ~TGraph();
+   ~TGraph() override;
 
    virtual void          AddPoint(Double_t x, Double_t y) { SetPoint(fNpoints, x, y); } ///< Append a new point to the graph.
    virtual void          Apply(TF1 *f);
-   virtual void          Browse(TBrowser *b);
+   void          Browse(TBrowser *b) override;
    virtual Double_t      Chisquare(TF1 *f1, Option_t *option="") const;
    static Bool_t         CompareArg(const TGraph* gr, Int_t left, Int_t right);
    static Bool_t         CompareX(const TGraph* gr, Int_t left, Int_t right);
    static Bool_t         CompareY(const TGraph* gr, Int_t left, Int_t right);
    static Bool_t         CompareRadius(const TGraph* gr, Int_t left, Int_t right);
    virtual void          ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
-   virtual Int_t         DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void          Draw(Option_t *chopt="");
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   void          Draw(Option_t *chopt="") override;
    virtual void          DrawGraph(Int_t n, const Int_t *x, const Int_t *y, Option_t *option="");
    virtual void          DrawGraph(Int_t n, const Float_t *x, const Float_t *y, Option_t *option="");
    virtual void          DrawGraph(Int_t n, const Double_t *x=nullptr, const Double_t *y=nullptr, Option_t *option="");
    virtual void          DrawPanel(); // *MENU*
    virtual Double_t      Eval(Double_t x, TSpline *spline=nullptr, Option_t *option="") const;
-   virtual void          ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void          ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual void          Expand(Int_t newsize);
    virtual void          Expand(Int_t newsize, Int_t step);
-   virtual TObject      *FindObject(const char *name) const;
-   virtual TObject      *FindObject(const TObject *obj) const;
+   TObject      *FindObject(const char *name) const override;
+   TObject      *FindObject(const TObject *obj) const override;
    virtual TFitResultPtr Fit(const char *formula ,Option_t *option="" ,Option_t *goption="", Axis_t xmin=0, Axis_t xmax=0); // *MENU*
    virtual TFitResultPtr Fit(TF1 *f1 ,Option_t *option="" ,Option_t *goption="", Axis_t xmin=0, Axis_t xmax=0);
    virtual void          FitPanel(); // *MENU*
@@ -145,7 +145,7 @@ public:
    Double_t              GetMinimum()  const {return fMinimum;}
    TAxis                *GetXaxis() const ;
    TAxis                *GetYaxis() const ;
-   virtual char         *GetObjectInfo(Int_t px, Int_t py) const;
+   char         *GetObjectInfo(Int_t px, Int_t py) const override;
    virtual Int_t         GetPoint(Int_t i, Double_t &x, Double_t &y) const;
    virtual Double_t      GetPointX(Int_t i) const;
    virtual Double_t      GetPointY(Int_t i) const;
@@ -163,15 +163,15 @@ public:
    virtual void          LeastSquareLinearFit(Int_t n, Double_t &a0, Double_t &a1, Int_t &ifail, Double_t xmin=0, Double_t xmax=0);
    virtual Int_t         Merge(TCollection* list);
    virtual void          MovePoints(Double_t dx, Double_t dy, Bool_t logx = kFALSE, Bool_t logy = kFALSE);
-   virtual void          Paint(Option_t *chopt="");
+   void          Paint(Option_t *chopt="") override;
    void                  PaintGraph(Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt);
    void                  PaintGrapHist(Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt);
    virtual void          PaintStats(TF1 *fit);
-   virtual void          Print(Option_t *chopt="") const;
-   virtual void          RecursiveRemove(TObject *obj);
+   void          Print(Option_t *chopt="") const override;
+   void          RecursiveRemove(TObject *obj) override;
    virtual Int_t         RemovePoint(); // *MENU*
    virtual Int_t         RemovePoint(Int_t ipoint);
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void          Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
    virtual void          SetEditable(Bool_t editable=kTRUE); // *TOGGLE* *GETTER=GetEditable
    virtual void          SetHighlight(Bool_t set = kTRUE); // *TOGGLE* *GETTER=IsHighlight
@@ -182,16 +182,16 @@ public:
    virtual void          SetPoint(Int_t i, Double_t x, Double_t y);
    virtual void          SetPointX(Int_t i, Double_t x);
    virtual void          SetPointY(Int_t i, Double_t y);
-   virtual void          SetName(const char *name=""); // *MENU*
-   virtual void          SetNameTitle(const char *name="", const char *title="");
+   void          SetName(const char *name="") override; // *MENU*
+   void          SetNameTitle(const char *name="", const char *title="") override;
    virtual void          SetStats(Bool_t stats=kTRUE); // *MENU*
-   virtual void          SetTitle(const char *title="");    // *MENU*
+   void          SetTitle(const char *title="") override;    // *MENU*
    virtual void          Sort(Bool_t (*greater)(const TGraph*, Int_t, Int_t)=&TGraph::CompareX,
                               Bool_t ascending=kTRUE, Int_t low=0, Int_t high=-1111);
-   virtual void          UseCurrentStyle();
+   void          UseCurrentStyle() override;
    void                  Zero(Int_t &k,Double_t AZ,Double_t BZ,Double_t E2,Double_t &X,Double_t &Y,Int_t maxiterations);
 
-   ClassDef(TGraph,4)  //Graph graphics class
+   ClassDefOverride(TGraph,4)  //Graph graphics class
 };
 
 #endif

--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -86,19 +86,19 @@ public:
    TGraph2D(const char *filename, const char *format="%lg %lg %lg", Option_t *option="");
    TGraph2D(const TGraph2D &);
 
-   virtual ~TGraph2D();
+   ~TGraph2D() override;
 
    TGraph2D& operator=(const TGraph2D &);
 
    virtual void          AddPoint(Double_t x, Double_t y, Double_t z) { SetPoint(fNpoints, x, y, z); } ///< Append a new point to the graph.
-   virtual void          Browse(TBrowser *);
-   virtual void          Clear(Option_t *option="");
+   void          Browse(TBrowser *) override;
+   void          Clear(Option_t *option="") override;
    virtual void          DirectoryAutoAdd(TDirectory *);
-   Int_t                 DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void          Draw(Option_t *option="P0");
-   void                  ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual TObject      *FindObject(const char *name) const;
-   virtual TObject      *FindObject(const TObject *obj) const;
+   Int_t                 DistancetoPrimitive(Int_t px, Int_t py) override;
+   void          Draw(Option_t *option="P0") override;
+   void                  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   TObject      *FindObject(const char *name) const override;
+   TObject      *FindObject(const TObject *obj) const override;
    virtual TFitResultPtr Fit(const char *formula ,Option_t *option="" ,Option_t *goption=""); // *MENU*
    virtual TFitResultPtr Fit(TF2 *f2 ,Option_t *option="" ,Option_t *goption=""); // *MENU*
    virtual void          FitPanel(); // *MENU*
@@ -138,11 +138,11 @@ public:
    virtual Double_t      GetZminE() const {return GetZmin();};
    virtual Int_t         GetPoint(Int_t i, Double_t &x, Double_t &y, Double_t &z) const;
    Double_t              Interpolate(Double_t x, Double_t y);
-   void                  Paint(Option_t *option="");
-   virtual void          Print(Option_t *chopt="") const;
+   void                  Paint(Option_t *option="") override;
+   void          Print(Option_t *chopt="") const override;
    TH1                  *Project(Option_t *option="x") const; // *MENU*
    Int_t                 RemovePoint(Int_t ipoint); // *MENU*
-   virtual void          SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void          Scale(Double_t c1=1., Option_t *option="z"); // *MENU*
    virtual void          Set(Int_t n);
    virtual void          SetDirectory(TDirectory *dir);
@@ -152,15 +152,15 @@ public:
    void                  SetMaximum(Double_t maximum=-1111); // *MENU*
    void                  SetMinimum(Double_t minimum=-1111); // *MENU*
    void                  SetMaxIter(Int_t n=100000) {fMaxIter = n;} // *MENU*
-   virtual void          SetName(const char *name); // *MENU*
-   virtual void          SetNameTitle(const char *name, const char *title);
+   void          SetName(const char *name) override; // *MENU*
+   void          SetNameTitle(const char *name, const char *title) override;
    void                  SetNpx(Int_t npx=40); // *MENU*
    void                  SetNpy(Int_t npx=40); // *MENU*
    virtual void          SetPoint(Int_t point, Double_t x, Double_t y, Double_t z); // *MENU*
-   virtual void          SetTitle(const char *title=""); // *MENU*
+   void          SetTitle(const char *title="") override; // *MENU*
 
 
-   ClassDef(TGraph2D,1)  //Set of n x[n],y[n],z[n] points with 3-d graphics including Delaunay triangulation
+   ClassDefOverride(TGraph2D,1)  //Set of n x[n],y[n],z[n] points with 3-d graphics including Delaunay triangulation
 };
 
 #endif

--- a/hist/hist/inc/TGraph2DErrors.h
+++ b/hist/hist/inc/TGraph2DErrors.h
@@ -40,27 +40,27 @@ public:
                   Double_t *ex=0, Double_t *ey=0, Double_t *ez=0, Option_t *option="");
    TGraph2DErrors(const TGraph2DErrors&);
    TGraph2DErrors& operator=(const TGraph2DErrors&);
-   virtual ~TGraph2DErrors();
-   Double_t        GetErrorX(Int_t bin) const;
-   Double_t        GetErrorY(Int_t bin) const;
-   Double_t        GetErrorZ(Int_t bin) const;
-   Double_t       *GetEX() const {return fEX;}
-   Double_t       *GetEY() const {return fEY;}
-   Double_t       *GetEZ() const {return fEZ;}
-   Double_t        GetXmaxE() const;
-   Double_t        GetXminE() const;
-   Double_t        GetYmaxE() const;
-   Double_t        GetYminE() const;
-   Double_t        GetZmaxE() const;
-   Double_t        GetZminE() const;
-   virtual void    Print(Option_t *chopt="") const;
+   ~TGraph2DErrors() override;
+   Double_t        GetErrorX(Int_t bin) const override;
+   Double_t        GetErrorY(Int_t bin) const override;
+   Double_t        GetErrorZ(Int_t bin) const override;
+   Double_t       *GetEX() const override {return fEX;}
+   Double_t       *GetEY() const override {return fEY;}
+   Double_t       *GetEZ() const override {return fEZ;}
+   Double_t        GetXmaxE() const override;
+   Double_t        GetXminE() const override;
+   Double_t        GetYmaxE() const override;
+   Double_t        GetYminE() const override;
+   Double_t        GetZmaxE() const override;
+   Double_t        GetZminE() const override;
+   void    Print(Option_t *chopt="") const override;
    Int_t           RemovePoint(Int_t ipoint); // *MENU*
-   virtual void    Scale(Double_t c1=1., Option_t *option="z"); // *MENU*
-   virtual void    Set(Int_t n);
-   virtual void    SetPoint(Int_t i, Double_t x, Double_t y, Double_t z);
+   void    Scale(Double_t c1=1., Option_t *option="z") override; // *MENU*
+   void    Set(Int_t n) override;
+   void    SetPoint(Int_t i, Double_t x, Double_t y, Double_t z) override;
    virtual void    SetPointError(Int_t i, Double_t ex, Double_t ey, Double_t ez);
 
-   ClassDef(TGraph2DErrors,1)  //A 2D graph with error bars
+   ClassDefOverride(TGraph2DErrors,1)  //A 2D graph with error bars
 };
 
 #endif

--- a/hist/hist/inc/TGraphAsymmErrors.h
+++ b/hist/hist/inc/TGraphAsymmErrors.h
@@ -31,17 +31,17 @@ protected:
    Double_t    *fEYlow;        ///<[fNpoints] array of Y low errors
    Double_t    *fEYhigh;       ///<[fNpoints] array of Y high errors
 
-   virtual void    SwapPoints(Int_t pos1, Int_t pos2);
+   void    SwapPoints(Int_t pos1, Int_t pos2) override;
 
-   virtual Double_t** Allocate(Int_t size);
-   virtual void       CopyAndRelease(Double_t **newarrays,
-                                     Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
-                                 Int_t obegin);
+   Double_t** Allocate(Int_t size) override;
+   void       CopyAndRelease(Double_t **newarrays,
+                                     Int_t ibegin, Int_t iend, Int_t obegin) override;
+   Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
+                                 Int_t obegin) override;
    Bool_t             CtorAllocate();
-   virtual void       FillZero(Int_t begin, Int_t end,
-                               Bool_t from_ctor = kTRUE);
-   virtual Bool_t     DoMerge(const TGraph * g);
+   void       FillZero(Int_t begin, Int_t end,
+                               Bool_t from_ctor = kTRUE) override;
+   Bool_t     DoMerge(const TGraph * g) override;
 
 public:
    TGraphAsymmErrors();
@@ -56,26 +56,26 @@ public:
    TGraphAsymmErrors(const TH1* pass, const TH1* total, Option_t *option="");
    TGraphAsymmErrors(const char *filename, const char *format="%lg %lg %lg %lg %lg %lg", Option_t *option="");
 
-   virtual ~TGraphAsymmErrors();
+   ~TGraphAsymmErrors() override;
 
-   virtual void    Apply(TF1 *f);
+   void    Apply(TF1 *f) override;
    virtual void    BayesDivide(const TH1* pass, const TH1* total, Option_t *opt="");
    virtual void    Divide(const TH1* pass, const TH1* total, Option_t *opt="cp");
-   virtual void    ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
-   Double_t        GetErrorX(Int_t bin)   const;
-   Double_t        GetErrorY(Int_t bin)   const;
-   Double_t        GetErrorXlow(Int_t i)  const;
-   Double_t        GetErrorXhigh(Int_t i) const;
-   Double_t        GetErrorYlow(Int_t i)  const;
-   Double_t        GetErrorYhigh(Int_t i) const;
-   Double_t       *GetEXlow()  const {return fEXlow;}
-   Double_t       *GetEXhigh() const {return fEXhigh;}
-   Double_t       *GetEYlow()  const {return fEYlow;}
-   Double_t       *GetEYhigh() const {return fEYhigh;}
-   virtual Int_t   Merge(TCollection* list);
-   virtual void    Print(Option_t *chopt="") const;
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void    Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
+   void    ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const override;
+   Double_t        GetErrorX(Int_t bin)   const override;
+   Double_t        GetErrorY(Int_t bin)   const override;
+   Double_t        GetErrorXlow(Int_t i)  const override;
+   Double_t        GetErrorXhigh(Int_t i) const override;
+   Double_t        GetErrorYlow(Int_t i)  const override;
+   Double_t        GetErrorYhigh(Int_t i) const override;
+   Double_t       *GetEXlow()  const override {return fEXlow;}
+   Double_t       *GetEXhigh() const override {return fEXhigh;}
+   Double_t       *GetEYlow()  const override {return fEYlow;}
+   Double_t       *GetEYhigh() const override {return fEYhigh;}
+   Int_t   Merge(TCollection* list) override;
+   void    Print(Option_t *chopt="") const override;
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void    Scale(Double_t c1=1., Option_t *option="y") override; // *MENU*
    virtual void    SetPointError(Double_t exl, Double_t exh, Double_t eyl, Double_t eyh); // *MENU*
    virtual void    SetPointError(Int_t i, Double_t exl, Double_t exh, Double_t eyl, Double_t eyh);
    virtual void    SetPointEXlow(Int_t i, Double_t exl);
@@ -83,7 +83,7 @@ public:
    virtual void    SetPointEYlow(Int_t i, Double_t eyl);
    virtual void    SetPointEYhigh(Int_t i, Double_t eyh);
 
-   ClassDef(TGraphAsymmErrors,3)  //A graph with asymmetric error bars
+   ClassDefOverride(TGraphAsymmErrors,3)  //A graph with asymmetric error bars
 };
 
 #endif

--- a/hist/hist/inc/TGraphBentErrors.h
+++ b/hist/hist/inc/TGraphBentErrors.h
@@ -35,17 +35,17 @@ protected:
    Double_t    *fEYlowd;       ///<[fNpoints] array of Y low displacements
    Double_t    *fEYhighd;      ///<[fNpoints] array of Y high displacements
 
-   virtual void       SwapPoints(Int_t pos1, Int_t pos2);
+   void       SwapPoints(Int_t pos1, Int_t pos2) override;
 
-   virtual Double_t** Allocate(Int_t size);
-   virtual void       CopyAndRelease(Double_t **newarrays,
-                                     Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
-                                 Int_t obegin);
+   Double_t** Allocate(Int_t size) override;
+   void       CopyAndRelease(Double_t **newarrays,
+                                     Int_t ibegin, Int_t iend, Int_t obegin) override;
+   Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
+                                 Int_t obegin) override;
    Bool_t             CtorAllocate();
-   virtual void       FillZero(Int_t begin, Int_t end,
-                               Bool_t from_ctor = kTRUE);
-   virtual Bool_t     DoMerge(const TGraph * g);
+   void       FillZero(Int_t begin, Int_t end,
+                               Bool_t from_ctor = kTRUE) override;
+   Bool_t     DoMerge(const TGraph * g) override;
 
 
 public:
@@ -64,27 +64,27 @@ public:
                     const Double_t *exld=0, const Double_t *exhd=0,
                     const Double_t *eyld=0, const Double_t *eyhd=0);
    TGraphBentErrors(const TGraphBentErrors &gr);
-   virtual ~TGraphBentErrors();
-   virtual void    Apply(TF1 *f);
-   virtual void    ComputeRange(Double_t &xmin, Double_t &ymin,
-                                Double_t &xmax, Double_t &ymax) const;
-   Double_t        GetErrorX(Int_t bin)     const;
-   Double_t        GetErrorY(Int_t bin)     const;
-   Double_t        GetErrorXlow(Int_t bin)  const;
-   Double_t        GetErrorXhigh(Int_t bin) const;
-   Double_t        GetErrorYlow(Int_t bin)  const;
-   Double_t        GetErrorYhigh(Int_t bin) const;
-   Double_t       *GetEXlow()   const {return fEXlow;}
-   Double_t       *GetEXhigh()  const {return fEXhigh;}
-   Double_t       *GetEYlow()   const {return fEYlow;}
-   Double_t       *GetEYhigh()  const {return fEYhigh;}
-   Double_t       *GetEXlowd()  const {return fEXlowd;}
-   Double_t       *GetEXhighd() const {return fEXhighd;}
-   Double_t       *GetEYlowd()  const {return fEYlowd;}
-   Double_t       *GetEYhighd() const {return fEYhighd;}
-   virtual void    Print(Option_t *chopt="") const;
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void    Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
+   ~TGraphBentErrors() override;
+   void    Apply(TF1 *f) override;
+   void    ComputeRange(Double_t &xmin, Double_t &ymin,
+                                Double_t &xmax, Double_t &ymax) const override;
+   Double_t        GetErrorX(Int_t bin)     const override;
+   Double_t        GetErrorY(Int_t bin)     const override;
+   Double_t        GetErrorXlow(Int_t bin)  const override;
+   Double_t        GetErrorXhigh(Int_t bin) const override;
+   Double_t        GetErrorYlow(Int_t bin)  const override;
+   Double_t        GetErrorYhigh(Int_t bin) const override;
+   Double_t       *GetEXlow()   const override {return fEXlow;}
+   Double_t       *GetEXhigh()  const override {return fEXhigh;}
+   Double_t       *GetEYlow()   const override {return fEYlow;}
+   Double_t       *GetEYhigh()  const override {return fEYhigh;}
+   Double_t       *GetEXlowd()  const override {return fEXlowd;}
+   Double_t       *GetEXhighd() const override {return fEXhighd;}
+   Double_t       *GetEYlowd()  const override {return fEYlowd;}
+   Double_t       *GetEYhighd() const override {return fEYhighd;}
+   void    Print(Option_t *chopt="") const override;
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void    Scale(Double_t c1=1., Option_t *option="y") override; // *MENU*
    virtual void    SetPointError(Double_t exl, Double_t exh,
                                  Double_t eyl, Double_t eyh,
                                  Double_t exld=0, Double_t exhd=0,
@@ -95,7 +95,7 @@ public:
                                  Double_t exld=0, Double_t exhd=0,
                                  Double_t eyld=0, Double_t eyhd=0);
 
-   ClassDef(TGraphBentErrors,1)  //A graph with bent, asymmetric error bars
+   ClassDefOverride(TGraphBentErrors,1)  //A graph with bent, asymmetric error bars
 };
 
 inline Double_t **TGraphBentErrors::Allocate(Int_t size) {

--- a/hist/hist/inc/TGraphDelaunay.h
+++ b/hist/hist/inc/TGraphDelaunay.h
@@ -77,7 +77,7 @@ public:
    TGraphDelaunay();
    TGraphDelaunay(TGraph2D *g);
 
-   virtual ~TGraphDelaunay();
+   ~TGraphDelaunay() override;
 
    Double_t  ComputeZ(Double_t x, Double_t y);
    void      FindAllTriangles();
@@ -97,7 +97,7 @@ public:
    void      SetMaxIter(Int_t n=100000);
    void      SetMarginBinsContent(Double_t z=0.);
 
-   ClassDef(TGraphDelaunay,1)  // Delaunay triangulation
+   ClassDefOverride(TGraphDelaunay,1)  // Delaunay triangulation
 };
 
 #endif

--- a/hist/hist/inc/TGraphDelaunay2D.h
+++ b/hist/hist/inc/TGraphDelaunay2D.h
@@ -65,7 +65,7 @@ public:
    Triangles::const_iterator begin() const { return fDelaunay.begin(); }
    Triangles::const_iterator end()  const { return fDelaunay.end(); }
 
-   ClassDef(TGraphDelaunay2D,1)  // Delaunay triangulation
+   ClassDefOverride(TGraphDelaunay2D,1)  // Delaunay triangulation
 
 private:
 

--- a/hist/hist/inc/TGraphErrors.h
+++ b/hist/hist/inc/TGraphErrors.h
@@ -29,17 +29,17 @@ protected:
    Double_t    *fEX;        ///<[fNpoints] array of X errors
    Double_t    *fEY;        ///<[fNpoints] array of Y errors
 
-   virtual void       SwapPoints(Int_t pos1, Int_t pos2);
+   void       SwapPoints(Int_t pos1, Int_t pos2) override;
 
-   virtual Double_t** Allocate(Int_t size);
-   virtual void       CopyAndRelease(Double_t **newarrays,
-                                     Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
-                                 Int_t obegin);
+   Double_t** Allocate(Int_t size) override;
+   void       CopyAndRelease(Double_t **newarrays,
+                                     Int_t ibegin, Int_t iend, Int_t obegin) override;
+   Bool_t     CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend,
+                                 Int_t obegin) override;
    Bool_t             CtorAllocate();
-   virtual void       FillZero(Int_t begin, Int_t end,
-                               Bool_t from_ctor = kTRUE);
-   virtual Bool_t     DoMerge(const TGraph * g);
+   void       FillZero(Int_t begin, Int_t end,
+                               Bool_t from_ctor = kTRUE) override;
+   Bool_t     DoMerge(const TGraph * g) override;
 
 
 public:
@@ -53,27 +53,27 @@ public:
    TGraphErrors& operator=(const TGraphErrors &gr);
    TGraphErrors(const TH1 *h);
    TGraphErrors(const char *filename, const char *format="%lg %lg %lg %lg", Option_t *option="");
-   virtual ~TGraphErrors();
-   virtual void    Apply(TF1 *f);
+   ~TGraphErrors() override;
+   void    Apply(TF1 *f) override;
    virtual void    ApplyX(TF1 *f);
    static Int_t    CalculateScanfFields(const char *fmt);
-   virtual void    ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
-   Double_t        GetErrorX(Int_t bin)     const;
-   Double_t        GetErrorY(Int_t bin)     const;
-   Double_t        GetErrorXhigh(Int_t bin) const;
-   Double_t        GetErrorXlow(Int_t bin)  const;
-   Double_t        GetErrorYhigh(Int_t bin) const;
-   Double_t        GetErrorYlow(Int_t bin)  const;
-   Double_t       *GetEX() const {return fEX;}
-   Double_t       *GetEY() const {return fEY;}
-   virtual Int_t   Merge(TCollection* list);
-   virtual void    Print(Option_t *chopt="") const;
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void    Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
+   void    ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const override;
+   Double_t        GetErrorX(Int_t bin)     const override;
+   Double_t        GetErrorY(Int_t bin)     const override;
+   Double_t        GetErrorXhigh(Int_t bin) const override;
+   Double_t        GetErrorXlow(Int_t bin)  const override;
+   Double_t        GetErrorYhigh(Int_t bin) const override;
+   Double_t        GetErrorYlow(Int_t bin)  const override;
+   Double_t       *GetEX() const override {return fEX;}
+   Double_t       *GetEY() const override {return fEY;}
+   Int_t   Merge(TCollection* list) override;
+   void    Print(Option_t *chopt="") const override;
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void    Scale(Double_t c1=1., Option_t *option="y") override; // *MENU*
    virtual void    SetPointError(Double_t ex, Double_t ey);  // *MENU
    virtual void    SetPointError(Int_t i, Double_t ex, Double_t ey);
 
-   ClassDef(TGraphErrors,3)  //A graph with error bars
+   ClassDefOverride(TGraphErrors,3)  //A graph with error bars
 };
 
 inline Double_t **TGraphErrors::Allocate(Int_t size) {

--- a/hist/hist/inc/TGraphMultiErrors.h
+++ b/hist/hist/inc/TGraphMultiErrors.h
@@ -41,16 +41,16 @@ protected:
    std::vector<TAttFill> fAttFill;      ///<  The AttFill attributes of the different errors
    std::vector<TAttLine> fAttLine;      ///<  The AttLine attributes of the different errors
 
-   virtual Double_t **Allocate(Int_t size);
+   Double_t **Allocate(Int_t size) override;
    Bool_t CtorAllocate();
 
-   virtual void CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual Bool_t CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend, Int_t obegin);
-   virtual void FillZero(Int_t begin, Int_t end, Bool_t from_ctor = kTRUE);
+   void CopyAndRelease(Double_t **newarrays, Int_t ibegin, Int_t iend, Int_t obegin) override;
+   Bool_t CopyPoints(Double_t **arrays, Int_t ibegin, Int_t iend, Int_t obegin) override;
+   void FillZero(Int_t begin, Int_t end, Bool_t from_ctor = kTRUE) override;
 
    void CalcYErrorsSum() const;
-   virtual Bool_t DoMerge(const TGraph *tg);
-   virtual void SwapPoints(Int_t pos1, Int_t pos2);
+   Bool_t DoMerge(const TGraph *tg) override;
+   void SwapPoints(Int_t pos1, Int_t pos2) override;
 
 public:
    enum ESummationModes {
@@ -117,30 +117,30 @@ public:
    TGraphMultiErrors(const TH1 *th, Int_t ne = 1);
    TGraphMultiErrors(const TH1 *pass, const TH1 *total, Int_t ne = 1, Option_t *option = "");
 
-   virtual ~TGraphMultiErrors();
+   ~TGraphMultiErrors() override;
 
    virtual void AddYError(Int_t np, const Double_t *eyL = nullptr, const Double_t *eyH = nullptr);
-   virtual void Apply(TF1 *f);
+   void Apply(TF1 *f) override;
    virtual void BayesDivide(const TH1 *pass, const TH1 *total, Option_t *opt = "");
    void Divide(const TH1 *pass, const TH1 *total, Option_t *opt = "cp");
-   virtual void ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const;
+   void ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double_t &ymax) const override;
    virtual void DeleteYError(Int_t e);
 
-   virtual Double_t GetErrorX(Int_t i) const;
-   virtual Double_t GetErrorY(Int_t i) const;
+   Double_t GetErrorX(Int_t i) const override;
+   Double_t GetErrorY(Int_t i) const override;
    virtual Double_t GetErrorY(Int_t i, Int_t e) const;
 
-   virtual Double_t GetErrorXlow(Int_t i) const;
-   virtual Double_t GetErrorXhigh(Int_t i) const;
-   virtual Double_t GetErrorYlow(Int_t i) const;
-   virtual Double_t GetErrorYhigh(Int_t i) const;
+   Double_t GetErrorXlow(Int_t i) const override;
+   Double_t GetErrorXhigh(Int_t i) const override;
+   Double_t GetErrorYlow(Int_t i) const override;
+   Double_t GetErrorYhigh(Int_t i) const override;
    virtual Double_t GetErrorYlow(Int_t i, Int_t e) const;
    virtual Double_t GetErrorYhigh(Int_t i, Int_t e) const;
 
-   virtual Double_t *GetEXlow() const { return fExL; }
-   virtual Double_t *GetEXhigh() const { return fExH; }
-   virtual Double_t *GetEYlow() const;
-   virtual Double_t *GetEYhigh() const;
+   Double_t *GetEXlow() const override { return fExL; }
+   Double_t *GetEXhigh() const override { return fExH; }
+   Double_t *GetEYlow() const override;
+   Double_t *GetEYhigh() const override;
    virtual Double_t *GetEYlow(Int_t e);
    virtual Double_t *GetEYhigh(Int_t e);
 
@@ -164,9 +164,9 @@ public:
    Int_t GetSumErrorsMode() const { return fSumErrorsMode; }
    Int_t GetNYErrors() const { return fNYErrors; }
 
-   virtual void Print(Option_t *chopt = "") const;
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
+   void Print(Option_t *chopt = "") const override;
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void Scale(Double_t c1=1., Option_t *option="y") override; // *MENU*
 
    virtual void SetPointError(Double_t exL, Double_t exH, Double_t eyL1, Double_t eyH1, Double_t eyL2 = 0.,
                               Double_t eyH2 = 0., Double_t eyL3 = 0., Double_t eyH3 = 0.); // *MENU*
@@ -209,7 +209,7 @@ public:
    virtual void SetLineStyle(Int_t e, Style_t lstyle);
    virtual void SetLineWidth(Int_t e, Width_t lwidth);
 
-   ClassDef(TGraphMultiErrors, 1) // A Graph with asymmetric error bars and multiple y error dimensions
+   ClassDefOverride(TGraphMultiErrors, 1) // A Graph with asymmetric error bars and multiple y error dimensions
 };
 
 #endif // ROOT_TGraphMultiErrors

--- a/hist/hist/inc/TGraphSmooth.h
+++ b/hist/hist/inc/TGraphSmooth.h
@@ -51,7 +51,7 @@ public :
    TGraphSmooth();
    TGraphSmooth(const char *name);
 //      TGraphSmooth(const TGraphSmooth &smoothReg);   //??
-   virtual ~TGraphSmooth();
+   ~TGraphSmooth() override;
 
    TGraph         *Approx(TGraph *grin, Option_t *option="linear", Int_t nout=50, Double_t *xout=0,
                           Double_t yleft=0, Double_t yright=0, Int_t rule=0, Double_t f=0, Option_t *ties="mean");
@@ -75,7 +75,7 @@ public :
    static void     BDRsmooth(Int_t n, Double_t *x, Double_t *y, Double_t *w,
                              Double_t span, Int_t iper, Double_t vsmlsq, Double_t *smo, Double_t *acvr);
 
-   ClassDef(TGraphSmooth,1) //Graph Smoother
+   ClassDefOverride(TGraphSmooth,1) //Graph Smoother
 };
 
 #endif

--- a/hist/hist/inc/TGraphTime.h
+++ b/hist/hist/inc/TGraphTime.h
@@ -44,16 +44,16 @@ public:
    TGraphTime();
    TGraphTime(Int_t nsteps, Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax);
    TGraphTime(const TGraphTime &gr);
-   virtual ~TGraphTime();
+   ~TGraphTime() override;
 
    virtual Int_t   Add(const TObject *obj, Int_t slot, Option_t *option="");
-   virtual void    Draw(Option_t *chopt="");
+   void    Draw(Option_t *chopt="") override;
    TObjArray      *GetSteps() const {return fSteps;}
-   virtual void    Paint(Option_t *chopt="");
+   void    Paint(Option_t *chopt="") override;
    virtual void    SaveAnimatedGif(const char *filename="") const;
    virtual void    SetSleepTime(Int_t stime=0) {fSleepTime = stime;}
 
-   ClassDef(TGraphTime,1)  //An array of objects evolving with time
+   ClassDefOverride(TGraphTime,1)  //An array of objects evolving with time
 };
 
 #endif

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -183,7 +183,7 @@ public:
    };
 
 
-   virtual ~TH1();
+   ~TH1() override;
 
    virtual Bool_t   Add(TF1 *h1, Double_t c1=1, Option_t *option="");
    virtual Bool_t   Add(const TH1 *h1, Double_t c1=1);
@@ -457,7 +457,7 @@ public:
    TH1C(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins);
    TH1C(const TH1C &h1c);
    TH1C& operator=(const TH1C &h1);
-   virtual ~TH1C();
+   ~TH1C() override;
 
    void     AddBinContent(Int_t bin) override;
    void     AddBinContent(Int_t bin, Double_t w) override;
@@ -498,7 +498,7 @@ public:
    TH1S(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins);
    TH1S(const TH1S &h1s);
    TH1S& operator=(const TH1S &h1);
-   virtual ~TH1S();
+   ~TH1S() override;
 
    void     AddBinContent(Int_t bin) override;
    void     AddBinContent(Int_t bin, Double_t w) override;
@@ -539,7 +539,7 @@ public:
    TH1I(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins);
    TH1I(const TH1I &h1i);
    TH1I& operator=(const TH1I &h1);
-   virtual ~TH1I();
+   ~TH1I() override;
 
    void     AddBinContent(Int_t bin) override;
    void     AddBinContent(Int_t bin, Double_t w) override;
@@ -581,7 +581,7 @@ public:
    explicit TH1F(const TVectorF &v);
    TH1F(const TH1F &h1f);
    TH1F& operator=(const TH1F &h1);
-   virtual ~TH1F();
+   ~TH1F() override;
 
    void     AddBinContent(Int_t bin) override {++fArray[bin];}
    void     AddBinContent(Int_t bin, Double_t w) override
@@ -624,7 +624,7 @@ public:
    explicit TH1D(const TVectorD &v);
    TH1D(const TH1D &h1d);
    TH1D& operator=(const TH1D &h1);
-   virtual ~TH1D();
+   ~TH1D() override;
 
    void     AddBinContent(Int_t bin) override {++fArray[bin];}
    void     AddBinContent(Int_t bin, Double_t w) override

--- a/hist/hist/inc/TH1K.h
+++ b/hist/hist/inc/TH1K.h
@@ -35,27 +35,27 @@ protected:
 public:
    TH1K();
    TH1K(const char *name,const char *title,Int_t nbinsx,Double_t xlow,Double_t xup,Int_t k=0);
-   virtual ~TH1K();
+   ~TH1K() override;
 
-   virtual void      Copy(TObject &obj) const;
-   virtual Int_t     Fill(Double_t x);
-   virtual Int_t     Fill(Double_t x,Double_t w){return TH1::Fill(x,w);}
-   virtual Int_t     Fill(const char *name,Double_t w){return TH1::Fill(name,w);}
-   virtual Double_t  GetBinContent(Int_t bin) const;
-   virtual Double_t  GetBinContent(Int_t bin,Int_t) const {return GetBinContent(bin);}
-   virtual Double_t  GetBinContent(Int_t bin,Int_t,Int_t) const {return GetBinContent(bin);}
+   void      Copy(TObject &obj) const override;
+   Int_t     Fill(Double_t x) override;
+   Int_t     Fill(Double_t x,Double_t w) override{return TH1::Fill(x,w);}
+   Int_t     Fill(const char *name,Double_t w) override{return TH1::Fill(name,w);}
+   Double_t  GetBinContent(Int_t bin) const override;
+   Double_t  GetBinContent(Int_t bin,Int_t) const override {return GetBinContent(bin);}
+   Double_t  GetBinContent(Int_t bin,Int_t,Int_t) const override {return GetBinContent(bin);}
 
-   virtual Double_t  GetBinError(Int_t bin) const;
-   virtual Double_t  GetBinError(Int_t bin,Int_t) const {return GetBinError(bin);}
-   virtual Double_t  GetBinError(Int_t bin,Int_t,Int_t) const {return GetBinError(bin);}
+   Double_t  GetBinError(Int_t bin) const override;
+   Double_t  GetBinError(Int_t bin,Int_t) const override {return GetBinError(bin);}
+   Double_t  GetBinError(Int_t bin,Int_t,Int_t) const override {return GetBinError(bin);}
 
 
-   virtual void      Reset(Option_t *option="");
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
+   void      Reset(Option_t *option="") override;
+   void      SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    void    SetKOrd(Int_t k){fKOrd=k;}
 
-   ClassDef(TH1K,2)  //1-Dim Nearest Kth neighbour method
+   ClassDefOverride(TH1K,2)  //1-Dim Nearest Kth neighbour method
 };
 
 #endif

--- a/hist/hist/inc/TH2Poly.h
+++ b/hist/hist/inc/TH2Poly.h
@@ -27,7 +27,7 @@ class TH2PolyBin: public TObject{
 public:
    TH2PolyBin();
    TH2PolyBin(TObject *poly, Int_t bin_number);
-   virtual ~TH2PolyBin();
+   ~TH2PolyBin() override;
 
    void      ClearContent(){fContent = 0;}
    void      Fill(Double_t w) {fContent = fContent+w; SetChanged(true);}
@@ -55,7 +55,7 @@ protected:
    Double_t  fXmax;      ///< X maximum value
    Double_t  fYmax;      ///< Y maximum value
 
-   ClassDef(TH2PolyBin,1)  //2-Dim polygon bins
+   ClassDefOverride(TH2PolyBin,1)  //2-Dim polygon bins
 };
 
 class TList;
@@ -69,84 +69,84 @@ public:
    TH2Poly();
    TH2Poly(const char *name,const char *title, Double_t xlow, Double_t xup, Double_t ylow, Double_t yup);
    TH2Poly(const char *name,const char *title, Int_t nX, Double_t xlow, Double_t xup,  Int_t nY, Double_t ylow, Double_t yup);
-   virtual ~TH2Poly();
+   ~TH2Poly() override;
 
    virtual TH2PolyBin *CreateBin(TObject *poly);
    virtual Int_t AddBin(TObject *poly);
    Int_t         AddBin(Int_t n, const Double_t *x, const Double_t *y);
    Int_t         AddBin(Double_t x1, Double_t y1, Double_t x2, Double_t  y2);
-   virtual Bool_t Add(const TH1 *h1, Double_t c1);
-   virtual Bool_t Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1);
-   virtual Bool_t Add(TF1 *h1, Double_t c1=1, Option_t *option="");
+   Bool_t Add(const TH1 *h1, Double_t c1) override;
+   Bool_t Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1) override;
+   Bool_t Add(TF1 *h1, Double_t c1=1, Option_t *option="") override;
    void          ClearBinContents();                 // Clears the content of all bins
-   TObject      *Clone(const char* newname = "") const;
+   TObject      *Clone(const char* newname = "") const override;
    void          ChangePartition(Int_t n, Int_t m);  // Sets the number of partition cells to another value
    using TH2::Multiply;
    using TH2::Divide;
    using TH2::Interpolate;
-   virtual Bool_t Divide(TF1 *, Double_t);
-   virtual Bool_t Multiply(TF1 *, Double_t);
-   virtual Double_t ComputeIntegral(Bool_t);
-   virtual TH1 *  FFT(TH1*, Option_t * );
+   Bool_t Divide(TF1 *, Double_t) override;
+   Bool_t Multiply(TF1 *, Double_t) override;
+   Double_t ComputeIntegral(Bool_t) override;
+   TH1 *  FFT(TH1*, Option_t * ) override;
    virtual TH1 *  GetAsymmetry(TH1* , Double_t,  Double_t);
    virtual Double_t Interpolate(Double_t, Double_t);
-   virtual Int_t Fill(Double_t x,Double_t y);
-   virtual Int_t Fill(Double_t x,Double_t y, Double_t w);
-   virtual Int_t Fill(const char* name, Double_t w);
-   void         FillN(Int_t ntimes, const Double_t* x, const Double_t* y, const Double_t* w, Int_t stride = 1);
-   Int_t        FindBin(Double_t x, Double_t y, Double_t z = 0);
+   Int_t Fill(Double_t x,Double_t y) override;
+   Int_t Fill(Double_t x,Double_t y, Double_t w) override;
+   Int_t Fill(const char* name, Double_t w) override;
+   void         FillN(Int_t ntimes, const Double_t* x, const Double_t* y, const Double_t* w, Int_t stride = 1) override;
+   Int_t        FindBin(Double_t x, Double_t y, Double_t z = 0) override;
    TList       *GetBins(){return fBins;} ///< Returns the TList of all bins in the histogram
-   virtual Double_t     GetBinContent(Int_t bin) const;
+   Double_t     GetBinContent(Int_t bin) const override;
    Bool_t       GetBinContentChanged() const{return fBinContentChanged;}
-   virtual Double_t GetBinError(Int_t bin) const;
+   Double_t GetBinError(Int_t bin) const override;
    const char  *GetBinName(Int_t bin) const;
    const char  *GetBinTitle(Int_t bin) const;
    Bool_t       GetFloat(){return fFloat;}
    Double_t     GetMaximum() const;
-   Double_t     GetMaximum(Double_t maxval) const;
+   Double_t     GetMaximum(Double_t maxval) const override;
    Double_t     GetMinimum() const;
-   Double_t     GetMinimum(Double_t minval) const;
+   Double_t     GetMinimum(Double_t minval) const override;
    Bool_t       GetNewBinAdded() const{return fNewBinAdded;}
    Int_t        GetNumberOfBins() const{return fNcells-kNOverflow;}
    void         Honeycomb(Double_t xstart, Double_t ystart, Double_t a, Int_t k, Int_t s);
-   Double_t     Integral(Option_t* option = "") const;
-   Long64_t     Merge(TCollection *);
-   virtual void Reset(Option_t *option);
-   virtual void Scale(Double_t c1 = 1, Option_t* option = "");
-   void         SavePrimitive(std::ostream& out, Option_t* option = "");
-   virtual void SetBinContent(Int_t bin, Double_t content);
-   virtual void SetBinError(Int_t bin, Double_t error);
+   Double_t     Integral(Option_t* option = "") const override;
+   Long64_t     Merge(TCollection *) override;
+   void Reset(Option_t *option) override;
+   void Scale(Double_t c1 = 1, Option_t* option = "") override;
+   void         SavePrimitive(std::ostream& out, Option_t* option = "") override;
+   void SetBinContent(Int_t bin, Double_t content) override;
+   void SetBinError(Int_t bin, Double_t error) override;
    void         SetBinContentChanged(Bool_t flag){fBinContentChanged = flag;}
    void         SetFloat(Bool_t flag = true);
    void         SetNewBinAdded(Bool_t flag){fNewBinAdded = flag;}
    Bool_t       IsInsideBin(Int_t binnr, Double_t x, Double_t y);
-   virtual void GetStats(Double_t *stats) const;
+   void GetStats(Double_t *stats) const override;
 
 
 protected:
 
    //functions not to be used for TH2Poly
 
-   Int_t        Fill(Double_t){return -1;}                              //MayNotUse
-   Int_t        Fill(Double_t , const char *, Double_t){return -1;}     //MayNotUse
-   Int_t        Fill(const char *, Double_t , Double_t ){return -1;}    //MayNotUse
-   Int_t        Fill(const char *, const char *, Double_t ){return -1;} //MayNotUse
-   void         FillN(Int_t, const Double_t*, const Double_t*, Int_t){return;}  //MayNotUse
+   Int_t        Fill(Double_t) override{return -1;}                              //MayNotUse
+   Int_t        Fill(Double_t , const char *, Double_t) override{return -1;}     //MayNotUse
+   Int_t        Fill(const char *, Double_t , Double_t ) override{return -1;}    //MayNotUse
+   Int_t        Fill(const char *, const char *, Double_t ) override{return -1;} //MayNotUse
+   void         FillN(Int_t, const Double_t*, const Double_t*, Int_t) override{return;}  //MayNotUse
 
-   Double_t     Integral(Int_t, Int_t, const Option_t*) const{return 0;}                             //MayNotUse
-   Double_t     Integral(Int_t, Int_t, Int_t, Int_t, const Option_t*) const{return 0;}               //MayNotUse
-   Double_t     Integral(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, const Option_t*) const{return 0;} //MayNotUse
+   Double_t     Integral(Int_t, Int_t, const Option_t*) const override{return 0;}                             //MayNotUse
+   Double_t     Integral(Int_t, Int_t, Int_t, Int_t, const Option_t*) const override{return 0;}               //MayNotUse
+   Double_t     Integral(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, const Option_t*) const override{return 0;} //MayNotUse
 
-   virtual Double_t     GetBinContent(Int_t, Int_t) const {return 0;}           //MayNotUse
-   virtual Double_t     GetBinContent(Int_t, Int_t, Int_t) const {return 0;}    //MayNotUse
+   Double_t     GetBinContent(Int_t, Int_t) const override {return 0;}           //MayNotUse
+   Double_t     GetBinContent(Int_t, Int_t, Int_t) const override {return 0;}    //MayNotUse
 
-   virtual Double_t GetBinError(Int_t , Int_t) const {return 0;}            //MayNotUse
-   virtual Double_t GetBinError(Int_t , Int_t , Int_t) const {return 0;}    //MayNotUse
+   Double_t GetBinError(Int_t , Int_t) const override {return 0;}            //MayNotUse
+   Double_t GetBinError(Int_t , Int_t , Int_t) const override {return 0;}    //MayNotUse
 
-   virtual void         SetBinContent(Int_t, Int_t, Double_t){}           //MayNotUse
-   virtual void         SetBinContent(Int_t, Int_t, Int_t, Double_t){}    //MayNotUse
-   virtual void         SetBinError(Int_t, Int_t, Double_t) {}
-   virtual void         SetBinError(Int_t, Int_t, Int_t, Double_t) {}
+   void         SetBinContent(Int_t, Int_t, Double_t) override{}           //MayNotUse
+   void         SetBinContent(Int_t, Int_t, Int_t, Double_t) override{}    //MayNotUse
+   void         SetBinError(Int_t, Int_t, Double_t) override {}
+   void         SetBinError(Int_t, Int_t, Int_t, Double_t) override {}
 
 
 protected:
@@ -171,14 +171,14 @@ protected:
    Bool_t IsIntersecting(TH2PolyBin *bin, Double_t xclipl, Double_t xclipr, Double_t yclipb, Double_t yclipt);
    Bool_t IsIntersectingPolygon(Int_t bn, Double_t *x, Double_t *y, Double_t xclipl, Double_t xclipr, Double_t yclipb, Double_t yclipt);
    // needed by TH1 - no need to have a separate implementation , but internal ibin=0 is first bin.
-   virtual Double_t RetrieveBinContent(Int_t bin) const {
+   Double_t RetrieveBinContent(Int_t bin) const override {
       return (bin>=kNOverflow) ? GetBinContent(bin-kNOverflow+1) : GetBinContent(-bin-1);
    }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) {
+   void     UpdateBinContent(Int_t bin, Double_t content) override {
       return (bin>=kNOverflow) ? SetBinContent(bin-kNOverflow+1,content) : SetBinContent(-bin-1,content);
    }
 
-   ClassDef(TH2Poly,3)  //2-Dim histogram with polygon bins
+   ClassDefOverride(TH2Poly,3)  //2-Dim histogram with polygon bins
  };
 
 #endif

--- a/hist/hist/inc/THLimitsFinder.h
+++ b/hist/hist/inc/THLimitsFinder.h
@@ -32,7 +32,7 @@ protected:
 
 public:
    THLimitsFinder();
-   virtual ~THLimitsFinder();
+   ~THLimitsFinder() override;
    virtual Int_t      FindGoodLimits(TH1 *h, Double_t xmin, Double_t xmax);
    virtual Int_t      FindGoodLimits(TH1 *h, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax);
    virtual Int_t      FindGoodLimits(TH1 *h, Double_t xmin, Double_t xmax, Double_t ymin, Double_t ymax, Double_t zmin, Double_t zmax);
@@ -43,7 +43,7 @@ public:
    static THLimitsFinder *GetLimitsFinder();
    static  void       SetLimitsFinder(THLimitsFinder *finder);
 
-   ClassDef(THLimitsFinder,0)  //Class to find best axis limits
+   ClassDefOverride(THLimitsFinder,0)  //Class to find best axis limits
 };
 
 #endif

--- a/hist/hist/inc/THStack.h
+++ b/hist/hist/inc/THStack.h
@@ -58,7 +58,7 @@ public:
            Int_t firstbin2 = 1, Int_t lastbin2 = -1,
            Option_t *proj_option = "", Option_t *draw_option = "");
    THStack(const THStack &hstack);
-   virtual ~THStack();
+   ~THStack() override;
    virtual void     Add(TH1 *h, Option_t *option="");
    void             Browse(TBrowser *b)  override;
    Int_t            DistancetoPrimitive(Int_t px, Int_t py) override;

--- a/hist/hist/inc/THn.h
+++ b/hist/hist/inc/THn.h
@@ -31,7 +31,7 @@ class THn: public THnBase {
 
 protected:
    void AllocCoordBuf() const;
-   void InitStorage(Int_t* nbins, Int_t chunkSize);
+   void InitStorage(Int_t* nbins, Int_t chunkSize) override;
 
    THn() = default;
    THn(const char* name, const char* title, Int_t dim, const Int_t* nbins,
@@ -41,7 +41,7 @@ protected:
        const std::vector<std::vector<double>> &xbins);
 
 public:
-   virtual ~THn();
+   ~THn() override;
 
    static THn* CreateHn(const char* name, const char* title, const TH1* h1) {
       return (THn*) CreateHnAny(name, title, h1, kFALSE /*THn*/, -1);
@@ -50,13 +50,13 @@ public:
       return (THn*) CreateHnAny(name, title, hn, kFALSE /*THn*/, -1);
    }
 
-   ROOT::Internal::THnBaseBinIter* CreateIter(Bool_t respectAxisRange) const;
-   Long64_t GetNbins() const { return GetArray().GetNbins(); }
+   ROOT::Internal::THnBaseBinIter* CreateIter(Bool_t respectAxisRange) const override;
+   Long64_t GetNbins() const override { return GetArray().GetNbins(); }
 
-   Long64_t GetBin(const Int_t* idx) const {
+   Long64_t GetBin(const Int_t* idx) const override {
       return GetArray().GetBin(idx);
    }
-   Long64_t GetBin(const Double_t* x) const {
+   Long64_t GetBin(const Double_t* x) const override {
       if (fCoordBuf.empty())
          AllocCoordBuf();
       for (Int_t d = 0; d < fNdimensions; ++d) {
@@ -64,7 +64,7 @@ public:
       }
       return GetArray().GetBin(fCoordBuf.data());
    }
-   Long64_t GetBin(const char* name[]) const {
+   Long64_t GetBin(const char* name[]) const override {
       if (fCoordBuf.empty())
          AllocCoordBuf();
       for (Int_t d = 0; d < fNdimensions; ++d) {
@@ -73,18 +73,18 @@ public:
       return GetArray().GetBin(fCoordBuf.data());
    }
 
-   Long64_t GetBin(const Int_t* idx, Bool_t /*allocate*/ = kTRUE) {
+   Long64_t GetBin(const Int_t* idx, Bool_t /*allocate*/ = kTRUE) override {
       return const_cast<const THn*>(this)->GetBin(idx);
    }
-   Long64_t GetBin(const Double_t* x, Bool_t /*allocate*/ = kTRUE) {
+   Long64_t GetBin(const Double_t* x, Bool_t /*allocate*/ = kTRUE) override {
       return const_cast<const THn*>(this)->GetBin(x);
    }
-   Long64_t GetBin(const char* name[], Bool_t /*allocate*/ = kTRUE) {
+   Long64_t GetBin(const char* name[], Bool_t /*allocate*/ = kTRUE) override {
       return const_cast<const THn*>(this)->GetBin(name);
    }
 
    /// Increment the bin content of "bin" by "w", return the bin index.
-   void FillBin(Long64_t bin, Double_t w) {
+   void FillBin(Long64_t bin, Double_t w) override {
       GetArray().AddAt(bin, w);
       if (GetCalculateErrors()) {
          fSumw2.AddAt(bin, w * w);
@@ -97,10 +97,10 @@ public:
    void SetBinContent(const Int_t* idx, Double_t v) {
       THnBase::SetBinContent(idx, v);
    }
-   void SetBinContent(Long64_t bin, Double_t v) {
+   void SetBinContent(Long64_t bin, Double_t v) override {
       GetArray().SetAsDouble(bin, v);
    }
-   void SetBinError2(Long64_t bin, Double_t e2) {
+   void SetBinError2(Long64_t bin, Double_t e2) override {
       if (!GetCalculateErrors()) Sumw2();
       fSumw2.At(bin) = e2;
    }
@@ -109,10 +109,10 @@ public:
    void AddBinContent(const Int_t* idx, Double_t v = 1.) {
       THnBase::AddBinContent(idx, v);
    }
-   void AddBinContent(Long64_t bin, Double_t v = 1.) {
+   void AddBinContent(Long64_t bin, Double_t v = 1.) override {
       GetArray().AddAt(bin, v);
    }
-   void AddBinError2(Long64_t bin, Double_t e2) {
+   void AddBinError2(Long64_t bin, Double_t e2) override {
       fSumw2.At(bin) += e2;
    }
    /// Forwards to THnBase::GetBinContent() overload.
@@ -121,7 +121,7 @@ public:
       return THnBase::GetBinContent(idx);
    }
    /// Get the content of bin, and set its index if idx is != 0.
-   Double_t GetBinContent(Long64_t bin, Int_t* idx = 0) const {
+   Double_t GetBinContent(Long64_t bin, Int_t* idx = 0) const override {
       if (idx) {
          const TNDArray& arr = GetArray();
          Long64_t prevCellSize = arr.GetNbins();
@@ -133,14 +133,14 @@ public:
       }
       return GetArray().AtAsDouble(bin);
    }
-   Double_t GetBinError2(Long64_t linidx) const {
+   Double_t GetBinError2(Long64_t linidx) const override {
       return GetCalculateErrors() ? fSumw2.At(linidx) : GetBinContent(linidx);
    }
 
    virtual const TNDArray& GetArray() const = 0;
    virtual TNDArray& GetArray() = 0;
 
-   void Sumw2();
+   void Sumw2() override;
 
    /// Forwards to THnBase::Projection().
    /// Non-virtual, as a CINT-compatible replacement of a using declaration.
@@ -174,13 +174,13 @@ public:
       return (THn*) RebinBase(group);
    }
 
-   void Reset(Option_t* option = "");
+   void Reset(Option_t* option = "") override;
 
 protected:
    TNDArrayT<Double_t> fSumw2; // bin error, lazy allocation happens in TNDArrayT
    mutable std::vector<Int_t> fCoordBuf; //! Temporary buffer
 
-   ClassDef(THn, 1); //Base class for multi-dimensional histogram
+   ClassDefOverride(THn, 1); //Base class for multi-dimensional histogram
 };
 
 
@@ -232,12 +232,12 @@ public:
    {
    }
 
-   const TNDArray& GetArray() const { return fArray; }
-   TNDArray& GetArray() { return fArray; }
+   const TNDArray& GetArray() const override { return fArray; }
+   TNDArray& GetArray() override { return fArray; }
 
 protected:
    TNDArrayT<T> fArray; ///< Bin content
-   ClassDef(THnT, 1);   ///< Multi-dimensional histogram with templated storage
+   ClassDefOverride(THnT, 1);   ///< Multi-dimensional histogram with templated storage
 };
 
 typedef THnT<Float_t>  THnF;

--- a/hist/hist/inc/THnBase.h
+++ b/hist/hist/inc/THnBase.h
@@ -123,7 +123,7 @@ protected:
                                Int_t chunkSize = 1024 * 16);
 
  public:
-   virtual ~THnBase();
+   ~THnBase() override;
 
    TObjArray* GetListOfAxes() { return &fAxes; }
    const TObjArray* GetListOfAxes() const { return &fAxes; }
@@ -190,7 +190,7 @@ protected:
    void SetBinError(Long64_t bin, Double_t e) { SetBinError2(bin, e*e); }
    void AddBinContent(const Int_t* x, Double_t v = 1.) { AddBinContent(GetBin(x), v); }
    void SetEntries(Double_t entries) { fEntries = entries; }
-   void SetTitle(const char *title);
+   void SetTitle(const char *title) override;
 
    Double_t GetBinContent(const Int_t *idx) const { return GetBinContent(GetBin(idx)); } // intentionally non-virtual
    virtual Double_t GetBinContent(Long64_t bin, Int_t* idx = 0) const = 0;
@@ -274,19 +274,19 @@ protected:
    Double_t ComputeIntegral();
    void GetRandom(Double_t *rand, Bool_t subBinRandom = kTRUE);
 
-   void Print(Option_t* option = "") const;
+   void Print(Option_t* option = "") const override;
    void PrintEntries(Long64_t from = 0, Long64_t howmany = -1, Option_t* options = 0) const;
    void PrintBin(Int_t* coord, Option_t* options) const {
       PrintBin(-1, coord, options);
    }
    void PrintBin(Long64_t idx, Option_t* options) const;
 
-   void Browse(TBrowser *b);
-   Bool_t IsFolder() const { return kTRUE; }
+   void Browse(TBrowser *b) override;
+   Bool_t IsFolder() const override { return kTRUE; }
 
    //void Draw(Option_t* option = "");
 
-   ClassDef(THnBase, 1); // Common base for n-dimensional histogram
+   ClassDefOverride(THnBase, 1); // Common base for n-dimensional histogram
 
    friend class THnIter;
 };
@@ -297,15 +297,15 @@ namespace Internal {
    class THnBaseBrowsable: public TNamed {
    public:
       THnBaseBrowsable(THnBase* hist, Int_t axis);
-      ~THnBaseBrowsable();
-      void Browse(TBrowser *b);
-      Bool_t IsFolder() const { return kFALSE; }
+      ~THnBaseBrowsable() override;
+      void Browse(TBrowser *b) override;
+      Bool_t IsFolder() const override { return kFALSE; }
 
    private:
       THnBase* fHist; // Original histogram
       Int_t    fAxis; // Axis to visualize
       TH1*     fProj; // Projection result
-      ClassDef(THnBaseBrowsable, 0); // Browser-helper for THnBase
+      ClassDefOverride(THnBaseBrowsable, 0); // Browser-helper for THnBase
    };
 
    // Base class for iterating over THnBase bins
@@ -331,7 +331,7 @@ class THnIter: public TObject {
 public:
    THnIter(const THnBase* hist, Bool_t respectAxisRange = kFALSE):
       fIter(hist->CreateIter(respectAxisRange)) {}
-   virtual ~THnIter();
+   ~THnIter() override;
 
    /// Return the next bin's index.
    /// If provided, set coord to that bin's coordinates (bin indexes).
@@ -347,7 +347,7 @@ public:
 
 private:
    ROOT::Internal::THnBaseBinIter* fIter;
-   ClassDef(THnIter, 0); //Iterator over bins of a THnBase.
+   ClassDefOverride(THnIter, 0); //Iterator over bins of a THnBase.
 };
 
 #endif //  ROOT_THnBase

--- a/hist/hist/inc/THnChain.h
+++ b/hist/hist/inc/THnChain.h
@@ -80,7 +80,7 @@ class THnChain : public TObject
 
    static bool CheckConsistency(const THnBase& h, const std::vector<TAxis*>& axes);
 
-   ClassDef(THnChain, 0);
+   ClassDefOverride(THnChain, 0);
 };
 
 #endif

--- a/hist/hist/inc/THnSparse.h
+++ b/hist/hist/inc/THnSparse.h
@@ -56,22 +56,22 @@ class THnSparse: public THnBase {
       return (THnSparseArrayChunk*) fBinContent[idx]; }
 
    THnSparseArrayChunk* AddChunk();
-   void Reserve(Long64_t nbins);
+   void Reserve(Long64_t nbins) override;
    void FillExMap();
    virtual TArray* GenerateArray() const = 0;
    Long64_t GetBinIndexForCurrentBin(Bool_t allocate);
 
    /// Increment the bin content of "bin" by "w",
    /// return the bin index.
-   void FillBin(Long64_t bin, Double_t w) {
+   void FillBin(Long64_t bin, Double_t w) override {
       THnSparseArrayChunk* chunk = GetChunk(bin / fChunkSize);
       chunk->AddBinContent(bin % fChunkSize, w);
       FillBinBase(w);
    }
-   void InitStorage(Int_t* nbins, Int_t chunkSize);
+   void InitStorage(Int_t* nbins, Int_t chunkSize) override;
 
  public:
-   virtual ~THnSparse();
+   ~THnSparse() override;
 
    static THnSparse* CreateSparse(const char* name, const char* title,
                                   const TH1* h1, Int_t chunkSize = 1024 * 16) {
@@ -87,33 +87,33 @@ class THnSparse: public THnBase {
    Int_t GetChunkSize() const { return fChunkSize; }
    Int_t GetNChunks() const { return fBinContent.GetEntriesFast(); }
 
-   ROOT::Internal::THnBaseBinIter* CreateIter(Bool_t respectAxisRange) const;
+   ROOT::Internal::THnBaseBinIter* CreateIter(Bool_t respectAxisRange) const override;
 
-   Long64_t GetNbins() const { return fFilledBins; }
-   void SetFilledBins(Long64_t nbins) { fFilledBins = nbins; }
+   Long64_t GetNbins() const override { return fFilledBins; }
+   void SetFilledBins(Long64_t nbins) override { fFilledBins = nbins; }
 
-   Long64_t GetBin(const Int_t* idx) const { return const_cast<THnSparse*>(this)->GetBin(idx, kFALSE); }
-   Long64_t GetBin(const Double_t* x) const { return const_cast<THnSparse*>(this)->GetBin(x, kFALSE); }
-   Long64_t GetBin(const char* name[]) const { return const_cast<THnSparse*>(this)->GetBin(name, kFALSE); }
-   Long64_t GetBin(const Int_t* idx, Bool_t allocate = kTRUE);
-   Long64_t GetBin(const Double_t* x, Bool_t allocate = kTRUE);
-   Long64_t GetBin(const char* name[], Bool_t allocate = kTRUE);
+   Long64_t GetBin(const Int_t* idx) const override { return const_cast<THnSparse*>(this)->GetBin(idx, kFALSE); }
+   Long64_t GetBin(const Double_t* x) const override { return const_cast<THnSparse*>(this)->GetBin(x, kFALSE); }
+   Long64_t GetBin(const char* name[]) const override { return const_cast<THnSparse*>(this)->GetBin(name, kFALSE); }
+   Long64_t GetBin(const Int_t* idx, Bool_t allocate = kTRUE) override;
+   Long64_t GetBin(const Double_t* x, Bool_t allocate = kTRUE) override;
+   Long64_t GetBin(const char* name[], Bool_t allocate = kTRUE) override;
 
    /// Forwards to THnBase::SetBinContent().
    /// Non-virtual, CINT-compatible replacement of a using declaration.
    void SetBinContent(const Int_t* idx, Double_t v) {
       THnBase::SetBinContent(idx, v);
    }
-   void SetBinContent(Long64_t bin, Double_t v);
-   void SetBinError2(Long64_t bin, Double_t e2);
+   void SetBinContent(Long64_t bin, Double_t v) override;
+   void SetBinError2(Long64_t bin, Double_t e2) override;
 
    /// Forwards to THnBase::SetBinContent().
    /// Non-virtual, CINT-compatible replacement of a using declaration.
    void AddBinContent(const Int_t* idx, Double_t v = 1.) {
       THnBase::AddBinContent(idx, v);
    }
-   void AddBinContent(Long64_t bin, Double_t v = 1.);
-   void AddBinError2(Long64_t bin, Double_t e2);
+   void AddBinContent(Long64_t bin, Double_t v = 1.) override;
+   void AddBinError2(Long64_t bin, Double_t e2) override;
 
    /// Forwards to THnBase::GetBinContent() overload.
    /// Non-virtual, CINT-compatible replacement of a using declaration.
@@ -121,8 +121,8 @@ class THnSparse: public THnBase {
 
       return THnBase::GetBinContent(idx);
    }
-   Double_t GetBinContent(Long64_t bin, Int_t* idx = 0) const;
-   Double_t GetBinError2(Long64_t linidx) const;
+   Double_t GetBinContent(Long64_t bin, Int_t* idx = 0) const override;
+   Double_t GetBinError2(Long64_t linidx) const override;
 
    Double_t GetSparseFractionBins() const;
    Double_t GetSparseFractionMem() const;
@@ -162,10 +162,10 @@ class THnSparse: public THnBase {
       return (THnSparse*) RebinBase(group);
    }
 
-   void Reset(Option_t* option = "");
-   void Sumw2();
+   void Reset(Option_t* option = "") override;
+   void Sumw2() override;
 
-   ClassDef(THnSparse, 3); // Interfaces of sparse n-dimensional histogram
+   ClassDefOverride(THnSparse, 3); // Interfaces of sparse n-dimensional histogram
 };
 
 
@@ -211,9 +211,9 @@ class THnSparseT: public THnSparse {
               const Double_t* xmax = 0, Int_t chunksize = 1024 * 16):
       THnSparse(name, title, dim, nbins, xmin, xmax, chunksize) {}
 
-   TArray* GenerateArray() const { return new CONT(GetChunkSize()); }
+   TArray* GenerateArray() const override { return new CONT(GetChunkSize()); }
  private:
-   ClassDef(THnSparseT, 1); // Sparse n-dimensional histogram with templated content
+   ClassDefOverride(THnSparseT, 1); // Sparse n-dimensional histogram with templated content
 };
 
 typedef THnSparseT<TArrayD> THnSparseD;

--- a/hist/hist/inc/THnSparse_Internal.h
+++ b/hist/hist/inc/THnSparse_Internal.h
@@ -39,7 +39,7 @@ class THnSparseArrayChunk: public TObject {
       fContent(0), fSumw2(0) {}
 
    THnSparseArrayChunk(Int_t coordsize, bool errors, TArray* cont);
-   virtual ~THnSparseArrayChunk();
+   ~THnSparseArrayChunk() override;
 
    Int_t    fCoordinateAllocationSize; ///<! Size of the allocated coordinate buffer; -1 means none or fCoordinatesSize
    Int_t    fSingleCoordinateSize;     ///<  Size of a single bin coordinate
@@ -64,7 +64,7 @@ class THnSparseArrayChunk: public TObject {
       return fSingleCoordinateSize <= 8 ||
          !memcmp(fCoordinates + idx * fSingleCoordinateSize, idxbuf, fSingleCoordinateSize); }
 
-   ClassDef(THnSparseArrayChunk, 1); // chunks of linearized bins
+   ClassDefOverride(THnSparseArrayChunk, 1); // chunks of linearized bins
 };
 #endif // ROOT_THnSparse_Internal
 

--- a/hist/hist/inc/TKDE.h
+++ b/hist/hist/inc/TKDE.h
@@ -111,7 +111,7 @@ public:
       Instantiate(new ROOT::Math::WrappedFunction<const KernelFunction&>(kernfunc), events, data, dataWeight, xMin, xMax, option, rho);
    }
 
-   virtual ~TKDE();
+   ~TKDE() override;
 
    void Fill(Double_t data);
    void Fill(Double_t data, Double_t weight);
@@ -124,7 +124,7 @@ public:
    void SetTuneFactor(Double_t rho);
    void SetRange(Double_t xMin, Double_t xMax); ///< By default computed from the data
 
-   virtual void Draw(const Option_t* option = "");
+   void Draw(const Option_t* option = "") override;
 
    Double_t operator()(Double_t x) const;
    Double_t operator()(const Double_t* x, const Double_t* p=0) const;  // Needed for creating TF1
@@ -298,7 +298,7 @@ private:
    TF1* GetPDFUpperConfidenceInterval(Double_t confidenceLevel = 0.95, UInt_t npx = 100, Double_t xMin = 1.0, Double_t xMax = 0.0);
    TF1* GetPDFLowerConfidenceInterval(Double_t confidenceLevel = 0.95, UInt_t npx = 100, Double_t xMin = 1.0, Double_t xMax = 0.0);
 
-   ClassDef(TKDE, 3) // One dimensional semi-parametric Kernel Density Estimation
+   ClassDefOverride(TKDE, 3) // One dimensional semi-parametric Kernel Density Estimation
 
 };
 

--- a/hist/hist/inc/TLimitDataSource.h
+++ b/hist/hist/inc/TLimitDataSource.h
@@ -24,7 +24,7 @@ class TH1;
 class TLimitDataSource : public TObject{
 public:
    TLimitDataSource();
-   virtual ~TLimitDataSource() {}
+   ~TLimitDataSource() override {}
    TLimitDataSource(TH1* s,TH1* b,TH1* d);
    TLimitDataSource(TH1* s,TH1* b,TH1* d, TVectorD* es,TVectorD* eb,TObjArray* names);
    virtual void AddChannel(TH1*,TH1*,TH1*);
@@ -53,7 +53,7 @@ private:
    TObjArray fDummyIds;          ///< Array of dummy object (used for bookeeping)
    ///@}
 
-   ClassDef(TLimitDataSource, 2 ) // Input for TLimit routines
+   ClassDefOverride(TLimitDataSource, 2 ) // Input for TLimit routines
 };
 
 #endif

--- a/hist/hist/inc/TMultiDimFit.h
+++ b/hist/hist/inc/TMultiDimFit.h
@@ -125,13 +125,13 @@ public:
    TMultiDimFit(Int_t dimension,
                 EMDFPolyType type=kMonomials,
                 Option_t *option="");
-   virtual ~TMultiDimFit();
+   ~TMultiDimFit() override;
 
    virtual void     AddRow(const Double_t *x, Double_t D, Double_t E=0);
    virtual void     AddTestRow(const Double_t *x, Double_t D, Double_t E=0);
-   virtual void     Browse(TBrowser* b);
-   virtual void     Clear(Option_t *option=""); // *MENU*
-   virtual void     Draw(Option_t * ="d") { }
+   void     Browse(TBrowser* b) override;
+   void     Clear(Option_t *option="") override; // *MENU*
+   void     Draw(Option_t * ="d") override { }
    virtual Double_t Eval(const Double_t *x, const Double_t *coeff=0) const;
    virtual Double_t EvalError(const Double_t *x, const Double_t *coeff=0) const;
    virtual void     FindParameterization(Option_t* option=""); // *MENU*
@@ -185,12 +185,12 @@ public:
    const TVectorD*  GetVariables()         const { return &fVariables; }
 
    static TMultiDimFit* Instance();
-   virtual Bool_t   IsFolder()             const { return kTRUE; }
+   Bool_t   IsFolder()             const override { return kTRUE; }
    virtual Double_t MakeChi2(const Double_t* coeff=0);
    virtual void     MakeCode(const char *functionName="MDF", Option_t *option=""); // *MENU*
    virtual void     MakeHistograms(Option_t* option="A"); // *MENU*
    virtual void     MakeMethod(const Char_t* className="MDF", Option_t* option=""); // *MENU*
-   virtual void     Print(Option_t *option="ps") const; // *MENU*
+   void     Print(Option_t *option="ps") const override; // *MENU*
 
    void             SetBinVarX(Int_t nbbinvarx) {fBinVarX = nbbinvarx;}
    void             SetBinVarY(Int_t nbbinvary) {fBinVarY = nbbinvary;}
@@ -204,7 +204,7 @@ public:
    void             SetPowerLimit(Double_t limit=1e-3);
    virtual void     SetPowers(const Int_t *powers, Int_t terms);
 
-   ClassDef(TMultiDimFit,2) // Multi dimensional fit class
+   ClassDefOverride(TMultiDimFit,2) // Multi dimensional fit class
 }
 ;
 #endif

--- a/hist/hist/inc/TMultiGraph.h
+++ b/hist/hist/inc/TMultiGraph.h
@@ -46,7 +46,7 @@ protected:
 public:
    TMultiGraph();
    TMultiGraph(const char *name, const char *title);
-   virtual ~TMultiGraph();
+   ~TMultiGraph() override;
 
    virtual void      Add(TGraph *graph, Option_t *chopt = "");
    virtual void      Add(TMultiGraph *multigraph, Option_t *chopt = "");

--- a/hist/hist/inc/TNDArray.h
+++ b/hist/hist/inc/TNDArray.h
@@ -84,7 +84,7 @@ public:
 
 protected:
    std::vector<Long64_t> fSizes; ///< bin count
-   ClassDef(TNDArray, 2);        ///< Base for n-dimensional array
+   ClassDefOverride(TNDArray, 2);        ///< Base for n-dimensional array
 };
 
 template <typename T>
@@ -117,12 +117,12 @@ public:
 
    TNDArrayT(Int_t ndim, const Int_t *nbins, bool addOverflow = false) : TNDArray(ndim, nbins, addOverflow), fData() {}
 
-   void Init(Int_t ndim, const Int_t* nbins, bool addOverflow = false) {
+   void Init(Int_t ndim, const Int_t* nbins, bool addOverflow = false) override {
       fData.clear();
       TNDArray::Init(ndim, nbins, addOverflow);
    }
 
-   void Reset(Option_t* /*option*/ = "") {
+   void Reset(Option_t* /*option*/ = "") override {
       // Reset the content
       fData.assign(fSizes[0], T());
    }
@@ -152,17 +152,17 @@ public:
       return fData[linidx];
    }
 
-   Double_t AtAsDouble(ULong64_t linidx) const {
+   Double_t AtAsDouble(ULong64_t linidx) const override {
       if (fData.empty())
          return 0.;
       return fData[linidx];
    }
-   void SetAsDouble(ULong64_t linidx, Double_t value) {
+   void SetAsDouble(ULong64_t linidx, Double_t value) override {
       if (fData.empty())
          fData.resize(fSizes[0], T());
       fData[linidx] = (T) value;
    }
-   void AddAt(ULong64_t linidx, Double_t value) {
+   void AddAt(ULong64_t linidx, Double_t value) override {
       if (fData.empty())
          fData.resize(fSizes[0], T());
       fData[linidx] += (T) value;
@@ -170,7 +170,7 @@ public:
 
 protected:
    std::vector<T> fData;   // data
-   ClassDef(TNDArrayT, 2); // N-dimensional array
+   ClassDefOverride(TNDArrayT, 2); // N-dimensional array
 };
 
 // FIXME: Remove once we implement https://sft.its.cern.ch/jira/browse/ROOT-6284

--- a/hist/hist/inc/TPolyMarker.h
+++ b/hist/hist/inc/TPolyMarker.h
@@ -44,23 +44,23 @@ public:
    TPolyMarker(Int_t n, Float_t *x, Float_t *y, Option_t *option="");
    TPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
    TPolyMarker(const TPolyMarker &polymarker);
-   virtual ~TPolyMarker();
-   virtual void     Copy(TObject &polymarker) const;
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *option="");
+   ~TPolyMarker() override;
+   void     Copy(TObject &polymarker) const override;
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     Draw(Option_t *option="") override;
    virtual void     DrawPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Int_t    GetLastPoint() const { return fLastPoint;}
    virtual Int_t    GetN() const {return fN;}
-   Option_t        *GetOption() const {return fOption.Data();}
+   Option_t        *GetOption() const override {return fOption.Data();}
    Double_t        *GetX() const {return fX;}
    Double_t        *GetY() const {return fY;}
-   virtual void     ls(Option_t *option="") const;
+   void     ls(Option_t *option="") const override;
    virtual Int_t    Merge(TCollection *list);
-   virtual void     Paint(Option_t *option="");
+   void     Paint(Option_t *option="") override;
    virtual void     PaintPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
-   virtual void     Print(Option_t *option="") const;
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void     Print(Option_t *option="") const override;
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual Int_t    SetNextPoint(Double_t x, Double_t y); // *MENU*
    virtual void     SetPoint(Int_t point, Double_t x, Double_t y); // *MENU*
    virtual void     SetPolyMarker(Int_t n);
@@ -68,7 +68,7 @@ public:
    virtual void     SetPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
    virtual Int_t    Size() const {return fLastPoint+1;}
 
-   ClassDef(TPolyMarker,4)  //An array of points with the same marker
+   ClassDefOverride(TPolyMarker,4)  //An array of points with the same marker
 };
 
 #endif

--- a/hist/hist/inc/TPrincipal.h
+++ b/hist/hist/inc/TPrincipal.h
@@ -50,12 +50,12 @@ protected:
 
 public:
    TPrincipal();
-   virtual ~TPrincipal();
+   ~TPrincipal() override;
    TPrincipal(Int_t nVariables, Option_t *opt="ND");
 
    virtual void       AddRow(const Double_t *x);
-   virtual void       Browse(TBrowser *b);
-   virtual void       Clear(Option_t *option="");
+   void       Browse(TBrowser *b) override;
+   void       Clear(Option_t *option="") override;
    const TMatrixD    *GetCovarianceMatrix() const {return &fCovarianceMatrix;}
    const TVectorD    *GetEigenValues() const      {return &fEigenValues;}
    const TMatrixD    *GetEigenVectors() const     {return &fEigenVectors;}
@@ -64,18 +64,18 @@ public:
    const Double_t    *GetRow(Int_t row);
    const TVectorD    *GetSigmas() const           {return &fSigmas;}
    const TVectorD    *GetUserData() const         {return &fUserData;}
-   Bool_t             IsFolder() const { return kTRUE;}
+   Bool_t             IsFolder() const override { return kTRUE;}
    virtual void       MakeCode(const char *filename ="pca", Option_t *option="");  // *MENU*
    virtual void       MakeHistograms(const char *name = "pca", Option_t *option="epsdx"); // *MENU*
    virtual void       MakeMethods(const char *classname = "PCA", Option_t *option=""); // *MENU*
    virtual void       MakePrincipals();            // *MENU*
    virtual void       P2X(const Double_t *p, Double_t *x, Int_t nTest);
-   virtual void       Print(Option_t *opt="MSE") const;         // *MENU*
+   void       Print(Option_t *opt="MSE") const override;         // *MENU*
    virtual void       SumOfSquareResiduals(const Double_t *x, Double_t *s);
    void               Test(Option_t *option="");       // *MENU*
    virtual void       X2P(const Double_t *x, Double_t *p);
 
-   ClassDef(TPrincipal,2) // Principal Components Analysis
+   ClassDefOverride(TPrincipal,2) // Principal Components Analysis
 }
 ;
 

--- a/hist/hist/inc/TProfile.h
+++ b/hist/hist/inc/TProfile.h
@@ -47,31 +47,31 @@ protected:
 
    static Bool_t fgApproximate; ///< bin error approximation option
 
-   virtual Int_t    BufferFill(Double_t, Double_t) {return -2;} //may not use
+   Int_t    BufferFill(Double_t, Double_t) override {return -2;} //may not use
    virtual Int_t    BufferFill(Double_t x, Double_t y, Double_t w);
 
    // helper methods for the Merge unification in TProfileHelper
    void SetBins(const Int_t* nbins, const Double_t* range) { SetBins(nbins[0], range[0], range[1]); };
    Int_t Fill(const Double_t* v) { return Fill(v[0], v[1], v[2]); };
 
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return (fBinEntries.fArray[bin] > 0) ? fArray[bin]/fBinEntries.fArray[bin] : 0; }
+   Double_t RetrieveBinContent(Int_t bin) const override { return (fBinEntries.fArray[bin] > 0) ? fArray[bin]/fBinEntries.fArray[bin] : 0; }
    //virtual void     UpdateBinContent(Int_t bin, Double_t content);
-   virtual Double_t GetBinErrorSqUnchecked(Int_t bin) const { Double_t err = GetBinError(bin); return err*err; }
+   Double_t GetBinErrorSqUnchecked(Int_t bin) const override { Double_t err = GetBinError(bin); return err*err; }
 
 private:
-   Int_t Fill(Double_t) { MayNotUse("Fill(Double_t)"); return -1;}
-   void FillN(Int_t, const Double_t *, const Double_t *, Int_t) { MayNotUse("FillN(Int_t, Double_t*, Double_t*, Int_t)"); }
+   Int_t Fill(Double_t) override { MayNotUse("Fill(Double_t)"); return -1;}
+   void FillN(Int_t, const Double_t *, const Double_t *, Int_t) override { MayNotUse("FillN(Int_t, Double_t*, Double_t*, Int_t)"); }
    Double_t *GetB()  {return &fBinEntries.fArray[0];}
    Double_t *GetB2() {return (fBinSumw2.fN ? &fBinSumw2.fArray[0] : 0 ); }
    Double_t *GetW()  {return &fArray[0];}
    Double_t *GetW2() {return &fSumw2.fArray[0];}
-   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t)
+   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t) override
       { MayNotUse("SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t"); }
-   void SetBins(Int_t, const Double_t*, Int_t, const Double_t*)
+   void SetBins(Int_t, const Double_t*, Int_t, const Double_t*) override
       { MayNotUse("SetBins(Int_t, const Double_t*, Int_t, const Double_t*"); }
-   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t, Int_t, Double_t, Double_t)
+   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t, Int_t, Double_t, Double_t) override
       { MayNotUse("SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t, Int_t, Double_t, Double_t"); }
-   void SetBins(Int_t, const Double_t *, Int_t, const Double_t *, Int_t, const Double_t *)
+   void SetBins(Int_t, const Double_t *, Int_t, const Double_t *, Int_t, const Double_t *) override
       { MayNotUse("SetBins(Int_t, const Double_t*, Int_t, const Double_t*, Int_t, const Double_t*"); }
 
 public:
@@ -83,59 +83,59 @@ public:
    TProfile(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins, Double_t ylow,Double_t yup, Option_t *option="");
    TProfile(const TProfile &profile);
    TProfile &operator=(const TProfile &profile);
-   virtual ~TProfile();
-   virtual Bool_t   Add(TF1 *h1, Double_t c1=1, Option_t *option="");
-   virtual Bool_t   Add(const TH1 *h1, Double_t c1=1);
-   virtual Bool_t   Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1); // *MENU*
+   ~TProfile() override;
+   Bool_t   Add(TF1 *h1, Double_t c1=1, Option_t *option="") override;
+   Bool_t   Add(const TH1 *h1, Double_t c1=1) override;
+   Bool_t   Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1) override; // *MENU*
    static  void     Approximate(Bool_t approx=kTRUE);
-   virtual Int_t    BufferEmpty(Int_t action=0);
+   Int_t    BufferEmpty(Int_t action=0) override;
            void     BuildOptions(Double_t ymin, Double_t ymax, Option_t *option);
-   virtual void     Copy(TObject &hnew) const;
-   virtual Bool_t   Divide(TF1 *h1, Double_t c1=1);
-   virtual Bool_t   Divide(const TH1 *h1);
-   virtual Bool_t   Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
-   virtual void     ExtendAxis(Double_t x, TAxis *axis);
-   virtual Int_t    Fill(Double_t x, Double_t y);
-   virtual Int_t    Fill(const char *namex, Double_t y);
+   void     Copy(TObject &hnew) const override;
+   Bool_t   Divide(TF1 *h1, Double_t c1=1) override;
+   Bool_t   Divide(const TH1 *h1) override;
+   Bool_t   Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override; // *MENU*
+   void     ExtendAxis(Double_t x, TAxis *axis) override;
+   Int_t    Fill(Double_t x, Double_t y) override;
+   Int_t    Fill(const char *namex, Double_t y) override;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t w);
    virtual Int_t    Fill(const char *namex, Double_t y, Double_t w);
-   virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride=1);
-   virtual Double_t GetBinContent(Int_t bin) const;
-   virtual Double_t GetBinContent(Int_t bin, Int_t) const {return GetBinContent(bin);}
-   virtual Double_t GetBinContent(Int_t bin, Int_t, Int_t) const {return GetBinContent(bin);}
-   virtual Double_t GetBinError(Int_t bin) const;
-   virtual Double_t GetBinError(Int_t bin, Int_t) const {return GetBinError(bin);}
-   virtual Double_t GetBinError(Int_t bin, Int_t, Int_t) const {return GetBinError(bin);}
+   void     FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride=1) override;
+   Double_t GetBinContent(Int_t bin) const override;
+   Double_t GetBinContent(Int_t bin, Int_t) const override {return GetBinContent(bin);}
+   Double_t GetBinContent(Int_t bin, Int_t, Int_t) const override {return GetBinContent(bin);}
+   Double_t GetBinError(Int_t bin) const override;
+   Double_t GetBinError(Int_t bin, Int_t) const override {return GetBinError(bin);}
+   Double_t GetBinError(Int_t bin, Int_t, Int_t) const override {return GetBinError(bin);}
    virtual Double_t GetBinEntries(Int_t bin) const;
    virtual Double_t GetBinEffectiveEntries(Int_t bin) const;
    virtual TArrayD *GetBinSumw2() {return &fBinSumw2;}
    virtual const TArrayD *GetBinSumw2() const {return &fBinSumw2;}
    Option_t        *GetErrorOption() const;
-   virtual void     GetStats(Double_t *stats) const;
+   void     GetStats(Double_t *stats) const override;
    virtual Double_t GetYmin() const {return fYmin;}
    virtual Double_t GetYmax() const {return fYmax;}
-   virtual void     LabelsDeflate(Option_t *axis="X");
-   virtual void     LabelsInflate(Option_t *axis="X");
-   virtual void     LabelsOption(Option_t *option="h", Option_t *axis="X");
-   virtual Long64_t Merge(TCollection *list);
-   virtual Bool_t   Multiply(TF1 *h1, Double_t c1=1);
-   virtual Bool_t   Multiply(const TH1 *h1);
-   virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
+   void     LabelsDeflate(Option_t *axis="X") override;
+   void     LabelsInflate(Option_t *axis="X") override;
+   void     LabelsOption(Option_t *option="h", Option_t *axis="X") override;
+   Long64_t Merge(TCollection *list) override;
+   Bool_t   Multiply(TF1 *h1, Double_t c1=1) override;
+   Bool_t   Multiply(const TH1 *h1) override;
+   Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override; // *MENU*
            TH1D    *ProjectionX(const char *name="_px", Option_t *option="e") const;
-   virtual void     PutStats(Double_t *stats);
-           TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);
-   virtual void     Reset(Option_t *option="");
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void     Scale(Double_t c1=1, Option_t *option="");
+   void     PutStats(Double_t *stats) override;
+           TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0) override;
+   void     Reset(Option_t *option="") override;
+   void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void     Scale(Double_t c1=1, Option_t *option="") override;
    virtual void     SetBinEntries(Int_t bin, Double_t w);
-   virtual void     SetBins(Int_t nbins, Double_t xmin, Double_t xmax);
-   virtual void     SetBins(Int_t nx, const Double_t *xbins);
-   virtual void     SetBinsLength(Int_t n=-1);
-   virtual void     SetBuffer(Int_t buffersize, Option_t *option="");
+   void     SetBins(Int_t nbins, Double_t xmin, Double_t xmax) override;
+   void     SetBins(Int_t nx, const Double_t *xbins) override;
+   void     SetBinsLength(Int_t n=-1) override;
+   void     SetBuffer(Int_t buffersize, Option_t *option="") override;
    virtual void     SetErrorOption(Option_t *option=""); // *MENU*
-   virtual void     Sumw2(Bool_t flag = kTRUE);
+   void     Sumw2(Bool_t flag = kTRUE) override;
 
-   ClassDef(TProfile,7)  //Profile histogram class
+   ClassDefOverride(TProfile,7)  //Profile histogram class
 };
 
 #endif

--- a/hist/hist/inc/TProfile2D.h
+++ b/hist/hist/inc/TProfile2D.h
@@ -41,8 +41,8 @@ protected:
    TArrayD     fBinSumw2;         ///< Array of sum of squares of weights per bin
    static Bool_t   fgApproximate; ///< Bin error approximation option
 
-   virtual Int_t    BufferFill(Double_t, Double_t) {return -2;} //may not use
-   virtual Int_t    BufferFill(Double_t, Double_t, Double_t) {return -2;} //may not use
+   Int_t    BufferFill(Double_t, Double_t) override {return -2;} //may not use
+   Int_t    BufferFill(Double_t, Double_t, Double_t) override {return -2;} //may not use
    virtual Int_t    BufferFill(Double_t x, Double_t y, Double_t z, Double_t w);
 
    // helper methods for the Merge unification in TProfileHelper
@@ -50,27 +50,27 @@ protected:
                                                                      nbins[1], range[2], range[3]); };
    Int_t Fill(const Double_t* v) { return Fill(v[0], v[1], v[2], v[3]); };
 
-   virtual TProfile *DoProfile(bool onX, const char *name, Int_t firstbin, Int_t lastbin, Option_t *option) const;
+   TProfile *DoProfile(bool onX, const char *name, Int_t firstbin, Int_t lastbin, Option_t *option) const override;
 
    using TH2::Fill;
-   Int_t             Fill(Double_t, Double_t) {return TH2::Fill(0); } //MayNotUse
+   Int_t             Fill(Double_t, Double_t) override {return TH2::Fill(0); } //MayNotUse
 
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return (fBinEntries.fArray[bin] > 0) ? fArray[bin]/fBinEntries.fArray[bin] : 0; }
+   Double_t RetrieveBinContent(Int_t bin) const override { return (fBinEntries.fArray[bin] > 0) ? fArray[bin]/fBinEntries.fArray[bin] : 0; }
    //virtual void     UpdateBinContent(Int_t bin, Double_t content);
-   virtual Double_t GetBinErrorSqUnchecked(Int_t bin) const { Double_t err = GetBinError(bin); return err*err; }
+   Double_t GetBinErrorSqUnchecked(Int_t bin) const override { Double_t err = GetBinError(bin); return err*err; }
 
 private:
    Double_t *GetB()  {return &fBinEntries.fArray[0];}
    Double_t *GetB2() {return (fBinSumw2.fN ? &fBinSumw2.fArray[0] : 0 ); }
    Double_t *GetW()  {return &fArray[0];}
    Double_t *GetW2() {return &fSumw2.fArray[0];}
-   void  SetBins(Int_t, Double_t, Double_t)
+   void  SetBins(Int_t, Double_t, Double_t) override
       { MayNotUse("SetBins(Int_t, Double_t, Double_t"); }
-   void  SetBins(Int_t, const Double_t*)
+   void  SetBins(Int_t, const Double_t*) override
       { MayNotUse("SetBins(Int_t, const Double_t*"); }
-   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t, Int_t, Double_t, Double_t)
+   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t, Int_t, Double_t, Double_t) override
       { MayNotUse("SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t, Int_t, Double_t, Double_t"); }
-   void SetBins(Int_t, const Double_t *, Int_t, const Double_t *, Int_t, const Double_t *)
+   void SetBins(Int_t, const Double_t *, Int_t, const Double_t *, Int_t, const Double_t *) override
       { MayNotUse("SetBins(Int_t, const Double_t*, Int_t, const Double_t*, Int_t, const Double_t*"); }
 
 public:
@@ -88,64 +88,64 @@ public:
                                ,Int_t nbinsy,const Double_t *ybins,Option_t *option="");
    TProfile2D(const TProfile2D &profile);
    TProfile2D &operator=(const TProfile2D &profile);
-   virtual ~TProfile2D();
-   virtual Bool_t    Add(TF1 *h1, Double_t c1=1, Option_t *option="");
-   virtual Bool_t    Add(const TH1 *h1, Double_t c1=1);
-   virtual Bool_t    Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1); // *MENU*
+   ~TProfile2D() override;
+   Bool_t    Add(TF1 *h1, Double_t c1=1, Option_t *option="") override;
+   Bool_t    Add(const TH1 *h1, Double_t c1=1) override;
+   Bool_t    Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1) override; // *MENU*
    static  void      Approximate(Bool_t approx=kTRUE);
    void              BuildOptions(Double_t zmin, Double_t zmax, Option_t *option);
-   virtual Int_t     BufferEmpty(Int_t action=0);
-   virtual void      Copy(TObject &hnew) const;
-   virtual Bool_t    Divide(TF1 *h1, Double_t c1=1);
-   virtual Bool_t    Divide(const TH1 *h1);
-   virtual Bool_t    Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
-   virtual void      ExtendAxis(Double_t x, TAxis *axis);
-   Int_t             Fill(Double_t x, Double_t y, Double_t z);
+   Int_t     BufferEmpty(Int_t action=0) override;
+   void      Copy(TObject &hnew) const override;
+   Bool_t    Divide(TF1 *h1, Double_t c1=1) override;
+   Bool_t    Divide(const TH1 *h1) override;
+   Bool_t    Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override; // *MENU*
+   void      ExtendAxis(Double_t x, TAxis *axis) override;
+   Int_t             Fill(Double_t x, Double_t y, Double_t z) override;
    virtual Int_t     Fill(Double_t x, const char *namey, Double_t z, Double_t w = 1.);
    virtual Int_t     Fill(const char *namex, Double_t y, Double_t z, Double_t w = 1.);
    virtual Int_t     Fill(const char *namex, const char *namey, Double_t z, Double_t w = 1.);
    virtual Int_t     Fill(Double_t x, Double_t y, Double_t z, Double_t w);
-   virtual Double_t  GetBinContent(Int_t bin) const;
-   virtual Double_t  GetBinContent(Int_t binx, Int_t biny) const {return GetBinContent(GetBin(binx,biny));}
-   virtual Double_t  GetBinContent(Int_t binx, Int_t biny, Int_t) const {return GetBinContent(GetBin(binx,biny));}
-   virtual Double_t  GetBinError(Int_t bin) const;
-   virtual Double_t  GetBinError(Int_t binx, Int_t biny) const {return GetBinError(GetBin(binx,biny));}
-   virtual Double_t  GetBinError(Int_t binx, Int_t biny, Int_t) const {return GetBinError(GetBin(binx,biny));}
+   Double_t  GetBinContent(Int_t bin) const override;
+   Double_t  GetBinContent(Int_t binx, Int_t biny) const override {return GetBinContent(GetBin(binx,biny));}
+   Double_t  GetBinContent(Int_t binx, Int_t biny, Int_t) const override {return GetBinContent(GetBin(binx,biny));}
+   Double_t  GetBinError(Int_t bin) const override;
+   Double_t  GetBinError(Int_t binx, Int_t biny) const override {return GetBinError(GetBin(binx,biny));}
+   Double_t  GetBinError(Int_t binx, Int_t biny, Int_t) const override {return GetBinError(GetBin(binx,biny));}
    virtual Double_t  GetBinEntries(Int_t bin) const;
    virtual Double_t  GetBinEffectiveEntries(Int_t bin);
    virtual TArrayD *GetBinSumw2() {return &fBinSumw2;}
    virtual const TArrayD *GetBinSumw2() const {return &fBinSumw2;}
    Option_t         *GetErrorOption() const;
-   virtual void      GetStats(Double_t *stats) const;
+   void      GetStats(Double_t *stats) const override;
    virtual Double_t  GetZmin() const {return fZmin;}
    virtual Double_t  GetZmax() const {return fZmax;}
-   virtual void      LabelsDeflate(Option_t *axis="X");
-   virtual void      LabelsInflate(Option_t *axis="X");
-   virtual void      LabelsOption(Option_t *option="h", Option_t *axis="X");
-   virtual Long64_t  Merge(TCollection *list);
-   virtual Bool_t    Multiply(TF1 *h1, Double_t c1=1);
-   virtual Bool_t    Multiply(const TH1 *h1);
-   virtual Bool_t    Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
+   void      LabelsDeflate(Option_t *axis="X") override;
+   void      LabelsInflate(Option_t *axis="X") override;
+   void      LabelsOption(Option_t *option="h", Option_t *axis="X") override;
+   Long64_t  Merge(TCollection *list) override;
+   Bool_t    Multiply(TF1 *h1, Double_t c1=1) override;
+   Bool_t    Multiply(const TH1 *h1) override;
+   Bool_t    Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override; // *MENU*
    TH2D             *ProjectionXY(const char *name="_pxy", Option_t *option="e") const;
    TProfile         *ProfileX(const char *name="_pfx", Int_t firstybin=0, Int_t lastybin=-1, Option_t *option="") const;   // *MENU*
    TProfile         *ProfileY(const char *name="_pfy", Int_t firstxbin=0, Int_t lastxbin=-1, Option_t *option="") const;   // *MENU*
-   virtual void      PutStats(Double_t *stats);
-   virtual void      Reset(Option_t *option="");
-   virtual TProfile2D *Rebin2D(Int_t nxgroup=2, Int_t nygroup=2, const char *newname="");
-   virtual TProfile2D *RebinX(Int_t ngroup=2, const char *newname="");
-   virtual TProfile2D *RebinY(Int_t ngroup=2, const char *newname="");
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void      Scale(Double_t c1=1, Option_t *option="");
+   void      PutStats(Double_t *stats) override;
+   void      Reset(Option_t *option="") override;
+   TProfile2D *Rebin2D(Int_t nxgroup=2, Int_t nygroup=2, const char *newname="") override;
+   TProfile2D *RebinX(Int_t ngroup=2, const char *newname="") override;
+   TProfile2D *RebinY(Int_t ngroup=2, const char *newname="") override;
+   void      SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void      Scale(Double_t c1=1, Option_t *option="") override;
    virtual void      SetBinEntries(Int_t bin, Double_t w);
-   virtual void      SetBins(Int_t nbinsx, Double_t xmin, Double_t xmax, Int_t nbinsy, Double_t ymin, Double_t ymax);
-   virtual void      SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t *yBins);
-   virtual void      SetBinsLength(Int_t n=-1);
-   virtual void      SetBuffer(Int_t buffersize, Option_t *option="");
+   void      SetBins(Int_t nbinsx, Double_t xmin, Double_t xmax, Int_t nbinsy, Double_t ymin, Double_t ymax) override;
+   void      SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t *yBins) override;
+   void      SetBinsLength(Int_t n=-1) override;
+   void      SetBuffer(Int_t buffersize, Option_t *option="") override;
    virtual void      SetErrorOption(Option_t *option=""); // *MENU*
-   virtual void      Sumw2(Bool_t flag = kTRUE);
+   void      Sumw2(Bool_t flag = kTRUE) override;
    Double_t GetNumberOfBins() { return fBinEntries.GetSize(); }
 
-   ClassDef(TProfile2D,8)  //Profile2D histogram class
+   ClassDefOverride(TProfile2D,8)  //Profile2D histogram class
 };
 
 #endif

--- a/hist/hist/inc/TProfile2Poly.h
+++ b/hist/hist/inc/TProfile2Poly.h
@@ -22,7 +22,7 @@ public:
 
    TProfile2PolyBin();
    TProfile2PolyBin(TObject *poly, Int_t bin_number);
-   virtual ~TProfile2PolyBin() {}
+   ~TProfile2PolyBin() override {}
 
    void Merge(const TProfile2PolyBin *toMerge);
 
@@ -52,7 +52,7 @@ protected:
    void UpdateError();
    void SetErrorOption(EErrorType type) { fErrorMode = type; }
 
-   ClassDef(TProfile2PolyBin, 1)
+   ClassDefOverride(TProfile2PolyBin, 1)
 };
 
 class TProfile2Poly : public TH2Poly {
@@ -65,15 +65,15 @@ public:
    TProfile2Poly(const char *name, const char *title, Double_t xlow, Double_t xup, Double_t ylow, Double_t yup);
    TProfile2Poly(const char *name, const char *title, Int_t nX, Double_t xlow, Double_t xup, Int_t nY, Double_t ylow,
                  Double_t yup);
-   virtual ~TProfile2Poly() {}
+   ~TProfile2Poly() override {}
 
    using TH2Poly::Fill;
-   virtual Int_t Fill(Double_t xcoord, Double_t ycoord, Double_t value) override;
+   Int_t Fill(Double_t xcoord, Double_t ycoord, Double_t value) override;
    virtual Int_t Fill(Double_t xcoord, Double_t ycoord, Double_t value, Double_t weight);
 
    Long64_t Merge(const std::vector<TProfile2Poly *> &list);
    Long64_t Merge(TCollection *in) override;
-   virtual void Reset(Option_t *option = "") override;
+   void Reset(Option_t *option = "") override;
 
    // option to display different measures on bins
    void SetContentToAverage(); // this one is used by default
@@ -88,12 +88,12 @@ public:
    Double_t GetBinEntriesWV2(Int_t bin) const;
 
    using TH2Poly::GetBinContent;
-   virtual Double_t GetBinContent(Int_t bin) const override;
+   Double_t GetBinContent(Int_t bin) const override;
 
    using TH2Poly::GetBinError;
-   virtual Double_t GetBinError(Int_t bin) const override;
+   Double_t GetBinError(Int_t bin) const override;
 
-   virtual void GetStats(Double_t *stats) const override;
+   void GetStats(Double_t *stats) const override;
 
 
    Double_t GetOverflowContent(Int_t idx) { return fOverflowBins[idx].fSumw; }
@@ -106,7 +106,7 @@ private:
    Double_t fTsumwz2;
 
 protected:
-   virtual TProfile2PolyBin *CreateBin(TObject *poly) override;
+   TProfile2PolyBin *CreateBin(TObject *poly) override;
 
    Int_t GetOverflowRegionFromCoordinates(Double_t x, Double_t y);
    Int_t OverflowIdxToArrayIdx(Int_t val) { return -val - 1; }

--- a/hist/hist/inc/TProfile3D.h
+++ b/hist/hist/inc/TProfile3D.h
@@ -41,9 +41,9 @@ protected:
    TArrayD       fBinSumw2;        ///< Array of sum of squares of weights per bin
    static Bool_t fgApproximate;    ///< Bin error approximation option
 
-   virtual Int_t    BufferFill(Double_t, Double_t) {return -2;} //may not use
-   virtual Int_t    BufferFill(Double_t, Double_t, Double_t) {return -2;} //may not use
-   virtual Int_t    BufferFill(Double_t, Double_t, Double_t, Double_t) {return -2;} //may not use
+   Int_t    BufferFill(Double_t, Double_t) override {return -2;} //may not use
+   Int_t    BufferFill(Double_t, Double_t, Double_t) override {return -2;} //may not use
+   Int_t    BufferFill(Double_t, Double_t, Double_t, Double_t) override {return -2;} //may not use
    virtual Int_t    BufferFill(Double_t x, Double_t y, Double_t z, Double_t t, Double_t w);
 
    // helper methods for the Merge unification in TProfileHelper
@@ -54,33 +54,33 @@ protected:
 
 
    using TH3::Fill;
-   Int_t             Fill(Double_t, Double_t,Double_t) {return TH3::Fill(0); } //MayNotUse
-   Int_t             Fill(const char *, const char *, const char *, Double_t) {return TH3::Fill(0); } //MayNotUse
-   Int_t             Fill(const char *, Double_t , const char *, Double_t) {return TH3::Fill(0); } //MayNotUse
-   Int_t             Fill(const char *, const char *, Double_t, Double_t) {return TH3::Fill(0); } //MayNotUse
-   Int_t             Fill(Double_t, const char *, const char *, Double_t) {return TH3::Fill(0); } //MayNotUse
-   Int_t             Fill(Double_t, const char *, Double_t, Double_t) {return TH3::Fill(0); } //MayNotUse
-   Int_t             Fill(Double_t, Double_t, const char *, Double_t) {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(Double_t, Double_t,Double_t) override {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(const char *, const char *, const char *, Double_t) override {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(const char *, Double_t , const char *, Double_t) override {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(const char *, const char *, Double_t, Double_t) override {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(Double_t, const char *, const char *, Double_t) override {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(Double_t, const char *, Double_t, Double_t) override {return TH3::Fill(0); } //MayNotUse
+   Int_t             Fill(Double_t, Double_t, const char *, Double_t) override {return TH3::Fill(0); } //MayNotUse
 
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return (fBinEntries.fArray[bin] > 0) ? fArray[bin]/fBinEntries.fArray[bin] : 0; }
+   Double_t RetrieveBinContent(Int_t bin) const override { return (fBinEntries.fArray[bin] > 0) ? fArray[bin]/fBinEntries.fArray[bin] : 0; }
    //virtual void     UpdateBinContent(Int_t bin, Double_t content);
-   virtual Double_t GetBinErrorSqUnchecked(Int_t bin) const { Double_t err = GetBinError(bin); return err*err; }
+   Double_t GetBinErrorSqUnchecked(Int_t bin) const override { Double_t err = GetBinError(bin); return err*err; }
 
-   virtual TProfile2D *DoProjectProfile2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
-                                          bool originalRange, bool useUF, bool useOF) const;
+   TProfile2D *DoProjectProfile2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
+                                          bool originalRange, bool useUF, bool useOF) const override;
 
 private:
    Double_t *GetB()  {return &fBinEntries.fArray[0];}
    Double_t *GetB2() {return (fBinSumw2.fN ? &fBinSumw2.fArray[0] : 0 ); }
    Double_t *GetW()  {return &fArray[0];}
    Double_t *GetW2() {return &fSumw2.fArray[0];}
-   void  SetBins(Int_t, Double_t, Double_t)
+   void  SetBins(Int_t, Double_t, Double_t) override
       { MayNotUse("SetBins(Int_t, Double_t, Double_t"); }
-   void  SetBins(Int_t, const Double_t*)
+   void  SetBins(Int_t, const Double_t*) override
       { MayNotUse("SetBins(Int_t, const Double_t*"); }
-   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t)
+   void SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t) override
       { MayNotUse("SetBins(Int_t, Double_t, Double_t, Int_t, Double_t, Double_t"); }
-   void SetBins(Int_t, const Double_t*, Int_t, const Double_t*)
+   void SetBins(Int_t, const Double_t*, Int_t, const Double_t*) override
       { MayNotUse("SetBins(Int_t, const Double_t*, Int_t, const Double_t*"); }
 
 public:
@@ -93,61 +93,61 @@ public:
                                                 ,Int_t nbinsz,const Double_t *zbins,Option_t *option="");
    TProfile3D(const TProfile3D &profile);
    TProfile3D &operator=(const TProfile3D &profile);
-   virtual ~TProfile3D();
-   virtual Bool_t    Add(TF1 *h1, Double_t c1=1, Option_t *option="");
-   virtual Bool_t    Add(const TH1 *h1, Double_t c1=1);
-   virtual Bool_t    Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1);
+   ~TProfile3D() override;
+   Bool_t    Add(TF1 *h1, Double_t c1=1, Option_t *option="") override;
+   Bool_t    Add(const TH1 *h1, Double_t c1=1) override;
+   Bool_t    Add(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1) override;
    static  void      Approximate(Bool_t approx=kTRUE);
    void              BuildOptions(Double_t tmin, Double_t tmax, Option_t *option);
-   virtual Int_t     BufferEmpty(Int_t action=0);
-   virtual void      Copy(TObject &hnew) const;
-   virtual Bool_t    Divide(TF1 *h1, Double_t c1=1);
-   virtual Bool_t    Divide(const TH1 *h1);
-   virtual Bool_t    Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="");
-   virtual void      ExtendAxis(Double_t x, TAxis *axis);
-   virtual Int_t     Fill(Double_t x, Double_t y, Double_t z, Double_t t);
+   Int_t     BufferEmpty(Int_t action=0) override;
+   void      Copy(TObject &hnew) const override;
+   Bool_t    Divide(TF1 *h1, Double_t c1=1) override;
+   Bool_t    Divide(const TH1 *h1) override;
+   Bool_t    Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override;
+   void      ExtendAxis(Double_t x, TAxis *axis) override;
+   Int_t     Fill(Double_t x, Double_t y, Double_t z, Double_t t) override;
    virtual Int_t     Fill(Double_t x, Double_t y, Double_t z, Double_t t, Double_t w);
-   virtual Double_t  GetBinContent(Int_t bin) const;
-   virtual Double_t  GetBinContent(Int_t,Int_t) const
+   Double_t  GetBinContent(Int_t bin) const override;
+   Double_t  GetBinContent(Int_t,Int_t) const override
                      { MayNotUse("GetBinContent(Int_t, Int_t"); return -1; }
-   virtual Double_t  GetBinContent(Int_t binx, Int_t biny, Int_t binz) const {return GetBinContent(GetBin(binx,biny,binz));}
-   virtual Double_t  GetBinError(Int_t bin) const;
-   virtual Double_t  GetBinError(Int_t,Int_t) const
+   Double_t  GetBinContent(Int_t binx, Int_t biny, Int_t binz) const override {return GetBinContent(GetBin(binx,biny,binz));}
+   Double_t  GetBinError(Int_t bin) const override;
+   Double_t  GetBinError(Int_t,Int_t) const override
                      { MayNotUse("GetBinError(Int_t, Int_t"); return -1; }
-   virtual Double_t  GetBinError(Int_t binx, Int_t biny, Int_t binz) const {return GetBinError(GetBin(binx,biny,binz));}
+   Double_t  GetBinError(Int_t binx, Int_t biny, Int_t binz) const override {return GetBinError(GetBin(binx,biny,binz));}
    virtual Double_t  GetBinEntries(Int_t bin) const;
    virtual Double_t  GetBinEffectiveEntries(Int_t bin);
    virtual TArrayD *GetBinSumw2() {return &fBinSumw2;}
    virtual const TArrayD *GetBinSumw2() const {return &fBinSumw2;}
    Option_t         *GetErrorOption() const;
-   virtual void      GetStats(Double_t *stats) const;
+   void      GetStats(Double_t *stats) const override;
    virtual Double_t  GetTmin() const {return fTmin;}
    virtual Double_t  GetTmax() const {return fTmax;}
-   virtual void      LabelsDeflate(Option_t *axis="X");
-   virtual void      LabelsInflate(Option_t *axis="X");
-   virtual void      LabelsOption(Option_t *option="h", Option_t *axis="X");
-   virtual Long64_t  Merge(TCollection *list);
-   virtual Bool_t    Multiply(TF1 *h1, Double_t c1=1);
-   virtual Bool_t    Multiply(const TH1 *h1);
-   virtual Bool_t    Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="");
+   void      LabelsDeflate(Option_t *axis="X") override;
+   void      LabelsInflate(Option_t *axis="X") override;
+   void      LabelsOption(Option_t *option="h", Option_t *axis="X") override;
+   Long64_t  Merge(TCollection *list) override;
+   Bool_t    Multiply(TF1 *h1, Double_t c1=1) override;
+   Bool_t    Multiply(const TH1 *h1) override;
+   Bool_t    Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option="") override;
    virtual TH3D     *ProjectionXYZ(const char *name="_pxyz", Option_t *option="e") const;
-   virtual TProfile2D  *Project3DProfile(Option_t *option="xy") const; // *MENU*
-   virtual void      PutStats(Double_t *stats);
-   virtual void      Reset(Option_t *option="");
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void      Scale(Double_t c1=1, Option_t *option="");
+   TProfile2D  *Project3DProfile(Option_t *option="xy") const override; // *MENU*
+   void      PutStats(Double_t *stats) override;
+   void      Reset(Option_t *option="") override;
+   void      SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void      Scale(Double_t c1=1, Option_t *option="") override;
    virtual void      SetBinEntries(Int_t bin, Double_t w);
-   virtual void      SetBins(Int_t nbinsx, Double_t xmin, Double_t xmax,
+   void      SetBins(Int_t nbinsx, Double_t xmin, Double_t xmax,
                              Int_t nbinsy, Double_t ymin, Double_t ymax,
-                             Int_t nbinsz, Double_t zmin, Double_t zmax);
-   virtual void      SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t * yBins, Int_t nz,
-                             const Double_t *zBins);
-   virtual void      SetBinsLength(Int_t n=-1);
-   virtual void      SetBuffer(Int_t buffersize, Option_t *opt="");
+                             Int_t nbinsz, Double_t zmin, Double_t zmax) override;
+   void      SetBins(Int_t nx, const Double_t *xBins, Int_t ny, const Double_t * yBins, Int_t nz,
+                             const Double_t *zBins) override;
+   void      SetBinsLength(Int_t n=-1) override;
+   void      SetBuffer(Int_t buffersize, Option_t *opt="") override;
    virtual void      SetErrorOption(Option_t *option=""); // *MENU*
-   virtual void      Sumw2(Bool_t flag = kTRUE);
+   void      Sumw2(Bool_t flag = kTRUE) override;
 
-   ClassDef(TProfile3D,8)  //Profile3D histogram class
+   ClassDefOverride(TProfile3D,8)  //Profile3D histogram class
 };
 
 #endif

--- a/hist/hist/inc/TSVDUnfold.h
+++ b/hist/hist/inc/TSVDUnfold.h
@@ -59,7 +59,7 @@ public:
    TSVDUnfold( const TSVDUnfold& other );
 
    // Destructor
-   virtual ~TSVDUnfold();
+   ~TSVDUnfold() override;
 
    // Set option to normalize unfolded spectrum to unit area
    // "normalize" - switch
@@ -153,7 +153,7 @@ private:
    ///@}
 
 
-   ClassDef( TSVDUnfold, 0 ) // Data unfolding using Singular Value Decomposition (hep-ph/9509307)
+   ClassDefOverride( TSVDUnfold, 0 ) // Data unfolding using Singular Value Decomposition (hep-ph/9509307)
 };
 
 #endif

--- a/hist/hist/inc/TSpline.h
+++ b/hist/hist/inc/TSpline.h
@@ -52,24 +52,24 @@ public:
       fDelta(delta), fXmin(xmin),
       fXmax(xmax), fNp(np), fKstep(step),
       fHistogram(0), fGraph(0), fNpx(100) {}
-   virtual ~TSpline();
+   ~TSpline() override;
 
    virtual void     GetKnot(Int_t i, Double_t &x, Double_t &y) const =0;
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *option="");
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   void     Draw(Option_t *option="") override;
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Double_t GetDelta() const {return fDelta;}
    TH1F            *GetHistogram() const {return fHistogram;}
    virtual Int_t    GetNp()    const {return fNp;}
    virtual Int_t    GetNpx()   const {return fNpx;}
    virtual Double_t GetXmin()  const {return fXmin;}
    virtual Double_t GetXmax()  const {return fXmax;}
-   virtual void     Paint(Option_t *option="");
+   void     Paint(Option_t *option="") override;
    virtual Double_t Eval(Double_t x) const=0;
-   virtual void     SaveAs(const char * /*filename*/,Option_t * /*option*/) const {;}
+   void     SaveAs(const char * /*filename*/,Option_t * /*option*/) const override {;}
    void             SetNpx(Int_t n) {fNpx=n;}
 
-   ClassDef (TSpline,2) // Spline base class
+   ClassDefOverride(TSpline,2) // Spline base class
 };
 
 
@@ -97,7 +97,7 @@ public:
    private:
    void CopyPoly(TSplinePoly const &other);
 
-   ClassDef(TSplinePoly,2) // Spline polynomial terms
+   ClassDefOverride(TSplinePoly,2) // Spline polynomial terms
 };
 
 inline TSplinePoly::TSplinePoly(TSplinePoly const &other)
@@ -127,7 +127,7 @@ public:
    Double_t &B() {return fB;}
    Double_t &C() {return fC;}
    Double_t &D() {return fD;}
-   Double_t Eval(Double_t x) const {
+   Double_t Eval(Double_t x) const override {
       Double_t dx=x-fX;
       return (fY+dx*(fB+dx*(fC+dx*fD)));
    }
@@ -139,7 +139,7 @@ public:
 private:
    void CopyPoly(TSplinePoly3 const &other);
 
-   ClassDef(TSplinePoly3,1)  // Third spline polynomial terms
+   ClassDefOverride(TSplinePoly3,1)  // Third spline polynomial terms
 };
 
 inline TSplinePoly3::TSplinePoly3(TSplinePoly3 const &other)
@@ -173,7 +173,7 @@ public:
    Double_t &D() {return fD;}
    Double_t &E() {return fE;}
    Double_t &F() {return fF;}
-   Double_t Eval(Double_t x) const {
+   Double_t Eval(Double_t x) const override {
       Double_t dx=x-fX;
       return (fY+dx*(fB+dx*(fC+dx*(fD+dx*(fE+dx*fF)))));
    }
@@ -185,7 +185,7 @@ public:
 private:
    void CopyPoly(TSplinePoly5 const &other);
 
-   ClassDef(TSplinePoly5,1)  // Quintic spline polynomial terms
+   ClassDefOverride(TSplinePoly5,1)  // Quintic spline polynomial terms
 };
 
 inline TSplinePoly5::TSplinePoly5(TSplinePoly5 const &other)
@@ -206,7 +206,7 @@ protected:
    Int_t          fBegCond;    ///< 0=no beg cond, 1=first derivative, 2=second derivative
    Int_t          fEndCond;    ///< 0=no end cond, 1=first derivative, 2=second derivative
 
-   void   BuildCoeff();
+   void   BuildCoeff() override;
    void   SetCond(const char *opt);
 
 public:
@@ -234,21 +234,21 @@ public:
    TSpline3(const TSpline3&);
    TSpline3& operator=(const TSpline3&);
    Int_t    FindX(Double_t x) const;
-   Double_t Eval(Double_t x) const;
+   Double_t Eval(Double_t x) const override;
    Double_t Derivative(Double_t x) const;
-   virtual ~TSpline3() {if (fPoly) delete [] fPoly;}
+   ~TSpline3() override {if (fPoly) delete [] fPoly;}
    void GetCoeff(Int_t i, Double_t &x, Double_t &y, Double_t &b,
                  Double_t &c, Double_t &d) {x=fPoly[i].X();y=fPoly[i].Y();
                   b=fPoly[i].B();c=fPoly[i].C();d=fPoly[i].D();}
-   void GetKnot(Int_t i, Double_t &x, Double_t &y) const
+   void GetKnot(Int_t i, Double_t &x, Double_t &y) const override
       {x=fPoly[i].X(); y=fPoly[i].Y();}
-   virtual  void     SaveAs(const char *filename,Option_t *option="") const;
-   virtual  void     SavePrimitive(std::ostream &out, Option_t *option = "");
+    void     SaveAs(const char *filename,Option_t *option="") const override;
+    void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual  void     SetPoint(Int_t i, Double_t x, Double_t y);
    virtual  void     SetPointCoeff(Int_t i, Double_t b, Double_t c, Double_t d);
    static void Test();
 
-   ClassDef (TSpline3,2)  // Class to create third natural splines
+   ClassDefOverride(TSpline3,2)  // Class to create third natural splines
 };
 
 
@@ -258,7 +258,7 @@ class TSpline5 : public TSpline
 protected:
    TSplinePoly5  *fPoly;     ///<[fNp] Array of polynomial terms
 
-   void BuildCoeff();
+   void BuildCoeff() override;
    void BoundaryConditions(const char *opt, Int_t &beg, Int_t &end,
                            const char *&cb1, const char *&ce1, const char *&cb2,
                            const char *&ce2);
@@ -295,24 +295,24 @@ public:
    TSpline5(const TSpline5&);
    TSpline5& operator=(const TSpline5&);
    Int_t    FindX(Double_t x) const;
-   Double_t Eval(Double_t x) const;
+   Double_t Eval(Double_t x) const override;
    Double_t Derivative(Double_t x) const;
-   virtual ~TSpline5() {if (fPoly) delete [] fPoly;}
+   ~TSpline5() override {if (fPoly) delete [] fPoly;}
    void GetCoeff(Int_t i, Double_t &x, Double_t &y, Double_t &b,
                  Double_t &c, Double_t &d, Double_t &e, Double_t &f)
       {x=fPoly[i].X();y=fPoly[i].Y();b=fPoly[i].B();
       c=fPoly[i].C();d=fPoly[i].D();
       e=fPoly[i].E();f=fPoly[i].F();}
-   void GetKnot(Int_t i, Double_t &x, Double_t &y) const
+   void GetKnot(Int_t i, Double_t &x, Double_t &y) const override
       {x=fPoly[i].X(); y=fPoly[i].Y();}
-   virtual  void     SaveAs(const char *filename,Option_t *option="") const;
-   virtual  void     SavePrimitive(std::ostream &out, Option_t *option = "");
+    void     SaveAs(const char *filename,Option_t *option="") const override;
+    void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual  void     SetPoint(Int_t i, Double_t x, Double_t y);
    virtual  void     SetPointCoeff(Int_t i, Double_t b, Double_t c, Double_t d,
                                    Double_t e, Double_t f);
    static void Test();
 
-   ClassDef (TSpline5,2) // Class to create quintic natural splines
+   ClassDefOverride(TSpline5,2) // Class to create quintic natural splines
 };
 
 #endif

--- a/hist/hist/inc/TVirtualFitter.h
+++ b/hist/hist/inc/TVirtualFitter.h
@@ -57,10 +57,10 @@ protected:
 
 public:
    TVirtualFitter();
-   virtual ~TVirtualFitter();
+   ~TVirtualFitter() override;
    virtual Double_t  Chisquare(Int_t npar, Double_t *params) const  = 0;
 
-   virtual void      Clear(Option_t *option="") = 0;
+   void      Clear(Option_t *option="") override = 0;
    virtual Int_t     ExecuteCommand(const char *command, Double_t *args, Int_t nargs) = 0;
    virtual void      FixParameter(Int_t ipar) = 0;
    virtual void      GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95);
@@ -117,7 +117,7 @@ public:
    static void      SetErrorDef(Double_t errdef=1);
    static void      SetPrecision(Double_t prec=1e-6);
 
-   ClassDef(TVirtualFitter,0)  //Abstract interface for fitting
+   ClassDefOverride(TVirtualFitter,0)  //Abstract interface for fitting
 };
 
 #endif

--- a/hist/hist/inc/TVirtualGraphPainter.h
+++ b/hist/hist/inc/TVirtualGraphPainter.h
@@ -31,7 +31,7 @@ private:
 
 public:
    TVirtualGraphPainter() { }
-   virtual ~TVirtualGraphPainter() { }
+   ~TVirtualGraphPainter() override { }
 
    virtual Int_t DistancetoPrimitiveHelper(TGraph *theGraph, Int_t px, Int_t py) = 0;
    virtual void  DrawPanelHelper(TGraph *theGraph) = 0;
@@ -46,7 +46,7 @@ public:
    static TVirtualGraphPainter *GetPainter();
    static void                  SetPainter(TVirtualGraphPainter *painter);
 
-   ClassDef(TVirtualGraphPainter,0)  //Abstract interface for histogram painters
+   ClassDefOverride(TVirtualGraphPainter,0)  //Abstract interface for histogram painters
 };
 
 #endif

--- a/hist/hist/inc/TVirtualHistPainter.h
+++ b/hist/hist/inc/TVirtualHistPainter.h
@@ -34,16 +34,16 @@ private:
 
 public:
    TVirtualHistPainter() { }
-   virtual ~TVirtualHistPainter() { }
-   virtual Int_t      DistancetoPrimitive(Int_t px, Int_t py) = 0;
+   ~TVirtualHistPainter() override { }
+   Int_t      DistancetoPrimitive(Int_t px, Int_t py) override = 0;
    virtual void       DrawPanel() = 0;
-   virtual void       ExecuteEvent(Int_t event, Int_t px, Int_t py) = 0;
+   void       ExecuteEvent(Int_t event, Int_t px, Int_t py) override = 0;
    virtual TList     *GetContourList(Double_t contour) const = 0;
-   virtual char      *GetObjectInfo(Int_t px, Int_t py) const = 0;
+   char      *GetObjectInfo(Int_t px, Int_t py) const override = 0;
    virtual TList     *GetStack() const = 0;
    virtual Bool_t     IsInside(Int_t x, Int_t y) = 0;
    virtual Bool_t     IsInside(Double_t x, Double_t y) = 0;
-   virtual void       Paint(Option_t *option="") = 0;
+   void       Paint(Option_t *option="") override = 0;
    virtual void       PaintStat(Int_t dostat, TF1 *fit) = 0;
    virtual void       ProcessMessage(const char *mess, const TObject *obj) = 0;
    virtual void       SetHighlight() = 0;
@@ -55,7 +55,7 @@ public:
    static TVirtualHistPainter *HistPainter(TH1 *obj);
    static void                 SetPainter(const char *painter);
 
-   ClassDef(TVirtualHistPainter,0)  //Abstract interface for histogram painters
+   ClassDefOverride(TVirtualHistPainter,0)  //Abstract interface for histogram painters
 };
 
 #endif

--- a/hist/hist/inc/v5/TF1Data.h
+++ b/hist/hist/inc/v5/TF1Data.h
@@ -54,10 +54,10 @@ struct TF1Data : public ROOT::v5::TFormula, public TAttLine, public TAttFill, pu
 
 
    TF1Data();
-   virtual   ~TF1Data();
+     ~TF1Data() override;
    void Streamer(TBuffer &b, Int_t version, UInt_t start, UInt_t count, const TClass *onfile_class = 0);
    
-   ClassDef(TF1Data,7)  //The Parametric 1-D function data structure  of v5::TF1
+   ClassDefOverride(TF1Data,7)  //The Parametric 1-D function data structure  of v5::TF1
 };
 
    }  // end namespace v5

--- a/hist/hist/inc/v5/TFormula.h
+++ b/hist/hist/inc/v5/TFormula.h
@@ -218,15 +218,15 @@ public:
                TFormula(const char *name,const char *formula);
                TFormula(const TFormula &formula);
    TFormula&   operator=(const TFormula &rhs);
-   virtual    ~TFormula();
+      ~TFormula() override;
 
  public:
    void                Optimize();
    virtual void        Analyze(const char *schain, Int_t &err, Int_t offset=0);
    virtual Bool_t      AnalyzeFunction(TString &chaine, Int_t &err, Int_t offset=0);
    virtual Int_t       Compile(const char *expression="");
-   virtual void        Copy(TObject &formula) const;
-   virtual void        Clear(Option_t *option="");
+   void        Copy(TObject &formula) const override;
+   void        Clear(Option_t *option="") override;
    virtual char       *DefinedString(Int_t code);
    virtual Double_t    DefinedValue(Int_t code);
    virtual Int_t       DefinedVariable(TString &variable,Int_t &action);
@@ -246,7 +246,7 @@ public:
    virtual Int_t       GetParNumber(const char *name) const;
    virtual Bool_t      IsLinear() const {return TestBit(kLinear);}
    virtual Bool_t      IsNormalized() const {return TestBit(kNormalized);}
-   virtual void        Print(Option_t *option="") const; // *MENU*
+   void        Print(Option_t *option="") const override; // *MENU*
    virtual void        ProcessLinear(TString &replaceformula);
    virtual void        SetNumber(Int_t number) {fNumber = number;}
    virtual void        SetParameter(const char *name, Double_t parvalue);
@@ -268,7 +268,7 @@ public:
    void Streamer(TBuffer &b, const TClass *onfile_class);
    void Streamer(TBuffer &b, Int_t version, UInt_t start, UInt_t count, const TClass *onfile_class = 0);
 
-   ClassDef(ROOT::v5::TFormula,8)  //The formula base class  f(x,y,z,par)
+   ClassDefOverride(ROOT::v5::TFormula,8)  //The formula base class  f(x,y,z,par)
 };
 
    } // end namespace v5

--- a/hist/hist/inc/v5/TFormulaPrimitive.h
+++ b/hist/hist/inc/v5/TFormulaPrimitive.h
@@ -90,7 +90,7 @@ public:
    Double_t Eval(TObject *o,  Double_t *x);      //eval member function
    Double_t Eval(Double_t *x, Double_t *param);  //eval primitive parametric function
 
-   ClassDef(ROOT::v5::TFormulaPrimitive,0)  //The primitive formula
+   ClassDefOverride(ROOT::v5::TFormulaPrimitive,0)  //The primitive formula
 };
 
    } // end namespace v5

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -200,7 +200,7 @@ public:
       if (par) fFunc->SetParameters(par);
    }
 
-   ROOT::Math::IGenFunction *Clone()  const
+   ROOT::Math::IGenFunction *Clone()  const override
    {
       // use default copy constructor
       TF1_EvalWrapper *f =  new TF1_EvalWrapper(*this);
@@ -208,7 +208,7 @@ public:
       return f;
    }
    // evaluate |f(x)|
-   Double_t DoEval(Double_t x) const
+   Double_t DoEval(Double_t x) const override
    {
       // use evaluation with stored parameters (i.e. pass zero)
       fX[0] = x;

--- a/hist/hist/src/THn.cxx
+++ b/hist/hist/src/THn.cxx
@@ -34,10 +34,10 @@ namespace {
    public:
       THnBinIter(Int_t dim, const TObjArray* axes, const TNDArray* arr,
                  Bool_t respectAxisRange);
-      ~THnBinIter() { delete [] fCounter; }
+      ~THnBinIter() override { delete [] fCounter; }
 
-      Long64_t Next(Int_t* coord = 0);
-      Int_t GetCoord(Int_t dim) const { return fCounter[dim].i; }
+      Long64_t Next(Int_t* coord = 0) override;
+      Int_t GetCoord(Int_t dim) const override { return fCounter[dim].i; }
    private:
       THnBinIter(const THnBinIter&); // intentionally unimplemented
       THnBinIter& operator=(const THnBinIter&); // intentionally unimplemented

--- a/hist/hist/src/THnSparse.cxx
+++ b/hist/hist/src/THnSparse.cxx
@@ -31,10 +31,10 @@ namespace {
          fCoord = new Int_t[hist->GetNdimensions()];
          fCoord[0] = -1;
       }
-      virtual ~THnSparseBinIter() { delete [] fCoord; }
+      ~THnSparseBinIter() override { delete [] fCoord; }
 
-      virtual Int_t GetCoord(Int_t dim) const;
-      virtual Long64_t Next(Int_t* coord = 0);
+      Int_t GetCoord(Int_t dim) const override;
+      Long64_t Next(Int_t* coord = 0) override;
 
    private:
       THnSparseBinIter(const THnSparseBinIter&); // intentionally unimplemented

--- a/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
+++ b/hist/histdrawv7/inc/ROOT/RHistStatBox.hxx
@@ -40,7 +40,7 @@ public:
    RDisplayHistStat() = default;
    RDisplayHistStat(const RDrawable &dr, unsigned mask, const std::vector<std::string> &entries, const std::vector<std::string> &lines) :
          RIndirectDisplayItem(dr), fShowMask(mask), fEntries(entries), fLines(lines) {}
-   virtual ~RDisplayHistStat() = default;
+   ~RDisplayHistStat() override = default;
 
    unsigned GetShowMask() const { return fShowMask; }
    const std::vector<std::string> &GetEntries() const { return fEntries; }
@@ -79,7 +79,7 @@ public:
       std::vector<std::string> &GetLines() { return lines; }
       void SetMask(unsigned _mask) { mask = _mask; }
       // virtual destructor - required to pin vtable
-      virtual ~RReply() = default;
+      ~RReply() override = default;
    };
 
    class RRequest : public RDrawableRequest {

--- a/hist/histpainter/inc/TGraph2DPainter.h
+++ b/hist/histpainter/inc/TGraph2DPainter.h
@@ -74,17 +74,17 @@ public:
    TGraph2DPainter(TGraphDelaunay *gd);
    TGraph2DPainter(TGraphDelaunay2D *gd);
 
-   virtual ~TGraph2DPainter();
+   ~TGraph2DPainter() override;
 
    TList *GetContourList(Double_t contour);
-   void   Paint(Option_t *option);
+   void   Paint(Option_t *option) override;
    void   PaintContour(Option_t *option);
    void   PaintErrors(Option_t *option);
    void   PaintPolyMarker(Option_t *option);
    void   PaintPolyLine(Option_t *option);
    void   PaintTriangles(Option_t *option);
 
-   ClassDef(TGraph2DPainter,0)  // TGraph2D painter
+   ClassDefOverride(TGraph2DPainter,0)  // TGraph2D painter
 };
 
 #endif

--- a/hist/histpainter/inc/TGraphPainter.h
+++ b/hist/histpainter/inc/TGraphPainter.h
@@ -32,19 +32,19 @@ public:
 
    TGraphPainter();
 
-   virtual ~TGraphPainter();
+   ~TGraphPainter() override;
 
    void           ComputeLogs(Int_t npoints, Int_t opt);
-   virtual Int_t  DistancetoPrimitiveHelper(TGraph *theGraph, Int_t px, Int_t py);
-   virtual void   DrawPanelHelper(TGraph *theGraph);
-   virtual void   ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, Int_t py);
-   virtual char  *GetObjectInfoHelper(TGraph *theGraph, Int_t px, Int_t py) const;
+   Int_t  DistancetoPrimitiveHelper(TGraph *theGraph, Int_t px, Int_t py) override;
+   void   DrawPanelHelper(TGraph *theGraph) override;
+   void   ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, Int_t py) override;
+   char  *GetObjectInfoHelper(TGraph *theGraph, Int_t px, Int_t py) const override;
    virtual Int_t  GetHighlightPoint(TGraph *theGraph) const;
    virtual void   HighlightPoint(TGraph *theGraph, Int_t hpoint, Int_t distance);
    virtual void   PaintHighlightPoint(TGraph *theGraph, Option_t *option);
-   void           PaintHelper(TGraph *theGraph, Option_t *option);
-   virtual void   PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt);
-   virtual void   PaintGrapHist(TGraph *theGraph, Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt);
+   void           PaintHelper(TGraph *theGraph, Option_t *option) override;
+   void   PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt) override;
+   void   PaintGrapHist(TGraph *theGraph, Int_t npoints, const Double_t *x, const Double_t *y, Option_t *chopt) override;
    void           PaintGraphAsymmErrors(TGraph *theGraph, Option_t *option);
    void           PaintGraphMultiErrors(TGraph *theGraph, Option_t *option);
    void           PaintGraphBentErrors(TGraph *theGraph, Option_t *option);
@@ -54,8 +54,8 @@ public:
    void           PaintGraphReverse(TGraph *theGraph, Option_t *option);
    void           PaintGraphSimple(TGraph *theGraph, Option_t *option);
    void           PaintPolyLineHatches(TGraph *theGraph, Int_t n, const Double_t *x, const Double_t *y);
-   void           PaintStats(TGraph *theGraph, TF1 *fit);
-   virtual void   SetHighlight(TGraph *theGraph);
+   void           PaintStats(TGraph *theGraph, TF1 *fit) override;
+   void   SetHighlight(TGraph *theGraph) override;
    void           Smooth(TGraph *theGraph, Int_t npoints, Double_t *x, Double_t *y, Int_t drawtype);
    static void    SetMaxPointsPerLine(Int_t maxp=50);
 
@@ -63,7 +63,7 @@ protected:
 
    static Int_t   fgMaxPointsPerLine;  //Number of points per chunks' line when drawing a graph.
 
-   ClassDef(TGraphPainter,0)  // TGraph painter
+   ClassDefOverride(TGraphPainter,0)  // TGraph painter
 };
 
 #endif

--- a/hist/histpainter/inc/THistPainter.h
+++ b/hist/histpainter/inc/THistPainter.h
@@ -74,22 +74,22 @@ private:
 
 public:
    THistPainter();
-   virtual ~THistPainter();
+   ~THistPainter() override;
    virtual void       DefineColorLevels(Int_t ndivz);
-   virtual Int_t      DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void       DrawPanel();
-   virtual void       ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual TList     *GetContourList(Double_t contour) const;
-   virtual char      *GetObjectInfo(Int_t px, Int_t py) const;
-   virtual TList     *GetStack() const {return fStack;}
+   Int_t      DistancetoPrimitive(Int_t px, Int_t py) override;
+   void       DrawPanel() override;
+   void       ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   TList     *GetContourList(Double_t contour) const override;
+   char      *GetObjectInfo(Int_t px, Int_t py) const override;
+   TList     *GetStack() const override {return fStack;}
    virtual Int_t      GetXHighlightBin() const { return fXHighlightBin; }
    virtual Int_t      GetYHighlightBin() const { return fYHighlightBin; }
    virtual void       HighlightBin(Int_t px, Int_t py);
-   virtual Bool_t     IsInside(Int_t x, Int_t y);
-   virtual Bool_t     IsInside(Double_t x, Double_t y);
+   Bool_t     IsInside(Int_t x, Int_t y) override;
+   Bool_t     IsInside(Double_t x, Double_t y) override;
    virtual Int_t      MakeChopt(Option_t *option);
-   virtual Int_t      MakeCuts(char *cutsopt);
-   virtual void       Paint(Option_t *option="");
+   Int_t      MakeCuts(char *cutsopt) override;
+   void       Paint(Option_t *option="") override;
    virtual void       PaintArrows(Option_t *option);
    virtual void       PaintAxis(Bool_t drawGridOnly=kFALSE);
    virtual void       PaintBar(Option_t *option);
@@ -124,7 +124,7 @@ public:
    virtual void       PaintLegoAxis(TGaxis *axis, Double_t ang);
    virtual void       PaintPalette();
    virtual void       PaintScatterPlot(Option_t *option);
-   virtual void       PaintStat(Int_t dostat, TF1 *fit);
+   void       PaintStat(Int_t dostat, TF1 *fit) override;
    virtual void       PaintStat2(Int_t dostat, TF1 *fit);
    virtual void       PaintStat3(Int_t dostat, TF1 *fit);
    virtual void       PaintSurface(Option_t *option);
@@ -133,17 +133,17 @@ public:
    virtual void       PaintText(Option_t *option);
    virtual void       PaintTitle();
    virtual void       PaintTF3();
-   virtual void       ProcessMessage(const char *mess, const TObject *obj);
+   void       ProcessMessage(const char *mess, const TObject *obj) override;
    static  Int_t      ProjectAitoff2xy(Double_t l, Double_t b, Double_t &Al, Double_t &Ab);
    static  Int_t      ProjectMercator2xy(Double_t l, Double_t b, Double_t &Al, Double_t &Ab);
    static  Int_t      ProjectSinusoidal2xy(Double_t l, Double_t b, Double_t &Al, Double_t &Ab);
    static  Int_t      ProjectParabolic2xy(Double_t l, Double_t b, Double_t &Al, Double_t &Ab);
    virtual void       RecalculateRange();
-   virtual void       RecursiveRemove(TObject *) {;}
-   virtual void       SetHighlight();
-   virtual void       SetHistogram(TH1 *h);
-   virtual void       SetStack(TList *stack) {fStack = stack;}
-   virtual void       SetShowProjection(const char *option,Int_t nbins);
+   void       RecursiveRemove(TObject *) override {;}
+   void       SetHighlight() override;
+   void       SetHistogram(TH1 *h) override;
+   void       SetStack(TList *stack) override {fStack = stack;}
+   void       SetShowProjection(const char *option,Int_t nbins) override;
    virtual void       ShowProjectionX(Int_t px, Int_t py);
    virtual void       ShowProjectionY(Int_t px, Int_t py);
    virtual void       ShowProjection3(Int_t px, Int_t py);
@@ -152,7 +152,7 @@ public:
    static const char *GetBestFormat(Double_t v, Double_t e, const char *f);
    static void        PaintSpecialObjects(const TObject *obj, Option_t *option);
 
-   ClassDef(THistPainter,0)  //Helper class to draw histograms
+   ClassDefOverride(THistPainter,0)  //Helper class to draw histograms
 };
 
 #endif

--- a/hist/histpainter/inc/TPaletteAxis.h
+++ b/hist/histpainter/inc/TPaletteAxis.h
@@ -39,19 +39,19 @@ public:
    TPaletteAxis();
    TPaletteAxis(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, TH1 *h);
    TPaletteAxis(const TPaletteAxis &palette);
-   virtual ~TPaletteAxis();
-   void Copy(TObject &palette) const;
+   ~TPaletteAxis() override;
+   void Copy(TObject &palette) const override;
    TPaletteAxis& operator=(const TPaletteAxis&);
 
-   virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   Int_t DistancetoPrimitive(Int_t px, Int_t py) override;
+   void  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    TGaxis       *GetAxis() {return &fAxis;}
    Int_t         GetBinColor(Int_t i, Int_t j);
    TH1*          GetHistogram(){return fH;}
-   virtual char *GetObjectInfo(Int_t px, Int_t py) const;
+   char *GetObjectInfo(Int_t px, Int_t py) const override;
    Int_t         GetValueColor(Double_t zc);
-   virtual void  Paint(Option_t *option="");
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void  Paint(Option_t *option="") override;
+   void  SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void          SetHistogram(TH1* h) {fH = h;}
    virtual void  SetLabelColor(Int_t labelcolor) {fAxis.SetLabelColor(labelcolor);} // *MENU*
    virtual void  SetLabelFont(Int_t labelfont) {fAxis.SetLabelFont(labelfont);} // *MENU*
@@ -59,11 +59,11 @@ public:
    virtual void  SetLabelSize(Float_t labelsize) {fAxis.SetLabelSize(labelsize);} // *MENU*
    virtual void  SetTitleOffset(Float_t titleoffset=1) {fAxis.SetTitleOffset(titleoffset);} // *MENU*
    virtual void  SetTitleSize(Float_t titlesize) {fAxis.SetTitleSize(titlesize);} // *MENU*
-   virtual void  SetLineColor(Color_t linecolor) {fAxis.SetLineColor(linecolor);} // *MENU*
-   virtual void  SetLineWidth(Width_t linewidth) {fAxis.SetLineWidth(linewidth);} // *MENU*
+   void  SetLineColor(Color_t linecolor) override {fAxis.SetLineColor(linecolor);} // *MENU*
+   void  SetLineWidth(Width_t linewidth) override {fAxis.SetLineWidth(linewidth);} // *MENU*
    virtual void  UnZoom();  // *MENU*
 
-   ClassDef(TPaletteAxis,4)  //class used to display a color palette axis for 2-d plots
+   ClassDefOverride(TPaletteAxis,4)  //class used to display a color palette axis for 2-d plots
 };
 
 #endif

--- a/hist/histpainter/src/TPainter3dAlgorithms.h
+++ b/hist/histpainter/src/TPainter3dAlgorithms.h
@@ -63,7 +63,7 @@ private:
 public:
    TPainter3dAlgorithms();
    TPainter3dAlgorithms(Double_t *rmin, Double_t *rmax, Int_t system=1);
-   virtual ~TPainter3dAlgorithms();
+   ~TPainter3dAlgorithms() override;
    void    BackBox(Double_t ang);
    void    FrontBox(Double_t ang);
    void    DrawFaceGouraudShaded(Int_t *icodes, Double_t xyz[][3], Int_t np, Int_t *iface, Double_t *t);

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -441,13 +441,13 @@ public:
    operator RAxisConfig() const { return RAxisConfig(GetTitle(), GetNBinsNoOver(), GetMinimum(), GetMaximum()); }
 
    /// Get the number of bins, excluding under- and overflow.
-   int GetNBinsNoOver() const noexcept final override { return fNBinsNoOver; }
+   int GetNBinsNoOver() const noexcept final { return fNBinsNoOver; }
 
    /// Find the adjusted bin index (returning `kUnderflowBin` for underflow and
    /// `kOverflowBin` for overflow) for the given coordinate.
    /// \note Passing a bin border coordinate can either return the bin above or
    /// below the bin border. I.e. don't do that for reliable results!
-   int FindBin(double x) const noexcept final override
+   int FindBin(double x) const noexcept final 
    {
       double rawbin = FindBinRaw(x);
       return AdjustOverflowBinNumber(rawbin);
@@ -466,13 +466,13 @@ public:
    /// For the bin == 1 (the first bin) of 2 bins for an axis (0., 1.), this
    /// returns 0.25.
    /// The result of this method on an overflow or underflow bin is unspecified.
-   double GetBinCenter(int bin) const final override { return fLow + (bin - GetFirstBin() + 0.5) / fInvBinWidth; }
+   double GetBinCenter(int bin) const final { return fLow + (bin - GetFirstBin() + 0.5) / fInvBinWidth; }
 
    /// Get the low bin border for the given bin index.
    /// For the bin == 1 (the first bin) of 2 bins for an axis (0., 1.), this
    /// returns 0.
    /// The result of this method on an underflow bin is unspecified.
-   double GetBinFrom(int bin) const final override {
+   double GetBinFrom(int bin) const final {
       const double result = (bin == kOverflowBin) ? GetMaximum() : fLow + (bin - GetFirstBin()) / fInvBinWidth;
       return result;
    }
@@ -480,7 +480,7 @@ public:
    /// If the coordinate `x` is within 10 ULPs of a bin low edge coordinate,
    /// return the bin for which this is a low edge. If it's not a bin edge,
    /// return `kInvalidBin`.
-   int GetBinIndexForLowEdge(double x) const noexcept final override;
+   int GetBinIndexForLowEdge(double x) const noexcept final ;
 };
 
 namespace Internal {
@@ -558,7 +558,7 @@ public:
    int Grow(int toBin);
 
    /// This axis kind can increase its range.
-   bool CanGrow() const noexcept final override { return true; }
+   bool CanGrow() const noexcept final { return true; }
 };
 
 namespace Internal {
@@ -664,12 +664,12 @@ public:
    operator RAxisConfig() const { return RAxisConfig(GetTitle(), GetBinBorders()); }
 
    /// Get the number of bins, excluding under- and overflow.
-   int GetNBinsNoOver() const noexcept final override { return fBinBorders.size() - 1; }
+   int GetNBinsNoOver() const noexcept final { return fBinBorders.size() - 1; }
 
    /// Find the bin index (adjusted with under- and overflow) for the given coordinate `x`.
    /// \note Passing a bin border coordinate can either return the bin above or
    /// below the bin border. I.e. don't do that for reliable results!
-   int FindBin(double x) const noexcept final override
+   int FindBin(double x) const noexcept final 
    {
       int rawbin = FindBinRaw(x);
       // No need for AdjustOverflowBinNumber(rawbin) here; lower_bound() is the
@@ -683,11 +683,11 @@ public:
 
    /// Get the bin center of the bin with the given index.
    /// The result of this method on an overflow or underflow bin is unspecified.
-   double GetBinCenter(int bin) const final override { return 0.5 * (fBinBorders[bin - 1] + fBinBorders[bin]); }
+   double GetBinCenter(int bin) const final { return 0.5 * (fBinBorders[bin - 1] + fBinBorders[bin]); }
 
    /// Get the lower bin border for a given bin index.
    /// The result of this method on an underflow bin is unspecified.
-   double GetBinFrom(int bin) const final override
+   double GetBinFrom(int bin) const final 
    {
       if (bin == kOverflowBin)
          return fBinBorders[GetLastBin()];
@@ -697,10 +697,10 @@ public:
    /// If the coordinate `x` is within 10 ULPs of a bin low edge coordinate,
    /// return the bin for which this is a low edge. If it's not a bin edge,
    /// return `kInvalidBin`.
-   int GetBinIndexForLowEdge(double x) const noexcept final override;
+   int GetBinIndexForLowEdge(double x) const noexcept final ;
 
    /// This axis cannot be extended.
-   bool CanGrow() const noexcept final override { return false; }
+   bool CanGrow() const noexcept final { return false; }
 
    /// Access to the bin borders used by this axis.
    const std::vector<double> &GetBinBorders() const noexcept { return fBinBorders; }

--- a/hist/spectrum/inc/TSpectrum.h
+++ b/hist/spectrum/inc/TSpectrum.h
@@ -51,13 +51,13 @@ public:
 
    TSpectrum();
    TSpectrum(Int_t maxpositions, Double_t resolution=1); // resolution is *NOT USED*
-   virtual ~TSpectrum();
+   ~TSpectrum() override;
    virtual TH1        *Background(const TH1 *hist,Int_t niter=20, Option_t *option="");
    TH1                *GetHistogram() const {return fHistogram;}
    Int_t               GetNPeaks() const {return fNPeaks;}
    Double_t            *GetPositionX() const {return fPositionX;}
    Double_t            *GetPositionY() const {return fPositionY;}
-   virtual void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
    virtual Int_t       Search(const TH1 *hist, Double_t sigma=2, Option_t *option="", Double_t threshold=0.05);
    static void         SetAverageWindow(Int_t w=3);   //set average window
    static void         SetDeconIterations(Int_t n=3); //set max number of decon iterations
@@ -75,7 +75,7 @@ public:
    static Int_t        StaticSearch(const TH1 *hist, Double_t sigma=2, Option_t *option="goff", Double_t threshold=0.05);
    static TH1         *StaticBackground(const TH1 *hist,Int_t niter=20, Option_t *option="");
 
-   ClassDef(TSpectrum,3)  //Peak Finder, background estimator, Deconvolution
+   ClassDefOverride(TSpectrum,3)  //Peak Finder, background estimator, Deconvolution
 };
 
 #endif

--- a/hist/spectrum/inc/TSpectrum2.h
+++ b/hist/spectrum/inc/TSpectrum2.h
@@ -37,13 +37,13 @@ public:
 
    TSpectrum2();
    TSpectrum2(Int_t maxpositions, Double_t resolution=1); // resolution is *NOT USED*
-   virtual ~TSpectrum2();
+   ~TSpectrum2() override;
    virtual TH1  *Background(const TH1 *hist, Int_t niter=20, Option_t *option="");
    TH1          *GetHistogram() const {return fHistogram;}
    Int_t         GetNPeaks() const {return fNPeaks;}
    Double_t      *GetPositionX() const {return fPositionX;}
    Double_t      *GetPositionY() const {return fPositionY;}
-   virtual void  Print(Option_t *option="") const;
+   void  Print(Option_t *option="") const override;
    virtual Int_t Search(const TH1 *hist, Double_t sigma=2, Option_t *option="", Double_t threshold=0.05);
    static void   SetAverageWindow(Int_t w=3);   //set average window
    static void   SetDeconIterations(Int_t n=3); //set max number of decon iterations
@@ -58,7 +58,7 @@ public:
    static Int_t        StaticSearch(const TH1 *hist, Double_t sigma=2, Option_t *option="goff", Double_t threshold=0.05);
    static TH1         *StaticBackground(const TH1 *hist,Int_t niter=20, Option_t *option="");
 
-   ClassDef(TSpectrum2,1)  //Peak Finder, background estimator, Deconvolution for 2-D histograms
+   ClassDefOverride(TSpectrum2,1)  //Peak Finder, background estimator, Deconvolution for 2-D histograms
 };
 
 #endif

--- a/hist/spectrum/inc/TSpectrum2Fit.h
+++ b/hist/spectrum/inc/TSpectrum2Fit.h
@@ -132,7 +132,7 @@ public:
    };
    TSpectrum2Fit(void); //default constructor
    TSpectrum2Fit(Int_t numberPeaks);
-   virtual ~TSpectrum2Fit();
+   ~TSpectrum2Fit() override;
    //auxiliary functions for 2. parameter fit functions
 protected:
    Double_t            Deramp2(Double_t x,Double_t y,Double_t x0,Double_t y0,Double_t sigmax,Double_t sigmay,Double_t ro,Double_t txy,Double_t sxy,Double_t bx,Double_t by);
@@ -187,7 +187,7 @@ public:
    void                SetPeakParameters(Double_t sigmaX, Bool_t fixSigmaX, Double_t sigmaY, Bool_t fixSigmaY, Double_t ro, Bool_t fixRo, const Double_t *positionInitX, const Bool_t *fixPositionX, const Double_t *positionInitY, const Bool_t *fixPositionY, const Double_t *positionInitX1, const Bool_t *fixPositionX1, const Double_t *positionInitY1, const Bool_t *fixPositionY1, const Double_t *ampInit, const Bool_t *fixAmp, const Double_t *ampInitX1, const Bool_t *fixAmpX1, const Double_t *ampInitY1, const Bool_t *fixAmpY1);
    void                SetTailParameters(Double_t tInitXY, Bool_t fixTxy, Double_t tInitX, Bool_t fixTx, Double_t tInitY, Bool_t fixTy, Double_t bInitX, Bool_t fixBx, Double_t bInitY, Bool_t fixBy, Double_t sInitXY, Bool_t fixSxy, Double_t sInitX, Bool_t fixSx, Double_t sInitY, Bool_t fixSy);
 
-   ClassDef(TSpectrum2Fit,1)  //Spectrum2 Fitter using algorithm without matrix inversion and conjugate gradient method for symmetrical matrices (Stiefel-Hestens method)
+   ClassDefOverride(TSpectrum2Fit,1)  //Spectrum2 Fitter using algorithm without matrix inversion and conjugate gradient method for symmetrical matrices (Stiefel-Hestens method)
 };
 
 #endif

--- a/hist/spectrum/inc/TSpectrum2Transform.h
+++ b/hist/spectrum/inc/TSpectrum2Transform.h
@@ -46,7 +46,7 @@ public:
    };
    TSpectrum2Transform();
    TSpectrum2Transform(Int_t sizeX, Int_t sizeY);
-   virtual ~TSpectrum2Transform();
+   ~TSpectrum2Transform() override;
 
 protected:
    void                BitReverse(Double_t *working_space,Int_t num);
@@ -70,7 +70,7 @@ public:
    void                SetTransformType(Int_t transType, Int_t degree);
    void                Transform(const Double_t **fSource, Double_t **fDest);
 
-   ClassDef(TSpectrum2Transform,1)  //Spectrum2 Transformer, it calculates classic orthogonal 2D transforms
+   ClassDefOverride(TSpectrum2Transform,1)  //Spectrum2 Transformer, it calculates classic orthogonal 2D transforms
 };
 
 #endif

--- a/hist/spectrum/inc/TSpectrum3.h
+++ b/hist/spectrum/inc/TSpectrum3.h
@@ -36,7 +36,7 @@ public:
 
    TSpectrum3();
    TSpectrum3(Int_t maxpositions, Double_t resolution=1); // resolution is *NOT USED*
-   virtual ~TSpectrum3();
+   ~TSpectrum3() override;
    virtual const char *Background(const TH1 *hist, Int_t niter, Option_t *option="goff");
    const char         *Background(Double_t ***spectrum, Int_t ssizex, Int_t ssizey, Int_t ssizez, Int_t numberIterationsX,Int_t numberIterationsY, Int_t numberIterationsZ, Int_t direction,Int_t filterType);
    const char         *Deconvolution(Double_t ***source, const Double_t ***resp, Int_t ssizex, Int_t ssizey, Int_t ssizez,Int_t numberIterations, Int_t numberRepetitions, Double_t boost);
@@ -45,14 +45,14 @@ public:
    Double_t            *GetPositionX() const {return fPositionX;}
    Double_t            *GetPositionY() const {return fPositionY;}
    Double_t            *GetPositionZ() const {return fPositionZ;}
-   virtual void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
    virtual Int_t       Search(const TH1 *hist, Double_t sigma=2, Option_t *option="goff", Double_t threshold=0.05);
    Int_t               SearchFast(const Double_t ***source, Double_t ***dest, Int_t ssizex, Int_t ssizey, Int_t ssizez, Double_t sigma, Double_t threshold, Bool_t markov, Int_t averWindow);
    Int_t               SearchHighRes(const Double_t ***source,Double_t ***dest, Int_t ssizex, Int_t ssizey, Int_t ssizez, Double_t sigma, Double_t threshold, Bool_t backgroundRemove,Int_t deconIterations, Bool_t markov, Int_t averWindow);
    void                SetResolution(Double_t resolution=1); // *NOT USED*
    const char         *SmoothMarkov(Double_t ***source, Int_t ssizex, Int_t ssizey, Int_t ssizez, Int_t averWindow);
 
-   ClassDef(TSpectrum3,1)  //Peak Finder, Background estimator, Markov smoothing and Deconvolution for 3-D histograms
+   ClassDefOverride(TSpectrum3,1)  //Peak Finder, Background estimator, Markov smoothing and Deconvolution for 3-D histograms
 };
 
 #endif

--- a/hist/spectrum/inc/TSpectrumFit.h
+++ b/hist/spectrum/inc/TSpectrumFit.h
@@ -85,7 +85,7 @@ public:
    };
    TSpectrumFit(void); //default constructor
    TSpectrumFit(Int_t numberPeaks);
-   virtual ~TSpectrumFit();
+   ~TSpectrumFit() override;
 
    //auxiliary functions for 1. parameter fit functions
 protected:
@@ -128,7 +128,7 @@ public:
    void                SetPeakParameters(Double_t sigma, Bool_t fixSigma, const Double_t *positionInit, const Bool_t *fixPosition, const Double_t *ampInit, const Bool_t *fixAmp);
    void                SetTailParameters(Double_t tInit, Bool_t fixT, Double_t bInit, Bool_t fixB, Double_t sInit, Bool_t fixS);
 
-   ClassDef(TSpectrumFit,1)  //Spectrum Fitter using algorithm without matrix inversion and conjugate gradient method for symmetrical matrices (Stiefel-Hestens method)
+   ClassDefOverride(TSpectrumFit,1)  //Spectrum Fitter using algorithm without matrix inversion and conjugate gradient method for symmetrical matrices (Stiefel-Hestens method)
 };
 
 #endif

--- a/hist/spectrum/inc/TSpectrumTransform.h
+++ b/hist/spectrum/inc/TSpectrumTransform.h
@@ -47,7 +47,7 @@ public:
    };
    TSpectrumTransform();
    TSpectrumTransform(Int_t size);
-   virtual ~TSpectrumTransform();
+   ~TSpectrumTransform() override;
 
 protected:
    void                BitReverse(Double_t *working_space,Int_t num);
@@ -68,7 +68,7 @@ public:
    void                SetTransformType(Int_t transType, Int_t degree);
    void                Transform(const Double_t *source, Double_t *destVector);
 
-   ClassDef(TSpectrumTransform,1)  //Spectrum Transformer, it calculates classic orthogonal 1D transforms
+   ClassDefOverride(TSpectrumTransform,1)  //Spectrum Transformer, it calculates classic orthogonal 1D transforms
 };
 
 

--- a/hist/spectrumpainter/inc/TSpectrum2Painter.h
+++ b/hist/spectrumpainter/inc/TSpectrum2Painter.h
@@ -31,7 +31,7 @@ class TSpectrum2Painter: public TNamed {
 
 public:
    TSpectrum2Painter(TH2* h2, Int_t bs);
-   virtual ~TSpectrum2Painter();
+   ~TSpectrum2Painter() override;
 
    void GetAngles(Int_t &alpha,Int_t &beta,Int_t &view);
    void GetBezier(Int_t &bezier);
@@ -47,7 +47,7 @@ public:
    void GetPenAttr(Int_t &color, Int_t &style, Int_t &width);
    void GetShading(Int_t &shading,Int_t &shadow);
    void GetZScale(Int_t &scale);
-   void Paint(Option_t *option);
+   void Paint(Option_t *option) override;
    void SetAngles(Int_t alpha,Int_t beta,Int_t view);
    void SetBezier(Int_t bezier);
    void SetChanGrid(Int_t enable,Int_t color);
@@ -202,7 +202,7 @@ protected:
    void     Transform(Int_t it,Int_t jt,Int_t zmt);//transform function
 
 public:
-   ClassDef(TSpectrum2Painter,0)   //TSpectrum 3d graphics package
+   ClassDefOverride(TSpectrum2Painter,0)   //TSpectrum 3d graphics package
 
 private:
    TSpectrum2Painter (const TSpectrum2Painter&);

--- a/hist/unfold/inc/TUnfold.h
+++ b/hist/unfold/inc/TUnfold.h
@@ -274,7 +274,7 @@ public:
            EConstraint constraint=kEConstraintArea);
    // for root streamer and derived classes
    TUnfold(void);
-   virtual ~TUnfold(void);
+   ~TUnfold(void) override;
    // define input distribution
    virtual Int_t SetInput(const TH1 *hist_y, Double_t scaleBias=0.0,Double_t oneOverZeroError=0.0,const TH2 *hist_vyy=0,const TH2 *hist_vyy_inv=0);
    // Unfold with given choice of tau and input 
@@ -338,7 +338,7 @@ public:
    /// matrices with rank problems
    void SetEpsMatrix(Double_t eps); // set accuracy for eigenvalue analysis
 
-   ClassDef(TUnfold, TUnfold_CLASS_VERSION) //Unfolding with support for L-curve analysis
+   ClassDefOverride(TUnfold, TUnfold_CLASS_VERSION) //Unfolding with support for L-curve analysis
 };
 
 #endif

--- a/hist/unfold/inc/TUnfoldBinning.h
+++ b/hist/unfold/inc/TUnfoldBinning.h
@@ -94,7 +94,7 @@ class TUnfoldBinning : public TNamed {
    Bool_t AddAxis(const char *name,Int_t nBins,Double_t xMin,Double_t xMax,
                 Bool_t hasUnderflow,Bool_t hasOverflow); // add an axis (equidistant bins) to the distribution associated with this node
    Bool_t AddAxis(const TAxis &axis,Bool_t includeUnderflow,Bool_t includeOverflow); // add an axis (from TAxis instance) to the distribution associated with this node
-   virtual ~TUnfoldBinning(void);
+   ~TUnfoldBinning(void) override;
    void PrintStream(std::ostream &out,Int_t indent=0,int debug=0) const;
    void SetBinFactorFunction(Double_t normalisation,TF1 *userFunc=0); // define function to calculate bin factor. Note: the function is not owned by this class
 
@@ -196,7 +196,7 @@ class TUnfoldBinning : public TNamed {
    Int_t FillBinMapSingleNode(const TH1 *hist,Int_t startBin,Int_t nDim,const Int_t *axisList,const char *axisSteering,Int_t *binMap) const; // fill bin map for a single node
    void SetBinFactor(Double_t normalisation,TObject *factors); // define function to calculate bin factor. Note: the object is owned by this class, unless it is a function
 
-   ClassDef(TUnfoldBinning, TUnfold_CLASS_VERSION) //Complex binning schemes for TUnfoldDensity
+   ClassDefOverride(TUnfoldBinning, TUnfold_CLASS_VERSION) //Complex binning schemes for TUnfoldDensity
 };
 
 #endif

--- a/hist/unfold/inc/TUnfoldBinningXML.h
+++ b/hist/unfold/inc/TUnfoldBinningXML.h
@@ -65,7 +65,7 @@ static TUnfoldBinningXML *ImportXML(const TXMLDocument *document,const char *nam
    void AddAxisXML(TXMLNode *node); // import axis information
 protected:
 
-   ClassDef(TUnfoldBinningXML, TUnfold_CLASS_VERSION) //Complex binning schemes for TUnfoldDensity
+   ClassDefOverride(TUnfoldBinningXML, TUnfold_CLASS_VERSION) //Complex binning schemes for TUnfoldDensity
 };
 
 #endif

--- a/hist/unfold/inc/TUnfoldDensity.h
+++ b/hist/unfold/inc/TUnfoldDensity.h
@@ -72,7 +72,7 @@ class TUnfoldDensity : public TUnfoldSys {
    };
  protected:
 
-   virtual TString GetOutputBinName(Int_t iBinX) const; // name a bin
+   TString GetOutputBinName(Int_t iBinX) const override; // name a bin
 
    Double_t GetDensityFactor(EDensityMode densityMode,Int_t iBin) const; // density correction factor for this bin
    void RegularizeDistributionRecursive
@@ -95,7 +95,7 @@ class TUnfoldDensity : public TUnfoldSys {
 		     const char *regularisationDistribution=0,
 		     const char *regularisationAxisSteering="*[UOB]"); // constructor for using the histogram classes. Default regularisation is on the curvature of the bin-width normalized density, excluding underflow and overflow bins
 
-   virtual ~ TUnfoldDensity(void); // delete data members
+   ~ TUnfoldDensity(void) override; // delete data members
 
    void RegularizeDistribution(ERegMode regmode,EDensityMode densityMode,
 			       const char *distribution,
@@ -195,7 +195,7 @@ class TUnfoldDensity : public TUnfoldSys {
    const TUnfoldBinning *GetOutputBinning(const char *distributionName=0) const; // find binning scheme for output bins
    /// return binning scheme for regularisation conditions (matrix L)
 TUnfoldBinning *GetLBinning(void) const { return fRegularisationConditions; }
-   ClassDef(TUnfoldDensity, TUnfold_CLASS_VERSION) //Unfolding with density regularisation
+   ClassDefOverride(TUnfoldDensity, TUnfold_CLASS_VERSION) //Unfolding with density regularisation
 };
 
 #endif

--- a/hist/unfold/inc/TUnfoldSys.h
+++ b/hist/unfold/inc/TUnfoldSys.h
@@ -87,7 +87,7 @@ class TUnfoldSys : public TUnfold {
    /// Result: systematic shift from tau
    TMatrixDSparse *fDeltaSysTau;
  protected:
-   virtual void ClearResults(void);     // clear all results
+   void ClearResults(void) override;     // clear all results
    virtual void PrepareSysError(void); // common calculations for syst.errors
    virtual TMatrixDSparse *PrepareUncorrEmat(const TMatrixDSparse *m1,const TMatrixDSparse *m2); // calculate uncorrelated error matrix
    virtual TMatrixDSparse *PrepareCorrEmat(const TMatrixDSparse *m1,const TMatrixDSparse *m2,const TMatrixDSparse *dsys); // calculate correlated error matrix
@@ -110,13 +110,13 @@ class TUnfoldSys : public TUnfold {
    TUnfoldSys(const TH2 *hist_A, EHistMap histmap, ERegMode regmode = kRegModeSize,
              EConstraint constraint=kEConstraintArea);      // constructor
    TUnfoldSys(void);            // for derived classes
-   virtual ~ TUnfoldSys(void);    // delete data members
+   ~ TUnfoldSys(void) override;    // delete data members
    void AddSysError(const TH2 *sysError,const char *name, EHistMap histmap,
                     ESysErrMode mode); // add a systematic error source
    void SubtractBackground(const TH1 *hist_bgr,const char *name,
                            Double_t scale=1.0,
                            Double_t scale_error=0.0); // subtract background prior to unfolding
-   virtual Int_t SetInput(const TH1 *hist_y,Double_t scaleBias=0.0,Double_t oneOverZeroError=0.0,const TH2 *hist_vyy=0,const TH2 *hist_vyy_inv=0); // define input consistently in case of background subtraction
+   Int_t SetInput(const TH1 *hist_y,Double_t scaleBias=0.0,Double_t oneOverZeroError=0.0,const TH2 *hist_vyy=0,const TH2 *hist_vyy_inv=0) override; // define input consistently in case of background subtraction
    void SetTauError(Double_t delta_tau); // set uncertainty on tau
    TSortedList *GetBgrSources(void) const; // get names of background sources
    TSortedList *GetSysSources(void) const; // get names of systematic sources
@@ -139,7 +139,7 @@ class TUnfoldSys : public TUnfold {
    void GetEmatrixTotal(TH2 *ematrix,const Int_t *binMap=0); // get total error including systematic,statistical,background,tau errors
    void GetRhoItotal(TH1 *rhoi,const Int_t *binMap=0,TH2 *invEmat=0); // get global correlation coefficients including systematic,statistical,background,tau errors
    Double_t GetChi2Sys(void); // get total chi**2 including all systematic errors
-   ClassDef(TUnfoldSys, TUnfold_CLASS_VERSION) //Unfolding with support for systematic error propagation
+   ClassDefOverride(TUnfoldSys, TUnfold_CLASS_VERSION) //Unfolding with support for systematic error propagation
 };
 
 #endif


### PR DESCRIPTION
As suggested by @lmoneta, this is now the equivalent PR to https://github.com/root-project/root/pull/9808, but for `hist` instead of `roofit`.

For developers, it is unconvenient that the `override` specifier
that flags member functions as overriding on first sight is not used so
much in `hist`.

Now that the v6.28 development cycle has just started and there are no
major developments in the pipeline yet, I think it is a good time to add
the missing `override` specifiers everywhere in `hist`, as done already
for RooFitV.

This commit was generated more or less automatically with this Python
script that uses `clang-tidy`:

```Python
import os
import glob
import subprocess
import tqdm

"""
For clang-tidy to work, you have to copy the compile_commands.json from the
build directory back into the repo directory (just like in
.ci/copy_headers.sh).
"""

def get_sources(directory, extensions):

    files = []

    for ext in extensions:
        files += glob.glob(
            os.path.join(directory, "**/*" + ext), recursive=True
        )

    return files

"""
Recursively find extensions in directory, to figure out whic hextensions
should be globbed for.
   find . -type f -name '*.*' | sed 's|.*\.||' | sort -u
"""
extensions = [".h", ".hpp", ".cpp", ".cc", ".cxx"]

"""
Some extensions are recognized as C and not as C++ files by clang-tidy. We
need to rename them, and this dict specifies how file extensions should be
replaced.
"""
rename_dict = {".h": ".hpp"}

files = get_sources("hist", extensions)

cflags = (
    subprocess.check_output(["root-config", "--cflags"]).strip().decode("utf-8")
)

for file in tqdm.tqdm(files):

    file_renamed = file
    for ext, ext_renamed in rename_dict.items():
        if file.endswith(ext):
            file_renamed = file.replace(ext, ext_renamed)

    if file_renamed != file:
        os.rename(file, file_renamed)

    cmd = [
        "clang-tidy",
        "-checks=modernize-use-override",
        "--fix",
        file_renamed,
        "--",
    ] + cflags.split(" ")
    subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

    if file_renamed != file:
        os.rename(file_renamed, file)

"""
Finally, replace the ClassDef with the ClassDefOverride macros.
  find hist -type f -print | xargs sed -i 's/ClassDef(/ClassDefOverride(/'
...and change back the ClassDefOverride of non-overriding base classes.
"""
```