### PR TITLE
[RF] Deprecate `RooAbsData::createHistogram` overload with `int` params

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -45,6 +45,9 @@ Please use their non-experimental counterparts `ROOT::TBufferMerger` and `ROOT::
 - The deprecated RooFit containers `RooHashTable`, `RooNameSet`, `RooSetPair`, and `RooList` are removed. Please use STL container classes instead, like `std::unordered_map`, `std::set`, and `std::vector`.
 - The `RooFit::FitOptions(const char*)` command to steer [RooAbsPdf::fitTo()](https://root.cern.ch/doc/v628/classRooAbsPdf.html) with an option string was removed. This way of configuring the fit was deprecated since at least since ROOT 5.02.
   Subsequently, the `RooMinimizer::fit(const char*)` function and the [RooMCStudy](https://root.cern.ch/doc/v628/classRooMCStudy.html) constructor that takes an option string was removed as well.
+- The overload of `RooAbsData::createHistogram` that takes integer parameters for the bin numbers is now deprecated and will be removed in ROOT 6.30.
+  This was done to avoid confusion with inconsistent behavior when compared to other `createHistogram` overloads.
+  Please use the verson of `createHistogram` that takes RooFit command arguments.
 
 ## Core Libraries
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -24,6 +24,7 @@
 #include "RooNameReg.h"
 #include "RooFit/UniqueId.h"
 
+#include <ROOT/RConfig.hxx> // R__DEPRECATED
 #include "TNamed.h"
 
 #include <map>
@@ -215,7 +216,8 @@ public:
                        const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none()) const ;
   /// Create and fill a ROOT histogram TH1,TH2 or TH3 with the values of this dataset.
   TH1 *createHistogram(const char *name, const RooAbsRealLValue& xvar, const RooLinkedList& argList) const ;
-  TH1 *createHistogram(const char* varNameList, Int_t xbins=0, Int_t ybins=0, Int_t zbins=0) const ;
+  TH1 *createHistogram(const char* varNameList, Int_t xbins=0, Int_t ybins=0, Int_t zbins=0) const
+      R__DEPRECATED(6, 30, "Use the overload of RooAbsData::createHistogram that takes RooFit command arguments.");
 
   // Fill an existing histogram
   virtual TH1 *fillHistogram(TH1 *hist, const RooArgList &plotVars, const char *cuts= "", const char* cutRange=0) const;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -628,6 +628,10 @@ RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooCmdArg& arg1, const RooCmdA
 
 TH1 *RooAbsData::createHistogram(const char* varNameList, Int_t xbins, Int_t ybins, Int_t zbins) const
 {
+  coutW(DataHandling) << "'RooAbsData::createHistogram' is deprecated and will be removed in ROOT v6.30: "
+                      << "Use the overload of 'RooAbsData::createHistogram' that takes RooFit command arguments."
+                      << std::endl;
+
   // Parse list of variable names
   const auto varNames = ROOT::Split(varNameList, ",:");
   RooLinkedList argList;


### PR DESCRIPTION
The `RooAbsData::createHistogram` has two overloads, one taking RooFit
command arguments and one taking integers for bin numbers (the version
with command arguments is much more common in RooFit code).

They behave inconsistently when using default parameters, e.g. these two
calls result in different binnings:
```C++
// 1. overload with int bin numbers:
data->createHistogram(obs->GetName());

// 2. overload with command arguments:
data->createHistogram(data->GetName(), dataObs);
```

The function with integer bin numbers defaults to computing a binning
automatically from the distribution in the dataset. The function with
command arguments defaults to the binning stored in the variable, which
is much more suitable for RooFit.

To avoid confusion in the future, this commit marks the overload with
the `int` parameters as deprecated so it is removed in ROOT 6.30.

Closes https://github.com/root-project/root/issues/10401.
