### PR TITLE
[skip-ci][win64] Fix potential crash in clingwrapper on Windows 64

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -567,7 +567,7 @@ Cppyy::TCppType_t Cppyy::GetActualClass(TCppType_t klass, TCppObject_t obj)
     TClassRef& cr = type_from_handle(klass);
     if (!cr.GetClass() || !obj) return klass;
 
-#if 0 // def _WIN64
+#ifdef _WIN64
 // Cling does not provide a consistent ImageBase address for calculating relative addresses
 // as used in Windows 64b RTTI. So, check for our own RTTI extension instead. If that fails,
 // see whether the unmangled raw_name is available (e.g. if this is an MSVC compiled rather
@@ -597,7 +597,7 @@ Cppyy::TCppType_t Cppyy::GetActualClass(TCppType_t klass, TCppObject_t obj)
     // if the raw name is the empty string (no guarantees that this is so as truly, the
     // address is corrupt, but it is common to be empty), then there is no accessible RTTI
     // and getting the unmangled name will crash ...
-        if (!raw || raw[0] == '\0')
+        if (!raw)
             return klass;
     } catch (std::bad_typeid) {
         return klass;        // can't risk passing to ROOT/meta as it may do RTTI

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -567,7 +567,7 @@ Cppyy::TCppType_t Cppyy::GetActualClass(TCppType_t klass, TCppObject_t obj)
     TClassRef& cr = type_from_handle(klass);
     if (!cr.GetClass() || !obj) return klass;
 
-#if 0 //def _WIN64
+#if 0 // def _WIN64
 // Cling does not provide a consistent ImageBase address for calculating relative addresses
 // as used in Windows 64b RTTI. So, check for our own RTTI extension instead. If that fails,
 // see whether the unmangled raw_name is available (e.g. if this is an MSVC compiled rather

--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -567,7 +567,7 @@ Cppyy::TCppType_t Cppyy::GetActualClass(TCppType_t klass, TCppObject_t obj)
     TClassRef& cr = type_from_handle(klass);
     if (!cr.GetClass() || !obj) return klass;
 
-#ifdef _WIN64
+#if 0 //def _WIN64
 // Cling does not provide a consistent ImageBase address for calculating relative addresses
 // as used in Windows 64b RTTI. So, check for our own RTTI extension instead. If that fails,
 // see whether the unmangled raw_name is available (e.g. if this is an MSVC compiled rather


### PR DESCRIPTION
Fix the following crash when running `roodataset-numpy` and `roodatahist-numpy` on Windows 64:
```
 *** Break *** abort

==========================================
=============== STACKTRACE ===============
==========================================

================ Thread 0 ================
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\cppyy-backend\clingwrapper\src\clingwrapper.cxx(198): `anonymous namespace'::TExceptionHandlerImp::HandleException()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\core\winnt\src\TWinNTSystem.cxx(1766): TWinNTSystem::DispatchSignals()
  ucrtbase!raise()
  ucrtbase!abort()
  ucrtbase!terminate()
  VCRUNTIME140!_std_terminate()
  VCRUNTIME140_1!??
  VCRUNTIME140_1!_NLG_Return2()
  VCRUNTIME140_1!_NLG_Return2()
  VCRUNTIME140_1!_NLG_Return2()
  VCRUNTIME140_1!_CxxFrameHandler4()
  d:\a01\_work\43\s\src\vctools\crt\vcstartup\src\gs\amd64\gshandlereh4.cpp(86): __GSHandlerCheck_EH4()
  ntdll!_chkstk()
  ntdll!RtlUnwindEx()
  ntdll!RtlUnwind()
  VCRUNTIME140!_report_gsfailure()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\core\base\src\TException.cxx(33): Throw()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\cppyy-backend\clingwrapper\src\clingwrapper.cxx(201): `anonymous namespace'::TExceptionHandlerImp::HandleException()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\core\winnt\src\TWinNTSystem.cxx(1766): TWinNTSystem::DispatchSignals()
  ucrtbase!seh_filter_exe()
  python!??
  VCRUNTIME140!_C_specific_handler()
  ntdll!_chkstk()
  ntdll!RtlRaiseException()
  ntdll!KiUserExceptionDispatcher()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\cppyy-backend\clingwrapper\src\clingwrapper.cxx(600): Cppyy::GetActualClass()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\ProxyWrappers.cxx(897): CPyCppyy::BindCppObject()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\Executors.cxx(626): CPyCppyy::`anonymous namespace'::InstanceRefExecutor::Execute()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\CPPMethod.cxx(74): CPyCppyy::CPPMethod::ExecuteFast()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\CPPMethod.cxx(150): CPyCppyy::CPPMethod::ExecuteProtected()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\CPPMethod.cxx(783): CPyCppyy::CPPMethod::Call()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\CPPOverload.cxx(567): CPyCppyy::`anonymous namespace'::mp_call()
  python38!PyObject_MakeTpCall()
  python38!Py_gitversion()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\Pythonize.cxx(905): `anonymous namespace'::StlIterNext()
  python38!PyLong_AsDouble()
  python38!PyVectorcall_Call()
  C:\build\night\LABEL\windows64\SPEC\default\V\master\root\bindings\pyroot\cppyy\CPyCppyy\src\CustomPyTypes.cxx(205): CPyCppyy::im_call()
  python38!PyObject_MakeTpCall()
  python38!PyNumber_Long()
  python38!PyLong_FromLongLong()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyObject_GetBuffer()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_GetBuffer()
  python38!PyVectorcall_Call()
  python38!PySequence_GetItem()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_FastCallDict()
  python38!PyObject_Call_Prepend()
  python38!PyNumber_InPlaceMultiply()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_GetBuffer()
  python38!PyVectorcall_Call()
  python38!PySequence_GetItem()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_FastCallDict()
  python38!PyObject_Call_Prepend()
  python38!PyNumber_InPlaceMultiply()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_GetBuffer()
  python38!PyVectorcall_Call()
  python38!PySequence_GetItem()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_FastCallDict()
  python38!PyObject_Call_Prepend()
  python38!PyNumber_InPlaceMultiply()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_GetBuffer()
  python38!PyVectorcall_Call()
  python38!PySequence_GetItem()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyObject_FastCallDict()
  python38!PyObject_Call_Prepend()
  python38!PyNumber_InPlaceMultiply()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyFloat_GetInfo()
  python38!PyTuple_New()
  python38!PyObject_MakeTpCall()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyEval_EvalCodeEx()
  python38!PyEval_EvalCode()
  python38!PyArena_New()
  python38!PyArena_New()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyEval_EvalFrameDefault()
  python38!PyEval_EvalCodeWithName()
  python38!PyFunction_Vectorcall()
  python38!PyVectorcall_Call()
  python38!PyObject_Call()
  python38!PyMem_SetupAllocators()
  python38!Py_RunMain()
  python38!Py_RunMain()
  python38!Py_Main()
  python!??
  KERNEL32!BaseThreadInitThunk()
  ntdll!RtlUserThreadStart()
```
