### PR TITLE
Fix invalid preprocessor command 'warning' on Windows

### DIFF
--- a/config/RConfigure.in
+++ b/config/RConfigure.in
@@ -24,7 +24,11 @@
 
 #define ROOT__cplusplus @__cplusplus@
 #if defined(__cplusplus) && (__cplusplus != ROOT__cplusplus)
-# warning "The C++ standard in this build does not match ROOT configuration (@__cplusplus@); this might cause unexpected issues"
+# if defined(_MSC_VER)
+#  pragma message("The C++ standard in this build does not match ROOT configuration (@__cplusplus@); this might cause unexpected issues. And please make sure you are using the -Zc:__cplusplus compilation flag")
+# else
+#  warning "The C++ standard in this build does not match ROOT configuration (@__cplusplus@); this might cause unexpected issues"
+# endif
 #endif
 
 #@setresuid@ R__HAS_SETRESUID   /**/


### PR DESCRIPTION
Fix the following error when compiling code using ROOT on Windows with the wrong `-std:c++` version or without the the `-Zc:__cplusplus` compilation flag:
```
RConfigure.h(27): fatal error C1021: invalid preprocessor command 'warning'
```
