### PR TITLE
[graphics] use c++ classes for temporary data in ExecuteEvent methods

### DIFF
--- a/graf2d/asimage/src/TASImage.cxx
+++ b/graf2d/asimage/src/TASImage.cxx
@@ -57,9 +57,10 @@ Several examples showing how to use this class are available in the
 ROOT tutorials: `$ROOTSYS/tutorials/image/`
 */
 
-#  include <ft2build.h>
-#  include FT_FREETYPE_H
-#  include FT_GLYPH_H
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_GLYPH_H
+
 #include "TASImage.h"
 #include "TASImagePlugin.h"
 #include "TROOT.h"
@@ -88,6 +89,8 @@ ROOT tutorials: `$ROOTSYS/tutorials/image/`
 #include "RConfigure.h"
 #include "TVirtualPadPainter.h"
 #include "snprintf.h"
+
+#include <memory>
 
 #ifndef WIN32
 #ifndef R__HAS_COCOA
@@ -1703,7 +1706,7 @@ Int_t TASImage::DistancetoPrimitive(Int_t px, Int_t py)
 
 void TASImage::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 {
-   static TBox *ZoomBox;
+   static std::unique_ptr<TBox> ZoomBox;
 
    if (!gPad) return;
 
@@ -1762,9 +1765,8 @@ void TASImage::ExecuteEvent(Int_t event, Int_t px, Int_t py)
                ZoomBox->SetY1(gPad->AbsPixeltoY(pyl));
                ZoomBox->SetX2(gPad->AbsPixeltoX(pxt));
                ZoomBox->SetY2(gPad->AbsPixeltoY(pyt));
-            }
-            else {
-               ZoomBox = new TBox(pxl, pyl, pxt, pyt);
+            } else {
+               ZoomBox = std::make_unique<TBox>(pxl, pyl, pxt, pyt);
                ZoomBox->SetFillStyle(0);
                ZoomBox->Draw("l*");
             }
@@ -1800,10 +1802,9 @@ void TASImage::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             Zoom((imgX1 < imgX2) ? imgX1 : imgX2, (imgY1 < imgY2) ? imgY1 : imgY2,
                  TMath::Abs(imgX1 - imgX2) + 1, TMath::Abs(imgY1 - imgY2) + 1);
 
-            if (ZoomBox) {
-               ZoomBox->Delete();
-               ZoomBox = 0;
-            }
+            if (ZoomBox)
+               ZoomBox.reset();
+               
             gPad->Modified(kTRUE);
             gPad->Update();
             break;

--- a/graf2d/graf/src/TAttImage.cxx
+++ b/graf2d/graf/src/TAttImage.cxx
@@ -92,7 +92,7 @@ This class provides a way to edit the palette via a GUI.
 #include "TColor.h"
 #include "TMath.h"
 #include "TStyle.h"
-
+#include <vector>
 
 ClassImp(TPaletteEditor);
 ClassImp(TAttImage);
@@ -171,10 +171,11 @@ public:
 
    Int_t *GetRootColors() override
    {
-      static Int_t *gRootColors = nullptr;
-      if (gRootColors) return gRootColors;
+      static std::vector<Int_t> gRootColors;
+      if (!gRootColors.empty())
+         return gRootColors.data();
 
-      gRootColors = new Int_t[216];
+      gRootColors.resize(216);
 
       int i = 0;
       for (int r = 0; r < 6; r++) {
@@ -185,7 +186,7 @@ public:
             }
          }
       }
-      return gRootColors;
+      return gRootColors.data();
    }
 };
 
@@ -508,15 +509,16 @@ Int_t TImagePalette::FindColor(UShort_t r, UShort_t g, UShort_t b)
 
 Int_t *TImagePalette::GetRootColors()
 {
-   static Int_t *gRootColors = 0;
-   if (gRootColors) return gRootColors;
+   static std::vector<Int_t> gRootColors;
+   if (!gRootColors.empty())
+      return gRootColors.data();
 
-   gRootColors = new Int_t[fNumPoints];
+   gRootColors.resize(fNumPoints);
 
-   for (UInt_t i = 0; i < fNumPoints; i++) {
+   for (UInt_t i = 0; i < fNumPoints; i++)
       gRootColors[i] = TColor::GetColor(fColorRed[i], fColorGreen[i], fColorBlue[i]);
-   }
-   return gRootColors;
+
+   return gRootColors.data();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -10,6 +10,7 @@
  *************************************************************************/
 
 #include <iostream>
+#include <vector>
 #include "TROOT.h"
 #include "TBuffer.h"
 #include "TMath.h"
@@ -267,7 +268,7 @@ void TPolyLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
    static Int_t px1,px2,py1,py2;
    static Int_t pxold, pyold, px1old, py1old, px2old, py2old;
    static Int_t dpx, dpy;
-   static Int_t *x=0, *y=0;
+   static std::vector<Int_t> x, y;
    Bool_t opaque  = gPad->OpaqueMoving();
 
    if (!gPad->IsEditable()) return;
@@ -286,9 +287,9 @@ void TPolyLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
       ipoint = -1;
 
 
-      if (x || y) break;
-      x = new Int_t[np+1];
-      y = new Int_t[np+1];
+      if (!x.empty() || !y.empty()) break;
+      x.resize(np+1, 0);
+      y.resize(np+1, 0);
       for (i=0;i<np;i++) {
          pxp = gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
          pyp = gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
@@ -423,7 +424,7 @@ void TPolyLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             pyold = TMath::Max(pyold, py2);
             pyold = TMath::Min(pyold, py1);
          }
-         if (x && y) {
+         if (!x.empty() && !y.empty()) {
             if (middle) {
                for(i=0;i<np;i++) {
                   fX[i] = gPad->PadtoX(gPad->AbsPixeltoX(x[i]+dpx));
@@ -458,7 +459,7 @@ void TPolyLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
                      ymax + dyr*gPad->GetTopMargin());
          gPad->RangeAxis(xmin, ymin, xmax, ymax);
 
-      if (x && y) {
+      if (!x.empty() && !y.empty()) {
          if (middle) {
             for(i=0;i<np;i++) {
                fX[i] = gPad->PadtoX(gPad->AbsPixeltoX(x[i]+dpx));
@@ -468,8 +469,8 @@ void TPolyLine::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             fX[ipoint] = gPad->PadtoX(gPad->AbsPixeltoX(pxold));
             fY[ipoint] = gPad->PadtoY(gPad->AbsPixeltoY(pyold));
          }
-         delete [] x; x = 0;
-         delete [] y; y = 0;
+         x.clear();
+         y.clear();
       }
       gPad->Modified(kTRUE);
       gVirtualX->SetLineColor(-1);

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -37,6 +37,7 @@
 #include "TRegexp.h"
 #include "strlcpy.h"
 #include "snprintf.h"
+#include <vector>
 
 Double_t *gxwork, *gywork, *gxworkl, *gyworkl;
 Int_t TGraphPainter::fgMaxPointsPerLine = 50;
@@ -836,7 +837,7 @@ void TGraphPainter::ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, 
    static Int_t px1,px2,py1,py2;
    static Int_t pxold, pyold, px1old, py1old, px2old, py2old;
    static Int_t dpx, dpy;
-   static Int_t *x=0, *y=0;
+   static std::vector<Int_t> x, y;
    Bool_t opaque  = gPad->OpaqueMoving();
 
    if (!theGraph->IsEditable() || theGraph->InheritsFrom(TGraphPolar::Class())) {
@@ -861,9 +862,9 @@ void TGraphPainter::ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, 
       ipoint = -1;
 
 
-      if (x || y) break;
-      x = new Int_t[theNpoints+1];
-      y = new Int_t[theNpoints+1];
+      if (!x.empty() || !y.empty()) break;
+      x.resize(theNpoints+1);
+      y.resize(theNpoints+1);
       for (i=0;i<theNpoints;i++) {
          pxp = gPad->XtoAbsPixel(gPad->XtoPad(theX[i]));
          pyp = gPad->YtoAbsPixel(gPad->YtoPad(theY[i]));
@@ -1013,8 +1014,8 @@ void TGraphPainter::ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, 
             pyold = py;
             for(i=0;i<theNpoints;i++) {
                if (badcase) continue;  //do not update if big zoom and points moved
-               if (x) theX[i] = gPad->PadtoX(gPad->AbsPixeltoX(x[i]+dpx));
-               if (y) theY[i] = gPad->PadtoY(gPad->AbsPixeltoY(y[i]+dpy));
+               if (!x.empty()) theX[i] = gPad->PadtoX(gPad->AbsPixeltoX(x[i]+dpx));
+               if (!y.empty()) theY[i] = gPad->PadtoY(gPad->AbsPixeltoY(y[i]+dpy));
             }
          } else {
             pxold = px;
@@ -1047,8 +1048,8 @@ void TGraphPainter::ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, 
 
       if (gROOT->IsEscaped()) {
          gROOT->SetEscape(kFALSE);
-         delete [] x; x = 0;
-         delete [] y; y = 0;
+         x.clear();
+         y.clear();
          break;
       }
 
@@ -1074,8 +1075,8 @@ void TGraphPainter::ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, 
       if (middle) {
          for(i=0;i<theNpoints;i++) {
             if (badcase) continue;  //do not update if big zoom and points moved
-            if (x) theX[i] = gPad->PadtoX(gPad->AbsPixeltoX(x[i]+dpx));
-            if (y) theY[i] = gPad->PadtoY(gPad->AbsPixeltoY(y[i]+dpy));
+            if (!x.empty()) theX[i] = gPad->PadtoX(gPad->AbsPixeltoX(x[i]+dpx));
+            if (!y.empty()) theY[i] = gPad->PadtoY(gPad->AbsPixeltoY(y[i]+dpy));
          }
       } else {
          theX[ipoint] = gPad->PadtoX(gPad->AbsPixeltoX(pxold));
@@ -1093,8 +1094,8 @@ void TGraphPainter::ExecuteEventHelper(TGraph *theGraph, Int_t event, Int_t px, 
          }
       }
       badcase = kFALSE;
-      delete [] x; x = 0;
-      delete [] y; y = 0;
+      x.clear();
+      y.clear();
       gPad->Modified(kTRUE);
       gVirtualX->SetLineColor(-1);
    }

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cctype>
 #include <iostream>
+#include <memory>
 
 #include "TROOT.h"
 #include "TSystem.h"
@@ -3471,7 +3472,7 @@ void THistPainter::ExecuteEvent(Int_t event, Int_t px, Int_t py)
    if (!gPad) return;
 
    static Int_t bin, px1, py1, px2, py2, pyold;
-   static TBox *zoombox = nullptr;
+   static std::unique_ptr<TBox> zoombox;
    Double_t zbx1,zbx2,zby1,zby2;
 
    Int_t bin1, bin2;
@@ -3538,7 +3539,7 @@ void THistPainter::ExecuteEvent(Int_t event, Int_t px, Int_t py)
             zby2 = TMath::Power(10,zby2);
          }
          if (zoombox) Error("ExecuteEvent", "Last zoom box was not deleted");
-         zoombox = new TBox(zbx1, zby1, zbx2, zby2);
+         zoombox = std::make_unique<TBox>(zbx1, zby1, zbx2, zby2);
          Int_t ci = TColor::GetColor("#7d7dff");
          TColor *zoomcolor = gROOT->GetColor(ci);
          if (!TCanvas::SupportAlpha() || !zoomcolor) zoombox->SetFillStyle(3002);
@@ -3678,8 +3679,7 @@ void THistPainter::ExecuteEvent(Int_t event, Int_t px, Int_t py)
                xaxis->SetRangeUser(x1, x2);
                yaxis->SetRangeUser(y1, y2);
             }
-            zoombox->Delete();
-            zoombox = nullptr;
+            zoombox.reset();
          }
       }
       gPad->Modified(kTRUE);

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -3153,7 +3153,7 @@ For more complex demo please see for example `$ROOTSYS/tutorials/tree/temperatur
 
 */
 
-TH1 *gCurrentHist = 0;
+TH1 *gCurrentHist = nullptr;
 
 Hoption_t Hoption;
 Hparam_t  Hparam;
@@ -3163,8 +3163,7 @@ const Int_t kNMAX = 2000;
 const Int_t kMAXCONTOUR  = 104;
 const UInt_t kCannotRotate = BIT(11);
 
-static TBox *gXHighlightBox = 0;   // highlight X box
-static TBox *gYHighlightBox = 0;   // highlight Y box
+static std::unique_ptr<TBox> gXHighlightBox, gYHighlightBox;   // highlight X and Y box
 
 static TString gStringEntries;
 static TString gStringMean;
@@ -3195,8 +3194,7 @@ ClassImp(THistPainter);
 
 THistPainter::THistPainter()
 {
-
-   fH = 0;
+   fH = nullptr;
    fXaxis = 0;
    fYaxis = 0;
    fZaxis = 0;
@@ -3206,8 +3204,8 @@ THistPainter::THistPainter()
    fNcuts = 0;
    fStack = 0;
    fLego  = 0;
-   fPie   = 0;
-   fGraph2DPainter = 0;
+   fPie   = nullptr;
+   fGraph2DPainter = nullptr;
    fShowProjection = 0;
    fShowOption = "";
    for (int i=0; i<kMaxCuts; i++) {
@@ -3710,9 +3708,6 @@ void THistPainter::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
 TList *THistPainter::GetContourList(Double_t contour) const
 {
-
-
-
    // Check if fH contains a TGraphDelaunay2D
    TList *hl = fH->GetListOfFunctions();
    TGraphDelaunay2D *dt = (TGraphDelaunay2D*)hl->FindObject("TGraphDelaunay2D");
@@ -3871,8 +3866,8 @@ void THistPainter::SetHighlight()
    fXHighlightBin = -1;
    fYHighlightBin = -1;
    // delete previous highlight box
-   if (gXHighlightBox) { gXHighlightBox->Delete(); gXHighlightBox = 0; }
-   if (gYHighlightBox) { gYHighlightBox->Delete(); gYHighlightBox = 0; }
+   if (gXHighlightBox) gXHighlightBox.reset();
+   if (gYHighlightBox) gYHighlightBox.reset();
    // emit Highlighted() signal (user can check on disabled)
    if (gPad->GetCanvas()) gPad->GetCanvas()->Highlighted(gPad, fH, fXHighlightBin, fYHighlightBin);
 }
@@ -3963,7 +3958,7 @@ void THistPainter::PaintHighlightBin(Option_t * /*option*/)
    }
 
    if (!gXHighlightBox) {
-      gXHighlightBox = new TBox(hbx1, hby1, hbx2, hby2);
+      gXHighlightBox = std::make_unique<TBox>(hbx1, hby1, hbx2, hby2);
       gXHighlightBox->SetBit(kCannotPick);
       gXHighlightBox->SetFillColor(TColor::GetColor("#9797ff"));
       if (!TCanvas::SupportAlpha()) gXHighlightBox->SetFillStyle(3001);
@@ -3986,7 +3981,7 @@ void THistPainter::PaintHighlightBin(Option_t * /*option*/)
    hby2 = fYaxis->GetBinUpEdge(fYHighlightBin);
 
    if (!gYHighlightBox) {
-      gYHighlightBox = new TBox(hbx1, hby1, hbx2, hby2);
+      gYHighlightBox = std::make_unique<TBox>(hbx1, hby1, hbx2, hby2);
       gYHighlightBox->SetBit(kCannotPick);
       gYHighlightBox->SetFillColor(gXHighlightBox->GetFillColor());
       gYHighlightBox->SetFillStyle(gXHighlightBox->GetFillStyle());
@@ -4505,7 +4500,7 @@ void THistPainter::Paint(Option_t *option)
       return;
    } else {
       if (fPie) delete fPie;
-      fPie = 0;
+      fPie = nullptr;
    }
 
    fXbuf  = new Double_t[kNMAX];


### PR DESCRIPTION
Ensure that static members line `Int_t *x` or `TBox *zoombox` correctly managed can cleanup even 
when mouse event handling is not working properly. Especially when exit application.



