### PR TITLE
REve: Support DigitSet visualization in the context of REveDataCollection

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveBoxSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveBoxSet.hxx
@@ -64,6 +64,7 @@ protected:
    Bool_t            fDrawConeCap;
 
    static Int_t SizeofAtom(EBoxType_e bt);
+   void WriteShapeData(REveDigitSet::DigitBase_t &digit);
 
 public:
    REveBoxSet(const char* n="REveBoxSet", const char* t="");

--- a/graf3d/eve7/src/REveDigitSet.cxx
+++ b/graf3d/eve7/src/REveDigitSet.cxx
@@ -12,6 +12,7 @@
 #include "ROOT/REveDigitSet.hxx"
 #include "ROOT/REveManager.hxx"
 #include "ROOT/REveTrans.hxx"
+#include "ROOT/REveSelection.hxx"
 
 #include "TRefArray.h"
 
@@ -142,7 +143,15 @@ REveDigitSet::DigitBase_t* REveDigitSet::NewDigit()
 
 void REveDigitSet::ReleaseIds()
 {
-   fDigitIds.clear();
+   if (fDigitIds)
+   {
+      const Int_t N = fDigitIds->GetSize();
+
+      for (Int_t i = 0; i < N; ++i)
+         delete fDigitIds->At(i);
+
+      fDigitIds->Expand(0);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -191,34 +200,32 @@ void REveDigitSet::UnHighlighted()
    REveElement::UnHighlighted();
 }
 
+*/
 ////////////////////////////////////////////////////////////////////////////////
 /// Return tooltip for highlighted element if always-sec-select is set.
 /// Otherwise return the tooltip for this element.
 
-TString REveDigitSet::GetHighlightTooltip()
+std::string REveDigitSet::GetHighlightTooltip(const std::set<int>& secondary_idcs) const
 {
-   if (fHighlightedSet.empty()) return "";
-
    if (GetAlwaysSecSelect())
    {
       if (fTooltipCBFoo)
       {
-         return (fTooltipCBFoo)(this, *fHighlightedSet.begin());
+        return (fTooltipCBFoo)(this, *secondary_idcs.begin());
       }
       else if (fDigitIds)
       {
-         TObject *o = GetId(*fHighlightedSet.begin());
+         TObject *o = GetId(*secondary_idcs.begin());
          if (o)
-            return TString(o->GetName());
+            return o->GetName();
       }
-      return TString::Format("%s; idx=%d", GetElementName(), *fHighlightedSet.begin());
+      return TString::Format("%s; idx=%d", GetCName(), *secondary_idcs.begin()).Data();
    }
    else
    {
-      return REveElement::GetHighlightTooltip();
+      return REveElement::GetHighlightTooltip(secondary_idcs);
    }
 }
-*/
 ////////////////////////////////////////////////////////////////////////////////
 /// Instruct underlying memory allocator to regroup itself into a
 /// contiguous memory chunk.
@@ -311,21 +318,34 @@ void REveDigitSet::DigitColor(UChar_t* rgba)
    x[0] = rgba[0]; x[1] = rgba[1]; x[2] = rgba[2]; x[3] = rgba[3];
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// Set external object reference for the last digit added.
+
+void REveDigitSet::DigitId(TObject* id)
+{
+   DigitId(fLastIdx, id);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set external id for the last added digit.
 
-void REveDigitSet::DigitId(Int_t n)
+void REveDigitSet::DigitId(Int_t n, TObject* id)
 {
-   fDigitIds.push_back(n);
+   if (!fDigitIds)
+      fDigitIds = new TRefArray;
+
+   if (fOwnIds && n < fDigitIds->GetSize() && fDigitIds->At(n))
+      delete fDigitIds->At(n);
+
+   fDigitIds->AddAtAndExpand(id, n);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set external object reference for digit n.
 
-Int_t REveDigitSet::GetId(Int_t n) const
+TObject* REveDigitSet::GetId(Int_t n) const
 {
-   return fDigitIds[n];
+   return fDigitIds ? fDigitIds->At(n) : 0;
 }
 
 /*
@@ -419,6 +439,99 @@ REveRGBAPalette* REveDigitSet::AssertPalette()
       }
    }
    return fPalette;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Utility function for maping digit idx with visible shape idx
+bool REveDigitSet::IsDigitVisible(const DigitBase_t *d) const
+{
+   if (fSingleColor) {
+      return true;
+   } else if (fValueIsColor) {
+      return d->fValue ? true : false;
+   } else {
+      if (fPalette)
+         return d->fValue > fPalette->GetMinVal() && d->fValue < fPalette->GetMaxVal();
+      else {
+         printf("Error REveDigitSet::IsDigitVisible() unhadled case\n");
+         return true;
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Utility function for maping digit idx with visible shape idx
+int REveDigitSet::GetAtomIdxFromShapeIdx(int iShapeIdx) const
+{
+   int atomIdx = 0;
+   int shapeIdx = 0;
+   for (Int_t c = 0; c < fPlex.VecSize(); ++c) {
+      Char_t *a = fPlex.Chunk(c);
+      Int_t n = fPlex.NAtoms(c);
+      while (n--) {
+         if (IsDigitVisible((DigitBase_t *)a)) {
+            if (shapeIdx == iShapeIdx)
+               return atomIdx;
+            shapeIdx++;
+         }
+         atomIdx++;
+         a += fPlex.S();
+      }
+   }
+
+   printf("REveDigitSet::GetAtomIdxFromShapeIdx Error locating atom idx from shape idx %d\n", iShapeIdx);
+   return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Utility function for maping shape idx to digit idx
+int REveDigitSet::GetShapeIdxFromAtomIdx(int iAtomIdx) const
+{
+   int atomIdx = 0;
+   int shapeIdx = 0;
+   for (Int_t c = 0; c < fPlex.VecSize(); ++c) {
+      Char_t *a = fPlex.Chunk(c);
+      Int_t n = fPlex.NAtoms(c);
+      while (n--) {
+         if (IsDigitVisible((DigitBase_t *)a)) {
+            if (atomIdx == iAtomIdx) {
+               return shapeIdx;
+            }
+            shapeIdx++;
+         }
+         atomIdx++;
+         a += fPlex.S();
+      }
+   }
+
+   printf("REveDigitSet::GetShapeIdxFromAtomIdx:: Atom with idx %d dose not have a visible shape \n", iAtomIdx);
+   return 0;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Direct callback from EveElemenControl, function elementSelected/elementHighligted controll
+//
+void REveDigitSet::NewShapePicked(int shapeIdx, Int_t selectionId, bool multi)
+{
+   int digitId = GetAtomIdxFromShapeIdx(shapeIdx);
+   auto digit = GetDigit(digitId);
+   if (gDebug) printf("REveDigitSet::NewShapePicked shape ID = %d, atom ID = %d, value = %d\n", shapeIdx, digitId, digit->fValue);
+
+   REveSelection *selection = dynamic_cast<REveSelection *>(ROOT::Experimental::gEve->FindElementById(selectionId));
+   std::set<int> sset = {digitId};
+
+   selection->NewElementPicked(GetElementId(), multi, true, sset);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// called from REveSelection to stream specific selection data
+void REveDigitSet::FillExtraSelectionData(nlohmann::json &j, const std::set<int> &secondary_idcs) const
+{
+   j["shape_idcs"] = nlohmann::json::array();
+   for (auto &i : secondary_idcs) {
+      j["shape_idcs"].push_back(GetShapeIdxFromAtomIdx(i));
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveDigitSet.cxx
+++ b/graf3d/eve7/src/REveDigitSet.cxx
@@ -480,7 +480,7 @@ int REveDigitSet::GetAtomIdxFromShapeIdx(int iShapeIdx) const
    }
 
    printf("REveDigitSet::GetAtomIdxFromShapeIdx Error locating atom idx from shape idx %d\n", iShapeIdx);
-   return 0;
+   return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -505,7 +505,7 @@ int REveDigitSet::GetShapeIdxFromAtomIdx(int iAtomIdx) const
    }
 
    printf("REveDigitSet::GetShapeIdxFromAtomIdx:: Atom with idx %d dose not have a visible shape \n", iAtomIdx);
-   return 0;
+   return -1;
 }
 
 
@@ -516,11 +516,12 @@ void REveDigitSet::NewShapePicked(int shapeIdx, Int_t selectionId, bool multi)
 {
    int digitId = GetAtomIdxFromShapeIdx(shapeIdx);
    auto digit = GetDigit(digitId);
-   if (gDebug) printf("REveDigitSet::NewShapePicked shape ID = %d, atom ID = %d, value = %d\n", shapeIdx, digitId, digit->fValue);
+   if (gDebug) printf("REveDigitSet::NewShapePicked elementId %d shape ID = %d, atom ID = %d, value = %d\n", GetElementId(), shapeIdx, digitId, digit->fValue);
 
    REveSelection *selection = dynamic_cast<REveSelection *>(ROOT::Experimental::gEve->FindElementById(selectionId));
    std::set<int> sset = {digitId};
 
+   RefSelectedSet() = sset;
    selection->NewElementPicked(GetElementId(), multi, true, sset);
 }
 
@@ -530,7 +531,9 @@ void REveDigitSet::FillExtraSelectionData(nlohmann::json &j, const std::set<int>
 {
    j["shape_idcs"] = nlohmann::json::array();
    for (auto &i : secondary_idcs) {
-      j["shape_idcs"].push_back(GetShapeIdxFromAtomIdx(i));
+      int shapeIdx =  GetShapeIdxFromAtomIdx(i);
+      if (shapeIdx >= 0)
+         j["shape_idcs"].push_back(GetShapeIdxFromAtomIdx(i));
    }
 }
 

--- a/tutorials/eve7/boxset.C
+++ b/tutorials/eve7/boxset.C
@@ -16,6 +16,12 @@
 using namespace ROOT::Experimental;
 
 
+std::string customTooltip(const ROOT::Experimental::REveDigitSet *digitSet, int n)
+{
+   auto d = digitSet->GetDigit(n);
+   return TString::Format("Custom tooltip:\n value %d idx %d\n", d->fValue, n).Data();
+}
+
 REveBoxSet* boxset(Int_t num=100)
 {
    auto eveMng = REveManager::Create();
@@ -23,6 +29,8 @@ REveBoxSet* boxset(Int_t num=100)
    TRandom r(0);
 
    auto pal = new REveRGBAPalette(0, 130);
+   pal->SetMin(80);
+
 
    auto q = new REveBoxSet("BoxSet");
    q->SetPalette(pal);
@@ -56,6 +64,8 @@ REveBoxSet* boxset(Int_t num=100)
    // Uncomment these two lines to get internal highlight / selection.
    q->SetPickable(1);
    q->SetAlwaysSecSelect(1);
+
+   q->SetTooltipCBFoo(customTooltip);
 
    eveMng->GetEventScene()->AddElement(q);
 

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -811,10 +811,9 @@ public:
                          const std::set<int> &secondary_idcs)
    {
       if (el) {
-         printf("DEVIATE %s \n", el->GetCName());
          auto *colItems = dynamic_cast<REveDataItemList *>(el);
          if (colItems) {
-            std::cout << "Deviate RefSelected=" << colItems->RefSelectedSet().size() << " passed set " << secondary_idcs.size() << "\n";
+            // std::cout << "Deviate RefSelected=" << colItems->RefSelectedSet().size() << " passed set " << secondary_idcs.size() << "\n";
             ExecuteNewElementPicked(selection, colItems, multi, true, colItems->RefSelectedSet());
             return true;
          }

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -861,13 +861,13 @@ void collection_proxies(bool proj=true)
 
    // create event data from list
    auto collectionMng = new CollectionManager(event);
-/*
+
    REveDataCollection* trackCollection = new REveDataCollection("Tracks");
    trackCollection->SetItemClass(TParticle::Class());
    trackCollection->SetMainColor(kGreen);
    trackCollection->SetFilterExpr("i.Pt() > 4.1 && std::abs(i.Eta()) < 1");
    collectionMng->addCollection(trackCollection, new TParticleProxyBuilder(), true);
-*/
+
    REveDataCollection* jetCollection = new REveDataCollection("Jets");
    jetCollection->SetItemClass(Jet::Class());
    jetCollection->SetMainColor(kYellow);
@@ -879,7 +879,7 @@ void collection_proxies(bool proj=true)
    hitCollection->SetMainColor(kOrange + 7);
    hitCollection->SetFilterExpr("i.fPt > 5");
    collectionMng->addCollection(hitCollection, new RecHitProxyBuilder(), true);
-/*
+
    // add calorimeters
    auto calo3d = new REveCalo3D(event->fCaloData);
    calo3d->SetBarrelRadius(kR_max);
@@ -897,7 +897,7 @@ void collection_proxies(bool proj=true)
    hcalCollection->SetItemClass(RCaloTower::Class());
    hcalCollection->SetMainColor(kBlue);
    collectionMng->addCollection(hcalCollection, new CaloTowerProxyBuilder(event->fCaloData));
-*/
+
    // event navigation
    auto eventMng = new EventManager(event, collectionMng);
    eventMng->SetName("EventManager");

--- a/tutorials/eve7/collection_proxies.C
+++ b/tutorials/eve7/collection_proxies.C
@@ -395,6 +395,7 @@ private:
    void buildBoxSet(REveBoxSet* boxset) {
       auto collection = Collection();
       boxset->SetMainColor(collection->GetMainColor());
+      boxset->SetPickable(true);
       boxset->Reset(REveBoxSet::kBT_FreeBox, true, collection->GetNItems());
       TRandom r(0);
 #define RND_BOX(x) (Float_t)r.Uniform(-(x), (x))
@@ -839,13 +840,13 @@ void collection_proxies(bool proj=true)
 
    // create event data from list
    auto collectionMng = new CollectionManager(event);
-
+/*
    REveDataCollection* trackCollection = new REveDataCollection("Tracks");
    trackCollection->SetItemClass(TParticle::Class());
    trackCollection->SetMainColor(kGreen);
    trackCollection->SetFilterExpr("i.Pt() > 4.1 && std::abs(i.Eta()) < 1");
    collectionMng->addCollection(trackCollection, new TParticleProxyBuilder(), true);
-
+*/
    REveDataCollection* jetCollection = new REveDataCollection("Jets");
    jetCollection->SetItemClass(Jet::Class());
    jetCollection->SetMainColor(kYellow);
@@ -856,8 +857,8 @@ void collection_proxies(bool proj=true)
    hitCollection->SetItemClass(RecHit::Class());
    hitCollection->SetMainColor(kOrange + 7);
    hitCollection->SetFilterExpr("i.fPt > 5");
-   collectionMng->addCollection(hitCollection, new RecHitProxyBuilder());
-
+   collectionMng->addCollection(hitCollection, new RecHitProxyBuilder(), true);
+/*
    // add calorimeters
    auto calo3d = new REveCalo3D(event->fCaloData);
    calo3d->SetBarrelRadius(kR_max);
@@ -875,7 +876,7 @@ void collection_proxies(bool proj=true)
    hcalCollection->SetItemClass(RCaloTower::Class());
    hcalCollection->SetMainColor(kBlue);
    collectionMng->addCollection(hcalCollection, new CaloTowerProxyBuilder(event->fCaloData));
-
+*/
    // event navigation
    auto eventMng = new EventManager(event, collectionMng);
    eventMng->SetName("EventManager");

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -64,8 +64,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(/*EveManager*/) {
 
    class BoxSetControl extends EveElemControl {
 
-      DrawForSelection(sec_idcs, res)
+      DrawForSelection(atom_idcs, res, extra)
       {
+         let sec_idcs = extra.shape_idcs;
          let geobox = new THREE.BufferGeometry();
          geobox.setAttribute( 'position', this.obj3d.geometry.getAttribute("position") );
 
@@ -113,19 +114,27 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(/*EveManager*/) {
          return t + " idx=" + idx;
       }
 
-      elementSelected(indx)
+      elementSelectedSendMIR(idx, selectionId)
       {
-         if (this.obj3d.eve_el.fDetIdsAsSecondaryIndices) {
-            let N = this.obj3d.eve_el.render_data.idxBuff.length / 2;
-            indx = this.obj3d.eve_el.render_data.idxBuff[N + indx];
-         }
+         let boxset = this.obj3d.eve_el;
+         let scene = this.obj3d.scene;
+         let multi = this.event?.ctrlKey ? true : false;
 
-         this.invokeSceneMethod("processElementSelected", indx);
+         let boxIdx = idx;
+
+         let fcall = "NewShapePicked(" + boxIdx + ", " + selectionId + ", " + multi + ")"
+         scene.mgr.SendMIR(fcall, boxset.fElementId, "ROOT::Experimental::REveDigitSet");
+         return true;
       }
 
-      elementHighlighted(indx)
+      elementSelected(idx)
       {
-         this.invokeSceneMethod("processElementHighlighted", indx);
+         return this.elementSelectedSendMIR(idx, this.obj3d.scene.mgr.global_selection_id);
+      }
+
+      elementHighlighted(idx)
+      {
+         return this.elementSelectedSendMIR(idx, this.obj3d.scene.mgr.global_highlight_id);
       }
 
       checkHighlightIndex(indx)

--- a/ui5/eve7/lib/EveElements.js
+++ b/ui5/eve7/lib/EveElements.js
@@ -906,6 +906,9 @@ sap.ui.define(['rootui5/eve7/lib/EveManager'], function(/*EveManager*/) {
 
       makeBoxSet(boxset, rnr_data)
       {
+         if (!rnr_data.vtxBuff)
+           return new THREE.Mesh();
+
          let vBuff;
          if (boxset.boxType == 1) // free box
          {


### PR DESCRIPTION

Add support for visualization of digit sets in the context of physics collections:
* tooltip related to selected collection item
* optimization  for filtered items, e.g. only visible digits are streamed to client

Exmaple of RecHits visualization in CMS
![Untitled](https://user-images.githubusercontent.com/2516492/175380176-3bf84d88-cd9a-410a-80db-264db1c5bed8.png)


