### PR TITLE
[DF] Define execute_graph at module level

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/__init__.py
@@ -100,6 +100,8 @@ def RunGraphs(proxies):
 
 
     """
+    # Import here to avoid circular dependencies in main module
+    from DistRDF.Proxy import execute_graph
 
     if not proxies:
         raise ValueError("The list of result pointers passed to RunGraphs is empty.")
@@ -110,7 +112,7 @@ def RunGraphs(proxies):
     # Submit all computation graphs concurrently from multiple Python threads.
     # The submission is not computationally intensive
     with concurrent.futures.ThreadPoolExecutor(max_workers=len(uniqueproxies)) as executor:
-        futures = [executor.submit(proxy.execute_graph) for proxy in uniqueproxies]
+        futures = [executor.submit(execute_graph, proxy.proxied_node) for proxy in uniqueproxies]
         concurrent.futures.wait(futures)
 
 


### PR DESCRIPTION
The execute_graph function logic is currently used both in ActionProxy
and in TransformationProxy when triggering the execution if an instant
action is asked. This commit moves the function at module level so that
both places can use it.