### PR TITLE
[textinput] Do not assign ESC a special meaning on history search mode

### DIFF
--- a/core/textinput/src/textinput/Editor.cpp
+++ b/core/textinput/src/textinput/Editor.cpp
@@ -152,7 +152,6 @@ namespace textinput {
     // Stop incremental history search, leaving text at the
     // history line currently selected.
     if (fMode == kInputMode) return;
-    fContext->GetKeyBinding()->EnableEscCmd(false);
     SetEditorPrompt(Text());
     DisplayR.ExtendPromptUpdate(Range::kUpdateEditorPrompt);
     fMode = kInputMode;
@@ -461,7 +460,6 @@ namespace textinput {
         fSearch.clear();
         fMode = (M == kCmdReverseSearch ? kHistRevSearchMode : kHistFwdSearchMode);
         SetHistSearchModePrompt(R.fDisplay);
-        fContext->GetKeyBinding()->EnableEscCmd(true);
         if (UpdateHistSearch(R)) return kPRSuccess;
         return kPRError;
       case kCmdHistReplay:


### PR DESCRIPTION
UNIX terminals, e.g. vt100, send escape sequences for many special key combinations. Entering the history search mode assigned a specific meaning to the `ESC` character and disabled the processing of escape sequences, thus accidentally printing some characters that are part of a CSI.

As a workaround, avoid changing the meaning of `ESC`; users can still use the well-known `ESC ESC` sequence (or any other editor command, e.g. move left/right) to exit the history search mode.

This change only affects UNIX terminals.

Closes issue #10209.

## Checklist:
- [X] tested changes locally

This PR fixes #10209.