### PR TITLE
[RF] Avoid using `_normSet` member in RooAddPdf

### DIFF
--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -127,7 +127,10 @@ protected:
                                const RooArgSet* auxProto=0, bool verbose= false) const override;
 
 
-  Double_t evaluate() const override;
+  Double_t evaluate() const override {
+      return getValV(nullptr);
+  }
+  double getValV(const RooArgSet* set=nullptr) const override ;
   void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooBatchCompute::DataMap&) const override;
   inline bool canComputeBatchWithCuda() const override { return true; }
 
@@ -152,7 +155,7 @@ protected:
   }
 
 private:
-  std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* defaultNorm = nullptr) const;
+  std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* nset) const;
   mutable RooFit::UniqueId<RooArgSet>::Value_t _idOfLastUsedNormSet = RooFit::UniqueId<RooArgSet>::nullval; ///<!
   mutable std::unique_ptr<const RooArgSet> _copyOfLastNormSet = nullptr; ///<!
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -701,8 +701,7 @@ void RooAddPdf::updateCoefficients(CacheElem& cache, const RooArgSet* nset) cons
 /// Look up projection cache and per-PDF norm sets. If a PDF doesn't have a special
 /// norm set, use the `defaultNorm`. If `defaultNorm == nullptr`, use the member
 /// _normSet.
-std::pair<const RooArgSet*, RooAddPdf::CacheElem*> RooAddPdf::getNormAndCache(const RooArgSet* defaultNorm) const {
-  const RooArgSet* nset = defaultNorm ? defaultNorm : _normSet;
+std::pair<const RooArgSet*, RooAddPdf::CacheElem*> RooAddPdf::getNormAndCache(const RooArgSet* nset) const {
 
   // Treat empty normalization set and nullptr the same way.
   if(nset && nset->empty()) nset = nullptr;
@@ -757,9 +756,9 @@ std::pair<const RooArgSet*, RooAddPdf::CacheElem*> RooAddPdf::getNormAndCache(co
 ////////////////////////////////////////////////////////////////////////////////
 /// Calculate and return the current value
 
-Double_t RooAddPdf::evaluate() const
+double RooAddPdf::getValV(const RooArgSet* normSet) const
 {
-  auto normAndCache = getNormAndCache();
+  auto normAndCache = getNormAndCache(normSet);
   const RooArgSet* nset = normAndCache.first;
   CacheElem* cache = normAndCache.second;
 
@@ -789,7 +788,7 @@ void RooAddPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvent
 {
   RooBatchCompute::VarVector pdfs;
   RooBatchCompute::ArgVector coefs;
-  CacheElem* cache = getNormAndCache().second;
+  CacheElem* cache = getNormAndCache(nullptr).second;
   for (unsigned int pdfNo = 0; pdfNo < _pdfList.size(); ++pdfNo)
   {
     auto pdf = static_cast<RooAbsPdf*>(&_pdfList[pdfNo]);


### PR DESCRIPTION
The `RooAbsPdf::_normSet` member should be not used, because it can
happen in many situations that the RooArgSet it points to gets out of
scope and then you get a crash. There were several cases reported on the
forum where this happened with a RooAddPdf recently, becaues with ROOT
6.26 some logic of the RooAddPdf got changed to better deal with empty
normalization sets.

This commit avoids using `_normSet` by overriding `getValV` in RooAddPdf
directly, instead of `evaluate()`. This way, it has access to the actual
normalization set that is passed to the call to `getVal()`.

For the batch mode, we now pass `nullptr` to
`RooAddPdf::getNormAndCache()` instead of `_normSet`. In this case it
falls back to using `_copyOfLastNormSet`, which is guaranteed to still
be valid because it's a unique_ptr owned by the RooAddPdf itself.

Needs to be backported to ROOT 6.26.