### PR TITLE
Complain about invalid sources again

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Serialization/ASTReader.cpp
@@ -1497,7 +1497,7 @@ bool ASTReader::ReadSLocEntry(int ID) {
     // We will detect whether a file changed and return 'Failure' for it, but
     // we will also try to fail gracefully by setting up the SLocEntry.
     unsigned InputID = Record[4];
-    InputFile IF = getInputFile(*F, InputID, /*Complain=*/false);
+    InputFile IF = getInputFile(*F, InputID);
     const FileEntry *File = IF.getFile();
     bool OverriddenBuffer = IF.isOverridden();
 


### PR DESCRIPTION
This reverts https://github.com/vgvassilev/clang/commit/a5ee33ae48

This patch previous tried to solve some problems with virtual files, but
when trying to upstream it, it brokes the tests below:

* Modules/module-file-modified.c
* Modules/explicit-build-missing-files.cpp


