### PR TITLE
[textinput] Clear the terminal screen on Ctrl+L

### DIFF
--- a/core/textinput/src/textinput/Display.h
+++ b/core/textinput/src/textinput/Display.h
@@ -46,6 +46,8 @@ namespace textinput {
     const TextInputContext* GetContext() const { return fContext; }
     void SetContext(TextInputContext* C) { fContext = C; }
 
+    /// If is a TTY, clear the terminal screen
+    virtual void Clear() {}
     virtual void Redraw() { NotifyTextChange(Range::AllWithPrompt()); }
 
     virtual void NotifyTextChange(Range r) = 0; // Update the displayed text

--- a/core/textinput/src/textinput/Editor.cpp
+++ b/core/textinput/src/textinput/Editor.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <vector>
 #include "textinput/Callbacks.h"
+#include "textinput/Display.h"
 #include "textinput/History.h"
 #include "textinput/KeyBinding.h"
 #include "textinput/StreamReaderUnix.h"
@@ -438,6 +439,11 @@ namespace textinput {
         fReplayHistEntry = fCurHistEntry;
         return kPRSuccess;
       case kCmdClearScreen:
+        for (auto *D : fContext->GetDisplays()) {
+          D->Clear();
+          D->Redraw();
+        }
+        return kPRSuccess;
       case kCmd_END_TEXT_MODIFYING_CMDS:
         return kPRError;
       case kCmdEsc:

--- a/core/textinput/src/textinput/TerminalDisplay.h
+++ b/core/textinput/src/textinput/TerminalDisplay.h
@@ -33,12 +33,12 @@ namespace textinput {
     ~TerminalDisplay();
     static TerminalDisplay* Create();
 
-    void NotifyTextChange(Range r);
-    void NotifyCursorChange();
-    void NotifyResetInput();
-    void NotifyError();
-    void Detach();
-    void DisplayInfo(const std::vector<std::string>& Options);
+    void NotifyTextChange(Range r) override;
+    void NotifyCursorChange() override;
+    void NotifyResetInput() override;
+    void NotifyError() override;
+    void Detach() override;
+    void DisplayInfo(const std::vector<std::string>& Options) override;
     bool IsTTY() const { return fIsTTY; }
 
   protected:

--- a/core/textinput/src/textinput/TerminalDisplayUnix.cpp
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.cpp
@@ -164,6 +164,13 @@ namespace textinput {
   }
 
   void
+  TerminalDisplayUnix::Clear() {
+    static const char text[] = "\033[2J\033[H";
+    if (!IsTTY()) return;
+    WriteRawString(text, sizeof(text));
+  }
+
+  void
   TerminalDisplayUnix::SetColor(char CIdx, const Color& C) {
     if (!IsTTY()) return;
 

--- a/core/textinput/src/textinput/TerminalDisplayUnix.h
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.h
@@ -31,20 +31,20 @@ namespace textinput {
     void HandleResizeSignal();
     void Clear() override;
 
-    void Attach();
-    void Detach();
+    void Attach() override;
+    void Detach() override;
 
   protected:
-    void MoveUp(size_t nLines = 1);
-    void MoveDown(size_t nLines = 1);
-    void MoveLeft(size_t nCols = 1);
-    void MoveRight(size_t nCols = 1);
+    void MoveUp(size_t nLines = 1) override;
+    void MoveDown(size_t nLines = 1) override;
+    void MoveLeft(size_t nCols = 1) override;
+    void MoveRight(size_t nCols = 1) override;
     void MoveInternal(char What, size_t n);
-    void MoveFront();
-    void SetColor(char CIdx, const Color& C);
-    void WriteRawString(const char* text, size_t len);
-    void ActOnEOL();
-    void EraseToRight();
+    void MoveFront() override;
+    void SetColor(char CIdx, const Color& C) override;
+    void WriteRawString(const char* text, size_t len) override;
+    void ActOnEOL() override;
+    void EraseToRight() override;
     int GetClosestColorIdx256(const Color& C);
     int GetClosestColorIdx16(const Color& C);
 

--- a/core/textinput/src/textinput/TerminalDisplayUnix.h
+++ b/core/textinput/src/textinput/TerminalDisplayUnix.h
@@ -29,6 +29,7 @@ namespace textinput {
     ~TerminalDisplayUnix();
 
     void HandleResizeSignal();
+    void Clear() override;
 
     void Attach();
     void Detach();

--- a/core/textinput/src/textinput/TerminalDisplayWin.cpp
+++ b/core/textinput/src/textinput/TerminalDisplayWin.cpp
@@ -75,6 +75,14 @@ namespace textinput {
   }
 
   void
+  TerminalDisplayWin::Clear() {
+    static const char text[] = "\033[2J\033[H";
+    if (!IsTTY()) return;
+    EnableVTProcessingRAII RAII(fOut);
+    WriteRawString(text, sizeof(text));
+  }
+
+  void
   TerminalDisplayWin::SetColor(char CIdx, const Color& C) {
     WORD Attribs = 0;
     // There is no underline since DOS has died.

--- a/core/textinput/src/textinput/TerminalDisplayWin.h
+++ b/core/textinput/src/textinput/TerminalDisplayWin.h
@@ -27,6 +27,7 @@ namespace textinput {
     ~TerminalDisplayWin();
 
     void HandleResizeEvent();
+    void Clear() override;
 
     void Attach();
     void Detach();
@@ -55,6 +56,17 @@ namespace textinput {
     DWORD fMyMode; // console configuration when active
     WORD fDefaultAttributes; // attributes to restore on destruction
     const UINT fOldCodePage; // saved codepage of console
+
+    /// RAII object that temporarily enables VT sequences for the given console
+    struct EnableVTProcessingRAII {
+      HANDLE fConsole;
+      DWORD fMode;
+      EnableVTProcessingRAII(HANDLE con) : fConsole(con) {
+        ::GetConsoleMode(fConsole, &fMode);
+        ::SetConsoleMode(fConsole, fMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+      }
+      ~EnableVTProcessingRAII() { ::SetConsoleMode(fConsole, fMode); }
+    };
   };
 }
 #endif // TEXTINPUT_TERMINALDISPLAYWIN_H

--- a/core/textinput/src/textinput/TerminalDisplayWin.h
+++ b/core/textinput/src/textinput/TerminalDisplayWin.h
@@ -29,21 +29,21 @@ namespace textinput {
     void HandleResizeEvent();
     void Clear() override;
 
-    void Attach();
-    void Detach();
+    void Attach() override;
+    void Detach() override;
 
   protected:
-    void Move(Pos p);
+    void Move(Pos p) override;
     void MoveInternal(Pos p);
-    void MoveUp(size_t nLines = 1);
-    void MoveDown(size_t nLines = 1);
-    void MoveLeft(size_t nCols = 1);
-    void MoveRight(size_t nCols = 1);
-    void MoveFront();
-    void SetColor(char CIdx, const Color& C);
-    void WriteRawString(const char* text, size_t len);
+    void MoveUp(size_t nLines = 1) override;
+    void MoveDown(size_t nLines = 1) override;
+    void MoveLeft(size_t nCols = 1) override;
+    void MoveRight(size_t nCols = 1) override;
+    void MoveFront() override;
+    void SetColor(char CIdx, const Color& C) override;
+    void WriteRawString(const char* text, size_t len) override;
 
-    void EraseToRight();
+    void EraseToRight() override;
     void CheckCursorPos();
 
     void ShowError(const char* Where) const;


### PR DESCRIPTION
This pull request implements the Ctrl+L keybinding (clear terminal screen) in ROOT's textinput.

## Changes or fixes:
- Adds the `Display::Clear()` member function, which clears the visible part of the screen on a TTY and moves the cursor to the home position.  For Windows, this requires to temporarily enable processing of VT control sequences.
- Provide implementation for the `kCmdClearScreen` editor command.

## Checklist:
- [X] tested changes locally

This PR fixes #10057.