### PR TITLE
[tree] Return `const&` and not TString by value in TTreeDrawArgsParser

### DIFF
--- a/tree/treeplayer/inc/TTreeDrawArgsParser.h
+++ b/tree/treeplayer/inc/TTreeDrawArgsParser.h
@@ -86,16 +86,16 @@ public:
    Bool_t         GetAdd() const { return fAdd; }
    Int_t          GetDimension() const { return fDimension; }
    Bool_t         GetShouldDraw() const { return fShouldDraw; }
-   TString        GetExp() const { return fExp; }
+   TString const& GetExp() const { return fExp; }
    Double_t       GetIfSpecified(Int_t num, Double_t def) const;
    Int_t          GetNoParameters() const { return fNoParameters; }
    Double_t       GetParameter(int num) const;
    TString        GetProofSelectorName() const;
-   TString        GetObjectName() const { return fName; }
+   TString const& GetObjectName() const { return fName; }
    TString        GetObjectTitle() const;
    Bool_t         GetOptionSame() const { return fOptionSame; }
    TObject       *GetOriginal() const { return fOriginal; }
-   TString        GetSelection() const { return fSelection; }
+   TString const& GetSelection() const { return fSelection; }
    TString        GetVarExp(Int_t num) const;
    TString        GetVarExp() const;
    Bool_t         IsSpecified(int num) const;


### PR DESCRIPTION
When the returned TString is directly a class member of
`TTreeDrawArgsParser`, a const reference can be returned instead of
making a copy.

This fixes some warnings I spotted when compiling with gcc 12.1.0:

```
root/proof/proofplayer/src/TProofDraw.cxx: In member function ‘virtual void TProofDrawHist::SlaveBegin(TTree*)’:
root/proof/proofplayer/src/TProofDraw.cxx:783:51: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  783 |       if (objname && strlen(objname) > 0 && strcmp(objname, "htemp")) {
      |                                             ~~~~~~^~~~~~~~~~~~~~~~~~
root/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
root/proof/proofplayer/src/TProofDraw.cxx:789:30: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  789 |             PDB(kDraw,1) Info("SlaveBegin", "original object '%s' not found"
      |                          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  790 |                                           " or it is not a histogram", objname);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
root/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
root/proof/proofplayer/src/TProofDraw.cxx:784:60: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  784 |          TH1 *hist = dynamic_cast<TH1*> (fInput->FindObject(objname));
      |                                          ~~~~~~~~~~~~~~~~~~^~~~~~~~~
root/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
root/proof/proofplayer/src/TProofDraw.cxx:783:38: warning: dangling pointer to an unnamed temporary may be used [-Wdangling-pointer=]
  783 |       if (objname && strlen(objname) > 0 && strcmp(objname, "htemp")) {
      |                      ~~~~~~~~~~~~~~~~^~~
root/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
```

Indeed, `GetObjectName()` returns a temporary `TString` here, and with
the implicit `const char*` conversion we get a dangling pointer to the
TString data.

If we avoid the copy in `GetObjectName()` and company such that a `const&` is returned, we not only fix the dangling pointer problem but also avoid an unnecessary copy.