### PR TITLE
Allow parallel build of tests from roottest on Windows

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -585,10 +585,14 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     set(pcm_name)
   else()
     if(CMAKE_PROJECT_NAME STREQUAL ROOT)
-      set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
-                  "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
-      # Modules need RConfigure.h copied into include/.
-      set(ROOTCINTDEP rootcling rconfigure)
+      if(MSVC AND CMAKE_ROOTTEST_DICT)
+        set(command ${CMAKE_COMMAND} -E env "ROOTIGNOREPREFIX=1" ${CMAKE_BINARY_DIR}/bin/rootcling.exe)
+      else()
+        set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+                    "ROOTIGNOREPREFIX=1" $<TARGET_FILE:rootcling> -rootbuild)
+        # Modules need RConfigure.h copied into include/.
+        set(ROOTCINTDEP rootcling rconfigure)
+      endif()
     elseif(TARGET ROOT::rootcling)
       set(command ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${ROOT_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}" $<TARGET_FILE:ROOT::rootcling>)
     else()


### PR DESCRIPTION
Fix the following kind of error when building tests (and using rootcling) in parallel on Windows:
```
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018: The "GetOutOfDateItems" task failed unexpectedly. [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018: System.IO.IOException: The process cannot access the file 'C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\x64\Release\X86CommonTableGen\X86Commo.12E1F1A7.tlog\CustomBuild.command.1.tlog' because it is being used by another process. [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath) [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost) [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost) [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at System.IO.StreamWriter.CreateFile(String path, Boolean append, Boolean checkHost) [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at System.IO.StreamWriter..ctor(String path, Boolean append, Encoding encoding, Int32 bufferSize, Boolean checkHost) [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at System.IO.File.InternalWriteAllText(String path, String contents, Encoding encoding, Boolean checkHost) [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at Microsoft.Build.CPPTasks.GetOutOfDateItems.Execute() [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute() [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(205,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext() [C:\Users\sftnight\build\release\interpreter\llvm\src\lib\Target\X86\X86CommonTableGen.vcxproj]
  obj.clangAST.vcxproj -> C:\Users\sftnight\build\release\interpreter\llvm\src\tools\clang\lib\AST\obj.clangAST.dir\Release\obj.clangAST.lib
```
Another patch will be applied in `roottest`, removing the `RUN_SERIAL` flag on many tests, allowing to save quite some time when running roottest in parallel
