### PR TITLE
[RF] Fix crash when using RooXYChi2Var with RooSimultaneous

### DIFF
--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -80,7 +80,7 @@ protected:
   double evaluatePartition(std::size_t firstEvent, std::size_t lastEvent, std::size_t stepSize) const override ;
 
   RooNumIntConfig   _intConfig ; ///< Numeric integrator configuration for integration of function over bin
-  RooAbsReal*       _funcInt ; ///<! Function integral
+  RooAbsReal*       _funcInt = nullptr; ///<! Function integral
   std::list<RooAbsBinning*> _binList ; ///<! Bin ranges
 
   ClassDefOverride(RooXYChi2Var,1) // Chi^2 function of p.d.f w.r.t a unbinned dataset with X and Y values

--- a/roofit/roofitcore/src/RooXYChi2Var.cxx
+++ b/roofit/roofitcore/src/RooXYChi2Var.cxx
@@ -63,7 +63,6 @@ namespace {
 
 RooXYChi2Var::RooXYChi2Var()
 {
-  _funcInt = 0 ;
 }
 
 
@@ -86,8 +85,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
   RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(false),
   _integrate(integrate),
-  _intConfig(*defaultIntegratorConfig()),
-  _funcInt(0)
+  _intConfig(*defaultIntegratorConfig())
 {
   _extended = false ;
   _yvar = 0 ;
@@ -114,8 +112,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsReal& func
   RooAbsOptTestStatistic(name,title,func,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(false),
   _integrate(integrate),
-  _intConfig(*defaultIntegratorConfig()),
-  _funcInt(0)
+  _intConfig(*defaultIntegratorConfig())
 {
   _extended = false ;
   _yvar = (RooRealVar*) _dataClone->get()->find(yvar.GetName()) ;
@@ -145,8 +142,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPd
   RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(true),
   _integrate(integrate),
-  _intConfig(*defaultIntegratorConfig()),
-  _funcInt(0)
+  _intConfig(*defaultIntegratorConfig())
 {
   if (!extPdf.canBeExtended()) {
     throw std::runtime_error(Form("RooXYChi2Var::RooXYChi2Var(%s) ERROR: Input p.d.f. must be extendible",GetName()));
@@ -179,8 +175,7 @@ RooXYChi2Var::RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPd
   RooAbsOptTestStatistic(name,title,extPdf,xydata,RooArgSet(),makeRooAbsTestStatisticCfg()),
   _extended(true),
   _integrate(integrate),
-  _intConfig(*defaultIntegratorConfig()),
-  _funcInt(0)
+  _intConfig(*defaultIntegratorConfig())
 {
   if (!extPdf.canBeExtended()) {
     throw std::runtime_error(Form("RooXYChi2Var::ctor(%s) ERROR: Input p.d.f. must be an extendible",GetName()));
@@ -199,8 +194,7 @@ RooXYChi2Var::RooXYChi2Var(const RooXYChi2Var& other, const char* name) :
   RooAbsOptTestStatistic(other,name),
   _extended(other._extended),
   _integrate(other._integrate),
-  _intConfig(other._intConfig),
-  _funcInt(0)
+  _intConfig(other._intConfig)
 {
   _yvar = other._yvar ? (RooRealVar*) _dataClone->get()->find(other._yvar->GetName()) : 0 ;
   initialize() ;
@@ -215,6 +209,11 @@ RooXYChi2Var::RooXYChi2Var(const RooXYChi2Var& other, const char* name) :
 
 void RooXYChi2Var::initialize()
 {
+  // If this tests statistic is not a "Slave" in the RooAbsOptTestStatistic
+  // framework, it doesn't do any actual computation and no initialization is
+  // needed. It would not even work, because _funcObsSet would be a nullptr.
+  if(operMode() != Slave) return;
+
   for(RooAbsArg * arg : *_funcObsSet) {
     if (auto* var = dynamic_cast<RooRealVar*>(arg)) {
       _rrvArgs.add(*var) ;


### PR DESCRIPTION
If a RooXYChi2Var is not a "Slave" in the RooAbsOptTestStatistic
framework, it doesn't do any actual computation and no initialization is
needed. It would not even work and causes a crash, because `_funcObsSet`
would be a `nullptr`.

