### PR TITLE
Fix several memory leaks and problems in graf2d/graf classes

### DIFF
--- a/graf2d/graf/inc/TGaxis.h
+++ b/graf2d/graf/inc/TGaxis.h
@@ -54,6 +54,9 @@ protected:
    TGaxis(const TGaxis&);
    TGaxis& operator=(const TGaxis&);
 
+   Bool_t IsOwnedModLabs() const;
+   void CleanupModLabs();
+
 public:
 
    TGaxis();

--- a/graf2d/graf/inc/TLatex.h
+++ b/graf2d/graf/inc/TLatex.h
@@ -13,7 +13,7 @@
 
 #include "TText.h"
 #include "TAttLine.h"
-
+#include <vector>
 
 class TLatex : public TText, public TAttLine {
 protected:
@@ -27,12 +27,6 @@ protected:
    };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief TLatex helper struct holding the dimensions of a piece of text.
-   struct FormSize_t {
-      Double_t fWidth, fOver, fUnder;
-   };
-
-////////////////////////////////////////////////////////////////////////////////
 /// @class TLatexFormSize
 /// @brief TLatex helper class used to compute the size of a portion of a formula.
 
@@ -42,7 +36,7 @@ protected:
 
    public:
       TLatexFormSize() = default;
-      TLatexFormSize(Double_t x, Double_t y1, Double_t y2) : fWidth(x), fOver(y1), fUnder(y2) { } // constructor
+      TLatexFormSize(Double_t width, Double_t over, Double_t under) : fWidth(width), fOver(over), fUnder(under) { } // constructor
 
       // definition of operators + and +=
       TLatexFormSize operator+(TLatexFormSize f)
@@ -65,64 +59,62 @@ protected:
       inline Double_t Height() const { return fOver+fUnder; }
    };
 
-      Double_t      fFactorSize;      ///<! Relative size of subscripts and superscripts
-      Double_t      fFactorPos;       ///<! Relative position of subscripts and superscripts
-      Int_t         fLimitFactorSize; ///< lower bound for subscripts/superscripts size
-      const Char_t *fError;           ///<! error code
-      Bool_t        fShow;            ///<! is true during the second pass (Painting)
-      FormSize_t   *fTabSize;         ///<! array of values for the different zones
-      Double_t      fOriginSize;      ///< Font size of the starting font
-      Int_t         fTabMax;          ///<! Maximum allocation for array fTabSize;
-      Int_t         fPos;             ///<! Current position in array fTabSize;
-      Bool_t        fItalic;          ///<! Currently inside italic operator
+   Double_t                    fFactorSize;      ///<! Relative size of subscripts and superscripts
+   Double_t                    fFactorPos;       ///<! Relative position of subscripts and superscripts
+   Int_t                       fLimitFactorSize; ///< lower bound for subscripts/superscripts size
+   const Char_t               *fError;           ///<! error code
+   Bool_t                      fShow;            ///<! is true during the second pass (Painting)
+   std::vector<TLatexFormSize> fTabSize;         ///<! array of values for the different zones
+   Double_t                    fOriginSize;      ///< Font size of the starting font
+   Bool_t                      fItalic;          ///<! Currently inside italic operator
 
-      TLatex& operator=(const TLatex&);
+   TLatex& operator=(const TLatex&);
 
-      //Text analysis and painting
-      TLatexFormSize Analyse(Double_t x, Double_t y, TextSpec_t spec, const Char_t* t,Int_t length);
-      TLatexFormSize Anal1(TextSpec_t spec, const Char_t* t,Int_t length);
+   //Text analysis and painting
+   TLatexFormSize Analyse(Double_t x, Double_t y, TextSpec_t spec, const Char_t* t,Int_t length);
+   TLatexFormSize Anal1(TextSpec_t spec, const Char_t* t,Int_t length);
 
-      void DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2, TextSpec_t spec);
-      void DrawCircle(Double_t x1, Double_t y1, Double_t r, TextSpec_t spec);
-      void DrawParenthesis(Double_t x1, Double_t y1, Double_t r1, Double_t r2, Double_t phimin, Double_t phimax, TextSpec_t spec);
+   void DrawLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2, TextSpec_t spec);
+   void DrawCircle(Double_t x1, Double_t y1, Double_t r, TextSpec_t spec);
+   void DrawParenthesis(Double_t x1, Double_t y1, Double_t r1, Double_t r2, Double_t phimin, Double_t phimax, TextSpec_t spec);
 
-      TLatexFormSize FirstParse(Double_t angle, Double_t size, const Char_t *text);
+   TLatexFormSize FirstParse(Double_t angle, Double_t size, const Char_t *text);
 
-      Int_t PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
+   Int_t PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
 
-      void Savefs(TLatexFormSize *fs);
-      TLatexFormSize Readfs();
+   void Savefs(TLatexFormSize *fs);
+   TLatexFormSize Readfs();
 
-      Int_t CheckLatexSyntax(TString &text) ;
+   Int_t CheckLatexSyntax(TString &text) ;
 
 public:
-      // TLatex status bits
-      enum {
-         kTextNDC = BIT(14) ///< The text postion is in NDC coordinates
-      };
+   // TLatex status bits
+   enum {
+      kTextNDC = BIT(14) ///< The text position is in NDC coordinates
+   };
 
-      TLatex();
-      TLatex(Double_t x, Double_t y, const char *text);
-      TLatex(const TLatex &text);
-      virtual ~TLatex();
+   TLatex();
+   TLatex(Double_t x, Double_t y, const char *text);
+   TLatex(const TLatex &text);
+   virtual ~TLatex();
 
-      void             Copy(TObject &text) const override;
+   void             Copy(TObject &text) const override;
 
-      TLatex          *DrawLatex(Double_t x, Double_t y, const char *text);
-      TLatex          *DrawLatexNDC(Double_t x, Double_t y, const char *text);
+   TLatex          *DrawLatex(Double_t x, Double_t y, const char *text);
+   TLatex          *DrawLatexNDC(Double_t x, Double_t y, const char *text);
 
-      Double_t         GetHeight() const;
-      Double_t         GetXsize();
-      Double_t         GetYsize();
-      void             GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE) override;
-      void             Paint(Option_t *option="") override;
-      virtual void     PaintLatex(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
+   Double_t         GetHeight() const;
+   Double_t         GetXsize();
+   Double_t         GetYsize();
+   void             GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE) override;
+   void             Paint(Option_t *option="") override;
+   virtual void     PaintLatex(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
 
-      void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
-      virtual void     SetIndiceSize(Double_t factorSize);
-      virtual void     SetLimitIndiceSize(Int_t limitFactorSize);
+   void             SavePrimitive(std::ostream &out, Option_t *option = "") override;
+   virtual void     SetIndiceSize(Double_t factorSize);
+   virtual void     SetLimitIndiceSize(Int_t limitFactorSize);
 
-      ClassDefOverride(TLatex,2)  //The Latex-style text processor class
+   ClassDefOverride(TLatex,2)  //The Latex-style text processor class
 };
 
 #endif

--- a/graf2d/graf/inc/TPieSlice.h
+++ b/graf2d/graf/inc/TPieSlice.h
@@ -30,13 +30,15 @@ public:
    TPieSlice(const char *, const char *, TPie*, Double_t val=0);
    virtual ~TPieSlice() {}
 
+   void           Copy(TObject &slice) const override;
    Int_t          DistancetoPrimitive(Int_t,Int_t) override;
-   Double_t       GetRadiusOffset();
-   Double_t       GetValue();
+   Double_t       GetRadiusOffset() const;
+   Double_t       GetValue() const;
    void           SavePrimitive(std::ostream &out, Option_t *opts="") override;
    void           SetIsActive(Bool_t is) { fIsActive = is; }
    void           SetRadiusOffset(Double_t);  // *MENU*
    void           SetValue(Double_t);         // *MENU*
+
 
    friend class TPie;
 

--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -392,7 +392,7 @@ void TCandle::Calculate() {
    Double_t max = -1e15;
 
    // Determining the quantiles
-   Double_t *prob = new Double_t[5];
+   Double_t prob[5];
 
    if (fWhiskerRange >= 1) {
       prob[0] = 1e-15;
@@ -402,7 +402,6 @@ void TCandle::Calculate() {
       prob[4] = 0.5 + fWhiskerRange/2.;
    }
 
-
    if (fBoxRange >= 1) {
       prob[1] = 1E-14;
       prob[3] = 1-1E-14;
@@ -411,9 +410,9 @@ void TCandle::Calculate() {
       prob[3] = 0.5 + fBoxRange/2.;
    }
 
-   prob[2]=0.5;
-   Double_t *quantiles = new Double_t[5];
-   quantiles[0]=0.; quantiles[1]=0.; quantiles[2] = 0.; quantiles[3] = 0.; quantiles[4] = 0.;
+   prob[2] = 0.5;
+
+   Double_t quantiles[5] = { 0., 0., 0., 0., 0. };
    if (!fIsRaw && fProj) { //Need a calculation for a projected histo
       if (((IsOption(kHistoLeft)) || (IsOption(kHistoRight)) || (IsOption(kHistoViolin))) && fProj->GetNbinsX() > 500) {
          // When using the histooption the number of bins of the projection is
@@ -432,8 +431,6 @@ void TCandle::Calculate() {
    // into account as well, we need to ignore this!
    if (quantiles[0] >= quantiles[4] ||
        quantiles[1] >= quantiles[3]) {
-      delete [] prob;
-      delete [] quantiles;
       return;
    }
 
@@ -486,9 +483,6 @@ void TCandle::Calculate() {
       fMean /= fNDatapoints;
       fMedianErr = 1.57*iqr/sqrt(fNDatapoints);
    }
-
-   delete [] prob;
-   delete [] quantiles;
 
    //Doing the outliers and other single points to show
    if (GetCandleOption(5) > 0) { //Draw outliers
@@ -659,7 +653,6 @@ void TCandle::Calculate() {
          fNHistoPoints *= 2;
       }
    }
-
 
    fIsCalculated = true;
 }

--- a/graf2d/graf/src/TCutG.cxx
+++ b/graf2d/graf/src/TCutG.cxx
@@ -98,8 +98,8 @@ ClassImp(TCutG);
 
 TCutG::TCutG() : TGraph()
 {
-   fObjectX  = 0;
-   fObjectY  = 0;
+   fObjectX  = nullptr;
+   fObjectY  = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -120,8 +120,8 @@ TCutG::TCutG(const TCutG &cutg)
 TCutG::TCutG(const char *name, Int_t n)
       :TGraph(n)
 {
-   fObjectX  = 0;
-   fObjectY  = 0;
+   fObjectX  = nullptr;
+   fObjectY  = nullptr;
    SetName(name);
    delete gROOT->GetListOfSpecials()->FindObject(name);
    gROOT->GetListOfSpecials()->Add(this);
@@ -161,8 +161,8 @@ TCutG::TCutG(const char *name, Int_t n)
 TCutG::TCutG(const char *name, Int_t n, const Float_t *x, const Float_t *y)
       :TGraph(n,x,y)
 {
-   fObjectX  = 0;
-   fObjectY  = 0;
+   fObjectX  = nullptr;
+   fObjectY  = nullptr;
    SetName(name);
    delete gROOT->GetListOfSpecials()->FindObject(name);
    gROOT->GetListOfSpecials()->Add(this);
@@ -202,8 +202,8 @@ TCutG::TCutG(const char *name, Int_t n, const Float_t *x, const Float_t *y)
 TCutG::TCutG(const char *name, Int_t n, const Double_t *x, const Double_t *y)
       :TGraph(n,x,y)
 {
-   fObjectX  = 0;
-   fObjectY  = 0;
+   fObjectX  = nullptr;
+   fObjectY  = nullptr;
    SetName(name);
    delete gROOT->GetListOfSpecials()->FindObject(name);
    gROOT->GetListOfSpecials()->Add(this);
@@ -403,7 +403,7 @@ void TCutG::SetVarX(const char *varx)
 {
    fVarX = varx;
    delete fObjectX;
-   fObjectX = 0;
+   fObjectX = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -413,7 +413,7 @@ void TCutG::SetVarY(const char *vary)
 {
    fVarY = vary;
    delete fObjectY;
-   fObjectY = 0;
+   fObjectY = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TGaxis.cxx
+++ b/graf2d/graf/src/TGaxis.cxx
@@ -712,11 +712,11 @@ TGaxis::TGaxis(): TLine(), TAttText(11,0,1,62,0.040)
    fTitle       = "";
    fTimeFormat  = "";
    fFunctionName= "";
-   fFunction    = 0;
-   fAxis        = 0;
+   fFunction    = nullptr;
+   fAxis        = nullptr;
    fNdiv        = 0;
    fNModLabs    = 0;
-   fModLabs     = 0;
+   fModLabs     = nullptr;
    fWmin        = 0.;
    fWmax        = 0.;
 }
@@ -734,7 +734,7 @@ TGaxis::TGaxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax,
    fWmax        = wmax;
    fNdiv        = ndiv;
    fNModLabs    = 0;
-   fModLabs     = 0;
+   fModLabs     = nullptr;
    fGridLength  = gridlength;
    fLabelOffset = 0.005;
    fLabelSize   = 0.040;
@@ -748,8 +748,8 @@ TGaxis::TGaxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax,
    fTitle       = "";
    fTimeFormat  = "";
    fFunctionName= "";
-   fFunction    = 0;
-   fAxis        = 0;
+   fFunction    = nullptr;
+   fAxis        = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -773,7 +773,7 @@ TGaxis::TGaxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax,
    fFunctionName= funcname;
    fNdiv        = ndiv;
    fNModLabs    = 0;
-   fModLabs     = 0;
+   fModLabs     = nullptr;
    fGridLength  = gridlength;
    fLabelOffset = 0.005;
    fLabelSize   = 0.040;
@@ -786,7 +786,7 @@ TGaxis::TGaxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t ymax,
    fName        = "";
    fTitle       = "";
    fTimeFormat  = "";
-   fAxis        = 0;
+   fAxis        = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1037,7 +1037,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
    char chlabel[256];
    char kchtemp[256];
    char chcoded[64];
-   TLine *linegrid;
+   TLine linegrid;
    TString timeformat;
    TString typolabel;
    time_t timelabel;
@@ -1052,7 +1052,6 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
    Double_t rwma = wmax;
    chtemp = &kchtemp[0];
    label  = &chlabel[0];
-   linegrid  = 0;
 
    fFunction = (TF1*)gROOT->GetFunction(fFunctionName.Data());
 
@@ -1111,7 +1110,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
          fModLabs = ml;
          fNModLabs = fModLabs->GetSize();
       } else {
-         fModLabs  = 0;
+         fModLabs  = nullptr;
          fNModLabs = 0;
       }
    }
@@ -1124,11 +1123,10 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
 
    if (optionGrid) {
       if (gridlength == 0) gridlength = 0.8;
-      linegrid = new TLine();
-      linegrid->SetLineColor(gStyle->GetGridColor());
-      if (linegrid->GetLineColor() == 0) linegrid->SetLineColor(GetLineColor());
-      linegrid->SetLineStyle(gStyle->GetGridStyle());
-      linegrid->SetLineWidth(gStyle->GetGridWidth());
+      linegrid.SetLineColor(gStyle->GetGridColor());
+      if (linegrid.GetLineColor() == 0) linegrid.SetLineColor(GetLineColor());
+      linegrid.SetLineStyle(gStyle->GetGridStyle());
+      linegrid.SetLineWidth(gStyle->GetGridWidth());
    }
 
 // No labels if the axis label offset is big.
@@ -1334,7 +1332,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
       return;
    }
 
-   TLatex *textaxis = new TLatex();
+   TLatex textaxis;
    SetLineStyle(1); // axis line style
    Int_t TitleColor = GetTextColor();
    Int_t TitleFont  = GetTextFont();
@@ -1348,7 +1346,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
    axis_length = TMath::Sqrt((x1-x0)*(x1-x0)+(y1-y0)*(y1-y0));
    if (axis_length == 0) {
       Error(where, "length of axis is 0");
-      goto L210;
+      return;
    }
    if (!optionNoopt || optionInt) {
       axis_lengthN = TMath::Sqrt((xx1-xx0)*(xx1-xx0)+(yy1-yy0)*(yy1-yy0));
@@ -1443,10 +1441,10 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
 
 // No bining
 
-   if (ndiv == 0)goto L210;
+   if (ndiv == 0) return;
    if (wmin == wmax) {
       Error(where, "wmin (%f) == wmax (%f)", wmin, wmax);
-      goto L210;
+      return;
    }
 
 // Labels preparation:
@@ -1456,24 +1454,24 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
 
    charheight = GetLabelSize();
    if (optionText && GetLabelFont()%10 != 3) charheight *= 0.66666;
-   textaxis->SetTextFont(GetLabelFont());
+   textaxis.SetTextFont(GetLabelFont());
    if ((GetLabelFont()%10 < 2) && optionLog) // force TLatex mode in PaintLatex
-      textaxis->SetTextFont((Int_t)(GetLabelFont()/10)*10+2);
-   textaxis->SetTextColor(GetLabelColor());
-   textaxis->SetTextSize (charheight);
-   textaxis->SetTextAngle(GetTextAngle());
+      textaxis.SetTextFont((Int_t)(GetLabelFont()/10)*10+2);
+   textaxis.SetTextColor(GetLabelColor());
+   textaxis.SetTextSize (charheight);
+   textaxis.SetTextAngle(GetTextAngle());
    if (GetLabelFont()%10 > 2) {
       charheight /= padh;
    }
    if (!optionUp && !optionDown && !optionY && !optionUnlab) {
       if (!drawGridOnly && optionText && ((ymin == ymax) || (xmin == xmax))) {
-         textaxis->SetTextAlign(32);
+         textaxis.SetTextAlign(32);
          optionText = 2;
          Int_t nl = fAxis->GetLast()-fAxis->GetFirst()+1;
          Double_t angle     = 0;
          for (i=fAxis->GetFirst(); i<=fAxis->GetLast(); i++) {
-            textaxis->SetText(0,0,fAxis->GetBinLabel(i));
-            if (textaxis->GetXsize() < (xmax-xmin)/nl) continue;
+            textaxis.SetText(0,0,fAxis->GetBinLabel(i));
+            if (textaxis.GetXsize() < (xmax-xmin)/nl) continue;
             angle = -20;
             break;
          }
@@ -1485,53 +1483,53 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
                if (fAxis->TestBit(TAxis::kLabelsVert)) angle = 90;
                if (fAxis->TestBit(TAxis::kLabelsUp))   angle = 20;
                if (fAxis->TestBit(TAxis::kLabelsDown)) angle =-20;
-               if (angle ==   0) textaxis->SetTextAlign(23);
-               if (angle == -20) textaxis->SetTextAlign(12);
-               textaxis->SetTextAngle(angle);
+               if (angle ==   0) textaxis.SetTextAlign(23);
+               if (angle == -20) textaxis.SetTextAlign(12);
+               textaxis.SetTextAngle(angle);
                Double_t s = -3;
                if (ymin == gPad->GetUymax()) {
-                  if (angle == 0) textaxis->SetTextAlign(21);
+                  if (angle == 0) textaxis.SetTextAlign(21);
                   s = 3;
                }
                strncpy(chtemp, fAxis->GetBinLabel(i), 255);
-               if (fNModLabs) ChangeLabelAttributes(i, fAxis->GetLabels()->GetSize()-1, textaxis, chtemp);
-               textaxis->PaintLatex(fAxis->GetBinCenter(i),
-                                    ymin + s*fAxis->GetLabelOffset()*(gPad->GetUymax()-gPad->GetUymin()),
-                                    textaxis->GetTextAngle(),
-                                    textaxis->GetTextSize(),
-                                    chtemp);
-               if (fNModLabs) ResetLabelAttributes(textaxis);
+               if (fNModLabs) ChangeLabelAttributes(i, fAxis->GetLabels()->GetSize()-1, &textaxis, chtemp);
+               textaxis.PaintLatex(fAxis->GetBinCenter(i),
+                                   ymin + s*fAxis->GetLabelOffset()*(gPad->GetUymax()-gPad->GetUymin()),
+                                   textaxis.GetTextAngle(),
+                                   textaxis.GetTextSize(),
+                                   chtemp);
+               if (fNModLabs) ResetLabelAttributes(&textaxis);
             } else if ((!strcmp(fAxis->GetName(),"yaxis") && !gPad->TestBit(kHori))
                     || (!strcmp(fAxis->GetName(),"xaxis") &&  gPad->TestBit(kHori))) {
                Double_t s = -3;
                if (xmin == gPad->GetUxmax()) {
-                  textaxis->SetTextAlign(12);
+                  textaxis.SetTextAlign(12);
                   s = 3;
                }
                if (autotoff) {
                   UInt_t w,h;
-                  textaxis->SetText(0.,0., fAxis->GetBinLabel(i));
-                  textaxis->GetBoundingBox(w,h);
+                  textaxis.SetText(0.,0., fAxis->GetBinLabel(i));
+                  textaxis.GetBoundingBox(w,h);
                   double scale=gPad->GetWw()*gPad->GetWNDC();
                   if (scale>0.0) toffset = TMath::Max(toffset,(double)w/scale);
                }
                strncpy(chtemp, fAxis->GetBinLabel(i), 255);
-               if (fNModLabs) ChangeLabelAttributes(i, fAxis->GetLabels()->GetSize()-1, textaxis, chtemp);
-               textaxis->PaintLatex(xmin + s*fAxis->GetLabelOffset()*(gPad->GetUxmax()-gPad->GetUxmin()),
-                                    fAxis->GetBinCenter(i),
-                                    0,
-                                    textaxis->GetTextSize(),
-                                    chtemp);
-               if (fNModLabs) ResetLabelAttributes(textaxis);
+               if (fNModLabs) ChangeLabelAttributes(i, fAxis->GetLabels()->GetSize()-1, &textaxis, chtemp);
+               textaxis.PaintLatex(xmin + s*fAxis->GetLabelOffset()*(gPad->GetUxmax()-gPad->GetUxmin()),
+                                   fAxis->GetBinCenter(i),
+                                   0,
+                                   textaxis.GetTextSize(),
+                                   chtemp);
+               if (fNModLabs) ResetLabelAttributes(&textaxis);
             } else {
                strncpy(chtemp, fAxis->GetBinLabel(i), 255);
-               if (fNModLabs) ChangeLabelAttributes(i, fAxis->GetLabels()->GetSize()-1, textaxis, chtemp);
-               textaxis->PaintLatex(xmin - 3*fAxis->GetLabelOffset()*(gPad->GetUxmax()-gPad->GetUxmin()),
-                                    ymin +(i-0.5)*(ymax-ymin)/nl,
-                                    0,
-                                    textaxis->GetTextSize(),
-                                    chtemp);
-               if (fNModLabs) ResetLabelAttributes(textaxis);
+               if (fNModLabs) ChangeLabelAttributes(i, fAxis->GetLabels()->GetSize()-1, &textaxis, chtemp);
+               textaxis.PaintLatex(xmin - 3*fAxis->GetLabelOffset()*(gPad->GetUxmax()-gPad->GetUxmin()),
+                                   ymin +(i-0.5)*(ymax-ymin)/nl,
+                                   0,
+                                   textaxis.GetTextSize(),
+                                   chtemp);
+               if (fNModLabs) ResetLabelAttributes(&textaxis);
             }
          }
       }
@@ -1561,7 +1559,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
       if (cosphi*sinphi > 0)  xalign = 1;
       if (cosphi*sinphi < 0)  xalign = 3;
    }
-   textaxis->SetTextAlign(10*xalign+yalign);
+   textaxis.SetTextAlign(10*xalign+yalign);
 
 // Position of labels in Y
    if (x0 == x1) {
@@ -1650,7 +1648,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
                      Rotate(xtick,0,cosphi ,sinphi,xx0,yy0 ,xpl2,ypl2);
                      Rotate(xtick,grid_side*gridlength ,cosphi,sinphi,xx0,yy0 ,xpl1,ypl1);
                   }
-                  linegrid->PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
+                  linegrid.PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
                }
             }
          }
@@ -1694,7 +1692,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
                   if (ltick == 0) {
                      Rotate(xtick0,0,cosphi,sinphi,xx0,yy0,xpl2,ypl2);
                      Rotate(xtick0,grid_side*gridlength ,cosphi,sinphi,xx0,yy0 ,xpl1,ypl1);
-                     linegrid->PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
+                     linegrid.PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
                   }
                }
                xtick0 -= dxtick;
@@ -1737,7 +1735,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
                   if (ltick == 0) {
                      Rotate(xtick1,0,cosphi,sinphi,xx0,yy0 ,xpl2,ypl2);
                      Rotate(xtick1,grid_side*gridlength,cosphi,sinphi,xx0,yy0,xpl1,ypl1);
-                     linegrid->PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
+                     linegrid.PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
                   }
                }
                xtick1 += dxtick;
@@ -1753,7 +1751,7 @@ void TGaxis::PaintAxis(Double_t xmin, Double_t ymin, Double_t xmax, Double_t yma
 // Spacing of labels
             if ((wmin == wmax) || (ndiv == 0)) {
                Error(where, "wmin (%f) == wmax (%f), or ndiv == 0", wmin, wmax);
-               goto L210;
+               return;
             }
             wlabel  = wmin;
             dwlabel = (wmax-wmin)/Double_t(n1a);
@@ -2001,31 +1999,31 @@ L110:
                   if (!optionText) {
                      if (first > last)  strncpy(chtemp, " ", 256);
                      else               strncpy(chtemp, &label[first], 255);
-                     if (fNModLabs) ChangeLabelAttributes(k+1, nlabels, textaxis, chtemp);
+                     if (fNModLabs) ChangeLabelAttributes(k+1, nlabels, &textaxis, chtemp);
                      typolabel = chtemp;
                      if (!optionTime) typolabel.ReplaceAll("-", "#minus");
                      if (autotoff) {
                         UInt_t w,h;
-                        textaxis->SetText(0.,0., typolabel.Data());
-                        textaxis->GetBoundingBox(w,h);
+                        textaxis.SetText(0.,0., typolabel.Data());
+                        textaxis.GetBoundingBox(w,h);
                         double scale=gPad->GetWw()*gPad->GetWNDC();
                         if (scale>0.0) toffset = TMath::Max(toffset,(double)w/scale);
                      }
-                     textaxis->PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
+                     textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
                            gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1()),
-                           textaxis->GetTextAngle(),
-                           textaxis->GetTextSize(),
+                           textaxis.GetTextAngle(),
+                           textaxis.GetTextSize(),
                            typolabel.Data());
-                     if (fNModLabs) ResetLabelAttributes(textaxis);
+                     if (fNModLabs) ResetLabelAttributes(&textaxis);
                   } else  {
                      strncpy(chtemp, fAxis->GetBinLabel(k+fAxis->GetFirst()), 255);
-                     if (fNModLabs) ChangeLabelAttributes(k+fAxis->GetFirst(), fAxis->GetLabels()->GetSize()-1, textaxis, chtemp);
-                     if (optionText == 1) textaxis->PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
+                     if (fNModLabs) ChangeLabelAttributes(k+fAxis->GetFirst(), fAxis->GetLabels()->GetSize()-1, &textaxis, chtemp);
+                     if (optionText == 1) textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
                                                    gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1()),
                                                    0,
-                                                   textaxis->GetTextSize(),
+                                                   textaxis.GetTextSize(),
                                                    chtemp);
-                     if (fNModLabs) ResetLabelAttributes(textaxis);
+                     if (fNModLabs) ResetLabelAttributes(&textaxis);
                   }
                } else {
 
@@ -2042,10 +2040,10 @@ L110:
                      }
                      typolabel = chtemp;
                      typolabel.ReplaceAll("-", "#minus");
-                     textaxis->PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
+                     textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
                            gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1()),
                            0,
-                           textaxis->GetTextSize(),
+                           textaxis.GetTextSize(),
                            typolabel.Data());
                      yy -= charheight*1.3;
                   }
@@ -2059,9 +2057,9 @@ L110:
                if (x0 != x1) { xfactor = axis_length+0.1*charheight; yfactor = 0; }
                else          { xfactor = y1-y0+0.1*charheight; yfactor = 0; }
                Rotate (xfactor,yfactor,cosphi,sinphi,x0,y0,xx,yy);
-               textaxis->SetTextAlign(11);
+               textaxis.SetTextAlign(11);
                if (GetLabelFont()%10 < 2) // force TLatex mode in PaintLatex
-                  textaxis->SetTextFont((Int_t)(GetLabelFont()/10)*10+2);
+                  textaxis.SetTextFont((Int_t)(GetLabelFont()/10)*10+2);
                if (fAxis && !strcmp(fAxis->GetName(),"xaxis")) {
                   xx = xx + fXAxisExpXOffset;
                   yy = yy + fXAxisExpYOffset;
@@ -2072,10 +2070,10 @@ L110:
                }
                typolabel = label;
                typolabel.ReplaceAll("-", "#minus");
-               textaxis->PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
+               textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
                            gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1()),
                            0,
-                           textaxis->GetTextSize(),
+                           textaxis.GetTextSize(),
                            typolabel.Data());
             }
          }
@@ -2089,15 +2087,15 @@ L110:
       Bool_t firstintlab = kTRUE, overlap = kFALSE;
       if ((wmin == wmax) || (ndiv == 0))  {
          Error(where, "wmin (%f) == wmax (%f), or ndiv == 0", wmin, wmax);
-         goto L210;
+         return;
       }
       if (wmin <= 0)   {
          Error(where, "negative logarithmic axis");
-         goto L210;
+         return;
       }
       if (wmax <= 0)     {
          Error(where, "negative logarithmic axis");
-         goto L210;
+         return;
       }
       xmnlog = TMath::Log10(wmin);
       if (xmnlog > 0) xmnlog += 1.E-6;
@@ -2156,7 +2154,7 @@ L110:
          if (optionGrid) {
             Rotate(xone,0,cosphi,sinphi,x0,y0,xpl2,ypl2);
             Rotate(xone,grid_side*gridlength,cosphi,sinphi,x0,y0,xpl1,ypl1);
-            linegrid->PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
+            linegrid.PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
          }
 
          if (!drawGridOnly && !optionUnlab)  {
@@ -2192,7 +2190,7 @@ L110:
             if ((y0 == y1) && !optionDown && !optionUp) {
                if (noExponent) yy += 0.33*charheight;
             }
-            if (n1a == 0)goto L210;
+            if (n1a == 0) return;
             kmod = nbinin/n1a;
             if (kmod == 0) kmod=1000000;
             if ((nbinin <= n1a) || (j == 1) || (j == nbinin) || ((nbinin > n1a) && (j%kmod == 0))) {
@@ -2210,21 +2208,21 @@ L110:
                if (fNModLabs) {
                   if (changelablogid  == 0) changelablognum = nbinin-j;
                   changelablogid++;
-                  ChangeLabelAttributes(changelablogid, changelablognum, textaxis, chtemp);
+                  ChangeLabelAttributes(changelablogid, changelablognum, &textaxis, chtemp);
                }
                typolabel = chtemp;
                typolabel.ReplaceAll("-", "#minus");
                if (autotoff) {
                   UInt_t w,h;
-                  textaxis->SetText(0.,0., typolabel.Data());
-                  textaxis->GetBoundingBox(w,h);
+                  textaxis.SetText(0.,0., typolabel.Data());
+                  textaxis.GetBoundingBox(w,h);
                   double scale=gPad->GetWw()*gPad->GetWNDC();
                   if (scale>0.0) toffset = TMath::Max(toffset,(double)w/scale);
                }
-               textaxis->PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
-                                    gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1()),
-                                    0, textaxis->GetTextSize(), typolabel.Data());
-               if (fNModLabs) ResetLabelAttributes(textaxis);
+               textaxis.PaintLatex(gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1()),
+                                   gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1()),
+                                   0, textaxis.GetTextSize(), typolabel.Data());
+               if (fNModLabs) ResetLabelAttributes(&textaxis);
             }
             labelnumber++;
          }
@@ -2298,22 +2296,22 @@ L160:
                         else            yy -= ylabel;
                      }
                   }
-                  textaxis->SetTitle(chtemp);
+                  textaxis.SetTitle(chtemp);
                   Double_t u = gPad->GetX1() + xx*(gPad->GetX2() - gPad->GetX1());
                   Double_t v = gPad->GetY1() + yy*(gPad->GetY2() - gPad->GetY1());
                   if (firstintlab) {
-                     textaxis->GetBoundingBox(wi, hi); wi=(UInt_t)(wi*1.3); hi=(UInt_t)(hi*1.3);
+                     textaxis.GetBoundingBox(wi, hi); wi=(UInt_t)(wi*1.3); hi=(UInt_t)(hi*1.3);
                      xi1 = gPad->XtoAbsPixel(u);
                      yi1 = gPad->YtoAbsPixel(v);
                      firstintlab = kFALSE;
                      if (fNModLabs) {
                         changelablogid++;
-                        ChangeLabelAttributes(changelablogid, 0, textaxis, chtemp);
+                        ChangeLabelAttributes(changelablogid, 0, &textaxis, chtemp);
                      }
                      typolabel = chtemp;
                      typolabel.ReplaceAll("-", "#minus");
-                     textaxis->PaintLatex(u,v,0,textaxis->GetTextSize(),typolabel.Data());
-                     if (fNModLabs) ResetLabelAttributes(textaxis);
+                     textaxis.PaintLatex(u,v,0,textaxis.GetTextSize(),typolabel.Data());
+                     if (fNModLabs) ResetLabelAttributes(&textaxis);
                   } else {
                      xi2 = gPad->XtoAbsPixel(u);
                      yi2 = gPad->YtoAbsPixel(v);
@@ -2324,15 +2322,15 @@ L160:
                      } else {
                         xi1 = xi2;
                         yi1 = yi2;
-                        textaxis->GetBoundingBox(wi, hi); wi=(UInt_t)(wi*1.3); hi=(UInt_t)(hi*1.3);
+                        textaxis.GetBoundingBox(wi, hi); wi=(UInt_t)(wi*1.3); hi=(UInt_t)(hi*1.3);
                         if (fNModLabs) {
                            changelablogid++;
-                           ChangeLabelAttributes(changelablogid, 0, textaxis, chtemp);
+                           ChangeLabelAttributes(changelablogid, 0, &textaxis, chtemp);
                         }
                         typolabel = chtemp;
                         typolabel.ReplaceAll("-", "#minus");
-                        textaxis->PaintLatex(u,v,0,textaxis->GetTextSize(),typolabel.Data());
-                        if (fNModLabs) ResetLabelAttributes(textaxis);
+                        textaxis.PaintLatex(u,v,0,textaxis.GetTextSize(),typolabel.Data());
+                        if (fNModLabs) ResetLabelAttributes(&textaxis);
                      }
                   }
                }
@@ -2341,7 +2339,7 @@ L160:
                if (optionGrid && nbinin <= 5 && ndiv > 100) {
                   Rotate(xone,0,cosphi,sinphi,x0,y0,xpl2, ypl2);
                   Rotate(xone,grid_side*gridlength,cosphi,sinphi,x0,y0, xpl1,ypl1);
-                  linegrid->PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
+                  linegrid.PaintLineNDC(xpl1, ypl1, xpl2, ypl2);
                }
             }  //endif ((nbinin <= idn) ||
          }  //endfor (k=2;k<10;k++)
@@ -2352,7 +2350,7 @@ L200:
 
 // Draw axis title if it exists
    if (!drawGridOnly && strlen(GetTitle())) {
-      textaxis->SetTextSize (GetTitleSize());
+      textaxis.SetTextSize (GetTitleSize());
       charheight = GetTitleSize();
       if ((GetTextFont() % 10) > 2) {
          charheight /= ((x1==x0) ? padw : padh);
@@ -2376,35 +2374,32 @@ L200:
       else                              axispos = axis_length;
       if (TestBit(TAxis::kRotateTitle)) {
          if (x1 >= x0) {
-            if (TestBit(TAxis::kCenterTitle)) textaxis->SetTextAlign(22);
-            else                              textaxis->SetTextAlign(12);
+            if (TestBit(TAxis::kCenterTitle)) textaxis.SetTextAlign(22);
+            else                              textaxis.SetTextAlign(12);
          } else {
-            if (TestBit(TAxis::kCenterTitle)) textaxis->SetTextAlign(22);
-            else                              textaxis->SetTextAlign(32);
+            if (TestBit(TAxis::kCenterTitle)) textaxis.SetTextAlign(22);
+            else                              textaxis.SetTextAlign(32);
          }
          phil+=kPI;
       } else {
          if (x1 >= x0) {
-            if (TestBit(TAxis::kCenterTitle)) textaxis->SetTextAlign(22);
-            else                              textaxis->SetTextAlign(32);
+            if (TestBit(TAxis::kCenterTitle)) textaxis.SetTextAlign(22);
+            else                              textaxis.SetTextAlign(32);
          } else {
-            if (TestBit(TAxis::kCenterTitle)) textaxis->SetTextAlign(22);
-            else                              textaxis->SetTextAlign(12);
+            if (TestBit(TAxis::kCenterTitle)) textaxis.SetTextAlign(22);
+            else                              textaxis.SetTextAlign(12);
          }
       }
       Rotate(axispos,ylabel,cosphi,sinphi,x0,y0,xpl1,ypl1);
-      textaxis->SetTextColor(TitleColor);
-      textaxis->SetTextFont(TitleFont);
-      textaxis->PaintLatex(gPad->GetX1() + xpl1*(gPad->GetX2() - gPad->GetX1()),
+      textaxis.SetTextColor(TitleColor);
+      textaxis.SetTextFont(TitleFont);
+      textaxis.PaintLatex(gPad->GetX1() + xpl1*(gPad->GetX2() - gPad->GetX1()),
                            gPad->GetY1() + ypl1*(gPad->GetY2() - gPad->GetY1()),
                            phil*180/kPI,
                            GetTitleSize(),
                            GetTitle());
    }
 
-L210:
-   if (optionGrid) delete linegrid;
-   delete textaxis;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -2552,8 +2547,8 @@ void TGaxis::SetDecimals(Bool_t dot)
 void TGaxis::SetFunction(const char *funcname)
 {
    fFunctionName = funcname;
-   if (!funcname[0]) {
-      fFunction = 0;
+   if (!funcname || !funcname[0]) {
+      fFunction = nullptr;
       return;
    }
    fFunction = (TF1*)gROOT->GetFunction(funcname);
@@ -2618,7 +2613,7 @@ void TGaxis::ChangeLabel(Int_t labNum, Double_t labAngle, Double_t labSize,
    // Reset the list of modified labels.
    if (labNum == 0) {
       delete fModLabs;
-      fModLabs  = 0;
+      fModLabs  = nullptr;
       fNModLabs = 0;
       return;
    }

--- a/graf2d/graf/src/TGraphPolar.cxx
+++ b/graf2d/graf/src/TGraphPolar.cxx
@@ -64,7 +64,7 @@ ClassImp(TGraphPolar);
 /// TGraphPolar default constructor.
 
 TGraphPolar::TGraphPolar() : TGraphErrors(),
-             fOptionAxis(kFALSE),fPolargram(0),fXpol(0),fYpol(0)
+             fOptionAxis(kFALSE),fPolargram(nullptr),fXpol(nullptr),fYpol(nullptr)
 {
 }
 
@@ -80,7 +80,7 @@ TGraphPolar::TGraphPolar() : TGraphErrors(),
 TGraphPolar::TGraphPolar(Int_t n, const Double_t* theta, const Double_t* r,
                                   const Double_t *etheta, const Double_t* er)
   : TGraphErrors(n,theta,r,etheta,er),
-             fOptionAxis(kFALSE),fPolargram(0),fXpol(0),fYpol(0)
+             fOptionAxis(kFALSE),fPolargram(nullptr),fXpol(nullptr),fYpol(nullptr)
 {
    SetEditable(kFALSE);
 }
@@ -90,8 +90,8 @@ TGraphPolar::TGraphPolar(Int_t n, const Double_t* theta, const Double_t* r,
 
 TGraphPolar::~TGraphPolar()
 {
-   delete []fXpol;
-   delete []fYpol;
+   delete [] fXpol;
+   delete [] fYpol;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TGraphPolargram.cxx
+++ b/graf2d/graf/src/TGraphPolargram.cxx
@@ -61,7 +61,7 @@ TGraphPolargram::TGraphPolargram(const char* name, Double_t rmin, Double_t rmax,
    Init();
    fNdivRad          = 508;
    fNdivPol          = 508;
-   fPolarLabels      = NULL;
+   fPolarLabels      = nullptr;
    fRwrmax           = rmax;
    fRwrmin           = rmin;
    fRwtmin           = tmin;
@@ -77,7 +77,7 @@ TGraphPolargram::TGraphPolargram(const char* name):
    Init();
    fNdivRad     = 0;
    fNdivPol     = 0;
-   fPolarLabels = NULL;
+   fPolarLabels = nullptr;
    fRwrmax      = 1;
    fRwrmin      = 0;
    fRwtmax      = 0;
@@ -89,7 +89,7 @@ TGraphPolargram::TGraphPolargram(const char* name):
 
 TGraphPolargram::~TGraphPolargram()
 {
-   if (fPolarLabels != NULL) delete [] fPolarLabels;
+   if (fPolarLabels) delete [] fPolarLabels;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -423,74 +423,74 @@ void TGraphPolargram::PaintPolarDivisions(Bool_t optionLabels)
          Double_t sinthetas = (1+fPolarOffset)*sintheta;
          Double_t corr = 0.01;
 
-         TLatex *textangular = new TLatex();
-         textangular->SetTextColor(GetPolarColorLabel());
-         textangular->SetTextFont(GetPolarLabelFont());
+         TLatex textangular;
+         textangular.SetTextColor(GetPolarColorLabel());
+         textangular.SetTextFont(GetPolarLabelFont());
 
-         const char* form = (char *)" ";
+         TString form = " ";
          TGaxis axis;
          if (TestBit(TGraphPolargram::kLabelOrtho)) {
             // Polar numbers are aligned with their axis.
-            if(fPolarLabels == NULL && optionLabels){;
+            if(!fPolarLabels && optionLabels){;
                if (fRadian) {
                   // Radian case.
                   ReduceFraction(2*i, ndivMajor, rnum, rden); // Reduces the fraction.
-                  if (rnum == 0)                       form = Form("%d",rnum);
-                  if (rnum == 1 && rden == 1)          form = Form("#pi");
-                  if (rnum == 1 && rden != 1)          form = Form("#frac{#pi}{%d}",rden);
-                  if (rnum != 1 && rden == 1 && i !=0) form= Form("%d#pi",rnum);
-                  if (rnum != 1 && rden != 1)          form = Form("#frac{%d#pi}{%d}",rnum,rden);
-                  textangular->SetTextAlign(FindAlign(theta));
-                  textangular->PaintLatex(costhetas,
+                  if (rnum == 0)                       form.Form("%d",rnum);
+                  if (rnum == 1 && rden == 1)          form = "#pi";
+                  if (rnum == 1 && rden != 1)          form.Form("#frac{#pi}{%d}",rden);
+                  if (rnum != 1 && rden == 1 && i !=0) form.Form("%d#pi",rnum);
+                  if (rnum != 1 && rden != 1)          form.Form("#frac{%d#pi}{%d}",rnum,rden);
+                  textangular.SetTextAlign(FindAlign(theta));
+                  textangular.PaintLatex(costhetas,
                                           sinthetas, FindTextAngle(theta),
-                                          GetPolarLabelSize(), form);
+                                          GetPolarLabelSize(), form.Data());
                } else {
                   // Any other cases: numbers are aligned with their axis.
-                  form = Form("%5.3g",txtval);
-                  axis.LabelsLimits(form,first,last);
-                  TString s = Form("%s",form);
+                  form.Form("%5.3g",txtval);
+                  axis.LabelsLimits(form.Data(),first,last);
+                  TString s = form;
                   if (first != 0) s.Remove(0, first);
-                  textangular->SetTextAlign(FindAlign(theta));
-                  textangular->PaintLatex(costhetas,
+                  textangular.SetTextAlign(FindAlign(theta));
+                  textangular.PaintLatex(costhetas,
                                           sinthetas, FindTextAngle(theta),
                                           GetPolarLabelSize(), s);
                }
             } else if (fPolarLabels){
                // print the specified polar labels
-               textangular->SetTextAlign(FindAlign(theta));
-               textangular->PaintLatex(costhetas,sinthetas,FindTextAngle(theta),
+               textangular.SetTextAlign(FindAlign(theta));
+               textangular.PaintLatex(costhetas,sinthetas,FindTextAngle(theta),
                                        GetPolarLabelSize(), fPolarLabels[i]);
             }
          } else {
             // Polar numbers are shown horizontally.
-            if(fPolarLabels == NULL && optionLabels){
+            if(!fPolarLabels && optionLabels){
                if (fRadian) {
                // Radian case
                   ReduceFraction(2*i, ndivMajor, rnum, rden);
-                  if (rnum == 0) form = Form("%d",rnum);
-                  if (rnum == 1 && rden == 1)          form = Form("#pi");
-                  if (rnum == 1 && rden != 1)          form = Form("#frac{#pi}{%d}",rden);
-                  if (rnum != 1 && rden == 1 && i !=0) form = Form("%d#pi",rnum);
-                  if (rnum != 1 && rden != 1)          form = Form("#frac{%d#pi}{%d}",rnum,rden);
+                  if (rnum == 0) form.Form("%d",rnum);
+                  if (rnum == 1 && rden == 1)          form = "#pi";
+                  if (rnum == 1 && rden != 1)          form.Form("#frac{#pi}{%d}",rden);
+                  if (rnum != 1 && rden == 1 && i !=0) form.Form("%d#pi",rnum);
+                  if (rnum != 1 && rden != 1)          form.Form("#frac{%d#pi}{%d}",rnum,rden);
                   if(theta >= 3*TMath::Pi()/12.0 && theta < 2*TMath::Pi()/3.0) corr=0.04;
-                  textangular->SetTextAlign(FindAlign(theta));
-                  textangular->PaintLatex(costhetas,corr+sinthetas,0,
-                                          GetPolarLabelSize(),form);
+                  textangular.SetTextAlign(FindAlign(theta));
+                  textangular.PaintLatex(costhetas,corr+sinthetas,0,
+                                          GetPolarLabelSize(),form.Data());
                } else {
                // Any other cases where numbers are shown horizontally.
-                  form = Form("%5.3g",txtval);
-                  axis.LabelsLimits(form,first,last);
-                  TString s = Form("%s",form);
+                  form.Form("%5.3g",txtval);
+                  axis.LabelsLimits(form.Data(),first,last);
+                  TString s = form;
                   if (first != 0) s.Remove(0, first);
                   if(theta >= 3*TMath::Pi()/12.0 && theta < 2*TMath::Pi()/3.0) corr=0.04;
-                  textangular->SetTextAlign(FindAlign(theta));
-                  textangular->PaintLatex(costhetas, //j'ai efface des offset la
+                  textangular.SetTextAlign(FindAlign(theta));
+                  textangular.PaintLatex(costhetas, //j'ai efface des offset la
                                           corr+sinthetas,0,GetPolarLabelSize(),s);
                }
             } else if (fPolarLabels) {
                // print the specified polar labels
-               textangular->SetTextAlign(FindAlign(theta));
-               textangular->PaintText(costhetas,sinthetas,fPolarLabels[i]);
+               textangular.SetTextAlign(FindAlign(theta));
+               textangular.PaintText(costhetas,sinthetas,fPolarLabels[i]);
             }
          }
          TAttLine::Modify();
@@ -510,7 +510,6 @@ void TGraphPolargram::PaintPolarDivisions(Bool_t optionLabels)
          TAttLine::SetLineStyle(1);
          TAttLine::Modify();
          gPad->PaintLine(0.,0.,costheta,sintheta);
-         delete textangular;
        // Add minor lines w/o text.
          Int_t oldLineStyle = GetLineStyle();
          TAttLine::SetLineStyle(2);  //Minor lines always in this style.
@@ -539,45 +538,45 @@ void TGraphPolargram::PaintPolarDivisions(Bool_t optionLabels)
          Double_t sinthetas = (1+fPolarOffset)*sintheta;
          Double_t corr      = 0.01;
 
-         TLatex *textangular = new TLatex();
-         textangular->SetTextColor(GetPolarColorLabel());
-         textangular->SetTextFont(GetPolarLabelFont());
+         TLatex textangular;
+         textangular.SetTextColor(GetPolarColorLabel());
+         textangular.SetTextFont(GetPolarLabelFont());
 
-         const char* form = (char *)" ";
+         TString form = " ";
          TGaxis axis;
 
          if (TestBit(TGraphPolargram::kLabelOrtho)) {
-            if(fPolarLabels==NULL && optionLabels){
+            if(!fPolarLabels && optionLabels){
             // Polar numbers are aligned with their axis.
-               form = Form("%5.3g",txtval);
-               axis.LabelsLimits(form,first,last);
-               TString s = Form("%s",form);
+               form.Form("%5.3g",txtval);
+               axis.LabelsLimits(form.Data(),first,last);
+               TString s = form;
                if (first != 0) s.Remove(0, first);
-               textangular->SetTextAlign(FindAlign(theta));
-               textangular->PaintLatex(costhetas,
+               textangular.SetTextAlign(FindAlign(theta));
+               textangular.PaintLatex(costhetas,
                                        sinthetas, FindTextAngle(theta), GetPolarLabelSize(), s);
             }
             else if (fPolarLabels){
                // print the specified polar labels
-               textangular->SetTextAlign(FindAlign(theta));
-               textangular->PaintText(costhetas,sinthetas,fPolarLabels[i]);
+               textangular.SetTextAlign(FindAlign(theta));
+               textangular.PaintText(costhetas,sinthetas,fPolarLabels[i]);
             }
 
          } else {
-            if(fPolarLabels==NULL && optionLabels){
+            if(!fPolarLabels && optionLabels){
             // Polar numbers are shown horizontally.
-               form = Form("%5.3g",txtval);
-               axis.LabelsLimits(form,first,last);
-               TString s = Form("%s",form);
+               form.Form("%5.3g",txtval);
+               axis.LabelsLimits(form.Data(),first,last);
+               TString s = form;
                if (first != 0) s.Remove(0, first);
                if(theta >= 3*TMath::Pi()/12.0 && theta < 2*TMath::Pi()/3.0) corr=0.04;
-               textangular->SetTextAlign(FindAlign(theta));
-               textangular->PaintLatex(costhetas,
+               textangular.SetTextAlign(FindAlign(theta));
+               textangular.PaintLatex(costhetas,
                                        corr+sinthetas,0,GetPolarLabelSize(),s);
             } else if (fPolarLabels){
                // print the specified polar labels
-               textangular->SetTextAlign(FindAlign(theta));
-               textangular->PaintText(costhetas,sinthetas,fPolarLabels[i]);
+               textangular.SetTextAlign(FindAlign(theta));
+               textangular.PaintText(costhetas,sinthetas,fPolarLabels[i]);
             }
          }
 
@@ -597,7 +596,6 @@ void TGraphPolargram::PaintPolarDivisions(Bool_t optionLabels)
          TAttLine::SetLineStyle(1);
          TAttLine::Modify();
          gPad->PaintLine(0.,0.,costheta,sintheta);
-         delete textangular;
          // Add minor lines w/o text.
          Int_t oldLineStyle = GetLineStyle();
          TAttLine::SetLineStyle(2);  //Minor lines always in this style.
@@ -793,9 +791,9 @@ void TGraphPolargram::SetNdivRadial(Int_t ndiv)
 
 void TGraphPolargram::SetPolarLabel(Int_t div, const TString & label)
 {
-   if(fPolarLabels == NULL)
+   if(!fPolarLabels)
       fPolarLabels = new TString[fNdivPol];
-   fPolarLabels[div]=label;
+   fPolarLabels[div] = label;
    if (gPad) gPad->Modified();
 }
 

--- a/graf2d/graf/src/TGraphQQ.cxx
+++ b/graf2d/graf/src/TGraphQQ.cxx
@@ -118,8 +118,8 @@ TGraphQQ::TGraphQQ(Int_t n, Double_t *x)
    TMath::Sort(n, x, index, kFALSE);
    for (Int_t i=0; i<fNpoints; i++)
       fY[i] = x[index[i]];
-   fF=0;
-   fY0=0;
+   fF = nullptr;
+   fY0 = nullptr;
    delete [] index;
 }
 
@@ -137,7 +137,7 @@ TGraphQQ::TGraphQQ(Int_t n, Double_t *x, TF1 *f)
       fY[i] = x[index[i]];
    delete [] index;
    fF = f;
-   fY0=0;
+   fY0 = nullptr;
    MakeFunctionQuantiles();
 }
 
@@ -152,10 +152,10 @@ TGraphQQ::TGraphQQ(Int_t nx, Double_t *x, Int_t ny, Double_t *y)
    fXq2 = 0.;
    fYq1 = 0.;
    fYq2 = 0.;
-   fF   = 0;
-   fY0  = 0;
+   fF   = nullptr;
+   fY0  = nullptr;
 
-   nx<=ny ? fNpoints=nx : fNpoints=ny;
+   fNpoints = (nx <= ny) ? nx : ny;
 
    if (!CtorAllocate()) return;
 
@@ -168,7 +168,7 @@ TGraphQQ::TGraphQQ(Int_t nx, Double_t *x, Int_t ny, Double_t *y)
       if (nx==ny){
          for (Int_t i=0; i<fNpoints; i++)
             fX[i] = y[index[i]];
-         fY0 = 0;
+         fY0 = nullptr;
          Quartiles();
       } else {
          fNy0 = ny;
@@ -188,7 +188,6 @@ TGraphQQ::TGraphQQ(Int_t nx, Double_t *x, Int_t ny, Double_t *y)
       MakeQuantiles();
    }
 
-
    delete [] index;
 }
 
@@ -200,7 +199,7 @@ TGraphQQ::~TGraphQQ()
    if (fY0)
       delete [] fY0;
    if (fF)
-      fF = 0;
+      fF = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -403,7 +403,7 @@ TLatex::TLatex()
 {
    fFactorSize  = 1.5;
    fFactorPos   = 0.6;
-   fError       = 0;
+   fError       = nullptr;
    fShow        = kFALSE;
    fOriginSize  = 0.04;
    fItalic      = kFALSE;
@@ -419,7 +419,7 @@ TLatex::TLatex(Double_t x, Double_t y, const char *text)
 {
    fFactorSize  = 1.5;
    fFactorPos   = 0.6;
-   fError       = 0;
+   fError       = nullptr;
    fShow        = kFALSE;
    fOriginSize  = 0.04;
    fItalic      = kFALSE;
@@ -441,7 +441,7 @@ TLatex::TLatex(const TLatex &text) : TText(text), TAttLine(text)
 {
    fFactorSize  = 1.5;
    fFactorPos   = 0.6;
-   fError       = 0;
+   fError       = nullptr;
    fShow        = kFALSE;
    fOriginSize  = 0.04;
    fItalic      = kFALSE;
@@ -544,11 +544,11 @@ TLatex::TLatexFormSize TLatex::Analyse(Double_t x, Double_t y, TextSpec_t spec, 
 
    const char *tab3[] = { "bar","vec","dot","hat","ddot","acute","grave","check","tilde","slash"};
 
-   if (fError != 0) return TLatexFormSize(0,0,0);
+   if (fError) return TLatexFormSize(0,0,0);
 
-   Int_t nBlancDeb=0,nBlancFin=0,l_nBlancDeb=0,l_nBlancFin=0;
-   Int_t i,k;
-   Int_t min=0, max=0;
+   Int_t nBlancDeb = 0, nBlancFin = 0, l_nBlancDeb = 0, l_nBlancFin = 0;
+   Int_t i, k;
+   Int_t min = 0, max = 0;
    Bool_t cont = kTRUE;
    while(cont) {
       // count leading blanks
@@ -2151,13 +2151,13 @@ Int_t TLatex::PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size,
    if( newText.Length() == 0) return 0;
    newText.ReplaceAll("#hbox","#mbox");
 
-   fError = 0 ;
+   fError = nullptr;
    if (CheckLatexSyntax(newText)) {
       std::cout<<"\n*ERROR<TLatex>: "<<fError<<std::endl;
       std::cout<<"==> "<<text1<<std::endl;
       return 0;
    }
-   fError = 0 ;
+   fError = nullptr;
 
    // Do not use Latex if font is low precision.
    if (fTextFont%10 < 2) {
@@ -2219,7 +2219,7 @@ Int_t TLatex::PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size,
    Short_t halign = fTextAlign/10;
    Short_t valign = fTextAlign - 10*halign;
    TextSpec_t newSpec = spec;
-   if (fError != 0) {
+   if (fError) {
       std::cout<<"*ERROR<TLatex>: "<<fError<<std::endl;
       std::cout<<"==> "<<text<<std::endl;
    } else {
@@ -2248,7 +2248,7 @@ Int_t TLatex::PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size,
    SetLineWidth(lineW);
    SetLineColor(lineC);
    fTabSize.clear();
-   if (fError != 0) return 0;
+   if (fError) return 0;
    return 1;
 }
 
@@ -2518,13 +2518,13 @@ Double_t TLatex::GetXsize()
       return tm.GetXsize();
    }
 
-   fError = 0 ;
+   fError = nullptr;
    if (CheckLatexSyntax(newText)) {
       std::cout<<"\n*ERROR<TLatex>: "<<fError<<std::endl;
       std::cout<<"==> "<<GetTitle()<<std::endl;
       return 0;
    }
-   fError = 0 ;
+   fError = nullptr;
 
    const Char_t *text = newText.Data() ;
    Double_t angle_old = GetTextAngle();
@@ -2550,13 +2550,13 @@ void TLatex::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle)
       return;
    }
 
-   fError = 0 ;
+   fError = nullptr;
    if (CheckLatexSyntax(newText)) {
       std::cout<<"\n*ERROR<TLatex>: "<<fError<<std::endl;
       std::cout<<"==> "<<GetTitle()<<std::endl;
       return;
    }
-   fError = 0 ;
+   fError = nullptr;
 
    if (angle) {
       Int_t cBoxX[4], cBoxY[4];
@@ -2606,15 +2606,15 @@ Double_t TLatex::GetYsize()
       return tm.GetYsize();
    }
 
-   fError = 0 ;
+   fError = nullptr;
    if (CheckLatexSyntax(newText)) {
       std::cout<<"\n*ERROR<TLatex>: "<<fError<<std::endl;
       std::cout<<"==> "<<GetTitle()<<std::endl;
       return 0;
    }
-   fError = 0 ;
+   fError = nullptr;
 
-   const Char_t *text = newText.Data() ;
+   const Char_t *text = newText.Data();
    Double_t angsav = fTextAngle;
    TLatexFormSize fs = FirstParse(0,GetTextSize(),text);
    fTextAngle = angsav;

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -405,10 +405,7 @@ TLatex::TLatex()
    fFactorPos   = 0.6;
    fError       = 0;
    fShow        = kFALSE;
-   fPos         = 0;
-   fTabMax      = 0;
    fOriginSize  = 0.04;
-   fTabSize     = 0;
    fItalic      = kFALSE;
    fLimitFactorSize = 3;
    SetLineWidth(2);
@@ -424,10 +421,7 @@ TLatex::TLatex(Double_t x, Double_t y, const char *text)
    fFactorPos   = 0.6;
    fError       = 0;
    fShow        = kFALSE;
-   fPos         = 0;
-   fTabMax      = 0;
    fOriginSize  = 0.04;
-   fTabSize     = 0;
    fItalic      = kFALSE;
    fLimitFactorSize = 3;
    SetLineWidth(2);
@@ -449,10 +443,7 @@ TLatex::TLatex(const TLatex &text) : TText(text), TAttLine(text)
    fFactorPos   = 0.6;
    fError       = 0;
    fShow        = kFALSE;
-   fPos         = 0;
-   fTabMax      = 0;
    fOriginSize  = 0.04;
-   fTabSize     = 0;
    fItalic      = kFALSE;
    fLimitFactorSize = 3;
    ((TLatex&)text).Copy(*this);
@@ -463,19 +454,17 @@ TLatex::TLatex(const TLatex &text) : TText(text), TAttLine(text)
 
 TLatex& TLatex::operator=(const TLatex& lt)
 {
-   if(this!=&lt) {
+   if (this != &lt) {
       TText::operator=(lt);
       TAttLine::operator=(lt);
-      fFactorSize=lt.fFactorSize;
-      fFactorPos=lt.fFactorPos;
-      fLimitFactorSize=lt.fLimitFactorSize;
-      fError=lt.fError;
-      fShow=lt.fShow;
-      fTabSize=lt.fTabSize;
-      fOriginSize=lt.fOriginSize;
-      fTabSize=lt.fTabSize;
-      fTabSize=lt.fTabSize;
-      fItalic=lt.fItalic;
+      fFactorSize = lt.fFactorSize;
+      fFactorPos = lt.fFactorPos;
+      fLimitFactorSize = lt.fLimitFactorSize;
+      fError = lt.fError;
+      fShow = lt.fShow;
+      fTabSize = lt.fTabSize;
+      fOriginSize = lt.fOriginSize;
+      fItalic = lt.fItalic;
    }
    return *this;
 }
@@ -490,10 +479,8 @@ void TLatex::Copy(TObject &obj) const
    ((TLatex&)obj).fLimitFactorSize  = fLimitFactorSize;
    ((TLatex&)obj).fError       = fError;
    ((TLatex&)obj).fShow        = fShow;
-   ((TLatex&)obj).fTabSize     = 0;
+   ((TLatex&)obj).fTabSize     = fTabSize;
    ((TLatex&)obj).fOriginSize  = fOriginSize;
-   ((TLatex&)obj).fTabMax      = fTabMax;
-   ((TLatex&)obj).fPos         = fPos;
    ((TLatex&)obj).fItalic      = fItalic;
    TText::Copy(obj);
    TAttLine::Copy(((TAttLine&)obj));
@@ -2260,7 +2247,7 @@ Int_t TLatex::PaintLatex1(Double_t x, Double_t y, Double_t angle, Double_t size,
    SetTextAlign(valign+10*halign);
    SetLineWidth(lineW);
    SetLineColor(lineC);
-   delete[] fTabSize;
+   fTabSize.clear();
    if (fError != 0) return 0;
    return 1;
 }
@@ -2474,12 +2461,7 @@ Int_t TLatex::CheckLatexSyntax(TString &text)
 
 TLatex::TLatexFormSize TLatex::FirstParse(Double_t angle, Double_t size, const Char_t *text)
 {
-   fError   = 0;
-   fTabMax  = 100;
-   fTabSize = new FormSize_t[fTabMax];
-   // we assume less than 100 parts in one formula
-   // we will reallocate if necessary.
-   fPos        = 0;
+   fTabSize.reserve(100); // ensure 100 entries before memory reallocation required
    fShow       = kFALSE;
    fOriginSize = size;
 
@@ -2548,7 +2530,7 @@ Double_t TLatex::GetXsize()
    Double_t angle_old = GetTextAngle();
    TLatexFormSize fs = FirstParse(0,GetTextSize(),text);
    SetTextAngle(angle_old);
-   delete[] fTabSize;
+   fTabSize.clear();
    return TMath::Abs(gPad->AbsPixeltoX(Int_t(fs.Width())) - gPad->AbsPixeltoX(0));
 }
 
@@ -2602,7 +2584,7 @@ void TLatex::GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle)
    } else {
       const Char_t *text = newText.Data() ;
       TLatexFormSize fs = FirstParse(GetTextAngle(),GetTextSize(),text);
-      delete[] fTabSize;
+      fTabSize.clear();
       w = (UInt_t)fs.Width();
       h = (UInt_t)fs.Height();
    }
@@ -2636,7 +2618,7 @@ Double_t TLatex::GetYsize()
    Double_t angsav = fTextAngle;
    TLatexFormSize fs = FirstParse(0,GetTextSize(),text);
    fTextAngle = angsav;
-   delete[] fTabSize;
+   fTabSize.clear();
    return TMath::Abs(gPad->AbsPixeltoY(Int_t(fs.Height())) - gPad->AbsPixeltoY(0));
 }
 
@@ -2645,8 +2627,13 @@ Double_t TLatex::GetYsize()
 
 TLatex::TLatexFormSize TLatex::Readfs()
 {
-   fPos--;
-   TLatexFormSize result(fTabSize[fPos].fWidth,fTabSize[fPos].fOver,fTabSize[fPos].fUnder);
+   if (fTabSize.empty()) {
+      Error("Readfs", "No data in fTabSize stack");
+      return TLatexFormSize(0,0,0);
+   }
+
+   TLatexFormSize result = fTabSize.back();
+   fTabSize.pop_back();
    return result;
 }
 
@@ -2655,21 +2642,7 @@ TLatex::TLatexFormSize TLatex::Readfs()
 
 void TLatex::Savefs(TLatex::TLatexFormSize *fs)
 {
-   fTabSize[fPos].fWidth  = fs->Width();
-   fTabSize[fPos].fOver   = fs->Over();
-   fTabSize[fPos].fUnder  = fs->Under();
-   fPos++;
-   if (fPos>=fTabMax) {
-      // allocate more memory
-      FormSize_t *temp = new FormSize_t[fTabMax+100];
-      // copy array
-      memcpy(temp,fTabSize,fTabMax*sizeof(FormSize_t));
-      fTabMax += 100;
-      // free previous array
-      delete [] fTabSize;
-      // swap pointers
-      fTabSize = temp;
-   }
+   fTabSize.emplace_back(*fs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -200,7 +200,7 @@ End_Macro
 TLegend::TLegend(): TPave(0.3,0.15,0.3,0.15,4,"brNDC"),
                     TAttText(12,0,1,gStyle->GetLegendFont(),0)
 {
-   fPrimitives = 0;
+   fPrimitives = nullptr;
    SetDefaults();
    SetBorderSize(gStyle->GetLegendBorderSize());
    SetFillColor(gStyle->GetLegendFillColor());
@@ -276,7 +276,7 @@ TLegend::TLegend( Double_t w, Double_t h, const char *header, Option_t *option)
 /// Copy constructor.
 
 TLegend::TLegend( const TLegend &legend ) : TPave(legend), TAttText(legend),
-                                            fPrimitives(0)
+                                            fPrimitives(nullptr)
 {
   if (legend.fPrimitives) {
       fPrimitives = new TList();
@@ -310,9 +310,10 @@ TLegend& TLegend::operator=(const TLegend &lg)
 
 TLegend::~TLegend()
 {
-   if (fPrimitives) fPrimitives->Delete();
+   if (fPrimitives)
+      fPrimitives->Delete();
    delete fPrimitives;
-   fPrimitives = 0;
+   fPrimitives = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -516,15 +517,14 @@ TLegendEntry *TLegend::GetEntry() const
 
 const char *TLegend::GetHeader() const
 {
-   if ( !fPrimitives ) return 0;
+   if ( !fPrimitives ) return nullptr;
       TIter next(fPrimitives);
-   TLegendEntry *first;   // header is always the first entry
-   if ((  first = (TLegendEntry*)next()  )) {
+   if (auto first = (TLegendEntry*)next()) {
       TString opt = first->GetOption();
       opt.ToLower();
       if ( opt.Contains("h") ) return first->GetLabel();
    }
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -637,8 +637,7 @@ void TLegend::PaintPrimitives()
       textsize = GetTextSize();
    }
    Bool_t autosize = kFALSE;
-   Double_t* columnWidths = new Double_t[fNColumns];
-   memset(columnWidths, 0, fNColumns*sizeof(Double_t));
+   std::vector<Double_t> columnWidths(fNColumns, 0.);
 
    if ( textsize == 0 ) {
       autosize = kTRUE;
@@ -691,10 +690,10 @@ void TLegend::PaintPrimitives()
    // don't want to ruin initialisation of these variables later on
    {
       TIter next(fPrimitives);
-      TLegendEntry *entry;
       Int_t iColumn = 0;
-      memset(columnWidths, 0, fNColumns*sizeof(Double_t));
-      while (( entry = (TLegendEntry *)next() )) {
+      for (Int_t k = 0; k < fNColumns; ++k)
+         columnWidths[k] = 0.;
+      while (auto entry = (TLegendEntry *)next()) {
          TLatex entrytex( 0, 0, entry->GetLabel() );
          entrytex.SetNDC();
          Style_t tfont = entry->GetTextFont();
@@ -1012,7 +1011,6 @@ void TLegend::PaintPrimitives()
       if ( opt.Contains("p"))  entrymarker.Paint();
    }
    SetTextSize(save_textsize);
-   delete [] columnWidths;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1030,9 +1028,9 @@ void TLegend::Print( Option_t* option ) const
 void TLegend::RecursiveRemove(TObject *obj)
 {
    TIter next(fPrimitives);
-   TLegendEntry *entry;
-   while (( entry = (TLegendEntry *)next() )) {
-      if (entry->GetObject() == obj) entry->SetObject((TObject*)0);
+   while (auto entry = (TLegendEntry *)next()) {
+      if (entry->GetObject() == obj)
+         entry->SetObject((TObject *)nullptr);
    }
 }
 

--- a/graf2d/graf/src/TMarker.cxx
+++ b/graf2d/graf/src/TMarker.cxx
@@ -102,32 +102,30 @@ void TMarker::Copy(TObject &obj) const
 
 void TMarker::DisplayMarkerTypes()
 {
-   TMarker *marker = new TMarker();
-   marker->SetMarkerSize(3);
-   TText *text = new TText();
-   text->SetTextFont(62);
-   text->SetTextAlign(22);
-   text->SetTextSize(0.1);
-   char atext[] = "       ";
+   TMarker marker;
+   TText text;
+   marker.SetMarkerSize(3);
+   text.SetTextFont(62);
+   text.SetTextAlign(22);
+   text.SetTextSize(0.1);
+   TString atext;
    Double_t x = 0;
    Double_t dx = 1/16.0;
    for (Int_t i=1;i<16;i++) {
       x += dx;
-      snprintf(atext,7,"%d",i);
-      marker->SetMarkerStyle(i);
-      marker->DrawMarker(x,.25);
-      text->DrawText(x,.12,atext);
-      snprintf(atext,7,"%d",i+19);
-      marker->SetMarkerStyle(i+19);
-      marker->DrawMarker(x,.55);
-      text->DrawText(x,.42,atext);
-      snprintf(atext,7,"%d",i+34);
-      marker->SetMarkerStyle(i+34);
-      marker->DrawMarker(x,.85);
-      text->DrawText(x,.72,atext);
+      atext.Form("%d",i);
+      marker.SetMarkerStyle(i);
+      marker.DrawMarker(x,.25);
+      text.DrawText(x,.12,atext.Data());
+      atext.Form("%d",i+19);
+      marker.SetMarkerStyle(i+19);
+      marker.DrawMarker(x,.55);
+      text.DrawText(x,.42,atext.Data());
+      atext.Form("%d",i+34);
+      marker.SetMarkerStyle(i+34);
+      marker.DrawMarker(x,.85);
+      text.DrawText(x,.72,atext.Data());
    }
-   delete marker;
-   delete text;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -135,36 +133,34 @@ void TMarker::DisplayMarkerTypes()
 
 void TMarker::DisplayMarkerLineWidths()
 {
-   TMarker *marker = new TMarker();
-   marker->SetMarkerSize(3);
-   TText *text = new TText();
-   text->SetTextFont(62);
-   text->SetTextAlign(22);
-   text->SetTextSize(0.075);
-   char atext[] = "       ";
+   TMarker marker;
+   TText text;
+   marker.SetMarkerSize(3);
+   text.SetTextFont(62);
+   text.SetTextAlign(22);
+   text.SetTextSize(0.075);
+   TString atext;
    Double_t x = 0;
    Double_t dx = 1/19.0;
    for (Int_t i=1;i<19;i++) {
       x += dx;
-      snprintf(atext,7,"%d",i+49);
-      marker->SetMarkerStyle(i+49);
-      marker->DrawMarker(x,0.19);
-      text->DrawText(x,0.08,atext);
-      snprintf(atext,7,"%d",i+67);
-      marker->SetMarkerStyle(i+67);
-      marker->DrawMarker(x,0.42);
-      text->DrawText(x,0.31,atext);
-      snprintf(atext,7,"%d",i+85);
-      marker->SetMarkerStyle(i+85);
-      marker->DrawMarker(x,0.65);
-      text->DrawText(x,0.54,atext);
-      snprintf(atext,7,"%d",i+103);
-      marker->SetMarkerStyle(i+103);
-      marker->DrawMarker(x,0.88);
-      text->DrawText(x,0.77,atext);
+      atext.Form("%d",i+49);
+      marker.SetMarkerStyle(i+49);
+      marker.DrawMarker(x,0.19);
+      text.DrawText(x,0.08,atext.Data());
+      atext.Form("%d",i+67);
+      marker.SetMarkerStyle(i+67);
+      marker.DrawMarker(x,0.42);
+      text.DrawText(x,0.31,atext.Data());
+      atext.Form("%d",i+85);
+      marker.SetMarkerStyle(i+85);
+      marker.DrawMarker(x,0.65);
+      text.DrawText(x,0.54,atext.Data());
+      atext.Form("%d",i+103);
+      marker.SetMarkerStyle(i+103);
+      marker.DrawMarker(x,0.88);
+      text.DrawText(x,0.77,atext.Data());
    }
-   delete marker;
-   delete text;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPaveStats.cxx
+++ b/graf2d/graf/src/TPaveStats.cxx
@@ -228,7 +228,7 @@ const UInt_t kTakeStyle = BIT(17); //see TStyle::SetOptFit/Stat
 
 TPaveStats::TPaveStats(): TPaveText()
 {
-   fParent  = 0;
+   fParent  = nullptr;
    fOptFit  = gStyle->GetOptFit();
    fOptStat = gStyle->GetOptStat();
 }
@@ -239,7 +239,7 @@ TPaveStats::TPaveStats(): TPaveText()
 TPaveStats::TPaveStats(Double_t x1, Double_t y1,Double_t x2, Double_t  y2, Option_t *option)
            :TPaveText(x1,y1,x2,y2,option)
 {
-   fParent = 0;
+   fParent  = nullptr;
    fOptFit  = gStyle->GetOptFit();
    fOptStat = gStyle->GetOptStat();
    SetFitFormat(gStyle->GetFitFormat());
@@ -349,7 +349,7 @@ void TPaveStats::Paint(Option_t *option)
    TIter next(fLines);
    Double_t longest = 0, titlelength = 0;
    Double_t w, wtok[2];
-   char *st, *sl=0;
+   char *st, *sl = nullptr;
    if (textsize == 0)  {
       textsize = 0.92*yspace/(y2 - y1);
       titlesize = textsize;
@@ -385,7 +385,7 @@ void TPaveStats::Paint(Option_t *option)
                if (titlelength > 0.98*dx) titlesize *= 0.98*dx/titlelength;
                latex->SetTextFont(tfont);
             }
-            delete [] sl; sl = 0;
+            delete [] sl; sl = nullptr;
          }
       }
       longest = wtok[0]+wtok[1]+2.*margin;

--- a/graf2d/graf/src/TPaveStats.cxx
+++ b/graf2d/graf/src/TPaveStats.cxx
@@ -344,8 +344,6 @@ void TPaveStats::Paint(Option_t *option)
    Float_t margin    = fMargin*dx;
    Double_t yspace   = dy/Double_t(nlines);
    Double_t textsave = textsize;
-   TObject *line;
-   TLatex *latex, *latex_tok;
    TIter next(fLines);
    Double_t longest = 0, titlelength = 0;
    Double_t w, wtok[2];
@@ -354,9 +352,9 @@ void TPaveStats::Paint(Option_t *option)
       textsize = 0.92*yspace/(y2 - y1);
       titlesize = textsize;
       wtok[0] = wtok[1] = 0;
-      while ((line = (TObject*) next())) {
+      while (auto line = (TObject*) next()) {
          if (line->IsA() == TLatex::Class()) {
-            latex = (TLatex*)line;
+            TLatex *latex = (TLatex*)line;
             Int_t nchs = strlen(latex->GetTitle());
             sl = new char[nchs+1];
             strlcpy(sl, latex->GetTitle(),nchs+1);
@@ -364,16 +362,15 @@ void TPaveStats::Paint(Option_t *option)
                st = strtok(sl, "=");
                Int_t itok = 0;
                while (( st != 0 ) && (itok < 2)) {
-                  latex_tok = new TLatex(0.,0.,st);
+                  TLatex latex_tok(0.,0.,st);
                   Style_t tfont = latex->GetTextFont();
                   if (tfont == 0) tfont = GetTextFont();
-                  latex_tok->SetTextFont(tfont);
-                  latex_tok->SetTextSize(textsize);
-                  w = latex_tok->GetXsize();
+                  latex_tok.SetTextFont(tfont);
+                  latex_tok.SetTextSize(textsize);
+                  w = latex_tok.GetXsize();
                   if (w > wtok[itok]) wtok[itok] = w;
                   st = strtok(0, "=");
                   ++itok;
-                  delete latex_tok;
                }
             } else if (strpbrk(sl, "|") !=0) {
             } else {
@@ -401,9 +398,9 @@ void TPaveStats::Paint(Option_t *option)
    // Iterate over all lines
    // Copy pavetext attributes to line attributes if line attributes not set
    next.Reset();
-   while ((line = (TObject*) next())) {
+   while (auto line = (TObject*) next()) {
       if (line->IsA() == TLatex::Class()) {
-         latex = (TLatex*)line;
+         TLatex *latex = (TLatex*)line;
          ytext -= yspace;
          Double_t xl    = latex->GetX();
          Double_t yl    = latex->GetY();
@@ -491,12 +488,11 @@ void TPaveStats::Paint(Option_t *option)
       x2 = x2ref - 0.25*dx;
       y1 = y2ref - 0.02*dy;
       y2 = y2ref + 0.02*dy;
-      TPaveLabel *title = new TPaveLabel(x1,y1,x2,y2,fLabel.Data(),GetDrawOption());
-      title->SetFillColor(GetFillColor());
-      title->SetTextColor(GetTextColor());
-      title->SetTextFont(GetTextFont());
-      title->Paint();
-      delete title;
+      TPaveLabel title(x1,y1,x2,y2,fLabel.Data(),GetDrawOption());
+      title.SetFillColor(GetFillColor());
+      title.SetTextColor(GetTextColor());
+      title.SetTextFont(GetTextFont());
+      title.Paint();
    }
 }
 

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -118,7 +118,7 @@ TPaveText::~TPaveText()
    if (!TestBit(kNotDeleted)) return;
    if (fLines) fLines->Delete();
    delete fLines;
-   fLines = 0;
+   fLines = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -131,7 +131,7 @@ TPaveText::TPaveText(const TPaveText &pavetext) : TPave(), TAttText()
    p->Streamer(b);
    b.SetReadMode();
    b.SetBufferOffset(0);
-   fLines = 0;
+   fLines = nullptr;
    Streamer(b);
 }
 
@@ -568,12 +568,11 @@ void TPaveText::PaintPrimitives(Int_t mode)
       x2 = fX2 - 0.25*dx;
       y1 = fY2 - 0.02*dy;
       y2 = fY2 + 0.02*dy;
-      TPaveLabel *title = new TPaveLabel(x1,y1,x2,y2,fLabel.Data(),GetDrawOption());
-      title->SetFillColor(GetFillColor());
-      title->SetTextColor(GetTextColor());
-      title->SetTextFont(GetTextFont());
-      title->Paint();
-      delete title;
+      TPaveLabel title(x1,y1,x2,y2,fLabel.Data(),GetDrawOption());
+      title.SetFillColor(GetFillColor());
+      title.SetTextColor(GetTextColor());
+      title.SetTextFont(GetTextFont());
+      title.Paint();
    }
 }
 

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -597,7 +597,6 @@ void TPaveText::ReadFile(const char *filename, Option_t *option, Int_t nlines, I
 {
    Int_t ival;
    Float_t val;
-   TText *lastline = 0;
    TString opt = option;
    if (!opt.Contains("+")) {
       Clear();
@@ -620,7 +619,7 @@ void TPaveText::ReadFile(const char *filename, Option_t *option, Int_t nlines, I
 
    const int linesize = 255;
    char currentline[linesize];
-   char *ss, *sclose, *s= 0;
+   char *ss, *sclose, *s = nullptr;
 
    Int_t kline = 0;
    while (1) {
@@ -633,7 +632,7 @@ void TPaveText::ReadFile(const char *filename, Option_t *option, Int_t nlines, I
             sclose = strstr(ss,")");
             if (!sclose) continue;
             *sclose = 0;
-            lastline = (TText*)fLines->Last();
+            TText *lastline = (TText*)fLines->Last();
             if (!lastline) continue;
             if (strstr(ss,"Color(")) {
                sscanf(ss+6,"%d",&ival);

--- a/graf2d/graf/src/TPie.cxx
+++ b/graf2d/graf/src/TPie.cxx
@@ -200,7 +200,7 @@ Int_t TPie::DistancetoSlice(Int_t px, Int_t py)
    Double_t radX  = fRadius;
    Double_t radY  = fRadius;
    Double_t radXY = 1.;
-   if (fIs3D==kTRUE) {
+   if (fIs3D) {
       radXY = TMath::Sin(fAngle3D/180.*TMath::Pi());
       radY  = radXY*radX;
    }
@@ -305,7 +305,7 @@ void TPie::DrawGhost()
       radXY = TMath::Sin(fAngle3D/180.*TMath::Pi());
    }
 
-   for (Int_t i=0;i<fNvals&&fIs3D==kTRUE;++i) {
+   for (Int_t i = 0; i < fNvals && fIs3D;++i) {
       Float_t minphi = (fSlices[i*2]+gAngularOffset+.5)*TMath::Pi()/180.;
       Float_t avgphi = (fSlices[i*2+1]+gAngularOffset)*TMath::Pi()/180.;
       Float_t maxphi = (fSlices[i*2+2]+gAngularOffset-.5)*TMath::Pi()/180.;
@@ -428,7 +428,7 @@ void TPie::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
    // XY metric
    Double_t radXY = 1.;
-   if (fIs3D==kTRUE) {
+   if (fIs3D) {
       radXY = TMath::Sin(fAngle3D/180.*TMath::Pi());
    }
 
@@ -593,7 +593,7 @@ void TPie::ExecuteEvent(Int_t event, Int_t px, Int_t py)
          if (isResizing)    isResizing    = kFALSE;
          if (isRotating)    {
             isRotating = kFALSE;
-            // this is important mainly when OpaqueMoving==kTRUE
+            // this is important mainly when OpaqueMoving == kTRUE
             gCurrent_ang += gAngularOffset/180.*TMath::Pi();
          }
 
@@ -805,19 +805,19 @@ void TPie::Paint(Option_t *option)
 
    TString soption(option);
 
-   bool optionSame(kFALSE);
+   Bool_t optionSame = kFALSE;
 
    // if true the lines around the slices are drawn, if false not
-   Bool_t optionLine(kTRUE);
+   Bool_t optionLine = kTRUE;
 
    // if true the labels' colors are the same as the slices' colors
-   Bool_t optionSameColor(kFALSE);
+   Bool_t optionSameColor = kFALSE;
 
    // For the label orientation there are 3 possibilities:
    //   0: horizontal
    //   1: radial
    //   2: tangent
-   Int_t lblor(0);
+   Int_t lblor = 0;
 
    // Parse the options
    Int_t idx;
@@ -883,9 +883,9 @@ void TPie::Paint(Option_t *option)
    if (!gPad) return;
 
    // Objects useful to draw labels and slices
-   TLatex *textlabel = new TLatex();
-   TArc *arc = new TArc();
-   TLine *line = new TLine();
+   TLatex textlabel;
+   TArc arc;
+   TLine line;
 
    // XY metric
    Double_t radX  = fRadius;
@@ -899,22 +899,22 @@ void TPie::Paint(Option_t *option)
 
    // Draw the slices.
    Int_t pixelHeight = gPad->YtoPixel(0)-gPad->YtoPixel(fHeight);
-   for (Int_t pi=0;pi<pixelHeight&&fIs3D==kTRUE; ++pi) { // loop for pseudo-3d effect
+   for (Int_t pi = 0; pi < pixelHeight && fIs3D; ++pi) { // loop for pseudo-3d effect
       for (Int_t i=0;i<fNvals;++i) {
          // draw the arc
          // set the color of the next slice
          if (pi>0) {
-            arc->SetFillStyle(0);
-            arc->SetLineColor(TColor::GetColorDark((fPieSlices[i]->GetFillColor())));
+            arc.SetFillStyle(0);
+            arc.SetLineColor(TColor::GetColorDark((fPieSlices[i]->GetFillColor())));
          } else {
-            arc->SetFillStyle(0);
-            if (optionLine==kTRUE) {
-               arc->SetLineColor(fPieSlices[i]->GetLineColor());
-               arc->SetLineStyle(fPieSlices[i]->GetLineStyle());
-               arc->SetLineWidth(fPieSlices[i]->GetLineWidth());
+            arc.SetFillStyle(0);
+            if (optionLine) {
+               arc.SetLineColor(fPieSlices[i]->GetLineColor());
+               arc.SetLineStyle(fPieSlices[i]->GetLineStyle());
+               arc.SetLineWidth(fPieSlices[i]->GetLineWidth());
             } else {
-               arc->SetLineWidth(1);
-               arc->SetLineColor(TColor::GetColorDark((fPieSlices[i]->GetFillColor())));
+               arc.SetLineWidth(1);
+               arc.SetLineColor(TColor::GetColorDark((fPieSlices[i]->GetFillColor())));
             }
          }
          // Paint the slice
@@ -923,38 +923,38 @@ void TPie::Paint(Option_t *option)
          Double_t ax = fX+TMath::Cos(aphi)*fPieSlices[i]->GetRadiusOffset();
          Double_t ay = fY+TMath::Sin(aphi)*fPieSlices[i]->GetRadiusOffset()*radXY+gPad->PixeltoY(pixelHeight-pi);
 
-         arc->PaintEllipse(ax, ay, radX, radY, fSlices[2*i],
+         arc.PaintEllipse(ax, ay, radX, radY, fSlices[2*i],
                                                fSlices[2*i+2], 0.);
 
-         if (optionLine==kTRUE) {
-            line->SetLineColor(fPieSlices[i]->GetLineColor());
-            line->SetLineStyle(fPieSlices[i]->GetLineStyle());
-            line->SetLineWidth(fPieSlices[i]->GetLineWidth());
-            line->PaintLine(ax,ay,ax,ay);
+         if (optionLine) {
+            line.SetLineColor(fPieSlices[i]->GetLineColor());
+            line.SetLineStyle(fPieSlices[i]->GetLineStyle());
+            line.SetLineWidth(fPieSlices[i]->GetLineWidth());
+            line.PaintLine(ax,ay,ax,ay);
 
             Double_t x0, y0;
             x0 = ax+radX*TMath::Cos(fSlices[2*i]/180.*TMath::Pi());
             y0 = ay+radY*TMath::Sin(fSlices[2*i]/180.*TMath::Pi());
-            line->PaintLine(x0,y0,x0,y0);
+            line.PaintLine(x0,y0,x0,y0);
 
             x0 = ax+radX*TMath::Cos(fSlices[2*i+2]/180.*TMath::Pi());
             y0 = ay+radY*TMath::Sin(fSlices[2*i+2]/180.*TMath::Pi());
-            line->PaintLine(x0,y0,x0,y0);
+            line.PaintLine(x0,y0,x0,y0);
          }
       }
    } // end loop for pseudo-3d effect
 
    for (Int_t i=0;i<fNvals;++i) { // loop for the piechart
       // Set the color of the next slice
-      arc->SetFillColor(fPieSlices[i]->GetFillColor());
-      arc->SetFillStyle(fPieSlices[i]->GetFillStyle());
-      if (optionLine==kTRUE) {
-         arc->SetLineColor(fPieSlices[i]->GetLineColor());
-         arc->SetLineStyle(fPieSlices[i]->GetLineStyle());
-         arc->SetLineWidth(fPieSlices[i]->GetLineWidth());
+      arc.SetFillColor(fPieSlices[i]->GetFillColor());
+      arc.SetFillStyle(fPieSlices[i]->GetFillStyle());
+      if (optionLine) {
+         arc.SetLineColor(fPieSlices[i]->GetLineColor());
+         arc.SetLineStyle(fPieSlices[i]->GetLineStyle());
+         arc.SetLineWidth(fPieSlices[i]->GetLineWidth());
       } else {
-         arc->SetLineWidth(1);
-         arc->SetLineColor(fPieSlices[i]->GetFillColor());
+         arc.SetLineWidth(1);
+         arc.SetLineColor(fPieSlices[i]->GetFillColor());
       }
 
       // Paint the slice
@@ -962,16 +962,16 @@ void TPie::Paint(Option_t *option)
 
       Double_t ax = fX+TMath::Cos(aphi)*fPieSlices[i]->GetRadiusOffset();
       Double_t ay = fY+TMath::Sin(aphi)*fPieSlices[i]->GetRadiusOffset()*radXY;
-      arc->PaintEllipse(ax, ay, radX, radY, fSlices[2*i],
+      arc.PaintEllipse(ax, ay, radX, radY, fSlices[2*i],
                                             fSlices[2*i+2], 0.);
 
    } // end loop to draw the slices
 
 
    // Set the font
-   textlabel->SetTextFont(GetTextFont());
-   textlabel->SetTextSize(GetTextSize());
-   textlabel->SetTextColor(GetTextColor());
+   textlabel.SetTextFont(GetTextFont());
+   textlabel.SetTextSize(GetTextSize());
+   textlabel.SetTextColor(GetTextColor());
 
    // Loop to place the labels.
    for (Int_t i=0;i<fNvals;++i) {
@@ -989,9 +989,9 @@ void TPie::Paint(Option_t *option)
       tmptxt.ReplaceAll("%frac",Form(fFractionFormat.Data(),fPieSlices[i]->GetValue()/fSum));
       tmptxt.ReplaceAll("%perc",Form(Form("%s %s",fPercentFormat.Data(),"%s"),(fPieSlices[i]->GetValue()/fSum)*100,"%"));
 
-      textlabel->SetTitle(tmptxt.Data());
-      Double_t h = textlabel->GetYsize();
-      Double_t w = textlabel->GetXsize();
+      textlabel.SetTitle(tmptxt.Data());
+      Double_t h = textlabel.GetYsize();
+      Double_t w = textlabel.GetXsize();
 
       Float_t lx = fX+(fRadius+fPieSlices[i]->GetRadiusOffset()+label_off)*TMath::Cos(aphi);
       Float_t ly = fY+(fRadius+fPieSlices[i]->GetRadiusOffset()+label_off)*TMath::Sin(aphi)*radXY;
@@ -1037,22 +1037,17 @@ void TPie::Paint(Option_t *option)
       if (rphi < 0 && fIs3D && label_off>=0.)
          ly -= fHeight;
 
-      if (optionSameColor) textlabel->SetTextColor((fPieSlices[i]->GetFillColor()));
-      textlabel->PaintLatex(lx,ly,
-                            lblang*180/TMath::Pi()+GetTextAngle(),
-                            GetTextSize(), tmptxt.Data());
+      if (optionSameColor) textlabel.SetTextColor((fPieSlices[i]->GetFillColor()));
+      textlabel.PaintLatex(lx,ly,
+                           lblang*180/TMath::Pi()+GetTextAngle(),
+                           GetTextSize(), tmptxt.Data());
    }
-
-   delete arc;
-   delete line;
-   delete textlabel;
 
    if (optionSame) return;
 
    // Draw title
-   TPaveText *title = 0;
-   TObject *obj;
-   if ((obj = gPad->GetListOfPrimitives()->FindObject("title"))) {
+   TPaveText *title = nullptr;
+   if (auto obj = gPad->GetListOfPrimitives()->FindObject("title")) {
       title = dynamic_cast<TPaveText*>(obj);
    }
 

--- a/graf2d/graf/src/TPie.cxx
+++ b/graf2d/graf/src/TPie.cxx
@@ -145,9 +145,8 @@ TPie::TPie(const TPie &cpy) : TNamed(cpy), TAttText(cpy)
 {
    Init(cpy.fNvals, cpy.fAngularOffset, cpy.fX, cpy.fY, cpy.fRadius);
 
-   for (Int_t i=0;i<fNvals;++i) {
-      fPieSlices[i] = cpy.fPieSlices[i];
-   }
+   for (Int_t i=0;i<fNvals;++i)
+      cpy.fPieSlices[i]->Copy(*fPieSlices[i]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPieSlice.cxx
+++ b/graf2d/graf/src/TPieSlice.cxx
@@ -65,7 +65,7 @@ Int_t TPieSlice::DistancetoPrimitive(Int_t /*px*/, Int_t /*py*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// return the value of the offset in radial direction for this slice.
 
-Double_t TPieSlice::GetRadiusOffset()
+Double_t TPieSlice::GetRadiusOffset() const
 {
    return fRadiusOffset;
 }
@@ -73,7 +73,7 @@ Double_t TPieSlice::GetRadiusOffset()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the value of this slice.
 
-Double_t TPieSlice::GetValue()
+Double_t TPieSlice::GetValue() const
 {
    return fValue;
 }
@@ -108,3 +108,19 @@ void TPieSlice::SetValue(Double_t val)
 
    fPie->MakeSlices(kTRUE);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// Copy TPieSlice
+
+void TPieSlice::Copy(TObject &obj) const
+{
+   auto &slice = (TPieSlice&)obj;
+
+   TNamed::Copy(slice);
+   TAttLine::Copy(slice);
+   TAttFill::Copy(slice);
+
+   slice.SetValue(GetValue());
+   slice.SetRadiusOffset(GetRadiusOffset());
+}
+

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -772,6 +772,8 @@ void TPolyLine::Streamer(TBuffer &b)
       b.CheckByteCount(R__s, R__c, TPolyLine::IsA());
       //====end of old versions
 
+      delete [] x;
+      delete [] y;
    } else {
       b.WriteClassBuffer(TPolyLine::Class(),this);
    }

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -47,8 +47,8 @@ End_Macro
 TPolyLine::TPolyLine(): TObject()
 {
    fN = 0;
-   fX = 0;
-   fY = 0;
+   fX = nullptr;
+   fY = nullptr;
    fLastPoint = -1;
 }
 
@@ -64,7 +64,7 @@ TPolyLine::TPolyLine(Int_t n, Option_t *option)
    if (n <= 0) {
       fN = 0;
       fLastPoint = -1;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN = n;
@@ -109,7 +109,7 @@ TPolyLine::TPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option)
    if (n <= 0) {
       fN = 0;
       fLastPoint = -1;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN = n;
@@ -146,8 +146,8 @@ TPolyLine::~TPolyLine()
 TPolyLine::TPolyLine(const TPolyLine &polyline) : TObject(polyline), TAttLine(polyline), TAttFill(polyline)
 {
    fN = 0;
-   fX = 0;
-   fY = 0;
+   fX = nullptr;
+   fY = nullptr;
    fLastPoint = -1;
    ((TPolyLine&)polyline).Copy(*this);
 }
@@ -168,8 +168,8 @@ void TPolyLine::Copy(TObject &obj) const
       ((TPolyLine&)obj).fY = new Double_t[fN];
       for (Int_t i=0; i<fN;i++)  {((TPolyLine&)obj).fX[i] = fX[i]; ((TPolyLine&)obj).fY[i] = fY[i];}
    } else {
-      ((TPolyLine&)obj).fX = 0;
-      ((TPolyLine&)obj).fY = 0;
+      ((TPolyLine&)obj).fX = nullptr;
+      ((TPolyLine&)obj).fY = nullptr;
    }
    ((TPolyLine&)obj).fOption = fOption;
    ((TPolyLine&)obj).fLastPoint = fLastPoint;
@@ -674,7 +674,7 @@ void TPolyLine::SetPolyLine(Int_t n)
       fLastPoint = -1;
       delete [] fX;
       delete [] fY;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    if (n < fN) {
@@ -697,7 +697,7 @@ void TPolyLine::SetPolyLine(Int_t n, Float_t *x, Float_t *y, Option_t *option)
       fLastPoint = -1;
       delete [] fX;
       delete [] fY;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN =n;
@@ -725,7 +725,7 @@ void TPolyLine::SetPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option)
       fLastPoint = -1;
       delete [] fX;
       delete [] fY;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN =n;


### PR DESCRIPTION
1. Fix error with copy and destroy of `TLatex::fTabSize`. Now it is `std::vector` and can be easily copied - if necessary. Also using as stack is much more convenient - just by using `emplace_back` and `pop_back`
2. Fix bug in `TPie` copy constructor
3. Fix memory leak with `TGaxis::fModLabs`. Array was never deleted and never copied properly. Extra problem because it may have pointer on list of labels from `TAxis`. Provide workaround for `TGaxis` objects stored before in ROOT files.
4. Use stack variables while painting - no need to call `new/delete` for simple objects like `TLine` or `TMarker`
5. Fix memory leak reading old version of TPolyLine
6. Use `TString::Form` instead of `snprinf`
7. Use `nullptr`