### PR TITLE
[RF] RooFit::TestStatistics performance fixes

### DIFF
--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooBinnedL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooBinnedL.h
@@ -15,11 +15,15 @@
 
 #include <RooFit/TestStatistics/RooAbsL.h>
 #include "RooAbsReal.h"
+
+#include "Math/Util.h" // KahanSum
+
 #include <vector>
 
 // forward declarations
 class RooAbsPdf;
 class RooAbsData;
+class RooChangeTracker;
 
 namespace RooFit {
 namespace TestStatistics {
@@ -27,6 +31,7 @@ namespace TestStatistics {
 class RooBinnedL : public RooAbsL {
 public:
    RooBinnedL(RooAbsPdf *pdf, RooAbsData *data);
+   ~RooBinnedL();
    ROOT::Math::KahanSum<double>
    evaluatePartition(Section bins, std::size_t components_begin, std::size_t components_end) override;
 
@@ -35,6 +40,8 @@ public:
 private:
    mutable bool _first = true;        ///<!
    mutable std::vector<double> _binw; ///<!
+   std::unique_ptr<RooChangeTracker> paramTracker_;
+   mutable ROOT::Math::KahanSum<double> cachedResult_ = 0;
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooUnbinnedL.h
@@ -15,6 +15,8 @@
 
 #include <RooFit/TestStatistics/RooAbsL.h>
 
+#include "Math/Util.h" // KahanSum
+
 // forward declarations
 class RooAbsPdf;
 class RooAbsData;
@@ -22,6 +24,7 @@ class RooArgSet;
 namespace RooBatchCompute {
 struct RunContext;
 }
+class RooChangeTracker;
 
 namespace RooFit {
 namespace TestStatistics {
@@ -31,6 +34,7 @@ public:
    RooUnbinnedL(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended extended = RooAbsL::Extended::Auto,
                 bool useBatchedEvaluations = false);
    RooUnbinnedL(const RooUnbinnedL &other);
+   ~RooUnbinnedL();
    bool setApplyWeightSquared(bool flag);
 
    ROOT::Math::KahanSum<double>
@@ -44,6 +48,8 @@ private:
    bool apply_weight_squared = false;                              ///< Apply weights squared?
    mutable bool _first = true;                                     ///<!
    bool useBatchedEvaluations_ = false;
+   std::unique_ptr<RooChangeTracker> paramTracker_;
+   mutable ROOT::Math::KahanSum<double> cachedResult_ = 0;
 };
 
 } // namespace TestStatistics

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -31,8 +31,7 @@ In extended mode, a
 #include "RooAbsDataStore.h"
 #include "RooNLLVar.h"  // RooNLLVar::ComputeScalar
 #include "RunContext.h"
-
-#include "Math/Util.h" // KahanSum
+#include "RooChangeTracker.h"
 
 namespace RooFit {
 namespace TestStatistics {
@@ -42,13 +41,18 @@ RooUnbinnedL::RooUnbinnedL(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended e
    : RooAbsL(RooAbsL::ClonePdfData{pdf, data}, data->numEntries(), 1, extended),
      useBatchedEvaluations_(useBatchedEvaluations)
 {
+   std::unique_ptr<RooArgSet> params(pdf->getParameters(data));
+   paramTracker_ = std::make_unique<RooChangeTracker>("chtracker","change tracker",*params,true);
 }
 
 RooUnbinnedL::RooUnbinnedL(const RooUnbinnedL &other)
    : RooAbsL(other), apply_weight_squared(other.apply_weight_squared), _first(other._first),
      useBatchedEvaluations_(other.useBatchedEvaluations_)
 {
+   paramTracker_ = std::make_unique<RooChangeTracker>(*other.paramTracker_);
 }
+
+RooUnbinnedL::~RooUnbinnedL() = default;
 
 //////////////////////////////////////////////////////////////////////////////////
 
@@ -82,6 +86,9 @@ RooUnbinnedL::evaluatePartition(Section events, std::size_t /*components_begin*/
    // expensive than that, we tolerate the additional cost...
    ROOT::Math::KahanSum<double> result;
    double sumWeight;
+
+   // Do not reevaluate likelihood if parameters have not changed
+   if (!paramTracker_->hasChanged(true) & (cachedResult_ != 0)) return cachedResult_;
 
    data_->store()->recalculateCache(nullptr, events.begin(N_events_), events.end(N_events_), 1, true);
 
@@ -161,6 +168,7 @@ RooUnbinnedL::evaluatePartition(Section events, std::size_t /*components_begin*/
       pdf_->wireAllCaches();
    }
 
+   cachedResult_ = result;
    return result;
 }
 

--- a/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
+++ b/roofit/roofitcore/src/TestStatistics/buildLikelihood.cxx
@@ -230,7 +230,7 @@ getSimultaneousComponents(RooAbsPdf *pdf, RooAbsData *data, RooAbsL::Extended ex
    TString simCatName(simCat.GetName());
    // Note: important not to use cloned dataset here (possible when this code is run in Roo[...]L ctor), use the
    // original one (which is data_ in Roo[...]L ctors, but data here)
-   std::unique_ptr<TList> dsetList{data->split(simCat, process_empty_data_sets)};
+   std::unique_ptr<TList> dsetList{data->split(*sim_pdf, process_empty_data_sets)};
    if (!dsetList) {
       throw std::logic_error(
          "getSimultaneousComponents ERROR, index category of simultaneous pdf is missing in dataset, aborting");


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
We found and fixed two bugs in the RooFit TestStatistics likelihoods that negatively affected performance:

1. TestStatistics likelihoods were being recalculated every time. They now have caching enabled, so they are only recalculated when parameters change.
2. While cloning the dataset inside the likelihood builder for simultaneous components, all parameters were cloned. Now we only clone the parameters relevant to the specific pdf component.

With these fixes, single-worker performance of MultiProcess enabled fits is now on par with old style RooFit fits, at least with batch mode disabled.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)