### PR TITLE
Add utility function to retrieve friend entries and use it in TTreeProcessorMT

### DIFF
--- a/tree/tree/inc/ROOT/InternalTreeUtils.hxx
+++ b/tree/tree/inc/ROOT/InternalTreeUtils.hxx
@@ -18,6 +18,7 @@
 #ifndef ROOT_INTERNAL_TREEUTILS_H
 #define ROOT_INTERNAL_TREEUTILS_H
 
+#include "TTree.h"
 #include "TChain.h"
 #include "TNotifyLink.h"
 #include "TObjArray.h"
@@ -27,8 +28,6 @@
 #include <string>
 #include <utility> // std::pair
 #include <vector>
-
-class TTree;
 
 namespace ROOT {
 namespace Internal {
@@ -41,7 +40,7 @@ namespace TreeUtils {
 
 std::vector<std::string> GetTopLevelBranchNames(TTree &t);
 std::vector<std::string> GetFileNamesFromTree(const TTree &tree);
-ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree);
+ROOT::TreeUtils::RFriendInfo GetFriendInfo(const TTree &tree, bool retrieveEntries = false);
 std::vector<std::string> GetTreeFullPaths(const TTree &tree);
 
 void ClearMustCleanupBits(TObjArray &arr);
@@ -77,6 +76,7 @@ public:
 };
 
 std::unique_ptr<TChain> MakeChainForMT(const std::string &name = "", const std::string &title = "");
+std::vector<std::unique_ptr<TChain>> MakeFriends(const ROOT::TreeUtils::RFriendInfo &finfo);
 
 } // namespace TreeUtils
 } // namespace Internal

--- a/tree/tree/inc/ROOT/RFriendInfo.hxx
+++ b/tree/tree/inc/ROOT/RFriendInfo.hxx
@@ -18,6 +18,7 @@
 #ifndef ROOT_RFRIENDINFO_H
 #define ROOT_RFRIENDINFO_H
 
+#include <cstdint> // std::int64_t
 #include <string>
 #include <utility> // std::pair
 #include <vector>
@@ -33,8 +34,10 @@ namespace TreeUtils {
 */
 struct RFriendInfo {
 
-   std::vector<std::pair<std::string, std::string>>
-      fFriendNames; ///< Pairs of names and aliases of friend trees/chains.
+   /**
+    * Pairs of names and aliases of each friend tree/chain.
+    */
+   std::vector<std::pair<std::string, std::string>> fFriendNames;
    /**
    Names of the files where each friend is stored. fFriendFileNames[i] is the
    list of files for friend with name fFriendNames[i].
@@ -48,6 +51,12 @@ struct RFriendInfo {
       vector.
    */
    std::vector<std::vector<std::string>> fFriendChainSubNames;
+   /**
+    * Number of entries contained in each tree of each friend. The outer
+    * dimension of the vector tracks the n-th friend tree/chain, the inner
+    * dimension tracks the number of entries of each tree in the current friend.
+    */
+   std::vector<std::vector<std::int64_t>> fNEntriesPerTreePerFriend;
 
    void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "");
 

--- a/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeProcessorMT.hxx
@@ -62,8 +62,7 @@ class TTreeView {
    std::unique_ptr<TChain> fChain; ///< Chain on which to operate
 
    void MakeChain(const std::vector<std::string> &treeName, const std::vector<std::string> &fileNames,
-                  const ROOT::TreeUtils::RFriendInfo &friendInfo, const std::vector<Long64_t> &nEntries,
-                  const std::vector<std::vector<Long64_t>> &friendEntries);
+                  const ROOT::TreeUtils::RFriendInfo &friendInfo, const std::vector<Long64_t> &nEntries);
 
 public:
    TTreeView() = default;
@@ -72,8 +71,7 @@ public:
    std::unique_ptr<TTreeReader> GetTreeReader(Long64_t start, Long64_t end, const std::vector<std::string> &treeName,
                                               const std::vector<std::string> &fileNames,
                                               const ROOT::TreeUtils::RFriendInfo &friendInfo,
-                                              const TEntryList &entryList, const std::vector<Long64_t> &nEntries,
-                                              const std::vector<std::vector<Long64_t>> &friendEntries);
+                                              const TEntryList &entryList, const std::vector<Long64_t> &nEntries);
    void Reset();
 };
 } // End of namespace Internal
@@ -84,7 +82,7 @@ private:
    const std::vector<std::string> fTreeNames; ///< TTree names (always same size and ordering as fFileNames)
    /// User-defined selection of entry numbers to be processed, empty if none was provided
    TEntryList fEntryList;
-   const ROOT::TreeUtils::RFriendInfo fFriendInfo;
+   ROOT::TreeUtils::RFriendInfo fFriendInfo;
    ROOT::TThreadExecutor fPool; ///<! Thread pool for processing.
 
    /// Thread-local TreeViews


### PR DESCRIPTION
First draft of creating a new utility function that allows creating the friend trees starting from an RFriendInfo object and attaching them to a tree. This required also taking care of the possibility of knowing/using entries of the friends. As a first example, the new functionality is used in TTreeProcessorMT