### PR TITLE
[rbrowser] let access in-memory objects from TDirectory

### DIFF
--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -111,6 +111,7 @@ std::shared_ptr<ROOT::Experimental::RCanvas> ROOT::Experimental::RCanvas::Create
 
    if (!RCanvasCleanup::gInstance) {
       auto cleanup = new RCanvasCleanup();
+      TDirectory::TContext ctxt(nullptr);
       TDirectory *dummydir = new TDirectory("rcanvas_cleanup_dummydir","title");
       dummydir->GetList()->Add(cleanup);
       gROOT->GetListOfClosedObjects()->Add(dummydir);

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -80,23 +80,6 @@ void ROOT::Experimental::RCanvas::Update(bool async, CanvasCallback_t callback)
       fPainter->CanvasUpdated(fModified, async, callback);
 }
 
-class RCanvasCleanup : public TObject {
-public:
-
-   static RCanvasCleanup *gInstance;
-
-   RCanvasCleanup() : TObject() { gInstance = this; }
-
-   virtual ~RCanvasCleanup()
-   {
-      gInstance = nullptr;
-      ROOT::Experimental::RCanvas::ReleaseHeldCanvases();
-   }
-};
-
-RCanvasCleanup *RCanvasCleanup::gInstance = nullptr;
-
-
 ///////////////////////////////////////////////////////////////////////////////////////
 /// Create new canvas instance
 
@@ -107,14 +90,6 @@ std::shared_ptr<ROOT::Experimental::RCanvas> ROOT::Experimental::RCanvas::Create
    {
       std::lock_guard<std::mutex> grd(GetHeldCanvasesMutex());
       GetHeldCanvases().emplace_back(pCanvas);
-   }
-
-   if (!RCanvasCleanup::gInstance) {
-      auto cleanup = new RCanvasCleanup();
-      TDirectory::TContext ctxt(nullptr);
-      TDirectory *dummydir = new TDirectory("rcanvas_cleanup_dummydir","title");
-      dummydir->GetList()->Add(cleanup);
-      gROOT->GetListOfClosedObjects()->Add(dummydir);
    }
 
    return pCanvas;

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -36,6 +36,8 @@ protected:
 
    bool IsSame(TObject *obj) const { return obj == fObj; }
 
+   virtual bool CheckObject() const;
+
 public:
    TObjectElement(TObject *obj, const std::string &name = "");
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -299,12 +299,27 @@ TObjectElement::TObjectElement(std::unique_ptr<RHolder> &obj, const std::string 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Check if object still exsists
+
+bool TObjectElement::CheckObject() const
+{
+   if (!fObj) return false;
+   if (fObj->IsZombie()) {
+      auto self = const_cast<TObjectElement *>(this);
+      self->fObj = nullptr;
+      return false;
+   }
+   return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
 /// Returns name of the TObject
 
 std::string TObjectElement::GetName() const
 {
    if (!fName.empty()) return fName;
-   return fObj ? fObj->GetName() : "";
+   return CheckObject() ? fObj->GetName() : "";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -312,7 +327,7 @@ std::string TObjectElement::GetName() const
 
 std::string TObjectElement::GetTitle() const
 {
-   return fObj ? fObj->GetTitle() : "";
+   return CheckObject() ? fObj->GetTitle() : "";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -320,7 +335,7 @@ std::string TObjectElement::GetTitle() const
 
 bool TObjectElement::IsFolder() const
 {
-   return fObj ? fObj->IsFolder() : false;
+   return CheckObject() ? fObj->IsFolder() : false;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -364,7 +379,7 @@ std::unique_ptr<RHolder> TObjectElement::GetObject()
 
 const TClass *TObjectElement::GetClass() const
 {
-   return fObj ? fObj->IsA() : nullptr;
+   return CheckObject() ? fObj->IsA() : nullptr;
 }
 
 


### PR DESCRIPTION
Before only list of TKeys was shown in TBrowser,
now also objects are shown. Fixes #10389 

Do not try to remove histograms from gDirectory.

Small fix for RCanvas cleanup