### PR TITLE
[core] Fix interaction of Maps of TThreadExecutor and std::vectors

### DIFF
--- a/core/imt/inc/ROOT/TThreadExecutor.hxx
+++ b/core/imt/inc/ROOT/TThreadExecutor.hxx
@@ -411,9 +411,8 @@ namespace ROOT {
 
       using retType = decltype(func(args.front()));
       std::vector<retType> reslist(actualChunks);
-      auto lambda = [&](unsigned int i)
-      {
-         std::vector<T> partialResults(step);
+      auto lambda = [&](unsigned int i) {
+         std::vector<retType> partialResults(step);
          for (unsigned j = 0; j < step && (i + j) < nToProcess; j++) {
             partialResults[j] = func(args[i + j]);
          }
@@ -444,9 +443,8 @@ namespace ROOT {
 
       using retType = decltype(func(args.front()));
       std::vector<retType> reslist(actualChunks);
-      auto lambda = [&](unsigned int i)
-      {
-         std::vector<T> partialResults(step);
+      auto lambda = [&](unsigned int i) {
+         std::vector<retType> partialResults(step);
          for (unsigned j = 0; j < step && (i + j) < nToProcess; j++) {
             partialResults[j] = func(args[i + j]);
          }


### PR DESCRIPTION
Fixed the types of the partial results after applying the function.
Otherwise, there is a problem if `retType` is different than the input type `T`.
