### PR TITLE
[config] correctly identify shell name from an executable script

### DIFF
--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -157,8 +157,12 @@ set_environment()
 getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
   local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
   # Determine the shell executable filename.
-  trueExe=$(ps -o comm= $$) || return 1
-  # Strip a leading "-", as added e.g. by OSX for login shells.
+  if [ "$(uname)" = 'Linux' ]; then
+    trueExe=$(cut -d '' -f1 /proc/$$/cmdline) || return 1
+  else
+    trueExe=$(ps -p $$ -o comm=) || return 1
+  fi
+  # Strip a leading "-", as added e.g. by macOS for login shells.
   [ "${trueExe#-}" = "$trueExe" ] || trueExe=${trueExe#-}
   # Determine full executable path.
   [ "${trueExe#/}" != "$trueExe" ] || trueExe=$([ -n "$ZSH_VERSION" ] && which -p "$trueExe" || which "$trueExe")
@@ -180,7 +184,8 @@ fi
 SHELLNAME=$(getTrueShellExeName)
 if [ "$SHELLNAME" = "bash" ]; then
    SOURCE=${BASH_ARGV[0]}
-elif [ "x${SHELLNAME}" = "x" ]; then # workaround, when running thisroot.sh from an executable script, getTrueShellExeName does not work, fall back to default
+elif [ "x${SHELLNAME}" = "x" ]; then # in case getTrueShellExeName does not work, fall back to default
+   echo WARNING: shell name was not recognized.
    SOURCE=${BASH_ARGV[0]}
 elif [ "$SHELLNAME" = "zsh" ]; then
    SOURCE=${(%):-%N}


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Shell-name was not being found if the script was an executable, in that case it was assumed it was bash (see https://github.com/root-project/root/pull/10418).

This PR applies a fix in the function getting the shell name, details are discussed here:
https://stackoverflow.com/questions/71944436/how-to-get-the-unix-shell-executable-name-for-a-script-marked-as-executable-and 

Now, the shell is correctly identified in all tested cases. For security, it will print a warning if shell name is not found, but still run.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

