### PR TITLE
Try to fix the issue #10271

### DIFF
--- a/core/rint/src/TRint.cxx
+++ b/core/rint/src/TRint.cxx
@@ -195,12 +195,6 @@ TRint::TRint(const char *appClassName, Int_t *argc, char **argv, void *options, 
       PrintLogo(lite);
    }
 
-   // Explicitly load libMathCore it cannot be auto-loaded it when using one
-   // of its freestanding functions. Once functions can trigger autoloading we
-   // can get rid of this.
-   if (!gClassTable->GetDict("TRandom"))
-      gSystem->Load("libMathCore");
-
    if (!gInterpreter->HasPCMForLibrary("std")) {
       // Load some frequently used includes
       Int_t includes = gEnv->GetValue("Rint.Includes", 1);


### PR DESCRIPTION
Remove the call to `gSystem->Load("libMathCore")` to try to remove dependency between the Rint and Mathcore c++ modules