### PR TITLE
[TMVA][SOFIE] Backport: Add header guards to the include file generated by SOFIE

### DIFF
--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -1,4 +1,6 @@
 #include <limits>
+#include <algorithm>
+#include <cctype>
 
 #include "TMVA/RModel.hxx"
 
@@ -174,6 +176,12 @@ namespace SOFIE{
       fUseSession = useSession;  // session flag is used in operator initialize
       Initialize();
       fGC += ("//Code generated automatically by TMVA for Inference of Model file [" + fFileName + "] at [" + fParseTime.substr(0, fParseTime.length()-1) +"] \n");
+      // add header guards
+      std::string hgname = fName;
+      std::transform(hgname.begin(), hgname.end(), hgname.begin(), [](unsigned char c){ return std::toupper(c);} );
+      hgname = "TMVA_SOFIE_" + hgname;
+      fGC += "\n#ifndef " + hgname + "\n";
+      fGC += "#define " + hgname + "\n\n";
       for (auto& i: fNeededStdLib) {
          fGC += "#include<" + i + ">\n";
       }
@@ -182,7 +190,7 @@ namespace SOFIE{
       fGC += "#include \"TMVA/SOFIE_common.hxx\"\n";
       if (useWeightFile)
          fGC += "#include <fstream>\n";
-      
+
       fGC += "\nnamespace TMVA_SOFIE_" + fName + "{\n";
       if (!fNeededBlasRoutines.empty()) {
          fGC += ("namespace BLAS{\n");
@@ -227,7 +235,7 @@ namespace SOFIE{
                fGC += "std::vector<float> fTensor_" + i.first + " = std::vector<float>(" + std::to_string(length) + ");\n";
                fGC += "float * tensor_" + i.first + " = fTensor_" + i.first + ".data();\n";
             }
-          
+
          }
       }
       for (auto&i: fIntermediateTensorInfos){
@@ -313,8 +321,8 @@ namespace SOFIE{
       }
       if (outputSize == 1) {
          size_t outputLength = ConvertShapeToLength(GetTensorShape(fOutputTensorNames[0]));
-         
-         fGC += "\tstd::vector<float> ret (tensor_" + fOutputTensorNames[0] + ", tensor_" + fOutputTensorNames[0] + " + " + 
+
+         fGC += "\tstd::vector<float> ret (tensor_" + fOutputTensorNames[0] + ", tensor_" + fOutputTensorNames[0] + " + " +
                std::to_string(outputLength) + ");\n";
       } else {
          for (size_t i = 0; i < outputSize; i++) {
@@ -322,7 +330,7 @@ namespace SOFIE{
                size_t outputLength = ConvertShapeToLength(GetTensorShape(fOutputTensorNames[i]));
                fGC += "\tstd::vector<float> ret_";
                fGC += std::to_string(i);
-               fGC += " (tensor_" + fOutputTensorNames[i] + ", tensor_" + fOutputTensorNames[i] + " + " + 
+               fGC += " (tensor_" + fOutputTensorNames[i] + ", tensor_" + fOutputTensorNames[i] + " + " +
                std::to_string(outputLength) + ");\n";
             }
          }
@@ -346,6 +354,7 @@ namespace SOFIE{
          fGC += "};\n";
       }
       fGC += ("} //TMVA_SOFIE_" + fName + "\n");
+      fGC += "\n#endif  // " + hgname + "\n";
    }
 
    void RModel::ReadInitializedTensorsFromFile() {
@@ -357,7 +366,7 @@ namespace SOFIE{
       fGC += "   }\n";
       fGC += "   std::string tensor_name;\n";
       fGC += "   int length;\n";
-      
+
       //loop on tensors and parse the file
       for (auto& i: fInitializedTensors){
          if (i.second.fType == ETensorType::FLOAT){
@@ -374,7 +383,7 @@ namespace SOFIE{
             fGC += "      throw std::runtime_error(err_msg);\n";
             fGC += "    }\n";
             fGC += "   if (length != " + slength + ") {\n";
-            fGC += "      std::string err_msg = \"TMVA-SOFIE failed to read the correct tensor size; expected size is " + 
+            fGC += "      std::string err_msg = \"TMVA-SOFIE failed to read the correct tensor size; expected size is " +
                    slength + " , read \" + std::to_string(length) ;\n";
             fGC += "      throw std::runtime_error(err_msg);\n";
             fGC += "    }\n";
@@ -386,7 +395,7 @@ namespace SOFIE{
    }
 
    void RModel::WriteInitializedTensorsToFile(std::string filename) {
-      // write the initialized tensors in a text file 
+      // write the initialized tensors in a text file
       if (filename == ""){
          filename = fName + ".data";
       }


### PR DESCRIPTION
This is a backport in 6,.26. This fixes  #10586

