### PR TITLE
Close files before deleting them in TContext tutorial

### DIFF
--- a/tutorials/pyroot/pyroot006_tcontext_context_manager.py
+++ b/tutorials/pyroot/pyroot006_tcontext_context_manager.py
@@ -52,5 +52,7 @@ with TDirectory.TContext(), TFile("pyroot006_file_3.root", "recreate") as f:
 print("Current directory: '{}'.\n".format(ROOT.gDirectory.GetName()))
 
 # Cleanup the files created for this tutorial
+file_1.Close();
+file_2.Close();
 for i in range(1, 4):
     os.remove("pyroot006_file_{}.root".format(i))


### PR DESCRIPTION
The TFile objects need to be closed before the ROOT files can be
deleted. Otherwise, we get errors such as these on Windows 10:

```
Traceback (most recent call last):
  File "C:/build/night/LABEL/windows10/SPEC/default/V/master/root/tutorials/pyroot/pyroot006_tcontext_context_manager.py", line 56, in <module>
    os.remove("pyroot006_file_{}.root".format(i))
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'pyroot006_file_1.root'
CMake Error at C:/build/night/LABEL/windows10/SPEC/default/V/master/build/RootTestDriver.cmake:227 (message):
  error code: 1
```

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=windows10,SPEC=default,V=master/lastBuild/testReport/projectroot/runtutorials/tutorial_pyroot_pyroot006_tcontext_context_manager_py/