### PR TITLE
[math] Fix Delaunay2D interpolation for input degenerate points

### DIFF
--- a/hist/hist/src/TGraphDelaunay2D.cxx
+++ b/hist/hist/src/TGraphDelaunay2D.cxx
@@ -17,13 +17,18 @@ ClassImp(TGraphDelaunay2D);
 
 /** \class TGraphDelaunay2D
     \ingroup Graphs
-TGraphDelaunay2D generates a Delaunay triangulation of a TGraph2D. This
-triangulation code derives from an implementation done by Luke Jones
-(Royal Holloway, University of London) in April 2002 in the PAW context.
+TGraphDelaunay2D generates a Delaunay triangulation of a TGraph2D.
+The algorithm used for finding the triangles is based on on
+**Triangle**, a two-dimensional quality mesh generator and
+Delaunay triangulator from Jonathan Richard Shewchuk.
+See [http://www.cs.cmu.edu/~quake/triangle.html]
+The ROOT::Math::Delaunay2D class provides a wrapper for using
+the **Triangle** library.
 
-This software cannot be guaranteed to work under all circumstances. They
-were originally written to work with a few hundred points in an XY space
-with similar X and Y ranges.
+This implementation provides large improvements in terms of computational performances
+compared to the legacy one available in TGraphDelaunay, and it is by default
+used in TGraph2D. The old, legacy implementation can be still used when calling
+`TGraph2D::GetHistogram` and `TGraph2D::Draw` with the `old` option.
 
 Definition of Delaunay triangulation (After B. Delaunay):
 For a set S of points in the Euclidean plane, the unique triangulation DT(S)

--- a/math/mathcore/inc/Math/Delaunay2D.h
+++ b/math/mathcore/inc/Math/Delaunay2D.h
@@ -92,7 +92,9 @@ public:
    /// set the input points for building the graph
    void SetInputPoints(int n, const double *x, const double * y, const double * z, double xmin=0, double xmax=0, double ymin=0, double ymax=0);
 
-   /// Return the Interpolated z value corresponding to the (x,y) point
+   /// Return the Interpolated z value corresponding to the given (x,y) point
+   /// Note that in case no Delaunay triangles are found, for example when the
+   /// points are aligned, then a default value of zero is always return
    double  Interpolate(double x, double y);
 
    /// Find all triangles


### PR DESCRIPTION

When xmin=xmax or ymin=ymax the transformed min max are Nan and this causes the
routine to find the triangles to hang forever.
Now in this case and when also no trisangles are found the default zero value is always return

Update also the documentation of the class and of TGraphDelaunay2D.

This Pull request fixes #10266


