### PR TITLE
Refactor dependency between head node and its backend

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Dask/Backend.py
@@ -153,5 +153,5 @@ class DaskBackend(Base.BaseBackend):
         #    `optimize_npartitions` function
         # 3. Set `npartitions` to 2
         npartitions = kwargs.pop("npartitions", self.optimize_npartitions())
-        headnode = HeadNode.get_headnode(npartitions, *args)
-        return DataFrame.RDataFrame(headnode, self)
+        headnode = HeadNode.get_headnode(self, npartitions, *args)
+        return DataFrame.RDataFrame(headnode)

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Spark/Backend.py
@@ -159,5 +159,5 @@ class SparkBackend(Base.BaseBackend):
         #    `optimize_npartitions` function
         # 3. Set `npartitions` to 2
         npartitions = kwargs.pop("npartitions", self.optimize_npartitions())
-        headnode = HeadNode.get_headnode(npartitions, *args)
-        return DataFrame.RDataFrame(headnode, self)
+        headnode = HeadNode.get_headnode(self, npartitions, *args)
+        return DataFrame.RDataFrame(headnode)

--- a/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
+++ b/bindings/experimental/distrdf/python/DistRDF/DataFrame.py
@@ -23,12 +23,10 @@ class RDataFrame(object):
     Interface to an RDataFrame that can run its computation graph distributedly.
     """
 
-    def __init__(self, headnode, backend):
+    def __init__(self, headnode):
         """Initialization of """
 
         self._headnode = headnode
-
-        self._headnode.backend = backend
 
         self._headproxy = Proxy.TransformationProxy(self._headnode)
 

--- a/bindings/experimental/distrdf/python/DistRDF/Proxy.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Proxy.py
@@ -18,7 +18,6 @@ from typing import Any, List, Optional, Union
 import ROOT
 
 from DistRDF import Operation
-from DistRDF.ComputationGraphGenerator import ComputationGraphGenerator
 from DistRDF.Node import Node
 
 logger = logging.getLogger(__name__)
@@ -51,10 +50,9 @@ def execute_graph(node: Node) -> None:
         # Creating a ROOT.TDirectory.TContext in a context manager so that
         # ROOT.gDirectory won't be changed by the event loop execution.
         with _managed_tcontext():
-            headnode = node.get_head()
-            graph_dict = headnode.generate_graph_dict()  # also takes care of pruning the graph
-            generator = ComputationGraphGenerator(headnode, graph_dict)
-            headnode.backend.execute(generator)
+            # All the information needed to reconstruct the computation graph on
+            # the workers is contained in the head node
+            node.get_head().execute_graph()
 
 
 def _create_new_node(parent: Node, operation: Operation.Operation) -> Node:
@@ -70,6 +68,7 @@ def _create_new_node(parent: Node, operation: Operation.Operation) -> Node:
     headnode.graph_nodes.appendleft(newnode)
 
     return newnode
+
 
 class Proxy(ABC):
     """

--- a/bindings/experimental/distrdf/python/DistRDF/Ranges.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Ranges.py
@@ -10,7 +10,15 @@ import ROOT
 logger = logging.getLogger(__name__)
 
 
-class EmptySourceRange(object):
+class DataRange:
+    """
+    A logical range of entries in which a dataset is split. Depending on the
+    input data source, this can have different attributes.
+    """
+    pass
+
+
+class EmptySourceRange(DataRange):
     """
     Empty source range of entries
 
@@ -80,7 +88,7 @@ def get_balanced_ranges(nentries, npartitions):
 
 
 @dataclass
-class TreeRange:
+class TreeRange(DataRange):
     """
     Range of entries in one of the trees in the chain of a single distributed task.
 
@@ -127,7 +135,7 @@ class TreeRange:
 
 
 @dataclass
-class TreeRangePerc:
+class TreeRangePerc(DataRange):
     """
     Range of percentages to be considered for a list of trees. Building block
     for an actual range of entries of a distributed task.

--- a/bindings/experimental/distrdf/test/backend/test_dist.py
+++ b/bindings/experimental/distrdf/test/backend/test_dist.py
@@ -37,7 +37,7 @@ class DistRDataFrameInvariants(unittest.TestCase):
     """
 
     class TestBackend(Base.BaseBackend):
-        """Dummy backend to test the build_ranges method in Dist class."""
+        """Dummy backend to test the _build_ranges method in Dist class."""
 
         def ProcessAndMerge(self, ranges, mapper, reducer):
             """
@@ -74,7 +74,7 @@ class DistRDataFrameInvariants(unittest.TestCase):
         filenames = ["1cluster_20entries.root"] * 5
 
         for npartitions in range(1, 6):
-            headnode = HeadNode.get_headnode(npartitions, treename, filenames)
             backend = DistRDataFrameInvariants.TestBackend()
-            rdf = DataFrame.RDataFrame(headnode, backend)
+            headnode = HeadNode.get_headnode(backend, npartitions, treename, filenames)
+            rdf = DataFrame.RDataFrame(headnode)
             self.assertEqual(rdf.Count().GetValue(), 100)

--- a/bindings/experimental/distrdf/test/test_callable_generator.py
+++ b/bindings/experimental/distrdf/test/test_callable_generator.py
@@ -8,7 +8,7 @@ def create_dummy_headnode(*args):
     """Create dummy head node instance needed in the test"""
     # Pass None as `npartitions`. The tests will modify this member
     # according to needs
-    return HeadNode.get_headnode(None, *args)
+    return HeadNode.get_headnode(None, None, *args)
 
 
 class ComputationGraphGeneratorTest(unittest.TestCase):
@@ -76,10 +76,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         n6 = node.Filter()  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         # Required order in the list of returned values (the nodes are stored
         # in DFS order the first time they are appended to the graph)
@@ -121,10 +121,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         # because it holds a reference to the ID of the father.
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         reqd_order = [1, 2, 2, 3, 2, 2]
 
@@ -159,10 +159,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         n5 = n1.Count()  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         reqd_order = [1, 2, 2, 3, 2, 3]
 
@@ -196,10 +196,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         n4 = n3 = n2 = None  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         reqd_order = [1, 2, 2]
 
@@ -233,10 +233,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         n2 = None
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         reqd_order = [1, 2, 2, 3, 2, 2]
         # Removing references from n2 will not prune any node
@@ -274,10 +274,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         n6.proxied_node.value = 1
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         # The node 'n6' will be pruned. Hence,
         # there's only one '3' in this list.
@@ -311,10 +311,10 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         n6 = node.Filter()  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         triggerables = mapper_func(graph_dict, t, 0)
-        nodes = hn.get_action_nodes()
+        nodes = hn._get_action_nodes()
 
         reqd_order = [1, 2, 2, 3, 3, 2]
 
@@ -344,7 +344,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
             n2 = n2.Filter()
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func = ComputationGraphGenerator.generate_computation_graph
         mapper_func(graph_dict, t, 0)
 
@@ -366,7 +366,7 @@ class ComputationGraphGeneratorTest(unittest.TestCase):
         t.ord_list = []
 
         # Generate and execute the mapper
-        graph_dict = hn.generate_graph_dict()
+        graph_dict = hn._generate_graph_dict()
         mapper_func(graph_dict, t, 0)
 
         # Required order in the list of returned values (the nodes are stored

--- a/bindings/experimental/distrdf/test/test_friendinfo.py
+++ b/bindings/experimental/distrdf/test/test_friendinfo.py
@@ -9,7 +9,7 @@ def create_dummy_headnode(*args):
     """Create dummy head node instance needed in the test"""
     # Pass None as `npartitions`. The tests will modify this member
     # according to needs
-    return get_headnode(None, *args)
+    return get_headnode(None, None, *args)
 
 class FriendInfoTest(unittest.TestCase):
     """Unit test for the FriendInfo class"""

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -11,7 +11,7 @@ def create_dummy_headnode(*args):
     """Create dummy head node instance needed in the test"""
     # Pass None as `npartitions`. The tests will modify this member
     # according to needs
-    return get_headnode(None, *args)
+    return get_headnode(None, None, *args)
 
 
 class DataFrameConstructorTests(unittest.TestCase):

--- a/bindings/experimental/distrdf/test/test_node.py
+++ b/bindings/experimental/distrdf/test/test_node.py
@@ -9,7 +9,7 @@ def create_dummy_headnode(*args):
     """Create dummy head node instance needed in the test"""
     # Pass None as `npartitions`. The tests will modify this member
     # according to needs
-    return get_headnode(None, *args)
+    return get_headnode(None, None, *args)
 
 
 class TestBackend(Base.BaseBackend):

--- a/bindings/experimental/distrdf/test/test_proxy.py
+++ b/bindings/experimental/distrdf/test/test_proxy.py
@@ -3,7 +3,15 @@ import unittest
 from DistRDF import Node
 from DistRDF import Proxy
 from DistRDF.Backends import Base
-from DistRDF.HeadNode import HeadNode
+from DistRDF.HeadNode import get_headnode
+
+
+def create_dummy_headnode(*args):
+    """Create dummy head node instance needed in the test"""
+    # Pass None as `npartitions`. The tests will modify this member
+    # according to needs
+    return get_headnode(None, None, *args)
+
 
 class ProxyInitTest(unittest.TestCase):
     """Proxy abstract class cannot be instantiated."""
@@ -25,7 +33,7 @@ class TypeReturnTest(unittest.TestCase):
         TransformationProxy object is of type `DistRDF.TransformationProxy` and
         wraps a node object.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         proxy = Proxy.TransformationProxy(node)
         self.assertIsInstance(proxy, Proxy.TransformationProxy)
@@ -36,7 +44,7 @@ class TypeReturnTest(unittest.TestCase):
         ActionProxy object is of type `DistRDF.ActionProxy` and
         wraps a node object.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         proxy = Proxy.ActionProxy(node)
         self.assertIsInstance(proxy, Proxy.ActionProxy)
@@ -71,7 +79,7 @@ class AttrReadTest(unittest.TestCase):
 
     def test_attr_simple_action(self):
         """ActionProxy object reads the right input attribute."""
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         proxy = Proxy.ActionProxy(node)
         func = proxy.attr
@@ -84,7 +92,7 @@ class AttrReadTest(unittest.TestCase):
         TransformationProxy object reads the right input attributes,
         returning the methods of the proxied node.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = AttrReadTest.TestBackend()
         proxy = Proxy.TransformationProxy(node)
 
@@ -106,7 +114,7 @@ class AttrReadTest(unittest.TestCase):
         When a node attribute is called on a TransformationProxy object, it
         correctly returns the attribute of the proxied node.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = AttrReadTest.TestBackend()
         proxy = Proxy.TransformationProxy(node)
 
@@ -129,7 +137,7 @@ class AttrReadTest(unittest.TestCase):
         When a non-defined Node class attribute is called on a
         TransformationProxy object, it raises an AttributeError.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         proxy = Proxy.TransformationProxy(node)
         with self.assertRaises(AttributeError):
@@ -142,7 +150,7 @@ class AttrReadTest(unittest.TestCase):
         `__del__` method switches the node attribute `has_user_references` from
         `True` to `False`.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         proxy = Proxy.TransformationProxy(node)
         self.assertTrue(node.has_user_references)
@@ -155,7 +163,7 @@ class AttrReadTest(unittest.TestCase):
         function call.
         """
         t = AttrReadTest.Temp()
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         node.value = t
         proxy = Proxy.ActionProxy(node)
@@ -194,7 +202,7 @@ class GetValueTests(unittest.TestCase):
         method in Proxy when the current action node
         already houses a value.
         """
-        node = HeadNode()
+        node = create_dummy_headnode(1)
         node.backend = None
         proxy = Proxy.ActionProxy(node)
         node.value = 5

--- a/bindings/experimental/distrdf/test/test_ranges.py
+++ b/bindings/experimental/distrdf/test/test_ranges.py
@@ -103,14 +103,14 @@ class EmptySourceRanges(unittest.TestCase):
 
     def test_buildranges_with_balanced_ranges(self):
         """
-        Check that build_ranges produces balanced ranges when there are no
+        Check that _build_ranges produces balanced ranges when there are no
         clusters involved.
         """
         npartitions = 16
         nentries = 50
-        headnode = get_headnode(npartitions, nentries)
+        headnode = get_headnode(None, npartitions, nentries)
 
-        crs = headnode.build_ranges()
+        crs = headnode._build_ranges()
         ranges = emptysourceranges_to_tuples(crs)
 
         ranges_reqd = [
@@ -222,7 +222,7 @@ class TreeRanges(unittest.TestCase):
         treename = "myTree"
         filename = "backend/2cluste*.root"
         npartitions = 2
-        rdf = get_headnode(npartitions, treename, filename)
+        rdf = get_headnode(None, npartitions, treename, filename)
 
         expected_inputfiles = ["backend/2clusters.root"]
         extracted_inputfiles = rdf.inputfiles
@@ -253,7 +253,7 @@ class TreeRanges(unittest.TestCase):
         chain.Add(str(filename1 + "?#" + treename1))
         chain.Add(str(filename2 + "?#" + treename2))
 
-        rdf = get_headnode(npartitions, chain)
+        rdf = get_headnode(None, npartitions, chain)
         extracted_subtreenames = rdf.subtreenames
         extracted_filenames = rdf.inputfiles
 


### PR DESCRIPTION
This class is not really needed, we can use free functions instead. This removes an implicit inter-dependency between the head node and the backend. Now it's only the head node that stores a reference to the backend needed to execute the graph, similarly to RLoopManager