### PR TITLE
[RF] Less code duplication in RooDataSet subset constructors

### DIFF
--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -47,12 +47,10 @@ public:
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 
-  // Ctors from TTree
-  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName=0) ;
+  // Constructor from TTree
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ;
 
-  // Ctors from DataStore
-  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName=0) ;
+  // Constructor from DataStore
   RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=0, const char* wgtVarName=0) ;
 
   RooTreeDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -711,28 +711,8 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset
 /// subset of an existing data
 
 RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset,
-             const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
-  RooAbsData(name,title,vars)
-{
-  // Initialize datastore
-  _dstore = new RooTreeDataStore(name,title,_vars,*dset->_dstore,cutVar,wgtVarName) ;
-
-  appendToDir(this,kTRUE) ;
-
-  if (wgtVarName) {
-    // Use the supplied weight column
-    initialize(wgtVarName) ;
-  } else {
-    if (dset->_wgtVar && vars.find(dset->_wgtVar->GetName())) {
-      // Use the weight column of the source data set
-      initialize(dset->_wgtVar->GetName()) ;
-    } else {
-      initialize(0) ;
-    }
-  }
-  TRACE_CREATE
-}
-
+             const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName)
+  : RooDataSet{name, title, dset, vars, cutVar.expression(), wgtVarName} {}
 
 
 
@@ -751,28 +731,8 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset
 /// constructor with a string based cut expression is recommended.
 
 RooDataSet::RooDataSet(RooStringView name, RooStringView title, TTree *theTree,
-    const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName) :
-  RooAbsData(name,title,vars)
-{
-  // Create tree version of datastore
-  RooTreeDataStore* tstore = new RooTreeDataStore(name,title,_vars,*theTree,cutVar,wgtVarName) ;
-
-  // Convert to vector datastore if needed
-  if (defaultStorageType==Tree) {
-    _dstore = tstore ;
-  } else if (defaultStorageType==Vector) {
-    RooVectorDataStore* vstore = new RooVectorDataStore(name,title,_vars,wgtVarName) ;
-    _dstore = vstore ;
-    _dstore->append(*tstore) ;
-    delete tstore ;
-  } else {
-    _dstore = 0 ;
-  }
-
-  appendToDir(this,kTRUE) ;
-  initialize(wgtVarName) ;
-  TRACE_CREATE
-}
+    const RooArgSet& vars, const RooFormulaVar& cutVar, const char* wgtVarName)
+  : RooDataSet{name, title, theTree, vars, cutVar.expression(), wgtVarName} {}
 
 
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -101,21 +101,6 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
 }
 
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const RooFormulaVar& select, const char* wgtVarName) :
-  RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName))
-{
-  initialize() ;
-  loadValues(&t,&select) ;
-}
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 
 RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr, const char* wgtVarName) :
@@ -133,20 +118,6 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, cons
     loadValues(&t);
   }
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const RooFormulaVar& select, const char* wgtVarName) :
-  RooAbsDataStore(name,title,varsNoWeight(vars,wgtVarName)),
-  _varsww(vars),
-  _wgtVar(weightVar(vars,wgtVarName))
-{
-  initialize() ;
-  loadValues(&tds,&select) ;
-}
-
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In RooDataSet, there are constructors to create a dataset as a subset of
another RooDataSet or a TTree, passing either a cut string or a
RooFormulaVar as the cut variable.

There were two implementations for the cut string and the RooFormulaVar
case, but it's better to implement one in terms of the other to avoid
code duplication and divergence.

The RooFormulaVar version has to be implemented in terms of the cut
string version, because the cut string version is more general: it can
also take an empty string, signifying no cut.

Removing functions from the public interface of the data store classes is
okay, because as implementation details of the RooFit dataset classes
they are not supposed to be public anyway.