### PR TITLE
v624: tree: Always register FriendElement in external list.

### DIFF
--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -67,6 +67,8 @@ public:
            Bool_t      IsUpdated() const { return TestBit(kUpdated); }
            void        ResetUpdated() { ResetBit(kUpdated); }
            void        MarkUpdated() { SetBit(kUpdated); }
+   virtual void        RecursiveRemove(TObject *obj);
+
 
    ClassDef(TFriendElement,2)  //A friend element of another TTree
 };

--- a/tree/tree/src/TChain.cxx
+++ b/tree/tree/src/TChain.cxx
@@ -725,7 +725,6 @@ TFriendElement* TChain::AddFriend(TTree* chain, const char* alias, Bool_t /* war
    if (!t) {
       Warning("AddFriend","Unknown TChain %s",chain->GetName());
    }
-   chain->RegisterExternalFriend(fe);
    return fe;
 }
 

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -140,6 +140,8 @@ TFriendElement::TFriendElement(TTree *tree, TTree* friendtree, const char *alias
       delete [] temp;
    }
 
+   if (fTree)
+      fTree->RegisterExternalFriend(this);
    // No need to Connect.
 }
 
@@ -220,11 +222,10 @@ TTree *TFriendElement::GetTree()
 
    if (GetFile()) {
       fFile->GetObject(GetTreeName(),fTree);
-      if (fTree) return fTree;
+   } else {
+      // This could be a memory tree or chain
+      fTree = dynamic_cast<TTree*>( gROOT->FindObject(GetTreeName()) );
    }
-
-   // This could be a memory tree or chain
-   fTree = dynamic_cast<TTree*>( gROOT->FindObject(GetTreeName()) );
 
    if (fTree)
       fTree->RegisterExternalFriend(this);
@@ -238,4 +239,15 @@ TTree *TFriendElement::GetTree()
 void TFriendElement::ls(Option_t *) const
 {
    printf(" Friend Tree: %s in file: %s\n",GetName(),GetTitle());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Forget deleted elements.
+
+void TFriendElement::RecursiveRemove(TObject *delobj)
+{
+   if (delobj == fTree)
+      fTree = nullptr;
+   if (delobj == fFile)
+      fFile = nullptr;
 }

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1400,10 +1400,10 @@ TFriendElement *TTree::AddFriend(TTree *tree, const char *alias, Bool_t warn)
               tree->GetName(), fe->GetFile() ? fe->GetFile()->GetName() : "(memory resident)", t->GetEntries(),
               fEntries);
    }
-   if (CheckReshuffling(*this, *t)) {
+   if (CheckReshuffling(*this, *t))
       fFriends->Add(fe);
-      tree->RegisterExternalFriend(fe);
-   }
+   else
+      tree->RemoveExternalFriend(fe);
    return fe;
 }
 


### PR DESCRIPTION
Always add the TFriendElement (owned by the main TTree) with the friend tree's fExternalFriends list
so that it can be reset if the friend is deleted before the main TTree.

Also implement TFriendElement::RecursiveRemove

