### PR TITLE
v626 stdpair: Don't reuse of emulated StreamerInfo (when having compiled info)

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -4623,7 +4623,7 @@ TVirtualStreamerInfo* TClass::GetStreamerInfoImpl(Int_t version, Bool_t silent) 
    //          user requested the emulated streamerInfo for an abstract
    //          base class, even though we have a dictionary for it.
 
-   if ((version < -1) || (version >= fStreamerInfo->GetSize())) {
+   if ((version < -1) || (version >= (fStreamerInfo->GetSize()-1))) {
       Error("GetStreamerInfo", "class: %s, attempting to access a wrong version: %d", GetName(), version);
       // FIXME: Shouldn't we go to -1 here, or better just abort?
       version = fClassVersion;

--- a/io/io/src/TGenCollectionProxy.cxx
+++ b/io/io/src/TGenCollectionProxy.cxx
@@ -905,7 +905,7 @@ TGenCollectionProxy *TGenCollectionProxy::InitializeEx(Bool_t silent)
                               nam.c_str());
                      }
                   } else {
-                     if (paircl->GetClassSize() != fValDiff) {
+                     if ((!paircl->IsSyntheticPair() && paircl->GetState() < TClass::kInterpreted) || paircl->GetClassSize() != fValDiff) {
                         if (paircl->GetState() >= TClass::kInterpreted)
                            Fatal("InitializeEx",
                                  "The %s for %s reports a class size that is inconsistent with the one registered "


### PR DESCRIPTION
Previously it was reused it just 'happened' to have the expected size. (This applies only for the treatment of the TClass for an std::pair) and help fix the tests on 32 bits platforms.

See test: https://github.com/root-project/roottest/pull/869

backport of https://github.com/root-project/root/pull/10416
