### PR TITLE
[RF] Defer loading of `RooBatchCompute` libs to first RooFitDriver use

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -61,7 +61,6 @@ enum Computer{AddPdf, ArgusBG, Bernstein, BifurGauss, BreitWigner, Bukin, CBShap
 class RooBatchComputeInterface {
   public:
     virtual ~RooBatchComputeInterface() = default;
-    virtual void   init() { throw std::bad_function_call(); }
     virtual void   compute(cudaStream_t*, Computer, RestrictArr, size_t, const DataMap&, const VarVector&, const ArgVector& ={}) = 0;
     virtual double sumReduce(cudaStream_t*, InputArr input, size_t n) = 0;
     virtual Architecture architecture() const = 0;

--- a/roofit/batchcompute/res/RooBatchCompute/Initialisation.h
+++ b/roofit/batchcompute/res/RooBatchCompute/Initialisation.h
@@ -1,0 +1,22 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN February 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOFIT_BATCHCOMPUTE_INITIALIZATION_H
+#define ROOFIT_BATCHCOMPUTE_INITIALIZATION_H
+
+namespace RooBatchCompute {
+
+void init();
+
+} // End namespace RooBatchCompute
+
+#endif

--- a/roofit/batchcompute/src/Initialisation.cxx
+++ b/roofit/batchcompute/src/Initialisation.cxx
@@ -53,11 +53,9 @@ void init()
    const std::string userChoice = gEnv->GetValue("RooFit.BatchCompute", "auto");
 #ifdef R__RF_ARCHITECTURE_SPECIFIC_LIBS
 #ifdef R__HAS_CUDA
-   TString libcudart{"libcudart"};
-   if (gSystem->FindDynamicLibrary(libcudart, true))
-      gSystem->Load("libRooBatchCompute_CUDA");
-   if (RooBatchCompute::dispatchCUDA)
-      RooBatchCompute::dispatchCUDA->init();
+   if(gSystem->Load("libRooBatchCompute_CUDA") != 0) {
+      RooBatchCompute::dispatchCUDA = nullptr;
+   }
 #endif // R__HAS_CUDA
 
    __builtin_cpu_init();

--- a/roofit/batchcompute/src/Initialisation.cxx
+++ b/roofit/batchcompute/src/Initialisation.cxx
@@ -37,9 +37,19 @@ void loadWithErrorChecking(const std::string &libName)
                              " was loaded before RooFit initialisation began.");
 }
 
+} // end anonymous namespace
+
+namespace RooBatchCompute {
+
 /// Inspect hardware capabilities, and load the optimal library for RooFit computations.
-void loadComputeLibrary()
+void init()
 {
+   // Check if the library was not initialised already
+   static bool isInitialised = false;
+   if (isInitialised)
+      return;
+   isInitialised = true;
+
    const std::string userChoice = gEnv->GetValue("RooFit.BatchCompute", "auto");
 #ifdef R__RF_ARCHITECTURE_SPECIFIC_LIBS
 #ifdef R__HAS_CUDA
@@ -83,10 +93,5 @@ void loadComputeLibrary()
    if (RooBatchCompute::dispatchCPU == nullptr)
       loadWithErrorChecking("libRooBatchCompute_GENERIC");
 }
-} // end anonymous namespace
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-/// A RAII that performs RooFit's static initialisation.
-static struct RooBatchComputeInitialiser {
-   RooBatchComputeInitialiser() { loadComputeLibrary(); }
-} __RooBatchComputeInitialiser;
+} // namespace RooBatchCompute

--- a/roofit/batchcompute/src/RooBatchCompute.cu
+++ b/roofit/batchcompute/src/RooBatchCompute.cu
@@ -69,20 +69,6 @@ public:
       return out;
    };
 
-   /** Initialize the cuda computation library.
-   This method needs to be called after the dynamic loading of the cuda instance of the
-   RooBatchCompute library. If cuda is not working properly, it will set the dispatchCUDA
-   pointer to nullptr. **/
-   void init()
-   {
-      cudaError_t err = cudaSetDevice(0);
-      if (err == cudaSuccess)
-         cudaFree(nullptr);
-      else {
-         dispatchCUDA = nullptr;
-         Error("RbcClass::init()", cudaGetErrorString(err));
-      }
-   }
    /** Compute multiple values using cuda kernels.
    This method creates a Batches object and passes it to the correct compute function.
    The compute function is launched as a cuda kernel.

--- a/roofit/roofitcore/src/Buffers.cxx
+++ b/roofit/roofitcore/src/Buffers.cxx
@@ -183,7 +183,7 @@ public:
 
    BufferImpl(std::size_t size)
    {
-      std::queue<Container> &q = _queues[size];
+      std::queue<Container> &q = queues()[size];
       if (q.empty()) {
          _vec = Container(size);
       } else {
@@ -192,7 +192,12 @@ public:
       }
    }
 
-   ~BufferImpl() override { _queues.at(_vec.size()).emplace(std::move(_vec)); }
+   static QueuesMap& queues() {
+      static QueuesMap queuesMap;
+      return queuesMap;
+   }
+
+   ~BufferImpl() override { queues().at(_vec.size()).emplace(std::move(_vec)); }
 
    double const *cpuReadPtr() const override { return _vec.cpuReadPtr(); }
    double const *gpuReadPtr() const override { return _vec.gpuReadPtr(); }
@@ -201,16 +206,12 @@ public:
    double *gpuWritePtr() override { return _vec.gpuWritePtr(); }
 
    Container _vec;
-   static QueuesMap _queues;
 };
 
 using ScalarBuffer = BufferImpl<ScalarBufferContainer>;
 using CPUBuffer = BufferImpl<CPUBufferContainer>;
 using GPUBuffer = BufferImpl<GPUBufferContainer>;
 using PinnedBuffer = BufferImpl<PinnedBufferContainer>;
-
-template <class Container>
-typename BufferImpl<Container>::QueuesMap BufferImpl<Container>::_queues = {};
 
 std::unique_ptr<AbsBuffer> makeScalarBuffer()
 {


### PR DESCRIPTION
Initializing RooBatchCompute takes over a second when CUDA is also
available on the system. It is unreasonable to do this everytime the
RooFit library is loaded. For example, the time of small unit tests was
completely dominated by the RooBatchCompute initialization time before
this commit.

This change entailed another change in `Buffers.cxx` to avoid static
initialization problems.

If possible, I'll still try to backport this to the release.