### PR TITLE
Fix compilation error of ntuple_types on Windows

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -365,10 +365,7 @@ public:
    /// Construct a RRecordField based on a vector of child fields. The ownership of the child fields is transferred
    /// to the RRecordField instance.
    RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<Detail::RFieldBase>> &&itemFields);
-   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<Detail::RFieldBase>> &itemFields)
-      : RRecordField(fieldName, std::move(itemFields))
-   {
-   }
+   RRecordField(std::string_view fieldName, std::vector<std::unique_ptr<Detail::RFieldBase>> &itemFields);
    RRecordField(RRecordField&& other) = default;
    RRecordField& operator =(RRecordField&& other) = default;
    ~RRecordField() = default;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -945,6 +945,12 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
    fSize += GetItemPadding(fSize, fMaxAlignment);
 }
 
+ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
+                                               std::vector<std::unique_ptr<Detail::RFieldBase>> &itemFields)
+   : ROOT::Experimental::RRecordField(fieldName, std::move(itemFields))
+{
+}
+
 std::size_t ROOT::Experimental::RRecordField::GetItemPadding(std::size_t baseOffset, std::size_t itemAlignment) const
 {
    if (itemAlignment > 1) {


### PR DESCRIPTION
Fix the following compilation error of `ntuple_types` on Windows:
```
ntuple_types.obj : error LNK2019: unresolved external symbol "const ROOT::Experimental::RRecordField::`vftable'" (??_7RRecordField@Experimental@ROOT@@6B@) referenced in function "private: virtual void __thiscall RNTuple_CreateField_Test::TestBody(void)" (?TestBody@RNTuple_CreateField_Test@@EAEXXZ) [C:\Users\bellenot\build\release\tree\ntuple\v7\test\ntuple_types.vcxproj]
C:\Users\bellenot\build\release\tree\ntuple\v7\test\Release\ntuple_types.exe : fatal error LNK1120: 1 unresolved externals [C:\Users\bellenot\build\release\tree\ntuple\v7\test\ntuple_types.vcxproj]
```
