### PR TITLE
Add missing header sys/socket.h.

### DIFF
--- a/core/base/src/TUUID.cxx
+++ b/core/base/src/TUUID.cxx
@@ -135,6 +135,7 @@ system clock catches up.
 #define random() rand()
 #else
 #include <unistd.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 #if defined(R__LINUX) && !defined(R__WINGCC)
 #include <sys/sysinfo.h>


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

At FreeBSD 13.1, the following compilation error appears:
```
core/base/src/TUUID.cxx:444:33: error: member access into incomplete type 'struct sockaddr'
               if (ifa->ifa_addr->sa_family != AF_INET) { // check only IP4
                                ^
/usr/include/ifaddrs.h:37:9: note: forward declaration of 'sockaddr'
        struct sockaddr *ifa_addr;
               ^
1 error generated.
```
The `struct sockaddr` is defined in the header file sys/socket.h ([specification](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/basedefs/sys_socket.h.html#tag_13_61)), which is missing. The header is added in this request.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

