### PR TITLE
Fix generation of G__NetxNG.cxx in paths with special characters (#10…

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -296,6 +296,9 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
     if(target_incdirs)
        foreach(dir ${target_incdirs})
           string(REGEX REPLACE "^[$]<BUILD_INTERFACE:(.+)>" "\\1" dir ${dir})
+          # BUILD_INTERFACE might contain space-separated paths. They are split by
+          # foreach, leaving a trailing 'include/something>'. Remove the trailing '>'.
+          string(REGEX REPLACE ">$" "" dir ${dir})
           # check that dir not a empty dir like $<BUILD_INTERFACE:>
           if(NOT ${dir} MATCHES "^[$]")
              list(APPEND incdirs ${dir})


### PR DESCRIPTION
…900)

* Fix generation of G__NetxNG.cxx in paths with special characters

Fix generation of `G__NetxNG.cxx` in paths with special characters, as described on the forum:
https://root-forum.cern.ch/t/6-26-04-build-error-in-debian-bullseye/50412

* Update cmake/modules/RootMacros.cmake

Co-authored-by: Axel Naumann <Axel.Naumann@cern.ch>

Co-authored-by: Axel Naumann <Axel.Naumann@cern.ch>
