### PR TITLE
[RF] Avoid any dependencies of RooFitHS3 for dictionary generation and update HistFactory::JSONTool interface

### DIFF
--- a/roofit/hs3/CMakeLists.txt
+++ b/roofit/hs3/CMakeLists.txt
@@ -39,7 +39,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitHS3
     ${RYMLSources}
   DICTIONARY_OPTIONS
     "-writeEmptyRootPCM"
-  DEPENDENCIES
+  LIBRARIES
     RooFit
     RooFitCore
     RooStats

--- a/roofit/hs3/inc/RooFitHS3/HistFactoryJSONTool.h
+++ b/roofit/hs3/inc/RooFitHS3/HistFactoryJSONTool.h
@@ -16,36 +16,25 @@
 #include <iostream>
 #include <string>
 
-namespace RooFit {
-namespace Experimental {
-class JSONNode;
-}
-} // namespace RooFit
-
 namespace RooStats {
 namespace HistFactory {
 
-class Channel;
 class Measurement;
-class Sample;
 
 class JSONTool {
-protected:
-   RooStats::HistFactory::Measurement *_measurement;
-
-   void Export(const RooStats::HistFactory::Channel &c, RooFit::Experimental::JSONNode &t) const;
-   void Export(const RooStats::HistFactory::Sample &s, RooFit::Experimental::JSONNode &t) const;
-
 public:
-   JSONTool(RooStats::HistFactory::Measurement *);
+   JSONTool(RooStats::HistFactory::Measurement &m) : _measurement(m) {}
 
    void PrintJSON(std::ostream &os = std::cout);
    void PrintJSON(std::string const &filename);
    void PrintYAML(std::ostream &os = std::cout);
    void PrintYAML(std::string const &filename);
-   void Export(RooFit::Experimental::JSONNode &t) const;
+
+private:
+   RooStats::HistFactory::Measurement &_measurement;
 };
 
 } // namespace HistFactory
 } // namespace RooStats
+
 #endif

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -13,13 +13,15 @@
 #ifndef RooFitHS3_RooJSONFactoryWSTool_h
 #define RooFitHS3_RooJSONFactoryWSTool_h
 
-#include <RooArgSet.h>
-#include <RooGlobalFunc.h>
-
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
+class RooArgList;
+class RooAbsData;
+class RooArgSet;
 class RooAbsArg;
 class RooAbsReal;
 class RooAbsPdf;
@@ -30,6 +32,7 @@ class RooRealVar;
 class RooWorkspace;
 
 class TH1;
+class TClass;
 
 namespace RooFit {
 namespace Experimental {
@@ -67,13 +70,13 @@ public:
       std::map<std::string, std::string> proxies;
    };
    struct ImportExpression {
-      TClass const* tclass = nullptr;
+      TClass const *tclass = nullptr;
       std::vector<std::string> arguments;
    };
 
    typedef std::map<const std::string, std::vector<std::unique_ptr<const Importer>>> ImportMap;
-   typedef std::map<TClass const*, std::vector<std::unique_ptr<const Exporter>>> ExportMap;
-   typedef std::map<TClass const*, ExportKeys> ExportKeysMap;
+   typedef std::map<TClass const *, std::vector<std::unique_ptr<const Exporter>>> ExportMap;
+   typedef std::map<TClass const *, ExportKeys> ExportKeysMap;
    typedef std::map<const std::string, ImportExpression> ImportExpressionMap;
 
    // The following maps to hold the importers and exporters for runtime lookup
@@ -96,11 +99,11 @@ public:
       Var(const RooFit::Experimental::JSONNode &val);
    };
 
-   std::ostream &log(RooFit::MsgLevel level) const;
+   std::ostream &log(int level) const;
 
 protected:
    struct Scope {
-      RooArgSet observables;
+      std::vector<RooAbsArg *> observables;
       std::map<std::string, RooAbsArg *> objects;
    };
    mutable Scope _scope;
@@ -227,7 +230,7 @@ public:
    readBinnedData(const RooFit::Experimental::JSONNode &n, const std::string &namecomp, RooArgList observables);
    static std::map<std::string, RooJSONFactoryWSTool::Var>
    readObservables(const RooFit::Experimental::JSONNode &n, const std::string &obsnamecomp);
-   RooArgSet getObservables(const RooFit::Experimental::JSONNode &n, const std::string &obsnamecomp);
+   void getObservables(const RooFit::Experimental::JSONNode &n, const std::string &obsnamecomp, RooArgSet &out);
    void setScopeObservables(const RooArgList &args);
    RooAbsArg *getScopeObject(const std::string &name);
    void setScopeObject(const std::string &key, RooAbsArg *obj);

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -372,7 +372,8 @@ public:
       if (!p.has_child("data")) {
          RooJSONFactoryWSTool::error("function '" + name + "' is of histogram type, but does not define a 'data' key");
       }
-      auto varlist = tool->getObservables(p["data"], name);
+      RooArgSet varlist;
+      tool->getObservables(p["data"], name, varlist);
       RooDataHist *dh = dynamic_cast<RooDataHist *>(tool->workspace()->embeddedData(name));
       if (!dh) {
          auto dhForImport = tool->readBinnedData(p["data"], name, varlist);

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -12,6 +12,7 @@
 
 #include <RooFitHS3/RooJSONFactoryWSTool.h>
 
+#include <RooGlobalFunc.h>
 #include <RooConstVar.h>
 #include <RooRealVar.h>
 #include <RooAbsCategory.h>
@@ -1056,11 +1057,13 @@ std::map<std::string, std::unique_ptr<RooAbsData>> RooJSONFactoryWSTool::loadDat
          continue;
       if (p.has_child("counts")) {
          // binned
-         auto vars = this->getObservables(p, name);
+         RooArgSet vars;
+         this->getObservables(p, name, vars);
          dataMap[name] = this->readBinnedData(p, name, vars);
       } else if (p.has_child("coordinates")) {
          // unbinned
-         auto vars = this->getObservables(p, name);
+         RooArgSet vars;
+         this->getObservables(p, name, vars);
          RooArgList varlist(vars);
          RooRealVar *weightVar = this->getWeightVar("weight");
          vars.add(*weightVar, true);
@@ -1224,27 +1227,28 @@ void RooJSONFactoryWSTool::exportData(RooAbsData *data, JSONNode &n)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // create several observables
-RooArgSet RooJSONFactoryWSTool::getObservables(const JSONNode &n, const std::string &obsnamecomp)
+void RooJSONFactoryWSTool::getObservables(const JSONNode &n, const std::string &obsnamecomp, RooArgSet &out)
 {
-   if (this->_scope.observables.size() > 0) {
-      return this->_scope.observables;
+   if (!_scope.observables.empty()) {
+      out.add(_scope.observables.begin(), _scope.observables.end());
+      return;
    }
    auto vars = readObservables(n, obsnamecomp);
-   RooArgList varlist;
    for (auto v : vars) {
       std::string name(v.first);
       if (_workspace->var(name)) {
-         varlist.add(*(_workspace->var(name)));
+         out.add(*(_workspace->var(name)));
       } else {
-         varlist.add(*RooJSONFactoryWSTool::createObservable(name, v.second));
+         out.add(*RooJSONFactoryWSTool::createObservable(name, v.second));
       }
    }
-   return varlist;
 }
 
 void RooJSONFactoryWSTool::setScopeObservables(const RooArgList &args)
 {
-   this->_scope.observables.add(args, true);
+   for (auto *arg : args) {
+      _scope.observables.push_back(arg);
+   }
 }
 void RooJSONFactoryWSTool::setScopeObject(const std::string &name, RooAbsArg *obj)
 {
@@ -1789,9 +1793,10 @@ bool RooJSONFactoryWSTool::importYML(std::string const &filename)
    return this->importYML(infile);
 }
 
-std::ostream &RooJSONFactoryWSTool::log(RooFit::MsgLevel level) const
+std::ostream &RooJSONFactoryWSTool::log(int level) const
 {
-   return RooMsgService::instance().log(static_cast<TObject *>(nullptr), level, RooFit::IO);
+   return RooMsgService::instance().log(static_cast<TObject *>(nullptr), static_cast<RooFit::MsgLevel>(level),
+                                        RooFit::IO);
 }
 
 RooJSONFactoryWSTool::ImportMap &RooJSONFactoryWSTool::staticImporters()


### PR DESCRIPTION
More info in the commit descriptions.

This should fix the compiler errors reported on the forum:
https://root-forum.cern.ch/t/error-compiling-with-ubuntu-20-04-4-lts/49097

Should be backported to 6.26.

This PR also suggests a slight change to the HistFactory::JSONTool interface which is not necessarily a bugfix, but it's better to hide away the `JSONTool::Export` function as of 6.26.02 such that people don't start using it and we we are stuck with that interface.

