### PR TITLE
[RF] Improve passing `nullptr` to RooFit message logger

### DIFF
--- a/roofit/histfactory/src/ConfigParser.cxx
+++ b/roofit/histfactory/src/ConfigParser.cxx
@@ -548,7 +548,7 @@ HistFactory::Measurement ConfigParser::CreateMeasurementFromDriverNode(TXMLNode 
       child = child->GetNextNode();
    }
 
-   measurement.PrintTree(oocoutI(static_cast<TObject *>(nullptr), HistFactory));
+   measurement.PrintTree(oocoutI(nullptr, HistFactory));
 
    return measurement;
 }
@@ -709,7 +709,7 @@ HistFactory::Channel ConfigParser::ParseChannelXMLFile( string filen ) {
   } // End loop over tags in this channel
 
   cxcoutIHF << "Created Channel: " << std::endl;
-  channel.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  channel.Print(oocoutI(nullptr, HistFactory));
 
   return channel;
 
@@ -1061,7 +1061,7 @@ HistFactory::NormFactor ConfigParser::MakeNormFactor( TXMLNode* node ) {
     throw hf_exc();
   }
 
-  norm.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  norm.Print(oocoutI(nullptr, HistFactory));
 
   return norm;
 
@@ -1175,7 +1175,7 @@ HistFactory::HistoSys ConfigParser::MakeHistoSys( TXMLNode* node ) {
   }
 
 
-  histoSys.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  histoSys.Print(oocoutI(nullptr, HistFactory));
 
   return histoSys;
 
@@ -1225,7 +1225,7 @@ HistFactory::OverallSys ConfigParser::MakeOverallSys( TXMLNode* node ) {
   }
 
 
-  overallSys.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  overallSys.Print(oocoutI(nullptr, HistFactory));
 
   return overallSys;
 
@@ -1305,7 +1305,7 @@ HistFactory::ShapeFactor ConfigParser::MakeShapeFactor( TXMLNode* node ) {
     shapeFactor.SetInputFile( ShapeInputFile );
   }
 
-  shapeFactor.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  shapeFactor.Print(oocoutI(nullptr, HistFactory));
 
   return shapeFactor;
 
@@ -1395,7 +1395,7 @@ HistFactory::ShapeSys ConfigParser::MakeShapeSys( TXMLNode* node ) {
     throw hf_exc();
   }
 
-  shapeSys.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  shapeSys.Print(oocoutI(nullptr, HistFactory));
 
   return shapeSys;
 
@@ -1483,7 +1483,7 @@ HistFactory::StatError ConfigParser::ActivateStatError( TXMLNode* node ) {
     }
   */
 
-  statError.Print(oocoutI(static_cast<TObject*>(nullptr), HistFactory));
+  statError.Print(oocoutI(nullptr, HistFactory));
 
   return statError;
 

--- a/roofit/histfactory/src/ParamHistFunc.cxx
+++ b/roofit/histfactory/src/ParamHistFunc.cxx
@@ -157,7 +157,7 @@ Int_t ParamHistFunc::GetNumBins( const RooArgSet& vars ) {
     if (!dynamic_cast<RooRealVar*>(comp)) {
       auto errorMsg = std::string("ParamHistFunc::GetNumBins") + vars.GetName() + ") ERROR: component "
                       + comp->GetName() + " in vars list is not of type RooRealVar";
-      oocoutE(static_cast<TObject*>(nullptr), InputArguments) <<  errorMsg << std::endl;
+      oocoutE(nullptr, InputArguments) <<  errorMsg << std::endl;
       throw std::runtime_error(errorMsg);
     }
     auto var = static_cast<RooRealVar*>(comp);

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -215,7 +215,7 @@ namespace {
 
 void logInputArgumentsError(std::stringstream &&ss)
 {
-   oocoutE(static_cast<RooAbsArg *>(nullptr), InputArguments) << ss.str();
+   oocoutE(nullptr, InputArguments) << ss.str();
 }
 
 } // namespace

--- a/roofit/roofit/src/RooLognormal.cxx
+++ b/roofit/roofit/src/RooLognormal.cxx
@@ -51,7 +51,7 @@ RooLognormal::RooLognormal(const char *name, const char *title,
 
     auto par = dynamic_cast<const RooAbsRealLValue*>(&_k);
     if (par && par->getMin()<=1 && par->getMax()>=1 ) {
-      oocoutE(this, InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
+      coutE(InputArguments) << "The parameter '" << par->GetName() << "' with range [" << par->getMin("") << ", "
           << par->getMax() << "] of the " << this->IsA()->GetName() << " '" << this->GetName()
           << "' can reach the unsafe value 1.0 " << ". Advise to limit its range." << std::endl;
     }

--- a/roofit/roofitcore/inc/RooMsgService.h
+++ b/roofit/roofitcore/inc/RooMsgService.h
@@ -16,13 +16,17 @@
 #ifndef ROO_MSG_SERVICE
 #define ROO_MSG_SERVICE
 
-#include "TObject.h"
+#include <RooCmdArg.h>
+#include <RooGlobalFunc.h>
+
+#include <TObject.h>
+
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <stack>
 #include <map>
-#include "RooCmdArg.h"
-#include "RooGlobalFunc.h"
+
 class RooAbsArg ;
 class RooWorkspace ;
 
@@ -166,6 +170,11 @@ public:
   // Back end -- Send message or check if particular logging configuration is active
   std::ostream& log(const RooAbsArg* self, RooFit::MsgLevel level, RooFit::MsgTopic facility, bool forceSkipPrefix=false) ;
   std::ostream& log(const TObject* self, RooFit::MsgLevel level, RooFit::MsgTopic facility, bool forceSkipPrefix=false) ;
+  // Overload to resolve the ambiguity when passing a `nullptr`. Without this,
+  // one would have to explicitly cast the `nullptr` to TObject* or RooAbsArg*.
+  inline std::ostream& log(std::nullptr_t, RooFit::MsgLevel level, RooFit::MsgTopic facility, bool forceSkipPrefix=false) {
+      return log(static_cast<TObject*>(nullptr), level, facility, forceSkipPrefix);
+  }
   bool isActive(const RooAbsArg* self, RooFit::MsgTopic facility, RooFit::MsgLevel level) ;
   bool isActive(const TObject* self, RooFit::MsgTopic facility, RooFit::MsgLevel level) ;
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1641,7 +1641,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   if (prefit != 0)  {
     size_t nEvents = static_cast<size_t>(prefit*data.numEntries());
     if (prefit > 0.5 || nEvents < 100)  {
-      oocoutW(this,InputArguments) << "PrefitDataFraction should be in suitable range."
+      coutW(InputArguments) << "PrefitDataFraction should be in suitable range."
       << "With the current PrefitDataFraction=" << prefit
       << ", the number of events would be " << nEvents<< " out of "
       << data.numEntries() << ". Skipping prefit..." << endl;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -3662,7 +3662,7 @@ void RooAbsReal::logEvalError(const RooAbsReal* originator, const char* origName
   }
 
   if (_evalErrorMode==PrintErrors) {
-   oocoutE((TObject*)0,Eval) << "RooAbsReal::logEvalError(" << "<STATIC>" << ") evaluation error, " << endl
+   oocoutE(nullptr,Eval) << "RooAbsReal::logEvalError(" << "<STATIC>" << ") evaluation error, " << endl
          << " origin       : " << origName << endl
          << " message      : " << ee._msg << endl
          << " server values: " << ee._srvval << endl ;

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -932,7 +932,7 @@ TH1 *RooAbsRealLValue::createHistogram(const char *name, RooArgList &vars, const
   // Check that we have 1-3 vars
   Int_t dim= vars.getSize();
   if(dim < 1 || dim > 3) {
-    oocoutE((TObject*)0,InputArguments) << "RooAbsReal::createHistogram: dimension not supported: " << dim << endl;
+    oocoutE(nullptr,InputArguments) << "RooAbsReal::createHistogram: dimension not supported: " << dim << endl;
     return 0;
   }
 
@@ -946,7 +946,7 @@ TH1 *RooAbsRealLValue::createHistogram(const char *name, RooArgList &vars, const
     const RooAbsArg *arg= vars.at(index);
     xyz[index]= dynamic_cast<const RooAbsRealLValue*>(arg);
     if(!xyz[index]) {
-      oocoutE((TObject*)0,InputArguments) << "RooAbsRealLValue::createHistogram: variable is not real lvalue: " << arg->GetName() << endl;
+      oocoutE(nullptr,InputArguments) << "RooAbsRealLValue::createHistogram: variable is not real lvalue: " << arg->GetName() << endl;
       return 0;
     }
     histName.Append("_");
@@ -993,7 +993,7 @@ TH1 *RooAbsRealLValue::createHistogram(const char *name, RooArgList &vars, const
     break;
   }
   if(!histogram) {
-    oocoutE((TObject*)0,InputArguments) << "RooAbsReal::createHistogram: unable to create a new histogram" << endl;
+    oocoutE(nullptr,InputArguments) << "RooAbsReal::createHistogram: unable to create a new histogram" << endl;
     return 0;
   }
 

--- a/roofit/roofitcore/src/RooAbsRootFinder.cxx
+++ b/roofit/roofitcore/src/RooAbsRootFinder.cxx
@@ -41,7 +41,7 @@ RooAbsRootFinder::RooAbsRootFinder(const RooAbsFunc& function) :
   _function(&function), _valid(function.isValid())
 {
   if(_function->getDimension() != 1) {
-    oocoutE((TObject*)0,Eval) << "RooAbsRootFinder:: cannot find roots for function of dimension "
+    oocoutE(nullptr,Eval) << "RooAbsRootFinder:: cannot find roots for function of dimension "
                << _function->getDimension() << endl;
     _valid= false;
   }

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -177,7 +177,7 @@ bool RooAdaptiveIntegratorND::checkLimits() const
 bool RooAdaptiveIntegratorND::setLimits(Double_t *xmin, Double_t *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE((TObject*)0,Integration) << "RooAdaptiveIntegratorND::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooAdaptiveIntegratorND::setLimits: cannot override integrand's limits" << endl;
     return false;
   }
   for (UInt_t i=0 ; i<_func->NDim() ; i++) {

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -737,7 +737,7 @@ std::pair<const RooArgSet*, RooAddPdf::CacheElem*> RooAddPdf::getNormAndCache(co
 
     // If nset is STILL nullptr, print a warning.
     if (nset == nullptr) {
-       oocoutW(this, Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
+       coutW(Eval) << "Evaluating RooAddPdf without a defined normalization set. This can lead to ambiguos "
           "coefficients definition and incorrect results."
                            << " Use RooAddPdf::fixCoefNormalization(nset) to provide a normalization set for "
           "defining uniquely RooAddPdf coefficients!"

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -99,7 +99,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function) :
     // Retrieve bin configuration from integrand
     std::unique_ptr<list<Double_t>> tmp{ _function->binBoundaries(i) };
     if (!tmp) {
-      oocoutW((TObject*)0,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #"
+      oocoutW(nullptr,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #"
           << i << " substituting default binning of " << _numBins << " bins" << endl ;
       tmp.reset( new list<Double_t> );
       for (Int_t j=0 ; j<=_numBins ; j++) {
@@ -148,7 +148,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, const RooNumIntCo
     // Retrieve bin configuration from integrand
     std::unique_ptr<list<Double_t>> tmp{ _function->binBoundaries(i) };
     if (!tmp) {
-      oocoutW((TObject*)0,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #"
+      oocoutW(nullptr,Integration) << "RooBinIntegrator::RooBinIntegrator WARNING: integrand provide no binning definition observable #"
           << i << " substituting default binning of " << _numBins << " bins" << endl ;
       tmp.reset( new list<Double_t> );
       for (Int_t j=0 ; j<=_numBins ; j++) {
@@ -199,7 +199,7 @@ RooBinIntegrator::~RooBinIntegrator()
 bool RooBinIntegrator::setLimits(Double_t *xmin, Double_t *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE((TObject*)0,Integration) << "RooBinIntegrator::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooBinIntegrator::setLimits: cannot override integrand's limits" << endl;
     return false;
   }
   _xmin[0]= *xmin;
@@ -225,7 +225,7 @@ bool RooBinIntegrator::checkLimits() const
   }
   for (UInt_t i=0 ; i<_function->getDimension() ; i++) {
     if (_xmax[i]<=_xmin[i]) {
-      oocoutE((TObject*)0,Integration) << "RooBinIntegrator::checkLimits: bad range with min >= max (_xmin = " << _xmin[i] << " _xmax = " << _xmax[i] << ")" << endl;
+      oocoutE(nullptr,Integration) << "RooBinIntegrator::checkLimits: bad range with min >= max (_xmin = " << _xmin[i] << " _xmax = " << _xmax[i] << ")" << endl;
       return false;
     }
     if (RooNumber::isInfinite(_xmin[i]) || RooNumber::isInfinite(_xmax[i])) {

--- a/roofit/roofitcore/src/RooBrentRootFinder.cxx
+++ b/roofit/roofitcore/src/RooBrentRootFinder.cxx
@@ -156,7 +156,7 @@ bool RooBrentRootFinder::findRoot(Double_t &result, Double_t xlo, Double_t xhi, 
 
   }
   // Return our best guess if we run out of iterations
-  oocoutE((TObject*)0,Eval) << "RooBrentRootFinder::findRoot(" << _function->getName() << "): maximum iterations exceeded." << endl;
+  oocoutE(nullptr,Eval) << "RooBrentRootFinder::findRoot(" << _function->getName() << "): maximum iterations exceeded." << endl;
   result= b;
 
   _function->restoreXVec() ;

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -95,7 +95,7 @@ bool RooClassFactory::makeAndCompilePdf(const char* name, const char* expression
       if (catArgNames.size()>0) catArgNames += "," ;
       catArgNames += arg->GetName() ;
     } else {
-      oocoutE((RooAbsArg*)0,InputArguments) << "RooClassFactory::makeAndCompilePdf ERROR input argument " << arg->GetName()
+      oocoutE(nullptr,InputArguments) << "RooClassFactory::makeAndCompilePdf ERROR input argument " << arg->GetName()
                      << " is neither RooAbsReal nor RooAbsCategory and is ignored" << endl ;
     }
   }
@@ -139,7 +139,7 @@ bool RooClassFactory::makeAndCompileFunction(const char* name, const char* expre
       if (catArgNames.size()>0) catArgNames += "," ;
       catArgNames += arg->GetName() ;
     } else {
-      oocoutE((RooAbsArg*)0,InputArguments) << "RooClassFactory::makeAndCompileFunction ERROR input argument " << arg->GetName()
+      oocoutE(nullptr,InputArguments) << "RooClassFactory::makeAndCompileFunction ERROR input argument " << arg->GetName()
                    << " is neither RooAbsReal nor RooAbsCategory and is ignored" << endl ;
     }
   }
@@ -415,22 +415,22 @@ bool RooClassFactory::makeClass(const char* baseName, const char* className, con
 {
   // Check that arguments were given
   if (!baseName) {
-    oocoutE((TObject*)0,InputArguments) << "RooClassFactory::makeClass: ERROR: a base class name must be given" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooClassFactory::makeClass: ERROR: a base class name must be given" << endl ;
     return true ;
   }
 
   if (!className) {
-    oocoutE((TObject*)0,InputArguments) << "RooClassFactory::makeClass: ERROR: a class name must be given" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooClassFactory::makeClass: ERROR: a class name must be given" << endl ;
     return true ;
   }
 
   if ((!realArgNames || !*realArgNames) && (!catArgNames || !*catArgNames)) {
-    oocoutE((TObject*)0,InputArguments) << "RooClassFactory::makeClass: ERROR: A list of input argument names must be given" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooClassFactory::makeClass: ERROR: A list of input argument names must be given" << endl ;
     return true ;
   }
 
   if (intExpression && !hasAnaInt) {
-    oocoutE((TObject*)0,InputArguments) << "RooClassFactory::makeClass: ERROR no analytical integration code requestion, but expression for analytical integral provided" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooClassFactory::makeClass: ERROR no analytical integration code requestion, but expression for analytical integral provided" << endl ;
     return true ;
   }
 

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -757,7 +757,7 @@ std::string RooCustomizer::CustIFace::create(RooFactoryWSTool& ft, const char* t
     if (orig && subst) {
       cust.replaceArg(*orig,*subst) ;
     } else {
-      oocoutW((TObject*)0,ObjectHandling) << "RooCustomizer::CustIFace::create() WARNING: input or replacement of a replacement operation not found, operation ignored"<< endl ;
+      oocoutW(nullptr,ObjectHandling) << "RooCustomizer::CustIFace::create() WARNING: input or replacement of a replacement operation not found, operation ignored"<< endl ;
     }
   }
 

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -1557,11 +1557,11 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
   } else {
     ownIsBlind = false ;
     if (blindState->IsA()!=RooCategory::Class()) {
-      oocoutE((TObject*)0,DataHandling) << "RooDataSet::read: ERROR: variable list already contains"
+      oocoutE(nullptr,DataHandling) << "RooDataSet::read: ERROR: variable list already contains"
           << "a non-RooCategory blindState member" << endl ;
       return 0 ;
     }
-    oocoutW((TObject*)0,DataHandling) << "RooDataSet::read: WARNING: recycling existing "
+    oocoutW(nullptr,DataHandling) << "RooDataSet::read: WARNING: recycling existing "
         << "blindState category in variable list" << endl ;
   }
   RooCategory* blindCat = (RooCategory*) blindState ;
@@ -1580,7 +1580,7 @@ RooDataSet *RooDataSet::read(const char *fileList, const RooArgList &varList,
   auto data = std::make_unique<RooDataSet>("dataset", fileList, variables);
   if (ownIsBlind) { variables.remove(*blindState) ; delete blindState ; }
   if(!data) {
-    oocoutE((TObject*)0,DataHandling) << "RooDataSet::read: unable to create a new dataset"
+    oocoutE(nullptr,DataHandling) << "RooDataSet::read: unable to create a new dataset"
         << endl;
     return nullptr;
   }

--- a/roofit/roofitcore/src/RooFitResult.cxx
+++ b/roofit/roofitcore/src/RooFitResult.cxx
@@ -935,9 +935,9 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
 {
   // Verify length of supplied varList
   if (varList.getSize()>0 && varList.getSize()!=gMinuit->fNu) {
-    oocoutE((TObject*)0,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: supplied variable list must be either empty " << endl
+    oocoutE(nullptr,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: supplied variable list must be either empty " << endl
                << "                             or match the number of variables of the last fit (" << gMinuit->fNu << ")" << endl ;
-    return 0 ;
+    return nullptr;
   }
 
   // Verify that all members of varList are of type RooRealVar
@@ -945,8 +945,8 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
   RooAbsArg* arg  ;
   while((arg=(RooAbsArg*)iter.Next())) {
     if (!dynamic_cast<RooRealVar*>(arg)) {
-      oocoutE((TObject*)0,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName() << "' is not of type RooRealVar" << endl ;
-      return 0 ;
+      oocoutE(nullptr,InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName() << "' is not of type RooRealVar" << endl ;
+      return nullptr;
     }
   }
 
@@ -987,7 +987,7 @@ RooFitResult* RooFitResult::lastMinuitFit(const RooArgList& varList)
    var->setRange(xlo,xhi) ;
       }
       if (varName.CompareTo(var->GetName())) {
-   oocoutI((TObject*)0,Eval) << "RooFitResult::lastMinuitFit: fit parameter '" << varName
+   oocoutI(nullptr,Eval) << "RooFitResult::lastMinuitFit: fit parameter '" << varName
               << "' stored in variable '" << var->GetName() << "'" << endl ;
       }
 
@@ -1030,7 +1030,7 @@ RooFitResult *RooFitResult::prefitResult(const RooArgList &paramList)
    RooAbsArg *arg;
    while ((arg = (RooAbsArg *)iter.Next())) {
       if (!dynamic_cast<RooRealVar *>(arg)) {
-         oocoutE((TObject *)0, InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName()
+         oocoutE(nullptr, InputArguments) << "RooFitResult::lastMinuitFit: ERROR: variable '" << arg->GetName()
                                                << "' is not of type RooRealVar" << endl;
          return nullptr;
       }

--- a/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
@@ -93,12 +93,12 @@ double RooGradMinimizerFcn::DoEval(const double *x) const
       if (_printEvalErrors >= 0) {
 
          if (_doEvalErrorWall) {
-            oocoutW(static_cast<RooAbsArg *>(nullptr), Eval)
+            oocoutW(nullptr, Eval)
                << "RooGradMinimizerFcn: Minimized function has error status." << std::endl
                << "Returning maximum FCN so far (" << _maxFCN
                << ") to force MIGRAD to back out of this region. Error log follows" << std::endl;
          } else {
-            oocoutW(static_cast<RooAbsArg *>(nullptr), Eval)
+            oocoutW(nullptr, Eval)
                << "RooGradMinimizerFcn: Minimized function has error status but is ignored" << std::endl;
          }
 

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -59,7 +59,7 @@ RooGrid::RooGrid(const RooAbsFunc &function)
 {
   // check that the input function is valid
   if(!(_valid= function.isValid())) {
-    oocoutE((TObject*)0,InputArguments) << ClassName() << ": cannot initialize using an invalid function" << endl;
+    oocoutE(nullptr,InputArguments) << ClassName() << ": cannot initialize using an invalid function" << endl;
     return;
   }
 
@@ -73,7 +73,7 @@ RooGrid::RooGrid(const RooAbsFunc &function)
   _xin= new Double_t[maxBins+1];
   _weight= new Double_t[maxBins];
   if(!_xl || !_xu || !_delx || !_d || !_xi || !_xin || !_weight) {
-    oocoutE((TObject*)0,Integration) << ClassName() << ": memory allocation failed" << endl;
+    oocoutE(nullptr,Integration) << ClassName() << ": memory allocation failed" << endl;
     _valid= false;
     return;
   }
@@ -110,17 +110,17 @@ bool RooGrid::initialize(const RooAbsFunc &function)
   for(UInt_t index= 0; index < _dim; index++) {
     _xl[index]= function.getMinLimit(index);
     if(RooNumber::isInfinite(_xl[index])) {
-      oocoutE((TObject*)0,Integration) << ClassName() << ": lower limit of dimension " << index << " is infinite" << endl;
+      oocoutE(nullptr,Integration) << ClassName() << ": lower limit of dimension " << index << " is infinite" << endl;
       return false;
     }
     _xu[index]= function.getMaxLimit(index);
     if(RooNumber::isInfinite(_xl[index])) {
-      oocoutE((TObject*)0,Integration) << ClassName() << ": upper limit of dimension " << index << " is infinite" << endl;
+      oocoutE(nullptr,Integration) << ClassName() << ": upper limit of dimension " << index << " is infinite" << endl;
       return false;
     }
     Double_t dx= _xu[index] - _xl[index];
     if(dx <= 0) {
-      oocoutE((TObject*)0,Integration) << ClassName() << ": bad range for dimension " << index << ": [" << _xl[index]
+      oocoutE(nullptr,Integration) << ClassName() << ": bad range for dimension " << index << ": [" << _xl[index]
                    << "," << _xu[index] << "]" << endl;
       return false;
     }

--- a/roofit/roofitcore/src/RooHistError.cxx
+++ b/roofit/roofitcore/src/RooHistError.cxx
@@ -101,7 +101,7 @@ bool RooHistError::getPoissonIntervalCalc(Int_t n, Double_t &mu1, Double_t &mu2,
 {
   // sanity checks
   if(n < 0) {
-    oocoutE((TObject*)0,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n = " << n << endl;
+    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n = " << n << endl;
     return false;
   }
 
@@ -133,7 +133,7 @@ bool RooHistError::getBinomialIntervalAsym(Int_t n, Int_t m,
 {
   // sanity checks
   if(n < 0 || m < 0) {
-    oocoutE((TObject*)0,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << endl;
+    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << endl;
     return false;
   }
 
@@ -196,7 +196,7 @@ bool RooHistError::getBinomialIntervalEff(Int_t n, Int_t m,
 {
   // sanity checks
   if(n < 0 || m < 0) {
-    oocoutE((TObject*)0,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << endl;
+    oocoutE(nullptr,Plotting) << "RooHistError::getPoissonInterval: cannot calculate interval for n,m = " << n << "," << m << endl;
     return false;
   }
 
@@ -298,7 +298,7 @@ bool RooHistError::getInterval(const RooAbsFunc *Qu, const RooAbsFunc *Ql, Doubl
     ok= lFinder.findRoot(lo,lo,lo+stepSize,alpha+beta);
     ok|= uFinder.findRoot(hi,hi-stepSize,hi,alpha);
   }
-  if(!ok) oocoutE((TObject*)0,Plotting) << "RooHistError::getInterval: failed to find root(s)" << endl;
+  if(!ok) oocoutE(nullptr,Plotting) << "RooHistError::getInterval: failed to find root(s)" << endl;
 
   return ok;
 }

--- a/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
@@ -139,7 +139,7 @@ RooAbsIntegrator* RooImproperIntegrator1D::clone(const RooAbsFunc& function, con
 void RooImproperIntegrator1D::initialize(const RooAbsFunc* function)
 {
   if(!isValid()) {
-    oocoutE((TObject*)0,Integration) << "RooImproperIntegrator: cannot integrate invalid function" << endl;
+    oocoutE(nullptr,Integration) << "RooImproperIntegrator: cannot integrate invalid function" << endl;
     return;
   }
   // Create a new function object that uses the change of vars: x -> 1/x
@@ -221,7 +221,7 @@ RooImproperIntegrator1D::~RooImproperIntegrator1D()
 bool RooImproperIntegrator1D::setLimits(Double_t *xmin, Double_t *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE((TObject*)0,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << endl;
     return false;
   }
 

--- a/roofit/roofitcore/src/RooIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooIntegrator1D.cxx
@@ -138,7 +138,7 @@ RooIntegrator1D::RooIntegrator1D(const RooAbsFunc& function, const RooNumIntConf
   _doExtrap = (bool) configSet.getCatIndex("extrapolation",1) ;
 
   if (_fixSteps>_maxSteps) {
-    oocoutE((TObject*)0,Integration) << "RooIntegrator1D::ctor() ERROR: fixSteps>maxSteps, fixSteps set to maxSteps" << endl ;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::ctor() ERROR: fixSteps>maxSteps, fixSteps set to maxSteps" << endl ;
     _fixSteps = _maxSteps ;
   }
 
@@ -199,7 +199,7 @@ bool RooIntegrator1D::initialize()
 
   // check that the integrand is a valid function
   if(!isValid()) {
-    oocoutE((TObject*)0,Integration) << "RooIntegrator1D::initialize: cannot integrate invalid function" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::initialize: cannot integrate invalid function" << endl;
     return false;
   }
 
@@ -239,7 +239,7 @@ RooIntegrator1D::~RooIntegrator1D()
 bool RooIntegrator1D::setLimits(Double_t *xmin, Double_t *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE((TObject*)0,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << endl;
     return false;
   }
   _xmin= *xmin;
@@ -261,7 +261,7 @@ bool RooIntegrator1D::checkLimits() const
   }
   const_cast<double&>(_range) = _xmax - _xmin;
   if (_range < 0.) {
-    oocoutE((TObject*)0,Integration) << "RooIntegrator1D::checkLimits: bad range with min > max (_xmin = " << _xmin << " _xmax = " << _xmax << ")" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::checkLimits: bad range with min > max (_xmin = " << _xmin << " _xmax = " << _xmax << ")" << endl;
     return false;
   }
   return (RooNumber::isInfinite(_xmin) || RooNumber::isInfinite(_xmax)) ? false : true;
@@ -335,10 +335,10 @@ Double_t RooIntegrator1D::integral(const Double_t *yvec)
     _h[j+1]= (_rule == Trapezoid) ? _h[j]/4. : _h[j]/9.;
   }
 
-  oocoutW((TObject*)0,Integration) << "RooIntegrator1D::integral: integral of " << _function->getName() << " over range (" << _xmin << "," << _xmax << ") did not converge after "
+  oocoutW(nullptr,Integration) << "RooIntegrator1D::integral: integral of " << _function->getName() << " over range (" << _xmin << "," << _xmax << ") did not converge after "
       << _maxSteps << " steps" << endl;
   for(Int_t j = 1; j <= _maxSteps; ++j) {
-    ooccoutW((TObject*)0,Integration) << "   [" << j << "] h = " << _h[j] << " , s = " << _s[j] << endl;
+    ooccoutW(nullptr,Integration) << "   [" << j << "] h = " << _h[j] << " , s = " << _s[j] << endl;
   }
 
   return _s[_maxSteps] ;
@@ -436,7 +436,7 @@ void RooIntegrator1D::extrapolate(Int_t n)
       hp=xa[i+m];
       w=_c[i+1]-_d[i];
       if((den=ho-hp) == 0.0) {
-   oocoutE((TObject*)0,Integration) << "RooIntegrator1D::extrapolate: internal error" << endl;
+   oocoutE(nullptr,Integration) << "RooIntegrator1D::extrapolate: internal error" << endl;
       }
       den=w/den;
       _d[i]=hp*den;

--- a/roofit/roofitcore/src/RooMCIntegrator.cxx
+++ b/roofit/roofitcore/src/RooMCIntegrator.cxx
@@ -311,7 +311,7 @@ Double_t RooMCIntegrator::vegas(Stage stage, UInt_t calls, UInt_t iterations, Do
           index += box[i] * sizeOfDim;
           sizeOfDim *= _grid.getNBoxes();
         }
-        oocoutP(this,Integration) << "RooMCIntegrator: still working ... iteration "
+        coutP(Integration) << "RooMCIntegrator: still working ... iteration "
             << it << '/' << iterations << "  box " << index << "/"<< std::pow(_grid.getNBoxes(), _grid.getDimension()) << endl;
         _timer.Start(true);
       }

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -826,14 +826,14 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
   // the fit parameters as the given varList of parameters.
 
   if (_theFitter==0 || _theFitter->GetMinimizer()==0) {
-    oocoutE((TObject*)0,InputArguments) << "RooMinimizer::save: Error, run minimization before!"
+    oocoutE(nullptr,InputArguments) << "RooMinimizer::save: Error, run minimization before!"
                << endl ;
     return nullptr;
   }
 
   // Verify length of supplied varList
   if (!varList.empty() && varList.size() != _theFitter->Result().NTotalParameters()) {
-    oocoutE((TObject*)0,InputArguments)
+    oocoutE(nullptr,InputArguments)
       << "RooMinimizer::lastMinuitFit: ERROR: supplied variable list must be either empty " << endl
       << "                             or match the number of variables of the last fit ("
       << _theFitter->Result().NTotalParameters() << ")" << endl ;
@@ -844,7 +844,7 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
   // Verify that all members of varList are of type RooRealVar
   for (RooAbsArg * arg : varList) {
     if (!dynamic_cast<RooRealVar*>(arg)) {
-      oocoutE((TObject*)0,InputArguments) << "RooMinimizer::lastMinuitFit: ERROR: variable '"
+      oocoutE(nullptr,InputArguments) << "RooMinimizer::lastMinuitFit: ERROR: variable '"
                  << arg->GetName() << "' is not of type RooRealVar" << endl ;
       return nullptr;
     }
@@ -887,7 +887,7 @@ RooFitResult* RooMinimizer::lastMinuitFit(const RooArgList& varList)
       }
 
       if (varName.CompareTo(var->GetName())) {
-   oocoutI((TObject*)0,Eval)  << "RooMinimizer::lastMinuitFit: fit parameter '" << varName
+   oocoutI(nullptr,Eval)  << "RooMinimizer::lastMinuitFit: fit parameter '" << varName
                << "' stored in variable '" << var->GetName() << "'" << endl ;
       }
 

--- a/roofit/roofitcore/src/RooMsgService.cxx
+++ b/roofit/roofitcore/src/RooMsgService.cxx
@@ -451,6 +451,7 @@ bool RooMsgService::StreamConfig::match(RooFit::MsgLevel level, RooFit::MsgTopic
 
   if (universal) return true ;
 
+  if (!obj) return false;
   if (objectName.size()>0 && objectName != obj->GetName()) return false ;
   if (className.size()>0 && className != obj->IsA()->GetName()) return false ;
   if (baseClassName.size()>0 && !obj->IsA()->InheritsFrom(baseClassName.c_str())) return false ;
@@ -471,6 +472,7 @@ bool RooMsgService::StreamConfig::match(RooFit::MsgLevel level, RooFit::MsgTopic
 
   if (universal) return true ;
 
+  if (!obj) return false;
   if (objectName.size()>0 && objectName != obj->GetName()) return false ;
   if (className.size()>0 && className != obj->IsA()->GetName()) return false ;
   if (baseClassName.size()>0 && !obj->IsA()->InheritsFrom(baseClassName.c_str())) return false ;

--- a/roofit/roofitcore/src/RooNumGenConfig.cxx
+++ b/roofit/roofitcore/src/RooNumGenConfig.cxx
@@ -290,7 +290,7 @@ const RooArgSet& RooNumGenConfig::getConfigSection(const char* name) const
   static RooArgSet dummy ;
   RooArgSet* config = (RooArgSet*) _configSets.FindObject(name) ;
   if (!config) {
-    oocoutE((TObject*)0,InputArguments) << "RooNumGenConfig::getIntegrator: ERROR: no configuration stored for integrator '" << name << "'" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumGenConfig::getIntegrator: ERROR: no configuration stored for integrator '" << name << "'" << endl ;
     return dummy ;
   }
   return *config ;

--- a/roofit/roofitcore/src/RooNumGenFactory.cxx
+++ b/roofit/roofitcore/src/RooNumGenFactory.cxx
@@ -190,7 +190,7 @@ RooAbsNumGenerator* RooNumGenFactory::createSampler(RooAbsReal& func, const RooA
 
   // Check that a method was defined for this case
   if (!method.CompareTo("N/A")) {
-    oocoutE((TObject*)0,Integration) << "RooNumGenFactory::createSampler: No sampler method has been defined for "
+    oocoutE(nullptr,Integration) << "RooNumGenFactory::createSampler: No sampler method has been defined for "
                  << (cond?"a conditional ":"a ") << ndim << "-dimensional p.d.f" << endl ;
     return 0 ;
   }

--- a/roofit/roofitcore/src/RooNumIntConfig.cxx
+++ b/roofit/roofitcore/src/RooNumIntConfig.cxx
@@ -217,7 +217,7 @@ const RooArgSet& RooNumIntConfig::getConfigSection(const char* name) const
   static RooArgSet dummy ;
   RooArgSet* config = (RooArgSet*) _configSets.FindObject(name) ;
   if (!config) {
-    oocoutE((TObject*)0,InputArguments) << "RooNumIntConfig::getConfigSection: ERROR: no configuration stored for integrator '" << name << "'" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::getConfigSection: ERROR: no configuration stored for integrator '" << name << "'" << endl ;
     return dummy ;
   }
   return *config ;
@@ -231,7 +231,7 @@ const RooArgSet& RooNumIntConfig::getConfigSection(const char* name) const
 void RooNumIntConfig::setEpsAbs(Double_t newEpsAbs)
 {
   if (newEpsAbs<0) {
-    oocoutE((TObject*)0,InputArguments) << "RooNumIntConfig::setEpsAbs: ERROR: target absolute precision must be greater or equal than zero" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::setEpsAbs: ERROR: target absolute precision must be greater or equal than zero" << endl ;
     return ;
   }
   _epsAbs = newEpsAbs ;
@@ -261,7 +261,7 @@ RooPrintable::StyleOption RooNumIntConfig::defaultPrintStyle(Option_t* opt) cons
 void RooNumIntConfig::setEpsRel(Double_t newEpsRel)
 {
   if (newEpsRel<0) {
-    oocoutE((TObject*)0,InputArguments) << "RooNumIntConfig::setEpsRel: ERROR: target absolute precision must be greater or equal than zero" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooNumIntConfig::setEpsRel: ERROR: target absolute precision must be greater or equal than zero" << endl ;
     return ;
   }
   _epsRel = newEpsRel ;

--- a/roofit/roofitcore/src/RooNumIntFactory.cxx
+++ b/roofit/roofitcore/src/RooNumIntFactory.cxx
@@ -45,8 +45,6 @@ the preference of the caller as encoded in the configuration object.
 #include "RooSegmentedIntegrator2D.h"
 #include "RooImproperIntegrator1D.h"
 #include "RooMCIntegrator.h"
-//#include "RooGaussKronrodIntegrator1D.h"
-//#include "RooAdaptiveGaussKronrodIntegrator1D.h"
 #include "RooAdaptiveIntegratorND.h"
 
 #include "RooMsgService.h"
@@ -82,7 +80,7 @@ void RooNumIntFactory::init() {
 #ifdef R__HAS_MATHMORE
   int iret = gSystem->Load("libRooFitMore");
   if (iret < 0) {
-     oocoutE((TObject*)nullptr, Integration) << " RooNumIntFactory::Init : libRooFitMore cannot be loaded. GSL integrators will not beavailable ! " << std::endl;
+     oocoutE(nullptr, Integration) << " RooNumIntFactory::Init : libRooFitMore cannot be loaded. GSL integrators will not beavailable ! " << std::endl;
   }
 #endif
 }
@@ -204,7 +202,7 @@ RooAbsIntegrator* RooNumIntFactory::createIntegrator(RooAbsFunc& func, const Roo
 
   // Check that a method was defined for this case
   if (!method.CompareTo("N/A")) {
-    oocoutE((TObject*)0,Integration) << "RooNumIntFactory::createIntegrator: No integration method has been defined for "
+    oocoutE(nullptr,Integration) << "RooNumIntFactory::createIntegrator: No integration method has been defined for "
                  << (openEnded?"an open ended ":"a ") << ndim << "-dimensional integral" << endl ;
     return 0 ;
   }

--- a/roofit/roofitcore/src/RooQuasiRandomGenerator.cxx
+++ b/roofit/roofitcore/src/RooQuasiRandomGenerator.cxx
@@ -101,7 +101,7 @@ bool RooQuasiRandomGenerator::generate(UInt_t dimension, Double_t vector[])
     else break;
   }
   if(r >= NBits) {
-    oocoutE((TObject*)0,Integration) << "RooQuasiRandomGenerator::generate: internal error!" << endl;
+    oocoutE(nullptr,Integration) << "RooQuasiRandomGenerator::generate: internal error!" << endl;
     return false;
   }
 

--- a/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
+++ b/roofit/roofitcore/src/RooRandomizeParamMCSModule.cxx
@@ -97,7 +97,7 @@ void RooRandomizeParamMCSModule::sampleUniform(RooRealVar& param, Double_t lo, D
   if (genParams()) {
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(param.GetName())) ;
     if (!actualPar) {
-      oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       return ;
     }
   }
@@ -118,7 +118,7 @@ void RooRandomizeParamMCSModule::sampleGaussian(RooRealVar& param, Double_t mean
   if (genParams()) {
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(param.GetName())) ;
     if (!actualPar) {
-      oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << param.GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       return ;
     }
   }
@@ -146,7 +146,7 @@ void RooRandomizeParamMCSModule::sampleSumUniform(const RooArgSet& paramSet, Dou
     // Check that arg is a RooRealVar
     RooRealVar* rrv = dynamic_cast<RooRealVar*>(arg) ;
     if (!rrv) {
-      oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << endl ;
       continue;
     }
     okset.add(*rrv) ;
@@ -162,7 +162,7 @@ void RooRandomizeParamMCSModule::sampleSumUniform(const RooArgSet& paramSet, Dou
     while ((arg2=(RooAbsArg*)psiter->Next())) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg2->GetName())) ;
       if (!actualVar) {
-   oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       } else {
    okset2.add(*actualVar) ;
       }
@@ -201,7 +201,7 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, Doubl
     // Check that arg is a RooRealVar
     RooRealVar* rrv = dynamic_cast<RooRealVar*>(arg) ;
     if (!rrv) {
-      oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::sampleSumGauss() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumGauss() ERROR: input parameter " << arg->GetName() << " is not a RooRealVar and is ignored" << endl ;
       continue;
     }
     okset.add(*rrv) ;
@@ -216,7 +216,7 @@ void RooRandomizeParamMCSModule::sampleSumGauss(const RooArgSet& paramSet, Doubl
     while ((arg2=(RooAbsArg*)psiter.Next())) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg2->GetName())) ;
       if (!actualVar) {
-   oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::sampleSumUniform: variable " << arg2->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       } else {
    okset2.add(*actualVar) ;
       }
@@ -247,7 +247,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     // Check that listed variable is actual generator model parameter
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(uiter->_param->GetName())) ;
     if (!actualPar) {
-      oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << uiter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << uiter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       uiter = _unifParams.erase(uiter) ;
       continue ;
     }
@@ -267,7 +267,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     // Check that listed variable is actual generator model parameter
     RooRealVar* actualPar = static_cast<RooRealVar*>(genParams()->find(giter->_param->GetName())) ;
     if (!actualPar) {
-      oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << giter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+      oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << giter->_param->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       giter = _gausParams.erase(giter) ;
       continue ;
     }
@@ -292,7 +292,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     while ((arg=(RooAbsArg*)psiter->Next())) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg->GetName())) ;
       if (!actualVar) {
-   oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       } else {
    actualPSet.add(*actualVar) ;
       }
@@ -324,7 +324,7 @@ bool RooRandomizeParamMCSModule::initializeInstance()
     while ((arg=(RooAbsArg*)psiter.Next())) {
       RooRealVar* actualVar= static_cast<RooRealVar*>(genParams()->find(arg->GetName())) ;
       if (!actualVar) {
-   oocoutW((TObject*)0,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
+   oocoutW(nullptr,InputArguments) << "RooRandomizeParamMCSModule::initializeInstance: variable " << arg->GetName() << " is not a parameter of RooMCStudy model and is ignored!" << endl ;
       } else {
    actualPSet.add(*actualVar) ;
       }
@@ -373,7 +373,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
   std::list<UniParam>::iterator uiter ;
   for (uiter= _unifParams.begin() ; uiter!= _unifParams.end() ; ++uiter) {
     Double_t newVal = RooRandom::randomGenerator()->Uniform(uiter->_lo,uiter->_hi) ;
-    oocoutE((TObject*)0,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying uniform smearing to generator parameter "
+    oocoutE(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying uniform smearing to generator parameter "
     << uiter->_param->GetName() << " in range [" << uiter->_lo << "," << uiter->_hi << "], chosen value for this sample is " << newVal << endl ;
     uiter->_param->setVal(newVal) ;
 
@@ -385,7 +385,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
   std::list<GausParam>::iterator giter ;
   for (giter= _gausParams.begin() ; giter!= _gausParams.end() ; ++giter) {
     Double_t newVal = RooRandom::randomGenerator()->Gaus(giter->_mean,giter->_sigma) ;
-    oocoutI((TObject*)0,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying gaussian smearing to generator parameter "
+    oocoutI(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying gaussian smearing to generator parameter "
     << giter->_param->GetName() << " with a mean of " << giter->_mean << " and a width of " << giter->_sigma << ", chosen value for this sample is " << newVal << endl ;
     giter->_param->setVal(newVal) ;
 
@@ -399,7 +399,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
 
     // Calculate new value for sum
     Double_t newVal = RooRandom::randomGenerator()->Uniform(usiter->_lo,usiter->_hi) ;
-    oocoutI((TObject*)0,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying uniform smearing to sum of set of generator parameters "
+    oocoutI(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying uniform smearing to sum of set of generator parameters "
                 <<  usiter->_pset
                 << " in range [" << usiter->_lo << "," << usiter->_hi << "], chosen sum value for this sample is " << newVal << endl ;
 
@@ -424,7 +424,7 @@ bool RooRandomizeParamMCSModule::processBeforeGen(Int_t /*sampleNum*/)
 
     // Calculate new value for sum
     Double_t newVal = RooRandom::randomGenerator()->Gaus(gsiter->_mean,gsiter->_sigma) ;
-    oocoutI((TObject*)0,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying gaussian smearing to sum of set of generator parameters "
+    oocoutI(nullptr,Generation) << "RooRandomizeParamMCSModule::processBeforeGen: applying gaussian smearing to sum of set of generator parameters "
                 << gsiter->_pset
                 << " with a mean of " << gsiter->_mean << " and a width of " << gsiter->_sigma
                 << ", chosen value for this sample is " << newVal << endl ;

--- a/roofit/roofitcore/src/RooRangeBinning.cxx
+++ b/roofit/roofitcore/src/RooRangeBinning.cxx
@@ -88,7 +88,7 @@ RooRangeBinning::~RooRangeBinning()
 void RooRangeBinning::setRange(Double_t xlo, Double_t xhi)
 {
   if (xlo>xhi) {
-    oocoutE((TObject*)0,InputArguments) << "RooRangeBinning::setRange: ERROR low bound > high bound" << endl ;
+    oocoutE(nullptr,InputArguments) << "RooRangeBinning::setRange: ERROR low bound > high bound" << endl ;
     return ;
   }
 

--- a/roofit/roofitcore/src/RooRealBinding.cxx
+++ b/roofit/roofitcore/src/RooRealBinding.cxx
@@ -60,12 +60,12 @@ RooRealBinding::RooRealBinding(const RooAbsReal& func, const RooArgSet &vars, co
     RooAbsArg* var = vars[index];
     _vars.push_back(dynamic_cast<RooAbsRealLValue*>(var));
     if(_vars.back() == nullptr) {
-      oocoutE((TObject*)0,InputArguments) << "RooRealBinding: cannot bind to " << var->GetName()
+      oocoutE(nullptr,InputArguments) << "RooRealBinding: cannot bind to " << var->GetName()
           << ". Variables need to be assignable, e.g. instances of RooRealVar." << endl ;
       _valid= false;
     }
     if (!_func->dependsOn(*_vars[index])) {
-      oocoutW((TObject*)nullptr, InputArguments) << "RooRealBinding: The function " << func.GetName() << " does not depend on the parameter " << _vars[index]->GetName()
+      oocoutW(nullptr, InputArguments) << "RooRealBinding: The function " << func.GetName() << " does not depend on the parameter " << _vars[index]->GetName()
           << ". Note that passing copies of the parameters is not supported." << std::endl;
     }
   }

--- a/roofit/roofitcore/src/RooSegmentedIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooSegmentedIntegrator1D.cxx
@@ -164,7 +164,7 @@ RooSegmentedIntegrator1D::~RooSegmentedIntegrator1D()
 bool RooSegmentedIntegrator1D::setLimits(Double_t* xmin, Double_t* xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE((TObject*)0,InputArguments) << "RooSegmentedIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,InputArguments) << "RooSegmentedIntegrator1D::setLimits: cannot override integrand's limits" << endl;
     return false;
   }
   _xmin= *xmin;
@@ -187,7 +187,7 @@ bool RooSegmentedIntegrator1D::checkLimits() const
   }
   _range= _xmax - _xmin;
   if(_range <= 0) {
-    oocoutE((TObject*)0,InputArguments) << "RooIntegrator1D::checkLimits: bad range with min >= max" << endl;
+    oocoutE(nullptr,InputArguments) << "RooIntegrator1D::checkLimits: bad range with min >= max" << endl;
     return false;
   }
   bool ret =  (RooNumber::isInfinite(_xmin) || RooNumber::isInfinite(_xmax)) ? false : true;

--- a/roofit/roofitcore/src/RooSegmentedIntegrator2D.cxx
+++ b/roofit/roofitcore/src/RooSegmentedIntegrator2D.cxx
@@ -120,7 +120,7 @@ bool RooSegmentedIntegrator2D::checkLimits() const
   }
   _range= _xmax - _xmin;
   if(_range <= 0) {
-    oocoutE((TObject*)0,InputArguments) << "RooIntegrator1D::checkLimits: bad range with min >= max" << endl;
+    oocoutE(nullptr,InputArguments) << "RooIntegrator1D::checkLimits: bad range with min >= max" << endl;
     return false;
   }
   bool ret =  (RooNumber::isInfinite(_xmin) || RooNumber::isInfinite(_xmax)) ? false : true;

--- a/roofit/roofitcore/src/RooStreamParser.cxx
+++ b/roofit/roofitcore/src/RooStreamParser.cxx
@@ -152,7 +152,7 @@ TString RooStreamParser::readToken()
   while(1) {
     // Buffer overflow protection
     if (bufptr >= 63999) {
-      oocoutW((TObject *)0, InputArguments)
+      oocoutW(nullptr, InputArguments)
               << "RooStreamParser::readToken: token length exceeds buffer capacity, terminating token early" << endl;
       break;
     }
@@ -260,7 +260,7 @@ TString RooStreamParser::readToken()
 
   // Check if closing quote was encountered
   if (quotedString) {
-    oocoutW((TObject*)0,InputArguments) << "RooStreamParser::readToken: closing quote (\") missing" << endl ;
+    oocoutW(nullptr,InputArguments) << "RooStreamParser::readToken: closing quote (\") missing" << endl ;
   }
 
   // Absorb trailing white space or absorb rest of line if // is encountered
@@ -398,7 +398,7 @@ bool RooStreamParser::expectToken(const TString& expected, bool zapOnError)
 
   bool error=token.CompareTo(expected) ;
   if (error && !_prefix.IsNull()) {
-    oocoutW((TObject*)0,InputArguments) << _prefix << ": parse error, expected '"
+    oocoutW(nullptr,InputArguments) << _prefix << ": parse error, expected '"
                << expected << "'" << ", got '" << token << "'" << endl ;
     if (zapOnError) zapToEnd(true) ;
   }
@@ -439,7 +439,7 @@ bool RooStreamParser::convertToDouble(const TString& token, Double_t& value)
   bool error = (endptr-data!=token.Length()) ;
 
   if (error && !_prefix.IsNull()) {
-    oocoutE((TObject*)0,InputArguments) << _prefix << ": parse error, cannot convert '"
+    oocoutE(nullptr,InputArguments) << _prefix << ": parse error, cannot convert '"
                << token << "'" << " to double precision" <<  endl ;
   }
   return error ;
@@ -472,7 +472,7 @@ bool RooStreamParser::convertToInteger(const TString& token, Int_t& value)
   bool error = (endptr-data!=token.Length()) ;
 
   if (error && !_prefix.IsNull()) {
-    oocoutE((TObject*)0,InputArguments)<< _prefix << ": parse error, cannot convert '"
+    oocoutE(nullptr,InputArguments)<< _prefix << ": parse error, cannot convert '"
                    << token << "'" << " to integer" <<  endl ;
   }
   return error ;
@@ -503,7 +503,7 @@ bool RooStreamParser::convertToString(const TString& token, TString& string)
    char buffer[64000], *ptr;
    strncpy(buffer, token.Data(), 63999);
    if (token.Length() >= 63999) {
-      oocoutW((TObject *)0, InputArguments) << "RooStreamParser::convertToString: token length exceeds 63999, truncated"
+      oocoutW(nullptr, InputArguments) << "RooStreamParser::convertToString: token length exceeds 63999, truncated"
                                             << endl;
       buffer[63999] = 0;
   }

--- a/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
+++ b/roofit/roofitcore/src/TestStatistics/ConstantTermsOptimizer.cxx
@@ -58,7 +58,7 @@ void ConstantTermsOptimizer::enableConstantTermsOptimization(RooAbsReal *functio
    // dataset is constructed in terms of a RooVectorDataStore
    if (applyTrackingOpt) {
       if (!dynamic_cast<RooVectorDataStore *>(dataset->store())) {
-         oocoutW((TObject *)nullptr, Optimization)
+         oocoutW(nullptr, Optimization)
             << "enableConstantTermsOptimization(function: " << function->GetName()
             << ", dataset: " << dataset->GetName()
             << ") WARNING Cache-and-track optimization (Optimize level 2) is only available for datasets"
@@ -103,21 +103,21 @@ void ConstantTermsOptimizer::enableConstantTermsOptimization(RooAbsReal *functio
    actualTrackNodes.remove(*constNodes);
    if (constNodes->getSize() > 0) {
       if (constNodes->getSize() < 20) {
-         oocoutI((TObject*)nullptr, Minimization)
+         oocoutI(nullptr, Minimization)
             << " The following expressions have been identified as constant and will be precalculated and cached: "
             << *constNodes << std::endl;
       } else {
-         oocoutI((TObject*)nullptr, Minimization) << " A total of " << constNodes->getSize()
+         oocoutI(nullptr, Minimization) << " A total of " << constNodes->getSize()
                              << " expressions have been identified as constant and will be precalculated and cached."
                              << std::endl;
       }
    }
    if (actualTrackNodes.getSize() > 0) {
       if (actualTrackNodes.getSize() < 20) {
-         oocoutI((TObject*)nullptr, Minimization) << " The following expressions will be evaluated in cache-and-track mode: "
+         oocoutI(nullptr, Minimization) << " The following expressions will be evaluated in cache-and-track mode: "
                              << actualTrackNodes << std::endl;
       } else {
-         oocoutI((TObject*)nullptr, Minimization) << " A total of " << constNodes->getSize()
+         oocoutI(nullptr, Minimization) << " A total of " << constNodes->getSize()
                              << " expressions will be evaluated in cache-and-track-mode." << std::endl;
       }
    }

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodWrapper.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodWrapper.cxx
@@ -94,7 +94,7 @@ void LikelihoodWrapper::setOffsettingMode(OffsettingMode mode)
 {
    offsetting_mode_ = mode;
    if (isOffsetting()) {
-      oocoutI(static_cast<RooAbsArg *>(nullptr), Minimization)
+      oocoutI(nullptr, Minimization)
          << "LikelihoodWrapper::setOffsettingMode(" << GetName()
          << "): changed offsetting mode while offsetting was enabled; resetting offset values" << std::endl;
       offset_ = {};
@@ -118,7 +118,7 @@ ROOT::Math::KahanSum<double> LikelihoodWrapper::applyOffsetting(ROOT::Math::Kaha
                return {current_value.Result() - offset_.Result()};
             }
          }
-         oocoutI(static_cast<RooAbsArg *>(nullptr), Minimization)
+         oocoutI(nullptr, Minimization)
             << "LikelihoodWrapper::applyOffsetting(" << GetName() << "): Likelihood offset now set to " << offset_
             << std::endl;
       }

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -88,12 +88,12 @@ double MinuitFcnGrad::DoEval(const double *x) const
       if (_printEvalErrors >= 0) {
 
          if (_doEvalErrorWall) {
-            oocoutW(static_cast<RooAbsArg *>(nullptr), Eval)
+            oocoutW(nullptr, Eval)
                << "RooGradMinimizerFcn: Minimized function has error status." << std::endl
                << "Returning maximum FCN so far (" << _maxFCN
                << ") to force MIGRAD to back out of this region. Error log follows" << std::endl;
          } else {
-            oocoutW(static_cast<RooAbsArg *>(nullptr), Eval)
+            oocoutW(nullptr, Eval)
                << "RooGradMinimizerFcn: Minimized function has error status but is ignored" << std::endl;
          }
 

--- a/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooAbsL.cxx
@@ -57,7 +57,7 @@ RooAbsL::RooAbsL(std::shared_ptr<RooAbsPdf> pdf, std::shared_ptr<RooAbsData> dat
    extended_ = isExtendedHelper(pdf_.get(), extended);
    if (extended == Extended::Auto) {
       if (extended_) {
-         oocoutI((TObject *)nullptr, Minimization)
+         oocoutI(nullptr, Minimization)
             << "in RooAbsL ctor: p.d.f. provides expected number of events, including extended term in likelihood."
             << std::endl;
       }
@@ -157,7 +157,7 @@ void RooAbsL::initClones(RooAbsPdf &inpdf, RooAbsData &indata)
       // Check that range of observables in pdf is equal or contained in range of observables in data
 
       if (!realReal->getBinning().lowBoundFunc() && realReal->getMin() < (datReal->getMin() - 1e-6)) {
-         oocoutE((TObject *)0, InputArguments) << "RooAbsL: ERROR minimum of FUNC observable " << arg->GetName() << "("
+         oocoutE(nullptr, InputArguments) << "RooAbsL: ERROR minimum of FUNC observable " << arg->GetName() << "("
                                                << realReal->getMin() << ") is smaller than that of " << arg->GetName()
                                                << " in the dataset (" << datReal->getMin() << ")" << std::endl;
          RooErrorHandler::softAbort();
@@ -165,7 +165,7 @@ void RooAbsL::initClones(RooAbsPdf &inpdf, RooAbsData &indata)
       }
 
       if (!realReal->getBinning().highBoundFunc() && realReal->getMax() > (datReal->getMax() + 1e-6)) {
-         oocoutE((TObject *)0, InputArguments)
+         oocoutE(nullptr, InputArguments)
             << "RooAbsL: ERROR maximum of FUNC observable " << arg->GetName() << " is larger than that of "
             << arg->GetName() << " in the dataset" << std::endl;
          RooErrorHandler::softAbort();

--- a/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooBinnedL.cxx
@@ -111,7 +111,7 @@ RooBinnedL::evaluatePartition(Section bins, std::size_t /*components_begin*/, st
          // Catch error condition: data present where zero events are predicted
 //         logEvalError(Form("Observed %f events in bin %d with zero event yield", N, i));
          // TODO: check if using regular stream vs logEvalError error gathering is ok
-         oocoutI(static_cast<RooAbsArg *>(nullptr), Minimization)
+         oocoutI(nullptr, Minimization)
             << "Observed " << N << " events in bin " << i << " with zero event yield" << std::endl;
 
       } else if (fabs(mu) < 1e-10 && fabs(N) < 1e-10) {

--- a/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSubsidiaryL.cxx
@@ -46,7 +46,7 @@ RooSubsidiaryL::RooSubsidiaryL(const std::string &parent_pdf_name, const RooArgS
 {
    for (const auto comp : pdfs) {
       if (!dynamic_cast<RooAbsPdf *>(comp)) {
-         oocoutE((TObject *)0, InputArguments) << "RooSubsidiaryL::ctor(" << GetName() << ") ERROR: component "
+         oocoutE(nullptr, InputArguments) << "RooSubsidiaryL::ctor(" << GetName() << ") ERROR: component "
                                                << comp->GetName() << " is not of type RooAbsPdf" << std::endl;
          RooErrorHandler::softAbort();
       }
@@ -60,7 +60,7 @@ ROOT::Math::KahanSum<double> RooSubsidiaryL::evaluatePartition(RooAbsL::Section 
                                                                std::size_t /*components_end*/)
 {
    if (events.begin_fraction != 0 || events.end_fraction != 1) {
-      oocoutW((TObject *)0, InputArguments) << "RooSubsidiaryL::evaluatePartition can only calculate everything, so "
+      oocoutW(nullptr, InputArguments) << "RooSubsidiaryL::evaluatePartition can only calculate everything, so "
                                                "section should be {0,1}, but it's not!"
                                             << std::endl;
    }

--- a/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
+++ b/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
@@ -95,7 +95,7 @@ RooArgSet getConstraintsSet(RooAbsPdf *pdf, RooAbsData *data, ConstrainedParamet
       std::unique_ptr<RooArgSet> allVars{pdf->getVariables()};
       global_observables.set.add(
          *dynamic_cast<RooArgSet *>(allVars->selectByAttrib(global_observables_tag.c_str(), true)));
-      oocoutI((TObject *)nullptr, Minimization)
+      oocoutI(nullptr, Minimization)
          << "User-defined specification of global observables definition with tag named '" << global_observables_tag
          << "'" << std::endl;
    } else if (global_observables.set.getSize() == 0) {
@@ -103,7 +103,7 @@ RooArgSet getConstraintsSet(RooAbsPdf *pdf, RooAbsData *data, ConstrainedParamet
       // node
       const char *defGlobObsTag = pdf->getStringAttribute("DefaultGlobalObservablesTag");
       if (defGlobObsTag) {
-         oocoutI((TObject *)nullptr, Minimization)
+         oocoutI(nullptr, Minimization)
             << "p.d.f. provides built-in specification of global observables definition with tag named '"
             << defGlobObsTag << "'" << std::endl;
          std::unique_ptr<RooArgSet> allVars{pdf->getVariables()};
@@ -156,10 +156,10 @@ buildSubsidiaryL(RooAbsPdf *pdf, RooAbsData *data, ConstrainedParameters constra
    // Include constraints, if any, in likelihood
    if (allConstraints.getSize() > 0) {
 
-      oocoutI((TObject *)nullptr, Minimization)
+      oocoutI(nullptr, Minimization)
          << " Including the following contraint terms in minimization: " << allConstraints << std::endl;
       if (global_observables.set.getSize() > 0) {
-         oocoutI((TObject *)nullptr, Minimization)
+         oocoutI(nullptr, Minimization)
             << "The following global observables have been defined: " << global_observables.set << std::endl;
       }
       std::string name("likelihood for pdf ");
@@ -308,7 +308,7 @@ getSimultaneousComponents(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended ex
          }
       }
    }
-   oocoutI((TObject *)nullptr, Fitting) << "getSimultaneousComponents: created " << n << " slave calculators."
+   oocoutI(nullptr, Fitting) << "getSimultaneousComponents: created " << n << " slave calculators."
                                         << std::endl;
 
    return components;

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -166,7 +166,7 @@ void RooAdaptiveGaussKronrodIntegrator1D::registerIntegrator(RooNumIntFactory& f
      method.defineType("61Points", 6);
      method.setIndex(2);
      fact.storeProtoIntegrator(new RooAdaptiveGaussKronrodIntegrator1D(), RooArgSet(maxSeg, method));
-     oocoutI((TObject*)nullptr,Integration)  << "RooAdaptiveGaussKronrodIntegrator1D has been registered " << std::endl;
+     oocoutI(nullptr,Integration)  << "RooAdaptiveGaussKronrodIntegrator1D has been registered " << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -400,7 +400,7 @@ Double_t RooAdaptiveGaussKronrodIntegrator1D::integral(const Double_t *yvec)
 #define GSL_ENOMEM   8  /* malloc failed */
 #define GSL_EBADTOL 13  /* user specified an invalid tolerance */
 #define GSL_ETOL    14  /* failed to reach the specified tolerance */
-#define GSL_ERROR(a,b) oocoutE((TObject*)0,Integration) << "RooAdaptiveGaussKronrodIntegrator1D::integral() ERROR: " << a << endl ; return b ;
+#define GSL_ERROR(a,b) oocoutE(nullptr,Integration) << "RooAdaptiveGaussKronrodIntegrator1D::integral() ERROR: " << a << endl ; return b ;
 #define GSL_DBL_MIN        2.2250738585072014e-308
 #define GSL_DBL_MAX        1.7976931348623157e+308
 #define GSL_DBL_EPSILON    2.2204460492503131e-16

--- a/roofit/roofitmore/src/RooFitMoreLib.cxx
+++ b/roofit/roofitmore/src/RooFitMoreLib.cxx
@@ -5,5 +5,5 @@
 // Load automatically RooFitMore library that automatically will register the
 // integrator classes
 void RooFitMoreLib::Load() {
-   oocoutI((TObject*)nullptr, InputArguments) << "libRooFitMore has been loaded " << std::endl;
+   oocoutI(nullptr, InputArguments) << "libRooFitMore has been loaded " << std::endl;
 }

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -102,7 +102,7 @@ static Roo_reg_GKInteg1D instance;
 void RooGaussKronrodIntegrator1D::registerIntegrator(RooNumIntFactory& fact)
 {
   fact.storeProtoIntegrator(new RooGaussKronrodIntegrator1D(),RooArgSet()) ;
-  oocoutI((TObject*)nullptr,Integration) << "RooGaussKronrodIntegrator1D has been registered" << std::endl;
+  oocoutI(nullptr,Integration) << "RooGaussKronrodIntegrator1D has been registered" << std::endl;
 }
 
 
@@ -192,7 +192,7 @@ RooGaussKronrodIntegrator1D::~RooGaussKronrodIntegrator1D()
 bool RooGaussKronrodIntegrator1D::setLimits(Double_t* xmin, Double_t* xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE((TObject*)0,Eval) << "RooGaussKronrodIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Eval) << "RooGaussKronrodIntegrator1D::setLimits: cannot override integrand's limits" << endl;
     return false;
   }
   _xmin= *xmin;
@@ -282,7 +282,7 @@ Double_t RooGaussKronrodIntegrator1D::integral(const Double_t *yvec)
 #define GSL_SUCCESS 0
 #define GSL_EBADTOL 13  /* user specified an invalid tolerance */
 #define GSL_ETOL    14  /* failed to reach the specified tolerance */
-#define GSL_ERROR(a,b) oocoutE((TObject*)0,Eval) << "RooGaussKronrodIntegrator1D::integral() ERROR: " << a << endl ; return b ;
+#define GSL_ERROR(a,b) oocoutE(nullptr,Eval) << "RooGaussKronrodIntegrator1D::integral() ERROR: " << a << endl ; return b ;
 #define GSL_DBL_MIN        2.2250738585072014e-308
 #define GSL_DBL_EPSILON    2.2204460492503131e-16
 

--- a/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCImportanceSampler.h
@@ -62,7 +62,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          if( (fromNull  &&  i >= fNullDensities.size())  ||
              (!fromNull &&  i >= fImportanceDensities.size())
          ) {
-            oocoutE((TObject*)0,InputArguments) << "Index out of range. Requested index: "<<i<<
+            oocoutE(nullptr,InputArguments) << "Index out of range. Requested index: "<<i<<
                " , but null densities: "<<fNullDensities.size()<<
                " and importance densities: "<<fImportanceDensities.size() << std::endl;
          }
@@ -80,11 +80,11 @@ class ToyMCImportanceSampler: public ToyMCSampler {
       /// is used. The snapshot is also optional.
       void AddImportanceDensity(RooAbsPdf* p, const RooArgSet* s) {
          if( p == NULL && s == NULL ) {
-            oocoutI((TObject*)0,InputArguments) << "Neither density nor snapshot given. Doing nothing." << std::endl;
+            oocoutI(nullptr,InputArguments) << "Neither density nor snapshot given. Doing nothing." << std::endl;
             return;
          }
          if( p == NULL && fPdf == NULL ) {
-            oocoutE((TObject*)0,InputArguments) << "No density given, but snapshot is there. Aborting." << std::endl;
+            oocoutE(nullptr,InputArguments) << "No density given, but snapshot is there. Aborting." << std::endl;
             return;
          }
 
@@ -101,7 +101,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
       /// is used. The snapshot and TestStatistic is also optional.
       void AddNullDensity(RooAbsPdf* p, const RooArgSet* s = NULL) {
          if( p == NULL && s == NULL ) {
-            oocoutI((TObject*)0,InputArguments) << "Neither density nor snapshot nor test statistic given. Doing nothing." << std::endl;
+            oocoutI(nullptr,InputArguments) << "Neither density nor snapshot nor test statistic given. Doing nothing." << std::endl;
             return;
          }
 
@@ -121,7 +121,7 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          if( fNullDensities.size() == 1 ) { fNullDensities[0] = &pdf; }
          else if( fNullDensities.size() == 0) AddNullDensity( &pdf );
          else{
-            oocoutE((TObject*)0,InputArguments) << "Cannot use SetPdf() when already multiple null densities are specified. Please use AddNullDensity()." << std::endl;
+            oocoutE(nullptr,InputArguments) << "Cannot use SetPdf() when already multiple null densities are specified. Please use AddNullDensity()." << std::endl;
          }
       }
       /// overwrite from ToyMCSampler
@@ -129,11 +129,11 @@ class ToyMCImportanceSampler: public ToyMCSampler {
          ToyMCSampler::SetParametersForTestStat(nullpoi);
          if( fNullSnapshots.size() == 0 ) AddNullDensity( NULL, &nullpoi );
          else if( fNullSnapshots.size() == 1 ) {
-            oocoutI((TObject*)0,InputArguments) << "Overwriting snapshot for the only defined null density." << std::endl;
+            oocoutI(nullptr,InputArguments) << "Overwriting snapshot for the only defined null density." << std::endl;
             if( fNullSnapshots[0] ) delete fNullSnapshots[0];
             fNullSnapshots[0] = (const RooArgSet*)nullpoi.snapshot();
          }else{
-            oocoutE((TObject*)0,InputArguments) << "Cannot use SetParametersForTestStat() when already multiple null densities are specified. Please use AddNullDensity()." << std::endl;
+            oocoutE(nullptr,InputArguments) << "Cannot use SetParametersForTestStat() when already multiple null densities are specified. Please use AddNullDensity()." << std::endl;
          }
       }
 

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -92,7 +92,7 @@ class ToyMCSampler: public TestStatSampler {
       /// is used. The snapshot and TestStatistic is also optional.
       virtual void AddTestStatistic(TestStatistic* t = NULL) {
          if( t == NULL ) {
-            oocoutI((TObject*)0,InputArguments) << "No test statistic given. Doing nothing." << std::endl;
+            oocoutI(nullptr,InputArguments) << "No test statistic given. Doing nothing." << std::endl;
             return;
          }
 
@@ -102,7 +102,7 @@ class ToyMCSampler: public TestStatSampler {
       /// generates toy data
       ///   without weight
       virtual RooAbsData* GenerateToyData(RooArgSet& paramPoint, RooAbsPdf& pdf) const {
-         if(fExpectedNuisancePar) oocoutE((TObject*)NULL,InputArguments) << "ToyMCSampler: using expected nuisance parameters but ignoring weight. Use GetSamplingDistribution(paramPoint, weight) instead." << std::endl;
+         if(fExpectedNuisancePar) oocoutE(nullptr,InputArguments) << "ToyMCSampler: using expected nuisance parameters but ignoring weight. Use GetSamplingDistribution(paramPoint, weight) instead." << std::endl;
          double weight;
          return GenerateToyData(paramPoint, weight, pdf);
       }
@@ -177,7 +177,7 @@ class ToyMCSampler: public TestStatSampler {
       /// Set the TestStatistic (want the argument to be a function of the data & parameter points
       virtual void SetTestStatistic(TestStatistic *testStatistic, unsigned int i) {
          if( fTestStatistics.size() < i ) {
-            oocoutE((TObject*)NULL,InputArguments) << "Cannot set test statistic for this index." << std::endl;
+            oocoutE(nullptr,InputArguments) << "Cannot set test statistic for this index." << std::endl;
             return;
          }
          if( fTestStatistics.size() == i)

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -113,7 +113,7 @@ AsymptoticCalculator::AsymptoticCalculator(
    if (muNull->getVal() == muNull->getMin()) {
       fOneSidedDiscovery = true;
       if (verbose > 0)
-         oocoutI((TObject*)0,InputArguments) << "AsymptotiCalculator: Minimum of POI is " << muNull->getMin() << " corresponds to null  snapshot   - default configuration is  one-sided discovery formulae  " << std::endl;
+         oocoutI(nullptr,InputArguments) << "AsymptotiCalculator: Minimum of POI is " << muNull->getMin() << " corresponds to null  snapshot   - default configuration is  one-sided discovery formulae  " << std::endl;
    }
 
 }
@@ -133,17 +133,17 @@ bool AsymptoticCalculator::Initialize() const {
 
    int verbose = fgPrintLevel;
    if (verbose >= 0)
-      oocoutP((TObject*)0,Eval) << "AsymptoticCalculator::Initialize...." << std::endl;
+      oocoutP(nullptr,Eval) << "AsymptoticCalculator::Initialize...." << std::endl;
 
 
    RooAbsPdf * nullPdf = GetNullModel()->GetPdf();
    if (!nullPdf) {
-      oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator::Initialize - ModelConfig has not a pdf defined" << std::endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize - ModelConfig has not a pdf defined" << std::endl;
       return false;
    }
    RooAbsData * obsData = const_cast<RooAbsData *>(GetData() );
    if (!obsData ) {
-      oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator::Initialize - data set has not been defined" << std::endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize - data set has not been defined" << std::endl;
       return false;
    }
    RooAbsData & data = *obsData;
@@ -152,11 +152,11 @@ bool AsymptoticCalculator::Initialize() const {
 
    const RooArgSet * poi = GetNullModel()->GetParametersOfInterest();
    if (!poi || poi->getSize() == 0) {
-      oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator::Initialize -  ModelConfig has not POI defined." << endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize -  ModelConfig has not POI defined." << endl;
       return false;
    }
    if (poi->getSize() > 1) {
-      oocoutW((TObject*)0,InputArguments) << "AsymptoticCalculator::Initialize - ModelConfig has more than one POI defined \n\t"
+      oocoutW(nullptr,InputArguments) << "AsymptoticCalculator::Initialize - ModelConfig has more than one POI defined \n\t"
                                           << "The asymptotic calculator works for only one POI - consider as POI only the first parameter"
                                           << std::endl;
    }
@@ -165,7 +165,7 @@ bool AsymptoticCalculator::Initialize() const {
    // This will set the poi value to the null snapshot value in the ModelConfig
    const RooArgSet * nullSnapshot = GetNullModel()->GetSnapshot();
    if(nullSnapshot == NULL || nullSnapshot->getSize() == 0) {
-      oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator::Initialize - Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::Initialize - Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
       return false;
    }
 
@@ -188,14 +188,14 @@ bool AsymptoticCalculator::Initialize() const {
 
    // evaluate the unconditional nll for the full model on the  observed data
    if (verbose >= 0)
-      oocoutP((TObject*)0,Eval) << "AsymptoticCalculator::Initialize - Find  best unconditional NLL on observed data" << endl;
+      oocoutP(nullptr,Eval) << "AsymptoticCalculator::Initialize - Find  best unconditional NLL on observed data" << endl;
    fNLLObs = EvaluateNLL( *nullPdf, data, GetNullModel()->GetConditionalObservables(),GetNullModel()->GetGlobalObservables());
    // fill also snapshot of best poi
    poi->snapshot(fBestFitPoi);
    RooRealVar * muBest = dynamic_cast<RooRealVar*>(fBestFitPoi.first());
    assert(muBest);
    if (verbose >= 0)
-      oocoutP((TObject*)0,Eval) << "Best fitted POI value = " << muBest->getVal() << " +/- " << muBest->getError() << std::endl;
+      oocoutP(nullptr,Eval) << "Best fitted POI value = " << muBest->getVal() << " +/- " << muBest->getError() << std::endl;
    // keep snapshot of all best fit parameters
    allParams->snapshot(fBestFitParams);
    delete allParams;
@@ -203,13 +203,13 @@ bool AsymptoticCalculator::Initialize() const {
    // compute Asimov data set for the background (alt poi ) value
    const RooArgSet * altSnapshot = GetAlternateModel()->GetSnapshot();
    if(altSnapshot == NULL || altSnapshot->getSize() == 0) {
-      oocoutE((TObject*)0,InputArguments) << "Alt (Background)  model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
+      oocoutE(nullptr,InputArguments) << "Alt (Background)  model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
       return false;
    }
 
    RooArgSet poiAlt(*altSnapshot);  // this is the poi snapshot of B (i.e. for mu=0)
 
-   oocoutP((TObject*)0,Eval) << "AsymptoticCalculator: Building Asimov data Set" << endl;
+   oocoutP(nullptr,Eval) << "AsymptoticCalculator: Building Asimov data Set" << endl;
 
    // check that in case of binned models the n number of bins of the observables are consistent
    // with the number of bins  in the observed data
@@ -222,7 +222,7 @@ bool AsymptoticCalculator::Initialize() const {
       if (data.IsA() == RooDataHist::Class() ) {
          if (data.numEntries() != xobs->getBins() ) {
             prevBins = xobs->getBins();
-            oocoutW((TObject*)0,InputArguments) << "AsymptoticCalculator: number of bins in " << xobs->GetName() << " are different than data bins "
+            oocoutW(nullptr,InputArguments) << "AsymptoticCalculator: number of bins in " << xobs->GetName() << " are different than data bins "
                                                 << " set the same data bins " << data.numEntries() << " in range "
                                                 << " [ " << xobs->getMin() << " , " << xobs->getMax() << " ]" << std::endl;
             xobs->setBins(data.numEntries());
@@ -232,7 +232,7 @@ bool AsymptoticCalculator::Initialize() const {
 
    if (!fNominalAsimov) {
       if (verbose >= 0)
-         oocoutI((TObject*)0,InputArguments) << "AsymptoticCalculator: Asimov data will be generated using fitted nuisance parameter values" << endl;
+         oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimov data will be generated using fitted nuisance parameter values" << endl;
       RooArgSet * tmp = (RooArgSet*) poiAlt.snapshot();
       fAsimovData = MakeAsimovData( data, *GetNullModel(), poiAlt, fAsimovGlobObs,tmp);
    }
@@ -240,13 +240,13 @@ bool AsymptoticCalculator::Initialize() const {
    else {
       // assume use current value of nuisance as nominal ones
       if (verbose >= 0)
-         oocoutI((TObject*)0,InputArguments) << "AsymptoticCalculator: Asimovdata set will be generated using nominal (current) nuisance parameter values" << endl;
+         oocoutI(nullptr,InputArguments) << "AsymptoticCalculator: Asimovdata set will be generated using nominal (current) nuisance parameter values" << endl;
       nominalParams.assign(poiAlt); // set poi to alt value but keep nuisance at the nominal one
       fAsimovData = MakeAsimovData( *GetNullModel(), nominalParams, fAsimovGlobObs);
    }
 
    if (!fAsimovData) {
-      oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator: Error : Asimov data set could not be generated " << endl;
+      oocoutE(nullptr,InputArguments) << "AsymptoticCalculator: Error : Asimov data set could not be generated " << endl;
       return false;
    }
 
@@ -268,7 +268,7 @@ bool AsymptoticCalculator::Initialize() const {
    RooRealVar * muAlt = (RooRealVar*) poiAlt.first();
    assert(muAlt);
    if (verbose>=0)
-      oocoutP((TObject*)0,Eval) << "AsymptoticCalculator::Initialize Find  best conditional NLL on ASIMOV data set for given alt POI ( " <<
+      oocoutP(nullptr,Eval) << "AsymptoticCalculator::Initialize Find  best conditional NLL on ASIMOV data set for given alt POI ( " <<
          muAlt->GetName() << " ) = " << muAlt->getVal() << std::endl;
 
    fNLLAsimov =  EvaluateNLL( *nullPdf, *fAsimovData, GetNullModel()->GetConditionalObservables(), GetNullModel()->GetGlobalObservables(), &poiAlt );
@@ -427,7 +427,7 @@ Double_t AsymptoticCalculator::EvaluateNLL(RooAbsPdf & pdf, RooAbsData& data,   
 
        }
        else {
-          oocoutE((TObject*)0,Fitting) << "FIT FAILED !- return a NaN NLL " << std::endl;
+          oocoutE(nullptr,Fitting) << "FIT FAILED !- return a NaN NLL " << std::endl;
           val =  TMath::QuietNaN();
        }
 
@@ -479,13 +479,13 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    // re-initialized the calculator in case it is needed (pdf or data modified)
    if (!fIsInitialized) {
       if (!Initialize() ) {
-         oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator::GetHypoTest - Error initializing Asymptotic calculator - return NULL result " << endl;
+         oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest - Error initializing Asymptotic calculator - return NULL result " << endl;
          return 0;
       }
    }
 
    if (!fAsimovData) {
-       oocoutE((TObject*)0,InputArguments) << "AsymptoticCalculator::GetHypoTest - Asimov data set has not been generated - return NULL result " << endl;
+       oocoutE(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest - Asimov data set has not been generated - return NULL result " << endl;
        return 0;
    }
 
@@ -505,7 +505,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    RooArgSet poiTest(*nullSnapshot);
 
    if (poiTest.getSize() > 1)  {
-      oocoutW((TObject*)0,InputArguments) << "AsymptoticCalculator::GetHypoTest: snapshot has more than one POI - assume as POI first parameter " << std::endl;
+      oocoutW(nullptr,InputArguments) << "AsymptoticCalculator::GetHypoTest: snapshot has more than one POI - assume as POI first parameter " << std::endl;
    }
 
    RooArgSet * allParams = nullPdf->getParameters(*GetData() );
@@ -523,8 +523,8 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
 
    if (verbose> 0) {
       std::cout << std::endl;
-      oocoutI((TObject*)0,Eval) << "AsymptoticCalculator::GetHypoTest: - perform  an hypothesis test for  POI ( " << muTest->GetName() << " ) = " << muTest->getVal() << std::endl;
-      oocoutP((TObject*)0,Eval) << "AsymptoticCalculator::GetHypoTest -  Find  best conditional NLL on OBSERVED data set ..... " << std::endl;
+      oocoutI(nullptr,Eval) << "AsymptoticCalculator::GetHypoTest: - perform  an hypothesis test for  POI ( " << muTest->GetName() << " ) = " << muTest->getVal() << std::endl;
+      oocoutP(nullptr,Eval) << "AsymptoticCalculator::GetHypoTest -  Find  best conditional NLL on OBSERVED data set ..... " << std::endl;
    }
 
    // evaluate the conditional NLL on the observed data for the snapshot value
@@ -535,7 +535,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
 
 
    if (verbose > 0)
-      oocoutP((TObject*)0,Eval) << "\t OBSERVED DATA :  qmu   = " << qmu << " condNLL = " << condNLL << " uncond " << fNLLObs << std::endl;
+      oocoutP(nullptr,Eval) << "\t OBSERVED DATA :  qmu   = " << qmu << " condNLL = " << condNLL << " uncond " << fNLLObs << std::endl;
 
 
    // this tolerance is used to avoid having negative qmu due to numerical errors
@@ -543,17 +543,17 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    if (qmu < -tol || TMath::IsNaN(fNLLObs) ) {
 
       if (qmu < 0)
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  Found a negative value of the qmu - retry to do the unconditional fit "
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  Found a negative value of the qmu - retry to do the unconditional fit "
                                            << std::endl;
       else
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  unconditional fit failed before - retry to do it now "
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  unconditional fit failed before - retry to do it now "
                                            << std::endl;
 
 
       double nll = EvaluateNLL( *nullPdf, const_cast<RooAbsData&>(*GetData()),GetNullModel()->GetConditionalObservables(),GetNullModel()->GetGlobalObservables());
 
       if (nll < fNLLObs || (TMath::IsNaN(fNLLObs) && !TMath::IsNaN(nll) ) ) {
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  Found a better unconditional minimum "
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  Found a better unconditional minimum "
                                            << " old NLL = " << fNLLObs << " old muHat " << muHat->getVal() << std::endl;
 
          // update values
@@ -566,26 +566,26 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
          muHat =  dynamic_cast<RooRealVar*> (  fBestFitPoi.first() );
          assert(muHat);
 
-        oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  New minimum  found for                       "
+        oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  New minimum  found for                       "
                                           << "    NLL = " << fNLLObs << "    muHat  " << muHat->getVal() << std::endl;
 
 
         qmu = 2.*(condNLL - fNLLObs);
 
         if (verbose > 0)
-           oocoutP((TObject*)0,Eval) << "After unconditional refit,  new qmu value is " << qmu << std::endl;
+           oocoutP(nullptr,Eval) << "After unconditional refit,  new qmu value is " << qmu << std::endl;
 
       }
    }
 
    if (qmu < -tol ) {
-      oocoutE((TObject*)0,Minimization) << "AsymptoticCalculator:  qmu is still < 0  for mu = "
+      oocoutE(nullptr,Minimization) << "AsymptoticCalculator:  qmu is still < 0  for mu = "
                                         <<  muTest->getVal() << " return a dummy result "
                                         << std::endl;
       return new HypoTestResult();
    }
    if (TMath::IsNaN(qmu) ) {
-      oocoutE((TObject*)0,Minimization) << "AsymptoticCalculator:  failure in fitting for qmu or qmuA "
+      oocoutE(nullptr,Minimization) << "AsymptoticCalculator:  failure in fitting for qmu or qmuA "
                                         <<  muTest->getVal() << " return a dummy result "
                                         << std::endl;
       return new HypoTestResult();
@@ -610,7 +610,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    }
 
 
-   if (verbose > 0) oocoutP((TObject*)0,Eval) << "AsymptoticCalculator::GetHypoTest -- Find  best conditional NLL on ASIMOV data set .... " << std::endl;
+   if (verbose > 0) oocoutP(nullptr,Eval) << "AsymptoticCalculator::GetHypoTest -- Find  best conditional NLL on ASIMOV data set .... " << std::endl;
 
    double condNLL_A = EvaluateNLL( *nullPdf, *fAsimovData, GetNullModel()->GetConditionalObservables(),  GetNullModel()->GetGlobalObservables(), &poiTest);
 
@@ -618,45 +618,45 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    double qmu_A = 2.*(condNLL_A - fNLLAsimov  );
 
    if (verbose > 0)
-      oocoutP((TObject*)0,Eval) << "\t ASIMOV data qmu_A = " << qmu_A << " condNLL = " << condNLL_A << " uncond " << fNLLAsimov << std::endl;
+      oocoutP(nullptr,Eval) << "\t ASIMOV data qmu_A = " << qmu_A << " condNLL = " << condNLL_A << " uncond " << fNLLAsimov << std::endl;
 
    if (qmu_A < -tol || TMath::IsNaN(fNLLAsimov) ) {
 
       if (qmu_A < 0)
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  Found a negative value of the qmu Asimov- retry to do the unconditional fit "
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  Found a negative value of the qmu Asimov- retry to do the unconditional fit "
                                            << std::endl;
       else
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  Fit failed for  unconditional the qmu Asimov- retry  unconditional fit "
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  Fit failed for  unconditional the qmu Asimov- retry  unconditional fit "
                                            << std::endl;
 
 
       double nll = EvaluateNLL( *nullPdf, *fAsimovData,  GetNullModel()->GetConditionalObservables(), GetNullModel()->GetGlobalObservables() );
 
       if (nll < fNLLAsimov || (TMath::IsNaN(fNLLAsimov) && !TMath::IsNaN(nll) )) {
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  Found a better unconditional minimum for Asimov data set"
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  Found a better unconditional minimum for Asimov data set"
                                            << " old NLL = " << fNLLAsimov << std::endl;
 
          // update values
          fNLLAsimov = nll;
 
-         oocoutW((TObject*)0,Minimization) << "AsymptoticCalculator:  New minimum  found for                       "
+         oocoutW(nullptr,Minimization) << "AsymptoticCalculator:  New minimum  found for                       "
                                            << "    NLL = " << fNLLAsimov << std::endl;
          qmu_A = 2.*(condNLL_A - fNLLAsimov);
 
         if (verbose > 0)
-           oocoutP((TObject*)0,Eval) << "After unconditional Asimov refit,  new qmu_A value is " << qmu_A << std::endl;
+           oocoutP(nullptr,Eval) << "After unconditional Asimov refit,  new qmu_A value is " << qmu_A << std::endl;
 
       }
    }
 
    if (qmu_A < - tol) {
-      oocoutE((TObject*)0,Minimization) << "AsymptoticCalculator:  qmu_A is still < 0  for mu = "
+      oocoutE(nullptr,Minimization) << "AsymptoticCalculator:  qmu_A is still < 0  for mu = "
                                         <<  muTest->getVal() << " return a dummy result "
                                         << std::endl;
       return new HypoTestResult();
    }
    if (TMath::IsNaN(qmu) ) {
-      oocoutE((TObject*)0,Minimization) << "AsymptoticCalculator:  failure in fitting for qmu or qmuA "
+      oocoutE(nullptr,Minimization) << "AsymptoticCalculator:  failure in fitting for qmu or qmuA "
                                         <<  muTest->getVal() << " return a dummy result "
                                         << std::endl;
       return new HypoTestResult();
@@ -687,10 +687,10 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
          assert(muAlt != 0 );
          if (muTest->getMin() == muAlt->getVal()   ) {
             fUseQTilde = 1;
-            oocoutI((TObject*)0,InputArguments) << "Minimum of POI is " << muTest->getMin() << " corresponds to alt  snapshot   - using qtilde asymptotic formulae  " << std::endl;
+            oocoutI(nullptr,InputArguments) << "Minimum of POI is " << muTest->getMin() << " corresponds to alt  snapshot   - using qtilde asymptotic formulae  " << std::endl;
          } else {
             fUseQTilde = 0;
-            oocoutI((TObject*)0,InputArguments) << "Minimum of POI is " << muTest->getMin() << " is different to alt snapshot " << muAlt->getVal()
+            oocoutI(nullptr,InputArguments) << "Minimum of POI is " << muTest->getMin() << " is different to alt snapshot " << muAlt->getVal()
                                                 << " - using standard q asymptotic formulae  " << std::endl;
          }
       }
@@ -701,14 +701,14 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
    //check for one side condition (remember this is valid only for one poi)
    if (fOneSided ) {
       if ( muHat->getVal() > muTest->getVal() ) {
-         oocoutI((TObject*)0,Eval) << "Using one-sided qmu - setting qmu to zero  muHat = " << muHat->getVal()
+         oocoutI(nullptr,Eval) << "Using one-sided qmu - setting qmu to zero  muHat = " << muHat->getVal()
                                    << " muTest = " << muTest->getVal() << std::endl;
          qmu = 0;
       }
    }
    if (fOneSidedDiscovery ) {
       if ( muHat->getVal() < muTest->getVal() ) {
-         oocoutI((TObject*)0,Eval) << "Using one-sided discovery qmu - setting qmu to zero  muHat = " << muHat->getVal()
+         oocoutI(nullptr,Eval) << "Using one-sided discovery qmu - setting qmu to zero  muHat = " << muHat->getVal()
                                    << " muTest = " << muTest->getVal() << std::endl;
          qmu = 0;
       }
@@ -736,16 +736,16 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       // for one-sided PL (q_mu : equations 56,57)
       if (verbose>2) {
          if (fOneSided)
-            oocoutI((TObject*)0,Eval) << "Using one-sided limit asymptotic formula (qmu)" << endl;
+            oocoutI(nullptr,Eval) << "Using one-sided limit asymptotic formula (qmu)" << endl;
          else
-            oocoutI((TObject*)0,Eval) << "Using one-sided discovery asymptotic formula (q0)" << endl;
+            oocoutI(nullptr,Eval) << "Using one-sided discovery asymptotic formula (q0)" << endl;
       }
       pnull = ROOT::Math::normal_cdf_c( sqrtqmu, 1.);
       palt = ROOT::Math::normal_cdf( sqrtqmu_A - sqrtqmu, 1.);
    }
    else  {
       // for 2-sided PL (t_mu : equations 35,36 in asymptotic paper)
-      if (verbose > 2) oocoutI((TObject*)0,Eval) << "Using two-sided asymptotic  formula (tmu)" << endl;
+      if (verbose > 2) oocoutI(nullptr,Eval) << "Using two-sided asymptotic  formula (tmu)" << endl;
       pnull = 2.*ROOT::Math::normal_cdf_c( sqrtqmu, 1.);
       palt = ROOT::Math::normal_cdf_c( sqrtqmu + sqrtqmu_A, 1.) +
          ROOT::Math::normal_cdf_c( sqrtqmu - sqrtqmu_A, 1.);
@@ -756,7 +756,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
       if (fOneSided) {
          // for bounded one-sided (q_mu_tilde: equations 64,65)
          if ( qmu > qmu_A && (qmu_A > 0 || qmu > tol) ) { // to avoid case 0/0
-            if (verbose > 2) oocoutI((TObject*)0,Eval) << "Using qmu_tilde (qmu is greater than qmu_A)" << endl;
+            if (verbose > 2) oocoutI(nullptr,Eval) << "Using qmu_tilde (qmu is greater than qmu_A)" << endl;
             pnull = ROOT::Math::normal_cdf_c( (qmu + qmu_A)/(2 * sqrtqmu_A), 1.);
             palt = ROOT::Math::normal_cdf_c( (qmu - qmu_A)/(2 * sqrtqmu_A), 1.);
          }
@@ -765,7 +765,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
          // for 2 sided bounded test statistic  (N.B there is no one sided discovery qtilde)
          // t_mu_tilde: equations 43,44 in asymptotic paper
          if ( qmu >  qmu_A  && (qmu_A > 0 || qmu > tol)  ) {
-            if (verbose > 2) oocoutI((TObject*)0,Eval) << "Using tmu_tilde (qmu is greater than qmu_A)" << endl;
+            if (verbose > 2) oocoutI(nullptr,Eval) << "Using tmu_tilde (qmu is greater than qmu_A)" << endl;
             pnull = ROOT::Math::normal_cdf_c(sqrtqmu,1.) +
                     ROOT::Math::normal_cdf_c( (qmu + qmu_A)/(2 * sqrtqmu_A), 1.);
             palt = ROOT::Math::normal_cdf_c( sqrtqmu_A + sqrtqmu, 1.) +
@@ -782,7 +782,7 @@ HypoTestResult* AsymptoticCalculator::GetHypoTest() const {
 
    if (verbose > 0)
       //std::cout
-      oocoutP((TObject*)0,Eval)
+      oocoutP(nullptr,Eval)
          << "poi = " << muTest->getVal() << " qmu = " << qmu << " qmu_A = " << qmu_A
          << " sigma = " << muTest->getVal()/sqrtqmu_A
          << "  CLsplusb = " << pnull << " CLb = " << palt << " CLs = " <<  res->CLs() << std::endl;
@@ -829,7 +829,7 @@ double AsymptoticCalculator::GetExpectedPValues(double pnull, double palt, doubl
    brf.SetFunction( wf, 0, 20);
    bool ret = brf.Solve();
    if (!ret) {
-      oocoutE((TObject*)0,Eval)  << "Error finding expected p-values - return -1" << std::endl;
+      oocoutE(nullptr,Eval)  << "Error finding expected p-values - return -1" << std::endl;
       return -1;
    }
    double sqrttmu_A = brf.Root();
@@ -840,7 +840,7 @@ double AsymptoticCalculator::GetExpectedPValues(double pnull, double palt, doubl
    brf.SetFunction(wf2,0,20);
    ret = brf.Solve();
    if (!ret) {
-      oocoutE((TObject*)0,Eval)  << "Error finding expected p-values - return -1" << std::endl;
+      oocoutE(nullptr,Eval)  << "Error finding expected p-values - return -1" << std::endl;
       return -1;
    }
    return  2*ROOT::Math::normal_cdf_c( brf.Root(),1.);
@@ -888,12 +888,12 @@ void AsymptoticCalculator::FillBins(const RooAbsPdf & pdf, const RooArgList &obs
          if (fval*expectedEvents <= 0)
          {
             if (fval*expectedEvents < 0) {
-               oocoutW(static_cast<TObject*>(nullptr),InputArguments)
+               oocoutW(nullptr,InputArguments)
                    << "AsymptoticCalculator::" << __func__
                    << "(): Detected a bin with negative expected events! Please check your inputs." << endl;
             }
             else {
-               oocoutW(static_cast<TObject*>(nullptr),InputArguments)
+               oocoutW(nullptr,InputArguments)
                    << "AsymptoticCalculator::" << __func__
                    << "(): Detected a bin with zero expected events- skip it" << endl;
             }
@@ -944,7 +944,7 @@ bool AsymptoticCalculator::SetObsToExpected(RooProdPdf &prod, const RooArgSet &o
             if (subprod)
                ret &= SetObsToExpected(*subprod, obs);
             else {
-               oocoutE(static_cast<TObject *>(nullptr), InputArguments)
+               oocoutE(nullptr, InputArguments)
                   << "Illegal term in counting model: "
                    << "the PDF " << a->GetName()
                    << " depends on the observables, but is not a Poisson, Gaussian or Product"
@@ -974,34 +974,34 @@ bool AsymptoticCalculator::SetObsToExpected(RooAbsPdf &pdf, const RooArgSet &obs
    for (RooAbsArg *a =  iter.next(); a != 0; a = iter.next()) {
       if (obs.contains(*a)) {
          if (myobs != 0) {
-            oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Has two observables ?? " << endl;
+            oocoutF(nullptr,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Has two observables ?? " << endl;
             return false;
          }
          myobs = dynamic_cast<RooRealVar *>(a);
          if (myobs == 0) {
-            oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Observable is not a RooRealVar??" << endl;
+            oocoutF(nullptr,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Observable is not a RooRealVar??" << endl;
             return false;
          }
       } else {
          if (!a->isConstant() ) {
             if (myexp != 0) {
-               oocoutE((TObject*)0,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Has two non-const arguments  " << endl;
+               oocoutE(nullptr,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Has two non-const arguments  " << endl;
                return false;
             }
             myexp = dynamic_cast<RooAbsReal *>(a);
             if (myexp == 0) {
-               oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Expected is not a RooAbsReal??" << endl;
+               oocoutF(nullptr,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : Expected is not a RooAbsReal??" << endl;
                return false;
             }
          }
       }
    }
    if (myobs == 0)  {
-      oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : No observable?" << endl;
+      oocoutF(nullptr,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : No observable?" << endl;
       return false;
    }
    if (myexp == 0) {
-      oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : No observable?" << endl;
+      oocoutF(nullptr,Generation) << "AsymptoticCalculator::SetObsExpected( " << pdfName << " ) : No observable?" << endl;
       return false;
    }
 
@@ -1038,7 +1038,7 @@ RooAbsData * AsymptoticCalculator::GenerateCountingAsimovData(RooAbsPdf & pdf, c
     } else if ((gaus = dynamic_cast<RooGaussian *>(&pdf)) != 0) {
         r = SetObsToExpected(*gaus, observables);
     } else {
-       oocoutE((TObject*)0,InputArguments) << "A counting model pdf must be either a RooProdPdf or a RooPoisson or a RooGaussian" << endl;
+       oocoutE(nullptr,InputArguments) << "A counting model pdf must be either a RooProdPdf or a RooPoisson or a RooGaussian" << endl;
     }
     if (!r) return 0;
     int icat = 0;
@@ -1157,7 +1157,7 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
   RooCategory& channelCat = const_cast<RooCategory&>(dynamic_cast<const RooCategory&>(simPdf->indexCat()));
   int nrIndices = channelCat.numTypes();
   if( nrIndices == 0 ) {
-    oocoutW((TObject*)0,Generation) << "Simultaneous pdf does not contain any categories." << endl;
+    oocoutW(nullptr,Generation) << "Simultaneous pdf does not contain any categories." << endl;
   }
   for (int i=0;i<nrIndices;i++){
     channelCat.setIndex(i);
@@ -1175,12 +1175,12 @@ RooAbsData * AsymptoticCalculator::GenerateAsimovData(const RooAbsPdf & pdf, con
     //((RooRealVar*)obstmp->first())->Print();
     //cout << "expected events " << pdftmp->expectedEvents(*obstmp) << endl;
     if (!dataSinglePdf) {
-       oocoutE((TObject*)0,Generation) << "Error generating an Asimov data set for pdf " << pdftmp->GetName() << endl;
+       oocoutE(nullptr,Generation) << "Error generating an Asimov data set for pdf " << pdftmp->GetName() << endl;
        return 0;
     }
 
     if (asimovDataMap.count(string(channelCat.getCurrentLabel())) != 0) {
-      oocoutE((TObject*)0,Generation) << "AsymptoticCalculator::GenerateAsimovData(): The PDF for " << channelCat.getCurrentLabel()
+      oocoutE(nullptr,Generation) << "AsymptoticCalculator::GenerateAsimovData(): The PDF for " << channelCat.getCurrentLabel()
           << " was already defined. It will be overridden. The faulty category definitions follow:" << endl;
       channelCat.Print("V");
     }
@@ -1403,7 +1403,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       RooArgSet nuis;
       if (model.GetNuisanceParameters()) nuis.add(*model.GetNuisanceParameters());
       if (nuis.getSize() == 0) {
-            oocoutW((TObject*)0,Generation) << "AsymptoticCalculator::MakeAsimovData: model does not have nuisance parameters but has global observables"
+            oocoutW(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData: model does not have nuisance parameters but has global observables"
                                             << " set global observables to model values " << endl;
             asimovGlobObs.assign(gobs);
             return asimov;
@@ -1412,7 +1412,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
       // part 1: create the nuisance pdf
       std::unique_ptr<RooAbsPdf> nuispdf(RooStats::MakeNuisancePdf(model,"TempNuisPdf") );
       if (nuispdf.get() == 0) {
-         oocoutF((TObject*)0,Generation) << "AsymptoticCalculator::MakeAsimovData: model has nuisance parameters and global obs but no nuisance pdf "
+         oocoutF(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData: model has nuisance parameters and global obs but no nuisance pdf "
                                          << std::endl;
       }
       // unfold the nuisance pdf if it is a prod pdf
@@ -1436,12 +1436,12 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
          std::unique_ptr<RooArgSet> cpars(cterm->getParameters(&gobs));
          std::unique_ptr<RooArgSet> cgobs(cterm->getObservables(&gobs));
          if (cgobs->getSize() > 1) {
-            oocoutE(static_cast<TObject*>(nullptr),Generation) << "AsymptoticCalculator::MakeAsimovData: constraint term  " <<  cterm->GetName()
+            oocoutE(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData: constraint term  " <<  cterm->GetName()
                                             << " has multiple global observables -cannot generate - skip it" << std::endl;
             continue;
          }
          else if (cgobs->getSize() == 0) {
-            oocoutW(static_cast<TObject *>(nullptr), Generation)
+            oocoutW(nullptr, Generation)
                << "AsymptoticCalculator::MakeAsimovData: constraint term  " << cterm->GetName()
                                             << " has no global observables - skip it" << std::endl;
             continue;
@@ -1452,7 +1452,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
          // remove the constant parameters in cpars
          RooStats::RemoveConstantParameters(cpars.get());
          if (cpars->getSize() != 1) {
-            oocoutE(static_cast<TObject *>(nullptr), Generation)
+            oocoutE(nullptr, Generation)
                << "AsymptoticCalculator::MakeAsimovData:constraint term "
                                             << cterm->GetName() << " has multiple floating params - cannot generate - skip it " << std::endl;
             continue;
@@ -1467,7 +1467,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
               cClass != RooGamma::Class() && cClass != RooLognormal::Class() &&
               cClass != RooBifurGauss::Class()  ) {
             TString className =  (cClass) ?  cClass->GetName() : "undefined";
-            oocoutW(static_cast<TObject *>(nullptr), Generation)
+            oocoutW(nullptr, Generation)
                << "AsymptoticCalculator::MakeAsimovData:constraint term "
                                             << cterm->GetName() << " of type " << className
                                             << " is a non-supported type - result might be not correct " << std::endl;
@@ -1487,7 +1487,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
             // in this case n+1 is the server and we don;t have a direct dependency, but we want to set n to the b value
             // so in case of the Gamma ignore this test
             if ( cClass != RooGamma::Class() ) {
-               oocoutE(static_cast<TObject *>(nullptr), Generation)
+               oocoutE(nullptr, Generation)
                   << "AsymptoticCalculator::MakeAsimovData:constraint term "
                                                << cterm->GetName() << " has no direct dependence on global observable- cannot generate it " << std::endl;
                continue;
@@ -1508,7 +1508,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
                }
             }
             if (thetaGamma == 0) {
-               oocoutI(static_cast<TObject *>(nullptr), Generation)
+               oocoutI(nullptr, Generation)
                   << "AsymptoticCalculator::MakeAsimovData:constraint term "
                                                << cterm->GetName() << " is a Gamma distribution and no server named theta is found. Assume that the Gamma scale is  1 " << std::endl;
             }
@@ -1526,7 +1526,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
 
                // found server depending on nuisance
                if (foundServer) {
-                  oocoutE(static_cast<TObject *>(nullptr),Generation) << "AsymptoticCalculator::MakeAsimovData:constraint term "
+                  oocoutE(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData:constraint term "
                                             << cterm->GetName() << " constraint term has more server depending on nuisance- cannot generate it " <<
                      std::endl;
                   foundServer = false;
@@ -1545,7 +1545,7 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(const ModelConfig & model, con
          }
 
          if (!foundServer) {
-            oocoutE(static_cast<TObject *>(nullptr),Generation) << "AsymptoticCalculator::MakeAsimovData - can't find nuisance for constraint term - global observables will not be set to Asimov value " << cterm->GetName() << std::endl;
+            oocoutE(nullptr,Generation) << "AsymptoticCalculator::MakeAsimovData - can't find nuisance for constraint term - global observables will not be set to Asimov value " << cterm->GetName() << std::endl;
             std::cerr << "Parameters: " << std::endl;
             cpars->Print("V");
             std::cerr << "Observables: " << std::endl;

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -121,20 +121,20 @@ struct  LikelihoodFunction {
 
       int nCalls = fFunc.binding().numCall();
       if (nCalls > 0 && nCalls % 1000 == 0) {
-         ooccoutD((TObject*)0,Eval) << "Likelihood evaluation ncalls = " << nCalls
+         ooccoutD(nullptr,Eval) << "Likelihood evaluation ncalls = " << nCalls
                                     << " x0 " << x[0] << "  nll = " << nll+fOffset;
-         if (fPrior) ooccoutD((TObject*)0,Eval) << " prior(x) = " << (*fPrior)(x);
-         ooccoutD((TObject*)0,Eval) << " likelihood " << likelihood
+         if (fPrior) ooccoutD(nullptr,Eval) << " prior(x) = " << (*fPrior)(x);
+         ooccoutD(nullptr,Eval) << " likelihood " << likelihood
                                     << " max Likelihood " << fMaxL << std::endl;
       }
 
       if  (likelihood > fMaxL ) {
          fMaxL = likelihood;
          if ( likelihood > 1.E10) {
-            ooccoutW((TObject*)0,Eval) << "LikelihoodFunction::()  WARNING - Huge likelihood value found for  parameters ";
+            ooccoutW(nullptr,Eval) << "LikelihoodFunction::()  WARNING - Huge likelihood value found for  parameters ";
             for (int i = 0; i < fFunc.nObs(); ++i)
-               ooccoutW((TObject*)0,Eval) << " x[" << i << " ] = " << x[i];
-            ooccoutW((TObject*)0,Eval) << "  nll = " << nll << " L = " << likelihood << std::endl;
+               ooccoutW(nullptr,Eval) << " x[" << i << " ] = " << x[i];
+            ooccoutW(nullptr,Eval) << "  nll = " << nll << " L = " << likelihood << std::endl;
          }
       }
 
@@ -182,7 +182,7 @@ public:
 
       fIntegrator.SetFunction(fLikelihood, bindParams.getSize() );
 
-      ooccoutD((TObject*)0,NumIntegration) << "PosteriorCdfFunction::Compute integral of posterior in nuisance and poi. "
+      ooccoutD(nullptr,NumIntegration) << "PosteriorCdfFunction::Compute integral of posterior in nuisance and poi. "
                                            << " nllMinimum is " << nllMinimum << std::endl;
 
       std::vector<double> par(bindParams.getSize());
@@ -191,18 +191,18 @@ public:
          fXmin[i] = var.getMin();
          fXmax[i] = var.getMax();
          par[i] = var.getVal();
-         ooccoutD((TObject*)0,NumIntegration) << "PosteriorFunction::Integrate" << var.GetName()
+         ooccoutD(nullptr,NumIntegration) << "PosteriorFunction::Integrate" << var.GetName()
                                               << " in interval [ " <<  fXmin[i] << " , " << fXmax[i] << " ] " << std::endl;
       }
 
-      fIntegrator.Options().Print(ooccoutD((TObject*)0,NumIntegration));
+      fIntegrator.Options().Print(ooccoutD(nullptr,NumIntegration));
 
       // store max POI value because it will be changed when evaluating the function
       fMaxPOI = fXmax[0];
 
       // compute first the normalization with  the poi
       fNorm = (*this)( fMaxPOI );
-      if (fError) ooccoutE((TObject*)0,NumIntegration) << "PosteriorFunction::Error computing normalization - norm = " << fNorm << std::endl;
+      if (fError) ooccoutE(nullptr,NumIntegration) << "PosteriorFunction::Error computing normalization - norm = " << fNorm << std::endl;
       fHasNorm = true;
       fNormCdfValues.insert(std::make_pair(fXmin[0], 0) );
       fNormCdfValues.insert(std::make_pair(fXmax[0], 1.0) );
@@ -243,7 +243,7 @@ public:
 
 
    ROOT::Math::IGenFunction * Clone() const override {
-      ooccoutD((TObject*)0,NumIntegration) << " cloning function .........." << std::endl;
+      ooccoutD(nullptr,NumIntegration) << " cloning function .........." << std::endl;
       return new PosteriorCdfFunction(*this);
    }
 
@@ -274,7 +274,7 @@ private:
          if (itr != fNormCdfValues.end() ) {
             fXmin[0] = itr->first;
             normcdf0 = itr->second;
-            // ooccoutD((TObject*)0,NumIntegration) << "PosteriorCdfFunction:   computing integral between in poi interval : "
+            // ooccoutD(nullptr,NumIntegration) << "PosteriorCdfFunction:   computing integral between in poi interval : "
             //                                      << fXmin[0] << " -  " << fXmax[0] << std::endl;
          }
       }
@@ -285,23 +285,23 @@ private:
       double error = fIntegrator.Error();
       double normcdf =  cdf/fNorm;  // normalize the cdf
 
-      ooccoutD((TObject*)0,NumIntegration) << "PosteriorCdfFunction: poi = [" << fXmin[0] << " , "
+      ooccoutD(nullptr,NumIntegration) << "PosteriorCdfFunction: poi = [" << fXmin[0] << " , "
                                            << fXmax[0] << "] integral =  " << cdf << " +/- " << error
                                            << "  norm-integ = " << normcdf << " cdf(x) = " << normcdf+normcdf0
                                            << " ncalls = " << fFunctor.binding().numCall() << std::endl;
 
       if (TMath::IsNaN(cdf) || cdf > std::numeric_limits<double>::max()) {
-         ooccoutE((TObject*)0,NumIntegration) << "PosteriorFunction::Error computing integral - cdf = "
+         ooccoutE(nullptr,NumIntegration) << "PosteriorFunction::Error computing integral - cdf = "
                                               << cdf << std::endl;
          fError = true;
       }
 
       if (cdf != 0 && error/cdf > 0.2 )
-         oocoutW((TObject*)0,NumIntegration) << "PosteriorCdfFunction: integration error  is larger than 20 %   x0 = " << fXmin[0]
+         oocoutW(nullptr,NumIntegration) << "PosteriorCdfFunction: integration error  is larger than 20 %   x0 = " << fXmin[0]
                                               << " x = " << x << " cdf(x) = " << cdf << " +/- " << error << std::endl;
 
       if (!fHasNorm) {
-         oocoutI((TObject*)0,NumIntegration) << "PosteriorCdfFunction - integral of posterior = "
+         oocoutI(nullptr,NumIntegration) << "PosteriorCdfFunction - integral of posterior = "
                                              << cdf << " +/- " << error << std::endl;
          fNormErr = error;
          return cdf;
@@ -316,7 +316,7 @@ private:
 
       double errnorm = sqrt( error*error + normcdf*normcdf * fNormErr * fNormErr )/fNorm;
       if (normcdf > 1. + 3 * errnorm) {
-         oocoutW((TObject*)0,NumIntegration) << "PosteriorCdfFunction: normalized cdf values is larger than 1"
+         oocoutW(nullptr,NumIntegration) << "PosteriorCdfFunction: normalized cdf values is larger than 1"
                                               << " x = " << x << " normcdf(x) = " << normcdf << " +/- " << error/fNorm << std::endl;
       }
 
@@ -366,12 +366,12 @@ public:
          fLikelihood.SetPrior(fPriorFunc.get() );
       }
 
-      ooccoutD((TObject*)0,NumIntegration) << "PosteriorFunction::Evaluate the posterior function by integrating the nuisances: " << std::endl;
+      ooccoutD(nullptr,NumIntegration) << "PosteriorFunction::Evaluate the posterior function by integrating the nuisances: " << std::endl;
       for (unsigned int i = 0; i < fXmin.size(); ++i) {
          RooRealVar & var = (RooRealVar &) nuisParams[i];
          fXmin[i] = var.getMin();
          fXmax[i] = var.getMax();
-         ooccoutD((TObject*)0,NumIntegration) << "PosteriorFunction::Integrate " << var.GetName()
+         ooccoutD(nullptr,NumIntegration) << "PosteriorFunction::Integrate " << var.GetName()
                                               << " in interval [" <<  fXmin[i] << " , " << fXmax[i] << " ] " << std::endl;
       }
       if (fXmin.size() == 1) { // 1D case
@@ -380,7 +380,7 @@ public:
          fIntegratorOneDim->SetFunction(fLikelihood);
          // interested only in relative tolerance
          //fIntegratorOneDim->SetAbsTolerance(1.E-300);
-         fIntegratorOneDim->Options().Print(ooccoutD((TObject*)0,NumIntegration) );
+         fIntegratorOneDim->Options().Print(ooccoutD(nullptr,NumIntegration) );
       }
       else if (fXmin.size() > 1) { // multiDim case
          fIntegratorMultiDim.reset(new ROOT::Math::IntegratorMultiDim(ROOT::Math::IntegratorMultiDim::GetType(integType) ) );
@@ -392,7 +392,7 @@ public:
          }
          //fIntegratorMultiDim->SetAbsTolerance(1.E-300);
          // print the options
-         opt.Print(ooccoutD((TObject*)0,NumIntegration) );
+         opt.Print(ooccoutD(nullptr,NumIntegration) );
       }
    }
 
@@ -428,7 +428,7 @@ private:
       }
 
       // debug
-      ooccoutD((TObject*)0,NumIntegration) << "PosteriorFunction:  POI value  =  "
+      ooccoutD(nullptr,NumIntegration) << "PosteriorFunction:  POI value  =  "
                                            << x << "\tf(x) =  " << f << " +/- " << error
                                            << "  norm-f(x) = " << f/fNorm
                                            << " ncalls = " << fFunctor.binding().numCall() << std::endl;
@@ -437,7 +437,7 @@ private:
 
 
       if (f != 0 && error/f > 0.2 )
-         ooccoutW((TObject*)0,NumIntegration) << "PosteriorFunction::DoEval - Error from integration in "
+         ooccoutW(nullptr,NumIntegration) << "PosteriorFunction::DoEval - Error from integration in "
                                               << fXmin.size() <<  " Dim is larger than 20 % "
                                               << "x = " << x << " p(x) = " << f << " +/- " << error << std::endl;
 
@@ -485,14 +485,14 @@ public:
          fLikelihood.SetPrior(fPriorFunc.get() );
       }
 
-      ooccoutI((TObject*)0,InputArguments) << "PosteriorFunctionFromToyMC::Evaluate the posterior function by randomizing the nuisances:  niter " << fNumIterations << std::endl;
+      ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Evaluate the posterior function by randomizing the nuisances:  niter " << fNumIterations << std::endl;
 
-      ooccoutI((TObject*)0,InputArguments) << "PosteriorFunctionFromToyMC::Pdf used for randomizing the nuisance is " << fPdf->GetName() << std::endl;
+      ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Pdf used for randomizing the nuisance is " << fPdf->GetName() << std::endl;
       // check that pdf contains  the nuisance
       RooArgSet * vars = fPdf->getVariables();
       for (int i = 0; i < fNuisParams.getSize(); ++i) {
          if (!vars->find( fNuisParams[i].GetName() ) ) {
-            ooccoutW((TObject*)0,InputArguments) << "Nuisance parameter " << fNuisParams[i].GetName()
+            ooccoutW(nullptr,InputArguments) << "Nuisance parameter " << fNuisParams[i].GetName()
                                                  << " is not part of sampling pdf. "
                                                  << "they will be treated as constant " << std::endl;
          }
@@ -500,7 +500,7 @@ public:
       delete vars;
 
       if (!fRedoToys) {
-         ooccoutI((TObject*)0,InputArguments) << "PosteriorFunctionFromToyMC::Generate nuisance toys only one time (for all POI points)" << std::endl;
+         ooccoutI(nullptr,InputArguments) << "PosteriorFunctionFromToyMC::Generate nuisance toys only one time (for all POI points)" << std::endl;
          GenerateToys();
       }
    }
@@ -512,7 +512,7 @@ public:
       if (fGenParams) delete fGenParams;
       fGenParams = fPdf->generate(fNuisParams, fNumIterations);
       if(fGenParams==0) {
-         ooccoutE((TObject*)0,InputArguments) << "PosteriorFunctionFromToyMC - failed to generate nuisance parameters" << std::endl;
+         ooccoutE(nullptr,InputArguments) << "PosteriorFunctionFromToyMC - failed to generate nuisance parameters" << std::endl;
       }
    }
 
@@ -571,25 +571,25 @@ private:
 
 
          if( fval > std::numeric_limits<double>::max()  ) {
-            ooccoutE((TObject*)0,Eval) <<  "BayesianCalculator::EvalPosteriorFunctionFromToy : "
+            ooccoutE(nullptr,Eval) <<  "BayesianCalculator::EvalPosteriorFunctionFromToy : "
                         << "Likelihood evaluates to infinity " << std::endl;
-            ooccoutE((TObject*)0,Eval) <<  "poi value =  " << x << std::endl;
-            ooccoutE((TObject*)0,Eval) <<  "Nuisance  parameter values :  ";
+            ooccoutE(nullptr,Eval) <<  "poi value =  " << x << std::endl;
+            ooccoutE(nullptr,Eval) <<  "Nuisance  parameter values :  ";
             for (int i = 0; i < npar; ++i)
-               ooccoutE((TObject*)0,Eval) << fNuisParams[i].GetName() << " = " << p[i] << " ";
-            ooccoutE((TObject*)0,Eval) <<  " - return 0   " << std::endl;
+               ooccoutE(nullptr,Eval) << fNuisParams[i].GetName() << " = " << p[i] << " ";
+            ooccoutE(nullptr,Eval) <<  " - return 0   " << std::endl;
 
             fError = 1.E30;
             return 0;
          }
          if(  TMath::IsNaN(fval) ) {
-            ooccoutE((TObject*)0,Eval) <<  "BayesianCalculator::EvalPosteriorFunctionFromToy : "
+            ooccoutE(nullptr,Eval) <<  "BayesianCalculator::EvalPosteriorFunctionFromToy : "
                         << "Likelihood is a NaN " << std::endl;
-            ooccoutE((TObject*)0,Eval) <<  "poi value =  " << x << std::endl;
-            ooccoutE((TObject*)0,Eval) <<  "Nuisance  parameter values :  ";
+            ooccoutE(nullptr,Eval) <<  "poi value =  " << x << std::endl;
+            ooccoutE(nullptr,Eval) <<  "Nuisance  parameter values :  ";
             for (int i = 0; i < npar; ++i)
-               ooccoutE((TObject*)0,Eval) << fNuisParams[i].GetName() << " = " << p[i] << " ";
-            ooccoutE((TObject*)0,Eval) <<  " - return 0   " << std::endl;
+               ooccoutE(nullptr,Eval) << fNuisParams[i].GetName() << " = " << p[i] << " ";
+            ooccoutE(nullptr,Eval) <<  " - return 0   " << std::endl;
             fError = 1.E30;
             return 0;
          }
@@ -606,12 +606,12 @@ private:
       fError = std::sqrt( dval2 / fNumIterations);
 
       // debug
-      ooccoutD((TObject*)0,NumIntegration) << "PosteriorFunctionFromToyMC:  POI value  =  "
+      ooccoutD(nullptr,NumIntegration) << "PosteriorFunctionFromToyMC:  POI value  =  "
                                            << x << "\tp(x) =  " << val << " +/- " << fError << std::endl;
 
 
       if (val != 0 && fError/val > 0.2 ) {
-         ooccoutW((TObject*)0,NumIntegration) << "PosteriorFunctionFromToyMC::DoEval"
+         ooccoutW(nullptr,NumIntegration) << "PosteriorFunctionFromToyMC::DoEval"
                                               << " - Error in estimating posterior is larger than 20% ! "
                                               << "x = " << x << " p(x) = " << val << " +/- " << fError << std::endl;
       }

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -70,7 +70,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    if( fNullModel->GetNuisanceParameters() ) {
       allButNuisance.remove(*fNullModel->GetNuisanceParameters());
       if( fConditionalMLEsNull ) {
-         oocoutI((TObject*)0,InputArguments) << "Using given conditional MLEs for Null." << endl;
+         oocoutI(nullptr,InputArguments) << "Using given conditional MLEs for Null." << endl;
          allParams->assign(*fConditionalMLEsNull);
          // LM: fConditionalMLEsNull must be nuisance parameters otherwise an error message will be printed
          allButNuisance.add( *fConditionalMLEsNull );
@@ -84,7 +84,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       doProfile = false;
    }
    if (doProfile) {
-      oocoutI((TObject*)0,InputArguments) << "Profiling conditional MLEs for Null." << endl;
+      oocoutI(nullptr,InputArguments) << "Profiling conditional MLEs for Null." << endl;
       RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
       RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
@@ -141,7 +141,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI((TObject*)0,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << endl;
 
       // variable number of toys
       if(fNToysNull >= 0) toymcs->SetNToys(fNToysNull);
@@ -151,7 +151,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
 
       // adaptive sampling
       if(fNToysNullTail) {
-         oocoutI((TObject*)0,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysRightTail(fNToysNullTail, obsTestStat);
          }else{
@@ -182,7 +182,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    if( fAltModel->GetNuisanceParameters() ) {
       allButNuisance.remove(*fAltModel->GetNuisanceParameters());
       if( fConditionalMLEsAlt ) {
-         oocoutI((TObject*)0,InputArguments) << "Using given conditional MLEs for Alt." << endl;
+         oocoutI(nullptr,InputArguments) << "Using given conditional MLEs for Alt." << endl;
          allParams->assign(*fConditionalMLEsAlt);
          // LM: fConditionalMLEsAlt must be nuisance parameters otherwise an error message will be printed
          allButNuisance.add( *fConditionalMLEsAlt );
@@ -196,7 +196,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       doProfile = false;
    }
    if (doProfile) {
-      oocoutI((TObject*)0,InputArguments) << "Profiling conditional MLEs for Alt." << endl;
+      oocoutI(nullptr,InputArguments) << "Profiling conditional MLEs for Alt." << endl;
       RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
       RooMsgService::instance().setGlobalKillBelow(RooFit::FATAL);
 
@@ -253,7 +253,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI((TObject*)0,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << endl;
 
       // variable number of toys
       if(fNToysAlt >= 0) toymcs->SetNToys(fNToysAlt);
@@ -263,7 +263,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
 
       // adaptive sampling
       if(fNToysAltTail) {
-         oocoutI((TObject*)0,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysLeftTail(fNToysAltTail, obsTestStat);
          }else{

--- a/roofit/roostats/src/HybridCalculator.cxx
+++ b/roofit/roostats/src/HybridCalculator.cxx
@@ -37,11 +37,11 @@ using namespace std;
 int HybridCalculator::CheckHook(void) const {
 
    if( fPriorNuisanceNull && (!fNullModel->GetNuisanceParameters() || fNullModel->GetNuisanceParameters()->getSize() == 0) ) {
-      oocoutE((TObject*)0,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Null ModelConfig." << endl;
+      oocoutE(nullptr,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Null ModelConfig." << endl;
       return -1; // error
    }
    if( fPriorNuisanceAlt && (!fAltModel->GetNuisanceParameters() || fAltModel->GetNuisanceParameters()->getSize() == 0) ) {
-      oocoutE((TObject*)0,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Alt ModelConfig" << endl;
+      oocoutE(nullptr,InputArguments)  << "HybridCalculator - Nuisance PDF has been specified, but is unaware of which parameters are the nuisance parameters. Must set nuisance parameters in the Alt ModelConfig" << endl;
       return -1; // error
    }
 
@@ -62,11 +62,11 @@ int HybridCalculator::PreNullHook(RooArgSet* /*parameterPoint*/, double obsTestS
       fNullModel->GetNuisanceParameters() == NULL ||
       fNullModel->GetNuisanceParameters()->getSize() == 0
    ) {
-      oocoutI((TObject*)0,InputArguments)
+      oocoutI(nullptr,InputArguments)
        << "HybridCalculator - No nuisance parameters specified for Null model and no prior forced. "
        << "Case is reduced to simple hypothesis testing with no uncertainty." << endl;
    } else {
-      oocoutI((TObject*)0,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Null model)." << endl;
+      oocoutI(nullptr,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Null model)." << endl;
    }
 
 
@@ -75,14 +75,14 @@ int HybridCalculator::PreNullHook(RooArgSet* /*parameterPoint*/, double obsTestS
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI((TObject*)0,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Null." << endl;
 
       // variable number of toys
       if(fNToysNull >= 0) toymcs->SetNToys(fNToysNull);
 
       // adaptive sampling
       if(fNToysNullTail) {
-         oocoutI((TObject*)0,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysRightTail(fNToysNullTail, obsTestStat);
          }else{
@@ -111,11 +111,11 @@ int HybridCalculator::PreAltHook(RooArgSet* /*parameterPoint*/, double obsTestSt
       fAltModel->GetNuisanceParameters()==NULL ||
       fAltModel->GetNuisanceParameters()->getSize()==0
    ) {
-      oocoutI((TObject*)0,InputArguments)
+      oocoutI(nullptr,InputArguments)
        << "HybridCalculator - No nuisance parameters specified for Alt model and no prior forced. "
        << "Case is reduced to simple hypothesis testing with no uncertainty." << endl;
    } else {
-      oocoutI((TObject*)0,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Alt model)." << endl;
+      oocoutI(nullptr,InputArguments) << "HybridCalculator - Using uniform prior on nuisance parameters (Alt model)." << endl;
    }
 
 
@@ -124,14 +124,14 @@ int HybridCalculator::PreAltHook(RooArgSet* /*parameterPoint*/, double obsTestSt
    // check whether TestStatSampler is a ToyMCSampler
    ToyMCSampler *toymcs = dynamic_cast<ToyMCSampler*>(GetTestStatSampler());
    if(toymcs) {
-      oocoutI((TObject*)0,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << endl;
+      oocoutI(nullptr,InputArguments) << "Using a ToyMCSampler. Now configuring for Alt." << endl;
 
       // variable number of toys
       if(fNToysAlt >= 0) toymcs->SetNToys(fNToysAlt);
 
       // adaptive sampling
       if(fNToysAltTail) {
-         oocoutI((TObject*)0,InputArguments) << "Adaptive Sampling" << endl;
+         oocoutI(nullptr,InputArguments) << "Adaptive Sampling" << endl;
          if(GetTestStatSampler()->GetTestStatistic()->PValueIsRightTail()) {
             toymcs->SetToysLeftTail(fNToysAltTail, obsTestStat);
          }else{

--- a/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
+++ b/roofit/roostats/src/HypoTestCalculatorGeneric.cxx
@@ -112,18 +112,18 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
 
    const RooArgSet * nullSnapshot = fNullModel->GetSnapshot();
    if(nullSnapshot == NULL) {
-      oocoutE((TObject*)0,Generation) << "Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
+      oocoutE(nullptr,Generation) << "Null model needs a snapshot. Set using modelconfig->SetSnapshot(poi)." << endl;
       return 0;
    }
 
    // CheckHook
    if(CheckHook() != 0) {
-      oocoutE((TObject*)0,Generation) << "There was an error in CheckHook(). Stop." << endl;
+      oocoutE(nullptr,Generation) << "There was an error in CheckHook(). Stop." << endl;
       return 0;
    }
 
    if (!fTestStatSampler  || !fTestStatSampler->GetTestStatistic() ) {
-      oocoutE((TObject*)0,InputArguments) << "Test Statistic Sampler or Test Statistics not defined. Stop." << endl;
+      oocoutE(nullptr,InputArguments) << "Test Statistic Sampler or Test Statistics not defined. Stop." << endl;
       return 0;
    }
 
@@ -147,7 +147,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    if( toymcs ) {
       allTS = toymcs->EvaluateAllTestStatistics(*const_cast<RooAbsData*>(fData), nullP);
       if (!allTS) return 0;
-      //oocoutP((TObject*)0,Generation) << "All Test Statistics on data: " << endl;
+      //oocoutP(nullptr,Generation) << "All Test Statistics on data: " << endl;
       //allTS->Print("v");
       RooRealVar* firstTS = (RooRealVar*)allTS->at(0);
       obsTestStat = firstTS->getVal();
@@ -158,7 +158,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    }else{
       obsTestStat = fTestStatSampler->EvaluateTestStatistic(*const_cast<RooAbsData*>(fData), nullP);
    }
-   oocoutP((TObject*)0,Generation) << "Test Statistic on data: " << obsTestStat << endl;
+   oocoutP(nullptr,Generation) << "Test Statistic on data: " << obsTestStat << endl;
 
    // set parameters back ... in case the evaluation of the test statistic
    // modified something (e.g. a nuisance parameter that is not randomized
@@ -171,7 +171,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    SetupSampler(*fNullModel);
    RooArgSet paramPointNull(*fNullModel->GetParametersOfInterest());
    if(PreNullHook(&paramPointNull, obsTestStat) != 0) {
-      oocoutE((TObject*)0,Generation) << "PreNullHook did not return 0." << endl;
+      oocoutE(nullptr,Generation) << "PreNullHook did not return 0." << endl;
    }
    SamplingDistribution* samp_null = NULL;
    RooDataSet* detOut_null = NULL;
@@ -193,7 +193,7 @@ HypoTestResult* HypoTestCalculatorGeneric::GetHypoTest() const {
    SetupSampler(*fAltModel);
    RooArgSet paramPointAlt(*fAltModel->GetParametersOfInterest());
    if(PreAltHook(&paramPointAlt, obsTestStat) != 0) {
-      oocoutE((TObject*)0,Generation) << "PreAltHook did not return 0." << endl;
+      oocoutE(nullptr,Generation) << "PreAltHook did not return 0." << endl;
    }
    SamplingDistribution* samp_alt = NULL;
    RooDataSet* detOut_alt = NULL;

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -128,10 +128,10 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
    const ModelConfig * modelSB = hc.GetNullModel();
    const ModelConfig * modelB = hc.GetAlternateModel();
    if (!modelSB || ! modelB)
-      oocoutF((TObject*)0,InputArguments) << "HypoTestInverter - model are not existing" << std::endl;
+      oocoutF(nullptr,InputArguments) << "HypoTestInverter - model are not existing" << std::endl;
    assert(modelSB && modelB);
 
-   oocoutI((TObject*)0,InputArguments) << "HypoTestInverter ---- Input models: \n"
+   oocoutI(nullptr,InputArguments) << "HypoTestInverter ---- Input models: \n"
                                        << "\t\t using as S+B (null) model     : "
                                        << modelSB->GetName() << "\n"
                                        << "\t\t using as B (alternate) model  : "
@@ -141,19 +141,19 @@ void HypoTestInverter::CheckInputModels(const HypoTestCalculatorGeneric &hc,cons
    RooAbsPdf * bPdf = modelB->GetPdf();
    const RooArgSet * bObs = modelB->GetObservables();
    if (!bPdf || !bObs) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - B model has no pdf or observables defined" <<  std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - B model has no pdf or observables defined" <<  std::endl;
       return;
    }
    RooArgSet * bParams = bPdf->getParameters(*bObs);
    if (!bParams) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - pdf of B model has no parameters" << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - pdf of B model has no parameters" << std::endl;
       return;
    }
    if (bParams->find(scanVariable.GetName() ) ) {
       const RooArgSet * poiB  = modelB->GetSnapshot();
       if (!poiB ||  !poiB->find(scanVariable.GetName()) ||
           ( (RooRealVar*)  poiB->find(scanVariable.GetName()) )->getVal() != 0 )
-         oocoutW((TObject*)0,InputArguments) << "HypoTestInverter - using a B model  with POI "
+         oocoutW(nullptr,InputArguments) << "HypoTestInverter - using a B model  with POI "
                                              <<    scanVariable.GetName()  << " not equal to zero "
                                              << " user must check input model configurations " << endl;
       if (poiB) delete poiB;
@@ -209,7 +209,7 @@ HypoTestInverter::HypoTestInverter( HypoTestCalculatorGeneric& hc,
       fScannedVariable = HypoTestInverter::GetVariableToScan(hc);
    }
    if (!fScannedVariable)
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
    else
       CheckInputModels(hc,*fScannedVariable);
 
@@ -231,7 +231,7 @@ HypoTestInverter::HypoTestInverter( HypoTestCalculatorGeneric& hc,
       fCalculator0 = asymCalc;
       return;
    }
-   oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - Type of hypotest calculator is not supported " <<std::endl;
+   oocoutE(nullptr,InputArguments) << "HypoTestInverter - Type of hypotest calculator is not supported " <<std::endl;
    fCalculator0 = &hc;
 }
 
@@ -262,7 +262,7 @@ HypoTestInverter::HypoTestInverter( HybridCalculator& hc,
       fScannedVariable = GetVariableToScan(hc);
    }
    if (!fScannedVariable)
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
    else
       CheckInputModels(hc,*fScannedVariable);
 
@@ -295,7 +295,7 @@ HypoTestInverter::HypoTestInverter( FrequentistCalculator& hc,
       fScannedVariable = GetVariableToScan(hc);
    }
    if (!fScannedVariable)
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
    else
       CheckInputModels(hc,*fScannedVariable);
 }
@@ -327,7 +327,7 @@ HypoTestInverter::HypoTestInverter( AsymptoticCalculator& hc,
       fScannedVariable = GetVariableToScan(hc);
    }
    if (!fScannedVariable)
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
    else
       CheckInputModels(hc,*fScannedVariable);
 
@@ -364,7 +364,7 @@ HypoTestInverter::HypoTestInverter( RooAbsData& data, ModelConfig &sbModel, Mode
       fScannedVariable = GetVariableToScan(*fCalculator0);
    }
    if (!fScannedVariable)
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - Cannot guess the variable to scan " << std::endl;
    else
       CheckInputModels(*fCalculator0,*fScannedVariable);
 
@@ -491,22 +491,22 @@ HypoTestInverterResult* HypoTestInverter::GetInterval() const {
 
    // if having a result with at least  one point return it
    if (fResults && fResults->ArraySize() >= 1) {
-      oocoutI((TObject*)0,Eval) << "HypoTestInverter::GetInterval - return an already existing interval " << std::endl;
+      oocoutI(nullptr,Eval) << "HypoTestInverter::GetInterval - return an already existing interval " << std::endl;
       return  (HypoTestInverterResult*)(fResults->Clone());
    }
 
    if (fNBins > 0) {
-      oocoutI((TObject*)0,Eval) << "HypoTestInverter::GetInterval - run a fixed scan" << std::endl;
+      oocoutI(nullptr,Eval) << "HypoTestInverter::GetInterval - run a fixed scan" << std::endl;
       bool ret = RunFixedScan(fNBins, fXmin, fXmax, fScanLog);
       if (!ret)
-         oocoutE((TObject*)0,Eval) << "HypoTestInverter::GetInterval - error running a fixed scan " << std::endl;
+         oocoutE(nullptr,Eval) << "HypoTestInverter::GetInterval - error running a fixed scan " << std::endl;
    }
    else {
-      oocoutI((TObject*)0,Eval) << "HypoTestInverter::GetInterval - run an automatic scan" << std::endl;
+      oocoutI(nullptr,Eval) << "HypoTestInverter::GetInterval - run an automatic scan" << std::endl;
       double limit(0),err(0);
       bool ret = RunLimit(limit,err);
       if (!ret)
-         oocoutE((TObject*)0,Eval) << "HypoTestInverter::GetInterval - error running an auto scan " << std::endl;
+         oocoutE(nullptr,Eval) << "HypoTestInverter::GetInterval - error running an auto scan " << std::endl;
    }
 
    if (fgCloseProof) ProofConfig::CloseProof();
@@ -532,7 +532,7 @@ HypoTestResult * HypoTestInverter::Eval(HypoTestCalculatorGeneric &hc, bool adap
    // run the hypothesis test
    HypoTestResult *  hcResult = hc.GetHypoTest();
    if (hcResult == 0) {
-      oocoutE((TObject*)0,Eval) << "HypoTestInverter::Eval - HypoTest failed" << std::endl;
+      oocoutE(nullptr,Eval) << "HypoTestInverter::Eval - HypoTest failed" << std::endl;
       return hcResult;
    }
 
@@ -574,7 +574,7 @@ HypoTestResult * HypoTestInverter::Eval(HypoTestCalculatorGeneric &hc, bool adap
 
    }
    if (fVerbose ) {
-      oocoutP((TObject*)0,Eval) << "P values for  " << fScannedVariable->GetName()  << " =  " <<
+      oocoutP(nullptr,Eval) << "P values for  " << fScannedVariable->GetName()  << " =  " <<
          fScannedVariable->getVal() << "\n" <<
          "\tCLs      = " << hcResult->CLs()      << " +/- " << hcResult->CLsError()      << "\n" <<
          "\tCLb      = " << hcResult->CLb()      << " +/- " << hcResult->CLbError()      << "\n" <<
@@ -611,35 +611,35 @@ bool HypoTestInverter::RunFixedScan( int nBins, double xMin, double xMax, bool s
 
    // safety checks
    if ( nBins<=0 ) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::RunFixedScan - Please provide nBins>0\n";
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter::RunFixedScan - Please provide nBins>0\n";
       return false;
    }
    if ( nBins==1 && xMin!=xMax ) {
-      oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RunFixedScan - nBins==1 -> I will run for xMin (" << xMin << ")\n";
+      oocoutW(nullptr,InputArguments) << "HypoTestInverter::RunFixedScan - nBins==1 -> I will run for xMin (" << xMin << ")\n";
    }
    if ( xMin==xMax && nBins>1 ) {
-      oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RunFixedScan - xMin==xMax -> I will enforce nBins==1\n";
+      oocoutW(nullptr,InputArguments) << "HypoTestInverter::RunFixedScan - xMin==xMax -> I will enforce nBins==1\n";
       nBins = 1;
    }
    if ( xMin>xMax ) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::RunFixedScan - Please provide xMin ("
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter::RunFixedScan - Please provide xMin ("
                                           << xMin << ") smaller than xMax (" << xMax << ")\n";
       return false;
    }
 
    if (xMin < fScannedVariable->getMin()) {
       xMin = fScannedVariable->getMin();
-      oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RunFixedScan - xMin < lower bound, using xmin = "
+      oocoutW(nullptr,InputArguments) << "HypoTestInverter::RunFixedScan - xMin < lower bound, using xmin = "
                                           << xMin << std::endl;
    }
    if (xMax > fScannedVariable->getMax()) {
       xMax = fScannedVariable->getMax();
-      oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RunFixedScan - xMax > upper bound, using xmax = "
+      oocoutW(nullptr,InputArguments) << "HypoTestInverter::RunFixedScan - xMax > upper bound, using xmax = "
                                           << xMax << std::endl;
    }
 
    if (xMin <= 0. && scanLog) {
-     oocoutE((TObject*)nullptr, InputArguments) << "HypoTestInverter::RunFixedScan - cannot go in log steps if xMin <= 0" << std::endl;
+     oocoutE(nullptr, InputArguments) << "HypoTestInverter::RunFixedScan - cannot go in log steps if xMin <= 0" << std::endl;
      return false;
    }
 
@@ -657,7 +657,7 @@ bool HypoTestInverter::RunFixedScan( int nBins, double xMin, double xMax, bool s
 
       // check if failed status
       if ( status==false ) {
-        oocoutW((TObject*)0,Eval) << "HypoTestInverter::RunFixedScan - The hypo test for point " << thisX << " failed. Skipping." << std::endl;
+        oocoutW(nullptr,Eval) << "HypoTestInverter::RunFixedScan - The hypo test for point " << thisX << " failed. Skipping." << std::endl;
       }
    }
 
@@ -674,7 +674,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
 
    // check if rVal is in the range specified for fScannedVariable
    if ( rVal < fScannedVariable->getMin() ) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::RunOnePoint - Out of range: using the lower bound "
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter::RunOnePoint - Out of range: using the lower bound "
                                           << fScannedVariable->getMin()
                                           << " on the scanned variable rather than " << rVal<< "\n";
      rVal = fScannedVariable->getMin();
@@ -682,7 +682,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    if ( rVal > fScannedVariable->getMax() ) {
       // print a message when you have a significative difference since rval is computed
       if ( rVal > fScannedVariable->getMax()*(1.+1.E-12) )
-         oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::RunOnePoint - Out of range: using the upper bound "
+         oocoutE(nullptr,InputArguments) << "HypoTestInverter::RunOnePoint - Out of range: using the upper bound "
                                              << fScannedVariable->getMax()
                                              << " on the scanned variable rather than " << rVal<< "\n";
      rVal = fScannedVariable->getMax();
@@ -702,12 +702,12 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    const_cast<ModelConfig*>(sbModel)->SetSnapshot(poi);
 
    if (fVerbose > 0)
-      oocoutP((TObject*)0,Eval) << "Running for " << fScannedVariable->GetName() << " = " << fScannedVariable->getVal() << endl;
+      oocoutP(nullptr,Eval) << "Running for " << fScannedVariable->GetName() << " = " << fScannedVariable->getVal() << endl;
 
    // compute the results
    std::unique_ptr<HypoTestResult> result( Eval(*fCalculator0,adaptive,clTarget) );
    if (!result) {
-      oocoutE((TObject*)0,Eval) << "HypoTestInverter - Error running point " << fScannedVariable->GetName() << " = " <<
+      oocoutE(nullptr,Eval) << "HypoTestInverter - Error running point " << fScannedVariable->GetName() << " = " <<
    fScannedVariable->getVal() << endl;
       return false;
    }
@@ -715,7 +715,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    const double nullPV = result->NullPValue();
    const double altPV = result->AlternatePValue();
    if (!std::isfinite(nullPV) || nullPV < 0. || nullPV > 1. || !std::isfinite(altPV) || altPV < 0. || altPV > 1.) {
-      oocoutW((TObject*)0,Eval) << "HypoTestInverter - Skipping invalid result for  point " << fScannedVariable->GetName() << " = " <<
+      oocoutW(nullptr,Eval) << "HypoTestInverter - Skipping invalid result for  point " << fScannedVariable->GetName() << " = " <<
          fScannedVariable->getVal() << ". null p-value=" << nullPV << ", alternate p-value=" << altPV << endl;
       return false;
    }
@@ -727,7 +727,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
    if ( (std::abs(rVal) < 1 && TMath::AreEqualAbs(rVal, lastXtested,1.E-12) ) ||
         (std::abs(rVal) >= 1 && TMath::AreEqualRel(rVal, lastXtested,1.E-12) ) ) {
 
-      oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunOnePoint - Merge with previous result for "
+      oocoutI(nullptr,Eval) << "HypoTestInverter::RunOnePoint - Merge with previous result for "
                                 << fScannedVariable->GetName() << " = " << rVal << std::endl;
       HypoTestResult* prevResult =  fResults->GetResult(fResults->ArraySize()-1);
       if (prevResult && prevResult->GetNullDistribution() && prevResult->GetAltDistribution()) {
@@ -735,7 +735,7 @@ bool HypoTestInverter::RunOnePoint( double rVal, bool adaptive, double clTarget)
       }
       else {
          // if it was empty we re-use it
-         oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunOnePoint - replace previous empty result\n";
+         oocoutI(nullptr,Eval) << "HypoTestInverter::RunOnePoint - replace previous empty result\n";
          auto oldObj = fResults->fYObjects.Remove(prevResult);
          delete oldObj;
 
@@ -777,7 +777,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
   if ((hint != 0) && (*hint > r->getMin())) {
      r->setMax(std::min<double>(3.0 * (*hint), r->getMax()));
      r->setMin(std::max<double>(0.3 * (*hint), r->getMin()));
-     oocoutI((TObject*)0,InputArguments) << "HypoTestInverter::RunLimit - Use hint value " << *hint
+     oocoutI(nullptr,InputArguments) << "HypoTestInverter::RunLimit - Use hint value " << *hint
                                          << " search in interval " << r->getMin() << " , " << r->getMax() << std::endl;
   }
 
@@ -800,7 +800,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
   if (fVerbose > 0) std::cout << "Search for upper limit to the limit" << std::endl;
   for (int tries = 0; tries < 6; ++tries) {
      if (! RunOnePoint(rMax) ) {
-        oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at upper limit of scan range: " << rMax << std::endl;
+        oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at upper limit of scan range: " << rMax << std::endl;
         rMax *= 0.95;
         continue;
      }
@@ -808,14 +808,14 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
      if (clsMax.first == 0 || clsMax.first + 3 * fabs(clsMax.second) < clsTarget ) break;
      rMax += rMax;
      if (tries == 5) {
-        oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Cannot determine upper limit of scan range. At " << r->GetName()
+        oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Cannot determine upper limit of scan range. At " << r->GetName()
                                   << " = " << rMax  << " still getting "
                                   << (fUseCLs ? "CLs" : "CLsplusb") << " = " << clsMax.first << std::endl;
         return false;
      }
   }
   if (fVerbose > 0) {
-     oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Search for lower limit to the limit" << std::endl;
+     oocoutI(nullptr,Eval) << "HypoTestInverter::RunLimit - Search for lower limit to the limit" << std::endl;
   }
 
   if ( fUseCLs && rMin == 0 ) {
@@ -823,7 +823,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
   }
   else {
      if (! RunOnePoint(rMin) ) {
-       oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at lower limit of scan range: " << rMin << std::endl;
+       oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at lower limit of scan range: " << rMin << std::endl;
        return false;
      }
      clsMin = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
@@ -836,7 +836,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
         rMin = -rMax / 4;
         for (int tries = 0; tries < 6; ++tries) {
            if (! RunOnePoint(rMin) ) {
-             oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at lower limit of scan range: " << rMin << std::endl;
+             oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypotest failed at lower limit of scan range: " << rMin << std::endl;
              rMin = rMin == 0. ? 0.1 : rMin * 1.1;
              continue;
            }
@@ -844,7 +844,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
            if (clsMin.first == 1 || clsMin.first - 3 * fabs(clsMin.second) > clsTarget) break;
            rMin += rMin;
            if (tries == 5) {
-              oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Cannot determine lower limit of scan range. At " << r->GetName()
+              oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Cannot determine lower limit of scan range. At " << r->GetName()
                                         << " = " << rMin << " still get " << (fUseCLs ? "CLs" : "CLsplusb")
                                         << " = " << clsMin.first << std::endl;
               return false;
@@ -854,12 +854,12 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
   }
 
   if (fVerbose > 0)
-      oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Now doing proper bracketing & bisection" << std::endl;
+      oocoutI(nullptr,Eval) << "HypoTestInverter::RunLimit - Now doing proper bracketing & bisection" << std::endl;
   do {
 
      // break loop in case max toys is reached
      if (fMaxToys > 0 && fTotalToysRun > fMaxToys ) {
-        oocoutW((TObject*)0,Eval) << "HypoTestInverter::RunLimit - maximum number of toys reached  " << std::endl;
+        oocoutW(nullptr,Eval) << "HypoTestInverter::RunLimit - maximum number of toys reached  " << std::endl;
         done = false; break;
      }
 
@@ -879,14 +879,14 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
      // exit if reached accuracy on r
      if (limitErr < std::max(absAccuracy, relAccuracy * limit)) {
         if (fVerbose > 1)
-            oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunLimit - reached accuracy " << limitErr
+            oocoutI(nullptr,Eval) << "HypoTestInverter::RunLimit - reached accuracy " << limitErr
                                       << " below " << std::max(absAccuracy, relAccuracy * limit)  << std::endl;
         done = true; break;
      }
 
      // evaluate point
      if (! RunOnePoint(limit, true, clsTarget) ) {
-       oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << limit << " when trying to find limit." << std::endl;
+       oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << limit << " when trying to find limit." << std::endl;
        return false;
      }
      clsMid = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
@@ -910,7 +910,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
        while (clsMin.second == 0 || fabs(rMin-limit) > std::max(absAccuracy, relAccuracy * limit)) {
          rMin = 0.5*(rMin+limit);
          if (!RunOnePoint(rMin,true, clsTarget) ) {
-           oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << rMin << " when trying to find limit from below." << std::endl;
+           oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << rMin << " when trying to find limit from below." << std::endl;
            return false;
          }
          clsMin = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
@@ -920,7 +920,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
        while (clsMax.second == 0 || fabs(rMax-limit) > std::max(absAccuracy, relAccuracy * limit)) {
          rMax = 0.5*(rMax+limit);
          if (!RunOnePoint(rMax,true,clsTarget) ) {
-           oocoutE((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << rMin << " when trying to find limit from above." << std::endl;
+           oocoutE(nullptr,Eval) << "HypoTestInverter::RunLimit - Hypo test failed at x=" << rMin << " when trying to find limit from above." << std::endl;
            return false;
          }
          clsMax = std::make_pair( fResults->GetLastYValue(), fResults->GetLastYError() );
@@ -934,7 +934,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
 
   if (!done) { // didn't reach accuracy with scan, now do fit
       if (fVerbose) {
-         oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Before fit   --- \n";
+         oocoutI(nullptr,Eval) << "HypoTestInverter::RunLimit - Before fit   --- \n";
          std::cout << "Limit: " << r->GetName() << " < " << limit << " +/- " << limitErr << " [" << rMin << ", " << rMax << "]\n";
       }
 
@@ -956,7 +956,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
           fLimitPlot->Sort();
           fLimitPlot->Fit(&expoFit,(fVerbose <= 1 ? "QNR EX0" : "NR EXO"));
           if (fVerbose) {
-               oocoutI((TObject*)0,Eval) << "Fit to " << npoints << " points: " << expoFit.GetParameter(2) << " +/- " << expoFit.GetParError(2) << std::endl;
+               oocoutI(nullptr,Eval) << "Fit to " << npoints << " points: " << expoFit.GetParameter(2) << " +/- " << expoFit.GetParError(2) << std::endl;
           }
           if ((rMin < expoFit.GetParameter(2))  && (expoFit.GetParameter(2) < rMax) && (expoFit.GetParError(2) < 0.5*(rMaxBound-rMinBound))) {
               // sanity check fit result
@@ -998,9 +998,9 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
       //c1->Print(plot_.c_str());
   }
 
-  oocoutI((TObject*)0,Eval) << "HypoTestInverter::RunLimit - Result:    \n"
+  oocoutI(nullptr,Eval) << "HypoTestInverter::RunLimit - Result:    \n"
                             << "\tLimit: " << r->GetName() << " < " << limit << " +/- " << limitErr << " @ " << (1-fSize) * 100 << "% CL\n";
-  if (fVerbose > 1) oocoutI((TObject*)0,Eval) << "Total toys: " << fTotalToysRun << std::endl;
+  if (fVerbose > 1) oocoutI(nullptr,Eval) << "Total toys: " << fTotalToysRun << std::endl;
 
   // set value in results
   fResults->fUpperLimit = limit;
@@ -1024,7 +1024,7 @@ bool HypoTestInverter::RunLimit(double &limit, double &limitErr, double absAccur
 SamplingDistribution * HypoTestInverter::GetLowerLimitDistribution(bool rebuild, int nToys) {
    if (!rebuild) {
       if (!fResults) {
-         oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::GetLowerLimitDistribution(false) - result not existing\n";
+         oocoutE(nullptr,InputArguments) << "HypoTestInverter::GetLowerLimitDistribution(false) - result not existing\n";
          return 0;
       }
       return fResults->GetLowerLimitDistribution();
@@ -1051,7 +1051,7 @@ SamplingDistribution * HypoTestInverter::GetLowerLimitDistribution(bool rebuild,
 SamplingDistribution * HypoTestInverter::GetUpperLimitDistribution(bool rebuild, int nToys) {
    if (!rebuild) {
       if (!fResults) {
-         oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::GetUpperLimitDistribution(false) - result not existing\n";
+         oocoutE(nullptr,InputArguments) << "HypoTestInverter::GetUpperLimitDistribution(false) - result not existing\n";
          return 0;
       }
       return fResults->GetUpperLimitDistribution();
@@ -1093,7 +1093,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
 
    const RooArgSet * poibkg = bModel->GetSnapshot();
    if (!poibkg) {
-      oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RebuildDistribution - background snapshot not existing"
+      oocoutW(nullptr,InputArguments) << "HypoTestInverter::RebuildDistribution - background snapshot not existing"
                                           << " assume is for POI = 0" << std::endl;
       fScannedVariable->setVal(0);
       paramPoint.assign(RooArgSet(*fScannedVariable));
@@ -1104,7 +1104,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
 
    ToyMCSampler * toymcSampler = dynamic_cast<ToyMCSampler *>(fCalculator0->GetTestStatSampler() );
    if (!toymcSampler) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter::RebuildDistribution - no toy MC sampler existing" << std::endl;
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter::RebuildDistribution - no toy MC sampler existing" << std::endl;
       return 0;
    }
    // set up test stat sampler in case of asymptotic calculator
@@ -1124,7 +1124,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
 
    bool storePValues = clsDist || clsbDist || clbDist;
    if (fNBins <=0  && storePValues) {
-      oocoutW((TObject*)0,InputArguments) << "HypoTestInverter::RebuildDistribution - cannot return p values distribution with the auto scan" << std::endl;
+      oocoutW(nullptr,InputArguments) << "HypoTestInverter::RebuildDistribution - cannot return p values distribution with the auto scan" << std::endl;
       storePValues = false;
       nPoints = 0;
    }
@@ -1132,7 +1132,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
    if (storePValues) {
       if (fResults) nPoints = fResults->ArraySize();
       if (nPoints <=0) {
-         oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - result is not existing and number of point to scan is not set"
+         oocoutE(nullptr,InputArguments) << "HypoTestInverter - result is not existing and number of point to scan is not set"
                                              << std::endl;
          return 0;
       }
@@ -1154,15 +1154,15 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
 
    std::vector<double> limit_values; limit_values.reserve(nToys);
 
-   oocoutI((TObject*)0,InputArguments) << "HypoTestInverter - rebuilding  the p value distributions by generating ntoys = "
+   oocoutI(nullptr,InputArguments) << "HypoTestInverter - rebuilding  the p value distributions by generating ntoys = "
                                        << nToys << std::endl;
 
 
-   oocoutI((TObject*)0,InputArguments) << "Rebuilding using parameter of interest point:  ";
-   RooStats::PrintListContent(paramPoint, oocoutI((TObject*)0,InputArguments) );
+   oocoutI(nullptr,InputArguments) << "Rebuilding using parameter of interest point:  ";
+   RooStats::PrintListContent(paramPoint, oocoutI(nullptr,InputArguments) );
    if (sbModel->GetNuisanceParameters() ) {
-      oocoutI((TObject*)0,InputArguments) << "And using nuisance parameters: ";
-      RooStats::PrintListContent(*sbModel->GetNuisanceParameters(), oocoutI((TObject*)0,InputArguments) );
+      oocoutI(nullptr,InputArguments) << "And using nuisance parameters: ";
+      RooStats::PrintListContent(*sbModel->GetNuisanceParameters(), oocoutI(nullptr,InputArguments) );
    }
    // save all parameters to restore them later
    assert(bModel->GetPdf() );
@@ -1173,7 +1173,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
 
    TFile * fileOut = TFile::Open(outputfile,"RECREATE");
    if (!fileOut) {
-      oocoutE((TObject*)0,InputArguments) << "HypoTestInverter - RebuildDistributions - Error opening file " << outputfile
+      oocoutE(nullptr,InputArguments) << "HypoTestInverter - RebuildDistributions - Error opening file " << outputfile
                                           << " - the resulting limits will not be stored" << std::endl;
    }
    // create  temporary histograms to store the limit result
@@ -1197,7 +1197,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
    // loop now on the toys
    for (int itoy = 0; itoy < nToys; ++itoy) {
 
-      oocoutP((TObject*)0,Eval) << "\nHypoTestInverter - RebuildDistributions - running toy # " << itoy << " / "
+      oocoutP(nullptr,Eval) << "\nHypoTestInverter - RebuildDistributions - running toy # " << itoy << " / "
                                        << nToys << std::endl;
 
 
@@ -1219,9 +1219,9 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       double nObs = bkgdata->sumEntries();
       // for debugging in case of number counting models
       if (bkgdata->numEntries() ==1 && !bModel->GetPdf()->canBeExtended()) {
-         oocoutP((TObject*)0,Generation) << "Generate observables are : ";
+         oocoutP(nullptr,Generation) << "Generate observables are : ";
          RooArgList  genObs(*bkgdata->get(0));
-         RooStats::PrintListContent(genObs, oocoutP((TObject*)0,Generation) );
+         RooStats::PrintListContent(genObs, oocoutP(nullptr,Generation) );
          nObs = 0;
          for (int i = 0; i < genObs.getSize(); ++i) {
             RooRealVar * x = dynamic_cast<RooRealVar*>(&genObs[i]);
@@ -1260,10 +1260,10 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       if (!storePValues) continue;
 
       if (nPoints < r->ArraySize()) {
-         oocoutW((TObject*)0,InputArguments) << "HypoTestInverter: skip extra points" << std::endl;
+         oocoutW(nullptr,InputArguments) << "HypoTestInverter: skip extra points" << std::endl;
       }
       else if (nPoints > r->ArraySize()) {
-         oocoutW((TObject*)0,InputArguments) << "HypoTestInverter: missing some points" << std::endl;
+         oocoutW(nullptr,InputArguments) << "HypoTestInverter: missing some points" << std::endl;
       }
 
 
@@ -1278,7 +1278,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
             hCLsb[ipoint]->Fill(  hr->CLsplusb() );
          }
          else {
-            oocoutW((TObject*)0,InputArguments) << "HypoTestInverter: missing result for point: x = "
+            oocoutW(nullptr,InputArguments) << "HypoTestInverter: missing result for point: x = "
                                                 << fResults->GetXValue(ipoint) <<  std::endl;
          }
       }
@@ -1302,7 +1302,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       if (clbDist) clbDist->SetOwner(true);
       if (clsbDist) clsbDist->SetOwner(true);
 
-      oocoutI((TObject*)0,InputArguments) << "HypoTestInverter: storing rebuilt p values  " << std::endl;
+      oocoutI(nullptr,InputArguments) << "HypoTestInverter: storing rebuilt p values  " << std::endl;
 
       for (int ipoint = 0; ipoint < nPoints; ++ipoint) {
          if (clsDist) {

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -237,7 +237,7 @@ int HypoTestInverterResult::ExclusionCleanup()
 
     const std::vector<double> & values = s->GetSamplingDistribution();
     if ((int) values.size() != fgAsymptoticNumPoints) {
-       oocoutE(this,Eval) << "HypoTestInverterResult::ExclusionCleanup - invalid size of sampling distribution" << std::endl;
+       coutE(Eval) << "HypoTestInverterResult::ExclusionCleanup - invalid size of sampling distribution" << std::endl;
        delete s;
        break;
     }
@@ -330,14 +330,14 @@ bool HypoTestInverterResult::Add( const HypoTestInverterResult& otherResult   )
    if (fExpPValues.GetSize() > 0 && fExpPValues.GetSize() != nThis ) return false;
    if (otherResult.fExpPValues.GetSize() > 0 && otherResult.fExpPValues.GetSize() != nOther ) return false;
 
-   oocoutI(this,Eval) << "HypoTestInverterResult::Add - merging result from " << otherResult.GetName()
+   coutI(Eval) << "HypoTestInverterResult::Add - merging result from " << otherResult.GetName()
                                 << " in " << GetName() << std::endl;
 
    bool addExpPValues = (fExpPValues.GetSize() == 0 && otherResult.fExpPValues.GetSize() > 0);
    bool mergeExpPValues = (fExpPValues.GetSize() > 0 && otherResult.fExpPValues.GetSize() > 0);
 
    if (addExpPValues || mergeExpPValues)
-      oocoutI(this,Eval) << "HypoTestInverterResult::Add - merging also the expected p-values from pseudo-data" << std::endl;
+      coutI(Eval) << "HypoTestInverterResult::Add - merging also the expected p-values from pseudo-data" << std::endl;
 
 
    // case current result is empty
@@ -371,7 +371,7 @@ bool HypoTestInverterResult::Add( const HypoTestInverterResult& otherResult   )
                   int thisNToys = (thisHTR->GetNullDistribution() ) ? thisHTR->GetNullDistribution()->GetSize() : 0;
                   int otherNToys = (otherHTR->GetNullDistribution() ) ? otherHTR->GetNullDistribution()->GetSize() : 0;
                   if (thisNToys != otherNToys )
-                     oocoutW(this,Eval) << "HypoTestInverterResult::Add expected p values have been generated with different toys " << thisNToys << " , " << otherNToys << std::endl;
+                     coutW(Eval) << "HypoTestInverterResult::Add expected p values have been generated with different toys " << thisNToys << " , " << otherNToys << std::endl;
                }
                break;
             }
@@ -390,10 +390,10 @@ bool HypoTestInverterResult::Add( const HypoTestInverterResult& otherResult   )
    }
 
    if (ArraySize() > nThis)
-      oocoutI(this,Eval) << "HypoTestInverterResult::Add  - new number of points is " << fXValues.size()
+      coutI(Eval) << "HypoTestInverterResult::Add  - new number of points is " << fXValues.size()
                          << std::endl;
    else
-      oocoutI(this,Eval) << "HypoTestInverterResult::Add  - new toys/point is "
+      coutI(Eval) << "HypoTestInverterResult::Add  - new toys/point is "
                          <<  ((HypoTestResult*) fYObjects.At(0))->GetNullDistribution()->GetSize()
                          << std::endl;
 
@@ -432,7 +432,7 @@ bool HypoTestInverterResult::Add (Double_t x, const HypoTestResult & res)
 double HypoTestInverterResult::GetXValue( int index ) const
 {
   if ( index >= ArraySize() || index<0 ) {
-    oocoutE(this,InputArguments) << "Problem: You are asking for an impossible array index value\n";
+    coutE(InputArguments) << "Problem: You are asking for an impossible array index value\n";
     return -999;
   }
 
@@ -551,7 +551,7 @@ double HypoTestInverterResult::CLsError( int index ) const
 HypoTestResult* HypoTestInverterResult::GetResult( int index ) const
 {
    if ( index >= ArraySize() || index<0 ) {
-      oocoutE(this,InputArguments) << "Problem: You are asking for an impossible array index value\n";
+      coutE(InputArguments) << "Problem: You are asking for an impossible array index value\n";
       return 0;
    }
 
@@ -723,7 +723,7 @@ double HypoTestInverterResult::FindInterpolatedLimit(double target, bool lowSear
 
    if (ArraySize()<2) {
       double val =  (lowSearch) ? xmin : xmax;
-      oocoutW(this,Eval) << "HypoTestInverterResult::FindInterpolatedLimit"
+      coutW(Eval) << "HypoTestInverterResult::FindInterpolatedLimit"
                          << " - not enough points to get the inverted interval - return "
                          <<  val << std::endl;
       fLowerLimit = varmin;
@@ -975,13 +975,13 @@ Double_t HypoTestInverterResult::CalculateEstimatedError(double target, bool low
 {
 
   if (ArraySize()==0) {
-     oocoutW(this,Eval) << "HypoTestInverterResult::CalculateEstimateError"
+     coutW(Eval) << "HypoTestInverterResult::CalculateEstimateError"
                         << "Empty result \n";
     return 0;
   }
 
   if (ArraySize()<2) {
-     oocoutW(this,Eval) << "HypoTestInverterResult::CalculateEstimateError"
+     coutW(Eval) << "HypoTestInverterResult::CalculateEstimateError"
                         << " only  points - return its error\n";
      return GetYError(0);
   }
@@ -1014,7 +1014,7 @@ Double_t HypoTestInverterResult::CalculateEstimatedError(double target, bool low
      }
   }
   if (graph.GetN() < 2) {
-     if (np >= 2) oocoutW(this,Eval) << "HypoTestInverterResult::CalculateEstimatedError - no valid points - cannot estimate  the " << type << " limit error " << std::endl;
+     if (np >= 2) coutW(Eval) << "HypoTestInverterResult::CalculateEstimatedError - no valid points - cannot estimate  the " << type << " limit error " << std::endl;
      return 0;
   }
 
@@ -1066,7 +1066,7 @@ Double_t HypoTestInverterResult::CalculateEstimatedError(double target, bool low
      }
   }
   else {
-     oocoutW(this,Eval) << "HypoTestInverterResult::CalculateEstimatedError - cannot estimate  the " << type << " limit error " << std::endl;
+     coutW(Eval) << "HypoTestInverterResult::CalculateEstimatedError - cannot estimate  the " << type << " limit error " << std::endl;
      theError = 0;
   }
   if (lower)
@@ -1182,7 +1182,7 @@ SamplingDistribution *  HypoTestInverterResult::GetExpectedPValueDist(int index)
 
 SamplingDistribution *  HypoTestInverterResult::GetLimitDistribution(bool lower ) const {
    if (ArraySize()<2) {
-      oocoutE(this,Eval) << "HypoTestInverterResult::GetLimitDistribution"
+      coutE(Eval) << "HypoTestInverterResult::GetLimitDistribution"
                          << " not  enough points -  return 0 " << std::endl;
       return 0;
    }

--- a/roofit/roostats/src/NeymanConstruction.cxx
+++ b/roofit/roostats/src/NeymanConstruction.cxx
@@ -190,7 +190,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
                      samplingDist,
                      additionalMC);
         if (!samplingDist) {
-           oocoutE((TObject*)0,Eval) << "Neyman Construction: error generating sampling distribution" << endl;
+           oocoutE(nullptr,Eval) << "Neyman Construction: error generating sampling distribution" << endl;
            return 0;
         }
    totalMC=samplingDist->GetSize();
@@ -239,7 +239,7 @@ PointSetInterval* NeymanConstruction::GetInterval() const {
       // generating the sampling dist of the test statistic.
       samplingDist = fTestStatSampler->GetSamplingDistribution(*point);
       if (!samplingDist) {
-         oocoutE((TObject*)0,Eval) << "Neyman Construction: error generating sampling distribution" << endl;
+         oocoutE(nullptr,Eval) << "Neyman Construction: error generating sampling distribution" << endl;
          return 0;
       }
 

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -147,17 +147,17 @@ RooAbsReal *  ProfileLikelihoodCalculator::DoGlobalFit() const {
    }
 
       // calculate MLE
-   oocoutP((TObject*)0,Minimization) << "ProfileLikelihoodCalcultor::DoGLobalFit - find MLE " << std::endl;
+   oocoutP(nullptr,Minimization) << "ProfileLikelihoodCalcultor::DoGLobalFit - find MLE " << std::endl;
 
    if (fFitResult) delete fFitResult;
    fFitResult = DoMinimizeNLL(nll);
 
    // print fit result
    if (fFitResult) {
-      fFitResult->printStream( oocoutI((TObject*)0,Minimization), fFitResult->defaultPrintContents(0), fFitResult->defaultPrintStyle(0) );
+      fFitResult->printStream( oocoutI(nullptr,Minimization), fFitResult->defaultPrintContents(0), fFitResult->defaultPrintStyle(0) );
 
       if (fFitResult->status() != 0)
-         oocoutW((TObject*)0,Minimization) << "ProfileLikelihoodCalcultor::DoGlobalFit -  Global fit failed - status = " << fFitResult->status() << std::endl;
+         oocoutW(nullptr,Minimization) << "ProfileLikelihoodCalcultor::DoGlobalFit -  Global fit failed - status = " << fFitResult->status() << std::endl;
       else
          fGlobalFitDone = true;
    }
@@ -174,7 +174,7 @@ RooFitResult * ProfileLikelihoodCalculator::DoMinimizeNLL(RooAbsReal * nll)  {
    int strategy = ROOT::Math::MinimizerOptions::DefaultStrategy();
    int level = ROOT::Math::MinimizerOptions::DefaultPrintLevel() -1;// RooFit level starts from  -1
    int tolerance = ROOT::Math::MinimizerOptions::DefaultTolerance();
-   oocoutP((TObject*)0,Minimization) << "ProfileLikelihoodCalcultor::DoMinimizeNLL - using " << minimType << " / " << minimAlgo << " with strategy " << strategy << std::endl;
+   oocoutP(nullptr,Minimization) << "ProfileLikelihoodCalcultor::DoMinimizeNLL - using " << minimType << " / " << minimAlgo << " with strategy " << strategy << std::endl;
    // do global fit and store fit result for further use
 
    const auto& config = GetGlobalRooStatsConfig();
@@ -362,17 +362,17 @@ HypoTestResult* ProfileLikelihoodCalculator::GetHypoTest() const {
 
    Double_t nLLatCondMLE = nLLatMLE;
    if (existVarParams) {
-      oocoutP((TObject*)0,Minimization) << "ProfileLikelihoodCalcultor::GetHypoTest - do conditional fit " << std::endl;
+      oocoutP(nullptr,Minimization) << "ProfileLikelihoodCalcultor::GetHypoTest - do conditional fit " << std::endl;
 
       RooFitResult * fit2 = DoMinimizeNLL(nll);
 
       // print fit result
       if (fit2) {
          nLLatCondMLE = fit2->minNll();
-         fit2->printStream( oocoutI((TObject*)0,Minimization), fit2->defaultPrintContents(0), fit2->defaultPrintStyle(0) );
+         fit2->printStream( oocoutI(nullptr,Minimization), fit2->defaultPrintContents(0), fit2->defaultPrintStyle(0) );
 
          if (fit2->status() != 0)
-            oocoutW((TObject*)0,Minimization) << "ProfileLikelihoodCalcultor::GetHypotest -  Conditional fit failed - status = " << fit2->status() << std::endl;
+            oocoutW(nullptr,Minimization) << "ProfileLikelihoodCalcultor::GetHypotest -  Conditional fit failed - status = " << fit2->status() << std::endl;
       }
 
    }

--- a/roofit/roostats/src/RatioOfProfiledLikelihoodsTestStat.cxx
+++ b/roofit/roostats/src/RatioOfProfiledLikelihoodsTestStat.cxx
@@ -74,7 +74,7 @@ Double_t RooStats::RatioOfProfiledLikelihoodsTestStat::ProfiledLikelihood(RooAbs
    else if (&pdf == fAltProfile.GetPdf() )
       return fAltProfile.EvaluateProfileLikelihood(type, data, poi);
 
-   oocoutE((TObject*)NULL,InputArguments) << "RatioOfProfiledLikelihoods::ProfileLikelihood - invalid pdf used for computing the profiled likelihood - return NaN"
+   oocoutE(nullptr,InputArguments) << "RatioOfProfiledLikelihoods::ProfileLikelihood - invalid pdf used for computing the profiled likelihood - return NaN"
                          << std::endl;
 
    return TMath::QuietNaN();

--- a/roofit/roostats/src/RooStatsUtils.cxx
+++ b/roofit/roostats/src/RooStatsUtils.cxx
@@ -125,7 +125,7 @@ namespace RooStats {
       // utility function to factorize constraint terms from a pdf
       // (from G. Petrucciani)
       if (!model.GetObservables() ) {
-         oocoutE((TObject*)0,InputArguments) << "RooStatsUtils::FactorizePdf - invalid input model: missing observables" << endl;
+         oocoutE(nullptr,InputArguments) << "RooStatsUtils::FactorizePdf - invalid input model: missing observables" << endl;
          return;
       }
       return FactorizePdf(*model.GetObservables(), pdf, obsTerms, constraints);
@@ -137,7 +137,7 @@ namespace RooStats {
       RooArgList obsTerms, constraints;
       FactorizePdf(observables, pdf, obsTerms, constraints);
       if(constraints.getSize() == 0) {
-         oocoutW((TObject *)0, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << endl;
+         oocoutW(nullptr, Eval) << "RooStatsUtils::MakeNuisancePdf - no constraints found on nuisance parameters in the input model" << endl;
          return 0;
       }
       return new RooProdPdf(name,"", constraints);
@@ -146,7 +146,7 @@ namespace RooStats {
    RooAbsPdf * MakeNuisancePdf(const RooStats::ModelConfig &model, const char *name) {
       // make a nuisance pdf by factorizing out all constraint terms in a common pdf
       if (!model.GetPdf() || !model.GetObservables() ) {
-         oocoutE((TObject*)0, InputArguments) << "RooStatsUtils::MakeNuisancePdf - invalid input model: missing pdf and/or observables" << endl;
+         oocoutE(nullptr, InputArguments) << "RooStatsUtils::MakeNuisancePdf - invalid input model: missing pdf and/or observables" << endl;
          return 0;
       }
       return MakeNuisancePdf(*model.GetPdf(), *model.GetObservables(), name);
@@ -216,8 +216,8 @@ namespace RooStats {
       // make a clone pdf without all constraint terms in a common pdf
       RooAbsPdf * unconstrainedPdf = StripConstraints(pdf, observables);
       if(!unconstrainedPdf) {
-         oocoutE((TObject *)NULL, InputArguments) << "RooStats::MakeUnconstrainedPdf - invalid observable list passed (observables not found in original pdf) or invalid pdf passed (without observables)" << endl;
-         return NULL;
+         oocoutE(nullptr, InputArguments) << "RooStats::MakeUnconstrainedPdf - invalid observable list passed (observables not found in original pdf) or invalid pdf passed (without observables)" << endl;
+         return nullptr;
       }
       if(name != NULL) unconstrainedPdf->SetName(name);
       return unconstrainedPdf;
@@ -226,8 +226,8 @@ namespace RooStats {
    RooAbsPdf * MakeUnconstrainedPdf(const RooStats::ModelConfig &model, const char *name) {
       // make a clone pdf without all constraint terms in a common pdf
       if(!model.GetPdf() || !model.GetObservables()) {
-         oocoutE((TObject *)NULL, InputArguments) << "RooStatsUtils::MakeUnconstrainedPdf - invalid input model: missing pdf and/or observables" << endl;
-         return NULL;
+         oocoutE(nullptr, InputArguments) << "RooStatsUtils::MakeUnconstrainedPdf - invalid input model: missing pdf and/or observables" << endl;
+         return nullptr;
       }
       return MakeUnconstrainedPdf(*model.GetPdf(), *model.GetObservables(), name);
    }

--- a/roofit/roostats/src/SamplingDistPlot.cxx
+++ b/roofit/roostats/src/SamplingDistPlot.cxx
@@ -282,7 +282,7 @@ void SamplingDistPlot::addObject(TObject *obj, Option_t *drawOptions)
 void SamplingDistPlot::addOtherObject(TObject *obj, Option_t *drawOptions)
 {
   if(0 == obj) {
-     oocoutE(this,InputArguments) << fName << "::addOtherObject: called with a null pointer" << std::endl;
+     coutE(InputArguments) << fName << "::addOtherObject: called with a null pointer" << std::endl;
      return;
   }
 
@@ -317,7 +317,7 @@ void SamplingDistPlot::Draw(Option_t * /*options */) {
    fRooPlot = xaxis.frame();
    RooPlot::setAddDirectoryStatus(dirStatus);
    if (!fRooPlot) {
-     oocoutE(this,InputArguments) << "invalid variable to plot" << std::endl;
+     coutE(InputArguments) << "invalid variable to plot" << std::endl;
      return;
    }
    fRooPlot->SetTitle("");

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -69,10 +69,10 @@ RooDataSet* ToyMCImportanceSampler::GetSamplingDistributionsSingleWorker(RooArgS
    for( int i = -1; i < (int)fImportanceDensities.size(); i++ ) {
       if( i < 0 ) {
          // generate null toys
-         oocoutP((TObject*)0,Generation) << endl << endl << "   GENERATING FROM NULL DENSITY " << endl << endl;
+         oocoutP(nullptr,Generation) << endl << endl << "   GENERATING FROM NULL DENSITY " << endl << endl;
          SetDensityToGenerateFromByIndex( 0, true ); // true = generate from null
       }else{
-         oocoutP((TObject*)0,Generation) << endl << endl << "   GENERATING IMP DENS/SNAP "<<i+1<<"  OUT OF "<<fImportanceDensities.size()<<endl<<endl;
+         oocoutP(nullptr,Generation) << endl << endl << "   GENERATING IMP DENS/SNAP "<<i+1<<"  OUT OF "<<fImportanceDensities.size()<<endl<<endl;
          SetDensityToGenerateFromByIndex( i, false ); // false = generate not from null
       }
 
@@ -90,8 +90,8 @@ RooDataSet* ToyMCImportanceSampler::GetSamplingDistributionsSingleWorker(RooArgS
          reweight.setVal( ((double)largestNToys) / fNToys );
       }
 
-      ooccoutI((TObject*)NULL,InputArguments) << "Generating " << fNToys << " toys for this density." << endl;
-      ooccoutI((TObject*)NULL,InputArguments) << "Reweight is " << reweight.getVal() << endl;
+      ooccoutI(nullptr,InputArguments) << "Generating " << fNToys << " toys for this density." << endl;
+      ooccoutI(nullptr,InputArguments) << "Reweight is " << reweight.getVal() << endl;
 
 
       RooDataSet* result = ToyMCSampler::GetSamplingDistributionsSingleWorker( paramPoint );
@@ -137,23 +137,23 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    double& weight
 ) const {
    if( fNullDensities.size() > 1 ) {
-      ooccoutI((TObject*)NULL,InputArguments) << "Null Densities:" << endl;
+      ooccoutI(nullptr,InputArguments) << "Null Densities:" << endl;
       for( unsigned int i=0; i < fNullDensities.size(); i++) {
-         ooccoutI((TObject*)NULL,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << endl;
+         ooccoutI(nullptr,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << endl;
       }
-      ooccoutE((TObject*)NULL,InputArguments) << "Cannot use multiple null densities and only ask for one weight." << endl;
+      ooccoutE(nullptr,InputArguments) << "Cannot use multiple null densities and only ask for one weight." << endl;
       return NULL;
    }
 
    if( fNullDensities.size() == 0  &&  fPdf ) {
-      ooccoutI((TObject*)NULL,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << endl;
+      ooccoutI(nullptr,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << endl;
       //AddNullDensity( fPdf, &paramPoint );
    }
 
    // do not do anything if the given parameter point if fNullSnapshots[0]
    // ... which is the most common case
    if( fNullSnapshots[0] != &paramPoint ) {
-      ooccoutD((TObject*)NULL,InputArguments) << "Using given parameter point. Replaces snapshot for the only null currently defined." << endl;
+      ooccoutD(nullptr,InputArguments) << "Using given parameter point. Replaces snapshot for the only null currently defined." << endl;
       if(fNullSnapshots[0]) delete fNullSnapshots[0];
       fNullSnapshots.clear();
       fNullSnapshots.push_back( (RooArgSet*)paramPoint.snapshot() );
@@ -181,20 +181,20 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    double& nullNLL
 ) const {
    if( fNullDensities.size() > 1 ) {
-      ooccoutI((TObject*)NULL,InputArguments) << "Null Densities:" << endl;
+      ooccoutI(nullptr,InputArguments) << "Null Densities:" << endl;
       for( unsigned int i=0; i < fNullDensities.size(); i++) {
-         ooccoutI((TObject*)NULL,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << endl;
+         ooccoutI(nullptr,InputArguments) << "  null density["<<i<<"]: " << fNullDensities[i] << " \t null snapshot["<<i<<"]: " << fNullSnapshots[i] << endl;
       }
-      ooccoutE((TObject*)NULL,InputArguments) << "Cannot use multiple null densities and only ask for one weight and NLL." << endl;
+      ooccoutE(nullptr,InputArguments) << "Cannot use multiple null densities and only ask for one weight and NLL." << endl;
       return NULL;
    }
 
    if( fNullDensities.size() == 0  &&  fPdf ) {
-      ooccoutI((TObject*)NULL,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << endl;
+      ooccoutI(nullptr,InputArguments) << "No explicit null densities specified. Going to add one based on the given paramPoint and the global fPdf. ... but cannot do that inside const function." << endl;
       //AddNullDensity( fPdf, &paramPoint );
    }
 
-   ooccoutI((TObject*)NULL,InputArguments) << "Using given parameter point. Overwrites snapshot for the only null currently defined." << endl;
+   ooccoutI(nullptr,InputArguments) << "Using given parameter point. Overwrites snapshot for the only null currently defined." << endl;
    if(fNullSnapshots[0]) delete fNullSnapshots[0];
    fNullSnapshots.clear();
    fNullSnapshots.push_back( (const RooArgSet*)paramPoint.snapshot() );
@@ -217,7 +217,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    vector<double>& weights
 ) const {
    if( fNullDensities.size() != weights.size() ) {
-      ooccoutI((TObject*)NULL,InputArguments) << "weights.size() != nullDesnities.size(). You need to provide a vector with the correct size." << endl;
+      ooccoutI(nullptr,InputArguments) << "weights.size() != nullDesnities.size(). You need to provide a vector with the correct size." << endl;
       //AddNullDensity( fPdf, &paramPoint );
    }
 
@@ -244,16 +244,16 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 ) const {
 
 
-   ooccoutD((TObject*)0,InputArguments) << endl;
-   ooccoutD((TObject*)0,InputArguments) << "GenerateToyDataImportanceSampling" << endl;
+   ooccoutD(nullptr,InputArguments) << endl;
+   ooccoutD(nullptr,InputArguments) << "GenerateToyDataImportanceSampling" << endl;
 
    if(!fObservables) {
-      ooccoutE((TObject*)NULL,InputArguments) << "Observables not set." << endl;
+      ooccoutE(nullptr,InputArguments) << "Observables not set." << endl;
       return NULL;
    }
 
    if( fNullDensities.size() == 0 ) {
-      oocoutE((TObject*)NULL,InputArguments) << "ToyMCImportanceSampler: Need to specify the null density explicitly." << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: Need to specify the null density explicitly." << endl;
       return NULL;
    }
 
@@ -266,14 +266,14 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    }
 
    if( fNullDensities.size() != fNullNLLs.size() ) {
-      oocoutE((TObject*)NULL,InputArguments) << "ToyMCImportanceSampler: Something wrong. NullNLLs must be of same size as null densities." << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: Something wrong. NullNLLs must be of same size as null densities." << endl;
       return NULL;
    }
 
    if( (!fGenerateFromNull  &&  fIndexGenDensity >= fImportanceDensities.size()) ||
        (fGenerateFromNull   &&  fIndexGenDensity >= fNullDensities.size())
    ) {
-      oocoutE((TObject*)NULL,InputArguments) << "ToyMCImportanceSampler: no importance density given or index out of range." << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: no importance density given or index out of range." << endl;
       return NULL;
    }
 
@@ -348,7 +348,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    //cout << "data generated: " << data << endl;
 
    if (!data) {
-      oocoutE((TObject*)0,InputArguments) << "ToyMCImportanceSampler: error generating data" << endl;
+      oocoutE(nullptr,InputArguments) << "ToyMCImportanceSampler: error generating data" << endl;
       return NULL;
    }
 
@@ -357,9 +357,9 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
    // Importance Sampling: adjust weight
    // Sources: Alex Read, presentation by Michael Woodroofe
 
-   ooccoutD((TObject*)0,InputArguments) << "About to create/calculate all nullNLLs." << endl;
+   ooccoutD(nullptr,InputArguments) << "About to create/calculate all nullNLLs." << endl;
    for( unsigned int i=0; i < fNullDensities.size(); i++ ) {
-      //oocoutI((TObject*)0,InputArguments) << "Setting variables to nullSnapshot["<<i<<"]"<<endl;
+      //oocoutI(nullptr,InputArguments) << "Setting variables to nullSnapshot["<<i<<"]"<<endl;
       //fNullSnapshots[i]->Print("v");
 
       allVars->assign(*fNullSnapshots[i]);
@@ -378,12 +378,12 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
 
    // for each null: find minNLLVal of null and all imp densities
-   ooccoutD((TObject*)0,InputArguments) << "About to find the minimum NLLs." << endl;
+   ooccoutD(nullptr,InputArguments) << "About to find the minimum NLLs." << endl;
    vector<double> minNLLVals;
    for( unsigned int i=0; i < nullNLLVals.size(); i++ ) minNLLVals.push_back( nullNLLVals[i] );
 
    for( unsigned int i=0; i < fImportanceDensities.size(); i++ ) {
-      //oocoutI((TObject*)0,InputArguments) << "Setting variables to impSnapshot["<<i<<"]"<<endl;
+      //oocoutI(nullptr,InputArguments) << "Setting variables to impSnapshot["<<i<<"]"<<endl;
       //fImportanceSnapshots[i]->Print("v");
 
       if( fImportanceSnapshots[i] ) {
@@ -403,13 +403,13 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
 
       for( unsigned int j=0; j < nullNLLVals.size(); j++ ) {
          if( impNLLVals[i] < minNLLVals[j] ) minNLLVals[j] = impNLLVals[i];
-         ooccoutD((TObject*)0,InputArguments) << "minNLLVals["<<j<<"]: " << minNLLVals[j] << "  nullNLLVals["<<j<<"]: " << nullNLLVals[j] << "    impNLLVals["<<i<<"]: " << impNLLVals[i] << endl;
+         ooccoutD(nullptr,InputArguments) << "minNLLVals["<<j<<"]: " << minNLLVals[j] << "  nullNLLVals["<<j<<"]: " << nullNLLVals[j] << "    impNLLVals["<<i<<"]: " << impNLLVals[i] << endl;
       }
    }
 
    // veto toys: this is a sort of "overlap removal" of the various distributions
    // if not vetoed: apply weight
-   ooccoutD((TObject*)0,InputArguments) << "About to apply vetos and calculate weights." << endl;
+   ooccoutD(nullptr,InputArguments) << "About to apply vetos and calculate weights." << endl;
    for( unsigned int j=0; j < nullNLLVals.size(); j++ ) {
       if     ( fApplyVeto  &&  fGenerateFromNull  &&  minNLLVals[j] != nullNLLVals[j] ) weights[j] = 0.0;
       else if( fApplyVeto  &&  !fGenerateFromNull  &&  minNLLVals[j] != impNLLVals[fIndexGenDensity] ) weights[j] = 0.0;
@@ -420,7 +420,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
          weights[j] *= exp(minNLLVals[j] - nullNLLVals[j]);
       }
 
-      ooccoutD((TObject*)0,InputArguments) << "weights["<<j<<"]: " << weights[j] << endl;
+      ooccoutD(nullptr,InputArguments) << "weights["<<j<<"]: " << weights[j] << endl;
    }
 
 
@@ -445,10 +445,10 @@ int ToyMCImportanceSampler::CreateImpDensitiesForOnePOIAdaptively( RooAbsPdf& pd
    // check whether error is trustworthy
    if( poi.getError() > 0.01  &&  poi.getError() < 5.0 ) {
       n = TMath::CeilNint( poi.getVal() / (2.*nStdDevOverlap*poi.getError()) ); // round up
-      oocoutI((TObject*)0,InputArguments) << "Using fitFavoredMu and error to set the number of imp points" << endl;
-      oocoutI((TObject*)0,InputArguments) << "muhat: " << poi.getVal() << "    optimize for distance: " << 2.*nStdDevOverlap*poi.getError() << endl;
-      oocoutI((TObject*)0,InputArguments) << "n = " << n << endl;
-      oocoutI((TObject*)0,InputArguments) << "This results in a distance of: " << impMaxMu / n << endl;
+      oocoutI(nullptr,InputArguments) << "Using fitFavoredMu and error to set the number of imp points" << endl;
+      oocoutI(nullptr,InputArguments) << "muhat: " << poi.getVal() << "    optimize for distance: " << 2.*nStdDevOverlap*poi.getError() << endl;
+      oocoutI(nullptr,InputArguments) << "n = " << n << endl;
+      oocoutI(nullptr,InputArguments) << "This results in a distance of: " << impMaxMu / n << endl;
    }
 
    // exclude the null, just return the number of importance snapshots
@@ -467,7 +467,7 @@ int ToyMCImportanceSampler::CreateNImpDensitiesForOnePOI( RooAbsPdf& pdf, const 
    if( impMaxMu > poiValueForBackground  &&  n > 0 ) {
       for( int i=1; i <= n; i++ ) {
          poi.setVal( poiValueForBackground + (double)i/(n)*(impMaxMu - poiValueForBackground) );
-         oocoutI((TObject*)0,InputArguments) << endl << "create point with poi: " << endl;
+         oocoutI(nullptr,InputArguments) << endl << "create point with poi: " << endl;
          poi.Print();
 
          // impSnaps without first snapshot because that is null hypothesis

--- a/roofit/roostats/src/ToyMCSampler.cxx
+++ b/roofit/roostats/src/ToyMCSampler.cxx
@@ -78,7 +78,7 @@ void NuisanceParametersSampler::NextPoint(RooArgSet& nuisPoint, Double_t& weight
 
    // check whether result will have any influence
    if(fPoints->weight() == 0.0) {
-      oocoutI((TObject*)NULL,Generation) << "Weight 0 encountered. Skipping." << endl;
+      oocoutI(nullptr,Generation) << "Weight 0 encountered. Skipping." << endl;
       NextPoint(nuisPoint, weight);
    }
 }
@@ -95,7 +95,7 @@ void NuisanceParametersSampler::Refresh() {
 
    if (fExpected) {
       // UNDER CONSTRUCTION
-      oocoutI((TObject*)NULL,InputArguments) << "Using expected nuisance parameters." << endl;
+      oocoutI(nullptr,InputArguments) << "Using expected nuisance parameters." << endl;
 
       int nBins = fNToys;
 
@@ -114,7 +114,7 @@ void NuisanceParametersSampler::Refresh() {
       ));
       if(fPoints->numEntries() != fNToys) {
          fNToys = fPoints->numEntries();
-         oocoutI((TObject*)NULL,InputArguments) <<
+         oocoutI(nullptr,InputArguments) <<
             "Adjusted number of toys to number of bins of nuisance parameters: " << fNToys << endl;
       }
 
@@ -131,7 +131,7 @@ void NuisanceParametersSampler::Refresh() {
 */
 
    }else{
-      oocoutI((TObject*)NULL,InputArguments) << "Using randomized nuisance parameters." << endl;
+      oocoutI(nullptr,InputArguments) << "Using randomized nuisance parameters." << endl;
 
       fPoints.reset(fPrior->generate(*fParams, fNToys));
    }
@@ -228,18 +228,10 @@ ToyMCSampler::~ToyMCSampler() {
 bool ToyMCSampler::CheckConfig(void) {
    bool goodConfig = true;
 
-   if(fTestStatistics.size() == 0 || fTestStatistics[0] == NULL) { ooccoutE((TObject*)NULL,InputArguments) << "Test statistic not set." << endl; goodConfig = false; }
-   if(!fObservables) { ooccoutE((TObject*)NULL,InputArguments) << "Observables not set." << endl; goodConfig = false; }
-   if(!fParametersForTestStat) { ooccoutE((TObject*)NULL,InputArguments) << "Parameter values used to evaluate the test statistic are not set." << endl; goodConfig = false; }
-   if(!fPdf) { ooccoutE((TObject*)NULL,InputArguments) << "Pdf not set." << endl; goodConfig = false; }
-
-
-   //ooccoutI((TObject*)NULL,InputArguments) << "ToyMCSampler configuration:" << endl;
-   //ooccoutI((TObject*)NULL,InputArguments) << "Pdf from SetPdf: " << fPdf << endl;
-   // for( unsigned int i=0; i < fTestStatistics.size(); i++ ) {
-   //   ooccoutI((TObject*)NULL,InputArguments) << "test statistics["<<i<<"]: " << fTestStatistics[i] << endl;
-   // }
-   //ooccoutI((TObject*)NULL,InputArguments) << endl;
+   if(fTestStatistics.size() == 0 || fTestStatistics[0] == NULL) { ooccoutE(nullptr,InputArguments) << "Test statistic not set." << endl; goodConfig = false; }
+   if(!fObservables) { ooccoutE(nullptr,InputArguments) << "Observables not set." << endl; goodConfig = false; }
+   if(!fParametersForTestStat) { ooccoutE(nullptr,InputArguments) << "Parameter values used to evaluate the test statistic are not set." << endl; goodConfig = false; }
+   if(!fPdf) { ooccoutE(nullptr,InputArguments) << "Pdf not set." << endl; goodConfig = false; }
 
    return goodConfig;
 }
@@ -287,15 +279,15 @@ const RooArgList* ToyMCSampler::EvaluateAllTestStatistics(RooAbsData& data, cons
 
 SamplingDistribution* ToyMCSampler::GetSamplingDistribution(RooArgSet& paramPointIn) {
    if(fTestStatistics.size() > 1) {
-      oocoutW((TObject*)NULL, InputArguments) << "Multiple test statistics defined, but only one distribution will be returned." << endl;
+      oocoutW(nullptr, InputArguments) << "Multiple test statistics defined, but only one distribution will be returned." << endl;
       for( unsigned int i=0; i < fTestStatistics.size(); i++ ) {
-         oocoutW((TObject*)NULL, InputArguments) << " \t test statistic: " << fTestStatistics[i] << endl;
+         oocoutW(nullptr, InputArguments) << " \t test statistic: " << fTestStatistics[i] << endl;
       }
    }
 
    RooDataSet* r = GetSamplingDistributions(paramPointIn);
    if(r == NULL || r->numEntries() == 0) {
-      oocoutW((TObject*)NULL, Generation) << "no sampling distribution generated" << endl;
+      oocoutW(nullptr, Generation) << "no sampling distribution generated" << endl;
       return NULL;
    }
 
@@ -316,7 +308,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributions(RooArgSet& paramPointIn)
 
    // ======= P A R A L L E L   R U N =======
    if (!CheckConfig()){
-      oocoutE((TObject*)NULL, InputArguments)
+      oocoutE(nullptr, InputArguments)
          << "Bad COnfiguration in ToyMCSampler "
          << endl;
       return nullptr;
@@ -325,7 +317,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributions(RooArgSet& paramPointIn)
    // turn adaptive sampling off if given
    if(fToysInTails) {
       fToysInTails = 0;
-      oocoutW((TObject*)NULL, InputArguments)
+      oocoutW(nullptr, InputArguments)
          << "Adaptive sampling in ToyMCSampler is not supported for parallel runs."
          << endl;
    }
@@ -371,7 +363,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
    ClearCache();
 
    if (!CheckConfig()){
-      oocoutE((TObject*)NULL, InputArguments)
+      oocoutE(nullptr, InputArguments)
          << "Bad COnfiguration in ToyMCSampler "
          << endl;
       return nullptr;
@@ -396,9 +388,9 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
 
       // status update
       if ( i% 500 == 0 && i>0 ) {
-         oocoutP((TObject*)0,Generation) << "generated toys: " << i << " / " << fNToys;
-         if (fToysInTails) ooccoutP((TObject*)0,Generation) << " (tails: " << toysInTails << " / " << fToysInTails << ")" << std::endl;
-         else ooccoutP((TObject*)0,Generation) << endl;
+         oocoutP(nullptr,Generation) << "generated toys: " << i << " / " << fNToys;
+         if (fToysInTails) ooccoutP(nullptr,Generation) << " (tails: " << toysInTails << " / " << fToysInTails << ")" << std::endl;
+         else ooccoutP(nullptr,Generation) << endl;
       }
 
       // TODO: change this treatment to keep track of all values so that the threshold
@@ -415,7 +407,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
         if (std::none_of(toySet->begin(), toySet->end(), [](const RooAbsArg* arg){
           return dynamic_cast<const RooAbsCategory*>(arg) != nullptr;
         }))
-          oocoutE((TObject*)nullptr, Generation) << "ToyMCSampler: Generated toy data didn't contain a category variable, although"
+          oocoutE(nullptr, Generation) << "ToyMCSampler: Generated toy data didn't contain a category variable, although"
             " a simultaneous PDF is in use. To generate events for a simultaneous PDF, all components need to be"
             " extended. Otherwise, the number of events to generate per component cannot be determined." << std::endl;
       }
@@ -432,7 +424,7 @@ RooDataSet* ToyMCSampler::GetSamplingDistributionsSingleWorker(RooArgSet& paramP
 
       // check for nan
       if(valueFirst != valueFirst) {
-         oocoutW((TObject*)NULL, Generation) << "skip: " << valueFirst << ", " << weight << endl;
+         oocoutW(nullptr, Generation) << "skip: " << valueFirst << ", " << weight << endl;
          continue;
       }
 
@@ -460,7 +452,7 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
 
 
    if(!fGlobalObservables  ||  fGlobalObservables->getSize()==0) {
-      ooccoutE((TObject*)NULL,InputArguments) << "Global Observables not set." << endl;
+      ooccoutE(nullptr,InputArguments) << "Global Observables not set." << endl;
       return;
    }
 
@@ -528,8 +520,8 @@ void ToyMCSampler::GenerateGlobalObservables(RooAbsPdf& pdf) const {
 RooAbsData* ToyMCSampler::GenerateToyData(RooArgSet& paramPoint, double& weight, RooAbsPdf& pdf) const {
 
    if(!fObservables) {
-      ooccoutE((TObject*)NULL,InputArguments) << "Observables not set." << endl;
-      return NULL;
+      ooccoutE(nullptr,InputArguments) << "Observables not set." << endl;
+      return nullptr;
    }
 
    // assign input paramPoint
@@ -541,7 +533,7 @@ RooAbsData* ToyMCSampler::GenerateToyData(RooArgSet& paramPoint, double& weight,
    if(!fNuisanceParametersSampler && fPriorNuisance && fNuisancePars) {
       fNuisanceParametersSampler = new NuisanceParametersSampler(fPriorNuisance, fNuisancePars, fNToys, fExpectedNuisancePar);
       if ((fUseMultiGen || fgAlwaysUseMultiGen) &&  fNuisanceParametersSampler )
-         oocoutI((TObject*)NULL,InputArguments) << "Cannot use multigen when nuisance parameters vary for every toy" << endl;
+         oocoutI(nullptr,InputArguments) << "Cannot use multigen when nuisance parameters vary for every toy" << endl;
    }
 
    // generate global observables
@@ -631,7 +623,7 @@ RooAbsData* ToyMCSampler::Generate(RooAbsPdf &pdf, RooArgSet &observables, const
         }
       }
     } else {
-      oocoutE((TObject*)0,InputArguments)
+      oocoutE(nullptr,InputArguments)
                 << "ToyMCSampler: Error : pdf is not extended and number of events per toy is zero"
                 << endl;
     }


### PR DESCRIPTION
This is done make the life of the developer easier when passing `nullptr` to the RooFit message logger.

After all, just `nullptr` is much less verbose than the modern C++ code that had to be used so far (`static_cast<TObject*>(nullptr)`). It also often confused new contributors why `nullptr` could not be passed directly.

All existing code was updated to not do the explicit casting to `TObject*` anymore. With this, we also avoid a lot of C-style casts in RooFit code.

More info in the commit descriptions.