### PR TITLE
[ntuple] RRecordField: accout for trailing padding

### DIFF
--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -940,6 +940,9 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
       fSize += item->GetValueSize();
       Attach(std::move(item));
    }
+   // Trailing padding: although this is implementation-dependent, most add enough padding to comply with the
+   // requirements of the type with strictest alignment
+   fSize += GetItemPadding(fSize, fMaxAlignment);
 }
 
 std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -27,6 +27,14 @@ TEST(RNTuple, CreateField)
    EXPECT_STREQ("std::vector<std::uint32_t>", field->GetType().c_str());
    auto value = field->GenerateValue();
    field->DestroyValue(value);
+
+   std::vector<std::unique_ptr<RFieldBase>> itemFields;
+   itemFields.push_back(std::make_unique<RField<std::uint32_t>>("u32"));
+   itemFields.push_back(std::make_unique<RField<std::uint8_t>>("u8"));
+   ROOT::Experimental::RRecordField record("test", itemFields);
+   EXPECT_EQ(alignof(std::uint32_t), record.GetAlignment());
+   // Check that trailing padding is added after `u8` to comply with the alignment requirements of uint32_t
+   EXPECT_EQ(sizeof(std::uint32_t) + alignof(std::uint32_t), record.GetValueSize());
 }
 
 TEST(RNTuple, StdPair)


### PR DESCRIPTION
Although padding is implementation-dependent, most add enough padding at the end to comply with the requirements of the type with strictest alignment.
Given that `GetValueSize()` is used to allocate memory for the described type, not accouting trailing padding may cause issues.

`ROOT::Experimental::RFieldDescriptor::CreateField()` has a direct use of RRecordField. Despite it seems to be working in all tested platforms, be on the safe side and add this padding.

This, does not affect derived classes `RPairField` and `RTupleField`, that override determination of the size of the type.

## Checklist:
- [X] tested changes locally