### PR TITLE
[cling] Remove unused include of "llvm/Config/config.h"

### DIFF
--- a/interpreter/cling/lib/Interpreter/PerfJITEventListener.cpp
+++ b/interpreter/cling/lib/Interpreter/PerfJITEventListener.cpp
@@ -17,7 +17,6 @@
 
 #ifdef __linux__
 
-#include "llvm/Config/config.h"
 #include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Object/SymbolSize.h"


### PR DESCRIPTION
Including that header from cling breaks building ROOT with
external llvm and clang (which is needed e.g. for the conda
package): `config.h` is not avaiable in that scenario.

cc: @chrisburr 