### PR TITLE
[RF] RooFit banner code returns and can be enabled by preprocessor flag

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -291,6 +291,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooArgList.cxx
     src/RooArgProxy.cxx
     src/RooArgSet.cxx
+    src/Initialisation.cxx
     src/RooBinIntegrator.cxx
     src/RooBinnedGenContext.cxx
     src/RooBinningCategory.cxx

--- a/roofit/roofitcore/src/Initialisation.cxx
+++ b/roofit/roofitcore/src/Initialisation.cxx
@@ -1,0 +1,43 @@
+#ifdef __ROOFIT_BANNER
+
+#include "RConfigure.h"
+#include "TEnv.h"
+
+#include <iostream>
+
+/**
+\file Initialisation.cxx
+\ingroup Roofitcore
+Run static initialisers on first load of RooFitCore.
+**/
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Print RooFit banner.
+void doBanner() {
+  if (gEnv->GetValue("RooFit.Banner", 1) == 0)
+    return;
+
+  /// RooFit version tag.
+  constexpr char VTAG[] = "3.60";
+
+  std::cout << '\n'
+      << "\033[1mRooFit v" << VTAG << " -- Developed by Wouter Verkerke and David Kirkby\033[0m " << '\n'
+      << "                Copyright (C) 2000-2013 NIKHEF, University of California & Stanford University" << '\n'
+      << "                All rights reserved, please read http://roofit.sourceforge.net/license.txt" << '\n'
+      << std::endl;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// A RAII that performs RooFit's static initialisation.
+static struct RooFitInitialiser {
+  RooFitInitialiser() {
+    doBanner();
+  }
+} __rooFitInitialiser;
+
+}
+
+#endif


### PR DESCRIPTION
The `roofit/roofitcore/src/Initialisation.cxx` file is brought back such
that it's easy to compile ROOT again with the RooFit banner enabled if
desired.

This is a follow up to https://github.com/root-project/root/pull/9965.