### PR TITLE
[RF] Introducing binned likelihood fit optimization in HistFactory

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -90,6 +90,28 @@ Before v6.28, it was ensured that no `RooArgSet` and `RooDataSet` objects on the
 With v6.28, this is not guaranteed anymore.
 Hence, if your code uses pointer comparisons to uniquely identify RooArgSet or RooDataSet instances, please consider using the new `RooArgSet::uniqueId()` or `RooAbsData::uniqueId()`.
 
+### Introducing binned likelihood fit optimization in HistFactory
+
+In a binned likelihood fit, it is possible to skip the PDF normalization when
+the unnormalized binned PDF can be interpreted directly in terms of event
+yields. This is now done by default for HistFactory models, which
+results in great speedups for binned fits with many channels. Some RooFit users
+like ATLAS were already using this for a long time.
+
+To disable this optimization when using the `hist2workspace` executable, add the `-disable_binned_fit_optimization` command line argument.
+Directly in C++, you can also set the `binnedFitOptimization` to `false` in the
+HistFactory configuration as follows:
+```C++
+RooStats::HistFactory::MakeModelAndMeasurementFast(measurement, {.binnedFitOptimization=false});
+```
+If your compiler doesn't support aggregate initialization with designators, you
+need to create and edit the configuration struct explicitely:
+```C++
+RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration hfCfg;
+hfCfg.binnedFitOptimization = false;
+RooStats::HistFactory::MakeModelAndMeasurementFast(measurement, hfCfg);
+```
+
 ### Removal of HistoToWorkspaceFactory (non-Fast)
 
 The original `HistoToWorkspaceFactory` produced models that consisted of a

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -45,10 +45,13 @@ namespace RooStats{
 
     public:
 
+      struct Configuration {
+        bool binnedFitOptimization = true;
+      };
 
-      HistoToWorkspaceFactoryFast();
-      HistoToWorkspaceFactoryFast(  RooStats::HistFactory::Measurement& Meas );
-      ~HistoToWorkspaceFactoryFast() override;
+      HistoToWorkspaceFactoryFast() {}
+      HistoToWorkspaceFactoryFast(RooStats::HistFactory::Measurement& Meas);
+      HistoToWorkspaceFactoryFast(RooStats::HistFactory::Measurement& Meas, Configuration const& cfg);
 
       static void ConfigureWorkspaceForMeasurement( const std::string& ModelName,
                       RooWorkspace* ws_single,
@@ -118,10 +121,10 @@ namespace RooStats{
 
       std::vector<std::string> fSystToFix;
       std::map<std::string, double> fParamValues;
-      double fNomLumi;
-      double fLumiError;
-      int fLowBin;
-      int fHighBin;
+      double fNomLumi = 1.0;
+      double fLumiError = 0.0;
+      int fLowBin = 0;
+      int fHighBin = 0;
 
     private:
 
@@ -130,6 +133,7 @@ namespace RooStats{
       std::vector<std::string> fObsNameVec;
       std::string fObsName;
       std::vector<std::string> fPreprocessFunctions;
+      const Configuration fCfg;
 
       RooArgList createObservables(const TH1 *hist, RooWorkspace *proto) const;
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -103,9 +103,6 @@ namespace RooStats{
       RooHistFunc* MakeExpectedHistFunc(const TH1* hist, RooWorkspace* proto, std::string prefix,
           const RooArgList& observables) const;
 
-      void SetObsToExpected(RooWorkspace* proto, std::string obsPrefix, std::string expPrefix,
-             int lowBin, int highBin);
-
       std::unique_ptr<TH1> MakeScaledUncertaintyHist(const std::string& Name,
                  std::vector< std::pair<const TH1*, const TH1*> > HistVec ) const;
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/MakeModelAndMeasurementsFast.h
@@ -8,6 +8,7 @@
 #include "RooStats/HistFactory/Measurement.h"
 #include "RooStats/HistFactory/Channel.h"
 #include "RooStats/HistFactory/EstimateSummary.h"
+#include "RooStats/HistFactory/HistoToWorkspaceFactoryFast.h"
 
 #include "RooWorkspace.h"
 #include "RooPlot.h"
@@ -18,11 +19,12 @@
 namespace RooStats{
   namespace HistFactory{
 
-    RooWorkspace* MakeModelAndMeasurementFast( RooStats::HistFactory::Measurement& measurement );
-    //RooWorkspace* MakeModelFast( RooStats::HistFactory::Measurement& measurement );
+    RooWorkspace* MakeModelAndMeasurementFast(
+            RooStats::HistFactory::Measurement& measurement,
+            HistoToWorkspaceFactoryFast::Configuration const& cfg={}
+    );
 
     std::vector<RooStats::HistFactory::EstimateSummary> GetChannelEstimateSummaries(RooStats::HistFactory::Measurement& measurement, RooStats::HistFactory::Channel& channel);
-    // void ConfigureWorkspaceForMeasurement( const std::string&, RooWorkspace*, RooStats::HistFactory::Measurement&);
 
     void FormatFrameForLikelihood(RooPlot* frame, std::string xTitle=std::string("#sigma / #sigma_{SM}"), std::string yTitle=std::string("-log likelihood"));
     void FitModel(RooWorkspace *, std::string data_name="obsData");

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -763,45 +763,6 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
     proto->defineSet(prefix.c_str(),Pois); // add argset to workspace
   }
 
-   void HistoToWorkspaceFactoryFast::SetObsToExpected(RooWorkspace* proto, string obsPrefix, string expPrefix, int lowBin, int highBin){
-    /////////////////////////////////
-    // set observed to expected
-     TTree* tree = new TTree();
-     Double_t* obsForTree = new Double_t[highBin-lowBin];
-     RooArgList obsList("obsList");
-
-     for(Int_t i=lowBin; i<highBin; ++i){
-       std::stringstream str;
-       str<<"_"<<i;
-       RooRealVar* obs = (RooRealVar*) proto->var(obsPrefix+str.str());
-       cout << "expected number of events called: " << expPrefix << endl;
-       RooAbsReal* exp = proto->function((expPrefix+str.str()).c_str());
-       if(obs && exp){
-
-         //proto->Print();
-         obs->setVal(  exp->getVal() );
-         cout << "setting obs"+str.str()+" to expected = " << exp->getVal() << " check: " << obs->getVal() << endl;
-
-         // add entry to array and attach to tree
-         obsForTree[i] = exp->getVal();
-         tree->Branch((obsPrefix+str.str()).c_str(), obsForTree+i ,(obsPrefix+str.str()+"/D").c_str());
-         obsList.add(*obs);
-       }else{
-         cout << "problem retrieving obs or exp " << obsPrefix+str.str() << obs << " " << expPrefix+str.str() << exp << endl;
-       }
-     }
-     tree->Fill();
-     RooDataSet* data = new RooDataSet("expData","", tree, obsList); // one experiment
-
-     delete tree;
-     delete [] obsForTree;
-
-     proto->import(*data);
-
-     delete data;
-
-  }
-
   //////////////////////////////////////////////////////////////////////////////
 
   void HistoToWorkspaceFactoryFast::EditSyst(RooWorkspace* proto, const char* pdfNameChar,

--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -92,21 +92,18 @@ ClassImp(RooStats::HistFactory::HistoToWorkspaceFactoryFast);
 namespace RooStats{
 namespace HistFactory{
 
-  HistoToWorkspaceFactoryFast::HistoToWorkspaceFactoryFast() :
-       fNomLumi(1.0), fLumiError(0),
-       fLowBin(0), fHighBin(0)
-  {}
+  HistoToWorkspaceFactoryFast::HistoToWorkspaceFactoryFast(RooStats::HistFactory::Measurement& measurement) :
+    HistoToWorkspaceFactoryFast{measurement, Configuration{}} {}
 
-  HistoToWorkspaceFactoryFast::~HistoToWorkspaceFactoryFast(){
-  }
-
-  HistoToWorkspaceFactoryFast::HistoToWorkspaceFactoryFast(RooStats::HistFactory::Measurement& measurement ) :
+  HistoToWorkspaceFactoryFast::HistoToWorkspaceFactoryFast(RooStats::HistFactory::Measurement& measurement,
+                                                           Configuration const& cfg) :
     fSystToFix( measurement.GetConstantParams() ),
     fParamValues( measurement.GetParamValues() ),
     fNomLumi( measurement.GetLumi() ),
     fLumiError( measurement.GetLumi()*measurement.GetLumiRelErr() ),
     fLowBin( measurement.GetBinLow() ),
-    fHighBin( measurement.GetBinHigh() ) {
+    fHighBin( measurement.GetBinHigh() ),
+    fCfg{cfg} {
 
     // Set Preprocess functions
     SetFunctionsToPreprocess( measurement.GetPreprocessFunctions() );
@@ -735,6 +732,11 @@ RooArgList HistoToWorkspaceFactoryFast::createObservables(const TH1 *hist, RooWo
 
     // for mixed generation in RooSimultaneous
     tot.setAttribute("GenerateBinned"); // for use with RooSimultaneous::generate in mixed mode
+
+    // Enable the binned likelihood optimization
+    if(fCfg.binnedFitOptimization) {
+      tot.setAttribute("BinnedLikelihood");
+    }
 
     proto->import(tot, RecycleConflictNodes());
   }

--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -8,8 +8,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-
-
+#include "RooStats/HistFactory/MakeModelAndMeasurementsFast.h"
 
 // from std
 #include <string>
@@ -34,10 +33,8 @@
 // from this package
 #include "RooStats/HistFactory/EstimateSummary.h"
 #include "RooStats/HistFactory/Measurement.h"
-#include "RooStats/HistFactory/HistoToWorkspaceFactoryFast.h"
 #include "RooStats/HistFactory/HistFactoryException.h"
 
-#include "RooStats/HistFactory/MakeModelAndMeasurementsFast.h"
 #include "HFMsgService.h"
 
 using namespace RooFit;
@@ -98,8 +95,8 @@ using namespace RooFit;
   </ul>
   </ul>
 */
-RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::HistFactory::Measurement& measurement ) {
-
+RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::HistFactory::Measurement& measurement, HistoToWorkspaceFactoryFast::Configuration const& cfg)
+{
   // This will be returned
   RooWorkspace* ws = NULL;
   TFile* outFile = NULL;
@@ -164,7 +161,7 @@ RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::Hist
     tableFile =  fopen( tableFileName.c_str(), "a");
 
     cxcoutIHF << "Creating the HistoToWorkspaceFactoryFast factory" << std::endl;
-    HistoToWorkspaceFactoryFast factory( measurement );
+    HistoToWorkspaceFactoryFast factory{measurement, cfg};
 
     // Make the factory, and do some preprocessing
     // HistoToWorkspaceFactoryFast factory(measurement, rowTitle, outFile);

--- a/roofit/histfactory/src/hist2workspace-argparse.py
+++ b/roofit/histfactory/src/hist2workspace-argparse.py
@@ -1,15 +1,14 @@
 import argparse
 
+
 def get_argparse():
-	DESCRIPTION = """hist2workspace is a utility to create RooFit/RooStats workspace from histograms
-"""
-	parser = argparse.ArgumentParser(prog='hist2workspace',
-	description = DESCRIPTION)
-	parser.add_argument("-standard_form", help="""default  model,  which  creates  an  extended PDF that interpolates between RooHistFuncs
-This is much faster for models with many bins and uses significantly less memory""")
-	parser.add_argument("-number_counting_form", help="""This was the original model in 5.28 (without patches). It uses a Poisson for each
-bin of the histogram.  This can become slow and memory intensive when there are many bins.
-""")
-	parser.add_argument("-v", help="""Switch HistFactory message stream to INFO level.""", action='store_true')
-	parser.add_argument("-vv", help="""Switch HistFactory message stream to DEBUG level.""", action='store_true')
-	return parser
+    DESCRIPTION = "hist2workspace is a utility to create RooFit/RooStats workspace from histograms"
+    parser = argparse.ArgumentParser(prog="hist2workspace", description=DESCRIPTION)
+    parser.add_argument("-v", help="switch HistFactory message stream to INFO level", action="store_true")
+    parser.add_argument("-vv", help="switch HistFactory message stream to DEBUG level", action="store_true")
+    parser.add_argument(
+        "-disable_binned_fit_optimization",
+        help="disable the binned fit optimization used in HistFactory since ROOT 6.28",
+        action="store_true",
+    )
+    return parser

--- a/roofit/histfactory/src/hist2workspace.cxx
+++ b/roofit/histfactory/src/hist2workspace.cxx
@@ -23,12 +23,9 @@
 #include "HFMsgService.h"
 #include "hist2workspaceCommandLineOptionsHelp.h"
 
-//_____________________________batch only_____________________
-#ifndef __CINT__
-
 namespace RooStats {
   namespace HistFactory {
-    void fastDriver(std::string input) {
+    void fastDriver(std::string const& input, HistoToWorkspaceFactoryFast::Configuration const& cfg) {
 
       // Create the initial list of measurements and channels
       std::vector< HistFactory::Measurement > measurement_list;
@@ -45,7 +42,7 @@ namespace RooStats {
       for(unsigned int i = 0; i < measurement_list.size(); ++i) {
    HistFactory::Measurement measurement = measurement_list.at(i);
    measurement.CollectHistograms();
-   MakeModelAndMeasurementFast( measurement );
+   MakeModelAndMeasurementFast(measurement, cfg);
       }
 
       return;
@@ -63,10 +60,9 @@ namespace RooStats {
  * \param[in] argv pointer to arguments
  *
  * -h Help
- * -standard_form Standard xml model definitions. See MakeModelAndMeasurementFast()
- * -number_counting_form Deprecated
  * -v Switch HistFactory message stream to INFO level.
  * -vv Switch HistFactory message stream to DEBUG level.
+ * -disable_binned_fit_optimization Disable the binned fit optimization used in HistFactory since ROOT 6.28.
  */
 int main(int argc, char** argv) {
 
@@ -84,6 +80,7 @@ int main(int argc, char** argv) {
   RooMsgService::instance().getStream(2).addTopic(RooFit::HistFactory);
 
   std::string driverArg;
+  RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration cfg{};
 
   for (int i=1; i < argc; ++i) {
     std::string input = argv[i];
@@ -105,13 +102,8 @@ int main(int argc, char** argv) {
       continue;
     }
 
-    if (input == "-number_counting_form") {
-      std::cout << "ERROR: 'number_counting_form' is now deprecated." << std::endl;
-      return 255;
-    }
-
-    if(input == "-standard_form") {
-      driverArg = argv[++i];
+    if(input == "-disable_binned_fit_optimization") {
+      cfg.binnedFitOptimization = false;
       continue;
     }
 
@@ -119,7 +111,7 @@ int main(int argc, char** argv) {
   }
 
   try {
-    RooStats::HistFactory::fastDriver(driverArg);
+    RooStats::HistFactory::fastDriver(driverArg, cfg);
   }
   catch(const std::string &str) {
     std::cerr << "hist2workspace - Caught exception: " << str << std::endl ;
@@ -137,5 +129,3 @@ int main(int argc, char** argv) {
 
   return 0;
 }
-
-#endif


### PR DESCRIPTION
In a binned likelihood fit, it is possible to skip the PDF normalization
when the unnormalized binned PDF can be interpreted directly in terms of
event yields. This is now done by default for models HistFactory models,
which results in great speedups for binned fits with many channels. Some
RooFit users like ATLAS were already using this for a long time, so this
feature is battle-tested.

To disable this optimization when using the `hist2workspace` executable,
add the `-disable_binned_fit_optimization` command line argument.
Directly in C++, you can also set the `binnedFitOptimization` to `false`
in the HistFactory configuration as follows:
```C++
RooStats::HistFactory::MakeModelAndMeasurementFast(measurement, {.binnedFitOptimization=false});
```
If your compiler doesn't support aggregate initialization with designators, you
need to create and edit the configuration struct explicitely:
```C++
RooStats::HistFactory::HistoToWorkspaceFactoryFast::Configuration hfCfg;
hfCfg.binnedFitOptimization = false;
RooStats::HistFactory::MakeModelAndMeasurementFast(measurement, hfCfg);
```