### PR TITLE
Align pythonization of TDirectory::WriteObject with its C++ counterpart

### DIFF
--- a/bindings/pyroot/pythonizations/src/TDirectoryPyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TDirectoryPyz.cxx
@@ -16,6 +16,7 @@
 #include "Utility.h"
 #include "PyzCppHelpers.hxx"
 #include "TClass.h"
+#include "TNamed.h"
 #include "TDirectory.h"
 #include "TKey.h"
 #include "Python.h"
@@ -47,13 +48,34 @@ PyObject *TDirectoryWriteObject(CPPInstance *self, PyObject *args)
                       "TDirectory::WriteObject must be called with a TDirectory instance as first argument");
       return nullptr;
    }
+
+   // Implement a check on whether the object is derived from TObject or not. Similarly to what is done in
+   // TDirectory::WriteObject with SFINAE. Unfortunately, 'wrt' is a void* in this scope and can't be casted to its
+   // concrete type.
+   auto *wrtclass = GetTClass(wrt);
+   void *wrtobj = wrt->GetObject();
    Int_t result = 0;
-   if (option != nullptr) {
-      result = dir->WriteObjectAny(wrt->GetObject(), GetTClass(wrt), CPyCppyy_PyText_AsString(name),
-                                   CPyCppyy_PyText_AsString(option), bufsize);
+
+   if (wrtclass->IsTObject()) {
+      // If the found TClass is derived from TObject, cast the object to a TNamed since we are just interested in the
+      // object title for the purposes of the WriteTObject function.
+      auto objtowrite = static_cast<TNamed *>(wrtclass->DynamicCast(TNamed::Class(), wrtobj));
+
+      if (option != nullptr) {
+         result =
+            dir->WriteTObject(objtowrite, CPyCppyy_PyText_AsString(name), CPyCppyy_PyText_AsString(option), bufsize);
+      } else {
+         result = dir->WriteTObject(objtowrite, CPyCppyy_PyText_AsString(name));
+      }
    } else {
-      result = dir->WriteObjectAny(wrt->GetObject(), GetTClass(wrt), CPyCppyy_PyText_AsString(name));
+      if (option != nullptr) {
+         result = dir->WriteObjectAny(wrtobj, wrtclass, CPyCppyy_PyText_AsString(name),
+                                      CPyCppyy_PyText_AsString(option), bufsize);
+      } else {
+         result = dir->WriteObjectAny(wrtobj, wrtclass, CPyCppyy_PyText_AsString(name));
+      }
    }
+
    return PyInt_FromLong((Long_t)result);
 }
 

--- a/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
+++ b/bindings/pyroot/pythonizations/test/tfile_attrsyntax_get_writeobject_open.py
@@ -75,6 +75,20 @@ class TFileOpenReadWrite(unittest.TestCase):
         handle = ROOT.TFile.AsyncOpen("inexistent_file.root")
         self.assertRaises(OSError, ROOT.TFile.Open, handle)
 
+    def test_keys_title(self):
+        """
+        Test that the TKey related to a histogram in the file contains the
+        histogram title as described in #9989.
+        """
+        finput = ROOT.TFile.Open(self.filename)
+        key1 = finput.GetListOfKeys().At(0)
+        key2 = finput.Get("dir1").GetListOfKeys().At(0)
+        key3 = finput.Get("dir1/dir2").GetListOfKeys().At(0)
+        self.assertEqual(key1.GetTitle(), "h")
+        self.assertEqual(key2.GetTitle(), "h1")
+        self.assertEqual(key3.GetTitle(), "h2")
+        finput.Close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #9989 