### PR TITLE
[rbrowser] Improve sub-directory browsing in TFile

### DIFF
--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -88,6 +88,9 @@ public:
    /** Should item representing element be expand by default */
    virtual bool IsExpandByDefault() const { return false; }
 
+   /** Select element as active */
+   virtual bool cd() { return false; }
+
    static std::shared_ptr<RElement> GetSubElement(std::shared_ptr<RElement> &elem, const RElementPath_t &path);
 
    static RElementPath_t ParsePath(const std::string &str);

--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -63,6 +63,8 @@ protected:
 
    void AddInitWidget(const std::string &kind);
 
+   void CheckWidgtesModified();
+
 public:
    RBrowser(bool use_rcanvas = true);
    virtual ~RBrowser();

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -114,8 +114,6 @@ public:
       return msg;
    }
 
-   virtual void CheckModified() {}
-
 };
 
 class RBrowserCatchedWidget : public RBrowserWidget {

--- a/gui/browserv7/src/RBrowser.cxx
+++ b/gui/browserv7/src/RBrowser.cxx
@@ -114,6 +114,8 @@ public:
       return msg;
    }
 
+   virtual void CheckModified() {}
+
 };
 
 class RBrowserCatchedWidget : public RBrowserWidget {
@@ -566,6 +568,15 @@ std::string RBrowser::NewWidgetMsg(std::shared_ptr<RBrowserWidget> &widget)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
+/// Check if any widget was modified and update if necessary
+
+void RBrowser::CheckWidgtesModified()
+{
+   for (auto &widget : fWidgets)
+      widget->CheckModified();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
 /// Process received message from the client
 
 void RBrowser::ProcessMsg(unsigned connid, const std::string &arg0)
@@ -629,12 +640,13 @@ void RBrowser::ProcessMsg(unsigned connid, const std::string &arg0)
       }
 
       std::ofstream ofs(pathtmp.str(), std::ofstream::out | std::ofstream::app);
-      ofs << sPrompt << msg;
+      ofs << sPrompt << msg << std::endl;
       ofs.close();
 
       gSystem->RedirectOutput(pathtmp.str().c_str(), "a");
       gROOT->ProcessLine(msg.c_str());
-      gSystem->RedirectOutput(0);
+      gSystem->RedirectOutput(nullptr);
+      CheckWidgtesModified();
    } else if (kind == "GETHISTORY") {
 
       auto history = GetRootHistory();

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -142,6 +142,8 @@ bool RBrowserData::ProcessBrowserRequest(const RBrowserRequest &request, RBrowse
 
       fLastPath = path;
       fLastElement = std::move(elem);
+
+      fLastElement->cd(); // set element active
    } else if (request.reload) {
       // only reload items from element, not need to reset element itself
       ResetLastRequestData(false);

--- a/gui/browserv7/src/RBrowserRCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserRCanvasWidget.cxx
@@ -76,6 +76,12 @@ public:
       return false;
    }
 
+   void CheckModified() override
+   {
+      if (fCanvas->IsModified())
+         fCanvas->Update();
+   }
+
 };
 
 // ======================================================================

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -142,6 +142,12 @@ public:
       return false;
    }
 
+   void CheckModified() override
+   {
+      if (fCanvas->IsModified())
+         fCanvas->Update();
+   }
+
 };
 
 // ======================================================================

--- a/gui/browserv7/src/RBrowserWidget.hxx
+++ b/gui/browserv7/src/RBrowserWidget.hxx
@@ -55,6 +55,8 @@ public:
 
    virtual bool DrawElement(std::shared_ptr<Browsable::RElement> &, const std::string &) { return false; }
    virtual std::string SendWidgetContent() { return ""; }
+
+   virtual void CheckModified() {}
 };
 
 class RBrowserWidgetProvider {


### PR DESCRIPTION
Every time when sub-directory items are requested, set it as `gDirectory`
This helps to directly access objects from that sub-directory in command line

Also automatically update canvas drawing if it was modified during command execution.

Add newline in command output