### PR TITLE
Make tests fail if ASan finds an errors

### DIFF
--- a/core/sanitizer/SanitizerSetup.cxx
+++ b/core/sanitizer/SanitizerSetup.cxx
@@ -36,7 +36,7 @@ const char* __asan_default_options() {
 /// These can be overridden / augmented by the LSAN_OPTIONS environment variable.
 /// Using LSAN_OPTIONS=help=1 and starting an instrumented ROOT exectuable, available options will be printed.
 const char* __lsan_default_options() {
-   return "exitcode=0:max_leaks=10:print_suppressions=1";
+   return "max_leaks=10:print_suppressions=1";
 }
 
 /// Default suppressions for leak sanitizer in ROOT.


### PR DESCRIPTION
The AddressSanitizer also loads the LeakSanitizer flags and even though the documentation suggests that `exitcode` can be set per sanitizer, this doesn't appear to be the case and our tests exit with code 0 after the AddressSanitizer found a problem. After this change, around 100 tests will fail due to several issues.