### PR TITLE
[RF] Removing unused `RooMinimizerFcn` class rule

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -349,7 +349,6 @@
 #pragma link C++ class std::pair<int,RooLinkedListElem*>+ ;
 #pragma link C++ class RooUnitTest+ ;
 #pragma link C++ class RooMinimizer+ ;
-#pragma link C++ class RooMinimizerFcn+ ;
 #pragma link C++ class RooFit::TestStatistics::RooRealL+ ;
 #pragma link C++ class RooAbsMoment+ ;
 #pragma link C++ class RooMoment+ ;


### PR DESCRIPTION
This is a followup to abdf727ae05, removing a classrule that is unused
since that commit.

