### PR TITLE
[RF] Make non-command arg constructors of `RooChi2Var` private

### DIFF
--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -27,25 +27,16 @@ public:
 
   // Constructors, assignment etc
   RooChi2Var(const char *name, const char* title, RooAbsReal& func, RooDataHist& data,
-        const RooCmdArg& arg1                  , const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
+        const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
         const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
         const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooDataHist& data,
-        const RooCmdArg& arg1                  , const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
+        const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),const RooCmdArg& arg3=RooCmdArg::none(),
         const RooCmdArg& arg4=RooCmdArg::none(), const RooCmdArg& arg5=RooCmdArg::none(),const RooCmdArg& arg6=RooCmdArg::none(),
         const RooCmdArg& arg7=RooCmdArg::none(), const RooCmdArg& arg8=RooCmdArg::none(),const RooCmdArg& arg9=RooCmdArg::none()) ;
 
   enum FuncMode { Function, Pdf, ExtendedPdf } ;
-
-  RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& data,
-             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{},
-             bool extended=false, RooDataHist::ErrorType=RooDataHist::SumW2) ;
-
-  RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& data,
-             const RooArgSet& projDeps, FuncMode funcMode,
-             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{},
-             RooDataHist::ErrorType=RooDataHist::SumW2) ;
 
   RooChi2Var(const RooChi2Var& other, const char* name=0);
   TObject* clone(const char* newname) const override { return new RooChi2Var(*this,newname); }
@@ -56,21 +47,27 @@ public:
     return new RooChi2Var(name,title,(RooAbsPdf&)pdf,(RooDataHist&)dhist,projDeps,_funcMode,cfg,_etype) ;
   }
 
-  ~RooChi2Var() override;
-
   double defaultErrorLevel() const override {
     // The default error level for MINUIT error analysis for a chi^2 is 1.0
     return 1.0 ;
   }
 
+private:
+
+  RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& data,
+             const RooArgSet& projDeps, FuncMode funcMode,
+             RooAbsTestStatistic::Configuration const& cfg,
+             RooDataHist::ErrorType etype)
+    : RooAbsOptTestStatistic(name,title,func,data,projDeps,cfg), _etype(etype), _funcMode(funcMode) {}
+
 protected:
+
+  double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
   static RooArgSet _emptySet ;        ///< Supports named argument constructor
 
   RooDataHist::ErrorType _etype ;     ///< Error type store in associated RooDataHist
   FuncMode _funcMode ;                ///< Function, P.d.f. or extended p.d.f?
-
-  double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
   ClassDefOverride(RooChi2Var,1) // Chi^2 function of p.d.f w.r.t a binned dataset
 };

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -199,71 +199,12 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor of a chi2 for given p.d.f. with respect given binned
-/// dataset. If cutRange is specified the calculation of the chi2 is
-/// restricted to that named range. If addCoefRange is specified, the
-/// interpretation of fractions for all component RooAddPdfs that do
-/// not have a frozen range interpretation is set to chosen range
-/// name. If nCPU is greater than one the chi^2 calculation is
-/// parallelized over the specified number of processors. If
-/// interleave is true the partitioning of event over processors
-/// follows a (i % n == i_set) strategy rather than a bulk
-/// partitioning strategy which may result in unequal load balancing
-/// in binned datasets with many (adjacent) zero bins. If
-/// splitCutRange is true the cutRange is used to construct an
-/// individual cutRange for each RooSimultaneous index category state
-/// name cutRange_{indexStateName}.
-
-RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsPdf& pdf, RooDataHist& hdata,
-                       RooAbsTestStatistic::Configuration const& cfg, bool extended, RooDataHist::ErrorType etype) :
-  RooAbsOptTestStatistic(name,title,pdf,hdata,RooArgSet(), cfg),
-   _etype(etype), _funcMode(extended?ExtendedPdf:Pdf)
-{
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor of a chi2 for given p.d.f. with respect given binned
-/// dataset taking the observables specified in projDeps as projected
-/// observables. If cutRange is specified the calculation of the chi2
-/// is restricted to that named range. If addCoefRange is specified,
-/// the interpretation of fractions for all component RooAddPdfs that
-/// do not have a frozen range interpretation is set to chosen range
-/// name. If nCPU is greater than one the chi^2 calculation is
-/// parallelized over the specified number of processors. If
-/// interleave is true the partitioning of event over processors
-/// follows a (i % n == i_set) strategy rather than a bulk
-/// partitioning strategy which may result in unequal load balancing
-/// in binned datasets with many (adjacent) zero bins. If
-/// splitCutRange is true the cutRange is used to construct an
-/// individual cutRange for each RooSimultaneous index category state
-/// name cutRange_{indexStateName}.
-
-RooChi2Var::RooChi2Var(const char *name, const char *title, RooAbsReal& func, RooDataHist& hdata,
-                       const RooArgSet& projDeps, RooChi2Var::FuncMode fmode,
-                       RooAbsTestStatistic::Configuration const& cfg,
-                       RooDataHist::ErrorType etype) :
-  RooAbsOptTestStatistic(name,title,func,hdata,projDeps,cfg),
-  _etype(etype), _funcMode(fmode)
-{
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor
 
 RooChi2Var::RooChi2Var(const RooChi2Var& other, const char* name) :
   RooAbsOptTestStatistic(other,name),
   _etype(other._etype),
   _funcMode(other._funcMode)
-{
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooChi2Var::~RooChi2Var()
 {
 }
 

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -4457,7 +4457,7 @@ public:
   // Construct a chi^2 of the data and the model,
   // which is the input probability density scaled
   // by the number of events in the dataset
-  RooChi2Var chi2("chi2","chi2",model,*dh) ;
+  RooChi2Var chi2("chi2","chi2",model,*dh, DataError(RooAbsData::SumW2), Verbose(false)) ;
 
   // Use RooMinimizer interface to minimize chi^2
   RooMinimizer m(chi2) ;


### PR DESCRIPTION
In the RooChi2Var, there was another case of inconsistency between
constructors that seemingly do the same but actually don't.

A RooChi2Var should be created with the constructors that take RooFit
command arguments. However, there were also other constructors used by
the RooFit test statistic implementation details (i.e. in
`RooAbsOptTestStatistic::create`) that when used with default aruments
behave inconsistently with the command arg constructors: the default
error type is different, and errors will be estimated from the pdf and
not from the data.

This lead to the confusing situation that when creates a `RooChi2Var`
without any command arguments, the default error mode is suddenly
different. This inconsistency should be removed by having only the
command argument constructors part of the public interface.

Making these constructors private should not be a problem. There were
already considered implementaiton details before, and their interface
was already changed anyway to use the configuration structs in 6.26.
Nobody has complained about that so far.

Closes #10557.
