### PR TITLE
Ensure registration of atexit function is done only once

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -79,6 +79,7 @@ def cleanup():
             # Hard teardown: run part of the gROOT shutdown sequence.
             # Running it here ensures that it is done before any ROOT libraries
             # are off-loaded, with unspecified order of static object destruction.
-            backend.gROOT.EndOfProcessCleanups()
+            from ROOT import TApplication
+            TApplication.RegisterEndOfProcessCleanups()
 
 atexit.register(cleanup)

--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -158,6 +158,7 @@ public:
    static TList   *GetApplications();
    static void     CreateApplication();
    static void     NeedGraphicsLibs();
+   static void     RegisterEndOfProcessCleanups();
 
    ClassDefOverride(TApplication,0)  //GUI application singleton
 };


### PR DESCRIPTION
Before this commit, the following triggered two calls to
TROOT::EndOfProcessCleanups:
```
python -c "import ROOT; ROOT.TH1F"
```
This happened because the TApplication constructor registered a
function that calls EndOfProcessCleanups with the C `atexit` and
PyROOT registered another similar function with the Python atexit
module in `__init__.py`. The Python atexit happened before the C
atexit.

This commit introduces a static function in TApplication that
registers the call to EndOfProcessCleanups with the C `atexit` and
this is guaranteed to be run only once through the use of
std::call_once. This new function can be called both from PyROOT
and the TApplication constructor, to make sure it will be
registered by either of them.

Furthermore, calling this from PyROOT means that now
EndOfProcessCleanups is always called at the very end of the
program, seemingly a more sensible choice.

This PR fixes #10743 

