### PR TITLE
[Math] Fix memory leak when using GSLMultiFit and improve Fitter class

### DIFF
--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -471,9 +471,13 @@ protected:
    // initialize the minimizer
    bool DoInitMinimizer();
    /// do minimization
-   bool DoMinimization(const BaseFunc & f, const ROOT::Math::IMultiGenFunction * chifunc = 0);
-   // do minimization after having set obj function
-   bool DoMinimization(const ROOT::Math::IMultiGenFunction * chifunc = 0);
+   template<class ObjFunc_t>
+   bool DoMinimization(std::unique_ptr<ObjFunc_t> f, const ROOT::Math::IMultiGenFunction * chifunc = nullptr);
+   // do minimization for weighted likelihood fits
+   template<class ObjFunc_t>
+   bool DoWeightMinimization(std::unique_ptr<ObjFunc_t> f, const ROOT::Math::IMultiGenFunction * chifunc = nullptr);
+   // do minimization after having set the objective function
+   bool DoMinimization(const ROOT::Math::IMultiGenFunction * chifunc = nullptr);
    // update config after fit
    void DoUpdateFitConfig();
    // update minimizer options for re-fitting

--- a/math/mathcore/inc/Math/BasicMinimizer.h
+++ b/math/mathcore/inc/Math/BasicMinimizer.h
@@ -153,8 +153,6 @@ public:
    /// return pointer to used gradient object function  (NULL if gradient is not supported)
    const ROOT::Math::IMultiGradFunction * GradObjFunction() const;
 
-   /// return transformation function (NULL if not having a transformation)
-   const ROOT::Math::MinimTransformFunction * TransformFunction() const;
 
    /// print result of minimization
    void PrintResult() const;
@@ -170,7 +168,7 @@ protected:
 
    MinimTransformFunction * CreateTransformation(std::vector<double> & startValues, const ROOT::Math::IMultiGradFunction * func = 0);
 
-   void SetFinalValues(const double * x);
+   void SetFinalValues(const double * x, const MinimTransformFunction * func = nullptr);
 
    void SetMinValue(double val) { fMinVal = val; }
 

--- a/math/mathcore/inc/Math/MinimTransformFunction.h
+++ b/math/mathcore/inc/Math/MinimTransformFunction.h
@@ -22,6 +22,8 @@
 
 #include <vector>
 #include <map>
+#include <memory>
+#include <iostream>
 
 namespace ROOT {
 
@@ -45,7 +47,7 @@ public:
 
 
    /**
-     Constructor from a IMultiGradFunction interface (which is managed by the class)
+     Constructor from a IMultiGradFunction interface that is externally managed
      vector specifying the variable types (free, bounded or fixed, defined in enum EMinimVariableTypes )
      variable values (used for the fixed ones) and a map with the bounds (for the bounded variables)
 
@@ -55,12 +57,9 @@ public:
 
 
    /**
-      Destructor (delete function pointer)
+      Destructor (no operation)
    */
-   ~MinimTransformFunction () override  {
-      if (fFunc) delete fFunc;
-   }
-
+   ~MinimTransformFunction () override  { }
 
    // method inherited from IFunction interface
 

--- a/math/mathcore/src/BasicMinimizer.cxx
+++ b/math/mathcore/src/BasicMinimizer.cxx
@@ -238,13 +238,13 @@ int BasicMinimizer::VariableIndex(const std::string & name) const {
 
 
 void BasicMinimizer::SetFunction(const ROOT::Math::IMultiGenFunction & func) {
-   // set the function to minimizer
+   // set the function to minimizer after cloning it
    fObjFunc = func.Clone();
    fDim = fObjFunc->NDim();
 }
 
 void BasicMinimizer::SetFunction(const ROOT::Math::IMultiGradFunction & func) {
-   // set the function to minimize
+   // set the gradient function to minimize after cloning it
    fObjFunc = dynamic_cast<const ROOT::Math::IMultiGradFunction *>( func.Clone());
    assert(fObjFunc != 0);
    fDim = fObjFunc->NDim();
@@ -279,37 +279,22 @@ MinimTransformFunction * BasicMinimizer::CreateTransformation(std::vector<double
 
    startValues = std::vector<double>(fValues.begin(), fValues.end() );
 
-   MinimTransformFunction * trFunc  = 0;
-
    // in case of transformation wrap objective function in a new transformation function
-   // and transform from external variables  to internals one
+   // and transform from external variables  to internals ones type
    // Transformations are supported only for gradient function
    const IMultiGradFunction * gradObjFunc = (func) ? func : dynamic_cast<const IMultiGradFunction *>(fObjFunc);
    doTransform &= (gradObjFunc != 0);
 
-   if (doTransform)   {
-      // minim transform function manages the passed function pointer (gradObjFunc)
-      trFunc =  new MinimTransformFunction ( gradObjFunc, fVarTypes, fValues, fBounds );
-      // transform from external to internal
-      trFunc->InvTransformation(&fValues.front(), &startValues[0]);
-      // size can be different since internal parameter can have smaller size
-      // if there are fixed parameters
-      startValues.resize( trFunc->NDim() );
-      // no need to save fObjFunc since trFunc will manage it
-      fObjFunc = trFunc;
-   }
-   else {
-      if (func) fObjFunc = func;  // to manege the passed function object
-   }
+   if (!doTransform) return nullptr;
 
-//    std::cout << " f has transform " << doTransform << "  " << fBounds.size() << "   " << startValues.size() <<  " ndim " << fObjFunc->NDim() << std::endl;   std::cout << "InitialValues external : ";
-//    for (int i = 0; i < fValues.size(); ++i) std::cout << fValues[i] << "  ";
-//    std::cout << "\n";
-//    std::cout << "InitialValues internal : ";
-//    for (int i = 0; i < startValues.size(); ++i) std::cout << startValues[i] << "  ";
-//    std::cout << "\n";
-
-
+   // minim transform function manages the passed function pointer (gradObjFunc)
+   auto trFunc =  new MinimTransformFunction ( gradObjFunc, fVarTypes, fValues, fBounds );
+   // transform from external to internal
+   trFunc->InvTransformation(&fValues.front(), &startValues[0]);
+   // size can be different since internal parameter can have smaller size
+   // if there are fixed parameters
+   startValues.resize( trFunc->NDim() );
+   // we transfer ownership of trFunc to the caller
    return trFunc;
 }
 
@@ -319,9 +304,8 @@ bool BasicMinimizer::Minimize() {
    return false;
 }
 
-void BasicMinimizer::SetFinalValues(const double * x) {
-   // check to see if a transformation need to be applied
-   const MinimTransformFunction * trFunc = TransformFunction();
+void BasicMinimizer::SetFinalValues(const double * x, const MinimTransformFunction * trFunc) {
+   // check to see if a transformation needs to be applied
    if (trFunc) {
       assert(fValues.size() >= trFunc->NTot() );
       trFunc->Transformation(x, &fValues[0]);
@@ -349,9 +333,6 @@ const ROOT::Math::IMultiGradFunction * BasicMinimizer::GradObjFunction() const {
       return  dynamic_cast<const ROOT::Math::IMultiGradFunction *>(fObjFunc);
 }
 
-const MinimTransformFunction * BasicMinimizer::TransformFunction() const {
-   return dynamic_cast<const MinimTransformFunction *>(fObjFunc);
-}
 
 unsigned int BasicMinimizer::NFree() const {
    // number of free variables

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -510,7 +510,7 @@ bool Fitter::DoBinnedLikelihoodFit(bool extended, const ROOT::EExecutionPolicy &
             return false;
          }
          // use gradient for minimization
-         // not-extended is not impelemented in this case
+         // not-extended is not implemented in this case
          if (!extended) {
             MATH_WARN_MSG("Fitter::DoBinnedLikelihoodFit",
                           "Not-extended binned fit with gradient not yet supported - do an extended fit");
@@ -764,15 +764,15 @@ bool Fitter::CalculateMinosErrors() {
    const std::vector<unsigned int> & ipars = fConfig.MinosParams();
    unsigned int n = (ipars.size() > 0) ? ipars.size() : fResult->Parameters().size();
    bool ok = false;
-  
-   int iparNewMin = 0; 
-   int iparMax = n; 
-   int iter = 0; 
+
+   int iparNewMin = 0;
+   int iparMax = n;
+   int iter = 0;
    // rerun minos for the parameters run before a new Minimum has been found
    do {
-      if (iparNewMin > 0) 
+      if (iparNewMin > 0)
          MATH_INFO_MSG("Fitter::CalculateMinosErrors","Run again Minos for some parameters because a new Minimum has been found");
-      iparNewMin = 0; 
+      iparNewMin = 0;
       for (int i = 0; i < iparMax; ++i) {
          double elow, eup;
          unsigned int index = (ipars.size() > 0) ? ipars[i] : i;
@@ -787,7 +787,7 @@ bool Fitter::CalculateMinosErrors() {
       }
 
       iparMax = iparNewMin;
-      iter++;  // to avoid infinite looping 
+      iter++;  // to avoid infinite looping
    }
    while( iparNewMin > 0 && iter < 10);
    if (!ok) {

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -52,7 +52,7 @@ namespace ROOT {
 /**
     LSResidualFunc class description.
     Internal class used for accessing the residuals of the Least Square function
-    and their derivates which are estimated numerically using GSL numerical derivation.
+    and their derivatives which are estimated numerically using GSL numerical derivation.
     The class contains a pointer to the fit method function and an index specifying
     the i-th residual and wraps it in a multi-dim gradient function interface
     ROOT::Math::IGradientFunctionMultiDim.

--- a/math/mathmore/inc/Math/MultiNumGradFunction.h
+++ b/math/mathmore/inc/Math/MultiNumGradFunction.h
@@ -63,7 +63,7 @@ public:
 
    /**
      Constructor from a generic function (pointer or reference) and number of dimension
-     implementiong operator () (double * x)
+     implementing operator () (double * x)
    */
 
    template<class FuncType>


### PR DESCRIPTION
This Pull request fixes a memory leak reported in https://root-forum.cern.ch/t/gslmultifit-memory-leak-with-root-fitter/49566 when using GSLMultiFit. 

In addition for fixing for the leak the handling of the internal transformation function is improved and an extra un-needed clone of the objective function in the Fitter class is avoided. 


