### PR TITLE
[tree] Add missing include in InternalTreeUtils.cxx

### DIFF
--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -7,11 +7,12 @@
  *************************************************************************/
 
 #include "ROOT/InternalTreeUtils.hxx"
-#include "TCollection.h" // TRangeStaticCast
-#include "TTree.h"
+#include "TBranch.h" // Usage of TBranch in ClearMustCleanupBits
 #include "TChain.h"
+#include "TCollection.h" // TRangeStaticCast
 #include "TFile.h"
 #include "TFriendElement.h"
+#include "TTree.h"
 
 #include <utility> // std::pair
 #include <vector>


### PR DESCRIPTION
I was failing to build ROOT on Fedora 36 (gcc 12) with the following error

```
/home/vpadulan/Programs/rootproject/rootsrc/tree/tree/src/InternalTreeUtils.cxx: In function ‘void ROOT::Internal::TreeUtils::ClearMustCleanupBits(TObjArray&)’:
/home/vpadulan/Programs/rootproject/rootsrc/tree/tree/src/InternalTreeUtils.cxx:238:13: error: invalid use of incomplete type ‘class TBranch’
  238 |       branch->ResetBit(kMustCleanup);
      |             ^~
In file included from /home/vpadulan/Programs/rootproject/rootsrc/tree/tree/inc/TTree.h:30,
                 from /home/vpadulan/Programs/rootproject/rootsrc/tree/tree/inc/TChain.h:24,
                 from /home/vpadulan/Programs/rootproject/rootsrc/tree/tree/inc/ROOT/InternalTreeUtils.hxx:21,
                 from /home/vpadulan/Programs/rootproject/rootsrc/tree/tree/src/InternalTreeUtils.cxx:9:
/home/vpadulan/Programs/rootproject/rootsrc/tree/tree/inc/ROOT/TIOFeatures.hxx:17:7: note: forward declaration of ‘class TBranch’
   17 | class TBranch;
      |       ^~~~~~~
/home/vpadulan/Programs/rootproject/rootsrc/tree/tree/src/InternalTreeUtils.cxx:239:38: error: invalid use of incomplete type ‘class TBranch’
  239 |       TObjArray *subBranches = branch->GetListOfBranches();
      |                                      ^~
/home/vpadulan/Programs/rootproject/rootsrc/tree/tree/inc/ROOT/TIOFeatures.hxx:17:7: note: forward declaration of ‘class TBranch’
   17 | class TBranch;
      |       ^~~~~~~
/home/vpadulan/Programs/rootproject/rootsrc/tree/tree/src/InternalTreeUtils.cxx:241:33: error: invalid use of incomplete type ‘class TBranch’
  241 |       TObjArray *leaves = branch->GetListOfLeaves();
```