### PR TITLE
Check whether ROOTSYS is defined in rootcling_stage1.

### DIFF
--- a/core/rootcling_stage1/src/rootcling_stage1.cxx
+++ b/core/rootcling_stage1/src/rootcling_stage1.cxx
@@ -25,21 +25,17 @@ ROOT::Internal::RootCling::TROOTSYSSetter gROOTSYSSetter;
 
 static const char *GetIncludeDir() {
    const char *rootsys = getenv("ROOTSYS");
-   static std::string incdir;
-   if (rootsys != nullptr)
-      incdir = std::string(rootsys) + "/include";
-   else
-      incdir = "/include";
+   // The environment variable ROOTSYS is expected to be set by SetRootSys().
+   assert(rootsys != nullptr);
+   static std::string incdir = std::string(rootsys) + "/include";
    return incdir.c_str();
 }
 
 static const char *GetEtcDir() {
    const char *rootsys = getenv("ROOTSYS");
-   static std::string etcdir;
-   if (rootsys != nullptr)
-      etcdir = std::string(rootsys) + "/etc";
-   else
-      etcdir = "/etc";
+   // The environment variable ROOTSYS is expected to be set by SetRootSys().
+   assert(rootsys != nullptr);
+   static std::string etcdir = std::string(rootsys) + "/etc";
    return etcdir.c_str();
 }
 

--- a/core/rootcling_stage1/src/rootcling_stage1.cxx
+++ b/core/rootcling_stage1/src/rootcling_stage1.cxx
@@ -11,6 +11,7 @@
 #include "rootcling_impl.h"
 #include "RConfigure.h"
 #include <ROOT/RConfig.hxx>
+#include <cassert>
 #include <cstdlib>
 #include <string>
 

--- a/core/rootcling_stage1/src/rootcling_stage1.cxx
+++ b/core/rootcling_stage1/src/rootcling_stage1.cxx
@@ -24,12 +24,22 @@ static void (*dlsymaddr)() = &usedToIdentifyRootClingByDlSym;
 ROOT::Internal::RootCling::TROOTSYSSetter gROOTSYSSetter;
 
 static const char *GetIncludeDir() {
-   static std::string incdir = std::string(getenv("ROOTSYS")) + "/include";
+   const char *rootsys = getenv("ROOTSYS");
+   static std::string incdir;
+   if (rootsys != nullptr)
+      incdir = std::string(rootsys) + "/include";
+   else
+      incdir = "/include";
    return incdir.c_str();
 }
 
 static const char *GetEtcDir() {
-   static std::string etcdir = std::string(getenv("ROOTSYS")) + "/etc";
+   const char *rootsys = getenv("ROOTSYS");
+   static std::string etcdir;
+   if (rootsys != nullptr)
+      etcdir = std::string(rootsys) + "/etc";
+   else
+      etcdir = "/etc";
    return etcdir.c_str();
 }
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

It is not checked in the existing code whether `getenv("ROOTSYS")` returns `NULL`. It does so if the environment variable is not defined; it is exactly what happens during building [here](https://github.com/root-project/root/blob/master/cmake/modules/RootMacros.cmake#L584). Then `std::string` gets initialized from the C string from address 0, which may result in a segmentation fault.

## Checklist:

- [ x ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

