### PR TITLE
[DF] Fix crash with jitted Define and non-jitted Vary

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -88,6 +88,29 @@ std::enable_if_t<IsRVec<Value_t>::value, const std::type_info &> GetInnerValueTy
       return typeid(typename Value_t::value_type);
 }
 
+// This overload is for the case of a single column and ret_type != RVec<RVec<...>>
+template <typename T>
+std::enable_if_t<!IsRVec<T>::value, void>
+ResizeResults(ROOT::RVec<T> &results, std::size_t /*nCols*/, std::size_t nVariations)
+{
+   results.resize(nVariations);
+}
+
+// This overload is for the case of ret_type == RVec<RVec<...>>
+template <typename T>
+std::enable_if_t<IsRVec<T>::value, void>
+ResizeResults(ROOT::RVec<T> &results, std::size_t nCols, std::size_t nVariations)
+{
+   if (nCols == 1) {
+      results.resize(nVariations);
+   } else {
+      results.resize(nCols);
+      for (auto &rvecOverVariations : results) {
+         rvecOverVariations.resize(nVariations);
+      }
+   }
+}
+
 template <typename F>
 class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    using ColumnTypes_t = typename CallableTraits<F>::arg_types;
@@ -153,7 +176,7 @@ public:
       fLoopManager->Register(this);
 
       for (auto i = 0u; i < lm.GetNSlots(); ++i)
-         fLastResults[i * RDFInternal::CacheLineStep<ret_type>()].resize(fVariationNames.size());
+         ResizeResults(fLastResults[i * RDFInternal::CacheLineStep<ret_type>()], colNames.size(), variationTags.size());
    }
 
    RVariation(const RVariation &) = delete;

--- a/tree/dataframe/src/RJittedDefine.cxx
+++ b/tree/dataframe/src/RJittedDefine.cxx
@@ -31,8 +31,13 @@ void *RJittedDefine::GetValuePtr(unsigned int slot)
 
 const std::type_info &RJittedDefine::GetTypeId() const
 {
-   assert(fConcreteDefine != nullptr);
-   return fConcreteDefine->GetTypeId();
+   if (fConcreteDefine)
+      return fConcreteDefine->GetTypeId();
+   else if (fTypeId)
+      return *fTypeId;
+   else
+      throw std::runtime_error("RDataFrame: Type info was requested for a Defined column type, but could not be "
+                               "retrieved. This should never happen, please report this as a bug.");
 }
 
 void RJittedDefine::Update(unsigned int slot, Long64_t entry)

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -127,6 +127,7 @@ TEST(RDFVary, RequireVariationsHaveConsistentType)
 #if !(defined(R__MACOSX) && defined(__arm64__))
 TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
 {
+   // non-jitted Define, jitted Vary with incompatible type
    auto df = ROOT::RDataFrame(10).Define("x", [] { return 1.f; });
    {
       auto s = df.Vary("x", "ROOT::RVecD{x*0.1}", 1).Sum<float>("x");
@@ -142,6 +143,7 @@ TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
          std::runtime_error);
    }
 
+   // non-jitted Define, jitted Vary with incompatible type (multiple columns varied simultaneously
    {
       auto s2 = df.Define("y", [] { return 1; })
                    .Vary({"x", "y"}, "ROOT::RVec<ROOT::RVecD>{{x*0.1}, {y*0.1}}", 1, "broken")
@@ -153,6 +155,39 @@ TEST(RDFVary, RequireVariationsHaveConsistentTypeJitted)
             const auto msg = "RVariationReader: type mismatch: column \"y\" is being used as int but the Define "
                              "or Vary node advertises it as double";
             EXPECT_STREQ(err.what(), msg);
+            throw;
+         },
+         std::runtime_error);
+   }
+
+   {
+      auto d2 = df.Define("z", "42");
+
+      // Jitted Define, non-jitted Vary with incompatible type
+      EXPECT_THROW(
+         try {
+            d2.Vary(
+               "z",
+               [] {
+                  return ROOT::RVecF{-1.f, 2.f};
+               },
+               {}, 2, "broken");
+         } catch (const std::runtime_error &err) {
+            const auto expected =
+               "Varied values for column \"z\" have a different type (float) than the nominal value (int).";
+            EXPECT_STREQ(err.what(), expected);
+            throw;
+         },
+         std::runtime_error);
+
+      // Jitted Define, jitted Vary with incompatible type
+      auto s = d2.Vary("z", "ROOT::RVecF{-1.f, 2.f}", 2, "broken").Sum<int>("z");
+      auto ss = ROOT::RDF::Experimental::VariationsFor(s);
+      EXPECT_THROW(
+         try { ss["broken:0"]; } catch (const std::runtime_error &err) {
+            const auto expected = "RVariationReader: type mismatch: column \"z\" is being used as int but the Define "
+                                  "or Vary node advertises it as float";
+            EXPECT_STREQ(err.what(), expected);
             throw;
          },
          std::runtime_error);

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -1472,6 +1472,24 @@ TEST_P(RDFVary, VarySnapshot)
       std::logic_error);
 }
 
+// this is a regression test, we used to read from wrong addresses in this case
+TEST_P(RDFVary, MoreVariedColumnsThanVariations)
+{
+   auto d = ROOT::RDataFrame(10)
+               .Define("x", [] { return 0; })
+               .Define("y", [] { return 0; })
+               .Vary(
+                  {"x", "y"},
+                  [] {
+                     return ROOT::RVec<ROOT::RVecI>{{1}, {2}};
+                  },
+                  {}, 1, "syst");
+   auto h = d.Sum<int>("y");
+   auto hs = ROOT::RDF::Experimental::VariationsFor(h);
+
+   EXPECT_EQ(hs["syst:0"], 20);
+}
+
 // instantiate single-thread tests
 INSTANTIATE_TEST_SUITE_P(Seq, RDFVary, ::testing::Values(false));
 


### PR DESCRIPTION
**First two commits**:

Sanity checks for a non-jitted Vary asked the nominal Define'd
columns static type information that a jitted Define did not have.

With this patch RJittedDefine should also have that type
information in most if not all cases.

**Last commit**:

Fix potential invalid memory access when using Vary.

Users can vary a single column or multiple columns simultaneously.
In the latter case, RVariation::fLastResults contains, for each
processing slot, an RVec of RVecs of results where the outer
dimension runs over the different columns and the inner one over
the varied values of each column.

Before this commit, RVariation was initializing fLastResults to
the wrong size in the case of multiple columns varied simultaneously,
which ended up causing invalid memory accesses during the event loop
in some cases.

This patch fixes the problem and adds a regression test.

