### PR TITLE
Remove defaulted copy constructors

### DIFF
--- a/interpreter/cling/include/cling/MetaProcessor/MetaLexer.h
+++ b/interpreter/cling/include/cling/MetaProcessor/MetaLexer.h
@@ -57,7 +57,6 @@ namespace cling {
     mutable unsigned value;
   public:
     Token(const char* Buf = nullptr) { startToken(Buf); }
-    Token(const Token&) = default;
 
     void startToken(const char* Pos = nullptr) {
       kind = tok::unknown;

--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -70,7 +70,6 @@ public:
    struct ObjClassId {
       daos_oclass_id_t fCid;
 
-      ObjClassId(const ObjClassId&) = default;
       ObjClassId(daos_oclass_id_t cid) : fCid(cid) {}
       ObjClassId(const std::string &name) : fCid(daos_oclass_name2id(name.data())) {}
 


### PR DESCRIPTION
Clang warns that "definition of implicit copy assignment operator for '...' is deprecated because it has a user-declared copy constructor". My understanding is that we should either declare both or none, and the compiler will default both unless there is a custom destructor.