### PR TITLE
[RF] Avoid using RooStringVar in RooCmdConfig

### DIFF
--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -97,6 +97,14 @@ public:
 
 protected:
 
+  struct StringVar {
+    std::string name;
+    std::string argName;
+    std::string val;
+    bool appendMode;
+    int stringNum;
+  };
+
   TString _name ;
 
   Bool_t _verbose = false;
@@ -105,7 +113,7 @@ protected:
 
   TList _iList ; ///< Integer list
   TList _dList ; ///< Double list
-  TList _sList ; ///< String list
+  std::vector<StringVar> _sList ; ///< String list
   TList _oList ; ///< Object list
   TList _cList ; ///< RooArgSet list
 


### PR DESCRIPTION
The RooStringVar class is planned to get deprecated soon, hence RooFit
code that is still using it is getting migrated away from it.

In the RooCmdConfig case, one can use simple configuration structs
insread of RooStringVar.

This change is tested by many unit tests in RooFit, as the
`RooCmdConfig` is used in many places, for example `RooAbsPdf::fitTo`.