### PR TITLE
[cling] Reset pragma diag state after fwd decls.

### DIFF
--- a/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
+++ b/interpreter/cling/lib/Interpreter/ForwardDeclPrinter.cpp
@@ -50,9 +50,12 @@ namespace cling {
 
     // Suppress some unfixable warnings.
     // TODO: Find proper fix for these issues
-    Out() << "#pragma clang diagnostic ignored \"-Wkeyword-compat\"" << "\n";
-    Out() << "#pragma clang diagnostic ignored \"-Wignored-attributes\"" <<"\n";
-    Out() << "#pragma clang diagnostic ignored \"-Wreturn-type-c-linkage\"" <<"\n";
+    Out() << R"(
+#pragma diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-compat"
+#pragma clang diagnostic ignored "-Wignored-attributes"
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+)";
     // Inject a special marker:
     Out() << "extern int __Cling_AutoLoading_Map;\n";
 
@@ -108,6 +111,7 @@ namespace cling {
         Out() << "#undef " << m << "\n";
       }
     }
+    Out() << "#pragma diagnostic pop\n";
   }
 
   void ForwardDeclPrinter::Visit(clang::QualType QT) {


### PR DESCRIPTION
Possibly fixes cling suppressing -Wreturn-type.
