### PR TITLE
[RF][RelNotes] Remove any support for deprecated string fit options in RooFit

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -66,6 +66,15 @@ The following people have contributed to this new version:
 - `TTree::GetEntry()` and `TTree::GetEvent()` no longer have 0 as the default value for the first parameter `entry`. We are not aware of correct uses of this function without providing an entry number. If you have one, please simply pass `0` from now on.
 - `TBufferMerger` is now out of the `Experimental` namespace (`ROOT::Experimental::TBufferMerger` is deprecated, please use `ROOT::TBufferMerger` instead)
 - RooFit container classes marked as deprecated with this release: `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList`. These classes are still available in this release, but will be removed in the next one. Please migrate to STL container classes, such as `std::unordered_map`, `std::set`, and `std::vector`.
+- The `RooFit::FitOptions(const char*)` command to steer [RooAbsPdf::fitTo()](https://root.cern.ch/doc/v628/classRooAbsPdf.html) with an option string in now deprecated and will be removed in ROOT v6.28. Please migrate to the RooCmdArg-based fit configuration. The former character flags map to RooFit command arguments as follows:
+    - `'h'` : RooFit::Hesse()
+    - `'m'` : RooFit::Minos()
+    - `'o'` : RooFit::Optimize(1)
+    - `'r'` : RooFit::Save()
+    - `'t'` : RooFit::Timer()
+    - `'v'` : RooFit::Verbose()
+    - `'0'` : RooFit::Strategy(0)
+  Subsequently, the `RooMinimizer::fit(const char*)` function and the [RooMCStudy](https://root.cern.ch/doc/v626/classRooMCStudy.html) constructor that takes an option string is deprecated as well.
 
 
 ## Core Libraries

--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -43,6 +43,8 @@ Please use their non-experimental counterparts `ROOT::TBufferMerger` and `ROOT::
 - `ROOT::RVec::emplace()` has now been removed after deprecation; please use `ROOT::RVec::insert()` instead.
 - The deprecated function `ROOT::Detail::RDF::RActionImpl<Helper>::GetDataBlockCallback()` is removed; please use `GetSampleCallback()` instead.
 - The deprecated RooFit containers `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList` are removed. Please use STL container classes instead, like `std::unordered_map`, `std::set`, and `std::vector`.
+- The `RooFit::FitOptions(const char*)` command to steer [RooAbsPdf::fitTo()](https://root.cern.ch/doc/v628/classRooAbsPdf.html) with an option string was removed. This way of configuring the fit was deprecated since at least since ROOT 5.02.
+  Subsequently, the `RooMinimizer::fit(const char*)` function and the [RooMCStudy](https://root.cern.ch/doc/v628/classRooMCStudy.html) constructor that takes an option string was removed as well.
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooAbsMCStudyModule.h
+++ b/roofit/roofitcore/inc/RooAbsMCStudyModule.h
@@ -150,11 +150,6 @@ protected:
 
    // Accessors for fit options, generator and MCstudy configuration flags
 
-   /// Return fit option string provided user
-   const char* fitOptions() {
-     return _mcs ? _mcs->_fitOptions.Data() : 0 ;
-   }
-
    /// Return list of fit options provided by user
    RooLinkedList* fitOptList() {
      return _mcs ? &_mcs->_fitOptList : 0 ;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -165,7 +165,6 @@ public:
   //RooAbsPdf::fitTo.
   struct MinimizerConfig {
       double recoverFromNaN = 10.;
-      std::string fitOpt = "";
       int optConst = 2;
       int verbose = 0;
       int doSave = 0;

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -47,12 +47,6 @@ class RooAbsCollection ;
 class TH1 ;
 class TTree ;
 
-namespace RooFitLegacy {
-
-RooCmdArg FitOptions(const char* opts);
-
-}
-
 /*! \namespace RooFit
 The namespace RooFit contains mostly switches that change the behaviour of functions of PDFs
 (or other types of arguments).
@@ -228,10 +222,6 @@ RooCmdArg IntegrateBins(double precision);
 
 // RooAbsPdf::fitTo arguments
 RooCmdArg PrefitDataFraction(Double_t data_ratio = 0.0) ;
-RooCmdArg FitOptions(const char* opts)
-  R__DEPRECATED(6,28,"Please migrate to the RooCmdArg-based fit configuration"
-                     " (or use RooFitLegacy::FitOptions(const char*) to silence this warning,"
-                     " but be warned that the RooFitLegacy function also gets removed in ROOT v6.28).") ;
 RooCmdArg Optimize(Int_t flag=2) ;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -18,6 +18,9 @@
 
 #include "RooCmdArg.h"
 #include "RooArgSet.h"
+
+#include "ROOT/RConfig.hxx"
+
 #include <map>
 #include <string>
 
@@ -43,6 +46,12 @@ class RooArgList ;
 class RooAbsCollection ;
 class TH1 ;
 class TTree ;
+
+namespace RooFitLegacy {
+
+RooCmdArg FitOptions(const char* opts);
+
+}
 
 /*! \namespace RooFit
 The namespace RooFit contains mostly switches that change the behaviour of functions of PDFs
@@ -219,7 +228,10 @@ RooCmdArg IntegrateBins(double precision);
 
 // RooAbsPdf::fitTo arguments
 RooCmdArg PrefitDataFraction(Double_t data_ratio = 0.0) ;
-RooCmdArg FitOptions(const char* opts) ;
+RooCmdArg FitOptions(const char* opts)
+  R__DEPRECATED(6,28,"Please migrate to the RooCmdArg-based fit configuration"
+                     " (or use RooFitLegacy::FitOptions(const char*) to silence this warning,"
+                     " but be warned that the RooFitLegacy function also gets removed in ROOT v6.28).") ;
 RooCmdArg Optimize(Int_t flag=2) ;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -40,7 +40,9 @@ public:
   RooMCStudy(const RooAbsPdf& genModel, const RooAbsPdf& fitModel,
         const RooArgSet& dependents, const char* genOptions="",
         const char* fitOptions="", const RooDataSet* genProtoData=0,
-        const RooArgSet& projDeps=RooArgSet()) ;
+        const RooArgSet& projDeps=RooArgSet()) R__DEPRECATED(6,28,
+  "please migrate to the other RooMCStudy constructor that doesn't use the deprecated string-based fit options.");
+
   ~RooMCStudy() override ;
 
   // Method to add study modules

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -37,12 +37,6 @@ public:
              const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
              const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
 
-  RooMCStudy(const RooAbsPdf& genModel, const RooAbsPdf& fitModel,
-        const RooArgSet& dependents, const char* genOptions="",
-        const char* fitOptions="", const RooDataSet* genProtoData=0,
-        const RooArgSet& projDeps=RooArgSet()) R__DEPRECATED(6,28,
-  "please migrate to the other RooMCStudy constructor that doesn't use the deprecated string-based fit options.");
-
   ~RooMCStudy() override ;
 
   // Method to add study modules
@@ -133,7 +127,6 @@ protected:
   TList       _fitResList ;     // List of RooFitResult fit output objects
   RooDataSet* _genParData ;     // List of of generated parameters of each sample
   RooDataSet* _fitParData ;     // Data set of fit parameters of each sample
-  TString     _fitOptions ;     // Fit options string
   RooLinkedList _fitOptList ;   // Fit option command list
   Bool_t      _extendedGen ;    // Add poisson term to number of events to generate?
   Bool_t      _binGenData ;     // Bin data between generating and fitting

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -27,8 +27,6 @@
 #include <utility>
 #include "TMatrixDSymfwd.h"
 
-#include "RooArgList.h" // cannot just use forward decl due to default argument in lastMinuitFit
-
 #include <RooAbsMinimizerFcn.h>
 #include <RooFit/TestStatistics/RooAbsL.h>
 #include <RooFit/TestStatistics/LikelihoodWrapper.h>
@@ -63,48 +61,49 @@ public:
 
   enum Strategy { Speed=0, Balance=1, Robustness=2 } ;
   enum PrintLevel { None=-1, Reduced=0, Normal=1, ExtraForProblem=2, Maximum=3 } ;
-  void setStrategy(Int_t strat) ;
-  void setErrorLevel(Double_t level) ;
-  void setEps(Double_t eps) ;
-  void optimizeConst(Int_t flag) ;
-  void setEvalErrorWall(Bool_t flag) { fitterFcn()->SetEvalErrorWall(flag); }
+  void setStrategy(int strat) ;
+  void setErrorLevel(double level) ;
+  void setEps(double eps) ;
+  void optimizeConst(int flag) ;
+  void setEvalErrorWall(bool flag) { fitterFcn()->SetEvalErrorWall(flag); }
   /// \copydoc RooMinimizerFcn::SetRecoverFromNaNStrength()
   void setRecoverFromNaNStrength(double strength) { fitterFcn()->SetRecoverFromNaNStrength(strength); }
-  void setOffsetting(Bool_t flag) ;
-  void setMaxIterations(Int_t n) ;
-  void setMaxFunctionCalls(Int_t n) ;
+  void setOffsetting(bool flag) ;
+  void setMaxIterations(int n) ;
+  void setMaxFunctionCalls(int n) ;
 
-  Int_t migrad() ;
-  Int_t hesse() ;
-  Int_t minos() ;
-  Int_t minos(const RooArgSet& minosParamList) ;
-  Int_t seek() ;
-  Int_t simplex() ;
-  Int_t improve() ;
+  int migrad() ;
+  int hesse() ;
+  int minos() ;
+  int minos(const RooArgSet& minosParamList) ;
+  int seek() ;
+  int simplex() ;
+  int improve() ;
 
-  Int_t minimize(const char* type, const char* alg=0) ;
+  int minimize(const char* type, const char* alg=0) ;
 
   RooFitResult* save(const char* name=0, const char* title=0) ;
   RooPlot* contour(RooRealVar& var1, RooRealVar& var2,
-         Double_t n1=1, Double_t n2=2, Double_t n3=0,
-         Double_t n4=0, Double_t n5=0, Double_t n6=0, unsigned int npoints = 50) ;
+         double n1=1, double n2=2, double n3=0,
+         double n4=0, double n5=0, double n6=0, unsigned int npoints = 50) ;
 
-  Int_t setPrintLevel(Int_t newLevel) ;
-  void setPrintEvalErrors(Int_t numEvalErrors) { fitterFcn()->SetPrintEvalErrors(numEvalErrors); }
-  void setVerbose(Bool_t flag=kTRUE) { _verbose = flag ; fitterFcn()->SetVerbose(flag); }
-  void setProfile(Bool_t flag=kTRUE) { _profile = flag ; }
-  Bool_t setLogFile(const char* logf=0) { return fitterFcn()->SetLogFile(logf); }
+  int setPrintLevel(int newLevel) ;
+  void setPrintEvalErrors(int numEvalErrors) { fitterFcn()->SetPrintEvalErrors(numEvalErrors); }
+  void setVerbose(bool flag=true) { _verbose = flag ; fitterFcn()->SetVerbose(flag); }
+  void setProfile(bool flag=true) { _profile = flag ; }
+  bool setLogFile(const char* logf=nullptr) { return fitterFcn()->SetLogFile(logf); }
 
-  Int_t getPrintLevel() const;
+  int getPrintLevel() const { return _printLevel; }
 
   void setMinimizerType(const char* type) ;
 
   static void cleanup() ;
-  static RooFitResult* lastMinuitFit(const RooArgList& varList=RooArgList()) ;
+  static RooFitResult* lastMinuitFit() ;
+  static RooFitResult* lastMinuitFit(const RooArgList& varList) ;
 
-  void saveStatus(const char* label, Int_t status) { _statusHistory.push_back(std::pair<std::string,int>(label,status)) ; }
+  void saveStatus(const char* label, int status) { _statusHistory.push_back(std::pair<std::string,int>(label,status)) ; }
 
-  Int_t evalCounter() const { return fitterFcn()->evalCounter() ; }
+  int evalCounter() const { return fitterFcn()->evalCounter() ; }
   void zeroEvalCount() { fitterFcn()->zeroEvalCount() ; }
 
   ROOT::Fit::Fitter* fitter() ;
@@ -113,7 +112,7 @@ public:
   ROOT::Math::IMultiGenFunction* getFitterMultiGenFcn() const;
   ROOT::Math::IMultiGenFunction* getMultiGenFcn() const;
 
-  inline Int_t getNPar() const { return fitterFcn()->getNDim() ; }
+  inline int getNPar() const { return fitterFcn()->getNDim() ; }
 
 protected:
 
@@ -124,7 +123,7 @@ protected:
   void profileStop() ;
 
   inline std::ofstream* logfile() { return fitterFcn()->GetLogFile(); }
-  inline Double_t& maxFCN() { return fitterFcn()->GetMaxFCN() ; }
+  inline double& maxFCN() { return fitterFcn()->GetMaxFCN() ; }
 
   const RooAbsMinimizerFcn *fitterFcn() const;
   RooAbsMinimizerFcn *fitterFcn();
@@ -136,22 +135,22 @@ private:
   void initMinimizerFirstPart();
   void initMinimizerFcnDependentPart(double defaultErrorLevel);
 
-  Int_t _printLevel = 1;
-  Int_t _status = -99;
-  Bool_t _profile = kFALSE;
+  int _printLevel = 1;
+  int _status = -99;
+  bool _profile = false;
 
-  Bool_t _verbose = kFALSE;
+  bool _verbose = false;
   TStopwatch _timer;
   TStopwatch _cumulTimer;
-  Bool_t _profileStart = kFALSE;
+  bool _profileStart = false;
 
-  TMatrixDSym *_extV = 0;
+  std::unique_ptr<TMatrixDSym> _extV;
 
   RooAbsMinimizerFcn *_fcn;
   std::string _minimizerType = "Minuit";
   FcnMode _fcnMode;
 
-  static ROOT::Fit::Fitter *_theFitter ;
+  static std::unique_ptr<ROOT::Fit::Fitter> _theFitter ;
 
   std::vector<std::pair<std::string,int> > _statusHistory ;
 

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -74,7 +74,8 @@ public:
   void setMaxIterations(Int_t n) ;
   void setMaxFunctionCalls(Int_t n) ;
 
-  RooFitResult* fit(const char* options) ;
+  RooFitResult* fit(const char* options) R__DEPRECATED(6,28,
+  "using RooMinimizer::fit() with string-based options is deprecated. Please use RooAbsPdf::fitTo() instead.");
 
   Int_t migrad() ;
   Int_t hesse() ;

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -74,9 +74,6 @@ public:
   void setMaxIterations(Int_t n) ;
   void setMaxFunctionCalls(Int_t n) ;
 
-  RooFitResult* fit(const char* options) R__DEPRECATED(6,28,
-  "using RooMinimizer::fit() with string-based options is deprecated. Please use RooAbsPdf::fitTo() instead.");
-
   Int_t migrad() ;
   Int_t hesse() ;
   Int_t minos() ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4698,7 +4698,24 @@ RooFitResult* RooAbsReal::chi2FitDriver(RooAbsReal& fcn, RooLinkedList& cmdList)
   if (fitOpt) {
 
     // Play fit options as historically defined
-    ret = m.fit(fitOpt) ;
+    // (code copied from RooMinimizer::fit() instead of calling said function to avoid deprecation warning)
+    TString opts(fitOpt) ;
+    opts.ToLower() ;
+
+    // Initial configuration
+    if (opts.Contains("v")) m.setVerbose(1) ;
+    if (opts.Contains("t")) m.setProfile(1) ;
+    if (opts.Contains("l")) m.setLogFile(Form("%s.log",fcn.GetName())) ;
+    if (opts.Contains("c")) m.optimizeConst(1) ;
+
+    // Fitting steps
+    if (opts.Contains("0")) m.setStrategy(0) ;
+    m.migrad() ;
+    if (opts.Contains("0")) m.setStrategy(1) ;
+    if (opts.Contains("h")||!opts.Contains("m")) m.hesse() ;
+    if (!opts.Contains("m")) m.minos() ;
+
+    ret = (opts.Contains("r")) ? m.save() : 0 ;
 
   } else {
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -29,6 +29,7 @@
 #include "RooAbsPdf.h"
 #include "RooFormulaVar.h"
 #include "RooHelpers.h"
+#include "RooMsgService.h"
 #include "TH1.h"
 
 #include <algorithm>
@@ -216,7 +217,22 @@ namespace RooFit {
 
   // RooAbsPdf::fitTo arguments
   RooCmdArg PrefitDataFraction(Double_t data_ratio)  { return RooCmdArg("Prefit",0,0,data_ratio,0,nullptr,nullptr,nullptr,nullptr) ; }
-  RooCmdArg FitOptions(const char* opts) { return RooCmdArg("FitOptions",0,0,0,0,opts,0,0,0) ; }
+  RooCmdArg FitOptions(const char* opts) {
+    oocoutW(static_cast<TObject*>(nullptr), Fitting)
+      << "RooFit::FitOptions(const char* opts) will be removed in ROOT v628!\n"
+      << "Please migrate to the RooCmdArg-based fit configuration.\n"
+      << "The former character flags map to RooFit command arguments as follows:\n"
+      << "    'h' : RooFit::Hesse()\n"
+      << "    'm' : RooFit::Minos()\n"
+      << "    'o' : RooFit::Optimize(1)\n"
+      << "    'r' : RooFit::Save()\n"
+      << "    't' : RooFit::Timer()\n"
+      << "    'v' : RooFit::Verbose()\n"
+      << "    '0' : RooFit::Strategy(0)\n"
+      << "You can alternatively silence this warning by using RooFitLegacy::FitOptions(const char*),\n"
+      << "but this will get removed in ROOT v6.28 as well.\n";
+    return RooFitLegacy::FitOptions(opts);
+  }
   RooCmdArg Optimize(Int_t flag)         { return RooCmdArg("Optimize",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Verbose(Bool_t flag)         { return RooCmdArg("Verbose",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Save(Bool_t flag)            { return RooCmdArg("Save",flag,0,0,0,0,0,0,0) ; }
@@ -392,6 +408,9 @@ namespace RooFit {
 
 } // End namespace RooFit
 
+namespace RooFitLegacy {
+  RooCmdArg FitOptions(const char* opts) { return RooCmdArg("FitOptions",0,0,0,0,opts,0,0,0) ; }
+}
 
 namespace RooFitShortHand {
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -217,22 +217,6 @@ namespace RooFit {
 
   // RooAbsPdf::fitTo arguments
   RooCmdArg PrefitDataFraction(Double_t data_ratio)  { return RooCmdArg("Prefit",0,0,data_ratio,0,nullptr,nullptr,nullptr,nullptr) ; }
-  RooCmdArg FitOptions(const char* opts) {
-    oocoutW(static_cast<TObject*>(nullptr), Fitting)
-      << "RooFit::FitOptions(const char* opts) will be removed in ROOT v628!\n"
-      << "Please migrate to the RooCmdArg-based fit configuration.\n"
-      << "The former character flags map to RooFit command arguments as follows:\n"
-      << "    'h' : RooFit::Hesse()\n"
-      << "    'm' : RooFit::Minos()\n"
-      << "    'o' : RooFit::Optimize(1)\n"
-      << "    'r' : RooFit::Save()\n"
-      << "    't' : RooFit::Timer()\n"
-      << "    'v' : RooFit::Verbose()\n"
-      << "    '0' : RooFit::Strategy(0)\n"
-      << "You can alternatively silence this warning by using RooFitLegacy::FitOptions(const char*),\n"
-      << "but this will get removed in ROOT v6.28 as well.\n";
-    return RooFitLegacy::FitOptions(opts);
-  }
   RooCmdArg Optimize(Int_t flag)         { return RooCmdArg("Optimize",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Verbose(Bool_t flag)         { return RooCmdArg("Verbose",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Save(Bool_t flag)            { return RooCmdArg("Save",flag,0,0,0,0,0,0,0) ; }
@@ -407,10 +391,6 @@ namespace RooFit {
 
 
 } // End namespace RooFit
-
-namespace RooFitLegacy {
-  RooCmdArg FitOptions(const char* opts) { return RooCmdArg("FitOptions",0,0,0,0,opts,0,0,0) ; }
-}
 
 namespace RooFitShortHand {
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -766,9 +766,9 @@ RooFitResult* RooMCStudy::doFit(RooAbsData* genSample)
   RooFitResult* fr ;
   if (_fitOptList.GetSize()==0) {
     if (_projDeps.getSize()>0) {
-      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFit::ConditionalObservables(_projDeps),RooFit::FitOptions(fitOpt2)) ;
+      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFit::ConditionalObservables(_projDeps),RooFitLegacy::FitOptions(fitOpt2)) ;
     } else {
-      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFit::FitOptions(fitOpt2)) ;
+      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFitLegacy::FitOptions(fitOpt2)) ;
     }
   } else {
     RooCmdArg save  = RooFit::Save() ;

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -303,40 +303,6 @@ const ROOT::Fit::Fitter* RooMinimizer::fitter() const
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Parse traditional RooAbsPdf::fitTo driver options
-///
-///  m - Run Migrad only
-///  h - Run Hesse to estimate errors
-///  v - Verbose mode
-///  l - Log parameters after each Minuit steps to file
-///  t - Activate profile timer
-///  r - Save fit result
-///  0 - Run Migrad with strategy 0
-
-RooFitResult* RooMinimizer::fit(const char* options)
-{
-  TString opts(options) ;
-  opts.ToLower() ;
-
-  // Initial configuration
-  if (opts.Contains("v")) setVerbose(1) ;
-  if (opts.Contains("t")) setProfile(1) ;
-  if (opts.Contains("l")) setLogFile(Form("%s.log",_fcn->getFunctionName().c_str())) ;
-  if (opts.Contains("c")) optimizeConst(1) ;
-
-  // Fitting steps
-  if (opts.Contains("0")) setStrategy(0) ;
-  migrad() ;
-  if (opts.Contains("0")) setStrategy(1) ;
-  if (opts.Contains("h")||!opts.Contains("m")) hesse() ;
-  if (!opts.Contains("m")) minos() ;
-
-  return (opts.Contains("r")) ? save() : 0 ;
-}
-
-
 bool RooMinimizer::fitFcn() const {
    bool ret;
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -67,16 +67,12 @@ automatic PDF optimization.
 #include <iostream>
 #include <fstream>
 
-#if (__GNUC__==3&&__GNUC_MINOR__==2&&__GNUC_PATCHLEVEL__==3)
-char* operator+( streampos&, char* );
-#endif
-
 using namespace std;
 
 ClassImp(RooMinimizer);
 ;
 
-ROOT::Fit::Fitter *RooMinimizer::_theFitter = 0 ;
+std::unique_ptr<ROOT::Fit::Fitter> RooMinimizer::_theFitter = {};
 
 
 
@@ -86,10 +82,7 @@ ROOT::Fit::Fitter *RooMinimizer::_theFitter = 0 ;
 
 void RooMinimizer::cleanup()
 {
-  if (_theFitter) {
-    delete _theFitter ;
-    _theFitter =0 ;
-  }
+  _theFitter.reset();
 }
 
 
@@ -150,10 +143,7 @@ void RooMinimizer::initMinimizerFirstPart()
 {
    RooSentinel::activate();
 
-   if (_theFitter) {
-      delete _theFitter;
-   }
-   _theFitter = new ROOT::Fit::Fitter;
+   _theFitter = std::make_unique<ROOT::Fit::Fitter>();
    _theFitter->Config().SetMinimizer(_minimizerType.c_str());
    setEps(1.0); // default tolerance
 }
@@ -188,10 +178,6 @@ void RooMinimizer::initMinimizerFcnDependentPart(double defaultErrorLevel)
 
 RooMinimizer::~RooMinimizer()
 {
-  if (_extV) {
-    delete _extV ;
-  }
-
   if (_fcn) {
     delete _fcn;
   }
@@ -206,7 +192,7 @@ RooMinimizer::~RooMinimizer()
 /// most efficiently with fast FCNs (0), expensive FCNs (2)
 /// and 'intermediate' FCNs (1)
 
-void RooMinimizer::setStrategy(Int_t istrat)
+void RooMinimizer::setStrategy(int istrat)
 {
   _theFitter->Config().MinimizerOptions().SetStrategy(istrat);
 
@@ -218,7 +204,7 @@ void RooMinimizer::setStrategy(Int_t istrat)
 /// Change maximum number of MINUIT iterations
 /// (RooMinimizer default 500 * #parameters)
 
-void RooMinimizer::setMaxIterations(Int_t n)
+void RooMinimizer::setMaxIterations(int n)
 {
   _theFitter->Config().MinimizerOptions().SetMaxIterations(n);
 }
@@ -230,7 +216,7 @@ void RooMinimizer::setMaxIterations(Int_t n)
 /// Change maximum number of likelihood function calss from MINUIT
 /// (RooMinimizer default 500 * #parameters)
 
-void RooMinimizer::setMaxFunctionCalls(Int_t n)
+void RooMinimizer::setMaxFunctionCalls(int n)
 {
   _theFitter->Config().MinimizerOptions().SetMaxFunctionCalls(n);
 }
@@ -244,7 +230,7 @@ void RooMinimizer::setMaxFunctionCalls(Int_t n)
 /// that is taken in the RooMinimizer constructor from
 /// the defaultErrorLevel() method of the input function
 
-void RooMinimizer::setErrorLevel(Double_t level)
+void RooMinimizer::setErrorLevel(double level)
 {
   _theFitter->Config().MinimizerOptions().SetErrorDef(level);
 
@@ -255,7 +241,7 @@ void RooMinimizer::setErrorLevel(Double_t level)
 ////////////////////////////////////////////////////////////////////////////////
 /// Change MINUIT epsilon
 
-void RooMinimizer::setEps(Double_t eps)
+void RooMinimizer::setEps(double eps)
 {
   _theFitter->Config().MinimizerOptions().SetTolerance(eps);
 
@@ -265,7 +251,7 @@ void RooMinimizer::setEps(Double_t eps)
 ////////////////////////////////////////////////////////////////////////////////
 /// Enable internal likelihood offsetting for enhanced numeric precision
 
-void RooMinimizer::setOffsetting(Bool_t flag)
+void RooMinimizer::setOffsetting(bool flag)
 {
   _fcn->setOffsetting(flag);
 }
@@ -290,7 +276,7 @@ void RooMinimizer::setMinimizerType(const char* type)
 
 ROOT::Fit::Fitter* RooMinimizer::fitter()
 {
-  return _theFitter ;
+  return _theFitter.get() ;
 }
 
 
@@ -299,7 +285,7 @@ ROOT::Fit::Fitter* RooMinimizer::fitter()
 
 const ROOT::Fit::Fitter* RooMinimizer::fitter() const
 {
-  return _theFitter ;
+  return _theFitter.get() ;
 }
 
 
@@ -333,7 +319,7 @@ bool RooMinimizer::fitFcn() const {
 /// \param[in] type Type of fitter to use, e.g. "Minuit" "Minuit2".
 /// \attention This overrides the default fitter of this RooMinimizer.
 /// \param[in] alg  Fit algorithm to use. (Optional)
-Int_t RooMinimizer::minimize(const char* type, const char* alg)
+int RooMinimizer::minimize(const char* type, const char* alg)
 {
   _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
           _fcn->getOptConst(),_verbose) ;
@@ -365,7 +351,7 @@ Int_t RooMinimizer::minimize(const char* type, const char* alg)
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::migrad()
+int RooMinimizer::migrad()
 {
   _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
           _fcn->getOptConst(),_verbose) ;
@@ -394,7 +380,7 @@ Int_t RooMinimizer::migrad()
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::hesse()
+int RooMinimizer::hesse()
 {
   if (_theFitter->GetMinimizer()==0) {
     coutW(Minimization) << "RooMinimizer::hesse: Error, run Migrad before Hesse!"
@@ -431,7 +417,7 @@ Int_t RooMinimizer::hesse()
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::minos()
+int RooMinimizer::minos()
 {
   if (_theFitter->GetMinimizer()==0) {
     coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!"
@@ -469,14 +455,14 @@ Int_t RooMinimizer::minos()
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::minos(const RooArgSet& minosParamList)
+int RooMinimizer::minos(const RooArgSet& minosParamList)
 {
   if (_theFitter->GetMinimizer()==0) {
     coutW(Minimization) << "RooMinimizer::minos: Error, run Migrad before Minos!"
          << endl ;
     _status = -1;
   }
-  else if (minosParamList.getSize()>0) {
+  else if (!minosParamList.empty()) {
 
     _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
             _fcn->getOptConst(),_verbose) ;
@@ -485,17 +471,14 @@ Int_t RooMinimizer::minos(const RooArgSet& minosParamList)
     RooAbsReal::clearEvalErrorLog() ;
 
     // get list of parameters for Minos
-    TIterator* aIter = minosParamList.createIterator() ;
-    RooAbsArg* arg ;
     std::vector<unsigned int> paramInd;
-    while((arg=(RooAbsArg*)aIter->Next())) {
+    for(RooAbsArg * arg : minosParamList) {
       RooAbsArg* par = _fcn->GetFloatParamList()->find(arg->GetName());
       if (par && !par->isConstant()) {
-   Int_t index = _fcn->GetFloatParamList()->index(par);
+   int index = _fcn->GetFloatParamList()->index(par);
    paramInd.push_back(index);
       }
     }
-    delete aIter ;
 
     if (paramInd.size()) {
       // set the parameter indeces
@@ -505,7 +488,7 @@ Int_t RooMinimizer::minos(const RooArgSet& minosParamList)
       bool ret = _theFitter->CalculateMinosErrors();
       _status = ((ret) ? _theFitter->Result().Status() : -1);
       // to avoid that following minimization computes automatically the Minos errors
-      _theFitter->Config().SetMinosErrors(kFALSE);
+      _theFitter->Config().SetMinosErrors(false);
 
     }
 
@@ -528,7 +511,7 @@ Int_t RooMinimizer::minos(const RooArgSet& minosParamList)
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::seek()
+int RooMinimizer::seek()
 {
   _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
           _fcn->getOptConst(),_verbose) ;
@@ -557,7 +540,7 @@ Int_t RooMinimizer::seek()
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::simplex()
+int RooMinimizer::simplex()
 {
   _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
           _fcn->getOptConst(),_verbose) ;
@@ -586,7 +569,7 @@ Int_t RooMinimizer::simplex()
 /// propagated back the RooRealVars representing
 /// the floating parameters in the MINUIT operation.
 
-Int_t RooMinimizer::improve()
+int RooMinimizer::improve()
 {
   _fcn->Synchronize(_theFitter->Config().ParamsSettings(),
           _fcn->getOptConst(),_verbose) ;
@@ -612,9 +595,9 @@ Int_t RooMinimizer::improve()
 ////////////////////////////////////////////////////////////////////////////////
 /// Change the MINUIT internal printing level
 
-Int_t RooMinimizer::setPrintLevel(Int_t newLevel)
+int RooMinimizer::setPrintLevel(int newLevel)
 {
-  Int_t ret = _printLevel ;
+  int ret = _printLevel ;
   _theFitter->Config().MinimizerOptions().SetPrintLevel(newLevel+1);
   _printLevel = newLevel+1 ;
   return ret ;
@@ -624,7 +607,7 @@ Int_t RooMinimizer::setPrintLevel(Int_t newLevel)
 /// If flag is true, perform constant term optimization on
 /// function being minimized.
 
-void RooMinimizer::optimizeConst(Int_t flag)
+void RooMinimizer::optimizeConst(int flag)
 {
    _fcn->setOptimizeConst(flag);
 }
@@ -644,7 +627,7 @@ RooFitResult* RooMinimizer::save(const char* userName, const char* userTitle)
   if (_theFitter->GetMinimizer()==0) {
     coutW(Minimization) << "RooMinimizer::save: Error, run minimization before!"
          << endl ;
-    return 0;
+    return nullptr;
   }
 
   TString name,title ;
@@ -653,14 +636,13 @@ RooFitResult* RooMinimizer::save(const char* userName, const char* userTitle)
   RooFitResult* fitRes = new RooFitResult(name,title) ;
 
   // Move eventual fixed parameters in floatList to constList
-  Int_t i ;
   RooArgList saveConstList(*(_fcn->GetConstParamList())) ;
   RooArgList saveFloatInitList(*(_fcn->GetInitFloatParamList())) ;
   RooArgList saveFloatFinalList(*(_fcn->GetFloatParamList())) ;
-  for (i=0 ; i<_fcn->GetFloatParamList()->getSize() ; i++) {
+  for (std::size_t i=0 ; i<_fcn->GetFloatParamList()->size() ; i++) {
     RooAbsArg* par = _fcn->GetFloatParamList()->at(i) ;
     if (par->isConstant()) {
-      saveFloatInitList.remove(*saveFloatInitList.find(par->GetName()),kTRUE) ;
+      saveFloatInitList.remove(*saveFloatInitList.find(par->GetName()),true) ;
       saveFloatFinalList.remove(*par) ;
       saveConstList.add(*par) ;
     }
@@ -687,9 +669,9 @@ RooFitResult* RooMinimizer::save(const char* userName, const char* userTitle)
     std::vector<double> globalCC;
     TMatrixDSym corrs(_theFitter->Result().Parameters().size()) ;
     TMatrixDSym covs(_theFitter->Result().Parameters().size()) ;
-    for (UInt_t ic=0; ic<_theFitter->Result().Parameters().size(); ic++) {
+    for (std::size_t ic=0; ic<_theFitter->Result().Parameters().size(); ic++) {
       globalCC.push_back(_theFitter->Result().GlobalCC(ic));
-      for (UInt_t ii=0; ii<_theFitter->Result().Parameters().size(); ii++) {
+      for (std::size_t ii=0; ii<_theFitter->Result().Parameters().size(); ii++) {
    corrs(ic,ii) = _theFitter->Result().Correlation(ic,ii);
    covs(ic,ii) = _theFitter->Result().CovMatrix(ic,ii);
       }
@@ -722,31 +704,29 @@ RooFitResult* RooMinimizer::save(const char* userName, const char* userTitle)
 /// See ROOT::Math::Minimizer::ErrorDef().
 
 RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
-                Double_t n1, Double_t n2, Double_t n3,
-                Double_t n4, Double_t n5, Double_t n6, unsigned int npoints)
+                double n1, double n2, double n3,
+                double n4, double n5, double n6, unsigned int npoints)
 {
-
-
   RooArgList* params = _fcn->GetFloatParamList() ;
-  RooArgList* paramSave = (RooArgList*) params->snapshot() ;
+  std::unique_ptr<RooArgList> paramSave{static_cast<RooArgList*>(params->snapshot())};
 
   // Verify that both variables are floating parameters of PDF
-  Int_t index1= _fcn->GetFloatParamList()->index(&var1);
+  int index1= _fcn->GetFloatParamList()->index(&var1);
   if(index1 < 0) {
     coutE(Minimization) << "RooMinimizer::contour(" << GetName()
          << ") ERROR: " << var1.GetName()
          << " is not a floating parameter of "
          << _fcn->getFunctionName() << endl ;
-    return 0;
+    return nullptr;
   }
 
-  Int_t index2= _fcn->GetFloatParamList()->index(&var2);
+  int index2= _fcn->GetFloatParamList()->index(&var2);
   if(index2 < 0) {
     coutE(Minimization) << "RooMinimizer::contour(" << GetName()
          << ") ERROR: " << var2.GetName()
          << " is not a floating parameter of PDF "
          << _fcn->getFunctionName() << endl ;
-    return 0;
+    return nullptr;
   }
 
   // create and draw a frame
@@ -766,21 +746,21 @@ RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
 
 
   // remember our original value of ERRDEF
-  Double_t errdef= _theFitter->GetMinimizer()->ErrorDef();
+  double errdef= _theFitter->GetMinimizer()->ErrorDef();
 
-  Double_t n[6] ;
+  double n[6] ;
   n[0] = n1 ; n[1] = n2 ; n[2] = n3 ; n[3] = n4 ; n[4] = n5 ; n[5] = n6 ;
 
-  for (Int_t ic = 0 ; ic<6 ; ic++) {
+  for (int ic = 0 ; ic<6 ; ic++) {
     if(n[ic] > 0) {
 
        // set the value corresponding to an n1-sigma contour
        _theFitter->GetMinimizer()->SetErrorDef(n[ic]*n[ic]*errdef);
 
       // calculate and draw the contour
-      Double_t *xcoor = new Double_t[npoints+1];
-      Double_t *ycoor = new Double_t[npoints+1];
-      bool ret = _theFitter->GetMinimizer()->Contour(index1,index2,npoints,xcoor,ycoor);
+      std::vector<double> xcoor(npoints+1);
+      std::vector<double> ycoor(npoints+1);
+      bool ret = _theFitter->GetMinimizer()->Contour(index1,index2,npoints,xcoor.data(),ycoor.data());
 
       if (!ret) {
    coutE(Minimization) << "RooMinimizer::contour("
@@ -790,7 +770,7 @@ RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
       } else {
    xcoor[npoints] = xcoor[0];
    ycoor[npoints] = ycoor[0];
-   TGraph* graph = new TGraph(npoints+1,xcoor,ycoor);
+   TGraph* graph = new TGraph(npoints+1,xcoor.data(),ycoor.data());
 
    graph->SetName(Form("contour_%s_n%f",_fcn->getFunctionName().c_str(),n[ic])) ;
    graph->SetLineStyle(ic+1) ;
@@ -798,9 +778,6 @@ RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
    graph->SetLineColor(kBlue) ;
    frame->addObject(graph,"L") ;
       }
-
-      delete [] xcoor;
-      delete [] ycoor;
     }
   }
 
@@ -810,7 +787,6 @@ RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
 
   // restore parameter values
   params->assign(*paramSave) ;
-  delete paramSave ;
 
   return frame ;
 
@@ -824,8 +800,8 @@ void RooMinimizer::profileStart()
 {
   if (_profile) {
     _timer.Start() ;
-    _cumulTimer.Start(_profileStart?kFALSE:kTRUE) ;
-    _profileStart = kTRUE ;
+    _cumulTimer.Start(_profileStart?false:true) ;
+    _profileStart = true ;
   }
 }
 
@@ -909,11 +885,13 @@ RooAbsMinimizerFcn *RooMinimizer::fitterFcn()
 
 void RooMinimizer::applyCovarianceMatrix(TMatrixDSym& V)
 {
-  _extV = (TMatrixDSym*) V.Clone() ;
+  _extV.reset(static_cast<TMatrixDSym*>(V.Clone()));
   _fcn->ApplyCovarianceMatrix(*_extV);
 
 }
 
+
+RooFitResult* RooMinimizer::lastMinuitFit() { return RooMinimizer::lastMinuitFit({}); }
 
 
 RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
@@ -924,27 +902,25 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
   if (_theFitter==0 || _theFitter->GetMinimizer()==0) {
     oocoutE((TObject*)0,InputArguments) << "RooMinimizer::save: Error, run minimization before!"
                << endl ;
-    return 0;
+    return nullptr;
   }
 
   // Verify length of supplied varList
-  if (varList.getSize()>0 && varList.getSize()!=Int_t(_theFitter->Result().NTotalParameters())) {
+  if (!varList.empty() && varList.size() != _theFitter->Result().NTotalParameters()) {
     oocoutE((TObject*)0,InputArguments)
       << "RooMinimizer::lastMinuitFit: ERROR: supplied variable list must be either empty " << endl
       << "                             or match the number of variables of the last fit ("
       << _theFitter->Result().NTotalParameters() << ")" << endl ;
-    return 0 ;
+    return nullptr;
   }
 
 
   // Verify that all members of varList are of type RooRealVar
-  TIter iter = varList.createIterator() ;
-  RooAbsArg* arg  ;
-  while((arg=(RooAbsArg*)iter.Next())) {
+  for (RooAbsArg * arg : varList) {
     if (!dynamic_cast<RooRealVar*>(arg)) {
       oocoutE((TObject*)0,InputArguments) << "RooMinimizer::lastMinuitFit: ERROR: variable '"
                  << arg->GetName() << "' is not of type RooRealVar" << endl ;
-      return 0 ;
+      return nullptr;
     }
   }
 
@@ -955,29 +931,29 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
   RooArgList constPars("constPars") ;
   RooArgList floatPars("floatPars") ;
 
-  UInt_t i ;
+  unsigned int i ;
   for (i = 0; i < _theFitter->Result().NTotalParameters(); ++i) {
 
     TString varName(_theFitter->Result().GetParameterName(i));
-    Bool_t isConst(_theFitter->Result().IsParameterFixed(i)) ;
+    bool isConst(_theFitter->Result().IsParameterFixed(i)) ;
 
-    Double_t xlo = _theFitter->Config().ParSettings(i).LowerLimit();
-    Double_t xhi = _theFitter->Config().ParSettings(i).UpperLimit();
-    Double_t xerr = _theFitter->Result().Error(i);
-    Double_t xval = _theFitter->Result().Value(i);
+    double xlo = _theFitter->Config().ParSettings(i).LowerLimit();
+    double xhi = _theFitter->Config().ParSettings(i).UpperLimit();
+    double xerr = _theFitter->Result().Error(i);
+    double xval = _theFitter->Result().Value(i);
 
-    RooRealVar* var ;
-    if (varList.getSize()==0) {
+    std::unique_ptr<RooRealVar> var ;
+    if (varList.empty()) {
 
       if ((xlo<xhi) && !isConst) {
-        var = new RooRealVar(varName,varName,xval,xlo,xhi) ;
+        var = std::make_unique<RooRealVar>(varName,varName,xval,xlo,xhi) ;
       } else {
-        var = new RooRealVar(varName,varName,xval) ;
+        var = std::make_unique<RooRealVar>(varName,varName,xval) ;
       }
       var->setConstant(isConst) ;
     } else {
 
-      var = (RooRealVar*) varList.at(i)->Clone() ;
+      var.reset(static_cast<RooRealVar*>(varList.at(i)->Clone()));
       var->setConstant(isConst) ;
       var->setVal(xval) ;
       if (xlo<xhi) {
@@ -992,10 +968,10 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
     }
 
     if (isConst) {
-      constPars.addOwned(*var) ;
+      constPars.addOwned(std::move(var)) ;
     } else {
       var->setError(xerr) ;
-      floatPars.addOwned(*var) ;
+      floatPars.addOwned(std::move(var)) ;
     }
   }
 
@@ -1009,9 +985,9 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
   std::vector<double> globalCC;
   TMatrixDSym corrs(_theFitter->Result().Parameters().size()) ;
   TMatrixDSym covs(_theFitter->Result().Parameters().size()) ;
-  for (UInt_t ic=0; ic<_theFitter->Result().Parameters().size(); ic++) {
+  for (unsigned int ic=0; ic<_theFitter->Result().Parameters().size(); ic++) {
     globalCC.push_back(_theFitter->Result().GlobalCC(ic));
-    for (UInt_t ii=0; ii<_theFitter->Result().Parameters().size(); ii++) {
+    for (unsigned int ii=0; ii<_theFitter->Result().Parameters().size(); ii++) {
       corrs(ic,ii) = _theFitter->Result().Correlation(ic,ii);
       covs(ic,ii) = _theFitter->Result().CovMatrix(ic,ii);
     }
@@ -1020,9 +996,4 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
 
   return res;
 
-}
-
-Int_t RooMinimizer::getPrintLevel() const
-{
-   return _printLevel;
 }

--- a/test/fit/testFitPerf.cxx
+++ b/test/fit/testFitPerf.cxx
@@ -517,10 +517,7 @@ int  FitUsingRooFit(TH1 * hist, TF1 * func) {
       assert(pdf != 0);
 #define USE_CHI2_FIT
 #ifdef USE_CHI2_FIT
-      RooChi2Var chi2("chi2","chi2",*pdf,data) ;
-      RooMinimizer m(chi2) ;
-      m.setPrintLevel(-1);
-      m.fit("mh") ;
+      pdf->chi2FitTo(data, RooFit::PrintLevel(-1));
 #else
       pdf->fitTo(data);
 #endif


### PR DESCRIPTION
The string-based fit options were deprecated for a long time, and now is
a good time to remove the support for this completely.

This will give us more flexibility when refactoring the RooMinimizer to
integrate new features like the batch mode, the new likelihood classes,
or automatic differentiation.