### PR TITLE
Fix `TMVA_Higgs_Classification.C` tutorial on Windows

### DIFF
--- a/tutorials/tmva/TMVA_Higgs_Classification.C
+++ b/tutorials/tmva/TMVA_Higgs_Classification.C
@@ -319,7 +319,9 @@ We can then book the DL method using the built option string
 
       m.SaveSource("make_higgs_model.py");
       // execute
-      gSystem->Exec(TMVA::Python_Executable() + " make_higgs_model.py");
+      auto ret = (TString *)gROOT->ProcessLine("TMVA::Python_Executable()");
+      TString python_exe = (ret) ? *(ret) : "python";
+      gSystem->Exec(python_exe + " make_higgs_model.py");
 
       if (gSystem->AccessPathName("Higgs_model.h5")) {
          Warning("TMVA_Higgs_Classification", "Error creating Keras model file - skip using Keras");


### PR DESCRIPTION
On Windows, the `TMVA_Higgs_Classification.C` tutorial gives the
following error:

```
Processing C:/build/night/LABEL/windows10/SPEC/default/V/master/root/tutorials/tmva/TMVA_Higgs_Classification.C...
In file included from input_line_10:1:
C:\build\night\LABEL\windows10\SPEC\default\V\master\root\tutorials\tmva\TMVA_Higgs_Classification.C:322:27: error: no member named 'Python_Executable' in namespace 'TMVA'
      gSystem->Exec(TMVA::Python_Executable() + " make_higgs_model.py");
                    ~~~~~~^
CMake Error at C:/build/night/LABEL/windows10/SPEC/default/V/master/build/RootTestDriver.cmake:227 (message):
  error code: 1
```

Using the same trick to get the Python executable name via
`gROOT->ProcessLine` that is also used in the other TMVA tutorials like
`TMVA_CNN_Classification.C` should fix the problem.

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=windows10,SPEC=default,V=master/lastBuild/testReport/projectroot/runtutorials/tutorial_tmva_TMVA_Higgs_Classification/