### PR TITLE
[RF] Put integrals separately into RooFit computation graph in RooFit batchmode

### DIFF
--- a/roofit/batchcompute/inc/RooBatchCompute.h
+++ b/roofit/batchcompute/inc/RooBatchCompute.h
@@ -38,7 +38,7 @@ enum class Architecture { AVX512, AVX2, AVX, SSE4, GENERIC, CUDA };
 
 enum Computer{AddPdf, ArgusBG, Bernstein, BifurGauss, BreitWigner, Bukin, CBShape, Chebychev,
               ChiSquare, DstD0BG, Exponential, Gamma, Gaussian, Johnson, Landau, Lognormal,
-              NegativeLogarithms, Novosibirsk, Poisson, Polynomial, ProdPdf, Voigtian};
+              NegativeLogarithms, Novosibirsk, Poisson, Polynomial, ProdPdf, Ratio, Voigtian};
 
 /**
  * \class RooBatchComputeInterface

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -56,7 +56,7 @@ __rooglobal__ void computeAddPdf(BatchesHandle batches)
 
 __rooglobal__ void computeArgusBG(BatchesHandle batches)
 {
-   Batch m = batches[0], m0 = batches[1], c = batches[2], p = batches[3], normVal = batches[4];
+   Batch m = batches[0], m0 = batches[1], c = batches[2], p = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double t = m[i] / m0[i];
       const double u = 1 - t * t;
@@ -66,7 +66,7 @@ __rooglobal__ void computeArgusBG(BatchesHandle batches)
       if (m[i] >= m0[i])
          batches._output[i] = 0.0;
       else
-         batches._output[i] = m[i] * fast_exp(batches._output[i]) / normVal[i];
+         batches._output[i] = m[i] * fast_exp(batches._output[i]);
    }
 }
 
@@ -76,7 +76,7 @@ __rooglobal__ void computeBernstein(BatchesHandle batches)
    const int degree = nCoef - 1;
    const double xmin = batches.extraArg(nCoef);
    const double xmax = batches.extraArg(nCoef + 1);
-   Batch xData = batches[0], normVal = batches[1];
+   Batch xData = batches[0];
 
    // apply binomial coefficient in-place so we don't have to allocate new memory
    double binomial = 1.0;
@@ -130,9 +130,6 @@ __rooglobal__ void computeBernstein(BatchesHandle batches)
          }
       }
 
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
-
    // reset extraArgs values so we don't mutate the Batches object
    binomial = 1.0;
    for (int k = 0; k < nCoef; k++) {
@@ -143,30 +140,29 @@ __rooglobal__ void computeBernstein(BatchesHandle batches)
 
 __rooglobal__ void computeBifurGauss(BatchesHandle batches)
 {
-   Batch X = batches[0], M = batches[1], SL = batches[2], SR = batches[3], normVal = batches[4];
+   Batch X = batches[0], M = batches[1], SL = batches[2], SR = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double arg = X[i] - M[i];
       if (arg < 0)
          arg /= SL[i];
       else
          arg /= SR[i];
-      batches._output[i] = fast_exp(-0.5 * arg * arg) / normVal[i];
+      batches._output[i] = fast_exp(-0.5 * arg * arg);
    }
 }
 
 __rooglobal__ void computeBreitWigner(BatchesHandle batches)
 {
-   Batch X = batches[0], M = batches[1], W = batches[2], normVal = batches[3];
+   Batch X = batches[0], M = batches[1], W = batches[2];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double arg = X[i] - M[i];
-      batches._output[i] = 1 / (arg * arg + 0.25 * W[i] * W[i]) / normVal[i];
+      batches._output[i] = 1 / (arg * arg + 0.25 * W[i] * W[i]);
    }
 }
 
 __rooglobal__ void computeBukin(BatchesHandle batches)
 {
-   Batch X = batches[0], XP = batches[1], SP = batches[2], XI = batches[3], R1 = batches[4], R2 = batches[5],
-         normVal = batches[6];
+   Batch X = batches[0], XP = batches[1], SP = batches[2], XI = batches[3], R1 = batches[4], R2 = batches[5];
    const double r3 = log(2.0);
    const double r6 = exp(-6.0);
    const double r7 = 2 * sqrt(2 * log(2.0));
@@ -201,12 +197,12 @@ __rooglobal__ void computeBukin(BatchesHandle batches)
          batches._output[i] = -4 * r3 * (X[i] - XP[i]) * (X[i] - XP[i]) * hp * hp;
    }
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
+      batches._output[i] = fast_exp(batches._output[i]);
 }
 
 __rooglobal__ void computeCBShape(BatchesHandle batches)
 {
-   Batch M = batches[0], M0 = batches[1], S = batches[2], A = batches[3], N = batches[4], normVal = batches[5];
+   Batch M = batches[0], M0 = batches[1], S = batches[2], A = batches[3], N = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double t = (M[i] - M0[i]) / S[i];
       if ((A[i] > 0 && t >= -A[i]) || (A[i] < 0 && -t >= A[i]))
@@ -219,12 +215,12 @@ __rooglobal__ void computeCBShape(BatchesHandle batches)
       }
    }
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
+      batches._output[i] = fast_exp(batches._output[i]);
 }
 
 __rooglobal__ void computeChebychev(BatchesHandle batches)
 {
-   Batch xData = batches[0], normVal = batches[1];
+   Batch xData = batches[0];
    const int nCoef = batches.getNExtraArgs() - 2;
    const double xmin = batches.extraArg(nCoef);
    const double xmax = batches.extraArg(nCoef + 1);
@@ -260,18 +256,15 @@ __rooglobal__ void computeChebychev(BatchesHandle batches)
             prev1 = next;
          }
       }
-
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
 }
 
 __rooglobal__ void computeChiSquare(BatchesHandle batches)
 {
-   Batch X = batches[0], normVal = batches[1];
+   Batch X = batches[0];
    const double ndof = batches.extraArg(0);
    const double gamma = 1 / std::tgamma(ndof / 2.0);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] = gamma / normVal[i];
+      batches._output[i] = gamma;
 
    constexpr double ln2 = 0.693147180559945309417232121458;
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -282,7 +275,7 @@ __rooglobal__ void computeChiSquare(BatchesHandle batches)
 
 __rooglobal__ void computeDstD0BG(BatchesHandle batches)
 {
-   Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4], normVal = batches[5];
+   Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double ratio = DM[i] / DM0[i];
       const double arg1 = (DM0[i] - DM[i]) / C[i];
@@ -293,20 +286,18 @@ __rooglobal__ void computeDstD0BG(BatchesHandle batches)
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       if (batches._output[i] < 0)
          batches._output[i] = 0;
-      else
-         batches._output[i] /= normVal[i];
 }
 
 __rooglobal__ void computeExponential(BatchesHandle batches)
 {
-   Batch x = batches[0], c = batches[1], normVal = batches[2];
+   Batch x = batches[0], c = batches[1];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] = fast_exp(x[i] * c[i]) / normVal[i];
+      batches._output[i] = fast_exp(x[i] * c[i]);
 }
 
 __rooglobal__ void computeGamma(BatchesHandle batches)
 {
-   Batch X = batches[0], G = batches[1], B = batches[2], M = batches[3], normVal = batches[4];
+   Batch X = batches[0], G = batches[1], B = batches[2], M = batches[3];
    double gamma = -std::lgamma(G[0]);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       if (X[i] == M[i])
@@ -326,18 +317,15 @@ __rooglobal__ void computeGamma(BatchesHandle batches)
          batches._output[i] = fast_exp(batches._output[i]);
          batches._output[i] *= invBeta;
       }
-
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
 }
 
 __rooglobal__ void computeGaussian(BatchesHandle batches)
 {
-   auto x = batches[0], mean = batches[1], sigma = batches[2], normVal = batches[3];
+   auto x = batches[0], mean = batches[1], sigma = batches[2];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double arg = x[i] - mean[i];
       const double halfBySigmaSq = -0.5 / (sigma[i] * sigma[i]);
-      batches._output[i] = fast_exp(arg * arg * halfBySigmaSq) / normVal[i];
+      batches._output[i] = fast_exp(arg * arg * halfBySigmaSq);
    }
 }
 
@@ -353,8 +341,7 @@ __rooglobal__ void computeNegativeLogarithms(BatchesHandle batches)
 
 __rooglobal__ void computeJohnson(BatchesHandle batches)
 {
-   Batch mass = batches[0], mu = batches[1], lambda = batches[2], gamma = batches[3], delta = batches[4],
-         normVal = batches[5];
+   Batch mass = batches[0], mu = batches[1], lambda = batches[2], gamma = batches[3], delta = batches[4];
    const double sqrtTwoPi = std::sqrt(TMath::TwoPi());
    const double massThreshold = batches.extraArg(0);
 
@@ -370,7 +357,7 @@ __rooglobal__ void computeJohnson(BatchesHandle batches)
          delta[i] * fast_exp(-0.5 * expo * expo) * fast_isqrt(1. + arg * arg) / (sqrtTwoPi * lambda[i]);
 
       const double passThrough = mass[i] >= massThreshold;
-      batches._output[i] = result * passThrough / normVal[i];
+      batches._output[i] = result * passThrough;
    }
 }
 
@@ -431,7 +418,7 @@ __rooglobal__ void computeLandau(BatchesHandle batches)
       return u * u * (1 + (a2[0] + a2[1] * u) * u);
    };
 
-   Batch X = batches[0], M = batches[1], S = batches[2], normVal = batches[3];
+   Batch X = batches[0], M = batches[1], S = batches[2];
 
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = (X[i] - M[i]) / S[i];
@@ -455,14 +442,11 @@ __rooglobal__ void computeLandau(BatchesHandle batches)
          batches._output[i] = case6(batches._output[i]);
       else
          batches._output[i] = case7(batches._output[i]);
-
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
 }
 
 __rooglobal__ void computeLognormal(BatchesHandle batches)
 {
-   Batch X = batches[0], M0 = batches[1], K = batches[2], normVal = batches[3];
+   Batch X = batches[0], M0 = batches[1], K = batches[2];
    const double rootOf2pi = 2.506628274631000502415765284811;
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double lnxOverM0 = fast_log(X[i] / M0[i]);
@@ -471,7 +455,7 @@ __rooglobal__ void computeLognormal(BatchesHandle batches)
          lnk = -lnk;
       double arg = lnxOverM0 / lnk;
       arg *= -0.5 * arg;
-      batches._output[i] = fast_exp(arg) / (X[i] * lnk * rootOf2pi * normVal[i]);
+      batches._output[i] = fast_exp(arg) / (X[i] * lnk * rootOf2pi);
    }
 }
 
@@ -485,7 +469,7 @@ __rooglobal__ void computeLognormal(BatchesHandle batches)
  */
 __rooglobal__ void computeNovosibirsk(BatchesHandle batches)
 {
-   Batch X = batches[0], P = batches[1], W = batches[2], T = batches[3], normVal = batches[4];
+   Batch X = batches[0], P = batches[1], W = batches[2], T = batches[3];
    constexpr double xi = 2.3548200450309494; // 2 Sqrt( Ln(4) )
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       double argasinh = 0.5 * xi * T[i];
@@ -501,12 +485,12 @@ __rooglobal__ void computeNovosibirsk(BatchesHandle batches)
 
    // faster if you exponentiate in a seperate loop (dark magic!)
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
+      batches._output[i] = fast_exp(batches._output[i]);
 }
 
 __rooglobal__ void computePoisson(BatchesHandle batches)
 {
-   Batch x = batches[0], mean = batches[1], normVal = batches[2];
+   Batch x = batches[0], mean = batches[1];
    bool protectNegative = batches.extraArg(0);
    bool noRounding = batches.extraArg(1);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -529,19 +513,16 @@ __rooglobal__ void computePoisson(BatchesHandle batches)
       if (protectNegative && mean[i] < 0)
          batches._output[i] = 1.E-3;
    }
-
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
 }
 
 __rooglobal__ void computePolynomial(BatchesHandle batches)
 {
-   Batch X = batches[0], normVal = batches[1];
+   Batch X = batches[0];
    const int nCoef = batches.getNExtraArgs() - 1;
    const int lowestOrder = batches.extraArg(nCoef);
    if (nCoef == 0) {
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-         batches._output[i] = (lowestOrder > 0.0) / normVal[i];
+         batches._output[i] = (lowestOrder > 0.0);
       return;
    } else
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
@@ -562,36 +543,38 @@ __rooglobal__ void computePolynomial(BatchesHandle batches)
          batches._output[i] = batches._output[i] * X[i] + batches.extraArg(0);
 
    // Increase the order of the polynomial, first by myltiplying with X[i]^2
-   if (lowestOrder == 0)
-      goto finale;
-   for (int k = 2; k <= lowestOrder; k += 2)
-      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-         batches._output[i] *= X[i] * X[i];
+   if (lowestOrder != 0) {
+      for (int k = 2; k <= lowestOrder; k += 2)
+         for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+            batches._output[i] *= X[i] * X[i];
 
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
-      if (lowestOrder % 2 == 1)
-         batches._output[i] *= X[i];
-      batches._output[i] += 1.0;
+      for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
+         if (lowestOrder % 2 == 1)
+            batches._output[i] *= X[i];
+         batches._output[i] += 1.0;
+      }
    }
-
-finale:
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
 }
 
 __rooglobal__ void computeProdPdf(BatchesHandle batches)
 {
    const int nPdfs = batches.extraArg(0);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] = 1 / batches[nPdfs][i]; // normalization
+      batches._output[i] = 1.;
    for (int pdf = 0; pdf < nPdfs; pdf++)
       for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
          batches._output[i] *= batches[pdf][i];
 }
 
+__rooglobal__ void computeRatio(BatchesHandle batches)
+{
+   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
+      batches._output[i] = batches[0][i] / batches[1][i];
+}
+
 __rooglobal__ void computeVoigtian(BatchesHandle batches)
 {
-   Batch X = batches[0], M = batches[1], W = batches[2], S = batches[3], normVal = batches[4];
+   Batch X = batches[0], M = batches[1], W = batches[2], S = batches[3];
    const double invSqrt2 = 0.707106781186547524400844362105;
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
       const double arg = (X[i] - M[i]) * (X[i] - M[i]);
@@ -613,9 +596,6 @@ __rooglobal__ void computeVoigtian(BatchesHandle batches)
          std::complex<double> z(batches._output[i] * (X[i] - M[i]), factor * batches._output[i] * W[i]);
          batches._output[i] *= faddeeva_impl::faddeeva(z).real();
       }
-
-   for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
-      batches._output[i] /= normVal[i];
 }
 
 /// Returns a std::vector of pointers to the compute functions in this file.
@@ -642,6 +622,7 @@ std::vector<void (*)(BatchesHandle)> getFunctions()
            computePoisson,
            computePolynomial,
            computeProdPdf,
+           computeRatio,
            computeVoigtian};
 }
 } // End namespace RF_ARCH

--- a/roofit/roofit/src/RooArgusBG.cxx
+++ b/roofit/roofit/src/RooArgusBG.cxx
@@ -91,7 +91,7 @@ Double_t RooArgusBG::evaluate() const {
 void RooArgusBG::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::ArgusBG, output, nEvents, dataMap, {&*m,&*m0,&*c,&*p,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::ArgusBG, output, nEvents, dataMap, {&*m,&*m0,&*c,&*p});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBernstein.cxx
+++ b/roofit/roofit/src/RooBernstein.cxx
@@ -140,7 +140,7 @@ void RooBernstein::computeBatch(cudaStream_t* stream, double* output, size_t nEv
   extraArgs[nCoef+1] = _x.max();
 
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Bernstein, output, nEvents, dataMap, {&*_x, &*_norm}, extraArgs);
+  dispatch->compute(stream, RooBatchCompute::Bernstein, output, nEvents, dataMap, {&*_x}, extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBifurGauss.cxx
+++ b/roofit/roofit/src/RooBifurGauss.cxx
@@ -82,7 +82,7 @@ Double_t RooBifurGauss::evaluate() const {
 void RooBifurGauss::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::BifurGauss, output, nEvents, dataMap, {&*x,&*mean,&*sigmaL,&*sigmaR,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::BifurGauss, output, nEvents, dataMap, {&*x,&*mean,&*sigmaL,&*sigmaR});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBreitWigner.cxx
+++ b/roofit/roofit/src/RooBreitWigner.cxx
@@ -67,7 +67,7 @@ Double_t RooBreitWigner::evaluate() const
 void RooBreitWigner::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::BreitWigner, output, nEvents, dataMap, {&*x,&*mean,&*width,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::BreitWigner, output, nEvents, dataMap, {&*x,&*mean,&*width});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooBukinPdf.cxx
+++ b/roofit/roofit/src/RooBukinPdf.cxx
@@ -144,5 +144,5 @@ Double_t RooBukinPdf::evaluate() const
 void RooBukinPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Bukin, output, nEvents, dataMap, {&*x,&*Xp,&*sigp,&*xi,&*rho1,&*rho2,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Bukin, output, nEvents, dataMap, {&*x,&*Xp,&*sigp,&*xi,&*rho1,&*rho2});
 }

--- a/roofit/roofit/src/RooCBShape.cxx
+++ b/roofit/roofit/src/RooCBShape.cxx
@@ -95,7 +95,7 @@ Double_t RooCBShape::evaluate() const {
 void RooCBShape::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::CBShape, output, nEvents, dataMap, {&*m,&*m0,&*sigma,&*alpha,&*n,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::CBShape, output, nEvents, dataMap, {&*m,&*m0,&*sigma,&*alpha,&*n});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooChebychev.cxx
+++ b/roofit/roofit/src/RooChebychev.cxx
@@ -191,7 +191,7 @@ void RooChebychev::computeBatch(cudaStream_t* stream, double* output, size_t nEv
   extraArgs.push_back( _x.min(_refRangeName?_refRangeName->GetName() : nullptr) );
   extraArgs.push_back( _x.max(_refRangeName?_refRangeName->GetName() : nullptr) );
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Chebychev, output, nEvents, dataMap, {&*_x,&*_norm}, extraArgs);
+  dispatch->compute(stream, RooBatchCompute::Chebychev, output, nEvents, dataMap, {&*_x}, extraArgs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooChiSquarePdf.cxx
+++ b/roofit/roofit/src/RooChiSquarePdf.cxx
@@ -66,7 +66,7 @@ Double_t RooChiSquarePdf::evaluate() const
 void RooChiSquarePdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::ChiSquare, output, nEvents, dataMap, {&*_x,&*_norm}, {_ndof});
+  dispatch->compute(stream, RooBatchCompute::ChiSquare, output, nEvents, dataMap, {&*_x}, {_ndof});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooDstD0BG.cxx
+++ b/roofit/roofit/src/RooDstD0BG.cxx
@@ -83,7 +83,7 @@ Double_t RooDstD0BG::evaluate() const
 void RooDstD0BG::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::DstD0BG, output, nEvents, dataMap, {&*dm,&*dm0,&*C,&*A,&*B,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::DstD0BG, output, nEvents, dataMap, {&*dm,&*dm0,&*C,&*A,&*B});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooExponential.cxx
+++ b/roofit/roofit/src/RooExponential.cxx
@@ -65,7 +65,7 @@ Double_t RooExponential::evaluate() const{
 void RooExponential::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Exponential, output, nEvents, dataMap, {&*x,&*c,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Exponential, output, nEvents, dataMap, {&*x,&*c});
 }
 
 

--- a/roofit/roofit/src/RooGamma.cxx
+++ b/roofit/roofit/src/RooGamma.cxx
@@ -90,7 +90,7 @@ Double_t RooGamma::evaluate() const
 void RooGamma::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Gamma, output, nEvents, dataMap, {&*x,&*gamma,&*beta,&*mu,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Gamma, output, nEvents, dataMap, {&*x,&*gamma,&*beta,&*mu});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooGaussian.cxx
+++ b/roofit/roofit/src/RooGaussian.cxx
@@ -67,7 +67,7 @@ Double_t RooGaussian::evaluate() const
 void RooGaussian::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Gaussian, output, nEvents, dataMap, {&*x,&*mean,&*sigma,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Gaussian, output, nEvents, dataMap, {&*x,&*mean,&*sigma});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooJohnson.cxx
+++ b/roofit/roofit/src/RooJohnson.cxx
@@ -115,7 +115,7 @@ double RooJohnson::evaluate() const
 void RooJohnson::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Johnson, output, nEvents, dataMap, {&*_mass,&*_mu,&*_lambda,&*_gamma,&*_delta,&*_norm},{_massThreshold});
+  dispatch->compute(stream, RooBatchCompute::Johnson, output, nEvents, dataMap, {&*_mass,&*_mu,&*_lambda,&*_gamma,&*_delta},{_massThreshold});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooLandau.cxx
+++ b/roofit/roofit/src/RooLandau.cxx
@@ -63,7 +63,7 @@ Double_t RooLandau::evaluate() const
 void RooLandau::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Landau, output, nEvents, dataMap, {&*x,&*mean,&*sigma,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Landau, output, nEvents, dataMap, {&*x,&*mean,&*sigma});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -85,7 +85,7 @@ Double_t RooLognormal::evaluate() const
 void RooLognormal::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Lognormal, output, nEvents, dataMap, {&*x,&*m0,&*k,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Lognormal, output, nEvents, dataMap, {&*x,&*m0,&*k});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooNovosibirsk.cxx
+++ b/roofit/roofit/src/RooNovosibirsk.cxx
@@ -92,7 +92,7 @@ Double_t RooNovosibirsk::evaluate() const
 void RooNovosibirsk::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Novosibirsk, output, nEvents, dataMap, {&*x,&*peak,&*width,&*tail,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Novosibirsk, output, nEvents, dataMap, {&*x,&*peak,&*width,&*tail});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -67,7 +67,7 @@ Double_t RooPoisson::evaluate() const
 void RooPoisson::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Poisson, output, nEvents, dataMap, {&*x,&*mean,&*_norm},
+  dispatch->compute(stream, RooBatchCompute::Poisson, output, nEvents, dataMap, {&*x,&*mean},
     {static_cast<double>(_protectNegative), static_cast<double>(_noRounding)});
 }
 

--- a/roofit/roofit/src/RooVoigtian.cxx
+++ b/roofit/roofit/src/RooVoigtian.cxx
@@ -102,5 +102,5 @@ Double_t RooVoigtian::evaluate() const
 void RooVoigtian::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::Voigtian, output, nEvents, dataMap, {&*x,&*mean,&*width,&*sigma,&*_norm});
+  dispatch->compute(stream, RooBatchCompute::Voigtian, output, nEvents, dataMap, {&*x,&*mean,&*width,&*sigma});
 }

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -252,6 +252,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/Buffers.cxx
     src/BidirMMapPipe.cxx
     src/BidirMMapPipe.h
+    src/NormalizationHelpers.cxx
     src/Roo1DTable.cxx
     src/RooAbsAnaConvPdf.cxx
     src/RooAbsArg.cxx

--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -385,6 +385,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooNLLVar.cxx
     src/RooNLLVarNew.cxx
     src/RooNormSetCache.cxx
+    src/RooNormalizedPdf.cxx
     src/RooNumber.cxx
     src/RooNumCdf.cxx
     src/RooNumConvolution.cxx

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -603,6 +603,8 @@ public:
 
   operator RooBatchCompute::DataKey() const { return RooBatchCompute::DataKey::create(this->namePtr()); }
 
+  virtual void fillNormSetForServer(RooArgSet const& normSet, RooAbsArg const& server, RooArgSet& serverNormSet) const;
+
 protected:
    void graphVizAddConnections(std::set<std::pair<RooAbsArg*,RooAbsArg*> >&) ;
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -241,16 +241,6 @@ public:
     return getNorm(&nset) ;
   }
   virtual Double_t getNorm(const RooArgSet* set=0) const ;
-  inline RooAbsReal* getIntegral(RooArgSet const& set) const {
-    syncNormalization(&set,true) ;
-    getVal(set);
-    assert(_norm != nullptr);
-    return _norm;
-  }
-  const RooAbsReal* getCachedLastIntegral() const {
-    return _norm;
-  }
-
 
   virtual void resetErrorCounters(Int_t resetValue=10) ;
   void setTraceCounter(Int_t value, Bool_t allNodes=kFALSE) ;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -236,8 +236,6 @@ public:
   RooSpan<const double> getLogProbabilities(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet = nullptr) const;
   void getLogProbabilities(RooSpan<const double> pdfValues, double * output) const;
 
-  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
-
   /// \copydoc getNorm(const RooArgSet*) const
   Double_t getNorm(const RooArgSet& nset) const {
     return getNorm(&nset) ;

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -106,6 +106,12 @@ public:
   const RooAbsPdf& pdf() const { return _pdf.arg(); }
   const RooAbsReal& observable() const { return _observable.arg(); }
 
+  void fillNormSetForServer(RooArgSet const& /*normSet*/,
+                         RooAbsArg const& /*server*/,
+                         RooArgSet& /*serverNormSet*/) const override {
+    // servers are evaluated unnormalized
+  }
+
 protected:
   double evaluate() const override;
   RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;

--- a/roofit/roofitcore/inc/RooConstraintSum.h
+++ b/roofit/roofitcore/inc/RooConstraintSum.h
@@ -53,6 +53,10 @@ public:
     return setData(static_cast<RooAbsData const&>(data), cloneData);
   }
 
+  void fillNormSetForServer(RooArgSet const& /*normSet*/, RooAbsArg const& server, RooArgSet& serverNormSet) const override {
+    for(auto * arg : _paramSet) if(server.dependsOn(*arg)) serverNormSet.add(*arg);
+  }
+
 protected:
 
   RooListProxy _set1 ;    ///< Set of constraint terms

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -93,9 +93,11 @@ public:
 
   RooArgSet* getConnectedParameters(const RooArgSet& observables) const ;
 
-  RooArgSet* findPdfNSet(RooAbsPdf& pdf) const ;
+  RooArgSet* findPdfNSet(RooAbsPdf const& pdf) const ;
 
   void writeCacheToStream(std::ostream& os, RooArgSet const* nset) const;
+
+  void fillNormSetForServer(RooArgSet const& normSet, RooAbsArg const& server, RooArgSet& serverNormSet) const override;
 
 private:
 

--- a/roofit/roofitcore/inc/RooRatio.h
+++ b/roofit/roofitcore/inc/RooRatio.h
@@ -48,10 +48,12 @@ public:
   ~RooRatio() override;
 
 protected:
+  Double_t evaluate() const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
+  inline bool canComputeBatchWithCuda() const override { return true; }
+
   RooRealProxy _numerator;
   RooRealProxy _denominator;
-
-  Double_t evaluate() const override;
 
   ClassDefOverride(RooRatio, 2) // Ratio of two RooAbsReal and/or numbers
 };

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -59,6 +59,8 @@ public:
    CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised; };
    void setCacheAndTrackHints(RooArgSet &) override;
 
+   void fillNormSetForServer(RooArgSet const& /*normSet*/, RooAbsArg const& /*server*/, RooArgSet& /*serverNormSet*/) const override {}
+
 protected:
    class CacheElem : public RooAbsCacheElement {
    public:

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -35,8 +35,6 @@ public:
    Double_t evaluate() const override;
    Bool_t checkObservables(const RooArgSet *nset) const override;
 
-   void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
-
    Bool_t forceAnalyticalInt(const RooAbsArg &arg) const override { return arg.isFundamental(); }
    Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &numVars, const RooArgSet *normSet,
                                  const char *rangeName = 0) const override;

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -68,6 +68,9 @@ public:
   CacheMode canNodeBeCached() const override { return RooAbsArg::NotAdvised ; } ;
   void setCacheAndTrackHints(RooArgSet&) override ;
 
+  void fillNormSetForServer(RooArgSet const& /*normSet*/, RooAbsArg const& /*server*/, RooArgSet& /*serverNormSet*/) const override {
+  }
+
 protected:
 
   class CacheElem : public RooAbsCacheElement {

--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -1,0 +1,160 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "NormalizationHelpers.h"
+
+#include <RooAbsCachedPdf.h>
+#include <RooAbsPdf.h>
+#include <RooAbsReal.h>
+#include <RooAddition.h>
+
+#include "RooNormalizedPdf.h"
+
+namespace {
+
+void treeNodeServerListAndNormSets(const RooAbsArg &arg, RooAbsCollection &list, RooArgSet const &normSet,
+                                   std::unordered_map<RooAbsArg const *, RooArgSet *> &normSets)
+{
+   list.add(arg, true);
+   normSets.insert({&arg, new RooArgSet{normSet}});
+
+   // Recurse if current node is derived
+   if (arg.isDerived() && !arg.isFundamental()) {
+      for (const auto server : arg.servers()) {
+         RooArgSet serverNormSet;
+         arg.fillNormSetForServer(normSet, *server, serverNormSet);
+         treeNodeServerListAndNormSets(*server, list, serverNormSet, normSets);
+      }
+   }
+}
+
+std::vector<std::unique_ptr<RooAbsArg>> unfoldIntegrals(RooAbsArg const &topNode, RooArgSet const &normSet,
+                                                        std::unordered_map<RooAbsArg const *, RooArgSet *> &normSets)
+{
+   std::vector<std::unique_ptr<RooAbsArg>> newNodes;
+
+   // No normalization set: we don't need to create any integrals
+   if (normSet.empty())
+      return newNodes;
+
+   RooArgSet nodes;
+   treeNodeServerListAndNormSets(topNode, nodes, normSet, normSets);
+
+   for (RooAbsArg *node : nodes) {
+
+      if (auto pdf = dynamic_cast<RooAbsPdf *>(node)) {
+
+         RooArgSet const &currNormSet = *normSets.at(pdf);
+
+         if (currNormSet.empty())
+            continue;
+
+         pdf->getVal(currNormSet);
+
+         if (pdf->selfNormalized() && !dynamic_cast<RooAbsCachedPdf *>(pdf))
+            continue;
+         if (pdf->getAttribute("_integral_unfolded"))
+            continue;
+
+         pdf->setAttribute("_integral_unfolded", true);
+
+         RooArgList originalClients;
+         for (auto *client : pdf->clients()) {
+            originalClients.add(*client);
+         }
+
+         auto normalizedPdf = std::make_unique<RooNormalizedPdf>(*pdf, currNormSet);
+
+         normalizedPdf->setAttribute((std::string("ORIGNAME:") + pdf->GetName()).c_str());
+         normalizedPdf->setStringAttribute("_normalized_pdf", pdf->GetName());
+
+         RooArgList newServerList{*normalizedPdf};
+         for (auto *client : originalClients) {
+            if (!nodes.containsInstance(*client))
+               continue;
+            if (dynamic_cast<RooAbsCachedPdf *>(client))
+               continue;
+            client->redirectServers(newServerList, false, true);
+         }
+
+         normalizedPdf->setAttribute((std::string("ORIGNAME:") + pdf->GetName()).c_str(), false);
+
+         newNodes.emplace_back(std::move(normalizedPdf));
+      }
+   }
+
+   return newNodes;
+}
+
+void foldIntegrals(RooAbsArg const &topNode)
+{
+   RooArgSet nodes;
+   topNode.treeNodeServerList(&nodes);
+
+   for (RooAbsArg *normalizedPdf : nodes) {
+
+      if (normalizedPdf->getStringAttribute("_normalized_pdf")) {
+
+         auto pdf = &nodes[normalizedPdf->getStringAttribute("_normalized_pdf")];
+
+         pdf->setAttribute((std::string("ORIGNAME:") + normalizedPdf->GetName()).c_str());
+         pdf->setAttribute("_integral_unfolded", false);
+
+         RooArgList newServerList{*pdf};
+         for (auto *client : normalizedPdf->clients()) {
+            if (!nodes.containsInstance(*client))
+               continue;
+            client->redirectServers(newServerList, false, true);
+         }
+      }
+   }
+}
+
+} // namespace
+
+/// \class NormalizationIntegralUnfolder
+/// \ingroup Roofitcore
+///
+/// A NormalizationIntegralUnfolder takes the top node of a computation graph
+/// and a normalization set for its constructor. The normalization integrals
+/// for the PDFs in that graph will be created, and placed into the computation
+/// graph itself, rewiring the existing RooAbsArgs. When the unfolder goes out
+/// of scope, all changes to the computation graph will be reverted.
+///
+/// Note that for evaluation, the original topNode should not be used anymore,
+/// because if it is a pdf there is now a new normalized pdf wrapping it,
+/// serving as the new top node. This normalized top node can be retreived by
+/// NormalizationIntegralUnfolder::arg().
+
+RooFit::NormalizationIntegralUnfolder::NormalizationIntegralUnfolder(RooAbsArg const &topNode, RooArgSet const &normSet)
+   : _topNodeWrapper{std::make_unique<RooAddition>("_dummy", "_dummy", RooArgList{topNode})}
+{
+   auto ownedArgs = unfoldIntegrals(*_topNodeWrapper, normSet, _normSets);
+   for (std::unique_ptr<RooAbsArg> &arg : ownedArgs) {
+      _topNodeWrapper->addOwnedComponents(std::move(arg));
+   }
+}
+
+RooFit::NormalizationIntegralUnfolder::~NormalizationIntegralUnfolder()
+{
+   foldIntegrals(*_topNodeWrapper);
+
+   for (auto &item : _normSets) {
+      delete item.second;
+   }
+}
+
+/// Returns the top node of the modified computation graph.
+RooAbsArg const &RooFit::NormalizationIntegralUnfolder::arg() const
+{
+   return static_cast<RooAddition &>(*_topNodeWrapper).list()[0];
+}

--- a/roofit/roofitcore/src/NormalizationHelpers.h
+++ b/roofit/roofitcore/src/NormalizationHelpers.h
@@ -1,0 +1,40 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_NormalizationHelpers_h
+#define RooFit_NormalizationHelpers_h
+
+#include <RooArgSet.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+class RooAbsArg;
+
+namespace RooFit {
+
+class NormalizationIntegralUnfolder {
+public:
+   NormalizationIntegralUnfolder(RooAbsArg const &topNode, RooArgSet const &normSet);
+   ~NormalizationIntegralUnfolder();
+
+   RooAbsArg const &arg() const;
+
+private:
+   std::unique_ptr<RooAbsArg> _topNodeWrapper;
+   std::unordered_map<RooAbsArg const *, RooArgSet*> _normSets;
+};
+
+} // namespace RooFit
+
+#endif

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2555,3 +2555,16 @@ void RooAbsArg::applyWeightSquared(bool flag) {
       server->applyWeightSquared(flag);
    }
 }
+
+
+/// Fills a RooArgSet to be used as the normalization set for a server, given a
+/// normalization set for this RooAbsArg.
+///
+/// \param[in] normSet The normalization set for this RooAbsArg.
+/// \param[in] server A server of this RooAbsArg that we determine the
+///            normalization set for.
+/// \param[out] serverNormSet Output parameter. Normalization set for the
+///             server.
+void RooAbsArg::fillNormSetForServer(RooArgSet const& normSet, RooAbsArg const& server, RooArgSet& serverNormSet) const {
+  for(auto * arg : normSet) if(server.dependsOn(*arg)) serverNormSet.add(*arg);
+}

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -339,7 +339,7 @@ Double_t RooAbsPdf::getValV(const RooArgSet* nset) const
 
   // Process change in last data set used
   Bool_t nsetChanged(kFALSE) ;
-  if (nset!=_normSet || _norm==0) {
+  if (RooFit::getUniqueId(nset) != RooFit::getUniqueId(_normSet) || _norm==0) {
     nsetChanged = syncNormalization(nset) ;
   }
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -3555,31 +3555,3 @@ void RooAbsPdf::setNormRangeOverride(const char* rangeName)
     _norm = 0 ;
   }
 }
-
-
-/** Base function for computing multiple values of a RooAbsPdf.
-First, the RooAbsReal base function is called to compute the raw values of the
-pdf. After that, divide by the normalization values found in the dataMap.
-\param stream pointer to cuda stream
-\param output The array where the results are stored
-\param nEvents The number of events to be processed
-\param dataMap A std::map containing the input data for the computations
-**/
-void RooAbsPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
-{
-  RooAbsReal::computeBatch(stream, output, nEvents, dataMap);
-
-  auto integralSpan = dataMap.at(_norm);
-
-  if(integralSpan.size() == 1) {
-    double oneOverNorm = 1. / integralSpan[0];
-    for (std::size_t i=0; i < nEvents; ++i) {
-      output[i] *= oneOverNorm;
-    }
-  } else {
-    assert(integralSpan.size() == nEvents);
-    for (std::size_t i=0; i < nEvents; ++i) {
-      output[i] = normalizeWithNaNPacking(output[i], integralSpan[i]);
-    }
-  }
-}

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -683,11 +683,10 @@ void RooFitDriver::determineOutputSizes()
 {
    for (auto *arg : _orderedNodes) {
       auto &argInfo = _nodeInfos.at(arg);
-      for (auto *client : arg->valueClients()) {
-         if (_orderedNodes.containsInstance(*client)) {
-            auto &clientInfo = _nodeInfos.at(client);
-            if (!client->isReducerNode()) {
-               clientInfo.outputSize = std::max(clientInfo.outputSize, argInfo.outputSize);
+      for (auto *server : arg->servers()) {
+         if (server->isValueServer(*arg)) {
+            if (!arg->isReducerNode()) {
+               argInfo.outputSize = std::max(_nodeInfos.at(server).outputSize, argInfo.outputSize);
             }
          }
       }

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -139,9 +139,6 @@ RooSpan<double> RooGenericPdf::evaluateSpan(RooBatchCompute::RunContext& inputDa
 void RooGenericPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
 {
   formula().computeBatch(stream, output, nEvents, dataMap);
-  RooSpan<const double> normVal = dataMap.at(&*_norm);
-  // TODO: also deal with non-scalar integral batch
-  for (size_t i=0; i<nEvents; i++) output[i] = normalizeWithNaNPacking(output[i], normVal[0]);
 }
 
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -54,19 +54,11 @@ std::unique_ptr<RooAbsReal> createRangeNormTerm(RooAbsPdf const &pdf, RooArgSet 
    RooArgSet observablesInPdf;
    pdf.getObservables(&observables, observablesInPdf);
 
-   RooArgList termList;
-
-   auto pdfIntegralCurrent = pdf.createIntegral(observablesInPdf, &observablesInPdf, nullptr, rangeNames.c_str());
-   auto term =
-      new RooFormulaVar((baseName + "_correctionTerm").c_str(), "(log(x[0]))", RooArgList(*pdfIntegralCurrent));
-   termList.add(*term);
-
-   auto integralFull = pdf.createIntegral(observablesInPdf, &observablesInPdf, nullptr);
-   auto fullRangeTerm = new RooFormulaVar((baseName + "_foobar").c_str(), "-(log(x[0]))", RooArgList(*integralFull));
-   termList.add(*fullRangeTerm);
-
-   auto out =
-      std::unique_ptr<RooAbsReal>{new RooAddition((baseName + "_correction").c_str(), "correction", termList, true)};
+   std::unique_ptr<RooAbsReal> integral{pdf.createIntegral(observablesInPdf,
+                                                           &observablesInPdf,
+                                                           pdf.getIntegratorConfig(), rangeNames.c_str())};
+   auto out = std::make_unique<RooFormulaVar>((baseName + "_correctionTerm").c_str(), "(log(x[0]))", RooArgList(*integral));
+   out->addOwnedComponents(std::move(integral));
    return out;
 }
 

--- a/roofit/roofitcore/src/RooNormalizedPdf.cxx
+++ b/roofit/roofitcore/src/RooNormalizedPdf.cxx
@@ -1,0 +1,38 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooNormalizedPdf.h"
+
+/**
+ * \class RooNormalizedPdf
+ *
+ * A RooNormalizedPdf wraps a pdf divided by its integral for a given
+ * normalization set into a new self-normalized pdf.
+ */
+
+void RooNormalizedPdf::computeBatch(cudaStream_t * /*stream*/, double *output, size_t nEvents,
+                                    RooBatchCompute::DataMap &dataMap) const
+{
+   auto nums = dataMap[*_pdf];
+   auto integralSpan = dataMap[*_normIntegral];
+
+   if (integralSpan.size() == 1) {
+      for (std::size_t i = 0; i < nEvents; ++i) {
+         output[i] = normalizeWithNaNPacking(nums[i], integralSpan[0]);
+      }
+   } else {
+      assert(integralSpan.size() == nEvents);
+      for (std::size_t i = 0; i < nEvents; ++i) {
+         output[i] = normalizeWithNaNPacking(nums[i], integralSpan[i]);
+      }
+   }
+}

--- a/roofit/roofitcore/src/RooNormalizedPdf.h
+++ b/roofit/roofitcore/src/RooNormalizedPdf.h
@@ -1,0 +1,80 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Jonas Rembser, CERN 2022
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_RooNormalizedPdf_h
+#define RooFit_RooNormalizedPdf_h
+
+#include <RooAbsPdf.h>
+#include <RooRealProxy.h>
+
+class RooNormalizedPdf : public RooAbsPdf {
+public:
+   RooNormalizedPdf(RooAbsPdf &pdf, RooArgSet const &normSet)
+      : _pdf("numerator", "numerator", this, pdf),
+        _normIntegral("denominator", "denominator", this,
+                      *pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), nullptr), true, false, true),
+        _normSet{normSet}
+   {
+      auto name = std::string(pdf.GetName()) + "_over_" + _normIntegral->GetName();
+      SetName(name.c_str());
+      SetTitle(name.c_str());
+   }
+
+   RooNormalizedPdf(const RooNormalizedPdf &other, const char *name)
+      : RooAbsPdf(other, name), _pdf("numerator", this, other._pdf),
+        _normIntegral("denominator", this, other._normIntegral), _normSet{other._normSet}
+   {
+   }
+
+   TObject *clone(const char *newname) const override { return new RooNormalizedPdf(*this, newname); }
+
+   bool selfNormalized() const override { return true; }
+
+   Bool_t forceAnalyticalInt(const RooAbsArg & /*dep*/) const override { return true; }
+   /// Forward determination of analytical integration capabilities to input p.d.f
+   Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &analVars, const RooArgSet * /*normSet*/,
+                                 const char *rangeName = 0) const override
+   {
+      return _pdf->getAnalyticalIntegralWN(allVars, analVars, &_normSet, rangeName);
+   }
+   /// Forward calculation of analytical integrals to input p.d.f
+   Double_t analyticalIntegralWN(Int_t code, const RooArgSet * /*normSet*/, const char *rangeName = 0) const override
+   {
+      return _pdf->analyticalIntegralWN(code, &_normSet, rangeName);
+   }
+
+   ExtendMode extendMode() const override { return static_cast<RooAbsPdf &>(*_pdf).extendMode(); }
+   Double_t expectedEvents(const RooArgSet *nset) const override
+   {
+      return static_cast<RooAbsPdf &>(*_pdf).expectedEvents(nset);
+   }
+
+protected:
+   void computeBatch(cudaStream_t *, double *output, size_t size, RooBatchCompute::DataMap &) const override;
+   double evaluate() const override
+   {
+      // The RooNormalizedPdf overloads RooAbsReal::getValV() directly, so evaluate() should not be called.
+      throw std::bad_function_call();
+      return 0.0;
+   }
+   double getValV(const RooArgSet * /*normSet*/) const override
+   {
+      return normalizeWithNaNPacking(_pdf->getVal(), _normIntegral->getVal());
+   };
+
+private:
+   RooRealProxy _pdf;
+   RooRealProxy _normIntegral;
+   RooArgSet const &_normSet;
+};
+
+#endif

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1976,7 +1976,7 @@ Bool_t RooProdPdf::isDirectGenSafe(const RooAbsArg& arg) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Look up user specified normalization set for given input PDF component
 
-RooArgSet* RooProdPdf::findPdfNSet(RooAbsPdf& pdf) const
+RooArgSet* RooProdPdf::findPdfNSet(RooAbsPdf const& pdf) const
 {
   Int_t idx = _pdfList.index(&pdf) ;
   if (idx<0) return nullptr;
@@ -2311,4 +2311,13 @@ void RooProdPdf::CacheElem::writeToStream(std::ostream& os) const {
 
 void RooProdPdf::writeCacheToStream(std::ostream& os, RooArgSet const* nset) const {
   getCacheElem(nset)->writeToStream(os);
+}
+
+void RooProdPdf::fillNormSetForServer(RooArgSet const& normSet, RooAbsArg const& server, RooArgSet& serverNormSet) const {
+  auto * pdfNset = findPdfNSet(static_cast<RooAbsPdf const&>(server));
+  if (pdfNset && !pdfNset->empty()) {
+    for(auto * arg : *pdfNset) if(server.dependsOn(*arg)) serverNormSet.add(*arg);
+  } else {
+    for(auto * arg : normSet) if(server.dependsOn(*arg)) serverNormSet.add(*arg);
+  }
 }

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -500,7 +500,6 @@ void RooProdPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEven
     pdfs.push_back(pdf);
   }
   RooBatchCompute::ArgVector special{ static_cast<double>(pdfs.size()) };
-  pdfs.push_back(&*_norm);
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
   dispatch->compute(stream, RooBatchCompute::ProdPdf, output, nEvents, dataMap, pdfs, special);
 }

--- a/roofit/roofitcore/src/RooRatio.cxx
+++ b/roofit/roofitcore/src/RooRatio.cxx
@@ -29,7 +29,10 @@ A RooRatio represents the ratio of two given RooAbsReal objects.
 #include "RooMsgService.h"
 #include "RooRealVar.h"
 #include "RooTrace.h"
+#include "RooBatchCompute.h"
+
 #include "TMath.h"
+
 #include <math.h>
 
 ClassImp(RooRatio);
@@ -103,4 +106,12 @@ RooRatio::RooRatio(const RooRatio &other, const char *name)
                                 : -1.0 * RooNumber::infinity();
   } else
     return _numerator / _denominator;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Evaluate in batch mode.
+void RooRatio::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const
+{
+  auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
+  dispatch->compute(stream, RooBatchCompute::Ratio, output, nEvents, dataMap, {&*_numerator, &*_denominator});
 }

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -257,36 +257,6 @@ Double_t RooRealSumFunc::evaluate() const
 }
 
 
-void RooRealSumFunc::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const {
-
-  // To evaluate this RooRealSumFunc, we have to undo the normalization of the
-  // pdf servers by convention. TODO: find a less hacky solution for this,
-  // which should be easy once the integrals are treated like separate nodes in
-  // the computation queue of the RooFit driver.
-
-  // remember copying a data map is cheap, because it only contains non-owning spans
-  RooBatchCompute::DataMap dataMapCopy = dataMap;
-
-  std::vector<std::vector<double>> buffers;
-
-  for(RooAbsArg const* func : _funcList) {
-      if(auto pdf = dynamic_cast<RooAbsPdf const*>(func)) {
-          auto pdfSpan = dataMapCopy.at(pdf);
-          std::size_t nEntries = pdfSpan.size();
-          auto integralSpan = dataMapCopy.at(pdf->getCachedLastIntegral());
-          buffers.emplace_back(nEntries);
-          auto& buffer = buffers.back();
-          for(std::size_t i = 0; i < nEntries; ++i) {
-            buffer[i] = pdfSpan[i] * integralSpan[integralSpan.size() == 1 ? 0 : i];
-          }
-          dataMapCopy[pdf] = RooSpan<const double>{buffer.begin(), buffer.end()};
-      }
-  }
-
-  RooAbsReal::computeBatch(stream, output, nEvents, dataMapCopy);
-}
-
-
 //_____________________________________________________________________________
 Bool_t RooRealSumFunc::checkObservables(const RooArgSet *nset) const
 {

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -258,31 +258,6 @@ Double_t RooRealSumPdf::evaluate() const
 
 
 void RooRealSumPdf::computeBatch(cudaStream_t* /*stream*/, double* output, size_t nEvents, RooBatchCompute::DataMap& dataMap) const {
-
-  // To evaluate this RooRealSumPdf, we have to undo the normalization of the
-  // pdf servers by convention. TODO: find a less hacky solution for this,
-  // which should be easy once the integrals are treated like separate nodes in
-  // the computation queue of the RooFit driver.
-
-  // remember copying a data map is cheap, because it only contains non-owning spans
-  RooBatchCompute::DataMap dataMapCopy = dataMap;
-
-  std::vector<std::vector<double>> buffers;
-
-  for(RooAbsArg const* func : _funcList) {
-      if(auto pdf = dynamic_cast<RooAbsPdf const*>(func)) {
-          auto pdfSpan = dataMapCopy.at(pdf);
-          std::size_t nEntries = pdfSpan.size();
-          auto integralSpan = dataMapCopy.at(pdf->getCachedLastIntegral());
-          buffers.emplace_back(nEntries);
-          auto& buffer = buffers.back();
-          for(std::size_t i = 0; i < nEntries; ++i) {
-            buffer[i] = pdfSpan[i] * integralSpan[integralSpan.size() == 1 ? 0 : i];
-          }
-          dataMapCopy[pdf] = RooSpan<const double>{buffer.begin(), buffer.end()};
-      }
-  }
-
   // Do running sum of coef/func pairs, calculate lastCoef.
   for (unsigned int j = 0; j < nEvents; ++j) {
     output[j] = 0.0;
@@ -295,7 +270,7 @@ void RooRealSumPdf::computeBatch(cudaStream_t* /*stream*/, double* output, size_
     const double coefVal = coef != nullptr ? coef->getVal() : (1. - sumCoeff);
 
     if (func->isSelectedComp()) {
-      auto funcValues = dataMapCopy[func];
+      auto funcValues = dataMap[func];
       if(funcValues.size() == 1) {
         for (unsigned int j = 0; j < nEvents; ++j) {
           output[j] += funcValues[0] * coefVal;
@@ -326,21 +301,6 @@ void RooRealSumPdf::computeBatch(cudaStream_t* /*stream*/, double* output, size_
   if (_doFloor || _doFloorGlobal) {
     for (unsigned int j = 0; j < nEvents; ++j) {
       output[j] += std::max(0., output[j]);
-    }
-  }
-
-  // normalize
-  auto integralSpan = dataMap.at(_norm);
-
-  if(integralSpan.size() == 1) {
-    double oneOverNorm = 1. / integralSpan[0];
-    for (std::size_t i=0; i < nEvents; ++i) {
-      output[i] *= oneOverNorm;
-    }
-  } else {
-    assert(integralSpan.size() == nEvents);
-    for (std::size_t i=0; i < nEvents; ++i) {
-      output[i] = normalizeWithNaNPacking(output[i], integralSpan[i]);
     }
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -243,6 +243,10 @@ if(ROOT_roofit_FOUND)
   endif()  
   configure_file(stressRooFit_ref.root stressRooFit_ref.root COPYONLY)
   ROOT_ADD_TEST(test-stressroofit COMMAND stressRooFit FAILREGEX "FAILED|Error in" LABELS longtest)
+  ROOT_ADD_TEST(test-stressroofit-batchmode-cpu COMMAND stressRooFit -b cpu FAILREGEX "FAILED|Error in" LABELS longtest)
+  if(CUDA_FOUND)
+    ROOT_ADD_TEST(test-stressroofit-batchmode-cuda COMMAND stressRooFit -b cuda FAILREGEX "FAILED|Error in" LABELS longtest)
+  endif()
   ROOT_ADD_TEST(test-stressroofit-interpreted COMMAND ${ROOT_root_CMD} -b -q -l ${CMAKE_CURRENT_SOURCE_DIR}/stressRooFit.cxx
                 FAILREGEX "FAILED|Error in" DEPENDS test-stressroofit )
 

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -1541,7 +1541,11 @@ public:
     RooDataSet* data = lxg.generate(t,10000) ;
 
     // Fit gxlx to data
-    lxg.fitTo(*data,BatchMode(_batchMode)) ;
+    {
+      // Get rid of the caching info prints
+    RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::Caching, true};
+      lxg.fitTo(*data,BatchMode(_batchMode)) ;
+    }
 
     // Plot data, landau pdf, landau (X) gauss pdf
     RooPlot* frame = t.frame(Title("landau (x) gauss convolution")) ;
@@ -5529,7 +5533,11 @@ public:
 
   // Fit pdf to toy data
   lmorph.setCacheAlpha(kTRUE) ;
-  lmorph.fitTo(*data,BatchMode(_batchMode)) ;
+  {
+    // Get rid of the caching info prints
+    RooHelpers::LocalChangeMsgLevel chmsglvl{RooFit::WARNING, 0u, RooFit::Caching, true};
+    lmorph.fitTo(*data,BatchMode(_batchMode)) ;
+  }
 
   // Plot fitted pdf and data overlaid
   RooPlot* frame2 = x.frame(Bins(100)) ;


### PR DESCRIPTION
With this PR, the normalization integrals are placed as separate objects in the serialized computation graph for the RooFitDriver.

This is done by modifying the RooFit computation graph, injecting a `RooNormalizedPdf` on top of every normalized pdf where the normalization is done instead of doing it hardcoded in the `computeBatch` function for each pdf.

These changes make all the stressRooFit unit tests pass with the `CPU` and `CUDA` batch mode, so stressRooFit runs with these instances are added as unit tests.

