### PR TITLE
Fix library link order

### DIFF
--- a/core/base/test/CMakeLists.txt
+++ b/core/base/test/CMakeLists.txt
@@ -22,6 +22,6 @@ ROOT_ADD_GTEST(CoreBaseTests
   TExceptionHandlerTests.cxx
   TStringTest.cxx
   TBitsTests.cxx
-  LIBRARIES Core RIO ${extralibs})
+  LIBRARIES ${extralibs} RIO Core)
 
 ROOT_ADD_GTEST(CoreErrorTests TErrorTests.cxx LIBRARIES Core)


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Fixes undefined references when linking CoreBaseTests

```
../../../lib/libCling.so.6.26.00: undefined reference to `TMemFile::TMemFile(char const*, TMemFile::ZeroCopyView_t const&)'
../../../lib/libCling.so.6.26.00: undefined reference to `TFile::TFile(char const*, char const*, char const*, int)'
../../../lib/libCling.so.6.26.00: undefined reference to `TFile::~TFile()'
../../../lib/libCling.so.6.26.00: undefined reference to `TStreamerInfo::TStreamerInfo()'
../../../lib/libCling.so.6.26.00: undefined reference to `TMemFile::~TMemFile()'
```

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
