### PR TITLE
[RF] Add flag to globally enable or disable all RooBinWidthFunctions

### DIFF
--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -25,7 +25,13 @@
 namespace BatchHelpers { struct RunContext; }
 
 class RooBinWidthFunction : public RooAbsReal {
-public:
+  static bool _enabled;
+  
+public:  
+  static void enable();
+  static void disable();
+  static bool enabled();    
+   
   /// Create an empty instance.
   RooBinWidthFunction() :
     _histFunc("HistFuncForBinWidth", "Handle to a RooHistFunc, whose bin volumes should be returned.", this,

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -29,7 +29,7 @@ class RooBinWidthFunction : public RooAbsReal {
   
 public:  
   static void enableClass();
-  static void disableClass());
+  static void disableClass();
   static bool isClassEnabled();    
    
   /// Create an empty instance.

--- a/roofit/roofitcore/inc/RooBinWidthFunction.h
+++ b/roofit/roofitcore/inc/RooBinWidthFunction.h
@@ -28,9 +28,9 @@ class RooBinWidthFunction : public RooAbsReal {
   static bool _enabled;
   
 public:  
-  static void enable();
-  static void disable();
-  static bool enabled();    
+  static void enableClass();
+  static void disableClass());
+  static bool isClassEnabled();    
    
   /// Create an empty instance.
   RooBinWidthFunction() :

--- a/roofit/roofitcore/src/RooBinWidthFunction.cxx
+++ b/roofit/roofitcore/src/RooBinWidthFunction.cxx
@@ -31,15 +31,18 @@
 
 bool RooBinWidthFunction::_enabled = true;
 
-void RooBinWidthFunction::enable() {
+void RooBinWidthFunction::enableClass() {
+  /// Globally enable bin-width corrections by this class.
   _enabled = true;
 }
 
-bool RooBinWidthFunction::enabled() {
+bool RooBinWidthFunction::isClassEnabled() {
+  /// Returns true if bin-width corrections by this class are globally enabled, false otherwise.
   return _enabled;
 }
 
-void RooBinWidthFunction::disable() {
+void RooBinWidthFunction::disableClass() {
+  /// Globally disnable bin-width corrections by this class.	
   _enabled = false;
 }
 

--- a/roofit/roofitcore/src/RooBinWidthFunction.cxx
+++ b/roofit/roofitcore/src/RooBinWidthFunction.cxx
@@ -31,18 +31,18 @@
 
 bool RooBinWidthFunction::_enabled = true;
 
+/// Globally enable bin-width corrections by this class.
 void RooBinWidthFunction::enableClass() {
-  /// Globally enable bin-width corrections by this class.
   _enabled = true;
 }
 
+/// Returns `true` if bin-width corrections by this class are globally enabled, `false` otherwise.
 bool RooBinWidthFunction::isClassEnabled() {
-  /// Returns true if bin-width corrections by this class are globally enabled, false otherwise.
   return _enabled;
 }
 
+/// Globally disable bin-width corrections by this class.
 void RooBinWidthFunction::disableClass() {
-  /// Globally disnable bin-width corrections by this class.	
   _enabled = false;
 }
 

--- a/roofit/roofitcore/src/RooBinWidthFunction.cxx
+++ b/roofit/roofitcore/src/RooBinWidthFunction.cxx
@@ -29,11 +29,25 @@
 #include "RooDataHist.h"
 #include "RunContext.h"
 
+bool RooBinWidthFunction::_enabled = true;
+
+void RooBinWidthFunction::enable() {
+  _enabled = true;
+}
+
+bool RooBinWidthFunction::enabled() {
+  return _enabled;
+}
+
+void RooBinWidthFunction::disable() {
+  _enabled = false;
+}
 
 /// Compute current bin of observable, and return its volume or inverse volume, depending
 /// on configuration chosen in the constructor.
 /// If the bin is not valid, return a volume of 1.
 double RooBinWidthFunction::evaluate() const {
+  if(!_enabled) return 1.;
   const RooDataHist& dataHist = _histFunc->dataHist();
   const auto idx = _histFunc->getBin();
   auto volumes = dataHist.binVolumes(0, dataHist.numEntries());
@@ -51,13 +65,19 @@ void RooBinWidthFunction::computeBatch(cudaStream_t*, double* output, size_t, Ro
   std::vector<Int_t> bins = _histFunc->getBins(dataMap);
   auto volumes = dataHist.binVolumes(0, dataHist.numEntries());
 
-  if (_divideByBinWidth) {
+  if(!_enabled){
     for (std::size_t i=0; i < bins.size(); ++i) {
-      output[i] = bins[i] >= 0 ? 1./volumes[bins[i]] : 1.;
+      output[i] = 1.;
     }
   } else {
-    for (std::size_t i=0; i < bins.size(); ++i) {
-      output[i] = bins[i] >= 0 ? volumes[bins[i]] : 1.;
+    if (_divideByBinWidth) {
+      for (std::size_t i=0; i < bins.size(); ++i) {
+	output[i] = bins[i] >= 0 ? 1./volumes[bins[i]] : 1.;
+      }
+    } else {
+      for (std::size_t i=0; i < bins.size(); ++i) {
+	output[i] = bins[i] >= 0 ? volumes[bins[i]] : 1.;
+      }
     }
   }
 }


### PR DESCRIPTION
# This Pull request:

With the (very useful) introduction of the RooBinWidthFunction, the bin width correction moved from the "coefficient" branch of the RooRealSumPdf to the "function" branch of the RooRealSumPdf in HistFactory.
This can cause some distress for users who meddle with histfactory models by hand, because bin correction can now appear at places that are different from what they were originally.

This PR adds a flag to globally disable all bin width corrections of RooBinWidthFunction, allowing the user to switch an entire model from density-mode to eventcount-mode.

## Changes or fixes:

Added flag to globally enable or disable all bin width functions.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

