### PR TITLE
[tcling,v6-24] Suppress `-Wunused-result` diagnostics in wrappers generated by TClingCallFunc

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -982,7 +982,7 @@ void TClingCallFunc::make_narg_call_with_return(const unsigned N, const string &
    //    new (ret) (return_type) ((class_name*)obj)->func(args...);
    // }
    // else {
-   //    ((class_name*)obj)->func(args...);
+   //    (void)(((class_name*)obj)->func(args...));
    // }
    //
    const FunctionDecl *FD = GetDecl();
@@ -1085,8 +1085,9 @@ void TClingCallFunc::make_narg_call_with_return(const unsigned N, const string &
          for (int i = 0; i < indent_level; ++i) {
             callbuf << kIndentString;
          }
+         callbuf << "(void)(";
          make_narg_call(type_name, N, typedefbuf, callbuf, class_name, indent_level);
-         callbuf << ";\n";
+         callbuf << ");\n";
          for (int i = 0; i < indent_level; ++i) {
             callbuf << kIndentString;
          }

--- a/core/metacling/test/TClingCallFuncTests.cxx
+++ b/core/metacling/test/TClingCallFuncTests.cxx
@@ -1,4 +1,4 @@
-#include "TError.h"
+#include "ROOTUnitTestSupport.h"
 #include "TInterpreter.h"
 
 #include "gtest/gtest.h"
@@ -14,19 +14,6 @@
 // of C++ code, so if these tests fail because this interface was replaced by another
 // system, feel free to delete them as these tests here don't represent things the user
 // should do in his code.
-
-class FilterDiagsRAII {
-   ErrorHandlerFunc_t fPrevHandler;
-public:
-   FilterDiagsRAII(ErrorHandlerFunc_t fn) : fPrevHandler(::GetErrorHandler()) {
-      ::SetErrorHandler(fn);
-      gInterpreter->ReportDiagnosticsToErrorHandler();
-   }
-   ~FilterDiagsRAII() {
-      gInterpreter->ReportDiagnosticsToErrorHandler(/*enable=*/false);
-      ::SetErrorHandler(fPrevHandler);
-   }
-};
 
 TEST(TClingCallFunc, FunctionWrapper)
 {


### PR DESCRIPTION
This pull-request is a backport of https://github.com/root-project/root/pull/9244 to v6.24.  The original PR suppresses `-Wunused-result` diagnostics for wrapper functions generated by TClingCallFunc.  For more information see #9244.

This PR fixes #8622.