### PR TITLE
Prevents doxygen from parsing non-C++-standard keywords [skip-ci]

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -2256,7 +2256,10 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             = R__CLING_PTRCHECK \
                          R__USE_IMT \
-                         R__SUGGEST_ALTERNATIVE(x)=
+                         R__SUGGEST_ALTERNATIVE(x)= \
+                         __attribute__(x)= \
+                         __declspec(x)= \
+                         __pragma(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Prevents doxygen from parsing non-C++-standard keywords and avoids corresponding warnings.
This follows the recommendation from https://www.doxygen.nl/manual/preprocessing.html concerning hiding attribute and declspec from doxygen.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)