### PR TITLE
[ntuple] Protect descriptor access in page source by r/w lock

### DIFF
--- a/gui/browsable/src/RFieldProvider.hxx
+++ b/gui/browsable/src/RFieldProvider.hxx
@@ -174,8 +174,11 @@ public:
       auto ntplSource = holder->GetNtplSource();
       std::string name = holder->GetParentName();
 
-      const auto &desc = ntplSource->GetDescriptor();
-      auto field = desc.GetFieldDescriptor(holder->GetId()).CreateField(desc);
+      std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> field;
+      {
+         auto descriptorGuard = ntplSource->GetSharedDescriptorGuard();
+         field = descriptorGuard->GetFieldDescriptor(holder->GetId()).CreateField(descriptorGuard.GetRef());
+      }
       name.append(field->GetName());
 
       RDrawVisitor drawVisitor(ntplSource);

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -272,10 +272,10 @@ void RNTupleDS::AddField(const RNTupleDescriptor &desc, std::string_view colName
 RNTupleDS::RNTupleDS(std::unique_ptr<Detail::RPageSource> pageSource)
 {
    pageSource->Attach();
-   const auto &descriptor = pageSource->GetDescriptor();
+   auto descriptorGuard = pageSource->GetSharedDescriptorGuard();
    fSources.emplace_back(std::move(pageSource));
 
-   AddField(descriptor, "", descriptor.GetFieldZeroId(), std::vector<DescriptorId_t>());
+   AddField(descriptorGuard.GetRef(), "", descriptorGuard->GetFieldZeroId(), std::vector<DescriptorId_t>());
 }
 
 RDF::RDataSource::Record_t RNTupleDS::GetColumnReadersImpl(std::string_view /* name */, const std::type_info & /* ti */)

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -247,7 +247,7 @@ public:
    void LoadEntry(NTupleSize_t index) {
       // TODO(jblomer): can be templated depending on the factory method / constructor
       if (R__unlikely(!fModel)) {
-         fModel = fSource->GetDescriptor().GenerateModel();
+         fModel = fSource->GetSharedDescriptorGuard()->GenerateModel();
          ConnectModel(*fModel);
       }
       LoadEntry(index, *fModel->GetDefaultEntry());
@@ -298,11 +298,10 @@ public:
    /// ~~~
    template <typename T>
    RNTupleView<T> GetView(std::string_view fieldName) {
-      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
+      auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName);
       if (fieldId == kInvalidDescriptorId) {
-         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
-            + fSource->GetDescriptor().GetName() + "'"
-         ));
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
+                                  fSource->GetSharedDescriptorGuard()->GetName() + "'"));
       }
       return RNTupleView<T>(fieldId, fSource.get());
    }
@@ -311,11 +310,10 @@ public:
    /// * there is no field with the given name or,
    /// * the field is not a collection
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
-      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName);
+      auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName);
       if (fieldId == kInvalidDescriptorId) {
-         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
-            + fSource->GetDescriptor().GetName() + "'"
-         ));
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
+                                  fSource->GetSharedDescriptorGuard()->GetName() + "'"));
       }
       return RNTupleViewCollection(fieldId, fSource.get());
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -201,7 +201,10 @@ public:
 
    RNTupleModel *GetModel();
    NTupleSize_t GetNEntries() const { return fSource->GetNEntries(); }
-   const RNTupleDescriptor &GetDescriptor() const { return fSource->GetDescriptor(); }
+
+   /// Returns a cached copy of the page source descriptor. The returned pointer remains valid until the next call
+   /// to LoadEntry or to any of the views returned from the reader.
+   const RNTupleDescriptor *GetDescriptor();
 
    /// Prints a detailed summary of the ntuple, including a list of fields.
    ///

--- a/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTuple.hxx
@@ -113,6 +113,12 @@ private:
    /// from the full model even if the analysis code uses only a subset of fields. The display reader
    /// is a clone of the original reader.
    std::unique_ptr<RNTupleReader> fDisplayReader;
+   /// The ntuple descriptor in the page source is protected by a read-write lock. We don't expose that to the
+   /// users of RNTupleReader::GetDescriptor().  Instead, if descriptor information is needed, we clone the
+   /// descriptor.  Using the descriptor's generation number, we know if the cached descriptor is stale.
+   /// Retrieving descriptor data from an RNTupleReader is supposed to be for testing and information purposes,
+   /// not on a hot code path.
+   std::unique_ptr<RNTupleDescriptor> fCachedDescriptor;
    Detail::RNTupleMetrics fMetrics;
 
    void ConnectModel(const RNTupleModel &model);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -390,6 +390,15 @@ private:
 
    std::uint64_t fNEntries = 0; ///< Updated by the descriptor builder when the cluster summaries are added
 
+   /**
+    * Once constructed by an RNTupleDescriptorBuilder, the descriptor is mostly immutable except for set of
+    * active the page locations.  During the lifetime of the descriptor, page location information for clusters
+    * can be added or removed.  When this happens, the generation should be increased, so that users of the
+    * descriptor know that the information changed.  The generation is increased, e.g., by the page source's
+    * exclusive lock guard around the descriptor.  It is used, e.g., by the descriptor cache in RNTupleReader.
+    */
+   std::uint64_t fGeneration = 0;
+
    std::unordered_map<DescriptorId_t, RFieldDescriptor> fFieldDescriptors;
    std::unordered_map<DescriptorId_t, RColumnDescriptor> fColumnDescriptors;
    std::unordered_map<DescriptorId_t, RClusterGroupDescriptor> fClusterGroupDescriptors;
@@ -612,6 +621,9 @@ public:
 
    std::uint64_t GetOnDiskHeaderSize() const { return fOnDiskHeaderSize; }
    std::uint64_t GetOnDiskFooterSize() const { return fOnDiskFooterSize; }
+
+   std::uint64_t GetGeneration() const { return fGeneration; }
+   void IncGeneration() { fGeneration++; }
 
    const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const {
       return fFieldDescriptors.at(fieldId);

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -291,6 +291,8 @@ public:
    RClusterDescriptor(RClusterDescriptor &&other) = default;
    RClusterDescriptor &operator =(RClusterDescriptor &&other) = default;
 
+   RClusterDescriptor Clone() const;
+
    bool operator==(const RClusterDescriptor &other) const;
 
    DescriptorId_t GetId() const { return fClusterId; }
@@ -342,6 +344,8 @@ public:
    RClusterGroupDescriptor &operator=(const RClusterGroupDescriptor &other) = delete;
    RClusterGroupDescriptor(RClusterGroupDescriptor &&other) = default;
    RClusterGroupDescriptor &operator=(RClusterGroupDescriptor &&other) = default;
+
+   RClusterGroupDescriptor Clone() const;
 
    bool operator==(const RClusterGroupDescriptor &other) const;
 
@@ -617,13 +621,12 @@ public:
    RNTupleDescriptor(RNTupleDescriptor &&other) = default;
    RNTupleDescriptor &operator=(RNTupleDescriptor &&other) = default;
 
+   std::unique_ptr<RNTupleDescriptor> Clone() const;
+
    bool operator ==(const RNTupleDescriptor &other) const;
 
    std::uint64_t GetOnDiskHeaderSize() const { return fOnDiskHeaderSize; }
    std::uint64_t GetOnDiskFooterSize() const { return fOnDiskFooterSize; }
-
-   std::uint64_t GetGeneration() const { return fGeneration; }
-   void IncGeneration() { fGeneration++; }
 
    const RFieldDescriptor& GetFieldDescriptor(DescriptorId_t fieldId) const {
       return fFieldDescriptors.at(fieldId);
@@ -710,6 +713,9 @@ public:
    /// Methods to load and drop cluster details
    RResult<void> AddClusterDetails(RClusterDescriptor &&clusterDesc);
    RResult<void> DropClusterDetails(DescriptorId_t clusterId);
+
+   std::uint64_t GetGeneration() const { return fGeneration; }
+   void IncGeneration() { fGeneration++; }
 
    /// Re-create the C++ model from the stored meta-data
    std::unique_ptr<RNTupleModel> GenerateModel() const;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleDescriptor.hxx
@@ -234,10 +234,11 @@ public:
       };
       struct RPageInfoExtended : RPageInfo {
          /// Index (in cluster) of the first element in page.
-         RClusterSize::ValueType fFirstInPage;
+         RClusterSize::ValueType fFirstInPage = 0;
          /// Page number in the corresponding RPageRange.
-         NTupleSize_t fPageNo;
+         NTupleSize_t fPageNo = 0;
 
+         RPageInfoExtended() = default;
          RPageInfoExtended(const RPageInfo &pi, RClusterSize::ValueType i, NTupleSize_t n)
             : RPageInfo(pi), fFirstInPage(i), fPageNo(n) {}
       };

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -161,14 +161,15 @@ private:
    Detail::RFieldValue fValue;
 
 public:
-
-   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource* pageSource)
-     : fField(pageSource->GetDescriptor().GetFieldDescriptor(fieldId).GetFieldName()), fValue(fField.GenerateValue())
+   RNTupleView(DescriptorId_t fieldId, Detail::RPageSource *pageSource)
+      : fField(pageSource->GetSharedDescriptorGuard()->GetFieldDescriptor(fieldId).GetFieldName()),
+        fValue(fField.GenerateValue())
    {
       fField.SetOnDiskId(fieldId);
       fField.ConnectPageSource(*pageSource);
       for (auto &f : fField) {
-         auto subFieldId = pageSource->GetDescriptor().FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId());
+         auto subFieldId =
+            pageSource->GetSharedDescriptorGuard()->FindFieldId(f.GetName(), f.GetParent()->GetOnDiskId());
          f.SetOnDiskId(subFieldId);
          f.ConnectPageSource(*pageSource);
       }
@@ -263,21 +264,19 @@ public:
    /// Raises an exception if there is no field with the given name.
    template <typename T>
    RNTupleView<T> GetView(std::string_view fieldName) {
-      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);
+      auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName, fCollectionFieldId);
       if (fieldId == kInvalidDescriptorId) {
-         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
-            + fSource->GetDescriptor().GetName() + "'"
-         ));
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
+                                  fSource->GetSharedDescriptorGuard()->GetName() + "'"));
       }
       return RNTupleView<T>(fieldId, fSource);
    }
    /// Raises an exception if there is no field with the given name.
    RNTupleViewCollection GetViewCollection(std::string_view fieldName) {
-      auto fieldId = fSource->GetDescriptor().FindFieldId(fieldName, fCollectionFieldId);
+      auto fieldId = fSource->GetSharedDescriptorGuard()->FindFieldId(fieldName, fCollectionFieldId);
       if (fieldId == kInvalidDescriptorId) {
-         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '"
-            + fSource->GetDescriptor().GetName() + "'"
-         ));
+         throw RException(R__FAIL("no field named '" + std::string(fieldName) + "' in RNTuple '" +
+                                  fSource->GetSharedDescriptorGuard()->GetName() + "'"));
       }
       return RNTupleViewCollection(fieldId, fSource);
    }

--- a/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSourceFriends.hxx
@@ -80,10 +80,8 @@ private:
    RNTupleDescriptorBuilder fBuilder;
    DescriptorId_t fNextId = 1;  ///< 0 is reserved for the friend zero field
 
-   void AddVirtualField(std::size_t originIdx,
-                        const RFieldDescriptor &originField,
-                        DescriptorId_t virtualParent,
-                        const std::string &virtualName);
+   void AddVirtualField(const RNTupleDescriptor &originDesc, std::size_t originIdx, const RFieldDescriptor &originField,
+                        DescriptorId_t virtualParent, const std::string &virtualName);
 
 protected:
    RNTupleDescriptor AttachImpl() final;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -404,7 +404,7 @@ public:
    void DropColumn(ColumnHandle_t columnHandle) override;
 
    /// Open the physical storage container for the tree
-   void Attach() { fDescriptor = AttachImpl(); }
+   void Attach() { GetExclDescriptorGuard().MoveIn(AttachImpl()); }
    NTupleSize_t GetNEntries();
    NTupleSize_t GetNElements(ColumnHandle_t columnHandle);
    ColumnId_t GetColumnId(ColumnHandle_t columnHandle);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -317,7 +317,7 @@ public:
          fLock.unlock();
       }
       RNTupleDescriptor *operator->() const { return &fDescriptor; }
-      RNTupleDescriptor *operator*() const { return &fDescriptor; }
+      void MoveIn(RNTupleDescriptor &&desc) { fDescriptor = std::move(desc); }
    };
 
 protected:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -294,6 +294,7 @@ public:
       RSharedDescriptorGuard &operator=(RSharedDescriptorGuard &&) = delete;
       ~RSharedDescriptorGuard() { fLock.unlock_shared(); }
       const RNTupleDescriptor *operator->() const { return &fDescriptor; }
+      const RNTupleDescriptor &GetRef() const { return fDescriptor; }
    };
 
    /// An RAII wrapper used for the writable access to RPageSource::fDescriptor
@@ -390,12 +391,13 @@ public:
    virtual std::unique_ptr<RPageSource> Clone() const = 0;
 
    EPageStorageType GetType() final { return EPageStorageType::kSource; }
+   const RNTupleReadOptions &GetReadOptions() const { return fOptions; }
+
    const RSharedDescriptorGuard GetSharedDescriptorGuard() const
    {
       return RSharedDescriptorGuard(fDescriptor, fDescriptorLock);
    }
-   const RNTupleDescriptor &GetDescriptor() const { return fDescriptor; }
-   const RNTupleReadOptions &GetReadOptions() const { return fOptions; }
+
    ColumnHandle_t AddColumn(DescriptorId_t fieldId, const RColumn &column) override;
    void DropColumn(ColumnHandle_t columnHandle) override;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -310,8 +310,13 @@ public:
       RExclDescriptorGuard &operator=(const RExclDescriptorGuard &) = delete;
       RExclDescriptorGuard(RExclDescriptorGuard &&) = delete;
       RExclDescriptorGuard &operator=(RExclDescriptorGuard &&) = delete;
-      ~RExclDescriptorGuard() { fLock.unlock(); }
+      ~RExclDescriptorGuard()
+      {
+         fDescriptor.IncGeneration();
+         fLock.unlock();
+      }
       RNTupleDescriptor *operator->() const { return &fDescriptor; }
+      RNTupleDescriptor *operator*() const { return &fDescriptor; }
    };
 
 protected:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -320,6 +320,10 @@ public:
       void MoveIn(RNTupleDescriptor &&desc) { fDescriptor = std::move(desc); }
    };
 
+private:
+   RNTupleDescriptor fDescriptor;
+   mutable std::shared_mutex fDescriptorLock;
+
 protected:
    /// Default I/O performance counters that get registered in fMetrics
    struct RCounters {
@@ -346,8 +350,6 @@ protected:
    RNTupleMetrics fMetrics;
 
    RNTupleReadOptions fOptions;
-   RNTupleDescriptor fDescriptor;
-   mutable std::shared_mutex fDescriptorLock;
    /// The active columns are implicitly defined by the model fields or views
    RCluster::ColumnSet_t fActiveColumns;
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -150,6 +150,16 @@ public:
 // clang-format on
 class RPageSourceDaos : public RPageSource {
 private:
+   /// Summarizes cluster-level information that are necessary to populate a certain page.
+   /// Used by PopulatePageFromCluster().
+   struct RClusterInfo {
+      DescriptorId_t fClusterId = 0;
+      /// Location of the page on disk
+      RClusterDescriptor::RPageRange::RPageInfoExtended fPageInfo;
+      /// The first element number of the page's column in the given cluster
+      std::uint64_t fColumnOffset = 0;
+   };
+
    /// Populated pages might be shared; the memory buffer is managed by the RPageAllocatorDaos
    std::unique_ptr<RPageAllocatorDaos> fPageAllocator;
    // TODO: the page pool should probably be handled by the base class.
@@ -164,7 +174,7 @@ private:
    /// The cluster pool asynchronously preloads the next few clusters
    std::unique_ptr<RClusterPool> fClusterPool;
 
-   RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
+   RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,
                                  ClusterSize_t::ValueType idxInCluster);
 
 protected:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -113,6 +113,16 @@ public:
 // clang-format on
 class RPageSourceFile : public RPageSource {
 private:
+   /// Summarizes cluster-level information that are necessary to populate a certain page.
+   /// Used by PopulatePageFromCluster().
+   struct RClusterInfo {
+      DescriptorId_t fClusterId = 0;
+      /// Location of the page on disk
+      RClusterDescriptor::RPageRange::RPageInfoExtended fPageInfo;
+      /// The first element number of the page's column in the given cluster
+      std::uint64_t fColumnOffset = 0;
+   };
+
    /// Populated pages might be shared; there memory buffer is managed by the RPageAllocatorFile
    std::unique_ptr<RPageAllocatorFile> fPageAllocator;
    /// The page pool might, at some point, be used by multiple page sources
@@ -127,7 +137,7 @@ private:
    std::unique_ptr<RClusterPool> fClusterPool;
 
    RPageSourceFile(std::string_view ntupleName, const RNTupleReadOptions &options);
-   RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterDescriptor &clusterDescriptor,
+   RPage PopulatePageFromCluster(ColumnHandle_t columnHandle, const RClusterInfo &clusterInfo,
                                  ClusterSize_t::ValueType idxInCluster);
 
    /// Helper function for LoadClusters: it prepares the memory buffer (page map) and the

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -112,10 +112,6 @@ public:
 */
 // clang-format on
 class RPageSourceFile : public RPageSource {
-public:
-   /// Cannot process pages larger than 1MB
-   static constexpr std::size_t kMaxPageSize = 1024 * 1024;
-
 private:
    /// Populated pages might be shared; there memory buffer is managed by the RPageAllocatorFile
    std::unique_ptr<RPageAllocatorFile> fPageAllocator;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageFile.hxx
@@ -154,8 +154,8 @@ public:
 
    RPageSourceFile(const RPageSourceFile&) = delete;
    RPageSourceFile& operator=(const RPageSourceFile&) = delete;
-   RPageSourceFile(RPageSourceFile&&) = default;
-   RPageSourceFile& operator=(RPageSourceFile&&) = default;
+   RPageSourceFile(RPageSourceFile &&) = delete;
+   RPageSourceFile &operator=(RPageSourceFile &&) = delete;
    virtual ~RPageSourceFile();
 
    RPage PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex) final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -353,7 +353,10 @@ void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSource(RPageSource &pageSource)
 {
    R__ASSERT(fColumns.empty());
-   GenerateColumnsImpl(pageSource.GetDescriptor());
+   {
+      const auto descriptorGuard = pageSource.GetSharedDescriptorGuard();
+      GenerateColumnsImpl(descriptorGuard.GetRef());
+   }
    if (!fColumns.empty())
       fPrincipalColumn = fColumns[0].get();
    for (auto& column : fColumns)

--- a/tree/ntuple/v7/src/RNTuple.cxx
+++ b/tree/ntuple/v7/src/RNTuple.cxx
@@ -268,6 +268,13 @@ void ROOT::Experimental::RNTupleReader::Show(NTupleSize_t index, const ENTupleSh
    }
 }
 
+const ROOT::Experimental::RNTupleDescriptor *ROOT::Experimental::RNTupleReader::GetDescriptor()
+{
+   auto descriptorGuard = fSource->GetSharedDescriptorGuard();
+   if (!fCachedDescriptor || fCachedDescriptor->GetGeneration() != descriptorGuard->GetGeneration())
+      fCachedDescriptor = descriptorGuard->Clone();
+   return fCachedDescriptor.get();
+}
 
 //------------------------------------------------------------------------------
 

--- a/tree/ntuple/v7/src/RNTupleDescriptor.cxx
+++ b/tree/ntuple/v7/src/RNTupleDescriptor.cxx
@@ -178,15 +178,28 @@ void ROOT::Experimental::RClusterDescriptor::EnsureHasPageLocations() const
       throw RException(R__FAIL("invalid attempt to access page locations of summary-only cluster descriptor"));
 }
 
+ROOT::Experimental::RClusterDescriptor ROOT::Experimental::RClusterDescriptor::Clone() const
+{
+   RClusterDescriptor clone;
+   clone.fClusterId = fClusterId;
+   clone.fFirstEntryIndex = fFirstEntryIndex;
+   clone.fNEntries = fNEntries;
+   clone.fHasPageLocations = fHasPageLocations;
+   clone.fColumnRanges = fColumnRanges;
+   for (const auto &d : fPageRanges)
+      clone.fPageRanges.emplace(d.first, d.second.Clone());
+   return clone;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 
 bool ROOT::Experimental::RNTupleDescriptor::operator==(const RNTupleDescriptor &other) const
 {
-   return fName == other.fName &&
-          fDescription == other.fDescription &&
-          fFieldDescriptors == other.fFieldDescriptors &&
+   return fName == other.fName && fDescription == other.fDescription && fNEntries == other.fNEntries &&
+          fGeneration == other.fGeneration && fFieldDescriptors == other.fFieldDescriptors &&
           fColumnDescriptors == other.fColumnDescriptors &&
+          fClusterGroupDescriptors == other.fClusterGroupDescriptors &&
           fClusterDescriptors == other.fClusterDescriptors;
 }
 
@@ -337,6 +350,25 @@ std::unique_ptr<ROOT::Experimental::RNTupleModel> ROOT::Experimental::RNTupleDes
    return model;
 }
 
+std::unique_ptr<ROOT::Experimental::RNTupleDescriptor> ROOT::Experimental::RNTupleDescriptor::Clone() const
+{
+   auto clone = std::make_unique<RNTupleDescriptor>();
+   clone->fName = fName;
+   clone->fDescription = fDescription;
+   clone->fOnDiskHeaderSize = fOnDiskHeaderSize;
+   clone->fOnDiskFooterSize = fOnDiskFooterSize;
+   clone->fNEntries = fNEntries;
+   clone->fGeneration = fGeneration;
+   for (const auto &d : fFieldDescriptors)
+      clone->fFieldDescriptors.emplace(d.first, d.second.Clone());
+   for (const auto &d : fColumnDescriptors)
+      clone->fColumnDescriptors.emplace(d.first, d.second.Clone());
+   for (const auto &d : fClusterGroupDescriptors)
+      clone->fClusterGroupDescriptors.emplace(d.first, d.second.Clone());
+   for (const auto &d : fClusterDescriptors)
+      clone->fClusterDescriptors.emplace(d.first, d.second.Clone());
+   return clone;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -350,6 +382,16 @@ bool ROOT::Experimental::RColumnGroupDescriptor::operator==(const RColumnGroupDe
 bool ROOT::Experimental::RClusterGroupDescriptor::operator==(const RClusterGroupDescriptor &other) const
 {
    return fClusterGroupId == other.fClusterGroupId && fClusterIds == other.fClusterIds;
+}
+
+ROOT::Experimental::RClusterGroupDescriptor ROOT::Experimental::RClusterGroupDescriptor::Clone() const
+{
+   RClusterGroupDescriptor clone;
+   clone.fClusterGroupId = fClusterGroupId;
+   clone.fClusterIds = fClusterIds;
+   clone.fPageListLocator = fPageListLocator;
+   clone.fPageListLength = fPageListLength;
+   return clone;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -78,7 +78,7 @@ ROOT::Experimental::Detail::RPageStorage::ColumnHandle_t
 ROOT::Experimental::Detail::RPageSource::AddColumn(DescriptorId_t fieldId, const RColumn &column)
 {
    R__ASSERT(fieldId != kInvalidDescriptorId);
-   auto columnId = fDescriptor.FindColumnId(fieldId, column.GetIndex());
+   auto columnId = GetSharedDescriptorGuard()->FindColumnId(fieldId, column.GetIndex());
    R__ASSERT(columnId != kInvalidDescriptorId);
    fActiveColumns.emplace(columnId);
    return ColumnHandle_t{columnId, &column};
@@ -91,12 +91,12 @@ void ROOT::Experimental::Detail::RPageSource::DropColumn(ColumnHandle_t columnHa
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNEntries()
 {
-   return fDescriptor.GetNEntries();
+   return GetSharedDescriptorGuard()->GetNEntries();
 }
 
 ROOT::Experimental::NTupleSize_t ROOT::Experimental::Detail::RPageSource::GetNElements(ColumnHandle_t columnHandle)
 {
-   return fDescriptor.GetNElements(columnHandle.fId);
+   return GetSharedDescriptorGuard()->GetNElements(columnHandle.fId);
 }
 
 ROOT::Experimental::ColumnId_t ROOT::Experimental::Detail::RPageSource::GetColumnId(ColumnHandle_t columnHandle)

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -375,9 +375,13 @@ void ROOT::Experimental::Detail::RPageSourceDaos::LoadSealedPage(
    DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage)
 {
    const auto clusterId = clusterIndex.GetClusterId();
-   const auto &clusterDescriptor = fDescriptor.GetClusterDescriptor(clusterId);
 
-   auto pageInfo = clusterDescriptor.GetPageRange(columnId).Find(clusterIndex.GetIndex());
+   RClusterDescriptor::RPageRange::RPageInfo pageInfo;
+   {
+      auto descriptorGuard = GetSharedDescriptorGuard();
+      const auto &clusterDescriptor = descriptorGuard->GetClusterDescriptor(clusterId);
+      pageInfo = clusterDescriptor.GetPageRange(columnId).Find(clusterIndex.GetIndex());
+   }
 
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
    sealedPage.fSize = bytesOnStorage;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -405,20 +405,23 @@ ROOT::Experimental::Detail::RPageSourceFile::PrepareSingleCluster(
       std::size_t fBufPos = 0;
    };
 
-   const auto &clusterDesc = GetDescriptor().GetClusterDescriptor(clusterKey.fClusterId);
-
-   // Collect the page necessary page meta-data and sum up the total size of the compressed and packed pages
    std::vector<ROnDiskPageLocator> onDiskPages;
    auto activeSize = 0;
-   for (auto columnId : clusterKey.fColumnSet) {
-      const auto &pageRange = clusterDesc.GetPageRange(columnId);
-      NTupleSize_t pageNo = 0;
-      for (const auto &pageInfo : pageRange.fPageInfos) {
-         const auto &pageLocator = pageInfo.fLocator;
-         activeSize += pageLocator.fBytesOnStorage;
-         onDiskPages.push_back(
-            {columnId, pageNo, std::uint64_t(pageLocator.fPosition), pageLocator.fBytesOnStorage, 0});
-         ++pageNo;
+   {
+      auto descriptorGuard = GetSharedDescriptorGuard();
+      const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterKey.fClusterId);
+
+      // Collect the page necessary page meta-data and sum up the total size of the compressed and packed pages
+      for (auto columnId : clusterKey.fColumnSet) {
+         const auto &pageRange = clusterDesc.GetPageRange(columnId);
+         NTupleSize_t pageNo = 0;
+         for (const auto &pageInfo : pageRange.fPageInfos) {
+            const auto &pageLocator = pageInfo.fLocator;
+            activeSize += pageLocator.fBytesOnStorage;
+            onDiskPages.push_back(
+               {columnId, pageNo, std::uint64_t(pageLocator.fPosition), pageLocator.fBytesOnStorage, 0});
+            ++pageNo;
+         }
       }
    }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -236,7 +236,7 @@ TEST(RNTuple, ClusterEntries)
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    // 100 entries / 5 entries per cluster
-   EXPECT_EQ(20, ntuple->GetDescriptor().GetNClusters());
+   EXPECT_EQ(20, ntuple->GetDescriptor()->GetNClusters());
 }
 
 TEST(RNTuple, PageSize)
@@ -257,7 +257,7 @@ TEST(RNTuple, PageSize)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto &col0_pages = ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(0);
+   const auto &col0_pages = ntuple->GetDescriptor()->GetClusterDescriptor(0).GetPageRange(0);
    // 1000 column elements / 50 elements per page
    EXPECT_EQ(20, col0_pages.fPageInfos.size());
 }
@@ -338,7 +338,7 @@ TEST(RNTupleModel, FieldDescriptions)
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    std::vector<std::string> fieldDescriptions;
-   for (auto& f: ntuple->GetDescriptor().GetTopLevelFields()) {
+   for (auto &f : ntuple->GetDescriptor()->GetTopLevelFields()) {
       fieldDescriptions.push_back(f.GetFieldDescription());
    }
    ASSERT_EQ(3, fieldDescriptions.size());
@@ -360,7 +360,7 @@ TEST(RNTupleModel, CollectionFieldDescriptions)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto& muon_desc = *ntuple->GetDescriptor().GetTopLevelFields().begin();
+   const auto &muon_desc = *ntuple->GetDescriptor()->GetTopLevelFields().begin();
    EXPECT_EQ(std::string("muons after basic selection"), muon_desc.GetFieldDescription());
 }
 

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -21,7 +21,7 @@ TEST(RNTuple, ReconstructModel)
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
 
-   auto modelReconstructed = source.GetDescriptor().GenerateModel();
+   auto modelReconstructed = source.GetSharedDescriptorGuard()->GenerateModel();
    try {
       modelReconstructed->GetDefaultEntry()->Get<float>("xyz");
       FAIL() << "invalid field name should throw";

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -61,9 +61,10 @@ public:
       for (unsigned i = 0; i <= 5; ++i) {
          descBuilder.AddClusterSummary(i, i, 1);
       }
-      fDescriptor = descBuilder.MoveDescriptor();
+      auto descriptorGuard = GetExclDescriptorGuard();
+      descriptorGuard.MoveIn(descBuilder.MoveDescriptor());
       for (unsigned i = 0; i <= 5; ++i) {
-         fDescriptor.AddClusterDetails(
+         descriptorGuard->AddClusterDetails(
             ROOT::Experimental::RClusterDescriptorBuilder(i, i, 1).MoveDescriptor().Unwrap());
       }
    }

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -300,9 +300,11 @@ TEST(PageStorageFile, LoadClusters)
       "myNTuple", fileGuard.GetPath(), ROOT::Experimental::RNTupleReadOptions());
    source.Attach();
 
-   auto ptId = source.GetDescriptor().FindFieldId("pt");
+   auto descriptorGuard = source.GetSharedDescriptorGuard();
+
+   auto ptId = descriptorGuard->FindFieldId("pt");
    EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, ptId);
-   auto colId = source.GetDescriptor().FindColumnId(ptId, 0);
+   auto colId = descriptorGuard->FindColumnId(ptId, 0);
    EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, colId);
 
    std::vector<ROOT::Experimental::Detail::RCluster::RKey> clusterKeys;

--- a/tree/ntuple/v7/test/ntuple_cluster.cxx
+++ b/tree/ntuple/v7/test/ntuple_cluster.cxx
@@ -300,12 +300,15 @@ TEST(PageStorageFile, LoadClusters)
       "myNTuple", fileGuard.GetPath(), ROOT::Experimental::RNTupleReadOptions());
    source.Attach();
 
-   auto descriptorGuard = source.GetSharedDescriptorGuard();
-
-   auto ptId = descriptorGuard->FindFieldId("pt");
-   EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, ptId);
-   auto colId = descriptorGuard->FindColumnId(ptId, 0);
-   EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, colId);
+   ROOT::Experimental::DescriptorId_t ptId;
+   ROOT::Experimental::DescriptorId_t colId;
+   {
+      auto descriptorGuard = source.GetSharedDescriptorGuard();
+      ptId = descriptorGuard->FindFieldId("pt");
+      EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, ptId);
+      colId = descriptorGuard->FindColumnId(ptId, 0);
+      EXPECT_NE(ROOT::Experimental::kInvalidDescriptorId, colId);
+   }
 
    std::vector<ROOT::Experimental::Detail::RCluster::RKey> clusterKeys;
    clusterKeys.push_back({0, {}});

--- a/tree/ntuple/v7/test/ntuple_descriptor.cxx
+++ b/tree/ntuple/v7/test/ntuple_descriptor.cxx
@@ -94,14 +94,14 @@ TEST(RNTupleDescriptor, QualifiedFieldName)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto &desc = ntuple->GetDescriptor();
-   EXPECT_TRUE(desc.GetQualifiedFieldName(desc.GetFieldZeroId()).empty());
-   auto fldIdInts = desc.FindFieldId("ints");
-   EXPECT_STREQ("ints", desc.GetQualifiedFieldName(fldIdInts).c_str());
-   auto fldIdJets = desc.FindFieldId("jets");
-   auto fldIdInner = desc.FindFieldId("_0", fldIdJets);
-   EXPECT_STREQ("jets", desc.GetQualifiedFieldName(fldIdJets).c_str());
-   EXPECT_STREQ("jets._0", desc.GetQualifiedFieldName(fldIdInner).c_str());
+   const auto desc = ntuple->GetDescriptor();
+   EXPECT_TRUE(desc->GetQualifiedFieldName(desc->GetFieldZeroId()).empty());
+   auto fldIdInts = desc->FindFieldId("ints");
+   EXPECT_STREQ("ints", desc->GetQualifiedFieldName(fldIdInts).c_str());
+   auto fldIdJets = desc->FindFieldId("jets");
+   auto fldIdInner = desc->FindFieldId("_0", fldIdJets);
+   EXPECT_STREQ("jets", desc->GetQualifiedFieldName(fldIdJets).c_str());
+   EXPECT_STREQ("jets._0", desc->GetQualifiedFieldName(fldIdInner).c_str());
 }
 
 TEST(RFieldDescriptorIterable, IterateOverFieldNames)
@@ -122,7 +122,7 @@ TEST(RFieldDescriptorIterable, IterateOverFieldNames)
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    // iterate over top-level fields
    std::vector<std::string> names{};
-   for (auto& f: ntuple->GetDescriptor().GetTopLevelFields()) {
+   for (auto &f : ntuple->GetDescriptor()->GetTopLevelFields()) {
       names.push_back(f.GetFieldName());
    }
    ASSERT_EQ(names.size(), 4);
@@ -131,18 +131,18 @@ TEST(RFieldDescriptorIterable, IterateOverFieldNames)
    EXPECT_EQ(names[2], std::string("bool_vec_vec"));
    EXPECT_EQ(names[3], std::string("ints"));
 
-   const auto& ntuple_desc = ntuple->GetDescriptor();
-   auto top_level_fields = ntuple_desc.GetTopLevelFields();
+   const auto ntuple_desc = ntuple->GetDescriptor();
+   auto top_level_fields = ntuple_desc->GetTopLevelFields();
 
    // iterate over child field ranges
    const auto& float_vec_desc = *top_level_fields.begin();
    EXPECT_EQ(float_vec_desc.GetFieldName(), std::string("jets"));
-   auto float_vec_child_range = ntuple_desc.GetFieldIterable(float_vec_desc);
+   auto float_vec_child_range = ntuple_desc->GetFieldIterable(float_vec_desc);
    std::vector<std::string> child_names{};
    for (auto& child_field: float_vec_child_range) {
       child_names.push_back(child_field.GetFieldName());
       // check the empty range
-      auto float_child_range = ntuple_desc.GetFieldIterable(child_field);
+      auto float_child_range = ntuple_desc->GetFieldIterable(child_field);
       EXPECT_EQ(float_child_range.begin(), float_child_range.end());
    }
    ASSERT_EQ(child_names.size(), 1);
@@ -155,7 +155,7 @@ TEST(RFieldDescriptorIterable, IterateOverFieldNames)
    EXPECT_EQ(bool_vec_vec_desc.GetFieldName(), std::string("bool_vec_vec"));
 
    child_names.clear();
-   for (auto& child_field: ntuple_desc.GetFieldIterable(bool_vec_vec_desc)) {
+   for (auto &child_field : ntuple_desc->GetFieldIterable(bool_vec_vec_desc)) {
       child_names.push_back(child_field.GetFieldName());
    }
    ASSERT_EQ(child_names.size(), 1);
@@ -178,14 +178,13 @@ TEST(RFieldDescriptorIterable, SortByLambda)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto& ntuple_desc = ntuple->GetDescriptor();
+   const auto ntuple_desc = ntuple->GetDescriptor();
    auto alpha_order = [&](auto lhs, auto rhs) {
-      return ntuple_desc.GetFieldDescriptor(lhs).GetFieldName()
-         < ntuple_desc.GetFieldDescriptor(rhs).GetFieldName();
+      return ntuple_desc->GetFieldDescriptor(lhs).GetFieldName() < ntuple_desc->GetFieldDescriptor(rhs).GetFieldName();
    };
 
    std::vector<std::string> sorted_names = {};
-   for (auto& f: ntuple_desc.GetTopLevelFields(alpha_order)) {
+   for (auto &f : ntuple_desc->GetTopLevelFields(alpha_order)) {
       sorted_names.push_back(f.GetFieldName());
    }
    ASSERT_EQ(sorted_names.size(), 4);
@@ -196,9 +195,7 @@ TEST(RFieldDescriptorIterable, SortByLambda)
 
    // reverse alphabetical
    sorted_names.clear();
-   for (auto& f: ntuple_desc.GetTopLevelFields(
-      [&](auto lhs, auto rhs) { return !alpha_order(lhs, rhs); }))
-   {
+   for (auto &f : ntuple_desc->GetTopLevelFields([&](auto lhs, auto rhs) { return !alpha_order(lhs, rhs); })) {
       sorted_names.push_back(f.GetFieldName());
    }
    ASSERT_EQ(sorted_names.size(), 4);
@@ -209,11 +206,10 @@ TEST(RFieldDescriptorIterable, SortByLambda)
 
    // alphabetical by type name
    std::vector<std::string> sorted_by_typename = {};
-   for (auto& f: ntuple_desc.GetTopLevelFields(
-      [&](auto lhs, auto rhs) {
-         return ntuple_desc.GetFieldDescriptor(lhs).GetTypeName()
-            < ntuple_desc.GetFieldDescriptor(rhs).GetTypeName(); }))
-   {
+   for (auto &f : ntuple_desc->GetTopLevelFields([&](auto lhs, auto rhs) {
+           return ntuple_desc->GetFieldDescriptor(lhs).GetTypeName() <
+                  ntuple_desc->GetFieldDescriptor(rhs).GetTypeName();
+        })) {
       sorted_by_typename.push_back(f.GetFieldName());
    }
    // int32_t, vector<bool>, vector<float>, vector<vector<bool>
@@ -239,26 +235,26 @@ TEST(RColumnDescriptorIterable, IterateOverColumns)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto &desc = ntuple->GetDescriptor();
+   const auto desc = ntuple->GetDescriptor();
 
    // No column attached to the zero field
    unsigned int counter = 0;
-   for (const auto &c : desc.GetColumnIterable(desc.GetFieldZeroId())) {
+   for (const auto &c : desc->GetColumnIterable(desc->GetFieldZeroId())) {
       (void)c;
       counter++;
    }
    EXPECT_EQ(0u, counter);
 
-   const auto tagId = desc.FindFieldId("tag");
-   for (const auto &c : desc.GetColumnIterable(tagId)) {
+   const auto tagId = desc->FindFieldId("tag");
+   for (const auto &c : desc->GetColumnIterable(tagId)) {
       EXPECT_EQ(tagId, c.GetFieldId());
       EXPECT_EQ(counter, c.GetIndex());
       counter++;
    }
    EXPECT_EQ(2, counter);
 
-   const auto jetsId = desc.FindFieldId("jets");
-   for (const auto &c : desc.GetColumnIterable(desc.FindFieldId("jets"))) {
+   const auto jetsId = desc->FindFieldId("jets");
+   for (const auto &c : desc->GetColumnIterable(desc->FindFieldId("jets"))) {
       EXPECT_EQ(jetsId, c.GetFieldId());
       counter++;
    }
@@ -284,11 +280,11 @@ TEST(RClusterDescriptor, GetBytesOnStorage)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto &desc = ntuple->GetDescriptor();
+   const auto desc = ntuple->GetDescriptor();
 
-   auto clusterID = desc.FindClusterId(0, 0);
+   auto clusterID = desc->FindClusterId(0, 0);
    ASSERT_NE(ROOT::Experimental::kInvalidDescriptorId, clusterID);
-   EXPECT_EQ(4 + 8 + 4 + 3, desc.GetClusterDescriptor(clusterID).GetBytesOnStorage());
+   EXPECT_EQ(4 + 8 + 4 + 3, desc->GetClusterDescriptor(clusterID).GetBytesOnStorage());
 }
 
 TEST(RNTupleDescriptor, Clone)
@@ -307,7 +303,7 @@ TEST(RNTupleDescriptor, Clone)
    }
 
    auto ntuple = RNTupleReader::Open("ntuple", fileGuard.GetPath());
-   const auto &desc = ntuple->GetDescriptor();
-   auto clone = desc.Clone();
-   EXPECT_EQ(desc, *clone);
+   const auto desc = ntuple->GetDescriptor();
+   auto clone = desc->Clone();
+   EXPECT_EQ(*desc, *clone);
 }

--- a/tree/ntuple/v7/test/ntuple_extended.cxx
+++ b/tree/ntuple/v7/test/ntuple_extended.cxx
@@ -93,7 +93,7 @@ TEST(RNTuple, RandomAccess)
    RNTupleReadOptions options;
    options.SetClusterCache(RNTupleReadOptions::EClusterCache::kOn);
    auto ntuple = RNTupleReader::Open("myNTuple", fileGuard.GetPath(), options);
-   EXPECT_EQ(10, ntuple->GetDescriptor().GetNClusters());
+   EXPECT_EQ(10, ntuple->GetDescriptor()->GetNClusters());
 
    auto viewValue = ntuple->GetView<std::int32_t>("value");
 

--- a/tree/ntuple/v7/test/ntuple_friends.cxx
+++ b/tree/ntuple/v7/test/ntuple_friends.cxx
@@ -29,9 +29,9 @@ TEST(RPageStorageFriends, Empty)
    EXPECT_EQ(0u, reader->GetModel()->GetFieldZero()->GetOnDiskId());
    EXPECT_EQ(0u, std::distance(reader->GetModel()->GetDefaultEntry()->begin(),
                                reader->GetModel()->GetDefaultEntry()->end()));
-   EXPECT_EQ(0u, reader->GetDescriptor().GetNColumns());
-   EXPECT_EQ(1u, reader->GetDescriptor().GetNFields()); // The zero field
-   EXPECT_EQ(0u, reader->GetDescriptor().GetNClusters());
+   EXPECT_EQ(0u, reader->GetDescriptor()->GetNColumns());
+   EXPECT_EQ(1u, reader->GetDescriptor()->GetNFields()); // The zero field
+   EXPECT_EQ(0u, reader->GetDescriptor()->GetNClusters());
 }
 
 

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -41,11 +41,11 @@ TEST(RPageStorage, ReadSealedPages)
 
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
-   auto descriptorGuard = source.GetSharedDescriptorGuard();
-   auto columnId = descriptorGuard->FindColumnId(descriptorGuard->FindFieldId("pt"), 0);
+   auto columnId =
+      source.GetSharedDescriptorGuard()->FindColumnId(source.GetSharedDescriptorGuard()->FindFieldId("pt"), 0);
 
    // Check first cluster consisting of a single entry
-   RClusterIndex index(descriptorGuard->FindClusterId(columnId, 0), 0);
+   RClusterIndex index(source.GetSharedDescriptorGuard()->FindClusterId(columnId, 0), 0);
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.fNElements);
@@ -58,9 +58,9 @@ TEST(RPageStorage, ReadSealedPages)
    EXPECT_EQ(42, ReadRawInt(sealedPage.fBuffer));
 
    // Check second, big cluster
-   auto clusterId = descriptorGuard->FindClusterId(columnId, 1);
+   auto clusterId = source.GetSharedDescriptorGuard()->FindClusterId(columnId, 1);
    ASSERT_NE(clusterId, index.GetClusterId());
-   const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterId);
+   const auto clusterDesc = source.GetSharedDescriptorGuard()->GetClusterDescriptor(clusterId).Clone();
    const auto &pageRange = clusterDesc.GetPageRange(columnId);
    EXPECT_GT(pageRange.fPageInfos.size(), 1U);
    std::uint32_t firstElementInPage = 0;

--- a/tree/ntuple/v7/test/ntuple_merger.cxx
+++ b/tree/ntuple/v7/test/ntuple_merger.cxx
@@ -41,11 +41,11 @@ TEST(RPageStorage, ReadSealedPages)
 
    RPageSourceFile source("myNTuple", fileGuard.GetPath(), RNTupleReadOptions());
    source.Attach();
-   const auto &descriptor = source.GetDescriptor();
-   auto columnId = descriptor.FindColumnId(descriptor.FindFieldId("pt"), 0);
+   auto descriptorGuard = source.GetSharedDescriptorGuard();
+   auto columnId = descriptorGuard->FindColumnId(descriptorGuard->FindFieldId("pt"), 0);
 
    // Check first cluster consisting of a single entry
-   RClusterIndex index(descriptor.FindClusterId(columnId, 0), 0);
+   RClusterIndex index(descriptorGuard->FindClusterId(columnId, 0), 0);
    RPageStorage::RSealedPage sealedPage;
    source.LoadSealedPage(columnId, index, sealedPage);
    ASSERT_EQ(1U, sealedPage.fNElements);
@@ -58,9 +58,9 @@ TEST(RPageStorage, ReadSealedPages)
    EXPECT_EQ(42, ReadRawInt(sealedPage.fBuffer));
 
    // Check second, big cluster
-   auto clusterId = descriptor.FindClusterId(columnId, 1);
+   auto clusterId = descriptorGuard->FindClusterId(columnId, 1);
    ASSERT_NE(clusterId, index.GetClusterId());
-   const auto &clusterDesc = descriptor.GetClusterDescriptor(clusterId);
+   const auto &clusterDesc = descriptorGuard->GetClusterDescriptor(clusterId);
    const auto &pageRange = clusterDesc.GetPageRange(columnId);
    EXPECT_GT(pageRange.fPageInfos.size(), 1U);
    std::uint32_t firstElementInPage = 0;

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -144,18 +144,18 @@ TEST(RNTuple, PageFilling) {
    for (std::int16_t i = 0; i < 8; ++i)
       EXPECT_EQ(i, viewX(i));
 
-   const auto &desc = ntuple->GetDescriptor();
-   EXPECT_EQ(3u, desc.GetNClusters());
-   const auto &cd1 = desc.GetClusterDescriptor(desc.FindClusterId(0, 0));
+   const auto desc = ntuple->GetDescriptor();
+   EXPECT_EQ(3u, desc->GetNClusters());
+   const auto &cd1 = desc->GetClusterDescriptor(desc->FindClusterId(0, 0));
    const auto &pr1 = cd1.GetPageRange(0);
    ASSERT_EQ(2u, pr1.fPageInfos.size());
    EXPECT_EQ(2u, pr1.fPageInfos[0].fNElements);
    EXPECT_EQ(1u, pr1.fPageInfos[1].fNElements);
-   const auto &cd2 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd1.GetId()));
+   const auto &cd2 = desc->GetClusterDescriptor(desc->FindNextClusterId(cd1.GetId()));
    const auto &pr2 = cd2.GetPageRange(0);
    ASSERT_EQ(1u, pr2.fPageInfos.size());
    EXPECT_EQ(2u, pr2.fPageInfos[0].fNElements);
-   const auto &cd3 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd2.GetId()));
+   const auto &cd3 = desc->GetClusterDescriptor(desc->FindNextClusterId(cd2.GetId()));
    const auto &pr3 = cd3.GetPageRange(0);
    ASSERT_EQ(2u, pr3.fPageInfos.size());
    EXPECT_EQ(2u, pr3.fPageInfos[0].fNElements);
@@ -199,20 +199,20 @@ TEST(RNTuple, PageFillingString) {
    EXPECT_EQ("",                         viewX(2));
    EXPECT_EQ("012345678901234567890123", viewX(3));
 
-   const auto &desc = ntuple->GetDescriptor();
-   EXPECT_EQ(4u, desc.GetNClusters());
-   const auto &cd1 = desc.GetClusterDescriptor(desc.FindClusterId(1, 0));
+   const auto desc = ntuple->GetDescriptor();
+   EXPECT_EQ(4u, desc->GetNClusters());
+   const auto &cd1 = desc->GetClusterDescriptor(desc->FindClusterId(1, 0));
    const auto &pr1 = cd1.GetPageRange(1);
    ASSERT_EQ(1u, pr1.fPageInfos.size());
    EXPECT_EQ(17u, pr1.fPageInfos[0].fNElements);
-   const auto &cd2 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd1.GetId()));
+   const auto &cd2 = desc->GetClusterDescriptor(desc->FindNextClusterId(cd1.GetId()));
    const auto &pr2 = cd2.GetPageRange(1);
    ASSERT_EQ(1u, pr2.fPageInfos.size());
    EXPECT_EQ(16u, pr2.fPageInfos[0].fNElements);
-   const auto &cd3 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd2.GetId()));
+   const auto &cd3 = desc->GetClusterDescriptor(desc->FindNextClusterId(cd2.GetId()));
    const auto &pr3 = cd3.GetPageRange(1);
    ASSERT_EQ(0u, pr3.fPageInfos.size());
-   const auto &cd4 = desc.GetClusterDescriptor(desc.FindNextClusterId(cd3.GetId()));
+   const auto &cd4 = desc->GetClusterDescriptor(desc->FindNextClusterId(cd3.GetId()));
    const auto &pr4 = cd4.GetPageRange(1);
    ASSERT_EQ(2u, pr4.fPageInfos.size());
    EXPECT_EQ(16u, pr4.fPageInfos[0].fNElements);
@@ -291,7 +291,7 @@ TEST(RPageSinkBuf, Basics)
 
    std::vector<std::pair<DescriptorId_t, std::int64_t>> pagePositions;
    std::size_t num_columns = 10;
-   const auto &cluster0 = ntupleBuf->GetDescriptor().GetClusterDescriptor(0);
+   const auto &cluster0 = ntupleBuf->GetDescriptor()->GetClusterDescriptor(0);
    for (std::size_t i = 0; i < num_columns; i++) {
       const auto &columnPages = cluster0.GetPageRange(i);
       for (const auto &page: columnPages.fPageInfos) {
@@ -378,8 +378,8 @@ TEST(RPageSink, Empty)
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
    EXPECT_EQ(0U, ntuple->GetNEntries());
-   EXPECT_EQ(0U, ntuple->GetDescriptor().GetNClusterGroups());
-   EXPECT_EQ(0U, ntuple->GetDescriptor().GetNClusters());
+   EXPECT_EQ(0U, ntuple->GetDescriptor()->GetNClusterGroups());
+   EXPECT_EQ(0U, ntuple->GetDescriptor()->GetNClusters());
 }
 
 TEST(RPageSink, MultipleClusterGroups)
@@ -404,8 +404,8 @@ TEST(RPageSink, MultipleClusterGroups)
    }
 
    auto ntuple = RNTupleReader::Open("f", fileGuard.GetPath());
-   EXPECT_EQ(2U, ntuple->GetDescriptor().GetNClusterGroups());
-   EXPECT_EQ(3U, ntuple->GetDescriptor().GetNClusters());
+   EXPECT_EQ(2U, ntuple->GetDescriptor()->GetNClusterGroups());
+   EXPECT_EQ(3U, ntuple->GetDescriptor()->GetNClusters());
    EXPECT_EQ(3U, ntuple->GetNEntries());
    auto rdPt = ntuple->GetModel()->GetDefaultEntry()->Get<float>("pt");
 

--- a/tree/ntuple/v7/test/rfield_string.cxx
+++ b/tree/ntuple/v7/test/rfield_string.cxx
@@ -21,9 +21,9 @@ TEST(RNTuple, ReadString)
 
    auto ntuple = RNTupleReader::Open(ntupleName, fileGuard.GetPath());
    auto viewSt = ntuple->GetView<std::string>("st");
-   if (ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(1).fPageInfos.size() < 2) {
+   if (ntuple->GetDescriptor()->GetClusterDescriptor(0).GetPageRange(1).fPageInfos.size() < 2) {
       FAIL(); // This means all entries are inside the same page and numEntries should be increased.
    }
-   int nElementsPerPage = ntuple->GetDescriptor().GetClusterDescriptor(0).GetPageRange(1).fPageInfos.at(1).fNElements;
+   int nElementsPerPage = ntuple->GetDescriptor()->GetClusterDescriptor(0).GetPageRange(1).fPageInfos.at(1).fNElements;
    EXPECT_EQ(contentString, viewSt(nElementsPerPage/7));
 }

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -54,11 +54,11 @@ TEST(RNTuple, InsideCollection)
    source->Attach();
    EXPECT_EQ(1U, source->GetNEntries());
 
-   auto idKlassVec = source->GetDescriptor().FindFieldId("klassVec");
+   auto idKlassVec = source->GetSharedDescriptorGuard()->FindFieldId("klassVec");
    ASSERT_NE(idKlassVec, ROOT::Experimental::kInvalidDescriptorId);
-   auto idKlass = source->GetDescriptor().FindFieldId("_0", idKlassVec);
+   auto idKlass = source->GetSharedDescriptorGuard()->FindFieldId("_0", idKlassVec);
    ASSERT_NE(idKlass, ROOT::Experimental::kInvalidDescriptorId);
-   auto idA = source->GetDescriptor().FindFieldId("a", idKlass);
+   auto idA = source->GetSharedDescriptorGuard()->FindFieldId("a", idKlass);
    ASSERT_NE(idA, ROOT::Experimental::kInvalidDescriptorId);
    auto fieldInner = std::unique_ptr<RFieldBase>(RFieldBase::Create("klassVec.a", "float").Unwrap());
    fieldInner->SetOnDiskId(idA);


### PR DESCRIPTION
In preparation of adding support for incremental loading page locations, the descriptor access in the page source needs to be locked. Currently, the descriptor is an immutable data structure. When page locations can be mapped in and out dynamically during the lifetime of an ntuple, the descriptor actually does change from time to time. This patch sets replaces direct descriptor access in the page source by a guarded access with a r/w lock. Read-only access is guarded by a shared lock, write access guarded by an exclusive lock.

A follow-up PR will change the page source API such that `Attach()` does not load any page locations but another call will be needed to load the page locations of a given cluster range or event range.