### PR TITLE
Improve RBrowser cleanup

### DIFF
--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -79,7 +79,11 @@ public:
    /** Access object */
    virtual std::unique_ptr<RHolder> GetObject() { return nullptr; }
 
+   /** Check if element contains provided pointer */
    virtual bool IsObject(void *) { return false; }
+
+   /** Check if element still contains valid content */
+   virtual bool CheckValid() { return true; }
 
    /** Get default action */
    virtual EActionKind GetDefaultAction() const { return kActNone; }

--- a/gui/browsable/inc/ROOT/Browsable/RElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/RElement.hxx
@@ -79,6 +79,8 @@ public:
    /** Access object */
    virtual std::unique_ptr<RHolder> GetObject() { return nullptr; }
 
+   virtual bool IsObject(void *) { return false; }
+
    /** Get default action */
    virtual EActionKind GetDefaultAction() const { return kActNone; }
 

--- a/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
+++ b/gui/browsable/inc/ROOT/Browsable/TObjectElement.hxx
@@ -64,6 +64,8 @@ public:
    /** Return copy of TObject holder - if possible */
    std::unique_ptr<RHolder> GetObject() override;
 
+   bool IsObject(void *) override;
+
    const TClass *GetClass() const;
 
    EActionKind GetDefaultAction() const override;

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -301,6 +301,10 @@ public:
       return std::make_unique<RAnyObjectHolder>(obj_class, obj, true);
    }
 
+   bool IsObject(void *obj) override
+   {
+      return obj == fDir;
+   }
 
    EActionKind GetDefaultAction() const override
    {
@@ -421,6 +425,11 @@ public:
       auto dir = GetDir();
 
       return dir ? std::make_unique<TDirectoryLevelIter>(dir) : nullptr;
+   }
+
+   bool IsObject(void *obj) override
+   {
+      return obj == fDir;
    }
 
    /** Get default action - browsing for the TFile/TDirectory*/

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -447,30 +447,6 @@ public:
 
 };
 
-
-class TObjectIndDirElement : public TObjectElement {
-protected:
-   TDirectory   *fDir{nullptr};
-
-   bool CheckObject() const override
-   {
-      if (!fDir || !fObj)
-        return false;
-
-      if (!fDir->IsZombie() || !fDir->FindObject(fObj)) {
-         auto self = const_cast<TObjectIndDirElement *>(this);
-         self->fDir = nullptr;
-         self->fObj = nullptr;
-         self->fObject.reset();
-         return false;
-      }
-      return true;
-   }
-
-public:
-   TObjectIndDirElement(TDirectory *dir, TObject *obj) : TObjectElement(obj), fDir(dir) {}
-};
-
 // ==============================================================================================
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -504,7 +480,6 @@ std::shared_ptr<RElement> TDirectoryLevelIter::GetElement()
 Provides access to ROOT files with extension "root"
 Other extensions can be registered
 */
-
 
 class RTFileProvider : public RProvider {
 

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -299,7 +299,7 @@ TObjectElement::TObjectElement(std::unique_ptr<RHolder> &obj, const std::string 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Check if object still exsists
+/// Check if object still exists
 
 bool TObjectElement::CheckObject() const
 {
@@ -356,7 +356,7 @@ std::unique_ptr<RLevelIter> TObjectElement::GetChildsIter()
 
    auto dupl = imp->IsDuplicated();
 
-   delete br; // also will destroy implementaion
+   delete br; // also will destroy implementation
 
    if (dupl || (iter->NumElements() == 0)) return nullptr;
 
@@ -375,13 +375,20 @@ std::unique_ptr<RHolder> TObjectElement::GetObject()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Returns true if holding specified object
+
+bool TObjectElement::IsObject(void *obj)
+{
+   return fObject && (fObject->get_object<TObject>() == obj);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Returns class for contained object
 
 const TClass *TObjectElement::GetClass() const
 {
    return CheckObject() ? fObj->IsA() : nullptr;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Provides default action which can be performed with the object

--- a/gui/browserv7/inc/ROOT/RBrowserData.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowserData.hxx
@@ -30,8 +30,11 @@ class RLogChannel;
 /// Log channel for Browser diagnostics.
 RLogChannel &BrowserLog();
 
+class RBrowserDataCleanup;
 
 class RBrowserData {
+
+   friend class RBrowserDataCleanup;
 
    std::shared_ptr<Browsable::RElement> fTopElement;    ///<! top element
 
@@ -46,17 +49,18 @@ class RBrowserData {
    std::vector<const Browsable::RItem *> fLastSortedItems;   ///<! sorted child items, used in requests
    std::string fLastSortMethod;                          ///<! last sort method
    bool fLastSortReverse{false};                         ///<! last request reverse order
+   std::unique_ptr<RBrowserDataCleanup> fCleanupHandle;  ///<! cleanup handle for RecursiveRemove
 
    void ResetLastRequestData(bool with_element);
 
    bool ProcessBrowserRequest(const RBrowserRequest &request, RBrowserReply &reply);
 
 public:
-   RBrowserData() = default;
+   RBrowserData();
 
-   RBrowserData(std::shared_ptr<Browsable::RElement> elem) { SetTopElement(elem); }
+   RBrowserData(std::shared_ptr<Browsable::RElement> elem) : RBrowserData()  { SetTopElement(elem); }
 
-   virtual ~RBrowserData() = default;
+   virtual ~RBrowserData();
 
    void SetTopElement(std::shared_ptr<Browsable::RElement> elem);
 
@@ -75,6 +79,11 @@ public:
    std::shared_ptr<Browsable::RElement> GetSubElement(const Browsable::RElementPath_t &path);
 
    void ClearCache();
+
+   bool RemoveFromCache(void *obj);
+
+   bool RemoveFromCache(const Browsable::RElementPath_t &path);
+
 };
 
 

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -68,6 +68,7 @@ public:
 RBrowserData::RBrowserData()
 {
    fCleanupHandle = std::make_unique<RBrowserDataCleanup>(*this);
+   R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfCleanups()->Add(fCleanupHandle.get());
 }
 
@@ -77,6 +78,7 @@ RBrowserData::RBrowserData()
 RBrowserData::~RBrowserData()
 {
    // should be here because of fCleanupHandle destructor
+   R__LOCKGUARD(gROOTMutex);
    gROOT->GetListOfCleanups()->Remove(fCleanupHandle.get());
 }
 

--- a/gui/browserv7/src/RBrowserData.cxx
+++ b/gui/browserv7/src/RBrowserData.cxx
@@ -310,6 +310,9 @@ std::shared_ptr<Browsable::RElement> RBrowserData::GetSubElement(const Browsable
    if (path.empty())
       return fTopElement;
 
+   // validate cache - removes no longer actual elements
+   RemoveFromCache(nullptr);
+
    // first check direct match in cache
    for (auto &entry : fCache)
       if (entry.first == path)
@@ -371,6 +374,7 @@ void RBrowserData::ClearCache()
 
 /////////////////////////////////////////////////////////////////////////
 /// Remove object from cache
+/// If nullptr specified - removes no-longer-valid elements
 /// Returns true if any element was removed
 
 bool RBrowserData::RemoveFromCache(void *obj)
@@ -380,7 +384,7 @@ bool RBrowserData::RemoveFromCache(void *obj)
    bool isany = false;
 
    while (pos < fCache.size()) {
-      if (!fCache[pos].second->IsObject(obj)) {
+      if (obj ? !fCache[pos].second->IsObject(obj) : fCache[pos].second->CheckValid()) {
          pos++;
          continue;
       }

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -101,6 +101,9 @@ public:
       fCanvas->SetCanvasImp(fWebCanvas);
       SetPrivateCanvasFields(true);
       fCanvas->cd();
+
+      R__LOCKGUARD(gROOTMutex);
+      gROOT->GetListOfCleanups()->Add(fCanvas.get());
    }
 
    RBrowserTCanvasWidget(const std::string &name, std::unique_ptr<TCanvas> &canv) : RBrowserWidget(name)
@@ -117,10 +120,18 @@ public:
       fCanvas->SetCanvasImp(fWebCanvas);
       SetPrivateCanvasFields(true);
       fCanvas->cd();
+
+      R__LOCKGUARD(gROOTMutex);
+      gROOT->GetListOfCleanups()->Add(fCanvas.get());
    }
 
    virtual ~RBrowserTCanvasWidget()
    {
+      {
+         R__LOCKGUARD(gROOTMutex);
+         gROOT->GetListOfCleanups()->Remove(fCanvas.get());
+      }
+
       SetPrivateCanvasFields(false);
 
       gROOT->GetListOfCanvases()->Remove(fCanvas.get());

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = "dev";
 
 /** @summary version date
   * @desc Release date in format day/month/year like "19/11/2021" */
-let version_date = "24/05/2022";
+let version_date = "31/05/2022";
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -64677,9 +64677,7 @@ class TH1Painter$2 extends THistPainter {
             yerr1 = yerr2 = 20;
          }
          return true;
-      };
-
-      let draw_errbin = () => {
+      }, draw_errbin = () => {
          let edx = 5;
          if (this.options.errorX > 0) {
             edx = Math.round((mx2-mx1)*this.options.errorX);
@@ -64696,9 +64694,7 @@ class TH1Painter$2 extends THistPainter {
             path_err += `M${midx},${my-yerr1+dend}v${yerr1+yerr2-2*dend}`;
          if (hints_err !== null)
             hints_err += `M${midx-edx},${my-yerr1}h${2*edx}v${yerr1+yerr2}h${-2*edx}z`;
-      };
-
-      const draw_bin = bin => {
+      }, draw_bin = bin => {
          if (extract_bin(bin)) {
             if (show_text) {
                let cont = text_profile ? histo.fBinEntries[bin+1] : bincont;
@@ -64714,7 +64710,7 @@ class TH1Painter$2 extends THistPainter {
             }
 
             if (show_line && (path_line !== null))
-               path_line += ((path_line.length===0) ? "M" : "L") + midx + "," + my;
+               path_line += ((path_line.length===0) ? "M" : "L") + `${midx},${my}`;
 
             if (draw_markers) {
                if ((my >= -yerr1) && (my <= height + yerr2)) {
@@ -65442,9 +65438,9 @@ class TH2Painter$2 extends THistPainter {
          // this is when projection should be created on the server side
          let exec = "EXECANDSEND:D" + this.is_projection + "PROJ:" + this.snapid + ":";
          if (this.is_projection == "X")
-            exec += 'ProjectionX("_projx",' + (jj1+1) + ',' + jj2 + ',"")';
+            exec += `ProjectionX("_projx",${jj1+1},${jj2},"")`;
          else
-            exec += 'ProjectionY("_projy",' + (ii1+1) + ',' + ii2 + ',"")';
+            exec += `ProjectionY("_projy",${ii1+1},${ii2},"")`;
          canp.sendWebsocket(exec);
          return;
       }
@@ -66200,7 +66196,7 @@ class TH2Painter$2 extends THistPainter {
           palette = this.getHistPalette(),
           func = main.getProjectionFunc();
 
-      const BuildPath = (xp,yp,iminus,iplus,do_close) => {
+      const buildPath = (xp,yp,iminus,iplus,do_close) => {
          let cmd = "", lastx, lasty, x0, y0, isany = false, matched, x, y;
          for (let i = iminus; i <= iplus; ++i) {
             if (func) {
@@ -66264,11 +66260,11 @@ class TH2Painter$2 extends THistPainter {
           t = t_numer / denom;
           return { x: Math.round(segm1.x1 + (t * s10_x)), y: Math.round(segm1.y1 + (t * s10_y)) };
 
-      }, BuildPathOutside = (xp,yp,iminus,iplus,side) => {
+      }, buildPathOutside = (xp,yp,iminus,iplus,side) => {
 
          // try to build path which fills area to outside borders
 
-         const points = [{ x: 0, y: 0 }, { x: frame_w, y: 0 }, { x: frame_w, y: frame_h }, { x: 0, y: frame_h }];
+         const points = [{x: 0, y: 0}, {x: frame_w, y: 0}, {x: frame_w, y: frame_h}, {x: 0, y: frame_h}];
 
          const get_intersect = (i,di) => {
             let segm = { x1: xp[i], y1: yp[i], x2: 2*xp[i] - xp[i+di], y2: 2*yp[i] - yp[i+di] };
@@ -66293,7 +66289,7 @@ class TH2Painter$2 extends THistPainter {
 
          // TODO: now side is always same direction, could be that side should be checked more precise
 
-         let dd = BuildPath(xp,yp,iminus,iplus),
+         let dd = buildPath(xp,yp,iminus,iplus),
              indx = pnt2.indx, step = side*0.5;
 
          dd += `L${pnt2.x},${pnt2.y}`;
@@ -66317,7 +66313,7 @@ class TH2Painter$2 extends THistPainter {
                xd[i+sz] = handle.origx[handle.i2];
                yd[i+sz] = (handle.origy[handle.j2]*(i+0.5) + handle.origy[handle.j1]*(sz-0.5-i))/sz;
             }
-            dd = BuildPath(xd,yd,0,2*sz-1, true);
+            dd = buildPath(xd,yd,0,2*sz-1, true);
          }
 
          this.draw_g
@@ -66337,16 +66333,16 @@ class TH2Painter$2 extends THistPainter {
             case 13: fillcolor = 'none'; lineatt = this.lineatt; break;
          }
 
-         let dd = BuildPath(xp, yp, iminus, iplus, fillcolor != 'none');
+         let dd = buildPath(xp, yp, iminus, iplus, fillcolor != 'none');
          if (dd == "<failed>")
-            dd = BuildPathOutside(xp, yp, iminus, iplus, 1);
+            dd = buildPathOutside(xp, yp, iminus, iplus, 1);
          if (!dd) return;
 
          let elem = this.draw_g
-                       .append("svg:path")
-                       .attr("class","th2_contour")
-                       .attr("d", dd)
-                       .style("fill", fillcolor);
+                        .append("svg:path")
+                        .attr("class","th2_contour")
+                        .attr("d", dd)
+                        .style("fill", fillcolor);
 
          if (lineatt)
             elem.call(lineatt.func);
@@ -66382,7 +66378,7 @@ class TH2Painter$2 extends THistPainter {
       };
 
       for (ngr = 0; ngr < ngraphs; ++ ngr) {
-         if (!gr || (ngr>0)) gr = bin.fPoly.fGraphs.arr[ngr];
+         if (!gr || (ngr > 0)) gr = bin.fPoly.fGraphs.arr[ngr];
 
          const x = gr.fX, y = gr.fY;
          let n, nextx, nexty, npnts = gr.fNpoints, dx, dy,
@@ -66532,7 +66528,7 @@ class TH2Painter$2 extends THistPainter {
           rotate = -1*this.options.TextAngle,
           draw_g = this.draw_g.append("svg:g").attr("class","th2_text"),
           text_size = 20, text_offset = 0,
-          profile2d = this.matchObjectType('TProfile2D') && (typeof histo.getBinEntries=='function'),
+          profile2d = this.matchObjectType('TProfile2D') && (typeof histo.getBinEntries == 'function'),
           show_err = (this.options.TextKind == "E"),
           latex = (show_err && !this.options.TextLine) ? 1 : 0;
 
@@ -66607,20 +66603,19 @@ class TH2Painter$2 extends THistPainter {
          for (i = handle.i1; i < handle.i2; ++i)
             for (j = handle.j1; j < handle.j2; ++j) {
 
-               if (i === handle.i1) {
+               if (i === handle.i1)
                   dx = histo.getBinContent(i+2, j+1) - histo.getBinContent(i+1, j+1);
-               } else if (i === handle.i2-1) {
+               else if (i === handle.i2-1)
                   dx = histo.getBinContent(i+1, j+1) - histo.getBinContent(i, j+1);
-               } else {
+               else
                   dx = 0.5*(histo.getBinContent(i+2, j+1) - histo.getBinContent(i, j+1));
-               }
-               if (j === handle.j1) {
+
+               if (j === handle.j1)
                   dy = histo.getBinContent(i+1, j+2) - histo.getBinContent(i+1, j+1);
-               } else if (j === handle.j2-1) {
+               else if (j === handle.j2-1)
                   dy = histo.getBinContent(i+1, j+1) - histo.getBinContent(i+1, j);
-               } else {
+               else
                   dy = 0.5*(histo.getBinContent(i+1, j+2) - histo.getBinContent(i+1, j));
-               }
 
                if (loop === 0) {
                   dn = Math.max(dn, Math.abs(dx), Math.abs(dy));
@@ -66666,7 +66661,7 @@ class TH2Painter$2 extends THistPainter {
           handle = this.prepareDraw({ rounding: false }),
           main = this.getMainPainter();
 
-      if (main===this) {
+      if (main === this) {
          if (main.maxbin === main.minbin) {
             main.maxbin = main.gmaxbin;
             main.minbin = main.gminbin;
@@ -67024,15 +67019,13 @@ class TH2Painter$2 extends THistPainter {
             lines += make_path(pnt.x1,pnt.y0,'H',pnt.x2);
          else if (isOption(kMedianNotched))
             lines += make_path(x1d,pnt.y0,'H',x2d);
-         else if (isOption(kMedianCircle)) {
+         else if (isOption(kMedianCircle))
             make_cmarker(center, pnt.y0);
-         }
 
-         if (isOption(kMeanCircle)) {
+         if (isOption(kMeanCircle))
             make_cmarker(center, y0m);
-         } else if (isOption(kMeanLine)) {
+         else if (isOption(kMeanLine))
             dashed_lines += make_path(pnt.x1,y0m,'H',pnt.x2);
-         }
 
          if (isOption(kBox))
             if (isOption(kMedianNotched))
@@ -67261,8 +67254,8 @@ class TH2Painter$2 extends THistPainter {
       // limit filling factor, do not try to produce as many points as filled area;
       if (this.maxbin > 0.7) factor = 0.7/this.maxbin;
 
-      let nlevels = Math.round(handle.max - handle.min);
-      let cntr = this.createContour((nlevels > 50) ? 50 : nlevels, this.minposbin, this.maxbin, this.minposbin);
+      let nlevels = Math.round(handle.max - handle.min),
+          cntr = this.createContour((nlevels > 50) ? 50 : nlevels, this.minposbin, this.maxbin, this.minposbin);
 
       // now start build
       for (i = handle.i1; i < handle.i2; ++i) {
@@ -75310,8 +75303,8 @@ class HierarchyPainter extends BasePainter {
       menu.add("Save settings", () => {
          let promise = readSettings(true) ? Promise.resolve(true) : menu.confirm("Save settings", "Pressing OK one agreess that JSROOT will store settings as browser cookies");
          promise.then(res => { if (res) { saveSettings(); saveStyle(); } });
-      });
-      menu.add("Delete settings", () => { saveSettings(-1); saveStyle(-1); });
+      }, "Store settings and gStyle as cookies");
+      menu.add("Delete settings", () => { saveSettings(-1); saveStyle(-1); }, "Delete settings and gStyle from cookies");
 
       if (!alone) menu.add("endsub:");
    }

--- a/js/changes.md
+++ b/js/changes.md
@@ -2,7 +2,7 @@
 
 ## Changes in dev
 1. Let change `settings` and `gStyle` parameters via "Settings" menu of the top hierarchy item
-2. Settings and gStyle can be stored as cookies, automatically read with every next load of website
+2. Settings and gStyle can be stored as cookies, automatically read when loading webpage with jsroot
 3. `settings.OnlyLastCycle` defines if only last object version show in TFile (also as `&lastcycle` URL parameter)
 4. `settings.DarkMode` configures dark mode for GUI and drawings (also as `&dark` URL parameter)
 5. Support new `TGraph2DAsymmErrors` class
@@ -13,7 +13,6 @@
 
 
 ## Changes in 7.0.1
-
 1. Fix problem with irregular axis labels
 2. Correctly scale and tilt large number of axes labels
 

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = "dev";
 
 /** @summary version date
   * @desc Release date in format day/month/year like "19/11/2021" */
-let version_date = "24/05/2022";
+let version_date = "31/05/2022";
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gui/HierarchyPainter.mjs
+++ b/js/modules/gui/HierarchyPainter.mjs
@@ -1951,8 +1951,8 @@ class HierarchyPainter extends BasePainter {
       menu.add("Save settings", () => {
          let promise = readSettings(true) ? Promise.resolve(true) : menu.confirm("Save settings", "Pressing OK one agreess that JSROOT will store settings as browser cookies");
          promise.then(res => { if (res) { saveSettings(); saveStyle(); } });
-      });
-      menu.add("Delete settings", () => { saveSettings(-1); saveStyle(-1); });
+      }, "Store settings and gStyle as cookies");
+      menu.add("Delete settings", () => { saveSettings(-1); saveStyle(-1); }, "Delete settings and gStyle from cookies");
 
       if (!alone) menu.add("endsub:");
    }

--- a/js/modules/hist2d/TH1Painter.mjs
+++ b/js/modules/hist2d/TH1Painter.mjs
@@ -525,9 +525,7 @@ class TH1Painter extends THistPainter {
             yerr1 = yerr2 = 20;
          }
          return true;
-      };
-
-      let draw_errbin = () => {
+      }, draw_errbin = () => {
          let edx = 5;
          if (this.options.errorX > 0) {
             edx = Math.round((mx2-mx1)*this.options.errorX);
@@ -544,9 +542,7 @@ class TH1Painter extends THistPainter {
             path_err += `M${midx},${my-yerr1+dend}v${yerr1+yerr2-2*dend}`;
          if (hints_err !== null)
             hints_err += `M${midx-edx},${my-yerr1}h${2*edx}v${yerr1+yerr2}h${-2*edx}z`;
-      };
-
-      const draw_bin = bin => {
+      }, draw_bin = bin => {
          if (extract_bin(bin)) {
             if (show_text) {
                let cont = text_profile ? histo.fBinEntries[bin+1] : bincont;
@@ -562,7 +558,7 @@ class TH1Painter extends THistPainter {
             }
 
             if (show_line && (path_line !== null))
-               path_line += ((path_line.length===0) ? "M" : "L") + midx + "," + my;
+               path_line += ((path_line.length===0) ? "M" : "L") + `${midx},${my}`;
 
             if (draw_markers) {
                if ((my >= -yerr1) && (my <= height + yerr2)) {

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -81,9 +81,9 @@ class TH2Painter extends THistPainter {
          // this is when projection should be created on the server side
          let exec = "EXECANDSEND:D" + this.is_projection + "PROJ:" + this.snapid + ":";
          if (this.is_projection == "X")
-            exec += 'ProjectionX("_projx",' + (jj1+1) + ',' + jj2 + ',"")';
+            exec += `ProjectionX("_projx",${jj1+1},${jj2},"")`;
          else
-            exec += 'ProjectionY("_projy",' + (ii1+1) + ',' + ii2 + ',"")';
+            exec += `ProjectionY("_projy",${ii1+1},${ii2},"")`;
          canp.sendWebsocket(exec);
          return;
       }
@@ -841,7 +841,7 @@ class TH2Painter extends THistPainter {
           palette = this.getHistPalette(),
           func = main.getProjectionFunc();
 
-      const BuildPath = (xp,yp,iminus,iplus,do_close) => {
+      const buildPath = (xp,yp,iminus,iplus,do_close) => {
          let cmd = "", lastx, lasty, x0, y0, isany = false, matched, x, y;
          for (let i = iminus; i <= iplus; ++i) {
             if (func) {
@@ -905,11 +905,11 @@ class TH2Painter extends THistPainter {
           t = t_numer / denom;
           return { x: Math.round(segm1.x1 + (t * s10_x)), y: Math.round(segm1.y1 + (t * s10_y)) };
 
-      }, BuildPathOutside = (xp,yp,iminus,iplus,side) => {
+      }, buildPathOutside = (xp,yp,iminus,iplus,side) => {
 
          // try to build path which fills area to outside borders
 
-         const points = [{ x: 0, y: 0 }, { x: frame_w, y: 0 }, { x: frame_w, y: frame_h }, { x: 0, y: frame_h }];
+         const points = [{x: 0, y: 0}, {x: frame_w, y: 0}, {x: frame_w, y: frame_h}, {x: 0, y: frame_h}];
 
          const get_intersect = (i,di) => {
             let segm = { x1: xp[i], y1: yp[i], x2: 2*xp[i] - xp[i+di], y2: 2*yp[i] - yp[i+di] };
@@ -934,7 +934,7 @@ class TH2Painter extends THistPainter {
 
          // TODO: now side is always same direction, could be that side should be checked more precise
 
-         let dd = BuildPath(xp,yp,iminus,iplus),
+         let dd = buildPath(xp,yp,iminus,iplus),
              indx = pnt2.indx, step = side*0.5;
 
          dd += `L${pnt2.x},${pnt2.y}`;
@@ -958,7 +958,7 @@ class TH2Painter extends THistPainter {
                xd[i+sz] = handle.origx[handle.i2];
                yd[i+sz] = (handle.origy[handle.j2]*(i+0.5) + handle.origy[handle.j1]*(sz-0.5-i))/sz;
             }
-            dd = BuildPath(xd,yd,0,2*sz-1, true);
+            dd = buildPath(xd,yd,0,2*sz-1, true);
          }
 
          this.draw_g
@@ -979,16 +979,16 @@ class TH2Painter extends THistPainter {
             case 14: break;
          }
 
-         let dd = BuildPath(xp, yp, iminus, iplus, fillcolor != 'none');
+         let dd = buildPath(xp, yp, iminus, iplus, fillcolor != 'none');
          if (dd == "<failed>")
-            dd = BuildPathOutside(xp, yp, iminus, iplus, 1);
+            dd = buildPathOutside(xp, yp, iminus, iplus, 1);
          if (!dd) return;
 
          let elem = this.draw_g
-                       .append("svg:path")
-                       .attr("class","th2_contour")
-                       .attr("d", dd)
-                       .style("fill", fillcolor);
+                        .append("svg:path")
+                        .attr("class","th2_contour")
+                        .attr("d", dd)
+                        .style("fill", fillcolor);
 
          if (lineatt)
             elem.call(lineatt.func);
@@ -1024,7 +1024,7 @@ class TH2Painter extends THistPainter {
       };
 
       for (ngr = 0; ngr < ngraphs; ++ ngr) {
-         if (!gr || (ngr>0)) gr = bin.fPoly.fGraphs.arr[ngr];
+         if (!gr || (ngr > 0)) gr = bin.fPoly.fGraphs.arr[ngr];
 
          const x = gr.fX, y = gr.fY;
          let n, nextx, nexty, npnts = gr.fNpoints, dx, dy,
@@ -1174,7 +1174,7 @@ class TH2Painter extends THistPainter {
           rotate = -1*this.options.TextAngle,
           draw_g = this.draw_g.append("svg:g").attr("class","th2_text"),
           text_size = 20, text_offset = 0,
-          profile2d = this.matchObjectType('TProfile2D') && (typeof histo.getBinEntries=='function'),
+          profile2d = this.matchObjectType('TProfile2D') && (typeof histo.getBinEntries == 'function'),
           show_err = (this.options.TextKind == "E"),
           latex = (show_err && !this.options.TextLine) ? 1 : 0;
 
@@ -1249,20 +1249,19 @@ class TH2Painter extends THistPainter {
          for (i = handle.i1; i < handle.i2; ++i)
             for (j = handle.j1; j < handle.j2; ++j) {
 
-               if (i === handle.i1) {
+               if (i === handle.i1)
                   dx = histo.getBinContent(i+2, j+1) - histo.getBinContent(i+1, j+1);
-               } else if (i === handle.i2-1) {
+               else if (i === handle.i2-1)
                   dx = histo.getBinContent(i+1, j+1) - histo.getBinContent(i, j+1);
-               } else {
+               else
                   dx = 0.5*(histo.getBinContent(i+2, j+1) - histo.getBinContent(i, j+1));
-               }
-               if (j === handle.j1) {
+
+               if (j === handle.j1)
                   dy = histo.getBinContent(i+1, j+2) - histo.getBinContent(i+1, j+1);
-               } else if (j === handle.j2-1) {
+               else if (j === handle.j2-1)
                   dy = histo.getBinContent(i+1, j+1) - histo.getBinContent(i+1, j);
-               } else {
+               else
                   dy = 0.5*(histo.getBinContent(i+1, j+2) - histo.getBinContent(i+1, j));
-               }
 
                if (loop === 0) {
                   dn = Math.max(dn, Math.abs(dx), Math.abs(dy));
@@ -1308,7 +1307,7 @@ class TH2Painter extends THistPainter {
           handle = this.prepareDraw({ rounding: false }),
           main = this.getMainPainter();
 
-      if (main===this) {
+      if (main === this) {
          if (main.maxbin === main.minbin) {
             main.maxbin = main.gmaxbin;
             main.minbin = main.gminbin;
@@ -1666,15 +1665,13 @@ class TH2Painter extends THistPainter {
             lines += make_path(pnt.x1,pnt.y0,'H',pnt.x2);
          else if (isOption(kMedianNotched))
             lines += make_path(x1d,pnt.y0,'H',x2d);
-         else if (isOption(kMedianCircle)) {
+         else if (isOption(kMedianCircle))
             make_cmarker(center, pnt.y0);
-         }
 
-         if (isOption(kMeanCircle)) {
+         if (isOption(kMeanCircle))
             make_cmarker(center, y0m);
-         } else if (isOption(kMeanLine)) {
+         else if (isOption(kMeanLine))
             dashed_lines += make_path(pnt.x1,y0m,'H',pnt.x2);
-         }
 
          if (isOption(kBox))
             if (isOption(kMedianNotched))
@@ -1903,8 +1900,8 @@ class TH2Painter extends THistPainter {
       // limit filling factor, do not try to produce as many points as filled area;
       if (this.maxbin > 0.7) factor = 0.7/this.maxbin;
 
-      let nlevels = Math.round(handle.max - handle.min);
-      let cntr = this.createContour((nlevels > 50) ? 50 : nlevels, this.minposbin, this.maxbin, this.minposbin);
+      let nlevels = Math.round(handle.max - handle.min),
+          cntr = this.createContour((nlevels > 50) ? 50 : nlevels, this.minposbin, this.maxbin, this.minposbin);
 
       // now start build
       for (i = handle.i1; i < handle.i2; ++i) {


### PR DESCRIPTION
Include `RBrowserData` and created `TCanvas` into `gROOT` list of cleanups

In case if any object is deleted, check if it also appears in list
of cached object in RBrowserData. Tries to catch situation when 
closing TFile let objects like histograms disappear.

Also special handling of TFile which do not automatically has cleanup bit set and
therefore can be deleted without any notice for RBrowser

Update jsroot