### PR TITLE
[RF] Change int types in UniqueId and RooNormSetCache

### DIFF
--- a/roofit/roofitcore/inc/RooFit/UniqueId.h
+++ b/roofit/roofitcore/inc/RooFit/UniqueId.h
@@ -14,7 +14,6 @@
 #define roofit_roofitcore_RooFit_UniqueId_h
 
 #include <atomic>
-#include <cstdint>
 
 namespace RooFit {
 
@@ -39,7 +38,7 @@ namespace RooFit {
 template <class Class>
 struct UniqueId {
 public:
-   using Value_t = std::uint64_t;
+   using Value_t = unsigned long;
 
    /// Create a new UniqueId with the next value from the static counter.
    UniqueId() : _val{++counter} {}

--- a/roofit/roofitcore/inc/RooNormSetCache.h
+++ b/roofit/roofitcore/inc/RooNormSetCache.h
@@ -18,8 +18,6 @@
 
 #include <RooArgSet.h>
 
-#include <Rtypes.h>
-
 #include <vector>
 #include <map>
 #include <string>
@@ -41,14 +39,14 @@ private:
   };
 
   typedef std::vector<Pair> PairVectType;
-  typedef std::map<Pair, ULong64_t> PairIdxMapType;
+  typedef std::map<Pair, std::size_t> PairIdxMapType;
 
 public:
-  RooNormSetCache(ULong_t max = 32) : _max(max) {}
+  RooNormSetCache(std::size_t max = 32) : _max(max) {}
 
   void add(const RooArgSet* set1, const RooArgSet* set2 = 0);
 
-  inline Int_t index(const RooArgSet* set1, const RooArgSet* set2 = 0,
+  inline int index(const RooArgSet* set1, const RooArgSet* set2 = 0,
       const TNamed* set2RangeName = 0)
   {
     // Match range name first
@@ -61,28 +59,28 @@ public:
     return -1;
   }
 
-  inline Bool_t contains(const RooArgSet* set1, const RooArgSet* set2 = 0,
+  inline bool contains(const RooArgSet* set1, const RooArgSet* set2 = 0,
       const TNamed* set2RangeName = 0)
   { return (index(set1,set2,set2RangeName) >= 0); }
 
-  inline Bool_t containsSet1(const RooArgSet* set1)
+  inline bool containsSet1(const RooArgSet* set1)
   {
     const Pair pair(set1, (const RooArgSet*)0);
     PairIdxMapType::const_iterator it = _pairToIdx.lower_bound(pair);
     if (_pairToIdx.end() != it && it->first.first() == RooFit::getUniqueId(set1))
-      return kTRUE;
-    return kFALSE;
+      return true;
+    return false;
   }
 
   const std::string& nameSet1() const { return _name1; }
   const std::string& nameSet2() const { return _name2; }
 
-  Bool_t autoCache(const RooAbsArg* self, const RooArgSet* set1,
+  bool autoCache(const RooAbsArg* self, const RooArgSet* set1,
       const RooArgSet* set2 = 0, const TNamed* set2RangeName = 0,
-      Bool_t autoRefill = kTRUE);
+      bool autoRefill = true);
 
   void clear();
-  Int_t entries() const { return _pairs.size(); }
+  std::size_t entries() const { return _pairs.size(); }
 
   void initialize(const RooNormSetCache& other) { clear(); *this = other; }
 
@@ -90,8 +88,8 @@ private:
 
   PairVectType _pairs; ///<!
   PairIdxMapType _pairToIdx; ///<!
-  ULong_t _max; ///<!
-  ULong_t _next = 0; ///<!
+  std::size_t _max; ///<!
+  std::size_t _next = 0; ///<!
 
   std::string _name1;   ///<!
   std::string _name2;   ///<!

--- a/roofit/roofitcore/src/RooNormSetCache.cxx
+++ b/roofit/roofitcore/src/RooNormSetCache.cxx
@@ -63,7 +63,7 @@ void RooNormSetCache::add(const RooArgSet* set1, const RooArgSet* set2)
     return;
   }
   // register pair -> index mapping
-  _pairToIdx.insert(it, std::make_pair(pair, ULong_t(_pairs.size())));
+  _pairToIdx.insert(it, std::make_pair(pair, _pairs.size()));
   // save pair at that index
   _pairs.push_back(pair);
   // if the cache grew too large, start replacing in a round-robin fashion
@@ -87,8 +87,8 @@ void RooNormSetCache::add(const RooArgSet* set1, const RooArgSet* set2)
 /// return `true`. If sets have not been seen and doRefill is true,
 /// update cache reference to current input sets.
 
-Bool_t RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
-   const RooArgSet* set2, const TNamed* set2RangeName, Bool_t doRefill)
+bool RooNormSetCache::autoCache(const RooAbsArg* self, const RooArgSet* set1,
+   const RooArgSet* set2, const TNamed* set2RangeName, bool doRefill)
 {
 
   // Automated cache management function - Returns `true` if cache is invalidated


### PR DESCRIPTION
This is to avoid crashes on 32-bit platforms. It's not necessary to use
64-bit integers anyway, because the return types of the caching codes
were `Int_t` anyway (now just int). And since caches are never part of
IO anyway, it's not important to be platform independent.

For the UniqueId, using `unsigned long` is fine too, because the unique
ID is transient and therefore doesn't need to be platform independent.
Any fixed-size choice here caused either problems on either 32- or
64-bit platforms.

This fixes crashes in the nightly builds on Debian 10 32-bit, which was verified on the Debian 10 build node.