### PR TITLE
[RF] Code modernization in RooFit tutorials

### DIFF
--- a/tutorials/roofit/rf102_dataimport.C
+++ b/tutorials/roofit/rf102_dataimport.C
@@ -179,8 +179,8 @@ TH1 *makeTH1()
 TTree *makeTTree()
 {
    TTree *tree = new TTree("tree", "tree");
-   Double_t *px = new Double_t;
-   Double_t *py = new Double_t;
+   double *px = new double;
+   double *py = new double;
    tree->Branch("x", px, "x/D");
    tree->Branch("y", py, "y/D");
    for (int i = 0; i < 100; i++) {

--- a/tutorials/roofit/rf104_classfactory.C
+++ b/tutorials/roofit/rf104_classfactory.C
@@ -60,7 +60,7 @@ void rf104_classfactory()
    // To use this class,
    //    - Compile and link class with '.x MyPdfV3.cxx+'
    //
-   RooClassFactory::makePdf("MyPdfV3", "x,A,B", "", "A*fabs(x)+pow(x-B,2)", kTRUE, kFALSE,
+   RooClassFactory::makePdf("MyPdfV3", "x,A,B", "", "A*fabs(x)+pow(x-B,2)", true, false,
                             "x:(A/2)*(pow(x.max(rangeName),2)+pow(x.min(rangeName),2))+(1./"
                             "3)*(pow(x.max(rangeName)-B,3)-pow(x.min(rangeName)-B,3))");
 

--- a/tutorials/roofit/rf201_composite.C
+++ b/tutorials/roofit/rf201_composite.C
@@ -94,7 +94,7 @@ void rf201_composite()
    //
    //   model2 = bkg + (sig1 + sig2)
    //
-   RooAddPdf model2("model", "g1+g2+a", RooArgList(bkg, sig1, sig2), RooArgList(bkgfrac, sig1frac), kTRUE);
+   RooAddPdf model2("model", "g1+g2+a", RooArgList(bkg, sig1, sig2), RooArgList(bkgfrac, sig1frac), true);
 
    // NB: Each coefficient is interpreted as the fraction of the
    // left-hand component of the i-th recursive sum, i.e.

--- a/tutorials/roofit/rf203_ranges.C
+++ b/tutorials/roofit/rf203_ranges.C
@@ -49,7 +49,7 @@ void rf203_ranges()
    // ---------------------------
 
    // Fit pdf to all data
-   RooFitResult *r_full = model.fitTo(*modelData, Save(kTRUE));
+   RooFitResult *r_full = model.fitTo(*modelData, Save(true));
 
    // F i t   p a r t i a l   r a n g e
    // ----------------------------------
@@ -58,7 +58,7 @@ void rf203_ranges()
    x.setRange("signal", -3, 3);
 
    // Fit pdf only to data in "signal" range
-   RooFitResult *r_sig = model.fitTo(*modelData, Save(kTRUE), Range("signal"));
+   RooFitResult *r_sig = model.fitTo(*modelData, Save(true), Range("signal"));
 
    // P l o t   /   p r i n t   r e s u l t s
    // ---------------------------------------

--- a/tutorials/roofit/rf207_comptools.C
+++ b/tutorials/roofit/rf207_comptools.C
@@ -118,7 +118,7 @@ void rf207_comptools()
    // The returned head node own all nodes that were cloned as part of
    // the build process so when cust_clone is deleted so will all other
    // nodes that were created in the process.
-   RooAbsPdf *cust_clone = (RooAbsPdf *)cust.build(kTRUE);
+   RooAbsPdf *cust_clone = (RooAbsPdf *)cust.build(true);
 
    // Print structure of clone of model with sig->sigsum replacement.
    cust_clone->Print("t");

--- a/tutorials/roofit/rf303_conditional.C
+++ b/tutorials/roofit/rf303_conditional.C
@@ -97,8 +97,8 @@ RooDataSet *makeFakeDataXY()
    RooDataSet *d = new RooDataSet("d", "d", RooArgSet(x, y));
 
    for (int i = 0; i < 10000; i++) {
-      Double_t tmpy = gRandom->Gaus(0, 10);
-      Double_t tmpx = gRandom->Gaus(0.5 * tmpy, 1);
+      double tmpy = gRandom->Gaus(0, 10);
+      double tmpx = gRandom->Gaus(0.5 * tmpy, 1);
       if (fabs(tmpy) < 10 && fabs(tmpx) < 10) {
          x.setVal(tmpx);
          y.setVal(tmpy);

--- a/tutorials/roofit/rf306_condpereventerrors.C
+++ b/tutorials/roofit/rf306_condpereventerrors.C
@@ -82,8 +82,8 @@ void rf306_condpereventerrors()
    //
    // Instead of integrating out dterr, make a weighted average of curves
    // at values dterr_i as given in the external dataset.
-   // (The kTRUE argument bins the data before projection to speed up the process)
-   decay_gm.plotOn(frame2, ProjWData(*expDataDterr, kTRUE));
+   // (The true argument bins the data before projection to speed up the process)
+   decay_gm.plotOn(frame2, ProjWData(*expDataDterr, true));
 
    // Draw all frames on canvas
    TCanvas *c = new TCanvas("rf306_condpereventerrors", "rf306_condperventerrors", 1200, 400);

--- a/tutorials/roofit/rf401_importttreethx.C
+++ b/tutorials/roofit/rf401_importttreethx.C
@@ -26,7 +26,7 @@
 
 using namespace RooFit;
 
-TH1 *makeTH1(const char *name, Double_t mean, Double_t sigma);
+TH1 *makeTH1(const char *name, double mean, double sigma);
 TTree *makeTTree();
 
 void rf401_importttreethx()
@@ -108,7 +108,7 @@ void rf401_importttreethx()
    dsABC->Print();
 }
 
-TH1 *makeTH1(const char *name, Double_t mean, Double_t sigma)
+TH1 *makeTH1(const char *name, double mean, double sigma)
 {
    // Create ROOT TH1 filled with a Gaussian distribution
 
@@ -124,9 +124,9 @@ TTree *makeTTree()
    // Create ROOT TTree filled with a Gaussian distribution in x and a uniform distribution in y
 
    TTree *tree = new TTree("tree", "tree");
-   Double_t *px = new Double_t;
-   Double_t *py = new Double_t;
-   Double_t *pz = new Double_t;
+   double *px = new double;
+   double *py = new double;
+   double *pz = new double;
    Int_t *pi = new Int_t;
    tree->Branch("x", px, "x/D");
    tree->Branch("y", py, "y/D");

--- a/tutorials/roofit/rf402_datahandling.C
+++ b/tutorials/roofit/rf402_datahandling.C
@@ -125,8 +125,8 @@ void rf402_datahandling()
 
    // Examine the statistics of a binned dataset
    cout << ">> number of bins in dh   : " << dh.numEntries() << endl;
-   cout << ">> sum of weights in dh   : " << dh.sum(kFALSE) << endl;
-   cout << ">> integral over histogram: " << dh.sum(kTRUE) << endl; // accounts for bin volume
+   cout << ">> sum of weights in dh   : " << dh.sum(false) << endl;
+   cout << ">> integral over histogram: " << dh.sum(true) << endl; // accounts for bin volume
 
    // Locate a bin from a set of coordinates and retrieve its properties
    x = 0.3;

--- a/tutorials/roofit/rf403_weightedevts.C
+++ b/tutorials/roofit/rf403_weightedevts.C
@@ -88,7 +88,7 @@ void rf403_weightedevts()
    //
    // A fit in this mode can be performed as follows:
 
-   RooFitResult *r_ml_wgt_corr = p2.fitTo(wdata, Save(), SumW2Error(kTRUE));
+   RooFitResult *r_ml_wgt_corr = p2.fitTo(wdata, Save(), SumW2Error(true));
 
    // P l o t   w e i g h e d   d a t a   a n d   f i t   r e s u l t
    // ---------------------------------------------------------------

--- a/tutorials/roofit/rf404_categories.C
+++ b/tutorials/roofit/rf404_categories.C
@@ -110,11 +110,11 @@ void rf404_categories()
 
    // Retrieve number of events from table
    // Number can be non-integer if source dataset has weighed events
-   Double_t nb0 = btable->get("B0");
+   double nb0 = btable->get("B0");
    std::cout << "Number of events with B0 flavor is " << nb0 << std::endl;
 
    // Retrieve fraction of events with "Lepton" tag
-   Double_t fracLep = ttable->getFrac("Lepton");
+   double fracLep = ttable->getFrac("Lepton");
    std::cout << "Fraction of events tagged with Lepton tag is " << fracLep << std::endl;
 
    // D e f i n i n g   r a n g e s   f o r   p l o t t i n g ,   f i t t i n g   o n   c a t e g o r i e s

--- a/tutorials/roofit/rf505_asciicfg.C
+++ b/tutorials/roofit/rf505_asciicfg.C
@@ -74,7 +74,7 @@ void rf505_asciicfg()
 
    // Print the list of parameters that were not read from Section3
    cout << "The following parameters of the were _not_ read from Section3: "
-        << (*params->selectByAttrib("READ", kFALSE)) << endl;
+        << (*params->selectByAttrib("READ", false)) << endl;
 
    // Read parameters from section 'Section4' of file, which contains
    // 'include file' statement of rf505_asciicfg_example.txt

--- a/tutorials/roofit/rf506_msgservice.C
+++ b/tutorials/roofit/rf506_msgservice.C
@@ -78,7 +78,7 @@ void rf506_msgservice()
    RooMsgService::instance().addStream(DEBUG, Topic(Tracing), ClassName("RooGaussian"));
 
    // Perform a fit to generate some tracing messages
-   model.fitTo(*data, Verbose(kTRUE));
+   model.fitTo(*data, Verbose(true));
 
    // Reset message service to default stream configuration
    RooMsgService::instance().reset();
@@ -87,7 +87,7 @@ void rf506_msgservice()
    RooMsgService::instance().addStream(DEBUG, Topic(Tracing), OutputFile("rf506_debug.log"));
 
    // Perform a fit to generate some tracing messages
-   model.fitTo(*data, Verbose(kTRUE));
+   model.fitTo(*data, Verbose(true));
 
    // Reset message service to default stream configuration
    RooMsgService::instance().reset();

--- a/tutorials/roofit/rf507_debugtools.C
+++ b/tutorials/roofit/rf507_debugtools.C
@@ -23,7 +23,7 @@ using namespace RooFit;
 void rf507_debugtools()
 {
    // Activate RooFit memory tracing
-   RooTrace::active(kTRUE);
+   RooTrace::active(true);
 
    // Construct gauss(x,m,s)
    RooRealVar x("x", "x", -10, 10);
@@ -35,7 +35,7 @@ void rf507_debugtools()
    RooTrace::dump();
 
    // Activate verbose mode
-   RooTrace::verbose(kTRUE);
+   RooTrace::verbose(true);
 
    // Construct poly(x,p0)
    RooRealVar p0("p0", "p0", 0.01, 0., 1.);

--- a/tutorials/roofit/rf508_listsetmanip.C
+++ b/tutorials/roofit/rf508_listsetmanip.C
@@ -75,7 +75,7 @@ void rf508_listsetmanip()
    RooArgSet *subset1 = (RooArgSet *)s.selectByName("a,b,c");
 
    // Construct asubset by attribute
-   RooArgSet *subset2 = (RooArgSet *)s.selectByAttrib("Constant", kTRUE);
+   RooArgSet *subset2 = (RooArgSet *)s.selectByAttrib("Constant", true);
 
    // Construct the subset of overlapping contents with another set
    RooArgSet s1(a, b, c);
@@ -117,7 +117,7 @@ void rf508_listsetmanip()
    // dependencies, that together form a self-consistent
    // set that is free of external dependencies
 
-   RooArgSet *sclone3 = (RooArgSet *)s3.snapshot(kTRUE);
+   RooArgSet *sclone3 = (RooArgSet *)s3.snapshot(true);
 
    // S e t   p r i n t i n g
    // ------------------------

--- a/tutorials/roofit/rf509_wsinteractive.C
+++ b/tutorials/roofit/rf509_wsinteractive.C
@@ -26,7 +26,7 @@ void rf509_wsinteractive()
    // but this does not work anymore in CLING.
    // so this tutorial is an example on how to
    // change the code
-   RooWorkspace *w1 = new RooWorkspace("w", kTRUE);
+   RooWorkspace *w1 = new RooWorkspace("w", true);
 
    // Fill workspace with pdf and data in a separate function
    fillWorkspace(*w1);

--- a/tutorials/roofit/rf510_wsnamedsets.C
+++ b/tutorials/roofit/rf510_wsnamedsets.C
@@ -131,17 +131,17 @@ void fillWorkspace(RooWorkspace &w)
    RooDataSet *refData = model.generate(x, 10000);
    model.fitTo(*refData, PrintLevel(-1));
 
-   // The kTRUE flag imports the values of the objects in (*params) into the workspace
+   // The true flag imports the values of the objects in (*params) into the workspace
    // If not set, the present values of the workspace parameters objects are stored
-   w.saveSnapshot("reference_fit", *params, kTRUE);
+   w.saveSnapshot("reference_fit", *params, true);
 
    // Make another fit with the signal component forced to zero
    // and save those parameters too
 
    bkgfrac.setVal(1);
-   bkgfrac.setConstant(kTRUE);
+   bkgfrac.setConstant(true);
    bkgfrac.removeError();
    model.fitTo(*refData, PrintLevel(-1));
 
-   w.saveSnapshot("reference_fit_bkgonly", *params, kTRUE);
+   w.saveSnapshot("reference_fit_bkgonly", *params, true);
 }

--- a/tutorials/roofit/rf511_wsfactory_basic.C
+++ b/tutorials/roofit/rf511_wsfactory_basic.C
@@ -21,7 +21,7 @@
 #include "TAxis.h"
 using namespace RooFit;
 
-void rf511_wsfactory_basic(Bool_t compact = kFALSE)
+void rf511_wsfactory_basic(bool compact = false)
 {
    RooWorkspace *w = new RooWorkspace("w");
 
@@ -59,7 +59,7 @@ void rf511_wsfactory_basic(Bool_t compact = kFALSE)
    //
    // P.d.f. constructor arguments may by any type of RooAbsArg, but also
    //
-   // Double_t --> converted to RooConst(...)
+   // double --> converted to RooConst(...)
    // {a,b,c} --> converted to RooArgSet() or RooArgList() depending on required ctor arg
    // dataset name --> converted to RooAbsData reference for any dataset residing in the workspace
    // enum --> Any enum label that belongs to an enum defined in the (base) class

--- a/tutorials/roofit/rf601_intminuit.C
+++ b/tutorials/roofit/rf601_intminuit.C
@@ -55,7 +55,7 @@ void rf601_intminuit()
    RooMinimizer m(*nll);
 
    // Activate verbose logging of MINUIT parameter space stepping
-   m.setVerbose(kTRUE);
+   m.setVerbose(true);
 
    // Call MIGRAD to minimize the likelihood
    m.migrad();
@@ -65,7 +65,7 @@ void rf601_intminuit()
    model.getParameters(x)->Print("s");
 
    // Disable verbose logging
-   m.setVerbose(kFALSE);
+   m.setVerbose(false);
 
    // Run HESSE to calculate errors from d2L/dp2
    m.hesse();
@@ -111,7 +111,7 @@ void rf601_intminuit()
    frac.Print();
 
    // Now fix sigma_g2
-   sigma_g2.setConstant(kTRUE);
+   sigma_g2.setConstant(true);
 
    // Rerun MIGRAD,HESSE
    m.migrad();

--- a/tutorials/roofit/rf603_multicpu.C
+++ b/tutorials/roofit/rf603_multicpu.C
@@ -60,7 +60,7 @@ void rf603_multicpu()
    // it back to MINUIT.
 
    // Use four processes and time results both in wall time and CPU time
-   model.fitTo(*data, NumCPU(4), Timer(kTRUE));
+   model.fitTo(*data, NumCPU(4), Timer(true));
 
    // P a r a l l e l   M C   p r o j e c t i o n s
    // ----------------------------------------------

--- a/tutorials/roofit/rf606_nllerrorhandling.C
+++ b/tutorials/roofit/rf606_nllerrorhandling.C
@@ -60,7 +60,7 @@ void rf606_nllerrorhandling()
 
    // Perform another fit. In this configuration only the number of errors per
    // likelihood evaluation is shown, if it is greater than zero. The
-   // EvalErrorWall(kFALSE) arguments disables the default error handling strategy
+   // EvalErrorWall(false) arguments disables the default error handling strategy
    // and will cause the actual (problematic) value of the likelihood to be passed
    // to MINUIT.
    //
@@ -70,7 +70,7 @@ void rf606_nllerrorhandling()
    // illustrated in the second plot
 
    m0.setError(0.1);
-   argus.fitTo(*data, PrintEvalErrors(0), EvalErrorWall(kFALSE));
+   argus.fitTo(*data, PrintEvalErrors(0), EvalErrorWall(false));
 
    // P l o t   l i k e l i h o o d   a s   f u n c t i o n   o f   m 0
    // ------------------------------------------------------------------

--- a/tutorials/roofit/rf609_xychi2fit.C
+++ b/tutorials/roofit/rf609_xychi2fit.C
@@ -71,7 +71,7 @@ void rf609_xychi2fit()
 
    // Alternative: fit chi^2 integrating f(x) over ranges defined by X errors, rather
    // than taking point at center of bin
-   f.chi2FitTo(dxy, YVar(y), Integrate(kTRUE));
+   f.chi2FitTo(dxy, YVar(y), Integrate(true));
 
    // Overlay alternate fit result
    f.plotOn(frame, LineStyle(kDashed), LineColor(kRed));

--- a/tutorials/roofit/rf610_visualerror.C
+++ b/tutorials/roofit/rf610_visualerror.C
@@ -81,13 +81,13 @@ void rf610_visualerror()
    // is chosen to be such that at least 100 curves are expected to be outside the N% interval, and is minimally
    // 100 (e.g. Z=1->Ncurve=356, Z=2->Ncurve=2156)) Intervals from the sampling method can be asymmetric,
    // and may perform better in the presence of strong correlations, but may take (much) longer to calculate
-   model.plotOn(frame, VisualizeError(*r, 1, kFALSE), DrawOption("L"), LineWidth(2), LineColor(kRed));
+   model.plotOn(frame, VisualizeError(*r, 1, false), DrawOption("L"), LineWidth(2), LineColor(kRed));
 
    // Perform the same type of error visualization on the background component only.
    // The VisualizeError() option can generally applied to _any_ kind of plot (components, asymmetries, efficiencies
    // etc..)
    model.plotOn(frame, VisualizeError(*r, 1), FillColor(kOrange), Components("bkg"));
-   model.plotOn(frame, VisualizeError(*r, 1, kFALSE), DrawOption("L"), LineWidth(2), LineColor(kRed), Components("bkg"),
+   model.plotOn(frame, VisualizeError(*r, 1, false), DrawOption("L"), LineWidth(2), LineColor(kRed), Components("bkg"),
                 LineStyle(kDashed));
 
    // Overlay central value

--- a/tutorials/roofit/rf702_efficiencyfit_2D.C
+++ b/tutorials/roofit/rf702_efficiencyfit_2D.C
@@ -27,7 +27,7 @@
 #include "RooPlot.h"
 using namespace RooFit;
 
-void rf702_efficiencyfit_2D(Bool_t flat = kFALSE)
+void rf702_efficiencyfit_2D(bool flat = false)
 {
    // C o n s t r u c t   e f f i c i e n c y   f u n c t i o n   e ( x , y )
    // -----------------------------------------------------------------------

--- a/tutorials/roofit/rf705_linearmorph.C
+++ b/tutorials/roofit/rf705_linearmorph.C
@@ -91,8 +91,8 @@ void rf705_linearmorph()
    RooDataSet *data = lmorph.generate(x, 1000);
 
    // Fit pdf to toy data
-   lmorph.setCacheAlpha(kTRUE);
-   lmorph.fitTo(*data, Verbose(kTRUE));
+   lmorph.setCacheAlpha(true);
+   lmorph.fitTo(*data, Verbose(true));
 
    // Plot fitted pdf and data overlaid
    RooPlot *frame2 = x.frame(Bins(100));
@@ -109,7 +109,7 @@ void rf705_linearmorph()
    std::unique_ptr<RooAbsReal> nll{lmorph.createNLL(*data)};
    nll->plotOn(frame3, ShiftToZero());
 
-   lmorph.setCacheAlpha(kFALSE);
+   lmorph.setCacheAlpha(false);
 
    TCanvas *c = new TCanvas("rf705_linearmorph", "rf705_linearmorph", 800, 800);
    c->Divide(2, 2);

--- a/tutorials/roofit/rf801_mcstudy.C
+++ b/tutorials/roofit/rf801_mcstudy.C
@@ -76,7 +76,7 @@ void rf801_mcstudy()
    // to speed up the study at the expense of some precision
 
    RooMCStudy *mcstudy =
-      new RooMCStudy(model, x, Binned(kTRUE), Silence(), Extended(), FitOptions(Save(kTRUE), PrintEvalErrors(0)));
+      new RooMCStudy(model, x, Binned(true), Silence(), Extended(), FitOptions(Save(true), PrintEvalErrors(0)));
 
    // G e n e r a t e   a n d   f i t   e v e n t s
    // ---------------------------------------------
@@ -90,7 +90,7 @@ void rf801_mcstudy()
    // Make plots of the distributions of mean, the error on mean and the pull of mean
    RooPlot *frame1 = mcstudy->plotParam(mean, Bins(40));
    RooPlot *frame2 = mcstudy->plotError(mean, Bins(40));
-   RooPlot *frame3 = mcstudy->plotPull(mean, Bins(40), FitGauss(kTRUE));
+   RooPlot *frame3 = mcstudy->plotPull(mean, Bins(40), FitGauss(true));
 
    // Plot distribution of minimized likelihood
    RooPlot *frame4 = mcstudy->plotNLL(Bins(40));

--- a/tutorials/roofit/rf803_mcstudy_addons2.C
+++ b/tutorials/roofit/rf803_mcstudy_addons2.C
@@ -58,8 +58,8 @@ void rf803_mcstudy_addons2()
 
    // Configure manager to perform binned extended likelihood fits (Binned(),Extended()) on data generated
    // with a Poisson fluctuation on Nobs (Extended())
-   RooMCStudy *mcs = new RooMCStudy(model, mjjj, Binned(), Silence(), Extended(kTRUE),
-                                    FitOptions(Extended(kTRUE), PrintEvalErrors(-1)));
+   RooMCStudy *mcs = new RooMCStudy(model, mjjj, Binned(), Silence(), Extended(true),
+                                    FitOptions(Extended(true), PrintEvalErrors(-1)));
 
    // C u s t o m i z e   m a n a g e r
    // ---------------------------------

--- a/tutorials/roofit/rf901_numintconfig.C
+++ b/tutorials/roofit/rf901_numintconfig.C
@@ -57,7 +57,7 @@ void rf901_numintconfig()
 
    // Calculate integral over landau with default choice of numeric integrator
    RooAbsReal *intLandau = landau.createIntegral(x);
-   Double_t val = intLandau->getVal();
+   double val = intLandau->getVal();
    cout << " [1] int_dx landau(x) = " << setprecision(15) << val << endl;
 
    // S a m e   w i t h   c u s t o m   c o n f i g u r a t i o n
@@ -74,7 +74,7 @@ void rf901_numintconfig()
 
    // Calculate integral over landau with custom integral specification
    RooAbsReal *intLandau2 = landau.createIntegral(x, NumIntConfig(customConfig));
-   Double_t val2 = intLandau2->getVal();
+   double val2 = intLandau2->getVal();
    cout << " [2] int_dx landau(x) = " << val2 << endl;
 
    // A d j u s t i n g   d e f a u l t   c o n f i g   f o r   a   s p e c i f i c   p d f
@@ -85,7 +85,7 @@ void rf901_numintconfig()
 
    // Calculate integral over landau custom numeric integrator specified as object default
    RooAbsReal *intLandau3 = landau.createIntegral(x);
-   Double_t val3 = intLandau3->getVal();
+   double val3 = intLandau3->getVal();
    cout << " [3] int_dx landau(x) = " << val3 << endl;
 
    // Another possibility: Change global default for 1D numeric integration strategy on finite domains

--- a/tutorials/roofit/rf902_numgenconfig.C
+++ b/tutorials/roofit/rf902_numgenconfig.C
@@ -32,22 +32,22 @@ void rf902_numgenconfig()
    RooChebychev model("model", "model", x, RooArgList(0, 0.5, -0.1));
 
    // Change global strategy for 1D sampling problems without conditional observable
-   // (1st kFALSE) and without discrete observable (2nd kFALSE) from RooFoamGenerator,
+   // (1st false) and without discrete observable (2nd false) from RooFoamGenerator,
    // ( an interface to the TFoam MC generator with adaptive subdivisioning strategy ) to RooAcceptReject,
    // a plain accept/reject sampling algorithm [ RooFit default before ROOT 5.23/04 ]
-   RooAbsPdf::defaultGeneratorConfig()->method1D(kFALSE, kFALSE).setLabel("RooAcceptReject");
+   RooAbsPdf::defaultGeneratorConfig()->method1D(false, false).setLabel("RooAcceptReject");
 
    // Generate 10Kevt using RooAcceptReject
-   RooDataSet *data_ar = model.generate(x, 10000, Verbose(kTRUE));
+   RooDataSet *data_ar = model.generate(x, 10000, Verbose(true));
    data_ar->Print();
 
    // A d j u s t i n g   d e f a u l t   c o n f i g   f o r   a   s p e c i f i c   p d f
    // -------------------------------------------------------------------------------------
 
    // Another possibility: associate custom MC sampling configuration as default for object 'model'
-   // The kTRUE argument will install a clone of the default configuration as specialized configuration
+   // The true argument will install a clone of the default configuration as specialized configuration
    // for this model if none existed so far
-   model.specialGeneratorConfig(kTRUE)->method1D(kFALSE, kFALSE).setLabel("RooFoamGenerator");
+   model.specialGeneratorConfig(true)->method1D(false, false).setLabel("RooFoamGenerator");
 
    // A d j u s t i n g   p a r a m e t e r s   o f   a   s p e c i f i c   t e c h n i q u e
    // ---------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf903_numintcache.C
+++ b/tutorials/roofit/rf903_numintcache.C
@@ -63,7 +63,7 @@ void rf903_numintcache(Int_t mode = 0)
    RooDataSet *d = w1->pdf("model")->generate(RooArgSet(*w1->var("x"), *w1->var("y"), *w1->var("z")), 1000);
 
    // This is slow in mode 0, but fast in mode 1
-   w1->pdf("model")->fitTo(*d, Verbose(kTRUE), Timer(kTRUE));
+   w1->pdf("model")->fitTo(*d, Verbose(true), Timer(true));
 
    // Projection on x (always slow as 2D integral over Y,Z at fitted value of a is not cached)
    RooPlot *framex = w1->var("x")->frame(Title("Projection of 3D model on X"));


### PR DESCRIPTION
It's important to follow modern ROOT code patterns in the tutorials,
such that the users will also get it right. Hence, the following
replacements are made in the RooFit tutorials:

  * `Double_t` to `double`
  * `Bool_t` to `bool`
  * `kTrue` to `true`
  * `kFalse` to `false`