### PR TITLE
[RF] Change buffer management in BatchMode such that queues get cleared

### DIFF
--- a/roofit/roofitcore/res/RooFit/Detail/Buffers.h
+++ b/roofit/roofitcore/res/RooFit/Detail/Buffers.h
@@ -30,10 +30,22 @@ public:
    virtual double *gpuWritePtr() = 0;
 };
 
-AbsBuffer* makeScalarBuffer();
-AbsBuffer* makeCpuBuffer(std::size_t size);
-AbsBuffer* makeGpuBuffer(std::size_t size);
-AbsBuffer* makePinnedBuffer(std::size_t size, cudaStream_t *stream = nullptr);
+struct BufferQueuesMaps;
+
+class BufferManager {
+
+public:
+   BufferManager();
+   ~BufferManager();
+
+   AbsBuffer *makeScalarBuffer();
+   AbsBuffer *makeCpuBuffer(std::size_t size);
+   AbsBuffer *makeGpuBuffer(std::size_t size);
+   AbsBuffer *makePinnedBuffer(std::size_t size, cudaStream_t *stream = nullptr);
+
+private:
+   BufferQueuesMaps *_queuesMaps;
+};
 
 } // end namespace Detail
 } // end namespace Experimental

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -17,6 +17,7 @@
 #include <RooFit/Detail/DataMap.h>
 #include <RooGlobalFunc.h>
 #include <RooHelpers.h>
+#include <RooFit/Detail/Buffers.h>
 
 #include <chrono>
 #include <memory>
@@ -72,6 +73,8 @@ private:
 
    ///////////////////////////
    // Private member variables
+
+   Detail::BufferManager _bufferManager; // The object managing the different buffers for the intermediate results
 
    const RooFit::BatchModeOption _batchMode = RooFit::BatchModeOption::Off;
    int _getValInvocations = 0;

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -57,8 +57,8 @@ private:
 
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooArgSet _observables;
-   mutable double _sumWeight = 0.0;         //!
-   mutable double _sumWeight2 = 0.0;        //!
+   mutable double _sumWeight = 0.0;  //!
+   mutable double _sumWeight2 = 0.0; //!
    bool _isExtended;
    bool _weightSquared = false;
    bool _binnedL = false;
@@ -66,7 +66,8 @@ private:
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
    std::unique_ptr<RooTemplateProxy<RooAbsReal>> _fractionInRange;
-   mutable std::vector<double> _binw; //!
+   mutable std::vector<double> _binw;            //!
+   mutable std::vector<double> _logProbasBuffer; //!
 
 }; // end class RooNLLVar
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -210,9 +210,8 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
 
    auto probas = dataMap.at(_pdf);
 
-   auto logProbasBuffer = ROOT::Experimental::Detail::makeCpuBuffer(nEvents);
-   RooSpan<double> logProbas{logProbasBuffer->cpuWritePtr(), nEvents};
-   (*_pdf).getLogProbabilities(probas, logProbas.data());
+   _logProbasBuffer.resize(nEvents);
+   (*_pdf).getLogProbabilities(probas, _logProbasBuffer.data());
 
    if ((_isExtended || _fractionInRange) && _sumWeight == 0.0) {
       _sumWeight = weights.size() == 1 ? weights[0] * nEvents : kahanSum(weights);
@@ -252,7 +251,7 @@ void RooNLLVarNew::computeBatch(cudaStream_t * /*stream*/, double *output, size_
       if (0. == eventWeight * eventWeight)
          continue;
 
-      const double term = -eventWeight * logProbas[i];
+      const double term = -eventWeight * _logProbasBuffer[i];
 
       kahanProb.Add(term);
       packedNaN.accumulate(term);


### PR DESCRIPTION
Change the buffer management in the new RooFit BatchMode such that
queues get cleared when the RooFitDriver gets destructed.

Like this one avoids the steady increase in memory that one would get
when doing different fits in one go with different numbers of events,
such as in test suites or MC studies with extended models.