### PR TITLE
[RF] Exclude categories from overlap checks in multi-range fits

### DIFF
--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -21,6 +21,7 @@
 #include "RooDataSet.h"
 #include "RooAbsRealLValue.h"
 #include "RooArgList.h"
+#include "RooAbsCategory.h"
 
 #include "ROOT/StringUtils.hxx"
 #include "TClass.h"
@@ -214,11 +215,13 @@ bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vec
 
   for (auto const& range : rangeNames) {
     for (auto const& obs : observables) {
-      auto rlv = dynamic_cast<RooAbsRealLValue const*>(obs);
-      if(!rlv) {
-        throw std::logic_error("Classes that represent observables are expected to inherit from RooAbsRealLValue!");
+      if(dynamic_cast<RooAbsCategory const*>(obs)) {
+        // Nothing to be done for category observables
+      } else if(auto * rlv = dynamic_cast<RooAbsRealLValue const*>(obs)) {
+        limits.push_back(getLimits(*rlv, range.c_str()));
+      } else {
+        throw std::logic_error("Classes that represent observables are expected to inherit from RooAbsRealLValue or RooAbsCategory!");
       }
-      limits.push_back(getLimits(*rlv, range.c_str()));
     }
   }
 

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -1,21 +1,22 @@
 // Tests for the RooSimultaneous
 // Authors: Jonas Rembser, CERN  06/2021
 
-#include "RooAddPdf.h"
-#include "RooConstVar.h"
-#include "RooCategory.h"
-#include "RooDataSet.h"
-#include "RooGenericPdf.h"
-#include "RooRealVar.h"
-#include "RooSimultaneous.h"
-#include "RooProdPdf.h"
+#include <RooAddPdf.h>
+#include <RooConstVar.h>
+#include <RooCategory.h>
+#include <RooDataSet.h>
+#include <RooGenericPdf.h>
+#include <RooRealVar.h>
+#include <RooSimultaneous.h>
+#include <RooProdPdf.h>
+#include <RooWorkspace.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <memory>
 
 /// GitHub issue #8307.
-/// A likelihood with a model wrapped in a RooSimultaneous ith one category
+/// A likelihood with a model wrapped in a RooSimultaneous in one category
 /// should give the same results as the likelihood with the model directly.
 TEST(RooSimultaneous, ImportFromTreeWithCut)
 {
@@ -49,4 +50,37 @@ TEST(RooSimultaneous, ImportFromTreeWithCut)
    std::unique_ptr<RooAbsReal> nllSimWrapped{modelSim.createNLL(combData, Constrain(constraints))};
 
    EXPECT_FLOAT_EQ(nllDirect->getVal(), nllSimWrapped->getVal());
+}
+
+/// Forum issue
+/// https://root-forum.cern.ch/t/roofit-failed-to-create-nll-for-simultaneous-pdfs-with-multiple-range-names/49363.
+/// Multi-range likelihoods should also work with RooSimultaneous, where one
+/// of the observables is a category.
+TEST(RooSimultaneous, MultiRangeNLL)
+{
+   using namespace RooFit;
+
+   RooWorkspace ws{};
+   ws.factory("Gaussian::pdfCat1(x[0,10],mu1[4,0,10],sigma[1.0,0.1,10.0])");
+   ws.factory("Gaussian::pdfCat2(x,mu2[6,0,10],sigma)");
+
+   auto &x = *ws.var("x");
+   auto &pdfCat1 = *ws.pdf("pdfCat1");
+   auto &pdfCat2 = *ws.pdf("pdfCat2");
+
+   // Create combined pdf
+   RooCategory indexCat("cat", "cat");
+   indexCat.defineType("cat1");
+   indexCat.defineType("cat2");
+   RooSimultaneous simPdf("simPdf", "", indexCat);
+   simPdf.addPdf(pdfCat1, "cat1");
+   simPdf.addPdf(pdfCat2, "cat2");
+
+   // Generate datasets
+   std::map<std::string, RooDataSet *> datasetMap{};
+   datasetMap["cat1"] = pdfCat1.generate(RooArgSet(x), 11000);
+   datasetMap["cat2"] = pdfCat2.generate(RooArgSet(x), 11000);
+   RooDataSet combData("combData", "", RooArgSet(x), Index(indexCat), Import(datasetMap));
+
+   std::unique_ptr<RooAbsReal> nll{simPdf.createNLL(combData, Range("range1,range2"), SplitRange())};
 }


### PR DESCRIPTION
This is necessary because some of the pdf observables can be categories,
e.g. in the case of the RooSimultaneous.

Since this problem was uncovered by a user when working with
RooSimultaneous, the reproducer of the original problem was turned into
a unit test in `testRooSimultaneous`.

Link to original forum post:
https://root-forum.cern.ch/t/roofit-failed-to-create-nll-for-simultaneous-pdfs-with-multiple-range-names/49363

Should be backported to the 6.26 branch.