### PR TITLE
[ntuple] Remove pre-C++17 header guards

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -36,9 +36,7 @@
 #include <string>
 #include <type_traits>
 #include <typeinfo>
-#if __cplusplus >= 201703L
 #include <variant>
-#endif
 #include <vector>
 #include <utility>
 
@@ -433,7 +431,6 @@ public:
    void AcceptVisitor(Detail::RFieldVisitor &visitor) const final;
 };
 
-#if __cplusplus >= 201703L
 /// The generic field for std::variant types
 class RVariantField : public Detail::RFieldBase {
 private:
@@ -470,7 +467,6 @@ public:
    size_t GetAlignment() const final { return fMaxAlignment; }
    void CommitCluster() final;
 };
-#endif
 
 
 /// Classes with dictionaries that can be inspected by TClass
@@ -1240,7 +1236,6 @@ public:
 };
 
 
-#if __cplusplus >= 201703L
 template <typename... ItemTs>
 class RField<std::variant<ItemTs...>> : public RVariantField {
    using ContainerT = typename std::variant<ItemTs...>;
@@ -1283,7 +1278,6 @@ public:
       return GenerateValue(where, ContainerT());
    }
 };
-#endif
 
 template <typename ItemT>
 class RField<std::vector<ItemT>> : public RVectorField {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -202,7 +202,6 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       auto itemField = Create(GetNormalizedType(arrayDef[0]), arrayDef[0]);
       result = std::make_unique<RArrayField>(fieldName, itemField.Unwrap(), arrayLength);
    }
-#if __cplusplus >= 201703L
    if (normalizedType.substr(0, 13) == "std::variant<") {
       auto innerTypes = TokenizeTypeList(normalizedType.substr(13, normalizedType.length() - 14));
       std::vector<RFieldBase *> items;
@@ -211,7 +210,6 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       }
       result = std::make_unique<RVariantField>(fieldName, items);
    }
-#endif
    // TODO: create an RCollectionField?
    if (normalizedType == ":Collection:")
      result = std::make_unique<RField<ClusterSize_t>>(fieldName);
@@ -1302,7 +1300,6 @@ void ROOT::Experimental::RArrayField::AcceptVisitor(Detail::RFieldVisitor &visit
 
 //------------------------------------------------------------------------------
 
-#if __cplusplus >= 201703L
 std::string ROOT::Experimental::RVariantField::GetTypeList(const std::vector<Detail::RFieldBase *> &itemFields)
 {
    std::string result;
@@ -1429,7 +1426,6 @@ void ROOT::Experimental::RVariantField::CommitCluster()
 {
    std::fill(fNWritten.begin(), fNWritten.end(), 0);
 }
-#endif
 
 
 //------------------------------------------------------------------------------

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -1,6 +1,5 @@
 #include "ntuple_test.hxx"
 
-#if __cplusplus >= 201703L
 TEST(RNTuple, ReconstructModel)
 {
    FileRaii fileGuard("test_ntuple_reconstruct.root");
@@ -38,7 +37,6 @@ TEST(RNTuple, ReconstructModel)
       std::variant<double, std::variant<std::string, double>>>("variant");
    EXPECT_TRUE(variant != nullptr);
 }
-#endif // __cplusplus >= 201703L
 
 TEST(RNTuple, MultipleInFile)
 {

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -46,9 +46,7 @@
 #include <string>
 #include <thread>
 #include <utility>
-#if __cplusplus >= 201703L
 #include <variant>
-#endif
 #include <vector>
 
 using ClusterSize_t = ROOT::Experimental::ClusterSize_t;

--- a/tree/ntuple/v7/test/rfield_variant.cxx
+++ b/tree/ntuple/v7/test/rfield_variant.cxx
@@ -1,6 +1,5 @@
 #include "ntuple_test.hxx"
 
-#if __cplusplus >= 201703L
 TEST(RNTuple, Variant)
 {
    FileRaii fileGuard("test_ntuple_variant.root");
@@ -34,9 +33,3 @@ TEST(RNTuple, Variant)
    ntuple.LoadEntry(2);
    EXPECT_EQ(8.0, *std::get_if<double>(rdVariant));
 }
-
-#else
-TEST(RNTuple, VariantNotSupported)
-{
-}
-#endif // __cplusplus >= 201703L


### PR DESCRIPTION
Since `ROOT::Experimental` moved to C++17, header guards for previous C++ versions are not required anymore.

