### PR TITLE
[RF] Also compare parameter errors in RooFitResult::isIdentical(NoCov)

### DIFF
--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -151,7 +151,7 @@ public:
   /// Generate random perturbations of the final parameters using the covariance matrix.
   const RooArgList& randomizePars() const;
 
-  bool isIdenticalNoCov(const RooFitResult& other, double tol=1e-6, bool verbose=true) const ;
+  bool isIdenticalNoCov(const RooFitResult& other, double tol=1e-6, double tolErr=1e-3, bool verbose=true) const ;
   bool isIdentical(const RooFitResult& other, double tol=1e-6, double tolCorr=1e-4, bool verbose=true) const ;
 
   void SetName(const char *name) override ;

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -52,12 +52,14 @@ TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
 
   a = 1.2;
   auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true), RooFit::PrintLevel(-1));
-  const double aError = a.getError();
   a = 1.2;
   auto result2 = pdf.fitTo(weightedData, RooFit::Save(), RooFit::SumW2Error(false), RooFit::PrintLevel(-1));
 
-  EXPECT_TRUE(result->isIdentical(*result2)) << "Fit results should be very similar.";
-  EXPECT_GT(aError, a.getError()*2.) << "Asymptotically correct errors should be significantly larger.";
+  // Set relative tolerance for errors to large value to only check for values
+  EXPECT_TRUE(result->isIdenticalNoCov(*result2, 1e-6, 10.0)) << "Fit results should be very similar.";
+  // Set non-verbose because we expect the comparison to fail
+  EXPECT_FALSE(result->isIdenticalNoCov(*result2, 1e-6, 1e-3, false))
+      << "Asymptotically correct errors should be significantly larger.";
 }
 
 
@@ -127,6 +129,7 @@ TEST(RooAbsPdf, ConditionalFitBatchMode)
 
     for(bool batchMode : {false, true}) {
       factor.setVal(1.0);
+      factor.setError(0.0);
       fitResults.emplace_back(
         model.fitTo(
               *data,
@@ -172,6 +175,10 @@ TEST(RooAbsPdf, MultiRangeFit)
   auto resetValues = [&](){
     mean.setVal(-1);
     width.setVal(3);
+    nsig.setVal(nEvents);
+    mean.setError(0.0);
+    width.setError(0.0);
+    nsig.setError(0.0);
   };
 
   // loop over non-extended and extended fit
@@ -250,6 +257,9 @@ TEST(RooAbsPdf, MultiRangeFit2D)
       mx.setVal(1.0);
       my.setVal(1.0);
       f.setVal(0.5);
+      mx.setError(0.0);
+      my.setError(0.0);
+      f.setError(0.0);
    };
 
    std::size_t nEvents = 100;


### PR DESCRIPTION
The `RooFitResult::isIdentical` method so far only compared parameter
values and covariance matrix values. Even though comparing the final
parameter errors would be redundant with the covariance matrix checks,
it's still important to check parameter errors for two reasons:

  1. Initial parameter errors need to be compared, because the the
     initial error determins the initial step size which influences the
     minimization path. If initial errors are different, the final
     parameter values are almost never identical.

     Catching differences in initial parameter errors informs the user
     that differences in fit result are because of the starting
     conditions.

  2. In the case of `RooFitResult::isIdenticalNoCov`, we need to check
     the error of final parameters because there is no comparison of
     covariance matrix values.

The signature of the public function `isIdenticalNoCov` is extended by a
tolerance parameter for the error comparison. This is expected to not
break user code, because the function was only introduced in 6.26 and is
so far only used in a single unit test (`testSumW2Error`).

The `testRooAbsPdf` unit test didn't reset the initial parameter errors
correctly, which is now fixed.
