### PR TITLE
Fix setting axis limits for TGraph when log scale

### DIFF
--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -709,8 +709,15 @@ void TGraph::ComputeRange(Double_t &xmin, Double_t &ymin, Double_t &xmax, Double
       xmin = xmax = ymin = ymax = 0;
       return;
    }
-   xmin = xmax = fX[0];
-   ymin = ymax = fY[0];
+   if (fHistogram) {
+      xmin = fHistogram->GetXaxis()->GetXmin();
+      xmax = fHistogram->GetXaxis()->GetXmax();
+      ymin = fHistogram->GetYaxis()->GetXmin();
+      ymax = fHistogram->GetYaxis()->GetXmax();
+   } else {
+      xmin = xmax = fX[0];
+      ymin = ymax = fY[0];
+   }
 
    Double_t xminl = 0; // Positive minimum. Used in case of log scale along X axis.
    Double_t yminl = 0; // Positive minimum. Used in case of log scale along Y axis.


### PR DESCRIPTION
# This Pull request:
Fixes setting axis limits when log scale is on.

## Changes or fixes:
In the following case without this fix limits to X axis wouldn't be applied:

```C++
root [0] TCanvas *c = new TCanvas("","",800,800)
(TCanvas *) 0x55ad27dfcd50
root [1] c->SetLogx()
root [2] double x[]={1,2}
(double [2]) { 1.0000000, 2.0000000 }
root [3] TGraph *g = new TGraph(2,x,x)
(TGraph *) 0x55ad2953bdd0
root [4] g->GetXaxis()->SetLimits(0,100)
root [5] g->Draw()
```

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)
