### PR TITLE
[RF] Add `RooAbsCollection::sortTopologically()` member function

### DIFF
--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -335,6 +335,7 @@ public:
   void takeOwnership() { _ownCont = kTRUE ; }
 
   void sort(Bool_t reverse = false);
+  void sortTopologically();
 
   void RecursiveRemove(TObject *obj) override;
 

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -355,9 +355,9 @@ protected:
   Storage_t _list;  ///< Actual object storage
   using LegacyIterator_t = TIteratorToSTLInterface<Storage_t>;
 
-  Bool_t _ownCont;  ///< Flag to identify a list that owns its contents.
-  TString _name;    ///< Our name.
-  Bool_t _allRRV ;  ///< All contents are RRV
+  Bool_t _ownCont = false; ///< Flag to identify a list that owns its contents.
+  TString _name;           ///< Our name.
+  Bool_t _allRRV = true;   ///< All contents are RRV
 
   void deleteList() ;
 
@@ -372,8 +372,8 @@ protected:
 
   inline void clearStructureTags() { _structureTag=0 ; _typedStructureTag = 0 ; }
 
-  void makeStructureTag() ;
-  void makeTypedStructureTag() ;
+  void makeStructureTag() {}
+  void makeTypedStructureTag() {}
 
   /// Determine whether it's possible to add a given RooAbsArg to the collection or not.
   virtual bool canBeAdded(const RooAbsArg& arg, bool silent) const = 0;
@@ -392,7 +392,7 @@ private:
 
   using HashAssistedFind = RooFit::Detail::HashAssistedFind;
   mutable std::unique_ptr<HashAssistedFind> _hashAssistedFind; ///<!
-  std::size_t _sizeThresholdForMapSearch; ///<!
+  std::size_t _sizeThresholdForMapSearch = 100; ///<!
 
   void insert(RooAbsArg*);
 

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1571,6 +1571,40 @@ void RooAbsCollection::sort(bool reverse) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Sort collection topologically: the servers of any RooAbsArg will be before
+/// that RooAbsArg in the collection. Will throw an exception if servers
+/// are missing in the collection.
+
+void RooAbsCollection::sortTopologically() {
+   std::unordered_set<TNamed const *> seenArgs;
+   for (std::size_t iArg = 0; iArg < _list.size(); ++iArg) {
+      RooAbsArg *arg = _list[iArg];
+      bool movedArg = false;
+      for (RooAbsArg *server : arg->servers()) {
+         if (seenArgs.find(server->namePtr()) == seenArgs.end()) {
+            auto found = std::find_if(_list.begin(), _list.end(),
+                                      [server](RooAbsArg *elem) { return elem->namePtr() == server->namePtr(); });
+            if (found == _list.end()) {
+               std::stringstream ss;
+               ss << "RooAbsArg \"" << arg->GetName() << "\" depends on \"" << server->GetName()
+                  << "\", but this arg is missing in the collection!";
+               throw std::runtime_error(ss.str());
+            }
+            _list.erase(found);
+            _list.insert(_list.begin() + iArg, server);
+            movedArg = true;
+            break;
+         }
+      }
+      if (movedArg) {
+         --iArg;
+         continue;
+      }
+      seenArgs.insert(arg->namePtr());
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Factory for legacy iterators.
 
 std::unique_ptr<RooAbsCollection::LegacyIterator_t> RooAbsCollection::makeLegacyIterator (bool forward) const {


### PR DESCRIPTION
Add member function to RooAbsCollection to sort topologically: the
servers of any RooAbsArg will be before that RooAbsArg in the
collection. Will throw an exception if servers are missing in the
collection.

This function is useful for computation graph analysis like in the
RooFitDriver.

In a second commit in this PR, some general code modernization to RooAbsCollection.cxx is done such that the total number of lines doesn't increase with the newly-added member function.

