### PR TITLE
[RF] Use `RooArgSet::uniqueId` instead of pointers in RooNormSetCache

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -148,7 +148,6 @@
 #pragma link C++ class RooMultiCategory+ ;
 #pragma link off class RooNameReg+ ;
 #pragma link C++ class RooNLLVar+ ;
-#pragma link C++ class RooNormSetCache+ ;
 #pragma link C++ class RooNumber+ ;
 #pragma link C++ class RooNumConvolution+ ;
 #pragma link C++ class RooNumConvPdf+ ;

--- a/roofit/roofitcore/inc/RooNormSetCache.h
+++ b/roofit/roofitcore/inc/RooNormSetCache.h
@@ -24,10 +24,8 @@
 #include <map>
 #include <string>
 
-typedef RooArgSet* pRooArgSet ;
-
 class RooNormSetCache {
-protected:
+private:
   class Pair {
   public:
     using Value_t = RooFit::UniqueId<RooArgSet>::Value_t;
@@ -46,8 +44,7 @@ protected:
   typedef std::map<Pair, ULong64_t> PairIdxMapType;
 
 public:
-  RooNormSetCache(ULong_t max = 32);
-  virtual ~RooNormSetCache();
+  RooNormSetCache(ULong_t max = 32) : _max(max) {}
 
   void add(const RooArgSet* set1, const RooArgSet* set2 = 0);
 
@@ -89,18 +86,16 @@ public:
 
   void initialize(const RooNormSetCache& other) { clear(); *this = other; }
 
-protected:
+private:
 
   PairVectType _pairs; ///<!
   PairIdxMapType _pairToIdx; ///<!
   ULong_t _max; ///<!
-  ULong_t _next; ///<!
+  ULong_t _next = 0; ///<!
 
   std::string _name1;   ///<!
   std::string _name2;   ///<!
-  TNamed*    _set2RangeName; ///<!
-
-  ClassDef(RooNormSetCache, 0) // Management tool for tracking sets of similar integration/normalization sets
+  TNamed*    _set2RangeName = nullptr; ///<!
 };
 
 #endif

--- a/roofit/roofitcore/src/RooNormSetCache.cxx
+++ b/roofit/roofitcore/src/RooNormSetCache.cxx
@@ -81,8 +81,7 @@ void RooNormSetCache::add(const RooArgSet* set1, const RooArgSet* set2)
 {
   const Pair pair(set1, set2);
   PairIdxMapType::iterator it = _pairToIdx.lower_bound(pair);
-  if (_pairToIdx.end() != it && !PairCmp()(it->first, pair) &&
-      !PairCmp()(pair, it->first)) {
+  if (_pairToIdx.end() != it && it->first == pair) {
     // not empty, and keys match - nothing to do
     return;
   }


### PR DESCRIPTION
This change was considered for some time now, and a bug recently
reported on the forum was the final motivation to open this PR:

https://root-forum.cern.ch/t/roodecay-getval-normalization-problem/49457

There are many problems with the pointer comparisons:

  1. If normalization sets are created on the stack it can often happen
     that the same address gets reused (as happened in that forum post,
     more precisely in the implementation of `RooAddModel`)
  2. Memeory might also be reused on the heap, which lead to the
     developement of a memory arena where memory is not reused. This
     memory arena often causes other problems related to heap
     fragmentation or dictionaries.
  3. Pointer comparisons still work if the RooArgSets for the cache
     entry are already out of scope, which can also cause problems

The `UniqueId` is unique for each `RooArgSet` instance created in a
RooFit process, no matter if on the heap or on the stack. The IDs are
also never reused. This makes the `UniqueId` much more practical for
cache keys than RooArgSet pointers.

