### PR TITLE
[cmake] Don't use ZMQ C++ headers from the system if ZMQ is too old

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1894,6 +1894,10 @@ if (roofit_multiprocess)
       if(NOT ZeroMQ_FOUND)
         message(STATUS "ZeroMQ not found. Switching on builtin_zeromq option")
         set(builtin_zeromq ON CACHE BOOL "Enabled because ZeroMQ not found (${builtin_zeromq_description})" FORCE)
+        # If the ZeroMQ system version is too old, we can't use the system C++
+        # headers either (note that find_package(ZeroMQ) not only checks if the
+        # library exists, but also if it's a recent version with zmq_ppoll).
+        set(builtin_cppzmq ON CACHE BOOL "Enabled because ZeroMQ not found (${builtin_cppzmq_description})" FORCE)
       endif()
     endif()
 

--- a/roofit/roofitZMQ/res/RooFit_ZMQ/ZeroMQSvc.h
+++ b/roofit/roofitZMQ/res/RooFit_ZMQ/ZeroMQSvc.h
@@ -25,6 +25,7 @@
 #include <ios>
 #include <iostream> // std::cerr
 #include <functional>
+#include <memory>
 
 // debugging
 #include <unistd.h> // getpid


### PR DESCRIPTION
If the ZeroMQ system version is too old, we can't use the system C++
headers either (note that `find_package(ZeroMQ)` not only checks if the
library exists, but also if it's a recent version with zmq_ppoll).

Therefore, we should also enable `builtin_cppzmq` if no usable ZMQ
version is found, not only `builtin_zeromq`.

This closes #10107.

@egpbos, FYI