### PR TITLE
[DF] Teach `GraphAsymmErrors` to accept systematic variations

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -704,6 +704,13 @@ public:
    std::string GetActionName() { return "GraphAsymmErrors"; }
 
    Result_t &PartialUpdate(unsigned int slot) { return *fGraphAsymmErrors[slot]; }
+
+   FillTGraphAsymmErrorsHelper MakeNew(void *newResult)
+   {
+      auto &result = *static_cast<std::shared_ptr<TGraphAsymmErrors> *>(newResult);
+      result->Set(0);
+      return FillTGraphAsymmErrorsHelper(result, fGraphAsymmErrors.size());
+   }
 };
 
 // In case of the take helper we have 4 cases:


### PR DESCRIPTION
Fix #10041 - Teach `GraphAsymmErrors` to accept systematic variations.
This is tested against the test [here](https://github.com/eguiraud/root/blob/e5dd150ac29bb2d6439c2138891cd65fab61a2f5/tree/dataframe/test/dataframe_vary.cxx#L941) (yet to be pushed to master).
