### PR TITLE
Add #include <cstring> for std::memcpy

### DIFF
--- a/tmva/sofie/inc/TMVA/SOFIE_common.hxx
+++ b/tmva/sofie/inc/TMVA/SOFIE_common.hxx
@@ -6,6 +6,7 @@
 
 #include <type_traits>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <vector>
 #include <memory>


### PR DESCRIPTION
```
In file included from /builddir/build/BUILD/root-6.26.00/tmva/sofie/inc/TMVA/RModel.hxx:14,
                 from /builddir/build/BUILD/root-6.26.00/tmva/sofie/src/RModel.cxx:3:
/builddir/build/BUILD/root-6.26.00/tmva/sofie/inc/TMVA/SOFIE_common.hxx: In member function 'void TMVA::Experimental::SOFIE::InitializedTensor::CastPersistentToShared()':
/builddir/build/BUILD/root-6.26.00/tmva/sofie/inc/TMVA/SOFIE_common.hxx:75:12: error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?
   75 |       std::memcpy(tData.get(), fPersistentData,fSize * sizeof(float));
      |            ^~~~~~
      |            wmemcpy
gmake[2]: *** [tmva/sofie/CMakeFiles/ROOTTMVASofie.dir/build.make:79: tmva/sofie/CMakeFiles/ROOTTMVASofie.dir/src/RModel.cxx.o] Error 1
```

# This Pull request:

## Changes or fixes:

Add #include \<cstring\> for std::memcpy

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

