### PR TITLE
[cmake] Suppress all warnings compiling builtin-zstd:

### DIFF
--- a/builtins/zstd/CMakeLists.txt
+++ b/builtins/zstd/CMakeLists.txt
@@ -91,7 +91,7 @@ set_target_properties(zstd PROPERTIES COMPILE_DEFINITIONS "ZSTD_HEAPMODE=0;_CRT_
 target_include_directories(zstd PRIVATE ${ZSTD_INCLUDE_DIR} INTERFACE $<BUILD_INTERFACE:${ZSTD_INCLUDE_DIR}>)
 target_link_libraries(zstd PRIVATE xxHash::xxHash)
 if(NOT MSVC)
-  target_compile_options(zstd PRIVATE -fPIC -Wno-unused-variable -O3)
+  target_compile_options(zstd PRIVATE -fPIC -w -O3)
 endif()
 add_library(ZSTD::ZSTD ALIAS zstd)
 


### PR DESCRIPTION
This fixes a warning seen on macOS:
```
zstd_compress_superblock.c:412:12: warning: variable 'litLengthSum' set but not used
```
As we won't fix those there's no need to emit them.
