### PR TITLE
Make sure the bar color is different from the frame color

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -37,7 +37,6 @@
 #include "TRegexp.h"
 #include "strlcpy.h"
 #include "snprintf.h"
-#include "TVirtualPadPainter.h"
 
 Double_t *gxwork, *gywork, *gxworkl, *gyworkl;
 Int_t TGraphPainter::fgMaxPointsPerLine = 50;
@@ -1596,12 +1595,15 @@ void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *
 
    // Draw the graph as a bar chart
    if (optionBar) {
-      if(theGraph->GetFillColor()==gPad->GetFrameFillColor()) {
+      Int_t FillSave = theGraph->GetFillColor();
+      if(FillSave == gPad->GetFrameFillColor()) {
          // make sure the bars' color is different from the frame background
          if (gPad->GetFrameFillColor()==1) {
-            gPad->GetPainter()->SetFillColor(0);
+            theGraph->SetFillColor(0);
+            theGraph->TAttFill::Modify();
          } else {
-            gPad->GetPainter()->SetFillColor(1);
+            theGraph->SetFillColor(1);
+            theGraph->TAttFill::Modify();
          }
       }
       if (!optionR) {
@@ -1659,6 +1661,8 @@ void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *
             gPad->PaintBox(gxworkl[0],gyworkl[0],gxworkl[1],gyworkl[1]);
          }
       }
+      theGraph->SetFillColor(FillSave);
+      theGraph->TAttFill::Modify();
    }
    gPad->ResetBit(TGraph::kClipFrame);
 

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -37,6 +37,7 @@
 #include "TRegexp.h"
 #include "strlcpy.h"
 #include "snprintf.h"
+#include "TVirtualPadPainter.h"
 
 Double_t *gxwork, *gywork, *gxworkl, *gyworkl;
 Int_t TGraphPainter::fgMaxPointsPerLine = 50;
@@ -1595,6 +1596,14 @@ void TGraphPainter::PaintGraph(TGraph *theGraph, Int_t npoints, const Double_t *
 
    // Draw the graph as a bar chart
    if (optionBar) {
+      if(theGraph->GetFillColor()==gPad->GetFrameFillColor()) {
+         // make sure the bars' color is different from the frame background
+         if (gPad->GetFrameFillColor()==1) {
+            gPad->GetPainter()->SetFillColor(0);
+         } else {
+            gPad->GetPainter()->SetFillColor(1);
+         }
+      }
       if (!optionR) {
          barxmin = x[0];
          barxmax = x[0];


### PR DESCRIPTION
Since the new defaults have been setup (ie the new "Clean Style")
the bar color for graphs was by default white (equal t the frame color).
As the bars are fill area only (no borders) they were invisible by default.
This patch make sure the bar color is different form the frame color.
This PR fixes: https://github.com/root-project/root/issues/9870

