### PR TITLE
[math] Improve gsl multifit algorithm with support for external gradient

### DIFF
--- a/hist/hist/inc/Math/WrappedMultiTF1.h
+++ b/hist/hist/inc/Math/WrappedMultiTF1.h
@@ -54,7 +54,7 @@ namespace ROOT {
          /**
             constructor from a function pointer to a TF1
             If dim = 0 dimension is taken from TF1::GetNdim().
-            IN case of multi-dimensional function created using directly TF1 object the dimension
+            In case of multi-dimensional function created using directly TF1 object the dimension
             returned by TF1::GetNdim is always 1. The user must then pass the correct value of dim
          */
          WrappedMultiTF1Templ(TF1 &f, unsigned int dim = 0);

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2480,8 +2480,12 @@ Double_t TF1::GradientPar(Int_t ipar, const Double_t *x, Double_t eps)
 
 void TF1::GradientPar(const Double_t *x, Double_t *grad, Double_t eps)
 {
-   if (fFormula && fFormula->HasGeneratedGradient())
-      fFormula->GradientPar(x,grad);
+   if (fFormula && fFormula->HasGeneratedGradient()) {
+      // need to allocate a vector here
+      std::vector<double> gvec(fNpar);
+      fFormula->GradientPar(x,gvec);
+      std::copy(gvec.begin(),gvec.end(), grad);
+   }
    else
       GradientParTempl<Double_t>(x, grad, eps);
 }

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2481,10 +2481,9 @@ Double_t TF1::GradientPar(Int_t ipar, const Double_t *x, Double_t eps)
 void TF1::GradientPar(const Double_t *x, Double_t *grad, Double_t eps)
 {
    if (fFormula && fFormula->HasGeneratedGradient()) {
-      // need to allocate a vector here
-      std::vector<double> gvec(fNpar);
-      fFormula->GradientPar(x,gvec);
-      std::copy(gvec.begin(),gvec.end(), grad);
+      // need to zero the gradient buffer
+      std::fill(grad, grad + fNpar, 0.);
+      fFormula->GradientPar(x,grad);
    }
    else
       GradientParTempl<Double_t>(x, grad, eps);

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -77,7 +77,7 @@ ClassImp(TFormula);
     - `gaus(x, [0..2])` is a more explicit way of writing `gaus(0)`
     - `expo(y, [3..4])` is a substitute for `exp([3]+[4]*y)`
 
-    See below the [full list of predefined functions](\ref FormulaFuncs) which can be used as shortcuts in 
+    See below the [full list of predefined functions](\ref FormulaFuncs) which can be used as shortcuts in
     TFormula.
 
     `TMath` functions can be part of the expression, eg:
@@ -163,24 +163,24 @@ ClassImp(TFormula);
     \anchor FormulaFuncs
     ### List of predefined functions
 
-    The list of available predefined functions which can be used as shortcuts is the following: 
-    1. One Dimensional functions: 
+    The list of available predefined functions which can be used as shortcuts is the following:
+    1. One Dimensional functions:
       - `gaus`  is a substitute for `[Constant]*exp(-0.5*((x-[Mean])/[Sigma])*((x-[Mean])/[Sigma]))`
       - `landau` is a substitute for `[Constant]*TMath::Landau (x,[MPV],[Sigma],false)`
       - `expo`  is a substitute for `exp([Constant]+[Slope]*x)`
       - `crystalball` is substitute for `[Constant]*ROOT::Math::crystalball_function (x,[Alpha],[N],[Sigma],[Mean])`
       - `breitwigner` is a substitute for `[p0]*ROOT::Math::breitwigner_pdf (x,[p2],[p1])`
-      - `pol0,1,2,...N` is a substitute for a polynomial of degree `N` : 
+      - `pol0,1,2,...N` is a substitute for a polynomial of degree `N` :
          `([p0]+[p1]*x+[p2]*pow(x,2)+....[pN]*pow(x,N)`
       - `cheb0,1,2,...N` is a substitute for a Chebyshev polynomial of degree `N`:
          `ROOT::Math::Chebyshev10(x,[p0],[p1],[p2],...[pN])`. Note the maximum N allowed here is 10.
-    2. Two Dimensional functions: 
+    2. Two Dimensional functions:
       - `xygaus` is a substitute for `[Constant]*exp(-0.5*pow(((x-[MeanX])/[SigmaX]),2 )- 0.5*pow(((y-[MeanY])/[SigmaY]),2))`, a 2d Gaussian without correlation.
       - `bigaus` is a substitute for `[Constant]*ROOT::Math::bigaussian_pdf (x,y,[SigmaX],[SigmaY],[Rho],[MeanX],[MeanY])`, a 2d gaussian including a correlation parameter.
-    3. Three Dimensional functions: 
-      - `xyzgaus` is for a 3d Gaussians without correlations: 
+    3. Three Dimensional functions:
+      - `xyzgaus` is for a 3d Gaussians without correlations:
       `[Constant]*exp(-0.5*pow(((x-[MeanX])/[SigmaX]),2 )- 0.5*pow(((y-[MeanY])/[SigmaY]),2 )- 0.5*pow(((z-[MeanZ])/[SigmaZ]),2))`
-      
+
 
     ### An expanded note on variables and parameters
 
@@ -3274,6 +3274,9 @@ bool TFormula::GenerateGradientPar() {
    return true;
 }
 
+// Compute the gradient with respect to the parameter passing
+/// a CladStorageObject, i.e. a std::vector, which has the size as the nnumber of parameters.
+/// Note that the result buffer needs to be initialized to zero before passing it to this function.
 void TFormula::GradientPar(const Double_t *x, TFormula::CladStorage& result)
 {
    if (DoEval(x) == TMath::QuietNaN())
@@ -3298,7 +3301,9 @@ void TFormula::GradientPar(const Double_t *x, TFormula::CladStorage& result)
    }
    GradientPar(x, result.data());
 }
-
+/// Compute the gradient with respect to the parameter passing
+/// a buffer with a size at least equal to the number of parameters.
+/// Note that the result buffer needs to be initialized to zero before passed to this function.
 void TFormula::GradientPar(const Double_t *x, Double_t *result) {
    const Double_t *vars = (x) ? x : fClingVariables.data();
    const Double_t *pars = (fNpar <= 0) ? nullptr : fClingParameters.data();

--- a/math/fumili/inc/TFumili.h
+++ b/math/fumili/inc/TFumili.h
@@ -109,7 +109,7 @@ public:
    void             SetData(Double_t *,Int_t,Int_t);
    void     SetFitMethod(const char *name) override;
    Int_t    SetParameter(Int_t ipar,const char *parname,Double_t value,Double_t verr,Double_t vlow, Double_t vhigh) override;
-   void             SetParNumber(Int_t ParNum) { fNpar = ParNum;};
+   void     SetParNumber(Int_t ParNum);
 
    ClassDefOverride(TFumili,0) //The FUMILI Minimization package
 };

--- a/math/fumili/src/TFumili.cxx
+++ b/math/fumili/src/TFumili.cxx
@@ -131,7 +131,6 @@ TFumili::TFumili(Int_t maxpar)
    // maxpar is the maximum number of parameters used with TFumili object
    //
    fMaxParam = TMath::Max(maxpar,25);
-   if (fMaxParam>200) fMaxParam=200;
    BuildArrays();
 
    fNumericDerivatives = true;
@@ -165,6 +164,15 @@ TFumili::TFumili(Int_t maxpar)
    gFumili = this;
    gROOT->GetListOfSpecials()->Add(gFumili);
 }
+
+void TFumili::SetParNumber(Int_t ParNum){
+   fNpar = ParNum;
+   if (fNpar > fMaxParam) {
+      DeleteArrays();
+      fMaxParam = fNpar;
+      BuildArrays();
+   }
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 ///

--- a/math/mathcore/inc/Fit/Chi2FCN.h
+++ b/math/mathcore/inc/Fit/Chi2FCN.h
@@ -117,7 +117,7 @@ public:
    /// i-th chi-square residual
    virtual double DataElement(const double *x, unsigned int i, double *g) const {
       if (i==0) this->UpdateNCalls();
-      return FitUtil::Evaluate<T>::EvalChi2Residual(BaseFCN::ModelFunction(), BaseFCN::Data(), x, i, g);
+      return FitUtil::Evaluate<T>::EvalChi2Residual(BaseFCN::ModelFunction(), BaseFCN::Data(), x, i, g, BaseFCN::IsAGradFCN());
    }
 
    // need to be virtual to be instantiated

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -1066,7 +1066,7 @@ namespace FitUtil {
          }
       }
 
-      static double EvalChi2Residual(const IModelFunctionTempl<T> &, const BinData &, const double *, unsigned int, double *)
+      static double EvalChi2Residual(const IModelFunctionTempl<T> &, const BinData &, const double *, unsigned int, double *, bool)
       {
          Error("FitUtil::Evaluate<T>::EvalChi2Residual", "The vectorized evaluation of the Chi2 with the ith residual is still not supported");
          return -1.;

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -335,7 +335,7 @@ namespace FitUtil {
       is used
   */
   double EvaluateChi2Residual(const IModelFunction &func, const BinData &data, const double *p, unsigned int ipoint,
-                              double *g = 0);
+                              double *g = 0, bool hasGrad = false);
 
   /**
       evaluate the pdf contribution to the LogL given a model function and the BinPoint data.
@@ -344,11 +344,11 @@ namespace FitUtil {
       is used
   */
   double
-  EvaluatePdf(const IModelFunction &func, const UnBinData &data, const double *p, unsigned int ipoint, double *g = 0);
+  EvaluatePdf(const IModelFunction &func, const UnBinData &data, const double *p, unsigned int ipoint, double *g = 0, bool hasGrad = false);
 
 #ifdef R__HAS_VECCORE
    template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
-   double EvaluatePdf(const IModelFunctionTempl<ROOT::Double_v> &func, const UnBinData &data, const double *p, unsigned int i, double *) {
+   double EvaluatePdf(const IModelFunctionTempl<ROOT::Double_v> &func, const UnBinData &data, const double *p, unsigned int i, double *, bool) {
       // evaluate the pdf contribution to the generic logl function in case of bin data
       // return actually the log of the pdf and its derivatives
       // func.SetParameters(p);
@@ -365,7 +365,7 @@ namespace FitUtil {
        If the function provides parameter derivatives they are used otherwise a simple derivative calculation
        is used
    */
-   double EvaluatePoissonBinPdf(const IModelFunction & func, const BinData & data, const double * x, unsigned int ipoint, double * g = 0);
+   double EvaluatePoissonBinPdf(const IModelFunction & func, const BinData & data, const double * x, unsigned int ipoint, double * g = 0, bool hasGrad = false);
 
    unsigned setAutomaticChunking(unsigned nEvents);
 
@@ -1074,7 +1074,7 @@ namespace FitUtil {
 
       /// evaluate the pdf (Poisson) contribution to the logl (return actually log of pdf)
       /// and its gradient
-      static double EvalPoissonBinPdf(const IModelFunctionTempl<T> &, const BinData &, const double *, unsigned int , double * ) {
+      static double EvalPoissonBinPdf(const IModelFunctionTempl<T> &, const BinData &, const double *, unsigned int , double * , bool) {
          Error("FitUtil::Evaluate<T>::EvaluatePoissonBinPdf", "The vectorized evaluation of the BinnedLikelihood fit evaluated point by point is still not supported");
          return -1.;
       }
@@ -1429,15 +1429,15 @@ namespace FitUtil {
       {
          FitUtil::EvaluateChi2Gradient(func, data, p, g, nPoints, executionPolicy, nChunks);
       }
-      static double EvalChi2Residual(const IModelFunctionTempl<double> &func, const BinData & data, const double * p, unsigned int i, double *g = 0)
+      static double EvalChi2Residual(const IModelFunctionTempl<double> &func, const BinData & data, const double * p, unsigned int i, double *g = 0, bool hasGrad=false)
       {
-         return FitUtil::EvaluateChi2Residual(func, data, p, i, g);
+         return FitUtil::EvaluateChi2Residual(func, data, p, i, g, hasGrad);
       }
 
       /// evaluate the pdf (Poisson) contribution to the logl (return actually log of pdf)
       /// and its gradient
-      static double EvalPoissonBinPdf(const IModelFunctionTempl<double> &func, const BinData & data, const double *p, unsigned int i, double *g ) {
-         return FitUtil::EvaluatePoissonBinPdf(func, data, p, i, g);
+      static double EvalPoissonBinPdf(const IModelFunctionTempl<double> &func, const BinData & data, const double *p, unsigned int i, double *g, bool hasGrad) {
+         return FitUtil::EvaluatePoissonBinPdf(func, data, p, i, g, hasGrad);
       }
 
       static void

--- a/math/mathcore/inc/Fit/LogLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/LogLikelihoodFCN.h
@@ -120,7 +120,7 @@ public:
    /// i-th likelihood contribution and its gradient
    virtual double DataElement(const double * x, unsigned int i, double * g) const {
       if (i==0) this->UpdateNCalls();
-      return FitUtil::EvaluatePdf(BaseFCN::ModelFunction(), BaseFCN::Data(), x, i, g);
+      return FitUtil::EvaluatePdf(BaseFCN::ModelFunction(), BaseFCN::Data(), x, i, g, BaseFCN::IsAGradFCN());
    }
 
    // need to be virtual to be instantiated

--- a/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
@@ -120,7 +120,7 @@ public:
    /// i-th likelihood element and its gradient
    virtual double DataElement(const double * x, unsigned int i, double * g) const {
       if (i==0) this->UpdateNCalls();
-      return FitUtil::Evaluate<typename BaseFCN::T>::EvalPoissonBinPdf(BaseFCN::ModelFunction(), BaseFCN::Data(), x, i, g);
+      return FitUtil::Evaluate<typename BaseFCN::T>::EvalPoissonBinPdf(BaseFCN::ModelFunction(), BaseFCN::Data(), x, i, g, BaseFCN::IsAGradFCN());
    }
 
    /// evaluate gradient

--- a/math/mathcore/inc/Math/FitMethodFunction.h
+++ b/math/mathcore/inc/Math/FitMethodFunction.h
@@ -94,28 +94,12 @@ public:
     */
    virtual void ResetNCalls() { fNCalls = 0; }
 
-
-
-public:
-
-  /* traits for knowing if is a function supporting gradient*/
-  static bool IsAGradFCN() {
-     return ObjFCNTrait<FunctionType>::IsGrad();
+   /**
+      Static function to indicate if a function is supporting gradient
+   */
+   static bool IsAGradFCN() {
+     return false;
   }
-
-
-protected:
-
-  // need to use partial specialization since
-  // full specialization is not allowed for nested classes
-  template<class F, bool Dummy = true>
-  struct ObjFCNTrait {
-   static bool IsGrad() { return false; }
-  };
-  template<bool Dummy>
-  struct ObjFCNTrait<ROOT::Math::IMultiGradFunction, Dummy> {
-     static bool IsGrad() { return true;}
-  };
 
 private:
 
@@ -126,29 +110,18 @@ private:
 
 };
 
-      // define the normal and gradient function
-      typedef BasicFitMethodFunction<ROOT::Math::IMultiGenFunction>  FitMethodFunction;
-      typedef BasicFitMethodFunction<ROOT::Math::IMultiGradFunction> FitMethodGradFunction;
+template<>
+inline bool BasicFitMethodFunction<ROOT::Math::IMultiGradFunction>::IsAGradFCN() {
+   return true;
+}
+
+// define the normal and gradient function
+typedef BasicFitMethodFunction<ROOT::Math::IMultiGenFunction>  FitMethodFunction;
+typedef BasicFitMethodFunction<ROOT::Math::IMultiGradFunction> FitMethodGradFunction;
 
 
-      // useful template definition to use these interface in
-      // generic programming
-      // (comment them out since they are not used anymore)
-/*
-      template<class FunType>
-      struct ParamFunctionTrait {
-         typedef  IParamMultiFunction PFType;
-      };
 
-      // specialization for the gradient param functions
-      template<>
-      struct ParamFunctionTrait<ROOT::Math::IMultiGradFunction>  {
-         typedef  IParamMultiGradFunction PFType;
-      };
-*/
-
-
-   } // end namespace Math
+} // end namespace Math
 
 } // end namespace ROOT
 

--- a/math/mathcore/inc/Math/FitMethodFunction.h
+++ b/math/mathcore/inc/Math/FitMethodFunction.h
@@ -98,9 +98,24 @@ public:
 
 public:
 
+  /* traits for knowing if is a function supporting gradient*/
+  static bool IsAGradFCN() {
+     return ObjFCNTrait<FunctionType>::IsGrad();
+  }
+
 
 protected:
 
+  // need to use partial specialization since
+  // full specialization is not allowed for nested classes
+  template<class F, bool Dummy = true>
+  struct ObjFCNTrait {
+   static bool IsGrad() { return false; }
+  };
+  template<bool Dummy>
+  struct ObjFCNTrait<ROOT::Math::IMultiGradFunction, Dummy> {
+     static bool IsGrad() { return true;}
+  };
 
 private:
 

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -622,9 +622,6 @@ double FitUtil::EvaluateChi2Residual(const IModelFunction & func, const BinData 
          //case function provides gradient
          if (!useBinIntegral ) {
             gfunc->ParameterGradient(  x , p, g);
-            // std::cout << "compute analytical gradient for model func at " << x[0] << " ";
-            // for (unsigned ip = 0; ip < npar; ip++) std::cout << "(" << p[ip] << ", " << g[ip] << ") " ;
-            // std::cout << std::endl;
          }
          else {
             // needs to calculate the integral for each partial derivative
@@ -635,9 +632,6 @@ double FitUtil::EvaluateChi2Residual(const IModelFunction & func, const BinData 
          SimpleGradientCalculator  gc( npar, func);
          if (!useBinIntegral ) {
             gc.ParameterGradient(x, p, fval, g);
-            // std::cout << "compute numerical gradient for model func at " << x[0] << " ";
-            // for (unsigned int ip = 0; ip < npar; ip++) std::cout << "(" << p[ip] << ", " << g[ip] << ") " ;
-            // std::cout << std::endl;
          } else {
             // needs to calculate the integral for each partial derivative
             CalculateGradientIntegral( gc, x1, x2, p, g);

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -840,7 +840,7 @@ void FitUtil::EvaluateChi2Gradient(const IModelFunction &f, const BinData &data,
    // }
    else {
       Error("FitUtil::EvaluateChi2Gradient",
-            "Execution policy unknown. Avalaible choices:\n 0: Serial (default)\n 1: MultiThread (requires IMT)\n");
+            "Execution policy unknown. Available choices:\n 0: Serial (default)\n 1: MultiThread (requires IMT)\n");
    }
 
 #ifndef R__USE_IMT
@@ -985,7 +985,7 @@ double FitUtil::EvaluateLogL(const IModelFunction &func, const UnBinData &data, 
             }
          }
 
-         // needed to compue effective global weight in case of extended likelihood
+         // needed to compute effective global weight in case of extended likelihood
 
          auto mapFunction = [&](const unsigned i) {
             double W = 0;
@@ -1077,7 +1077,7 @@ double FitUtil::EvaluateLogL(const IModelFunction &func, const UnBinData &data, 
     sumW=resArray.weight;
     sumW2=resArray.weight2;
 #endif
-//   } else if(executionPolicy == ROOT::Fit::kMultitProcess){
+//   } else if(executionPolicy == ROOT::Fit::kMultiProcess){
     // ROOT::TProcessExecutor pool;
     // res = pool.MapReduce(mapFunction, ROOT::TSeq<unsigned>(0, n), redFunction);
   } else{

--- a/math/mathcore/src/FitUtil.cxx
+++ b/math/mathcore/src/FitUtil.cxx
@@ -634,7 +634,6 @@ double FitUtil::EvaluateChi2Residual(const IModelFunction & func, const BinData 
       else {
          SimpleGradientCalculator  gc( npar, func);
          if (!useBinIntegral ) {
-            SimpleGradientCalculator  gc( npar, func);
             gc.ParameterGradient(x, p, fval, g);
             // std::cout << "compute numerical gradient for model func at " << x[0] << " ";
             // for (unsigned int ip = 0; ip < npar; ip++) std::cout << "(" << p[ip] << ", " << g[ip] << ") " ;

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -40,7 +40,6 @@
 #include "Math/MinimTransformVariable.h"
 
 #include <vector>
-#include <cassert>
 
 namespace ROOT {
 
@@ -116,7 +115,7 @@ private:
 
    double DoDerivative(const double * /* x */, unsigned int /* icoord */) const override {
       //this function should not be called by GSL
-      assert(false);
+      throw std::runtime_error("LSRESidualFunc::DoDerivative");
       return 0;
    }
 
@@ -223,17 +222,14 @@ private:
 
    bool fUseGradFunction = false; // flag to indicate if using external gradients
    unsigned int fNFree;      // dimension of the internal function to be minimized
-   //unsigned int fSize;        // number of fit points (residuals)
    unsigned int fNCalls;        // number of function calls
 
    ROOT::Math::GSLMultiFit * fGSLMultiFit;        // pointer to GSL multi fit solver
-   //const ROOT::Math::FitMethodFunction * fChi2Func;      // pointer to Least square function
 
    double fEdm;                                   // edm value
    double fLSTolerance;                           // Line Search Tolerance
    std::vector<double> fErrors;
    std::vector<double> fCovMatrix;              //  cov matrix (stored as cov[ i * dim + j]
-   //std::vector<LSResidualFunc> fResiduals;   //! transient Vector of the residual functions
 
 
 

--- a/tutorials/fit/minuit2GausFit.C
+++ b/tutorials/fit/minuit2GausFit.C
@@ -59,15 +59,15 @@ void testGausFit( std::string type = "Minuit2", int n = 1000) {
    h1->Draw();
    c1->cd(2);
    std::cout << "\nDo Fit 2\n";
-   h2->Fit("gaus","VE");
+   h2->Fit("gaus","E");
    h2->Draw();
    c1->cd(3);
    std::cout << "\nDo Fit 3\n";
-   h3->Fit("gaus","IE");
+   h3->Fit("gaus","IGE");
    h3->Draw();
    c1->cd(4);
    std::cout << "\nDo Fit 4\n";
-   h4->Fit("gaus","VLE");
+   h4->Fit("gaus","LE");
    h4->Draw();
 
 }
@@ -79,6 +79,3 @@ void minuit2GausFit() {
    testGausFit("Fumili2",n);
 
 }
-
-
-


### PR DESCRIPTION


This PR fixes allows to use external gradient (for example computed with CLAD in TFormula) in the GSLMultiFit algorithm. 
A fix is applied also in TF1::GradientPar where in case of CLAD gradient a vector is allocated for storing the gradient. Using an external pointer, for example coming from GSL has shown to be problematic.  

