### PR TITLE
Added cmakeDir for Windows- Cling Packaging Tool (cpt.py)

### DIFF
--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -1343,6 +1343,7 @@ def get_win_dep():
     zip.extractall(tmp_bin_dir)
     print('Remove file: ' + os.path.join(TMP_PREFIX, 'cmake-3.6.2.zip'))
 
+    cmakeDir = TMP_PREFIX + "\\bin\\cmake"
     if is_os_64bit():
         os.rename(os.path.join(tmp_bin_dir, 'cmake-3.6.2-win64-x64'), cmakeDir)
     else:


### PR DESCRIPTION
# This Pull request:
Fixes the cmakeDIr undefined error that occurs on Windows 
## Changes or fixes:
Added cmakeDir variable to cpt.py

## Checklist:

- [X] tested changes locally: Ran --last-stable nsis with cpt.py, the error does not occur anymore
- [NA] updated the docs (if necessary)

This PR fixes issue 426 (ihttps://github.com/root-project/cling/issues/426)

