### PR TITLE
[skip-ci] Xml tutorials generate errors

### DIFF
--- a/tutorials/xml/DOMParsePerson.C
+++ b/tutorials/xml/DOMParsePerson.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_xml
-/// \notebook -nodraw
+///
 /// ROOT implementation of a XML DOM Parser
 ///
 /// This is an example of how Dom Parser works. It will parse the xml file

--- a/tutorials/xml/DOMRecursive.C
+++ b/tutorials/xml/DOMRecursive.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_xml
-/// \notebook -nodraw
+///
 /// ROOT implementation of a XML DOM Parser
 ///
 /// This is an example of how Dom Parser walks the DOM tree recursively.

--- a/tutorials/xml/xmlnewfile.C
+++ b/tutorials/xml/xmlnewfile.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_xml
-/// \notebook -nodraw
+///
 /// Example to create a new xml file with the TXMLEngine class
 ///
 /// \macro_code


### PR DESCRIPTION

More XML tutorials generate errors when converted into notebooks.

