### PR TITLE
specify that multiple ROOT files can be opened

### DIFF
--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -22,5 +22,5 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
 	parser.add_argument('[data1.root...dataN.root]', help='Open the given ROOT files; remote protocols (such as http://) are supported')
-	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nArguments can be passed to the macro with round parentheses after each filename.\nBetween filename and args, add "+" to precompile if needed\n"++" to force recompile, and "g" to include debug symbols')
+	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nPrecompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
 	return parser

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -22,5 +22,5 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
 	parser.add_argument('[data1.root...dataN.root]', help='Open the ROOT files data1.root ... dataN.root')
-	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C')
+	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nArguments can be passed to the macro with round parentheses after each filename.\nBetween filename and args, add "+" to precompile if needed\n"++" to force recompile, and "g" to include debug symbols')
 	return parser

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -21,6 +21,6 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web', help='Display graphics in a default web browser')
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
-	parser.add_argument('[file:data.root]', help='Open the ROOT file data.root')
+	parser.add_argument('[data1.root...dataN.root]', help='Open the ROOT files data1.root ... dataN.root')
 	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C')
 	return parser

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -21,6 +21,6 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web', help='Display graphics in a default web browser')
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
-	parser.add_argument('[data1.root...dataN.root]', help='Open the ROOT files data1.root ... dataN.root')
+	parser.add_argument('[data1.root...dataN.root]', help='Open the given ROOT files; remote protocols (such as http://) are supported')
 	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nArguments can be passed to the macro with round parentheses after each filename.\nBetween filename and args, add "+" to precompile if needed\n"++" to force recompile, and "g" to include debug symbols')
 	return parser

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -22,5 +22,5 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
 	parser.add_argument('[data1.root...dataN.root]', help='Open the given ROOT files; remote protocols (such as http://) are supported')
-	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nPrecompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
+	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nCompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
 	return parser


### PR DESCRIPTION

# This Pull request:

## Changes or fixes:
specify that multiple ROOT files can be opened from CLI args

and point to manual for compilation flags

## Checklist:

- [ ] tested changes locally
- [x] updated the docs (if necessary)

