### PR TITLE
Avoid deleting TFormulas twice

### DIFF
--- a/tutorials/gl/gltf3.C
+++ b/tutorials/gl/gltf3.C
@@ -27,8 +27,8 @@ void gltf3()
    TPad *tf3Pad  = new TPad("box", "box", 0.04, 0.04, 0.96, 0.8);
    tf3Pad->Draw();
 
-   TFormula f1 = TFormula("f1", "x*x + y*y + z*z + 2*y - 1");
-   TFormula f2 = TFormula("f2", "x*x + y*y + z*z - 2*y - 1");
+   TFormula *f1 = new TFormula("f1", "x*x + y*y + z*z + 2*y - 1");
+   TFormula *f2 = new TFormula("f2", "x*x + y*y + z*z - 2*y - 1");
 
    // Klein bottle with cut top&bottom parts
    // The Klein bottle is a closed non-orientable surface that has no


### PR DESCRIPTION
Example failure:

 562/1224 Test  #541: tutorial-gl-gltf3 ...................................................***Failed  Error regular expression found in output. Regex=[Error in <]  1.36 sec
Processing /builddir/build/BUILD/root-6.26.00/tutorials/gl/gltf3.C...
Error in <TList::Delete>: A list is accessing an object (0x7fffd1c959a0) already deleted (list name = Functions)
Error in <TList::Delete>: A list is accessing an object (0x7fffd1c95750) already deleted (list name = Functions)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

