### PR TITLE
[v626][RF] Backports of RooFit PRs to `v6-26-00-patches`: Part 7

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -65,6 +65,7 @@ The following people have contributed to this new version:
 - `TTreeProcessorMT::SetMaxTasksPerFilePerWorker` has been removed. `TTreeProcessorMT::SetTasksPerWorkerHint` is a superior alternative.
 - `TTree::GetEntry()` and `TTree::GetEvent()` no longer have 0 as the default value for the first parameter `entry`. We are not aware of correct uses of this function without providing an entry number. If you have one, please simply pass `0` from now on.
 - `TBufferMerger` is now out of the `Experimental` namespace (`ROOT::Experimental::TBufferMerger` is deprecated, please use `ROOT::TBufferMerger` instead)
+- RooFit container classes marked as deprecated with this release: `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList`. These classes are still available in this release, but will be removed in the next one. Please migrate to STL container classes, such as `std::unordered_map`, `std::set`, and `std::vector`.
 - `TTree.AsMatrix` has been removed, after being deprecated in 6.24. Instead, please use `RDataFrame.AsNumpy` from now on as a way to read and process data in ROOT files and store it in NumPy arrays (a tutorial can be found [here](https://root.cern/doc/master/df026__AsNumpyArrays_8py.html)).
 
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooworkspace.py
@@ -61,6 +61,18 @@ class RooWorkspace(object):
         """
         return getattr(self, "import")(*args, **kwargs)
 
+    def __setattr__(self, name, value):
+        # Many people pythonized the RooWorkspace themselves, by adding a new
+        # attribute `_import` that calls getattr(self, "import") under the
+        # hood. However, `_import` is now the reference to the original cppyy
+        # overload, and resetting it with a wrapper around `import` would cause
+        # infinite recursions! We prevent resetting any import-related function
+        # here, which results in a clearer error to the user than an infinite
+        # call stack involving the internal pythonization code.
+        if name in ["_import", "import", "Import"]:
+            raise AttributeError("Resetting the \"" + name + "\" attribute of a RooWorkspace is not allowed!")
+        object.__setattr__(self, name, value)
+
 
 def RooWorkspace_import(self, *args, **kwargs):
     r"""The RooWorkspace::import function can't be used in PyROOT because `import` is a reserved python keyword.


### PR DESCRIPTION
This is a backport of all the RooFit PRs that were merged to `master` edit to `v6-26-00-patches` (in the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/9881 (only first commit)
2. https://github.com/root-project/root/pull/9896


