### PR TITLE
Use more override syntax in main interface classes

### DIFF
--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -97,7 +97,7 @@ protected:
 
 public:
    TApplication(const char *appClassName, Int_t *argc, char **argv,
-                void *options = 0, Int_t numOptions = 0);
+                void *options = nullptr, Int_t numOptions = 0);
    virtual ~TApplication();
 
    void            InitializeGraphics();
@@ -110,8 +110,8 @@ public:
    virtual void    HandleIdleTimer();   //*SIGNAL*
    virtual Bool_t  HandleTermInput() { return kFALSE; }
    virtual void    Init() { fAppImp->Init(); }
-   virtual Longptr_t ProcessLine(const char *line, Bool_t sync = kFALSE, Int_t *error = 0);
-   virtual Longptr_t ProcessFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
+   virtual Longptr_t ProcessLine(const char *line, Bool_t sync = kFALSE, Int_t *error = nullptr);
+   virtual Longptr_t ProcessFile(const char *file, Int_t *error = nullptr, Bool_t keep = kFALSE);
    virtual void    Run(Bool_t retrn = kFALSE);
    virtual void    SetIdleTimer(UInt_t idleTimeInSec, const char *command);
    virtual void    RemoveIdleTimer();
@@ -130,7 +130,7 @@ public:
    virtual Bool_t  IsCmdThread() { return fAppImp ? fAppImp->IsCmdThread() : kTRUE; }
    virtual TApplicationImp *GetApplicationImp() { return fAppImp;}
 
-   virtual void    ls(Option_t *option="") const;
+   void            ls(Option_t *option="") const override;
 
    Int_t           Argc() const  { return fArgc; }
    char          **Argv() const  { return fArgv; }
@@ -154,12 +154,12 @@ public:
    virtual void    ReturnPressed(char *text );        //*SIGNAL*
    virtual Int_t   TabCompletionHook(char *buf, int *pLoc, std::ostream& out);
 
-   static Longptr_t ExecuteFile(const char *file, Int_t *error = 0, Bool_t keep = kFALSE);
+   static Longptr_t ExecuteFile(const char *file, Int_t *error = nullptr, Bool_t keep = kFALSE);
    static TList   *GetApplications();
    static void     CreateApplication();
    static void     NeedGraphicsLibs();
 
-   ClassDef(TApplication,0)  //GUI application singleton
+   ClassDefOverride(TApplication,0)  //GUI application singleton
 };
 
 R__EXTERN TApplication *gApplication;

--- a/core/base/inc/TBuffer3D.h
+++ b/core/base/inc/TBuffer3D.h
@@ -118,7 +118,7 @@ public:
    mutable UInt_t fPhysicalID;   // Unique replica ID.
 
 
-   ClassDef(TBuffer3D,0)     // 3D primitives description
+   ClassDefOverride(TBuffer3D,0)     // 3D primitives description
 };
 
 /** \class TBuffer3DSphere

--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -39,7 +39,7 @@ public:
    TColor &operator=(const TColor &color);
    virtual ~TColor();
    const char   *AsHexString() const;
-   void          Copy(TObject &color) const;
+   void          Copy(TObject &color) const override;
    static void   CreateColorWheel();
    static void   CreateColorsGray();
    static void   CreateColorsCircle(Int_t offset, const char *name, UChar_t *rgb);
@@ -63,8 +63,8 @@ public:
    Float_t       GetSaturation() const { return IsGrayscale() ? 0 : fSaturation; }
    Float_t       GetAlpha() const { return fAlpha; }
    virtual Float_t GetGrayscale() const { /*ITU*/ return 0.299f*fRed + 0.587f*fGreen + 0.114f*fBlue; }
-   virtual void  ls(Option_t *option="") const;
-   virtual void  Print(Option_t *option="") const;
+   void          ls(Option_t *option="") const override;
+   void          Print(Option_t *option="") const override;
    virtual void  SetAlpha(Float_t a) { fAlpha = a; }
    virtual void  SetRGB(Float_t r, Float_t g, Float_t b);
 
@@ -100,9 +100,9 @@ public:
    static void    InvertPalette();
    static Bool_t  IsGrayscale();
    static void    SetGrayscale(Bool_t set = kTRUE);
-   static void    SetPalette(Int_t ncolors, Int_t *colors,Float_t alpha=1.);
+   static void    SetPalette(Int_t ncolors, Int_t *colors, Float_t alpha=1.);
 
-   ClassDef(TColor,2)  //Color defined by RGB or HLS
+   ClassDefOverride(TColor,2)  //Color defined by RGB or HLS
 };
 
    enum EColorPalette {kDeepSea=51,          kGreyScale=52,    kDarkBodyRadiator=53,

--- a/core/base/inc/TColorGradient.h
+++ b/core/base/inc/TColorGradient.h
@@ -84,16 +84,16 @@ public:
                    const Double_t *colorIndices);
 
    void SetCoordinateMode(ECoordinateMode mode);
-   ECoordinateMode GetCoordinateMode()const;
+   ECoordinateMode GetCoordinateMode() const;
 
-   SizeType_t GetNumberOfSteps()const;
-   const Double_t *GetColorPositions()const;
-   const Double_t *GetColors()const;
+   SizeType_t GetNumberOfSteps() const;
+   const Double_t *GetColorPositions() const;
+   const Double_t *GetColors() const;
 
 private:
    void RegisterColor(Color_t colorIndex);
 
-   ClassDef(TColorGradient, 0); //Gradient fill.
+   ClassDefOverride(TColorGradient, 0); //Gradient fill.
 };
 
 class TLinearGradient : public TColorGradient {
@@ -107,14 +107,14 @@ public:
 
    //points are always in NDC (and also affected by fCoordinateMode).
    void SetStartEnd(const Point &p1, const Point &p2);
-   const Point &GetStart()const;
-   const Point &GetEnd()const;
+   const Point &GetStart() const;
+   const Point &GetEnd() const;
 
 private:
    Point fStart;
    Point fEnd;
 
-   ClassDef(TLinearGradient, 0); //Linear gradient fill.
+   ClassDefOverride(TLinearGradient, 0); //Linear gradient fill.
 };
 
 //
@@ -147,10 +147,10 @@ public:
    //Extended gradient.
    void SetStartEndR1R2(const Point &p1, Double_t r1,
                         const Point &p2, Double_t r2);
-   const Point &GetStart()const;
-   Double_t GetR1()const;
-   const Point &GetEnd()const;
-   Double_t GetR2()const;
+   const Point &GetStart() const;
+   Double_t GetR1() const;
+   const Point &GetEnd() const;
+   Double_t GetR2() const;
 
    //Simple radial gradient: the same as extended with
    //start == end, r1 = 0, r2 = radius.
@@ -166,7 +166,7 @@ private:
 
    EGradientType fType = kSimple;
 
-   ClassDef(TRadialGradient, 0); //Radial gradient fill.
+   ClassDefOverride(TRadialGradient, 0); //Radial gradient fill.
 };
 
 

--- a/core/base/inc/TEnv.h
+++ b/core/base/inc/TEnv.h
@@ -98,7 +98,7 @@ private:
    Bool_t      fModified;   // if env rec has been modified
 
    TEnvRec(const char *n, const char *v, const char *t, EEnvLevel l);
-   Int_t    Compare(const TObject *obj) const;
+   Int_t    Compare(const TObject *obj) const override;
    void     ChangeValue(const char *v, const char *t, EEnvLevel l,
                         Bool_t append = kFALSE, Bool_t ignoredup = kFALSE);
    TString  ExpandValue(const char *v);
@@ -106,13 +106,13 @@ private:
 public:
    TEnvRec(): fName(), fType(), fValue(), fLevel(kEnvAll), fModified(kTRUE) { }
    ~TEnvRec();
-   const char *GetName() const { return fName; }
+   const char *GetName() const override { return fName; }
    const char *GetValue() const { return fValue; }
    const char *GetType() const { return fType; }
    EEnvLevel   GetLevel() const { return fLevel; }
-   ULong_t     Hash() const { return fName.Hash(); }
+   ULong_t     Hash() const override { return fName.Hash(); }
 
-   ClassDef(TEnvRec,2)  // Individual TEnv records
+   ClassDefOverride(TEnvRec,2)  // Individual TEnv records
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -160,11 +160,11 @@ public:
    virtual Int_t       WriteFile(const char *fname, EEnvLevel level = kEnvAll);
    virtual void        Save();
    virtual void        SaveLevel(EEnvLevel level);
-   virtual void        Print(Option_t *option="") const;
+   void                Print(Option_t *option="") const override;
    virtual void        PrintEnv(EEnvLevel level = kEnvAll) const;
    Bool_t              IgnoreDuplicates(Bool_t ignore);
 
-   ClassDef(TEnv,2)  // Handle ROOT configuration resources
+   ClassDefOverride(TEnv,2)  // Handle ROOT configuration resources
 };
 
 R__EXTERN TEnv *gEnv;

--- a/core/base/inc/TExec.h
+++ b/core/base/inc/TExec.h
@@ -34,11 +34,11 @@ public:
    TExec(const TExec &text);
    virtual ~TExec();
    virtual void     Exec(const char *command="");
-   virtual void     Paint(Option_t *option="");
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             Paint(Option_t *option="") override;
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetAction(const char *action) {SetTitle(action);}
 
-   ClassDef(TExec,1);  //To execute a CINT command
+   ClassDefOverride(TExec,1);  //To execute a CINT command
 };
 
 #endif

--- a/core/base/inc/TFileCollection.h
+++ b/core/base/inc/TFileCollection.h
@@ -77,7 +77,7 @@ public:
    Int_t           Update(Long64_t avgsize = -1);
    void            Sort(Bool_t useindex = kFALSE);
    void            SetAnchor(const char *anchor);
-   void            Print(Option_t *option = "") const;
+   void            Print(Option_t *option = "") const override;
 
    void            SetBitAll(UInt_t f);
    void            ResetBitAll(UInt_t f);
@@ -95,17 +95,17 @@ public:
    void            SetDefaultTreeName(const char* treeName) { fDefaultTree = treeName; }
    Long64_t        GetTotalEntries(const char *tree) const;
 
-   TFileInfoMeta  *GetMetaData(const char *meta = 0) const;
+   TFileInfoMeta  *GetMetaData(const char *meta = nullptr) const;
    void            SetDefaultMetaData(const char *meta);
    Bool_t          AddMetaData(TObject *meta);
-   void            RemoveMetaData(const char *meta = 0);
+   void            RemoveMetaData(const char *meta = nullptr);
 
    TFileCollection *GetStagedSubset();
 
    TFileCollection *GetFilesOnServer(const char *server);
    TMap            *GetFilesPerServer(const char *exclude = 0, Bool_t curronly =  kFALSE);
 
-   ClassDef(TFileCollection, 3)  // Collection of TFileInfo objects
+   ClassDefOverride(TFileCollection, 3)  // Collection of TFileInfo objects
 };
 
 #endif

--- a/core/base/inc/TFileInfo.h
+++ b/core/base/inc/TFileInfo.h
@@ -60,8 +60,8 @@ public:
       kSortWithIndex  = BIT(17)     // Use index when sorting (in Compare)
    };
 
-   TFileInfo(const char *url = 0, Long64_t size = -1, const char *uuid = 0,
-             const char *md5 = 0, TObject *meta = 0);
+   TFileInfo(const char *url = 0, Long64_t size = -1, const char *uuid = nullptr,
+             const char *md5 = nullptr, TObject *meta = nullptr);
    TFileInfo(const TFileInfo &);
 
    virtual ~TFileInfo();
@@ -91,17 +91,17 @@ public:
    Bool_t          AddUrl(const char *url, Bool_t infront = kFALSE);
    Bool_t          RemoveUrl(const char *url);
    Bool_t          AddMetaData(TObject *meta);
-   Bool_t          RemoveMetaData(const char *meta = 0);
+   Bool_t          RemoveMetaData(const char *meta = nullptr);
 
-   Bool_t          IsSortable() const { return kTRUE; }
-   Int_t           Compare(const TObject *obj) const;
+   Bool_t          IsSortable() const override { return kTRUE; }
+   Int_t           Compare(const TObject *obj) const override;
 
    Int_t           GetIndex() const { return fIndex; }
    void            SetIndex(Int_t idx) { fIndex = idx; }
 
-   void            Print(Option_t *options="") const;
+   void            Print(Option_t *options="") const override;
 
-   ClassDef(TFileInfo,4)   // Describes generic file info including meta data information
+   ClassDefOverride(TFileInfo,4)   // Describes generic file info including meta data information
 };
 
 
@@ -150,9 +150,9 @@ public:
    void            SetTotBytes(Long64_t tot)    { fTotBytes = tot; }
    void            SetZipBytes(Long64_t zip)    { fZipBytes = zip; }
 
-   void            Print(Option_t *options="") const;
+   void            Print(Option_t *options="") const override;
 
-   ClassDef(TFileInfoMeta,2)   // Describes TFileInfo meta data
+   ClassDefOverride(TFileInfoMeta,2)   // Describes TFileInfo meta data
 };
 
 #endif

--- a/core/base/inc/TInetAddress.h
+++ b/core/base/inc/TInetAddress.h
@@ -74,11 +74,11 @@ public:
    const AddressList_t &GetAddresses() const { return fAddresses; }
    const AliasList_t   &GetAliases() const { return fAliases; }
    Bool_t      IsValid() const { return fFamily == -1 ? kFALSE : kTRUE; }
-   void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
 
    static const char *GetHostAddress(UInt_t addr);
 
-   ClassDef(TInetAddress,4)  //Represents an Internet Protocol (IP) address
+   ClassDefOverride(TInetAddress,4)  //Represents an Internet Protocol (IP) address
 };
 
 #endif

--- a/core/base/inc/TMacro.h
+++ b/core/base/inc/TMacro.h
@@ -43,20 +43,20 @@ public:
    virtual ~TMacro();
    TMacro& operator=(const TMacro&);
    virtual TObjString  *AddLine(const char *text);
-   virtual void         Browse(TBrowser *b);
+   void                 Browse(TBrowser *b) override;
    virtual TMD5        *Checksum();
    virtual TObjString  *GetLineWith(const char *text) const;
    virtual Bool_t       Load() const; //*MENU*
    virtual Longptr_t    Exec(const char *params = 0, Int_t* error = 0); //*MENU*
    TList               *GetListOfLines() const {return fLines;}
-   virtual void         Paint(Option_t *option="");
-   virtual void         Print(Option_t *option="") const;  //*MENU*
+   void                 Paint(Option_t *option="") override;
+   void                 Print(Option_t *option="") const override;  //*MENU*
    virtual Int_t        ReadFile(const char *filename);
    virtual void         SaveSource(const char *filename);  //*MENU*
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
+   void                 SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void         SetParams(const char *params=0); //*MENU*
 
-   ClassDef(TMacro,1)  // Class supporting a collection of lines with C++ code.
+   ClassDefOverride(TMacro,1)  // Class supporting a collection of lines with C++ code.
 };
 
 #endif

--- a/core/base/inc/TMessageHandler.h
+++ b/core/base/inc/TMessageHandler.h
@@ -42,7 +42,7 @@ protected:
    Long_t         *fMessIds;    // message ids
    Bool_t          fDerived;    // if true handle messages also for derived classes
 
-   void  *GetSender() { return this; }  //used to set gTQSender
+   void  *GetSender() override { return this; }  //used to set gTQSender
 
 public:
    TMessageHandler(const TClass *cl, Bool_t derived = kTRUE);
@@ -55,17 +55,17 @@ public:
    Bool_t          HandleDerived() const { return fDerived; }
    virtual void    HandleMessage(Long_t id, const TObject *obj);
 
-   virtual void    Print(Option_t *option= "") const;
+   void            Print(Option_t *option= "") const override;
 
    virtual void    Add();
    virtual void    Remove();
-   virtual Bool_t  Notify();
+   Bool_t          Notify() override;
 
    virtual void    Added()    { Emit("Added()"); }       //*SIGNAL*
    virtual void    Removed()  { Emit("Removed()"); }     //*SIGNAL*
    virtual void    Notified() { Emit("Notified()"); }    //*SIGNAL*
 
-   ClassDef(TMessageHandler,0)  // Generic message handler
+   ClassDefOverride(TMessageHandler,0)  // Generic message handler
 };
 
 #endif

--- a/core/base/inc/TNotifyLink.h
+++ b/core/base/inc/TNotifyLink.h
@@ -40,7 +40,8 @@ public:
       kLinked = BIT(11) // Used when the TNotifyLink is connected to a TTree.
    };
 
-   void Clear(Option_t * /*option*/ ="") {
+   void Clear(Option_t * /*option*/ ="") override
+   {
       auto current = this;
       do {
          auto next = dynamic_cast<TNotifyLinkBase*>(fNext);
@@ -52,7 +53,8 @@ public:
    }
 
    template <class Notifier>
-   void PrependLink(Notifier &notifier) {
+   void PrependLink(Notifier &notifier)
+   {
       SetBit(kLinked);
 
       fNext = notifier.GetNotify();
@@ -63,7 +65,8 @@ public:
    }
 
    template <class Notifier>
-   void RemoveLink(Notifier &notifier) {
+   void RemoveLink(Notifier &notifier)
+   {
       ResetBit(kLinked);
 
       if (notifier.GetNotify() == this) {
@@ -79,11 +82,12 @@ public:
       fNext = nullptr;
    }
 
-   Bool_t IsLinked() {
+   Bool_t IsLinked()
+   {
       return TestBit(kLinked);
    }
 
-   ClassDef(TNotifyLinkBase, 0);
+   ClassDefOverride(TNotifyLinkBase, 0);
 };
 
 template <class Type>

--- a/core/base/inc/TObjString.h
+++ b/core/base/inc/TObjString.h
@@ -33,21 +33,21 @@ private:
 public:
    TObjString(const char *s = "") : fString(s) { }
    ~TObjString();
-   Int_t       Compare(const TObject *obj) const;
+   Int_t       Compare(const TObject *obj) const override;
    TString     CopyString() const { return fString; }
-   const char *GetName() const { return fString; }
-   ULong_t     Hash() const { return fString.Hash(); }
+   const char *GetName() const override { return fString; }
+   ULong_t     Hash() const override { return fString.Hash(); }
    void        FillBuffer(char *&buffer) { fString.FillBuffer(buffer); }
-   void        Print(Option_t *) const { Printf("TObjString = %s", (const char*)fString); }
-   Bool_t      IsSortable() const { return kTRUE; }
-   Bool_t      IsEqual(const TObject *obj) const;
+   void        Print(Option_t *) const override { Printf("TObjString = %s", (const char*)fString); }
+   Bool_t      IsSortable() const override { return kTRUE; }
+   Bool_t      IsEqual(const TObject *obj) const override;
    void        ReadBuffer(char *&buffer) { fString.ReadBuffer(buffer); }
    void        SetString(const char *s) { fString = s; }
    const TString &GetString() const { return fString; }
    Int_t       Sizeof() const { return fString.Sizeof(); }
    TString    &String() { return fString; }
 
-   ClassDef(TObjString,1)  //Collectable string class
+   ClassDefOverride(TObjString,1)  //Collectable string class
 };
 
 #endif

--- a/core/base/inc/TParameter.h
+++ b/core/base/inc/TParameter.h
@@ -63,7 +63,7 @@ public:
       ROOT::CallRecursiveRemoveIfNeeded(*this);
    }
 
-   const char       *GetName() const { return fName; }
+   const char       *GetName() const override { return fName; }
    const AParamType &GetVal() const { return fVal; }
    Bool_t            IsConst() const { return (TestBit(kIsConst) ? kTRUE : kFALSE); }
    void              SetVal(const AParamType &val) { fVal = val; }
@@ -75,7 +75,7 @@ public:
    //  'm'             minimum ('AND' for booleans)
    //  'f'             first value
    //  'l'             last value
-   void  SetMergeMode(char mergemode = '+') {
+   void SetMergeMode(char mergemode = '+') {
       Reset();
       if (mergemode == '*') {
          SetBit(kMultiply);
@@ -89,9 +89,10 @@ public:
          SetBit(kLast);
       }
    }
-   virtual ULong_t  Hash() const { return fName.Hash(); }
-   virtual Bool_t   IsSortable() const { return kTRUE; }
-   virtual Int_t    Compare(const TObject *obj) const {
+   ULong_t  Hash() const override { return fName.Hash(); }
+   Bool_t   IsSortable() const override { return kTRUE; }
+   Int_t    Compare(const TObject *obj) const override
+   {
       // Compare two TParameter objects. Returns 0 when equal, -1 when this is
       // smaller and +1 when bigger (like strcmp).
 
@@ -99,13 +100,15 @@ public:
       return fName.CompareTo(obj->GetName());
    }
 
-   virtual void ls(Option_t *) const {
+   void ls(Option_t *) const override
+   {
       // Print this parameter content
       TROOT::IndentLevel();
       std::cout << "OBJ: " << IsA()->GetName() << "\t" << fName << " = " << fVal << std::endl;
    }
 
-   virtual void Print(Option_t *) const {
+   void Print(Option_t *) const override
+   {
       // Print this parameter content
       TROOT::IndentLevel();
       std::cout << IsA()->GetName() << "\t" << fName << " = " << fVal << std::endl;
@@ -113,7 +116,7 @@ public:
 
    virtual Int_t Merge(TCollection *in);
 
-   ClassDef(TParameter,2)  //Named templated parameter type
+   ClassDefOverride(TParameter,2)  //Named templated parameter type
 };
 
 template <class AParamType>

--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -172,9 +172,9 @@ public:
       return ExecPluginImpl(params...);
    }
 
-   void        Print(Option_t *opt = "") const;
+   void        Print(Option_t *opt = "") const override;
 
-   ClassDef(TPluginHandler,3)  // Handler for plugin libraries
+   ClassDefOverride(TPluginHandler,3)  // Handler for plugin libraries
 };
 
 
@@ -202,11 +202,11 @@ public:
 
    TPluginHandler *FindHandler(const char *base, const char *uri = 0);
 
-   void   Print(Option_t *opt = "") const;
+   void   Print(Option_t *opt = "") const override;
    Int_t  WritePluginMacros(const char *dir, const char *plugin = 0) const;
    Int_t  WritePluginRecords(const char *envFile, const char *plugin = 0) const;
 
-   ClassDef(TPluginManager,1)  // Manager for plugin handlers
+   ClassDefOverride(TPluginManager,1)  // Manager for plugin handlers
 };
 
 R__EXTERN TPluginManager *gPluginMgr;

--- a/core/base/inc/TProcessID.h
+++ b/core/base/inc/TProcessID.h
@@ -74,8 +74,8 @@ namespace ROOT {
 class TProcessID : public TNamed {
 
 private:
-   TProcessID(const TProcessID &ref);            // TProcessID are not copiable.
-   TProcessID& operator=(const TProcessID &ref); // TProcessID are not copiable.
+   TProcessID(const TProcessID &ref) = delete;
+   TProcessID& operator=(const TProcessID &ref) = delete;
 
 protected:
    std::atomic_int    fCount;                           //!Reference count to this object (from TFile)
@@ -92,14 +92,14 @@ public:
    TProcessID();
    virtual ~TProcessID();
    void             CheckInit();
-   virtual void     Clear(Option_t *option="");
+   void             Clear(Option_t *option="") override;
    Int_t            DecrementCount();
    Int_t            IncrementCount();
    Int_t            GetCount() const {return fCount;}
    TObjArray       *GetObjects() const {return fObjects;}
    TObject         *GetObjectWithID(UInt_t uid);
-   void             PutObjectWithID(TObject *obj, UInt_t uid=0);
-   virtual void     RecursiveRemove(TObject *obj);
+   void             PutObjectWithID(TObject *obj, UInt_t uid = 0);
+   void             RecursiveRemove(TObject *obj) override;
 
    static TProcessID  *AddProcessID();
    static UInt_t       AssignID(TObject *obj);
@@ -115,7 +115,7 @@ public:
    static  Bool_t      IsValid(TProcessID *pid);
    static  void        SetObjectCount(UInt_t number);
 
-   ClassDef(TProcessID,1)  //Process Unique Identifier in time and space
+   ClassDefOverride(TProcessID,1)  //Process Unique Identifier in time and space
 };
 
 #endif

--- a/core/base/inc/TProcessUUID.h
+++ b/core/base/inc/TProcessUUID.h
@@ -32,8 +32,8 @@ class TObjString;
 class TProcessUUID : public TProcessID {
 
 private:
-   TProcessUUID(const TProcessID&);              // TProcessUUID are not copiable.
-   TProcessUUID &operator=(const TProcessUUID&); // TProcessUUID are not copiable.
+   TProcessUUID(const TProcessID&) = delete;
+   TProcessUUID &operator=(const TProcessUUID&) = delete;
 
 protected:
    TList       *fUUIDs;        //Global list of TUUIDs
@@ -50,7 +50,7 @@ public:
    TList             *GetUUIDs()  const {return fUUIDs;}
    void               RemoveUUID(UInt_t number);
 
-   ClassDef(TProcessUUID,1)  //TProcessID managing UUIDs
+   ClassDefOverride(TProcessUUID,1)  //TProcessID managing UUIDs
 };
 
 #endif

--- a/core/base/inc/TQClass.h
+++ b/core/base/inc/TQClass.h
@@ -33,22 +33,22 @@
 class TQClass : public TQObject, public TClass {
 
 private:
-   TQClass(const TClass&) : TQObject(), TClass() {};
-   TQClass& operator=(const TQClass&) { return *this; }
+   TQClass(const TClass&) = delete;
+   TQClass& operator=(const TQClass&) = delete;
 
 friend class TQObject;
 
 public:
    TQClass(const char *name, Version_t cversion,
            const std::type_info &info, TVirtualIsAProxy *isa,
-           const char *dfil = 0, const char *ifil = 0,
+           const char *dfil = nullptr, const char *ifil = nullptr,
            Int_t dl = 0, Int_t il = 0) :
            TQObject(),
            TClass(name, cversion, info,isa,dfil, ifil, dl, il) { }
 
    virtual ~TQClass() { Disconnect(); }
 
-   ClassDef(TQClass,0)  // Class with connections
+   ClassDefOverride(TQClass,0)  // Class with connections
 };
 
 
@@ -62,10 +62,10 @@ namespace Internal {
    class TDefaultInitBehavior;
    class TQObjectInitBehavior : public TDefaultInitBehavior {
    public:
-      virtual TClass *CreateClass(const char *cname, Version_t id,
-                                  const std::type_info &info, TVirtualIsAProxy *isa,
-                                  const char *dfil, const char *ifil,
-                                  Int_t dl, Int_t il) const
+      TClass *CreateClass(const char *cname, Version_t id,
+                          const std::type_info &info, TVirtualIsAProxy *isa,
+                          const char *dfil, const char *ifil,
+                          Int_t dl, Int_t il) const override
       {
          return new TQClass(cname, id, info, isa, dfil, ifil,dl, il);
       }

--- a/core/base/inc/TQCommand.h
+++ b/core/base/inc/TQCommand.h
@@ -44,7 +44,7 @@ protected:
 
    virtual void Init(const char *cl, void *object,
                      const char *redo, const char *undo);
-   virtual void PrintCollectionHeader(Option_t* option) const;
+   void PrintCollectionHeader(Option_t* option) const override;
 
 private:
    TQCommand &operator=(const TQCommand &); // Not yet implemented.
@@ -66,7 +66,7 @@ public:
    virtual Long64_t Merge(TCollection*,TFileMergeInfo*);
    virtual Bool_t CanCompress(TQCommand *c) const;
    virtual void   Compress(TQCommand *c);
-   virtual Bool_t IsEqual(const TObject* obj) const;
+   Bool_t         IsEqual(const TObject* obj) const override;
    virtual Bool_t IsSetter() const;
    virtual Bool_t CanRedo() const;
    virtual Bool_t CanUndo() const;
@@ -86,16 +86,16 @@ public:
    Bool_t         IsExecuting() const;
    virtual void   SetName(const char *name);
    virtual void   SetTitle(const char *title);
-   virtual void   ls(Option_t *option="") const;
-   virtual void   Add(TObject *obj, Option_t *opt);
-   virtual void   Add(TObject *obj) { Add(obj, 0); }
-   virtual void   Delete(Option_t *option="");
-   virtual const char *GetName() const;
-   virtual const char *GetTitle() const;
+   void           ls(Option_t *option="") const override;
+   void           Add(TObject *obj, Option_t *opt) override;
+   void           Add(TObject *obj) override { Add(obj, 0); }
+   void           Delete(Option_t *option="") override;
+   const char    *GetName() const override;
+   const char    *GetTitle() const override;
 
    static TQCommand *GetCommand();
 
-   ClassDef(TQCommand,0) // encapsulates the information for undo/redo a single action.
+   ClassDefOverride(TQCommand,0) // encapsulates the information for undo/redo a single action.
 };
 
 
@@ -109,18 +109,18 @@ protected:
    TList      *fLogBook; // listing of all actions during execution
    Bool_t      fLogging; // kTRUE if logging is ON
 
-   virtual void PrintCollectionEntry(TObject* entry, Option_t* option, Int_t recurse) const;
+   void PrintCollectionEntry(TObject* entry, Option_t* option, Int_t recurse) const override;
 
 public:
    TQUndoManager();
    virtual ~TQUndoManager();
 
-   virtual void   Add(TObject *obj, Option_t *opt);
-   virtual void   Add(TObject *obj) { Add(obj, 0); }
-   virtual void   Redo(Option_t *option="");
-   virtual void   Undo(Option_t *option="");
-   virtual Bool_t CanRedo() const;
-   virtual Bool_t CanUndo() const;
+   void           Add(TObject *obj, Option_t *opt) override;
+   void           Add(TObject *obj) override { Add(obj, nullptr); }
+   void           Redo(Option_t *option="") override;
+   void           Undo(Option_t *option="") override;
+   Bool_t         CanRedo() const override;
+   Bool_t         CanUndo() const override;
    virtual void   SetLogging(Bool_t on = kTRUE);
    Bool_t         IsLogging() const;
    TQCommand     *GetCurrent() const;
@@ -128,9 +128,9 @@ public:
    UInt_t         GetLimit() const;
    virtual void   SetLimit(UInt_t limit);
    virtual void   CurrentChanged(TQCommand *c); //*SIGNAL*
-   virtual void   ls(Option_t *option="") const;
+   void           ls(Option_t *option="") const override;
 
-   ClassDef(TQUndoManager,0) // recorder of operations for undo and redo
+   ClassDefOverride(TQUndoManager,0) // recorder of operations for undo and redo
 };
 
 #endif

--- a/core/base/inc/TQConnection.h
+++ b/core/base/inc/TQConnection.h
@@ -36,8 +36,8 @@ class TQSlot;
 
 class TQConnection : public TVirtualQConnection, public TQObject {
 protected:
-   TQSlot  *fSlot = 0;       // slot-method calling interface
-   void    *fReceiver = 0;   // ptr to object to which slot is applied
+   TQSlot  *fSlot = nullptr;       // slot-method calling interface
+   void    *fReceiver = nullptr;   // ptr to object to which slot is applied
    TString  fClassName;  // class name of the receiver
 
    virtual void PrintCollectionHeader(Option_t* option) const override;
@@ -46,19 +46,19 @@ protected:
    void       *GetSlotAddress() const;
    CallFunc_t *LockSlot() const;
    void        UnLockSlot(TQSlot *) const;
-   virtual CallFunc_t *GetSlotCallFunc() const override;
+   CallFunc_t *GetSlotCallFunc() const override;
 
    TQConnection &operator=(const TQConnection &) = delete;
 
-   virtual void SetArg(Long_t param) override { SetArgImpl(param); }
-   virtual void SetArg(ULong_t param) override { SetArgImpl(param); }
-   virtual void SetArg(Float_t param) override { SetArgImpl(param); }
-   virtual void SetArg(Double_t param) override { SetArgImpl(param); }
-   virtual void SetArg(Long64_t param) override { SetArgImpl(param); }
-   virtual void SetArg(ULong64_t param) override { SetArgImpl(param); }
-   virtual void SetArg(const char * param) override { SetArgImpl(param); }
+   void SetArg(Long_t param) override { SetArgImpl(param); }
+   void SetArg(ULong_t param) override { SetArgImpl(param); }
+   void SetArg(Float_t param) override { SetArgImpl(param); }
+   void SetArg(Double_t param) override { SetArgImpl(param); }
+   void SetArg(Long64_t param) override { SetArgImpl(param); }
+   void SetArg(ULong64_t param) override { SetArgImpl(param); }
+   void SetArg(const char * param) override { SetArgImpl(param); }
 
-   virtual void SetArg(const Longptr_t *params, Int_t nparam = -1) override;
+   void SetArg(const Longptr_t *params, Int_t nparam = -1) override;
 
    template <typename T> void SetArgImpl(T arg)
    {
@@ -66,7 +66,7 @@ protected:
       gInterpreter->CallFunc_SetArg(func, arg);
    }
 
-   virtual void SendSignal() override
+   void SendSignal() override
    {
       CallFunc_t *func = LockSlot();
 

--- a/core/base/inc/TQObject.h
+++ b/core/base/inc/TQObject.h
@@ -236,22 +236,22 @@ protected:
    void    *fSender;        //delegation object
    TString  fSenderClass;   //class name of delegation object
 
-   virtual void       *GetSender() { return fSender; }
-   virtual const char *GetSenderClassName() const { return fSenderClass; }
+   void       *GetSender() override { return fSender; }
+   const char *GetSenderClassName() const override { return fSenderClass.Data(); }
 
 private:
    TQObjSender(const TQObjSender&) = delete;
    TQObjSender& operator=(const TQObjSender&) = delete;
 
 public:
-   TQObjSender() : TQObject(), fSender(0), fSenderClass() { }
+   TQObjSender() : TQObject(), fSender(nullptr), fSenderClass() { }
    virtual ~TQObjSender() { Disconnect(); }
 
    virtual void SetSender(void *sender) { fSender = sender; }
    void SetSenderClassName(const char *sclass = "") { fSenderClass = sclass; }
 
-   ClassDef(TQObjSender,0) //Used to "delegate" TQObject functionality
-                           //to interpreted classes, see also RQ_OBJECT.h
+   ClassDefOverride(TQObjSender,0) //Used to "delegate" TQObject functionality
+                                   //to interpreted classes, see also RQ_OBJECT.h
 };
 
 

--- a/core/base/inc/TRef.h
+++ b/core/base/inc/TRef.h
@@ -61,7 +61,7 @@ public:
    friend Bool_t operator==(const TRef &r1, const TRef &r2);
    friend Bool_t operator!=(const TRef &r1, const TRef &r2);
 
-   ClassDef(TRef,1)  //Persistent Reference link to a TObject
+   ClassDefOverride(TRef,1)  //Persistent Reference link to a TObject
 };
 
 #endif

--- a/core/base/inc/TRemoteObject.h
+++ b/core/base/inc/TRemoteObject.h
@@ -47,8 +47,8 @@ public:
 
    virtual ~TRemoteObject();
 
-   virtual void            Browse(TBrowser *b);
-   Bool_t                  IsFolder() const { return fIsFolder; }
+   void                    Browse(TBrowser *b) override;
+   Bool_t                  IsFolder() const override { return fIsFolder; }
    TList                  *Browse();
    Bool_t                  GetFileStat(FileStat_t *sbuf);
    const char             *GetClassName() const { return fClassName.Data(); }
@@ -59,7 +59,7 @@ public:
    void                    SetKeyClassName(const char *name) { fKeyClassName = name; }
    void                    SetRemoteAddress(Longptr_t addr) { fRemoteAddress = addr; }
 
-   ClassDef(TRemoteObject,0)  //A remote object
+   ClassDefOverride(TRemoteObject,0)  //A remote object
 };
 
 #endif

--- a/core/base/inc/TStopwatch.h
+++ b/core/base/inc/TStopwatch.h
@@ -53,9 +53,9 @@ public:
    void        ResetCpuTime(Double_t time = 0) { Stop();  fTotalCpuTime = time; }
    void        ResetRealTime(Double_t time = 0) { Stop(); fTotalRealTime = time; }
    Double_t    CpuTime();
-   void        Print(Option_t *option="") const;
+   void        Print(Option_t *option="") const override;
 
-   ClassDef(TStopwatch,1)  //A stopwatch which times real and cpu time
+   ClassDefOverride(TStopwatch,1)  //A stopwatch which times real and cpu time
 };
 
 #endif

--- a/core/base/inc/TStyle.h
+++ b/core/base/inc/TStyle.h
@@ -146,18 +146,19 @@ public:
    TStyle(const TStyle &style);
    TStyle& operator=(const TStyle& style);
    virtual          ~TStyle();
-   inline Int_t     AxisChoice(Option_t *axis) const {
+   inline Int_t     AxisChoice(Option_t *axis) const
+   {
       // Return axis number (1 for X, 2 for Y, 3 for Z)
       UChar_t a = *axis;
       a -= (a >= 'x') ? 'x' : 'X'; // toupper and a-='X'; intentional underflow
       return (a > 2) ? 0 : (Int_t)(a+1);
-   };
-   virtual void     Browse(TBrowser *b);
+   }
+   void             Browse(TBrowser *b) override;
    static  void     BuildStyles();
-   virtual void     Copy(TObject &style) const;
+   void             Copy(TObject &style) const override;
    virtual void     cd();
 
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
+   Int_t            DistancetoPrimitive(Int_t px, Int_t py) override;
    Int_t            GetNdivisions(Option_t *axis="X") const;
    TAttText        *GetAttDate() {return &fAttDate;}
    Color_t          GetAxisColor(Option_t *axis="X") const;
@@ -280,7 +281,7 @@ public:
    Float_t          GetLineScalePS() const {return fLineScalePS;}
 
    Bool_t           IsReading() const {return fIsReading;}
-   virtual void     Paint(Option_t *option="");
+   void             Paint(Option_t *option="") override;
    virtual void     Reset(Option_t *option="");
 
    void             SetColorModelPS(Int_t c=0);
@@ -403,10 +404,10 @@ public:
    void             SetIsReading(Bool_t reading=kTRUE);
    void             SetPalette(Int_t ncolors=kBird, Int_t *colors=0, Float_t alpha=1.);
    void             SetPalette(TString fileName, Float_t alpha=1.);
-   void             SavePrimitive(std::ostream &out, Option_t * = "");
-   void             SaveSource(const char *filename, Option_t *option=0);
+   void             SavePrimitive(std::ostream &out, Option_t * = "") override;
+   void             SaveSource(const char *filename, Option_t *option = nullptr);
 
-   ClassDef(TStyle, 19);  //A collection of all graphics attributes
+   ClassDefOverride(TStyle, 19);  //A collection of all graphics attributes
 };
 
 

--- a/core/base/inc/TSysEvtHandler.h
+++ b/core/base/inc/TSysEvtHandler.h
@@ -30,7 +30,7 @@ class TSysEvtHandler : public TObject, public TQObject {
 private:
    Bool_t   fIsActive;    // kTRUE if handler is active, kFALSE if not active
 
-   void  *GetSender() { return this; }  //used to set gTQSender
+   void  *GetSender() override { return this; }  //used to set gTQSender
 
 public:
    TSysEvtHandler() : fIsActive(kTRUE) { }
@@ -42,7 +42,7 @@ public:
 
    virtual void     Add()    = 0;
    virtual void     Remove() = 0;
-   virtual Bool_t   Notify() = 0;
+   virtual Bool_t   Notify() override = 0;
 
    virtual void     Activated()   { Emit("Activated()"); }   //*SIGNAL*
    virtual void     DeActivated() { Emit("DeActivated()"); } //*SIGNAL*
@@ -50,7 +50,7 @@ public:
    virtual void     Added()       { Emit("Added()"); }       //*SIGNAL*
    virtual void     Removed()     { Emit("Removed()"); }     //*SIGNAL*
 
-   ClassDef(TSysEvtHandler,0)  //ABC for handling system events
+   ClassDefOverride(TSysEvtHandler,0)  //ABC for handling system events
 };
 
 
@@ -78,7 +78,7 @@ public:
    virtual ~TFileHandler() { Remove(); }
    int             GetFd() const { return fFileNum; }
    void            SetFd(int fd) { fFileNum = fd; }
-   virtual Bool_t  Notify();
+   Bool_t          Notify() override;
    virtual Bool_t  ReadNotify();
    virtual Bool_t  WriteNotify();
    virtual Bool_t  HasReadInterest();
@@ -89,10 +89,10 @@ public:
    virtual void    SetWriteReady() { fReadyMask |= 0x2; }
    virtual Bool_t  IsReadReady() const { return (fReadyMask & 0x1) == 0x1; }
    virtual Bool_t  IsWriteReady() const { return (fReadyMask & 0x2) == 0x2; }
-   virtual void    Add();
-   virtual void    Remove();
+   void            Add() override;
+   void            Remove() override;
 
-   ClassDef(TFileHandler,0)  //Handles events on file descriptors
+   ClassDefOverride(TFileHandler,0)  //Handles events on file descriptors
 };
 
 
@@ -142,11 +142,11 @@ public:
    void           SetSignal(ESignals sig) { fSignal = sig; }
    Bool_t         IsSync() const { return fSync; }
    Bool_t         IsAsync() const { return !fSync; }
-   virtual Bool_t Notify();
-   virtual void   Add();
-   virtual void   Remove();
+   Bool_t         Notify() override;
+   void           Add() override;
+   void           Remove() override;
 
-   ClassDef(TSignalHandler,0)  //Signal event handler
+   ClassDefOverride(TSignalHandler,0)  //Signal event handler
 };
 
 inline void TSignalHandler::HandleDelayedSignal()
@@ -177,13 +177,13 @@ public:
    TStdExceptionHandler();
    virtual ~TStdExceptionHandler() { }
 
-   virtual void     Add();
-   virtual void     Remove();
-   virtual Bool_t   Notify();
+   void     Add() override;
+   void     Remove() override;
+   Bool_t   Notify() override;
 
    virtual EStatus  Handle(std::exception& exc) = 0;
 
-   ClassDef(TStdExceptionHandler,0)  //C++ exception handler
+   ClassDefOverride(TStdExceptionHandler,0)  //C++ exception handler
 };
 
 #endif

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -257,9 +257,9 @@ R__EXTERN TVirtualMutex *gSystemMutex;
 class TProcessEventTimer : public TTimer {
 public:
    TProcessEventTimer(Long_t delay);
-   Bool_t Notify() { return kTRUE; }
+   Bool_t Notify() override { return kTRUE; }
    Bool_t ProcessEvents();
-   ClassDef(TProcessEventTimer,0)  // Process pending events at fixed time intervals
+   ClassDefOverride(TProcessEventTimer,0)  // Process pending events at fixed time intervals
 };
 
 
@@ -553,7 +553,7 @@ public:
    virtual TString         SplitAclicMode(const char *filename, TString &mode, TString &args, TString &io) const;
    virtual void            CleanCompiledMacros();
 
-   ClassDef(TSystem,0)  //ABC defining a generic interface to the OS
+   ClassDefOverride(TSystem,0)  //ABC defining a generic interface to the OS
 };
 
 R__EXTERN TSystem *gSystem;

--- a/core/base/inc/TSystemDirectory.h
+++ b/core/base/inc/TSystemDirectory.h
@@ -48,26 +48,27 @@ public:
 
    virtual ~TSystemDirectory();
 
-   virtual Bool_t IsFolder() const { return kTRUE; }
-   virtual Bool_t IsDirectory(const char * = 0) const { return kTRUE; }
+   Bool_t      IsFolder() const override { return kTRUE; }
+   Bool_t      IsDirectory(const char * = nullptr) const override { return kTRUE; }
 
-   virtual void   Browse(TBrowser *b);
-   virtual void   Edit() { }
+   void        Browse(TBrowser *b) override;
+   void        Edit() override {}
    virtual TList *GetListOfFiles() const;
    virtual void   SetDirectory(const char *name);
-   virtual void   Delete() {}
-   virtual void   Copy(const char *) {}
-   virtual void   Move(const char *) {}
+   void        Delete() override {}
+   void        Copy(const char *) override {}
+   void        Move(const char *) override {}
 
    // dummy methods from TObject
-   void        DrawClass() const { }
-   TObject    *DrawClone(Option_t *) const { return 0; }
-   void        SetDrawOption(Option_t *) { }
-   void        SetName(const char *name) { TSystemFile::SetName(name); }
-   void        SetTitle(const char *title) { TSystemFile::SetTitle(title); }
-   void        Delete(Option_t *) { }
-   void        Copy(TObject & ) const { }
-   ClassDef(TSystemDirectory,0)  //A system directory
+   void        DrawClass() const override { }
+   TObject    *DrawClone(Option_t *) const override { return nullptr; }
+   void        SetDrawOption(Option_t *) override { }
+   void        SetName(const char *name) override { TSystemFile::SetName(name); }
+   void        SetTitle(const char *title) override { TSystemFile::SetTitle(title); }
+   void        Delete(Option_t *) override { }
+   void        Copy(TObject & ) const override { }
+
+   ClassDefOverride(TSystemDirectory,0)  //A system directory
 };
 
 #endif

--- a/core/base/inc/TSystemFile.h
+++ b/core/base/inc/TSystemFile.h
@@ -34,7 +34,6 @@ public:
    TSystemFile();
    TSystemFile(const char *filename, const char *dirname);
    virtual ~TSystemFile();
-   virtual void     Browse(TBrowser *b);
    virtual void     Rename(const char *name);      // *MENU*
    virtual void     Delete();                      // *MENU*
    virtual void     Copy(const char *to);          // *MENU*
@@ -43,21 +42,23 @@ public:
 
    virtual Bool_t   IsDirectory(const char *dir = 0) const;
    virtual void     SetIconName(const char *name) { fIconName = name; }
-   const char      *GetIconName() const { return fIconName.Data(); }
+   const char      *GetIconName() const override { return fIconName.Data(); }
+
+   void         Browse(TBrowser *b) override;
 
    // dummy methods from TObject
-   virtual void     Inspect() const;
-   virtual void     Dump() const;
+   void        Inspect() const override;
+   void        Dump() const  override;
 
-   void        DrawClass() const { }
-   TObject    *DrawClone(Option_t *) const { return 0; }
-   void        SetDrawOption(Option_t *) { }
-   void        SetName(const char *name) { TNamed::SetName(name); }
-   void        SetTitle(const char *title) { TNamed::SetTitle(title); }
-   void        Delete(Option_t *) { }
-   void        Copy(TObject & ) const { }
+   void        DrawClass() const override { }
+   TObject    *DrawClone(Option_t *) const override { return nullptr; }
+   void        SetDrawOption(Option_t *) override { }
+   void        SetName(const char *name) override { TNamed::SetName(name); }
+   void        SetTitle(const char *title)  override { TNamed::SetTitle(title); }
+   void        Delete(Option_t *) override { }
+   void        Copy(TObject &) const override { }
 
-   ClassDef(TSystemFile,0)  //A system file
+   ClassDefOverride(TSystemFile,0)  //A system file
 };
 
 #endif

--- a/core/base/inc/TTask.h
+++ b/core/base/inc/TTask.h
@@ -56,24 +56,24 @@ public:
 
    virtual void  Abort();  // *MENU*
    virtual void  Add(TTask *task);
-   virtual void  Browse(TBrowser *b);
+           void  Browse(TBrowser *b) override;
    virtual void  CleanTasks();
-   virtual void  Clear(Option_t *option="");
+           void  Clear(Option_t *option="") override;
    virtual void  Continue(); // *MENU*
    virtual void  Exec(Option_t *option);
    virtual void  ExecuteTask(Option_t *option="0");  // *MENU*
    virtual void  ExecuteTasks(Option_t *option);
-   Int_t         GetBreakin() const { return fBreakin; }
-   Int_t         GetBreakout() const { return fBreakout; }
+          Int_t  GetBreakin() const { return fBreakin; }
+          Int_t  GetBreakout() const { return fBreakout; }
          Bool_t  IsActive() const { return fActive; }
-         Bool_t  IsFolder() const { return kTRUE; }
-   virtual void  ls(Option_t *option="*") const;  // *MENU*
+         Bool_t  IsFolder() const override { return kTRUE; }
+           void  ls(Option_t *option="*") const override;  // *MENU*
            void  SetActive(Bool_t active=kTRUE) { fActive = active; } // *TOGGLE*
            void  SetBreakin(Int_t breakin=1) { fBreakin = breakin; } // *TOGGLE*
            void  SetBreakout(Int_t breakout=1) { fBreakout = breakout; } // *TOGGLE*
-   TList        *GetListOfTasks() const { return fTasks; }
+          TList *GetListOfTasks() const { return fTasks; }
 
-   ClassDef(TTask,1)  //Base class for tasks
+   ClassDefOverride(TTask,1)  //Base class for tasks
 };
 
 #endif

--- a/core/base/inc/TTimer.h
+++ b/core/base/inc/TTimer.h
@@ -81,9 +81,9 @@ public:
    Bool_t         IsAsync() const { return !fSync; }
    Bool_t         IsInterruptingSyscalls() const { return fIntSyscalls; }
    Bool_t         IsRunning();
-   virtual Bool_t Notify();
-   void           Add() { TurnOn(); }
-   void           Remove() { TurnOff(); }
+   Bool_t         Notify() override;
+   void           Add() override { TurnOn(); }
+   void           Remove() override { TurnOff(); }
    void           Reset();
    void           SetCommand(const char *command);
    void           SetObject(TObject *object);
@@ -99,7 +99,7 @@ public:
    static void    SingleShot(Int_t milliSec, const char *receiver_class,
                              void *receiver, const char *method);
 
-   ClassDef(TTimer,0)  //Handle timer event
+   ClassDefOverride(TTimer,0)  //Handle timer event
 };
 
 #endif

--- a/core/base/inc/TVirtualAuth.h
+++ b/core/base/inc/TVirtualAuth.h
@@ -27,8 +27,8 @@ class TSocket;
 class TVirtualAuth {
 
 public:
-   TVirtualAuth() { }
-   virtual ~TVirtualAuth() { }
+   TVirtualAuth() {}
+   virtual ~TVirtualAuth() {}
 
    virtual TSecContext *Authenticate(TSocket *, const char *host,
                                      const char *user, Option_t *options) = 0;

--- a/core/base/inc/TVirtualFFT.h
+++ b/core/base/inc/TVirtualFFT.h
@@ -129,7 +129,7 @@ class TVirtualFFT: public TObject {
    static const char*  GetDefaultFFT();
    static void         SetDefaultFFT(const char *name ="");
 
-   ClassDef(TVirtualFFT, 0); //abstract interface for FFT calculations
+   ClassDefOverride(TVirtualFFT, 0); //abstract interface for FFT calculations
 };
 
 #endif

--- a/core/base/inc/TVirtualGL.h
+++ b/core/base/inc/TVirtualGL.h
@@ -70,6 +70,8 @@ public:
 class TGLManager : public TNamed {
 public:
    TGLManager();
+   TGLManager(const TGLManager &) = delete;
+   TGLManager &operator = (const TGLManager &) = delete;
 
    //index returned can be used as a result of gVirtualX->InitWindow
    virtual Int_t    InitGLWindow(Window_t winID) = 0;
@@ -115,11 +117,7 @@ public:
 
    static TGLManager *&Instance();
 
-private:
-   TGLManager(const TGLManager &);
-   TGLManager &operator = (const TGLManager &);
-
-   ClassDef(TGLManager, 0)// Interface for OpenGL manager
+   ClassDefOverride(TGLManager, 0)// Interface for OpenGL manager
 };
 
 namespace Rgl {

--- a/core/base/inc/TVirtualPS.h
+++ b/core/base/inc/TVirtualPS.h
@@ -68,13 +68,13 @@ public:
    virtual void  WriteInteger(Int_t i, Bool_t space=kTRUE);
    virtual void  WriteReal(Float_t r, Bool_t space=kTRUE);
    virtual void  PrintRaw(Int_t len, const char *str);
-   virtual void *GetStream() const {  return (void*)fStream; }
-   virtual void  SetStream(std::ofstream *os) {  fStream = os; }
+   virtual void *GetStream() const { return (void*)fStream; }
+   virtual void  SetStream(std::ofstream *os) { fStream = os; }
 
    virtual void  SetType(Int_t /*type*/ = -111) { }
    virtual Int_t GetType() const { return 111; }
 
-   ClassDef(TVirtualPS,0)  //Abstract interface to a PostScript driver
+   ClassDefOverride(TVirtualPS,0)  //Abstract interface to a PostScript driver
 };
 
 

--- a/core/base/inc/TVirtualPerfStats.h
+++ b/core/base/inc/TVirtualPerfStats.h
@@ -90,7 +90,7 @@ public:
 
    static const char *EventType(EEventType type);
 
-   ClassDef(TVirtualPerfStats,0)  // ABC for collecting PROOF statistics
+   ClassDefOverride(TVirtualPerfStats,0)  // ABC for collecting PROOF statistics
 };
 
 

--- a/core/base/inc/TVirtualTableInterface.h
+++ b/core/base/inc/TVirtualTableInterface.h
@@ -17,8 +17,8 @@
 class TVirtualTableInterface {
 
 public:
-   TVirtualTableInterface() {;}
-   virtual ~TVirtualTableInterface() {;}
+   TVirtualTableInterface() {}
+   virtual ~TVirtualTableInterface() {}
 
    virtual Double_t    GetValue(UInt_t row, UInt_t column) = 0;
    virtual const char *GetValueAsString(UInt_t row, UInt_t column) = 0;

--- a/core/base/inc/TVirtualViewer3D.h
+++ b/core/base/inc/TVirtualViewer3D.h
@@ -64,7 +64,7 @@ public:
    virtual void   CloseComposite() = 0;
    virtual void   AddCompositeOp(UInt_t operation) = 0;
 
-   virtual TObject *SelectObject(Int_t, Int_t){return 0;}
+   virtual TObject *SelectObject(Int_t, Int_t) { return nullptr; }
    virtual void   DrawViewer(){}
 
    virtual void PrintObjects(){}
@@ -73,7 +73,7 @@ public:
 
    static  TVirtualViewer3D *Viewer3D(TVirtualPad *pad = 0, Option_t *type = "");
 
-   ClassDef(TVirtualViewer3D,0) // Abstract interface to 3D viewers
+   ClassDefOverride(TVirtualViewer3D,0) // Abstract interface to 3D viewers
 };
 
 #endif

--- a/core/base/inc/TVirtualX.h
+++ b/core/base/inc/TVirtualX.h
@@ -55,9 +55,9 @@ protected:
    EDrawMode fDrawMode;           //Drawing mode
 
 public:
-   TVirtualX(): fDrawMode() { }
+   TVirtualX(): fDrawMode() {}
    TVirtualX(const char *name, const char *title);
-   virtual ~TVirtualX() { }
+   virtual ~TVirtualX() {}
 
    virtual Bool_t    Init(void *display = nullptr);
    virtual void      ClearWindow();
@@ -91,7 +91,7 @@ public:
    EDrawMode         GetDrawMode() { return fDrawMode; }
    virtual Int_t     GetDoubleBuffer(Int_t wid);
    virtual void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   virtual const char *DisplayName(const char * = 0);
+   virtual const char *DisplayName(const char * = nullptr);
    virtual Handle_t  GetNativeEvent() const;
    virtual ULong_t   GetPixel(Color_t cindex);
    virtual void      GetPlanes(Int_t &nplanes);
@@ -128,23 +128,23 @@ public:
    virtual void      SetDoubleBufferOFF();
    virtual void      SetDoubleBufferON();
    virtual void      SetDrawMode(EDrawMode mode);
-   virtual void      SetFillColor(Color_t cindex);
-   virtual void      SetFillStyle(Style_t style);
-   virtual void      SetLineColor(Color_t cindex);
+           void      SetFillColor(Color_t cindex) override;
+           void      SetFillStyle(Style_t style) override;
+           void      SetLineColor(Color_t cindex) override;
    virtual void      SetLineType(Int_t n, Int_t *dash);
-   virtual void      SetLineStyle(Style_t linestyle);
-   virtual void      SetLineWidth(Width_t width);
-   virtual void      SetMarkerColor(Color_t cindex);
-   virtual void      SetMarkerSize(Float_t markersize);
-   virtual void      SetMarkerStyle(Style_t markerstyle);
+           void      SetLineStyle(Style_t linestyle) override;
+           void      SetLineWidth(Width_t width) override;
+           void      SetMarkerColor(Color_t cindex) override;
+           void      SetMarkerSize(Float_t markersize) override;
+           void      SetMarkerStyle(Style_t markerstyle) override;
    virtual void      SetOpacity(Int_t percent);
    virtual void      SetRGB(Int_t cindex, Float_t r, Float_t g, Float_t b);
-   virtual void      SetTextAlign(Short_t talign=11);
-   virtual void      SetTextColor(Color_t cindex);
+           void      SetTextAlign(Short_t talign=11) override;
+           void      SetTextColor(Color_t cindex) override;
    virtual Int_t     SetTextFont(char *fontname, ETextSetMode mode);
-   virtual void      SetTextFont(Font_t fontnumber);
+           void      SetTextFont(Font_t fontnumber) override;
    virtual void      SetTextMagnitude(Float_t mgn);
-   virtual void      SetTextSize(Float_t textsize);
+           void      SetTextSize(Float_t textsize) override;
    virtual void      Sync(Int_t mode);
    virtual void      UpdateWindow(Int_t mode);
    virtual void      Warp(Int_t ix, Int_t iy, Window_t id = 0);
@@ -278,7 +278,7 @@ public:
                                        Bool_t del);
    virtual void         TranslateCoordinates(Window_t src, Window_t dest, Int_t src_x,Int_t src_y,
                                              Int_t &dest_x, Int_t &dest_y, Window_t &child);
-   virtual void         GetWindowSize(Drawable_t id, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
+   virtual void         GetWindowSize(Drawable_t id, Int_t &x, Int_t & overridey, UInt_t &w, UInt_t &h);
    virtual void         FillPolygon(Window_t id, GContext_t gc, Point_t *points, Int_t npnt);
    virtual void         QueryPointer(Window_t id, Window_t &rootw, Window_t &childw,
                                      Int_t &root_x, Int_t &root_y, Int_t &win_x,
@@ -331,7 +331,7 @@ public:
 
    static TVirtualX    *&Instance();
 
-   ClassDef(TVirtualX,0)  //ABC defining a generic interface to graphics system
+   ClassDefOverride(TVirtualX,0)  //ABC defining a generic interface to graphics system
 };
 
 #ifndef __CINT__

--- a/core/gui/inc/TBrowser.h
+++ b/core/gui/inc/TBrowser.h
@@ -87,7 +87,7 @@ public:
    void          CheckObjectItem(TObject *obj, Bool_t check = kFALSE);
    void          RemoveCheckBox(TObject *obj);
 
-   virtual void  Create(TObject *obj = 0);      // Create this Browser
+   virtual void  Create(TObject *obj = nullptr);      // Create this Browser
    virtual void  Destructor();
    void          BrowseObject(TObject *obj)    { if (fImp) fImp->BrowseObj(obj); }
    void          ExecuteDefaultAction(TObject *obj);
@@ -98,15 +98,15 @@ public:
    TObject      *GetSelected() const           { return fLastSelectedObject; }
    void          SetRefreshFlag(Bool_t flag)   { fNeedRefresh = flag; }
    void          Iconify()                     { if (fImp) fImp->Iconify(); }
-   virtual void  RecursiveRemove(TObject *obj);
+   void          RecursiveRemove(TObject *obj) override;
    void          Refresh();
    void          SetSelected(TObject *clickedObject);
    void          Show()                        { if (fImp) fImp->Show(); }
-   void          SetDrawOption(Option_t *option="") { if (fImp) fImp->SetDrawOption(option); }
-   Option_t     *GetDrawOption() const { return  (fImp) ? fImp->GetDrawOption() : 0; }
+   void          SetDrawOption(Option_t *option="") override { if (fImp) fImp->SetDrawOption(option); }
+   Option_t     *GetDrawOption() const override { return  (fImp) ? fImp->GetDrawOption() : nullptr; }
 
-   Longptr_t     ExecPlugin(const char *name = 0, const char *fname = 0,
-                            const char *cmd = 0, Int_t pos = 1, Int_t subpos = -1) {
+   Longptr_t     ExecPlugin(const char *name = nullptr, const char *fname = nullptr,
+                            const char *cmd = nullptr, Int_t pos = 1, Int_t subpos = -1) {
                     return (fImp) ? fImp->ExecPlugin(name, fname, cmd, pos, subpos) : -1;
                  }
    void          SetStatusText(const char *txt, Int_t col) {
@@ -117,7 +117,7 @@ public:
                  }
    void          StopEmbedding(const char *name = "") { if (fImp) fImp->StopEmbedding(name); }
 
-   ClassDef(TBrowser,0)  //ROOT Object Browser
+   ClassDefOverride(TBrowser,0)  //ROOT Object Browser
 };
 
 #endif

--- a/core/gui/inc/TCanvasImp.h
+++ b/core/gui/inc/TCanvasImp.h
@@ -44,7 +44,7 @@ protected:
 
    virtual Bool_t IsWeb() const { return kFALSE; }
    virtual Bool_t PerformUpdate() { return kFALSE; }
-   virtual TVirtualPadPainter *CreatePadPainter() { return 0; }
+   virtual TVirtualPadPainter *CreatePadPainter() { return nullptr; }
 
 public:
    TCanvasImp(TCanvas *c=0) : fCanvas(c) { }
@@ -58,7 +58,7 @@ public:
    virtual UInt_t GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
    virtual void   Iconify() { }
    virtual Int_t  InitWindow() { return 0; }
-   virtual void   SetStatusText(const char *text = 0, Int_t partidx = 0);
+   virtual void   SetStatusText(const char *text = nullptr, Int_t partidx = 0);
    virtual void   SetWindowPosition(Int_t x, Int_t y);
    virtual void   SetWindowSize(UInt_t w, UInt_t h);
    virtual void   SetWindowTitle(const char *newTitle);

--- a/core/gui/inc/TClassMenuItem.h
+++ b/core/gui/inc/TClassMenuItem.h
@@ -55,11 +55,11 @@ protected:
 public:
    TClassMenuItem();
    TClassMenuItem(Int_t type, TClass *parent, const char *title="",
-                  const char *functionname="", TObject *obj=0,
+                  const char *functionname="", TObject *obj=nullptr,
                   const char *args="", Int_t selfobjposition=-1,
                   Bool_t self=kFALSE);
    virtual        ~TClassMenuItem();
-   virtual const char *GetTitle() const { return fTitle; }
+   const char    *GetTitle() const override { return fTitle.Data(); }
    virtual const char *GetFunctionName() const { return fFunctionName; }
    virtual const char *GetArgs() const { return fArgs; }
    virtual TObject *GetCalledObject() const { return fCalledObject; }
@@ -78,7 +78,7 @@ public:
                        { fCalledObject = obj; fFunctionName = method;
                          fArgs = args; fSelfObjectPos = selfobjposition;}
 
-   ClassDef(TClassMenuItem,0)  //One element of the class context menu
+   ClassDefOverride(TClassMenuItem,0)  //One element of the class context menu
 };
 
 #endif

--- a/core/gui/inc/TContextMenu.h
+++ b/core/gui/inc/TContextMenu.h
@@ -76,8 +76,8 @@ public:
    virtual const char *CreateArgumentTitle(TMethodArg *argument);
    virtual const char *CreateDialogTitle(TObject *object, TFunction *method);
    virtual const char *CreatePopupTitle(TObject *object );
-   virtual void Execute(const char *method,  const char *params, Int_t *error=nullptr) { TObject::Execute(method, params, error); }
-   virtual void Execute(TMethod *method, TObjArray *params, Int_t *error=nullptr) { TObject::Execute(method, params, error); }
+   void Execute(const char *method,  const char *params, Int_t *error=nullptr) override { TObject::Execute(method, params, error); }
+   void Execute(TMethod *method, TObjArray *params, Int_t *error=nullptr) override { TObject::Execute(method, params, error); }
    virtual void Execute(TObject *object, TFunction *method, const char *params);
    virtual void Execute(TObject *object, TFunction *method, TObjArray *params);
    void Execute(const char *params) { Execute(fCalledObject, fSelectedMethod, params); }
@@ -97,11 +97,11 @@ public:
    virtual void SetMethod(TFunction *m) { fSelectedMethod = m; }
    virtual void SetCalledObject(TObject *o) { fCalledObject = o; }
    virtual void SetSelectedMenuItem(TClassMenuItem *mi) { fSelectedMenuItem = mi; }
-   virtual void SetNameTitle(const char *name, const char *title) { TNamed::SetNameTitle(name, title); }
+   void SetNameTitle(const char *name, const char *title) override { TNamed::SetNameTitle(name, title); }
    virtual void SetObject(TObject *o) { fSelectedObject = o; }
    virtual void SetPad(TVirtualPad *p) { fSelectedPad = p; }
 
-   ClassDef(TContextMenu,0)  //Context sensitive popup menu
+   ClassDefOverride(TContextMenu,0)  //Context sensitive popup menu
 };
 
 #endif

--- a/core/gui/inc/TGuiFactory.h
+++ b/core/gui/inc/TGuiFactory.h
@@ -60,7 +60,7 @@ public:
 
    virtual TInspectorImp *CreateInspectorImp(const TObject *obj, UInt_t width, UInt_t height);
 
-   ClassDef(TGuiFactory,0)  //Abstract factory for GUI components
+   ClassDefOverride(TGuiFactory,0)  //Abstract factory for GUI components
 };
 
 R__EXTERN TGuiFactory *gGuiFactory;

--- a/core/gui/inc/TObjectSpy.h
+++ b/core/gui/inc/TObjectSpy.h
@@ -41,11 +41,11 @@ public:
    TObjectSpy(TObject *obj = nullptr, Bool_t fixMustCleanupBit=kTRUE);
    virtual ~TObjectSpy();
 
-   virtual void  RecursiveRemove(TObject *obj);
+   void          RecursiveRemove(TObject *obj) override;
    TObject      *GetObject() const { return fObj; }
-   void          SetObject(TObject *obj, Bool_t fixMustCleanupBit=kTRUE);
+   void          SetObject(TObject *obj, Bool_t fixMustCleanupBit = kTRUE);
 
-   ClassDef(TObjectSpy, 0);  // Spy object pointer for deletion
+   ClassDefOverride(TObjectSpy, 0);  // Spy object pointer for deletion
 };
 
 
@@ -63,10 +63,10 @@ public:
    TObjectRefSpy(TObject *&obj, Bool_t fixMustCleanupBit=kTRUE);
    virtual ~TObjectRefSpy();
 
-   virtual void  RecursiveRemove(TObject *obj);
+   void          RecursiveRemove(TObject *obj) override;
    TObject      *GetObject() const { return fObj; }
 
-   ClassDef(TObjectRefSpy, 0);  // Spy object reference for deletion
+   ClassDefOverride(TObjectRefSpy, 0);  // Spy object reference for deletion
 };
 
 #endif

--- a/core/gui/inc/TToggle.h
+++ b/core/gui/inc/TToggle.h
@@ -69,24 +69,24 @@ public:
 
    virtual void    SetToggledVariable(Int_t &var);
 
-   virtual Bool_t  IsInitialized(){return fInitialized;};
+   virtual Bool_t  IsInitialized(){ return fInitialized; }
 
    virtual Bool_t  GetState();
    virtual void    SetState(Bool_t state);
    virtual void    Toggle();
 
-   virtual void    SetOnValue(Long_t lon){fOnValue=lon;};
-   virtual Long_t  GetOnValue(){return fOnValue;};
-   virtual void    SetOffValue(Long_t lof){fOffValue=lof;};
-   virtual Long_t  GetOffValue(){return fOffValue;};
+   virtual void    SetOnValue(Long_t lon) { fOnValue=lon; }
+   virtual Long_t  GetOnValue() { return fOnValue; }
+   virtual void    SetOffValue(Long_t lof) { fOffValue=lof; }
+   virtual Long_t  GetOffValue() { return fOffValue; }
 
-   virtual Int_t   GetValue(){return fValue;};
+   virtual Int_t   GetValue() { return fValue; }
    virtual void    SetValue(Long_t val);
 
    TMethodCall    *GetGetter() const { return fGetter; }
    TMethodCall    *GetSetter() const { return fSetter; }
 
-   ClassDef(TToggle,0)  //Facility for toggling datamembers on/off
+   ClassDefOverride(TToggle,0)  //Facility for toggling datamembers on/off
 };
 
 #endif

--- a/core/gui/inc/TToggleGroup.h
+++ b/core/gui/inc/TToggleGroup.h
@@ -37,24 +37,24 @@ public:
    TToggleGroup(const TToggleGroup&);
    TToggleGroup &operator=(const TToggleGroup&);
    virtual ~TToggleGroup();
-   virtual Int_t       GetTogglesCount() {return fToggles->GetSize();};
-   virtual TToggle    *At(Int_t idx) {return (TToggle*)fToggles->At(idx);};
+   virtual Int_t       GetTogglesCount() {return fToggles->GetSize();}
+   virtual TToggle    *At(Int_t idx) {return (TToggle*)fToggles->At(idx);}
 
-   virtual void        Remove(TToggle *t) {fToggles->Remove(t);};
-   virtual void        Remove(Int_t pos) {fToggles->RemoveAt(pos);};
+   virtual void        Remove(TToggle *t) {fToggles->Remove(t);}
+   virtual void        Remove(Int_t pos) {fToggles->RemoveAt(pos);}
 
    virtual void        DeleteAll();
-   virtual TToggle    *First() {return (TToggle*)fToggles->First();};
-   virtual TToggle    *Last()  {return (TToggle*)fToggles->Last();};
+   virtual TToggle    *First() {return (TToggle*)fToggles->First();}
+   virtual TToggle    *Last()  {return (TToggle*)fToggles->Last();}
 
-   virtual Int_t       IndexOf(TToggle *t) {return fToggles->IndexOf(t);};
+   virtual Int_t       IndexOf(TToggle *t) {return fToggles->IndexOf(t);}
 
    virtual Int_t       Add(TToggle *t, Bool_t select=1);
    virtual Int_t       InsertAt(TToggle *t, Int_t pos,Bool_t select=1);
    virtual void        Select(Int_t idx);
    virtual void        Select(TToggle *t);
 
-   ClassDef(TToggleGroup,0)  // Group of contex-menu toggle objects
+   ClassDefOverride(TToggleGroup,0)  // Group of contex-menu toggle objects
 };
 
 #endif

--- a/core/meta/inc/TBaseClass.h
+++ b/core/meta/inc/TBaseClass.h
@@ -55,17 +55,18 @@ private:
 
 public:
    TBaseClass(BaseClassInfo_t *info = nullptr, TClass *cl = nullptr);
-   virtual     ~TBaseClass();
-   virtual void   Browse(TBrowser *b);
-   const char    *GetTitle() const;
+   virtual ~TBaseClass();
+
+   void           Browse(TBrowser *b) override;
+   const char    *GetTitle() const override;
    TClass        *GetClassPointer(Bool_t load=kTRUE);
    Int_t          GetDelta();
-   Bool_t         IsFolder() const {return kTRUE;}
+   Bool_t         IsFolder() const override {return kTRUE;}
    ROOT::ESTLType IsSTLContainer();
-   Long_t         Property() const;
+   Long_t         Property() const override;
    void           SetClass(TClass* cl) { fClass = cl; }
 
-   ClassDef(TBaseClass,2)  //Description of a base class
+   ClassDefOverride(TBaseClass,2)  //Description of a base class
 };
 
 #endif

--- a/core/meta/inc/TClassGenerator.h
+++ b/core/meta/inc/TClassGenerator.h
@@ -37,7 +37,7 @@ public:
    virtual TClass *GetClass(const char* classname, Bool_t load, Bool_t silent);
    virtual TClass *GetClass(const std::type_info& typeinfo, Bool_t load, Bool_t silent);
 
-   ClassDef(TClassGenerator,1);  // interface for TClass generators
+   ClassDefOverride(TClassGenerator,1);  // interface for TClass generators
 };
 
 #endif

--- a/core/meta/inc/TClassStreamer.h
+++ b/core/meta/inc/TClassStreamer.h
@@ -25,7 +25,7 @@
 
 class TClassStreamer {
 protected:
-   TClassStreamer() : fStreamer(0) {};
+   TClassStreamer() : fStreamer(nullptr) {};
    TClassStreamer(const TClassStreamer &rhs) : fStreamer(rhs.fStreamer), fOnFileClass() {};
    TClassStreamer &operator=(const TClassStreamer &rhs) {   fOnFileClass = rhs.fOnFileClass; fStreamer = rhs.fStreamer; return *this; }
 
@@ -55,7 +55,7 @@ public:
       // the handling of the onfileClass (rather than storing and restoring from the
       // fOnFileClass member.
 
-      // Note we can not name this routine 'operator()' has it would be slightly
+      // Note we can not name this routine 'ope overriderator()' has it would be slightly
       // backward incompatible and lead to the following warning/error from the
       // compiler in the derived class overloading the other operator():
 //      include/TClassStreamer.h:51: error: ‘virtual void TClassStreamer::operator()(TBuffer&, void*, const TClass*)’ was hidden

--- a/core/meta/inc/TClassStreamer.h
+++ b/core/meta/inc/TClassStreamer.h
@@ -55,7 +55,7 @@ public:
       // the handling of the onfileClass (rather than storing and restoring from the
       // fOnFileClass member.
 
-      // Note we can not name this routine 'ope overriderator()' has it would be slightly
+      // Note we can not name this routine 'operator' has it would be slightly
       // backward incompatible and lead to the following warning/error from the
       // compiler in the derived class overloading the other operator():
 //      include/TClassStreamer.h:51: error: ‘virtual void TClassStreamer::operator()(TBuffer&, void*, const TClass*)’ was hidden

--- a/core/meta/inc/TDataMember.h
+++ b/core/meta/inc/TDataMember.h
@@ -67,7 +67,7 @@ protected:
 
 public:
 
-   TDataMember(DataMemberInfo_t *info = 0, TClass *cl = 0);
+   TDataMember(DataMemberInfo_t *info = nullptr, TClass *cl = nullptr);
    virtual       ~TDataMember();
    Int_t          GetArrayDim() const;
    DeclId_t       GetDeclId() const;
@@ -83,7 +83,7 @@ public:
    Int_t          GetUnitSize() const;
    TList         *GetOptions();
    TMethodCall   *SetterMethod(TClass *cl);
-   TMethodCall   *GetterMethod(TClass *cl = 0);
+   TMethodCall   *GetterMethod(TClass *cl = nullptr);
 
    Bool_t         IsBasic() const;
    Bool_t         IsEnum() const;

--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -51,7 +51,7 @@ public:
                        kALoadAndInterpLookup = 3
                       };
 
-   TEnum() = default;
+   TEnum() : TDictionary()  {}
    TEnum(const char *name, DeclId_t declid, TClass *cls);
    virtual ~TEnum();
 
@@ -61,21 +61,21 @@ public:
    const TEnumConstant  *GetConstant(const char *name) const { return (TEnumConstant *)fConstantList.FindObject(name); }
    DeclId_t              GetDeclId() const;
 
-   /// Get the unterlying integer type of the enum:
+   /// Get the underlying integer type of the enum:
    ///     enum E { kOne }; //  ==> int
    ///     enum F: long; //  ==> long
    /// Returns kNumDataTypes if the enum is unknown / invalid.
    EDataType             GetUnderlyingType() const { return fUnderlyingType; };
 
    Bool_t                IsValid();
-   Long_t                Property() const;
+   Long_t                Property() const override;
    void                  SetClass(TClass *cl) { fClass = cl; }
    void                  Update(DeclId_t id);
    const char*           GetQualifiedName() const { return fQualName.c_str(); }
    static TEnum         *GetEnum(const std::type_info &ti, ESearchAction sa = kALoadAndInterpLookup);
    static TEnum         *GetEnum(const char *enumName, ESearchAction sa = kALoadAndInterpLookup);
 
-   ClassDef(TEnum, 2) //Enum type class
+   ClassDefOverride(TEnum, 2) //Enum type class
 };
 
 #endif

--- a/core/meta/inc/TEnumConstant.h
+++ b/core/meta/inc/TEnumConstant.h
@@ -32,7 +32,7 @@ private:
    Long64_t           fValue; //the value for the constant
 
 public:
-   TEnumConstant(): fEnum(0), fValue(-1) {}
+   TEnumConstant(): fEnum(nullptr), fValue(-1) {}
    TEnumConstant(DataMemberInfo_t *info, const char* name, Long64_t value, TEnum* type);
    virtual ~TEnumConstant();
 

--- a/core/meta/inc/TFileMergeInfo.h
+++ b/core/meta/inc/TFileMergeInfo.h
@@ -57,7 +57,7 @@ public:
    TFileMergeInfo(TDirectory *outputfile) : fOutputDirectory(outputfile) {}
    virtual ~TFileMergeInfo() { delete fUserData; } ;
 
-   void Reset() { fIsFirst = kTRUE; delete fUserData; fUserData = 0; }
+   void Reset() { fIsFirst = kTRUE; delete fUserData; fUserData = nullptr; }
 
    ClassDef(TFileMergeInfo, 0);
 };

--- a/core/meta/inc/TFunction.h
+++ b/core/meta/inc/TFunction.h
@@ -41,11 +41,12 @@ protected:
    virtual void    CreateSignature();
 
 public:
-   TFunction(MethodInfo_t *info = 0);
+   TFunction(MethodInfo_t *info = nullptr);
    TFunction(const TFunction &orig);
    TFunction& operator=(const TFunction &rhs);
    virtual            ~TFunction();
-   virtual TObject    *Clone(const char *newname="") const;
+
+   TObject            *Clone(const char *newname="") const override;
    virtual const char *GetMangledName() const;
    virtual const char *GetPrototype() const;
    const char         *GetSignature();
@@ -57,14 +58,14 @@ public:
    DeclId_t            GetDeclId() const;
    void               *InterfaceMethod() const;
    virtual Bool_t      IsValid();
-   virtual void        Print(Option_t *option="") const;
-   Long_t              Property() const;
+   void                Print(Option_t *option="") const override;
+   Long_t              Property() const override;
    Long_t              ExtraProperty() const;
    virtual bool        Update(MethodInfo_t *info);
 
-   virtual void        ls(Option_t *option="") const;
+   void                ls(Option_t *option="") const override;
 
-   ClassDef(TFunction,0)  //Dictionary for global function
+   ClassDefOverride(TFunction,0)  //Dictionary for global function
 };
 
 #endif

--- a/core/meta/inc/TFunctionTemplate.h
+++ b/core/meta/inc/TFunctionTemplate.h
@@ -33,19 +33,20 @@ public:
    TFunctionTemplate(const TFunctionTemplate &orig);
    TFunctionTemplate& operator=(const TFunctionTemplate &rhs);
    virtual            ~TFunctionTemplate();
-   virtual TObject   *Clone(const char *newname="") const;
+
+   TObject            *Clone(const char *newname="") const override;
 
    DeclId_t            GetDeclId() const;
    UInt_t              GetTemplateNargs() const;
    UInt_t              GetTemplateMinReqArgs() const;
 
    virtual Bool_t      IsValid();
-   Long_t              Property() const;
+   Long_t              Property() const override;
    Long_t              ExtraProperty() const;
 
    virtual bool        Update(FuncTempInfo_t *info);
 
-   ClassDef(TFunctionTemplate,0)  //Dictionary for function template
+   ClassDefOverride(TFunctionTemplate,0)  //Dictionary for function template
 
 };
 

--- a/core/meta/inc/TGlobal.h
+++ b/core/meta/inc/TGlobal.h
@@ -43,10 +43,10 @@ public:
    virtual const char *GetTypeName() const;
    virtual const char *GetFullTypeName() const;
    virtual Bool_t IsValid();
-   virtual Long_t Property() const;
+   Long_t Property() const override;
    virtual bool   Update(DataMemberInfo_t *info);
 
-   ClassDef(TGlobal,2)  //Global variable class
+   ClassDefOverride(TGlobal,2)  //Global variable class
 };
 
 // Class to map the "funcky" globals and be able to add them to the list of globals.

--- a/core/meta/inc/TListOfDataMembers.h
+++ b/core/meta/inc/TListOfDataMembers.h
@@ -66,40 +66,40 @@ public:
 
    ~TListOfDataMembers();
 
-   virtual void Clear(Option_t *option);
-   virtual void Delete(Option_t *option="");
+   void       Clear(Option_t *option = "") override;
+   void       Delete(Option_t *option="") override;
 
    using THashList::FindObject;
-   virtual TObject   *FindObject(const char *name) const;
+   TObject   *FindObject(const char *name) const override;
 
    TDictionary *Find(DeclId_t id) const;
    TDictionary *Get(DeclId_t id);
    TDictionary *Get(DataMemberInfo_t *info, bool skipChecks=kFALSE);
 
    Bool_t     IsLoaded() const { return fIsLoaded; }
-   void       AddFirst(TObject *obj);
-   void       AddFirst(TObject *obj, Option_t *opt);
-   void       AddLast(TObject *obj);
-   void       AddLast(TObject *obj, Option_t *opt);
-   void       AddAt(TObject *obj, Int_t idx);
-   void       AddAfter(const TObject *after, TObject *obj);
-   void       AddAfter(TObjLink *after, TObject *obj);
-   void       AddBefore(const TObject *before, TObject *obj);
-   void       AddBefore(TObjLink *before, TObject *obj);
+   void       AddFirst(TObject *obj) override;
+   void       AddFirst(TObject *obj, Option_t *opt) override;
+   void       AddLast(TObject *obj) override;
+   void       AddLast(TObject *obj, Option_t *opt) override;
+   void       AddAt(TObject *obj, Int_t idx) override;
+   void       AddAfter(const TObject *after, TObject *obj) override;
+   void       AddAfter(TObjLink *after, TObject *obj) override;
+   void       AddBefore(const TObject *before, TObject *obj) override;
+   void       AddBefore(TObjLink *before, TObject *obj) override;
 
    TClass    *GetClass() const { return fClass; }
    void       SetClass(TClass* cl) { fClass = cl; }
    void       Update(TDictionary *member);
 
-   void       RecursiveRemove(TObject *obj);
-   TObject   *Remove(TObject *obj);
-   TObject   *Remove(TObjLink *lnk);
+   void       RecursiveRemove(TObject *obj) override;
+   TObject   *Remove(TObject *obj) override;
+   TObject   *Remove(TObjLink *lnk) override;
 
    void Load();
    void Unload();
    void Unload(TDictionary *member);
 
-   ClassDef(TListOfDataMembers,2);  // List of TDataMembers for a class
+   ClassDefOverride(TListOfDataMembers,2);  // List of TDataMembers for a class
 };
 
 #endif // ROOT_TListOfDataMembers

--- a/core/meta/inc/TListOfEnumsWithLock.h
+++ b/core/meta/inc/TListOfEnumsWithLock.h
@@ -95,9 +95,9 @@ class TListOfEnumsWithLockIter : public TListIter
 
    using TListIter::operator=;
 
-   TObject *Next();
+   TObject *Next() override;
 
-   ClassDef(TListOfEnumsWithLockIter,0)
+   ClassDefOverride(TListOfEnumsWithLockIter,0)
 };
 
 #endif // ROOT_TListOfEnumsWithLock

--- a/core/meta/inc/TListOfFunctionTemplates.h
+++ b/core/meta/inc/TListOfFunctionTemplates.h
@@ -56,35 +56,35 @@ public:
    TListOfFunctionTemplates(TClass *cl);
    ~TListOfFunctionTemplates();
 
-   virtual void Clear(Option_t *option);
-   virtual void Delete(Option_t *option="");
+   void       Clear(Option_t *option="") override;
+   void       Delete(Option_t *option="") override;
 
    using THashList::FindObject;
-   virtual TObject   *FindObject(const char *name) const;
+   TObject   *FindObject(const char *name) const override;
    virtual TList     *GetListForObject(const char* name) const;
    virtual TList     *GetListForObject(const TObject* obj) const;
 
    TFunctionTemplate *Get(DeclId_t id);
 
-   void       AddFirst(TObject *obj);
-   void       AddFirst(TObject *obj, Option_t *opt);
-   void       AddLast(TObject *obj);
-   void       AddLast(TObject *obj, Option_t *opt);
-   void       AddAt(TObject *obj, Int_t idx);
-   void       AddAfter(const TObject *after, TObject *obj);
-   void       AddAfter(TObjLink *after, TObject *obj);
-   void       AddBefore(const TObject *before, TObject *obj);
-   void       AddBefore(TObjLink *before, TObject *obj);
+   void       AddFirst(TObject *obj) override;
+   void       AddFirst(TObject *obj, Option_t *opt) override;
+   void       AddLast(TObject *obj) override;
+   void       AddLast(TObject *obj, Option_t *opt) override;
+   void       AddAt(TObject *obj, Int_t idx) override;
+   void       AddAfter(const TObject *after, TObject *obj) override;
+   void       AddAfter(TObjLink *after, TObject *obj) override;
+   void       AddBefore(const TObject *before, TObject *obj) override;
+   void       AddBefore(TObjLink *before, TObject *obj) override;
 
-   void       RecursiveRemove(TObject *obj);
-   TObject   *Remove(TObject *obj);
-   TObject   *Remove(TObjLink *lnk);
+   void       RecursiveRemove(TObject *obj) override;
+   TObject   *Remove(TObject *obj) override;
+   TObject   *Remove(TObjLink *lnk) override;
 
    void Load();
    void Unload();
    void Unload(TFunctionTemplate *func);
 
-   ClassDef(TListOfFunctionTemplates,0);  // List of TFunctions for a class
+   ClassDefOverride(TListOfFunctionTemplates,0);  // List of TFunctions for a class
 };
 
 #endif // ROOT_TListOfFunctionTemplates

--- a/core/meta/inc/TListOfFunctions.h
+++ b/core/meta/inc/TListOfFunctions.h
@@ -55,52 +55,51 @@ public:
    TListOfFunctions(TClass *cl);
    ~TListOfFunctions();
 
-   virtual void Clear(Option_t *option);
-   virtual void Delete(Option_t *option="");
+   void       Clear(Option_t *option="") override;
+   void       Delete(Option_t *option="") override;
 
-   virtual TObject   *FindObject(const TObject* obj) const;
-   virtual TObject   *FindObject(const char *name) const;
+   TObject   *FindObject(const TObject* obj) const override;
+   TObject   *FindObject(const char *name) const override;
    virtual TList     *GetListForObject(const char* name) const;
    virtual TList     *GetListForObject(const TObject* obj) const;
-   virtual TIterator *MakeIterator(Bool_t dir = kIterForward) const;
+   TIterator *MakeIterator(Bool_t dir = kIterForward) const override;
 
-   virtual TObject  *At(Int_t idx) const;
-   virtual TObject  *After(const TObject *obj) const;
-   virtual TObject  *Before(const TObject *obj) const;
-   virtual TObject  *First() const;
-   virtual TObjLink *FirstLink() const;
-   virtual TObject **GetObjectRef(const TObject *obj) const;
-   virtual TObject  *Last() const;
-   virtual TObjLink *LastLink() const;
+   TObject   *At(Int_t idx) const override;
+   TObject   *After(const TObject *obj) const override;
+   TObject   *Before(const TObject *obj) const override;
+   TObject   *First() const override;
+   TObjLink  *FirstLink() const override;
+   TObject  **GetObjectRef(const TObject *obj) const override;
+   TObject   *Last() const override;
+   TObjLink  *LastLink() const override;
 
-   virtual Int_t     GetLast() const;
-   virtual Int_t     IndexOf(const TObject *obj) const;
+   Int_t      GetLast() const override;
+   Int_t      IndexOf(const TObject *obj) const override;
 
-   virtual Int_t      GetSize() const;
-
+   Int_t      GetSize() const override;
 
    TFunction *Find(DeclId_t id) const;
    TFunction *Get(DeclId_t id);
 
-   void       AddFirst(TObject *obj);
-   void       AddFirst(TObject *obj, Option_t *opt);
-   void       AddLast(TObject *obj);
-   void       AddLast(TObject *obj, Option_t *opt);
-   void       AddAt(TObject *obj, Int_t idx);
-   void       AddAfter(const TObject *after, TObject *obj);
-   void       AddAfter(TObjLink *after, TObject *obj);
-   void       AddBefore(const TObject *before, TObject *obj);
-   void       AddBefore(TObjLink *before, TObject *obj);
+   void       AddFirst(TObject *obj) override;
+   void       AddFirst(TObject *obj, Option_t *opt) override;
+   void       AddLast(TObject *obj) override;
+   void       AddLast(TObject *obj, Option_t *opt) override;
+   void       AddAt(TObject *obj, Int_t idx) override;
+   void       AddAfter(const TObject *after, TObject *obj) override;
+   void       AddAfter(TObjLink *after, TObject *obj) override;
+   void       AddBefore(const TObject *before, TObject *obj) override;
+   void       AddBefore(TObjLink *before, TObject *obj) override;
 
-   void       RecursiveRemove(TObject *obj);
-   TObject   *Remove(TObject *obj);
-   TObject   *Remove(TObjLink *lnk);
+   void       RecursiveRemove(TObject *obj) override;
+   TObject   *Remove(TObject *obj) override;
+   TObject   *Remove(TObjLink *lnk) override;
 
    void Load();
    void Unload();
    void Unload(TFunction *func);
 
-   ClassDef(TListOfFunctions,0);  // List of TFunctions for a class
+   ClassDefOverride(TListOfFunctions,0);  // List of TFunctions for a class
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -117,9 +116,9 @@ public:
 
    using TListIter::operator=;
 
-   TObject           *Next();
+   TObject           *Next() override;
 
-   ClassDef(TListOfFunctionsIter,0)
+   ClassDefOverride(TListOfFunctionsIter,0)
 };
 
 

--- a/core/meta/inc/TMemberStreamer.h
+++ b/core/meta/inc/TMemberStreamer.h
@@ -25,7 +25,7 @@
 
 class TMemberStreamer {
 protected:
-   TMemberStreamer() : fStreamer(0) {};
+   TMemberStreamer() : fStreamer(nullptr) {};
 
 public:
    TMemberStreamer(MemberStreamerFunc_t pointer) : fStreamer(pointer) {};

--- a/core/meta/inc/TMethod.h
+++ b/core/meta/inc/TMethod.h
@@ -44,28 +44,28 @@ private:
    TMethodCall            *fGetterMethod;    //methodcall for state getter in case this is a *TOGGLE method
    TMethodCall            *fSetterMethod;    //methodcall for state setter in case this is a *TOGGLE method
 
-   void                    CreateSignature();
+   void                    CreateSignature() override;
    void                    SetMenuItem(const char *docstring);    //Must not be virtual. Used in constructor.
 public:
-                           TMethod(MethodInfo_t *info = 0, TClass *cl = 0);
-                           TMethod(const TMethod &org);
+   TMethod(MethodInfo_t *info = nullptr, TClass *cl = nullptr);
+   TMethod(const TMethod &org);
+   virtual ~TMethod();
    TMethod&                operator=(const TMethod &rhs);
-   virtual                ~TMethod();
-   virtual TObject        *Clone(const char *newname="") const;
+   TObject                *Clone(const char *newname="") const override;
    TClass                 *GetClass() const { return fClass; }
    EMenuItemKind           IsMenuItem() const { return fMenuItem; }
-   virtual Bool_t          IsValid();
+   Bool_t                  IsValid() override;
    virtual const char     *GetCommentString();
    virtual const char     *Getter() const { return fGetter; }
    virtual TMethodCall    *GetterMethod();
    virtual TMethodCall    *SetterMethod();
    virtual TDataMember    *FindDataMember();
    virtual TList          *GetListOfMethodArgs();
-   virtual void            SetMenuItem(EMenuItemKind menuItem) {fMenuItem=menuItem;}
+   virtual void            SetMenuItem(EMenuItemKind menuItem) { fMenuItem = menuItem; }
 
-   virtual Bool_t          Update(MethodInfo_t *info);
+   Bool_t                  Update(MethodInfo_t *info) override;
 
-   ClassDef(TMethod,0)  //Dictionary for a class member function (method)
+   ClassDefOverride(TMethod,0)  //Dictionary for a class member function (method)
 };
 
 #endif

--- a/core/meta/inc/TMethodArg.h
+++ b/core/meta/inc/TMethodArg.h
@@ -53,14 +53,14 @@ public:
    const char    *GetTypeName() const;
    const char    *GetFullTypeName() const;
    std::string    GetTypeNormalizedName() const;
-   Long_t         Property() const;
+   Long_t         Property() const override;
 
    TDataMember   *GetDataMember() const;
    TList         *GetOptions() const;
 
    void           Update(MethodArgInfo_t *info);
 
-   ClassDef(TMethodArg,0)  //Dictionary for a method argument
+   ClassDefOverride(TMethodArg,0)  //Dictionary for a method argument
 };
 
 #endif

--- a/core/meta/inc/TMethodCall.h
+++ b/core/meta/inc/TMethodCall.h
@@ -61,8 +61,8 @@ private:
    Bool_t         fDtorOnly;  //call only dtor and not delete when calling ~xxx
    EReturnType    fRetType;   //method return type
 
-   void Execute(const char *,  const char *, int * /*error*/ = 0) { }    // versions of TObject
-   void Execute(TMethod *, TObjArray *, int * /*error*/ = 0) { }
+   void Execute(const char *,  const char *, int * /*error*/ = nullptr) override { }    // versions of TObject
+   void Execute(TMethod *, TObjArray *, int * /*error*/ = nullptr) override { }
 
    void InitImplementation(const char *methodname, const char *params, const char *proto, Bool_t objectIsConst, TClass *cl, const ClassInfo_t *cinfo, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
 
@@ -83,7 +83,7 @@ public:
    void           InitWithPrototype(TClass *cl, const char *method, const char *proto, Bool_t objectIsConst = kFALSE, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    void           InitWithPrototype(const char *function, const char *proto, ROOT::EFunctionMatchMode mode = ROOT::kConversionMatch);
    Bool_t         IsValid() const;
-   TObject       *Clone(const char *newname="") const;
+   TObject       *Clone(const char *newname="") const override;
    void           CallDtorOnly(Bool_t set = kTRUE) { fDtorOnly = set; }
 
    TFunction     *GetMethod();
@@ -123,9 +123,9 @@ public:
    void     Execute(Double_t &retDouble);
    void     Execute(const char *params, Double_t &retDouble);
 
-   void     Execute(void *objAddress, const void* args[], int nargs, void *ret = 0);
+   void     Execute(void *objAddress, const void* args[], int nargs, void *ret = nullptr);
 
-   ClassDef(TMethodCall,0)  //Method calling interface
+   ClassDefOverride(TMethodCall,0)  //Method calling interface
 };
 
 inline void TMethodCall::Execute()

--- a/core/meta/inc/TProtoClass.h
+++ b/core/meta/inc/TProtoClass.h
@@ -95,7 +95,7 @@ private:
 
 public:
    TProtoClass():
-      fBase(0), fEnums(0), fSizeof(0), fCheckSum(0), fCanSplit(0),
+      fBase(nullptr), fEnums(nullptr), fSizeof(0), fCheckSum(0), fCanSplit(0),
       fStreamerType(0), fProperty(0), fClassProperty(0),
       fOffsetStreamer(0) {
    }
@@ -105,10 +105,8 @@ public:
    virtual ~TProtoClass();
 
    Bool_t FillTClass(TClass *pcl);
-   const TList *GetListOfEnums() {
-      return fEnums;
-   };
-   void Delete(Option_t *opt = "");
+   const TList *GetListOfEnums() { return fEnums; };
+   void Delete(Option_t *opt = "") override;
 
    int GetSize() { return fSizeof; }
    TList * GetBaseList() { return fBase; }
@@ -118,8 +116,7 @@ public:
    std::vector<TDataMember *> & GetData() { return fData; }
    std::vector<TString> & GetDepClasses() { return fDepClasses; }
 
-
-   ClassDef(TProtoClass, 2); //Persistent TClass
+   ClassDefOverride(TProtoClass, 2); //Persistent TClass
 };
 
 #endif

--- a/core/meta/inc/TRealData.h
+++ b/core/meta/inc/TRealData.h
@@ -49,17 +49,17 @@ public:
    virtual     ~TRealData();
 
    void                AdoptStreamer(TMemberStreamer *p);
-   virtual const char *GetName() const {return fName.Data();}
-   TDataMember        *GetDataMember() const {return fDataMember;}
+   const char         *GetName() const override { return fName.Data(); }
+   TDataMember        *GetDataMember() const { return fDataMember; }
    TMemberStreamer    *GetStreamer() const;
-   Long_t              GetThisOffset() const {return fThisOffset;}
-   Bool_t              IsObject() const {return fIsObject;}
-   void                SetIsObject(Bool_t isObject) {fIsObject=isObject;}
+   Long_t              GetThisOffset() const { return fThisOffset; }
+   Bool_t              IsObject() const { return fIsObject; }
+   void                SetIsObject(Bool_t isObject) { fIsObject = isObject; }
    void                WriteRealData(void *pointer, char *&buffer);
 
    static void         GetName(TString &output, TDataMember *dm);
 
-   ClassDef(TRealData,0)  //Description of persistent data members
+   ClassDefOverride(TRealData,0)  //Description of persistent data members
 };
 
 #endif

--- a/core/meta/inc/TSchemaRule.h
+++ b/core/meta/inc/TSchemaRule.h
@@ -16,7 +16,7 @@ class TObjArray;
 
 namespace ROOT {
 
-   class TSchemaRule: public TObject
+   class TSchemaRule : public TObject
    {
       public:
 
@@ -24,10 +24,10 @@ namespace ROOT {
          private:
             TString fDimensions;
          public:
-            TSources(const char *name = 0, const char *title = 0, const char *dims = 0) : TNamed(name,title),fDimensions(dims) {}
+            TSources(const char *name = nullptr, const char *title = nullptr, const char *dims = nullptr) : TNamed(name,title), fDimensions(dims) {}
             const char *GetDimensions() { return fDimensions; }
 
-            ClassDef(TSources,2);
+            ClassDefOverride(TSources,2);
          };
 
          typedef enum
@@ -48,7 +48,7 @@ namespace ROOT {
          Bool_t operator == ( const TSchemaRule& rhs ) const;
 
 
-         void             Clear(Option_t * /*option*/ ="");
+         void             Clear(Option_t * /*option*/ ="") override;
          Bool_t           SetFromRule( const char *rule );
 
          const char      *GetVersion( ) const;
@@ -88,9 +88,7 @@ namespace ROOT {
          Bool_t           Conflicts( const TSchemaRule* rule ) const;
 
          void             AsString( TString &out, const char *options = "" ) const;
-         void             ls(Option_t *option="") const;
-
-         ClassDef( TSchemaRule, 1 );
+         void             ls(Option_t *option="") const override;
 
       private:
 
@@ -118,6 +116,9 @@ namespace ROOT {
          ReadRawFuncPtr_t             fReadRawFuncPtr; //! Conversion function pointer for readraw rule
          RuleType_t                   fRuleType;       //  Type of the rule
          TString                      fAttributes;     //  Attributes to be applied to the member (like Owner/NotOwner)
+
+      ClassDefOverride( TSchemaRule, 1 );
+
    };
 } // End of namespace ROOT
 

--- a/core/meta/inc/TSchemaRuleSet.h
+++ b/core/meta/inc/TSchemaRuleSet.h
@@ -61,10 +61,8 @@ namespace Detail {
       void                RemoveRules( TObjArray* rules );
       void                SetClass( TClass* cls );
 
-      void                ls(Option_t *option="") const;
+      void                ls(Option_t *option="") const override;
       void                AsString(TString &out) const;
-
-      ClassDef( TSchemaRuleSet, 1 )
 
    private:
       TObjArray* fPersistentRules; //  Array of the rules that will be embeded in the file
@@ -74,6 +72,9 @@ namespace Detail {
       TString    fClassName;       //  Target class name
       Int_t      fVersion;         //  Target class version
       UInt_t     fCheckSum;        //  Target class checksum
+
+   ClassDefOverride( TSchemaRuleSet, 1 )
+
    };
 
 } // End of Namespace Detail

--- a/core/meta/inc/TStreamerElement.h
+++ b/core/meta/inc/TStreamerElement.h
@@ -12,7 +12,6 @@
 #ifndef ROOT_TStreamerElement
 #define ROOT_TStreamerElement
 
-
 //////////////////////////////////////////////////////////////////////////
 //                                                                      //
 // TStreamerElement                                                     //
@@ -125,13 +124,13 @@ public:
    Double_t         GetFactor() const {return fFactor;}
    Double_t         GetXmin()   const {return fXmin;}
    Double_t         GetXmax()   const {return fXmax;}
-   virtual void     Init(TVirtualStreamerInfo *obj=0);
+   virtual void     Init(TVirtualStreamerInfo *obj = nullptr);
    virtual Bool_t   IsaPointer() const {return kFALSE;}
    virtual Bool_t   HasCounter() const {return kFALSE;}
    virtual Bool_t   IsOldFormat(const char *newTypeName);
    virtual Bool_t   IsBase() const;
    virtual Bool_t   IsTransient() const;
-   virtual void     ls(Option_t *option="") const;
+   void             ls(Option_t *option="") const override;
    virtual void     SetArrayDim(Int_t dim);
    virtual void     SetMaxIndex(Int_t dim, Int_t max);
    virtual void     SetOffset(Int_t offset) {fOffset=offset;}
@@ -144,7 +143,7 @@ public:
    virtual void     SetTypeName(const char *name) {fTypeName = name; fClassObject = (TClass*)-1; }
    virtual void     Update(const TClass *oldClass, TClass *newClass);
 
-   ClassDef(TStreamerElement,4)  //Base class for one element (data member) to be Streamed
+   ClassDefOverride(TStreamerElement,4)  //Base class for one element (data member) to be Streamed
 };
 
 //________________________________________________________________________
@@ -173,26 +172,26 @@ public:
    virtual         ~TStreamerBase();
    Int_t            GetBaseVersion() {return fBaseVersion;}
    UInt_t           GetBaseCheckSum() {return fBaseCheckSum;}
-   virtual TClass  *GetClassPointer() const;
+   TClass          *GetClassPointer() const override;
    const char      *GetErrorMessage() const { return fErrorMsg; }
-   const char      *GetInclude() const;
+   const char      *GetInclude() const override;
    TClass          *GetNewBaseClass() { return fNewBaseClass; }
-   ULongptr_t       GetMethod() const {return 0;}
-   Int_t            GetSize() const;
-   TVirtualStreamerInfo *GetBaseStreamerInfo () const { return fStreamerInfo; }
-   virtual void     Init(TVirtualStreamerInfo *obj=0);
+   ULongptr_t       GetMethod() const override {return 0;}
+   Int_t            GetSize() const override;
+   TVirtualStreamerInfo *GetBaseStreamerInfo() const { return fStreamerInfo; }
+   void             Init(TVirtualStreamerInfo *obj = nullptr) override;
    void             Init(Bool_t isTransient = kFALSE);
-   Bool_t           IsBase() const;
-   virtual void     ls(Option_t *option="") const;
+   Bool_t           IsBase() const override;
+   void             ls(Option_t *option="") const override;
    Int_t            ReadBuffer (TBuffer &b, char *pointer);
    void             SetNewBaseClass( TClass* cl ) { fNewBaseClass = cl; InitStreaming(kFALSE); }
    void             SetBaseVersion(Int_t v) {fBaseVersion = v;}
    void             SetBaseCheckSum(UInt_t cs) {fBaseCheckSum = cs;}
    void             SetErrorMessage(const char *msg) { fErrorMsg = msg; }
-   virtual void     Update(const TClass *oldClass, TClass *newClass);
+   void             Update(const TClass *oldClass, TClass *newClass) override;
    Int_t            WriteBuffer(TBuffer &b, char *pointer);
 
-   ClassDef(TStreamerBase,3)  //Streamer element of type base class
+   ClassDefOverride(TStreamerBase,3)  //Streamer element of type base class
 };
 
 //________________________________________________________________________
@@ -214,22 +213,22 @@ public:
    TStreamerBasicPointer(const char *name, const char *title, Int_t offset, Int_t dtype,
                          const char *countName, const char *countClass, Int_t version, const char *typeName);
    virtual       ~TStreamerBasicPointer();
-   TClass        *GetClassPointer() const { return nullptr; }
+   TClass        *GetClassPointer() const override { return nullptr; }
    const char    *GetCountClass()   const {return fCountClass.Data();}
    const char    *GetCountName()    const {return fCountName.Data();}
    Int_t          GetCountVersion() const {return fCountVersion;}
-   ULongptr_t     GetMethod() const;
-   Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj=0);
-   virtual Bool_t HasCounter() const                {return fCounter!=0;   }
-   virtual Bool_t IsaPointer() const                {return kTRUE;         }
-   void           SetArrayDim(Int_t dim);
-   void           SetCountClass(const char *clname) {fCountClass = clname; }
-   void           SetCountName(const char *name)    {fCountName = name;    }
-   void           SetCountVersion(Int_t count)      {fCountVersion = count;}
-   virtual void   Update(const TClass * /* oldClass */, TClass * /*newClass*/ ) {}
+   ULongptr_t     GetMethod() const override;
+   Int_t          GetSize() const override;
+   void           Init(TVirtualStreamerInfo *obj = nullptr) override;
+   Bool_t         HasCounter() const override { return fCounter != nullptr; }
+   Bool_t         IsaPointer() const override { return kTRUE; }
+   void           SetArrayDim(Int_t dim) override;
+   void           SetCountClass(const char *clname) { fCountClass = clname; }
+   void           SetCountName(const char *name)    { fCountName = name; }
+   void           SetCountVersion(Int_t count)      { fCountVersion = count; }
+   void           Update(const TClass * /* oldClass */, TClass * /*newClass*/ ) override {}
 
-   ClassDef(TStreamerBasicPointer,2)  //Streamer element for a pointer to a basic type
+   ClassDefOverride(TStreamerBasicPointer,2)  //Streamer element for a pointer to a basic type
 };
 
 //________________________________________________________________________
@@ -253,17 +252,17 @@ public:
    const char    *GetCountClass()   const {return fCountClass.Data();}
    const char    *GetCountName()    const {return fCountName.Data();}
    Int_t          GetCountVersion() const {return fCountVersion;}
-   const char    *GetInclude() const;
-   ULongptr_t     GetMethod() const;
-   Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
-   virtual Bool_t IsaPointer() const                {return kTRUE;         }
-   virtual Bool_t HasCounter() const                {return fCounter!=0;   }
-   void           SetCountClass(const char *clname) {fCountClass = clname; }
-   void           SetCountName(const char *name)    {fCountName = name;    }
-   void           SetCountVersion(Int_t count)      {fCountVersion = count;}
+   const char    *GetInclude() const override;
+   ULongptr_t     GetMethod() const override;
+   Int_t          GetSize() const override;
+   void           Init(TVirtualStreamerInfo *obj = nullptr) override;
+   Bool_t         IsaPointer() const override {return kTRUE; }
+   Bool_t         HasCounter() const  override { return fCounter != nullptr; }
+   void           SetCountClass(const char *clname) { fCountClass = clname; }
+   void           SetCountName(const char *name) { fCountName = name; }
+   void           SetCountVersion(Int_t count) { fCountVersion = count; }
 
-   ClassDef(TStreamerLoop,2)  //Streamer element for a pointer to an array of objects
+   ClassDefOverride(TStreamerLoop,2)  //Streamer element for a pointer to an array of objects
 };
 
 //________________________________________________________________________
@@ -281,13 +280,13 @@ public:
    TStreamerBasicType();
    TStreamerBasicType(const char *name, const char *title, Int_t offset, Int_t dtype, const char *typeName);
    virtual       ~TStreamerBasicType();
-   TClass        *GetClassPointer() const { return nullptr; }
-   Int_t          GetCounter() const {return fCounter;}
-   ULongptr_t     GetMethod() const;
-   Int_t          GetSize() const;
-   virtual void   Update(const TClass * /* oldClass */, TClass * /* newClass */) {}
+   TClass        *GetClassPointer() const override { return nullptr; }
+   Int_t          GetCounter() const { return fCounter; }
+   ULongptr_t     GetMethod() const override;
+   Int_t          GetSize() const override;
+   void           Update(const TClass * /* oldClass */, TClass * /* newClass */) override {}
 
-   ClassDef(TStreamerBasicType,2)  //Streamer element for a basic type
+   ClassDefOverride(TStreamerBasicType,2)  //Streamer element for a basic type
 };
 
 //________________________________________________________________________
@@ -302,11 +301,11 @@ public:
    TStreamerObject();
    TStreamerObject(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObject();
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
+   void           Init(TVirtualStreamerInfo *obj = nullptr) override;
 
-   ClassDef(TStreamerObject,2)  //Streamer element of type object
+   ClassDefOverride(TStreamerObject,2)  //Streamer element of type object
 };
 
 //________________________________________________________________________
@@ -321,11 +320,11 @@ public:
    TStreamerObjectAny();
    TStreamerObjectAny(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObjectAny();
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj=0);
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
+   void           Init(TVirtualStreamerInfo *obj = nullptr) override;
 
-   ClassDef(TStreamerObjectAny,2)  //Streamer element of type object other than TObject
+   ClassDefOverride(TStreamerObjectAny,2)  //Streamer element of type object other than TObject
 };
 
 //________________________________________________________________________
@@ -340,13 +339,13 @@ public:
    TStreamerObjectPointer();
    TStreamerObjectPointer(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObjectPointer();
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
-   virtual Bool_t IsaPointer() const {return kTRUE;}
-   virtual void   SetArrayDim(Int_t dim);
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
+   void           Init(TVirtualStreamerInfo *obj = nullptr) override;
+   Bool_t         IsaPointer() const override {return kTRUE;}
+   void           SetArrayDim(Int_t dim) override;
 
-   ClassDef(TStreamerObjectPointer,2)  //Streamer element of type pointer to a TObject
+   ClassDefOverride(TStreamerObjectPointer,2)  //Streamer element of type pointer to a TObject
 };
 
 //________________________________________________________________________
@@ -361,13 +360,13 @@ public:
    TStreamerObjectAnyPointer();
    TStreamerObjectAnyPointer(const char *name, const char *title, Int_t offset, const char *typeName);
    virtual       ~TStreamerObjectAnyPointer();
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
-   virtual void   Init(TVirtualStreamerInfo *obj = nullptr);
-   virtual Bool_t IsaPointer() const {return kTRUE;}
-   virtual void   SetArrayDim(Int_t dim);
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
+   void           Init(TVirtualStreamerInfo *obj = nullptr) override;
+   Bool_t         IsaPointer() const override { return kTRUE; }
+   void           SetArrayDim(Int_t dim) override;
 
-   ClassDef(TStreamerObjectAnyPointer,1)  //Streamer element of type pointer to a non TObject
+   ClassDefOverride(TStreamerObjectAnyPointer,1)  //Streamer element of type pointer to a non TObject
 };
 
 //________________________________________________________________________
@@ -382,10 +381,10 @@ public:
    TStreamerString();
    TStreamerString(const char *name, const char *title, Int_t offset);
    virtual       ~TStreamerString();
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
 
-   ClassDef(TStreamerString,2)  //Streamer element of type TString
+   ClassDefOverride(TStreamerString,2)  //Streamer element of type TString
 };
 
 //________________________________________________________________________
@@ -407,19 +406,19 @@ public:
    TStreamerSTL(const char *name, const char *title, Int_t offset,
                 const char *typeName, const TVirtualCollectionProxy &proxy , Bool_t dmPointer);
    virtual       ~TStreamerSTL();
-   Bool_t         CannotSplit() const;
-   Bool_t         IsaPointer() const;
-   Bool_t         IsBase() const;
+   Bool_t         CannotSplit() const override;
+   Bool_t         IsaPointer() const override;
+   Bool_t         IsBase() const override;
    Int_t          GetSTLtype() const {return fSTLtype;}
    Int_t          GetCtype()   const {return fCtype;}
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
-   virtual void   ls(Option_t *option="") const;
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
+   void           ls(Option_t *option="") const override;
    void           SetSTLtype(Int_t t) {fSTLtype = t;}
    void           SetCtype(Int_t t) {fCtype = t;}
-   virtual void   SetStreamer(TMemberStreamer *streamer);
+   void           SetStreamer(TMemberStreamer *streamer) override;
 
-   ClassDef(TStreamerSTL,3)  //Streamer element of type STL container
+   ClassDefOverride(TStreamerSTL,3)  //Streamer element of type STL container
 };
 
 //________________________________________________________________________
@@ -435,10 +434,10 @@ public:
    TStreamerSTLstring(const char *name, const char *title, Int_t offset,
                       const char *typeName, Bool_t dmPointer);
    virtual       ~TStreamerSTLstring();
-   const char    *GetInclude() const;
-   Int_t          GetSize() const;
+   const char    *GetInclude() const override;
+   Int_t          GetSize() const override;
 
-   ClassDef(TStreamerSTLstring,2)  //Streamer element of type  C++ string
+   ClassDefOverride(TStreamerSTLstring,2)  //Streamer element of type  C++ string
 };
 
 class TVirtualObject;
@@ -468,7 +467,7 @@ public:
    ROOT::TSchemaRule::ReadFuncPtr_t     GetReadFunc();
    ROOT::TSchemaRule::ReadRawFuncPtr_t  GetReadRawFunc();
 
-   ClassDef(TStreamerArtificial, 0); // StreamerElement injected by a TSchemaRule. Transient only to preverse forward compatibility.
+   ClassDefOverride(TStreamerArtificial, 0); // StreamerElement injected by a TSchemaRule. Transient only to preserve forward compatibility.
 };
 
 #endif

--- a/core/meta/inc/TVirtualStreamerInfo.h
+++ b/core/meta/inc/TVirtualStreamerInfo.h
@@ -139,7 +139,7 @@ public:
    virtual void        BuildOld() = 0;
    virtual Bool_t      BuildFor( const TClass *cl ) = 0;
    virtual void        CallShowMembers(const void* obj, TMemberInspector &insp, Bool_t isTransient) const = 0;
-   virtual void        Clear(Option_t *) = 0;
+   virtual void        Clear(Option_t * = "") override = 0;
    virtual Bool_t      CompareContent(TClass *cl,TVirtualStreamerInfo *info, Bool_t warn, Bool_t complete, TFile *file) = 0;
    virtual void        Compile() = 0;
    virtual void        ForceWriteInfo(TFile *file, Bool_t force=kFALSE) = 0;
@@ -163,10 +163,10 @@ public:
            Bool_t      IsCompiled() const { return fIsCompiled; }
            Bool_t      IsOptimized() const { return fOptimized; }
            Int_t       IsRecovered() const { return TestBit(kRecovered); }
-   virtual void        ls(Option_t *option="") const = 0;
+   virtual void        ls(Option_t * = "") const override = 0;
    virtual TVirtualStreamerInfo *NewInfo(TClass *cl) = 0;
    virtual void       *New(void *obj = 0) = 0;
-   virtual void       *NewArray(Long_t nElements, void* ary = 0) = 0;
+   virtual void       *NewArray(Long_t nElements, void* ary = nullptr) = 0;
    virtual void        Destructor(void* p, Bool_t dtorOnly = kFALSE) = 0;
    virtual void        DeleteArray(void* p, Bool_t dtorOnly = kFALSE) = 0;
 
@@ -203,7 +203,7 @@ public:
    static TVirtualStreamerInfo *Factory();
 
    //WARNING this class version must be the same as TStreamerInfo
-   ClassDef(TVirtualStreamerInfo,6)  //Abstract Interface describing Streamer information for one class
+   ClassDefOverride(TVirtualStreamerInfo,6)  //Abstract Interface describing Streamer information for one class
 };
 
 #ifdef _MSC_VER

--- a/core/thread/inc/TCondition.h
+++ b/core/thread/inc/TCondition.h
@@ -53,7 +53,7 @@ public:
    Int_t   Signal() { if (fConditionImp) return fConditionImp->Signal(); return -1; }
    Int_t   Broadcast() { if (fConditionImp) return fConditionImp->Broadcast(); return -1; }
 
-   ClassDef(TCondition,0)  // Condition variable class
+   ClassDefOverride(TCondition,0)  // Condition variable class
 };
 
 #endif

--- a/core/thread/inc/TConditionImp.h
+++ b/core/thread/inc/TConditionImp.h
@@ -34,7 +34,7 @@ public:
    virtual Int_t  Signal() = 0;
    virtual Int_t  Broadcast() = 0;
 
-   ClassDef(TConditionImp,0)  // Condition variable implementation ABC
+   ClassDefOverride(TConditionImp,0)  // Condition variable implementation ABC
 };
 
 #endif

--- a/core/thread/inc/TMutex.h
+++ b/core/thread/inc/TMutex.h
@@ -42,18 +42,18 @@ public:
    TMutex(Bool_t recursive = kFALSE);
    virtual ~TMutex() { delete fMutexImp; }
 
-   Int_t  Lock();
-   Int_t  TryLock();
-   Int_t  UnLock();
-   Int_t  CleanUp();
+   Int_t  Lock() override;
+   Int_t  TryLock() override;
+   Int_t  UnLock() override;
+   Int_t  CleanUp() override;
 
    // Compatibility with standard library
    void lock() { TMutex::Lock(); }
    void unlock() { TMutex::UnLock(); }
 
-   TVirtualMutex *Factory(Bool_t recursive = kFALSE);
+   TVirtualMutex *Factory(Bool_t recursive = kFALSE) override;
 
-   ClassDef(TMutex,0)  // Mutex lock class
+   ClassDefOverride(TMutex,0)  // Mutex lock class
 };
 
 #endif

--- a/core/thread/inc/TMutexImp.h
+++ b/core/thread/inc/TMutexImp.h
@@ -34,7 +34,7 @@ public:
    virtual Int_t  TryLock() = 0;
    virtual Int_t  UnLock() = 0;
 
-   ClassDef(TMutexImp,0)  // Mutex lock implementation ABC
+   ClassDefOverride(TMutexImp,0)  // Mutex lock implementation ABC
 };
 
 #endif

--- a/core/thread/inc/TPosixCondition.h
+++ b/core/thread/inc/TPosixCondition.h
@@ -44,12 +44,12 @@ public:
    TPosixCondition(TMutexImp *m);
    virtual ~TPosixCondition();
 
-   Int_t  Wait();
-   Int_t  TimedWait(ULong_t secs, ULong_t nanoSecs = 0);
-   Int_t  Signal();
-   Int_t  Broadcast();
+   Int_t  Wait() override;
+   Int_t  TimedWait(ULong_t secs, ULong_t nanoSecs = 0) override;
+   Int_t  Signal() override;
+   Int_t  Broadcast() override;
 
-   ClassDef(TPosixCondition,0)   // Posix condition variable
+   ClassDefOverride(TPosixCondition,0)   // Posix condition variable
 };
 
 #endif

--- a/core/thread/inc/TPosixMutex.h
+++ b/core/thread/inc/TPosixMutex.h
@@ -42,11 +42,11 @@ public:
    TPosixMutex(Bool_t recursive=kFALSE);
    virtual ~TPosixMutex();
 
-   Int_t  Lock();
-   Int_t  UnLock();
-   Int_t  TryLock();
+   Int_t  Lock() override;
+   Int_t  UnLock() override;
+   Int_t  TryLock() override;
 
-   ClassDef(TPosixMutex,0)  // Posix mutex lock
+   ClassDefOverride(TPosixMutex,0)  // Posix mutex lock
 };
 
 #endif

--- a/core/thread/inc/TPosixThread.h
+++ b/core/thread/inc/TPosixThread.h
@@ -38,23 +38,23 @@ public:
    TPosixThread() { }
    ~TPosixThread() { }
 
-   virtual Int_t  Join(TThread *th, void **ret);
-   virtual Long_t SelfId();
-   virtual Int_t  Run(TThread *th, const int affinity = -1);
+   Int_t  Join(TThread *th, void **ret) override;
+   Long_t SelfId() override;
+   Int_t  Run(TThread *th, const int affinity = -1) override;
 
-   virtual Int_t  Kill(TThread *th);
-   virtual Int_t  SetCancelOff();
-   virtual Int_t  SetCancelOn();
-   virtual Int_t  SetCancelAsynchronous();
-   virtual Int_t  SetCancelDeferred();
-   virtual Int_t  CancelPoint();
-   virtual Int_t  CleanUpPush(void **main, void *free,void *arg);
-   virtual Int_t  CleanUpPop(void **main, Int_t exe);
-   virtual Int_t  CleanUp(void **main);
+   Int_t  Kill(TThread *th) override;
+   Int_t  SetCancelOff() override;
+   Int_t  SetCancelOn() override;
+   Int_t  SetCancelAsynchronous() override;
+   Int_t  SetCancelDeferred() override;
+   Int_t  CancelPoint() override;
+   Int_t  CleanUpPush(void **main, void *free,void *arg) override;
+   Int_t  CleanUpPop(void **main, Int_t exe) override;
+   Int_t  CleanUp(void **main) override;
 
-   virtual Int_t  Exit(void *ret);
+   Int_t  Exit(void *ret) override;
 
-   ClassDef(TPosixThread,0)  // TPosixThread class
+   ClassDefOverride(TPosixThread,0)  // TPosixThread class
 };
 
 

--- a/core/thread/inc/TPosixThreadFactory.h
+++ b/core/thread/inc/TPosixThreadFactory.h
@@ -34,11 +34,11 @@ public:
    TPosixThreadFactory(const char *name = "Posix", const char *title = "Posix Thread Factory");
    virtual ~TPosixThreadFactory() { }
 
-   virtual TMutexImp      *CreateMutexImp(Bool_t recursive);
-   virtual TConditionImp  *CreateConditionImp(TMutexImp *m);
-   virtual TThreadImp     *CreateThreadImp();
+   TMutexImp      *CreateMutexImp(Bool_t recursive) override;
+   TConditionImp  *CreateConditionImp(TMutexImp *m) override;
+   TThreadImp     *CreateThreadImp() override;
 
-   ClassDef(TPosixThreadFactory,0)  // Posix thread factory
+   ClassDefOverride(TPosixThreadFactory,0)  // Posix thread factory
 };
 
 #endif

--- a/core/thread/inc/TRWLock.h
+++ b/core/thread/inc/TRWLock.h
@@ -48,7 +48,7 @@ public:
    Int_t  WriteLock();
    Int_t  WriteUnLock();
 
-   ClassDef(TRWLock,0)  // Reader/writer lock
+   ClassDefOverride(TRWLock,0)  // Reader/writer lock
 };
 
 #endif

--- a/core/thread/inc/TSemaphore.h
+++ b/core/thread/inc/TSemaphore.h
@@ -46,7 +46,7 @@ public:
    Int_t  TryWait();
    Int_t  Post();
 
-   ClassDef(TSemaphore, 0)  // Counting semaphore
+   ClassDefOverride(TSemaphore, 0)  // Counting semaphore
 };
 
 #endif

--- a/core/thread/inc/TThread.h
+++ b/core/thread/inc/TThread.h
@@ -102,7 +102,7 @@ private:
    void           Constructor();
    void           SetComment(const char *txt = nullptr)
                      { fComment[0] = 0; if (txt) { strncpy(fComment, txt, 99); fComment[99] = 0; } }
-   void           DoError(Int_t level, const char *location, const char *fmt, va_list va) const;
+   void           DoError(Int_t level, const char *location, const char *fmt, va_list va) const override;
    void           ErrorHandler(int level, const char *location, const char *fmt, va_list ap) const;
    static void    Init();
    static void   *Function(void *ptr);
@@ -124,7 +124,7 @@ public:
    Int_t            Kill();
    Int_t            Run(void *arg = nullptr, const int affinity = -1);
    void             SetPriority(EPriority pri);
-   void             Delete(Option_t *option="") { TObject::Delete(option); }
+   void             Delete(Option_t *option="") override { TObject::Delete(option); }
    EPriority        GetPriority() const { return fPriority; }
    EState           GetState() const { return fState; }
    Long_t           GetId() const { return fId; }
@@ -177,7 +177,7 @@ public:
    ;
    static void      XAction();
 
-   ClassDef(TThread,0)  // Thread class
+   ClassDefOverride(TThread,0)  // Thread class
 };
 
 
@@ -206,7 +206,7 @@ public:
    // can not exit and have its caller react to the other TTimer's actions (like the request
    // to stop the event loop) until there is another type of event.
    TThreadTimer(Long_t ms = kItimerResolution + 10);
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 #endif

--- a/core/thread/inc/TThreadFactory.h
+++ b/core/thread/inc/TThreadFactory.h
@@ -39,7 +39,7 @@ public:
    virtual TConditionImp  *CreateConditionImp(TMutexImp *m) = 0;
    virtual TThreadImp     *CreateThreadImp() = 0;
 
-   ClassDef(TThreadFactory,0)  // Thread factory ABC
+   ClassDefOverride(TThreadFactory,0)  // Thread factory ABC
 };
 
 R__EXTERN TThreadFactory *gThreadFactory;

--- a/core/thread/inc/TThreadImp.h
+++ b/core/thread/inc/TThreadImp.h
@@ -49,7 +49,7 @@ public:
 
    virtual Int_t  Exit(void *ret) = 0;
 
-   ClassDef(TThreadImp,0)  // ThreadImp class
+   ClassDefOverride(TThreadImp,0)  // ThreadImp class
 };
 
 #endif

--- a/core/thread/inc/TWin32Condition.h
+++ b/core/thread/inc/TWin32Condition.h
@@ -66,12 +66,12 @@ public:
    TWin32Condition(TMutexImp *m);
    virtual ~TWin32Condition();
 
-   Int_t  Wait();
-   Int_t  TimedWait(ULong_t secs, ULong_t nanoSecs = 0);
-   Int_t  Signal();
-   Int_t  Broadcast();
+   Int_t  Wait() override;
+   Int_t  TimedWait(ULong_t secs, ULong_t nanoSecs = 0) override;
+   Int_t  Signal() override;
+   Int_t  Broadcast() override;
 
-   ClassDef(TWin32Condition,0)   // Posix condition variable
+   ClassDefOverride(TWin32Condition,0)   // Posix condition variable
 };
 
 #endif

--- a/core/thread/inc/TWin32Mutex.h
+++ b/core/thread/inc/TWin32Mutex.h
@@ -42,11 +42,11 @@ public:
    TWin32Mutex(Bool_t recursive=kFALSE);
    virtual ~TWin32Mutex();
 
-   Int_t  Lock();
-   Int_t  UnLock();
-   Int_t  TryLock();
+   Int_t  Lock() override;
+   Int_t  UnLock() override;
+   Int_t  TryLock() override;
 
-   ClassDef(TWin32Mutex,0)  // Win32 mutex lock
+   ClassDefOverride(TWin32Mutex,0)  // Win32 mutex lock
 };
 
 #endif

--- a/core/thread/inc/TWin32Thread.h
+++ b/core/thread/inc/TWin32Thread.h
@@ -33,25 +33,25 @@ public:
    TWin32Thread() { }
    ~TWin32Thread() { }
 
-   virtual Int_t  Join(TThread *th, void **ret);
-   virtual Long_t SelfId();
-   virtual Int_t  Run(TThread *th, const int affinity = -1);
+   Int_t  Join(TThread *th, void **ret) override;
+   Long_t SelfId() override;
+   Int_t  Run(TThread *th, const int affinity = -1) override;
 
-   virtual Int_t  Kill(TThread *th);
+   Int_t  Kill(TThread *th) override;
 
-   virtual Int_t  SetCancelOff();
-   virtual Int_t  SetCancelOn();
-   virtual Int_t  SetCancelAsynchronous();
-   virtual Int_t  SetCancelDeferred();
-   virtual Int_t  CancelPoint();
+   Int_t  SetCancelOff() override;
+   Int_t  SetCancelOn() override;
+   Int_t  SetCancelAsynchronous() override;
+   Int_t  SetCancelDeferred() override;
+   Int_t  CancelPoint() override;
 
-   virtual Int_t  CleanUpPush(void **main, void *free,void *arg);
-   virtual Int_t  CleanUpPop(void **main, Int_t exe);
-   virtual Int_t  CleanUp(void **main);
+   Int_t  CleanUpPush(void **main, void *free,void *arg) override;
+   Int_t  CleanUpPop(void **main, Int_t exe) override;
+   Int_t  CleanUp(void **main) override;
 
-   virtual Int_t  Exit(void *ret);
+   Int_t  Exit(void *ret);
 
-   ClassDef(TWin32Thread,0)  // TWin32Thread class
+   ClassDefOverride(TWin32Thread,0)  // TWin32Thread class
 };
 
 

--- a/core/thread/inc/TWin32ThreadFactory.h
+++ b/core/thread/inc/TWin32ThreadFactory.h
@@ -34,11 +34,11 @@ public:
    TWin32ThreadFactory(const char *name = "Win32", const char *title = "Win32 Thread Factory");
    virtual ~TWin32ThreadFactory() { }
 
-   virtual TMutexImp      *CreateMutexImp(Bool_t recursive);
-   virtual TConditionImp  *CreateConditionImp(TMutexImp *m);
-   virtual TThreadImp     *CreateThreadImp();
+   TMutexImp      *CreateMutexImp(Bool_t recursive) override;
+   TConditionImp  *CreateConditionImp(TMutexImp *m) override;
+   TThreadImp     *CreateThreadImp() override;
 
-   ClassDef(TWin32ThreadFactory,0)  // Win32 thread factory
+   ClassDefOverride(TWin32ThreadFactory,0)  // Win32 thread factory
 };
 
 #endif

--- a/graf2d/graf/inc/TArc.h
+++ b/graf2d/graf/inc/TArc.h
@@ -31,12 +31,13 @@ public:
       , Double_t phimin=0,Double_t phimax=360);
    TArc(const TArc &arc);
    virtual ~TArc();
-   void Copy(TObject &arc) const;
+
+   void Copy(TObject &arc) const override;
    virtual TArc *DrawArc(Double_t x1, Double_t y1, Double_t radius
                        ,Double_t  phimin=0, Double_t  phimax=360, Option_t *option="");
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TArc,1)  //Arc of a circle
+   ClassDefOverride(TArc,1)  //Arc of a circle
 };
 
 #endif

--- a/graf2d/graf/inc/TArrow.h
+++ b/graf2d/graf/inc/TArrow.h
@@ -38,35 +38,35 @@ protected:
 
 public:
    TArrow();
-   TArrow(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2
-         ,Float_t arrowsize=0.05
-         ,Option_t *option=">");
+   TArrow(Double_t x1, Double_t y1, Double_t x2 ,Double_t y2,
+          Float_t arrowsize=0.05, Option_t *option=">");
    TArrow(const TArrow &arrow);
    virtual ~TArrow();
-   void Copy(TObject &arrow) const;
 
-   virtual void    Draw(Option_t *option="");
-   virtual TArrow *DrawArrow(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2
-                               ,Float_t arrowsize=0 ,Option_t *option="");
+   void Copy(TObject &arrow) const override;
+
+   void            Draw(Option_t *option="") override;
+   virtual TArrow *DrawArrow(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+                             Float_t arrowsize=0 ,Option_t *option="");
    Float_t         GetAngle() const {return fAngle;}
    Float_t         GetArrowSize() const {return fArrowSize;}
-   Option_t       *GetOption() const { return fOption.Data();}
-   virtual void    Paint(Option_t *option="");
+   Option_t       *GetOption() const override { return fOption.Data();}
+   void            Paint(Option_t *option="") override;
    virtual void    PaintArrow(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2
                              ,Float_t arrowsize=0.05 ,Option_t *option=">");
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
+   void            SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void    SetAngle(Float_t angle=60) {fAngle=angle;} // *MENU*
    virtual void    SetArrowSize(Float_t arrowsize=0.05) {fArrowSize=arrowsize;} // *MENU*
    virtual void    SetOption(Option_t *option=">"){ fOption = option;}
 
-   static void SetDefaultAngle     (Float_t  Angle    );
-   static void SetDefaultArrowSize (Float_t  ArrowSize);
-   static void SetDefaultOption    (Option_t *Option  );
-   static Float_t GetDefaultAngle    ();
+   static void SetDefaultAngle(Float_t  Angle    );
+   static void SetDefaultArrowSize(Float_t  ArrowSize);
+   static void SetDefaultOption(Option_t *Option  );
+   static Float_t GetDefaultAngle();
    static Float_t GetDefaultArrowSize();
-   static Option_t *GetDefaultOption ();
+   static Option_t *GetDefaultOption();
 
-   ClassDef(TArrow,1)  // An arrow (line with a arrowhead)
+   ClassDefOverride(TArrow,1)  // An arrow (line with a arrowhead)
 };
 
 #endif

--- a/graf2d/graf/inc/TBox.h
+++ b/graf2d/graf/inc/TBox.h
@@ -41,11 +41,12 @@ public:
    TBox(const TBox &box);
    TBox& operator=(const TBox&);
    virtual ~TBox();
-   void Copy(TObject &box) const;
-   virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void  Draw(Option_t *option="");
+
+   void          Copy(TObject &box) const override;
+   Int_t         DistancetoPrimitive(Int_t px, Int_t py) override;
+   void          Draw(Option_t *option="") override;
    virtual TBox *DrawBox(Double_t x1, Double_t y1, Double_t x2, Double_t  y2);
-   virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void          ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Bool_t        IsBeingResized() const { return fResizing; }
    Double_t      GetX1() const { return fX1; }
    Double_t      GetX2() const { return fX2; }
@@ -53,27 +54,27 @@ public:
    Double_t      GetY2() const { return fY2; }
    virtual void  HideToolTip(Int_t event);
    virtual Int_t IsInside(Double_t x, Double_t y) const;
-   virtual void  ls(Option_t *option="") const;
-   virtual void  Paint(Option_t *option="");
+   void          ls(Option_t *option="") const override;
+   void          Paint(Option_t *option="") override;
    virtual void  PaintBox(Double_t x1, Double_t y1, Double_t x2, Double_t y2, Option_t *option="");
-   virtual void  Print(Option_t *option="") const;
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          Print(Option_t *option="") const override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void  SetX1(Double_t x1) {fX1=x1;}
    virtual void  SetX2(Double_t x2) {fX2=x2;}
    virtual void  SetY1(Double_t y1) {fY1=y1;}
    virtual void  SetY2(Double_t y2) {fY2=y2;}
    virtual void  SetToolTipText(const char *text, Long_t delayms = 1000);
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x);
-   virtual void         SetBBoxX2(const Int_t x);
-   virtual void         SetBBoxY1(const Int_t y);
-   virtual void         SetBBoxY2(const Int_t y);
+   Rectangle_t   GetBBox() override;
+   TPoint        GetBBoxCenter() override;
+   void          SetBBoxCenter(const TPoint &p) override;
+   void          SetBBoxCenterX(const Int_t x) override;
+   void          SetBBoxCenterY(const Int_t y) override;
+   void          SetBBoxX1(const Int_t x) override;
+   void          SetBBoxX2(const Int_t x) override;
+   void          SetBBoxY1(const Int_t y) override;
+   void          SetBBoxY2(const Int_t y) override;
 
-   ClassDef(TBox,3)  //Box class
+   ClassDefOverride(TBox,3)  //Box class
 };
 
 #endif

--- a/graf2d/graf/inc/TCrown.h
+++ b/graf2d/graf/inc/TCrown.h
@@ -24,15 +24,16 @@ public:
           Double_t phimin=0,Double_t phimax=360);
    TCrown(const TCrown &crown);
    virtual ~TCrown();
-   void   Copy(TObject &crown) const;
-   virtual Int_t   DistancetoPrimitive(Int_t px, Int_t py);
+
+   void   Copy(TObject &crown) const override;
+   Int_t   DistancetoPrimitive(Int_t px, Int_t py) override;
    virtual TCrown *DrawCrown(Double_t x1, Double_t y1, Double_t radin, Double_t radout,
                              Double_t  phimin=0, Double_t  phimax=360, Option_t *option="");
-   virtual void    ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual void    Paint(Option_t *option="");
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
+   void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   void    Paint(Option_t *option="") override;
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TCrown,1)  //A crown or segment of crown
+   ClassDefOverride(TCrown,1)  //A crown or segment of crown
 };
 
 #endif

--- a/graf2d/graf/inc/TCurlyArc.h
+++ b/graf2d/graf/inc/TCurlyArc.h
@@ -13,8 +13,6 @@
 
 #include "TCurlyLine.h"
 
-class TPoint;
-
 class TCurlyArc : public TCurlyLine {
 
 private:
@@ -32,10 +30,11 @@ public:
    TCurlyArc(Double_t x1, Double_t y1, Double_t rad,
              Double_t phimin, Double_t phimax,
              Double_t wl = .02, Double_t amp = .01);
-   virtual     ~TCurlyArc(){;}
-   virtual void Build();
-   Int_t        DistancetoPrimitive(Int_t px, Int_t py);
-   void         ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   virtual ~TCurlyArc() {}
+
+   void         Build() override;
+   Int_t        DistancetoPrimitive(Int_t px, Int_t py) override;
+   void         ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Double_t     GetRadius() const {return fR1;}
    Double_t     GetPhimin() const {return fPhimin;}
    Double_t     GetPhimax() const {return fPhimax;}
@@ -43,7 +42,7 @@ public:
    virtual void SetRadius(Double_t radius);          // *MENU* *ARGS={radius=>fR1}
    virtual void SetPhimin(Double_t phimin);          // *MENU* *ARGS={phimin=>fPhimin}
    virtual void SetPhimax(Double_t phimax);          // *MENU* *ARGS={phimax=>fPhimax}
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void         SavePrimitive(std::ostream &out, Option_t * = "") override;
 
    static void          SetDefaultWaveLength(Double_t WaveLength);
    static void          SetDefaultAmplitude (Double_t Amplitude );
@@ -51,17 +50,18 @@ public:
    static Double_t      GetDefaultWaveLength();
    static Double_t      GetDefaultAmplitude ();
    static Bool_t        GetDefaultIsCurly   ();
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x);
-   virtual void         SetBBoxX2(const Int_t x);
-   virtual void         SetBBoxY1(const Int_t y);
-   virtual void         SetBBoxY2(const Int_t y);
 
-   ClassDef(TCurlyArc,3) // A curly arc
+   Rectangle_t  GetBBox() override;
+   TPoint       GetBBoxCenter() override;
+   void         SetBBoxCenter(const TPoint &p) override;
+   void         SetBBoxCenterX(const Int_t x) override;
+   void         SetBBoxCenterY(const Int_t y) override;
+   void         SetBBoxX1(const Int_t x) override;
+   void         SetBBoxX2(const Int_t x) override;
+   void         SetBBoxY1(const Int_t y) override;
+   void         SetBBoxY2(const Int_t y) override;
+
+   ClassDefOverride(TCurlyArc,3) // A curly arc
 };
 
 #endif

--- a/graf2d/graf/inc/TCurlyLine.h
+++ b/graf2d/graf/inc/TCurlyLine.h
@@ -39,8 +39,8 @@ public:
               Double_t amp = .01);
    virtual ~TCurlyLine(){;}
    virtual void Build();
-   Int_t        DistancetoPrimitive(Int_t px, Int_t py);
-   void         ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   Int_t        DistancetoPrimitive(Int_t px, Int_t py) override;
+   void         ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Bool_t       GetCurly() const     {return fIsCurly;}
    Double_t     GetWaveLength() const{return fWaveLength;}
    Double_t     GetAmplitude() const {return fAmplitude;}
@@ -54,7 +54,7 @@ public:
    virtual void SetAmplitude(Double_t x);               // *MENU* *ARGS={x=>fAmplitude}
    virtual void SetStartPoint(Double_t x1, Double_t y1);
    virtual void SetEndPoint  (Double_t x2, Double_t y2);
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void         SavePrimitive(std::ostream &out, Option_t * = "") override;
 
    static void     SetDefaultWaveLength(Double_t WaveLength);
    static void     SetDefaultAmplitude (Double_t Amplitude );
@@ -62,17 +62,18 @@ public:
    static Double_t GetDefaultWaveLength();
    static Double_t GetDefaultAmplitude ();
    static Bool_t   GetDefaultIsCurly   ();
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x);
-   virtual void         SetBBoxX2(const Int_t x);
-   virtual void         SetBBoxY1(const Int_t y);
-   virtual void         SetBBoxY2(const Int_t y);
 
-   ClassDef(TCurlyLine,3) // A curly polyline
+   Rectangle_t  GetBBox() override;
+   TPoint       GetBBoxCenter() override;
+   void         SetBBoxCenter(const TPoint &p) override;
+   void         SetBBoxCenterX(const Int_t x) override;
+   void         SetBBoxCenterY(const Int_t y) override;
+   void         SetBBoxX1(const Int_t x) override;
+   void         SetBBoxX2(const Int_t x) override;
+   void         SetBBoxY1(const Int_t y) override;
+   void         SetBBoxY2(const Int_t y) override;
+
+   ClassDefOverride(TCurlyLine,3) // A curly polyline
 };
 
 #endif

--- a/graf2d/graf/inc/TCutG.h
+++ b/graf2d/graf/inc/TCutG.h
@@ -41,13 +41,13 @@ public:
    const char      *GetVarX() const {return fVarX.Data();}
    const char      *GetVarY() const {return fVarY.Data();}
    virtual Double_t IntegralHist(TH2 *h, Option_t *option="") const;
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetObjectX(TObject *obj);
    virtual void     SetObjectY(TObject *obj);
    virtual void     SetVarX(const char *varx); // *MENU*
    virtual void     SetVarY(const char *vary); // *MENU*
 
-   ClassDef(TCutG,2)  // A Graphical cut.
+   ClassDefOverride(TCutG,2)  // A Graphical cut.
 };
 
 #endif

--- a/graf2d/graf/inc/TDiamond.h
+++ b/graf2d/graf/inc/TDiamond.h
@@ -21,13 +21,13 @@ public:
    TDiamond(Double_t x1, Double_t y1,Double_t x2, Double_t  y2);
    TDiamond(const TDiamond &diamond);
    virtual ~TDiamond();
-   virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void  Draw(Option_t *option="");
-   virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual void  Paint(Option_t *option="");
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   Int_t DistancetoPrimitive(Int_t px, Int_t py) override;
+   void  Draw(Option_t *option="") override;
+   void  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   void  Paint(Option_t *option="") override;
+   void  SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TDiamond,1)  //Diamond class
+   ClassDefOverride(TDiamond,1)  //Diamond class
 };
 
 #endif

--- a/graf2d/graf/inc/TEllipse.h
+++ b/graf2d/graf/inc/TEllipse.h
@@ -40,11 +40,11 @@ public:
    TEllipse(Double_t x1, Double_t y1,Double_t r1,Double_t r2=0,Double_t phimin=0, Double_t phimax=360,Double_t theta=0);
    TEllipse(const TEllipse &ellipse);
    virtual ~TEllipse();
-   void   Copy(TObject &ellipse) const;
-   virtual Int_t        DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void         Draw(Option_t *option="");
+   void                 Copy(TObject &ellipse) const override;
+   Int_t                DistancetoPrimitive(Int_t px, Int_t py) override;
+   void                 Draw(Option_t *option="") override;
    virtual TEllipse    *DrawEllipse(Double_t x1, Double_t y1, Double_t r1,Double_t r2,Double_t phimin, Double_t phimax,Double_t theta,Option_t *option="");
-   virtual void         ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void                 ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Double_t             GetX1() const {return fX1;}
    Double_t             GetY1() const {return fY1;}
    Double_t             GetR1() const {return fR1;}
@@ -53,11 +53,11 @@ public:
    Double_t             GetPhimax() const {return fPhimax;}
    Double_t             GetTheta() const  {return fTheta;}
    Bool_t               GetNoEdges() const;
-   virtual void         ls(Option_t *option="") const;
-   virtual void         Paint(Option_t *option="");
+   void                 ls(Option_t *option="") const override;
+   void                 Paint(Option_t *option="") override;
    virtual void         PaintEllipse(Double_t x1, Double_t y1, Double_t r1,Double_t r2,Double_t phimin, Double_t phimax,Double_t theta,Option_t *option="");
-   virtual void         Print(Option_t *option="") const;
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
+   void                 Print(Option_t *option="") const override;
+   void                 SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void         SetNoEdges(Bool_t noEdges=kTRUE); // *TOGGLE* *GETTER=GetNoEdges
    virtual void         SetPhimin(Double_t phi=0)   {fPhimin=phi;} // *MENU*
    virtual void         SetPhimax(Double_t phi=360) {fPhimax=phi;} // *MENU*
@@ -66,18 +66,17 @@ public:
    virtual void         SetTheta(Double_t theta=0) {fTheta=theta;} // *MENU*
    virtual void         SetX1(Double_t x1) {fX1=x1;} // *MENU*
    virtual void         SetY1(Double_t y1) {fY1=y1;} // *MENU*
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x);
-   virtual void         SetBBoxX2(const Int_t x);
-   virtual void         SetBBoxY1(const Int_t y);
-   virtual void         SetBBoxY2(const Int_t y);
+   Rectangle_t          GetBBox() override;
+   TPoint               GetBBoxCenter() override;
+   void                 SetBBoxCenter(const TPoint &p) override;
+   void                 SetBBoxCenterX(const Int_t x) override;
+   void                 SetBBoxCenterY(const Int_t y) override;
+   void                 SetBBoxX1(const Int_t x) override;
+   void                 SetBBoxX2(const Int_t x) override;
+   void                 SetBBoxY1(const Int_t y) override;
+   void                 SetBBoxY2(const Int_t y) override;
 
-
-   ClassDef(TEllipse,3)  //An ellipse
+   ClassDefOverride(TEllipse,3)  //An ellipse
 };
 
 #endif

--- a/graf2d/graf/inc/TFrame.h
+++ b/graf2d/graf/inc/TFrame.h
@@ -24,15 +24,15 @@ public:
    TFrame(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2);
    TFrame(const TFrame &frame);
    virtual ~TFrame();
-   void  Copy(TObject &frame) const;
-   virtual void  Draw(Option_t *option="");
-   virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   virtual void  Paint(Option_t *option="");
-   virtual void  Pop();
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void  UseCurrentStyle();  // *MENU*
+   void  Copy(TObject &frame) const override;
+   void  Draw(Option_t *option="") override;
+   void  ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   void  Paint(Option_t *option="") override;
+   void  Pop() override;
+   void  SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void  UseCurrentStyle() override;  // *MENU*
 
-   ClassDef(TFrame,1)  //Pad graphics frame
+   ClassDefOverride(TFrame,1)  //Pad graphics frame
 };
 
 #endif

--- a/graf2d/graf/inc/TGaxis.h
+++ b/graf2d/graf/inc/TGaxis.h
@@ -81,9 +81,9 @@ public:
    Float_t             GetLabelSize() const    {return fLabelSize;}
    Float_t             GetTitleOffset() const  {return fTitleOffset;}
    Float_t             GetTitleSize() const    {return fTitleSize;}
-   virtual const char *GetName() const  {return fName.Data();}
-   virtual const char *GetOption() const {return fChopt.Data();}
-   virtual const char *GetTitle() const {return fTitle.Data();}
+   const char         *GetName() const  override {return fName.Data();}
+   const char         *GetOption() const override {return fChopt.Data();}
+   const char         *GetTitle() const override {return fTitle.Data();}
    static Int_t        GetMaxDigits();
    Int_t               GetNdiv() const         {return fNdiv;}
    Double_t            GetWmin() const         {return fWmin;}
@@ -91,14 +91,14 @@ public:
    Float_t             GetTickSize() const     {return fTickSize;}
    virtual void        ImportAxisAttributes(TAxis *axis);
    void                LabelsLimits(const char *label, Int_t &first, Int_t &last);
-   virtual void        Paint(Option_t *chopt="");
+   void                Paint(Option_t *chopt="") override;
    virtual void        PaintAxis(Double_t xmin,Double_t ymin,Double_t xmax,Double_t ymax,
                                  Double_t &wmin,Double_t &wmax,Int_t &ndiv, Option_t *chopt="",
                                  Double_t gridlength = 0, Bool_t drawGridOnly = kFALSE);
    virtual void        Rotate(Double_t X,  Double_t Y,  Double_t CFI, Double_t SFI
                              ,Double_t XT, Double_t YT, Double_t &U,   Double_t &V);
    void                ResetLabelAttributes(TLatex* t);
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
+   void                SavePrimitive(std::ostream &out, Option_t *option = "") override;
    void                SetFunction(const char *funcname="");
    void                SetOption(Option_t *option="");
    void                SetLabelColor(Int_t labelcolor) {fLabelColor = labelcolor;} // *MENU*
@@ -129,7 +129,7 @@ public:
    void                SetWmax(Double_t wmax) {fWmax = wmax;}
    static void         SetExponentOffset(Float_t xoff=0., Float_t yoff=0., Option_t *axis="xy");
 
-   ClassDef(TGaxis,6)  //Graphics axis
+   ClassDefOverride(TGaxis,6)  //Graphics axis
 };
 
 #endif

--- a/graf2d/graf/inc/TGraphPolar.h
+++ b/graf2d/graf/inc/TGraphPolar.h
@@ -20,7 +20,7 @@ class TGraphPolargram;
 #include "TGraphPolargram.h"
 #endif
 
-class TGraphPolar: public TGraphErrors {
+class TGraphPolar : public TGraphErrors {
 
 private:
    Bool_t fOptionAxis;          ///< Force drawing of new coord system
@@ -30,29 +30,28 @@ protected:
    Double_t* fXpol;             ///< [fNpoints] points in polar coordinates
    Double_t* fYpol;             ///< [fNpoints] points in polar coordinates
 
-
 public:
    TGraphPolar();
-   TGraphPolar(Int_t n, const Double_t* theta=0, const Double_t* r=0,
-                        const Double_t* etheta=0, const Double_t* er=0);
+   TGraphPolar(Int_t n, const Double_t* theta = nullptr, const Double_t* r = nullptr,
+                        const Double_t* etheta = nullptr, const Double_t* er = nullptr);
    virtual ~TGraphPolar();
 
-   TGraphPolargram *GetPolargram() {return fPolargram;};
+   TGraphPolargram *GetPolargram() {return fPolargram;}
 
-   void             Draw(Option_t* options = "");
-   Bool_t           GetOptionAxis() {return fOptionAxis;};
+   void             Draw(Option_t* options = "") override;
+   Bool_t           GetOptionAxis() {return fOptionAxis;}
    void             SetMaxRadial(Double_t maximum = 1); //*MENU*
    void             SetMinRadial(Double_t minimum = 0); //*MENU*
-   void             SetMaximum(Double_t maximum = 1) {SetMaxRadial(maximum);}
-   void             SetMinimum(Double_t minimum = 0) {SetMinRadial(minimum);}
+   void             SetMaximum(Double_t maximum = 1) override {SetMaxRadial(maximum);}
+   void             SetMinimum(Double_t minimum = 0) override {SetMinRadial(minimum);}
    void             SetMaxPolar(Double_t maximum = 6.28318530717958623); //*MENU*
    void             SetMinPolar(Double_t minimum = 0); //*MENU*
-   void             SetOptionAxis(Bool_t opt) {fOptionAxis = opt;};
-   void             SetPolargram(TGraphPolargram *p) {fPolargram = p;};
+   void             SetOptionAxis(Bool_t opt) {fOptionAxis = opt;}
+   void             SetPolargram(TGraphPolargram *p) {fPolargram = p;}
    Double_t        *GetXpol();
    Double_t        *GetYpol();
 
-   ClassDef(TGraphPolar,1); // Polar graph
+   ClassDefOverride(TGraphPolar,1); // Polar graph
 };
 
 #endif

--- a/graf2d/graf/inc/TGraphPolargram.h
+++ b/graf2d/graf/inc/TGraphPolargram.h
@@ -48,7 +48,7 @@ private:
 
    TString* fPolarLabels;      ///<! [fNdivPol] Specified polar labels
 
-   void Paint(Option_t* options="");
+   void Paint(Option_t* options="") override;
    void PaintRadialDivisions(Bool_t drawaxis);
    void PaintPolarDivisions(Bool_t noLabels);
    void ReduceFraction(Int_t Num, Int_t Denom, Int_t &rnum, Int_t &rden);
@@ -66,34 +66,34 @@ public:
    TGraphPolargram(const char* name="");
    virtual ~TGraphPolargram();
 
-   Color_t  GetPolarColorLabel (){ return fPolarLabelColor;};
-   Color_t  GetRadialColorLabel (){ return fRadialLabelColor;};
+   Color_t  GetPolarColorLabel() { return fPolarLabelColor;}
+   Color_t  GetRadialColorLabel() { return fRadialLabelColor;}
 
-   Double_t GetAngle() { return fAxisAngle;};
-   Double_t GetPolarLabelSize() {return fPolarTextSize;};
-   Double_t GetPolarOffset() { return fPolarOffset; };
-   Double_t GetRadialLabelSize() {return fRadialTextSize;};
-   Double_t GetRadialOffset() { return fRadialOffset; };
-   Double_t GetRMin() { return fRwrmin;};
-   Double_t GetRMax() { return fRwrmax;};
-   Double_t GetTickpolarSize() {return fTickpolarSize;};
-   Double_t GetTMin() { return fRwtmin;};
-   Double_t GetTMax() { return fRwtmax;};
+   Double_t GetAngle() { return fAxisAngle;}
+   Double_t GetPolarLabelSize() {return fPolarTextSize;}
+   Double_t GetPolarOffset() { return fPolarOffset; }
+   Double_t GetRadialLabelSize() {return fRadialTextSize; }
+   Double_t GetRadialOffset() { return fRadialOffset; }
+   Double_t GetRMin() { return fRwrmin; }
+   Double_t GetRMax() { return fRwrmax; }
+   Double_t GetTickpolarSize() {return fTickpolarSize; }
+   Double_t GetTMin() { return fRwtmin; }
+   Double_t GetTMax() { return fRwtmax; }
 
-   Font_t   GetPolarLabelFont() { return fPolarLabelFont;};
-   Font_t   GetRadialLabelFont() { return fRadialLabelFont;};
+   Font_t   GetPolarLabelFont() { return fPolarLabelFont; }
+   Font_t   GetRadialLabelFont() { return fRadialLabelFont; }
 
-   Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   Int_t    GetNdivPolar() { return fNdivPol;};
-   Int_t    GetNdivRadial() { return fNdivRad;};
+   Int_t    DistancetoPrimitive(Int_t px, Int_t py) override;
+   Int_t    GetNdivPolar() { return fNdivPol; }
+   Int_t    GetNdivRadial() { return fNdivRad; }
 
-   Bool_t   IsDegree() {return fDegree;};
-   Bool_t   IsRadian() {return fRadian;};
-   Bool_t   IsGrad()   {return fGrad;};
+   Bool_t   IsDegree() {return fDegree; }
+   Bool_t   IsRadian() {return fRadian; }
+   Bool_t   IsGrad()   {return fGrad; }
 
    void     ChangeRangePolar(Double_t tmin, Double_t tmax);
-   void     Draw(Option_t* options="");
-   void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void     Draw(Option_t* options="") override;
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    void     PaintCircle(Double_t x, Double_t y, Double_t r,
                         Double_t phimin, Double_t phimax, Double_t theta);
    void     SetAxisAngle(Double_t angle = 0); //*MENU*
@@ -116,7 +116,7 @@ public:
    void     SetToRadian(); //*MENU*
    void     SetTwoPi();
 
-   ClassDef(TGraphPolargram,1); // Polar axis
+   ClassDefOverride(TGraphPolargram,1); // Polar axis
 };
 
 #endif

--- a/graf2d/graf/inc/TGraphQQ.h
+++ b/graf2d/graf/inc/TGraphQQ.h
@@ -43,7 +43,7 @@ public:
    Double_t  GetYq2() const {return fYq2;}
    TF1      *GetF()   const {return fF;}
 
-   ClassDef(TGraphQQ, 1); // to create and to draw quantile-quantile plots
+   ClassDefOverride(TGraphQQ, 1); // to create and to draw quantile-quantile plots
 };
 
 #endif

--- a/graf2d/graf/inc/TImagePlugin.h
+++ b/graf2d/graf/inc/TImagePlugin.h
@@ -34,9 +34,9 @@ public:
 
    virtual unsigned char *ReadFile(const char *filename, UInt_t &w,  UInt_t &h) = 0;
    virtual Bool_t WriteFile(const char *filename, unsigned char *argb, UInt_t w,  UInt_t  h) = 0;
-   ULong_t Hash() const { return fExtension.Hash(); }
+   ULong_t Hash() const override { return fExtension.Hash(); }
 
-   ClassDef(TImagePlugin, 0)  // base class for different image format handlers(plugins)
+   ClassDefOverride(TImagePlugin, 0)  // base class for different image format handlers(plugins)
 };
 
 #endif

--- a/graf2d/graf/inc/TLatex.h
+++ b/graf2d/graf/inc/TLatex.h
@@ -105,7 +105,8 @@ public:
       TLatex(Double_t x, Double_t y, const char *text);
       TLatex(const TLatex &text);
       virtual ~TLatex();
-      void             Copy(TObject &text) const;
+
+      void             Copy(TObject &text) const override;
 
       TLatex          *DrawLatex(Double_t x, Double_t y, const char *text);
       TLatex          *DrawLatexNDC(Double_t x, Double_t y, const char *text);
@@ -113,15 +114,15 @@ public:
       Double_t         GetHeight() const;
       Double_t         GetXsize();
       Double_t         GetYsize();
-      void             GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE);
-      virtual void     Paint(Option_t *option="");
+      void             GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE) override;
+      void             Paint(Option_t *option="") override;
       virtual void     PaintLatex(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
 
-      virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+      void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
       virtual void     SetIndiceSize(Double_t factorSize);
       virtual void     SetLimitIndiceSize(Int_t limitFactorSize);
 
-      ClassDef(TLatex,2)  //The Latex-style text processor class
+      ClassDefOverride(TLatex,2)  //The Latex-style text processor class
 };
 
 #endif

--- a/graf2d/graf/inc/TLegend.h
+++ b/graf2d/graf/inc/TLegend.h
@@ -31,14 +31,14 @@ public:
             const char* header = "", Option_t* option="brNDC" );
    TLegend( Double_t w, Double_t h, const char* header = "", Option_t* option="brNDC" );
    virtual ~TLegend();
-   TLegend( const TLegend &legend );
+   TLegend(const TLegend &legend);
 
    TLegendEntry   *AddEntry(const TObject* obj, const char* label = "", Option_t* option = "lpf" );
    TLegendEntry   *AddEntry(const char *name, const char* label = "", Option_t* option = "lpf" );
-   virtual void    Clear( Option_t* option = "" ); // *MENU*
-   virtual void    Copy( TObject &obj ) const;
+   void            Clear( Option_t* option = "" ) override; // *MENU*
+   void            Copy( TObject &obj ) const override;
    virtual void    DeleteEntry(); // *MENU*
-   virtual void    Draw( Option_t* option = "" );
+   void            Draw( Option_t* option = "" ) override;
    virtual void    EditEntryAttFill();
    virtual void    EditEntryAttLine();
    virtual void    EditEntryAttMarker();
@@ -53,11 +53,11 @@ public:
    Int_t           GetNRows() const;
    virtual void    InsertEntry( const char* objectName = "",const char* label = "",
                              Option_t* option = "lpf" ); // *MENU*
-   virtual void    Paint( Option_t* option = "" );
+   void            Paint( Option_t* option = "" ) override;
    virtual void    PaintPrimitives();
-   virtual void    Print( Option_t* option = "" ) const;
-   virtual void    RecursiveRemove(TObject *obj);
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option  = "");
+   void            Print( Option_t* option = "" ) const override;
+   void            RecursiveRemove(TObject *obj) override;
+   void            SavePrimitive(std::ostream &out, Option_t *option  = "") override;
    void            SetDefaults() { fEntrySeparation = 0.1f; fMargin = 0.25f; fNColumns = 1; fColumnSeparation = 0.0f; }
    void            SetColumnSeparation( Float_t columnSeparation )
                      { fColumnSeparation = columnSeparation; } // *MENU*
@@ -79,7 +79,7 @@ protected:
    Float_t    fColumnSeparation; ///< Separation between columns, as a fraction of
                                  ///< The space allowed to one column
 
-   ClassDef(TLegend,3) // Legend of markers/lines/boxes to represent obj's
+   ClassDefOverride(TLegend,3) // Legend of markers/lines/boxes to represent obj's
 };
 
 #endif

--- a/graf2d/graf/inc/TLegendEntry.h
+++ b/graf2d/graf/inc/TLegendEntry.h
@@ -25,14 +25,14 @@ class TLegendEntry : public TObject, public TAttText, public TAttLine,
                      public TAttFill, public TAttMarker {
 public:
    TLegendEntry();
-   TLegendEntry(const TObject *obj, const char *label = 0, Option_t *option="lpf" );
+   TLegendEntry(const TObject *obj, const char *label = nullptr, Option_t *option="lpf" );
    TLegendEntry( const TLegendEntry &entry );
    virtual ~TLegendEntry();
-   virtual void          Copy( TObject &obj ) const;
+   void                  Copy( TObject &obj ) const override;
    virtual const char   *GetLabel() const { return fLabel.Data(); }
    virtual TObject      *GetObject() const { return fObject; }
-   virtual Option_t     *GetOption() const { return fOption.Data(); }
-   virtual void          Print( Option_t *option = "" ) const;
+   Option_t             *GetOption() const override { return fOption.Data(); }
+   void                  Print( Option_t *option = "" ) const override;
    virtual void          SaveEntry( std::ostream &out, const char *name );
    virtual void          SetLabel( const char *label = "" ) { fLabel = label; } // *MENU*
    virtual void          SetObject(TObject* obj );
@@ -45,9 +45,9 @@ protected:
    TString       fOption;   ///< Options associated with this entry
 
 private:
-   TLegendEntry& operator=(const TLegendEntry&); // Not implemented
+   TLegendEntry& operator=(const TLegendEntry&) = delete;
 
-   ClassDef(TLegendEntry,1) // Storage class for one entry of a TLegend
+   ClassDefOverride(TLegendEntry,1) // Storage class for one entry of a TLegend
 };
 
 #endif

--- a/graf2d/graf/inc/TLine.h
+++ b/graf2d/graf/inc/TLine.h
@@ -42,23 +42,23 @@ public:
 
    TLine &operator=(const TLine &src);
 
-   void                 Copy(TObject &line) const;
-   virtual Int_t        DistancetoPrimitive(Int_t px, Int_t py);
+   void                 Copy(TObject &line) const override;
+   Int_t                DistancetoPrimitive(Int_t px, Int_t py) override;
    virtual TLine       *DrawLine(Double_t x1, Double_t y1,Double_t x2, Double_t y2);
    virtual TLine       *DrawLineNDC(Double_t x1, Double_t y1,Double_t x2, Double_t y2);
-   virtual void         ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void                 ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Double_t             GetX1() const {return fX1;}
    Double_t             GetX2() const {return fX2;}
    Double_t             GetY1() const {return fY1;}
    Double_t             GetY2() const {return fY2;}
    Bool_t               IsHorizontal();
    Bool_t               IsVertical();
-   virtual void         ls(Option_t *option="") const;
-   virtual void         Paint(Option_t *option="");
+   void                 ls(Option_t *option="") const override;
+   void                 Paint(Option_t *option="") override;
    virtual void         PaintLine(Double_t x1, Double_t y1,Double_t x2, Double_t  y2);
    virtual void         PaintLineNDC(Double_t u1, Double_t v1,Double_t u2, Double_t  v2);
-   virtual void         Print(Option_t *option="") const;
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
+   void                 Print(Option_t *option="") const override;
+   void                 SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void         SetNDC(Bool_t isNDC=kTRUE);
    void                 SetHorizontal(Bool_t set = kTRUE); // *TOGGLE* *GETTER=IsHorizontal
    void                 SetVertical(Bool_t set = kTRUE); // *TOGGLE* *GETTER=IsVertical
@@ -66,17 +66,17 @@ public:
    virtual void         SetX2(Double_t x2) {fX2=x2;}
    virtual void         SetY1(Double_t y1) {fY1=y1;}
    virtual void         SetY2(Double_t y2) {fY2=y2;}
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x);
-   virtual void         SetBBoxX2(const Int_t x);
-   virtual void         SetBBoxY1(const Int_t y);
-   virtual void         SetBBoxY2(const Int_t y);
+   Rectangle_t          GetBBox() override;
+   TPoint               GetBBoxCenter() override;
+   void                 SetBBoxCenter(const TPoint &p) override;
+   void                 SetBBoxCenterX(const Int_t x) override;
+   void                 SetBBoxCenterY(const Int_t y) override;
+   void                 SetBBoxX1(const Int_t x) override;
+   void                 SetBBoxX2(const Int_t x) override;
+   void                 SetBBoxY1(const Int_t y) override;
+   void                 SetBBoxY2(const Int_t y) override;
 
-   ClassDef(TLine,3)  //A line segment
+   ClassDefOverride(TLine,3)  //A line segment
 };
 
 #endif

--- a/graf2d/graf/inc/TLink.h
+++ b/graf2d/graf/inc/TLink.h
@@ -12,7 +12,6 @@
 #ifndef ROOT_TLink
 #define ROOT_TLink
 
-
 #include "TText.h"
 
 class TLink : public TText {
@@ -26,9 +25,9 @@ public:
    TLink();
    TLink(Double_t x, Double_t y, void *pointer);
    virtual ~TLink();
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 
-   ClassDef(TLink,0)  //Link: hypertext link to an object
+   ClassDefOverride(TLink,0)  //Link: hypertext link to an object
 };
 
 #endif

--- a/graf2d/graf/inc/TMarker.h
+++ b/graf2d/graf/inc/TMarker.h
@@ -36,38 +36,37 @@ public:
    TMarker(const TMarker &marker);
    virtual ~TMarker();
 
-   void             Copy(TObject &marker) const;
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void     Draw(Option_t *option="");
+   void             Copy(TObject &marker) const override;
+   Int_t            DistancetoPrimitive(Int_t px, Int_t py) override;
+   void             Draw(Option_t *option="") override;
    virtual TMarker *DrawMarker(Double_t x, Double_t y);
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void             ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Double_t         GetX() const  {return fX;}
    Double_t         GetY() const  {return fY;}
-   virtual void     ls(Option_t *option="") const;
-   virtual void     Paint(Option_t *option="");
+   void             ls(Option_t *option="") const override;
+   void             Paint(Option_t *option="") override;
    virtual void     PaintMarker(Double_t x, Double_t y);
    virtual void     PaintMarkerNDC(Double_t u, Double_t v);
-   virtual void     Print(Option_t *option="") const;
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             Print(Option_t *option="") const override;
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetNDC(Bool_t isNDC=kTRUE);
    virtual void     SetX(Double_t x) { fX = x;} // *MENU*
    virtual void     SetY(Double_t y) { fY = y;} // *MENU*
 
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x);
-   virtual void         SetBBoxX2(const Int_t x);
-   virtual void         SetBBoxY1(const Int_t y);
-   virtual void         SetBBoxY2(const Int_t y);
+   Rectangle_t      GetBBox() override;
+   TPoint           GetBBoxCenter() override;
+   void             SetBBoxCenter(const TPoint &p) override;
+   void             SetBBoxCenterX(const Int_t x) override;
+   void             SetBBoxCenterY(const Int_t y) override;
+   void             SetBBoxX1(const Int_t x) override;
+   void             SetBBoxX2(const Int_t x) override;
+   void             SetBBoxY1(const Int_t y) override;
+   void             SetBBoxY2(const Int_t y) override;
 
    static  void     DisplayMarkerTypes();
    static  void     DisplayMarkerLineWidths();
 
-   ClassDef(TMarker,3)  //Marker
+   ClassDefOverride(TMarker,3)  //Marker
 };
 
 #endif
-

--- a/graf2d/graf/inc/TMathText.h
+++ b/graf2d/graf/inc/TMathText.h
@@ -36,27 +36,21 @@ public:
       enum {
          kTextNDC = BIT(14)
       };
-      TMathText(void);
-      TMathText(
-         Double_t x, Double_t y, const char *text);
+      TMathText();
+      TMathText(Double_t x, Double_t y, const char *text);
       TMathText(const TMathText &text);
-      virtual ~TMathText(void);
-      void Copy(TObject &text) const;
-      TMathText *DrawMathText(
-         Double_t x, Double_t y, const char *text);
-      void GetBoundingBox(
-         UInt_t &w, UInt_t &h, Bool_t angle = kFALSE);
-      Double_t GetXsize(void);
-      Double_t GetYsize(void);
-      virtual void Paint(Option_t *option = "");
-      virtual void PaintMathText(
-         Double_t x, Double_t y, Double_t angle, Double_t size,
-         const char *text);
-      virtual void SavePrimitive(
-         std::ostream &out, Option_t *option = "");
+      virtual ~TMathText();
+      void Copy(TObject &text) const override;
+      TMathText *DrawMathText(Double_t x, Double_t y, const char *text);
+      void GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE) override;
+      Double_t GetXsize();
+      Double_t GetYsize();
+      void Paint(Option_t *option = "") override;
+      virtual void PaintMathText(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
+      void SavePrimitive(std::ostream &out, Option_t *option = "") override;
       friend class TMathTextRenderer;
 
-      ClassDef(TMathText,2) //TeX mathematical formula
+      ClassDefOverride(TMathText,2) //TeX mathematical formula
 };
 
 #endif

--- a/graf2d/graf/inc/TPave.h
+++ b/graf2d/graf/inc/TPave.h
@@ -44,47 +44,47 @@ public:
 
    TPave &operator=(const TPave &src);
 
-   void  Copy(TObject &pave) const;
+   void           Copy(TObject &pave) const override;
    virtual void   ConvertNDCtoPad();
-   virtual Int_t  DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void   Draw(Option_t *option="");
+   Int_t          DistancetoPrimitive(Int_t px, Int_t py) override;
+   void           Draw(Option_t *option="") override;
    virtual TPave *DrawPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
                           Int_t bordersize=4 ,Option_t *option="br");
-   virtual void   ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void           ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Int_t          GetBorderSize() const { return fBorderSize;}
    Double_t       GetCornerRadius() const {return fCornerRadius;}
-   Option_t      *GetName() const {return fName.Data();}
-   Option_t      *GetOption() const {return fOption.Data();}
+   Option_t      *GetName() const override {return fName.Data();}
+   Option_t      *GetOption() const override {return fOption.Data();}
    Int_t          GetShadowColor() const {return fShadowColor;}
    Double_t       GetX1NDC() const {return fX1NDC;}
    Double_t       GetX2NDC() const {return fX2NDC;}
    Double_t       GetY1NDC() const {return fY1NDC;}
    Double_t       GetY2NDC() const {return fY2NDC;}
-   virtual ULong_t  Hash() const { return fName.Hash(); }
-   virtual Bool_t   IsSortable() const { return kTRUE; }
-   virtual void  ls(Option_t *option="") const;
-   virtual void  Paint(Option_t *option="");
-   virtual void  PaintPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
-                           Int_t bordersize=4 ,Option_t *option="br");
-   virtual void  PaintPaveArc(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
-                              Int_t bordersize=4 ,Option_t *option="br");
-   virtual void  Print(Option_t *option="") const;
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void  SetBorderSize(Int_t bordersize=4) {fBorderSize = bordersize;} // *MENU*
-   virtual void  SetCornerRadius(Double_t rad = 0.2) {fCornerRadius = rad;} // *MENU*
-   virtual void  SetName(const char *name="") {fName = name;} // *MENU*
-   virtual void  SetOption(Option_t *option="br") {fOption = option;}
-   virtual void  SetShadowColor(Int_t color) {fShadowColor=color;} // *MENU*
-   virtual void  SetX1NDC(Double_t x1) {fX1NDC=x1;}
-   virtual void  SetX2NDC(Double_t x2) {fX2NDC=x2;}
-   virtual void  SetY1NDC(Double_t y1) {fY1NDC=y1;}
-   virtual void  SetY2NDC(Double_t y2) {fY2NDC=y2;}
-   virtual void  SetX1(Double_t x1);
-   virtual void  SetX2(Double_t x2);
-   virtual void  SetY1(Double_t y1);
-   virtual void  SetY2(Double_t y2);
+   ULong_t        Hash() const override { return fName.Hash(); }
+   Bool_t         IsSortable() const override { return kTRUE; }
+   void           ls(Option_t *option="") const override;
+   void           Paint(Option_t *option="") override;
+   virtual void   PaintPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+                            Int_t bordersize=4 ,Option_t *option="br");
+   virtual void   PaintPaveArc(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+                               Int_t bordersize=4 ,Option_t *option="br");
+   void           Print(Option_t *option="") const override;
+   void           SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   virtual void   SetBorderSize(Int_t bordersize=4) {fBorderSize = bordersize;} // *MENU*
+   virtual void   SetCornerRadius(Double_t rad = 0.2) {fCornerRadius = rad;} // *MENU*
+   virtual void   SetName(const char *name="") {fName = name;} // *MENU*
+   virtual void   SetOption(Option_t *option="br") {fOption = option;}
+   virtual void   SetShadowColor(Int_t color) {fShadowColor=color;} // *MENU*
+   virtual void   SetX1NDC(Double_t x1) {fX1NDC=x1;}
+   virtual void   SetX2NDC(Double_t x2) {fX2NDC=x2;}
+   virtual void   SetY1NDC(Double_t y1) {fY1NDC=y1;}
+   virtual void   SetY2NDC(Double_t y2) {fY2NDC=y2;}
+   virtual void   SetX1(Double_t x1) override;
+   virtual void   SetX2(Double_t x2) override;
+   virtual void   SetY1(Double_t y1) override;
+   virtual void   SetY2(Double_t y2) override;
 
-   ClassDef(TPave,3)  //Pave. A box with shadowing
+   ClassDefOverride(TPave,3)  //Pave. A box with shadowing
 };
 
 #endif

--- a/graf2d/graf/inc/TPaveLabel.h
+++ b/graf2d/graf/inc/TPaveLabel.h
@@ -35,19 +35,19 @@ public:
    }
    virtual ~TPaveLabel();
 
-   void                Copy(TObject &pavelabel) const;
-   virtual void        Draw(Option_t *option="");
+   void                Copy(TObject &pavelabel) const override;
+   void                Draw(Option_t *option="") override;
    virtual TPaveLabel *DrawPaveLabel(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
                                      const char *label, Option_t *option="");
    const char         *GetLabel() const {return fLabel.Data();}
-   const char         *GetTitle() const {return fLabel.Data();}
-   virtual void        Paint(Option_t *option="");
+   const char         *GetTitle() const override {return fLabel.Data();}
+   void                Paint(Option_t *option="") override;
    virtual void        PaintPaveLabel(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
                                       const char *label, Option_t *option="");
-   virtual void        SavePrimitive(std::ostream &out, Option_t *option = "");
+   void                SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void        SetLabel(const char *label) {fLabel = label;} // *MENU*
 
-   ClassDef(TPaveLabel,1)  //PaveLabel. A Pave with a label
+   ClassDefOverride(TPaveLabel,1)  //PaveLabel. A Pave with a label
 };
 
 #endif

--- a/graf2d/graf/inc/TPaveStats.h
+++ b/graf2d/graf/inc/TPaveStats.h
@@ -28,31 +28,31 @@ public:
    TPaveStats();
    TPaveStats(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, Option_t *option="br");
    virtual ~TPaveStats();
-   virtual TBox    *AddBox(Double_t , Double_t , Double_t , Double_t) {return 0;}
-   virtual TLine   *AddLine(Double_t , Double_t , Double_t, Double_t) {return 0;}
-   virtual void     DeleteText() { }
-   virtual void     EditText() { }
+   TBox            *AddBox(Double_t , Double_t , Double_t , Double_t) override {return nullptr;}
+   TLine           *AddLine(Double_t , Double_t , Double_t, Double_t) override {return nullptr;}
+   void             DeleteText() override {}
+   void             EditText() override {}
    virtual const char  *GetFitFormat()  const {return fFitFormat.Data();}
    virtual const char  *GetStatFormat() const {return fStatFormat.Data();}
    Int_t            GetOptFit() const;
    Int_t            GetOptStat() const;
-   virtual TObject *GetParent() const {return fParent;}
-   virtual void     Paint(Option_t *option="");
-   virtual void     InsertText(const char *) { }
-   virtual void     InsertLine() { }
-   virtual void     ReadFile(const char *, Option_t *, Int_t, Int_t) { }
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   TObject         *GetParent() const override { return fParent; }
+   void             Paint(Option_t *option="") override;
+   void             InsertText(const char *) override { }
+   void             InsertLine() override { }
+   void             ReadFile(const char *, Option_t *, Int_t, Int_t) override {}
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SaveStyle(); // *MENU*
-   virtual void     SetAllWith(const char *, Option_t *, Double_t) { }
-   virtual void     SetMargin(Float_t) { }
+   void             SetAllWith(const char *, Option_t *, Double_t) override {}
+   void             SetMargin(Float_t) override { }
    virtual void     SetFitFormat(const char *format="5.4g");    // *MENU*
    virtual void     SetStatFormat(const char *format="6.4g");   // *MENU*
    void             SetOptFit(Int_t fit=1);                     // *MENU*
    void             SetOptStat(Int_t stat=1);                   // *MENU*
-   virtual void     SetParent(TObject*obj) {fParent = obj;}
-   virtual void     UseCurrentStyle();
+   void             SetParent(TObject*obj) override { fParent = obj; }
+   void             UseCurrentStyle() override;
 
-   ClassDef(TPaveStats,5)  //A special TPaveText to draw histogram statistics.
+   ClassDefOverride(TPaveStats,5)  //A special TPaveText to draw histogram statistics.
 };
 
 #endif

--- a/graf2d/graf/inc/TPaveText.h
+++ b/graf2d/graf/inc/TPaveText.h
@@ -38,9 +38,9 @@ public:
    virtual TLine   *AddLine(Double_t x1=0, Double_t y1=0, Double_t x2=0, Double_t y2=0);
    virtual TText   *AddText(Double_t x1, Double_t y1, const char *label);
    virtual TText   *AddText(const char *label);
-   virtual void     Clear(Option_t *option="");  // *MENU*
+   void             Clear(Option_t *option="") override;  // *MENU*
    virtual void     DeleteText(); // *MENU*
-   virtual void     Draw(Option_t *option="");
+   void             Draw(Option_t *option="") override;
    virtual void     DrawFile(const char *filename, Option_t *option="");
    virtual void     EditText(); // *MENU*
    const char      *GetLabel() const {return fLabel.Data();}
@@ -52,18 +52,18 @@ public:
    virtual Int_t    GetSize() const;
    virtual void     InsertLine(); // *MENU*
    virtual void     InsertText(const char *label); // *MENU*
-   virtual void     Paint(Option_t *option="");
+   void             Paint(Option_t *option="") override;
    virtual void     PaintPrimitives(Int_t mode);
-   virtual void     Print(Option_t *option="") const;
+   void             Print(Option_t *option="") const override;
    virtual void     ReadFile(const char *filename, Option_t *option="", Int_t nlines=50, Int_t fromline=0); // *MENU*
    virtual void     SaveLines(std::ostream &out, const char *name, Bool_t saved);
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetAllWith(const char *text, Option_t *option, Double_t value); // *MENU*
    virtual void     SetLabel(const char *label) {fLabel = label;} // *MENU*
    virtual void     SetMargin(Float_t margin=0.05) {fMargin=margin;} // *MENU*
-   virtual void     UseCurrentStyle();
+   void             UseCurrentStyle() override;
 
-   ClassDef(TPaveText,2)  //PaveText. A Pave with several lines of text.
+   ClassDefOverride(TPaveText,2)  //PaveText. A Pave with several lines of text.
 };
 
 #endif

--- a/graf2d/graf/inc/TPavesText.h
+++ b/graf2d/graf/inc/TPavesText.h
@@ -26,13 +26,13 @@ public:
    TPavesText(const TPavesText &pavestext);
    virtual ~TPavesText();
 
-   virtual void  Draw(Option_t *option="");
+   void          Draw(Option_t *option="") override;
    virtual Int_t GetNpaves() {return fNpaves;}
-   virtual void  Paint(Option_t *option="");
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          Paint(Option_t *option="") override;
+   void          SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void  SetNpaves(Int_t npaves=5) {fNpaves=npaves;} // *MENU*
 
-   ClassDef(TPavesText,1)  //Stacked Paves with text strings
+   ClassDefOverride(TPavesText,1)  //Stacked Paves with text strings
 };
 
 #endif

--- a/graf2d/graf/inc/TPie.h
+++ b/graf2d/graf/inc/TPie.h
@@ -54,10 +54,10 @@ public:
    TPie(const TPie&);
    ~TPie();
 
-   virtual Int_t  DistancetoPrimitive(Int_t px, Int_t py);
+   Int_t          DistancetoPrimitive(Int_t px, Int_t py) override;
    Int_t          DistancetoSlice(Int_t,Int_t);
-   virtual void   Draw(Option_t *option="l"); // *MENU*
-   virtual void   ExecuteEvent(Int_t,Int_t,Int_t);
+   void           Draw(Option_t *option="l") override; // *MENU*
+   void           ExecuteEvent(Int_t,Int_t,Int_t) override;
    Float_t        GetAngle3D() { return fAngle3D; }
    Double_t       GetAngularOffset() { return fAngularOffset; }
    Int_t          GetEntryFillColor(Int_t);
@@ -82,8 +82,8 @@ public:
    Double_t       GetY() { return fY; }
    TLegend       *MakeLegend(Double_t x1=.65,Double_t y1=.65,Double_t x2=.95, Double_t y2=.95, const char *leg_header="");
    void           MakeSlices(Bool_t force=kFALSE);
-   virtual void   Paint(Option_t *);
-   void           SavePrimitive(std::ostream &out, Option_t *opts="");
+   void           Paint(Option_t *) override;
+   void           SavePrimitive(std::ostream &out, Option_t *opts="") override;
    void           SetAngle3D(Float_t val = 30.); // *MENU*
    void           SetAngularOffset(Double_t);
    void           SetCircle(Double_t x=.5, Double_t y=.5, Double_t rad=.4);
@@ -108,7 +108,7 @@ public:
    void           SetY(Double_t); // *MENU*
    void           SortSlices(Bool_t amode=kTRUE,Float_t merge_thresold=.0);
 
-   ClassDef(TPie,1) //Pie chart graphics class
+   ClassDefOverride(TPie,1) //Pie chart graphics class
 };
 
 #endif // ROOT_TPie

--- a/graf2d/graf/inc/TPieSlice.h
+++ b/graf2d/graf/inc/TPieSlice.h
@@ -28,19 +28,19 @@ protected:
 public:
    TPieSlice();
    TPieSlice(const char *, const char *, TPie*, Double_t val=0);
-   virtual ~TPieSlice() {;}
+   virtual ~TPieSlice() {}
 
-   virtual Int_t  DistancetoPrimitive(Int_t,Int_t);
+   Int_t          DistancetoPrimitive(Int_t,Int_t) override;
    Double_t       GetRadiusOffset();
    Double_t       GetValue();
-   void           SavePrimitive(std::ostream &out, Option_t *opts="");
+   void           SavePrimitive(std::ostream &out, Option_t *opts="") override;
    void           SetIsActive(Bool_t is) { fIsActive = is; }
    void           SetRadiusOffset(Double_t);  // *MENU*
    void           SetValue(Double_t);         // *MENU*
 
    friend class TPie;
 
-   ClassDef(TPieSlice,1)            // Slice of a pie chart graphics class
+   ClassDefOverride(TPieSlice,1)            // Slice of a pie chart graphics class
 };
 
 #endif

--- a/graf2d/graf/inc/TPolyLine.h
+++ b/graf2d/graf/inc/TPolyLine.h
@@ -44,23 +44,23 @@ public:
    TPolyLine(const TPolyLine &polyline);
    virtual ~TPolyLine();
 
-   virtual void       Copy(TObject &polyline) const;
-   virtual Int_t      DistancetoPrimitive(Int_t px, Int_t py);
-   virtual void       Draw(Option_t *option="");
+   void               Copy(TObject &polyline) const override;
+   Int_t              DistancetoPrimitive(Int_t px, Int_t py) override;
+   void               Draw(Option_t *option="") override;
    virtual TPolyLine *DrawPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
-   virtual void       ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void               ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    virtual Int_t      GetLastPoint() const { return fLastPoint;}
    Int_t              GetN() const {return fN;}
    Double_t          *GetX() const {return fX;}
    Double_t          *GetY() const {return fY;}
-   Option_t          *GetOption() const {return fOption.Data();}
-   virtual void       ls(Option_t *option="") const;
+   Option_t          *GetOption() const override { return fOption.Data(); }
+   void               ls(Option_t *option="") const override;
    virtual Int_t      Merge(TCollection *list);
-   virtual void       Paint(Option_t *option="");
+   void               Paint(Option_t *option="") override;
    virtual void       PaintPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
    virtual void       PaintPolyLineNDC(Int_t n, Double_t *x, Double_t *y, Option_t *option="");
-   virtual void       Print(Option_t *option="") const;
-   virtual void       SavePrimitive(std::ostream &out, Option_t *option = "");
+   void               Print(Option_t *option="") const override;
+   void               SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void       SetNDC(Bool_t isNDC=kTRUE);
    virtual Int_t      SetNextPoint(Double_t x, Double_t y); // *MENU*
    virtual void       SetOption(Option_t *option="") {fOption = option;}
@@ -70,7 +70,7 @@ public:
    virtual void       SetPolyLine(Int_t n, Double_t *x, Double_t *y3, Option_t *option="");
    virtual Int_t      Size() const {return fLastPoint+1;}
 
-   ClassDef(TPolyLine,3)  //A PolyLine
+   ClassDefOverride(TPolyLine,3)  //A PolyLine
 };
 
 #endif

--- a/graf2d/graf/inc/TText.h
+++ b/graf2d/graf/inc/TText.h
@@ -40,13 +40,13 @@ public:
 
    TText &operator=(const TText &src);
 
-   void             Copy(TObject &text) const;
-   virtual Int_t    DistancetoPrimitive(Int_t px, Int_t py);
+   void             Copy(TObject &text) const override;
+   Int_t            DistancetoPrimitive(Int_t px, Int_t py) override;
    virtual TText   *DrawText(Double_t x, Double_t y, const char *text);
    virtual TText   *DrawText(Double_t x, Double_t y, const wchar_t *text);
    virtual TText   *DrawTextNDC(Double_t x, Double_t y, const char *text);
    virtual TText   *DrawTextNDC(Double_t x, Double_t y, const wchar_t *text);
-   virtual void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void             ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 
    virtual void     GetControlBox(Int_t x, Int_t y, Double_t theta,
                                   Int_t cBoxX[4], Int_t cBoxY[4]);
@@ -60,15 +60,15 @@ public:
    const void *     GetWcsTitle(void) const;
    Double_t         GetY() const  { return fY; }
 
-   virtual void     ls(Option_t *option="") const;
-   virtual void     Paint(Option_t *option="");
+   void             ls(Option_t *option="") const override;
+   void             Paint(Option_t *option="") override;
    virtual void     PaintControlBox(Int_t x, Int_t y, Double_t theta);
    virtual void     PaintText(Double_t x, Double_t y, const char *text);
    virtual void     PaintText(Double_t x, Double_t y, const wchar_t *text);
    virtual void     PaintTextNDC(Double_t u, Double_t v, const char *text);
    virtual void     PaintTextNDC(Double_t u, Double_t v, const wchar_t *text);
-   virtual void     Print(Option_t *option="") const;
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             Print(Option_t *option="") const override;
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void     SetMbTitle(const wchar_t *title=L"");
    virtual void     SetNDC(Bool_t isNDC=kTRUE);
    virtual void     SetText(Double_t x, Double_t y, const char *text) {fX=x; fY=y; SetTitle(text);} // *MENU* *ARGS={x=>fX,y=>fY,text=>fTitle}
@@ -76,17 +76,17 @@ public:
    virtual void     SetX(Double_t x) { fX = x; } // *MENU*
    virtual void     SetY(Double_t y) { fY = y; } // *MENU*
 
-   virtual Rectangle_t  GetBBox();
-   virtual TPoint       GetBBoxCenter();
-   virtual void         SetBBoxCenter(const TPoint &p);
-   virtual void         SetBBoxCenterX(const Int_t x);
-   virtual void         SetBBoxCenterY(const Int_t y);
-   virtual void         SetBBoxX1(const Int_t x); //Not Implemented
-   virtual void         SetBBoxX2(const Int_t x); //Not Implemented
-   virtual void         SetBBoxY1(const Int_t y); //Not Implemented
-   virtual void         SetBBoxY2(const Int_t y); //Not Implemented
+   Rectangle_t      GetBBox() override;
+   TPoint           GetBBoxCenter() override;
+   void             SetBBoxCenter(const TPoint &p) override;
+   void             SetBBoxCenterX(const Int_t x) override;
+   void             SetBBoxCenterY(const Int_t y) override;
+   void             SetBBoxX1(const Int_t) override; //Not Implemented
+   void             SetBBoxX2(const Int_t) override; //Not Implemented
+   void             SetBBoxY1(const Int_t) override; //Not Implemented
+   void             SetBBoxY2(const Int_t) override; //Not Implemented
 
-   ClassDef(TText,3)  //Text
+   ClassDefOverride(TText,3)  //Text
 };
 
 #endif

--- a/graf2d/graf/inc/TWbox.h
+++ b/graf2d/graf/inc/TWbox.h
@@ -32,26 +32,26 @@ public:
 
    TWbox &operator=(const TWbox &src);
 
-   void           Copy(TObject &wbox) const;
-   virtual void   Draw(Option_t *option="");
+   void           Copy(TObject &wbox) const override;
+   void           Draw(Option_t *option="") override;
    virtual TWbox *DrawWbox(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
                            Color_t color=33 ,Short_t bordersize=5 ,Short_t bordermode=-1);
-   virtual void   ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void           ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
    Short_t        GetBorderMode() const { return fBorderMode;}
    Short_t        GetBorderSize() const { return fBorderSize;}
    Int_t          GetDarkColor() const  {return TColor::GetColorDark(GetFillColor());}
    Int_t          GetLightColor() const {return TColor::GetColorBright(GetFillColor());}
-   virtual void   Paint(Option_t *option="");
+   void           Paint(Option_t *option="") override;
    virtual void   PaintFrame(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
                              Color_t color, Short_t bordersize, Short_t bordermode,
                              Bool_t tops);
    virtual void   PaintWbox(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
                   Color_t color=33, Short_t bordersize=5, Short_t bordermode=-1);
-   virtual void   SavePrimitive(std::ostream &out, Option_t *option = "");
+   void           SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void   SetBorderMode(Short_t bordermode) {fBorderMode = bordermode;} // *MENU*
    virtual void   SetBorderSize(Short_t bordersize) {fBorderSize = bordersize;} // *MENU*
 
-   ClassDef(TWbox,1)  //A window box (box with 3-D effects)
+   ClassDefOverride(TWbox,1)  //A window box (box with 3-D effects)
 };
 
 #endif

--- a/graf2d/x11/inc/TGX11.h
+++ b/graf2d/x11/inc/TGX11.h
@@ -161,247 +161,247 @@ public:
    TGX11(const char *name, const char *title);
    virtual ~TGX11();
 
-   Bool_t    Init(void *display);
-   void      ClearWindow();
-   void      ClosePixmap();
-   void      CloseWindow();
-   void      CopyPixmap(Int_t wid, Int_t xpos, Int_t ypos);
-   void      DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, EBoxMode mode);
-   void      DrawCellArray(Int_t x1, Int_t y1, Int_t x2, Int_t y2, Int_t nx, Int_t ny, Int_t *ic);
-   void      DrawFillArea(Int_t n, TPoint *xy);
-   void      DrawLine(Int_t x1, Int_t y1, Int_t x2, Int_t y2);
-   void      DrawPolyLine(Int_t n, TPoint *xy);
-   void      DrawPolyMarker(Int_t n, TPoint *xy);
-   virtual void DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn, const char *text, ETextMode mode);
-   virtual void DrawText(Int_t, Int_t, Float_t, Float_t, const wchar_t *, ETextMode) {}
-   void      GetCharacterUp(Float_t &chupx, Float_t &chupy);
-   Int_t     GetDoubleBuffer(Int_t wid);
-   void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   const char *DisplayName(const char *dpyName = 0);
-   Handle_t  GetNativeEvent() const { return (Handle_t) fXEvent; }
-   ULong_t   GetPixel(Color_t cindex);
-   void      GetPlanes(Int_t &nplanes);
-   void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b);
-   virtual void GetTextExtent(UInt_t &w, UInt_t &h, char *mess);
-   virtual void GetTextExtent(UInt_t &, UInt_t &, wchar_t *){}
-   Float_t   GetTextMagnitude() { return fTextMagnitude; }
-   Window_t  GetWindowID(Int_t wid);
-   Bool_t    HasTTFonts() const { return fHasTTFonts; }
-   Int_t     InitWindow(ULong_t window);
-   Int_t     AddWindow(ULong_t qwid, UInt_t w, UInt_t h);
-   Int_t     AddPixmap(ULong_t pixid, UInt_t w, UInt_t h);
-   void      RemoveWindow(ULong_t qwid);
-   void      MoveWindow(Int_t wid, Int_t x, Int_t y);
+   Bool_t    Init(void *display) override;
+   void      ClearWindow() override;
+   void      ClosePixmap() override;
+   void      CloseWindow() override;
+   void      CopyPixmap(Int_t wid, Int_t xpos, Int_t ypos) override;
+   void      DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, EBoxMode mode) override;
+   void      DrawCellArray(Int_t x1, Int_t y1, Int_t x2, Int_t y2, Int_t nx, Int_t ny, Int_t *ic) override;
+   void      DrawFillArea(Int_t n, TPoint *xy) override;
+   void      DrawLine(Int_t x1, Int_t y1, Int_t x2, Int_t y2) override;
+   void      DrawPolyLine(Int_t n, TPoint *xy) override;
+   void      DrawPolyMarker(Int_t n, TPoint *xy) override;
+   void      DrawText(Int_t x, Int_t y, Float_t angle, Float_t mgn, const char *text, ETextMode mode) override;
+   void      DrawText(Int_t, Int_t, Float_t, Float_t, const wchar_t *, ETextMode) override {}
+   void      GetCharacterUp(Float_t &chupx, Float_t &chupy) override;
+   Int_t     GetDoubleBuffer(Int_t wid) override;
+   void      GetGeometry(Int_t wid, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h) override;
+   const char *DisplayName(const char *dpyName = nullptr) override;
+   Handle_t  GetNativeEvent() const override { return (Handle_t) fXEvent; }
+   ULong_t   GetPixel(Color_t cindex) override;
+   void      GetPlanes(Int_t &nplanes) override;
+   void      GetRGB(Int_t index, Float_t &r, Float_t &g, Float_t &b) override;
+   void      GetTextExtent(UInt_t &w, UInt_t &h, char *mess) override;
+   void      GetTextExtent(UInt_t &, UInt_t &, wchar_t *) override {}
+   Float_t   GetTextMagnitude() override { return fTextMagnitude; }
+   Window_t  GetWindowID(Int_t wid) override;
+   Bool_t    HasTTFonts() const override { return fHasTTFonts; }
+   Int_t     InitWindow(ULong_t window) override;
+   Int_t     AddWindow(ULong_t qwid, UInt_t w, UInt_t h) override;
+   Int_t     AddPixmap(ULong_t pixid, UInt_t w, UInt_t h) override;
+   void      RemoveWindow(ULong_t qwid) override;
+   void      MoveWindow(Int_t wid, Int_t x, Int_t y) override;
    Int_t     OpenDisplay(void *display);
-   Int_t     OpenPixmap(UInt_t w, UInt_t h);
-   void      QueryPointer(Int_t &ix, Int_t &iy);
-   Pixmap_t  ReadGIF(Int_t x0, Int_t y0, const char *file, Window_t id=0);
-   Int_t     RequestLocator(Int_t mode, Int_t ctyp, Int_t &x, Int_t &y);
-   Int_t     RequestString(Int_t x, Int_t y, char *text);
-   void      RescaleWindow(Int_t wid, UInt_t w, UInt_t h);
-   Int_t     ResizePixmap(Int_t wid, UInt_t w, UInt_t h);
-   void      ResizeWindow(Int_t wid);
-   void      SelectWindow(Int_t wid);
-   void      SetCharacterUp(Float_t chupx, Float_t chupy);
-   void      SetClipOFF(Int_t wid);
-   void      SetClipRegion(Int_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void      SetCursor(Int_t win, ECursor cursor);
-   void      SetDoubleBuffer(Int_t wid, Int_t mode);
-   void      SetDoubleBufferOFF();
-   void      SetDoubleBufferON();
-   void      SetDrawMode(EDrawMode mode);
-   void      SetFillColor(Color_t cindex);
-   void      SetFillStyle(Style_t style);
-   void      SetLineColor(Color_t cindex);
-   void      SetLineType(Int_t n, Int_t *dash);
-   void      SetLineStyle(Style_t linestyle);
-   void      SetLineWidth(Width_t width);
-   void      SetMarkerColor(Color_t cindex);
-   void      SetMarkerSize(Float_t markersize);
-   void      SetMarkerStyle(Style_t markerstyle);
-   void      SetOpacity(Int_t percent);
-   void      SetRGB(Int_t cindex, Float_t r, Float_t g, Float_t b);
-   void      SetTextAlign(Short_t talign=11);
-   void      SetTextColor(Color_t cindex);
-   virtual Int_t SetTextFont(char *fontname, ETextSetMode mode);
-   virtual void  SetTextFont(Font_t fontnumber);
-   void      SetTextMagnitude(Float_t mgn=1) { fTextMagnitude = mgn;}
-   virtual void SetTextSize(Float_t textsize);
-   void      Sync(Int_t mode);
-   void      UpdateWindow(Int_t mode);
-   void      Warp(Int_t ix, Int_t iy, Window_t id = 0);
-   Int_t     WriteGIF(char *name);
-   void      WritePixmap(Int_t wid, UInt_t w, UInt_t h, char *pxname);
-   Window_t  GetCurrentWindow() const;
-   Int_t     SupportsExtension(const char *ext) const;
+   Int_t     OpenPixmap(UInt_t w, UInt_t h) override;
+   void      QueryPointer(Int_t &ix, Int_t &iy) override;
+   Pixmap_t  ReadGIF(Int_t x0, Int_t y0, const char *file, Window_t id = 0) override;
+   Int_t     RequestLocator(Int_t mode, Int_t ctyp, Int_t &x, Int_t &y) override;
+   Int_t     RequestString(Int_t x, Int_t y, char *text) override;
+   void      RescaleWindow(Int_t wid, UInt_t w, UInt_t h) override;
+   Int_t     ResizePixmap(Int_t wid, UInt_t w, UInt_t h) override;
+   void      ResizeWindow(Int_t wid) override;
+   void      SelectWindow(Int_t wid) override;
+   void      SetCharacterUp(Float_t chupx, Float_t chupy) override;
+   void      SetClipOFF(Int_t wid) override;
+   void      SetClipRegion(Int_t wid, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   void      SetCursor(Int_t win, ECursor cursor) override;
+   void      SetDoubleBuffer(Int_t wid, Int_t mode) override;
+   void      SetDoubleBufferOFF() override;
+   void      SetDoubleBufferON() override;
+   void      SetDrawMode(EDrawMode mode) override;
+   void      SetFillColor(Color_t cindex) override;
+   void      SetFillStyle(Style_t style) override;
+   void      SetLineColor(Color_t cindex) override;
+   void      SetLineType(Int_t n, Int_t *dash) override;
+   void      SetLineStyle(Style_t linestyle) override;
+   void      SetLineWidth(Width_t width) override;
+   void      SetMarkerColor(Color_t cindex) override;
+   void      SetMarkerSize(Float_t markersize) override;
+   void      SetMarkerStyle(Style_t markerstyle) override;
+   void      SetOpacity(Int_t percent) override;
+   void      SetRGB(Int_t cindex, Float_t r, Float_t g, Float_t b) override;
+   void      SetTextAlign(Short_t talign=11) override;
+   void      SetTextColor(Color_t cindex) override;
+   Int_t     SetTextFont(char *fontname, ETextSetMode mode) override;
+   void      SetTextFont(Font_t fontnumber) override;
+   void      SetTextMagnitude(Float_t mgn=1) override { fTextMagnitude = mgn;}
+   void      SetTextSize(Float_t textsize) override;
+   void      Sync(Int_t mode) override;
+   void      UpdateWindow(Int_t mode) override;
+   void      Warp(Int_t ix, Int_t iy, Window_t id = 0) override;
+   Int_t     WriteGIF(char *name) override;
+   void      WritePixmap(Int_t wid, UInt_t w, UInt_t h, char *pxname) override;
+   Window_t  GetCurrentWindow() const override;
+   Int_t     SupportsExtension(const char *ext) const override;
 
    //---- Methods used for GUI -----
-   void         GetWindowAttributes(Window_t id, WindowAttributes_t &attr);
-   void         MapWindow(Window_t id);
-   void         MapSubwindows(Window_t id);
-   void         MapRaised(Window_t id);
-   void         UnmapWindow(Window_t id);
-   void         DestroyWindow(Window_t id);
-   void         DestroySubwindows(Window_t id);
-   void         RaiseWindow(Window_t id);
-   void         LowerWindow(Window_t id);
-   void         MoveWindow(Window_t id, Int_t x, Int_t y);
-   void         MoveResizeWindow(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   void         ResizeWindow(Window_t id, UInt_t w, UInt_t h);
-   void         IconifyWindow(Window_t id);
-   void         ReparentWindow(Window_t id, Window_t pid, Int_t x, Int_t y);
-   void         SetWindowBackground(Window_t id, ULong_t color);
-   void         SetWindowBackgroundPixmap(Window_t id, Pixmap_t pxm);
+   void         GetWindowAttributes(Window_t id, WindowAttributes_t &attr) override;
+   void         MapWindow(Window_t id) override;
+   void         MapSubwindows(Window_t id) override;
+   void         MapRaised(Window_t id) override;
+   void         UnmapWindow(Window_t id) override;
+   void         DestroyWindow(Window_t id) override;
+   void         DestroySubwindows(Window_t id) override;
+   void         RaiseWindow(Window_t id) override;
+   void         LowerWindow(Window_t id) override;
+   void         MoveWindow(Window_t id, Int_t x, Int_t y) override;
+   void         MoveResizeWindow(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   void         ResizeWindow(Window_t id, UInt_t w, UInt_t h) override;
+   void         IconifyWindow(Window_t id) override;
+   void         ReparentWindow(Window_t id, Window_t pid, Int_t x, Int_t y) override;
+   void         SetWindowBackground(Window_t id, ULong_t color) override;
+   void         SetWindowBackgroundPixmap(Window_t id, Pixmap_t pxm) override;
    Window_t     CreateWindow(Window_t parent, Int_t x, Int_t y,
                              UInt_t w, UInt_t h, UInt_t border,
                              Int_t depth, UInt_t clss,
                              void *visual, SetWindowAttributes_t *attr,
-                             UInt_t wtype);
-   Int_t        OpenDisplay(const char *dpyName);
-   void         CloseDisplay();
-   Display_t    GetDisplay() const;
-   Visual_t     GetVisual() const;
-   Int_t        GetScreen() const;
-   Int_t        GetDepth() const;
-   Colormap_t   GetColormap() const;
-   Atom_t       InternAtom(const char *atom_name, Bool_t only_if_exist);
-   Window_t     GetDefaultRootWindow() const;
-   Window_t     GetParent(Window_t id) const;
-   FontStruct_t LoadQueryFont(const char *font_name);
-   FontH_t      GetFontHandle(FontStruct_t fs);
-   void         DeleteFont(FontStruct_t fs);
-   GContext_t   CreateGC(Drawable_t id, GCValues_t *gval);
-   void         ChangeGC(GContext_t gc, GCValues_t *gval);
-   void         CopyGC(GContext_t org, GContext_t dest, Mask_t mask);
-   void         DeleteGC(GContext_t gc);
-   Cursor_t     CreateCursor(ECursor cursor);
-   void         SetCursor(Window_t id, Cursor_t curid);
-   Pixmap_t     CreatePixmap(Drawable_t id, UInt_t w, UInt_t h);
+                             UInt_t wtype) override;
+   Int_t        OpenDisplay(const char *dpyName) override;
+   void         CloseDisplay() override;
+   Display_t    GetDisplay() const override;
+   Visual_t     GetVisual() const override;
+   Int_t        GetScreen() const override;
+   Int_t        GetDepth() const override;
+   Colormap_t   GetColormap() const override;
+   Atom_t       InternAtom(const char *atom_name, Bool_t only_if_exist) override;
+   Window_t     GetDefaultRootWindow() const override;
+   Window_t     GetParent(Window_t id) const override;
+   FontStruct_t LoadQueryFont(const char *font_name) override;
+   FontH_t      GetFontHandle(FontStruct_t fs) override;
+   void         DeleteFont(FontStruct_t fs) override;
+   GContext_t   CreateGC(Drawable_t id, GCValues_t *gval) override;
+   void         ChangeGC(GContext_t gc, GCValues_t *gval) override;
+   void         CopyGC(GContext_t org, GContext_t dest, Mask_t mask) override;
+   void         DeleteGC(GContext_t gc) override;
+   Cursor_t     CreateCursor(ECursor cursor) override;
+   void         SetCursor(Window_t id, Cursor_t curid) override;
+   Pixmap_t     CreatePixmap(Drawable_t id, UInt_t w, UInt_t h) override;
    Pixmap_t     CreatePixmap(Drawable_t id, const char *bitmap, UInt_t width,
                              UInt_t height, ULong_t forecolor, ULong_t backcolor,
-                             Int_t depth);
-   unsigned char *GetColorBits(Drawable_t wid, Int_t x = 0, Int_t y = 0, UInt_t w = 0, UInt_t h = 0);
-   Pixmap_t     CreatePixmapFromData(unsigned char *bits, UInt_t width, UInt_t height);
+                             Int_t depth) override;
+   unsigned char *GetColorBits(Drawable_t wid, Int_t x = 0, Int_t y = 0, UInt_t w = 0, UInt_t h = 0) override;
+   Pixmap_t     CreatePixmapFromData(unsigned char *bits, UInt_t width, UInt_t height) override;
    Pixmap_t     CreateBitmap(Drawable_t id, const char *bitmap,
-                             UInt_t width, UInt_t height);
-   void         DeletePixmap(Pixmap_t pmap);
+                             UInt_t width, UInt_t height) override;
+   void         DeletePixmap(Pixmap_t pmap) override;
    Bool_t       CreatePictureFromFile(Drawable_t id, const char *filename,
                                       Pixmap_t &pict, Pixmap_t &pict_mask,
-                                      PictureAttributes_t &attr);
+                                      PictureAttributes_t &attr) override;
    Bool_t       CreatePictureFromData(Drawable_t id, char **data,
                                       Pixmap_t &pict, Pixmap_t &pict_mask,
-                                      PictureAttributes_t &attr);
-   Bool_t       ReadPictureDataFromFile(const char *filename, char ***ret_data);
-   void         DeletePictureData(void *data);
-   void         SetDashes(GContext_t gc, Int_t offset, const char *dash_list, Int_t n);
-   Bool_t       ParseColor(Colormap_t cmap, const char *cname, ColorStruct_t &color);
-   Bool_t       AllocColor(Colormap_t cmap, ColorStruct_t &color);
-   void         QueryColor(Colormap_t cmap, ColorStruct_t &color);
-   void         FreeColor(Colormap_t cmap, ULong_t pixel);
-   Int_t        EventsPending();
-   void         NextEvent(Event_t &event);
-   void         Bell(Int_t percent);
+                                      PictureAttributes_t &attr) override;
+   Bool_t       ReadPictureDataFromFile(const char *filename, char ***ret_data) override;
+   void         DeletePictureData(void *data) override;
+   void         SetDashes(GContext_t gc, Int_t offset, const char *dash_list, Int_t n) override;
+   Bool_t       ParseColor(Colormap_t cmap, const char *cname, ColorStruct_t &color) override;
+   Bool_t       AllocColor(Colormap_t cmap, ColorStruct_t &color) override;
+   void         QueryColor(Colormap_t cmap, ColorStruct_t &color) override;
+   void         FreeColor(Colormap_t cmap, ULong_t pixel) override;
+   Int_t        EventsPending() override;
+   void         NextEvent(Event_t &event) override;
+   void         Bell(Int_t percent) override;
    void         CopyArea(Drawable_t src, Drawable_t dest, GContext_t gc,
                          Int_t src_x, Int_t src_y, UInt_t width, UInt_t height,
-                         Int_t dest_x, Int_t dest_y);
-   void         ChangeWindowAttributes(Window_t id, SetWindowAttributes_t *attr);
+                         Int_t dest_x, Int_t dest_y) override;
+   void         ChangeWindowAttributes(Window_t id, SetWindowAttributes_t *attr) override;
    void         ChangeProperty(Window_t id, Atom_t property, Atom_t type,
-                               UChar_t *data, Int_t len);
-   void         DrawLine(Drawable_t id, GContext_t gc, Int_t x1, Int_t y1, Int_t x2, Int_t y2);
-   void         ClearArea(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h);
-   Bool_t       CheckEvent(Window_t id, EGEventType type, Event_t &ev);
-   void         SendEvent(Window_t id, Event_t *ev);
-   void         WMDeleteNotify(Window_t id);
-   void         SetKeyAutoRepeat(Bool_t on = kTRUE);
-   void         GrabKey(Window_t id, Int_t keycode, UInt_t modifier, Bool_t grab = kTRUE);
+                               UChar_t *data, Int_t len) override;
+   void         DrawLine(Drawable_t id, GContext_t gc, Int_t x1, Int_t y1, Int_t x2, Int_t y2) override;
+   void         ClearArea(Window_t id, Int_t x, Int_t y, UInt_t w, UInt_t h) override;
+   Bool_t       CheckEvent(Window_t id, EGEventType type, Event_t &ev) override;
+   void         SendEvent(Window_t id, Event_t *ev) override;
+   void         WMDeleteNotify(Window_t id) override;
+   void         SetKeyAutoRepeat(Bool_t on = kTRUE) override;
+   void         GrabKey(Window_t id, Int_t keycode, UInt_t modifier, Bool_t grab = kTRUE) override;
    void         GrabButton(Window_t id, EMouseButton button, UInt_t modifier,
                            UInt_t evmask, Window_t confine, Cursor_t cursor,
-                           Bool_t grab = kTRUE);
+                           Bool_t grab = kTRUE) override;
    void         GrabPointer(Window_t id, UInt_t evmask, Window_t confine,
                             Cursor_t cursor, Bool_t grab = kTRUE,
-                            Bool_t owner_events = kTRUE);
-   void         SetWindowName(Window_t id, char *name);
-   void         SetIconName(Window_t id, char *name);
-   void         SetIconPixmap(Window_t id, Pixmap_t pic);
-   void         SetClassHints(Window_t id, char *className, char *resourceName);
-   void         SetMWMHints(Window_t id, UInt_t value, UInt_t funcs, UInt_t input);
-   void         SetWMPosition(Window_t id, Int_t x, Int_t y);
-   void         SetWMSize(Window_t id, UInt_t w, UInt_t h);
+                            Bool_t owner_events = kTRUE) override;
+   void         SetWindowName(Window_t id, char *name) override;
+   void         SetIconName(Window_t id, char *name) override;
+   void         SetIconPixmap(Window_t id, Pixmap_t pic) override;
+   void         SetClassHints(Window_t id, char *className, char *resourceName) override;
+   void         SetMWMHints(Window_t id, UInt_t value, UInt_t funcs, UInt_t input) override;
+   void         SetWMPosition(Window_t id, Int_t x, Int_t y) override;
+   void         SetWMSize(Window_t id, UInt_t w, UInt_t h) override;
    void         SetWMSizeHints(Window_t id, UInt_t wmin, UInt_t hmin,
-                               UInt_t wmax, UInt_t hmax, UInt_t winc, UInt_t hinc);
-   void         SetWMState(Window_t id, EInitialState state);
-   void         SetWMTransientHint(Window_t id, Window_t main_id);
+                               UInt_t wmax, UInt_t hmax, UInt_t winc, UInt_t hinc) override;
+   void         SetWMState(Window_t id, EInitialState state) override;
+   void         SetWMTransientHint(Window_t id, Window_t main_id) override;
    void         DrawString(Drawable_t id, GContext_t gc, Int_t x, Int_t y,
-                           const char *s, Int_t len);
-   Int_t        TextWidth(FontStruct_t font, const char *s, Int_t len);
-   void         GetFontProperties(FontStruct_t font, Int_t &max_ascent, Int_t &max_descent);
-   void         GetGCValues(GContext_t gc, GCValues_t &gval);
-   FontStruct_t GetFontStruct(FontH_t fh);
-   void         FreeFontStruct(FontStruct_t fs);
-   void         ClearWindow(Window_t id);
-   Int_t        KeysymToKeycode(UInt_t keysym);
+                           const char *s, Int_t len) override;
+   Int_t        TextWidth(FontStruct_t font, const char *s, Int_t len) override;
+   void         GetFontProperties(FontStruct_t font, Int_t &max_ascent, Int_t &max_descent) override;
+   void         GetGCValues(GContext_t gc, GCValues_t &gval) override;
+   FontStruct_t GetFontStruct(FontH_t fh) override;
+   void         FreeFontStruct(FontStruct_t fs) override;
+   void         ClearWindow(Window_t id) override;
+   Int_t        KeysymToKeycode(UInt_t keysym) override;
    void         FillRectangle(Drawable_t id, GContext_t gc, Int_t x, Int_t y,
-                              UInt_t w, UInt_t h);
+                              UInt_t w, UInt_t h) override;
    void         DrawRectangle(Drawable_t id, GContext_t gc, Int_t x, Int_t y,
-                              UInt_t w, UInt_t h);
-   void         DrawSegments(Drawable_t id, GContext_t gc, Segment_t *seg, Int_t nseg);
-   void         SelectInput(Window_t id, UInt_t evmask);
-   Window_t     GetInputFocus();
-   void         SetInputFocus(Window_t id);
-   Window_t     GetPrimarySelectionOwner();
-   void         SetPrimarySelectionOwner(Window_t id);
-   void         ConvertPrimarySelection(Window_t id, Atom_t clipboard, Time_t when);
-   void         LookupString(Event_t *event, char *buf, Int_t buflen, UInt_t &keysym);
+                              UInt_t w, UInt_t h) override;
+   void         DrawSegments(Drawable_t id, GContext_t gc, Segment_t *seg, Int_t nseg) override;
+   void         SelectInput(Window_t id, UInt_t evmask) override;
+   Window_t     GetInputFocus() override;
+   void         SetInputFocus(Window_t id) override;
+   Window_t     GetPrimarySelectionOwner() override;
+   void         SetPrimarySelectionOwner(Window_t id) override;
+   void         ConvertPrimarySelection(Window_t id, Atom_t clipboard, Time_t when) override;
+   void         LookupString(Event_t *event, char *buf, Int_t buflen, UInt_t &keysym) override;
    void         GetPasteBuffer(Window_t id, Atom_t atom, TString &text,
-                               Int_t &nchar, Bool_t del);
+                               Int_t &nchar, Bool_t del) override;
    void         TranslateCoordinates(Window_t src, Window_t dest, Int_t src_x,
-                    Int_t src_y, Int_t &dest_x, Int_t &dest_y, Window_t &child);
-   void         GetWindowSize(Drawable_t id, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   void         FillPolygon(Window_t id, GContext_t gc, Point_t *points, Int_t npnt);
+                    Int_t src_y, Int_t &dest_x, Int_t &dest_y, Window_t &child) override;
+   void         GetWindowSize(Drawable_t id, Int_t &x, Int_t &y, UInt_t &w, UInt_t &h) override;
+   void         FillPolygon(Window_t id, GContext_t gc, Point_t *points, Int_t npnt) override;
    void         QueryPointer(Window_t id, Window_t &rootw, Window_t &childw,
                              Int_t &root_x, Int_t &root_y, Int_t &win_x,
-                             Int_t &win_y, UInt_t &mask);
-   void         SetForeground(GContext_t gc, ULong_t foreground);
-   void         SetClipRectangles(GContext_t gc, Int_t x, Int_t y, Rectangle_t *recs, Int_t n);
-   void         Update(Int_t mode = 0);
-   Region_t     CreateRegion();
-   void         DestroyRegion(Region_t reg);
-   void         UnionRectWithRegion(Rectangle_t *rect, Region_t src, Region_t dest);
-   Region_t     PolygonRegion(Point_t *points, Int_t np, Bool_t winding);
-   void         UnionRegion(Region_t rega, Region_t regb, Region_t result);
-   void         IntersectRegion(Region_t rega, Region_t regb, Region_t result);
-   void         SubtractRegion(Region_t rega, Region_t regb, Region_t result);
-   void         XorRegion(Region_t rega, Region_t regb, Region_t result);
-   Bool_t       EmptyRegion(Region_t reg);
-   Bool_t       PointInRegion(Int_t x, Int_t y, Region_t reg);
-   Bool_t       EqualRegion(Region_t rega, Region_t regb);
-   void         GetRegionBox(Region_t reg, Rectangle_t *);
-   char       **ListFonts(const char *fontname, Int_t max, Int_t &count);
-   void         FreeFontNames(char **fontlist);
-   Drawable_t   CreateImage(UInt_t width, UInt_t height);
-   void         GetImageSize(Drawable_t id, UInt_t &width, UInt_t &height);
-   void         PutPixel(Drawable_t id, Int_t x, Int_t y, ULong_t pixel);
+                             Int_t &win_y, UInt_t &mask) override;
+   void         SetForeground(GContext_t gc, ULong_t foreground) override;
+   void         SetClipRectangles(GContext_t gc, Int_t x, Int_t y, Rectangle_t *recs, Int_t n) override;
+   void         Update(Int_t mode = 0) override;
+   Region_t     CreateRegion() override;
+   void         DestroyRegion(Region_t reg) override;
+   void         UnionRectWithRegion(Rectangle_t *rect, Region_t src, Region_t dest) override;
+   Region_t     PolygonRegion(Point_t *points, Int_t np, Bool_t winding) override;
+   void         UnionRegion(Region_t rega, Region_t regb, Region_t result) override;
+   void         IntersectRegion(Region_t rega, Region_t regb, Region_t result) override;
+   void         SubtractRegion(Region_t rega, Region_t regb, Region_t result) override;
+   void         XorRegion(Region_t rega, Region_t regb, Region_t result) override;
+   Bool_t       EmptyRegion(Region_t reg) override;
+   Bool_t       PointInRegion(Int_t x, Int_t y, Region_t reg) override;
+   Bool_t       EqualRegion(Region_t rega, Region_t regb) override;
+   void         GetRegionBox(Region_t reg, Rectangle_t *) override;
+   char       **ListFonts(const char *fontname, Int_t max, Int_t &count) override;
+   void         FreeFontNames(char **fontlist) override;
+   Drawable_t   CreateImage(UInt_t width, UInt_t height) override;
+   void         GetImageSize(Drawable_t id, UInt_t &width, UInt_t &height) override;
+   void         PutPixel(Drawable_t id, Int_t x, Int_t y, ULong_t pixel) override;
    void         PutImage(Drawable_t id, GContext_t gc, Drawable_t img,
                          Int_t dx, Int_t dy, Int_t x, Int_t y,
-                         UInt_t w, UInt_t h);
-   void         DeleteImage(Drawable_t img);
-   void         ShapeCombineMask(Window_t id, Int_t x, Int_t y, Pixmap_t mask);
-   UInt_t       ScreenWidthMM() const;
+                         UInt_t w, UInt_t h) override;
+   void         DeleteImage(Drawable_t img) override;
+   void         ShapeCombineMask(Window_t id, Int_t x, Int_t y, Pixmap_t mask) override;
+   UInt_t       ScreenWidthMM() const override;
 
-   void         DeleteProperty(Window_t, Atom_t&);
+   void         DeleteProperty(Window_t, Atom_t&) override;
    Int_t        GetProperty(Window_t, Atom_t, Long_t, Long_t, Bool_t, Atom_t,
-                            Atom_t*, Int_t*, ULong_t*, ULong_t*, unsigned char**);
-   void         ChangeActivePointerGrab(Window_t, UInt_t, Cursor_t);
-   void         ConvertSelection(Window_t, Atom_t&, Atom_t&, Atom_t&, Time_t&);
-   Bool_t       SetSelectionOwner(Window_t, Atom_t&);
+                            Atom_t*, Int_t*, ULong_t*, ULong_t*, unsigned char**) override;
+   void         ChangeActivePointerGrab(Window_t, UInt_t, Cursor_t) override;
+   void         ConvertSelection(Window_t, Atom_t&, Atom_t&, Atom_t&, Time_t&) override;
+   Bool_t       SetSelectionOwner(Window_t, Atom_t&) override;
    void         ChangeProperties(Window_t id, Atom_t property, Atom_t type,
-                                 Int_t format, UChar_t *data, Int_t len);
-   void         SetDNDAware(Window_t, Atom_t *);
-   void         SetTypeList(Window_t win, Atom_t prop, Atom_t *typelist);
-   Window_t     FindRWindow(Window_t win, Window_t dragwin, Window_t input, int x, int y, int maxd);
-   Bool_t       IsDNDAware(Window_t win, Atom_t *typelist);
+                                 Int_t format, UChar_t *data, Int_t len) override;
+   void         SetDNDAware(Window_t, Atom_t *) override;
+   void         SetTypeList(Window_t win, Atom_t prop, Atom_t *typelist) override;
+   Window_t     FindRWindow(Window_t win, Window_t dragwin, Window_t input, int x, int y, int maxd) override;
+   Bool_t       IsDNDAware(Window_t win, Atom_t *typelist) override;
 
-   ClassDef(TGX11,0)  //Interface to X11
+   ClassDefOverride(TGX11,0)  //Interface to X11
 };
 
 #endif

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -341,7 +341,7 @@ TGX11::~TGX11()
 
 Bool_t TGX11::Init(void *display)
 {
-   if (OpenDisplay((Display *) display) == -1) return kFALSE;
+   if (OpenDisplay(display) == -1) return kFALSE;
    return kTRUE;
 }
 
@@ -1098,7 +1098,7 @@ Int_t TGX11::OpenDisplay(void *disp)
 
    if (fDisplay) return 0;
 
-   fDisplay      = disp;
+   fDisplay      = (void *) disp;
    fScreenNumber = DefaultScreen((Display*)fDisplay);
 
    FindBestVisual();

--- a/gui/ged/inc/TGedEditor.h
+++ b/gui/ged/inc/TGedEditor.h
@@ -62,7 +62,7 @@ public:
    virtual ~TGedEditor();
 
    void          PrintFrameStat();
-   virtual void  Update(TGedFrame* frame = 0);
+   virtual void  Update(TGedFrame* frame = nullptr);
    void          ReinitWorkspace();
    void          ActivateEditor (TClass* cl, Bool_t recurse);
    void          ActivateEditors(TList* bcl, Bool_t recurse);
@@ -74,28 +74,28 @@ public:
    virtual TGCompositeFrame* GetEditorTab(const char* name);
    virtual TGedTabInfo*      GetEditorTabInfo(const char* name);
 
-   virtual TCanvas*          GetCanvas() const { return fCanvas; }
+   TCanvas*                  GetCanvas() const override { return fCanvas; }
    virtual TVirtualPad*      GetPad()    const { return fPad; }
    virtual TObject*          GetModel()  const { return fModel; }
 
 
-   virtual void   CloseWindow();
+   void           CloseWindow() override;
    virtual void   ConnectToCanvas(TCanvas *c);
    virtual void   DisconnectFromCanvas();
-   virtual Bool_t IsGlobal() const  { return fGlobal; }
-   virtual void   Hide();
+   Bool_t         IsGlobal() const  override { return fGlobal; }
+   void           Hide() override;
    virtual void   GlobalClosed();
    virtual void   SetCanvas(TCanvas *c);
-   virtual void   SetGlobal(Bool_t global);
+   void           SetGlobal(Bool_t global) override;
    virtual void   GlobalSetModel(TVirtualPad *, TObject *, Int_t);
    virtual void   SetModel(TVirtualPad* pad, TObject* obj, Int_t event, Bool_t force=kFALSE);
-   virtual void   Show();
-   virtual void   RecursiveRemove(TObject* obj);
+   void           Show() override;
+   void           RecursiveRemove(TObject* obj) override;
 
    static TGedEditor* GetFrameCreator();
    static void SetFrameCreator(TGedEditor* e);
 
-   ClassDef(TGedEditor,0)  // ROOT graphics editor
+   ClassDefOverride(TGedEditor,0)  // ROOT graphics editor
 };
 
 #endif

--- a/gui/gui/inc/TG3DLine.h
+++ b/gui/gui/inc/TG3DLine.h
@@ -18,30 +18,30 @@
 class TGHorizontal3DLine : public TGFrame {
 
 public:
-   TGHorizontal3DLine(const TGWindow *p = 0, UInt_t w = 4, UInt_t h = 2,
+   TGHorizontal3DLine(const TGWindow *p = nullptr, UInt_t w = 4, UInt_t h = 2,
                       UInt_t options = kChildFrame,
                       Pixel_t back = GetDefaultFrameBackground());
 
-   virtual void DrawBorder();
+   void DrawBorder() override;
 
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGHorizontal3DLine,0)  //A horizontal 3D separator line
+   ClassDefOverride(TGHorizontal3DLine,0)  //A horizontal 3D separator line
 };
 
 
 class TGVertical3DLine : public TGFrame {
 
 public:
-   TGVertical3DLine(const TGWindow *p = 0, UInt_t w = 2, UInt_t h = 4,
+   TGVertical3DLine(const TGWindow *p = nullptr, UInt_t w = 2, UInt_t h = 4,
                     UInt_t options = kChildFrame,
                     Pixel_t back = GetDefaultFrameBackground());
 
-   virtual void DrawBorder();
+   void DrawBorder() override;
 
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGVertical3DLine,0)  //A vertical 3D separator line
+   ClassDefOverride(TGVertical3DLine,0)  //A vertical 3D separator line
 };
 
 #endif

--- a/gui/gui/inc/TGApplication.h
+++ b/gui/gui/inc/TGApplication.h
@@ -25,8 +25,8 @@ private:
    TGClient      *fClient{nullptr};   ///< pointer to the client environment
 
 protected:
-   TGApplication() : TApplication() { }
-   virtual void LoadGraphicsLibs();
+   TGApplication() : TApplication() {}
+   void LoadGraphicsLibs() override;
 
 public:
    TGApplication(const char *appClassName,
@@ -34,9 +34,9 @@ public:
                  void *options = nullptr, Int_t numOptions = 0);
    virtual ~TGApplication();
 
-   virtual void GetOptions(Int_t *argc, char **argv);
+   void GetOptions(Int_t *argc, char **argv) override;
 
-   ClassDef(TGApplication,0)  //GUI application singleton
+   ClassDefOverride(TGApplication,0)  //GUI application singleton
 };
 
 #endif

--- a/gui/gui/inc/TGButton.h
+++ b/gui/gui/inc/TGButton.h
@@ -82,7 +82,7 @@ protected:
    Pixel_t        fHighColor;   ///< highlight color
    UInt_t         fStyle;       ///< button style (modern or classic)
 
-   virtual void   SetToggleButton(Bool_t) { }
+   virtual void   SetToggleButton(Bool_t) {}
    virtual void   EmitSignals(Bool_t wasUp);
 
    static const TGGC *fgDefaultGC;
@@ -102,8 +102,8 @@ public:
             UInt_t option = kRaisedFrame | kDoubleBorder);
    virtual ~TGButton();
 
-   virtual Bool_t       HandleButton(Event_t *event);
-   virtual Bool_t       HandleCrossing(Event_t *event);
+   Bool_t               HandleButton(Event_t *event) override;
+   Bool_t               HandleCrossing(Event_t *event) override;
    virtual void         SetUserData(void *userData) { fUserData = userData; }
    virtual void        *GetUserData() const { return fUserData; }
    virtual void         SetToolTipText(const char *text, Long_t delayms = 400);  //*MENU*
@@ -126,16 +126,16 @@ public:
    virtual void         SetStyle(UInt_t newstyle);
    virtual void         SetStyle(const char *style);
 
-   virtual void         SavePrimitive(std::ostream &out, Option_t *option = "");
+   void                 SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   GContext_t GetNormGC() const { return fNormGC; }
+   GContext_t           GetNormGC() const { return fNormGC; }
 
    virtual void Pressed()  { Emit("Pressed()"); }   // *SIGNAL*
    virtual void Released() { Emit("Released()"); }  // *SIGNAL*
    virtual void Clicked()  { Emit("Clicked()"); }   // *SIGNAL*
    virtual void Toggled(Bool_t on) { Emit("Toggled(Bool_t)", on); }  // *SIGNAL*
 
-   ClassDef(TGButton,0)  // Button widget abstract base class
+   ClassDefOverride(TGButton,0)  // Button widget abstract base class
 };
 
 
@@ -154,12 +154,12 @@ protected:
    FontStruct_t   fFontStruct;    // font to draw text
    Bool_t         fHasOwnFont;    // kTRUE - font defined locally,  kFALSE - globally
    Bool_t         fStateOn;       // bit to save the state across disable/enable
-   Bool_t         fPrevStateOn;   // bit to save previos state On/Off
+   Bool_t         fPrevStateOn;   // bit to save previous state On/Off
 
    static const TGFont *fgDefaultFont;
 
    void Init();
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
 private:
    TGTextButton(const TGTextButton&) = delete;
@@ -172,7 +172,7 @@ public:
                 GContext_t norm = GetDefaultGC()(),
                 FontStruct_t font = GetDefaultFontStruct(),
                 UInt_t option = kRaisedFrame | kDoubleBorder);
-   TGTextButton(const TGWindow *p = 0, const char *s = 0, Int_t id = -1,
+   TGTextButton(const TGWindow *p = nullptr, const char *s = nullptr, Int_t id = -1,
                 GContext_t norm = GetDefaultGC()(),
                 FontStruct_t font = GetDefaultFontStruct(),
                 UInt_t option = kRaisedFrame | kDoubleBorder);
@@ -183,11 +183,11 @@ public:
 
    virtual ~TGTextButton();
 
-   virtual TGDimension GetDefaultSize() const;
+   TGDimension        GetDefaultSize() const override;
 
-   virtual Bool_t     HandleKey(Event_t *event);
+   Bool_t             HandleKey(Event_t *event) override;
    const TGHotString *GetText() const { return fLabel; }
-   virtual const char *GetTitle() const { return fLabel->Data(); }
+   const char        *GetTitle() const override { return fLabel->Data(); }
    TString            GetString() const { return TString(fLabel->GetString()); }
    virtual void       SetTextJustify(Int_t tmode);
    Int_t GetTextJustify() const { return fTMode; }
@@ -197,7 +197,7 @@ public:
    virtual void       SetFont(FontStruct_t font, Bool_t global = kFALSE);
    virtual void       SetFont(const char *fontName, Bool_t global = kFALSE);
    virtual void       SetTextColor(Pixel_t color, Bool_t global = kFALSE);
-   virtual void       SetForegroundColor(Pixel_t fore) { SetTextColor(fore); }
+   void               SetForegroundColor(Pixel_t fore) override { SetTextColor(fore); }
    Bool_t             HasOwnFont() const;
    void               SetWrapLength(Int_t wl) { fWrapLength = wl; Layout(); }
    Int_t              GetWrapLength() const { return fWrapLength; }
@@ -216,12 +216,12 @@ public:
 
    void               ChangeText(const char *title)  { SetTitle(title); } //*MENU*icon=bld_rename.png*
 
-   FontStruct_t GetFontStruct() const { return fFontStruct; }
+   FontStruct_t       GetFontStruct() const { return fFontStruct; }
 
-   virtual void       Layout();
-   virtual void       SavePrimitive(std::ostream &out, Option_t *option = "");
+   void               Layout() override;
+   void               SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGTextButton,0)  // A text button widget
+   ClassDefOverride(TGTextButton,0)  // A text button widget
 };
 
 
@@ -232,7 +232,7 @@ protected:
    const TGPicture   *fPicD;           ///< picture shown when button disabled
    Bool_t             fOwnDisabledPic; ///< kTRUE if disabled picture was autogenerated
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
    virtual void CreateDisabledPicture();
 
 private:
@@ -246,7 +246,7 @@ public:
    TGPictureButton(const TGWindow *p, const TGPicture *pic, const char *cmd,
                    Int_t id = -1, GContext_t norm = GetDefaultGC()(),
                    UInt_t option = kRaisedFrame | kDoubleBorder);
-   TGPictureButton(const TGWindow *p = nullptr, const char* pic = 0, Int_t id = -1,
+   TGPictureButton(const TGWindow *p = nullptr, const char* pic = nullptr, Int_t id = -1,
                    GContext_t norm = GetDefaultGC()(),
                    UInt_t option = kRaisedFrame | kDoubleBorder);
    virtual ~TGPictureButton();
@@ -255,9 +255,9 @@ public:
    virtual void     SetDisabledPicture(const TGPicture *pic);
    const TGPicture *GetPicture() const { return fPic; };
    const TGPicture *GetDisabledPicture() const { return fPicD; };
-   virtual void     SavePrimitive(std::ostream &out, Option_t *option = "");
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGPictureButton,0)  // A picture button widget
+   ClassDefOverride(TGPictureButton,0)  // A picture button widget
 };
 
 
@@ -275,11 +275,10 @@ protected:
    const TGPicture   *fDisOn;         ///< button disabled and was ON picture
    const TGPicture   *fDisOff;        ///< button disabled and was OFF picture
 
-
    void Init();
    void PSetState(EButtonState state, Bool_t emit);
-   virtual void DoRedraw();
-   virtual void EmitSignals(Bool_t wasUp = kTRUE);
+   void DoRedraw() override;
+   void EmitSignals(Bool_t wasUp = kTRUE) override;
 
    static const TGFont *fgDefaultFont;
    static const TGGC   *fgDefaultGC;
@@ -292,7 +291,7 @@ public:
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
-   TGCheckButton(const TGWindow *p = 0, const char *s = 0, Int_t id = -1,
+   TGCheckButton(const TGWindow *p = nullptr, const char *s = nullptr, Int_t id = -1,
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
@@ -302,20 +301,20 @@ public:
                  UInt_t option = 0);
    virtual ~TGCheckButton();
 
-   virtual TGDimension GetDefaultSize() const;
+   TGDimension    GetDefaultSize() const override;
 
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual Bool_t HandleCrossing(Event_t *event);
-   virtual Bool_t IsToggleButton() const { return kTRUE; }
-   virtual Bool_t IsOn() const { return fState == kButtonDown; }
-   virtual Bool_t IsDown() const { return fState == kButtonDown; }
+   Bool_t         HandleButton(Event_t *event) override;
+   Bool_t         HandleKey(Event_t *event) override;
+   Bool_t         HandleCrossing(Event_t *event) override;
+   Bool_t         IsToggleButton() const override { return kTRUE; }
+   Bool_t         IsOn() const override { return fState == kButtonDown; }
+   Bool_t         IsDown() const override { return fState == kButtonDown; }
    virtual Bool_t IsDisabledAndSelected() const { return ((fState == kButtonDisabled) && fStateOn); }
    virtual void   SetDisabledAndSelected(Bool_t);
-   virtual void   SetState(EButtonState state, Bool_t emit = kFALSE);
-   virtual void   SavePrimitive(std::ostream &out, Option_t *option = "");
+   void           SetState(EButtonState state, Bool_t emit = kFALSE) override;
+   void           SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGCheckButton,0)  // A check button widget
+   ClassDefOverride(TGCheckButton,0)  // A check button widget
 };
 
 
@@ -334,8 +333,8 @@ protected:
 
    void Init();
    void PSetState(EButtonState state, Bool_t emit);
-   virtual void DoRedraw();
-   virtual void EmitSignals(Bool_t wasUp = kTRUE);
+   void DoRedraw() override;
+   void EmitSignals(Bool_t wasUp = kTRUE) override;
 
    static const TGFont *fgDefaultFont;
    static const TGGC   *fgDefaultGC;
@@ -348,7 +347,7 @@ public:
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
-   TGRadioButton(const TGWindow *p = 0, const char *s = 0, Int_t id = -1,
+   TGRadioButton(const TGWindow *p = nullptr, const char *s = nullptr, Int_t id = -1,
                  GContext_t norm = GetDefaultGC()(),
                  FontStruct_t font = GetDefaultFontStruct(),
                  UInt_t option = 0);
@@ -358,21 +357,21 @@ public:
                  UInt_t option = 0);
    virtual ~TGRadioButton();
 
-   virtual TGDimension GetDefaultSize() const;
+   TGDimension    GetDefaultSize() const override;
 
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual Bool_t HandleCrossing(Event_t *event);
-   virtual void   SetState(EButtonState state, Bool_t emit = kFALSE);
+   Bool_t         HandleButton(Event_t *event) override;
+   Bool_t         HandleKey(Event_t *event) override;
+   Bool_t         HandleCrossing(Event_t *event) override;
+   void           SetState(EButtonState state, Bool_t emit = kFALSE) override;
    virtual void   SetDisabledAndSelected(Bool_t);
-   virtual Bool_t IsToggleButton() const { return kTRUE; }
-   virtual Bool_t IsExclusiveToggle() const { return kTRUE; }
-   virtual Bool_t IsOn() const { return fStateOn; }
-   virtual Bool_t IsDown() const { return fStateOn; }
+   Bool_t         IsToggleButton() const override { return kTRUE; }
+   Bool_t         IsExclusiveToggle() const override { return kTRUE; }
+   Bool_t         IsOn() const override { return fStateOn; }
+   Bool_t         IsDown() const override { return fStateOn; }
    virtual Bool_t IsDisabledAndSelected() const { return ((fState == kButtonDisabled) && fStateOn); }
-   virtual void   SavePrimitive(std::ostream &out, Option_t *option = "");
+   void           SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGRadioButton,0)  // A radio button widget
+   ClassDefOverride(TGRadioButton,0)  // A radio button widget
 };
 
 
@@ -407,7 +406,7 @@ protected:
    TGString     fHeighestLabel; ///< highest label that can be on the button
 ///@]
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
    void Init();
    void BindKeys(Bool_t on = kTRUE);
    void BindMenuKeys(Bool_t on = kTRUE);
@@ -421,20 +420,20 @@ public:
 
    virtual ~TGSplitButton();
 
-   virtual TGDimension GetDefaultSize() const ;
+   TGDimension  GetDefaultSize() const override;
 
-   virtual void   SetText(TGHotString *new_label);
-   virtual void   SetText(const TString &new_label);
-   virtual void   SetFont(FontStruct_t font, Bool_t global = kFALSE);
-   virtual void   SetFont(const char *fontName, Bool_t global = kFALSE);
-   virtual void   SetMBState(EButtonState state);
-   virtual void   SetSplit(Bool_t split);
-   Bool_t         IsSplit() { return fSplit; }
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t HandleCrossing(Event_t *event);
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual Bool_t HandleMotion(Event_t *event);
-   virtual void   Layout();
+   void         SetText(TGHotString *new_label) override;
+   void         SetText(const TString &new_label) override;
+   void         SetFont(FontStruct_t font, Bool_t global = kFALSE) override;
+   void         SetFont(const char *fontName, Bool_t global = kFALSE) override;
+   virtual void SetMBState(EButtonState state);
+   virtual void SetSplit(Bool_t split);
+   Bool_t       IsSplit() { return fSplit; }
+   Bool_t       HandleButton(Event_t *event) override;
+   Bool_t       HandleCrossing(Event_t *event) override;
+   Bool_t       HandleKey(Event_t *event) override;
+   Bool_t       HandleMotion(Event_t *event) override;
+   void         Layout() override;
 
    virtual void MBPressed()  { Emit("MBPressed()"); }   // *SIGNAL*
    virtual void MBReleased() { Emit("MBReleased()"); }  // *SIGNAL*
@@ -442,9 +441,9 @@ public:
    virtual void ItemClicked(Int_t id) { Emit("ItemClicked(Int_t)", id); } // *SIGNAL*
 
    // Slots
-   void HandleMenu(Int_t id) ;
+   void HandleMenu(Int_t id);
 
-   ClassDef(TGSplitButton, 0) //a split button widget
+   ClassDefOverride(TGSplitButton,0) //a split button widget
 };
 
 #endif

--- a/gui/gui/inc/TGButtonGroup.h
+++ b/gui/gui/inc/TGButtonGroup.h
@@ -34,10 +34,10 @@ protected:
    TMap   *fMapOfButtons;    ///< map of button/id pairs in this group
 
    void Init();
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
 public:
-   TGButtonGroup(const TGWindow *parent = 0,
+   TGButtonGroup(const TGWindow *parent = nullptr,
                  const TString &title = "",
                  UInt_t options = kChildFrame | kVerticalFrame,
                  GContext_t norm = GetDefaultGC()(),
@@ -74,8 +74,8 @@ public:
    virtual void SetState(Bool_t state = kTRUE);
    virtual void SetBorderDrawn(Bool_t enable = kTRUE);
    virtual void SetButton(Int_t id, Bool_t down = kTRUE);
-   virtual void SetTitle(TGString *title);
-   virtual void SetTitle(const char *title);
+   void         SetTitle(TGString *title) override;
+   void         SetTitle(const char *title) override;
 
    virtual Int_t     Insert(TGButton *button, int id = -1);
    virtual void      Remove(TGButton *button);
@@ -83,11 +83,11 @@ public:
    virtual TGButton *GetButton(Int_t id) const { return Find(id); }
    virtual void      Show();
    virtual void      Hide();
-   virtual void      DrawBorder();
-   virtual void      SetLayoutHints(TGLayoutHints *l, TGButton *button = 0);
-   virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
+   void              DrawBorder() override;
+   virtual void      SetLayoutHints(TGLayoutHints *l, TGButton *button = nullptr);
+   void              SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGButtonGroup,0)  // Organizes TGButtons in a group
+   ClassDefOverride(TGButtonGroup,0)  // Organizes TGButtons in a group
 };
 
 
@@ -100,12 +100,12 @@ public:
                   FontStruct_t font = GetDefaultFontStruct(),
                   Pixel_t back = GetDefaultFrameBackground()) :
       TGButtonGroup(parent, title, kChildFrame | kVerticalFrame,
-                    norm, font, back) { }
+                    norm, font, back) {}
 
-   virtual ~TGVButtonGroup() { }
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   virtual ~TGVButtonGroup() {}
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGVButtonGroup,0)  // A button group with one vertical column
+   ClassDefOverride(TGVButtonGroup,0)  // A button group with one vertical column
 };
 
 
@@ -120,10 +120,10 @@ public:
       TGButtonGroup(parent, title, kChildFrame | kHorizontalFrame,
                     norm, font, back) { }
 
-   virtual ~TGHButtonGroup() { }
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   virtual ~TGHButtonGroup() {}
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGHButtonGroup,0)  // A button group with one horizontal row
+   ClassDefOverride(TGHButtonGroup,0)  // A button group with one horizontal row
 };
 
 #endif

--- a/gui/gui/inc/TGCanvas.h
+++ b/gui/gui/inc/TGCanvas.h
@@ -64,7 +64,7 @@ protected:
    static TGGC       *fgLineGC;
    static const TGGC &GetLineGC();
 
-   virtual void DoRedraw();
+   void         DoRedraw() override;
    virtual void ActivateItem(TGFrameElement* el);
    virtual void DeActivateItem(TGFrameElement* el);
    virtual void SearchPattern();
@@ -92,9 +92,9 @@ public:
    virtual void SetPagePosition(Int_t x, Int_t y);
    virtual void SetPageDimension(const TGDimension& dim);
    virtual void SetPageDimension(UInt_t w, UInt_t h);
-   virtual void RemoveAll();
+   void         RemoveAll() override;
    virtual void RemoveItem(TGFrame *item);
-   virtual void Layout();
+   void         Layout() override;
 
    TGCanvas         *GetCanvas() const { return fCanvas; }
    const TGWindow   *GetMessageWindow() const { return fMsgWindow; }
@@ -103,7 +103,7 @@ public:
 
    virtual Int_t  NumSelected() const { return fSelected; }
    virtual Int_t  NumItems() const { return fTotal; }
-   virtual TGFrameElement *FindFrame(Int_t x,Int_t y,Bool_t exclude=kTRUE);
+   virtual TGFrameElement *FindFrame(Int_t x,Int_t y, Bool_t exclude=kTRUE);
    virtual TGFrame        *FindFrameByName(const char *name);
    virtual TGHScrollBar *GetHScrollbar() const;
    virtual TGVScrollBar *GetVScrollbar() const;
@@ -124,15 +124,15 @@ public:
                           Bool_t subString = kFALSE);
 
    virtual const TGFrame *GetNextSelected(void **current);
-   virtual TGFrame *GetLastActive() const { return fLastActiveEl ? fLastActiveEl->fFrame : 0; }
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   virtual TGFrame *GetLastActive() const { return fLastActiveEl ? fLastActiveEl->fFrame : nullptr; }
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   virtual Bool_t HandleDNDFinished() { fBdown = kFALSE; return kTRUE; }
-   virtual Bool_t HandleExpose(Event_t *event);
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t HandleDoubleClick(Event_t *event);
-   virtual Bool_t HandleMotion(Event_t *event);
-   virtual Bool_t HandleKey(Event_t *event);
+   Bool_t HandleDNDFinished() override { fBdown = kFALSE; return kTRUE; }
+   Bool_t HandleExpose(Event_t *event) override;
+   Bool_t HandleButton(Event_t *event) override;
+   Bool_t HandleDoubleClick(Event_t *event) override;
+   Bool_t HandleMotion(Event_t *event) override;
+   Bool_t HandleKey(Event_t *event) override;
 
    const TGPicture *GetObjPicture(TGFrame *f);
    virtual void SetDragPixmap(const TGPicture *pic);
@@ -151,7 +151,7 @@ public:
    virtual void DoubleClicked(TGFrame *f, Int_t btn, Int_t x, Int_t y); //*SIGNAL*
    virtual void Clicked(TGFrame *f, Int_t btn, Int_t x, Int_t y);       //*SIGNAL*
 
-   ClassDef(TGContainer,0)  // Canvas container
+   ClassDefOverride(TGContainer,0)  // Canvas container
 };
 
 
@@ -173,9 +173,9 @@ public:
    TGFrame *GetContainer() const { return fContainer; }
    void SetContainer(TGFrame *f);
 
-   virtual void DrawBorder() { };
-   virtual void Layout() { }
-   virtual TGDimension GetDefaultSize() const { return TGDimension(fWidth, fHeight); }
+   void DrawBorder() override {}
+   void Layout() override {}
+   TGDimension GetDefaultSize() const override { return TGDimension(fWidth, fHeight); }
 
    virtual void SetHPos(Int_t xpos);
    virtual void SetVPos(Int_t ypos);
@@ -183,9 +183,9 @@ public:
 
    Int_t GetHPos() const { return fX0; }
    Int_t GetVPos() const { return fY0; }
-   virtual Bool_t HandleConfigureNotify(Event_t *event);
+   Bool_t HandleConfigureNotify(Event_t *event) override;
 
-   ClassDef(TGViewPort,0)  // Viewport through which to look at a container frame
+   ClassDefOverride(TGViewPort,0)  // Viewport through which to look at a container frame
 };
 
 
@@ -220,9 +220,9 @@ public:
 
    virtual void  AddFrame(TGFrame *f, TGLayoutHints *l = 0);
    virtual void  SetContainer(TGFrame *f) { fVport->SetContainer(f); }
-   virtual void  MapSubwindows();
-   virtual void  DrawBorder();
-   virtual void  Layout();
+   void          MapSubwindows() override;
+   void          DrawBorder() override;
+   void          Layout() override;
    virtual void  ClearViewPort();
    virtual Int_t GetHsbPosition() const;
    virtual Int_t GetVsbPosition() const;
@@ -231,12 +231,12 @@ public:
    void          SetScrolling(Int_t scrolling);
    Int_t         GetScrolling() const { return fScrolling; }
 
-   virtual TGDimension GetDefaultSize() const { return TGDimension(fWidth, fHeight); }
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   TGDimension GetDefaultSize() const override { return TGDimension(fWidth, fHeight); }
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGCanvas,0)  // A canvas with two scrollbars and a viewport
+   ClassDefOverride(TGCanvas,0)  // A canvas with two scrollbars and a viewport
 };
 
 

--- a/gui/gui/inc/TGClient.h
+++ b/gui/gui/inc/TGClient.h
@@ -150,7 +150,7 @@ public:
 
    static TGClient *Instance();
 
-   ClassDef(TGClient,0)  // Class making connection to display server
+   ClassDefOverride(TGClient,0)  // Class making connection to display server
 };
 
 #ifndef __CINT__

--- a/gui/gui/inc/TGFont.h
+++ b/gui/gui/inc/TGFont.h
@@ -118,7 +118,7 @@ protected:
    void operator=(const TGTextLayout &tlayout) = delete;
 
 public:
-   TGTextLayout(): fFont(nullptr), fString(""), fWidth(0), fNumChunks(0), fChunks(NULL) {}
+   TGTextLayout(): fFont(nullptr), fString(""), fWidth(0), fNumChunks(0), fChunks(nullptr) {}
    virtual ~TGTextLayout();
 
    void   DrawText(Drawable_t dst, GContext_t gc, Int_t x, Int_t y,
@@ -131,7 +131,7 @@ public:
    Int_t  IntersectText(Int_t x, Int_t y, Int_t w, Int_t h) const;
    void   ToPostscript(TString *dst) const;
 
-   ClassDef(TGTextLayout,0)   // Keep track of string  measurement information.
+   ClassDefOverride(TGTextLayout,0)   // Keep track of string  measurement information.
 };
 
 
@@ -162,7 +162,7 @@ private:
 protected:
    TGFont(const char *name)
      : TNamed(name,""), TRefCnt(), fFontStruct(0), fFontH(0), fFM(),
-     fFA(), fNamedHash(0), fTabWidth(0), fUnderlinePos(0), fUnderlineHeight(0), fBarHeight(0)
+        fFA(), fNamedHash(nullptr), fTabWidth(0), fUnderlinePos(0), fUnderlineHeight(0), fBarHeight(0)
    {
       SetRefCount(1);
       for (Int_t i=0; i<256; i++) {
@@ -203,10 +203,10 @@ public:
    void   DrawChars(Drawable_t dst, GContext_t gc, const char *source,
                    Int_t numChars, Int_t x, Int_t y) const;
 
-   void  Print(Option_t *option="") const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Print(Option_t *option="") const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGFont,0)   // GUI font description
+   ClassDefOverride(TGFont,0)   // GUI font description
 };
 
 
@@ -255,9 +255,9 @@ public:
    Bool_t   ParseFontName(const char *string, FontAttributes_t *fa);
    const char *NameOfFont(TGFont *font);
 
-   void     Print(Option_t *option="") const;
+   void     Print(Option_t *option="") const override;
 
-   ClassDef(TGFontPool,0)  // Font pool
+   ClassDefOverride(TGFontPool,0)  // Font pool
 };
 
 #endif

--- a/gui/gui/inc/TGFrame.h
+++ b/gui/gui/inc/TGFrame.h
@@ -115,10 +115,10 @@ protected:
 
    static Time_t      GetLastClick();
 
-   virtual void  *GetSender() { return this; }  //used to set gTQSender
+   void  *GetSender() override { return this; }  //used to set gTQSender
    virtual void   Draw3dRectangle(UInt_t type, Int_t x, Int_t y,
                                   UInt_t w, UInt_t h);
-   virtual void   DoRedraw();
+   void   DoRedraw() override;
 
    const TGResourcePool *GetResourcePool() const
       { return fClient->GetResourcePool(); }
@@ -156,7 +156,7 @@ public:
    void   AddInput(UInt_t emask);
    void   RemoveInput(UInt_t emask);
 
-   virtual Bool_t HandleEvent(Event_t *event);
+           Bool_t HandleEvent(Event_t *event) override;
    virtual Bool_t HandleConfigureNotify(Event_t *event);
    virtual Bool_t HandleButton(Event_t *) { return kFALSE; }
    virtual Bool_t HandleDoubleClick(Event_t *) { return kFALSE; }
@@ -183,35 +183,35 @@ public:
    virtual Bool_t ProcessMessage(Longptr_t, Longptr_t, Longptr_t) { return kFALSE; }
 
    virtual TGDimension GetDefaultSize() const ;
-   virtual void    Move(Int_t x, Int_t y);
-   virtual void    Resize(UInt_t w = 0, UInt_t h = 0);
+           void    Move(Int_t x, Int_t y) override;
+           void    Resize(UInt_t w = 0, UInt_t h = 0) override;
    virtual void    Resize(TGDimension size);
-   virtual void    MoveResize(Int_t x, Int_t y, UInt_t w = 0, UInt_t h = 0);
+           void    MoveResize(Int_t x, Int_t y, UInt_t w = 0, UInt_t h = 0) override;
    virtual UInt_t  GetDefaultWidth() const { return GetDefaultSize().fWidth; }
    virtual UInt_t  GetDefaultHeight() const { return GetDefaultSize().fHeight; }
    virtual Pixel_t GetBackground() const { return fBackground; }
    virtual void    ChangeBackground(Pixel_t back);
-   virtual void    SetBackgroundColor(Pixel_t back);
+           void    SetBackgroundColor(Pixel_t back) override;
    virtual Pixel_t GetForeground() const;
    virtual void    SetForegroundColor(Pixel_t /*fore*/) { }
    virtual UInt_t  GetOptions() const { return fOptions; }
    virtual void    ChangeOptions(UInt_t options);
    virtual void    Layout() { }
-   virtual void    MapSubwindows() { }  // Simple frames do not have subwindows
+           void    MapSubwindows() override {}  // Simple frames do not have subwindows
                                         // Redefine this in TGCompositeFrame!
-   virtual void    ReparentWindow(const TGWindow *p, Int_t x = 0, Int_t y = 0)
+           void    ReparentWindow(const TGWindow *p, Int_t x = 0, Int_t y = 0) override
                      { TGWindow::ReparentWindow(p, x, y); Move(x, y); }
-   virtual void    MapWindow() { TGWindow::MapWindow(); if (fFE) fFE->fState |= kIsVisible; }
-   virtual void    MapRaised() { TGWindow::MapRaised(); if (fFE) fFE->fState |= kIsVisible; }
-   virtual void    UnmapWindow() { TGWindow::UnmapWindow(); if (fFE) fFE->fState &= ~kIsVisible; }
+           void    MapWindow() override { TGWindow::MapWindow(); if (fFE) fFE->fState |= kIsVisible; }
+           void    MapRaised() override { TGWindow::MapRaised(); if (fFE) fFE->fState |= kIsVisible; }
+           void    UnmapWindow() override { TGWindow::UnmapWindow(); if (fFE) fFE->fState &= ~kIsVisible; }
 
    virtual void    DrawBorder();
    virtual void    DrawCopy(Handle_t /*id*/, Int_t /*x*/, Int_t /*y*/) { }
    virtual void    Activate(Bool_t) { }
    virtual Bool_t  IsActive() const { return kFALSE; }
    virtual Bool_t  IsComposite() const { return kFALSE; }
-   virtual Bool_t  IsEditable() const { return kFALSE; }
-   virtual void    SetEditable(Bool_t) {}
+           Bool_t  IsEditable() const override { return kFALSE; }
+           void    SetEditable(Bool_t) override {}
    virtual void    SetLayoutBroken(Bool_t = kTRUE) {}
    virtual Bool_t  IsLayoutBroken() const { return kFALSE; }
    virtual void    SetCleanup(Int_t = kLocalCleanup) { /* backward compatibility */ }
@@ -238,7 +238,7 @@ public:
    Bool_t Contains(Int_t x, Int_t y) const
       { return ((x >= 0) && (x < (Int_t)fWidth) && (y >= 0) && (y < (Int_t)fHeight)); }
    virtual TGFrame *GetFrameFromPoint(Int_t x, Int_t y)
-      { return (Contains(x, y) ? this : 0); }
+      { return Contains(x, y) ? this : nullptr; }
 
    // Modifiers (without graphic update)
    virtual void SetX(Int_t x) { fX = x; }
@@ -252,17 +252,17 @@ public:
    virtual void SetSize(const TGDimension &s) { fWidth = s.fWidth; fHeight = s.fHeight; }
 
    // Printing and saving
-   virtual void Print(Option_t *option="") const;
+   void Print(Option_t *option="") const override;
    void SaveUserColor(std::ostream &out, Option_t *);
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    // dummy to remove from context menu
-   virtual void        Delete(Option_t * /*option*/ ="") { }
-   virtual TObject    *DrawClone(Option_t * /*option */="") const { return 0; }
-   virtual void        DrawClass() const { }
-   virtual void        Dump() const { }
-   virtual void        Inspect() const { }
-   virtual void        SetDrawOption(Option_t * /*option*/="") { }
+   void        Delete(Option_t * /*option*/ ="") override {}
+   TObject    *DrawClone(Option_t * /*option */="") const override { return nullptr; }
+   void        DrawClass() const override {}
+   void        Dump() const override {}
+   void        Inspect() const override {}
+   void        SetDrawOption(Option_t * /*option*/="") override {}
 
    // drag and drop...
    void                SetDNDSource(Bool_t onoff)
@@ -280,7 +280,7 @@ public:
    virtual Bool_t      HandleDNDLeave() { return kFALSE; }
    virtual Bool_t      HandleDNDFinished() { return kFALSE; }
 
-   ClassDef(TGFrame,0)  // Base class for simple widgets (button, etc.)
+   ClassDefOverride(TGFrame,0)  // Base class for simple widgets (button, etc.)
 };
 
 
@@ -309,31 +309,31 @@ public:
 
    virtual TList *GetList() const { return fList; }
 
-   virtual UInt_t GetDefaultWidth() const
+   UInt_t GetDefaultWidth() const override
                      { return GetDefaultSize().fWidth; }
-   virtual UInt_t GetDefaultHeight() const
+   UInt_t GetDefaultHeight() const override
                      { return GetDefaultSize().fHeight; }
-   virtual TGDimension GetDefaultSize() const
+   TGDimension GetDefaultSize() const override
                      { return (IsLayoutBroken() ? TGDimension(fWidth, fHeight) :
                                fLayoutManager->GetDefaultSize()); }
-   virtual TGFrame *GetFrameFromPoint(Int_t x, Int_t y);
+   TGFrame *GetFrameFromPoint(Int_t x, Int_t y) override;
    virtual Bool_t TranslateCoordinates(TGFrame *child, Int_t x, Int_t y,
                                        Int_t &fx, Int_t &fy);
-   virtual void   MapSubwindows();
-   virtual void   Layout();
-   virtual Bool_t HandleButton(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleDoubleClick(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleCrossing(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleMotion(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleKey(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleFocusChange(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleSelection(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleDragEnter(TGFrame *);
-   virtual Bool_t HandleDragLeave(TGFrame *);
-   virtual Bool_t HandleDragMotion(TGFrame *);
-   virtual Bool_t HandleDragDrop(TGFrame *frame, Int_t x, Int_t y, TGLayoutHints *lo);
-   virtual void   ChangeOptions(UInt_t options);
-   virtual Bool_t ProcessMessage(Longptr_t, Longptr_t, Longptr_t) { return kFALSE; }
+   void   MapSubwindows() override;
+   void   Layout() override;
+   Bool_t HandleButton(Event_t *) override { return kFALSE; }
+   Bool_t HandleDoubleClick(Event_t *) override { return kFALSE; }
+   Bool_t HandleCrossing(Event_t *) override { return kFALSE; }
+   Bool_t HandleMotion(Event_t *) override { return kFALSE; }
+   Bool_t HandleKey(Event_t *) override { return kFALSE; }
+   Bool_t HandleFocusChange(Event_t *) override { return kFALSE; }
+   Bool_t HandleSelection(Event_t *) override { return kFALSE; }
+   Bool_t HandleDragEnter(TGFrame *) override;
+   Bool_t HandleDragLeave(TGFrame *) override;
+   Bool_t HandleDragMotion(TGFrame *) override;
+   Bool_t HandleDragDrop(TGFrame *frame, Int_t x, Int_t y, TGLayoutHints *lo) override;
+   void   ChangeOptions(UInt_t options) override;
+   Bool_t ProcessMessage(Longptr_t, Longptr_t, Longptr_t) override { return kFALSE; }
 
    virtual TGLayoutManager *GetLayoutManager() const { return fLayoutManager; }
    virtual void SetLayoutManager(TGLayoutManager *l);
@@ -350,25 +350,24 @@ public:
    Bool_t         IsVisible(TGFrameElement *ptr) const { return (ptr->fState & kIsVisible); }
    Bool_t         IsArranged(TGFrame *f) const;
    Bool_t         IsArranged(TGFrameElement *ptr) const { return (ptr->fState & kIsArranged); }
-   Bool_t         IsComposite() const { return kTRUE; }
-   virtual Bool_t IsEditable() const;
-   virtual void   SetEditable(Bool_t on = kTRUE);
-   virtual void   SetLayoutBroken(Bool_t on = kTRUE);
-   virtual Bool_t IsLayoutBroken() const
-                  { return fLayoutBroken || !fLayoutManager; }
-   virtual void   SetEditDisabled(UInt_t on = 1);
-   virtual void   SetCleanup(Int_t mode = kLocalCleanup);
-   virtual Int_t  MustCleanup() const { return fMustCleanup; }
+   Bool_t         IsComposite() const override { return kTRUE; }
+   Bool_t         IsEditable() const override;
+   void           SetEditable(Bool_t on = kTRUE) override;
+   void           SetLayoutBroken(Bool_t on = kTRUE) override;
+   Bool_t         IsLayoutBroken() const  override { return fLayoutBroken || !fLayoutManager; }
+   void           SetEditDisabled(UInt_t on = 1) override;
+   void           SetCleanup(Int_t mode = kLocalCleanup) override;
+   Int_t          MustCleanup() const override { return fMustCleanup; }
    virtual void   Cleanup();
-   virtual void   SetMapSubwindows(Bool_t on) {  fMapSubwindows = on; }
-   virtual Bool_t IsMapSubwindows() const { return fMapSubwindows; }
+   void           SetMapSubwindows(Bool_t on) override {  fMapSubwindows = on; }
+   Bool_t         IsMapSubwindows() const override { return fMapSubwindows; }
 
-   virtual void   Print(Option_t *option="") const;
+   void           Print(Option_t *option="") const override;
    virtual void   ChangeSubframesBackground(Pixel_t back);
-   virtual void   SavePrimitive(std::ostream &out, Option_t *option = "");
+   void           SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void   SavePrimitiveSubframes(std::ostream &out, Option_t *option = "");
 
-   ClassDef(TGCompositeFrame,0)  // Base class for composite widgets (menubars, etc.)
+   ClassDefOverride(TGCompositeFrame,0)  // Base class for composite widgets (menubars, etc.)
 };
 
 
@@ -378,9 +377,9 @@ public:
                    UInt_t options = kChildFrame,
                    Pixel_t back = GetDefaultFrameBackground()) :
       TGCompositeFrame(p, w, h, options | kVerticalFrame, back) { SetWindowName(); }
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGVerticalFrame,0)  // Composite frame with vertical child layout
+   ClassDefOverride(TGVerticalFrame,0)  // Composite frame with vertical child layout
 };
 
 class TGHorizontalFrame : public TGCompositeFrame {
@@ -389,9 +388,9 @@ public:
                      UInt_t options = kChildFrame,
                      Pixel_t back = GetDefaultFrameBackground()) :
       TGCompositeFrame(p, w, h, options | kHorizontalFrame, back) { SetWindowName(); }
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGHorizontalFrame,0)  // Composite frame with horizontal child layout
+   ClassDefOverride(TGHorizontalFrame,0)  // Composite frame with horizontal child layout
 };
 
 
@@ -446,19 +445,19 @@ public:
                UInt_t options = kVerticalFrame);
    virtual ~TGMainFrame();
 
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual Bool_t HandleClientMessage(Event_t *event);
-   virtual Bool_t HandleSelection(Event_t *event);
-   virtual Bool_t HandleSelectionRequest(Event_t *event);
-   virtual Bool_t HandleButton(Event_t *event);
-   virtual Bool_t HandleMotion(Event_t *event);
+   Bool_t HandleKey(Event_t *event) override;
+   Bool_t HandleClientMessage(Event_t *event) override;
+   Bool_t HandleSelection(Event_t *event) override;
+   Bool_t HandleSelectionRequest(Event_t *event) override;
+   Bool_t HandleButton(Event_t *event) override;
+   Bool_t HandleMotion(Event_t *event) override;
    virtual Bool_t SaveFrameAsCodeOrImage();
    virtual Bool_t SaveFrameAsCodeOrImage(const TString &fileName);
    virtual void   SendCloseMessage();
    virtual void   CloseWindow();   //*SIGNAL*
 
    void DontCallClose();
-   void SetWindowName(const char *name = 0);
+   void SetWindowName(const char *name = nullptr) override;
    void SetIconName(const char *name);
    const TGPicture *SetIconPixmap(const char *iconName);
    void SetIconPixmap(char **xpm_array);
@@ -475,7 +474,7 @@ public:
    TList *GetBindList() const { return fBindList; }
 
    const char *GetWindowName() const { return fWindowName; }
-   const char *GetIconName() const { return fIconName; }
+   const char *GetIconName() const override { return fIconName; }
    const char *GetIconPixmap() const { return fIconPixmap; }
    void GetClassHints(const char *&className, const char *&resourceName) const
       { className = fClassName.Data(); resourceName = fResourceName.Data(); }
@@ -489,10 +488,10 @@ public:
         hmax = fWMMaxHeight; winc = fWMWidthInc; hinc = fWMHeightInc; }
    EInitialState GetWMState() const { return fWMInitState; }
 
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
    virtual void SaveSource(const char *filename = "Rootappl.C", Option_t *option = ""); // *MENU*icon=bld_save.png*
 
-   ClassDef(TGMainFrame,0)  // Top level window frame
+   ClassDefOverride(TGMainFrame,0)  // Top level window frame
 };
 
 
@@ -513,10 +512,10 @@ public:
                      kBottomLeft, kBottomRight };
    virtual void    CenterOnParent(Bool_t croot = kTRUE, EPlacement pos = kCenter);
    const TGWindow *GetMain() const { return fMain; }
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void    SaveSource(const char *filename = "Rootdlog.C", Option_t *option = ""); // *MENU*icon=bld_save.png*
+   void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   void SaveSource(const char *filename = "Rootdlog.C", Option_t *option = "") override; // *MENU*icon=bld_save.png*
 
-   ClassDef(TGTransientFrame,0)  // Frame for dialog (transient) windows
+   ClassDefOverride(TGTransientFrame,0)  // Frame for dialog (transient) windows
 };
 
 
@@ -529,7 +528,7 @@ protected:
    Int_t          fTitlePos;     ///< *OPTION={GetMethod="GetTitlePos";SetMethod="SetTitlePos";Items=(-1="Left",0="Center",1="Right")}*
    Bool_t         fHasOwnFont;   ///< kTRUE - font defined locally,  kFALSE - globally
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
    static const TGFont *fgDefaultFont;
    static const TGGC   *fgDefaultGC;
@@ -556,8 +555,8 @@ public:
                 Pixel_t back = GetDefaultFrameBackground());
    virtual ~TGGroupFrame();
 
-   virtual TGDimension GetDefaultSize() const;
-   virtual void  DrawBorder();
+   TGDimension GetDefaultSize() const override;
+   void  DrawBorder() override;
    virtual void  SetTitle(TGString *title);
    virtual void  SetTitle(const char *title);
    virtual void  Rename(const char *title)  { SetTitle(title); } //*MENU*icon=bld_rename.png*
@@ -569,12 +568,12 @@ public:
    GContext_t GetNormGC() const { return fNormGC; }
    FontStruct_t GetFontStruct() const { return fFontStruct; }
 
-   virtual const char *GetTitle() const { return fText->GetString(); }
+   const char *GetTitle() const override { return fText->GetString(); }
    Bool_t HasOwnFont() const;
 
-   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void  SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGGroupFrame,0)  // A composite frame with border and title
+   ClassDefOverride(TGGroupFrame,0)  // A composite frame with border and title
 };
 
 
@@ -597,13 +596,13 @@ public:
                  UInt_t options = kChildFrame,
                  Pixel_t back = GetDefaultFrameBackground());
 
-   virtual Bool_t HandleButton(Event_t* event);
-   virtual Bool_t HandleMotion(Event_t* event);
-   virtual Bool_t HandleDoubleClick(Event_t *event);
+   Bool_t HandleButton(Event_t* event) override;
+   Bool_t HandleMotion(Event_t* event) override;
+   Bool_t HandleDoubleClick(Event_t *event) override;
 
    void SetColumnsInfo(Int_t nColumns, TGTextButton  **colHeader, TGVFileSplitter  **splitHeader);
 
-   ClassDef(TGHeaderFrame,0)  // Header frame with buttons and splitters
+   ClassDefOverride(TGHeaderFrame,0)  // Header frame with buttons and splitters
 };
 
 

--- a/gui/gui/inc/TGGC.h
+++ b/gui/gui/inc/TGGC.h
@@ -93,10 +93,10 @@ public:
    const char       *GetDashes() const { return fValues.fDashes; }
    Int_t             GetArcMode() const { return fValues.fArcMode; }
 
-   void Print(Option_t *option="") const;
-   void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void Print(Option_t *option="") const override;
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGGC,0)  // Graphics context
+   ClassDefOverride(TGGC,0)  // Graphics context
 };
 
 
@@ -114,8 +114,13 @@ private:
 protected:
    TGGCPool(const TGGCPool& gp) : TGObject(gp), fList(gp.fList) { }
    TGGCPool& operator=(const TGGCPool& gp)
-     {if(this!=&gp) {TGObject::operator=(gp); fList=gp.fList;}
-     return *this;}
+   {
+      if (this != &gp) {
+         TGObject::operator=(gp);
+         fList = gp.fList;
+      }
+      return *this;
+   }
 
 public:
    TGGCPool(TGClient *client);
@@ -129,9 +134,9 @@ public:
    TGGC *FindGC(const TGGC *gc);
    TGGC *FindGC(GContext_t gc);
 
-   void  Print(Option_t *option="") const;
+   void  Print(Option_t *option="") const override;
 
-   ClassDef(TGGCPool,0)  // Graphics context pool
+   ClassDefOverride(TGGCPool,0)  // Graphics context pool
 };
 
 #endif

--- a/gui/gui/inc/TGLayout.h
+++ b/gui/gui/inc/TGLayout.h
@@ -56,7 +56,7 @@ private:
    TGFrameElement *fFE;       // back pointer to the last frame element
    TGFrameElement *fPrev;     // previous element sharing this layout_hints
 
-   TGLayoutHints& operator=(const TGLayoutHints&);
+   TGLayoutHints& operator=(const TGLayoutHints&) = delete;
 
 protected:
    ULong_t  fLayoutHints;     // layout hints (combination of ELayoutHints)
@@ -71,7 +71,7 @@ public:
    TGLayoutHints(ULong_t hints = kLHintsNormal,
                  Int_t padleft = 0, Int_t padright = 0,
                  Int_t padtop = 0, Int_t padbottom = 0):
-     fFE(0), fPrev(0), fLayoutHints(hints), fPadtop(padtop), fPadbottom(padbottom),
+     fFE(nullptr), fPrev(nullptr), fLayoutHints(hints), fPadtop(padtop), fPadbottom(padbottom),
      fPadleft(padleft), fPadright(padright)
      { SetRefCount(0); }
 
@@ -91,12 +91,12 @@ public:
    virtual void SetPadLeft(Int_t v)  {  fPadleft = v; }
    virtual void SetPadRight(Int_t v)  {  fPadright = v; }
 
-   void Print(Option_t* option = "") const;
-   void ls(Option_t* option = "") const { Print(option); }
+   void Print(Option_t* option = "") const override;
+   void ls(Option_t* option = "") const override { Print(option); }
 
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGLayoutHints,0)  // Class describing GUI layout hints
+   ClassDefOverride(TGLayoutHints,0)  // Class describing GUI layout hints
 };
 
 // Temporarily public as we need to share this class definition
@@ -113,14 +113,14 @@ public:
    Int_t           fState;    // EFrameState defined in TGFrame.h
    TGLayoutHints  *fLayout;   // layout hints used in layout
 
-   TGFrameElement() : fFrame(0), fState(0), fLayout(0) { }
+   TGFrameElement() : fFrame(nullptr), fState(0), fLayout(nullptr) { }
    TGFrameElement(TGFrame *f, TGLayoutHints *l);
    ~TGFrameElement();
 
-   void Print(Option_t* option = "") const;
-   void ls(Option_t* option = "") const { Print(option); }
+   void Print(Option_t* option = "") const override;
+   void ls(Option_t* option = "") const override { Print(option); }
 
-   ClassDef(TGFrameElement, 0); // Base class used in GUI containers
+   ClassDefOverride(TGFrameElement, 0); // Base class used in GUI containers
 };
 
 
@@ -144,9 +144,9 @@ public:
    virtual void SetDefaultWidth(UInt_t /* w */) {}
    virtual void SetDefaultHeight(UInt_t /* h */) {}
    virtual Bool_t IsModified() const { return fModified; }
-   virtual void   SetModified(Bool_t flag = kTRUE) { fModified = flag; }
+   virtual void SetModified(Bool_t flag = kTRUE) { fModified = flag; }
 
-   ClassDef(TGLayoutManager,0)  // Layout manager abstract base class
+   ClassDefOverride(TGLayoutManager,0)  // Layout manager abstract base class
 };
 
 
@@ -171,11 +171,11 @@ protected:
 public:
    TGVerticalLayout(TGCompositeFrame *main);
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGVerticalLayout,0)  // Vertical layout manager
+   ClassDefOverride(TGVerticalLayout,0)  // Vertical layout manager
 };
 
 /** \class TGHorizontalLayout
@@ -188,11 +188,11 @@ class TGHorizontalLayout : public TGVerticalLayout {
 public:
    TGHorizontalLayout(TGCompositeFrame *main) : TGVerticalLayout(main) { }
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGHorizontalLayout,0)  // Horizontal layout manager
+   ClassDefOverride(TGHorizontalLayout,0)  // Horizontal layout manager
 };
 
 
@@ -211,11 +211,11 @@ public:
    TGRowLayout(TGCompositeFrame *main, Int_t s = 0) :
       TGVerticalLayout(main), fSep(s) { }
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGRowLayout,0)  // Row layout manager
+   ClassDefOverride(TGRowLayout,0)  // Row layout manager
 };
 
 /** \class TGColumnLayout
@@ -230,11 +230,11 @@ class TGColumnLayout : public TGRowLayout {
 public:
    TGColumnLayout(TGCompositeFrame *main, Int_t s = 0) : TGRowLayout(main, s) { }
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGColumnLayout,0)  // Column layout manager
+   ClassDefOverride(TGColumnLayout,0)  // Column layout manager
 };
 
 
@@ -269,8 +269,8 @@ Notes : If both column and row are fixed values, any remaining
 class TGMatrixLayout : public TGLayoutManager {
 
 private:
-   TGMatrixLayout(const TGMatrixLayout&);
-   TGMatrixLayout& operator=(const TGMatrixLayout&);
+   TGMatrixLayout(const TGMatrixLayout&) = delete;
+   TGMatrixLayout& operator=(const TGMatrixLayout&) = delete;
 
 protected:
    TGCompositeFrame *fMain;           ///< container frame
@@ -284,11 +284,11 @@ public:
 
    TGMatrixLayout(TGCompositeFrame *main, UInt_t r, UInt_t c, Int_t s=0, Int_t h=0);
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGMatrixLayout,0)  // Matrix layout manager
+   ClassDefOverride(TGMatrixLayout,0)  // Matrix layout manager
 };
 
 
@@ -303,8 +303,8 @@ This is a layout manager for the TGListView widget.
 class TGTileLayout : public TGLayoutManager {
 
 private:
-   TGTileLayout(const TGTileLayout&);
-   TGTileLayout& operator=(const TGTileLayout&);
+   TGTileLayout(const TGTileLayout&) = delete;
+   TGTileLayout& operator=(const TGTileLayout&) = delete;
 
 protected:
    Int_t             fSep;     ///< separation between tiles
@@ -316,12 +316,12 @@ protected:
 public:
    TGTileLayout(TGCompositeFrame *main, Int_t sep = 0);
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual Bool_t IsModified() const { return fModified; }
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   Bool_t IsModified() const override { return fModified; }
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGTileLayout,0)  // Tile layout manager
+   ClassDefOverride(TGTileLayout,0)  // Tile layout manager
 };
 
 /** \class TGListLayout
@@ -337,11 +337,11 @@ public:
    TGListLayout(TGCompositeFrame *main, Int_t sep = 0) :
       TGTileLayout(main, sep) { }
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGListLayout,0)  // Layout manager for TGListView widget
+   ClassDefOverride(TGListLayout,0)  // Layout manager for TGListView widget
 };
 
 /** \class TGListDetailsLayout
@@ -360,12 +360,12 @@ public:
    TGListDetailsLayout(TGCompositeFrame *main, Int_t sep = 0, UInt_t w = 0) :
       TGTileLayout(main, sep), fWidth(w) { }
 
-   virtual void Layout();
-   virtual TGDimension GetDefaultSize() const;
-   virtual void SetDefaultWidth(UInt_t w) { fWidth = w; }
-   virtual void SavePrimitive(std::ostream &out, Option_t * = "");
+   void Layout() override;
+   TGDimension GetDefaultSize() const override;
+   void SetDefaultWidth(UInt_t w) override { fWidth = w; }
+   void SavePrimitive(std::ostream &out, Option_t * = "") override;
 
-   ClassDef(TGListDetailsLayout,0)  // Layout manager for TGListView details
+   ClassDefOverride(TGListDetailsLayout,0)  // Layout manager for TGListView details
 };
 
 #endif

--- a/gui/gui/inc/TGMenu.h
+++ b/gui/gui/inc/TGMenu.h
@@ -81,7 +81,7 @@ public:
    virtual ~TGMenuEntry() { if (fLabel) delete fLabel; if (fShortcut) delete fShortcut; }
 
    Int_t          GetEntryId() const { return fEntryId; }
-   const char    *GetName() const { return fLabel ? fLabel->GetString() : nullptr; }
+   const char    *GetName() const override { return fLabel ? fLabel->GetString() : nullptr; }
    const char    *GetShortcutText() const { return fShortcut ? fShortcut->GetString() : nullptr; }
    virtual Int_t  GetStatus() const { return fStatus; }
    EMenuEntryType GetType() const { return fType; }
@@ -95,7 +95,7 @@ public:
    const TGPicture *GetPic() const { return fPic; }
    void          *GetUserData() const { return fUserData; }
 
-   ClassDef(TGMenuEntry,0);  // Menu entry class
+   ClassDefOverride(TGMenuEntry,0);  // Menu entry class
 };
 
 
@@ -143,7 +143,7 @@ protected:
    void DrawTrianglePattern(GContext_t gc, Int_t l, Int_t t, Int_t r, Int_t b);
    void DrawCheckMark(GContext_t gc, Int_t l, Int_t t, Int_t r, Int_t b);
    void DrawRCheckMark(GContext_t gc, Int_t l, Int_t t, Int_t r, Int_t b);
-   virtual void DoRedraw();
+   void DoRedraw() override;
    virtual void DrawEntry(TGMenuEntry *entry);
    virtual void Reposition();
 
@@ -198,17 +198,17 @@ public:
    virtual TGMenuEntry *GetCurrent() const { return fCurrent; }
    virtual TGMenuEntry *GetEntry(const char *s);
    const TList    *GetListOfEntries() const { return fEntryList; }
-   virtual void    DrawBorder();
-   virtual Bool_t  HandleButton(Event_t *event);
-   virtual Bool_t  HandleMotion(Event_t *event);
-   virtual Bool_t  HandleCrossing(Event_t *event);
-   virtual Bool_t  HandleTimer(TTimer *t);
+   void            DrawBorder() override;
+   Bool_t          HandleButton(Event_t *event) override;
+   Bool_t          HandleMotion(Event_t *event) override;
+   Bool_t          HandleCrossing(Event_t *event) override;
+   Bool_t          HandleTimer(TTimer *t) override;
    virtual void    Associate(const TGWindow *w) { fMsgWindow = w; }
    virtual void    SetMenuBar(TGMenuBar *bar) { fMenuBar = bar; }
    TGMenuBar      *GetMenuBar() const { return fMenuBar; }
-   virtual void    Activate(Bool_t) { }
+   void            Activate(Bool_t) override {}
    virtual void    Activate(TGMenuEntry *entry);
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
+   void            SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
    UInt_t GetEntrySep()  const { return fEntrySep; }
    virtual void SetEntrySep(UInt_t sep)  { fEntrySep = sep; }
@@ -218,7 +218,7 @@ public:
    virtual void Highlighted(Int_t id) { Emit("Highlighted(Int_t)", id); } // *SIGNAL*
    virtual void Activated(Int_t id) { Emit("Activated(Int_t)", id); }     // *SIGNAL*
 
-   ClassDef(TGPopupMenu,0)  // Popup menu
+   ClassDefOverride(TGPopupMenu,0)  // Popup menu
 };
 
 
@@ -244,7 +244,7 @@ protected:
    Pixel_t         fTextColor;        ///< text color
    GContext_t      fNormGC, fSelGC;   ///< normal and selection graphics contexts
 
-   virtual void DoRedraw();
+   void DoRedraw() override;
 
    static const TGFont *fgDefaultFont;
    static const TGGC   *fgDefaultSelectedGC;
@@ -271,11 +271,11 @@ public:
    Bool_t       GetState() const { return fState; }
    Int_t        GetHotKeyCode() const { return fHkeycode; }
    TGPopupMenu *GetMenu() const { return fMenu; }
-   const char  *GetName() const { return fLabel ? fLabel->GetString() : nullptr; }
+   const char  *GetName() const override { return fLabel ? fLabel->GetString() : nullptr; }
    virtual void DoSendMessage();
-   virtual void SavePrimitive(std::ostream &out, Option_t *option = "");
+   void         SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-   ClassDef(TGMenuTitle,0)  // Menu title class
+   ClassDefOverride(TGMenuTitle,0)  // Menu title class
 };
 
 
@@ -308,7 +308,7 @@ private:
    TGMenuBar& operator=(const TGMenuBar&) = delete;
 
 public:
-   TGMenuBar(const TGWindow *p = 0, UInt_t w = 60, UInt_t h = 20,
+   TGMenuBar(const TGWindow *p = nullptr, UInt_t w = 60, UInt_t h = 20,
              UInt_t options = kHorizontalFrame | kRaisedFrame);
    virtual ~TGMenuBar();
 
@@ -325,15 +325,15 @@ public:
 
    virtual TGMenuTitle *GetCurrent() const { return fCurrent; }
    virtual TList  *GetTitles() const { return fTitles; }
-   virtual Bool_t  HandleButton(Event_t *event);
-   virtual Bool_t  HandleMotion(Event_t *event);
-   virtual Bool_t  HandleKey(Event_t *event);
-   virtual void    SavePrimitive(std::ostream &out, Option_t *option = "");
-   virtual void    Layout();
+           Bool_t  HandleButton(Event_t *event) override;
+           Bool_t  HandleMotion(Event_t *event) override;
+           Bool_t  HandleKey(Event_t *event) override;
+           void    SavePrimitive(std::ostream &out, Option_t *option = "") override;
+           void    Layout() override;
            void    PopupConnection();
    TGFrameElement* GetLastOnLeft();
 
-   ClassDef(TGMenuBar,0)  // Menu bar class
+   ClassDefOverride(TGMenuBar,0)  // Menu bar class
 };
 
 #endif

--- a/gui/gui/inc/TGMimeTypes.h
+++ b/gui/gui/inc/TGMimeTypes.h
@@ -39,7 +39,7 @@ private:
    TRegexp  *fReg;        ///< pattern regular expression
 
 public:
-   TGMime() : fReg(0) {}
+   TGMime() : fReg(nullptr) {}
    ~TGMime();
 };
 
@@ -63,12 +63,12 @@ public:
    void   SaveMimes();
    Bool_t HasChanged() const { return fChanged; }
    void   AddType(const char *type, const char *pat, const char *icon, const char *sicon, const char *action);
-   void   Print(Option_t *option="") const;
+   void   Print(Option_t *option="") const override;
    Bool_t GetAction(const char *filename, char *action);
    Bool_t GetType(const char *filename, char *type);
    const TGPicture *GetIcon(const char *filename, Bool_t small_icon);
 
-   ClassDef(TGMimeTypes,0)  // Pool of mime type objects
+   ClassDefOverride(TGMimeTypes,0)  // Pool of mime type objects
 };
 
 #endif

--- a/gui/gui/inc/TGObject.h
+++ b/gui/gui/inc/TGObject.h
@@ -18,29 +18,33 @@
 
 class TGClient;
 
-
 class TGObject : public TObject {
-
 
 protected:
    Handle_t    fId;                  ///< X11/Win32 Window identifier
    TGClient   *fClient;              ///< Connection to display server
 
-   TGObject& operator=(const TGObject& tgo)
-     {if(this!=&tgo) { TObject::operator=(tgo); fId=tgo.fId;
-     fClient=tgo.fClient; } return *this; }
+   TGObject &operator=(const TGObject& tgo)
+   {
+      if(this!=&tgo) {
+         TObject::operator=(tgo);
+         fId=tgo.fId;
+         fClient=tgo.fClient;
+      }
+      return *this;
+   }
 
 public:
-   TGObject(): fId(0), fClient(0) { }
+   TGObject(): fId(0), fClient(nullptr) { }
    TGObject(const TGObject& tgo): TObject(tgo), fId(tgo.fId), fClient(tgo.fClient) { }
    virtual ~TGObject();
    Handle_t  GetId() const { return fId; }
    TGClient *GetClient() const { return fClient; }
-   ULong_t   Hash() const { return (ULong_t) fId >> 0; }
-   Bool_t    IsEqual(const TObject *obj) const;
-   virtual void SaveAs(const char* filename = "", Option_t* option = "") const;
+   ULong_t   Hash() const override { return (ULong_t) fId >> 0; }
+   Bool_t    IsEqual(const TObject *obj) const override;
+   void SaveAs(const char* filename = "", Option_t* option = "") const override;
 
-   ClassDef(TGObject,0)  //ROOT GUI base class
+   ClassDefOverride(TGObject,0)  //ROOT GUI base class
 };
 
 #endif

--- a/gui/gui/inc/TGPicture.h
+++ b/gui/gui/inc/TGPicture.h
@@ -43,24 +43,24 @@ protected:
    TGPicture(const char *name, Pixmap_t pxmap, Pixmap_t mask = 0);
 
    // override default of TObject
-   void Draw(Option_t * = "") { MayNotUse("Draw(Option_t*)"); }
+   void Draw(Option_t * = "") override { MayNotUse("Draw(Option_t*)"); }
 
 public:
    virtual ~TGPicture();
 
-   const char *GetName() const { return fName; }
+   const char *GetName() const override { return fName.Data(); }
    UInt_t      GetWidth() const { return fAttributes.fWidth; }
    UInt_t      GetHeight() const { return fAttributes.fHeight; }
    Pixmap_t    GetPicture() const { return fPic; }
    Pixmap_t    GetMask() const { return fMask; }
    Bool_t      IsScaled() const { return fScaled; }
-   ULong_t     Hash() const { return fName.Hash(); }
+   ULong_t     Hash() const override { return fName.Hash(); }
    static const char *HashName(const char *name, Int_t width, Int_t height);
 
    virtual void Draw(Handle_t id, GContext_t gc, Int_t x, Int_t y) const;
-   void         Print(Option_t *option="") const;
+   void         Print(Option_t *option="") const override;
 
-   ClassDef(TGPicture,0)  // Pictures and icons used by the GUI classes
+   ClassDefOverride(TGPicture,0)  // Pictures and icons used by the GUI classes
 };
 
 
@@ -82,7 +82,7 @@ public:
    TGSelectedPicture(const TGClient *client, const TGPicture *p);
    virtual ~TGSelectedPicture();
 
-   ClassDef(TGSelectedPicture,0)  // Selected looking picture
+   ClassDefOverride(TGSelectedPicture,0)  // Selected looking picture
 };
 
 
@@ -98,7 +98,7 @@ protected:
 
 public:
    TGPicturePool(const TGClient *client, const char *path):
-      fClient(client), fPath(path), fPicList(0) { }
+      fClient(client), fPath(path), fPicList(nullptr) { }
    virtual ~TGPicturePool();
 
    const char      *GetPath() const { return fPath; }
@@ -108,9 +108,9 @@ public:
    const TGPicture *GetPicture(const char *name, Pixmap_t pxmap, Pixmap_t mask =  0);
    void             FreePicture(const TGPicture *pic);
 
-   void             Print(Option_t *option="") const;
+   void             Print(Option_t *option="") const override;
 
-   ClassDef(TGPicturePool,0)  // Picture and icon cache
+   ClassDefOverride(TGPicturePool,0)  // Picture and icon cache
 };
 
 #endif

--- a/gui/gui/inc/TGString.h
+++ b/gui/gui/inc/TGString.h
@@ -24,7 +24,7 @@ public:
    TGString(const char *s) : TString(s) { }
    TGString(Int_t number) : TString() { *this += number; }
    TGString(const TGString *s);
-   virtual ~TGString() { }
+   virtual ~TGString() {}
 
    Int_t GetLength() const { return Length(); }
    const char  *GetString() const { return Data(); }
@@ -35,7 +35,7 @@ public:
                             Int_t x, Int_t y, UInt_t w, FontStruct_t font);
    virtual Int_t GetLines(FontStruct_t font, UInt_t w);
 
-   ClassDef(TGString,0)  // Graphics string
+   ClassDefOverride(TGString,0)  // Graphics string
 };
 
 
@@ -56,11 +56,11 @@ public:
 
    Int_t GetHotChar() const { return fHotChar; }
    Int_t GetHotPos() const { return fHotPos; }
-   virtual void Draw(Drawable_t id, GContext_t gc, Int_t x, Int_t y);
-   virtual void DrawWrapped(Drawable_t id, GContext_t gc,
-                            Int_t x, Int_t y, UInt_t w, FontStruct_t font);
+   void Draw(Drawable_t id, GContext_t gc, Int_t x, Int_t y) override;
+   void DrawWrapped(Drawable_t id, GContext_t gc,
+                    Int_t x, Int_t y, UInt_t w, FontStruct_t font) override;
 
-   ClassDef(TGHotString,0)  // Graphics string with hot character
+   ClassDefOverride(TGHotString,0)  // Graphics string with hot character
 };
 
 #endif

--- a/gui/gui/inc/TGWindow.h
+++ b/gui/gui/inc/TGWindow.h
@@ -94,7 +94,7 @@ public:
    virtual Bool_t HandleExpose(Event_t *event)
                   { if (event->fCount == 0) fClient->NeedRedraw(this); return kTRUE; }
    virtual Bool_t HandleEvent(Event_t *) { return kFALSE; }
-   virtual Bool_t HandleTimer(TTimer *) { return kFALSE; }
+   Bool_t         HandleTimer(TTimer *) override { return kFALSE; }
    virtual Bool_t HandleIdleEvent(TGIdleHandler *) { return kFALSE; }
 
    virtual void   Move(Int_t x, Int_t y);
@@ -105,20 +105,20 @@ public:
    virtual UInt_t GetEditDisabled() const { return fEditDisabled; }
    virtual void   SetEditDisabled(UInt_t on = kEditDisable) { fEditDisabled = on; }
    virtual void   SetEditable(Bool_t on = kTRUE)
-                  { if (!(fEditDisabled & kEditDisable)) fClient->SetRoot(on ? this : 0); }
+                  { if (!(fEditDisabled & kEditDisable)) fClient->SetRoot(on ? this : nullptr); }
    virtual Int_t  MustCleanup() const { return 0; }
-   virtual void   Print(Option_t *option="") const;
+   void           Print(Option_t *option="") const override;
 
-   virtual void        SetWindowName(const char *name = 0);
-   virtual const char *GetName() const;
-   virtual void        SetName(const char *name) { fName = name; }
+   virtual void   SetWindowName(const char *name = nullptr);
+   const char    *GetName() const override;
+   virtual void   SetName(const char *name) { fName = name; }
 
    virtual void   SetMapSubwindows(Bool_t /*on*/) {  }
    virtual Bool_t IsMapSubwindows() const { return kTRUE; }
 
-   static Int_t        GetCounter();
+   static Int_t   GetCounter();
 
-   ClassDef(TGWindow, 0);  // GUI Window base class
+   ClassDefOverride(TGWindow, 0);  // GUI Window base class
 };
 
 
@@ -134,12 +134,12 @@ Typically windows created by Xt or Motif.
 class TGUnknownWindowHandler : public TObject {
 
 public:
-   TGUnknownWindowHandler() { }
-   virtual ~TGUnknownWindowHandler() { }
+   TGUnknownWindowHandler() {}
+   virtual ~TGUnknownWindowHandler() {}
 
    virtual Bool_t HandleEvent(Event_t *) = 0;
 
-   ClassDef(TGUnknownWindowHandler,0)  // Abstract event handler for unknown windows
+   ClassDefOverride(TGUnknownWindowHandler,0)  // Abstract event handler for unknown windows
 };
 
 #endif

--- a/io/io/inc/TArchiveFile.h
+++ b/io/io/inc/TArchiveFile.h
@@ -38,7 +38,7 @@ protected:
    static Bool_t ParseUrl(const char *url, TString &archive, TString &member, TString &type);
 
 public:
-   TArchiveFile() : fArchiveName(""), fMemberName(""), fMemberIndex(-1), fFile(0), fMembers(0), fCurMember(0) { }
+   TArchiveFile() : fArchiveName(""), fMemberName(""), fMemberIndex(-1), fFile(nullptr), fMembers(nullptr), fCurMember(nullptr) { }
    TArchiveFile(const char *archive, const char *member, TFile *file);
    virtual ~TArchiveFile();
 
@@ -58,7 +58,7 @@ public:
 
    static TArchiveFile *Open(const char *url, TFile *file);
 
-   ClassDef(TArchiveFile,1)  //An archive file containing multiple sub-files (like a ZIP archive)
+   ClassDefOverride(TArchiveFile,1)  //An archive file containing multiple sub-files (like a ZIP archive)
 };
 
 
@@ -83,7 +83,7 @@ public:
    TArchiveMember &operator=(const TArchiveMember &rhs);
    virtual ~TArchiveMember() { }
 
-   const char *GetName() const { return fName; }
+   const char *GetName() const override { return fName; }
    const char *GetComment() const { return fComment; }
    TDatime     GetModTime() const { return fModTime; }
    Long64_t    GetPosition() const { return fPosition; }
@@ -92,7 +92,7 @@ public:
    Long64_t    GetDecompressedSize() const { return fDsize; }
    Bool_t      IsDirectory() const { return fDirectory; }
 
-   ClassDef(TArchiveMember,1)  //An archive member file
+   ClassDefOverride(TArchiveMember,1)  //An archive member file
 };
 
 #endif

--- a/io/io/inc/TEmulatedCollectionProxy.h
+++ b/io/io/inc/TEmulatedCollectionProxy.h
@@ -28,7 +28,7 @@ public:
 protected:
 
    // Some hack to avoid const-ness
-   virtual TGenCollectionProxy* InitializeEx(Bool_t silent);
+   TGenCollectionProxy* InitializeEx(Bool_t silent) override;
 
    // Object input streamer
    void ReadItems(int nElements, TBuffer &b);
@@ -47,7 +47,7 @@ private:
 
 public:
    // Virtual copy constructor
-   virtual TVirtualCollectionProxy* Generate() const;
+   TVirtualCollectionProxy* Generate() const override;
 
    // Copy constructor
    TEmulatedCollectionProxy(const TEmulatedCollectionProxy& copy);
@@ -59,69 +59,70 @@ public:
    virtual ~TEmulatedCollectionProxy();
 
    // Virtual constructor
-   virtual void* New()   const             {  return new Cont_t;         }
+   void* New() const override             {  return new Cont_t;         }
 
    // Virtual in-place constructor
-   virtual void* New(void* memory)   const {  return new(memory) Cont_t; }
+   void* New(void* memory) const override {  return new(memory) Cont_t; }
 
    // Virtual constructor
-   virtual TClass::ObjectPtr NewObject()   const             {  return {new Cont_t, nullptr};         }
+   TClass::ObjectPtr NewObject() const override             {  return {new Cont_t, nullptr};         }
 
    // Virtual in-place constructor
-   virtual TClass::ObjectPtr NewObject(void* memory)   const {  return {new(memory) Cont_t, nullptr}; }
+   TClass::ObjectPtr NewObject(void* memory) const override {  return {new(memory) Cont_t, nullptr}; }
 
    // Virtual array constructor
-   virtual void* NewArray(Int_t nElements)   const             {  return new Cont_t[nElements];         }
+   void* NewArray(Int_t nElements) const override             {  return new Cont_t[nElements]; }
 
    // Virtual in-place constructor
-   virtual void* NewArray(Int_t nElements, void* memory)   const {  return new(memory) Cont_t[nElements]; }
+   void* NewArray(Int_t nElements, void* memory) const override {  return new(memory) Cont_t[nElements]; }
 
    // Virtual array constructor
-   virtual TClass::ObjectPtr NewObjectArray(Int_t nElements)   const             {  return {new Cont_t[nElements], nullptr};         }
+   TClass::ObjectPtr NewObjectArray(Int_t nElements) const override  {  return {new Cont_t[nElements], nullptr}; }
 
    // Virtual in-place constructor
-   virtual TClass::ObjectPtr NewObjectArray(Int_t nElements, void* memory)   const {  return {new(memory) Cont_t[nElements], nullptr}; }
+   TClass::ObjectPtr NewObjectArray(Int_t nElements, void* memory) const override {  return {new(memory) Cont_t[nElements], nullptr}; }
 
    // Virtual destructor
-   virtual void  Destructor(void* p, Bool_t dtorOnly = kFALSE) const;
+   void  Destructor(void* p, Bool_t dtorOnly = kFALSE) const override;
 
    // Virtual array destructor
-   virtual void  DeleteArray(void* p, Bool_t dtorOnly = kFALSE) const;
+   void  DeleteArray(void* p, Bool_t dtorOnly = kFALSE) const override;
 
    // TVirtualCollectionProxy overload: Return the sizeof the collection object.
-   virtual UInt_t Sizeof() const           {  return sizeof(Cont_t);     }
+   UInt_t Sizeof() const override { return sizeof(Cont_t); }
 
    // Return the address of the value at index 'idx'
-   virtual void *At(UInt_t idx);
+   void *At(UInt_t idx) override;
 
    // Clear the container
-   virtual void Clear(const char *opt = "");
+   void Clear(const char *opt = "") override;
 
    // Resize the container
-   virtual void Resize(UInt_t n, Bool_t force_delete);
+   void Resize(UInt_t n, Bool_t force_delete) override;
 
    // Return the current size of the container
-   virtual UInt_t Size() const;
+   UInt_t Size() const override;
 
    // Block allocation of containees
-   virtual void* Allocate(UInt_t n, Bool_t forceDelete);
+   void* Allocate(UInt_t n, Bool_t forceDelete) override;
 
    // Block commit of containees
-   virtual void Commit(void* env);
+   void Commit(void* env) override;
 
    // Insert data into the container where data is a C-style array of the actual type contained in the collection
    // of the given size.   For associative container (map, etc.), the data type is the pair<key,value>.
-   virtual void  Insert(const void *data, void *container, size_t size);
+   void  Insert(const void *data, void *container, size_t size) override;
 
    // Read portion of the streamer
-   virtual void ReadBuffer(TBuffer &buff, void *pObj);
-   virtual void ReadBuffer(TBuffer &buff, void *pObj, const TClass *onfile);
+   void ReadBuffer(TBuffer &buff, void *pObj) override;
+   void ReadBuffer(TBuffer &buff, void *pObj, const TClass *onfile) override;
 
    // Streamer for I/O handling
-   virtual void Streamer(TBuffer &refBuffer);
+   void Streamer(TBuffer &refBuffer) override;
 
    // Streamer I/O overload
-   virtual void Streamer(TBuffer &buff, void *pObj, int siz) {
+   void Streamer(TBuffer &buff, void *pObj, int siz) override
+   {
       TGenCollectionProxy::Streamer(buff,pObj,siz);
    }
 

--- a/io/io/inc/TEmulatedMapProxy.h
+++ b/io/io/inc/TEmulatedMapProxy.h
@@ -26,7 +26,7 @@ private:
 
 public:
    // Virtual copy constructor
-   virtual TVirtualCollectionProxy* Generate() const;
+   TVirtualCollectionProxy* Generate() const override;
 
    // Copy constructor
    TEmulatedMapProxy(const TEmulatedMapProxy& copy);
@@ -38,20 +38,21 @@ public:
    virtual ~TEmulatedMapProxy();
 
    // Return the address of the value at index 'idx'
-   virtual void *At(UInt_t idx);
+   void *At(UInt_t idx) override;
 
    // Return the current size of the container
-   virtual UInt_t Size() const;
+   UInt_t Size() const override;
 
    // Read portion of the streamer
-   virtual void ReadBuffer(TBuffer &buff, void *pObj);
-   virtual void ReadBuffer(TBuffer &buff, void *pObj, const TClass *onfile);
+   void ReadBuffer(TBuffer &buff, void *pObj) override;
+   void ReadBuffer(TBuffer &buff, void *pObj, const TClass *onfile) override;
 
    // Streamer for I/O handling
-   virtual void Streamer(TBuffer &refBuffer);
+   void Streamer(TBuffer &refBuffer) override;
 
    // Streamer I/O overload
-   virtual void Streamer(TBuffer &buff, void *pObj, int siz) {
+   void Streamer(TBuffer &buff, void *pObj, int siz) override
+   {
       TEmulatedCollectionProxy::Streamer(buff,pObj,siz);
    }
 };

--- a/io/io/inc/TFileCacheRead.h
+++ b/io/io/inc/TFileCacheRead.h
@@ -102,7 +102,7 @@ public:
    virtual Bool_t      IsLearning() const {return kFALSE;}
    virtual Int_t       LearnBranch(TBranch * /*b*/, Bool_t /*subbranches*/ = kFALSE) { return 0; }
    virtual void        Prefetch(Long64_t pos, Int_t len);
-   virtual void        Print(Option_t *option="") const;
+           void        Print(Option_t *option="") const override;
    virtual Int_t       ReadBufferExt(char *buf, Long64_t pos, Int_t len, Int_t &loc);
    virtual Int_t       ReadBufferExtNormal(char *buf, Long64_t pos, Int_t len, Int_t &loc);
    virtual Int_t       ReadBufferExtPrefetch(char *buf, Long64_t pos, Int_t len, Int_t &loc);
@@ -116,7 +116,7 @@ public:
    virtual TFilePrefetch* GetPrefetchObj();
    virtual void        WaitFinishPrefetch();                  //Gracefully join the prefetching thread
 
-   ClassDef(TFileCacheRead,2)  //TFile cache when reading
+   ClassDefOverride(TFileCacheRead,2)  //TFile cache when reading
 };
 
 #endif

--- a/io/io/inc/TFileCacheWrite.h
+++ b/io/io/inc/TFileCacheWrite.h
@@ -36,12 +36,12 @@ public:
    virtual ~TFileCacheWrite();
    virtual Bool_t      Flush();
    virtual Int_t       GetBytesInCache() const { return fNtot; }
-   virtual void        Print(Option_t *option="") const;
+           void        Print(Option_t *option="") const override;
    virtual Int_t       ReadBuffer(char *buf, Long64_t pos, Int_t len);
    virtual Int_t       WriteBuffer(const char *buf, Long64_t pos, Int_t len);
    virtual void        SetFile(TFile *file);
 
-   ClassDef(TFileCacheWrite,1)  //TFile cache when writing
+   ClassDefOverride(TFileCacheWrite,1)  //TFile cache when writing
 };
 
 #endif

--- a/io/io/inc/TFileMerger.h
+++ b/io/io/inc/TFileMerger.h
@@ -104,7 +104,7 @@ public:
 
     //--- file management interface
    virtual Bool_t SetCWD(const char * /*path*/) { MayNotUse("SetCWD"); return kFALSE; }
-   virtual const char *GetCWD() { MayNotUse("GetCWD"); return 0; }
+   virtual const char *GetCWD() { MayNotUse("GetCWD"); return nullptr; }
 
    //--- file merging interface
    virtual void   Reset();
@@ -122,9 +122,9 @@ public:
    virtual void   SetFastMethod(Bool_t fast=kTRUE)  {fFastMethod = fast;}
            Bool_t GetNotrees() const { return fNoTrees; }
    virtual void   SetNotrees(Bool_t notrees=kFALSE) {fNoTrees = notrees;}
-   virtual void        RecursiveRemove(TObject *obj);
+           void   RecursiveRemove(TObject *obj) override;
 
-   ClassDef(TFileMerger, 6)  // File copying and merging services
+   ClassDefOverride(TFileMerger, 6)  // File copying and merging services
 };
 
 #endif

--- a/io/io/inc/TFilePrefetch.h
+++ b/io/io/inc/TFilePrefetch.h
@@ -81,7 +81,7 @@ public:
    void      WaitFinishPrefetch();
    Bool_t    IsPrefetchFinished() const { return fPrefetchFinished; }
 
-   ClassDef(TFilePrefetch, 0);  // File block prefetcher
+   ClassDefOverride(TFilePrefetch, 0);  // File block prefetcher
 };
 
 #endif

--- a/io/io/inc/TFree.h
+++ b/io/io/inc/TFree.h
@@ -39,13 +39,13 @@ public:
            TFree    *GetBestFree(TList *lfree, Int_t nbytes);
            Long64_t  GetFirst() const {return fFirst;}
            Long64_t  GetLast() const {return fLast;}
-           void      ls(Option_t * = "") const;
+           void      ls(Option_t * = "") const override;
    virtual void      ReadBuffer(char *&buffer);
            void      SetFirst(Long64_t first) {fFirst=first;}
            void      SetLast(Long64_t last) {fLast=last;}
            Int_t     Sizeof() const;
 
-   ClassDef(TFree,1);  //Description of free segments on a file
+   ClassDefOverride(TFree,1);  //Description of free segments on a file
 };
 
 #endif

--- a/io/io/inc/TKey.h
+++ b/io/io/inc/TKey.h
@@ -51,12 +51,11 @@ protected:
    UShort_t    fPidOffset;   ///<!Offset to be added to the pid index in this key/buffer.  This is actually saved in the high bits of fSeekPdir
    TDirectory *fMotherDir;   ///<!pointer to mother directory
 
-   virtual Int_t    Read(const char *name) { return TObject::Read(name); }
-   virtual void     Create(Int_t nbytes, TFile* f = 0);
+           Int_t    Read(const char *name) override { return TObject::Read(name); }
+   virtual void     Create(Int_t nbytes, TFile* f = nullptr);
            void     Build(TDirectory* motherDir, const char* classname, Long64_t filepos);
            void     Reset(); // Currently only for the use of TBasket.
-   virtual Int_t    WriteFileKeepBuffer(TFile *f = 0);
-
+   virtual Int_t    WriteFileKeepBuffer(TFile *f = nullptr);
 
  public:
    TKey();
@@ -66,16 +65,16 @@ protected:
    TKey(const TString &name, const TString &title, const TClass *cl, Int_t nbytes, TDirectory* motherDir);
    TKey(const TObject *obj, const char *name, Int_t bufsize, TDirectory* motherDir);
    TKey(const void *obj, const TClass *cl, const char *name, Int_t bufsize, TDirectory* motherDir);
-   TKey(Long64_t pointer, Int_t nbytes, TDirectory* motherDir = 0);
+   TKey(Long64_t pointer, Int_t nbytes, TDirectory* motherDir = nullptr);
    virtual ~TKey();
 
-   virtual void        Browse(TBrowser *b);
-   virtual void        Delete(Option_t *option="");
+           void        Browse(TBrowser *b) override;
+           void        Delete(Option_t *option="") override;
    virtual void        DeleteBuffer();
-   virtual void        FillBuffer(char *&buffer);
+           void        FillBuffer(char *&buffer) override;
    virtual const char *GetClassName() const {return fClassName.Data();}
-   virtual const char *GetIconName() const;
-   virtual const char *GetTitle() const;
+           const char *GetIconName() const override;
+           const char *GetTitle() const override;
    virtual char       *GetBuffer() const {return fBuffer+fKeylen;}
            TBuffer    *GetBufferRef() const {return fBufferRef;}
            Short_t     GetCycle() const;
@@ -90,11 +89,11 @@ protected:
    virtual Long64_t    GetSeekKey() const  {return fSeekKey;}
    virtual Long64_t    GetSeekPdir() const {return fSeekPdir;}
    virtual void        IncrementPidOffset(UShort_t offset);
-           Bool_t      IsFolder() const;
+           Bool_t      IsFolder() const override;
    virtual void        Keep();
    virtual void        ls(Bool_t current) const;
-   virtual void        ls(Option_t *option="") const;
-   virtual void        Print(Option_t *option="") const;
+           void        ls(Option_t *option="") const override;
+           void        Print(Option_t *option="") const override;
    virtual Int_t       Read(TObject *obj);
    virtual TObject    *ReadObj();
    virtual TObject    *ReadObjWithBuffer(char *bufferRead);
@@ -111,10 +110,10 @@ protected:
    virtual void        SetBuffer() { DeleteBuffer(); fBuffer = new char[fNbytes];}
    virtual void        SetParent(const TObject *parent);
            void        SetMotherDir(TDirectory* dir) { fMotherDir = dir; }
-   virtual Int_t       Sizeof() const;
-   virtual Int_t       WriteFile(Int_t cycle=1, TFile* f = 0);
+           Int_t       Sizeof() const override;
+   virtual Int_t       WriteFile(Int_t cycle = 1, TFile* f = nullptr);
 
-   ClassDef(TKey,4); //Header description of a logical record on file.
+   ClassDefOverride(TKey,4); //Header description of a logical record on file.
 };
 
 #endif

--- a/io/io/inc/TKeyMapFile.h
+++ b/io/io/inc/TKeyMapFile.h
@@ -29,9 +29,9 @@ public:
    TKeyMapFile();
    TKeyMapFile(const char *name, const char *classname, TMapFile *mapfile);
    virtual ~TKeyMapFile() {;}
-   virtual void      Browse(TBrowser *b);
+   void      Browse(TBrowser *b) override;
 
-   ClassDef(TKeyMapFile,0);  //Utility class for browsing TMapFile objects.
+   ClassDefOverride(TKeyMapFile,0);  //Utility class for browsing TMapFile objects.
 };
 
 #endif

--- a/io/io/inc/TLockFile.h
+++ b/io/io/inc/TLockFile.h
@@ -31,7 +31,7 @@ public:
    TLockFile(const char *path, Int_t timeLimit = 0);
    virtual ~TLockFile();
 
-   ClassDef(TLockFile, 0) //Lock an object using a file
+   ClassDefOverride(TLockFile, 0) //Lock an object using a file
 };
 
 #endif

--- a/io/io/inc/TMapFile.h
+++ b/io/io/inc/TMapFile.h
@@ -65,7 +65,7 @@ protected:
    void       SumBuffer(Int_t bufsize);
    Int_t      GetBestBuffer();
 
-   void   CreateSemaphore(Int_t pid=0);
+   void   CreateSemaphore(Int_t pid = 0);
    Int_t  AcquireSemaphore();
    Int_t  ReleaseSemaphore();
    void   DeleteSemaphore();
@@ -83,25 +83,25 @@ public:
    void *operator new[](size_t sz, void *vp) { return TObject::operator new[](sz, vp); }
    void     operator delete(void *vp);
 
-   void          Browse(TBrowser *b);
+   void          Browse(TBrowser *b) override;
    void          Close(Option_t *option = "");
    void         *GetBaseAddr() const { return (void *)fBaseAddr; }
    void         *GetBreakval() const;
    TDirectory   *GetDirectory() const {return fDirectory;}
    Int_t         GetFd() const { return fFd; }
    void         *GetMmallocDesc() const { return fMmallocDesc; }
-   const char   *GetName() const { return fName; }
+   const char   *GetName() const override { return fName; }
    Int_t         GetSize() const { return fSize; }
-   const char   *GetOption() const { return fOption; }
-   const char   *GetTitle() const { return fTitle; }
+   const char   *GetOption() const override { return fOption; }
+   const char   *GetTitle() const override { return fTitle; }
    TMapRec      *GetFirst() const { return (TMapRec*)((Longptr_t) fFirst + fOffset); }
    TMapRec      *GetLast() const { return (TMapRec*)((Longptr_t) fLast + fOffset); }
-   Bool_t        IsFolder() const;
+   Bool_t        IsFolder() const override;
    Bool_t        IsWritable() const { return fWritable; }
    void         *OrgAddress(void *addr) const { return (void *)((Longptr_t)addr - fOffset); }
-   void          Print(Option_t *option="") const;
-   void          ls(Option_t *option="") const;
-   Bool_t        cd(const char *path = 0);
+   void          Print(Option_t *option="") const override;
+   void          ls(Option_t *option="") const override;
+   Bool_t        cd(const char *path = nullptr);
 
    void          Add(const TObject *obj, const char *name = "");
    void          Update(TObject *obj = 0);
@@ -114,7 +114,7 @@ public:
    static TMapFile *WhichMapFile(void *addr);
    static void      SetMapAddress(Longptr_t addr);
 
-   ClassDef(TMapFile,0)  // Memory mapped directory structure
+   ClassDefOverride(TMapFile,0)  // Memory mapped directory structure
 };
 
 

--- a/io/io/inc/TStreamerInfo.h
+++ b/io/io/inc/TStreamerInfo.h
@@ -182,29 +182,29 @@ public:
    TStreamerInfo();
    TStreamerInfo(TClass *cl);
    virtual            ~TStreamerInfo();
-   void                Build(Bool_t isTransient = kFALSE);
-   void                BuildCheck(TFile *file = 0, Bool_t load = kTRUE);
-   void                BuildEmulated(TFile *file);
-   void                BuildOld();
-   virtual Bool_t      BuildFor( const TClass *cl );
-   void                CallShowMembers(const void* obj, TMemberInspector &insp, Bool_t isTransient) const;
-   void                Clear(Option_t *);
-   TObject            *Clone(const char *newname = "") const;
-   Bool_t              CompareContent(TClass *cl,TVirtualStreamerInfo *info, Bool_t warn, Bool_t complete, TFile *file);
-   void                Compile();
+   void                Build(Bool_t isTransient = kFALSE) override;
+   void                BuildCheck(TFile *file = nullptr, Bool_t load = kTRUE) override;
+   void                BuildEmulated(TFile *file) override;
+   void                BuildOld() override;
+   Bool_t              BuildFor( const TClass *cl ) override;
+   void                CallShowMembers(const void* obj, TMemberInspector &insp, Bool_t isTransient) const override;
+   void                Clear(Option_t * = "") override;
+   TObject            *Clone(const char *newname = "") const override;
+   Bool_t              CompareContent(TClass *cl,TVirtualStreamerInfo *info, Bool_t warn, Bool_t complete, TFile *file) override;
+   void                Compile() override;
    void                ComputeSize();
-   void                ForceWriteInfo(TFile *file, Bool_t force=kFALSE);
-   Int_t               GenerateHeaderFile(const char *dirname, const TList *subClasses = 0, const TList *extrainfos = 0);
-   TClass             *GetActualClass(const void *obj) const;
-   TClass             *GetClass() const {return fClass;}
-   UInt_t              GetCheckSum() const {return fCheckSum;}
+   void                ForceWriteInfo(TFile *file, Bool_t force = kFALSE) override;
+   Int_t               GenerateHeaderFile(const char *dirname, const TList *subClasses = nullptr, const TList *extrainfos = nullptr) override;
+   TClass             *GetActualClass(const void *obj) const override;
+   TClass             *GetClass() const override { return fClass; }
+   UInt_t              GetCheckSum() const override { return fCheckSum; }
    UInt_t              GetCheckSum(TClass::ECheckSum code) const;
-   Int_t               GetClassVersion() const {return fClassVersion;}
+   Int_t               GetClassVersion() const override { return fClassVersion; }
    Int_t               GetDataMemberOffset(TDataMember *dm, TMemberStreamer *&streamer) const;
-   TObjArray          *GetElements() const {return fElements;}
-   TStreamerElement   *GetElem(Int_t id) const {return fComp[id].fElem;}  // Return the element for the list of optimized elements (max GetNdata())
-   TStreamerElement   *GetElement(Int_t id) const {return (TStreamerElement*)fElements->At(id);} // Return the element for the complete list of elements (max GetElements()->GetEntries())
-   Int_t               GetElementOffset(Int_t id) const {return fCompFull[id]->fOffset;}
+   TObjArray          *GetElements() const override {return fElements;}
+   TStreamerElement   *GetElem(Int_t id) const override { return fComp[id].fElem; }  // Return the element for the list of optimized elements (max GetNdata())
+   TStreamerElement   *GetElement(Int_t id) const override {return (TStreamerElement*)fElements->At(id);} // Return the element for the complete list of elements (max GetElements()->GetEntries())
+   Int_t               GetElementOffset(Int_t id) const override {return fCompFull[id]->fOffset;}
    TStreamerInfoActions::TActionSequence *GetReadMemberWiseActions(Bool_t forCollection) { return forCollection ? fReadMemberWiseVecPtr : fReadMemberWise; }
    TStreamerInfoActions::TActionSequence *GetReadObjectWiseActions() { return fReadObjectWise; }
    TStreamerInfoActions::TActionSequence *GetReadTextActions() { return fReadText; }
@@ -213,17 +213,17 @@ public:
    TStreamerInfoActions::TActionSequence *GetWriteTextActions() { return fWriteText; }
    Int_t               GetNdata()   const {return fNdata;}
    Int_t               GetNelement() const { return fElements->GetEntriesFast(); }
-   Int_t               GetNumber()  const {return fNumber;}
+   Int_t               GetNumber()  const override { return fNumber; }
    Int_t               GetLength(Int_t id) const {return fComp[id].fLength;}
    ULongptr_t          GetMethod(Int_t id) const {return fComp[id].fMethod;}
    Int_t               GetNewType(Int_t id) const {return fComp[id].fNewType;}
-   Int_t               GetOffset(const char *) const;
-   Int_t               GetOffset(Int_t id) const {return fComp[id].fOffset;}
-   Version_t           GetOldVersion() const {return fOldVersion;}
-   Int_t               GetOnFileClassVersion() const {return fOnFileClassVersion;}
-   Int_t               GetSize()    const;
-   Int_t               GetSizeElements()    const;
-   TStreamerElement   *GetStreamerElement(const char*datamember, Int_t& offset) const;
+   Int_t               GetOffset(const char *) const override;
+   Int_t               GetOffset(Int_t id) const override {return fComp[id].fOffset;}
+   Version_t           GetOldVersion() const override {return fOldVersion;}
+   Int_t               GetOnFileClassVersion() const override {return fOnFileClassVersion;}
+   Int_t               GetSize() const override;
+   Int_t               GetSizeElements() const;
+   TStreamerElement   *GetStreamerElement(const char*datamember, Int_t& offset) const  override;
    TStreamerElement   *GetStreamerElementReal(Int_t i, Int_t j) const;
    Int_t               GetType(Int_t id)   const {return fComp[id].fType;}
    template <typename T> T GetTypedValue(char *pointer, Int_t i, Int_t j, Int_t len) const;
@@ -234,13 +234,13 @@ public:
    Double_t            GetValueClones(TClonesArray *clones, Int_t i, Int_t j, Int_t k, Int_t eoffset) const { return GetTypedValueClones<Double_t>(clones, i, j, k, eoffset); }
    Double_t            GetValueSTL(TVirtualCollectionProxy *cont, Int_t i, Int_t j, Int_t k, Int_t eoffset) const { return GetTypedValueSTL<Double_t>(cont, i, j, k, eoffset); }
    Double_t            GetValueSTLP(TVirtualCollectionProxy *cont, Int_t i, Int_t j, Int_t k, Int_t eoffset) const { return GetTypedValueSTLP<Double_t>(cont, i, j, k, eoffset); }
-   void                ls(Option_t *option="") const;
+   void                ls(Option_t *option="") const override;
    Bool_t              MatchLegacyCheckSum(UInt_t checksum) const;
-   TVirtualStreamerInfo *NewInfo(TClass *cl) {return new TStreamerInfo(cl);}
-   void               *New(void *obj = 0);
-   void               *NewArray(Long_t nElements, void* ary = 0);
-   void                Destructor(void* p, Bool_t dtorOnly = kFALSE);
-   void                DeleteArray(void* p, Bool_t dtorOnly = kFALSE);
+   TVirtualStreamerInfo *NewInfo(TClass *cl) override { return new TStreamerInfo(cl); }
+   void               *New(void *obj = nullptr) override;
+   void               *NewArray(Long_t nElements, void* ary = nullptr) override;
+   void                Destructor(void* p, Bool_t dtorOnly = kFALSE) override;
+   void                DeleteArray(void* p, Bool_t dtorOnly = kFALSE) override;
    void                PrintValue(const char *name, char *pointer, Int_t i, Int_t len, Int_t lenmax=1000) const;
    void                PrintValueClones(const char *name, TClonesArray *clones, Int_t i, Int_t eoffset, Int_t lenmax=1000) const;
    void                PrintValueSTL(const char *name, TVirtualCollectionProxy *cont, Int_t i, Int_t eoffset, Int_t lenmax=1000) const;
@@ -256,11 +256,11 @@ public:
 
    Int_t               ReadBufferClones(TBuffer &b, TClonesArray *clones, Int_t nc, Int_t first, Int_t eoffset);
    Int_t               ReadBufferSTL(TBuffer &b, TVirtualCollectionProxy *cont, Int_t nc, Int_t eoffset, Bool_t v7 = kTRUE );
-   void                SetCheckSum(UInt_t checksum) {fCheckSum = checksum;}
-   void                SetClass(TClass *cl);
-   void                SetClassVersion(Int_t vers) {fClassVersion=vers;}
-   void                SetOnFileClassVersion(Int_t vers) {fOnFileClassVersion=vers;}
-   void                TagFile(TFile *fFile);
+   void                SetCheckSum(UInt_t checksum) override { fCheckSum = checksum; }
+   void                SetClass(TClass *cl) override;
+   void                SetClassVersion(Int_t vers) override { fClassVersion = vers; }
+   void                SetOnFileClassVersion(Int_t vers) { fOnFileClassVersion = vers; }
+   void                TagFile(TFile *fFile) override;
 private:
    // Try to remove those functions from the public interface.
    Int_t               WriteBuffer(TBuffer &b, char *pointer, Int_t first);
@@ -268,7 +268,7 @@ private:
    Int_t               WriteBufferSTL   (TBuffer &b, TVirtualCollectionProxy *cont,   Int_t nc);
    Int_t               WriteBufferSTLPtrs( TBuffer &b, TVirtualCollectionProxy *cont, Int_t nc, Int_t first, Int_t eoffset);
 public:
-   virtual void        Update(const TClass *oldClass, TClass *newClass);
+   void                Update(const TClass *oldClass, TClass *newClass) override;
 
    /// \brief Generate the TClass and TStreamerInfo for the requested pair.
    /// This creates a TVirtualStreamerInfo for the pair and trigger the BuildCheck/Old to
@@ -276,13 +276,13 @@ public:
    /// std::pair<const int, int> to already exist (or the interpreter information being available)
    /// as it is used as a template.
    /// \note The returned object is owned by the caller.
-   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname, bool silent, size_t hint_pair_offset, size_t hint_pair_size);
-   virtual TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent, size_t hint_pair_offset, size_t hint_pair_size);
+   TVirtualStreamerInfo *GenerateInfoForPair(const std::string &pairclassname, bool silent, size_t hint_pair_offset, size_t hint_pair_size) override;
+   TVirtualStreamerInfo *GenerateInfoForPair(const std::string &firstname, const std::string &secondname, bool silent, size_t hint_pair_offset, size_t hint_pair_size) override;
 
-   virtual TVirtualCollectionProxy *GenEmulatedProxy(const char* class_name, Bool_t silent);
-   virtual TClassStreamer *GenEmulatedClassStreamer(const char* class_name, Bool_t silent);
-   virtual TVirtualCollectionProxy *GenExplicitProxy( const ::ROOT::Detail::TCollectionProxyInfo &info, TClass *cl );
-   virtual TClassStreamer *GenExplicitClassStreamer( const ::ROOT::Detail::TCollectionProxyInfo &info, TClass *cl );
+   TVirtualCollectionProxy *GenEmulatedProxy(const char* class_name, Bool_t silent) override;
+   TClassStreamer *GenEmulatedClassStreamer(const char* class_name, Bool_t silent) override;
+   TVirtualCollectionProxy *GenExplicitProxy(const ::ROOT::Detail::TCollectionProxyInfo &info, TClass *cl) override;
+   TClassStreamer *GenExplicitClassStreamer(const ::ROOT::Detail::TCollectionProxyInfo &info, TClass *cl) override;
 
    static TStreamerElement   *GetCurrentElement();
 
@@ -292,7 +292,7 @@ public:
    Int_t               WriteBufferAux      (TBuffer &b, const T &arr, TCompInfo *const*const compinfo, Int_t first, Int_t last, Int_t narr,Int_t eoffset,Int_t mode);
 
    //WARNING this class version must be the same as TVirtualStreamerInfo
-   ClassDef(TStreamerInfo,9)  //Streamer information for one class version
+   ClassDefOverride(TStreamerInfo,9)  //Streamer information for one class version
 };
 
 

--- a/io/io/inc/TStreamerInfoActions.h
+++ b/io/io/inc/TStreamerInfoActions.h
@@ -82,7 +82,7 @@ namespace TStreamerInfoActions {
    private:
       // assignment operator must be the default because the 'copy' constructor is actually a move constructor and must be used.
    public:
-      TConfiguredAction() : fAction(0), fConfiguration(0) {}
+      TConfiguredAction() : fAction(0), fConfiguration(nullptr) {}
       TConfiguredAction(const TConfiguredAction &rval) : TObject(rval), fAction(rval.fAction), fConfiguration(rval.fConfiguration)
       {
          // WARNING: Technically this is a move constructor ...
@@ -131,7 +131,7 @@ namespace TStreamerInfoActions {
          return fLoopAction(buffer, start_collection, end_collection, loopconf, fConfiguration);
       }
 
-      ClassDef(TConfiguredAction,0); // A configured action
+      ClassDefOverride(TConfiguredAction,0); // A configured action
    };
 
    struct TIDNode;
@@ -217,7 +217,7 @@ namespace TStreamerInfoActions {
       TActionSequence *CreateSubSequence(const TIDs &element_ids, size_t offset, SequenceGetter_t create);
       void AddToSubSequence(TActionSequence *sequence, const TIDs &element_ids, Int_t offset, SequenceGetter_t create);
 
-      void Print(Option_t * = "") const;
+      void Print(Option_t * = "") const override;
 
       // Maybe owner unique_ptr
       struct SequencePtr {
@@ -293,7 +293,7 @@ namespace TStreamerInfoActions {
          auto seq = info->GetWriteMemberWiseActions(kFALSE);
          return {seq, kFALSE};
       }
-      ClassDef(TActionSequence,0);
+      ClassDefOverride(TActionSequence,0);
    };
 
 }

--- a/io/io/inc/TZIPFile.h
+++ b/io/io/inc/TZIPFile.h
@@ -136,12 +136,12 @@ public:
    TZIPFile(const char *archive, const char *member, TFile *file);
    virtual ~TZIPFile() { }
 
-   virtual Int_t OpenArchive();
-   virtual Int_t SetCurrentMember();
+   Int_t      OpenArchive() override;
+   Int_t      SetCurrentMember() override;
 
-   void          Print(Option_t *option = "") const;
+   void       Print(Option_t *option = "") const override;
 
-   ClassDef(TZIPFile,1)  //A ZIP archive file
+   ClassDefOverride(TZIPFile,1)  //A ZIP archive file
 };
 
 /**
@@ -185,9 +185,9 @@ public:
    UInt_t    GetMethod() const { return fMethod; }
    UInt_t    GetLevel() const { return fLevel; }
 
-   void      Print(Option_t *option = "") const;
+   void      Print(Option_t *option = "") const override;
 
-   ClassDef(TZIPMember, 0);  //A ZIP archive member file
+   ClassDefOverride(TZIPMember, 0);  //A ZIP archive member file
 };
 
 #endif

--- a/io/xml/inc/TXMLEngine.h
+++ b/io/xml/inc/TXMLEngine.h
@@ -105,7 +105,7 @@ public:
    void SaveSingleNode(XMLNodePointer_t xmlnode, TString *res, Int_t layout = 1);
    XMLNodePointer_t ReadSingleNode(const char *src);
 
-   ClassDef(TXMLEngine, 1); // ROOT XML I/O parser, user by TXMLFile to read/write xml files
+   ClassDefOverride(TXMLEngine, 1); // ROOT XML I/O parser, user by TXMLFile to read/write xml files
 };
 
 #endif

--- a/net/net/inc/TApplicationRemote.h
+++ b/net/net/inc/TApplicationRemote.h
@@ -96,25 +96,25 @@ public:
    TApplicationRemote(const char *url, Int_t debug = 0, const char *script = 0);
    virtual ~TApplicationRemote();
 
-   virtual void  Browse(TBrowser *b);
-   Bool_t        IsFolder() const { return kTRUE; }
-   const char   *ApplicationName() const { return fName; }
-   Longptr_t     ProcessLine(const char *line, Bool_t /*sync*/ = kFALSE, Int_t *error = 0);
+   void          Browse(TBrowser *b) override;
+   Bool_t        IsFolder() const override { return kTRUE; }
+   const char   *ApplicationName() const override { return fName; }
+   Longptr_t     ProcessLine(const char *line, Bool_t /*sync*/ = kFALSE, Int_t *error = nullptr) override;
 
    Int_t         SendFile(const char *file, Int_t opt = kAscii,
-                          const char *rfile = 0);
+                          const char *rfile = nullptr);
    Int_t         SendObject(const TObject *obj);
 
    void          Interrupt(Int_t type = kRRI_Hard);
    Bool_t        IsValid() const { return (fSocket) ? kTRUE : kFALSE; }
 
-   void          Print(Option_t *option="") const;
+   void          Print(Option_t *option="") const override;
 
-   void          Terminate(Int_t status = 0);
+   void          Terminate(Int_t status = 0) override;
 
    static void   SetPortParam(Int_t lower = -1, Int_t upper = -1, Int_t attempts = -1);
 
-   ClassDef(TApplicationRemote,0)  //Remote Application Interface
+   ClassDefOverride(TApplicationRemote,0)  //Remote Application Interface
 };
 
 //
@@ -126,7 +126,7 @@ private:
 public:
    TARInterruptHandler(TApplicationRemote *r)
       : TSignalHandler(kSigInterrupt, kFALSE), fApplicationRemote(r) { }
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 #endif

--- a/net/net/inc/TApplicationServer.h
+++ b/net/net/inc/TApplicationServer.h
@@ -66,7 +66,7 @@ public:
    TApplicationServer(Int_t *argc, char **argv, FILE *flog, const char *logfile);
    virtual ~TApplicationServer();
 
-   void           GetOptions(Int_t *argc, char **argv);
+   void           GetOptions(Int_t *argc, char **argv) override;
    Int_t          GetProtocol() const   { return fProtocol; }
    Int_t          GetPort() const       { return fUrl.GetPort(); }
    const char    *GetUser() const       { return fUrl.GetUser(); }
@@ -79,19 +79,19 @@ public:
    void           Interrupt() { fInterrupt = kTRUE; }
    Bool_t         IsValid() const { return fIsValid; }
 
-   Longptr_t      ProcessLine(const char *line, Bool_t = kFALSE, Int_t *err = 0);
+   Longptr_t      ProcessLine(const char *line, Bool_t = kFALSE, Int_t *err = nullptr) override;
 
    void           Reset(const char *dir);
    Int_t          ReceiveFile(const char *file, Bool_t bin, Long64_t size);
-   void           Run(Bool_t retrn = kFALSE);
+   void           Run(Bool_t retrn = kFALSE) override;
    void           SendLogFile(Int_t status = 0, Int_t start = -1, Int_t end = -1);
    Int_t          BrowseDirectory(const char *dirname);
    Int_t          BrowseFile(const char *fname);
    Int_t          BrowseKey(const char *keyname);
 
-   void           Terminate(Int_t status);
+   void           Terminate(Int_t status) override;
 
-   ClassDef(TApplicationServer,0)  //Remote Application Interface
+   ClassDefOverride(TApplicationServer,0)  //Remote Application Interface
 };
 
 
@@ -113,8 +113,8 @@ public:
 
    Bool_t IsValid() { return ((fFile && fSocket) ? kTRUE : kFALSE); }
 
-   Bool_t Notify();
-   Bool_t ReadNotify() { return Notify(); }
+   Bool_t Notify() override;
+   Bool_t ReadNotify() override { return Notify(); }
 
    static void SetDefaultPrefix(const char *pfx);
 };

--- a/net/net/inc/TFTP.h
+++ b/net/net/inc/TFTP.h
@@ -73,7 +73,7 @@ public:
    };
 
    TFTP(const char *url, Int_t parallel = 1, Int_t wsize = kDfltWindowSize,
-        TSocket *sock = 0);
+        TSocket *sock = nullptr);
    virtual ~TFTP();
 
    void     SetBlockSize(Int_t blockSize);
@@ -83,10 +83,10 @@ public:
    Int_t    GetMode() const { return fMode; }
 
    Bool_t   IsOpen() const { return fSocket ? kTRUE : kFALSE; }
-   void     Print(Option_t *opt = "") const;
+   void     Print(Option_t *opt = "") const override;
 
-   Long64_t PutFile(const char *file, const char *remoteName = 0);
-   Long64_t GetFile(const char *file, const char *localName = 0);
+   Long64_t PutFile(const char *file, const char *remoteName = nullptr);
+   Long64_t GetFile(const char *file, const char *localName = nullptr);
 
    Bool_t   AccessPathName(const char *path, EAccessMode mode = kFileExists,
                            Bool_t print = kFALSE);
@@ -113,7 +113,7 @@ public:
    void cd(const char *dir) const { ChangeDirectory(dir); }
    void mkdir(const char *dir) const { MakeDirectory(dir); }
    void rmdir(const char *dir) const { DeleteDirectory(dir); }
-   void ls(Option_t *cmd = "") const { ListDirectory(cmd); }
+   void ls(Option_t *cmd = "") const override { ListDirectory(cmd); }
    void pwd() const { PrintDirectory(); }
    void mv(const char *file1, const char *file2) const { RenameFile(file1, file2); }
    void rm(const char *file) const { DeleteFile(file); }
@@ -122,7 +122,7 @@ public:
    void bin() { Binary(); }
    void ascii() { Ascii(); }
 
-   ClassDef(TFTP, 1)  // File Transfer Protocol class using rootd
+   ClassDefOverride(TFTP, 1)  // File Transfer Protocol class using rootd
 };
 
 #endif

--- a/net/net/inc/TFileStager.h
+++ b/net/net/inc/TFileStager.h
@@ -55,7 +55,7 @@ public:
    //--- Load desired plugin
    static TFileStager *Open(const char *stager);
 
-   ClassDef(TFileStager,0)  // ABC defining interface to a stager
+   ClassDefOverride(TFileStager,0)  // ABC defining interface to a stager
 };
 
 #endif

--- a/net/net/inc/TGrid.h
+++ b/net/net/inc/TGrid.h
@@ -53,8 +53,8 @@ protected:
    Int_t          fPort;    // port to which we are connected
 
 public:
-   TGrid() : fGridUrl(), fGrid(), fHost(), fUser(), fPw(), fOptions(), fPort(-1) { }
-   virtual ~TGrid() { }
+   TGrid() : fGridUrl(), fGrid(), fHost(), fUser(), fPw(), fOptions(), fPort(-1) {}
+   virtual ~TGrid() {}
 
    const char    *GridUrl() const { return fGridUrl; }
    const char    *GetGrid() const { return fGrid; }
@@ -72,21 +72,21 @@ public:
    virtual TGridResult *Command(const char * /*command*/,
                                 Bool_t /*interactive*/ = kFALSE,
                                 UInt_t /*stream*/ = 2)
-      { MayNotUse("Command"); return 0; }
+      { MayNotUse("Command"); return nullptr; }
 
    virtual TGridResult *Query(const char * /*path*/, const char * /*pattern*/,
                               const char * /*conditions*/ = "", const char * /*options*/ = "")
-      { MayNotUse("Query"); return 0; }
+      { MayNotUse("Query"); return nullptr; }
 
-   virtual TGridResult *LocateSites() { MayNotUse("LocalSites"); return 0; }
+   virtual TGridResult *LocateSites() { MayNotUse("LocalSites"); return nullptr; }
 
    //--- Catalogue Interface
    virtual TGridResult *Ls(const char* /*ldn*/ ="", Option_t* /*options*/ ="", Bool_t /*verbose*/ =kFALSE)
-      { MayNotUse("Ls"); return 0; }
+      { MayNotUse("Ls"); return nullptr; }
    virtual const char  *Pwd(Bool_t /*verbose*/ =kFALSE)
-      { MayNotUse("Pwd"); return 0; }
+      { MayNotUse("Pwd"); return nullptr; }
    virtual const char  *GetHomeDirectory()
-      { MayNotUse("GetHomeDirectory"); return 0; }
+      { MayNotUse("GetHomeDirectory"); return nullptr; }
    virtual Bool_t Cd(const char* /*ldn*/ ="",Bool_t /*verbose*/ =kFALSE)
       { MayNotUse("Cd"); return kFALSE; }
    virtual Int_t  Mkdir(const char* /*ldn*/ ="", Option_t* /*options*/ ="", Bool_t /*verbose*/ =kFALSE)
@@ -100,29 +100,29 @@ public:
 
    //--- Job Submission Interface
    virtual TGridJob *Submit(const char * /*jdl*/)
-      { MayNotUse("Submit"); return 0; }
+      { MayNotUse("Submit"); return nullptr; }
    virtual TGridJDL *GetJDLGenerator()
-      { MayNotUse("GetJDLGenerator"); return 0; }
+      { MayNotUse("GetJDLGenerator"); return nullptr; }
    virtual TGridCollection *OpenCollection(const char *, UInt_t /*maxentries*/ = 1000000)
-      { MayNotUse("OpenCollection"); return 0; }
+      { MayNotUse("OpenCollection"); return nullptr; }
    virtual TGridCollection *OpenCollectionQuery(TGridResult * /*queryresult*/,Bool_t /*nogrouping*/ = kFALSE)
-      { MayNotUse("OpenCollection"); return 0; }
+      { MayNotUse("OpenCollection"); return nullptr; }
    virtual TGridJobStatusList* Ps(const char* /*options*/, Bool_t /*verbose*/ = kTRUE)
-      { MayNotUse("Ps"); return 0; }
+      { MayNotUse("Ps"); return nullptr; }
    virtual Bool_t KillById(TString /*jobid*/)
       { MayNotUse("KillById"); return kFALSE; }
    virtual Bool_t ResubmitById(TString /*jobid*/)
-      { MayNotUse("ResubmitById"); return 0; }
+      { MayNotUse("ResubmitById"); return kFALSE; }
    virtual Bool_t Kill(TGridJob *gridjob)
       { return ((gridjob)?KillById(gridjob->GetJobID()):kFALSE); }
    virtual Bool_t Resubmit(TGridJob* gridjob)
       { return ((gridjob)?ResubmitById(gridjob->GetJobID()):kFALSE); }
 
    //--- Load desired plugin and setup conection to GRID
-   static TGrid *Connect(const char *grid, const char *uid = 0,
-                         const char *pw = 0, const char *options = 0);
+   static TGrid *Connect(const char *grid, const char *uid = nullptr,
+                         const char *pw = nullptr, const char *options = nullptr);
 
-   ClassDef(TGrid,0)  // ABC defining interface to GRID services
+   ClassDefOverride(TGrid,0)  // ABC defining interface to GRID services
 };
 
 R__EXTERN TGrid *gGrid;

--- a/net/net/inc/TGridCollection.h
+++ b/net/net/inc/TGridCollection.h
@@ -73,7 +73,7 @@ public:
       { MayNotUse("GetExportUrl"); return 0;}
    virtual Bool_t      SetExportUrl(const char * /*exporturl*/ = 0)
       { MayNotUse("SetExportUrl"); return kFALSE;}
-   virtual void         Print(Option_t *) const
+   virtual void         Print(Option_t * = "") const override
       { MayNotUse("Print"); }
    virtual TFile       *OpenFile(const char *)
       { MayNotUse("OpenFile"); return 0;}
@@ -112,7 +112,7 @@ public:
    virtual TFileCollection* GetFileCollection(const char* /*name*/ = "", const char* /*title*/ = "") const
       { MayNotUse("GetFileCollection"); return 0;}
 
-   ClassDef(TGridCollection,1)  // ABC managing collection of files on the Grid
+   ClassDefOverride(TGridCollection,1)  // ABC managing collection of files on the Grid
 };
 
 #endif

--- a/net/net/inc/TGridJDL.h
+++ b/net/net/inc/TGridJDL.h
@@ -45,7 +45,7 @@ public:
    void             AddToSet(const char *key, const char *value);
    void             AddToSetDescription(const char *key, const char *description);
    virtual TString  Generate();
-   virtual void     Clear(const Option_t* = 0);
+   void             Clear(const Option_t* = "") override;
 
    virtual void SetExecutable(const char *value=0, const char *description=0) = 0;
    virtual void SetArguments(const char *value=0, const char *description=0) = 0;
@@ -72,7 +72,7 @@ public:
                               const char *type="VO_ALICE", const char *description=0) = 0;
    virtual void AddToOutputArchive(const char *value=0, const char *description=0) = 0;
 
-   ClassDef(TGridJDL,1)  // ABC defining interface JDL generator
+   ClassDefOverride(TGridJDL,1)  // ABC defining interface JDL generator
 };
 
 #endif

--- a/net/net/inc/TGridJob.h
+++ b/net/net/inc/TGridJob.h
@@ -44,7 +44,7 @@ public:
 
    virtual Bool_t          Resubmit() = 0;
    virtual Bool_t          Cancel () = 0;
-   ClassDef(TGridJob,1)  // ABC defining interface to a GRID job
+   ClassDefOverride(TGridJob,1)  // ABC defining interface to a GRID job
 };
 
 #endif

--- a/net/net/inc/TGridJobStatus.h
+++ b/net/net/inc/TGridJobStatus.h
@@ -37,7 +37,7 @@ public:
   // implementation
   virtual EGridJobStatus GetStatus() const = 0;
 
-  ClassDef(TGridJobStatus,1)  // ABC defining status of a Grid job
+  ClassDefOverride(TGridJobStatus,1)  // ABC defining status of a Grid job
 };
 
 #endif

--- a/net/net/inc/TGridJobStatusList.h
+++ b/net/net/inc/TGridJobStatusList.h
@@ -36,7 +36,7 @@ public:
    TGridJobStatusList() : fJobID("") { }
    virtual ~TGridJobStatusList() { }
 
-   ClassDef(TGridJobStatusList,1)  // ABC defining interface to a list of GRID jobs
+   ClassDefOverride(TGridJobStatusList,1)  // ABC defining interface to a list of GRID jobs
 };
 
 R__EXTERN TGridJobStatusList *gGridJobStatusList;

--- a/net/net/inc/TGridResult.h
+++ b/net/net/inc/TGridResult.h
@@ -35,21 +35,21 @@ public:
    virtual ~TGridResult() { }
 
    virtual const char *GetFileName(UInt_t) const
-      { MayNotUse("GetFileName"); return 0; }
+      { MayNotUse("GetFileName"); return nullptr; }
    virtual const char *GetFileNamePath(UInt_t) const
-      { MayNotUse("GetFileNamePath"); return 0; }
+      { MayNotUse("GetFileNamePath"); return nullptr; }
    virtual const char *GetPath(UInt_t) const
-      { MayNotUse("GetPath"); return 0; }
+      { MayNotUse("GetPath"); return nullptr; }
    virtual const TEntryList *GetEntryList(UInt_t) const
-      { MayNotUse("GetEntryList"); return 0; }
+      { MayNotUse("GetEntryList"); return nullptr; }
    virtual const char *GetKey(UInt_t, const char*) const
-      { MayNotUse("GetKey"); return 0; }
+      { MayNotUse("GetKey"); return nullptr; }
    virtual Bool_t      SetKey(UInt_t, const char*, const char*)
-      { MayNotUse("SetKey"); return 0; }
+      { MayNotUse("SetKey"); return kFALSE; }
    virtual TList      *GetFileInfoList() const
-      { MayNotUse("GetFileInfoList"); return 0; }
+      { MayNotUse("GetFileInfoList"); return nullptr; }
 
-   ClassDef(TGridResult,1)  // ABC defining interface to GRID result set
+   ClassDefOverride(TGridResult,1)  // ABC defining interface to GRID result set
 };
 
 #endif

--- a/net/net/inc/TMonitor.h
+++ b/net/net/inc/TMonitor.h
@@ -48,7 +48,7 @@ private:
    Bool_t    fInterrupt;  //flags an interrupt to Select
 
    void  SetReady(TSocket *sock);
-   void *GetSender() { return this; }  // used to get gTQSender
+   void *GetSender() override { return this; }  // used to get gTQSender
 
 public:
    enum EInterest { kRead = 1, kWrite = 2 };
@@ -82,7 +82,7 @@ public:
 
    Bool_t IsActive(TSocket *s) const;
 
-   ClassDef(TMonitor,0)  //Monitor activity on a set of TSocket objects
+   ClassDefOverride(TMonitor,0)  //Monitor activity on a set of TSocket objects
 };
 
 #endif

--- a/net/net/inc/TNetFile.h
+++ b/net/net/inc/TNetFile.h
@@ -50,35 +50,35 @@ protected:
                               Bool_t forceRead);
    virtual void Create(const char *url, Option_t *option, Int_t netopt);
    virtual void Create(TSocket *s, Option_t *option, Int_t netopt);
-   void         Init(Bool_t create);
-   void         Print(Option_t *option) const;
+   void         Init(Bool_t create) override;
+   void         Print(Option_t *option) const override;
    void         PrintError(const char *where, Int_t err);
    Int_t        Recv(Int_t &status, EMessageTypes &kind);
-   Int_t        SysOpen(const char *pathname, Int_t flags, UInt_t mode);
-   Int_t        SysClose(Int_t fd);
-   Int_t        SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime);
+   Int_t        SysOpen(const char *pathname, Int_t flags, UInt_t mode) override;
+   Int_t        SysClose(Int_t fd) override;
+   Int_t        SysStat(Int_t fd, Long_t *id, Long64_t *size, Long_t *flags, Long_t *modtime) override;
 
 public:
    TNetFile(const char *url, Option_t *option = "", const char *ftitle = "",
             Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault, Int_t netopt = 0);
-   TNetFile() : fEndpointUrl(), fUser(), fSocket(0), fProtocol(0), fErrorCode(0), fNetopt(0) { }
+   TNetFile() : fEndpointUrl(), fUser(), fSocket(nullptr), fProtocol(0), fErrorCode(0), fNetopt(0) { }
    virtual ~TNetFile();
 
-   void    Close(Option_t *option="");  // *MENU*
-   void    Flush();
+   void    Close(Option_t *option="") override;  // *MENU*
+   void    Flush() override;
    Int_t   GetErrorCode() const { return fErrorCode; }
-   Bool_t  IsOpen() const;
-   Bool_t  Matches(const char *url);
-   Int_t   ReOpen(Option_t *mode);
-   Bool_t  ReadBuffer(char *buf, Int_t len);
-   Bool_t  ReadBuffer(char *buf, Long64_t pos, Int_t len);
-   Bool_t  ReadBuffers(char *buf,  Long64_t *pos, Int_t *len, Int_t nbuf);
-   Bool_t  WriteBuffer(const char *buf, Int_t len);
-   void    Seek(Long64_t offset, ERelativeTo pos = kBeg);
+   Bool_t  IsOpen() const override;
+   Bool_t  Matches(const char *url) override;
+   Int_t   ReOpen(Option_t *mode) override;
+   Bool_t  ReadBuffer(char *buf, Int_t len) override;
+   Bool_t  ReadBuffer(char *buf, Long64_t pos, Int_t len) override;
+   Bool_t  ReadBuffers(char *buf,  Long64_t *pos, Int_t *len, Int_t nbuf) override;
+   Bool_t  WriteBuffer(const char *buf, Int_t len) override;
+   void    Seek(Long64_t offset, ERelativeTo pos = kBeg) override;
 
-   const TUrl *GetEndpointUrl() const { return &fEndpointUrl; }
+   const TUrl *GetEndpointUrl() const override { return &fEndpointUrl; }
 
-   ClassDef(TNetFile,1)  //A ROOT file that reads/writes via a rootd server
+   ClassDefOverride(TNetFile,1)  //A ROOT file that reads/writes via a rootd server
 };
 
 
@@ -93,16 +93,16 @@ private:
    TString     fUser;        // Remote user
    Int_t       fPort;        // Remote port
 
-   TNetSystem(const TNetSystem&);             // not implemented
-   TNetSystem& operator=(const TNetSystem&);  // not implemented
+   TNetSystem(const TNetSystem&) = delete;
+   TNetSystem& operator=(const TNetSystem&) = delete;
 
-   void       *GetDirPtr() const { return fDirp; }
+   void       *GetDirPtr() const override { return fDirp; }
 
 protected:
    Bool_t      fIsLocal;     // TRUE if the path points to this host
    TString     fLocalPrefix; // if fIsLocal, prefix to be prepend locally
 
-   void        Create(const char *url, TSocket *sock = 0);
+   void        Create(const char *url, TSocket *sock = nullptr);
    void        InitRemoteEntity(const char *url);
 
 public:
@@ -110,16 +110,16 @@ public:
    TNetSystem(const char *url, Bool_t ftpowner = kTRUE);
    virtual ~TNetSystem();
 
-   Bool_t      ConsistentWith(const char *path, void *dirptr);
-   Int_t       MakeDirectory(const char *name);
-   void       *OpenDirectory(const char *name);
-   void        FreeDirectory(void *dirp = 0);
-   const char *GetDirEntry(void *dirp = 0);
-   Int_t       GetPathInfo(const char *path, FileStat_t &buf);
-   Bool_t      AccessPathName(const char *path, EAccessMode mode);
-   int         Unlink(const char *path);
+   Bool_t      ConsistentWith(const char *path, void *dirptr) override;
+   Int_t       MakeDirectory(const char *name) override;
+   void       *OpenDirectory(const char *name) override;
+   void        FreeDirectory(void *dirp = nullptr) override;
+   const char *GetDirEntry(void *dirp = nullptr) override;
+   Int_t       GetPathInfo(const char *path, FileStat_t &buf) override;
+   Bool_t      AccessPathName(const char *path, EAccessMode mode) override;
+   int         Unlink(const char *path) override;
 
-   ClassDef(TNetSystem,0)  // Directory handler for NetSystem
+   ClassDefOverride(TNetSystem,0)  // Directory handler for NetSystem
 };
 
 #endif

--- a/net/net/inc/TNetFileStager.h
+++ b/net/net/inc/TNetFileStager.h
@@ -37,15 +37,15 @@ public:
    TNetFileStager(const char *stager = "");
    virtual ~TNetFileStager();
 
-   Bool_t  IsStaged(const char *path);
-   Int_t   Locate(const char *path, TString &endpath);
-   Bool_t  Matches(const char *s);
+   Bool_t  IsStaged(const char *path) override;
+   Int_t   Locate(const char *path, TString &endpath) override;
+   Bool_t  Matches(const char *s) override;
 
-   Bool_t  IsValid() const { return (fSystem ? kTRUE : kFALSE); }
+   Bool_t  IsValid() const override { return fSystem ? kTRUE : kFALSE; }
 
-   void    Print(Option_t *option = "") const;
+   void    Print(Option_t *option = "") const override;
 
-   ClassDef(TNetFileStager,0)  // Implementation for a 'rootd' backend
+   ClassDefOverride(TNetFileStager,0)  // Implementation for a 'rootd' backend
 };
 
 #endif

--- a/net/net/inc/TPServerSocket.h
+++ b/net/net/inc/TPServerSocket.h
@@ -35,8 +35,8 @@ class TPServerSocket : public TServerSocket {
 private:
    Int_t  fTcpWindowSize; // size of tcp window (for window scaling)
 
-   TPServerSocket(const TPServerSocket &);  // not implemented
-   void operator=(const TPServerSocket &);  // idem
+   TPServerSocket(const TPServerSocket &) = delete;
+   void operator=(const TPServerSocket &) = delete;
 
 public:
    TPServerSocket(Int_t port, Bool_t reuse = kFALSE,
@@ -46,11 +46,11 @@ public:
                   Int_t backlog = kDefaultBacklog,
                   Int_t tcpwindowsize = -1);
 
-   virtual ~TPServerSocket() { }
+   virtual ~TPServerSocket() {}
 
-   virtual TSocket *Accept(UChar_t Opt = kSrvNoAuth);
+   TSocket *Accept(UChar_t Opt = kSrvNoAuth) override;
 
-   ClassDef(TPServerSocket,0)  // Parallel server socket
+   ClassDefOverride(TPServerSocket,0)  // Parallel server socket
 };
 
 #endif

--- a/net/net/inc/TPSocket.h
+++ b/net/net/inc/TPSocket.h
@@ -45,10 +45,10 @@ private:
    char      **fReadPtr;         // pointer to read buffer for specified socket
 
    TPSocket(TSocket *pSockets[], Int_t size);
-   TPSocket(const TPSocket &);        // not implemented
-   void operator=(const TPSocket &);  // idem
-   void Init(Int_t tcpwindowsize, TSocket *sock = 0);
-   Option_t *GetOption() const { return TObject::GetOption(); }
+   TPSocket(const TPSocket &) = delete;
+   void operator=(const TPSocket &) = delete;
+   void Init(Int_t tcpwindowsize, TSocket *sock = nullptr);
+   Option_t *GetOption() const override { return TObject::GetOption(); }
 
 public:
    TPSocket(TInetAddress address, const char *service, Int_t size,
@@ -61,28 +61,28 @@ public:
    TPSocket(const char *host, Int_t port, Int_t size, TSocket *sock);
    virtual ~TPSocket();
 
-   void          Close(Option_t *opt="");
-   Int_t         GetDescriptor() const;
-   TInetAddress  GetLocalInetAddress();
+   void          Close(Option_t *opt="") override;
+   Int_t         GetDescriptor() const override;
+   TInetAddress  GetLocalInetAddress() override;
 
-   Int_t   Send(const TMessage &mess);
-   Int_t   Send(Int_t kind) { return TSocket::Send(kind); }
-   Int_t   Send(Int_t status, Int_t kind) { return TSocket::Send(status, kind); }
-   Int_t   Send(const char *mess, Int_t kind = kMESS_STRING) { return TSocket::Send(mess, kind); }
-   Int_t   SendRaw(const void *buffer, Int_t length, ESendRecvOptions opt);
-   Int_t   Recv(TMessage *&mess);
-   Int_t   Recv(Int_t &status, Int_t &kind) { return TSocket::Recv(status, kind); }
-   Int_t   Recv(char *mess, Int_t max) { return TSocket::Recv(mess, max); }
-   Int_t   Recv(char *mess, Int_t max, Int_t &kind) { return TSocket::Recv(mess, max, kind); }
-   Int_t   RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt);
+   Int_t   Send(const TMessage &mess) override;
+   Int_t   Send(Int_t kind) override { return TSocket::Send(kind); }
+   Int_t   Send(Int_t status, Int_t kind) override { return TSocket::Send(status, kind); }
+   Int_t   Send(const char *mess, Int_t kind = kMESS_STRING) override { return TSocket::Send(mess, kind); }
+   Int_t   SendRaw(const void *buffer, Int_t length, ESendRecvOptions opt) override;
+   Int_t   Recv(TMessage *&mess) override;
+   Int_t   Recv(Int_t &status, Int_t &kind) override { return TSocket::Recv(status, kind); }
+   Int_t   Recv(char *mess, Int_t max) override { return TSocket::Recv(mess, max); }
+   Int_t   Recv(char *mess, Int_t max, Int_t &kind) override { return TSocket::Recv(mess, max, kind); }
+   Int_t   RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt) override;
 
-   Bool_t  IsValid() const { return fSockets ? kTRUE : kFALSE; }
+   Bool_t  IsValid() const override { return fSockets ? kTRUE : kFALSE; }
    Int_t   GetErrorCode() const;
-   Int_t   SetOption(ESockOptions opt, Int_t val);
-   Int_t   GetOption(ESockOptions opt, Int_t &val);
+   Int_t   SetOption(ESockOptions opt, Int_t val) override;
+   Int_t   GetOption(ESockOptions opt, Int_t &val) override;
    Int_t   GetSize() const { return fSize; }
 
-   ClassDef(TPSocket,0)  // Parallel client socket
+   ClassDefOverride(TPSocket,0)  // Parallel client socket
 };
 
 #endif

--- a/net/net/inc/TParallelMergingFile.h
+++ b/net/net/inc/TParallelMergingFile.h
@@ -49,13 +49,13 @@ public:
    TParallelMergingFile(const char *filename, Option_t *option = "", const char *ftitle = "", Int_t compress = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
    ~TParallelMergingFile();
 
-   virtual void   Close(Option_t *option="");
-           Bool_t UploadAndReset();
-   virtual Int_t  Write(const char *name=0, Int_t opt=0, Int_t bufsiz=0);
-   virtual Int_t  Write(const char *name=0, Int_t opt=0, Int_t bufsiz=0) const;
-   virtual void   WriteStreamerInfo();
+   void   Close(Option_t *option="") override;
+   Bool_t UploadAndReset();
+   Int_t  Write(const char *name=nullptr, Int_t opt=0, Int_t bufsiz=0) override;
+   Int_t  Write(const char *name=nullptr, Int_t opt=0, Int_t bufsiz=0) const override;
+   void   WriteStreamerInfo() override;
 
-   ClassDef(TParallelMergingFile, 0);  // TFile specialization that will semi-automatically upload its content to a merging server.
+   ClassDefOverride(TParallelMergingFile, 0);  // TFile specialization that will semi-automatically upload its content to a merging server.
 };
 
 #endif // ROOT_TParallelMergingFile

--- a/net/net/inc/TS3HTTPRequest.h
+++ b/net/net/inc/TS3HTTPRequest.h
@@ -80,7 +80,7 @@ public:
                 EAuthType authType, const TString& accessKey,
                 const TString& secretKey);
    TS3HTTPRequest(const TS3HTTPRequest& m);
-   virtual ~TS3HTTPRequest() { }
+   virtual ~TS3HTTPRequest() {}
 
    EHTTPVerb       GetHTTPVerb() const { return fVerb; }
    const TString&  GetHost() const { return fHost; }
@@ -101,7 +101,7 @@ public:
    TS3HTTPRequest& SetAuthType(TS3HTTPRequest::EAuthType authType);
    TS3HTTPRequest& SetSessionToken(const TString& token);
 
-   ClassDef(TS3HTTPRequest, 0)  // Create generic HTTP request for Amazon S3 and Google Storage services
+   ClassDefOverride(TS3HTTPRequest, 0)  // Create generic HTTP request for Amazon S3 and Google Storage services
 };
 
 

--- a/net/net/inc/TS3WebFile.h
+++ b/net/net/inc/TS3WebFile.h
@@ -75,9 +75,9 @@ private:
 
 protected:
    // Super-class methods extended by this class
-   virtual Int_t GetHead();
-   virtual void SetMsgReadBuffer10(const char* redirectLocation = 0, Bool_t tempRedirect = kFALSE);
-   virtual void ProcessHttpHeader(const TString& headerLine);
+   Int_t GetHead() override;
+   void SetMsgReadBuffer10(const char* redirectLocation = nullptr, Bool_t tempRedirect = kFALSE) override;
+   void ProcessHttpHeader(const TString& headerLine) override;
 
    // Modifiers of data members (to be used mainly by subclasses)
    void SetAccessKey(const TString& accessKey) { fS3Request.SetAccessKey(accessKey); }
@@ -100,9 +100,9 @@ public:
    const TUrl&     GetUrl() const { return fUrl; }
 
    // Modifiers
-   virtual Bool_t ReadBuffers(char* buf, Long64_t* pos, Int_t* len, Int_t nbuf);
+   Bool_t ReadBuffers(char* buf, Long64_t* pos, Int_t* len, Int_t nbuf) override;
 
-   ClassDef(TS3WebFile, 0)  // Read a ROOT file from a S3 server
+   ClassDefOverride(TS3WebFile, 0)  // Read a ROOT file from a S3 server
 };
 
 #endif // ROOT_TS3WebFile

--- a/net/net/inc/TSQLColumnInfo.h
+++ b/net/net/inc/TSQLColumnInfo.h
@@ -50,9 +50,9 @@ public:
    Bool_t      IsSigned()    const { return fSigned==1; }
    Bool_t      IsUnsigned()  const { return fSigned==0; }
 
-   virtual void Print(Option_t* option = "") const;
+   void Print(Option_t* option = "") const override;
 
-   ClassDef(TSQLColumnInfo, 0) // Summury information about column from SQL table
+   ClassDefOverride(TSQLColumnInfo, 0) // Summury information about column from SQL table
 };
 
 #endif

--- a/net/net/inc/TSQLMonitoring.h
+++ b/net/net/inc/TSQLMonitoring.h
@@ -37,18 +37,18 @@ private:
 
    Bool_t       fVerbose;         // Verbosity toggle
 
-   TSQLMonitoringWriter(const TSQLMonitoringWriter&);            // not implemented
-   TSQLMonitoringWriter& operator=(const TSQLMonitoringWriter&); // not implemented
+   TSQLMonitoringWriter(const TSQLMonitoringWriter&) = delete;
+   TSQLMonitoringWriter& operator=(const TSQLMonitoringWriter&) = delete;
 
 public:
    TSQLMonitoringWriter(const char *serv, const char *user, const char *pass, const char *table);
    virtual ~TSQLMonitoringWriter();
 
-   Bool_t SendParameters(TList *values, const char * /*identifier*/);
+   Bool_t SendParameters(TList *values, const char * /*identifier*/) override;
 
-   void Verbose(Bool_t onoff) { fVerbose = onoff; }
+   void Verbose(Bool_t onoff) override { fVerbose = onoff; }
 
-   ClassDef(TSQLMonitoringWriter, 0)   // Sending monitoring data to a SQL DB
+   ClassDefOverride(TSQLMonitoringWriter, 0)   // Sending monitoring data to a SQL DB
 };
 
 #endif

--- a/net/net/inc/TSQLResult.h
+++ b/net/net/inc/TSQLResult.h
@@ -28,16 +28,15 @@
 
 class  TSQLRow;
 
-
 class TSQLResult : public TObject {
 
 protected:
    Int_t    fRowCount;   // number of rows in result
 
-   TSQLResult() : fRowCount(0) { }
+   TSQLResult() : fRowCount(0) {}
 
 public:
-   virtual ~TSQLResult() { }
+   virtual ~TSQLResult() {}
 
    virtual void        Close(Option_t *option="") = 0;
    virtual Int_t       GetFieldCount() = 0;
@@ -45,7 +44,7 @@ public:
    virtual Int_t       GetRowCount() const { return fRowCount; }
    virtual TSQLRow    *Next() = 0;
 
-   ClassDef(TSQLResult,0)  // SQL query result
+   ClassDefOverride(TSQLResult,0)  // SQL query result
 };
 
 #endif

--- a/net/net/inc/TSQLRow.h
+++ b/net/net/inc/TSQLRow.h
@@ -30,17 +30,17 @@
 class TSQLRow : public TObject {
 
 protected:
-   TSQLRow() { }
+   TSQLRow() {}
 
 public:
-   virtual ~TSQLRow() { }
+   virtual ~TSQLRow() {}
 
    virtual void        Close(Option_t *option="") = 0;
    virtual ULong_t     GetFieldLength(Int_t field) = 0;
    virtual const char *GetField(Int_t field) = 0;
    const char         *operator[](Int_t field) { return GetField(field); }
 
-   ClassDef(TSQLRow,0)  // One row of an SQL query result
+   ClassDefOverride(TSQLRow,0)  // One row of an SQL query result
 };
 
 #endif

--- a/net/net/inc/TSQLServer.h
+++ b/net/net/inc/TSQLServer.h
@@ -96,7 +96,7 @@ public:
    const char         *GetHost() const { return fHost.Data(); }
    Int_t               GetPort() const { return fPort; }
 
-   virtual Bool_t      IsError() const { return GetErrorCode()!=0; }
+   virtual Bool_t      IsError() const { return GetErrorCode() != 0; }
    virtual Int_t       GetErrorCode() const;
    virtual const char* GetErrorMsg() const;
    virtual void        EnableErrorOutput(Bool_t on = kTRUE) { fErrorOut = on; }
@@ -114,7 +114,7 @@ public:
    static    void     SetFloatFormat(const char* fmt = "%e");
    static const char* GetFloatFormat();
 
-   ClassDef(TSQLServer,0)  // Connection to SQL server
+   ClassDefOverride(TSQLServer,0)  // Connection to SQL server
 };
 
 #endif

--- a/net/net/inc/TSQLStatement.h
+++ b/net/net/inc/TSQLStatement.h
@@ -38,7 +38,7 @@ public:
 
    virtual Bool_t      NextIteration() = 0;
 
-   virtual   void      Close(Option_t * = "") {}
+   virtual void        Close(Option_t * = "") {}
 
    virtual Bool_t      SetNull(Int_t) { return kFALSE; }
    virtual Bool_t      SetInt(Int_t, Int_t) { return kFALSE; }
@@ -114,7 +114,7 @@ public:
    virtual const char* GetErrorMsg() const;
    virtual void        EnableErrorOutput(Bool_t on = kTRUE) { fErrorOut = on; }
 
-   ClassDef(TSQLStatement, 0) //SQL statement
+   ClassDefOverride(TSQLStatement, 0) //SQL statement
 };
 
 #endif

--- a/net/net/inc/TSQLTableInfo.h
+++ b/net/net/inc/TSQLTableInfo.h
@@ -30,12 +30,12 @@ public:
    TSQLTableInfo(const char* tablename,
                  TList* columns,
                  const char* comment = "SQL table",
-                 const char* engine = 0,
-                 const char* create_time = 0,
-                 const char* update_time = 0);
+                 const char* engine = nullptr,
+                 const char* create_time = nullptr,
+                 const char* update_time = nullptr);
    virtual ~TSQLTableInfo();
 
-   virtual void Print(Option_t* option = "") const;
+   void Print(Option_t* option = "") const override;
 
    TList* GetColumns() const { return fColumns; }
 
@@ -45,7 +45,7 @@ public:
    const char* GetCreateTime() const { return fCreateTime.Data(); }
    const char* GetUpdateTime() const { return fUpdateTime.Data(); }
 
-   ClassDef(TSQLTableInfo, 0) // Summury information about SQL table
+   ClassDefOverride(TSQLTableInfo, 0) // Summary information about SQL table
 };
 
 #endif

--- a/net/net/inc/TSSLSocket.h
+++ b/net/net/inc/TSSLSocket.h
@@ -53,7 +53,7 @@ public:
    TSSLSocket(const TSSLSocket &s);
    virtual ~TSSLSocket();
 
-   void  Close(Option_t *option="");
+   void Close(Option_t *option="") override;
 
    // Set up the SSL environment for the next instantiation
    static void SetUpSSL(const char *cafile, const char *capath,
@@ -61,21 +61,21 @@ public:
 
    // The rest of the Send and Recv calls rely ultimately on these,
    // so it is enough to overload them
-   Int_t Recv(TMessage *&mess);
-   Int_t RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt = kDefault);
-   Int_t Send(const TMessage &mess);
+   Int_t Recv(TMessage *&mess) override;
+   Int_t RecvRaw(void *buffer, Int_t length, ESendRecvOptions opt = kDefault) override;
+   Int_t Send(const TMessage &mess) override;
    Int_t SendRaw(const void *buffer, Int_t length,
-                 ESendRecvOptions opt = kDefault);
+                 ESendRecvOptions opt = kDefault) override;
 
    // Issue with hidden method :(
-   Int_t Send(Int_t kind)                                  { return TSocket::Send(kind); }
-   Int_t Send(Int_t status, Int_t kind)                    { return TSocket::Send(status, kind); }
-   Int_t Send(const char *mess, Int_t kind = kMESS_STRING) { return TSocket::Send(mess, kind); }
-   Int_t Recv(Int_t &status, Int_t &kind)                  { return TSocket::Recv(status, kind); }
-   Int_t Recv(char *mess, Int_t max)                       { return TSocket::Recv(mess, max); }
-   Int_t Recv(char *mess, Int_t max, Int_t &kind)          { return TSocket::Recv(mess, max, kind); }
+   Int_t Send(Int_t kind) override                         { return TSocket::Send(kind); }
+   Int_t Send(Int_t status, Int_t kind) override           { return TSocket::Send(status, kind); }
+   Int_t Send(const char *mess, Int_t kind = kMESS_STRING) override { return TSocket::Send(mess, kind); }
+   Int_t Recv(Int_t &status, Int_t &kind) override         { return TSocket::Recv(status, kind); }
+   Int_t Recv(char *mess, Int_t max) override              { return TSocket::Recv(mess, max); }
+   Int_t Recv(char *mess, Int_t max, Int_t &kind) override { return TSocket::Recv(mess, max, kind); }
 
-   ClassDef(TSSLSocket,0)  // SSL wrapped socket
+   ClassDefOverride(TSSLSocket,0)  // SSL wrapped socket
 };
 
 #endif

--- a/net/net/inc/TSecContext.h
+++ b/net/net/inc/TSecContext.h
@@ -84,14 +84,14 @@ public:
    Bool_t      IsA(const char *methodname);
    Bool_t      IsActive()   const;
 
-   virtual void Print(Option_t *option = "F") const;
+   void Print(Option_t *option = "F") const override;
 
    void        SetExpDate(TDatime expdate)  { fExpDate= expdate; }
    void        SetID(const char *id)        { fID= id; }
    void        SetOffSet(Int_t offset)      { fOffSet = offset; }
    void        SetUser(const char *user)    { fUser   = user; }
 
-   ClassDef(TSecContext,0)  // Class providing host specific authentication information
+   ClassDefOverride(TSecContext,0)  // Class providing host specific authentication information
 };
 
 //
@@ -121,7 +121,7 @@ public:
    Int_t   GetProtocol() const { return fServerProtocol; }
    Int_t   GetType() const { return fServerType; }
 
-   ClassDef(TSecContextCleanup,0) //Update the remote authentication table
+   ClassDefOverride(TSecContextCleanup,0) //Update the remote authentication table
 };
 
 //
@@ -143,7 +143,6 @@ public:
    Bool_t      IsPwHash() const { return fPwHash; }
 
 };
-
 
 
 #endif

--- a/net/net/inc/TServerSocket.h
+++ b/net/net/inc/TServerSocket.h
@@ -62,37 +62,37 @@ public:
    virtual ~TServerSocket();
 
    virtual TSocket      *Accept(UChar_t Opt = 0);
-   virtual TInetAddress  GetLocalInetAddress();
-   virtual Int_t         GetLocalPort();
+   TInetAddress  GetLocalInetAddress() override;
+   Int_t         GetLocalPort() override;
 
-   Int_t         Send(const TMessage &)
+   Int_t         Send(const TMessage &) override
                     { MayNotUse("Send(const TMessage &)"); return 0; }
-   Int_t         Send(Int_t)
+   Int_t         Send(Int_t) override
                     { MayNotUse("Send(Int_t)"); return 0; }
-   Int_t         Send(Int_t, Int_t)
+   Int_t         Send(Int_t, Int_t) override
                     { MayNotUse("Send(Int_t, Int_t)"); return 0; }
-   Int_t         Send(const char *, Int_t = kMESS_STRING)
+   Int_t         Send(const char *, Int_t = kMESS_STRING) override
                     { MayNotUse("Send(const char *, Int_t)"); return 0; }
-   Int_t         SendObject(const TObject *, Int_t = kMESS_OBJECT)
+   Int_t         SendObject(const TObject *, Int_t = kMESS_OBJECT) override
                     { MayNotUse("SendObject(const TObject *, Int_t)"); return 0; }
-   Int_t         SendRaw(const void *, Int_t, ESendRecvOptions = kDefault)
+   Int_t         SendRaw(const void *, Int_t, ESendRecvOptions = kDefault) override
                     { MayNotUse("SendRaw(const void *, Int_t, ESendRecvOptions)"); return 0; }
-   Int_t         Recv(TMessage *&)
+   Int_t         Recv(TMessage *&) override
                     { MayNotUse("Recv(TMessage *&)"); return 0; }
-   Int_t         Recv(Int_t &, Int_t &)
+   Int_t         Recv(Int_t &, Int_t &) override
                     { MayNotUse("Recv(Int_t &, Int_t &)"); return 0; }
-   Int_t         Recv(char *, Int_t)
+   Int_t         Recv(char *, Int_t) override
                     { MayNotUse("Recv(char *, Int_t)"); return 0; }
-   Int_t         Recv(char *, Int_t, Int_t &)
+   Int_t         Recv(char *, Int_t, Int_t &) override
                     { MayNotUse("Recv(char *, Int_t, Int_t &)"); return 0; }
-   Int_t         RecvRaw(void *, Int_t, ESendRecvOptions = kDefault)
+   Int_t         RecvRaw(void *, Int_t, ESendRecvOptions = kDefault) override
                     { MayNotUse("RecvRaw(void *, Int_t, ESendRecvOptions)"); return 0; }
 
    static UChar_t     GetAcceptOptions();
    static void        SetAcceptOptions(UChar_t Opt);
    static void        ShowAcceptOptions();
 
-   ClassDef(TServerSocket, 0);  //This class implements server sockets
+   ClassDefOverride(TServerSocket, 0);  //This class implements server sockets
 };
 
 #endif

--- a/net/net/inc/TSocket.h
+++ b/net/net/inc/TSocket.h
@@ -94,8 +94,8 @@ protected:
    void         MarkBrokenConnection();
 
 private:
-   TSocket&      operator=(const TSocket &);  // not implemented
-   Option_t     *GetOption() const { return TObject::GetOption(); }
+   TSocket&      operator=(const TSocket &) = delete;
+   Option_t     *GetOption() const override { return TObject::GetOption(); }
 
 public:
    TSocket(TInetAddress address, const char *service, Int_t tcpwindowsize = -1);
@@ -127,7 +127,7 @@ public:
    TSecContext          *GetSecContext() const { return fSecContext; }
    Int_t                 GetTcpWindowSize() const { return fTcpWindowSize; }
    TTimeStamp            GetLastUsage() { R__LOCKGUARD2(fLastUsageMtx); return fLastUsage; }
-   const char           *GetUrl() const { return fUrl; }
+   const char           *GetUrl() const { return fUrl.Data(); }
    virtual Bool_t        IsAuthenticated() const { return fSecContext ? kTRUE : kFALSE; }
    virtual Bool_t        IsValid() const { return fSocket < 0 ? kFALSE : kTRUE; }
    virtual Int_t         Recv(TMessage *&mess);
@@ -168,7 +168,7 @@ public:
                                           Int_t tcpwindowsize = -1, TSocket *s = 0, Int_t *err = 0);
    static void           NetError(const char *where, Int_t error);
 
-   ClassDef(TSocket,0)  //This class implements client sockets
+   ClassDefOverride(TSocket,0)  //This class implements client sockets
 };
 
 //______________________________________________________________________________

--- a/net/net/inc/TUDPSocket.h
+++ b/net/net/inc/TUDPSocket.h
@@ -68,9 +68,9 @@ protected:
    static ULong64_t fgBytesSent;  // total bytes sent by all socket objects
 
    TUDPSocket() : fAddress(), fBytesRecv(0), fBytesSent(0), fCompress(0),
-                  fLocalAddress(), fRemoteProtocol(), fSecContext(0), fService(),
+                  fLocalAddress(), fRemoteProtocol(), fSecContext(nullptr), fService(),
                   fServType(kSOCKD), fSocket(-1), fUrl(),
-                  fBitsInfo(), fUUIDs(0), fLastUsageMtx(0), fLastUsage() { }
+                  fBitsInfo(), fUUIDs(nullptr), fLastUsageMtx(0), fLastUsage() { }
 
    void         SetDescriptor(Int_t desc) { fSocket = desc; }
    void         SendStreamerInfos(const TMessage &mess);
@@ -79,8 +79,8 @@ protected:
    Bool_t       RecvProcessIDs(TMessage *mess);
 
 private:
-   TUDPSocket&   operator=(const TUDPSocket &);  // not implemented
-   Option_t     *GetOption() const { return TObject::GetOption(); }
+   TUDPSocket&   operator=(const TUDPSocket &) = delete;
+   Option_t     *GetOption() const override { return TObject::GetOption(); }
 
 public:
    TUDPSocket(TInetAddress address, const char *service);
@@ -148,7 +148,7 @@ public:
 
    static void           NetError(const char *where, Int_t error);
 
-   ClassDef(TUDPSocket,0)  //This class implements UDP client sockets
+   ClassDefOverride(TUDPSocket,0)  //This class implements UDP client sockets
 };
 
 //______________________________________________________________________________

--- a/net/net/inc/TWebFile.h
+++ b/net/net/inc/TWebFile.h
@@ -36,7 +36,7 @@ friend class TWebSocket;
 friend class TWebSystem;
 
 private:
-   TWebFile() : fSocket(0) { }
+   TWebFile() : fSocket(nullptr) {}
 
 protected:
    mutable Long64_t  fSize;             // file size
@@ -57,7 +57,7 @@ protected:
    static TUrl       fgProxy;           // globally set proxy URL
    static Long64_t   fgMaxFullCacheSize; // maximal size of full-cached content, 500 MB by default
 
-   virtual void        Init(Bool_t readHeadOnly);
+           void        Init(Bool_t readHeadOnly) override;
    virtual void        CheckProxy();
    virtual TString     BasicAuthentication();
    virtual Int_t       GetHead();
@@ -77,13 +77,13 @@ public:
    TWebFile(TUrl url, Option_t *opt="");
    virtual ~TWebFile();
 
-   virtual Long64_t    GetSize() const;
-   virtual Bool_t      IsOpen() const;
-   virtual Int_t       ReOpen(Option_t *mode);
-   virtual Bool_t      ReadBuffer(char *buf, Int_t len);
-   virtual Bool_t      ReadBuffer(char *buf, Long64_t pos, Int_t len);
-   virtual Bool_t      ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf);
-   virtual void        Seek(Long64_t offset, ERelativeTo pos = kBeg);
+   Long64_t    GetSize() const override;
+   Bool_t      IsOpen() const override;
+   Int_t       ReOpen(Option_t *mode) override;
+   Bool_t      ReadBuffer(char *buf, Int_t len) override;
+   Bool_t      ReadBuffer(char *buf, Long64_t pos, Int_t len) override;
+   Bool_t      ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbuf) override;
+   void        Seek(Long64_t offset, ERelativeTo pos = kBeg) override;
 
    static void        SetProxy(const char *url);
    static const char *GetProxy();
@@ -91,7 +91,7 @@ public:
    static Long64_t    GetMaxFullCacheSize();
    static void        SetMaxFullCacheSize(Long64_t sz);
 
-   ClassDef(TWebFile,2)  //A ROOT file that reads via a http server
+   ClassDefOverride(TWebFile,2)  //A ROOT file that reads via a http server
 };
 
 
@@ -100,21 +100,21 @@ class TWebSystem : public TSystem {
 private:
    void *fDirp;    // directory handler
 
-   void *GetDirPtr() const { return fDirp; }
+   void *GetDirPtr() const override { return fDirp; }
 
 public:
    TWebSystem();
-   virtual ~TWebSystem() { }
+   virtual ~TWebSystem() {}
 
-   Int_t       MakeDirectory(const char *name);
-   void       *OpenDirectory(const char *name);
-   void        FreeDirectory(void *dirp);
-   const char *GetDirEntry(void *dirp);
-   Int_t       GetPathInfo(const char *path, FileStat_t &buf);
-   Bool_t      AccessPathName(const char *path, EAccessMode mode);
-   Int_t       Unlink(const char *path);
+   Int_t       MakeDirectory(const char *name) override;
+   void       *OpenDirectory(const char *name) override;
+   void        FreeDirectory(void *dirp) override;
+   const char *GetDirEntry(void *dirp) override;
+   Int_t       GetPathInfo(const char *path, FileStat_t &buf) override;
+   Bool_t      AccessPathName(const char *path, EAccessMode mode) override;
+   Int_t       Unlink(const char *path) override;
 
-   ClassDef(TWebSystem,0)  // Directory handler for HTTP (TWebFiles)
+   ClassDefOverride(TWebSystem,0)  // Directory handler for HTTP (TWebFiles)
 };
 
 #endif

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -86,7 +86,7 @@ private:
 }
 }
 
-class TBranch : public TNamed , public TAttFill {
+class TBranch : public TNamed, public TAttFill {
    using TIOFeatures = ROOT::TIOFeatures;
 
 protected:
@@ -194,7 +194,7 @@ public:
    virtual void      AddBasket(TBasket &b, Bool_t ondisk, Long64_t startEntry);
    virtual void      AddLastBasket(Long64_t startEntry);
            Int_t     BackFill();
-   virtual void      Browse(TBrowser *b);
+           void      Browse(TBrowser *b) override;
    virtual void      DeleteBaskets(Option_t* option="");
    virtual void      DropBaskets(Option_t *option = "");
            void      ExpandBasketArrays();
@@ -223,11 +223,11 @@ public:
            Int_t     GetEntryOffsetLen() const { return fEntryOffsetLen; }
            Int_t     GetEvent(Long64_t entry=0) {return GetEntry(entry);}
    virtual TString   GetFullName() const;
-   const char       *GetIconName() const;
+         const char *GetIconName() const override;
    virtual Int_t     GetExpectedType(TClass *&clptr,EDataType &type);
    virtual TLeaf    *GetLeaf(const char *name) const;
    virtual TFile    *GetFile(Int_t mode=0);
-   const char       *GetFileName()    const {return fFileName.Data();}
+         const char *GetFileName()    const {return fFileName.Data();}
            Int_t     GetOffset()      const {return fOffset;}
            Int_t     GetReadBasket()  const {return fReadBasket;}
            Long64_t  GetReadEntry()   const {return fReadEntry;}
@@ -248,14 +248,14 @@ public:
            TTree    *GetTree()        const {return fTree;}
    virtual Int_t     GetRow(Int_t row);
    virtual Bool_t    GetMakeClass() const;
-   TBranch          *GetMother() const;
-   TBranch          *GetSubBranch(const TBranch *br) const;
-   TBuffer          *GetTransientBuffer(Int_t size);
-   Bool_t            IsAutoDelete() const;
-   Bool_t            IsFolder() const;
+           TBranch  *GetMother() const;
+           TBranch  *GetSubBranch(const TBranch *br) const;
+           TBuffer  *GetTransientBuffer(Int_t size);
+           Bool_t    IsAutoDelete() const;
+           Bool_t    IsFolder() const override;
    virtual void      KeepCircular(Long64_t maxEntries);
    virtual Int_t     LoadBaskets();
-   virtual void      Print(Option_t *option="") const;
+           void      Print(Option_t *option="") const override;
            void      PrintCacheInfo() const;
    virtual void      ReadBasket(TBuffer &b);
    virtual void      Refresh(TBranch *b);
@@ -268,27 +268,27 @@ public:
    virtual void      SetAutoDelete(Bool_t autodel=kTRUE);
    virtual void      SetBasketSize(Int_t buffsize);
    virtual void      SetBufferAddress(TBuffer *entryBuffer);
-   void              SetCompressionAlgorithm(Int_t algorithm = ROOT::RCompressionSetting::EAlgorithm::kUseGlobal);
-   void              SetCompressionLevel(Int_t level = ROOT::RCompressionSetting::ELevel::kUseMin);
-   void              SetCompressionSettings(Int_t settings = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
+           void      SetCompressionAlgorithm(Int_t algorithm = ROOT::RCompressionSetting::EAlgorithm::kUseGlobal);
+           void      SetCompressionLevel(Int_t level = ROOT::RCompressionSetting::ELevel::kUseMin);
+           void      SetCompressionSettings(Int_t settings = ROOT::RCompressionSetting::EDefaults::kUseCompiledDefault);
    virtual void      SetEntries(Long64_t entries);
    virtual void      SetEntryOffsetLen(Int_t len, Bool_t updateSubBranches = kFALSE);
-   virtual void      SetFirstEntry( Long64_t entry );
-   virtual void      SetFile(TFile *file=0);
+   virtual void      SetFirstEntry(Long64_t entry);
+   virtual void      SetFile(TFile *file = nullptr);
    virtual void      SetFile(const char *filename);
-   void              SetIOFeatures(TIOFeatures &features) {fIOFeatures = features;}
+           void      SetIOFeatures(TIOFeatures &features) {fIOFeatures = features;}
    virtual Bool_t    SetMakeClass(Bool_t decomposeObj = kTRUE);
    virtual void      SetOffset(Int_t offset=0) {fOffset=offset;}
    virtual void      SetStatus(Bool_t status=1);
-   virtual void      SetTree(TTree *tree) { fTree = tree;}
+   virtual void      SetTree(TTree *tree) { fTree = tree; }
    virtual void      SetupAddresses();
            Bool_t    SupportsBulkRead() const;
-   virtual void      UpdateAddress() {;}
+   virtual void      UpdateAddress() {}
    virtual void      UpdateFile();
 
    static  void      ResetCount();
 
-   ClassDef(TBranch, 13); // Branch descriptor
+   ClassDefOverride(TBranch, 13); // Branch descriptor
 };
 
 //______________________________________________________________________________

--- a/tree/tree/inc/TBranchElement.h
+++ b/tree/tree/inc/TBranchElement.h
@@ -104,8 +104,8 @@ protected:
 
 // Not implemented
 private:
-   TBranchElement(const TBranchElement&);            // not implemented
-   TBranchElement& operator=(const TBranchElement&); // not implemented
+   TBranchElement(const TBranchElement&) = delete;
+   TBranchElement& operator=(const TBranchElement&) = delete;
 
    static void SwitchContainer(TObjArray *);
 
@@ -145,7 +145,7 @@ protected:
    void SetReadLeavesPtr();
    void SetReadActionSequence();
    void SetupAddressesImpl();
-   void SetAddressImpl(void *addr, Bool_t implied);
+   void SetAddressImpl(void *addr, Bool_t implied) override;
 
    void FillLeavesImpl(TBuffer& b);
    void FillLeavesMakeClass(TBuffer& b);
@@ -175,26 +175,26 @@ public:
 
    virtual                  ~TBranchElement();
 
-   virtual void             Browse(TBrowser* b);
-   virtual TBranch         *FindBranch(const char *name);
-   virtual TLeaf           *FindLeaf(const char *name);
-   virtual char            *GetAddress() const;
+           void             Browse(TBrowser* b) override;
+           TBranch         *FindBranch(const char *name) override;
+           TLeaf           *FindLeaf(const char *name) override;
+           char            *GetAddress() const override;
            TBranchElement  *GetBranchCount() const { return fBranchCount; }
            TBranchElement  *GetBranchCount2() const { return fBranchCount2; }
            Int_t           *GetBranchOffset() const { return fBranchOffset; }
            UInt_t           GetCheckSum() { return fCheckSum; }
-   virtual const char      *GetClassName() const { return fClassName.Data(); }
+           const char      *GetClassName() const override { return fClassName.Data(); }
    virtual TClass          *GetClass() const { return fBranchClass; }
    virtual const char      *GetClonesName() const { return fClonesName.Data(); }
    TVirtualCollectionProxy *GetCollectionProxy();
    TClass                  *GetCurrentClass(); // Class referenced by transient description
-   virtual Int_t            GetEntry(Long64_t entry = 0, Int_t getall = 0);
-   virtual Int_t            GetExpectedType(TClass *&clptr,EDataType &type);
-   virtual TString          GetFullName() const;
-           const char      *GetIconName() const;
+           Int_t            GetEntry(Long64_t entry = 0, Int_t getall = 0) override;
+           Int_t            GetExpectedType(TClass *&clptr,EDataType &type) override;
+           TString          GetFullName() const override;
+           const char      *GetIconName() const override;
            Int_t            GetID() const { return fID; }
            TStreamerInfo   *GetInfo() const;
-           Bool_t           GetMakeClass() const;
+           Bool_t           GetMakeClass() const override;
            char            *GetObject() const;
            TVirtualArray   *GetOnfileObject() const { return fOnfileObject; }
    virtual const char      *GetParentName() const { return fParentName.Data(); }
@@ -209,30 +209,30 @@ public:
    virtual void            *GetValuePointer() const;
            Int_t            GetClassVersion() { return fClassVersion; }
            Bool_t           IsBranchFolder() const { return TestBit(kBranchFolder); }
-           Bool_t           IsFolder() const;
+           Bool_t           IsFolder() const override;
    virtual Bool_t           IsObjectOwner() const { return TestBit(kDeleteObject); }
-   virtual Bool_t           Notify() { if (fAddress) { ResetAddress(); } return 1; }
-   virtual void             Print(Option_t* option = "") const;
+           Bool_t           Notify() override { if (fAddress) { ResetAddress(); } return 1; }
+           void             Print(Option_t* option = "") const override;
            void             PrintValue(Int_t i) const;
-   virtual void             Reset(Option_t* option = "");
-   virtual void             ResetAfterMerge(TFileMergeInfo *);
-   virtual void             ResetAddress();
+           void             Reset(Option_t* option = "") override;
+           void             ResetAfterMerge(TFileMergeInfo *) override;
+           void             ResetAddress() override;
    virtual void             ResetDeleteObject();
    virtual void             ResetInitInfo(bool recurse);
-   virtual void             SetAddress(void* addobj);
-   virtual Bool_t           SetMakeClass(Bool_t decomposeObj = kTRUE);
-   virtual void             SetObject(void *objadd);
-   virtual void             SetBasketSize(Int_t buffsize);
+           void             SetAddress(void* addobj) override;
+           Bool_t           SetMakeClass(Bool_t decomposeObj = kTRUE) override;
+           void             SetObject(void *objadd) override;
+           void             SetBasketSize(Int_t buffsize) override;
    virtual void             SetBranchFolder() { SetBit(kBranchFolder); }
    virtual void             SetClassName(const char* name) { fClassName = name; }
-   virtual void             SetOffset(Int_t offset);
+           void             SetOffset(Int_t offset) override;
    virtual void             SetMissing();
    inline  void             SetParentClass(TClass* clparent);
    virtual void             SetParentName(const char* name) { fParentName = name; }
    virtual void             SetTargetClass(const char *name);
-   virtual void             SetupAddresses();
+           void             SetupAddresses() override;
    virtual void             SetType(Int_t btype) { fType = btype; }
-   virtual void             UpdateFile();
+           void             UpdateFile() override;
            void             Unroll(const char *name, TClass *cl, TStreamerInfo *sinfo, char* objptr, Int_t bufsize, Int_t splitlevel);
 
    enum EBranchElementType {
@@ -250,9 +250,9 @@ public:
    };
 
 private:
-   virtual Int_t            FillImpl(ROOT::Internal::TBranchIMTHelper *);
+   Int_t            FillImpl(ROOT::Internal::TBranchIMTHelper *) override;
 
-   ClassDef(TBranchElement,10)  // Branch in case of an object
+   ClassDefOverride(TBranchElement,10)  // Branch in case of an object
 };
 
 inline void TBranchElement::SetParentClass(TClass* clparent)

--- a/tree/tree/inc/TBranchObject.h
+++ b/tree/tree/inc/TBranchObject.h
@@ -50,25 +50,25 @@ public:
    TBranchObject(TTree *tree, const char *name, const char *classname, void *addobj, Int_t basketsize=32000, Int_t splitlevel = 0, Int_t compress = ROOT::RCompressionSetting::EAlgorithm::kInherit, Bool_t isptrptr = kTRUE);
    virtual ~TBranchObject();
 
-   virtual void        Browse(TBrowser *b);
-   virtual const char* GetClassName() const { return fClassName.Data(); };
+           void        Browse(TBrowser *b) override;
+           const char* GetClassName() const override { return fClassName.Data(); };
    virtual const char* GetObjClassName() { return fClassName.Data(); };
-   virtual Int_t       GetEntry(Long64_t entry=0, Int_t getall = 0);
-   virtual Int_t       GetExpectedType(TClass *&clptr,EDataType &type);
-   Bool_t              IsFolder() const;
-   virtual void        Print(Option_t *option="") const;
-   virtual void        Reset(Option_t *option="");
-   virtual void        ResetAfterMerge(TFileMergeInfo *);
-   virtual void        SetAddress(void *addobj);
-   virtual void        SetAutoDelete(Bool_t autodel=kTRUE);
-   virtual void        SetBasketSize(Int_t buffsize);
-   virtual void        SetupAddresses();
-   virtual void        UpdateAddress();
+           Int_t       GetEntry(Long64_t entry=0, Int_t getall = 0) override;
+           Int_t       GetExpectedType(TClass *&clptr,EDataType &type) override;
+           Bool_t      IsFolder() const override;
+           void        Print(Option_t *option="") const override;
+           void        Reset(Option_t *option="") override;
+           void        ResetAfterMerge(TFileMergeInfo *) override;
+           void        SetAddress(void *addobj) override;
+           void        SetAutoDelete(Bool_t autodel=kTRUE) override;
+           void        SetBasketSize(Int_t buffsize) override;
+           void        SetupAddresses() override;
+           void        UpdateAddress() override;
 
 private:
-   virtual Int_t       FillImpl(ROOT::Internal::TBranchIMTHelper *);
+           Int_t       FillImpl(ROOT::Internal::TBranchIMTHelper *) override;
 
-   ClassDef(TBranchObject,1);  //Branch in case of an object
+   ClassDefOverride(TBranchObject,1);  //Branch in case of an object
 };
 
 #endif

--- a/tree/tree/inc/TBranchRef.h
+++ b/tree/tree/inc/TBranchRef.h
@@ -45,19 +45,19 @@ public:
    TBranchRef();
    TBranchRef(TTree *tree);
    virtual ~TBranchRef();
-   virtual void    Clear(Option_t *option="");
+           void    Clear(Option_t *option="") override;
    TRefTable      *GetRefTable() const {return fRefTable;}
-   virtual Bool_t  Notify();
-   virtual void    Print(Option_t *option="") const;
-   virtual void    Reset(Option_t *option="");
-   virtual void    ResetAfterMerge(TFileMergeInfo *);
+           Bool_t  Notify() override;
+           void    Print(Option_t *option="") const override;
+           void    Reset(Option_t *option="") override;
+           void    ResetAfterMerge(TFileMergeInfo *) override;
    virtual Int_t   SetParent(const TObject* obj, Int_t branchID);
    virtual void    SetRequestedEntry(Long64_t entry) {fRequestedEntry = entry;}
 
 private:
-   virtual Int_t   FillImpl(ROOT::Internal::TBranchIMTHelper *);
+           Int_t   FillImpl(ROOT::Internal::TBranchIMTHelper *) override;
 
-   ClassDef(TBranchRef,1);  //to support referenced objects on other branches
+   ClassDefOverride(TBranchRef,1);  //to support referenced objects on other branches
 };
 
 #endif

--- a/tree/tree/inc/TBranchSTL.h
+++ b/tree/tree/inc/TBranchSTL.h
@@ -30,28 +30,28 @@ class TBranchSTL: public TBranch {
                   Int_t buffsize, Int_t splitlevel,
                   TStreamerInfo* info, Int_t id );
       virtual ~TBranchSTL();
-      virtual void           Browse( TBrowser *b );
-      virtual Bool_t         IsFolder() const;
-      virtual const char    *GetClassName() const { return fClassName.Data(); }
-      virtual Int_t          GetExpectedType(TClass *&clptr,EDataType &type);
-      virtual Int_t          GetEntry( Long64_t entry = 0, Int_t getall = 0 );
+              void           Browse( TBrowser *b ) override;
+              Bool_t         IsFolder() const override;
+              const char    *GetClassName() const override { return fClassName.Data(); }
+              Int_t          GetExpectedType(TClass *&clptr,EDataType &type) override;
+              Int_t          GetEntry(Long64_t entry = 0, Int_t getall = 0) override;
       virtual TStreamerInfo *GetInfo() const;
-      virtual void           Print(Option_t*) const;
-      virtual void           SetAddress( void* addr );
+              void           Print(Option_t* = "") const override;
+              void           SetAddress(void* addr) override;
 
-      ClassDef( TBranchSTL, 1 ) //Branch handling STL collection of pointers
+      ClassDefOverride(TBranchSTL, 1) //Branch handling STL collection of pointers
 
    private:
 
       void ReadLeavesImpl( TBuffer& b );
       void FillLeavesImpl( TBuffer& b );
-      virtual Int_t          FillImpl(ROOT::Internal::TBranchIMTHelper *);
+              Int_t          FillImpl(ROOT::Internal::TBranchIMTHelper *) override;
 
       struct ElementBranchHelper_t
       {
          ElementBranchHelper_t():
-            fBranch( 0 ), fPointers( 0 ), fId( 0 ),
-            fBaseOffset( 0 ), fPosition( 0 ) {}
+            fBranch(nullptr), fPointers(nullptr), fId(0),
+            fBaseOffset(0), fPosition(0) {}
 
          TBranchElement*     fBranch;
          std::vector<void*>* fPointers;

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -108,7 +108,7 @@ public:
    TLeaf(TBranch *parent, const char *name, const char *type);
    virtual ~TLeaf();
 
-   virtual void     Browse(TBrowser *b);
+           void     Browse(TBrowser *b) override;
    virtual Bool_t   CanGenerateOffsetArray() {return fLeafCount;} // overload and return true if this leaf can generate its own offset array.
    virtual void     Export(TClonesArray *, Int_t) {}
    virtual void     FillBasket(TBuffer &b);
@@ -135,7 +135,7 @@ public:
    virtual Int_t    GetMinimum() const { return 0; }
    virtual Int_t    GetNdata() const { return fNdata; }
    virtual Int_t    GetOffset() const { return fOffset; }
-   virtual void    *GetValuePointer() const { return 0; }
+   virtual void    *GetValuePointer() const { return nullptr; }
    virtual const char *GetTypeName() const { return ""; }
 
    virtual Double_t GetValue(Int_t i = 0) const;
@@ -152,12 +152,12 @@ public:
    virtual void     ReadBasket(TBuffer &) {}
    virtual void     ReadBasketExport(TBuffer &, TClonesArray *, Int_t) {}
    virtual bool     ReadBasketFast(TBuffer&, Long64_t) { return false; }  // Read contents of leaf into a user-provided buffer.
-   virtual bool     ReadBasketSerialized(TBuffer&, Long64_t) { return true; } 
+   virtual bool     ReadBasketSerialized(TBuffer&, Long64_t) { return true; }
    virtual void     ReadValue(std::istream & /*s*/, Char_t /*delim*/ = ' ') {
       Error("ReadValue", "Not implemented!");
    }
            Int_t    ResetAddress(void *add, Bool_t calledFromDestructor = kFALSE);
-   virtual void     SetAddress(void *add = 0);
+   virtual void     SetAddress(void *add = nullptr);
    virtual void     SetBranch(TBranch *branch) { fBranch = branch; }
    virtual void     SetLeafCount(TLeaf *leaf);
    virtual void     SetLen(Int_t len = 1) { fLen = len; }
@@ -165,7 +165,7 @@ public:
    virtual void     SetRange(Bool_t range = kTRUE) { fIsRange = range; }
    virtual void     SetUnsigned() { fIsUnsigned = kTRUE; }
 
-   ClassDef(TLeaf, 2); // Leaf: description of a Branch data type
+   ClassDefOverride(TLeaf, 2); // Leaf: description of a Branch data type
 };
 
 

--- a/tree/tree/inc/TLeafB.h
+++ b/tree/tree/inc/TLeafB.h
@@ -36,29 +36,29 @@ public:
    TLeafB(TBranch *parent, const char* name, const char* type);
    virtual ~TLeafB();
 
-   virtual void    Export(TClonesArray* list, Int_t n);
-   virtual void    FillBasket(TBuffer& b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kZeroCopy; }
-   virtual Int_t   GetMaximum() const { return fMaximum; }
-   virtual Int_t   GetMinimum() const { return fMinimum; }
-   const char     *GetTypeName() const;
-   Double_t        GetValue(Int_t i = 0) const { return IsUnsigned() ? (Double_t)((UChar_t) fValue[i]) : (Double_t)fValue[i]; }
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray* list, Int_t n);
-   virtual void    PrintValue(Int_t i = 0) const;
-   virtual void    ReadBasket(TBuffer&);
-   virtual void    ReadBasketExport(TBuffer&, TClonesArray* list, Int_t n);
-   virtual void    ReadValue(std::istream &s, Char_t delim = ' ');
-   virtual void    SetAddress(void* addr = 0);
+   void            Export(TClonesArray* list, Int_t n) override;
+   void            FillBasket(TBuffer& b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kZeroCopy; }
+   Int_t           GetMaximum() const override { return fMaximum; }
+   Int_t           GetMinimum() const override { return fMinimum; }
+   const char     *GetTypeName() const override;
+   Double_t        GetValue(Int_t i = 0) const override { return IsUnsigned() ? (Double_t)((UChar_t) fValue[i]) : (Double_t)fValue[i]; }
+   void           *GetValuePointer() const override { return fValue; }
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray* list, Int_t n) override;
+   void            PrintValue(Int_t i = 0) const override;
+   void            ReadBasket(TBuffer&) override;
+   void            ReadBasketExport(TBuffer&, TClonesArray* list, Int_t n) override;
+   void            ReadValue(std::istream &s, Char_t delim = ' ') override;
+   void            SetAddress(void* addr = nullptr) override;
    virtual void    SetMaximum(Char_t max) { fMaximum = max; }
    virtual void    SetMinimum(Char_t min) { fMinimum = min; }
 
    // Deserialize N events from an input buffer.  Since chars are stored unchanged, there
    // is nothing to do here but return true if we don't have variable-length arrays.
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t) { return true; }
+   bool            ReadBasketFast(TBuffer&, Long64_t) override { return true; }
 
-   ClassDef(TLeafB,1);  //A TLeaf for an 8 bit Integer data type.
+   ClassDefOverride(TLeafB,1);  //A TLeaf for an 8 bit Integer data type.
 };
 
 #endif

--- a/tree/tree/inc/TLeafC.h
+++ b/tree/tree/inc/TLeafC.h
@@ -36,25 +36,25 @@ public:
    TLeafC(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafC();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual Int_t   GetMaximum() const {return fMaximum;}
-   virtual Int_t   GetMinimum() const {return fMinimum;}
-   const char     *GetTypeName() const;
-   Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
-   char           *GetValueString()  const {return fValue;}
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   Int_t           GetMaximum() const override {return fMaximum;}
+   Int_t           GetMinimum() const override {return fMinimum;}
+   const char     *GetTypeName() const override;
+   Double_t        GetValue(Int_t i=0) const override;
+   void           *GetValuePointer() const override {return fValue;}
+   virtual char   *GetValueString() const {return fValue;}
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add = nullptr) override;
    virtual void    SetMaximum(Int_t max) {fMaximum = max;}
    virtual void    SetMinimum(Int_t min) {fMinimum = min;}
 
-   ClassDef(TLeafC,1);  //A TLeaf for a variable length string.
+   ClassDefOverride(TLeafC,1);  //A TLeaf for a variable length string.
 };
 
 inline Double_t TLeafC::GetValue(Int_t i) const { return fValue[i]; }

--- a/tree/tree/inc/TLeafD.h
+++ b/tree/tree/inc/TLeafD.h
@@ -36,22 +36,22 @@ public:
    TLeafD(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafD();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kInPlace; }
-   const char     *GetTypeName() const { return "Double_t"; }
-   Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kInPlace; }
+   const char     *GetTypeName() const override { return "Double_t"; }
+   Double_t        GetValue(Int_t i=0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add=nullptr) override;
 
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
+   bool            ReadBasketFast(TBuffer&, Long64_t) override;
 
-   ClassDef(TLeafD,1);  //A TLeaf for a 64 bit floating point data type.
+   ClassDefOverride(TLeafD,1);  //A TLeaf for a 64 bit floating point data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafD32.h
+++ b/tree/tree/inc/TLeafD32.h
@@ -39,20 +39,20 @@ public:
    TLeafD32(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafD32();
 
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kExternal; }
-   virtual void Export(TClonesArray *list, Int_t n);
-   virtual void FillBasket(TBuffer &b);
-   const char *GetTypeName() const { return "Double32_t"; }
-   Double_t GetValue(Int_t i = 0) const;
-   virtual void *GetValuePointer() const { return fValue; }
-   virtual void Import(TClonesArray *list, Int_t n);
-   virtual void PrintValue(Int_t i = 0) const;
-   virtual void ReadBasket(TBuffer &b);
-   virtual void ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual void ReadValue(std::istream &s, Char_t delim = ' ');
-   virtual void SetAddress(void *add = 0);
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kExternal; }
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   const char     *GetTypeName() const override { return "Double32_t"; }
+   Double_t        GetValue(Int_t i = 0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i = 0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   void            ReadValue(std::istream &s, Char_t delim = ' ') override;
+   void            SetAddress(void *add = nullptr) override;
 
-   ClassDef(TLeafD32, 1); // A TLeaf for a 24 bit truncated floating point data type.
+   ClassDefOverride(TLeafD32, 1); // A TLeaf for a 24 bit truncated floating point data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafElement.h
+++ b/tree/tree/inc/TLeafElement.h
@@ -39,39 +39,39 @@ protected:
    mutable std::atomic<EDataType> fDataTypeCache{EDataType::kOther_t}; ///<! Cache of the EDataType of deserialization.
 
 private:
-   virtual Int_t       GetOffsetHeaderSize() const {return 1;}
+   Int_t            GetOffsetHeaderSize() const override {return 1;}
 
 public:
    TLeafElement();
    TLeafElement(TBranch *parent, const char *name, Int_t id, Int_t type);
    virtual ~TLeafElement();
 
-   virtual Bool_t   CanGenerateOffsetArray() { return fLeafCount && fLenType; }
+   Bool_t           CanGenerateOffsetArray() override { return fLeafCount && fLenType; }
    virtual Int_t   *GenerateOffsetArrayBase(Int_t /*base*/, Int_t /*events*/) { return nullptr; }
-   virtual DeserializeType GetDeserializeType() const;
+   DeserializeType  GetDeserializeType() const override;
 
-           Int_t    GetID() const { return fID; }
-   virtual TString  GetFullName() const;
-   virtual Int_t    GetLen() const {return ((TBranchElement*)fBranch)->GetNdata()*fLen;}
+   Int_t            GetID() const { return fID; }
+   TString          GetFullName() const override;
+   Int_t            GetLen() const override { return ((TBranchElement*)fBranch)->GetNdata()*fLen; }
    TMethodCall     *GetMethodCall(const char *name);
-   virtual Int_t    GetMaximum() const {return ((TBranchElement*)fBranch)->GetMaximum();}
-   virtual Int_t    GetNdata() const {return ((TBranchElement*)fBranch)->GetNdata()*fLen;}
-   virtual const char *GetTypeName() const {return ((TBranchElement*)fBranch)->GetTypeName();}
+   Int_t            GetMaximum() const override { return ((TBranchElement*)fBranch)->GetMaximum(); }
+   Int_t            GetNdata() const override { return ((TBranchElement*)fBranch)->GetNdata()*fLen; }
+   const char      *GetTypeName() const override { return ((TBranchElement*)fBranch)->GetTypeName(); }
 
-   virtual Double_t     GetValue(Int_t i=0) const { return ((TBranchElement*)fBranch)->GetValue(i, fLen, kFALSE);}
-   virtual Long64_t     GetValueLong64(Int_t i = 0) const { return ((TBranchElement*)fBranch)->GetTypedValue<Long64_t>(i, fLen, kFALSE); }
-   virtual LongDouble_t GetValueLongDouble(Int_t i = 0) const { return ((TBranchElement*)fBranch)->GetTypedValue<LongDouble_t>(i, fLen, kFALSE); }
+   Double_t         GetValue(Int_t i=0) const override { return ((TBranchElement*)fBranch)->GetValue(i, fLen, kFALSE);}
+   Long64_t         GetValueLong64(Int_t i = 0) const override { return ((TBranchElement*)fBranch)->GetTypedValue<Long64_t>(i, fLen, kFALSE); }
+   LongDouble_t     GetValueLongDouble(Int_t i = 0) const override { return ((TBranchElement*)fBranch)->GetTypedValue<LongDouble_t>(i, fLen, kFALSE); }
    template<typename T> T GetTypedValueSubArray(Int_t i=0, Int_t j=0) const {return ((TBranchElement*)fBranch)->GetTypedValue<T>(i, j, kTRUE);}
 
-   virtual bool     ReadBasketFast(TBuffer&, Long64_t);
- 
-   virtual void    *GetValuePointer() const { return ((TBranchElement*)fBranch)->GetValuePointer(); }
-   virtual Bool_t   IncludeRange(TLeaf *);
-   virtual Bool_t   IsOnTerminalBranch() const;
-   virtual void     PrintValue(Int_t i=0) const {((TBranchElement*)fBranch)->PrintValue(i);}
-   virtual void     SetLeafCount(TLeaf *leaf) {fLeafCount = leaf;}
+   bool             ReadBasketFast(TBuffer&, Long64_t) override;
 
-   ClassDef(TLeafElement,1);  //A TLeaf for a general object derived from TObject.
+   void            *GetValuePointer() const override { return ((TBranchElement*)fBranch)->GetValuePointer(); }
+   Bool_t           IncludeRange(TLeaf *) override;
+   Bool_t           IsOnTerminalBranch() const override;
+   void             PrintValue(Int_t i=0) const override {((TBranchElement*)fBranch)->PrintValue(i);}
+   void             SetLeafCount(TLeaf *leaf) override { fLeafCount = leaf; }
+
+   ClassDefOverride(TLeafElement,1);  //A TLeaf for a general object derived from TObject.
 };
 
 #endif

--- a/tree/tree/inc/TLeafF.h
+++ b/tree/tree/inc/TLeafF.h
@@ -36,22 +36,22 @@ public:
    TLeafF(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafF();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kInPlace; }
-   const char     *GetTypeName() const { return "Float_t"; }
-   Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kInPlace; }
+   const char     *GetTypeName() const override { return "Float_t"; }
+   Double_t        GetValue(Int_t i=0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add = nullptr) override;
 
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
+   bool            ReadBasketFast(TBuffer&, Long64_t) override;
 
-   ClassDef(TLeafF,1);  //A TLeaf for a 32 bit floating point data type.
+   ClassDefOverride(TLeafF,1);  //A TLeaf for a 32 bit floating point data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafF16.h
+++ b/tree/tree/inc/TLeafF16.h
@@ -38,20 +38,20 @@ public:
    TLeafF16(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafF16();
 
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kExternal; }
-   virtual void Export(TClonesArray *list, Int_t n);
-   virtual void FillBasket(TBuffer &b);
-   const char *GetTypeName() const { return "Float16_t"; }
-   Double_t GetValue(Int_t i = 0) const;
-   virtual void *GetValuePointer() const { return fValue; }
-   virtual void Import(TClonesArray *list, Int_t n);
-   virtual void PrintValue(Int_t i = 0) const;
-   virtual void ReadBasket(TBuffer &b);
-   virtual void ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual void ReadValue(std::istream &s, Char_t delim = ' ');
-   virtual void SetAddress(void *add = 0);
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kExternal; }
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   const char     *GetTypeName() const override { return "Float16_t"; }
+   Double_t        GetValue(Int_t i = 0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i = 0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   void            ReadValue(std::istream &s, Char_t delim = ' ') override;
+   void            SetAddress(void *add = nullptr) override;
 
-   ClassDef(TLeafF16, 1); // A TLeaf for a 24 bit truncated floating point data type.
+   ClassDefOverride(TLeafF16, 1); // A TLeaf for a 24 bit truncated floating point data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafG.h
+++ b/tree/tree/inc/TLeafG.h
@@ -37,28 +37,28 @@ public:
    TLeafG(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafG();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kInPlace; }
-   const char     *GetTypeName() const;
-   virtual Int_t   GetMaximum() const { return (Int_t)fMaximum; }
-   virtual Int_t   GetMinimum() const { return (Int_t)fMinimum; }
-   virtual Double_t     GetValue(Int_t i=0) const;
-   virtual Long64_t     GetValueLong64(Int_t i = 0) const ;
-   virtual LongDouble_t GetValueLongDouble(Int_t i = 0) const;
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kInPlace; }
+   const char     *GetTypeName() const override;
+   Int_t           GetMaximum() const override { return (Int_t)fMaximum; }
+   Int_t           GetMinimum() const override { return (Int_t)fMinimum; }
+   Double_t        GetValue(Int_t i=0) const override;
+   Long64_t        GetValueLong64(Int_t i = 0) const override;
+   LongDouble_t    GetValueLongDouble(Int_t i = 0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   bool            ReadBasketFast(TBuffer&, Long64_t) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add=nullptr) override;
    virtual void    SetMaximum(Long_t max) {fMaximum = max;}
    virtual void    SetMinimum(Long_t min) {fMinimum = min;}
 
-   ClassDef(TLeafG,1);  //A TLeaf for a long integer data type.
+   ClassDefOverride(TLeafG,1);  //A TLeaf for a long integer data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafI.h
+++ b/tree/tree/inc/TLeafI.h
@@ -37,26 +37,26 @@ public:
    TLeafI(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafI();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kInPlace; }
-   const char     *GetTypeName() const;
-   virtual Int_t   GetMaximum() const { return fMaximum; }
-   virtual Int_t   GetMinimum() const { return fMinimum; }
-   Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kInPlace; }
+   const char     *GetTypeName() const override;
+   Int_t           GetMaximum() const override { return fMaximum; }
+   Int_t           GetMinimum() const override { return fMinimum; }
+   Double_t        GetValue(Int_t i=0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   bool            ReadBasketFast(TBuffer&, Long64_t) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add=nullptr) override;
    virtual void    SetMaximum(Int_t max) {fMaximum = max;}
    virtual void    SetMinimum(Int_t min) {fMinimum = min;}
 
-   ClassDef(TLeafI,1);  //A TLeaf for an Integer data type.
+   ClassDefOverride(TLeafI,1);  //A TLeaf for an Integer data type.
 };
 
 #endif

--- a/tree/tree/inc/TLeafL.h
+++ b/tree/tree/inc/TLeafL.h
@@ -37,28 +37,28 @@ public:
    TLeafL(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafL();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kInPlace; }
-   const char     *GetTypeName() const;
-   virtual Int_t   GetMaximum() const { return (Int_t)fMaximum; }
-   virtual Int_t   GetMinimum() const { return (Int_t)fMinimum; }
-   virtual Double_t     GetValue(Int_t i=0) const;
-   virtual Long64_t     GetValueLong64(Int_t i = 0) const ;
-   virtual LongDouble_t GetValueLongDouble(Int_t i = 0) const;
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kInPlace; }
+   const char     *GetTypeName() const override;
+   Int_t           GetMaximum() const override { return (Int_t)fMaximum; }
+   Int_t           GetMinimum() const override { return (Int_t)fMinimum; }
+   Double_t        GetValue(Int_t i=0) const override;
+   Long64_t        GetValueLong64(Int_t i = 0) const override;
+   LongDouble_t    GetValueLongDouble(Int_t i = 0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   bool            ReadBasketFast(TBuffer&, Long64_t) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add=nullptr) override;
    virtual void    SetMaximum(Long64_t max) {fMaximum = max;}
    virtual void    SetMinimum(Long64_t min) {fMinimum = min;}
 
-   ClassDef(TLeafL,1);  //A TLeaf for a 64 bit Integer data type.
+   ClassDefOverride(TLeafL,1);  //A TLeaf for a 64 bit Integer data type.
 };
 
 // if leaf is a simple type, i must be set to 0

--- a/tree/tree/inc/TLeafO.h
+++ b/tree/tree/inc/TLeafO.h
@@ -36,29 +36,29 @@ public:
    TLeafO(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafO();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kZeroCopy; }
-   virtual Int_t   GetMaximum() const {return fMaximum;}
-   virtual Int_t   GetMinimum() const {return fMinimum;}
-   const char     *GetTypeName() const;
-   Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kZeroCopy; }
+   Int_t           GetMaximum() const override {return fMaximum;}
+   Int_t           GetMinimum() const override {return fMinimum;}
+   const char     *GetTypeName() const override;
+   Double_t        GetValue(Int_t i=0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add=nullptr) override;
    virtual void    SetMaximum(Bool_t max) { fMaximum = max; }
    virtual void    SetMinimum(Bool_t min) { fMinimum = min; }
 
    // Deserialize N events from an input buffer.  Since chars are stored unchanged, there
    // is nothing to do here but return true if we don't have variable-length arrays.
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t) { return true; }
+   bool            ReadBasketFast(TBuffer&, Long64_t) override { return true; }
 
-   ClassDef(TLeafO,1);  //A TLeaf for an 8 bit Integer data type.
+   ClassDefOverride(TLeafO,1);  //A TLeaf for an 8 bit Integer data type.
 };
 
 inline Double_t TLeafO::GetValue(Int_t i) const { return fValue[i]; }

--- a/tree/tree/inc/TLeafObject.h
+++ b/tree/tree/inc/TLeafObject.h
@@ -53,23 +53,23 @@ public:
    TLeafObject(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafObject();
 
-   virtual Bool_t  CanGenerateOffsetArray() { return false; }
-   virtual void    FillBasket(TBuffer &b);
+   Bool_t          CanGenerateOffsetArray() override { return false; }
+   void            FillBasket(TBuffer &b) override;
    virtual Int_t  *GenerateOffsetArrayBase(Int_t /*base*/, Int_t /*events*/) { return nullptr; }
    TClass         *GetClass() const {return fClass;}
    TMethodCall    *GetMethodCall(const char *name);
    TObject        *GetObject() const {return (TObject*)(*fObjAddress);}
-   const char     *GetTypeName() const ;
-   virtual void   *GetValuePointer() const {return fObjAddress;}
-   Bool_t          IsOnTerminalBranch() const;
+   const char     *GetTypeName() const override;
+   void           *GetValuePointer() const override {return fObjAddress;}
+   Bool_t          IsOnTerminalBranch() const override;
    Bool_t          IsVirtual() const {return fVirtual;}
-   virtual Bool_t  Notify();
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    SetAddress(void *add=0);
+   Bool_t          Notify() override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            SetAddress(void *add=nullptr) override;
    virtual void    SetVirtual(Bool_t virt=kTRUE) {fVirtual=virt;}
 
-   ClassDef(TLeafObject,4);  //A TLeaf for a general object derived from TObject.
+   ClassDefOverride(TLeafObject,4);  //A TLeaf for a general object derived from TObject.
 };
 
 #endif

--- a/tree/tree/inc/TLeafS.h
+++ b/tree/tree/inc/TLeafS.h
@@ -36,26 +36,26 @@ public:
    TLeafS(TBranch *parent, const char *name, const char *type);
    virtual ~TLeafS();
 
-   virtual void    Export(TClonesArray *list, Int_t n);
-   virtual void    FillBasket(TBuffer &b);
-   virtual DeserializeType GetDeserializeType() const { return DeserializeType::kInPlace; }
-   virtual Int_t   GetMaximum() const { return fMaximum; }
-   virtual Int_t   GetMinimum() const { return fMinimum; }
-   const char     *GetTypeName() const;
-   Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const { return fValue; }
-   virtual Bool_t  IncludeRange(TLeaf *);
-   virtual void    Import(TClonesArray *list, Int_t n);
-   virtual void    PrintValue(Int_t i=0) const;
-   virtual void    ReadBasket(TBuffer &b);
-   virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
-   virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
-   virtual void    SetAddress(void *add=0);
+   void            Export(TClonesArray *list, Int_t n) override;
+   void            FillBasket(TBuffer &b) override;
+   DeserializeType GetDeserializeType() const override { return DeserializeType::kInPlace; }
+   Int_t           GetMaximum() const override { return fMaximum; }
+   Int_t           GetMinimum() const override { return fMinimum; }
+   const char     *GetTypeName() const override;
+   Double_t        GetValue(Int_t i=0) const override;
+   void           *GetValuePointer() const override { return fValue; }
+   Bool_t          IncludeRange(TLeaf *) override;
+   void            Import(TClonesArray *list, Int_t n) override;
+   void            PrintValue(Int_t i=0) const override;
+   void            ReadBasket(TBuffer &b) override;
+   void            ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n) override;
+   bool            ReadBasketFast(TBuffer&, Long64_t) override;
+   void            ReadValue(std::istream& s, Char_t delim = ' ') override;
+   void            SetAddress(void *add=nullptr) override;
    virtual void    SetMaximum(Short_t max) { fMaximum = max; }
    virtual void    SetMinimum(Short_t min) { fMinimum = min; }
 
-   ClassDef(TLeafS,1);  //A TLeaf for a 16 bit Integer data type.
+   ClassDefOverride(TLeafS,1);  //A TLeaf for a 16 bit Integer data type.
 };
 
 #endif

--- a/tree/tree/inc/TNtuple.h
+++ b/tree/tree/inc/TNtuple.h
@@ -31,19 +31,19 @@ protected:
    Int_t       fNvar;            ///<  Number of columns
    Float_t    *fArgs;            ///<! [fNvar] Array of variables
 
-   virtual Int_t  Fill();
+   Int_t  Fill() override;
 
 private:
-   TNtuple(const TNtuple&);             // not implemented
-   TNtuple& operator=(const TNtuple&);  // not implemented
+   TNtuple(const TNtuple&) = delete;
+   TNtuple& operator=(const TNtuple&) = delete;
 
 public:
    TNtuple();
    TNtuple(const char *name,const char *title, const char *varlist, Int_t bufsize=32000);
    virtual ~TNtuple();
 
-   virtual void      Browse(TBrowser *b);
-   virtual TTree    *CloneTree(Long64_t nentries = -1, Option_t* option = "");
+           void      Browse(TBrowser *b) override;
+           TTree    *CloneTree(Long64_t nentries = -1, Option_t* option = "") override;
    virtual Int_t     Fill(const Float_t *x);
            Int_t     Fill(Int_t x0) { return Fill((Float_t)x0); }
            Int_t     Fill(Double_t x0) { return Fill((Float_t)x0); }
@@ -54,11 +54,11 @@ public:
                           Float_t x14=0);
    virtual Int_t     GetNvar() const { return fNvar; }
            Float_t  *GetArgs() const { return fArgs; }
-   virtual Long64_t  ReadStream(std::istream& inputStream, const char *branchDescriptor="", char delimiter = ' ');
-   virtual void      ResetBranchAddress(TBranch *);
-           void      ResetBranchAddresses();
+           Long64_t  ReadStream(std::istream& inputStream, const char *branchDescriptor="", char delimiter = ' ') override;
+           void      ResetBranchAddress(TBranch *) override;
+           void      ResetBranchAddresses() override;
 
-   ClassDef(TNtuple,2);  //A simple tree with branches of floats.
+   ClassDefOverride(TNtuple,2);  //A simple tree with branches of floats.
 };
 
 #endif

--- a/tree/tree/inc/TNtupleD.h
+++ b/tree/tree/inc/TNtupleD.h
@@ -31,18 +31,18 @@ protected:
    Int_t       fNvar;            ///<  Number of columns
    Double_t    *fArgs;           ///<! [fNvar] Array of variables
 
-   virtual Int_t  Fill();
+   Int_t  Fill() override;
 
 private:
-   TNtupleD(const TNtupleD&);             // not implemented
-   TNtupleD& operator=(const TNtupleD&);  // not implemented
+   TNtupleD(const TNtupleD&) = delete;
+   TNtupleD& operator=(const TNtupleD&) = delete;
 
 public:
    TNtupleD();
    TNtupleD(const char *name,const char *title, const char *varlist, Int_t bufsize=32000);
    virtual ~TNtupleD();
 
-   virtual void      Browse(TBrowser *b);
+           void      Browse(TBrowser *b) override;
    virtual Int_t     Fill(const Double_t *x);
    virtual Int_t     Fill(Double_t x0, Double_t x1, Double_t x2=0, Double_t x3=0,
                           Double_t x4=0, Double_t x5=0, Double_t x6=0, Double_t x7=0,
@@ -51,11 +51,11 @@ public:
                           Double_t x14=0);
    virtual Int_t     GetNvar() const { return fNvar; }
            Double_t *GetArgs() const { return fArgs; }
-   virtual Long64_t  ReadStream(std::istream& inputstream, const char *branchDescriptor="", char delimiter = ' ');
-   virtual void      ResetBranchAddress(TBranch *);
-           void      ResetBranchAddresses();
+           Long64_t  ReadStream(std::istream& inputstream, const char *branchDescriptor="", char delimiter = ' ') override;
+           void      ResetBranchAddress(TBranch *) override;
+           void      ResetBranchAddresses() override;
 
-   ClassDef(TNtupleD,1)  //A simple tree with branches of floats.
+   ClassDefOverride(TNtupleD,1)  //A simple tree with branches of floats.
 };
 
 #endif

--- a/tree/tree/inc/TQueryResult.h
+++ b/tree/tree/inc/TQueryResult.h
@@ -107,15 +107,15 @@ protected:
 
 public:
    TQueryResult() : fSeqNum(-1), fDraw(0), fStatus(kSubmitted), fUsedCPU(0.),
-                    fInputList(0), fEntries(-1), fFirst(-1), fBytes(0),
-                    fLogFile(0), fSelecHdr(0), fSelecImp(0),
-                    fLibList("-"), fOutputList(0),
+                    fInputList(nullptr), fEntries(-1), fFirst(-1), fBytes(0),
+                    fLogFile(nullptr), fSelecHdr(nullptr), fSelecImp(nullptr),
+                    fLibList("-"), fOutputList(nullptr),
                     fFinalized(kFALSE), fArchived(kFALSE), fPrepTime(0.),
                     fInitTime(0.), fProcTime(0.), fMergeTime(0.),
                     fRecvTime(-1), fTermTime(0.), fNumWrks(-1), fNumMergers(-1) { }
    virtual ~TQueryResult();
 
-   void           Browse(TBrowser *b = 0);
+   void           Browse(TBrowser *b = nullptr) override;
 
    Int_t          GetSeqNum() const { return fSeqNum; }
    EQueryStatus   GetStatus() const { return fStatus; }
@@ -151,9 +151,9 @@ public:
 
    Bool_t         Matches(const char *ref);
 
-   void Print(Option_t *opt = "") const;
+   void           Print(Option_t *opt = "") const override;
 
-   ClassDef(TQueryResult,5)  //Class describing a query
+   ClassDefOverride(TQueryResult,5)  //Class describing a query
 };
 
 inline Bool_t operator!=(const TQueryResult &qr1,  const TQueryResult &qr2)

--- a/tree/tree/inc/TSelector.h
+++ b/tree/tree/inc/TSelector.h
@@ -53,8 +53,8 @@ public:
    virtual void        Init(TTree *) { }
    virtual void        Begin(TTree *) { }
    virtual void        SlaveBegin(TTree *) { }
-   virtual Bool_t      Notify() { return kTRUE; }
-   virtual const char *GetOption() const { return fOption; }
+           Bool_t      Notify() override { return kTRUE; }
+           const char *GetOption() const override { return fOption.Data(); }
    virtual Long64_t    GetStatus() const { return fStatus; }
    virtual Int_t       GetEntry(Long64_t /*entry*/, Int_t /*getall*/ = 0) { return 0; }
    virtual Bool_t      ProcessCut(Long64_t /*entry*/);
@@ -76,7 +76,7 @@ public:
    static  TSelector  *GetSelector(const char *filename);
    static  Bool_t      IsStandardDraw(const char *selec);
 
-   ClassDef(TSelector,2)  //A utility class for tree and object processing
+   ClassDefOverride(TSelector,2)  //A utility class for tree and object processing
 };
 
 #endif

--- a/tree/tree/inc/TSelectorList.h
+++ b/tree/tree/inc/TSelectorList.h
@@ -37,17 +37,17 @@ private:
 public:
    TSelectorList() : THashList() { SetOwner();}
 
-   void AddFirst(TObject *obj);
-   void AddFirst(TObject *obj, Option_t *opt);
-   void AddLast(TObject *obj);
-   void AddLast(TObject *obj, Option_t *opt);
-   void AddAt(TObject *obj, Int_t idx);
-   void AddAfter(const TObject *after, TObject *obj);
-   void AddAfter(TObjLink *after, TObject *obj);
-   void AddBefore(const TObject *before, TObject *obj);
-   void AddBefore(TObjLink *before, TObject *obj);
+   void AddFirst(TObject *obj) override;
+   void AddFirst(TObject *obj, Option_t *opt) override;
+   void AddLast(TObject *obj) override;
+   void AddLast(TObject *obj, Option_t *opt) override;
+   void AddAt(TObject *obj, Int_t idx) override;
+   void AddAfter(const TObject *after, TObject *obj) override;
+   void AddAfter(TObjLink *after, TObject *obj) override;
+   void AddBefore(const TObject *before, TObject *obj) override;
+   void AddBefore(TObjLink *before, TObject *obj) override;
 
-   ClassDef(TSelectorList,1)  //Special TList used in the TSelector
+   ClassDefOverride(TSelectorList,1)  //Special TList used in the TSelector
 };
 
 #endif

--- a/tree/tree/inc/TSelectorScalar.h
+++ b/tree/tree/inc/TSelectorScalar.h
@@ -40,9 +40,9 @@ public:
    ~TSelectorScalar() { }
 
    void     Inc(Long_t n = 1);
-   Int_t    Merge(TCollection *list);
+   Int_t    Merge(TCollection *list) override;
 
-   ClassDef(TSelectorScalar,1)  // Mergeable scalar
+   ClassDefOverride(TSelectorScalar,1)  // Mergeable scalar
 };
 
 

--- a/tree/tree/inc/TTreeCache.h
+++ b/tree/tree/inc/TTreeCache.h
@@ -129,8 +129,8 @@ public:
    TTreeCache();
    TTreeCache(TTree *tree, Int_t buffersize=0);
    virtual ~TTreeCache();
-   virtual Int_t        AddBranch(TBranch *b, Bool_t subgbranches = kFALSE);
-   virtual Int_t        AddBranch(const char *branch, Bool_t subbranches = kFALSE);
+   Int_t                AddBranch(TBranch *b, Bool_t subgbranches = kFALSE) override;
+   Int_t                AddBranch(const char *branch, Bool_t subbranches = kFALSE) override;
    virtual Int_t        DropBranch(TBranch *b, Bool_t subbranches = kFALSE);
    virtual Int_t        DropBranch(const char *branch, Bool_t subbranches = kFALSE);
    virtual void         Disable() {fEnabled = kFALSE;}
@@ -149,22 +149,22 @@ public:
    TTree               *GetTree() const {return fTree;}
    Bool_t               IsAutoCreated() const {return fAutoCreated;}
    virtual Bool_t       IsEnabled() const {return fEnabled;}
-   virtual Bool_t       IsLearning() const {return fIsLearning;}
+   Bool_t               IsLearning() const override {return fIsLearning;}
 
    virtual Bool_t       FillBuffer();
-   virtual Int_t        LearnBranch(TBranch *b, Bool_t subgbranches = kFALSE);
+   Int_t                LearnBranch(TBranch *b, Bool_t subgbranches = kFALSE) override;
    virtual void         LearnPrefill();
 
-   virtual void         Print(Option_t *option="") const;
-   virtual Int_t        ReadBuffer(char *buf, Long64_t pos, Int_t len);
+   void                 Print(Option_t *option="") const override;
+   Int_t                ReadBuffer(char *buf, Long64_t pos, Int_t len) override;
    virtual Int_t        ReadBufferNormal(char *buf, Long64_t pos, Int_t len);
    virtual Int_t        ReadBufferPrefetch(char *buf, Long64_t pos, Int_t len);
    virtual void         ResetCache();
    void                 ResetMissCache(); // Reset the miss cache.
    void                 SetAutoCreated(Bool_t val) {fAutoCreated = val;}
-   virtual Int_t        SetBufferSize(Int_t buffersize);
+   Int_t                SetBufferSize(Int_t buffersize) override;
    virtual void         SetEntryRange(Long64_t emin,   Long64_t emax);
-   virtual void         SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect);
+   void                 SetFile(TFile *file, TFile::ECacheAction action=TFile::kDisconnect) override;
    virtual void         SetLearnPrefill(EPrefillType type = kNoPrefill);
    static void          SetLearnEntries(Int_t n = 10);
    void                 SetOptimizeMisses(Bool_t opt);
@@ -172,7 +172,7 @@ public:
    virtual void         StopLearningPhase();
    virtual void         UpdateBranches(TTree *tree);
 
-   ClassDef(TTreeCache,3)  //Specialization of TFileCacheRead for a TTree
+   ClassDefOverride(TTreeCache,3)  //Specialization of TFileCacheRead for a TTree
 };
 
 #endif

--- a/tree/tree/inc/TTreeCacheUnzip.h
+++ b/tree/tree/inc/TTreeCacheUnzip.h
@@ -50,7 +50,7 @@ protected:
       // However, in future upgrade we cannot use make_vector in C++14.
       std::unique_ptr<char[]> *fUnzipChunks;     ///<! [fNseek] Individual unzipped chunks. Their summed size is kept under control.
       std::vector<Int_t>       fUnzipLen;        ///<! [fNseek] Length of the unzipped buffers
-      std::atomic<Byte_t>     *fUnzipStatus;     ///<! [fNSeek] 
+      std::atomic<Byte_t>     *fUnzipStatus;     ///<! [fNSeek]
 
       UnzipState() {
          fUnzipChunks = nullptr;
@@ -106,8 +106,8 @@ protected:
    Int_t       fNUnzip;           ///<! number of blocks that were unzipped
 
 private:
-   TTreeCacheUnzip(const TTreeCacheUnzip &);            //this class cannot be copied
-   TTreeCacheUnzip& operator=(const TTreeCacheUnzip &);
+   TTreeCacheUnzip(const TTreeCacheUnzip &) = delete;
+   TTreeCacheUnzip& operator=(const TTreeCacheUnzip &) = delete;
 
    char *fCompBuffer;
    Int_t fCompBufferSize;
@@ -120,13 +120,13 @@ public:
    TTreeCacheUnzip(TTree *tree, Int_t buffersize=0);
    virtual ~TTreeCacheUnzip();
 
-   virtual Int_t       AddBranch(TBranch *b, Bool_t subbranches = kFALSE);
-   virtual Int_t       AddBranch(const char *branch, Bool_t subbranches = kFALSE);
-   Bool_t              FillBuffer();
-   virtual Int_t       ReadBufferExt(char *buf, Long64_t pos, Int_t len, Int_t &loc);
-   void                SetEntryRange(Long64_t emin,   Long64_t emax);
-   virtual void        StopLearningPhase();
-   void                UpdateBranches(TTree *tree);
+   Int_t               AddBranch(TBranch *b, Bool_t subbranches = kFALSE) override;
+   Int_t               AddBranch(const char *branch, Bool_t subbranches = kFALSE) override;
+   Bool_t              FillBuffer() override;
+   Int_t               ReadBufferExt(char *buf, Long64_t pos, Int_t len, Int_t &loc) override;
+   void                SetEntryRange(Long64_t emin,   Long64_t emax) override;
+   void                StopLearningPhase() override;
+   void                UpdateBranches(TTree *tree) override;
 
    // Methods related to the thread
    static EParUnzipMode GetParallelUnzip();
@@ -138,10 +138,10 @@ public:
    Int_t          CreateTasks();
 #endif
    Int_t          GetRecordHeader(char *buf, Int_t maxbytes, Int_t &nbytes, Int_t &objlen, Int_t &keylen);
-   virtual Int_t  GetUnzipBuffer(char **buf, Long64_t pos, Int_t len, Bool_t *free);
+   Int_t          GetUnzipBuffer(char **buf, Long64_t pos, Int_t len, Bool_t *free) override;
    Int_t          GetUnzipGroupSize() { return fUnzipGroupSize; }
-   virtual void   ResetCache();
-   virtual Int_t  SetBufferSize(Int_t buffersize);
+   void           ResetCache() override;
+   Int_t          SetBufferSize(Int_t buffersize) override;
    void           SetUnzipBufferSize(Long64_t bufferSize);
    void           SetUnzipGroupSize(Int_t groupSize) { fUnzipGroupSize = groupSize; }
    static void    SetUnzipRelBufferSize(Float_t relbufferSize);
@@ -153,10 +153,10 @@ public:
    Int_t  GetNMissed(){ return fNMissed; }
    Int_t  GetNFound() { return fNFound; }
 
-   void Print(Option_t* option = "") const;
+   void Print(Option_t* option = "") const override;
 
    // static members
-   ClassDef(TTreeCacheUnzip,0)  //Specialization of TTreeCache for parallel unzipping
+   ClassDefOverride(TTreeCacheUnzip,0)  //Specialization of TTreeCache for parallel unzipping
 };
 
 #endif

--- a/tree/tree/inc/TTreeResult.h
+++ b/tree/tree/inc/TTreeResult.h
@@ -50,13 +50,13 @@ public:
    TTreeResult(Int_t nfields);
    virtual ~TTreeResult();
 
-   void        Close(Option_t *option="");
-   Int_t       GetFieldCount();
-   const char *GetFieldName(Int_t field);
-   TObjArray  *GetRows() const {return fResult;}
-   TSQLRow    *Next();
+   void        Close(Option_t *option="") override;
+   Int_t       GetFieldCount() override;
+   const char *GetFieldName(Int_t field) override;
+   TObjArray  *GetRows() const { return fResult; }
+   TSQLRow    *Next() override;
 
-   ClassDef(TTreeResult,1)  // TTree query result
+   ClassDefOverride(TTreeResult,1)  // TTree query result
 };
 
 #endif

--- a/tree/tree/inc/TTreeRow.h
+++ b/tree/tree/inc/TTreeRow.h
@@ -40,8 +40,8 @@ private:
    TTreeRow(TSQLRow *original);
    Bool_t  IsValid(Int_t field);
 
-   TTreeRow(const TTreeRow&);            // Not implemented.
-   TTreeRow &operator=(const TTreeRow&); // Not implemented.
+   TTreeRow(const TTreeRow&) = delete;
+   TTreeRow &operator=(const TTreeRow&) = delete;
 
 public:
    TTreeRow();
@@ -49,12 +49,12 @@ public:
    TTreeRow(Int_t nfields, const Int_t *fields, const char *row);
    virtual ~TTreeRow();
 
-   void        Close(Option_t *option="");
-   ULong_t     GetFieldLength(Int_t field);
-   const char *GetField(Int_t field);
+   void        Close(Option_t *option="") override;
+   ULong_t     GetFieldLength(Int_t field) override;
+   const char *GetField(Int_t field) override;
    void        SetRow(const Int_t *fields, const char *row);
 
-   ClassDef(TTreeRow,1)  // One row of a TTree query result
+   ClassDefOverride(TTreeRow,1)  // One row of a TTree query result
 };
 
 #endif

--- a/tree/tree/inc/TTreeSQL.h
+++ b/tree/tree/inc/TTreeSQL.h
@@ -53,8 +53,8 @@ protected:
    Bool_t                 fBranchChecked;
    TSQLTableInfo         *fTableInfo;
 
-   void                   CheckBasket(TBranch * tb);
-   Bool_t                 CheckBranch(TBranch * tb);
+   void                   CheckBasket(TBranch *tb);
+   Bool_t                 CheckBranch(TBranch *tb);
    Bool_t                 CheckTable(const TString &table) const;
    void                   CreateBranches();
    std::vector<Int_t>    *GetColumnIndice(TBranch *branch);
@@ -63,35 +63,35 @@ protected:
    TString                ConvertTypeName(const TString& typeName );
    virtual void           CreateBranch(const TString& branchName,const TString &typeName);
    Bool_t                 CreateTable(const TString& table);
-   virtual TBasket       *CreateBasket(TBranch * br);
+   TBasket               *CreateBasket(TBranch * br) override;
 
-   virtual TBranch *BranchImp(const char *branchname, const char *classname, TClass *ptrClass, void *addobj, Int_t bufsize, Int_t splitlevel);
-   virtual TBranch *BranchImp(const char *branchname, TClass *ptrClass, void *addobj, Int_t bufsize, Int_t splitlevel);
+   TBranch               *BranchImp(const char *branchname, const char *classname, TClass *ptrClass, void *addobj, Int_t bufsize, Int_t splitlevel) override;
+   TBranch               *BranchImp(const char *branchname, TClass *ptrClass, void *addobj, Int_t bufsize, Int_t splitlevel) override;
 
 public:
    TTreeSQL(TSQLServer * server, TString DB, const TString& table);
-
-   virtual Int_t          Branch(TCollection *list, Int_t bufsize=32000, Int_t splitlevel=99, const char *name="");
-   virtual Int_t          Branch(TList *list, Int_t bufsize=32000, Int_t splitlevel=99);
-   virtual Int_t          Branch(const char *folder, Int_t bufsize=32000, Int_t splitlevel=99);
-   virtual TBranch       *Bronch(const char *name, const char *classname, void *addobj, Int_t bufsize=32000, Int_t splitlevel=99);
-   virtual TBranch       *BranchOld(const char *name, const char *classname, void *addobj, Int_t bufsize=32000, Int_t splitlevel=1);
-   virtual TBranch       *Branch(const char *name, const char *classname, void *addobj, Int_t bufsize=32000, Int_t splitlevel=99);
-
-   virtual TBranch       *Branch(const char *name, void *address, const char *leaflist, Int_t bufsize);
-
-   virtual Int_t          Fill();
-   virtual Int_t          GetEntry(Long64_t entry=0, Int_t getall=0);
-   virtual Long64_t       GetEntries()    const;
-   virtual Long64_t       GetEntries(const char *sel) { return TTree::GetEntries(sel); }
-   virtual Long64_t       GetEntriesFast()const;
-           TString        GetTableName(){ return fTable; }
-   virtual Long64_t       LoadTree(Long64_t entry);
-   virtual Long64_t       PrepEntry(Long64_t entry);
-           void           Refresh();
-
    virtual ~TTreeSQL();
-   ClassDef(TTreeSQL,2);  // TTree Implementation read and write to a SQL database.
+
+   Int_t                  Branch(TCollection *list, Int_t bufsize=32000, Int_t splitlevel=99, const char *name="") override;
+   Int_t                  Branch(TList *list, Int_t bufsize=32000, Int_t splitlevel=99) override;
+   Int_t                  Branch(const char *folder, Int_t bufsize=32000, Int_t splitlevel=99) override;
+   TBranch               *Bronch(const char *name, const char *classname, void *addobj, Int_t bufsize=32000, Int_t splitlevel=99) override;
+   TBranch               *BranchOld(const char *name, const char *classname, void *addobj, Int_t bufsize=32000, Int_t splitlevel=1) override;
+   TBranch               *Branch(const char *name, const char *classname, void *addobj, Int_t bufsize=32000, Int_t splitlevel=99) override;
+
+   TBranch               *Branch(const char *name, void *address, const char *leaflist, Int_t bufsize) override;
+
+   virtual Int_t          Fill() override;
+   virtual Int_t          GetEntry(Long64_t entry=0, Int_t getall=0) override;
+   virtual Long64_t       GetEntries() const override;
+   Long64_t               GetEntries(const char *sel) override { return TTree::GetEntries(sel); }
+   Long64_t               GetEntriesFast()const override;
+   TString                GetTableName(){ return fTable; }
+   virtual Long64_t       LoadTree(Long64_t entry) override;
+   virtual Long64_t       PrepEntry(Long64_t entry);
+   void                   Refresh() override;
+
+   ClassDefOverride(TTreeSQL,2);  // TTree Implementation read and write to a SQL database.
 };
 
 

--- a/tree/tree/inc/TVirtualIndex.h
+++ b/tree/tree/inc/TVirtualIndex.h
@@ -47,7 +47,7 @@ public:
    virtual void           UpdateFormulaLeaves(const TTree *parent) = 0;
    virtual void           SetTree(const TTree *T) = 0;
 
-   ClassDef(TVirtualIndex,1);  //Abstract interface for Tree Index
+   ClassDefOverride(TVirtualIndex,1);  //Abstract interface for Tree Index
 };
 
 #endif


### PR DESCRIPTION
Let compile large ROOT-based project with `-Wsuggest-override` compile options.

At some point `-Wsuggest-override` can be add to `-Ddev=ON` compilation mode for ROOT itself