### PR TITLE
TClingUtils: Avoid growing paths in GetFileName

### DIFF
--- a/core/clingutils/res/TClingUtils.h
+++ b/core/clingutils/res/TClingUtils.h
@@ -561,8 +561,7 @@ bool HasCustomConvStreamerMemberFunction(const AnnotatedRecordDecl &cl,
 
 //______________________________________________________________________________
 // Return the header file to be included to declare the Decl
-llvm::StringRef GetFileName(const clang::Decl& decl,
-                            const cling::Interpreter& interp);
+std::string GetFileName(const clang::Decl& decl, const cling::Interpreter& interp);
 
 //______________________________________________________________________________
 // Return the dictionary file name for a module


### PR DESCRIPTION
Strip of ../ so that the search finds a valid longest match. With the upcoming upgrade of LLVM 13, this would otherwise lead to an error "File name too long" but it's already wrong now.