### PR TITLE
[RF] Bring back missing IO constructor to RooBernstein

### DIFF
--- a/roofit/roofit/inc/RooBernstein.h
+++ b/roofit/roofit/inc/RooBernstein.h
@@ -26,6 +26,7 @@ class RooArgList;
 class RooBernstein : public RooAbsPdf {
 public:
 
+  RooBernstein() {}
   RooBernstein(const char *name, const char *title,
                RooAbsRealLValue& _x, const RooArgList& _coefList) ;
 


### PR DESCRIPTION
In commit 0d1f0bbde0, the IO constructor of RooBernstein has
accidentally been removed, which broke reading RooBernstein instances
from ROOT files. Hence, this commit brings it back.

No backport needed, because the IO constructor was removed in the same
development cycle (leading up to 6.28).