### PR TITLE
[RF] Avoid using RooTObjWrap, RooDouble, and RooInt in RooCmdConfig

### DIFF
--- a/roofit/roofitcore/inc/RooBinning.h
+++ b/roofit/roofitcore/inc/RooBinning.h
@@ -17,7 +17,6 @@
 #define ROO_BINNING
 
 #include "Rtypes.h"
-#include "RooDouble.h"
 #include "RooAbsBinning.h"
 #include "RooNumber.h"
 #include <vector>

--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -17,13 +17,16 @@
 #ifndef ROO_CMD_CONFIG
 #define ROO_CMD_CONFIG
 
-#include "TObject.h"
-#include "TObjString.h"
-#include "TString.h"
-#include "TList.h"
-#include "RooCmdArg.h"
-#include "RooArgSet.h"
+#include <RooCmdArg.h>
+
+#include <TList.h>
+#include <TObjString.h>
+#include <TObject.h>
+#include <TString.h>
+
 #include <string>
+
+class RooArgSet;
 
 class RooCmdConfig : public TObject {
 public:
@@ -97,12 +100,13 @@ public:
 
 protected:
 
-  struct StringVar {
+  template<class T>
+  struct Var {
     std::string name;
     std::string argName;
-    std::string val;
+    T val;
     bool appendMode;
-    int stringNum;
+    int num;
   };
 
   TString _name ;
@@ -111,11 +115,11 @@ protected:
   Bool_t _error = false;
   Bool_t _allowUndefined = false;
 
-  TList _iList ; ///< Integer list
-  TList _dList ; ///< Double list
-  std::vector<StringVar> _sList ; ///< String list
-  TList _oList ; ///< Object list
-  TList _cList ; ///< RooArgSet list
+  std::vector<Var<int>> _iList ; ///< Integer list
+  std::vector<Var<double>> _dList ; ///< Double list
+  std::vector<Var<std::string>> _sList ; ///< String list
+  std::vector<Var<RooLinkedList>> _oList ; ///< Object list
+  std::vector<Var<RooArgSet*>> _cList ; ///< RooArgSet list
 
   TList _rList ; ///< Required cmd list
   TList _fList ; ///< Forbidden cmd list

--- a/test/stressRooFit.cxx
+++ b/test/stressRooFit.cxx
@@ -3,13 +3,6 @@
 
 #include "RooGlobalFunc.h"
 #include "RooMsgService.h"
-#include "RooPlot.h"
-#include "RooFitResult.h"
-#include "RooDouble.h"
-#include "RooWorkspace.h"
-#include "Roo1DTable.h"
-#include "RooCurve.h"
-#include "RooHist.h"
 #include "RooRandom.h"
 #include "RooTrace.h"
 

--- a/test/stressRooStats.cxx
+++ b/test/stressRooStats.cxx
@@ -25,13 +25,6 @@
 #include "RooNumIntConfig.h"
 #include "RooMsgService.h"
 #include "RooResolutionModel.h"
-#include "RooPlot.h"
-#include "RooFitResult.h"
-#include "RooDouble.h"
-#include "RooWorkspace.h"
-#include "Roo1DTable.h"
-#include "RooCurve.h"
-#include "RooHist.h"
 #include "RooRandom.h"
 #include "RooTrace.h"
 


### PR DESCRIPTION
Part of the RooFit code modernization, avoiding the use of unnecessary
wrapper classes and using a simple templated struct instead.

The change in this PR is thoroughly tested by `stressRooFit`.