### PR TITLE
Ignore warnings

### DIFF
--- a/core/testsupport/src/TestSupport.cxx
+++ b/core/testsupport/src/TestSupport.cxx
@@ -73,6 +73,13 @@ static struct ForbidDiagnostics {
         return;
       }
 
+      // FIXME: RooNaNPacker warns about not being implemented for big endian
+      if (level == kWarning
+	  && strcmp(msg, "Fast recovery from undefined function values only implemented for little-endian machines. If necessary, request an extension of functionality on https://root.cern") == 0) {
+        std::cerr << "Warning in " << location << " " << msg << std::endl;
+        return;
+      }
+
       FAIL() << "Received unexpected diagnostic of severity "
          << level
          << " at '" << location << "' reading '" << msg << "'.\n"


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Many RooFit test fails on s390x due to a warning about RooNaNPacker not being implemented for big endian.
There are too many of them to add RAIIs for each of them, so I added the warning to the default list in this PR.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
