### PR TITLE
[skip-ci][win64] Fix fatal compilation error on Windows 64

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -70,6 +70,9 @@ configure_file(RCsvDS_test_empty.csv . COPYONLY)
 configure_file(RCsvDS_test_win.csv . COPYONLY)
 configure_file(RCsvDS_test_NaNs.csv . COPYONLY)
 ROOT_ADD_GTEST(datasource_csv datasource_csv.cxx LIBRARIES ROOTDataFrame)
+if(MSVC AND "${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64")
+  set_source_files_properties(dataframe_vary.cxx COMPILE_FLAGS "-bigobj")
+endif()
 
 #### TESTS REQUIRING EXTRA ROOT FEATURES ####
 if (imt)


### PR DESCRIPTION
Fix the following compilation error on Windows 64:
```
dataframe_vary.cxx : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
```
