### PR TITLE
Fix stressgraphics-interpreted on Windows 64

### DIFF
--- a/test/stressGraphics.cxx
+++ b/test/stressGraphics.cxx
@@ -515,23 +515,23 @@ Int_t AnalysePS(const TString &filename)
    Bool_t counting = kFALSE;
    Int_t count = 0;
 
-   FILE *fp;
-   Int_t status;
-   if ((fp=fopen(filename.Data(), "r"))==NULL) {
+   char *line = new char[251];
+   TString l;
+   std::ifstream in(filename.Data());
+   if (!in.is_open()) {
       printf("ERROR1 : File can not open !..\n");
       return 0;
    }
-
-   char *line = new char[251];
-   TString l;
-   while((status=fscanf(fp, "%s", line)) != EOF) {
+   while (in.is_open() && !in.eof()) {
+      in >> line;
+      if (!in.good())
+         break;
       l = line;
       if (l.Contains("%!PS-Adobe"))  counting = kFALSE;
       if (l.Contains("%%EndProlog")) counting = kTRUE;
       if (counting) count = count+l.Length();
    }
    if (gVerbose==1) printf(">>>>>>>>> Number of characters found in %s: %d\n",filename.Data(),count);
-   fclose(fp);
    delete [] line;
    return count;
 }


### PR DESCRIPTION
Fix an access violation error when using `fscanf` on Windows 64 bit:
```
243: Processing C:/Users/sftnight/git/master/test/stressGraphics.cxx...
243: **********************************************************************
243: *  Starting  Graphics - S T R E S S suite                            *
243: **********************************************************************
243: *  Starting Basic Graphics - S T R E S S                             *
243: **********************************************************************
243: CMake Error at C:/Users/sftnight/build/release/RootTestDriver.cmake:227 (message):
243:   error code: Access violation
243:
243:
1/1 Test #243: test-stressgraphics-interpreted ...***Failed    4.33 sec
```
