### PR TITLE
[RF] Backport in 6.26 a fix suppressing a RooFit Warning message

### DIFF
--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -434,7 +434,7 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   // This is not a problem since we do noty use the returned value from getVal()
   // we then disable the produced warning message in the RooFit::Eval topic
   std::unique_ptr<RooHelpers::LocalChangeMsgLevel> msgChanger;
-  if (_funcNormSet == nullptr) {
+  if (_funcNormSet == nullptr || _funcNormSet->getSize() == 0) {
      // remove only the RooFit::Eval message topic from current active streams
      // passed level can be whatever if we provide a false as last argument   
      msgChanger = std::make_unique<RooHelpers::LocalChangeMsgLevel>(RooFit::WARNING, 0u, RooFit::Eval, false);


### PR DESCRIPTION
In some case when calling `RooAddPdf::generate`  an evaluation of the RooAddPdf happens without the normalisation set defined, causing the priting of a Warning message. Since in this case the evaluation result is not used we can suppress this message. 
Here is the example code reproducing this:
```
void testRooAddPdfGenerate()  {

   RooWorkspace w("w");

   w.factory("Gaussian::f1(x[0,10],m1[3,0,10],s1[1,0,10])");
   w.factory("Gaussian::f2(x,m2[7,0,10],s2[0.5,0,10])");
   w.factory("SUM::sigPdf(n1[1000,0,100000]*f1, n2[1000,0,100000]*f2)");
   w.factory("Gaussian::bkgPdf(x,mb[5,0,10],sb[7,0,10])");
   w.factory("sum::ns(n1,n2)");
   w.factory("SUM::model(ns*sigPdf,nb[2000,0,100000]*bkgPdf)");
   
   auto x = w.var("x");
   auto pdf = w.pdf("model");

   auto data = pdf->generate(*x);

   
}
```



