### PR TITLE
Protect `strlen(nullptr)` in hist classes, fix memory leak in TF1 constructor

### DIFF
--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -618,11 +618,11 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       // Go char-by-char to split terms and define the relevant functions
       int parenCount = 0;
       int termStart = 0;
-      TObjArray *newFuncs = new TObjArray();
-      newFuncs->SetOwner(kTRUE);
-      TObjArray *coeffNames = new TObjArray();
-      coeffNames->SetOwner(kTRUE);
-      TString fullFormula("");
+      TObjArray newFuncs;
+      newFuncs.SetOwner(kTRUE);
+      TObjArray coeffNames;
+      coeffNames.SetOwner(kTRUE);
+      TString fullFormula;
       for (int i = 0; i < formDense.Length(); ++i) {
          if (formDense[i] == '(')
             parenCount++;
@@ -630,11 +630,11 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
             parenCount--;
          else if (formDense[i] == delimiter && parenCount == 0) {
             // term goes from termStart to i
-            DefineNSUMTerm(newFuncs, coeffNames, fullFormula, formDense, termStart, i, xmin, xmax);
+            DefineNSUMTerm(&newFuncs, &coeffNames, fullFormula, formDense, termStart, i, xmin, xmax);
             termStart = i + 1;
          }
       }
-      DefineNSUMTerm(newFuncs, coeffNames, fullFormula, formDense, termStart, formDense.Length(), xmin, xmax);
+      DefineNSUMTerm(&newFuncs, &coeffNames, fullFormula, formDense, termStart, formDense.Length(), xmin, xmax);
 
       TF1NormSum *normSum = new TF1NormSum(fullFormula, xmin, xmax);
 
@@ -651,9 +651,8 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
 
       // Parameter names
       for (int i = 0; i < fNpar; i++) {
-         if (coeffNames->At(i)) {
-            TString coeffName = ((TObjString *)coeffNames->At(i))->GetString();
-            this->SetParName(i, coeffName.Data());
+         if (coeffNames.At(i)) {
+            this->SetParName(i, coeffNames.At(i)->GetName());
          } else {
             this->SetParName(i, normSum->GetParName(i));
          }

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -523,16 +523,16 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
    TNamed(name, formula), TAttLine(), TAttFill(), TAttMarker(), fType(EFType::kFormula)
 {
    if (xmin < xmax) {
-      fXmin      = xmin;
-      fXmax      = xmax;
+      fXmin = xmin;
+      fXmax = xmax;
    } else {
-      fXmin = xmax; //when called from TF2,TF3
+      fXmin = xmax; // when called from TF2,TF3
       fXmax = xmin;
    }
    // Create rep formula (no need to add to gROOT list since we will add the TF1 object)
-   const auto formulaLength = strlen(formula);
+   const auto formulaLength = formula ? strlen(formula) : 0;
    // First check if we are making a convolution
-   if (strncmp(formula, "CONV(", 5) == 0 && formula[formulaLength - 1] == ')') {
+   if (formulaLength > 5 && strncmp(formula, "CONV(", 5) == 0 && formula[formulaLength - 1] == ')') {
       // Look for single ',' delimiter
       int delimPosition = -1;
       int parenCount = 0;
@@ -559,15 +559,15 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       formula2.ReplaceAll(' ', "");
 
       TF1 *function1 = (TF1 *)(gROOT->GetListOfFunctions()->FindObject(formula1));
-      if (function1 == nullptr)
-         function1 = new TF1((const char *)formula1, (const char *)formula1, xmin, xmax);
+      if (!function1)
+         function1 = new TF1(formula1.Data(), formula1.Data(), xmin, xmax);
       TF1 *function2 = (TF1 *)(gROOT->GetListOfFunctions()->FindObject(formula2));
-      if (function2 == nullptr)
-         function2 = new TF1((const char *)formula2, (const char *)formula2, xmin, xmax);
+      if (!function2)
+         function2 = new TF1(formula2.Data(), formula2.Data(), xmin, xmax);
 
       // std::cout << "functions have been defined" << std::endl;
 
-      TF1Convolution *conv = new TF1Convolution(function1, function2,xmin,xmax);
+      TF1Convolution *conv = new TF1Convolution(function1, function2, xmin, xmax);
 
       // (note: currently ignoring `useFFT` option)
       fNpar = conv->GetNpar();
@@ -576,7 +576,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       fType = EFType::kCompositionFcn;
       fComposition = std::unique_ptr<TF1AbsComposition>(conv);
 
-      fParams = std::unique_ptr<TF1Parameters>(new TF1Parameters(fNpar)); // default to zeros (TF1Convolution has no GetParameters())
+      fParams = std::make_unique<TF1Parameters>(fNpar); // default to zeros (TF1Convolution has no GetParameters())
       // set parameter names
       for (int i = 0; i < fNpar; i++)
          this->SetParName(i, conv->GetParName(i));
@@ -605,7 +605,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       }
 
       // Then check if we need NSUM syntax:
-   } else if (strncmp(formula, "NSUM(", 5) == 0 && formula[formulaLength - 1] == ')') {
+   } else if (formulaLength > 5 && strncmp(formula, "NSUM(", 5) == 0 && formula[formulaLength - 1] == ')') {
       // using comma as delimiter
       char delimiter = ',';
       // first, remove "NSUM(" and ")" and spaces
@@ -646,21 +646,21 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
       fType = EFType::kCompositionFcn;
       fComposition = std::unique_ptr<TF1AbsComposition>(normSum);
 
-      fParams = std::unique_ptr<TF1Parameters>(new TF1Parameters(fNpar));
+      fParams = std::make_unique<TF1Parameters>(fNpar);
       fParams->SetParameters(&(normSum->GetParameters())[0]); // inherit default parameters from normSum
 
       // Parameter names
       for (int i = 0; i < fNpar; i++) {
-         if (coeffNames->At(i) != nullptr) {
+         if (coeffNames->At(i)) {
             TString coeffName = ((TObjString *)coeffNames->At(i))->GetString();
-            this->SetParName(i, (const char *)coeffName);
+            this->SetParName(i, coeffName.Data());
          } else {
             this->SetParName(i, normSum->GetParName(i));
          }
       }
 
    } else { // regular TFormula
-      fFormula = std::unique_ptr<TFormula>(new TFormula(name, formula, false, vectorize));
+      fFormula = std::make_unique<TFormula>(name, formula, false, vectorize);
       fNpar = fFormula->GetNpar();
       // TFormula can have dimension zero, but since this is a TF1 minimal dim is 1
       fNdim = fFormula->GetNdim() == 0 ? 1 : fFormula->GetNdim();
@@ -679,7 +679,9 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, EA
 
    DoInitialize(addToGlobList);
 }
-TF1::EAddToList GetGlobalListOption(Option_t * opt)  {
+
+TF1::EAddToList GetGlobalListOption(Option_t * opt)
+{
    if (opt == nullptr) return TF1::EAddToList::kDefault;
    TString option(opt);
    option.ToUpper();
@@ -687,13 +689,16 @@ TF1::EAddToList GetGlobalListOption(Option_t * opt)  {
    if (option.Contains("GL")) return TF1::EAddToList::kAdd;
    return TF1::EAddToList::kDefault;
 }
-bool GetVectorizedOption(Option_t * opt)  {
-   if (opt == nullptr) return false;
+
+bool GetVectorizedOption(Option_t * opt)
+{
+   if (!opt) return false;
    TString option(opt);
    option.ToUpper();
    if (option.Contains("VEC")) return true;
    return false;
 }
+
 TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, Option_t * opt) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Same constructor as above (for TFormula based function) but passing an option strings
@@ -705,6 +710,7 @@ TF1::TF1(const char *name, const char *formula, Double_t xmin, Double_t xmax, Op
 ///////////////////////////////////////////////////////////////////////////////////
    TF1(name, formula, xmin, xmax, GetGlobalListOption(opt), GetVectorizedOption(opt) )
 {}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// F1 constructor using name of an interpreted function.
 ///

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -453,7 +453,8 @@ TFormula::TFormula()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-static bool IsReservedName(const char* name){
+static bool IsReservedName(const char* name)
+{
    if (strlen(name)!=1) return false;
    for (auto const & specialName : {"x","y","z","t"}){
       if (strcmp(name,specialName)==0) return true;

--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -191,7 +191,7 @@ TFormula::TFormula(const char *name,const char *expression) :
 
    //eliminate blanks in expression
    Int_t i,j,nch;
-   nch = strlen(expression);
+   nch = expression ? strlen(expression) : 0;
    char *expr = new char[nch+1];
    j = 0;
    for (i=0;i<nch;i++) {

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -822,7 +822,7 @@ void TGraph::Draw(Option_t *option)
 
    // If no option is specified, it is defined as "alp" in case there
    // no current pad or if the current pad as no axis defined.
-   if (!strlen(option)) {
+   if (!option || !strlen(option)) {
       if (gPad) {
          if (!gPad->GetListOfPrimitives()->FindObject("TFrame")) opt = "alp";
       } else {

--- a/hist/hist/src/TGraphTime.cxx
+++ b/hist/hist/src/TGraphTime.cxx
@@ -174,7 +174,7 @@ void TGraphTime::Paint(Option_t *option)
 void TGraphTime::SaveAnimatedGif(const char *filename) const
 {
    TObject *frame = gPad->GetPrimitive("frame");
-   TList *list = 0;
+   TList *list = nullptr;
    TObjLink *lnk;
 
    for (Int_t s=0;s<fNsteps;s++) {
@@ -190,9 +190,12 @@ void TGraphTime::SaveAnimatedGif(const char *filename) const
             lnk = lnk->Next();
          }
          gPad->Update();
-         if (strlen(filename) > 0) gPad->Print(Form("%s+",filename));
-         else                      gPad->Print(Form("%s+",GetName()));
-         if (fSleepTime > 0) gSystem->Sleep(fSleepTime);
+         if (filename && strlen(filename) > 0)
+            gPad->Print(Form("%s+", filename));
+         else
+            gPad->Print(Form("%s+", GetName()));
+         if (fSleepTime > 0)
+            gSystem->Sleep(fSleepTime);
       }
    }
 }

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -6202,8 +6202,10 @@ void TH1::Paint(Option_t *option)
    GetPainter(option);
 
    if (fPainter) {
-      if (strlen(option) > 0) fPainter->Paint(option);
-      else                    fPainter->Paint(fOption.Data());
+      if (option && strlen(option) > 0)
+         fPainter->Paint(option);
+      else
+         fPainter->Paint(fOption.Data());
    }
 }
 

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1132,7 +1132,7 @@ void TMultiGraph::Paint(Option_t *choptin)
 
    char option[128];
    strlcpy(option,choptin,128);
-   Int_t nch = strlen(choptin);
+   Int_t nch = choptin ? strlen(choptin) : 0;
    for (Int_t i=0;i<nch;i++) option[i] = toupper(option[i]);
 
    // Automatic color

--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -271,7 +271,7 @@ TPrincipal::TPrincipal(Int_t nVariables, Option_t *opt)
    fIsNormalised       = kFALSE;
    fNumberOfDataPoints = 0;
    fNumberOfVariables  = nVariables;
-   while (strlen(opt) > 0) {
+   while (opt && strlen(opt) > 0) {
       switch(*opt++) {
          case 'N':
          case 'n':
@@ -580,7 +580,7 @@ void TPrincipal::MakeHistograms(const char *name, Option_t *opt)
    Bool_t makeE  = kFALSE;
    Bool_t makeS  = kFALSE;
 
-   Int_t len     = strlen(opt);
+   Int_t len     = opt ? strlen(opt) : 0;
    Int_t i,j,k;
    for (i = 0; i < len; i++) {
       switch (opt[i]) {
@@ -1090,7 +1090,7 @@ void TPrincipal::Print(Option_t *opt) const
    Bool_t printS = kFALSE;
    Bool_t printE = kFALSE;
 
-   Int_t len     = strlen(opt);
+   Int_t len     = opt ? strlen(opt) : 0;
    for (Int_t i = 0; i < len; i++) {
       switch (opt[i]) {
          case 'V':

--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -1820,7 +1820,7 @@ TProfile2D * TProfile2D::Rebin2D(Int_t nxgroup ,Int_t nygroup,const char * newna
    }
    //nxgroup == nygroup == 1
    else{
-      if((newname) && (strlen(newname) > 0))
+      if(newname && (strlen(newname) > 0))
          return (TProfile2D*)Clone(newname);
       else
          return this;


### PR DESCRIPTION
System crashes when calling `strlen(nullptr)`, therefore protect in cases when argument can be directly set as external parameter.

Fix memory leak in TF1 constructor NSUM(...) parsing - created objects are not deleted

Use `std::make_unique<>()` to create `unique_ptr`. Provided as standard from c++14.

Use `TString::Data() ` instead of casting into `(const char *)`