### PR TITLE
[DF] Fix iteration over multimap

### DIFF
--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -117,9 +117,9 @@ RVariationBase &RColumnRegister::FindVariation(const std::string &colName, const
    auto range = fVariations->equal_range(colName);
    assert(range.first != fVariations->end() && "Could not find the variation you asked for. This should never happen.");
    auto it = range.first;
-   while (it != fVariations->end() && !IsStrInVec(variationName, it->second->GetVariationNames()))
+   while (it != range.second && !IsStrInVec(variationName, it->second->GetVariationNames()))
       ++it;
-   assert(it != fVariations->end() && "Could not find the variation you asked for. This should never happen.");
+   assert(it != range.second && "Could not find the variation you asked for. This should never happen.");
    return *it->second;
 }
 


### PR DESCRIPTION
Before this patch, we were iterating until the end of the map
rather than until the end of the equal_range (this was not a
problem in practice because program logic guaranteed that we would
find what we were looking for and break out of the loop early).