### PR TITLE
Restore 32-bit dataframe

### DIFF
--- a/build/unix/makepchinput.py
+++ b/build/unix/makepchinput.py
@@ -252,9 +252,6 @@ def isDirForPCH(dirName, legacyPyROOT):
                            "math/vdt",
                            "tmva/rmva"]
 
-   if (sys.platform != 'win32' and sys.maxsize <= 2**32): # https://docs.python.org/3/library/platform.html#cross-platform
-      PCHPatternsBlacklist.append("tree/dataframe")
-
    accepted = isAnyPatternInString(PCHPatternsWhitelist,dirName) and \
                not isAnyPatternInString(PCHPatternsBlacklist,dirName)
 

--- a/cmake/modules/RootBuildOptions.cmake
+++ b/cmake/modules/RootBuildOptions.cmake
@@ -344,11 +344,6 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES aarch64)
   set(runtime_cxxmodules_defvalue OFF)
 endif()
 
-# Disable RDataFrame on 32-bit UNIX platforms due to ROOT-9236
-if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 4)
-    set(dataframe_defvalue OFF)
-endif()
-
 # MultiProcess is not possible on Windows, so fail if it is manually set:
 if(roofit_multiprocess AND WIN32)
     message(FATAL_ERROR ">>> Option 'roofit_multiprocess' is not supported on Windows.")

--- a/tree/dataframe/test/dataframe_cache.cxx
+++ b/tree/dataframe/test/dataframe_cache.cxx
@@ -224,8 +224,6 @@ TEST(Cache, evtCounter)
 
 }
 
-#ifdef R__B64
-
 TEST(Cache, Regex)
 {
 
@@ -328,8 +326,6 @@ TEST(Cache, Carrays)
 
    gSystem->Unlink(fileName);
 }
-
-#endif // R__B64
 
 // ROOT-10563
 TEST(Cache, Alias)

--- a/tree/dataframe/test/datasource_arrow.cxx
+++ b/tree/dataframe/test/datasource_arrow.cxx
@@ -177,8 +177,6 @@ TEST(RArrowDS, SetNSlotsTwice)
 }
 #endif
 
-#ifdef R__B64
-
 TEST(RArrowDS, FromARDF)
 {
    std::unique_ptr<RDataSource> tds(new RArrowDS(createTestTable(), {}));
@@ -250,5 +248,3 @@ TEST(RArrowDS, FromARDFWithJittingMT)
 }
 
 #endif // R__USE_IMT
-
-#endif // R__B64

--- a/tree/dataframe/test/datasource_csv.cxx
+++ b/tree/dataframe/test/datasource_csv.cxx
@@ -210,8 +210,6 @@ TEST(RCsvDS, SetNSlotsTwice)
 }
 #endif
 
-#ifdef R__B64
-
 TEST(RCsvDS, FromARDF)
 {
    std::unique_ptr<RDataSource> tds(new RCsvDS(fileName0));
@@ -324,5 +322,3 @@ TEST(RCsvDS, ProgressiveReadingRDFMT)
 }
 
 #endif // R__USE_IMT
-
-#endif // R__B64

--- a/tree/dataframe/test/datasource_root.cxx
+++ b/tree/dataframe/test/datasource_root.cxx
@@ -117,8 +117,6 @@ TEST(TRootTDS, SetNSlotsTwice)
 }
 #endif
 
-#ifdef R__B64
-
 TEST(TRootTDS, FromARDF)
 {
    std::unique_ptr<RDataSource> tds(new ROOT::Internal::RDF::RRootDS(treeName, fileGlob));
@@ -190,5 +188,3 @@ TEST(TRootTDS, FromARDFWithJittingMT)
 }
 
 #endif // R__USE_IMT
-
-#endif // R__B64

--- a/tree/dataframe/test/datasource_trivial.cxx
+++ b/tree/dataframe/test/datasource_trivial.cxx
@@ -141,8 +141,6 @@ TEST(RTrivialDS, EarlyQuitWithRange)
    EXPECT_EQ(df.Range(10).Count().GetValue(), 10);
 }
 
-#ifdef R__B64
-
 TEST(RTrivialDS, FromARDFWithJitting)
 {
    std::unique_ptr<RDataSource> tds(new RTrivialDS(32));
@@ -245,5 +243,3 @@ TEST(RTrivialDS, SkipEntriesMT)
 }
 
 #endif // R__USE_IMT
-
-#endif // R__B64

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -332,10 +332,6 @@ else()
   list(APPEND root7_veto ${v7_veto_files})
 endif()
 
-if( CMAKE_SIZEOF_VOID_P EQUAL 4 )
-  set(bits32_veto dataframe/*.C graphs/timeSeriesFrom*.C v7/ntuple/ntpl004_dimuon.C)
-endif()
-
 if (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64)
    set(macm1_veto dataframe/df107_SingleTopAnalysis.py)
 endif()
@@ -391,7 +387,6 @@ set(all_veto hsimple.C
              ${classic_veto}
              ${pythia_veto}
              ${root7_veto}
-             ${bits32_veto}
              ${xrootd_veto}
              ${mlp_veto}
              ${spectrum_veto}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

With the improvements in dataframe with better distinction between long, long long and pointers it works OK on ix86 when compiled with gcc 12.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

```
          Start   54: pyunittests-pyroot-pyz-rdataframe-asnumpy
          Start   55: pyunittests-pyroot-pyz-rdataframe-makenumpy
 134/1231 Test   #55: pyunittests-pyroot-pyz-rdataframe-makenumpy .........................   Passed   10.99 sec
 151/1231 Test   #54: pyunittests-pyroot-pyz-rdataframe-asnumpy ...........................   Passed   23.56 sec
          Start  363: gtest-tree-dataframe-test-dataframe-friends
          Start  364: gtest-tree-dataframe-test-dataframe-colnames
          Start  365: gtest-tree-dataframe-test-dataframe-cache
 388/1231 Test  #364: gtest-tree-dataframe-test-dataframe-colnames ........................   Passed    4.40 sec
          Start  366: gtest-tree-dataframe-test-dataframe-callbacks
 389/1231 Test  #363: gtest-tree-dataframe-test-dataframe-friends .........................   Passed   10.87 sec
          Start  367: gtest-tree-dataframe-test-dataframe-histomodels
 390/1231 Test  #366: gtest-tree-dataframe-test-dataframe-callbacks .......................   Passed    8.60 sec
          Start  368: gtest-tree-dataframe-test-dataframe-interface
          Start  369: gtest-tree-dataframe-test-dataframe-nodes
 392/1231 Test  #369: gtest-tree-dataframe-test-dataframe-nodes ...........................   Passed    2.13 sec
          Start  370: gtest-tree-dataframe-test-dataframe-regression
 393/1231 Test  #367: gtest-tree-dataframe-test-dataframe-histomodels .....................   Passed   19.30 sec
          Start  371: gtest-tree-dataframe-test-dataframe-utils
 394/1231 Test  #371: gtest-tree-dataframe-test-dataframe-utils ...........................   Passed    1.38 sec
          Start  372: gtest-tree-dataframe-test-dataframe-report
 395/1231 Test  #370: gtest-tree-dataframe-test-dataframe-regression ......................   Passed   12.11 sec
          Start  373: gtest-tree-dataframe-test-dataframe-splitcoll-arrayview
 396/1231 Test  #372: gtest-tree-dataframe-test-dataframe-report ..........................   Passed    0.79 sec
          Start  374: gtest-tree-dataframe-test-dataframe-redefine
 397/1231 Test  #373: gtest-tree-dataframe-test-dataframe-splitcoll-arrayview .............   Passed    1.07 sec
          Start  375: gtest-tree-dataframe-test-dataframe-definepersample
 398/1231 Test  #374: gtest-tree-dataframe-test-dataframe-redefine ........................   Passed    3.63 sec
          Start  376: gtest-tree-dataframe-test-dataframe-simple
 399/1231 Test  #375: gtest-tree-dataframe-test-dataframe-definepersample .................   Passed    3.06 sec
          Start  377: gtest-tree-dataframe-test-dataframe-helpers
 400/1231 Test  #368: gtest-tree-dataframe-test-dataframe-interface .......................   Passed   21.83 sec
          Start  378: gtest-tree-dataframe-test-dataframe-vecops
 401/1231 Test  #378: gtest-tree-dataframe-test-dataframe-vecops ..........................   Passed    3.95 sec
          Start  379: gtest-tree-dataframe-test-dataframe-snapshot
 402/1231 Test  #377: gtest-tree-dataframe-test-dataframe-helpers .........................   Passed    8.48 sec
          Start  380: gtest-tree-dataframe-test-dataframe-display
 403/1231 Test  #365: gtest-tree-dataframe-test-dataframe-cache ...........................   Passed   44.39 sec
          Start  381: gtest-tree-dataframe-test-dataframe-ranges
          Start  382: gtest-tree-dataframe-test-dataframe-leaves
 405/1231 Test  #381: gtest-tree-dataframe-test-dataframe-ranges ..........................   Passed    2.10 sec
          Start  383: gtest-tree-dataframe-test-dataframe-resptr
 406/1231 Test  #383: gtest-tree-dataframe-test-dataframe-resptr ..........................   Passed    0.61 sec
          Start  384: gtest-tree-dataframe-test-dataframe-take
 407/1231 Test  #382: gtest-tree-dataframe-test-dataframe-leaves ..........................   Passed    2.14 sec
          Start  385: gtest-tree-dataframe-test-dataframe-entrylist
 408/1231 Test  #385: gtest-tree-dataframe-test-dataframe-entrylist .......................   Passed    0.90 sec
          Start  386: gtest-tree-dataframe-test-dataframe-merge-results
 409/1231 Test  #386: gtest-tree-dataframe-test-dataframe-merge-results ...................   Passed    0.54 sec
          Start  387: gtest-tree-dataframe-test-dataframe-samplecallback
 410/1231 Test  #384: gtest-tree-dataframe-test-dataframe-take ............................   Passed    2.19 sec
          Start  388: gtest-tree-dataframe-test-dataframe-vary
 411/1231 Test  #387: gtest-tree-dataframe-test-dataframe-samplecallback ..................   Passed    1.09 sec
          Start  389: gtest-tree-dataframe-test-datasource-more
 412/1231 Test  #380: gtest-tree-dataframe-test-dataframe-display .........................   Passed   10.54 sec
          Start  390: gtest-tree-dataframe-test-datasource-root
          Start  391: gtest-tree-dataframe-test-datasource-trivial
 414/1231 Test  #390: gtest-tree-dataframe-test-datasource-root ...........................   Passed    4.54 sec
          Start  392: gtest-tree-dataframe-test-datasource-lazy
 415/1231 Test  #392: gtest-tree-dataframe-test-datasource-lazy ...........................   Passed    0.28 sec
          Start  393: gtest-tree-dataframe-test-datasource-csv
 416/1231 Test  #388: gtest-tree-dataframe-test-dataframe-vary ............................   Passed    6.93 sec
          Start  394: gtest-tree-dataframe-test-dataframe-concurrency
 417/1231 Test  #379: gtest-tree-dataframe-test-dataframe-snapshot ........................   Passed   20.68 sec
          Start  395: gtest-tree-dataframe-test-datasource-ntuple
 418/1231 Test  #389: gtest-tree-dataframe-test-datasource-more ...........................   Passed    7.48 sec
          Start  396: gtest-tree-dataframe-test-datasource-sqlite
 419/1231 Test  #395: gtest-tree-dataframe-test-datasource-ntuple .........................   Passed    1.80 sec
          Start  397: pyunittests-dataframe-misc
 420/1231 Test  #393: gtest-tree-dataframe-test-datasource-csv ............................   Passed    3.56 sec
          Start  398: pyunittests-dataframe-histograms
 421/1231 Test  #391: gtest-tree-dataframe-test-datasource-trivial ........................   Passed    6.48 sec
          Start  399: pyunittests-dataframe-cache
 422/1231 Test  #396: gtest-tree-dataframe-test-datasource-sqlite .........................   Passed    4.60 sec
          Start  400: pyunittests-dataframe-merge-results
 423/1231 Test  #397: pyunittests-dataframe-misc ..........................................   Passed    3.66 sec
 424/1231 Test  #398: pyunittests-dataframe-histograms ....................................   Passed    3.40 sec
 444/1231 Test  #400: pyunittests-dataframe-merge-results .................................   Passed    4.48 sec
 446/1231 Test  #376: gtest-tree-dataframe-test-dataframe-simple ..........................   Passed   38.57 sec
 447/1231 Test  #399: pyunittests-dataframe-cache .........................................   Passed   10.50 sec
          Start  447: tutorial-dataframe-df000_simple
          Start  448: tutorial-dataframe-df001_introduction
          Start  449: tutorial-dataframe-df002_dataModel
 470/1231 Test  #447: tutorial-dataframe-df000_simple .....................................   Passed    2.85 sec
          Start  450: tutorial-dataframe-df003_profiles
          Start  451: tutorial-dataframe-df004_cutFlowReport
 472/1231 Test  #450: tutorial-dataframe-df003_profiles ...................................   Passed    5.31 sec
          Start  452: tutorial-dataframe-df005_fillAnyObject
 473/1231 Test  #449: tutorial-dataframe-df002_dataModel ..................................   Passed    9.46 sec
          Start  453: tutorial-dataframe-df006_ranges
 474/1231 Test  #451: tutorial-dataframe-df004_cutFlowReport ..............................   Passed    6.28 sec
          Start  454: tutorial-dataframe-df007_snapshot
 475/1231 Test  #448: tutorial-dataframe-df001_introduction ...............................   Passed   13.89 sec
          Start  455: tutorial-dataframe-df008_createDataSetFromScratch
 476/1231 Test  #452: tutorial-dataframe-df005_fillAnyObject ..............................   Passed    6.60 sec
          Start  456: tutorial-dataframe-df009_FromScratchVSTTree
 477/1231 Test  #453: tutorial-dataframe-df006_ranges .....................................   Passed    7.33 sec
          Start  457: tutorial-dataframe-df010_trivialDataSource
 478/1231 Test  #455: tutorial-dataframe-df008_createDataSetFromScratch ...................   Passed    3.90 sec
          Start  458: tutorial-dataframe-df012_DefinesAndFiltersAsStrings
 479/1231 Test  #394: gtest-tree-dataframe-test-dataframe-concurrency .....................   Passed   44.21 sec
          Start  459: tutorial-dataframe-df014_CSVDataSource
 480/1231 Test  #456: tutorial-dataframe-df009_FromScratchVSTTree .........................   Passed    4.16 sec
          Start  460: tutorial-dataframe-df015_LazyDataSource
 481/1231 Test  #454: tutorial-dataframe-df007_snapshot ...................................   Passed    9.31 sec
          Start  461: tutorial-dataframe-df016_vecOps
 482/1231 Test  #457: tutorial-dataframe-df010_trivialDataSource ..........................   Passed    3.32 sec
          Start  462: tutorial-dataframe-df017_vecOpsHEP
 483/1231 Test  #458: tutorial-dataframe-df012_DefinesAndFiltersAsStrings .................   Passed    5.07 sec
          Start  463: tutorial-dataframe-df018_customActions
 484/1231 Test  #461: tutorial-dataframe-df016_vecOps .....................................   Passed    3.80 sec
          Start  464: tutorial-dataframe-df019_Cache
 485/1231 Test  #462: tutorial-dataframe-df017_vecOpsHEP ..................................   Passed    4.31 sec
          Start  465: tutorial-dataframe-df020_helpers
 486/1231 Test  #459: tutorial-dataframe-df014_CSVDataSource ..............................   Passed    6.87 sec
          Start  466: tutorial-dataframe-df021_createTGraph
 487/1231 Test  #460: tutorial-dataframe-df015_LazyDataSource .............................   Passed    6.11 sec
          Start  467: tutorial-dataframe-df022_useKahan
 488/1231 Test  #463: tutorial-dataframe-df018_customActions ..............................   Passed    3.66 sec
          Start  468: tutorial-dataframe-df023_aggregate
 489/1231 Test  #466: tutorial-dataframe-df021_createTGraph ...............................   Passed    2.94 sec
          Start  469: tutorial-dataframe-df024_Display
 490/1231 Test  #467: tutorial-dataframe-df022_useKahan ...................................   Passed    3.26 sec
          Start  470: tutorial-dataframe-df025_RNode
 491/1231 Test  #465: tutorial-dataframe-df020_helpers ....................................   Passed    3.82 sec
          Start  471: tutorial-dataframe-df031_Stats
 492/1231 Test  #468: tutorial-dataframe-df023_aggregate ..................................   Passed    2.25 sec
 498/1231 Test  #470: tutorial-dataframe-df025_RNode ......................................   Passed    2.80 sec
 502/1231 Test  #464: tutorial-dataframe-df019_Cache ......................................   Passed    7.71 sec
 506/1231 Test  #471: tutorial-dataframe-df031_Stats ......................................   Passed    3.82 sec
 507/1231 Test  #469: tutorial-dataframe-df024_Display ....................................   Passed    4.58 sec
          Start 1071: tutorial-dataframe-df000_simple-py
          Start 1072: tutorial-dataframe-df001_introduction-py
          Start 1073: tutorial-dataframe-df002_dataModel-py
          Start 1074: tutorial-dataframe-df003_profiles-py
1072/1231 Test #1071: tutorial-dataframe-df000_simple-py ..................................   Passed    2.85 sec
          Start 1075: tutorial-dataframe-df004_cutFlowReport-py
1073/1231 Test #1074: tutorial-dataframe-df003_profiles-py ................................   Passed    5.32 sec
          Start 1076: tutorial-dataframe-df006_ranges-py
1074/1231 Test #1072: tutorial-dataframe-df001_introduction-py ............................   Passed    7.77 sec
          Start 1077: tutorial-dataframe-df007_snapshot-py
1075/1231 Test #1075: tutorial-dataframe-df004_cutFlowReport-py ...........................   Passed    5.88 sec
          Start 1078: tutorial-dataframe-df008_createDataSetFromScratch-py
1076/1231 Test #1073: tutorial-dataframe-df002_dataModel-py ...............................   Passed    8.55 sec
          Start 1079: tutorial-dataframe-df010_trivialDataSource-py
1077/1231 Test #1079: tutorial-dataframe-df010_trivialDataSource-py .......................   Passed    3.14 sec
          Start 1080: tutorial-dataframe-df012_DefinesAndFiltersAsStrings-py
1078/1231 Test #1078: tutorial-dataframe-df008_createDataSetFromScratch-py ................   Passed    3.91 sec
          Start 1081: tutorial-dataframe-df014_CSVDataSource-py
1079/1231 Test #1076: tutorial-dataframe-df006_ranges-py ..................................   Passed    7.30 sec
          Start 1082: tutorial-dataframe-df016_vecOps-py
          Start 1083: tutorial-dataframe-df017_vecOpsHEP-py
1081/1231 Test #1077: tutorial-dataframe-df007_snapshot-py ................................   Passed    9.12 sec
          Start 1084: tutorial-dataframe-df019_Cache-py
1082/1231 Test #1080: tutorial-dataframe-df012_DefinesAndFiltersAsStrings-py ..............   Passed    5.30 sec
          Start 1085: tutorial-dataframe-df021_createTGraph-py
1083/1231 Test #1082: tutorial-dataframe-df016_vecOps-py ..................................   Passed    4.06 sec
          Start 1086: tutorial-dataframe-df024_Display-py
1084/1231 Test #1083: tutorial-dataframe-df017_vecOpsHEP-py ...............................   Passed    3.68 sec
          Start 1087: tutorial-dataframe-df026_AsNumpyArrays-py
1085/1231 Test #1081: tutorial-dataframe-df014_CSVDataSource-py ...........................   Passed    7.49 sec
          Start 1090: tutorial-dataframe-df031_Stats-py
1087/1231 Test #1085: tutorial-dataframe-df021_createTGraph-py ............................   Passed    3.08 sec
          Start 1091: tutorial-dataframe-df032_MakeNumpyDataFrame-py
1088/1231 Test #1086: tutorial-dataframe-df024_Display-py .................................   Passed    4.99 sec
1089/1231 Test #1084: tutorial-dataframe-df019_Cache-py ...................................   Passed    6.22 sec
1090/1231 Test #1090: tutorial-dataframe-df031_Stats-py ...................................   Passed    3.39 sec
1095/1231 Test #1087: tutorial-dataframe-df026_AsNumpyArrays-py ...........................   Passed    6.89 sec
1103/1231 Test #1091: tutorial-dataframe-df032_MakeNumpyDataFrame-py ......................   Passed    6.12 sec

          Start  635: tutorial-graphs-timeSeriesFromCSV
          Start  636: tutorial-graphs-timeSeriesFromCSV_TDF
 655/1231 Test  #635: tutorial-graphs-timeSeriesFromCSV ...................................   Passed    0.37 sec
 674/1231 Test  #636: tutorial-graphs-timeSeriesFromCSV_TDF ...............................   Passed    2.75 sec
          Start 1093: tutorial-graphs-timeSeriesFromCSV-py
1092/1231 Test #1093: tutorial-graphs-timeSeriesFromCSV-py ................................   Passed    0.78 sec
```

