### PR TITLE
Fix crash, if cling is started with the arguments `-xcuda -fsyntax-only`

### DIFF
--- a/interpreter/cling/lib/Interpreter/Interpreter.cpp
+++ b/interpreter/cling/lib/Interpreter/Interpreter.cpp
@@ -280,7 +280,7 @@ namespace cling {
       setupCallbacks(*this, parentInterp);
     }
 
-    if(m_Opts.CompilerOpts.CUDAHost){
+    if (m_Opts.CompilerOpts.CUDAHost && !isInSyntaxOnlyMode()) {
       if (getDynamicLibraryManager()->loadLibrary("libcudart.so", true) ==
           cling::DynamicLibraryManager::LoadLibResult::kLoadLibNotFound){
         llvm::errs() << "Error: libcudart.so not found!\n" <<


### PR DESCRIPTION
The crash occurs due to a missing guard that prevents `libcudart.so` from being loaded. Loading a library requires an executor which is not available in syntax-only mode.

Without guard, the following assert is triggered in a debug build:
```
cling: /home/sehrig/workspace/cling/llvm/tools/cling/lib/Interpreter/Interpreter.cpp:1657: const cling::DynamicLibraryManager *cling::Interpreter::getDynamicLibraryManager() const: Assertion `m_Executor.get() && "We must have an executor"' failed.
```
