### PR TITLE
[cmake] Reset variable in ROOT_FIND_DIRS_WITH_HEADERS

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1166,6 +1166,7 @@ endfunction(ROOT_GENERATE_ROOTMAP)
 #---ROOT_FIND_DIRS_WITH_HEADERS([dir1 dir2 ...] OPTIONS [options])
 #---------------------------------------------------------------------------------------------------
 function(ROOT_FIND_DIRS_WITH_HEADERS result_dirs)
+  set(dirs "")
   if(ARGN)
     set(dirs ${ARGN})
   else()


### PR DESCRIPTION
This makes sure that the list of directories is actually empty in case neither `inc/` nor `v7/inc/` exist, and does not contain left-overs that were stored in this variable in a parent scope.

After this change, `roottest/root/meta/rootcling/module.modulemap` is much shorter and in particular free of non-existent entries complained about by the LLVM 13 upgrade.