### PR TITLE
Remove "private" implementation of function deprecated in v6.24

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -574,13 +574,6 @@ namespace Internal {
       return 0;
 #endif
    }
-
-   ////////////////////////////////////////////////////////////////////////////////
-   /// Returns the size of the pool used for implicit multi-threading.
-   UInt_t GetImplicitMTPoolSize()
-   {
-      return GetThreadPoolSize();
-   }
 } // end of ROOT namespace
 
 TROOT *ROOT::Internal::gROOTLocal = ROOT::GetROOT();


### PR DESCRIPTION
The corresponding declaration in the header has already been removed
in 6.24, so this function cannot be called outside of this
source file.

See also #10413 .