### PR TITLE
[cling,tcling,v6-24] Allow reporting cling diagnostics via the ROOT error handler

### DIFF
--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -267,6 +267,8 @@ public:
            int    SetClassAutoloading(int a) const { return SetClassAutoLoading(a); }  // Deprecated
    virtual int    SetClassAutoparsing(int) {return 0;};
    virtual void   SetErrmsgcallback(void * /* p */) const {;}
+   /// \brief Report diagnostics to the ROOT error handler (see TError.h).
+   virtual void   ReportDiagnosticsToErrorHandler(bool /*enable*/ = true) {}
    virtual void   SetTempLevel(int /* val */) const {;}
    virtual int    UnloadFile(const char * /* path */) const {return 0;}
 

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -10,9 +10,11 @@
 
 if(MSVC)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -GR-)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingDiagnostics.cxx COMPILE_FLAGS -GR-)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingRdictModuleFileExtension.cxx COMPILE_FLAGS -GR-)
 else()
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -fno-rtti)
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingDiagnostics.cxx COMPILE_FLAGS -fno-rtti)
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingRdictModuleFileExtension.cxx COMPILE_FLAGS -fno-rtti)
 endif()
 
@@ -25,6 +27,7 @@ ROOT_OBJECT_LIBRARY(MetaCling
   TClingClassInfo.cxx
   TClingDataMemberInfo.cxx
   TClingDeclInfo.cxx
+  TClingDiagnostics.cxx
   TClingMemberIter.cxx
   TClingMethodArgInfo.cxx
   TClingMethodInfo.cxx

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -40,6 +40,7 @@ clang/LLVM technology.
 #include "TClassEdit.h"
 #include "TClassTable.h"
 #include "TClingCallbacks.h"
+#include "TClingDiagnostics.h"
 #include "TBaseClass.h"
 #include "TDataMember.h"
 #include "TMemberInspector.h"
@@ -7577,6 +7578,28 @@ void TCling::SetErrmsgcallback(void* p) const
 #endif
 #endif
 }
+
+void TCling::ReportDiagnosticsToErrorHandler(bool enable)
+{
+   if (enable) {
+      auto consumer = new TClingDelegateDiagnosticPrinter(
+         &fInterpreter->getDiagnostics().getDiagnosticOptions(),
+         fInterpreter->getCI()->getLangOpts(),
+         [] (clang::DiagnosticsEngine::Level Level, const std::string &Info) {
+            if (Level == clang::DiagnosticsEngine::Warning) {
+               ::Warning("cling", "%s", Info.c_str());
+            } else if (Level == clang::DiagnosticsEngine::Error
+                       || Level == clang::DiagnosticsEngine::Fatal) {
+               ::Error("cling", "%s", Info.c_str());
+            } else {
+               ::Info("cling", "%s", Info.c_str());
+            }
+         });
+      fInterpreter->replaceDiagnosticConsumer(consumer, /*Own=*/true);
+   } else {
+      fInterpreter->replaceDiagnosticConsumer(nullptr);
+   }
+}  
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/metacling/src/TCling.h
+++ b/core/metacling/src/TCling.h
@@ -354,6 +354,7 @@ public: // Public Interface
    virtual int    SetClassAutoparsing(int) ;
            Bool_t IsAutoParsingSuspended() const { return fIsAutoParsingSuspended; }
    virtual void   SetErrmsgcallback(void* p) const;
+   virtual void   ReportDiagnosticsToErrorHandler(bool enable = true);
    virtual void   SetTempLevel(int val) const;
    virtual int    UnloadFile(const char* path) const;
 

--- a/core/metacling/src/TClingDiagnostics.cxx
+++ b/core/metacling/src/TClingDiagnostics.cxx
@@ -1,0 +1,29 @@
+// @(#)root/core/metacling:$Id$
+// Author: Javier Lopez-Gomez   16/07/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "TClingDiagnostics.h"
+
+TClingDelegateDiagnosticPrinter::TClingDelegateDiagnosticPrinter
+(clang::DiagnosticOptions *DiagOpts, clang::LangOptions &LangOpts, handler_t fn)
+  : TextDiagnosticPrinter(fOS, DiagOpts), fOS(fOS_out), fHandler(fn)
+{
+   // Required to initialize the internal `clang::TextDiagnostic` instance.
+   TextDiagnosticPrinter::BeginSourceFile(LangOpts, nullptr);
+}
+
+void
+TClingDelegateDiagnosticPrinter::HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                                                  const clang::Diagnostic &Info)
+{
+   fOS_out.clear();
+   TextDiagnosticPrinter::HandleDiagnostic(Level, Info);
+   fHandler(Level, fOS.str());
+}

--- a/core/metacling/src/TClingDiagnostics.h
+++ b/core/metacling/src/TClingDiagnostics.h
@@ -1,0 +1,45 @@
+// @(#)root/core/metacling:$Id$
+// Author: Javier Lopez-Gomez   16/07/2021
+
+/*************************************************************************
+ * Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_TClingDiagnostics
+#define ROOT_TClingDiagnostics
+
+#include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+namespace clang {
+   class LangOptions;
+}
+
+/// \brief Uses `clang::TextDiagnosticPrinter` to format diagnostics, which
+///  are then passed to a user-specified function.
+///
+class TClingDelegateDiagnosticPrinter : public clang::TextDiagnosticPrinter {
+public:
+   typedef void (*handler_t)(clang::DiagnosticsEngine::Level Level,
+                             const std::string &Info);
+private:
+   std::string fOS_out;
+   llvm::raw_string_ostream fOS;
+   handler_t fHandler;
+
+public:
+   TClingDelegateDiagnosticPrinter(clang::DiagnosticOptions *DiagOpts,
+                                   clang::LangOptions &LangOpts, handler_t fn);
+   ~TClingDelegateDiagnosticPrinter() override = default;
+
+   void HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                         const clang::Diagnostic &Info) override;
+};
+
+#endif // ROOT_TClingDiagnostics

--- a/interpreter/cling/include/cling/Interpreter/Interpreter.h
+++ b/interpreter/cling/include/cling/Interpreter/Interpreter.h
@@ -37,6 +37,7 @@ namespace clang {
   class CompilerInstance;
   class Decl;
   class DeclContext;
+  class DiagnosticConsumer;
   class DiagnosticsEngine;
   class FunctionDecl;
   class GlobalDecl;
@@ -342,6 +343,8 @@ namespace cling {
                       nullptr) {}
 
     ///\brief Constructor for child Interpreter.
+    /// If the parent Interpreter has a replacement DiagnosticConsumer, it is
+    /// inherited by the child (not owned).
     ///\param[in] parentInterpreter - the  parent interpreter of this interpreter
     ///\param[in] argc - no. of args.
     ///\param[in] argv - arguments passed when driver is invoked.
@@ -692,6 +695,13 @@ namespace cling {
     clang::CompilerInstance* getCIOrNull() const;
     clang::Sema& getSema() const;
     clang::DiagnosticsEngine& getDiagnostics() const;
+
+    /// \brief Replaces the default DiagnosticConsumer.
+    /// \param[in] Consumer - The replacement `clang::DiagnosticConsumer`
+    /// \param[in] Own - Whether the pointee is owned by this instance.
+    ///
+    void replaceDiagnosticConsumer(clang::DiagnosticConsumer* Consumer, bool Own = false);
+    bool hasReplacedDiagnosticConsumer() const;
 
     IncrementalCUDADeviceCompiler* getCUDACompiler() const {
       return m_CUDACompiler.get();

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -107,8 +107,23 @@ namespace {
     return false;
   }
 
+  /// \brief Overrides the current DiagnosticConsumer to supress many warnings
+  /// issued as a result of incremental compilation (see `HandleDiagnostic()`).
+  ///
+  /// Diagnostics passing the filter are, by default, forwarded to the previous
+  /// DiagnosticConsumer instance.  A different consumer may be specified via
+  /// `setTargetConsumer()`.
+  /// In that case, given that internal state might be updated as part of
+  /// `{Begin,End}SourceFile` (e.g. in TextDiagnosticPrinter), calls to such
+  /// functions will be forwarded to both, the user-specified and the original
+  /// consumer; however `HandleDiagnostic()` calls shall only be seen by the
+  /// former.
+  ///
+  /// On destruction, the original (i.e. overridden consumer) is restored.
+  ///
   class FilteringDiagConsumer : public cling::utils::DiagnosticsOverride {
     std::stack<bool> m_IgnorePromptDiags;
+    llvm::PointerIntPair<DiagnosticConsumer*, 1, bool /*Own*/> m_Target{};
 
     void SyncDiagCountWithTarget() {
       NumWarnings = m_PrevClient.getNumWarnings();
@@ -118,20 +133,28 @@ namespace {
     void BeginSourceFile(const LangOptions &LangOpts,
                          const Preprocessor *PP=nullptr) override {
       m_PrevClient.BeginSourceFile(LangOpts, PP);
+      if (auto C = m_Target.getPointer())
+        C->BeginSourceFile(LangOpts, PP);
     }
 
     void EndSourceFile() override {
       m_PrevClient.EndSourceFile();
+      if (auto C = m_Target.getPointer())
+        C->EndSourceFile();
       SyncDiagCountWithTarget();
     }
 
     void finish() override {
       m_PrevClient.finish();
+      if (auto C = m_Target.getPointer())
+        C->finish();
       SyncDiagCountWithTarget();
     }
 
     void clear() override {
       m_PrevClient.clear();
+      if (auto C = m_Target.getPointer())
+        C->clear();
       SyncDiagCountWithTarget();
     }
 
@@ -159,7 +182,19 @@ namespace {
           return; // ignore!
         }
       }
-      m_PrevClient.HandleDiagnostic(DiagLevel, Info);
+
+      // In principle, for simplicity, we preserve the old behavior of
+      // delivering diagnostics to just one consumer (that is why we don't emit
+      // to both), but we allow the "sink" to be changed.
+      // Note, however, that consumers might update their internal state in
+      // calls to, e.g. `BeginSourceFile()` or `EndSourceFile()` (actually,
+      // `TextDiagnosticPrinter` is an example of this), so in order to be able
+      // to restore the original consumer, we need to keep forwarding these
+      // calls also to `m_PrevClient` (see above).
+      if (auto C = m_Target.getPointer())
+        C->HandleDiagnostic(DiagLevel, Info);
+      else
+        m_PrevClient.HandleDiagnostic(DiagLevel, Info);
       SyncDiagCountWithTarget();
     }
 
@@ -168,9 +203,26 @@ namespace {
     }
 
   public:
-    FilteringDiagConsumer(DiagnosticsEngine& Diags, bool Own) :
-      DiagnosticsOverride(Diags, Own) {
+    FilteringDiagConsumer(DiagnosticsEngine& Diags, bool Own)
+      : DiagnosticsOverride(Diags, Own) {}
+    virtual ~FilteringDiagConsumer() { setTargetConsumer(nullptr); }
+
+    /// \brief Sets the DiagnosticConsumer that sees `HandleDiagnostic()` calls.
+    /// \param[in] Consumer - The target DiagnosticConsumer, or `nullptr` to
+    ///    revert to original client.
+    /// \param[in] Own - Whether we own the pointee
+    ///
+    void setTargetConsumer(DiagnosticConsumer* Consumer, bool Own = false) {
+      if (m_Target.getInt())
+        if (auto C = m_Target.getPointer())
+          delete C;
+
+      m_Target.setPointer(Consumer);
+      m_Target.setInt(Own);
     }
+
+    DiagnosticConsumer* getTargetConsumer() const
+    { return m_Target.getPointer(); }
 
     struct RAAI {
       FilteringDiagConsumer& m_Client;
@@ -389,6 +441,17 @@ namespace cling {
 
   const Transaction* IncrementalParser::getCurrentTransaction() const {
     return m_Consumer->getTransaction();
+  }
+
+  void IncrementalParser::setDiagnosticConsumer(DiagnosticConsumer* Consumer,
+						bool Own) {
+    static_cast<
+      FilteringDiagConsumer&>(*m_DiagConsumer).setTargetConsumer(Consumer, Own);
+  }
+
+  DiagnosticConsumer* IncrementalParser::getDiagnosticConsumer() const {
+    return static_cast<
+      FilteringDiagConsumer&>(*m_DiagConsumer).getTargetConsumer();
   }
 
   SourceLocation IncrementalParser::getNextAvailableUniqueSourceLoc() {

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -127,6 +127,9 @@ namespace cling {
     clang::CodeGenerator* getCodeGenerator() const { return m_CodeGen; }
     bool hasCodeGenerator() const { return m_CodeGen; }
 
+    void setDiagnosticConsumer(clang::DiagnosticConsumer* Consumer, bool Own);
+    clang::DiagnosticConsumer* getDiagnosticConsumer() const;
+
     /// Returns the next available unique source location. It is an offset into
     /// the limitless virtual file. Each time this interface is used it bumps
     /// an internal counter. This is very useful for using the various API in

--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -369,6 +369,9 @@ namespace cling {
       // Give my IncrementalExecutor a pointer to the Incremental executor of the
       // parent Interpreter.
       m_Executor->setExternalIncrementalExecutor(parentInterpreter.m_Executor.get());
+
+      if (auto C = parentInterpreter.m_IncrParser->getDiagnosticConsumer())
+        m_IncrParser->setDiagnosticConsumer(C, /*Own=*/false);
     }
   }
 
@@ -739,6 +742,15 @@ namespace cling {
 
   DiagnosticsEngine& Interpreter::getDiagnostics() const {
     return getCI()->getDiagnostics();
+  }
+
+  void Interpreter::replaceDiagnosticConsumer(clang::DiagnosticConsumer* Consumer,
+					      bool Own) {
+    m_IncrParser->setDiagnosticConsumer(Consumer, Own);
+  }
+
+  bool Interpreter::hasReplacedDiagnosticConsumer() const {
+    return m_IncrParser->getDiagnosticConsumer() != nullptr;
   }
 
   CompilationOptions Interpreter::makeDefaultCompilationOpts() const {


### PR DESCRIPTION
This PR enables cling diagnostics to be reported via the ROOT error handler, as required by the experiments. Independently, this error handler may be changed by the user (see TError.h).

This is a backport of PR https://github.com/root-project/root/pull/8737/ and is required for the unit tests of another backport: https://github.com/root-project/root/pull/10120.

This PR closes JIRA issue [ROOT-7587](https://sft.its.cern.ch/jira/browse/ROOT-7587).