### PR TITLE
[cmake,config] Warn if the C++ standard does not match ROOT's

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -679,6 +679,11 @@ if(PYTHON_VERSION_STRING_Development_Other)
 endif()
 
 #---RConfigure.h---------------------------------------------------------------------------------------------
+try_compile(has__cplusplus "${CMAKE_BINARY_DIR}" SOURCES "${CMAKE_SOURCE_DIR}/config/__cplusplus.cxx"
+            OUTPUT_VARIABLE __cplusplus_PPout)
+string(REGEX MATCH "__cplusplus=([0-9]+)" __cplusplus "${__cplusplus_PPout}")
+set(__cplusplus ${CMAKE_MATCH_1}L)
+
 configure_file(${PROJECT_SOURCE_DIR}/config/RConfigure.in ginclude/RConfigure.h NEWLINE_STYLE UNIX)
 install(FILES ${CMAKE_BINARY_DIR}/ginclude/RConfigure.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 

--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -22,6 +22,11 @@
 
 #define EXTRAICONPATH "@extraiconpath@"
 
+#define ROOT__cplusplus @__cplusplus@
+#if defined(__cplusplus) && (__cplusplus != ROOT__cplusplus)
+# warning "The C++ standard in this build does not match ROOT configuration (@__cplusplus@); this might cause unexpected issues"
+#endif
+
 #@setresuid@ R__HAS_SETRESUID   /**/
 #@hasmathmore@ R__HAS_MATHMORE   /**/
 #@haspthread@ R__HAS_PTHREAD    /**/

--- a/config/__cplusplus.cxx
+++ b/config/__cplusplus.cxx
@@ -1,0 +1,10 @@
+#define _STRINGIFY(x) #x
+#define STRINGIFY(x) _STRINGIFY(x)
+
+// `#pragma message` is supported in well-known compilers including gcc, clang, icc, and MSVC
+#pragma message("__cplusplus=" STRINGIFY(__cplusplus))
+
+int main(void)
+{
+   return 0;
+}


### PR DESCRIPTION
Building external applications that use ROOT oftentimes fail if there is a mismatch in the C++ standard between ROOT and the application.

To make this visible, diagnose if there is a mismatch in the value of the `__cplusplus` macro w.r.t. when ROOT was configured.
The check is performed in `RConfigure.h`, a common header also included in backports, e.g. RStringView.hxx.

## Changes or fixes:
- Generated `RConfigure.h` during build defines `ROOT__cplusplus`, which contains the value of the  `__cplusplus` macro at the time ROOT was configured.
- Because `RConfigure.h` is included from many ROOT headers (e.g., backports), it seems a viable candidate to also add the mismatch check.
On mismatch, emit a warning (should it be an `#error` instead?).

## Checklist:
- [X] tested changes locally

This PR fixes #8063.