### PR TITLE
Core Library Atomic Fixes, master branch (2022.02.25.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -271,6 +271,7 @@ target_link_libraries(Core
     ${ZSTD_LIBRARIES}
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
+    ${ROOT_ATOMIC_LIBS}
     ${corelinklibs}
 )
 add_dependencies(Core CLING)

--- a/core/rootcling_stage1/CMakeLists.txt
+++ b/core/rootcling_stage1/CMakeLists.txt
@@ -26,7 +26,7 @@ ROOT_EXECUTABLE(rootcling_stage1 src/rootcling_stage1.cxx
                               $<TARGET_OBJECTS:ClingUtils>
                               $<TARGET_OBJECTS:Dictgen>
                               $<TARGET_OBJECTS:Foundation_Stage1>
-                              LIBRARIES ${CLING_LIBRARIES} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT}
+                              LIBRARIES ${CLING_LIBRARIES} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${ROOT_ATOMIC_LIBS}
                               NOINSTALL)
 
 target_include_directories(rootcling_stage1 PRIVATE


### PR DESCRIPTION
# This Pull request:

Explicitly linked the core library against `libatomic`. This is necessary on some platforms in order to use the atomic operations performed by the library.

## Changes or fixes:

The current master branch, without the fix, produces the following build error on Raspberry Pi OS with GCC 11. (Though the exact GCC version doesn't matter much, just that it would not be the built-in GCC 6.3 coming with the OS.)

```
[100%] Linking CXX executable src/rootcling_stage1
../foundation/CMakeFiles/Foundation_Stage1.dir/src/RLogger.cxx.o: In function `ROOT::Experimental::RLogManager::Emit(ROOT::Experimental::RLogEntry const&)':
RLogger.cxx:(.text+0x99c): undefined reference to `__atomic_fetch_add_8'
RLogger.cxx:(.text+0x9c8): undefined reference to `__atomic_fetch_add_8'
RLogger.cxx:(.text+0x9e8): undefined reference to `__atomic_fetch_add_8'
RLogger.cxx:(.text+0xa08): undefined reference to `__atomic_fetch_add_8'
RLogger.cxx:(.text+0xa30): undefined reference to `__atomic_fetch_add_8'
../foundation/CMakeFiles/Foundation_Stage1.dir/src/RLogger.cxx.o:RLogger.cxx:(.text+0xa58): more undefined references to `__atomic_fetch_add_8' follow
collect2: error: ld returned 1 exit status
core/rootcling_stage1/CMakeFiles/rootcling_stage1.dir/build.make:242: recipe for target 'core/rootcling_stage1/src/rootcling_stage1' failed
make[3]: *** [core/rootcling_stage1/src/rootcling_stage1] Error 1
CMakeFiles/Makefile2:26106: recipe for target 'core/rootcling_stage1/CMakeFiles/rootcling_stage1.dir/all' failed
make[2]: *** [core/rootcling_stage1/CMakeFiles/rootcling_stage1.dir/all] Error 2
CMakeFiles/Makefile2:26113: recipe for target 'core/rootcling_stage1/CMakeFiles/rootcling_stage1.dir/rule' failed
make[1]: *** [core/rootcling_stage1/CMakeFiles/rootcling_stage1.dir/rule] Error 2
Makefile:8132: recipe for target 'rootcling_stage1' failed
make: *** [rootcling_stage1] Error 2
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary) - **Not applicable**
