### PR TITLE
[RF] Correctly restore the error definition in the Minimizer class after contour()

### DIFF
--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -762,7 +762,7 @@ RooPlot* RooMinimizer::contour(RooRealVar& var1, RooRealVar& var2,
 
 
   // restore the original ERRDEF
-  _theFitter->Config().MinimizerOptions().SetErrorDef(errdef);
+  _theFitter->GetMinimizer()->SetErrorDef(errdef);
 
   // restore parameter values
   params->assign(*paramSave) ;


### PR DESCRIPTION
This Pull request resets correctly the original error definition in the Minimizer class and fixes the problem of calling two times RooMinimizer::contour() (issue #10440)

The problem is that resetting as before using the FitConfig class does not work because the 
values stored in the FitConfig are set in the Minimizer only before Fitting or when calling Hesse or Minos. So, the resetting works for a following call to migrad() but not for a call to contour(). 

This PR fixes #10440 

