### PR TITLE
[RF] Add class rules for `RooCollectionProxy` for forward compatibility

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -136,6 +136,7 @@
 #pragma link C++ class RooLinTransBinning+ ;
 #pragma link C++ class RooList+ ;
 #pragma link C++ class RooListProxy+ ;
+#pragma read sourceClass="RooCollectionProxy<RooArgList>" targetClass="RooListProxy" ;
 #pragma link C++ class RooMappedCategory+ ;
 #pragma read sourceClass="RooMappedCategory" targetClass="RooMappedCategory" version="[1]" include="RooFitLegacy/RooCatTypeLegacy.h" source="RooCatType* _defCat" target="_defCat" code="{ _defCat = onfile._defCat->getVal(); }"
 #pragma link C++ class RooMappedCategory::Entry+;
@@ -211,6 +212,7 @@
 #pragma link C++ class RooSegmentedIntegrator2D+ ;
 #pragma link C++ class RooSetPair+ ;
 #pragma link C++ class RooSetProxy+ ;
+#pragma read sourceClass="RooCollectionProxy<RooArgSet>" targetClass="RooSetProxy" ;
 #pragma link C++ class RooSharedProperties+ ;
 #pragma link C++ class RooSimGenContext+ ;
 #pragma link C++ class RooSimSplitGenContext+ ;


### PR DESCRIPTION
In ROOT 6.28, some proxy classes were replaced:

`RooSetProxy` -> `RooCollectionProxy<RooArgSet>`
`RooListProxy` -> `RooCollectionProxy<RooListProxy>`

This breaks reading workspaces created with 6.28 by 6.26.

Even though we generally don't guarantee forward compatibility, the
problem can be fixed easily in this case by adding a class rule to treat
the new class names as aliases for the old ones.