### PR TITLE
Some refactoring of the build system of core/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     " Please see README/INSTALL for more information.")
 endif()
 
-set(policy_new CMP0072 CMP0077)
+set(policy_new CMP0072 CMP0076 CMP0077)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     " Please see README/INSTALL for more information.")
 endif()
 
-set(policy_new CMP0072 CMP0076 CMP0077)
+set(policy_new CMP0072 CMP0076 CMP0077 CMP0079)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -76,8 +76,6 @@ add_dependencies(Core CLING gitcommit rconfigure)
 
 target_link_libraries(Core
   PRIVATE
-    ZLIB::ZLIB
-    ${ZSTD_LIBRARIES}
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${ROOT_ATOMIC_LIBS}
@@ -108,8 +106,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Zip>
-  $<TARGET_OBJECTS:Zstd>
   $<TARGET_OBJECTS:Meta>
   $<TARGET_OBJECTS:GuiCore>
   $<TARGET_OBJECTS:TextInput>
@@ -158,7 +154,6 @@ target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/meta/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/zip/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/textinput/inc>
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -114,7 +114,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Cont>
   $<TARGET_OBJECTS:Foundation>
   $<TARGET_OBJECTS:Lzma>
   $<TARGET_OBJECTS:Lz4>
@@ -166,7 +165,6 @@ target_compile_definitions(Core PRIVATE
 target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/foundation/inc>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/cont/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/meta/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -106,7 +106,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Meta>
   $<TARGET_OBJECTS:GuiCore>
   $<TARGET_OBJECTS:TextInput>
 )
@@ -152,7 +151,6 @@ target_compile_definitions(Core PRIVATE
 target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/meta/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/textinput/inc>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -194,18 +194,10 @@ if (runtime_cxxmodules)
   list(APPEND core_implicit_modules "-mByproduct" "ROOT_Rtypes")
 endif(runtime_cxxmodules)
 
+get_target_property(CORE_DICT_HEADERS Core DICT_HEADERS)
+
 ROOT_GENERATE_DICTIONARY(G__Core
-  ${Core_dict_headers}
-  ${Clib_dict_headers}
-  ${Cont_dict_headers}
-  ${Foundation_dict_headers}
-  ${Macosx_dict_headers}
-  ${Unix_dict_headers}
-  ${Winnt_dict_headers}
-  ${ClingUtils_dict_headers}
-  ${GuiCore_dict_headers}
-  ${Meta_dict_headers}
-  ${TextInput_dict_headers}
+  ${CORE_DICT_HEADERS}
   STAGE1
   MODULE
     Core

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -76,8 +76,6 @@ add_dependencies(Core CLING gitcommit rconfigure)
 
 target_link_libraries(Core
   PRIVATE
-    xxHash::xxHash
-    LZ4::LZ4
     ZLIB::ZLIB
     ${ZSTD_LIBRARIES}
     ${CMAKE_DL_LIBS}
@@ -110,7 +108,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Lz4>
   $<TARGET_OBJECTS:Zip>
   $<TARGET_OBJECTS:Zstd>
   $<TARGET_OBJECTS:Meta>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,9 +74,6 @@ generateHeader(Core
 
 add_dependencies(Core CLING gitcommit rconfigure)
 
-# For FoundationUtils.hxx
-target_include_directories(Core PRIVATE foundation/res)
-
 target_link_libraries(Core
   PRIVATE
     ${LIBLZMA_LIBRARIES}
@@ -114,7 +111,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Foundation>
   $<TARGET_OBJECTS:Lzma>
   $<TARGET_OBJECTS:Lz4>
   $<TARGET_OBJECTS:Zip>
@@ -164,7 +160,6 @@ target_compile_definitions(Core PRIVATE
 
 target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/foundation/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/meta/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
@@ -174,10 +169,6 @@ target_include_directories(Core PUBLIC
 )
 
 target_include_directories(Core PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/clingutils/inc>)
-
-if(root7 OR CMAKE_CXX_STANDARD GREATER 11)
-  target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/foundation/v7/inc>)
-endif()
 
 if (runtime_cxxmodules)
   if(MSVC)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -65,7 +65,12 @@ set_source_files_properties(${CMAKE_BINARY_DIR}/include/RGitCommit.h
 install(FILES ${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-ROOT_LINKER_LIBRARY(Core base/src/TROOT.cxx BUILTINS LZMA)
+ROOT_LINKER_LIBRARY(Core BUILTINS LZMA)
+
+generateHeader(Core
+  ${CMAKE_SOURCE_DIR}/core/base/src/root-argparse.py
+  ${CMAKE_BINARY_DIR}/ginclude/TApplicationCommandLineOptionsHelp.h
+)
 
 add_dependencies(Core CLING gitcommit rconfigure)
 
@@ -74,7 +79,6 @@ target_include_directories(Core PRIVATE foundation/res)
 
 target_link_libraries(Core
   PRIVATE
-    PCRE::PCRE
     ${LIBLZMA_LIBRARIES}
     xxHash::xxHash
     LZ4::LZ4
@@ -108,7 +112,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Base>
   $<TARGET_OBJECTS:Clib>
   $<TARGET_OBJECTS:Cont>
   $<TARGET_OBJECTS:Foundation>
@@ -124,10 +127,6 @@ target_sources(Core PRIVATE
 add_subdirectory(macosx)
 add_subdirectory(unix)
 add_subdirectory(winnt)
-
-if(CMAKE_CXX_STANDARD GREATER 11)
-  set(dict_v7dirs base/v7/inc)
-endif()
 
 add_subdirectory(rootcling_stage1)
 
@@ -167,7 +166,6 @@ target_compile_definitions(Core PRIVATE
 
 target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/base/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/foundation/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/cont/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
@@ -182,7 +180,6 @@ target_include_directories(Core PUBLIC
 target_include_directories(Core PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/clingutils/inc>)
 
 if(root7 OR CMAKE_CXX_STANDARD GREATER 11)
-  target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/base/v7/inc>)
   target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/foundation/v7/inc>)
 endif()
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -89,6 +89,8 @@ target_link_libraries(Core
     ${ROOT_ATOMIC_LIBS}
 )
 
+add_subdirectory(rootcling_stage1)
+
 add_subdirectory(base)
 add_subdirectory(clib)
 add_subdirectory(clingutils)
@@ -127,8 +129,6 @@ target_sources(Core PRIVATE
 add_subdirectory(macosx)
 add_subdirectory(unix)
 add_subdirectory(winnt)
-
-add_subdirectory(rootcling_stage1)
 
 #-------------------------------------------------------------------------------
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -105,10 +105,6 @@ add_subdirectory(lzma)
 add_subdirectory(lz4)
 add_subdirectory(zstd)
 
-target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:TextInput>
-)
-
 add_subdirectory(macosx)
 add_subdirectory(unix)
 add_subdirectory(winnt)
@@ -151,7 +147,6 @@ target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/textinput/inc>
 )
 
 target_include_directories(Core PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/clingutils/inc>)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -62,6 +62,37 @@ set_source_files_properties(${CMAKE_BINARY_DIR}/include/RGitCommit.h
 install(FILES ${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+if(WIN32)
+  set(corelinklibs shell32.lib WSock32.lib Oleaut32.lib Iphlpapi.lib)
+elseif(APPLE)
+  if(cocoa)
+     set(corelinklibs "-framework Cocoa -F/System/Library/PrivateFrameworks -framework CoreSymbolication")
+  else()
+     set(corelinklibs "-F/System/Library/PrivateFrameworks -framework CoreSymbolication")
+  endif()
+endif()
+
+ROOT_LINKER_LIBRARY(Core base/src/TROOT.cxx BUILTINS LZMA)
+
+add_dependencies(Core CLING gitcommit rconfigure)
+
+# For FoundationUtils.hxx
+target_include_directories(Core PRIVATE foundation/res)
+
+target_link_libraries(Core
+  PRIVATE
+    PCRE::PCRE
+    ${LIBLZMA_LIBRARIES}
+    xxHash::xxHash
+    LZ4::LZ4
+    ZLIB::ZLIB
+    ${ZSTD_LIBRARIES}
+    ${CMAKE_DL_LIBS}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${ROOT_ATOMIC_LIBS}
+    ${corelinklibs}
+)
+
 add_subdirectory(clib)
 add_subdirectory(clingutils)
 add_subdirectory(cont)
@@ -94,72 +125,40 @@ endif()
 
 add_subdirectory(base)
 
+target_sources(Core PRIVATE
+  $<TARGET_OBJECTS:Base>
+  $<TARGET_OBJECTS:Clib>
+  $<TARGET_OBJECTS:Cont>
+  $<TARGET_OBJECTS:Foundation>
+  $<TARGET_OBJECTS:Lzma>
+  $<TARGET_OBJECTS:Lz4>
+  $<TARGET_OBJECTS:Zip>
+  $<TARGET_OBJECTS:Zstd>
+  $<TARGET_OBJECTS:Meta>
+  $<TARGET_OBJECTS:GuiCore>
+  $<TARGET_OBJECTS:TextInput>
+)
+
 if(UNIX)
   add_subdirectory(unix)
-  set(unix_objects $<TARGET_OBJECTS:Unix>)
+  target_sources(Core PRIVATE $<TARGET_OBJECTS:Unix>)
 endif()
 if(WIN32)
   add_subdirectory(winnt)
-  set(winnt_objects $<TARGET_OBJECTS:Winnt>)
+  target_sources(Core PRIVATE $<TARGET_OBJECTS:Winnt>)
 endif()
 if(cocoa)
   add_subdirectory(macosx)
-  set(macosx_objects $<TARGET_OBJECTS:Macosx>)
+  target_sources(Core PRIVATE $<TARGET_OBJECTS:Macosx>)
 endif()
 
 if(CMAKE_CXX_STANDARD GREATER 11)
   set(dict_v7dirs base/v7/inc)
 endif()
 
-#---G__Core--------------------------------------------------------------------
-
-# Uses includes path as defined by Core module.
-
-set(objectlibs $<TARGET_OBJECTS:Base>
-               $<TARGET_OBJECTS:Clib>
-               $<TARGET_OBJECTS:Cont>
-               $<TARGET_OBJECTS:Foundation>
-               $<TARGET_OBJECTS:Lzma>
-               $<TARGET_OBJECTS:Lz4>
-               $<TARGET_OBJECTS:Zstd>
-               $<TARGET_OBJECTS:Zip>
-               $<TARGET_OBJECTS:Meta>
-               $<TARGET_OBJECTS:GuiCore>
-               $<TARGET_OBJECTS:TextInput>
-               ${macosx_objects}
-               ${unix_objects}
-               ${winnt_objects})
-
-ROOT_OBJECT_LIBRARY(BaseTROOT ${CMAKE_SOURCE_DIR}/core/base/src/TROOT.cxx ${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h)
-target_include_directories(BaseTROOT PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_BINARY_DIR}/ginclude
-)
-
-add_dependencies(BaseTROOT gitcommit rconfigure)
-#----------------------------------------------------------------------------------------
-
-if(WIN32)
-  set(corelinklibs shell32.lib WSock32.lib Oleaut32.lib Iphlpapi.lib)
-elseif(APPLE)
-  if(cocoa)
-     set(corelinklibs "-framework Cocoa -F/System/Library/PrivateFrameworks -framework CoreSymbolication")
-  else()
-     set(corelinklibs "-F/System/Library/PrivateFrameworks -framework CoreSymbolication")
-  endif()
-endif()
-
 add_subdirectory(rootcling_stage1)
 
 #-------------------------------------------------------------------------------
-ROOT_LINKER_LIBRARY(Core $<TARGET_OBJECTS:BaseTROOT> ${objectlibs} BUILTINS LZMA)
 
 if (libcxx AND NOT APPLE)
   # In case we use libcxx and glibc together there is a mismatch of the
@@ -217,13 +216,10 @@ endif()
 
 if(ROOT_ARCHITECTURE MATCHES macosx)
   target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/unix/inc> $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/macosx/inc>)
-  target_include_directories(BaseTROOT PRIVATE ${CMAKE_SOURCE_DIR}/core/unix/inc ${CMAKE_SOURCE_DIR}/core/macosx/inc)
 elseif(ROOT_ARCHITECTURE MATCHES win32 OR ROOT_ARCHITECTURE MATCHES win64)
   target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/winnt/inc>)
-  target_include_directories(BaseTROOT PRIVATE ${CMAKE_SOURCE_DIR}/core/winnt/inc)
 else()
   target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/unix/inc>)
-  target_include_directories(BaseTROOT PRIVATE ${CMAKE_SOURCE_DIR}/core/unix/inc)
 endif()
 
 if (runtime_cxxmodules)
@@ -258,20 +254,3 @@ ROOT_GENERATE_DICTIONARY(G__Core
   LINKDEF
     base/inc/LinkDef.h
 )
-
-target_include_directories(G__Core PRIVATE ${CMAKE_SOURCE_DIR}/core/clingutils/inc)
-
-target_link_libraries(Core
-  PRIVATE
-    PCRE::PCRE
-    ${LIBLZMA_LIBRARIES}
-    xxHash::xxHash
-    LZ4::LZ4
-    ZLIB::ZLIB
-    ${ZSTD_LIBRARIES}
-    ${CMAKE_DL_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${ROOT_ATOMIC_LIBS}
-    ${corelinklibs}
-)
-add_dependencies(Core CLING)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -51,7 +51,10 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/include/RGitCommit.h
     ${CMAKE_BINARY_DIR}/RGitCommit.h.tmp
 )
 
-add_custom_target(gitcommit ALL DEPENDS ${CMAKE_BINARY_DIR}/include/RGitCommit.h)
+add_custom_target(gitcommit ALL DEPENDS
+  ${CMAKE_BINARY_DIR}/include/RGitCommit.h
+  ${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h
+)
 
 set_source_files_properties(${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h
   PROPERTIES GENERATED TRUE HEADER_FILE_ONLY TRUE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -62,16 +62,6 @@ set_source_files_properties(${CMAKE_BINARY_DIR}/include/RGitCommit.h
 install(FILES ${CMAKE_BINARY_DIR}/ginclude/RGitCommit.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-if(WIN32)
-  set(corelinklibs shell32.lib WSock32.lib Oleaut32.lib Iphlpapi.lib)
-elseif(APPLE)
-  if(cocoa)
-     set(corelinklibs "-framework Cocoa -F/System/Library/PrivateFrameworks -framework CoreSymbolication")
-  else()
-     set(corelinklibs "-F/System/Library/PrivateFrameworks -framework CoreSymbolication")
-  endif()
-endif()
-
 ROOT_LINKER_LIBRARY(Core base/src/TROOT.cxx BUILTINS LZMA)
 
 add_dependencies(Core CLING gitcommit rconfigure)
@@ -90,40 +80,29 @@ target_link_libraries(Core
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${ROOT_ATOMIC_LIBS}
-    ${corelinklibs}
 )
 
+add_subdirectory(base)
 add_subdirectory(clib)
 add_subdirectory(clingutils)
 add_subdirectory(cont)
 add_subdirectory(dictgen)
 add_subdirectory(foundation)
 add_subdirectory(gui)
+add_subdirectory(imt)
 add_subdirectory(meta)
 add_subdirectory(metacling)
-if(NOT WIN32)
 add_subdirectory(multiproc)
-endif()
+add_subdirectory(newdelete)
 add_subdirectory(rint)
+add_subdirectory(sanitizer)
+add_subdirectory(testsupport)
 add_subdirectory(textinput)
 add_subdirectory(thread)
-add_subdirectory(imt)
 add_subdirectory(zip)
 add_subdirectory(lzma)
 add_subdirectory(lz4)
 add_subdirectory(zstd)
-if(testing)
-  add_subdirectory(testsupport)
-endif()
-if(asan)
-  add_subdirectory(sanitizer)
-endif()
-
-if(NOT WIN32)
-  add_subdirectory(newdelete)
-endif()
-
-add_subdirectory(base)
 
 target_sources(Core PRIVATE
   $<TARGET_OBJECTS:Base>
@@ -139,18 +118,9 @@ target_sources(Core PRIVATE
   $<TARGET_OBJECTS:TextInput>
 )
 
-if(UNIX)
-  add_subdirectory(unix)
-  target_sources(Core PRIVATE $<TARGET_OBJECTS:Unix>)
-endif()
-if(WIN32)
-  add_subdirectory(winnt)
-  target_sources(Core PRIVATE $<TARGET_OBJECTS:Winnt>)
-endif()
-if(cocoa)
-  add_subdirectory(macosx)
-  target_sources(Core PRIVATE $<TARGET_OBJECTS:Macosx>)
-endif()
+add_subdirectory(macosx)
+add_subdirectory(unix)
+add_subdirectory(winnt)
 
 if(CMAKE_CXX_STANDARD GREATER 11)
   set(dict_v7dirs base/v7/inc)
@@ -211,15 +181,6 @@ target_include_directories(Core PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/co
 if(root7 OR CMAKE_CXX_STANDARD GREATER 11)
   target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/base/v7/inc>)
   target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/foundation/v7/inc>)
-endif()
-
-
-if(ROOT_ARCHITECTURE MATCHES macosx)
-  target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/unix/inc> $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/macosx/inc>)
-elseif(ROOT_ARCHITECTURE MATCHES win32 OR ROOT_ARCHITECTURE MATCHES win64)
-  target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/winnt/inc>)
-else()
-  target_include_directories(Core PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/unix/inc>)
 endif()
 
 if (runtime_cxxmodules)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -114,7 +114,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Clib>
   $<TARGET_OBJECTS:Cont>
   $<TARGET_OBJECTS:Foundation>
   $<TARGET_OBJECTS:Lzma>
@@ -170,7 +169,6 @@ target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/cont/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/meta/inc>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/clib/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/zip/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -106,7 +106,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:GuiCore>
   $<TARGET_OBJECTS:TextInput>
 )
 
@@ -150,7 +149,6 @@ target_compile_definitions(Core PRIVATE
 
 target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/gui/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/textinput/inc>

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -145,7 +145,6 @@ target_compile_definitions(Core PRIVATE
 
 target_include_directories(Core PUBLIC
    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/rint/inc>
    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>
 )
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -81,6 +81,10 @@ target_link_libraries(Core
     ${ROOT_ATOMIC_LIBS}
 )
 
+target_include_directories(Core PUBLIC
+   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
+)
+
 add_subdirectory(rootcling_stage1)
 
 add_subdirectory(base)
@@ -140,15 +144,6 @@ target_compile_definitions(Core PRIVATE
 
   __CLANG_STDATOMIC_H
  )
-
-#while basic libs do not depend on Core, we have to add includes directly
-
-target_include_directories(Core PUBLIC
-   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/ginclude>
-   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/thread/inc>
-)
-
-target_include_directories(Core PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/core/clingutils/inc>)
 
 if (runtime_cxxmodules)
   if(MSVC)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -76,7 +76,6 @@ add_dependencies(Core CLING gitcommit rconfigure)
 
 target_link_libraries(Core
   PRIVATE
-    ${LIBLZMA_LIBRARIES}
     xxHash::xxHash
     LZ4::LZ4
     ZLIB::ZLIB
@@ -111,7 +110,6 @@ add_subdirectory(lz4)
 add_subdirectory(zstd)
 
 target_sources(Core PRIVATE
-  $<TARGET_OBJECTS:Lzma>
   $<TARGET_OBJECTS:Lz4>
   $<TARGET_OBJECTS:Zip>
   $<TARGET_OBJECTS:Zstd>

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -165,6 +165,7 @@ set(BASE_SOURCES
   src/TRef.cxx
   src/TRegexp.cxx
   src/TRemoteObject.cxx
+  src/TROOT.cxx
   src/TStopwatch.cxx
   src/TStorage.cxx
   src/TString.cxx
@@ -200,41 +201,20 @@ if(root7)
   list(APPEND BASE_HEADERS
       ROOT/RDirectoryEntry.hxx
       ROOT/RIndexIter.hxx)
-  set(BASE_V7_INC ${CMAKE_SOURCE_DIR}/core/base/v7/inc)
-  set(BASE_HEADER_DIRS inc/ v7/inc/)
-  list(APPEND BASE_SOURCES
-      RDirectory.cxx)
+  target_sources(Core PRIVATE v7/src/RDirectory.cxx)
 endif()
 
 # only here complete list of headers can be propogated to parent cmake file
 set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${BASE_HEADERS})
 
-ROOT_OBJECT_LIBRARY(Base ${BASE_SOURCES})
+target_sources(Core PRIVATE ${BASE_SOURCES})
 
-target_include_directories(Base PRIVATE
-   ${BASE_V7_INC}
-   ${PCRE_INCLUDE_DIR}
-   res
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_include_directories(Core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/v7/inc>
 )
 
-if(MSVC)
-   target_include_directories(Base PRIVATE ${CMAKE_SOURCE_DIR}/core/winnt/inc)
-endif()
-
-
-#---CreateTApplicationCommandLineOptions------------------------------------------------------------------
-generateHeader(Base
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/root-argparse.py
-  ${CMAKE_BINARY_DIR}/ginclude/TApplicationCommandLineOptionsHelp.h
-)
+target_link_libraries(Core PRIVATE PCRE::PCRE)
 
 ROOT_INSTALL_HEADERS(${BASE_HEADER_DIRS})
 

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -196,7 +196,6 @@ set(BASE_SOURCES
 )
 
 if(root7)
-  set(BASE_V7_INC ${CMAKE_SOURCE_DIR}/core/base/v7/inc)
   set(BASE_HEADER_DIRS inc/ v7/inc/)
   list(APPEND BASE_HEADERS
       ROOT/RDirectoryEntry.hxx

--- a/core/base/CMakeLists.txt
+++ b/core/base/CMakeLists.txt
@@ -206,9 +206,8 @@ if(root7)
       RDirectory.cxx)
 endif()
 
-
 # only here complete list of headers can be propogated to parent cmake file
-set(Core_dict_headers ${BASE_HEADERS} PARENT_SCOPE)
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ${BASE_HEADERS})
 
 ROOT_OBJECT_LIBRARY(Base ${BASE_SOURCES})
 

--- a/core/clib/CMakeLists.txt
+++ b/core/clib/CMakeLists.txt
@@ -8,9 +8,11 @@
 # CMakeLists.txt file for building ROOT core/clib package
 ############################################################################
 
-set(Clib_dict_headers strlcpy.h
-                      snprintf.h
-                      strtok.h PARENT_SCOPE)
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
+  strlcpy.h
+  snprintf.h
+  strtok.h
+)
 
 ROOT_OBJECT_LIBRARY(Clib
   src/Demangle.c

--- a/core/clib/CMakeLists.txt
+++ b/core/clib/CMakeLists.txt
@@ -36,10 +36,20 @@ ROOT_OBJECT_LIBRARY(Clib
   src/strlcpy.c
 )
 
-target_include_directories(Clib PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/clib/res
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_include_directories(Clib
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  PRIVATE
+    ${CMAKE_BINARY_DIR}/ginclude
+    ${CMAKE_CURRENT_SOURCE_DIR}/res
+    ${CMAKE_CURRENT_SOURCE_DIR}/../foundation/inc # for RConfig.hxx
 )
+
+target_include_directories(Core
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)
+
+target_sources(Core PRIVATE $<TARGET_OBJECTS:Clib>)
 
 ROOT_INSTALL_HEADERS()

--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -15,6 +15,11 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   root_std_complex.h
 )
 
+target_include_directories(Core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/res>
+)
+
 ROOT_OBJECT_LIBRARY(ClingUtils
   src/RStl.cxx
   src/TClingUtils.cxx

--- a/core/clingutils/CMakeLists.txt
+++ b/core/clingutils/CMakeLists.txt
@@ -11,9 +11,8 @@
 # These files depend on cling/clang/llvm; they need to be linked into libCling.
 # They are used by rootcling_stage1, rootcling and libCling.
 
-set(ClingUtils_dict_headers
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   root_std_complex.h
-  PARENT_SCOPE
 )
 
 ROOT_OBJECT_LIBRARY(ClingUtils

--- a/core/cont/CMakeLists.txt
+++ b/core/cont/CMakeLists.txt
@@ -40,7 +40,7 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TVirtualCollectionProxy.h
 )
 
-ROOT_OBJECT_LIBRARY(Cont
+target_sources(Core PRIVATE
   src/TArrayC.cxx
   src/TArray.cxx
   src/TArrayD.cxx
@@ -69,15 +69,8 @@ ROOT_OBJECT_LIBRARY(Cont
   src/TSortedList.cxx
 )
 
-target_include_directories(Cont PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_BINARY_DIR}/ginclude)
+target_include_directories(Core
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>)
 
 ROOT_INSTALL_HEADERS()
 

--- a/core/cont/CMakeLists.txt
+++ b/core/cont/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/cont package
 ############################################################################
 
-set(Cont_dict_headers
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   ROOT/TSeq.hxx
   TArrayC.h
   TArrayD.h
@@ -38,7 +38,6 @@ set(Cont_dict_headers
   TSeqCollection.h
   TSortedList.h
   TVirtualCollectionProxy.h
-  PARENT_SCOPE
 )
 
 ROOT_OBJECT_LIBRARY(Cont

--- a/core/foundation/CMakeLists.txt
+++ b/core/foundation/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/foundation package
 ############################################################################
 
-set(Foundation_dict_headers
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   ESTLType.h
   RStringView.h
   TClassEdit.h
@@ -22,7 +22,6 @@ set(Foundation_dict_headers
   ROOT/StringUtils.hxx
   ROOT/span.hxx
   ROOT/TypeTraits.hxx
-  PARENT_SCOPE
 )
 
 set(FOUNDATION_SOURCES
@@ -37,8 +36,7 @@ set(FOUNDATION_SOURCES
 set(FOUNDATION_HEADER_DIRS inc/)
 
 if(root7)
-  list(APPEND Foundation_dict_headers
-    ROOT/RError.hxx)
+  set_property(TARGET Core APPEND PROPERTY DICT_HEADERS ROOT/RError.hxx)
   list(APPEND FOUNDATION_SOURCES
     v7/src/RError.cxx)
   list(APPEND FOUNDATION_HEADER_DIRS v7/inc/)

--- a/core/foundation/CMakeLists.txt
+++ b/core/foundation/CMakeLists.txt
@@ -40,28 +40,28 @@ if(root7)
   list(APPEND FOUNDATION_SOURCES
     v7/src/RError.cxx)
   list(APPEND FOUNDATION_HEADER_DIRS v7/inc/)
-  set(FOUNDATION_V7_INC ${CMAKE_SOURCE_DIR}/core/foundation/v7/inc)
   ROOT_ADD_TEST_SUBDIRECTORY(v7/test)
 endif()
 
-ROOT_OBJECT_LIBRARY(Foundation ${FOUNDATION_SOURCES})
-target_include_directories(Foundation PRIVATE
-   ${FOUNDATION_V7_INC}
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_BINARY_DIR}/ginclude
+target_sources(Core PRIVATE ${FOUNDATION_SOURCES})
+
+target_include_directories(Core
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/v7/inc>
+  PRIVATE
+    res
 )
 
 ROOT_OBJECT_LIBRARY(Foundation_Stage1 ${FOUNDATION_SOURCES}) # used by rootcling_stage1
-target_include_directories(Foundation_Stage1 PRIVATE
-   ${FOUNDATION_V7_INC}
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_BINARY_DIR}/ginclude
-)
 
-if(MSVC)
-   target_include_directories(Foundation PRIVATE ${CMAKE_SOURCE_DIR}/core/winnt/inc)
-   target_include_directories(Foundation_Stage1 PRIVATE ${CMAKE_SOURCE_DIR}/core/winnt/inc)
-endif()
+target_include_directories(Foundation_Stage1
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  PRIVATE
+    $<$<BOOL:${MSVC}>:${CMAKE_SOURCE_DIR}/core/winnt/inc>
+    ${CMAKE_BINARY_DIR}/ginclude res
+)
 
 set_target_properties(Foundation_Stage1 PROPERTIES
   COMPILE_FLAGS "${COMPILE_FLAGS} ${CLING_CXXFLAGS}"

--- a/core/gui/CMakeLists.txt
+++ b/core/gui/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/meta package
 ############################################################################
 
-set(GuiCore_dict_headers
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   GuiTypes.h
   TApplicationImp.h
   TBrowser.h
@@ -23,7 +23,6 @@ set(GuiCore_dict_headers
   TObjectSpy.h
   TToggleGroup.h
   TToggle.h
-  PARENT_SCOPE
 )
 
 ROOT_OBJECT_LIBRARY(GuiCore

--- a/core/gui/CMakeLists.txt
+++ b/core/gui/CMakeLists.txt
@@ -25,7 +25,7 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TToggle.h
 )
 
-ROOT_OBJECT_LIBRARY(GuiCore
+target_sources(Core PRIVATE
   src/InitGui.cxx
   src/TApplicationImp.cxx
   src/TBrowser.cxx
@@ -42,14 +42,8 @@ ROOT_OBJECT_LIBRARY(GuiCore
   src/TToggleGroup.cxx
 )
 
-target_include_directories(GuiCore PRIVATE 
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_include_directories(Core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
 ROOT_INSTALL_HEADERS()

--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -23,11 +23,6 @@ ROOT_LINKER_LIBRARY(Imt
     TBB
 )
 
-target_include_directories(Clib PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_BINARY_DIR}/ginclude
-)
-
 target_link_libraries(Imt PRIVATE Thread INTERFACE Core)
 
 if(imt)

--- a/core/lz4/CMakeLists.txt
+++ b/core/lz4/CMakeLists.txt
@@ -7,12 +7,10 @@
 find_package(LZ4 REQUIRED)
 find_package(xxHash REQUIRED)
 
-ROOT_OBJECT_LIBRARY(Lz4 src/ZipLZ4.cxx)
-target_include_directories(Lz4 PRIVATE
-   ${LZ4_INCLUDE_DIR}
-   ${xxHash_INCLUDE_DIR}
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_sources(Core PRIVATE src/ZipLZ4.cxx)
+target_link_libraries(Core PRIVATE xxHash::xxHash LZ4::LZ4)
+target_include_directories(Core PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
 ROOT_INSTALL_HEADERS()

--- a/core/lzma/CMakeLists.txt
+++ b/core/lzma/CMakeLists.txt
@@ -8,12 +8,14 @@
 # CMakeLists.txt file for building ROOT core/lzma package
 ############################################################################
 
-ROOT_OBJECT_LIBRARY(Lzma src/ZipLZMA.c BUILTINS LZMA)
+target_sources(Core PRIVATE src/ZipLZMA.c)
 
-target_include_directories(Lzma PRIVATE
-   ${LIBLZMA_INCLUDE_DIR}
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_link_libraries(Core PRIVATE ${LIBLZMA_LIBRARIES})
+
+target_include_directories(Core
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+    $<BUILD_INTERFACE:${LIBLZMA_INCLUDE_DIR}>
 )
 
 ROOT_INSTALL_HEADERS()

--- a/core/macosx/CMakeLists.txt
+++ b/core/macosx/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT APPLE)
   return()
 endif()
 
-set(Macosx_dict_headers TMacOSXSystem.h PARENT_SCOPE)
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS TMacOSXSystem.h)
 
 target_include_directories(Core PRIVATE inc)
 

--- a/core/macosx/CMakeLists.txt
+++ b/core/macosx/CMakeLists.txt
@@ -8,29 +8,30 @@
 # CMakeLists.txt file for building ROOT core/macosx package
 ############################################################################
 
-set(Macosx_dict_headers
-  TMacOSXSystem.h
-  PARENT_SCOPE
+if(NOT APPLE)
+  return()
+endif()
+
+set(Macosx_dict_headers TMacOSXSystem.h PARENT_SCOPE)
+
+target_include_directories(Core PRIVATE inc)
+
+target_link_libraries(Core PRIVATE
+  "-F/System/Library/PrivateFrameworks -framework CoreSymbolication"
 )
 
-ROOT_OBJECT_LIBRARY(Macosx
-  src/CocoaUtils.mm
-  src/TMacOSXSystem.mm
-)
+if(cocoa)
+  target_link_libraries(Core PRIVATE "-framework Cocoa")
 
-target_compile_options(Macosx PRIVATE -ObjC++)
+  ROOT_OBJECT_LIBRARY(Macosx
+    src/CocoaUtils.mm
+    src/TMacOSXSystem.mm
+  )
 
-target_include_directories(Macosx PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/unix/inc
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_SOURCE_DIR}/core/textinput/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_BINARY_DIR}/ginclude
-)
+  target_compile_options(Macosx PRIVATE -ObjC++)
+
+  target_sources(Core PRIVATE $<TARGET_OBJECTS:Macosx>)
+
+endif()
 
 ROOT_INSTALL_HEADERS()

--- a/core/meta/CMakeLists.txt
+++ b/core/meta/CMakeLists.txt
@@ -8,7 +8,7 @@
 # CMakeLists.txt file for building ROOT core/meta package
 ############################################################################
 
-set(Meta_dict_headers
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TBaseClass.h
   TClassGenerator.h
   TClass.h
@@ -50,7 +50,6 @@ set(Meta_dict_headers
   TVirtualStreamerInfo.h
   TVirtualArray.h
   TVirtualObject.h
-  PARENT_SCOPE
 )
 
 ROOT_OBJECT_LIBRARY(Meta

--- a/core/meta/CMakeLists.txt
+++ b/core/meta/CMakeLists.txt
@@ -52,7 +52,7 @@ set_property(TARGET Core APPEND PROPERTY DICT_HEADERS
   TVirtualObject.h
 )
 
-ROOT_OBJECT_LIBRARY(Meta
+target_sources(Core PRIVATE
   src/TBaseClass.cxx
   src/TClass.cxx
   src/TClassGenerator.cxx
@@ -88,24 +88,10 @@ ROOT_OBJECT_LIBRARY(Meta
   src/TVirtualStreamerInfo.cxx
 )
 
-target_include_directories(Meta PRIVATE
-  ${CMAKE_SOURCE_DIR}/core/meta/res
-  ${CMAKE_SOURCE_DIR}/core/foundation/res
-  ${CMAKE_SOURCE_DIR}/core/base/inc
-  ${CMAKE_SOURCE_DIR}/core/clib/inc
-  ${CMAKE_SOURCE_DIR}/core/cont/inc
-  ${CMAKE_SOURCE_DIR}/core/thread/inc
-  ${CMAKE_SOURCE_DIR}/core/gui/inc
-  ${CMAKE_SOURCE_DIR}/core/foundation/inc
-  ${CMAKE_BINARY_DIR}/ginclude
+target_include_directories(Core
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
-
-if(MSVC)
-   target_include_directories(Meta PRIVATE
-      ${CMAKE_SOURCE_DIR}/core/winnt/inc
-   )
-endif()
-
 
 ROOT_INSTALL_HEADERS()
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -48,18 +48,16 @@ target_include_directories(MetaCling SYSTEM PRIVATE
 
 target_include_directories(MetaCling PRIVATE
    ${CLING_INCLUDE_DIRS}
-   ${CMAKE_SOURCE_DIR}/core/metacling/res
-   ${CMAKE_SOURCE_DIR}/core/clingutils/res
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_SOURCE_DIR}/core/zip/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/res
    ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
    ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
+   ${CMAKE_SOURCE_DIR}/core/clingutils/res
    ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
+   ${CMAKE_SOURCE_DIR}/core/foundation/inc
+   ${CMAKE_SOURCE_DIR}/core/foundation/res
+   ${CMAKE_SOURCE_DIR}/core/meta/inc
+   ${CMAKE_SOURCE_DIR}/core/metacling/res
+   ${CMAKE_SOURCE_DIR}/core/thread/inc
+   ${CMAKE_SOURCE_DIR}/core/zip/inc
    ${CMAKE_SOURCE_DIR}/io/io/inc
    ${CMAKE_BINARY_DIR}/ginclude
 )

--- a/core/multiproc/CMakeLists.txt
+++ b/core/multiproc/CMakeLists.txt
@@ -8,6 +8,10 @@
 # CMakeLists.txt file for building ROOT core/multiproc package
 ############################################################################
 
+if(WIN32)
+  return()
+endif()
+
 ROOT_STANDARD_LIBRARY_PACKAGE(MultiProc STAGE1
   HEADERS
     MPCode.h

--- a/core/newdelete/CMakeLists.txt
+++ b/core/newdelete/CMakeLists.txt
@@ -8,6 +8,10 @@
 # CMakeLists.txt file for building ROOT core/newdelete package
 ############################################################################
 
+if(WIN32)
+  return()
+endif()
+
 ROOT_LINKER_LIBRARY(New
   src/NewDelete.cxx
   DEPENDENCIES

--- a/core/rint/CMakeLists.txt
+++ b/core/rint/CMakeLists.txt
@@ -22,4 +22,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Rint
     Core
 )
 
+target_include_directories(Core PRIVATE inc)
+
 ROOT_ADD_TEST_SUBDIRECTORY(test)

--- a/core/sanitizer/CMakeLists.txt
+++ b/core/sanitizer/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT asan)
+  return()
+endif()
+
 # Make a shared library that holds the ROOT default config for address sanitizer.
 # This is can be used with LD_PRELOAD
 add_library(ROOTSanitizerConfig SHARED SanitizerSetup.cxx)

--- a/core/testsupport/CMakeLists.txt
+++ b/core/testsupport/CMakeLists.txt
@@ -4,6 +4,10 @@
 # higher than kInfo are issued by tests.
 # Stephan Hageboeck, CERN, 2022
 
+if(NOT testing)
+  return()
+endif()
+
 set(libname TestSupport)
 set(header_dir ROOT/)
 

--- a/core/textinput/CMakeLists.txt
+++ b/core/textinput/CMakeLists.txt
@@ -8,10 +8,7 @@
 # CMakeLists.txt file for building ROOT core/textinout package
 ############################################################################
 
-set(TextInput_dict_headers
-  Getline.h
-  PARENT_SCOPE
-)
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS Getline.h)
 
 ROOT_OBJECT_LIBRARY(TextInput
   src/Getline_color.cxx

--- a/core/textinput/CMakeLists.txt
+++ b/core/textinput/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 set_property(TARGET Core APPEND PROPERTY DICT_HEADERS Getline.h)
 
-ROOT_OBJECT_LIBRARY(TextInput
+target_sources(Core PRIVATE
   src/Getline_color.cxx
   src/Getline.cxx
   src/textinput/Editor.cpp
@@ -29,16 +29,11 @@ ROOT_OBJECT_LIBRARY(TextInput
   src/textinput/TextInput.cpp
 )
 
-target_include_directories(TextInput PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/textinput/src
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_include_directories(Core
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  PRIVATE
+    src
 )
 
 ROOT_INSTALL_HEADERS()

--- a/core/thread/CMakeLists.txt
+++ b/core/thread/CMakeLists.txt
@@ -69,12 +69,14 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Thread
   INSTALL_OPTIONS ${installoptions}
 )
 
+target_include_directories(Core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)
+
 target_link_libraries(Thread PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
-target_include_directories(Thread PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_include_directories(Thread PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
 # keep include directory for ROOT/RSha256.hxx private

--- a/core/unix/CMakeLists.txt
+++ b/core/unix/CMakeLists.txt
@@ -8,28 +8,12 @@
 # CMakeLists.txt file for building ROOT core/unix package
 ############################################################################
 
-set(Unix_dict_headers
-  TUnixSystem.h
-  PARENT_SCOPE
-)
+if(NOT UNIX)
+  return()
+endif()
 
-ROOT_OBJECT_LIBRARY(Unix
-  src/TUnixSystem.cxx
-)
-
-target_include_directories(Unix PRIVATE 
-   ${CMAKE_SOURCE_DIR}/core/clib/res
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/textinput/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
-)
-
+set(Unix_dict_headers TUnixSystem.h PARENT_SCOPE)
+target_sources(Core PRIVATE src/TUnixSystem.cxx)
+target_include_directories(Core PRIVATE inc ../clib/res)
 
 ROOT_INSTALL_HEADERS()

--- a/core/unix/CMakeLists.txt
+++ b/core/unix/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT UNIX)
   return()
 endif()
 
-set(Unix_dict_headers TUnixSystem.h PARENT_SCOPE)
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS TUnixSystem.h)
 target_sources(Core PRIVATE src/TUnixSystem.cxx)
 target_include_directories(Core PRIVATE inc ../clib/res)
 

--- a/core/winnt/CMakeLists.txt
+++ b/core/winnt/CMakeLists.txt
@@ -8,28 +8,25 @@
 # CMakeLists.txt file for building ROOT core/winnt package
 ############################################################################
 
-set(Winnt_dict_headers
-  TWinNTSystem.h
-  PARENT_SCOPE
-)
+if(NOT WIN32)
+  return()
+endif()
 
-ROOT_OBJECT_LIBRARY(Winnt
+set(Winnt_dict_headers TWinNTSystem.h PARENT_SCOPE)
+
+target_sources(Core PRIVATE
   src/TWin32SplashThread.cxx
   src/TWinNTSystem.cxx
   src/Win32Splash.cxx
 )
 
-target_include_directories(Winnt PRIVATE
-   ${CMAKE_SOURCE_DIR}/core/foundation/res
-   ${CMAKE_SOURCE_DIR}/core/base/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/cont/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_SOURCE_DIR}/core/textinput/inc
-   ${CMAKE_SOURCE_DIR}/core/gui/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_link_libraries(Core PRIVATE
+  shell32.lib
+  WSock32.lib
+  Oleaut32.lib
+  Iphlpapi.lib
 )
+
+target_include_directories(Core PRIVATE inc)
 
 ROOT_INSTALL_HEADERS()

--- a/core/winnt/CMakeLists.txt
+++ b/core/winnt/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT WIN32)
   return()
 endif()
 
-set(Winnt_dict_headers TWinNTSystem.h PARENT_SCOPE)
+set_property(TARGET Core APPEND PROPERTY DICT_HEADERS TWinNTSystem.h)
 
 target_sources(Core PRIVATE
   src/TWin32SplashThread.cxx

--- a/core/zip/CMakeLists.txt
+++ b/core/zip/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 find_package(ZLIB REQUIRED)
 
-ROOT_OBJECT_LIBRARY(Zip
+target_sources(Core PRIVATE
   src/Bits.c
   src/ZDeflate.c
   src/ZTrees.c
@@ -15,16 +15,10 @@ ROOT_OBJECT_LIBRARY(Zip
   src/RZip.cxx
 )
 
-target_include_directories(Zip PRIVATE
-   ${ZLIB_INCLUDE_DIR}
-   ${CMAKE_SOURCE_DIR}/core/lzma/inc
-   ${CMAKE_SOURCE_DIR}/core/lz4/inc
-   ${CMAKE_SOURCE_DIR}/core/zstd/inc
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_SOURCE_DIR}/core/clib/inc
-   ${CMAKE_SOURCE_DIR}/core/meta/inc
-   ${CMAKE_SOURCE_DIR}/core/thread/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_link_libraries(Core PRIVATE ZLIB::ZLIB)
+
+target_include_directories(Core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
 )
 
 ROOT_INSTALL_HEADERS()

--- a/core/zstd/CMakeLists.txt
+++ b/core/zstd/CMakeLists.txt
@@ -4,16 +4,12 @@
 
 find_package(ZSTD REQUIRED)
 
-#---Declare ZipZSTD sources as part of libCore-------------------------------
-set(headers ${CMAKE_CURRENT_SOURCE_DIR}/inc/ZipZSTD.hxx)
-set(sources ${CMAKE_CURRENT_SOURCE_DIR}/src/ZipZSTD.cxx)
-
-ROOT_OBJECT_LIBRARY(Zstd ${sources} BUILTINS ZSTD)
-target_compile_definitions(Zstd PRIVATE ${ZSTD_DEFINITIONS})
-target_include_directories(Zstd PRIVATE
-   ${ZSTD_INCLUDE_DIR}
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude
+target_sources(Core PRIVATE src/ZipZSTD.cxx)
+target_link_libraries(Core PRIVATE ${ZSTD_LIBRARIES})
+target_compile_definitions(Core PRIVATE ${ZSTD_DEFINITIONS})
+target_include_directories(Core PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+  $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>
 )
 
 ROOT_INSTALL_HEADERS()

--- a/tmva/pymva/test/CMakeLists.txt
+++ b/tmva/pymva/test/CMakeLists.txt
@@ -54,8 +54,6 @@ endif()
    target_include_directories(emitFromPyTorch PRIVATE
                               ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
                               ${CMAKE_SOURCE_DIR}/tmva/inc
-                              ${CMAKE_SOURCE_DIR}/core/foundation/inc
-                              ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
                )
    set_target_properties(emitFromPyTorch PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
    add_custom_target(SofieCompileModels_PyTorch)
@@ -119,8 +117,6 @@ endif()
    target_include_directories(emitFromKeras PRIVATE
                  ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
                  ${CMAKE_SOURCE_DIR}/tmva/inc
-                 ${CMAKE_SOURCE_DIR}/core/foundation/inc
-                 ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
                )
    set_target_properties(emitFromKeras PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
    add_custom_target(SofieCompileModels_Keras)

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -42,8 +42,6 @@ target_include_directories(emitFromONNX PRIVATE
    ${SOFIE_PARSERS_DIR}/inc
    ${CMAKE_SOURCE_DIR}/tmva/inc
    ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 
 target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie ROOTTMVASofieParser)
@@ -85,8 +83,6 @@ target_include_directories(emitFromROOT PRIVATE
    ${SOFIE_PARSERS_DIR}/inc
    ${CMAKE_SOURCE_DIR}/tmva/inc
    ${CMAKE_CURRENT_BINARY_DIR}
-   ${CMAKE_SOURCE_DIR}/core/foundation/inc
-   ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie ROOTTMVASofieParser)
 set_target_properties(emitFromROOT PROPERTIES POSITION_INDEPENDENT_CODE TRUE)


### PR DESCRIPTION
This is an old branch I had from when I was working on ROOT, but at the time I could not merge it because it required at least CMake 3.12 to work, and we were still requiring only 3.9 at the time. I took the time to rework the commits against the current master yesterday and today, as rebasing was too hard. The original pull request that contained these changes was https://github.com/root-project/root/pull/4299, but the refactoring of core/ was removed. I hope now this would be ok to merge to simplify a bit how libCore is built and avoid having to add include directories by hand to targets that link against libCore.