### PR TITLE
[textinput] Clear undo buffer after taking an input line

### DIFF
--- a/core/textinput/src/textinput/Editor.cpp
+++ b/core/textinput/src/textinput/Editor.cpp
@@ -88,6 +88,7 @@ namespace textinput {
     fContext->SetCursor(0);
     ClearPasteBuf();
     fSearch.clear();
+    fUndoBuf.clear();
     CancelSpecialInputMode(R);
     if (fReplayHistEntry != (size_t) -1) {
       --fReplayHistEntry; // intentional overflow to -1


### PR DESCRIPTION
The undo buffer should only be kept for the current line (as in GNU readline).  This commit clears the undo buffer in `Editor::ResetText()`, which is called after reading an input line.

Fixes #10182.

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #10182.