### PR TITLE
Several small fixes for webgui (6.26)

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -399,8 +399,10 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          const char *opt = argv[i] + 5;
          argv[i] = null;
          TString argw;
-         if (gROOT->IsBatch()) argw = "batch";
-         if (*opt == '=') argw.Append(opt+1);
+         if (*opt == '=')
+            argw.Append(opt+1);
+         else if (gROOT->IsBatch())
+            argw = "batch";
          if (argw == "off") {
             gROOT->SetWebDisplay(argw.Data());
             gEnv->SetValue("Browser.Name", "TRootBrowser"); // force usage of TBrowser back

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2774,6 +2774,12 @@ void TROOT::SetWebDisplay(const char *webdisplay)
       fIsWebDisplay = kFALSE;
       fIsWebDisplayBatch = kFALSE;
       fWebDisplay = "";
+   } else if (!strncmp(wd, "server", 6)) {
+      fIsWebDisplay = kTRUE;
+      fIsWebDisplayBatch = kFALSE;
+      fWebDisplay = "server";
+      if (wd[6] == ':')
+         gEnv->SetValue("WebGui.HttpPort", TString(wd+7).Atoi());
    } else {
       fIsWebDisplay = kTRUE;
       if (!strncmp(wd, "batch", 5)) {

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2778,8 +2778,13 @@ void TROOT::SetWebDisplay(const char *webdisplay)
       fIsWebDisplay = kTRUE;
       fIsWebDisplayBatch = kFALSE;
       fWebDisplay = "server";
-      if (wd[6] == ':')
-         gEnv->SetValue("WebGui.HttpPort", TString(wd+7).Atoi());
+      if (wd[6] == ':') {
+         auto port = TString(wd+7).Atoi();
+         if (port > 0)
+            gEnv->SetValue("WebGui.HttpPort", port);
+         else
+            Error("SetWebDisplay","Wrong port parameter %s for server", wd+7);
+      }
    } else {
       fIsWebDisplay = kTRUE;
       if (!strncmp(wd, "batch", 5)) {

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -1279,6 +1279,7 @@ const char *THttpServer::GetMimeType(const char *path)
                              {".shtml", 6, "text/html"},
                              {".css", 4, "text/css"},
                              {".js", 3, "application/x-javascript"},
+                             {".mjs", 4, "text/javascript"},
                              {".ico", 4, "image/x-icon"},
                              {".jpeg", 5, "image/jpeg"},
                              {".svg", 4, "image/svg+xml"},


### PR DESCRIPTION
1. Let configure `--web` also in batch mode
2. Support `--web=server:port`
3. Support `.mjs` extension, will be required for latest JSROOT