### PR TITLE
Distrdf histoxd nomodel error

### DIFF
--- a/bindings/experimental/distrdf/test/test_operation.py
+++ b/bindings/experimental/distrdf/test/test_operation.py
@@ -1,5 +1,8 @@
-from DistRDF import Operation
 import unittest
+
+from DistRDF import Operation
+
+import ROOT
 
 
 class ClassifyTest(unittest.TestCase):
@@ -52,3 +55,60 @@ class ArgsTest(unittest.TestCase):
         op = Operation.create_op("Define")
         self.assertEqual(op.args, [])
         self.assertEqual(op.kwargs, {})
+
+
+class HistoModelTests(unittest.TestCase):
+    """
+    Test that Histo*D operations work only when the histogram model is passed.
+    """
+
+    def test_histo1d_with_tuple(self):
+        """A tuple can be used as a histogram model."""
+        op = Operation.create_op("Histo1D", ("name", "title", 10, 0, 10), "x")
+        self.assertIsInstance(op, Operation.Histo)
+        self.assertEqual(op.name, "Histo1D")
+        self.assertEqual(op.args, [("name", "title", 10, 0, 10), "x"])
+
+    def test_histo1d_with_th1dmodel(self):
+        """TH1DModel"""
+        op = Operation.create_op("Histo1D", ROOT.RDF.TH1DModel(), "x")
+        self.assertIsInstance(op, Operation.Histo)
+        self.assertEqual(op.name, "Histo1D")
+
+    def test_histo1d_without_model(self):
+        """Creating a histogram without model raises ValueError."""
+        with self.assertRaises(ValueError):
+            _ = Operation.create_op("Histo1D", "x")
+
+    def test_histo2d_with_th2dmodel(self):
+        """TH2DModel"""
+        op = Operation.create_op("Histo2D", ROOT.RDF.TH2DModel(), "x", "y")
+        self.assertIsInstance(op, Operation.Histo)
+        self.assertEqual(op.name, "Histo2D")
+
+    def test_histo2d_without_model(self):
+        """Creating a histogram without model raises ValueError."""
+        with self.assertRaises(ValueError):
+            _ = Operation.create_op("Histo2D", "x", "y")
+
+    def test_histo3d_with_th3dmodel(self):
+        """TH3DModel"""
+        op = Operation.create_op("Histo3D", ROOT.RDF.TH3DModel(), "x", "y", "z")
+        self.assertIsInstance(op, Operation.Histo)
+        self.assertEqual(op.name, "Histo3D")
+
+    def test_histo3d_without_model(self):
+        """Creating a histogram without model raises ValueError."""
+        with self.assertRaises(ValueError):
+            _ = Operation.create_op("Histo3D", "x", "y", "z")
+
+    def test_histond_with_thndmodel(self):
+        """THnDModel"""
+        op = Operation.create_op("HistoND", ROOT.RDF.THnDModel(), ["a", "b", "c", "d"])
+        self.assertIsInstance(op, Operation.Histo)
+        self.assertEqual(op.name, "HistoND")
+
+    def test_histond_without_model(self):
+        """Creating a histogram without model raises ValueError."""
+        with self.assertRaises(ValueError):
+            _ = Operation.create_op("HistoND", ["a", "b", "c", "d"])


### PR DESCRIPTION
If the user doesn't provide a histogram model in distributed mode, the
merging of different histograms coming from different distributed tasks
would not work since the histograms would most probably have
incompatible bins. Rather than wait for failures like

`Error in <Merge>: Cannot merge histograms - limits are inconsistent`

that happen only when the distributed execution has already started and
may be hidden inside worker logs, raise an error in the local user
machine.

An example of the error raised with this change: running this snippet
```python
import ROOT
RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
from dask.distributed import Client, LocalCluster

def create_connection():
    cluster = LocalCluster(n_workers=2, threads_per_worker=1, processes=True)
    client = Client(cluster)
    return client

if __name__ == "__main__":
    df = RDataFrame(10, daskclient = create_connection()).Define("x","rdfentry_")
    m = ROOT.RDF.TH1DModel("name","title",10,0,10)
    df.Histo1D(m, "x")
    print("After first Histo1D")
    df.Histo1D(("name","title",10,0,10), "x")
    print("After second Histo1D")
    df.Histo1D("x")
    print("After third Histo1D")
```
results in
```
After first Histo1D
After second Histo1D
Traceback (most recent call last):
  File "/home/vpadulan/projects/rootcode/distrdf-histo-nomodel/test.py", line 17, in <module>
    df.Histo1D("x")
  File "/home/vpadulan/programs/rootproject/rootbuild/master-default/lib/DistRDF/Proxy.py", line 240, in _create_new_op
    op = Operation.create_op(self.proxied_node._new_op_name, *args, **kwargs)
  File "/home/vpadulan/programs/rootproject/rootbuild/master-default/lib/DistRDF/Operation.py", line 118, in create_op
    return SUPPORTED_OPERATIONS[name](name, *args, **kwargs)
  File "/home/vpadulan/programs/rootproject/rootbuild/master-default/lib/DistRDF/Operation.py", line 60, in __init__
    raise TypeError(textwrap.fill(message))
TypeError: A histogram was created without a model. This cannot work in
distributed mode because histograms resulting from different tasks
would have incompatible bins. Please make sure to pass the histogram
model as the first argument to the function. See the RDataFrame docs
for help.
```