### PR TITLE
[TRint] If `*argc` is `nullptr`, do not attempt to deref it.

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -141,15 +141,17 @@ namespace {
 static int SetExtraClingArgsBeforeTAppCtor(Int_t *argc, char **argv)
 {
    bool forcePtrCheck = false;
-   for (int iarg = 1; iarg < *argc; ++iarg) {
-      if (!strcmp(argv[iarg], "--ptrcheck")) {
-         // Hide this, by moving all other args one down...
-         for (int jarg = iarg + 1; jarg < *argc; ++jarg)
-            argv[jarg - 1] = argv[jarg];
-         // ... and updating argc accordingly.
-         --*argc;
-         forcePtrCheck = true;
-         break;
+   if (argc != nullptr) {
+      for (int iarg = 1; iarg < *argc; ++iarg) {
+         if (!strcmp(argv[iarg], "--ptrcheck")) {
+            // Hide this, by moving all other args one down...
+            for (int jarg = iarg + 1; jarg < *argc; ++jarg)
+               argv[jarg - 1] = argv[jarg];
+            // ... and updating argc accordingly.
+            --*argc;
+            forcePtrCheck = true;
+            break;
+         }
       }
    }
 #ifdef R__UNIX
@@ -171,7 +173,7 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options, 
      fCaughtSignal(-1)
 {
 
-   if (*argc > 1) {
+   if (argc != nullptr && *argc > 1) {
       // Early exit if there are remaining unrecognized options
       for (auto n = 1; n < *argc; n++) {
          std::cerr << "root: unrecognized option '" << argv[n] << "'\n";


### PR DESCRIPTION
The `TApplication` default constructor uses `*argc=nullptr` and `**argv=nullptr` as default values, and ignores the args if that is passed in.
For symmetry and by principle of least surprise, ensure that this also works with `TRint`, which can also be used as base class (or helper class) in existing applications.

see #10090

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

