### PR TITLE
[6.26] Add RMergeableValue<THnD> to LinkDef.h

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -53,6 +53,7 @@
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TH1D>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TH2D>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TH3D>+;
+#pragma link C++ class ROOT::Detail::RDF::RMergeableValue<THnD>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TGraph>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TStatistic>+;
 #pragma link C++ class ROOT::Detail::RDF::RMergeableValue<TProfile>+;


### PR DESCRIPTION
The introduction of a mergeable value for the `HistoND` operation did
not add the corresponding instance to the LinkDef.h file. This leads to
warnings issued when using such mergeable value (notably in distributed
mode) that there is no dictionary for that class.
