### PR TITLE
[RF] Fix SumW2Error with extended term BatchMode

### DIFF
--- a/roofit/roofit/test/CMakeLists.txt
+++ b/roofit/roofit/test/CMakeLists.txt
@@ -15,4 +15,3 @@ ROOT_ADD_GTEST(testRooParamHistFunc testRooParamHistFunc.cxx LIBRARIES Gpad RooF
 ROOT_ADD_GTEST(testRooExponential testRooExponential.cxx
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/exponentialPdf.root
   LIBRARIES Core RooFitCore RooFit)
-ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore RooFit)

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -297,7 +297,7 @@ public:
   static void verboseEval(Int_t stat) ;
   static int verboseEval() ;
 
-  double extendedTerm(double observedEvents, const RooArgSet* nset=0) const;
+  double extendedTerm(double sumEntries, const RooArgSet* nset, double sumEntriesW2=0.0) const;
   double extendedTerm(RooAbsData const& data, bool weightSquared) const;
 
   void setNormRange(const char* rangeName) ;

--- a/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
+++ b/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
@@ -31,6 +31,16 @@ std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, std::uni
                                       RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
                                       RooFit::BatchModeOption batchMode);
 
+// Little wrapper to use a TNamed directly as a RooBatchCompute DataKey.
+class NamePtrWrapper {
+public:
+   NamePtrWrapper(TNamed const *namePtr) : _namePtr(namePtr) {}
+   operator RooBatchCompute::DataKey() const { return RooBatchCompute::DataKey::create(_namePtr); }
+
+private:
+   TNamed const *_namePtr;
+};
+
 }
 } // namespace RooFit
 

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -29,11 +29,10 @@ public:
    // The names for the weight variables that the RooNLLVarNew expects
    static constexpr const char *weightVarName = "_weight";
    static constexpr const char *weightVarNameSumW2 = "_weight_sumW2";
-   static constexpr const char *weightVarNameSumW2Suffix = "_sumW2";
 
    RooNLLVarNew(){};
-   RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, RooAbsReal *weight,
-                bool isExtended, std::string const &rangeName);
+   RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
+                std::string const &rangeName);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = 0);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 
@@ -59,10 +58,12 @@ protected:
 
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooArgSet _observables;
-   std::unique_ptr<RooTemplateProxy<RooAbsReal>> _weight;
    mutable double _sumWeight = 0.0;         //!
+   mutable double _sumWeight2 = 0.0;        //!
    mutable double _sumCorrectionTerm = 0.0; //!
    bool _isExtended;
+   bool _weightSquared = false;
+   std::string _prefix;
    std::unique_ptr<RooTemplateProxy<RooAbsReal>> _rangeNormTerm;
 
    double evaluate() const override;

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -765,11 +765,41 @@ void RooAbsPdf::getLogProbabilities(RooSpan<const double> pdfValues, double * ou
 /// it is extendable by overloading `canBeExtended()`, and must
 /// implement the `expectedEvents()` function.
 ///
+/// \param[in] observed The number of observed events.
+/// \param[in] nset The normalization set when asking the pdf for the expected
+///            number of events.
+/// \param[in] observedSumW2 The number of observed events when weighting with
+///            squared weights. If non-zero, the weight-squared error
+///            correction is applied to the extended term.
+///
+/// The weight-squared error correction works as follows:
+/// adjust poisson such that
+/// estimate of \f$N_\mathrm{expect}\f$ stays at the same value, but has a different variance, rescale
+/// both the observed and expected count of the Poisson with a factor \f$ \sum w_{i} / \sum w_{i}^2 \f$
+/// (the effective weight of the Poisson term),
+/// i.e., change \f$\mathrm{Poisson}(N_\mathrm{observed} = \sum w_{i} | N_\mathrm{expect} )\f$
+/// to \f$ \mathrm{Poisson}(\sum w_{i} \cdot \sum w_{i} / \sum w_{i}^2 | N_\mathrm{expect} \cdot \sum w_{i} / \sum w_{i}^2 ) \f$,
+/// weighted by the effective weight \f$ \sum w_{i}^2 / \sum w_{i} \f$ in the likelihood.
+/// Since here we compute the likelihood with the weight square, we need to multiply by the
+/// square of the effective weight:
+///   - \f$ W_\mathrm{expect}   = N_\mathrm{expect} \cdot \sum w_{i} / \sum w_{i}^2 \f$ : effective expected entrie
+///   - \f$ W_\mathrm{observed} = \sum w_{i} \cdot \sum w_{i} / \sum w_{i}^2 \f$        : effective observed entries
+///
+/// The extended term for the likelihood weighted by the square of the weight will be then:
+///
+///  \f$ \left(\sum w_{i}^2 / \sum w_{i}\right)^2 \cdot W_\mathrm{expect} - (\sum w_{i}^2 / \sum w_{i})^2 \cdot W_\mathrm{observed} \cdot \log{W_\mathrm{expect}} \f$
+///
+///  aund this is using the previous expressions for \f$ W_\mathrm{expect} \f$ and \f$ W_\mathrm{observed} \f$:
+///
+///  \f$ \sum w_{i}^2 / \sum w_{i} \cdot N_\mathrm{expect} - \sum w_{i}^2 \cdot \log{W_\mathrm{expect}} \f$
+///
+///  Since the weights are constants in the likelihood we can use \f$\log{N_\mathrm{expect}}\f$ instead of \f$\log{W_\mathrm{expect}}\f$.
+///
 /// See also RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared),
-/// which takes a dataset to extract (\f$N_\mathrm{observed}\f$) and the
+/// which takes a dataset to extract \f$N_\mathrm{observed}\f$ and the
 /// normalization set.
 
-double RooAbsPdf::extendedTerm(double observed, const RooArgSet* nset) const
+double RooAbsPdf::extendedTerm(double sumEntries, const RooArgSet* nset, double sumEntriesW2) const
 {
   // check if this PDF supports extended maximum likelihood fits
   if(!canBeExtended()) {
@@ -778,7 +808,7 @@ double RooAbsPdf::extendedTerm(double observed, const RooArgSet* nset) const
     return 0;
   }
 
-  Double_t expected= expectedEvents(nset);
+  double expected = expectedEvents(nset);
   if(expected < 0) {
     coutE(InputArguments) << fName << ": calculated negative expected events: " << expected
          << endl;
@@ -788,7 +818,7 @@ double RooAbsPdf::extendedTerm(double observed, const RooArgSet* nset) const
 
 
   // Explicitly handle case Nobs=Nexp=0
-  if (fabs(expected)<1e-10 && fabs(observed)<1e-10) {
+  if (std::abs(expected)<1e-10 && std::abs(sumEntries)<1e-10) {
     return 0 ;
   }
 
@@ -798,37 +828,12 @@ double RooAbsPdf::extendedTerm(double observed, const RooArgSet* nset) const
     return TMath::QuietNaN() ;
   }
 
-  // calculate and return the negative log-likelihood of the Poisson
-  // factor for this dataset, dropping the constant log(observed!)
-  //   Double_t extra=0;
-  //   if(observed<1000000) {
-  //     Double_t Delta1 = (expected-observed);
-  //     Double_t Delta2 = observed*(log(expected)-log(observed+1));
-  //     Double_t Const3 = 0.5*log(observed+1);
-  //     extra= Delta1 - Delta2 + Const3;
+  double extra = expected - sumEntries*log(expected);
 
-  //     cout << " extra obs = " << observed << " exp = " << expected << endl ;
-  //     cout << " extra orig = " << expected - observed*log(expected) << endl ;
-  //     cout << " extra orig fix = " << expected - observed*log(expected) + log(TMath::Gamma(observed+1)) << endl ;
-  //     cout << " extra new  = " << extra << endl ;
-
-  //   } else {
-  //     Double_t sigma_square=expected;
-  //     Double_t diff=observed-expected;
-  //     extra=-log(sigma_square)/2 + (diff*diff)/(2*sigma_square);
-  //   }
-
-  Double_t extra= expected - observed*log(expected);
-
-//   cout << "RooAbsPdf::extendedTerm(" << GetName() << ") observed = " << observed << " expected = " << expected << endl ;
-
-  Bool_t trace(kFALSE) ;
-  if(trace) {
-    cxcoutD(Tracing) << fName << "::extendedTerm: expected " << expected << " events, got "
-           << observed << " events. extendedTerm = " << extra << endl;
+  if(sumEntriesW2 != 0.0) {
+    extra *= sumEntriesW2 / sumEntries;
   }
 
-//   cout << "RooAbsPdf::extendedTerm(" << GetName() << ") nExp = " << expected << " nObs = " << observed << endl ;
   return extra;
 }
 
@@ -849,7 +854,7 @@ double RooAbsPdf::extendedTerm(double observed, const RooArgSet* nset) const
 ///            number of expected events.
 /// \param[in] weightSquared If set to `true`, the extended term will be scaled by
 ///            the ratio of squared event weights over event weights:
-///            (\f$ \sum w_{i}^2 / \sum w_{i} \f$).
+///            \f$ \sum w_{i}^2 / \sum w_{i} \f$.
 ///            Indended to be used by fits with the `SumW2Error()` option that
 ///            can be passed to
 ///            RooAbsPdf::fitTo(RooAbsData&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)
@@ -858,29 +863,11 @@ double RooAbsPdf::extendedTerm(double observed, const RooArgSet* nset) const
 
 double RooAbsPdf::extendedTerm(RooAbsData const& data, bool weightSquared) const {
   double sumW = data.sumEntries();
-  double term = extendedTerm(sumW, data.get());
+  double sumW2 = 0.0;
   if (weightSquared) {
-
-    // Adjust calculation of extended term with W^2 weighting: adjust poisson such that
-    // estimate of Nexpected stays at the same value, but has a different variance, rescale
-    // both the observed and expected count of the Poisson with a factor sum[w] / sum[w^2] which is
-    // the effective weight of the Poisson term.
-    // i.e. change Poisson(Nobs = sum[w]| Nexp ) --> Poisson( sum[w] * sum[w] / sum[w^2] | Nexp * sum[w] / sum[w^2] )
-    // weighted by the effective weight  sum[w^2]/ sum[w] in the likelihood.
-    // Since here we compute the likelihood with the weight square we need to multiply by the
-    // square of the effective weight
-    // expectedW = expected * sum[w] / sum[w^2]   : effective expected entries
-    // observedW =  sum[w]  * sum[w] / sum[w^2]   : effective observed entries
-    // The extended term for the likelihood weighted by the square of the weight will be then:
-    //  (sum[w^2]/ sum[w] )^2 * expectedW -  (sum[w^2]/ sum[w] )^2 * observedW * log (expectedW)  and this is
-    //  using the previous expressions for expectedW and observedW
-    //  sum[w^2] / sum[w] * expected - sum[w^2] * log (expectedW)
-    //  and since the weights are constants in the likelihood we can use log(expected) instead of log(expectedW)
-
-    double sumW2 = data.sumEntriesW2();
-    term *= sumW2 / sumW;
+    sumW2 = data.sumEntriesW2();
   }
-  return term;
+  return extendedTerm(sumW, data.get(), sumW2);
 }
 
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -22,28 +22,28 @@ transfered away to other classes, like the `RooFitDriver`. This class also calls
 functions from `RooBatchCompute` library to provide faster computation times.
 **/
 
-#include "RooNLLVarNew.h"
+#include <RooNLLVarNew.h>
 
-#include "RooAddition.h"
-#include "RooFormulaVar.h"
-#include "RooNaNPacker.h"
+#include <RooAddition.h>
+#include <RooFormulaVar.h>
+#include <RooNaNPacker.h>
+#include <RooFit/BatchModeHelpers.h>
+#include <RooFit/Detail/Buffers.h>
 
-#include "RooFit/Detail/Buffers.h"
+#include <ROOT/StringUtils.hxx>
 
-#include "ROOT/StringUtils.hxx"
-
-#include "Math/Util.h"
+#include <Math/Util.h>
 
 #include <numeric>
 #include <stdexcept>
 #include <vector>
 
 using namespace ROOT::Experimental;
+using RooFit::BatchModeHelpers::NamePtrWrapper;
 
 // Declare constexpr static members to make them available if odr-used in C++14.
 constexpr const char *RooNLLVarNew::weightVarName;
 constexpr const char *RooNLLVarNew::weightVarNameSumW2;
-constexpr const char *RooNLLVarNew::weightVarNameSumW2Suffix;
 
 namespace {
 
@@ -83,17 +83,13 @@ double kahanSum(Input const &input)
 \param title the title
 \param pdf The pdf for which the nll is computed for
 \param observables The observabes of the pdf
-\param weight A pointer to the weight variable (if exists)
 \param isExtended Set to true if this is an extended fit
 \param rangeName the range name
 **/
 RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
-                           RooAbsReal *weight, bool isExtended, std::string const &rangeName)
+                           bool isExtended, std::string const &rangeName)
    : RooAbsReal(name, title), _pdf{"pdf", "pdf", this, pdf}, _observables{observables}, _isExtended{isExtended}
-//_rangeNormTerm{rangeName.empty() ? nullptr : createRangeNormTerm(pdf, observables, pdf.GetName(), rangeName)}
 {
-   if (weight)
-      _weight = std::make_unique<RooTemplateProxy<RooAbsReal>>("_weight", "_weight", this, *weight);
    if (!rangeName.empty()) {
       auto term = createRangeNormTerm(pdf, observables, pdf.GetName(), rangeName);
       _rangeNormTerm = std::make_unique<RooTemplateProxy<RooAbsReal>>("_rangeNormTerm", "_rangeNormTerm", this, *term);
@@ -104,8 +100,6 @@ RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, 
 RooNLLVarNew::RooNLLVarNew(const RooNLLVarNew &other, const char *name)
    : RooAbsReal(other, name), _pdf{"pdf", this, other._pdf}, _observables{other._observables}
 {
-   if (other._weight)
-      _weight = std::make_unique<RooTemplateProxy<RooAbsReal>>("_weight", this, *other._weight);
    if (other._rangeNormTerm)
       _rangeNormTerm = std::make_unique<RooTemplateProxy<RooAbsReal>>("_rangeNormTerm", this, *other._rangeNormTerm);
 }
@@ -127,62 +121,60 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
    RooSpan<double> logProbas{logProbasBuffer->cpuWritePtr(), nEvents};
    (*_pdf).getLogProbabilities(probas, logProbas.data());
 
-   std::vector<double> nlls(nEvents);
-   nlls.reserve(nEvents);
-
-   if (_weight) {
-      double const *weights = dataMap[&**_weight].data();
-      for (std::size_t i = 0; i < nEvents; ++i) {
-         // Explicitely add zero if zero weight to get rid of eventual NaNs in
-         // logProbas that have no weight anyway.
-         nlls.push_back(weights[i] == 0.0 ? 0.0 : -logProbas[i] * weights[i]);
-      }
-   } else {
-      for (auto const &p : logProbas)
-         nlls.push_back(-p);
-   }
+   auto &nameReg = RooNameReg::instance();
+   auto weights = dataMap.at(NamePtrWrapper(nameReg.constPtr((_prefix + weightVarName).c_str())));
+   auto weightsSumW2 = dataMap.at(NamePtrWrapper(nameReg.constPtr((_prefix + weightVarNameSumW2).c_str())));
+   auto weightSpan = _weightSquared ? weightsSumW2 : weights;
 
    if ((_isExtended || _rangeNormTerm) && _sumWeight == 0.0) {
-      if (!_weight) {
-         _sumWeight = nEvents;
-      } else {
-         auto weightSpan = dataMap[&**_weight];
-         _sumWeight = weightSpan.size() == 1 ? weightSpan[0] * nEvents : kahanSum(dataMap[&**_weight]);
-      }
+      _sumWeight = weights.size() == 1 ? weights[0] * nEvents : kahanSum(weights);
+   }
+   if ((_isExtended || _rangeNormTerm) && _weightSquared && _sumWeight2 == 0.0) {
+      _sumWeight2 = weights.size() == 1 ? weightsSumW2[0] * nEvents : kahanSum(weightsSumW2);
    }
    if (_rangeNormTerm) {
       auto rangeNormTermSpan = dataMap[&**_rangeNormTerm];
       if (rangeNormTermSpan.size() == 1) {
-         _sumCorrectionTerm = _sumWeight * rangeNormTermSpan[0];
+         _sumCorrectionTerm = (_weightSquared ? _sumWeight2 : _sumWeight) * rangeNormTermSpan[0];
       } else {
-         if (!_weight) {
-            _sumCorrectionTerm = kahanSum(rangeNormTermSpan);
+         if (weightSpan.size() == 1) {
+            _sumCorrectionTerm = weightSpan[0] * kahanSum(rangeNormTermSpan);
          } else {
-            auto weightSpan = dataMap[&**_weight];
-            if (weightSpan.size() == 1) {
-               _sumCorrectionTerm = weightSpan[0] * kahanSum(rangeNormTermSpan);
-            } else {
-               // We don't need to use the library for now because the weights and
-               // correction term integrals are always in the CPU map.
-               _sumCorrectionTerm = 0.0;
-               for (std::size_t i = 0; i < nEvents; ++i) {
-                  _sumCorrectionTerm += weightSpan[i] * rangeNormTermSpan[i];
-               }
+            // We don't need to use the library for now because the weights and
+            // correction term integrals are always in the CPU map.
+            _sumCorrectionTerm = 0.0;
+            for (std::size_t i = 0; i < nEvents; ++i) {
+               _sumCorrectionTerm += weightSpan[i] * rangeNormTermSpan[i];
             }
          }
       }
    }
 
-   double nll = kahanSum(nlls);
+   std::vector<double> nlls(nEvents);
+   nlls.reserve(nEvents);
+   double nll = 0.0;
+
+   if (weightSpan.size() > 1) {
+      for (std::size_t i = 0; i < nEvents; ++i) {
+         // Explicitely add zero if zero weight to get rid of eventual NaNs in
+         // logProbas that have no weight anyway.
+         nlls.push_back(weightSpan[i] == 0.0 ? 0.0 : -logProbas[i] * weightSpan[i]);
+      }
+      nll = kahanSum(nlls);
+   } else {
+      for (auto const &p : logProbas) {
+         nlls.push_back(-p);
+      }
+      nll = weightSpan[0] * kahanSum(nlls);
+   }
 
    if (std::isnan(nll)) {
       // Special handling of evaluation errors.
       // We can recover if the bin/event that results in NaN has a weight of zero:
       RooNaNPacker nanPacker;
       for (std::size_t i = 0; i < probas.size(); ++i) {
-         if (_weight) {
-            double const *weights = dataMap[&**_weight].data();
-            if (std::isnan(logProbas[i]) && weights[i] != 0.0) {
+         if (weightSpan.size() > 1) {
+            if (std::isnan(logProbas[i]) && weightSpan[i] != 0.0) {
                nanPacker.accumulate(logProbas[i]);
             }
          }
@@ -199,7 +191,7 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
 
    if (_isExtended) {
       assert(_sumWeight != 0.0);
-      nll += _pdf->extendedTerm(_sumWeight, &_observables);
+      nll += _pdf->extendedTerm(_sumWeight, &_observables, _weightSquared ? _sumWeight2 : 0.0);
    }
    if (_rangeNormTerm) {
       nll += _sumCorrectionTerm;
@@ -223,8 +215,6 @@ void RooNLLVarNew::getParametersHook(const RooArgSet * /*nset*/, RooArgSet *para
 {
    // strip away the observables and weights
    params->remove(_observables, true, true);
-   if (_weight)
-      params->remove(**_weight, true, true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -234,9 +224,9 @@ void RooNLLVarNew::getParametersHook(const RooArgSet * /*nset*/, RooArgSet *para
 /// \param[in] prefix The prefix to add to the observables and weight names.
 RooArgSet RooNLLVarNew::prefixObservableAndWeightNames(std::string const &prefix)
 {
+   _prefix = prefix;
+
    RooArgSet obsSet{_observables};
-   if (_weight)
-      obsSet.add(**_weight);
    RooArgSet obsClones;
    obsSet.snapshot(obsClones);
    for (RooAbsArg *arg : obsClones) {
@@ -246,9 +236,6 @@ RooArgSet RooNLLVarNew::prefixObservableAndWeightNames(std::string const &prefix
    recursiveRedirectServers(obsClones, false, true);
 
    RooArgSet newObservables{obsClones};
-   if (_weight) {
-      newObservables.remove(**_weight);
-   }
 
    setObservables(obsClones);
    addOwnedComponents(std::move(obsClones));
@@ -256,36 +243,9 @@ RooArgSet RooNLLVarNew::prefixObservableAndWeightNames(std::string const &prefix
    return newObservables;
 }
 
-namespace {
-
-inline bool endsWith(std::string const &value, std::string_view ending)
-{
-   if (ending.size() > value.size())
-      return false;
-   return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-}
-
-} // namespace
-
 ////////////////////////////////////////////////////////////////////////////////
-/// Toggles the weight square correction by changing the name of the weight
-/// variable to get different weights from the RooFitDriver data map. The
-/// RooNLLVarNew::weightVarNameSumW2Suffix is either added or removed from the
-/// weight variable name.
+/// Toggles the weight square correction.
 void RooNLLVarNew::applyWeightSquared(bool flag)
 {
-   if (!_weight)
-      return;
-   auto &w = **_weight;
-
-   const std::string name = w.GetName();
-   const std::string suffix = weightVarNameSumW2Suffix;
-
-   bool isAlreadyWeightSquared = endsWith(name, suffix);
-
-   if (isAlreadyWeightSquared && !flag) {
-      w.SetName(name.substr(0, name.length() - suffix.length()).c_str());
-   } else if (!isAlreadyWeightSquared && flag) {
-      w.SetName((name + suffix).c_str());
-   }
+   _weightSquared = flag;
 }

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -53,6 +53,7 @@ ROOT_ADD_GTEST(testLikelihoodSerial TestStatistics/testLikelihoodSerial.cxx LIBR
 ROOT_ADD_GTEST(testRooRealL TestStatistics/RooRealL.cpp LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFit)
 ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFit)
+ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
 if (roofit_multiprocess)
   ROOT_ADD_GTEST(testTestStatisticsPlot TestStatistics/testPlot.cpp LIBRARIES RooFitMultiProcess RooFitCore RooFit 
                  COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/TestStatistics/TestStatistics_ref.root)

--- a/roofit/roofitcore/test/testRooFitDriver.cxx
+++ b/roofit/roofitcore/test/testRooFitDriver.cxx
@@ -83,11 +83,12 @@ TEST(testRooFitDriver, SimpleLikelihoodFit)
    resetGraph();
 
    // ...and now the new way with RooFitDriver
-   ROOT::Experimental::RooNLLVarNew nll("nll", "nll", model, *data->get(), nullptr, false, "");
+   ROOT::Experimental::RooNLLVarNew nll("nll", "nll", model, *data->get(), false, "");
    ROOT::Experimental::RooFitDriver driver(*data, nll, x, RooFit::BatchModeOption::Cpu, "");
    auto resultBatchNew = doFit(*driver.makeAbsRealWrapper());
-   if (verbose)
+   if (verbose) {
       std::cout << "-  batch mode fit took " << resultBatchNew.elapsedTime << " ms" << std::endl;
+   }
 
    // make sure the fit result is the same and that there were the same number
    // of evaluations

--- a/roofit/roofitcore/test/testSumW2Error.cxx
+++ b/roofit/roofitcore/test/testSumW2Error.cxx
@@ -1,17 +1,16 @@
 // Tests for the SumW2Error correction
 // Author: Jonas Rembser, CERN  10/2021
 
-#include "RooFitResult.h"
-#include "RooAbsPdf.h"
-#include "RooGaussian.h"
-#include "RooExponential.h"
-#include "RooAddPdf.h"
-#include "RooRandom.h"
-#include "RooDataHist.h"
-#include "RooDataSet.h"
-#include "RooRealVar.h"
+#include <RooFitResult.h>
+#include <RooAbsPdf.h>
+#include <RooAddPdf.h>
+#include <RooRandom.h>
+#include <RooDataHist.h>
+#include <RooDataSet.h>
+#include <RooRealVar.h>
+#include <RooWorkspace.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 // GitHub issue 9118: Problem running weighted binned fit in batch mode
 TEST(SumW2Error, BatchMode)
@@ -19,15 +18,18 @@ TEST(SumW2Error, BatchMode)
    auto &msg = RooMsgService::instance();
    msg.setGlobalKillBelow(RooFit::WARNING);
 
-   RooRealVar x{"x", "x", 0, 0, 10};
-   RooRealVar mu{"mu", "mu", 3, 0, 10};
-   RooRealVar s{"s", "s", 1.0, 0.1, 5};
-   RooRealVar c1{"c1", "c1", -0.5, -3, -0.1};
-   RooRealVar f{"f", "f", 0.2, 0.0, 1.0};
+   RooWorkspace ws{"workspace"};
+   ws.factory("Gaussian::sig(x[0,0,10],mu[3,0,10],s[1, 0.1, 5])");
+   ws.factory("Exponential::bkg(x,c1[-0.5, -3, -0.1])");
+   ws.factory("SUM::model(f[0.2, 0.0, 1.0] * sig, bkg)");
 
-   RooGaussian sig{"sig", "sig", x, mu, s};
-   RooExponential bkg{"bkg", "bkg", x, c1};
-   RooAddPdf model{"model", "model", {sig, bkg}, {f}};
+   auto& x = *ws.var("x");
+   auto& mu = *ws.var("mu");
+   auto& s = *ws.var("s");
+   auto& c1 = *ws.var("c1");
+   auto& f = *ws.var("f");
+
+   auto& model = *ws.pdf("model");
 
    auto resetParametersToInitialFitValues = [&]() {
       mu.setVal(4.0);
@@ -101,4 +103,56 @@ TEST(SumW2Error, BatchMode)
       << " different results for Minuit2 fit to weighted RooDataSet with SumW2Error correction.";
    EXPECT_TRUE(fit(dataHistWeighted, 1, 0, "Minuit2")->isIdenticalNoCov(*fit(dataHistWeighted, 1, 1, "Minuit2")))
       << " different results for Minuit2 fit to weighted RooDataHist with SumW2Error correction.";
+}
+
+TEST(SumW2Error, ExtendedFit)
+{
+   using namespace RooFit;
+
+   RooWorkspace ws("workspace");
+   auto *x = static_cast<RooRealVar *>(ws.factory("x[-10, 10]"));
+   x->setRange("subrange", -5.0, 5.0);
+   ws.factory("Gaussian::sig(x, mu[-1, 1], s[0.1, 5])");
+   ws.factory("Chebychev::bkg(x, {c1[0.1, -1, 1]})");
+   auto *shp = static_cast<RooAddPdf *>(ws.factory("SUM::shp(Nsig[0, 20000] * sig, Nbkg[0, 20000] * bkg)"));
+   std::unique_ptr<RooDataSet> dataNoWeights{shp->generate(RooArgSet(*x))};
+   auto *wFunc = ws.factory("w[0.1]");
+   auto *w = dataNoWeights->addColumn(*wFunc);
+   RooDataSet data{dataNoWeights->GetName(),
+                   dataNoWeights->GetTitle(),
+                   dataNoWeights.get(),
+                   *dataNoWeights->get(),
+                   "",
+                   w->GetName()};
+   RooDataHist datahist{"datahist", "datahist", *data.get(), data};
+
+   std::vector<std::pair<std::string, double>> inVals;
+   for (auto const *v : ws.allVars()) {
+      inVals.emplace_back(v->GetName(), static_cast<RooRealVar const *>(v)->getVal());
+   }
+
+   auto resetVals = [&]() {
+      for (auto const &item : inVals) {
+         ws.var(item.first)->setError(0.0);
+         ws.var(item.first)->setVal(item.second);
+      }
+   };
+
+   auto doFit = [&](bool batchMode, bool sumW2Error, const char *range) {
+      resetVals();
+      return std::unique_ptr<RooFitResult>{shp->fitTo(datahist, Extended(), Range(range), Save(),
+                                                      SumW2Error(sumW2Error), Strategy(1), PrintLevel(-1),
+                                                      BatchMode(batchMode), Minimizer("Minuit2", "migrad"))};
+   };
+
+   // compare batch mode and scalar mode fit results for full range
+   {
+      auto yy = doFit(true, true, nullptr);
+      auto yn = doFit(true, false, nullptr);
+      auto ny = doFit(false, true, nullptr);
+      auto nn = doFit(false, false, nullptr);
+
+      EXPECT_TRUE(yy->isIdenticalNoCov(*ny)) << "different results for extended fit with SumW2Error in BatchMode";
+      EXPECT_TRUE(yn->isIdenticalNoCov(*nn)) << "different results for extended fit without SumW2Error in BatchMode";
+   }
 }


### PR DESCRIPTION
The extended term needs a special correction, it should not just be
reevaluated with the squared weights replacing the weights. This is not
implemented correctly.

The way how weights are handled in the batch mode was also simplified.
Previously, a dummy `RooRealVar` was created for the weight and the
squared weight each, but now the conventional name for the weight
variable is used directly to look up the names in the data map.

In the second commit, a unit test is added for this, inspired by the following forum post:
https://root-forum.cern.ch/t/batchmode-gives-wrong-errors-with-sumw2errors/49597/8
