### PR TITLE
[ntuple] Add more test coverage for RNTuple+RVec

### DIFF
--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -5,12 +5,13 @@
 template <typename T>
 using Vector_t = std::vector<T>;
 
-TEST(RNTuple, ClassVector)
+template <template <typename> class Coll_t>
+void TestClassVector()
 {
    FileRaii fileGuard("test_ntuple_classvector.root");
 
    auto modelWrite = RNTupleModel::Create();
-   auto wrKlassVec = modelWrite->MakeField<std::vector<CustomStruct>>("klassVec");
+   auto wrKlassVec = modelWrite->MakeField<Coll_t<CustomStruct>>("klassVec");
    CustomStruct klass;
    klass.a = 42.0;
    klass.v1.emplace_back(1.0);
@@ -21,7 +22,7 @@ TEST(RNTuple, ClassVector)
 
    {
       RNTupleWriter ntuple(std::move(modelWrite),
-         std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
+                           std::make_unique<RPageSinkFile>("myNTuple", fileGuard.GetPath(), RNTupleWriteOptions()));
       ntuple.Fill();
    }
 
@@ -51,6 +52,15 @@ TEST(RNTuple, ClassVector)
    }
 }
 
+TEST(RNTuple, ClassVector)
+{
+   TestClassVector<Vector_t>();
+}
+
+TEST(RNTuple, ClassRVec)
+{
+   TestClassVector<ROOT::RVec>();
+}
 
 TEST(RNTuple, InsideCollection)
 {

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -6,9 +6,9 @@ template <typename T>
 using Vector_t = std::vector<T>;
 
 template <template <typename> class Coll_t>
-void TestClassVector()
+void TestClassVector(const char *fname)
 {
-   FileRaii fileGuard("test_ntuple_classvector.root");
+   FileRaii fileGuard(fname);
 
    auto modelWrite = RNTupleModel::Create();
    auto wrKlassVec = modelWrite->MakeField<Coll_t<CustomStruct>>("klassVec");
@@ -87,12 +87,12 @@ void TestClassVector()
 
 TEST(RNTuple, ClassVector)
 {
-   TestClassVector<Vector_t>();
+   TestClassVector<Vector_t>("test_ntuple_classvector.root");
 }
 
 TEST(RNTuple, ClassRVec)
 {
-   TestClassVector<ROOT::RVec>();
+   TestClassVector<ROOT::RVec>("test_ntuple_classrvec.root");
 }
 
 TEST(RNTuple, InsideCollection)


### PR DESCRIPTION
This PR brings coverage of RNTuple+RVec almost on par with RNTuple+std::vector, e.g. by templating some existing std::vector tests over the collection type.

There is one issue: in `RNTuple.ComplexRVec`, the element type's constructor and destructor gets called a different number of times for RVec than for std::vector, but I _think_ RVec is right and std::vector is wrong because of https://github.com/root-project/root/issues/10520 . I'd like to hear what Jakob thinks though :)