### PR TITLE
Fix several `Copy(TObject &)` methods

### DIFF
--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -637,10 +637,9 @@ void TStyle::Copy(TObject &obj) const
    ((TStyle&)obj).fLegendFont       = fLegendFont;
    ((TStyle&)obj).fLegendTextSize   = fLegendTextSize;
 
-   Int_t i;
-   for (i=0;i<30;i++) {
+   for (Int_t i=0;i<30;i++)
       ((TStyle&)obj).fLineStyle[i]     = fLineStyle[i];
-   }
+
    ((TStyle&)obj).fHeaderPS       = fHeaderPS;
    ((TStyle&)obj).fTitlePS        = fTitlePS;
    ((TStyle&)obj).fLineScalePS    = fLineScalePS;
@@ -1543,9 +1542,8 @@ void TStyle::SetOptFit(Int_t mode)
 {
    fOptFit = mode;
    if (gPad) {
-      TObject *obj;
       TIter next(gPad->GetListOfPrimitives());
-      while ((obj = next())) {
+      while (auto obj = next()) {
          TObject *stats = obj->FindObject("stats");
          if (stats) stats->SetBit(kTakeStyle);
       }
@@ -1591,9 +1589,8 @@ void TStyle::SetOptStat(Int_t mode)
 {
    fOptStat = mode;
    if (gPad) {
-      TObject *obj;
       TIter next(gPad->GetListOfPrimitives());
-      while ((obj = next())) {
+      while (auto obj = next()) {
          TObject *stats = obj->FindObject("stats");
          if (stats) stats->SetBit(kTakeStyle);
       }

--- a/graf3d/g3d/inc/TXTRU.h
+++ b/graf3d/g3d/inc/TXTRU.h
@@ -58,16 +58,16 @@ protected:
    void            CheckOrdering();
    virtual void    SetPoints(Double_t *points) const;
 
-   Int_t       fNxy;       // number of x-y points in the cross section
-   Int_t       fNxyAlloc;  // number of x-y points allocated
-   Int_t       fNz;        // number of z planes
-   Int_t       fNzAlloc;   // number of z planes allocated
-   Float_t    *fXvtx;      //[fNxyAlloc] array of x positions
-   Float_t    *fYvtx;      //[fNxyAlloc] array of y positions
-   Float_t    *fZ;         //[fNzAlloc] array of z planes
-   Float_t    *fScale;     //[fNzAlloc] array of scale factors (for each z)
-   Float_t    *fX0;        //[fNzAlloc] array of x offsets (for each z)
-   Float_t    *fY0;        //[fNzAlloc] array of y offsets (for each z)
+   Int_t       fNxy{0};             // number of x-y points in the cross section
+   Int_t       fNxyAlloc{0};        // number of x-y points allocated
+   Int_t       fNz{0};              // number of z planes
+   Int_t       fNzAlloc{0};         // number of z planes allocated
+   Float_t    *fXvtx{nullptr};      //[fNxyAlloc] array of x positions
+   Float_t    *fYvtx{nullptr};      //[fNxyAlloc] array of y positions
+   Float_t    *fZ{nullptr};         //[fNzAlloc] array of z planes
+   Float_t    *fScale{nullptr};     //[fNzAlloc] array of scale factors (for each z)
+   Float_t    *fX0{nullptr};        //[fNzAlloc] array of x offsets (for each z)
+   Float_t    *fY0{nullptr};        //[fNzAlloc] array of y offsets (for each z)
 
    enum EXYChecked {kUncheckedXY, kMalformedXY,
                     kConvexCCW,   kConvexCW,
@@ -76,13 +76,13 @@ protected:
                     kConvexIncZ,  kConvexDecZ,
                     kConcaveIncZ, kConcaveDecZ};
 
-   EXYChecked  fPolygonShape;   // CCW vs. CW, convex vs. concave
-   EZChecked   fZOrdering;      // increasing or decreasing
+   EXYChecked  fPolygonShape{kUncheckedXY};   // CCW vs. CW, convex vs. concave
+   EZChecked   fZOrdering{kUncheckedZ};      // increasing or decreasing
 
    // Concave polygon division (into convex polygons) is not yet supported
    // but if split one gets correct solid rendering but extra lines
    // in wire mode; if not split....the converse.
-   Bool_t      fSplitConcave;
+   Bool_t      fSplitConcave{kFALSE};
 
 private:
    void DumpPoints(int npoints, float *pointbuff) const;

--- a/graf3d/g3d/src/TAxis3D.cxx
+++ b/graf3d/g3d/src/TAxis3D.cxx
@@ -130,7 +130,7 @@ TAxis3D::TAxis3D(Option_t *) : TNamed(TAxis3D::fgRulerName,"ruler")
 
 TAxis3D::TAxis3D(const TAxis3D &axis) : TNamed(axis)
 {
-   ((TAxis3D&)axis).Copy(*this);
+   axis.Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -139,7 +139,8 @@ TAxis3D::TAxis3D(const TAxis3D &axis) : TNamed(axis)
 void TAxis3D::Copy(TObject &obj) const
 {
    TNamed::Copy(obj);
-   for (Int_t i=0;i<2;i++) fAxis[i].Copy(((TAxis3D&)obj).fAxis[i]);
+   for (Int_t i = 0; i < 3; i++)
+      fAxis[i].Copy(((TAxis3D &)obj).fAxis[i]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/THelix.cxx
+++ b/graf3d/g3d/src/THelix.cxx
@@ -125,7 +125,7 @@ THelix::THelix()
    fW        = 1.5E7;   // roughly the cyclon frequency of proton in AMS
    fRange[0] = 0.0;
    fRange[1] = 1.0;
-   fRotMat   = 0;
+   fRotMat   = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -143,8 +143,8 @@ THelix::THelix(Double_t x,  Double_t y,  Double_t z,
    v[0] = vx;
    v[1] = vy;
    v[2] = vz;
-   Double_t *range = 0;
-   fRotMat   = 0;
+   Double_t *range = nullptr;
+   fRotMat   = nullptr;
 
    SetHelix(p, v, w, range, kHelixZ);
    fOption = "";
@@ -164,7 +164,7 @@ THelix::THelix(Double_t const* xyz, Double_t const* v, Double_t w,
       r[0] = 0.0;        r[1] = 1.0;
    }
 
-   fRotMat   = 0;
+   fRotMat   = nullptr;
    if ( axis ) {                        // specify axis
       SetHelix(xyz, v, w, r, rType, axis);
    } else {                             // default axis
@@ -213,7 +213,8 @@ THelix& THelix::operator=(const THelix& hx)
       fW=hx.fW;
       for(Int_t i=0; i<3; i++)
          fAxis[i]=hx.fAxis[i];
-      fRotMat=hx.fRotMat;
+      delete fRotMat;
+      fRotMat = hx.fRotMat ? new TRotMatrix(*hx.fRotMat) : nullptr;
       for(Int_t i=0; i<2; i++)
          fRange[i]=hx.fRange[i];
    }
@@ -234,7 +235,7 @@ THelix::~THelix()
 
 THelix::THelix(const THelix &helix) : TPolyLine3D(helix)
 {
-   fRotMat=0;
+   fRotMat = nullptr;
    ((THelix&)helix).THelix::Copy(*this);
 }
 
@@ -259,7 +260,8 @@ void THelix::Copy(TObject &obj) const
 
    if (((THelix&)obj).fRotMat)
       delete ((THelix&)obj).fRotMat;
-   ((THelix&)obj).fRotMat    = new TRotMatrix(*fRotMat);
+
+   ((THelix&)obj).fRotMat    = fRotMat ? new TRotMatrix(*fRotMat) : nullptr;
 
    ((THelix&)obj).fRange[0]  = fRange[0];
    ((THelix&)obj).fRange[1]  = fRange[1];

--- a/graf3d/g3d/src/TXTRU.cxx
+++ b/graf3d/g3d/src/TXTRU.cxx
@@ -74,12 +74,7 @@ and thus it is left to the user to avoid this mistake.
 /// TXTRU shape - default constructor
 
 TXTRU::TXTRU()
-   : fNxy(0), fNxyAlloc(0), fNz(0), fNzAlloc(0), fXvtx(0), fYvtx(0),
-     fZ(0), fScale(0), fX0(0), fY0(0)
 {
-   fPolygonShape  = kUncheckedXY;
-   fZOrdering     = kUncheckedZ;
-   fSplitConcave  = kFALSE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -93,21 +88,6 @@ TXTRU::TXTRU(const char *name, const char *title, const char *material,
    : TShape (name,title,material)
 {
    // start in a known state even if "Error" is encountered
-   fNxy      = 0;
-   fNxyAlloc = 0;
-   fNz       = 0;
-   fNzAlloc  = 0;
-   fXvtx     = 0;
-   fYvtx     = 0;
-   fZ        = 0;
-   fScale    = 0;
-   fX0       = 0;
-   fY0       = 0;
-
-   fPolygonShape  = kUncheckedXY;
-   fZOrdering     = kUncheckedZ;
-   fSplitConcave  = kFALSE;
-
    if ( nxy < 3 ) {
       Error(name,"number of x-y points for %s must be at least three!",name);
       return;
@@ -123,10 +103,9 @@ TXTRU::TXTRU(const char *name, const char *title, const char *material,
    fXvtx      = new Float_t [fNxyAlloc];
    fYvtx      = new Float_t [fNxyAlloc];
    // zero out the vertex points
-   Int_t i = 0;
-   for (i = 0; i < fNxyAlloc; i++) {
-      fXvtx[i] = 0;
-      fYvtx[i] = 0;
+   for (Int_t i = 0; i < fNxyAlloc; i++) {
+      fXvtx[i] = 0.;
+      fYvtx[i] = 0.;
    }
 
    // allocate space for Nz sections
@@ -137,12 +116,11 @@ TXTRU::TXTRU(const char *name, const char *title, const char *material,
    fX0        = new Float_t [fNzAlloc];
    fY0        = new Float_t [fNzAlloc];
    // zero out the z points
-   Int_t j = 0;
-   for (j = 0; j < fNzAlloc; j++) {
-      fZ[j]     = 0;
-      fScale[j] = 0;
-      fX0[j]    = 0;
-      fY0[j]    = 0;
+   for (Int_t j = 0; j < fNzAlloc; j++) {
+      fZ[j]     = 0.;
+      fScale[j] = 0.;
+      fX0[j]    = 0.;
+      fY0[j]    = 0.;
    }
 
 }
@@ -152,9 +130,7 @@ TXTRU::TXTRU(const char *name, const char *title, const char *material,
 
 TXTRU::TXTRU(const TXTRU &xtru) : TShape(xtru)
 {
-   // patterned after other ROOT objects
-
-   ((TXTRU&)xtru).Copy(*this);
+   xtru.Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -164,8 +140,8 @@ TXTRU::~TXTRU()
 {
    if (fXvtx) delete [] fXvtx;
    if (fYvtx) delete [] fYvtx;
-   fXvtx     = 0;
-   fYvtx     = 0;
+   fXvtx     = nullptr;
+   fYvtx     = nullptr;
    fNxy      = 0;
    fNxyAlloc = 0;
 
@@ -173,10 +149,10 @@ TXTRU::~TXTRU()
    if (fScale) delete [] fScale;
    if (fX0)    delete [] fX0;
    if (fY0)    delete [] fY0;
-   fZ        = 0;
-   fScale    = 0;
-   fX0       = 0;
-   fY0       = 0;
+   fZ        = nullptr;
+   fScale    = nullptr;
+   fX0       = nullptr;
+   fY0       = nullptr;
    fNz       = 0;
    fNzAlloc  = 0;
 
@@ -190,19 +166,8 @@ TXTRU::~TXTRU()
 TXTRU& TXTRU::operator=(const TXTRU &rhs)
 {
    // protect against self-assignment
-   if (this == &rhs) return *this;
-
-   if (fNxyAlloc) {
-      delete [] fXvtx;
-      delete [] fYvtx;
-   }
-   if (fNzAlloc) {
-      delete [] fZ;
-      delete [] fScale;
-      delete [] fX0;
-      delete [] fY0;
-   }
-   ((TXTRU&)rhs).Copy(*this);
+   if (this != &rhs)
+      rhs.Copy(*this);
 
    return *this;
 }
@@ -212,35 +177,40 @@ TXTRU& TXTRU::operator=(const TXTRU &rhs)
 
 void TXTRU::Copy(TObject &obj) const
 {
-   // patterned after other ROOT objects
+   auto &tgt = static_cast<TXTRU &>(obj);
+
+   delete [] tgt.fXvtx;  tgt.fXvtx = nullptr;
+   delete [] tgt.fYvtx;  tgt.fYvtx = nullptr;
+   delete [] tgt.fZ;     tgt.fZ = nullptr;
+   delete [] tgt.fScale; tgt.fScale = nullptr;
+   delete [] tgt.fX0;    tgt.fX0 = nullptr;
+   delete [] tgt.fY0;    tgt.fY0 = nullptr;
 
    TObject::Copy(obj);
-   ((TXTRU&)obj).fNxy       = fNxy;
-   ((TXTRU&)obj).fNxyAlloc  = fNxyAlloc;
-   ((TXTRU&)obj).fXvtx = new Float_t [fNxyAlloc];
-   ((TXTRU&)obj).fYvtx = new Float_t [fNxyAlloc];
-   Int_t i = 0;
-   for (i = 0; i < fNxyAlloc; i++) {
-      ((TXTRU&)obj).fXvtx[i] = fXvtx[i];
-      ((TXTRU&)obj).fYvtx[i] = fYvtx[i];
+   tgt.fNxy       = fNxy;
+   tgt.fNxyAlloc  = fNxyAlloc;
+   tgt.fXvtx = new Float_t [fNxyAlloc];
+   tgt.fYvtx = new Float_t [fNxyAlloc];
+   for (Int_t i = 0; i < fNxyAlloc; i++) {
+      tgt.fXvtx[i] = fXvtx[i];
+      tgt.fYvtx[i] = fYvtx[i];
    }
 
-   ((TXTRU&)obj).fNz       = fNz;
-   ((TXTRU&)obj).fNzAlloc  = fNzAlloc;
-   ((TXTRU&)obj).fZ     = new Float_t [fNzAlloc];
-   ((TXTRU&)obj).fScale = new Float_t [fNzAlloc];
-   ((TXTRU&)obj).fX0    = new Float_t [fNzAlloc];
-   ((TXTRU&)obj).fY0    = new Float_t [fNzAlloc];
-   Int_t j = 0;
-   for (j = 0; j < fNzAlloc; j++) {
-      ((TXTRU&)obj).fZ[j]     = fZ[j];
-      ((TXTRU&)obj).fScale[j] = fScale[j];
-      ((TXTRU&)obj).fX0[j]    = fX0[j];
-      ((TXTRU&)obj).fY0[j]    = fY0[j];
+   tgt.fNz       = fNz;
+   tgt.fNzAlloc  = fNzAlloc;
+   tgt.fZ        = new Float_t [fNzAlloc];
+   tgt.fScale    = new Float_t [fNzAlloc];
+   tgt.fX0       = new Float_t [fNzAlloc];
+   tgt.fY0       = new Float_t [fNzAlloc];
+   for (Int_t j = 0; j < fNzAlloc; j++) {
+      tgt.fZ[j]     = fZ[j];
+      tgt.fScale[j] = fScale[j];
+      tgt.fX0[j]    = fX0[j];
+      tgt.fY0[j]    = fY0[j];
    }
 
-   ((TXTRU&)obj).fPolygonShape = fPolygonShape;
-   ((TXTRU&)obj).fZOrdering    = fZOrdering;
+   tgt.fPolygonShape = fPolygonShape;
+   tgt.fZOrdering    = fZOrdering;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/inc/TPolyMarker.h
+++ b/hist/hist/inc/TPolyMarker.h
@@ -30,11 +30,11 @@ class TCollection;
 
 class TPolyMarker : public TObject, public TAttMarker {
 protected:
-   Int_t       fN;            ///< Number of points
-   Int_t       fLastPoint;    ///< The index of the last filled point
-   Double_t   *fX;            ///<[fN] Array of X coordinates
-   Double_t   *fY;            ///<[fN] Array of Y coordinates
-   TString     fOption;       ///< Options
+   Int_t       fN{0};             ///< Number of points
+   Int_t       fLastPoint{-1};    ///< The index of the last filled point
+   Double_t   *fX{nullptr};       ///<[fN] Array of X coordinates
+   Double_t   *fY{nullptr};       ///<[fN] Array of Y coordinates
+   TString     fOption;           ///< Options
 
    TPolyMarker& operator=(const TPolyMarker&);
 

--- a/hist/hist/src/TAxis.cxx
+++ b/hist/hist/src/TAxis.cxx
@@ -226,16 +226,13 @@ void TAxis::Copy(TObject &obj) const
    if (axis.fLabels) {
       axis.fLabels->Delete();
       delete axis.fLabels;
-      axis.fLabels = 0;
+      axis.fLabels = nullptr;
    }
    if (fLabels) {
       //Properly handle case where not all bins have labels
+      axis.fLabels = new THashList(axis.fNbins, 3);
       TIter next(fLabels);
-      TObjString *label;
-      if(! axis.fLabels) {
-         axis.fLabels = new THashList(axis.fNbins, 3);
-      }
-      while( (label=(TObjString*)next()) ) {
+      while(auto label = (TObjString *)next()) {
          TObjString *copyLabel = new TObjString(*label);
          axis.fLabels->Add(copyLabel);
          copyLabel->SetUniqueID(label->GetUniqueID());
@@ -244,15 +241,12 @@ void TAxis::Copy(TObject &obj) const
    if (axis.fModLabs) {
       axis.fModLabs->Delete();
       delete axis.fModLabs;
-      axis.fModLabs = 0;
+      axis.fModLabs = nullptr;
    }
    if (fModLabs) {
+      axis.fModLabs = new TList();
       TIter next(fModLabs);
-      TAxisModLab *modlabel;
-      if(! axis.fModLabs) {
-         axis.fModLabs = new TList();
-      }
-      while( (modlabel=(TAxisModLab*)next()) ) {
+      while(auto modlabel=(TAxisModLab *)next()) {
          TAxisModLab *copyModLabel = new TAxisModLab(*modlabel);
          axis.fModLabs->Add(copyModLabel);
          copyModLabel->SetUniqueID(modlabel->GetUniqueID());

--- a/hist/hist/src/TPolyMarker.cxx
+++ b/hist/hist/src/TPolyMarker.cxx
@@ -33,7 +33,7 @@ See TMarker for the list of possible marker types.
 TPolyMarker::TPolyMarker(): TObject()
 {
    fN = 0;
-   fX = fY = 0;
+   fX = fY = nullptr;
    fLastPoint = -1;
 }
 
@@ -49,7 +49,7 @@ TPolyMarker::TPolyMarker(Int_t n, Option_t *option)
    if (n <= 0) {
       fN = 0;
       fLastPoint = -1;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN = n;
@@ -69,7 +69,7 @@ TPolyMarker::TPolyMarker(Int_t n, Float_t *x, Float_t *y, Option_t *option)
    if (n <= 0) {
       fN = 0;
       fLastPoint = -1;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN = n;
@@ -92,7 +92,7 @@ TPolyMarker::TPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option)
    if (n <= 0) {
       fN = 0;
       fLastPoint = -1;
-      fX = fY = 0;
+      fX = fY = nullptr;
       return;
    }
    fN = n;
@@ -108,18 +108,9 @@ TPolyMarker::TPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option)
 
 TPolyMarker& TPolyMarker::operator=(const TPolyMarker& pm)
 {
-   if(this!=&pm) {
-      TObject::operator=(pm);
-      TAttMarker::operator=(pm);
-      fN=pm.fN;
-      fLastPoint=pm.fLastPoint;
-   // delete first previous existing fX and fY
-      if (fX) delete [] fX;
-      if (fY) delete [] fY;
-      fX=pm.fX;
-      fY=pm.fY;
-      fOption=pm.fOption;
-   }
+   if(this != &pm)
+      pm.Copy(*this);
+
    return *this;
 }
 
@@ -139,17 +130,16 @@ TPolyMarker::~TPolyMarker()
 TPolyMarker::TPolyMarker(const TPolyMarker &polymarker) : TObject(polymarker), TAttMarker(polymarker)
 {
    fN = 0;
-   fX = fY = 0;
+   fX = fY = nullptr;
    fLastPoint = -1;
-   ((TPolyMarker&)polymarker).Copy(*this);
+   polymarker.Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Copy TPolyMarker into provided object
 
 void TPolyMarker::Copy(TObject &obj) const
 {
-   // Copy.
-
    TObject::Copy(obj);
    TAttMarker::Copy(((TPolyMarker&)obj));
    ((TPolyMarker&)obj).fN = fN;
@@ -159,10 +149,13 @@ void TPolyMarker::Copy(TObject &obj) const
    if (fN > 0) {
       ((TPolyMarker&)obj).fX = new Double_t [fN];
       ((TPolyMarker&)obj).fY = new Double_t [fN];
-      for (Int_t i=0; i<fN;i++) { ((TPolyMarker&)obj).fX[i] = fX[i], ((TPolyMarker&)obj).fY[i] = fY[i]; }
+      for (Int_t i=0; i<fN;i++) {
+         ((TPolyMarker&)obj).fX[i] = fX[i];
+         ((TPolyMarker&)obj).fY[i] = fY[i];
+      }
    } else {
-      ((TPolyMarker&)obj).fX = 0;
-      ((TPolyMarker&)obj).fY = 0;
+      ((TPolyMarker&)obj).fX = nullptr;
+      ((TPolyMarker&)obj).fY = nullptr;
    }
    ((TPolyMarker&)obj).fOption = fOption;
    ((TPolyMarker&)obj).fLastPoint = fLastPoint;


### PR DESCRIPTION
Typical problem - direct copy of self-allocated memory which will lead to error in destructor
Also adjust some assign operators where `Copy` can be used. 

