### PR TITLE
[skip-ci][win64] Disable failing test on Windows 64

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -128,7 +128,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tf_pycallables tf_pycallables.py)
 
 if(roofit)
   # RooAbsCollection and subclasses pythonizations
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabscollection roofit/rooabscollection.py)
+  if(NOT MSVC OR "${CMAKE_GENERATOR_PLATFORM}" MATCHES "Win32" OR win_broken_tests)
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabscollection roofit/rooabscollection.py)
+  endif()
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooarglist roofit/rooarglist.py)
 
   # RooDataHist pythonisations


### PR DESCRIPTION
Disable the `pyroot_roofit_rooabscollection` test which is failing on Windows 64:
```
45: test_iterator_rooarglist (rooabscollection.TestRooAbsCollection) ...  *** Break *** segmentation violation
```
