### PR TITLE
[ntuple,daos] Adapt I/O backend to DAOSv2 API

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -27,6 +27,10 @@
 #include <type_traits>
 #include <vector>
 
+#ifndef DAOS_UUID_STR_SIZE
+#define DAOS_UUID_STR_SIZE 37
+#endif
+
 namespace ROOT {
 
 namespace Experimental {
@@ -41,14 +45,16 @@ class RDaosPool {
    friend class RDaosContainer;
 private:
    daos_handle_t fPoolHandle{};
+   uuid_t fPoolUuid{};
    std::string fPoolLabel{};
 
 public:
    RDaosPool(const RDaosPool&) = delete;
-   RDaosPool(std::string_view poolLabel);
+   RDaosPool(std::string_view poolId);
    ~RDaosPool();
 
    RDaosPool& operator=(const RDaosPool&) = delete;
+   std::string GetPoolUuid();
 };
 
 /**
@@ -134,6 +140,8 @@ public:
       std::vector<d_iov_t> fIovs{};
    };
 
+   std::string GetContainerUuid();
+
 private:
    struct DaosEventQueue {
       std::size_t fSize;
@@ -149,6 +157,7 @@ private:
    };
 
    daos_handle_t fContainerHandle{};
+   uuid_t fContainerUuid{};
    std::string fContainerLabel{};
    std::shared_ptr<RDaosPool> fPool;
    ObjClassId_t fDefaultObjectClass{OC_SX};
@@ -180,7 +189,7 @@ private:
    }
 
 public:
-   RDaosContainer(std::shared_ptr<RDaosPool> pool, std::string_view containerLabel, bool create = false);
+   RDaosContainer(std::shared_ptr<RDaosPool> pool, std::string_view containerId, bool create = false);
    ~RDaosContainer();
 
    ObjClassId_t GetDefaultObjectClass() const { return fDefaultObjectClass; }

--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -20,9 +20,6 @@
 #include <ROOT/TypeTraits.hxx>
 
 #include <daos.h>
-// Avoid depending on `gurt/common.h` as the only required declaration is `d_rank_list_free()`.
-// Also, this header file is known to provide macros that conflict with std::min()/std::max().
-extern "C" void d_rank_list_free(d_rank_list_t *rank_list);
 
 #include <functional>
 #include <memory>
@@ -44,11 +41,11 @@ class RDaosPool {
    friend class RDaosContainer;
 private:
    daos_handle_t fPoolHandle{};
-   uuid_t fPoolUuid{};
+   std::string fPoolLabel{};
 
 public:
    RDaosPool(const RDaosPool&) = delete;
-   RDaosPool(std::string_view poolUuid, std::string_view serviceReplicas);
+   RDaosPool(std::string_view poolLabel);
    ~RDaosPool();
 
    RDaosPool& operator=(const RDaosPool&) = delete;
@@ -107,7 +104,7 @@ public:
 
    RDaosObject() = delete;
    /// Provides low-level access to an object. If `cid` is OC_UNKNOWN, the user is responsible for
-   /// calling `daos_obj_generate_id()` to fill the reserved bits in `oid` before calling this constructor.
+   /// calling `daos_obj_generate_oid()` to fill the reserved bits in `oid` before calling this constructor.
    RDaosObject(RDaosContainer &container, daos_obj_id_t oid, ObjClassId cid = OC_UNKNOWN);
    ~RDaosObject();
 
@@ -152,7 +149,7 @@ private:
    };
 
    daos_handle_t fContainerHandle{};
-   uuid_t fContainerUuid{};
+   std::string fContainerLabel{};
    std::shared_ptr<RDaosPool> fPool;
    ObjClassId_t fDefaultObjectClass{OC_SX};
 
@@ -183,7 +180,7 @@ private:
    }
 
 public:
-   RDaosContainer(std::shared_ptr<RDaosPool> pool, std::string_view containerUuid, bool create = false);
+   RDaosContainer(std::shared_ptr<RDaosPool> pool, std::string_view containerLabel, bool create = false);
    ~RDaosContainer();
 
    ObjClassId_t GetDefaultObjectClass() const { return fDefaultObjectClass; }

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -100,7 +100,7 @@ private:
    std::unique_ptr<RDaosContainer> fDaosContainer;
    /// OID for the next committed page; it is automatically incremented in `CommitSealedPageImpl()`
    std::atomic<std::uint64_t> fOid{0};
-   /// \brief A URI to a DAOS pool of the form 'daos://pool-uuid:svc_replicas/container-uuid'
+   /// \brief A URI to a DAOS pool of the form 'daos://pool-label/container-label'
    std::string fURI;
    /// Tracks the number of bytes committed to the current cluster
    std::uint64_t fNBytesCurrentCluster{0};
@@ -169,7 +169,7 @@ private:
    RCluster *fCurrentCluster = nullptr;
    /// A container that stores object data (header/footer, pages, etc.)
    std::unique_ptr<RDaosContainer> fDaosContainer;
-   /// A URI to a DAOS pool of the form 'daos://pool-uuid:svc_replicas/container-uuid'
+   /// A URI to a DAOS pool of the form 'daos://pool-label/container-label'
    std::string fURI;
    /// The cluster pool asynchronously preloads the next few clusters
    std::unique_ptr<RClusterPool> fClusterPool;

--- a/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
+++ b/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
@@ -239,36 +239,10 @@ typedef struct {
 
 #define DAOS_PROP_LABEL_MAX_LEN (127)
 #define DAOS_PROP_MAX_LABEL_BUF_LEN (DAOS_PROP_LABEL_MAX_LEN + 1)
+#define DAOS_UUID_STR_SIZE (37) // 36 + 1 for '\0'
 
-/**
- * Check if DAOS (pool or container property) label string is valid.
- * DAOS labels must consist only of alphanumeric characters, colon ':',
- * period '.', hyphen '-' or underscore '_', and must be of length
- * [1 - DAOS_PROP_LABEL_MAX_LEN].
- * Unlike in libdaos, UUIDs are deemed valid labels for libdaos_mock.
- * \param[in] label	    Label string
- * \return	  true      Label meets length/format requirements
- *			  false     Label is not valid length or format
- */
-static inline bool daos_label_is_valid(const char *label)
+static inline bool daos_label_is_valid(const char * /*label*/)
 {
-   int len;
-   int i;
-
-   if (label == NULL)
-      return false;
-
-   len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN + 1);
-   if (len == 0 || len > DAOS_PROP_LABEL_MAX_LEN)
-      return false;
-
-   // Verify that it contains only alphanumeric characters or :.-_
-   for (i = 0; i < len; i++) {
-      char c = label[i];
-      if (isalnum(c) || c == '.' || c == '_' || c == ':' || c == '-')
-         continue;
-      return false;
-   }
    return true;
 }
 
@@ -280,10 +254,9 @@ static inline bool daos_label_is_valid(const char *label)
 
 /** Container information */
 typedef struct {
-	char		unused; // silence [-Wextern-c-compat]
+   uuid_t ci_uuid;
 } daos_cont_info_t;
 
-int daos_cont_create(daos_handle_t poh, uuid_t uuid, daos_prop_t *cont_prop, daos_event_t *ev);
 int daos_cont_create_with_label(daos_handle_t poh, const char *label, daos_prop_t *cont_prop, uuid_t *uuid,
                                 daos_event_t *ev);
 int daos_cont_open(daos_handle_t poh, const char *uuid, unsigned int flags, daos_handle_t *coh, daos_cont_info_t *info,
@@ -295,7 +268,7 @@ int daos_cont_close(daos_handle_t coh, daos_event_t *ev);
 
 /** Storage pool */
 typedef struct {
-	char		unused; // silence [-Wextern-c-compat]
+   uuid_t pi_uuid;
 } daos_pool_info_t;
 
 int daos_pool_connect(const char *pool, const char *grp, unsigned int flags, daos_handle_t *poh, daos_pool_info_t *info,

--- a/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
+++ b/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
@@ -16,22 +16,22 @@
 /**
  * \file
  *
- * This file is a reduced version of `daos_xxx.h` headers that provides (simplified) declarations for use in libdaos_mock.
+ * This file is a reduced version of `daos_xxx.h` headers that provides (simplified) declarations for use in
+ * libdaos_mock.
  */
 
 #ifndef __DAOS_H__
 #define __DAOS_H__
 extern "C" {
 
-
 //////////////////////////////////////////////////////////////////////////////// daos_types.h
-
 
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>
 #include <uuid/uuid.h>
+#include <ctype.h>
 
 /** iovec for memory buffer */
 typedef struct {
@@ -39,10 +39,6 @@ typedef struct {
 	size_t		iov_buf_len;
 	size_t		iov_len;
 } d_iov_t;
-
-typedef struct {
-	char		unused; // silence [-Wextern-c-compat]
-} d_rank_list_t;
 
 /** Scatter/gather list for memory buffers */
 typedef struct {
@@ -63,6 +59,12 @@ typedef uint64_t	daos_size_t;
 typedef struct {
 	uint64_t	cookie;
 } daos_handle_t;
+
+typedef enum {
+   DAOS_EQR_COMPLETED = (1),
+   DAOS_EQR_WAITING = (1 << 1),
+   DAOS_EQR_ALL = (DAOS_EQR_COMPLETED | DAOS_EQR_WAITING),
+} daos_eq_query_t;
 
 #define DAOS_HDL_INVAL	((daos_handle_t){0})
 #define DAOS_TX_NONE	DAOS_HDL_INVAL
@@ -90,14 +92,12 @@ typedef struct daos_event {
 
 //////////////////////////////////////////////////////////////////////////////// daos_event.h
 
-
 int daos_eq_create(daos_handle_t *eqh);
 int daos_eq_destroy(daos_handle_t eqh, int flags);
-int daos_eq_poll(daos_handle_t eqh, int wait_running,
-	     int64_t timeout, unsigned int nevents, daos_event_t **events);
+int daos_eq_poll(daos_handle_t eqh, int wait_running, int64_t timeout, unsigned int nevents, daos_event_t **events);
+
 int daos_event_init(daos_event_t *ev, daos_handle_t eqh, daos_event_t *parent);
 int daos_event_fini(daos_event_t *ev);
-
 
 //////////////////////////////////////////////////////////////////////////////// daos_obj_class.h
 
@@ -130,8 +130,8 @@ enum {
 	OC_RESERVED		= (1U << 10),
 };
 
-typedef uint16_t		daos_oclass_id_t;
-typedef uint16_t		daos_ofeat_t;
+typedef uint16_t daos_oclass_id_t;
+typedef uint16_t daos_oclass_hints_t;
 
 int daos_oclass_name2id(const char *name);
 int daos_oclass_id2name(daos_oclass_id_t oc_id, char *name);
@@ -145,33 +145,42 @@ typedef struct {
 	uint64_t	hi;
 } daos_obj_id_t;
 
-#define OID_FMT_VER		1
+#define DAOS_OBJ_NIL ((daos_obj_id_t){0})
 
-#define OID_FMT_INTR_BITS	32
-#define OID_FMT_VER_BITS	4
-#define OID_FMT_FEAT_BITS	16
-#define OID_FMT_CLASS_BITS	(OID_FMT_INTR_BITS - OID_FMT_VER_BITS - \
-				 OID_FMT_FEAT_BITS)
+#define OID_FMT_INTR_BITS 32 // 32 bits for DAOS internal use
+#define OID_FMT_TYPE_BITS 8
+#define OID_FMT_CLASS_BITS 8
+#define OID_FMT_META_BITS 16
 
-#define OID_FMT_VER_SHIFT	(64 - OID_FMT_VER_BITS)
-#define OID_FMT_FEAT_SHIFT	(OID_FMT_VER_SHIFT - OID_FMT_FEAT_BITS)
-#define OID_FMT_CLASS_SHIFT	(OID_FMT_FEAT_SHIFT - OID_FMT_CLASS_BITS)
+#define OID_FMT_TYPE_SHIFT (64 - OID_FMT_TYPE_BITS)
+#define OID_FMT_CLASS_SHIFT (OID_FMT_TYPE_SHIFT - OID_FMT_CLASS_BITS)
+#define OID_FMT_META_SHIFT (OID_FMT_CLASS_SHIFT - OID_FMT_META_BITS)
 
-enum {
-	DAOS_OF_DKEY_UINT64	= (1 << 0),
-	DAOS_OF_AKEY_UINT64	= (1 << 2),
-	DAOS_OF_ARRAY_BYTE	= (1 << 7),
+/// DAOS object type
+enum daos_otype_t {
+   DAOS_OT_MULTI_HASHED = 0, // default: multi-level KV with hashed [ad]keys
+   DAOS_OT_DKEY_UINT64 = 2,
+   DAOS_OT_AKEY_UINT64 = 3,
+   DAOS_OT_MULTI_UINT64 = 4,
+   DAOS_OT_ARRAY = 11,
+   DAOS_OT_ARRAY_BYTE = 13,
+   DAOS_OT_MAX = 13,
 };
 
+static inline bool daos_otype_t_is_valid(enum daos_otype_t type)
+{
+   return type <= DAOS_OT_MAX;
+}
+
 enum {
-	DAOS_COND_DKEY_FETCH	= (1 << 3),
-	DAOS_COND_AKEY_FETCH	= (1 << 6),
+   DAOS_COND_DKEY_FETCH = (1 << 3),
+   DAOS_COND_AKEY_FETCH = (1 << 6),
 };
 
 /** Object open modes */
 enum {
-	DAOS_OO_RO             = (1 << 1),
-	DAOS_OO_RW             = (1 << 2),
+   DAOS_OO_RO = (1 << 1),
+   DAOS_OO_RW = (1 << 2),
 };
 
 typedef struct {
@@ -201,33 +210,17 @@ enum {
 	DAOS_REC_ANY		= 0,
 };
 
-static inline int daos_obj_generate_id(daos_obj_id_t *oid, daos_ofeat_t ofeats,
-		     daos_oclass_id_t cid, uint32_t args)
-{
-	(void)args;
-	uint64_t hdr;
+/// Flags for oclass hints
+enum {
+   // OC Redundancy flags
+   DAOS_OCH_RDD_DEF = (1 << 0), // Default: RF prop
+   // OC Sharding flags
+   DAOS_OCH_SHD_DEF = (1 << 4), // Default: MAX for array & flat KV, else 1
+};
 
-	/* TODO: add check at here, it should return error if user specified
-	 * bits reserved by DAOS
-	 */
-	oid->hi &= (1ULL << OID_FMT_INTR_BITS) - 1;
-	/**
-	 * | Upper bits contain
-	 * | OID_FMT_VER_BITS (version)		 |
-	 * | OID_FMT_FEAT_BITS (object features) |
-	 * | OID_FMT_CLASS_BITS (object class)	 |
-	 * | 96-bit for upper layer ...		 |
-	 */
-	hdr  = ((uint64_t)OID_FMT_VER << OID_FMT_VER_SHIFT);
-	hdr |= ((uint64_t)ofeats << OID_FMT_FEAT_SHIFT);
-	hdr |= ((uint64_t)cid << OID_FMT_CLASS_SHIFT);
-	oid->hi |= hdr;
-
-	return 0;
-}
-
-int daos_obj_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode,
-	      daos_handle_t *oh, daos_event_t *ev);
+int daos_obj_generate_oid(daos_handle_t coh, daos_obj_id_t *oid, enum daos_otype_t type, daos_oclass_id_t cid,
+                          daos_oclass_hints_t hints, uint32_t args);
+int daos_obj_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode, daos_handle_t *oh, daos_event_t *ev);
 int daos_obj_close(daos_handle_t oh, daos_event_t *ev);
 int daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
@@ -239,12 +232,45 @@ int daos_obj_update(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 
 //////////////////////////////////////////////////////////////////////////////// daos_prop.h
 
-
 /** daos properties, for pool or container */
 typedef struct {
 	char		unused; // silence [-Wextern-c-compat]
 } daos_prop_t;
 
+#define DAOS_PROP_LABEL_MAX_LEN (127)
+#define DAOS_PROP_MAX_LABEL_BUF_LEN (DAOS_PROP_LABEL_MAX_LEN + 1)
+
+/**
+ * Check if DAOS (pool or container property) label string is valid.
+ * DAOS labels must consist only of alphanumeric characters, colon ':',
+ * period '.', hyphen '-' or underscore '_', and must be of length
+ * [1 - DAOS_PROP_LABEL_MAX_LEN].
+ * Unlike in libdaos, UUIDs are deemed valid labels for libdaos_mock.
+ * \param[in] label	    Label string
+ * \return	  true      Label meets length/format requirements
+ *			  false     Label is not valid length or format
+ */
+static inline bool daos_label_is_valid(const char *label)
+{
+   int len;
+   int i;
+
+   if (label == NULL)
+      return false;
+
+   len = strnlen(label, DAOS_PROP_LABEL_MAX_LEN + 1);
+   if (len == 0 || len > DAOS_PROP_LABEL_MAX_LEN)
+      return false;
+
+   // Verify that it contains only alphanumeric characters or :.-_
+   for (i = 0; i < len; i++) {
+      char c = label[i];
+      if (isalnum(c) || c == '.' || c == '_' || c == ':' || c == '-')
+         continue;
+      return false;
+   }
+   return true;
+}
 
 //////////////////////////////////////////////////////////////////////////////// daos_cont.h
 
@@ -257,14 +283,12 @@ typedef struct {
 	char		unused; // silence [-Wextern-c-compat]
 } daos_cont_info_t;
 
-d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
-
-int daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
-		 daos_event_t *ev);
-int daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
-	       daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev);
+int daos_cont_create(daos_handle_t poh, uuid_t uuid, daos_prop_t *cont_prop, daos_event_t *ev);
+int daos_cont_create_with_label(daos_handle_t poh, const char *label, daos_prop_t *cont_prop, uuid_t *uuid,
+                                daos_event_t *ev);
+int daos_cont_open(daos_handle_t poh, const char *uuid, unsigned int flags, daos_handle_t *coh, daos_cont_info_t *info,
+                   daos_event_t *ev);
 int daos_cont_close(daos_handle_t coh, daos_event_t *ev);
-
 
 //////////////////////////////////////////////////////////////////////////////// daos_pool.h
 
@@ -274,17 +298,16 @@ typedef struct {
 	char		unused; // silence [-Wextern-c-compat]
 } daos_pool_info_t;
 
-int daos_pool_connect(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, unsigned int flags,
-		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
+int daos_pool_connect(const char *pool, const char *grp, unsigned int flags, daos_handle_t *poh, daos_pool_info_t *info,
+                      daos_event_t *ev);
 int daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev);
-
 
 //////////////////////////////////////////////////////////////////////////////// daos_errno.h
 
-
 #define DER_ERR_GURT_BASE 1000
-#define DER_INVAL		(DER_ERR_GURT_BASE + 3)
+#define DER_INVAL (DER_ERR_GURT_BASE + 3)
+#define DER_EXIST (DER_ERR_GURT_BASE + 4)
+
 const char *d_errstr(int rc);
 
 
@@ -293,6 +316,5 @@ const char *d_errstr(int rc);
 
 int daos_init(void);
 int daos_fini(void);
-
 }
 #endif /* __DAOS_H__ */

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -41,24 +41,22 @@
 
 namespace {
 struct RDaosURI {
-   /// \brief UUID of the DAOS pool
-   std::string fPoolUuid;
-   /// \brief Ranks of the service replicas, separated by `_`
-   std::string fSvcReplicas;
-   /// \brief UUID of the container for this RNTuple
-   std::string fContainerUuid;
+   /// \brief Label of the DAOS pool
+   std::string fPoolLabel;
+   /// \brief Label of the container for this RNTuple
+   std::string fContainerLabel;
 };
 
 /**
-  \brief Parse a DAOS RNTuple URI of the form 'daos://pool-uuid:svc_replicas/container_uuid'.
+  \brief Parse a DAOS RNTuple URI of the form 'daos://pool_id/container_id'.
 */
 RDaosURI ParseDaosURI(std::string_view uri)
 {
-   std::regex re("daos://([[:xdigit:]-]+):([[:digit:]_]+)/([[:xdigit:]-]+)");
+   std::regex re("daos://([^/]+)/(.+)");
    std::cmatch m;
    if (!std::regex_match(uri.data(), m, re))
       throw ROOT::Experimental::RException(R__FAIL("Invalid DAOS pool URI."));
-   return { m[1], m[2], m[3] };
+   return {m[1], m[2]};
 }
 
 /// \brief Some random distribution/attribute key.  TODO: apply recommended schema, i.e.
@@ -148,8 +146,8 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CreateImpl(const RNTupleModel & 
       throw ROOT::Experimental::RException(R__FAIL("Unknown object class " + fNTupleAnchor.fObjClass));
 
    auto args = ParseDaosURI(fURI);
-   auto pool = std::make_shared<RDaosPool>(args.fPoolUuid, args.fSvcReplicas);
-   fDaosContainer = std::make_unique<RDaosContainer>(pool, args.fContainerUuid, /*create =*/ true);
+   auto pool = std::make_shared<RDaosPool>(args.fPoolLabel);
+   fDaosContainer = std::make_unique<RDaosContainer>(pool, args.fContainerLabel, /*create =*/true);
    fDaosContainer->SetDefaultObjectClass(oclass);
 
    auto zipBuffer = std::make_unique<unsigned char[]>(length);
@@ -303,8 +301,8 @@ ROOT::Experimental::Detail::RPageSourceDaos::RPageSourceDaos(std::string_view nt
    EnableDefaultMetrics("RPageSourceDaos");
 
    auto args = ParseDaosURI(uri);
-   auto pool = std::make_shared<RDaosPool>(args.fPoolUuid, args.fSvcReplicas);
-   fDaosContainer = std::make_unique<RDaosContainer>(pool, args.fContainerUuid);
+   auto pool = std::make_shared<RDaosPool>(args.fPoolLabel);
+   fDaosContainer = std::make_unique<RDaosContainer>(pool, args.fContainerLabel);
 }
 
 

--- a/tree/ntuple/v7/src/libdaos_mock/libdaos_mock.cxx
+++ b/tree/ntuple/v7/src/libdaos_mock/libdaos_mock.cxx
@@ -276,17 +276,6 @@ int daos_oclass_id2name(daos_oclass_id_t oc_id, char *name)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-int daos_cont_create(daos_handle_t poh, uuid_t uuid, daos_prop_t * /*cont_prop*/, daos_event_t * /*ev*/)
-{
-   auto pool = RDaosHandle::ToPointer<RDaosFakePool>(poh);
-
-   if (!pool)
-      return -DER_INVAL;
-
-   pool->CreateContainer(label_t(reinterpret_cast<char *>(uuid)));
-   return 0;
-}
-
 int daos_cont_create_with_label(daos_handle_t poh, const char *label, daos_prop_t * /*cont_prop*/, uuid_t * /*uuid*/,
                                 daos_event_t * /*ev*/)
 {

--- a/tree/ntuple/v7/test/CMakeLists.txt
+++ b/tree/ntuple/v7/test/CMakeLists.txt
@@ -52,7 +52,7 @@ ROOT_ADD_GTEST(ntuple_extended ntuple_extended.cxx LIBRARIES ROOTDataFrame ROOTN
 if(daos OR daos_mock)
   # UUID of the DAOS pool used for testing, if not provided (may be any for libdaos_mock).
   if(NOT daos_test_pool)
-    set(daos_test_pool 1b245c52-765e-449d-80b1-8dce93bafc4b)
+    set(daos_test_pool ntuple-daos-test-pool)
   endif()
   set_property(SOURCE ntuple_storage_daos.cxx
                APPEND PROPERTY COMPILE_DEFINITIONS R__DAOS_TEST_POOL="${daos_test_pool}")

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -1,15 +1,16 @@
 #include "ntuple_test.hxx"
 #include <ROOT/RPageStorageDaos.hxx>
 #include "ROOT/TestSupport.hxx"
+#include <iostream>
 
 TEST(RPageStorageDaos, Basics)
 {
    ROOT::TestSupport::CheckDiagsRAII diags;
-   diags.requiredDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
+   diags.optionalDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
    diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos", "The DAOS backend is experimental and still under development.", false);
    diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
 
-   std::string daosUri("daos://" R__DAOS_TEST_POOL ":1/a947484e-e3bc-48cb-8f71-3292c19b59a4");
+   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-1");
 
    auto model = RNTupleModel::Create();
    auto wrPt = model->MakeField<float>("pt", 42.0);
@@ -39,7 +40,7 @@ TEST(RPageStorageDaos, Basics)
 
 TEST(RPageStorageDaos, Extended)
 {
-   std::string daosUri("daos://" R__DAOS_TEST_POOL ":1/a947484e-e3bc-48cb-8f71-3292c19b59a4");
+   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-2");
 
    auto model = RNTupleModel::Create();
    auto wrVector = model->MakeField<std::vector<double>>("vector");
@@ -78,7 +79,7 @@ TEST(RPageStorageDaos, Extended)
 
 TEST(RPageStorageDaos, Options)
 {
-   std::string daosUri("daos://" R__DAOS_TEST_POOL ":1/a947484e-e3bc-48cb-8f71-3292c19b59a4");
+   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-3");
 
    {
       auto model = RNTupleModel::Create();


### PR DESCRIPTION
# This Pull request:
Makes changes to ROOT v7 in order to comply with the API for DAOS 2.0.x, affecting the libraries `RPageStorageDaos`, `RDaos` and `libdaos_mock`, as well as the `ntuple_storage_daos` test suite.

## Changes or fixes:
- As of DAOS 2.0, pool service replica ranks are not longer specified in DAOS URIs.  Thus, `daos_pool_connect` now forgoes the `svc_rank_list` argument.
  - Container addresses follow the simplified pattern `daos://($pool)/($container)`. 
  - `RPageStorageDaos` consequently drops parsing enforcement of the previous pattern.
- DAOS 2.0 introduced support for creating pools and containers from a label that is then hashed internally as a UUID. Pool and containers are now identifiable by user-provided labels of up to 127 characters (alphanumeric, colon, period, hyphen or underscore) or by 36-character UUIDs. Labels that match a UUID pattern are explicitly forbidden. 
  - `RDaos` now only supports container creation from user-supplied labels (via `daos_cont_create_with_label`), due to deprecated usage of `daos_cont_create` with user-supplied UUIDs. However, existing containers may still be opened by their UUIDs. 
  - `RPool` and `RContainer` maintain a copy of valid labels (when supplied) and UUIDs (after successfully opening pools and containers respectively)
- Generation of object IDs in `RDaos`: new redundancy, sharding and object type flags; `daos_obj_generate_oid` replaces `daos_obj_generate_id`. 
- The `libdaos_mock` library is updated in lockstep.
- RNTuple backend testing is updated to follow the DAOS 2.0 URI pattern, using labels for default test pool and containers.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 
