### PR TITLE
[DF] Remove some protections from compiler warnings

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1670,25 +1670,23 @@ public:
       // With this code, we set the value of the pointer in the output branch anew when needed.
       // Nota bene: the extra ",0" after the invocation of SetAddress, is because that method returns void and
       // we need an int for the expander list.
-      (void)slot; // avoid bogus 'unused parameter' warning
       int expander[] = {(fBranches[slot][S] && fBranchAddresses[slot][S] != GetData(values)
                          ? fBranches[slot][S]->SetAddress(GetData(values)),
                          fBranchAddresses[slot][S] = GetData(values), 0 : 0, 0)...,
                         0};
-      (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
+      (void)expander; // avoid unused parameter warnings (gcc 12.1)
    }
 
    template <std::size_t... S>
    void SetBranches(unsigned int slot, ColTypes &... values, std::index_sequence<S...> /*dummy*/)
    {
-         // hack to call TTree::Branch on all variadic template arguments
-         int expander[] = {(SetBranchesHelper(fInputTrees[slot], *fOutputTrees[slot], fInputBranchNames[S],
-                                              fOutputBranchNames[S], fBranches[slot][S], fBranchAddresses[slot][S],
-                                              &values, fOutputBranches[slot], fIsDefine[S]),
-                            0)...,
-                           0};
-         (void)expander; // avoid unused variable warnings for older compilers such as gcc 4.9
-         (void)slot;     // avoid unused variable warnings in gcc6.2
+      // hack to call TTree::Branch on all variadic template arguments
+      int expander[] = {(SetBranchesHelper(fInputTrees[slot], *fOutputTrees[slot], fInputBranchNames[S],
+                                           fOutputBranchNames[S], fBranches[slot][S], fBranchAddresses[slot][S],
+                                           &values, fOutputBranches[slot], fIsDefine[S]),
+                         0)...,
+                        0};
+      (void)expander; // avoid unused parameter warnings (gcc 12.1)
    }
 
    void Initialize()

--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -110,10 +110,6 @@ MakeColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, cons
                                                                : nullptr,
                                          variationName))}...}};
    return ret;
-
-   // avoid bogus "unused variable" warnings
-   (void)slot;
-   (void)r;
 }
 
 // Shortcut overload for the case of no columns

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -104,7 +104,7 @@ public:
    void CallExec(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
       fHelper.Exec(slot, fValues[slot][S]->template Get<ColTypes>(entry)...);
-      (void)entry; // avoid "unused parameter" warnings
+      (void)entry; // avoid unused parameter warning (gcc 12.1)
    }
 
    void Run(unsigned int slot, Long64_t entry) final

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -75,9 +75,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    {
       fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
          fExpression(fValues[slot][S]->template Get<ColTypes>(entry)...);
-      // silence "unused parameter" warnings in gcc
-      (void)slot;
-      (void)entry;
+      (void)entry; // avoid unused parameter warning (gcc 12.1)
    }
 
    template <typename... ColTypes, std::size_t... S>
@@ -85,9 +83,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    {
       fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
          fExpression(slot, fValues[slot][S]->template Get<ColTypes>(entry)...);
-      // silence "unused parameter" warnings in gcc
-      (void)slot;
-      (void)entry;
+      (void)entry; // avoid unused parameter warning (gcc 12.1)
    }
 
    template <typename... ColTypes, std::size_t... S>
@@ -96,9 +92,6 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    {
       fLastResults[slot * RDFInternal::CacheLineStep<ret_type>()] =
          fExpression(slot, entry, fValues[slot][S]->template Get<ColTypes>(entry)...);
-      // silence "unused parameter" warnings in gcc
-      (void)slot;
-      (void)entry;
    }
 
 public:

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -110,10 +110,10 @@ public:
    template <typename... ColTypes, std::size_t... S>
    bool CheckFilterHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
    {
-      // silence "unused parameter" warnings in gcc
+      return fFilter(fValues[slot][S]->template Get<ColTypes>(entry)...);
+      // avoid unused parameter warnings (gcc 12.1)
       (void)slot;
       (void)entry;
-      return fFilter(fValues[slot][S]->template Get<ColTypes>(entry)...);
    }
 
    void InitSlot(TTreeReader *r, unsigned int slot) final

--- a/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RNodeBase.hxx
@@ -74,11 +74,10 @@ public:
    const std::vector<std::string> &GetVariations() const { return fVariations; }
 
    /// Return a clone of this node that acts as a Filter working with values in the variationName "universe".
-   virtual std::shared_ptr<RNodeBase> GetVariedFilter(const std::string &variationName)
+   virtual std::shared_ptr<RNodeBase> GetVariedFilter(const std::string & /*variationName*/)
    {
       R__ASSERT(false &&
                 "GetVariedFilter was called on a node type that does not implement it. This should never happen.");
-      (void)variationName;
       return nullptr;
    }
 };

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -155,6 +155,7 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    {
       // fExpression must return an RVec<T>
       auto &&results = fExpression(fValues[slot][S]->template Get<ColTypes>(entry)...);
+      (void)entry; // avoid unused parameter warnings (gcc 12.1)
 
       if (!ResultsSizeEq(results, fVariationNames.size(), fColNames.size())) {
          std::string variationName = fVariationNames[0].substr(0, fVariationNames[0].find_first_of(':'));
@@ -164,10 +165,6 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
       }
 
       AssignResults(fLastResults[slot * CacheLineStep<ret_type>()], std::move(results), fColNames.size());
-
-      // silence "unused parameter" warnings in gcc
-      (void)slot;
-      (void)entry;
    }
 
    // This overload is for the case of a single column and ret_type != RVec<RVec<...>> -- the colIdx is ignored.

--- a/tree/dataframe/test/dataframe_simple.cxx
+++ b/tree/dataframe/test/dataframe_simple.cxx
@@ -576,15 +576,9 @@ TEST_P(RDFSimpleTests, Graph)
 
    // Create the graph from the Dataframe
    ROOT::RDataFrame d(NR_ELEMENTS);
-   auto dd = d.DefineSlotEntry("x1",
-                               [&source](unsigned int slot, ULong64_t entry) {
-                                  (void)slot;
-                                  return source[entry];
-                               })
-                .DefineSlotEntry("x2", [&source](unsigned int slot, ULong64_t entry) {
-                   (void)slot;
-                   return source[entry];
-                });
+   auto dd = d.DefineSlotEntry("x1", [&source](unsigned int /*slot*/, ULong64_t entry) {
+                 return source[entry];
+              }).DefineSlotEntry("x2", [&source](unsigned int /*slot*/, ULong64_t entry) { return source[entry]; });
 
    auto dfGraph = dd.Graph("x1", "x2");
    EXPECT_EQ(dfGraph->GetN(), NR_ELEMENTS);
@@ -663,12 +657,9 @@ public:
    double stdDevFromWelford()
    {
       ROOT::RDataFrame d(samples.size());
-      return *d.DefineSlotEntry("x",
-                                [this](unsigned int slot, ULong64_t entry) {
-                                   (void)slot;
-                                   return samples[entry];
-                                })
-                 .StdDev("x");
+      return *d.DefineSlotEntry("x", [this](unsigned int /*slot*/, ULong64_t entry) {
+                  return samples[entry];
+               }).StdDev("x");
    }
 };
 

--- a/tree/dataframe/test/datasource_csv.cxx
+++ b/tree/dataframe/test/datasource_csv.cxx
@@ -253,7 +253,6 @@ TEST(RCsvDS, WindowsLinebreaks)
 
 TEST(RCsvDS, Remote)
 {
-   (void)url0; // silence -Wunused-const-variable
 #ifdef R__HAS_DAVIX
    auto tdf = ROOT::RDF::MakeCsvDataFrame(url0, false);
    EXPECT_EQ(1U, *tdf.Count());

--- a/tree/dataframe/test/datasource_sqlite.cxx
+++ b/tree/dataframe/test/datasource_sqlite.cxx
@@ -228,7 +228,6 @@ TEST(RSqliteDS, IMT)
 
 TEST(RSqliteDS, Davix)
 {
-   (void)url1; // silence -Wunused-const-variable
 #ifdef R__HAS_DAVIX
    auto rdf = MakeSqliteDataFrame(url0, query0);
    EXPECT_EQ(1, *rdf.Min("fint"));
@@ -237,5 +236,6 @@ TEST(RSqliteDS, Davix)
    EXPECT_THROW(MakeSqliteDataFrame(url1, query0), std::runtime_error);
 #else
    EXPECT_THROW(MakeSqliteDataFrame(url0, query0), std::runtime_error);
+   (void)url1; // silence -Wunused-const-variable
 #endif
 }


### PR DESCRIPTION
This way we can check if they are still useful with modern compilers (e.g. with gcc 12.1 I get no warnings).