### PR TITLE
Let use class comments after ClassDefOverride in dictionary generation

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4343,7 +4343,7 @@ llvm::StringRef ROOT::TMetaUtils::GetClassComment(const clang::CXXRecordDecl &de
 
    // For now we allow only a special macro (ClassDef) to have meaningful comments
    SourceLocation maybeMacroLoc = DeclFileLineDecl->getLocation();
-   bool isClassDefMacro = maybeMacroLoc.isMacroID() && sema.findMacroSpelling(maybeMacroLoc, "ClassDef");
+   bool isClassDefMacro = maybeMacroLoc.isMacroID() && (sema.findMacroSpelling(maybeMacroLoc, "ClassDef") || sema.findMacroSpelling(maybeMacroLoc, "ClassDefOverride"));
    if (isClassDefMacro) {
       comment = ROOT::TMetaUtils::GetComment(*DeclFileLineDecl, &commentSLoc);
       if (comment.size()) {

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -2769,10 +2769,10 @@ const char *ROOT::TMetaUtils::ShortTypeName(const char *typeDesc)
 bool ROOT::TMetaUtils::IsStreamableObject(const clang::FieldDecl &m,
                                           const cling::Interpreter& interp)
 {
-   const char *comment = ROOT::TMetaUtils::GetComment( m ).data();
+   auto comment = ROOT::TMetaUtils::GetComment( m );
 
    // Transient
-   if (comment[0] == '!') return false;
+   if ((comment.size() > 0) && (comment[0] == '!')) return false;
 
    clang::QualType type = m.getType();
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -362,7 +362,7 @@ void AnnotateDecl(clang::CXXRecordDecl &CXXRD,
 
          // For now we allow only a special macro (ClassDef) to have meaningful comments
          SourceLocation maybeMacroLoc = (*I)->getLocation();
-         bool isClassDefMacro = maybeMacroLoc.isMacroID() && S.findMacroSpelling(maybeMacroLoc, "ClassDef");
+         bool isClassDefMacro = maybeMacroLoc.isMacroID() && (S.findMacroSpelling(maybeMacroLoc, "ClassDef") || S.findMacroSpelling(maybeMacroLoc, "ClassDefOverride"));
          if (isClassDefMacro) {
             while (isa<NamedDecl>(*I) && cast<NamedDecl>(*I)->getName() != "DeclFileLine") {
                ++I;


### PR DESCRIPTION
Up to now comments were ignored:
```
     ClassDefOverride(name,version) // class comments
```

Also fix error of accessing transient memory.

Solves some test errors in #9932 