### PR TITLE
[TTreeReader] Add support for Short_t, UShort_t array sizes 

### DIFF
--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -268,10 +268,18 @@ namespace {
             fSizeReader.reset(new TSizeReaderImpl<Short_t>(*treeReader, foundLeafName.c_str()));
          } else if (leafType == "UShort_t") {
             fSizeReader.reset(new TSizeReaderImpl<UShort_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "Long_t") {
+            fSizeReader.reset(new TSizeReaderImpl<Long_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "ULong_t") {
+            fSizeReader.reset(new TSizeReaderImpl<ULong_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "Long64_t") {
+            fSizeReader.reset(new TSizeReaderImpl<Long64_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "ULong64_t") {
+            fSizeReader.reset(new TSizeReaderImpl<ULong64_t>(*treeReader, foundLeafName.c_str()));
          } else {
             Error("TUIntOrIntReader",
-                  "Unsupported size type for leaf %s. Supported types are int, short int, and their unsigned "
-                  "counterparts.",
+                  "Unsupported size type for leaf %s. Supported types are int, short int, long int, long long int and "
+                  "their unsigned counterparts.",
                   leafName);
          }
       }

--- a/tree/treeplayer/src/TTreeReaderArray.cxx
+++ b/tree/treeplayer/src/TTreeReaderArray.cxx
@@ -259,10 +259,20 @@ namespace {
             return;
          }
 
-         if (sizeLeaf->IsUnsigned()) {
-            fSizeReader.reset(new TSizeReaderImpl<UInt_t>(*treeReader, foundLeafName.c_str()));
-         } else {
+         const std::string leafType = sizeLeaf->GetTypeName();
+         if (leafType == "Int_t") {
             fSizeReader.reset(new TSizeReaderImpl<Int_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "UInt_t") {
+            fSizeReader.reset(new TSizeReaderImpl<UInt_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "Short_t") {
+            fSizeReader.reset(new TSizeReaderImpl<Short_t>(*treeReader, foundLeafName.c_str()));
+         } else if (leafType == "UShort_t") {
+            fSizeReader.reset(new TSizeReaderImpl<UShort_t>(*treeReader, foundLeafName.c_str()));
+         } else {
+            Error("TUIntOrIntReader",
+                  "Unsupported size type for leaf %s. Supported types are int, short int, and their unsigned "
+                  "counterparts.",
+                  leafName);
          }
       }
 

--- a/tree/treeplayer/test/array.cxx
+++ b/tree/treeplayer/test/array.cxx
@@ -270,23 +270,20 @@ TEST(TTreeReaderArray, LongIntArray)
    EXPECT_FALSE(r.Next());
 }
 
-TEST(TTreeReaderArray, ShortSize)
+template <typename Size_t>
+void TestReadingNonIntArraySizes()
 {
    TTree t("t", "t");
-   short sizes = 1;
-   unsigned short sizeus = 1;
+   Size_t sizes = 1;
    float arr[10]{};
 
    t.Branch("sizes", &sizes);
-   t.Branch("sizeus", &sizeus);
    t.Branch("arrs", arr, "arrs[sizes]/F");
-   t.Branch("arrus", arr, "arrus[sizeus]/F");
 
    arr[0] = 42.f;
    t.Fill();
 
    sizes = 3;
-   sizeus = 3;
    arr[0] = 1.f;
    arr[1] = 2.f;
    arr[2] = 3.f;
@@ -294,19 +291,52 @@ TEST(TTreeReaderArray, ShortSize)
 
    TTreeReader r(&t);
    TTreeReaderArray<float> ras(r, "arrs");
-   TTreeReaderArray<float> raus(r, "arrus");
    r.Next();
    EXPECT_EQ(ras.GetSize(), 1);
    EXPECT_FLOAT_EQ(ras[0], 42.f);
-   EXPECT_EQ(raus.GetSize(), 1);
-   EXPECT_FLOAT_EQ(raus[0], 42.f);
    r.Next();
    EXPECT_EQ(ras.GetSize(), 3);
    EXPECT_FLOAT_EQ(ras[0], 1.f);
    EXPECT_FLOAT_EQ(ras[1], 2.f);
    EXPECT_FLOAT_EQ(ras[2], 3.f);
-   EXPECT_EQ(raus.GetSize(), 3);
-   EXPECT_FLOAT_EQ(raus[0], 1.f);
-   EXPECT_FLOAT_EQ(raus[1], 2.f);
-   EXPECT_FLOAT_EQ(raus[2], 3.f);
+}
+
+TEST(TTreeReaderArray, ShortSize)
+{
+   TestReadingNonIntArraySizes<short>();
+}
+
+TEST(TTreeReaderArray, UShortSize)
+{
+   TestReadingNonIntArraySizes<unsigned short>();
+}
+
+TEST(TTreeReaderArray, LongSize)
+{
+   TestReadingNonIntArraySizes<long>();
+}
+
+TEST(TTreeReaderArray, ULongSize)
+{
+   TestReadingNonIntArraySizes<unsigned long>();
+}
+
+TEST(TTreeReaderArray, LongLongSize)
+{
+   TestReadingNonIntArraySizes<long long>();
+}
+
+TEST(TTreeReaderArray, ULongLongSize)
+{
+   TestReadingNonIntArraySizes<unsigned long long>();
+}
+
+TEST(TTreeReaderArray, Long64Size)
+{
+   TestReadingNonIntArraySizes<Long64_t>();
+}
+
+TEST(TTreeReaderArray, ULong64Size)
+{
+   TestReadingNonIntArraySizes<ULong64_t>();
 }

--- a/tree/treeplayer/test/array.cxx
+++ b/tree/treeplayer/test/array.cxx
@@ -269,3 +269,44 @@ TEST(TTreeReaderArray, LongIntArray)
    EXPECT_EQ(rg[1], std::numeric_limits<unsigned long int>::max());
    EXPECT_FALSE(r.Next());
 }
+
+TEST(TTreeReaderArray, ShortSize)
+{
+   TTree t("t", "t");
+   short sizes = 1;
+   unsigned short sizeus = 1;
+   float arr[10]{};
+
+   t.Branch("sizes", &sizes);
+   t.Branch("sizeus", &sizeus);
+   t.Branch("arrs", arr, "arrs[sizes]/F");
+   t.Branch("arrus", arr, "arrus[sizeus]/F");
+
+   arr[0] = 42.f;
+   t.Fill();
+
+   sizes = 3;
+   sizeus = 3;
+   arr[0] = 1.f;
+   arr[1] = 2.f;
+   arr[2] = 3.f;
+   t.Fill();
+
+   TTreeReader r(&t);
+   TTreeReaderArray<float> ras(r, "arrs");
+   TTreeReaderArray<float> raus(r, "arrus");
+   r.Next();
+   EXPECT_EQ(ras.GetSize(), 1);
+   EXPECT_FLOAT_EQ(ras[0], 42.f);
+   EXPECT_EQ(raus.GetSize(), 1);
+   EXPECT_FLOAT_EQ(raus[0], 42.f);
+   r.Next();
+   EXPECT_EQ(ras.GetSize(), 3);
+   EXPECT_FLOAT_EQ(ras[0], 1.f);
+   EXPECT_FLOAT_EQ(ras[1], 2.f);
+   EXPECT_FLOAT_EQ(ras[2], 3.f);
+   EXPECT_EQ(raus.GetSize(), 3);
+   EXPECT_FLOAT_EQ(raus[0], 1.f);
+   EXPECT_FLOAT_EQ(raus[1], 2.f);
+   EXPECT_FLOAT_EQ(raus[2], 3.f);
+}


### PR DESCRIPTION
This fixes [ROOT-8827](https://sft.its.cern.ch/jira/browse/ROOT-8827).

@pcanal I'm not sure whether `Long_t` and `Long64_t` should also be in the picture, let me know.