### PR TITLE
PaintArrow shifted the bin center by an arbitrary value (0.03)

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -4669,8 +4669,8 @@ void THistPainter::PaintArrows(Option_t *)
    Double_t yrg = gPad->GetUymin();
    Double_t xln = gPad->GetUxmax() - xrg;
    Double_t yln = gPad->GetUymax() - yrg;
-   Double_t cx  = (xln/Double_t(ncx) -0.03)/2;
-   Double_t cy  = (yln/Double_t(ncy) -0.03)/2;
+   Double_t cx  = (xln/Double_t(ncx))/2.;
+   Double_t cy  = (yln/Double_t(ncy))/2.;
    Double_t dn  = 1.E-30;
 
    auto arrow = new TArrow();


### PR DESCRIPTION
The following example produced a weird plot:
```
{
   TH2D *blah = new TH2D("","",11,0.079,0.101,8,-0.0075,0.0005);
   for (int i=1; i<=blah->GetNbinsX();i++) {
      for (int j=1; j<=blah->GetNbinsY();j++) blah->SetBinContent(i, j, i*j);
   }
   blah->Draw("ARR");
}
```
<img width="695" alt="Screenshot 2022-04-28 at 11 20 41" src="https://user-images.githubusercontent.com/4697738/165725025-64cd7c79-6fd8-4bac-9739-9d10d0a8f21e.png">

This was because the bin center was shifted by an arbitrary value of 0.03. When the axis dynamic was large compared to 0.03 this was not visible. In the above example, it is not the case and therefore the plot was wrong. Removing that arbitrary shift gives the right plot.

<img width="687" alt="Screenshot 2022-04-28 at 11 44 44" src="https://user-images.githubusercontent.com/4697738/165725594-ed76528f-f409-4f56-9143-bd798ab1a49f.png">

This arbitrary shift comes from the 22 years old FORTRAN version of the code.