### PR TITLE
[cling,windows] Disable the `-O1` optimization flag on Windows

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1426,11 +1426,16 @@ TCling::TCling(const char *name, const char *title, const char* const argv[])
 
       clingArgsStorage.push_back("-Wno-undefined-inline");
       clingArgsStorage.push_back("-fsigned-char");
+      // The -O1 optimization flag has nasty side effects on Windows (32 and 64 bit)
+      // See the GitHub issues #9809 and #9944
+      // TODO: to be reviewed after the upgrade of LLVM & Clang
+#ifndef _MSC_VER
       clingArgsStorage.push_back("-O1");
       // Disable optimized register allocation which is turned on automatically
       // by -O1, but seems to require -O2 to not explode in run time.
       clingArgsStorage.push_back("-mllvm");
       clingArgsStorage.push_back("-optimize-regalloc=0");
+#endif
    }
 
    // Process externally passed arguments if present.


### PR DESCRIPTION
The `-O1` optimization flag has nasty side effects on Windows (32 and 64 bit). These side effects are described in the issue #9809 on Win32 and the issue #9944 on Win64. To be reviewed after the upgrade of LLVM & Clang
