### PR TITLE
NENTRIES is not always a multiple of the expected size

### DIFF
--- a/tree/dataframe/test/dataframe_samplecallback.cxx
+++ b/tree/dataframe/test/dataframe_samplecallback.cxx
@@ -125,11 +125,13 @@ TEST_P(RDFSampleCallback, EmptySourceSampleID) {
       // RDF with empty sources tries to produce 2 tasks per slot when MT is enabled
       const auto expectedSize = std::min(NENTRIES, df.GetNSlots() * 2ull);
       ASSERT_EQ(result->size(), expectedSize);
+      ULong64_t entries = 0;
       for (auto &id : *result) {
          // check that all entries start with the expected string
          EXPECT_TRUE(id.AsString().rfind("Empty source, range: {", 0) == 0);
-         EXPECT_EQ(id.NEntries(), NENTRIES / expectedSize);
+         entries += id.NEntries();
       }
+      EXPECT_EQ(entries, NENTRIES);
    } else {
       ASSERT_EQ(result->size(), 1);
       const auto &id = result->at(0);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

NENTRIES is 10.
On a 4 core machine the expected size in 2 × 4 = 8.
Looping over the 8 IDs, 2 have 2 entries the remaining 6 have 1 entry
for a total of 10 (NENTRIES) entries.
The test checked that each ID had NENTRIES/(expected size) entries,
which in this case with integer division equals 1 entry, which was not
the correct test.
This commit chenges to test to check that the total number of entries
summed for all IDs equals NENTRIES.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
