### PR TITLE
[RF] CUDA API backwards compatible call to `cudaStreamWaitEvent`

### DIFF
--- a/roofit/batchcompute/src/RooBatchCompute.cu
+++ b/roofit/batchcompute/src/RooBatchCompute.cu
@@ -143,7 +143,7 @@ public:
    }
    virtual void cudaStreamWaitEvent(cudaStream_t *stream, cudaEvent_t *event)
    {
-      ERRCHECK(::cudaStreamWaitEvent(*stream, *event));
+      ERRCHECK(::cudaStreamWaitEvent(*stream, *event, 0));
    }
    virtual float cudaEventElapsedTime(cudaEvent_t *begin, cudaEvent_t *end)
    {


### PR DESCRIPTION
In older CUDA versions, the `cudaStreamWaitEvent` function didn't have a
default `flags` parameter.

Compare for example the newest CUDA:
https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html

With CUDA 10.2:
https://docs.nvidia.com/cuda/archive/10.2/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM