### PR TITLE
Fix generation of G__NetxNG.cxx in paths with special characters

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -296,6 +296,8 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     if(target_incdirs)
        foreach(dir ${target_incdirs})
           string(REGEX REPLACE "^[$]<BUILD_INTERFACE:(.+)>" "\\1" dir ${dir})
+          # rootcling doesn't like paths terminated by a '>'
+          string(REGEX REPLACE ">$" "" dir ${dir})
           # check that dir not a empty dir like $<BUILD_INTERFACE:>
           if(NOT ${dir} MATCHES "^[$]")
              list(APPEND incdirs ${dir})

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -296,7 +296,8 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     if(target_incdirs)
        foreach(dir ${target_incdirs})
           string(REGEX REPLACE "^[$]<BUILD_INTERFACE:(.+)>" "\\1" dir ${dir})
-          # rootcling doesn't like paths terminated by a '>'
+          # BUILD_INTERFACE might contain space-separated paths. They are split by
+          # foreach, leaving a trailing 'include/something>'. Remove the trailing '>'.
           string(REGEX REPLACE ">$" "" dir ${dir})
           # check that dir not a empty dir like $<BUILD_INTERFACE:>
           if(NOT ${dir} MATCHES "^[$]")


### PR DESCRIPTION
Fix generation of `G__NetxNG.cxx` in paths with special characters, as described on the forum:
https://root-forum.cern.ch/t/6-26-04-build-error-in-debian-bullseye/50412
