### PR TITLE
[inc] avoid doxygen warnings

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -2236,7 +2236,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc ../../interpreter/llvm/src/tools/clang/include
+INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc ../../interpreter/llvm/src/tools/clang/include ../../graf2d/gpadv7/inc
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the

--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -2236,7 +2236,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc ../../interpreter/llvm/src/tools/clang/include ../../graf2d/gpadv7/inc
+INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc ../../interpreter/llvm/src/tools/clang/include ../../graf2d/gpadv7/inc ../../tmva/tmva/inc
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the

--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -2236,7 +2236,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc
+INCLUDE_PATH           = ../../core/base/inc ../../bindings/r/inc ../../interpreter/llvm/src/tools/clang/include
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This is needed to avoid doxygen warning about `clang/Basic/LangOptions.def` not being found, for example when including it from `core/dictgen/src/rootcling_impl.cxx`

as well as one from `graf2d/gpadv7/inc/ROOT/RAttrAxis.hxx:36: warning: Found ';' while parsing initializer list! (doxygen could be confused by a macro call without semicolon)`

## Checklist:

- [x] tested changes locally
