### PR TITLE
[textinput] Fix implementation of the `kCmdWordTo{Lower,Upper}` editor commands

### DIFF
--- a/core/textinput/src/textinput/Editor.cpp
+++ b/core/textinput/src/textinput/Editor.cpp
@@ -371,15 +371,15 @@ namespace textinput {
         size_t posWord = FindWordBoundary(1);
         if (M == kCmdWordToUpper) {
           for (size_t i = Cursor; i < posWord; ++i) {
-            Line[Cursor] =  toupper(Line[Cursor]);
+            Line[i] =  toupper(Line[i]);
           }
         } else {
           for (size_t i = Cursor; i < posWord; ++i) {
-            Line[Cursor] =  tolower(Line[Cursor]);
+            Line[i] =  tolower(Line[i]);
           }
         }
-        R.fEdit.Extend(Range(Cursor, posWord - Cursor));
-        R.fDisplay.Extend(Range(Cursor, posWord - Cursor));
+        R.fEdit.Extend(Range(Cursor, posWord));
+        R.fDisplay.Extend(Range(Cursor, posWord));
         fContext->SetCursor(posWord);
         return kPRSuccess;
       }


### PR DESCRIPTION
These commands, bound respectively to `ESC l` and `ESC u`, should {lower,upper}case the next word; however, only the first character was changed.

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #10136.