### PR TITLE
TBranchElement: no drilling through new members. 

### DIFF
--- a/core/meta/src/TIsAProxy.cxx
+++ b/core/meta/src/TIsAProxy.cxx
@@ -47,7 +47,7 @@ namespace {
 
 TIsAProxy::TIsAProxy(const std::type_info& typ)
    : fType(&typ), fClass(nullptr),
-     fSubTypesReaders(0), fSubTypesWriteLockTaken(kFALSE),
+     fSubTypesReaders(0), fSubTypesWriteLockTaken(kFALSE), fNextLastSlot(0),
      fInit(kFALSE), fVirtual(kFALSE)
 {
    static_assert(sizeof(ClassMap_t)<=sizeof(fSubTypes), "ClassMap size is to large for array");

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2068,16 +2068,24 @@ static void GatherArtificialElements(const TObjArray &branches, TStreamerInfoAct
             subprefix = ename + ".";
          }
          auto nbranches = search->GetEntriesFast();
+         bool foundRelatedSplit = false;
          for (Int_t bi = 0; bi < nbranches; ++bi) {
             TBranchElement* subbe = (TBranchElement*)search->At(bi);
+            bool matchSubPrefix = strncmp(subbe->GetFullName(), subprefix.Data(), subprefix.Length()) == 0;
+            if (!foundRelatedSplit)
+               foundRelatedSplit = matchSubPrefix;
             if (elementClass == subbe->GetInfo()->GetClass() // Use GetInfo to provoke its creation.
                && subbe->GetOnfileObject()
-               && strncmp(subbe->GetFullName(), subprefix.Data(), subprefix.Length()) == 0)
+               && matchSubPrefix)
             {
                nextinfo = subbe->GetInfo();
                onfileObject = subbe->GetOnfileObject();
                break;
             }
+         }
+
+         if (!foundRelatedSplit) {
+            continue;
          }
 
          if (!nextinfo) {

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2236,7 +2236,7 @@ void TBranchElement::InitInfo()
             Bool_t seenExisting = kFALSE;
 
             fOnfileObject = new TVirtualArray( info->GetElement(0)->GetClassPointer(), arrlen );
-            // Propagate this to all the other branch belonging to the same object.
+            // Propagate this to all the other branches belonging to the same object.
             TObjArray *branches = toplevel ? GetListOfBranches() : GetMother()->GetSubBranch(this)->GetListOfBranches();
             Int_t nbranches = branches->GetEntriesFast();
             TBranchElement *lastbranch = this;


### PR DESCRIPTION
See https://github.com/root-project/root/pull/9913

This resolved the problem seen at: https://github.com/cms-sw/cmssw/issues/36908#issuecomment-1036397481
and fix #9899.

The problem is the rules are applied to a data member nested inside an object nested inside
an STL collection that is a new data member of the class reco::HaloClusterCandidateHCAL,
since it is a new member compared to the layout on file, none of the objects; from the new
member down to the object on which the rules need to be run) are actually streamed and the
code gathering the information to run the rule got a bit lost ; it is likely (I am checking
as we speak) that in previous release the rule was not even attempted to be run ... which
might actually be the desired behavior in this specific case.

The solution is to have GatherArtificialElements stop drilling through data members which
are not stored in the existing TTree