### PR TITLE
[cling] Fix value printing of expressions with `auto` type (ROOT-9687)

### DIFF
--- a/interpreter/cling/CREDITS.txt
+++ b/interpreter/cling/CREDITS.txt
@@ -33,6 +33,10 @@ N: Lukasz Janyst
 E: ljanyst@cern.ch
 D: Initial prototype of cling.
 
+N: Javier Lopez-Gomez
+E: javier.lopez.gomez@cern.ch
+D: Support for entity redefinition (shadowing), general improvements, bug fixes
+
 N: Roman Zulak (aka Frederich Munch)
 E: machtyrtle@gmail.com
 D: Various contributions.

--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -638,9 +638,7 @@ static const char* BuildAndEmitVPWrapperBody(cling::Interpreter &Interp,
         && !Ctx.hasSameType(QTPointeeUnqual, Ctx.WCharTy)
         && !Ctx.hasSameType(QTPointeeUnqual, Ctx.Char16Ty)
         && !Ctx.hasSameType(QTPointeeUnqual, Ctx.Char32Ty)) {
-      QT = Ctx.VoidTy;
-      QT.addConst();
-      QT = Ctx.getPointerType(QT);
+      QT = Ctx.getPointerType(Ctx.VoidTy.withConst());
     }
   } else if (auto RTy
              = llvm::dyn_cast<clang::ReferenceType>(QT.getTypePtr())) {

--- a/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ValuePrinter.cpp
@@ -621,6 +621,15 @@ static const char* BuildAndEmitVPWrapperBody(cling::Interpreter &Interp,
                                           R.begin(),
                                           R.end());
 
+  // For `auto foo = bar;` decls, we are interested in the deduced type, i.e.
+  // AutoType 0x55e5ac848030 'int *' sugar
+  // `-PointerType 0x55e5ac847f70 'int *' << this type
+  //   `-BuiltinType 0x55e5ab517420 'int'
+  if (auto AT = llvm::dyn_cast<clang::AutoType>(QT.getTypePtr())) {
+    if (AT->isDeduced())
+      QT = AT->getDeducedType();
+  }
+
   if (auto PT = llvm::dyn_cast<clang::PointerType>(QT.getTypePtr())) {
     // Normalize `X*` to `const void*`, invoke `printValue(const void**)`,
     // unless it's a character string.

--- a/interpreter/cling/test/Prompt/ValuePrinter/Ptrs.C
+++ b/interpreter/cling/test/Prompt/ValuePrinter/Ptrs.C
@@ -15,6 +15,13 @@
 int *i_ptr = nullptr
 //CHECK: (int *) nullptr
 
+// For `auto`, the deduced type should be used (ROOT-9687)
+int i = 0;
+&i
+//CHECK: (int *) [[PTR:0x[0-9a-f]+]] 
+auto p = &i
+//CHECK: (int *) [[PTR]]
+
 std::unique_ptr<int> i_uptr
 //CHECK: (std::unique_ptr<int> &) std::unique_ptr -> nullptr 
 


### PR DESCRIPTION
This pull request fixes value printing of an expression of type `AutoType`, which ended up in calling the general fallback `printValue(const void *)`.
To call the appropriate overload, the deduced type should be used instead.

## Changes or fixes:
- Value printing of expressions of type `AutoType` use the deduced type instead.
- Update CREDITS.txt file

## Checklist:
- [X] tested changes locally

This PR fixes [ROOT-9687](https://sft.its.cern.ch/jira/browse/ROOT-9687).