### PR TITLE
[DF] Better names for fill helpers

### DIFF
--- a/tree/dataframe/inc/LinkDef.h
+++ b/tree/dataframe/inc/LinkDef.h
@@ -36,7 +36,7 @@
 #pragma link C++ class ROOT::RDF::TProfile1DModel-;
 #pragma link C++ class ROOT::RDF::TProfile2DModel-;
 #pragma link C++ class ROOT::Internal::RDF::RIgnoreErrorLevelRAII-;
-#pragma link C++ class ROOT::Internal::RDF::FillHelper-;
+#pragma link C++ class ROOT::Internal::RDF::BufferedFillHelper-;
 #pragma link C++ class ROOT::RDF::RTrivialDS-;
 #pragma link C++ class ROOT::Internal::RDF::RRootDS-;
 #pragma link C++ class ROOT::RDF::RCsvDS-;

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -133,12 +133,12 @@ std::unique_ptr<RActionBase>
 BuildAction(const ColumnNames_t &bl, const std::shared_ptr<ActionResultType> &h, const unsigned int nSlots,
             std::shared_ptr<PrevNodeType> prevNode, ActionTag, const RColumnRegister &colRegister)
 {
-   using Helper_t = FillParHelper<ActionResultType>;
+   using Helper_t = FillHelper<ActionResultType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
    return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
 }
 
-// Histo1D filling (must handle the special case of distinguishing FillParHelper and FillHelper
+// Histo1D filling (must handle the special case of distinguishing FillHelper and BufferedFillHelper
 template <typename... ColTypes, typename PrevNodeType>
 std::unique_ptr<RActionBase>
 BuildAction(const ColumnNames_t &bl, const std::shared_ptr<::TH1D> &h, const unsigned int nSlots,
@@ -147,11 +147,11 @@ BuildAction(const ColumnNames_t &bl, const std::shared_ptr<::TH1D> &h, const uns
    auto hasAxisLimits = HistoUtils<::TH1D>::HasAxisLimits(*h);
 
    if (hasAxisLimits) {
-      using Helper_t = FillParHelper<::TH1D>;
+      using Helper_t = FillHelper<::TH1D>;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
       return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
    } else {
-      using Helper_t = FillHelper;
+      using Helper_t = BufferedFillHelper;
       using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
       return std::make_unique<Action_t>(Helper_t(h, nSlots), bl, std::move(prevNode), colRegister);
    }

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -224,7 +224,7 @@ constexpr std::size_t CacheLineStep() {
 void CheckReaderTypeMatches(const std::type_info &colType, const std::type_info &requestedType,
                             const std::string &colName, const std::string &where);
 
-// TODO in C++17 this could be a lambda within FillParHelper::Exec
+// TODO in C++17 this could be a lambda within FillHelper::Exec
 template <typename T>
 constexpr std::size_t FindIdxTrue(const T &arr)
 {

--- a/tree/dataframe/src/RDFActionHelpers.cxx
+++ b/tree/dataframe/src/RDFActionHelpers.cxx
@@ -37,7 +37,7 @@ ULong64_t &CountHelper::PartialUpdate(unsigned int slot)
    return fCounts[slot];
 }
 
-void FillHelper::UpdateMinMax(unsigned int slot, double v)
+void BufferedFillHelper::UpdateMinMax(unsigned int slot, double v)
 {
    auto &thisMin = fMin[slot];
    auto &thisMax = fMax[slot];
@@ -45,7 +45,7 @@ void FillHelper::UpdateMinMax(unsigned int slot, double v)
    thisMax = std::max(thisMax, v);
 }
 
-FillHelper::FillHelper(const std::shared_ptr<Hist_t> &h, const unsigned int nSlots)
+BufferedFillHelper::BufferedFillHelper(const std::shared_ptr<Hist_t> &h, const unsigned int nSlots)
    : fResultHist(h), fNSlots(nSlots), fBufSize(fgTotalBufSize / nSlots), fPartialHists(fNSlots),
      fMin(nSlots, std::numeric_limits<BufEl_t>::max()), fMax(nSlots, std::numeric_limits<BufEl_t>::lowest())
 {
@@ -59,20 +59,20 @@ FillHelper::FillHelper(const std::shared_ptr<Hist_t> &h, const unsigned int nSlo
    }
 }
 
-void FillHelper::Exec(unsigned int slot, double v)
+void BufferedFillHelper::Exec(unsigned int slot, double v)
 {
    UpdateMinMax(slot, v);
    fBuffers[slot].emplace_back(v);
 }
 
-void FillHelper::Exec(unsigned int slot, double v, double w)
+void BufferedFillHelper::Exec(unsigned int slot, double v, double w)
 {
    UpdateMinMax(slot, v);
    fBuffers[slot].emplace_back(v);
    fWBuffers[slot].emplace_back(w);
 }
 
-Hist_t &FillHelper::PartialUpdate(unsigned int slot)
+Hist_t &BufferedFillHelper::PartialUpdate(unsigned int slot)
 {
    auto &partialHist = fPartialHists[slot];
    // TODO it is inefficient to re-create the partial histogram everytime the callback is called
@@ -83,7 +83,7 @@ Hist_t &FillHelper::PartialUpdate(unsigned int slot)
    return *partialHist;
 }
 
-void FillHelper::Finalize()
+void BufferedFillHelper::Finalize()
 {
    for (unsigned int i = 0; i < fNSlots; ++i) {
       if (!fWBuffers[i].empty() && fBuffers[i].size() != fWBuffers[i].size()) {
@@ -105,16 +105,17 @@ void FillHelper::Finalize()
    }
 }
 
-template void FillHelper::Exec(unsigned int, const std::vector<float> &);
-template void FillHelper::Exec(unsigned int, const std::vector<double> &);
-template void FillHelper::Exec(unsigned int, const std::vector<char> &);
-template void FillHelper::Exec(unsigned int, const std::vector<int> &);
-template void FillHelper::Exec(unsigned int, const std::vector<unsigned int> &);
-template void FillHelper::Exec(unsigned int, const std::vector<float> &, const std::vector<float> &);
-template void FillHelper::Exec(unsigned int, const std::vector<double> &, const std::vector<double> &);
-template void FillHelper::Exec(unsigned int, const std::vector<char> &, const std::vector<char> &);
-template void FillHelper::Exec(unsigned int, const std::vector<int> &, const std::vector<int> &);
-template void FillHelper::Exec(unsigned int, const std::vector<unsigned int> &, const std::vector<unsigned int> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<float> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<double> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<char> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<int> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<unsigned int> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<float> &, const std::vector<float> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<double> &, const std::vector<double> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<char> &, const std::vector<char> &);
+template void BufferedFillHelper::Exec(unsigned int, const std::vector<int> &, const std::vector<int> &);
+template void
+BufferedFillHelper::Exec(unsigned int, const std::vector<unsigned int> &, const std::vector<unsigned int> &);
 
 // TODO
 // template void MinHelper::Exec(unsigned int, const std::vector<float> &);

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -187,7 +187,7 @@ TEST_P(RDFVary, SimpleHisto)
    EXPECT_DOUBLE_EQ(hs["x:1"].GetMean(), 2);
 }
 
-TEST_P(RDFVary, SimpleHistoWithAxes) // uses FillParHelper instead of FillHelper
+TEST_P(RDFVary, SimpleHistoWithAxes) // uses FillHelper instead of DelayedFillHelper
 {
    auto df = ROOT::RDataFrame(10).Define("x", [] { return 1; });
    auto h = df.Vary("x", SimpleVariation, {}, 2).Histo1D<int>({"", "", 20, -10, 10}, "x");


### PR DESCRIPTION
The generic fill helper was called FillParHelper, now it is just
called FillHelper, which suggests it is what we use by default.

The special case of the one-dim histogram filling helper that buffers
values and delayes the actual histogram filling to the end of the
processing had the deceptively simple name FillHelper, it is now
called DelayedFillHelper to call out that it is doing something
interesting.