### PR TITLE
Fix potential issues with PyLong_AsLong

### DIFF
--- a/bindings/pyroot/pythonizations/src/PyzCppHelpers.cxx
+++ b/bindings/pyroot/pythonizations/src/PyzCppHelpers.cxx
@@ -100,7 +100,7 @@ unsigned long long GetDataPointerFromArrayInterface(PyObject *obj)
       PyErr_SetString(PyExc_RuntimeError, "Object not convertible: __array_interface__['data'] does not exist.");
       return 0;
    }
-   return PyLong_AsLong(PyTuple_GetItem(pydata, 0));
+   return PyLong_AsLongLong(PyTuple_GetItem(pydata, 0));
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/bindings/pyroot/pythonizations/src/TClassPyz.cxx
+++ b/bindings/pyroot/pythonizations/src/TClassPyz.cxx
@@ -50,7 +50,7 @@ PyObject *TClassDynamicCastPyz(CPPInstance *self, PyObject *args)
    if (CPPInstance_Check(pyobject)) {
       address = ((CPPInstance *)pyobject)->GetObject();
    } else if (PyInt_Check(pyobject) || PyLong_Check(pyobject)) {
-      address = (void *)PyLong_AsLong(pyobject);
+      address = (void *)PyLong_AsLongLong(pyobject);
    } else {
       Utility::GetBuffer(pyobject, '*', 1, address, false);
    }


### PR DESCRIPTION
Replace a couple of `PyLong_AsLong` by `PyLong_AsLongLong` when returning a `long long` and when converting to `void*` (would truncate the pointer value on Win64)
