### PR TITLE
Add missing TClass.h include in NormalizationHelpers.cxx

### DIFF
--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -12,6 +12,7 @@
 
 #include "NormalizationHelpers.h"
 
+#include <TClass.h>
 #include <RooAbsCachedPdf.h>
 #include <RooAbsPdf.h>
 #include <RooAbsReal.h>


### PR DESCRIPTION
Need when compiled with `-Ddev=ON` option