### PR TITLE
[rint] Add boolean flag to exit on unknown arguments

### DIFF
--- a/core/rint/inc/TRint.h
+++ b/core/rint/inc/TRint.h
@@ -48,8 +48,8 @@ private:
    Longptr_t ProcessLineNr(const char* filestem, const char *line, Int_t *error = nullptr);
 
 public:
-   TRint(const char *appClassName, Int_t *argc, char **argv,
-         void *options = 0, Int_t numOptions = 0, Bool_t noLogo = kFALSE);
+   TRint(const char *appClassName, Int_t *argc, char **argv, void *options = 0, Int_t numOptions = 0,
+         Bool_t noLogo = kFALSE, Bool_t exitOnUnknownArgs = kFALSE);
    virtual             ~TRint();
    virtual char       *GetPrompt();
    virtual const char *SetPrompt(const char *newPrompt);

--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -168,13 +168,15 @@ static int SetExtraClingArgsBeforeTAppCtor(Int_t *argc, char **argv)
 /// of TApplication and in addition provides interactive access to
 /// the Cling C++ interpreter via the command line.
 
-TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options, Int_t numOptions, Bool_t noLogo)
+TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options, Int_t numOptions, Bool_t noLogo,
+             Bool_t exitOnUnknownArgs)
    : TApplication(appClassName, argc, argv, options, numOptions + SetExtraClingArgsBeforeTAppCtor(argc, argv)),
      fCaughtSignal(-1)
 {
 
-   if (argc != nullptr && *argc > 1) {
+   if (exitOnUnknownArgs && argc != nullptr && *argc > 1) {
       // Early exit if there are remaining unrecognized options
+      // This branch supposes that TRint is created as a result of using the `root` command
       for (auto n = 1; n < *argc; n++) {
          std::cerr << "root: unrecognized option '" << argv[n] << "'\n";
       }

--- a/core/rint/test/TRintTests.cxx
+++ b/core/rint/test/TRintTests.cxx
@@ -8,7 +8,7 @@
 using testing::internal::CaptureStderr;
 using testing::internal::GetCapturedStderr;
 
-TEST(TRint, UnrecognizedOptions)
+TEST(TRint, ExitOnUnknownArgs)
 {
    // Create array of options.
    // We need to create it as a dynamic array for the following reasons:
@@ -25,7 +25,8 @@ TEST(TRint, UnrecognizedOptions)
 
    CaptureStderr();
    // Unrecognized options will be printed to stderr
-   TRint app{"App", &argc, argv};
+   TRint app{"App", &argc, argv, /*options*/ nullptr, /*numOptions*/ 0, /*noLogo*/ kTRUE, /*exitOnUnknownArgs*/
+             kTRUE};
    std::string trinterr = GetCapturedStderr();
 
    const std::string expected{"root: unrecognized option '-z'\n"
@@ -33,4 +34,38 @@ TEST(TRint, UnrecognizedOptions)
                               "Try 'root --help' for more information.\n"};
 
    EXPECT_EQ(trinterr, expected);
+}
+
+TEST(TRint, KeepUnknownArgs)
+{
+   // Create array of options.
+   // We need to create it as a dynamic array for the following reasons:
+   // - TRint constructor accepts a char** so we construct directly that type
+   // - TRint will modify this array, removing recognized options and leaving
+   //   only unrecognized ones, so we can't create an std::vector and pass its
+   //   data to TRint directly.
+   int argc{4};
+   char e1[]{"-q"};
+   char e2[]{"-z"};
+   char e3[]{"--nonexistingoption"};
+   char e4[]{"-b"};
+   char *argv[]{e1, e2, e3, e4};
+
+   CaptureStderr();
+
+   TRint app{"App", &argc, argv};
+   // By default, unrecognized options are stored and can be retrieved via app.Argv()
+   int appArgc{app.Argc()};
+   auto appArgv{app.Argv()};
+   std::vector<std::string> argVec{appArgv, appArgv + appArgc};
+   std::vector<std::string> expectedVec{"-q", "-z", "--nonexistingoption", "-b"};
+
+   // Nothing should be printed to stderr
+   std::string trinterr = GetCapturedStderr();
+   EXPECT_EQ(trinterr, "");
+
+   ASSERT_EQ(argVec.size(), expectedVec.size());
+   for (std::size_t i = 0; i < argVec.size(); ++i) {
+      EXPECT_EQ(argVec[i], expectedVec[i]);
+   }
 }

--- a/main/src/rmain.cxx
+++ b/main/src/rmain.cxx
@@ -77,7 +77,8 @@ int main(int argc, char **argv)
 {
    handle_notebook_option(argc, argv);
 
-   TRint *theApp = new TRint("Rint", &argc, argv);
+   TRint *theApp = new TRint("Rint", &argc, argv, /*options*/ nullptr, /*numOptions*/ 0, /*noLogo*/ kFALSE,
+                             /*exitOnUnknownArgs*/ kTRUE);
 
    // and enter the event loop...
    theApp->Run();


### PR DESCRIPTION
This addresses second part of https://github.com/root-project/root/issues/10090 .

A boolean flag is added to the `TRint` constructor. `false` by default, if `true` it forces exit on unknown arguments supplied by the user. This behaviour is specifically intended for the usage of `TRint` as the result of calling the `root` command. Other use cases may actually need to pass arguments unknown to `TRint` but known to some derived class.