### PR TITLE
[ntuple] `std::tuple` RField support

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -591,6 +591,11 @@ Variants are stored in $n+1$ fields:
 A pair is stored using an empty mother field with two subfields, one of type `T1` and one of type `T2`. `T1` and `T2` must be types with RNTuple I/O support.
 The child fileds are named `_0` and `_1`.
 
+#### std::tuple<T1, T2, ..., Tn>
+
+A tuple is stored using an empty mother field with $n$ subfields of type `T1`, `T2`, ..., `Tn`. All types must have RNTuple I/O support.
+The child fileds are named `_0`, `_1`, ...
+
 ### User-defined classes
 
 User defined C++ classes are supported with the following limitations

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -924,9 +924,10 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
    : ROOT::Experimental::Detail::RFieldBase(fieldName, "", ENTupleStructure::kRecord, false /* isSimple */)
 {
    for (auto &item : itemFields) {
+      fSize += GetItemPadding(fSize, item->GetAlignment());
       fOffsets.push_back(fSize);
       fMaxAlignment = std::max(fMaxAlignment, item->GetAlignment());
-      fSize += GetItemPadding(fSize, item->GetAlignment()) + item->GetValueSize();
+      fSize += item->GetValueSize();
       Attach(std::move(item));
    }
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -128,7 +128,7 @@ std::string GetNormalizedType(const std::string &typeName) {
    if (normalizedType.substr(0, 6) == "array<") normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 8) == "variant<") normalizedType = "std::" + normalizedType;
    if (normalizedType.substr(0, 5) == "pair<") normalizedType = "std::" + normalizedType;
-   if (normalizedType.substr(0, 8) == "tuple<") normalizedType = "std::" + normalizedType;
+   if (normalizedType.substr(0, 6) == "tuple<") normalizedType = "std::" + normalizedType;
 
    return normalizedType;
 }

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1749,10 +1749,11 @@ std::string ROOT::Experimental::RTupleField::RTupleField::GetTypeList(
    const std::vector<std::unique_ptr<Detail::RFieldBase>> &itemFields)
 {
    std::string result;
+   if (itemFields.empty())
+      throw RException(R__FAIL("the type list for std::tuple must have at least one element"));
    for (size_t i = 0; i < itemFields.size(); ++i) {
       result += itemFields[i]->GetType() + ",";
    }
-   R__ASSERT(!result.empty()); // there is always at least one type
    result.pop_back();          // remove trailing comma
    return result;
 }
@@ -1781,8 +1782,10 @@ ROOT::Experimental::RTupleField::RTupleField(std::string_view fieldName,
    // Use TClass to get their offsets; in case a particular `std::tuple` implementation does not define such
    // members, the assertion below will fail.
    for (unsigned i = 0; i < fSubFields.size(); ++i) {
-      auto member = fClass->GetRealData(("_" + std::to_string(i)).c_str());
-      R__ASSERT(member != nullptr);
+      std::string memberName("_" + std::to_string(i));
+      auto member = fClass->GetRealData(memberName.c_str());
+      if (!member)
+         throw RException(R__FAIL(memberName + ": no such member"));
       fOffsets.push_back(member->GetThisOffset());
    }
 }


### PR DESCRIPTION
This pull request adds `std::tuple<...>` RField support (see notes below).  Follow-up PR of #10631.

## Changes or fixes:
- Amend `RRecordField` offsets computation: account for padding inserted before each member to comply with the alignment requirements of the type.
- Add `std::tuple` RField support.
ISO C++ does not guarantee neither specific layout nor member names for `std::tuple`.
Therefore, for the type-erased `RTupleField`, we guess the offsets assuming that most implementations store it as a standard-layout type with members reversed w.r.t. the type list.  A test has been added to check that this renders usable `RTupleField`s in all CI configurations, even when padding is added (see `char` members). 
**EDIT:** most implementations including libstdc++ (gcc), libc++ (llvm), and MSVC name members as `_0`, `_1`, ..., `_N-1`, following the order of the type list.
Use TClass to get their offsets; in case a particular `std::tuple` implementation does not define such members, an assertion will fail.
This fixes the issue of libc++ using a different member ordering w.r.t. other STL implementations (see failing test below).
- Update `specifications.md` accordingly.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #10632.