### PR TITLE
Improve GetColorTransparent.

### DIFF
--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -2027,7 +2027,8 @@ Int_t TColor::GetColorDark(Int_t n)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Static function: Returns the transparent color number corresponding to n.
-/// The transparency level is given by the alpha value a.
+/// The transparency level is given by the alpha value a. If a color with the same
+/// RGBa values already exists it is returned.
 
 Int_t TColor::GetColorTransparent(Int_t n, Float_t a)
 {
@@ -2035,6 +2036,18 @@ Int_t TColor::GetColorTransparent(Int_t n, Float_t a)
 
    TColor *color = gROOT->GetColor(n);
    if (color) {
+      TObjArray *colors  = (TObjArray*) gROOT->GetListOfColors();
+      Int_t ncolors = colors->GetSize();
+      TColor *col = 0;
+      for (Int_t i = 0; i<ncolors; i++) {
+         col = (TColor*)colors->At(i);
+         if (col) {
+            if (col->GetRed()   == color->GetRed()   &&
+                col->GetGreen() == color->GetGreen() &&
+                col->GetBlue()  == color->GetBlue()  &&
+                col->GetAlpha() == a) return col->GetNumber();
+         }
+      }
       TColor *colort = new TColor(gROOT->GetListOfColors()->GetLast()+1,
                                   color->GetRed(), color->GetGreen(), color->GetBlue());
       colort->SetAlpha(a);


### PR DESCRIPTION
As pointed in this issue https://github.com/root-project/root/issues/10299, a new color was defined each time a transparent color (with alpha channel) was requested.  This PR fixes that by checking if a similar transparent color exists.

