### PR TITLE
[RF] Export RooSimultaneous channels as dictionary of names in JSON

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -119,7 +119,7 @@ public:
 
    void importFunctions(const RooFit::Detail::JSONNode &n);
    void importFunction(const RooFit::Detail::JSONNode &n, bool isPdf);
-   void exportObject(const RooAbsArg *func, RooFit::Detail::JSONNode &n);
+   RooFit::Detail::JSONNode *exportObject(const RooAbsArg *func);
 
    static std::unique_ptr<RooFit::Detail::JSONTree> createNewJSONTree();
 
@@ -188,11 +188,9 @@ private:
    void exportAttributes(const RooAbsArg *arg, RooFit::Detail::JSONNode &n);
    void exportVariable(const RooAbsArg *v, RooFit::Detail::JSONNode &n);
    void exportVariables(const RooArgSet &allElems, RooFit::Detail::JSONNode &n);
-   void exportFunctions(const RooArgSet &allElems, RooFit::Detail::JSONNode &n);
 
    void exportAllObjects(RooFit::Detail::JSONNode &n);
-   void exportDependants(const RooAbsArg *source, RooFit::Detail::JSONNode &n);
-   void exportDependants(const RooAbsArg *source, RooFit::Detail::JSONNode *n);
+   void exportDependants(const RooAbsArg *source);
 
    // member variables
    const RooFit::Detail::JSONNode *_rootnode_input = nullptr;

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -155,8 +155,9 @@ void exportMeasurement(RooStats::HistFactory::Measurement &measurement, JSONNode
    auto &ch = sim["channels"];
    ch.set_map();
    for (const auto &c : measurement.GetChannels()) {
-      auto &thisch = ch[c.GetName()];
-      exportChannel(c, thisch);
+      auto pdfName = std::string("model_") + c.GetName();
+      ch[c.GetName()] << pdfName;
+      exportChannel(c, pdflist[pdfName]);
    }
 
    // the variables

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -684,9 +684,6 @@ public:
    bool tryExport(const RooProdPdf *prodpdf, JSONNode &elem) const
    {
       std::string chname(prodpdf->GetName());
-      if (chname.find("model_") == 0) {
-         chname = chname.substr(6);
-      }
       RooRealSumPdf *sumpdf = nullptr;
       for (const auto &v : prodpdf->pdfList()) {
          if (v->InheritsFrom(RooRealSumPdf::Class())) {

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -177,7 +177,6 @@ public:
       for (const auto &comp : p["channels"].children()) {
          std::string catname(RooJSONFactoryWSTool::name(comp));
          RooJSONFactoryWSTool::log(RooFit::INFO) << "importing category " << catname << std::endl;
-         tool->importFunction(comp, true);
          std::string pdfname(comp.has_val() ? comp.val() : RooJSONFactoryWSTool::name(comp));
          RooAbsPdf *pdf = tool->request<RooAbsPdf>(pdfname, name);
          components[catname] = pdf;
@@ -294,8 +293,7 @@ public:
       const static std::string keystring = "simultaneous";
       return keystring;
    }
-   bool autoExportDependants() const override { return false; }
-   bool exportObject(RooJSONFactoryWSTool *tool, const RooAbsArg *func, JSONNode &elem) const override
+   bool exportObject(RooJSONFactoryWSTool *, const RooAbsArg *func, JSONNode &elem) const override
    {
       const RooSimultaneous *sim = static_cast<const RooSimultaneous *>(func);
       elem["type"] << key();
@@ -308,7 +306,7 @@ public:
          RooAbsPdf *pdf = sim->getPdf(catname);
          if (!pdf)
             RooJSONFactoryWSTool::error("no pdf found for category");
-         tool->exportObject(pdf);
+         channels[catname] << pdf->GetName();
       }
       return true;
    }

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -308,7 +308,7 @@ public:
          RooAbsPdf *pdf = sim->getPdf(catname);
          if (!pdf)
             RooJSONFactoryWSTool::error("no pdf found for category");
-         tool->exportObject(pdf, channels);
+         tool->exportObject(pdf);
       }
       return true;
    }

--- a/tutorials/roofit/rf515_hfJSON.json
+++ b/tutorials/roofit/rf515_hfJSON.json
@@ -10,78 +10,76 @@
                 "toplevel"
             ],
             "channels": {
-                "channel1": {
-                    "type": "histfactory",
-                    "observables": {
-                        "obs_x_channel1": {
-                            "nbins": 2,
-                            "min": 1,
-                            "max": 2
+                "channel1" : "model_channel1"
+            }
+        },
+        "model_channel1": {
+            "type": "histfactory",
+            "observables": {
+                "obs_x_channel1": {
+                    "nbins": 2,
+                    "min": 1,
+                    "max": 2
+                }
+            },
+            "samples": {
+                "signal": {
+                    "overallSystematics": {
+                        "syst1": {
+                            "low": 0.95,
+                            "high": 1.05
                         }
                     },
-                    "samples": {
-                        "signal": {
-                            "type": "hist-sample",
-                            "overallSystematics": {
-                                "syst1": {
-                                    "low": 0.95,
-                                    "high": 1.05
-                                }
-                            },
-                            "normFactors": [
-                                "mu"
-                            ],
-                            "statError": 0,
-                            "data": {
-                                "counts": [
-                                    20,
-                                    10
-                                ]
-                            }
-                        },
-                        "background1": {
-                            "type": "hist-sample",
-                            "overallSystematics": {
-                                "syst2": {
-                                    "low": 0.95,
-                                    "high": 1.05
-                                }
-                            },
-                            "statError": 1,
-                            "data": {
-                                "counts": [
-                                    100,
-                                    0
-                                ],
-                                "errors": [
-                                    5,
-                                    0
-                                ]
-                            }
-                        },
-                        "background2": {
-                            "type": "hist-sample",
-                            "overallSystematics": {
-                                "syst3": {
-                                    "low": 0.95,
-                                    "high": 1.05
-                                }
-                            },
-                            "dict": {
-                                "normalizeByTheory": 1
-                            },
-                            "statError": 1,
-                            "data": {
-                                "counts": [
-                                    0,
-                                    100
-                                ],
-                                "errors": [
-                                    0,
-                                    10
-                                ]
-                            }
+                    "normFactors": [
+                        "mu"
+                    ],
+                    "statError": 0,
+                    "data": {
+                        "counts": [
+                            20,
+                            10
+                        ]
+                    }
+                },
+                "background1": {
+                    "overallSystematics": {
+                        "syst2": {
+                            "low": 0.95,
+                            "high": 1.05
                         }
+                    },
+                    "statError": 1,
+                    "data": {
+                        "counts": [
+                            100,
+                            0
+                        ],
+                        "errors": [
+                            5,
+                            0
+                        ]
+                    }
+                },
+                "background2": {
+                    "overallSystematics": {
+                        "syst3": {
+                            "low": 0.95,
+                            "high": 1.05
+                        }
+                    },
+                    "dict": {
+                        "normalizeByTheory": 1
+                    },
+                    "statError": 1,
+                    "data": {
+                        "counts": [
+                            0,
+                            100
+                        ],
+                        "errors": [
+                            0,
+                            10
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
Export RooSimultaneous channels as dictionary of names instead of having
the full pdf specification as the value.

This change is done because all pdfs should be specified in the
top-level `pdf` structure.

The code of the `RooJSONFactoryWSTool` is also refactored such that
`exportObject` doesn't need to take the node where is should put the
object. It's better if it figures out itself to avoid errors when
calling it.

Also, I suggest to not strip the `model_` prefix of the name from the
pdf that specifies a HistFactory channel. Otherwise, the name values in
the RooSimultaneous don't match anymore, which is a problem now that we
use names as values.