### PR TITLE
[ntuple] Capture, do not generate value in RVecField::ReadGlobalImpl

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1399,7 +1399,7 @@ protected:
       fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
       typedValue->resize(nItems);
       for (unsigned i = 0; i < nItems; ++i) {
-         auto itemValue = fSubFields[0]->GenerateValue(&typedValue->data()[i]);
+         auto itemValue = fSubFields[0]->CaptureValue(&typedValue->data()[i]);
          fSubFields[0]->Read(collectionStart + i, &itemValue);
       }
    }


### PR DESCRIPTION
The `resize` called a few lines above initializes elements as
necessary. We don't need to call GenerateValue on those memory
locations (which performs another placement new on them), rather
a CaptureValue is enough.