### PR TITLE
[cling] Do not skip hidden directories:

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -345,15 +345,13 @@ std::string cached_realpath(llvm::StringRef path, llvm::StringRef base_path = ""
 
   // Handle path list items
   for (auto item : p) {
-    if (item.startswith(".")) {
-      if (item == "..") {
-        size_t s = result.rfind(sep);
-        if (s != llvm::StringRef::npos) result.resize(s);
-        if (result.empty()) result = sep;
-      }
-      continue;
-    } else if (item == "~") {
-      continue;
+    if (item == ".")
+      continue; // skip "." element in "abc/./def"
+    if (item == "..") {
+      // collapse "a/b/../c" to "a/c"
+      size_t s = result.rfind(sep);
+      if (s != llvm::StringRef::npos) result.resize(s);
+      if (result.empty()) result = sep;
     }
 
     size_t old_size = result.size();

--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -352,6 +352,7 @@ std::string cached_realpath(llvm::StringRef path, llvm::StringRef base_path = ""
       size_t s = result.rfind(sep);
       if (s != llvm::StringRef::npos) result.resize(s);
       if (result.empty()) result = sep;
+      continue;
     }
 
     size_t old_size = result.size();


### PR DESCRIPTION
path elements starting with "." should not be ignored, only "./" itself.
Fixes issue #9697.

(cherry picked from commit 37a396c)# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

