### PR TITLE
DynamicLibraryManager::loadLibrary if the parameter resolve is false

### DIFF
--- a/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/interpreter/cling/lib/Interpreter/DynamicLibraryManager.cpp
@@ -355,11 +355,12 @@ namespace cling {
         (resolved ? "resolved" : "not-resolved") << "\n";
     }
 
-    std::string lResolved;
-    const std::string& canonicalLoadedLib = resolved ? libStem.str() : lResolved;
-    if (!resolved) {
-      lResolved = lookupLibrary(libStem);
-      if (lResolved.empty())
+    std::string canonicalLoadedLib;
+    if (resolved) {
+      canonicalLoadedLib = libStem.str();
+    } else {
+      canonicalLoadedLib = lookupLibrary(libStem);
+      if (canonicalLoadedLib.empty())
         return kLoadLibNotFound;
     }
 


### PR DESCRIPTION
The error occurs only when `loadLibrary()` is called with the argument `resolved = false`.
The const reference of lResolved in the statement `const std::string& canonicalLoadedLib = resolved ? libStem.str() : lResolved;` is a copy because the compiler insert the copy constructor and creates a temporary object. This is required, that the return type of libStem.str() and  lResolved has the same value
type: prvalue.

## Checklist:

- [ ] tested changes locally

Related cling PR: https://github.com/root-project/cling/pull/455

