### PR TITLE
[core] Rework the field lookups in base classes to avoid iteration.

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -354,7 +354,7 @@ clang::QualType AddDefaultParameters(clang::QualType instanceType,
                                      const TNormalizedCtxt &normCtxt);
 
 //______________________________________________________________________________
-llvm::StringRef DataMemberInfo__ValidArrayIndex(const clang::DeclaratorDecl &m, int *errnum = 0, llvm::StringRef  *errstr = 0);
+llvm::StringRef DataMemberInfo__ValidArrayIndex(const cling::Interpreter& interp, const clang::DeclaratorDecl &m, int *errnum = 0, llvm::StringRef  *errstr = 0);
 
 enum class EIOCtorCategory : short { kAbsent, kDefault, kIOPtrType, kIORefType };
 

--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -354,7 +354,7 @@ clang::QualType AddDefaultParameters(clang::QualType instanceType,
                                      const TNormalizedCtxt &normCtxt);
 
 //______________________________________________________________________________
-llvm::StringRef DataMemberInfo__ValidArrayIndex(const cling::Interpreter& interp, const clang::DeclaratorDecl &m, int *errnum = 0, llvm::StringRef  *errstr = 0);
+llvm::StringRef DataMemberInfo__ValidArrayIndex(const cling::Interpreter& interp, const clang::DeclaratorDecl &m, int *errnum = nullptr, llvm::StringRef *errstr = nullptr);
 
 enum class EIOCtorCategory : short { kAbsent, kDefault, kIOPtrType, kIORefType };
 

--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -3084,7 +3084,7 @@ clang::QualType ROOT::TMetaUtils::AddDefaultParameters(clang::QualType instanceT
 /// If errstr is not null, *errstr is updated with the address of a static
 ///   string containing the part of the index with is invalid.
 
-llvm::StringRef ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(const cling::Interpreter& interp, const clang::DeclaratorDecl &m, int *errnum, llvm::StringRef *errstr)
+llvm::StringRef ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(const cling::Interpreter &interp, const clang::DeclaratorDecl &m, int *errnum, llvm::StringRef *errstr)
 {
    llvm::StringRef title;
 

--- a/core/dictgen/src/rootcling_impl.cxx
+++ b/core/dictgen/src/rootcling_impl.cxx
@@ -1334,12 +1334,12 @@ void WriteNamespaceInit(const clang::NamespaceDecl *cl,
 /// array data member.
 /// In case of error, or if the size is not specified, GrabIndex returns 0.
 
-llvm::StringRef GrabIndex(const clang::FieldDecl &member, int printError)
+llvm::StringRef GrabIndex(const cling::Interpreter& interp, const clang::FieldDecl &member, int printError)
 {
    int error;
    llvm::StringRef where;
 
-   llvm::StringRef index = ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(member, &error, &where);
+   llvm::StringRef index = ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(interp, member, &error, &where);
    if (index.size() == 0 && printError) {
       const char *errorstring;
       switch (error) {
@@ -1522,7 +1522,7 @@ void WriteStreamer(const ROOT::TMetaUtils::AnnotatedRecordDecl &cl,
                      dictStream << "         ;//R__b.WriteArray(" << field_iter->getName().str() << ", __COUNTER__);" << std::endl;
                   }
                } else if (type.getTypePtr()->isPointerType()) {
-                  llvm::StringRef indexvar = GrabIndex(**field_iter, i == 0);
+                  llvm::StringRef indexvar = GrabIndex(interp, **field_iter, i == 0);
                   if (indexvar.size() == 0) {
                      if (i == 0) {
                         ROOT::TMetaUtils::Error(nullptr, "*** Datamember %s::%s: pointer to fundamental type (need manual intervention)\n", fullname.c_str(), field_iter->getName().str().c_str());

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -669,7 +669,8 @@ llvm::StringRef TClingDataMemberInfo::ValidArrayIndex() const
       return llvm::StringRef();
    }
    const clang::DeclaratorDecl *FD = llvm::dyn_cast<clang::DeclaratorDecl>(GetTargetValueDecl());
-   if (FD) return ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(*fInterp, *FD);
-   else return llvm::StringRef();
+   if (FD)
+      return ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(*fInterp, *FD);
+   return {};
 }
 

--- a/core/metacling/src/TClingDataMemberInfo.cxx
+++ b/core/metacling/src/TClingDataMemberInfo.cxx
@@ -669,7 +669,7 @@ llvm::StringRef TClingDataMemberInfo::ValidArrayIndex() const
       return llvm::StringRef();
    }
    const clang::DeclaratorDecl *FD = llvm::dyn_cast<clang::DeclaratorDecl>(GetTargetValueDecl());
-   if (FD) return ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(*FD);
+   if (FD) return ROOT::TMetaUtils::DataMemberInfo__ValidArrayIndex(*fInterp, *FD);
    else return llvm::StringRef();
 }
 


### PR DESCRIPTION
The past approach was slow but also does not allow us to migrate to llvm13 as
the CXXBasePath cannot take the lookup iterator anymore.

See llvm/llvm-project@0cb7e7ca0c864e052bf49978f3bcd667c9e16930