### PR TITLE
[DF] Avoid ROOT attribute lookup at module level

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/CppWorkflow.py
+++ b/bindings/experimental/distrdf/python/DistRDF/CppWorkflow.py
@@ -13,7 +13,7 @@ import os
 from collections import namedtuple
 
 import ROOT
-RunGraphs = ROOT.RDF.RunGraphs
+
 
 class CppWorkflow(object):
     '''
@@ -471,6 +471,7 @@ class CppWorkflow(object):
 
         if v_results:
             # We trigger the event loop here, so make sure we release the GIL
+            RunGraphs = ROOT.RDF.RunGraphs
             old_rg = RunGraphs.__release_gil__
             RunGraphs.__release_gil__ = True
             RunGraphs(v_results)


### PR DESCRIPTION
Attribute lookup of the `RDF` property of the `ROOTFacade` class can
potentially lead to issues with the facade not being initialised yet at
that moment. This can happen since creation of the distributed RDataFrame
module is also part of the logic of the `RDF` property.

An example of such issues can be reproduced by adding the line
`from DistRDF import CppWorkflow` to the `__init__.py` file. Without
this commit, it would trigger this error:

```python
>>> import DistRDF
Traceback (most recent call last):
  File ".../lib/ROOT/_facade.py", line 326, in RDF
    ns.Experimental.Distributed = _create_rdf_experimental_distributed_module(ns.Experimental)
  File ".../lib/ROOT/_facade.py", line 65, in _create_rdf_experimental_distributed_module
    return DistRDF.create_distributed_module(parent)
AttributeError: partially initialized module 'DistRDF' has no attribute 'create_distributed_module' (most likely due to a circular import)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../lib/DistRDF/__init__.py", line 20, in <module>
    from DistRDF import CppWorkflow
  File ".../lib/DistRDF/CppWorkflow.py", line 16, in <module>
    RunGraphs = ROOT.RDF.RunGraphs
  File ".../lib/ROOT/_facade.py", line 328, in RDF
    raise Exception('Failed to pythonize the namespace RDF')
Exception: Failed to pythonize the namespace RDF
```
