### PR TITLE
[skip-ci] Some tutorials need python3

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: filter folders mathjax js images doxygen
 
-PYTHON_EXECUTABLE ?= /usr/bin/python
+PYTHON_EXECUTABLE ?= /usr/bin/python3
 export PYTHON_EXECUTABLE
 
 DOXYGEN_OUTPUT_DIRECTORY ?= $(HOME)/rootdoc


### PR DESCRIPTION
python3  is now used to build the reference because some tutorials like `distrdf001_spark_connection.py` require python3. 
