### PR TITLE
[RF] Fix architecture logging RooFitDriver

### DIFF
--- a/roofit/batchcompute/src/RooBatchCompute.cxx
+++ b/roofit/batchcompute/src/RooBatchCompute.cxx
@@ -54,7 +54,12 @@ public:
    std::string architectureName() const override
    {
       // transform to lower case to match the original architecture name passed to the compiler
-      std::string out = _QUOTE_(RF_ARCH);
+#ifdef _QUOTEVAL_ // to quote the value of the preprocessor macro instead of the name
+#error "It's unexpected that _QUOTEVAL_ is defined at this point!"
+#endif
+#define _QUOTEVAL_(x) _QUOTE_(x)
+      std::string out = _QUOTEVAL_(RF_ARCH);
+#undef _QUOTEVAL_
       std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) { return std::tolower(c); });
       ;
       return out;

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -60,6 +60,43 @@ public:
 private:
    TNamed const *_namePtr;
 };
+
+void logArchitectureInfo(RooFit::BatchModeOption batchMode)
+{
+   // We have to exit early if the message stream is not active. Otherwise it's
+   // possible that this funciton skips logging because it thinks it has
+   // already logged, but actually it didn't.
+   if (!RooMsgService::instance().isActive(static_cast<RooAbsArg *>(nullptr), RooFit::Fitting, RooFit::INFO))
+      return;
+
+   // Don't repeat logging architecture info if the batchMode option didn't change
+   {
+      // Second element of pair tracks whether this function has already been called
+      static std::pair<RooFit::BatchModeOption, bool> lastBatchMode;
+      if (lastBatchMode.second && lastBatchMode.first == batchMode)
+         return;
+      lastBatchMode = {batchMode, true};
+   }
+
+   auto log = [](std::string_view message) {
+      oocxcoutI(static_cast<RooAbsArg *>(nullptr), Fitting) << message << std::endl;
+   };
+
+   if (batchMode == RooFit::BatchModeOption::Cuda && !RooBatchCompute::dispatchCUDA) {
+      throw std::runtime_error(std::string("In: ") + __func__ + "(), " + __FILE__ + ":" + __LINE__ +
+                               ": Cuda implementation of the computing library is not available\n");
+   }
+   if (RooBatchCompute::dispatchCPU->architecture() == RooBatchCompute::Architecture::GENERIC) {
+      log("using generic CPU library compiled with no vectorizations");
+   } else {
+      log(std::string("using CPU computation library compiled with -m") +
+          RooBatchCompute::dispatchCPU->architectureName());
+   }
+   if (batchMode == RooFit::BatchModeOption::Cuda) {
+      log("using CUDA computation library");
+   }
+}
+
 } // namespace
 
 namespace ROOT {
@@ -234,25 +271,7 @@ void RooFitDriver::init()
    RooBatchCompute::init();
 
    // Some checks and logging of used architectures
-   {
-      auto log = [](std::string_view message) {
-         oocxcoutI(static_cast<RooAbsArg *>(nullptr), Fitting) << message << std::endl;
-      };
-
-      if (_batchMode == RooFit::BatchModeOption::Cuda && !RooBatchCompute::dispatchCUDA) {
-         throw std::runtime_error(std::string("In: ") + __func__ + "(), " + __FILE__ + ":" + __LINE__ +
-                                  ": Cuda implementation of the computing library is not available\n");
-      }
-      if (RooBatchCompute::dispatchCPU->architecture() == RooBatchCompute::Architecture::GENERIC) {
-         log("using generic CPU library compiled with no vectorizations");
-      } else {
-         log(std::string("using CPU computation library compiled with -m") +
-             RooBatchCompute::dispatchCPU->architectureName());
-      }
-      if (_batchMode == RooFit::BatchModeOption::Cuda) {
-         log("using CUDA computation library");
-      }
-   }
+   logArchitectureInfo(_batchMode);
 
    // Get a serial list of the nodes in the computation graph.
    // treeNodeServelList() is recursive and adds the top node before the children,


### PR DESCRIPTION
  * print the **value** of the `RF_ARCH` macro, not the macro name

  * avoid looging same info repeatedly