### PR TITLE
[DF] Remove redundant calls to RDefine::InitSlot

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -121,9 +121,6 @@ public:
                                            fLoopManager->GetDataSource()};
       fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
       fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
-
-      for (auto &e : fVariedDefines)
-         e.second->InitSlot(r, slot);
    }
 
    /// Return the (type-erased) address of the Define'd value for the given processing slot.

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -212,8 +212,6 @@ public:
 
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
-      for (auto &define : fColumnRegister.GetDefines())
-         define.second->InitSlot(r, slot);
       RColumnReadersInfo info{fInputColumns, fColumnRegister, fIsDefine.data(), fLoopManager->GetDSValuePtrs(),
                               fLoopManager->GetDataSource()};
       fValues[slot] = MakeColumnReaders(slot, r, ColumnTypes_t{}, info);


### PR DESCRIPTION
We now register all RDefine nodes, incuding varied defines, with
RLoopManager, which is in charge of calling InitSlot on all
registered nodes, so we do not need to propagate the InitSlot call
from RVariation or RDefine to other RDefines.