### PR TITLE
Fix access violation with df017_vecOpsHEP.C on Windows

### DIFF
--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -64,6 +64,11 @@ namespace Internal {
    class TTreeReaderValueBase;
 } // namespace Internal
 
+// prevent access violation when executing the df017_vecOpsHEP.C tutorial with ROOT built in release mode
+// TODO: to be reviewed when updating Visual Studio or LLVM
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma optimize( "", off )
+#endif
 
 namespace Detail {
    class TBranchProxy {
@@ -513,6 +518,10 @@ public:
       Int_t GetOffset() { return fOffset; }
    };
 } // namespace Detail
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma optimize( "", on )
+#endif
 
 namespace Internal {
 

--- a/tree/treeplayer/inc/TBranchProxy.h
+++ b/tree/treeplayer/inc/TBranchProxy.h
@@ -67,7 +67,7 @@ namespace Internal {
 // prevent access violation when executing the df017_vecOpsHEP.C tutorial with ROOT built in release mode
 // TODO: to be reviewed when updating Visual Studio or LLVM
 #if defined(_MSC_VER) && !defined(__clang__)
-#pragma optimize( "", off )
+#pragma optimize("", off)
 #endif
 
 namespace Detail {
@@ -520,7 +520,7 @@ public:
 } // namespace Detail
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#pragma optimize( "", on )
+#pragma optimize("", on)
 #endif
 
 namespace Internal {


### PR DESCRIPTION
Prevent access violation when executing the df017_vecOpsHEP.C tutorial with ROOT built in release mode. To be reviewed when updating Visual Studio or LLVM