### PR TITLE
Backporting some commits that avoid unused variable warnings on mac

### DIFF
--- a/interpreter/cling/lib/Interpreter/Exception.cpp
+++ b/interpreter/cling/lib/Interpreter/Exception.cpp
@@ -32,8 +32,6 @@ CLING_LIB_EXPORT
 void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
                                                    const void* Arg) {
 
-  const clang::Expr* const E = (const clang::Expr*)Expr;
-
 #if defined(__APPLE__) && defined(__arm64__)
   // See https://github.com/root-project/root/issues/7541 and
   // https://bugs.llvm.org/show_bug.cgi?id=49692 :
@@ -42,6 +40,8 @@ void* cling_runtime_internal_throwIfInvalidPointer(void* Interp, void* Expr,
   (void)Interp;
   (void)Expr;
 #else
+  const clang::Expr* const E = (const clang::Expr*)Expr;
+
   // The isValidAddress function return true even when the pointer is
   // null thus the checks have to be done before returning successfully from the
   // function in this specific order.

--- a/math/mathcore/src/VectorizedTMath.cxx
+++ b/math/mathcore/src/VectorizedTMath.cxx
@@ -94,7 +94,7 @@ namespace TMath {
 
    ::ROOT::Double_v v = vecCore::math::Abs(x) / w2;
 
-   ::ROOT::Double_v ap, aq, h, hc, y, result;
+   ::ROOT::Double_v result;
 
    vecCore::Mask<::ROOT::Double_v> mask1 = v < ::ROOT::Double_v(0.5);
    vecCore::Mask<::ROOT::Double_v> mask2 = !mask1 && v < ::ROOT::Double_v(4.0);


### PR DESCRIPTION
Backpots of:
* https://github.com/root-project/root/pull/9877
* https://github.com/root-project/root/pull/9876