### PR TITLE
[RF] Correctly implement additional dataset feature in HistFactory

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Channel.h
@@ -78,7 +78,7 @@ public:
   const std::vector< RooStats::HistFactory::Sample >& GetSamples() const { return fSamples; }
 
   void Print(std::ostream& = std::cout);
-  void PrintXML( std::string Directory, std::string Prefix="" );
+  void PrintXML( std::string const& directory, std::string const& prefix="" ) const;
 
   void CollectHistograms();
   bool CheckHistograms() const;

--- a/roofit/histfactory/inc/RooStats/HistFactory/Data.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Data.h
@@ -26,24 +26,24 @@ class Data {
 public:
   //friend class Channel;
 
-  Data();
+  Data() {}
   /// constructor from name, file and path. Name of the histogram should not include the path
   Data( std::string HistoName, std::string InputFile, std::string HistoPath="" );
 
-  std::string GetName() const { return fName; }
+  std::string const& GetName() const { return fName; }
   void SetName(const std::string& name) { fName=name; }
 
   void SetInputFile(const std::string& InputFile) { fInputFile = InputFile; }
-  std::string GetInputFile() const { return fInputFile; }
+  std::string const& GetInputFile() const { return fInputFile; }
 
   void SetHistoName(const std::string& HistoName) { fHistoName = HistoName; }
-  std::string GetHistoName() const { return fHistoName; }
+  std::string const& GetHistoName() const { return fHistoName; }
 
   void SetHistoPath(const std::string& HistoPath) { fHistoPath = HistoPath; }
-  std::string GetHistoPath() const { return fHistoPath; }
+  std::string const& GetHistoPath() const { return fHistoPath; }
 
   void Print(std::ostream& = std::cout);
-  void PrintXML( std::ostream& );
+  void PrintXML( std::ostream& ) const;
   void writeToFile( std::string FileName, std::string DirName );
 
   TH1* GetHisto();

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -98,8 +98,8 @@ namespace RooStats{
 
       RooDataSet* MergeDataSets(RooWorkspace* combined,
             std::vector<std::unique_ptr<RooWorkspace>>& wspace_vec,
-            std::vector<std::string> channel_names,
-            std::string dataSetName,
+            std::vector<std::string> const& channel_names,
+            std::string const& dataSetName,
             RooArgList obsList,
             RooCategory* channelCat);
 
@@ -116,8 +116,8 @@ namespace RooStats{
                    ParamHistFunc& paramHist, const TH1* uncertHist,
                    Constraint::Type type, double minSigma );
 
-      void ConfigureHistFactoryDataset(RooDataSet* obsData, TH1* nominal, RooWorkspace* proto,
-                   std::vector<std::string> obsNameVec);
+      void ConfigureHistFactoryDataset(RooDataSet& obsData, TH1 const& nominal, RooWorkspace& proto,
+                   std::vector<std::string> const& obsNameVec);
 
       std::vector<std::string> fSystToFix;
       std::map<std::string, double> fParamValues;

--- a/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/Sample.h
@@ -38,7 +38,7 @@ public:
   ~Sample();
 
   void Print(std::ostream& = std::cout) const;
-  void PrintXML( std::ofstream& xml );
+  void PrintXML( std::ofstream& xml ) const;
   void writeToFile( std::string FileName, std::string DirName );
 
   const TH1* GetHisto() const;

--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -134,6 +134,9 @@ void RooStats::HistFactory::Channel::PrintXML( std::string const& directory, std
   xml << "  <Channel Name=\"" << fName << "\" InputFile=\"" << fInputFile << "\" >" << std::endl << std::endl;
 
   fData.PrintXML( xml );
+  for(auto const& data : fAdditionalData) {
+    data.PrintXML(xml);
+  }
 
   fStatErrorConfig.PrintXML( xml );
   /*

--- a/roofit/histfactory/src/Channel.cxx
+++ b/roofit/histfactory/src/Channel.cxx
@@ -102,13 +102,13 @@ void RooStats::HistFactory::Channel::Print( std::ostream& stream ) {
 }
 
 
-void RooStats::HistFactory::Channel::PrintXML( std::string directory, std::string prefix ) {
+void RooStats::HistFactory::Channel::PrintXML( std::string const& directory, std::string const& prefix ) const {
 
   // Create an XML file for this channel
   cxcoutPHF << "Printing XML Files for channel: " << GetName() << std::endl;
 
   std::string XMLName = prefix + fName + ".xml";
-  if( directory != "" ) XMLName = directory + "/" + XMLName;
+  if(!directory.empty()) XMLName = directory + "/" + XMLName;
 
   ofstream xml( XMLName.c_str() );
 
@@ -134,12 +134,6 @@ void RooStats::HistFactory::Channel::PrintXML( std::string directory, std::strin
   xml << "  <Channel Name=\"" << fName << "\" InputFile=\"" << fInputFile << "\" >" << std::endl << std::endl;
 
   fData.PrintXML( xml );
-  /*
-  xml << "    <Data HistoName=\"" << fData.GetHistoName() << "\" "
-      << "InputFile=\"" << fData.GetInputFile() << "\" "
-      << "HistoPath=\"" << fData.GetHistoPath() << "\" "
-      << " /> " << std::endl << std::endl;
-  */
 
   fStatErrorConfig.PrintXML( xml );
   /*
@@ -148,8 +142,8 @@ void RooStats::HistFactory::Channel::PrintXML( std::string directory, std::strin
       << "/> " << std::endl << std::endl;
   */
 
-  for( unsigned int i = 0; i < fSamples.size(); ++i ) {
-    fSamples.at(i).PrintXML( xml );
+  for(auto const& sample : fSamples) {
+    sample.PrintXML( xml );
     xml << std::endl << std::endl;
   }
 
@@ -233,8 +227,7 @@ void RooStats::HistFactory::Channel::CollectHistograms() {
   }
 
   // Collect any histograms for additional Datasets
-  for( unsigned int i=0; i < fAdditionalData.size(); ++i) {
-    RooStats::HistFactory::Data& data = fAdditionalData.at(i);
+  for(auto& data : fAdditionalData) {
     if( data.GetInputFile() != "" ) {
       data.SetHisto( GetHistogram(data.GetInputFile(), data.GetHistoPath(), data.GetHistoName(), fileHandles) );
     }

--- a/roofit/histfactory/src/Data.cxx
+++ b/roofit/histfactory/src/Data.cxx
@@ -17,10 +17,6 @@
 #include "RooStats/HistFactory/Data.h"
 
 
-RooStats::HistFactory::Data::Data() : fName("") {
-  ;
-}
-
 RooStats::HistFactory::Data::Data( std::string HistoName, std::string InputFile,
                std::string HistoPath ) :
   fInputFile( InputFile ), fHistoName( HistoName ), fHistoPath( HistoPath ) {;}
@@ -65,7 +61,7 @@ void RooStats::HistFactory::Data::writeToFile( std::string OutputFileName, std::
 }
 
 
-void RooStats::HistFactory::Data::PrintXML( std::ostream& xml ) {
+void RooStats::HistFactory::Data::PrintXML( std::ostream& xml ) const {
 
   xml << "    <Data HistoName=\"" << GetHistoName() << "\" "
       << "InputFile=\"" << GetInputFile() << "\" "

--- a/roofit/histfactory/src/Data.cxx
+++ b/roofit/histfactory/src/Data.cxx
@@ -65,7 +65,10 @@ void RooStats::HistFactory::Data::PrintXML( std::ostream& xml ) const {
 
   xml << "    <Data HistoName=\"" << GetHistoName() << "\" "
       << "InputFile=\"" << GetInputFile() << "\" "
-      << "HistoPath=\"" << GetHistoPath() << "\" "
-      << " /> " << std::endl << std::endl;
+      << "HistoPath=\"" << GetHistoPath() << "\" ";
+  if(!GetName().empty()) {
+     xml << "Name=\"" << GetName() << "\" ";
+  }
+  xml << " /> " << std::endl << std::endl;
 
 }

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -155,22 +155,6 @@ namespace HistFactory{
     // Name of an 'edited' model, if necessary
     std::string NewModelName = "newSimPdf"; // <- This name is hard-coded in HistoToWorkspaceFactoryFast::EditSyt.  Probably should be changed to : std::string("new") + ModelName;
 
-#ifdef DO_EDIT_WS
-    // Activate Additional Constraint Terms
-    if(    measurement.GetGammaSyst().size() > 0
-   || measurement.GetUniformSyst().size() > 0
-   || measurement.GetLogNormSyst().size() > 0
-   || measurement.GetNoSyst().size() > 0) {
-      HistoToWorkspaceFactoryFast::EditSyst( ws_single, (ModelName).c_str(),
-                    measurement.GetGammaSyst(),
-                    measurement.GetUniformSyst(),
-                    measurement.GetLogNormSyst(),
-                    measurement.GetNoSyst());
-
-      proto_config->SetPdf( *ws_single->pdf( "newSimPdf" ) );
-    }
-#endif
-
     // Set the ModelConfig's Params of Interest
     RooAbsData* expData = ws_single->data("asimovData");
     if( !expData ) {
@@ -1752,8 +1736,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       auto obsDataUnbinned = make_unique<RooDataSet>("obsData","",*proto->set("obsAndWeight"),weightName);
 
 
-      ConfigureHistFactoryDataset( obsDataUnbinned.get(), mnominal,
-          proto, fObsNameVec );
+      ConfigureHistFactoryDataset( *obsDataUnbinned, *mnominal,
+          *proto, fObsNameVec );
 
       proto->import(*obsDataUnbinned);
     } // End: Has non-null 'data' entry
@@ -1774,8 +1758,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       auto obsDataUnbinned = make_unique<RooDataSet>(dataName.c_str(), dataName.c_str(),
           *proto->set("obsAndWeight"), weightName);
 
-      ConfigureHistFactoryDataset( obsDataUnbinned.get(), mnominal,
-          proto, fObsNameVec );
+      ConfigureHistFactoryDataset( *obsDataUnbinned, *mnominal,
+          *proto, fObsNameVec );
 
       proto->import(*obsDataUnbinned);
 
@@ -1788,50 +1772,48 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
   }
 
 
-  void HistoToWorkspaceFactoryFast::ConfigureHistFactoryDataset( RooDataSet* obsDataUnbinned,
-                         TH1* mnominal,
-                         RooWorkspace* proto,
-                         std::vector<std::string> ObsNameVec) {
+  void HistoToWorkspaceFactoryFast::ConfigureHistFactoryDataset( RooDataSet& obsDataUnbinned,
+                         TH1 const& mnominal,
+                         RooWorkspace& proto,
+                         std::vector<std::string> const& obsNameVec) {
 
     // Take a RooDataSet and fill it with the entries
     // from a TH1*, using the observable names to
     // determine the columns
 
-     if (ObsNameVec.empty() ) {
+     if (obsNameVec.empty() ) {
         Error("ConfigureHistFactoryDataset","Invalid input - return");
         return;
      }
 
-    //ES// TH1* mnominal = summary.at(0).nominal;
-    // TH1* mnominal = data.GetHisto();
-    TAxis* ax = mnominal->GetXaxis();
-    TAxis* ay = mnominal->GetYaxis();
-    TAxis* az = mnominal->GetZaxis();
+    TAxis const* ax = mnominal.GetXaxis();
+    TAxis const* ay = mnominal.GetYaxis();
+    TAxis const* az = mnominal.GetZaxis();
 
     for (int i=1; i<=ax->GetNbins(); ++i) { // 1 or more dimension
 
       double xval = ax->GetBinCenter(i);
-      proto->var( ObsNameVec[0] )->setVal( xval );
+      proto.var( obsNameVec[0] )->setVal( xval );
 
-      if(ObsNameVec.size()==1) {
-   double fval = mnominal->GetBinContent(i);
-   obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
+      if(obsNameVec.size()==1) {
+   double fval = mnominal.GetBinContent(i);
+   obsDataUnbinned.add( *proto.set("obsAndWeight"), fval );
       } else { // 2 or more dimensions
 
    for(int j=1; j<=ay->GetNbins(); ++j) {
      double yval = ay->GetBinCenter(j);
-     proto->var( ObsNameVec[1] )->setVal( yval );
+     proto.var( obsNameVec[1] )->setVal( yval );
 
-     if(ObsNameVec.size()==2) {
-       double fval = mnominal->GetBinContent(i,j);
-       obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
+     if(obsNameVec.size()==2) {
+       double fval = mnominal.GetBinContent(i,j);
+       obsDataUnbinned.add( *proto.set("obsAndWeight"), fval );
      } else { // 3 dimensions
 
        for(int k=1; k<=az->GetNbins(); ++k) {
          double zval = az->GetBinCenter(k);
-         proto->var( ObsNameVec[2] )->setVal( zval );
-         double fval = mnominal->GetBinContent(i,j,k);
-         obsDataUnbinned->add( *proto->set("obsAndWeight"), fval );
+         proto.var( obsNameVec[2] )->setVal( zval );
+         double fval = mnominal.GetBinContent(i,j,k);
+         obsDataUnbinned.add( *proto.set("obsAndWeight"), fval );
        }
      }
    }
@@ -1946,23 +1928,7 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     combined->factory("weightVar[0,-1e10,1e10]");
     obsList.add(*combined->var("weightVar"));
 
-    // Loop over channels and create the asimov
-    /*
-    for(unsigned int i = 0; i< ch_names.size(); ++i){
-      cout << "merging data for channel " << ch_names[i].c_str() << endl;
-      RooDataSet * tempData=new RooDataSet(ch_names[i].c_str(),"", obsList, Index(*channelCat),
-                  WeightVar("weightVar"),
-                 Import(ch_names[i].c_str(),*(RooDataSet*)chs[i]->data("asimovData")));
-      if(simData){
-   simData->append(*tempData);
-      delete tempData;
-      }else{
-   simData = tempData;
-      }
-    }
-
-    if (simData) combined->import(*simData,Rename("asimovData"));
-    */
+    // Create Asimov data for the combined dataset
     RooDataSet* asimov_combined = (RooDataSet*) AsymptoticCalculator::GenerateAsimovData(*simPdf,
                                   obsList);
     if( asimov_combined ) {
@@ -1979,50 +1945,6 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
       MergeDataSets(combined, chs, ch_names, "obsData", obsList, channelCat);
     }
 
-    /*
-    if(chs[0]->data("obsData") != NULL){
-      RooDataSet * simData=NULL;
-      //simData=NULL;
-
-      // Loop through channels, get their individual datasets,
-      // and add them to the combined dataset
-      for(unsigned int i = 0; i< ch_names.size(); ++i){
-   cout << "merging data for channel " << ch_names[i].c_str() << endl;
-
-   RooDataSet* obsDataInChannel = (RooDataSet*) chs[i]->data("obsData");
-   RooDataSet * tempData = new RooDataSet(ch_names[i].c_str(),"", obsList, Index(*channelCat),
-                      WeightVar("weightVar"),
-                      Import(ch_names[i].c_str(),*obsDataInChannel));
-   // *(RooDataSet*) chs[i]->data("obsData")));
-   if(simData) {
-     simData->append(*tempData);
-     delete tempData;
-   }
-   else {
-     simData = tempData;
-   }
-      } // End Loop Over Channels
-
-      // Check that we successfully created the dataset
-      // and import it into the workspace
-      if(simData) {
-   combined->import(*simData, Rename("obsData"));
-      }
-      else {
-   std::cout << "Error: Unable to merge observable datasets" << std::endl;
-   throw hf_exc();
-      }
-
-    } // End 'if' on data != NULL
-    */
-
-    // Now, create any additional Asimov datasets that
-    // are configured in the measurement
-
-
-    //    obsList.Print();
-    //    combined->import(obsList);
-    //    combined->Print();
 
     obsList.add(*channelCat);
     combined->defineSet("observables",obsList);
@@ -2086,8 +2008,8 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
   RooDataSet* HistoToWorkspaceFactoryFast::MergeDataSets(RooWorkspace* combined,
                       std::vector<std::unique_ptr<RooWorkspace>>& wspace_vec,
-                      std::vector<std::string> channel_names,
-                      std::string dataSetName,
+                      std::vector<std::string> const& channel_names,
+                      std::string const& dataSetName,
                       RooArgList obsList,
                       RooCategory* channelCat) {
 

--- a/roofit/histfactory/src/Sample.cxx
+++ b/roofit/histfactory/src/Sample.cxx
@@ -201,7 +201,7 @@ void RooStats::HistFactory::Sample::Print( std::ostream& stream ) const {
 
 }
 
-void RooStats::HistFactory::Sample::PrintXML( std::ofstream& xml ) {
+void RooStats::HistFactory::Sample::PrintXML( std::ofstream& xml ) const {
 
 
   // Create the sample tag


### PR DESCRIPTION
In HistFactory, the presence of a `Channel::GetAdditionalDatas` function
hinted to the possibility of defining additional datases for a
HistFactory model, besides the nominal observations dataset named
`"obsData"`.

When reading a user-generated HistFactory XML, the additional datasets
were in fact read into the `Channel::fAdditionalData` member, and
corresponding RooDataSets were created in the per-channel proto
workspaces.

However, when defining the Measurement object in C++ and dumping the XML
via `PrintXML`, the additional datasets were not considered. They were
also not considered when merging the datasets in the per-channel proto
workspaces into the simultaneous dataset. This commit suggests to
implement this correctly.

Now, one can define additional datasets as follows in the XML:
```xml
<Data HistoName="data" InputFile="data/example.root" HistoPath="" Name="addData"/>
```
If there is no `Name` tag, the RooDataSet in the workspace will use the
`HistoName` as its name.

In the touched code, some cleaning of commented out code and general code modernization is also suggested.

Closes #10538.
