### PR TITLE
[cling] TransactionUnloader: ensure function instantiations are processed only once

### DIFF
--- a/interpreter/cling/test/CodeUnloading/RereadFile.C
+++ b/interpreter/cling/test/CodeUnloading/RereadFile.C
@@ -28,3 +28,8 @@ macro() // CHECK: 2.version 2
 //CHECK: 13
 .x unnamedns.h
 //CHECK-NEXT: 13
+
+.x templatedfunc.h
+//CHECK: 4
+.x templatedfunc.h
+//CHECK-NEXT: 4

--- a/interpreter/cling/test/CodeUnloading/templatedfunc.h
+++ b/interpreter/cling/test/CodeUnloading/templatedfunc.h
@@ -1,0 +1,10 @@
+template <typename T> T square(T x) {
+  // This unused lambda caused a crash if the file is unloaded; see
+  // https://github.com/root-project/root/issues/9850
+  auto lambda = [](double x) { return x; };
+  return x * x;
+}
+
+void templatedfunc() {
+  printf("%d\n", square(2));
+}


### PR DESCRIPTION
Implicit instantiation of a function template calls `DeclCollector::HandleCXXImplicitFunctionInstantiation()`, which appends the
FunctionDecl to the transaction.  According to clang documentation [here](https://clang.llvm.org/doxygen/classclang_1_1ASTConsumer.html#a880e9a2fd04c8abd5cd218e0a4ed2e56), the body of the function has not yet been instantiated. `HandleTopLevelDecl()` will be called again for this decl at the end of the TU, which will append it again to the transaction - same `Decl *`, different ConsumerCallInfo.

This is by design. However, unloading of decls in the transaction should not process the same `Decl *` twice. In particular, entries with `ConsumerCallInfo == kCCIHandleCXXImplicitFunctionInstantiation` will omitted.

## Changes or fixes:
- Do not call `UnloadDecl()` if the declaration came through `HandleCXXImplicitFunctionInstantiation()`.

## Checklist:
- [X] tested changes locally

This PR fixes #9850.