### PR TITLE
Limit the number of threads in TMVA CNN/DNN test to save memory

### DIFF
--- a/tutorials/tmva/TMVA_CNN_Classification.C
+++ b/tutorials/tmva/TMVA_CNN_Classification.C
@@ -125,14 +125,15 @@ void TMVA_CNN_Classification(std::vector<bool> opt = {1, 1, 1, 1, 1})
 
    bool writeOutputFile = true;
 
-   int num_threads = 0;  // use default threads
+   int num_threads = 32;
 
    TMVA::Tools::Instance();
 
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);
-      if (num_threads > 0) gSystem->Setenv("OMP_NUM_THREADS", TString::Format("%d",num_threads));
+      if (ROOT::GetThreadPoolSize() > 0)
+         gSystem->Setenv("OMP_NUM_THREADS", TString::Format("%u", ROOT::GetThreadPoolSize()));
    }
    else
       gSystem->Setenv("OMP_NUM_THREADS", "1");

--- a/tutorials/tmva/TMVA_RNN_Classification.C
+++ b/tutorials/tmva/TMVA_RNN_Classification.C
@@ -190,11 +190,12 @@ void TMVA_RNN_Classification(int use_type = 1)
    useKeras = false;
 #endif
 
-   int num_threads = 0;   // use by default all threads
+   int num_threads = 32;
    // do enable MT running
    if (num_threads >= 0) {
       ROOT::EnableImplicitMT(num_threads);
-      if (num_threads > 0) gSystem->Setenv("OMP_NUM_THREADS", TString::Format("%d",num_threads));
+      if (ROOT::GetThreadPoolSize() > 0)
+         gSystem->Setenv("OMP_NUM_THREADS", TString::Format("%u", ROOT::GetThreadPoolSize()));
    }
    else
       gSystem->Setenv("OMP_NUM_THREADS", "1");


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

```
Processing /builddir/build/BUILD/root-6.26.00/tutorials/tmva/TMVA_CNN_Classification.C...
Running with nthreads  = 224

[ ... ]

OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.
 *** Break *** segmentation violation
 *** Break *** segmentation violation
 *** Break *** segmentation violation
 *** Break *** segmentation violation
 *** Break *** segmentation violation
 *** Break *** segmentation violation
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
