### PR TITLE
[math] Add missing `override` specifiers in Math

### DIFF
--- a/math/fftw/inc/TFFTComplex.h
+++ b/math/fftw/inc/TFFTComplex.h
@@ -34,35 +34,35 @@ public:
    TFFTComplex();
    TFFTComplex(Int_t n, Bool_t inPlace);
    TFFTComplex(Int_t ndim, Int_t *n, Bool_t inPlace = kFALSE);
-   virtual ~TFFTComplex();
+   ~TFFTComplex() override;
 
-   virtual void       Init(Option_t *flags, Int_t sign, const Int_t* /*kind*/);
+   void       Init(Option_t *flags, Int_t sign, const Int_t* /*kind*/) override;
 
-   virtual Int_t     *GetN()    const {return fN;}
-   virtual Int_t      GetNdim() const {return fNdim;}
+   Int_t     *GetN()    const override {return fN;}
+   Int_t      GetNdim() const override {return fNdim;}
    virtual Int_t      GetSize() const {return fTotalSize;}
-   virtual Option_t  *GetType() const {if (fSign==-1) return "C2CBackward"; else return "C2CForward";}
-   virtual Int_t      GetSign() const {return fSign;}
-   virtual Option_t  *GetTransformFlag() const {return fFlags;}
-   virtual Bool_t     IsInplace() const {if (fOut) return kTRUE; else return kFALSE;};
+   Option_t  *GetType() const override {if (fSign==-1) return "C2CBackward"; else return "C2CForward";}
+   Int_t      GetSign() const override {return fSign;}
+   Option_t  *GetTransformFlag() const override {return fFlags;}
+   Bool_t     IsInplace() const override {if (fOut) return kTRUE; else return kFALSE;};
 
-   virtual void       GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const;
-   virtual Double_t   GetPointReal(Int_t /*ipoint*/, Bool_t /*fromInput = kFALSE*/) const {return 0;};
-   virtual Double_t   GetPointReal(const Int_t* /*ipoint*/, Bool_t /*fromInput=kFALSE*/) const{return 0;}
-   virtual void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
-   virtual void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
-   virtual Double_t*  GetPointsReal(Bool_t /*fromInput=kFALSE*/) const {return 0;};
-   virtual void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const ;
-   virtual void       GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const ;
+   void       GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const override;
+   Double_t   GetPointReal(Int_t /*ipoint*/, Bool_t /*fromInput = kFALSE*/) const override {return 0;};
+   Double_t   GetPointReal(const Int_t* /*ipoint*/, Bool_t /*fromInput=kFALSE*/) const override{return 0;}
+   void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
+   void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
+   Double_t*  GetPointsReal(Bool_t /*fromInput=kFALSE*/) const override {return 0;};
+   void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const override ;
+   void       GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const override ;
 
-   virtual void       SetPoint(Int_t ipoint, Double_t re, Double_t im = 0);
-   virtual void       SetPoint(const Int_t *ipoint, Double_t re, Double_t im = 0);
-   virtual void       SetPoints(const Double_t *data);
-   virtual void       SetPointComplex(Int_t ipoint, TComplex &c);
-   virtual void       SetPointsComplex(const Double_t *re, const Double_t *im);
-   virtual void       Transform();
+   void       SetPoint(Int_t ipoint, Double_t re, Double_t im = 0) override;
+   void       SetPoint(const Int_t *ipoint, Double_t re, Double_t im = 0) override;
+   void       SetPoints(const Double_t *data) override;
+   void       SetPointComplex(Int_t ipoint, TComplex &c) override;
+   void       SetPointsComplex(const Double_t *re, const Double_t *im) override;
+   void       Transform() override;
 
-   ClassDef(TFFTComplex,0);
+   ClassDefOverride(TFFTComplex,0);
 };
 
 #endif

--- a/math/fftw/inc/TFFTComplexReal.h
+++ b/math/fftw/inc/TFFTComplexReal.h
@@ -35,35 +35,35 @@ class TFFTComplexReal: public TVirtualFFT {
    TFFTComplexReal();
    TFFTComplexReal(Int_t n, Bool_t inPlace);
    TFFTComplexReal(Int_t ndim, Int_t *n, Bool_t inPlace);
-   virtual ~TFFTComplexReal();
+   ~TFFTComplexReal() override;
 
-   virtual void       Init( Option_t *flags, Int_t /*sign*/,const Int_t* /*kind*/);
+   void       Init( Option_t *flags, Int_t /*sign*/,const Int_t* /*kind*/) override;
 
    virtual Int_t      GetSize() const {return fTotalSize;}
-   virtual Int_t     *GetN()    const {return fN;}
-   virtual Int_t      GetNdim() const {return fNdim;}
-   virtual Option_t  *GetType() const {return "C2R";}
-   virtual Int_t      GetSign() const {return -1;}
-   virtual Option_t  *GetTransformFlag() const {return fFlags;}
-   virtual Bool_t     IsInplace() const {if (fOut) return kTRUE; else return kFALSE;};
+   Int_t     *GetN()    const override {return fN;}
+   Int_t      GetNdim() const override {return fNdim;}
+   Option_t  *GetType() const override {return "C2R";}
+   Int_t      GetSign() const override {return -1;}
+   Option_t  *GetTransformFlag() const override {return fFlags;}
+   Bool_t     IsInplace() const override {if (fOut) return kTRUE; else return kFALSE;};
 
-   virtual void       GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const;
-   virtual Double_t   GetPointReal(Int_t ipoint, Bool_t fromInput = kFALSE) const;
-   virtual Double_t   GetPointReal(const Int_t *ipoint, Bool_t fromInput = kFALSE) const;
-   virtual void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
-   virtual void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
-   virtual Double_t*  GetPointsReal(Bool_t fromInput=kFALSE) const;
-   virtual void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const ;
-   virtual void       GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const ;
+   void       GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const override;
+   Double_t   GetPointReal(Int_t ipoint, Bool_t fromInput = kFALSE) const override;
+   Double_t   GetPointReal(const Int_t *ipoint, Bool_t fromInput = kFALSE) const override;
+   void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
+   void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
+   Double_t*  GetPointsReal(Bool_t fromInput=kFALSE) const override;
+   void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const override ;
+   void       GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const override ;
 
-   virtual void       SetPoint(Int_t ipoint, Double_t re, Double_t im = 0);
-   virtual void       SetPoint(const Int_t *ipoint, Double_t re, Double_t im = 0);
-   virtual void       SetPoints(const Double_t *data);
-   virtual void       SetPointComplex(Int_t ipoint, TComplex &c);
-   virtual void       SetPointsComplex(const Double_t *re, const Double_t *im);
-   virtual void       Transform();
+   void       SetPoint(Int_t ipoint, Double_t re, Double_t im = 0) override;
+   void       SetPoint(const Int_t *ipoint, Double_t re, Double_t im = 0) override;
+   void       SetPoints(const Double_t *data) override;
+   void       SetPointComplex(Int_t ipoint, TComplex &c) override;
+   void       SetPointsComplex(const Double_t *re, const Double_t *im) override;
+   void       Transform() override;
 
-   ClassDef(TFFTComplexReal,0);
+   ClassDefOverride(TFFTComplexReal,0);
 };
 
 #endif

--- a/math/fftw/inc/TFFTReal.h
+++ b/math/fftw/inc/TFFTReal.h
@@ -35,38 +35,38 @@ class TFFTReal: public TVirtualFFT{
    TFFTReal();
    TFFTReal(Int_t n, Bool_t inPlace=kFALSE);
    TFFTReal(Int_t ndim, Int_t *n, Bool_t inPlace=kFALSE);
-   virtual ~TFFTReal();
+   ~TFFTReal() override;
 
-   virtual void      Init( Option_t *flags,Int_t sign, const Int_t *kind);
+   void      Init( Option_t *flags,Int_t sign, const Int_t *kind) override;
 
    virtual Int_t     GetSize() const {return fTotalSize;}
-   virtual Int_t    *GetN()    const {return fN;}
-   virtual Int_t     GetNdim() const {return fNdim;}
-   virtual Option_t *GetType() const;
-   virtual Int_t     GetSign() const {return 0;}
-   virtual Option_t *GetTransformFlag() const {return fFlags;}
-   virtual Bool_t    IsInplace() const {if (fOut) return kTRUE; else return kFALSE;}
+   Int_t    *GetN()    const override {return fN;}
+   Int_t     GetNdim() const override {return fNdim;}
+   Option_t *GetType() const override;
+   Int_t     GetSign() const override {return 0;}
+   Option_t *GetTransformFlag() const override {return fFlags;}
+   Bool_t    IsInplace() const override {if (fOut) return kTRUE; else return kFALSE;}
 
-   virtual void      GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const;
-   virtual Double_t  GetPointReal(Int_t ipoint, Bool_t fromInput = kFALSE) const;
-   virtual Double_t  GetPointReal(const Int_t *ipoint, Bool_t fromInput = kFALSE) const;
-   virtual void      GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
+   void      GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const override;
+   Double_t  GetPointReal(Int_t ipoint, Bool_t fromInput = kFALSE) const override;
+   Double_t  GetPointReal(const Int_t *ipoint, Bool_t fromInput = kFALSE) const override;
+   void      GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
 
-   virtual void      GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
+   void      GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
 
-   virtual Double_t *GetPointsReal(Bool_t fromInput=kFALSE) const;
-   virtual void      GetPointsComplex(Double_t* /*re*/, Double_t* /*im*/, Bool_t /*fromInput = kFALSE*/) const{};
-   virtual  void     GetPointsComplex(Double_t* /*data*/, Bool_t /*fromInput = kFALSE*/) const {};
+   Double_t *GetPointsReal(Bool_t fromInput=kFALSE) const override;
+   void      GetPointsComplex(Double_t* /*re*/, Double_t* /*im*/, Bool_t /*fromInput = kFALSE*/) const override{};
+    void     GetPointsComplex(Double_t* /*data*/, Bool_t /*fromInput = kFALSE*/) const override {};
 
-   virtual void      SetPoint(Int_t ipoint, Double_t re, Double_t im = 0);
-   virtual void      SetPoint(const Int_t *ipoint, Double_t re, Double_t /*im=0*/);
-   virtual void      SetPoints(const Double_t *data);
-   virtual void      SetPointComplex(Int_t /*ipoint*/, TComplex &/*c*/){};
-   virtual void      SetPointsComplex(const Double_t* /*re*/, const Double_t* /*im*/){};
-   virtual void      Transform();
+   void      SetPoint(Int_t ipoint, Double_t re, Double_t im = 0) override;
+   void      SetPoint(const Int_t *ipoint, Double_t re, Double_t /*im=0*/) override;
+   void      SetPoints(const Double_t *data) override;
+   void      SetPointComplex(Int_t /*ipoint*/, TComplex &/*c*/) override{};
+   void      SetPointsComplex(const Double_t* /*re*/, const Double_t* /*im*/) override{};
+   void      Transform() override;
 
 
-   ClassDef(TFFTReal,0);
+   ClassDefOverride(TFFTReal,0);
 };
 
 #endif

--- a/math/fftw/inc/TFFTRealComplex.h
+++ b/math/fftw/inc/TFFTRealComplex.h
@@ -33,35 +33,35 @@ class TFFTRealComplex: public TVirtualFFT {
    TFFTRealComplex();
    TFFTRealComplex(Int_t n, Bool_t inPlace);
    TFFTRealComplex(Int_t ndim, Int_t *n, Bool_t inPlace);
-   virtual ~TFFTRealComplex();
+   ~TFFTRealComplex() override;
 
-   virtual void       Init( Option_t *flags, Int_t /*sign*/,const Int_t* /*kind*/);
+   void       Init( Option_t *flags, Int_t /*sign*/,const Int_t* /*kind*/) override;
 
    virtual Int_t      GetSize() const {return fTotalSize;}
-   virtual Int_t     *GetN()    const {return fN;}
-   virtual Int_t      GetNdim() const {return fNdim;}
-   virtual Option_t  *GetType() const {return "R2C";}
-   virtual Int_t      GetSign() const {return 1;}
-   virtual Option_t  *GetTransformFlag() const {return fFlags;}
-   virtual Bool_t     IsInplace() const {if (fOut) return kTRUE; else return kFALSE;};
+   Int_t     *GetN()    const override {return fN;}
+   Int_t      GetNdim() const override {return fNdim;}
+   Option_t  *GetType() const override {return "R2C";}
+   Int_t      GetSign() const override {return 1;}
+   Option_t  *GetTransformFlag() const override {return fFlags;}
+   Bool_t     IsInplace() const override {if (fOut) return kTRUE; else return kFALSE;};
 
-   virtual void       GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const;
-   virtual Double_t   GetPointReal(Int_t ipoint, Bool_t fromInput = kFALSE) const;
-   virtual Double_t   GetPointReal(const Int_t *ipoint, Bool_t fromInput = kFALSE) const;
-   virtual void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
-   virtual void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const;
-   virtual Double_t  *GetPointsReal(Bool_t fromInput=kFALSE) const;
-   virtual void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const ;
-   virtual  void      GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const ;
+   void       GetPoints(Double_t *data, Bool_t fromInput = kFALSE) const override;
+   Double_t   GetPointReal(Int_t ipoint, Bool_t fromInput = kFALSE) const override;
+   Double_t   GetPointReal(const Int_t *ipoint, Bool_t fromInput = kFALSE) const override;
+   void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
+   void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
+   Double_t  *GetPointsReal(Bool_t fromInput=kFALSE) const override;
+   void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const override ;
+    void      GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const override ;
 
-   virtual void       SetPoint(Int_t ipoint, Double_t re, Double_t im = 0);
-   virtual void       SetPoint(const Int_t *ipoint, Double_t re, Double_t im = 0);
-   virtual void       SetPoints(const Double_t *data);
-   virtual void       SetPointComplex(Int_t ipoint, TComplex &c);
-   virtual void       SetPointsComplex(const Double_t *re, const Double_t *im);
-   virtual void       Transform();
+   void       SetPoint(Int_t ipoint, Double_t re, Double_t im = 0) override;
+   void       SetPoint(const Int_t *ipoint, Double_t re, Double_t im = 0) override;
+   void       SetPoints(const Double_t *data) override;
+   void       SetPointComplex(Int_t ipoint, TComplex &c) override;
+   void       SetPointsComplex(const Double_t *re, const Double_t *im) override;
+   void       Transform() override;
 
-   ClassDef(TFFTRealComplex,0);
+   ClassDefOverride(TFFTRealComplex,0);
 };
 
 #endif

--- a/math/foam/inc/TFoam.h
+++ b/math/foam/inc/TFoam.h
@@ -76,7 +76,7 @@ protected:
 public:
    TFoam();                          // Default constructor (used only by ROOT streamer)
    TFoam(const Char_t*);             // Principal user-defined constructor
-   virtual ~TFoam();                 // Default destructor
+   ~TFoam() override;                 // Default destructor
    TFoam(const TFoam&);              // Copy Constructor  NOT USED
    // Initialization
    virtual void Initialize();                // Initialization of the FOAM (grid, cells, etc), mandatory!
@@ -139,7 +139,7 @@ public:
 private:
    Double_t Sqr(Double_t x) const { return x*x;}      // Square function
 
-   ClassDef(TFoam,2);   // General purpose self-adapting Monte Carlo event generator
+   ClassDefOverride(TFoam,2);   // General purpose self-adapting Monte Carlo event generator
 };
 
 #endif

--- a/math/foam/inc/TFoamCell.h
+++ b/math/foam/inc/TFoamCell.h
@@ -35,7 +35,7 @@ public:
    TFoamCell();                          // Default Constructor for ROOT streamers
    TFoamCell(Int_t);                     // User Constructor
    TFoamCell(TFoamCell &);               // Copy Constructor
-   virtual ~TFoamCell();                 // Destructor
+   ~TFoamCell() override;                 // Destructor
    void  Fill(Int_t, TFoamCell*, TFoamCell*, TFoamCell*);    // Assigns values of attributes
    TFoamCell&  operator=(const TFoamCell&);       // Substitution operator (never used)
    //--------------- Geometry ----------------------------------
@@ -65,8 +65,8 @@ public:
    void      SetSerial(Int_t Serial){ fSerial=Serial;}    // Set serial number
    Int_t     GetSerial() const { return fSerial;}         // Get serial number
    //--- other ---
-   void Print(Option_t *option) const ;                   // Prints cell content
+   void Print(Option_t *option) const override ;                   // Prints cell content
 
-   ClassDef(TFoamCell,1)  //Single cell of FOAM
+   ClassDefOverride(TFoamCell,1)  //Single cell of FOAM
 };
 #endif

--- a/math/foam/inc/TFoamIntegrand.h
+++ b/math/foam/inc/TFoamIntegrand.h
@@ -9,10 +9,10 @@
 class TFoamIntegrand : public TObject  {
 public:
    TFoamIntegrand() { };
-   virtual ~TFoamIntegrand() { };
+   ~TFoamIntegrand() override { };
    virtual Double_t Density(Int_t ndim, Double_t *) = 0;
 
-   ClassDef(TFoamIntegrand,1); //n-dimensional real positive integrand of FOAM
+   ClassDefOverride(TFoamIntegrand,1); //n-dimensional real positive integrand of FOAM
 };
 
 #endif

--- a/math/foam/inc/TFoamMaxwt.h
+++ b/math/foam/inc/TFoamMaxwt.h
@@ -22,13 +22,13 @@ public:
    TFoamMaxwt();                            // NOT IMPLEMENTED (NEVER USED)
    TFoamMaxwt(Double_t, Int_t);             // Principal Constructor
    TFoamMaxwt(TFoamMaxwt &From);            // Copy constructor
-   virtual ~TFoamMaxwt();                   // Destructor
+   ~TFoamMaxwt() override;                   // Destructor
    void Reset();                            // Reset
    TFoamMaxwt& operator=(const TFoamMaxwt &);    // operator =
    void Fill(Double_t);
    void Make(Double_t, Double_t&);
    void GetMCeff(Double_t, Double_t&, Double_t&);  // get MC efficiency= <w>/wmax
 
-   ClassDef(TFoamMaxwt,1); //Controlling of the MC weight (maximum weight)
+   ClassDefOverride(TFoamMaxwt,1); //Controlling of the MC weight (maximum weight)
 };
 #endif

--- a/math/foam/inc/TFoamSampler.h
+++ b/math/foam/inc/TFoamSampler.h
@@ -45,13 +45,13 @@ public:
 
 
    /// virtual destructor
-   virtual ~TFoamSampler();
+   ~TFoamSampler() override;
 
 
    using DistSampler::SetFunction;
 
    /// set the parent function distribution to use for random sampling (one dim case)
-   void SetFunction(const ROOT::Math::IGenFunction & func)  {
+   void SetFunction(const ROOT::Math::IGenFunction & func) override  {
       fFunc1D = &func;
       SetFunction<const ROOT::Math::IGenFunction>(func, 1);
    }
@@ -63,38 +63,38 @@ public:
    /**
       initialize the generators with the default options
    */
-   bool Init(const char * = "");
+   bool Init(const char * = "") override;
 
    /**
       initialize the generators with the given options
    */
-   bool Init(const ROOT::Math::DistSamplerOptions & opt );
+   bool Init(const ROOT::Math::DistSamplerOptions & opt ) override;
 
    /**
        Set the random engine to be used
        Needs to be called before Init to have effect
    */
-   void SetRandom(TRandom * r);
+   void SetRandom(TRandom * r) override;
 
    /**
        Set the random seed for the TRandom instances used by the sampler
        classes
        Needs to be called before Init to have effect
    */
-   void SetSeed(unsigned int seed);
+   void SetSeed(unsigned int seed) override;
 
 
    /**
       Get the random engine used by the sampler
     */
-   TRandom * GetRandom();
+   TRandom * GetRandom() override;
 
 
    /**
       sample one event in multi-dimension by filling the given array
       return false if sampling failed
    */
-   bool Sample(double * x);
+   bool Sample(double * x) override;
 
    /**
       sample one bin given an estimated of the pdf in the bin
@@ -102,7 +102,7 @@ public:
       divided by the bin width)
       By default do not do random sample, just return the function values
     */
-   bool SampleBin(double prob, double & value, double *error = 0);
+   bool SampleBin(double prob, double & value, double *error = 0) override;
 
 
 
@@ -120,7 +120,7 @@ private:
    TFoam *                           fFoam;        // foam engine class
    TFoamIntegrand *                  fFoamDist;    // foam distribution interface
 
-   //ClassDef(TFoamSampler,1)  //Distribution sampler class based on FOAM
+   //ClassDefOverride(TFoamSampler,1)  //Distribution sampler class based on FOAM
 
 };
 

--- a/math/foam/inc/TFoamVect.h
+++ b/math/foam/inc/TFoamVect.h
@@ -16,7 +16,7 @@ public:
    TFoamVect();                          // Constructor
    TFoamVect(Int_t);                     // USER Constructor
    TFoamVect(const TFoamVect &);         // Copy constructor
-   virtual ~TFoamVect();                 // Destructor
+   ~TFoamVect() override;                 // Destructor
 
    TFoamVect& operator =(const TFoamVect&);  // = operator; Substitution
    Double_t &operator[](Int_t);              // [] provides POINTER to coordinate
@@ -28,11 +28,11 @@ public:
    TFoamVect& operator*=(const Double_t&);   // *=; mult. by scalar v*=x (FAST)
    TFoamVect  operator+( const  TFoamVect&); // +;  u=v+s, NEVER USE IT, SLOW!!!
    TFoamVect  operator-( const  TFoamVect&); // -;  u=v-s, NEVER USE IT, SLOW!!!
-   void Print(Option_t *option) const;   // Prints vector
+   void Print(Option_t *option) const override;   // Prints vector
    Int_t    GetDim() const { return fDim; }  // Returns dimension
    Double_t GetCoord(Int_t i) const {return fCoords[i];};   // Returns coordinate
 
-   ClassDef(TFoamVect,1) //n-dimensional vector with dynamical allocation
+   ClassDefOverride(TFoamVect,1) //n-dimensional vector with dynamical allocation
 };
 
 #endif

--- a/math/foam/src/TFoam.cxx
+++ b/math/foam/src/TFoam.cxx
@@ -126,10 +126,10 @@ public:
 
    FoamIntegrandFunction(FunctionPtr func) : fFunc(func) {}
 
-   virtual ~FoamIntegrandFunction() {}
+   ~FoamIntegrandFunction() override {}
 
    // evaluate the density using the provided function pointer
-   Double_t Density (Int_t nDim, Double_t * x) {
+   Double_t Density (Int_t nDim, Double_t * x) override {
       return fFunc(nDim,x);
    }
 

--- a/math/foam/src/TFoamSampler.cxx
+++ b/math/foam/src/TFoamSampler.cxx
@@ -51,7 +51,7 @@ public:
    }
    // in principle function does not need to be cloned
 
-   virtual double Density(int ndim, double * x) {
+   double Density(int ndim, double * x) override {
       assert(ndim == (int) fFunc.NDim() );
       for (int i = 0; i < ndim; ++i)
          fX[i] = fMinX[i] + x[i] * fDeltaX[i];

--- a/math/fumili/inc/TFumili.h
+++ b/math/fumili/inc/TFumili.h
@@ -71,47 +71,47 @@ private:
 public:
 
    TFumili(Int_t maxpar=25);
-   virtual  ~TFumili();
+    ~TFumili() override;
 
    void             BuildArrays();
-   virtual Double_t Chisquare(Int_t npar, Double_t *params) const;
-   virtual void     Clear(Option_t *opt="");
+   Double_t Chisquare(Int_t npar, Double_t *params) const override;
+   void     Clear(Option_t *opt="") override;
    void             DeleteArrays();
    void             Derivatives(Double_t*,Double_t*);
    Int_t            Eval(Int_t& npar, Double_t *grad, Double_t &fval, Double_t *par, Int_t flag); // Evaluate the minimisation function
    Double_t         EvalTFN(Double_t *,Double_t*);
-   virtual Int_t    ExecuteCommand(const char *command, Double_t *args, Int_t nargs);
+   Int_t    ExecuteCommand(const char *command, Double_t *args, Int_t nargs) override;
    Int_t            ExecuteSetCommand(Int_t );
    virtual void     FitChisquare(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
    virtual void     FitChisquareI(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
    virtual void     FitLikelihood(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
    virtual void     FitLikelihoodI(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
-   virtual void     FixParameter(Int_t ipar);
-   virtual Double_t *GetCovarianceMatrix() const;
-   virtual Double_t GetCovarianceMatrixElement(Int_t i, Int_t j) const;
-   virtual Int_t    GetErrors(Int_t ipar,Double_t &eplus, Double_t &eminus, Double_t &eparab, Double_t &globcc) const;
-   virtual Int_t    GetNumberTotalParameters() const;
-   virtual Int_t    GetNumberFreeParameters() const;
+   void     FixParameter(Int_t ipar) override;
+   Double_t *GetCovarianceMatrix() const override;
+   Double_t GetCovarianceMatrixElement(Int_t i, Int_t j) const override;
+   Int_t    GetErrors(Int_t ipar,Double_t &eplus, Double_t &eminus, Double_t &eparab, Double_t &globcc) const override;
+   Int_t    GetNumberTotalParameters() const override;
+   Int_t    GetNumberFreeParameters() const override;
    Double_t*        GetPL0() const { return fPL0;}
-   virtual Double_t GetParError(Int_t ipar) const;
-   virtual Double_t GetParameter(Int_t ipar) const ;
-   virtual Int_t    GetParameter(Int_t ipar,char *name,Double_t &value,Double_t &verr,Double_t &vlow, Double_t &vhigh) const;
-   virtual const char *GetParName(Int_t ipar) const;
-   virtual Int_t    GetStats(Double_t &amin, Double_t &edm, Double_t &errdef, Int_t &nvpar, Int_t &nparx) const;
-   virtual Double_t GetSumLog(Int_t );
+   Double_t GetParError(Int_t ipar) const override;
+   Double_t GetParameter(Int_t ipar) const override ;
+   Int_t    GetParameter(Int_t ipar,char *name,Double_t &value,Double_t &verr,Double_t &vlow, Double_t &vhigh) const override;
+   const char *GetParName(Int_t ipar) const override;
+   Int_t    GetStats(Double_t &amin, Double_t &edm, Double_t &errdef, Int_t &nvpar, Int_t &nparx) const override;
+   Double_t GetSumLog(Int_t ) override;
    Double_t*        GetZ() const { return fZ;}
    void             InvertZ(Int_t);
-   virtual Bool_t   IsFixed(Int_t ipar) const;
+   Bool_t   IsFixed(Int_t ipar) const override;
    Int_t            Minimize();
-   virtual void     PrintResults(Int_t k,Double_t p) const;
-   virtual void     ReleaseParameter(Int_t ipar);
+   void     PrintResults(Int_t k,Double_t p) const override;
+   void     ReleaseParameter(Int_t ipar) override;
    Int_t            SGZ();
    void             SetData(Double_t *,Int_t,Int_t);
-   virtual void     SetFitMethod(const char *name);
-   virtual Int_t    SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh);
+   void     SetFitMethod(const char *name) override;
+   Int_t    SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh) override;
    void             SetParNumber(Int_t ParNum) { fNpar = ParNum;};
 
-   ClassDef(TFumili,0) //The FUMILI Minimization package
+   ClassDefOverride(TFumili,0) //The FUMILI Minimization package
 };
 
 R__EXTERN TFumili * gFumili;

--- a/math/fumili/inc/TFumiliMinimizer.h
+++ b/math/fumili/inc/TFumiliMinimizer.h
@@ -53,7 +53,7 @@ public:
    /**
       Destructor (no operations)
    */
-   ~TFumiliMinimizer ();
+   ~TFumiliMinimizer () override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -71,16 +71,16 @@ private:
 public:
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
 
    /// set free variable
-   virtual bool SetVariable(unsigned int ivar, const std::string & name, double val, double step);
+   bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
 
    /// set upper/lower limited variable (override if minimizer supports them )
-   virtual bool SetLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double /* lower */, double /* upper */);
+   bool SetLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double /* lower */, double /* upper */) override;
 
 #ifdef LATER
    /// set lower limit variable  (override if minimizer supports them )
@@ -90,55 +90,55 @@ public:
 #endif
 
    /// set fixed variable (override if minimizer supports them )
-   virtual bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */);
+   bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */) override;
 
    /// set the value of an existing variable
-   virtual bool SetVariableValue(unsigned int ivar, double val );
+   bool SetVariableValue(unsigned int ivar, double val ) override;
 
    /// method to perform the minimization
-   virtual  bool Minimize();
+    bool Minimize() override;
 
    /// return minimum function value
-   virtual double MinValue() const { return fMinVal; }
+   double MinValue() const override { return fMinVal; }
 
    /// return expected distance reached from the minimum
-   virtual double Edm() const { return fEdm; }
+   double Edm() const override { return fEdm; }
 
    /// return  pointer to X values at the minimum
-   virtual const double *  X() const { return &fParams.front(); }
+   const double *  X() const override { return &fParams.front(); }
 
    /// return pointer to gradient values at the minimum
-   virtual const double *  MinGradient() const { return 0; } // not available
+   const double *  MinGradient() const override { return 0; } // not available
 
    /// number of function calls to reach the minimum
-   virtual unsigned int NCalls() const { return 0; }
+   unsigned int NCalls() const override { return 0; }
 
    /// this is <= Function().NDim() which is the total
    /// number of variables (free+ constrained ones)
-   virtual unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    /// number of free variables (real dimension of the problem)
    /// this is <= Function().NDim() which is the total
-   virtual unsigned int NFree() const { return fNFree; }
+   unsigned int NFree() const override { return fNFree; }
 
    /// minimizer provides error and error matrix
-   virtual bool ProvidesError() const { return true; }
+   bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   virtual const double * Errors() const { return  &fErrors.front(); }
+   const double * Errors() const override { return  &fErrors.front(); }
 
    /** return covariance matrices elements
        if the variable is fixed the matrix is zero
        The ordering of the variables is the same as in errors
    */
-   virtual double CovMatrix(unsigned int i, unsigned int j) const {
+   double CovMatrix(unsigned int i, unsigned int j) const override {
       return fCovar[i + fDim* j];
    }
 
    /*
      return covariance matrix status
    */
-   virtual int CovMatrixStatus() const {
+   int CovMatrixStatus() const override {
       if (fCovar.size() == 0) return 0;
       return (fStatus ==0) ? 3 : 1;
    }

--- a/math/genetic/inc/Math/GeneticMinimizer.h
+++ b/math/genetic/inc/Math/GeneticMinimizer.h
@@ -64,30 +64,30 @@ public:
 
    //GeneticMinimizer (int = 0);
    GeneticMinimizer (int i = 0);
-   virtual ~GeneticMinimizer ();
+   ~GeneticMinimizer () override;
 
-   virtual void Clear();
+   void Clear() override;
    using ROOT::Math::Minimizer::SetFunction;
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
-   virtual bool SetLimitedVariable(unsigned int , const std::string& , double , double , double, double);
-   virtual bool SetVariable(unsigned int ivar, const std::string & name, double val, double step);
-   virtual bool SetFixedVariable(unsigned int ivar  , const std::string & name , double val);
+   bool SetLimitedVariable(unsigned int , const std::string& , double , double , double, double) override;
+   bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
+   bool SetFixedVariable(unsigned int ivar  , const std::string & name , double val) override;
 
-   virtual  bool Minimize();
-   virtual double MinValue() const;
-   virtual double Edm() const;
-   virtual const double *  X() const;
-   virtual const double *  MinGradient() const;
-   virtual unsigned int NCalls() const;
+    bool Minimize() override;
+   double MinValue() const override;
+   double Edm() const override;
+   const double *  X() const override;
+   const double *  MinGradient() const override;
+   unsigned int NCalls() const override;
 
-   virtual unsigned int NDim() const;
-   virtual unsigned int NFree() const;
+   unsigned int NDim() const override;
+   unsigned int NFree() const override;
 
-   virtual bool ProvidesError() const;
-   virtual const double * Errors() const;
+   bool ProvidesError() const override;
+   const double * Errors() const override;
 
-   virtual double CovMatrix(unsigned int i, unsigned int j) const;
+   double CovMatrix(unsigned int i, unsigned int j) const override;
 
    void SetParameters(const GeneticMinimizerParameters & params );
 
@@ -95,7 +95,7 @@ public:
 
    const GeneticMinimizerParameters & MinimizerParameters() const { return fParameters; }
 
-   virtual ROOT::Math::MinimizerOptions Options() const;
+   ROOT::Math::MinimizerOptions Options() const override;
 
    virtual void SetOptions(const ROOT::Math::MinimizerOptions & opt);
 

--- a/math/genvector/inc/Math/GenVector/BitReproducible.h
+++ b/math/genvector/inc/Math/GenVector/BitReproducible.h
@@ -31,7 +31,7 @@ class BitReproducibleException  : public std::exception
 {
 public:
   BitReproducibleException(const std::string & w) noexcept : fMsg(w) {}
-  ~BitReproducibleException() noexcept {}
+  ~BitReproducibleException() noexcept override {}
   const char *what() const noexcept override { return fMsg.c_str(); }
   private:
   std::string fMsg;

--- a/math/mathcore/inc/Fit/BinData.h
+++ b/math/mathcore/inc/Fit/BinData.h
@@ -102,7 +102,7 @@ public :
    /**
       destructor
    */
-   virtual ~BinData();
+   ~BinData() override;
 
    /**
       copy constructors

--- a/math/mathcore/inc/Fit/FcnAdapter.h
+++ b/math/mathcore/inc/Fit/FcnAdapter.h
@@ -33,11 +33,11 @@ public:
       fFCN(fcn)
    {}
 
-   virtual ~FcnAdapter() {}
+   ~FcnAdapter() override {}
 
-   virtual  unsigned int NDim() const { return fDim; }
+    unsigned int NDim() const override { return fDim; }
 
-   ROOT::Math::IMultiGenFunction * Clone() const {
+   ROOT::Math::IMultiGenFunction * Clone() const override {
       return new FcnAdapter(fFCN,fDim);
    }
 
@@ -45,7 +45,7 @@ public:
 
 private:
 
-   virtual double DoEval(const double * x) const {
+   double DoEval(const double * x) const override {
       double fval = 0;
       int dim = fDim;
       // call with flag 4

--- a/math/mathcore/inc/Fit/SparseData.h
+++ b/math/mathcore/inc/Fit/SparseData.h
@@ -32,7 +32,7 @@ namespace ROOT {
          SparseData(const unsigned int dim, double min[], double max[]);
 
          //Destructor
-         ~SparseData();
+         ~SparseData() override;
 
          //Returns the number of points stored
          unsigned int NPoints() const;

--- a/math/mathcore/inc/Fit/UnBinData.h
+++ b/math/mathcore/inc/Fit/UnBinData.h
@@ -183,7 +183,7 @@ public:
   /**
     destructor, delete pointer to internal data or external data wrapper
   */
-  virtual ~UnBinData() {
+  ~UnBinData() override {
   }
 
   /**

--- a/math/mathcore/inc/Math/AdaptiveIntegratorMultiDim.h
+++ b/math/mathcore/inc/Math/AdaptiveIntegratorMultiDim.h
@@ -110,13 +110,13 @@ public:
    /**
       destructor (no operations)
     */
-   virtual ~AdaptiveIntegratorMultiDim() {}
+   ~AdaptiveIntegratorMultiDim() override {}
 
 
    /**
       evaluate the integral with the previously given function between xmin[] and xmax[]
    */
-   double Integral(const double* xmin, const double * xmax) {
+   double Integral(const double* xmin, const double * xmax) override {
       return DoIntegral(xmin,xmax, false);
    }
 
@@ -125,13 +125,13 @@ public:
    double Integral(const IMultiGenFunction &f, const double* xmin, const double * xmax);
 
    /// set the integration function (must implement multi-dim function interface: IBaseFunctionMultiDim)
-   void SetFunction(const IMultiGenFunction &f);
+   void SetFunction(const IMultiGenFunction &f) override;
 
    /// return result of integration
-   double Result() const { return fResult; }
+   double Result() const override { return fResult; }
 
    /// return integration error
-   double Error() const { return fError; }
+   double Error() const override { return fError; }
 
    /// return relative error
    double RelError() const { return fRelError; }
@@ -146,16 +146,16 @@ public:
    ///    size is too small for the specified number MAXPTS of function evaluations.
    ///  - status = 3
    ///    wrong dimension , N<2 or N > 15. Returned result and error are zero
-   int Status() const { return fStatus; }
+   int Status() const override { return fStatus; }
 
    /// return number of function evaluations in calculating the integral
-   int NEval() const { return fNEval; }
+   int NEval() const override { return fNEval; }
 
    /// set relative tolerance
-   void SetRelTolerance(double relTol);
+   void SetRelTolerance(double relTol) override;
 
    /// set absolute tolerance
-   void SetAbsTolerance(double absTol);
+   void SetAbsTolerance(double absTol) override;
 
    ///set workspace size
    void SetSize(unsigned int size) { fSize = size; }
@@ -167,10 +167,10 @@ public:
    void SetMaxPts(unsigned int n) { fMaxPts = n; }
 
    /// set the options
-   void SetOptions(const ROOT::Math::IntegratorMultiDimOptions & opt);
+   void SetOptions(const ROOT::Math::IntegratorMultiDimOptions & opt) override;
 
    ///  get the option used for the integration
-   ROOT::Math::IntegratorMultiDimOptions Options() const;
+   ROOT::Math::IntegratorMultiDimOptions Options() const override;
 
 protected:
 

--- a/math/mathcore/inc/Math/BasicMinimizer.h
+++ b/math/mathcore/inc/Math/BasicMinimizer.h
@@ -64,7 +64,7 @@ public:
    /**
       Destructor
    */
-   virtual ~BasicMinimizer ();
+   ~BasicMinimizer () override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -85,64 +85,64 @@ private:
 public:
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
    /// set gradient the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
 
    /// set free variable
-   virtual bool SetVariable(unsigned int ivar, const std::string & name, double val, double step);
+   bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
 
 
    /// set lower limit variable  (override if minimizer supports them )
-   virtual bool SetLowerLimitedVariable(unsigned int  ivar , const std::string & name , double val , double step , double lower );
+   bool SetLowerLimitedVariable(unsigned int  ivar , const std::string & name , double val , double step , double lower ) override;
    /// set upper limit variable (override if minimizer supports them )
-   virtual bool SetUpperLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double upper );
+   bool SetUpperLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double upper ) override;
    /// set upper/lower limited variable (override if minimizer supports them )
-   virtual bool SetLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double /* lower */, double /* upper */);
+   bool SetLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double /* lower */, double /* upper */) override;
    /// set fixed variable (override if minimizer supports them )
-   virtual bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */);
+   bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */) override;
    /// set the value of an existing variable
-   virtual bool SetVariableValue(unsigned int ivar, double val );
+   bool SetVariableValue(unsigned int ivar, double val ) override;
    /// set the values of all existing variables (array must be dimensioned to the size of existing parameters)
-   virtual bool SetVariableValues(const double * x);
+   bool SetVariableValues(const double * x) override;
    /// set the step size of an already existing variable
-   virtual bool SetVariableStepSize(unsigned int ivar, double step );
+   bool SetVariableStepSize(unsigned int ivar, double step ) override;
    /// set the lower-limit of an already existing variable
-   virtual bool SetVariableLowerLimit(unsigned int ivar, double lower);
+   bool SetVariableLowerLimit(unsigned int ivar, double lower) override;
    /// set the upper-limit of an already existing variable
-   virtual bool SetVariableUpperLimit(unsigned int ivar, double upper);
+   bool SetVariableUpperLimit(unsigned int ivar, double upper) override;
    /// set the limits of an already existing variable
-   virtual bool SetVariableLimits(unsigned int ivar, double lower, double upper);
+   bool SetVariableLimits(unsigned int ivar, double lower, double upper) override;
    /// fix an existing variable
-   virtual bool FixVariable(unsigned int ivar);
+   bool FixVariable(unsigned int ivar) override;
    /// release an existing variable
-   virtual bool ReleaseVariable(unsigned int ivar);
+   bool ReleaseVariable(unsigned int ivar) override;
    /// query if an existing variable is fixed (i.e. considered constant in the minimization)
    /// note that by default all variables are not fixed
-   virtual bool IsFixedVariable(unsigned int ivar)  const;
+   bool IsFixedVariable(unsigned int ivar)  const override;
    /// get variable settings in a variable object (like ROOT::Fit::ParamsSettings)
-   virtual bool GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings & varObj) const;
+   bool GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings & varObj) const override;
    /// get name of variables (override if minimizer support storing of variable names)
-   virtual std::string VariableName(unsigned int ivar) const;
+   std::string VariableName(unsigned int ivar) const override;
    /// get index of variable given a variable given a name
    /// return -1 if variable is not found
-   virtual int VariableIndex(const std::string & name) const;
+   int VariableIndex(const std::string & name) const override;
 
    /// method to perform the minimization
-   virtual  bool Minimize();
+    bool Minimize() override;
 
    /// return minimum function value
-   virtual double MinValue() const { return fMinVal; }
+   double MinValue() const override { return fMinVal; }
 
    /// return  pointer to X values at the minimum
-   virtual const double *  X() const { return &fValues.front(); }
+   const double *  X() const override { return &fValues.front(); }
 
    /// number of dimensions
-   virtual unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    /// number of free variables (real dimension of the problem)
-   virtual unsigned int NFree() const;
+   unsigned int NFree() const override;
 
    /// total number of parameter defined
    virtual unsigned int NPar() const { return fValues.size(); }

--- a/math/mathcore/inc/Math/BrentMinimizer1D.h
+++ b/math/mathcore/inc/Math/BrentMinimizer1D.h
@@ -78,27 +78,27 @@ namespace Math {
       BrentMinimizer1D();
 
       /** Default Destructor. */
-      virtual ~BrentMinimizer1D() {}
+      ~BrentMinimizer1D() override {}
 
    public:
 
       /** Return current estimate of the position of the minimum. */
-      virtual double XMinimum() const {   return fXMinimum;  }
+      double XMinimum() const override {   return fXMinimum;  }
 
       /** Return current lower bound of the minimization interval. */
-      virtual double XLower() const {   return fXMin;  }
+      double XLower() const override {   return fXMin;  }
 
       /** Return current upper bound of the minimization interval. */
-      virtual double XUpper() const {   return fXMax;  }
+      double XUpper() const override {   return fXMax;  }
 
       /** Return function value at current estimate of the minimum. */
-      virtual double FValMinimum() const;
+      double FValMinimum() const override;
 
       /** Return function value at current lower bound of the minimization interval. */
-      virtual double FValLower() const;
+      double FValLower() const override;
 
       /** Return function value at current upper bound of the minimization interval. */
-      virtual double FValUpper() const;
+      double FValUpper() const override;
 
       /** Find minimum position iterating until convergence specified by the absolute and relative tolerance or
           the maximum number of iteration is reached.
@@ -107,13 +107,13 @@ namespace Math {
           \@param absTol desired absolute error in the minimum position (default 1.E-8)
           \@param absTol desired relative error in the minimum position (default = 1.E-10)
       */
-      virtual bool Minimize( int maxIter, double absTol = 1.E-8, double relTol = 1.E-10);
+      bool Minimize( int maxIter, double absTol = 1.E-8, double relTol = 1.E-10) override;
 
       /** Return number of iteration used to find minimum */
-      virtual int Iterations() const { return fNIter; }
+      int Iterations() const override { return fNIter; }
 
       /** Return name of minimization algorithm ("BrentMinimizer1D") */
-      virtual const char * Name() const;
+      const char * Name() const override;
 
       /** Sets function to be minimized.
 
@@ -134,7 +134,7 @@ namespace Math {
 
 
       /** Returns status of last estimate. If = 0 is OK */
-      int Status() const { return fStatus; }
+      int Status() const override { return fStatus; }
 
       // static function used to modify the default parameters
 

--- a/math/mathcore/inc/Math/BrentRootFinder.h
+++ b/math/mathcore/inc/Math/BrentRootFinder.h
@@ -68,7 +68,7 @@ namespace Math {
 
 
       /** Default Destructor. */
-      virtual ~BrentRootFinder() {}
+      ~BrentRootFinder() override {}
 
 
       /** Set function to solve and the interval in where to look for the root.
@@ -78,7 +78,7 @@ namespace Math {
           \@param xup Upper bound of the search interval.
       */
       using IRootFinderMethod::SetFunction;
-      bool SetFunction(const ROOT::Math::IGenFunction& f, double xlow, double xup);
+      bool SetFunction(const ROOT::Math::IGenFunction& f, double xlow, double xup) override;
 
 
       /** Returns the X value corresponding to the function value fy for (xmin<x<xmax).
@@ -94,7 +94,7 @@ namespace Math {
           \@param absTol desired absolute error in the minimum position.
           \@param absTol desired relative error in the minimum position.
       */
-      bool Solve(int maxIter = 100, double absTol = 1E-8, double relTol = 1E-10);
+      bool Solve(int maxIter = 100, double absTol = 1E-8, double relTol = 1E-10) override;
 
       /** Set the number of point used to bracket root using a grid */
       void SetNpx(int npx) { fNpx = npx; }
@@ -106,16 +106,16 @@ namespace Math {
       void SetLogScan(bool on) { fLogScan = on; }
 
       /** Returns root value. Need to call first Solve(). */
-      double Root() const { return fRoot; }
+      double Root() const override { return fRoot; }
 
       /** Returns status of last estimate. If = 0 is OK */
-      int Status() const { return fStatus; }
+      int Status() const override { return fStatus; }
 
       /** Return number of iteration used to find minimum */
-      int Iterations() const { return fNIter; }
+      int Iterations() const override { return fNIter; }
 
       /** Return name of root finder algorithm ("BrentRootFinder"). */
-      const char* Name() const;
+      const char* Name() const override;
 
       // static function used to modify the default parameters
 

--- a/math/mathcore/inc/Math/GaussIntegrator.h
+++ b/math/mathcore/inc/Math/GaussIntegrator.h
@@ -43,7 +43,7 @@ class GaussIntegrator: public VirtualIntegratorOneDim {
 public:
 
    /** Destructor */
-   virtual ~GaussIntegrator();
+   ~GaussIntegrator() override;
 
    /** Default Constructor.
        If the tolerance are not given, use default values specified in  ROOT::Math::IntegratorOneDimOptions
@@ -62,19 +62,19 @@ public:
    // Implementing VirtualIntegrator Interface
 
    /** Set the desired relative Error. */
-   virtual void SetRelTolerance (double eps) { fEpsRel = eps; }
+   void SetRelTolerance (double eps) override { fEpsRel = eps; }
 
    /** This method is not implemented. */
-   virtual void SetAbsTolerance (double eps) { fEpsAbs = eps; }
+   void SetAbsTolerance (double eps) override { fEpsAbs = eps; }
 
    /** Returns the result of the last Integral calculation. */
-   double Result () const;
+   double Result () const override;
 
    /** Return the estimate of the absolute Error of the last Integral calculation. */
-   double Error () const;
+   double Error () const override;
 
    /** return the status of the last integration - 0 in case of success */
-   int Status () const;
+   int Status () const override;
 
    // Implementing VirtualIntegratorOneDim Interface
 
@@ -146,7 +146,7 @@ public:
       required. The subprogram may therefore be used when these values are
       undefined
    */
-   double Integral (double a, double b);
+   double Integral (double a, double b) override;
 
    /** Returns Integral of function on an infinite interval.
       This function computes, to an attempted specified accuracy, the value of the integral:
@@ -159,7 +159,7 @@ public:
 
       The integral is mapped onto [0,1] using a transformation then integral computation is surrogated to DoIntegral.
    */
-   double Integral ();
+   double Integral () override;
 
    /** Returns Integral of function on an upper semi-infinite interval.
       This function computes, to an attempted specified accuracy, the value of the integral:
@@ -173,7 +173,7 @@ public:
 
       The integral is mapped onto [0,1] using a transformation then integral computation is surrogated to DoIntegral.
    */
-   double IntegralUp (double a);
+   double IntegralUp (double a) override;
 
    /** Returns Integral of function on a lower semi-infinite interval.
        This function computes, to an attempted specified accuracy, the value of the integral:
@@ -187,25 +187,25 @@ public:
 
       The integral is mapped onto [0,1] using a transformation then integral computation is surrogated to DoIntegral.
    */
-   double IntegralLow (double b);
+   double IntegralLow (double b) override;
 
 
    /** Set integration function (flag control if function must be copied inside).
        \@param f Function to be used in the calculations.
    */
-   void SetFunction (const IGenFunction &);
+   void SetFunction (const IGenFunction &) override;
 
    /** This method is not implemented. */
-   double Integral (const std::vector< double > &pts);
+   double Integral (const std::vector< double > &pts) override;
 
    /** This method is not implemented. */
-   double IntegralCauchy (double a, double b, double c);
+   double IntegralCauchy (double a, double b, double c) override;
 
    ///  get the option used for the integration
-   virtual ROOT::Math::IntegratorOneDimOptions Options() const;
+   ROOT::Math::IntegratorOneDimOptions Options() const override;
 
    // set the options
-   virtual void SetOptions(const ROOT::Math::IntegratorOneDimOptions & opt);
+   void SetOptions(const ROOT::Math::IntegratorOneDimOptions & opt) override;
 
 private:
 
@@ -237,8 +237,8 @@ public:
    IntegrandTransform(const IGenFunction* integrand);
    IntegrandTransform(const double boundary, ESemiInfinitySign sign, const IGenFunction* integrand);
    double operator()(double x) const;
-   double DoEval(double x) const;
-   IGenFunction* Clone() const;
+   double DoEval(double x) const override;
+   IGenFunction* Clone() const override;
 private:
    ESemiInfinitySign fSign;
    const IGenFunction* fIntegrand;

--- a/math/mathcore/inc/Math/GaussLegendreIntegrator.h
+++ b/math/mathcore/inc/Math/GaussLegendreIntegrator.h
@@ -44,17 +44,17 @@ public:
    GaussLegendreIntegrator(int num = 10 ,double eps=1e-12);
 
    /** Default Destructor */
-   virtual ~GaussLegendreIntegrator();
+   ~GaussLegendreIntegrator() override;
 
    /** Set the number of points used in the calculation of the
        integral */
    void SetNumberPoints(int num);
 
    /** Set the desired relative Error. */
-   virtual void SetRelTolerance (double);
+   void SetRelTolerance (double) override;
 
    /** This method is not implemented. */
-   virtual void SetAbsTolerance (double);
+   void SetAbsTolerance (double) override;
 
 
    /** Returns the arrays x and w containing the abscissa and weight of
@@ -71,14 +71,14 @@ public:
        return number of function evaluations in calculating the integral
        This is equivalent to the number of points
    */
-   int NEval() const { return fNum; }
+   int NEval() const override { return fNum; }
 
 
    ///  get the option used for the integration
-   virtual ROOT::Math::IntegratorOneDimOptions Options() const;
+   ROOT::Math::IntegratorOneDimOptions Options() const override;
 
    // set the options
-   virtual void SetOptions(const ROOT::Math::IntegratorOneDimOptions & opt);
+   void SetOptions(const ROOT::Math::IntegratorOneDimOptions & opt) override;
 
 private:
 
@@ -86,7 +86,7 @@ private:
       Integration surrogate method. Return integral of passed function in  interval [a,b]
       Reimplement method of GaussIntegrator using CalcGaussLegendreSamplingPoints
    */
-   virtual double DoIntegral (double a, double b, const IGenFunction* func);
+   double DoIntegral (double a, double b, const IGenFunction* func) override;
 
    /**
       Type: unsafe but fast interface filling the arrays x and w (static method)

--- a/math/mathcore/inc/Math/GenAlgoOptions.h
+++ b/math/mathcore/inc/Math/GenAlgoOptions.h
@@ -35,7 +35,7 @@ public:
 
    GenAlgoOptions() /* : fExtraOptions(0) */  {}
 
-   virtual ~GenAlgoOptions() {}// { if (fExtraOptions) delete fExtraOptions; }
+   ~GenAlgoOptions() override {}// { if (fExtraOptions) delete fExtraOptions; }
 
    // use default copy constructor and assignment operator
 
@@ -44,28 +44,28 @@ public:
 
    // methods implementing the  IOptions interface
 
-   virtual IOptions * Clone() const {
+   IOptions * Clone() const override {
       return new GenAlgoOptions(*this);
    }
 
    // t.b.d need probably to implement in a .cxx file for CINT
 
 
-   virtual bool GetRealValue(const char * name, double & val) const {
+   bool GetRealValue(const char * name, double & val) const override {
       const double * pval = FindValue(name, fRealOpts);
       if (!pval) return false;
       val = *pval;
       return true;
    }
 
-   virtual bool GetIntValue(const char * name, int & val) const {
+   bool GetIntValue(const char * name, int & val) const override {
       const int * pval = FindValue(name, fIntOpts);
       if (!pval) return false;
       val = *pval;
       return true;
    }
 
-   virtual bool GetNamedValue(const char * name, std::string & val) const {
+   bool GetNamedValue(const char * name, std::string & val) const override {
       const std::string * pval = FindValue(name, fNamOpts);
       if (!pval) return false;
       val = *pval;
@@ -73,15 +73,15 @@ public:
    }
 
    /// method wich need to be re-implemented by the derived classes
-   virtual void SetRealValue(const char * name, double val)  {
+   void SetRealValue(const char * name, double val) override  {
       InsertValue(name, fRealOpts, val);
    }
 
-   virtual void SetIntValue(const char * name , int val) {
+   void SetIntValue(const char * name , int val) override {
       InsertValue(name, fIntOpts, val);
    }
 
-   virtual void SetNamedValue(const char * name, const char * val) {
+   void SetNamedValue(const char * name, const char * val) override {
       InsertValue(name, fNamOpts, std::string(val));
    }
 
@@ -111,7 +111,7 @@ public:
    }
 
    /// print options
-   virtual void Print(std::ostream & os = std::cout ) const {
+   void Print(std::ostream & os = std::cout ) const override {
       Print(fNamOpts,os);
       Print(fIntOpts,os);
       Print(fRealOpts,os);

--- a/math/mathcore/inc/Math/IFunction.h
+++ b/math/mathcore/inc/Math/IFunction.h
@@ -418,7 +418,7 @@ namespace ROOT {
          /**
              Virtual Destructor (no operations)
          */
-         virtual ~IGradientFunctionOneDim() {}
+         ~IGradientFunctionOneDim() override {}
 
 
          /**
@@ -428,7 +428,7 @@ namespace ROOT {
              evaluate value and derivative at the same time
 
          */
-         virtual void FdF(double x, double &f, double &df) const
+         void FdF(double x, double &f, double &df) const override
          {
             f = operator()(x);
             df = Derivative(x);

--- a/math/mathcore/inc/Math/IParamFunction.h
+++ b/math/mathcore/inc/Math/IParamFunction.h
@@ -197,7 +197,7 @@ namespace ROOT {
          /**
             Implement the ROOT::Math::IBaseFunctionOneDim interface DoEval(x) using the cached parameter values
          */
-         virtual double DoEval(double x) const
+         double DoEval(double x) const override
          {
             return DoEvalPar(x, Parameters());
          }
@@ -232,7 +232,7 @@ namespace ROOT {
          /**
             Virtual Destructor (no operations)
          */
-         virtual ~IParametricGradFunctionMultiDimTempl()  {}
+         ~IParametricGradFunctionMultiDimTempl() override  {}
 
 
          /* Reimplementation instead of using BaseParamFunc::operator();
@@ -284,8 +284,8 @@ namespace ROOT {
             Evaluate the partial derivative w.r.t a parameter ipar , to be implemented by the derived classes
           */
          virtual T DoParameterDerivative(const T *x, const double *p, unsigned int ipar) const = 0;
-         virtual T DoEvalPar(const T *x, const double *p) const = 0;
-         virtual T DoEval(const T *x) const
+         virtual T DoEvalPar(const T *x, const double *p) const override = 0;
+         virtual T DoEval(const T *x) const override
          {
             return DoEvalPar(x, Parameters());
          }
@@ -320,7 +320,7 @@ namespace ROOT {
          /**
             Virtual Destructor (no operations)
          */
-         virtual ~IParametricGradFunctionOneDim()  {}
+         ~IParametricGradFunctionOneDim() override  {}
 
 
          using BaseParamFunc::operator();

--- a/math/mathcore/inc/Math/IntegratorOptions.h
+++ b/math/mathcore/inc/Math/IntegratorOptions.h
@@ -119,7 +119,7 @@ public:
    /// can pass a pointer to extra options (N.B. pointer will be managed by the class)
    IntegratorOneDimOptions(IOptions * extraOpts = 0);
 
-   virtual ~IntegratorOneDimOptions() {}
+   ~IntegratorOneDimOptions() override {}
 
    /// copy constructor
    IntegratorOneDimOptions(const IntegratorOneDimOptions & rhs) :
@@ -143,7 +143,7 @@ public:
    unsigned int NPoints() const { return fNCalls; }
 
    /// name of 1D integrator
-   std::string  Integrator() const;
+   std::string  Integrator() const override;
 
    /// type of the integrator (return the enumeration type)
    IntegrationOneDim::Type IntegratorType() const { return (IntegrationOneDim::Type) fIntegType; }
@@ -200,7 +200,7 @@ public:
    /// can pass a pointer to extra options (N.B. pointer will be managed by the class)
    IntegratorMultiDimOptions(IOptions * extraOpts = 0);
 
-   virtual ~IntegratorMultiDimOptions() {}
+   ~IntegratorMultiDimOptions() override {}
 
    /// copy constructor
    IntegratorMultiDimOptions(const IntegratorMultiDimOptions & rhs) :
@@ -222,7 +222,7 @@ public:
    unsigned int NCalls() const { return fNCalls; }
 
    /// name of multi-dim integrator
-   std::string  Integrator() const;
+   std::string  Integrator() const override;
 
    /// type of the integrator (return the enumeration type)
    IntegrationMultiDim::Type IntegratorType() const { return (IntegrationMultiDim::Type) fIntegType; }

--- a/math/mathcore/inc/Math/LCGEngine.h
+++ b/math/mathcore/inc/Math/LCGEngine.h
@@ -41,11 +41,11 @@ namespace ROOT {
 
          LCGEngine() : fSeed(65539) { }
 
-         virtual ~LCGEngine() {}
+         ~LCGEngine() override {}
 
          void SetSeed(uint32_t seed) { fSeed = seed; }
 
-         virtual double Rndm() {
+         double Rndm() override {
             //double Rndm() {
             return Rndm_impl();
          }

--- a/math/mathcore/inc/Math/MersenneTwisterEngine.h
+++ b/math/mathcore/inc/Math/MersenneTwisterEngine.h
@@ -61,11 +61,11 @@ namespace ROOT {
             SetSeed(seed);
          }
 
-         virtual ~MersenneTwisterEngine() {}
+         ~MersenneTwisterEngine() override {}
 
          void SetSeed(Result_t seed);
 
-         virtual double Rndm() {
+         double Rndm() override {
             return Rndm_impl();
          }
          inline double operator() () { return Rndm_impl(); }

--- a/math/mathcore/inc/Math/MinimTransformFunction.h
+++ b/math/mathcore/inc/Math/MinimTransformFunction.h
@@ -57,19 +57,19 @@ public:
    /**
       Destructor (delete function pointer)
    */
-   ~MinimTransformFunction ()  {
+   ~MinimTransformFunction () override  {
       if (fFunc) delete fFunc;
    }
 
 
    // method inherited from IFunction interface
 
-   unsigned int NDim() const { return fIndex.size(); }
+   unsigned int NDim() const override { return fIndex.size(); }
 
    unsigned int NTot() const { return fFunc->NDim(); }
 
    /// clone:  not supported (since unique_ptr used in the fVariables)
-   IMultiGenFunction * Clone() const {
+   IMultiGenFunction * Clone() const override {
       return 0;
    }
 
@@ -105,7 +105,7 @@ public:
 private:
 
    /// function evaluation
-   virtual double DoEval(const double * x) const {
+   double DoEval(const double * x) const override {
 #ifndef DO_THREADSAFE
       return (*fFunc)(Transformation(x));
 #else
@@ -116,7 +116,7 @@ private:
    }
 
    /// calculate derivatives
-   virtual double DoDerivative (const double * x, unsigned int icoord  ) const {
+   double DoDerivative (const double * x, unsigned int icoord  ) const override {
       const MinimTransformVariable & var = fVariables[ fIndex[icoord] ];
       double dExtdInt = (var.IsLimited() ) ? var.DerivativeIntToExt( x[icoord] ) : 1.0;
       double deriv =  fFunc->Derivative( Transformation(x) , fIndex[icoord] );

--- a/math/mathcore/inc/Math/MinimizerVariableTransformation.h
+++ b/math/mathcore/inc/Math/MinimizerVariableTransformation.h
@@ -39,11 +39,11 @@ class SinVariableTransformation : public MinimizerVariableTransformation {
 
 public:
 
-   virtual ~SinVariableTransformation() {}
+   ~SinVariableTransformation() override {}
 
-   double Int2ext(double value, double lower, double upper) const;
-   double Ext2int(double value, double lower, double upper) const;
-   double DInt2Ext(double value, double lower, double upper) const;
+   double Int2ext(double value, double lower, double upper) const override;
+   double Ext2int(double value, double lower, double upper) const override;
+   double DInt2Ext(double value, double lower, double upper) const override;
 
 private:
 
@@ -58,11 +58,11 @@ private:
 class SqrtLowVariableTransformation : public  MinimizerVariableTransformation {
 public:
 
-   virtual ~SqrtLowVariableTransformation() {}
+   ~SqrtLowVariableTransformation() override {}
 
-   double Int2ext(double value, double lower, double upper) const;
-   double Ext2int(double value, double lower, double upper) const;
-   double DInt2Ext(double value, double lower, double upper) const;
+   double Int2ext(double value, double lower, double upper) const override;
+   double Ext2int(double value, double lower, double upper) const override;
+   double DInt2Ext(double value, double lower, double upper) const override;
 
 };
 
@@ -74,11 +74,11 @@ public:
 class SqrtUpVariableTransformation : public  MinimizerVariableTransformation {
 public:
 
-   virtual ~SqrtUpVariableTransformation() {}
+   ~SqrtUpVariableTransformation() override {}
 
-   double Int2ext(double value, double lower, double upper) const;
-   double Ext2int(double value, double lower, double upper) const;
-   double DInt2Ext(double value, double lower, double upper) const;
+   double Int2ext(double value, double lower, double upper) const override;
+   double Ext2int(double value, double lower, double upper) const override;
+   double DInt2Ext(double value, double lower, double upper) const override;
 
 };
 

--- a/math/mathcore/inc/Math/MixMaxEngine.h
+++ b/math/mathcore/inc/Math/MixMaxEngine.h
@@ -116,7 +116,7 @@ http://dx.doi.org/10.1016/j.chaos.2016.05.003
 
          MixMaxEngine(uint64_t seed=1);
 
-         virtual ~MixMaxEngine();
+         ~MixMaxEngine() override;
 
 
          /// Get the size of the generator
@@ -132,7 +132,7 @@ http://dx.doi.org/10.1016/j.chaos.2016.05.003
          void  SetSeed(Result_t seed);
 
          // generate a random number (virtual interface)
-         virtual double Rndm() { return Rndm_impl(); }
+         double Rndm() override { return Rndm_impl(); }
 
          /// generate a double random number (faster interface)
          inline double operator() () { return Rndm_impl(); }

--- a/math/mathcore/inc/Math/MultiDimParamFunctionAdapter.h
+++ b/math/mathcore/inc/Math/MultiDimParamFunctionAdapter.h
@@ -81,7 +81,7 @@ namespace ROOT {
          /**
             Destructor (no operations)
          */
-         virtual ~MultiDimParamFunctionAdapter()
+         ~MultiDimParamFunctionAdapter() override
          {
             if (fOwn && fFunc != 0) delete fFunc;
          }
@@ -105,7 +105,7 @@ namespace ROOT {
          /**
             clone
          */
-         virtual BaseFunc *Clone() const
+         BaseFunc *Clone() const override
          {
             return new MultiDimParamFunctionAdapter(*this);
          }
@@ -113,22 +113,22 @@ namespace ROOT {
       public:
 
          // methods required by interface
-         const double *Parameters() const
+         const double *Parameters() const override
          {
             return  fFunc->Parameters();
          }
 
-         void SetParameters(const double *p)
+         void SetParameters(const double *p) override
          {
             fFunc->SetParameters(p);
          }
 
-         unsigned int NPar() const
+         unsigned int NPar() const override
          {
             return fFunc->NPar();
          }
 
-         unsigned int NDim() const
+         unsigned int NDim() const override
          {
             return 1;
          }
@@ -137,7 +137,7 @@ namespace ROOT {
       private:
 
          /// needed by the interface
-         double DoEvalPar(const double *x, const double *p) const
+         double DoEvalPar(const double *x, const double *p) const override
          {
             return (*fFunc)(*x, p);
          }
@@ -212,7 +212,7 @@ namespace ROOT {
          /**
             Destructor (no operations)
          */
-         virtual ~MultiDimParamGradFunctionAdapter()
+         ~MultiDimParamGradFunctionAdapter() override
          {
             if (fOwn && fFunc != 0) delete fFunc;
          }
@@ -236,7 +236,7 @@ namespace ROOT {
          /**
             clone
          */
-         virtual BaseFunc *Clone() const
+         BaseFunc *Clone() const override
          {
             return new MultiDimParamGradFunctionAdapter(*this);
          }
@@ -244,22 +244,22 @@ namespace ROOT {
       public:
 
          // methods required by interface
-         const double *Parameters() const
+         const double *Parameters() const override
          {
             return  fFunc->Parameters();
          }
 
-         void SetParameters(const double *p)
+         void SetParameters(const double *p) override
          {
             fFunc->SetParameters(p);
          }
 
-         unsigned int NPar() const
+         unsigned int NPar() const override
          {
             return fFunc->NPar();
          }
 
-         unsigned int NDim() const
+         unsigned int NDim() const override
          {
             return 1;
          }
@@ -268,7 +268,7 @@ namespace ROOT {
 //       grad[0] = fFunc->Derivative( *x);
 //    }
 
-         void ParameterGradient(const double *x, const double *p, double *grad) const
+         void ParameterGradient(const double *x, const double *p, double *grad) const override
          {
             fFunc->ParameterGradient(*x, p, grad);
          }
@@ -278,7 +278,7 @@ namespace ROOT {
       private:
 
          /// functions needed by interface
-         double DoEvalPar(const double *x, const double *p) const
+         double DoEvalPar(const double *x, const double *p) const override
          {
             return (*fFunc)(*x, p);
          }
@@ -287,7 +287,7 @@ namespace ROOT {
 //       return fFunc->Derivative(*x);
 //    }
 
-         double DoParameterDerivative(const double *x, const double *p, unsigned int ipar) const
+         double DoParameterDerivative(const double *x, const double *p, unsigned int ipar) const override
          {
             return fFunc->ParameterDerivative(*x, p, ipar);
          }

--- a/math/mathcore/inc/Math/OneDimFunctionAdapter.h
+++ b/math/mathcore/inc/Math/OneDimFunctionAdapter.h
@@ -92,12 +92,12 @@ public:
    /**
       Destructor (no operations)
    */
-   virtual ~OneDimMultiFunctionAdapter ()  { if (fOwn && fX) delete [] fX; }
+   ~OneDimMultiFunctionAdapter () override  { if (fOwn && fX) delete [] fX; }
 
    /**
       clone
    */
-   virtual OneDimMultiFunctionAdapter * Clone( ) const {
+   OneDimMultiFunctionAdapter * Clone( ) const override {
       if (fOwn) {
          OneDimMultiFunctionAdapter * f =  new OneDimMultiFunctionAdapter( fFunc, fDim, fCoord, fParams);
          std::copy(fX, fX+fDim, f->fX);
@@ -166,7 +166,7 @@ private:
       evaluate function at the  values x[] given in the constructor and
       as function of  the coordinate fCoord.
    */
-   double DoEval(double x) const {
+   double DoEval(double x) const override {
       if (fOwn) {
          fX[fCoord] = x;
          return EvaluatorOneDim<MultiFuncType>::F( fFunc, fX, fParams );
@@ -231,12 +231,12 @@ public:
    /**
       Destructor (no operations)
    */
-   ~OneDimParamFunctionAdapter ()  {}
+   ~OneDimParamFunctionAdapter () override  {}
 
    /**
       clone
    */
-   virtual OneDimParamFunctionAdapter * Clone( ) const {
+   OneDimParamFunctionAdapter * Clone( ) const override {
       return new OneDimParamFunctionAdapter(fFunc, fX, fParams, fIpar);
    }
 
@@ -248,7 +248,7 @@ private:
       evaluate function at the  values x[] given in the constructor and
       as function of  the coordinate fCoord.
    */
-   double DoEval(double x) const {
+   double DoEval(double x) const override {
       // HACK: use const_cast to modify the function values x[] and restore afterwards the original ones
       double * p = const_cast<double *>(fParams);
       double pprev = fParams[fIpar]; // keep original value to restore in fX

--- a/math/mathcore/inc/Math/RanluxppEngine.h
+++ b/math/mathcore/inc/Math/RanluxppEngine.h
@@ -32,7 +32,7 @@ private:
 
 public:
    RanluxppEngine(uint64_t seed = 314159265);
-   virtual ~RanluxppEngine();
+   ~RanluxppEngine() override;
 
    /// Generate a double-precision random number with 48 bits of randomness
    double Rndm() override;
@@ -66,7 +66,7 @@ private:
 
 public:
    RanluxppCompatEngineJames(uint64_t seed = 314159265);
-   virtual ~RanluxppCompatEngineJames();
+   ~RanluxppCompatEngineJames() override;
 
    /// Generate a floating point random number with 24 bits of randomness
    double Rndm() override;
@@ -105,7 +105,7 @@ private:
 
 public:
    RanluxppCompatEngineGslRanlxs(uint64_t seed = 1);
-   virtual ~RanluxppCompatEngineGslRanlxs();
+   ~RanluxppCompatEngineGslRanlxs() override;
 
    /// Generate a floating point random number with 24 bits of randomness
    double Rndm() override;
@@ -142,7 +142,7 @@ private:
 
 public:
    RanluxppCompatEngineGslRanlxd(uint64_t seed = 1);
-   virtual ~RanluxppCompatEngineGslRanlxd();
+   ~RanluxppCompatEngineGslRanlxd() override;
 
    /// Generate a floating point random number with 48 bits of randomness
    double Rndm() override;
@@ -180,7 +180,7 @@ private:
 
 public:
    RanluxppCompatEngineLuescherRanlxs(uint64_t seed = 314159265);
-   virtual ~RanluxppCompatEngineLuescherRanlxs();
+   ~RanluxppCompatEngineLuescherRanlxs() override;
 
    /// Generate a floating point random number with 24 bits of randomness
    double Rndm() override;
@@ -217,7 +217,7 @@ private:
 
 public:
    RanluxppCompatEngineLuescherRanlxd(uint64_t seed = 314159265);
-   virtual ~RanluxppCompatEngineLuescherRanlxd();
+   ~RanluxppCompatEngineLuescherRanlxd() override;
 
    /// Generate a floating point random number with 48 bits of randomness
    double Rndm() override;
@@ -250,7 +250,7 @@ private:
 
 public:
    RanluxppCompatEngineStdRanlux24(uint64_t seed = 19780503);
-   virtual ~RanluxppCompatEngineStdRanlux24();
+   ~RanluxppCompatEngineStdRanlux24() override;
 
    /// Generate a floating point random number with 24 bits of randomness
    double Rndm() override;
@@ -278,7 +278,7 @@ private:
 
 public:
    RanluxppCompatEngineStdRanlux48(uint64_t seed = 19780503);
-   virtual ~RanluxppCompatEngineStdRanlux48();
+   ~RanluxppCompatEngineStdRanlux48() override;
 
    /// Generate a floating point random number with 48 bits of randomness
    double Rndm() override;

--- a/math/mathcore/inc/Math/VirtualIntegrator.h
+++ b/math/mathcore/inc/Math/VirtualIntegrator.h
@@ -103,7 +103,7 @@ class VirtualIntegratorOneDim : public VirtualIntegrator {
 public:
 
    /// destructor: no operation
-   virtual ~VirtualIntegratorOneDim() {}
+   ~VirtualIntegratorOneDim() override {}
 
    /// evaluate integral
    virtual double Integral(double a, double b) = 0;
@@ -162,7 +162,7 @@ class VirtualIntegratorMultiDim : public VirtualIntegrator {
 public:
 
    /// destructor: no operation
-   virtual ~VirtualIntegratorMultiDim() {}
+   ~VirtualIntegratorMultiDim() override {}
 
    /// evaluate multi-dim integral
    virtual double Integral(const double*, const double*)  = 0;

--- a/math/mathcore/inc/Math/WrappedFunction.h
+++ b/math/mathcore/inc/Math/WrappedFunction.h
@@ -68,7 +68,7 @@ class WrappedFunction : public IGenFunction {
    // use default copy constructor and assignment operator
 
    /// clone (required by the interface)
-   WrappedFunction * Clone() const {
+   WrappedFunction * Clone() const override {
       return new WrappedFunction(fFunc);
    }
 
@@ -76,7 +76,7 @@ class WrappedFunction : public IGenFunction {
 
 private:
 
-   virtual double DoEval (double x) const {
+   double DoEval (double x) const override {
       return fFunc( x );
    }
 
@@ -119,14 +119,14 @@ class WrappedMemFunction : public IGenFunction {
    // use default  copy constructor and assignment operator
 
    /// clone (required by the interface)
-   WrappedMemFunction * Clone() const {
+   WrappedMemFunction * Clone() const override {
       return new WrappedMemFunction(*fObj,fMemFunc);
    }
 
 
 private:
 
-   virtual double DoEval (double x) const {
+   double DoEval (double x) const override {
       return ((*fObj).*fMemFunc)( x );
    }
 
@@ -167,17 +167,17 @@ class WrappedMultiFunction : public IMultiGenFunction {
    // use default  copy contructor and assignment operator
 
    /// clone (required by the interface)
-   WrappedMultiFunction * Clone() const {
+   WrappedMultiFunction * Clone() const override {
       return new WrappedMultiFunction(fFunc,fDim);
    }
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    //  virtual ~WrappedFunction() { /**/ }
 
 private:
 
-   virtual double DoEval (const double * x) const {
+   double DoEval (const double * x) const override {
       return fFunc( x );
    }
 
@@ -207,16 +207,16 @@ class WrappedMemMultiFunction : public IMultiGenFunction {
    // use default  copy constructor and assignment operator
 
    /// clone (required by the interface)
-   WrappedMemMultiFunction * Clone() const {
+   WrappedMemMultiFunction * Clone() const override {
       return new WrappedMemMultiFunction(*fObj,fMemFunc,fDim);
    }
 
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
 private:
 
-   virtual double DoEval (const double * x) const {
+   double DoEval (const double * x) const override {
       return ((*fObj).*fMemFunc)( x );
    }
 

--- a/math/mathcore/inc/Math/WrappedParamFunction.h
+++ b/math/mathcore/inc/Math/WrappedParamFunction.h
@@ -90,27 +90,27 @@ public:
 //    {}
 
    /// clone the function
-   IMultiGenFunction * Clone() const {
+   IMultiGenFunction * Clone() const override {
       return new WrappedParamFunction(fFunc, fDim, fParams.begin(), fParams.end());
    }
 
-   const double * Parameters() const {
+   const double * Parameters() const override {
       return fParams.empty() ? nullptr : &fParams.front();
    }
 
-   void SetParameters(const double * p)  {
+   void SetParameters(const double * p) override  {
       std::copy(p, p+NPar(), fParams.begin() );
    }
 
-   unsigned int NPar() const { return fParams.size(); }
+   unsigned int NPar() const override { return fParams.size(); }
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
 
 private:
 
    /// evaluate the function given values and parameters (requested interface)
-   double DoEvalPar(const double * x, const double * p) const {
+   double DoEvalPar(const double * x, const double * p) const override {
       return (*fFunc)( x, p );
    }
 
@@ -171,7 +171,7 @@ public:
    }
 
    /// clone the function
-   IMultiGenFunction * Clone() const {
+   IMultiGenFunction * Clone() const override {
       return new WrappedParamFunctionGen(fFunc, fDim, fParams.size(), fParams.empty() ? nullptr : &fParams.front(), fParIndices.empty() ? nullptr : &fParIndices.front());
    }
 
@@ -182,19 +182,19 @@ private:
 
 public:
 
-   const double * Parameters() const {
+   const double * Parameters() const override {
       return fParams.empty() ? nullptr : &fParams.front();
    }
 
-   void SetParameters(const double * p)  {
+   void SetParameters(const double * p) override  {
       unsigned int npar = NPar();
       std::copy(p, p+ npar, fParams.begin() );
       SetParValues(npar, p);
    }
 
-   unsigned int NPar() const { return fParams.size(); }
+   unsigned int NPar() const override { return fParams.size(); }
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
 //    // re-implement this since is more efficient
 //    double operator() (const double * x, const double * p) {
@@ -207,7 +207,7 @@ public:
 private:
 
    /// evaluate the function (re-implement for being more efficient)
-   double DoEval(const double * x) const {
+   double DoEval(const double * x) const override {
 
 //       std::cout << this << fDim << " x : ";
 //       std::ostream_iterator<double> oix(std::cout," ,  ");
@@ -234,7 +234,7 @@ private:
    /**
        implement the required IParamFunction interface
    */
-   double DoEvalPar(const double * x, const double * p ) const {
+   double DoEvalPar(const double * x, const double * p ) const override {
       SetParValues(NPar(), p);
       return DoEval(x);
    }

--- a/math/mathcore/inc/TKDTree.h
+++ b/math/mathcore/inc/TKDTree.h
@@ -13,7 +13,7 @@ public:
    TKDTree();
    TKDTree(Index npoints, Index ndim, UInt_t bsize);
    TKDTree(Index npoints, Index ndim, UInt_t bsize, Value **data);
-   ~TKDTree();
+   ~TKDTree() override;
 
    void            Build();  // build the tree
 
@@ -97,7 +97,7 @@ public:
                         ///<  that belongs to the first node on the second row.
 
 
-   ClassDef(TKDTree, 1)  // KD tree
+   ClassDefOverride(TKDTree, 1)  // KD tree
 };
 
 

--- a/math/mathcore/inc/TKDTreeBinning.h
+++ b/math/mathcore/inc/TKDTreeBinning.h
@@ -70,7 +70,7 @@ public:
    TKDTreeBinning(); // default constructor (for I/O)
    TKDTreeBinning(UInt_t dataSize, UInt_t dataDim, Double_t* data, UInt_t nBins = 100, bool adjustBinEdges = false);
    TKDTreeBinning(UInt_t dataSize, UInt_t dataDim, const std::vector<double> & data, UInt_t nBins = 100, bool adjustBinEdges = false);
-   ~TKDTreeBinning();
+   ~TKDTreeBinning() override;
    void SetNBins(UInt_t bins);
    void SortBinsByDensity(Bool_t sortAsc = kTRUE);
    const Double_t* GetBinsMinEdges() const;
@@ -98,7 +98,7 @@ public:
    UInt_t FindBin(const Double_t * point) const;
    std::vector<std::vector<Double_t> > GetPointsInBin(UInt_t bin) const;
 
-   ClassDef(TKDTreeBinning, 1)
+   ClassDefOverride(TKDTreeBinning, 1)
 
 };
 

--- a/math/mathcore/inc/TRandom.h
+++ b/math/mathcore/inc/TRandom.h
@@ -31,7 +31,7 @@ protected:
 
 public:
    TRandom(UInt_t seed=65539);
-   virtual ~TRandom();
+   ~TRandom() override;
    virtual  Int_t    Binomial(Int_t ntot, Double_t prob);
    virtual  Double_t BreitWigner(Double_t mean=0, Double_t gamma=1);
    virtual  void     Circle(Double_t &x, Double_t &y, Double_t r);
@@ -46,7 +46,7 @@ public:
    virtual  void     Rannor(Double_t &a, Double_t &b);
    virtual  void     ReadRandom(const char *filename);
    virtual  void     SetSeed(ULong_t seed=0);
-   virtual  Double_t Rndm();
+    Double_t Rndm() override;
    // keep for backward compatibility
    virtual  Double_t Rndm(Int_t ) { return Rndm(); }
    virtual  void     RndmArray(Int_t n, Float_t *array);
@@ -56,7 +56,7 @@ public:
    virtual  Double_t Uniform(Double_t x1, Double_t x2);
    virtual  void     WriteRandom(const char *filename) const;
 
-   ClassDef(TRandom,3)  //Simple Random number generator (periodicity = 10**9)
+   ClassDefOverride(TRandom,3)  //Simple Random number generator (periodicity = 10**9)
 };
 
 R__EXTERN TRandom *gRandom;

--- a/math/mathcore/inc/TRandom1.h
+++ b/math/mathcore/inc/TRandom1.h
@@ -45,27 +45,27 @@ public:
    TRandom1();
    TRandom1(UInt_t seed, Int_t lux = 3 );
    TRandom1(Int_t rowIndex, Int_t colIndex, Int_t lux );
-   virtual ~TRandom1();
+   ~TRandom1() override;
    virtual  Int_t    GetLuxury() const {return fLuxury;}
                     // Get the current seed (first element of the table)
-   virtual  UInt_t   GetSeed() const { return  UInt_t ( fFloatSeedTable[0] /  fMantissaBit24 ) ; }
+    UInt_t   GetSeed() const override { return  UInt_t ( fFloatSeedTable[0] /  fMantissaBit24 ) ; }
                     // Gets the current seed.
    const UInt_t     *GetTheSeeds() const {return fTheSeeds;}
                      // Gets the current array of seeds.
    static   void     GetTableSeeds(UInt_t* seeds, Int_t index);
                      // Gets back seed values stored in the table, given the index.
    using TRandom::Rndm;
-   virtual  Double_t Rndm( );
-   virtual  void     RndmArray(Int_t size, Float_t *vect);
-   virtual  void     RndmArray(Int_t size, Double_t *vect);
+    Double_t Rndm( ) override;
+    void     RndmArray(Int_t size, Float_t *vect) override;
+    void     RndmArray(Int_t size, Double_t *vect) override;
    virtual  void     SetSeed2(UInt_t seed, Int_t lux=3);
                      // Sets the state of the algorithm according to seed.
    virtual  void     SetSeeds(const UInt_t * seeds, Int_t lux=3);
                      // Sets the state of the algorithm according to the zero terminated
                      // array of seeds. Only the first seed is used.
-   virtual  void     SetSeed(ULong_t seed);
+    void     SetSeed(ULong_t seed) override;
 
-   ClassDef(TRandom1,2)  //Ranlux Random number generators with periodicity > 10**14
+   ClassDefOverride(TRandom1,2)  //Ranlux Random number generators with periodicity > 10**14
 };
 
 R__EXTERN TRandom *gRandom;

--- a/math/mathcore/inc/TRandom2.h
+++ b/math/mathcore/inc/TRandom2.h
@@ -32,14 +32,14 @@ protected:
 
 public:
    TRandom2(UInt_t seed=1);
-   virtual ~TRandom2();
-   virtual  Double_t Rndm( );
+   ~TRandom2() override;
+    Double_t Rndm( ) override;
    using TRandom::Rndm;
-   virtual  void     RndmArray(Int_t n, Float_t *array);
-   virtual  void     RndmArray(Int_t n, Double_t *array);
-   virtual  void     SetSeed(ULong_t seed=0);
+    void     RndmArray(Int_t n, Float_t *array) override;
+    void     RndmArray(Int_t n, Double_t *array) override;
+    void     SetSeed(ULong_t seed=0) override;
 
-   ClassDef(TRandom2,1)  //Random number generator with periodicity of 10**26
+   ClassDefOverride(TRandom2,1)  //Random number generator with periodicity of 10**26
 };
 
 R__EXTERN TRandom *gRandom;

--- a/math/mathcore/inc/TRandom3.h
+++ b/math/mathcore/inc/TRandom3.h
@@ -32,18 +32,18 @@ private:
 
 public:
    TRandom3(UInt_t seed=4357);
-   virtual ~TRandom3();
+   ~TRandom3() override;
    /// return current element of the state used for generate the random number
    /// Note that it is not the seed of the generator that was used in the SetSeed function
-   virtual  UInt_t    GetSeed() const { return fMt[fCount624];}
+    UInt_t    GetSeed() const override { return fMt[fCount624];}
    using TRandom::Rndm;
-   virtual  Double_t  Rndm( );
-   virtual  void      RndmArray(Int_t n, Float_t *array);
-   virtual  void      RndmArray(Int_t n, Double_t *array);
-   virtual  void      SetSeed(ULong_t seed=0);
+    Double_t  Rndm( ) override;
+    void      RndmArray(Int_t n, Float_t *array) override;
+    void      RndmArray(Int_t n, Double_t *array) override;
+    void      SetSeed(ULong_t seed=0) override;
    virtual const UInt_t *GetState() const { return fMt; }
 
-   ClassDef(TRandom3,2)  //Random number generator: Mersenne Twister
+   ClassDefOverride(TRandom3,2)  //Random number generator: Mersenne Twister
 };
 
 R__EXTERN TRandom *gRandom;

--- a/math/mathcore/inc/TRandomGen.h
+++ b/math/mathcore/inc/TRandomGen.h
@@ -57,20 +57,20 @@ public:
       SetName(TString::Format("Random_%s", std::string(fEngine.Name()).c_str()));
       SetTitle(TString::Format("Random number generator: %s", std::string(fEngine.Name()).c_str()));
    }
-   virtual ~TRandomGen() {}
+   ~TRandomGen() override {}
    using TRandom::Rndm;
-   virtual  Double_t Rndm( ) { return fEngine(); }
-   virtual  void     RndmArray(Int_t n, Float_t *array) {
+    Double_t Rndm( ) override { return fEngine(); }
+    void     RndmArray(Int_t n, Float_t *array) override {
       for (int i = 0; i < n; ++i) array[i] = fEngine();
    }
-   virtual  void     RndmArray(Int_t n, Double_t *array) {
+    void     RndmArray(Int_t n, Double_t *array) override {
             for (int i = 0; i < n; ++i) array[i] = fEngine();
    }
-   virtual  void     SetSeed(ULong_t seed=0) {
+    void     SetSeed(ULong_t seed=0) override {
       fEngine.SetSeed(seed);
    }
 
-   ClassDef(TRandomGen,1)  //Generic Random number generator template on the Engine type
+   ClassDefOverride(TRandomGen,1)  //Generic Random number generator template on the Engine type
 };
 
 // some useful typedef

--- a/math/mathcore/inc/TStatistic.h
+++ b/math/mathcore/inc/TStatistic.h
@@ -46,11 +46,11 @@ public:
 
    TStatistic(const char *name = "") : fName(name), fN(0), fW(0.), fW2(0.), fM(0.), fM2(0.), fMin(TMath::Limits<Double_t>::Max()), fMax(-TMath::Limits<Double_t>::Max()) { }
    TStatistic(const char *name, Int_t n, const Double_t *val, const Double_t *w = nullptr);
-   ~TStatistic();
+   ~TStatistic() override;
 
    // Getters
-   const char    *GetName() const { return fName; }
-   ULong_t        Hash() const { return fName.Hash(); }
+   const char    *GetName() const override { return fName; }
+   ULong_t        Hash() const override { return fName.Hash(); }
 
    inline       Long64_t GetN() const { return fN; }
    inline       Long64_t GetNeff() const { return fW*fW/fW2; }
@@ -71,10 +71,10 @@ public:
    void Fill(Double_t val, Double_t w = 1.);
 
    // Print
-   void Print(Option_t * = "") const;
-   void ls(Option_t *opt = "") const { Print(opt); }
+   void Print(Option_t * = "") const override;
+   void ls(Option_t *opt = "") const override { Print(opt); }
 
-   ClassDef(TStatistic,3)  // Named statistical variable
+   ClassDefOverride(TStatistic,3)  // Named statistical variable
 };
 
 #endif

--- a/math/mathcore/src/GoFTest.cxx
+++ b/math/mathcore/src/GoFTest.cxx
@@ -44,7 +44,7 @@ namespace Math {
       const IGenFunction* fCDF; // cdf pointer (owned by the class)
 
 
-      virtual ~CDFWrapper() { if (fCDF) delete fCDF; }
+      ~CDFWrapper() override { if (fCDF) delete fCDF; }
 
       CDFWrapper(const IGenFunction& cdf, Double_t xmin=0, Double_t xmax=-1) :
          fCDF(cdf.Clone())
@@ -61,13 +61,13 @@ namespace Math {
          }
       }
 
-      Double_t DoEval(Double_t x) const {
+      Double_t DoEval(Double_t x) const override {
          if (x <= fXmin) return 0;
          if (x >= fXmax) return 1.0;
          return (*fCDF)(x)/fNorm;
       }
 
-      IGenFunction* Clone() const {
+      IGenFunction* Clone() const override {
          return new CDFWrapper(*fCDF,fXmin,fXmax);
       }
    };
@@ -81,7 +81,7 @@ namespace Math {
       const IGenFunction* fPDF; // pdf pointer (owned by the class)
    public:
 
-      virtual ~PDFIntegral() { if (fPDF) delete fPDF; }
+      ~PDFIntegral() override { if (fPDF) delete fPDF; }
 
       PDFIntegral(const IGenFunction& pdf, Double_t xmin = 0, Double_t xmax = -1) :
          fXmin(xmin),
@@ -106,7 +106,7 @@ namespace Math {
             fNorm = fIntegral.Integral(fXmin, fXmax);
       }
 
-      Double_t DoEval(Double_t x) const {
+      Double_t DoEval(Double_t x) const override {
          if (x <= fXmin) return 0;
          if (x >= fXmax) return 1.0;
          if (fXmin == -std::numeric_limits<double>::infinity() )
@@ -115,7 +115,7 @@ namespace Math {
             return fIntegral.Integral(fXmin,x)/fNorm;
       }
 
-      IGenFunction* Clone() const {
+      IGenFunction* Clone() const override {
          return new PDFIntegral(*fPDF, fXmin, fXmax);
       }
    };

--- a/math/mathcore/test/fit/testFit.cxx
+++ b/math/mathcore/test/fit/testFit.cxx
@@ -363,16 +363,16 @@ int testHisto1DFit() {
 
 class Func1D : public ROOT::Math::IParamFunction {
 public:
-   void SetParameters(const double *p) { std::copy(p,p+NPar(),fp);}
-   const double * Parameters() const { return fp; }
-   ROOT::Math::IGenFunction * Clone() const {
+   void SetParameters(const double *p) override { std::copy(p,p+NPar(),fp);}
+   const double * Parameters() const override { return fp; }
+   ROOT::Math::IGenFunction * Clone() const override {
       Func1D * f =  new Func1D();
       f->SetParameters(fp);
       return f;
    };
-   unsigned int NPar() const { return 3; }
+   unsigned int NPar() const override { return 3; }
 private:
-   double DoEvalPar( double x, const double *p) const {
+   double DoEvalPar( double x, const double *p) const override {
       return p[0]*x*x + p[1]*x + p[2];
    }
    double fp[3];
@@ -382,17 +382,17 @@ private:
 // gradient 2D function
 class GradFunc2D : public ROOT::Math::IParamMultiGradFunction {
 public:
-   void SetParameters(const double *p) { std::copy(p,p+NPar(),fp);}
-   const double * Parameters() const { return fp; }
-   ROOT::Math::IMultiGenFunction * Clone() const {
+   void SetParameters(const double *p) override { std::copy(p,p+NPar(),fp);}
+   const double * Parameters() const override { return fp; }
+   ROOT::Math::IMultiGenFunction * Clone() const override {
       GradFunc2D * f =  new GradFunc2D();
       f->SetParameters(fp);
       return f;
    };
-   unsigned int NDim() const { return 2; }
-   unsigned int NPar() const { return 5; }
+   unsigned int NDim() const override { return 2; }
+   unsigned int NPar() const override { return 5; }
 
-   void ParameterGradient( const double * x, const double * , double * grad) const {
+   void ParameterGradient( const double * x, const double * , double * grad) const override {
       grad[0] = x[0]*x[0];
       grad[1] = x[0];
       grad[2] = x[1]*x[1];
@@ -402,7 +402,7 @@ public:
 
 private:
 
-   double DoEvalPar( const double *x, const double * p) const {
+   double DoEvalPar( const double *x, const double * p) const override {
       return p[0]*x[0]*x[0] + p[1]*x[0] + p[2]*x[1]*x[1] + p[3]*x[1] + p[4];
    }
 //    double DoDerivative(const double *x,  unsigned int icoord = 0) const {
@@ -413,7 +413,7 @@ private:
 //          return 2. * fp[2] * x[1] + fp[3];
 //    }
 
-   double DoParameterDerivative(const double * x, const double * p, unsigned int ipar) const {
+   double DoParameterDerivative(const double * x, const double * p, unsigned int ipar) const override {
       std::vector<double> grad(NPar());
       ParameterGradient(x, p, &grad[0] );
       return grad[ipar];

--- a/math/mathcore/test/fit/testLogLExecPolicy.cxx
+++ b/math/mathcore/test/fit/testLogLExecPolicy.cxx
@@ -34,7 +34,7 @@ public:
 
    }
 
-   virtual T DoEvalPar(const T *data, const Double_t *p) const
+   T DoEvalPar(const T *data, const Double_t *p) const override
    {
 
       if (data == nullptr) {
@@ -77,17 +77,17 @@ public:
       return f1 + f2;
    }
 
-      virtual ROOT::Math::IBaseFunctionMultiDimTempl<T> *Clone() const {
+      ROOT::Math::IBaseFunctionMultiDimTempl<T> *Clone() const override {
          return new Func<T>(*this); 
       }
-      virtual unsigned int NDim() const { return 1; }
-      virtual unsigned int NPar() const {
+      unsigned int NDim() const override { return 1; }
+      unsigned int NPar() const override {
          return paramSize;
       }
-      virtual const double * Parameters() const {
+      const double * Parameters() const override {
          return params.data(); 
       }
-      virtual void SetParameters(const double * p) {
+      void SetParameters(const double * p) override {
          std::copy(p, p+paramSize, params.begin() );
          ComputeIntegrals(p);
       }

--- a/math/mathcore/test/fit/testMinim.cxx
+++ b/math/mathcore/test/fit/testMinim.cxx
@@ -60,9 +60,9 @@ class RosenBrockFunction : public ROOT::Math::IMultiGenFunction {
 public :
 
 
-   unsigned int NDim() const { return 2; }
+   unsigned int NDim() const override { return 2; }
 
-   ROOT::Math::IMultiGenFunction * Clone() const {
+   ROOT::Math::IMultiGenFunction * Clone() const override {
       return new RosenBrockFunction();
    }
 
@@ -78,7 +78,7 @@ public :
 
    private:
 
-   inline double DoEval (const double * x) const {
+   inline double DoEval (const double * x) const override {
 #ifdef USE_FREE_FUNC
       double f = 0;
       int ierr = 0;
@@ -136,9 +136,9 @@ public :
    }
 
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
-   ROOT::Math::IMultiGenFunction * Clone() const {
+   ROOT::Math::IMultiGenFunction * Clone() const override {
       TrigoFletcherFunction * f = new TrigoFletcherFunction(*this);
 //       std::cerr <<"cannot clone this function" << std::endl;
 //       assert(0);
@@ -167,7 +167,7 @@ public :
 
    double TrueMinimum() const { return 0; }
 
-   void  Gradient (const double * x, double * g) const {
+   void  Gradient (const double * x, double * g) const override {
       gNCall2++;
 
       for (unsigned int i = 0; i < fDim ; ++i) {
@@ -219,7 +219,7 @@ public :
 //    TrigoFletcherFunction(const TrigoFletcherFunction & ) {}
 //    TrigoFletcherFunction & operator=(const TrigoFletcherFunction &) { return *this; }
 
-   double DoEval (const double * x) const {
+   double DoEval (const double * x) const override {
       gNCall++;
 
 
@@ -235,7 +235,7 @@ public :
    }
 
 
-   double DoDerivative (const double * x, unsigned int i ) const {
+   double DoDerivative (const double * x, unsigned int i ) const override {
       std::vector<double> g(fDim);
       Gradient(x,&g[0]);
       return  g[i];
@@ -273,9 +273,9 @@ public :
    {
    }
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
-   ROOT::Math::IMultiGenFunction * Clone() const {
+   ROOT::Math::IMultiGenFunction * Clone() const override {
       return new ChebyQuadFunction(*this);
    }
 
@@ -295,7 +295,7 @@ public :
 
    // compute gradient
 
-   void Gradient(const double * x, double * g) const {
+   void Gradient(const double * x, double * g) const override {
       gNCall2++;
       unsigned int n = fDim;
       // estimate first the fvec
@@ -325,7 +325,7 @@ public :
 
    private:
 
-   double DoEval (const double * x) const {
+   double DoEval (const double * x) const override {
 
       gNCall++;
       DoCalculatefi(x);
@@ -337,7 +337,7 @@ public :
 
    }
 
-   double DoDerivative (const double * x, unsigned int i ) const {
+   double DoDerivative (const double * x, unsigned int i ) const override {
       std::vector<double> g(fDim);
       Gradient(x,&g[0]);
       return  g[i];

--- a/math/mathcore/test/stress/StatFunction.h
+++ b/math/mathcore/test/stress/StatFunction.h
@@ -37,10 +37,10 @@ public:
       for (int i = 0; i < NPAR; ++i) fParams[i] = 0;
    }
 
-   unsigned int NPar() const { return NPAR; }
-   const double *Parameters() const { return fParams; }
-   ROOT::Math::IGenFunction *Clone() const { return new StatFunction(fPdf, fCdf, fQuant); }
-   void SetParameters(const double *p) { std::copy(p, p + NPAR, fParams); }
+   unsigned int NPar() const override { return NPAR; }
+   const double *Parameters() const override { return fParams; }
+   ROOT::Math::IGenFunction *Clone() const override { return new StatFunction(fPdf, fCdf, fQuant); }
+   void SetParameters(const double *p) override { std::copy(p, p + NPAR, fParams); }
    void SetParameters(double p0) { *fParams = p0; }
    void SetParameters(double p0, double p1)
    {
@@ -110,7 +110,7 @@ public:
    void ScaleTol2(double s) { fScale2 *= s; }
 
 private:
-   double DoEvalPar(double x, const double *) const
+   double DoEvalPar(double x, const double *) const override
    {
       // implement explicitly using cached parameter values
       return Evaluator<Func, NPAR>::F(fPdf, x, fParams);

--- a/math/mathcore/test/stress/testGenVector.cxx
+++ b/math/mathcore/test/stress/testGenVector.cxx
@@ -27,7 +27,7 @@ protected:
    std::vector<typename T::V2_t> fV2;
    const int fDim = T::GetDim();
 
-   virtual void SetUp()
+   void SetUp() override
    {
       fVectorTest.GenData();
       fV1.reserve(fNGen);

--- a/math/mathcore/test/stress/testSMatrix.cxx
+++ b/math/mathcore/test/stress/testSMatrix.cxx
@@ -35,7 +35,7 @@ protected:
 
    VectorTest<R_t::kSize> fVectorTest;
 
-   virtual void SetUp()
+   void SetUp() override
    {
       fVectorTest.GenDataN();
       v1.reserve(fNGen);

--- a/math/mathcore/test/stress/testVector.cxx
+++ b/math/mathcore/test/stress/testVector.cxx
@@ -17,7 +17,7 @@ protected:
    VectorTest<T::kSize> fVectorTest;
    std::vector<T> fV1;
 
-   virtual void SetUp()
+   void SetUp() override
    {
       fVectorTest.GenDataN();
       fV1.reserve(fNGen);

--- a/math/mathcore/test/stress/testVector34.cxx
+++ b/math/mathcore/test/stress/testVector34.cxx
@@ -22,7 +22,7 @@ protected:
    typedef SVector<double, T::GetDim()> SV_t;
    std::vector<SV_t> fV1;
 
-   virtual void SetUp()
+   void SetUp() override
    {
       fVectorTest.GenData();
       fV1.reserve(fNGen);

--- a/math/mathcore/test/testGradient.cxx
+++ b/math/mathcore/test/testGradient.cxx
@@ -325,7 +325,7 @@ struct Chi2GradientTestEvaluation : public GradientTestEvaluation<T, ROOT::Fit::
 
    Chi2GradientTestEvaluation() { SetFitter(); }
 
-   virtual void SetFitter() override
+   void SetFitter() override
    {
       this->fFitter = new ROOT::Fit::Chi2FCN<GradFunctionType, BaseFunctionType>(*(this->fData), *(this->fFitFunction),
                                                                                  T::ExecutionPolicyType());
@@ -340,7 +340,7 @@ struct PoissonLikelihoodGradientTestEvaluation : public GradientTestEvaluation<T
 
    PoissonLikelihoodGradientTestEvaluation() { SetFitter(); }
 
-   virtual void SetFitter() override
+   void SetFitter() override
    {
       this->fFitter = new ROOT::Fit::PoissonLikelihoodFCN<GradFunctionType, BaseFunctionType>(
          *(this->fData), *(this->fFitFunction), 0, true, T::ExecutionPolicyType());
@@ -355,7 +355,7 @@ struct LogLikelihoodGradientTestEvaluation : public GradientTestEvaluation<T, RO
 
    LogLikelihoodGradientTestEvaluation() { SetFitter(); }
 
-   virtual void SetFitter() override
+   void SetFitter() override
    {
       this->fFitter = new ROOT::Fit::LogLikelihoodFCN<GradFunctionType, BaseFunctionType>(
          *(this->fData), *(this->fFitFunction), 0, false, T::ExecutionPolicyType());
@@ -372,7 +372,7 @@ class Chi2GradientTest : public ::testing::Test, public Chi2GradientTestEvaluati
    using typename Chi2GradientTestEvaluation<T>::ScalarSerial;
 
 protected:
-   virtual void SetUp()
+   void SetUp() override
    {
       T::PrintTypeInfo("Chi2FCN");
 
@@ -397,7 +397,7 @@ class PoissonLikelihoodGradientTest : public ::testing::Test, public PoissonLike
    using typename PoissonLikelihoodGradientTestEvaluation<T>::ScalarSerial;
 
 protected:
-   virtual void SetUp()
+   void SetUp() override
    {
       T::PrintTypeInfo("PoissonLikelihoodFCN");
 
@@ -422,7 +422,7 @@ class LogLikelihoodGradientTest : public ::testing::Test, public LogLikelihoodGr
    using typename LogLikelihoodGradientTestEvaluation<T>::ScalarSerial;
 
 protected:
-   virtual void SetUp()
+   void SetUp() override
    {
       T::PrintTypeInfo("LogLikelihoodFCN");
 

--- a/math/mathcore/test/testGradientFitting.cxx
+++ b/math/mathcore/test/testGradientFitting.cxx
@@ -21,26 +21,26 @@
 template <class T>
 class GradFunc2D : public ROOT::Math::IParamMultiGradFunctionTempl<T> {
 public:
-   void SetParameters(const double *p) {
+   void SetParameters(const double *p) override {
       std::copy(p, p + NPar(), fParameters);
       // compute integral in interval [0,1][0,1]
       fIntegral = Integral(p);
    }
 
-   const double *Parameters() const { return fParameters; }
+   const double *Parameters() const override { return fParameters; }
 
-   ROOT::Math::IBaseFunctionMultiDimTempl<T> *Clone() const
+   ROOT::Math::IBaseFunctionMultiDimTempl<T> *Clone() const override
    {
       GradFunc2D<T> *f = new GradFunc2D<T>();
       f->SetParameters(fParameters);
       return f;
    }
 
-   unsigned int NDim() const { return 2; }
+   unsigned int NDim() const override { return 2; }
 
-   unsigned int NPar() const { return 5; }
+   unsigned int NPar() const override { return 5; }
 
-   void ParameterGradient(const T *x, const double * p, T *grad) const
+   void ParameterGradient(const T *x, const double * p, T *grad) const override
    {
       if (p == nullptr) {
          ParameterGradient(x, fParameters, grad);
@@ -73,14 +73,14 @@ private:
       return fval;
    }
 
-   T DoEvalPar(const T *x, const double *p) const
+   T DoEvalPar(const T *x, const double *p) const override
    {
       if (p == nullptr)
          return DoEvalPar(x, fParameters);
       return p[0] * FVal(x,p) / fIntegral;
    }
 
-   T DoParameterDerivative(const T *x, const double *p, unsigned int ipar) const
+   T DoParameterDerivative(const T *x, const double *p, unsigned int ipar) const override
    {
       std::vector<T> grad(NPar());
       ParameterGradient(x, p, &grad[0]);
@@ -118,7 +118,7 @@ int printLevel = 0;
 template <class T>
 class GradientFittingTest : public ::testing::Test {
 protected:
-   virtual void SetUp()
+   void SetUp() override
    {
       // Create TF2 from model function and initialize the fit function
       std::stringstream streamTF2;

--- a/math/mathmore/inc/Math/GSLIntegrator.h
+++ b/math/mathmore/inc/Math/GSLIntegrator.h
@@ -145,7 +145,7 @@ namespace Math {
          */
       GSLIntegrator(const char *  type, int rule, double absTol, double relTol, size_t size );
 
-      virtual ~GSLIntegrator();
+      ~GSLIntegrator() override;
       //~GSLIntegrator();
 
       // disable copy ctrs
@@ -167,7 +167,7 @@ namespace Math {
           */
 
 
-      void SetFunction(const IGenFunction &f);
+      void SetFunction(const IGenFunction &f) override;
 
       /**
          Set function from a GSL pointer function type
@@ -200,7 +200,7 @@ namespace Math {
         @param b lower interval value
         @param c singular value of f
         */
-      double IntegralCauchy(double a, double b, double c);
+      double IntegralCauchy(double a, double b, double c) override;
 
       /**
        evaluate the Cauchy principal value of the integral of  a function f over the defined interval (a,b)
@@ -243,32 +243,32 @@ namespace Math {
        @param b upper value of the integration interval
        */
 
-      double Integral(double a, double b);
+      double Integral(double a, double b) override;
 
 
       /**
          evaluate the Integral over the infinite interval (-inf,+inf) using the function previously set with GSLIntegrator::SetFunction method.
        */
-      double Integral( );
+      double Integral( ) override;
 
       /**
          evaluate the Integral of a function f over the semi-infinite interval (a,+inf) using the function previously set with GSLIntegrator::SetFunction method.
        @param a lower value of the integration interval
        */
-      double IntegralUp(double a );
+      double IntegralUp(double a ) override;
 
       /**
          evaluate the Integral of a function f over the over the semi-infinite interval (-inf,b) using the function previously set with GSLIntegrator::SetFunction method.
        @param b upper value of the integration interval
        */
-      double IntegralLow( double b );
+      double IntegralLow( double b ) override;
 
       /**
          evaluate the Integral over the defined interval (a,b) using the function previously set with GSLIntegrator::SetFunction method. The function has known singular points.
        @param pts vector containing both the function singular points and the lower/upper edges of the interval. The vector must have as first element the lower edge of the integration Integral ( \a a) and last element the upper value.
 
        */
-      double Integral( const std::vector<double> & pts);
+      double Integral( const std::vector<double> & pts) override;
 
       // evaluate using free function pointer (same GSL signature)
 
@@ -315,35 +315,35 @@ namespace Math {
       /**
          return  the Result of the last Integral calculation
        */
-      double Result() const;
+      double Result() const override;
 
       /**
          return the estimate of the absolute Error of the last Integral calculation
        */
-      double Error() const;
+      double Error() const override;
 
       /**
          return the Error Status of the last Integral calculation
        */
-      int Status() const;
+      int Status() const override;
 
       /**
           return number of function evaluations in calculating the integral
       */
-      int NEval() const { return fNEval; }
+      int NEval() const override { return fNEval; }
 
       // setter for control Parameters  (getters are not needed so far )
 
       /**
          set the desired relative Error
        */
-      void SetRelTolerance(double relTolerance);
+      void SetRelTolerance(double relTolerance) override;
 
 
       /**
          set the desired absolute Error
        */
-      void SetAbsTolerance(double absTolerance);
+      void SetAbsTolerance(double absTolerance) override;
 
       /**
          set the integration rule (Gauss-Kronrod rule).
@@ -353,10 +353,10 @@ namespace Math {
       void SetIntegrationRule(Integration::GKRule );
 
       /// set the options
-      virtual void SetOptions(const ROOT::Math::IntegratorOneDimOptions & opt);
+      void SetOptions(const ROOT::Math::IntegratorOneDimOptions & opt) override;
 
       ///  get the option used for the integration
-      virtual ROOT::Math::IntegratorOneDimOptions Options() const;
+      ROOT::Math::IntegratorOneDimOptions Options() const override;
 
       /// get type name
       IntegrationOneDim::Type GetType() const { return fType; }

--- a/math/mathmore/inc/Math/GSLMCIntegrator.h
+++ b/math/mathmore/inc/Math/GSLMCIntegrator.h
@@ -112,7 +112,7 @@ namespace Math {
       /**
           destructor
       */
-      virtual ~GSLMCIntegrator();
+      ~GSLMCIntegrator() override;
 
       // disable copy ctrs
 
@@ -135,7 +135,7 @@ public:
           */
 
 
-      void SetFunction(const IMultiGenFunction &f);
+      void SetFunction(const IMultiGenFunction &f) override;
 
 
       typedef double ( * GSLMonteFuncPointer ) ( double *, size_t, void *);
@@ -159,7 +159,7 @@ public:
       /**
          evaluate the integral using the previously defined function
        */
-      double Integral(const double* a, const double* b);
+      double Integral(const double* a, const double* b) override;
 
 
       // to be added later
@@ -175,24 +175,24 @@ public:
       /**
          return  the Result of the last Integral calculation
        */
-      double Result() const;
+      double Result() const override;
 
       /**
          return the estimate of the absolute Error of the last Integral calculation
        */
-      double Error() const;
+      double Error() const override;
 
       /**
          return the Error Status of the last Integral calculation
        */
-      int Status() const;
+      int Status() const override;
 
 
       /**
           return number of function evaluations in calculating the integral
           (This is an fixed by the user)
       */
-      int NEval() const { return fCalls; }
+      int NEval() const override { return fCalls; }
 
 
       // setter for control Parameters  (getters are not needed so far )
@@ -200,18 +200,18 @@ public:
       /**
          set the desired relative Error
        */
-      void SetRelTolerance(double relTolerance);
+      void SetRelTolerance(double relTolerance) override;
 
 
       /**
          set the desired absolute Error
        */
-      void SetAbsTolerance(double absTolerance);
+      void SetAbsTolerance(double absTolerance) override;
 
       /**
          set the integration options
        */
-      void SetOptions(const ROOT::Math::IntegratorMultiDimOptions & opt);
+      void SetOptions(const ROOT::Math::IntegratorMultiDimOptions & opt) override;
 
 
       /**
@@ -280,7 +280,7 @@ public:
       /**
          get the option used for the integration
       */
-      ROOT::Math::IntegratorMultiDimOptions Options() const;
+      ROOT::Math::IntegratorMultiDimOptions Options() const override;
 
       /**
          get the specific options (for Vegas or Miser)

--- a/math/mathmore/inc/Math/GSLMinimizer.h
+++ b/math/mathmore/inc/Math/GSLMinimizer.h
@@ -93,7 +93,7 @@ public:
    /**
       Destructor
    */
-   virtual ~GSLMinimizer ();
+   ~GSLMinimizer () override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -114,31 +114,31 @@ private:
 public:
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func) { BasicMinimizer::SetFunction(func);}
+   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override { BasicMinimizer::SetFunction(func);}
 
    /// method to perform the minimization
-   virtual  bool Minimize();
+    bool Minimize() override;
 
 
    /// return expected distance reached from the minimum
-   virtual double Edm() const { return 0; } // not impl. }
+   double Edm() const override { return 0; } // not impl. }
 
 
    /// return pointer to gradient values at the minimum
-   virtual const double *  MinGradient() const;
+   const double *  MinGradient() const override;
 
    /// number of function calls to reach the minimum
-   virtual unsigned int NCalls() const;
+   unsigned int NCalls() const override;
 
 
    /// minimizer provides error and error matrix
-   virtual bool ProvidesError() const { return false; }
+   bool ProvidesError() const override { return false; }
 
    /// return errors at the minimum
-   virtual const double * Errors() const {
+   const double * Errors() const override {
       return 0;
    }
 
@@ -146,7 +146,7 @@ public:
        if the variable is fixed the matrix is zero
        The ordering of the variables is the same as in errors
    */
-   virtual double CovMatrix(unsigned int , unsigned int ) const { return 0; }
+   double CovMatrix(unsigned int , unsigned int ) const override { return 0; }
 
 
 

--- a/math/mathmore/inc/Math/GSLMinimizer1D.h
+++ b/math/mathmore/inc/Math/GSLMinimizer1D.h
@@ -91,7 +91,7 @@ This class does not support copying
       /**
          Destructor: free allocated resources
       */
-      virtual ~GSLMinimizer1D();
+      ~GSLMinimizer1D() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -129,32 +129,32 @@ This class does not support copying
       /**
           Return current estimate of the position of the minimum
       */
-      double XMinimum() const;
+      double XMinimum() const override;
 
       /**
          Return current lower bound of the minimization interval
       */
-      double XLower() const;
+      double XLower() const override;
 
       /**
          Return current upper bound of the minimization interval
       */
-      double XUpper() const;
+      double XUpper() const override;
 
       /**
           Return function value at current estimate of the minimum
       */
-      double FValMinimum() const;
+      double FValMinimum() const override;
 
       /**
          Return function value at current lower bound of the minimization interval
       */
-      double FValLower() const;
+      double FValLower() const override;
 
       /**
          Return function value at current upper bound of the minimization interval
       */
-      double FValUpper() const;
+      double FValUpper() const override;
 
 
       /**
@@ -165,25 +165,25 @@ This class does not support copying
          \@param absTol desired absolute error in the minimum position
          \@param absTol desired relative error in the minimum position
       */
-      bool Minimize( int maxIter, double absTol, double relTol);
+      bool Minimize( int maxIter, double absTol, double relTol) override;
 
 
       /**
          Return number of iteration used to find minimum
       */
-      int Iterations() const {
+      int Iterations() const override {
          return fIter;
       }
 
       /**
          Return status of last minimization
        */
-      int Status() const { return fStatus; }
+      int Status() const override { return fStatus; }
 
       /**
          Return name of minimization algorithm
       */
-      const char * Name() const;
+      const char * Name() const override;
 
       /**
          Test convergence of the interval.

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -92,18 +92,18 @@ public:
       return *this;
    }
 
-   IMultiGenFunction * Clone() const {
+   IMultiGenFunction * Clone() const override {
       return new LSResidualFunc(*fChi2,fIndex);
    }
 
-   unsigned int NDim() const { return fChi2->NDim(); }
+   unsigned int NDim() const override { return fChi2->NDim(); }
 
-   void Gradient( const double * x, double * g) const {
+   void Gradient( const double * x, double * g) const override {
       double f0 = 0;
       FdF(x,f0,g);
    }
 
-   void FdF (const double * x, double & f, double * g) const {
+   void FdF (const double * x, double & f, double * g) const override {
       unsigned int n = NDim();
       std::copy(x,x+n,fX2.begin());
       const double kEps = 1.0E-4;
@@ -118,11 +118,11 @@ public:
 
 private:
 
-   double DoEval (const double * x) const {
+   double DoEval (const double * x) const override {
       return fChi2->DataElement(x, fIndex);
    }
 
-   double DoDerivative(const double * x, unsigned int icoord) const {
+   double DoDerivative(const double * x, unsigned int icoord) const override {
       //return  ROOT::Math::Derivator::Eval(*this, x, icoord, 1E-8);
       std::copy(x,x+NDim(),fX2.begin());
       const double kEps = 1.0E-4;
@@ -157,7 +157,7 @@ public:
    /**
       Destructor (no operations)
    */
-   ~GSLNLSMinimizer ();
+   ~GSLNLSMinimizer () override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -178,35 +178,35 @@ private:
 public:
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
    /// set gradient the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
 
 
    /// method to perform the minimization
-   virtual  bool Minimize();
+    bool Minimize() override;
 
 
    /// return expected distance reached from the minimum
-   virtual double Edm() const { return fEdm; } // not impl. }
+   double Edm() const override { return fEdm; } // not impl. }
 
 
    /// return pointer to gradient values at the minimum
-   virtual const double *  MinGradient() const;
+   const double *  MinGradient() const override;
 
    /// number of function calls to reach the minimum
-   virtual unsigned int NCalls() const { return (fChi2Func) ? fChi2Func->NCalls() : 0; }
+   unsigned int NCalls() const override { return (fChi2Func) ? fChi2Func->NCalls() : 0; }
 
    /// number of free variables (real dimension of the problem)
    /// this is <= Function().NDim() which is the total
 //   virtual unsigned int NFree() const { return fNFree; }
 
    /// minimizer provides error and error matrix
-   virtual bool ProvidesError() const { return true; }
+   bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   virtual const double * Errors() const { return (fErrors.size() > 0) ? &fErrors.front() : 0; }
+   const double * Errors() const override { return (fErrors.size() > 0) ? &fErrors.front() : 0; }
 //  {
 //       static std::vector<double> err;
 //       err.resize(fDim);
@@ -217,10 +217,10 @@ public:
        if the variable is fixed the matrix is zero
        The ordering of the variables is the same as in errors
    */
-   virtual double CovMatrix(unsigned int , unsigned int ) const;
+   double CovMatrix(unsigned int , unsigned int ) const override;
 
    /// return covariance matrix status
-   virtual int CovMatrixStatus() const;
+   int CovMatrixStatus() const override;
 
 protected:
 

--- a/math/mathmore/inc/Math/GSLRndmEngines.h
+++ b/math/mathmore/inc/Math/GSLRndmEngines.h
@@ -518,7 +518,7 @@ namespace Math {
    public:
       typedef GSLRandomEngine BaseType; 
       GSLRngMixMax();
-      virtual ~GSLRngMixMax();  // we need a dtcor since is not a standard GSL engine
+      ~GSLRngMixMax() override;  // we need a dtcor since is not a standard GSL engine
    };
 
 } // namespace Math

--- a/math/mathmore/inc/Math/GSLRootFinder.h
+++ b/math/mathmore/inc/Math/GSLRootFinder.h
@@ -74,7 +74,7 @@ namespace Math {
 
  public:
     GSLRootFinder();
-    virtual ~GSLRootFinder();
+    ~GSLRootFinder() override;
 
  private:
     // usually copying is non trivial, so we make this unaccessible
@@ -85,13 +85,13 @@ namespace Math {
 
 
 #if defined(__MAKECINT__) || defined(G__DICTIONARY)
-    bool SetFunction( const IGradFunction & , double ) {
+    bool SetFunction( const IGradFunction & , double ) override {
        std::cerr <<"GSLRootFinder - Error : this method must be used with a Root Finder algorithm using derivatives" << std::endl;
        return false;
     }
 #endif
 
-    bool SetFunction( const IGenFunction & f, double xlow, double xup);
+    bool SetFunction( const IGenFunction & f, double xlow, double xup) override;
 
     typedef double ( * GSLFuncPointer ) ( double, void *);
     bool SetFunction( GSLFuncPointer  f, void * params, double xlow, double xup);
@@ -99,26 +99,26 @@ namespace Math {
     using IRootFinderMethod::SetFunction;
 
     // iterate to find ROOTS return GSL_CONTINUE if iteration was successful or another error
-    int Iterate();
+    int Iterate() override;
 
-    double Root() const;
+    double Root() const override;
 
     //double XLower() const;
 
     //double XUpper() const;
 
     /// Find the root
-    bool Solve( int maxIter = 100, double absTol = 1E-8, double relTol = 1E-10);
+    bool Solve( int maxIter = 100, double absTol = 1E-8, double relTol = 1E-10) override;
 
     /// Return number of iterations
-    int Iterations() const {
+    int Iterations() const override {
        return fIter;
     }
 
     /// Return the status of last root finding
-    int Status() const { return fStatus; }
+    int Status() const override { return fStatus; }
 
-    const char * Name() const;
+    const char * Name() const override;
 
 
  protected:

--- a/math/mathmore/inc/Math/GSLRootFinderDeriv.h
+++ b/math/mathmore/inc/Math/GSLRootFinderDeriv.h
@@ -75,7 +75,7 @@ class GSLRootFinderDeriv: public IRootFinderMethod {
 
 public:
    GSLRootFinderDeriv();
-   virtual ~GSLRootFinderDeriv();
+   ~GSLRootFinderDeriv() override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -87,13 +87,13 @@ public:
 
 
 #if defined(__MAKECINT__) || defined(G__DICTIONARY)
-   bool SetFunction( const IGenFunction & , double , double ) {
+   bool SetFunction( const IGenFunction & , double , double ) override {
       std::cerr <<"GSLRootFinderDeriv - Error : Algorithm requirs derivatives" << std::endl;
       return false;
    }
 #endif
 
-   bool SetFunction( const IGradFunction & f, double xstart) {
+   bool SetFunction( const IGradFunction & f, double xstart) override {
       const void * p = &f;
       return SetFunction(  &GSLFunctionAdapter<IGradFunction>::F, &GSLFunctionAdapter<IGradFunction>::Df, &GSLFunctionAdapter<IGradFunction>::Fdf, const_cast<void *>(p), xstart );
    }
@@ -106,22 +106,22 @@ public:
    using IRootFinderMethod::SetFunction;
 
    /// iterate (return GSL_SUCCESS in case of successful iteration)
-   int Iterate();
+   int Iterate() override;
 
-   double Root() const;
+   double Root() const override;
 
    /// Find the root (return false if failed)
-   bool Solve( int maxIter = 100, double absTol = 1E-8, double relTol = 1E-10);
+   bool Solve( int maxIter = 100, double absTol = 1E-8, double relTol = 1E-10) override;
 
    /// Return number of iterations
-   int Iterations() const {
+   int Iterations() const override {
       return fIter;
    }
 
    /// Return the status of last root finding
-   int Status() const { return fStatus; }
+   int Status() const override { return fStatus; }
 
-   const char * Name() const;
+   const char * Name() const override;
 
 protected:
 

--- a/math/mathmore/inc/Math/GSLSimAnMinimizer.h
+++ b/math/mathmore/inc/Math/GSLSimAnMinimizer.h
@@ -83,7 +83,7 @@ namespace ROOT {
       /**
          Destructor (no operations)
       */
-      virtual ~GSLSimAnMinimizer();
+      ~GSLSimAnMinimizer() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -105,10 +105,10 @@ namespace ROOT {
 
    public:
       /// method to perform the minimization
-      virtual bool Minimize();
+      bool Minimize() override;
 
       /// number of calls
-      unsigned int NCalls() const;
+      unsigned int NCalls() const override;
 
       /// Get current minimizer option parameteres
       const GSLSimAnParams &MinimizerParameters() const { return fSolver.Params(); }

--- a/math/mathmore/inc/Math/MultiNumGradFunction.h
+++ b/math/mathmore/inc/Math/MultiNumGradFunction.h
@@ -79,18 +79,18 @@ public:
    /**
       Destructor (no operations)
    */
-   ~MultiNumGradFunction ()  {
+   ~MultiNumGradFunction () override  {
       if (fOwner) delete fFunc;
    }
 
 
    // method inheritaed from IFunction interface
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    unsigned int NCalls() const { return fNCalls; }
 
-   IMultiGenFunction * Clone() const {
+   IMultiGenFunction * Clone() const override {
       if (!fOwner)
          return new MultiNumGradFunction(*fFunc);
       else {
@@ -115,13 +115,13 @@ public:
 private:
 
 
-   double DoEval(const double * x) const {
+   double DoEval(const double * x) const override {
       fNCalls++;
       return (*fFunc)(x);
    }
 
    // calculate derivative using mathcore derivator
-   double DoDerivative (const double * x, unsigned int icoord  ) const;
+   double DoDerivative (const double * x, unsigned int icoord  ) const override;
 
    // adapat internal function type to IMultiGenFunction needed by derivative calculation
    const IMultiGenFunction * fFunc;

--- a/math/mathmore/inc/Math/Polynomial.h
+++ b/math/mathmore/inc/Math/Polynomial.h
@@ -97,7 +97,7 @@ public:
    Polynomial(double a, double b, double c, double d, double e);
 
 
-   virtual ~Polynomial() {}
+   ~Polynomial() override {}
 
    // use default copy-ctor and assignment operators
 
@@ -134,14 +134,14 @@ public:
    unsigned int Order() const { return fOrder; }
 
 
-   IGenFunction * Clone() const;
+   IGenFunction * Clone() const override;
 
    /**
        Optimized method to evaluate at the same time the function value and derivative at a point x.
        Implement the interface specified bby ROOT::Math::IGradientOneDim.
        In the case of polynomial there is no advantage to compute both at the same time
    */
-   void FdF (double x, double & f, double & df) const {
+   void FdF (double x, double & f, double & df) const override {
       f = (*this)(x);
       df = Derivative(x);
    }
@@ -149,11 +149,11 @@ public:
 
 private:
 
-   double DoEvalPar ( double x, const double * p ) const ;
+   double DoEvalPar ( double x, const double * p ) const override ;
 
-   double DoDerivative (double x) const ;
+   double DoDerivative (double x) const override ;
 
-   double DoParameterDerivative(double x, const double * p, unsigned int ipar) const;
+   double DoParameterDerivative(double x, const double * p, unsigned int ipar) const override;
 
 
    // cache order = number of params - 1)

--- a/math/mathmore/inc/Math/RootFinderAlgorithms.h
+++ b/math/mathmore/inc/Math/RootFinderAlgorithms.h
@@ -59,7 +59,7 @@ namespace Roots {
    public:
 
       Bisection();
-      virtual ~Bisection();
+      ~Bisection() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -81,7 +81,7 @@ namespace Roots {
    public:
 
       FalsePos();
-      virtual ~FalsePos();
+      ~FalsePos() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -106,7 +106,7 @@ namespace Roots {
    public:
 
       Brent();
-      virtual ~Brent();
+      ~Brent() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -134,7 +134,7 @@ namespace Roots {
    public:
 
       Newton();
-      virtual ~Newton();
+      ~Newton() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -157,7 +157,7 @@ namespace Roots {
    public:
 
       Secant();
-      virtual ~Secant();
+      ~Secant() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible
@@ -180,7 +180,7 @@ namespace Roots {
    public:
 
       Steffenson();
-      virtual ~Steffenson();
+      ~Steffenson() override;
 
    private:
       // usually copying is non trivial, so we make this unaccessible

--- a/math/mathmore/inc/Math/VavilovAccurate.h
+++ b/math/mathmore/inc/Math/VavilovAccurate.h
@@ -149,7 +149,7 @@ public:
    /**
      Destructor
    */
-   virtual ~VavilovAccurate();
+   ~VavilovAccurate() override;
 
 
 public:
@@ -159,7 +159,7 @@ public:
 
        @param x The Landau parameter \f$x = \lambda_L\f$
    */
-   double Pdf (double x) const;
+   double Pdf (double x) const override;
 
    /**
        Evaluate the Vavilov probability density function,
@@ -169,14 +169,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Pdf (double x, double kappa, double beta2);
+   double Pdf (double x, double kappa, double beta2) override;
 
    /**
        Evaluate the Vavilov cumulative probability density function
 
        @param x The Landau parameter \f$x = \lambda_L\f$
    */
-   double Cdf (double x) const;
+   double Cdf (double x) const override;
 
    /**
        Evaluate the Vavilov cumulative probability density function,
@@ -186,14 +186,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Cdf (double x, double kappa, double beta2);
+   double Cdf (double x, double kappa, double beta2) override;
 
    /**
        Evaluate the Vavilov complementary cumulative probability density function
 
        @param x The Landau parameter \f$x = \lambda_L\f$
    */
-   double Cdf_c (double x) const;
+   double Cdf_c (double x) const override;
 
    /**
        Evaluate the Vavilov complementary cumulative probability density function,
@@ -203,14 +203,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Cdf_c (double x, double kappa, double beta2);
+   double Cdf_c (double x, double kappa, double beta2) override;
 
    /**
        Evaluate the inverse of the Vavilov cumulative probability density function
 
        @param z The argument \f$z\f$, which must be in the range \f$0 \le z \le 1\f$
    */
-   double Quantile (double z) const;
+   double Quantile (double z) const override;
 
    /**
        Evaluate the inverse of the Vavilov cumulative probability density function,
@@ -220,14 +220,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Quantile (double z, double kappa, double beta2);
+   double Quantile (double z, double kappa, double beta2) override;
 
    /**
        Evaluate the inverse of the complementary Vavilov cumulative probability density function
 
        @param z The argument \f$z\f$, which must be in the range \f$0 \le z \le 1\f$
    */
-   double Quantile_c (double z) const;
+   double Quantile_c (double z) const override;
 
    /**
        Evaluate the inverse of the complementary Vavilov cumulative probability density function,
@@ -237,7 +237,7 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Quantile_c (double z, double kappa, double beta2);
+   double Quantile_c (double z, double kappa, double beta2) override;
 
    /**
       Change \f$\kappa\f$ and \f$\beta^2\f$ and recalculate coefficients if necessary
@@ -245,7 +245,7 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   virtual void SetKappaBeta2 (double kappa, double beta2);
+   void SetKappaBeta2 (double kappa, double beta2) override;
 
 
    /**
@@ -265,28 +265,28 @@ public:
       Return the minimum value of \f$\lambda\f$ for which \f$p(\lambda; \kappa, \beta^2)\f$
       is nonzero in the current approximation
    */
-   virtual double GetLambdaMin() const;
+   double GetLambdaMin() const override;
 
    /**
       Return the maximum value of \f$\lambda\f$ for which \f$p(\lambda; \kappa, \beta^2)\f$
       is nonzero in the current approximation
    */
-   virtual double GetLambdaMax() const;
+   double GetLambdaMax() const override;
 
    /**
       Return the current value of \f$\kappa\f$
    */
-   virtual double GetKappa()     const;
+   double GetKappa()     const override;
 
    /**
       Return the current value of \f$\beta^2\f$
    */
-   virtual double GetBeta2()     const;
+   double GetBeta2()     const override;
 
    /**
       Return the value of \f$\lambda\f$ where the pdf is maximal
    */
-   virtual double Mode() const;
+   double Mode() const override;
 
    /**
       Return the value of \f$\lambda\f$ where the pdf is maximal function,
@@ -295,7 +295,7 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$\kappa \ge 0.001 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   virtual double Mode(double kappa, double beta2);
+   double Mode(double kappa, double beta2) override;
 
    /**
       Return the current value of \f$\epsilon^+ = \epsilon^-\f$

--- a/math/mathmore/inc/Math/VavilovAccurateCdf.h
+++ b/math/mathmore/inc/Math/VavilovAccurateCdf.h
@@ -86,30 +86,30 @@ class VavilovAccurateCdf: public IParametricFunctionOneDim {
       /**
          Destructor
       */
-      virtual ~VavilovAccurateCdf ();
+      ~VavilovAccurateCdf () override;
 
       /**
          Access the parameter values
       */
-      virtual const double * Parameters() const;
+      const double * Parameters() const override;
 
       /**
          Set the parameter values
          @param p vector of doubles containing the parameter values (Norm, x0, xi, kappa, beta2).
 
       */
-      virtual void SetParameters(const double * p );
+      void SetParameters(const double * p ) override;
 
       /**
          Return the number of Parameters
       */
-      virtual unsigned int NPar() const;
+      unsigned int NPar() const override;
 
       /**
          Return the name of the i-th parameter (starting from zero)
          Overwrite if want to avoid the default name ("Par_0, Par_1, ...")
        */
-      virtual std::string ParameterName(unsigned int i) const;
+      std::string ParameterName(unsigned int i) const override;
 
       /**
          Evaluate the function
@@ -117,7 +117,7 @@ class VavilovAccurateCdf: public IParametricFunctionOneDim {
        @param x The Landau parameter \f$x = \lambda_L\f$
 
        */
-      virtual double DoEval(double x) const;
+      double DoEval(double x) const override;
 
       /**
          Evaluate the function, using parameters p
@@ -125,12 +125,12 @@ class VavilovAccurateCdf: public IParametricFunctionOneDim {
        @param x The Landau parameter \f$x = \lambda_L\f$
          @param p vector of doubles containing the parameter values (Norm, x0, xi, kappa, beta2).
        */
-      virtual double DoEvalPar(double x, const double * p) const;
+      double DoEvalPar(double x, const double * p) const override;
 
       /**
          Return a clone of the object
        */
-      virtual IBaseFunctionOneDim  * Clone() const;
+      IBaseFunctionOneDim  * Clone() const override;
 
    private:
      double fP[5];

--- a/math/mathmore/inc/Math/VavilovAccuratePdf.h
+++ b/math/mathmore/inc/Math/VavilovAccuratePdf.h
@@ -86,12 +86,12 @@ class VavilovAccuratePdf: public IParametricFunctionOneDim {
       /**
          Destructor
       */
-      virtual ~VavilovAccuratePdf ();
+      ~VavilovAccuratePdf () override;
 
       /**
          Access the parameter values
       */
-      virtual const double * Parameters() const;
+      const double * Parameters() const override;
 
       /**
          Set the parameter values
@@ -99,24 +99,24 @@ class VavilovAccuratePdf: public IParametricFunctionOneDim {
          @param p vector of doubles containing the parameter values (Norm, x0, xi, kappa, beta2).
 
       */
-      virtual void SetParameters(const double * p );
+      void SetParameters(const double * p ) override;
 
       /**
          Return the number of Parameters
       */
-      virtual unsigned int NPar() const;
+      unsigned int NPar() const override;
 
       /**
          Return the name of the i-th parameter (starting from zero)
        */
-      virtual std::string ParameterName(unsigned int i) const;
+      std::string ParameterName(unsigned int i) const override;
 
       /**
          Evaluate the function
 
        @param x The Landau parameter \f$x = \lambda_L\f$
        */
-      virtual double DoEval(double x) const;
+      double DoEval(double x) const override;
 
       /**
          Evaluate the function, using parameters p
@@ -124,12 +124,12 @@ class VavilovAccuratePdf: public IParametricFunctionOneDim {
        @param x The Landau parameter \f$x = \lambda_L\f$
          @param p vector of doubles containing the parameter values (Norm, x0, xi, kappa, beta2).
        */
-      virtual double DoEvalPar(double x, const double * p) const;
+      double DoEvalPar(double x, const double * p) const override;
 
       /**
          Return a clone of the object
        */
-      virtual IBaseFunctionOneDim  * Clone() const;
+      IBaseFunctionOneDim  * Clone() const override;
 
    private:
       double fP[5];

--- a/math/mathmore/inc/Math/VavilovAccurateQuantile.h
+++ b/math/mathmore/inc/Math/VavilovAccurateQuantile.h
@@ -86,36 +86,36 @@ class VavilovAccurateQuantile: public IParametricFunctionOneDim {
       /**
          Destructor
       */
-      virtual ~VavilovAccurateQuantile ();
+      ~VavilovAccurateQuantile () override;
 
       /**
          Access the parameter values
       */
-      virtual const double * Parameters() const;
+      const double * Parameters() const override;
 
       /**
          Set the parameter values
          @param p vector of doubles containing the parameter values (Norm, x0, xi, kappa, beta2).
 
       */
-      virtual void SetParameters(const double * p );
+      void SetParameters(const double * p ) override;
 
       /**
          Return the number of Parameters
       */
-      virtual unsigned int NPar() const;
+      unsigned int NPar() const override;
 
       /**
          Return the name of the i-th parameter (starting from zero)
        */
-      virtual std::string ParameterName(unsigned int i) const;
+      std::string ParameterName(unsigned int i) const override;
 
       /**
          Evaluate the function
 
        @param x The Quantile \f$z\f$ , \f$0 \le z \le 1\f$
        */
-      virtual double DoEval(double x) const;
+      double DoEval(double x) const override;
 
       /**
          Evaluate the function, using parameters p
@@ -123,12 +123,12 @@ class VavilovAccurateQuantile: public IParametricFunctionOneDim {
        @param x The Quantile \f$z\f$, \f$0 \le z \le 1\f$
          @param p vector of doubles containing the parameter values (Norm, x0, xi, kappa, beta2).
        */
-      virtual double DoEvalPar(double x, const double * p) const;
+      double DoEvalPar(double x, const double * p) const override;
 
       /**
          Return a clone of the object
        */
-      virtual IBaseFunctionOneDim  * Clone() const;
+      IBaseFunctionOneDim  * Clone() const override;
 
    private:
      double fP[5];

--- a/math/mathmore/inc/Math/VavilovFast.h
+++ b/math/mathmore/inc/Math/VavilovFast.h
@@ -131,7 +131,7 @@ public:
    /**
      Destructor
    */
-   virtual ~VavilovFast();
+   ~VavilovFast() override;
 
 
 public:
@@ -141,7 +141,7 @@ public:
 
        @param x The Landau parameter \f$x = \lambda_L\f$
    */
-   double Pdf (double x) const;
+   double Pdf (double x) const override;
 
    /**
        Evaluate the Vavilov probability density function,
@@ -151,14 +151,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$0.01 \le \kappa \le 12 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Pdf (double x, double kappa, double beta2);
+   double Pdf (double x, double kappa, double beta2) override;
 
    /**
        Evaluate the Vavilov cumulative probability density function
 
        @param x The Landau parameter \f$x = \lambda_L\f$
    */
-   double Cdf (double x) const;
+   double Cdf (double x) const override;
 
    /**
        Evaluate the Vavilov cumulative probability density function,
@@ -168,14 +168,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$0.01 \le \kappa \le 12 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Cdf (double x, double kappa, double beta2);
+   double Cdf (double x, double kappa, double beta2) override;
 
    /**
        Evaluate the Vavilov complementary cumulative probability density function
 
        @param x The Landau parameter \f$x = \lambda_L\f$
    */
-   double Cdf_c (double x) const;
+   double Cdf_c (double x) const override;
 
    /**
        Evaluate the Vavilov complementary cumulative probability density function,
@@ -185,14 +185,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$0.01 \le \kappa \le 12 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Cdf_c (double x, double kappa, double beta2);
+   double Cdf_c (double x, double kappa, double beta2) override;
 
    /**
        Evaluate the inverse of the Vavilov cumulative probability density function
 
        @param z The argument \f$z\f$, which must be in the range \f$0 \le z \le 1\f$
    */
-   double Quantile (double z) const;
+   double Quantile (double z) const override;
 
    /**
        Evaluate the inverse of the Vavilov cumulative probability density function,
@@ -202,14 +202,14 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$0.01 \le \kappa \le 12 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Quantile (double z, double kappa, double beta2);
+   double Quantile (double z, double kappa, double beta2) override;
 
    /**
        Evaluate the inverse of the complementary Vavilov cumulative probability density function
 
        @param z The argument \f$z\f$, which must be in the range \f$0 \le z \le 1\f$
    */
-   double Quantile_c (double z) const;
+   double Quantile_c (double z) const override;
 
    /**
        Evaluate the inverse of the complementary Vavilov cumulative probability density function,
@@ -219,7 +219,7 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$0.01 \le \kappa \le 12 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   double Quantile_c (double z, double kappa, double beta2);
+   double Quantile_c (double z, double kappa, double beta2) override;
 
    /**
       Change \f$\kappa\f$ and \f$\beta^2\f$ and recalculate coefficients if necessary
@@ -227,29 +227,29 @@ public:
        @param kappa The parameter \f$\kappa\f$, which must be in the range \f$0.01 \le \kappa \le 12 \f$
        @param beta2 The parameter \f$\beta^2\f$, which must be in the range \f$0 \le \beta^2 \le 1 \f$
    */
-   virtual void SetKappaBeta2 (double kappa, double beta2);
+   void SetKappaBeta2 (double kappa, double beta2) override;
 
    /**
       Return the minimum value of \f$\lambda\f$ for which \f$p(\lambda; \kappa, \beta^2)\f$
       is nonzero in the current approximation
    */
-   virtual double GetLambdaMin() const;
+   double GetLambdaMin() const override;
 
    /**
       Return the maximum value of \f$\lambda\f$ for which \f$p(\lambda; \kappa, \beta^2)\f$
       is nonzero in the current approximation
    */
-   virtual double GetLambdaMax() const;
+   double GetLambdaMax() const override;
 
    /**
       Return the current value of \f$\kappa\f$
    */
-   virtual double GetKappa()     const;
+   double GetKappa()     const override;
 
    /**
       Return the current value of \f$\beta^2\f$
    */
-   virtual double GetBeta2()     const;
+   double GetBeta2()     const override;
 
    /**
       Returns a static instance of class VavilovFast

--- a/math/mathmore/src/GSLMCIntegrationWorkspace.h
+++ b/math/mathmore/src/GSLMCIntegrationWorkspace.h
@@ -89,13 +89,13 @@ namespace Math {
          if (dim > 0) Init(dim);
       }
 
-      bool Init(size_t dim) {
+      bool Init(size_t dim) override {
          fWs = gsl_monte_vegas_alloc( dim);
          if (fWs) SetVegasParameters();
          return (fWs != 0);
       }
 
-      bool ReInit() {
+      bool ReInit() override {
          // according to the code - reinit just reset default GSL values
          if (!fWs) return false;
          int iret = gsl_monte_vegas_init( fWs );
@@ -103,7 +103,7 @@ namespace Math {
          return (iret == 0);
       }
 
-      void Clear() {
+      void Clear() override {
          if (fWs) gsl_monte_vegas_free( fWs);
          fWs = 0;
       }
@@ -115,7 +115,7 @@ namespace Math {
          if (fWs) SetVegasParameters();
       }
 
-      size_t NDim() const { return (fWs) ? fWs->dim : 0; }
+      size_t NDim() const override { return (fWs) ? fWs->dim : 0; }
 
       double Result() const {  return (fWs) ? fWs->result : -1;}
 
@@ -123,12 +123,12 @@ namespace Math {
 
       double Chisq() const {  return (fWs) ? fWs->chisq: -1;}
 
-      MCIntegration::Type Type() const { return MCIntegration::kVEGAS; }
+      MCIntegration::Type Type() const override { return MCIntegration::kVEGAS; }
 
       const VegasParameters & Parameters() const { return fParams; }
       VegasParameters & Parameters()  { return fParams; }
 
-      virtual ROOT::Math::IOptions * Options() const {
+      ROOT::Math::IOptions * Options() const override {
          return fParams();
       }
 
@@ -165,7 +165,7 @@ namespace Math {
       }
 
 
-      bool Init(size_t dim) {
+      bool Init(size_t dim) override {
          fWs = gsl_monte_miser_alloc( dim);
          // need this to set parameters according to dimension
          if (!fHaveNewParams) fParams = MiserParameters(dim);
@@ -173,7 +173,7 @@ namespace Math {
          return (fWs != 0);
       }
 
-      bool ReInit() {
+      bool ReInit() override {
          // according to the code - reinit just reset default GSL values
          if (!fWs) return false;
          int iret = gsl_monte_miser_init( fWs );
@@ -181,7 +181,7 @@ namespace Math {
          return (iret == 0);
       }
 
-      void Clear() {
+      void Clear() override {
          if (fWs) gsl_monte_miser_free( fWs);
          fWs = 0;
       }
@@ -194,15 +194,15 @@ namespace Math {
          if (fWs) SetMiserParameters();
       }
 
-      size_t NDim() const { return (fWs) ? fWs->dim : 0; }
+      size_t NDim() const override { return (fWs) ? fWs->dim : 0; }
 
-      MCIntegration::Type Type() const { return MCIntegration::kMISER; }
+      MCIntegration::Type Type() const override { return MCIntegration::kMISER; }
 
 
       const MiserParameters & Parameters() const { return fParams; }
       MiserParameters & Parameters()  { return fParams; }
 
-      virtual ROOT::Math::IOptions * Options() const {
+      ROOT::Math::IOptions * Options() const override {
          return fParams();
       }
 
@@ -235,19 +235,19 @@ namespace Math {
          fWs(0)
       {  }
 
-      bool Init(size_t dim) {
+      bool Init(size_t dim) override {
          fWs = gsl_monte_plain_alloc( dim);
          // no parameter exists for plain
          return (fWs != 0);
       }
 
-      bool ReInit() {
+      bool ReInit() override {
          if (!fWs) return false;
          int iret = gsl_monte_plain_init( fWs );
          return (iret == GSL_SUCCESS);
       }
 
-      void Clear() {
+      void Clear() override {
          if (fWs) gsl_monte_plain_free( fWs);
          fWs = 0;
       }
@@ -256,11 +256,11 @@ namespace Math {
 
       //void SetParameters(const struct PlainParameters &p);
 
-      MCIntegration::Type Type() const { return MCIntegration::kPLAIN; }
+      MCIntegration::Type Type() const override { return MCIntegration::kPLAIN; }
 
-      size_t NDim() const { return (fWs) ? fWs->dim : 0; }
+      size_t NDim() const override { return (fWs) ? fWs->dim : 0; }
 
-      virtual ROOT::Math::IOptions * Options() const {
+      ROOT::Math::IOptions * Options() const override {
          return 0;
       }
 

--- a/math/mathmore/src/GSLMultiRootSolver.h
+++ b/math/mathmore/src/GSLMultiRootSolver.h
@@ -170,7 +170,7 @@ public:
    /**
       Destructor (no operations)
    */
-   virtual ~GSLMultiRootSolver ()  {
+   ~GSLMultiRootSolver () override  {
       if (fSolver) gsl_multiroot_fsolver_free(fSolver);
       if (fVec != 0) gsl_vector_free(fVec);
    }
@@ -205,7 +205,7 @@ public:
 
 
    /// set the solver parameters
-   virtual int SetSolver(const std::vector<ROOT::Math::IMultiGenFunction*> & funcVec, const double * x) {
+   int SetSolver(const std::vector<ROOT::Math::IMultiGenFunction*> & funcVec, const double * x) override {
       // create a vector of the fit contributions
       // create function wrapper from an iterator of functions
       assert(fSolver !=0);
@@ -221,29 +221,29 @@ public:
       return gsl_multiroot_fsolver_set(fSolver, fFunctions.GetFunctions(), fVec);
    }
 
-   virtual const std::string & Name() const {
+   const std::string & Name() const override {
       return fName; 
    }
 
-   virtual int Iterate() {
+   int Iterate() override {
       if (fSolver == 0) return -1;
       return gsl_multiroot_fsolver_iterate(fSolver);
    }
 
    /// solution values at the current iteration
-   virtual gsl_vector * GetRoot() const {
+   gsl_vector * GetRoot() const override {
       if (fSolver == 0) return 0;
       return  gsl_multiroot_fsolver_root(fSolver);
    }
 
    /// return function values
-   virtual gsl_vector * GetF() const {
+   gsl_vector * GetF() const override {
       if (fSolver == 0) return 0;
       return  gsl_multiroot_fsolver_f(fSolver);
    }
 
    /// return function steps
-   virtual gsl_vector * GetDx() const {
+   gsl_vector * GetDx() const override {
       if (fSolver == 0) return 0;
       return gsl_multiroot_fsolver_dx(fSolver);
    }
@@ -283,7 +283,7 @@ public:
    /**
       Destructor (no operations)
    */
-   virtual ~GSLMultiRootDerivSolver ()  {
+   ~GSLMultiRootDerivSolver () override  {
       if (fDerivSolver) gsl_multiroot_fdfsolver_free(fDerivSolver);
       if (fVec != 0) gsl_vector_free(fVec);
    }
@@ -320,7 +320,7 @@ public:
 
 
    /// set the solver parameters for the case of derivative
-   virtual int SetSolver(const std::vector<ROOT::Math::IMultiGenFunction*> & funcVec, const double * x) {
+   int SetSolver(const std::vector<ROOT::Math::IMultiGenFunction*> & funcVec, const double * x) override {
       // create a vector of the fit contributions
       // need to create a vecctor of gradient functions, convert and store in the class
       // the new vector pointer
@@ -345,29 +345,29 @@ public:
       return gsl_multiroot_fdfsolver_set(fDerivSolver, fDerivFunctions.GetFunctions(), fVec);
    }
 
-   virtual const std::string & Name() const {
+   const std::string & Name() const override {
       return fName; 
    }
 
-   virtual int Iterate() {
+   int Iterate() override {
       if (fDerivSolver == 0) return -1;
       return gsl_multiroot_fdfsolver_iterate(fDerivSolver);
    }
 
    /// solution values at the current iteration
-   virtual gsl_vector * GetRoot() const {
+   gsl_vector * GetRoot() const override {
       if (fDerivSolver == 0) return 0;
       return gsl_multiroot_fdfsolver_root(fDerivSolver);
    }
 
    /// return function values
-   virtual gsl_vector * GetF() const {
+   gsl_vector * GetF() const override {
       if (fDerivSolver == 0) return 0;
       return  gsl_multiroot_fdfsolver_f(fDerivSolver);
    }
 
    /// return function steps
-   virtual gsl_vector * GetDx() const {
+   gsl_vector * GetDx() const override {
       if (fDerivSolver == 0) return 0;
       return  gsl_multiroot_fdfsolver_dx(fDerivSolver);
    }

--- a/math/mathmore/src/GSLNLSMinimizer.cxx
+++ b/math/mathmore/src/GSLNLSMinimizer.cxx
@@ -62,7 +62,7 @@ public:
       // constructor from al already existing Transformation object. Ownership of the transformation onbect is passed to caller
    }
 
-   ~FitTransformFunction() {
+   ~FitTransformFunction() override {
       if (fOwnTransformation) {
          assert(fTransform);
          delete fTransform;
@@ -70,7 +70,7 @@ public:
    }
 
    // re-implement data element
-   virtual double DataElement(const double *  x, unsigned i, double * g = 0) const {
+   double DataElement(const double *  x, unsigned i, double * g = 0) const override {
       // transform from x internal to x external
       const double * xExt = fTransform->Transformation(x);
       if ( g == 0) return fFunc.DataElement( xExt, i );
@@ -82,13 +82,13 @@ public:
    }
 
 
-   IMultiGenFunction * Clone() const {
+   IMultiGenFunction * Clone() const override {
       // not supported
       return 0;
    }
 
    // dimension (this is number of free dimensions)
-   unsigned int NDim() const {
+   unsigned int NDim() const override {
       return fTransform->NDim();
    }
 
@@ -117,7 +117,7 @@ private:
    FitTransformFunction(const FitTransformFunction& rhs);
    FitTransformFunction& operator=(const FitTransformFunction& rhs);
 
-   double DoEval(const double * x) const {
+   double DoEval(const double * x) const override {
       return fFunc( fTransform->Transformation(x) );
    }
 

--- a/math/mathmore/test/StatFunction.h
+++ b/math/mathmore/test/StatFunction.h
@@ -24,7 +24,7 @@ const int N_PAR = 2;
 
 class StatFunction : public ROOT::Math::IParamFunction {
 private:
-   double DoEvalPar(double x, const double *) const
+   double DoEvalPar(double x, const double *) const override
    {
       // use explicitly cached param values
       return fPdf(x, fParams[0], fParams[1]);
@@ -60,11 +60,11 @@ public:
       if (fXUp < INF) fHasUpRange = true;
    }
 
-   unsigned int NPar() const { return N_PAR; }
-   const double *Parameters() const { return fParams; }
-   ROOT::Math::IGenFunction *Clone() const { return new StatFunction(fPdf, fCdf, fQuant); }
+   unsigned int NPar() const override { return N_PAR; }
+   const double *Parameters() const override { return fParams; }
+   ROOT::Math::IGenFunction *Clone() const override { return new StatFunction(fPdf, fCdf, fQuant); }
 
-   void SetParameters(const double *p) { std::copy(p, p + N_PAR, fParams); }
+   void SetParameters(const double *p) override { std::copy(p, p + N_PAR, fParams); }
 
    void SetParameters(double p0, double p1)
    {

--- a/math/mathmore/test/simanTSP.cxx
+++ b/math/mathmore/test/simanTSP.cxx
@@ -115,18 +115,18 @@ public:
    }
 
 
-   virtual ~MySimAnFunc() {}
+   ~MySimAnFunc() override {}
 
    unsigned int Route(unsigned int i) const { return fRoute[i]; }
 
    const unsigned int * Route()  const { return fRoute; }
    unsigned int * Route()   { return fRoute; }
 
-   virtual MySimAnFunc * Clone() const { return new MySimAnFunc(*this); }
+   MySimAnFunc * Clone() const override { return new MySimAnFunc(*this); }
 
    std::vector<double> & AllDist() { return *fDist; }
 
-   virtual double Energy() const {
+   double Energy() const override {
       // calculate the energy
 
 
@@ -141,7 +141,7 @@ public:
       return enrg;
    }
 
-   virtual double Distance(const GSLSimAnFunc & f) const {
+   double Distance(const GSLSimAnFunc & f) const override {
       const MySimAnFunc * f2 = dynamic_cast<const MySimAnFunc *> (&f);
       assert (f2 != 0);
       double d = 0;
@@ -151,7 +151,7 @@ public:
       }
       return d;
    }
-   virtual void Step(const GSLRandomEngine & r, double ) {
+   void Step(const GSLRandomEngine & r, double ) override {
       // swap to city in the matrix
       int x1, x2, dummy;
 
@@ -171,7 +171,7 @@ public:
 
    }
 
-   virtual void Print() {
+   void Print() override {
       printf("  [");
       for (unsigned i = 0; i < N_CITIES; ++i) {
          printf(" %d ", fRoute[i]);
@@ -181,7 +181,7 @@ public:
    }
 
    // fast copy (need to keep base class type for using virtuality
-   virtual MySimAnFunc & FastCopy(const GSLSimAnFunc & f) {
+   MySimAnFunc & FastCopy(const GSLSimAnFunc & f) override {
       const MySimAnFunc * rhs = dynamic_cast<const MySimAnFunc *>(&f);
       assert (rhs != 0);
       std::copy(rhs->fRoute, rhs->fRoute + N_CITIES, fRoute);

--- a/math/mathmore/test/testChebyshev.cxx
+++ b/math/mathmore/test/testChebyshev.cxx
@@ -33,13 +33,13 @@ class GammaFunction : public ROOT::Math::IGenFunction {
 public:
 
 
-  ROOT::Math::IGenFunction * Clone() const {
+  ROOT::Math::IGenFunction * Clone() const override {
     return new GammaFunction();
   }
 
 private:
 
-  double DoEval ( double x) const {
+  double DoEval ( double x) const override {
     return ROOT::Math::tgamma(x);
   }
 

--- a/math/mathmore/test/testFunctor.cxx
+++ b/math/mathmore/test/testFunctor.cxx
@@ -108,16 +108,16 @@ class DerivFunction : public ROOT::Math::IMultiGenFunction {
 public:
 
 
-   unsigned int NDim() const { return 2; }
+   unsigned int NDim() const override { return 2; }
 
-   DerivFunction *  Clone() const {
+   DerivFunction *  Clone() const override {
       return new DerivFunction();
    }
 
 private:
 
 
-   double DoEval(const double *x) const {
+   double DoEval(const double *x) const override {
       return FUNC;
    }
 
@@ -128,14 +128,14 @@ class DerivFunction1D : public ROOT::Math::IGenFunction {
 
 public:
 
-   DerivFunction1D *  Clone() const {
+   DerivFunction1D *  Clone() const override {
       return new DerivFunction1D();
    }
 
 private:
 
 
-   double DoEval(double x) const {
+   double DoEval(double x) const override {
       return FUNC1D;
    }
 

--- a/math/matrix/inc/TDecompBK.h
+++ b/math/matrix/inc/TDecompBK.h
@@ -31,7 +31,7 @@ protected :
    Int_t    *fIpiv;     //[fNIpiv] row permutation index
    TMatrixD  fU;        // decomposed matrix so that a = u d u^T
 
-   virtual const TMatrixDBase &GetDecompMatrix() const { return fU; }
+   const TMatrixDBase &GetDecompMatrix() const override { return fU; }
 
 public :
 
@@ -40,34 +40,34 @@ public :
    TDecompBK(Int_t row_lwb,Int_t row_upb);
    TDecompBK(const TMatrixDSym &m,Double_t tol = 0.0);
    TDecompBK(const TDecompBK &another);
-   virtual ~TDecompBK() {if (fIpiv) delete [] fIpiv; fIpiv = 0; }
+   ~TDecompBK() override {if (fIpiv) delete [] fIpiv; fIpiv = 0; }
 
-   virtual       Int_t     GetNrows  () const { return fU.GetNrows(); }
-   virtual       Int_t     GetNcols  () const { return fU.GetNcols(); }
+         Int_t     GetNrows  () const override { return fU.GetNrows(); }
+         Int_t     GetNcols  () const override { return fU.GetNcols(); }
    const TMatrixD &GetU      ()       { if ( !TestBit(kDecomposed) ) Decompose();
                                                   return fU; }
 
    virtual       void      SetMatrix (const TMatrixDSym &a);
 
-   virtual Bool_t   Decompose  ();
-   virtual Bool_t   Solve      (      TVectorD &b);
-   virtual TVectorD Solve      (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   Solve      (      TMatrixDColumn &b);
-   virtual Bool_t   TransSolve (      TVectorD &b)            { return Solve(b); }
-   virtual TVectorD TransSolve (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   TransSolve (      TMatrixDColumn &b)      { return Solve(b); }
-   virtual void     Det        (Double_t &/*d1*/,Double_t &/*d2*/)
+   Bool_t   Decompose  () override;
+   Bool_t   Solve      (      TVectorD &b) override;
+   TVectorD Solve      (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   Solve      (      TMatrixDColumn &b) override;
+   Bool_t   TransSolve (      TVectorD &b) override            { return Solve(b); }
+   TVectorD TransSolve (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   TransSolve (      TMatrixDColumn &b) override      { return Solve(b); }
+   void     Det        (Double_t &/*d1*/,Double_t &/*d2*/) override
                                 { MayNotUse("Det(Double_t&,Double_t&)"); }
 
    Bool_t      Invert  (TMatrixDSym &inv);
    TMatrixDSym Invert  (Bool_t &status);
    TMatrixDSym Invert  () { Bool_t status; return Invert(status); }
 
-   void        Print(Option_t *opt ="") const; // *MENU*
+   void        Print(Option_t *opt ="") const override; // *MENU*
 
    TDecompBK &operator= (const TDecompBK &source);
 
-   ClassDef(TDecompBK,1) // Matrix Decomposition Bunch-Kaufman
+   ClassDefOverride(TDecompBK,1) // Matrix Decomposition Bunch-Kaufman
 };
 
 #endif

--- a/math/matrix/inc/TDecompBase.h
+++ b/math/matrix/inc/TDecompBase.h
@@ -62,7 +62,7 @@ protected :
 public :
    TDecompBase();
    TDecompBase(const TDecompBase &another);
-   virtual ~TDecompBase() {};
+   ~TDecompBase() override {};
 
    inline  Double_t GetTol       () const { return fTol; }
    inline  Double_t GetDet1      () const { return fDet1; }
@@ -86,11 +86,11 @@ public :
 
    virtual Bool_t   MultiSolve (TMatrixD &B);
 
-   void Print(Option_t *opt="") const;
+   void Print(Option_t *opt="") const override;
 
    TDecompBase &operator= (const TDecompBase &source);
 
-   ClassDef(TDecompBase,2) // Matrix Decomposition Base
+   ClassDefOverride(TDecompBase,2) // Matrix Decomposition Base
 };
 
 Double_t TDecompBase::SetTol(Double_t newTol)

--- a/math/matrix/inc/TDecompChol.h
+++ b/math/matrix/inc/TDecompChol.h
@@ -27,7 +27,7 @@ protected :
 
    TMatrixD fU; // decomposed matrix fU so that a = fU^T fU
 
-   virtual const TMatrixDBase &GetDecompMatrix() const { return fU; }
+   const TMatrixDBase &GetDecompMatrix() const override { return fU; }
 
 public :
 
@@ -37,33 +37,33 @@ public :
    TDecompChol(const TMatrixDSym &a,Double_t tol = 0.0);
    TDecompChol(const TMatrixD    &a,Double_t tol = 0.0);
    TDecompChol(const TDecompChol &another);
-   virtual ~TDecompChol() {}
+   ~TDecompChol() override {}
 
            const TMatrixDSym GetMatrix ();
-   virtual       Int_t       GetNrows  () const { return fU.GetNrows(); }
-   virtual       Int_t       GetNcols  () const { return fU.GetNcols(); }
+         Int_t       GetNrows  () const override { return fU.GetNrows(); }
+         Int_t       GetNcols  () const override { return fU.GetNcols(); }
            const TMatrixD   &GetU      () const { return fU; }
 
    virtual       void        SetMatrix (const TMatrixDSym &a);
 
-   virtual Bool_t   Decompose  ();
-   virtual Bool_t   Solve      (      TVectorD &b);
-   virtual TVectorD Solve      (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   Solve      (      TMatrixDColumn &b);
-   virtual Bool_t   TransSolve (      TVectorD &b)            { return Solve(b); }
-   virtual TVectorD TransSolve (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   TransSolve (      TMatrixDColumn &b)      { return Solve(b); }
-   virtual void     Det        (Double_t &d1,Double_t &d2);
+   Bool_t   Decompose  () override;
+   Bool_t   Solve      (      TVectorD &b) override;
+   TVectorD Solve      (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   Solve      (      TMatrixDColumn &b) override;
+   Bool_t   TransSolve (      TVectorD &b) override            { return Solve(b); }
+   TVectorD TransSolve (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   TransSolve (      TMatrixDColumn &b) override      { return Solve(b); }
+   void     Det        (Double_t &d1,Double_t &d2) override;
 
            Bool_t      Invert  (TMatrixDSym &inv);
            TMatrixDSym Invert  (Bool_t &status);
            TMatrixDSym Invert  () { Bool_t status; return Invert(status); }
 
-   void Print(Option_t *opt ="") const; // *MENU*
+   void Print(Option_t *opt ="") const override; // *MENU*
 
    TDecompChol &operator= (const TDecompChol &source);
 
-   ClassDef(TDecompChol,2) // Matrix Decompositition Cholesky
+   ClassDefOverride(TDecompChol,2) // Matrix Decompositition Cholesky
 };
 
 TVectorD NormalEqn(const TMatrixD &A,const TVectorD &b);

--- a/math/matrix/inc/TDecompLU.h
+++ b/math/matrix/inc/TDecompLU.h
@@ -35,7 +35,7 @@ protected :
    static Bool_t DecomposeLUCrout(TMatrixD &lu,Int_t *index,Double_t &sign,Double_t tol,Int_t &nrZeros);
    static Bool_t DecomposeLUGauss(TMatrixD &lu,Int_t *index,Double_t &sign,Double_t tol,Int_t &nrZeros);
 
-   virtual const TMatrixDBase &GetDecompMatrix() const { return fLU; }
+   const TMatrixDBase &GetDecompMatrix() const override { return fLU; }
 
 public :
 
@@ -44,35 +44,35 @@ public :
    TDecompLU(Int_t row_lwb,Int_t row_upb);
    TDecompLU(const TMatrixD &m,Double_t tol = 0.0,Int_t implicit = 1);
    TDecompLU(const TDecompLU &another);
-   virtual ~TDecompLU() {if (fIndex) delete [] fIndex; fIndex = 0; }
+   ~TDecompLU() override {if (fIndex) delete [] fIndex; fIndex = 0; }
 
            const TMatrixD  GetMatrix ();
-   virtual       Int_t     GetNrows  () const { return fLU.GetNrows(); }
-   virtual       Int_t     GetNcols  () const { return fLU.GetNcols(); }
+         Int_t     GetNrows  () const override { return fLU.GetNrows(); }
+         Int_t     GetNcols  () const override { return fLU.GetNcols(); }
            const TMatrixD &GetLU     ()       { if ( !TestBit(kDecomposed) ) Decompose();
                                                 return fLU; }
 
    virtual       void      SetMatrix (const TMatrixD &a);
 
-   virtual Bool_t   Decompose  ();
-   virtual Bool_t   Solve      (      TVectorD &b);
-   virtual TVectorD Solve      (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   Solve      (      TMatrixDColumn &b);
-   virtual Bool_t   TransSolve (      TVectorD &b);
-   virtual TVectorD TransSolve (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = TransSolve(x); return x; }
-   virtual Bool_t   TransSolve (      TMatrixDColumn &b);
-   virtual void     Det        (Double_t &d1,Double_t &d2);
+   Bool_t   Decompose  () override;
+   Bool_t   Solve      (      TVectorD &b) override;
+   TVectorD Solve      (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   Solve      (      TMatrixDColumn &b) override;
+   Bool_t   TransSolve (      TVectorD &b) override;
+   TVectorD TransSolve (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = TransSolve(x); return x; }
+   Bool_t   TransSolve (      TMatrixDColumn &b) override;
+   void     Det        (Double_t &d1,Double_t &d2) override;
 
    static  Bool_t   InvertLU  (TMatrixD &a,Double_t tol,Double_t *det=0);
    Bool_t           Invert    (TMatrixD &inv);
    TMatrixD         Invert    (Bool_t &status);
    TMatrixD         Invert    () { Bool_t status; return Invert(status); }
 
-   void Print(Option_t *opt ="") const; // *MENU*
+   void Print(Option_t *opt ="") const override; // *MENU*
 
    TDecompLU &operator= (const TDecompLU &source);
 
-   ClassDef(TDecompLU,1) // Matrix Decompositition LU
+   ClassDefOverride(TDecompLU,1) // Matrix Decompositition LU
 };
 
 #endif

--- a/math/matrix/inc/TDecompQRH.h
+++ b/math/matrix/inc/TDecompQRH.h
@@ -34,7 +34,7 @@ protected :
 
    static Bool_t QRH(TMatrixD &q,TVectorD &diagR,TVectorD &up,TVectorD &w,Double_t tol);
 
-   virtual const TMatrixDBase &GetDecompMatrix() const { return fR; }
+   const TMatrixDBase &GetDecompMatrix() const override { return fR; }
 
 public :
 
@@ -45,10 +45,10 @@ public :
    TDecompQRH(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    TDecompQRH(const TMatrixD &m,Double_t tol = 0.0); // be careful for slicing in operator=
    TDecompQRH(const TDecompQRH &another);
-   virtual ~TDecompQRH() {}
+   ~TDecompQRH() override {}
 
-   virtual       Int_t     GetNrows () const { return fQ.GetNrows(); }
-   virtual       Int_t     GetNcols () const { return fQ.GetNcols(); }
+         Int_t     GetNrows () const override { return fQ.GetNrows(); }
+         Int_t     GetNcols () const override { return fQ.GetNcols(); }
    virtual const TMatrixD &GetQ     ()       { if ( !TestBit(kDecomposed) ) Decompose();
                                                return fQ; }
    virtual const TMatrixD &GetR     ()       { if ( !TestBit(kDecomposed) ) Decompose();
@@ -63,24 +63,24 @@ public :
 
    virtual       void      SetMatrix(const TMatrixD &a);
 
-   virtual Bool_t   Decompose  ();
-   virtual Bool_t   Solve      (      TVectorD &b);
-   virtual TVectorD Solve      (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   Solve      (      TMatrixDColumn &b);
-   virtual Bool_t   TransSolve (      TVectorD &b);
-   virtual TVectorD TransSolve (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = TransSolve(x); return x; }
-   virtual Bool_t   TransSolve (      TMatrixDColumn &b);
-   virtual void     Det        (Double_t &d1,Double_t &d2);
+   Bool_t   Decompose  () override;
+   Bool_t   Solve      (      TVectorD &b) override;
+   TVectorD Solve      (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   Solve      (      TMatrixDColumn &b) override;
+   Bool_t   TransSolve (      TVectorD &b) override;
+   TVectorD TransSolve (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = TransSolve(x); return x; }
+   Bool_t   TransSolve (      TMatrixDColumn &b) override;
+   void     Det        (Double_t &d1,Double_t &d2) override;
 
            Bool_t   Invert     (TMatrixD &inv);
            TMatrixD Invert     (Bool_t &status);
            TMatrixD Invert     () { Bool_t status; return Invert(status); }
 
-   void Print(Option_t *opt ="") const; // *MENU*
+   void Print(Option_t *opt ="") const override; // *MENU*
 
    TDecompQRH &operator= (const TDecompQRH &source);
 
-   ClassDef(TDecompQRH,1) // Matrix Decompositition QRH
+   ClassDefOverride(TDecompQRH,1) // Matrix Decompositition QRH
 };
 
 #endif

--- a/math/matrix/inc/TDecompSVD.h
+++ b/math/matrix/inc/TDecompSVD.h
@@ -36,7 +36,7 @@ protected :
    static void   Diag_3       (TMatrixD &v,TMatrixD &u,TVectorD &sDiag,TVectorD &oDiag,Int_t k,Int_t l);
    static void   SortSingular (TMatrixD &v,TMatrixD &u,TVectorD &sDiag);
 
-   virtual const TMatrixDBase &GetDecompMatrix() const { return fU; }
+   const TMatrixDBase &GetDecompMatrix() const override { return fU; }
 
 public :
 
@@ -47,11 +47,11 @@ public :
    TDecompSVD(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    TDecompSVD(const TMatrixD &m,Double_t tol = 0.0);
    TDecompSVD(const TDecompSVD &another);
-   virtual ~TDecompSVD() {}
+   ~TDecompSVD() override {}
 
            const TMatrixD  GetMatrix ();
-   virtual Int_t     GetNrows  () const;
-   virtual Int_t     GetNcols  () const;
+   Int_t     GetNrows  () const override;
+   Int_t     GetNcols  () const override;
            const TMatrixD &GetU      ()       { if ( !TestBit(kDecomposed) ) Decompose();
                                                  return fU; }
            const TMatrixD &GetV      ()       { if ( !TestBit(kDecomposed) ) Decompose();
@@ -61,31 +61,31 @@ public :
 
    virtual       void      SetMatrix (const TMatrixD &a);
 
-   virtual Bool_t   Decompose  ();
-   virtual Bool_t   Solve      (      TVectorD &b);
-   virtual TVectorD Solve      (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x);
+   Bool_t   Decompose  () override;
+   Bool_t   Solve      (      TVectorD &b) override;
+   TVectorD Solve      (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x);
                                                                 const Int_t rowLwb = GetRowLwb();
                                                                 x.ResizeTo(rowLwb,rowLwb+GetNcols()-1);
                                                                 return x; }
-   virtual Bool_t   Solve      (      TMatrixDColumn &b);
-   virtual Bool_t   TransSolve (      TVectorD &b);
-   virtual TVectorD TransSolve (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = TransSolve(x);
+   Bool_t   Solve      (      TMatrixDColumn &b) override;
+   Bool_t   TransSolve (      TVectorD &b) override;
+   TVectorD TransSolve (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = TransSolve(x);
                                                                 const Int_t rowLwb = GetRowLwb();
                                                                 x.ResizeTo(rowLwb,rowLwb+GetNcols()-1);
                                                                 return x; }
-   virtual Bool_t   TransSolve (      TMatrixDColumn &b);
-   virtual Double_t Condition  ();
-   virtual void     Det        (Double_t &d1,Double_t &d2);
+   Bool_t   TransSolve (      TMatrixDColumn &b) override;
+   Double_t Condition  () override;
+   void     Det        (Double_t &d1,Double_t &d2) override;
 
            Bool_t   Invert     (TMatrixD &inv);
            TMatrixD Invert     (Bool_t &status);
            TMatrixD Invert     () {Bool_t status; return Invert(status); }
 
-   void Print(Option_t *opt ="") const; // *MENU*
+   void Print(Option_t *opt ="") const override; // *MENU*
 
    TDecompSVD &operator= (const TDecompSVD &source);
 
-   ClassDef(TDecompSVD,1) // Matrix Decompositition SVD
+   ClassDefOverride(TDecompSVD,1) // Matrix Decompositition SVD
 };
 
 #endif

--- a/math/matrix/inc/TDecompSparse.h
+++ b/math/matrix/inc/TDecompSparse.h
@@ -136,7 +136,7 @@ protected :
    inline void     SetThresholdPivoting(Double_t piv) { fCntl[1] = piv; }
    inline void     SetTreatAsZero      (Double_t tol) { fCntl[3] = tol; }
 
-   virtual const TMatrixDBase &GetDecompMatrix() const { MayNotUse("GetDecompMatrix()"); return fA; }
+   const TMatrixDBase &GetDecompMatrix() const override { MayNotUse("GetDecompMatrix()"); return fA; }
 
 public :
 
@@ -145,35 +145,35 @@ public :
    TDecompSparse(Int_t row_lwb,Int_t row_upb,Int_t nr_nonZeros,Int_t verbose);
    TDecompSparse(const TMatrixDSparse &a,Int_t verbose);
    TDecompSparse(const TDecompSparse &another);
-   virtual ~TDecompSparse() {}
+   ~TDecompSparse() override {}
 
    inline  void     SetVerbose (Int_t v) { fVerbose = (v) ? 1 : 0;
                                             if (fVerbose) { fIcntl[1] = fIcntl[2] = 1; fIcntl[3] = 2; }
                                             else          { fIcntl[1] = fIcntl[2] = fIcntl[3] = 0; }
                                          }
-   virtual Int_t    GetNrows   () const { return fA.GetNrows(); }
-   virtual Int_t    GetNcols   () const { return fA.GetNcols(); }
+   Int_t    GetNrows   () const override { return fA.GetNrows(); }
+   Int_t    GetNcols   () const override { return fA.GetNcols(); }
 
    virtual void     SetMatrix  (const TMatrixDSparse &a);
 
-   virtual Bool_t   Decompose  ();
-   virtual Bool_t   Solve      (      TVectorD &b);
-   virtual TVectorD Solve      (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   Solve      (      TMatrixDColumn & /*b*/)
+   Bool_t   Decompose  () override;
+   Bool_t   Solve      (      TVectorD &b) override;
+   TVectorD Solve      (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   Solve      (      TMatrixDColumn & /*b*/) override
                                { MayNotUse("Solve(TMatrixDColumn &)"); return kFALSE; }
-   virtual Bool_t   TransSolve (      TVectorD &b)            { return Solve(b); }
-   virtual TVectorD TransSolve (const TVectorD& b,Bool_t &ok) { TVectorD x = b; ok = Solve(x); return x; }
-   virtual Bool_t   TransSolve (      TMatrixDColumn & /*b*/)
+   Bool_t   TransSolve (      TVectorD &b) override            { return Solve(b); }
+   TVectorD TransSolve (const TVectorD& b,Bool_t &ok) override { TVectorD x = b; ok = Solve(x); return x; }
+   Bool_t   TransSolve (      TMatrixDColumn & /*b*/) override
                                { MayNotUse("TransSolve(TMatrixDColumn &)"); return kFALSE; }
 
-   virtual void     Det        (Double_t &/*d1*/,Double_t &/*d2*/)
+   void     Det        (Double_t &/*d1*/,Double_t &/*d2*/) override
                                 { MayNotUse("Det(Double_t&,Double_t&)"); }
 
-   void Print(Option_t *opt ="") const; // *MENU*
+   void Print(Option_t *opt ="") const override; // *MENU*
 
    TDecompSparse &operator= (const TDecompSparse &source);
 
-   ClassDef(TDecompSparse,1) // Matrix Decompositition LU
+   ClassDefOverride(TDecompSparse,1) // Matrix Decompositition LU
 };
 
 #endif

--- a/math/matrix/inc/TMatrixT.h
+++ b/math/matrix/inc/TMatrixT.h
@@ -80,7 +80,7 @@ public:
    TMatrixT(const TMatrixTSym <Element> &a,EMatrixCreatorsOp2 op,const TMatrixTSym<Element> &b);
    TMatrixT(const TMatrixTLazy<Element> &lazy_constructor);
 
-   virtual ~TMatrixT() { TMatrixT::Clear(); }
+   ~TMatrixT() override { TMatrixT::Clear(); }
 
    // Elementary constructors
 
@@ -107,17 +107,17 @@ public:
    void MultT(const TMatrixTSym<Element> &a,const TMatrixT   <Element> &b);
    void MultT(const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b) { Mult(a,b); }
 
-   virtual const Element *GetMatrixArray  () const;
-   virtual       Element *GetMatrixArray  ();
-   virtual const Int_t   *GetRowIndexArray() const { return 0; }
-   virtual       Int_t   *GetRowIndexArray()       { return 0; }
-   virtual const Int_t   *GetColIndexArray() const { return 0; }
-   virtual       Int_t   *GetColIndexArray()       { return 0; }
+   const Element *GetMatrixArray  () const override;
+         Element *GetMatrixArray  () override;
+   const Int_t   *GetRowIndexArray() const override { return 0; }
+         Int_t   *GetRowIndexArray() override       { return 0; }
+   const Int_t   *GetColIndexArray() const override { return 0; }
+         Int_t   *GetColIndexArray() override       { return 0; }
 
-   virtual       TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
-   virtual       TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
+         TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) override { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
+         TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) override { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
 
-   virtual void Clear(Option_t * /*option*/ ="") { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
+   void Clear(Option_t * /*option*/ ="") override { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
                                                    else fElements = 0;
                                                    this->fNelems = 0; }
 
@@ -130,19 +130,19 @@ public:
            TMatrixT    <Element> &Use     (TMatrixT<Element> &a);
    const   TMatrixT    <Element> &Use     (const TMatrixT<Element> &a) const;
 
-   virtual TMatrixTBase<Element> &GetSub  (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
-                                           TMatrixTBase<Element> &target,Option_t *option="S") const;
+   TMatrixTBase<Element> &GetSub  (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
+                                           TMatrixTBase<Element> &target,Option_t *option="S") const override;
            TMatrixT    <Element>  GetSub  (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Option_t *option="S") const;
-   virtual TMatrixTBase<Element> &SetSub  (Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source);
+   TMatrixTBase<Element> &SetSub  (Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source) override;
 
-   virtual TMatrixTBase<Element> &ResizeTo(Int_t nrows,Int_t ncols,Int_t /*nr_nonzeros*/ =-1);
-   virtual TMatrixTBase<Element> &ResizeTo(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t /*nr_nonzeros*/ =-1);
+   TMatrixTBase<Element> &ResizeTo(Int_t nrows,Int_t ncols,Int_t /*nr_nonzeros*/ =-1) override;
+   TMatrixTBase<Element> &ResizeTo(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t /*nr_nonzeros*/ =-1) override;
    inline  TMatrixTBase<Element> &ResizeTo(const TMatrixT<Element> &m) {
                                             return ResizeTo(m.GetRowLwb(),m.GetRowUpb(),m.GetColLwb(),m.GetColUpb());
                                  }
 
-   virtual Double_t Determinant  () const;
-   virtual void     Determinant  (Double_t &d1,Double_t &d2) const;
+   Double_t Determinant  () const override;
+   void     Determinant  (Double_t &d1,Double_t &d2) const override;
 
            TMatrixT<Element> &Invert      (Double_t *det=0);
            TMatrixT<Element> &InvertFast  (Double_t *det=0);
@@ -156,8 +156,8 @@ public:
    TMatrixT<Element> &NormByRow   (const TVectorT<Element> &v,Option_t *option="D");
 
    // Either access a_ij as a(i,j)
-   inline       Element                     operator()(Int_t rown,Int_t coln) const;
-   inline       Element                    &operator()(Int_t rown,Int_t coln);
+   inline       Element                     operator()(Int_t rown,Int_t coln) const override;
+   inline       Element                    &operator()(Int_t rown,Int_t coln) override;
 
    // or as a[i][j]
    inline const TMatrixTRow_const<Element>  operator[](Int_t rown) const { return TMatrixTRow_const<Element>(*this,rown); }
@@ -204,7 +204,7 @@ public:
 
    const TMatrixT<Element> EigenVectors(TVectorT<Element> &eigenValues) const;
 
-   ClassDef(TMatrixT,4) // Template of General Matrix class
+   ClassDefOverride(TMatrixT,4) // Template of General Matrix class
 };
 
 #ifndef __CINT__

--- a/math/matrix/inc/TMatrixTBase.h
+++ b/math/matrix/inc/TMatrixTBase.h
@@ -116,7 +116,7 @@ public:
      fNrows(0), fNcols(0), fRowLwb(0), fColLwb(0), fNelems(0), fNrowIndex(0),
      fTol(0), fIsOwner(kTRUE) { }
 
-   virtual ~TMatrixTBase() {}
+   ~TMatrixTBase() override {}
 
            inline       Int_t     GetRowLwb     () const { return fRowLwb; }
            inline       Int_t     GetRowUpb     () const { return fNrows+fRowLwb-1; }
@@ -139,7 +139,7 @@ public:
    virtual              TMatrixTBase<Element> &SetMatrixArray  (const Element *data,Option_t *option="");
            inline       Element                SetTol          (Element tol);
 
-   virtual void   Clear      (Option_t *option="") = 0;
+   void   Clear      (Option_t *option="") override = 0;
 
    inline  void   Invalidate ()       { SetBit(kStatus); }
    inline  void   MakeValid  ()       { ResetBit(kStatus); }
@@ -180,8 +180,8 @@ public:
    virtual Element Min        () const;
    virtual Element Max        () const;
 
-   void Draw (Option_t *option="");       // *MENU*
-   void Print(Option_t *name  ="") const; // *MENU*
+   void Draw (Option_t *option="") override;       // *MENU*
+   void Print(Option_t *name  ="") const override; // *MENU*
 
    virtual Element   operator()(Int_t rown,Int_t coln) const = 0;
    virtual Element  &operator()(Int_t rown,Int_t coln)       = 0;
@@ -201,7 +201,7 @@ public:
    // make it public since it can be called by TMatrixTRow
    static Element & NaNValue();
 
-   ClassDef(TMatrixTBase,5) // Matrix base class (template)
+   ClassDefOverride(TMatrixTBase,5) // Matrix base class (template)
 };
 
 #ifndef __CLING__

--- a/math/matrix/inc/TMatrixTLazy.h
+++ b/math/matrix/inc/TMatrixTLazy.h
@@ -64,14 +64,14 @@ public:
        : fRowUpb(nrows-1),fRowLwb(0),fColUpb(ncols-1),fColLwb(0) { }
    TMatrixTLazy(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb)
        : fRowUpb(row_upb),fRowLwb(row_lwb),fColUpb(col_upb),fColLwb(col_lwb) { }
-   virtual ~TMatrixTLazy() {}
+   ~TMatrixTLazy() override {}
 
    inline Int_t GetRowLwb() const { return fRowLwb; }
    inline Int_t GetRowUpb() const { return fRowUpb; }
    inline Int_t GetColLwb() const { return fColLwb; }
    inline Int_t GetColUpb() const { return fColUpb; }
 
-   ClassDef(TMatrixTLazy,3)  // Template of Lazy Matrix class
+   ClassDefOverride(TMatrixTLazy,3)  // Template of Lazy Matrix class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -105,12 +105,12 @@ public:
        : fRowUpb(nrows-1),fRowLwb(0) { }
    TMatrixTSymLazy(Int_t row_lwb,Int_t row_upb)
        : fRowUpb(row_upb),fRowLwb(row_lwb) { }
-   virtual ~TMatrixTSymLazy() {}
+   ~TMatrixTSymLazy() override {}
 
    inline Int_t GetRowLwb() const { return fRowLwb; }
    inline Int_t GetRowUpb() const { return fRowUpb; }
 
-   ClassDef(TMatrixTSymLazy,2)  // Template of Lazy Symmeytric class
+   ClassDefOverride(TMatrixTSymLazy,2)  // Template of Lazy Symmeytric class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -122,14 +122,14 @@ public:
 template<class Element> class THaarMatrixT: public TMatrixTLazy<Element> {
 
 private:
-   void FillIn(TMatrixT<Element> &m) const;
+   void FillIn(TMatrixT<Element> &m) const override;
 
 public:
    THaarMatrixT() {}
    THaarMatrixT(Int_t n,Int_t no_cols = 0);
    virtual ~THaarMatrixT() {}
 
-   ClassDef(THaarMatrixT,2)  // Template of Haar Matrix class
+   ClassDefOverride(THaarMatrixT,2)  // Template of Haar Matrix class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -141,7 +141,7 @@ public:
 template<class Element> class THilbertMatrixT : public TMatrixTLazy<Element> {
 
 private:
-   void FillIn(TMatrixT<Element> &m) const;
+   void FillIn(TMatrixT<Element> &m) const override;
 
 public:
    THilbertMatrixT() {}
@@ -149,7 +149,7 @@ public:
    THilbertMatrixT(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    virtual ~THilbertMatrixT() {}
 
-   ClassDef(THilbertMatrixT,2)  // Template of Hilbert Matrix class
+   ClassDefOverride(THilbertMatrixT,2)  // Template of Hilbert Matrix class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -161,7 +161,7 @@ public:
 template<class Element> class THilbertMatrixTSym : public TMatrixTSymLazy<Element> {
 
 private:
-   void FillIn(TMatrixTSym<Element> &m) const;
+   void FillIn(TMatrixTSym<Element> &m) const override;
 
 public:
    THilbertMatrixTSym() {}
@@ -169,7 +169,7 @@ public:
    THilbertMatrixTSym(Int_t row_lwb,Int_t row_upb);
    virtual ~THilbertMatrixTSym() {}
 
-   ClassDef(THilbertMatrixTSym,2)  // Template of Symmetric Hilbert Matrix class
+   ClassDefOverride(THilbertMatrixTSym,2)  // Template of Symmetric Hilbert Matrix class
 };
 
 #endif

--- a/math/matrix/inc/TMatrixTSparse.h
+++ b/math/matrix/inc/TMatrixTSparse.h
@@ -83,17 +83,17 @@ public:
    TMatrixTSparse(const TMatrixTSparse<Element> &a,EMatrixCreatorsOp2 op,const TMatrixT      <Element> &b);
    TMatrixTSparse(const TMatrixT      <Element> &a,EMatrixCreatorsOp2 op,const TMatrixTSparse<Element> &b);
 
-   virtual ~TMatrixTSparse() { TMatrixTSparse::Clear(); }
+   ~TMatrixTSparse() override { TMatrixTSparse::Clear(); }
 
-   virtual const Element *GetMatrixArray  () const;
-   virtual       Element *GetMatrixArray  ();
-   virtual const Int_t    *GetRowIndexArray() const;
-   virtual       Int_t    *GetRowIndexArray();
-   virtual const Int_t    *GetColIndexArray() const;
-   virtual       Int_t    *GetColIndexArray();
+   const Element *GetMatrixArray  () const override;
+         Element *GetMatrixArray  () override;
+   const Int_t    *GetRowIndexArray() const override;
+         Int_t    *GetRowIndexArray() override;
+   const Int_t    *GetColIndexArray() const override;
+         Int_t    *GetColIndexArray() override;
 
-   virtual TMatrixTBase<Element>   &SetRowIndexArray(Int_t *data) { memmove(fRowIndex,data,(this->fNrows+1)*sizeof(Int_t)); return *this; }
-   virtual TMatrixTBase<Element>   &SetColIndexArray(Int_t *data) { memmove(fColIndex,data,this->fNelems*sizeof(Int_t)); return *this; }
+   TMatrixTBase<Element>   &SetRowIndexArray(Int_t *data) override { memmove(fRowIndex,data,(this->fNrows+1)*sizeof(Int_t)); return *this; }
+   TMatrixTBase<Element>   &SetColIndexArray(Int_t *data) override { memmove(fColIndex,data,this->fNelems*sizeof(Int_t)); return *this; }
 
            TMatrixTSparse<Element> &SetSparseIndex  (Int_t nelem_new);
            TMatrixTSparse<Element> &SetSparseIndex  (const TMatrixTBase<Element> &another);
@@ -102,19 +102,19 @@ public:
            TMatrixTSparse<Element> &SetSparseIndexAB(const TMatrixTSparse<Element> &a,const TMatrixT      <Element> &b)
                                               { return SetSparseIndexAB(b,a); }
 
-   virtual void                     GetMatrix2Array (Element *data,Option_t * /*option*/ ="") const;
-   virtual TMatrixTBase<Element>   &SetMatrixArray  (const Element *data,Option_t * /*option*/="")
+   void                     GetMatrix2Array (Element *data,Option_t * /*option*/ ="") const override;
+   TMatrixTBase<Element>   &SetMatrixArray  (const Element *data,Option_t * /*option*/="") override
                                                     { memcpy(fElements,data,this->fNelems*sizeof(Element)); return *this; }
    virtual TMatrixTBase<Element>   &SetMatrixArray  (Int_t nr_nonzeros,Int_t *irow,Int_t *icol,Element *data);
-   virtual TMatrixTBase<Element>   &InsertRow       (Int_t row,Int_t col,const Element *v,Int_t n=-1);
-   virtual void                     ExtractRow      (Int_t row,Int_t col,      Element *v,Int_t n=-1) const;
+   TMatrixTBase<Element>   &InsertRow       (Int_t row,Int_t col,const Element *v,Int_t n=-1) override;
+   void                     ExtractRow      (Int_t row,Int_t col,      Element *v,Int_t n=-1) const override;
 
-   virtual TMatrixTBase<Element>   &ResizeTo(Int_t nrows,Int_t ncols,Int_t nr_nonzeros=-1);
-   virtual TMatrixTBase<Element>   &ResizeTo(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t nr_nonzeros=-1);
+   TMatrixTBase<Element>   &ResizeTo(Int_t nrows,Int_t ncols,Int_t nr_nonzeros=-1) override;
+   TMatrixTBase<Element>   &ResizeTo(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t nr_nonzeros=-1) override;
    inline  TMatrixTBase<Element>   &ResizeTo(const TMatrixTSparse<Element> &m) {return ResizeTo(m.GetRowLwb(),m.GetRowUpb(),m.GetColLwb(),
                                                                                                 m.GetColUpb(),m.GetNoElements()); }
 
-   virtual void Clear(Option_t * /*option*/ ="") { if (this->fIsOwner) {
+   void Clear(Option_t * /*option*/ ="") override { if (this->fIsOwner) {
                                                       if (fElements) { delete [] fElements; fElements = 0; }
                                                       if (fRowIndex) { delete [] fRowIndex; fRowIndex = 0; }
                                                       if (fColIndex) { delete [] fColIndex; fColIndex = 0; }
@@ -139,30 +139,30 @@ public:
            TMatrixTSparse<Element> &Use   (TMatrixTSparse<Element> &a);
    const   TMatrixTSparse<Element> &Use   (const TMatrixTSparse<Element> &a) const;
 
-   virtual TMatrixTBase<Element>   &GetSub(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
-                                            TMatrixTBase<Element> &target,Option_t *option="S") const;
+   TMatrixTBase<Element>   &GetSub(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
+                                            TMatrixTBase<Element> &target,Option_t *option="S") const override;
            TMatrixTSparse<Element>  GetSub(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Option_t *option="S") const;
-   virtual TMatrixTBase<Element>   &SetSub(Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source);
+   TMatrixTBase<Element>   &SetSub(Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source) override;
 
-   virtual Bool_t IsSymmetric() const { return (*this == TMatrixTSparse<Element>(kTransposed,*this)); }
+   Bool_t IsSymmetric() const override { return (*this == TMatrixTSparse<Element>(kTransposed,*this)); }
    TMatrixTSparse<Element> &Transpose (const TMatrixTSparse<Element> &source);
    inline TMatrixTSparse<Element> &T () { return this->Transpose(*this); }
 
    inline void Mult(const TMatrixTSparse<Element> &a,const TMatrixTSparse<Element> &b) { AMultB(a,b,0); }
 
-   virtual TMatrixTBase<Element> &Zero       ();
-   virtual TMatrixTBase<Element> &UnitMatrix ();
+   TMatrixTBase<Element> &Zero       () override;
+   TMatrixTBase<Element> &UnitMatrix () override;
 
-   virtual Element RowNorm () const;
-   virtual Element ColNorm () const;
-   virtual Int_t   NonZeros() const { return this->fNelems; }
+   Element RowNorm () const override;
+   Element ColNorm () const override;
+   Int_t   NonZeros() const override { return this->fNelems; }
 
-   virtual TMatrixTBase<Element> &NormByDiag(const TVectorT<Element> &/*v*/,Option_t * /*option*/)
+   TMatrixTBase<Element> &NormByDiag(const TVectorT<Element> &/*v*/,Option_t * /*option*/) override
                                               { MayNotUse("NormByDiag"); return *this; }
 
    // Either access a_ij as a(i,j)
-   Element  operator()(Int_t rown,Int_t coln) const;
-   Element &operator()(Int_t rown,Int_t coln);
+   Element  operator()(Int_t rown,Int_t coln) const override;
+   Element &operator()(Int_t rown,Int_t coln) override;
 
    // or as a[i][j]
    inline const TMatrixTSparseRow_const<Element> operator[](Int_t rown) const { return TMatrixTSparseRow_const<Element>(*this,rown); }
@@ -196,10 +196,10 @@ public:
                                                                                 AMultB(tmp,source,1);
                                                                                 return *this; }
 
-   virtual TMatrixTBase  <Element> &Randomize  (Element alpha,Element beta,Double_t &seed);
+   TMatrixTBase  <Element> &Randomize  (Element alpha,Element beta,Double_t &seed) override;
    virtual TMatrixTSparse<Element> &RandomizePD(Element alpha,Element beta,Double_t &seed);
 
-   ClassDef(TMatrixTSparse,3) // Template of Sparse Matrix class
+   ClassDefOverride(TMatrixTSparse,3) // Template of Sparse Matrix class
 };
 
 #ifndef __CINT__

--- a/math/matrix/inc/TMatrixTSym.h
+++ b/math/matrix/inc/TMatrixTSym.h
@@ -69,7 +69,7 @@ public:
    TMatrixTSym(const TMatrixTSym<Element> &a,EMatrixCreatorsOp2 op,const TMatrixTSym<Element> &b);
    TMatrixTSym(const TMatrixTSymLazy<Element> &lazy_constructor);
 
-   virtual ~TMatrixTSym() { TMatrixTSym::Clear(); }
+   ~TMatrixTSym() override { TMatrixTSym::Clear(); }
 
    // Elementary constructors
    void TMult(const TMatrixT   <Element> &a);
@@ -79,20 +79,20 @@ public:
    void Plus (const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b);
    void Minus(const TMatrixTSym<Element> &a,const TMatrixTSym<Element> &b);
 
-   virtual const Element *GetMatrixArray  () const;
-   virtual       Element *GetMatrixArray  ();
-   virtual const Int_t   *GetRowIndexArray() const { return 0; }
-   virtual       Int_t   *GetRowIndexArray()       { return 0; }
-   virtual const Int_t   *GetColIndexArray() const { return 0; }
-   virtual       Int_t   *GetColIndexArray()       { return 0; }
+   const Element *GetMatrixArray  () const override;
+         Element *GetMatrixArray  () override;
+   const Int_t   *GetRowIndexArray() const override { return 0; }
+         Int_t   *GetRowIndexArray() override       { return 0; }
+   const Int_t   *GetColIndexArray() const override { return 0; }
+         Int_t   *GetColIndexArray() override       { return 0; }
 
-   virtual       TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
-   virtual       TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
+         TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) override { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
+         TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) override { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
 
-   virtual void   Clear      (Option_t * /*option*/ ="") { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
+   void   Clear      (Option_t * /*option*/ ="") override { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
                                                            else fElements = 0;
                                                            this->fNelems = 0; }
-   virtual Bool_t IsSymmetric() const { return kTRUE; }
+   Bool_t IsSymmetric() const override { return kTRUE; }
 
            TMatrixTSym <Element> &Use           (Int_t row_lwb,Int_t row_upb,Element *data);
    const   TMatrixTSym <Element> &Use           (Int_t row_lwb,Int_t row_upb,const Element *data) const
@@ -104,22 +104,22 @@ public:
    const   TMatrixTSym <Element> &Use           (const TMatrixTSym<Element> &a) const;
 
            TMatrixTSym <Element> &GetSub        (Int_t row_lwb,Int_t row_upb,TMatrixTSym<Element> &target,Option_t *option="S") const;
-   virtual TMatrixTBase<Element> &GetSub        (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
-                                                TMatrixTBase<Element> &target,Option_t *option="S") const;
+   TMatrixTBase<Element> &GetSub        (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,
+                                                TMatrixTBase<Element> &target,Option_t *option="S") const override;
            TMatrixTSym <Element>  GetSub        (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Option_t *option="S") const;
            TMatrixTSym <Element> &SetSub        (Int_t row_lwb,const TMatrixTBase<Element> &source);
-   virtual TMatrixTBase<Element> &SetSub        (Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source);
+   TMatrixTBase<Element> &SetSub        (Int_t row_lwb,Int_t col_lwb,const TMatrixTBase<Element> &source) override;
 
-   virtual TMatrixTBase<Element> &SetMatrixArray(const Element *data, Option_t *option="");
+   TMatrixTBase<Element> &SetMatrixArray(const Element *data, Option_t *option="") override;
 
-   virtual TMatrixTBase<Element> &Shift         (Int_t row_shift,Int_t col_shift);
-   virtual TMatrixTBase<Element> &ResizeTo      (Int_t nrows,Int_t ncols,Int_t /*nr_nonzeros*/ =-1);
-   virtual TMatrixTBase<Element> &ResizeTo      (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t /*nr_nonzeros*/ =-1);
+   TMatrixTBase<Element> &Shift         (Int_t row_shift,Int_t col_shift) override;
+   TMatrixTBase<Element> &ResizeTo      (Int_t nrows,Int_t ncols,Int_t /*nr_nonzeros*/ =-1) override;
+   TMatrixTBase<Element> &ResizeTo      (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t /*nr_nonzeros*/ =-1) override;
    inline  TMatrixTBase<Element> &ResizeTo      (const TMatrixTSym<Element> &m) {
                                                 return ResizeTo(m.GetRowLwb(),m.GetRowUpb(),m.GetColLwb(),m.GetColUpb()); }
 
-   virtual Double_t      Determinant   () const;
-   virtual void          Determinant   (Double_t &d1,Double_t &d2) const;
+   Double_t      Determinant   () const override;
+   void          Determinant   (Double_t &d1,Double_t &d2) const override;
 
            TMatrixTSym<Element>  &Invert        (Double_t *det=0);
            TMatrixTSym<Element>  &InvertFast    (Double_t *det=0);
@@ -132,8 +132,8 @@ public:
            TMatrixTSym<Element>  &SimilarityT   (const TMatrixT   <Element> &n);
 
    // Either access a_ij as a(i,j)
-   inline       Element                    operator()(Int_t rown,Int_t coln) const;
-   inline       Element                   &operator()(Int_t rown,Int_t coln);
+   inline       Element                    operator()(Int_t rown,Int_t coln) const override;
+   inline       Element                   &operator()(Int_t rown,Int_t coln) override;
 
    // or as a[i][j]
    inline const TMatrixTRow_const<Element> operator[](Int_t rown) const { return TMatrixTRow_const<Element>(*this,rown); }
@@ -165,15 +165,15 @@ public:
    TMatrixTSym &operator+=(const TMatrixTSym &source);
    TMatrixTSym &operator-=(const TMatrixTSym &source);
 
-   TMatrixTBase<Element> &Apply(const TElementActionT   <Element> &action);
-   TMatrixTBase<Element> &Apply(const TElementPosActionT<Element> &action);
+   TMatrixTBase<Element> &Apply(const TElementActionT   <Element> &action) override;
+   TMatrixTBase<Element> &Apply(const TElementPosActionT<Element> &action) override;
 
-   virtual TMatrixTBase<Element> &Randomize  (Element alpha,Element beta,Double_t &seed);
+   TMatrixTBase<Element> &Randomize  (Element alpha,Element beta,Double_t &seed) override;
    virtual TMatrixTSym <Element> &RandomizePD(Element alpha,Element beta,Double_t &seed);
 
    const TMatrixT<Element> EigenVectors(TVectorT<Element> &eigenValues) const;
 
-   ClassDef(TMatrixTSym,2) // Template of Symmetric Matrix class
+   ClassDefOverride(TMatrixTSym,2) // Template of Symmetric Matrix class
 };
 #ifndef __CINT__
 // When building with -fmodules, it instantiates all pending instantiations,

--- a/math/matrix/inc/TMatrixTUtils.h
+++ b/math/matrix/inc/TMatrixTUtils.h
@@ -200,7 +200,7 @@ public:
    void operator+=(const TMatrixTRow_const<Element> &r);
    void operator*=(const TMatrixTRow_const<Element> &r);
 
-   ClassDef(TMatrixTRow,0)  // Template of General Matrix Row Access class
+   ClassDefOverride(TMatrixTRow,0)  // Template of General Matrix Row Access class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -302,7 +302,7 @@ public:
    void operator+=(const TMatrixTColumn_const<Element> &c);
    void operator*=(const TMatrixTColumn_const<Element> &c);
 
-   ClassDef(TMatrixTColumn,0)  // Template of General Matrix Column Access class
+   ClassDefOverride(TMatrixTColumn,0)  // Template of General Matrix Column Access class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -392,7 +392,7 @@ public:
    void operator+=(const TMatrixTDiag_const<Element> &d);
    void operator*=(const TMatrixTDiag_const<Element> &d);
 
-   ClassDef(TMatrixTDiag,0)  // Template of General Matrix Diagonal Access class
+   ClassDefOverride(TMatrixTDiag,0)  // Template of General Matrix Diagonal Access class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -478,7 +478,7 @@ public:
    void operator+=(const TMatrixTFlat_const<Element> &f);
    void operator*=(const TMatrixTFlat_const<Element> &f);
 
-   ClassDef(TMatrixTFlat,0)  // Template of General Matrix Flat Representation class
+   ClassDefOverride(TMatrixTFlat,0)  // Template of General Matrix Flat Representation class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -571,7 +571,7 @@ public:
    void operator*=(const TMatrixT         <Element> &m);
    void operator*=(const TMatrixTSym      <Element> &m);
 
-   ClassDef(TMatrixTSub,0)  // Template of Sub Matrix Access class
+   ClassDefOverride(TMatrixTSub,0)  // Template of Sub Matrix Access class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -637,7 +637,7 @@ public:
    void operator+=(const TMatrixTSparseRow_const<Element> &r);
    void operator*=(const TMatrixTSparseRow_const<Element> &r);
 
-   ClassDef(TMatrixTSparseRow,0)  // Template of Sparse Matrix Row Access class
+   ClassDefOverride(TMatrixTSparseRow,0)  // Template of Sparse Matrix Row Access class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -699,7 +699,7 @@ public:
    void operator+=(const TMatrixTSparseDiag_const<Element> &d);
    void operator*=(const TMatrixTSparseDiag_const<Element> &d);
 
-   ClassDef(TMatrixTSparseDiag,0)  // Template of Sparse Matrix Diagonal Access class
+   ClassDefOverride(TMatrixTSparseDiag,0)  // Template of Sparse Matrix Diagonal Access class
 };
 
 Double_t Drand(Double_t &ix);

--- a/math/matrix/inc/TVectorT.h
+++ b/math/matrix/inc/TVectorT.h
@@ -68,7 +68,7 @@ public:
 #ifndef __CINT__
    TVectorT(Int_t lwb,Int_t upb,Double_t iv1, ...);
 #endif
-   virtual ~TVectorT() { TVectorT::Clear(); }
+   ~TVectorT() override { TVectorT::Clear(); }
 
    inline          Int_t     GetLwb       () const { return fRowLwb; }
    inline          Int_t     GetUpb       () const { return fNrows+fRowLwb-1; }
@@ -171,13 +171,13 @@ public:
 
    void Add(const TVectorT<Element> &v);
    void Add(const TVectorT<Element> &v1, const TVectorT<Element> &v2);
-   void Clear(Option_t * /*option*/ ="") { if (fIsOwner) Delete_m(fNrows,fElements);
+   void Clear(Option_t * /*option*/ ="") override { if (fIsOwner) Delete_m(fNrows,fElements);
                                            else fElements = 0;
                                            fNrows = 0; }
-   void Draw (Option_t *option=""); // *MENU*
-   void Print(Option_t *option="") const;  // *MENU*
+   void Draw (Option_t *option="") override; // *MENU*
+   void Print(Option_t *option="") const override;  // *MENU*
 
-   ClassDef(TVectorT,4)  // Template of Vector class
+   ClassDefOverride(TVectorT,4)  // Template of Vector class
 };
 
 #ifndef __CINT__

--- a/math/minuit/inc/TFitter.h
+++ b/math/minuit/inc/TFitter.h
@@ -29,37 +29,37 @@ private:
 
 public:
    TFitter(Int_t maxpar = 25);
-   virtual ~TFitter();
-   virtual Double_t   Chisquare(Int_t npar, Double_t *params) const ;
-   virtual void       Clear(Option_t *option="");
-   virtual Int_t      ExecuteCommand(const char *command, Double_t *args, Int_t nargs);
+   ~TFitter() override;
+   Double_t   Chisquare(Int_t npar, Double_t *params) const override ;
+   void       Clear(Option_t *option="") override;
+   Int_t      ExecuteCommand(const char *command, Double_t *args, Int_t nargs) override;
    // virtual void       FitChisquare(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
    // virtual void       FitChisquareI(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
    // virtual void       FitLikelihood(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
    // virtual void       FitLikelihoodI(Int_t &npar, Double_t *gin, Double_t &f, Double_t *u, Int_t flag);
-   virtual void       FixParameter(Int_t ipar);
-   virtual void       GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95);
-   virtual void       GetConfidenceIntervals(TObject *obj, Double_t cl=0.95);
-   virtual Double_t  *GetCovarianceMatrix() const;
-   virtual Double_t   GetCovarianceMatrixElement(Int_t i, Int_t j) const;
-   virtual Int_t      GetErrors(Int_t ipar,Double_t &eplus, Double_t &eminus, Double_t &eparab, Double_t &globcc) const;
+   void       FixParameter(Int_t ipar) override;
+   void       GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95) override;
+   void       GetConfidenceIntervals(TObject *obj, Double_t cl=0.95) override;
+   Double_t  *GetCovarianceMatrix() const override;
+   Double_t   GetCovarianceMatrixElement(Int_t i, Int_t j) const override;
+   Int_t      GetErrors(Int_t ipar,Double_t &eplus, Double_t &eminus, Double_t &eparab, Double_t &globcc) const override;
    TMinuit           *GetMinuit() const {return fMinuit;}
-   virtual Int_t      GetNumberTotalParameters() const;
-   virtual Int_t      GetNumberFreeParameters() const;
-   virtual Double_t   GetParError(Int_t ipar) const;
-   virtual Double_t   GetParameter(Int_t ipar) const;
-   virtual Int_t      GetParameter(Int_t ipar,char *name,Double_t &value,Double_t &verr,Double_t &vlow, Double_t &vhigh) const;
-   virtual const char *GetParName(Int_t ipar) const;
-   virtual Int_t      GetStats(Double_t &amin, Double_t &edm, Double_t &errdef, Int_t &nvpar, Int_t &nparx) const;
-   virtual Double_t   GetSumLog(Int_t i);
-   virtual Bool_t     IsFixed(Int_t ipar) const;
-   virtual void       PrintResults(Int_t level, Double_t amin) const;
-   virtual void       ReleaseParameter(Int_t ipar);
-   virtual void       SetFCN(void (*fcn)(Int_t &, Double_t *, Double_t &f, Double_t *, Int_t));
-   virtual void       SetFitMethod(const char *name);
-   virtual Int_t      SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh);
+   Int_t      GetNumberTotalParameters() const override;
+   Int_t      GetNumberFreeParameters() const override;
+   Double_t   GetParError(Int_t ipar) const override;
+   Double_t   GetParameter(Int_t ipar) const override;
+   Int_t      GetParameter(Int_t ipar,char *name,Double_t &value,Double_t &verr,Double_t &vlow, Double_t &vhigh) const override;
+   const char *GetParName(Int_t ipar) const override;
+   Int_t      GetStats(Double_t &amin, Double_t &edm, Double_t &errdef, Int_t &nvpar, Int_t &nparx) const override;
+   Double_t   GetSumLog(Int_t i) override;
+   Bool_t     IsFixed(Int_t ipar) const override;
+   void       PrintResults(Int_t level, Double_t amin) const override;
+   void       ReleaseParameter(Int_t ipar) override;
+   void       SetFCN(void (*fcn)(Int_t &, Double_t *, Double_t &f, Double_t *, Int_t)) override;
+   void       SetFitMethod(const char *name) override;
+   Int_t      SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh) override;
 
-    ClassDef(TFitter,0)  //The ROOT standard fitter based on TMinuit
+    ClassDefOverride(TFitter,0)  //The ROOT standard fitter based on TMinuit
 };
 
 #endif

--- a/math/minuit/inc/TLinearFitter.h
+++ b/math/minuit/inc/TLinearFitter.h
@@ -216,7 +216,7 @@ public:
    TLinearFitter(Int_t ndim);
    TLinearFitter(TFormula *function, Option_t *opt="D");
    TLinearFitter(const TLinearFitter& tlf);
-   virtual ~TLinearFitter();
+   ~TLinearFitter() override;
 
    TLinearFitter& operator=(const TLinearFitter& tlf);
    virtual void       Add(TLinearFitter *tlf);
@@ -224,39 +224,39 @@ public:
    virtual void       AddTempMatrices();
    virtual void       AssignData(Int_t npoints, Int_t xncols, Double_t *x, Double_t *y, Double_t *e=0);
 
-   virtual void       Clear(Option_t *option="");
+   void       Clear(Option_t *option="") override;
    virtual void       ClearPoints();
    virtual void       Chisquare();
    virtual Int_t      Eval();
    virtual Int_t      EvalRobust(Double_t h=-1);
-   virtual Int_t      ExecuteCommand(const char *command, Double_t *args, Int_t nargs);
-   virtual void       FixParameter(Int_t ipar);
+   Int_t      ExecuteCommand(const char *command, Double_t *args, Int_t nargs) override;
+   void       FixParameter(Int_t ipar) override;
    virtual void       FixParameter(Int_t ipar, Double_t parvalue);
    virtual void       GetAtbVector(TVectorD &v);
    virtual Double_t   GetChisquare();
-   virtual void       GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95);
-   virtual void       GetConfidenceIntervals(TObject *obj, Double_t cl=0.95);
-   virtual Double_t*  GetCovarianceMatrix() const;
+   void       GetConfidenceIntervals(Int_t n, Int_t ndim, const Double_t *x, Double_t *ci, Double_t cl=0.95) override;
+   void       GetConfidenceIntervals(TObject *obj, Double_t cl=0.95) override;
+   Double_t*  GetCovarianceMatrix() const override;
    virtual void       GetCovarianceMatrix(TMatrixD &matr);
-   virtual Double_t   GetCovarianceMatrixElement(Int_t i, Int_t j) const {return fParCovar(i, j);}
+   Double_t   GetCovarianceMatrixElement(Int_t i, Int_t j) const override {return fParCovar(i, j);}
    virtual void       GetDesignMatrix(TMatrixD &matr);
    virtual void       GetErrors(TVectorD &vpar);
-   virtual Int_t      GetNumberTotalParameters() const {return fNfunctions;}
-   virtual Int_t      GetNumberFreeParameters() const {return fNfunctions-fNfixed;}
+   Int_t      GetNumberTotalParameters() const override {return fNfunctions;}
+   Int_t      GetNumberFreeParameters() const override {return fNfunctions-fNfixed;}
    virtual Int_t      GetNpoints() { return fNpoints; }
    virtual void       GetParameters(TVectorD &vpar);
-   virtual Double_t   GetParameter(Int_t ipar) const {return fParams(ipar);}
-   virtual Int_t      GetParameter(Int_t ipar,char* name,Double_t& value,Double_t& /*verr*/,Double_t& /*vlow*/, Double_t& /*vhigh*/) const;
-   virtual const char *GetParName(Int_t ipar) const;
-   virtual Double_t   GetParError(Int_t ipar) const;
+   Double_t   GetParameter(Int_t ipar) const override {return fParams(ipar);}
+   Int_t      GetParameter(Int_t ipar,char* name,Double_t& value,Double_t& /*verr*/,Double_t& /*vlow*/, Double_t& /*vhigh*/) const override;
+   const char *GetParName(Int_t ipar) const override;
+   Double_t   GetParError(Int_t ipar) const override;
    virtual Double_t   GetParTValue(Int_t ipar);
    virtual Double_t   GetParSignificance(Int_t ipar);
    virtual void       GetFitSample(TBits& bits);
    virtual Double_t   GetY2() const {return fY2;}
-   virtual Bool_t     IsFixed(Int_t ipar) const {return fFixedParams[ipar];}
+   Bool_t     IsFixed(Int_t ipar) const override {return fFixedParams[ipar];}
    virtual Int_t      Merge(TCollection *list);
-   virtual void       PrintResults(Int_t level, Double_t amin=0) const;
-   virtual void       ReleaseParameter(Int_t ipar);
+   void       PrintResults(Int_t level, Double_t amin=0) const override;
+   void       ReleaseParameter(Int_t ipar) override;
    virtual void       SetBasisFunctions(TObjArray * functions);
    virtual void       SetDim(Int_t n);
    virtual void       SetFormula(const char* formula);
@@ -266,15 +266,15 @@ public:
    virtual Bool_t     UpdateMatrix();
 
    //dummy functions for TVirtualFitter:
-   virtual Double_t  Chisquare(Int_t /*npar*/, Double_t * /*params*/) const {return 0;}
-   virtual Int_t     GetErrors(Int_t /*ipar*/,Double_t & /*eplus*/, Double_t & /*eminus*/, Double_t & /*eparab*/, Double_t & /*globcc*/) const {return 0;}
+   Double_t  Chisquare(Int_t /*npar*/, Double_t * /*params*/) const override {return 0;}
+   Int_t     GetErrors(Int_t /*ipar*/,Double_t & /*eplus*/, Double_t & /*eminus*/, Double_t & /*eparab*/, Double_t & /*globcc*/) const override {return 0;}
 
-   virtual Int_t     GetStats(Double_t& /*amin*/, Double_t& /*edm*/, Double_t& /*errdef*/, Int_t& /*nvpar*/, Int_t& /*nparx*/) const {return 0;}
-   virtual Double_t  GetSumLog(Int_t /*i*/) {return 0;}
-   virtual void      SetFitMethod(const char * /*name*/) {;}
-   virtual Int_t     SetParameter(Int_t /*ipar*/,const char * /*parname*/,Double_t /*value*/,Double_t /*verr*/,Double_t /*vlow*/, Double_t /*vhigh*/) {return 0;}
+   Int_t     GetStats(Double_t& /*amin*/, Double_t& /*edm*/, Double_t& /*errdef*/, Int_t& /*nvpar*/, Int_t& /*nparx*/) const override {return 0;}
+   Double_t  GetSumLog(Int_t /*i*/) override {return 0;}
+   void      SetFitMethod(const char * /*name*/) override {;}
+   Int_t     SetParameter(Int_t /*ipar*/,const char * /*parname*/,Double_t /*value*/,Double_t /*verr*/,Double_t /*vlow*/, Double_t /*vhigh*/) override {return 0;}
 
-   ClassDef(TLinearFitter, 2) //fit a set of data points with a linear combination of functions
+   ClassDefOverride(TLinearFitter, 2) //fit a set of data points with a linear combination of functions
 };
 
 #endif

--- a/math/minuit/inc/TLinearMinimizer.h
+++ b/math/minuit/inc/TLinearMinimizer.h
@@ -45,7 +45,7 @@ public:
    /**
       Destructor (no operations)
    */
-   virtual ~TLinearMinimizer ();
+   ~TLinearMinimizer () override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -63,59 +63,59 @@ private:
 public:
 
    /// set the fit model function
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
 
    /// set free variable (dummy impl. )
-   virtual bool SetVariable(unsigned int , const std::string & , double , double ) { return false; }
+   bool SetVariable(unsigned int , const std::string & , double , double ) override { return false; }
 
    /// set fixed variable (override if minimizer supports them )
-   virtual bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */);
+   bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */) override;
 
    /// method to perform the minimization
-   virtual  bool Minimize();
+    bool Minimize() override;
 
    /// return minimum function value
-   virtual double MinValue() const { return fMinVal; }
+   double MinValue() const override { return fMinVal; }
 
    /// return expected distance reached from the minimum
-   virtual double Edm() const { return 0; }
+   double Edm() const override { return 0; }
 
    /// return  pointer to X values at the minimum
-   virtual const double *  X() const { return &fParams.front(); }
+   const double *  X() const override { return &fParams.front(); }
 
    /// return pointer to gradient values at the minimum
-   virtual const double *  MinGradient() const { return 0; } // not available in Minuit2
+   const double *  MinGradient() const override { return 0; } // not available in Minuit2
 
    /// number of function calls to reach the minimum
-   virtual unsigned int NCalls() const { return 0; }
+   unsigned int NCalls() const override { return 0; }
 
    /// this is <= Function().NDim() which is the total
    /// number of variables (free+ constrained ones)
-   virtual unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    /// number of free variables (real dimension of the problem)
    /// this is <= Function().NDim() which is the total
-   virtual unsigned int NFree() const { return fNFree; }
+   unsigned int NFree() const override { return fNFree; }
 
    /// minimizer provides error and error matrix
-   virtual bool ProvidesError() const { return true; }
+   bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   virtual const double * Errors() const { return  (fErrors.empty()) ? 0 : &fErrors.front(); }
+   const double * Errors() const override { return  (fErrors.empty()) ? 0 : &fErrors.front(); }
 
    /** return covariance matrices elements
        if the variable is fixed the matrix is zero
        The ordering of the variables is the same as in errors
    */
-   virtual double CovMatrix(unsigned int i, unsigned int j) const {
+   double CovMatrix(unsigned int i, unsigned int j) const override {
       return (fCovar.empty()) ? 0 : fCovar[i + fDim* j];
    }
 
    /// return covariance matrix status
-   virtual int CovMatrixStatus() const {
+   int CovMatrixStatus() const override {
       if (fCovar.size() == 0) return 0;
       return (fStatus ==0) ? 3 : 1;
    }

--- a/math/minuit/inc/TMinuit.h
+++ b/math/minuit/inc/TMinuit.h
@@ -181,9 +181,9 @@ public:
 public:
    TMinuit();
    TMinuit(Int_t maxpar);
-   virtual       ~TMinuit();
+         ~TMinuit() override;
    virtual void   BuildArrays(Int_t maxpar=15);
-   virtual TObject *Clone(const char *newname="") const;   //Clone-Method to copy the function-pointer fFCN
+   TObject *Clone(const char *newname="") const override;   //Clone-Method to copy the function-pointer fFCN
    virtual Int_t  Command(const char *command);
    virtual TObject *Contour(Int_t npoints=10, Int_t pa1=0, Int_t pa2=1);
    virtual Int_t  DefineParameter( Int_t parNo, const char *name, Double_t initVal, Double_t initErr, Double_t lowerLimit, Double_t upperLimit );
@@ -265,7 +265,7 @@ public:
    virtual void   SetObjectFit(TObject *obj) {fObjectFit=obj;}
    virtual Int_t  SetPrintLevel( Int_t printLevel=0 );
 
-   ClassDef(TMinuit,1)  //The MINUIT minimisation package
+   ClassDefOverride(TMinuit,1)  //The MINUIT minimisation package
 };
 
 R__EXTERN TMinuit  *gMinuit;

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -65,7 +65,7 @@ public:
    /**
       Destructor (no operations)
    */
-   ~TMinuitMinimizer ();
+   ~TMinuitMinimizer () override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -83,85 +83,85 @@ private:
 public:
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction & func) override;
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction & func);
+   void SetFunction(const ROOT::Math::IMultiGradFunction & func) override;
 
    /// set free variable
-   virtual bool SetVariable(unsigned int ivar, const std::string & name, double val, double step);
+   bool SetVariable(unsigned int ivar, const std::string & name, double val, double step) override;
 
    /// set upper/lower limited variable (override if minimizer supports them )
-   virtual bool SetLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double /* lower */, double /* upper */);
+   bool SetLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double /* lower */, double /* upper */) override;
 
    /// set lower limit variable  (override if minimizer supports them )
-   virtual bool SetLowerLimitedVariable(unsigned int  ivar , const std::string & name , double val , double step , double lower );
+   bool SetLowerLimitedVariable(unsigned int  ivar , const std::string & name , double val , double step , double lower ) override;
 
    /// set upper limit variable (override if minimizer supports them )
-   virtual bool SetUpperLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double upper );
+   bool SetUpperLimitedVariable(unsigned int ivar , const std::string & name , double val , double step , double upper ) override;
 
    /// set fixed variable (override if minimizer supports them )
-   virtual bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */);
+   bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */) override;
 
    /// set the value of an existing variable
-   virtual bool SetVariableValue(unsigned int , double );
+   bool SetVariableValue(unsigned int , double ) override;
 
    /// set the step size of an existing variable
-   virtual bool SetVariableStepSize(unsigned int , double );
+   bool SetVariableStepSize(unsigned int , double ) override;
    /// set the lower-limit of an existing variable
-   virtual bool SetVariableLowerLimit(unsigned int , double );
+   bool SetVariableLowerLimit(unsigned int , double ) override;
    /// set the upper-limit of an existing variable
-   virtual bool SetVariableUpperLimit(unsigned int , double );
+   bool SetVariableUpperLimit(unsigned int , double ) override;
    /// set the limits of an existing variable
-   virtual bool SetVariableLimits(unsigned int ivar, double lower, double upper);
+   bool SetVariableLimits(unsigned int ivar, double lower, double upper) override;
    /// fix an existing variable
-   virtual bool FixVariable(unsigned int);
+   bool FixVariable(unsigned int) override;
    /// release an existing variable
-   virtual bool ReleaseVariable(unsigned int);
+   bool ReleaseVariable(unsigned int) override;
    /// query if an existing variable is fixed (i.e. considered constant in the minimization)
    /// note that by default all variables are not fixed
-   virtual bool IsFixedVariable(unsigned int) const;
+   bool IsFixedVariable(unsigned int) const override;
    /// get variable settings in a variable object (like ROOT::Fit::ParamsSettings)
-   virtual bool GetVariableSettings(unsigned int, ROOT::Fit::ParameterSettings & ) const;
+   bool GetVariableSettings(unsigned int, ROOT::Fit::ParameterSettings & ) const override;
 
 
    /// method to perform the minimization
-   virtual  bool Minimize();
+    bool Minimize() override;
 
    /// return minimum function value
-   virtual double MinValue() const;
+   double MinValue() const override;
 
    /// return expected distance reached from the minimum
-   virtual double Edm() const;
+   double Edm() const override;
 
    /// return  pointer to X values at the minimum
-   virtual const double *  X() const { return &fParams.front(); }
+   const double *  X() const override { return &fParams.front(); }
 
    /// return pointer to gradient values at the minimum
-   virtual const double *  MinGradient() const { return 0; } // not available in Minuit2
+   const double *  MinGradient() const override { return 0; } // not available in Minuit2
 
    /// number of function calls to reach the minimum
-   virtual unsigned int NCalls() const;
+   unsigned int NCalls() const override;
 
    /// this is <= Function().NDim() which is the total
    /// number of variables (free+ constrained ones)
-   virtual unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    /// number of free variables (real dimension of the problem)
    /// this is <= Function().NDim() which is the total
-   virtual unsigned int NFree() const;
+   unsigned int NFree() const override;
 
    /// minimizer provides error and error matrix
-   virtual bool ProvidesError() const { return true; }
+   bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   virtual const double * Errors() const { return  &fErrors.front(); }
+   const double * Errors() const override { return  &fErrors.front(); }
 
    /** return covariance matrices elements
        if the variable is fixed the matrix is zero
        The ordering of the variables is the same as in errors
    */
-   virtual double CovMatrix(unsigned int i, unsigned int j) const {
+   double CovMatrix(unsigned int i, unsigned int j) const override {
       return ( fCovar.size() > (i + fDim* j) ) ? fCovar[i + fDim* j] : 0;
    }
 
@@ -173,7 +173,7 @@ public:
        This is different from the direct interface of Minuit2 or TMinuit where the
        values were obtained only to variable parameters
    */
-   virtual bool GetCovMatrix(double * cov) const;
+   bool GetCovMatrix(double * cov) const override;
 
    /**
        Fill the passed array with the Hessian matrix elements
@@ -182,52 +182,52 @@ public:
        If the variable is fixed or const the values for that variables are zero.
        The array will be filled as h[i *ndim + j]
    */
-   virtual bool GetHessianMatrix(double * h) const;
+   bool GetHessianMatrix(double * h) const override;
 
    ///return status of covariance matrix
-   virtual int CovMatrixStatus() const;
+   int CovMatrixStatus() const override;
 
    ///global correlation coefficient for variable i
-   virtual double GlobalCC(unsigned int ) const;
+   double GlobalCC(unsigned int ) const override;
 
    /// minos error for variable i, return false if Minos failed
-   virtual bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0);
+   bool GetMinosError(unsigned int i, double & errLow, double & errUp, int = 0) override;
 
    /// minos status code of last Minos run
    /// minos status = -1   : Minos is not run
    ///              =  0   : last MINOS run was succesfull
    ///              >  0   : some problems encountered when running MINOS
-   virtual int MinosStatus() const { return fMinosStatus; }
+   int MinosStatus() const override { return fMinosStatus; }
 
    /**
       perform a full calculation of the Hessian matrix for error calculation
     */
-   virtual bool Hesse();
+   bool Hesse() override;
 
    /**
       scan a parameter i around the minimum. A minimization must have been done before,
       return false if it is not the case
     */
-   virtual bool Scan(unsigned int i, unsigned int &nstep, double * x, double * y, double xmin = 0, double xmax = 0);
+   bool Scan(unsigned int i, unsigned int &nstep, double * x, double * y, double xmin = 0, double xmax = 0) override;
 
    /**
       find the contour points (xi,xj) of the function for parameter i and j around the minimum
       The contour will be find for value of the function = Min + ErrorUp();
     */
-   virtual bool Contour(unsigned int i, unsigned int j, unsigned int & npoints, double *xi, double *xj);
+   bool Contour(unsigned int i, unsigned int j, unsigned int & npoints, double *xi, double *xj) override;
 
 
-   virtual void PrintResults();
+   void PrintResults() override;
 
    /// return reference to the objective function
    ///virtual const ROOT::Math::IGenFunction & Function() const;
 
    /// get name of variables (override if minimizer support storing of variable names)
-   virtual std::string VariableName(unsigned int ivar) const;
+   std::string VariableName(unsigned int ivar) const override;
 
    /// get index of variable given a variable given a name
    /// return always -1 . (It is Not implemented)
-   virtual int VariableIndex(const std::string & name) const;
+   int VariableIndex(const std::string & name) const override;
 
    /// static function to switch on/off usage of static global TMinuit instance (gMinuit)
    /// By default it is used (i.e. is on). Method returns the previous state

--- a/math/minuit2/inc/Minuit2/AnalyticalGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/AnalyticalGradientCalculator.h
@@ -27,11 +27,11 @@ public:
    {
    }
 
-   ~AnalyticalGradientCalculator() {}
+   ~AnalyticalGradientCalculator() override {}
 
-   virtual FunctionGradient operator()(const MinimumParameters &) const;
+   FunctionGradient operator()(const MinimumParameters &) const override;
 
-   virtual FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const;
+   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 
    virtual bool CheckGradient() const;
 

--- a/math/minuit2/inc/Minuit2/BFGSErrorUpdator.h
+++ b/math/minuit2/inc/Minuit2/BFGSErrorUpdator.h
@@ -24,9 +24,9 @@ class BFGSErrorUpdator : public MinimumErrorUpdator {
 public:
    BFGSErrorUpdator() {}
 
-   virtual ~BFGSErrorUpdator() {}
+   ~BFGSErrorUpdator() override {}
 
-   virtual MinimumError Update(const MinimumState &, const MinimumParameters &, const FunctionGradient &) const;
+   MinimumError Update(const MinimumState &, const MinimumParameters &, const FunctionGradient &) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/CombinedMinimizer.h
+++ b/math/minuit2/inc/Minuit2/CombinedMinimizer.h
@@ -32,11 +32,11 @@ class CombinedMinimizer : public ModularFunctionMinimizer {
 public:
    CombinedMinimizer() : fMinSeedGen(MnSeedGenerator()), fMinBuilder(CombinedMinimumBuilder()) {}
 
-   ~CombinedMinimizer() {}
+   ~CombinedMinimizer() override {}
 
-   const MinimumSeedGenerator &SeedGenerator() const { return fMinSeedGen; }
-   const MinimumBuilder &Builder() const { return fMinBuilder; }
-   MinimumBuilder &Builder() { return fMinBuilder; }
+   const MinimumSeedGenerator &SeedGenerator() const override { return fMinSeedGen; }
+   const MinimumBuilder &Builder() const override { return fMinBuilder; }
+   MinimumBuilder &Builder() override { return fMinBuilder; }
 
 private:
    MnSeedGenerator fMinSeedGen;

--- a/math/minuit2/inc/Minuit2/CombinedMinimumBuilder.h
+++ b/math/minuit2/inc/Minuit2/CombinedMinimumBuilder.h
@@ -23,19 +23,19 @@ class CombinedMinimumBuilder : public MinimumBuilder {
 public:
    CombinedMinimumBuilder() : fVMMinimizer(VariableMetricMinimizer()), fSimplexMinimizer(SimplexMinimizer()) {}
 
-   ~CombinedMinimumBuilder() {}
+   ~CombinedMinimumBuilder() override {}
 
-   virtual FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
-                                   unsigned int, double) const;
+   FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
+                                   unsigned int, double) const override;
 
    // re-implement setter of base class. Need also to store in the base class for consistency
-   virtual void SetPrintLevel(int level)
+   void SetPrintLevel(int level) override
    {
       MinimumBuilder::SetPrintLevel(level);
       fVMMinimizer.Builder().SetPrintLevel(level);
       fSimplexMinimizer.Builder().SetPrintLevel(level);
    }
-   virtual void SetStorageLevel(int level)
+   void SetStorageLevel(int level) override
    {
       MinimumBuilder::SetStorageLevel(level);
       fVMMinimizer.Builder().SetStorageLevel(level);
@@ -43,7 +43,7 @@ public:
    }
 
    // set trace object (user manages it)
-   virtual void SetTraceObject(MnTraceObject &obj)
+   void SetTraceObject(MnTraceObject &obj) override
    {
       MinimumBuilder::SetTraceObject(obj);
       fVMMinimizer.Builder().SetTraceObject(obj);

--- a/math/minuit2/inc/Minuit2/DavidonErrorUpdator.h
+++ b/math/minuit2/inc/Minuit2/DavidonErrorUpdator.h
@@ -24,9 +24,9 @@ class DavidonErrorUpdator : public MinimumErrorUpdator {
 public:
    DavidonErrorUpdator() {}
 
-   virtual ~DavidonErrorUpdator() {}
+   ~DavidonErrorUpdator() override {}
 
-   virtual MinimumError Update(const MinimumState &, const MinimumParameters &, const FunctionGradient &) const;
+   MinimumError Update(const MinimumState &, const MinimumParameters &, const FunctionGradient &) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/ExternalInternalGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/ExternalInternalGradientCalculator.h
@@ -35,11 +35,11 @@ public:
    {
    }
 
-   ~ExternalInternalGradientCalculator() {}
+   ~ExternalInternalGradientCalculator() override {}
 
-   virtual FunctionGradient operator()(const MinimumParameters &) const;
+   FunctionGradient operator()(const MinimumParameters &) const override;
 
-   virtual FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const;
+   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 };
 
 } // namespace Minuit2

--- a/math/minuit2/inc/Minuit2/FCNAdapter.h
+++ b/math/minuit2/inc/Minuit2/FCNAdapter.h
@@ -35,13 +35,13 @@ class FCNAdapter : public FCNBase {
 public:
    FCNAdapter(const Function &f, double up = 1.) : fFunc(f), fUp(up) {}
 
-   ~FCNAdapter() {}
+   ~FCNAdapter() override {}
 
-   double operator()(const std::vector<double> &v) const { return fFunc.operator()(&v[0]); }
+   double operator()(const std::vector<double> &v) const override { return fFunc.operator()(&v[0]); }
    double operator()(const double *v) const { return fFunc.operator()(v); }
-   double Up() const { return fUp; }
+   double Up() const override { return fUp; }
 
-   void SetErrorDef(double up) { fUp = up; }
+   void SetErrorDef(double up) override { fUp = up; }
 
    // virtual std::vector<double> Gradient(const std::vector<double>&) const;
 

--- a/math/minuit2/inc/Minuit2/FCNBase.h
+++ b/math/minuit2/inc/Minuit2/FCNBase.h
@@ -45,7 +45,7 @@ Interface (abstract class) defining the function to be minimized, which has to b
 class FCNBase : public GenericFunction {
 
 public:
-   virtual ~FCNBase() {}
+   ~FCNBase() override {}
 
    /**
 
@@ -69,7 +69,7 @@ public:
 
    */
 
-   virtual double operator()(const std::vector<double> &v) const = 0;
+   double operator()(const std::vector<double> &v) const override = 0;
 
    /**
 

--- a/math/minuit2/inc/Minuit2/FCNGradAdapter.h
+++ b/math/minuit2/inc/Minuit2/FCNGradAdapter.h
@@ -36,7 +36,7 @@ class FCNGradAdapter : public FCNGradientBase {
 public:
    FCNGradAdapter(const Function &f, double up = 1.) : fFunc(f), fUp(up), fGrad(std::vector<double>(fFunc.NDim())) {}
 
-   ~FCNGradAdapter() {}
+   ~FCNGradAdapter() override {}
 
    double operator()(const std::vector<double> &v) const override { return fFunc.operator()(&v[0]); }
    double operator()(const double *v) const { return fFunc.operator()(v); }

--- a/math/minuit2/inc/Minuit2/FCNGradientBase.h
+++ b/math/minuit2/inc/Minuit2/FCNGradientBase.h
@@ -38,7 +38,7 @@ enum class GradientParameterSpace {
 class FCNGradientBase : public FCNBase {
 
 public:
-   virtual ~FCNGradientBase() {}
+   ~FCNGradientBase() override {}
 
    virtual std::vector<double> Gradient(const std::vector<double> &) const = 0;
    virtual std::vector<double> GradientWithPrevResult(const std::vector<double> &parameters, double * /*previous_grad*/,

--- a/math/minuit2/inc/Minuit2/FumiliBuilder.h
+++ b/math/minuit2/inc/Minuit2/FumiliBuilder.h
@@ -42,7 +42,7 @@ class FumiliBuilder : public MinimumBuilder {
 public:
    FumiliBuilder() : fEstimator(VariableMetricEDMEstimator()), fErrorUpdator(FumiliErrorUpdator()) {}
 
-   ~FumiliBuilder() {}
+   ~FumiliBuilder() override {}
 
    /**
 
@@ -71,9 +71,9 @@ public:
 
    */
 
-   virtual FunctionMinimum Minimum(const MnFcn &fMnFcn, const GradientCalculator &fGradienCalculator,
+   FunctionMinimum Minimum(const MnFcn &fMnFcn, const GradientCalculator &fGradienCalculator,
                                    const MinimumSeed &fMinimumSeed, const MnStrategy &fMnStrategy, unsigned int maxfcn,
-                                   double edmval) const;
+                                   double edmval) const override;
 
    /**
 

--- a/math/minuit2/inc/Minuit2/FumiliChi2FCN.h
+++ b/math/minuit2/inc/Minuit2/FumiliChi2FCN.h
@@ -51,7 +51,7 @@ class FumiliChi2FCN : public FumiliFCNBase {
 public:
    FumiliChi2FCN() {}
 
-   virtual ~FumiliChi2FCN() {}
+   ~FumiliChi2FCN() override {}
 
    /**
 
@@ -129,7 +129,7 @@ public:
 
    */
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double chiSquare = 0.0;
@@ -148,7 +148,7 @@ public:
 
    */
 
-   virtual double Up() const { return 1.0; }
+   double Up() const override { return 1.0; }
 
 private:
    // A pointer to the model function which describes the data

--- a/math/minuit2/inc/Minuit2/FumiliErrorUpdator.h
+++ b/math/minuit2/inc/Minuit2/FumiliErrorUpdator.h
@@ -49,7 +49,7 @@ class FumiliErrorUpdator : public MinimumErrorUpdator {
 public:
    FumiliErrorUpdator() {}
 
-   ~FumiliErrorUpdator() {}
+   ~FumiliErrorUpdator() override {}
 
    /**
 
@@ -87,7 +87,7 @@ public:
 
    */
 
-   virtual MinimumError Update(const MinimumState &, const MinimumParameters &, const FunctionGradient &) const;
+   MinimumError Update(const MinimumState &, const MinimumParameters &, const FunctionGradient &) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/FumiliFCNAdapter.h
+++ b/math/minuit2/inc/Minuit2/FumiliFCNAdapter.h
@@ -48,13 +48,13 @@ public:
 
    FumiliFCNAdapter(const Function &f, unsigned int ndim, double up = 1.) : FumiliFCNBase(ndim), fFunc(f), fUp(up) {}
 
-   ~FumiliFCNAdapter() {}
+   ~FumiliFCNAdapter() override {}
 
-   double operator()(const std::vector<double> &v) const { return fFunc.operator()(&v[0]); }
+   double operator()(const std::vector<double> &v) const override { return fFunc.operator()(&v[0]); }
    double operator()(const double *v) const { return fFunc.operator()(v); }
-   double Up() const { return fUp; }
+   double Up() const override { return fUp; }
 
-   void SetErrorDef(double up) { fUp = up; }
+   void SetErrorDef(double up) override { fUp = up; }
 
    // virtual std::vector<double> Gradient(const std::vector<double>&) const;
 
@@ -64,7 +64,7 @@ public:
    /**
        evaluate gradient hessian and function value needed by fumili
      */
-   void EvaluateAll(const std::vector<double> &v);
+   void EvaluateAll(const std::vector<double> &v) override;
 
 private:
    // data member

--- a/math/minuit2/inc/Minuit2/FumiliFCNBase.h
+++ b/math/minuit2/inc/Minuit2/FumiliFCNBase.h
@@ -70,7 +70,7 @@ public:
 
    //   FumiliFCNBase(const ParametricFunction& modelFCN) { fModelFunction = &modelFCN; }
 
-   virtual ~FumiliFCNBase() {}
+   ~FumiliFCNBase() override {}
 
    /**
 

--- a/math/minuit2/inc/Minuit2/FumiliGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/FumiliGradientCalculator.h
@@ -28,11 +28,11 @@ public:
    {
    }
 
-   ~FumiliGradientCalculator() {}
+   ~FumiliGradientCalculator() override {}
 
-   FunctionGradient operator()(const MinimumParameters &) const;
+   FunctionGradient operator()(const MinimumParameters &) const override;
 
-   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const;
+   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 
    const MnUserTransformation &Trafo() const { return fTransformation; }
 

--- a/math/minuit2/inc/Minuit2/FumiliMaximumLikelihoodFCN.h
+++ b/math/minuit2/inc/Minuit2/FumiliMaximumLikelihoodFCN.h
@@ -48,7 +48,7 @@ class FumiliMaximumLikelihoodFCN : public FumiliFCNBase {
 public:
    FumiliMaximumLikelihoodFCN() {}
 
-   virtual ~FumiliMaximumLikelihoodFCN() {}
+   ~FumiliMaximumLikelihoodFCN() override {}
 
    /**
 
@@ -126,7 +126,7 @@ public:
 
    */
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double sumoflogs = 0.0;
@@ -150,7 +150,7 @@ public:
 
    */
 
-   virtual double Up() const { return 0.5; }
+   double Up() const override { return 0.5; }
 
 private:
    // A pointer to the model function which describes the data

--- a/math/minuit2/inc/Minuit2/FumiliMinimizer.h
+++ b/math/minuit2/inc/Minuit2/FumiliMinimizer.h
@@ -60,7 +60,7 @@ public:
 
    FumiliMinimizer() : fMinSeedGen(MnSeedGenerator()), fMinBuilder(FumiliBuilder()) {}
 
-   ~FumiliMinimizer() {}
+   ~FumiliMinimizer() override {}
 
    /**
 
@@ -70,7 +70,7 @@ public:
 
    */
 
-   const MinimumSeedGenerator &SeedGenerator() const { return fMinSeedGen; }
+   const MinimumSeedGenerator &SeedGenerator() const override { return fMinSeedGen; }
 
    /**
 
@@ -80,73 +80,73 @@ public:
 
    */
 
-   const FumiliBuilder &Builder() const { return fMinBuilder; }
-   FumiliBuilder &Builder() { return fMinBuilder; }
+   const FumiliBuilder &Builder() const override { return fMinBuilder; }
+   FumiliBuilder &Builder() override { return fMinBuilder; }
 
    // for Fumili
 
    FunctionMinimum Minimize(const FCNBase &, const MnUserParameterState &, const MnStrategy &, unsigned int maxfcn = 0,
-                            double toler = 0.1) const;
+                            double toler = 0.1) const override;
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameterState &, const MnStrategy &,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const;
+   FunctionMinimum Minimize(const FCNGradientBase &, const MnUserParameterState &, const MnStrategy &,
+                                    unsigned int maxfcn = 0, double toler = 0.1) const override;
 
    // need to re-implement all function in ModularFuncitionMinimizer otherwise they will be hided
 
-   virtual FunctionMinimum Minimize(const FCNBase &fcn, const std::vector<double> &par, const std::vector<double> &err,
-                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const
+   FunctionMinimum Minimize(const FCNBase &fcn, const std::vector<double> &par, const std::vector<double> &err,
+                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, err, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &fcn, const std::vector<double> &par,
+   FunctionMinimum Minimize(const FCNGradientBase &fcn, const std::vector<double> &par,
                                     const std::vector<double> &err, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const
+                                    double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, err, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNBase &fcn, const std::vector<double> &par, unsigned int nrow,
+   FunctionMinimum Minimize(const FCNBase &fcn, const std::vector<double> &par, unsigned int nrow,
                                     const std::vector<double> &cov, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const
+                                    double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, nrow, cov, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &fcn, const std::vector<double> &par, unsigned int nrow,
+   FunctionMinimum Minimize(const FCNGradientBase &fcn, const std::vector<double> &par, unsigned int nrow,
                                     const std::vector<double> &cov, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const
+                                    double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, nrow, cov, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNBase &fcn, const MnUserParameters &par, const MnStrategy &stra,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const
+   FunctionMinimum Minimize(const FCNBase &fcn, const MnUserParameters &par, const MnStrategy &stra,
+                                    unsigned int maxfcn = 0, double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &fcn, const MnUserParameters &par, const MnStrategy &stra,
-                                    unsigned int maxfcn = 0, double toler = 0.1) const
+   FunctionMinimum Minimize(const FCNGradientBase &fcn, const MnUserParameters &par, const MnStrategy &stra,
+                                    unsigned int maxfcn = 0, double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNBase &fcn, const MnUserParameters &par, const MnUserCovariance &cov,
-                                    const MnStrategy &stra, unsigned int maxfcn = 0, double toler = 0.1) const
+   FunctionMinimum Minimize(const FCNBase &fcn, const MnUserParameters &par, const MnUserCovariance &cov,
+                                    const MnStrategy &stra, unsigned int maxfcn = 0, double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, cov, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &fcn, const MnUserParameters &par,
+   FunctionMinimum Minimize(const FCNGradientBase &fcn, const MnUserParameters &par,
                                     const MnUserCovariance &cov, const MnStrategy &stra, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const
+                                    double toler = 0.1) const override
    {
       return ModularFunctionMinimizer::Minimize(fcn, par, cov, stra, maxfcn, toler);
    }
 
-   virtual FunctionMinimum Minimize(const MnFcn &mfcn, const GradientCalculator &gc, const MinimumSeed &seed,
-                                    const MnStrategy &stra, unsigned int maxfcn, double toler) const
+   FunctionMinimum Minimize(const MnFcn &mfcn, const GradientCalculator &gc, const MinimumSeed &seed,
+                                    const MnStrategy &stra, unsigned int maxfcn, double toler) const override
    {
       return ModularFunctionMinimizer::Minimize(mfcn, gc, seed, stra, maxfcn, toler);
    }

--- a/math/minuit2/inc/Minuit2/FumiliStandardChi2FCN.h
+++ b/math/minuit2/inc/Minuit2/FumiliStandardChi2FCN.h
@@ -119,7 +119,7 @@ public:
       }
    }
 
-   ~FumiliStandardChi2FCN() {}
+   ~FumiliStandardChi2FCN() override {}
 
    /**
 
@@ -138,7 +138,7 @@ public:
 
    */
 
-   std::vector<double> Elements(const std::vector<double> &par) const;
+   std::vector<double> Elements(const std::vector<double> &par) const override;
 
    /**
 
@@ -150,7 +150,7 @@ public:
 
    */
 
-   virtual const std::vector<double> &GetMeasurement(int Index) const;
+   const std::vector<double> &GetMeasurement(int Index) const override;
 
    /**
 
@@ -161,7 +161,7 @@ public:
 
    */
 
-   virtual int GetNumberOfMeasurements() const;
+   int GetNumberOfMeasurements() const override;
 
    /**
 
@@ -173,7 +173,7 @@ public:
 
    **/
 
-   virtual void EvaluateAll(const std::vector<double> &par);
+   void EvaluateAll(const std::vector<double> &par) override;
 
 private:
    std::vector<double> fMeasurements;

--- a/math/minuit2/inc/Minuit2/FumiliStandardMaximumLikelihoodFCN.h
+++ b/math/minuit2/inc/Minuit2/FumiliStandardMaximumLikelihoodFCN.h
@@ -74,7 +74,7 @@ public:
       fPositions = pos;
    }
 
-   ~FumiliStandardMaximumLikelihoodFCN() {}
+   ~FumiliStandardMaximumLikelihoodFCN() override {}
 
    /**
 
@@ -88,7 +88,7 @@ public:
 
    */
 
-   std::vector<double> Elements(const std::vector<double> &par) const;
+   std::vector<double> Elements(const std::vector<double> &par) const override;
 
    /**
 
@@ -100,7 +100,7 @@ public:
 
    */
 
-   virtual const std::vector<double> &GetMeasurement(int Index) const;
+   const std::vector<double> &GetMeasurement(int Index) const override;
 
    /**
 
@@ -111,7 +111,7 @@ public:
 
    */
 
-   virtual int GetNumberOfMeasurements() const;
+   int GetNumberOfMeasurements() const override;
 
    /**
 
@@ -123,7 +123,7 @@ public:
 
    **/
 
-   virtual void EvaluateAll(const std::vector<double> &par);
+   void EvaluateAll(const std::vector<double> &par) override;
 
 private:
    std::vector<std::vector<double>> fPositions;

--- a/math/minuit2/inc/Minuit2/HessianGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/HessianGradientCalculator.h
@@ -35,11 +35,11 @@ public:
    {
    }
 
-   virtual ~HessianGradientCalculator() {}
+   ~HessianGradientCalculator() override {}
 
-   virtual FunctionGradient operator()(const MinimumParameters &) const;
+   FunctionGradient operator()(const MinimumParameters &) const override;
 
-   virtual FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const;
+   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 
    std::pair<FunctionGradient, MnAlgebraicVector>
    DeltaGradient(const MinimumParameters &, const FunctionGradient &) const;

--- a/math/minuit2/inc/Minuit2/InitialGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/InitialGradientCalculator.h
@@ -30,11 +30,11 @@ public:
    InitialGradientCalculator(const MnFcn &fcn, const MnUserTransformation &par, const MnStrategy &stra)
       : fFcn(fcn), fTransformation(par), fStrategy(stra){};
 
-   virtual ~InitialGradientCalculator() {}
+   ~InitialGradientCalculator() override {}
 
-   virtual FunctionGradient operator()(const MinimumParameters &) const;
+   FunctionGradient operator()(const MinimumParameters &) const override;
 
-   virtual FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const;
+   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 
    const MnFcn &Fcn() const { return fFcn; }
    const MnUserTransformation &Trafo() const { return fTransformation; }

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -66,7 +66,7 @@ public:
    /**
       Destructor (no operations)
    */
-   virtual ~Minuit2Minimizer();
+   ~Minuit2Minimizer() override;
 
 private:
    // usually copying is non trivial, so we make this unaccessible
@@ -83,54 +83,54 @@ private:
 
 public:
    // clear resources (parameters) for consecutives minimizations
-   virtual void Clear();
+   void Clear() override;
 
    /// set the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGenFunction &func);
+   void SetFunction(const ROOT::Math::IMultiGenFunction &func) override;
 
    /// set gradient the function to minimize
-   virtual void SetFunction(const ROOT::Math::IMultiGradFunction &func);
+   void SetFunction(const ROOT::Math::IMultiGradFunction &func) override;
 
    /// set free variable
-   virtual bool SetVariable(unsigned int ivar, const std::string &name, double val, double step);
+   bool SetVariable(unsigned int ivar, const std::string &name, double val, double step) override;
 
    /// set lower limit variable  (override if minimizer supports them )
-   virtual bool
-   SetLowerLimitedVariable(unsigned int ivar, const std::string &name, double val, double step, double lower);
+   bool
+   SetLowerLimitedVariable(unsigned int ivar, const std::string &name, double val, double step, double lower) override;
    /// set upper limit variable (override if minimizer supports them )
-   virtual bool
-   SetUpperLimitedVariable(unsigned int ivar, const std::string &name, double val, double step, double upper);
+   bool
+   SetUpperLimitedVariable(unsigned int ivar, const std::string &name, double val, double step, double upper) override;
    /// set upper/lower limited variable (override if minimizer supports them )
-   virtual bool SetLimitedVariable(unsigned int ivar, const std::string &name, double val, double step,
-                                   double /* lower */, double /* upper */);
+   bool SetLimitedVariable(unsigned int ivar, const std::string &name, double val, double step,
+                                   double /* lower */, double /* upper */) override;
    /// set fixed variable (override if minimizer supports them )
-   virtual bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */);
+   bool SetFixedVariable(unsigned int /* ivar */, const std::string & /* name */, double /* val */) override;
    /// set variable
-   virtual bool SetVariableValue(unsigned int ivar, double val);
+   bool SetVariableValue(unsigned int ivar, double val) override;
    // set variable values
-   virtual bool SetVariableValues(const double *val);
+   bool SetVariableValues(const double *val) override;
    /// set the step size of an already existing variable
-   virtual bool SetVariableStepSize(unsigned int ivar, double step);
+   bool SetVariableStepSize(unsigned int ivar, double step) override;
    /// set the lower-limit of an already existing variable
-   virtual bool SetVariableLowerLimit(unsigned int ivar, double lower);
+   bool SetVariableLowerLimit(unsigned int ivar, double lower) override;
    /// set the upper-limit of an already existing variable
-   virtual bool SetVariableUpperLimit(unsigned int ivar, double upper);
+   bool SetVariableUpperLimit(unsigned int ivar, double upper) override;
    /// set the limits of an already existing variable
-   virtual bool SetVariableLimits(unsigned int ivar, double lower, double upper);
+   bool SetVariableLimits(unsigned int ivar, double lower, double upper) override;
    /// fix an existing variable
-   virtual bool FixVariable(unsigned int ivar);
+   bool FixVariable(unsigned int ivar) override;
    /// release an existing variable
-   virtual bool ReleaseVariable(unsigned int ivar);
+   bool ReleaseVariable(unsigned int ivar) override;
    /// query if an existing variable is fixed (i.e. considered constant in the minimization)
    /// note that by default all variables are not fixed
-   virtual bool IsFixedVariable(unsigned int ivar) const;
+   bool IsFixedVariable(unsigned int ivar) const override;
    /// get variable settings in a variable object (like ROOT::Fit::ParamsSettings)
-   virtual bool GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings &varObj) const;
+   bool GetVariableSettings(unsigned int ivar, ROOT::Fit::ParameterSettings &varObj) const override;
    /// get name of variables (override if minimizer support storing of variable names)
-   virtual std::string VariableName(unsigned int ivar) const;
+   std::string VariableName(unsigned int ivar) const override;
    /// get index of variable given a variable given a name
    /// return -1 if variable is not found
-   virtual int VariableIndex(const std::string &name) const;
+   int VariableIndex(const std::string &name) const override;
 
    /**
        method to perform the minimization.
@@ -144,36 +144,36 @@ public:
        status = 4    : Reached call limit
        status = 5    : Any other failure
    */
-   virtual bool Minimize();
+   bool Minimize() override;
 
    /// return minimum function value
-   virtual double MinValue() const { return fState.Fval(); }
+   double MinValue() const override { return fState.Fval(); }
 
    /// return expected distance reached from the minimum
-   virtual double Edm() const { return fState.Edm(); }
+   double Edm() const override { return fState.Edm(); }
 
    /// return  pointer to X values at the minimum
-   virtual const double *X() const { return &fValues.front(); }
+   const double *X() const override { return &fValues.front(); }
 
    /// return pointer to gradient values at the minimum
-   virtual const double *MinGradient() const { return 0; } // not available in Minuit2
+   const double *MinGradient() const override { return 0; } // not available in Minuit2
 
    /// number of function calls to reach the minimum
-   virtual unsigned int NCalls() const { return fState.NFcn(); }
+   unsigned int NCalls() const override { return fState.NFcn(); }
 
    /// this is <= Function().NDim() which is the total
    /// number of variables (free+ constrained ones)
-   virtual unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
    /// number of free variables (real dimension of the problem)
    /// this is <= Function().NDim() which is the total
-   virtual unsigned int NFree() const { return fState.VariableParameters(); }
+   unsigned int NFree() const override { return fState.VariableParameters(); }
 
    /// minimizer provides error and error matrix
-   virtual bool ProvidesError() const { return true; }
+   bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   virtual const double *Errors() const;
+   const double *Errors() const override;
 
    /**
        return covariance matrix elements
@@ -182,7 +182,7 @@ public:
        This is different from the direct interface of Minuit2 or TMinuit where the
        values were obtained only to variable parameters
    */
-   virtual double CovMatrix(unsigned int i, unsigned int j) const;
+   double CovMatrix(unsigned int i, unsigned int j) const override;
 
    /**
        Fill the passed array with the  covariance matrix elements
@@ -192,7 +192,7 @@ public:
        This is different from the direct interface of Minuit2 or TMinuit where the
        values were obtained only to variable parameters
    */
-   virtual bool GetCovMatrix(double *cov) const;
+   bool GetCovMatrix(double *cov) const override;
 
    /**
        Fill the passed array with the Hessian matrix elements
@@ -201,7 +201,7 @@ public:
        If the variable is fixed or const the values for that variables are zero.
        The array will be filled as h[i *ndim + j]
    */
-   virtual bool GetHessianMatrix(double *h) const;
+   bool GetHessianMatrix(double *h) const override;
 
    /**
       return the status of the covariance matrix
@@ -212,12 +212,12 @@ public:
        status =  3 : full accurate matrix
 
     */
-   virtual int CovMatrixStatus() const;
+   int CovMatrixStatus() const override;
    /**
       return correlation coefficient between variable i and j.
       If the variable is fixed or const the return value is zero
     */
-   virtual double Correlation(unsigned int i, unsigned int j) const;
+   double Correlation(unsigned int i, unsigned int j) const override;
 
    /**
       get global correlation coefficient for the variable i. This is a number between zero and one which gives
@@ -225,7 +225,7 @@ public:
       is most strongly correlated with i.
       If the variable is fixed or const the return value is zero
     */
-   virtual double GlobalCC(unsigned int i) const;
+   double GlobalCC(unsigned int i) const override;
 
    /**
       get the minos error for parameter i, return false if Minos failed
@@ -234,7 +234,7 @@ public:
       status += 10 * minosStatus.
       The Minos status of last Minos run can also be retrieved by calling MinosStatus()
    */
-   virtual bool GetMinosError(unsigned int i, double &errLow, double &errUp, int = 0);
+   bool GetMinosError(unsigned int i, double &errLow, double &errUp, int = 0) override;
 
    /**
       MINOS status code of last Minos run
@@ -244,19 +244,19 @@ public:
        `status & 8 > 0`  : a new minimum has been found
        `status & 16 > 0` : error is truncated because parameter is at lower/upper limit
    */
-   virtual int MinosStatus() const { return fMinosStatus; }
+   int MinosStatus() const override { return fMinosStatus; }
 
    /**
       scan a parameter i around the minimum. A minimization must have been done before,
       return false if it is not the case
     */
-   virtual bool Scan(unsigned int i, unsigned int &nstep, double *x, double *y, double xmin = 0, double xmax = 0);
+   bool Scan(unsigned int i, unsigned int &nstep, double *x, double *y, double xmin = 0, double xmax = 0) override;
 
    /**
       find the contour points (xi,xj) of the function for parameter i and j around the minimum
       The contour will be find for value of the function = Min + ErrorUp();
     */
-   virtual bool Contour(unsigned int i, unsigned int j, unsigned int &npoints, double *xi, double *xj);
+   bool Contour(unsigned int i, unsigned int j, unsigned int &npoints, double *xi, double *xj) override;
 
    /**
       perform a full calculation of the Hessian matrix for error calculation
@@ -268,13 +268,13 @@ public:
       status = 2 : matrix inversion failed
       status = 3 : matrix is not pos defined
     */
-   virtual bool Hesse();
+   bool Hesse() override;
 
    /// return reference to the objective function
    /// virtual const ROOT::Math::IGenFunction & Function() const;
 
    /// print result of minimization
-   virtual void PrintResults();
+   void PrintResults() override;
 
    /// set an object to trace operation for each iteration
    /// The object must be a (or inherit from) ROOT::Minuit2::MnTraceObject and implement operator() (int, const

--- a/math/minuit2/inc/Minuit2/MnFumiliMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnFumiliMinimize.h
@@ -85,15 +85,15 @@ public:
    {
    }
 
-   virtual ~MnFumiliMinimize() {}
+   ~MnFumiliMinimize() override {}
 
-   FumiliMinimizer &Minimizer() { return fMinimizer; }
-   const FumiliMinimizer &Minimizer() const { return fMinimizer; }
+   FumiliMinimizer &Minimizer() override { return fMinimizer; }
+   const FumiliMinimizer &Minimizer() const override { return fMinimizer; }
 
-   const FumiliFCNBase &Fcnbase() const { return fFCN; }
+   const FumiliFCNBase &Fcnbase() const override { return fFCN; }
 
    /// overwrite Minimize to use FumiliFCNBase
-   virtual FunctionMinimum operator()(unsigned int = 0, double = 0.1);
+   FunctionMinimum operator()(unsigned int = 0, double = 0.1) override;
 
 private:
    FumiliMinimizer fMinimizer;

--- a/math/minuit2/inc/Minuit2/MnMigrad.h
+++ b/math/minuit2/inc/Minuit2/MnMigrad.h
@@ -112,7 +112,7 @@ public:
    {
    }
 
-   ~MnMigrad() {}
+   ~MnMigrad() override {}
 
    /// Copy constructor, copy shares the reference to the same FCNBase in MnApplication
    MnMigrad(const MnMigrad &) = default;
@@ -120,8 +120,8 @@ public:
    // Copy assignment deleted, since MnApplication has unassignable reference to FCNBase
    MnMigrad &operator=(const MnMigrad &) = delete;
 
-   ModularFunctionMinimizer &Minimizer() { return fMinimizer; }
-   const ModularFunctionMinimizer &Minimizer() const { return fMinimizer; }
+   ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
+   const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
 
 private:
    VariableMetricMinimizer fMinimizer;

--- a/math/minuit2/inc/Minuit2/MnMinimize.h
+++ b/math/minuit2/inc/Minuit2/MnMinimize.h
@@ -114,10 +114,10 @@ public:
    {
    }
 
-   ~MnMinimize() {}
+   ~MnMinimize() override {}
 
-   ModularFunctionMinimizer &Minimizer() { return fMinimizer; }
-   const ModularFunctionMinimizer &Minimizer() const { return fMinimizer; }
+   ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
+   const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
 
 private:
    CombinedMinimizer fMinimizer;

--- a/math/minuit2/inc/Minuit2/MnScan.h
+++ b/math/minuit2/inc/Minuit2/MnScan.h
@@ -75,10 +75,10 @@ public:
    {
    }
 
-   ~MnScan() {}
+   ~MnScan() override {}
 
-   ModularFunctionMinimizer &Minimizer() { return fMinimizer; }
-   const ModularFunctionMinimizer &Minimizer() const { return fMinimizer; }
+   ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
+   const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
 
    std::vector<std::pair<double, double>>
    Scan(unsigned int par, unsigned int maxsteps = 41, double low = 0., double high = 0.);

--- a/math/minuit2/inc/Minuit2/MnSeedGenerator.h
+++ b/math/minuit2/inc/Minuit2/MnSeedGenerator.h
@@ -25,13 +25,13 @@ class MnSeedGenerator : public MinimumSeedGenerator {
 public:
    MnSeedGenerator() {}
 
-   virtual ~MnSeedGenerator() {}
+   ~MnSeedGenerator() override {}
 
-   virtual MinimumSeed
-   operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &, const MnStrategy &) const;
+   MinimumSeed
+   operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &, const MnStrategy &) const override;
 
-   virtual MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
-                                  const MnStrategy &) const;
+   MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
+                                  const MnStrategy &) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/MnSimplex.h
+++ b/math/minuit2/inc/Minuit2/MnSimplex.h
@@ -77,10 +77,10 @@ public:
    {
    }
 
-   ~MnSimplex() {}
+   ~MnSimplex() override {}
 
-   ModularFunctionMinimizer &Minimizer() { return fMinimizer; }
-   const ModularFunctionMinimizer &Minimizer() const { return fMinimizer; }
+   ModularFunctionMinimizer &Minimizer() override { return fMinimizer; }
+   const ModularFunctionMinimizer &Minimizer() const override { return fMinimizer; }
 
 private:
    SimplexMinimizer fMinimizer;

--- a/math/minuit2/inc/Minuit2/MnUserFcn.h
+++ b/math/minuit2/inc/Minuit2/MnUserFcn.h
@@ -30,9 +30,9 @@ public:
    {
    }
 
-   ~MnUserFcn() {}
+   ~MnUserFcn() override {}
 
-   virtual double operator()(const MnAlgebraicVector &) const;
+   double operator()(const MnAlgebraicVector &) const override;
 
 private:
    const MnUserTransformation &fTransform;

--- a/math/minuit2/inc/Minuit2/ModularFunctionMinimizer.h
+++ b/math/minuit2/inc/Minuit2/ModularFunctionMinimizer.h
@@ -40,22 +40,22 @@ class FumiliFCNBase;
 class ModularFunctionMinimizer : public FunctionMinimizer {
 
 public:
-   virtual ~ModularFunctionMinimizer() {}
+   ~ModularFunctionMinimizer() override {}
 
    // inherited interface
-   virtual FunctionMinimum Minimize(const FCNBase &, const std::vector<double> &, const std::vector<double> &,
-                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const;
+   FunctionMinimum Minimize(const FCNBase &, const std::vector<double> &, const std::vector<double> &,
+                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const override;
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, const std::vector<double> &, const std::vector<double> &,
-                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const;
+   FunctionMinimum Minimize(const FCNGradientBase &, const std::vector<double> &, const std::vector<double> &,
+                                    unsigned int stra = 1, unsigned int maxfcn = 0, double toler = 0.1) const override;
 
-   virtual FunctionMinimum Minimize(const FCNBase &, const std::vector<double> &, unsigned int,
+   FunctionMinimum Minimize(const FCNBase &, const std::vector<double> &, unsigned int,
                                     const std::vector<double> &, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const;
+                                    double toler = 0.1) const override;
 
-   virtual FunctionMinimum Minimize(const FCNGradientBase &, const std::vector<double> &, unsigned int,
+   FunctionMinimum Minimize(const FCNGradientBase &, const std::vector<double> &, unsigned int,
                                     const std::vector<double> &, unsigned int stra = 1, unsigned int maxfcn = 0,
-                                    double toler = 0.1) const;
+                                    double toler = 0.1) const override;
 
    // extension
    virtual FunctionMinimum Minimize(const FCNBase &, const MnUserParameters &, const MnStrategy &,

--- a/math/minuit2/inc/Minuit2/Numerical2PGradientCalculator.h
+++ b/math/minuit2/inc/Minuit2/Numerical2PGradientCalculator.h
@@ -37,13 +37,13 @@ public:
    {
    }
 
-   virtual ~Numerical2PGradientCalculator() {}
+   ~Numerical2PGradientCalculator() override {}
 
-   virtual FunctionGradient operator()(const MinimumParameters &) const;
+   FunctionGradient operator()(const MinimumParameters &) const override;
 
    virtual FunctionGradient operator()(const std::vector<double> &params) const;
 
-   virtual FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const;
+   FunctionGradient operator()(const MinimumParameters &, const FunctionGradient &) const override;
 
    const MnFcn &Fcn() const { return fFcn; }
    const MnUserTransformation &Trafo() const { return fTransformation; }

--- a/math/minuit2/inc/Minuit2/ParametricFunction.h
+++ b/math/minuit2/inc/Minuit2/ParametricFunction.h
@@ -65,7 +65,7 @@ public:
 
    ParametricFunction(int nparams) : par(nparams) {}
 
-   virtual ~ParametricFunction() {}
+   ~ParametricFunction() override {}
 
    /**
 
@@ -115,7 +115,7 @@ public:
 
    */
 
-   virtual double operator()(const std::vector<double> &x) const = 0;
+   double operator()(const std::vector<double> &x) const override = 0;
 
    /**
 

--- a/math/minuit2/inc/Minuit2/ScanBuilder.h
+++ b/math/minuit2/inc/Minuit2/ScanBuilder.h
@@ -29,10 +29,10 @@ class ScanBuilder : public MinimumBuilder {
 public:
    ScanBuilder() {}
 
-   ~ScanBuilder() {}
+   ~ScanBuilder() override {}
 
-   virtual FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
-                                   unsigned int, double) const;
+   FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
+                                   unsigned int, double) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/ScanMinimizer.h
+++ b/math/minuit2/inc/Minuit2/ScanMinimizer.h
@@ -30,11 +30,11 @@ class ScanMinimizer : public ModularFunctionMinimizer {
 public:
    ScanMinimizer() : fSeedGenerator(SimplexSeedGenerator()), fBuilder(ScanBuilder()) {}
 
-   ~ScanMinimizer() {}
+   ~ScanMinimizer() override {}
 
-   const MinimumSeedGenerator &SeedGenerator() const { return fSeedGenerator; }
-   const MinimumBuilder &Builder() const { return fBuilder; }
-   MinimumBuilder &Builder() { return fBuilder; }
+   const MinimumSeedGenerator &SeedGenerator() const override { return fSeedGenerator; }
+   const MinimumBuilder &Builder() const override { return fBuilder; }
+   MinimumBuilder &Builder() override { return fBuilder; }
 
 private:
    SimplexSeedGenerator fSeedGenerator;

--- a/math/minuit2/inc/Minuit2/SimplexBuilder.h
+++ b/math/minuit2/inc/Minuit2/SimplexBuilder.h
@@ -29,10 +29,10 @@ class SimplexBuilder : public MinimumBuilder {
 public:
    SimplexBuilder() {}
 
-   ~SimplexBuilder() {}
+   ~SimplexBuilder() override {}
 
-   virtual FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
-                                   unsigned int, double) const;
+   FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
+                                   unsigned int, double) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/SimplexMinimizer.h
+++ b/math/minuit2/inc/Minuit2/SimplexMinimizer.h
@@ -30,11 +30,11 @@ class SimplexMinimizer : public ModularFunctionMinimizer {
 public:
    SimplexMinimizer() : fSeedGenerator(SimplexSeedGenerator()), fBuilder(SimplexBuilder()) {}
 
-   ~SimplexMinimizer() {}
+   ~SimplexMinimizer() override {}
 
-   const MinimumSeedGenerator &SeedGenerator() const { return fSeedGenerator; }
-   const MinimumBuilder &Builder() const { return fBuilder; }
-   MinimumBuilder &Builder() { return fBuilder; }
+   const MinimumSeedGenerator &SeedGenerator() const override { return fSeedGenerator; }
+   const MinimumBuilder &Builder() const override { return fBuilder; }
+   MinimumBuilder &Builder() override { return fBuilder; }
 
 private:
    SimplexSeedGenerator fSeedGenerator;

--- a/math/minuit2/inc/Minuit2/SimplexSeedGenerator.h
+++ b/math/minuit2/inc/Minuit2/SimplexSeedGenerator.h
@@ -29,13 +29,13 @@ class SimplexSeedGenerator : public MinimumSeedGenerator {
 public:
    SimplexSeedGenerator() {}
 
-   ~SimplexSeedGenerator() {}
+   ~SimplexSeedGenerator() override {}
 
-   virtual MinimumSeed
-   operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &, const MnStrategy &) const;
+   MinimumSeed
+   operator()(const MnFcn &, const GradientCalculator &, const MnUserParameterState &, const MnStrategy &) const override;
 
-   virtual MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
-                                  const MnStrategy &) const;
+   MinimumSeed operator()(const MnFcn &, const AnalyticalGradientCalculator &, const MnUserParameterState &,
+                                  const MnStrategy &) const override;
 
 private:
 };

--- a/math/minuit2/inc/Minuit2/VariableMetricBuilder.h
+++ b/math/minuit2/inc/Minuit2/VariableMetricBuilder.h
@@ -44,10 +44,10 @@ public:
          fErrorUpdator = std::unique_ptr<MinimumErrorUpdator>(new DavidonErrorUpdator());
    }
 
-   ~VariableMetricBuilder() {}
+   ~VariableMetricBuilder() override {}
 
-   virtual FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
-                                   unsigned int, double) const;
+   FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, const MnStrategy &,
+                                   unsigned int, double) const override;
 
    FunctionMinimum Minimum(const MnFcn &, const GradientCalculator &, const MinimumSeed &, std::vector<MinimumState> &,
                            unsigned int, double) const;

--- a/math/minuit2/inc/Minuit2/VariableMetricMinimizer.h
+++ b/math/minuit2/inc/Minuit2/VariableMetricMinimizer.h
@@ -43,11 +43,11 @@ public:
    {
    }
 
-   ~VariableMetricMinimizer() {}
+   ~VariableMetricMinimizer() override {}
 
-   const MinimumSeedGenerator &SeedGenerator() const { return fMinSeedGen; }
-   const MinimumBuilder &Builder() const { return fMinBuilder; }
-   MinimumBuilder &Builder() { return fMinBuilder; }
+   const MinimumSeedGenerator &SeedGenerator() const override { return fMinSeedGen; }
+   const MinimumBuilder &Builder() const override { return fMinBuilder; }
+   MinimumBuilder &Builder() override { return fMinBuilder; }
 
 private:
    MnSeedGenerator fMinSeedGen;

--- a/math/minuit2/inc/TMinuit2TraceObject.h
+++ b/math/minuit2/inc/TMinuit2TraceObject.h
@@ -32,13 +32,13 @@ class TMinuit2TraceObject : public ROOT::Minuit2::MnTraceObject, public TNamed {
 public:
    TMinuit2TraceObject(int parNumber = -1);
 
-   virtual ~TMinuit2TraceObject();
+   ~TMinuit2TraceObject() override;
 
-   virtual void Init(const ROOT::Minuit2::MnUserParameterState &state);
+   void Init(const ROOT::Minuit2::MnUserParameterState &state) override;
 
-   virtual void operator()(int i, const ROOT::Minuit2::MinimumState &state);
+   void operator()(int i, const ROOT::Minuit2::MinimumState &state) override;
 
-   ClassDef(TMinuit2TraceObject, 0) // Example Trace Object for Minuit2
+   ClassDefOverride(TMinuit2TraceObject, 0) // Example Trace Object for Minuit2
 
       private :
 

--- a/math/minuit2/test/MnSim/GaussFcn.h
+++ b/math/minuit2/test/MnSim/GaussFcn.h
@@ -26,16 +26,16 @@ public:
    {
    }
 
-   ~GaussFcn() {}
+   ~GaussFcn() override {}
 
-   virtual double Up() const { return fErrorDef; }
-   virtual double operator()(const std::vector<double> &) const;
+   double Up() const override { return fErrorDef; }
+   double operator()(const std::vector<double> &) const override;
 
    std::vector<double> Measurements() const { return fMeasurements; }
    std::vector<double> Positions() const { return fPositions; }
    std::vector<double> Variances() const { return fMVariances; }
 
-   void SetErrorDef(double def) { fErrorDef = def; }
+   void SetErrorDef(double def) override { fErrorDef = def; }
 
 private:
    std::vector<double> fMeasurements;

--- a/math/minuit2/test/MnSim/GaussFcn2.h
+++ b/math/minuit2/test/MnSim/GaussFcn2.h
@@ -26,13 +26,13 @@ public:
    {
       Init();
    }
-   ~GaussFcn2() {}
+   ~GaussFcn2() override {}
 
    virtual void Init();
 
-   virtual double Up() const { return 1.; }
-   virtual double operator()(const std::vector<double> &) const;
-   virtual double ErrorDef() const { return Up(); }
+   double Up() const override { return 1.; }
+   double operator()(const std::vector<double> &) const override;
+   double ErrorDef() const override { return Up(); }
 
    std::vector<double> Measurements() const { return fMeasurements; }
    std::vector<double> Positions() const { return fPositions; }

--- a/math/minuit2/test/MnSim/GaussianModelFunction.h
+++ b/math/minuit2/test/MnSim/GaussianModelFunction.h
@@ -82,7 +82,7 @@ public:
 
    GaussianModelFunction(const std::vector<double> &params) : ParametricFunction(params) { assert(params.size() == 1); }
 
-   ~GaussianModelFunction() {}
+   ~GaussianModelFunction() override {}
 
    /**
 
@@ -97,7 +97,7 @@ public:
 
    */
 
-   double operator()(const std::vector<double> &x) const
+   double operator()(const std::vector<double> &x) const override
    {
 
       assert(x.size() == 3);
@@ -128,7 +128,7 @@ public:
 
    */
 
-   double operator()(const std::vector<double> &x, const std::vector<double> &param) const
+   double operator()(const std::vector<double> &x, const std::vector<double> &param) const override
    {
 
       constexpr double two_pi = 2 * 3.14159265358979323846; // M_PI is not standard
@@ -146,9 +146,9 @@ public:
 
    */
 
-   virtual double Up() const { return 1.0; }
+   double Up() const override { return 1.0; }
 
-   std::vector<double> GetGradient(const std::vector<double> &x) const
+   std::vector<double> GetGradient(const std::vector<double> &x) const override
    {
 
       const std::vector<double> &param = GetParameters();

--- a/math/minuit2/test/MnSim/ParallelTest.cxx
+++ b/math/minuit2/test/MnSim/ParallelTest.cxx
@@ -59,7 +59,7 @@ struct LogLikeFCN : public FCNBase {
 
    LogLikeFCN(const Data &data) : fData(data) {}
 
-   double operator()(const std::vector<double> &p) const
+   double operator()(const std::vector<double> &p) const override
    {
       double logl = 0;
       int ndata = fData.size();
@@ -68,7 +68,7 @@ struct LogLikeFCN : public FCNBase {
       }
       return logl;
    }
-   double Up() const { return 0.5; }
+   double Up() const override { return 0.5; }
    const Data &fData;
 };
 

--- a/math/minuit2/test/MnSim/PaulTest4.cxx
+++ b/math/minuit2/test/MnSim/PaulTest4.cxx
@@ -51,9 +51,9 @@ public:
    {
    }
 
-   ~PowerLawChi2FCN() {}
+   ~PowerLawChi2FCN() override {}
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
       assert(par.size() == 2);
       PowerLawFunc pl(par[0], par[1]);
@@ -66,7 +66,7 @@ public:
       return chi2;
    }
 
-   double Up() const { return 1.; }
+   double Up() const override { return 1.; }
 
 private:
    std::vector<double> fMeasurements;
@@ -82,9 +82,9 @@ public:
    {
    }
 
-   ~PowerLawLogLikeFCN() {}
+   ~PowerLawLogLikeFCN() override {}
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
       assert(par.size() == 2);
       PowerLawFunc pl(par[0], par[1]);
@@ -99,7 +99,7 @@ public:
       return -logsum;
    }
 
-   double Up() const { return 0.5; }
+   double Up() const override { return 0.5; }
 
 private:
    std::vector<double> fMeasurements;

--- a/math/minuit2/test/MnSim/ReneTest.cxx
+++ b/math/minuit2/test/MnSim/ReneTest.cxx
@@ -28,9 +28,9 @@ class ReneFcn : public FCNBase {
 public:
    ReneFcn(const std::vector<double> &meas) : fMeasurements(meas) {}
 
-   virtual ~ReneFcn() {}
+   ~ReneFcn() override {}
 
-   virtual double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
       double a = par[2];
       double b = par[1];
@@ -63,7 +63,7 @@ public:
       return fval;
    }
 
-   virtual double Up() const { return 1.; }
+   double Up() const override { return 1.; }
 
 private:
    std::vector<double> fMeasurements;

--- a/math/minuit2/test/MnTutorial/Quad12F.h
+++ b/math/minuit2/test/MnTutorial/Quad12F.h
@@ -18,7 +18,7 @@ namespace Minuit2 {
 class Quad12F : public FCNBase {
 
 public:
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -39,7 +39,7 @@ public:
               (1. / 70.) * (21 * x1 * x1 + 20 * y1 * y1 + 19 * z1 * z1 - 14 * x1 * z1 - 20 * y1 * z1) + w1 * w1);
    }
 
-   double Up() const { return 1.; }
+   double Up() const override { return 1.; }
 
 private:
 };

--- a/math/minuit2/test/MnTutorial/Quad1F.h
+++ b/math/minuit2/test/MnTutorial/Quad1F.h
@@ -20,9 +20,9 @@ class Quad1F : public FCNGradientBase {
 public:
    Quad1F() : fErrorDef(1.) {}
 
-   ~Quad1F() {}
+   ~Quad1F() override {}
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -30,7 +30,7 @@ public:
       return (x * x);
    }
 
-   std::vector<double> Gradient(const std::vector<double> &par) const
+   std::vector<double> Gradient(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -38,9 +38,9 @@ public:
       return (std::vector<double>(1, 2. * x));
    }
 
-   void SetErrorDef(double up) { fErrorDef = up; }
+   void SetErrorDef(double up) override { fErrorDef = up; }
 
-   double Up() const { return fErrorDef; }
+   double Up() const override { return fErrorDef; }
 
    const FCNBase *Base() const { return this; }
 

--- a/math/minuit2/test/MnTutorial/Quad4F.h
+++ b/math/minuit2/test/MnTutorial/Quad4F.h
@@ -20,9 +20,9 @@ class Quad4F : public FCNBase {
 public:
    Quad4F() {}
 
-   ~Quad4F() {}
+   ~Quad4F() override {}
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -33,7 +33,7 @@ public:
       return ((1. / 70.) * (21 * x * x + 20 * y * y + 19 * z * z - 14 * x * z - 20 * y * z) + w * w);
    }
 
-   double Up() const { return 1.; }
+   double Up() const override { return 1.; }
 
 private:
 };
@@ -44,9 +44,9 @@ class Quad4FGrad : public FCNGradientBase {
 public:
    Quad4FGrad() {}
 
-   ~Quad4FGrad() {}
+   ~Quad4FGrad() override {}
 
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -57,7 +57,7 @@ public:
       return ((1. / 70.) * (21 * x * x + 20 * y * y + 19 * z * z - 14 * x * z - 20 * y * z) + w * w);
    }
 
-   std::vector<double> Gradient(const std::vector<double> &par) const
+   std::vector<double> Gradient(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -73,7 +73,7 @@ public:
       return g;
    }
 
-   double Up() const { return 1.; }
+   double Up() const override { return 1.; }
 
 private:
 };

--- a/math/minuit2/test/MnTutorial/Quad8F.h
+++ b/math/minuit2/test/MnTutorial/Quad8F.h
@@ -18,7 +18,7 @@ namespace Minuit2 {
 class Quad8F : public FCNBase {
 
 public:
-   double operator()(const std::vector<double> &par) const
+   double operator()(const std::vector<double> &par) const override
    {
 
       double x = par[0];
@@ -34,7 +34,7 @@ public:
               (1. / 70.) * (21 * x0 * x0 + 20 * y0 * y0 + 19 * z0 * z0 - 14 * x0 * z0 - 20 * y0 * z0) + w0 * w0);
    }
 
-   double Up() const { return 1.; }
+   double Up() const override { return 1.; }
 
 private:
 };

--- a/math/minuit2/test/testMinimizer.cxx
+++ b/math/minuit2/test/testMinimizer.cxx
@@ -50,11 +50,11 @@ void RosenBrock(Int_t &, Double_t *, Double_t &f, Double_t *par, Int_t /*iflag*/
 class RosenBrockFunction : public ROOT::Math::IMultiGenFunction {
 
 public:
-   virtual ~RosenBrockFunction() {}
+   ~RosenBrockFunction() override {}
 
-   unsigned int NDim() const { return 2; }
+   unsigned int NDim() const override { return 2; }
 
-   ROOT::Math::IMultiGenFunction *Clone() const { return new RosenBrockFunction(); }
+   ROOT::Math::IMultiGenFunction *Clone() const override { return new RosenBrockFunction(); }
 
    const double *TrueMinimum() const
    {
@@ -64,7 +64,7 @@ public:
    }
 
 private:
-   inline double DoEval(const double *x) const
+   inline double DoEval(const double *x) const override
    {
 #ifdef USE_FREE_FUNC
       double f = 0;
@@ -120,9 +120,9 @@ public:
       v0 = A * sx0 + B * cx0;
    }
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
-   ROOT::Math::IMultiGenFunction *Clone() const
+   ROOT::Math::IMultiGenFunction *Clone() const override
    {
       TrigoFletcherFunction *f = new TrigoFletcherFunction(*this);
       //       std::cerr <<"cannot clone this function" << std::endl;
@@ -149,7 +149,7 @@ public:
 
    const double *TrueMinimum() const { return x0.GetMatrixArray(); }
 
-   void Gradient(const double *x, double *g) const
+   void Gradient(const double *x, double *g) const override
    {
       gNCall2++;
 
@@ -199,7 +199,7 @@ private:
    //    TrigoFletcherFunction(const TrigoFletcherFunction & ) {}
    //    TrigoFletcherFunction & operator=(const TrigoFletcherFunction &) { return *this; }
 
-   double DoEval(const double *x) const
+   double DoEval(const double *x) const override
    {
       gNCall++;
 
@@ -214,7 +214,7 @@ private:
       return r * r;
    }
 
-   double DoDerivative(const double *x, unsigned int i) const
+   double DoDerivative(const double *x, unsigned int i) const override
    {
       std::vector<double> g(fDim);
       Gradient(x, &g[0]);
@@ -243,9 +243,9 @@ class ChebyQuadFunction : public ROOT::Math::IMultiGradFunction {
 public:
    ChebyQuadFunction(unsigned int n) : fDim(n), fvec(std::vector<double>(n)), fTrueMin(std::vector<double>(n)) {}
 
-   unsigned int NDim() const { return fDim; }
+   unsigned int NDim() const override { return fDim; }
 
-   ROOT::Math::IMultiGenFunction *Clone() const { return new ChebyQuadFunction(*this); }
+   ROOT::Math::IMultiGenFunction *Clone() const override { return new ChebyQuadFunction(*this); }
 
    const double *TrueMinimum() const { return &fTrueMin[0]; }
 
@@ -260,7 +260,7 @@ public:
 
    // compute gradient
 
-   void Gradient(const double *x, double *g) const
+   void Gradient(const double *x, double *g) const override
    {
       gNCall2++;
       unsigned int n = fDim;
@@ -288,7 +288,7 @@ public:
    }
 
 private:
-   double DoEval(const double *x) const
+   double DoEval(const double *x) const override
    {
 
       gNCall++;
@@ -300,7 +300,7 @@ private:
       return f;
    }
 
-   double DoDerivative(const double *x, unsigned int i) const
+   double DoDerivative(const double *x, unsigned int i) const override
    {
       std::vector<double> g(fDim);
       Gradient(x, &g[0]);

--- a/math/mlp/inc/TMLPAnalyzer.h
+++ b/math/mlp/inc/TMLPAnalyzer.h
@@ -41,7 +41,7 @@ public:
       fNetwork(&net), fAnalysisTree(0), fIOTree(0) {}
    TMLPAnalyzer(TMultiLayerPerceptron* net):
       fNetwork(net), fAnalysisTree(0), fIOTree(0) {}
-   virtual ~TMLPAnalyzer();
+   ~TMLPAnalyzer() override;
    void DrawNetwork(Int_t neuron, const char* signal, const char* bg);
    void DrawDInput(Int_t i);
    void DrawDInputs();
@@ -55,7 +55,7 @@ public:
    void GatherInformations();
    TTree* GetIOTree() const { return fIOTree;}
 
-   ClassDef(TMLPAnalyzer, 0) // A simple analysis class for MLP
+   ClassDefOverride(TMLPAnalyzer, 0) // A simple analysis class for MLP
 };
 
 #endif

--- a/math/mlp/inc/TMultiLayerPerceptron.h
+++ b/math/mlp/inc/TMultiLayerPerceptron.h
@@ -53,7 +53,7 @@ class TMultiLayerPerceptron : public TObject {
                          TEventList* test,
                          TNeuron::ENeuronType type = TNeuron::kSigmoid,
                          const char* extF = "", const char* extD  = "");
-   virtual ~TMultiLayerPerceptron();
+   ~TMultiLayerPerceptron() override;
    void SetData(TTree*);
    void SetTrainingDataSet(TEventList* train);
    void SetTestDataSet(TEventList* test);
@@ -87,7 +87,7 @@ class TMultiLayerPerceptron : public TObject {
    Bool_t LoadWeights(Option_t* filename = "");
    Double_t Evaluate(Int_t index, Double_t* params) const;
    void Export(Option_t* filename = "NNfunction", Option_t* language = "C++") const;
-   virtual void Draw(Option_t *option="");
+   void Draw(Option_t *option="") override;
 
  protected:
    void AttachData();
@@ -148,7 +148,7 @@ class TMultiLayerPerceptron : public TObject {
    Bool_t fTrainingOwner;           ///<! internal flag whether one has to delete fTraining or not
    Bool_t fTestOwner;               ///<! internal flag whether one has to delete fTest or not
 
-   ClassDef(TMultiLayerPerceptron, 4) // a Neural Network
+   ClassDefOverride(TMultiLayerPerceptron, 4) // a Neural Network
 };
 
 #endif

--- a/math/mlp/inc/TNeuron.h
+++ b/math/mlp/inc/TNeuron.h
@@ -31,7 +31,7 @@ class TNeuron : public TNamed {
    TNeuron(ENeuronType type = kSigmoid,
            const char* name = "", const char* title = "",
            const char* extF = "", const char* extD  = "" );
-   virtual ~TNeuron() {}
+   ~TNeuron() override {}
    inline TSynapse* GetPre(Int_t n) const { return (TSynapse*) fpre.At(n); }
    inline TSynapse* GetPost(Int_t n) const { return (TSynapse*) fpost.At(n); }
    inline TNeuron* GetInLayer(Int_t n) const { return (TNeuron*) flayer.At(n); }
@@ -84,7 +84,7 @@ class TNeuron : public TNamed {
    Double_t fDeDw;        ///<! buffer containing the last derivative of the error
    Double_t fDEDw;        ///<! buffer containing the sum over all examples of DeDw
 
-   ClassDef(TNeuron, 4)   // Neuron for MultiLayerPerceptrons
+   ClassDefOverride(TNeuron, 4)   // Neuron for MultiLayerPerceptrons
 };
 
 #endif

--- a/math/mlp/inc/TSynapse.h
+++ b/math/mlp/inc/TSynapse.h
@@ -21,7 +21,7 @@ class TSynapse : public TObject {
  public:
    TSynapse();
    TSynapse(TNeuron*, TNeuron*, Double_t w = 1);
-   virtual ~TSynapse() {}
+   ~TSynapse() override {}
    void SetPre(TNeuron* pre);
    void SetPost(TNeuron* post);
    inline TNeuron* GetPre()  const { return fpre; }
@@ -39,7 +39,7 @@ class TSynapse : public TObject {
    Double_t fweight;      ///< the weight of the synapse
    Double_t fDEDw;        ///<! the derivative of the total error wrt the synapse weight
 
-   ClassDef(TSynapse, 1)  ///< simple weighted bidirectional connection between 2 neurons
+   ClassDefOverride(TSynapse, 1)  ///< simple weighted bidirectional connection between 2 neurons
 };
 
 #endif

--- a/math/physics/inc/TFeldmanCousins.h
+++ b/math/physics/inc/TFeldmanCousins.h
@@ -75,7 +75,7 @@ protected:
 
 public:
    TFeldmanCousins(Double_t newCL=0.9, TString options = "");
-   virtual ~TFeldmanCousins();
+   ~TFeldmanCousins() override;
 
    ////////////////////////////////////////////////
    // calculate the upper limit given Nobserved  //
@@ -105,7 +105,7 @@ public:
    void            SetMuMax(Double_t  newMax    = 50.0);
    void            SetMuStep(Double_t newMuStep = 0.005);
 
-   ClassDef(TFeldmanCousins,1) //calculate the CL upper limit using the Feldman-Cousins method
+   ClassDefOverride(TFeldmanCousins,1) //calculate the CL upper limit using the Feldman-Cousins method
 };
 
 #endif

--- a/math/physics/inc/TGenPhaseSpace.h
+++ b/math/physics/inc/TGenPhaseSpace.h
@@ -26,7 +26,7 @@ private:
 public:
    TGenPhaseSpace(): fNt(0), fMass(), fBeta(), fTeCmTm(0.), fWtMax(0.) {}
    TGenPhaseSpace(const TGenPhaseSpace &gen);
-   virtual ~TGenPhaseSpace() {}
+   ~TGenPhaseSpace() override {}
    TGenPhaseSpace& operator=(const TGenPhaseSpace &gen);
 
    Bool_t          SetDecay(TLorentzVector &P, Int_t nt, const Double_t *mass, Option_t *opt="");
@@ -36,7 +36,7 @@ public:
    Int_t    GetNt()      const { return fNt;}
    Double_t GetWtMax()   const { return fWtMax;}
 
-   ClassDef(TGenPhaseSpace,1) //Simple Phase Space Generator
+   ClassDefOverride(TGenPhaseSpace,1) //Simple Phase Space Generator
 };
 
 #endif

--- a/math/physics/inc/TLorentzRotation.h
+++ b/math/physics/inc/TLorentzRotation.h
@@ -134,7 +134,7 @@ protected:
                     Double_t, Double_t, Double_t, Double_t);
    // Protected constructor.
 
-   ClassDef(TLorentzRotation,1) // Lorentz transformations including boosts and rotations
+   ClassDefOverride(TLorentzRotation,1) // Lorentz transformations including boosts and rotations
 
 };
 

--- a/math/physics/inc/TLorentzVector.h
+++ b/math/physics/inc/TLorentzVector.h
@@ -58,7 +58,7 @@ public:
    TLorentzVector(const TLorentzVector & lorentzvector);
    // Copy constructor.
 
-   virtual ~TLorentzVector(){};
+   ~TLorentzVector() override{};
    // Destructor
 
    // inline operator TVector3 () const;
@@ -257,9 +257,9 @@ public:
    TLorentzVector & Transform(const TLorentzRotation &);
    // Transformation with HepLorenzRotation.
 
-   virtual void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
 
-   ClassDef(TLorentzVector,4) // A four vector with (-,-,-,+) metric
+   ClassDefOverride(TLorentzVector,4) // A four vector with (-,-,-,+) metric
 };
 
 

--- a/math/physics/inc/TQuaternion.h
+++ b/math/physics/inc/TQuaternion.h
@@ -21,7 +21,7 @@ public:
    TQuaternion(const TQuaternion &);
    // The copy constructor.
 
-   virtual ~TQuaternion();
+   ~TQuaternion() override;
    // Destructor
 
    Double_t operator () (int) const;
@@ -105,12 +105,12 @@ public:
    void Rotate(TVector3& vect) const;
    TVector3 Rotation(const TVector3& vect) const;
 
-   void Print(Option_t* option="") const;
+   void Print(Option_t* option="") const override;
 
    Double_t fRealPart;          // Real part
    TVector3 fVectorPart; // vector part
 
-   ClassDef(TQuaternion,1) // a quaternion class
+   ClassDefOverride(TQuaternion,1) // a quaternion class
 };
 
 

--- a/math/physics/inc/TRobustEstimator.h
+++ b/math/physics/inc/TRobustEstimator.h
@@ -75,7 +75,7 @@ public:
 
    TRobustEstimator();
    TRobustEstimator(Int_t nvectors, Int_t nvariables, Int_t hh=0);
-   virtual ~TRobustEstimator(){;}
+   ~TRobustEstimator() override{;}
 
    void    AddColumn(Double_t *col);         //adds a column to the data matrix
    void    AddRow(Double_t *row);            //adds a row to the data matrix
@@ -107,7 +107,7 @@ public:
                       //cutoff value, should be considered outliers!
    Double_t GetChiQuant(Int_t i) const;
 
-   ClassDef(TRobustEstimator,1)  //Minimum Covariance Determinant Estimator
+   ClassDefOverride(TRobustEstimator,1)  //Minimum Covariance Determinant Estimator
 
 };
 

--- a/math/physics/inc/TRolke.h
+++ b/math/physics/inc/TRolke.h
@@ -115,7 +115,7 @@ public:
    TRolke(Double_t CL = 0.9, Option_t *option = "");
 
    /* Destructor */
-   virtual ~TRolke();
+   ~TRolke() override;
 
    /* Get and set the Confidence Level */
    Double_t GetCL() const         {
@@ -189,9 +189,9 @@ public:
    void SetSwitch(bool bnd) ;
 
    /* Dump internals. Option is not used */
-   void Print(Option_t*) const;
+   void Print(Option_t*) const override;
 
-   ClassDef(TRolke, 2)
+   ClassDefOverride(TRolke, 2)
 };
 
 //calculate confidence limits using the Rolke method

--- a/math/physics/inc/TRotation.h
+++ b/math/physics/inc/TRotation.h
@@ -41,7 +41,7 @@ private:
    TRotation(const TQuaternion &);
    // Copy constructor.
 
-   virtual ~TRotation() {;};
+   ~TRotation() override {;};
 
    inline Double_t XX() const;
    inline Double_t XY() const;
@@ -182,7 +182,7 @@ protected:
    Double_t fxx, fxy, fxz, fyx, fyy, fyz, fzx, fzy, fzz;
    // The matrix elements.
 
-   ClassDef(TRotation,1) // Rotations of TVector3 objects
+   ClassDefOverride(TRotation,1) // Rotations of TVector3 objects
 
 };
 

--- a/math/physics/inc/TVector2.h
+++ b/math/physics/inc/TVector2.h
@@ -34,7 +34,7 @@ public:
    TVector2 (const TVector2&) = default;
    TVector2 (Double_t *s);
    TVector2 (Double_t x0, Double_t y0);
-   virtual ~TVector2();
+   ~TVector2() override;
                                         // ****** unary operators
 
    TVector2&       operator  = (TVector2 const & v);
@@ -103,9 +103,9 @@ public:
    static Double_t Phi_mpi_pi(Double_t x);
 
 
-   void Print(Option_t* option="") const;
+   void Print(Option_t* option="") const override;
 
-   ClassDef(TVector2,3)  // A 2D physics vector
+   ClassDefOverride(TVector2,3)  // A 2D physics vector
 
 };
 

--- a/math/physics/inc/TVector3.h
+++ b/math/physics/inc/TVector3.h
@@ -37,7 +37,7 @@ public:
    TVector3(const TVector3 &);
    // The copy constructor.
 
-   virtual ~TVector3() {};
+   ~TVector3() override {};
    // Destructor
 
    Double_t operator () (int) const;
@@ -178,14 +178,14 @@ public:
 
    inline TVector2 XYvector() const;
 
-   void Print(Option_t* option="") const;
+   void Print(Option_t* option="") const override;
 
 private:
 
    Double_t fX, fY, fZ;
    // The components.
 
-   ClassDef(TVector3,3) // A 3D physics vector
+   ClassDefOverride(TVector3,3) // A 3D physics vector
 
    // make TLorentzVector a friend class
    friend class TLorentzVector;

--- a/math/quadp/inc/TGondzioSolver.h
+++ b/math/quadp/inc/TGondzioSolver.h
@@ -88,18 +88,18 @@ public:
    TGondzioSolver(TQpProbBase *of,TQpDataBase *prob,Int_t verbose=0);
    TGondzioSolver(const TGondzioSolver &another);
 
-   virtual ~TGondzioSolver();
+   ~TGondzioSolver() override;
 
-   virtual Int_t Solve           (TQpDataBase *prob,TQpVar *iterate,TQpResidual *resid);
+   Int_t Solve           (TQpDataBase *prob,TQpVar *iterate,TQpResidual *resid) override;
 
    virtual void  Reset_parameters() {}         // reset parameters to their default values
 
-   virtual void  DefMonitor      (TQpDataBase *data,TQpVar *vars,TQpResidual *resids,
+   void  DefMonitor      (TQpDataBase *data,TQpVar *vars,TQpResidual *resids,
                                   Double_t alpha,Double_t sigma,Int_t i,Double_t mu,
-                                  Int_t status_code,Int_t level);
+                                  Int_t status_code,Int_t level) override;
 
    TGondzioSolver &operator=(const TGondzioSolver &source);
 
-   ClassDef(TGondzioSolver,1)                  // Gondzio Qp Solver class
+   ClassDefOverride(TGondzioSolver,1)                  // Gondzio Qp Solver class
 };
 #endif

--- a/math/quadp/inc/TMehrotraSolver.h
+++ b/math/quadp/inc/TMehrotraSolver.h
@@ -73,15 +73,15 @@ public:
    TMehrotraSolver(TQpProbBase *of,TQpDataBase *prob,Int_t verbose=0);
    TMehrotraSolver(const TMehrotraSolver &another);
 
-   virtual ~TMehrotraSolver();
+   ~TMehrotraSolver() override;
 
-   virtual Int_t Solve           (TQpDataBase *prob,TQpVar *iterate,TQpResidual *resid);
-   virtual void  DefMonitor      (TQpDataBase *data,TQpVar *vars,TQpResidual *resids,
+   Int_t Solve           (TQpDataBase *prob,TQpVar *iterate,TQpResidual *resid) override;
+   void  DefMonitor      (TQpDataBase *data,TQpVar *vars,TQpResidual *resids,
                                   Double_t alpha,Double_t sigma,Int_t i,Double_t mu,
-                                  Int_t status_code,Int_t level);
+                                  Int_t status_code,Int_t level) override;
 
    TMehrotraSolver &operator=(const TMehrotraSolver &source);
 
-   ClassDef(TMehrotraSolver,1)                 // Mehrotra Qp Solver class
+   ClassDefOverride(TMehrotraSolver,1)                 // Mehrotra Qp Solver class
 };
 #endif

--- a/math/quadp/inc/TQpDataBase.h
+++ b/math/quadp/inc/TQpDataBase.h
@@ -88,7 +88,7 @@ public:
    TQpDataBase();
    TQpDataBase(Int_t nx,Int_t my,Int_t mz);
    TQpDataBase(const TQpDataBase &another);
-   virtual ~TQpDataBase() {}
+   ~TQpDataBase() override {}
 
    virtual void PutQIntoAt(TMatrixDBase &M,Int_t row,Int_t col) = 0;
    virtual void PutAIntoAt(TMatrixDBase &M,Int_t row,Int_t col) = 0;
@@ -120,6 +120,6 @@ public:
 
    TQpDataBase &operator= (const TQpDataBase &source);
 
-   ClassDef(TQpDataBase,1)                     // Qp Base Data class
+   ClassDefOverride(TQpDataBase,1)                     // Qp Base Data class
 };
 #endif

--- a/math/quadp/inc/TQpDataDens.h
+++ b/math/quadp/inc/TQpDataDens.h
@@ -81,41 +81,41 @@ public:
                TVectorD &iclow,TVectorD &cupp,TVectorD &icupp);
    TQpDataDens(const TQpDataDens &another);
 
-   virtual ~TQpDataDens() {}
+   ~TQpDataDens() override {}
 
-   virtual void PutQIntoAt(TMatrixDBase &M,Int_t row,Int_t col);
+   void PutQIntoAt(TMatrixDBase &M,Int_t row,Int_t col) override;
                                                // insert the Hessian Q into the matrix M for the fundamental
                                                // linear system, where M is stored as a TMatrixD
-   virtual void PutAIntoAt(TMatrixDBase &M,Int_t row,Int_t col);
+   void PutAIntoAt(TMatrixDBase &M,Int_t row,Int_t col) override;
                                                // insert the constraint matrix A into the matrix M for the
                                                // fundamental linear system, where M is stored as a TMatrixD
-   virtual void PutCIntoAt(TMatrixDBase &M,Int_t row,Int_t col);
+   void PutCIntoAt(TMatrixDBase &M,Int_t row,Int_t col) override;
                                                // insert the constraint matrix C into the matrix M for the
                                                // fundamental linear system, where M is stored as a TMatrixD
 
-   virtual void Qmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void Qmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * Q * x
-   virtual void Amult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void Amult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * A * x
-   virtual void Cmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void Cmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * C * x
-   virtual void ATransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void ATransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * A^T * x
-   virtual void CTransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void CTransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * C^T * x
 
-   virtual void GetDiagonalOfQ(TVectorD &dQ);  // extract the diagonal of Q and put it in the vector dQ
+   void GetDiagonalOfQ(TVectorD &dQ) override;  // extract the diagonal of Q and put it in the vector dQ
 
-   virtual Double_t DataNorm();
-   virtual void DataRandom(TVectorD &x,TVectorD &y,TVectorD &z,TVectorD &s);
+   Double_t DataNorm() override;
+   void DataRandom(TVectorD &x,TVectorD &y,TVectorD &z,TVectorD &s) override;
                                                // Create a random problem (x,y,z,s)
                                                // the solution to the random problem
-   virtual void Print(Option_t *opt="") const;
+   void Print(Option_t *opt="") const override;
 
-   virtual Double_t ObjectiveValue(TQpVar *vars);
+   Double_t ObjectiveValue(TQpVar *vars) override;
 
    TQpDataDens &operator= (const TQpDataDens &source);
 
-   ClassDef(TQpDataDens,1)                     // Qp Data class for Dens formulation
+   ClassDefOverride(TQpDataDens,1)                     // Qp Data class for Dens formulation
 };
 #endif

--- a/math/quadp/inc/TQpDataSparse.h
+++ b/math/quadp/inc/TQpDataSparse.h
@@ -78,44 +78,44 @@ public:
                  TVectorD &iclow,TVectorD &cupp,TVectorD &icupp);
    TQpDataSparse(const TQpDataSparse &another);
 
-   virtual ~TQpDataSparse() {}
+   ~TQpDataSparse() override {}
 
    void SetNonZeros(Int_t nnzQ,Int_t nnzA,Int_t nnzC);
 
-   virtual void PutQIntoAt(TMatrixDBase &M,Int_t row,Int_t col);
+   void PutQIntoAt(TMatrixDBase &M,Int_t row,Int_t col) override;
                                                // insert the Hessian Q into the matrix M for the fundamental
                                                // linear system, where M is stored as a TMatrixDSparse
-   virtual void PutAIntoAt(TMatrixDBase &M,Int_t row,Int_t col);
+   void PutAIntoAt(TMatrixDBase &M,Int_t row,Int_t col) override;
                                                // insert the constraint matrix A into the matrix M for the
                                                // fundamental linear system, where M is stored as a TMatrixDSparse
-   virtual void PutCIntoAt(TMatrixDBase &M,Int_t row,Int_t col);
+   void PutCIntoAt(TMatrixDBase &M,Int_t row,Int_t col) override;
                                                // insert the constraint matrix C into the matrix M for the
                                                // fundamental linear system, where M is stored as a
                                                // TMatrixDSparse
 
-   virtual void Qmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void Qmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * Q * x
-   virtual void Amult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void Amult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * A * x
-   virtual void Cmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void Cmult     (Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * C * x
-   virtual void ATransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void ATransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * A^T * x
-   virtual void CTransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x);
+   void CTransmult(Double_t beta,TVectorD& y,Double_t alpha,const TVectorD& x) override;
                                                // y = beta * y + alpha * C^T * x
 
-   virtual void GetDiagonalOfQ(TVectorD &dQ);  // extract the diagonal of Q and put it in the vector dQ
+   void GetDiagonalOfQ(TVectorD &dQ) override;  // extract the diagonal of Q and put it in the vector dQ
 
-   virtual Double_t DataNorm();
-   virtual void DataRandom(TVectorD &x,TVectorD &y,TVectorD &z,TVectorD &s);
+   Double_t DataNorm() override;
+   void DataRandom(TVectorD &x,TVectorD &y,TVectorD &z,TVectorD &s) override;
                                                // Create a random problem (x,y,z,s)
                                                // the solution to the random problem
-   virtual void Print(Option_t *opt="") const;
+   void Print(Option_t *opt="") const override;
 
-   virtual Double_t ObjectiveValue(TQpVar *vars);
+   Double_t ObjectiveValue(TQpVar *vars) override;
 
    TQpDataSparse &operator= (const TQpDataSparse &source);
 
-   ClassDef(TQpDataSparse,1)                   // Qp Data class for Sparse formulation
+   ClassDefOverride(TQpDataSparse,1)                   // Qp Data class for Sparse formulation
 };
 #endif

--- a/math/quadp/inc/TQpLinSolverBase.h
+++ b/math/quadp/inc/TQpLinSolverBase.h
@@ -95,7 +95,7 @@ public:
    TQpLinSolverBase(TQpProbBase *factory,TQpDataBase *data);
    TQpLinSolverBase(const TQpLinSolverBase &another);
 
-   virtual ~TQpLinSolverBase() {}
+   ~TQpLinSolverBase() override {}
 
    virtual void Factor          (TQpDataBase *prob,TQpVar *vars);
                                                // sets up the matrix for the main linear system in
@@ -150,6 +150,6 @@ public:
 
    TQpLinSolverBase &operator= (const TQpLinSolverBase &source);
 
-   ClassDef(TQpLinSolverBase,1)                // Qp linear solver base class
+   ClassDefOverride(TQpLinSolverBase,1)                // Qp linear solver base class
 };
 #endif

--- a/math/quadp/inc/TQpLinSolverDens.h
+++ b/math/quadp/inc/TQpLinSolverDens.h
@@ -70,15 +70,15 @@ public:
    TQpLinSolverDens(TQpProbDens *factory,TQpDataDens *data);
    TQpLinSolverDens(const TQpLinSolverDens &another);
 
-   virtual ~TQpLinSolverDens() {}
+   ~TQpLinSolverDens() override {}
 
-   virtual void Factor         (TQpDataBase *prob,TQpVar *vars);
-   virtual void SolveCompressed(TVectorD &rhs);
-   virtual void PutXDiagonal   (TVectorD &xdiag);
-   virtual void PutZDiagonal   (TVectorD &zdiag);
+   void Factor         (TQpDataBase *prob,TQpVar *vars) override;
+   void SolveCompressed(TVectorD &rhs) override;
+   void PutXDiagonal   (TVectorD &xdiag) override;
+   void PutZDiagonal   (TVectorD &zdiag) override;
 
    TQpLinSolverDens &operator= (const TQpLinSolverDens &source);
 
-   ClassDef(TQpLinSolverDens,1)                // Qp linear solver class for Dens formulation
+   ClassDefOverride(TQpLinSolverDens,1)                // Qp linear solver class for Dens formulation
 };
 #endif

--- a/math/quadp/inc/TQpLinSolverSparse.h
+++ b/math/quadp/inc/TQpLinSolverSparse.h
@@ -70,15 +70,15 @@ public:
    TQpLinSolverSparse(TQpProbSparse *factory,TQpDataSparse *data);
    TQpLinSolverSparse(const TQpLinSolverSparse &another);
 
-   virtual ~TQpLinSolverSparse() {}
+   ~TQpLinSolverSparse() override {}
 
-   virtual void Factor         (TQpDataBase *prob,TQpVar *vars);
-   virtual void SolveCompressed(TVectorD &rhs);
-   virtual void PutXDiagonal   (TVectorD &xdiag);
-   virtual void PutZDiagonal   (TVectorD &zdiag);
+   void Factor         (TQpDataBase *prob,TQpVar *vars) override;
+   void SolveCompressed(TVectorD &rhs) override;
+   void PutXDiagonal   (TVectorD &xdiag) override;
+   void PutZDiagonal   (TVectorD &zdiag) override;
 
    TQpLinSolverSparse &operator= (const TQpLinSolverSparse &source);
 
-   ClassDef(TQpLinSolverSparse,1)              // Qp linear solver class for Sparse formulation
+   ClassDefOverride(TQpLinSolverSparse,1)              // Qp linear solver class for Sparse formulation
 };
 #endif

--- a/math/quadp/inc/TQpProbBase.h
+++ b/math/quadp/inc/TQpProbBase.h
@@ -97,7 +97,7 @@ public:
    TQpProbBase(Int_t nx,Int_t my,Int_t mz);
    TQpProbBase(const TQpProbBase &another);
 
-   virtual ~TQpProbBase() {}
+   ~TQpProbBase() override {}
 
    virtual TQpDataBase      *MakeData     (TVectorD     &c,
                                            TMatrixDBase &Q_in,
@@ -116,6 +116,6 @@ public:
 
    TQpProbBase &operator= (const TQpProbBase &source);
 
-   ClassDef(TQpProbBase,1)                     // Qp problem formulation base class
+   ClassDefOverride(TQpProbBase,1)                     // Qp problem formulation base class
 };
 #endif

--- a/math/quadp/inc/TQpProbDens.h
+++ b/math/quadp/inc/TQpProbDens.h
@@ -66,7 +66,7 @@ public:
    TQpProbDens(Int_t nx,Int_t my,Int_t mz);
    TQpProbDens(const TQpProbDens &another);
 
-   virtual ~TQpProbDens() {}
+   ~TQpProbDens() override {}
 
    virtual TQpDataBase      *MakeData     (Double_t *c,
                                            Double_t *Q,
@@ -76,24 +76,24 @@ public:
                                            Double_t *C,
                                            Double_t *clo,Bool_t *iclo,
                                            Double_t *cup,Bool_t *icup);
-   virtual TQpDataBase      *MakeData     (TVectorD     &c,
+   TQpDataBase      *MakeData     (TVectorD     &c,
                                            TMatrixDBase &Q_in,
                                            TVectorD     &xlo, TVectorD &ixlo,
                                            TVectorD     &xup, TVectorD &ixup,
                                            TMatrixDBase &A_in,TVectorD &bA,
                                            TMatrixDBase &C_in,
                                            TVectorD     &clo, TVectorD &iclo,
-                                           TVectorD     &cup, TVectorD &icup);
-   virtual TQpResidual      *MakeResiduals(const TQpDataBase *data);
-   virtual TQpVar           *MakeVariables(const TQpDataBase *data);
-   virtual TQpLinSolverBase *MakeLinSys   (const TQpDataBase *data);
+                                           TVectorD     &cup, TVectorD &icup) override;
+   TQpResidual      *MakeResiduals(const TQpDataBase *data) override;
+   TQpVar           *MakeVariables(const TQpDataBase *data) override;
+   TQpLinSolverBase *MakeLinSys   (const TQpDataBase *data) override;
 
-   virtual void JoinRHS       (TVectorD &rhs_in,TVectorD &rhs1_in,TVectorD &rhs2_in,TVectorD &rhs3_in);
-   virtual void SeparateVars  (TVectorD &x_in,TVectorD &y_in,TVectorD &z_in,TVectorD &vars_in);
+   void JoinRHS       (TVectorD &rhs_in,TVectorD &rhs1_in,TVectorD &rhs2_in,TVectorD &rhs3_in) override;
+   void SeparateVars  (TVectorD &x_in,TVectorD &y_in,TVectorD &z_in,TVectorD &vars_in) override;
            void MakeRandomData(TQpDataDens *&data,TQpVar *&soln,Int_t nnzQ,Int_t nnzA,Int_t nnzC);
 
    TQpProbDens &operator= (const TQpProbDens &source);
 
-   ClassDef(TQpProbDens,1)                     // Qp dens problem formulation class
+   ClassDefOverride(TQpProbDens,1)                     // Qp dens problem formulation class
 };
 #endif

--- a/math/quadp/inc/TQpProbSparse.h
+++ b/math/quadp/inc/TQpProbSparse.h
@@ -64,7 +64,7 @@ public:
    TQpProbSparse(Int_t nx,Int_t my,Int_t mz);
    TQpProbSparse(const TQpProbSparse &another);
 
-   virtual ~TQpProbSparse() {}
+   ~TQpProbSparse() override {}
 
 #ifndef __CINT__
    virtual TQpDataBase      *MakeData      (Double_t *c,
@@ -77,24 +77,24 @@ public:
                                             Double_t *clo,Bool_t *iclo,
                                             Double_t *cup,Bool_t *icup);
 #endif
-   virtual TQpDataBase      *MakeData     (TVectorD     &c,
+   TQpDataBase      *MakeData     (TVectorD     &c,
                                             TMatrixDBase &Q_in,
                                             TVectorD     &xlo, TVectorD &ixlo,
                                             TVectorD     &xup, TVectorD &ixup,
                                             TMatrixDBase &A_in,TVectorD &bA,
                                             TMatrixDBase &C_in,
                                             TVectorD     &clo, TVectorD &iclo,
-                                            TVectorD     &cup, TVectorD &icup);
-   virtual TQpResidual      *MakeResiduals(const TQpDataBase *data);
-   virtual TQpVar           *MakeVariables(const TQpDataBase *data);
-   virtual TQpLinSolverBase *MakeLinSys   (const TQpDataBase *data);
+                                            TVectorD     &cup, TVectorD &icup) override;
+   TQpResidual      *MakeResiduals(const TQpDataBase *data) override;
+   TQpVar           *MakeVariables(const TQpDataBase *data) override;
+   TQpLinSolverBase *MakeLinSys   (const TQpDataBase *data) override;
 
-   virtual void JoinRHS       (TVectorD &rhs_in,TVectorD &rhs1_in,TVectorD &rhs2_in,TVectorD &rhs3_in);
-   virtual void SeparateVars  (TVectorD &x_in,TVectorD &y_in,TVectorD &z_in,TVectorD &vars_in);
+   void JoinRHS       (TVectorD &rhs_in,TVectorD &rhs1_in,TVectorD &rhs2_in,TVectorD &rhs3_in) override;
+   void SeparateVars  (TVectorD &x_in,TVectorD &y_in,TVectorD &z_in,TVectorD &vars_in) override;
            void MakeRandomData(TQpDataSparse *&data,TQpVar *&soln,Int_t nnzQ,Int_t nnzA,Int_t nnzC);
 
    TQpProbSparse &operator=(const TQpProbSparse &source);
 
-   ClassDef(TQpProbSparse,1)                   // Qp sparse problem formulation class
+   ClassDefOverride(TQpProbSparse,1)                   // Qp sparse problem formulation class
 };
 #endif

--- a/math/quadp/inc/TQpResidual.h
+++ b/math/quadp/inc/TQpResidual.h
@@ -103,7 +103,7 @@ public:
                TVectorD &ixlow,TVectorD &ixupp,TVectorD &iclow,TVectorD &icupp);
    TQpResidual(const TQpResidual &another);
 
-   virtual ~TQpResidual() {}
+   ~TQpResidual() override {}
 
    Double_t GetResidualNorm() { return fResidualNorm; }
    Double_t GetDualityGap  () { return fDualityGap; };
@@ -136,6 +136,6 @@ public:
 
    TQpResidual &operator= (const TQpResidual &source);
 
-   ClassDef(TQpResidual,1)                     // Qp Residual class
+   ClassDefOverride(TQpResidual,1)                     // Qp Residual class
 };
 #endif

--- a/math/quadp/inc/TQpSolverBase.h
+++ b/math/quadp/inc/TQpSolverBase.h
@@ -99,7 +99,7 @@ public:
    TQpSolverBase();
    TQpSolverBase(const TQpSolverBase &another);
 
-   virtual ~TQpSolverBase();
+   ~TQpSolverBase() override;
 
    virtual void     Start       (TQpProbBase *formulation,
                                  TQpVar *iterate,TQpDataBase *prob,
@@ -161,6 +161,6 @@ public:
 
    TQpSolverBase &operator= (const TQpSolverBase &source);
 
-   ClassDef(TQpSolverBase,1)                   // Qp Solver class
+   ClassDefOverride(TQpSolverBase,1)                   // Qp Solver class
 };
 #endif

--- a/math/quadp/inc/TQpVar.h
+++ b/math/quadp/inc/TQpVar.h
@@ -117,7 +117,7 @@ public:
       TVectorD &ixlow,TVectorD &ixupp,TVectorD &iclow,TVectorD &icupp);
    TQpVar(const TQpVar &another);
 
-   virtual ~TQpVar() {}
+   ~TQpVar() override {}
 
    // Indicates what type is the blocking variable in the step length determination. If kt_block,
    // then the blocking variable is one of the slack variables t for a general lower bound,
@@ -180,13 +180,13 @@ public:
                                                // sanity check.
    virtual Double_t Violation    ();           // The amount by which the current variables violate the
                                                //  non-negativity constraints.
-   virtual void     Print        (Option_t *option="") const;
+   void     Print        (Option_t *option="") const override;
    virtual Double_t Norm1        ();           // compute the 1-norm of the variables
    virtual Double_t NormInf      ();           // compute the inf-norm of the variables
    virtual Bool_t   ValidNonZeroPattern();
 
    TQpVar &operator= (const TQpVar &source);
 
-   ClassDef(TQpVar,1)                          // Qp Variables class
+   ClassDefOverride(TQpVar,1)                          // Qp Variables class
 };
 #endif

--- a/math/rtools/inc/Math/RMinimizer.h
+++ b/math/rtools/inc/Math/RMinimizer.h
@@ -50,22 +50,22 @@ namespace ROOT {
             */	
             RMinimizer(Option_t *method);
             ///Destructor
-            virtual ~RMinimizer() {}
+            ~RMinimizer() override {}
             ///Function to find the minimum
-            virtual bool Minimize();
+            bool Minimize() override;
             ///Returns the number of function calls
-            virtual unsigned int NCalls() const;
+            unsigned int NCalls() const override;
             ///Returns the ith jth component of the Hessian matrix
             double HessMatrix(unsigned int i, unsigned int j) const;
             /// minimizer provides error and error matrix
-            virtual bool ProvidesError() const { return !(fErrors.empty()); }
+            bool ProvidesError() const override { return !(fErrors.empty()); }
             /// return errors at the minimum
-            virtual const double * Errors() const { return fErrors.data(); }
+            const double * Errors() const override { return fErrors.data(); }
             /** return covariance matrices element for variables ivar,jvar
             if the variable is fixed the return value is zero
             The ordering of the variables is the same as in the parameter and errors vectors
             */
-           virtual double CovMatrix(unsigned int  ivar , unsigned int jvar ) const {
+           double CovMatrix(unsigned int  ivar , unsigned int jvar ) const override {
               return fCovMatrix(ivar, jvar);
             }
             /**
@@ -76,7 +76,7 @@ namespace ROOT {
             This is different from the direct interface of Minuit2 or TMinuit where the
             values were obtained only to variable parameters
             */
-            virtual bool GetCovMatrix(double * covMat) const {
+            bool GetCovMatrix(double * covMat) const override {
                int ndim = NDim(); 
                if (fCovMatrix.GetNrows() != ndim || fCovMatrix.GetNcols() != ndim ) return false; 
                std::copy(fCovMatrix.GetMatrixArray(), fCovMatrix.GetMatrixArray() + ndim*ndim, covMat);

--- a/math/splot/inc/TSPlot.h
+++ b/math/splot/inc/TSPlot.h
@@ -50,10 +50,10 @@ protected:
 public:
    TSPlot();
    TSPlot(Int_t nx, Int_t ny, Int_t ne, Int_t ns, TTree* tree);
-   virtual ~TSPlot();
+   ~TSPlot() override;
 
-   void       Browse(TBrowser *b);
-   Bool_t     IsFolder() const { return kTRUE;}
+   void       Browse(TBrowser *b) override;
+   Bool_t     IsFolder() const override { return kTRUE;}
 
    void       FillXvarHists(Int_t nbins = 100);
    void       FillYvarHists(Int_t nbins = 100);
@@ -87,7 +87,7 @@ public:
    void       SetTree(TTree *tree);
    void       SetTreeSelection(const char* varexp="", const char *selection="", Long64_t firstentry=0);
 
-   ClassDef(TSPlot, 1)  //class to disentangle signal from background
+   ClassDefOverride(TSPlot, 1)  //class to disentangle signal from background
 };
 
 #endif

--- a/math/unuran/inc/TUnuranContDist.h
+++ b/math/unuran/inc/TUnuranContDist.h
@@ -80,7 +80,7 @@ public:
    /**
       Destructor
    */
-   virtual ~TUnuranContDist ();
+   ~TUnuranContDist () override;
 
 
    /**
@@ -96,7 +96,7 @@ public:
    /**
       Clone (required by base class)
     */
-   virtual TUnuranContDist * Clone() const { return new TUnuranContDist(*this); }
+   TUnuranContDist * Clone() const override { return new TUnuranContDist(*this); }
 
 
    /**
@@ -213,7 +213,7 @@ private:
    bool  fOwnFunc;          ///< flag to indicate if class manages the function pointers
    //mutable double fX[1];  ///<! cached vector for using TF1::EvalPar
 
-   ClassDef(TUnuranContDist,1)  //Wrapper class for one dimensional continuous distribution
+   ClassDefOverride(TUnuranContDist,1)  //Wrapper class for one dimensional continuous distribution
 
 
 };

--- a/math/unuran/inc/TUnuranDiscrDist.h
+++ b/math/unuran/inc/TUnuranDiscrDist.h
@@ -83,7 +83,7 @@ public:
    /**
       Destructor
    */
-   virtual ~TUnuranDiscrDist ();
+   ~TUnuranDiscrDist () override;
 
    /**
       Copy constructor
@@ -98,7 +98,7 @@ public:
    /**
       Clone (required by base class)
     */
-   virtual TUnuranDiscrDist * Clone() const { return new TUnuranDiscrDist(*this); }
+   TUnuranDiscrDist * Clone() const override { return new TUnuranDiscrDist(*this); }
 
    /**
       set cdf distribution from a generic function interface. If a method requires it
@@ -213,7 +213,7 @@ private:
    bool  fHasSum;                ///< flag to control if distribution has a pre-computed sum of the probabilities
    bool  fOwnFunc;               ///< flag to control if distribution owns the function pointers
 
-   ClassDef(TUnuranDiscrDist,1)  //Wrapper class for one dimensional discrete distribution
+   ClassDefOverride(TUnuranDiscrDist,1)  //Wrapper class for one dimensional discrete distribution
 
 
 };

--- a/math/unuran/inc/TUnuranEmpDist.h
+++ b/math/unuran/inc/TUnuranEmpDist.h
@@ -88,7 +88,7 @@ public:
    /**
       Destructor (no operations)
    */
-   virtual ~TUnuranEmpDist () {}
+   ~TUnuranEmpDist () override {}
 
 
    /**
@@ -105,7 +105,7 @@ public:
    /**
       Clone (required by base class)
     */
-   TUnuranEmpDist * Clone() const { return new TUnuranEmpDist(*this); }
+   TUnuranEmpDist * Clone() const override { return new TUnuranEmpDist(*this); }
 
 
    /**
@@ -144,7 +144,7 @@ private:
    double fMax;                      ///< max values (used in the binned case)
    bool   fBinned;                   ///< flag for binned/unbinned data
 
-   ClassDef(TUnuranEmpDist,1)        //Wrapper class for empirical distribution
+   ClassDefOverride(TUnuranEmpDist,1)        //Wrapper class for empirical distribution
 
 
 };

--- a/math/unuran/inc/TUnuranMultiContDist.h
+++ b/math/unuran/inc/TUnuranMultiContDist.h
@@ -67,7 +67,7 @@ public:
    /**
       Destructor
    */
-   virtual ~TUnuranMultiContDist ();
+   ~TUnuranMultiContDist () override;
 
 
    /**
@@ -83,7 +83,7 @@ public:
    /**
       Clone (required by base class)
     */
-   virtual TUnuranMultiContDist * Clone() const { return new TUnuranMultiContDist(*this); }
+   TUnuranMultiContDist * Clone() const override { return new TUnuranMultiContDist(*this); }
 
 
    /**
@@ -173,7 +173,7 @@ private:
    bool  fOwnFunc;                ///< flag to indicate if class manages the function pointers
 
 
-   ClassDef(TUnuranMultiContDist,1)  //Wrapper class for multi dimensional continuous distribution
+   ClassDefOverride(TUnuranMultiContDist,1)  //Wrapper class for multi dimensional continuous distribution
 
 
 };

--- a/math/unuran/inc/TUnuranSampler.h
+++ b/math/unuran/inc/TUnuranSampler.h
@@ -57,13 +57,13 @@ public:
 
 
    /// virtual destructor
-   virtual ~TUnuranSampler();
+   ~TUnuranSampler() override;
 
 
    using DistSampler::SetFunction;
 
    /// Set the parent function distribution to use for random sampling (one dim case).
-   void SetFunction(const ROOT::Math::IGenFunction & func)  {
+   void SetFunction(const ROOT::Math::IGenFunction & func) override  {
       fFunc1D = &func;
       SetFunction<const ROOT::Math::IGenFunction>(func, 1);
    }
@@ -72,36 +72,36 @@ public:
    void SetFunction(TF1 * pdf);
 
    /// set the cumulative distribution function of the PDF used for random sampling (one dim case)
-   void SetCdf(const ROOT::Math::IGenFunction &cdf);
+   void SetCdf(const ROOT::Math::IGenFunction &cdf) override;
 
    /// set the Derivative of the PDF used for random sampling (one dim continuous case)
-   void SetDPdf(const ROOT::Math::IGenFunction &dpdf);
+   void SetDPdf(const ROOT::Math::IGenFunction &dpdf) override;
 
    /**
       initialize the generators with the given algorithm
       If no algorithm is passed used the default one for the type of distribution
    */
-   bool Init(const char * algo ="");
+   bool Init(const char * algo ="") override;
 
 
    /**
       initialize the generators with the given algorithm
       If no algorithm is passed used the default one for the type of distribution
    */
-   bool Init(const ROOT::Math::DistSamplerOptions & opt );
+   bool Init(const ROOT::Math::DistSamplerOptions & opt ) override;
 
    /**
        Set the random engine to be used
        Needs to be called before Init to have effect
    */
-   void SetRandom(TRandom * r);
+   void SetRandom(TRandom * r) override;
 
    /**
        Set the random seed for the TRandom instances used by the sampler
        classes
        Needs to be called before Init to have effect
    */
-   void SetSeed(unsigned int seed);
+   void SetSeed(unsigned int seed) override;
 
    /**
       Set the print level
@@ -112,7 +112,7 @@ public:
    /*
       set the mode (1D distribution)
     */
-   void SetMode(double mode) {
+   void SetMode(double mode) override {
       fMode = mode;
       fHasMode = true;
    }
@@ -120,30 +120,30 @@ public:
    /*
       set the mode (Multidim distribution)
    */
-   void SetMode(const std::vector<double> &modes);
+   void SetMode(const std::vector<double> &modes) override;
 
 
    /*
      set the area
     */
-   void SetArea(double area) {
+   void SetArea(double area) override {
       fArea = area;
       fHasArea = true;
    }
 
    /// Set using of logarithm of PDF (only for 1D continuous case)
-   void SetUseLogPdf(bool on = true) { fUseLogPdf = on; }
+   void SetUseLogPdf(bool on = true) override { fUseLogPdf = on; }
 
    /**
       Get the random engine used by the sampler
     */
-   TRandom * GetRandom();
+   TRandom * GetRandom() override;
 
    /**
       sample one event in one dimension
       better implementation could be provided by the derived classes
    */
-   double Sample1D();//  {
+   double Sample1D() override;//  {
 //       return fUnuran->Sample();
 //    }
 
@@ -151,7 +151,7 @@ public:
       sample one event in multi-dimension by filling the given array
       return false if sampling failed
    */
-   bool Sample(double * x);
+   bool Sample(double * x) override;
 //  {
 //       if (!fOneDim) return fUnuran->SampleMulti(x);
 //       x[0] = Sample1D();
@@ -164,7 +164,7 @@ public:
       divided by the bin width)
       By default do not do random sample, just return the function values
     */
-   bool SampleBin(double prob, double & value, double *error = 0);
+   bool SampleBin(double prob, double & value, double *error = 0) override;
 
 
 


### PR DESCRIPTION
As suggested by @lmoneta, this is now the equivalent PR to
https://github.com/root-project/root/pull/9808, but for `math` instead
of `roofit` because inheritance is also used a lot in Math.

For developers, it is unconvenient that the `override` specifier
that flags member functions as overriding on first sight is not used so
much in `hist`.

Now that the v6.28 development cycle has just started and there are no
major developments in the pipeline yet, I think it is a good time to add
the missing `override` specifiers everywhere in `hist`, as done already
for RooFitV.

This commit was generated more or less automatically with this Python
script that uses `clang-tidy`:

```Python
import os
import glob
import subprocess
import tqdm

"""
For clang-tidy to work, you have to copy the compile_commands.json from the
build directory back into the repo directory (just like in
.ci/copy_headers.sh).
"""

def get_sources(directory, extensions):

    files = []

    for ext in extensions:
        files += glob.glob(
            os.path.join(directory, "**/*" + ext), recursive=True
        )

    return files

"""
Recursively find extensions in directory, to figure out whic hextensions
should be globbed for.
   find . -type f -name '*.*' | sed 's|.*\.||' | sort -u
"""
extensions = [".h", ".hpp", ".hxx", ".cpp", ".cc", ".cxx"]

"""
Some extensions are recognized as C and not as C++ files by clang-tidy. We
need to rename them, and this dict specifies how file extensions should be
replaced.
"""
rename_dict = {".h": ".hpp"}

files = get_sources("math", extensions)

cflags = (
    subprocess.check_output(["root-config", "--cflags"]).strip().decode("utf-8")
)

for file in tqdm.tqdm(files):

    file_renamed = file
    for ext, ext_renamed in rename_dict.items():
        if file.endswith(ext):
            file_renamed = file.replace(ext, ext_renamed)

    if file_renamed != file:
        os.rename(file, file_renamed)

    cmd = [
        "clang-tidy",
        "-checks=modernize-use-override",
        "--fix",
        file_renamed,
        "--",
    ] + cflags.split(" ")
    subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

    if file_renamed != file:
        os.rename(file_renamed, file)

"""
Finally, replace the ClassDef with the ClassDefOverride macros.
  find math -type f -print | xargs sed -i 's/ClassDef(/ClassDefOverride(/'
...and change back the ClassDefOverride of non-overriding base classes.
"""
```