### PR TITLE
[DF] Backport some fixes to RDF Vary (v6.26)

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -70,11 +70,12 @@ public:
 
    void FinaliseSlot(unsigned int) final {}
 
-   void MakeVariations(const std::vector<std::string> &) final { R__ASSERT(false && "Unimplemented"); }
+   // No-op for RDefinePerSample: it never depends on systematic variations
+   void MakeVariations(const std::vector<std::string> &) final {}
 
    RDefineBase &GetVariedDefine(const std::string &) final
    {
-      R__ASSERT(false && "Unimplemented");
+      R__ASSERT(false && "This should never be called");
       return *this;
    }
 };

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -820,6 +820,13 @@ public:
          const auto demangledType = RDFInternal::DemangleTypeIdName(typeid(RetType));
          retTypeName = "CLING_UNKNOWN_TYPE_" + demangledType;
       }
+
+      // when varying multiple columns, they must be different columns
+      if (colNames.size() > 1) {
+         std::set<std::string> uniqueCols(colNames.begin(), colNames.end());
+         if (uniqueCols.size() != colNames.size())
+            throw std::logic_error("The same column was passed multiple times the same column twice: ");
+      }
       /* SANITY CHECKS END */
 
       auto variation = std::make_shared<RDFInternal::RVariation<F_t>>(
@@ -958,6 +965,13 @@ public:
                                          fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
       }
       RDFInternal::CheckValidCppVarName(variationName, "Vary");
+
+      // when varying multiple columns, they must be different columns
+      if (colNames.size() > 1) {
+         std::set<std::string> uniqueCols(colNames.begin(), colNames.end());
+         if (uniqueCols.size() != colNames.size())
+            throw std::logic_error("The same column was passed multiple times the same column twice: ");
+      }
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedVariation =

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -93,12 +93,9 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    using ColumnTypes_t = typename CallableTraits<F>::arg_types;
    using TypeInd_t = std::make_index_sequence<ColumnTypes_t::list_size>;
    using ret_type = typename CallableTraits<F>::ret_type;
-   // Avoid instantiating vector<bool> as `operator[]` returns temporaries in that case. Use std::deque instead.
-   using ValuesPerSlot_t =
-      std::conditional_t<std::is_same<ret_type, bool>::value, std::deque<ret_type>, std::vector<ret_type>>;
 
    F fExpression;
-   ValuesPerSlot_t fLastResults;
+   std::vector<ret_type> fLastResults;
 
    /// Column readers per slot and per input column
    std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -204,8 +204,7 @@ namespace Experimental {
 ///
 /// \note Currently, producing variations for the results of \ref ROOT::RDF::RInterface::Display() "Display",
 ///       \ref ROOT::RDF::RInterface::Report() "Report" and \ref ROOT::RDF::RInterface::Snapshot() "Snapshot"
-///       actions is not supported, as well as varying a column defined via
-///       \ref ROOT::RDF::RInterface::DefinePerSample() "DefinePerSample".
+///       actions is not supported.
 //
 // TODO The current implementation duplicates work for the nominal value. In principle we could rewire things
 // so that the nominal value is calculated only once, either in the original action or in the varied action.

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -996,9 +996,7 @@ shorthand that automatically generates tags 0 to N-1 (in this case 0 and 1).
       programming model will be streamlined in future versions.
 
 \note As of v6.26, the results of a Snapshot(), Report() or Display() call cannot be varied (i.e. it is not possible to
-      call VariationsFor() on them. Varying a column defined via DefinePerSample() is similarly not supported, but this
-      limitation can be circumvented by interposing an extra Define() between the DefinePerSample() and Vary() calls.
-      These limitations will be lifted in future releases.
+      call VariationsFor() on them. These limitations will be lifted in future releases.
 
 \anchor rnode
 ### RDataFrame objects as function arguments and return values

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -35,6 +35,21 @@ TEST(RDFVary, RequireExistingColumn)
    EXPECT_THROW(df.Vary("x", SimpleVariation, {}, 2), std::runtime_error);
 }
 
+TEST(RDFVary, VaryTwiceTheSameColumn)
+{
+   auto df = ROOT::RDataFrame(10).Define("x", [] { return 1; });
+   EXPECT_THROW(df.Vary(
+                   {"x", "x"},
+                   [] {
+                      return ROOT::RVec<ROOT::RVecI>{{0}, {0}};
+                   },
+                   {}, 1, "broken"),
+                std::logic_error);
+
+   // and now the jitted version
+   EXPECT_THROW(df.Vary({"x", "x"}, "ROOT::RVec<ROOT::RVecI>{{0}, {0}}", 1, "broken"), std::logic_error);
+}
+
 TEST(RDFVary, RequireVariationsHaveConsistentType)
 {
    auto df = ROOT::RDataFrame(10).Define("x", [] { return 1.f; });

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -126,6 +126,16 @@ TEST(RDFVary, GetVariations)
                   "Variations {x:0, x:1} affect column x\nVariations {xy:0, xy:1} affect columns {x, y}\n");
 }
 
+TEST(RDFVary, VaryDefinePerSample)
+{
+   auto df = ROOT::RDataFrame(10).DefinePerSample("x", [](unsigned int, const ROOT::RDF::RSampleInfo &) { return 1; });
+   auto s = df.Vary("x", SimpleVariation, {}, 2).Sum<int>("x");
+   auto ss = ROOT::RDF::Experimental::VariationsFor(s);
+   EXPECT_EQ(ss["nominal"], 1 * 10);
+   EXPECT_EQ(ss["x:0"], -1 * 10);
+   EXPECT_EQ(ss["x:1"], 2 * 10);
+}
+
 TEST_P(RDFVary, SimpleSum)
 {
    auto df = ROOT::RDataFrame(10).Define("x", [] { return 1; });

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -56,8 +56,9 @@ TEST(RDFVary, RequireVariationsHaveConsistentType)
    EXPECT_THROW(df.Vary("x", SimpleVariation, {}, 2), std::runtime_error);
 }
 
-// throwing exceptions from jitted code cause problems on windows
+// throwing exceptions from jitted code cause problems on windows and MacOS+M1
 #if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
+#if !(defined(R__MACOSX) && defined(__arm64__))
 TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
 {
      auto df = ROOT::RDataFrame(10).Define("x", [] { return 1.f; });
@@ -77,6 +78,7 @@ TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
         EXPECT_THROW(ss2["nominal"], std::runtime_error);
      }
 }
+#endif
 #endif
 
 TEST(RDFVary, RequireReturnTypeIsRVec)

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -56,6 +56,8 @@ TEST(RDFVary, RequireVariationsHaveConsistentType)
    EXPECT_THROW(df.Vary("x", SimpleVariation, {}, 2), std::runtime_error);
 }
 
+// throwing exceptions from jitted code cause problems on windows
+#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
 TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
 {
      auto df = ROOT::RDataFrame(10).Define("x", [] { return 1.f; });
@@ -75,6 +77,7 @@ TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
         EXPECT_THROW(ss2["nominal"], std::runtime_error);
      }
 }
+#endif
 
 TEST(RDFVary, RequireReturnTypeIsRVec)
 {


### PR DESCRIPTION
- Fix Vary+DefinePerSample
- Add diagnostics for simultaneous variation of the same column