### PR TITLE
Generate an error at the end of XML file

### DIFF
--- a/tutorials/xml/SAXHandler.C
+++ b/tutorials/xml/SAXHandler.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_xml
-/// \notebook -nodraw
+///
 /// ROOT implementation of a simple SAX Handler.
 ///
 /// This handler uses TSAXParser, a SAX Parser using the SAX interface


### PR DESCRIPTION
In notebook this script generates:
```
Error in <TXMLEngine::ParseFile>: Unexpected end of xml file
```
This patch deactivate the notebook generation as this error seems to be the last one preventing to have
the ref guide build green.
