### PR TITLE
Remove raw string literals usage in ClangAttrEmitter.cpp

### DIFF
--- a/interpreter/llvm/src/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/interpreter/llvm/src/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -447,13 +447,12 @@ namespace {
     }
 
     void writeValue(raw_ostream &OS) const override {
-      OS << "R\\\"ATTRDUMP(\" << get" << getUpperName()
-         << "() << \")ATTRDUMP\\\"";
+      OS << "\\\"\" << get" << getUpperName() << "() << \"\\\"";
     }
 
     void writeDump(raw_ostream &OS) const override {
-      OS << "    OS << \" R\\\"ATTRDUMP(\" << SA->get" << getUpperName()
-         << "() << \")ATTRDUMP\\\"\";\n";
+      OS << "    OS << \" \\\"\" << SA->get" << getUpperName()
+         << "() << \"\\\"\";\n";
     }
   };
 

--- a/interpreter/llvm/src/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/interpreter/llvm/src/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -447,12 +447,13 @@ namespace {
     }
 
     void writeValue(raw_ostream &OS) const override {
-      OS << "\\\"\" << get" << getUpperName() << "() << \"\\\"";
+      OS << R"(\"" << get)" << getUpperName() << R"(() << "\")";
     }
 
     void writeDump(raw_ostream &OS) const override {
-      OS << "    OS << \" \\\"\" << SA->get" << getUpperName()
-         << "() << \"\\\"\";\n";
+      OS << R"(    OS << " \"" << SA->get)" << getUpperName()
+         << R"(() << "\"";
+)";
     }
   };
 


### PR DESCRIPTION
This revert https://github.com/vgvassilev/clang/commit/d5f1068de9

I have tested it in the cling and it breaks no new tests so I assume it
should be a NFC patch and we should remove it as it makes upstream
test suite failed.
Signed-off-by: Jun Zhang <jun@junz.org>

Let's test it in the ROOT repo.
CC @vgvassilev @Axel-Naumann 

