### PR TITLE
[RF] Make RooAbsReal::getValues use the batch mode via RooFitDriver

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -105,7 +105,7 @@ protected:
   Int_t addParamSet( const RooArgList& params );
   static Int_t GetNumBins( const RooArgSet& vars );
   double evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
 private:
   static NumBins getNumBinsPerDim(RooArgSet const& vars);

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -97,7 +97,7 @@ protected:
   std::vector<int> _interpCode;
 
   Double_t evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
   ClassDefOverride(PiecewiseInterpolation,4) // Sum of RooAbsReal objects
 };

--- a/roofit/histfactory/src/PiecewiseInterpolation.cxx
+++ b/roofit/histfactory/src/PiecewiseInterpolation.cxx
@@ -318,15 +318,16 @@ Double_t PiecewiseInterpolation::evaluate() const
 /// Interpolate between input distributions for all values of the observable in `evalData`.
 /// \param[in,out] evalData Struct holding spans pointing to input data. The results of this function will be stored here.
 /// \param[in] normSet Arguments to normalise over.
-RooSpan<double> PiecewiseInterpolation::evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-  auto nominal = _nominal->getValues(evalData, normSet);
-  auto sum = evalData.makeBatch(this, nominal.size());
-  std::copy(nominal.begin(), nominal.end(), sum.begin());
+void PiecewiseInterpolation::computeBatch(cudaStream_t*, double* sum, size_t /*size*/, RooBatchCompute::DataMap& dataMap) const {
+  auto nominal = dataMap[&*_nominal];
+  for(unsigned int j=0; j < nominal.size(); ++j) {
+    sum[j] = nominal[j];
+  }
 
   for (unsigned int i=0; i < _paramSet.size(); ++i) {
     const double param = static_cast<RooAbsReal*>(_paramSet.at(i))->getVal();
-    auto low   = static_cast<RooAbsReal*>(_lowSet.at(i) )->getValues(evalData, normSet);
-    auto high  = static_cast<RooAbsReal*>(_highSet.at(i))->getValues(evalData, normSet);
+    auto low   = dataMap[_lowSet.at(i)];
+    auto high  = dataMap[_highSet.at(i)];
     const int icode = _interpCode[i];
 
     switch(icode) {
@@ -436,13 +437,11 @@ RooSpan<double> PiecewiseInterpolation::evaluateSpan(RooBatchCompute::RunContext
   }
 
   if (_positiveDefinite) {
-    for (double& val : sum) {
-      if (val < 0.)
-        val = 0.;
+    for(unsigned int j=0; j < nominal.size(); ++j) {
+      if (sum[j] < 0.)
+        sum[j] = 0.;
     }
   }
-
-  return sum;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -599,7 +599,7 @@ public:
   virtual bool canComputeBatchWithCuda() const { return false; }
   virtual bool isReducerNode() const { return false; }
 
-  operator RooBatchCompute::DataKey() const { return RooBatchCompute::DataKey::create(this); }
+  operator RooBatchCompute::DataKey() const { return RooBatchCompute::DataKey::create(this->namePtr()); }
 
 protected:
    void graphVizAddConnections(std::set<std::pair<RooAbsArg*,RooAbsArg*> >&) ;

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -137,7 +137,7 @@ public:
 #endif
   /// \copydoc getValBatch(std::size_t, std::size_t, const RooArgSet*)
   virtual RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet = nullptr) const;
-  std::vector<double> getValues(RooAbsData& data, RooFit::BatchModeOption batchMode=RooFit::BatchModeOption::Cpu) const;
+  std::vector<double> getValues(RooAbsData const& data, RooFit::BatchModeOption batchMode=RooFit::BatchModeOption::Cpu) const;
 
   Double_t getPropagatedError(const RooFitResult &fr, const RooArgSet &nset = RooArgSet()) const;
 

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -71,7 +71,7 @@ public:
   bool divideByBinWidth() const { return _divideByBinWidth; }
   const RooHistFunc& histFunc() const { return (*_histFunc); }
   double evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
 
 private:
   RooTemplateProxy<const RooHistFunc> _histFunc;

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -86,7 +86,7 @@ public:
 
 
   Int_t getBin() const;
-  std::vector<Int_t> getBins(RooBatchCompute::RunContext& evalData) const;
+  std::vector<Int_t> getBins(RooBatchCompute::DataMap& dataMap) const;
 
 protected:
 
@@ -94,7 +94,7 @@ protected:
   Bool_t areIdentical(const RooDataHist& dh1, const RooDataHist& dh2) ;
 
   Double_t evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* /*normSet*/) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooBatchCompute::DataMap&) const override;
   friend class RooAbsCachedReal ;
 
   void ioStreamerPass2() override ;

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -77,7 +77,7 @@ protected:
 
   Double_t calculate(const RooArgList& partIntList) const;
   Double_t evaluate() const override;
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
+  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
 
   const char* makeFPName(const char *pfx,const RooArgSet& terms) const ;
   ProdMap* groupProductTerms(const RooArgSet&) const;

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -69,7 +69,6 @@ public:
   void setCacheAndTrackHints(RooArgSet&) override ;
 
 protected:
-  RooSpan<double> evaluateSpan(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
 
   class CacheElem : public RooAbsCacheElement {
   public:

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -159,6 +159,8 @@ private:
          }
       }
 
+      RooAbsArg *absArg = nullptr;
+
       std::unique_ptr<Detail::AbsBuffer> buffer;
 
       cudaEvent_t *event = nullptr;
@@ -185,6 +187,7 @@ private:
             RooBatchCompute::dispatchCUDA->deleteCudaStream(stream);
       }
    };
+   double getValHeterogeneous();
    void updateMyClients(const RooAbsArg *node);
    void updateMyServers(const RooAbsArg *node);
    void handleIntegral(const RooAbsArg *node);
@@ -222,8 +225,11 @@ private:
    RooBatchCompute::DataMap _dataMapCUDA;
    const RooAbsReal &_topNode;
    RooArgSet _normSet;
-   std::unordered_map<const RooAbsArg *, NodeInfo> _nodeInfos;
-   std::unordered_map<const RooAbsArg *, NodeInfo> _integralInfos;
+   std::map<RooAbsArg const *, NodeInfo> _nodeInfos;
+   std::map<RooAbsArg const *, NodeInfo> _integralInfos;
+
+   // the ordered computation graph
+   std::vector<RooAbsArg *> _orderedNodes;
 
    // used for preserving resources
    std::vector<double> _nonDerivedValues;

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -151,11 +151,10 @@ RooFit::BatchModeHelpers::createNLL(RooAbsPdf &pdf, RooAbsData &data, std::uniqu
       RooArgSet parameters;
       pdf.getParameters(data.get(), parameters);
       nll->recursiveRedirectServers(parameters);
-      driver = std::make_unique<ROOT::Experimental::RooFitDriver>(data, *nll, observables, observables, batchMode,
-                                                                  rangeName, &simPdf->indexCat());
+      driver = std::make_unique<ROOT::Experimental::RooFitDriver>(data, *nll, observables, batchMode, rangeName,
+                                                                  &simPdf->indexCat());
    } else {
-      driver =
-         std::make_unique<ROOT::Experimental::RooFitDriver>(data, *nll, observables, observables, batchMode, rangeName);
+      driver = std::make_unique<ROOT::Experimental::RooFitDriver>(data, *nll, observables, batchMode, rangeName);
    }
 
    // Set the fitrange attribute so that RooPlot can automatically plot the fitting range by default

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -377,54 +377,15 @@ Double_t RooAbsPdf::getValV(const RooArgSet* nset) const
 /// \return RooSpan with probabilities. The memory of this span is owned by `evalData`.
 /// \see RooAbsReal::getValues().
 RooSpan<const double> RooAbsPdf::getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const {
-  auto item = evalData.spans.find(this);
-  if (item != evalData.spans.end()) {
-    return item->second;
-  }
-
-  auto outputs = evaluateSpan(evalData, normSet);
-  assert(evalData.spans.count(this) > 0);
-
-  if (normSet != nullptr) {
-    if (normSet != _normSet || _norm == nullptr) {
-      syncNormalization(normSet);
-    }
-    // Evaluate denominator
-    // In most cases, the integral will be a scalar.  But it can still happen
-    // that the integral is a vector, for example in a conditional fit where
-    // pdf is parametrized by another observable that is also a batch. That's
-    // why we have to use the batch interface also for the integral.
-    auto const& normVals = _norm->getValues(evalData);
-
-    if(normVals.size() > 1) {
-      for(std::size_t i = 0; i < outputs.size(); ++i) {
-        if (normVals[i] < 0. || (normVals[i] == 0. && outputs[i] != 0)) {
-          logEvalError(Form("p.d.f normalization integral is zero or negative."
-              "\n\tInt(%s) = %f", GetName(), normVals[i]));
-        }
-        if(normVals[i] != 1. && normVals[i] > 0.) {
-          outputs[i] /= normVals[i];
-        }
-      }
-
-    } else {
-      const double normVal = normVals[0];
-      if (normVal < 0.
-          || (normVal == 0. && std::any_of(outputs.begin(), outputs.end(), [](double val){return val != 0;}))) {
-        logEvalError(Form("p.d.f normalization integral is zero or negative."
-            "\n\tInt(%s) = %f", GetName(), normVal));
-      }
-
-      if (normVal != 1. && normVal > 0.) {
-        const double invNorm = 1./normVal;
-        for (double& val : outputs) { //CHECK_VECTORISE
-          val *= invNorm;
-        }
-      }
-    }
-  }
-
-  return outputs;
+  // To avoid side effects of this function, the pointer to the last norm
+  // sets and integral objects are remembered and reset at the end of this
+  // function.
+  auto * prevNorm = _norm;
+  auto * prevNormSet = _normSet;
+  auto out = RooAbsReal::getValues(evalData, normSet);
+  _norm = prevNorm;
+  _normSet = prevNormSet;
+  return out;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -223,7 +223,7 @@ void RooFitDriver::init()
    // Some checks and logging of used architectures
    {
       auto log = [](std::string_view message) {
-         oocxcoutI(static_cast<RooAbsArg *>(nullptr), FastEvaluations) << message << std::endl;
+         oocxcoutI(static_cast<RooAbsArg *>(nullptr), Fitting) << message << std::endl;
       };
 
       if (_batchMode == RooFit::BatchModeOption::Cuda && !RooBatchCompute::dispatchCUDA) {

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -219,12 +219,8 @@ RooFitDriver::RooFitDriver(const RooAbsData &data, const RooAbsReal &topNode, Ro
    // Get a serial list of the nodes in the computation graph.
    // treeNodeServelList() is recursive and adds the top node before the children,
    // so reversing the list gives us a topological ordering of the graph.
-   RooArgSet serverSet;
-   _topNode.treeNodeServerList(&serverSet, nullptr, true, true, true);
-
-   if (indexCat) {
-      _dataset.splitByCategory(*indexCat);
-   }
+   RooArgList serverList;
+   _topNode.treeNodeServerList(&serverList, nullptr, true, true, true);
 
    // The treeNodeServerList recursion stops at fundamental RooAbsArgs, such as
    // RooRealVar. But there can also be servers to fundamental types if they are
@@ -232,15 +228,33 @@ RooFitDriver::RooFitDriver(const RooAbsData &data, const RooAbsReal &topNode, Ro
    // explicitely add the servers of the observables here.
    for (auto *obs : observables) {
       for (auto *server : obs->servers()) {
-         RooArgSet tmp;
+         RooArgList tmp;
          server->treeNodeServerList(&tmp, nullptr, true, true, true);
-         serverSet.add(tmp);
+         serverList.add(tmp);
       }
    }
 
-   for (std::size_t iNode = serverSet.size(); iNode > 0; --iNode) {
-      RooAbsArg *arg = serverSet[iNode - 1];
+   // To remove duplicates via the RooArgSet deduplication, we have to fill the
+   // set in reverse order because that's the dependency ordering of the graph.
+   RooArgSet serverSet;
+   std::unordered_map<TNamed const *, RooAbsArg *> instanceMap;
+   for (std::size_t iNode = serverList.size(); iNode > 0; --iNode) {
+      RooAbsArg *arg = &serverList[iNode - 1];
+      if (instanceMap.find(arg->namePtr()) != instanceMap.end()) {
+         if (arg != instanceMap.at(arg->namePtr())) {
+            serverSet.remove(*instanceMap.at(arg->namePtr()));
+         }
+      }
+      instanceMap[arg->namePtr()] = arg;
+      serverSet.add(*arg);
+   }
 
+   if (indexCat) {
+      _dataset.splitByCategory(*indexCat);
+   }
+
+   for (RooAbsArg *arg : serverSet) {
+      _orderedNodes.push_back(arg);
       auto &argInfo = _nodeInfos[arg];
       if (_dataset.contains(arg)) {
          _dataMapCPU[arg] = _dataset.span(arg);
@@ -257,6 +271,33 @@ RooFitDriver::RooFitDriver(const RooAbsData &data, const RooAbsReal &topNode, Ro
          ++clientInfo.nServers;
          ++argInfo.nClients;
       }
+   }
+
+   // Sort the nodes for good
+   std::unordered_set<TNamed const *> seenNodes;
+   for (std::size_t iNode = 0; iNode < _orderedNodes.size(); ++iNode) {
+      RooAbsArg *node = _orderedNodes[iNode];
+      bool movedNode = false;
+      for (RooAbsArg *server : node->servers()) {
+         if (server->isValueServer(*node) && seenNodes.find(server->namePtr()) == seenNodes.end()) {
+            auto found = std::find_if(_orderedNodes.begin(), _orderedNodes.end(),
+                                      [server](RooAbsArg *arg) { return arg->namePtr() == server->namePtr(); });
+            if (found == _orderedNodes.end()) {
+
+               throw std::runtime_error(std::string("Node ") + node->GetName() + " depends on " + server->GetName() +
+                                        ", but this node is missing in the computation queue!");
+            }
+            _orderedNodes.erase(found);
+            _orderedNodes.insert(_orderedNodes.begin() + iNode, server);
+            movedNode = true;
+            break;
+         }
+      }
+      if (movedNode) {
+         --iNode;
+         continue;
+      }
+      seenNodes.insert(node->namePtr());
    }
 
    determineOutputSizes(serverSet);
@@ -340,6 +381,7 @@ void RooFitDriver::computeCPUNode(const RooAbsArg *node, NodeInfo &info)
       _nonDerivedValues.push_back(nodeAbsCategory ? nodeAbsCategory->getIndex() : nodeAbsReal->getVal(&_normSet));
       _dataMapCPU[node] = _dataMapCUDA[node] = RooSpan<const double>(&_nonDerivedValues.back(), nOut);
    } else if (nOut == 1) {
+      handleIntegral(node);
       _nonDerivedValues.push_back(0.0);
       _dataMapCPU[node] = _dataMapCUDA[node] = RooSpan<const double>(&_nonDerivedValues.back(), nOut);
       nodeAbsReal->computeBatch(nullptr, &_nonDerivedValues.back(), nOut, _dataMapCPU);
@@ -369,17 +411,34 @@ void RooFitDriver::computeCPUNode(const RooAbsArg *node, NodeInfo &info)
 /// Returns the value of the top node in the computation graph
 double RooFitDriver::getVal()
 {
-   // In a cuda fit, use first 3 fits to determine the execution times
-   // and the hardware that computes each part of the graph
-   if (_batchMode == RooFit::BatchModeOption::Cuda && ++_getValInvocations <= 3)
-      markGPUNodes();
+   _nonDerivedValues.clear();
+   _nonDerivedValues.reserve(_orderedNodes.size()); // to avoid reallocation
 
+   if (_batchMode == RooFit::BatchModeOption::Cuda)
+      return getValHeterogeneous();
+
+   for (std::size_t iNode = 0; iNode < _orderedNodes.size(); ++iNode) {
+      RooAbsArg *node = _orderedNodes[iNode];
+      if (!_dataset.contains(node)) {
+         computeCPUNode(node, _nodeInfos[node]);
+      }
+   }
+   // return the final value
+   return _dataMapCPU.at(&_topNode)[0];
+}
+
+/// Returns the value of the top node in the computation graph
+double RooFitDriver::getValHeterogeneous()
+{
    for (auto &item : _nodeInfos) {
       item.second.remClients = item.second.nClients;
       item.second.remServers = item.second.nServers;
    }
-   _nonDerivedValues.clear();
-   _nonDerivedValues.reserve(_nodeInfos.size()); // to avoid reallocation
+
+   // In a cuda fit, use first 3 fits to determine the execution times
+   // and the hardware that computes each part of the graph
+   if (_batchMode == RooFit::BatchModeOption::Cuda && ++_getValInvocations <= 3)
+      markGPUNodes();
 
    // find initial gpu nodes and assign them to gpu
    for (const auto &it : _nodeInfos)
@@ -736,30 +795,15 @@ void RooFitDriver::markGPUNodes()
 
 void RooFitDriver::determineOutputSizes(RooArgSet const &serverSet)
 {
-   std::size_t totalSize = 1;
-   std::size_t prevTotalSize = 0;
-
-   // Usually, the serverSet is sorted by dependency and one or two passes in
-   // reverse order are enough the propagate through all clinet-server
-   // relationships and converge to the correct output sizes. Indeed, this
-   // function takes a negligible fraction of the time of the NLL creation for
-   // large ATLAS Higgs combination models.
-   while (totalSize != prevTotalSize) {
-      prevTotalSize = totalSize;
-      totalSize = 0;
-
-      for (std::size_t iNode = serverSet.size(); iNode > 0; --iNode) {
-         RooAbsArg const *arg = serverSet[iNode - 1];
-         auto &argInfo = _nodeInfos[arg];
-         for (auto *client : arg->valueClients()) {
-            if (serverSet.containsInstance(*client)) {
-               auto &clientInfo = _nodeInfos[client];
-               if (!client->isReducerNode()) {
-                  clientInfo.outputSize = std::max(clientInfo.outputSize, argInfo.outputSize);
-               }
+   for (auto *arg : _orderedNodes) {
+      auto &argInfo = _nodeInfos[arg];
+      for (auto *client : arg->valueClients()) {
+         if (serverSet.containsInstance(*client)) {
+            auto &clientInfo = _nodeInfos[client];
+            if (!client->isReducerNode()) {
+               clientInfo.outputSize = std::max(clientInfo.outputSize, argInfo.outputSize);
             }
          }
-         totalSize += argInfo.outputSize;
       }
    }
 }

--- a/roofit/roofitcore/test/testRooFitDriver.cxx
+++ b/roofit/roofitcore/test/testRooFitDriver.cxx
@@ -84,7 +84,7 @@ TEST(testRooFitDriver, SimpleLikelihoodFit)
 
    // ...and now the new way with RooFitDriver
    ROOT::Experimental::RooNLLVarNew nll("nll", "nll", model, *data->get(), nullptr, false, "");
-   ROOT::Experimental::RooFitDriver driver(*data, nll, x, x, RooFit::BatchModeOption::Cpu, "");
+   ROOT::Experimental::RooFitDriver driver(*data, nll, x, RooFit::BatchModeOption::Cpu, "");
    auto resultBatchNew = doFit(*driver.makeAbsRealWrapper());
    if (verbose)
       std::cout << "-  batch mode fit took " << resultBatchNew.elapsedTime << " ms" << std::endl;


### PR DESCRIPTION
The `RooAbsReal::getValues` has already been established as the entry
point for evaluating RooFit objects with the batch mode and it should
not be broken.

In 6.26, the `getValues` function was broken to fall back on the scalar
mode all the time, because the `evaluateSpan` funtions it used got
replaced by `computeBatch`. In this commit, the desired behavior of
using the BatchMode is restored by using the RooFitDriver. To that end, a
new constructor has been added to the RooFitDriver that takes a
`RooBatchCompute::RunContext` directly.

The override of `getValues` in RooAbsPdf was also removed now, because
it's the job of the RooFitDriver to treat pdfs correctly.

This PR fixes the performance regression that was observed in the vectorized pdf tests in `roottest`. To fix the performance regression completely, this PR also includes a commit to avoid some overhead in the pure CPU batch mode with RooFitDriver.


This bugfix should also be backported to 6.26 as a bugfix for the patch release.
