### PR TITLE
[RF] Fix problem of RooProduct and RooProdPdf with RooWorkspace factory

### DIFF
--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -34,7 +34,6 @@ class RooProdPdf : public RooAbsPdf {
 public:
 
   RooProdPdf() ;
-  RooProdPdf(const char *name, const char *title, double cutOff=0);
   RooProdPdf(const char *name, const char *title,
        RooAbsPdf& pdf1, RooAbsPdf& pdf2, double cutOff=0) ;
   RooProdPdf(const char* name, const char* title, const RooArgList& pdfList, double cutOff=0) ;

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -30,7 +30,8 @@ class RooProduct : public RooAbsReal {
 public:
 
   RooProduct() ;
-  RooProduct(const char *name, const char *title, const RooArgList& _prodSet) ;
+  RooProduct(const char *name, const char *title, const RooArgList& prodSet) ;
+  RooProduct(const char *name, const char *title, RooAbsReal& real1, RooAbsReal& real2) ;
 
   RooProduct(const RooProduct& other, const char* name = 0);
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -92,26 +92,6 @@ RooProdPdf::RooProdPdf() :
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Dummy constructor
-
-RooProdPdf::RooProdPdf(const char *name, const char *title, double cutOff) :
-  RooAbsPdf(name,title),
-  _cacheMgr(this,10),
-  _genCode(10),
-  _cutOff(cutOff),
-  _pdfList("!pdfs","List of PDFs",this),
-  _extendedIndex(-1),
-  _useDefaultGen(false),
-  _refRangeName(0),
-  _selfNorm(true)
-{
-  TRACE_CREATE
-}
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with 2 PDFs (most frequent use case).
 ///

--- a/roofit/roofitcore/src/RooProduct.cxx
+++ b/roofit/roofitcore/src/RooProduct.cxx
@@ -86,6 +86,9 @@ RooProduct::RooProduct(const char* name, const char* title, const RooArgList& pr
 }
 
 
+RooProduct::RooProduct(const char *name, const char *title, RooAbsReal& real1, RooAbsReal& real2) :
+  RooProduct{name, title, {real1, real2}} {}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor


### PR DESCRIPTION
This commit fixes two issues:

1. Introduce `RooProduct` constructor from two RooAbsReals to be
   consistent with the `RooRrodPdf`, which has a constructor from two
   RooAbsPdfs.

2. Remove a useless dummy constructor for a `RooProdPdf` with no
   factors, which somehow prevented the constructor from a RooFit
   collection to be picked up correctly by `RooWorkspace::factory()`

The request to change the RooProduct and RooProdPdf constructors from
RooFit collections to take RooArgSets and not RooArgLists (https://github.com/root-project/root/issues/7809#issuecomment-817683625) was not
followed. This would be a breaking change for people that use
`RooProduct` to square a function for example.

A unit test for the issue was also implemented.

Closes https://github.com/root-project/root/issues/7809.