### PR TITLE
[skip-ci] Remove ellipsis

### DIFF
--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -515,7 +515,7 @@ their color. The simplest way is to pick colors in the current active color
 palette. Palette coloring for histogram is activated thanks to the options `PFC`
 (Palette Fill Color), `PLC` (Palette Line Color) and `PMC` (Palette Marker Color).
 When one of these options is given to `TGraph::Draw` the graph get its color
-from the current color palette defined by `gStyle->SetPalette(…)`. The color
+from the current color palette defined by `gStyle->SetPalette(...)`. The color
 is determined according to the number of objects having palette coloring in
 the current pad.
 

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -450,7 +450,7 @@ their color. The simplest way is to pick colors in the current active color
 palette. Palette coloring for histogram is activated thanks to the options `PFC`
 (Palette Fill Color), `PLC` (Palette Line Color) and `PMC` (Palette Marker Color).
 When one of these options is given to `TH1::Draw` the histogram get its color
-from the current color palette defined by `gStyle->SetPalette(…)`. The color
+from the current color palette defined by `gStyle->SetPalette(...)`. The color
 is determined according to the number of objects having palette coloring in
 the current pad.
 

--- a/tutorials/graphs/graphpalettecolor.C
+++ b/tutorials/graphs/graphpalettecolor.C
@@ -4,7 +4,7 @@
 /// Palette coloring for graphs is activated thanks to the options `PFC` (Palette Fill
 /// Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color). When
 /// one of these options is given to `TGraph::Draw` the `TGraph` get its color
-/// from the current color palette defined by `gStyle->SetPalette(…)`. The color
+/// from the current color palette defined by `gStyle->SetPalette(...)`. The color
 /// is determined according to the number of objects having palette coloring in
 /// the current pad.
 ///

--- a/tutorials/graphs/multigraphpalettecolor.C
+++ b/tutorials/graphs/multigraphpalettecolor.C
@@ -5,7 +5,7 @@
 /// (Palette Fill Color), `PLC` (Palette Line Color) and `AMC` (Palette Marker Color).
 /// When one of these options is given to `TMultiGraph::Draw` the `TGraph`s  in the
 /// `TMultiGraph`get their color from the current color palette defined by
-/// `gStyle->SetPalette(…)`. The color is determined according to the number of
+/// `gStyle->SetPalette(...)`. The color is determined according to the number of
 /// `TGraph`s.
 ///
 /// In this example four graphs are displayed with palette coloring for lines and


### PR DESCRIPTION
Remove the ellipsis character in documentation.
It created problems during doxygen  build.

