### PR TITLE
[daos] Generalize daos_mock's fetch/update to accept multiple I/O descriptors

### DIFF
--- a/tree/ntuple/v7/src/libdaos_mock/libdaos_mock.cxx
+++ b/tree/ntuple/v7/src/libdaos_mock/libdaos_mock.cxx
@@ -94,12 +94,12 @@ int RDaosFakeObject::Fetch(daos_key_t *dkey, unsigned int nr, daos_iod_t *iods, 
    /* Iterate over pairs of (I/O descriptor, scatter-gather list) */
    for (unsigned i = 0; i < nr; i++) {
       /* Retrieve entry data for (dkey, akey). Fails if not found */
-      auto data = fStorage.find(GetKey(dkey, /*akey=*/ &iods[i].iod_name));
+      auto data = fStorage.find(GetKey(dkey, /*akey=*/&iods[i].iod_name));
       if (data == fStorage.end())
          return -DER_INVAL;
 
       /* In principle, we can safely assume that each attribute key is associated to a single value,
-       * i.e. one extent per I/O descriptor, and that the corresponding data is copied to a exactly one
+       * i.e. one extent per I/O descriptor; and that the corresponding data is copied to exactly one
        * I/O vector. */
       if (iods[i].iod_nr != 1 || iods[i].iod_type != DAOS_IOD_SINGLE)
          return -DER_INVAL;
@@ -120,8 +120,9 @@ int RDaosFakeObject::Update(daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
    std::lock_guard<std::mutex> lock(fMutexStorage);
    /* Process each I/O descriptor and associated SG list */
    for (unsigned i = 0; i < nr; i++) {
-      auto &data = fStorage[GetKey(dkey, /*akey=*/ &iods[i].iod_name)];
-      /* Assumption: each (dkey, akey) contains a single value */
+      auto &data = fStorage[GetKey(dkey, /*akey=*/&iods[i].iod_name)];
+      /* We assume each attribute key is associated to a single value whose corresponding data is
+       * updated from exactly one I/O vector. */
       if (iods[i].iod_nr != 1 || iods[i].iod_type != DAOS_IOD_SINGLE)
          return -DER_INVAL;
       if (sgls[i].sg_nr != 1)

--- a/tree/ntuple/v7/src/libdaos_mock/libdaos_mock.cxx
+++ b/tree/ntuple/v7/src/libdaos_mock/libdaos_mock.cxx
@@ -30,26 +30,32 @@
 
 using Uuid_t = std::array<unsigned char, 16>;
 namespace std {
-   // Required by `std::unordered_map<daos_obj_id, ...>`. Based on boost::hash_combine().
-   template <> struct hash<daos_obj_id_t> {
-      std::size_t operator()(const daos_obj_id_t& oid) const {
-         auto seed = std::hash<uint64_t>{}(oid.lo);
-         seed ^= std::hash<uint64_t>{}(oid.hi) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-         return seed;
-      }
-   };
+// Required by `std::unordered_map<daos_obj_id, ...>`. Based on boost::hash_combine().
+template <>
+struct hash<daos_obj_id_t> {
+   std::size_t operator()(const daos_obj_id_t &oid) const
+   {
+      auto seed = std::hash<uint64_t>{}(oid.lo);
+      seed ^= std::hash<uint64_t>{}(oid.hi) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+      return seed;
+   }
+};
 
-   // Required by `std::unordered_map<Uuid_t, ...>`; forward to std::hash<std::string_view>{}()
-   template <> struct hash<Uuid_t> {
-      std::size_t operator()(const Uuid_t& u) const {
-         return std::hash<std::string_view>{}
-                  (std::string_view(reinterpret_cast<std::string_view::const_pointer>(u.data()), u.size()));
-      }
-   };
+// Required by `std::unordered_map<Uuid_t, ...>`; forward to std::hash<std::string_view>{}()
+template <>
+struct hash<Uuid_t> {
+   std::size_t operator()(const Uuid_t &u) const
+   {
+      return std::hash<std::string_view>{}(
+         std::string_view(reinterpret_cast<std::string_view::const_pointer>(u.data()), u.size()));
+   }
+};
+} // namespace std
+
+inline bool operator==(const daos_obj_id_t &lhs, const daos_obj_id_t &rhs)
+{
+   return (lhs.lo == rhs.lo) && (lhs.hi == rhs.hi);
 }
-
-inline bool operator==(const daos_obj_id_t& lhs, const daos_obj_id_t& rhs)
-{ return (lhs.lo == rhs.lo) && (lhs.hi == rhs.hi); }
 
 namespace {
 // clang-format off
@@ -66,9 +72,10 @@ private:
    std::unordered_map<std::string, std::string> fStorage;
 
    /// \brief Return the internal storage key by concatenating both dkey and akey.
-   static std::string GetKey(daos_key_t *dkey, daos_key_t *akey) {
-     return std::string{reinterpret_cast<char *>(dkey->iov_buf), dkey->iov_buf_len}
-          .append(reinterpret_cast<char *>(akey->iov_buf), akey->iov_buf_len);
+   static std::string GetKey(daos_key_t *dkey, daos_key_t *akey)
+   {
+      return std::string{reinterpret_cast<char *>(dkey->iov_buf), dkey->iov_buf_len}.append(
+         reinterpret_cast<char *>(akey->iov_buf), akey->iov_buf_len);
    }
 
 public:
@@ -81,30 +88,48 @@ public:
 
 int RDaosFakeObject::Fetch(daos_key_t *dkey, unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls)
 {
-   if (nr != 1 || iods[0].iod_nr !=1 || iods[0].iod_type != DAOS_IOD_SINGLE
-      || sgls[0].sg_nr != 1)
-      return -DER_INVAL;
+   /* For documentation see DAOS' daos_obj_fetch */
 
    std::lock_guard<std::mutex> lock(fMutexStorage);
-   auto it = fStorage.find(GetKey(dkey, &iods[0].iod_name));
-   if (it == fStorage.end())
-      return -DER_INVAL;
-   d_iov_t &iov = sgls[0].sg_iovs[0];
-   std::copy_n(std::begin(it->second), std::min(iov.iov_buf_len, it->second.size()),
-               reinterpret_cast<char *>(iov.iov_buf));
+   /* Iterate over pairs of (I/O descriptor, scatter-gather list) */
+   for (int i = 0; i < (int)nr; i++) {
+      /* Retrieve entry data for (dkey, akey). Fails if not found */
+      auto data = fStorage.find(GetKey(dkey, &iods[i].iod_name));
+      if (data == fStorage.end())
+         return -DER_INVAL;
+
+      /* Assumption: each (dkey, akey) contains a blob
+       * ==> One extent per I/O descriptor
+       * ==> One I/O vector per scatter-gather list  */
+      if (iods[i].iod_nr != 1 || iods[i].iod_type != DAOS_IOD_SINGLE)
+         return -DER_INVAL;
+      if (sgls[i].sg_nr != 1)
+         return -DER_INVAL;
+
+      d_iov_t &iov = sgls[i].sg_iovs[0];
+      std::copy_n(std::begin(data->second), std::min(iov.iov_buf_len, data->second.size()),
+                  reinterpret_cast<char *>(iov.iov_buf));
+   }
    return 0;
 }
 
 int RDaosFakeObject::Update(daos_key_t *dkey, unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls)
 {
-   if (nr != 1 || iods[0].iod_nr !=1 || iods[0].iod_type != DAOS_IOD_SINGLE
-      || sgls[0].sg_nr != 1)
-      return -DER_INVAL;
+   /* For documentation see DAOS' daos_obj_update */
 
    std::lock_guard<std::mutex> lock(fMutexStorage);
-   auto &data = fStorage[GetKey(dkey, &iods[0].iod_name)];
-   d_iov_t &iov = sgls[0].sg_iovs[0];
-   data.assign(reinterpret_cast<char *>(iov.iov_buf), iov.iov_buf_len);
+   /* Process each I/O descriptor and associated SG list */
+   for (int i = 0; i < (int)nr; i++) {
+      auto &data = fStorage[GetKey(dkey, &iods[i].iod_name)]; // entry with (dkey, akey)
+      /* Assumption: each (dkey, akey) contains a blob */
+      if (iods[i].iod_nr != 1 || iods[i].iod_type != DAOS_IOD_SINGLE)
+         return -DER_INVAL;
+      if (sgls[i].sg_nr != 1)
+         return -DER_INVAL;
+
+      d_iov_t &iov = sgls[i].sg_iovs[0];
+      data.assign(reinterpret_cast<char *>(iov.iov_buf), iov.iov_buf_len); // Write to buffer
+   }
    return 0;
 }
 
@@ -123,7 +148,8 @@ public:
    RDaosFakeContainer() = default;
    ~RDaosFakeContainer() = default;
 
-   RDaosFakeObject *GetObject(daos_obj_id_t oid, unsigned int mode) {
+   RDaosFakeObject *GetObject(daos_obj_id_t oid, unsigned int mode)
+   {
       (void)mode;
       std::lock_guard<std::mutex> lock(fMutexObjects);
       auto &obj = fObjects[oid];
@@ -150,7 +176,8 @@ private:
 public:
    /// \brief Get a pointer to a RDaosFakePool object associated to the given UUID.
    /// Non-existent pools shall be created on-demand.
-   static RDaosFakePool *GetPool(const Uuid_t uuid) {
+   static RDaosFakePool *GetPool(const Uuid_t uuid)
+   {
       std::lock_guard<std::mutex> lock(fMutexPools);
       auto &pool = fPools[uuid];
       if (!pool)
@@ -161,12 +188,14 @@ public:
    RDaosFakePool() = default;
    ~RDaosFakePool() = default;
 
-   void CreateContainer(const Uuid_t uuid) {
+   void CreateContainer(const Uuid_t uuid)
+   {
       std::lock_guard<std::mutex> lock(fMutexContainers);
       fContainers.emplace(uuid, std::make_unique<RDaosFakeContainer>());
    }
 
-   RDaosFakeContainer *GetContainer(const Uuid_t uuid) {
+   RDaosFakeContainer *GetContainer(const Uuid_t uuid)
+   {
       std::lock_guard<std::mutex> lock(fMutexContainers);
       auto it = fContainers.find(uuid);
       return (it != fContainers.end()) ? it->second.get() : nullptr;
@@ -200,16 +229,18 @@ private:
 
 public:
    template <typename T>
-   static inline daos_handle_t ToHandle(const T& p)
-   { return { reinterpret_cast<decltype(daos_handle_t::cookie)>(new Cookie(p)) }; }
+   static inline daos_handle_t ToHandle(const T &p)
+   {
+      return {reinterpret_cast<decltype(daos_handle_t::cookie)>(new Cookie(p))};
+   }
 
    template <typename T>
    static inline typename std::add_pointer<T>::type ToPointer(const daos_handle_t h)
-   { return reinterpret_cast<typename std::add_pointer<T>::type>(
-                   reinterpret_cast<Cookie *>(h.cookie)->GetPointer()); }
+   {
+      return reinterpret_cast<typename std::add_pointer<T>::type>(reinterpret_cast<Cookie *>(h.cookie)->GetPointer());
+   }
 
-   static inline void Invalidate(daos_handle_t h)
-   { delete reinterpret_cast<Cookie *>(h.cookie); }
+   static inline void Invalidate(daos_handle_t h) { delete reinterpret_cast<Cookie *>(h.cookie); }
 };
 
 } // anonymous namespace
@@ -245,8 +276,10 @@ const char *d_errstr(int rc)
 
 int daos_oclass_name2id(const char *name)
 {
-   if (strcmp(name, "SX") == 0) return OC_SX;
-   if (strcmp(name, "RP_XSF") == 0) return OC_RP_XSF;
+   if (strcmp(name, "SX") == 0)
+      return OC_SX;
+   if (strcmp(name, "RP_XSF") == 0)
+      return OC_RP_XSF;
    return OC_UNKNOWN;
 }
 
@@ -263,12 +296,9 @@ int daos_oclass_id2name(daos_oclass_id_t oc_id, char *name)
    return -1;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
-
-int daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
-                     daos_event_t *ev)
+int daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop, daos_event_t *ev)
 {
    (void)cont_prop;
    (void)ev;
@@ -282,8 +312,8 @@ int daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_pro
    return 0;
 }
 
-int daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
-                   daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev)
+int daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags, daos_handle_t *coh, daos_cont_info_t *info,
+                   daos_event_t *ev)
 {
    (void)flags;
    (void)info;
@@ -309,9 +339,7 @@ int daos_cont_close(daos_handle_t coh, daos_event_t *ev)
    return 0;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
-
 
 int daos_eq_create(daos_handle_t *eqh)
 {
@@ -326,8 +354,7 @@ int daos_eq_destroy(daos_handle_t eqh, int flags)
    return 0;
 }
 
-int daos_eq_poll(daos_handle_t eqh, int wait_running,
-                 int64_t timeout, unsigned int nevents, daos_event_t **events)
+int daos_eq_poll(daos_handle_t eqh, int wait_running, int64_t timeout, unsigned int nevents, daos_event_t **events)
 {
    (void)eqh;
    (void)wait_running;
@@ -350,12 +377,9 @@ int daos_event_fini(daos_event_t *ev)
    return 0;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
-
-int daos_obj_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode,
-                  daos_handle_t *oh, daos_event_t *ev)
+int daos_obj_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode, daos_handle_t *oh, daos_event_t *ev)
 {
    (void)ev;
 
@@ -374,9 +398,8 @@ int daos_obj_close(daos_handle_t oh, daos_event_t *ev)
    return 0;
 }
 
-int daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
-                   daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
-                   d_sg_list_t *sgls, daos_iom_t *ioms, daos_event_t *ev)
+int daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags, daos_key_t *dkey, unsigned int nr,
+                   daos_iod_t *iods, d_sg_list_t *sgls, daos_iom_t *ioms, daos_event_t *ev)
 {
    (void)th;
    (void)flags;
@@ -389,9 +412,8 @@ int daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
    return obj->Fetch(dkey, nr, iods, sgls);
 }
 
-int daos_obj_update(daos_handle_t oh, daos_handle_t th, uint64_t flags,
-                    daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
-                    d_sg_list_t *sgls, daos_event_t *ev)
+int daos_obj_update(daos_handle_t oh, daos_handle_t th, uint64_t flags, daos_key_t *dkey, unsigned int nr,
+                    daos_iod_t *iods, d_sg_list_t *sgls, daos_event_t *ev)
 {
    (void)th;
    (void)flags;
@@ -403,12 +425,9 @@ int daos_obj_update(daos_handle_t oh, daos_handle_t th, uint64_t flags,
    return obj->Update(dkey, nr, iods, sgls);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
-
-int daos_pool_connect(const uuid_t uuid, const char *grp,
-                      const d_rank_list_t *svc, unsigned int flags,
+int daos_pool_connect(const uuid_t uuid, const char *grp, const d_rank_list_t *svc, unsigned int flags,
                       daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
 {
    (void)grp;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
- Generalizes the fetch/update calls in the mocked-up version of DAOS to support multiple I/O descriptors per request. 
- This change will support planned improvements on the mapping between RNTuple and DAOS to leverage its backend parallelization. 
- Passes previously-existing v7 unit tests (which send a single IOD per request)

## Checklist:

- [x] tested changes locally

This PR fixes # 

