### PR TITLE
[RF] Introduce separate RooMinimizer evaluation counter variable

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -38,6 +38,7 @@ class RooArgList ;
 class RooRealVar ;
 class RooArgSet ;
 class RooPlot ;
+class RooDataSet ;
 
 class RooMinimizer : public TObject {
 public:
@@ -85,6 +86,9 @@ public:
   void setProfile(bool flag=true) { _profile = flag ; }
   bool setLogFile(const char* logf=nullptr) ;
 
+  void setLoggingToDataSet(bool flag=true) { _loggingToDataSet = flag ; }
+  RooDataSet * getLogDataSet() const { return _logDataSet.get(); }
+
   int getPrintLevel() const { return _printLevel; }
 
   void setMinimizerType(const char* type) ;
@@ -128,11 +132,12 @@ private:
   int _printLevel = 1;
   int _status = -99;
   bool _profile = false;
-
+  bool _loggingToDataSet = false;
   bool _verbose = false;
+  bool _profileStart = false;
+
   TStopwatch _timer;
   TStopwatch _cumulTimer;
-  bool _profileStart = false;
 
   std::unique_ptr<TMatrixDSym> _extV;
 
@@ -144,6 +149,8 @@ private:
 
   std::vector<std::pair<std::string,int> > _statusHistory ;
   int _evalCounter = 0;
+
+  std::unique_ptr<RooDataSet> _logDataSet;
 
   ClassDefOverride(RooMinimizer,0) // RooFit interface to ROOT::Fit::Fitter
 } ;

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -95,8 +95,8 @@ public:
 
   void saveStatus(const char* label, int status) { _statusHistory.push_back(std::pair<std::string,int>(label,status)) ; }
 
-  int evalCounter() const ;
-  void zeroEvalCount() ;
+  int evalCounter() const {return _evalCounter; }
+  void zeroEvalCount() { _evalCounter = 0; }
 
   ROOT::Fit::Fitter* fitter() ;
   const ROOT::Fit::Fitter* fitter() const ;
@@ -108,6 +108,10 @@ public:
   void applyCovarianceMatrix(TMatrixDSym const& V) ;
 
 private:
+
+  friend class RooAbsMinimizerFcn;
+
+  void incrementEvalCounter() { _evalCounter++; }
 
   void profileStart() ;
   void profileStop() ;
@@ -139,6 +143,7 @@ private:
   static std::unique_ptr<ROOT::Fit::Fitter> _theFitter ;
 
   std::vector<std::pair<std::string,int> > _statusHistory ;
+  int _evalCounter = 0;
 
   ClassDefOverride(RooMinimizer,0) // RooFit interface to ROOT::Fit::Fitter
 } ;

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -442,6 +442,18 @@ void RooAbsMinimizerFcn::printEvalErrors() const {
   ooccoutW(_context,Minimization) << msg.str() << endl;
 }
 
+void RooAbsMinimizerFcn::incrementEvalCounter() const {
+   // The counters in the RooMinimizer and in the RooAbsMinimizerFcn are not
+   // redundant! Every time the ROOT::Fit::Fitter is invoked with this
+   // RooAbsMinimizerFcn, it is copied. Therefore, only the counter in a copy
+   // unknown to the RooMinimizer context is incremented. To give the
+   // RooMinimizer information on the total number of function evaluations, we
+   // also have to increment the counter of the RooMinimizer.
+
+   _context->incrementEvalCounter();
+   _evalCounter++;
+}
+
 void RooAbsMinimizerFcn::setOptimizeConst(Int_t flag)
 {
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -25,6 +25,7 @@
 #include "RooAbsArg.h"
 #include "RooAbsPdf.h"
 #include "RooArgSet.h"
+#include "RooDataSet.h"
 #include "RooRealVar.h"
 #include "RooAbsRealLValue.h"
 #include "RooMsgService.h"
@@ -442,7 +443,17 @@ void RooAbsMinimizerFcn::printEvalErrors() const {
   ooccoutW(_context,Minimization) << msg.str() << endl;
 }
 
-void RooAbsMinimizerFcn::incrementEvalCounter() const {
+void RooAbsMinimizerFcn::finishDoEval() const {
+
+   if(_context->_loggingToDataSet) {
+
+      if(!_context->_logDataSet) {
+         _context->_logDataSet = std::make_unique<RooDataSet>("minimizer_path", "minimizer_path", *_floatParamList);
+      }
+
+      _context->_logDataSet->add(*_floatParamList);
+   }
+
    // The counters in the RooMinimizer and in the RooAbsMinimizerFcn are not
    // redundant! Every time the ROOT::Fit::Fitter is invoked with this
    // RooAbsMinimizerFcn, it is copied. Therefore, only the counter in a copy

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.cxx
@@ -442,59 +442,6 @@ void RooAbsMinimizerFcn::printEvalErrors() const {
   ooccoutW(_context,Minimization) << msg.str() << endl;
 }
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Logistics
-
-RooArgList *RooAbsMinimizerFcn::GetFloatParamList()
-{
-   return _floatParamList.get();
-}
-RooArgList *RooAbsMinimizerFcn::GetConstParamList()
-{
-   return _constParamList.get();
-}
-RooArgList *RooAbsMinimizerFcn::GetInitFloatParamList()
-{
-   return _initFloatParamList.get();
-}
-RooArgList *RooAbsMinimizerFcn::GetInitConstParamList()
-{
-   return _initConstParamList.get();
-}
-
-void RooAbsMinimizerFcn::SetEvalErrorWall(bool flag)
-{
-   _doEvalErrorWall = flag;
-}
-void RooAbsMinimizerFcn::SetPrintEvalErrors(Int_t numEvalErrors)
-{
-   _printEvalErrors = numEvalErrors;
-}
-
-double &RooAbsMinimizerFcn::GetMaxFCN()
-{
-   return _maxFCN;
-}
-Int_t RooAbsMinimizerFcn::GetNumInvalidNLL() const
-{
-   return _numBadNLL;
-}
-
-Int_t RooAbsMinimizerFcn::evalCounter() const
-{
-   return _evalCounter;
-}
-void RooAbsMinimizerFcn::zeroEvalCount()
-{
-   _evalCounter = 0;
-}
-
-void RooAbsMinimizerFcn::SetVerbose(bool flag)
-{
-   _verbose = flag;
-}
-
 void RooAbsMinimizerFcn::setOptimizeConst(Int_t flag)
 {
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
@@ -533,11 +480,6 @@ void RooAbsMinimizerFcn::optimizeConstantTerms(bool constStatChange, bool constV
    }
 
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::PrintErrors) ;
-}
-
-bool RooAbsMinimizerFcn::getOptConst()
-{
-   return _optConst;
 }
 
 std::vector<double> RooAbsMinimizerFcn::getParameterValues() const

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -64,8 +64,6 @@ public:
    void SetRecoverFromNaNStrength(double strength) { _recoverFromNaNStrength = strength; }
    void SetPrintEvalErrors(Int_t numEvalErrors) { _printEvalErrors = numEvalErrors; }
    double &GetMaxFCN() { return _maxFCN; }
-   Int_t evalCounter() const {return _evalCounter; }
-   void zeroEvalCount() { _evalCounter = 0; }
    /// Return a possible offset that's applied to the function to separate invalid function values from valid ones.
    double getOffset() const { return _funcOffset; }
    void SetVerbose(bool flag = true) { _verbose = flag; }
@@ -116,6 +114,8 @@ protected:
    void SetPdfParamErr(Int_t index, double loVal, double hiVal);
 
    void printEvalErrors() const;
+
+   void incrementEvalCounter() const;
 
    // members
    RooMinimizer *_context;

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -48,27 +48,27 @@ public:
    /// but Synchronize can be overridden to e.g. also include gradient strategy synchronization in subclasses.
    virtual bool Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters, bool optConst, bool verbose);
 
-   RooArgList *GetFloatParamList();
-   RooArgList *GetConstParamList();
-   RooArgList *GetInitFloatParamList();
-   RooArgList *GetInitConstParamList();
-   Int_t GetNumInvalidNLL() const;
+   RooArgList *GetFloatParamList() { return _floatParamList.get(); }
+   RooArgList *GetConstParamList() { return _constParamList.get(); }
+   RooArgList *GetInitFloatParamList() { return _initFloatParamList.get(); }
+   RooArgList *GetInitConstParamList() { return _initConstParamList.get(); }
+   Int_t GetNumInvalidNLL() const { return _numBadNLL; }
 
    // need access from Minimizer:
-   void SetEvalErrorWall(bool flag);
+   void SetEvalErrorWall(bool flag) { _doEvalErrorWall = flag; }
    /// Try to recover from invalid function values. When invalid function values are encountered,
    /// a penalty term is returned to the minimiser to make it back off. This sets the strength of this penalty.
    /// \note A strength of zero is equivalent to a constant penalty (= the gradient vanishes, ROOT < 6.24).
    /// Positive values lead to a gradient pointing away from the undefined regions. Use ~10 to force the minimiser
    /// away from invalid function values.
    void SetRecoverFromNaNStrength(double strength) { _recoverFromNaNStrength = strength; }
-   void SetPrintEvalErrors(Int_t numEvalErrors);
-   double &GetMaxFCN();
-   Int_t evalCounter() const;
-   void zeroEvalCount();
+   void SetPrintEvalErrors(Int_t numEvalErrors) { _printEvalErrors = numEvalErrors; }
+   double &GetMaxFCN() { return _maxFCN; }
+   Int_t evalCounter() const {return _evalCounter; }
+   void zeroEvalCount() { _evalCounter = 0; }
    /// Return a possible offset that's applied to the function to separate invalid function values from valid ones.
    double getOffset() const { return _funcOffset; }
-   void SetVerbose(bool flag = true);
+   void SetVerbose(bool flag = true) { _verbose = flag; }
 
    /// Put Minuit results back into RooFit objects.
    void BackProp(const ROOT::Fit::FitResult &results);
@@ -94,7 +94,7 @@ public:
 
    void setOptimizeConst(Int_t flag);
 
-   bool getOptConst();
+   bool getOptConst() { return _optConst; }
    std::vector<double> getParameterValues() const;
 
    bool SetPdfParamVal(int index, double value) const;

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -115,7 +115,7 @@ protected:
 
    void printEvalErrors() const;
 
-   void incrementEvalCounter() const;
+   void finishDoEval() const;
 
    // members
    RooMinimizer *_context;

--- a/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
@@ -137,11 +137,7 @@ double RooGradMinimizerFcn::DoEval(const double *x) const
       std::cout.flush();
    }
 
-   _evalCounter++;
-   //#ifndef NDEBUG
-   //  std::cout << "RooGradMinimizerFcn " << this << " evaluations (in DoEval): " << _evalCounter <<
-   //  std::endl;
-   //#endif
+   incrementEvalCounter();
    return fvalue;
 }
 

--- a/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooGradMinimizerFcn.cxx
@@ -137,7 +137,7 @@ double RooGradMinimizerFcn::DoEval(const double *x) const
       std::cout.flush();
    }
 
-   incrementEvalCounter();
+   finishDoEval();
    return fvalue;
 }
 

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -932,9 +932,6 @@ void RooMinimizer::setPrintEvalErrors(Int_t numEvalErrors) { _fcn->SetPrintEvalE
 void RooMinimizer::setVerbose(bool flag) { _verbose = flag ; _fcn->SetVerbose(flag); }
 bool RooMinimizer::setLogFile(const char* logf) { return _fcn->SetLogFile(logf); }
 
-int RooMinimizer::evalCounter() const { return _fcn->evalCounter() ; }
-void RooMinimizer::zeroEvalCount() { _fcn->zeroEvalCount() ; }
-
 int RooMinimizer::getNPar() const { return _fcn->getNDim() ; }
 
 std::ofstream* RooMinimizer::logfile() { return _fcn->GetLogFile(); }

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -45,6 +45,7 @@ automatic PDF optimization.
 #include "RooArgList.h"
 #include "RooAbsReal.h"
 #include "RooAbsRealLValue.h"
+#include "RooDataSet.h"
 #include "RooRealVar.h"
 #include "RooSentinel.h"
 #include "RooMsgService.h"

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -121,7 +121,7 @@ double RooMinimizerFcn::DoEval(const double *x) const {
     cout.flush() ;
   }
 
-  incrementEvalCounter();
+  finishDoEval();
 
   return fvalue;
 }

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -121,7 +121,7 @@ double RooMinimizerFcn::DoEval(const double *x) const {
     cout.flush() ;
   }
 
-  _evalCounter++ ;
+  incrementEvalCounter();
 
   return fvalue;
 }

--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -15,22 +15,14 @@
 #ifndef ROO_MINIMIZER_FCN
 #define ROO_MINIMIZER_FCN
 
-#include "Math/IFunction.h"
-#include "Fit/ParameterSettings.h"
-#include "Fit/FitResult.h"
-
-#include "RooAbsReal.h"
-#include "RooArgList.h"
+#include <Math/IFunction.h>
 
 #include <fstream>
 #include <vector>
 
 #include "RooAbsMinimizerFcn.h"
 
-template<typename T> class TMatrixTSym;
-using TMatrixDSym = TMatrixTSym<double>;
-
-// forward declaration
+class RooAbsReal;
 class RooMinimizer;
 
 class RooMinimizerFcn : public RooAbsMinimizerFcn, public ROOT::Math::IBaseFunctionMultiDim {

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -131,7 +131,7 @@ double MinuitFcnGrad::DoEval(const double *x) const
       std::cout.flush();
    }
 
-   incrementEvalCounter();
+   finishDoEval();
    return fvalue;
 }
 

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -131,7 +131,7 @@ double MinuitFcnGrad::DoEval(const double *x) const
       std::cout.flush();
    }
 
-   _evalCounter++;
+   incrementEvalCounter();
    return fvalue;
 }
 


### PR DESCRIPTION
The RooAbsMinimizerFcn object is copied by the fitter, so the
`_evalCounter` of the original object will never be increased. Hence,
`RooMinimizer::evalCount()` will always return zero, which is
unexpected.

To make `RooMinimizer::evalCount()` reliable again, this commit suggests
to habe a second counter variable that is a member of the `RooMinimizer`
itself.

