### PR TITLE
[RF] Don't used fixed-size stack arrays in RooBatchCompute in CPU case

### DIFF
--- a/roofit/batchcompute/src/Batches.h
+++ b/roofit/batchcompute/src/Batches.h
@@ -29,8 +29,12 @@ so that they can contain data for every kind of compute function.
 
 namespace RooBatchCompute {
 
+#ifdef __CUDACC__
+// In the CPU case we use std::vector instead of fixed size arrays to pass
+// around data, so no maximum size variables are necessary.
 constexpr uint8_t maxParams = 8;
 constexpr uint8_t maxExtraArgs = 16;
+#endif // #ifdef __CUDACC__
 constexpr uint16_t bufferSize = 64;
 
 namespace RF_ARCH {
@@ -64,22 +68,40 @@ public:
 
 class Batches {
 private:
+#ifdef __CUDACC__
+   // In the GPU case, we used fixed-size buffers to pass around input arrays by value.
    Batch _arrays[maxParams];
-   size_t _nEvents = 0;
    double _extraArgs[maxExtraArgs];
+#else
+   std::vector<Batch> _arrays;
+   std::vector<double> _extraArgs;
+#endif // #ifdef __CUDACC__
+   size_t _nEvents = 0;
    uint8_t _nBatches = 0;
-   uint8_t _nExtraArgs;
+   uint8_t _nExtraArgs = 0;
 
 public:
    RestrictArr _output = nullptr;
 
    Batches(RestrictArr output, size_t nEvents, const DataMap &varData, const VarVector &vars,
-           const ArgVector &extraArgs = {}, double stackArr[maxParams][bufferSize] = nullptr);
+           const ArgVector &extraArgs = {}, double *buffer = nullptr);
+
+#ifdef __CUDACC__
+#else
+   // As we don't pass around Batches by value in the CPU case, delete copying
+   // and moving to it's not done accidentally.
+   Batches(const Batches &) = delete;
+   Batches &operator=(const Batches &) = delete;
+   Batches(Batches &&) = delete;
+   Batches &operator=(Batches &&) = delete;
+#endif // #ifdef __CUDACC__
+
    __roodevice__ size_t getNEvents() const { return _nEvents; }
    __roodevice__ uint8_t getNExtraArgs() const { return _nExtraArgs; }
    __roodevice__ double extraArg(uint8_t i) const { return _extraArgs[i]; }
+   __roodevice__ void setExtraArg(uint8_t i, double val) { _extraArgs[i] = val; }
    __roodevice__ Batch operator[](int batchIdx) const { return _arrays[batchIdx]; }
-   inline void setNEvents(size_t n = bufferSize) { _nEvents = n; }
+   inline void setNEvents(size_t n) { _nEvents = n; }
    inline void advance(size_t nEvents)
    {
       for (int i = 0; i < _nBatches; i++)
@@ -87,6 +109,14 @@ public:
       _output += nEvents;
    }
 }; // end class Batches
+
+#ifdef __CUDACC__
+// In the GPU case, we have to pass the Batches object to the compute functions by value.
+using BatchesHandle = Batches;
+#else
+using BatchesHandle = Batches &;
+#endif // #ifdef __CUDACC__
+
 } // End namespace RF_ARCH
 } // end namespace RooBatchCompute
 #endif // #ifdef ROOFIT_BATCHCOMPUTE_BATCHES_H

--- a/roofit/batchcompute/src/ComputeFunctions.cxx
+++ b/roofit/batchcompute/src/ComputeFunctions.cxx
@@ -44,7 +44,7 @@ https://developer.nvidia.com/blog/cuda-pro-tip-write-flexible-kernels-grid-strid
 namespace RooBatchCompute {
 namespace RF_ARCH {
 
-__rooglobal__ void computeAddPdf(Batches batches)
+__rooglobal__ void computeAddPdf(BatchesHandle batches)
 {
    const int nPdfs = batches.getNExtraArgs();
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
@@ -54,7 +54,7 @@ __rooglobal__ void computeAddPdf(Batches batches)
          batches._output[i] += batches.extraArg(pdf) * batches[pdf][i];
 }
 
-__rooglobal__ void computeArgusBG(Batches batches)
+__rooglobal__ void computeArgusBG(BatchesHandle batches)
 {
    Batch m = batches[0], m0 = batches[1], c = batches[2], p = batches[3], normVal = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -70,7 +70,7 @@ __rooglobal__ void computeArgusBG(Batches batches)
    }
 }
 
-__rooglobal__ void computeBernstein(Batches batches)
+__rooglobal__ void computeBernstein(BatchesHandle batches)
 {
    const int nCoef = batches.getNExtraArgs() - 2;
    const int degree = nCoef - 1;
@@ -78,9 +78,12 @@ __rooglobal__ void computeBernstein(Batches batches)
    const double xmax = batches.extraArg(nCoef + 1);
    Batch xData = batches[0], normVal = batches[1];
 
-   double Binomial[maxExtraArgs] = {1.0}; // Binomial stores values c(degree,i) for i in [0..degree]
-   for (int i = 1; i <= degree; i++)
-      Binomial[i] = Binomial[i - 1] * (degree - i + 1) / i;
+   // apply binomial coefficient in-place so we don't have to allocate new memory
+   double binomial = 1.0;
+   for (int k = 0; k < nCoef; k++) {
+      batches.setExtraArg(k, batches.extraArg(k) * binomial);
+      binomial = (binomial * (degree - k)) / (k + 1);
+   }
 
    if (STEP == 1) {
       double X[bufferSize], _1_X[bufferSize], powX[bufferSize], pow_1_X[bufferSize];
@@ -106,7 +109,7 @@ __rooglobal__ void computeBernstein(Batches batches)
 
       for (int k = 0; k < nCoef; k++)
          for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
-            batches._output[i] += batches.extraArg(k) * Binomial[k] * powX[i] * pow_1_X[i];
+            batches._output[i] += batches.extraArg(k) * powX[i] * pow_1_X[i];
 
             // calculating next power for x and 1-x
             powX[i] *= X[i];
@@ -121,7 +124,7 @@ __rooglobal__ void computeBernstein(Batches batches)
             pow_1_X *= 1 - X;
          const double _1_X = 1 / (1 - X);
          for (int k = 0; k < nCoef; k++) {
-            batches._output[i] += batches.extraArg(k) * Binomial[k] * powX * pow_1_X;
+            batches._output[i] += batches.extraArg(k) * powX * pow_1_X;
             powX *= X;
             pow_1_X *= _1_X;
          }
@@ -129,9 +132,16 @@ __rooglobal__ void computeBernstein(Batches batches)
 
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] /= normVal[i];
+
+   // reset extraArgs values so we don't mutate the Batches object
+   binomial = 1.0;
+   for (int k = 0; k < nCoef; k++) {
+      batches.setExtraArg(k, batches.extraArg(k) / binomial);
+      binomial = (binomial * (degree - k)) / (k + 1);
+   }
 }
 
-__rooglobal__ void computeBifurGauss(Batches batches)
+__rooglobal__ void computeBifurGauss(BatchesHandle batches)
 {
    Batch X = batches[0], M = batches[1], SL = batches[2], SR = batches[3], normVal = batches[4];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -144,7 +154,7 @@ __rooglobal__ void computeBifurGauss(Batches batches)
    }
 }
 
-__rooglobal__ void computeBreitWigner(Batches batches)
+__rooglobal__ void computeBreitWigner(BatchesHandle batches)
 {
    Batch X = batches[0], M = batches[1], W = batches[2], normVal = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -153,7 +163,7 @@ __rooglobal__ void computeBreitWigner(Batches batches)
    }
 }
 
-__rooglobal__ void computeBukin(Batches batches)
+__rooglobal__ void computeBukin(BatchesHandle batches)
 {
    Batch X = batches[0], XP = batches[1], SP = batches[2], XI = batches[3], R1 = batches[4], R2 = batches[5],
          normVal = batches[6];
@@ -194,7 +204,7 @@ __rooglobal__ void computeBukin(Batches batches)
       batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
 }
 
-__rooglobal__ void computeCBShape(Batches batches)
+__rooglobal__ void computeCBShape(BatchesHandle batches)
 {
    Batch M = batches[0], M0 = batches[1], S = batches[2], A = batches[3], N = batches[4], normVal = batches[5];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -212,7 +222,7 @@ __rooglobal__ void computeCBShape(Batches batches)
       batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
 }
 
-__rooglobal__ void computeChebychev(Batches batches)
+__rooglobal__ void computeChebychev(BatchesHandle batches)
 {
    Batch xData = batches[0], normVal = batches[1];
    const int nCoef = batches.getNExtraArgs() - 2;
@@ -255,7 +265,7 @@ __rooglobal__ void computeChebychev(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__rooglobal__ void computeChiSquare(Batches batches)
+__rooglobal__ void computeChiSquare(BatchesHandle batches)
 {
    Batch X = batches[0], normVal = batches[1];
    const double ndof = batches.extraArg(0);
@@ -270,7 +280,7 @@ __rooglobal__ void computeChiSquare(Batches batches)
    }
 }
 
-__rooglobal__ void computeDstD0BG(Batches batches)
+__rooglobal__ void computeDstD0BG(BatchesHandle batches)
 {
    Batch DM = batches[0], DM0 = batches[1], C = batches[2], A = batches[3], B = batches[4], normVal = batches[5];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -287,14 +297,14 @@ __rooglobal__ void computeDstD0BG(Batches batches)
          batches._output[i] /= normVal[i];
 }
 
-__rooglobal__ void computeExponential(Batches batches)
+__rooglobal__ void computeExponential(BatchesHandle batches)
 {
    Batch x = batches[0], c = batches[1], normVal = batches[2];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = fast_exp(x[i] * c[i]) / normVal[i];
 }
 
-__rooglobal__ void computeGamma(Batches batches)
+__rooglobal__ void computeGamma(BatchesHandle batches)
 {
    Batch X = batches[0], G = batches[1], B = batches[2], M = batches[3], normVal = batches[4];
    double gamma = -std::lgamma(G[0]);
@@ -321,7 +331,7 @@ __rooglobal__ void computeGamma(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__rooglobal__ void computeGaussian(Batches batches)
+__rooglobal__ void computeGaussian(BatchesHandle batches)
 {
    auto x = batches[0], mean = batches[1], sigma = batches[2], normVal = batches[3];
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP) {
@@ -331,7 +341,7 @@ __rooglobal__ void computeGaussian(Batches batches)
    }
 }
 
-__rooglobal__ void computeNegativeLogarithms(Batches batches)
+__rooglobal__ void computeNegativeLogarithms(BatchesHandle batches)
 {
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
       batches._output[i] = -fast_log(batches[0][i]);
@@ -341,7 +351,7 @@ __rooglobal__ void computeNegativeLogarithms(Batches batches)
          batches._output[i] *= batches[1][i];
 }
 
-__rooglobal__ void computeJohnson(Batches batches)
+__rooglobal__ void computeJohnson(BatchesHandle batches)
 {
    Batch mass = batches[0], mu = batches[1], lambda = batches[2], gamma = batches[3], delta = batches[4],
          normVal = batches[5];
@@ -368,7 +378,7 @@ __rooglobal__ void computeJohnson(Batches batches)
  * Code copied from function landau_pdf (math/mathcore/src/PdfFuncMathCore.cxx)
  * and rewritten to enable vectorization.
  */
-__rooglobal__ void computeLandau(Batches batches)
+__rooglobal__ void computeLandau(BatchesHandle batches)
 {
    auto case0 = [](double x) {
       const double a1[3] = {0.04166666667, -0.01996527778, 0.02709538966};
@@ -450,7 +460,7 @@ __rooglobal__ void computeLandau(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__rooglobal__ void computeLognormal(Batches batches)
+__rooglobal__ void computeLognormal(BatchesHandle batches)
 {
    Batch X = batches[0], M0 = batches[1], K = batches[2], normVal = batches[3];
    const double rootOf2pi = 2.506628274631000502415765284811;
@@ -473,7 +483,7 @@ __rooglobal__ void computeLognormal(Batches batches)
  * ln is the logarithm that was solely present in the initial
  * formula, that is before the asinh replacement
  */
-__rooglobal__ void computeNovosibirsk(Batches batches)
+__rooglobal__ void computeNovosibirsk(BatchesHandle batches)
 {
    Batch X = batches[0], P = batches[1], W = batches[2], T = batches[3], normVal = batches[4];
    constexpr double xi = 2.3548200450309494; // 2 Sqrt( Ln(4) )
@@ -494,7 +504,7 @@ __rooglobal__ void computeNovosibirsk(Batches batches)
       batches._output[i] = fast_exp(batches._output[i]) / normVal[i];
 }
 
-__rooglobal__ void computePoisson(Batches batches)
+__rooglobal__ void computePoisson(BatchesHandle batches)
 {
    Batch x = batches[0], mean = batches[1], normVal = batches[2];
    bool protectNegative = batches.extraArg(0);
@@ -524,7 +534,7 @@ __rooglobal__ void computePoisson(Batches batches)
       batches._output[i] /= normVal[i];
 }
 
-__rooglobal__ void computePolynomial(Batches batches)
+__rooglobal__ void computePolynomial(BatchesHandle batches)
 {
    Batch X = batches[0], normVal = batches[1];
    const int nCoef = batches.getNExtraArgs() - 1;
@@ -569,7 +579,7 @@ finale:
       batches._output[i] /= normVal[i];
 }
 
-__rooglobal__ void computeProdPdf(Batches batches)
+__rooglobal__ void computeProdPdf(BatchesHandle batches)
 {
    const int nPdfs = batches.extraArg(0);
    for (size_t i = BEGIN; i < batches.getNEvents(); i += STEP)
@@ -579,7 +589,7 @@ __rooglobal__ void computeProdPdf(Batches batches)
          batches._output[i] *= batches[pdf][i];
 }
 
-__rooglobal__ void computeVoigtian(Batches batches)
+__rooglobal__ void computeVoigtian(BatchesHandle batches)
 {
    Batch X = batches[0], M = batches[1], W = batches[2], S = batches[3], normVal = batches[4];
    const double invSqrt2 = 0.707106781186547524400844362105;
@@ -609,7 +619,7 @@ __rooglobal__ void computeVoigtian(Batches batches)
 }
 
 /// Returns a std::vector of pointers to the compute functions in this file.
-std::vector<void (*)(Batches)> getFunctions()
+std::vector<void (*)(BatchesHandle)> getFunctions()
 {
    return {computeAddPdf,
            computeArgusBG,

--- a/roofit/batchcompute/src/RooBatchCompute.cu
+++ b/roofit/batchcompute/src/RooBatchCompute.cu
@@ -180,9 +180,18 @@ For every scalar parameter a `Batch` object inside the `Batches` object is set a
 a data member of type double gets assigned the scalar value. This way, when the cuda kernel
 is launched this scalar value gets copied automatically and thus no call to cudaMemcpy is needed **/
 Batches::Batches(RestrictArr output, size_t nEvents, const DataMap &varData, const VarVector &vars,
-                 const ArgVector &extraArgs, double[maxParams][bufferSize])
+                 const ArgVector &extraArgs, double *)
    : _nEvents(nEvents), _nBatches(vars.size()), _nExtraArgs(extraArgs.size()), _output(output)
 {
+   if (vars.size() > maxParams) {
+      throw std::runtime_error(std::string("Size of vars is ") + std::to_string(vars.size()) +
+                               ", which is larger than maxParams = " + std::to_string(maxParams) + "!");
+   }
+   if (extraArgs.size() > maxExtraArgs) {
+      throw std::runtime_error(std::string("Size of extraArgs is ") + std::to_string(extraArgs.size()) +
+                               ", which is larger than maxExtraArgs = " + std::to_string(maxExtraArgs) + "!");
+   }
+
    for (int i = 0; i < vars.size(); i++) {
       const RooSpan<const double> &span = varData.at(vars[i]);
       size_t size = span.size();


### PR DESCRIPTION
In the CPU case in `RooBatchCompute`, we can use `std::vector` instead
of fixed-size stack arrays to pass data around, and the `Batches` object
can be passed to the compute functions by reference.

This fixes crashes with models where the numer of inputs for a RooAbsArg
exceeds the maximum number of parameters supported by the fixed-size
array buffer, at least in the CPU case.

In the GPU case, we now throw a nicer error if the buffers are to small,
instead of just crashing.

The `stressRooFit` tests for the CPU or GPU batch mode still pass after
this commit.