### PR TITLE
[cling] add missing newline and separating space

### DIFF
--- a/interpreter/cling/lib/MetaProcessor/Display.cpp
+++ b/interpreter/cling/lib/MetaProcessor/Display.cpp
@@ -1505,6 +1505,7 @@ void TypedefPrinter::DisplayTypedefDecl(TypedefNameDecl* typedefDecl)const
     llvm::raw_string_ostream out(textLine);
     typedefDecl->getUnderlyingType().
        getDesugaredType(typedefDecl->getASTContext()).print(out,printingPolicy);
+    out << ' ';
     //Name for diagnostic will include template arguments if any.
     typedefDecl->getNameForDiagnostic(out,
                                       printingPolicy,/*qualified=*/true);

--- a/interpreter/cling/lib/MetaProcessor/Display.cpp
+++ b/interpreter/cling/lib/MetaProcessor/Display.cpp
@@ -523,7 +523,7 @@ void ClassPrinter::DisplayAllClasses()const
   const TranslationUnitDecl* const tuDecl = compiler->getASTContext().getTranslationUnitDecl();
   assert(tuDecl != 0 && "DisplayAllClasses, translation unit is empty");
 
-  fOut.Print("List of classes");
+  fOut.Print("List of classes\n");
   // Could trigger deserialization of decls.
   Interpreter::PushTransactionRAII RAII(const_cast<Interpreter*>(fInterpreter));
   for (decl_iterator decl = tuDecl->decls_begin(); decl != tuDecl->decls_end(); ++decl)

--- a/interpreter/cling/lib/MetaProcessor/Display.cpp
+++ b/interpreter/cling/lib/MetaProcessor/Display.cpp
@@ -1416,7 +1416,7 @@ void TypedefPrinter::DisplayTypedefs()const
   const TranslationUnitDecl* const tuDecl = compiler->getASTContext().getTranslationUnitDecl();
   assert(tuDecl != 0 && "DisplayTypedefs, translation unit is empty");
 
-  fOut.Print("List of typedefs");
+  fOut.Print("List of typedefs\n");
   ProcessNestedDeclarations(tuDecl);
 }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
If you type ".typedef" in the ROOT prompt, it prints with weird format

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)