### PR TITLE
[RF] Error out when setting out-of-range variable value instead of clipping

### DIFF
--- a/README/ReleaseNotes/v638/index.md
+++ b/README/ReleaseNotes/v638/index.md
@@ -2,3 +2,13 @@
 
 * The `RooDataSet` constructors to construct a dataset from a part of an existing dataset were deprecated in ROOT 6.36 and are now removed. This is to avoid interface duplication. Please use `RooAbsData::reduce()` instead, or if you need to change the weight column, use the universal constructor with the `Import()`, `Cut()`, and `WeightVar()` arguments.
 * The `RooStats::HLFactory` class that was deprecated in ROOT 6.36 is now removed. It provided little advantage over using the RooWorkspace directly or any of the other higher-level frameworks that exist in the RooFit ecosystem.
+
+## RooFit
+
+### Error out when setting out-of-range variable value instead of silent clipping
+
+In previous versions, if you set the value of a variable with `RooRealVar::setVal()`, the value was silently clippend when it was outside the variable range.
+This silent mutation of data can be dangerous.
+With ROOT 6.38, an exception will be thrown instead.
+If you know what you are doing and want to restore the old clipping behavior, you can do so with `RooRealVar::enableSilentClipping()`, but this is not recommended.
+

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -55,6 +55,7 @@ public:
   std::size_t valueResetCounter() const { return _valueResetCounter; }
   void setVal(double value) override;
   void setVal(double value, const char* rangeName) override;
+  static void enableSilentClipping(bool flag = true);
   inline double getError() const { return _error>=0?_error:0. ; }
   inline bool hasError(bool allowZero=true) const { return allowZero ? (_error>=0) : (_error>0) ; }
   inline void setError(double value) { _error= value ; }
@@ -167,6 +168,8 @@ public:
   std::shared_ptr<RooRealVarSharedProperties> _sharedProp; ///<! Shared binnings associated with this instance
 
   std::size_t _valueResetCounter = 0; ///<! How many times the value of this variable was reset
+
+  static bool &isSilentClippingEnabled();
 
   ClassDefOverride(RooRealVar,10); // Real-valued variable
 };

--- a/roofit/roofitcore/test/stressRooFit_tests.h
+++ b/roofit/roofitcore/test/stressRooFit_tests.h
@@ -3529,28 +3529,6 @@ public:
       // Perform fit and save result
       std::unique_ptr<RooFitResult> r{model.fitTo(*data, Save())};
 
-      // V i s u a l i z e   c o r r e l a t i o n   m a t r i x
-      // -------------------------------------------------------
-
-      // Construct 2D color plot of correlation matrix
-      gStyle->SetOptStat(0);
-      gStyle->SetPalette(1);
-      TH2 *hcorr = r->correlationHist();
-
-      // Sample dataset with parameter values according to distribution
-      // of covariance matrix of fit result
-      RooDataSet randPars("randPars", "randPars", r->floatParsFinal());
-      for (int i = 0; i < 10000; i++) {
-         randPars.add(r->randomizePars());
-      }
-
-      // make histogram of 2D distribution in sigma1 vs sig1frac
-      TH1 *hhrand =
-         randPars.createHistogram("hhrand", sigma1, Binning(35, 0.25, 0.65), YVar(sig1frac, Binning(35, 0.3, 1.1)));
-
-      regTH(hcorr, "rf607_hcorr");
-      regTH(hhrand, "rf607_hhand");
-
       return true;
    }
 };

--- a/roofit/roofitcore/test/test_lib.h
+++ b/roofit/roofitcore/test/test_lib.h
@@ -117,12 +117,14 @@ generate_ND_gaussian_pdf_nll(RooWorkspace &ws, unsigned int n, unsigned long nEv
       {
          std::ostringstream os;
          os << "m" << ix;
-         dynamic_cast<RooRealVar *>(ws.arg(os.str()))->setVal(RooRandom::randomGenerator()->Gaus(0, 2));
+         auto *val = static_cast<RooRealVar *>(ws.arg(os.str().c_str()));
+         val->setVal(RooRandom::randomGenerator()->Uniform(val->getMin(), val->getMax()));
       }
       {
          std::ostringstream os;
          os << "s" << ix;
-         dynamic_cast<RooRealVar *>(ws.arg(os.str()))->setVal(0.1 + std::abs(RooRandom::randomGenerator()->Gaus(0, 2)));
+         auto *val = static_cast<RooRealVar *>(ws.arg(os.str().c_str()));
+         val->setVal(RooRandom::randomGenerator()->Uniform(val->getMin(), val->getMax()));
       }
    }
 

--- a/tutorials/roofit/roofit/rf111_derivatives.C
+++ b/tutorials/roofit/roofit/rf111_derivatives.C
@@ -14,12 +14,15 @@
 /// \date July 2008
 /// \author Wouter Verkerke
 
+#include "RooDerivative.h"
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooGaussian.h"
+#include "RooPlot.h"
+
 #include "TCanvas.h"
 #include "TAxis.h"
-#include "RooPlot.h"
+
 using namespace RooFit;
 
 void rf111_derivatives()
@@ -31,6 +34,12 @@ void rf111_derivatives()
    RooRealVar x("x", "x", -10, 10);
    RooRealVar mean("mean", "mean of gaussian", 1, -10, 10);
    RooRealVar sigma("sigma", "width of gaussian", 1, 0.1, 10);
+
+   // Ranges for plotting derivatives. They can't be the full range, because
+   // the derivatives is calculated by variation around the central point. We
+   // need to ensure that the varied values are still in the full range.
+   x.setRange("plotrange", -9.95, 9.95);
+   sigma.setRange("plotrange", 0.15, 1.95);
 
    // Build gaussian pdf in terms of x,mean and sigma
    RooGaussian gauss("gauss", "gaussian PDF", x, mean, sigma);
@@ -52,9 +61,9 @@ void rf111_derivatives()
    gauss.plotOn(xframe);
 
    // Plot derivatives in same frame
-   dgdx->plotOn(xframe, LineColor(kMagenta));
-   d2gdx2->plotOn(xframe, LineColor(kRed));
-   d3gdx3->plotOn(xframe, LineColor(kOrange));
+   dgdx->plotOn(xframe, LineColor(kMagenta), Range("plotrange"));
+   d2gdx2->plotOn(xframe, LineColor(kRed), Range("plotrange"));
+   d3gdx3->plotOn(xframe, LineColor(kOrange), Range("plotrange"));
 
    // C r e a t e   a n d   p l o t  d e r i v a t i v e s   w . r . t .   s i g m a
    // ------------------------------------------------------------------------------
@@ -73,9 +82,9 @@ void rf111_derivatives()
    gauss.plotOn(sframe);
 
    // Plot derivatives in same frame
-   dgds->plotOn(sframe, LineColor(kMagenta));
-   d2gds2->plotOn(sframe, LineColor(kRed));
-   d3gds3->plotOn(sframe, LineColor(kOrange));
+   dgds->plotOn(sframe, LineColor(kMagenta), Range("plotrange"));
+   d2gds2->plotOn(sframe, LineColor(kRed), Range("plotrange"));
+   d3gds3->plotOn(sframe, LineColor(kOrange), Range("plotrange"));
 
    // Draw all frames on a canvas
    TCanvas *c = new TCanvas("rf111_derivatives", "rf111_derivatives", 800, 400);

--- a/tutorials/roofit/roofit/rf111_derivatives.py
+++ b/tutorials/roofit/roofit/rf111_derivatives.py
@@ -25,6 +25,12 @@ x = ROOT.RooRealVar("x", "x", -10, 10)
 mean = ROOT.RooRealVar("mean", "mean of gaussian", 1, -10, 10)
 sigma = ROOT.RooRealVar("sigma", "width of gaussian", 1, 0.1, 10)
 
+# Ranges for plotting derivatives. They can't be the full range, because
+# the derivatives is calculated by variation around the central point. We
+# need to ensure that the varied values are still in the full range.
+x.setRange("plotrange", -9.95, 9.95)
+sigma.setRange("plotrange", 0.15, 1.95)
+
 # Build gaussian pdf in terms of x, and sigma
 gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
 
@@ -45,9 +51,9 @@ xframe = x.frame(Title="d(Gauss)/dx")
 gauss.plotOn(xframe)
 
 # Plot derivatives in same frame
-dgdx.plotOn(xframe, LineColor="m")
-d2gdx2.plotOn(xframe, LineColor="r")
-d3gdx3.plotOn(xframe, LineColor="kOrange")
+dgdx.plotOn(xframe, LineColor="m", Range="plotrange")
+d2gdx2.plotOn(xframe, LineColor="r", Range="plotrange")
+d3gdx3.plotOn(xframe, LineColor="kOrange", Range="plotrange")
 
 # Create and plot derivatives w.r.t. sigma
 # ------------------------------------------------------------------------------
@@ -66,9 +72,9 @@ sframe = sigma.frame(Title="d(Gauss)/d(sigma)", Range=(0.0, 2.0))
 gauss.plotOn(sframe)
 
 # Plot derivatives in same frame
-dgds.plotOn(sframe, LineColor="m")
-d2gds2.plotOn(sframe, LineColor="r")
-d3gds3.plotOn(sframe, LineColor="kOrange")
+dgds.plotOn(sframe, LineColor="m", Range="plotrange")
+d2gds2.plotOn(sframe, LineColor="r", Range="plotrange")
+d3gds3.plotOn(sframe, LineColor="kOrange", Range="plotrange")
 
 # Draw all frames on a canvas
 c = ROOT.TCanvas("rf111_derivatives", "rf111_derivatives", 800, 400)


### PR DESCRIPTION
In previous ROOT versions, if you set the value of a variable with
`RooRealVar::setVal()`, the value was silently clippend when it was
outside the variable range. This silent mutation of data can be
dangerous. With ROOT 6.36, an exception will be thrown instead. If you
know what you are doing and want to restore the old clipping behavior,
you can do so with `RooRealVar::enableSilentClipping()`, but this is not
recommended.

This change caught a logic error in `stressRooFit` where a background
fraction was randomized to be outside the `[0,1]` interval. That part of
the test was therefore removed (it was already removed from the
corresponding tutorial).

Closes https://github.com/root-project/root/issues/6937.
