### PR TITLE
[RF] Also read other types than `int` into RooAbsCategory from TTree

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -33,6 +33,7 @@ class TTree;
 class RooVectorDataStore;
 class Roo1DTable;
 class TIterator;
+struct TreeReadBuffer; /// A space to attach TBranches
 
 class RooAbsCategory : public RooAbsArg {
 public:
@@ -40,7 +41,7 @@ public:
   using value_type = int;
 
   // Constructors, assignment etc.
-  RooAbsCategory() { };
+  RooAbsCategory();
   RooAbsCategory(const char *name, const char *title);
   RooAbsCategory(const RooAbsCategory& other, const char* name=0) ;
   ~RooAbsCategory() override;
@@ -215,13 +216,14 @@ protected:
   mutable value_type _currentIndex{std::numeric_limits<int>::min()}; ///< Current category state
   std::map<std::string, value_type> _stateNames;                     ///< Map state names to index numbers. Make sure state names are updated in recomputeShape().
   std::vector<std::string> _insertionOrder;                          ///< Keeps track in which order state numbers have been inserted. Make sure this is updated in recomputeShape().
-  mutable UChar_t _byteValue{0};                                     ///<! Transient cache for byte values from tree branches
   mutable std::map<value_type, std::unique_ptr<RooCatType, std::function<void(RooCatType*)>> > _legacyStates; ///<! Map holding pointers to RooCatType instances. Only for legacy interface. Don't use if possible.
-  bool _treeVar{false}; ///< Is this category attached to a tree?
 
   static const decltype(_stateNames)::value_type& invalidCategory();
 
-  ClassDefOverride(RooAbsCategory, 3) // Abstract discrete variable
+private:
+  std::unique_ptr<TreeReadBuffer> _treeReadBuffer; //! A buffer for reading values from trees
+
+  ClassDefOverride(RooAbsCategory, 4) // Abstract discrete variable
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -84,6 +84,7 @@
 #include "RooCachedReal.h"
 #include "RooHelpers.h"
 #include "RunContext.h"
+#include "TreeReadBuffer.h"
 #include "ValueChecking.h"
 
 #include "ROOT/StringUtils.hxx"
@@ -3205,12 +3206,6 @@ RooAbsFunc *RooAbsReal::bindVars(const RooArgSet &vars, const RooArgSet* nset, B
 
 
 
-struct TreeReadBuffer {
-  virtual ~TreeReadBuffer() = default;
-  virtual operator double() = 0;
-};
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy the cached value of another RooAbsArg to our cache.
 /// Warning: This function just copies the cached values of source,
@@ -3235,30 +3230,6 @@ void RooAbsReal::attachToVStore(RooVectorDataStore& vstore)
 {
   RooVectorDataStore::RealVector* rv = vstore.addReal(this) ;
   rv->setBuffer(this,&_value) ;
-}
-
-
-namespace {
-/// Helper for reading branches with various types from a TTree, and convert all to double.
-template<typename T>
-struct TypedTreeReadBuffer final : public TreeReadBuffer {
-  operator double() override {
-    return _value;
-  }
-  T _value;
-};
-
-/// Create a TreeReadBuffer to hold the specified type, and attach to the branch passed as argument.
-/// \tparam T Type of branch to be read.
-/// \param[in] branchName Attach to this branch.
-/// \param[in] tree Tree to attach to.
-template<typename T>
-std::unique_ptr<TreeReadBuffer> createTreeReadBuffer(const TString& branchName, TTree& tree) {
-  auto buf = new TypedTreeReadBuffer<T>();
-  tree.SetBranchAddress(branchName.Data(), &buf->_value);
-  return std::unique_ptr<TreeReadBuffer>(buf);
-}
-
 }
 
 

--- a/roofit/roofitcore/src/TreeReadBuffer.h
+++ b/roofit/roofitcore/src/TreeReadBuffer.h
@@ -1,0 +1,44 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   Stephan Hageboeck, CERN 2020
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_TreeReadBuffer_h
+#define RooFit_TreeReadBuffer_h
+
+#include <TTree.h>
+
+struct TreeReadBuffer {
+   virtual ~TreeReadBuffer() = default;
+   virtual operator double() = 0;
+   virtual operator int() = 0;
+};
+
+/// Helper for reading branches with various types from a TTree, and convert all to double.
+template <typename T>
+struct TypedTreeReadBuffer final : public TreeReadBuffer {
+   operator double() override { return _value; }
+   operator int() override { return _value; }
+   T _value;
+};
+
+/// Create a TreeReadBuffer to hold the specified type, and attach to the branch passed as argument.
+/// \tparam T Type of branch to be read.
+/// \param[in] branchName Attach to this branch.
+/// \param[in] tree Tree to attach to.
+template <typename T>
+std::unique_ptr<TreeReadBuffer> createTreeReadBuffer(const TString &branchName, TTree &tree)
+{
+   auto buf = new TypedTreeReadBuffer<T>();
+   tree.SetBranchAddress(branchName.Data(), &buf->_value);
+   return std::unique_ptr<TreeReadBuffer>(buf);
+}
+
+#endif

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -9,6 +9,7 @@
 
 ROOT_ADD_GTEST(simple simple.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooCacheManager testRooCacheManager.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testRooCategory testRooCategory.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testWorkspace testWorkspace.cxx LIBRARIES RooFitCore RooStats)
 if(NOT MSVC OR win_broken_tests)
   ROOT_ADD_GTEST(testRooDataHist testRooDataHist.cxx LIBRARIES RooFitCore

--- a/roofit/roofitcore/test/testRooCategory.cxx
+++ b/roofit/roofitcore/test/testRooCategory.cxx
@@ -1,0 +1,26 @@
+// Tests for the RooCategory
+// Author: Jonas Rembser, CERN  04/2021
+
+#include <RooCategory.h>
+#include <RooDataSet.h>
+#include <RooGlobalFunc.h>
+
+#include <TTree.h>
+
+#include <gtest/gtest.h>
+
+// GitHub issue 10278: RooDataSet incorrectly loads RooCategory values from TTree branch of type Short_t
+TEST(RooCategory, CategoryDefineMultiState)
+{
+   TTree tree("test_tree", "Test tree");
+   Short_t cat_in;
+   tree.Branch("cat", &cat_in);
+
+   cat_in = 2; // category B
+   tree.Fill();
+
+   RooCategory cat("cat", "Category", {{"B_cat", 2}, {"A_cat", 3}});
+   RooDataSet data("data", "RooDataSet", RooArgSet(cat), RooFit::Import(tree));
+
+   EXPECT_EQ(static_cast<RooCategory &>((*data.get(0))["cat"]).getCurrentIndex(), 2);
+}


### PR DESCRIPTION
For `RooAbsReal`, this was already implemented in [1] with the
TreeReadBuffer mechanism. This commit uses the same approach for the
RooAbsCategory as well, such that one can read TTree branches of all
fundamental types to RooFit categories.

Fixes #10278.

[1] a18675ad7fd, "Add capability to read ULong64_t + more into RooDataSets."