### PR TITLE
[DF] Centralize RDefineReaders and RVariationReaders 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -44,13 +44,13 @@ class RVariationReader;
 class RDefinesWithReaders {
    using RDefineBase = RDFDetail::RDefineBase;
 
-   std::shared_ptr<RDefineBase> fDefine;
+   std::shared_ptr<RDefineBase> fDefine; // cannot be null
    // Column readers per variation (in the map) per slot (in the vector).
    std::vector<std::unordered_map<std::string, std::shared_ptr<RDefineReader>>> fReadersPerVariation;
 
 public:
    RDefinesWithReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
-   RDefineBase *GetDefine() const { return fDefine.get(); }
+   RDefineBase &GetDefine() const { return *fDefine; }
    std::shared_ptr<RDefineReader>
    GetReader(unsigned int slot, const std::string &variationName, const std::type_info &);
 };

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -41,7 +41,7 @@ class RVariationBase;
 class RVariationReader;
 
 /// A helper type that keeps track of RDefine objects and their corresponding RDefineReaders.
-class RDefineAndReaders {
+class RDefinesWithReaders {
    using RDefineBase = RDFDetail::RDefineBase;
 
    std::shared_ptr<RDefineBase> fDefine;
@@ -49,19 +49,19 @@ class RDefineAndReaders {
    std::vector<std::unordered_map<std::string, std::shared_ptr<RDefineReader>>> fReadersPerVariation;
 
 public:
-   RDefineAndReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
+   RDefinesWithReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
    RDefineBase *GetDefine() const { return fDefine.get(); }
    std::shared_ptr<RDefineReader>
    GetReader(unsigned int slot, const std::string &variationName, const std::type_info &);
 };
 
-class RVariationAndReaders {
+class RVariationsWithReaders {
    std::shared_ptr<RVariationBase> fVariation;
    // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
    std::vector<std::unordered_map<std::string, std::shared_ptr<RVariationReader>>> fReadersPerVariation;
 
 public:
-   RVariationAndReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
+   RVariationsWithReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
    RVariationBase *GetVariation() const { return fVariation.get(); }
    std::shared_ptr<RVariationReader> GetReader(unsigned int slot, const std::string &colName,
                                                const std::string &variationName, const std::type_info &tid);
@@ -75,9 +75,9 @@ public:
  */
 class RColumnRegister {
    using ColumnNames_t = std::vector<std::string>;
-   using DefinesMap_t = std::unordered_map<std::string, std::shared_ptr<RDefineAndReaders>>;
+   using DefinesMap_t = std::unordered_map<std::string, std::shared_ptr<RDefinesWithReaders>>;
    /// See fVariations for more information on this type.
-   using VariationsMap_t = std::unordered_multimap<std::string, std::shared_ptr<RVariationAndReaders>>;
+   using VariationsMap_t = std::unordered_multimap<std::string, std::shared_ptr<RVariationsWithReaders>>;
 
    std::shared_ptr<RDFDetail::RLoopManager> fLoopManager;
 
@@ -95,7 +95,7 @@ class RColumnRegister {
 
    void AddName(std::string_view name);
 
-   RVariationAndReaders *FindVariationAndReaders(const std::string &colName, const std::string &variationName);
+   RVariationsWithReaders *FindVariationAndReaders(const std::string &colName, const std::string &variationName);
 
 public:
    RColumnRegister(const RColumnRegister &) = default;

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -25,6 +25,7 @@ class RVariationsDescription;
 }
 namespace Detail {
 namespace RDF {
+class RColumnReaderBase;
 class RDefineBase;
 class RLoopManager;
 }
@@ -35,7 +36,36 @@ namespace RDF {
 
 namespace RDFDetail = ROOT::Detail::RDF;
 
+class RDefineReader;
 class RVariationBase;
+class RVariationReader;
+
+/// A helper type that keeps track of RDefine objects and their corresponding RDefineReaders.
+class RDefineAndReaders {
+   using RDefineBase = RDFDetail::RDefineBase;
+
+   std::shared_ptr<RDefineBase> fDefine;
+   // Column readers per variation (in the map) per slot (in the vector).
+   std::vector<std::unordered_map<std::string, std::shared_ptr<RDefineReader>>> fReadersPerVariation;
+
+public:
+   RDefineAndReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
+   RDefineBase *GetDefine() const { return fDefine.get(); }
+   std::shared_ptr<RDefineReader>
+   GetReader(unsigned int slot, const std::string &variationName, const std::type_info &);
+};
+
+class RVariationAndReaders {
+   std::shared_ptr<RVariationBase> fVariation;
+   // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
+   std::vector<std::unordered_map<std::string, std::shared_ptr<RVariationReader>>> fReadersPerVariation;
+
+public:
+   RVariationAndReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
+   RVariationBase *GetVariation() const { return fVariation.get(); }
+   std::shared_ptr<RVariationReader> GetReader(unsigned int slot, const std::string &colName,
+                                               const std::string &variationName, const std::type_info &tid);
+};
 
 /**
  * \class ROOT::Internal::RDF::RColumnRegister
@@ -45,26 +75,27 @@ class RVariationBase;
  */
 class RColumnRegister {
    using ColumnNames_t = std::vector<std::string>;
-   using DefinesMap_t = std::unordered_map<std::string, std::shared_ptr<RDFDetail::RDefineBase>>;
+   using DefinesMap_t = std::unordered_map<std::string, std::shared_ptr<RDefineAndReaders>>;
    /// See fVariations for more information on this type.
-   using VariationsMap_t = std::unordered_multimap<std::string, std::shared_ptr<RVariationBase>>;
+   using VariationsMap_t = std::unordered_multimap<std::string, std::shared_ptr<RVariationAndReaders>>;
 
    std::shared_ptr<RDFDetail::RLoopManager> fLoopManager;
 
-   /// Immutable map of Defines, can be shared among several nodes.
-   /// When a new define is added (through a call to RInterface::Define or similar) a new map with the extra element is
-   /// created.
-   std::shared_ptr<const DefinesMap_t> fDefines;
+   /// Immutable collection of Defines, can be shared among several nodes.
+   /// The pointee changes if a new Define node is added to the RColumnRegister.
+   std::shared_ptr<DefinesMap_t> fDefines;
    /// Immutable map of Aliases, can be shared among several nodes.
    std::shared_ptr<const std::unordered_map<std::string, std::string>> fAliases;
    /// Immutable multimap of Variations, can be shared among several nodes.
    /// The key is the name of an existing column, the values are all variations that affect that column.
    /// Variations that affect multiple columns are inserted in the map multiple times, once per column,
    /// and conversely each column (i.e. each key) can have several associated variations.
-   std::shared_ptr<const VariationsMap_t> fVariations;
+   std::shared_ptr<VariationsMap_t> fVariations;
    std::shared_ptr<const ColumnNames_t> fColumnNames; ///< Names of Defines and Aliases registered so far.
 
    void AddName(std::string_view name);
+
+   RVariationAndReaders *FindVariationAndReaders(const std::string &colName, const std::string &variationName);
 
 public:
    RColumnRegister(const RColumnRegister &) = default;
@@ -108,6 +139,9 @@ public:
    ROOT::RDF::RVariationsDescription BuildVariationsDescription() const;
 
    RVariationBase &FindVariation(const std::string &colName, const std::string &variationName) const;
+
+   std::shared_ptr<RDFDetail::RColumnReaderBase> GetReader(unsigned int slot, const std::string &colName,
+                                                           const std::string &variationName, const std::type_info &tid);
 };
 
 } // Namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -56,13 +56,13 @@ public:
 };
 
 class RVariationsWithReaders {
-   std::shared_ptr<RVariationBase> fVariation;
+   std::shared_ptr<RVariationBase> fVariation; // cannot be null
    // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
    std::vector<std::unordered_map<std::string, std::shared_ptr<RVariationReader>>> fReadersPerVariation;
 
 public:
    RVariationsWithReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
-   RVariationBase *GetVariation() const { return fVariation.get(); }
+   RVariationBase &GetVariation() const { return *fVariation; }
    std::shared_ptr<RVariationReader> GetReader(unsigned int slot, const std::string &colName,
                                                const std::string &variationName, const std::type_info &tid);
 };

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -138,8 +138,6 @@ public:
 
    ROOT::RDF::RVariationsDescription BuildVariationsDescription() const;
 
-   RVariationBase &FindVariation(const std::string &colName, const std::string &variationName) const;
-
    std::shared_ptr<RDFDetail::RColumnReaderBase> GetReader(unsigned int slot, const std::string &colName,
                                                            const std::string &variationName, const std::type_info &tid);
 };

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -118,7 +118,7 @@ void RColumnRegister::AddDefine(std::shared_ptr<RDFDetail::RDefineBase> define)
    auto newDefines = std::make_shared<DefinesMap_t>(*fDefines);
    const std::string &colName = define->GetName();
 
-   // this will assign over a pre-exising element in case this AddDefine is due to a Redefine
+   // this will assign over a pre-existing element in case this AddDefine is due to a Redefine
    (*newDefines)[colName] = std::make_shared<RDefineAndReaders>(define, fLoopManager->GetNSlots());
 
    fDefines = std::move(newDefines);

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -143,7 +143,7 @@ std::vector<std::string> RColumnRegister::GetVariationsFor(const std::string &co
    std::vector<std::string> variations;
    auto range = fVariations->equal_range(column);
    for (auto it = range.first; it != range.second; ++it)
-      for (const auto &variationName : it->second->GetVariation()->GetVariationNames())
+      for (const auto &variationName : it->second->GetVariation().GetVariationNames())
          variations.emplace_back(variationName);
 
    return variations;
@@ -195,7 +195,7 @@ RColumnRegister::FindVariationAndReaders(const std::string &colName, const std::
    if (range.first == fVariations->end())
       return nullptr;
    for (auto it = range.first; it != range.second; ++it) {
-      if (IsStrInVec(variationName, it->second->GetVariation()->GetVariationNames()))
+      if (IsStrInVec(variationName, it->second->GetVariation().GetVariationNames()))
          return it->second.get();
    }
 
@@ -206,7 +206,7 @@ ROOT::RDF::RVariationsDescription RColumnRegister::BuildVariationsDescription() 
 {
    std::set<const RVariationBase *> uniqueVariations;
    for (auto &e : *fVariations)
-      uniqueVariations.insert(e.second->GetVariation());
+      uniqueVariations.insert(&e.second->GetVariation());
 
    const std::vector<const RVariationBase *> variations(uniqueVariations.begin(), uniqueVariations.end());
    return ROOT::RDF::RVariationsDescription{variations};

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -99,7 +99,7 @@ ColumnNames_t RColumnRegister::BuildDefineNames() const
 RDFDetail::RDefineBase *RColumnRegister::GetDefine(const std::string &colName) const
 {
    auto it = fDefines->find(colName);
-   return it == fDefines->end() ? nullptr : it->second->GetDefine();
+   return it == fDefines->end() ? nullptr : &it->second->GetDefine();
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -177,7 +177,7 @@ std::vector<std::string> RColumnRegister::GetVariationDeps(const ColumnNames_t &
       // For Define'd columns, add the systematic variations they depend on to the set
       auto defineIt = fDefines->find(col);
       if (defineIt != fDefines->end()) {
-         for (const auto &v : defineIt->second->GetDefine()->GetVariations())
+         for (const auto &v : defineIt->second->GetDefine().GetVariations())
             variationNames.insert(v);
       }
    }

--- a/tree/dataframe/src/RDFColumnRegister.cxx
+++ b/tree/dataframe/src/RDFColumnRegister.cxx
@@ -186,19 +186,6 @@ std::vector<std::string> RColumnRegister::GetVariationDeps(const ColumnNames_t &
 }
 
 ////////////////////////////////////////////////////////////////////////////
-/// \brief Return the RVariation object that handles the specified variation of the specified column.
-RVariationBase &RColumnRegister::FindVariation(const std::string &colName, const std::string &variationName) const
-{
-   auto range = fVariations->equal_range(colName);
-   assert(range.first != fVariations->end() && "Could not find the variation you asked for. This should never happen.");
-   auto it = range.first;
-   while (it != range.second && !IsStrInVec(variationName, it->second->GetVariation()->GetVariationNames()))
-      ++it;
-   assert(it != range.second && "Could not find the variation you asked for. This should never happen.");
-   return *it->second->GetVariation();
-}
-
-////////////////////////////////////////////////////////////////////////////
 /// \brief Return the RVariationAndReaders object that handles the specified variation of the specified column, or null.
 RVariationAndReaders *
 RColumnRegister::FindVariationAndReaders(const std::string &colName, const std::string &variationName)


### PR DESCRIPTION
Rather than constructing a different reader for each node that
needs it, with this patch we now leverage RColumnRegister as
a "cache" of RDefineReaders and RVariationReaders so that nodes
in the computation graph share the same reader objects (per
processing slot). This is analogous to what RLoopManager does
for RDSColumnReaders and RTreeColumnReaders.

Sharing column readers across the computation graph will be useful
for bulk loading of event values (which we do not want to repeat
for different instances of a given column's reader).