### PR TITLE
Simple TGraph ctor

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -117,6 +117,25 @@ In the unlikely case that this causes any problem for you, please open a GitHub 
 - Implement the option "File": The current file name is painted on the bottom right of each plot
   if the option `File` is set on via `gStyle->SetOptFile()`.
 
+- In matplolib one can use the "Default X-Points" feature to plot X/Y graphs: If one do not
+  specify the points in the x-axis, they will get the default values 0, 1, 2, 3, (etc. depending
+  on the length of the y-points). The matplotlib script will be:
+```
+   import matplotlib.pyplot as plt
+   import numpy as np
+   points = np.array([3, 8, 1, 10, 5, 7])
+   plt.plot(ypoints)
+   plt. show()
+```
+It is now possible to do the same with the ROOt TGraph:
+```
+   double y[6] = {3, 8, 1, 10, 5, 7};
+   auto g = new TGraph(6,y);
+   g->Draw();
+```
+
+So, if we take the same example as above, and leave out the x-points, the diagram will look like this:
+
 ## 3D Graphics Libraries
 
 

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -80,6 +80,7 @@ public:
    TGraph(Int_t n, const Int_t *x, const Int_t *y);
    TGraph(Int_t n, const Float_t *x, const Float_t *y);
    TGraph(Int_t n, const Double_t *x, const Double_t *y);
+   TGraph(Int_t n, const Double_t *y, Double_t start=0.);
    TGraph(const TGraph &gr);
    TGraph& operator=(const TGraph&);
    TGraph(const TVectorF &vx, const TVectorF &vy);

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -142,6 +142,25 @@ TGraph::TGraph(Int_t n, const Float_t *x, const Float_t *y)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Default X-Points constructor. The points along the x-axis get the default
+/// values `start`, `start+1`, `start+2`, `start+3`, etc ...
+
+TGraph::TGraph(Int_t n, const Double_t *y, Double_t start)
+   : TNamed("Graph", "Graph"), TAttLine(), TAttFill(0, 1000), TAttMarker()
+{
+   if (!y) {
+      fNpoints = 0;
+   } else {
+      fNpoints = n;
+   }
+   if (!CtorAllocate()) return;
+   for (Int_t i = 0; i < n; i++) {
+      fX[i] = start+i;
+      fY[i] = y[i];
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Graph normal constructor with doubles.
 
 TGraph::TGraph(Int_t n, const Double_t *x, const Double_t *y)


### PR DESCRIPTION
- In matplolib one can use the "Default X-Points" feature to plot X/Y graphs: If one do not
  specify the points in the x-axis, they will get the default values 0, 1, 2, 3, (etc. depending
  on the length of the y-points). The matplotlib script will be:
```
   import matplotlib.pyplot as plt
   import numpy as np
   points = np.array([3, 8, 1, 10, 5, 7])
   plt.plot(ypoints)
   plt. show()
```
It is now possible to do the same with the ROOt TGraph:
```
   double y[6] = {3, 8, 1, 10, 5, 7};
   auto g = new TGraph(6,y);
   g->Draw();
```