### PR TITLE
[skip-ci][v6-26]Replace __x86_64__ by R__x86_64__ on Win64

### DIFF
--- a/build/win/w32pragma.h
+++ b/build/win/w32pragma.h
@@ -67,7 +67,7 @@
 #define G__WIN32 1
 
 #ifdef _WIN64
-#define __x86_64__ 1
+#define R__x86_64__ 1
 #define WIN64 1
 #define G__WIN64 1
 #else

--- a/core/foundation/inc/ROOT/RConfig.hxx
+++ b/core/foundation/inc/ROOT/RConfig.hxx
@@ -392,7 +392,7 @@
 #   ifndef WIN64
 #      define WIN64
 #   endif
-#   define __x86_64__ 1
+#   define R__x86_64__ 1
 #   define R__B64      /* enable when 64 bit machine */
 #endif
 


### PR DESCRIPTION
Replace `__x86_64__` by `R__x86_64__` on Win64 to prevent possible conflicts, as [reported on the forum](https://root-forum.cern.ch/t/preprocessor-macro-x86-64-problem-with-clhep-on-windows/50431)
