### PR TITLE
[skip-ci] Fix the double "author"

### DIFF
--- a/tutorials/roofit/rf102_dataimport.py
+++ b/tutorials/roofit/rf102_dataimport.py
@@ -7,8 +7,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 from array import array

--- a/tutorials/roofit/rf105_funcbinding.py
+++ b/tutorials/roofit/rf105_funcbinding.py
@@ -8,8 +8,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 

--- a/tutorials/roofit/rf109_chi2residpull.py
+++ b/tutorials/roofit/rf109_chi2residpull.py
@@ -8,8 +8,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 from __future__ import print_function
 import ROOT

--- a/tutorials/roofit/rf208_convolution.py
+++ b/tutorials/roofit/rf208_convolution.py
@@ -10,8 +10,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 

--- a/tutorials/roofit/rf210_angularconv.py
+++ b/tutorials/roofit/rf210_angularconv.py
@@ -14,8 +14,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 

--- a/tutorials/roofit/rf211_paramconv.py
+++ b/tutorials/roofit/rf211_paramconv.py
@@ -10,8 +10,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 

--- a/tutorials/roofit/rf303_conditional.py
+++ b/tutorials/roofit/rf303_conditional.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 

--- a/tutorials/roofit/rf401_importttreethx.py
+++ b/tutorials/roofit/rf401_importttreethx.py
@@ -10,8 +10,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 from array import array

--- a/tutorials/roofit/rf403_weightedevts.py
+++ b/tutorials/roofit/rf403_weightedevts.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 from __future__ import print_function
 import ROOT

--- a/tutorials/roofit/rf503_wspaceread.py
+++ b/tutorials/roofit/rf503_wspaceread.py
@@ -11,8 +11,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 import ROOT
 

--- a/tutorials/roofit/rf508_listsetmanip.py
+++ b/tutorials/roofit/rf508_listsetmanip.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 from __future__ import print_function
 import ROOT

--- a/tutorials/roofit/rf510_wsnamedsets.py
+++ b/tutorials/roofit/rf510_wsnamedsets.py
@@ -10,8 +10,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 
 import ROOT

--- a/tutorials/roofit/rf512_wsfactory_oper.py
+++ b/tutorials/roofit/rf512_wsfactory_oper.py
@@ -10,8 +10,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 
 import ROOT
@@ -55,7 +54,7 @@ w.factory("prod::uv(u[10],v[10])")
 # Function addition is done with sum(func1,func2)
 w.factory("sum::uv2(u,v)")
 
-# Lagrangian morphing function for the example shown in rf711_lagrangianmorph 
+# Lagrangian morphing function for the example shown in rf711_lagrangianmorph
 infilename = ROOT.gROOT.GetTutorialDir().Data() + "/roofit/input_histos_rf_lagrangianmorph.root";
 w.factory("lagrangianmorph::morph($observableName('pTV'),$fileName('"+infilename+"'),$couplings({cHq3[0,1],SM[1]}),$NewPhysics(cHq3=1,SM=0),$folders({'SM_NPsq0','cHq3_NPsq1','cHq3_NPsq2'}))")
 

--- a/tutorials/roofit/rf601_intminuit.py
+++ b/tutorials/roofit/rf601_intminuit.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 
 import ROOT

--- a/tutorials/roofit/rf602_chi2fit.py
+++ b/tutorials/roofit/rf602_chi2fit.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 from __future__ import print_function
 import ROOT

--- a/tutorials/roofit/rf605_profilell.py
+++ b/tutorials/roofit/rf605_profilell.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 
 import ROOT

--- a/tutorials/roofit/rf606_nllerrorhandling.py
+++ b/tutorials/roofit/rf606_nllerrorhandling.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 
 import ROOT

--- a/tutorials/roofit/rf705_linearmorph.py
+++ b/tutorials/roofit/rf705_linearmorph.py
@@ -9,8 +9,7 @@
 ## \macro_code
 ##
 ## \date February 2018
-## \author Clemens Lange
-## \author Wouter Verkerke (C version)
+## \authors Clemens Lange, Wouter Verkerke (C version)
 
 
 import ROOT

--- a/tutorials/v7/browser.cxx
+++ b/tutorials/v7/browser.cxx
@@ -5,8 +5,7 @@
 ///
 /// \date 2019-05-29
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-/// \author Bertrand Bellenot <Bertrand.Bellenot@cern.ch>
-/// \author Sergey Linev <S.Linev@gsi.de>
+/// \authors Bertrand Bellenot <Bertrand.Bellenot@cern.ch>, Sergey Linev <S.Linev@gsi.de>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *

--- a/tutorials/v7/fitpanel6.cxx
+++ b/tutorials/v7/fitpanel6.cxx
@@ -5,8 +5,7 @@
 ///
 /// \date 2019-04-11
 /// \warning This is part of the ROOT 7 prototype! It will change without notice. It might trigger earthquakes. Feedback is welcome!
-/// \author Sergey Linev <S.Linev@gsi.de>
-/// \author Iliana Betsou <Iliana.Betsou@cern.ch>
+/// \authors Sergey Linev <S.Linev@gsi.de>, Iliana Betsou <Iliana.Betsou@cern.ch>
 
 /*************************************************************************
  * Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.               *


### PR DESCRIPTION
Some tutorials had two `\author` lines. This generates the doxygen error:
```
\endcond command within this file
```
These double lines are replaced by the `\authors` single line.