### PR TITLE
[RF] Don't ignore ParamSetting values in HistFactory Asimov dataset

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/HistoToWorkspaceFactoryFast.h
@@ -100,7 +100,7 @@ namespace RooStats{
             std::vector<std::unique_ptr<RooWorkspace>>& wspace_vec,
             std::vector<std::string> const& channel_names,
             std::string const& dataSetName,
-            RooArgList obsList,
+            RooArgList const& obsList,
             RooCategory* channelCat);
 
       RooHistFunc* MakeExpectedHistFunc(const TH1* hist, RooWorkspace* proto, std::string prefix,


### PR DESCRIPTION
HistFactory allows to set nuisance parameters to given values (and
possibly set them to constant) by using something like

```
<ParamSetting Val=1 Const="True"> myNP </ParamSetting>
```

However the Asimov dataset created by `hist2workspace` does not respect
this setting, because in
[MakeCombiendModel](https://root.cern/doc/master/HistoToWorkspaceFactoryFast_8cxx_source.html#l02109)
the Asimov workspace is created before the ParamSettings are applied.

This commit is fixing this problem.

The problem can be reproduced with the following script/instructions:

```C++
using namespace RooStats;
using namespace HistFactory;

// Step 1: initialize the XML files
//
// Run prepareHistFactory before in this directory
//
// Modify the GaussExample in the generated example to be:
//
// <Measurement Name="GaussExample" Lumi="1." LumiRelErr="0.1" >
//   <POI>SigXsecOverSM</POI>
//   <ParamSetting Const="True">Lumi</ParamSetting>
//   <ParamSetting Val="20" Const="True">alpha_syst1</ParamSetting>
// </Measurement>

// Step 2: Create the RooWorkspace
//

ConfigParser parser{};
auto measurements = parser.GetMeasurementsFromXML("config/example.xml");

// Get the first example, the GaussExample
Measurement& meas = measurements.front();

// Collect the histograms from their files,
meas.CollectHistograms();

// Now, do the measurement
std::unique_ptr<RooWorkspace> ws{MakeModelAndMeasurementFast( meas )};

// Step 3: Validation plot to show mismatch between model and Asimov data
//

auto x = ws->var("obs_x_channel1");
auto data = ws->data("asimovData");
auto pdf = ws->pdf("model_channel1");

// Draw the asimov data together with the model and check if they match
TCanvas c1("c1");
RooPlot *xframe = x->frame();
data->plotOn(xframe);
pdf->plotOn(xframe);

xframe->Draw();

c1.SaveAs("plot.png");

// Note that the errors will be plotted wrongly if the Asimov data is
// correct. That's because if the changed alpha_syst1 value is considered
// correctly, the asimov dataset has non-integer weights. In this case, the
// plotting uses SumW2 errors instead of Poisson erros, and the weights
// squared is not filled correctly in the Asimov data that is created by
// AsymptoticCalculator::GenerateAsimovData(). But this is a completely
// different issue.
```
Closes #8186.
