### PR TITLE
[RF] Avoid using test statistics constructors directly in user code

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -38,7 +38,6 @@
 #include "RooSimultaneous.h"
 #include "RooMultiVarGaussian.h"
 #include "RooNumIntConfig.h"
-#include "RooNLLVar.h"
 #include "RooProfileLL.h"
 #include "RooFitResult.h"
 #include "RooDataHist.h"

--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -29,7 +29,6 @@
 #include "RooAbsData.h"
 #include "RooMsgService.h"
 #include "RooRealVar.h"
-#include "RooNLLVar.h"
 
 #include "RooStats/RooStatsUtils.h"
 #include "RooProdPdf.h"

--- a/roofit/roofit/src/RooChi2MCSModule.cxx
+++ b/roofit/roofit/src/RooChi2MCSModule.cxx
@@ -26,13 +26,13 @@ is store in the summary dataset.
 
 #include "Riostream.h"
 
+#include "RooAbsPdf.h"
 #include "RooDataSet.h"
 #include "RooRealVar.h"
 #include "TString.h"
 #include "RooFitResult.h"
 #include "RooChi2MCSModule.h"
 #include "RooMsgService.h"
-#include "RooChi2Var.h"
 #include "RooDataHist.h"
 #include "TMath.h"
 #include "RooGlobalFunc.h"
@@ -131,11 +131,11 @@ bool RooChi2MCSModule::processAfterFit(Int_t /*sampleNum*/)
     binnedData = ((RooDataSet*)data)->binnedClone() ;
   }
 
-  RooChi2Var chi2Var("chi2Var","chi2Var",*fitModel(),*binnedData,RooFit::Extended(extendedGen()),RooFit::DataError(RooAbsData::SumW2)) ;
+  std::unique_ptr<RooAbsReal> chi2Var{fitModel()->createChi2(*binnedData,RooFit::Extended(extendedGen()),RooFit::DataError(RooAbsData::SumW2))};
 
   RooArgSet* floatPars = (RooArgSet*) fitParams()->selectByAttrib("Constant",false) ;
 
-  _chi2->setVal(chi2Var.getVal()) ;
+  _chi2->setVal(chi2Var->getVal()) ;
   _ndof->setVal(binnedData->numEntries()-floatPars->getSize()-1) ;
   _chi2red->setVal(_chi2->getVal()/_ndof->getVal()) ;
   _prob->setVal(TMath::Prob(_chi2->getVal(),static_cast<int>(_ndof->getVal()))) ;

--- a/roofit/roofitcore/test/testRooFitDriver.cxx
+++ b/roofit/roofitcore/test/testRooFitDriver.cxx
@@ -15,7 +15,6 @@
 #include "RooConstVar.h"
 #include "RooArgusBG.h"
 #include "RooAddPdf.h"
-#include "RooNLLVar.h"
 #include "RooNLLVarNew.h"
 #include "RooFitDriver.h"
 #include "RooFit/BatchModeHelpers.h"

--- a/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
+++ b/roofit/roostats/inc/RooStats/MaxLikelihoodEstimateTestStat.h
@@ -16,8 +16,6 @@
 
 #include "Rtypes.h"
 
-#include "RooNLLVar.h"
-
 #include "RooFitResult.h"
 #include "RooStats/TestStatistic.h"
 #include "RooAbsPdf.h"

--- a/roofit/roostats/inc/RooStats/MinNLLTestStat.h
+++ b/roofit/roostats/inc/RooStats/MinNLLTestStat.h
@@ -25,7 +25,6 @@
 
 #include "RooRealVar.h"
 #include "RooProfileLL.h"
-#include "RooNLLVar.h"
 #include "RooMsgService.h"
 
 #include "RooMinimizer.h"

--- a/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
+++ b/roofit/roostats/inc/RooStats/ProfileLikelihoodTestStat.h
@@ -20,8 +20,6 @@
 
 #include "RooRealVar.h"
 
-#include "RooNLLVar.h"
-
 #include "Math/MinimizerOptions.h"
 
 #include "RooStats/RooStatsUtils.h"

--- a/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
+++ b/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
@@ -14,8 +14,6 @@
 
 #include "Rtypes.h"
 
-#include "RooNLLVar.h"
-
 #include "RooStats/TestStatistic.h"
 
 #include "RooStats/ProfileLikelihoodTestStat.h"

--- a/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
+++ b/roofit/roostats/inc/RooStats/SimpleLikelihoodRatioTestStat.h
@@ -13,8 +13,7 @@
 
 #include "Rtypes.h"
 
-#include "RooNLLVar.h"
-
+#include "RooAbsPdf.h"
 #include "RooRealVar.h"
 
 #include "RooStats/TestStatistic.h"

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -52,7 +52,6 @@ The calculator can generate Asimov datasets from two kinds of PDFs:
 #include "RooRealVar.h"
 #include "RooMinimizer.h"
 #include "RooFitResult.h"
-#include "RooNLLVar.h"
 #include "Math/MinimizerOptions.h"
 #include "RooPoisson.h"
 #include "RooUniform.h"

--- a/roofit/roostats/src/BernsteinCorrection.cxx
+++ b/roofit/roostats/src/BernsteinCorrection.cxx
@@ -59,7 +59,6 @@ generating the toys (either via a histogram or via an independent model that is 
 #include <iostream>
 
 #include "RooEffProd.h"
-#include "RooNLLVar.h"
 #include "RooWorkspace.h"
 #include "RooDataHist.h"
 #include "RooHistPdf.h"

--- a/roofit/roostats/src/HybridResult.cxx
+++ b/roofit/roostats/src/HybridResult.cxx
@@ -33,7 +33,6 @@ TConfidenceLevel class (http://root.cern.ch/root/html/TConfidenceLevel.html).
 #include "RooDataHist.h"
 #include "RooDataSet.h"
 #include "RooGlobalFunc.h" // for RooFit::Extended()
-#include "RooNLLVar.h"
 #include "RooRealVar.h"
 #include "RooAbsData.h"
 

--- a/roofit/roostats/src/LikelihoodInterval.cxx
+++ b/roofit/roostats/src/LikelihoodInterval.cxx
@@ -65,12 +65,6 @@
 #include <functional>
 #include <ctype.h>   // need to use c version of toupper defined here
 
-/*
-// for debugging
-#include "RooNLLVar.h"
-#include "RooDataSet.h"
-#include "RooAbsData.h"
-*/
 
 ClassImp(RooStats::LikelihoodInterval); ;
 

--- a/roofit/roostats/src/MetropolisHastings.cxx
+++ b/roofit/roostats/src/MetropolisHastings.cxx
@@ -49,7 +49,6 @@ uniformly over their intervals before construction of the MarkovChain begins.
 
 #include "Rtypes.h"
 #include "RooRealVar.h"
-#include "RooNLLVar.h"
 #include "RooGlobalFunc.h"
 #include "RooDataSet.h"
 #include "RooArgSet.h"

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -61,7 +61,6 @@ AsymptoticCalculator, which can compute in addition the expected
 #include "RooFitResult.h"
 #include "RooRealVar.h"
 #include "RooProfileLL.h"
-#include "RooNLLVar.h"
 #include "RooGlobalFunc.h"
 #include "RooMsgService.h"
 

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -31,7 +31,6 @@ either use:
 #include "RooStats/DetailedOutputAggregator.h"
 
 #include "RooProfileLL.h"
-#include "RooNLLVar.h"
 #include "RooMsgService.h"
 #include "RooMinimizer.h"
 #include "RooArgSet.h"

--- a/roofit/roostats/src/UpperLimitMCSModule.cxx
+++ b/roofit/roostats/src/UpperLimitMCSModule.cxx
@@ -29,7 +29,6 @@ upper limit for each toy-MC sample generated
 #include "RooStats/LikelihoodIntervalPlot.h"
 #include "RooStats/ProfileLikelihoodCalculator.h"
 #include "TCanvas.h"
-#include "RooNLLVar.h"
 #include "RooCmdArg.h"
 #include "RooRealVar.h"
 

--- a/test/fit/testFitPerf.cxx
+++ b/test/fit/testFitPerf.cxx
@@ -45,7 +45,6 @@
 #include "RooRealVar.h"
 #include "RooGaussian.h"
 #include "RooMinimizer.h"
-#include "RooChi2Var.h"
 #include "RooGlobalFunc.h"
 #include "RooFitResult.h"
 #include "RooProdPdf.h"

--- a/tutorials/roofit/rf403_weightedevts.C
+++ b/tutorials/roofit/rf403_weightedevts.C
@@ -17,7 +17,6 @@
 #include "RooFormulaVar.h"
 #include "RooGenericPdf.h"
 #include "RooPolynomial.h"
-#include "RooChi2Var.h"
 #include "RooMinimizer.h"
 #include "TCanvas.h"
 #include "TAxis.h"
@@ -131,8 +130,8 @@ void rf403_weightedevts()
    // NB: Within the usual approximations of a chi2 fit, a chi2 fit to weighted
    // data using sum-of-weights-squared errors does give correct error
    // estimates
-   RooChi2Var chi2("chi2", "chi2", p2, *binnedData, DataError(RooAbsData::SumW2));
-   RooMinimizer m(chi2);
+   std::unique_ptr<RooAbsReal> chi2{p2.createChi2(*binnedData, DataError(RooAbsData::SumW2))};
+   RooMinimizer m(*chi2);
    m.migrad();
    m.hesse();
 

--- a/tutorials/roofit/rf403_weightedevts.py
+++ b/tutorials/roofit/rf403_weightedevts.py
@@ -122,7 +122,7 @@ binnedData.Print("v")
 # NB: Within the usual approximations of a chi2 fit, chi2 fit to weighted
 # data using sum-of-weights-squared errors does give correct error
 # estimates
-chi2 = ROOT.RooChi2Var("chi2", "chi2", p2, binnedData, ROOT.RooFit.DataError("SumW2"))
+chi2 = p2.createChi2(binnedData, ROOT.RooFit.DataError("SumW2"))
 m = ROOT.RooMinimizer(chi2)
 m.migrad()
 m.hesse()

--- a/tutorials/roofit/rf602_chi2fit.C
+++ b/tutorials/roofit/rf602_chi2fit.C
@@ -14,7 +14,6 @@
 #include "RooGaussian.h"
 #include "RooChebychev.h"
 #include "RooAddPdf.h"
-#include "RooChi2Var.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"
@@ -71,6 +70,6 @@ void rf602_chi2fit()
    // messages
    RooDataSet *dsmall = (RooDataSet *)d->reduce(EventRange(1, 100));
    RooDataHist *dhsmall = dsmall->binnedClone();
-   RooChi2Var chi2_lowstat("chi2_lowstat", "chi2", model, *dhsmall);
-   cout << chi2_lowstat.getVal() << endl;
+   std::unique_ptr<RooAbsReal> chi2_lowstat{model.createChi2(*dhsmall)};
+   cout << chi2_lowstat->getVal() << endl;
 }

--- a/tutorials/roofit/rf602_chi2fit.py
+++ b/tutorials/roofit/rf602_chi2fit.py
@@ -65,5 +65,5 @@ model.chi2FitTo(dh, ll)
 # messages
 dsmall = d.reduce(ROOT.RooFit.EventRange(1, 100))
 dhsmall = dsmall.binnedClone()
-chi2_lowstat = ROOT.RooChi2Var("chi2_lowstat", "chi2", model, dhsmall)
+chi2_lowstat = model.createChi2(dhsmall)
 print(chi2_lowstat.getVal())

--- a/tutorials/roofit/rf606_nllerrorhandling.C
+++ b/tutorials/roofit/rf606_nllerrorhandling.C
@@ -13,7 +13,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooArgusBG.h"
-#include "RooNLLVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"
@@ -77,7 +76,7 @@ void rf606_nllerrorhandling()
    // ------------------------------------------------------------------
 
    // Construct likelihood function of model and data
-   RooNLLVar nll("nll", "nll", argus, *data);
+   std::unique_ptr<RooAbsReal> nll{argus.createNLL(*data)};
 
    // Plot likelihood in m0 in range that includes problematic values
    // In this configuration no messages are printed for likelihood evaluation errors,
@@ -85,7 +84,7 @@ void rf606_nllerrorhandling()
    // on the curve will be set to the value given in EvalErrorValue().
 
    RooPlot *frame2 = m0.frame(Range(5.288, 5.293), Title("-log(L) scan vs m0, problematic regions masked"));
-   nll.plotOn(frame2, PrintEvalErrors(-1), ShiftToZero(), EvalErrorValue(nll.getVal() + 10), LineColor(kRed));
+   nll->plotOn(frame2, PrintEvalErrors(-1), ShiftToZero(), EvalErrorValue(nll->getVal() + 10), LineColor(kRed));
    frame2->SetMaximum(15);
    frame2->SetMinimum(0);
 

--- a/tutorials/roofit/rf606_nllerrorhandling.py
+++ b/tutorials/roofit/rf606_nllerrorhandling.py
@@ -71,7 +71,7 @@ argus.fitTo(data, PrintEvalErrors=0, EvalErrorWall=False)
 # ------------------------------------------------------------------
 
 # Construct likelihood function of model and data
-nll = ROOT.RooNLLVar("nll", "nll", argus, data)
+nll = argus.createNLL(data)
 
 # Plot likelihood in m0 in range that includes problematic values
 # In self configuration no messages are printed for likelihood evaluation errors,

--- a/tutorials/roofit/rf609_xychi2fit.C
+++ b/tutorials/roofit/rf609_xychi2fit.C
@@ -14,7 +14,6 @@
 #include "RooRealVar.h"
 #include "RooDataSet.h"
 #include "RooPolyVar.h"
-#include "RooChi2Var.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"

--- a/tutorials/roofit/rf705_linearmorph.C
+++ b/tutorials/roofit/rf705_linearmorph.C
@@ -15,7 +15,6 @@
 #include "RooGaussian.h"
 #include "RooPolynomial.h"
 #include "RooIntegralMorph.h"
-#include "RooNLLVar.h"
 #include "TCanvas.h"
 #include "TAxis.h"
 #include "RooPlot.h"
@@ -107,8 +106,8 @@ void rf705_linearmorph()
    RooPlot *frame3 = alpha.frame(Bins(100), Range(0.1, 0.9));
 
    // Make 2D pdf of histogram
-   RooNLLVar nll("nll", "nll", lmorph, *data);
-   nll.plotOn(frame3, ShiftToZero());
+   std::unique_ptr<RooAbsReal> nll{lmorph.createNLL(*data)};
+   nll->plotOn(frame3, ShiftToZero());
 
    lmorph.setCacheAlpha(kFALSE);
 

--- a/tutorials/roofit/rf705_linearmorph.py
+++ b/tutorials/roofit/rf705_linearmorph.py
@@ -98,7 +98,7 @@ lmorph.plotOn(frame2)
 frame3 = alpha.frame(Bins=100, Range=(0.1, 0.9))
 
 # Make 2D pdf of histogram
-nll = ROOT.RooNLLVar("nll", "nll", lmorph, data)
+nll = lmorph.createNLL(data)
 nll.plotOn(frame3, ShiftToZero=True)
 
 lmorph.setCacheAlpha(False)

--- a/tutorials/roostats/rs401d_FeldmanCousins.C
+++ b/tutorials/roostats/rs401d_FeldmanCousins.C
@@ -37,7 +37,6 @@
 #include "RooPolynomial.h"
 #include "RooRandom.h"
 
-#include "RooNLLVar.h"
 #include "RooProfileLL.h"
 
 #include "RooPlot.h"
@@ -187,8 +186,8 @@ void rs401d_FeldmanCousins(bool doFeldmanCousins = false, bool doMCMC = true)
 
    // plot the likelihood function
    dataCanvas->cd(3);
-   RooNLLVar nll("nll", "nll", model, *data, Extended());
-   RooProfileLL pll("pll", "", nll, RooArgSet(deltaMSq, sinSq2theta));
+   std::unique_ptr<RooAbsReal> nll{model.createNLL(*data, Extended)};
+   RooProfileLL pll("pll", "", *nll, RooArgSet(deltaMSq, sinSq2theta));
    //  TH1* hhh = nll.createHistogram("hhh",sinSq2theta,Binning(40),YVar(deltaMSq,Binning(40))) ;
    TH1 *hhh = pll.createHistogram("hhh", sinSq2theta, Binning(40), YVar(deltaMSq, Binning(40)), Scaling(kFALSE));
    hhh->SetLineColor(kBlue);

--- a/tutorials/roostats/rs_bernsteinCorrection.C
+++ b/tutorials/roostats/rs_bernsteinCorrection.C
@@ -42,7 +42,6 @@
 #include "RooProdPdf.h"
 #include "RooAddPdf.h"
 #include "RooGaussian.h"
-#include "RooNLLVar.h"
 #include "RooProfileLL.h"
 #include "RooWorkspace.h"
 


### PR DESCRIPTION
The direct creation of RooFit test statistics instances is discouraged
because the more configurable `createNLL` and `createChi2` should be
prefered.