### PR TITLE
[hist] Fix axis computation for buffer histograms when data have infinities

### DIFF
--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -1426,10 +1426,12 @@ Int_t TH1::BufferEmpty(Int_t action)
    }
    if (CanExtendAllAxes() || (fXaxis.GetXmax() <= fXaxis.GetXmin())) {
       //find min, max of entries in buffer
-      Double_t xmin = fBuffer[2];
-      Double_t xmax = xmin;
-      for (Int_t i=1;i<nbentries;i++) {
+      Double_t xmin = TMath::Infinity();
+      Double_t xmax = -TMath::Infinity();
+      for (Int_t i=0;i<nbentries;i++) {
          Double_t x = fBuffer[2*i+2];
+         // skip infinity or NaN values
+         if (!std::isfinite(x)) continue;
          if (x < xmin) xmin = x;
          if (x > xmax) xmax = x;
       }


### PR DESCRIPTION
When the input data to fill an histogram contains infinity or Nan, the automatic axis computation does not work anymore. 
This PR fixes by excluding the non-finite data in the min/max computation.

This simple code shows the problem:
```
double x[] = {1.1,2.2,3.3,TMath::Infinity()};
auto h1 = new TH1D("h1","h1",10,1,0);
h1->FillN(4,x,nullptr);
h1->Draw();
```

and it works after applying this PR, with the infinity values appearing in the overflow bin. 

