### PR TITLE
[RF] Fix dirty flag resetting when the normalization set is changed

### DIFF
--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1390,6 +1390,10 @@ void RooAbsArg::setProxyNormSet(const RooArgSet* nset)
   for ( auto& p : _proxyListCache.cache ) {
     p->changeNormSet(nset);
   }
+
+  // If the proxy normSet changed, we also have to set our value dirty flag.
+  // Otherwise, value for the new normalization set might not get recomputed!
+  setValueDirty();
 }
 
 

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -2,6 +2,7 @@
 // Authors: Stephan Hageboeck, CERN 04/2020
 //          Jonas Rembser, CERN 04/2021
 
+#include <RooAddition.h>
 #include <RooAddPdf.h>
 #include <RooCategory.h>
 #include <RooConstVar.h>
@@ -327,4 +328,22 @@ TEST(RooAbsPdf, ProblemsWith2DSimultaneousFit)
    simPdf.addPdf(model, "cat1");
 
    simPdf.fitTo(data, PrintLevel(-1));
+}
+
+// Verifies that a server pdf gets correctly reevaluated when the normalization
+// set is changed.
+TEST(RooAbsPdf, NormSetChange)
+{
+   using namespace RooFit;
+
+   RooRealVar x("x", "x", 0, -10, 10);
+   RooGaussian gauss("gauss", "gauss", x, RooConst(0), RooConst(2));
+   RooAddition add("add", "add",  {gauss});
+
+   double v1 = add.getVal();
+   double v2 = add.getVal(x);
+
+   // The change of normalization set should trigger a recomputation of the
+   // value, so val2 should be different from val1. }
+   EXPECT_NE(v1, v2);
 }


### PR DESCRIPTION
If the proxy normSet changed, we also have to set the value dirty flag
of the proxy owner. Otherwise, value for the new normalization set might
not get recomputed, which causes bugs!

The issue can be reproduced with this small code snippet:

```C++
using namespace RooFit;

RooRealVar x("x", "x", 0, -10, 10);
RooGaussian gauss("gauss", "gauss", x, RooConst(0), RooConst(2));
RooAddition add("add", "add",  {gauss});

std::cout << add.getVal() << std::endl;
std::cout << add.getVal(x) << std::endl;
```

Without this commit, the value will be the same with and without
normalization set, because changing only the normalization set didn't
trigger a recomputation.

This code snippet has also been implemented as a unit test now, where it
is tested that the values are different.

