### PR TITLE
[ntuple] Replace old uses of `std::runtime_error` by `RException`

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -767,7 +767,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    , fClass(classp)
 {
    if (fClass == nullptr) {
-      throw std::runtime_error("RField: no I/O support for type " + std::string(className));
+      throw RException(R__FAIL("RField: no I/O support for type " + std::string(className)));
    }
    // Avoid accidentally supporting std types through TClass.
    if (fClass->Property() & kIsDefinedInStd) {

--- a/tree/ntuple/v7/test/rfield_class.cxx
+++ b/tree/ntuple/v7/test/rfield_class.cxx
@@ -6,7 +6,7 @@ class RNoDictionary {};
 
 TEST(RNTuple, TClass) {
    auto modelFail = RNTupleModel::Create();
-   EXPECT_THROW(modelFail->MakeField<RNoDictionary>("nodict"), std::runtime_error);
+   EXPECT_THROW(modelFail->MakeField<RNoDictionary>("nodict"), ROOT::Experimental::RException);
 
    auto model = RNTupleModel::Create();
    auto ptrKlass = model->MakeField<CustomStruct>("klass");


### PR DESCRIPTION
This pull request replaces old uses of `std::runtime_error` by `RException`.

## Checklist:
- [X] tested changes locally