### PR TITLE
Avoid crashes due to static initialization order

### DIFF
--- a/graf2d/gpadv7/src/RColor.cxx
+++ b/graf2d/gpadv7/src/RColor.cxx
@@ -232,10 +232,10 @@ std::vector<uint8_t> RColor::AsRGBA() const
 
 std::string RColor::toHex(uint8_t v)
 {
-   static const char *digits = "0123456789ABCDEF";
+   auto digits = [](auto d) { return d < 10 ? '0' + d : 'A' - 10 + d; };
    std::string res(2,'0');
-   res[0] = digits[v >> 4];
-   res[1] = digits[v & 0xf];
+   res[0] = digits(v >> 4);
+   res[1] = digits(v & 0xf);
    return res;
 }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Most commonly seen on ppc64le. Backtrace:
```
===========================================================
The lines below might hint at the cause of the crash.
You may get help by asking at the ROOT forum https://root.cern/forum
Only if you are really convinced it is a bug in ROOT then please submit a
report at https://root.cern/bugs Please post the ENTIRE stack trace
from above as an attachment in addition to anything else
that might help us fixing this issue.
===========================================================
 #11 ROOT::Experimental::RColor::toHex[abi:cxx11](unsigned char) (v=<optimized out>) at /usr/include/c++/11/ext/new_allocator.h:82
 #12 0x00007fff90c220ec in ROOT::Experimental::RColor::SetRGB (this=0x7fffeadf5d10, r=<optimized out>, g=<optimized out>, b=<optimized out>) at /usr/include/c++/11/ext/new_allocator.h:89
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
