### PR TITLE
remove unused variable warnings in macos cocoa

### DIFF
--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -4964,9 +4964,8 @@ static void GetDarwinProcInfo(ProcInfo_t *procinfo)
       mach_port_t object_name;
       vm_address_t address;
       vm_region_top_info_data_t info;
-      vm_size_t /*vsize,*/ vprvt, rsize, size;
+      vm_size_t vprvt, rsize, size;
       rsize = ti.resident_size;
-      //vsize = ti.virtual_size;
       vprvt = 0;
       for (address = 0; ; address += size) {
          // get memory region
@@ -4993,11 +4992,6 @@ static void GetDarwinProcInfo(ProcInfo_t *procinfo)
                                 &object_name) != KERN_SUCCESS) {
                   break;
                }
-
-               //if (b_info.reserved) {
-                  //vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
-                  //break;  // only for vsize
-               //}
             }
             // Short circuit the loop if this isn't a shared
             // private region, since that's the only region
@@ -5025,7 +5019,6 @@ static void GetDarwinProcInfo(ProcInfo_t *procinfo)
       }
 
       procinfo->fMemResident = (Long_t)(rsize / 1024);
-      //procinfo->fMemVirtual  = (Long_t)(vsize / 1024);
       procinfo->fMemVirtual  = (Long_t)(vprvt / 1024);
    }
 }

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -4923,7 +4923,7 @@ static void GetDarwinMemInfo(MemInfo_t *meminfo)
 /// http://www.opensource.apple.com/source/top/top-15/libtop.c
 /// The virtual memory usage is slightly over estimated as we don't
 /// subtract shared regions, but the value makes more sense
-/// then pure vsize, which is useless on 64-bit machines.
+/// than pure vsize, which is useless on 64-bit machines.
 
 static void GetDarwinProcInfo(ProcInfo_t *procinfo)
 {
@@ -4964,9 +4964,9 @@ static void GetDarwinProcInfo(ProcInfo_t *procinfo)
       mach_port_t object_name;
       vm_address_t address;
       vm_region_top_info_data_t info;
-      vm_size_t vsize, vprvt, rsize, size;
+      vm_size_t /*vsize,*/ vprvt, rsize, size;
       rsize = ti.resident_size;
-      vsize = ti.virtual_size;
+      //vsize = ti.virtual_size;
       vprvt = 0;
       for (address = 0; ; address += size) {
          // get memory region
@@ -4994,10 +4994,10 @@ static void GetDarwinProcInfo(ProcInfo_t *procinfo)
                   break;
                }
 
-               if (b_info.reserved) {
-                  vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
+               //if (b_info.reserved) {
+                  //vsize -= (SHARED_TEXT_REGION_SIZE + SHARED_DATA_REGION_SIZE);
                   //break;  // only for vsize
-               }
+               //}
             }
             // Short circuit the loop if this isn't a shared
             // private region, since that's the only region

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -4923,7 +4923,7 @@ static void GetDarwinMemInfo(MemInfo_t *meminfo)
 /// http://www.opensource.apple.com/source/top/top-15/libtop.c
 /// The virtual memory usage is slightly over estimated as we don't
 /// subtract shared regions, but the value makes more sense
-/// than pure vsize, which is useless on 64-bit machines.
+/// than using `virtual_size`, which is useless on 64-bit machines.
 
 static void GetDarwinProcInfo(ProcInfo_t *procinfo)
 {

--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -2197,8 +2197,6 @@ void TASImage::GetZoomPosition(UInt_t &x, UInt_t &y, UInt_t &w, UInt_t &h) const
 
 Bool_t TASImage::InitVisual()
 {
-   Display *disp;
-
    Bool_t inbatch = fgVisual && (fgVisual->dpy == (void*)1); // was in batch
    Bool_t noX = gROOT->IsBatch() || gVirtualX->InheritsFrom("TGWin32");
 
@@ -2214,7 +2212,6 @@ Bool_t TASImage::InitVisual()
 
    // batch or win32 mode
    if (!fgVisual && noX) {
-      disp = 0;
       fgVisual = create_asvisual(0, 0, 0, 0);
       fgVisual->dpy = (Display*)1; //fake (not used)
       return kTRUE;
@@ -2225,7 +2222,7 @@ Bool_t TASImage::InitVisual()
    fgVisual = create_asvisual(0, 0, 0, 0);
    fgVisual->dpy = (Display*)1; //fake (not used)
 #else
-   disp = (Display*) gVirtualX->GetDisplay();
+   Display *disp = (Display*) gVirtualX->GetDisplay();
    Int_t screen  = gVirtualX->GetScreen();
    Int_t depth   = gVirtualX->GetDepth();
    Visual *vis   = (Visual*) gVirtualX->GetVisual();

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -1532,9 +1532,11 @@ void TPad::DrawCrosshair()
    canvas->FeedbackMode(kTRUE);
 
    //erase old position and draw a line at current position
-   Int_t pxmin,pxmax,pymin,pymax,pxold,pyold,px,py;
-   pxold = fCrosshairPos%10000;
-   pyold = fCrosshairPos/10000;
+   Int_t pxmin,pxmax,pymin,pymax,px,py;
+#ifndef R__HAS_COCOA
+   Int_t pxold = fCrosshairPos%10000;
+   Int_t pyold = fCrosshairPos/10000;
+#endif // R__HAS_COCOA
    px    = cpad->GetEventX();
    py    = cpad->GetEventY()+1;
    if (canvas->GetCrosshair() > 1) {  //crosshair only in the current pad

--- a/gui/fitpanel/src/TFitEditor.cxx
+++ b/gui/fitpanel/src/TFitEditor.cxx
@@ -2803,9 +2803,9 @@ void TFitEditor::DoSliderXMoved()
 
 void TFitEditor::DrawSelection(bool restore)
 {
-   #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
    static Int_t  px1old, py1old, px2old, py2old; // to remember the square drawn.
-   #endif
+#endif
 
    if ( !fParentPad ) return;
 

--- a/gui/fitpanel/src/TFitEditor.cxx
+++ b/gui/fitpanel/src/TFitEditor.cxx
@@ -2803,15 +2803,19 @@ void TFitEditor::DoSliderXMoved()
 
 void TFitEditor::DrawSelection(bool restore)
 {
+   #ifndef R__HAS_COCOA
    static Int_t  px1old, py1old, px2old, py2old; // to remember the square drawn.
+   #endif
 
    if ( !fParentPad ) return;
 
    if (restore) {
+      #ifndef R__HAS_COCOA
       px1old = fParentPad->XtoAbsPixel(fParentPad->GetUxmin());
       py1old = fParentPad->YtoAbsPixel(fParentPad->GetUymin());
       px2old = fParentPad->XtoAbsPixel(fParentPad->GetUxmax());
       py2old = fParentPad->YtoAbsPixel(fParentPad->GetUymax());
+      #endif
       return;
    }
 
@@ -2852,13 +2856,13 @@ void TFitEditor::DrawSelection(bool restore)
    // done by clearing the backing store and repainting inside a special
    // window.
    gVirtualX->DrawBox(px1old, py1old, px2old, py2old, TVirtualX::kHollow);
-#endif // R__HAS_COCOA
-   gVirtualX->DrawBox(px1, py1, px2, py2, TVirtualX::kHollow);
 
    px1old = px1;
    py1old = py1;
-   px2old = px2 ;
+   px2old = px2;
    py2old = py2;
+#endif // R__HAS_COCOA
+   gVirtualX->DrawBox(px1, py1, px2, py2, TVirtualX::kHollow);
 
    if(save) gPad = save;
 }

--- a/gui/fitpanel/src/TFitEditor.cxx
+++ b/gui/fitpanel/src/TFitEditor.cxx
@@ -2810,12 +2810,12 @@ void TFitEditor::DrawSelection(bool restore)
    if ( !fParentPad ) return;
 
    if (restore) {
-      #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
       px1old = fParentPad->XtoAbsPixel(fParentPad->GetUxmin());
       py1old = fParentPad->YtoAbsPixel(fParentPad->GetUymin());
       px2old = fParentPad->XtoAbsPixel(fParentPad->GetUxmax());
       py2old = fParentPad->YtoAbsPixel(fParentPad->GetUymax());
-      #endif
+#endif
       return;
    }
 

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -533,9 +533,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       } else {
          xdest = 0;
          xsrc =  Int_t(new_top - fVisible.fX);
-         #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
          cpywidth = xsrc;
-         #endif
+#endif
          if (xsrc > (Int_t)fCanvas->GetWidth()) {
             xsrc = fCanvas->GetWidth();
          }

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -487,9 +487,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       if (new_top < fVisible.fY) {
          ysrc = 0;
          ydest = Int_t(fVisible.fY - new_top);
-         #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
          cpyheight = ydest;
-         #endif
+#endif
          if (ydest > (Int_t)fCanvas->GetHeight()) {
             ydest = fCanvas->GetHeight();
          }

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -521,9 +521,6 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       points[0].fY = points[1].fY = 0;
       points[2].fY = points[3].fY = fCanvas->GetHeight();
       ysrc = ydest = 0;
-      #ifndef R__HAS_COCOA
-      cpyheight = 0;
-      #endif
 
       if (new_top < fVisible.fX) {
          xsrc = 0;

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -465,9 +465,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
 {
    Point_t points[4];
    Int_t xsrc, ysrc, xdest, ydest;
-   #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
    Int_t cpyheight = 0, cpywidth = 0;
-   #endif
+#endif
 
    if (new_top < 0) {
       return;

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -464,7 +464,10 @@ void TGView::ScrollToPosition(TGLongPosition pos)
 void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
 {
    Point_t points[4];
-   Int_t xsrc, ysrc, xdest, ydest, cpyheight, cpywidth;
+   Int_t xsrc, ysrc, xdest, ydest;
+   #ifndef R__HAS_COCOA
+   Int_t cpyheight, cpywidth;
+   #endif
 
    if (new_top < 0) {
       return;
@@ -478,11 +481,15 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       points[0].fX = points[3].fX = 0;
       points[1].fX = points[2].fX = fCanvas->GetWidth();
       xsrc = xdest = 0;
+      #ifndef R__HAS_COCOA
       cpywidth = 0;
+      #endif
       if (new_top < fVisible.fY) {
          ysrc = 0;
          ydest = Int_t(fVisible.fY - new_top);
+         #ifndef R__HAS_COCOA
          cpyheight = ydest;
+         #endif
          if (ydest > (Int_t)fCanvas->GetHeight()) {
             ydest = fCanvas->GetHeight();
          }
@@ -492,7 +499,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       } else {
          ydest = 0;
          ysrc = Int_t(new_top - fVisible.fY);
+         #ifndef R__HAS_COCOA
          cpyheight= ysrc;
+         #endif
          if (ysrc > (Int_t)fCanvas->GetHeight()) {
             ysrc = fCanvas->GetHeight();
          }
@@ -512,12 +521,16 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       points[0].fY = points[1].fY = 0;
       points[2].fY = points[3].fY = fCanvas->GetHeight();
       ysrc = ydest = 0;
+      #ifndef R__HAS_COCOA
       cpyheight = 0;
+      #endif
 
       if (new_top < fVisible.fX) {
          xsrc = 0;
          xdest = Int_t(fVisible.fX - new_top);
+         #ifndef R__HAS_COCOA
          cpywidth = xdest;
+         #endif
          if (xdest < 0) {
             xdest = fCanvas->GetWidth();
          }
@@ -526,7 +539,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       } else {
          xdest = 0;
          xsrc =  Int_t(new_top - fVisible.fX);
+         #ifndef R__HAS_COCOA
          cpywidth = xsrc;
+         #endif
          if (xsrc > (Int_t)fCanvas->GetWidth()) {
             xsrc = fCanvas->GetWidth();
          }

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -466,7 +466,7 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
    Point_t points[4];
    Int_t xsrc, ysrc, xdest, ydest;
    #ifndef R__HAS_COCOA
-   Int_t cpyheight, cpywidth;
+   Int_t cpyheight = 0, cpywidth = 0;
    #endif
 
    if (new_top < 0) {

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -499,9 +499,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       } else {
          ydest = 0;
          ysrc = Int_t(new_top - fVisible.fY);
-         #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
          cpyheight= ysrc;
-         #endif
+#endif
          if (ysrc > (Int_t)fCanvas->GetHeight()) {
             ysrc = fCanvas->GetHeight();
          }

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -522,9 +522,9 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       if (new_top < fVisible.fX) {
          xsrc = 0;
          xdest = Int_t(fVisible.fX - new_top);
-         #ifndef R__HAS_COCOA
+#ifndef R__HAS_COCOA
          cpywidth = xdest;
-         #endif
+#endif
          if (xdest < 0) {
             xdest = fCanvas->GetWidth();
          }

--- a/gui/gui/src/TGView.cxx
+++ b/gui/gui/src/TGView.cxx
@@ -481,9 +481,6 @@ void TGView::ScrollCanvas(Int_t new_top, Int_t direction)
       points[0].fX = points[3].fX = 0;
       points[1].fX = points[2].fX = fCanvas->GetWidth();
       xsrc = xdest = 0;
-      #ifndef R__HAS_COCOA
-      cpywidth = 0;
-      #endif
       if (new_top < fVisible.fY) {
          ysrc = 0;
          ydest = Int_t(fVisible.fY - new_top);

--- a/proof/proof/src/TProof.cxx
+++ b/proof/proof/src/TProof.cxx
@@ -1044,7 +1044,9 @@ void TProof::ParseConfigField(const char *config)
 {
    TString sconf(config), opt;
    Ssiz_t from = 0;
+   #ifdef R__LINUX
    Bool_t cpuPin = kFALSE;
+   #endif
 
    // Analysise the field
    const char *cq = (IsLite()) ? "\"" : "";
@@ -1225,7 +1227,9 @@ void TProof::ParseConfigField(const char *config)
          }
          opt.ReplaceAll("_", "");
          TProof::AddEnvVar("PROOF_SLAVE_CPUPIN_ORDER", opt);
+         #ifdef R__LINUX
          cpuPin = kTRUE;
+         #endif
       } else if (opt.BeginsWith("workers=")) {
 
          // Request for a given number of workers (within the max) or worker


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
some unused variables warnings in MacOs cocoa

I not sure how to fix this one:
```
Building CXX object graf2d/cocoa/CMakeFiles/GCocoa.dir/src/MenuLoader.mm.o
/Users/rdm/rootsrc/graf2d/cocoa/src/MenuLoader.mm:92:16: warning: variable 'menuItem' set but not used [-Wunused-but-set-variable]
   NSMenuItem *menuItem = [aMenu addItemWithTitle : NSLocalizedString(@"Minimize", nil)
```

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes https://github.com/root-project/root/issues/10572

