### PR TITLE
[RF] RooAbsData code modernization and docmumentation update

### DIFF
--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -362,13 +362,13 @@ protected:
   RooArgSet _vars;         ///< Dimensions of this data set
   RooArgSet _cachedVars ;  ///<! External variables cached with this data set
 
-  RooAbsDataStore* _dstore ; ///< Data storage implementation
+  RooAbsDataStore* _dstore = nullptr; ///< Data storage implementation
 
   std::map<std::string,RooAbsData*> _ownedComponents ; ///< Owned external components
 
   std::unique_ptr<RooArgSet> _globalObservables; ///< Snapshot of global observables
 
-  mutable const TNamed * _namePtr ; ///<! De-duplicated name pointer. This will be equal for all objects with the same name.
+  mutable const TNamed * _namePtr = nullptr; ///<! De-duplicated name pointer. This will be equal for all objects with the same name.
 
 private:
   void copyGlobalObservables(const RooAbsData& other);

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -625,6 +625,11 @@ RooPlot* RooAbsData::plotOn(RooPlot* frame, const RooCmdArg& arg1, const RooCmdA
 /// use the createHistogram() method below with named arguments
 ///
 /// The caller takes ownership of the returned histogram
+///
+/// \deprecated This function is deprecated and will be removed in ROOT v6.30.
+/// Use the overload
+/// RooAbsData::createHistogram(const char*, const RooCmdArg&, const RooCmdArg&, const RooCmdArg&)
+/// that takes RooFit command arguments.
 
 TH1 *RooAbsData::createHistogram(const char* varNameList, Int_t xbins, Int_t ybins, Int_t zbins) const
 {


### PR DESCRIPTION
One of the overloads of `RooAbsData::createHistogram` was deprecated
because it behaved inconsistently with another more frequently used
overload (see https://github.com/root-project/root/pull/10411).

However, I forgot to mention the deprecation in the documentation and
pointed it out only in the source code with the deprecated macro. This
commit adds the corresponding `\deprecated` note to the reference guide.

Also, some code modernizations were applied to the source file while at it:

* replace `TString` with `std::string`

* replace `0` with `nullptr`

* replace iterator loops with range-based loops

* memory management with `std::unique_ptr`


