### PR TITLE
[TO REVERT] Add debug prints to dataframe_snapshot

### DIFF
--- a/tree/dataframe/test/dataframe_snapshot.cxx
+++ b/tree/dataframe/test/dataframe_snapshot.cxx
@@ -293,12 +293,18 @@ void checkSnapshotArrayFile(RResultPtr<RInterface<RLoopManager>> &df, unsigned i
       const auto &bv = varSizeBoolArr->at(i);
       EXPECT_EQ(thisSize, dv.size());
       EXPECT_EQ(thisSize, bv.size());
+      std::cout << "bv: ";
+      for (auto j = 0u; j < thisSize; ++j)
+         std::cout << bv[j] << ' ';
+      std::cout << "\nexpected: ";
       for (auto j = 0u; j < thisSize; ++j) {
          EXPECT_DOUBLE_EQ(dv[j], i * j);
          const bool value = bv[j];
          const bool expected = j % 2 == 0;
+         std::cout << expected << ' ';
          EXPECT_EQ(value, expected);
       }
+      std::cout << '\n';
    }
 }
 


### PR DESCRIPTION
In order to debug not understood test failures that we could
not reproduce outside of the CI.
