### PR TITLE
[DF] Throw if a varied column is redefined

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -322,6 +322,8 @@ void CheckForRedefinition(const std::string &where, std::string_view definedCol,
 void CheckForDefinition(const std::string &where, std::string_view definedColView, const RColumnRegister &customCols,
                         const ColumnNames_t &treeColumns, const ColumnNames_t &dataSourceColumns);
 
+void CheckForNoVariations(const std::string &where, std::string_view definedColView, const RColumnRegister &customCols);
+
 std::string PrettyPrintAddr(const void *const addr);
 
 std::shared_ptr<RJittedFilter> BookFilterJit(std::shared_ptr<RNodeBase> *prevNodeOnHeap, std::string_view name,

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -563,6 +563,7 @@ public:
       RDFInternal::CheckValidCppVarName(name, where);
       RDFInternal::CheckForDefinition(where, name, fColRegister, fLoopManager->GetBranchNames(),
                                       fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+      RDFInternal::CheckForNoVariations(where, name, fColRegister);
 
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fColRegister,
@@ -3250,6 +3251,7 @@ private:
       } else {
          RDFInternal::CheckForDefinition(where, name, fColRegister, fLoopManager->GetBranchNames(),
                                          fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{});
+         RDFInternal::CheckForNoVariations(where, name, fColRegister);
       }
 
       using ArgTypes_t = typename TTraits::CallableTraits<F>::arg_types;

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -544,6 +544,19 @@ void CheckForDefinition(const std::string &where, std::string_view definedColVie
    }
 }
 
+/// Throw if the column has systematic variations attached.
+void CheckForNoVariations(const std::string &where, std::string_view definedColView, const RColumnRegister &customCols)
+{
+   const std::string definedCol(definedColView);
+   const auto &variationDeps = customCols.GetVariationDeps(definedCol);
+   if (!variationDeps.empty()) {
+      const std::string error =
+         "RDataFrame::" + where + ": cannot redefine column \"" + definedCol +
+         "\". The column depends on one or more systematic variations and re-defining varied columns is not supported.";
+      throw std::runtime_error(error);
+   }
+}
+
 void CheckTypesAndPars(unsigned int nTemplateParams, unsigned int nColumnNames)
 {
    if (nTemplateParams != nColumnNames) {


### PR DESCRIPTION
...because we'd only redefine the _nominal_ value, which would be extremely confusing.

A test for this case will soon be added as part of a general improvement to Vary's test coverage.