### PR TITLE
[skip-ci] Uniformize \authors

### DIFF
--- a/tutorials/geom/webdemo.C
+++ b/tutorials/geom/webdemo.C
@@ -6,8 +6,7 @@
 ///
 /// \macro_code
 ///
-/// \author Andrei Gheata
-/// \author Sergey Linev
+/// \authors Andrei Gheata, Sergey Linev
 
 #include <vector>
 #include <string>

--- a/tutorials/graphs/zdemo.C
+++ b/tutorials/graphs/zdemo.C
@@ -16,7 +16,7 @@
 /// \macro_image
 /// \macro_code
 ///
-/// \authors Michael Tokarev and Elena Potrebenikova (JINR Dubna)
+/// \authors Michael Tokarev, Elena Potrebenikova (JINR Dubna)
 
 #include "TCanvas.h"
 #include "TPad.h"

--- a/tutorials/math/Rolke.C
+++ b/tutorials/math/Rolke.C
@@ -11,7 +11,7 @@
 /// \macro_output
 /// \macro_code
 ///
-/// \authors Jan Conrad. Johan Lundberg
+/// \authors Jan Conrad, Johan Lundberg
 
 #include "TROOT.h"
 #include "TSystem.h"

--- a/tutorials/math/exampleFunction.py
+++ b/tutorials/math/exampleFunction.py
@@ -4,7 +4,7 @@
 ## Example of using Python functions and input to numerical algorithm
 ## using the ROOT Functor class 
 ##
-## \authors Lorenzo Moneta
+## \author Lorenzo Moneta
 
 import ROOT
 import array

--- a/tutorials/math/principal.py
+++ b/tutorials/math/principal.py
@@ -13,7 +13,7 @@
 ## \macro_output
 ## \macro_code
 ##
-## \authors Juan Fernando Jaramillo Botero
+## \authors Juan Fernando, Jaramillo Botero
 
 from ROOT import TPrincipal, gRandom, TBrowser, vector
 

--- a/tutorials/rcanvas/raxis.cxx
+++ b/tutorials/rcanvas/raxis.cxx
@@ -10,7 +10,7 @@
 /// \date 2020-11-03
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback
 /// is welcome!
-/// \authors Sergey Linev <S.Linev@gsi.de>
+/// \author Sergey Linev <S.Linev@gsi.de>
 
 #include <ROOT/RCanvas.hxx>
 #include <ROOT/RAxisDrawable.hxx>

--- a/tutorials/roofit/rf710_roopoly.py
+++ b/tutorials/roofit/rf710_roopoly.py
@@ -8,7 +8,7 @@
 ## \macro_code
 ##
 ## \date November 2021
-## \authors Rahul Balasubramanian
+## \author Rahul Balasubramanian
 
 import ROOT
 

--- a/tutorials/roofit/rf711_lagrangianmorph.py
+++ b/tutorials/roofit/rf711_lagrangianmorph.py
@@ -10,7 +10,7 @@
 ## \macro_code
 ##
 ## \date January 2022
-## \authors Rahul Balasubramanian
+## \author Rahul Balasubramanian
 
 import ROOT
 

--- a/tutorials/roofit/rf712_lagrangianmorphfit.py
+++ b/tutorials/roofit/rf712_lagrangianmorphfit.py
@@ -8,7 +8,7 @@
 ## \macro_code
 ##
 ## \date January 2022
-## \authors Rahul Balasubramanian
+## \author Rahul Balasubramanian
 
 import ROOT
 

--- a/tutorials/roostats/MultivariateGaussianTest.C
+++ b/tutorials/roostats/MultivariateGaussianTest.C
@@ -22,7 +22,7 @@
 /// \macro_output
 /// \macro_code
 ///
-/// \authors Kevin Belasco and Kyle Cranmer
+/// \authors Kevin Belasco, Kyle Cranmer
 
 #include "RooGlobalFunc.h"
 #include <stdlib.h>

--- a/tutorials/roostats/OneSidedFrequentistUpperLimitWithBands.C
+++ b/tutorials/roostats/OneSidedFrequentistUpperLimitWithBands.C
@@ -102,7 +102,7 @@
 /// \macro_output
 /// \macro_code
 ///
-/// \authors Kyle Cranmer Haichen Wang Daniel Whiteson
+/// \authors Kyle Cranmer, Haichen Wang, Daniel Whiteson
 
 #include "TFile.h"
 #include "TROOT.h"

--- a/tutorials/roostats/Zbi_Zgamma.C
+++ b/tutorials/roostats/Zbi_Zgamma.C
@@ -7,7 +7,7 @@
 /// \macro_output
 /// \macro_code
 ///
-/// \authors Kyle Cranmer & Wouter Verkerke
+/// \authors Kyle Cranmer, Wouter Verkerke
 
 #include "RooRealVar.h"
 #include "RooProdPdf.h"


### PR DESCRIPTION
Uniformize the `\authors` directive in tutorials.

