### PR TITLE
[rbrowser] fix handling of multiple cycles in ROOT file

### DIFF
--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -228,7 +228,8 @@ public:
       if (!obj_class)
          return nullptr;
 
-      void *obj = fDir->GetObjectChecked(fKeyName.c_str(), obj_class);
+      std::string namecycle = fKeyName + ";"s + std::to_string(fKeyCycle);
+      void *obj = fDir->GetObjectChecked(namecycle.c_str(), obj_class);
       if (!obj)
          return nullptr;
 


### PR DESCRIPTION
By mistake only last cycle was read.

Also let display only last cycle in list of TDirectory keys
One need to set "WebGui.LastCycle: yes" in rootrc file.
Default is no - means all keys will be displayed in browser