### PR TITLE
[cling] DeclUnloader: reset the anonymous namespace for the parent DC where appropriate

### DIFF
--- a/interpreter/cling/test/CodeUnloading/RereadFile.C
+++ b/interpreter/cling/test/CodeUnloading/RereadFile.C
@@ -23,3 +23,8 @@ macro() // CHECK: version 1
 .L macro2.h
 macro() // CHECK: 2.version 2
 //CHECK: (int) 2
+
+.x unnamedns.h
+//CHECK: 13
+.x unnamedns.h
+//CHECK-NEXT: 13

--- a/interpreter/cling/test/CodeUnloading/unnamedns.h
+++ b/interpreter/cling/test/CodeUnloading/unnamedns.h
@@ -1,0 +1,7 @@
+namespace {
+  int h = 12;
+}
+
+void unnamedns() {
+  printf("%d\n", ++h);
+}


### PR DESCRIPTION
From SemaDeclCXX.cpp:
```
C++ [namespace.unnamed]p1.  An unnamed-namespace-definition behaves as if it
were replaced by
     namespace unique { /* empty body */ }
     using namespace unique;
     namespace unique { namespace-body }
where all occurrences of 'unique' in a translation unit are replaced by the same
identifier and this identifier differs from all other identifiers in the entire
program.
```
Thus, the first declaration of an unnamed namespace creates an implicit UsingDirectiveDecl that makes the names available in the parent DC.

This pull request resets the anonymous namespace for the parent DeclContext when such first declaration is unloaded, so that the implicit UsingDirectiveDecl is created again when parsing the next anonymous namespace.

## Changes or fixes:
- Reset the anonymous namespace for the parent DeclContext for the case described above.

## Checklist:
- [X] tested changes locally

This PR fixes #7483.