### PR TITLE
Move private declarations away from the public header file

### DIFF
--- a/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
+++ b/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
@@ -1,80 +1,19 @@
 #ifndef TMVA_SOFIE_RMODELPARSER_ONNX
 #define TMVA_SOFIE_RMODELPARSER_ONNX
 
-
-
 #include "TMVA/SOFIE_common.hxx"
 #include "TMVA/RModel.hxx"
-#include "TMVA/OperatorList.hxx"
 
 #include <string>
-#include <fstream>
-#include <memory>
-#include <ctime>
-
-//forward delcaration
-namespace onnx{
-   class NodeProto;
-   class GraphProto;
-}
 
 namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
-namespace INTERNAL{
-
-std::unique_ptr<ROperator> make_ROperator_Transpose(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Relu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Selu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Sigmoid(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Gemm(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Conv(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_RNN(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_LSTM(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_BatchNormalization(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Pool(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Add(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Reshape(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Slice(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_GRU(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-
-
-using factoryMethodMap = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(const onnx::NodeProto&, const onnx::GraphProto&, std::unordered_map<std::string, ETensorType>&)>;
-const factoryMethodMap mapOptypeOperator = {
-   {"Gemm", &make_ROperator_Gemm},
-   {"Transpose", &make_ROperator_Transpose},
-   {"Relu", &make_ROperator_Relu},
-   {"Conv", &make_ROperator_Conv},
-   {"RNN", &make_ROperator_RNN},
-   {"Selu", &make_ROperator_Selu},
-   {"Sigmoid", &make_ROperator_Sigmoid},
-   {"LSTM", &make_ROperator_LSTM},
-   {"GRU", &make_ROperator_GRU},
-   {"BatchNormalization", &make_ROperator_BatchNormalization},
-   {"AveragePool", &make_ROperator_Pool},
-   {"GlobalAveragePool", &make_ROperator_Pool},
-   {"MaxPool", &make_ROperator_Pool},
-   {"Add", &make_ROperator_Add},
-   {"Reshape", &make_ROperator_Reshape},
-   {"Flatten", &make_ROperator_Reshape},
-   {"Slice", &make_ROperator_Slice},
-   {"Squeeze", &make_ROperator_Reshape},
-   {"Unsqueeze", &make_ROperator_Reshape},
-   {"Flatten", &make_ROperator_Reshape}
-};
-
-std::unique_ptr<ROperator> make_ROperator(size_t idx, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-}//INTERNAL
-
-
-
 class RModelParser_ONNX{
 public:
    RModel Parse(std::string filename);
 };
-
-
 
 }//SOFIE
 }//Experimental


### PR DESCRIPTION
This fixes warnings such as these:
```
IncrementalExecutor::executeFunction: symbol '_ZN4TMVA12Experimental5SOFIE8INTERNAL19make_ROperator_SeluERKN4onnx9NodeProtoERKNS3_10GraphProtoERSt13unordered_mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEENS1_11ETensorTypeESt4hashISG_ESt8equal_toISG_ESaISt4pairIKSG_SH_EEE' unresolved while linking function '_GLOBAL__sub_I_cling_module_0'!
You are probably missing the definition of TMVA::Experimental::SOFIE::INTERNAL::make_ROperator_Selu(onnx::NodeProto const&, onnx::GraphProto const&, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, TMVA::Experimental::SOFIE::ETensorType, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, TMVA::Experimental::SOFIE::ETensorType> > >&)
Maybe you need to load the corresponding shared library?
```
# This Pull request:

## Changes or fixes:

Move private declarations away from the public header file

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
