### PR TITLE
make thisroot.sh compatible with dash and ksh shell

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -178,14 +178,13 @@ fi
 
 
 SHELLNAME=$(getTrueShellExeName)
-if [ "$SHELLNAME" = "dash" ]; then
+if [ "$SHELLNAME" = "bash" ]; then
+   SOURCE=${BASH_ARGV[0]}
+elif [ "$SHELLNAME" = "zsh" ]; then
+   SOURCE=${(%):-%N}
+else # dash or ksh
    x=$(lsof -p $$ -Fn0 2>/dev/null | tail -1); # Paul Brannan https://stackoverflow.com/a/42815001/7471760
    SOURCE=${x#*n}
-else
-   SOURCE=${BASH_ARGV[0]}
-   if [ "x$SOURCE" = "x" ]; then
-      SOURCE=${(%):-%N} # for zsh
-   fi
 fi
 
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Dash (or ksh) shell might be used in Ubuntu18 (sh links by default to dash), but using `. bin/thisroot.sh` inside these shells was not compatible with it.

Now it works in dash, bash, zsh and ksh simultaneously.

Before:
```
dash /opt/root_bld/bin/thisroot.sh
/opt/root_bld/bin/thisroot.sh: 166: /opt/root_bld/bin/thisroot.sh: Bad substitution
```

After:
`dash /opt/root_bld/bin/thisroot.sh`
--> No error

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/10298