### PR TITLE
[TMVA][SOFIE] Use enum for options.

### DIFF
--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -1,6 +1,7 @@
 #ifndef TMVA_SOFIE_RMODEL
 #define TMVA_SOFIE_RMODEL
 
+#include <type_traits>
 #include <unordered_set>
 #include <vector>
 #include <unordered_map>
@@ -19,14 +20,14 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
-enum class GenerateOption : int8_t {
+enum class Options {
    kDefault = 0x0,
    kNoSession = 0x1,
    kNoWeightFile = 0x2,
 };
 
-int8_t operator|(GenerateOption opA, GenerateOption opB);
-int8_t operator|(int8_t opA, GenerateOption opB);
+std::underlying_type_t<Options> operator|(Options opA, Options opB);
+std::underlying_type_t<Options> operator|(std::underlying_type_t<Options> opA, Options opB);
 
 class RModel: public TObject{
 
@@ -93,9 +94,9 @@ public:
 
 
    void Initialize(int batchSize=1);
-   void Generate(int8_t options, int batchSize = 1);
-   void Generate(GenerateOption options = GenerateOption::kDefault, int batchSize = 1) {
-      Generate(static_cast<int8_t>(options), batchSize);
+   void Generate(std::underlying_type_t<Options> options, int batchSize = 1);
+   void Generate(Options options = Options::kDefault, int batchSize = 1) {
+      Generate(static_cast<std::underlying_type_t<Options>>(options), batchSize);
    }
 
    void ReadInitializedTensorsFromFile();

--- a/tmva/sofie/inc/TMVA/RModel.hxx
+++ b/tmva/sofie/inc/TMVA/RModel.hxx
@@ -19,10 +19,18 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
+enum class GenerateOption : int8_t {
+   kDefault = 0x0,
+   kNoSession = 0x1,
+   kNoWeightFile = 0x2,
+};
+
+int8_t operator|(GenerateOption opA, GenerateOption opB);
+int8_t operator|(int8_t opA, GenerateOption opB);
+
 class RModel: public TObject{
 
 private:
-
    std::unordered_map<std::string, InputTensorInfo> fInputTensorInfos; //graph input only; not including operator input (intermediate tensors)
    std::unordered_map<std::string, TensorInfo> fReadyInputTensorInfos;
    std::unordered_map<std::string, InitializedTensor> fInitializedTensors;
@@ -42,10 +50,8 @@ private:
 
    const std::unordered_set<std::string> fAllowedStdLib = {"vector", "algorithm", "cmath"};
    std::unordered_set<std::string> fNeededStdLib = {"vector"};
-   bool fUseWeightFile = false;
-   bool fUseSession = false;
-
-
+   bool fUseWeightFile = true;
+   bool fUseSession = true;
 
 public:
 
@@ -87,7 +93,10 @@ public:
 
 
    void Initialize(int batchSize=1);
-   void Generate(bool useSession = true, bool useWeightFile = true, int batchSize = 1);
+   void Generate(int8_t options, int batchSize = 1);
+   void Generate(GenerateOption options = GenerateOption::kDefault, int batchSize = 1) {
+      Generate(static_cast<int8_t>(options), batchSize);
+   }
 
    void ReadInitializedTensorsFromFile();
    void WriteInitializedTensorsToFile(std::string filename = "");

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -11,6 +11,13 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
+   int8_t operator|(GenerateOption opA, GenerateOption opB) {
+      return static_cast<int8_t>(opA) | static_cast<int8_t>(opB);
+   }
+   int8_t operator|(int8_t opA, GenerateOption opB) {
+      return opA | static_cast<int8_t>(opB);
+   }
+
    RModel::RModel(RModel&& other){
       fInputTensorInfos = std::move(other.fInputTensorInfos);
       fReadyInputTensorInfos = std::move(other.fReadyInputTensorInfos);
@@ -199,8 +206,12 @@ namespace SOFIE{
       }
    }
 
-   void RModel::Generate(bool useSession, bool useWeightFile, int batchSize){
-      fUseSession = useSession;  // session flag is used in operator initialize
+   void RModel::Generate(int8_t options, int batchSize){
+      // session flag is used in operator initialize
+      if (static_cast<int8_t>(GenerateOption::kNoSession) & options)
+         fUseSession = false;
+      if (static_cast<int8_t>(GenerateOption::kNoWeightFile) & options)
+         fUseWeightFile = false;
       Initialize(batchSize);
       fGC += ("//Code generated automatically by TMVA for Inference of Model file [" + fFileName + "] at [" + fParseTime.substr(0, fParseTime.length()-1) +"] \n");
       // add header guards
@@ -215,7 +226,7 @@ namespace SOFIE{
       // for the session we need to include SOFIE_Common functions
       //needed for convolution operator (need to add a flag)
       fGC += "#include \"TMVA/SOFIE_common.hxx\"\n";
-      if (useWeightFile)
+      if (fUseWeightFile)
          fGC += "#include <fstream>\n";
 
       fGC += "\nnamespace TMVA_SOFIE_" + fName + "{\n";
@@ -238,7 +249,7 @@ namespace SOFIE{
          }
          fGC += ("}//BLAS\n");
       }
-      if (useSession) {
+      if (fUseSession) {
          fGC += "struct Session {\n";
       }
       for (auto& i: fInitializedTensors){
@@ -247,7 +258,7 @@ namespace SOFIE{
             for (auto & dim: i.second.fShape){
                length *= dim;
             }
-            if (!useWeightFile) {
+            if (!fUseWeightFile) {
                fGC += "float tensor_" + i.first + "[" + std::to_string(length) + "] = {";
                std::shared_ptr<float> data = std::static_pointer_cast<float>(i.second.fData);
                std::stringstream floats;
@@ -276,7 +287,7 @@ namespace SOFIE{
             fGC += "float * tensor_" + i.first + " = fTensor_" + i.first  + ".data();\n";
          }
       }
-      if (useSession) {
+      if (fUseSession) {
          // add here specific operator code that needs to define session data members
          fGC += "\n";
          for (size_t id = 0; id < fOperators.size(); id++) {
@@ -286,10 +297,10 @@ namespace SOFIE{
          fGC += "\n";
          fGC += "Session(std::string filename =\"\") {\n";
          // here add initialization and reading of weight tensors
-         if (useWeightFile) {
+         if (fUseWeightFile) {
             fGC += "   if (filename.empty()) filename = \"" + fName + ".dat\";\n";
             ReadInitializedTensorsFromFile();
-            fUseWeightFile = useWeightFile;
+            //fUseWeightFile = fUseWeightFile;
          }
          // add here initialization code
          for (size_t id = 0; id < fOperators.size() ; id++){
@@ -373,7 +384,7 @@ namespace SOFIE{
       }
       fGC += "\treturn ret;\n";
       fGC += "}\n";
-      if (useSession) {
+      if (fUseSession) {
          fGC += "};\n";
       }
       fGC += ("} //TMVA_SOFIE_" + fName + "\n");

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -11,11 +11,11 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
-   int8_t operator|(GenerateOption opA, GenerateOption opB) {
-      return static_cast<int8_t>(opA) | static_cast<int8_t>(opB);
+   std::underlying_type_t<Options> operator|(Options opA, Options opB) {
+      return static_cast<std::underlying_type_t<Options>>(opA) | static_cast<std::underlying_type_t<Options>>(opB);
    }
-   int8_t operator|(int8_t opA, GenerateOption opB) {
-      return opA | static_cast<int8_t>(opB);
+   std::underlying_type_t<Options> operator|(std::underlying_type_t<Options> opA, Options opB) {
+      return opA | static_cast<std::underlying_type_t<Options>>(opB);
    }
 
    RModel::RModel(RModel&& other){
@@ -206,11 +206,11 @@ namespace SOFIE{
       }
    }
 
-   void RModel::Generate(int8_t options, int batchSize){
+   void RModel::Generate(std::underlying_type_t<Options> options, int batchSize){
       // session flag is used in operator initialize
-      if (static_cast<int8_t>(GenerateOption::kNoSession) & options)
+      if (static_cast<std::underlying_type_t<Options>>(Options::kNoSession) & options)
          fUseSession = false;
-      if (static_cast<int8_t>(GenerateOption::kNoWeightFile) & options)
+      if (static_cast<std::underlying_type_t<Options>>(Options::kNoWeightFile) & options)
          fUseWeightFile = false;
       Initialize(batchSize);
       fGC += ("//Code generated automatically by TMVA for Inference of Model file [" + fFileName + "] at [" + fParseTime.substr(0, fParseTime.length()-1) +"] \n");

--- a/tmva/sofie/test/EmitFromRoot.cxx
+++ b/tmva/sofie/test/EmitFromRoot.cxx
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]){
    fileRead.GetObject("model",modelPtr);
    fileRead.Close();
    // in this case we don't write session class and weight file
-   modelPtr->Generate(GenerateOption::kNoSession | GenerateOption::kNoWeightFile);
+   modelPtr->Generate(Options::kNoSession | Options::kNoWeightFile);
    modelPtr->OutputGenerated(outname+"_FromROOT.hxx");
    return 0;
 }

--- a/tmva/sofie/test/EmitFromRoot.cxx
+++ b/tmva/sofie/test/EmitFromRoot.cxx
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]){
    fileRead.GetObject("model",modelPtr);
    fileRead.Close();
    // in this case we don't write session class and weight file
-   modelPtr->Generate(false, false);
+   modelPtr->Generate(GenerateOption::kNoSession | GenerateOption::kNoWeightFile);
    modelPtr->OutputGenerated(outname+"_FromROOT.hxx");
    return 0;
 }

--- a/tmva/sofie/test/TestSofieModels.cxx
+++ b/tmva/sofie/test/TestSofieModels.cxx
@@ -22,7 +22,7 @@ void ExecuteSofieParser(std::string modelName) {
    std::cout << "parsing file " << inputName << std::endl;
    SOFIE::RModel model = parser.Parse(inputName);
    std::cout << "generating model.....\n";
-   model.Generate(1, 1);
+   model.Generate();
    std::string outputName = modelName + ".hxx";
    std::cout << "writing model as header .....\n";
    model.OutputGenerated(); // outputName);


### PR DESCRIPTION
## This Pull request:
Use enum as flags for RModel::Generate().

 By default, SOFIE will generate a session class and store the weights in a file:
 ```
using namespace TMVA::Experimental::SOFIE;
RModelParser_ONNX parser;
RModel model = parser.Parse("path/to/model.onnx");
model.Generate();
```

Here's how the options can be used to :
- not use the session class
```
model.Generate(Options::kNoSession);
```
- not save the weights in a file
```
model.Generate(Options::kNoWeightFile);
```
- not use both
```
model.Generate(Options::kNoSession | Options::kNoWeightFile);
```

## Checklist:

- [x] tested changes locally
- [] updated the docs (if necessary)
