### PR TITLE
[skip-ci][win64] Fix potential crash when using fscanf from the interpreter

### DIFF
--- a/math/mathcore/src/MixMaxEngineImpl.h
+++ b/math/mathcore/src/MixMaxEngineImpl.h
@@ -21,7 +21,7 @@ namespace {
 
 #ifdef WIN32
 #define __thread __declspec(thread)
-extern "C" int fscanf ( FILE * stream, const char * format, ... );
+extern "C" int fscanf(FILE *stream, const char *format, ...);
 #endif
 
 #include "mixmax.icc"

--- a/math/mathcore/src/MixMaxEngineImpl.h
+++ b/math/mathcore/src/MixMaxEngineImpl.h
@@ -21,6 +21,7 @@ namespace {
 
 #ifdef WIN32
 #define __thread __declspec(thread)
+extern "C" int fscanf ( FILE * stream, const char * format, ... );
 #endif
 
 #include "mixmax.icc"


### PR DESCRIPTION
Forward declare `fscanf` used in `mixmax.icc`. This fixes this kind of crash when using `fscanf` in the interpreter:
```
C:\Users\sftnight\git\roottest\cling\bytecode>root -l
root [0] double x(0), y(0), xE(0), yE(0);
root [1] FILE *d = fopen("henry.dat", "r")
(FILE *) 0x7ffffaa5fa90
root [2] fscanf(d, "%lf %lf %lf %lf",&x,&xE,&y,&yE)

==========================================
=============== STACKTRACE ===============
==========================================

================ Thread 0 ================
  libCore!TWinNTSystem::DispatchSignals()
  ucrtbase!seh_filter_exe()
  root!Init_thread_header()
  VCRUNTIME140!_C_specific_handler()
  ntdll!_chkstk()
  ntdll!RtlRaiseException()
  ntdll!KiUserExceptionDispatcher()
  ntdll!RtlWaitOnAddress()
  ntdll!RtlEnterCriticalSection()
  ntdll!RtlEnterCriticalSection()
  ucrtbase!getw()
  ucrtbase!_stdio_common_vfscanf()
  libMathCore!fscanf()
  0x2332c6f411f ??
  0xb8450d993a87 ??
  0x2332c704000 ??
  0x23335b00040 ??
  0x23335b00050 ??
  0x23335b00048 ??
  0x23335b00058 ??
```
Note this line:
```
  libMathCore!fscanf()
```
