### PR TITLE
[DF] More uniform naming for internal RLoopManager methods

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -68,7 +68,7 @@ public:
       : RActionBase(pd->GetLoopManagerUnchecked(), columns, colRegister, pd->GetVariations()),
         fHelper(std::forward<Helper>(h)), fPrevNodePtr(std::move(pd)), fPrevNode(*fPrevNodePtr), fValues(GetNSlots())
    {
-      fLoopManager->Book(this);
+      fLoopManager->Register(this);
 
       const auto nColumns = columns.size();
       const auto &customCols = GetColRegister();

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -108,7 +108,7 @@ public:
       : RDefineBase(name, type, colRegister, lm, columns, variationName), fExpression(std::move(expression)),
         fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<ret_type>()), fValues(lm.GetNSlots())
    {
-      fLoopManager->Book(this);
+      fLoopManager->Register(this);
    }
 
    RDefine(const RDefine &) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -78,7 +78,7 @@ public:
         fFilter(std::move(f)), fValues(pd->GetLoopManagerUnchecked()->GetNSlots()), fPrevNodePtr(std::move(pd)),
         fPrevNode(*fPrevNodePtr)
    {
-      fLoopManager->Book(this);
+      fLoopManager->Register(this);
    }
 
    RFilter(const RFilter &) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -169,15 +169,15 @@ public:
    ::TDirectory *GetDirectory() const;
    ULong64_t GetNEmptyEntries() const { return fNEmptyEntries; }
    RDataSource *GetDataSource() const { return fDataSource.get(); }
-   void Book(RDFInternal::RActionBase *actionPtr);
+   void Register(RDFInternal::RActionBase *actionPtr);
    void Deregister(RDFInternal::RActionBase *actionPtr);
-   void Book(RFilterBase *filterPtr);
+   void Register(RFilterBase *filterPtr);
    void Deregister(RFilterBase *filterPtr);
-   void Book(RRangeBase *rangePtr);
+   void Register(RRangeBase *rangePtr);
    void Deregister(RRangeBase *rangePtr);
-   void Book(RDefineBase *definePtr);
+   void Register(RDefineBase *definePtr);
    void Deregister(RDefineBase *definePtr);
-   void Book(RDFInternal::RVariationBase *varPtr);
+   void Register(RDFInternal::RVariationBase *varPtr);
    void Deregister(RDFInternal::RVariationBase *varPtr);
    bool CheckFilters(unsigned int, Long64_t) final;
    unsigned int GetNSlots() const { return fNSlots; }

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -51,7 +51,7 @@ public:
                    pd->GetVariations()),
         fPrevNodePtr(std::move(pd)), fPrevNode(*fPrevNodePtr)
    {
-      fLoopManager->Book(this);
+      fLoopManager->Register(this);
    }
 
    RRange(const RRange &) = delete;

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -150,7 +150,7 @@ public:
         fExpression(std::move(expression)), fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<ret_type>()),
         fValues(lm.GetNSlots())
    {
-      fLoopManager->Book(this);
+      fLoopManager->Register(this);
 
       for (auto i = 0u; i < lm.GetNSlots(); ++i)
          fLastResults[i * RDFInternal::CacheLineStep<ret_type>()].resize(fVariationNames.size());

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -82,7 +82,7 @@ public:
       : RActionBase(prevNode->GetLoopManagerUnchecked(), columns, colRegister, prevNode->GetVariations()),
         fHelpers(std::move(helpers)), fPrevNodes(MakePrevFilters(prevNode)), fInputValues(GetNSlots())
    {
-      fLoopManager->Book(this);
+      fLoopManager->Register(this);
 
       const auto &defines = colRegister.GetColumns();
       for (auto i = 0u; i < columns.size(); ++i) {

--- a/tree/dataframe/src/RJittedFilter.cxx
+++ b/tree/dataframe/src/RJittedFilter.cxx
@@ -28,7 +28,7 @@ RJittedFilter::RJittedFilter(RLoopManager *lm, std::string_view name, const std:
    // So RJittedFilters register themselves with RLoopManager at construction time and deregister themselves
    // in SetFilter, i.e. when they are sure that the concrete filter has been instantiated in jitted code and it has
    // been registered with RLoopManager, making the RJittedFilter registration redundant.
-   fLoopManager->Book(this);
+   fLoopManager->Register(this);
 }
 
 RJittedFilter::~RJittedFilter()

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -783,7 +783,7 @@ TTree *RLoopManager::GetTree() const
    return fTree.get();
 }
 
-void RLoopManager::Book(RDFInternal::RActionBase *actionPtr)
+void RLoopManager::Register(RDFInternal::RActionBase *actionPtr)
 {
    fBookedActions.emplace_back(actionPtr);
 }
@@ -794,7 +794,7 @@ void RLoopManager::Deregister(RDFInternal::RActionBase *actionPtr)
    RDFInternal::Erase(actionPtr, fBookedActions);
 }
 
-void RLoopManager::Book(RFilterBase *filterPtr)
+void RLoopManager::Register(RFilterBase *filterPtr)
 {
    fBookedFilters.emplace_back(filterPtr);
    if (filterPtr->HasName()) {
@@ -809,7 +809,7 @@ void RLoopManager::Deregister(RFilterBase *filterPtr)
    RDFInternal::Erase(filterPtr, fBookedNamedFilters);
 }
 
-void RLoopManager::Book(RRangeBase *rangePtr)
+void RLoopManager::Register(RRangeBase *rangePtr)
 {
    fBookedRanges.emplace_back(rangePtr);
 }
@@ -819,7 +819,7 @@ void RLoopManager::Deregister(RRangeBase *rangePtr)
    RDFInternal::Erase(rangePtr, fBookedRanges);
 }
 
-void RLoopManager::Book(RDefineBase *ptr)
+void RLoopManager::Register(RDefineBase *ptr)
 {
    fBookedDefines.emplace_back(ptr);
 }
@@ -829,7 +829,7 @@ void RLoopManager::Deregister(RDefineBase *ptr)
    RDFInternal::Erase(ptr, fBookedDefines);
 }
 
-void RLoopManager::Book(RDFInternal::RVariationBase *v)
+void RLoopManager::Register(RDFInternal::RVariationBase *v)
 {
    fBookedVariations.emplace_back(v);
 }


### PR DESCRIPTION
We now use Register/Deregister instead of Book/Deregister (where "booking" is an overloaded term in RDF too).