### PR TITLE
[RF] Remove evaluation of pdf in RooRealIntegral constructor if the normalisation set is not defined

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -437,7 +437,7 @@ std::pair<const RooArgSet*, AddCacheElem*> RooAddPdf::getNormAndCache(const RooA
 
     // If nset is STILL nullptr, print a warning.
     if (nset == nullptr) {
-       coutW(Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
+       coutW(Eval) << "Evaluating RooAddPdf " << GetName()  << " without a defined normalization set. This can lead to ambiguous "
           "coefficients definition and incorrect results."
                            << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for "
           "defining uniquely RooAddPdf coefficients!"

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -433,21 +433,11 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
     oocxcoutI(&function,Integration) << function.GetName() << ": Function integrated observables " << _anaList << " internally with code " << _mode << std::endl ;
   }
 
-  // when _funcNormSet is a nullptr a warning message appears for RooAddPdf functions
-  // This is not a problem since we do noty use the returned value from getVal()
-  // we then disable the produced warning message in the RooFit::Eval topic
-  std::unique_ptr<RooHelpers::LocalChangeMsgLevel> msgChanger;
-  if (_funcNormSet == nullptr) {
-     // remove only the RooFit::Eval message topic from current active streams
-     // passed level can be whatever if we provide a false as last argument
-     msgChanger = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::WARNING, 0u, RooFit::Eval, false);
-  }
-
   // WVE kludge: synchronize dset for use in analyticalIntegral
-  // LM : is this really needed ??
-  function.getVal(_funcNormSet) ;
-  // delete LocalChangeMsgLevel which will restore previous message level
-  msgChanger.reset(nullptr);
+  // LM : I think this is needed only if  _funcNormSet is not an empty set
+  if (_funcNormSet && _funcNormSet->getSize() > 0) {
+    function.getVal(_funcNormSet) ;
+  }
 
   // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
   // * F) Make list of numerical integration variables consisting of:            *


### PR DESCRIPTION
In the RooRealIntegral constructor a integrand function.getVal() is called probably to initialise the cache. 
The intention is to remove this, and for the time being keep only if the normalisation set is defined.
