### PR TITLE
[DF] Improve encapsulation of RColumnRegister data members

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -20,6 +20,9 @@
 #include <vector>
 
 namespace ROOT {
+namespace RDF {
+class RVariationsDescription;
+}
 namespace Detail {
 namespace RDF {
 class RDefineBase;
@@ -81,9 +84,6 @@ public:
 
    ColumnNames_t GetDefineNames() const;
 
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Return the multimap of systematic variations, see fVariations.
-   const VariationsMap_t &GetVariations() const { return *fVariations; }
    RDFDetail::RDefineBase *GetDefine(const std::string &colName) const;
 
    bool IsDefineOrAlias(std::string_view name) const;
@@ -103,6 +103,8 @@ public:
    std::vector<std::string> GetVariationDeps(const std::string &column) const;
 
    std::vector<std::string> GetVariationDeps(const ColumnNames_t &columns) const;
+
+   ROOT::RDF::RVariationsDescription GetVariationsDescription() const;
 
    RVariationBase &FindVariation(const std::string &colName, const std::string &variationName) const;
 };

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -82,7 +82,7 @@ public:
    /// \brief Return the list of the names of the defined columns (Defines + Aliases).
    ColumnNames_t GetNames() const { return *fColumnNames; }
 
-   ColumnNames_t GetDefineNames() const;
+   ColumnNames_t BuildDefineNames() const;
 
    RDFDetail::RDefineBase *GetDefine(const std::string &colName) const;
 
@@ -104,7 +104,7 @@ public:
 
    std::vector<std::string> GetVariationDeps(const ColumnNames_t &columns) const;
 
-   ROOT::RDF::RVariationsDescription GetVariationsDescription() const;
+   ROOT::RDF::RVariationsDescription BuildVariationsDescription() const;
 
    RVariationBase &FindVariation(const std::string &colName, const std::string &variationName) const;
 };

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -79,13 +79,12 @@ public:
    /// \brief Return the list of the names of the defined columns (Defines + Aliases).
    ColumnNames_t GetNames() const { return *fColumnNames; }
 
-   ////////////////////////////////////////////////////////////////////////////
-   /// \brief Return a map of pointers to the defined columns.
-   const DefinesMap_t &GetDefines() const { return *fDefines; }
+   ColumnNames_t GetDefineNames() const;
 
    ////////////////////////////////////////////////////////////////////////////
    /// \brief Return the multimap of systematic variations, see fVariations.
    const VariationsMap_t &GetVariations() const { return *fVariations; }
+   RDFDetail::RDefineBase *GetDefine(const std::string &colName) const;
 
    bool IsDefineOrAlias(std::string_view name) const;
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2733,7 +2733,7 @@ public:
    {
       ColumnNames_t definedColumns;
 
-      const auto columns = fColRegister.GetDefineNames();
+      const auto columns = fColRegister.BuildDefineNames();
       for (const auto &column : columns) {
          if (!RDFInternal::IsInternalColumn(column))
             definedColumns.emplace_back(column);
@@ -2754,7 +2754,7 @@ public:
    /// variations.Print();
    /// ~~~
    ///
-   RVariationsDescription GetVariations() const { return fColRegister.GetVariationsDescription(); }
+   RVariationsDescription GetVariations() const { return fColRegister.BuildVariationsDescription(); }
 
    /// \brief Checks if a column is present in the dataset.
    /// \return true if the column is available, false otherwise

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2754,7 +2754,7 @@ public:
    /// variations.Print();
    /// ~~~
    ///
-   RVariationsDescription GetVariations() const { return {fColRegister.GetVariations()}; }
+   RVariationsDescription GetVariations() const { return fColRegister.GetVariationsDescription(); }
 
    /// \brief Checks if a column is present in the dataset.
    /// \return true if the column is available, false otherwise

--- a/tree/dataframe/inc/ROOT/RDF/RVariationsDescription.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationsDescription.hxx
@@ -15,7 +15,7 @@
 
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 namespace ROOT {
 namespace RDF {
@@ -23,7 +23,7 @@ namespace RDF {
 /// A descriptor for the systematic variations known to a given RDataFrame node.
 class RVariationsDescription {
    std::string fStringRepr;
-   using Variations_t = std::unordered_multimap<std::string, std::shared_ptr<ROOT::Internal::RDF::RVariationBase>>;
+   using Variations_t = std::vector<const ROOT::Internal::RDF::RVariationBase *>;
 
 public:
    RVariationsDescription(const Variations_t &variations);

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -83,12 +83,11 @@ public:
    {
       fLoopManager->Register(this);
 
-      const auto &defines = colRegister.GetDefines();
       for (auto i = 0u; i < columns.size(); ++i) {
-         auto it = defines.find(columns[i]);
-         fIsDefine[i] = it != defines.end();
+         auto *define = colRegister.GetDefine(columns[i]);
+         fIsDefine[i] = define != nullptr;
          if (fIsDefine[i])
-            (it->second)->MakeVariations(GetVariations());
+            define->MakeVariations(GetVariations());
       }
    }
 

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -9,6 +9,7 @@
 #include "ROOT/RDF/RColumnRegister.hxx"
 #include "ROOT/RDF/RDefineBase.hxx"
 #include "ROOT/RDF/RVariationBase.hxx"
+#include "ROOT/RDF/RVariationsDescription.hxx"
 #include "ROOT/RDF/Utils.hxx" // IsStrInVec
 
 #include <cassert>
@@ -141,6 +142,16 @@ RVariationBase &RColumnRegister::FindVariation(const std::string &colName, const
       ++it;
    assert(it != fVariations->end() && "Could not find the variation you asked for. This should never happen.");
    return *it->second;
+}
+
+ROOT::RDF::RVariationsDescription RColumnRegister::GetVariationsDescription() const
+{
+   std::set<const RVariationBase *> uniqueVariations;
+   for (auto &e : *fVariations)
+      uniqueVariations.insert(e.second.get());
+
+   const std::vector<const RVariationBase *> variations(uniqueVariations.begin(), uniqueVariations.end());
+   return ROOT::RDF::RVariationsDescription{variations};
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -31,6 +31,26 @@ RColumnRegister::~RColumnRegister()
 }
 
 ////////////////////////////////////////////////////////////////////////////
+/// \brief Return the list of the names of defined columns (no aliases).
+ColumnNames_t RColumnRegister::GetDefineNames() const
+{
+   ColumnNames_t names;
+   names.reserve(fDefines->size());
+   for (auto &kv : *fDefines) {
+      names.emplace_back(kv.first);
+   }
+   return names;
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Return the RDefine for the requested column name, or nullptr.
+RDFDetail::RDefineBase *RColumnRegister::GetDefine(const std::string &colName) const
+{
+   auto it = fDefines->find(colName);
+   return it == fDefines->end() ? nullptr : (it->second).get();
+}
+
+////////////////////////////////////////////////////////////////////////////
 /// \brief Check if the provided name is tracked in the names list
 bool RColumnRegister::IsDefineOrAlias(std::string_view name) const
 {

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -33,7 +33,7 @@ RColumnRegister::~RColumnRegister()
 
 ////////////////////////////////////////////////////////////////////////////
 /// \brief Return the list of the names of defined columns (no aliases).
-ColumnNames_t RColumnRegister::GetDefineNames() const
+ColumnNames_t RColumnRegister::BuildDefineNames() const
 {
    ColumnNames_t names;
    names.reserve(fDefines->size());
@@ -144,7 +144,7 @@ RVariationBase &RColumnRegister::FindVariation(const std::string &colName, const
    return *it->second;
 }
 
-ROOT::RDF::RVariationsDescription RColumnRegister::GetVariationsDescription() const
+ROOT::RDF::RVariationsDescription RColumnRegister::BuildVariationsDescription() const
 {
    std::set<const RVariationBase *> uniqueVariations;
    for (auto &e : *fVariations)

--- a/tree/dataframe/src/RDFGraphUtils.cxx
+++ b/tree/dataframe/src/RDFGraphUtils.cxx
@@ -72,10 +72,9 @@ GraphDrawing::AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRe
 {
    auto upmostNode = node;
    const auto &defineNames = colRegister.GetNames();
-   const auto &defineMap = colRegister.GetDefines();
    for (auto i = int(defineNames.size()) - 1; i >= 0; --i) { // walk backwards through the names of defined columns
       const auto colName = defineNames[i];
-      const bool isAlias = defineMap.find(colName) == defineMap.end();
+      const bool isAlias = colRegister.IsDefineOrAlias(colName) && colRegister.GetDefine(colName) == nullptr;
       if (isAlias || IsInternalColumn(colName))
          continue; // aliases appear in the list of defineNames but we don't support them yet
       const bool isANewDefine =
@@ -84,7 +83,7 @@ GraphDrawing::AddDefinesToGraph(std::shared_ptr<GraphNode> node, const RColumnRe
          break; // we walked back through all new defines, the rest is stuff that was already in the graph
 
       // create a node for this new Define
-      auto defineNode = RDFGraphDrawing::CreateDefineNode(colName, defineMap.at(colName).get(), visitedMap);
+      auto defineNode = RDFGraphDrawing::CreateDefineNode(colName, colRegister.GetDefine(colName), visitedMap);
       upmostNode->SetPrevNode(defineNode);
       upmostNode = defineNode;
    }

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -930,7 +930,7 @@ std::vector<std::string> GetValidatedArgTypes(const ColumnNames_t &colNames, con
                                               bool vector2rvec)
 {
    auto toCheckedArgType = [&](const std::string &c) {
-      RDFDetail::RDefineBase *define = colRegister.IsDefineOrAlias(c) ? colRegister.GetDefines().at(c).get() : nullptr;
+      RDFDetail::RDefineBase *define = colRegister.GetDefine(c);
       const auto colType = ColumnName2ColumnTypeName(c, tree, ds, define, vector2rvec);
       if (colType.rfind("CLING_UNKNOWN_TYPE", 0) == 0) { // the interpreter does not know this type
          const auto msg =

--- a/tree/dataframe/src/RDefineBase.cxx
+++ b/tree/dataframe/src/RDefineBase.cxx
@@ -32,7 +32,7 @@ RDefineBase::RDefineBase(std::string_view name, std::string_view type, const RDF
    for (auto i = 0u; i < nColumns; ++i) {
       fIsDefine[i] = fColRegister.IsDefineOrAlias(fColumnNames[i]);
       if (fVariation != "nominal" && fIsDefine[i])
-         fColRegister.GetDefines().at(fColumnNames[i])->MakeVariations({fVariation});
+         fColRegister.GetDefine(fColumnNames[i])->MakeVariations({fVariation});
    }
 }
 

--- a/tree/dataframe/src/RFilterBase.cxx
+++ b/tree/dataframe/src/RFilterBase.cxx
@@ -30,7 +30,7 @@ RFilterBase::RFilterBase(RLoopManager *implPtr, std::string_view name, const uns
    for (auto i = 0u; i < nColumns; ++i) {
       fIsDefine[i] = fColRegister.IsDefineOrAlias(fColumnNames[i]);
       if (fVariation != "nominal" && fIsDefine[i])
-         fColRegister.GetDefines().at(fColumnNames[i])->MakeVariations({fVariation});
+         fColRegister.GetDefine(fColumnNames[i])->MakeVariations({fVariation});
    }
 }
 

--- a/tree/dataframe/src/RVariationsDescription.cxx
+++ b/tree/dataframe/src/RVariationsDescription.cxx
@@ -11,21 +11,14 @@
 #include "ROOT/RDF/RVariationsDescription.hxx"
 
 #include <iostream>
-#include <unordered_set>
 
 namespace {
-static std::string GetStringRepr(
-   const std::unordered_multimap<std::string, std::shared_ptr<ROOT::Internal::RDF::RVariationBase>> &variationsMap)
+static std::string GetStringRepr(const std::vector<const ROOT::Internal::RDF::RVariationBase *> &variations)
 {
-   std::unordered_set<ROOT::Internal::RDF::RVariationBase*> uniqueVariations;
    std::string s;
 
-   for (const auto &e : variationsMap) {
-      const auto it = uniqueVariations.insert(e.second.get());
-      if (!it.second) // we have already seen this variation
-         continue;
-
-      const auto &variation = *e.second;
+   for (const auto &e : variations) {
+      const auto &variation = *e;
 
       s += "Variations {";
       for (const auto &tag : variation.GetVariationNames())
@@ -46,7 +39,7 @@ static std::string GetStringRepr(
    }
    return s;
 }
-} // namespace
+} // anonymous namespace
 
 namespace ROOT {
 namespace RDF {

--- a/tree/dataframe/src/RVariationsDescription.cxx
+++ b/tree/dataframe/src/RVariationsDescription.cxx
@@ -17,8 +17,8 @@ static std::string GetStringRepr(const std::vector<const ROOT::Internal::RDF::RV
 {
    std::string s;
 
-   for (const auto &e : variations) {
-      const auto &variation = *e;
+   for (const auto *varPtr : variations) {
+      const auto &variation = *varPtr;
 
       s += "Variations {";
       for (const auto &tag : variation.GetVariationNames())

--- a/tree/dataframe/src/RVariationsDescription.cxx
+++ b/tree/dataframe/src/RVariationsDescription.cxx
@@ -44,6 +44,7 @@ static std::string GetStringRepr(const std::vector<const ROOT::Internal::RDF::RV
 namespace ROOT {
 namespace RDF {
 
+// Pre-condition: elements in variations are expected to be unique.
 RVariationsDescription::RVariationsDescription(const Variations_t &variations) : fStringRepr(GetStringRepr(variations))
 {
 }


### PR DESCRIPTION
This simplifies client code and it makes it simpler to evolve RColumnRegister internals in the future, which will be needed e.g. for bulk processing in RDF.