### PR TITLE
[DF] Consistently fall back to FindBranch in SetBranchesHelper

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1278,8 +1278,13 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
                        RBranchSet &outputBranches)
 {
    static TClassRef TBOClRef("TBranchObject");
-   // FIXME we should be using FindBranch as a fallback if GetBranch fails
-   TBranch *inputBranch = inputTree ? inputTree->GetBranch(inName.c_str()) : nullptr;
+
+   TBranch *inputBranch = nullptr;
+   if (inputTree) {
+      inputBranch = inputTree->GetBranch(inName.c_str());
+      if (!inputBranch) // try harder
+         inputBranch = inputTree->FindBranch(inName.c_str());
+   }
 
    auto *outputBranch = outputBranches.Get(name);
    if (outputBranch) {
@@ -1337,10 +1342,8 @@ void SetBranchesHelper(TTree *inputTree, TTree &outputTree, const std::string &i
    TBranch *inputBranch = nullptr;
    if (inputTree) {
       inputBranch = inputTree->GetBranch(inName.c_str());
-      if (!inputBranch) {
-         // try harder
+      if (!inputBranch) // try harder
          inputBranch = inputTree->FindBranch(inName.c_str());
-      }
    }
    auto *outputBranch = outputBranches.Get(outName);
    const bool isTClonesArray = inputBranch != nullptr && std::string(inputBranch->GetClassName()) == "TClonesArray";


### PR DESCRIPTION
Before this commit, one overload of SetBranchesHelper was using
TTree::FindBranch as a fallback in case GetBranch failed and the
other did not.