### PR TITLE
[DF] Avoid expensive stringstream construction in RCsvDS

### DIFF
--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -229,7 +229,7 @@ std::vector<std::string> RCsvDS::ParseColumns(const std::string &line)
 
 size_t RCsvDS::ParseValue(const std::string &line, std::vector<std::string> &columns, size_t i)
 {
-   std::stringstream val;
+   std::string val;
    bool quoted = false;
 
    for (; i < line.size(); ++i) {
@@ -240,14 +240,14 @@ size_t RCsvDS::ParseValue(const std::string &line, std::vector<std::string> &col
          if (line[i + 1] != '"') {
             quoted = !quoted;
          } else {
-            val << line[++i];
+            val += line[++i];
          }
       } else {
-         val << line[i];
+         val += line[i];
       }
    }
 
-   columns.emplace_back(val.str());
+   columns.emplace_back(std::move(val));
 
    return i;
 }

--- a/tree/dataframe/src/RCsvDS.cxx
+++ b/tree/dataframe/src/RCsvDS.cxx
@@ -113,7 +113,6 @@ void RCsvDS::FillHeaders(const std::string &line)
 
 void RCsvDS::FillRecord(const std::string &line, Record_t &record)
 {
-   std::istringstream lineStream(line);
    auto i = 0U;
 
    auto columns = ParseColumns(line);


### PR DESCRIPTION
With these changes, reading in a CSV of 32M lines takes 43 seconds on my laptop instead of 1m48s.