### PR TITLE
Use mathjax 3. It is faster than mathjax 2.

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -1669,7 +1669,7 @@ USE_MATHJAX            = YES
 # The default value is: MathJax_2.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_VERSION        = MathJax_2
+MATHJAX_VERSION        = MathJax_3
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. For more details about the output format see MathJax


### PR DESCRIPTION
https://docs.mathjax.org/en/latest/upgrading/whats-new-3.0.html#improved-speed

Also the size of the tar file is smaller


