### PR TITLE
[RF] Correcly pythonize RooAbsCollection::addClone() for all overloads

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabscollection.py
@@ -27,18 +27,24 @@ class RooAbsCollection(object):
     \endcode
     """
 
-    @cpp_signature("RooAbsArg *RooAbsCollection::addClone(const RooAbsArg& var, Bool_t silent=kFALSE) ;")
     def addClone(self, arg, silent=False):
-        r"""The RooAbsCollection::addClone() function is pythonized with the command argument pythonization.
-        The keywords must correspond to the CmdArgs of the function.
-        """
         clonedArg = self._addClone(arg, silent)
-        SetOwnership(clonedArg, False)
+        # There are two overloads of RooAbsCollection::addClone():
+        #
+        #   - RooAbsArg *addClone(const RooAbsArg& var, bool silent=false);
+        #   - void addClone(const RooAbsCollection& list, bool silent=false);
+        #
+        # In the case of the RooAbsArg overload, we need to tell Python that it
+        # doesn't own the returned pointer. That's because the function name
+        # contains "Clone", which makes cppyy guess that the returned pointer
+        # points to a clone owned by the caller. In the case of the
+        # RooAbsCollection input, the return value will be `None` and we don't
+        # need to change any ownership flags (in fact, calling
+        # SetOwnership(None, False) would cause a crash).
+        if clonedArg is not None:
+            SetOwnership(clonedArg, False)
 
-    @cpp_signature("Bool_t RooAbsCollection::addOwned(RooAbsArg& var, Bool_t silent=kFALSE);")
     def addOwned(self, arg, silent=False):
-        r"""The RooAbsCollection::addOwned() function is pythonized with the command argument pythonization.
-        The keywords must correspond to the CmdArgs of the function."""
         self._addOwned(arg, silent)
         SetOwnership(arg, False)
 

--- a/bindings/pyroot/pythonizations/test/roofit/rooabscollection.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooabscollection.py
@@ -135,6 +135,15 @@ class TestRooAbsCollection(unittest.TestCase):
         var0 = ROOT.RooRealVar("var0", "var0", 0)
         self.assertEqual(ROOT.RooArgSet(var0)["var0"], var0)
 
+    def test_clone_collection(self):
+        # Check explicitely that both overloads of addClone work.
+        x = ROOT.RooRealVar("x", "x", 1.0)
+        s1 = ROOT.RooArgSet(x)
+        s2 = ROOT.RooArgSet()
+        s3 = ROOT.RooArgSet()
+
+        s2.addClone(s1) # addClone(const RooAbsCollection& list)
+        s3.addClone(x) # addClone(const RooAbsArg& var)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
There are two overloads of RooAbsCollection::addClone():

  - RooAbsArg *addClone(const RooAbsArg& var, bool silent=false);
  - void addClone(const RooAbsCollection& list, bool silent=false);

In the case of the RooAbsArg overload, we need to tell Python that it
doesn't own the returned pointer. That's because the function name
contains "Clone", which makes cppyy guess that the returned pointer
points to a clone owned by the caller. In the case of the
RooAbsCollection input, the return value will be `None` and we don't
need to change any ownership flags (in fact, calling
SetOwnership(None, False) would cause a crash).

The check for the `None` return value was so far not done in the
pythonization and is added with this commit.

A unit test was also added to check that the RooAbsCollection overloads
both work.

This commit fixes the following Jira issue for good:
[ROOT-9580](https://sft.its.cern.ch/jira/browse/ROOT-9580).