### PR TITLE
Better detection of XrootD version

### DIFF
--- a/cmake/modules/FindXROOTD.cmake
+++ b/cmake/modules/FindXROOTD.cmake
@@ -35,7 +35,7 @@ if (XROOTD_INCLUDE_DIR)
   if (${xrdvers} STREQUAL "\"unknown\"")
     math(EXPR xrdversnum 1000000000)
   else ()
-    string(REGEX REPLACE "[^v\\.]+" "" xrdversdots ${xrdvers})
+    string(REGEX REPLACE "[^v\\.-]+" "" xrdversdots ${xrdvers})
     if (${xrdversdots} STREQUAL "v..")
        # Regular version string; parse it out
        string(REGEX MATCH "[0-9\\.]+" xrdvers ${xrdvers})
@@ -43,6 +43,9 @@ if (XROOTD_INCLUDE_DIR)
        string(REGEX REPLACE "^([^.]*)\\.(.*)\\.(.*)" "\\2" xrdversminor ${xrdvers})
        string(REGEX REPLACE "^([^.]*)\\.(.*)\\.(.*)" "\\3" xrdverspatch ${xrdvers})
        math(EXPR xrdversnum ${xrdversmajor}*100000000+${xrdversminor}*10000+${xrdverspatch})
+    elseif (${xrdversdots} STREQUAL "v-")
+       # Untagged commit
+       math(EXPR xrdversnum 1000000000)
     else ()
        # Old version string: we keep only the first numerics, i.e. the date
        string(REGEX REPLACE "[v\"]" "" xrdvers ${xrdvers})


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Detection of XrootD built from git commit

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes #10604
