### PR TITLE
Test the files existence before using them

### DIFF
--- a/tutorials/fit/fit1.C
+++ b/tutorials/fit/fit1.C
@@ -37,8 +37,11 @@ void fit1() {
    //
    TString dir = gROOT->GetTutorialDir();
    dir.Append("/fit/");
-   TFile *file = TFile::Open("fillrandom.root");
-   if (!file) {
+   TFile *file = nullptr;
+   if (!gSystem->AccessPathName("fillrandom.root")) {
+      // file exists
+      file = TFile::Open("fillrandom.root");
+   } else {
       gROOT->ProcessLine(Form(".x %s../hist/fillrandom.C(0)",dir.Data()));
       file = TFile::Open("fillrandom.root");
       if (!file) return;

--- a/tutorials/histfactory/example.py
+++ b/tutorials/histfactory/example.py
@@ -20,6 +20,9 @@ def main():
     """
 
     InputFile = "./data/example.root"
+    if (ROOT.gSystem.AccessPathName(InputFile)) :
+        ROOT.Info("example.py", InputFile+" does not exist")
+        exit()
 
     # Create the measurement
     meas = ROOT.RooStats.HistFactory.Measurement("meas", "meas")
@@ -68,7 +71,7 @@ def main():
     meas.AddChannel( chan )
 
     # Collect the histograms from their files,
-    # print some output, 
+    # print some output,
     meas.CollectHistograms()
     meas.PrintTree();
 

--- a/tutorials/pyroot/fit1.py
+++ b/tutorials/pyroot/fit1.py
@@ -9,6 +9,7 @@
 ##
 ## \author Wim Lavrijsen
 
+import ROOT
 from os import path
 from ROOT import TCanvas, TFile, TPaveText
 from ROOT import gROOT, gBenchmark
@@ -24,7 +25,12 @@ gBenchmark.Start( 'fit1' )
 #
 # We connect the ROOT file generated in a previous tutorial
 #
-fill = TFile( 'py-fillrandom.root' )
+File = "py-fillrandom.root"
+if (ROOT.gSystem.AccessPathName(File)) :
+    ROOT.Info("fit1.py", File+" does not exist")
+    exit()
+
+fill = TFile(File)
 
 #
 # The function "ls()" lists the directory contents of this file

--- a/tutorials/pyroot/h1ReadAndDraw.py
+++ b/tutorials/pyroot/h1ReadAndDraw.py
@@ -9,6 +9,7 @@
 ##
 ## \author Wim Lavrijsen
 
+import ROOT
 from ROOT import TCanvas, TPad, TFile, TPaveLabel, TPaveText
 from ROOT import gROOT
 
@@ -23,7 +24,12 @@ pad3.Draw()
 #
 # We connect the ROOT file generated in a previous tutorial
 #
-example = TFile( 'py-hsimple.root' )
+File = "py-hsimple.root"
+if (ROOT.gSystem.AccessPathName(File)) :
+    ROOT.Info("h1ReadAndDraw.py", File+" does not exist")
+    exit()
+
+example = TFile(File)
 example.ls()
 
 # Draw a global picture title

--- a/tutorials/tmva/tmva102_Testing.py
+++ b/tutorials/tmva/tmva102_Testing.py
@@ -21,7 +21,12 @@ from tmva101_Training import load_data
 x, y_true, w = load_data("test_signal.root", "test_background.root")
 
 # Load trained model
-bdt = ROOT.TMVA.Experimental.RBDT[""]("myBDT", "tmva101.root")
+File = "tmva101.root"
+if (ROOT.gSystem.AccessPathName(File)) :
+    ROOT.Info("tmva102_Testing.py", File+"does not exist")
+    exit()
+
+bdt = ROOT.TMVA.Experimental.RBDT[""]("myBDT", File)
 
 # Make prediction
 y_pred = bdt.Compute(x)


### PR DESCRIPTION
Using TFile::Open produces an Error message catch by the jenkins rules declaring the doc failure. These changes test the file existence before using them. A warning (not an Error) is printed if not.
