### PR TITLE
Deal with multi schema layout for a pair (caused enum underlying type)

### DIFF
--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -197,7 +197,7 @@ namespace TClassEdit {
    {
       return 0 == name.compare(0, 17, "std::__pair_base<") || 0 == name.compare(0, 12, "__pair_base<");
    }
-   inline bool IsStdPairBase(ROOT::Internal::TStringView name) {return IsStdPair(std::string_view(name)); }
+   inline bool IsStdPairBase(ROOT::Internal::TStringView name) {return IsStdPairBase(std::string_view(name)); }
    inline std::string GetUniquePtrType(std::string_view name)
    {
       // Find the first template parameter

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -295,7 +295,6 @@ private:
              Int_t dl, Int_t il,
              ClassInfo_t *classInfo,
              Bool_t silent);
-   void ForceReload (TClass* oldcl);
    void LoadClassInfo() const;
 
    static TClass     *LoadClassDefault(const char *requestedname, Bool_t silent);
@@ -401,6 +400,7 @@ public:
    TVirtualStreamerInfo     *FindConversionStreamerInfo( const char* onfile_classname, UInt_t checksum ) const;
    TVirtualStreamerInfo     *GetConversionStreamerInfo( const TClass* onfile_cl, Int_t version ) const;
    TVirtualStreamerInfo     *FindConversionStreamerInfo( const TClass* onfile_cl, UInt_t checksum ) const;
+   void               ForceReload (TClass* oldcl);
    Bool_t             HasDataMemberInfo() const { return fIsSyntheticPair || fHasRootPcmInfo || HasInterpreterInfo(); }
    Bool_t             HasDefaultConstructor(Bool_t testio = kFALSE) const;
    Bool_t             HasInterpreterInfoInMemory() const { return 0 != fClassInfo; }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1531,7 +1531,9 @@ void TClass::Init(const char *name, Version_t cversion,
       } else {
          // In this case we initialised this TClass instance starting from the fwd declared state
          // and we know we have no dictionary: no need to warn
-         ::Warning("TClass::Init", "no dictionary for class %s is available", fName.Data());
+         const bool ispairbase = TClassEdit::IsStdPairBase(fName.Data()) && !IsFromRootCling();
+         if (!ispairbase)
+            ::Warning("TClass::Init", "no dictionary for class %s is available", fName.Data());
       }
    }
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1344,9 +1344,15 @@ void TClass::ForceReload (TClass* oldcl)
    while ((info = (TVirtualStreamerInfo*)next())) {
       info->Clear("build");
       info->SetClass(this);
-      if (IsSyntheticPair())
-         info->BuildOld();
-      fStreamerInfo->AddAtAndExpand(info,info->GetClassVersion());
+      if (IsSyntheticPair()) {
+         // Some pair's StreamerInfo were inappropriately marked as versioned
+         info->SetClassVersion(1);
+         // There is already a TStreamerInfo put there by the synthetic
+         // creation.
+         fStreamerInfo->Add(info);
+      } else {
+         fStreamerInfo->AddAtAndExpand(info,info->GetClassVersion());
+      }
    }
    oldcl->fStreamerInfo->Clear();
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5923,7 +5923,9 @@ Bool_t  TClass::IsTObject() const
 Bool_t  TClass::IsForeign() const
 {
    if (fProperty==(-1)) Property();
-   return TestBit(kIsForeign);
+   // If the property are not set and the class is a pair, hard code that
+   // it is a unversioned/Foreign class.
+   return TestBit(kIsForeign) || (fProperty == -1 && TClassEdit::IsStdPair(GetName()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1389,6 +1389,9 @@ void TClass::Init(const char *name, Version_t cversion,
    fStreamerInfo   = new TObjArray(fClassVersion+2+10,-1); // +10 to read new data by old
    fProperty       = -1;
    fClassProperty  = 0;
+   const bool ispair = TClassEdit::IsStdPair(fName);
+   if (ispair)
+      SetBit(kIsForeign);
 
    ResetInstanceCount();
 
@@ -5926,7 +5929,7 @@ Bool_t  TClass::IsForeign() const
    if (fProperty==(-1)) Property();
    // If the property are not set and the class is a pair, hard code that
    // it is a unversioned/Foreign class.
-   return TestBit(kIsForeign) || (fProperty == -1 && TClassEdit::IsStdPair(GetName()));
+   return TestBit(kIsForeign);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3122,7 +3122,8 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
    if (ispair) {
       if (hint_pair_offset && hint_pair_size) {
          auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName, silent, hint_pair_offset, hint_pair_size);
-         //return pairinfo ? pairinfo->GetClass() : nullptr;
+         // Fall-through to allow TClass to be created when known by the interpreter
+         // This is used in the case where TStreamerInfo can not handle them.
          if (pairinfo)
             return pairinfo->GetClass();
       } else {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1531,8 +1531,6 @@ void TClass::Init(const char *name, Version_t cversion,
                     fName.Data());
          }
       } else {
-         // In this case we initialised this TClass instance starting from the fwd declared state
-         // and we know we have no dictionary: no need to warn
          const bool ispairbase = TClassEdit::IsStdPairBase(fName.Data()) && !IsFromRootCling();
          if (!ispairbase)
             ::Warning("TClass::Init", "no dictionary for class %s is available", fName.Data());

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1344,6 +1344,8 @@ void TClass::ForceReload (TClass* oldcl)
    while ((info = (TVirtualStreamerInfo*)next())) {
       info->Clear("build");
       info->SetClass(this);
+      if (IsSyntheticPair())
+         info->BuildOld();
       fStreamerInfo->AddAtAndExpand(info,info->GetClassVersion());
    }
    oldcl->fStreamerInfo->Clear();

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3119,11 +3119,32 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
    // TClass if we have one.
    if (cl) return cl;
 
-   if (ispair &&  hint_pair_offset && hint_pair_size) {
-      auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName, silent, hint_pair_offset, hint_pair_size);
-      //return pairinfo ? pairinfo->GetClass() : nullptr;
-      if (pairinfo)
-         return pairinfo->GetClass();
+   if (ispair) {
+      if (hint_pair_offset && hint_pair_size) {
+         auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName, silent, hint_pair_offset, hint_pair_size);
+         //return pairinfo ? pairinfo->GetClass() : nullptr;
+         if (pairinfo)
+            return pairinfo->GetClass();
+      } else {
+         //  Check if we have an STL container that might provide it.
+         static const size_t slen = strlen("pair");
+         static const char *associativeContainer[] = { "map", "unordered_map", "multimap",
+            "unordered_multimap", "set", "unordered_set", "multiset", "unordered_multiset" };
+         for(auto contname : associativeContainer) {
+            std::string collname = contname;
+            collname.append( normalizedName.c_str() + slen );
+            TClass *collcl = TClass::GetClass(collname.c_str(), false, silent);
+            if (!collcl)
+               collcl = LoadClassDefault(collname.c_str(), silent);
+            if (collcl) {
+               auto p = collcl->GetCollectionProxy();
+               if (p)
+                  cl = p->GetValueClass();
+               if (cl)
+                  return cl;
+            }
+         }
+      }
    } else if (TClassEdit::IsSTLCont( normalizedName.c_str() )) {
 
       return gInterpreter->GenerateTClass(normalizedName.c_str(), kTRUE, silent);

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -900,8 +900,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                               Fatal("InitializeEx",
                                     "The TClass creation for %s did not get the right size: %d instead of%d\n",
                                     nam.c_str(), (int)paircl->GetClassSize(), (int)fValDiff);
-                           paircl->ReplaceWith(newpaircl);
-                           delete paircl;
+                           newpaircl->ForceReload(paircl);
                         }
                      }
                   }

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2134,7 +2134,7 @@ void TStreamerInfo::BuildOld()
                auto pattern = (TStreamerInfo*)fClass->GetStreamerInfos()->At(fClass->GetClassVersion());
                streamer = 0;
                element->Init(this);
-               if (pattern) {
+               if (pattern && pattern != this && pattern->IsBuilt()) {
                   int pair_element_offset = kMissing;
                   pattern->GetStreamerElement(element->GetName(), pair_element_offset);
                   if (offset != kMissing)

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -783,13 +783,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
             return;
          }
       }
-      if (fClass->fIsSyntheticPair) {
-         // The format never change, no need to import the old StreamerInfo
-         // (which anyway would have issue when being setup due to the lack
-         // of TDataMember in the TClass.
-         SetBit(kCanDelete);
-         return;
-      }
+      bool isStdPair = TClassEdit::IsStdPair(GetName());
 
       if (0 == strcmp("string",fClass->GetName())) {
          // We know we do not need any offset check for a string

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -887,7 +887,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
       else {
          // We are in the case of an 'emulated' class.
 
-         if (fOnFileClassVersion >= 2) {
+         if (fOnFileClassVersion >= 2 && !isStdPair) {
             // The class version was specified when the object was
             // written
 
@@ -952,7 +952,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
             // The TStreamerInfo's checksum is different from the checksum for the compile class.
 
             match = kFALSE;
-            oldIsNonVersioned = info->fOnFileClassVersion==1 && info->fClassVersion != 1;
+            oldIsNonVersioned = (info->fOnFileClassVersion==1 && info->fClassVersion != 1) || isStdPair;
 
             if (fClass->IsLoaded() && (fClassVersion == fClass->GetClassVersion()) && fClass->HasDataMemberInfo()) {
                // In the case where the read-in TStreamerInfo does not
@@ -1003,7 +1003,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
                // The on-file TStreamerInfo's checksum differs from the checksum of a TStreamerInfo on another file.
 
                match = kFALSE;
-               oldIsNonVersioned = info->fOnFileClassVersion==1 && info->fClassVersion != 1;
+               oldIsNonVersioned = (info->fOnFileClassVersion==1 && info->fClassVersion != 1) || isStdPair;
 
                // In the case where the read-in TStreamerInfo does not
                // match in the 'current' in memory TStreamerInfo for


### PR DESCRIPTION
This fixes #10131.

The core issue is that TDataMember::Init and TStreamerInfo::GenerateInfoForPair were not consistent. TDataMember::Init was ignoring the underlying type of an enum while the newer TStreamerInfo::GenerateInfoForPair was taking it in consideration. In the reported case, it meant that some of the pair's TStreamerInfo recorded the type as being 'signed intwhile other was recording the type asunsigned int`.

In addition the whole infrastructure assumed (but only in "some/most" places) that the TStreamerInfo for a std::pair could never change and the infrastructure was also inconsistent on knowing whether the schema layout for std::pair is version of non-versioned.

NOTE: The last commit is might cause the user classes to require a version incrementing when using enums ... (i.e. this commit might be removed) ... it was indeed removing ... in addition changing the stored type of the enum changes the schema layout but does not (sometimes?) change (yet?) the checksum so it leads to incorrect reading of data .... 

