### PR TITLE
[DF] Some cleanups to teardown

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -78,9 +78,6 @@ public:
    RAction &operator=(const RAction &) = delete;
    ~RAction()
    {
-      // must Deregister objects from the RLoopManager here, before the fPrevNode data member is destroyed:
-      // otherwise if fPrevNode is the RLoopManager, it will be destroyed before the calls to Deregister happen.
-      RActionBase::GetColRegister().Clear(); // triggers RDefine deregistration
       fLoopManager->Deregister(this);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -76,10 +76,6 @@ public:
 
    RAction(const RAction &) = delete;
    RAction &operator=(const RAction &) = delete;
-   ~RAction()
-   {
-      fLoopManager->Deregister(this);
-   }
 
    /**
       Retrieve a wrapper to the result of the action that knows how to merge

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -55,7 +55,6 @@ class RColumnRegister {
    void AddName(std::string_view name);
 
 private:
-   // N.B. must come before fDefines, to be destructed after them
    std::shared_ptr<RDFDetail::RLoopManager> fLoopManager;
 
    /// Immutable map of Defines, can be shared among several nodes.
@@ -81,6 +80,7 @@ public:
         fVariations(std::make_shared<VariationsMap_t>()), fColumnNames(std::make_shared<ColumnNames_t>())
    {
    }
+   ~RColumnRegister();
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Returns the list of the names of the defined columns (Defines + Aliases).
@@ -141,11 +141,6 @@ public:
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Return the RVariation object that handles the specified variation of the specified column.
    RVariationBase &FindVariation(const std::string &colName, const std::string &variationName) const;
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Empty the contents of this ledger.
-   /// The only allowed operation on a RColumnRegister object after a call to Clear is its destruction.
-   void Clear();
 };
 
 } // Namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -80,7 +80,6 @@ public:
    ~RFilter() {
       // must Deregister objects from the RLoopManager here, before the fPrevNode data member is destroyed:
       // otherwise if fPrevNode is the RLoopManager, it will be destroyed before the calls to Deregister happen.
-      fColRegister.Clear(); // triggers RDefine deregistration
       fLoopManager->Deregister(this);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -92,10 +92,6 @@ public:
 
    RVariedAction(const RVariedAction &) = delete;
    RVariedAction &operator=(const RVariedAction &) = delete;
-   ~RVariedAction()
-   {
-      fLoopManager->Deregister(this);
-   }
 
    void Initialize() final
    {

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -94,9 +94,6 @@ public:
    RVariedAction &operator=(const RVariedAction &) = delete;
    ~RVariedAction()
    {
-      // must Deregister objects from the RLoopManager here, before the fPrevDataFrame data member is destroyed:
-      // otherwise if fPrevDataFrame is the RLoopManager, it will be destroyed before the calls to Deregister happen.
-      RActionBase::GetColRegister().Clear(); // triggers RDefine deregistration
       fLoopManager->Deregister(this);
    }
 

--- a/tree/dataframe/src/RActionBase.cxx
+++ b/tree/dataframe/src/RActionBase.cxx
@@ -22,4 +22,8 @@ RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const 
 }
 
 // outlined to pin virtual table
-RActionBase::~RActionBase() {}
+RActionBase::~RActionBase()
+{
+   // The RLoopManager is kept alive via fColRegister.
+   fLoopManager->Deregister(this);
+}

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -18,6 +18,18 @@ namespace ROOT {
 namespace Internal {
 namespace RDF {
 
+RColumnRegister::~RColumnRegister()
+{
+   // Explicitly empty the containers to decrement the reference count of the
+   // various shared_ptr's, which might cause destructors to be called. For
+   // this, we need the RLoopManager to stay around and we do not want to rely
+   // on the order during member destruction.
+   fAliases.reset();
+   fDefines.reset();
+   fVariations.reset();
+   fColumnNames.reset();
+}
+
 bool RColumnRegister::HasName(std::string_view name) const
 {
    const auto ccolnamesEnd = fColumnNames->end();
@@ -130,14 +142,6 @@ std::string RColumnRegister::ResolveAlias(std::string_view alias) const
       return it->second;
 
    return aliasStr; // not an alias, i.e. already resolved
-}
-
-void RColumnRegister::Clear()
-{
-   fAliases.reset();
-   fDefines.reset();
-   fVariations.reset();
-   fColumnNames.reset();
 }
 
 } // namespace RDF

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -28,10 +28,7 @@ RJittedAction::RJittedAction(RLoopManager &lm, const ROOT::RDF::ColumnNames_t &c
 {
 }
 
-RJittedAction::~RJittedAction()
-{
-   fLoopManager->Deregister(this);
-}
+RJittedAction::~RJittedAction() {}
 
 void RJittedAction::Run(unsigned int slot, Long64_t entry)
 {

--- a/tree/dataframe/src/RJittedAction.cxx
+++ b/tree/dataframe/src/RJittedAction.cxx
@@ -30,9 +30,6 @@ RJittedAction::RJittedAction(RLoopManager &lm, const ROOT::RDF::ColumnNames_t &c
 
 RJittedAction::~RJittedAction()
 {
-   // must Deregister objects from the RLoopManager here, before the fConcreteAction data member is destroyed:
-   // otherwise if fConcreteAction is the RLoopManager, it will be destroyed before the calls to Deregister happen.
-   GetColRegister().Clear(); // triggers RDefine deregistration
    fLoopManager->Deregister(this);
 }
 

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -15,10 +15,7 @@
 
 using namespace ROOT::Detail::RDF;
 
-RJittedDefine::~RJittedDefine()
-{
-   fLoopManager->Deregister(this);
-}
+RJittedDefine::~RJittedDefine() {}
 
 void RJittedDefine::InitSlot(TTreeReader *r, unsigned int slot)
 {

--- a/tree/dataframe/src/RJittedVariation.cxx
+++ b/tree/dataframe/src/RJittedVariation.cxx
@@ -15,10 +15,7 @@
 
 using namespace ROOT::Internal::RDF;
 
-RJittedVariation::~RJittedVariation()
-{
-   fLoopManager->Deregister(this);
-}
+RJittedVariation::~RJittedVariation() {}
 
 void RJittedVariation::InitSlot(TTreeReader *r, unsigned int slot)
 {


### PR DESCRIPTION
Simplify the deregistration procedure to `RLoopManager` and avoid relying on the order during member destruction of `RColumnRegister`.