### PR TITLE
Improve syntax of main hist classes

### DIFF
--- a/hist/hist/inc/TGraphDelaunay.h
+++ b/hist/hist/inc/TGraphDelaunay.h
@@ -31,8 +31,8 @@ class TGraphDelaunay : public TNamed {
 
 private:
 
-   TGraphDelaunay(const TGraphDelaunay&); // Not implemented
-   TGraphDelaunay& operator=(const TGraphDelaunay&); // Not implemented
+   TGraphDelaunay(const TGraphDelaunay&) = delete;
+   TGraphDelaunay& operator=(const TGraphDelaunay&) = delete;
 
 protected:
 

--- a/hist/hist/inc/TGraphDelaunay2D.h
+++ b/hist/hist/inc/TGraphDelaunay2D.h
@@ -35,8 +35,8 @@ public:
 
 
 private:
-   TGraphDelaunay2D(const TGraphDelaunay2D&);            // Not implemented
-   TGraphDelaunay2D& operator=(const TGraphDelaunay2D&); // Not implemented
+   TGraphDelaunay2D(const TGraphDelaunay2D&) = delete;
+   TGraphDelaunay2D& operator=(const TGraphDelaunay2D&) = delete;
 
 protected:
 

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -123,8 +123,7 @@ private:
    void    Build();
 
    TH1(const TH1&);
-   TH1& operator=(const TH1&); // Not implemented
-
+   TH1& operator=(const TH1&) = delete;
 
 protected:
    TH1();
@@ -193,27 +192,27 @@ public:
    virtual void     AddBinContent(Int_t bin, Double_t w);
    static  void     AddDirectory(Bool_t add=kTRUE);
    static  Bool_t   AddDirectoryStatus();
-   virtual void     Browse(TBrowser *b);
+           void     Browse(TBrowser *b) override;
    virtual Bool_t   CanExtendAllAxes() const;
    virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = 0) const;
    virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = 0) const;
    virtual Double_t Chisquare(TF1 * f1, Option_t *option = "") const;
    virtual void     ClearUnderflowAndOverflow();
    virtual Double_t ComputeIntegral(Bool_t onlyPositive = false);
-   TObject*         Clone(const char* newname=0) const;
-   virtual void     Copy(TObject &hnew) const;
+           TObject* Clone(const char *newname = "") const override;
+           void     Copy(TObject &hnew) const override;
    virtual void     DirectoryAutoAdd(TDirectory *);
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
+           Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
    virtual Bool_t   Divide(TF1 *f1, Double_t c1=1);
    virtual Bool_t   Divide(const TH1 *h1);
    virtual Bool_t   Divide(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
-   virtual void     Draw(Option_t *option="");
+           void     Draw(Option_t *option = "") override;
    virtual TH1     *DrawCopy(Option_t *option="", const char * name_postfix = "_copy") const;
    virtual TH1     *DrawNormalized(Option_t *option="", Double_t norm=1) const;
    virtual void     DrawPanel(); // *MENU*
    virtual Int_t    BufferEmpty(Int_t action=0);
    virtual void     Eval(TF1 *f1, Option_t *option="");
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+           void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual void     ExtendAxis(Double_t x, TAxis *axis);
    virtual TH1     *FFT(TH1* h_output, Option_t *option);
    virtual Int_t    Fill(Double_t x);
@@ -227,8 +226,8 @@ public:
    virtual Int_t    FindFixBin(Double_t x, Double_t y=0, Double_t z=0) const;
    virtual Int_t    FindFirstBinAbove(Double_t threshold=0, Int_t axis=1, Int_t firstBin=1, Int_t lastBin=-1) const;
    virtual Int_t    FindLastBinAbove (Double_t threshold=0, Int_t axis=1, Int_t firstBin=1, Int_t lastBin=-1) const;
-   virtual TObject *FindObject(const char *name) const;
-   virtual TObject *FindObject(const TObject *obj) const;
+           TObject *FindObject(const char *name) const override;
+           TObject *FindObject(const TObject *obj) const override;
    virtual TFitResultPtr    Fit(const char *formula ,Option_t *option="" ,Option_t *goption="", Double_t xmin=0, Double_t xmax=0); // *MENU*
    virtual TFitResultPtr    Fit(TF1 *f1 ,Option_t *option="" ,Option_t *goption="", Double_t xmin=0, Double_t xmax=0);
    virtual void     FitPanel(); // *MENU*
@@ -254,7 +253,7 @@ public:
    virtual Float_t  GetTickLength(Option_t *axis="X") const;
    virtual Float_t  GetBarOffset() const {return Float_t(0.001*Float_t(fBarOffset));}
    virtual Float_t  GetBarWidth() const  {return Float_t(0.001*Float_t(fBarWidth));}
-   virtual Int_t    GetContour(Double_t *levels=0);
+   virtual Int_t    GetContour(Double_t *levels = nullptr);
    virtual Double_t GetContourLevel(Int_t level) const;
    virtual Double_t GetContourLevelPad(Int_t level) const;
 
@@ -298,8 +297,8 @@ public:
    virtual Int_t    GetNbinsZ() const {return fZaxis.GetNbins();}
    virtual Int_t    GetNcells() const {return fNcells; }
    virtual Double_t GetNormFactor() const {return fNormFactor;}
-   virtual char    *GetObjectInfo(Int_t px, Int_t py) const;
-   Option_t        *GetOption() const {return fOption.Data();}
+           char    *GetObjectInfo(Int_t px, Int_t py) const override;
+          Option_t *GetOption() const  override { return fOption.Data(); }
 
    TVirtualHistPainter *GetPainter(Option_t *option="");
 
@@ -343,16 +342,16 @@ public:
    virtual Bool_t   Multiply(TF1 *f1, Double_t c1=1);
    virtual Bool_t   Multiply(const TH1 *h1);
    virtual Bool_t   Multiply(const TH1 *h1, const TH1 *h2, Double_t c1=1, Double_t c2=1, Option_t *option=""); // *MENU*
-   virtual void     Paint(Option_t *option="");
-   virtual void     Print(Option_t *option="") const;
+           void     Paint(Option_t *option = "") override;
+           void     Print(Option_t *option = "") const override;
    virtual void     PutStats(Double_t *stats);
-   virtual TH1     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);  // *MENU*
-   virtual TH1     *RebinX(Int_t ngroup=2, const char*newname="") { return Rebin(ngroup,newname, (Double_t*) 0); }
-   virtual void     Rebuild(Option_t *option="");
-   virtual void     RecursiveRemove(TObject *obj);
-   virtual void     Reset(Option_t *option="");
+   virtual TH1     *Rebin(Int_t ngroup = 2, const char *newname = "", const Double_t *xbins = 0);  // *MENU*
+   virtual TH1     *RebinX(Int_t ngroup = 2, const char *newname = "") { return Rebin(ngroup,newname, (Double_t*) nullptr); }
+   virtual void     Rebuild(Option_t *option = "");
+           void     RecursiveRemove(TObject *obj) override;
+   virtual void     Reset(Option_t *option = "");
    virtual void     ResetStats();
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+           void     SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     Scale(Double_t c1=1, Option_t *option="");
    virtual void     SetAxisColor(Color_t color=1, Option_t *axis="X");
    virtual void     SetAxisRange(Double_t xmin, Double_t xmax, Option_t *axis="X");
@@ -398,8 +397,8 @@ public:
    virtual void     SetMaximum(Double_t maximum = -1111) { fMaximum = maximum; }; // *MENU*
    virtual void     SetMinimum(Double_t minimum = -1111) { fMinimum = minimum; }; // *MENU*
 
-   virtual void     SetName(const char *name); // *MENU*
-   virtual void     SetNameTitle(const char *name, const char *title);
+           void     SetName(const char *name) override; // *MENU*
+           void     SetNameTitle(const char *name, const char *title) override;
    virtual void     SetNdivisions(Int_t n=510, Option_t *axis="X");
    virtual void     SetNormFactor(Double_t factor=1) {fNormFactor = factor;}
    virtual void     SetStats(Bool_t stats=kTRUE); // *MENU*
@@ -409,7 +408,7 @@ public:
    virtual void     SetTitleOffset(Float_t offset=1, Option_t *axis="X");
    virtual void     SetTitleSize(Float_t size=0.02, Option_t *axis="X");
            void     SetStatOverflows(EStatOverflows statOverflows) {fStatOverflows = statOverflows;}; ///< See GetStatOverflows for more information.
-   virtual void     SetTitle(const char *title);  // *MENU*
+           void     SetTitle(const char *title) override;  // *MENU*
    virtual void     SetXTitle(const char *title) {fXaxis.SetTitle(title);}
    virtual void     SetYTitle(const char *title) {fYaxis.SetTitle(title);}
    virtual void     SetZTitle(const char *title) {fZaxis.SetTitle(title);}
@@ -419,7 +418,7 @@ public:
    static  void     SmoothArray(Int_t NN, Double_t *XX, Int_t ntimes=1);
    static  void     StatOverflows(Bool_t flag=kTRUE);
    virtual void     Sumw2(Bool_t flag = kTRUE);
-   void             UseCurrentStyle();
+           void     UseCurrentStyle() override;
    static  TH1     *TransformHisto(TVirtualFFT *fft, TH1* h_output,  Option_t *option);
 
 
@@ -435,7 +434,7 @@ public:
    virtual void     SetCellError(Int_t binx, Int_t biny, Double_t content)
                         { Obsolete("SetCellError", "v6-00", "v6-04"); SetBinError(binx, biny, content); }
 
-   ClassDef(TH1,8)  //1-Dim histogram base class
+   ClassDefOverride(TH1,8)  //1-Dim histogram base class
 
 protected:
    virtual Double_t RetrieveBinContent(Int_t bin) const;
@@ -460,13 +459,13 @@ public:
    TH1C& operator=(const TH1C &h1);
    virtual ~TH1C();
 
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+   void     AddBinContent(Int_t bin) override;
+   void     AddBinContent(Int_t bin, Double_t w) override;
+   void     Copy(TObject &hnew) const override;
+   void     Reset(Option_t *option="") override;
+   void     SetBinsLength(Int_t n=-1) override;
 
-   ClassDef(TH1C,3)  //1-Dim histograms (one char per channel)
+   ClassDefOverride(TH1C,3)  //1-Dim histograms (one char per channel)
 
    friend  TH1C     operator*(Double_t c1, const TH1C &h1);
    friend  TH1C     operator*(const TH1C &h1, Double_t c1);
@@ -476,8 +475,8 @@ public:
    friend  TH1C     operator/(const TH1C &h1, const TH1C &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Char_t (content); }
+   Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+   void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Char_t (content); }
 };
 
 TH1C operator*(Double_t c1, const TH1C &h1);
@@ -501,13 +500,13 @@ public:
    TH1S& operator=(const TH1S &h1);
    virtual ~TH1S();
 
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+   void     AddBinContent(Int_t bin) override;
+   void     AddBinContent(Int_t bin, Double_t w) override;
+   void     Copy(TObject &hnew) const override;
+   void     Reset(Option_t *option="") override;
+   void     SetBinsLength(Int_t n=-1) override;
 
-   ClassDef(TH1S,3)  //1-Dim histograms (one short per channel)
+   ClassDefOverride(TH1S,3)  //1-Dim histograms (one short per channel)
 
    friend  TH1S     operator*(Double_t c1, const TH1S &h1);
    friend  TH1S     operator*(const TH1S &h1, Double_t c1);
@@ -517,8 +516,8 @@ public:
    friend  TH1S     operator/(const TH1S &h1, const TH1S &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Short_t (content); }
+   Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+   void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Short_t (content); }
 };
 
 TH1S operator*(Double_t c1, const TH1S &h1);
@@ -542,13 +541,13 @@ public:
    TH1I& operator=(const TH1I &h1);
    virtual ~TH1I();
 
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+   void     AddBinContent(Int_t bin) override;
+   void     AddBinContent(Int_t bin, Double_t w) override;
+   void     Copy(TObject &hnew) const override;
+   void     Reset(Option_t *option="") override;
+   void     SetBinsLength(Int_t n=-1) override;
 
-   ClassDef(TH1I,3)  //1-Dim histograms (one 32 bits integer per channel)
+   ClassDefOverride(TH1I,3)  //1-Dim histograms (one 32 bits integer per channel)
 
    friend  TH1I     operator*(Double_t c1, const TH1I &h1);
    friend  TH1I     operator*(const TH1I &h1, Double_t c1);
@@ -558,8 +557,8 @@ public:
    friend  TH1I     operator/(const TH1I &h1, const TH1I &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Int_t (content); }
+   Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+   void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Int_t (content); }
 };
 
 TH1I operator*(Double_t c1, const TH1I &h1);
@@ -584,14 +583,14 @@ public:
    TH1F& operator=(const TH1F &h1);
    virtual ~TH1F();
 
-   virtual void     AddBinContent(Int_t bin) {++fArray[bin];}
-   virtual void     AddBinContent(Int_t bin, Double_t w)
-                                 {fArray[bin] += Float_t (w);}
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+   void     AddBinContent(Int_t bin) override {++fArray[bin];}
+   void     AddBinContent(Int_t bin, Double_t w) override
+                          { fArray[bin] += Float_t (w); }
+   void     Copy(TObject &hnew) const override;
+   void     Reset(Option_t *option = "") override;
+   void     SetBinsLength(Int_t n=-1) override;
 
-   ClassDef(TH1F,3)  //1-Dim histograms (one float per channel)
+   ClassDefOverride(TH1F,3)  //1-Dim histograms (one float per channel)
 
    friend  TH1F     operator*(Double_t c1, const TH1F &h1);
    friend  TH1F     operator*(const TH1F &h1, Double_t c1);
@@ -601,8 +600,8 @@ public:
    friend  TH1F     operator/(const TH1F &h1, const TH1F &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Float_t (content); }
+   Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+   void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Float_t (content); }
 };
 
 TH1F operator*(Double_t c1, const TH1F &h1);
@@ -627,14 +626,14 @@ public:
    TH1D& operator=(const TH1D &h1);
    virtual ~TH1D();
 
-   virtual void     AddBinContent(Int_t bin) {++fArray[bin];}
-   virtual void     AddBinContent(Int_t bin, Double_t w)
-                                 {fArray[bin] += Double_t (w);}
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+   void     AddBinContent(Int_t bin) override {++fArray[bin];}
+   void     AddBinContent(Int_t bin, Double_t w) override
+                          {fArray[bin] += Double_t (w);}
+   void     Copy(TObject &hnew) const override;
+   void     Reset(Option_t *option = "") override;
+   void     SetBinsLength(Int_t n=-1) override;
 
-   ClassDef(TH1D,3)  //1-Dim histograms (one double per channel)
+   ClassDefOverride(TH1D,3)  //1-Dim histograms (one double per channel)
 
    friend  TH1D     operator*(Double_t c1, const TH1D &h1);
    friend  TH1D     operator*(const TH1D &h1, Double_t c1);
@@ -644,8 +643,8 @@ public:
    friend  TH1D     operator/(const TH1D &h1, const TH1D &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return fArray[bin]; }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = content; }
+   Double_t RetrieveBinContent(Int_t bin) const override { return fArray[bin]; }
+   void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = content; }
 };
 
 TH1D operator*(Double_t c1, const TH1D &h1);

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -53,11 +53,11 @@ protected:
    virtual TH1D     *DoQuantiles(bool onX, const char *name, Double_t prob) const;
    virtual void      DoFitSlices(bool onX, TF1 *f1, Int_t firstbin, Int_t lastbin, Int_t cut, Option_t *option, TObjArray* arr);
 
-   Int_t    BufferFill(Double_t, Double_t) {return -2;} //may not use
-   Int_t    Fill(Double_t); //MayNotUse
-   Int_t    Fill(const char*, Double_t) { return Fill(0);}  //MayNotUse
+   Int_t    BufferFill(Double_t, Double_t) override {return -2;} //may not use
+   Int_t    Fill(Double_t) override; //MayNotUse
+   Int_t    Fill(const char*, Double_t) override { return Fill(0);}  //MayNotUse
 
-   virtual Double_t Interpolate(Double_t x) const; // may not use
+   Double_t Interpolate(Double_t x) const override; // may not use
 
 private:
 
@@ -70,24 +70,24 @@ private:
 
 public:
    virtual ~TH2();
-   virtual Int_t    BufferEmpty(Int_t action=0);
-   virtual void     Copy(TObject &hnew) const;
-   virtual Int_t    Fill(Double_t x, Double_t y);
+           Int_t    BufferEmpty(Int_t action=0) override;
+           void     Copy(TObject &hnew) const override;
+           Int_t    Fill(Double_t x, Double_t y) override;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t w);
    virtual Int_t    Fill(Double_t x, const char *namey, Double_t w);
    virtual Int_t    Fill(const char *namex, Double_t y, Double_t w);
    virtual Int_t    Fill(const char *namex, const char *namey, Double_t w);
-   virtual void     FillN(Int_t, const Double_t *, const Double_t *, Int_t) {;} //MayNotUse
-   virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride=1);
-   virtual void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom * rng = nullptr);
-   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom * rng = nullptr);
+           void     FillN(Int_t, const Double_t *, const Double_t *, Int_t) override {;} //MayNotUse
+           void     FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride=1) override;
+           void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom *rng = nullptr) override;
+           void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom *rng = nullptr) override;
    virtual void     FitSlicesX(TF1 *f1=0,Int_t firstybin=0, Int_t lastybin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
    virtual void     FitSlicesY(TF1 *f1=0,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
-   virtual Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz = 0) const;
+           Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz = 0) const override;
    virtual Double_t GetBinWithContent2(Double_t c, Int_t &binx, Int_t &biny, Int_t firstxbin=1, Int_t lastxbin=-1,Int_t firstybin=1, Int_t lastybin=-1, Double_t maxdiff=0) const;
-   virtual Double_t GetBinContent(Int_t bin) const { return TH1::GetBinContent(bin); }
-   virtual Double_t GetBinContent(Int_t binx, Int_t biny) const { return TH1::GetBinContent( GetBin(binx, biny) ); }
-   virtual Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const { return TH1::GetBinContent( GetBin(binx, biny) ); }
+           Double_t GetBinContent(Int_t bin) const override { return TH1::GetBinContent(bin); }
+           Double_t GetBinContent(Int_t binx, Int_t biny) const override { return TH1::GetBinContent( GetBin(binx, biny) ); }
+           Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const override { return TH1::GetBinContent( GetBin(binx, biny) ); }
    using TH1::GetBinErrorLow;
    using TH1::GetBinErrorUp;
    virtual Double_t GetBinErrorLow(Int_t binx, Int_t biny) { return TH1::GetBinErrorLow( GetBin(binx, biny) ); }
@@ -95,37 +95,37 @@ public:
    virtual Double_t GetCorrelationFactor(Int_t axis1=1,Int_t axis2=2) const;
    virtual Double_t GetCovariance(Int_t axis1=1,Int_t axis2=2) const;
    virtual void     GetRandom2(Double_t &x, Double_t &y, TRandom * rng = nullptr);
-   virtual void     GetStats(Double_t *stats) const;
-   virtual Double_t Integral(Option_t *option="") const;
+           void     GetStats(Double_t *stats) const override;
+           Double_t Integral(Option_t *option="") const override;
    //virtual Double_t Integral(Int_t, Int_t, Option_t * ="") const {return 0;}
    virtual Double_t Integral(Int_t binx1, Int_t binx2, Int_t biny1, Int_t biny2, Option_t *option="") const;
    virtual Double_t Integral(Int_t, Int_t, Int_t, Int_t, Int_t, Int_t, Option_t * ="") const {return 0;}
    virtual Double_t IntegralAndError(Int_t binx1, Int_t binx2, Int_t biny1, Int_t biny2, Double_t & err, Option_t *option="") const;
-   virtual Double_t Interpolate(Double_t x, Double_t y) const;
-   virtual Double_t Interpolate(Double_t x, Double_t y, Double_t z) const;
-   virtual Double_t KolmogorovTest(const TH1 *h2, Option_t *option="") const;
-   virtual TH2     *RebinX(Int_t ngroup=2, const char *newname=""); // *MENU*
+           Double_t Interpolate(Double_t x, Double_t y) const override;
+           Double_t Interpolate(Double_t x, Double_t y, Double_t z) const override;
+           Double_t KolmogorovTest(const TH1 *h2, Option_t *option="") const override;
+           TH2     *RebinX(Int_t ngroup=2, const char *newname="") override; // *MENU*
    virtual TH2     *RebinY(Int_t ngroup=2, const char *newname=""); // *MENU*
-   virtual TH2     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins=0);  // re-implementation of the TH1 function using RebinX
+           TH2     *Rebin(Int_t ngroup=2, const char*newname="", const Double_t *xbins = nullptr) override;  // re-implementation of the TH1 function using RebinX
    virtual TH2     *Rebin2D(Int_t nxgroup=2, Int_t nygroup=2, const char *newname=""); // *MENU*
-      TProfile     *ProfileX(const char *name="_pfx", Int_t firstybin=1, Int_t lastybin=-1, Option_t *option="") const;   // *MENU*
-      TProfile     *ProfileY(const char *name="_pfy", Int_t firstxbin=1, Int_t lastxbin=-1, Option_t *option="") const;   // *MENU*
-         TH1D      *ProjectionX(const char *name="_px", Int_t firstybin=0, Int_t lastybin=-1, Option_t *option="") const; // *MENU*
-         TH1D      *ProjectionY(const char *name="_py", Int_t firstxbin=0, Int_t lastxbin=-1, Option_t *option="") const; // *MENU*
-   virtual void     PutStats(Double_t *stats);
-   TH1D            *QuantilesX(Double_t prob = 0.5, const char * name = "_qx" ) const;
-   TH1D            *QuantilesY(Double_t prob = 0.5, const char * name = "_qy" ) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinContent(Int_t bin, Double_t content);
-   virtual void     SetBinContent(Int_t binx, Int_t biny, Double_t content) { SetBinContent(GetBin(binx, biny), content); }
-   virtual void     SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) { SetBinContent(GetBin(binx, biny), content); }
+          TProfile *ProfileX(const char *name="_pfx", Int_t firstybin=1, Int_t lastybin=-1, Option_t *option="") const;   // *MENU*
+          TProfile *ProfileY(const char *name="_pfy", Int_t firstxbin=1, Int_t lastxbin=-1, Option_t *option="") const;   // *MENU*
+           TH1D    *ProjectionX(const char *name="_px", Int_t firstybin=0, Int_t lastybin=-1, Option_t *option="") const; // *MENU*
+           TH1D    *ProjectionY(const char *name="_py", Int_t firstxbin=0, Int_t lastxbin=-1, Option_t *option="") const; // *MENU*
+           void     PutStats(Double_t *stats) override;
+           TH1D    *QuantilesX(Double_t prob = 0.5, const char * name = "_qx" ) const;
+           TH1D    *QuantilesY(Double_t prob = 0.5, const char * name = "_qy" ) const;
+           void     Reset(Option_t *option="") override;
+           void     SetBinContent(Int_t bin, Double_t content) override;
+           void     SetBinContent(Int_t binx, Int_t biny, Double_t content) override { SetBinContent(GetBin(binx, biny), content); }
+           void     SetBinContent(Int_t binx, Int_t biny, Int_t, Double_t content) override { SetBinContent(GetBin(binx, biny), content); }
    virtual void     SetShowProjectionX(Int_t nbins=1);  // *MENU*
    virtual void     SetShowProjectionY(Int_t nbins=1);  // *MENU*
-   virtual TH1     *ShowBackground(Int_t niter=20, Option_t *option="same");
-   virtual Int_t    ShowPeaks(Double_t sigma=2, Option_t *option="", Double_t threshold=0.05); // *MENU*
-   virtual void     Smooth(Int_t ntimes=1, Option_t *option=""); // *MENU*
+           TH1     *ShowBackground(Int_t niter=20, Option_t *option="same") override;
+           Int_t    ShowPeaks(Double_t sigma=2, Option_t *option="", Double_t threshold=0.05) override; // *MENU*
+           void     Smooth(Int_t ntimes=1, Option_t *option="") override; // *MENU*
 
-   ClassDef(TH2,5)  //2-Dim histogram base class
+   ClassDefOverride(TH2,5)  //2-Dim histogram base class
 };
 
 
@@ -147,11 +147,13 @@ public:
                                           ,Int_t nbinsy,const Float_t  *ybins);
    TH2C(const TH2C &h2c);
    virtual ~TH2C();
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+
+           void     AddBinContent(Int_t bin) override;
+           void     AddBinContent(Int_t bin, Double_t w) override;
+           void     Copy(TObject &hnew) const override;
+           void     Reset(Option_t *option="") override;
+           void     SetBinsLength(Int_t n=-1) override;
+
            TH2C&    operator=(const TH2C &h1);
    friend  TH2C     operator*(Float_t c1, TH2C &h1);
    friend  TH2C     operator*(TH2C &h1, Float_t c1) {return operator*(c1,h1);}
@@ -161,10 +163,10 @@ public:
    friend  TH2C     operator/(TH2C &h1, TH2C &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Char_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Char_t (content); }
 
-   ClassDef(TH2C,4)  //2-Dim histograms (one char per channel)
+   ClassDefOverride(TH2C,4)  //2-Dim histograms (one char per channel)
 };
 
 
@@ -186,11 +188,13 @@ public:
                                           ,Int_t nbinsy,const Float_t  *ybins);
    TH2S(const TH2S &h2s);
    virtual ~TH2S();
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+
+           void     AddBinContent(Int_t bin) override;
+           void     AddBinContent(Int_t bin, Double_t w) override;
+           void     Copy(TObject &hnew) const override;
+           void     Reset(Option_t *option="") override;
+           void     SetBinsLength(Int_t n=-1) override;
+
            TH2S&    operator=(const TH2S &h1);
    friend  TH2S     operator*(Float_t c1, TH2S &h1);
    friend  TH2S     operator*(TH2S &h1, Float_t c1) {return operator*(c1,h1);}
@@ -200,10 +204,10 @@ public:
    friend  TH2S     operator/(TH2S &h1, TH2S &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Short_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Short_t (content); }
 
-   ClassDef(TH2S,4)  //2-Dim histograms (one short per channel)
+   ClassDefOverride(TH2S,4)  //2-Dim histograms (one short per channel)
 };
 
 
@@ -225,11 +229,13 @@ public:
                                           ,Int_t nbinsy,const Float_t  *ybins);
    TH2I(const TH2I &h2i);
    virtual ~TH2I();
-   virtual void     AddBinContent(Int_t bin);
-   virtual void     AddBinContent(Int_t bin, Double_t w);
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+
+           void     AddBinContent(Int_t bin) override;
+           void     AddBinContent(Int_t bin, Double_t w) override;
+           void     Copy(TObject &hnew) const override;
+           void     Reset(Option_t *option="") override;
+           void     SetBinsLength(Int_t n=-1) override;
+
            TH2I&    operator=(const TH2I &h1);
    friend  TH2I     operator*(Float_t c1, TH2I &h1);
    friend  TH2I     operator*(TH2I &h1, Float_t c1) {return operator*(c1,h1);}
@@ -239,10 +245,10 @@ public:
    friend  TH2I     operator/(TH2I &h1, TH2I &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Int_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Int_t (content); }
 
-   ClassDef(TH2I,4)  //2-Dim histograms (one 32 bits integer per channel)
+   ClassDefOverride(TH2I,4)  //2-Dim histograms (one 32 bits integer per channel)
 };
 
 
@@ -265,12 +271,14 @@ public:
    TH2F(const TMatrixFBase &m);
    TH2F(const TH2F &h2f);
    virtual ~TH2F();
-   virtual void     AddBinContent(Int_t bin) {++fArray[bin];}
-   virtual void     AddBinContent(Int_t bin, Double_t w)
+
+           void     AddBinContent(Int_t bin) override {++fArray[bin];}
+           void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+           void     Copy(TObject &hnew) const override;
+           void     Reset(Option_t *option="") override;
+           void     SetBinsLength(Int_t n=-1) override;
+
            TH2F&    operator=(const TH2F &h1);
    friend  TH2F     operator*(Float_t c1, TH2F &h1);
    friend  TH2F     operator*(TH2F &h1, Float_t c1);
@@ -280,10 +288,10 @@ public:
    friend  TH2F     operator/(TH2F &h1, TH2F &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Float_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Float_t (content); }
 
-   ClassDef(TH2F,4)  //2-Dim histograms (one float per channel)
+   ClassDefOverride(TH2F,4)  //2-Dim histograms (one float per channel)
 };
 
 
@@ -306,12 +314,14 @@ public:
    TH2D(const TMatrixDBase &m);
    TH2D(const TH2D &h2d);
    virtual ~TH2D();
-   virtual void     AddBinContent(Int_t bin) {++fArray[bin];}
-   virtual void     AddBinContent(Int_t bin, Double_t w)
+
+           void     AddBinContent(Int_t bin) override {++fArray[bin];}
+           void     AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
-   virtual void     Copy(TObject &hnew) const;
-   virtual void     Reset(Option_t *option="");
-   virtual void     SetBinsLength(Int_t n=-1);
+           void     Copy(TObject &hnew) const override;
+           void     Reset(Option_t *option="") override;
+           void     SetBinsLength(Int_t n=-1) override;
+
            TH2D&    operator=(const TH2D &h1);
    friend  TH2D     operator*(Float_t c1, TH2D &h1);
    friend  TH2D     operator*(TH2D &h1, Float_t c1) {return operator*(c1,h1);}
@@ -321,10 +331,10 @@ public:
    friend  TH2D     operator/(TH2D &h1, TH2D &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return fArray[bin]; }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = content; }
+           Double_t RetrieveBinContent(Int_t bin) const override { return fArray[bin]; }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = content; }
 
-   ClassDef(TH2D,4)  //2-Dim histograms (one double per channel)
+   ClassDefOverride(TH2D,4)  //2-Dim histograms (one double per channel)
 };
 
 #endif

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -85,7 +85,7 @@ public:
    virtual void     FitSlicesY(TF1 *f1=0,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
            Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz = 0) const override;
    virtual Double_t GetBinWithContent2(Double_t c, Int_t &binx, Int_t &biny, Int_t firstxbin=1, Int_t lastxbin=-1,Int_t firstybin=1, Int_t lastybin=-1, Double_t maxdiff=0) const;
-           Double_t GetBinContent(Int_t bin) const override { return TH1::GetBinContent(bin); }
+   using TH1::GetBinContent;
            Double_t GetBinContent(Int_t binx, Int_t biny) const override { return TH1::GetBinContent( GetBin(binx, biny) ); }
            Double_t GetBinContent(Int_t binx, Int_t biny, Int_t) const override { return TH1::GetBinContent( GetBin(binx, biny) ); }
    using TH1::GetBinErrorLow;

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -62,7 +62,7 @@ protected:
 private:
 
    TH2(const TH2&);
-   TH2& operator=(const TH2&); // Not implemented
+   TH2& operator=(const TH2&) = delete;
 
    // make private methods which have a TH1 signature and should not
    using TH1::Integral;

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -68,7 +68,7 @@ protected:
 private:
 
    TH3(const TH3&);
-   TH3& operator=(const TH3&); // Not implemented
+   TH3& operator=(const TH3&) = delete;
 
    using TH1::Integral;
    using TH1::IntegralAndError;

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -93,8 +93,7 @@ public:
    virtual void     FitSlicesZ(TF1 *f1=0,Int_t binminx=1, Int_t binmaxx=0,Int_t binminy=1, Int_t binmaxy=0,
                                         Int_t cut=0 ,Option_t *option="QNR"); // *MENU*
            Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz) const override;
-           Double_t GetBinContent(Int_t bin) const override { return TH1::GetBinContent(bin); }
-           Double_t GetBinContent(Int_t bin, Int_t) const override { return TH1::GetBinContent(bin); }
+   using TH1::GetBinContent;
            Double_t GetBinContent(Int_t binx, Int_t biny, Int_t binz) const override { return TH1::GetBinContent( GetBin(binx, biny, binz) ); }
    using TH1::GetBinErrorLow;
    using TH1::GetBinErrorUp;

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -53,17 +53,17 @@ protected:
 
    void DoFillProfileProjection(TProfile2D * p2, const TAxis & a1, const TAxis & a2, const TAxis & a3, Int_t bin1, Int_t bin2, Int_t bin3, Int_t inBin, Bool_t useWeights) const;
 
-   virtual Int_t    BufferFill(Double_t, Double_t) {return -2;} //may not use
+           Int_t    BufferFill(Double_t, Double_t) override {return -2;} //may not use
    virtual Int_t    BufferFill(Double_t, Double_t, Double_t) {return -2;} //may not use
-   Int_t    Fill(Double_t);        //MayNotUse
-   Int_t    Fill(Double_t,Double_t) {return Fill(0.);} //MayNotUse
-   Int_t    Fill(const char*, Double_t) {return Fill(0);} //MayNotUse
-   Int_t    Fill(Double_t,const char*,Double_t) {return Fill(0);} //MayNotUse
-   Int_t    Fill(const char*,Double_t,Double_t) {return Fill(0);} //MayNotUse
-   Int_t    Fill(const char*,const char*,Double_t) {return Fill(0);} //MayNotUse
+           Int_t    Fill(Double_t) override;        //MayNotUse
+           Int_t    Fill(Double_t,Double_t) override {return Fill(0.);} //MayNotUse
+           Int_t    Fill(const char*, Double_t) override {return Fill(0);} //MayNotUse
+           Int_t    Fill(Double_t,const char*,Double_t) {return Fill(0);} //MayNotUse
+           Int_t    Fill(const char*,Double_t,Double_t)  {return Fill(0);} //MayNotUse
+           Int_t    Fill(const char*,const char*,Double_t) {return Fill(0);} //MayNotUse
 
-   virtual Double_t Interpolate(Double_t x, Double_t y) const; // May not use
-   virtual Double_t Interpolate(Double_t x) const; // MayNotUse
+           Double_t Interpolate(Double_t x, Double_t y) const override; // May not use
+           Double_t Interpolate(Double_t x) const override; // MayNotUse
 
 private:
 
@@ -75,8 +75,8 @@ private:
 
 public:
    virtual ~TH3();
-   virtual Int_t    BufferEmpty(Int_t action=0);
-   virtual void     Copy(TObject &hnew) const;
+           Int_t    BufferEmpty(Int_t action = 0) override;
+           void     Copy(TObject &hnew) const override;
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z);
    virtual Int_t    Fill(Double_t x, Double_t y, Double_t z, Double_t w);
 
@@ -88,14 +88,14 @@ public:
    virtual Int_t    Fill(Double_t x, const char *namey, Double_t z, Double_t w);
    virtual Int_t    Fill(Double_t x, Double_t y, const char *namez, Double_t w);
 
-   virtual void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom * rng = nullptr);
-   virtual void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom * rng = nullptr);
+           void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom *rng = nullptr) override;
+           void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom *rng = nullptr) override;
    virtual void     FitSlicesZ(TF1 *f1=0,Int_t binminx=1, Int_t binmaxx=0,Int_t binminy=1, Int_t binmaxy=0,
                                         Int_t cut=0 ,Option_t *option="QNR"); // *MENU*
-   virtual Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz) const;
-   virtual Double_t GetBinContent(Int_t bin) const { return TH1::GetBinContent(bin); }
-   virtual Double_t GetBinContent(Int_t bin, Int_t) const { return TH1::GetBinContent(bin); }
-   virtual Double_t GetBinContent(Int_t binx, Int_t biny, Int_t binz) const { return TH1::GetBinContent( GetBin(binx, biny, binz) ); }
+           Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz) const override;
+           Double_t GetBinContent(Int_t bin) const override { return TH1::GetBinContent(bin); }
+           Double_t GetBinContent(Int_t bin, Int_t) const override { return TH1::GetBinContent(bin); }
+           Double_t GetBinContent(Int_t binx, Int_t biny, Int_t binz) const override { return TH1::GetBinContent( GetBin(binx, biny, binz) ); }
    using TH1::GetBinErrorLow;
    using TH1::GetBinErrorUp;
    virtual Double_t GetBinErrorLow(Int_t binx, Int_t biny, Int_t binz) { return TH1::GetBinErrorLow( GetBin(binx, biny, binz) ); }
@@ -104,12 +104,12 @@ public:
    virtual Double_t GetCorrelationFactor(Int_t axis1=1,Int_t axis2=2) const;
    virtual Double_t GetCovariance(Int_t axis1=1,Int_t axis2=2) const;
    virtual void     GetRandom3(Double_t &x, Double_t &y, Double_t &, TRandom * rng = nullptr);
-   virtual void     GetStats(Double_t *stats) const;
-   virtual Double_t Integral(Option_t *option="") const;
+           void     GetStats(Double_t *stats) const override;
+           Double_t Integral(Option_t *option="") const override;
    virtual Double_t Integral(Int_t binx1, Int_t binx2, Int_t biny1, Int_t biny2, Int_t binz1, Int_t binz2, Option_t *option="") const;
    virtual Double_t IntegralAndError(Int_t binx1, Int_t binx2, Int_t biny1, Int_t biny2, Int_t binz1, Int_t binz2, Double_t & err, Option_t *option="") const;
-   virtual Double_t Interpolate(Double_t x, Double_t y, Double_t z) const;
-   virtual Double_t KolmogorovTest(const TH1 *h2, Option_t *option="") const;
+           Double_t Interpolate(Double_t x, Double_t y, Double_t z) const override;
+           Double_t KolmogorovTest(const TH1 *h2, Option_t *option="") const override;
    virtual TH1D    *ProjectionX(const char *name="_px", Int_t iymin=0, Int_t iymax=-1, Int_t izmin=0,
                                 Int_t izmax=-1, Option_t *option="") const; // *MENU*
    virtual TH1D    *ProjectionY(const char *name="_py", Int_t ixmin=0, Int_t ixmax=-1, Int_t izmin=0,
@@ -118,15 +118,15 @@ public:
                                 Int_t iymax=-1, Option_t *option="") const; // *MENU*
    virtual TH1     *Project3D(Option_t *option="x") const; // *MENU*
    virtual TProfile2D  *Project3DProfile(Option_t *option="xy") const; // *MENU*
-   virtual void     PutStats(Double_t *stats);
-   virtual TH3     *RebinX(Int_t ngroup = 2, const char *newname = "");
+           void     PutStats(Double_t *stats) override;
+           TH3     *RebinX(Int_t ngroup = 2, const char *newname = "") override;
    virtual TH3     *RebinY(Int_t ngroup = 2, const char *newname = "");
    virtual TH3     *RebinZ(Int_t ngroup = 2, const char *newname = "");
    virtual TH3     *Rebin3D(Int_t nxgroup = 2, Int_t nygroup = 2, Int_t nzgroup = 2, const char *newname = "");
-   virtual void     Reset(Option_t *option="");
-   virtual void      SetBinContent(Int_t bin, Double_t content);
-   virtual void      SetBinContent(Int_t bin, Int_t, Double_t content) { SetBinContent(bin, content); }
-   virtual void      SetBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t content) { SetBinContent(GetBin(binx, biny, binz), content); }
+           void     Reset(Option_t *option="") override;
+           void     SetBinContent(Int_t bin, Double_t content) override;
+           void     SetBinContent(Int_t bin, Int_t, Double_t content) override { SetBinContent(bin, content); }
+           void     SetBinContent(Int_t binx, Int_t biny, Int_t binz, Double_t content) override { SetBinContent(GetBin(binx, biny, binz), content); }
    virtual void     SetShowProjection(const char *option="xy",Int_t nbins=1);   // *MENU*
 
 protected:
@@ -151,7 +151,7 @@ protected:
       return h.DoProject2D(name, title, projX,projY, computeErrors, originalRange, useUF, useOF);
    }
 
-   ClassDef(TH3,6)  //3-Dim histogram base class
+   ClassDefOverride(TH3,6)  //3-Dim histogram base class
 };
 
 //________________________________________________________________________
@@ -170,11 +170,13 @@ public:
                                           ,Int_t nbinsz,const Double_t *zbins);
    TH3C(const TH3C &h3c);
    virtual ~TH3C();
-   virtual void      AddBinContent(Int_t bin);
-   virtual void      AddBinContent(Int_t bin, Double_t w);
-   virtual void      Copy(TObject &hnew) const;
-   virtual void      Reset(Option_t *option="");
-   virtual void      SetBinsLength(Int_t n=-1);
+
+           void      AddBinContent(Int_t bin) override;
+           void      AddBinContent(Int_t bin, Double_t w) override;
+           void      Copy(TObject &hnew) const override;
+           void      Reset(Option_t *option="") override;
+           void      SetBinsLength(Int_t n=-1) override;
+
            TH3C&     operator=(const TH3C &h1);
    friend  TH3C      operator*(Float_t c1, TH3C &h1);
    friend  TH3C      operator*(TH3C &h1, Float_t c1) {return operator*(c1,h1);}
@@ -184,10 +186,10 @@ public:
    friend  TH3C      operator/(TH3C &h1, TH3C &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Char_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Char_t (content); }
 
-   ClassDef(TH3C,4)  //3-Dim histograms (one char per channel)
+   ClassDefOverride(TH3C,4)  //3-Dim histograms (one char per channel)
 };
 
 //________________________________________________________________________
@@ -206,11 +208,13 @@ public:
                                           ,Int_t nbinsz,const Double_t *zbins);
    TH3S(const TH3S &h3s);
    virtual ~TH3S();
-   virtual void      AddBinContent(Int_t bin);
-   virtual void      AddBinContent(Int_t bin, Double_t w);
-   virtual void      Copy(TObject &hnew) const;
-   virtual void      Reset(Option_t *option="");
-   virtual void      SetBinsLength(Int_t n=-1);
+
+           void      AddBinContent(Int_t bin) override;
+           void      AddBinContent(Int_t bin, Double_t w) override;
+           void      Copy(TObject &hnew) const override;
+           void      Reset(Option_t *option="") override;
+           void      SetBinsLength(Int_t n=-1) override;
+
            TH3S&     operator=(const TH3S &h1);
    friend  TH3S      operator*(Float_t c1, TH3S &h1);
    friend  TH3S      operator*(TH3S &h1, Float_t c1) {return operator*(c1,h1);}
@@ -220,10 +224,10 @@ public:
    friend  TH3S      operator/(TH3S &h1, TH3S &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Short_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Short_t (content); }
 
-   ClassDef(TH3S,4)  //3-Dim histograms (one short per channel)
+   ClassDefOverride(TH3S,4)  //3-Dim histograms (one short per channel)
 };
 
 //________________________________________________________________________
@@ -242,11 +246,13 @@ public:
                                           ,Int_t nbinsz,const Double_t *zbins);
    TH3I(const TH3I &h3i);
    virtual ~TH3I();
-   virtual void      AddBinContent(Int_t bin);
-   virtual void      AddBinContent(Int_t bin, Double_t w);
-   virtual void      Copy(TObject &hnew) const;
-   virtual void      Reset(Option_t *option="");
-   virtual void      SetBinsLength(Int_t n=-1);
+
+           void      AddBinContent(Int_t bin) override;
+           void      AddBinContent(Int_t bin, Double_t w) override;
+           void      Copy(TObject &hnew) const override;
+           void      Reset(Option_t *option="") override;
+           void      SetBinsLength(Int_t n=-1) override;
+
            TH3I&     operator=(const TH3I &h1);
    friend  TH3I      operator*(Float_t c1, TH3I &h1);
    friend  TH3I      operator*(TH3I &h1, Float_t c1) {return operator*(c1,h1);}
@@ -256,10 +262,10 @@ public:
    friend  TH3I      operator/(TH3I &h1, TH3I &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Int_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Int_t (content); }
 
-   ClassDef(TH3I,4)  //3-Dim histograms (one 32 bits integer per channel)
+   ClassDefOverride(TH3I,4)  //3-Dim histograms (one 32 bits integer per channel)
 };
 
 
@@ -279,12 +285,14 @@ public:
                                           ,Int_t nbinsz,const Double_t *zbins);
    TH3F(const TH3F &h3f);
    virtual ~TH3F();
-   virtual void      AddBinContent(Int_t bin) {++fArray[bin];}
-   virtual void      AddBinContent(Int_t bin, Double_t w)
+
+           void      AddBinContent(Int_t bin) override {++fArray[bin];}
+           void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Float_t (w);}
-   virtual void      Copy(TObject &hnew) const;
-   virtual void      Reset(Option_t *option="");
-   virtual void      SetBinsLength(Int_t n=-1);
+           void      Copy(TObject &hnew) const override;
+           void      Reset(Option_t *option="") override;
+           void      SetBinsLength(Int_t n=-1) override;
+
            TH3F&     operator=(const TH3F &h1);
    friend  TH3F      operator*(Float_t c1, TH3F &h1);
    friend  TH3F      operator*(TH3F &h1, Float_t c1) {return operator*(c1,h1);}
@@ -294,10 +302,10 @@ public:
    friend  TH3F      operator/(TH3F &h1, TH3F &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return Double_t (fArray[bin]); }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = Float_t (content); }
+           Double_t RetrieveBinContent(Int_t bin) const override { return Double_t (fArray[bin]); }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = Float_t (content); }
 
-   ClassDef(TH3F,4)  //3-Dim histograms (one float per channel)
+   ClassDefOverride(TH3F,4)  //3-Dim histograms (one float per channel)
 };
 
 //________________________________________________________________________
@@ -316,12 +324,14 @@ public:
                                           ,Int_t nbinsz,const Double_t *zbins);
    TH3D(const TH3D &h3d);
    virtual ~TH3D();
-   virtual void      AddBinContent(Int_t bin) {++fArray[bin];}
-   virtual void      AddBinContent(Int_t bin, Double_t w)
+
+           void      AddBinContent(Int_t bin) override {++fArray[bin];}
+           void      AddBinContent(Int_t bin, Double_t w) override
                                  {fArray[bin] += Double_t (w);}
-   virtual void      Copy(TObject &hnew) const;
-   virtual void      Reset(Option_t *option="");
-   virtual void      SetBinsLength(Int_t n=-1);
+           void      Copy(TObject &hnew) const override;
+           void      Reset(Option_t *option="") override;
+           void      SetBinsLength(Int_t n=-1) override;
+
            TH3D&     operator=(const TH3D &h1);
    friend  TH3D      operator*(Float_t c1, TH3D &h1);
    friend  TH3D      operator*(TH3D &h1, Float_t c1) {return operator*(c1,h1);}
@@ -331,10 +341,10 @@ public:
    friend  TH3D      operator/(TH3D &h1, TH3D &h2);
 
 protected:
-   virtual Double_t RetrieveBinContent(Int_t bin) const { return fArray[bin]; }
-   virtual void     UpdateBinContent(Int_t bin, Double_t content) { fArray[bin] = content; }
+           Double_t RetrieveBinContent(Int_t bin) const override { return fArray[bin]; }
+           void     UpdateBinContent(Int_t bin, Double_t content) override { fArray[bin] = content; }
 
-   ClassDef(TH3D,4)  //3-Dim histograms (one double per channel)
+   ClassDefOverride(TH3D,4)  //3-Dim histograms (one double per channel)
 };
 
 #endif

--- a/hist/hist/inc/THStack.h
+++ b/hist/hist/inc/THStack.h
@@ -37,32 +37,32 @@ class TFileMergeInfo;
 
 class THStack : public TNamed {
 private:
-   THStack& operator=(const THStack&); // Not implemented
+   THStack& operator=(const THStack&) = delete;
 
 protected:
-   TList      *fHists;      ///<  Pointer to array of TH1
-   TObjArray  *fStack;      ///<! Pointer to array of sums of TH1
-   TH1        *fHistogram;  ///<  Pointer to histogram used for drawing axis
-   Double_t    fMaximum;    ///<  Maximum value for plotting along y
-   Double_t    fMinimum;    ///<  Minimum value for plotting along y
+   TList      *fHists{nullptr};      ///<  Pointer to array of TH1
+   TObjArray  *fStack{nullptr};      ///<! Pointer to array of sums of TH1
+   TH1        *fHistogram{nullptr};  ///<  Pointer to histogram used for drawing axis
+   Double_t    fMaximum{-1111};      ///<  Maximum value for plotting along y
+   Double_t    fMinimum{-1111};      ///<  Minimum value for plotting along y
 
    void BuildStack();
 
 public:
 
-   THStack();
+   THStack() {}
    THStack(const char *name, const char *title);
    THStack(TH1* hist, Option_t *axis="x",
-           const char *name=0, const char *title=0,
-           Int_t firstbin=1, Int_t lastbin=-1,
-           Int_t firstbin2=1, Int_t lastbin2=-1,
-           Option_t* proj_option="", Option_t* draw_option="");
+           const char *name = nullptr, const char *title = nullptr,
+           Int_t firstbin = 1, Int_t lastbin = -1,
+           Int_t firstbin2 = 1, Int_t lastbin2 = -1,
+           Option_t *proj_option = "", Option_t *draw_option = "");
    THStack(const THStack &hstack);
    virtual ~THStack();
    virtual void     Add(TH1 *h, Option_t *option="");
-   virtual void     Browse(TBrowser *b);
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *chopt="");
+   void             Browse(TBrowser *b)  override;
+   Int_t            DistancetoPrimitive(Int_t px, Int_t py) override;
+   void             Draw(Option_t *chopt="")  override;
    TH1             *GetHistogram() const;
    TList           *GetHists()  const { return fHists; }
    TIter            begin() const;
@@ -74,18 +74,18 @@ public:
    TAxis           *GetXaxis() const;
    TAxis           *GetYaxis() const;
    TAxis           *GetZaxis() const;
-   virtual void     ls(Option_t *option="") const;
+   void             ls(Option_t *option="") const  override;
    virtual Long64_t Merge(TCollection* li, TFileMergeInfo *info);
    virtual void     Modified();
-   virtual void     Paint(Option_t *chopt="");
-   virtual void     Print(Option_t *chopt="") const;
-   virtual void     RecursiveRemove(TObject *obj);
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void     SetHistogram(TH1 *h) {fHistogram = h;}
+   void             Paint(Option_t *chopt = "") override;
+   void             Print(Option_t *chopt = "") const override;
+   void             RecursiveRemove(TObject *obj)  override;
+   void             SavePrimitive(std::ostream &out, Option_t *option = "")  override;
+   virtual void     SetHistogram(TH1 *h) { fHistogram = h; }
    virtual void     SetMaximum(Double_t maximum=-1111); // *MENU*
    virtual void     SetMinimum(Double_t minimum=-1111); // *MENU*
 
-   ClassDef(THStack,2)  //A collection of histograms
+   ClassDefOverride(THStack,2)  //A collection of histograms
 };
 
 #endif

--- a/hist/hist/inc/THnSparse.h
+++ b/hist/hist/inc/THnSparse.h
@@ -42,8 +42,8 @@ class THnSparse: public THnBase {
    TExMap     fBinsContinued;               ///<! Filled bins for non-unique hashes, containing pairs of (bin index 0, bin index 1)
    THnSparseCompactBinCoord *fCompactCoord; ///<! Compact coordinate
 
-   THnSparse(const THnSparse&); // Not implemented
-   THnSparse& operator=(const THnSparse&); // Not implemented
+   THnSparse(const THnSparse&) = delete;
+   THnSparse& operator=(const THnSparse&) = delete;
 
  protected:
 

--- a/hist/hist/inc/THnSparse_Internal.h
+++ b/hist/hist/inc/THnSparse_Internal.h
@@ -30,8 +30,8 @@ class THnSparse;
 class THnSparseArrayChunk: public TObject {
  private:
 
-   THnSparseArrayChunk(const THnSparseArrayChunk&); // Not implemented
-   THnSparseArrayChunk& operator=(const THnSparseArrayChunk&); // Not implemented
+   THnSparseArrayChunk(const THnSparseArrayChunk&) = delete;
+   THnSparseArrayChunk& operator=(const THnSparseArrayChunk&) = delete;
 
  public:
    THnSparseArrayChunk():

--- a/hist/hist/inc/TMultiGraph.h
+++ b/hist/hist/inc/TMultiGraph.h
@@ -48,11 +48,11 @@ public:
    TMultiGraph(const char *name, const char *title);
    virtual ~TMultiGraph();
 
-   virtual void      Add(TGraph *graph, Option_t *chopt="");
-   virtual void      Add(TMultiGraph *multigraph, Option_t *chopt="");
-   virtual void      Browse(TBrowser *b);
-   virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void      Draw(Option_t *chopt="");
+   virtual void      Add(TGraph *graph, Option_t *chopt = "");
+   virtual void      Add(TMultiGraph *multigraph, Option_t *chopt = "");
+   void              Browse(TBrowser *b) override;
+   Int_t             DistancetoPrimitive(Int_t px, Int_t py) override;
+   void              Draw(Option_t *chopt = "") override;
    virtual TFitResultPtr Fit(const char *formula ,Option_t *option="" ,Option_t *goption="", Axis_t xmin=0, Axis_t xmax=0);
    virtual TFitResultPtr Fit(TF1 *f1 ,Option_t *option="" ,Option_t *goption="", Axis_t rxmin=0, Axis_t rxmax=0);
    virtual void      FitPanel(); // *MENU*
@@ -72,19 +72,17 @@ public:
    const TList      *GetListOfFunctions() const { return fFunctions; }
    TAxis            *GetXaxis();
    TAxis            *GetYaxis();
-   virtual void      Paint(Option_t *chopt="");
-   void              PaintPads(Option_t *chopt="");
-   void              PaintPolyLine3D(Option_t *chopt="");
-   void              PaintReverse(Option_t *chopt="");
-   virtual void      Print(Option_t *chopt="") const;
-   virtual void      RecursiveRemove(TObject *obj);
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
+   void              Paint(Option_t *chopt = "") override;
+   void              PaintPads(Option_t *chopt = "");
+   void              PaintPolyLine3D(Option_t *chopt = "");
+   void              PaintReverse(Option_t *chopt = "");
+   void              Print(Option_t *chopt="") const override;
+   void              RecursiveRemove(TObject *obj) override;
+   void              SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void      SetMaximum(Double_t maximum=-1111);
    virtual void      SetMinimum(Double_t minimum=-1111);
 
-   ClassDef(TMultiGraph,2)  //A collection of TGraph objects
+   ClassDefOverride(TMultiGraph,2)  // A collection of TGraph objects
 };
 
 #endif
-
-

--- a/hist/hist/inc/v5/TFormulaPrimitive.h
+++ b/hist/hist/inc/v5/TFormulaPrimitive.h
@@ -68,8 +68,8 @@ protected:
    Int_t      fNParameters;                               //number of parameters
    Bool_t     fIsStatic;                                  // indication if the function is static
 private:
-   TFormulaPrimitive(const TFormulaPrimitive&); // Not implemented
-   TFormulaPrimitive& operator=(const TFormulaPrimitive&); // Not implemented
+   TFormulaPrimitive(const TFormulaPrimitive&) = delete;
+   TFormulaPrimitive& operator=(const TFormulaPrimitive&) = delete;
 public:
    TFormulaPrimitive();
    TFormulaPrimitive(const char *name,const char *formula, GenFunc0 fpointer);

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -160,7 +160,7 @@ Histograms may also be created by:
 
  This default behaviour can be changed by:
 ~~~ {.cpp}
-       h->SetDirectory(0);          // for the current histogram h
+       h->SetDirectory(nullptr);          // for the current histogram h
        TH1::AddDirectory(kFALSE);   // sets a global switch disabling the referencing
 ~~~
  When the histogram is deleted, the reference to it is removed from
@@ -595,18 +595,18 @@ ClassImp(TH1);
 
 TH1::TH1(): TNamed(), TAttLine(), TAttFill(), TAttMarker()
 {
-   fDirectory     = 0;
+   fDirectory     = nullptr;
    fFunctions     = new TList;
    fNcells        = 0;
-   fIntegral      = 0;
-   fPainter       = 0;
+   fIntegral      = nullptr;
+   fPainter       = nullptr;
    fEntries       = 0;
    fNormFactor    = 0;
    fTsumw         = fTsumw2=fTsumwx=fTsumwx2=0;
    fMaximum       = -1111;
    fMinimum       = -1111;
    fBufferSize    = 0;
-   fBuffer        = 0;
+   fBuffer        = nullptr;
    fBinStatErrOpt = kNormal;
    fStatOverflows = EStatOverflows::kNeutral;
    fXaxis.SetName("xaxis");
@@ -627,14 +627,14 @@ TH1::~TH1()
       return;
    }
    delete[] fIntegral;
-   fIntegral = 0;
+   fIntegral = nullptr;
    delete[] fBuffer;
-   fBuffer = 0;
+   fBuffer = nullptr;
    if (fFunctions) {
       R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
       fFunctions->SetBit(kInvalidObject);
-      TObject* obj = 0;
+      TObject* obj = nullptr;
       //special logic to support the case where the same object is
       //added multiple times in fFunctions.
       //This case happens when the same object is added with different
@@ -648,17 +648,17 @@ TH1::~TH1()
             break;
          }
          delete obj;
-         obj = 0;
+         obj = nullptr;
       }
       delete fFunctions;
-      fFunctions = 0;
+      fFunctions = nullptr;
    }
    if (fDirectory) {
       fDirectory->Remove(this);
-      fDirectory = 0;
+      fDirectory = nullptr;
    }
    delete fPainter;
-   fPainter = 0;
+   fPainter = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -761,16 +761,16 @@ void TH1::Browse(TBrowser *b)
 
 void TH1::Build()
 {
-   fDirectory     = 0;
-   fPainter       = 0;
-   fIntegral      = 0;
+   fDirectory     = nullptr;
+   fPainter       = nullptr;
+   fIntegral      = nullptr;
    fEntries       = 0;
    fNormFactor    = 0;
    fTsumw         = fTsumw2=fTsumwx=fTsumwx2=0;
    fMaximum       = -1111;
    fMinimum       = -1111;
    fBufferSize    = 0;
-   fBuffer        = 0;
+   fBuffer        = nullptr;
    fBinStatErrOpt = kNormal;
    fStatOverflows = EStatOverflows::kNeutral;
    fXaxis.SetName("xaxis");
@@ -1268,7 +1268,7 @@ void TH1::AddBinContent(Int_t, Double_t)
 /// By default (fAddDirectory = kTRUE), histograms are automatically added
 /// to the list of objects in memory.
 /// Note that one histogram can be removed from its support directory
-/// by calling h->SetDirectory(0) or h->SetDirectory(dir) to add it
+/// by calling h->SetDirectory(nullptr) or h->SetDirectory(dir) to add it
 /// to the list of objects in the directory dir.
 ///
 /// NOTE that this is a static function. To call it, use;
@@ -1407,7 +1407,7 @@ Int_t TH1::BufferEmpty(Int_t action)
       // this will avoid infinite recursion
       if (action > 0) {
          delete [] fBuffer;
-         fBuffer = 0;
+         fBuffer = nullptr;
          fBufferSize = 0;
       }
       return 0;
@@ -1418,8 +1418,8 @@ Int_t TH1::BufferEmpty(Int_t action)
    if (nbentries < 0) {
       nbentries  = -nbentries;
       //  a reset might call BufferEmpty() giving an infinite recursion
-      // Protect it by setting fBuffer = 0
-      fBuffer=0;
+      // Protect it by setting fBuffer = nullptr
+      fBuffer = nullptr;
        //do not reset the list of functions
       Reset("ICES");
       fBuffer = buffer;
@@ -1443,7 +1443,7 @@ Int_t TH1::BufferEmpty(Int_t action)
          if (rc < 0)
             THLimitsFinder::GetLimitsFinder()->FindGoodLimits(this, xmin, xmax);
       } else {
-         fBuffer = 0;
+         fBuffer = nullptr;
          Int_t keep = fBufferSize; fBufferSize = 0;
          if (xmin <  fXaxis.GetXmin()) ExtendAxis(xmin, &fXaxis);
          if (xmax >= fXaxis.GetXmax()) ExtendAxis(xmax, &fXaxis);
@@ -1455,14 +1455,14 @@ Int_t TH1::BufferEmpty(Int_t action)
    // call DoFillN which will not put entries in the buffer as FillN does
    // set fBuffer to zero to avoid re-emptying the buffer from functions called
    // by DoFillN (e.g Sumw2)
-   buffer = fBuffer; fBuffer = 0;
+   buffer = fBuffer; fBuffer = nullptr;
    DoFillN(nbentries,&buffer[2],&buffer[1],2);
    fBuffer = buffer;
 
    // if action == 1 - delete the buffer
    if (action > 0) {
       delete [] fBuffer;
-      fBuffer = 0;
+      fBuffer = nullptr;
       fBufferSize = 0;
    } else {
       // if number of entries is consistent with buffer - set it negative to avoid
@@ -2664,7 +2664,7 @@ void TH1::Copy(TObject &obj) const
       // with TNamed::Copy, to keep things correct, we need to
       // clean up its existing entries.
       ((TH1&)obj).fDirectory->Remove(&obj);
-      ((TH1&)obj).fDirectory = 0;
+      ((TH1&)obj).fDirectory = nullptr;
    }
    TNamed::Copy(obj);
    ((TH1&)obj).fDimension = fDimension;
@@ -2677,9 +2677,9 @@ void TH1::Copy(TObject &obj) const
    ((TH1&)obj).fBufferSize= fBufferSize;
    // copy the Buffer
    // delete first a previously existing buffer
-   if (((TH1&)obj).fBuffer != 0)  {
-      delete []  ((TH1&)obj).fBuffer;
-      ((TH1&)obj).fBuffer = 0;
+   if (((TH1&)obj).fBuffer != nullptr)  {
+      delete [] ((TH1&)obj).fBuffer;
+      ((TH1&)obj).fBuffer = nullptr;
    }
    if (fBuffer) {
       Double_t *buf = new Double_t[fBufferSize];
@@ -2720,13 +2720,13 @@ void TH1::Copy(TObject &obj) const
    // when copying an histogram if the AddDirectoryStatus() is true it
    // will be added to gDirectory independently of the fDirectory stored.
    // and if the AddDirectoryStatus() is false it will not be added to
-   // any directory (fDirectory = 0)
+   // any directory (fDirectory = nullptr)
    if (fgAddDirectory && gDirectory) {
       gDirectory->Append(&obj);
       ((TH1&)obj).fFunctions->UseRWLock();
       ((TH1&)obj).fDirectory = gDirectory;
    } else
-      ((TH1&)obj).fDirectory = 0;
+      ((TH1&)obj).fDirectory = nullptr;
 
 }
 
@@ -3119,9 +3119,10 @@ TH1 *TH1::DrawCopy(Option_t *option, const char * name_postfix) const
    TString opt = option;
    opt.ToLower();
    if (gPad && !opt.Contains("same")) gPad->Clear();
-   TString newName = (name_postfix) ? TString::Format("%s%s", GetName(), name_postfix) : TString();
-   TH1 *newth1 = (TH1 *)Clone(newName);
-   newth1->SetDirectory(0);
+   TString newName;
+   if (name_postfix) newName.Form("%s%s", GetName(), name_postfix);
+   TH1 *newth1 = (TH1 *)Clone(newName.Data());
+   newth1->SetDirectory(nullptr);
    newth1->SetBit(kCanDelete);
    if (gPad) gPad->IncrementPaletteColor(1, opt);
 
@@ -3149,7 +3150,7 @@ TH1 *TH1::DrawNormalized(Option_t *option, Double_t norm) const
    Double_t sum = GetSumOfWeights();
    if (sum == 0) {
       Error("DrawNormalized","Sum of weights is null. Cannot normalize histogram: %s",GetName());
-      return 0;
+      return nullptr;
    }
    Bool_t addStatus = TH1::AddDirectoryStatus();
    TH1::AddDirectory(kFALSE);
@@ -3459,7 +3460,7 @@ void TH1::FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride
          else BufferFill(x[i], 1.);
       }
       // fill the remaining entries if the buffer has been deleted
-      if (i < ntimes && fBuffer==0) {
+      if (i < ntimes && !fBuffer) {
          auto weights = w ? &w[i] : nullptr;
          DoFillN((ntimes-i)/stride,&x[i],weights,stride);
       }
@@ -5241,7 +5242,7 @@ void TH1::LabelsDeflate(Option_t *ax)
 
    TH1 *hold = (TH1*)IsA()->New();
    R__ASSERT(hold);
-   hold->SetDirectory(0);
+   hold->SetDirectory(nullptr);
    Copy(*hold);
 
    Bool_t timedisp = axis->GetTimeDisplay();
@@ -5291,7 +5292,7 @@ void TH1::LabelsInflate(Option_t *ax)
    if (!axis) return;
 
    TH1 *hold = (TH1*)IsA()->New();
-   hold->SetDirectory(0);
+   hold->SetDirectory(nullptr);
    Copy(*hold);
    hold->ResetBit(kMustCleanup);
 
@@ -6503,7 +6504,7 @@ void TH1::ExtendAxis(Double_t x, TAxis *axis)
 
    //save a copy of this histogram
    TH1 *hold = (TH1*)IsA()->New();
-   hold->SetDirectory(0);
+   hold->SetDirectory(nullptr);
    Copy(*hold);
    //set new axis limits
    axis->SetLimits(xmin,xmax);
@@ -6927,7 +6928,7 @@ void TH1::Streamer(TBuffer &b)
       UInt_t R__s, R__c;
       Version_t R__v = b.ReadVersion(&R__s, &R__c);
       if (fDirectory) fDirectory->Remove(this);
-      fDirectory = 0;
+      fDirectory = nullptr;
       if (R__v > 2) {
          b.ReadClassBuffer(TH1::Class(), this, R__v, R__s, R__c);
 
@@ -7099,7 +7100,10 @@ void TH1::Reset(Option_t *option)
    TString opt = option;
    opt.ToUpper();
    fSumw2.Reset();
-   if (fIntegral) {delete [] fIntegral; fIntegral = 0;}
+   if (fIntegral) {
+      delete [] fIntegral;
+      fIntegral = nullptr;
+   }
 
    if (opt.Contains("M")) {
       SetMinimum();
@@ -7307,8 +7311,8 @@ void TH1::SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *opti
    if (fEntries != 0) {
       out<<"   "<<hname<<"->SetEntries("<<fEntries<<");"<<std::endl;
    }
-   if (fDirectory == 0) {
-      out<<"   "<<hname<<"->SetDirectory(0);"<<std::endl;
+   if (!fDirectory) {
+      out<<"   "<<hname<<"->SetDirectory(nullptr);"<<std::endl;
    }
    if (TestBit(kNoStats)) {
       out<<"   "<<hname<<"->SetStats(0);"<<std::endl;
@@ -7338,7 +7342,7 @@ void TH1::SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *opti
    static Int_t funcNumber = 0;
    while (lnk) {
       obj = lnk->GetObject();
-      obj->SavePrimitive(out,Form("nodraw #%d\n",++funcNumber));
+      obj->SavePrimitive(out, TString::Format("nodraw #%d\n",++funcNumber).Data());
       if (obj->InheritsFrom(TF1::Class())) {
          TString fname;
          fname.Form("%s%d",obj->GetName(),funcNumber);
@@ -8327,7 +8331,7 @@ void TH1::SetBuffer(Int_t buffersize, Option_t * /*option*/)
    if (fBuffer) {
       BufferEmpty();
       delete [] fBuffer;
-      fBuffer = 0;
+      fBuffer = nullptr;
    }
    if (buffersize <= 0) {
       fBufferSize = 0;
@@ -8336,7 +8340,7 @@ void TH1::SetBuffer(Int_t buffersize, Option_t * /*option*/)
    if (buffersize < 100) buffersize = 100;
    fBufferSize = 1 + buffersize*(fDimension+1);
    fBuffer = new Double_t[fBufferSize];
-   memset(fBuffer,0,sizeof(Double_t)*fBufferSize);
+   memset(fBuffer, 0, sizeof(Double_t)*fBufferSize);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9153,9 +9157,8 @@ void TH1::SetBinError(Int_t binx, Int_t biny, Int_t binz, Double_t error)
 
 TH1 *TH1::ShowBackground(Int_t niter, Option_t *option)
 {
-
-   return (TH1*)gROOT->ProcessLineFast(Form("TSpectrum::StaticBackground((TH1*)0x%zx,%d,\"%s\")",
-                                            (size_t)this, niter, option));
+   return (TH1*)gROOT->ProcessLineFast(TString::Format("TSpectrum::StaticBackground((TH1*)0x%zx,%d,\"%s\")",
+                                            (size_t)this, niter, option).Data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9168,8 +9171,8 @@ TH1 *TH1::ShowBackground(Int_t niter, Option_t *option)
 
 Int_t TH1::ShowPeaks(Double_t sigma, Option_t *option, Double_t threshold)
 {
-   return (Int_t)gROOT->ProcessLineFast(Form("TSpectrum::StaticSearch((TH1*)0x%zx,%g,\"%s\",%g)",
-                                             (size_t)this, sigma, option, threshold));
+   return (Int_t)gROOT->ProcessLineFast(TString::Format("TSpectrum::StaticSearch((TH1*)0x%zx,%g,\"%s\",%g)",
+                                             (size_t)this, sigma, option, threshold).Data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9462,7 +9465,7 @@ TH1C operator*(Double_t c1, const TH1C &h1)
 {
    TH1C hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9473,7 +9476,7 @@ TH1C operator+(const TH1C &h1, const TH1C &h2)
 {
    TH1C hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9484,7 +9487,7 @@ TH1C operator-(const TH1C &h1, const TH1C &h2)
 {
    TH1C hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9495,7 +9498,7 @@ TH1C operator*(const TH1C &h1, const TH1C &h2)
 {
    TH1C hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9506,7 +9509,7 @@ TH1C operator/(const TH1C &h1, const TH1C &h2)
 {
    TH1C hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9644,7 +9647,7 @@ TH1S operator*(Double_t c1, const TH1S &h1)
 {
    TH1S hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9655,7 +9658,7 @@ TH1S operator+(const TH1S &h1, const TH1S &h2)
 {
    TH1S hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9666,7 +9669,7 @@ TH1S operator-(const TH1S &h1, const TH1S &h2)
 {
    TH1S hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9677,7 +9680,7 @@ TH1S operator*(const TH1S &h1, const TH1S &h2)
 {
    TH1S hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9688,7 +9691,7 @@ TH1S operator/(const TH1S &h1, const TH1S &h2)
 {
    TH1S hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9828,7 +9831,7 @@ TH1I operator*(Double_t c1, const TH1I &h1)
 {
    TH1I hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9839,7 +9842,7 @@ TH1I operator+(const TH1I &h1, const TH1I &h2)
 {
    TH1I hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9850,7 +9853,7 @@ TH1I operator-(const TH1I &h1, const TH1I &h2)
 {
    TH1I hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9861,7 +9864,7 @@ TH1I operator*(const TH1I &h1, const TH1I &h2)
 {
    TH1I hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -9872,7 +9875,7 @@ TH1I operator/(const TH1I &h1, const TH1I &h2)
 {
    TH1I hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10008,7 +10011,7 @@ TH1F operator*(Double_t c1, const TH1F &h1)
 {
    TH1F hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10019,7 +10022,7 @@ TH1F operator+(const TH1F &h1, const TH1F &h2)
 {
    TH1F hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10030,7 +10033,7 @@ TH1F operator-(const TH1F &h1, const TH1F &h2)
 {
    TH1F hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10041,7 +10044,7 @@ TH1F operator*(const TH1F &h1, const TH1F &h2)
 {
    TH1F hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10052,7 +10055,7 @@ TH1F operator/(const TH1F &h1, const TH1F &h2)
 {
    TH1F hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10187,7 +10190,7 @@ TH1D operator*(Double_t c1, const TH1D &h1)
 {
    TH1D hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10198,7 +10201,7 @@ TH1D operator+(const TH1D &h1, const TH1D &h2)
 {
    TH1D hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10209,7 +10212,7 @@ TH1D operator-(const TH1D &h1, const TH1D &h2)
 {
    TH1D hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10220,7 +10223,7 @@ TH1D operator*(const TH1D &h1, const TH1D &h2)
 {
    TH1D hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -10231,7 +10234,7 @@ TH1D operator/(const TH1D &h1, const TH1D &h2)
 {
    TH1D hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -2614,8 +2614,8 @@ void TH2::SetShowProjectionY(Int_t nbins)
 TH1 *TH2::ShowBackground(Int_t niter, Option_t *option)
 {
 
-   return (TH1*)gROOT->ProcessLineFast(Form("TSpectrum2::StaticBackground((TH1*)0x%zx,%d,\"%s\")",
-                                            (size_t)this, niter, option));
+   return (TH1 *)gROOT->ProcessLineFast(TString::Format("TSpectrum2::StaticBackground((TH1*)0x%zx,%d,\"%s\")",
+                                            (size_t)this, niter, option).Data());
 }
 
 
@@ -2630,8 +2630,8 @@ TH1 *TH2::ShowBackground(Int_t niter, Option_t *option)
 Int_t TH2::ShowPeaks(Double_t sigma, Option_t *option, Double_t threshold)
 {
 
-   return (Int_t)gROOT->ProcessLineFast(Form("TSpectrum2::StaticSearch((TH1*)0x%zx,%g,\"%s\",%g)",
-                                             (size_t)this, sigma, option, threshold));
+   return (Int_t)gROOT->ProcessLineFast(TString::Format("TSpectrum2::StaticSearch((TH1*)0x%zx,%g,\"%s\",%g)",
+                                             (size_t)this, sigma, option, threshold).Data());
 }
 
 
@@ -2992,7 +2992,7 @@ TH2C operator*(Float_t c1, TH2C &h1)
 {
    TH2C hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3004,7 +3004,7 @@ TH2C operator+(TH2C &h1, TH2C &h2)
 {
    TH2C hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3016,7 +3016,7 @@ TH2C operator-(TH2C &h1, TH2C &h2)
 {
    TH2C hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3028,7 +3028,7 @@ TH2C operator*(TH2C &h1, TH2C &h2)
 {
    TH2C hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3040,7 +3040,7 @@ TH2C operator/(TH2C &h1, TH2C &h2)
 {
    TH2C hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3252,7 +3252,7 @@ TH2S operator*(Float_t c1, TH2S &h1)
 {
    TH2S hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3264,7 +3264,7 @@ TH2S operator+(TH2S &h1, TH2S &h2)
 {
    TH2S hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3276,7 +3276,7 @@ TH2S operator-(TH2S &h1, TH2S &h2)
 {
    TH2S hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3288,7 +3288,7 @@ TH2S operator*(TH2S &h1, TH2S &h2)
 {
    TH2S hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3300,7 +3300,7 @@ TH2S operator/(TH2S &h1, TH2S &h2)
 {
    TH2S hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3477,7 +3477,7 @@ TH2I operator*(Float_t c1, TH2I &h1)
 {
    TH2I hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3489,7 +3489,7 @@ TH2I operator+(TH2I &h1, TH2I &h2)
 {
    TH2I hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3501,7 +3501,7 @@ TH2I operator-(TH2I &h1, TH2I &h2)
 {
    TH2I hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3513,7 +3513,7 @@ TH2I operator*(TH2I &h1, TH2I &h2)
 {
    TH2I hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3525,7 +3525,7 @@ TH2I operator/(TH2I &h1, TH2I &h2)
 {
    TH2I hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3736,7 +3736,7 @@ TH2F operator*(Float_t c1, TH2F &h1)
 {
    TH2F hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3748,7 +3748,7 @@ TH2F operator*(TH2F &h1, Float_t c1)
 {
    TH2F hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3760,7 +3760,7 @@ TH2F operator+(TH2F &h1, TH2F &h2)
 {
    TH2F hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3772,7 +3772,7 @@ TH2F operator-(TH2F &h1, TH2F &h2)
 {
    TH2F hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3784,7 +3784,7 @@ TH2F operator*(TH2F &h1, TH2F &h2)
 {
    TH2F hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3796,7 +3796,7 @@ TH2F operator/(TH2F &h1, TH2F &h2)
 {
    TH2F hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4009,7 +4009,7 @@ TH2D operator*(Float_t c1, TH2D &h1)
 {
    TH2D hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4021,7 +4021,7 @@ TH2D operator+(TH2D &h1, TH2D &h2)
 {
    TH2D hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4033,7 +4033,7 @@ TH2D operator-(TH2D &h1, TH2D &h2)
 {
    TH2D hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4045,7 +4045,7 @@ TH2D operator*(TH2D &h1, TH2D &h2)
 {
    TH2D hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4057,6 +4057,6 @@ TH2D operator/(TH2D &h1, TH2D &h2)
 {
    TH2D hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -3631,7 +3631,7 @@ TH3C operator*(Float_t c1, TH3C &h1)
 {
    TH3C hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3643,7 +3643,7 @@ TH3C operator+(TH3C &h1, TH3C &h2)
 {
    TH3C hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3655,7 +3655,7 @@ TH3C operator-(TH3C &h1, TH3C &h2)
 {
    TH3C hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3667,7 +3667,7 @@ TH3C operator*(TH3C &h1, TH3C &h2)
 {
    TH3C hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3679,7 +3679,7 @@ TH3C operator/(TH3C &h1, TH3C &h2)
 {
    TH3C hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3867,7 +3867,7 @@ TH3S operator*(Float_t c1, TH3S &h1)
 {
    TH3S hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3879,7 +3879,7 @@ TH3S operator+(TH3S &h1, TH3S &h2)
 {
    TH3S hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3891,7 +3891,7 @@ TH3S operator-(TH3S &h1, TH3S &h2)
 {
    TH3S hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3903,7 +3903,7 @@ TH3S operator*(TH3S &h1, TH3S &h2)
 {
    TH3S hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -3915,7 +3915,7 @@ TH3S operator/(TH3S &h1, TH3S &h2)
 {
    TH3S hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4070,7 +4070,7 @@ TH3I operator*(Float_t c1, TH3I &h1)
 {
    TH3I hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4082,7 +4082,7 @@ TH3I operator+(TH3I &h1, TH3I &h2)
 {
    TH3I hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4094,7 +4094,7 @@ TH3I operator-(TH3I &h1, TH3I &h2)
 {
    TH3I hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4106,7 +4106,7 @@ TH3I operator*(TH3I &h1, TH3I &h2)
 {
    TH3I hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4118,7 +4118,7 @@ TH3I operator/(TH3I &h1, TH3I &h2)
 {
    TH3I hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4285,7 +4285,7 @@ TH3F operator*(Float_t c1, TH3F &h1)
 {
    TH3F hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4297,7 +4297,7 @@ TH3F operator+(TH3F &h1, TH3F &h2)
 {
    TH3F hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4309,7 +4309,7 @@ TH3F operator-(TH3F &h1, TH3F &h2)
 {
    TH3F hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4321,7 +4321,7 @@ TH3F operator*(TH3F &h1, TH3F &h2)
 {
    TH3F hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4333,7 +4333,7 @@ TH3F operator/(TH3F &h1, TH3F &h2)
 {
    TH3F hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4500,7 +4500,7 @@ TH3D operator*(Float_t c1, TH3D &h1)
 {
    TH3D hnew = h1;
    hnew.Scale(c1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4512,7 +4512,7 @@ TH3D operator+(TH3D &h1, TH3D &h2)
 {
    TH3D hnew = h1;
    hnew.Add(&h2,1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4524,7 +4524,7 @@ TH3D operator-(TH3D &h1, TH3D &h2)
 {
    TH3D hnew = h1;
    hnew.Add(&h2,-1);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4536,7 +4536,7 @@ TH3D operator*(TH3D &h1, TH3D &h2)
 {
    TH3D hnew = h1;
    hnew.Multiply(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }
 
@@ -4548,6 +4548,6 @@ TH3D operator/(TH3D &h1, TH3D &h2)
 {
    TH3D hnew = h1;
    hnew.Divide(&h2);
-   hnew.SetDirectory(0);
+   hnew.SetDirectory(nullptr);
    return hnew;
 }

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1606,7 +1606,7 @@ void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 
       while (lnk) {
          g = lnk->GetObject();
-         g->SavePrimitive(out, Form("multigraph%s",lnk->GetOption()));
+         g->SavePrimitive(out, TString::Format("multigraph%s",lnk->GetOption()).Data());
          lnk = (TObjOptLink*)lnk->Next();
       }
    }


### PR DESCRIPTION
1. Use `override` syntax
2. Use `nullptr`
3. Mark as `= delete` not implemented methods
4. Replace `Form()` by `TString::Format().Data()`
4. `using TH1::GetBinContent` in TH2 and TH3, saves method call