### PR TITLE
Updated RModelParser_PyTorch.cxx -Fixes the bug related to build

### DIFF
--- a/tmva/pymva/src/RModelParser_PyTorch.cxx
+++ b/tmva/pymva/src/RModelParser_PyTorch.cxx
@@ -414,8 +414,6 @@ RModel Parse(std::string filename, std::vector<std::vector<size_t>> inputShapes,
         PyRunString("dummyInputs.append(torch.rand(*inputShape))",fGlobalNS,fLocalNS);
     }
 
-    //Finding example outputs from dummy
-    PyRunString("output=model(*dummyInputs)",fGlobalNS,fLocalNS);
 
     //Getting the ONNX graph from model using the dummy inputs and example outputs
     PyRunString("_set_onnx_shape_inference(True)",fGlobalNS,fLocalNS);

--- a/tmva/pymva/src/RModelParser_PyTorch.cxx
+++ b/tmva/pymva/src/RModelParser_PyTorch.cxx
@@ -419,7 +419,7 @@ RModel Parse(std::string filename, std::vector<std::vector<size_t>> inputShapes,
 
     //Getting the ONNX graph from model using the dummy inputs and example outputs
     PyRunString("_set_onnx_shape_inference(True)",fGlobalNS,fLocalNS);
-    PyRunString("graph=_model_to_graph(model,dummyInputs,example_outputs=output)",fGlobalNS,fLocalNS);
+    PyRunString("graph=_model_to_graph(model,dummyInputs)",fGlobalNS,fLocalNS);
 
 
     //Extracting the model information in list modelData


### PR DESCRIPTION
# This Pull request: Fixes the bug to build ROOT in Ubuntu 20.04
![image](https://user-images.githubusercontent.com/84740927/159856024-8b399e36-d835-4726-b6dc-9d1a5b90dbc3.png)

The above bug was noticed by me when i was building boost in my local computer. This can be resolved by just removing example_outputs argument from PyRunString function over [here](https://github.com/root-project/root/blob/master/tmva/pymva/src/RModelParser_PyTorch.cxx#L422)

## Changes or fixes:
Bug-issue related to build

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)



