### PR TITLE
Miscellaneous non-functional changes

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Base.py
@@ -1,4 +1,4 @@
-## @author Vincenzo Eduardo Padulano
+#  @author Vincenzo Eduardo Padulano
 #  @author Enric Tejedor
 #  @date 2021-02
 
@@ -11,17 +11,11 @@
 ################################################################################
 
 import functools
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 import ROOT
 
 from DistRDF.Backends import Utils
-
-# Abstract class declaration
-# This ensures compatibility between Python 2 and 3 versions, since in
-# Python 2 there is no ABC class
-ABC = ABCMeta("ABC", (object,), {})
 
 
 class BaseBackend(ABC):

--- a/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
+++ b/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
@@ -1,4 +1,4 @@
-## @author Vincenzo Eduardo Padulano
+#  @author Vincenzo Eduardo Padulano
 #  @author Enric Tejedor
 #  @date 2021-02
 
@@ -9,8 +9,6 @@
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
-
-from __future__ import print_function
 
 import logging
 

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -20,6 +20,8 @@ from DistRDF.ComputationGraphGenerator import ComputationGraphGenerator
 from DistRDF.Node import Node
 from DistRDF.Operation import Operation
 
+logger = logging.getLogger(__name__)
+
 
 @contextmanager
 def _managed_tcontext():
@@ -37,9 +39,6 @@ def _managed_tcontext():
         yield None
     finally:
         ctxt.__destruct__()
-
-
-logger = logging.getLogger(__name__)
 
 
 class Proxy(ABC):

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -10,8 +10,6 @@
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
 
-from __future__ import print_function
-
 import logging
 from abc import ABC, abstractmethod
 from contextlib import contextmanager

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -1,4 +1,4 @@
-## @author Vincenzo Eduardo Padulano
+#  @author Vincenzo Eduardo Padulano
 #  @author Enric Tejedor
 #  @date 2021-02
 
@@ -13,8 +13,7 @@
 from __future__ import print_function
 
 import logging
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
 import ROOT
@@ -41,11 +40,6 @@ def _managed_tcontext():
     finally:
         ctxt.__destruct__()
 
-
-# Abstract class declaration
-# This ensures compatibility between Python 2 and 3 versions, since in
-# Python 2 there is no ABC class
-ABC = ABCMeta('ABC', (object,), {})
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
* Remove unnecessary alias for `ABC` in Python 2
* Remove spurious `from __future__ import print_function`
* Place creation of `logger` variable after import statements in `Proxy.py`
