### PR TITLE
[RF] Fixup to ignoring categories in overlap check in RooFitHelpers

### DIFF
--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -206,12 +206,9 @@ bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vec
     return std::pair<double, double>{rlv.getMin(), rlv.getMax()};
   };
 
-  auto nObs = observables.size();
-  auto nRanges = rangeNames.size();
-
   // cache the range limits in a flat vector
   std::vector<std::pair<double,double>> limits;
-  limits.reserve(nRanges * nObs);
+  limits.reserve(rangeNames.size() * observables.size());
 
   for (auto const& range : rangeNames) {
     for (auto const& obs : observables) {
@@ -224,6 +221,9 @@ bool checkIfRangesOverlap(RooAbsPdf const& pdf, RooAbsData const& data, std::vec
       }
     }
   }
+
+  auto nRanges = rangeNames.size();
+  auto nObs = limits.size() / nRanges; // number of observables that are not categories
 
   // loop over pairs of ranges
   for(size_t ir1 = 0; ir1 < nRanges; ++ir1) {

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -68,6 +68,10 @@ TEST(RooSimultaneous, MultiRangeNLL)
    auto &pdfCat1 = *ws.pdf("pdfCat1");
    auto &pdfCat2 = *ws.pdf("pdfCat2");
 
+   // set the ranges
+   x.setRange("range1", 0.0, 4.0);
+   x.setRange("range2", 6.0, 10.0);
+
    // Create combined pdf
    RooCategory indexCat("cat", "cat");
    indexCat.defineType("cat1");


### PR DESCRIPTION
This is a fixup to a previous commit.

