### PR TITLE
[RF] Fix recently-introduced hash table bug in `RooLinkedList`

### DIFF
--- a/roofit/roofitcore/src/RooLinkedList.cxx
+++ b/roofit/roofitcore/src/RooLinkedList.cxx
@@ -605,7 +605,8 @@ TObject* RooLinkedList::find(const char* name) const
 {
 
   if (_htableName) {
-    TObject *a = const_cast<TObject*>((*_htableName)[name]) ;
+    auto found = _htableName->find(name);
+    TObject *a = found != _htableName->end() ? const_cast<TObject*>(found->second) : nullptr;
     // RooHashTable::find could return false negative if element was renamed to 'name'.
     // The list search means it won't return false positive, so can return here.
     if (a) return a;


### PR DESCRIPTION
In `RooLinkedList::find()`, the `operator[]` of `unordered_map` was used
to look up elements. However, this has the side effect that if the
elment for the key doesn't exists, it is implicitly created and
instantiated with `nullptr`! Now the desaster continues: new elements
are added in `RooLinkedList::Add()` via `unordered_map::insert()`.
But `insert()` method doesn't do anything if an item already exists!

This means that if you look up an element in a `RooLinkedList` that is
long enough to use the hash tables, and this element is not found,
adding this element to the list then will not succeed.

It's surprising that this problem was uncovered only now, thanks to
@cburgard who provided a reproducer.