### PR TITLE
Use override syntax in some core classes

### DIFF
--- a/core/base/inc/Rtypes.h
+++ b/core/base/inc/Rtypes.h
@@ -162,20 +162,20 @@ namespace ROOT {
 
    class TDefaultInitBehavior: public TInitBehavior {
    public:
-      virtual void Register(const char *cname, Version_t id,
+      void Register(const char *cname, Version_t id,
                             const std::type_info &info,
-                            DictFuncPtr_t dict, Int_t pragmabits) const {
+                            DictFuncPtr_t dict, Int_t pragmabits) const override {
          ROOT::AddClass(cname, id, info, dict, pragmabits);
       }
 
-      virtual void Unregister(const char *classname) const {
+      void Unregister(const char *classname) const override {
          ROOT::RemoveClass(classname);
       }
 
-      virtual TClass *CreateClass(const char *cname, Version_t id,
+      TClass *CreateClass(const char *cname, Version_t id,
                                   const std::type_info &info, TVirtualIsAProxy *isa,
                                   const char *dfil, const char *ifil,
-                                  Int_t dl, Int_t il) const {
+                                  Int_t dl, Int_t il) const override {
          return ROOT::CreateClass(cname, id, info, isa, dfil, ifil, dl, il);
       }
    };
@@ -387,7 +387,7 @@ public:                                                                         
          }                                                                  \
       }                                                                     \
    }
-   
+
 #define NamespaceImp(name) NamespaceImpUnique(name,default)
 
 //---- ClassDefT macros for templates with one template argument ---------------

--- a/core/base/inc/TBuffer.h
+++ b/core/base/inc/TBuffer.h
@@ -63,10 +63,10 @@ protected:
    TBuffer(const TBuffer &) = delete;
    void operator=(const TBuffer &) = delete;
 
-   Int_t Read(const char *name) { return TObject::Read(name); }
-   Int_t Write(const char *name, Int_t opt, Int_t bufs)
+   Int_t Read(const char *name) override { return TObject::Read(name); }
+   Int_t Write(const char *name, Int_t opt, Int_t bufs) override
                               { return TObject::Write(name, opt, bufs); }
-   Int_t Write(const char *name, Int_t opt, Int_t bufs) const
+   Int_t Write(const char *name, Int_t opt, Int_t bufs) const override
                               { return TObject::Write(name, opt, bufs); }
 
 public:
@@ -337,7 +337,7 @@ public:
    static TClass *GetClass(const std::type_info &typeinfo);
    static TClass *GetClass(const char *className);
 
-   ClassDef(TBuffer,0)  //Buffer base class used for serializing objects
+   ClassDefOverride(TBuffer,0)  //Buffer base class used for serializing objects
 };
 
 //---------------------- TBuffer default external operators --------------------

--- a/core/base/inc/TFolder.h
+++ b/core/base/inc/TFolder.h
@@ -34,8 +34,8 @@ protected:
    Bool_t             fIsOwner;        //true if folder own its contained objects
 
 private:
-   TFolder(const TFolder &folder);  //folders cannot be copied
-   void operator=(const TFolder &);
+   TFolder(const TFolder &folder) = delete;  //folders cannot be copied
+   void operator=(const TFolder &)= delete;
 
 public:
 
@@ -43,26 +43,26 @@ public:
    TFolder(const char *name, const char *title);
    virtual ~TFolder();
    virtual void        Add(TObject *obj);
-   TFolder            *AddFolder(const char *name, const char *title, TCollection *collection=0);
-   virtual void        Browse(TBrowser *b);
-   virtual void        Clear(Option_t *option="");
-   virtual void        Copy(TObject &) const { MayNotUse("Copy(TObject &)"); }
+   TFolder            *AddFolder(const char *name, const char *title, TCollection *collection=nullptr);
+   void                Browse(TBrowser *b) override;
+   void                Clear(Option_t *option="") override;
+   void                Copy(TObject &) const override { MayNotUse("Copy(TObject &)"); }
    virtual const char *FindFullPathName(const char *name) const;
    virtual const char *FindFullPathName(const TObject *obj) const;
-   virtual TObject    *FindObject(const char *name) const;
-   virtual TObject    *FindObject(const TObject *obj) const;
+   TObject            *FindObject(const char *name) const override;
+   TObject            *FindObject(const TObject *obj) const override;
    virtual TObject    *FindObjectAny(const char *name) const;
    TCollection        *GetListOfFolders() const { return fFolders; }
-   Bool_t              IsFolder() const { return kTRUE; }
+   Bool_t              IsFolder() const override { return kTRUE; }
    Bool_t              IsOwner()  const;
-   virtual void        ls(Option_t *option="") const;  // *MENU*
+   void                ls(Option_t *option="") const override;  // *MENU*
    virtual Int_t       Occurence(const TObject *obj) const;
-   virtual void        RecursiveRemove(TObject *obj);
+   void                RecursiveRemove(TObject *obj) override;
    virtual void        Remove(TObject *obj);
-   virtual void        SaveAs(const char *filename="",Option_t *option="") const; // *MENU*
+   void                SaveAs(const char *filename="",Option_t *option="") const override; // *MENU*
    virtual void        SetOwner(Bool_t owner=kTRUE);
 
-   ClassDef(TFolder,1)  //Describe a folder: a list of objects and folders
+   ClassDefOverride(TFolder,1)  //Describe a folder: a list of objects and folders
 };
 
 #endif

--- a/core/base/inc/TNamed.h
+++ b/core/base/inc/TNamed.h
@@ -39,23 +39,23 @@ public:
    TNamed(const TNamed &named);
    TNamed& operator=(const TNamed& rhs);
    virtual ~TNamed();
-   virtual void     Clear(Option_t *option ="");
-   virtual TObject *Clone(const char *newname="") const;
-   virtual Int_t    Compare(const TObject *obj) const;
-   virtual void     Copy(TObject &named) const;
-   virtual void     FillBuffer(char *&buffer);
-   virtual const char  *GetName() const { return fName; }
-   virtual const char  *GetTitle() const { return fTitle; }
-   virtual ULong_t  Hash() const { return fName.Hash(); }
-   virtual Bool_t   IsSortable() const { return kTRUE; }
-   virtual void     SetName(const char *name); // *MENU*
-   virtual void     SetNameTitle(const char *name, const char *title);
-   virtual void     SetTitle(const char *title=""); // *MENU*
-   virtual void     ls(Option_t *option="") const;
-   virtual void     Print(Option_t *option="") const;
-   virtual Int_t    Sizeof() const;
+            void     Clear(Option_t *option ="") override;
+            TObject *Clone(const char *newname="") const override;
+            Int_t    Compare(const TObject *obj) const override;
+            void     Copy(TObject &named) const override;
+   virtual  void     FillBuffer(char *&buffer);
+            const char  *GetName() const override { return fName; }
+            const char  *GetTitle() const override { return fTitle; }
+            ULong_t  Hash() const override { return fName.Hash(); }
+            Bool_t   IsSortable() const override { return kTRUE; }
+   virtual  void     SetName(const char *name); // *MENU*
+   virtual  void     SetNameTitle(const char *name, const char *title);
+   virtual  void     SetTitle(const char *title=""); // *MENU*
+            void     ls(Option_t *option="") const override;
+            void     Print(Option_t *option="") const override;
+   virtual  Int_t    Sizeof() const;
 
-   ClassDef(TNamed,1)  //The basis for a named object (name, title)
+   ClassDefOverride(TNamed,1)  //The basis for a named object (name, title)
 };
 
 #endif

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -190,15 +190,15 @@ public:
    virtual           ~TROOT();
    void              AddClass(TClass *cl);
    void              AddClassGenerator(TClassGenerator *gen);
-   virtual void      Append(TObject *obj, Bool_t replace = kFALSE);
-   void              Browse(TBrowser *b);
+   void              Append(TObject *obj, Bool_t replace = kFALSE) override;
+   void              Browse(TBrowser *b) override;
    Bool_t            ClassSaved(TClass *cl);
    void              CloseFiles();
    void              EndOfProcessCleanups();
-   virtual TObject  *FindObject(const char *name) const;
-   virtual TObject  *FindObject(const TObject *obj) const;
-   virtual TObject  *FindObjectAny(const char *name) const;
-   virtual TObject  *FindObjectAnyFile(const char *name) const;
+   TObject          *FindObject(const char *name) const override;
+   TObject          *FindObject(const TObject *obj) const override;
+   TObject          *FindObjectAny(const char *name) const override;
+   TObject          *FindObjectAnyFile(const char *name) const override;
    TObject          *FindSpecialObject(const char *name, void *&where);
    const char       *FindObjectClassName(const char *name) const;
    const char       *FindObjectPathName(const TObject *obj) const;
@@ -257,7 +257,7 @@ public:
    TCollection      *GetListOfFunctionTemplates();
    TList            *GetListOfBrowsables() const { return fBrowsables; }
    TDataType        *GetType(const char *name, Bool_t load = kFALSE) const;
-   TFile            *GetFile() const { if (gDirectory != this) return gDirectory->GetFile(); else return 0;}
+   TFile            *GetFile() const override { if (gDirectory != this) return gDirectory->GetFile(); else return nullptr;}
    TFile            *GetFile(const char *name) const;
    TFunctionTemplate*GetFunctionTemplate(const char *name);
    TStyle           *GetStyle(const char *name) const;
@@ -278,7 +278,7 @@ public:
    Int_t             IgnoreInclude(const char *fname, const char *expandedfname);
    Bool_t            IsBatch() const { return fBatch; }
    Bool_t            IsExecutingMacro() const { return fExecutingMacro; }
-   Bool_t            IsFolder() const { return kTRUE; }
+   Bool_t            IsFolder() const override { return kTRUE; }
    Bool_t            IsInterrupted() const { return fInterrupt; }
    Bool_t            IsEscaped() const { return fEscape; }
    Bool_t            IsLineProcessing() const { return fLineIsProcessing ? kTRUE : kFALSE; }
@@ -286,7 +286,7 @@ public:
    Bool_t            IsRootFile(const char *filename) const;
    Bool_t            IsWebDisplay() const { return fIsWebDisplay; }
    Bool_t            IsWebDisplayBatch() const { return fIsWebDisplayBatch; }
-   void              ls(Option_t *option = "") const;
+   void              ls(Option_t *option = "") const override;
    Int_t             LoadClass(const char *classname, const char *libname, Bool_t check = kFALSE);
    TClass           *LoadClass(const char *name, Bool_t silent = kFALSE) const;
    Int_t             LoadMacro(const char *filename, Int_t *error = 0, Bool_t check = kFALSE);
@@ -298,7 +298,7 @@ public:
    Longptr_t         ProcessLineSync(const char *line, Int_t *error = 0);
    Longptr_t         ProcessLineFast(const char *line, Int_t *error = 0);
    Bool_t            ReadingObject() const;
-   void              RecursiveRemove(TObject *obj);
+   void              RecursiveRemove(TObject *obj) override;
    void              RefreshBrowsers();
    static void       RegisterModule(const char* modulename,
                                     const char** headers,
@@ -309,7 +309,7 @@ public:
                                     const FwdDeclArgsToKeepCollection_t& fwdDeclsArgToSkip,
                                     const char** classesHeaders,
                                     bool hasCxxModule = false);
-   TObject          *Remove(TObject*);
+   TObject          *Remove(TObject*) override;
    void              RemoveClass(TClass *);
    void              Reset(Option_t *option="");
    void              SaveContext();
@@ -367,7 +367,7 @@ public:
    static const char *GetTutorialsDir();
    static void ShutDown();
 
-   ClassDef(TROOT,0)  //Top level (or root) structure for all classes
+   ClassDefOverride(TROOT,0)  //Top level (or root) structure for all classes
 };
 
 

--- a/core/base/inc/TUri.h
+++ b/core/base/inc/TUri.h
@@ -112,8 +112,8 @@ public:
 
    Bool_t SetRelativePart(const TString&);
 
-   void   Print(Option_t *option = "") const;
-   Bool_t IsSortable() const { return kTRUE; }
+   void   Print(Option_t *option = "") const override;
+   Bool_t IsSortable() const override { return kTRUE; }
 
    void Normalise();
    void Reset();
@@ -154,7 +154,7 @@ public:
    static TUri Transform(const TUri &reference, const TUri &base);
    static const TString MergePaths(const TUri &reference, const TUri &base);
 
-   ClassDef(TUri, 1)  //Represents an URI
+   ClassDefOverride(TUri, 1)  //Represents an URI
 };
 
 #endif

--- a/core/base/inc/TUrl.h
+++ b/core/base/inc/TUrl.h
@@ -88,14 +88,14 @@ public:
    void        SetPort(Int_t port) { fPort = port; fUrl = ""; }
    void        SetUrl(const char *url, Bool_t defaultIsFile = kFALSE);
 
-   Bool_t      IsSortable() const { return kTRUE; }
-   Int_t       Compare(const TObject *obj) const;
+   Bool_t      IsSortable() const override { return kTRUE; }
+   Int_t       Compare(const TObject *obj) const override;
 
-   void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
 
    static TObjArray *GetSpecialProtocols();
 
-   ClassDef(TUrl,1)  //Represents an URL
+   ClassDefOverride(TUrl,1)  //Represents an URL
 };
 
 #endif

--- a/core/base/src/TFolder.cxx
+++ b/core/base/src/TFolder.cxx
@@ -125,14 +125,6 @@ TFolder::TFolder(const char *name, const char *title) : TNamed(name,title)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor.
-
-TFolder::TFolder(const TFolder &folder) : TNamed(folder),fFolders(nullptr),fIsOwner(kFALSE)
-{
-   ((TFolder&)folder).Copy(*this);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Folder destructor. Remove all objects from its lists and delete
 /// all its sub folders.
 

--- a/core/cont/inc/TArrayC.h
+++ b/core/cont/inc/TArrayC.h
@@ -42,16 +42,16 @@ public:
    void          Copy(TArrayC &array) const {array.Set(fN,fArray);}
    const Char_t *GetArray() const { return fArray; }
    Char_t       *GetArray() { return fArray; }
-   Double_t      GetAt(Int_t i) const { return At(i); }
+   Double_t      GetAt(Int_t i) const override { return At(i); }
    Stat_t        GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void          Reset(Char_t val=0)  {memset(fArray,val,fN*sizeof(Char_t));}
-   void          Set(Int_t n);
+   void          Set(Int_t n) override;
    void          Set(Int_t n, const Char_t *array);
-   void          SetAt(Double_t v, Int_t i) { AddAt((Char_t)v, i); }
+   void          SetAt(Double_t v, Int_t i) override { AddAt((Char_t)v, i); }
    Char_t       &operator[](Int_t i);
    Char_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayC,1)  //Array of chars
+   ClassDefOverride(TArrayC,1)  //Array of chars
 };
 
 

--- a/core/cont/inc/TArrayD.h
+++ b/core/cont/inc/TArrayD.h
@@ -42,17 +42,17 @@ public:
    void            Copy(TArrayD &array) const {array.Set(fN,fArray);}
    const Double_t *GetArray() const { return fArray; }
    Double_t       *GetArray() { return fArray; }
-   Double_t        GetAt(Int_t i) const { return At(i); }
+   Double_t        GetAt(Int_t i) const override { return At(i); }
    Stat_t          GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void            Reset()             {memset(fArray, 0, fN*sizeof(Double_t));}
    void            Reset(Double_t val) {for (Int_t i=0;i<fN;i++) fArray[i] = val;}
-   void            Set(Int_t n);
+   void            Set(Int_t n) override;
    void            Set(Int_t n, const Double_t *array);
-   void            SetAt(Double_t v, Int_t i) { AddAt(v, i); }
+   void            SetAt(Double_t v, Int_t i) override { AddAt(v, i); }
    Double_t       &operator[](Int_t i);
    Double_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayD,1)  //Array of doubles
+   ClassDefOverride(TArrayD,1)  //Array of doubles
 };
 
 

--- a/core/cont/inc/TArrayF.h
+++ b/core/cont/inc/TArrayF.h
@@ -42,17 +42,17 @@ public:
    void           Copy(TArrayF &array) const {array.Set(fN,fArray);}
    const Float_t *GetArray() const { return fArray; }
    Float_t       *GetArray() { return fArray; }
-   Double_t       GetAt(Int_t i) const { return At(i); }
+   Double_t       GetAt(Int_t i) const override { return At(i); }
    Stat_t         GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void           Reset()             {memset(fArray,  0, fN*sizeof(Float_t));}
    void           Reset(Float_t val)  {for (Int_t i=0;i<fN;i++) fArray[i] = val;}
-   void           Set(Int_t n);
+   void           Set(Int_t n) override;
    void           Set(Int_t n, const Float_t *array);
-   void           SetAt(Double_t v, Int_t i) { AddAt((Float_t)v, i); }
+   void           SetAt(Double_t v, Int_t i) override { AddAt((Float_t)v, i); }
    Float_t       &operator[](Int_t i);
    Float_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayF,1)  //Array of floats
+   ClassDefOverride(TArrayF,1)  //Array of floats
 };
 
 #if defined R__TEMPLATE_OVERLOAD_BUG

--- a/core/cont/inc/TArrayI.h
+++ b/core/cont/inc/TArrayI.h
@@ -42,17 +42,17 @@ public:
    void         Copy(TArrayI &array) const {array.Set(fN,fArray);}
    const Int_t *GetArray() const { return fArray; }
    Int_t       *GetArray() { return fArray; }
-   Double_t     GetAt(Int_t i) const { return At(i); }
+   Double_t     GetAt(Int_t i) const override { return At(i); }
    Stat_t       GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void         Reset()           {memset(fArray, 0, fN*sizeof(Int_t));}
    void         Reset(Int_t val)  {for (Int_t i=0;i<fN;i++) fArray[i] = val;}
-   void         Set(Int_t n);
+   void         Set(Int_t n) override;
    void         Set(Int_t n, const Int_t *array);
-   void         SetAt(Double_t v, Int_t i) { AddAt((Int_t)v, i); }
+   void         SetAt(Double_t v, Int_t i) override { AddAt((Int_t)v, i); }
    Int_t       &operator[](Int_t i);
    Int_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayI,1)  //Array of ints
+   ClassDefOverride(TArrayI,1)  //Array of ints
 };
 
 

--- a/core/cont/inc/TArrayL.h
+++ b/core/cont/inc/TArrayL.h
@@ -42,17 +42,17 @@ public:
    void          Copy(TArrayL &array) const {array.Set(fN,fArray);}
    const Long_t *GetArray() const { return fArray; }
    Long_t       *GetArray() { return fArray; }
-   Double_t      GetAt(Int_t i) const { return At(i); }
+   Double_t      GetAt(Int_t i) const override { return At(i); }
    Stat_t        GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void          Reset()           {memset(fArray,  0, fN*sizeof(Long_t));}
    void          Reset(Long_t val) {for (Int_t i=0;i<fN;i++) fArray[i] = val;}
-   void          Set(Int_t n);
+   void          Set(Int_t n) override;
    void          Set(Int_t n, const Long_t *array);
-   void          SetAt(Double_t v, Int_t i) { AddAt((Long_t)v, i); }
+   void          SetAt(Double_t v, Int_t i) override { AddAt((Long_t)v, i); }
    Long_t       &operator[](Int_t i);
    Long_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayL,1)  //Array of longs
+   ClassDefOverride(TArrayL,1)  //Array of longs
 };
 
 

--- a/core/cont/inc/TArrayL64.h
+++ b/core/cont/inc/TArrayL64.h
@@ -42,17 +42,17 @@ public:
    void            Copy(TArrayL64 &array) const {array.Set(fN,fArray);}
    const Long64_t *GetArray() const { return fArray; }
    Long64_t       *GetArray() { return fArray; }
-   Double_t        GetAt(Int_t i) const { return At(i); }
+   Double_t        GetAt(Int_t i) const override { return At(i); }
    Stat_t          GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void            Reset()           {memset(fArray,  0, fN*sizeof(Long64_t));}
    void            Reset(Long64_t val) {for (Int_t i=0;i<fN;i++) fArray[i] = val;}
-   void            Set(Int_t n);
+   void            Set(Int_t n) override;
    void            Set(Int_t n, const Long64_t *array);
-   void            SetAt(Double_t v, Int_t i) { AddAt((Long64_t)v, i); }
+   void            SetAt(Double_t v, Int_t i) override { AddAt((Long64_t)v, i); }
    Long64_t       &operator[](Int_t i);
    Long64_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayL64,1)  //Array of long64s
+   ClassDefOverride(TArrayL64,1)  //Array of long64s
 };
 
 

--- a/core/cont/inc/TArrayS.h
+++ b/core/cont/inc/TArrayS.h
@@ -42,17 +42,17 @@ public:
    void           Copy(TArrayS &array) const {array.Set(fN,fArray);}
    const Short_t *GetArray() const { return fArray; }
    Short_t       *GetArray() { return fArray; }
-   Double_t       GetAt(Int_t i) const { return At(i); }
+   Double_t       GetAt(Int_t i) const override { return At(i); }
    Stat_t         GetSum() const {Stat_t sum=0; for (Int_t i=0;i<fN;i++) sum+=fArray[i]; return sum;}
    void           Reset()             {memset(fArray, 0,fN*sizeof(Short_t));}
    void           Reset(Short_t val)  {for (Int_t i=0;i<fN;i++) fArray[i] = val;}
-   void           Set(Int_t n);
+   void           Set(Int_t n) override;
    void           Set(Int_t n, const Short_t *array);
-   void           SetAt(Double_t v, Int_t i) { AddAt((Short_t)v, i); }
+   void           SetAt(Double_t v, Int_t i) override { AddAt((Short_t)v, i); }
    Short_t       &operator[](Int_t i);
    Short_t        operator[](Int_t i) const;
 
-   ClassDef(TArrayS,1)  //Array of shorts
+   ClassDefOverride(TArrayS,1)  //Array of shorts
 };
 
 #if defined R__TEMPLATE_OVERLOAD_BUG

--- a/core/cont/inc/TBits.h
+++ b/core/cont/inc/TBits.h
@@ -124,7 +124,7 @@ public:
    void   Get(ULong64_t *array) const { Get((Long64_t*)array); }
 
    //----- Utilities
-   void    Clear(Option_t *option="");
+   void    Clear(Option_t *option="") override;
    void    Compact();               // Reduce the space used.
    UInt_t  CountBits(UInt_t startBit=0)     const ;  // return number of bits set to 1
    UInt_t  FirstNullBit(UInt_t startBit=0)  const;
@@ -137,11 +137,11 @@ public:
    Bool_t  operator==(const TBits &other) const;
    Bool_t  operator!=(const TBits &other) const { return !(*this==other); }
 
-   void    Paint(Option_t *option="");        // to visualize the bits array as an histogram, etc
-   void    Print(Option_t *option="") const;  // to show the list of active bits
+   void    Paint(Option_t *option="") override;        // to visualize the bits array as an histogram, etc
+   void    Print(Option_t *option="") const override;  // to show the list of active bits
    void    Output(std::ostream &) const;
 
-   ClassDef(TBits,1)        // Bit container
+   ClassDefOverride(TBits,1)        // Bit container
 };
 
 

--- a/core/cont/inc/TBtree.h
+++ b/core/cont/inc/TBtree.h
@@ -70,26 +70,26 @@ public:
 
    TBtree(Int_t ordern = 3);  //create a TBtree of order n
    virtual     ~TBtree();
-   void        Clear(Option_t *option="");
-   void        Delete(Option_t *option="");
-   TObject    *FindObject(const char *name) const;
-   TObject    *FindObject(const TObject *obj) const;
-   TObject   **GetObjectRef(const TObject *) const { return 0; }
-   TIterator  *MakeIterator(Bool_t dir = kIterForward) const;
+   void        Clear(Option_t *option="") override;
+   void        Delete(Option_t *option="") override;
+   TObject    *FindObject(const char *name) const override;
+   TObject    *FindObject(const TObject *obj) const override;
+   TObject   **GetObjectRef(const TObject *) const override { return nullptr; }
+   TIterator  *MakeIterator(Bool_t dir = kIterForward) const override;
 
-   void        Add(TObject *obj);
-   void        AddFirst(TObject *obj) { Add(obj); }
-   void        AddLast(TObject *obj) { Add(obj); }
-   void        AddAt(TObject *obj, Int_t) { Add(obj); }
-   void        AddAfter(const TObject *, TObject *obj) { Add(obj); }
-   void        AddBefore(const TObject *, TObject *obj) { Add(obj); }
-   TObject    *Remove(TObject *obj);
+   void        Add(TObject *obj) override;
+   void        AddFirst(TObject *obj) override { Add(obj); }
+   void        AddLast(TObject *obj) override { Add(obj); }
+   void        AddAt(TObject *obj, Int_t) override { Add(obj); }
+   void        AddAfter(const TObject *, TObject *obj) override { Add(obj); }
+   void        AddBefore(const TObject *, TObject *obj) override { Add(obj); }
+   TObject    *Remove(TObject *obj) override;
 
-   TObject    *At(Int_t idx) const;
-   TObject    *Before(const TObject *obj) const;
-   TObject    *After(const TObject *obj) const;
-   TObject    *First() const;
-   TObject    *Last() const;
+   TObject    *At(Int_t idx) const override;
+   TObject    *Before(const TObject *obj) const override;
+   TObject    *After(const TObject *obj) const override;
+   TObject    *First() const override;
+   TObject    *Last() const override;
 
    //void PrintOn(std::ostream &os) const;
 
@@ -97,7 +97,7 @@ public:
    TObject    *operator[](Int_t i) const;
    Int_t       Rank(const TObject *obj) const;
 
-   ClassDef(TBtree,0)  //A B-tree
+   ClassDefOverride(TBtree,0)  //A B-tree
 };
 
 

--- a/core/cont/inc/TClassTable.h
+++ b/core/cont/inc/TClassTable.h
@@ -84,12 +84,12 @@ public:
    static TProtoClass  *GetProtoNorm(const char *cname);
    static void          Init();
    static char         *Next();
-   void                 Print(Option_t *option="") const;
+   void                 Print(Option_t *option="") const override;
    static void          PrintTable();
    static void          Remove(const char *cname);
    static void          Terminate();
 
-   ClassDef(TClassTable,0)  //Table of known classes
+   ClassDefOverride(TClassTable,0)  //Table of known classes
 };
 
 R__EXTERN TClassTable *gClassTable;

--- a/core/cont/inc/TClonesArray.h
+++ b/core/cont/inc/TClonesArray.h
@@ -44,22 +44,22 @@ public:
    TClonesArray(const TClonesArray& tc);
    virtual         ~TClonesArray();
    TClonesArray& operator=(const TClonesArray& tc);
-   virtual void     Compress();
-   virtual void     Clear(Option_t *option="");
-   virtual void     Delete(Option_t *option="");
-   virtual void     Expand(Int_t newSize);
+   void             Compress() override;
+   void             Clear(Option_t *option="") override;
+   void             Delete(Option_t *option="") override;
+   void             Expand(Int_t newSize) override;
    virtual void     ExpandCreate(Int_t n);
    virtual void     ExpandCreateFast(Int_t n);
    TClass          *GetClass() const { return fClass; }
-   virtual void     SetOwner(Bool_t enable = kTRUE);
+   void             SetOwner(Bool_t enable = kTRUE) override;
 
-   void             AddFirst(TObject *) { MayNotUse("AddFirst"); }
-   void             AddLast(TObject *) { MayNotUse("AddLast"); }
-   void             AddAt(TObject *, Int_t) { MayNotUse("AddAt"); }
-   void             AddAtAndExpand(TObject *, Int_t) { MayNotUse("AddAtAndExpand"); }
-   Int_t            AddAtFree(TObject *) { MayNotUse("AddAtFree"); return 0; }
-   void             AddAfter(const TObject *, TObject *) { MayNotUse("AddAfter"); }
-   void             AddBefore(const TObject *, TObject *) { MayNotUse("AddBefore"); }
+   void             AddFirst(TObject *) override { MayNotUse("AddFirst"); }
+   void             AddLast(TObject *) override { MayNotUse("AddLast"); }
+   void             AddAt(TObject *, Int_t) override { MayNotUse("AddAt"); }
+   void             AddAtAndExpand(TObject *, Int_t) override { MayNotUse("AddAtAndExpand"); }
+   Int_t            AddAtFree(TObject *) override { MayNotUse("AddAtFree"); return 0; }
+   void             AddAfter(const TObject *, TObject *) override { MayNotUse("AddAfter"); }
+   void             AddBefore(const TObject *, TObject *) override { MayNotUse("AddBefore"); }
    void             BypassStreamer(Bool_t bypass=kTRUE);
    Bool_t           CanBypassStreamer() const { return TestBit(kBypassStreamer); }
    TObject         *ConstructedAt(Int_t idx);
@@ -70,17 +70,17 @@ public:
    void             AbsorbObjects(TClonesArray *tc);
    void             AbsorbObjects(TClonesArray *tc, Int_t idx1, Int_t idx2);
    void             MultiSort(Int_t nTCs, TClonesArray** tcs, Int_t upto = kMaxInt);
-   virtual TObject *RemoveAt(Int_t idx);
-   virtual TObject *Remove(TObject *obj);
-   virtual void     RemoveRange(Int_t idx1, Int_t idx2);
-   virtual void     Sort(Int_t upto = kMaxInt);
+   TObject         *RemoveAt(Int_t idx) override;
+   TObject         *Remove(TObject *obj) override;
+   void             RemoveRange(Int_t idx1, Int_t idx2) override;
+   void             Sort(Int_t upto = kMaxInt) override;
 
    TObject         *New(Int_t idx);
    TObject         *AddrAt(Int_t idx);
-   TObject         *&operator[](Int_t idx);
-   TObject         *operator[](Int_t idx) const;
+   TObject         *&operator[](Int_t idx) override;
+   TObject         *operator[](Int_t idx) const override;
 
-   ClassDef(TClonesArray,4)  //An array of clone objects
+   ClassDefOverride(TClonesArray,4)  //An array of clone objects
 };
 
 inline TObject *TClonesArray::AddrAt(Int_t idx)

--- a/core/cont/inc/TCollection.h
+++ b/core/cont/inc/TCollection.h
@@ -136,8 +136,8 @@ private:
    static Bool_t        fgEmptyingGarbage;    //used by garbage collector
    static Int_t         fgGarbageStack;       //used by garbage collector
 
-   TCollection(const TCollection &);    //private and not-implemented, collections
-   void operator=(const TCollection &); //are too complex to be automatically copied
+   TCollection(const TCollection &) = delete;    //private and not-implemented, collections
+   void operator=(const TCollection &) = delete; //are too complex to be automatically copied
 
 protected:
    enum EStatusBits {
@@ -163,42 +163,42 @@ public:
    void               AddVector(TObject *obj1, ...);
    virtual void       AddAll(const TCollection *col);
    Bool_t             AssertClass(TClass *cl) const;
-   void               Browse(TBrowser *b);
+   void               Browse(TBrowser *b) override;
    Int_t              Capacity() const { return fSize; }
-   virtual void       Clear(Option_t *option="") = 0;
-   virtual TObject   *Clone(const char *newname="") const;
-   Int_t              Compare(const TObject *obj) const;
-   Bool_t             Contains(const char *name) const { return FindObject(name) != 0; }
-   Bool_t             Contains(const TObject *obj) const { return FindObject(obj) != 0; }
-   virtual void       Delete(Option_t *option="") = 0;
-   virtual void       Draw(Option_t *option="");
-   virtual void       Dump() const ;
-   virtual TObject   *FindObject(const char *name) const;
+   void               Clear(Option_t *option="") override = 0;
+   TObject           *Clone(const char *newname="") const override;
+   Int_t              Compare(const TObject *obj) const override;
+   Bool_t             Contains(const char *name) const { return FindObject(name) != nullptr; }
+   Bool_t             Contains(const TObject *obj) const { return FindObject(obj) != nullptr; }
+   void               Delete(Option_t *option="") override = 0;
+   void               Draw(Option_t *option="") override;
+   void               Dump() const override;
+   TObject           *FindObject(const char *name) const override;
    TObject           *operator()(const char *name) const;
-   virtual TObject   *FindObject(const TObject *obj) const;
+   TObject           *FindObject(const TObject *obj) const override;
    virtual Int_t      GetEntries() const { return GetSize(); }
-   virtual const char *GetName() const;
+   const char        *GetName() const override;
    virtual TObject  **GetObjectRef(const TObject *obj) const = 0;
    /// Return the *capacity* of the collection, i.e. the current total amount of space that has been allocated so far.
    /// Same as `Capacity`. Use `GetEntries` to get the number of elements currently in the collection.
    virtual Int_t      GetSize() const { return fSize; }
    virtual Int_t      GrowBy(Int_t delta) const;
-   ULong_t            Hash() const { return fName.Hash(); }
+   ULong_t            Hash() const override { return fName.Hash(); }
    Bool_t             IsArgNull(const char *where, const TObject *obj) const;
    virtual Bool_t     IsEmpty() const { return GetSize() <= 0; }
-   virtual Bool_t     IsFolder() const { return kTRUE; }
+   Bool_t             IsFolder() const override { return kTRUE; }
    Bool_t             IsOwner() const { return TestBit(kIsOwner); }
-   Bool_t             IsSortable() const { return kTRUE; }
-   virtual void       ls(Option_t *option="") const ;
-   virtual Bool_t     Notify();
+   Bool_t             IsSortable() const override { return kTRUE; }
+   void               ls(Option_t *option="") const override;
+   Bool_t             Notify() override;
    virtual TIterator *MakeIterator(Bool_t dir = kIterForward) const = 0;
    virtual TIterator *MakeReverseIterator() const { return MakeIterator(kIterBackward); }
-   virtual void       Paint(Option_t *option="");
-   virtual void       Print(Option_t *option="") const;
+   void               Paint(Option_t *option="") override;
+   void               Print(Option_t *option="") const override;
    virtual void       Print(Option_t *option, Int_t recurse) const;
    virtual void       Print(Option_t *option, const char* wildcard, Int_t recurse=1) const;
    virtual void       Print(Option_t *option, TPRegexp& regexp, Int_t recurse=1) const;
-   virtual void       RecursiveRemove(TObject *obj);
+   void               RecursiveRemove(TObject *obj) override;
    virtual TObject   *Remove(TObject *obj) = 0;
    virtual void       RemoveAll(TCollection *col);
    void               RemoveAll() { Clear(); }
@@ -206,8 +206,8 @@ public:
    void               SetName(const char *name) { fName = name; }
    virtual void       SetOwner(Bool_t enable = kTRUE);
    virtual bool       UseRWLock(Bool_t enable = true);
-   virtual Int_t      Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t      Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+   Int_t              Write(const char *name = nullptr, Int_t option = 0, Int_t bufsize = 0) override;
+   Int_t              Write(const char *name = nullptr, Int_t option = 0, Int_t bufsize = 0) const override;
 
    R__ALWAYS_INLINE Bool_t IsUsingRWLock() const { return TestBit(TCollection::kUseRWLock); }
 
@@ -219,7 +219,7 @@ public:
    TIter begin() const;
    TIter end() const;
 
-   ClassDef(TCollection,3)  //Collection abstract base class
+   ClassDefOverride(TCollection,3)  //Collection abstract base class
 };
 
 

--- a/core/cont/inc/TExMap.h
+++ b/core/cont/inc/TExMap.h
@@ -65,7 +65,7 @@ public:
    void      Add(ULong64_t hash, Long64_t key, Long64_t value);
    void      Add(Long64_t key, Long64_t value) { Add(key, key, value); }
    void      AddAt(UInt_t slot, ULong64_t hash, Long64_t key, Long64_t value);
-   void      Delete(Option_t *opt = "");
+   void      Delete(Option_t *opt = "") override;
    Int_t     Capacity() const { return fSize; }
    void      Expand(Int_t newsize);
    Int_t     GetSize() const { return fTally; }
@@ -78,7 +78,7 @@ public:
    Long64_t &operator()(ULong64_t hash, Long64_t key);
    Long64_t &operator()(Long64_t key) { return operator()(key, key); }
 
-   ClassDef(TExMap,3)  //Map with external hash
+   ClassDefOverride(TExMap,3)  //Map with external hash
 };
 
 

--- a/core/cont/inc/THashList.h
+++ b/core/cont/inc/THashList.h
@@ -45,31 +45,31 @@ public:
    THashList(TObject *parent, Int_t capacity=TCollection::kInitHashTableCapacity, Int_t rehash=0);
    virtual    ~THashList();
    Float_t    AverageCollisions() const;
-   void       Clear(Option_t *option="");
-   void       Delete(Option_t *option="");
+   void       Clear(Option_t *option="") override;
+   void       Delete(Option_t *option="") override;
 
-   TObject   *FindObject(const char *name) const;
-   TObject   *FindObject(const TObject *obj) const;
+   TObject   *FindObject(const char *name) const override;
+   TObject   *FindObject(const TObject *obj) const override;
 
    const TList *GetListForObject(const char *name) const;
    const TList *GetListForObject(const TObject *obj) const;
 
-   void       AddFirst(TObject *obj);
-   void       AddFirst(TObject *obj, Option_t *opt);
-   void       AddLast(TObject *obj);
-   void       AddLast(TObject *obj, Option_t *opt);
-   void       AddAt(TObject *obj, Int_t idx);
-   void       AddAfter(const TObject *after, TObject *obj);
-   void       AddAfter(TObjLink *after, TObject *obj);
-   void       AddBefore(const TObject *before, TObject *obj);
-   void       AddBefore(TObjLink *before, TObject *obj);
-   void       RecursiveRemove(TObject *obj);
+   void       AddFirst(TObject *obj) override;
+   void       AddFirst(TObject *obj, Option_t *opt) override;
+   void       AddLast(TObject *obj) override;
+   void       AddLast(TObject *obj, Option_t *opt) override;
+   void       AddAt(TObject *obj, Int_t idx) override;
+   void       AddAfter(const TObject *after, TObject *obj) override;
+   void       AddAfter(TObjLink *after, TObject *obj) override;
+   void       AddBefore(const TObject *before, TObject *obj) override;
+   void       AddBefore(TObjLink *before, TObject *obj) override;
+   void       RecursiveRemove(TObject *obj) override;
    void       Rehash(Int_t newCapacity);
-   TObject   *Remove(TObject *obj);
-   TObject   *Remove(TObjLink *lnk);
-   bool       UseRWLock(Bool_t enable = true);
+   TObject   *Remove(TObject *obj) override;
+   TObject   *Remove(TObjLink *lnk) override;
+   bool       UseRWLock(Bool_t enable = true) override;
 
-   ClassDef(THashList,0)  //Doubly linked list with hashtable for lookup
+   ClassDefOverride(THashList,0)  //Doubly linked list with hashtable for lookup
 };
 
 #endif

--- a/core/cont/inc/THashTable.h
+++ b/core/cont/inc/THashTable.h
@@ -55,31 +55,31 @@ private:
 public:
    THashTable(Int_t capacity = TCollection::kInitHashTableCapacity, Int_t rehash = 0);
    virtual       ~THashTable();
-   void          Add(TObject *obj);
+   void          Add(TObject *obj) override;
    void          AddBefore(const TObject *before, TObject *obj);
-   virtual void  AddAll(const TCollection *col);
+   void          AddAll(const TCollection *col) override;
    Float_t       AverageCollisions() const;
-   void          Clear(Option_t *option="");
+   void          Clear(Option_t *option="") override;
    Int_t         Collisions(const char *name) const;
    Int_t         Collisions(TObject *obj) const;
-   void          Delete(Option_t *option="");
+   void          Delete(Option_t *option="") override;
    Bool_t        Empty() const { return fEntries == 0; }
-   TObject      *FindObject(const char *name) const;
-   TObject      *FindObject(const TObject *obj) const;
+   TObject      *FindObject(const char *name) const override;
+   TObject      *FindObject(const TObject *obj) const override;
    const TList  *GetListForObject(const char *name) const;
    const TList  *GetListForObject(const TObject *obj) const;
-   TObject     **GetObjectRef(const TObject *obj) const;
+   TObject     **GetObjectRef(const TObject *obj) const override;
    Int_t         GetRehashLevel() const { return fRehashLevel; }
-   Int_t         GetSize() const { return fEntries; }
-   TIterator    *MakeIterator(Bool_t dir = kIterForward) const;
-   void          Print(Option_t *option, Int_t recurse) const;
-   using TCollection::Print;
+   Int_t         GetSize() const override { return fEntries; }
+   TIterator    *MakeIterator(Bool_t dir = kIterForward) const override;
+   using         TCollection::Print;
+   void          Print(Option_t *option, Int_t recurse) const override;
    void          Rehash(Int_t newCapacity, Bool_t checkObjValidity = kTRUE);
-   TObject      *Remove(TObject *obj);
+   TObject      *Remove(TObject *obj) override;
    TObject      *RemoveSlow(TObject *obj);
    void          SetRehashLevel(Int_t rehash) { fRehashLevel = rehash; }
 
-   ClassDef(THashTable,0)  //A hash table
+   ClassDefOverride(THashTable,0)  //A hash table
 };
 
 inline Float_t THashTable::AverageCollisions() const
@@ -126,17 +126,17 @@ public:
    THashTableIter(const THashTable *ht, Bool_t dir = kIterForward);
    THashTableIter(const THashTableIter &iter);
    ~THashTableIter();
-   TIterator      &operator=(const TIterator &rhs);
+   TIterator      &operator=(const TIterator &rhs) override;
    THashTableIter &operator=(const THashTableIter &rhs);
 
-   const TCollection *GetCollection() const { return fTable; }
-   TObject           *Next();
-   void               Reset();
-   Bool_t             operator!=(const TIterator &aIter) const;
+   const TCollection *GetCollection() const override { return fTable; }
+   TObject           *Next() override;
+   void               Reset() override;
+   Bool_t             operator!=(const TIterator &aIter) const override;
    Bool_t             operator!=(const THashTableIter &aIter) const;
-   TObject           *operator*() const;
+   TObject           *operator*() const override;
 
-   ClassDef(THashTableIter,0)  //Hash table iterator
+   ClassDefOverride(THashTableIter,0)  //Hash table iterator
 };
 
 #endif

--- a/core/cont/inc/TList.h
+++ b/core/cont/inc/TList.h
@@ -78,42 +78,42 @@ public:
    TList() : fAscending(kTRUE) { }
    TList(TObject *) : fAscending(kTRUE) { } // for backward compatibility, don't use
    virtual           ~TList();
-   virtual void      Clear(Option_t *option="");
-   virtual void      Delete(Option_t *option="");
-   virtual TObject  *FindObject(const char *name) const;
-   virtual TObject  *FindObject(const TObject *obj) const;
-   virtual TIterator *MakeIterator(Bool_t dir = kIterForward) const;
+   void              Clear(Option_t *option="") override;
+   void              Delete(Option_t *option="") override;
+   TObject          *FindObject(const char *name) const override;
+   TObject          *FindObject(const TObject *obj) const override;
+   TIterator        *MakeIterator(Bool_t dir = kIterForward) const override;
 
-   virtual void      Add(TObject *obj) { AddLast(obj); }
+   void              Add(TObject *obj) override { AddLast(obj); }
    virtual void      Add(TObject *obj, Option_t *opt) { AddLast(obj, opt); }
-   virtual void      AddFirst(TObject *obj);
+   void              AddFirst(TObject *obj) override;
    virtual void      AddFirst(TObject *obj, Option_t *opt);
-   virtual void      AddLast(TObject *obj);
+   void              AddLast(TObject *obj) override;
    virtual void      AddLast(TObject *obj, Option_t *opt);
-   virtual void      AddAt(TObject *obj, Int_t idx);
-   virtual void      AddAfter(const TObject *after, TObject *obj);
+   void              AddAt(TObject *obj, Int_t idx) override;
+   void              AddAfter(const TObject *after, TObject *obj) override;
    virtual void      AddAfter(TObjLink *after, TObject *obj);
-   virtual void      AddBefore(const TObject *before, TObject *obj);
+   void              AddBefore(const TObject *before, TObject *obj) override;
    virtual void      AddBefore(TObjLink *before, TObject *obj);
-   virtual TObject  *Remove(TObject *obj);
+   TObject  *Remove(TObject *obj) override;
    virtual TObject  *Remove(TObjLink *lnk);
-           TObject  *Remove(const TObjLinkPtr_t &lnk) { return Remove(lnk.get()); }
-   virtual void      RemoveLast();
-   virtual void      RecursiveRemove(TObject *obj);
+   TObject          *Remove(const TObjLinkPtr_t &lnk) { return Remove(lnk.get()); }
+   void              RemoveLast() override;
+   void              RecursiveRemove(TObject *obj) override;
 
-   virtual TObject  *At(Int_t idx) const;
-   virtual TObject  *After(const TObject *obj) const;
-   virtual TObject  *Before(const TObject *obj) const;
-   virtual TObject  *First() const;
+   TObject          *At(Int_t idx) const override;
+   TObject          *After(const TObject *obj) const override;
+   TObject          *Before(const TObject *obj) const override;
+   TObject          *First() const override;
    virtual TObjLink *FirstLink() const { return fFirst.get(); }
-   virtual TObject **GetObjectRef(const TObject *obj) const;
-   virtual TObject  *Last() const;
+   TObject         **GetObjectRef(const TObject *obj) const override;
+   TObject          *Last() const override;
    virtual TObjLink *LastLink() const { return fLast.get(); }
 
    virtual void      Sort(Bool_t order = kSortAscending);
    Bool_t            IsAscending() { return fAscending; }
 
-   ClassDef(TList,5)  //Doubly linked list
+   ClassDefOverride(TList,5)  //Doubly linked list
 };
 
 
@@ -215,19 +215,19 @@ public:
    TListIter(const TList *l, Bool_t dir = kIterForward);
    TListIter(const TListIter &iter);
    ~TListIter() { }
-   TIterator &operator=(const TIterator &rhs);
+   TIterator &operator=(const TIterator &rhs) override;
    TListIter &operator=(const TListIter &rhs);
 
-   const TCollection *GetCollection() const { return fList; }
-   Option_t          *GetOption() const;
+   const TCollection *GetCollection() const override { return fList; }
+   Option_t          *GetOption() const override;
    void               SetOption(Option_t *option);
-   TObject           *Next();
-   void               Reset();
-   Bool_t             operator!=(const TIterator &aIter) const;
+   TObject           *Next() override;
+   void               Reset() override;
+   Bool_t             operator!=(const TIterator &aIter) const override;
    Bool_t             operator!=(const TListIter &aIter) const;
-   TObject           *operator*() const { return (fCurCursor ? fCurCursor->GetObject() : nullptr); }
+   TObject           *operator*() const override { return (fCurCursor ? fCurCursor->GetObject() : nullptr); }
 
-   ClassDef(TListIter,0)  //Linked list iterator
+   ClassDefOverride(TListIter,0)  //Linked list iterator
 };
 
 inline bool operator==(TObjOptLink *l, const std::shared_ptr<TObjLink> &r) {

--- a/core/cont/inc/TMap.h
+++ b/core/cont/inc/TMap.h
@@ -50,44 +50,44 @@ private:
 protected:
    enum EStatusBits { kIsOwnerValue = BIT(15) };
 
-   virtual void        PrintCollectionEntry(TObject* entry, Option_t* option, Int_t recurse) const;
+   void        PrintCollectionEntry(TObject* entry, Option_t* option, Int_t recurse) const override;
 
 public:
    typedef TMapIter Iterator_t;
 
    TMap(Int_t capacity = TCollection::kInitHashTableCapacity, Int_t rehash = 0);
    virtual           ~TMap();
-   void              Add(TObject *obj);
+   void              Add(TObject *obj) override;
    void              Add(TObject *key, TObject *value);
    Float_t           AverageCollisions() const;
    Int_t             Capacity() const;
-   void              Clear(Option_t *option="");
+   void              Clear(Option_t *option="") override;
    Int_t             Collisions(const char *keyname) const;
    Int_t             Collisions(TObject *key) const;
-   void              Delete(Option_t *option="");
+   void              Delete(Option_t *option="") override;
    void              DeleteKeys() { Delete(); }
    void              DeleteValues();
    void              DeleteAll();
    Bool_t            DeleteEntry(TObject *key);
-   TObject          *FindObject(const char *keyname) const;
-   TObject          *FindObject(const TObject *key) const;
-   TObject         **GetObjectRef(const TObject *obj) const { return fTable->GetObjectRef(obj); }
+   TObject          *FindObject(const char *keyname) const override;
+   TObject          *FindObject(const TObject *key) const override;
+   TObject         **GetObjectRef(const TObject *obj) const override { return fTable->GetObjectRef(obj); }
    const THashTable *GetTable() const { return fTable; }
    TObject          *GetValue(const char *keyname) const;
    TObject          *GetValue(const TObject *key) const;
    Bool_t            IsOwnerValue() const { return TestBit(kIsOwnerValue); }
    TObject          *operator()(const char *keyname) const { return GetValue(keyname); }
    TObject          *operator()(const TObject *key) const { return GetValue(key); }
-   TIterator        *MakeIterator(Bool_t dir = kIterForward) const;
+   TIterator        *MakeIterator(Bool_t dir = kIterForward) const override;
    void              Rehash(Int_t newCapacity, Bool_t checkObjValidity = kTRUE);
-   TObject          *Remove(TObject *key);
+   TObject          *Remove(TObject *key) override;
    TPair            *RemoveEntry(TObject *key);
    virtual void      SetOwnerValue(Bool_t enable = kTRUE);
    virtual void      SetOwnerKeyValue(Bool_t ownkeys = kTRUE, Bool_t ownvals = kTRUE);
-   virtual Int_t     Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t     Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+   Int_t             Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) override;
+   Int_t             Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) const override;
 
-   ClassDef(TMap,3)  //A (key,value) map
+   ClassDefOverride(TMap,3)  //A (key,value) map
 };
 
 
@@ -111,17 +111,17 @@ public:
    TPair(TObject *key, TObject *value) : fKey(key), fValue(value) { }
    TPair(const TPair &a) : TObject(), fKey(a.fKey), fValue(a.fValue) { }
    virtual               ~TPair();
-   Bool_t                IsFolder() const { return kTRUE;}
-   virtual void          Browse(TBrowser *b);
-   const char           *GetName() const { return fKey->GetName(); }
-   const char           *GetTitle() const { return fKey->GetTitle(); }
-   ULong_t               Hash() const { return fKey->Hash(); }
-   Bool_t                IsEqual(const TObject *obj) const { return fKey->IsEqual(obj); }
+   Bool_t                IsFolder() const override { return kTRUE;}
+   void                  Browse(TBrowser *b) override;
+   const char           *GetName() const override { return fKey->GetName(); }
+   const char           *GetTitle() const override { return fKey->GetTitle(); }
+   ULong_t               Hash() const override { return fKey->Hash(); }
+   Bool_t                IsEqual(const TObject *obj) const override { return fKey->IsEqual(obj); }
    TObject              *Key() const { return fKey; }
    TObject              *Value() const { return fValue; }
    void                  SetValue(TObject *val) { fValue = val; }
 
-   ClassDef(TPair,0); // Pair TObject*, TObject*
+   ClassDefOverride(TPair,0); // Pair TObject*, TObject*
 };
 
 typedef TPair   TAssoc;     // for backward compatibility
@@ -157,17 +157,17 @@ public:
    TMapIter(const TMap *map, Bool_t dir = kIterForward);
    TMapIter(const TMapIter &iter);
    ~TMapIter();
-   TIterator &operator=(const TIterator &rhs);
+   TIterator &operator=(const TIterator &rhs) override;
    TMapIter  &operator=(const TMapIter &rhs);
 
-   const TCollection *GetCollection() const { return fMap; }
-   TObject           *Next();
-   void               Reset();
-   Bool_t             operator!=(const TIterator &aIter) const;
+   const TCollection *GetCollection() const override { return fMap; }
+   TObject           *Next() override;
+   void               Reset() override;
+   Bool_t             operator!=(const TIterator &aIter) const override;
    Bool_t             operator!=(const TMapIter &aIter) const;
-   TObject           *operator*() const;
+   TObject           *operator*() const override;
 
-   ClassDef(TMapIter,0)  //Map iterator
+   ClassDefOverride(TMapIter,0)  //Map iterator
 };
 
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40600

--- a/core/cont/inc/TObjArray.h
+++ b/core/cont/inc/TObjArray.h
@@ -86,12 +86,12 @@ public:
    virtual void     RemoveRange(Int_t idx1, Int_t idx2);
    virtual void     RecursiveRemove(TObject *obj);
 
-   TObject         *At(Int_t idx) const;
+   TObject         *At(Int_t idx) const override;
    TObject         *UncheckedAt(Int_t i) const { return fCont[i-fLowerBound]; }
-   TObject         *Before(const TObject *obj) const;
-   TObject         *After(const TObject *obj) const;
-   TObject         *First() const;
-   TObject         *Last() const;
+   TObject         *Before(const TObject *obj) const override;
+   TObject         *After(const TObject *obj) const override;
+   TObject         *First() const override;
+   TObject         *Last() const override;
    virtual TObject *&operator[](Int_t i);
    virtual TObject *operator[](Int_t i) const;
    Int_t            LowerBound() const { return fLowerBound; }
@@ -102,7 +102,7 @@ public:
    virtual void     Sort(Int_t upto = kMaxInt);
    virtual Int_t    BinarySearch(TObject *obj, Int_t upto = kMaxInt); // the TObjArray has to be sorted, -1 == not found !!
 
-   ClassDef(TObjArray,3)  //An array of objects
+   ClassDefOverride(TObjArray,3)  //An array of objects
 };
 
 
@@ -137,17 +137,17 @@ public:
    TObjArrayIter(const TObjArray *arr, Bool_t dir = kIterForward);
    TObjArrayIter(const TObjArrayIter &iter);
    ~TObjArrayIter() { }
-   TIterator     &operator=(const TIterator &rhs);
+   TIterator     &operator=(const TIterator &rhs) override;
    TObjArrayIter &operator=(const TObjArrayIter &rhs);
 
-   const TCollection *GetCollection() const { return fArray; }
-   TObject           *Next();
-   void               Reset();
-   Bool_t             operator!=(const TIterator &aIter) const;
+   const TCollection *GetCollection() const override { return fArray; }
+   TObject           *Next() override;
+   void               Reset() override;
+   Bool_t             operator!=(const TIterator &aIter) const override;
    Bool_t             operator!=(const TObjArrayIter &aIter) const;
-   TObject           *operator*() const;
+   TObject           *operator*() const override;
 
-   ClassDef(TObjArrayIter,0)  //Object array iterator
+   ClassDefOverride(TObjArrayIter,0)  //Object array iterator
 };
 
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40600

--- a/core/cont/inc/TObjectTable.h
+++ b/core/cont/inc/TObjectTable.h
@@ -54,11 +54,11 @@ public:
 
    void      Add(TObject *obj);
    void     *CheckPtrAndWarn(const char *msg, void *vp);
-   void      Delete(Option_t *opt = "");
+   void      Delete(Option_t *opt = "") override;
    Int_t     GetSize() const { return fSize; }
    Int_t     Instances() const { return fTally; }
    void      InstanceStatistics() const;
-   void      Print(Option_t *option="") const;
+   void      Print(Option_t *option="") const override;
    Bool_t    PtrIsValid(TObject *obj);
    void      Remove(TObject *obj);
    void      RemoveQuietly(TObject *obj);
@@ -68,7 +68,7 @@ public:
 
    static void AddObj(TObject *obj);
 
-   ClassDef(TObjectTable,0)  //Table of active objects
+   ClassDefOverride(TObjectTable,0)  //Table of active objects
 };
 
 

--- a/core/cont/inc/TOrdCollection.h
+++ b/core/cont/inc/TOrdCollection.h
@@ -57,31 +57,31 @@ public:
 
    TOrdCollection(Int_t capacity = kDefaultCapacity);
    ~TOrdCollection();
-   void          Clear(Option_t *option="");
-   void          Delete(Option_t *option="");
-   TObject     **GetObjectRef(const TObject *obj) const;
-   Int_t         IndexOf(const TObject *obj) const;
-   TIterator    *MakeIterator(Bool_t dir = kIterForward) const;
+   void          Clear(Option_t *option="") override;
+   void          Delete(Option_t *option="") override;
+   TObject     **GetObjectRef(const TObject *obj) const override;
+   Int_t         IndexOf(const TObject *obj) const override;
+   TIterator    *MakeIterator(Bool_t dir = kIterForward) const override;
 
-   void          AddFirst(TObject *obj);
-   void          AddLast(TObject *obj);
-   void          AddAt(TObject *obj, Int_t idx);
-   void          AddAfter(const TObject *after, TObject *obj);
-   void          AddBefore(const TObject *before, TObject *obj);
+   void          AddFirst(TObject *obj) override;
+   void          AddLast(TObject *obj) override;
+   void          AddAt(TObject *obj, Int_t idx) override;
+   void          AddAfter(const TObject *after, TObject *obj) override;
+   void          AddBefore(const TObject *before, TObject *obj) override;
    void          PutAt(TObject *obj, Int_t idx);
-   TObject      *RemoveAt(Int_t idx);
-   TObject      *Remove(TObject *obj);
+   TObject      *RemoveAt(Int_t idx) override;
+   TObject      *Remove(TObject *obj) override;
 
-   TObject      *At(Int_t idx) const;
-   TObject      *Before(const TObject *obj) const;
-   TObject      *After(const TObject *obj) const;
-   TObject      *First() const;
-   TObject      *Last() const;
+   TObject      *At(Int_t idx) const override;
+   TObject      *Before(const TObject *obj) const override;
+   TObject      *After(const TObject *obj) const override;
+   TObject      *First() const override;
+   TObject      *Last() const override;
 
    void          Sort();
    Int_t         BinarySearch(TObject *obj);
 
-   ClassDef(TOrdCollection,0)  //An ordered collection
+   ClassDefOverride(TOrdCollection,0)  //An ordered collection
 };
 
 
@@ -110,17 +110,17 @@ public:
    TOrdCollectionIter(const TOrdCollection *col, Bool_t dir = kIterForward);
    TOrdCollectionIter(const TOrdCollectionIter &iter);
    ~TOrdCollectionIter() { }
-   TIterator          &operator=(const TIterator &rhs);
+   TIterator          &operator=(const TIterator &rhs) override;
    TOrdCollectionIter &operator=(const TOrdCollectionIter &rhs);
 
-   const TCollection *GetCollection() const { return fCol; }
-   TObject           *Next();
-   void               Reset();
-   Bool_t             operator!=(const TIterator &aIter) const;
+   const TCollection *GetCollection() const override { return fCol; }
+   TObject           *Next() override;
+   void               Reset() override;
+   Bool_t             operator!=(const TIterator &aIter) const override;
    Bool_t             operator!=(const TOrdCollectionIter &aIter) const;
-   TObject           *operator*() const;
+   TObject           *operator*() const override;
 
-   ClassDef(TOrdCollectionIter,0)  //Ordered collection iterator
+   ClassDefOverride(TOrdCollectionIter,0)  //Ordered collection iterator
 };
 
 

--- a/core/cont/inc/TRefArray.h
+++ b/core/cont/inc/TRefArray.h
@@ -56,15 +56,15 @@ protected:
 public:
    typedef TRefArrayIter Iterator_t;
 
-   TRefArray(TProcessID *pid = 0);
+   TRefArray(TProcessID *pid = nullptr);
    TRefArray(Int_t s, TProcessID *pid);
-   TRefArray(Int_t s, Int_t lowerBound = 0, TProcessID *pid = 0);
+   TRefArray(Int_t s, Int_t lowerBound = 0, TProcessID *pid = nullptr);
    TRefArray(const TRefArray &a);
    TRefArray& operator=(const TRefArray &a);
    virtual          ~TRefArray();
-   virtual void     Clear(Option_t *option="");
+   void             Clear(Option_t *option="") override;
    virtual void     Compress();
-   virtual void     Delete(Option_t *option="");
+   void             Delete(Option_t *option="") override;
    virtual void     Expand(Int_t newSize);   // expand or shrink an array
    Int_t            GetEntries() const;
    Int_t            GetEntriesFast() const {
@@ -77,31 +77,31 @@ public:
    Bool_t           IsEmpty() const { return GetAbsLast() == -1; }
    TIterator       *MakeIterator(Bool_t dir = kIterForward) const;
 
-   void             Add(TObject *obj) { AddLast(obj); }
-   virtual void     AddFirst(TObject *obj);
-   virtual void     AddLast(TObject *obj);
-   virtual void     AddAt(TObject *obj, Int_t idx);
+   void             Add(TObject *obj) override { AddLast(obj); }
+   void             AddFirst(TObject *obj) override;
+   void             AddLast(TObject *obj) override;
+   void             AddAt(TObject *obj, Int_t idx) override;
    virtual void     AddAtAndExpand(TObject *obj, Int_t idx);
    virtual Int_t    AddAtFree(TObject *obj);
-   virtual void     AddAfter(const TObject *after, TObject *obj);
-   virtual void     AddBefore(const TObject *before, TObject *obj);
-   virtual TObject *RemoveAt(Int_t idx);
-   virtual TObject *Remove(TObject *obj);
+   void             AddAfter(const TObject *after, TObject *obj);
+   void             AddBefore(const TObject *before, TObject *obj);
+   TObject         *RemoveAt(Int_t idx) override;
+   TObject         *Remove(TObject *obj) override;
 
-   TObject         *At(Int_t idx) const;
-   TObject         *Before(const TObject *obj) const;
-   TObject         *After(const TObject *obj) const;
-   TObject         *First() const;
-   TObject         *Last() const;
+   TObject         *At(Int_t idx) const override;
+   TObject         *Before(const TObject *obj) const override;
+   TObject         *After(const TObject *obj) const override;
+   TObject         *First() const override;
+   TObject         *Last() const override;
    virtual TObject *operator[](Int_t i) const;
    Int_t            LowerBound() const { return fLowerBound; }
-   Int_t            IndexOf(const TObject *obj) const;
+   Int_t            IndexOf(const TObject *obj) const override;
    void             SetLast(Int_t last);
 
    virtual void     Sort(Int_t upto = kMaxInt);
    virtual Int_t    BinarySearch(TObject *obj, Int_t upto = kMaxInt); // the TRefArray has to be sorted, -1 == not found !!
 
-   ClassDef(TRefArray,1)  //An array of references to TObjects
+   ClassDefOverride(TRefArray,1)  //An array of references to TObjects
 };
 
 
@@ -139,14 +139,14 @@ public:
    TIterator         &operator=(const TIterator &rhs);
    TRefArrayIter     &operator=(const TRefArrayIter &rhs);
 
-   const TCollection *GetCollection() const { return fArray; }
-   TObject           *Next();
-   void               Reset();
-   Bool_t             operator!=(const TIterator &aIter) const;
+   const TCollection *GetCollection() const override { return fArray; }
+   TObject           *Next() override;
+   void               Reset() override;
+   Bool_t             operator!=(const TIterator &aIter) const override;
    Bool_t             operator!=(const TRefArrayIter &aIter) const;
-   TObject           *operator*() const;
+   TObject           *operator*() const override;
 
-   ClassDef(TRefArrayIter,0)  //Object array iterator
+   ClassDefOverride(TRefArrayIter,0)  //Object array iterator
 };
 
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 40600

--- a/core/cont/inc/TRefTable.h
+++ b/core/cont/inc/TRefTable.h
@@ -66,8 +66,8 @@ public:
    TRefTable();
    TRefTable(TObject *owner, Int_t size);
    virtual ~TRefTable();
-   virtual Int_t      Add(Int_t uid, TProcessID* context = 0);
-   virtual void       Clear(Option_t * /*option*/ ="");
+   virtual Int_t      Add(Int_t uid, TProcessID* context = nullptr);
+   void               Clear(Option_t * /*option*/ ="") override;
    virtual Int_t      Expand(Int_t pid, Int_t newsize);
    virtual void       FillBuffer(TBuffer &b);
    static TRefTable  *GetRefTable();
@@ -79,14 +79,14 @@ public:
    TObjArray         *GetParents() const {return fParents;}
    UInt_t             GetUID() const {return fUID;}
    TProcessID        *GetUIDContext() const {return fUIDContext;}
-   virtual Bool_t     Notify();
+   Bool_t             Notify() override;
    virtual void       ReadBuffer(TBuffer &b);
    virtual void       Reset(Option_t * /* option */ ="");
    virtual Int_t      SetParent(const TObject* parent, Int_t branchID);
    static  void       SetRefTable(TRefTable *table);
    virtual void       SetUID(UInt_t uid, TProcessID* context = 0) {fUID=uid; fUIDContext = context;}
 
-   ClassDef(TRefTable,3)  //Table of referenced objects during an I/O operation
+   ClassDefOverride(TRefTable,3)  //Table of referenced objects during an I/O operation
 };
 
 #endif

--- a/core/cont/inc/TSeqCollection.h
+++ b/core/cont/inc/TSeqCollection.h
@@ -35,7 +35,7 @@ protected:
 
 public:
    virtual           ~TSeqCollection() { }
-   virtual void      Add(TObject *obj) { AddLast(obj); }
+   void              Add(TObject *obj) override { AddLast(obj); }
    virtual void      AddFirst(TObject *obj) = 0;
    virtual void      AddLast(TObject *obj) = 0;
    virtual void      AddAt(TObject *obj, Int_t idx) = 0;
@@ -64,7 +64,7 @@ public:
    static inline void QSort(TObject **a, TObject **b, Int_t first, Int_t last) { QSort(a, 1, &b, first, last); }
    static void        QSort(TObject **a, Int_t nBs, TObject ***b, Int_t first, Int_t last);
 
-   ClassDef(TSeqCollection,0)  //Sequenceable collection ABC
+   ClassDefOverride(TSeqCollection,0)  //Sequenceable collection ABC
 };
 
 #endif

--- a/core/cont/inc/TSortedList.h
+++ b/core/cont/inc/TSortedList.h
@@ -30,24 +30,24 @@ class TSortedList : public TList {
 public:
    TSortedList(Bool_t order = kSortAscending) { fAscending = order; }
 
-   void      Add(TObject *obj);
-   void      Add(TObject *obj, Option_t *opt);
+   void      Add(TObject *obj) override;
+   void      Add(TObject *obj, Option_t *opt) override;
 
-   Bool_t    IsSorted() const { return kTRUE; }
+   Bool_t    IsSorted() const override { return kTRUE; }
 
    //---- the following methods are overridden to preserve sorting order
-   void      AddFirst(TObject *obj) { Add(obj); }
-   void      AddFirst(TObject *obj, Option_t *opt) { Add(obj, opt); }
-   void      AddLast(TObject *obj) { Add(obj); }
-   void      AddLast(TObject *obj, Option_t *opt) { Add(obj, opt); }
-   void      AddAt(TObject *obj, Int_t) { Add(obj); }
-   void      AddAfter(const TObject *, TObject *obj) { Add(obj); }
-   void      AddAfter(TObjLink *, TObject *obj) { Add(obj); }
-   void      AddBefore(const TObject *, TObject *obj) { Add(obj); }
-   void      AddBefore(TObjLink *, TObject *obj) { Add(obj); }
-   void      Sort(Bool_t = kSortAscending) { }
+   void      AddFirst(TObject *obj) override { Add(obj); }
+   void      AddFirst(TObject *obj, Option_t *opt) override { Add(obj, opt); }
+   void      AddLast(TObject *obj) override { Add(obj); }
+   void      AddLast(TObject *obj, Option_t *opt) override { Add(obj, opt); }
+   void      AddAt(TObject *obj, Int_t) override { Add(obj); }
+   void      AddAfter(const TObject *, TObject *obj) override { Add(obj); }
+   void      AddAfter(TObjLink *, TObject *obj) override { Add(obj); }
+   void      AddBefore(const TObject *, TObject *obj) override { Add(obj); }
+   void      AddBefore(TObjLink *, TObject *obj) override { Add(obj); }
+   void      Sort(Bool_t = kSortAscending) override { }
 
-   ClassDef(TSortedList,0)  //A sorted list
+   ClassDefOverride(TSortedList,0)  //A sorted list
 };
 
 #endif

--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -381,7 +381,7 @@ public:
    static Int_t       ReadRules(const char *filename);
    static Int_t       ReadRules();
    void               AdoptSchemaRules( ROOT::Detail::TSchemaRuleSet *rules );
-   virtual void       Browse(TBrowser *b);
+   void               Browse(TBrowser *b) override;
    void               BuildRealData(void *pointer=0, Bool_t isTransient = kFALSE);
    void               BuildEmulatedRealData(const char *name, Longptr_t offset, TClass *cl, Bool_t isTransient = kFALSE);
    void               CalculateStreamerOffset() const;
@@ -389,10 +389,10 @@ public:
    Bool_t             CanSplit() const;
    Bool_t             CanIgnoreTObjectStreamer() { return TestBit(kIgnoreTObjectStreamer);}
    Long_t             ClassProperty() const;
-   TObject           *Clone(const char *newname="") const;
+   TObject           *Clone(const char *newname="") const override;
    void               CopyCollectionProxy(const TVirtualCollectionProxy&);
-   void               Draw(Option_t *option="");
-   void               Dump() const { TDictionary::Dump(); }
+   void               Draw(Option_t *option="") override;
+   void               Dump() const override { TDictionary::Dump(); }
    void               Dump(const void *obj, Bool_t noAddr = kFALSE) const;
    char              *EscapeChars(const char *text) const;
    TVirtualStreamerInfo     *FindStreamerInfo(UInt_t checksum, Bool_t isTransient = kFALSE) const;
@@ -503,13 +503,13 @@ public:
    }
    Bool_t             HasDictionary() const;
    static Bool_t      HasDictionarySelection(const char* clname);
-   Bool_t HasLocalHashMember() const;
+   Bool_t             HasLocalHashMember() const;
    void               GetMissingDictionaries(THashTable& result, bool recurse = false);
    void               IgnoreTObjectStreamer(Bool_t ignore=kTRUE);
-   Bool_t             InheritsFrom(const char *cl) const;
-   Bool_t             InheritsFrom(const TClass *cl) const;
+   Bool_t             InheritsFrom(const char *cl) const override;
+   Bool_t             InheritsFrom(const TClass *cl) const override;
    void               InterpretedShowMembers(void* obj, TMemberInspector &insp, Bool_t isTransient);
-   Bool_t             IsFolder() const { return kTRUE; }
+   Bool_t             IsFolder() const override { return kTRUE; }
    Bool_t             IsLoaded() const;
    Bool_t             IsForeign() const;
    Bool_t             IsStartingWithTObject() const;
@@ -517,7 +517,7 @@ public:
    Bool_t             IsVersioned() const { return !( GetClassVersion()<=1 && IsForeign() ); }
    Bool_t             IsTObject() const;
    static TClass     *LoadClass(const char *requestedname, Bool_t silent);
-   void               ls(Option_t *opt="") const;
+   void               ls(Option_t *opt="") const override;
    void               MakeCustomMenuList();
    Bool_t             MatchLegacyCheckSum(UInt_t checksum) const;
    void               Move(void *arenaFrom, void *arenaTo) const;
@@ -530,7 +530,7 @@ public:
    ObjectPtr          NewObjectArray(Long_t nElements, ENewType defConstructor = kClassNew) const;
    ObjectPtr          NewObjectArray(Long_t nElements, void *arena, ENewType defConstructor = kClassNew) const;
    virtual void       PostLoadCheck();
-   Long_t             Property() const;
+   Long_t             Property() const override;
    Int_t              ReadBuffer(TBuffer &b, void *pointer, Int_t version, UInt_t start, UInt_t count);
    Int_t              ReadBuffer(TBuffer &b, void *pointer);
    void               RegisterStreamerInfo(TVirtualStreamerInfo *info);
@@ -610,7 +610,7 @@ public:
 #endif
    }
 
-   ClassDef(TClass,0)  //Dictionary containing class information
+   ClassDefOverride(TClass,0)  //Dictionary containing class information
 };
 
 namespace ROOT {

--- a/core/meta/inc/TDataMember.h
+++ b/core/meta/inc/TDataMember.h
@@ -91,11 +91,11 @@ public:
    Bool_t         IsPersistent() const { return TestBit(kObjIsPersistent); }
    Int_t          IsSTLContainer();
    Bool_t         IsValid();
-   Long_t         Property() const;
+   Long_t         Property() const override;
    void           SetClass(TClass* cl) { fClass = cl; }
    virtual bool   Update(DataMemberInfo_t *info);
 
-   ClassDef(TDataMember,2)  //Dictionary for a class data member
+   ClassDefOverride(TDataMember,2)  //Dictionary for a class data member
 };
 
 
@@ -112,12 +112,12 @@ public:
    TString          fOptName;        //Text assigned to option which appears in option menu
    TString          fOptLabel;       //Text (or enum) value assigned to option.
    TOptionListItem():
-      fDataMember(0), fValue(0), fValueMaskBit(0), fToggleMaskBit(0)
+      fDataMember(nullptr), fValue(0), fValueMaskBit(0), fToggleMaskBit(0)
    {}
    TOptionListItem(TDataMember *m,Long_t val, Long_t valmask, Long_t tglmask,
                    const char *name, const char *label);
 
-   ClassDef(TOptionListItem,2); //Element in the list of options.
+   ClassDefOverride(TOptionListItem,2); //Element in the list of options.
 };
 
 #endif

--- a/core/meta/inc/TDataType.h
+++ b/core/meta/inc/TDataType.h
@@ -61,7 +61,7 @@ protected:
    TDataType& operator=(const TDataType&);
 
 public:
-   TDataType(TypedefInfo_t *info = 0);
+   TDataType(TypedefInfo_t *info = nullptr);
    TDataType(const char *typenam);
    virtual       ~TDataType();
    Int_t          Size() const;
@@ -69,14 +69,14 @@ public:
    TString        GetTypeName();
    const char    *GetFullTypeName() const;
    const char    *AsString(void *buf) const;
-   Long_t         Property() const;
+   Long_t         Property() const override;
 
    static const char *GetTypeName(EDataType type);
    static TDataType  *GetDataType(EDataType type);
    static EDataType GetType(const std::type_info &typeinfo);
    static void AddBuiltins(TCollection* types);
 
-   ClassDef(TDataType,2)  //Basic data type descriptor
+   ClassDefOverride(TDataType,2)  //Basic data type descriptor
 };
 
 #endif

--- a/core/meta/inc/TDictAttributeMap.h
+++ b/core/meta/inc/TDictAttributeMap.h
@@ -39,13 +39,13 @@ public:
    Int_t       GetPropertySize() const { return fStringProperty.GetSize(); }
    TString     RemovePropertyString(const char* key);
    Bool_t      RemoveProperty(const char* key);
-   void        Clear(Option_t* option = "");
+   void        Clear(Option_t* option = "") override;
 
 private:
 
    THashTable     fStringProperty;         //all properties of String type
 
-   ClassDef(TDictAttributeMap,2)  // Container for name/value pairs of TDictionary attributes
+   ClassDefOverride(TDictAttributeMap,2)  // Container for name/value pairs of TDictionary attributes
 };
 
 #endif // ROOT_TDictAttributeMap

--- a/core/meta/inc/TDictionary.h
+++ b/core/meta/inc/TDictionary.h
@@ -221,7 +221,7 @@ public:
    static bool WantsUsingDecls(EMemberSelection sel) { return sel != EMemberSelection::kNoUsingDecls; }
 
    typedef const void *DeclId_t;
-   ClassDef(TDictionary,2)  //Interface to dictionary
+   ClassDefOverride(TDictionary,2)  //Interface to dictionary
 };
 
 #endif

--- a/core/meta/inc/TInterpreter.h
+++ b/core/meta/inc/TInterpreter.h
@@ -64,7 +64,7 @@ struct InterpreterMutexRegistrationRAII {
 class TInterpreter : public TNamed {
 
 protected:
-   virtual void Execute(TMethod *method, TObjArray *params, int *error = 0) = 0;
+           void Execute(TMethod *method, TObjArray *params, int *error = nullptr) override = 0;
    virtual Bool_t SetSuspendAutoParsing(Bool_t value) = 0;
 
    friend class SuspendAutoParsing;
@@ -233,7 +233,7 @@ public:
    virtual void     GetInterpreterTypeName(const char *name, std::string &output, Bool_t full = kFALSE) = 0;
    virtual void    *GetInterfaceMethod(TClass *cl, const char *method, const char *params, Bool_t objectIsConst = kFALSE) = 0;
    virtual void    *GetInterfaceMethodWithPrototype(TClass *cl, const char *method, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode /* mode */ = ROOT::kConversionMatch) = 0;
-   virtual void     Execute(const char *function, const char *params, int *error = 0) = 0;
+           void     Execute(const char *function, const char *params, int *error = 0) override = 0;
    virtual void     Execute(TObject *obj, TClass *cl, const char *method, const char *params, int *error = 0) = 0;
    virtual void     Execute(TObject *obj, TClass *cl, TMethod *method, TObjArray *params, int *error = 0) = 0;
    virtual void     ExecuteWithArgsAndReturn(TMethod *method, void* address, const void* args[] = 0, int /*nargs*/ = 0, void* ret= 0) const = 0;
@@ -553,7 +553,7 @@ public:
 
    static TInterpreter *Instance();
 
-   ClassDef(TInterpreter,0)  //ABC defining interface to generic interpreter
+   ClassDefOverride(TInterpreter,0)  //ABC defining interface to generic interpreter
 };
 
 

--- a/core/meta/inc/TIsAProxy.h
+++ b/core/meta/inc/TIsAProxy.h
@@ -57,9 +57,9 @@ public:
    // Standard destructor
    virtual ~TIsAProxy();
    // Callbacl to set the class
-   virtual void SetClass(TClass *cl);
+   void SetClass(TClass *cl) override;
    // IsA callback
-   virtual TClass* operator()(const void *obj);
+   TClass* operator()(const void *obj) override;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -85,10 +85,10 @@ public:
    // Standard destructor
    virtual ~TInstrumentedIsAProxy()                    {}
    // Callbacl to set the class
-   virtual void SetClass(TClass *cl)                   { fClass = cl; }
+   virtual void SetClass(TClass *cl) override          { fClass = cl; }
    // IsA callback
-   virtual TClass* operator()(const void *obj) {
-      return obj==0 ? fClass : ((const T*)obj)->IsA();
+   TClass* operator()(const void *obj) override {
+      return !obj ? fClass : ((const T*)obj)->IsA();
    }
 };
 

--- a/graf2d/graf/inc/TAttImage.h
+++ b/graf2d/graf/inc/TAttImage.h
@@ -53,7 +53,7 @@ public:
    static TImagePalette* Create(Option_t* opts);
    static TImagePalette* CreateCOLPalette(Int_t nContours);
 
-   ClassDef(TImagePalette,2)  // Color Palette for value -> color conversion
+   ClassDefOverride(TImagePalette,2)  // Color Palette for value -> color conversion
 };
 
 class TAttImage {

--- a/graf2d/graf/inc/TImage.h
+++ b/graf2d/graf/inc/TImage.h
@@ -108,7 +108,7 @@ public:
    virtual ~TImage() { }
 
    // Cloning
-   virtual TObject *Clone(const char *) const { return 0; }
+           TObject *Clone(const char *) const override { return nullptr; }
 
    // Input / output
    virtual void ReadImage(const char * /*file*/, EImageFileTypes /*type*/ = TImage::kUnknown) {}
@@ -255,9 +255,9 @@ public:
    TImage    &operator+=(const TImage &i) { Append(&i, "+"); return *this; }
    TImage    &operator/=(const TImage &i) { Append(&i, "/"); return *this; }
 
-   virtual void  ls(Option_t *option="") const;
+           void  ls(Option_t *option="") const override;
 
-   ClassDef(TImage,1)  // Abstract image class
+   ClassDefOverride(TImage,1)  // Abstract image class
 };
 
 

--- a/net/http/inc/THttpCallArg.h
+++ b/net/http/inc/THttpCallArg.h
@@ -250,7 +250,7 @@ public:
       AssignWSId();
    }
 
-   ClassDef(THttpCallArg, 0) // Arguments for single HTTP call
+   ClassDefOverride(THttpCallArg, 0) // Arguments for single HTTP call
 };
 
 #endif

--- a/net/http/inc/THttpEngine.h
+++ b/net/http/inc/THttpEngine.h
@@ -39,7 +39,7 @@ public:
    /** Returns pointer to THttpServer associated with engine */
    THttpServer *GetServer() const { return fServer; }
 
-   ClassDef(THttpEngine, 0) // abstract class which should provide http-based protocol for server
+   ClassDefOverride(THttpEngine, 0) // abstract class which should provide http-based protocol for server
 };
 
 #endif

--- a/net/http/inc/THttpWSHandler.h
+++ b/net/http/inc/THttpWSHandler.h
@@ -108,7 +108,7 @@ public:
 
    virtual Bool_t ProcessWS(THttpCallArg *arg) = 0;
 
-   ClassDef(THttpWSHandler, 0) // abstract class for handling websocket requests
+   ClassDefOverride(THttpWSHandler, 0) // abstract class for handling websocket requests
 };
 
 #endif

--- a/net/http/inc/TRootSnifferStore.h
+++ b/net/http/inc/TRootSnifferStore.h
@@ -45,7 +45,7 @@ public:
    Int_t GetResRestrict() const { return fResRestrict; }
    virtual Bool_t IsXml() const { return kFALSE; }
 
-   ClassDef(TRootSnifferStore, 0) // structure for results store of objects sniffer
+   ClassDefOverride(TRootSnifferStore, 0) // structure for results store of objects sniffer
 };
 
 // ========================================================================

--- a/tree/tree/inc/TTree.h
+++ b/tree/tree/inc/TTree.h
@@ -413,7 +413,7 @@ public:
    virtual TBranch        *Bronch(const char* name, const char* classname, void* addobj, Int_t bufsize = 32000, Int_t splitlevel = 99);
    virtual TBranch        *BranchOld(const char* name, const char* classname, void* addobj, Int_t bufsize = 32000, Int_t splitlevel = 1);
    virtual TBranch        *BranchRef();
-   virtual void            Browse(TBrowser*);
+           void            Browse(TBrowser*) override;
    virtual Int_t           BuildIndex(const char* majorname, const char* minorname = "0");
    TStreamerInfo          *BuildStreamerInfo(TClass* cl, void* pointer = 0, Bool_t canOptimize = kTRUE);
    virtual TFile          *ChangeFile(TFile* file);
@@ -423,9 +423,9 @@ public:
    virtual TTree          *CopyTree(const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual TBasket        *CreateBasket(TBranch*);
    virtual void            DirectoryAutoAdd(TDirectory *);
-   Int_t                   Debug() const { return fDebug; }
-   virtual void            Delete(Option_t* option = ""); // *MENU*
-   virtual void            Draw(Option_t* opt) { Draw(opt, "", "", kMaxEntries, 0); }
+           Int_t           Debug() const { return fDebug; }
+           void            Delete(Option_t* option = "") override; // *MENU*
+           void            Draw(Option_t* opt) override { Draw(opt, "", "", kMaxEntries, 0); }
    virtual Long64_t        Draw(const char* varexp, const TCut& selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
    virtual Long64_t        Draw(const char* varexp, const char* selection, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual void            DropBaskets();
@@ -436,9 +436,9 @@ public:
    virtual Int_t           Fit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Option_t* goption = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual Int_t           FlushBaskets(Bool_t create_cluster = true) const;
    virtual const char     *GetAlias(const char* aliasName) const;
-   UInt_t                  GetAllocationCount() const { return fAllocationCount; }
+           UInt_t          GetAllocationCount() const { return fAllocationCount; }
 #ifdef R__TRACK_BASKET_ALLOC_TIME
-   ULong64_t               GetAllocationTime() const { return fAllocationTime; }
+           ULong64_t       GetAllocationTime() const { return fAllocationTime; }
 #endif
    virtual Long64_t        GetAutoFlush() const {return fAutoFlush;}
    virtual Long64_t        GetAutoSave()  const {return fAutoSave;}
@@ -451,7 +451,7 @@ public:
    virtual Long64_t        GetChainEntryNumber(Long64_t entry) const { return entry; }
    virtual Long64_t        GetChainOffset() const { return fChainOffset; }
    virtual Bool_t          GetClusterPrefetch() const { return fCacheDoClusterPrefetch; }
-   TFile                  *GetCurrentFile() const;
+           TFile          *GetCurrentFile() const;
            Int_t           GetDefaultEntryOffsetLen() const {return fDefaultEntryOffsetLen;}
            Long64_t        GetDebugMax()  const { return fDebugMax; }
            Long64_t        GetDebugMin()  const { return fDebugMin; }
@@ -472,7 +472,7 @@ public:
    virtual Int_t           GetFileNumber() const { return fFileNumber; }
    virtual TTree          *GetFriend(const char*) const;
    virtual const char     *GetFriendAlias(TTree*) const;
-   TH1                    *GetHistogram() { return GetPlayer()->GetHistogram(); }
+           TH1            *GetHistogram() { return GetPlayer()->GetHistogram(); }
    virtual Bool_t          GetImplicitMT() { return fIMTEnabled; }
    virtual Int_t          *GetIndex() { return &fIndex.fArray[0]; }
    virtual Double_t       *GetIndexValues() { return &fIndexValues.fArray[0]; }
@@ -496,7 +496,7 @@ public:
    virtual Long64_t        GetMaxVirtualSize() const { return fMaxVirtualSize; }
    virtual Double_t        GetMinimum(const char* columname);
    virtual Int_t           GetNbranches() { return fBranches.GetEntriesFast(); }
-   TObject                *GetNotify() const { return fNotify; }
+           TObject        *GetNotify() const { return fNotify; }
    TVirtualTreePlayer     *GetPlayer();
    virtual Int_t           GetPacketSize() const { return fPacketSize; }
    virtual TVirtualPerfStats *GetPerfStats() const { return fPerfStats; }
@@ -505,7 +505,7 @@ public:
    virtual Long64_t        GetReadEntry()  const { return fReadEntry; }
    virtual Long64_t        GetReadEvent()  const { return fReadEntry; }
    virtual Int_t           GetScanField()  const { return fScanField; }
-   TTreeFormula           *GetSelect()    { return GetPlayer()->GetSelect(); }
+           TTreeFormula   *GetSelect()    { return GetPlayer()->GetSelect(); }
    virtual Long64_t        GetSelectedRows() { return GetPlayer()->GetSelectedRows(); }
    virtual Int_t           GetTimerInterval() const { return fTimerInterval; }
            TBuffer*        GetTransientBuffer(Int_t size);
@@ -540,7 +540,7 @@ public:
    virtual Double_t        GetWeight() const   { return fWeight; }
    virtual Long64_t        GetZipBytes() const { return fZipBytes; }
    virtual void            IncrementTotalBuffers(Int_t nbytes) { fTotalBuffers += nbytes; }
-   Bool_t                  IsFolder() const { return kTRUE; }
+           Bool_t          IsFolder() const override { return kTRUE; }
    virtual Bool_t          InPlaceClone(TDirectory *newdirectory, const char *options = "");
    virtual Int_t           LoadBaskets(Long64_t maxmemory = 2000000000);
    virtual Long64_t        LoadTree(Long64_t entry);
@@ -553,10 +553,10 @@ public:
    virtual Long64_t        Merge(TCollection* list, Option_t* option = "");
    virtual Long64_t        Merge(TCollection* list, TFileMergeInfo *info);
    static  TTree          *MergeTrees(TList* list, Option_t* option = "");
-   virtual Bool_t          Notify();
+           Bool_t          Notify() override;
    virtual void            OptimizeBaskets(ULong64_t maxMemory=10000000, Float_t minComp=1.1, Option_t *option="");
-   TPrincipal             *Principal(const char* varexp = "", const char* selection = "", Option_t* option = "np", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
-   virtual void            Print(Option_t* option = "") const; // *MENU*
+           TPrincipal     *Principal(const char* varexp = "", const char* selection = "", Option_t* option = "np", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
+           void            Print(Option_t* option = "") const override; // *MENU*
    virtual void            PrintCacheStats(Option_t* option = "") const;
    virtual Long64_t        Process(const char* filename, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0); // *MENU*
    virtual Long64_t        Process(TSelector* selector, Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
@@ -568,7 +568,7 @@ public:
    virtual void            RegisterExternalFriend(TFriendElement *);
    virtual void            RemoveExternalFriend(TFriendElement *);
    virtual void            RemoveFriend(TTree*);
-   virtual void            RecursiveRemove(TObject *obj);
+           void            RecursiveRemove(TObject *obj) override;
    virtual void            Reset(Option_t* option = "");
    virtual void            ResetAfterMerge(TFileMergeInfo *);
    virtual void            ResetBranchAddress(TBranch *);
@@ -619,7 +619,7 @@ public:
    virtual void            SetMaxEntryLoop(Long64_t maxev = kMaxEntries) { fMaxEntryLoop = maxev; } // *MENU*
    static  void            SetMaxTreeSize(Long64_t maxsize = 100000000000LL);
    virtual void            SetMaxVirtualSize(Long64_t size = 0) { fMaxVirtualSize = size; } // *MENU*
-   virtual void            SetName(const char* name); // *MENU*
+           void            SetName(const char* name) override; // *MENU*
 
    /**
     * @brief Sets the address of the object to be notified when the tree is loaded.
@@ -646,11 +646,11 @@ public:
    virtual void            StartViewer(); // *MENU*
    virtual Int_t           StopCacheLearningPhase();
    virtual Int_t           UnbinnedFit(const char* funcname, const char* varexp, const char* selection = "", Option_t* option = "", Long64_t nentries = kMaxEntries, Long64_t firstentry = 0);
-   void                    UseCurrentStyle();
-   virtual Int_t           Write(const char *name=0, Int_t option=0, Int_t bufsize=0);
-   virtual Int_t           Write(const char *name=0, Int_t option=0, Int_t bufsize=0) const;
+           void            UseCurrentStyle() override;
+           Int_t           Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) override;
+           Int_t           Write(const char *name=nullptr, Int_t option=0, Int_t bufsize=0) const override;
 
-   ClassDef(TTree, 20) // Tree descriptor (the main ROOT I/O class)
+   ClassDefOverride(TTree, 20) // Tree descriptor (the main ROOT I/O class)
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -669,21 +669,21 @@ protected:
    TIterator         *fTreeIter;     ///< current tree sub-iterator.
    Bool_t             fDirection;    ///< iteration direction
 
-   TTreeFriendLeafIter() : fTree(0), fLeafIter(0), fTreeIter(0),
-       fDirection(0) { }
+   TTreeFriendLeafIter() : fTree(nullptr), fLeafIter(nullptr), fTreeIter(nullptr),
+       fDirection(kFALSE) { }
 
 public:
    TTreeFriendLeafIter(const TTree* t, Bool_t dir = kIterForward);
    TTreeFriendLeafIter(const TTreeFriendLeafIter &iter);
    ~TTreeFriendLeafIter() { SafeDelete(fLeafIter); SafeDelete(fTreeIter); }
-   TIterator &operator=(const TIterator &rhs);
+   TIterator &operator=(const TIterator &rhs) override;
    TTreeFriendLeafIter &operator=(const TTreeFriendLeafIter &rhs);
 
-   const TCollection *GetCollection() const { return 0; }
-   Option_t          *GetOption() const;
-   TObject           *Next();
-   void               Reset() { SafeDelete(fLeafIter); SafeDelete(fTreeIter); }
-   Bool_t operator !=(const TIterator&) const {
+   const TCollection *GetCollection() const override { return nullptr; }
+   Option_t          *GetOption() const override;
+   TObject           *Next() override;
+   void               Reset() override { SafeDelete(fLeafIter); SafeDelete(fTreeIter); }
+   Bool_t operator !=(const TIterator&) const override {
       // TODO: Implement me
       return false;
    }
@@ -691,11 +691,11 @@ public:
       // TODO: Implement me
       return false;
    }
-   TObject *operator*() const {
+   TObject *operator*() const override {
       // TODO: Implement me
       return nullptr;
    }
-   ClassDef(TTreeFriendLeafIter,0)  //Linked list iterator
+   ClassDefOverride(TTreeFriendLeafIter,0)  //Linked list iterator
  };
 
 

--- a/tree/tree/inc/TVirtualTreePlayer.h
+++ b/tree/tree/inc/TVirtualTreePlayer.h
@@ -100,7 +100,7 @@ public:
    static  TVirtualTreePlayer *TreePlayer(TTree *obj);
    static void        SetPlayer(const char *player);
 
-   ClassDef(TVirtualTreePlayer,0);  //Abstract interface for Tree players
+   ClassDefOverride(TVirtualTreePlayer,0);  //Abstract interface for Tree players
 };
 
 #endif


### PR DESCRIPTION
Let avoid compiler warnings if sub-project compiled with `-Wsuggest-override` 

Only some classes are adjusted