### PR TITLE
[cling-cpt] Fixed llvm_flags undefined error that occurred when --last-stable option used [skip-ci]

### DIFF
--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -2251,6 +2251,7 @@ if args['last_stable']:
     args["with_binary_llvm"] = True
 
     if args["with_binary_llvm"]:
+        download_llvm_binary()
         compile = compile_for_binary
         install_prefix = install_prefix_for_binary
         fetch_clang(llvm_revision)


### PR DESCRIPTION
# This Pull request: 
Fixes the undefined llvm_flags error that occurs when --last-stable is called

## Changes or fixes: 
Added a call to the download_llvm_binary function, which sets the llvm_flags variable


## Checklist:

- [X] tested changes locally
- [NA] updated the docs (if necessary)

This PR fixes issue 423 (https://github.com/root-project/cling/issues/423)

