### PR TITLE
[textinput] Add a missing new-line after `.q` if quitting a ROOT session via Ctrl+D (EOF)

### DIFF
--- a/core/textinput/src/textinput/TextInput.cpp
+++ b/core/textinput/src/textinput/TextInput.cpp
@@ -163,7 +163,7 @@ namespace textinput {
                     fContext->GetDisplays().end(),
                     [](Display *D) { return D->NotifyWindowChange(); });
     } else if (Cmd.isCtrlD()) {
-      fContext->SetLine(".q"), Redraw();
+      fContext->SetLine(".q\n"), Redraw();
       fLastReadResult = kRREOF;
       return;
     } else {


### PR DESCRIPTION
Minor aesthetic fix: add a missing new-line after `.q` if quitting a ROOT session via the Ctrl+D keybinding (EOF).

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #10135.