### PR TITLE
[config] Fix thisroot.sh when run from an executable script

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -180,6 +180,8 @@ fi
 SHELLNAME=$(getTrueShellExeName)
 if [ "$SHELLNAME" = "bash" ]; then
    SOURCE=${BASH_ARGV[0]}
+elif [ "x${SHELLNAME}" = "x" ]; then # workaround, when running thisroot.sh from an executable script, getTrueShellExeName does not work, fall back to default
+   SOURCE=${BASH_ARGV[0]}
 elif [ "$SHELLNAME" = "zsh" ]; then
    SOURCE=${(%):-%N}
 else # dash or ksh


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Support for dash was added recently to thisroot.sh, but this has led to a problem when calling thisroot.sh from an executed script. The regression is fixed now by defaulting to the previous behaviour if the shell-name is not found.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes [#](https://github.com/root-project/root/issues/10417) 

