### PR TITLE
TClassEdit: make usage of static cache container thread safe.

### DIFF
--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -1231,13 +1231,14 @@ int TClassEdit::GetSplit(const char *type, vector<string>& output, int &nestedLo
 string TClassEdit::CleanType(const char *typeDesc, int mode, const char **tail)
 {
    static const char* remove[] = {"class","const","volatile",0};
-   static std::vector<size_t> lengths{ []() {
+   auto initLengthsVector = []() {
       std::vector<size_t> create_lengths;
       for (int k=0; remove[k]; ++k) {
          create_lengths.push_back(strlen(remove[k]));
       }
       return create_lengths;
-   }() };
+   };
+   static std::vector<size_t> lengths{ initLengthsVector() };
 
    string result;
    result.reserve(strlen(typeDesc)*2);
@@ -1913,14 +1914,15 @@ string TClassEdit::InsertStd(const char *tname)
 
    if (tname==0 || tname[0]==0) return "";
 
-   static ShuttingDownSignaler<std::set<std::string>> sSetSTLtypes{ []() {
+   auto initSetSTLtypes = []() {
       std::set<std::string> iSetSTLtypes;
       // set up static set
       const size_t nSTLtypes = sizeof(sSTLtypes) / sizeof(const char*);
       for (size_t i = 0; i < nSTLtypes; ++i)
          iSetSTLtypes.insert(sSTLtypes[i]);
       return iSetSTLtypes;
-   } () };
+   };
+   static ShuttingDownSignaler<std::set<std::string>> sSetSTLtypes{ initSetSTLtypes() };
 
    size_t b = 0;
    size_t len = strlen(tname);

--- a/core/foundation/src/TClassEdit.cxx
+++ b/core/foundation/src/TClassEdit.cxx
@@ -83,19 +83,20 @@ static size_t StdLen(const std::string_view name)
                   if (i+1<name.length() && name[i+1]==':') {
                      len += 2;
                   }
-               }
-
-               std::string scoperesult;
-               if (!gInterpreterHelper->ExistingTypeCheck(scope, scoperesult)
-                   && gInterpreterHelper->IsDeclaredScope(scope,isInlined)) {
-                  if (isInlined) {
-                     {
-                        ROOT::Internal::TSpinLockGuard lock(spinFlag);
-                        gInlined.insert(scope);
-                     }
-                     len = i;
-                     if (i+1<name.length() && name[i+1]==':') {
-                        len += 2;
+               } else {
+                  std::string scoperesult;
+                  if (!gInterpreterHelper->ExistingTypeCheck(scope, scoperesult)
+                     && gInterpreterHelper->IsDeclaredScope(scope, isInlined))
+                  {
+                     if (isInlined) {
+                        {
+                           ROOT::Internal::TSpinLockGuard lock(spinFlag);
+                           gInlined.insert(scope);
+                        }
+                        len = i;
+                        if (i+1<name.length() && name[i+1]==':') {
+                           len += 2;
+                        }
                      }
                   }
                }


### PR DESCRIPTION
This should fix issue #10353.

Use a spin lock to protect gInlined.

Also, use in-place lamba calls instead of checking at each call if the static was initialized.
In addition to the (slight) performance gain, this make those intialization thread safe.



