### PR TITLE
Fix for name resolution of GDML objects defined in children files.

### DIFF
--- a/geom/gdml/inc/TGDMLParse.h
+++ b/geom/gdml/inc/TGDMLParse.h
@@ -176,6 +176,13 @@ private:
    //'setup' section
    XMLNodePointer_t  TopProcess(TXMLEngine* gdml, XMLNodePointer_t node);
 
+   // Find defined objects by name
+   TGeoTranslation  *GetPosition(const char *name);
+   TGeoRotation     *GetRotation(const char *name);
+   TGeoScale        *GetScaleObj(const char *name);
+   TGeoShape        *GetSolid(const char *name);
+   TGeoVolume       *GetVolume(const char *name);
+
    typedef TGDMMapHelper<TGeoTranslation> PosMap;
    typedef TGDMMapHelper<TGeoRotation> RotMap;
    typedef TGDMMapHelper<TGeoScale> SclMap;

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -1031,8 +1031,9 @@ XMLNodePointer_t TGDMLParse::IsoProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       attr = gdml->GetNextAttr(attr);
    }
 
+   TString local_name = name;
    if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
    }
 
    Int_t z2 = (Int_t)Value(z);
@@ -1048,7 +1049,7 @@ XMLNodePointer_t TGDMLParse::IsoProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    } else if (gDebug >= 2) {
       Info("TGDMLParse", "Re-use existing isotope: %s", iso->GetName());
    }
-   fisomap[name.Data()] = iso;
+   fisomap[local_name.Data()] = iso;
 
    return node;
 }
@@ -1063,7 +1064,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
 {
    TString z = "0";
-   TString name = "";
+   TString name, local_name;
    TString formula = "";
    TString atom = "0";
    TString tempattr;
@@ -1086,9 +1087,9 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
          tempattr = gdml->GetAttrName(attr);
          if (tempattr == "name") {
             name = gdml->GetAttrValue(attr);
-
+            local_name = name;
             if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-               name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+               local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
             }
             break;
          }
@@ -1133,7 +1134,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             ele->AddIsotope((TGeoIsotope *)fisomap[f->first], f->second);
          }
       }
-      felemap[name.Data()] = ele;
+      felemap[local_name.Data()] = ele;
       return child;
    } // hasisotopes end loop
 
@@ -1146,9 +1147,9 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
 
          if (tempattr == "name") {
             name = gdml->GetAttrValue(attr);
-
+            local_name = name;
             if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-               name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+               local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
             }
             break;
          }
@@ -1193,7 +1194,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
             ele->AddIsotope((TGeoIsotope *)fisomap[f->first], f->second);
          }
       }
-      felemap[name.Data()] = ele;
+      felemap[local_name.Data()] = ele;
       return child;
    } // hasisotopesExtended end loop
 
@@ -1233,8 +1234,9 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       attr = gdml->GetNextAttr(attr);
    }
 
+   local_name = name;
    if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
    }
 
    Int_t z2 = (Int_t)Value(z);
@@ -1249,7 +1251,7 @@ XMLNodePointer_t TGDMLParse::EleProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    } else if (gDebug >= 2) {
       Info("TGDMLParse", "Re-use existing element: %s", ele->GetName());
    }
-   felemap[name.Data()] = ele;
+   felemap[local_name.Data()] = ele;
    return node;
 }
 
@@ -1281,7 +1283,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TString tempattr = "";
    Int_t ncompo = 0, mixflag = 2;
    Double_t density = 0;
-   TString name = "";
+   TString name, local_name;
    TGeoMixture *mix = 0;
    TGeoMaterial *mat = 0;
    TString tempconst = "";
@@ -1293,8 +1295,9 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       Double_t d = 0;
 
       name = gdml->GetAttr(node, "name");
+      local_name = name;
       if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-         name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+         local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
       }
 
       while (child != 0) {
@@ -1395,7 +1398,7 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       } else if (gDebug >= 2) {
          Info("TGDMLParse", "Re-use existing material-element: %s", mat_ele->GetName());
       }
-      felemap[name.Data()] = mat_ele;
+      felemap[local_name.Data()] = mat_ele;
    }
 
    else if (z == 0) {
@@ -1486,8 +1489,9 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
       // still in the not Z else...but not in the while..
 
       name = gdml->GetAttr(node, "name");
+      local_name = name;
       if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-         name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+         local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
       }
       // mix = new TGeoMixture(NameShort(name), 0 /*ncompo*/, density);
       mixflag = 1;
@@ -1549,16 +1553,16 @@ XMLNodePointer_t TGDMLParse::MatProcess(TXMLEngine *gdml, XMLNodePointer_t node,
    TGeoMedium *med = mgr->GetMedium(NameShort(name));
    if (!med) {
       if (mixflag == 1) {
-         fmixmap[name.Data()] = mix;
+         fmixmap[local_name.Data()] = mix;
          med = new TGeoMedium(NameShort(name), medid, mix);
       } else if (mixflag == 0) {
-         fmatmap[name.Data()] = mat;
+         fmatmap[local_name.Data()] = mat;
          med = new TGeoMedium(NameShort(name), medid, mat);
       }
    } else if (gDebug >= 2) {
       Info("TGDMLParse", "Re-use existing medium: %s", med->GetName());
    }
-   fmedmap[name.Data()] = med;
+   fmedmap[local_name.Data()] = med;
 
    return child;
 }
@@ -1603,7 +1607,7 @@ XMLNodePointer_t TGDMLParse::SkinSurfaceProcess(TXMLEngine *gdml, XMLNodePointer
    if (!surf)
       Fatal("SkinSurfaceProcess", "Skin surface %s: referenced optical surface %s not defined", name.Data(),
             surfname.Data());
-   TGeoVolume *vol = fvolmap[volname.Data()];
+   TGeoVolume *vol = GetVolume(volname.Data());
    TGeoSkinSurface *skin = new TGeoSkinSurface(name, surfname, surf, vol);
    gGeoManager->AddSkinSurface(skin);
    return child;
@@ -1661,6 +1665,91 @@ XMLNodePointer_t TGDMLParse::BorderSurfaceProcess(TXMLEngine *gdml, XMLNodePoint
    TGeoBorderSurface *border = new TGeoBorderSurface(name, surfname, surf, node1, node2);
    gGeoManager->AddBorderSurface(border);
    return child;
+}
+
+TGeoTranslation *TGDMLParse::GetPosition(const char *name)
+{
+   // Get defined position by name, in local file scope.
+   TGeoTranslation *pos = nullptr;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
+      // Search local file namespace first
+      TString reftemp = TString::Format("%s_%s", name, fCurrentFile);
+      if (fposmap.find(reftemp.Data()) != fposmap.end())
+         pos = fposmap[reftemp.Data()];
+   }
+
+   if (!pos && fposmap.find(name) != fposmap.end())
+      pos = fposmap[name];
+
+   return pos;
+}
+
+TGeoRotation *TGDMLParse::GetRotation(const char *name)
+{
+   // Get defined rotation by name.
+   TGeoRotation *rot = nullptr;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
+      // Search local file namespace first
+      TString reftemp = TString::Format("%s_%s", name, fCurrentFile);
+      if (frotmap.find(reftemp.Data()) != frotmap.end())
+         rot = frotmap[reftemp.Data()];
+   }
+
+   if (!rot && frotmap.find(name) != frotmap.end())
+      rot = frotmap[name];
+
+   return rot;
+}
+
+TGeoScale *TGDMLParse::GetScaleObj(const char *name)
+{
+   // Get defined scale by name.
+   TGeoScale *scl = nullptr;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
+      // Search local file namespace first
+      TString reftemp = TString::Format("%s_%s", name, fCurrentFile);
+      if (fsclmap.find(reftemp.Data()) != fsclmap.end())
+         scl = fsclmap[reftemp.Data()];
+   }
+
+   if (!scl && fsclmap.find(name) != fsclmap.end())
+      scl = fsclmap[name];
+
+   return scl;
+}
+
+TGeoShape *TGDMLParse::GetSolid(const char *name)
+{
+   // Get defined solid by name.
+   TGeoShape *sol = nullptr;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
+      // Search local file namespace first
+      TString reftemp = TString::Format("%s_%s", name, fCurrentFile);
+      if (fsolmap.find(reftemp.Data()) != fsolmap.end())
+         sol = fsolmap[reftemp.Data()];
+   }
+
+   if (!sol && fsolmap.find(name) != fsolmap.end())
+      sol = fsolmap[name];
+
+   return sol;
+}
+
+TGeoVolume *TGDMLParse::GetVolume(const char *name)
+{
+   // Get defined solid by name.
+   TGeoVolume *vol = nullptr;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
+      // Search local file namespace first
+      TString reftemp = TString::Format("%s_%s", name, fCurrentFile);
+      if (fvolmap.find(reftemp.Data()) != fvolmap.end())
+         vol = fvolmap[reftemp.Data()];
+   }
+
+   if (!vol && fvolmap.find(name) != fvolmap.end())
+      vol = fvolmap[name];
+
+   return vol;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1731,9 +1820,9 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
    }
 
    name = gdml->GetAttr(node, "name");
-
+   TString local_name = name;
    if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
    }
 
    if (reflex == 0) {
@@ -1746,7 +1835,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
       yesrefl = 1;
    }
 
-   fvolmap[name.Data()] = vol;
+   fvolmap[local_name.Data()] = vol;
 
    // PHYSVOL - run through child nodes of VOLUME again..
 
@@ -1772,10 +1861,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
             if (tempattr == "volumeref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               lv = fvolmap[reftemp.Data()];
+               lv = GetVolume(reftemp.Data());
                volref = reftemp;
             } else if (tempattr == "file") {
                const char *filevol;
@@ -1803,18 +1889,13 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
                   ffilemap[fCurrentFile] = volref;
                }
 
-               if (filevol) {
-                  volref = filevol;
-                  if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                     volref = TString::Format("%s_%s", volref.Data(), fCurrentFile);
-                  }
-               }
+               if (filevol) volref = filevol;
+               lv = GetVolume(volref.Data());
 
                fFILENO = fFILENO - 1;
                gdml = fFileEngine[fFILENO];
                fCurrentFile = prevfile;
 
-               lv = fvolmap[volref.Data()];
                // File tree complete - Release memory before exit
 
                gdml->FreeDoc(filedoc1);
@@ -1823,53 +1904,32 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
                attr = gdml->GetFirstAttr(subchild);
                PosProcess(gdml, subchild, attr);
                reftemp = gdml->GetAttr(subchild, "name");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               pos = fposmap[reftemp.Data()];
+               pos = GetPosition(reftemp.Data());
             } else if (tempattr == "positionref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               if (fposmap.find(reftemp.Data()) != fposmap.end())
-                  pos = fposmap[reftemp.Data()];
-               else
-                  std::cout << "ERROR! Physvol's position " << reftemp << " not found!" << std::endl;
+               pos = GetPosition(reftemp.Data());
+               if (!pos)
+                  Fatal("VolProcess", "Physvol's position %s not found", reftemp.Data());
             } else if (tempattr == "rotation") {
                attr = gdml->GetFirstAttr(subchild);
                RotProcess(gdml, subchild, attr);
                reftemp = gdml->GetAttr(subchild, "name");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               rot = frotmap[reftemp.Data()];
+               rot = GetRotation(reftemp.Data());
             } else if (tempattr == "rotationref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               if (frotmap.find(reftemp.Data()) != frotmap.end())
-                  rot = frotmap[reftemp.Data()];
-               else
-                  std::cout << "ERROR! Physvol's rotation " << reftemp << " not found!" << std::endl;
+               rot = GetRotation(reftemp.Data());
+               if (!rot)
+                  Fatal("VolProcess", "Physvol's rotation %s not found", reftemp.Data());
             } else if (tempattr == "scale") {
                attr = gdml->GetFirstAttr(subchild);
                SclProcess(gdml, subchild, attr);
                reftemp = gdml->GetAttr(subchild, "name");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               scl = fsclmap[reftemp.Data()];
+               scl = GetScaleObj(reftemp.Data());
             } else if (tempattr == "scaleref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               if (fsclmap.find(reftemp.Data()) != fsclmap.end())
-                  scl = fsclmap[reftemp.Data()];
-               else
-                  std::cout << "ERROR! Physvol's scale " << reftemp << " not found!" << std::endl;
+               scl = GetScaleObj(reftemp.Data());
+               if (!scl)
+                  Fatal("VolProcess", "Physvol's scale %s not found", reftemp.Data());
             }
 
             subchild = gdml->GetNext(subchild);
@@ -1930,6 +1990,8 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          TString width = "";
          TString offset = "";
          TString lunit = fDefault_lunit.c_str();
+         reftemp = "";
+         local_name = "";
 
          attr = gdml->GetFirstAttr(child);
 
@@ -1961,8 +2023,9 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
             if (tempattr == "volumeref") {
                reftemp = gdml->GetAttr(subchild, "ref");
+               local_name = reftemp;
                if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
+                  local_name = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
                }
                divVolref = reftemp;
             }
@@ -1983,10 +2046,9 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          Double_t start = xlo + offsetline;
 
          Int_t numed = 0;
-         TGeoVolume *old = fvolmap[NameShort(reftemp)];
+         TGeoVolume *old = GetVolume(reftemp);
          if (old) {
             // We need to recreate the content of the divided volume
-            old = fvolmap[NameShort(reftemp)];
             // medium id
             numed = old->GetMedium()->GetId();
          }
@@ -1998,7 +2060,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          if (old && old->GetNdaughters()) {
             divvol->ReplayCreation(old);
          }
-         fvolmap[NameShort(reftemp)] = divvol;
+         fvolmap[local_name.Data()] = divvol;
 
       } // end of Division else if
 
@@ -2013,6 +2075,8 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          TString ounit = fDefault_lunit.c_str();
          Double_t wvalue = 0;
          Double_t ovalue = 0;
+         reftemp = "";
+         local_name = "";
 
          attr = gdml->GetFirstAttr(child);
 
@@ -2035,8 +2099,9 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
             if (tempattr == "volumeref") {
                reftemp = gdml->GetAttr(subchild, "ref");
+               local_name = reftemp;
                if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
+                  local_name = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
                }
                divVolref = reftemp;
             }
@@ -2114,10 +2179,9 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
          Double_t step = widthline;
          Int_t numed = 0;
-         TGeoVolume *old = fvolmap[NameShort(reftemp)];
+         TGeoVolume *old = GetVolume(reftemp);
          if (old) {
             // We need to recreate the content of the divided volume
-            old = fvolmap[NameShort(reftemp)];
             // medium id
             numed = old->GetMedium()->GetId();
          }
@@ -2129,7 +2193,7 @@ XMLNodePointer_t TGDMLParse::VolProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          if (old && old->GetNdaughters()) {
             divvol->ReplayCreation(old);
          }
-         fvolmap[NameShort(reftemp)] = divvol;
+         fvolmap[local_name.Data()] = divvol;
 
       } // End of replicavol
       else if (strcmp(gdml->GetNodeName(child), "auxiliary") == 0) {
@@ -2196,9 +2260,10 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
    secondRot->RotateX(0);
 
    TString name = gdml->GetAttr(node, "name");
+   TString local_name = name;
 
    if ((strcmp(fCurrentFile, fStartFile)) != 0)
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    while (child != 0) {
       tempattr = gdml->GetNodeName(child);
@@ -2206,84 +2271,54 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
 
       if (tempattr == "first") {
          reftemp = gdml->GetAttr(child, "ref");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         if (fsolmap.find(reftemp.Data()) != fsolmap.end()) {
-            first = fsolmap[reftemp.Data()];
-         }
+         first = GetSolid(reftemp.Data());
+         if (!first)
+            Fatal("BooSolid", "First solid %s not found", reftemp.Data());
       } else if (tempattr == "second") {
          reftemp = gdml->GetAttr(child, "ref");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         if (fsolmap.find(reftemp.Data()) != fsolmap.end()) {
-            second = fsolmap[reftemp.Data()];
-         }
+         second = GetSolid(reftemp.Data());
+         if (!second)
+            Fatal("BooSolid", "Second solid %s not found", reftemp.Data());
       } else if (tempattr == "position") {
          attr = gdml->GetFirstAttr(child);
          PosProcess(gdml, child, attr);
          reftemp = gdml->GetAttr(child, "name");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         secondPos = fposmap[reftemp.Data()];
+         secondPos = GetPosition(reftemp.Data());
       } else if (tempattr == "positionref") {
          reftemp = gdml->GetAttr(child, "ref");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         if (fposmap.find(reftemp.Data()) != fposmap.end()) {
-            secondPos = fposmap[reftemp.Data()];
-         }
+         secondPos = GetPosition(reftemp.Data());
+         if (!secondPos)
+            Fatal("BooSolid", "Second position %s not found", reftemp.Data());
       } else if (tempattr == "rotation") {
          attr = gdml->GetFirstAttr(child);
          RotProcess(gdml, child, attr);
          reftemp = gdml->GetAttr(child, "name");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         secondRot = frotmap[reftemp.Data()];
+         secondRot = GetRotation(reftemp.Data());
       } else if (tempattr == "rotationref") {
          reftemp = gdml->GetAttr(child, "ref");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         if (frotmap.find(reftemp.Data()) != frotmap.end()) {
-            secondRot = frotmap[reftemp.Data()];
-         }
+         secondRot = GetRotation(reftemp.Data());
+         if (!secondRot)
+            Fatal("BooSolid", "Second rotation %s not found", reftemp.Data());
       } else if (tempattr == "firstposition") {
          attr = gdml->GetFirstAttr(child);
          PosProcess(gdml, child, attr);
          reftemp = gdml->GetAttr(child, "name");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         firstPos = fposmap[reftemp.Data()];
+         firstPos = GetPosition(reftemp.Data());
       } else if (tempattr == "firstpositionref") {
          reftemp = gdml->GetAttr(child, "ref");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         if (fposmap.find(reftemp.Data()) != fposmap.end()) {
-            firstPos = fposmap[reftemp.Data()];
-         }
+         firstPos = GetPosition(reftemp.Data());
+         if (!firstPos)
+            Fatal("BooSolid", "First position %s not found", reftemp.Data());
       } else if (tempattr == "firstrotation") {
          attr = gdml->GetFirstAttr(child);
          RotProcess(gdml, child, attr);
          reftemp = gdml->GetAttr(child, "name");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         firstRot = frotmap[reftemp.Data()];
+         firstRot = GetRotation(reftemp.Data());
       } else if (tempattr == "firstrotationref") {
          reftemp = gdml->GetAttr(child, "ref");
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         if (frotmap.find(reftemp.Data()) != frotmap.end()) {
-            firstRot = frotmap[reftemp.Data()];
-         }
+         firstRot = GetRotation(reftemp.Data());
+         if (!firstRot)
+            Fatal("BooSolid", "First rotation %s not found", reftemp.Data());
       }
       child = gdml->GetNext(child);
    }
@@ -2292,10 +2327,6 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
    TGeoMatrix *secondMatrix = new TGeoCombiTrans(*secondPos, secondRot->Inverse());
 
    TGeoCompositeShape *boolean = 0;
-   if (!first || !second) {
-      Fatal("BooSolid", "Incomplete solid %s, missing shape components", name.Data());
-      return child;
-   }
    switch (num) {
    case 1:
       boolean = new TGeoCompositeShape(NameShort(name), new TGeoSubtraction(first, second, firstMatrix, secondMatrix));
@@ -2309,7 +2340,7 @@ XMLNodePointer_t TGDMLParse::BooSolid(TXMLEngine *gdml, XMLNodePointer_t node, X
    default: break;
    }
 
-   fsolmap[name.Data()] = boolean;
+   fsolmap[local_name.Data()] = boolean;
 
    return child;
 }
@@ -2373,11 +2404,11 @@ XMLNodePointer_t TGDMLParse::UsrProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 XMLNodePointer_t TGDMLParse::AssProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 {
    TString name = gdml->GetAttr(node, "name");
+   TString local_name = name;
    TString reftemp = "";
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    XMLAttrPointer_t attr;
    XMLNodePointer_t subchild;
@@ -2410,42 +2441,27 @@ XMLNodePointer_t TGDMLParse::AssProcess(TXMLEngine *gdml, XMLNodePointer_t node)
 
             if (tempattr == "volumeref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               lv = fvolmap[reftemp.Data()];
+               lv = GetVolume(reftemp.Data());
             } else if (tempattr == "positionref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               if (fposmap.find(reftemp.Data()) != fposmap.end()) {
-                  pos = fposmap[reftemp.Data()];
-               }
-            } else if (tempattr == "position") {
+               pos = GetPosition(reftemp.Data());
+               if (!pos)
+                  Fatal("AssProcess", "Position %s not found", reftemp.Data());
+           } else if (tempattr == "position") {
                attr = gdml->GetFirstAttr(subchild);
                PosProcess(gdml, subchild, attr);
                reftemp = gdml->GetAttr(subchild, "name");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               pos = fposmap[reftemp.Data()];
+               pos = GetPosition(reftemp.Data());
             } else if (tempattr == "rotationref") {
                reftemp = gdml->GetAttr(subchild, "ref");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               if (frotmap.find(reftemp.Data()) != frotmap.end()) {
-                  rot = frotmap[reftemp.Data()];
-               }
+               rot = GetRotation(reftemp.Data());
+               if (!rot)
+                  Fatal("AssProcess", "Rotation %s not found", reftemp.Data());
             } else if (tempattr == "rotation") {
                attr = gdml->GetFirstAttr(subchild);
                RotProcess(gdml, subchild, attr);
                reftemp = gdml->GetAttr(subchild, "name");
-               if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-                  reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-               }
-               rot = frotmap[reftemp.Data()];
+               rot = GetRotation(reftemp.Data());
             }
 
             subchild = gdml->GetNext(subchild);
@@ -2463,7 +2479,7 @@ XMLNodePointer_t TGDMLParse::AssProcess(TXMLEngine *gdml, XMLNodePointer_t node)
       child = gdml->GetNext(child);
    }
 
-   fvolmap[name.Data()] = assem;
+   fvolmap[local_name.Data()] = assem;
    return child;
 }
 
@@ -2485,11 +2501,7 @@ XMLNodePointer_t TGDMLParse::TopProcess(TXMLEngine *gdml, XMLNodePointer_t node)
          // const char* reftemp;
          // TString reftemp = "";
          reftemp = gdml->GetAttr(child, "ref");
-
-         if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-            reftemp = TString::Format("%s_%s", reftemp.Data(), fCurrentFile);
-         }
-         fWorld = fvolmap[reftemp.Data()];
+         fWorld = GetVolume(reftemp.Data());
          fWorldName = reftemp.Data();
       }
       child = gdml->GetNext(child);
@@ -2533,9 +2545,9 @@ XMLNodePointer_t TGDMLParse::Box(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retunit = GetScaleVal(lunit);
 
@@ -2545,7 +2557,7 @@ XMLNodePointer_t TGDMLParse::Box(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
 
    TGeoBBox *box = new TGeoBBox(NameShort(name), xline, yline, zline);
 
-   fsolmap[name.Data()] = box;
+   fsolmap[local_name.Data()] = box;
 
    return node;
 }
@@ -2595,9 +2607,9 @@ XMLNodePointer_t TGDMLParse::Ellipsoid(TXMLEngine *gdml, XMLNodePointer_t node, 
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retunit = GetScaleVal(lunit);
 
@@ -2630,7 +2642,7 @@ XMLNodePointer_t TGDMLParse::Ellipsoid(TXMLEngine *gdml, XMLNodePointer_t node, 
    TGeoBBox *pCutBox = new TGeoBBox("cutBox", dx, dy, dz, origin);
    TGeoBoolNode *pBoolNode = new TGeoIntersection(shape, pCutBox, 0, 0);
    TGeoCompositeShape *cs = new TGeoCompositeShape(NameShort(name), pBoolNode);
-   fsolmap[name.Data()] = cs;
+   fsolmap[local_name.Data()] = cs;
 
    return node;
 }
@@ -2676,9 +2688,9 @@ XMLNodePointer_t TGDMLParse::ElCone(TXMLEngine *gdml, XMLNodePointer_t node, XML
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    // semiaxises of elliptical cone (elcone) are different then ellipsoid
 
@@ -2708,7 +2720,7 @@ XMLNodePointer_t TGDMLParse::ElCone(TXMLEngine *gdml, XMLNodePointer_t node, XML
    TGeoScale *scl = new TGeoScale("", sx, sy, sz);
    TGeoScaledShape *shape = new TGeoScaledShape(NameShort(name), con, scl);
 
-   fsolmap[name.Data()] = shape;
+   fsolmap[local_name.Data()] = shape;
 
    return node;
 }
@@ -2749,9 +2761,9 @@ XMLNodePointer_t TGDMLParse::Paraboloid(TXMLEngine *gdml, XMLNodePointer_t node,
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retunit = GetScaleVal(lunit);
 
@@ -2761,7 +2773,7 @@ XMLNodePointer_t TGDMLParse::Paraboloid(TXMLEngine *gdml, XMLNodePointer_t node,
 
    TGeoParaboloid *paraboloid = new TGeoParaboloid(NameShort(name), rlo, rhi, dz);
 
-   fsolmap[name.Data()] = paraboloid;
+   fsolmap[local_name.Data()] = paraboloid;
 
    return node;
 }
@@ -2844,9 +2856,9 @@ XMLNodePointer_t TGDMLParse::Arb8(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retunit = GetScaleVal(lunit);
 
@@ -2879,7 +2891,7 @@ XMLNodePointer_t TGDMLParse::Arb8(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    arb8->SetVertex(6, v7x, v7y);
    arb8->SetVertex(7, v8x, v8y);
 
-   fsolmap[name.Data()] = arb8;
+   fsolmap[local_name.Data()] = arb8;
 
    return node;
 }
@@ -2929,9 +2941,9 @@ XMLNodePointer_t TGDMLParse::Tube(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -2948,7 +2960,7 @@ XMLNodePointer_t TGDMLParse::Tube(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       tube = new TGeoTubeSeg(NameShort(name), rminline, rmaxline, zline / 2, startphideg, endphideg);
    else
       tube = new TGeoTube(NameShort(name), rminline, rmaxline, zline / 2);
-   fsolmap[name.Data()] = tube;
+   fsolmap[local_name.Data()] = tube;
 
    return node;
 }
@@ -3016,9 +3028,9 @@ XMLNodePointer_t TGDMLParse::CutTube(TXMLEngine *gdml, XMLNodePointer_t node, XM
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3038,7 +3050,7 @@ XMLNodePointer_t TGDMLParse::CutTube(TXMLEngine *gdml, XMLNodePointer_t node, XM
    TGeoCtub *cuttube = new TGeoCtub(NameShort(name), rminline, rmaxline, zline / 2, startphiline, deltaphiline,
                                     lowXline, lowYline, lowZline, highXline, highYline, highZline);
 
-   fsolmap[name.Data()] = cuttube;
+   fsolmap[local_name.Data()] = cuttube;
 
    return node;
 }
@@ -3094,9 +3106,9 @@ XMLNodePointer_t TGDMLParse::Cone(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3116,7 +3128,7 @@ XMLNodePointer_t TGDMLParse::Cone(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    else
       cone = new TGeoCone(NameShort(name), zline / 2, rmin1line, rmax1line, rmin2line, rmax2line);
 
-   fsolmap[name.Data()] = cone;
+   fsolmap[local_name.Data()] = cone;
 
    return node;
 }
@@ -3184,9 +3196,9 @@ XMLNodePointer_t TGDMLParse::Trap(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3206,7 +3218,7 @@ XMLNodePointer_t TGDMLParse::Trap(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
    TGeoTrap *trap = new TGeoTrap(NameShort(name), zline / 2, thetaline, philine, y1line / 2, x1line / 2, x2line / 2,
                                  alpha1line, y2line / 2, x3line / 2, x4line / 2, alpha2line);
 
-   fsolmap[name.Data()] = trap;
+   fsolmap[local_name.Data()] = trap;
 
    return node;
 }
@@ -3253,9 +3265,9 @@ XMLNodePointer_t TGDMLParse::Trd(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
 
@@ -3267,7 +3279,7 @@ XMLNodePointer_t TGDMLParse::Trd(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
 
    TGeoTrd2 *trd = new TGeoTrd2(NameShort(name), x1line / 2, x2line / 2, y1line / 2, y2line / 2, zline / 2);
 
-   fsolmap[name.Data()] = trd;
+   fsolmap[local_name.Data()] = trd;
 
    return node;
 }
@@ -3311,9 +3323,9 @@ XMLNodePointer_t TGDMLParse::Polycone(TXMLEngine *gdml, XMLNodePointer_t node, X
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3387,7 +3399,7 @@ XMLNodePointer_t TGDMLParse::Polycone(TXMLEngine *gdml, XMLNodePointer_t node, X
       zno = zno + 1;
    }
 
-   fsolmap[name.Data()] = poly;
+   fsolmap[local_name.Data()] = poly;
    for (i = 0; i < numplanes; i++) {
       delete[] table[i];
    }
@@ -3439,9 +3451,9 @@ XMLNodePointer_t TGDMLParse::Polyhedra(TXMLEngine *gdml, XMLNodePointer_t node, 
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3516,7 +3528,7 @@ XMLNodePointer_t TGDMLParse::Polyhedra(TXMLEngine *gdml, XMLNodePointer_t node, 
       zno = zno + 1;
    }
 
-   fsolmap[name.Data()] = polyg;
+   fsolmap[local_name.Data()] = polyg;
    for (i = 0; i < numplanes; i++) {
       delete[] table[i];
    }
@@ -3572,9 +3584,9 @@ XMLNodePointer_t TGDMLParse::Sphere(TXMLEngine *gdml, XMLNodePointer_t node, XML
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3589,7 +3601,7 @@ XMLNodePointer_t TGDMLParse::Sphere(TXMLEngine *gdml, XMLNodePointer_t node, XML
    TGeoSphere *sphere =
       new TGeoSphere(NameShort(name), rminline, rmaxline, startthetaline, deltathetaline, startphiline, deltaphiline);
 
-   fsolmap[name.Data()] = sphere;
+   fsolmap[local_name.Data()] = sphere;
 
    return node;
 }
@@ -3639,9 +3651,9 @@ XMLNodePointer_t TGDMLParse::Torus(TXMLEngine *gdml, XMLNodePointer_t node, XMLA
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3654,7 +3666,7 @@ XMLNodePointer_t TGDMLParse::Torus(TXMLEngine *gdml, XMLNodePointer_t node, XMLA
 
    TGeoTorus *torus = new TGeoTorus(NameShort(name), rtorline, rminline, rmaxline, startphiline, deltaphiline);
 
-   fsolmap[name.Data()] = torus;
+   fsolmap[local_name.Data()] = torus;
 
    return node;
 }
@@ -3703,9 +3715,9 @@ XMLNodePointer_t TGDMLParse::Hype(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3718,7 +3730,7 @@ XMLNodePointer_t TGDMLParse::Hype(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
 
    TGeoHype *hype = new TGeoHype(NameShort(name), rminline, instline, rmaxline, outstline, zline / 2);
 
-   fsolmap[name.Data()] = hype;
+   fsolmap[local_name.Data()] = hype;
 
    return node;
 }
@@ -3771,9 +3783,9 @@ XMLNodePointer_t TGDMLParse::Para(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3787,7 +3799,7 @@ XMLNodePointer_t TGDMLParse::Para(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
 
    TGeoPara *para = new TGeoPara(NameShort(name), xline / 2, yline / 2, zline / 2, alphaline, thetaline, philine);
 
-   fsolmap[name.Data()] = para;
+   fsolmap[local_name.Data()] = para;
 
    return node;
 }
@@ -3859,9 +3871,9 @@ XMLNodePointer_t TGDMLParse::TwistTrap(TXMLEngine *gdml, XMLNodePointer_t node, 
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
    Double_t retaunit = GetScaleVal(aunit);
@@ -3882,7 +3894,7 @@ XMLNodePointer_t TGDMLParse::TwistTrap(TXMLEngine *gdml, XMLNodePointer_t node, 
    TGeoGtra *twtrap = new TGeoGtra(NameShort(name), zline / 2, thetaline, philine, twistline, y1line / 2, x1line / 2,
                                    x2line / 2, alpha1line, y2line / 2, x3line / 2, x4line / 2, alpha2line);
 
-   fsolmap[name.Data()] = twtrap;
+   fsolmap[local_name.Data()] = twtrap;
 
    return node;
 }
@@ -3923,9 +3935,9 @@ XMLNodePointer_t TGDMLParse::ElTube(TXMLEngine *gdml, XMLNodePointer_t node, XML
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retunit = GetScaleVal(lunit);
 
@@ -3935,7 +3947,7 @@ XMLNodePointer_t TGDMLParse::ElTube(TXMLEngine *gdml, XMLNodePointer_t node, XML
 
    TGeoEltu *eltu = new TGeoEltu(NameShort(name), xline, yline, zline);
 
-   fsolmap[name.Data()] = eltu;
+   fsolmap[local_name.Data()] = eltu;
 
    return node;
 }
@@ -3969,9 +3981,9 @@ XMLNodePointer_t TGDMLParse::Orb(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retunit = GetScaleVal(lunit);
 
@@ -3979,7 +3991,7 @@ XMLNodePointer_t TGDMLParse::Orb(TXMLEngine *gdml, XMLNodePointer_t node, XMLAtt
 
    TGeoSphere *orb = new TGeoSphere(NameShort(name), 0, rline, 0, 180, 0, 360);
 
-   fsolmap[name.Data()] = orb;
+   fsolmap[local_name.Data()] = orb;
 
    return node;
 }
@@ -4022,9 +4034,9 @@ XMLNodePointer_t TGDMLParse::Xtru(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    Double_t retlunit = GetScaleVal(lunit);
 
@@ -4139,7 +4151,7 @@ XMLNodePointer_t TGDMLParse::Xtru(TXMLEngine *gdml, XMLNodePointer_t node, XMLAt
       xtru->DefineSection((int)section[j][0], section[j][1], section[j][2], section[j][3], section[j][4]);
    }
 
-   fsolmap[name.Data()] = xtru;
+   fsolmap[local_name.Data()] = xtru;
    delete[] vertx;
    delete[] verty;
    for (i = 0; i < nosects; i++) {
@@ -4170,9 +4182,9 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
       attr = gdml->GetNextAttr(attr);
    }
 
-   if ((strcmp(fCurrentFile, fStartFile)) != 0) {
-      name = TString::Format("%s_%s", name.Data(), fCurrentFile);
-   }
+   TString local_name = name;
+   if ((strcmp(fCurrentFile, fStartFile)) != 0)
+      local_name = TString::Format("%s_%s", name.Data(), fCurrentFile);
 
    auto tsl = new TGeoTessellated(NameShort(name));
    TGeoTranslation *pos = nullptr;
@@ -4216,27 +4228,24 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
 
             if (tempattr == "vertex1") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(0, pos);
             }
 
             else if (tempattr == "vertex2") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(1, pos);
             }
 
             else if (tempattr == "vertex3") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(2, pos);
             }
@@ -4261,36 +4270,32 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
 
             if (tempattr == "vertex1") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(0, pos);
             }
 
             else if (tempattr == "vertex2") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(1, pos);
             }
 
             else if (tempattr == "vertex3") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(2, pos);
             }
 
             else if (tempattr == "vertex4") {
                vname = gdml->GetAttrValue(attr);
-               if (fposmap.find(vname.Data()) != fposmap.end())
-                  pos = fposmap[vname.Data()];
-               else
+               pos = GetPosition(vname.Data());
+               if (!pos)
                   Fatal("Tessellated", "Vertex %s not defined", vname.Data());
                SetVertex(3, pos);
             }
@@ -4309,7 +4314,7 @@ XMLNodePointer_t TGDMLParse::Tessellated(TXMLEngine *gdml, XMLNodePointer_t node
    }
    tsl->CloseShape(false);
 
-   fsolmap[name.Data()] = tsl;
+   fsolmap[local_name.Data()] = tsl;
 
    return node;
 }


### PR DESCRIPTION
# This Pull request:
Fixes GDML name resolution for positions, rotations, scales, solids and volumes defined in a secondary file.
## Changes or fixes:
GDML allows implicit namespacing for objects defined in children files. The current implementation of the ROOT GDML parser is flawed in this respect. Objects are temporarily stored with an appended suffix to their name, but their subsequent search by name ignores the suffix, not finding the ones already defined. The fix corrects this by first searching in the local file namespace, then in the global namespace.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #9744  

