### PR TITLE
Avoid pointer subtraction with null pointers

### DIFF
--- a/core/clib/res/mmprivate.h
+++ b/core/clib/res/mmprivate.h
@@ -59,6 +59,8 @@
 #   include <stdlib.h>
 #endif
 
+#include <stdint.h>
+
 #ifndef MIN
 #  define MIN(A, B) ((A) < (B) ? (A) : (B))
 #endif
@@ -79,14 +81,7 @@
 #define BLOCKSIZE ((unsigned int) 1 << BLOCKLOG)
 #define BLOCKIFY(SIZE) (((SIZE) + BLOCKSIZE - 1) / BLOCKSIZE)
 
-/* The difference between two pointers is a signed int.  On machines where
- the data addresses have the high bit set, we need to ensure that the
- difference becomes an unsigned int when we are using the address as an
- integral value.  In addition, when using with the '%' operator, the
- sign of the result is machine dependent for negative values, so force
- it to be treated as an unsigned int. */
-
-#define ADDR2UINT(addr) ((unsigned int) ((char *) (addr) - (char *) NULL))
+#define ADDR2UINT(addr) ((uintptr_t)(addr))
 #define RESIDUAL(addr,bsize) ((unsigned int) (ADDR2UINT (addr) % (bsize)))
 
 /* Determine the amount of memory spanned by the initial heap table

--- a/net/http/civetweb/md5.inl
+++ b/net/http/civetweb/md5.inl
@@ -131,6 +131,7 @@ MD5_STATIC void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
  */
 
 #if !defined(MD5_STATIC)
+#include <stdint.h>
 #include <string.h>
 #endif
 
@@ -239,7 +240,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 			 * On little-endian machines, we can process properly aligned
 			 * data without copying it.
 			 */
-			if (!((data - (const md5_byte_t *)0) & 3)) {
+			if (!(((uintptr_t) data) & 3)) {
 				/* data are properly aligned, a direct assignment is possible */
 				/* cast through a (void *) should avoid a compiler warning,
 				   see


### PR DESCRIPTION
Clang 13 complains that this has undefined behavior.