### PR TITLE
[core] Avoid deprecated `std::iterator`

### DIFF
--- a/core/base/v7/inc/ROOT/RIndexIter.hxx
+++ b/core/base/v7/inc/ROOT/RIndexIter.hxx
@@ -32,13 +32,20 @@ namespace Internal {
 
 template <class REFERENCE,
           class POINTER = typename std::add_pointer<typename std::remove_reference<REFERENCE>::type>::type>
-class RIndexIter: public std::iterator<std::random_access_iterator_tag, REFERENCE, POINTER> {
+class RIndexIter {
    size_t fIndex;
 
 protected:
    static constexpr size_t fgEndIndex = (size_t)-1;
 
 public:
+   using iterator_category = std::random_access_iterator_tag;
+   using value_type = REFERENCE;
+   using difference_type = POINTER;
+   using pointer = POINTER;
+   using const_pointer = const POINTER;
+   using reference = REFERENCE &;
+
    RIndexIter(size_t idx): fIndex(idx) {}
 
    /// Get the current index value.

--- a/core/base/v7/inc/ROOT/RIndexIter.hxx
+++ b/core/base/v7/inc/ROOT/RIndexIter.hxx
@@ -40,11 +40,10 @@ protected:
 
 public:
    using iterator_category = std::random_access_iterator_tag;
-   using value_type = REFERENCE;
-   using difference_type = POINTER;
+   using value_type = typename std::remove_reference<REFERENCE>::type;
+   using difference_type = std::ptrdiff_t;
    using pointer = POINTER;
-   using const_pointer = const POINTER;
-   using reference = REFERENCE &;
+   using reference = REFERENCE;
 
    RIndexIter(size_t idx): fIndex(idx) {}
 

--- a/core/cont/inc/TBtree.h
+++ b/core/cont/inc/TBtree.h
@@ -331,10 +331,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TBtreeIter : public TIterator,
-                   public std::iterator<std::bidirectional_iterator_tag,
-                                        TObject*, std::ptrdiff_t,
-                                        const TObject**, const TObject*&> {
+class TBtreeIter : public TIterator {
 
 private:
    const TBtree  *fTree;      //btree being iterated
@@ -345,6 +342,13 @@ private:
    TBtreeIter() : fTree(nullptr), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TBtreeIter(const TBtree *t, Bool_t dir = kIterForward);
    TBtreeIter(const TBtreeIter &iter);
    ~TBtreeIter() { }
@@ -360,7 +364,6 @@ public:
 
    ClassDefOverride(TBtreeIter,0)  //B-tree iterator
 };
-
 
 //----- TBtree inlines ---------------------------------------------------------
 

--- a/core/cont/inc/TList.h
+++ b/core/cont/inc/TList.h
@@ -28,12 +28,6 @@
 #include <iterator>
 #include <memory>
 
-#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
-// Prevent -Weffc++ from complaining about the inheritance
-// TListIter from std::iterator.
-#pragma GCC system_header
-#endif
-
 const Bool_t kSortAscending  = kTRUE;
 const Bool_t kSortDescending = !kSortAscending;
 

--- a/core/cont/inc/TList.h
+++ b/core/cont/inc/TList.h
@@ -194,10 +194,7 @@ public:
 // Iterator of linked list.                                             //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-class TListIter : public TIterator,
-                  public std::iterator<std::bidirectional_iterator_tag,
-                                       TObject*, std::ptrdiff_t,
-                                       const TObject**, const TObject*&> {
+class TListIter : public TIterator {
 
 protected:
    using TObjLinkPtr_t = std::shared_ptr<TObjLink>;
@@ -212,6 +209,13 @@ protected:
                  fStarted(kFALSE) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TListIter(const TList *l, Bool_t dir = kIterForward);
    TListIter(const TListIter &iter);
    ~TListIter() { }

--- a/core/cont/inc/TMap.h
+++ b/core/cont/inc/TMap.h
@@ -141,10 +141,7 @@ typedef TPair   TAssoc;     // for backward compatibility
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TMapIter : public TIterator,
-                 public std::iterator<std::bidirectional_iterator_tag,
-                                      TObject*, std::ptrdiff_t,
-                                      const TObject**, const TObject*&> {
+class TMapIter : public TIterator {
 
 private:
    const TMap       *fMap;         //map being iterated
@@ -154,6 +151,13 @@ private:
    TMapIter() : fMap(nullptr), fCursor(nullptr), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TMapIter(const TMap *map, Bool_t dir = kIterForward);
    TMapIter(const TMapIter &iter);
    ~TMapIter();

--- a/core/cont/inc/TObjArray.h
+++ b/core/cont/inc/TObjArray.h
@@ -120,10 +120,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TObjArrayIter : public TIterator,
-                      public std::iterator<std::bidirectional_iterator_tag, // TODO: ideally it should be a  randomaccess_iterator_tag
-                                           TObject*, std::ptrdiff_t,
-                                           const TObject**, const TObject*&> {
+class TObjArrayIter : public TIterator {
 
 private:
    const TObjArray  *fArray;     //array being iterated
@@ -134,6 +131,13 @@ private:
    TObjArrayIter() : fArray(0), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag; // TODO: ideally it should be a randomaccess_iterator_tag
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TObjArrayIter(const TObjArray *arr, Bool_t dir = kIterForward);
    TObjArrayIter(const TObjArrayIter &iter);
    ~TObjArrayIter() { }

--- a/core/cont/inc/TObjArray.h
+++ b/core/cont/inc/TObjArray.h
@@ -26,12 +26,6 @@
 
 #include <iterator>
 
-#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
-// Prevent -Weffc++ from complaining about the inheritance
-// TObjArrayIter from std::iterator.
-#pragma GCC system_header
-#endif
-
 class TObjArrayIter;
 
 class TObjArray : public TSeqCollection {

--- a/core/cont/inc/TOrdCollection.h
+++ b/core/cont/inc/TOrdCollection.h
@@ -93,10 +93,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TOrdCollectionIter : public TIterator,
-                           public std::iterator<std::bidirectional_iterator_tag,
-                                                TObject*, std::ptrdiff_t,
-                                                const TObject**, const TObject*&> {
+class TOrdCollectionIter : public TIterator {
 
 private:
    const TOrdCollection  *fCol;       //collection being iterated
@@ -107,6 +104,13 @@ private:
    TOrdCollectionIter() : fCol(nullptr), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TOrdCollectionIter(const TOrdCollection *col, Bool_t dir = kIterForward);
    TOrdCollectionIter(const TOrdCollectionIter &iter);
    ~TOrdCollectionIter() { }
@@ -122,7 +126,6 @@ public:
 
    ClassDefOverride(TOrdCollectionIter,0)  //Ordered collection iterator
 };
-
 
 //---- inlines -----------------------------------------------------------------
 

--- a/core/cont/inc/TRefArray.h
+++ b/core/cont/inc/TRefArray.h
@@ -27,12 +27,6 @@
 
 #include <iterator>
 
-#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
-// Prevent -Weffc++ from complaining about the inheritance
-// TRefArrayIter from std::iterator.
-#pragma GCC system_header
-#endif
-
 class TSystem;
 class TRefArrayIter;
 

--- a/core/cont/inc/TRefArray.h
+++ b/core/cont/inc/TRefArray.h
@@ -119,10 +119,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TRefArrayIter : public TIterator,
-                      public std::iterator<std::bidirectional_iterator_tag, // TODO: ideally it should be a  randomaccess_iterator_tag
-                                           TObject*, std::ptrdiff_t,
-                                           const TObject**, const TObject*&> {
+class TRefArrayIter : public TIterator {
 
 private:
    const TRefArray  *fArray;      //array being iterated
@@ -133,6 +130,13 @@ private:
    TRefArrayIter() : fArray(0), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag; // TODO: ideally it should be a randomaccess_iterator_tag
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TRefArrayIter(const TRefArray *arr, Bool_t dir = kIterForward);
    TRefArrayIter(const TRefArrayIter &iter);
    ~TRefArrayIter() { }

--- a/core/meta/src/TViewPubFunctions.h
+++ b/core/meta/src/TViewPubFunctions.h
@@ -93,11 +93,7 @@ public:
 // Iterator of view of linked list.      `1234                               //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-class TViewPubFunctionsIter : public TIterator,
-                              public std::iterator<std::bidirectional_iterator_tag,
-                                                   TObject*, std::ptrdiff_t,
-                                                    const TObject**, const TObject*&>
-{
+class TViewPubFunctionsIter : public TIterator {
 protected:
    const TList *fView;   //View we are iterating over.
    TIter        fClassIter;    //iterator over the classes
@@ -108,6 +104,13 @@ protected:
    TViewPubFunctionsIter() : fView(0), fClassIter((TCollection *)0), fFuncIter((TCollection *)0), fStarted(kFALSE), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TViewPubFunctionsIter(const TViewPubFunctions *l, Bool_t dir = kIterForward);
    TViewPubFunctionsIter(const TViewPubFunctionsIter &iter);
    ~TViewPubFunctionsIter() { }


### PR DESCRIPTION
Deprecated `std::iterator` since C++17 is substituted in:
* `TViewPubFunctionsIter`
* `TBtreeIter`
* `TListIter`
* `TMapIter`
* `TObjArrayIter`
* `TOrdCollectionIter`
* `TRefArrayIter`
* `RIndexIter`