### PR TITLE
[DF] Do not ask cling a typeid if it does not know the type

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -814,8 +814,12 @@ public:
 
          const auto &innerTypeID = typeid(RDFInternal::InnerValueType_t<RetType>);
 
+         const auto &definesMap = fColRegister.GetColumns();
          for (auto i = 0u; i < colTypes.size(); ++i) {
-            if (innerTypeID != RDFInternal::TypeName2TypeID(colTypes[i]))
+            const auto it = definesMap.find(colNames[i]);
+            const auto &expectedTypeID =
+               it == definesMap.end() ? RDFInternal::TypeName2TypeID(colTypes[i]) : it->second->GetTypeId();
+            if (innerTypeID != expectedTypeID)
                throw std::runtime_error("Varied values for column \"" + colNames[i] + "\" have a different type (" +
                                         RDFInternal::TypeID2TypeName(innerTypeID) + ") than the nominal value (" +
                                         colTypes[i] + ").");
@@ -823,7 +827,11 @@ public:
       } else {
          const auto &retTypeID = typeid(typename RetType::value_type);
          const auto &colName = colNames[0]; // we have only one element in there
-         if (retTypeID != RDFInternal::TypeName2TypeID(GetColumnType(colName)))
+         const auto &definesMap = fColRegister.GetColumns();
+         const auto it = definesMap.find(colName);
+         const auto &expectedTypeID =
+            it == definesMap.end() ? RDFInternal::TypeName2TypeID(GetColumnType(colName)) : it->second->GetTypeId();
+         if (retTypeID != expectedTypeID)
             throw std::runtime_error("Varied values for column \"" + colName + "\" have a different type (" +
                                      RDFInternal::TypeID2TypeName(retTypeID) + ") than the nominal value (" +
                                      GetColumnType(colName) + ").");


### PR DESCRIPTION
Before this patch, in order to assert that the column type
returned by a Vary expression matched the type of the column we
always asked cling to provide a type id for the existing column
via TypeName2TypeID(GetColumnType(colName)). That failed if the
column had a type not known to the interpreter, e.g. because it
was Define'd and the expression returned a user-defined type.

With this patch we use the typeid information coming from the
RDefine node if it is available, otherwise we try with cling.

A corresponding test is coming soon in another PR.