### PR TITLE
[GH] Allow starting Bug Report from ROOT prompt with prepopulated setup field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,7 +4,7 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to fill out this bug report!
+      value: Thanks for taking the time to fill out this bug report! Note that you can also prefill this template (from v6.28/06) using: `root -b -e '.gh bug' -q`
   - type: checkboxes
     id: check-duplicates
     attributes:
@@ -44,6 +44,7 @@ body:
     attributes:
       label: ROOT version
       description: What version of ROOT are you running?
+      placeholder: Unix `root -b -q | xclip -sel clip`, Windows: `root -b -q | clip.exe`
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,7 +39,7 @@ body:
         3. How to run your code and / or build it, e.g. `root myMacro.C`, ...
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: root-version
     attributes:
       label: ROOT version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,9 @@ name: Feature request
 description: Propose a new feature for ROOT.
 labels: ["new feature"]
 body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this feature request! Note that you can also prefill this template (from v6.28/06) using: `root -b -e '.gh feature' -q`
   - type: textarea
     id: problem-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/improvement_report.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_report.yml
@@ -2,6 +2,9 @@ name: Improvement
 description: Suggest something that could be improved.
 labels: ["improvement"]
 body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to fill out this improvement suggestion! Note that you can also prefill this template (from v6.28/06) using: `root -b -e '.gh improvement' -q`
   - type: textarea
     id: improvement-description
     attributes:
@@ -30,6 +33,7 @@ body:
     attributes:
       label: ROOT version
       description: What version of ROOT are you running?
+      placeholder: Unix `root -b -q | xclip -sel clip`, Windows: `root -b -q | clip.exe`
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/improvement_report.yml
+++ b/.github/ISSUE_TEMPLATE/improvement_report.yml
@@ -28,7 +28,7 @@ body:
         3. How to run your code and / or build it, e.g. `root myMacro.C`, ...
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: root-version
     attributes:
       label: ROOT version

--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -84,6 +84,8 @@ protected:
    TApplication();
 
    virtual Longptr_t  ProcessRemote(const char *line, Int_t *error = nullptr);
+   virtual void       Forum(const char *line);
+   virtual void       GitHub(const char *line);
    virtual void       Help(const char *line);
    virtual void       LoadGraphicsLibs();
    virtual void       MakeBatch();
@@ -104,6 +106,9 @@ public:
    virtual void    GetOptions(Int_t *argc, char **argv);
    TSignalHandler *GetSignalHandler() const { return fSigHandler; }
    virtual void    SetEchoMode(Bool_t mode);
+   TString GetSetup();
+   void OpenForumTopic(const TString & type);
+   void OpenGitHubIssue(const TString & type);
    void OpenInBrowser(const TString & url);
    void OpenReferenceGuideFor(const TString & strippedClass);
    virtual void    HandleException(Int_t sig);

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1054,9 +1054,9 @@ void TApplication::OpenGitHubIssue(const TString &type)
     // https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-url-query
 
     if (type == "bug") {
-       OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=bug&template=bug_report.yml&root-version="+GetSetup()+"\"");
+      OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=bug&template=bug_report.yml&root-version="+FormatHttpUrl(GetSetup())+"\"");
     } else if (type == "improvement") {
-       OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=improvement&template=improvement_report.yml&root-version="+GetSetup()+"\"");
+      OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=improvement&template=improvement_report.yml&root-version="+FormatHttpUrl(GetSetup())+"\"");
     } else if (type == "feature") {
     OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=new+feature&template=feature_request.yml\"");
 } else {

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1168,7 +1168,8 @@ void TApplication::OpenReferenceGuideFor(const TString &strippedClass)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// The function (".forum <type>") submits a new issue on GitHub via web browser.
+/// The function (".forum <type>") submits a new post on the ROOT forum
+/// via web browser.
 /// \note You can use "bug" as <type>.
 /// \param[in] line command from the command line
 

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -751,6 +751,7 @@ static TString FormatHttpUrl(TString text)
    text.ReplaceAll("\"","%22");
    text.ReplaceAll("`","%60");
    text.ReplaceAll("+","%2B");
+   text.ReplaceAll("/","%2F");
    return text;
 }
 } // namespace

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -737,6 +737,26 @@ static TString FormatMethodArgsForDoxygen(const TString &scopeName, TFunction *f
 
 namespace {
 ////////////////////////////////////////////////////////////////////////////////
+/// The function returns a TString with the text as an encoded url so that it
+/// can be passed to the function OpenInBrowser
+///
+/// \param[in] text the input text
+/// \return the text appropriately escaped
+
+static TString FormatHttpUrl(TString text)
+{
+   text.ReplaceAll("\n","%0A");
+   text.ReplaceAll("#","%23");
+   text.ReplaceAll(";","%3B");
+   text.ReplaceAll("\"","%22");
+   text.ReplaceAll("`","%60");
+   text.ReplaceAll("+","%2B");
+   return text;
+}
+} // namespace
+
+namespace {
+////////////////////////////////////////////////////////////////////////////////
 /// The function checks if a member function of a scope is defined as inline.
 /// If so, it also checks if it is virtual. Then the return type of "func" is
 /// modified for the need of Doxygen and with respect to the function
@@ -928,6 +948,121 @@ static TString GetUrlForMethod(const TString &scopeName, const TString &methodNa
 }
 } // namespace
 
+////////////////////////////////////////////////////////////////////////////////
+/// It gets the ROOT installation setup as TString
+///
+/// \return a string with several lines
+///
+TString TApplication::GetSetup()
+{
+   std::vector<TString> lines;
+   lines.emplace_back(TString::Format("ROOT v%s",
+                                      gROOT->GetVersion()));
+   lines.emplace_back(TString::Format("Built for %s on %s", gSystem->GetBuildArch(), gROOT->GetGitDate()));
+   if (!strcmp(gROOT->GetGitBranch(), gROOT->GetGitCommit())) {
+      static const char *months[] = {"January","February","March","April","May",
+                                     "June","July","August","September","October",
+                                     "November","December"};
+      Int_t idatqq = gROOT->GetVersionDate();
+      Int_t iday   = idatqq%100;
+      Int_t imonth = (idatqq/100)%100;
+      Int_t iyear  = (idatqq/10000);
+
+      lines.emplace_back(TString::Format("From tag %s, %d %s %4d",
+                                         gROOT->GetGitBranch(),
+                                         iday,months[imonth-1],iyear));
+   } else {
+      // If branch and commit are identical - e.g. "v5-34-18" - then we have
+      // a release build. Else specify the git hash this build was made from.
+      lines.emplace_back(TString::Format("From %s@%s",
+                                         gROOT->GetGitBranch(),
+                                         gROOT->GetGitCommit()));
+   }
+   lines.emplace_back(TString::Format("With %s",
+                                      gSystem->GetBuildCompilerVersionStr()));
+   lines.emplace_back("Binary directory: "+ gROOT->GetBinDir());
+   TString setup = "";
+   for (auto& line : lines) {
+      setup.Append(line);
+      setup.Append("\n");
+   }
+   return setup;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// It opens a Forum topic in a web browser with prefilled ROOT version
+///
+/// \param[in] type the issue type (only bug supported right now)
+
+void TApplication::OpenForumTopic(const TString &type)
+{
+   // https://meta.discourse.org/t/how-to-create-a-post-clicking-a-link/96197
+
+   if (type == "bug") {
+      //OpenInBrowser("\"https://root-forum.cern.ch/new-topic?title=topic%20title&body=topic%20body&category=category/subcategory&tags=email,planned\"");
+      TString report_template =
+R"(___
+_Please read [tips for efficient and successful posting](https://root-forum.cern.ch/t/tips-for-efficient-and-successful-posting/28292) and [posting code](https://root-forum.cern.ch/t/posting-code-read-this-first/28293)_
+
+### Describe the bug
+<!--
+A clear and concise description of what the wrong behavior is.
+-->
+### Expected behavior
+<!--
+A clear and concise description of what you expected to happen.
+-->
+
+### To Reproduce
+<!--
+Steps to reproduce the behavior:
+1. Your code that triggers the issue: at least a part; ideally something we can run ourselves.
+2. Don't forget to attach the required input files!
+3. How to run your code and / or build it, e.g. `root myMacro.C`, ...
+-->
+
+### Setup
+```
+)"+GetSetup()+
+R"(```
+
+<!--
+Please specify also how you obtained ROOT, such as `dnf install` / binary download / you built it yourself.
+-->
+
+### Additional context
+<!--
+Add any other context about the problem here.
+-->)";
+      report_template = FormatHttpUrl(report_template);
+
+      OpenInBrowser("\"https://root-forum.cern.ch/new-topic?category=ROOT&tags=bug&body="+report_template+"&\"");
+   } else {
+      Warning("OpenForumTopic", "cannot find \"%s\" as type for a Forum topic\n"
+                                 "Available types are 'bug'.", type.Data());
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// It opens a GitHub issue in a web browser with prefilled ROOT version
+///
+/// \param[in] type the issue type (bug, feature or improvement)
+
+void TApplication::OpenGitHubIssue(const TString &type)
+{
+    // https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-url-query
+
+    if (type == "bug") {
+       OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=bug&template=bug_report.yml&root-version="+GetSetup()+"\"");
+    } else if (type == "improvement") {
+       OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=improvement&template=improvement_report.yml&root-version="+GetSetup()+"\"");
+    } else if (type == "feature") {
+    OpenInBrowser("\"https://github.com/root-project/root/issues/new?labels=new+feature&template=feature_request.yml\"");
+} else {
+       Warning("OpenGitHubIssue", "cannot find \"%s\" as type for a GitHub issue\n"
+               "Available types are 'bug', 'feature' or 'improvement'.", type.Data());
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// It opens the online reference guide, generated with Doxygen, for the
@@ -1027,8 +1162,50 @@ void TApplication::OpenReferenceGuideFor(const TString &strippedClass)
 
    // Warning message will appear if the user types the function name incorrectly
    // or the function is not a member function of "cl" or any of its base classes.
-   Warning("Help", "cannot find \"%s\" as member of %s or its base classes! Check %s\n", memberName.Data(),
+   Warning("OpenReferenceGuideFor", "cannot find \"%s\" as member of %s or its base classes! Check %s\n", memberName.Data(),
            scopeName.Data(), UrlGenerator(scopeName, scopeType).Data());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// The function (".forum <type>") submits a new issue on GitHub via web browser.
+/// \note You can use "bug" as <type>.
+/// \param[in] line command from the command line
+
+void TApplication::Forum(const char *line)
+{
+   // We first check if the user chose a correct syntax.
+   TString strippedCommand = TString(line).Strip(TString::kBoth);
+   if (!strippedCommand.BeginsWith(".forum ")) {
+      Error("Forum", "Unknown command! Use 'bug' after '.forum '");
+      return;
+   }
+   // We remove the command ".forum" from the TString.
+   strippedCommand.Remove(0, 7);
+   // We strip the command line after removing ".help" or ".?".
+   strippedCommand = strippedCommand.Strip(TString::kBoth);
+
+   OpenForumTopic(strippedCommand);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// The function (".gh <type>") submits a new issue on GitHub via web browser.
+/// \note You can use "bug", "feature" or "improvement" as <type>.
+/// \param[in] line command from the command line
+
+void TApplication::GitHub(const char *line)
+{
+   // We first check if the user chose a correct syntax.
+   TString strippedCommand = TString(line).Strip(TString::kBoth);
+   if (!strippedCommand.BeginsWith(".gh ")) {
+      Error("GitHub", "Unknown command! Use 'bug', 'feature' or 'improvement' after '.gh '");
+      return;
+   }
+   // We remove the command ".gh" from the TString.
+   strippedCommand.Remove(0, 4);
+   // We strip the command line after removing ".help" or ".?".
+   strippedCommand = strippedCommand.Strip(TString::kBoth);
+
+   OpenGitHubIssue(strippedCommand);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1054,6 +1231,9 @@ void TApplication::Help(const char *line)
              "                         with signature: ret_type filename(args).");
       Printf("   .credits            : show credits");
       Printf("   .demo               : launch GUI demo");
+      Printf("   .forum bug          : ask for help with a bug or crash at the ROOT forum.");
+      Printf("   .gh [bug|feature|improvement]\n"
+             "                       : submit a bug report, feature or improvement suggestion");
       Printf("   .help Class::Member : open reference guide for that class member (or .?).\n"
              "                         Specifying '::Member' is optional.");
       Printf("   .help edit          : show line editing shortcuts (or .?)");
@@ -1415,6 +1595,16 @@ Longptr_t TApplication::ProcessLine(const char *line, Bool_t sync, Int_t *err)
    } else if (!strncasecmp(line, ".exit", 4) || !strncasecmp(line, ".quit", 2)) {
       Terminate(0);
       return 0;
+   }
+
+   if (!strncmp(line, ".gh", 3)) {
+      GitHub(line);
+      return 1;
+   }
+
+   if (!strncmp(line, ".forum", 6)) {
+      Forum(line);
+      return 1;
    }
 
    if (!strncmp(line, ".?", 2) || !strncmp(line, ".help", 5)) {

--- a/etc/gdb-backtrace.sh
+++ b/etc/gdb-backtrace.sh
@@ -227,8 +227,10 @@ $line"
             echo 'If you see question marks in one or more lines of the stack trace, try'
             echo 'exporting the environment variable CLING_DEBUG=1 and running again.'
             echo 'You may get help by asking at the ROOT forum https://root.cern/forum'
+            echo 'preferably using the command (.forum bug) in the ROOT prompt.'
             echo 'If you are really convinced it is a bug in ROOT then please submit a report'
-            echo 'at https://root.cern/bugs Please post the ENTIRE stack trace'
+            echo 'at https://root.cern/bugs or (preferably) using the command (.gh bug) in'
+            echo 'the ROOT prompt. Please post the ENTIRE stack trace'
             echo 'from above as an attachment in addition to anything else'
             echo 'that might help us fixing this issue.'
          fi
@@ -242,8 +244,10 @@ $line"
             echo 'marks as part of the stack trace, try to recompile with debugging information'
             echo 'enabled and export CLING_DEBUG=1 environment variable before running.'
             echo 'You may get help by asking at the ROOT forum https://root.cern/forum'
+            echo 'preferably using the command (.forum bug) in the ROOT prompt.'
             echo 'Only if you are really convinced it is a bug in ROOT then please submit a'
-            echo 'report at https://root.cern/bugs Please post the ENTIRE stack trace'
+            echo 'report at https://root.cern/bugs or (preferably) using the command (.gh bug) in'
+            echo 'the ROOT prompt. Please post the ENTIRE stack trace'
             echo 'from above as an attachment in addition to anything else'
             echo 'that might help us fixing this issue.'
          fi


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
- Mentions/Suggests in the GH template how to paste the setup information when reporting a bug via the web browser
- Adds the ability to submit a bug report by opening web browser from the ROOT prompt, with command `.gh`
- Adds the ability to auto-populate a GitHub bug report with your current system setup.
- Similarly for reporting a crash or bug in the forum

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)
- [FOR LATER BY AXEL] Add backtrace also in form, if any
- [NOT NEEDED] Strip or Obfuscate paths of backtrace that are outside of ROOT folder, or within GetHomeDirectory. Potentially also in GetBinaryDirectory within GetSetup function
- [ ] We would need the name of the build machine, for instance. I don't know how else to figure out whether it's one of our binaries, a package, or built by the user? Iirc that's not available right now?
- [ ] Maybe we fill out the OS name also?
- [ ] Update on web full list of commands, add .gh issue, do as in https://github.com/root-project/web/pull/776
- [ ] Recommend also on manual this command
- [ ] Maybe add similar instruction on main ROOT webpage as https://www.kicad.org/help/report-an-issue/
- [x] Discuss if more things need to be added to the setup
- [ ] Mention in the Forum
- [ ] Add aliases?
- [ ] https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/
- [x] Somehow, the forum topic opened does not have the // after https

This PR fixes https://github.com/root-project/root/issues/8795

The way to submit a bug report without opening ROOT by hand would be:
```
root -b -e '.gh bug' -q
root -b -e '.gh feature' -q
root -b -e '.gh improvement' -q
root -b -e '.forum bug' -q
```

Not sure if it's worth to define an alias to these commands, in a similar fashion to `rootbrowse`, etc.

For example:
```
rootbug
rootfeature
rootimprovement
rootforum
```
