### PR TITLE
[DF] Simplify reg-/deregistration with RLoopManager

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -68,6 +68,8 @@ public:
       : RActionBase(pd->GetLoopManagerUnchecked(), columns, colRegister, pd->GetVariations()),
         fHelper(std::forward<Helper>(h)), fPrevNodePtr(std::move(pd)), fPrevNode(*fPrevNodePtr), fValues(GetNSlots())
    {
+      fLoopManager->Book(this);
+
       const auto nColumns = columns.size();
       const auto &customCols = GetColRegister();
       for (auto i = 0u; i < nColumns; ++i)
@@ -76,6 +78,8 @@ public:
 
    RAction(const RAction &) = delete;
    RAction &operator=(const RAction &) = delete;
+
+   ~RAction() { fLoopManager->Deregister(this); }
 
    /**
       Retrieve a wrapper to the result of the action that knows how to merge

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -108,10 +108,12 @@ public:
       : RDefineBase(name, type, colRegister, lm, columns, variationName), fExpression(std::move(expression)),
         fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<ret_type>()), fValues(lm.GetNSlots())
    {
+      fLoopManager->Book(this);
    }
 
    RDefine(const RDefine &) = delete;
    RDefine &operator=(const RDefine &) = delete;
+   ~RDefine() { fLoopManager->Deregister(this); }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -78,6 +78,7 @@ public:
         fFilter(std::move(f)), fValues(pd->GetLoopManagerUnchecked()->GetNSlots()), fPrevNodePtr(std::move(pd)),
         fPrevNode(*fPrevNodePtr)
    {
+      fLoopManager->Book(this);
    }
 
    RFilter(const RFilter &) = delete;
@@ -215,7 +216,6 @@ public:
       // TODO document this
       auto variedFilter = std::unique_ptr<RFilterBase>(
          new RFilter(fFilter, fColumnNames, std::move(prevNode), fColRegister, fName, variationName));
-      fLoopManager->Book(variedFilter.get());
       auto e = fVariedFilters.insert({variationName, std::move(variedFilter)});
       return e.first->second;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -295,7 +295,6 @@ public:
       using F_t = RDFDetail::RFilter<F, Proxied>;
 
       auto filterPtr = std::make_shared<F_t>(std::move(f), validColumnNames, fProxiedPtr, fColRegister, name);
-      fLoopManager->Book(filterPtr.get());
       return RInterface<F_t, DS_t>(std::move(filterPtr), *fLoopManager, fColRegister, fDataSource);
    }
 
@@ -354,7 +353,6 @@ public:
          RDFInternal::BookFilterJit(upcastNodeOnHeap, name, expression, fLoopManager->GetBranchNames(), fColRegister,
                                     fLoopManager->GetTree(), fDataSource);
 
-      fLoopManager->Book(jittedFilter.get());
       return RInterface<RDFDetail::RJittedFilter, DS_t>(std::move(jittedFilter), *fLoopManager, fColRegister,
                                                         fDataSource);
    }
@@ -477,7 +475,6 @@ public:
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fColRegister,
                                                      fLoopManager->GetBranchNames(), upcastNodeOnHeap);
-      fLoopManager->Book(jittedDefine.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddColumn(jittedDefine);
@@ -568,7 +565,6 @@ public:
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine = RDFInternal::BookDefineJit(name, expression, *fLoopManager, fDataSource, fColRegister,
                                                      fLoopManager->GetBranchNames(), upcastNodeOnHeap);
-      fLoopManager->Book(jittedDefine.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddColumn(jittedDefine);
@@ -800,7 +796,6 @@ public:
       auto variation = std::make_shared<RDFInternal::RVariation<F_t>>(
          colNames, variationName, std::forward<F>(expression), variationTags, retTypeName, fColRegister, *fLoopManager,
          validColumnNames);
-      fLoopManager->Book(variation.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddVariation(variation);
@@ -945,7 +940,6 @@ public:
       auto jittedVariation =
          RDFInternal::BookVariationJit(colNames, variationName, variationTags, expression, *fLoopManager, fDataSource,
                                        fColRegister, fLoopManager->GetBranchNames(), upcastNodeOnHeap);
-      fLoopManager->Book(jittedVariation.get());
 
       RDFInternal::RColumnRegister newColRegister(fColRegister);
       newColRegister.AddVariation(std::move(jittedVariation));
@@ -1314,7 +1308,6 @@ public:
 
       using Range_t = RDFDetail::RRange<Proxied>;
       auto rangePtr = std::make_shared<Range_t>(begin, end, stride, fProxiedPtr);
-      fLoopManager->Book(rangePtr.get());
       RInterface<RDFDetail::RRange<Proxied>, DS_t> tdf_r(std::move(rangePtr), *fLoopManager, fColRegister, fDataSource);
       return tdf_r;
    }
@@ -1389,7 +1382,6 @@ public:
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
 
       auto action = std::make_unique<Action_t>(Helper_t(std::move(f)), validColumnNames, fProxiedPtr, fColRegister);
-      fLoopManager->Book(action.get());
 
       fLoopManager->Run();
    }
@@ -1474,7 +1466,6 @@ public:
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
       auto action = std::make_unique<Action_t>(Helper_t(cSPtr, nSlots), ColumnNames_t({}), fProxiedPtr,
                                                RDFInternal::RColumnRegister(fColRegister));
-      fLoopManager->Book(action.get());
       return MakeResultPtr(cSPtr, *fLoopManager, std::move(action));
    }
 
@@ -1513,7 +1504,6 @@ public:
 
       auto action =
          std::make_unique<Action_t>(Helper_t(valuesPtr, nSlots), validColumnNames, fProxiedPtr, fColRegister);
-      fLoopManager->Book(action.get());
       return MakeResultPtr(valuesPtr, *fLoopManager, std::move(action));
    }
 
@@ -2548,7 +2538,6 @@ public:
       auto action = std::make_unique<Action_t>(Helper_t(rep, fProxiedPtr, returnEmptyReport), ColumnNames_t({}),
                                                fProxiedPtr, RDFInternal::RColumnRegister(fColRegister));
 
-      fLoopManager->Book(action.get());
       return MakeResultPtr(rep, *fLoopManager, std::move(action));
    }
 
@@ -2897,7 +2886,6 @@ public:
       auto action = std::make_unique<Action_t>(
          Helper_t(std::move(aggregator), std::move(merger), accObjPtr, fLoopManager->GetNSlots()), validColumnNames,
          fProxiedPtr, fColRegister);
-      fLoopManager->Book(action.get());
       return MakeResultPtr(accObjPtr, *fLoopManager, std::move(action));
    }
 
@@ -3153,7 +3141,6 @@ private:
 
       auto action = RDFInternal::BuildAction<ColTypes...>(validColumnNames, helperArg, nSlots, fProxiedPtr, ActionTag{},
                                                           fColRegister);
-      fLoopManager->Book(action.get());
       fLoopManager->AddSampleCallback(action->GetSampleCallback());
       return MakeResultPtr(r, *fLoopManager, std::move(action));
    }
@@ -3187,7 +3174,6 @@ private:
       auto toJit =
          RDFInternal::JitBuildAction(validColumnNames, upcastNodeOnHeap, typeid(HelperArgType), typeid(ActionTag),
                                      helperArgOnHeap, tree, nSlots, fColRegister, fDataSource, jittedActionOnHeap);
-      fLoopManager->Book(jittedAction.get());
       fLoopManager->ToJitExec(toJit);
       return MakeResultPtr(r, *fLoopManager, std::move(jittedAction));
    }
@@ -3229,7 +3215,6 @@ private:
       using NewCol_t = RDFDetail::RDefine<F, DefineType>;
       auto newColumn = std::make_shared<NewCol_t>(name, retTypeName, std::forward<F>(expression), validColumnNames,
                                                   fColRegister, *fLoopManager);
-      fLoopManager->Book(newColumn.get());
 
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddColumn(newColumn);

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -41,7 +41,7 @@ class RJittedFilter final : public RFilterBase {
 
 public:
    RJittedFilter(RLoopManager *lm, std::string_view name, const std::vector<std::string> &variations);
-   ~RJittedFilter() { fLoopManager->Deregister(this); }
+   ~RJittedFilter();
 
    void SetFilter(std::unique_ptr<RFilterBase> f);
 

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -51,6 +51,7 @@ public:
                    pd->GetVariations()),
         fPrevNodePtr(std::move(pd)), fPrevNode(*fPrevNodePtr)
    {
+      fLoopManager->Book(this);
    }
 
    RRange(const RRange &) = delete;
@@ -155,7 +156,6 @@ public:
          prevNode = std::static_pointer_cast<PrevNode_t>(prevNode->GetVariedFilter(variationName));
 
       auto variedRange = std::unique_ptr<RRangeBase>(new RRange(fStart, fStop, fStride, std::move(prevNode)));
-      fLoopManager->Book(variedRange.get());
       auto e = fVariedRanges.insert({variationName, std::move(variedRange)});
       return e.first->second;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -150,12 +150,15 @@ public:
         fExpression(std::move(expression)), fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<ret_type>()),
         fValues(lm.GetNSlots())
    {
+      fLoopManager->Book(this);
+
       for (auto i = 0u; i < lm.GetNSlots(); ++i)
          fLastResults[i * RDFInternal::CacheLineStep<ret_type>()].resize(fVariationNames.size());
    }
 
    RVariation(const RVariation &) = delete;
    RVariation &operator=(const RVariation &) = delete;
+   ~RVariation() { fLoopManager->Deregister(this); }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -82,6 +82,8 @@ public:
       : RActionBase(prevNode->GetLoopManagerUnchecked(), columns, colRegister, prevNode->GetVariations()),
         fHelpers(std::move(helpers)), fPrevNodes(MakePrevFilters(prevNode)), fInputValues(GetNSlots())
    {
+      fLoopManager->Book(this);
+
       const auto &defines = colRegister.GetColumns();
       for (auto i = 0u; i < columns.size(); ++i) {
          auto it = defines.find(columns[i]);
@@ -93,6 +95,8 @@ public:
 
    RVariedAction(const RVariedAction &) = delete;
    RVariedAction &operator=(const RVariedAction &) = delete;
+
+   ~RVariedAction() { fLoopManager->Deregister(this); }
 
    void Initialize() final
    {

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -248,7 +248,6 @@ RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
    // this recursively creates all the required varied column readers and upstream nodes of the computation graph
    std::unique_ptr<RDFInternal::RActionBase> variedAction{
       resPtr.fActionPtr->MakeVariedAction(std::move(typeErasedResults))};
-   resPtr.fLoopManager->Book(variedAction.get());
 
    return RDFInternal::MakeResultMap<T>(std::move(results), std::move(variations), *resPtr.fLoopManager,
                                         std::move(variedAction));

--- a/tree/dataframe/src/RActionBase.cxx
+++ b/tree/dataframe/src/RActionBase.cxx
@@ -22,8 +22,4 @@ RActionBase::RActionBase(RLoopManager *lm, const ColumnNames_t &colNames, const 
 }
 
 // outlined to pin virtual table
-RActionBase::~RActionBase()
-{
-   // The RLoopManager is kept alive via fColRegister.
-   fLoopManager->Deregister(this);
-}
+RActionBase::~RActionBase() = default;

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -37,7 +37,7 @@ RDefineBase::RDefineBase(std::string_view name, std::string_view type, const RDF
 }
 
 // pin vtable. Work around cling JIT issue.
-RDefineBase::~RDefineBase() { fLoopManager->Deregister(this); }
+RDefineBase::~RDefineBase() = default;
 
 std::string RDefineBase::GetName() const
 {

--- a/tree/dataframe/src/RVariationBase.cxx
+++ b/tree/dataframe/src/RVariationBase.cxx
@@ -32,10 +32,7 @@ RVariationBase::RVariationBase(const std::vector<std::string> &colNames, std::st
       fIsDefine[i] = fColumnRegister.HasName(fInputColumns[i]);
 }
 
-RVariationBase::~RVariationBase()
-{
-   fLoopManager->Deregister(this);
-}
+RVariationBase::~RVariationBase() = default;
 
 const std::vector<std::string> &RVariationBase::GetColumnNames() const
 {

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -117,55 +117,55 @@ public:
 
    std::string GetRealRepresentationFromRoot()
    {
-      return std::string("digraph {\n\t8 [label=<Mean") +
+      return std::string("digraph {\n\t7 [label=<Count") +
              (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
              ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
-             "\t6 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
-             "\t7 [label=<Define<BR/>Branch_1_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
              "\t3 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
-             "\t4 [label=<Define<BR/>Branch_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
-             "\t5 [label=<Define<BR/>Root_def2>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t4 [label=<Define<BR/>Branch_1_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t5 [label=<Define<BR/>Branch_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t6 [label=<Define<BR/>Root_def2>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
              "\t1 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
              "\t2 [label=<Define<BR/>Root_def1>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
              "\t0 [label=<Empty source<BR/>Entries: 8>, style=\"filled\", fillcolor=\"#f4b400\", shape=\"ellipse\"];\n"
-             "\t11 [label=<Count" +
+             "\t8 [label=<Count" +
              (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
              ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
-             "\t9 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
-             "\t10 [label=<Define<BR/>Branch_1_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
-             "\t17 [label=<Max" +
+             "\t9 [label=<Define<BR/>Branch_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t13 [label=<Mean" +
              (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
              ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
              "\", shape=\"box\"];\n"
+             "\t11 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t12 [label=<Define<BR/>Branch_1_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t10 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t18 [label=<Max" +
+             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
+             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
+             "\", shape=\"box\"];\n"
+             "\t15 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
+             "\t16 [label=<Define<BR/>Branch_2_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
+             "\t17 [label=<Define<BR/>Branch_2_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
              "\t14 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
-             "\t15 [label=<Define<BR/>Branch_2_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
-             "\t16 [label=<Define<BR/>Branch_2_1_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
-             "\t12 [label=<Filter>, style=\"filled\", fillcolor=\"#0f9d58\", shape=\"hexagon\"];\n"
-             "\t13 [label=<Define<BR/>Branch_2_def>, style=\"filled\", fillcolor=\"#4285f4\", shape=\"ellipse\"];\n"
-             "\t18 [label=<Count" +
-             (hasLoopRun ? "<BR/><FONT POINT-SIZE=\"10.0\">Already Run</FONT>" : "") +
-             ">, style=\"filled\", fillcolor=\"" + (hasLoopRun ? "#e6e5e6" : "#e47c7e") +
-             "\", shape=\"box\"];\n"
-             "\t6 -> 8;\n"
-             "\t7 -> 6;\n"
              "\t3 -> 7;\n"
              "\t4 -> 3;\n"
              "\t5 -> 4;\n"
-             "\t1 -> 5;\n"
+             "\t6 -> 5;\n"
+             "\t1 -> 6;\n"
              "\t2 -> 1;\n"
              "\t0 -> 2;\n"
-             "\t9 -> 11;\n"
-             "\t10 -> 9;\n"
-             "\t4 -> 10;\n"
-             "\t14 -> 17;\n"
-             "\t15 -> 14;\n"
+             "\t9 -> 8;\n"
+             "\t6 -> 9;\n"
+             "\t11 -> 13;\n"
+             "\t12 -> 11;\n"
+             "\t10 -> 12;\n"
+             "\t5 -> 10;\n"
+             "\t15 -> 18;\n"
              "\t16 -> 15;\n"
-             "\t12 -> 16;\n"
-             "\t13 -> 12;\n"
-             "\t5 -> 13;\n"
-             "\t13 -> 18;\n}";
+             "\t17 -> 16;\n"
+             "\t14 -> 17;\n"
+             "\t9 -> 14;\n}";
    }
 
    std::string GetRepresentationFromAction() { return SaveGraph(branch1_1); }


### PR DESCRIPTION
Before this commit, whenever a function was constructing a node
of the computation graph it had to "remember" to also register
that node with the RLoopManager, which needs to know which nodes
are around so it can tell them e.g. to execute task initialization
and task finalization logic.
Deregistration happened in the node's destructors.

With this patch, registration happen in the constructor and
deregistration in the destructor of a node, i.e. this logic is
where a reader might expect it to be and new code does not have
to "remember" to register objects with the RLoopManager.

Jitted nodes of the computation graph (e.g. RJittedAction,
RJittedDefine) don't need to register themselves with the
RLoopManager: the _concrete_ nodes will be registered right
before the event loop, at jitting time, and that is good enough.
RJittedFilter is an exception: RLoopManager needs to know what
filters have been booked even before the event loop (i.e. before
concrete filters are instantiated by jitted code) in order to
return a correct list from RLoopManager::GetFiltersNames().
So RJittedFilters register themselves with RLoopManager at
construction time and deregister themselves in
RJittedFilter::SetFilter, i.e. when they can be sure that the
concrete filter has been instantiated in jitted code and it has
been registered with RLoopManager, making the RJittedFilter
registration redundant.

To the reviewers: I'll make the naming more uniform (Register/Deregister instead of Book/Deregister) in a subsequent PR.