### PR TITLE
Additional fixes for std::pair's StreamerInfo handling

### DIFF
--- a/core/cont/inc/TVirtualCollectionProxy.h
+++ b/core/cont/inc/TVirtualCollectionProxy.h
@@ -68,14 +68,14 @@ public:
       TPushPop& operator=(const TPushPop&) = delete;
    };
 
-   TVirtualCollectionProxy() : fClass(), fProperties(0) {};
-   TVirtualCollectionProxy(TClass *cl) : fClass(cl), fProperties(0) {};
+   TVirtualCollectionProxy() : fClass(), fProperties(0) {}
+   TVirtualCollectionProxy(TClass *cl) : fClass(cl), fProperties(0) {}
 
    virtual TVirtualCollectionProxy* Generate() const = 0; // Returns an object of the actual CollectionProxy class
-   virtual ~TVirtualCollectionProxy() {};
+   virtual ~TVirtualCollectionProxy() {}
 
    // Reset the info gathered from StreamerInfos and value's TClass.
-   virtual Bool_t    Reset() { return kTRUE; };
+   virtual Bool_t    Reset() { return kTRUE; }
 
    virtual TClass   *GetCollectionClass() const { return fClass; }
    // Return a pointer to the TClass representing the container

--- a/core/cont/inc/TVirtualCollectionProxy.h
+++ b/core/cont/inc/TVirtualCollectionProxy.h
@@ -74,6 +74,9 @@ public:
    virtual TVirtualCollectionProxy* Generate() const = 0; // Returns an object of the actual CollectionProxy class
    virtual ~TVirtualCollectionProxy() {};
 
+   // Reset the info gathered from StreamerInfos and value's TClass.
+   virtual Bool_t    Reset() { return kTRUE; };
+
    virtual TClass   *GetCollectionClass() const { return fClass; }
    // Return a pointer to the TClass representing the container
 

--- a/core/meta/inc/TListOfEnums.h
+++ b/core/meta/inc/TListOfEnums.h
@@ -71,6 +71,9 @@ public:
    TEnum     *Find(DeclId_t id) const;
    virtual TEnum *GetObject(const char*) const;
 
+   TObject  *FindObject(const char*) const override;
+   using THashList::FindObject;
+
    void Clear(Option_t *option) override;
    void Delete(Option_t *option="") override;
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6011,6 +6011,10 @@ void TClass::PostLoadCheck()
          noffset = 3;
       else if (strncmp(GetName(), "multimap<", 9) == 0)
          noffset = 8;
+      else if (strncmp(GetName(), "unordered_map<", 14) == 0)
+         noffset = 13;
+      else if (strncmp(GetName(), "unordered_multimap<", 19) == 0)
+         noffset = 18;
       if (noffset) {
          std::string pairname("pair");
          pairname.append(GetName() + noffset);

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -7308,6 +7308,10 @@ void TClass::RemoveStreamerInfo(Int_t slot)
       R__LOCKGUARD(gInterpreterMutex);
       TVirtualStreamerInfo *info = (TVirtualStreamerInfo*)fStreamerInfo->At(slot);
       fStreamerInfo->RemoveAt(fClassVersion);
+      if (fLastReadInfo.load() == info)
+         fLastReadInfo = nullptr;
+      if (fCurrentInfo.load() == info)
+         fCurrentInfo = nullptr;
       delete info;
       if (fState == kEmulated && fStreamerInfo->GetEntries() == 0) {
          fState = kForwardDeclared;

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6018,7 +6018,8 @@ void TClass::PostLoadCheck()
       if (noffset) {
          std::string pairname("pair");
          pairname.append(GetName() + noffset);
-         if ( auto pcl = TClass::GetClass(pairname.c_str(), false, false) )
+         auto pcl = TClass::GetClass(pairname.c_str(), false, false);
+         if ( pcl && !pcl->IsLoaded() && !pcl->IsSyntheticPair() )
          {
             TInterpreter::SuspendAutoLoadingRAII autoloadOff(gInterpreter);
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -6004,6 +6004,26 @@ void TClass::PostLoadCheck()
          }
       }
    }
+   if (fCollectionProxy) {
+      // Update the related pair's TClass if it has already been created.
+      size_t noffset = 0;
+      if (strncmp(GetName(), "map<", 4) == 0)
+         noffset = 3;
+      else if (strncmp(GetName(), "multimap<", 9) == 0)
+         noffset = 8;
+      if (noffset) {
+         std::string pairname("pair");
+         pairname.append(GetName() + noffset);
+         if ( auto pcl = TClass::GetClass(pairname.c_str(), false, false) )
+         {
+            TIter next(pcl->GetStreamerInfos());
+            while (auto info = (TVirtualStreamerInfo*)next()) {
+               info->Clear("build");
+            }
+            fCollectionProxy->GetValueClass();
+         }
+      }
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/meta/src/TListOfEnums.cxx
+++ b/core/meta/src/TListOfEnums.cxx
@@ -184,6 +184,22 @@ TEnum *TListOfEnums::Find(DeclId_t id) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Specialize FindObject to do search for the
+/// a enum just by name or create it if its not already in the list
+
+TObject *TListOfEnums::FindObject(const char *name) const
+{
+   TObject *result = THashList::FindObject(name);
+   if (!result) {
+      TInterpreter::DeclId_t decl;
+      if (GetClass()) decl = gInterpreter->GetEnum(GetClass(), name);
+      else            decl = gInterpreter->GetEnum(nullptr, name);
+      if (decl) result = const_cast<TListOfEnums *>(this)->Get(decl, name);
+   }
+   return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Return (after creating it if necessary) the TEnum
 /// describing the enum corresponding to the Decl 'id'.
 

--- a/core/meta/src/TListOfEnums.cxx
+++ b/core/meta/src/TListOfEnums.cxx
@@ -192,8 +192,7 @@ TObject *TListOfEnums::FindObject(const char *name) const
    TObject *result = THashList::FindObject(name);
    if (!result) {
       TInterpreter::DeclId_t decl;
-      if (GetClass()) decl = gInterpreter->GetEnum(GetClass(), name);
-      else            decl = gInterpreter->GetEnum(nullptr, name);
+      decl = gInterpreter->GetEnum(GetClass(), name);
       if (decl) result = const_cast<TListOfEnums *>(this)->Get(decl, name);
    }
    return result;

--- a/core/meta/src/TListOfEnumsWithLock.cxx
+++ b/core/meta/src/TListOfEnumsWithLock.cxx
@@ -156,16 +156,7 @@ void TListOfEnumsWithLock::Delete(Option_t *option /* ="" */)
 TObject *TListOfEnumsWithLock::FindObject(const char *name) const
 {
    R__LOCKGUARD(gInterpreterMutex);
-   TObject *result = TListOfEnums::FindObject(name);
-   if (!result) {
-
-
-      TInterpreter::DeclId_t decl;
-      if (GetClass()) decl = gInterpreter->GetEnum(GetClass(), name);
-      else        decl = gInterpreter->GetEnum(nullptr, name);
-      if (decl) result = const_cast<TListOfEnumsWithLock *>(this)->Get(decl, name);
-   }
-   return result;
+   return TListOfEnums::FindObject(name);
 }
 
 

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1734,51 +1734,6 @@ void TCling::LoadPCMImpl(TFile &pcmFile)
    if (gDebug > 1)
       ::Info("TCling::LoadPCMImpl", "reading protoclasses for %s \n", pcmFile.GetName());
 
-   pcmFile.GetObject("__ProtoClasses", protoClasses);
-
-   if (protoClasses) {
-      for (auto obj : *protoClasses) {
-         TProtoClass *proto = (TProtoClass *)obj;
-         TClassTable::Add(proto);
-      }
-      // Now that all TClass-es know how to set them up we can update
-      // existing TClasses, which might cause the creation of e.g. TBaseClass
-      // objects which in turn requires the creation of TClasses, that could
-      // come from the PCH, but maybe later in the loop. Instead of resolving
-      // a dependency graph the addition to the TClassTable above allows us
-      // to create these dependent TClasses as needed below.
-      for (auto proto : *protoClasses) {
-         if (TClass *existingCl = (TClass *)gROOT->GetListOfClasses()->FindObject(proto->GetName())) {
-            // We have an existing TClass object. It might be emulated
-            // or interpreted; we now have more information available.
-            // Make that available.
-            if (existingCl->GetState() != TClass::kHasTClassInit) {
-               DictFuncPtr_t dict = gClassTable->GetDict(proto->GetName());
-               if (!dict) {
-                  ::Error("TCling::LoadPCM", "Inconsistent TClassTable for %s", proto->GetName());
-               } else {
-                  // This will replace the existing TClass.
-                  TClass *ncl = (*dict)();
-                  if (ncl)
-                     ncl->PostLoadCheck();
-               }
-            }
-         }
-      }
-
-      protoClasses->Clear(); // Ownership was transfered to TClassTable.
-      delete protoClasses;
-   }
-
-   TObjArray *dataTypes;
-   pcmFile.GetObject("__Typedefs", dataTypes);
-   if (dataTypes) {
-      for (auto typedf : *dataTypes)
-         gROOT->GetListOfTypes()->Add(typedf);
-      dataTypes->Clear(); // Ownership was transfered to TListOfTypes.
-      delete dataTypes;
-   }
-
    TObjArray *enums;
    pcmFile.GetObject("__Enums", enums);
    if (enums) {
@@ -1827,6 +1782,51 @@ void TCling::LoadPCMImpl(TFile &pcmFile)
       }
       enums->Clear();
       delete enums;
+   }
+
+   pcmFile.GetObject("__ProtoClasses", protoClasses);
+
+   if (protoClasses) {
+      for (auto obj : *protoClasses) {
+         TProtoClass *proto = (TProtoClass *)obj;
+         TClassTable::Add(proto);
+      }
+      // Now that all TClass-es know how to set them up we can update
+      // existing TClasses, which might cause the creation of e.g. TBaseClass
+      // objects which in turn requires the creation of TClasses, that could
+      // come from the PCH, but maybe later in the loop. Instead of resolving
+      // a dependency graph the addition to the TClassTable above allows us
+      // to create these dependent TClasses as needed below.
+      for (auto proto : *protoClasses) {
+         if (TClass *existingCl = (TClass *)gROOT->GetListOfClasses()->FindObject(proto->GetName())) {
+            // We have an existing TClass object. It might be emulated
+            // or interpreted; we now have more information available.
+            // Make that available.
+            if (existingCl->GetState() != TClass::kHasTClassInit) {
+               DictFuncPtr_t dict = gClassTable->GetDict(proto->GetName());
+               if (!dict) {
+                  ::Error("TCling::LoadPCM", "Inconsistent TClassTable for %s", proto->GetName());
+               } else {
+                  // This will replace the existing TClass.
+                  TClass *ncl = (*dict)();
+                  if (ncl)
+                     ncl->PostLoadCheck();
+               }
+            }
+         }
+      }
+
+      protoClasses->Clear(); // Ownership was transfered to TClassTable.
+      delete protoClasses;
+   }
+
+   TObjArray *dataTypes;
+   pcmFile.GetObject("__Typedefs", dataTypes);
+   if (dataTypes) {
+      for (auto typedf : *dataTypes)
+         gROOT->GetListOfTypes()->Add(typedf);
+      dataTypes->Clear(); // Ownership was transfered to TListOfTypes.
+      delete dataTypes;
    }
 }
 

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -70,7 +70,7 @@ public:
       // Default copy constructor has the correct implementation.
 
       // Initializing constructor
-      Value(const std::string& info, Bool_t silent);
+      Value(const std::string& info, Bool_t silent, size_t hint_pair_offset = 0, size_t hint_pair_size = 0);
       // Delete individual item from STL container
       void DeleteItem(void* ptr);
 

--- a/io/io/inc/TGenCollectionProxy.h
+++ b/io/io/inc/TGenCollectionProxy.h
@@ -359,6 +359,9 @@ public:
    // Standard destructor.
    virtual ~TGenCollectionProxy();
 
+   // Reset the info gathered from StreamerInfos and value's TClass.
+   virtual Bool_t Reset();
+
    // Return a pointer to the TClass representing the container.
    virtual TClass *GetCollectionClass() const;
 

--- a/io/io/src/TBufferFile.cxx
+++ b/io/io/src/TBufferFile.cxx
@@ -3521,6 +3521,8 @@ Int_t TBufferFile::WriteClassBuffer(const TClass *cl, void *pointer)
       //Have to be sure between the check and the taking of the lock if the current streamer has changed
       R__LOCKGUARD(gInterpreterMutex);
       sinfo = (TStreamerInfo*)const_cast<TClass*>(cl)->GetCurrentStreamerInfo();
+      if (sinfo == nullptr)
+         sinfo = (TStreamerInfo*)const_cast<TClass*>(cl)->GetStreamerInfo();
       if (sinfo == nullptr) {
          const_cast<TClass*>(cl)->BuildRealData(pointer);
          sinfo = new TStreamerInfo(const_cast<TClass*>(cl));

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -313,7 +313,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor.
 
-TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent)
+TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent, size_t hint_pair_offset, size_t hint_pair_size)
 {
    std::string inside = (inside_type.find("const ")==0) ? inside_type.substr(6) : inside_type;
    fCase = 0;
@@ -364,7 +364,7 @@ TGenCollectionProxy::Value::Value(const std::string& inside_type, Bool_t silent)
       // might fail because CINT does not known the nesting
       // scope, so let's first look for an emulated class:
 
-      fType = TClass::GetClass(intype.c_str(),kTRUE,silent);
+      fType = TClass::GetClass(intype.c_str(),kTRUE,silent, hint_pair_offset, hint_pair_size);
 
       if (fType) {
          if (isPointer) {
@@ -828,9 +828,10 @@ void TGenCollectionProxy::CheckFunctions() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Utility routine to issue a Fatal error is the Value object is not valid
 
-static TGenCollectionProxy::Value *R__CreateValue(const std::string &name, Bool_t silent)
+static TGenCollectionProxy::Value *R__CreateValue(const std::string &name, Bool_t silent,
+                                                  size_t hint_pair_offset = 0, size_t hint_pair_size = 0)
 {
-   TGenCollectionProxy::Value *val = new TGenCollectionProxy::Value( name, silent );
+   TGenCollectionProxy::Value *val = new TGenCollectionProxy::Value( name, silent, hint_pair_offset, hint_pair_size );
    if ( !val->IsValid() ) {
       Fatal("TGenCollectionProxy","Could not find %s!",name.c_str());
    }
@@ -923,7 +924,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                      }
                   }
                }
-               newfValue = R__CreateValue(nam, silent);
+               newfValue = R__CreateValue(nam, silent, fValOffset, fValDiff);
 
                fPointers = (0 != (fKey->fCase&kIsPointer));
                if (fPointers || (0 != (fKey->fProperties&kNeedDelete))) {

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -896,7 +896,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                         else {
                            gROOT->GetListOfClasses()->Remove(paircl);
                            TClass *newpaircl = TClass::GetClass(nam.c_str(), true, false, fValOffset, fValDiff);
-                           if (newpaircl == paircl || newpaircl->GetClassSize() != fValDiff)
+                           if (!newpaircl || newpaircl == paircl || newpaircl->GetClassSize() != fValDiff)
                               Fatal("InitializeEx",
                                     "The TClass creation for %s did not get the right size: %d instead of%d\n",
                                     nam.c_str(), (int)paircl->GetClassSize(), (int)fValDiff);

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -894,11 +894,16 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
 
                {
                   TInterpreter::SuspendAutoParsing autoParseRaii(gCling);
-                  if (0==TClass::GetClass(nam.c_str(), true, false, fValOffset, fValDiff)) {
+                  TClass *paircl = TClass::GetClass(nam.c_str(), true, false, fValOffset, fValDiff);
+                  if (paircl == nullptr) {
                      // We need to emulate the pair
-                     TVirtualStreamerInfo::Factory()->GenerateInfoForPair(inside[1], inside[2], silent, fValOffset, fValDiff);
+                     auto info = TVirtualStreamerInfo::Factory()->GenerateInfoForPair(inside[1], inside[2], silent, fValOffset, fValDiff);
+                     if (!info) {
+                        Fatal("InitializeEx",
+                              "Could not load nor generate the dictionary for \"%s\", some element might be missing their dictionary (eg. enums)",
+                              nam.c_str());
+                     }
                   } else {
-                     TClass *paircl = TClass::GetClass(nam.c_str());
                      if (paircl->GetClassSize() != fValDiff) {
                         if (paircl->GetState() >= TClass::kInterpreted)
                            Fatal("InitializeEx",

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -776,6 +776,19 @@ TGenCollectionProxy *TGenCollectionProxy::Initialize(Bool_t silent) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Reset the info gathered from StreamerInfos and value's TClass.
+Bool_t TGenCollectionProxy::Reset()
+{
+   if (fReadMemberWise)
+      fReadMemberWise->Clear();
+   delete fWriteMemberWise;
+   fWriteMemberWise = nullptr;
+   if (fConversionReadMemberWise)
+      fConversionReadMemberWise->clear();
+   return kTRUE;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Check existence of function pointers
 
 void TGenCollectionProxy::CheckFunctions() const

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2617,10 +2617,12 @@ void TStreamerInfo::Clear(Option_t *option)
       delete [] fComp;     fComp    = 0;
       delete [] fCompFull; fCompFull= 0;
       delete [] fCompOpt;  fCompOpt = 0;
+
       fNdata = 0;
       fNfulldata = 0;
       fNslots= 0;
       fSize = 0;
+
       ResetIsCompiled();
       ResetBit(kBuildOldUsed);
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2137,8 +2137,9 @@ void TStreamerInfo::BuildOld()
                if (pattern && pattern != this && pattern->IsBuilt()) {
                   int pair_element_offset = kMissing;
                   pattern->GetStreamerElement(element->GetName(), pair_element_offset);
-                  if (offset != kMissing)
-                     element->SetOffset(offset);
+                  if (pair_element_offset != kMissing) {
+                     element->SetOffset(pair_element_offset);
+                  }
                }
             } else if (strcmp(element->GetName(), "fData") == 0 && strncmp(GetName(), "ROOT::VecOps::RVec", 18) == 0) {
                Error("BuildCheck", "Reading RVecs that were written directly to file before ROOT v6.24 is not "

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -2623,6 +2623,11 @@ void TStreamerInfo::Clear(Option_t *option)
       ResetIsCompiled();
       ResetBit(kBuildOldUsed);
 
+      TIter next(fElements);
+      while (auto element = (TStreamerElement*)next()) {
+         element->SetOffset(0);
+      }
+
       if (fReadObjectWise) fReadObjectWise->fActions.clear();
       if (fReadMemberWise) fReadMemberWise->fActions.clear();
       if (fReadMemberWiseVecPtr) fReadMemberWiseVecPtr->fActions.clear();

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -213,7 +213,8 @@ TStreamerInfo::~TStreamerInfo()
    // Note: If a StreamerInfo is loaded from a file and is the same information
    // as an existing one, it is assigned the same "unique id" and we need to double
    // check before removing it from the global list.
-   if (fNumber >=0 && gROOT->GetListOfStreamerInfo()->At(fNumber) == this)
+   if (fNumber >=0 && gROOT->GetListOfStreamerInfo()->GetSize() > fNumber
+       && gROOT->GetListOfStreamerInfo()->At(fNumber) == this)
       gROOT->GetListOfStreamerInfo()->RemoveAt(fNumber);
 
    delete [] fComp;     fComp     = 0;

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -248,6 +248,8 @@ bool CloseStreamerInfoROOTFile(bool writeEmptyRootPCM)
             Error("CloseStreamerInfoROOTFile", "Cannot find TClass instance for namespace %s.", nsName.c_str());
             return false;
          }
+         if (!(tclassInstance->Property() & kIsNamespace))
+            continue; // Enum will be part of the TClass.
          auto enumListPtr = tclassInstance->GetListOfEnums();
          if (!enumListPtr) {
             Error("CloseStreamerInfoROOTFile", "TClass instance for namespace %s does not have any enum associated. This is an inconsistency.", nsName.c_str());

--- a/io/rootpcm/src/rootclingIO.cxx
+++ b/io/rootpcm/src/rootclingIO.cxx
@@ -200,7 +200,8 @@ bool CloseStreamerInfoROOTFile(bool writeEmptyRootPCM)
 
       if (auto pr = cl->GetCollectionProxy()) {
          auto colltype = pr->GetCollectionType();
-         if (colltype == ROOT::kSTLmap || colltype == ROOT::kSTLmultimap) {
+         if (colltype == ROOT::kSTLmap || colltype == ROOT::kSTLmultimap ||
+             colltype == ROOT::kSTLunorderedmap || colltype == ROOT::kSTLunorderedmultimap) {
             if (auto pcl = pr->GetValueClass()) {
                if (auto pcl_dms = pcl->GetListOfDataMembers()) {
                   for (auto dmObj : *pcl_dms) {


### PR DESCRIPTION
This repairs crash seem in [testProxiesAndCategories](https://lcgapp-services.cern.ch/root-jenkins/job/root-pullrequests-build/139900/testReport/projectroot.roofit.roofitcore/test/gtest_roofit_roofitcore_test_testProxiesAndCategories/) on the v6.24 branches and a few additional issues seen during testing.