### PR TITLE
[cxxmodules] Reduce the amount of header duplications in the modules. [v6.26]

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -419,10 +419,18 @@ module "std" [system] {
     export *
     header "bits/locale_facets.h"
   }
+  module "bits/stl_algobase.h" {
+    export *
+    header "bits/stl_algobase.h"
+  }
   module "bits/stl_map.h" {
     export *
     export bits_stl_tree_h
     header "bits/stl_map.h"
+  }
+  module "bits/stl_pair.h" {
+    export *
+    header "bits/stl_pair.h"
   }
   explicit module "bits_stl_tree_h" {
     export *


### PR DESCRIPTION
This resolves a merging bug with libstdc++12. Fixes root-project/root#10478

Backport includes the following commit:
    [cxxmodules] Fix std.modulemap for older GCC (#10529)

    The header bits/utility.h only exists since libstdc++-12.

(cherry picked from commits e88d533f1c79754dae892249818f53d0155e88fa
and 2750395660c5c8c3ae617a18fefd27193587ec79)

Backport of PRs #10498 and #10529