### PR TITLE
[qt5web] add workaround for es6 modules [skip-ci] [6.26]

### DIFF
--- a/documentation/users-guide/WebDisplay.md
+++ b/documentation/users-guide/WebDisplay.md
@@ -95,15 +95,15 @@ The minimal HTML/JavaScript code, which establish connection with the server, lo
      <script>
        JSROOT.connectWebWindow({
           receiver: {
-              OnWebsocketOpened: function(handle) {
+              onWebsocketOpened: function(handle) {
                   console.log('Connected');
                   handle.Send("Init msg from client");
               },
-              OnWebsocketMsg: function(handle, msg) {
+              onWebsocketMsg: function(handle, msg) {
                   console.log('Get message ' + msg);
                   document.getElementById("main").innerHTML = msg;
               },
-              OnWebsocketClosed: function(handle) {
+              onWebsocketClosed: function(handle) {
                  // when connection closed, close panel as well
                  if (window) window.close();
               }

--- a/documentation/users-guide/WebDisplay.md
+++ b/documentation/users-guide/WebDisplay.md
@@ -97,7 +97,7 @@ The minimal HTML/JavaScript code, which establish connection with the server, lo
           receiver: {
               onWebsocketOpened: function(handle) {
                   console.log('Connected');
-                  handle.Send("Init msg from client");
+                  handle.send("Init msg from client");
               },
               onWebsocketMsg: function(handle, msg) {
                   console.log('Get message ' + msg);

--- a/gui/qt5webdisplay/rootqt5.cpp
+++ b/gui/qt5webdisplay/rootqt5.cpp
@@ -88,7 +88,9 @@ protected:
          // if (fHandler)
          //   QWebEngineProfile::defaultProfile()->removeUrlSchemeHandler(fHandler.get());
 
-         R__LOG_DEBUG(0, QtWebDisplayLog()) << "Deleting Qt5Creator";
+         // do not try to destroy objects during exit
+         fHandler.release();
+         fTimer.release();
       }
 
       std::unique_ptr<RWebDisplayHandle> Display(const RWebDisplayArgs &args) override

--- a/gui/qt5webdisplay/rooturlschemehandler.cpp
+++ b/gui/qt5webdisplay/rooturlschemehandler.cpp
@@ -15,6 +15,7 @@
 #include "rooturlschemehandler.h"
 
 #include "rootwebpage.h" // only because of logger channel
+#include <cstring>
 
 #include <QBuffer>
 #include <QByteArray>
@@ -98,6 +99,13 @@ public:
       buffer->open(QIODevice::WriteOnly);
       if (file.open(QIODevice::ReadOnly)) {
          QByteArray arr = file.readAll();
+         if (strstr(fname, ".mjs") && !strcmp(mime, "text/javascript")) {
+            const char *mark1 = "///_begin_exclude_in_qt5web_", *mark2 = "///_end_exclude_in_qt5web_";
+            auto p1 = arr.indexOf(mark1);
+            auto p2 = arr.indexOf(mark2);
+            if ((p1 > 0) && (p2 > p1)) arr.remove(p1, p2 - p1 + strlen(mark2));
+         }
+
          buffer->write(arr);
       }
       file.close();
@@ -109,6 +117,8 @@ public:
          buffer->connect(req, &QObject::destroyed, buffer, &QObject::deleteLater);
          req->reply(mime, buffer);
          fRequest.reset();
+      } else {
+         delete buffer;
       }
    }
 

--- a/tutorials/geom/webdemo.html
+++ b/tutorials/geom/webdemo.html
@@ -89,16 +89,16 @@
      JSROOT.connectWebWindow({
        receiver: {
           // method called when connection to server is established
-          OnWebsocketOpened: function(handle) {
+          onWebsocketOpened: function(handle) {
              conn_handle = handle;
           },
 
           // method with new message from server
-          OnWebsocketMsg: function(handle, msg, offset) {
+          onWebsocketMsg: function(handle, msg, offset) {
           },
 
           // method called when connection is gone
-          OnWebsocketClosed: function(handle) {
+          onWebsocketClosed: function(handle) {
              conn_handle = null;
              // when connection closed, close panel as well
              if (window) window.close();

--- a/tutorials/geom/webdemo.html
+++ b/tutorials/geom/webdemo.html
@@ -43,7 +43,7 @@
 
      function SendMsg(txt) {
        if (conn_handle)
-          conn_handle.Send(txt);
+          conn_handle.send(txt);
      }
 
      function AddButton(text, exec, title) {

--- a/tutorials/geom/webhelp.html
+++ b/tutorials/geom/webhelp.html
@@ -22,17 +22,17 @@
      JSROOT.connectWebWindow({
        receiver: {
           // method called when connection to server is established
-          OnWebsocketOpened: function(handle) {
+          onWebsocketOpened: function(handle) {
              conn_handle = handle;
           },
 
           // method with new message from server
-          OnWebsocketMsg: function(handle, msg, offset) {
+          onWebsocketMsg: function(handle, msg, offset) {
              document.body.innerHTML = msg;
           },
 
           // method called when connection is gone
-          OnWebsocketClosed: function(handle) {
+          onWebsocketClosed: function(handle) {
              conn_handle = null;
              // when connection closed, close panel as well
              if (window) window.close();

--- a/ui5/panel/panel.html
+++ b/ui5/panel/panel.html
@@ -47,10 +47,10 @@
             if ((p > 1) && (p < viewName.length - 1)) {
                let tgtpath = "/currentdir/";
                let pp = JSROOT.source_dir.indexOf("/jsrootsys/");
-               if (pp > 0) tgtpath = JSROOT.source_dir.substr(0,pp) + "currentdir/";
+               if (pp > 0) tgtpath = JSROOT.source_dir.slice(0,pp) + "/currentdir/";
                let _paths = {};
-               _paths[viewName.substr(0,p)] = tgtpath;
-               console.log('Register module path', viewName.substr(0,p), ' as ', tgtpath);
+               _paths[viewName.slice(0,p)] = tgtpath;
+               console.log('Register module path', viewName.slice(0,p), ' as ', tgtpath);
                sap.ui.loader.config({ paths: _paths });
             }
          }


### PR DESCRIPTION
Used in Qt5WebEngine chrome does not support `await import` statement
in main module body. But this is the only way for now to work with
node.js. To avoid problems just exclude peace of code marked
correspondently. Just a workaround.

Backport of #10196 