### PR TITLE
Fix problems in several graf classes

### DIFF
--- a/graf2d/graf/inc/TMathText.h
+++ b/graf2d/graf/inc/TMathText.h
@@ -18,7 +18,7 @@ class TMathTextRenderer;
 
 class TMathText : public TText, public TAttFill {
 protected:
-      void *fRenderer; //!TMathText Painter
+      TMathTextRenderer *fRenderer; //!TMathText Painter
       TMathText &operator=(const TMathText &);
 
       void Render(const Double_t x, const Double_t y,

--- a/graf2d/graf/inc/TMathText.h
+++ b/graf2d/graf/inc/TMathText.h
@@ -18,39 +18,41 @@ class TMathTextRenderer;
 
 class TMathText : public TText, public TAttFill {
 protected:
-      TMathTextRenderer *fRenderer; //!TMathText Painter
-      TMathText &operator=(const TMathText &);
 
-      void Render(const Double_t x, const Double_t y,
+   friend class TMathTextRenderer;
+
+   TMathTextRenderer *fRenderer{nullptr}; //!TMathText Painter
+   TMathText &operator=(const TMathText &);
+
+   void Render(const Double_t x, const Double_t y,
                const Double_t size, const Double_t angle,
                const Char_t *t, const Int_t length);
-      void GetSize(Double_t &x0, Double_t &y0,
+   void GetSize(Double_t &x0, Double_t &y0,
                 Double_t &x1, Double_t &y1,
                 const Double_t size, const Double_t angle,
                 const Char_t *t, const Int_t length);
-      void GetAlignPoint(Double_t &x0, Double_t &y0,
-                     const Double_t size, const Double_t angle,
-                     const Char_t *t, const Int_t length,
-                     const Short_t align);
+   void GetAlignPoint(Double_t &x0, Double_t &y0,
+                      const Double_t size, const Double_t angle,
+                      const Char_t *t, const Int_t length,
+                      const Short_t align);
 public:
-      enum {
-         kTextNDC = BIT(14)
-      };
-      TMathText();
-      TMathText(Double_t x, Double_t y, const char *text);
-      TMathText(const TMathText &text);
-      virtual ~TMathText();
-      void Copy(TObject &text) const override;
-      TMathText *DrawMathText(Double_t x, Double_t y, const char *text);
-      void GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE) override;
-      Double_t GetXsize();
-      Double_t GetYsize();
-      void Paint(Option_t *option = "") override;
-      virtual void PaintMathText(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
-      void SavePrimitive(std::ostream &out, Option_t *option = "") override;
-      friend class TMathTextRenderer;
+   enum {
+      kTextNDC = BIT(14)
+   };
+   TMathText();
+   TMathText(Double_t x, Double_t y, const char *text);
+   TMathText(const TMathText &text);
+   virtual ~TMathText();
+   void Copy(TObject &text) const override;
+   TMathText *DrawMathText(Double_t x, Double_t y, const char *text);
+   void GetBoundingBox(UInt_t &w, UInt_t &h, Bool_t angle = kFALSE) override;
+   Double_t GetXsize();
+   Double_t GetYsize();
+   void Paint(Option_t *option = "") override;
+   virtual void PaintMathText(Double_t x, Double_t y, Double_t angle, Double_t size, const char *text);
+   void SavePrimitive(std::ostream &out, Option_t *option = "") override;
 
-      ClassDefOverride(TMathText,2) //TeX mathematical formula
+   ClassDefOverride(TMathText,2) //TeX mathematical formula
 };
 
 #endif

--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -225,8 +225,8 @@ TLegend::TLegend( Double_t x1, Double_t y1,Double_t x2, Double_t y2,
         :TPave(x1,y1,x2,y2,4,option), TAttText(12,0,1,gStyle->GetLegendFont(),0)
 {
    fPrimitives = new TList;
-   if ( header && strlen(header) > 0) {
-      TLegendEntry *headerEntry = new TLegendEntry( 0, header, "h" );
+   if (header && strlen(header) > 0) {
+      TLegendEntry *headerEntry = new TLegendEntry( nullptr, header, "h" );
       headerEntry->SetTextAlign(0);
       headerEntry->SetTextAngle(0);
       headerEntry->SetTextColor(0);
@@ -258,8 +258,8 @@ TLegend::TLegend( Double_t w, Double_t h, const char *header, Option_t *option)
         :TPave(w,h,w,h,4,option), TAttText(12,0,1,gStyle->GetLegendFont(),0)
 {
    fPrimitives = new TList;
-   if ( header && strlen(header) > 0) {
-      TLegendEntry *headerEntry = new TLegendEntry( 0, header, "h" );
+   if (header && strlen(header) > 0) {
+      TLegendEntry *headerEntry = new TLegendEntry(nullptr, header, "h");
       headerEntry->SetTextAlign(0);
       headerEntry->SetTextAngle(0);
       headerEntry->SetTextColor(0);
@@ -275,18 +275,16 @@ TLegend::TLegend( Double_t w, Double_t h, const char *header, Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor.
 
-TLegend::TLegend( const TLegend &legend ) : TPave(legend), TAttText(legend),
-                                            fPrimitives(nullptr)
+TLegend::TLegend(const TLegend &legend) : TPave(legend), TAttText(legend),
+                                           fPrimitives(nullptr)
 {
   if (legend.fPrimitives) {
       fPrimitives = new TList();
-      TListIter it(legend.fPrimitives);
-      while (TLegendEntry *e = (TLegendEntry *)it.Next()) {
-         TLegendEntry *newentry = new TLegendEntry(*e);
-         fPrimitives->Add(newentry);
-      }
+      TIter next(legend.fPrimitives);
+      while (auto entry = (TLegendEntry *) next())
+         fPrimitives->Add(new TLegendEntry(*entry));
    }
-   ((TLegend&)legend).Copy(*this);
+   legend.Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -297,10 +295,20 @@ TLegend& TLegend::operator=(const TLegend &lg)
    if(this!=&lg) {
       TPave::operator=(lg);
       TAttText::operator=(lg);
-      fPrimitives=lg.fPrimitives;
-      fEntrySeparation=lg.fEntrySeparation;
-      fMargin=lg.fMargin;
-      fNColumns=lg.fNColumns;
+      if (fPrimitives) {
+         fPrimitives->Delete();
+         delete fPrimitives;
+         fPrimitives = nullptr;
+      }
+      if (lg.fPrimitives) {
+         fPrimitives = new TList();
+         TIter next(lg.fPrimitives);
+         while (auto entry = (TLegendEntry *) next())
+            fPrimitives->Add(new TLegendEntry(*entry));
+      }
+      fEntrySeparation = lg.fEntrySeparation;
+      fMargin = lg.fMargin;
+      fNColumns = lg.fNColumns;
    }
    return *this;
 }

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -372,7 +372,6 @@ TMathText::~TMathText(void)
 TMathText::TMathText(const TMathText &text)
    : TText(text), TAttFill(text)
 {
-   ((TMathText &)text).Copy(*this);
    fRenderer = new TMathTextRenderer(this);
 }
 
@@ -382,8 +381,10 @@ TMathText::TMathText(const TMathText &text)
 TMathText &TMathText::operator=(const TMathText &rhs)
 {
    if (this != &rhs) {
-      TText::operator    = (rhs);
-      TAttFill::operator = (rhs);
+      TText::operator=(rhs);
+      TAttFill::operator=(rhs);
+      delete fRenderer;
+      fRenderer = new TMathTextRenderer(this);
    }
    return *this;
 }
@@ -393,9 +394,12 @@ TMathText &TMathText::operator=(const TMathText &rhs)
 
 void TMathText::Copy(TObject &obj) const
 {
-   ((TMathText &)obj).fRenderer = fRenderer;
-   TText::Copy(obj);
-   TAttFill::Copy((TAttFill &)obj);
+   TMathText &tgt = (TMathText &)obj;
+   delete tgt.fRenderer;
+   TText::Copy(tgt);
+   TAttFill::Copy(tgt);
+   tgt.fRenderer = new TMathTextRenderer(&tgt);
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -363,6 +363,7 @@ TMathText::TMathText(Double_t x, Double_t y, const char *text)
 
 TMathText::~TMathText(void)
 {
+   delete fRenderer;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TMathText.cxx
+++ b/graf2d/graf/src/TMathText.cxx
@@ -343,7 +343,7 @@ ClassImp(TMathText);
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
-TMathText::TMathText(void)
+TMathText::TMathText()
    : TAttFill(0, 1001)
 {
    fRenderer = new TMathTextRenderer(this);
@@ -361,7 +361,7 @@ TMathText::TMathText(Double_t x, Double_t y, const char *text)
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
 
-TMathText::~TMathText(void)
+TMathText::~TMathText()
 {
    delete fRenderer;
 }
@@ -405,43 +405,33 @@ void TMathText::Copy(TObject &obj) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Render the text.
 
-void TMathText::
-Render(const Double_t x, const Double_t y, const Double_t size,
-      const Double_t angle, const Char_t *t, const Int_t /*length*/)
+void TMathText::Render(const Double_t x, const Double_t y, const Double_t size,
+                       const Double_t angle, const Char_t *t, const Int_t /*length*/)
 {
    const mathtext::math_text_t math_text(t);
-   TMathTextRenderer *renderer = (TMathTextRenderer *)fRenderer;
 
-   renderer->set_parameter(x, y, size, angle);
-   renderer->text(0, 0, math_text);
+   fRenderer->set_parameter(x, y, size, angle);
+   fRenderer->text(0, 0, math_text);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Get the text bounding box.
 
-void TMathText::
-GetSize(Double_t &x0, Double_t &y0, Double_t &x1, Double_t &y1,
-      const Double_t size, const Double_t angle, const Char_t *t,
-      const Int_t /*length*/)
+void TMathText::GetSize(Double_t &x0, Double_t &y0, Double_t &x1, Double_t &y1,
+                        const Double_t size, const Double_t angle, const Char_t *t,
+                        const Int_t /*length*/)
 {
    const mathtext::math_text_t math_text(t);
-   TMathTextRenderer *renderer = (TMathTextRenderer *)fRenderer;
 
-   renderer->set_parameter(0, 0, size, angle);
+   fRenderer->set_parameter(0, 0, size, angle);
 
-   const mathtext::bounding_box_t bounding_box =
-      renderer->bounding_box(math_text);
-   double x[4];
-   double y[4];
+   const mathtext::bounding_box_t bounding_box = fRenderer->bounding_box(math_text);
+   double x[4], y[4];
 
-   renderer->transform_pad(
-      x[0], y[0], bounding_box.left(), bounding_box.bottom());
-   renderer->transform_pad(
-      x[1], y[1], bounding_box.right(), bounding_box.bottom());
-   renderer->transform_pad(
-      x[2], y[2], bounding_box.right(), bounding_box.top());
-   renderer->transform_pad(
-      x[3], y[3], bounding_box.left(), bounding_box.top());
+   fRenderer->transform_pad(x[0], y[0], bounding_box.left(), bounding_box.bottom());
+   fRenderer->transform_pad(x[1], y[1], bounding_box.right(), bounding_box.bottom());
+   fRenderer->transform_pad(x[2], y[2], bounding_box.right(), bounding_box.top());
+   fRenderer->transform_pad(x[3], y[3], bounding_box.left(), bounding_box.top());
 
    x0 = std::min(std::min(x[0], x[1]), std::min(x[2], x[3]));
    y0 = std::min(std::min(y[0], y[1]), std::min(y[2], y[3]));
@@ -452,21 +442,17 @@ GetSize(Double_t &x0, Double_t &y0, Double_t &x1, Double_t &y1,
 ////////////////////////////////////////////////////////////////////////////////
 /// Alignment.
 
-void TMathText::
-GetAlignPoint(Double_t &x0, Double_t &y0,
-           const Double_t size, const Double_t angle,
-           const Char_t *t, const Int_t /*length*/,
-           const Short_t align)
+void TMathText::GetAlignPoint(Double_t &x0, Double_t &y0,
+                              const Double_t size, const Double_t angle,
+                              const Char_t *t, const Int_t /*length*/,
+                              const Short_t align)
 {
    const mathtext::math_text_t math_text(t);
-   TMathTextRenderer *renderer = (TMathTextRenderer *)fRenderer;
 
-   renderer->set_parameter(0, 0, size, angle);
+   fRenderer->set_parameter(0, 0, size, angle);
 
-   const mathtext::bounding_box_t bounding_box =
-      renderer->bounding_box(math_text);
-   float x = 0;
-   float y = 0;
+   const mathtext::bounding_box_t bounding_box = fRenderer->bounding_box(math_text);
+   float x = 0, y = 0;
 
    Short_t halign = align / 10;
    Short_t valign = align - 10 * halign;
@@ -483,7 +469,7 @@ GetAlignPoint(Double_t &x0, Double_t &y0,
       case 2:   y = bounding_box.vertical_center();   break;
       case 3:   y = bounding_box.top();               break;
    }
-   renderer->transform_pad(x0, y0, x, y);
+   fRenderer->transform_pad(x0, y0, x, y);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -124,15 +124,13 @@ TPaveText::~TPaveText()
 ////////////////////////////////////////////////////////////////////////////////
 /// pavetext copy constructor.
 
-TPaveText::TPaveText(const TPaveText &pavetext) : TPave(), TAttText()
+TPaveText::TPaveText(const TPaveText &pavetext) : TPave(pavetext), TAttText(pavetext)
 {
-   TBufferFile b(TBuffer::kWrite);
-   TPaveText *p = (TPaveText*)(&pavetext);
-   p->Streamer(b);
-   b.SetReadMode();
-   b.SetBufferOffset(0);
-   fLines = nullptr;
-   Streamer(b);
+   fLabel = pavetext.fLabel;
+   fLongest = pavetext.fLongest;
+   fMargin = pavetext.fMargin;
+   if (pavetext.fLines)
+      fLines = (TList *) pavetext.fLines->Clone();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -140,13 +138,19 @@ TPaveText::TPaveText(const TPaveText &pavetext) : TPave(), TAttText()
 
 TPaveText& TPaveText::operator=(const TPaveText& pt)
 {
-   if(this!=&pt) {
+   if(this != &pt) {
       TPave::operator=(pt);
       TAttText::operator=(pt);
-      fLabel=pt.fLabel;
-      fLongest=pt.fLongest;
-      fMargin=pt.fMargin;
-      fLines=pt.fLines;
+      fLabel = pt.fLabel;
+      fLongest = pt.fLongest;
+      fMargin = pt.fMargin;
+      if (fLines) {
+         fLines->Delete();
+         delete fLines;
+         fLines = nullptr;
+      }
+      if (pt.fLines)
+         fLines = (TList *)pt.fLines->Clone();
    }
    return *this;
 }


### PR DESCRIPTION
1. Major memory leak in `TMathText` - renderer was never deleted
2. `TMathTex`t copy constructor and assign operator
3. `TLegend` assign operator
4. `TPaveText` copy constructor and assign operator
5. Errors in `TPaveText::GetLine` and `TPaveText::GetLineWidth`
