### PR TITLE
Control `strlen(nullptr)` in several core classes

### DIFF
--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -227,7 +227,7 @@ TObject *TObject::DrawClone(Option_t *option) const
    TObject *newobj = Clone();
    if (!newobj) return nullptr;
    if (pad) {
-      if (option && strlen(option))
+      if (option && *option)
          pad->GetListOfPrimitives()->Add(newobj, option);
       else
          pad->GetListOfPrimitives()->Add(newobj, GetDrawOption());
@@ -236,7 +236,7 @@ TObject *TObject::DrawClone(Option_t *option) const
       if (padsav) padsav->cd();
       return newobj;
    }
-   if (option && strlen(option))
+   if (option && *option)
       newobj->Draw(option);
    else
       newobj->Draw(GetDrawOption());

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -127,7 +127,7 @@ TString::TString(const std::string &s)
 TString::TString(const char *cs, Ssiz_t n)
 {
    if (!cs) {
-      Error("TString::TString", "Missing input string!");
+      Error("TString::TString", "NULL input string!");
       Zero();
       return;
    }

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -126,6 +126,11 @@ TString::TString(const std::string &s)
 
 TString::TString(const char *cs, Ssiz_t n)
 {
+   if (!cs) {
+      Error("TString::TString", "Missing input string!");
+      Zero();
+      return;
+   }
    if (n < 0) {
       Error("TString::TString", "Negative length!");
       Zero();

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -1431,7 +1431,7 @@ void TStyle::SetLabelSize(Float_t size, Option_t *axis)
 
 void TStyle::SetLineStyleString(Int_t i, const char *text)
 {
-
+   if (!text) text = "";
    char *l;
    Int_t nch = strlen(text);
    char *st = new char[nch+10];
@@ -1829,7 +1829,7 @@ void TStyle::SetStripDecimals(Bool_t strip)
 void TStyle::SaveSource(const char *filename, Option_t *option)
 {
    // Opens a file named filename or "Rootstyl.C"
-   TString ff = strlen(filename) ? filename : "Rootstyl.C";
+   TString ff = filename && strlen(filename) ? filename : "Rootstyl.C";
 
    // Computes the main method name.
    const char *fname = gSystem->BaseName(ff);

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -1829,7 +1829,7 @@ void TStyle::SetStripDecimals(Bool_t strip)
 void TStyle::SaveSource(const char *filename, Option_t *option)
 {
    // Opens a file named filename or "Rootstyl.C"
-   TString ff = filename && strlen(filename) ? filename : "Rootstyl.C";
+   TString ff = filename && *filename ? filename : "Rootstyl.C";
 
    // Computes the main method name.
    const char *fname = gSystem->BaseName(ff);

--- a/core/cont/src/TClassTable.cxx
+++ b/core/cont/src/TClassTable.cxx
@@ -250,9 +250,9 @@ TClassTable::~TClassTable()
    for (UInt_t i = 0; i < fgSize; i++) {
       delete fgTable[i]; // Will delete all the elements in the chain.
    }
-   delete [] fgTable; fgTable = 0;
-   delete [] fgSortedTable; fgSortedTable = 0;
-   delete fgIdMap; fgIdMap = 0;
+   delete [] fgTable; fgTable = nullptr;
+   delete [] fgSortedTable; fgSortedTable = nullptr;
+   delete fgIdMap; fgIdMap = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -260,7 +260,8 @@ TClassTable::~TClassTable()
 /// If the table does not exist but the delayed list does, then
 /// create the table and return true.
 
-inline Bool_t TClassTable::CheckClassTableInit() {
+inline Bool_t TClassTable::CheckClassTableInit()
+{
    if (!gClassTable || !fgTable) {
       if (GetDelayedAddClass().size()) {
          new TClassTable;
@@ -286,6 +287,7 @@ void TClassTable::Print(Option_t *option) const
 
    int n = 0, ninit = 0, nl = 0;
 
+   if (!option) option = "";
    int nch = strlen(option);
    TRegexp re(option, kTRUE);
 
@@ -325,7 +327,7 @@ char *TClassTable::At(UInt_t index)
       TClassRec *r = fgSortedTable[index];
       if (r) return r->fName;
    }
-   return 0;
+   return nullptr;
 }
 
 //______________________________________________________________________________
@@ -490,7 +492,7 @@ void TClassTable::Remove(const char *cname)
    UInt_t slot = ROOT::ClassTableHash(cname,fgSize);
 
    TClassRec *r;
-   TClassRec *prev = 0;
+   TClassRec *prev = nullptr;
    for (r = fgTable[slot]; r; r = r->fNext) {
       if (!strcmp(r->fName, cname)) {
          if (prev)
@@ -498,7 +500,7 @@ void TClassTable::Remove(const char *cname)
          else
             fgTable[slot] = r->fNext;
          fgIdMap->Remove(r->fInfo->name());
-         r->fNext = 0; // Do not delete the others.
+         r->fNext = nullptr; // Do not delete the others.
          delete r;
          fgTally--;
          fgSorted = kFALSE;
@@ -520,7 +522,7 @@ TClassRec *TClassTable::FindElementImpl(const char *cname, Bool_t insert)
    for (TClassRec *r = fgTable[slot]; r; r = r->fNext)
       if (strcmp(cname,r->fName)==0) return r;
 
-   if (!insert) return 0;
+   if (!insert) return nullptr;
 
    fgTable[slot] = new TClassRec(fgTable[slot]);
 
@@ -580,7 +582,7 @@ DictFuncPtr_t TClassTable::GetDict(const char *cname)
 
    TClassRec *r = FindElement(cname);
    if (r) return r->fDict;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -598,7 +600,7 @@ DictFuncPtr_t TClassTable::GetDict(const std::type_info& info)
 
    TClassRec *r = fgIdMap->Find(info.name());
    if (r) return r->fDict;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -616,7 +618,7 @@ DictFuncPtr_t TClassTable::GetDictNorm(const char *cname)
 
    TClassRec *r = FindElementImpl(cname,kFALSE);
    if (r) return r->fDict;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -638,7 +640,7 @@ TProtoClass *TClassTable::GetProto(const char *cname)
 
    TClassRec *r = FindElement(cname);
    if (r) return r->fProto;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -659,7 +661,7 @@ TProtoClass *TClassTable::GetProtoNorm(const char *cname)
 
    TClassRec *r = FindElementImpl(cname,kFALSE);
    if (r) return r->fProto;
-   return 0;
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -683,8 +685,9 @@ char *TClassTable::Next()
    if (fgCursor < fgTally) {
       TClassRec *r = fgSortedTable[fgCursor++];
       return r->fName;
-   } else
-      return 0;
+   }
+
+   return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -748,9 +751,9 @@ void TClassTable::Terminate()
       for (UInt_t i = 0; i < fgSize; i++)
          delete fgTable[i]; // Will delete all the elements in the chain.
 
-      delete [] fgTable; fgTable = 0;
-      delete [] fgSortedTable; fgSortedTable = 0;
-      delete fgIdMap; fgIdMap = 0;
+      delete [] fgTable; fgTable = nullptr;
+      delete [] fgSortedTable; fgSortedTable = nullptr;
+      delete fgIdMap; fgIdMap = nullptr;
       fgSize = 0;
       SafeDelete(gClassTable);
    }
@@ -880,7 +883,7 @@ TNamed *ROOT::RegisterClassTemplate(const char *name, const char *file,
       obj->SetUniqueID(line);
       table.Add(obj);
       return obj;
-   } else {
-      return (TNamed*)table.FindObject(classname);
    }
+
+   return (TNamed*)table.FindObject(classname);
 }

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -196,7 +196,7 @@ TClass::TDeclNameRegistry::TDeclNameRegistry(Int_t verbLevel): fVerbLevel(verbLe
 void TClass::TDeclNameRegistry::AddQualifiedName(const char *name)
 {
    // Sanity check
-   auto strLen = strlen(name);
+   auto strLen = name ? strlen(name) : 0;
    if (strLen == 0) return;
    // find <. If none, put end of string
    const char* endCharPtr = strchr(name, '<');
@@ -2297,9 +2297,8 @@ Bool_t TClass::CanSplitBaseAllow()
 
    // Look at inheritance tree
    while (lnk) {
-      TClass     *c;
       TBaseClass *base = (TBaseClass*) lnk->GetObject();
-      c = base->GetClassPointer();
+      TClass *c = base->GetClassPointer();
       if(!c) {
          // If there is a missing base class, we can't split the immediate
          // derived class.
@@ -2571,7 +2570,7 @@ char *TClass::EscapeChars(const char *text) const
    static const UInt_t maxsize = 255;
    static char name[maxsize+2]; //One extra if last char needs to be escaped
 
-   UInt_t nch = strlen(text);
+   UInt_t nch = text ? strlen(text) : 0;
    UInt_t icur = 0;
    for (UInt_t i = 0; i < nch && icur < maxsize; ++i, ++icur) {
       if (text[i] == '\"' || text[i] == '[' || text[i] == '~' ||
@@ -2607,7 +2606,8 @@ char *TClass::EscapeChars(const char *text) const
 
 TClass *TClass::GetActualClass(const void *object) const
 {
-   if (object==nullptr) return (TClass*)this;
+   if (!object)
+      return (TClass*)this;
    if (fIsA) {
       return (*fIsA)(object); // ROOT::IsA((ThisClass*)object);
    } else if (fGlobalIsA) {
@@ -6365,7 +6365,7 @@ TVirtualStreamerInfo *TClass::SetStreamerInfo(Int_t /*version*/, const char * /*
 
 /*
    TDataMember *dm;
-   Int_t nch = strlen(info);
+   Int_t nch = info ? strlen(info) : 0;
    Bool_t update = kTRUE;
    if (nch != 0) {
       //decode strings like "TObject;TAttLine;fA;fB;Int_t i,j,k;"


### PR DESCRIPTION
Prevent crash when user specifies `nullptr` as argument for `const char*`