### PR TITLE
[PyROOT] Find rootlogon in home or current working directory

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -229,25 +229,32 @@ class ROOTFacade(types.ModuleType):
 
         return setattr(self, name, val)
 
+    def _execute_rootlogon_module(self, file_path):
+        """Execute the 'rootlogon.py' module found at the given 'file_path'"""
+        # Could also have used execfile, but import is likely to give fewer surprises
+        module_name = 'rootlogon'
+        if sys.version_info >= (3, 5):
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(module_name, file_path)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+        else:
+            import imp
+            imp.load_module(module_name, open(file_path, 'r'), file_path, ('.py', 'r', 1))
+            del imp
+
     def _run_rootlogon(self):
         # Run custom logon file (must be after creation of ROOT globals)
         hasargv = hasattr(sys, 'argv')
         # -n disables the reading of the logon file, just like with root
         if hasargv and not '-n' in sys.argv and not self.PyConfig.DisableRootLogon:
-            file_path = os.path.expanduser('~/.rootlogon.py')
-            if os.path.exists(file_path):
-                # Could also have used execfile, but import is likely to give fewer surprises
-                module_name = 'rootlogon'
-                if sys.version_info >= (3,5):
-                    import importlib.util
-                    spec = importlib.util.spec_from_file_location(module_name, file_path)
-                    module = importlib.util.module_from_spec(spec)
-                    sys.modules[module_name] = module
-                    spec.loader.exec_module(module)
-                else:
-                    import imp
-                    imp.load_module(module_name, open(file_path, 'r'), file_path, ('.py','r',1))
-                    del imp
+            file_path_home = os.path.expanduser('~/.rootlogon.py')
+            file_path_local = os.path.join(os.getcwd(), '.rootlogon.py')
+            if os.path.exists(file_path_home):
+                self._execute_rootlogon_module(file_path_home)
+            elif os.path.exists(file_path_local):
+                self._execute_rootlogon_module(file_path_local)
             else:
                 # If the .py version of rootlogon exists, the .C is ignored (the user can
                 # load the .C from the .py, if so desired).


### PR DESCRIPTION
The rootlogon.C file is searched both in the user home directory and in
the current working directory. Align this behaviour on the PyROOT side.
