### PR TITLE
Use logical operators for boolean operands

### DIFF
--- a/interpreter/cling/lib/Utils/Output.cpp
+++ b/interpreter/cling/lib/Utils/Output.cpp
@@ -80,10 +80,12 @@ namespace cling {
 
     bool ColorizeOutput(unsigned Which) {
 #define COLOR_FLAG(Fv, Fn) (Which == 8 ? llvm::sys::Process::Fn() : Which & Fv)
-      return static_cast<ColoredOutput &>(outs()).Colors(
-                              COLOR_FLAG(1, StandardOutIsDisplayed)) |
-             static_cast<ColoredOutput &>(errs()).Colors(
-                              COLOR_FLAG(2, StandardErrIsDisplayed));
+      bool colorStdout = COLOR_FLAG(1, StandardOutIsDisplayed);
+      bool colorStderr = COLOR_FLAG(2, StandardErrIsDisplayed);
+      // The following calls have side effects because they set m_Colorize!
+      static_cast<ColoredOutput &>(outs()).Colors(colorStdout);
+      static_cast<ColoredOutput &>(errs()).Colors(colorStderr);
+      return colorStdout || colorStderr;
     }
   }
 }

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -206,7 +206,7 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_v
             observable->inRange({dataSpans.at(observable->namePtr()).data(), nEvents}, range, isInSubRange);
          }
          for (std::size_t i = 0; i < isInSubRange.size(); ++i) {
-            isInRange[i] = isInRange[i] | isInSubRange[i];
+            isInRange[i] = isInRange[i] || isInSubRange[i];
          }
       }
 

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -129,7 +129,7 @@ void RooAbsRealLValue::inRange(std::span<const double> values, std::string const
   const bool infiniteMax = RooNumber::isInfinite(max);
 
   for(std::size_t i = 0; i < values.size(); ++i) {
-    out[i] = out[i] & ((infiniteMax | (values[i] <= (max+1e-6))) && (infiniteMin | (values[i] >= (min-1e-6))));
+    out[i] = out[i] && ((infiniteMax | (values[i] <= (max+1e-6))) && (infiniteMin | (values[i] >= (min-1e-6))));
   }
 
 }


### PR DESCRIPTION
This addresses a warning of recent Clang versions about the `use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]`.