### PR TITLE
Using higher-level wrapper of OpenSSL SHA1 hash function in civetweb

### DIFF
--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -12321,8 +12321,10 @@ mg_unlock_context(struct mg_context *ctx)
 #if defined(USE_WEBSOCKET)
 
 #if !defined(NO_SSL_DL)
+#if !defined(OPENSSL_API_3_0)
 #define SHA_API static
 #include "sha1.inl"
+#endif
 #endif
 
 static int
@@ -12330,6 +12332,9 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 {
 	static const char *magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 	char buf[100], sha[20], b64_sha[sizeof(sha) * 2];
+#if !defined(OPENSSL_API_3_0)
+	SHA_CTX sha_ctx;
+#endif
 	int truncated;
 
 	/* Calculate Sec-WebSocket-Accept reply from Sec-WebSocket-Key. */
@@ -12341,8 +12346,14 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 
 	DEBUG_TRACE("%s", "Send websocket handshake");
 
+#if defined(OPENSSL_API_3_0)
 	EVP_Digest((unsigned char *)buf, (uint32_t)strlen(buf), (unsigned char *)sha,
 		NULL, EVP_get_digestbyname("sha1"), NULL);
+#else
+	SHA1_Init(&sha_ctx);
+	SHA1_Update(&sha_ctx, (unsigned char *)buf, (uint32_t)strlen(buf));
+	SHA1_Final((unsigned char *)sha, &sha_ctx);
+#endif
 	base64_encode((unsigned char *)sha, sizeof(sha), b64_sha);
 	mg_printf(conn,
 	          "HTTP/1.1 101 Switching Protocols\r\n"

--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -12330,7 +12330,6 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 {
 	static const char *magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 	char buf[100], sha[20], b64_sha[sizeof(sha) * 2];
-	SHA_CTX sha_ctx;
 	int truncated;
 
 	/* Calculate Sec-WebSocket-Accept reply from Sec-WebSocket-Key. */
@@ -12342,9 +12341,8 @@ send_websocket_handshake(struct mg_connection *conn, const char *websock_key)
 
 	DEBUG_TRACE("%s", "Send websocket handshake");
 
-	SHA1_Init(&sha_ctx);
-	SHA1_Update(&sha_ctx, (unsigned char *)buf, (uint32_t)strlen(buf));
-	SHA1_Final((unsigned char *)sha, &sha_ctx);
+	EVP_Digest((unsigned char *)buf, (uint32_t)strlen(buf), (unsigned char *)sha,
+		NULL, EVP_get_digestbyname("sha1"), NULL);
 	base64_encode((unsigned char *)sha, sizeof(sha), b64_sha);
 	mg_printf(conn,
 	          "HTTP/1.1 101 Switching Protocols\r\n"


### PR DESCRIPTION
This is to get rid of deprecation warninigs when building on Ubuntu
22.04.

Should cause no backwards compatibility poblems, as the functions that
are used now are around at least since OpenSSL 1.0.2:
https://www.openssl.org/docs/man1.0.2/man3/EVP_DigestInit_ex.html

This patch was already applied to upstream civet:
https://github.com/civetweb/civetweb/pull/1072