### PR TITLE
[RF] Correctly implement data reduction also for RooCompositeDataStore

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -341,7 +341,6 @@ protected:
   virtual void setArgStatus(const RooArgSet& set, Bool_t active) ;
   virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
 
-  virtual RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) = 0 ; // DERIVED
   virtual RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
                            std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) = 0 ; // DERIVED
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -342,7 +342,7 @@ protected:
   virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
 
   virtual RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
-                           std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) = 0 ; // DERIVED
+                           std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max()) = 0 ;
 
   RooRealVar* dataRealVar(const char* methodname, const RooRealVar& extVar) const ;
 

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -51,6 +51,10 @@ public:
   virtual RooAbsDataStore* clone(const char* newname=0) const = 0 ;
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const = 0 ;
 
+  virtual RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+                                  const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
+                                  std::size_t nStart, std::size_t nStop) = 0 ;
+
   // Write current row
   virtual Int_t fill() = 0 ;
 

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -120,11 +120,11 @@ public:
   void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override ;
 
   std::map<Int_t,RooAbsDataStore*> _dataMap ;
-  RooCategory* _indexCat ;
-  mutable RooAbsDataStore* _curStore ; ///<! Datastore associated with current event
-  mutable Int_t _curIndex ; ///<! Index associated with current event
+  RooCategory* _indexCat = nullptr;
+  mutable RooAbsDataStore* _curStore = nullptr; ///<! Datastore associated with current event
+  mutable Int_t _curIndex = 0; ///<! Index associated with current event
   mutable std::unique_ptr<std::vector<double>> _weightBuffer; ///<! Buffer for weights in case a batch of values is requested.
-  Bool_t _ownComps ; ///<!
+  Bool_t _ownComps = false; ///<!
 
   ClassDefOverride(RooCompositeDataStore,1) // Composite Data Storage class
 };

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -37,14 +37,19 @@ public:
   RooCompositeDataStore() ;
 
   // Ctors from DataStore
-  RooCompositeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> inputData) ;
+  RooCompositeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> const& inputData) ;
 
   // Empty ctor
   RooAbsDataStore* clone(const char* newname=0) const override { return new RooCompositeDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooCompositeDataStore(*this,vars,newname) ; }
 
+  RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+                          const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
+                          std::size_t nStart, std::size_t nStop) override;
+
   RooCompositeDataStore(const RooCompositeDataStore& other, const char* newname=0) ;
   RooCompositeDataStore(const RooCompositeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
+
   ~RooCompositeDataStore() override ;
 
   void dump() override ;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -245,9 +245,9 @@ protected:
 
   void initialize(const char* binningName=0,Bool_t fillTree=kTRUE) ;
   RooDataHist(RooStringView name, RooStringView title, RooDataHist* h, const RooArgSet& varSubset,
-        const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) ;
+        const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop) ;
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
-                  std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max(), Bool_t copyCache=kTRUE) override;
+                  std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max()) override;
   double interpolateDim(int iDim, double xval, size_t centralIdx, int intOrder, bool correctForBinSize, bool cdfBoundaries) ;
   const std::vector<double>& calculatePartialBinVolume(const RooArgSet& dimSet) const ;
   void checkBinBounds() const;

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -257,8 +257,6 @@ protected:
   void importTH1Set(const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> hmap, Double_t initWgt, Bool_t doDensityCorrection) ;
   void importDHistSet(const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dmap, Double_t initWgt) ;
 
-  RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) override ;
-
   Double_t get_wgt(std::size_t idx)   const { return _wgt[idx]; }
   Double_t get_errLo(std::size_t idx) const { return _errLo ? _errLo[idx] : -1.; }
   Double_t get_errHi(std::size_t idx) const { return _errHi ? _errHi[idx] : -1.; }

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -169,11 +169,10 @@ protected:
 
   // Cache copy feature is not publicly accessible
   RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
-                        std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max(),
-                        Bool_t copyCache=kTRUE) override;
+                        std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *ntuple,
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-             std::size_t nStart, std::size_t nStop, Bool_t copyCache, const char* wgtVarName=0);
+             std::size_t nStart, std::size_t nStop, const char* wgtVarName=0);
 
   RooArgSet addWgtVar(const RooArgSet& origVars, const RooAbsArg* wgtVar) ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -172,7 +172,7 @@ protected:
                         std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *ntuple,
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-             std::size_t nStart, std::size_t nStop, const char* wgtVarName=0);
+             std::size_t nStart, std::size_t nStop);
 
   RooArgSet addWgtVar(const RooArgSet& origVars, const RooAbsArg* wgtVar) ;
 

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -163,8 +163,6 @@ public:
 
 protected:
 
-  RooAbsData* cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName=0) override;
-
   friend class RooProdGenContext ;
 
   void initialize(const char* wgtVarName) ;

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -43,6 +43,10 @@ public:
   RooAbsDataStore* clone(const char* newname=0) const override { return new RooTreeDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooTreeDataStore(*this,vars,newname) ; }
 
+  RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+                          const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
+                          std::size_t nStart, std::size_t nStop) override;
+
   // Ctors from TTree
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ;
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ;

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -161,13 +161,13 @@ public:
   static Int_t _defTreeBufSize ;
 
   void createTree(RooStringView name, RooStringView title) ;
-  TTree *_tree ;           // TTree holding the data points
-  TTree *_cacheTree ;      //! TTree holding the cached function values
-  const RooAbsArg* _cacheOwner ; //! Object owning cache contents
-  mutable Bool_t _defCtor ;//! Was object constructed with default ctor?
+  TTree *_tree = nullptr;                 // TTree holding the data points
+  TTree *_cacheTree = nullptr;            //! TTree holding the cached function values
+  const RooAbsArg* _cacheOwner = nullptr; //! Object owning cache contents
+  mutable Bool_t _defCtor = false;        //! Was object constructed with default ctor?
 
   RooArgSet _varsww ;
-  RooRealVar* _wgtVar ;     // Pointer to weight variable (if set)
+  RooRealVar* _wgtVar = nullptr;     // Pointer to weight variable (if set)
 
   const Double_t* _extWgtArray{nullptr};         ///<! External weight array
   const Double_t* _extWgtErrLoArray{nullptr};    ///<! External weight array - low error
@@ -175,10 +175,10 @@ public:
   const Double_t* _extSumW2Array{nullptr};       ///<! External sum of weights array
   mutable std::unique_ptr<std::vector<double>> _weightBuffer; //! Buffer for weights in case a batch of values is requested.
 
-  mutable Double_t  _curWgt ;      ///< Weight of current event
-  mutable Double_t  _curWgtErrLo ; ///< Weight of current event
-  mutable Double_t  _curWgtErrHi ; ///< Weight of current event
-  mutable Double_t  _curWgtErr ;   ///< Weight of current event
+  mutable Double_t  _curWgt = 1.0;      ///< Weight of current event
+  mutable Double_t  _curWgtErrLo = 0.0; ///< Weight of current event
+  mutable Double_t  _curWgtErrHi = 0.0; ///< Weight of current event
+  mutable Double_t  _curWgtErr = 0.0;   ///< Weight of current event
 
   RooArgSet _attachedBuffers ; ///<! Currently attached buffers (if different from _varsww)
 

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -53,7 +53,7 @@ public:
 
   RooTreeDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
                    const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-                   Int_t nStart, Int_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
+                   Int_t nStart, Int_t nStop, const char* wgtVarName=0) ;
 
   RooTreeDataStore(const RooTreeDataStore& other, const char* newname=0) ;
   RooTreeDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=0) ;

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -48,6 +48,10 @@ public:
   RooAbsDataStore* clone(const char* newname=0) const override { return new RooVectorDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooVectorDataStore(*this,vars,newname) ; }
 
+  RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+                          const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
+                          std::size_t nStart, std::size_t nStop) override;
+
   RooVectorDataStore(const RooVectorDataStore& other, const char* newname=0) ;
   RooVectorDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
   RooVectorDataStore(const RooVectorDataStore& other, const RooArgSet& vars, const char* newname=0) ;

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -55,7 +55,7 @@ public:
 
   RooVectorDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
                      const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-                     std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName=0) ;
+                     std::size_t nStart, std::size_t nStop, const char* wgtVarName=0) ;
 
   ~RooVectorDataStore() override ;
 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -672,7 +672,7 @@ public:
 
  private:
   RooArgSet _varsww ;
-  RooRealVar* _wgtVar ;     ///< Pointer to weight variable (if set)
+  RooRealVar* _wgtVar = nullptr; ///< Pointer to weight variable (if set)
 
   std::vector<RealVector*> _realStoreList ;
   std::vector<RealFullVector*> _realfStoreList ;
@@ -680,20 +680,20 @@ public:
 
   void setAllBuffersNative() ;
 
-  Double_t _sumWeight ;
-  Double_t _sumWeightCarry;
+  Double_t _sumWeight = 0.0;
+  Double_t _sumWeightCarry = 0.0;
 
-  const Double_t* _extWgtArray ;         ///<! External weight array
-  const Double_t* _extWgtErrLoArray ;    ///<! External weight array - low error
-  const Double_t* _extWgtErrHiArray ;    ///<! External weight array - high error
-  const Double_t* _extSumW2Array ;       ///<! External sum of weights array
+  const Double_t* _extWgtArray = nullptr;      ///<! External weight array
+  const Double_t* _extWgtErrLoArray = nullptr; ///<! External weight array - low error
+  const Double_t* _extWgtErrHiArray = nullptr; ///<! External weight array - high error
+  const Double_t* _extSumW2Array = nullptr;    ///<! External sum of weights array
 
   mutable ULong64_t _currentWeightIndex{0}; ///<
 
-  RooVectorDataStore* _cache ; ///<! Optimization cache
-  RooAbsArg* _cacheOwner ; ///<! Cache owner
+  RooVectorDataStore* _cache = nullptr; ///<! Optimization cache
+  RooAbsArg* _cacheOwner = nullptr; ///<! Cache owner
 
-  Bool_t _forcedUpdate ; ///<! Request for forced cache update
+  Bool_t _forcedUpdate = false; ///<! Request for forced cache update
 
   ClassDefOverride(RooVectorDataStore, 7) // STL-vector-based Data Storage class
 };

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -503,15 +503,15 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
   if (cutSpec) {
 
     RooFormulaVar cutVarTmp(cutSpec,cutSpec,*get()) ;
-    ret =  reduceEng(varSubset,&cutVarTmp,cutRange,nStart,nStop,kFALSE) ;
+    ret =  reduceEng(varSubset,&cutVarTmp,cutRange,nStart,nStop) ;
 
   } else if (cutVar) {
 
-    ret = reduceEng(varSubset,cutVar,cutRange,nStart,nStop,kFALSE) ;
+    ret = reduceEng(varSubset,cutVar,cutRange,nStart,nStop) ;
 
   } else {
 
-    ret = reduceEng(varSubset,0,cutRange,nStart,nStop,kFALSE) ;
+    ret = reduceEng(varSubset,0,cutRange,nStart,nStop) ;
 
   }
 
@@ -533,7 +533,7 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
 RooAbsData* RooAbsData::reduce(const char* cut)
 {
   RooFormulaVar cutVar(cut,cut,*get()) ;
-  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
   return ret;
 }
@@ -545,7 +545,7 @@ RooAbsData* RooAbsData::reduce(const char* cut)
 
 RooAbsData* RooAbsData::reduce(const RooFormulaVar& cutVar)
 {
-  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  RooAbsData* ret = reduceEng(*get(),&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
   return ret;
 }
@@ -573,9 +573,9 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const char* cut)
   RooAbsData* ret = nullptr;
   if (cut && strlen(cut)>0) {
     RooFormulaVar cutVar(cut, cut, *get(), false);
-    ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max(),false);
+    ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max());
   } else {
-    ret = reduceEng(varSubset2,0,0,0,std::numeric_limits<std::size_t>::max(),false);
+    ret = reduceEng(varSubset2,0,0,0,std::numeric_limits<std::size_t>::max());
   }
   ret->copyGlobalObservables(*this);
   return ret;
@@ -600,7 +600,7 @@ RooAbsData* RooAbsData::reduce(const RooArgSet& varSubset, const RooFormulaVar& 
     }
   }
 
-  RooAbsData* ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max(),kFALSE) ;
+  RooAbsData* ret = reduceEng(varSubset2,&cutVar,0,0,std::numeric_limits<std::size_t>::max()) ;
   ret->copyGlobalObservables(*this);
   return ret;
 }

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -865,24 +865,6 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, RooDataHist* h
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Construct a clone of this dataset that contains only the cached variables
-
-RooAbsData* RooDataHist::cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName)
-{
-  checkInit() ;
-
-  RooDataHist* dhist = new RooDataHist(newName?newName:GetName(),GetTitle(),this,*get(),0,0,0,2000000000,kTRUE) ;
-
-  RooArgSet* selCacheVars = (RooArgSet*) newCacheVars->selectCommon(dhist->_cachedVars) ;
-  dhist->attachCache(newCacheOwner, *selCacheVars) ;
-  delete selCacheVars ;
-
-  return dhist ;
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Implementation of RooAbsData virtual method that drives the RooAbsData::reduce() methods
 
 RooAbsData* RooDataHist::reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange,

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -841,11 +841,11 @@ RooDataHist::RooDataHist(const RooDataHist& other, const char* newname) :
 /// is the most convenient way to create a subset of an existing data
 
 RooDataHist::RooDataHist(RooStringView name, RooStringView title, RooDataHist* h, const RooArgSet& varSubset,
-          const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop, Bool_t copyCache) :
+          const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop) :
   RooAbsData(name,title,varSubset)
 {
   // Initialize datastore
-  _dstore = new RooTreeDataStore(name,title,*h->_dstore,_vars,cutVar,cutRange,nStart,nStop,copyCache) ;
+  _dstore = new RooTreeDataStore(name,title,*h->_dstore,_vars,cutVar,cutRange,nStart,nStop) ;
 
   initialize(0,kFALSE) ;
 
@@ -868,7 +868,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, RooDataHist* h
 /// Implementation of RooAbsData virtual method that drives the RooAbsData::reduce() methods
 
 RooAbsData* RooDataHist::reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange,
-    std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/)
+    std::size_t nStart, std::size_t nStop)
 {
   checkInit() ;
   RooArgSet* myVarSubset = (RooArgSet*) _vars.selectCommon(varSubset) ;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -841,16 +841,10 @@ RooDataSet::RooDataSet(RooDataSet const & other, const char* newname) :
 
 RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset,
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-             std::size_t nStart, std::size_t nStop, const char* wgtVarName) :
+             std::size_t nStart, std::size_t nStop) :
   RooAbsData(name,title,vars)
 {
-  if (defaultStorageType == Tree) {
-    _dstore = new RooTreeDataStore(name, title, *dset->_dstore, _vars, cutVar, cutRange, nStart, nStop,
-        wgtVarName);
-  } else {
-    _dstore = new RooVectorDataStore(name, title, *dset->_dstore, _vars, cutVar, cutRange, nStart,
-        nStop, wgtVarName);
-  }
+  _dstore = dset->_dstore->reduce(name, title, _vars, cutVar, cutRange, nStart, nStop);
 
    _cachedVars.add(_dstore->cachedVars());
 
@@ -936,21 +930,11 @@ RooAbsData* RooDataSet::reduceEng(const RooArgSet& varSubset, const RooFormulaVa
               std::size_t nStart, std::size_t nStop)
 {
   checkInit() ;
-
-  //cout << "reduceEng varSubset = " << varSubset << " _wgtVar = " << (_wgtVar ? _wgtVar->GetName() : "") << endl;
-
   RooArgSet tmp(varSubset) ;
   if (_wgtVar) {
     tmp.add(*_wgtVar) ;
   }
-  RooDataSet* ret =  new RooDataSet(GetName(), GetTitle(), this, tmp, cutVar, cutRange, nStart, nStop,_wgtVar?_wgtVar->GetName():0) ;
-
-  // WVE - propagate optional weight variable
-  //       check behaviour in plotting.
-  // if (_wgtVar) {
-  //   ret->setWeightVar(_wgtVar->GetName()) ;
-  // }
-  return ret ;
+  return new RooDataSet(GetName(), GetTitle(), this, tmp, cutVar, cutRange, nStart, nStop) ;
 }
 
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -872,24 +872,6 @@ RooArgSet RooDataSet::addWgtVar(const RooArgSet& origVars, const RooAbsArg* wgtV
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Return a clone of this dataset containing only the cached variables
-
-RooAbsData* RooDataSet::cacheClone(const RooAbsArg* newCacheOwner, const RooArgSet* newCacheVars, const char* newName)
-{
-  RooDataSet* dset = new RooDataSet(newName?newName:GetName(),GetTitle(),this,_vars,(RooFormulaVar*)0,0,0,2000000000,kTRUE,_wgtVar?_wgtVar->GetName():0) ;
-  //if (_wgtVar) dset->setWeightVar(_wgtVar->GetName()) ;
-
-  RooArgSet* selCacheVars = (RooArgSet*) newCacheVars->selectCommon(dset->_cachedVars) ;
-  dset->attachCache(newCacheOwner, *selCacheVars) ;
-  delete selCacheVars ;
-
-  return dset ;
-}
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Return an empty clone of this dataset. If vars is not null, only the variables in vars
 /// are added to the definition of the empty clone

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -841,15 +841,15 @@ RooDataSet::RooDataSet(RooDataSet const & other, const char* newname) :
 
 RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset,
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-             std::size_t nStart, std::size_t nStop, Bool_t copyCache, const char* wgtVarName) :
+             std::size_t nStart, std::size_t nStop, const char* wgtVarName) :
   RooAbsData(name,title,vars)
 {
   if (defaultStorageType == Tree) {
     _dstore = new RooTreeDataStore(name, title, *dset->_dstore, _vars, cutVar, cutRange, nStart, nStop,
-        copyCache, wgtVarName);
+        wgtVarName);
   } else {
     _dstore = new RooVectorDataStore(name, title, *dset->_dstore, _vars, cutVar, cutRange, nStart,
-        nStop, copyCache, wgtVarName);
+        nStop, wgtVarName);
   }
 
    _cachedVars.add(_dstore->cachedVars());
@@ -933,7 +933,7 @@ void RooDataSet::initialize(const char* wgtVarName)
 /// Implementation of RooAbsData virtual method that drives the RooAbsData::reduce() methods
 
 RooAbsData* RooDataSet::reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange,
-              std::size_t nStart, std::size_t nStop, Bool_t copyCache)
+              std::size_t nStart, std::size_t nStop)
 {
   checkInit() ;
 
@@ -943,7 +943,7 @@ RooAbsData* RooDataSet::reduceEng(const RooArgSet& varSubset, const RooFormulaVa
   if (_wgtVar) {
     tmp.add(*_wgtVar) ;
   }
-  RooDataSet* ret =  new RooDataSet(GetName(), GetTitle(), this, tmp, cutVar, cutRange, nStart, nStop, copyCache,_wgtVar?_wgtVar->GetName():0) ;
+  RooDataSet* ret =  new RooDataSet(GetName(), GetTitle(), this, tmp, cutVar, cutRange, nStart, nStop,_wgtVar?_wgtVar->GetName():0) ;
 
   // WVE - propagate optional weight variable
   //       check behaviour in plotting.

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -266,6 +266,17 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, RooA
 }
 
 
+RooAbsDataStore* RooTreeDataStore::reduce(RooStringView name, RooStringView title,
+                        const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
+                        std::size_t nStart, std::size_t nStop) {
+  RooArgSet tmp(vars) ;
+  if(_wgtVar && !tmp.contains(*_wgtVar)) {
+    tmp.add(*_wgtVar) ;
+  }
+  const char* wgtVarName = _wgtVar ? _wgtVar->GetName() : nullptr;
+  return new RooTreeDataStore(name, title, *this, tmp, cutVar, cutRange, nStart, nStop, wgtVarName);
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Utility function for constructors

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -71,18 +71,7 @@ Int_t RooTreeDataStore::_defTreeBufSize = 10*1024*1024;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooTreeDataStore::RooTreeDataStore() :
-  _tree(0),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kTRUE),
-  _wgtVar(0),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
-{
-}
+RooTreeDataStore::RooTreeDataStore() : _defCtor(true) {}
 
 
 
@@ -92,12 +81,9 @@ RooTreeDataStore::RooTreeDataStore() :
 RooTreeDataStore::RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore("blah","blah",varsNoWeight(vars,wgtVarName)),
   _tree(t),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kTRUE),
+  _defCtor(true),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
 }
 
@@ -108,16 +94,8 @@ RooTreeDataStore::RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* 
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _tree(0),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kFALSE),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   initialize() ;
 }
@@ -129,16 +107,8 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _tree(0),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kFALSE),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   initialize() ;
   loadValues(&t,&select) ;
@@ -150,16 +120,8 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _tree(0),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kFALSE),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   initialize() ;
 
@@ -178,16 +140,8 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _tree(0),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kFALSE),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   initialize() ;
   loadValues(&tds,&select) ;
@@ -199,16 +153,8 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& ads, const char* selExpr, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _tree(0),
-  _cacheTree(0),
-  _cacheOwner(0),
-  _defCtor(kFALSE),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   initialize() ;
 
@@ -231,11 +177,7 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, RooA
           Int_t nStart, Int_t nStop, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)), _defCtor(kFALSE),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _curWgt(1),
-  _curWgtErrLo(0),
-  _curWgtErrHi(0),
-  _curWgtErr(0)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   // WVE NEED TO ADJUST THIS FOR WEIGHTS
 
@@ -340,9 +282,6 @@ void RooTreeDataStore::attachCache(const RooAbsArg* newOwner, const RooArgSet& c
 
 RooTreeDataStore::RooTreeDataStore(const RooTreeDataStore& other, const char* newname) :
   RooAbsDataStore(other,newname),
-  _tree(0),
-  _cacheTree(0),
-  _defCtor(kFALSE),
   _varsww(other._varsww),
   _wgtVar(other._wgtVar),
   _extWgtArray(other._extWgtArray),
@@ -363,9 +302,6 @@ RooTreeDataStore::RooTreeDataStore(const RooTreeDataStore& other, const char* ne
 
 RooTreeDataStore::RooTreeDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname) :
   RooAbsDataStore(other,varsNoWeight(vars,other._wgtVar?other._wgtVar->GetName():0),newname),
-  _tree(0),
-  _cacheTree(0),
-  _defCtor(kFALSE),
   _varsww(vars),
   _wgtVar(other._wgtVar?weightVar(vars,other._wgtVar->GetName()):0),
   _extWgtArray(other._extWgtArray),

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -228,7 +228,7 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-          Int_t nStart, Int_t nStop, Bool_t /*copyCache*/, const char* wgtVarName) :
+          Int_t nStart, Int_t nStop, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)), _defCtor(kFALSE),
   _varsww(vars),
   _wgtVar(weightVar(vars,wgtVarName)),

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -281,6 +281,16 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const Ro
 }
 
 
+RooAbsDataStore* RooVectorDataStore::reduce(RooStringView name, RooStringView title,
+                        const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
+                        std::size_t nStart, std::size_t nStop) {
+  RooArgSet tmp(vars) ;
+  if(_wgtVar && !tmp.contains(*_wgtVar)) {
+    tmp.add(*_wgtVar) ;
+  }
+  const char* wgtVarName = _wgtVar ? _wgtVar->GetName() : nullptr;
+  return new RooVectorDataStore(name, title, *this, tmp, cutVar, cutRange, nStart, nStop, wgtVarName);
+}
 
 
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -57,17 +57,7 @@ ClassImp(RooVectorDataStore::RealVector);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-RooVectorDataStore::RooVectorDataStore() :
-  _wgtVar(0),
-  _sumWeight(0),
-  _sumWeightCarry(0),
-  _extWgtArray(0),
-  _extWgtErrLoArray(0),
-  _extWgtErrHiArray(0),
-  _extSumW2Array(0),
-  _cache(0),
-  _cacheOwner(0),
-  _forcedUpdate(kFALSE)
+RooVectorDataStore::RooVectorDataStore()
 {
   TRACE_CREATE
 }
@@ -79,16 +69,7 @@ RooVectorDataStore::RooVectorDataStore() :
 RooVectorDataStore::RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName) :
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _sumWeight(0),
-  _sumWeightCarry(0),
-  _extWgtArray(0),
-  _extWgtErrLoArray(0),
-  _extWgtErrHiArray(0),
-  _extSumW2Array(0),
-  _cache(0),
-  _cacheOwner(0),
-  _forcedUpdate(kFALSE)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   for (auto arg : _varsww) {
     arg->attachToVStore(*this) ;
@@ -167,10 +148,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const ch
   _extWgtErrLoArray(other._extWgtErrLoArray),
   _extWgtErrHiArray(other._extWgtErrHiArray),
   _extSumW2Array(other._extSumW2Array),
-  _currentWeightIndex(other._currentWeightIndex),
-  _cache(0),
-  _cacheOwner(0),
-  _forcedUpdate(kFALSE)
+  _currentWeightIndex(other._currentWeightIndex)
 {
   for (const auto realVec : other._realStoreList) {
     _realStoreList.push_back(new RealVector(*realVec, (RooAbsReal*)_varsww.find(realVec->_nativeReal->GetName()))) ;
@@ -195,17 +173,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const ch
 RooVectorDataStore::RooVectorDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname) :
   RooAbsDataStore(other,varsNoWeight(vars,other._wgtVar?other._wgtVar->GetName():0),newname),
   _varsww(vars),
-  _wgtVar(weightVar(vars,other._wgtVar?other._wgtVar->GetName():0)),
-  _sumWeight(0),
-  _sumWeightCarry(0),
-  _extWgtArray(0),
-  _extWgtErrLoArray(0),
-  _extWgtErrHiArray(0),
-  _extSumW2Array(0),
-  _currentWeightIndex(0),
-  _cache(0),
-  _cacheOwner(0),
-  _forcedUpdate(kFALSE)
+  _wgtVar(weightVar(vars,other._wgtVar?other._wgtVar->GetName():0))
 {
   for (const auto arg : _varsww) {
     arg->attachToVStore(*this) ;
@@ -238,9 +206,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const Ro
   _extWgtErrLoArray(other._extWgtErrLoArray),
   _extWgtErrHiArray(other._extWgtErrHiArray),
   _extSumW2Array(other._extSumW2Array),
-  _currentWeightIndex(other._currentWeightIndex),
-  _cache(0),
-  _forcedUpdate(kFALSE)
+  _currentWeightIndex(other._currentWeightIndex)
 {
   for (const auto realVec : other._realStoreList) {
     auto real = static_cast<RooAbsReal*>(vars.find(realVec->bufArg()->GetName()));
@@ -302,15 +268,7 @@ RooVectorDataStore::RooVectorDataStore(RooStringView name, RooStringView title, 
 
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName)),
-  _sumWeight(0),
-  _sumWeightCarry(0),
-  _extWgtArray(0),
-  _extWgtErrLoArray(0),
-  _extWgtErrHiArray(0),
-  _extSumW2Array(0),
-  _cache(0),
-  _forcedUpdate(kFALSE)
+  _wgtVar(weightVar(vars,wgtVarName))
 {
   for (const auto arg : _varsww) {
     arg->attachToVStore(*this) ;

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -288,7 +288,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const Ro
 
 RooVectorDataStore::RooVectorDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-          std::size_t nStart, std::size_t nStop, Bool_t /*copyCache*/, const char* wgtVarName) :
+          std::size_t nStart, std::size_t nStop, const char* wgtVarName) :
 
   RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
   _varsww(vars),


### PR DESCRIPTION
In the current implementation of `RooDataSet::reduceEng`, the dataset
itself was queried to get the weight variable used in the reduced
dataset. This didn't work with the `RooCompositeDataStore`, because a
dataset with this data store doesn't have a weight variable, as these
are encapsulated in the components of the composite store. Hence,
reducing a weighted dataset with a RooCompositeDataStore yields an
unweighted dataset, which is a bug.

To fix this problem, this commit implements a separate reduction logic
for the RooCompositeDataStore: the components are now reduced
individually, instead of naively creating a RooCompositeDataStore from a
RooVectorDataStore/RooTreeDataStore. To avoid further code branches in
RooDataSet, a new virtual function `RooAbsDataStore::reduce` is
introduced.

The first two commits update the data reduction implementation details such the bugfix is easier to implement (see commit messages for more details).

This closes https://github.com/root-project/root/issues/6951..
