### PR TITLE
Use calls from Python directly

### DIFF
--- a/tutorials/roofit/rf105_funcbinding.py
+++ b/tutorials/roofit/rf105_funcbinding.py
@@ -17,15 +17,8 @@ import ROOT
 # ---------------------------------------------------
 
 # Bind one-dimensional ROOT.TMath.Erf function as ROOT.RooAbsReal function
-# Directly trying this in python doesn't work:
-# x = ROOT.RooRealVar("x", "x", -3, 3)
-# erf = ROOT.RooFit.bindFunction("erf", ROOT.TMath.Erf, x)
-# Need to go through C interface
-ROOT.gInterpreter.ProcessLine(
-    'auto x = RooRealVar("x", "x", -3, 3); auto myerf = RooFit::bindFunction("erf", TMath::Erf, x)'
-)
-x = ROOT.x
-erf = ROOT.myerf
+x = ROOT.RooRealVar("x", "x", -3, 3)
+erf = ROOT.RooFit.bindFunction("erf", ROOT.TMath.Erf, x)
 
 # Print erf definition
 erf.Print()
@@ -38,21 +31,10 @@ erf.plotOn(frame1)
 # -----------------------------------------------------------------------
 
 # Bind pdf ROOT.Math.Beta with three variables as ROOT.RooAbsPdf function
-# As above, this does not work directly in python
-# x2 = ROOT.RooRealVar("x2", "x2", 0, 0.999)
-# a = ROOT.RooRealVar("a", "a", 5, 0, 10)
-# b = ROOT.RooRealVar("b", "b", 2, 0, 10)
-# beta = ROOT.RooFit.bindPdf("beta", ROOT.Math.beta_pdf, x2, a, b)
-ROOT.gInterpreter.ProcessLine(
-    'auto x2 = RooRealVar("x2", "x2", 0, 0.999);\
-    auto a = RooRealVar("a", "a", 5, 0, 10);\
-    auto b = RooRealVar("b", "b", 5, 0, 10);\
-    auto beta = RooFit::bindPdf("beta", ROOT::Math::beta_pdf, x2, a, b)'
-)
-x2 = ROOT.x2
-a = ROOT.a
-b = ROOT.b
-beta = ROOT.beta
+x2 = ROOT.RooRealVar("x2", "x2", 0, 0.999)
+a = ROOT.RooRealVar("a", "a", 5, 0, 10)
+b = ROOT.RooRealVar("b", "b", 2, 0, 10)
+beta = ROOT.RooFit.bindPdf("beta", ROOT.Math.beta_pdf, x2, a, b)
 
 # Perf beta definition
 beta.Print()


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

The rf105_funcbinding.py tutorial used to trigger errors due to unknown symbols. In particular the custom new and delete operators used in RooFit were not autoloaded when needed.

In the tutorial there was a workaround implemented to call ProcessLine instead of making calls directly form Python, to make the autoloading from the C++ side of ROOT instead. This did not quite fix the problem, and the tutorial still randomly failed due to missing symbols.

After changing the algorthm used for autoloading in commit 6ae602bba7d33c900a117c9de0187ab5a28e14b8 these problems were solved.

After this fix using the direct calls from Python also works, so this PR suggests updating the tutorial to do that.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
