### PR TITLE
[core] Update "logo" to 2022 (NFC).

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -518,7 +518,7 @@ void TRint::PrintLogo(Bool_t lite)
       // Here, %%s results in %s after TString::Format():
       lines.emplace_back(TString::Format("Welcome to ROOT %s%%shttps://root.cern",
                                          gROOT->GetVersion()));
-      lines.emplace_back(TString::Format("(c) 1995-2021, The ROOT Team; conception: R. Brun, F. Rademakers%%s"));
+      lines.emplace_back(TString::Format("(c) 1995-2022, The ROOT Team; conception: R. Brun, F. Rademakers%%s"));
       lines.emplace_back(TString::Format("Built for %s on %s%%s", gSystem->GetBuildArch(), gROOT->GetGitDate()));
       if (!strcmp(gROOT->GetGitBranch(), gROOT->GetGitCommit())) {
          static const char *months[] = {"January","February","March","April","May",


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
It updates the "logo" to reference `2022` instead of `2021`, which is currently still shown in the latest release:
```
   ------------------------------------------------------------------
  | Welcome to ROOT 6.26/00                        https://root.cern |
  | (c) 1995-2021, The ROOT Team; conception: R. Brun, F. Rademakers |
  | Built for linuxx8664gcc on Mar 03 2022, 06:51:13                 |
  | From tags/v6-26-00@v6-26-00                                      |
  | With                                                             |
  | Try '.help', '.demo', '.license', '.credits', '.quit'/'.q'       |
   ------------------------------------------------------------------
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

I realized just now my shiny new ROOT 6.26.00 build does not yet mention 2022 — so this PR essentially repeats the yearly chore:
https://github.com/root-project/root/commit/aeb621a5bc4bf86796598e63d3ceb6e12c94d87c
:wink: 

Hope this helps,
Oliver