### PR TITLE
[DF] Do not duplicate work for nominal case when variations are present

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -155,10 +155,10 @@ public:
    std::unique_ptr<RActionBase> MakeVariedAction(std::vector<void *> &&results) final
    {
       const auto nVariations = GetVariations().size();
-      assert(results.size() == nVariations + 1);
+      assert(results.size() == nVariations);
 
       std::vector<Helper> helpers;
-      helpers.reserve(nVariations + 1);
+      helpers.reserve(nVariations);
 
       for (auto &&res : results)
          helpers.emplace_back(fHelper.CallMakeNew(res));

--- a/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RMergeableValue.hxx
@@ -601,6 +601,16 @@ public:
       : fKeys{std::move(keys)}, fValues{std::move(values)}
    {
    }
+
+   /////////////////////////////////////////////////////////////////////////////
+   /// \brief Add an entry for the "nominal" value.
+   ///
+   /// The way client code is structured, the nominal value is provided separately from the others.
+   void AddNominal(std::unique_ptr<RMergeableValueBase> value)
+   {
+      fKeys.insert(fKeys.begin(), "nominal");
+      fValues.insert(fValues.begin(), std::move(value));
+   }
 };
 
 /**

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -56,11 +56,10 @@ class R__CLING_PTRCHECK(off) RVariedAction final : public RActionBase {
    {
       const auto &variations = GetVariations();
       std::vector<std::shared_ptr<PrevNodeType>> prevFilters;
-      prevFilters.reserve(variations.size() + 1);
-      prevFilters.emplace_back(nominal);
+      prevFilters.reserve(variations.size());
       if (static_cast<RNodeBase *>(nominal.get()) == fLoopManager) {
          // just fill this with the RLoopManager N times
-         prevFilters.resize(variations.size() + 1, nominal);
+         prevFilters.resize(variations.size(), nominal);
       } else {
          // create varied versions of the previous filter node
          const auto &prevVariations = nominal->GetVariations();
@@ -104,8 +103,7 @@ public:
       RDFInternal::RColumnReadersInfo info{GetColumnNames(), GetColRegister(), fIsDefine.data(),
                                            fLoopManager->GetDSValuePtrs(), fLoopManager->GetDataSource()};
 
-      // get readers for the nominal case + each systematic variation
-      fInputValues[slot].emplace_back(MakeColumnReaders(slot, r, ColumnTypes_t{}, info /*, "nominal"*/));
+      // get readers for each systematic variation
       for (const auto &variation : GetVariations())
          fInputValues[slot].emplace_back(MakeColumnReaders(slot, r, ColumnTypes_t{}, info, variation));
 
@@ -122,7 +120,7 @@ public:
 
    void Run(unsigned int slot, Long64_t entry) final
    {
-      for (auto varIdx = 0u; varIdx < GetVariations().size() + 1; ++varIdx) {
+      for (auto varIdx = 0u; varIdx < GetVariations().size(); ++varIdx) {
          if (fPrevNodes[varIdx]->CheckFilters(slot, entry))
             CallExec(slot, varIdx, entry, ColumnTypes_t{}, TypeInd_t{});
       }
@@ -180,7 +178,6 @@ public:
    std::unique_ptr<RMergeableValueBase> GetMergeableValue() const final
    {
       std::vector<std::string> keys{GetVariations()};
-      keys.insert(keys.begin(), "nominal");
 
       std::vector<std::unique_ptr<RDFDetail::RMergeableValueBase>> values;
       values.reserve(fHelpers.size());

--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -205,9 +205,6 @@ namespace Experimental {
 ///       \ref ROOT::RDF::RInterface::Report() "Report" and \ref ROOT::RDF::RInterface::Snapshot() "Snapshot"
 ///       actions is not supported.
 //
-// TODO The current implementation duplicates work for the nominal value. In principle we could rewire things
-// so that the nominal value is calculated only once, either in the original action or in the varied action.
-//
 // An overview of how systematic variations work internally. Given N variations (including the nominal):
 //
 // RResultMap   owns    RVariedAction
@@ -216,8 +213,6 @@ namespace Experimental {
 //                       N*#input_cols column readers
 //
 // ...and each RFilter and RDefine knows for what universe it needs to construct column readers ("nominal" by default).
-//
-//
 template <typename T>
 RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
 {
@@ -227,11 +222,10 @@ RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
    // RJittedFilters
    resPtr.fLoopManager->Jit();
 
-   std::shared_ptr<RDFInternal::RActionBase> action = resPtr.fActionPtr;
+   std::shared_ptr<RDFInternal::RActionBase> nominalAction = resPtr.fActionPtr;
 
    // clone the result once for each variation
-   std::vector<std::string> variations = action->GetVariations();
-   variations.insert(variations.begin(), "nominal");
+   std::vector<std::string> variations = nominalAction->GetVariations();
    const auto nVariations = variations.size();
    std::vector<std::shared_ptr<T>> results;
    results.reserve(nVariations);
@@ -250,8 +244,8 @@ RResultMap<T> VariationsFor(RResultPtr<T> resPtr)
       resPtr.fActionPtr->MakeVariedAction(std::move(typeErasedResults))};
    resPtr.fLoopManager->Book(variedAction.get());
 
-   return RDFInternal::MakeResultMap<T>(std::move(results), std::move(variations), *resPtr.fLoopManager,
-                                        std::move(variedAction));
+   return RDFInternal::MakeResultMap<T>(resPtr.fObjPtr, std::move(results), std::move(variations), *resPtr.fLoopManager,
+                                        std::move(nominalAction), std::move(variedAction));
 }
 
 } // namespace Experimental


### PR DESCRIPTION
With this patch, RResultMap points to the one and only nominal
result and we do not duplicate work for the nominal value (i.e.
we don't handle the nominal case in RVariedAction anymore).

Vincenzo please check whether things make sense for RMergeableValues.