### PR TITLE
[RF] Avoid code duplication in RooFit addition classes

### DIFF
--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -27,10 +27,9 @@ class RooArgList ;
 class RooAddition : public RooAbsReal {
 public:
 
-  RooAddition() ;
+  RooAddition() : _cacheMgr(this,10) {}
   RooAddition(const char *name, const char *title, const RooArgList& sumSet, bool takeOwnerShip=false) ;
   RooAddition(const char *name, const char *title, const RooArgList& sumSet1, const RooArgList& sumSet2, bool takeOwnerShip=false) ;
-  ~RooAddition() override ;
 
   RooAddition(const RooAddition& other, const char* name = 0);
   TObject* clone(const char* newname) const override { return new RooAddition(*this, newname); }
@@ -66,10 +65,9 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-      ~CacheElem() override;
       // Payload
       RooArgList _I ;
-      RooArgList containedArgs(Action) override ;
+      RooArgList containedArgs(Action) override { return _I; }
   };
   mutable RooObjCacheManager _cacheMgr ; ///<! The cache manager
 

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -95,6 +95,8 @@ protected:
 
 private:
 
+  friend class RooAddPdf;
+  friend class RooAddition;
   friend class RooRealSumFunc;
 
   static void initializeFuncsAndCoefs(RooAbsReal const& caller,

--- a/roofit/roofitcore/src/RooRealSumPdf.cxx
+++ b/roofit/roofitcore/src/RooRealSumPdf.cxx
@@ -602,8 +602,7 @@ bool RooRealSumPdf::isBinnedDistribution(const RooArgSet& obs) const
 
 bool RooRealSumPdf::isBinnedDistribution(RooArgList const& funcList, const RooArgSet& obs)
 {
-  for (const auto elm : funcList) {
-    auto func = static_cast<RooAbsReal*>(elm);
+  for (auto* func : static_range_cast<RooAbsReal*>(funcList)) {
 
     if (func->dependsOn(obs) && !func->isBinnedDistribution(obs)) {
       return false ;
@@ -624,7 +623,7 @@ std::list<double>* RooRealSumPdf::plotSamplingHint(RooAbsRealLValue& obs, double
 
 std::list<double>* RooRealSumPdf::plotSamplingHint(RooArgList const& funcList, RooAbsRealLValue& obs, double xlo, double xhi)
 {
-  std::list<double>* sumHint = 0 ;
+  std::list<double>* sumHint = nullptr;
   bool needClean(false) ;
 
   // Loop over components pdf
@@ -642,7 +641,7 @@ std::list<double>* RooRealSumPdf::plotSamplingHint(RooArgList const& funcList, R
 
       } else {
 
-   list<double>* newSumHint = new list<double>(sumHint->size()+funcHint->size()) ;
+   auto* newSumHint = new std::list<double>(sumHint->size()+funcHint->size()) ;
 
    // Merge hints into temporary array
    merge(funcHint->begin(),funcHint->end(),sumHint->begin(),sumHint->end(),newSumHint->begin()) ;


### PR DESCRIPTION
Much of the functionality of RooAddition and RooAddPdf is implemented in exactly the
same way as in RooRealSumPdf. Hence, to avoid code duplication, we can
reuse the static functions in RooRealSumPdf that provide this
implementation.
