### PR TITLE
[math] Define TDataPointN::kDimension in template

### DIFF
--- a/math/mathcore/inc/Math/TDataPointN.h
+++ b/math/mathcore/inc/Math/TDataPointN.h
@@ -62,8 +62,8 @@ private:
    value_type    m_fWeight;
 };
 
-template<> UInt_t TDataPointN<Float_t>::kDimension = 0;
-template<> UInt_t TDataPointN<Double_t>::kDimension = 0;
+template <typename _val_type>
+UInt_t TDataPointN<_val_type>::kDimension = 0;
 
 }//namespace Math
 }//namespace ROOT


### PR DESCRIPTION
This makes it part of the template instantiation and requires the compiler / linker to de-duplicate it.