### PR TITLE
[RF] Synchronize param settings in RooMinimizer when returning function

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -140,11 +140,13 @@ public:
 private:
    friend class RooAbsMinimizerFcn;
 
-   void profileStart();
-   void profileStop();
+   bool synchronizeParameterSettings() const;
 
    std::ofstream *logfile();
    double &maxFCN();
+
+   void profileStart();
+   void profileStop();
 
    bool fitFcn() const;
 


### PR DESCRIPTION
Some users get the `RooMinimizer::getMultiGenFcn()` to get a pointer to
the fit function object passed to minuit to do their own routines before
doing the actual Minimization. The parameters settings should better be
synchronized before returning.

@cburgard 