### PR TITLE
[RF] Fix schema evolution rule for old RooProduct versions

### DIFF
--- a/roofit/roofitcore/inc/LinkDef.h
+++ b/roofit/roofitcore/inc/LinkDef.h
@@ -166,8 +166,16 @@
 #pragma link C++ class RooPrintable+ ;
 #pragma link C++ class RooProdGenContext+ ;
 #pragma link C++ class RooProduct+ ;
-#pragma read sourceClass="RooProduct" targetClass="RooProduct" version="[1]" source="RooSetProxy _compRSet" target="_compRSet" code="{ _compRSet.add(onfile._compRSet) ; }"
-#pragma read sourceClass="RooProduct" targetClass="RooProduct" version="[1]" source="RooSetProxy _compCSet" target="_compCSet" code="{ _compCSet.add(onfile._compCSet) ; }"
+#pragma read sourceClass="RooProduct" targetClass="RooProduct" version="[1]"                      \
+             source="RooSetProxy _compRSet" target="_compRSet"                                    \
+             code="{                                                                              \
+                 _compRSet = RooListProxy(onfile._compRSet.GetName(), newObj, onfile._compRSet) ; \
+             }"
+#pragma read sourceClass="RooProduct" targetClass="RooProduct" version="[1]"                      \
+             source="RooSetProxy _compCSet" target="_compCSet"                                    \
+             code="{                                                                              \
+                 _compCSet = RooListProxy(onfile._compCSet.GetName(), newObj, onfile._compCSet) ; \
+             }"
 #pragma link C++ class RooPullVar+ ;
 #pragma link C++ class RooQuasiRandomGenerator+ ;
 #pragma link C++ class RooRatio+ ;

--- a/roofit/roofitcore/inc/RooCollectionProxy.h
+++ b/roofit/roofitcore/inc/RooCollectionProxy.h
@@ -53,9 +53,10 @@ public:
    }
 
    /// Copy constructor.
-   RooCollectionProxy(const char *inName, RooAbsArg *owner, const RooCollectionProxy &other)
-      : RooCollection_t(other, inName), _owner(owner), _defValueServer(other._defValueServer),
-        _defShapeServer(other._defShapeServer)
+   template<class Other_t>
+   RooCollectionProxy(const char *inName, RooAbsArg *owner, const Other_t &other)
+      : RooCollection_t(other, inName), _owner(owner), _defValueServer(other.defValueServer()),
+        _defShapeServer(other.defShapeServer())
    {
       _owner->registerProxy(*this);
    }
@@ -110,6 +111,9 @@ public:
       RooCollection_t::operator=(other);
       return *this;
    }
+
+   bool defValueServer() const { return _defValueServer; }
+   bool defShapeServer() const { return _defShapeServer; }
 
 private:
    RooAbsArg *_owner = nullptr;


### PR DESCRIPTION
There was a bug in a schema evolution rule for a very old RooProduct
version, where a `RooSetProxy` member was replaced by a `RooListProxy`.
The problem was that only the content was copied to the new proxy list,
not the other members. This lead to an invalid state for the
RooSetProxy, because it had no registered owner.

The fix is to use a real copy constructor from `RooSetProxy` to
`RooListProxy`, which is also introduced in this commit with the schema
evolution rule fix.