### PR TITLE
Increase test timeout

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1779,6 +1779,7 @@ endfunction()
 #----------------------------------------------------------------------------
 # function ROOT_ADD_GTEST(<testsuite> source1 source2...
 #                        [WILLFAIL] Negate output of test
+#                        [TIMEOUT seconds]
 #                        [COPY_TO_BUILDDIR file1 file2] Copy listed files when ctest invokes the test.
 #                        [LIBRARIES lib1 lib2...] -- Libraries to link against
 #                        [LABELS label1 label2...] -- Labels to annotate the test
@@ -1790,7 +1791,7 @@ endfunction()
 function(ROOT_ADD_GTEST test_suite)
   cmake_parse_arguments(ARG
     "WILLFAIL"
-    "REPEATS;FAILREGEX"
+    "TIMEOUT;REPEATS;FAILREGEX"
     "COPY_TO_BUILDDIR;LIBRARIES;LABELS;INCLUDE_DIRS" ${ARGN})
 
   ROOT_GET_SOURCES(source_files . ${ARG_UNPARSED_ARGUMENTS})
@@ -1821,9 +1822,7 @@ function(ROOT_ADD_GTEST test_suite)
   if(ARG_WILLFAIL)
     set(willfail WILLFAIL)
   endif()
-  if(ARG_LABELS)
-    set(labels "LABELS ${ARG_LABELS}")
-  endif()
+
   if(ARG_REPEATS)
     set(extra_command --gtest_repeat=${ARG_REPEATS} --gtest_break_on_failure)
   endif()
@@ -1833,10 +1832,11 @@ function(ROOT_ADD_GTEST test_suite)
     gtest${mangled_name}
     COMMAND ${test_suite} ${extra_command}
     WORKING_DIR ${CMAKE_CURRENT_BINARY_DIR}
-    COPY_TO_BUILDDIR ${ARG_COPY_TO_BUILDDIR}
+    COPY_TO_BUILDDIR "${ARG_COPY_TO_BUILDDIR}"
     ${willfail}
-    ${labels}
-    FAILREGEX ${ARG_FAILREGEX}
+    TIMEOUT "${ARG_TIMEOUT}"
+    LABELS "${ARG_LABELS}"
+    FAILREGEX "${ARG_FAILREGEX}"
   )
 endfunction()
 

--- a/tmva/tmva/test/DNN/CMakeLists.txt
+++ b/tmva/tmva/test/DNN/CMakeLists.txt
@@ -144,7 +144,7 @@ ROOT_ADD_TEST(TMVA-DNN-MethodDL-SGD-Optimization-Cpu COMMAND testMethodDLSGDOpti
 
 # DNN - MethodDL Adam Optimization CPU
 ROOT_EXECUTABLE(testMethodDLAdamOptimizationCpu TestMethodDLAdamOptimizationCpu.cxx LIBRARIES ${Libraries})
-ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adam-Optimization-Cpu COMMAND testMethodDLAdamOptimizationCpu)
+ROOT_ADD_TEST(TMVA-DNN-MethodDL-Adam-Optimization-Cpu COMMAND testMethodDLAdamOptimizationCpu TIMEOUT 1800)
 
 # DNN - MethodDL Adagrad Optimization CPU
 ROOT_EXECUTABLE(testMethodDLAdagradOptimizationCpu TestMethodDLAdagradOptimizationCpu.cxx LIBRARIES ${Libraries})

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -20,7 +20,7 @@ ROOT_ADD_GTEST(testBulkApi BulkApi.cxx LIBRARIES RIO Tree TreePlayer)
 #FIXME: tests are having timeout on 32bit CERN VM (in docker container everything is fine),
 # to be reverted after investigation.
 if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
-  ROOT_ADD_GTEST(testBulkApiMultiple BulkApiMultiple.cxx LIBRARIES RIO Tree TreePlayer)
+  ROOT_ADD_GTEST(testBulkApiMultiple BulkApiMultiple.cxx LIBRARIES RIO Tree TreePlayer TIMEOUT 3000)
   ROOT_ADD_GTEST(testBulkApiVarLength BulkApiVarLength.cxx LIBRARIES RIO Tree TreePlayer)
   ROOT_ADD_GTEST(testBulkApiSillyStruct BulkApiSillyStruct.cxx LIBRARIES RIO Tree TreePlayer SillyStruct)
 endif()

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -593,7 +593,7 @@ foreach(t ${tutorials})
 
    # These tests on ARM64 need much more than 20 minutes - increase the timeout
    if(ROOT_ARCHITECTURE MATCHES arm64 OR ROOT_ARCHITECTURE MATCHES ppc64)
-     set(thisTestTimeout 2400) # 40m
+     set(thisTestTimeout 3000) # 50m
    else()
      set(thisTestTimeout 1200) # 20m
    endif()
@@ -627,7 +627,7 @@ foreach(t ${mpi_tutorials})
 
    # These tests on ARM64 need much more than 20 minutes - increase the timeout
    if(ROOT_ARCHITECTURE MATCHES arm64 OR ROOT_ARCHITECTURE MATCHES ppc64)
-     set(thisTestTimeout 2400) # 40m
+     set(thisTestTimeout 3000) # 50m
    else()
      set(thisTestTimeout 1200) # 20m
    endif()


### PR DESCRIPTION
# This Pull request:

Increase some test timeouts

## Changes or fixes:

Fixes occasional test timeout failures. Mostly seen on aarch64.
```
The following tests FAILED:
	330 - TMVA-DNN-MethodDL-Adam-Optimization-Cpu (Timeout)
	967 - tutorial-tmva-TMVAMulticlass (Timeout)
```
The timeout has been seen for various tutorial-tmva-TMVA* tests, not just the one mentions above.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
