### PR TITLE
[RF] RooStringView now takes ownership of `string` if it's a temporary

### DIFF
--- a/roofit/roofitcore/inc/RooStringView.h
+++ b/roofit/roofitcore/inc/RooStringView.h
@@ -29,10 +29,13 @@ public:
    RooStringView(const char *str) : _cstr{str} {}
    RooStringView(TString const &str) : _cstr{str} {}
    RooStringView(std::string const &str) : _cstr{str.c_str()} {}
+   // If the string is a temporary, we have to store it ourselves, otherwise the C-style string would be invalid.
+   RooStringView(std::string &&str) : _strp{std::make_shared<std::string>(std::move(str))}, _cstr{_strp->c_str()} {}
    operator const char *() { return _cstr; }
    operator std::string_view() { return _cstr; }
 
 private:
+   std::shared_ptr<std::string> _strp;
    const char *_cstr;
 };
 


### PR DESCRIPTION
This fixes a problem with string ownership in PyROOT.

```Python
import ROOT
ROOT.RooDataSet("x", "t", ROOT.RooArgSet()).GetName()
```
It will wrongly print out `"t"`, while the name should actually be
`"x"`.