### PR TITLE
[DF] Share datasource/tree column readers between all nodes in the computation graph

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -16,6 +16,7 @@
 #include "RDefineBase.hxx"
 #include "RDefineReader.hxx"
 #include "RDSColumnReader.hxx"
+#include "RLoopManager.hxx"
 #include "RTreeColumnReader.hxx"
 #include "RVariationBase.hxx"
 #include "RVariationReader.hxx"
@@ -40,13 +41,11 @@ using namespace ROOT::TypeTraits;
 namespace RDFDetail = ROOT::Detail::RDF;
 
 template <typename T>
-std::unique_ptr<RDFDetail::RColumnReaderBase>
-MakeColumnReader(unsigned int slot, RDefineBase *define,
-                 const std::map<std::string, std::vector<void *>> &DSValuePtrsMap, TTreeReader *r,
-                 ROOT::RDF::RDataSource *ds, const std::string &colName, RVariationBase *variation,
-                 const std::string &variationName)
+std::shared_ptr<RDFDetail::RColumnReaderBase>
+MakeColumnReader(unsigned int slot, RDefineBase *define, RLoopManager &lm, TTreeReader *r, const std::string &colName,
+                 RVariationBase *variation, const std::string &variationName)
 {
-   using Ret_t = std::unique_ptr<RDFDetail::RColumnReaderBase>;
+   using Ret_t = std::shared_ptr<RDFDetail::RColumnReaderBase>;
 
    // variations have precedence over everything else: if this is not null, it means we are in the
    // universe where this variation applies.
@@ -60,17 +59,9 @@ MakeColumnReader(unsigned int slot, RDefineBase *define,
       return Ret_t{new RDefineReader(slot, *define, typeid(T))};
    }
 
-   const auto DSValuePtrsIt = DSValuePtrsMap.find(colName);
-   if (DSValuePtrsIt != DSValuePtrsMap.end()) {
-      // reading from a RDataSource with the old column reader interface
-      const std::vector<void *> &DSValuePtrs = DSValuePtrsIt->second;
-      return Ret_t(new RDSColumnReader<T>(DSValuePtrs[slot]));
-   }
-
-   if (ds != nullptr) {
-      // reading from a RDataSource with the new column reader interface
-      return ds->GetColumnReaders(slot, colName, typeid(T));
-   }
+   auto dsColreader = lm.GetDatasetColumnReader(slot, colName);
+   if (dsColreader != nullptr)
+      return dsColreader;
 
    assert(r != nullptr && "We could not find a reader for this column, this should never happen at this point.");
 
@@ -86,20 +77,18 @@ struct RColumnReadersInfo {
    const std::vector<std::string> &fColNames;
    const RColumnRegister &fColRegister;
    const bool *fIsDefine;
-   const std::map<std::string, std::vector<void *>> &fDSValuePtrsMap;
-   ROOT::RDF::RDataSource *fDataSource;
+   RLoopManager &fLoopManager;
 };
 
 /// Create a group of column readers, one per type in the parameter pack.
 template <typename... ColTypes>
-std::array<std::unique_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)>
+std::array<std::shared_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)>
 MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, const RColumnReadersInfo &colInfo,
                   const std::string &variationName = "nominal")
 {
    // see RColumnReadersInfo for why we pass these arguments like this rather than directly as function arguments
    const auto &colNames = colInfo.fColNames;
-   const auto &DSValuePtrsMap = colInfo.fDSValuePtrsMap;
-   auto *ds = colInfo.fDataSource;
+   auto &lm = colInfo.fLoopManager;
    const auto &colRegister = colInfo.fColRegister;
 
    // the i-th element indicates whether variation variationName provides alternative values for the i-th column
@@ -112,21 +101,20 @@ MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, cons
    }
 
    int i = -1;
-   std::array<std::unique_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)> ret{
-      {{(++i, MakeColumnReader<ColTypes>(slot, colRegister.GetDefine(colNames[i]), DSValuePtrsMap, r, ds, colNames[i],
+   std::array<std::shared_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)> ret{
+      {{(++i, MakeColumnReader<ColTypes>(slot, colRegister.GetDefine(colNames[i]), lm, r, colNames[i],
                                          doesVariationApply[i] ? &colRegister.FindVariation(colNames[i], variationName)
                                                                : nullptr,
                                          variationName))}...}};
    return ret;
 
    // avoid bogus "unused variable" warnings
-   (void)ds;
    (void)slot;
    (void)r;
 }
 
-// dummy overload for for the case of no columns, to silence compiler warnings
-inline std::array<std::unique_ptr<RDFDetail::RColumnReaderBase>, 0>
+// Shortcut overload for the case of no columns
+inline std::array<std::shared_ptr<RDFDetail::RColumnReaderBase>, 0>
 MakeColumnReaders(unsigned int, TTreeReader *, TypeList<>, const RColumnReadersInfo &, const std::string & = "nominal")
 {
    return {};

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -69,8 +69,7 @@ MakeColumnReader(unsigned int slot, RDefineBase *define, RLoopManager &lm, TTree
 
    // Make a RTreeColumnReader for this column and insert it in RLoopManager's map
    auto treeColReader = std::make_unique<RTreeColumnReader<T>>(*r, colName);
-   lm.AddTreeColumnReader(slot, colName, std::move(treeColReader), typeid(T));
-   return lm.GetDatasetColumnReader(slot, colName, typeid(T));
+   return lm.AddTreeColumnReader(slot, colName, std::move(treeColReader), typeid(T));
 }
 
 /// This type aggregates some of the arguments passed to MakeColumnReaders.

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -68,7 +68,7 @@ MakeColumnReader(unsigned int slot, RDefineBase *define, RLoopManager &lm, TTree
    assert(r != nullptr && "We could not find a reader for this column, this should never happen at this point.");
 
    // Make a RTreeColumnReader for this column and insert it in RLoopManager's map
-   auto treeColReader = std::unique_ptr<ROOT::Detail::RDF::RColumnReaderBase>{new RTreeColumnReader<T>(*r, colName)};
+   auto treeColReader = std::make_unique<RTreeColumnReader<T>>(*r, colName);
    lm.AddTreeColumnReader(slot, colName, std::move(treeColReader), typeid(T));
    return lm.GetDatasetColumnReader(slot, colName, typeid(T));
 }

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -386,7 +386,8 @@ std::vector<bool> FindUndefinedDSColumns(const ColumnNames_t &requestedCols, con
 template <typename T>
 void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSource &ds, RColumnRegister &colRegister)
 {
-   if (colRegister.IsDefineOrAlias(colName) || !ds.HasColumn(colName) || lm.HasDataSourceColumnReaders(colName))
+   if (colRegister.IsDefineOrAlias(colName) || !ds.HasColumn(colName) ||
+       lm.HasDataSourceColumnReaders(colName, typeid(T)))
       return;
 
    const auto nSlots = lm.GetNSlots();
@@ -404,7 +405,7 @@ void AddDSColumnsHelper(const std::string &colName, RLoopManager &lm, RDataSourc
          colReaders.emplace_back(ds.GetColumnReaders(slot, colName, typeid(T)));
    }
 
-   lm.AddDataSourceColumnReaders(colName, std::move(colReaders));
+   lm.AddDataSourceColumnReaders(colName, std::move(colReaders), typeid(T));
 }
 
 /// Take list of column names that must be defined, current map of custom columns, current list of defined column names,

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -58,7 +58,7 @@ class R__CLING_PTRCHECK(off) RAction : public RActionBase {
    const std::shared_ptr<PrevNode> fPrevNodePtr;
    PrevNode &fPrevNode;
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
@@ -95,8 +95,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
       RDFInternal::RColumnReadersInfo info{RActionBase::GetColumnNames(), RActionBase::GetColRegister(),
-                                           fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
-                                           fLoopManager->GetDataSource()};
+                                           fIsDefine.data(), *fLoopManager};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
       fHelper.InitTask(r, slot);
    }

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -64,7 +64,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    ValuesPerSlot_t fLastResults;
 
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    /// Define objects corresponding to systematic variations other than nominal for this defined column.
    /// The map key is the full variation name, e.g. "pt:up".
@@ -117,8 +117,7 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
-                                           fLoopManager->GetDataSource()};
+      RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), *fLoopManager};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
       fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -65,7 +65,7 @@ class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
 
    FilterF fFilter;
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
    const std::shared_ptr<PrevNode_t> fPrevNodePtr;
    PrevNode_t &fPrevNode;
 
@@ -118,8 +118,7 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
-                                           fLoopManager->GetDataSource()};
+      RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), *fLoopManager};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
       fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -198,8 +198,9 @@ public:
    bool HasDataSourceColumnReaders(const std::string &col, const std::type_info &ti) const;
    void AddDataSourceColumnReaders(const std::string &col, std::vector<std::unique_ptr<RColumnReaderBase>> &&readers,
                                    const std::type_info &ti);
-   void AddTreeColumnReader(unsigned int slot, const std::string &col, std::unique_ptr<RColumnReaderBase> &&reader,
-                            const std::type_info &ti);
+   std::shared_ptr<RColumnReaderBase> AddTreeColumnReader(unsigned int slot, const std::string &col,
+                                                          std::unique_ptr<RColumnReaderBase> &&reader,
+                                                          const std::type_info &ti);
    std::shared_ptr<RColumnReaderBase>
    GetDatasetColumnReader(unsigned int slot, const std::string &col, const std::type_info &ti) const;
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -86,9 +86,11 @@ public:
    }
 };
 
-} // ns RDF
-} // ns Internal
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
 
+namespace ROOT {
 namespace Detail {
 namespace RDF {
 namespace RDFInternal = ROOT::Internal::RDF;
@@ -193,9 +195,13 @@ public:
    void ToJitExec(const std::string &) const;
    void RegisterCallback(ULong64_t everyNEvents, std::function<void(unsigned int)> &&f);
    unsigned int GetNRuns() const { return fNRuns; }
-   bool HasDataSourceColumnReaders(const std::string &col) const;
-   void AddDataSourceColumnReaders(const std::string &col, std::vector<std::unique_ptr<RColumnReaderBase>> &&readers);
-   std::shared_ptr<RColumnReaderBase> GetDatasetColumnReader(unsigned int slot, const std::string &col) const;
+   bool HasDataSourceColumnReaders(const std::string &col, const std::type_info &ti) const;
+   void AddDataSourceColumnReaders(const std::string &col, std::vector<std::unique_ptr<RColumnReaderBase>> &&readers,
+                                   const std::type_info &ti);
+   void AddTreeColumnReader(unsigned int slot, const std::string &col, std::unique_ptr<RColumnReaderBase> &&reader,
+                            const std::type_info &ti);
+   std::shared_ptr<RColumnReaderBase>
+   GetDatasetColumnReader(unsigned int slot, const std::string &col, const std::type_info &ti) const;
 
    /// End of recursive chain of calls, does nothing
    void AddFilterName(std::vector<std::string> &) {}
@@ -219,6 +225,6 @@ public:
 
 } // ns RDF
 } // ns Detail
-} // ns ROOT
+} // namespace ROOT
 
 #endif

--- a/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
@@ -65,12 +65,16 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Det
    /// Signal whether we ever checked that the branch we are reading with a TTreeReaderArray stores array elements
    /// in contiguous memory.
    EStorageType fStorageType = EStorageType::kUnknown;
+   Long64_t fLastEntry = -1;
 
    /// Whether we already printed a warning about performing a copy of the TTreeReaderArray contents
    bool fCopyWarningPrinted = false;
 
-   void *GetImpl(Long64_t) final
+   void *GetImpl(Long64_t entry) final
    {
+      if (entry == fLastEntry)
+         return &fRVec; // we already pointed our fRVec to the right address
+
       auto &readerArray = *fTreeArray;
       // We only use TTreeReaderArrays to read columns that users flagged as type `RVec`, so we need to check
       // that the branch stores the array as contiguous memory that we can actually wrap in an `RVec`.
@@ -122,6 +126,7 @@ class R__CLING_PTRCHECK(off) RTreeColumnReader<RVec<T>> final : public ROOT::Det
             swap(fRVec, emptyVec);
          }
       }
+      fLastEntry = entry;
       return &fRVec;
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -148,7 +148,7 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    std::vector<ret_type> fLastResults;
 
    /// Column readers per slot and per input column
-   std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
 
    template <typename... ColTypes, std::size_t... S>
    void UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
@@ -212,8 +212,7 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      RColumnReadersInfo info{fInputColumns, fColumnRegister, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
-                              fLoopManager->GetDataSource()};
+      RColumnReadersInfo info{fInputColumns, fColumnRegister, fIsDefine.data(), *fLoopManager};
       fValues[slot] = MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
       fLastCheckedEntry[slot * CacheLineStep<Long64_t>()] = -1;
    }

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -47,7 +47,7 @@ class R__CLING_PTRCHECK(off) RVariedAction final : public RActionBase {
    std::vector<std::shared_ptr<PrevNodeType>> fPrevNodes;
 
    /// Column readers per slot (outer dimension), per variation and per input column (inner dimension, std::array).
-   std::vector<std::vector<std::array<std::unique_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>>> fInputValues;
+   std::vector<std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>>> fInputValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
@@ -103,8 +103,7 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      RDFInternal::RColumnReadersInfo info{GetColumnNames(), GetColRegister(), fIsDefine.data(),
-                                           fLoopManager->GetDSValuePtrs(), fLoopManager->GetDataSource()};
+      RDFInternal::RColumnReadersInfo info{GetColumnNames(), GetColRegister(), fIsDefine.data(), *fLoopManager};
 
       // get readers for each systematic variation
       for (const auto &variation : GetVariations())

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -973,14 +973,17 @@ void RLoopManager::AddDataSourceColumnReaders(const std::string &col,
 }
 
 // Differently from AddDataSourceColumnReaders, this can be called from multiple threads concurrently
-void RLoopManager::AddTreeColumnReader(unsigned int slot, const std::string &col,
-                                       std::unique_ptr<RColumnReaderBase> &&reader, const std::type_info &ti)
+/// \brief Register a new RTreeColumnReader with this RLoopManager.
+/// \return A shared pointer to the inserted column reader.
+std::shared_ptr<RColumnReaderBase> RLoopManager::AddTreeColumnReader(unsigned int slot, const std::string &col,
+                                                                     std::unique_ptr<RColumnReaderBase> &&reader,
+                                                                     const std::type_info &ti)
 {
    auto &readers = fDatasetColumnReaders[slot];
    const auto key = MakeDatasetColReadersKey(col, ti);
    // if a reader for this column and this slot was already there, we are doing something wrong
    assert(readers.find(key) == readers.end() || readers[key] == nullptr);
-   readers[key] = std::move(reader);
+   return readers[key] = std::move(reader);
 }
 
 std::shared_ptr<RColumnReaderBase>


### PR DESCRIPTION
Before this patch, each node in the computation graph was
re-creating or re-requesting column readers for datasource and TTree/TChain
columns separately.

We now create column readers for datasource and TTree/TChain columns early and
store them in RLoopManager which then gives out pointers to the
same RColumnReaderBase objects to all nodes.

This is the first part of a series of changes aimed at
centralizing ownership and creation of all kinds of column
readers (defines and variations will come in a subsequent PR).
Sharing column readers among nodes of the computation
graph saves some redundant work and it is a pre-requisite for bulk
processing at the level of RDF.