### PR TITLE
Add support for profiling/debugging interpreted/JITted code

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -49,6 +49,7 @@
 #include "llvm/Target/TargetOptions.h"
 
 #include <cstdio>
+#include <cstdlib>
 #include <ctime>
 #include <limits>
 #include <memory>
@@ -1322,6 +1323,12 @@ namespace {
     if(COpts.CUDAHost)
       argvCompile.push_back("--cuda-host-only");
 
+#ifdef __linux__
+    // Keep frame pointer to make JIT stack unwinding reliable for profiling
+    if (std::getenv("CLING_PROFILE"))
+      argvCompile.push_back("-fno-omit-frame-pointer");
+#endif
+
     // argv[0] already inserted, get the rest
     argvCompile.insert(argvCompile.end(), argv+1, argv + argc);
 
@@ -1660,7 +1667,10 @@ namespace {
     // adjusted per transaction in IncrementalParser::codeGenTransaction().
     CGOpts.setInlining(CodeGenOptions::NormalInlining);
 
-    // CGOpts.setDebugInfo(clang::CodeGenOptions::FullDebugInfo);
+    // Add debugging info when debugging or profiling
+    if (std::getenv("CLING_DEBUG") || std::getenv("CLING_PROFILE"))
+      CGOpts.setDebugInfo(clang::codegenoptions::FullDebugInfo);
+
     // CGOpts.EmitDeclMetadata = 1; // For unloading, for later
     // aliasing the complete ctor to the base ctor causes the JIT to crash
     CGOpts.CXXCtorDtorAliases = 0;

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -87,6 +87,7 @@ add_cling_library(clingInterpreter OBJECT
   InvocationOptions.cpp
   LookupHelper.cpp
   NullDerefProtectionTransformer.cpp
+  PerfJITEventListener.cpp
   RequiredSymbols.cpp
   Transaction.cpp
   TransactionUnloader.cpp

--- a/interpreter/cling/lib/Interpreter/IncrementalJIT.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalJIT.h
@@ -45,7 +45,8 @@ public:
 private:
   friend class Azog;
 
-  llvm::JITEventListener* m_GDBListener; // owned by llvm::ManagedStaticBase
+  // owned by llvm::ManagedStaticBase
+  std::vector<llvm::JITEventListener*> m_Listeners;
 
   SymbolMapT m_SymbolMap;
 
@@ -53,21 +54,14 @@ private:
   public:
     NotifyObjectLoadedT(IncrementalJIT &jit) : m_JIT(jit) {}
     void operator()(llvm::orc::VModuleKey K,
-                    const llvm::object::ObjectFile &Object,
-                    const llvm::LoadedObjectInfo &/*Info*/) const {
+                    const llvm::object::ObjectFile& Object,
+                    const llvm::RuntimeDyld::LoadedObjectInfo& Info) const {
       m_JIT.m_UnfinalizedSections[K]
         = std::move(m_JIT.m_SectionsAllocatedSinceLastLoad);
       m_JIT.m_SectionsAllocatedSinceLastLoad = SectionAddrSet();
 
-      // FIXME: NotifyObjectEmitted requires a RuntimeDyld::LoadedObjectInfo
-      // object. In order to get it one should call
-      // RTDyld.loadObject(*ObjToLoad->getBinary()) according to r306058.
-      // Moreover this should be done in the finalizer. Currently we are
-      // disabling this since we have globally disabled this functionality in
-      // IncrementalJIT.cpp (m_GDBListener = 0).
-      //
-      // if (auto GDBListener = m_JIT.m_GDBListener)
-      //   GDBListener->NotifyObjectEmitted(*Object->getBinary(), Info);
+      for (auto listener : m_JIT.m_Listeners)
+        listener->notifyObjectLoaded(K, Object, Info);
 
       for (const auto &Symbol: Object.symbols()) {
         auto Flags = Symbol.getFlags();

--- a/interpreter/cling/lib/Interpreter/PerfJITEventListener.cpp
+++ b/interpreter/cling/lib/Interpreter/PerfJITEventListener.cpp
@@ -1,0 +1,129 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author: Guilherme Amadio <amadio@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+//
+// This file implements a JITEventListener object that tells perf about JITted
+// symbols using perf map files (/tmp/perf-%d.map, where %d = pid of process).
+//
+// Documentation for this perf jit interface is available at:
+// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jit-interface.txt
+//
+//------------------------------------------------------------------------------
+
+#ifdef __linux__
+
+#include "llvm/Config/config.h"
+#include "llvm/ExecutionEngine/JITEventListener.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Object/SymbolSize.h"
+#include "llvm/Support/ManagedStatic.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+
+#include <unistd.h>
+
+using namespace llvm;
+using namespace llvm::object;
+
+namespace {
+
+  class PerfJITEventListener : public JITEventListener {
+  public:
+    PerfJITEventListener();
+    ~PerfJITEventListener() {
+      if (m_Perfmap)
+        fclose(m_Perfmap);
+    }
+
+    void notifyObjectLoaded(ObjectKey K, const ObjectFile& Obj,
+                            const RuntimeDyld::LoadedObjectInfo& L) override;
+    void notifyFreeingObject(ObjectKey K) override;
+
+  private:
+    std::mutex m_Mutex;
+    FILE* m_Perfmap;
+  };
+
+  PerfJITEventListener::PerfJITEventListener() {
+    char filename[64];
+    snprintf(filename, 64, "/tmp/perf-%d.map", getpid());
+    m_Perfmap = fopen(filename, "a");
+  }
+
+  void PerfJITEventListener::notifyObjectLoaded(
+      ObjectKey K, const ObjectFile& Obj,
+      const RuntimeDyld::LoadedObjectInfo& L) {
+
+    if (!m_Perfmap)
+      return;
+
+    OwningBinary<ObjectFile> DebugObjOwner = L.getObjectForDebug(Obj);
+    const ObjectFile& DebugObj = *DebugObjOwner.getBinary();
+
+    // For each symbol, we want to check its address and size
+    // if it's a function and write the information to the perf
+    // map file, otherwise we just ignore the symbol and any
+    // related errors. This implementation is adapted from LLVM:
+    // llvm/src/lib/ExecutionEngine/PerfJITEvents/PerfJITEventListener.cpp
+
+    for (const std::pair<SymbolRef, uint64_t>& P :
+         computeSymbolSizes(DebugObj)) {
+      SymbolRef Sym = P.first;
+
+      Expected<SymbolRef::Type> SymTypeOrErr = Sym.getType();
+      if (!SymTypeOrErr) {
+        consumeError(SymTypeOrErr.takeError());
+        continue;
+      }
+
+      SymbolRef::Type SymType = *SymTypeOrErr;
+      if (SymType != SymbolRef::ST_Function)
+        continue;
+
+      Expected<StringRef> Name = Sym.getName();
+      if (!Name) {
+        consumeError(Name.takeError());
+        continue;
+      }
+
+      Expected<uint64_t> AddrOrErr = Sym.getAddress();
+      if (!AddrOrErr) {
+        consumeError(AddrOrErr.takeError());
+        continue;
+      }
+
+      uint64_t address = *AddrOrErr;
+      uint64_t size = P.second;
+
+      if (size == 0)
+        continue;
+
+      std::lock_guard<std::mutex> lock(m_Mutex);
+      fprintf(m_Perfmap, "%" PRIx64 " %" PRIx64 " %s\n", address, size, Name->data());
+    }
+
+    fflush(m_Perfmap);
+  }
+
+  void PerfJITEventListener::notifyFreeingObject(ObjectKey K) {
+    // nothing to be done
+  }
+
+  llvm::ManagedStatic<PerfJITEventListener> PerfListener;
+
+} // end anonymous namespace
+
+namespace cling {
+
+  JITEventListener* createPerfJITEventListener() { return &*PerfListener; }
+
+} // namespace cling
+
+#endif


### PR DESCRIPTION
This commit builds on previous work for getting GDB support for JITted and interpreted code working in cling. It adds a JIT event listener as well to create perf map files to allow profiling of interpreted/JITted code with cling.

The functionality provided is disabled by default. The interface to enable it has been chosen to be via environment variables to allow both interpreted code and code that only links against ROOT to optionally
enable debugging/profiling.

For reference, I am attaching examples using `hsimple.C` tutorial below:

```sh
$ export CLING_DEBUG=1
$ gdb --args bin/root.exe -l tutorials/hsimple.C
GNU gdb (Gentoo 12.1 vanilla) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://bugs.gentoo.org/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from bin/root.exe...
(gdb) break hsimple
Function "hsimple" not defined.
Make breakpoint pending on future shared library load? (y or [n]) y
Breakpoint 1 (hsimple) pending.
(gdb) run
Starting program: /srv/root/src/build/bin/root.exe -l tutorials/hsimple.C
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
[Detaching after vfork from child process 813528]
[Detaching after vfork from child process 813530]
[Detaching after vfork from child process 813533]
[Detaching after vfork from child process 813557]
root [0] 
Processing tutorials/hsimple.C...

Breakpoint 1, hsimple (getFile=0) at tutorials/hsimple.C:36
36	   TString filename = "hsimple.root";
(gdb) bt
#0  hsimple (getFile=0) at tutorials/hsimple.C:36
#1  0x00007ffff7add02b in __cling_Un1Qu30 (vpClingValue=0x7fffffffa390) at input_line_9:2
#2  0x00007ffff2cc087f in cling::IncrementalExecutor::executeWrapper(llvm::StringRef, cling::Value*) const () from /srv/root/src/build/lib/libCling.so
#3  0x00007ffff2c312f0 in cling::Interpreter::RunFunction(clang::FunctionDecl const*, cling::Value*) () from /srv/root/src/build/lib/libCling.so
#4  0x00007ffff2c32e38 in cling::Interpreter::EvaluateInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cling::CompilationOptions, cling::Value*, cling::Transaction**, unsigned long) () from /srv/root/src/build/lib/libCling.so
#5  0x00007ffff2d30967 in cling::MetaSema::actOnxCommand(llvm::StringRef, llvm::StringRef, cling::Value*) () from /srv/root/src/build/lib/libCling.so
#6  0x00007ffff2d3eefb in cling::MetaParser::isXCommand(cling::MetaSema::ActionResult&, cling::Value*) () from /srv/root/src/build/lib/libCling.so
#7  0x00007ffff2d4055e in cling::MetaParser::isCommand(cling::MetaSema::ActionResult&, cling::Value*) () from /srv/root/src/build/lib/libCling.so
#8  0x00007ffff2d2a9d6 in cling::MetaProcessor::process(llvm::StringRef, cling::Interpreter::CompilationResult&, cling::Value*, bool) () from /srv/root/src/build/lib/libCling.so
#9  0x00007ffff2b384ed in HandleInterpreterException(cling::MetaProcessor*, char const*, cling::Interpreter::CompilationResult&, cling::Value*) () from /srv/root/src/build/lib/libCling.so
#10 0x00007ffff2b55671 in TCling::ProcessLine(char const*, TInterpreter::EErrorCode*) ()
   from /srv/root/src/build/lib/libCling.so
#11 0x00007ffff2b5597a in TCling::ProcessLineSynch(char const*, TInterpreter::EErrorCode*) ()
   from /srv/root/src/build/lib/libCling.so
#12 0x00007ffff7cb2f76 in TApplication::ExecuteFile(char const*, int*, bool) ()
   from /srv/root/src/build/lib/libCore.so
#13 0x00007ffff7fa4f54 in TRint::ProcessLineNr(char const*, char const*, int*) ()
   from /srv/root/src/build/lib/libRint.so
#14 0x00007ffff7fa6daf in TRint::Run(bool) () from /srv/root/src/build/lib/libRint.so
#15 0x00005555555551e0 in main ()
(gdb) n
37	   TString dir = gROOT->GetTutorialDir();
(gdb) n
38	   dir.ReplaceAll("/./","/");
(gdb) n
40	   if (getFile) {
(gdb) quit
A debugging session is active.

	Inferior 1 [process 813525] will be killed.

Quit anyway? (y or n) y
```

**Flamegraphs**

Before:
![hsimple-nojit](https://user-images.githubusercontent.com/249404/171405807-d9d0f46a-ceb8-42c2-8f15-577cc60a0f80.svg)

After (i.e. with `CLING_PROFILE=1`):
![hsimple-jit](https://user-images.githubusercontent.com/249404/171405859-c6eb2c9f-5a48-4fc0-b855-a8b0af528c1f.svg)

