### PR TITLE
[cxxmodules] Fix std.modulemap for older GCC

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -436,9 +436,4 @@ module "std" [system] {
     export *
     header "bits/stl_tree.h"
   }
-  module "bits/utility.h" {
-    requires cplusplus17
-    export *
-    header "bits/utility.h"
-  }
 }


### PR DESCRIPTION
The header `bits/utility.h` only exists since libstdc++-12.