### PR TITLE
[v626][RF][RelNotes] Deprecated string fit options in RooFit

### DIFF
--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -66,8 +66,16 @@ The following people have contributed to this new version:
 - `TTree::GetEntry()` and `TTree::GetEvent()` no longer have 0 as the default value for the first parameter `entry`. We are not aware of correct uses of this function without providing an entry number. If you have one, please simply pass `0` from now on.
 - `TBufferMerger` is now out of the `Experimental` namespace (`ROOT::Experimental::TBufferMerger` is deprecated, please use `ROOT::TBufferMerger` instead)
 - RooFit container classes marked as deprecated with this release: `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList`. These classes are still available in this release, but will be removed in the next one. Please migrate to STL container classes, such as `std::unordered_map`, `std::set`, and `std::vector`.
+- The `RooFit::FitOptions(const char*)` command to steer [RooAbsPdf::fitTo()](https://root.cern.ch/doc/v628/classRooAbsPdf.html) with an option string in now deprecated and will be removed in ROOT v6.28. Please migrate to the RooCmdArg-based fit configuration. The former character flags map to RooFit command arguments as follows:
+    - `'h'` : RooFit::Hesse()
+    - `'m'` : RooFit::Minos()
+    - `'o'` : RooFit::Optimize(1)
+    - `'r'` : RooFit::Save()
+    - `'t'` : RooFit::Timer()
+    - `'v'` : RooFit::Verbose()
+    - `'0'` : RooFit::Strategy(0)
+  Subsequently, the `RooMinimizer::fit(const char*)` function and the [RooMCStudy](https://root.cern.ch/doc/v626/classRooMCStudy.html) constructor that takes an option string is deprecated as well.
 - `TTree.AsMatrix` has been removed, after being deprecated in 6.24. Instead, please use `RDataFrame.AsNumpy` from now on as a way to read and process data in ROOT files and store it in NumPy arrays (a tutorial can be found [here](https://root.cern/doc/master/df026__AsNumpyArrays_8py.html)).
-- RooFit container classes marked as deprecated with this release: `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList`. These classes are still available in this release, but will be removed in the next one. Please migrate to STL container classes, such as `std::unordered_map`, `std::set`, and `std::vector`.
 
 
 ## Core Libraries

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -18,6 +18,9 @@
 
 #include "RooCmdArg.h"
 #include "RooArgSet.h"
+
+#include "ROOT/RConfig.hxx"
+
 #include <map>
 #include <string>
 
@@ -43,6 +46,12 @@ class RooArgList ;
 class RooAbsCollection ;
 class TH1 ;
 class TTree ;
+
+namespace RooFitLegacy {
+
+RooCmdArg FitOptions(const char* opts);
+
+}
 
 /*! \namespace RooFit
 The namespace RooFit contains mostly switches that change the behaviour of functions of PDFs
@@ -219,7 +228,10 @@ RooCmdArg IntegrateBins(double precision);
 
 // RooAbsPdf::fitTo arguments
 RooCmdArg PrefitDataFraction(Double_t data_ratio = 0.0) ;
-RooCmdArg FitOptions(const char* opts) ;
+RooCmdArg FitOptions(const char* opts)
+  R__DEPRECATED(6,28,"Please migrate to the RooCmdArg-based fit configuration"
+                     " (or use RooFitLegacy::FitOptions(const char*) to silence this warning,"
+                     " but be warned that the RooFitLegacy function also gets removed in ROOT v6.28).") ;
 RooCmdArg Optimize(Int_t flag=2) ;
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -36,13 +36,15 @@ public:
 	     const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
              const RooCmdArg& arg3=RooCmdArg::none(), const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),
              const RooCmdArg& arg6=RooCmdArg::none(), const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) ;
-	
-  RooMCStudy(const RooAbsPdf& genModel, const RooAbsPdf& fitModel, 
-	     const RooArgSet& dependents, const char* genOptions="",
-	     const char* fitOptions="", const RooDataSet* genProtoData=0,
-	     const RooArgSet& projDeps=RooArgSet()) ;
+
+  RooMCStudy(const RooAbsPdf& genModel, const RooAbsPdf& fitModel,
+        const RooArgSet& dependents, const char* genOptions="",
+        const char* fitOptions="", const RooDataSet* genProtoData=0,
+        const RooArgSet& projDeps=RooArgSet()) R__DEPRECATED(6,28,
+  "please migrate to the other RooMCStudy constructor that doesn't use the deprecated string-based fit options.");
+
   virtual ~RooMCStudy() ;
-  
+
   // Method to add study modules
   void addModule(RooAbsMCStudyModule& module) ;
 

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -74,7 +74,8 @@ public:
   void setMaxIterations(Int_t n) ;
   void setMaxFunctionCalls(Int_t n) ;
 
-  RooFitResult* fit(const char* options) ;
+  RooFitResult* fit(const char* options) R__DEPRECATED(6,28,
+  "using RooMinimizer::fit() with string-based options is deprecated. Please use RooAbsPdf::fitTo() instead.");
 
   Int_t migrad() ;
   Int_t hesse() ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4698,7 +4698,24 @@ RooFitResult* RooAbsReal::chi2FitDriver(RooAbsReal& fcn, RooLinkedList& cmdList)
   if (fitOpt) {
 
     // Play fit options as historically defined
-    ret = m.fit(fitOpt) ;
+    // (code copied from RooMinimizer::fit() instead of calling said function to avoid deprecation warning)
+    TString opts(fitOpt) ;
+    opts.ToLower() ;
+
+    // Initial configuration
+    if (opts.Contains("v")) m.setVerbose(1) ;
+    if (opts.Contains("t")) m.setProfile(1) ;
+    if (opts.Contains("l")) m.setLogFile(Form("%s.log",fcn.GetName())) ;
+    if (opts.Contains("c")) m.optimizeConst(1) ;
+
+    // Fitting steps
+    if (opts.Contains("0")) m.setStrategy(0) ;
+    m.migrad() ;
+    if (opts.Contains("0")) m.setStrategy(1) ;
+    if (opts.Contains("h")||!opts.Contains("m")) m.hesse() ;
+    if (!opts.Contains("m")) m.minos() ;
+
+    ret = (opts.Contains("r")) ? m.save() : 0 ;
 
   } else {
 

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -29,6 +29,7 @@
 #include "RooAbsPdf.h"
 #include "RooFormulaVar.h"
 #include "RooHelpers.h"
+#include "RooMsgService.h"
 #include "TH1.h"
 
 #include <algorithm>
@@ -216,7 +217,22 @@ namespace RooFit {
   
   // RooAbsPdf::fitTo arguments
   RooCmdArg PrefitDataFraction(Double_t data_ratio)  { return RooCmdArg("Prefit",0,0,data_ratio,0,nullptr,nullptr,nullptr,nullptr) ; }
-  RooCmdArg FitOptions(const char* opts) { return RooCmdArg("FitOptions",0,0,0,0,opts,0,0,0) ; }
+  RooCmdArg FitOptions(const char* opts) {
+    oocoutW(static_cast<TObject*>(nullptr), Fitting)
+      << "RooFit::FitOptions(const char* opts) will be removed in ROOT v628!\n"
+      << "Please migrate to the RooCmdArg-based fit configuration.\n"
+      << "The former character flags map to RooFit command arguments as follows:\n"
+      << "    'h' : RooFit::Hesse()\n"
+      << "    'm' : RooFit::Minos()\n"
+      << "    'o' : RooFit::Optimize(1)\n"
+      << "    'r' : RooFit::Save()\n"
+      << "    't' : RooFit::Timer()\n"
+      << "    'v' : RooFit::Verbose()\n"
+      << "    '0' : RooFit::Strategy(0)\n"
+      << "You can alternatively silence this warning by using RooFitLegacy::FitOptions(const char*),\n"
+      << "but this will get removed in ROOT v6.28 as well.\n";
+    return RooFitLegacy::FitOptions(opts);
+  }
   RooCmdArg Optimize(Int_t flag)         { return RooCmdArg("Optimize",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Verbose(Bool_t flag)         { return RooCmdArg("Verbose",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg Save(Bool_t flag)            { return RooCmdArg("Save",flag,0,0,0,0,0,0,0) ; }
@@ -392,6 +408,9 @@ namespace RooFit {
  
 } // End namespace RooFit
 
+namespace RooFitLegacy {
+  RooCmdArg FitOptions(const char* opts) { return RooCmdArg("FitOptions",0,0,0,0,opts,0,0,0) ; }
+}
 
 namespace RooFitShortHand {
 

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -766,9 +766,9 @@ RooFitResult* RooMCStudy::doFit(RooAbsData* genSample)
   RooFitResult* fr ;
   if (_fitOptList.GetSize()==0) {
     if (_projDeps.getSize()>0) {
-      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFit::ConditionalObservables(_projDeps),RooFit::FitOptions(fitOpt2)) ;
+      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFit::ConditionalObservables(_projDeps),RooFitLegacy::FitOptions(fitOpt2)) ;
     } else {
-      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFit::FitOptions(fitOpt2)) ;
+      fr = (RooFitResult*) _fitModel->fitTo(*data,RooFitLegacy::FitOptions(fitOpt2)) ;
     }
   } else {
     RooCmdArg save  = RooFit::Save() ;

--- a/test/fit/testFitPerf.cxx
+++ b/test/fit/testFitPerf.cxx
@@ -517,10 +517,7 @@ int  FitUsingRooFit(TH1 * hist, TF1 * func) {
       assert(pdf != 0);
 #define USE_CHI2_FIT
 #ifdef USE_CHI2_FIT
-      RooChi2Var chi2("chi2","chi2",*pdf,data) ;
-      RooMinimizer m(chi2) ;
-      m.setPrintLevel(-1);
-      m.fit("mh") ;
+      pdf->chi2FitTo(data, RooFit::PrintLevel(-1));
 #else
       pdf->fitTo(data);
 #endif


### PR DESCRIPTION
The string-based fit options are officially deprecated with this commit,
to finally remove them in the next release (ROOT v6.28).

This will give us more flexibility when refactoring the RooMinimizer to
integrate new features like the batch mode, the new likelihood classes,
or automatic differentiation.