### PR TITLE
[RF] Improve RooStats::HistFactory::PreprocessFunction class

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/PreprocessFunction.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PreprocessFunction.h
@@ -1,54 +1,39 @@
-
 #ifndef PREPROCESS_FUNCTION_H
 #define PREPROCESS_FUNCTION_H
 
 #include <string>
 #include <iostream>
 
-namespace RooStats{
+namespace RooStats {
 namespace HistFactory {
 
-  class PreprocessFunction {
-  public:
+class PreprocessFunction {
+public:
+   PreprocessFunction() {}
 
-    PreprocessFunction();
+   PreprocessFunction(std::string const &name, std::string const &expression, std::string const &dependents);
 
+   void Print(std::ostream & = std::cout) const;
+   void PrintXML(std::ostream &) const;
 
-    PreprocessFunction(std::string Name, std::string Expression, std::string Dependents);
-    std::string GetCommand(std::string Name, std::string Expression, std::string Dependents);
+   void SetName(const std::string &name) { fName = name; }
+   std::string const &GetName() const { return fName; }
 
+   void SetExpression(const std::string &expression) { fExpression = expression; }
+   std::string const &GetExpression() const { return fExpression; }
 
-    void Print(std::ostream& = std::cout);
-    void PrintXML(std::ostream& );
+   void SetDependents(const std::string &dependents) { fDependents = dependents; }
+   std::string const &GetDependents() const { return fDependents; }
 
-    void SetName( const std::string& Name) { fName = Name; }
-    std::string GetName() const { return fName; }
+   std::string GetCommand() const;
 
-    void SetExpression( const std::string& Expression) { fExpression = Expression; }
-    std::string GetExpression() const { return fExpression; }
+private:
+   std::string fName;
+   std::string fExpression;
+   std::string fDependents;
+};
 
-    void SetDependents( const std::string& Dependents) { fDependents = Dependents; }
-    std::string GetDependents() const { return fDependents; }
-
-    void SetCommand( const std::string& Command) { fCommand = Command; }
-    std::string GetCommand() const { return fCommand; }
-
-  protected:
-
-
-    std::string fName;
-    std::string fExpression;
-    std::string fDependents;
-
-    std::string fCommand;
-
-
-
-  };
-
-
-}
-}
-
+} // namespace HistFactory
+} // namespace RooStats
 
 #endif

--- a/roofit/histfactory/src/PreprocessFunction.cxx
+++ b/roofit/histfactory/src/PreprocessFunction.cxx
@@ -13,34 +13,52 @@
  * \ingroup HistFactory
  */
 
-#include "RooStats/HistFactory/PreprocessFunction.h"
+#include <RooStats/HistFactory/PreprocessFunction.h>
 
+#include <sstream>
 
-RooStats::HistFactory::PreprocessFunction::PreprocessFunction() {;}
+namespace {
 
-RooStats::HistFactory::PreprocessFunction::PreprocessFunction(std::string Name, std::string Expression, std::string Dependents) :
-  fName(Name), fExpression(Expression), fDependents(Dependents) {
-  fCommand = GetCommand(Name, Expression, Dependents);
+/// Replaces the XML special characters with their escape codes.
+std::string escapeXML(const std::string &src)
+{
+   std::stringstream dst;
+   for (char ch : src) {
+      switch (ch) {
+      case '&': dst << "&amp;"; break;
+      case '\'': dst << "&apos;"; break;
+      case '"': dst << "&quot;"; break;
+      case '<': dst << "&lt;"; break;
+      case '>': dst << "&gt;"; break;
+      default: dst << ch; break;
+      }
+   }
+   return dst.str();
 }
 
-std::string RooStats::HistFactory::PreprocessFunction::GetCommand(std::string Name, std::string Expression, std::string Dependents) {
-  std::string command = "expr::"+Name+"('"+Expression+"',{"+Dependents+"})";
-  return command;
+} // namespace
+
+RooStats::HistFactory::PreprocessFunction::PreprocessFunction(std::string const &name, std::string const &expression,
+                                                              std::string const &dependents)
+   : fName(name), fExpression(expression), fDependents(dependents)
+{
 }
 
-
-void RooStats::HistFactory::PreprocessFunction::Print( std::ostream& stream ) {
-
-  stream << "\t \t Name: " << fName
-    << "\t \t Expression: " << fExpression
-    << "\t \t Dependents: " << fDependents
-    << std::endl;
-
+std::string RooStats::HistFactory::PreprocessFunction::GetCommand() const
+{
+   return "expr::" + fName + "('" + fExpression + "',{" + fDependents + "})";
 }
 
-void RooStats::HistFactory::PreprocessFunction::PrintXML( std::ostream& xml ) {
-  xml << "<Function Name=\"" << GetName() << "\" "
-      << "Expression=\""     << GetExpression() << "\" "
-      << "Dependents=\""     << GetDependents() << "\" "
-      << "/>" << std::endl;
+void RooStats::HistFactory::PreprocessFunction::Print(std::ostream &stream) const
+{
+   stream << "\t \t Name: " << fName << "\t \t Expression: " << fExpression << "\t \t Dependents: " << fDependents
+          << std::endl;
+}
+
+void RooStats::HistFactory::PreprocessFunction::PrintXML(std::ostream &xml) const
+{
+   xml << "<Function Name=\"" << fName << "\" "
+       << "Expression=\"" << escapeXML(fExpression) << "\" "
+       << "Dependents=\"" << fDependents << "\" "
+       << "/>\n";
 }


### PR DESCRIPTION
Some improvements are made to the `PreprocessFunction` class:

  * add `const` to all the relevant member functions
  * remove the `fCommand` member, because it can be inferred from the
    other 3 members and it should not be set independently
  * use `std::string` by const-reference when possible
  * follow the RooFit coding style of using lower-case vor function
    argument names

Furthermore, a bugfix is also done:

  * in `PreprocessFunction::PrintXML`, replace the XML special
    characters which almost always appear in any formula with the XML
    escape codes

The bugfix addresses a problem where it was not possible to read an XML
generated by `Measurement::PrintXML` because the special characters in
the formula expression were not properly escaped.

With all these changes applied, the source files for this class changed
almost completely, and this opportunity was taken to reformat the code
with the ROOT `clang-format` style.

Closes #10840.
