### PR TITLE
[code] Add `InvokeResult_t`, use that instead of deprecated `std::result_of` 

### DIFF
--- a/core/base/inc/ROOT/TSequentialExecutor.hxx
+++ b/core/base/inc/ROOT/TSequentialExecutor.hxx
@@ -14,10 +14,10 @@
 #include "ROOT/EExecutionPolicy.hxx"
 #include "ROOT/TExecutorCRTP.hxx"
 #include "ROOT/TSeq.hxx"
+#include "ROOT/TypeTraits.hxx" // InvokeResult_t
 
 #include <initializer_list>
 #include <numeric> //std::accumulate
-#include <type_traits> //std::enable_if, std::result_of
 #include <utility> //std::move
 #include <vector>
 
@@ -25,6 +25,10 @@ namespace ROOT {
 
    class TSequentialExecutor: public TExecutorCRTP<TSequentialExecutor> {
       friend TExecutorCRTP;
+
+      template <typename F, typename... Args>
+      using InvokeResult_t = ROOT::TypeTraits::InvokeResult_t<F, Args...>;
+
    public:
 
       TSequentialExecutor() = default;
@@ -68,13 +72,13 @@ namespace ROOT {
        // Implementation of the Map functions declared in the parent class (TExecutorCRTP)
       //
       template<class F, class Cond = noReferenceCond<F>>
-      auto MapImpl(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
+      auto MapImpl(F func, unsigned nTimes) -> std::vector<InvokeResult_t<F>>;
       template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
-      auto MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
+      auto MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<InvokeResult_t<F, INTEGER>>;
       template<class F, class T, class Cond = noReferenceCond<F, T>>
-      auto MapImpl(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+      auto MapImpl(F func, std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>;
       template<class F, class T, class Cond = noReferenceCond<F, T>>
-      auto MapImpl(F func, const std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+      auto MapImpl(F func, const std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>;
    };
 
    /************ TEMPLATE METHODS IMPLEMENTATION ******************/
@@ -140,7 +144,7 @@ namespace ROOT {
    ///
    /// \copydetails TExecutorCRTP::Map(F func,unsigned nTimes)
    template<class F, class Cond>
-   auto TSequentialExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type> {
+   auto TSequentialExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<InvokeResult_t<F>> {
       using retType = decltype(func());
       std::vector<retType> reslist;
       reslist.reserve(nTimes);
@@ -156,7 +160,7 @@ namespace ROOT {
    ///
    /// \copydetails TExecutorCRTP::Map(F func,ROOT::TSeq<INTEGER> args)
    template<class F, class INTEGER, class Cond>
-   auto TSequentialExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
+   auto TSequentialExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<InvokeResult_t<F, INTEGER>> {
       using retType = decltype(func(*args.begin()));
       std::vector<retType> reslist;
       reslist.reserve(args.size());
@@ -171,7 +175,7 @@ namespace ROOT {
    ///
    /// \copydetails TExecutorCRTP::Map(F func,std::vector<T> &args)
    template<class F, class T, class Cond>
-   auto TSequentialExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type> {
+   auto TSequentialExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>> {
       // //check whether func is callable
       using retType = decltype(func(args.front()));
       std::vector<retType> reslist;
@@ -188,7 +192,7 @@ namespace ROOT {
    ///
    /// \copydetails TExecutorCRTP::Map(F func,const std::vector<T> &args)
    template<class F, class T, class Cond>
-   auto TSequentialExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type> {
+   auto TSequentialExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>> {
       // //check whether func is callable
       using retType = decltype(func(args.front()));
       std::vector<retType> reslist;

--- a/core/foundation/inc/ROOT/RNotFn.hxx
+++ b/core/foundation/inc/ROOT/RNotFn.hxx
@@ -23,6 +23,8 @@
 
 #define R__NOTFN_BACKPORT
 
+#include "ROOT/TypeTraits.hxx" // InvokeInvokeResult_t
+                               //
 #include <type_traits> // std::decay
 #include <utility>     // std::forward, std::declval
 
@@ -39,14 +41,14 @@ public:
    not_fn_t(const not_fn_t &f) = default;
 
    template <class... Args>
-   auto operator()(Args &&... args) & -> decltype(
-      !std::declval<std::result_of_t<std::decay_t<F>(Args...)>>())
+   auto
+   operator()(Args &&...args) & -> decltype(!std::declval<ROOT::TypeTraits::InvokeResult_t<std::decay_t<F>, Args...>>())
    {
       return !fFun(std::forward<Args>(args)...);
    }
    template <class... Args>
-   auto operator()(Args &&... args) const & -> decltype(
-      !std::declval<std::result_of_t<std::decay_t<F> const(Args...)>>())
+   auto operator()(Args &&...args)
+      const & -> decltype(!std::declval<ROOT::TypeTraits::InvokeResult_t<std::decay_t<F> const, Args...>>())
    {
       return !fFun(std::forward<Args>(args)...);
    }

--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -193,6 +193,20 @@ struct HasBeginAndEnd {
    static constexpr bool const value = Check<T>(0);
 };
 
+#ifdef __cpp_lib_is_invocable
+// can use std::invoke_result_t (a C++17 feature)
+#define INVOKE_RESULT(x, ...) std::invoke_result_t<x, __VA_ARGS__>
+#else
+// must use std::result_of_t (e.g. because we are using C++14)
+#define INVOKE_RESULT(x, ...) std::result_of_t<x(__VA_ARGS__)>
+#endif
+
+/// An adapter for std::invoke_result that falls back to std::result_of if the former is not available.
+template <typename F, typename... Args>
+using InvokeResult_t = INVOKE_RESULT(F, Args...);
+
+#undef INVOKE_RESULT
+
 } // ns TypeTraits
 } // ns ROOT
 #endif // ROOT_TTypeTraits

--- a/core/foundation/inc/ROOT/TypeTraits.hxx
+++ b/core/foundation/inc/ROOT/TypeTraits.hxx
@@ -193,19 +193,13 @@ struct HasBeginAndEnd {
    static constexpr bool const value = Check<T>(0);
 };
 
-#ifdef __cpp_lib_is_invocable
-// can use std::invoke_result_t (a C++17 feature)
-#define INVOKE_RESULT(x, ...) std::invoke_result_t<x, __VA_ARGS__>
-#else
-// must use std::result_of_t (e.g. because we are using C++14)
-#define INVOKE_RESULT(x, ...) std::result_of_t<x(__VA_ARGS__)>
-#endif
-
 /// An adapter for std::invoke_result that falls back to std::result_of if the former is not available.
 template <typename F, typename... Args>
-using InvokeResult_t = INVOKE_RESULT(F, Args...);
-
-#undef INVOKE_RESULT
+#ifdef __cpp_lib_is_invocable
+using InvokeResult_t = std::invoke_result_t<F, Args...>;
+#else
+using InvokeResult_t = std::result_of_t<F(Args...)>;
+#endif
 
 } // ns TypeTraits
 } // ns ROOT

--- a/core/imt/inc/ROOT/TExecutor.hxx
+++ b/core/imt/inc/ROOT/TExecutor.hxx
@@ -15,6 +15,7 @@
 #include "ROOT/TExecutorCRTP.hxx"
 #include "ROOT/TSeq.hxx"
 #include "ROOT/TSequentialExecutor.hxx"
+#include "ROOT/TypeTraits.hxx" // InvokeResult_t
 #ifdef R__USE_IMT
 #include "ROOT/TThreadExecutor.hxx"
 #endif
@@ -27,7 +28,7 @@
 #include <initializer_list>
 #include <memory>
 #include <thread>
-#include <type_traits> //std::enable_if, std::result_of
+#include <type_traits> //std::enable_if
 #include <stdexcept> //std::invalid_argument
 #include <utility> //std::move
 
@@ -36,6 +37,10 @@ namespace ROOT{
 namespace Internal{
 class TExecutor: public TExecutorCRTP<TExecutor> {
    friend TExecutorCRTP;
+
+   template <typename F, typename... Args>
+   using InvokeResult_t = ROOT::TypeTraits::InvokeResult_t<F, Args...>;
+
 public:
 
    /// \brief Class constructor. Sets the default execution policy and initializes the corresponding executor.
@@ -64,16 +69,16 @@ public:
    // other than checking that func is compatible with the type of arguments.
    // a static_assert check in TExecutor::Reduce is used to check that redfunc is compatible with the type returned by func
    using TExecutorCRTP<TExecutor>::MapReduce;
-   template<class F, class R, class Cond = noReferenceCond<F>>
-   auto MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> typename std::result_of<F()>::type;
-   template<class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
-   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(INTEGER)>::type;
-   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
-   auto MapReduce(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type;
-   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
-   auto MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type;
-   template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
-   auto MapReduce(F func, const std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type;
+   template <class F, class R, class Cond = noReferenceCond<F>>
+   auto MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> InvokeResult_t<F>;
+   template <class F, class INTEGER, class R, class Cond = noReferenceCond<F, INTEGER>>
+   auto MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, INTEGER>;
+   template <class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto MapReduce(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, T>;
+   template <class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, T>;
+   template <class F, class T, class R, class Cond = noReferenceCond<F, T>>
+   auto MapReduce(F func, const std::vector<T> &args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, T>;
 
    // Reduce
    //
@@ -84,14 +89,14 @@ public:
 private:
    // Implementation of the Map functions declared in the parent class (TExecutorCRTP)
    //
-   template<class F, class Cond = noReferenceCond<F>>
-   auto MapImpl(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
-   template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
-   auto MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
-   template<class F, class T, class Cond = noReferenceCond<F, T>>
-   auto MapImpl(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
-   template<class F, class T, class Cond = noReferenceCond<F, T>>
-   auto MapImpl(F func, const std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+   template <class F, class Cond = noReferenceCond<F>>
+   auto MapImpl(F func, unsigned nTimes) -> std::vector<InvokeResult_t<F>>;
+   template <class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
+   auto MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<InvokeResult_t<F, INTEGER>>;
+   template <class F, class T, class Cond = noReferenceCond<F, T>>
+   auto MapImpl(F func, std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>;
+   template <class F, class T, class Cond = noReferenceCond<F, T>>
+   auto MapImpl(F func, const std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>;
 
    ROOT::EExecutionPolicy fExecPolicy;
 
@@ -120,12 +125,12 @@ private:
    /// necessary to infer the ResolveExecutorAndMap function type
    template<class F, class CONTAINER>
    struct MapRetType {
-      using type = typename std::result_of<F(typename CONTAINER::value_type)>::type;
+      using type = InvokeResult_t<F, typename CONTAINER::value_type>;
    };
 
    template<class F>
    struct MapRetType<F, unsigned> {
-      using type = typename std::result_of<F()>::type;
+      using type = InvokeResult_t<F>;
    };
 
 
@@ -157,8 +162,9 @@ private:
 /// Implementation of the Map method.
 ///
 /// \copydetails TExecutorCRTP::Map(F func,unsigned nTimes)
-template<class F, class Cond>
-auto TExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type> {
+template <class F, class Cond>
+auto TExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<InvokeResult_t<F>>
+{
    return ResolveExecutorAndMap(func, nTimes);
 }
 
@@ -167,8 +173,9 @@ auto TExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<typename std::re
 /// Implementation of the Map method.
 ///
 /// \copydetails TExecutorCRTP::Map(F func,ROOT::TSeq<INTEGER> args)
-template<class F, class INTEGER, class Cond>
-auto TExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type> {
+template <class F, class INTEGER, class Cond>
+auto TExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<InvokeResult_t<F, INTEGER>>
+{
    return ResolveExecutorAndMap(func, args);
 }
 
@@ -177,8 +184,9 @@ auto TExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typenam
 /// Implementation of the Map method.
 ///
 /// \copydetails TExecutorCRTP::Map(F func,std::vector<T> &args)
-template<class F, class T, class Cond>
-auto TExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type> {
+template <class F, class T, class Cond>
+auto TExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>
+{
    return ResolveExecutorAndMap(func, args);
 }
 
@@ -187,8 +195,9 @@ auto TExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<typename st
 /// Implementation of the Map method.
 ///
 /// \copydetails TExecutorCRTP::Map(F func,const std::vector<T> &args)
-template<class F, class T, class Cond>
-auto TExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type> {
+template <class F, class T, class Cond>
+auto TExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>
+{
    return ResolveExecutorAndMap(func, args);
 }
 
@@ -203,8 +212,9 @@ auto TExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<typen
 /// into a final result. Must return the same type as `func`.
 /// \param nChunks Number of chunks to split the input data for processing.
 /// \return A value result of "reducing" the vector returned by the Map operation into a single object.
-template<class F, class R, class Cond>
-auto TExecutor::MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> typename std::result_of<F()>::type {
+template <class F, class R, class Cond>
+auto TExecutor::MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) -> InvokeResult_t<F>
+{
    if (fExecPolicy == ROOT::EExecutionPolicy::kMultiThread) {
       return fThreadExecutor->MapReduce(func, nTimes, redfunc, nChunks);
    }
@@ -222,8 +232,9 @@ auto TExecutor::MapReduce(F func, unsigned nTimes, R redfunc, unsigned nChunks) 
 /// into a final result. Must return the same type as `func`.
 /// \param nChunks Number of chunks to split the input data for processing.
 /// \return A value result of "reducing" the vector returned by the Map operation into a single object.
-template<class F, class INTEGER, class R, class Cond>
-auto TExecutor::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(INTEGER)>::type {
+template <class F, class INTEGER, class R, class Cond>
+auto TExecutor::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, INTEGER>
+{
    if (fExecPolicy == ROOT::EExecutionPolicy::kMultiThread) {
       return fThreadExecutor->MapReduce(func, args, redfunc, nChunks);
    }
@@ -241,8 +252,9 @@ auto TExecutor::MapReduce(F func, ROOT::TSeq<INTEGER> args, R redfunc, unsigned 
 /// into a final result. Must return the same type as `func`.
 /// \param nChunks Number of chunks to split the input data for processing.
 /// \return A value result of "reducing" the vector returned by the Map operation into a single object.
-template<class F, class T, class R, class Cond>
-auto TExecutor::MapReduce(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type {
+template <class F, class T, class R, class Cond>
+auto TExecutor::MapReduce(F func, std::initializer_list<T> args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, T>
+{
    if (fExecPolicy == ROOT::EExecutionPolicy::kMultiThread) {
       return fThreadExecutor->MapReduce(func, args, redfunc, nChunks);
    }
@@ -260,8 +272,9 @@ auto TExecutor::MapReduce(F func, std::initializer_list<T> args, R redfunc, unsi
 /// into a final result. Must return the same type as `func`.
 /// \param nChunks Number of chunks to split the input data for processing.
 /// \return A value result of "reducing" the vector returned by the Map operation into a single object.
-template<class F, class T, class R, class Cond>
-auto TExecutor::MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type {
+template <class F, class T, class R, class Cond>
+auto TExecutor::MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, T>
+{
    if (fExecPolicy == ROOT::EExecutionPolicy::kMultiThread) {
       return fThreadExecutor->MapReduce(func, args, redfunc, nChunks);
    }
@@ -279,8 +292,9 @@ auto TExecutor::MapReduce(F func, std::vector<T> &args, R redfunc, unsigned nChu
 /// into a final result. Must return the same type as `func`.
 /// \param nChunks Number of chunks to split the input data for processing.
 /// \return A value result of "reducing" the vector returned by the Map operation into a single object.
-template<class F, class T, class R, class Cond>
-auto TExecutor::MapReduce(F func, const std::vector<T> &args, R redfunc, unsigned nChunks) -> typename std::result_of<F(T)>::type {
+template <class F, class T, class R, class Cond>
+auto TExecutor::MapReduce(F func, const std::vector<T> &args, R redfunc, unsigned nChunks) -> InvokeResult_t<F, T>
+{
    if (fExecPolicy == ROOT::EExecutionPolicy::kMultiThread) {
       return fThreadExecutor->MapReduce(func, args, redfunc, nChunks);
    }

--- a/core/multiproc/inc/ROOT/TProcessExecutor.hxx
+++ b/core/multiproc/inc/ROOT/TProcessExecutor.hxx
@@ -18,6 +18,7 @@
 #include "PoolUtils.h"
 #include "ROOT/TExecutorCRTP.hxx"
 #include "ROOT/TSeq.hxx"
+#include "ROOT/TypeTraits.hxx"
 #include "TError.h"
 #include "TFileCollection.h"
 #include "TFileInfo.h"
@@ -28,7 +29,6 @@
 #include <algorithm> //std::generate
 #include <numeric> //std::iota
 #include <string>
-#include <type_traits> //std::result_of, std::enable_if
 #include <functional> //std::reference_wrapper
 #include <vector>
 
@@ -36,6 +36,10 @@ namespace ROOT {
 
 class TProcessExecutor : public TExecutorCRTP<TProcessExecutor>, private TMPClient {
    friend TExecutorCRTP;
+
+   template <typename F, typename... Args>
+   using InvokeResult_t = ROOT::TypeTraits::InvokeResult_t<F, Args...>;
+
 public:
    explicit TProcessExecutor(unsigned nWorkers = 0); //default number of workers is the number of processors
    ~TProcessExecutor() = default;
@@ -52,11 +56,11 @@ public:
    // TProcessExecutor's logic
    using TExecutorCRTP<TProcessExecutor>::MapReduce;
    template<class F, class R, class Cond = noReferenceCond<F>>
-   auto MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type;
+   auto MapReduce(F func, unsigned nTimes, R redfunc) -> InvokeResult_t<F>;
    template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
-   auto MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type;
+   auto MapReduce(F func, std::vector<T> &args, R redfunc) -> InvokeResult_t<F, T>;
    template<class F, class T, class R, class Cond = noReferenceCond<F, T>>
-   auto MapReduce(F func, const std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type;
+   auto MapReduce(F func, const std::vector<T> &args, R redfunc) -> InvokeResult_t<F, T>;
 
    // Reduce
    //
@@ -74,13 +78,13 @@ private:
    // Implementation of the Map functions declared in the parent class (TExecutorCRTP)
    //
    template<class F, class Cond = noReferenceCond<F>>
-   auto MapImpl(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>;
+   auto MapImpl(F func, unsigned nTimes) -> std::vector<InvokeResult_t<F>>;
    template<class F, class INTEGER, class Cond = noReferenceCond<F, INTEGER>>
-   auto MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>;
+   auto MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<InvokeResult_t<F, INTEGER>>;
    template<class F, class T, class Cond = noReferenceCond<F, T>>
-   auto MapImpl(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+   auto MapImpl(F func, std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>;
    template<class F, class T, class Cond = noReferenceCond<F, T>>
-   auto MapImpl(F func, const std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>;
+   auto MapImpl(F func, const std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>;
 
    template<class T> void Collect(std::vector<T> &reslist);
    template<class T> void HandlePoolCode(MPCodeBufPair &msg, TSocket *sender, std::vector<T> &reslist);
@@ -115,7 +119,7 @@ private:
 ///
 /// \copydetails TExecutorCRTP::Map(F func,unsigned nTimes)
 template<class F, class Cond>
-auto TProcessExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<typename std::result_of<F()>::type>
+auto TProcessExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<InvokeResult_t<F>>
 {
    using retType = decltype(func());
    //prepare environment
@@ -156,7 +160,7 @@ auto TProcessExecutor::MapImpl(F func, unsigned nTimes) -> std::vector<typename 
 ///
 /// \copydetails TExecutorCRTP::Map(F func,std::vector<T> &args)
 template<class F, class T, class Cond>
-auto TProcessExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>
+auto TProcessExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>
 {
    //check whether func is callable
    using retType = decltype(func(args.front()));
@@ -201,7 +205,7 @@ auto TProcessExecutor::MapImpl(F func, std::vector<T> &args) -> std::vector<type
 ///
 /// \copydetails TExecutorCRTP::Map(F func,const std::vector<T> &args)
 template<class F, class T, class Cond>
-auto TProcessExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<typename std::result_of<F(T)>::type>
+auto TProcessExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vector<InvokeResult_t<F, T>>
 {
    //check whether func is callable
    using retType = decltype(func(args.front()));
@@ -246,7 +250,7 @@ auto TProcessExecutor::MapImpl(F func, const std::vector<T> &args) -> std::vecto
 ///
 /// \copydetails TExecutorCRTP::Map(F func,ROOT::TSeq<INTEGER> args)
 template<class F, class INTEGER, class Cond>
-auto TProcessExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<typename std::result_of<F(INTEGER)>::type>
+auto TProcessExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<InvokeResult_t<F, INTEGER>>
 {
    std::vector<INTEGER> vargs(args.size());
    std::copy(args.begin(), args.end(), vargs.begin());
@@ -258,7 +262,7 @@ auto TProcessExecutor::MapImpl(F func, ROOT::TSeq<INTEGER> args) -> std::vector<
 /// \brief Execute a function `nTimes` in parallel (Map) and accumulate the results into a single value (Reduce).
 /// \copydetails  ROOT::Internal::TExecutor::MapReduce(F func,unsigned nTimes,R redfunc)
 template<class F, class R, class Cond>
-auto TProcessExecutor::MapReduce(F func, unsigned nTimes, R redfunc) -> typename std::result_of<F()>::type
+auto TProcessExecutor::MapReduce(F func, unsigned nTimes, R redfunc) -> InvokeResult_t<F>
 {
    using retType = decltype(func());
    //prepare environment
@@ -298,7 +302,7 @@ auto TProcessExecutor::MapReduce(F func, unsigned nTimes, R redfunc) -> typename
 ///
 /// \copydetails ROOT::Internal::TExecutor::MapReduce(F func,std::vector<T> &args,R redfunc,unsigned nChunks).
 template<class F, class T, class R, class Cond>
-auto TProcessExecutor::MapReduce(F func, std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type
+auto TProcessExecutor::MapReduce(F func, std::vector<T> &args, R redfunc) -> InvokeResult_t<F, T>
 {
 
    using retType = decltype(func(args.front()));
@@ -340,7 +344,7 @@ auto TProcessExecutor::MapReduce(F func, std::vector<T> &args, R redfunc) -> typ
 ///
 /// \copydetails ROOT::Internal::TExecutor::MapReduce(F func,const std::vector<T> &args,R redfunc,unsigned nChunks).
 template<class F, class T, class R, class Cond>
-auto TProcessExecutor::MapReduce(F func, const std::vector<T> &args, R redfunc) -> typename std::result_of<F(T)>::type
+auto TProcessExecutor::MapReduce(F func, const std::vector<T> &args, R redfunc) -> InvokeResult_t<F, T>
 {
 
    using retType = decltype(func(args.front()));

--- a/core/multiproc/inc/TMPWorker.h
+++ b/core/multiproc/inc/TMPWorker.h
@@ -20,7 +20,6 @@
 #include <memory> //unique_ptr
 #include <string>
 #include <sstream>
-#include <type_traits> //std::result_of
 #include <unistd.h> //pid_t
 
 class TMPWorker {

--- a/tree/treeplayer/inc/TMPWorkerTree.h
+++ b/tree/treeplayer/inc/TMPWorkerTree.h
@@ -12,6 +12,7 @@
 #ifndef ROOT_TMPWorkerTree
 #define ROOT_TMPWorkerTree
 
+#include "ROOT/TypeTraits.hxx" // InvokeResult_t
 #include "TMPWorker.h"
 #include "TFile.h"
 #include "TEntryList.h"
@@ -26,7 +27,7 @@
 #include <memory> //unique_ptr
 #include <string>
 #include <sstream>
-#include <type_traits> //std::result_of
+#include <type_traits> //std::enable_if_t
 #include <unistd.h> //pid_t
 #include <vector>
 
@@ -97,7 +98,7 @@ private:
 
    F  fProcFunc; ///< copy the function to be executed
    /// the results of the executions of fProcFunc merged together
-   std::result_of_t<F(std::reference_wrapper<TTreeReader>)> fReducedResult;
+   ROOT::TypeTraits::InvokeResult_t<F, std::reference_wrapper<TTreeReader>> fReducedResult;
    /// true if fReducedResult can be reduced with a new result, false until we have produced one result
    bool fCanReduce;
 };


### PR DESCRIPTION
`ROOT::TypeTraits::InvokeResult_t` is a wrapper for `std::invoke_result_t` that falls back to
`std::result_of_t` if the former is not available. It is useful as a
C++-standard-agnostic wrapper for this functionality, as
`std::result_of` has been deprecated in C++17 but `std::invoke_result`
is only available since C++17.

I substituted all usages of `std::result_of` in `tree/` and `core/` with usages of `InvokeResult_t`, which removes deprecation warnings when building ROOT with C++17 (esp. with clang) and indirectly provides _a lot_ of test coverage.