### PR TITLE
[RF] Use `TUUID` directly as the key for shared property maps

### DIFF
--- a/roofit/roofitcore/inc/RooCategory.h
+++ b/roofit/roofitcore/inc/RooCategory.h
@@ -17,6 +17,7 @@
 #define ROO_CATEGORY
 
 #include "RooAbsCategoryLValue.h"
+#include "RooSharedProperties.h"
 
 #include <vector>
 #include <map>
@@ -133,7 +134,7 @@ private:
   void installLegacySharedProp(const RooCategorySharedProperties* sp);
   void installSharedRange(std::unique_ptr<RangeMap_t>&& rangeMap);
   /// Helper for restoring shared ranges from old versions of this class read from files. Maps TUUID names to shared ranges.
-  static std::map<std::string, std::weak_ptr<RangeMap_t>> _uuidToSharedRangeIOHelper;
+  static std::map<RooSharedProperties::UUID, std::weak_ptr<RangeMap_t>> _uuidToSharedRangeIOHelper;
   /// Helper for restoring shared ranges from current versions of this class read from files. Maps category names to shared ranges.
   static std::map<std::string, std::weak_ptr<RangeMap_t>> _sharedRangeIOHelper;
 

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -17,6 +17,7 @@
 #define ROO_REAL_VAR
 
 #include "RooAbsRealLValue.h"
+#include "RooSharedProperties.h"
 
 #include "TString.h"
 
@@ -162,7 +163,10 @@ public:
 
   void setExpensiveObjectCache(RooExpensiveObjectCache&) override { ; } ///< variables don't need caches
   static RooRealVarSharedProperties& _nullProp(); ///< Null property
-  static std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>* sharedPropList(); ///< List of properties shared among clones of a variable
+
+  using SharedPropertiesMap = std::map<RooSharedProperties::UUID,std::weak_ptr<RooRealVarSharedProperties>>;
+
+  static SharedPropertiesMap* sharedPropList(); ///< List of properties shared among clones of a variable
 
   std::shared_ptr<RooRealVarSharedProperties> _sharedProp; ///<! Shared binnings associated with this instance
 

--- a/roofit/roofitcore/inc/RooSharedProperties.h
+++ b/roofit/roofitcore/inc/RooSharedProperties.h
@@ -45,7 +45,18 @@ public:
   void setInSharedList() { _inSharedList = kTRUE ; }
   Bool_t inSharedList() const { return _inSharedList ; }
 
-   TString asString() const { return TString(_uuid.AsString()); }
+   // Wrapper class to make the TUUID comparable for use as key type in std::map.
+   class UUID {
+   public:
+     UUID(TUUID const& tuuid) : _uuid{tuuid} {}
+     bool operator<(UUID const& other) const { return _uuid.Compare(other._uuid) < 0; }
+     bool operator>(UUID const& other) const { return _uuid.Compare(other._uuid) > 0; }
+     bool operator==(UUID const& other) const { return _uuid.Compare(other._uuid) == 0; }
+   private:
+     TUUID _uuid;
+   };
+
+   UUID uuid() const { return _uuid; }
 
 protected:
 

--- a/roofit/roofitcore/src/RooCategory.cxx
+++ b/roofit/roofitcore/src/RooCategory.cxx
@@ -96,7 +96,7 @@ using namespace std;
 
 ClassImp(RooCategory);
 
-std::map<std::string, std::weak_ptr<RooCategory::RangeMap_t>> RooCategory::_uuidToSharedRangeIOHelper; // Helper for restoring shared properties
+std::map<RooSharedProperties::UUID, std::weak_ptr<RooCategory::RangeMap_t>> RooCategory::_uuidToSharedRangeIOHelper; // Helper for restoring shared properties
 std::map<std::string, std::weak_ptr<RooCategory::RangeMap_t>> RooCategory::_sharedRangeIOHelper;
 
 
@@ -482,7 +482,7 @@ void RooCategory::installLegacySharedProp(const RooCategorySharedProperties* pro
   if (props == nullptr || (*props == RooCategorySharedProperties("00000000-0000-0000-0000-000000000000")))
     return;
 
-  auto& weakPtr = _uuidToSharedRangeIOHelper[props->asString().Data()];
+  auto& weakPtr = _uuidToSharedRangeIOHelper[props->uuid()];
   if (auto existingObject = weakPtr.lock()) {
     // We know this range, start sharing
     _ranges = std::move(existingObject);

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -58,11 +58,11 @@ Int_t  RooRealVar::_printSigDigits(5) ;
 static bool staticSharedPropListCleanedUp = false;
 
 /// Return a reference to a map of weak pointers to RooRealVarSharedProperties.
-std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>* RooRealVar::sharedPropList()
+RooRealVar::SharedPropertiesMap* RooRealVar::sharedPropList()
 {
   RooSentinel::activate();
   if(!staticSharedPropListCleanedUp) {
-    static auto * staticSharedPropList = new std::map<std::string,std::weak_ptr<RooRealVarSharedProperties>>();
+    static auto * staticSharedPropList = new SharedPropertiesMap{};
     return staticSharedPropList;
   }
   return nullptr;
@@ -1316,7 +1316,7 @@ void RooRealVar::installSharedProp(std::shared_ptr<RooRealVarSharedProperties>&&
   }
 
 
-  auto& weakPtr = (*sharedPropList())[prop->asString().Data()];
+  auto& weakPtr = (*sharedPropList())[prop->uuid()];
   std::shared_ptr<RooRealVarSharedProperties> existingProp;
   if ( (existingProp = weakPtr.lock()) ) {
     // Property exists, discard incoming
@@ -1339,7 +1339,7 @@ void RooRealVar::deleteSharedProperties()
   if(!_sharedProp) return;
 
   // Get the key for the _sharedPropList.
-  const std::string key = _sharedProp->asString().Data();
+  auto key = _sharedProp->uuid(); // we have to make a copy because _sharedPropList gets delete next.
 
   // Actually delete the shared properties object.
   _sharedProp.reset();


### PR DESCRIPTION
Before, the expensive `TUUID::AsString` function was used to generate
the key.

This is a performance optimization that speeds up the RooRealVar
destructor by about a factor ten, which measurably benefits workflows
with large workspaces.

Here a profile of a CMS combine toy experiment workflow to show this:
* before this PR: https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/combine_example_toys
* after this PR: https://rembserj.web.cern.ch/rembserj/cgi-bin/igprof-navigator/combine_example_toys_2