### PR TITLE
Use pthread_attr_setaffinity_np only on glibc

### DIFF
--- a/core/thread/src/TPosixThread.cxx
+++ b/core/thread/src/TPosixThread.cxx
@@ -37,13 +37,13 @@ Int_t TPosixThread::Run(TThread *th, const int affinity)
    pthread_attr_init(attr);
    
    if (affinity >= 0) {
-   #ifdef R__MACOSX
-      Warning("Run", "Affinity setting not yet implemented on MacOS");
-   #else
+   #ifdef __GLIBC__
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
       CPU_SET(affinity, &cpuset);
       pthread_attr_setaffinity_np(attr, sizeof(cpu_set_t), &cpuset);
+   #else
+      Warning("Run", "Affinity setting not yet implemented on this platform");
    #endif
    }
 


### PR DESCRIPTION
# This pull request:

Switches ROOT to only using "pthread_attr_setaffinity_np" on glibc, instead of all platforms that aren't MacOS. This function is only available on glibc (see [here](http://stress.stappe.de/software/gnulib/manual/html_node/pthread_005fattr_005fsetaffinity_005fnp.html), so this can currently not be compiled on other libc's for linux, such as musl, or other OS's besides MacOS that don't use glibc.

## Changes or fixes:

Fixes compatibility for platforms that aren't MacOS or glibc. 

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)


