### PR TITLE
[DF] Reset kMustCleanup bit on all branches in MT runs

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -11,6 +11,7 @@
 #ifndef ROOT_RLOOPMANAGER
 #define ROOT_RLOOPMANAGER
 
+#include "ROOT/InternalTreeUtils.hxx" // RNoCleanupNotifier
 #include "ROOT/RDF/RNodeBase.hxx"
 #include "ROOT/RDF/RNewSampleNotifier.hxx"
 #include "ROOT/RDF/RSampleInfo.hxx"
@@ -136,6 +137,8 @@ class RLoopManager : public RNodeBase {
    /// Cache of the tree/chain branch names. Never access directy, always use GetBranchNames().
    ColumnNames_t fValidBranchNames;
 
+   ROOT::Internal::TreeUtils::RNoCleanupNotifier fNoCleanupNotifier;
+
    void RunEmptySourceMT();
    void RunEmptySource();
    void RunTreeProcessorMT();
@@ -183,7 +186,7 @@ public:
    void Report(ROOT::RDF::RCutFlowReport &rep) const final;
    /// End of recursive chain of calls, does nothing
    void PartialReport(ROOT::RDF::RCutFlowReport &) const final {}
-   void SetTree(const std::shared_ptr<TTree> &tree) { fTree = tree; }
+   void SetTree(std::shared_ptr<TTree> tree);
    void IncrChildrenCount() final { ++fNChildren; }
    void StopProcessing() final { ++fNStopsReceived; }
    void ToJitExec(const std::string &) const;

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -852,6 +852,15 @@ void RLoopManager::Report(ROOT::RDF::RCutFlowReport &rep) const
       fPtr->FillReport(rep);
 }
 
+void RLoopManager::SetTree(std::shared_ptr<TTree> tree)
+{
+   fTree = std::move(tree);
+
+   TChain *ch = nullptr;
+   if ((ch = dynamic_cast<TChain *>(fTree.get())))
+      fNoCleanupNotifier.RegisterChain(*ch);
+}
+
 void RLoopManager::ToJitExec(const std::string &code) const
 {
    R__LOCKGUARD(gROOTMutex);

--- a/tree/tree/inc/LinkDef.h
+++ b/tree/tree/inc/LinkDef.h
@@ -93,5 +93,7 @@
 #pragma read sourceClass="TTree" targetClass="TTree" version="[-18]" source="" target="fNClusterRange" code="{ fNClusterRange = 0; }"
 
 #pragma link C++ namespace ROOT::Internal::TreeUtils;
+#pragma link C++ class ROOT::Internal::TreeUtils::RNoCleanupNotifier;
+#pragma link C++ class TNotifyLink<ROOT::Internal::TreeUtils::RNoCleanupNotifierHelper>;
 
 #endif

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -7,6 +7,7 @@
  *************************************************************************/
 
 #include "ROOT/InternalTreeUtils.hxx"
+#include "TCollection.h" // TRangeStaticCast
 #include "TTree.h"
 #include "TChain.h"
 #include "TFile.h"
@@ -220,6 +221,29 @@ std::vector<std::string> GetTreeFullPaths(const TTree &tree)
 
    // We do our best and return the name of the tree
    return {tree.GetName()};
+}
+
+/// Reset the kMustCleanup bit of a TObjArray of TBranch objects (e.g. returned by TTree::GetListOfBranches).
+///
+/// In some rare cases, all branches in a TTree can have their kMustCleanup bit set, which causes a large amount
+/// of contention at teardown due to concurrent calls to RecursiveRemove (which needs to take the global lock).
+/// This helper function checks the first branch of the array and if it has the kMustCleanup bit set, it resets
+/// it for all branches in the array, recursively going through sub-branches and leaves.
+void ClearMustCleanupBits(TObjArray &branches)
+{
+   if (branches.GetEntries() == 0 || branches.At(0)->TestBit(kMustCleanup) == false)
+      return; // we assume either no branches have the bit set, or all do. we never encountered an hybrid case
+
+   for (auto *branch : ROOT::Detail::TRangeStaticCast<TBranch>(branches)) {
+      branch->ResetBit(kMustCleanup);
+      TObjArray *subBranches = branch->GetListOfBranches();
+      ClearMustCleanupBits(*subBranches);
+      TObjArray *leaves = branch->GetListOfLeaves();
+      if (leaves->GetEntries() > 0 && leaves->At(0)->TestBit(kMustCleanup) == true) {
+         for (TObject *leaf : *leaves)
+            leaf->ResetBit(kMustCleanup);
+      }
+   }
 }
 
 } // namespace TreeUtils

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -49,7 +49,8 @@ namespace ROOT {
 namespace Internal {
 
 class TTreeView {
-private:
+   ROOT::Internal::TreeUtils::RNoCleanupNotifier fNoCleanupNotifier;
+
    std::vector<std::unique_ptr<TChain>> fFriends; ///< Friends of the tree/chain, if present
    std::unique_ptr<TEntryList> fEntryList;        ///< TEntryList for fChain, if present
    // NOTE: fFriends and fEntryList MUST come before fChain to be deleted after it, because neither friend trees nor

--- a/tree/treeplayer/src/TTreeProcessorMT.cxx
+++ b/tree/treeplayer/src/TTreeProcessorMT.cxx
@@ -159,6 +159,7 @@ static ClustersAndEntries MakeClusters(const std::vector<std::string> &treeNames
 
       // Avoid calling TROOT::RecursiveRemove for this tree, it takes the read lock and we don't need it.
       t->ResetBit(kMustCleanup);
+      ROOT::Internal::TreeUtils::ClearMustCleanupBits(*t->GetListOfBranches());
       auto clusterIter = t->GetClusterIterator(0);
       Long64_t start = 0ll, end = 0ll;
       const Long64_t entries = t->GetEntries();
@@ -312,6 +313,7 @@ void TTreeView::MakeChain(const std::vector<std::string> &treeNames, const std::
       fChain->Add((fileNames[i] + "?#" + treeNames[i]).c_str(), nEntries[i]);
    }
    fChain->ResetBit(TObject::kMustCleanup);
+   fNoCleanupNotifier.RegisterChain(*fChain.get());
 
    fFriends.clear();
    const auto nFriends = friendNames.size();


### PR DESCRIPTION
Having that bit set on TBranches causes _a lot_ of thread
contention (~TBranch -> ~TNamed -> RecursiveRemove).
Similarly for leaves.

This mitigates performance issues with MT runs on certain samples
where all branches and leaves have this bit set.

For a reproducer provided by a CMS user, this patch provides a factor 9 speed-up, up to a factor 30 for a stripped down version of said reproducer that exacerbates the issue.