### PR TITLE
[http] adjust THttpServer to new JSROOT

### DIFF
--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = "modules";
 
 /** @summary version date
   * @desc Release date in format day/month/year like "19/11/2021" */
-let version_date = "24/03/2022";
+let version_date = "29/03/2022";
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -1599,15 +1599,6 @@ function isRootCollection(lst, typename) {
           (typename === 'TObjArray') || (typename === 'TClonesArray');
 }
 
-/** @summary tag item in hierarchy painter as streamer info
-  * @desc this function used on THttpServer to mark streamer infos list
-  * as fictional TStreamerInfoList class, which has special draw function
-  * @private */
-function markAsStreamerInfo(h, item, obj) {
-   if (obj && (obj._typename == 'TList'))
-      obj._typename = 'TStreamerInfoList';
-}
-
 /** @summary Check if object is a Promise
   * @private */
 function isPromise(obj) {
@@ -1675,6 +1666,5 @@ createTMultiGraph,
 getMethods,
 registerMethods,
 isRootCollection,
-markAsStreamerInfo,
 isPromise,
 _ensureJSROOT };

--- a/js/modules/draw/TTree.mjs
+++ b/js/modules/draw/TTree.mjs
@@ -126,12 +126,12 @@ function createTreePlayer(player) {
 
    player.draw_first = true;
 
-   player.configureOnline = function(itemname, url, askey, root_version, dflt_expr) {
+   player.configureOnline = function(itemname, url, askey, root_version, expr) {
       this.setItemName(itemname, "", this);
       this.url = url;
       this.root_version = root_version;
       this.askey = askey;
-      this.dflt_expr = dflt_expr;
+      this.draw_expr = expr;
    }
 
    player.configureTree = function(tree) {
@@ -152,10 +152,10 @@ function createTreePlayer(player) {
           '<button class="treedraw_clear" title="Clear drawing">Clear</button>';
 
       main.select('.treedraw_exe').on("click", () => this.performDraw());
-      main.select(".treedraw_cut").property("value", args && args.parse_cut ? args.parse_cut : "").on("change", () => this.performDraw());
-      main.select(".treedraw_opt").property("value", args && args.drawopt ? args.drawopt : "").on("change", () => this.performDraw());
-      main.select(".treedraw_number").attr("value", args && args.numentries ? args.numentries : ""); // .on("change", () => this.performDraw());
-      main.select(".treedraw_first").attr("value", args && args.firstentry ? args.firstentry : ""); // .on("change", () => this.performDraw());
+      main.select(".treedraw_cut").property("value", args?.parse_cut || "").on("change", () => this.performDraw());
+      main.select(".treedraw_opt").property("value", args?.drawopt || "").on("change", () => this.performDraw());
+      main.select(".treedraw_number").attr("value", args?.numentries || ""); // .on("change", () => this.performDraw());
+      main.select(".treedraw_first").attr("value", args?.firstentry || ""); // .on("change", () => this.performDraw());
       main.select(".treedraw_clear").on("click", () => cleanup(this.drawid));
    }
 
@@ -165,7 +165,7 @@ function createTreePlayer(player) {
 
       this.drawid = "jsroot_tree_player_" + internals.id_counter++ + "_draw";
 
-      let show_extra = args && (args.parse_cut || args.numentries || args.firstentry);
+      let show_extra = args?.parse_cut || args?.numentries || args?.firstentry;
 
       main.html('<div style="display:flex; flex-flow:column; height:100%; width:100%;">'+
                    '<div class="treedraw_buttons" style="flex: 0 1 auto;margin-top:0.2em;">' +
@@ -187,7 +187,7 @@ function createTreePlayer(player) {
              .attr("title", "Tree draw player for: " + this.local_tree.fName);
       main.select('.treedraw_exe').on("click", () => this.performDraw());
       main.select('.treedraw_varexp')
-          .attr("value", args && args.parse_expr ? args.parse_expr : (this.dflt_expr || "px:py"))
+          .attr("value", args?.parse_expr || this.draw_expr || "px:py")
           .on("change", () => this.performDraw());
       main.select('.treedraw_varexp_info')
           .attr('title', "Example of valid draw expressions:\n" +
@@ -300,6 +300,8 @@ function createTreePlayer(player) {
          });
       };
 
+      this.draw_expr = expr;
+
       if (this.askey) {
          // first let read tree from the file
          this.askey = false;
@@ -323,11 +325,11 @@ function drawTreePlayer(hpainter, itemname, askey, asleaf) {
 
    let item = hpainter.findItem(itemname),
        top = hpainter.getTopOnlineItem(item),
-       draw_expr = "", leaf_cnt = 0;
+       expr = "", leaf_cnt = 0;
    if (!item || !top) return null;
 
    if (asleaf) {
-      draw_expr = item._name;
+      expr = item._name;
       while (item && !item._ttree) item = item._parent;
       if (!item) return null;
       itemname = hpainter.itemFullName(item);
@@ -351,13 +353,13 @@ function drawTreePlayer(hpainter, itemname, askey, asleaf) {
       for (let n = 0; n < item._childs.length; ++n) {
          let leaf = item._childs[n];
          if (leaf && leaf._kind && (leaf._kind.indexOf("ROOT.TLeaf") == 0) && (leaf_cnt < 2)) {
-            if (leaf_cnt++ > 0) draw_expr+=":";
-            draw_expr+=leaf._name;
+            if (leaf_cnt++ > 0) expr += ":";
+            expr += leaf._name;
          }
       }
 
    createTreePlayer(player);
-   player.configureOnline(itemname, url, askey, root_version, draw_expr);
+   player.configureOnline(itemname, url, askey, root_version, expr);
    player.showPlayer();
 
    return player;

--- a/js/modules/hist/TF1Painter.mjs
+++ b/js/modules/hist/TF1Painter.mjs
@@ -8,16 +8,6 @@ import { TH1Painter } from '../hist2d/TH1Painter.mjs';
 
 import * as jsroot_math from '../base/math.mjs';
 
-function funcEvalPar(x, y) {
-   if (! ('_func' in this) || (this._title !== this.fTitle)) {
-
-     this._title = this.fTitle;
-   }
-
-   return this._func(x, y);
-}
-
-
 function proivdeEvalPar(obj) {
 
    obj._math = jsroot_math;

--- a/net/http/inc/THttpEngine.h
+++ b/net/http/inc/THttpEngine.h
@@ -20,7 +20,7 @@ class THttpEngine : public TNamed {
 protected:
    friend class THttpServer;
 
-   THttpServer *fServer; ///<! object server
+   THttpServer *fServer{nullptr}; ///<! object server
 
    THttpEngine(const char *name, const char *title);
 

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -10,8 +10,8 @@
 
 #include "TCivetweb.h"
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #ifdef _MSC_VER
 #include <windows.h>

--- a/net/http/src/TFastCgi.cxx
+++ b/net/http/src/TFastCgi.cxx
@@ -50,7 +50,7 @@ public:
 
 #include "fcgiapp.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 void FCGX_ROOT_send_file(FCGX_Request *request, const char *fname)
 {

--- a/net/http/src/THttpCallArg.cxx
+++ b/net/http/src/THttpCallArg.cxx
@@ -11,7 +11,8 @@
 
 #include "THttpCallArg.h"
 
-#include <string.h>
+#include <cstring>
+
 #include "RZip.h"
 #include "THttpWSEngine.h"
 

--- a/net/http/src/THttpEngine.cxx
+++ b/net/http/src/THttpEngine.cxx
@@ -11,8 +11,6 @@
 
 #include "THttpEngine.h"
 
-#include <string.h>
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // THttpEngine                                                          //
@@ -26,6 +24,6 @@ ClassImp(THttpEngine);
 ////////////////////////////////////////////////////////////////////////////////
 /// normal constructor
 
-THttpEngine::THttpEngine(const char *name, const char *title) : TNamed(name, title), fServer(nullptr)
+THttpEngine::THttpEngine(const char *name, const char *title) : TNamed(name, title)
 {
 }

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -29,10 +29,10 @@
 #include "TRootSnifferStore.h"
 #include "THttpCallArg.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <memory>
 #include <vector>
-#include <string.h>
+#include <cstring>
 
 const char *item_prop_kind = "_kind";
 const char *item_prop_more = "_more";

--- a/net/http/src/TRootSniffer.cxx
+++ b/net/http/src/TRootSniffer.cxx
@@ -978,7 +978,8 @@ void TRootSniffer::ScanRoot(TRootSnifferScanRec &rec)
          chld.SetField(item_prop_kind, "ROOT.TStreamerInfoList");
          chld.SetField(item_prop_title, "List of streamer infos for binary I/O");
          chld.SetField(item_prop_hidden, "true", kFALSE);
-         chld.SetField("_after_request", "JSROOT.markAsStreamerInfo");
+         chld.SetField("_module", "hierarchy");
+         chld.SetField("_after_request", "markAsStreamerInfo");
       }
    }
 

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -38,8 +38,8 @@
 #include "TRootSnifferStore.h"
 #include "THttpCallArg.h"
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -100,8 +100,8 @@ void TRootSnifferFull::ScanObjectProperties(TRootSnifferScanRec &rec, TObject *o
    if (obj && obj->InheritsFrom(TLeaf::Class())) {
       rec.SetField("_more", "false", kFALSE);
       rec.SetField("_can_draw", "false", kFALSE);
-      rec.SetField("_player", "JSROOT.drawLeafPlayer");
-      rec.SetField("_prereq", "hierarchy");
+      rec.SetField("_player", "drawLeafPlayer");
+      rec.SetField("_module", "draw_tree");
       return;
    }
 
@@ -126,8 +126,8 @@ void TRootSnifferFull::ScanKeyProperties(TRootSnifferScanRec &rec, TKey *key, TO
                obj_class = obj->IsA();
          } else {
             rec.SetField("_ttree", "true", kFALSE); // indicate ROOT TTree
-            rec.SetField("_player", "JSROOT.drawTreePlayerKey");
-            rec.SetField("_prereq", "hierarchy");
+            rec.SetField("_player", "drawTreePlayerKey");
+            rec.SetField("_module", "draw_tree");
             // rec.SetField("_more", "true", kFALSE); // one could allow to extend
          }
       }
@@ -143,8 +143,8 @@ void TRootSnifferFull::ScanObjectChilds(TRootSnifferScanRec &rec, TObject *obj)
    if (obj->InheritsFrom(TTree::Class())) {
       if (!rec.IsReadOnly(fReadOnly)) {
          rec.SetField("_ttree", "true", kFALSE); // indicate ROOT TTree
-         rec.SetField("_player", "JSROOT.drawTreePlayer");
-         rec.SetField("_prereq", "hierarchy");
+         rec.SetField("_player", "drawTreePlayer");
+         rec.SetField("_module", "draw_tree");
       }
       ScanCollection(rec, ((TTree *)obj)->GetListOfLeaves());
    } else if (obj->InheritsFrom(TBranch::Class())) {


### PR DESCRIPTION
Custom functionality loaded as modules and not as prerequicities.
Although old method with `_prereq` will continue to work.

Fix minor problems with TTree player in JSROOT

Small code adjustments in THttp classes