### PR TITLE
hadd: Remove inadvertent deletion (and subsequent re-reading) of TDirectory

### DIFF
--- a/io/io/src/TFileMerger.cxx
+++ b/io/io/src/TFileMerger.cxx
@@ -800,7 +800,7 @@ Bool_t TFileMerger::MergeOne(TDirectory *target, TList *sourcelist, Int_t type, 
       }
    }
    info.Reset();
-
+   dirtodelete.Clear("nodelete");  // If needed the delete is done explicitly above.
    return kTRUE;
 }
 


### PR DESCRIPTION

This fixes issue #9939.

The mechanism introduced in commits e97dc3678ae9da6628242afceca3142d6c319832
and 30fd4c79425c8be12be7af6fe1936317d1f5eec7 : TFileMerger delete directory only if we induced its creation/loading
also had the unforunate consequence leading to the deletion of the
TDirectory object when reading other objects, leading to the need
to re-read the TDirectory objects as many time as object in
the directory ... (This is triggered only for the 2nd and higher files).

