### PR TITLE
[ntuple] Allow for vector commit of sealed pages

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -106,7 +106,7 @@ private:
       // Using a deque guarantees that element iterators are never invalidated
       // by appends to the end of the iterator by BufferPage.
       std::deque<RPageZipItem> fBufferedPages;
-      // Pages that have been alredy sealed by a concurrent task. A vector commit can be issued if all
+      // Pages that have been already sealed by a concurrent task. A vector commit can be issued if all
       // buffered pages have been sealed.
       RPageStorage::SealedPageSequence_t fSealedPages;
    };

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -80,7 +80,7 @@ private:
          return std::prev(fBufferedPages.end());
       }
       const RPageStorage::ColumnHandle_t &GetHandle() const { return fCol; }
-      bool HasSealedPagesOnly() const { return fBufferedPages.size() == fSealedPages.size(); }
+      bool HasSealedPagesOnly() const { return fBufferedPages.size() && fBufferedPages.size() == fSealedPages.size(); }
       const RPageStorage::SealedPageSequence_t &GetSealedPages() const { return fSealedPages; }
 
       using BufferedPages_t = std::tuple<std::deque<RPageZipItem>, RPageStorage::SealedPageSequence_t>;

--- a/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageSinkBuf.hxx
@@ -23,6 +23,7 @@
 #include <deque>
 #include <iterator>
 #include <memory>
+#include <tuple>
 
 namespace ROOT {
 namespace Experimental {
@@ -48,12 +49,10 @@ private:
          RPage fPage;
          // Compression scratch buffer for fSealedPage.
          std::unique_ptr<unsigned char[]> fBuf;
-         RPageStorage::RSealedPage fSealedPage;
+         RPageStorage::RSealedPage *fSealedPage = nullptr;
          explicit RPageZipItem(RPage page)
             : fPage(page), fBuf(nullptr) {}
-         bool IsSealed() const {
-            return fSealedPage.fBuffer != nullptr;
-         }
+         bool IsSealed() const { return fSealedPage != nullptr; }
          void AllocateSealedPageBuf() {
             fBuf = std::make_unique<unsigned char[]>(fPage.GetNBytes());
          }
@@ -81,18 +80,35 @@ private:
          return std::prev(fBufferedPages.end());
       }
       const RPageStorage::ColumnHandle_t &GetHandle() const { return fCol; }
+      bool HasSealedPagesOnly() const { return fBufferedPages.size() == fSealedPages.size(); }
+      const RPageStorage::SealedPageSequence_t &GetSealedPages() const { return fSealedPages; }
+
+      using BufferedPages_t = std::tuple<std::deque<RPageZipItem>, RPageStorage::SealedPageSequence_t>;
       // When the return value of DrainBufferedPages() is destroyed, all iterators
       // returned by GetBuffer are invalidated.
-      std::deque<RPageZipItem> DrainBufferedPages() {
-         std::deque<RPageZipItem> drained;
-         std::swap(fBufferedPages, drained);
+      BufferedPages_t DrainBufferedPages()
+      {
+         BufferedPages_t drained;
+         std::swap(fBufferedPages, std::get<decltype(fBufferedPages)>(drained));
+         std::swap(fSealedPages, std::get<decltype(fSealedPages)>(drained));
          return drained;
       }
+
+      // The returned iterator points to a default-constructed RSealedPage. This iterator can be used
+      // to fill in data after sealing.
+      RPageStorage::SealedPageSequence_t::iterator RegisterSealedPage()
+      {
+         return fSealedPages.emplace(std::end(fSealedPages));
+      }
+
    private:
       RPageStorage::ColumnHandle_t fCol;
       // Using a deque guarantees that element iterators are never invalidated
       // by appends to the end of the iterator by BufferPage.
       std::deque<RPageZipItem> fBufferedPages;
+      // Pages that have been alredy sealed by a concurrent task. A vector commit can be issued if all
+      // buffered pages have been sealed.
+      RPageStorage::SealedPageSequence_t fSealedPages;
    };
 
 private:

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -269,7 +269,7 @@ public:
    void CommitPage(ColumnHandle_t columnHandle, const RPage &page);
    /// Write a preprocessed page to storage. The column must have been added before.
    void CommitSealedPage(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage);
-   /// Write a vector of preprocessed pages to storage. The column must have been added before.
+   /// Write a vector of preprocessed pages to storage. The corresponding columns must have been added before.
    void CommitSealedPageV(const std::vector<RPageStorage::RSealedPageGroup> &ranges);
    /// Finalize the current cluster and create a new one for the following data.
    /// Returns the number of bytes written to storage (excluding meta-data).

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -98,12 +98,12 @@ public:
 
    using SealedPageSequence_t = std::deque<RSealedPage>;
    /// A range of sealed pages referring to the same column that can be used for vector commit
-   struct RSealedPageRange {
+   struct RSealedPageGroup {
       DescriptorId_t fColumnId;
       SealedPageSequence_t::const_iterator fFirst;
       SealedPageSequence_t::const_iterator fLast;
 
-      RSealedPageRange(DescriptorId_t d, SealedPageSequence_t::const_iterator b, SealedPageSequence_t::const_iterator e)
+      RSealedPageGroup(DescriptorId_t d, SealedPageSequence_t::const_iterator b, SealedPageSequence_t::const_iterator e)
          : fColumnId(d), fFirst(b), fLast(e)
       {
       }
@@ -212,7 +212,7 @@ protected:
    /// followed by M entries that refer to the M pages in `ranges[1]`, etc.
    /// The default is to call `CommitSealedPageImpl` for each page; derived classes may provide an
    /// optimized implementation though.
-   virtual std::vector<RNTupleLocator> CommitSealedPagesImpl(const std::vector<RPageStorage::RSealedPageRange> &ranges);
+   virtual std::vector<RNTupleLocator> CommitSealedPageVImpl(const std::vector<RPageStorage::RSealedPageGroup> &ranges);
    /// Returns the number of bytes written to storage (excluding metadata)
    virtual std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) = 0;
    /// Returns the locator of the page list envelope of the given buffer that contains the serialized page list.
@@ -270,7 +270,7 @@ public:
    /// Write a preprocessed page to storage. The column must have been added before.
    void CommitSealedPage(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage);
    /// Write a vector of preprocessed pages to storage. The column must have been added before.
-   void CommitSealedPages(const std::vector<RPageStorage::RSealedPageRange> &ranges);
+   void CommitSealedPageV(const std::vector<RPageStorage::RSealedPageGroup> &ranges);
    /// Finalize the current cluster and create a new one for the following data.
    /// Returns the number of bytes written to storage (excluding meta-data).
    std::uint64_t CommitCluster(NTupleSize_t nEntries);

--- a/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorage.hxx
@@ -206,13 +206,13 @@ protected:
    virtual RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) = 0;
    virtual RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId,
                                                const RPageStorage::RSealedPage &sealedPage) = 0;
-   /// Vector commit of preprocessed pages. The `ranges` vector specifies a range of sealed pages to be
+   /// Vector commit of preprocessed pages. The `ranges` array specifies a range of sealed pages to be
    /// committed for each column.  The returned vector contains, in order, the RNTupleLocator for each
    /// page on each range in `ranges`, i.e. the first N entries refer to the N pages in `ranges[0]`,
    /// followed by M entries that refer to the M pages in `ranges[1]`, etc.
    /// The default is to call `CommitSealedPageImpl` for each page; derived classes may provide an
    /// optimized implementation though.
-   virtual std::vector<RNTupleLocator> CommitSealedPageVImpl(const std::vector<RPageStorage::RSealedPageGroup> &ranges);
+   virtual std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges);
    /// Returns the number of bytes written to storage (excluding metadata)
    virtual std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) = 0;
    /// Returns the locator of the page list envelope of the given buffer that contains the serialized page list.
@@ -270,7 +270,7 @@ public:
    /// Write a preprocessed page to storage. The column must have been added before.
    void CommitSealedPage(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage);
    /// Write a vector of preprocessed pages to storage. The corresponding columns must have been added before.
-   void CommitSealedPageV(const std::vector<RPageStorage::RSealedPageGroup> &ranges);
+   void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges);
    /// Finalize the current cluster and create a new one for the following data.
    /// Returns the number of bytes written to storage (excluding meta-data).
    std::uint64_t CommitCluster(NTupleSize_t nEntries);

--- a/tree/ntuple/v7/src/RPageSinkBuf.cxx
+++ b/tree/ntuple/v7/src/RPageSinkBuf.cxx
@@ -117,8 +117,9 @@ ROOT::Experimental::Detail::RPageSinkBuf::CommitClusterImpl(ROOT::Experimental::
       auto drained = bufColumn.DrainBufferedPages();
       if (hasSealedPagesOnly) {
          const auto &sealedPages = std::get<RPageStorage::SealedPageSequence_t>(drained);
-         fInnerSink->CommitSealedPageV(std::vector<RPageStorage::RSealedPageGroup>{
-            RSealedPageGroup(bufColumn.GetHandle().fId, sealedPages.cbegin(), sealedPages.cend())});
+         RPageStorage::RSealedPageGroup toCommit[] = {
+            RSealedPageGroup(bufColumn.GetHandle().fId, sealedPages.cbegin(), sealedPages.cend())};
+         fInnerSink->CommitSealedPageV({std::begin(toCommit), std::end(toCommit)});
          continue;
       }
 

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -338,7 +338,7 @@ void ROOT::Experimental::Detail::RPageSink::CommitSealedPage(
 }
 
 std::vector<ROOT::Experimental::RNTupleLocator>
-ROOT::Experimental::Detail::RPageSink::CommitSealedPagesImpl(const std::vector<RPageStorage::RSealedPageRange> &ranges)
+ROOT::Experimental::Detail::RPageSink::CommitSealedPageVImpl(const std::vector<RPageStorage::RSealedPageGroup> &ranges)
 {
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
    for (auto &range : ranges) {
@@ -348,9 +348,9 @@ ROOT::Experimental::Detail::RPageSink::CommitSealedPagesImpl(const std::vector<R
    return locators;
 }
 
-void ROOT::Experimental::Detail::RPageSink::CommitSealedPages(const std::vector<RPageStorage::RSealedPageRange> &ranges)
+void ROOT::Experimental::Detail::RPageSink::CommitSealedPageV(const std::vector<RPageStorage::RSealedPageGroup> &ranges)
 {
-   auto locators = CommitSealedPagesImpl(ranges);
+   auto locators = CommitSealedPageVImpl(ranges);
    unsigned i = 0;
 
    for (auto &range : ranges) {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -337,6 +337,33 @@ void ROOT::Experimental::Detail::RPageSink::CommitSealedPage(
    fOpenPageRanges.at(columnId).fPageInfos.emplace_back(pageInfo);
 }
 
+std::vector<ROOT::Experimental::RNTupleLocator>
+ROOT::Experimental::Detail::RPageSink::CommitSealedPagesImpl(const std::vector<RPageStorage::RSealedPageRange> &ranges)
+{
+   std::vector<ROOT::Experimental::RNTupleLocator> locators;
+   for (auto &range : ranges) {
+      for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt)
+         locators.push_back(CommitSealedPageImpl(range.fColumnId, *sealedPageIt));
+   }
+   return locators;
+}
+
+void ROOT::Experimental::Detail::RPageSink::CommitSealedPages(const std::vector<RPageStorage::RSealedPageRange> &ranges)
+{
+   auto locators = CommitSealedPagesImpl(ranges);
+   unsigned i = 0;
+
+   for (auto &range : ranges) {
+      for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
+         fOpenColumnRanges.at(range.fColumnId).fNElements += sealedPageIt->fNElements;
+
+         RClusterDescriptor::RPageRange::RPageInfo pageInfo;
+         pageInfo.fNElements = sealedPageIt->fNElements;
+         pageInfo.fLocator = locators[i++];
+         fOpenPageRanges.at(range.fColumnId).fPageInfos.emplace_back(pageInfo);
+      }
+   }
+}
 
 std::uint64_t ROOT::Experimental::Detail::RPageSink::CommitCluster(ROOT::Experimental::NTupleSize_t nEntries)
 {

--- a/tree/ntuple/v7/src/RPageStorage.cxx
+++ b/tree/ntuple/v7/src/RPageStorage.cxx
@@ -338,7 +338,7 @@ void ROOT::Experimental::Detail::RPageSink::CommitSealedPage(
 }
 
 std::vector<ROOT::Experimental::RNTupleLocator>
-ROOT::Experimental::Detail::RPageSink::CommitSealedPageVImpl(const std::vector<RPageStorage::RSealedPageGroup> &ranges)
+ROOT::Experimental::Detail::RPageSink::CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges)
 {
    std::vector<ROOT::Experimental::RNTupleLocator> locators;
    for (auto &range : ranges) {
@@ -348,7 +348,7 @@ ROOT::Experimental::Detail::RPageSink::CommitSealedPageVImpl(const std::vector<R
    return locators;
 }
 
-void ROOT::Experimental::Detail::RPageSink::CommitSealedPageV(const std::vector<RPageStorage::RSealedPageGroup> &ranges)
+void ROOT::Experimental::Detail::RPageSink::CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges)
 {
    auto locators = CommitSealedPageVImpl(ranges);
    unsigned i = 0;


### PR DESCRIPTION
This pull request extends `RPageSink` to allow for vector commit of sealed pages.  The prototype of the new functions is as follows:
```c++
virtual std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges);
void CommitSealedPageV(std::span<RPageStorage::RSealedPageGroup> ranges);
```

These changes enable (parallel) vector writes in concrete backends, e.g. in DAOS.  Derived classes that do not override the base implementation will see a sequence of calls to `CommitSealedPage()`.

The first measurements of vector writes on DAOS based on this PR, indicate an improvement of _an order of magnitude_ in the write throughput.

The refactor in this PR passes all the RPageSinkBuf tests.

## Changes or fixes:
- Add `CommitSealedPageV()` to the public interface of `RPageSink`. This function carries out a vector write of a number of sealed page ranges.  Each range applies to a given columnId.
The default implementation of `CommitSealedPageVImpl()` sequentially calls `CommitSealedPageImpl()` for each page on each range, but derived classes can override it to provide an optimized implementation.
- Use `CommitSealedPageV()` in RPageSinkBuf.  If a buffered column contains only sealed pages, commit the whole range
via `CommitSealedPageV()`.
- If all buffered columns consist solely of sealed pages, coalesce all pages to be committed in a single `CommitSealedPageV()` call that includes a sealed page range per column.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #10719.