### PR TITLE
[RF] Consistent behavior for uniform constraint terms in HistFactory

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -87,9 +87,6 @@ namespace RooStats{
             std::map<std::string,double> logNormSyst,
             std::map<std::string,double> noSyst);
 
-      RooAbsArg* MakeLinInterpWithConstraint(RooHistFunc* nominalHistFunc, RooWorkspace* proto, const std::vector<HistoSys>&,
-               const std::string& prefix, std::vector<std::string>& likelihoodTermNames, const RooArgList& observables) const;
-
       RooWorkspace* MakeSingleChannelWorkspace(Measurement& measurement, Channel& channel);
 
       void MakeTotalExpected(RooWorkspace* proto, const std::string& totName,

--- a/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Measurement.h
@@ -123,6 +123,11 @@ public:
   std::map< std::string, double >& GetLogNormSyst() { return fLogNormSyst; }
   std::map< std::string, double >& GetNoSyst() { return fNoSyst; }
 
+  std::map< std::string, double > const& GetGammaSyst() const { return fGammaSyst; }
+  std::map< std::string, double > const& GetUniformSyst() const { return fUniformSyst; }
+  std::map< std::string, double > const& GetLogNormSyst() const { return fLogNormSyst; }
+  std::map< std::string, double > const& GetNoSyst() const { return fNoSyst; }
+
   std::string GetInterpolationScheme() { return fInterpolationScheme; }
 
 private:


### PR DESCRIPTION
In HistFactory, normalization uncertainties and shape uncertainties were
treated differently when setting the constraint type to uniform, e.g.:

```xml
<ConstraintTerm Type="Uniform" RelativeUncertainty="1">NP_shape</ConstraintTerm>
<ConstraintTerm Type="Uniform" RelativeUncertainty="1">NP_norm</ConstraintTerm>
```

See #9070 for a very good explanation of the problem.

For non-shape uncertainties, the uniform constraint was treated as a
special case of the Gaussian constraint with "infinite" sigma. For shape
uncertainties, the `Uniform` type was ignored.

This commit suggests to refactor the creation of Gaussian constraints
such that the logic that considers the "Uniform" tag is also used for
shape uncertainties.

Closes #9070.
