### PR TITLE
[textinput] Bind Ctrl+Del to `Editor::kCmdCutNextWord` (kill next word)

### DIFF
--- a/core/textinput/src/textinput/KeyBinding.cpp
+++ b/core/textinput/src/textinput/KeyBinding.cpp
@@ -142,7 +142,8 @@ namespace textinput {
         if (HadEscPending) {
           return C(Editor::kCmdCutPrevWord);
         } else {
-          return C(Editor::kCmdDel);
+          return (modifier & InputData::kModCtrl)
+                 ? C(Editor::kCmdCutNextWord) : C(Editor::kCmdDel);
         }
       case InputData::kEIIns: return C(Editor::kCmdToggleOverwriteMode);
       case InputData::kEITab: return C(Editor::kCmdComplete);

--- a/core/textinput/src/textinput/StreamReaderUnix.cpp
+++ b/core/textinput/src/textinput/StreamReaderUnix.cpp
@@ -224,6 +224,8 @@ namespace textinput {
                                          InputData::kModCtrl);
       gExtKeyMap['[']['1'][';']['5']['D'].Set(InputData::kEILeft,
                                          InputData::kModCtrl);
+      gExtKeyMap['[']['3'][';']['5']['~'].Set(InputData::kEIDel,
+                                         InputData::kModCtrl);
 
       // MacOS
       gExtKeyMap['O']['A'] = InputData::kEIUp;


### PR DESCRIPTION
This pull request adds a keybinding for Ctrl+Del to kill the next word.  This keybinding is quite popular, thus desirable to have it in ROOT.
The change is equivalent to the GNU Readline keybinding:
```bash
"\e[3;5~": kill-word
```

This PR is part of a series to improve line editing at the prompt.  See also: PRs #9753 and #10078.

## Changes or fixes:
- The `[3;5~` CSI was added in StreamReaderUnix.cpp.  No additional changes required to StreamReaderWin.cpp due to the separation of `dwControlKeyState` and `wVirtualKeyCode`.
- Add Ctrl+Del key binding to `Editor::kCmdCutNextWord`.

## Checklist:
- [X] tested changes locally