### PR TITLE
Implement SavesAs .csv, .tsv and .txt

### DIFF
--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -172,6 +172,7 @@ public:
    virtual Int_t         RemovePoint(); // *MENU*
    virtual Int_t         RemovePoint(Int_t ipoint);
    void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void          SaveAs(const char *filename, Option_t *option = "") const override;
    virtual void          Scale(Double_t c1=1., Option_t *option="y"); // *MENU*
    virtual void          SetEditable(Bool_t editable=kTRUE); // *TOGGLE* *GETTER=GetEditable
    virtual void          SetHighlight(Bool_t set = kTRUE); // *TOGGLE* *GETTER=IsHighlight

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2030,42 +2030,44 @@ Int_t TGraph::RemovePoint(Int_t ipoint)
 
 void TGraph::SaveAs(const char *filename, Option_t *option) const
 {
-   TString del = "";
+   char del = '\0';
    TString ext = "";
+   TString fname = filename;
+   TString opt = option;
 
    if (filename) {
-      if      (strstr(filename,".csv")) {del = ",";  ext = "csv";}
-      else if (strstr(filename,".tsv")) {del = "\t"; ext = "tsv";}
-      else if (strstr(filename,".txt")) {del = " ";  ext = "txt";}
+      if      (fname.EndsWith(".csv")) {del = ',';  ext = "csv";}
+      else if (fname.EndsWith(".tsv")) {del = '\t'; ext = "tsv";}
+      else if (fname.EndsWith(".txt")) {del = ' ';  ext = "txt";}
    }
-   if (del.Length()>0) {
+   if (del) {
       std::ofstream out;
       out.open(filename, std::ios::out);
       if (!out.good ()) {
          Error("SaveAs", "cannot open file: %s", filename);
          return;
       }
-      if (this->InheritsFrom(TGraphErrors::Class()) ) {
-         if(strstr(option,"title"))
+      if (InheritsFrom(TGraphErrors::Class()) ) {
+         if(opt.Contains("title"))
          out << "# " << GetXaxis()->GetTitle() << "\tex\t" << GetYaxis()->GetTitle() << "\tey" << std::endl;
          double *ex = this->GetEX();
          double *ey = this->GetEY();
          for(int i=0 ; i<fNpoints ; i++)
-         out << fX[i] << del.Data() << (ex?ex[i]:0) << del.Data() << fY[i] << del.Data() << (ey?ey[i]:0) << std::endl;
-      } else if (this->InheritsFrom(TGraphAsymmErrors::Class()) || this->InheritsFrom(TGraphBentErrors::Class())) {
-         if(strstr(option,"title"))
+         out << fX[i] << del << (ex?ex[i]:0) << del << fY[i] << del << (ey?ey[i]:0) << std::endl;
+      } else if (InheritsFrom(TGraphAsymmErrors::Class()) || InheritsFrom(TGraphBentErrors::Class())) {
+         if(opt.Contains("title"))
          out << "# " << GetXaxis()->GetTitle() << "\texl\t" << "\texh\t" << GetYaxis()->GetTitle() << "\teyl" << "\teyh" << std::endl;
          double *exl = this->GetEXlow();
          double *exh = this->GetEXhigh();
          double *eyl = this->GetEYlow();
          double *eyh = this->GetEYhigh();
          for(int i=0 ; i<fNpoints ; i++)
-         out << fX[i] << del.Data() << (exl?exl[i]:0) << del.Data() << (exh?exh[i]:0) << del.Data() << fY[i] << del.Data() << (eyl?eyl[i]:0) << del.Data() << (exh?eyh[i]:0) << std::endl;
+         out << fX[i] << del << (exl?exl[i]:0) << del << (exh?exh[i]:0) << del << fY[i] << del << (eyl?eyl[i]:0) << del << (eyh?eyh[i]:0) << std::endl;
       } else {
-         if (strstr(option,"title"))
+         if(opt.Contains("title"))
          out << "# " << GetXaxis()->GetTitle() << "\t" << GetYaxis()->GetTitle() << std::endl;
          for (int i=0 ; i<fNpoints ; i++)
-         out << fX[i] << del.Data() << fY[i] << std::endl;
+         out << fX[i] << del << fY[i] << std::endl;
       }
       out.close();
       Info("SaveAs", "%s file: %s has been generated", ext.Data(), filename);


### PR DESCRIPTION
Implement the possibility to save TGraph* as .csv, .tsv and .txt
as requested here https://github.com/root-project/root/issues/9491

Test example:

```
{
   auto c = new TCanvas("c","A Simple Graph without axis",700,500);

   const Int_t n = 10;
   auto gr = new TGraph(n);
   gr->SetTitle("A Simple Graph");
   gr->GetXaxis()->SetTitle("X axis");
   gr->GetYaxis()->SetTitle("Y axis");

   auto gre = new TGraphErrors(n);
   gre->GetXaxis()->SetTitle("X axis");
   gre->GetYaxis()->SetTitle("Y axis");
   gre->SetTitle("A Simple Graph with errors");

   auto gra = new TGraphAsymmErrors(n);
   gra->GetXaxis()->SetTitle("X axis");
   gra->GetYaxis()->SetTitle("Y axis");
   gra->SetTitle("A Simple Graph with asymmetric errors");

   auto grb = new TGraphBentErrors(n);
   grb->GetXaxis()->SetTitle("X axis");
   grb->GetYaxis()->SetTitle("Y axis");
   grb->SetTitle("A Simple Graph with bent errors");

   Double_t x, y, exl, exh, eyl, eyh;
   for (Int_t i=0;i<n;i++) {
      x = i*0.123;
      y = 10*sin(x+0.2);
      exl = x*0.01;
      exh = x*0.1;
      eyl = y*0.01;
      eyh = y*0.1;
      gr->SetPoint(i,x,y);
      gre->SetPoint(i,x,y);
      gre->SetPointError(i,exl,eyl);
      gra->SetPoint(i,x,y);
      gra->SetPointError(i,exl,exh, eyl, eyh);
      grb->SetPoint(i,x,y);
      grb->SetPointError(i,exl,exh, eyl, eyh);
   }

   gr->Draw("A*L");
   gr->SaveAs("graph.csv", "title");
   gr->SaveAs("graph.tsv", "title");
   gr->SaveAs("graph.txt", "title");
   gr->SaveAs("graph.C");
   gre->SaveAs("grapherror.csv", "title");
   gre->SaveAs("grapherror.tsv", "title");
   gre->SaveAs("grapherror.txt", "title");
   gra->SaveAs("graphaerror.csv", "title");
   gra->SaveAs("graphaerror.tsv", "title");
   gra->SaveAs("graphaerror.txt", "title");
   grb->SaveAs("graphberror.csv", "title");
   grb->SaveAs("graphberror.tsv", "title");
   grb->SaveAs("graphberror.txt", "title");

 }
```
