### PR TITLE
[RF] Fix debug build with C++14

### DIFF
--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -27,9 +27,9 @@ class RooNLLVarNew : public RooAbsReal {
 
 public:
    // The names for the weight variables that the RooNLLVarNew expects
-   static constexpr auto weightVarName = "_weight";
-   static constexpr auto weightVarNameSumW2 = "_weight_sumW2";
-   static constexpr auto weightVarNameSumW2Suffix = "_sumW2";
+   static constexpr const char *weightVarName = "_weight";
+   static constexpr const char *weightVarNameSumW2 = "_weight_sumW2";
+   static constexpr const char *weightVarNameSumW2Suffix = "_sumW2";
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, RooAbsReal *weight,

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -40,6 +40,11 @@ functions from `RooBatchCompute` library to provide faster computation times.
 
 using namespace ROOT::Experimental;
 
+// Declare constexpr static members to make them available if odr-used in C++14.
+constexpr const char *RooNLLVarNew::weightVarName;
+constexpr const char *RooNLLVarNew::weightVarNameSumW2;
+constexpr const char *RooNLLVarNew::weightVarNameSumW2Suffix;
+
 namespace {
 
 std::unique_ptr<RooAbsReal> createRangeNormTerm(RooAbsPdf const &pdf, RooArgSet const &observables,


### PR DESCRIPTION
Commit ff86c30992 ("[RF] Implement SumW2 correction in new BatchMode with RooFitDriver") introduced some `static constexpr`. When building with C++14, at least `weightVarName` requires a declaration because it is odr-used. Provide them for all three variables to avoid undefined references seen in debug builds without compiler optimizations.