### PR TITLE
[RF] Avoid code duplication in RooRealSumFunc/RooRealSumPdf

### DIFF
--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -16,7 +16,6 @@
 #ifndef ROO_REAL_SUM_FUNC
 #define ROO_REAL_SUM_FUNC
 
-#include "RooRealSumPdf.h"
 #include "RooAbsPdf.h"
 #include "RooListProxy.h"
 #include "RooAICRegistry.h"
@@ -30,7 +29,7 @@ public:
    RooRealSumFunc(const char *name, const char *title);
    RooRealSumFunc(const char *name, const char *title, const RooArgList &funcList, const RooArgList &coefList);
    RooRealSumFunc(const char *name, const char *title, RooAbsReal &func1, RooAbsReal &func2, RooAbsReal &coef1);
-   RooRealSumFunc(const RooRealSumFunc &other, const char *name = 0);
+   RooRealSumFunc(const RooRealSumFunc &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooRealSumFunc(*this, newname); }
    ~RooRealSumFunc() override;
 
@@ -39,8 +38,8 @@ public:
 
    bool forceAnalyticalInt(const RooAbsArg &arg) const override { return arg.isFundamental(); }
    Int_t getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &numVars, const RooArgSet *normSet,
-                                 const char *rangeName = 0) const override;
-   double analyticalIntegralWN(Int_t code, const RooArgSet *normSet, const char *rangeName = 0) const override;
+                                 const char *rangeName = nullptr) const override;
+   double analyticalIntegralWN(Int_t code, const RooArgSet *normSet, const char *rangeName = nullptr) const override;
 
    const RooArgList &funcList() const { return _funcList; }
    const RooArgList &coefList() const { return _coefList; }
@@ -64,7 +63,6 @@ public:
    }
 
 protected:
-   using CacheElem = RooRealSumPdf::CacheElem;
    mutable RooObjCacheManager _normIntMgr; //! The integration cache manager
 
    bool _haveLastCoef;

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -16,10 +16,12 @@
 #ifndef ROO_REAL_SUM_FUNC
 #define ROO_REAL_SUM_FUNC
 
+#include "RooRealSumPdf.h"
 #include "RooAbsPdf.h"
 #include "RooListProxy.h"
 #include "RooAICRegistry.h"
 #include "RooObjCacheManager.h"
+
 #include <list>
 
 class RooRealSumFunc : public RooAbsReal {
@@ -62,19 +64,7 @@ public:
    }
 
 protected:
-   class CacheElem : public RooAbsCacheElement {
-   public:
-      CacheElem(){};
-      ~CacheElem() override{};
-      RooArgList containedArgs(Action) override
-      {
-         RooArgList ret(_funcIntList);
-         ret.add(_funcNormList);
-         return ret;
-      }
-      RooArgList _funcIntList;
-      RooArgList _funcNormList;
-   };
+   using CacheElem = RooRealSumPdf::CacheElem;
    mutable RooObjCacheManager _normIntMgr; //! The integration cache manager
 
    bool _haveLastCoef;
@@ -82,9 +72,9 @@ protected:
    RooListProxy _funcList; ///<  List of component FUNCs
    RooListProxy _coefList; ///<  List of coefficients
 
-   bool _doFloor;              ///< Introduce floor at zero in pdf
+   bool _doFloor = false;           ///< Introduce floor at zero in pdf
    mutable bool _haveWarned{false}; ///<!
-   static bool _doFloorGlobal; ///< Global flag for introducing floor at zero in pdf
+   static bool _doFloorGlobal;      ///< Global flag for introducing floor at zero in pdf
 
 private:
    ClassDefOverride(RooRealSumFunc, 4) // PDF constructed from a sum of (non-pdf) functions

--- a/roofit/roofitcore/inc/RooRealSumFunc.h
+++ b/roofit/roofitcore/inc/RooRealSumFunc.h
@@ -83,6 +83,7 @@ protected:
    RooListProxy _coefList; ///<  List of coefficients
 
    bool _doFloor;              ///< Introduce floor at zero in pdf
+   mutable bool _haveWarned{false}; ///<!
    static bool _doFloorGlobal; ///< Global flag for introducing floor at zero in pdf
 
 private:

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -95,6 +95,17 @@ protected:
 
 private:
 
+  friend class RooRealSumFunc;
+
+  static double evaluate(RooAbsReal const& caller,
+                         RooArgList const& funcList,
+                         RooArgList const& coefList,
+                         bool doFloor,
+                         bool & hasWarnedBefore);
+
+  static bool checkObservables(RooAbsReal const& caller, RooArgSet const* nset,
+                               RooArgList const& funcList, RooArgList const& coefList);
+
   bool haveLastCoef() const {
     return _funcList.size() == _coefList.size();
   }

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -106,9 +106,20 @@ private:
   static bool checkObservables(RooAbsReal const& caller, RooArgSet const* nset,
                                RooArgList const& funcList, RooArgList const& coefList);
 
-  bool haveLastCoef() const {
-    return _funcList.size() == _coefList.size();
-  }
+  static Int_t getAnalyticalIntegralWN(RooAbsReal const& caller, RooObjCacheManager & normIntMgr,
+                                       RooArgList const& funcList, RooArgList const& coefList,
+                                       RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName);
+  static double analyticalIntegralWN(RooAbsReal const& caller, RooObjCacheManager & normIntMgr,
+                                     RooArgList const& funcList, RooArgList const& coefList,
+                                     Int_t code, const RooArgSet* normSet, const char* rangeName,
+                                     bool hasWarnedBefore);
+
+  static std::list<double>* binBoundaries(
+          RooArgList const& funcList, RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/);
+  static std::list<double>* plotSamplingHint(
+          RooArgList const& funcList, RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/);
+
+  static void printMetaArgs(RooArgList const& funcList, RooArgList const& coefList, std::ostream& os);
 
   ClassDefOverride(RooRealSumPdf, 5) // PDF constructed from a sum of (non-pdf) functions
 };

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -97,6 +97,10 @@ private:
 
   friend class RooRealSumFunc;
 
+  static void initializeFuncsAndCoefs(RooAbsReal const& caller,
+                                      const RooArgList& inFuncList, const RooArgList& inCoefList,
+                                      RooArgList& funcList, RooArgList& coefList);
+
   static double evaluate(RooAbsReal const& caller,
                          RooArgList const& funcList,
                          RooArgList const& coefList,
@@ -118,8 +122,11 @@ private:
           RooArgList const& funcList, RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/);
   static std::list<double>* plotSamplingHint(
           RooArgList const& funcList, RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/);
+  static bool isBinnedDistribution(RooArgList const& funcList, const RooArgSet& obs);
 
   static void printMetaArgs(RooArgList const& funcList, RooArgList const& coefList, std::ostream& os);
+
+  static void setCacheAndTrackHints(RooArgList const& funcList, RooArgSet& trackNodes);
 
   ClassDefOverride(RooRealSumPdf, 5) // PDF constructed from a sum of (non-pdf) functions
 };

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -35,9 +35,6 @@
 
 #include "RooRealSumFunc.h"
 
-#include "RooRealSumPdf.h"
-#include "RooRealProxy.h"
-#include "RooPlot.h"
 #include "RooRealVar.h"
 #include "RooAddGenContext.h"
 #include "RooRealConstant.h"
@@ -48,10 +45,7 @@
 
 #include "Riostream.h"
 
-#include <algorithm>
 #include <memory>
-
-using namespace std;
 
 ClassImp(RooRealSumFunc);
 
@@ -62,15 +56,13 @@ RooRealSumFunc::RooRealSumFunc() : _normIntMgr(this, 10)
 {
    // Default constructor
    // coverity[UNINIT_CTOR]
-   _doFloor = false;
    TRACE_CREATE
 }
 
 //_____________________________________________________________________________
 RooRealSumFunc::RooRealSumFunc(const char *name, const char *title)
    : RooAbsReal(name, title), _normIntMgr(this, 10), _haveLastCoef(false),
-     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this),
-     _doFloor(false)
+     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this)
 {
    // Constructor with name and title
    TRACE_CREATE
@@ -80,8 +72,7 @@ RooRealSumFunc::RooRealSumFunc(const char *name, const char *title)
 RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, RooAbsReal &func1, RooAbsReal &func2,
                                RooAbsReal &coef1)
    : RooAbsReal(name, title), _normIntMgr(this, 10), _haveLastCoef(false),
-     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this),
-     _doFloor(false)
+     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this)
 {
    // Construct p.d.f consisting of coef1*func1 + (1-coef1)*func2
    // The input coefficients and functions are allowed to be negative
@@ -99,8 +90,7 @@ RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, RooAbsReal &
 RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, const RooArgList &inFuncList,
                                const RooArgList &inCoefList)
    : RooAbsReal(name, title), _normIntMgr(this, 10), _haveLastCoef(false),
-     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this),
-     _doFloor(false)
+     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this)
 {
    // Constructor p.d.f implementing sum_i [ coef_i * func_i ], if N_coef==N_func
    // or sum_i [ coef_i * func_i ] + (1 - sum_i [ coef_i ] )* func_N if Ncoef==N_func-1
@@ -191,195 +181,19 @@ bool RooRealSumFunc::checkObservables(const RooArgSet *nset) const
 Int_t RooRealSumFunc::getAnalyticalIntegralWN(RooArgSet &allVars, RooArgSet &analVars, const RooArgSet *normSet2,
                                               const char *rangeName) const
 {
-   // cout <<
-   // "RooRealSumFunc::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<",analVars,"<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
-   // << endl;
-   // Advertise that all integrals can be handled internally.
-
-   // Handle trivial no-integration scenario
-   if (allVars.empty())
-      return 0;
-   if (_forceNumInt)
-      return 0;
-
-   // Select subset of allVars that are actual dependents
-   analVars.add(allVars);
-   RooArgSet *normSet = normSet2 ? getObservables(normSet2) : 0;
-
-   // Check if this configuration was created before
-   Int_t sterileIdx(-1);
-   CacheElem *cache = (CacheElem *)_normIntMgr.getObj(normSet, &analVars, &sterileIdx, RooNameReg::ptr(rangeName));
-   if (cache) {
-      // cout <<
-      // "RooRealSumFunc("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
-      // << " -> " << _normIntMgr.lastIndex()+1 << " (cached)" << endl;
-      return _normIntMgr.lastIndex() + 1;
-   }
-
-   // Create new cache element
-   cache = new CacheElem;
-
-   // Make list of function projection and normalization integrals
-  for (const auto elm : _funcList) {
-    const auto func = static_cast<RooAbsReal*>(elm);
-      RooAbsReal *funcInt = func->createIntegral(analVars, rangeName);
-     if(funcInt->InheritsFrom(RooRealIntegral::Class())) ((RooRealIntegral*)funcInt)->setAllowComponentSelection(true);
-      cache->_funcIntList.addOwned(*funcInt);
-      if (normSet && normSet->getSize() > 0) {
-         RooAbsReal *funcNorm = func->createIntegral(*normSet);
-         cache->_funcNormList.addOwned(*funcNorm);
-      }
-   }
-
-   // Store cache element
-   Int_t code = _normIntMgr.setObj(normSet, &analVars, (RooAbsCacheElement *)cache, RooNameReg::ptr(rangeName));
-
-   if (normSet) {
-      delete normSet;
-   }
-
-   // cout <<
-   // "RooRealSumFunc("<<this<<")::getAnalyticalIntegralWN:"<<GetName()<<"("<<allVars<<","<<analVars<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
-   // << " -> " << code+1 << endl;
-   return code + 1;
+   return RooRealSumPdf::getAnalyticalIntegralWN(*this, _normIntMgr, _funcList, _coefList, allVars, analVars, normSet2, rangeName);
 }
 
 //_____________________________________________________________________________
 double RooRealSumFunc::analyticalIntegralWN(Int_t code, const RooArgSet *normSet2, const char *rangeName) const
 {
-   // cout <<
-   // "RooRealSumFunc::analyticalIntegralWN:"<<GetName()<<"("<<code<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
-   // << endl;
-   // Implement analytical integrations by deferring integration of component
-   // functions to integrators of components
-
-   // Handle trivial passthrough scenario
-   if (code == 0)
-      return getVal(normSet2);
-
-   // WVE needs adaptation for rangeName feature
-   CacheElem *cache = (CacheElem *)_normIntMgr.getObjByIndex(code - 1);
-   if (cache == 0) { // revive the (sterilized) cache
-      // cout <<
-      // "RooRealSumFunc("<<this<<")::analyticalIntegralWN:"<<GetName()<<"("<<code<<","<<(normSet2?*normSet2:RooArgSet())<<","<<(rangeName?rangeName:"<none>")
-      // << ": reviving cache "<< endl;
-      std::unique_ptr<RooArgSet> vars(getParameters(RooArgSet()));
-      RooArgSet iset = _normIntMgr.selectFromSet2(*vars, code - 1);
-      RooArgSet nset = _normIntMgr.selectFromSet1(*vars, code - 1);
-      RooArgSet dummy;
-      Int_t code2 = getAnalyticalIntegralWN(iset, dummy, &nset, rangeName);
-      assert(code == code2); // must have revived the right (sterilized) slot...
-      (void)code2;
-      cache = (CacheElem *)_normIntMgr.getObjByIndex(code - 1);
-      assert(cache != 0);
-   }
-
-   RooFIter funcIntIter = cache->_funcIntList.fwdIterator();
-   RooFIter coefIter = _coefList.fwdIterator();
-   RooFIter funcIter = _funcList.fwdIterator();
-   RooAbsReal *coef(0), *funcInt(0), *func(0);
-   double value(0);
-
-   // N funcs, N-1 coefficients
-   double lastCoef(1);
-   while ((coef = (RooAbsReal *)coefIter.next())) {
-      funcInt = (RooAbsReal *)funcIntIter.next();
-      func = (RooAbsReal *)funcIter.next();
-      double coefVal = coef->getVal(normSet2);
-      if (coefVal) {
-         assert(func);
-         if (normSet2 == 0 || func->isSelectedComp()) {
-            assert(funcInt);
-            value += funcInt->getVal() * coefVal;
-         }
-         lastCoef -= coef->getVal(normSet2);
-      }
-   }
-
-   if (!_haveLastCoef) {
-      // Add last func with correct coefficient
-      funcInt = (RooAbsReal *)funcIntIter.next();
-      if (normSet2 == 0 || func->isSelectedComp()) {
-         assert(funcInt);
-         value += funcInt->getVal() * lastCoef;
-      }
-
-      // Warn about coefficient degeneration
-      if (lastCoef < 0 || lastCoef > 1) {
-         coutW(Eval) << "RooRealSumFunc::evaluate(" << GetName()
-                     << " WARNING: sum of FUNC coefficients not in range [0-1], value=" << 1 - lastCoef << endl;
-      }
-   }
-
-   double normVal(1);
-   if (normSet2 && normSet2->getSize() > 0) {
-      normVal = 0;
-
-      // N funcs, N-1 coefficients
-      RooAbsReal *funcNorm;
-      RooFIter funcNormIter = cache->_funcNormList.fwdIterator();
-      RooFIter coefIter2 = _coefList.fwdIterator();
-      while ((coef = (RooAbsReal *)coefIter2.next())) {
-         funcNorm = (RooAbsReal *)funcNormIter.next();
-         double coefVal = coef->getVal(normSet2);
-         if (coefVal) {
-            assert(funcNorm);
-            normVal += funcNorm->getVal() * coefVal;
-         }
-      }
-
-      // Add last func with correct coefficient
-      if (!_haveLastCoef) {
-         funcNorm = (RooAbsReal *)funcNormIter.next();
-         assert(funcNorm);
-         normVal += funcNorm->getVal() * lastCoef;
-      }
-   }
-
-   return value / normVal;
+   return RooRealSumPdf::analyticalIntegralWN(*this, _normIntMgr, _funcList, _coefList, code, normSet2, rangeName, _haveWarned);
 }
 
 //_____________________________________________________________________________
 std::list<double> *RooRealSumFunc::binBoundaries(RooAbsRealLValue &obs, double xlo, double xhi) const
 {
-   list<double> *sumBinB = 0;
-   bool needClean(false);
-
-   RooFIter iter = _funcList.fwdIterator();
-   RooAbsReal *func;
-   // Loop over components pdf
-   while ((func = (RooAbsReal *)iter.next())) {
-
-      list<double> *funcBinB = func->binBoundaries(obs, xlo, xhi);
-
-      // Process hint
-      if (funcBinB) {
-         if (!sumBinB) {
-            // If this is the first hint, then just save it
-            sumBinB = funcBinB;
-         } else {
-
-            list<double> *newSumBinB = new list<double>(sumBinB->size() + funcBinB->size());
-
-            // Merge hints into temporary array
-            merge(funcBinB->begin(), funcBinB->end(), sumBinB->begin(), sumBinB->end(), newSumBinB->begin());
-
-            // Copy merged array without duplicates to new sumBinBArrau
-            delete sumBinB;
-            delete funcBinB;
-            sumBinB = newSumBinB;
-            needClean = true;
-         }
-      }
-   }
-
-   // Remove consecutive duplicates
-   if (needClean) {
-      list<double>::iterator new_end = unique(sumBinB->begin(), sumBinB->end());
-      sumBinB->erase(new_end, sumBinB->end());
-   }
-
-   return sumBinB;
+   return RooRealSumPdf::binBoundaries(_funcList, obs, xlo, xhi);
 }
 
 //_____________________________________________________________________________B
@@ -401,45 +215,7 @@ bool RooRealSumFunc::isBinnedDistribution(const RooArgSet &obs) const
 //_____________________________________________________________________________
 std::list<double> *RooRealSumFunc::plotSamplingHint(RooAbsRealLValue &obs, double xlo, double xhi) const
 {
-   list<double> *sumHint = 0;
-   bool needClean(false);
-
-   RooFIter iter = _funcList.fwdIterator();
-   RooAbsReal *func;
-   // Loop over components pdf
-   while ((func = (RooAbsReal *)iter.next())) {
-
-      list<double> *funcHint = func->plotSamplingHint(obs, xlo, xhi);
-
-      // Process hint
-      if (funcHint) {
-         if (!sumHint) {
-
-            // If this is the first hint, then just save it
-            sumHint = funcHint;
-
-         } else {
-
-            list<double> *newSumHint = new list<double>(sumHint->size() + funcHint->size());
-
-            // Merge hints into temporary array
-            merge(funcHint->begin(), funcHint->end(), sumHint->begin(), sumHint->end(), newSumHint->begin());
-
-            // Copy merged array without duplicates to new sumHintArrau
-            delete sumHint;
-            sumHint = newSumHint;
-            needClean = true;
-         }
-      }
-   }
-
-   // Remove consecutive duplicates
-   if (needClean) {
-      list<double>::iterator new_end = unique(sumHint->begin(), sumHint->end());
-      sumHint->erase(new_end, sumHint->end());
-   }
-
-   return sumHint;
+   return RooRealSumPdf::plotSamplingHint(_funcList, obs, xlo, xhi);
 }
 
 //_____________________________________________________________________________
@@ -457,41 +233,10 @@ void RooRealSumFunc::setCacheAndTrackHints(RooArgSet &trackNodes)
    }
 }
 
-//_____________________________________________________________________________
-void RooRealSumFunc::printMetaArgs(ostream &os) const
+/// Customized printing of arguments of a RooRealSumFunc to more intuitively
+/// reflect the contents of the product operator construction.
+
+void RooRealSumFunc::printMetaArgs(std::ostream &os) const
 {
-   // Customized printing of arguments of a RooRealSumFuncy to more intuitively reflect the contents of the
-   // product operator construction
-
-   bool first(true);
-
-   if (_coefList.getSize()!=0) {
-       auto funcIter = _funcList.begin();
-
-       for (const auto coef : _coefList) {
-         if (!first) {
-            os << " + ";
-         } else {
-            first = false;
-         }
-         const auto func = *(funcIter++);
-         os << coef->GetName() << " * " << func->GetName();
-       }
-
-       if (funcIter != _funcList.end()) {
-         os << " + [%] * " << (*funcIter)->GetName() ;
-       }
-   } else {
-
-      for (const auto func : _funcList) {
-         if (!first) {
-            os << " + ";
-         } else {
-            first = false;
-         }
-         os << func->GetName();
-      }
-   }
-
-   os << " ";
+   RooRealSumPdf::printMetaArgs(_funcList, _coefList, os);
 }

--- a/roofit/roofitcore/src/RooRealSumFunc.cxx
+++ b/roofit/roofitcore/src/RooRealSumFunc.cxx
@@ -34,18 +34,8 @@
 /// - RooRealSumFunc is a sum of functions. It is neither normalised, nor need it be positive.
 
 #include "RooRealSumFunc.h"
-
-#include "RooRealVar.h"
-#include "RooAddGenContext.h"
-#include "RooRealConstant.h"
-#include "RooRealIntegral.h"
-#include "RooMsgService.h"
-#include "RooNameReg.h"
+#include "RooRealSumPdf.h"
 #include "RooTrace.h"
-
-#include "Riostream.h"
-
-#include <memory>
 
 ClassImp(RooRealSumFunc);
 
@@ -71,8 +61,7 @@ RooRealSumFunc::RooRealSumFunc(const char *name, const char *title)
 //_____________________________________________________________________________
 RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, RooAbsReal &func1, RooAbsReal &func2,
                                RooAbsReal &coef1)
-   : RooAbsReal(name, title), _normIntMgr(this, 10), _haveLastCoef(false),
-     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this)
+   : RooRealSumFunc{name, title}
 {
    // Construct p.d.f consisting of coef1*func1 + (1-coef1)*func2
    // The input coefficients and functions are allowed to be negative
@@ -89,8 +78,7 @@ RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, RooAbsReal &
 //_____________________________________________________________________________
 RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, const RooArgList &inFuncList,
                                const RooArgList &inCoefList)
-   : RooAbsReal(name, title), _normIntMgr(this, 10), _haveLastCoef(false),
-     _funcList("!funcList", "List of functions", this), _coefList("!coefList", "List of coefficients", this)
+   : RooRealSumFunc{name, title}
 {
    // Constructor p.d.f implementing sum_i [ coef_i * func_i ], if N_coef==N_func
    // or sum_i [ coef_i * func_i ] + (1 - sum_i [ coef_i ] )* func_N if Ncoef==N_func-1
@@ -98,51 +86,7 @@ RooRealSumFunc::RooRealSumFunc(const char *name, const char *title, const RooArg
    // All coefficients and functions are allowed to be negative
    // but the sum is not, which is enforced at runtime.
 
-   const std::string ownName(GetName() ? GetName() : "");
-   if (!(inFuncList.getSize() == inCoefList.getSize() + 1 || inFuncList.getSize() == inCoefList.getSize())) {
-      coutE(InputArguments) << "RooRealSumFunc::RooRealSumFunc(" << ownName
-                            << ") number of pdfs and coefficients inconsistent, must have Nfunc=Ncoef or Nfunc=Ncoef+1"
-                            << "\n";
-      assert(0);
-   }
-
-   // Constructor with N functions and N or N-1 coefs
-
-   std::string funcName;
-   for (unsigned int i = 0; i < inCoefList.size(); ++i) {
-      const auto& func = inFuncList[i];
-      const auto& coef = inCoefList[i];
-
-      if (!dynamic_cast<RooAbsReal const*>(&coef)) {
-         const std::string coefName(coef.GetName() ? coef.GetName() : "");
-         coutW(InputArguments) << "RooRealSumFunc::RooRealSumFunc(" << ownName << ") coefficient " << coefName
-                               << " is not of type RooAbsReal, ignored"
-                               << "\n";
-         continue;
-      }
-      if (!dynamic_cast<RooAbsReal const*>(&func)) {
-         funcName = (func.GetName() ? func.GetName() : "");
-         coutW(InputArguments) << "RooRealSumFunc::RooRealSumFunc(" << ownName << ") func " << funcName
-                               << " is not of type RooAbsReal, ignored"
-                               << "\n";
-         continue;
-      }
-      _funcList.add(func);
-      _coefList.add(coef);
-   }
-
-   if (inFuncList.size() == inCoefList.size() + 1) {
-      const auto& func = inFuncList[inFuncList.size()-1];
-      if (!dynamic_cast<RooAbsReal const*>(&func)) {
-         funcName = (func.GetName() ? func.GetName() : "");
-         coutE(InputArguments) << "RooRealSumFunc::RooRealSumFunc(" << ownName << ") last func " << funcName
-                               << " is not of type RooAbsReal, fatal error\n";
-         throw std::invalid_argument("RooRealSumFunc: Function passed as is not of type RooAbsReal.");
-      }
-      _funcList.add(func);
-   } else {
-      _haveLastCoef = true;
-   }
+   RooRealSumPdf::initializeFuncsAndCoefs(*this, inFuncList, inCoefList, _funcList, _coefList);
 
    TRACE_CREATE
 }
@@ -199,17 +143,7 @@ std::list<double> *RooRealSumFunc::binBoundaries(RooAbsRealLValue &obs, double x
 //_____________________________________________________________________________B
 bool RooRealSumFunc::isBinnedDistribution(const RooArgSet &obs) const
 {
-   // If all components that depend on obs are binned that so is the product
-
-   RooFIter iter = _funcList.fwdIterator();
-   RooAbsReal *func;
-   while ((func = (RooAbsReal *)iter.next())) {
-      if (func->dependsOn(obs) && !func->isBinnedDistribution(obs)) {
-         return false;
-      }
-   }
-
-   return true;
+   return RooRealSumPdf::isBinnedDistribution(_funcList, obs);
 }
 
 //_____________________________________________________________________________
@@ -221,16 +155,7 @@ std::list<double> *RooRealSumFunc::plotSamplingHint(RooAbsRealLValue &obs, doubl
 //_____________________________________________________________________________
 void RooRealSumFunc::setCacheAndTrackHints(RooArgSet &trackNodes)
 {
-   // Label OK'ed components of a RooRealSumFunc with cache-and-track
-   RooFIter siter = funcList().fwdIterator();
-   RooAbsArg *sarg;
-   while ((sarg = siter.next())) {
-      if (sarg->canNodeBeCached() == Always) {
-         trackNodes.add(*sarg);
-         // cout << "tracking node RealSumFunc component " << sarg->ClassName() << "::" << sarg->GetName() << endl
-         // ;
-      }
-   }
+   RooRealSumPdf::setCacheAndTrackHints(_funcList, trackNodes);
 }
 
 /// Customized printing of arguments of a RooRealSumFunc to more intuitively


### PR DESCRIPTION
All functions in RooRealSumFunc and RooRealSumPdf are overloaded in
exactly the same way. The two classes only differ in the base class.

To avoid code duplication, the member functions are implemented as private
static functions in RooRealSumPdf, which the friend class RooRealSumFunc
can also use. This pattern might be used also to avoid further code
duplication, also with the other addition classes like RooAddition and
RooAddPdf in the future.

This solution was preferred over changing the classes themselves, because
the right to run into schema evolution problems is much higher then.

This closes also the RooRealSumFunc modernization issue #8374, as now
its implementation uses the code from the RooRealSumPdf which is already
modernized.