### PR TITLE
add option to skip TFile UUID registration

### DIFF
--- a/io/io/inc/TFile.h
+++ b/io/io/inc/TFile.h
@@ -134,6 +134,7 @@ protected:
    static std::atomic<Int_t>     fgReadCalls;             ///<Number of bytes read from all TFile objects
    static Int_t     fgReadaheadSize;         ///<Readahead buffer size
    static Bool_t    fgReadInfo;              ///<if true (default) ReadStreamerInfo is called when opening a file
+   static Bool_t    fgRegisterUUID;          ///<if true (default) TFile UUID is registered in the global list
 
    virtual EAsyncOpenStatus GetAsyncOpenStatus() { return fAsyncOpenStatus; }
    virtual void        Init(Bool_t create);
@@ -337,6 +338,9 @@ public:
    static UInt_t       GetOpenTimeout(); // in ms
    static Bool_t       SetOnlyStaged(Bool_t onlystaged);
    static Bool_t       GetOnlyStaged();
+   
+   static void         SetRegisterUUID(Bool_t registeruuid=kTRUE);
+   static Bool_t       GetRegisterUUID();
 
    ClassDefOverride(TFile,8)  //ROOT file
 };

--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -154,6 +154,7 @@ Bool_t   TFile::fgCacheFileForce = kFALSE;
 Bool_t   TFile::fgCacheFileDisconnected = kTRUE;
 UInt_t   TFile::fgOpenTimeout = TFile::kEternalTimeout;
 Bool_t   TFile::fgOnlyStaged = kFALSE;
+Bool_t   TFile::fgRegisterUUID = kTRUE;
 #ifdef R__USE_IMT
 ROOT::Internal::RConcurrentHashColl TFile::fgTsSIHashes;
 #endif
@@ -547,12 +548,14 @@ TFile::~TFile()
    SafeDelete(fInfoCache);
    SafeDelete(fOpenPhases);
 
-   {
+   if (fGlobalRegistration || fgRegisterUUID) {
       R__LOCKGUARD(gROOTMutex);
       if (fGlobalRegistration) {
          gROOT->GetListOfClosedObjects()->Remove(this);
       }
-      gROOT->GetUUIDs()->RemoveUUID(GetUniqueID());
+      if (fgRegisterUUID) {
+         gROOT->GetUUIDs()->RemoveUUID(GetUniqueID());
+      }
    }
 
    if (IsOnHeap()) {
@@ -834,12 +837,14 @@ void TFile::Init(Bool_t create)
       }
    }
 
-   {
+   if (fGlobalRegistration || fgRegisterUUID) {
       R__LOCKGUARD(gROOTMutex);
       if (fGlobalRegistration) {
          gROOT->GetListOfFiles()->Add(this);
       }
-      gROOT->GetUUIDs()->AddUUID(fUUID, this);
+      if (fgRegisterUUID) {
+         gROOT->GetUUIDs()->AddUUID(fUUID, this);
+      }
    }
 
    // Create StreamerInfo index
@@ -5153,4 +5158,28 @@ Int_t TFile::GetBytesToPrefetch() const
       return ((bytes < 0) ? 0 : bytes);
    }
    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Specify if the UUID must be registered in the global list.
+///
+/// If fgRegisterUUID is true (default) the TFile UUID will be added
+/// to the global list, allowing a TFile object to be referenced by a TRef.
+/// if fgRegisterUUID is false, then TRefs to TFiles will not be functional,
+/// but the use of the global write lock to fill and clear the global UUID
+/// list will be avoided, potentially speeding up multithreaded event loops
+
+void TFile::SetRegisterUUID(Bool_t registeruuid)
+{
+   fgRegisterUUID = registeruuid;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// If the TFile UUID should be registered in the global list
+///
+/// See TFile::SetRegisterUUID for more documentation.
+
+Bool_t TFile::GetRegisterUUID()
+{
+   return fgRegisterUUID;
 }


### PR DESCRIPTION
Adds an option to skip registration of TFile UUIDs in the global list.

This allows to avoid the final use of the global write lock during typical RDataFrame event loops, significantly improving multi-threaded performance for cases with many files and many threads.

This follows up on https://github.com/root-project/root/pull/9486 and mostly finishes addressing https://github.com/root-project/root/issues/7710

It would still be nice to allow this behaviour to be the default for some/all cases, but this would break potential existing use cases where TRefs reference a TFile object.

A test case is below.

Produce the test dataset:

```cpp
#include "TFile.h"
#include "TTree.h"
#include "TString.h"
#include <thread>

void testwrite() {

  const unsigned int nfiles = 4000;
  const unsigned int nentries = 1000*1000;

  float outval = 1.;

  for (unsigned int ifile = 0; ifile < nfiles; ++ifile) {
    TFile *fout = TFile::Open(TString::Format("test_%i.root", ifile), "RECREATE");
    TTree *tree = new TTree("tree", "");
    tree->Branch("outval", &outval);
    for (unsigned int ientry = 0; ientry < nentries; ++ientry) {
      tree->Fill();
    }
    tree->Write();
    fout->Close();
  }

}
```

Test event loop:

```python
import ROOT
ROOT.gInterpreter.ProcessLine(".O3")
ROOT.ROOT.EnableImplicitMT()


chain = ROOT.TChain("tree")
chain.Add("test_*.root")

d = ROOT.ROOT.RDataFrame(chain)
res = d.Sum("outval")

#disable TFile UUID registration before the event loop
ROOT.TFile.SetRegisterUUID(False)
resval = res.GetValue()
print(resval)
```

With 256 threads (on partly loaded machine, but still representative):

Baseline:
    Percent of CPU this job got: 1557%
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:49.89

+disabling TFile UUID registration
    Percent of CPU this job got: 14271%
    Elapsed (wall clock) time (h:mm:ss or m:ss): 0:21.11
