### PR TITLE
Avoid using deprecated `std::iterator` in TSeq and TTreeReader classes

### DIFF
--- a/core/cont/inc/ROOT/TSeq.hxx
+++ b/core/cont/inc/ROOT/TSeq.hxx
@@ -83,11 +83,18 @@ namespace ROOT {
          checkIntegralType();
       }
 
-      class iterator: public std::iterator<std::random_access_iterator_tag, T, difference_type> {
+      class iterator {
       private:
          T fCounter;
          T fStep;
       public:
+         using iterator_category = std::random_access_iterator_tag;
+         using value_type = T;
+         using difference_type = typename std::make_signed<T>::type;
+         using pointer = T *;
+         using const_pointer = const T *;
+         using reference = T &;
+
          iterator(T start, T step): fCounter(start), fStep(step) {}
          T operator*() const {
             return fCounter;

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -53,8 +53,7 @@ public:
    /// It does not really represent a data element; it simply
    /// returns the entry number (or -1 once the end of the tree
    /// is reached).
-   class Iterator_t:
-      public std::iterator<std::input_iterator_tag, const Long64_t, Long64_t> {
+   class Iterator_t {
    private:
       Long64_t fEntry; ///< Entry number of the tree referenced by this iterator; -1 is invalid.
       TTreeReader* fReader; ///< The reader we select the entries on.
@@ -63,6 +62,13 @@ public:
       bool IsValid() const { return fEntry >= 0; }
 
    public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = const Long64_t;
+      using difference_type = Long64_t;
+      using pointer = const Long64_t *;
+      using const_pointer = const Long64_t *;
+      using reference = const Long64_t &;
+
       /// Default-initialize the iterator as "past the end".
       Iterator_t(): fEntry(-1), fReader(nullptr) {}
 


### PR DESCRIPTION
`std::iterator` is deprecated with C++17, hence alternative is applied.

