### PR TITLE
[core] TViewPubDataMembersIter: avoid using deprecated `std::iterator`

### DIFF
--- a/core/meta/src/TViewPubDataMembers.h
+++ b/core/meta/src/TViewPubDataMembers.h
@@ -93,9 +93,14 @@ public:
 // Iterator of view of linked list.      `                              //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-class TViewPubDataMembersIter : public TIterator,
-                                public std::iterator<std::bidirectional_iterator_tag, TObject *, std::ptrdiff_t,
-                                                     const TObject **, const TObject *&> {
+class TViewPubDataMembersIter : public TIterator {
+public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = const TObject **;
+   using reference =  const TObject *&;
+
 protected:
    const TList *fView;   //View we are iterating over.
    TIter        fClassIter;    //iterator over the classes


### PR DESCRIPTION
`std::iterator<...>` was deprecated in C++17; manually declare the expected member types instead.

## Checklist:
- [X] tested changes locally

This PR fixes #10351.