### PR TITLE
[DF] Fix invalid reads in Vary with many variations and multiple columns

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -111,6 +111,37 @@ ResizeResults(ROOT::RVec<T> &results, std::size_t nCols, std::size_t nVariations
    }
 }
 
+// Assign into fLastResults[slot] without changing the addresses of its elements (we gave those addresses away in
+// GetValuePtr)
+// This overload is for the case of a single column and ret_type != RVec<RVec<...>>
+template <typename T>
+std::enable_if_t<!IsRVec<T>::value, void>
+AssignResults(ROOT::RVec<T> &resStorage, ROOT::RVec<T> &&tmpResults, std::size_t /*nCols*/)
+{
+   const auto nVariations = resStorage.size(); // we have already checked that tmpResults has the same size
+
+   for (auto i = 0u; i < nVariations; ++i)
+      resStorage[i] = std::move(tmpResults[i]);
+}
+
+// This overload is for the case of ret_type == RVec<RVec<...>>
+template <typename T>
+std::enable_if_t<IsRVec<T>::value, void>
+AssignResults(ROOT::RVec<T> &resStorage, ROOT::RVec<T> &&tmpResults, std::size_t nCols)
+{
+   // we have already checked that tmpResults has the same inner size
+   const auto nVariations = nCols == 1 ? resStorage.size() : resStorage[0].size();
+
+   if (nCols == 1) {
+      for (auto varIdx = 0u; varIdx < nVariations; ++varIdx)
+         resStorage[varIdx] = std::move(tmpResults[varIdx]);
+   } else {
+      for (auto colIdx = 0u; colIdx < nCols; ++colIdx)
+         for (auto varIdx = 0u; varIdx < nVariations; ++varIdx)
+            resStorage[colIdx][varIdx] = std::move(tmpResults[colIdx][varIdx]);
+   }
+}
+
 template <typename F>
 class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    using ColumnTypes_t = typename CallableTraits<F>::arg_types;
@@ -127,16 +158,16 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    void UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
       // fExpression must return an RVec<T>
-      const auto &results = fExpression(fValues[slot][S]->template Get<ColTypes>(entry)...);
+      auto &&results = fExpression(fValues[slot][S]->template Get<ColTypes>(entry)...);
+
       if (!ResultsSizeEq(results, fVariationNames.size(), fColNames.size())) {
          std::string variationName = fVariationNames[0].substr(0, fVariationNames[0].find_first_of(':'));
          throw std::runtime_error("The evaluation of the expression for variation \"" + variationName +
                                   "\" resulted in " + std::to_string(GetNVariations(results)) + " values, but " +
                                   std::to_string(fVariationNames.size()) + " were expected.");
       }
-      // Assign into fLastResults without changing the addresses of its elements (we gave those addresses away in
-      // GetValuePtr)
-      fLastResults[slot * CacheLineStep<ret_type>()].assign(results.begin(), results.end());
+
+      AssignResults(fLastResults[slot * CacheLineStep<ret_type>()], std::move(results), fColNames.size());
 
       // silence "unused parameter" warnings in gcc
       (void)slot;

--- a/tree/dataframe/test/dataframe_vary.cxx
+++ b/tree/dataframe/test/dataframe_vary.cxx
@@ -1490,6 +1490,33 @@ TEST_P(RDFVary, MoreVariedColumnsThanVariations)
    EXPECT_EQ(hs["syst:0"], 20);
 }
 
+// this is a regression test for an issue that was hidden by RVec's small buffer optimization
+// when the variations don't fit in the smalll buffer and we are varying multiple columns simultaneously,
+// RVariation was changing the address of the varied values between entries, resulting in invalid reads
+// on the part of the RVariationReader.
+TEST_P(RDFVary, ManyVariationsManyColumns)
+{
+   auto d = ROOT::RDataFrame(10)
+               .Define("x", [] { return 0; })
+               .Define("y", [] { return 0; })
+               .Vary(
+                  {"x", "y"},
+                  [] {
+                     return ROOT::RVec<ROOT::RVecI>{ROOT::RVecI(100, 42), ROOT::RVecI(100, 8)};
+                  },
+                  {}, 100, "syst");
+
+   auto sx = d.Sum<int>("x");
+   auto sxs = ROOT::RDF::Experimental::VariationsFor(sx);
+   auto sy = d.Sum<int>("y");
+   auto sys = ROOT::RDF::Experimental::VariationsFor(sy);
+
+   for (int i = 0; i < 100; ++i) {
+      EXPECT_EQ(sxs["syst:" + std::to_string(i)], 420);
+      EXPECT_EQ(sys["syst:" + std::to_string(i)], 80);
+   }
+}
+
 // instantiate single-thread tests
 INSTANTIATE_TEST_SUITE_P(Seq, RDFVary, ::testing::Values(false));
 


### PR DESCRIPTION
When varying multiple columns simultaneously, RVariation was destroying
and re-creating the per-column RVecs of varied values at every entry,
which resulted in a change in  the address of the varied values between
entries, which caused invalid reads on the part of the RVariationReader
(which assumes the addresses of varied values are stable).

The issue was hidden by RVec's small buffer optimization, which was
keeping addresses stable as long as the number of variations fit the
small buffer.