### PR TITLE
[ntuple] Add test for classes using empty base optimization

### DIFF
--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -34,6 +34,12 @@ struct DerivedC : public DerivedA, public DerivedA2 {
    DerivedA2 c_a2;
 };
 
+struct EmptyBase {
+};
+struct alignas(std::uint64_t) TestEBO : public EmptyBase {
+   std::uint64_t u64;
+};
+
 /// The classes below are based on an excerpt provided by Marcin Nowak (EP-UAT)
 ///
 struct IAuxSetOption {};

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -9,6 +9,7 @@
 #pragma link C++ class DerivedA2+;
 #pragma link C++ class DerivedB+;
 #pragma link C++ class DerivedC+;
+#pragma link C++ class TestEBO+;
 
 #pragma link C++ class IAuxSetOption+;
 #pragma link C++ class PackedParameters+;


### PR DESCRIPTION
Add a unit test that checks RNTuple serialization/deserialization of classes using empty base optimization.

## Checklist:
- [X] tested changes locally

This PR fixes #10323.