### PR TITLE
[ntuple,daos] Enable configurable cluster prefetching

### DIFF
--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -288,14 +288,11 @@ void ROOT::Experimental::Detail::RPageAllocatorDaos::DeletePage(const RPage& pag
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
 ROOT::Experimental::Detail::RPageSourceDaos::RPageSourceDaos(std::string_view ntupleName, std::string_view uri,
-   const RNTupleReadOptions &options)
-   : RPageSource(ntupleName, options)
-   , fPageAllocator(std::make_unique<RPageAllocatorDaos>())
-   , fPagePool(std::make_shared<RPagePool>())
-   , fURI(uri)
-   , fClusterPool(std::make_unique<RClusterPool>(*this))
+                                                             const RNTupleReadOptions &options)
+   : RPageSource(ntupleName, options), fPageAllocator(std::make_unique<RPageAllocatorDaos>()),
+     fPagePool(std::make_shared<RPagePool>()), fURI(uri),
+     fClusterPool(std::make_unique<RClusterPool>(*this, options.GetClusterBunchSize()))
 {
    fDecompressor = std::make_unique<RNTupleDecompressor>();
    EnableDefaultMetrics("RPageSourceDaos");

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -65,7 +65,9 @@ TEST(RPageStorageDaos, Extended)
       }
    }
 
-   auto ntuple = RNTupleReader::Open("f", daosUri);
+   RNTupleReadOptions options;
+   options.SetClusterBunchSize(5);
+   auto ntuple = RNTupleReader::Open("f", daosUri, options);
    auto rdVector = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
@@ -105,8 +107,11 @@ TEST(RPageStorageDaos, Options)
       ntuple->CommitCluster();
    }
 
-   ROOT::Experimental::Detail::RPageSourceDaos source("ntuple", daosUri, RNTupleReadOptions());
+   auto readOptions = RNTupleReadOptions();
+   readOptions.SetClusterBunchSize(3);
+   ROOT::Experimental::Detail::RPageSourceDaos source("ntuple", daosUri, readOptions);
    source.Attach();
    EXPECT_STREQ("RP_XSF", source.GetObjectClass().c_str());
+   EXPECT_EQ(3U, source.GetReadOptions().GetClusterBunchSize());
    EXPECT_EQ(1U, source.GetNEntries());
 }


### PR DESCRIPTION
This Pull request fixes a bug in `RPageSourceDaos` in which the cluster bunch default size does not get overridden by the one provided in `RNTupleReadOptions`. This change thus enables the prefetching of a configurable number of clusters while the current bunch is being processed, similarly to what is done in the constructor for `RPageSourceFile`.

## Changes or fixes:

- `RPageSourceDaos` ctor now uses the value in `RNTupleReadOptions::fClusterBunchSize` to initialize its `RClusterPool` with configurable read-ahead number of clusters, overwriting the default value of `1`. The change parallels the constructor implementation of `RPageSourceFile`. 

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

Related to PR #9100, which introduced the prefetching capability.