### PR TITLE
[Interpreter] remove EmittedDeferredDecls in CodeGenModule

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -368,7 +368,6 @@ void CodeGenModule::checkAliases() {
 
 void CodeGenModule::clear() {
   DeferredDeclsToEmit.clear();
-  EmittedDeferredDecls.clear();
   if (OpenMPRuntime)
     OpenMPRuntime->clear();
 }
@@ -392,9 +391,6 @@ void InstrProfStats::reportDiagnostics(DiagnosticsEngine &Diags,
 
 void CodeGenModule::Release() {
   EmitDeferred();
-  DeferredDecls.insert(EmittedDeferredDecls.begin(),
-                       EmittedDeferredDecls.end());
-  EmittedDeferredDecls.clear();
   EmitVTablesOpportunistically();
   applyGlobalValReplacements();
   applyReplacements();
@@ -2535,7 +2531,6 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
   if (MustBeEmitted(Global) && MayBeEmittedEagerly(Global)) {
     // Emit the definition if it can't be deferred.
     EmitGlobalDefinition(GD);
-    addEmittedDeferredDecl(GD, StringRef());
     return;
   }
 

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.h
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.h
@@ -341,25 +341,6 @@ private:
   /// yet.
   std::map<StringRef, GlobalDecl> DeferredDecls;
 
-  /// Decls that were DeferredDecls and have now been emitted.
-  std::map<StringRef, GlobalDecl> EmittedDeferredDecls;
-  void addEmittedDeferredDecl(GlobalDecl GD, StringRef MangledName) {
-    bool IsAFunction = isa<FunctionDecl>(GD.getDecl());
-    const VarDecl* VD = IsAFunction ? nullptr : dyn_cast<VarDecl>(GD.getDecl());
-    assert((IsAFunction || VD) && "Unexpected Decl type!");
-    bool ExcludeCtor = false; // FIXME: this is too simple!
-    llvm::GlobalValue::LinkageTypes L
-      = IsAFunction ? getFunctionLinkage(GD) :
-      getLLVMLinkageVarDefinition(VD, isTypeConstant(VD->getType(),
-                                                     ExcludeCtor));
-    if (llvm::GlobalValue::isLinkOnceLinkage(L)
-        || llvm::GlobalValue::isWeakLinkage(L)) {
-      if (MangledName.empty())
-        MangledName = getMangledName(GD);
-      EmittedDeferredDecls[MangledName] = GD;
-    }
-  }
-
   /// This is a list of deferred decls which we have seen that *are* actually
   /// referenced. These get code generated when the module is done.
   struct DeferredGlobal {
@@ -371,7 +352,6 @@ private:
   void addDeferredDeclToEmit(llvm::GlobalValue *GV, GlobalDecl GD,
                              StringRef MangledName) {
     DeferredDeclsToEmit.emplace_back(GV, GD);
-    addEmittedDeferredDecl(GD, MangledName);
   }
 
   /// List of alias we have emitted. Used to make sure that what they point to

--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -149,9 +149,6 @@ namespace clang {
              && "Newly created module should not have deferred decls");
       Builder->DeferredDecls.swap(OldBuilder->DeferredDecls);
 
-      assert(OldBuilder->EmittedDeferredDecls.empty()
-             && "Still have (unmerged) EmittedDeferredDecls deferred decls");
-
       assert(Builder->DeferredVTables.empty()
              && "Newly created module should not have deferred vtables");
       Builder->DeferredVTables.swap(OldBuilder->DeferredVTables);


### PR DESCRIPTION
This reverts:
* https://github.com/vgvassilev/clang/commit/d238d797fc
* https://github.com/vgvassilev/clang/commit/3b79abbb1b
* https://github.com/vgvassilev/clang/commit/be91dad03a

After communicating with the upstream, we found that this field
may not be needed to fix the inline functions in the cling. Related
discussion can be found here: https://reviews.llvm.org/D126781

Signed-off-by: Jun Zhang <jun@junz.org>

CC @vgvassilev @Axel-Naumann 


