### PR TITLE
[cmake] Enable openssl3 for xrootd:

### DIFF
--- a/builtins/xrootd/CMakeLists.txt
+++ b/builtins/xrootd/CMakeLists.txt
@@ -26,6 +26,10 @@ foreach(lib XrdUtils XrdCl)
   list(APPEND XROOTD_LIBRARIES ${XROOTD_PREFIX}/${XROOTD_LIBDIR}/${libname})
 endforeach()
 
+if(OPENSSL_VERSION VERSION_GREATER_EQUAL 3)
+   set(XROOTD_WITH_OPENSSL3 "-DWITH_OPENSSL3=TRUE")
+endif()
+
 ExternalProject_Add(
     XROOTD
     URL ${XROOTD_SRC_URI}
@@ -42,6 +46,7 @@ ExternalProject_Add(
                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
                -DENABLE_PYTHON=OFF
                -DENABLE_CEPH=OFF
+               ${XROOTD_WITH_OPENSSL3}
                -DCMAKE_INSTALL_RPATH:STRING=${XROOTD_PREFIX}/${XROOTD_LIBDIR}
     INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
             COMMAND ${CMAKE_COMMAND} -E copy_directory <INSTALL_DIR>/include/xrootd <INSTALL_DIR>/include


### PR DESCRIPTION
For Ubuntu 22.04 we will otherwise get a build error.
See https://github.com/xrootd/xrootd/issues/1666

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

