### PR TITLE
[RF] Remove integration code from RooEffProd

### DIFF
--- a/roofit/roofitcore/inc/RooEffProd.h
+++ b/roofit/roofitcore/inc/RooEffProd.h
@@ -20,8 +20,6 @@
 class RooEffProd: public RooAbsPdf {
 public:
   // Constructors, assignment etc
-  inline RooEffProd() : _cacheMgr(this,10), _nset(0), _fixedNset(0) { };
-  ~RooEffProd() override;
   RooEffProd(const char *name, const char *title, RooAbsPdf& pdf, RooAbsReal& efficiency);
   RooEffProd(const RooEffProd& other, const char* name=0);
 
@@ -30,47 +28,13 @@ public:
   RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype,
                                        const RooArgSet* auxProto, Bool_t verbose) const override;
 
-  /// Return kTRUE to force RooRealIntegral to offer all observables for internal integration
-  Bool_t forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
-    return kTRUE ;
-  }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  Double_t analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
-
 protected:
-
-  /// Return pointer to pdf in product
-  const RooAbsPdf* pdf() const {
-    return (RooAbsPdf*) _pdf.absArg() ;
-  }
-  /// Return pointer to efficiency function in product
-  const RooAbsReal* eff() const {
-    return (RooAbsReal*) _eff.absArg() ;
-  }
 
   // Function evaluation
   Double_t evaluate() const override ;
 
-  class CacheElem : public RooAbsCacheElement {
-  public:
-    CacheElem() : _clone(0), _int(0) {}
-    ~CacheElem() override { delete _int ; delete _clone ; }
-    // Payload
-    RooArgSet   _intObs ;
-    RooEffProd* _clone ;
-    RooAbsReal* _int ;
-    // Cache management functions
-    RooArgList containedArgs(Action) override ;
-  } ;
-  mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager
-
-
-  // the real stuff...
   RooRealProxy _pdf ;               ///< Probability Density function
   RooRealProxy _eff;                ///< Efficiency function
-  mutable const RooArgSet* _nset  ; ///<! Normalization set to be used in evaluation
-
-  RooArgSet* _fixedNset ; ///<! Fixed normalization set overriding default normalization set (if provided)
 
   ClassDefOverride(RooEffProd,2) // Product operator p.d.f of (PDF x efficiency) implementing optimized generator context
 };

--- a/roofit/roofitcore/src/RooEffProd.cxx
+++ b/roofit/roofitcore/src/RooEffProd.cxx
@@ -27,12 +27,6 @@
 #include "RooNameReg.h"
 #include "RooRealVar.h"
 
-using namespace std;
-
-ClassImp(RooEffProd);
-  ;
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of a a production of p.d.f inPdf with efficiency
@@ -41,15 +35,10 @@ ClassImp(RooEffProd);
 RooEffProd::RooEffProd(const char *name, const char *title,
                              RooAbsPdf& inPdf, RooAbsReal& inEff) :
   RooAbsPdf(name,title),
-  _cacheMgr(this,10),
   _pdf("pdf","pre-efficiency pdf", this,inPdf),
-  _eff("eff","efficiency function",this,inEff),
-  _nset(0),
-  _fixedNset(0)
+  _eff("eff","efficiency function",this,inEff)
 {
 }
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,25 +46,10 @@ RooEffProd::RooEffProd(const char *name, const char *title,
 
 RooEffProd::RooEffProd(const RooEffProd& other, const char* name) :
   RooAbsPdf(other, name),
-  _cacheMgr(other._cacheMgr,this),
   _pdf("pdf",this,other._pdf),
-  _eff("acc",this,other._eff),
-  _nset(0),
-  _fixedNset(0)
+  _eff("acc",this,other._eff)
 {
 }
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooEffProd::~RooEffProd()
-{
-}
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,9 +57,8 @@ RooEffProd::~RooEffProd()
 
 Double_t RooEffProd::evaluate() const
 {
-  return eff()->getVal() * pdf()->getVal(_fixedNset ? _fixedNset : _normSet);
+  return _eff * _pdf;
 }
-
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -95,105 +68,8 @@ Double_t RooEffProd::evaluate() const
 RooAbsGenContext* RooEffProd::genContext(const RooArgSet &vars, const RooDataSet *prototype,
                                             const RooArgSet* auxProto, Bool_t verbose) const
 {
-  assert(pdf()!=0);
-  assert(eff()!=0);
-  return new RooEffGenContext(*this,*pdf(),*eff(),vars,prototype,auxProto,verbose) ;
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return internal integration capabilities of the p.d.f. Given a set 'allVars' for which
-/// integration is requested, returned the largest subset for which internal (analytical)
-/// integration is implemented (in argument analVars). The return value is a unique integer
-/// code that identifies the integration configuration (integrated observables and range name).
-///
-/// This implementation in RooEffProd catches all integrals without normalization and reroutes them
-/// through a custom integration routine that properly accounts for the use of normalized p.d.f.
-/// in the evaluate() expression, which breaks the default RooAbsPdf normalization handling
-
-Int_t RooEffProd::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
-                 const RooArgSet* normSet, const char* rangeName) const
-{
-
-  // No special handling required if a normalization set is given
-  if (normSet && normSet->getSize()>0) {
-    return 0 ;
-  }
-  // No special handling required if running with a fixed normalization set
-  if (_fixedNset) {
-    return 0 ;
-  }
-
-  // Special handling of integrals w/o normalization set. We need to pass _a_ normalization set
-  // to pdf().getVal(nset) in evaluate() because for certain p.d.fs the shape depends on the
-  // chosen normalization set. This functions correctly automatically for plain getVal() calls,
-  // however when the (numeric) normalization is calculated, getVal() is called without any normalization
-  // set causing the normalization to be calculated for a possibly different shape. To fix that
-  // integrals over a RooEffProd without normalization setup are explicitly handled here. These integrals
-  // are calculated using a clone of the RooEffProd that has a fixed normalization set passed to the
-  // underlying p.d.f regardless of the normalization set passed to getVal(). Here the set of observables
-  // over which is integrated is passed.
-
-  // Declare that we can analytically integrate all requested observables
-  analVars.add(allVars) ;
-
-  // Check if cache was previously created
-  Int_t sterileIndex(-1) ;
-  CacheElem* cache = (CacheElem*) _cacheMgr.getObj(&allVars,&allVars,&sterileIndex,RooNameReg::ptr(rangeName)) ;
-  if (cache) {
-    return _cacheMgr.lastIndex()+1;
-  }
-
-  // Construct cache with clone of p.d.f that has fixed normalization set that is passed to input pdf
-  cache = new CacheElem ;
-  cache->_intObs.addClone(allVars) ;
-  cache->_clone = (RooEffProd*) clone(Form("%s_clone",GetName())) ;
-  cache->_clone->_fixedNset = &cache->_intObs ;
-  cache->_int = cache->_clone->createIntegral(cache->_intObs,rangeName) ;
-
-  // Store cache and return index as code
-  Int_t code = _cacheMgr.setObj(&allVars,&allVars,(RooAbsCacheElement*)cache,RooNameReg::ptr(rangeName)) ;
-
-  return code+1 ;
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return value of integral identified by code, which should be a return value of getAnalyticalIntegralWN,
-/// Code zero is always handled and signifies no integration (return value is normalized p.d.f. value)
-
-Double_t RooEffProd::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* /*rangeName*/) const
-{
-  // Return analytical integral defined by given scenario code
-
-  // No integration scenario
-  if (code==0) {
-    return getVal(normSet) ;
-  }
-
-  // Partial integration scenarios
-  CacheElem* cache = (CacheElem*) _cacheMgr.getObjByIndex(code-1) ;
-
-  return cache->_int->getVal() ;
-}
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Report all RooAbsArg derived objects contained in Cache Element (used in function optimization and
-/// and server redirect management of the cache)
-
-RooArgList RooEffProd::CacheElem::containedArgs(Action)
-{
-  RooArgList ret(_intObs) ;
-  ret.add(*_int) ;
-  ret.add(*_clone) ;
-  return ret ;
+  return new RooEffGenContext(*this,
+                              static_cast<RooAbsPdf const&>(_pdf.arg()),
+                              static_cast<RooAbsReal const&>(_eff.arg()),
+                              vars,prototype,auxProto,verbose) ;
 }


### PR DESCRIPTION
The `RooEffProd` class contains some caching logic to always provide a
normalization set to the integrated pdf. However, this should better not
be done, because as the the former documentation sais it "breaks the
default RooAbsPdf normalization handling". It is also inconsistent,
because, other RooFit classes like `RooProduct` don't do that.

Also, it is not the task of the RooEffProd to protect pdfs from being
evaluated without normalization set if their shape depends on it. The
concerned pdfs (like RooAddPdf) already do that themselves.

The reason why this is removed now it that the caching of normalization
integrals doesn't work with the new RooFit batch mode.

This commit is tested by the `stressRooFit` unit test.