### PR TITLE
[DF] Fix Vary+DefinePerSample

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -70,11 +70,12 @@ public:
 
    void FinalizeSlot(unsigned int) final {}
 
-   void MakeVariations(const std::vector<std::string> &) final { R__ASSERT(false && "Unimplemented"); }
+   // No-op for RDefinePerSample: it never depends on systematic variations
+   void MakeVariations(const std::vector<std::string> &) final {}
 
    RDefineBase &GetVariedDefine(const std::string &) final
    {
-      R__ASSERT(false && "Unimplemented");
+      R__ASSERT(false && "This should never be called");
       return *this;
    }
 };

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -203,8 +203,7 @@ namespace Experimental {
 ///
 /// \note Currently, producing variations for the results of \ref ROOT::RDF::RInterface::Display() "Display",
 ///       \ref ROOT::RDF::RInterface::Report() "Report" and \ref ROOT::RDF::RInterface::Snapshot() "Snapshot"
-///       actions is not supported, as well as varying a column defined via
-///       \ref ROOT::RDF::RInterface::DefinePerSample() "DefinePerSample".
+///       actions is not supported.
 //
 // TODO The current implementation duplicates work for the nominal value. In principle we could rewire things
 // so that the nominal value is calculated only once, either in the original action or in the varied action.

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -909,9 +909,7 @@ shorthand that automatically generates tags 0 to N-1 (in this case 0 and 1).
       programming model will be streamlined in future versions.
 
 \note As of v6.26, the results of a Snapshot(), Report() or Display() call cannot be varied (i.e. it is not possible to
-      call VariationsFor() on them. Varying a column defined via DefinePerSample() is similarly not supported, but this
-      limitation can be circumvented by interposing an extra Define() between the DefinePerSample() and Vary() calls.
-      These limitations will be lifted in future releases.
+      call VariationsFor() on them. These limitations will be lifted in future releases.
 
 \anchor rnode
 ### RDataFrame objects as function arguments and return values

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -91,6 +91,16 @@ TEST(RDFVary, GetVariations)
                   "Variations {x:0, x:1} affect column x\nVariations {xy:0, xy:1} affect columns {x, y}\n");
 }
 
+TEST(RDFVary, VaryDefinePerSample)
+{
+   auto df = ROOT::RDataFrame(10).DefinePerSample("x", [](unsigned int, const ROOT::RDF::RSampleInfo &) { return 1; });
+   auto s = df.Vary("x", SimpleVariation, {}, 2).Sum<int>("x");
+   auto ss = ROOT::RDF::Experimental::VariationsFor(s);
+   EXPECT_EQ(ss["nominal"], 1 * 10);
+   EXPECT_EQ(ss["x:0"], -1 * 10);
+   EXPECT_EQ(ss["x:1"], 2 * 10);
+}
+
 TEST_P(RDFVary, SimpleSum)
 {
    auto df = ROOT::RDataFrame(10).Define("x", [] { return 1; });


### PR DESCRIPTION
Columns defined via DefinePerSample cannot ever have a dependency
on the systematic variation (they don't depend on any dataset
column), so when a RDefinePerSample is asked to `MakeVariations`
it just does nothing, and program logic should never end up
requesting a varied value for a RDefinePerSample.

The commit also adds a test for this case.