### PR TITLE
[IO] Introduce TFile::MakeUnique

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -22,6 +22,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include <atomic>
+#include <memory>
 #include <string>
 
 #include "Compression.h"
@@ -298,6 +299,9 @@ public:
                                  const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault,
                                  Int_t netopt = 0);
    static TFile       *Open(const char *name, Option_t *option = "",
+                            const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault,
+                            Int_t netopt = 0);
+   static std::unique_ptr<TFile> MakeUnique(const char *name, Option_t *option = "",
                             const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault,
                             Int_t netopt = 0);
    static TFile       *Open(TFileOpenHandle *handle);

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -4241,6 +4241,23 @@ TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// \brief Call TFile::Open and return a std::unique_ptr.
+///
+/// \param[in] url Full path to the (remote) file.
+/// \param[in] options Options to pass when opening the file.
+/// \param[in] ftitle File title.
+/// \param[in] compress ROOT compression settings.
+/// \param[in] netopt Argument specific to TNetFile.
+///
+/// This function calls TFile::Open passing the input arguments as they are. The
+/// returned file is wrapped in a unique_ptr.
+std::unique_ptr<TFile>
+TFile::MakeUnique(const char *url, Option_t *options, const char *ftitle, Int_t compress, Int_t netopt)
+{
+   return std::unique_ptr<TFile>{TFile::Open(url, options, ftitle, compress, netopt)};
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Submit an asynchronous open request.
 
 /// See TFile::Open(const char *, ...) for an


### PR DESCRIPTION
This is removes the need of writing

```
std::unique_ptr<TFile> myfile{TFile::Open("myfile.root")};
```

And gives users a better alternative to receiving a raw pointer when
opening a file.
