### PR TITLE
[tree] Fix GetTreeFullPaths in case of `protocol://`

### DIFF
--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -212,7 +212,7 @@ std::vector<std::string> GetTreeFullPaths(const TTree &tree)
          return {tree.GetName()};
       }
       std::string fullPath = treeDir->GetPath();           // e.g. "file.root:/dir"
-      fullPath = fullPath.substr(fullPath.find(":/") + 1); // e.g. "/dir"
+      fullPath = fullPath.substr(fullPath.rfind(":/") + 1); // e.g. "/dir"
       fullPath += "/";
       fullPath += tree.GetName(); // e.g. "/dir/tree"
       return {fullPath};


### PR DESCRIPTION
GetTreeFullPaths assumed that the first occurrence of ":/" was
the separator between filename and tree name in strings such as
"file.root:/dir/tree". However, the separator is the _last_
occurrence of ":/" -- e.g. if the file is read via a remote
protocol, its name starts with "protocol://".

This logic is of course still broken in case the name of the tree
or the one of the directory that contains it contains ":/", we
do not support that case.

This fixes #10216.

