### PR TITLE
 [cling] Do not ACLiC-link against (non-existent) libssl and libcrypto - 6.24 backport 

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3386,6 +3386,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        || strstr(filename, "/usr/lib/libAudioToolboxUtility")
        || strstr(filename, "/usr/lib/liboah")
        || strstr(filename, "/usr/lib/libRosetta")
+       || strstr(filename, "/usr/lib/libssl.")
        // "cannot link directly with dylib/framework, your binary is not an allowed client of
        // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/
        // SDKs/MacOSX.sdk/usr/lib/libAudioToolboxUtility.tbd for architecture x86_64

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3387,6 +3387,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        || strstr(filename, "/usr/lib/liboah")
        || strstr(filename, "/usr/lib/libRosetta")
        || strstr(filename, "/usr/lib/libssl.")
+       || strstr(filename, "/usr/lib/libcrypto.")
        // "cannot link directly with dylib/framework, your binary is not an allowed client of
        // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/
        // SDKs/MacOSX.sdk/usr/lib/libAudioToolboxUtility.tbd for architecture x86_64


### PR DESCRIPTION
Backport of https://github.com/root-project/root/pull/9803