### PR TITLE
bypass UUID registration when using READ_WITHOUT_GLOBALREGISTRATION (v6.26)

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -547,11 +547,9 @@ TFile::~TFile()
    SafeDelete(fInfoCache);
    SafeDelete(fOpenPhases);
 
-   {
+   if (fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
-      if (fGlobalRegistration) {
-         gROOT->GetListOfClosedObjects()->Remove(this);
-      }
+      gROOT->GetListOfClosedObjects()->Remove(this);
       gROOT->GetUUIDs()->RemoveUUID(GetUniqueID());
    }
 
@@ -834,11 +832,9 @@ void TFile::Init(Bool_t create)
       }
    }
 
-   {
+   if (fGlobalRegistration) {
       R__LOCKGUARD(gROOTMutex);
-      if (fGlobalRegistration) {
-         gROOT->GetListOfFiles()->Add(this);
-      }
+      gROOT->GetListOfFiles()->Add(this);
       gROOT->GetUUIDs()->AddUUID(fUUID, this);
    }
 


### PR DESCRIPTION
A backport of #10318 . cc: @bendavid 