### PR TITLE
TMVA::DataSetInfo incorrectly handles reading of array of variables

### DIFF
--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -250,13 +250,13 @@ void TMVA::DataSetInfo::AddVariablesArray(const TString &expression, Int_t size,
 
       // move "external" pointer to the next variable in the array
       if (varType == 'F') {
-         float* ptr = (float*) external;
+         float* ptr = (float *)external;
          ++ptr;
-         external = (void*) ptr;
+         external = (void *) ptr;
       } else if (varType == 'I') {
-         int* ptr = (int*) external;
+         int* ptr = (int *)external;
          ++ptr;
-         external = (void*) ptr;
+         external = (void *)ptr;
       } else {
          Error("TMVA::DataSetInfo::AddVariablesArray", "'%c' variable type is not supported", varType);
       }

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -250,11 +250,11 @@ void TMVA::DataSetInfo::AddVariablesArray(const TString &expression, Int_t size,
 
       // move "external" pointer to the next variable in the array
       if (varType == 'F') {
-         float* ptr = (float *)external;
+         float *ptr = (float *)external;
          ++ptr;
-         external = (void *) ptr;
+         external = (void *)ptr;
       } else if (varType == 'I') {
-         int* ptr = (int *)external;
+         int *ptr = (int *)external;
          ++ptr;
          external = (void *)ptr;
       } else {

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -250,15 +250,15 @@ void TMVA::DataSetInfo::AddVariablesArray(const TString &expression, Int_t size,
 
       // move "external" pointer to the next variable in the array
       if (varType == 'F') {
-		  float* ptr = (float*) external;
-		  ++ptr;
-		  external = (void*) ptr;
+         float* ptr = (float*) external;
+         ++ptr;
+         external = (void*) ptr;
       } else if (varType == 'I') {
-		  int* ptr = (int*) external;
-		  ++ptr;
-		  external = (void*) ptr;
+         int* ptr = (int*) external;
+         ++ptr;
+         external = (void*) ptr;
       } else {
-		  Error("TMVA::DataSetInfo::AddVariablesArray", "'%c' variable type is not supported", varType);
+         Error("TMVA::DataSetInfo::AddVariablesArray", "'%c' variable type is not supported", varType);
       }
    }
    fVarArrays[regexpr] = size;

--- a/tmva/tmva/src/DataSetInfo.cxx
+++ b/tmva/tmva/src/DataSetInfo.cxx
@@ -247,6 +247,19 @@ void TMVA::DataSetInfo::AddVariablesArray(const TString &expression, Int_t size,
       fVariables.back().SetBit(kIsArrayVariable);
       TString newVarName = fVariables.back().GetInternalName() + TString::Format("[%d]", i);
       fVariables.back().SetInternalName(newVarName);
+
+      // move "external" pointer to the next variable in the array
+      if (varType == 'F') {
+		  float* ptr = (float*) external;
+		  ++ptr;
+		  external = (void*) ptr;
+      } else if (varType == 'I') {
+		  int* ptr = (int*) external;
+		  ++ptr;
+		  external = (void*) ptr;
+      } else {
+		  Error("TMVA::DataSetInfo::AddVariablesArray", "'%c' variable type is not supported", varType);
+      }
    }
    fVarArrays[regexpr] = size;
    fNeedsRebuilding = kTRUE;


### PR DESCRIPTION
# Problem Outline:
Precondition. On the **training (classification)** stage user adds array of variables to the `TMVA::DataLoader` object with a new method introduced in ROOT 6.20:
```
TMVA::DataLoader *loader = new TMVA::DataLoader(...)
loader->AddVariablesArray("vars", nBins);
```

On the next stage - **classification application** user creates `TMVA::Reader` object and adds an array of variables to it:
```
TMVA::Reader* reader = new TMVA::Reader(...);
std::vector<float> fValues(nBins);
reader->DataInfo().AddVariablesArray("vars", nBins, "", "", 0, 0, 'F', kFALSE, &fValues[0]);
```

Pointer to the first element of the `&fValues[0]` passed to the `TMVA::DataSetInfo::AddVariablesArray(..., void *external)` function. Inside `AddVariablesArray()` pointer is **not incremented** in the loop where variables are defined. This provides faulty `reader->EvaluateMVA` output.

# This Pull Request:
Modifies `TMVA::DataSetInfo::AddVariablesArray(..., void *external)` function. Depending on the variable type `char varType`, `void * external` pointer is incremented in the loop. This provides correct TMVA evaluation.

## Changes or fixes:
Please refer to the commit details.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

