### PR TITLE
[rootfit] add missing include in RooFitDriver.cxx

### DIFF
--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -46,6 +46,7 @@ and gets destroyed when the fitting ends.
 #include <iomanip>
 #include <numeric>
 #include <thread>
+#include <unordered_set>
 
 namespace ROOT {
 namespace Experimental {


### PR DESCRIPTION
Missing when compiled with -Ddev=ON option
