### PR TITLE
[RF] Speed up RooDecay by at least a factor two by optimizing `evalCerf` in RooGaussModel

### DIFF
--- a/roofit/roofit/src/RooGaussModel.cxx
+++ b/roofit/roofit/src/RooGaussModel.cxx
@@ -56,6 +56,16 @@ std::complex<double> evalCerfApprox(double _x, double u, double c)
 // Calculate exp(-u^2) cwerf(swt*c + i(u+c)), taking care of numerical instabilities
 inline std::complex<double> evalCerf(double swt, double u, double c)
 {
+  if(swt == 0.0) {
+    // For a purely complex argument z, the faddeeva function equals to
+    // exp(z*z) * erfc(z). Together with coefficient exp(-u*u), this means the
+    // function can be simplified to:
+    const double z = u + c;
+    return z > -4.0 ? (std::exp(c * (c + 2.*u)) * std::erfc(z)) : evalCerfApprox(0.,u,c);
+    // This version with std::erfc is about twice as fast as the faddeeva_fast
+    // code path, speeding up in particular the analytical convolution of an
+    // exponential decay with a Gaussian (like in RooDecay).
+  }
   std::complex<double> z(swt*c,u+c);
   return (z.imag()>-4.0) ? (std::exp(-u*u)*RooMath::faddeeva_fast(z)) : evalCerfApprox(swt,u,c);
 }


### PR DESCRIPTION
In the RooDecay case, the evalCerf function called internally in
RooGaussModel passes a purely imaginary argument to
`RooMath::faddeeva_fast`. In this case, the Faddeeva function is equal
to a scaled complementary error function, which can be evaluated more
efficiently using `std::erfc`.

The speedup can be seen in the stressRooFit tests that involve the
RooDecay, for example:
`Test 22 : Full per-event error p.d.f. F(t|dt)G(dt)`
The test can be run individually to verify this speedup:

```
`./stressRooFit -n 22`
```