### PR TITLE
[RF] Fix normalization issues with RooGenericPdf and RooFormulaVar

### DIFF
--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -147,7 +147,7 @@ RooFormula& RooFormulaVar::getFormula() const
 
 double RooFormulaVar::evaluate() const
 {
-  return getFormula().eval(_lastNSet);
+  return getFormula().eval(_actualVars.nset());
 }
 
 

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -119,7 +119,7 @@ RooFormula& RooGenericPdf::formula() const
 
 double RooGenericPdf::evaluate() const
 {
-  return formula().eval(_normSet) ;
+  return formula().eval(_actualVars.nset()) ;
 }
 
 

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -19,7 +19,7 @@ ROOT_ADD_GTEST(testRooBinSamplingPdf testRooBinSamplingPdf.cxx LIBRARIES RooFitC
 ROOT_ADD_GTEST(testRooSimPdfBuilder testRooSimPdfBuilder.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testRooFitDriver testRooFitDriver.cxx LIBRARIES RooFitCore RooFit)
-ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
+ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)


### PR DESCRIPTION
As a normalization set within `evaluate()`, the RooGenericPdf used the
`RooAbsPdf::_normSet` member, and the RooFormulaVar used the
`RooAbsReal::_lastNSet` member. Both of them are not supposed to be used
outside the implementation of `RooAbsPdf::getValV()` and
`RooAbsReal::getValV()` and they are unreliable in any other context.

Actually, in `evaluate()`, one should always use the normalization set
from the proxy, which is in this case a RooArgList (see for example how
the RooAddition does it). This commit suggests to do that for the
RooGenericPdf and RooFormulaVar.

This change fixes the following Jira issue:
[ROOT-5101](https://sft.its.cern.ch/jira/browse/ROOT-5101)

A new unit test is implemented in `testGenericPdf` to cover the problem
reported in that issue.