### PR TITLE
[RF] Remove unused RooList class rule

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -133,7 +133,6 @@
 #pragma link C++ class RooLinkedListElem+ ;
 #pragma link C++ class RooLinkedList- ;
 #pragma link C++ class RooLinTransBinning+ ;
-#pragma link C++ class RooList+ ;
 #pragma read sourceClass="RooList" targetClass="TList";
 #pragma link C++ class RooListProxy+ ;
 #pragma link C++ class RooCollectionProxy<RooArgList>+ ;


### PR DESCRIPTION
The RooList class was removed recently, but I missed to remove the
corresponding class rule in the LinkDef.h file. This is done now in this
commit.

This is a follow-up to https://github.com/root-project/root/pull/9851.