### PR TITLE
[rbrowser] check classes hierarchy when browsing TFile

### DIFF
--- a/gui/browsable/src/RSysFile.cxx
+++ b/gui/browsable/src/RSysFile.cxx
@@ -369,7 +369,9 @@ std::string RSysFile::GetFileIcon(const std::string &fname)
        (EndsWith(".cxx")) ||
        (EndsWith(".c++")) ||
        (EndsWith(".cxx")) ||
+       (EndsWith(".cc")) ||
        (EndsWith(".h")) ||
+       (EndsWith(".hh")) ||
        (EndsWith(".hpp")) ||
        (EndsWith(".hxx")) ||
        (EndsWith(".h++")) ||


### PR DESCRIPTION
If class name in TKey not directly match with registered classes,
try to call `TClass::GetClass()` to check base classes - but without trying to load library.
Should allow to handle user-derived classes for TTree, histograms, ...
