### PR TITLE
[skip-ci][win] Export a couple of missing symbols

### DIFF
--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -126,10 +126,14 @@ if(MSVC)
       __std_reverse_trivially_swappable_4
       __std_reverse_trivially_swappable_8
       __std_terminate
-      _Smtx_lock_shared
-      _Smtx_unlock_shared
       cling_runtime_internal_throwIfInvalidPointer
   )
+  if(CMAKE_CXX_STANDARD GREATER 14)
+    set(cling_exports ${cling_exports}
+      _Smtx_lock_shared
+      _Smtx_unlock_shared
+    )
+  endif()
   if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")
     set(cling_exports ${cling_exports}
       ??2@YAPEAX_K@Z

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -126,6 +126,8 @@ if(MSVC)
       __std_reverse_trivially_swappable_4
       __std_reverse_trivially_swappable_8
       __std_terminate
+      _Smtx_lock_shared
+      _Smtx_unlock_shared
       cling_runtime_internal_throwIfInvalidPointer
   )
   if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")


### PR DESCRIPTION
Fix the `ntpl002_vector.C`, `ntpl005_introspection.C`, `ntpl006_friends.C`, and `ntpl007_mtFill.C` tutorials failing with the following errors:
```
Processing ntpl002_vector.C...
IncrementalExecutor::executeFunction: symbol '_Smtx_unlock_shared' unresolved while linking [cling interface function]!
You are probably missing the definition of _Smtx_unlock_shared
Maybe you need to load the corresponding shared library?
IncrementalExecutor::executeFunction: symbol '_Smtx_lock_shared' unresolved while linking [cling interface function]!
You are probably missing the definition of _Smtx_lock_shared
Maybe you need to load the corresponding shared library?
```
