### PR TITLE
[DF] Fix wrong downcast in {RRange,RFilter}::GetVariedFilter 

### DIFF
--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -563,6 +563,26 @@ TEST_P(RDFVary, JittedFilter)
    EXPECT_EQ(sums2["x:1"], 420);
 }
 
+TEST_P(RDFVary, FilterAfterJittedFilter)
+{
+   auto c = ROOT::RDataFrame(10)
+               .Define("x", [](ULong64_t e) { return int(e); }, {"rdfentry_"})
+               .Vary(
+                  "x",
+                  [](int x) {
+                     return ROOT::RVecI{x - 1, x + 1};
+                  },
+                  {"x"}, 2)
+               .Filter("x > 1")
+               .Filter([](int x) { return x > 5; }, {"x"})
+               .Count();
+   auto cs = ROOT::RDF::Experimental::VariationsFor(c);
+   EXPECT_EQ(*c, 4);
+   EXPECT_EQ(cs["nominal"], *c);
+   EXPECT_EQ(cs["x:0"], 3);
+   EXPECT_EQ(cs["x:1"], 5);
+}
+
 TEST_P(RDFVary, JittedVary)
 {
    auto df = ROOT::RDataFrame(10).Define("x", [] { return 1; });


### PR DESCRIPTION
When previous node of a RRange or RFilter node was a RJittedFilter,
we were wrongly downcasting _varied_ filters to the RJittedFilter type,
but varied filters are _not_ jitted filters, they are copies of the
actual concrete filter.

With this patch, if the type of the previous node is RJittedFilter,
we treat it everywhere as the generic base class RFilterBase, which
fixes the problem and it is consistent with what we already do in
RVariedAction.

The PR comes with the corresponding regression test.
