### PR TITLE
Fix test when long is 32 bits

### DIFF
--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -470,11 +470,11 @@ void ReadWriteCarray(const char *outFileNameBase)
    auto size = 0;
    int v[maxArraySize];
    bool vb[maxArraySize];
-   long int vl[maxArraySize];
+   long long int vl[maxArraySize];
    t.Branch("size", &size, "size/I");
    t.Branch("v", v, "v[size]/I");
    t.Branch("vb", vb, "vb[size]/O");
-   t.Branch("vl", vl, "vl[size]/G");
+   t.Branch("vl", vl, "vl[size]/L");
 
    // Size 1
    size = 1;
@@ -518,7 +518,7 @@ void ReadWriteCarray(const char *outFileNameBase)
       TTreeReader r(treename, &f2);
       TTreeReaderArray<int> rv(r, "v");
       TTreeReaderArray<bool> rvb(r, "vb");
-      TTreeReaderArray<long int> rvl(r, "vl");
+      TTreeReaderArray<long long int> rvl(r, "vl");
 
       // Size 1
       EXPECT_TRUE(r.Next());
@@ -571,7 +571,7 @@ void ReadWriteCarray(const char *outFileNameBase)
 
    const auto outfname2 = outFileNameBaseStr + "_out2.root";
    RDataFrame(treename, fname)
-      .Snapshot<int, RVec<int>, RVec<bool>, RVec<long int>>(treename, outfname2, {"size", "v", "vb", "vl"});
+      .Snapshot<int, RVec<int>, RVec<bool>, RVec<long long int>>(treename, outfname2, {"size", "v", "vb", "vl"});
    outputChecker(outfname2.c_str());
 
    gSystem->Unlink(fname.c_str());


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This test tests support for 64 bit values. But it uses a long type, which fails on platforme where a long is 32 bits.

This commit changes the test to use a long long type instead.

```[ RUN      ] RDFSnapshotMore.ReadWriteCarray
/builddir/build/BUILD/root-6.26.00/tree/dataframe/test/dataframe_snapshot.cxx:530: Failure
Expected equality of these values:
  rvl[0]
    Which is: 0
  8589934592
/builddir/build/BUILD/root-6.26.00/tree/dataframe/test/dataframe_snapshot.cxx:530: Failure
Expected equality of these values:
  rvl[0]
    Which is: 0
  8589934592
[  FAILED  ] RDFSnapshotMore.ReadWriteCarray (1667 ms)
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
