### PR TITLE
[DF] Add internal function to retrieve tree info

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -49,6 +49,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/GraphUtils.hxx
     ROOT/RDF/HistoModels.hxx
     ROOT/RDF/InterfaceUtils.hxx
+    ROOT/RDF/InternalUtils.hxx
     ROOT/RDF/RActionBase.hxx
     ROOT/RDF/RAction.hxx
     ROOT/RDF/RActionImpl.hxx
@@ -101,6 +102,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RDFGraphUtils.cxx
     src/RDFHistoModels.cxx
     src/RDFInterfaceUtils.cxx
+    src/RDFInternalUtils.cxx
     src/RDFUtils.cxx
     src/RDFHelpers.cxx
     src/RFilterBase.cxx

--- a/tree/dataframe/inc/ROOT/RDF/InternalUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InternalUtils.hxx
@@ -1,0 +1,55 @@
+// Author: Vincenzo Eduardo Padulano CERN/UPV 08/2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_INTERNALUTILS
+#define ROOT_RDF_INTERNALUTILS
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ROOT {
+namespace Detail {
+namespace RDF {
+class RNodeBase;
+} // namespace RDF
+} // namespace Detail
+} // namespace ROOT
+
+namespace ROOT {
+namespace RDF {
+template <typename T, typename V>
+class RInterface;
+using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
+} // namespace RDF
+} // namespace ROOT
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+/**
+\struct ROOT::Internal::RDF::RTreeInfo
+\brief Information about the trees to be processed by an RDataFrame.
+\ingroup dataframe
+*/
+struct RTreeInfo {
+   std::string fTreeName;
+   std::vector<std::string> fFileNames;
+   std::vector<std::string> fTreeNamesInFiles;
+};
+
+std::unique_ptr<RTreeInfo> MakeTreeInfo(const ROOT::RDF::RNode &node);
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
+
+#endif // ROOT_RDF_INTERNALUTILS

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -70,6 +70,8 @@ class RDataFrame;
 namespace Internal {
 namespace RDF {
 class GraphCreatorHelper;
+struct RTreeInfo;
+std::unique_ptr<RTreeInfo> MakeTreeInfo(const ROOT::RDF::RNode &node);
 }
 } // namespace Internal
 } // namespace ROOT
@@ -113,6 +115,7 @@ class RInterface {
    friend class RInterface;
 
    friend void RDFInternal::TriggerRun(RNode &node);
+   friend std::unique_ptr<RDFInternal::RTreeInfo> RDFInternal::MakeTreeInfo(const RNode &rdf);
 
    std::shared_ptr<Proxied> fProxiedPtr; ///< Smart pointer to the graph node encapsulated by this RInterface.
    ///< The RLoopManager at the root of this computation graph. Never null.

--- a/tree/dataframe/src/RDFInternalUtils.cxx
+++ b/tree/dataframe/src/RDFInternalUtils.cxx
@@ -1,0 +1,39 @@
+// Author: Vincenzo Eduardo Padulano CERN/UPV 08/2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include <string>
+
+#include "ROOT/InternalTreeUtils.hxx"
+#include "ROOT/RDF/InternalUtils.hxx"
+#include "ROOT/RDF/RInterface.hxx"
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Gets information about the internal tree in the dataframe.
+/// \param[in] node A node of the computation graph.
+/// \returns The name of the dataset, the filenames and the tree names inside
+///          the files. If the RDataFrame is not processing a TTree-based
+///          dataset, returns nullptr.
+std::unique_ptr<RTreeInfo> MakeTreeInfo(const ROOT::RDF::RNode &node)
+{
+   const auto *tree = node.GetLoopManager()->GetTree();
+   if (!tree)
+      return nullptr;
+   return std::unique_ptr<RTreeInfo>{new RTreeInfo{std::string{tree->GetName()},
+                                                   ROOT::Internal::TreeUtils::GetFileNamesFromTree(*tree),
+                                                   ROOT::Internal::TreeUtils::GetTreeFullPaths(*tree)}};
+}
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -15,6 +15,7 @@ ROOT_ADD_GTEST(dataframe_histomodels dataframe_histomodels.cxx LIBRARIES ROOTDat
 ROOT_ADD_GTEST(dataframe_interface dataframe_interface.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_nodes dataframe_nodes.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_regression dataframe_regression.cxx LIBRARIES Physics ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_internalutils dataframe_internalutils.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_utils dataframe_utils.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_report dataframe_report.cxx LIBRARIES ROOTDataFrame)
 

--- a/tree/dataframe/test/dataframe_internalutils.cxx
+++ b/tree/dataframe/test/dataframe_internalutils.cxx
@@ -1,0 +1,46 @@
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ROOT/RDataFrame.hxx"
+#include "ROOT/RDFHelpers.hxx"
+#include "ROOT/RDF/InternalUtils.hxx"
+#include "TSystem.h"
+#include "TTree.h"
+
+#include "gtest/gtest.h"
+
+void EXPECT_VEC_EQ(const std::vector<std::string> &vec1, const std::vector<std::string> &vec2)
+{
+   ASSERT_EQ(vec1.size(), vec2.size());
+   for (std::size_t i = 0u; i < vec1.size(); ++i)
+      EXPECT_EQ(vec1[i], vec2[i]);
+}
+
+TEST(RDataFrameInternalUtils, CheckTreeInfo)
+{
+   std::string treename{"tree_1"};
+   const char *filename = "dataframe_internalutils_file_1.root";
+
+   {
+      ROOT::RDataFrame df{1};
+      df.Define("x", []() -> int { return 42; }).Snapshot<int>(treename, filename, {"x"});
+   }
+
+   ROOT::RDataFrame df{treename, filename};
+
+   auto ti = ROOT::Internal::RDF::MakeTreeInfo(ROOT::RDF::AsRNode(df));
+   ASSERT_TRUE(ti != nullptr);
+   EXPECT_EQ(ti->fTreeName, treename);
+   EXPECT_VEC_EQ(ti->fFileNames, {std::string{filename}});
+   EXPECT_VEC_EQ(ti->fTreeNamesInFiles, {treename});
+
+   gSystem->Unlink(filename);
+}
+
+TEST(RDataFrameInternalUtils, NoTreeInfo)
+{
+   ROOT::RDataFrame df{1};
+   auto ti = ROOT::Internal::RDF::MakeTreeInfo(ROOT::RDF::AsRNode(df));
+   ASSERT_TRUE(ti == nullptr);
+}


### PR DESCRIPTION
This could be a useful thing to have around for internal use. For example, this could enable in distrdf creating directly an RDF object in the headnode, then querying the list of tree/file names from it