### PR TITLE
[ntuple,daos] Support RW operations with multiple attribute keys

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -33,32 +33,10 @@
 #define DAOS_UUID_STR_SIZE 37
 #endif
 
-namespace std {
-// Required by `std::unordered_map<daos_obj_id, ...>`. Based on boost::hash_combine().
-template <>
-struct hash<daos_obj_id_t> {
-   std::size_t operator()(const daos_obj_id_t &oid) const
-   {
-      auto seed = std::hash<uint64_t>{}(oid.lo);
-      seed ^= std::hash<uint64_t>{}(oid.hi) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-      return seed;
-   }
-};
-inline bool operator==(const daos_obj_id_t &lhs, const daos_obj_id_t &rhs)
-{
-   return (lhs.lo == rhs.lo) && (lhs.hi == rhs.hi);
-}
-} // namespace std
-
 namespace ROOT {
 
 namespace Experimental {
 namespace Detail {
-
-inline bool operator!=(daos_obj_id_t &lhs, daos_obj_id_t &rhs)
-{
-   return !((lhs.lo == rhs.lo) && (lhs.hi == rhs.hi));
-}
 
 struct RDaosEventQueue {
    daos_handle_t fQueue;
@@ -173,34 +151,46 @@ public:
    using AttributeKey_t = RDaosObject::AttributeKey_t;
    using ObjClassId_t = RDaosObject::ObjClassId;
 
+   /// \brief A pair of <object ID, distribution key> that can be used to issue a fetch/update request for multiple
+   /// attribute keys.
+   struct ROidDkeyPair {
+      daos_obj_id_t oid{};
+      DistributionKey_t dkey{};
+      ROidDkeyPair() = default;
+
+      inline bool operator==(const ROidDkeyPair &other) const
+      {
+         return this->oid.lo == other.oid.lo && this->oid.hi == other.oid.hi && this->dkey == other.dkey;
+      }
+
+      struct Hash {
+         auto operator()(const ROidDkeyPair &x) const
+         {
+            /// Implementation borrowed from `boost::hash_combine`. Comparable to initial seeding with `oid.hi` followed
+            /// by two subsequent hash calls for `oid.lo` and `dkey`.
+            auto seed = std::hash<uint64_t>{}(x.oid.hi);
+            seed ^= std::hash<uint64_t>{}(x.oid.lo) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            seed ^= std::hash<DistributionKey_t>{}(x.dkey) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+            return seed;
+         }
+      };
+   };
+
    /// \brief Describes a read/write operation on multiple objects; see the `ReadV`/`WriteV` functions.
    struct RWOperation {
       RWOperation() = default;
       RWOperation(daos_obj_id_t o, DistributionKey_t d, std::vector<AttributeKey_t> &&as, std::vector<d_iov_t> &&vs)
          : fOid(o), fDistributionKey(d), fAttributeKeys(std::move(as)), fIovs(std::move(vs)){};
+      RWOperation(ROidDkeyPair &k) : fOid(k.oid), fDistributionKey(k.dkey){};
       daos_obj_id_t fOid{};
       DistributionKey_t fDistributionKey{};
       std::vector<AttributeKey_t> fAttributeKeys{};
       std::vector<d_iov_t> fIovs{};
 
-      /// \brief Inserts a new pair of attribute key and I/O operation vector, provided that the object ID and
-      /// distribution key match the structure's. Initializes object ID and distribution key if there are none.
-      /// \return 0 on successful insertion, otherwise -1
-      int insert(daos_obj_id_t oid, DistributionKey_t dist, AttributeKey_t attr, d_iov_t &vec)
+      void insert(AttributeKey_t attr, d_iov_t &vec)
       {
-         // Initialize oid and dkey if this is the first attribute key
-         if (fAttributeKeys.empty()) {
-            fOid = oid;
-            fDistributionKey = dist;
-         }
-
-         // Enforce single oid and dkey per `RWOperation`
-         if (fOid != oid || fDistributionKey != dist)
-            return -1;
-
          fAttributeKeys.emplace_back(attr);
          fIovs.emplace_back(vec);
-         return 0;
       }
    };
 
@@ -221,8 +211,8 @@ private:
      \param fn Either `&RDaosObject::Fetch` (read) or `&RDaosObject::Update` (write).
      \return 0 if the operation succeeded; a negative DAOS error number otherwise.
      */
-   int VectorReadWrite(std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation> &map,
-                       ObjClassId_t cid, int (RDaosObject::*fn)(RDaosObject::FetchUpdateArgs &));
+   int VectorReadWrite(std::unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash> &map, ObjClassId_t cid,
+                       int (RDaosObject::*fn)(RDaosObject::FetchUpdateArgs &));
 
 public:
    RDaosContainer(std::shared_ptr<RDaosPool> pool, std::string_view containerId, bool create = false);
@@ -265,32 +255,32 @@ public:
 
    /**
      \brief Perform a vector read operation on multiple objects.
-     \param map A `std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation>` that describes read
+     \param map A `std::unordered_map<ROidDkeyPair, RWOperation>` that describes read
      operations to perform.
      \param cid An object class ID.
      \return Number of operations that could not complete.
      */
-   int ReadV(std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation> &map, ObjClassId_t cid)
+   int ReadV(std::unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash> &map, ObjClassId_t cid)
    {
       return VectorReadWrite(map, cid, &RDaosObject::Fetch);
    }
-   int ReadV(std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation> &map)
+   int ReadV(std::unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash> &map)
    {
       return ReadV(map, fDefaultObjectClass);
    }
 
    /**
      \brief Perform a vector write operation on multiple objects.
-     \param map A `std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation>` that describes write
+     \param map A `std::unordered_map<ROidDkeyPair, RWOperation>` that describes write
      operations to perform.
      \param cid An object class ID.
      \return Number of operations that could not complete.
      */
-   int WriteV(std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation> &map, ObjClassId_t cid)
+   int WriteV(std::unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash> &map, ObjClassId_t cid)
    {
       return VectorReadWrite(map, cid, &RDaosObject::Update);
    }
-   int WriteV(std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation> &map)
+   int WriteV(std::unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash> &map)
    {
       return WriteV(map, fDefaultObjectClass);
    }
@@ -300,18 +290,5 @@ public:
 
 } // namespace Experimental
 } // namespace ROOT
-
-namespace std {
-template <>
-struct hash<std::pair<daos_obj_id_t, ROOT::Experimental::Detail::RDaosObject::DistributionKey_t>> {
-   std::size_t
-   operator()(std::pair<daos_obj_id_t, ROOT::Experimental::Detail::RDaosObject::DistributionKey_t> const &pair) const
-   {
-      using std::hash;
-      return hash<daos_obj_id_t>{}(pair.first) ^
-             (hash<ROOT::Experimental::Detail::RDaosObject::DistributionKey_t>{}(pair.second) << 1);
-   }
-};
-} // namespace std
 
 #endif

--- a/tree/ntuple/v7/src/RDaos.cxx
+++ b/tree/ntuple/v7/src/RDaos.cxx
@@ -229,7 +229,7 @@ int ROOT::Experimental::Detail::RDaosContainer::WriteSingleAkey(const void *buff
 }
 
 int ROOT::Experimental::Detail::RDaosContainer::VectorReadWrite(
-   std::unordered_map<std::pair<daos_obj_id_t, DistributionKey_t>, RWOperation> &map, ObjClassId_t cid,
+   std::unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash> &map, ObjClassId_t cid,
    int (RDaosObject::*fn)(RDaosObject::FetchUpdateArgs &))
 {
    using request_t = std::tuple<std::unique_ptr<RDaosObject>, RDaosObject::FetchUpdateArgs>;

--- a/tree/ntuple/v7/src/RDaos.cxx
+++ b/tree/ntuple/v7/src/RDaos.cxx
@@ -64,32 +64,39 @@ std::string ROOT::Experimental::Detail::RDaosObject::ObjClassId::ToString() cons
 }
 
 ROOT::Experimental::Detail::RDaosObject::FetchUpdateArgs::FetchUpdateArgs(FetchUpdateArgs &&fua)
-   : fDkey(fua.fDkey), fAkey(fua.fAkey), fIods{fua.fIods[0]}, fSgls{fua.fSgls[0]}, fIovs(std::move(fua.fIovs)),
-     fEvent(std::move(fua.fEvent))
+   : fDkey(fua.fDkey), fAkeys(std::move(fua.fAkeys)), fIods(std::move(fua.fIods)), fSgls(std::move(fua.fSgls)),
+     fIovs(std::move(fua.fIovs)), fEvent(std::move(fua.fEvent))
 {
    d_iov_set(&fDistributionKey, &fDkey, sizeof(fDkey));
-   d_iov_set(&fIods[0].iod_name, &fAkey, sizeof(fAkey));
 }
 
-ROOT::Experimental::Detail::RDaosObject::FetchUpdateArgs::FetchUpdateArgs(DistributionKey_t &d, AttributeKey_t &a,
-                                                                          std::vector<d_iov_t> &v, bool is_async)
-   : fDkey(d), fAkey(a), fIovs(v)
+ROOT::Experimental::Detail::RDaosObject::FetchUpdateArgs::FetchUpdateArgs(DistributionKey_t &d,
+                                                                          std::vector<AttributeKey_t> &&as,
+                                                                          std::vector<d_iov_t> &&vs, bool is_async)
+   : fDkey(d), fAkeys(std::move(as)), fIovs(std::move(vs))
 {
    if (is_async)
       fEvent.emplace();
 
+   fSgls.reserve(fAkeys.size());
+   fIods.reserve(fAkeys.size());
    d_iov_set(&fDistributionKey, &fDkey, sizeof(fDkey));
 
-   d_iov_set(&fIods[0].iod_name, &fAkey, sizeof(fAkey));
-   fIods[0].iod_nr = 1;
-   fIods[0].iod_size = std::accumulate(v.begin(), v.end(), 0,
-                                       [](daos_size_t _a, d_iov_t _b) { return _a + _b.iov_len; });
-   fIods[0].iod_recxs = nullptr;
-   fIods[0].iod_type = DAOS_IOD_SINGLE;
+   for (unsigned i = 0; i < fAkeys.size(); ++i) {
+      daos_iod_t iod;
+      iod.iod_nr = 1;
+      iod.iod_size = fIovs[i].iov_len;
+      iod.iod_recxs = nullptr;
+      iod.iod_type = DAOS_IOD_SINGLE;
+      d_iov_set(&iod.iod_name, &(fAkeys[i]), sizeof(fAkeys[i]));
+      fIods.push_back(iod);
 
-   fSgls[0].sg_nr_out = 0;
-   fSgls[0].sg_nr = fIovs.size();
-   fSgls[0].sg_iovs = fIovs.data();
+      d_sg_list_t sgl;
+      sgl.sg_nr_out = 0;
+      sgl.sg_nr = 1;
+      sgl.sg_iovs = &fIovs[i];
+      fSgls.push_back(sgl);
+   }
 }
 
 daos_event_t *ROOT::Experimental::Detail::RDaosObject::FetchUpdateArgs::GetEventPointer()
@@ -115,15 +122,15 @@ ROOT::Experimental::Detail::RDaosObject::~RDaosObject()
 
 int ROOT::Experimental::Detail::RDaosObject::Fetch(FetchUpdateArgs &args)
 {
-   args.fIods[0].iod_size = (daos_size_t)DAOS_REC_ANY;
    return daos_obj_fetch(fObjectHandle, DAOS_TX_NONE, DAOS_COND_DKEY_FETCH | DAOS_COND_AKEY_FETCH,
-                         &args.fDistributionKey, 1, args.fIods, args.fSgls, nullptr, args.GetEventPointer());
+                         &args.fDistributionKey, args.fAkeys.size(), args.fIods.data(), args.fSgls.data(), nullptr,
+                         args.GetEventPointer());
 }
 
 int ROOT::Experimental::Detail::RDaosObject::Update(FetchUpdateArgs &args)
 {
-   return daos_obj_update(fObjectHandle, DAOS_TX_NONE, 0, &args.fDistributionKey, 1, args.fIods, args.fSgls,
-                          args.GetEventPointer());
+   return daos_obj_update(fObjectHandle, DAOS_TX_NONE, 0, &args.fDistributionKey, args.fAkeys.size(), args.fIods.data(),
+                          args.fSgls.data(), args.GetEventPointer());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -203,19 +210,21 @@ int ROOT::Experimental::Detail::RDaosContainer::ReadSingleAkey(void *buffer, std
                                                                DistributionKey_t dkey, AttributeKey_t akey,
                                                                ObjClassId_t cid)
 {
+   std::vector<AttributeKey_t> akeys{akey};
    std::vector<d_iov_t> iovs(1);
    d_iov_set(&iovs[0], buffer, length);
-   RDaosObject::FetchUpdateArgs args(dkey, akey, iovs);
+   RDaosObject::FetchUpdateArgs args(dkey, std::move(akeys), std::move(iovs));
    return RDaosObject(*this, oid, cid.fCid).Fetch(args);
 }
 
-int ROOT::Experimental::Detail::RDaosContainer::WriteSingleAkey(const void *buffer, std::size_t length, daos_obj_id_t oid,
-                                                                DistributionKey_t dkey, AttributeKey_t akey,
-                                                                ObjClassId_t cid)
+int ROOT::Experimental::Detail::RDaosContainer::WriteSingleAkey(const void *buffer, std::size_t length,
+                                                                daos_obj_id_t oid, DistributionKey_t dkey,
+                                                                AttributeKey_t akey, ObjClassId_t cid)
 {
+   std::vector<AttributeKey_t> akeys{akey};
    std::vector<d_iov_t> iovs(1);
    d_iov_set(&iovs[0], const_cast<void *>(buffer), length);
-   RDaosObject::FetchUpdateArgs args(dkey, akey, iovs);
+   RDaosObject::FetchUpdateArgs args(dkey, std::move(akeys), std::move(iovs));
    return RDaosObject(*this, oid, cid.fCid).Update(args);
 }
 
@@ -234,9 +243,10 @@ int ROOT::Experimental::Detail::RDaosContainer::VectorReadWrite(std::vector<RWOp
       return ret;
 
    for (size_t i = 0; i < vec.size(); ++i) {
-      requests.push_back(std::make_tuple(
-         std::make_unique<RDaosObject>(*this, vec[i].fOid, cid.fCid),
-         RDaosObject::FetchUpdateArgs{vec[i].fDistributionKey, vec[i].fAttributeKey, vec[i].fIovs, /*is_async=*/true}));
+      requests.push_back(
+         std::make_tuple(std::make_unique<RDaosObject>(*this, vec[i].fOid, cid.fCid),
+                         RDaosObject::FetchUpdateArgs{vec[i].fDistributionKey, std::move(vec[i].fAttributeKeys),
+                                                      std::move(vec[i].fIovs), /*is_async=*/true}));
 
       if ((ret = fPool->fEventQueue->InitializeEvent(std::get<1>(requests.back()).GetEventPointer(), &parent_event)) <
           0)
@@ -244,8 +254,7 @@ int ROOT::Experimental::Detail::RDaosContainer::VectorReadWrite(std::vector<RWOp
 
       // Launch operation
       if ((ret = (std::get<0>(requests.back()).get()->*fn)(std::get<1>(requests.back()))) < 0)
-         ;
-      return ret;
+         return ret;
    }
 
    // Sets parent barrier and waits for all children launched before it.

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -553,10 +553,10 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
       std::vector<RDaosContainer::RWOperation> readRequests;
       auto buffer = new unsigned char[szPayload];
       for (auto &s : onDiskPages) {
+         std::vector<RDaosContainer::AttributeKey_t> akeys{kAttributeKey};
          std::vector<d_iov_t> iovs(1);
          d_iov_set(&iovs[0], buffer + s.fBufPos, s.fSize);
-         readRequests.emplace_back(daos_obj_id_t{s.fObjectId, 0},
-                                   kDistributionKey, kAttributeKey, iovs);
+         readRequests.emplace_back(daos_obj_id_t{s.fObjectId, 0}, kDistributionKey, std::move(akeys), std::move(iovs));
       }
       fCounters->fSzReadPayload.Add(szPayload);
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -550,8 +550,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
       }
 
       // Prepare the input map for the RDaosContainer::ReadV() call
-      std::unordered_map<RDaosContainer::ROidDkeyPair, RDaosContainer::RWOperation, RDaosContainer::ROidDkeyPair::Hash>
-         readRequests;
+      RDaosContainer::MultiObjectRWOperation_t readRequests;
       std::vector<d_iov_t> iovs(onDiskPages.size());
       auto buffer = new unsigned char[szPayload];
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -549,14 +549,19 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
          }
       }
 
-      // Prepare the input vector for the RDaosContainer::ReadV() call
-      std::vector<RDaosContainer::RWOperation> readRequests;
+      // Prepare the input map for the RDaosContainer::ReadV() call
+      std::unordered_map<std::pair<daos_obj_id_t, RDaosContainer::DistributionKey_t>, RDaosContainer::RWOperation>
+         readRequests;
+      std::vector<d_iov_t> iovs(onDiskPages.size());
       auto buffer = new unsigned char[szPayload];
-      for (auto &s : onDiskPages) {
-         std::vector<RDaosContainer::AttributeKey_t> akeys{kAttributeKey};
-         std::vector<d_iov_t> iovs(1);
-         d_iov_set(&iovs[0], buffer + s.fBufPos, s.fSize);
-         readRequests.emplace_back(daos_obj_id_t{s.fObjectId, 0}, kDistributionKey, std::move(akeys), std::move(iovs));
+
+      for (unsigned i = 0; i < onDiskPages.size(); ++i) {
+         auto &s = onDiskPages[i];
+         d_iov_set(&iovs[i], buffer + s.fBufPos, s.fSize);
+         auto key = std::make_pair(daos_obj_id_t{s.fObjectId, 0}, kDistributionKey);
+
+         if (int err = readRequests[key].insert(key.first, key.second, kAttributeKey, iovs[i]))
+            throw ROOT::Experimental::RException(R__FAIL("RWOperation insert: error " + std::to_string(err)));
       }
       fCounters->fSzReadPayload.Add(szPayload);
 
@@ -570,7 +575,8 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
 
       {
          RNTupleAtomicTimer timer(fCounters->fTimeWallRead, fCounters->fTimeCpuRead);
-         fDaosContainer->ReadV(readRequests);
+         if (int err = fDaosContainer->ReadV(readRequests))
+            throw ROOT::Experimental::RException(R__FAIL("ReadV: error" + std::string(d_errstr(err))));
       }
       fCounters->fNReadV.Inc();
       fCounters->fNRead.Add(readRequests.size());


### PR DESCRIPTION
This pull request generalizes the `RDaos` backend to support multiple attribute keys per read-write operation, grouping requested blobs by their corresponding <object id, distribution key> pairs - defined as a struct `RDaosContainer::ROidDkeyPair(daos_obj_id_t, DistributionKey_t)`. 

## Changes or fixes:

- `RDaosObject::FetchUpdateArgs`, which prepares the arguments for requests to `daos_obj_fetch` or `daos_obj_update`. Now supports multiple attribute keys, I/O operation descriptors and I/O vectors, to send in one RW call to distributed storage.
- `RDaosContainer::RWOperation`, which interfaces between `RPageStorageDaos` and `RDaosObject`, supports multiple attribute keys and I/O vectors. 
- `RPageSourceDaos::LoadClusters` collects requested pages in an `unordered_map<ROidDkeyPair, RWOperation, ROidDkeyPair::Hash>` by their corresponding object IDs and distribution keys (currently, OID: unique page number and Dkey: const, so this PR should have no real effect on performance or results)
- `RDaosContainer::VectorReadWrite` and its wrappers `WriteV`, `ReadV` now take an `unordered_map<ROidDkeyPair. RWOperation, ROidDkeyPair::Hash>` instead of `vector<RWOperation>`. This should allow for multiple requests spread throughout the container to be sent out in once call, each of which fetching or updating several blobs at once.
- `RDaosContainer::VectorReadWrite` implementation has been moved to `RDaos.cxx` file, de-templating the function argument (which is always expected to be either a `RDaosObject::Fetch` or a `::Update` non-static method)

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

