### PR TITLE
[RF] Consistently do bin width correction when creating a RooHist from a TH1

### DIFF
--- a/roofit/roofitcore/inc/RooHist.h
+++ b/roofit/roofitcore/inc/RooHist.h
@@ -35,7 +35,6 @@ public:
   RooHist(const RooHist& hist1, const RooHist& hist2, Double_t wgt1=1.0, Double_t wgt2=1.0,
      RooAbsData::ErrorType etype=RooAbsData::Poisson, Double_t xErrorFrac=1.0) ;
   RooHist(const RooAbsReal &f, RooAbsRealLValue &x, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0, const RooArgSet *normVars = 0, const RooFitResult* fr = 0);
-  ~RooHist() override;
 
   // add a datapoint for a bin with n entries, using a Poisson error
   void addBin(Axis_t binCenter, Double_t n, Double_t binWidth= 0, Double_t xErrorFrac=1.0, Double_t scaleFactor=1.0);

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1075,7 +1075,6 @@ RooPlot *RooDataHist::plotOn(RooPlot *frame, PlotOpt o) const
   }
 
   o.bins = &dataVar->getBinning() ;
-  o.correctForBinWidth = kFALSE ;
   return RooAbsData::plotOn(frame,o) ;
 }
 

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -87,6 +87,11 @@ RooHist::RooHist(const TH1 &data, Double_t nominalBinWidth, Double_t nSigma, Roo
        Bool_t correctForBinWidth, Double_t scaleFactor) :
   TGraphAsymmErrors(), _nominalBinWidth(nominalBinWidth), _nSigma(nSigma), _rawEntries(-1)
 {
+  if(etype == RooAbsData::Poisson && correctForBinWidth == false) {
+    throw std::invalid_argument(
+            "To ensure consistent behavior prior releases, it's not possible to create a RooHist from a TH1 with no bin width correction when using Poisson errors.");
+  }
+
   initialize();
   // copy the input histogram's name and title
   SetName(data.GetName());
@@ -97,10 +102,6 @@ RooHist::RooHist(const TH1 &data, Double_t nominalBinWidth, Double_t nSigma, Roo
     if(axis->GetNbins() > 0) _nominalBinWidth= (axis->GetXmax() - axis->GetXmin())/axis->GetNbins();
   }
   setYAxisLabel(data.GetYaxis()->GetTitle());
-
-  if (correctForBinWidth && etype == RooAbsData::Poisson) {
-    coutW(Plotting) << "Cannot apply a bin width correction and use Poisson errors. Not correcting for bin width." << std::endl;
-  }
 
   // initialize our contents from the input histogram's contents
   Int_t nbin= data.GetNbinsX();
@@ -619,16 +620,6 @@ void RooHist::addEfficiencyBinWithError(Axis_t binCenter, Double_t n1, Double_t 
   updateYAxisLimits(scale*yp);
   updateYAxisLimits(scale*ym);
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooHist::~RooHist()
-{
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
[RF] Consistently do bin width correction when making RooHist from TH1

The RooPlot constructor from TH1 had an option to disable the bin width
correction, but this argument was not even used when the RooHist was
created with Poisson errors, which is the default case. The Bin width
correction was always done in this case, no matter what was the value of
`correctForBinWith`.

However, when SumW2 errors are used, the `correctForBinWith` parameter
was actually considered! This caused inconsitent behavior, because when
plotting a `RooDataHist` the `correctForBinWith` parameter is hardcoded
to `false, meaning the bin width correction is done for Poisson errors
but not for SumW2 errors.

This commit fixes this behavior by following the precedent set by the
more common Poisson error: the `correctForBinWith` parameter is
consistently ignored, and an exception is thrown when it's false.

Consequently, the `correctForBinWith` parameter is also not hardcoded to
`false` in `RooDataHist::plotOn` anymore.

The correct way to disable the bin width correction is to enable the
interpretation as a density when importing a TH1 to a RooDataHist.

This commit fixes a bug reported on the forum.