### PR TITLE
[skip-ci] Some files in the webgui tutorials should not be scanned by doxygen.

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -985,7 +985,10 @@ EXCLUDE_PATTERNS       = */G__* \
                          LinkDef*.h \
                          launcher.py \
                          */io/io/res/* \
-                         */src/lexertk.hpp
+                         */src/lexertk.hpp \
+                         *.xml \
+                         *.dtd \
+                         */tutorials/webgui/qt5web/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION

Some files in the webgui tutorials should not be scanned by doxygen. They produce errors.