### PR TITLE
Minor Geometry optimization [v6-26]

### DIFF
--- a/geom/geom/inc/TGeoVolume.h
+++ b/geom/geom/inc/TGeoVolume.h
@@ -113,7 +113,8 @@ public:
    virtual Bool_t  IsFolder() const;
    Bool_t          IsRunTime() const {return fShape->IsRunTimeShape();}
    virtual Bool_t  IsVolumeMulti() const {return kFALSE;}
-   virtual void    AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat=0, Option_t *option="");       // most general case
+   virtual TGeoNode *
+   AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat = 0, Option_t *option = ""); // most general case
    void            AddNodeOffset(TGeoVolume *vol, Int_t copy_no, Double_t offset=0, Option_t *option="");
    virtual void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat=0, Option_t *option="");
 
@@ -272,7 +273,8 @@ public:
 
    void            AddVolume(TGeoVolume *vol);
    TGeoVolume     *GetVolume(Int_t id) const {return (TGeoVolume*)fVolumes->At(id);}
-   virtual void    AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option="");       // most general case
+   virtual TGeoNode *
+   AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option = ""); // most general case
    virtual void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option="");
    virtual TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="");
    TGeoShape      *GetLastShape() const;
@@ -329,7 +331,7 @@ public:
    TGeoVolumeAssembly(const char *name);
    virtual ~TGeoVolumeAssembly();
 
-   virtual void    AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat=0, Option_t *option="");
+   virtual TGeoNode *AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat = 0, Option_t *option = "");
    virtual void    AddNodeOverlap(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option);
    virtual TGeoVolume *CloneVolume() const;
    virtual TGeoVolume *Divide(const char *divname, Int_t iaxis, Int_t ndiv, Double_t start, Double_t step, Int_t numed=0, Option_t *option="");

--- a/geom/geom/src/TGeoVolume.cxx
+++ b/geom/geom/src/TGeoVolume.cxx
@@ -929,26 +929,26 @@ void TGeoVolume::cd(Int_t inode) const
 /// Add a TGeoNode to the list of nodes. This is the usual method for adding
 /// daughters inside the container volume.
 
-void TGeoVolume::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t * /*option*/)
+TGeoNode *TGeoVolume::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t * /*option*/)
 {
    TGeoMatrix *matrix = mat;
    if (matrix==0) matrix = gGeoIdentity;
    else           matrix->RegisterYourself();
    if (!vol) {
       Error("AddNode", "Volume is NULL");
-      return;
+      return 0;
    }
    if (!vol->IsValid()) {
       Error("AddNode", "Won't add node with invalid shape");
       printf("### invalid volume was : %s\n", vol->GetName());
-      return;
+      return 0;
    }
    if (!fNodes) fNodes = new TObjArray();
 
    if (fFinder) {
       // volume already divided.
       Error("AddNode", "Cannot add node %s_%i into divided volume %s", vol->GetName(), copy_no, GetName());
-      return;
+      return 0;
    }
 
    TGeoNodeMatrix *node = 0;
@@ -962,6 +962,7 @@ void TGeoVolume::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option
    node->SetNumber(copy_no);
    fRefCount++;
    vol->Grab();
+   return node;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2452,9 +2453,9 @@ void TGeoVolumeMulti::AddVolume(TGeoVolume *vol)
 /// Add a new node to the list of nodes. This is the usual method for adding
 /// daughters inside the container volume.
 
-void TGeoVolumeMulti::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option)
+TGeoNode *TGeoVolumeMulti::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option)
 {
-   TGeoVolume::AddNode(vol, copy_no, mat, option);
+   TGeoNode *n = TGeoVolume::AddNode(vol, copy_no, mat, option);
    Int_t nvolumes = fVolumes->GetEntriesFast();
    TGeoVolume *volume = 0;
    for (Int_t ivo=0; ivo<nvolumes; ivo++) {
@@ -2465,7 +2466,8 @@ void TGeoVolumeMulti::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, O
       volume->SetVisibility(IsVisible());
       volume->AddNode(vol, copy_no, mat, option);
    }
-//   printf("--- vmulti %s : node %s added to %i components\n", GetName(), vol->GetName(), nvolumes);
+   //   printf("--- vmulti %s : node %s added to %i components\n", GetName(), vol->GetName(), nvolumes);
+   return n;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2802,11 +2804,12 @@ TGeoVolumeAssembly::~TGeoVolumeAssembly()
 ////////////////////////////////////////////////////////////////////////////////
 /// Add a component to the assembly.
 
-void TGeoVolumeAssembly::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option)
+TGeoNode *TGeoVolumeAssembly::AddNode(TGeoVolume *vol, Int_t copy_no, TGeoMatrix *mat, Option_t *option)
 {
-   TGeoVolume::AddNode(vol,copy_no,mat,option);
-//   ((TGeoShapeAssembly*)fShape)->RecomputeBoxLast();
+   TGeoNode *node = TGeoVolume::AddNode(vol, copy_no, mat, option);
+   //   ((TGeoShapeAssembly*)fShape)->RecomputeBoxLast();
    ((TGeoShapeAssembly*)fShape)->NeedsBBoxRecompute();
+   return node;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# This Pull request:
- Returns the newly added node from call to TGeoVolume::AddNode
- Allows an option to avoid voxelation

back port of #10576

## Changes or fixes:
Profiling geometry building in CMSSW turned up two issues

1. Doing a linear lookup for newly added nodes to a TGeoVolume was very slow2.
2. CMS uses DD4Hep (which uses ROOT) as a geometry description system not as a geometry navigation system. The building of the voxels was slow and is never used in CMSSW.

This change was temporarily incorporated into CMS' development branch and did not cause any noticeable problems and did give a speed boost.



## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

