### PR TITLE
[RF] Implement likelihood offsetting in new RooFit BatchMode

### DIFF
--- a/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
+++ b/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
@@ -38,7 +38,7 @@ makeDriverAbsRealWrapper(std::unique_ptr<ROOT::Experimental::RooFitDriver> drive
 std::unique_ptr<RooAbsReal> createNLL(RooAbsPdf &pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &&constraints,
                                       std::string const &rangeName, std::string const &addCoefRangeName,
                                       RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
-                                      RooFit::BatchModeOption batchMode);
+                                      RooFit::BatchModeOption batchMode, bool doOffset);
 
 void logArchitectureInfo(RooFit::BatchModeOption batchMode);
 

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -18,6 +18,8 @@
 #include "RooAbsReal.h"
 #include "RooTemplateProxy.h"
 
+#include <Math/Util.h>
+
 #include "RooBatchComputeTypes.h"
 
 namespace ROOT {
@@ -32,7 +34,7 @@ public:
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
-                std::string const &rangeName);
+                std::string const &rangeName, bool doOffset);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = 0);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 
@@ -62,12 +64,14 @@ private:
    bool _isExtended;
    bool _weightSquared = false;
    bool _binnedL = false;
+   bool _doOffset = false;
    std::string _prefix;
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
    std::unique_ptr<RooTemplateProxy<RooAbsReal>> _fractionInRange;
-   mutable std::vector<double> _binw;            //!
-   mutable std::vector<double> _logProbasBuffer; //!
+   mutable std::vector<double> _binw;                  ///<!
+   mutable std::vector<double> _logProbasBuffer;       ///<!
+   mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision
 
 }; // end class RooNLLVar
 

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -35,7 +35,7 @@ using ROOT::Experimental::RooNLLVarNew;
 namespace {
 
 std::unique_ptr<RooAbsArg> prepareSimultaneousModelForBatchMode(RooSimultaneous &simPdf, RooArgSet &observables,
-                                                                bool isExtended, std::string const &rangeName)
+                                                                bool isExtended, std::string const &rangeName, bool doOffset)
 {
    // Prepare the NLLTerms for each component
    RooArgList nllTerms;
@@ -44,7 +44,7 @@ std::unique_ptr<RooAbsArg> prepareSimultaneousModelForBatchMode(RooSimultaneous 
       auto const &catName = catItem.first;
       if (RooAbsPdf *pdf = simPdf.getPdf(catName.c_str())) {
          auto nllName = std::string("nll_") + pdf->GetName();
-         auto *nll = new RooNLLVarNew(nllName.c_str(), nllName.c_str(), *pdf, observables, isExtended, rangeName);
+         auto *nll = new RooNLLVarNew(nllName.c_str(), nllName.c_str(), *pdf, observables, isExtended, rangeName, doOffset);
          // Rename the observables and weights
          newObservables.add(nll->prefixObservableAndWeightNames(std::string("_") + catName + "_"));
          nllTerms.add(*nll);
@@ -64,7 +64,7 @@ std::unique_ptr<RooAbsReal>
 RooFit::BatchModeHelpers::createNLL(RooAbsPdf &pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &&constraints,
                                     std::string const &rangeName, std::string const &addCoefRangeName,
                                     RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
-                                    RooFit::BatchModeOption batchMode)
+                                    RooFit::BatchModeOption batchMode, bool doOffset)
 {
    std::unique_ptr<RooFitDriver> driver;
 
@@ -99,10 +99,10 @@ RooFit::BatchModeHelpers::createNLL(RooAbsPdf &pdf, RooAbsData &data, std::uniqu
       auto *simPdfClone = static_cast<RooSimultaneous *>(simPdf->cloneTree());
       simPdfClone->wrapPdfsInBinSamplingPdfs(data, integrateOverBinsPrecision);
       // Warning! This mutates "observables"
-      nllTerms.addOwned(prepareSimultaneousModelForBatchMode(*simPdfClone, observables, isExtended, rangeName));
+      nllTerms.addOwned(prepareSimultaneousModelForBatchMode(*simPdfClone, observables, isExtended, rangeName, doOffset));
    } else {
       nllTerms.addOwned(
-         std::make_unique<RooNLLVarNew>("RooNLLVarNew", "RooNLLVarNew", finalPdf, observables, isExtended, rangeName));
+         std::make_unique<RooNLLVarNew>("RooNLLVarNew", "RooNLLVarNew", finalPdf, observables, isExtended, rangeName, doOffset));
    }
    if (constraints) {
       nllTerms.addOwned(std::move(constraints));

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1113,7 +1113,8 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
                                                projDeps,
                                                ext,
                                                pc.getDouble("IntegrateBins"),
-                                               batchMode).release();
+                                               batchMode,
+                                               doOffset).release();
   }
 
   // Construct NLL

--- a/roofit/roofitcore/test/testRooFitDriver.cxx
+++ b/roofit/roofitcore/test/testRooFitDriver.cxx
@@ -84,7 +84,7 @@ TEST(testRooFitDriver, SimpleLikelihoodFit)
 
    // ...and now the new way with RooFitDriver
    using namespace ROOT::Experimental;
-   RooNLLVarNew nll("nll", "nll", model, *data->get(), false, "");
+   RooNLLVarNew nll("nll", "nll", model, *data->get(), false, "", false);
    auto driver = std::make_unique<RooFitDriver>(nll, x, RooFit::BatchModeOption::Cpu);
    driver->setData(*data);
    auto wrapper = RooFit::BatchModeHelpers::makeDriverAbsRealWrapper(std::move(driver), *data->get());


### PR DESCRIPTION
This is necessary to make the more complicated fits converge, like the
ATLAS Higgs combination fits.

