### PR TITLE
Improve TGraph2D limits computation

### DIFF
--- a/hist/hist/inc/TGraph2D.h
+++ b/hist/hist/inc/TGraph2D.h
@@ -152,7 +152,7 @@ public:
    virtual void          Scale(Double_t c1=1., Option_t *option="z"); // *MENU*
    virtual void          Set(Int_t n);
    virtual void          SetDirectory(TDirectory *dir);
-   virtual void          SetHistogram(TH2 *h);
+   virtual void          SetHistogram(TH2 *h, Option_t *option="");
    void                  SetMargin(Double_t m=0.1); // *MENU*
    void                  SetMarginBinsContent(Double_t z=0.); // *MENU*
    void                  SetMaximum(Double_t maximum=-1111); // *MENU*

--- a/hist/hist/src/TGraph2D.cxx
+++ b/hist/hist/src/TGraph2D.cxx
@@ -1534,14 +1534,21 @@ void TGraph2D::SetDirectory(TDirectory *dir)
 /// 5. Call h->SetDirectory(0)
 /// 6. Call g->SetHistogram(h) again
 /// 7. Carry on as normal
+///
+/// By default use the new interpolation routine based on Triangles
+/// If the option "old" the old interpolation is used
 
-void TGraph2D::SetHistogram(TH2 *h)
+void TGraph2D::SetHistogram(TH2 *h, Option_t *option)
 {
+   TString opt = option;
+   opt.ToLower();
+   Bool_t oldInterp = opt.Contains("old");
+
    fUserHisto = kTRUE;
    fHistogram = (TH2D*)h;
    fNpx       = h->GetNbinsX();
    fNpy       = h->GetNbinsY();
-   CreateInterpolator(kTRUE);
+   CreateInterpolator(oldInterp);
 }
 
 


### PR DESCRIPTION
When TGraph2D points are almost aligned, the computation of the plot limits did not work for example like the one exposed here:
https://root-forum.cern.ch/t/issue-related-to-contour-plots-with-tgraph2d/50153

a reproducer is:
```
void Contour(){
   double x[20] = {300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000, 300, 400};
   double y[20] = {1.00e-07, 2.00e-07, 3.00e-07, 4.00e-07, 5.00e-07, 5.00e-07, 6.00e-07, 7.00e-07, 8.00e-07, 9.00e-07, 5.00e-07, 9.10e-07, 9.20e-07, 9.30e-07, 9.40e-07, 9.50e-07, 9.60e-07, 9.70e-07, 1.00e-06, 2.00e-06};
   double z[20] = {17.7646, 15.2535, 17.7124, 9.47505, 9.16325, 8.72872, 6.42959, 3.16349, 5.01813, 4.37426, 3.21201, 3.60176, 1.77229, 1.80264, 1.38047, 0.816474, 0.801699, 0.385277, 16.3985, 16.0283};
   auto g = new TGraph2D("contour","contour",20,x,y,z);
   g->Draw("cont4 z");
}
```

This PR also allows to define properly the 2D histogram. In the past old interpolator was used by SetHistogram(). Now the default is the new one.
```
void Contour(){
   double x[20] = {300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000, 300, 400};
   double y[20] = {1.00e-07, 2.00e-07, 3.00e-07, 4.00e-07, 5.00e-07, 5.00e-07, 6.00e-07, 7.00e-07, 8.00e-07, 9.00e-07, 5.00e-07, 9.10e-07, 9.20e-07, 9.30e-07, 9.40e-07, 9.50e-07, 9.60e-07, 9.70e-07, 1.00e-06, 2.00e-06};
   double z[20] = {17.7646, 15.2535, 17.7124, 9.47505, 9.16325, 8.72872, 6.42959, 3.16349, 5.01813, 4.37426, 3.21201, 3.60176, 1.77229, 1.80264, 1.38047, 0.816474, 0.801699, 0.385277, 16.3985, 16.0283};
   auto g = new TGraph2D("contour","contour",20,x,y,z);
   auto h = new TH2D("h","h",40,200,3000,40,1.00e-07,1.00e-06);
   g->SetHistogram(h);
   g->Draw("cont4 z");
}

```