### PR TITLE
Fix issue #10283 Imported targets improperly forwarded

### DIFF
--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -146,6 +146,8 @@ ROOT_BUILD_OPTION(mathmore ON "Build libMathMore extended math library (requires
 ROOT_BUILD_OPTION(memory_termination OFF "Free internal ROOT memory before process termination (experimental, used for leak checking)")
 ROOT_BUILD_OPTION(mlp ON "Enable support for TMultilayerPerceptron classes' federation")
 ROOT_BUILD_OPTION(minuit2 ON "Build Minuit2 minimization library")
+ROOT_BUILD_OPTION(minuit2_mpi OFF "Enable support for MPI in Minuit2")
+ROOT_BUILD_OPTION(minuit2_omp OFF "Enable support for OpenMP in Minuit2")
 ROOT_BUILD_OPTION(monalisa OFF "Enable support for monitoring with Monalisa (requires libapmoncpp)")
 ROOT_BUILD_OPTION(mpi OFF "Enable support for Message Passing Interface (MPI)")
 ROOT_BUILD_OPTION(mysql ON "Enable support for MySQL databases")

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -90,6 +90,15 @@ if (NOT ROOT_builtin_nlohmannjson_FOUND)
   include(CMakeFindDependencyMacro)
   find_dependency(nlohmann_json @nlohmann_json_VERSION@)
 endif()
+if(ROOT_minuit2_mpi_FOUND)
+  include(CMakeFindDependencyMacro)
+  find_dependency(MPI)
+endif()
+if(ROOT_minuit2_omp_FOUND)
+  include(CMakeFindDependencyMacro)
+  find_dependency(OpenMP)
+  find_dependency(Threads)
+endif()
 
 #----------------------------------------------------------------------------
 # Now set them to ROOT_LIBRARIES

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -86,16 +86,14 @@ endforeach()
 
 #----------------------------------------------------------------------------
 # Find external packages which were used in ROOT
+include(CMakeFindDependencyMacro)
 if (NOT ROOT_builtin_nlohmannjson_FOUND)
-  include(CMakeFindDependencyMacro)
   find_dependency(nlohmann_json @nlohmann_json_VERSION@)
 endif()
 if(ROOT_minuit2_mpi_FOUND)
-  include(CMakeFindDependencyMacro)
   find_dependency(MPI)
 endif()
 if(ROOT_minuit2_omp_FOUND)
-  include(CMakeFindDependencyMacro)
   find_dependency(OpenMP)
   find_dependency(Threads)
 endif()

--- a/math/minuit2/CMakeLists.txt
+++ b/math/minuit2/CMakeLists.txt
@@ -8,10 +8,9 @@ cmake_minimum_required(VERSION 3.1)
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
   project(Minuit2 LANGUAGES CXX)
+  option(minuit2_mpi "Enable support for MPI in Minuit2")
+  option(minuit2_omp "Enable support for OpenMP in Minuit2")
 endif(NOT CMAKE_PROJECT_NAME STREQUAL ROOT)
-
-option(minuit2_mpi "Enable support for MPI in Minuit2")
-option(minuit2_omp "Enable support for OpenMP in Minuit2")
 
 # This package can be built separately
 # or as part of ROOT.


### PR DESCRIPTION
Fix an issue with `Threads`, `MPI`, and `OpenMP` not being properly exported when ROOT is built with `minuit2_omp=ON` and `minuit2_mp=ON`. Thanks to @ferdymercury for the hint and @amadio for the solution!
This PR fixes #10283 

