### PR TITLE
[v626][RF] Backports of RooFit PRs to `v6-26-00-patches`: Part 11

### DIFF
--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1728,13 +1728,16 @@ void RooJSONFactoryWSTool::importAllNodes(const RooFit::Experimental::JSONNode &
          std::string name = RooJSONFactoryWSTool::name(snsh);
          if (name == "fromJSON")
             continue;
+         RooArgSet vars;
          for (const auto &var : snsh.children()) {
             std::string vname = RooJSONFactoryWSTool::name(var);
             RooRealVar *rrv = this->_workspace->var(vname.c_str());
             if (!rrv)
                continue;
             this->configureVariable(var, *rrv);
+            vars.add(*rrv);
          }
+         this->_workspace->saveSnapshot(name.c_str(), vars);
       }
    }
    this->_workspace->loadSnapshot("fromJSON");


### PR DESCRIPTION
This is a backport of all the RooFit PRs that were merged to `master` to `v6-26-00-patches` (in the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/10293

