### PR TITLE
[RF] RooBinSamplingPdf fixes to re-enable `IntegrateBins_SubRange` test

### DIFF
--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -31,7 +31,6 @@ public:
   RooBinSamplingPdf() { };
   RooBinSamplingPdf(const char *name, const char *title, RooAbsRealLValue& observable, RooAbsPdf& inputPdf,
       double epsilon = 1.E-4);
-  ~RooBinSamplingPdf() override {};
 
   RooBinSamplingPdf(const RooBinSamplingPdf& other, const char* name = 0);
 
@@ -62,8 +61,16 @@ public:
     return _pdf->analyticalIntegral(code, rangeName);
   }
 
-  /// Since contained PDF is already normalised, this always returns true.
-  bool selfNormalized() const override { return true; }
+  /// Forwards to the PDF's implementation.
+  bool selfNormalized() const override { return _pdf->selfNormalized(); }
+
+  /// Forwards to the PDF's implementation.
+  RooAbsReal* createIntegral(const RooArgSet& iset,
+                             const RooArgSet* nset=nullptr,
+                             const RooNumIntConfig* cfg=nullptr,
+                             const char* rangeName=nullptr) const override {
+    return _pdf->createIntegral(iset, nset, cfg, rangeName);
+  }
 
   ExtendMode extendMode() const override { return _pdf->extendMode(); }
   Double_t expectedEvents(const RooArgSet* nset) const override { return _pdf->expectedEvents(nset); }
@@ -118,7 +125,6 @@ private:
 
   mutable std::unique_ptr<ROOT::Math::IntegratorOneDim> _integrator{nullptr}; ///<! Integrator used to sample bins.
   mutable std::vector<double> _binBoundaries; ///<! Workspace to store data for bin sampling
-  mutable const RooArgSet* _normSetForIntegrator{nullptr}; ///<! Normalisation set for operator() calls.
 
   ClassDefOverride(RooBinSamplingPdf,1)
 };

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -294,16 +294,13 @@ std::unique_ptr<ROOT::Math::IntegratorOneDim>& RooBinSamplingPdf::integrator() c
 /// Binding used by the integrator to evaluate the PDF.
 double RooBinSamplingPdf::operator()(double x) const {
   _observable->setVal(x);
-  return _pdf->getVal(_normSetForIntegrator);
+  return _pdf->getVal();
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Integrate the wrapped PDF using our current integrator, with given norm set and limits.
-double RooBinSamplingPdf::integrate(const RooArgSet* normSet, double low, double high) const {
-  // Need to set this because operator() only takes one argument.
-  _normSetForIntegrator = normSet;
-
+double RooBinSamplingPdf::integrate(const RooArgSet* /*normSet*/, double low, double high) const {
   return integrator()->Integral(low, high);
 }
 

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT MSVC OR win_broken_tests)
                      ${CMAKE_CURRENT_SOURCE_DIR}/dataHistv5_ref.root
                      ${CMAKE_CURRENT_SOURCE_DIR}/dataHistv6_ref.root)
 endif()
+ROOT_ADD_GTEST(testRooBinSamplingPdf testRooBinSamplingPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooSimPdfBuilder testRooSimPdfBuilder.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testRooFitDriver testRooFitDriver.cxx LIBRARIES RooFitCore RooFit)

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -1,0 +1,77 @@
+// Tests for the RooBinSamplingPdf
+// Authors: Jonas Rembser, CERN  03/2022
+
+#include <RooArgSet.h>
+#include <RooBinSamplingPdf.h>
+#include <RooGenericPdf.h>
+#include <RooAddPdf.h>
+#include <RooRandom.h>
+#include <RooDataSet.h>
+#include <RooDataHist.h>
+#include <RooRealVar.h>
+#include <RooMsgService.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+// For a linear pdf, doing the bin sampling should make no difference because
+// the integral of a linear function is the same as the central point.
+TEST(RooBinSamplingPdf, LinearPdfCrossCheck)
+{
+   using namespace RooFit;
+
+   auto& msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(RooFit::WARNING);
+
+   RooRandom::randomGenerator()->SetSeed(1337ul);
+
+   RooRealVar x("x", "x", 0.1, 5.1);
+   x.setBins(10);
+
+   RooGenericPdf pdf("lin", "x", RooArgSet(x));
+   std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
+   RooRealVar w("w", "weight", 0., 0., 10000.);
+   RooDataSet data("data", "data", RooArgSet(x, w), RooFit::WeightVar(w));
+   for (int i = 0; i < dataH->numEntries(); ++i) {
+      auto coords = dataH->get(i);
+      data.add(*coords, dataH->weight());
+   }
+
+   std::unique_ptr<RooAbsReal> nll1(pdf.createNLL(data));
+   std::unique_ptr<RooAbsReal> nll2(pdf.createNLL(data, IntegrateBins(1.E-3)));
+
+   EXPECT_FLOAT_EQ(nll2->getVal(), nll1->getVal());
+}
+
+// For a linear pdf, doing the bin sampling should make no difference because
+// the integral of a linear function is the same as the central point.
+// Similar to "LinearPdfCrossCheck", but this time for a subrange fit.
+TEST(RooBinSamplingPdf, LinearPdfSubRangeCrossCheck)
+{
+   using namespace RooFit;
+
+   auto& msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(RooFit::WARNING);
+
+   RooRandom::randomGenerator()->SetSeed(1337ul);
+
+   RooRealVar x("x", "x", 0.1, 5.1);
+   x.setBins(10);
+   x.setRange("range", 0.1, 4.1);
+   x.setBins(8, "range"); // consistent binning
+
+   RooGenericPdf pdf("lin", "x", RooArgSet(x));
+   std::unique_ptr<RooDataHist> dataH(pdf.generateBinned(x, 10000));
+   RooRealVar w("w", "weight", 0., 0., 10000.);
+   RooDataSet data("data", "data", RooArgSet(x, w), RooFit::WeightVar(w));
+   for (int i = 0; i < dataH->numEntries(); ++i) {
+      auto coords = dataH->get(i);
+      data.add(*coords, dataH->weight());
+   }
+
+   std::unique_ptr<RooAbsReal> nll1(pdf.createNLL(data, Range("range")));
+   std::unique_ptr<RooAbsReal> nll2(pdf.createNLL(data, Range("range"), IntegrateBins(1.E-3)));
+
+   EXPECT_FLOAT_EQ(nll2->getVal(), nll1->getVal());
+}

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -77,7 +77,7 @@ TEST(RooNLLVar, IntegrateBins) {
 /// Prepare a RooDataSet that looks like the one that HistFactory uses:
 /// It pretends to be an unbinned dataset, but instead of single events,
 /// events are aggregated in the bin centres using weights.
-TEST(RooNLLVar, DISABLED_IntegrateBins_SubRange) {
+TEST(RooNLLVar, IntegrateBins_SubRange) {
   RooRandom::randomGenerator()->SetSeed(1337ul);
 
   RooRealVar x("x", "x", 0.1, 5.1);
@@ -85,7 +85,7 @@ TEST(RooNLLVar, DISABLED_IntegrateBins_SubRange) {
   x.setRange("range", 0.1, 4.1);
   x.setBins(8, "range"); // consistent binning
 
-  RooRealVar a("a", "a", -0.7, -5., 5.);
+  RooRealVar a("a", "a", -0.3, -5., 5.);
   RooArgSet targetValues;
   RooArgSet(a).snapshot(targetValues);
 


### PR DESCRIPTION
This PR applies some fixes described in detail in the commit messages, with the goal to enable again the `IntegrateBins_SubRange` unit test which is done in the last commit.
