### PR TITLE
Protect `strlen(nullptr)` in gpad and graf classes, improve/simplify TMultiGraph "pads" drawing

### DIFF
--- a/graf2d/gpad/src/TButton.cxx
+++ b/graf2d/gpad/src/TButton.cxx
@@ -95,12 +95,12 @@ Executing the macro above produces the following dialog canvas:
 
 TButton::TButton(): TPad()
 {
-   fFraming = 0;
+   fFraming = kFALSE;
    fMethod  = "";
    fLogx    = kFALSE;
    fLogy    = kFALSE;
    SetEditable(kFALSE);
-   fFocused = 0;
+   fFocused = kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -111,18 +111,18 @@ TButton::TButton(): TPad()
 TButton::TButton(const char *title, const char *method, Double_t x1, Double_t y1,Double_t x2, Double_t  y2)
            :TPad("button",title,x1,y1,x2,y2,18,2,1), TAttText(22,0,1,61,0.65)
 {
-   fFraming=0;
+   fFraming = kFALSE;
    SetBit(kCanDelete);
    fModified = kTRUE;
    fMethod = method;
-   if (strlen(title)) {
-      TLatex *text = new TLatex(0.5*(fX1+fX2),0.5*(fY1+fY2),title);
+   if (title && strlen(title)) {
+      TLatex *text = new TLatex(0.5 * (fX1 + fX2), 0.5 * (fY1 + fY2), title);
       fPrimitives->Add(text);
    }
    fLogx    = kFALSE;
    fLogy    = kFALSE;
    SetEditable(kFALSE);
-   fFocused = 0;
+   fFocused = kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -167,7 +167,7 @@ void TButton::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
    case kButton1Down:
       SetBorderMode(-1);
-      fFocused=1;
+      fFocused = kTRUE;
       Modified();
       Update();
       break;
@@ -181,14 +181,14 @@ void TButton::ExecuteEvent(Int_t event, Int_t px, Int_t py)
           py<YtoAbsPixel(0) && py>YtoAbsPixel(1)) {
          if (!fFocused) {
             SetBorderMode(-1);
-            fFocused=1;
+            fFocused = kTRUE;
             Modified();
             GetCanvas()->Modified();
             Update();
          }
       } else if (fFocused) {
          SetBorderMode(1);
-         fFocused=0;
+         fFocused = kFALSE;
          Modified();
          GetCanvas()->Modified();
          Update();
@@ -275,7 +275,7 @@ void TButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    } else {
       out<<"   TButton *";
    }
-   char *cm = (char*)GetMethod();
+   const char *cm = GetMethod();
    Int_t nch = strlen(cm);
    char *cmethod = new char[nch+10];
    Int_t i = 0;
@@ -333,7 +333,7 @@ void TButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 
 void TButton::SetFraming(Bool_t f)
 {
-   fFraming=f;
+   fFraming = f;
    if (f) SetBit(kFraming);
    else   ResetBit(kFraming);
 }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -505,19 +505,19 @@ TLegend *TPad::BuildLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
    TLegend *leg = nullptr;
    TIter next(lop);
    TString mes;
-   TString opt("");
+   TString opt;
    while(auto o = next()) {
       if ((o->InheritsFrom(TAttLine::Class()) || o->InheritsFrom(TAttMarker::Class()) ||
           o->InheritsFrom(TAttFill::Class())) &&
          ( !(o->InheritsFrom(TFrame::Class())) && !(o->InheritsFrom(TPave::Class())) )) {
             if (!leg) leg = new TLegend(x1, y1, x2, y2, title);
-            if (o->InheritsFrom(TNamed::Class()) && strlen(((TNamed *)o)->GetTitle()))
-               mes = ((TNamed *)o)->GetTitle();
+            if (o->InheritsFrom(TNamed::Class()) && strlen(o->GetTitle()))
+               mes = o->GetTitle();
             else if (strlen(o->GetName()))
                mes = o->GetName();
             else
                mes = o->ClassName();
-            if (strlen(option)) {
+            if (option && strlen(option)) {
                opt = option;
             } else {
                if (o->InheritsFrom(TAttLine::Class()))   opt += "l";
@@ -536,7 +536,7 @@ TLegend *TPad::BuildLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
             if      (strlen(gr->GetTitle())) mes = gr->GetTitle();
             else if (strlen(gr->GetName()))  mes = gr->GetName();
             else                             mes = gr->ClassName();
-            if (strlen(option))              opt = option;
+            if (option && strlen(option))    opt = option;
             else                             opt = "lpf";
             leg->AddEntry( obj, mes.Data(), opt );
          }
@@ -544,14 +544,12 @@ TLegend *TPad::BuildLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
          if (!leg) leg = new TLegend(x1, y1, x2, y2, title);
          TList * hlist = ((THStack *)o)->GetHists();
          TIter nexthist(hlist);
-         TH1 * hist;
-         TObject * obj;
-         while ((obj = nexthist())) {
-            hist = (TH1*) obj;
+         while (auto obj = nexthist()) {
+            TH1 *hist = (TH1*) obj;
             if      (strlen(hist->GetTitle())) mes = hist->GetTitle();
             else if (strlen(hist->GetName()))  mes = hist->GetName();
             else                               mes = hist->ClassName();
-            if (strlen(option))                opt = option;
+            if (option && strlen(option))      opt = option;
             else                               opt = "lpf";
             leg->AddEntry( obj, mes.Data(), opt );
          }
@@ -6868,15 +6866,15 @@ TObject *TPad::WaitPrimitive(const char *pname, const char *emode)
 {
    if (!gPad) return nullptr;
 
-   if (strlen(emode)) gROOT->SetEditorMode(emode);
-   if (gROOT->GetEditorMode() == 0 && strlen(pname) > 2) gROOT->SetEditorMode(&pname[1]);
+   if (emode && strlen(emode)) gROOT->SetEditorMode(emode);
+   if (gROOT->GetEditorMode() == 0 && pname && strlen(pname) > 2) gROOT->SetEditorMode(&pname[1]);
 
    if (!fPrimitives) fPrimitives = new TList;
    gSystem->ProcessEvents();
    TObject *oldlast = gPad->GetListOfPrimitives() ? gPad->GetListOfPrimitives()->Last() : nullptr;
    TObject *obj = nullptr;
    Bool_t testlast = kFALSE;
-   Bool_t hasname = strlen(pname) > 0;
+   Bool_t hasname = pname && (strlen(pname) > 0);
    if (!pname[0] && !emode[0]) testlast = kTRUE;
    if (testlast) gROOT->SetEditorMode();
    while (!gSystem->ProcessEvents() && gROOT->GetSelectedPad() && gPad) {

--- a/graf2d/graf/src/TPaveLabel.cxx
+++ b/graf2d/graf/src/TPaveLabel.cxx
@@ -102,7 +102,7 @@ void TPaveLabel::Paint(Option_t *option)
    // Convert from NDC to pad coordinates
    TPave::ConvertNDCtoPad();
 
-   PaintPaveLabel(fX1, fY1, fX2, fY2, GetLabel(), strlen(option)?option:GetOption());
+   PaintPaveLabel(fX1, fY1, fX2, fY2, GetLabel(), option && strlen(option) ? option : GetOption());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -112,7 +112,7 @@ void TPaveLabel::PaintPaveLabel(Double_t x1, Double_t y1,Double_t x2, Double_t  
                       const char *label ,Option_t *option)
 {
    if (!gPad) return;
-   Int_t nch = strlen(label);
+   Int_t nch = label ? strlen(label) : 0;
 
    // Draw the pave
    TPave::PaintPave(x1,y1,x2,y2,GetBorderSize(),option);

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -187,7 +187,7 @@ TText *TPaveText::AddText(Double_t x1, Double_t y1, const char *text)
    newtext->SetTextColor(0);
    newtext->SetTextFont(0);
    newtext->SetTextSize(0);
-   Int_t nch = strlen(text);
+   Int_t nch = text ? strlen(text) : 0;
    if (nch > fLongest) fLongest = nch;
 
    if (!fLines) fLines = new TList;
@@ -603,16 +603,15 @@ void TPaveText::ReadFile(const char *filename, Option_t *option, Int_t nlines, I
    }
    SetTextAlign(12);
    // Get file name
-   Int_t nch = strlen(filename);
-   if (nch == 0) return;
+   TString fname = filename;
+   if (fname.EndsWith(";"))
+      fname.Resize(fname.Length() - 1);
+   if (fname.Length() == 0)
+      return;
 
-   char *fname = StrDup(filename);
-   if (fname[nch-1] == ';') { nch--; fname[nch]=0;}
-
-   std::ifstream file(fname,std::ios::in);
+   std::ifstream file(fname.Data(),std::ios::in);
    if (!file.good()) {
-      Error("ReadFile", "illegal file name");
-      delete [] fname;
+      Error("ReadFile", "illegal file name %s", fname.Data());
       return;
    }
 
@@ -664,7 +663,6 @@ void TPaveText::ReadFile(const char *filename, Option_t *option, Int_t nlines, I
       kline++;
    }
    file.close();
-   delete [] fname;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -529,11 +529,11 @@ Int_t TPolyLine::Merge(TCollection *li)
 void TPolyLine::Paint(Option_t *option)
 {
    if (TestBit(kPolyLineNDC)) {
-      if (strlen(option) > 0) PaintPolyLineNDC(fLastPoint+1, fX, fY, option);
-      else                    PaintPolyLineNDC(fLastPoint+1, fX, fY, fOption.Data());
+      if (option && strlen(option)) PaintPolyLineNDC(fLastPoint+1, fX, fY, option);
+      else                          PaintPolyLineNDC(fLastPoint+1, fX, fY, fOption.Data());
    } else {
-      if (strlen(option) > 0) PaintPolyLine(fLastPoint+1, fX, fY, option);
-      else                    PaintPolyLine(fLastPoint+1, fX, fY, fOption.Data());
+      if (option && strlen(option)) PaintPolyLine(fLastPoint+1, fX, fY, option);
+      else                          PaintPolyLine(fLastPoint+1, fX, fY, fOption.Data());
    }
 }
 
@@ -545,8 +545,7 @@ void TPolyLine::Paint(Option_t *option)
 
 void TPolyLine::PaintPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option)
 {
-   if (!gPad) return;
-   if (n <= 0) return;
+   if (!gPad || n <= 0) return;
    TAttLine::Modify();  //Change line attributes only if necessary
    TAttFill::Modify();  //Change fill area attributes only if necessary
    Double_t *xx = x;
@@ -559,10 +558,14 @@ void TPolyLine::PaintPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *optio
       yy = new Double_t[n];
       for (Int_t iy=0;iy<n;iy++) yy[iy] = gPad->YtoPad(y[iy]);
    }
-   if (*option == 'f' || *option == 'F') gPad->PaintFillArea(n,xx,yy,option);
-   else                                  gPad->PaintPolyLine(n,xx,yy,option);
-   if (x != xx) delete [] xx;
-   if (y != yy) delete [] yy;
+   if (option && (*option == 'f' || *option == 'F'))
+      gPad->PaintFillArea(n, xx, yy, option);
+   else
+      gPad->PaintPolyLine(n, xx, yy, option);
+   if (x != xx)
+      delete[] xx;
+   if (y != yy)
+      delete[] yy;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1366,17 +1366,17 @@ void TMultiGraph::Paint(Option_t *choptin)
 
 void TMultiGraph::PaintPads(Option_t *option)
 {
-   TIter next(fGraphs);
+   if (!gPad) return;
+
    Int_t neededPads = fGraphs->GetSize();
    Int_t existingPads = 0;
-   TString opt = (TString)option;
 
    TVirtualPad *curPad = gPad;
-   TObject *obj;
    TIter nextPad(curPad->GetListOfPrimitives());
 
-   while ((obj = nextPad())) {
-      if (obj->InheritsFrom(TVirtualPad::Class())) existingPads++;
+   while (auto obj = nextPad()) {
+      if (obj->InheritsFrom(TVirtualPad::Class()))
+         existingPads++;
    }
    if (existingPads < neededPads) {
       curPad->Clear();
@@ -1388,20 +1388,13 @@ void TMultiGraph::PaintPads(Option_t *option)
    }
    Int_t i = 0;
 
-   TObjOptLink *lnk = (TObjOptLink*)fGraphs->FirstLink();
-
-   while (lnk) {
-      TGraph *g = (TGraph*)lnk->GetObject();
-      i++;
-      curPad->cd(i);
-      TString apopt = lnk->GetOption();
-      if (strlen(apopt)) {
-         g->Draw((apopt.Append("A")).Data());
-      } else {
-         if (strlen(opt)) g->Draw(opt.Append("A"));
-         else             g->Draw("LA");
-      }
-      lnk = (TObjOptLink*)lnk->Next();
+   TIter nextGraph(fGraphs);
+   while (auto g = (TGraph *) nextGraph()) {
+      curPad->cd(++i);
+      TString apopt = nextGraph.GetOption();
+      if ((apopt.Length() == 0) && option) apopt = option;
+      if (apopt.Length() == 0) apopt = "L";
+      g->Draw(apopt.Append("A").Data());
    }
 
    curPad->cd();


### PR DESCRIPTION
System crashes when calling `strlen(nullptr)`,  therefore protect in cases when argument can be directly set as external parameter

Simplify TMultiGraph::PaintPads, do not use `TString` as `strlen()` argument