### PR TITLE
Eve-7 Support arbitrary association in selection

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveCaloData.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCaloData.hxx
@@ -176,7 +176,7 @@ public:
    REveCaloData(const char* n="REveCaloData", const char* t="");
    virtual ~REveCaloData() {}
 
-   void    FillImpliedSelectedSet(Set_t& impSelSet) override;
+   void    FillImpliedSelectedSet(Set_t& impSelSet, const std::set<int>& sec_idcs) override;
 
    virtual void    GetCellList(Float_t etaMin, Float_t etaMax,
                                Float_t phi,    Float_t phiRng,

--- a/graf3d/eve7/inc/ROOT/REveCompound.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCompound.hxx
@@ -51,7 +51,7 @@ public:
    void RemoveElementLocal(REveElement *el) override;
    void RemoveElementsLocal() override;
 
-   void FillImpliedSelectedSet(Set_t &impSelSet) override;
+   void FillImpliedSelectedSet(Set_t &impSelSet, const std::set<int>&) override;
 
    TClass *ProjectedClass(const REveProjection *p) const override;
 };

--- a/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
@@ -64,7 +64,7 @@ class REveDataItemList: public REveElement,
 
 public:
    typedef  std::function<void (REveDataItemList*, const std::vector<int>&)> ItemsChangeFunc_t;
-   typedef  std::function<void (REveDataItemList*, Set_t&)> FillImpliedSelectedFunc_t;
+   typedef  std::function<void (REveDataItemList*, Set_t&, const std::set<int>&)> FillImpliedSelectedFunc_t;
 
    struct TTip {
       std::string    fTooltipTitle;
@@ -85,7 +85,7 @@ public:
 
    virtual void ItemChanged(REveDataItem *item);
    virtual void ItemChanged(Int_t idx);
-   void FillImpliedSelectedSet(Set_t &impSelSet) override;
+   void FillImpliedSelectedSet(Set_t &impSelSet, const std::set<int>& sec_idcs) override;
 
    void SetItemVisible(Int_t idx, Bool_t visible);
    void SetItemColorRGB(Int_t idx, UChar_t r, UChar_t g, UChar_t b);
@@ -105,7 +105,7 @@ public:
    void SetFillImpliedSelectedDelegate (FillImpliedSelectedFunc_t);
 
    static void DummyItemsChange(REveDataItemList*, const std::vector<int>&);
-   static void DummyFillImpliedSelected(REveDataItemList*, Set_t& impSelSet);
+   static void DummyFillImpliedSelected(REveDataItemList*, Set_t& impSelSet, const std::set<int>& sec_idcs);
 
    std::vector< std::unique_ptr<TTip> >& RefToolTipExpressions() {return fTooltipExpressions;}
 };

--- a/graf3d/eve7/inc/ROOT/REveDataProxyBuilderBase.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataProxyBuilderBase.hxx
@@ -56,7 +56,7 @@ public:
    virtual REveElement* CreateProduct(const std::string& viewType, const REveViewContext*);
    //  void removePerViewProduct(const REveViewContext* vc);
 
-   void FillImpliedSelected(REveElement::Set_t& impSet);
+   void FillImpliedSelected(REveElement::Set_t& impSet, const std::set<int>&);
    void ModelChanges(const REveDataCollection::Ids_t&);
    void CollectionChanged(const REveDataCollection*);
 
@@ -80,7 +80,7 @@ protected:
    virtual void BuildProductViewType(const REveDataCollection* iItem, REveElement* product, const std::string& viewType, const REveViewContext*);
 
    virtual void ModelChanges(const REveDataCollection::Ids_t&, Product*) = 0;
-   virtual void FillImpliedSelected( REveElement::Set_t& /*impSet*/, Product*) {};
+   virtual void FillImpliedSelected( REveElement::Set_t& /*impSet*/, const std::set<int>&, Product*) {};
    virtual void LocalModelChanges(int idx, REveElement* el, const REveViewContext* ctx);
 
    virtual void ScaleProduct(REveElement*, const std::string&) {};

--- a/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataSimpleProxyBuilder.hxx
@@ -62,7 +62,7 @@ protected:
    virtual void BuildItemViewType(const void* data, int index, REveElement* iCollectionHolder, const std::string& viewType, const REveViewContext*) = 0;
 
    void ModelChanges(const REveDataCollection::Ids_t& iIds, Product* p) override;
-   void FillImpliedSelected(REveElement::Set_t& impSet, Product* p) override;
+   void FillImpliedSelected(REveElement::Set_t& impSet, const std::set<int>& sec_idcs, Product* p) override;
    void Clean() override; // Utility
    REveCollectionCompound* CreateCompound(bool set_color=true, bool propagate_color_to_all_children=false);
 

--- a/graf3d/eve7/inc/ROOT/REveElement.hxx
+++ b/graf3d/eve7/inc/ROOT/REveElement.hxx
@@ -307,7 +307,7 @@ public:
    virtual REveElement* GetSelectionMaster();
    void         SetSelectionMaster(REveElement *el) { fSelectionMaster = el; }
 
-   virtual void FillImpliedSelectedSet(Set_t& impSelSet);
+   virtual void FillImpliedSelectedSet(Set_t& impSelSet, const std::set<int>&);
 
    void   IncImpliedSelected() { ++fImpliedSelected; }
    void   DecImpliedSelected() { --fImpliedSelected; }

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -64,6 +64,13 @@ public:
       bool is_secondary() const { return f_is_sec; }
    };
 
+   class Deviator {
+    public:
+      virtual ~Deviator(){};
+      Deviator() {}
+      virtual bool DeviateSelection(REveSelection*, REveElement*, bool multi, bool secondary, const std::set<int>& secondary_idcs) = 0;
+   };
+
    typedef std::map<REveElement*, Record>  SelMap_t;
    typedef SelMap_t::iterator              SelMap_i;
 
@@ -80,6 +87,8 @@ protected:
    Bool_t           fIsMaster{kFALSE}; ///<!
 
    SelMap_t         fMap;              ///<!
+   
+   Deviator*        fDeviator{nullptr};///<!
 
    Record* find_record(REveElement *el)
    {
@@ -108,6 +117,9 @@ public:
 
    Bool_t GetIsMaster()   const { return fIsMaster; }
    void   SetIsMaster(Bool_t m) { fIsMaster = m; }
+
+   Deviator* GetDeviator() const { return fDeviator; }
+   void   SetDeviator(Deviator* d) { fDeviator = d; }
 
    bool   IsEmpty()  const { return   fMap.empty(); }
    bool   NotEmpty() const { return ! fMap.empty(); }

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -95,7 +95,7 @@ protected:
 
    SelMap_t         fMap;              ///<!
    
-   std::shared_ptr<Deviator>        fDeviator{nullptr};///<!
+   std::shared_ptr<Deviator>        fDeviator;///<!
 
    Record* find_record(REveElement *el)
    {

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -95,7 +95,7 @@ protected:
 
    SelMap_t         fMap;              ///<!
    
-   Deviator*        fDeviator{nullptr};///<!
+   std::shared_ptr<Deviator>        fDeviator{nullptr};///<!
 
    Record* find_record(REveElement *el)
    {
@@ -129,8 +129,8 @@ public:
    Bool_t GetIsMaster()   const { return fIsMaster; }
    void   SetIsMaster(Bool_t m) { fIsMaster = m; }
 
-   Deviator* GetDeviator() const { return fDeviator; }
-   void   SetDeviator(Deviator* d) { fDeviator = d; }
+   std::shared_ptr<Deviator> GetDeviator() const { return fDeviator; }
+   void   SetDeviator(std::shared_ptr<Deviator> d) { fDeviator = d; }
 
    bool   IsEmpty()  const { return   fMap.empty(); }
    bool   NotEmpty() const { return ! fMap.empty(); }

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -27,6 +27,8 @@ namespace Experimental {
 class REveSelection : public REveElement,
                       public REveAunt
 {
+   friend class Deviator;
+
 public:
    enum EPickToSelect   // How to convert picking events to top selected element:
    { kPS_Ignore,        // ignore picking
@@ -68,7 +70,12 @@ public:
     public:
       virtual ~Deviator(){};
       Deviator() {}
-      virtual bool DeviateSelection(REveSelection*, REveElement*, bool multi, bool secondary, const std::set<int>& secondary_idcs) = 0;
+      virtual bool DeviateSelection(REveSelection* s, REveElement* el, bool multi, bool secondary, const std::set<int>& secondary_idcs) = 0;
+   protected:
+      void ExecuteNewElementPicked(REveSelection* s, REveElement* el, bool multi, bool secondary, const std::set<int>& secondary_idcs)
+      {
+         s->NewElementPickedInternal(el, multi, secondary, secondary_idcs);
+      }
    };
 
    typedef std::map<REveElement*, Record>  SelMap_t;
@@ -102,6 +109,8 @@ protected:
    void RecheckImpliedSet(SelMap_i &entry);
 
    void AddNieceForSelection(REveElement*, bool secondary, const std::set<int>&);
+
+   void NewElementPickedInternal(REveElement* el, bool multi, bool secondary, const std::set<int>& secondary_idcs);
 
 public:
    REveSelection(const std::string &n = "REveSelection", const std::string &t = "",

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -101,6 +101,8 @@ protected:
 
    void RecheckImpliedSet(SelMap_i &entry);
 
+   void AddNieceForSelection(REveElement*, bool secondary, const std::set<int>&);
+
 public:
    REveSelection(const std::string &n = "REveSelection", const std::string &t = "",
                  Color_t col_visible = kViolet, Color_t col_hidden = kPink);

--- a/graf3d/eve7/src/REveCaloData.cxx
+++ b/graf3d/eve7/src/REveCaloData.cxx
@@ -155,7 +155,7 @@ void REveCaloData::ProcessSelection(vCellId_t& sel_cells, UInt_t selectionId, Bo
 /// Populate set impSelSet with derived / dependant elements.
 ///
 
-void REveCaloData::FillImpliedSelectedSet(Set_t& impSelSet)
+void REveCaloData::FillImpliedSelectedSet(Set_t& impSelSet, const std::set<int>&)
 {
    // printf("REveCaloData::FillImpliedSelectedSet\n");
    for (auto &n : fNieces)

--- a/graf3d/eve7/src/REveCompound.cxx
+++ b/graf3d/eve7/src/REveCompound.cxx
@@ -143,18 +143,19 @@ void REveCompound::RemoveElementsLocal()
 /// Note that projected replicas of the compound will be added to
 /// the set in base-class function that handles projectable.
 
-void REveCompound::FillImpliedSelectedSet(Set_t& impSelSet)
+void REveCompound::FillImpliedSelectedSet(Set_t& impSelSet, const std::set<int>& sec_idcs)
 {
    Bool_t select_all = TestCSCBits(kCSCBImplySelectAllChildren);
 
    for (auto &c: fChildren) {
       if (select_all || c->GetCompound() == this) {
-         if (impSelSet.insert(c).second)
-            c->FillImpliedSelectedSet(impSelSet);
+         if (impSelSet.insert(c).second) {
+            c->FillImpliedSelectedSet(impSelSet, sec_idcs);
+         }
       }
    }
 
-   REveElement::FillImpliedSelectedSet(impSelSet);
+   REveElement::FillImpliedSelectedSet(impSelSet, sec_idcs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -44,8 +44,8 @@ REveDataItemList::REveDataItemList(const std::string& n, const std::string& t):
       REveDataItemList::DummyItemsChange(collection, ids);
    });
 
-   SetFillImpliedSelectedDelegate([&](REveDataItemList *collection, REveElement::Set_t &impSelSet) {
-      REveDataItemList::DummyFillImpliedSelected(collection, impSelSet);
+   SetFillImpliedSelectedDelegate([&](REveDataItemList *collection, REveElement::Set_t &impSelSet, const std::set<int>& sec_idcs) {
+      REveDataItemList::DummyFillImpliedSelected(collection, impSelSet, sec_idcs);
    });
 
    SetupDefaultColorAndTransparency(REveDataCollection::fgDefaultColor, true, true);
@@ -96,17 +96,11 @@ void REveDataItemList::ItemChanged(Int_t idx)
 
 //______________________________________________________________________________
 
-void REveDataItemList::FillImpliedSelectedSet( Set_t& impSelSet)
-{ 
-   printf("REveDataItemList::FillImpliedSelectedSet colecction setsize %zu\n",   RefSelectedSet().size());
-   for (auto &x : impSelSet)
-      x->DecImpliedSelected();
-   impSelSet.clear();
-
-   fHandlerFillImplied( this ,  impSelSet);
-
-   for (auto &x : impSelSet)
-      x->IncImpliedSelected();
+void REveDataItemList::FillImpliedSelectedSet(Set_t &impSelSet, const std::set<int> &sec_idcs)
+{
+   // printf("REveDataItemList::FillImpliedSelectedSet colecction setsize %zu\n", sec_idcs.size());
+   RefSelectedSet() = sec_idcs;
+   fHandlerFillImplied(this, impSelSet, sec_idcs);
 }
 
 //______________________________________________________________________________
@@ -250,7 +244,7 @@ void REveDataItemList::DummyItemsChange(REveDataItemList*, const std::vector<int
 
 
 //______________________________________________________________________________
-void REveDataItemList::DummyFillImpliedSelected(REveDataItemList*, REveElement::Set_t&)
+void REveDataItemList::DummyFillImpliedSelected(REveDataItemList*, REveElement::Set_t&, const std::set<int>&)
 {
    if (gDebug) {
       printf("REveDataItemList::DummyFillImpliedSelectedDelegate not implemented\n");

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -97,13 +97,16 @@ void REveDataItemList::ItemChanged(Int_t idx)
 //______________________________________________________________________________
 
 void REveDataItemList::FillImpliedSelectedSet( Set_t& impSelSet)
-{
-   /*
+{ 
    printf("REveDataItemList::FillImpliedSelectedSet colecction setsize %zu\n",   RefSelectedSet().size());
-   for (auto x : RefSelectedSet())
-      printf("%d \n", x);
-   */
+   for (auto &x : impSelSet)
+      x->DecImpliedSelected();
+   impSelSet.clear();
+
    fHandlerFillImplied( this ,  impSelSet);
+
+   for (auto &x : impSelSet)
+      x->IncImpliedSelected();
 }
 
 //______________________________________________________________________________

--- a/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
+++ b/graf3d/eve7/src/REveDataProxyBuilderBase.cxx
@@ -197,11 +197,11 @@ REveDataProxyBuilderBase::LocalModelChanges(int, REveElement*, const REveViewCon
 //------------------------------------------------------------------------------
 
 void
-REveDataProxyBuilderBase::FillImpliedSelected( REveElement::Set_t& impSet)
+REveDataProxyBuilderBase::FillImpliedSelected( REveElement::Set_t& impSet, const std::set<int> &sec_idcs)
 {
    for (auto &prod: m_products)
    {
-      FillImpliedSelected(impSet, prod);
+      FillImpliedSelected(impSet, sec_idcs, prod);
    }
 }
 

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -252,15 +252,20 @@ REveDataSimpleProxyBuilder::VisibilityModelChanges(int idx, REveElement* iCompou
 
 void REveDataSimpleProxyBuilder::FillImpliedSelected(REveElement::Set_t &impSet, const std::set<int>& sec_idcs, Product* p)
 {
-   // first check if product is added in any scene
-   if (p->m_elements->GetElementId()) {
-      // printf("[%s] REveDataSimpleProxyBuilder::FillImpliedSelected Fill implied selected %lu \n", p->m_viewType.c_str(),sec_idcs.size());
-      for (auto &s : sec_idcs) {
-         auto spb = fProductMap[p->m_elements];
-         auto it = spb->map.find(s);
-         if (it != spb->map.end()) {
-            it->second->FillImpliedSelectedSet(impSet, sec_idcs);
-         }
+   for (auto &s : sec_idcs) {
+      auto spb = fProductMap[p->m_elements];
+      auto it = spb->map.find(s);
+      if (it != spb->map.end()) {
+         it->second->FillImpliedSelectedSet(impSet, sec_idcs);
+      }
+   }
+
+   // remove elements that are not added in any scene
+   for (auto it = impSet.begin(); it != impSet.end();) {
+      if ((*it)->GetElementId()) {
+         ++it;
+      } else {
+         it = impSet.erase(it);
       }
    }
 }

--- a/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
+++ b/graf3d/eve7/src/REveDataSimpleProxyBuilder.cxx
@@ -250,15 +250,17 @@ REveDataSimpleProxyBuilder::VisibilityModelChanges(int idx, REveElement* iCompou
 
 //______________________________________________________________________________
 
-void REveDataSimpleProxyBuilder::FillImpliedSelected(REveElement::Set_t &impSet, Product* p)
+void REveDataSimpleProxyBuilder::FillImpliedSelected(REveElement::Set_t &impSet, const std::set<int>& sec_idcs, Product* p)
 {
-   for (auto &s : Collection()->GetItemList()->RefSelectedSet()) {
-      // printf("Fill implied selected %d \n", s);
-      auto spb = fProductMap[p->m_elements];
-      auto it = spb->map.find(s);
-      if (it != spb->map.end()) {
-         // printf("Fill implied selected %s \n", it->second->GetCName());
-         it->second->FillImpliedSelectedSet(impSet);
+   // first check if product is added in any scene
+   if (p->m_elements->GetElementId()) {
+      // printf("[%s] REveDataSimpleProxyBuilder::FillImpliedSelected Fill implied selected %lu \n", p->m_viewType.c_str(),sec_idcs.size());
+      for (auto &s : sec_idcs) {
+         auto spb = fProductMap[p->m_elements];
+         auto it = spb->map.find(s);
+         if (it != spb->map.end()) {
+            it->second->FillImpliedSelectedSet(impSet, sec_idcs);
+         }
       }
    }
 }

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -1374,7 +1374,7 @@ REveElement *REveElement::GetSelectionMaster()
 /// Note that this also takes care of projections of REveCompound
 /// class, which is also a projectable.
 
-void REveElement::FillImpliedSelectedSet(Set_t &impSelSet)
+void REveElement::FillImpliedSelectedSet(Set_t &impSelSet, const std::set<int>&)
 {
    REveProjectable* p = dynamic_cast<REveProjectable*>(this);
    if (p)

--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -484,7 +484,6 @@ void REveSelection::NewElementPicked(ElementId_t id, bool multi, bool secondary,
    static const REveException eh("REveSelection::NewElementPicked ");
 
    REveElement *pel = nullptr, *el = nullptr;
-   REveSecondarySelectable* secondarySelectable = nullptr;
 
    std::set<int> secondary_idcs = in_secondary_idcs;
 
@@ -495,15 +494,6 @@ void REveSelection::NewElementPicked(ElementId_t id, bool multi, bool secondary,
      if ( ! pel) throw eh + "picked element id=" + id + " not found.";
 
      el = MapPickedToSelected(pel);
-
-     secondarySelectable = dynamic_cast<REveSecondarySelectable*>(el);
-     if (el != pel) {
-        if (!secondary && secondarySelectable) {
-           // case for mapping EveCompound to REveDataCollection
-           secondary = true;
-           secondary_idcs = secondarySelectable->RefSelectedSet(); 
-        }
-     }
 
      if (fDeviator && fDeviator->DeviateSelection(this, el, multi, secondary, secondary_idcs)) {
         return;
@@ -555,7 +545,9 @@ void REveSelection::NewElementPicked(ElementId_t id, bool multi, bool secondary,
                   rec = find_record(el);
                   rec->f_is_sec   = true;
                   rec->f_sec_idcs = secondary_idcs;
-                  // need to update secondarySelectables indices
+
+                  // temporary solution FillImpliedSelectedSet does not passes indices
+                  REveSecondarySelectable* secondarySelectable = dynamic_cast<REveSecondarySelectable*>(el);
                   if (secondarySelectable)
                       secondarySelectable->RefSelectedSet() = secondary_idcs;
                   

--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -505,6 +505,10 @@ void REveSelection::NewElementPicked(ElementId_t id, bool multi, bool secondary,
      }
    }
 
+   if (fDeviator && fDeviator->DeviateSelection(this, el, multi, secondary, secondary_idcs)) {
+      return;
+   }
+
    if (gDebug > 0) {
       std::string debug_secondary;
       if (secondary) {

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -810,7 +810,7 @@ void collection_proxies(bool proj=true)
    event->Create();
 
    // divert selection to map proxy builder products with collection
-   auto deviator = new FWSelectionDeviator();
+   auto deviator = std::shared_ptr<FWSelectionDeviator>(new FWSelectionDeviator());
    eveMng->GetSelection()->SetDeviator(deviator);
    eveMng->GetHighlight()->SetDeviator(deviator);
 

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -779,7 +779,28 @@ public:
    }
 };
 
+class FWSelectionDeviator : public REveSelection::Deviator {
+public:
+   FWSelectionDeviator() {}
 
+   using REveSelection::Deviator::DeviateSelection;
+   bool DeviateSelection(REveSelection *selection, REveElement *el, bool multi, bool secondary,
+                         const std::set<int> &secondary_idcs)
+   {
+      if (el) {
+         auto *colItems = dynamic_cast<REveDataItemList *>(el);
+         if (!colItems)
+            return false;
+
+         selection->SetDeviator(nullptr);
+         selection->NewElementPicked(colItems->GetElementId(), multi, true, colItems->RefSelectedSet());
+         selection->SetDeviator(this);
+
+         return true;
+      } else
+         return false;
+   }
+};
 //==============================================================================
 //== main() ====================================================================
 //==============================================================================
@@ -789,6 +810,10 @@ void collection_proxies(bool proj=true)
    eveMng = REveManager::Create();
    auto event = new Event();
    event->Create();
+
+   // divert selection to map proxy builder products with collection
+   auto deviator = new FWSelectionDeviator();
+   eveMng->GetSelection()->SetDeviator(deviator);
 
    // create scenes and views
    REveScene* rhoZEventScene = nullptr;

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -810,7 +810,7 @@ void collection_proxies(bool proj=true)
    event->Create();
 
    // divert selection to map proxy builder products with collection
-   auto deviator = std::shared_ptr<FWSelectionDeviator>(new FWSelectionDeviator());
+   auto deviator = std::make_shared<FWSelectionDeviator>();
    eveMng->GetSelection()->SetDeviator(deviator);
    eveMng->GetHighlight()->SetDeviator(deviator);
 

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -791,10 +791,8 @@ public:
       if (el) {
          auto *colItems = dynamic_cast<REveDataItemList *>(el);
          if (colItems) {
-            selection->SetDeviator(nullptr);
-            // std::cout << "Deviate " << colItems->RefSelectedSet().size() << " passed set " << secondary_idcs.size() << "\n";
-            selection->NewElementPicked(colItems->GetElementId(), multi, true, colItems->RefSelectedSet());
-            selection->SetDeviator(this);
+            // std::cout << "Deviate RefSelected=" << colItems->RefSelectedSet().size() << " passed set " << secondary_idcs.size() << "\n";
+            ExecuteNewElementPicked(selection, colItems, multi, true, colItems->RefSelectedSet());
             return true;
          }
       }
@@ -851,7 +849,7 @@ void collection_proxies(bool proj=true)
    REveDataCollection* jetCollection = new REveDataCollection("Jets");
    jetCollection->SetItemClass(Jet::Class());
    jetCollection->SetMainColor(kYellow);
-   jetCollection->SetFilterExpr("i.Pt() > 14");
+   jetCollection->SetFilterExpr("i.Pt() > 1");
    collectionMng->addCollection(jetCollection, new JetProxyBuilder());
 
    REveDataCollection* hitCollection = new REveDataCollection("RecHits");


### PR DESCRIPTION
# This Pull request:
This change gives the possibility to steer selection through REveSelection::Deviator. This was a request for CMS event display where highlight and selection need to be propagated to associated collections. For example, associated hits can be highlighted with a reconstructed cluster.

The list of changed files is long because REveEelement::FillImpliedSet needed one additional argument. In REveSelection the NewElementPicked function is split into two parts: one does mapping of picked element and possibly calls deviator. The second part compares and stores the selection state in the internal map. 


## Changes or fixes:
The change also enables the deselection of a single item in the secondary selectable objects in the multiple select mode (Ctrl key modifier). For example, a single track, a hit, or a calorimeter tower can be deselected on the second click.

The table view now restores row selection state on reload or on change of displayed collection.


## Checklist:
The selection tests has been made macros collection_proxies.C, event_demo.C, calorimeters.C, and boxset.C

This PR fixes # 

