### PR TITLE
[RF] Convert three RooStats tutorials to Python

### DIFF
--- a/tutorials/roostats/IntervalExamples.py
+++ b/tutorials/roostats/IntervalExamples.py
@@ -1,0 +1,157 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook
+## Example showing confidence intervals with four techniques.
+##
+## An example that shows confidence intervals with four techniques.
+## The model is a Normal Gaussian G(x|mu,sigma) with 100 samples of x.
+## The answer is known analytically, so this is a good example to validate
+## the RooStats tools.
+##
+##  - expected interval is [-0.162917, 0.229075]
+##  - plc  interval is     [-0.162917, 0.229075]
+##  - fc   interval is     [-0.17    , 0.23]        // stepsize is 0.01
+##  - bc   interval is     [-0.162918, 0.229076]
+##  - mcmc interval is     [-0.166999, 0.230224]
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Kyle Cranmer (C++ version)
+
+import ROOT
+
+# Time this macro
+t = ROOT.TStopwatch()
+t.Start()
+
+# set RooFit random seed for reproducible results
+ROOT.RooRandom.randomGenerator().SetSeed(3001)
+
+# make a simple model via the workspace factory
+wspace = ROOT.RooWorkspace()
+wspace.factory("Gaussian::normal(x[-10,10],mu[-1,1],sigma[1])")
+wspace.defineSet("poi", "mu")
+wspace.defineSet("obs", "x")
+
+# specify components of model for statistical tools
+modelConfig = ROOT.RooStats.ModelConfig("Example G(x|mu,1)")
+modelConfig.SetWorkspace(wspace)
+modelConfig.SetPdf(wspace["normal"])
+modelConfig.SetParametersOfInterest(wspace.set("poi"))
+modelConfig.SetObservables(wspace.set("obs"))
+
+# create a toy dataset
+data = wspace["normal"].generate(wspace.set("obs"), 100)
+data.Print()
+
+# for convenience later on
+x = wspace["x"]
+mu = wspace["mu"]
+
+# set confidence level
+confidenceLevel = 0.95
+
+# example use profile likelihood calculator
+plc = ROOT.RooStats.ProfileLikelihoodCalculator(data, modelConfig)
+plc.SetConfidenceLevel(confidenceLevel)
+plInt = plc.GetInterval()
+
+# example use of Feldman-Cousins
+fc = ROOT.RooStats.FeldmanCousins(data, modelConfig)
+fc.SetConfidenceLevel(confidenceLevel)
+fc.SetNBins(100)  # number of points to test per parameter
+fc.UseAdaptiveSampling(True)  # make it go faster
+
+# Here, we consider only ensembles with 100 events
+# The PDF could be extended and this could be removed
+fc.FluctuateNumDataEntries(False)
+
+interval = fc.GetInterval()
+
+# example use of BayesianCalculator
+# now we also need to specify a prior in the ModelConfig
+wspace.factory("Uniform::prior(mu)")
+modelConfig.SetPriorPdf(wspace["prior"])
+
+# example usage of BayesianCalculator
+bc = ROOT.RooStats.BayesianCalculator(data, modelConfig)
+bc.SetConfidenceLevel(confidenceLevel)
+bcInt = bc.GetInterval()
+
+# example use of MCMCInterval
+mc = ROOT.RooStats.MCMCCalculator(data, modelConfig)
+mc.SetConfidenceLevel(confidenceLevel)
+# special options
+mc.SetNumBins(200)  # bins used internally for representing posterior
+mc.SetNumBurnInSteps(500)  # first N steps to be ignored as burn-in
+mc.SetNumIters(100000)  # how long to run chain
+mc.SetLeftSideTailFraction(0.5)  # for central interval
+mcInt = mc.GetInterval()
+
+# for this example we know the expected intervals
+expectedLL = data.mean(x) + ROOT.Math.normal_quantile((1 - confidenceLevel) / 2, 1) / ROOT.sqrt(data.numEntries())
+expectedUL = data.mean(x) + ROOT.Math.normal_quantile_c((1 - confidenceLevel) / 2, 1) / ROOT.sqrt(data.numEntries())
+
+# Use the intervals
+print("expected interval is [{}, {}]".format(expectedLL, expectedUL))
+print("plc interval is [{}, {}]".format(plInt.LowerLimit(mu), plInt.UpperLimit(mu)))
+print("fc interval is [{}, {}]".format(interval.LowerLimit(mu), interval.UpperLimit(mu)))
+print("bc interval is [{}, {}]".format(bcInt.LowerLimit(), bcInt.UpperLimit()))
+print("mc interval is [{}, {}]".format(mcInt.LowerLimit(mu), mcInt.UpperLimit(mu)))
+mu.setVal(0)
+print("is mu=0 in the interval? ", plInt.IsInInterval({mu}))
+
+# make a reasonable style
+ROOT.gStyle.SetCanvasColor(0)
+ROOT.gStyle.SetCanvasBorderMode(0)
+ROOT.gStyle.SetPadBorderMode(0)
+ROOT.gStyle.SetPadColor(0)
+ROOT.gStyle.SetCanvasColor(0)
+ROOT.gStyle.SetTitleFillColor(0)
+ROOT.gStyle.SetFillColor(0)
+ROOT.gStyle.SetFrameFillColor(0)
+ROOT.gStyle.SetStatColor(0)
+
+# some plots
+canvas = ROOT.TCanvas("canvas")
+canvas.Divide(2, 2)
+
+# plot the data
+canvas.cd(1)
+frame = x.frame()
+data.plotOn(frame)
+data.statOn(frame)
+frame.Draw()
+
+# plot the profile likelihood
+canvas.cd(2)
+plot = ROOT.RooStats.LikelihoodIntervalPlot(plInt)
+plot.Draw()
+
+# plot the MCMC interval
+canvas.cd(3)
+mcPlot = ROOT.RooStats.MCMCIntervalPlot(mcInt)
+mcPlot.SetLineColor(ROOT.kGreen)
+mcPlot.SetLineWidth(2)
+mcPlot.Draw()
+
+canvas.cd(4)
+bcPlot = bc.GetPosteriorPlot()
+bcPlot.Draw()
+
+canvas.Update()
+
+t.Stop()
+t.Print()
+
+canvas.SaveAs("IntervalExamples.png")
+
+# TODO: The MCMCCalculator has to be destructed first. Otherwise, we can get
+# segmentation faults depending on the destruction order, which is random in
+# Python. Probably the issue is that some object has a non-owning pointer to
+# another object, which it uses in its destructor. This should be fixed either
+# in the design of RooStats in C++, or with phythonizations.
+del mc

--- a/tutorials/roostats/IntervalExamples.py
+++ b/tutorials/roostats/IntervalExamples.py
@@ -149,9 +149,11 @@ t.Print()
 
 canvas.SaveAs("IntervalExamples.png")
 
-# TODO: The MCMCCalculator has to be destructed first. Otherwise, we can get
-# segmentation faults depending on the destruction order, which is random in
-# Python. Probably the issue is that some object has a non-owning pointer to
-# another object, which it uses in its destructor. This should be fixed either
-# in the design of RooStats in C++, or with phythonizations.
+# TODO: The BayesianCalculator and MCMCCalculator have to be destructed first.
+# Otherwise, we can get segmentation faults depending on the destruction order,
+# which is random in Python. Probably the issue is that some object has a
+# non-owning pointer to another object, which it uses in its destructor. This
+# should be fixed either in the design of RooStats in C++, or with
+# phythonizations.
+del bc
 del mc

--- a/tutorials/roostats/rs401c_FeldmanCousins.py
+++ b/tutorials/roostats/rs401c_FeldmanCousins.py
@@ -26,7 +26,7 @@ t.Start()
 x = ROOT.RooRealVar("x", "", 1, 0, 50)
 mu = ROOT.RooRealVar("mu", "", 2.5, 0, 15)  # with a limit on mu>=0
 b = ROOT.RooConstVar("b", "", 3.0)
-mean = ROOT.RooAddition("mean", "", ROOT.RooArgList(mu, b))
+mean = ROOT.RooAddition("mean", "", [mu, b])
 pois = ROOT.RooPoisson("pois", "", x, mean)
 parameters = {mu}
 

--- a/tutorials/roostats/rs401c_FeldmanCousins.py
+++ b/tutorials/roostats/rs401c_FeldmanCousins.py
@@ -1,0 +1,95 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook
+## Produces an interval on the mean signal in a number counting experiment with known background using the
+## Feldman-Cousins technique.
+##
+## Using the RooStats FeldmanCousins tool with 200 bins
+## it takes 1 min and the interval is [0.2625, 10.6125]
+## with a step size of 0.075.
+## The interval in Feldman & Cousins's original paper is [.29, 10.81] Phys.Rev.D57:3873-3889,1998.
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Kyle Cranmer (C++ version)
+
+import ROOT
+
+# to time the macro... about 30 s
+t = ROOT.TStopwatch()
+t.Start()
+
+# make a simple model
+x = ROOT.RooRealVar("x", "", 1, 0, 50)
+mu = ROOT.RooRealVar("mu", "", 2.5, 0, 15)  # with a limit on mu>=0
+b = ROOT.RooConstVar("b", "", 3.0)
+mean = ROOT.RooAddition("mean", "", ROOT.RooArgList(mu, b))
+pois = ROOT.RooPoisson("pois", "", x, mean)
+parameters = {mu}
+
+# create a toy dataset
+data = pois.generate({x}, 1)
+data.Print("v")
+
+dataCanvas = ROOT.TCanvas("dataCanvas")
+frame = x.frame()
+data.plotOn(frame)
+frame.Draw()
+dataCanvas.Update()
+
+w = ROOT.RooWorkspace()
+modelConfig = ROOT.RooStats.ModelConfig("poissonProblem", w)
+modelConfig.SetPdf(pois)
+modelConfig.SetParametersOfInterest(parameters)
+modelConfig.SetObservables({x})
+w.Print()
+
+# show use of Feldman-Cousins
+fc = ROOT.RooStats.FeldmanCousins(data, modelConfig)
+fc.SetTestSize(0.05)  # set size of test
+fc.UseAdaptiveSampling(True)
+fc.FluctuateNumDataEntries(False)  # number counting analysis: dataset always has 1 entry with N events observed
+fc.SetNBins(100)  # number of points to test per parameter
+
+# use the Feldman-Cousins tool
+interval = fc.GetInterval()
+
+# make a canvas for plots
+intervalCanvas = ROOT.TCanvas("intervalCanvas")
+
+print("is this point in the interval? ", interval.IsInInterval(parameters))
+print("interval is [{}, {}]".format(interval.LowerLimit(mu), interval.UpperLimit(mu)))
+
+# using 200 bins it takes 1 min and the answer is
+# interval is [0.2625, 10.6125] with a step size of .075
+# The interval in Feldman & Cousins's original paper is [.29, 10.81]
+# Phys.Rev.D57:3873-3889,1998.
+
+# No dedicated plotting class yet, so do it by hand:
+parameterScan = fc.GetPointsToScan()
+hist = parameterScan.createHistogram("mu", 30)
+hist.Draw()
+
+marks = []
+# loop over points to test
+for i in range(parameterScan.numEntries()):
+    # get a parameter point from the list of points to test.
+    tmpPoint = parameterScan.get(i).clone("temp")
+
+    mark = ROOT.TMarker(tmpPoint.getRealValue("mu"), 1, 25)
+    if interval.IsInInterval(tmpPoint):
+        mark.SetMarkerColor(ROOT.kBlue)
+    else:
+        mark.SetMarkerColor(ROOT.kRed)
+
+    mark.Draw("s")
+    marks.append(mark)
+
+t.Stop()
+t.Print()
+
+dataCanvas.SaveAs("rs401c_FeldmanCousins_data.png")
+intervalCanvas.SaveAs("rs401c_FeldmanCousins_hist.png")

--- a/tutorials/roostats/rs401c_FeldmanCousins.py
+++ b/tutorials/roostats/rs401c_FeldmanCousins.py
@@ -70,7 +70,7 @@ print("interval is [{}, {}]".format(interval.LowerLimit(mu), interval.UpperLimit
 
 # No dedicated plotting class yet, so do it by hand:
 parameterScan = fc.GetPointsToScan()
-hist = parameterScan.createHistogram("mu", 30)
+hist = parameterScan.createHistogram("mu", ROOT.RooFit.Binning(30))
 hist.Draw()
 
 marks = []

--- a/tutorials/roostats/rs_numbercountingutils.py
+++ b/tutorials/roostats/rs_numbercountingutils.py
@@ -1,0 +1,110 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook -nodraw
+## 'Number Counting Utils' RooStats tutorial
+##
+## This tutorial shows an example of the RooStats standalone
+## utilities that calculate the p-value or Z value (eg. significance in
+## 1-sided Gaussian standard deviations) for a number counting experiment.
+## This is a hypothesis test between background only and signal-plus-background.
+## The background estimate has uncertainty derived from an auxiliary or sideband
+## measurement.
+##
+## Documentation for these utilities can be found here:
+## http://root.cern.ch/root/html/RooStats__NumberCountingUtils.html
+##
+##
+## This problem is often called a proto-type problem for high energy physics.
+## In some references it is referred to as the on/off problem.
+##
+## The problem is treated in a fully frequentist fashion by
+## interpreting the relative background uncertainty as
+## being due to an auxiliary or sideband observation
+## that is also Poisson distributed with only background.
+## Finally, one considers the test as a ratio of Poisson means
+## where an interval is well known based on the conditioning on the total
+## number of events and the binomial distribution.
+## For more on this, see
+##  - http://arxiv.org/abs/0905.3831
+##  - http://arxiv.org/abs/physics/physics/0702156
+##  - http://arxiv.org/abs/physics/0511028
+##
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Kyle Cranmer (C++ version)
+
+import ROOT
+
+# From the root prompt, you can see the full list of functions by using tab-completion
+# ~~~{.bash}
+# root [0] RooStats::NumberCountingUtils::  <tab>
+# BinomialExpZ
+# BinomialWithTauExpZ
+# BinomialObsZ
+# BinomialWithTauObsZ
+# BinomialExpP
+# BinomialWithTauExpP
+# BinomialObsP
+# BinomialWithTauObsP
+# ~~~
+
+# For each of the utilities you can inspect the arguments by tab completion
+# ~~~{.bash}
+# root [1] NumberCountingUtils::BinomialExpZ( <tab>
+# Double_t BinomialExpZ(Double_t sExp, Double_t bExp, Double_t fractionalBUncertainty)
+# ~~~
+
+# -------------------------------------------------
+# Here we see common usages where the experimenter
+# has a relative background uncertainty, without
+# explicit reference to the auxiliary or sideband
+# measurement
+
+# -------------------------------------------------------------
+# Expected p-values and significance with background uncertainty
+sExpected = 50
+bExpected = 100
+relativeBkgUncert = 0.1
+
+pExp = ROOT.RooStats.NumberCountingUtils.BinomialExpP(sExpected, bExpected, relativeBkgUncert)
+zExp = ROOT.RooStats.NumberCountingUtils.BinomialExpZ(sExpected, bExpected, relativeBkgUncert)
+print("expected p-value = {}  Z value (Gaussian sigma) = {}".format(pExp, zExp))
+
+# -------------------------------------------------
+# Expected p-values and significance with background uncertainty
+observed = 150
+pObs = ROOT.RooStats.NumberCountingUtils.BinomialObsP(observed, bExpected, relativeBkgUncert)
+zObs = ROOT.RooStats.NumberCountingUtils.BinomialObsZ(observed, bExpected, relativeBkgUncert)
+print("observed p-value = {}  Z value (Gaussian sigma) = {}".format(pObs, zObs))
+
+# ---------------------------------------------------------
+# Here we see usages where the experimenter has knowledge
+# about the properties of the auxiliary or sideband
+# measurement.  In particular, the ratio tau of background
+# in the auxiliary measurement to the main measurement.
+# Large values of tau mean small background uncertainty
+# because the sideband is very constraining.
+
+# Usage:
+# ~~~{.bash}
+# root [0] RooStats::NumberCountingUtils::BinomialWithTauExpP(
+# Double_t BinomialWithTauExpP(Double_t sExp, Double_t bExp, Double_t tau)
+# ~~~
+
+# --------------------------------------------------------------
+# Expected p-values and significance with background uncertainty
+tau = 1
+
+pExpWithTau = ROOT.RooStats.NumberCountingUtils.BinomialWithTauExpP(sExpected, bExpected, tau)
+zExpWithTau = ROOT.RooStats.NumberCountingUtils.BinomialWithTauExpZ(sExpected, bExpected, tau)
+print("observed p-value = {}  Z value (Gaussian sigma) = {}".format(pExpWithTau, zExpWithTau))
+
+# ---------------------------------------------------------------
+# Expected p-values and significance with background uncertainty
+pObsWithTau = ROOT.RooStats.NumberCountingUtils.BinomialWithTauObsP(observed, bExpected, tau)
+zObsWithTau = ROOT.RooStats.NumberCountingUtils.BinomialWithTauObsZ(observed, bExpected, tau)
+print("observed p-value = {}  Z value (Gaussian sigma) = {}".format(pObsWithTau, zObsWithTau))


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Add rs401c_FeldmanCousins.py, IntervalExamples.py, rs_numbercountingutils.py

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
- [x] Formatted with `black --line-length=120 <tutorial file>.py`

This PR is a partial fix for #8758 

