### PR TITLE
Enable TContext usage as a Python context manager

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -41,6 +41,7 @@ set(py_sources
   ROOT/_pythonization/_tclonesarray.py
   ROOT/_pythonization/_tcollection.py
   ROOT/_pythonization/_tcomplex.py
+  ROOT/_pythonization/_tcontext.py
   ROOT/_pythonization/_tdirectory.py
   ROOT/_pythonization/_tdirectoryfile.py
   ROOT/_pythonization/_tfile.py

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcontext.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tcontext.py
@@ -1,0 +1,101 @@
+# Author: Vincenzo Eduardo Padulano CERN/UPV 2022
+
+################################################################################
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+r'''
+/**
+\class TDirectory::TContext
+\brief \parblock \endparblock
+\htmlonly
+<div class="pyrootbox">
+\endhtmlonly
+## PyROOT
+
+The functionality offered by TContext can be used in PyROOT with a context manager. Here are a few examples:
+\code{.py}
+import ROOT
+from ROOT import TDirectory
+
+with TDirectory.TContext():
+    # Open some file here
+    file = ROOT.TFile(...)
+    # Retrieve contents from the file
+    histo = file.Get("myhisto")
+
+# After the 'with' statement, the current directory is restored to ROOT.gROOT
+\endcode
+\n 
+\code{.py}
+import ROOT
+from ROOT import TDirectory
+
+file1 = ROOT.TFile("file1.root", "recreate")
+#...
+file2 = ROOT.TFile("file2.root", "recreate")
+#...
+file3 = ROOT.TFile("file3.root", "recreate")
+
+# Before the 'with' statement, the current directory is file3 (the last file opened)
+with TDirectory.TContext(file1):
+    # Inside the statement, the current directory is file1
+    histo = ROOT.TH1F(...)
+    histo.Write()
+
+# After the statement, the current directory is restored to file3
+\endcode
+\n 
+\code{.py}
+import ROOT
+from ROOT import TDirectory
+
+file1 = ROOT.TFile("file1.root")
+file2 = ROOT.TFile("file2.root")
+
+with TDirectory.TContext(file1, file2):
+    # Manage content in file2
+    histo = ROOT.TH1F(...)
+    # histo will be written to file2
+    histo.Write()
+
+# Current directory is set to 'file1.root'
+\endcode
+
+Note that TContext restores the current directory to its status before the 'with'
+statement, but does not change the status of any file that has been opened inside
+the context (e.g. it does not automatically close the file).
+\htmlonly
+</div>
+\endhtmlonly
+*/
+'''
+
+from . import pythonization
+
+
+def _TContextExit(ctxt, exc_type, exc_val, exc_tb):
+    """
+    Destroy the TContext, mimicking its RAII behaviour.
+    Signature and return value are imposed by Python, see
+    https://docs.python.org/3/library/stdtypes.html#typecontextmanager.
+    """
+    ctxt.__destruct__()
+    return False
+
+
+@pythonization("TContext", ns="TDirectory")
+def pythonize_tcontext(klass):
+    """
+    TContext pythonizations:
+    - __enter__ and __exit__ methods are defined to make it work as a context manager.
+    """
+
+    # The user doesn't need to do anything with the TContext object itself, so
+    # we don't provide it in the context manager expression
+    klass.__enter__ = lambda ctxt: None
+    klass.__exit__ = _TContextExit

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -36,6 +36,9 @@ ROOT_ADD_PYUNITTEST(pyroot_pyz_tobject_comparisonops tobject_comparisonops.py)
 # TClass pythonisations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tclass_dynamiccast tclass_dynamiccast.py)
 
+# TContext pythonizations
+ROOT_ADD_PYUNITTEST(pyroot_pyz_tcontext_contextmanager tcontext_contextmanager.py)
+
 # TDirectory and subclasses pythonizations
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectory_attrsyntax tdirectory_attrsyntax.py)
 ROOT_ADD_PYUNITTEST(pyroot_pyz_tdirectoryfile_attrsyntax_get tdirectoryfile_attrsyntax_get.py)

--- a/bindings/pyroot/pythonizations/test/tcontext_contextmanager.py
+++ b/bindings/pyroot/pythonizations/test/tcontext_contextmanager.py
@@ -1,0 +1,82 @@
+import os
+import unittest
+
+import ROOT
+
+from ROOT import TDirectory
+
+
+class TContextContextManager(unittest.TestCase):
+    """
+    Test of TContext used as context manager
+    """
+
+    def default_constructor(self):
+        """
+        Check status of gDirectory with default constructor.
+        """
+        filename = "TContextContextManager_test_default_constructor.root"
+        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
+
+        with TDirectory.TContext():
+            # Create a file to change gDirectory
+            testfile = ROOT.TFile(filename, "recreate")
+            self.assertEqual(ROOT.gDirectory, testfile)
+            testfile.Close()
+
+        self.assertEqual(ROOT.gDirectory, ROOT.gROOT)
+        os.remove(filename)
+
+    def constructor_onearg(self):
+        """
+        Check status of gDirectory with constructor taking a new directory.
+        """
+        filenames = ["TContextContextManager_test_constructor_onearg_{}.root".format(i) for i in range(2)]
+
+        file0 = ROOT.TFile(filenames[0], "recreate")
+        file1 = ROOT.TFile(filenames[1], "recreate")
+        self.assertEqual(ROOT.gDirectory, file1)
+
+        with TDirectory.TContext(file0):
+            self.assertEqual(ROOT.gDirectory, file0)
+
+        self.assertEqual(ROOT.gDirectory, file1)
+        file0.Close()
+        file1.Close()
+        for filename in filenames:
+            os.remove(filename)
+
+    def constructor_twoargs(self):
+        """
+        Check status of gDirectory with constructor taking the previous directory and a new one.
+        """
+        filenames = ["TContextContextManager_test_constructor_onearg_{}.root".format(i) for i in range(3)]
+
+        file0 = ROOT.TFile(filenames[0], "recreate")
+        file1 = ROOT.TFile(filenames[1], "recreate")
+        file2 = ROOT.TFile(filenames[2], "recreate")
+        self.assertEqual(ROOT.gDirectory, file2)
+
+        with TDirectory.TContext(file0, file1):
+            self.assertEqual(ROOT.gDirectory, file1)
+
+        self.assertEqual(ROOT.gDirectory, file0)
+        file0.Close()
+        file1.Close()
+        file2.Close()
+        for filename in filenames:
+            os.remove(filename)
+
+    def test_all(self):
+        """
+        Run all tests of this class sequentially.
+        The tests of this class rely on the current directory, which can be changed
+        unpredictably if they are run concurrently.
+        """
+        self.default_constructor()
+        self.constructor_onearg()
+        self.constructor_twoargs()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As a result of discussing #9947 , the following two use cases have arised (in terms of what a user would want to do with a TFile):

1. Open the file, `cd` into it, write/read stuff to/from it, `cd` out of it (thus restoring the `gDirectory` to the previous open file or something like `gROOT`
2. Open a file, write/read stuff to/from it, close the file and forget about it and its content.

While case 2 can be better addressed with the original idea of the TFile pythonization of the PR linked above, case 1 is actually the purpose of the `TDirectory::TContext` class. Currently, there is no easy way to use this class in Python because it's an RAII construct that fulfills its mission at destruction time. Python scopes are quite different to C++ scopes, and calling the destructor of the TContext explicitly would mean calling the `__destruct__` magic method (which is maybe not even intended for public usage).

Thus. a much more pythonic approach is to enable usage of `TContext` as a Python context manager. This allows for example the following:

```python
import ROOT
from ROOT import TDirectory

with TDirectory.TContext():
    # Open some file here
    file = ROOT.TFile(...)
    # Retrieve contents from the file
    histo = file.Get("myhisto")
```
where after the `with` statement, the current directory is restored to ROOT.gROOT. Or also

```python
import ROOT
from ROOT import TDirectory

file1 = ROOT.TFile("file1.root")
file2 = ROOT.TFile("file2.root")

with TDirectory.TContext(file1, file2):
    histo = ROOT.TH1F(...)
    histo.Write()
```

where inside the `with` statement the current directory would be `file2`, and afterwards it would be set to `file1`.

As an aside, this functionality would not modify anything of the TFile itself, e.g. it would not close it after the `with`. This means that all objects created or read from the file in the with statement would still be alive and accessible afterwards