### PR TITLE
v622: Deal with multi schema layout for a pair (caused enum underlying type

### DIFF
--- a/core/foundation/inc/TClassEdit.h
+++ b/core/foundation/inc/TClassEdit.h
@@ -196,7 +196,7 @@ namespace TClassEdit {
    {
       return 0 == name.compare(0, 17, "std::__pair_base<") || 0 == name.compare(0, 12, "__pair_base<");
    }
-   inline bool IsStdPairBase(ROOT::Internal::TStringView name) {return IsStdPair(std::string_view(name)); }
+   inline bool IsStdPairBase(ROOT::Internal::TStringView name) {return IsStdPairBase(std::string_view(name)); }
    inline std::string GetUniquePtrType(std::string_view name)
    {
       // Find the first template parameter

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1371,6 +1371,9 @@ void TClass::Init(const char *name, Version_t cversion,
    fStreamerInfo   = new TObjArray(fClassVersion+2+10,-1); // +10 to read new data by old
    fProperty       = -1;
    fClassProperty  = 0;
+   const bool ispair = TClassEdit::IsStdPair(fName);
+   if (ispair)
+      SetBit(kIsForeign);
 
    ResetInstanceCount();
 
@@ -5903,7 +5906,7 @@ Bool_t  TClass::IsForeign() const
    if (fProperty==(-1)) Property();
    // If the property are not set and the class is a pair, hard code that
    // it is a unversioned/Foreign class.
-   return TestBit(kIsForeign) || (fProperty == -1 && TClassEdit::IsStdPair(GetName()));
+   return TestBit(kIsForeign);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1513,7 +1513,9 @@ void TClass::Init(const char *name, Version_t cversion,
       } else {
          // In this case we initialised this TClass instance starting from the fwd declared state
          // and we know we have no dictionary: no need to warn
-         ::Warning("TClass::Init", "no dictionary for class %s is available", fName.Data());
+         const bool ispairbase = TClassEdit::IsStdPairBase(fName.Data()) && !IsFromRootCling();
+         if (!ispairbase)
+            ::Warning("TClass::Init", "no dictionary for class %s is available", fName.Data());
       }
    }
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1326,9 +1326,15 @@ void TClass::ForceReload (TClass* oldcl)
    while ((info = (TVirtualStreamerInfo*)next())) {
       info->Clear("build");
       info->SetClass(this);
-      if (IsSyntheticPair())
-         info->BuildOld();
-      fStreamerInfo->AddAtAndExpand(info,info->GetClassVersion());
+      if (IsSyntheticPair()) {
+         // Some pair's StreamerInfo were inappropriately marked as versioned
+         info->SetClassVersion(1);
+         // There is already a TStreamerInfo put there by the synthetic
+         // creation.
+         fStreamerInfo->Add(info);
+      } else {
+         fStreamerInfo->AddAtAndExpand(info,info->GetClassVersion());
+      }
    }
    oldcl->fStreamerInfo->Clear();
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -5900,7 +5900,9 @@ Bool_t  TClass::IsTObject() const
 Bool_t  TClass::IsForeign() const
 {
    if (fProperty==(-1)) Property();
-   return TestBit(kIsForeign);
+   // If the property are not set and the class is a pair, hard code that
+   // it is a unversioned/Foreign class.
+   return TestBit(kIsForeign) || (fProperty == -1 && TClassEdit::IsStdPair(GetName()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1513,8 +1513,6 @@ void TClass::Init(const char *name, Version_t cversion,
                     fName.Data());
          }
       } else {
-         // In this case we initialised this TClass instance starting from the fwd declared state
-         // and we know we have no dictionary: no need to warn
          const bool ispairbase = TClassEdit::IsStdPairBase(fName.Data()) && !IsFromRootCling();
          if (!ispairbase)
             ::Warning("TClass::Init", "no dictionary for class %s is available", fName.Data());

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -3104,7 +3104,8 @@ TClass *TClass::GetClass(const char *name, Bool_t load, Bool_t silent, size_t hi
    if (ispair) {
       if (hint_pair_offset && hint_pair_size) {
          auto pairinfo = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(normalizedName, silent, hint_pair_offset, hint_pair_size);
-         //return pairinfo ? pairinfo->GetClass() : nullptr;
+         // Fall-through to allow TClass to be created when known by the interpreter
+         // This is used in the case where TStreamerInfo can not handle them.
          if (pairinfo)
             return pairinfo->GetClass();
       } else {

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -1326,6 +1326,8 @@ void TClass::ForceReload (TClass* oldcl)
    while ((info = (TVirtualStreamerInfo*)next())) {
       info->Clear("build");
       info->SetClass(this);
+      if (IsSyntheticPair())
+         info->BuildOld();
       fStreamerInfo->AddAtAndExpand(info,info->GetClassVersion());
    }
    oldcl->fStreamerInfo->Clear();

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2125,7 +2125,7 @@ void TStreamerInfo::BuildOld()
                auto pattern = (TStreamerInfo*)fClass->GetStreamerInfos()->At(fClass->GetClassVersion());
                streamer = 0;
                element->Init(this);
-               if (pattern) {
+               if (pattern && pattern != this && pattern->IsBuilt()) {
                   int pair_element_offset = kMissing;
                   pattern->GetStreamerElement(element->GetName(), pair_element_offset);
                   if (offset != kMissing)

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -878,7 +878,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
       else {
          // We are in the case of an 'emulated' class.
 
-         if (fOnFileClassVersion >= 2) {
+         if (fOnFileClassVersion >= 2 && !isStdPair) {
             // The class version was specified when the object was
             // written
 
@@ -943,7 +943,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
             // The TStreamerInfo's checksum is different from the checksum for the compile class.
 
             match = kFALSE;
-            oldIsNonVersioned = info->fOnFileClassVersion==1 && info->fClassVersion != 1;
+            oldIsNonVersioned = (info->fOnFileClassVersion==1 && info->fClassVersion != 1) || isStdPair;
 
             if (fClass->IsLoaded() && (fClassVersion == fClass->GetClassVersion()) && fClass->HasDataMemberInfo()) {
                // In the case where the read-in TStreamerInfo does not
@@ -994,7 +994,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
                // The on-file TStreamerInfo's checksum differs from the checksum of a TStreamerInfo on another file.
 
                match = kFALSE;
-               oldIsNonVersioned = info->fOnFileClassVersion==1 && info->fClassVersion != 1;
+               oldIsNonVersioned = (info->fOnFileClassVersion==1 && info->fClassVersion != 1) || isStdPair;
 
                // In the case where the read-in TStreamerInfo does not
                // match in the 'current' in memory TStreamerInfo for

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -774,13 +774,7 @@ void TStreamerInfo::BuildCheck(TFile *file /* = 0 */, Bool_t load /* = kTRUE */)
             return;
          }
       }
-      if (fClass->fIsSyntheticPair) {
-         // The format never change, no need to import the old StreamerInof
-         // (which anyway would have issue when being setup due to the lack
-         // of TDataMember in the TClass.
-         SetBit(kCanDelete);
-         return;
-      }
+      bool isStdPair = TClassEdit::IsStdPair(GetName());
 
       if (0 == strcmp("string",fClass->GetName())) {
          // We know we do not need any offset check for a string

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2044,7 +2044,7 @@ void TStreamerInfo::BuildOld()
       Bool_t isStdArray(kFALSE);
 
       // First set the offset and sizes.
-      if (fClass->GetState() <= TClass::kEmulated) {
+      if (fClass->GetState() <= TClass::kEmulated && !fClass->IsSyntheticPair()) {
          // Note the initilization in this case are
          // delayed until __after__ the schema evolution
          // section, just in case the info has changed.
@@ -2121,6 +2121,16 @@ void TStreamerInfo::BuildOld()
                }
                int dsize = dm->GetUnitSize();
                element->SetSize(dsize*narr);
+            } else if (fClass->IsSyntheticPair()) {
+               auto pattern = (TStreamerInfo*)fClass->GetStreamerInfos()->At(fClass->GetClassVersion());
+               streamer = 0;
+               element->Init(this);
+               if (pattern) {
+                  int pair_element_offset = kMissing;
+                  pattern->GetStreamerElement(element->GetName(), pair_element_offset);
+                  if (offset != kMissing)
+                     element->SetOffset(offset);
+               }
             }
          }
       } // Class corresponding to StreamerInfo is emulated or not.
@@ -3114,7 +3124,7 @@ void TStreamerInfo::ComputeSize()
    // to be aligned.  So let's be on the safe side and align on the size of
    // the pointers.  (Question: is that the right thing on x32 ABI ?)
    constexpr size_t kSizeOfPtr = sizeof(void*);
-   if ((fSize % kSizeOfPtr) != 0) {
+   if ((fSize % kSizeOfPtr) != 0 && !fClass->IsSyntheticPair()) {
       fSize = fSize - (fSize % kSizeOfPtr) + kSizeOfPtr;
    }
 }


### PR DESCRIPTION

This fixes #10131.

The core issue is that TDataMember::Init and TStreamerInfo::GenerateInfoForPair were not consistent. TDataMember::Init was ignoring the underlying type of an enum while the newer TStreamerInfo::GenerateInfoForPair was taking it in consideration. In the reported case, it meant that some of the pair's TStreamerInfo recorded the type as being 'signed intwhile other was recording the type asunsigned int`.

In addition the whole infrastructure assumed (but only in "some/most" places) that the TStreamerInfo for a std::pair could never change and the infrastructure was also inconsistent on knowing whether the schema layout for std::pair is version of non-versioned.

NOTE: The last commit is might cause the user classes to require a version incrementing when using enums ... (i.e. this commit might be removed) ... it was indeed removing ... in addition changing the stored type of the enum changes the schema layout but does not (sometimes?) change (yet?) the checksum so it leads to incorrect reading of data .... 
