### PR TITLE
[cmake] Update XRootD to v5.4.3

### DIFF
--- a/builtins/xrootd/CMakeLists.txt
+++ b/builtins/xrootd/CMakeLists.txt
@@ -8,8 +8,8 @@ include(ExternalProject)
 
 find_package(OpenSSL REQUIRED)
 
-set(XROOTD_VERSION "5.4.2")
-set(XROOTD_VERSIONNUM 500040002 CACHE INTERNAL "" FORCE)
+set(XROOTD_VERSION "5.4.3")
+set(XROOTD_VERSIONNUM 500040003 CACHE INTERNAL "" FORCE)
 set(lcgpackages http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources)
 set(XROOTD_SRC_URI ${lcgpackages}/xrootd-${XROOTD_VERSION}.tar.gz)
 set(XROOTD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/XROOTD-prefix)
@@ -34,7 +34,7 @@ endif()
 ExternalProject_Add(
     XROOTD
     URL ${XROOTD_SRC_URI}
-    URL_HASH SHA256=84e8a9a2bcad116df479f94e985c287dd99fbac0613d4fbb61f4ccc0cef81fa3
+    URL_HASH SHA256=56a29c88232f2f384e151b148fcaaa8d8db5c5fdc4615193978c8f4f3a99663c
     INSTALL_DIR ${XROOTD_PREFIX}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                -DCMAKE_PREFIX_PATH:STRING=${OPENSSL_PREFIX}


### PR DESCRIPTION
# This Pull request:

* Update XRootD builtin from [`v5.4.2`](https://github.com/xrootd/xrootd/releases/tag/v5.4.2) to [`v5.4.3`](https://github.com/xrootd/xrootd/releases/tag/v5.4.3)
* Follow up to PR #10025 for v5.4.2

## Changes or fixes:

* Update XRootD builtin from v5.4.2 to v5.4.3
   - c.f. https://github.com/xrootd/xrootd/issues/1699 for full details.

## Checklist:

- [x] tested changes locally

   - I didn't build ROOT from source (though c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/71 for a source build with effectively this change) but PR #10025 builds and 
```console
$ curl -sLO https://github.com/xrootd/xrootd/archive/v5.4.3.tar.gz
$ sha256sum v5.4.3.tar.gz 
56a29c88232f2f384e151b148fcaaa8d8db5c5fdc4615193978c8f4f3a99663c  v5.4.3.tar.gz
```

so as this PR is mirroring 10025 it should be fine.

- [N/A] updated the docs (if necessary)