### PR TITLE
Adjust new JSROOT to jupyter lab/notebooks [skip-ci]

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -74,7 +74,7 @@ if (typeof requirejs !== 'undefined') {{
 
     // We are in jupyter notebooks, use require.js which should be configured already
     requirejs.config({{
-       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.1.1/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.1.1/scripts/JSRoot.core.min' ] }}
+       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.3.4/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.3.4/scripts/JSRoot.core.min' ] }}
     }})(['JSRootCore'],  function(Core) {{
        display_{jsDivId}(Core);
     }});
@@ -97,7 +97,7 @@ if (typeof requirejs !== 'undefined') {{
     // Try loading a local version of requirejs and fallback to cdn if not possible.
     script_load_{jsDivId}(base_url + 'static/scripts/JSRoot.core.js', function(){{
         console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file');
-        script_load_{jsDivId}('https://root.cern/js/6.1.1/scripts/JSRoot.core.min.js', function(){{
+        script_load_{jsDivId}('https://root.cern/js/6.3.4/scripts/JSRoot.core.min.js', function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = "modules";
 
 /** @summary version date
   * @desc Release date in format day/month/year like "19/11/2021" */
-let version_date = "29/03/2022";
+let version_date = "30/03/2022";
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/draw/TTree.mjs
+++ b/js/modules/draw/TTree.mjs
@@ -338,7 +338,7 @@ function drawTreePlayer(hpainter, itemname, askey, asleaf) {
    let url = hpainter.getOnlineItemUrl(itemname);
    if (!url) return null;
 
-   let root_version = top._root_version ? parseInt(top._root_version) : 396545; // by default use version number 6-13-01
+   let root_version = top._root_version || 400129; // by default use version number 6-27-01
 
    let mdi = hpainter.getDisplay();
    if (!mdi) return null;
@@ -455,7 +455,7 @@ function drawTree() {
       args.testio = true;
       args.showProgress = showProgress;
       pr = treeIOTest(tree, args);
-   } else if (args.expr) {
+   } else if (args.expr || args.branch) {
       pr = treeDraw(tree, args);
    } else
       return Promise.resolve(painter);

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -1584,16 +1584,16 @@ class HierarchyPainter extends BasePainter {
 
       if (place == "item") {
 
-         if ('_player' in hitem)
+         if (hitem._player)
             return this.player(itemname);
 
-         if (handle && handle.aslink)
+         if (handle?.aslink)
             return window.open(itemname + "/");
 
-         if (handle && handle.execute)
+         if (handle?.execute)
             return this.executeCommand(itemname, node.parentNode);
 
-         if (handle && handle.ignore_online && this.isOnlineItem(hitem)) return;
+         if (handle?.ignore_online && this.isOnlineItem(hitem)) return;
 
          let can_draw = hitem._can_draw,
              can_expand = hitem._more,
@@ -1621,10 +1621,10 @@ class HierarchyPainter extends BasePainter {
          if (can_draw && can_expand && !drawopt) {
             // if default action specified as expand, disable drawing
             // if already displayed, try to expand
-            if (dflt_expand || (handle && (handle.dflt === 'expand')) || this.isItemDisplayed(itemname)) can_draw = false;
+            if (dflt_expand || (handle?.dflt === 'expand') || this.isItemDisplayed(itemname)) can_draw = false;
          }
 
-         if (can_draw && !drawopt && handle && handle.dflt && (handle.dflt !== 'expand'))
+         if (can_draw && !drawopt && handle?.dflt && (handle?.dflt !== 'expand'))
             drawopt = handle.dflt;
 
          if (can_draw)


### PR DESCRIPTION
Provide functions which are used in JSROOT-based display in `jupyter`.

After final v7 JSROOT release code in `jupyter` will be adjusted to dynamic modules loading.
