### PR TITLE
[core] Fix interaction of TThreadExecutor and TSeq with specified beginning/range

### DIFF
--- a/core/imt/test/testRTaskArena.cxx
+++ b/core/imt/test/testRTaskArena.cxx
@@ -267,4 +267,35 @@ TEST(TThreadExecutor, StdVectorChunks)
    EXPECT_EQ(ttex.MapReduce(func, cvec, redfunc, 9), 5040);
 }
 
+TEST(TThreadExecutor, TSeqActions)
+{
+   ROOT::TThreadExecutor ttex;
+   auto func = [](int x) -> int { return x; };
+   auto redfunc = [](const std::vector<int> &v) { return std::accumulate(v.begin(), v.end(), 0); };
+
+   // MapReduce on TSeq with end specified only
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(5), redfunc, 3), 10); // with 3 chunks
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(5), redfunc), 10);    // with 0 chunks
+
+   // MapReduce on TSeq with begin and end specified only
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(2, 5), redfunc, 3), 9);
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(2, 5), redfunc), 9);
+
+   // MapReduce on increasing and decreasing TSeq with begin, end and step specified
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(2, 5, 2), redfunc, 3), 6);
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(2, 5, 2), redfunc), 6);
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(5, 2, -2), redfunc, 3), 8);
+   EXPECT_EQ(ttex.MapReduce(func, ROOT::TSeqI(5, 2, -2), redfunc), 8);
+
+   // Map on TSeq with end specified only
+   EXPECT_EQ(redfunc(ttex.Map(func, ROOT::TSeqI(5))), 10);
+
+   // Map on TSeq with begin and end specified only
+   EXPECT_EQ(redfunc(ttex.Map(func, ROOT::TSeqI(2, 5))), 9);
+
+   // Map on increasing and decreasing TSeq with begin, end and step specified
+   EXPECT_EQ(redfunc(ttex.Map(func, ROOT::TSeqI(2, 5, 2))), 6);
+   EXPECT_EQ(redfunc(ttex.Map(func, ROOT::TSeqI(5, 2, -2))), 8);
+}
+
 #endif


### PR DESCRIPTION
* Modified the logic of MapReduce and Map of the TThreadExecutor which were
initially broken for the TThreadExecutor;
* Added corresponding tests.

Fix https://github.com/root-project/root/issues/10404

