### PR TITLE
[llvm] Build llvm with rtti enabled.

### DIFF
--- a/interpreter/CMakeLists.txt
+++ b/interpreter/CMakeLists.txt
@@ -4,6 +4,7 @@ if (NOT builtin_clang)
 endif()
 
 #---Define the way we want to build and what of llvm/clang/cling------------------------------------
+set(LLVM_ENABLE_RTTI ON CACHE BOOL "")
 set(LLVM_APPEND_VC_REV OFF CACHE BOOL "")
 set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "")
 set(LLVM_ENABLE_FFI OFF CACHE BOOL "")


### PR DESCRIPTION
Recent llvm versions use llvm::Error as a facility for error handling. It includes an ErrorInfoBase class which has virtual methods (with a pinned vtable in the object file). This makes it harder to include headers that use transitively include llvm/Support/Error.h crossing rtti/no-rtti worlds (that is llvm is compiled with -fno-rtti and TCling and friends with -frtti).

Newer llvm versions have a lot of usage of llvm::Error in its header files and it is practically impossible to solve this problem by avoiding the headers that use ErrorInfoBase.

There are two other alternatives. First we can outline the functions in Error.h which use ErrorInfoBase but then we will hit other things like RTTIRoot which also needs special treatment. Secondly, we can enable llvm's RTTI builds for ROOT and this is what this patch does.

