### PR TITLE
Properly use `Copy(TObject &)` methods in `graf` classes 

### DIFF
--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1125,12 +1125,13 @@ TColor::~TColor()
 
 TColor::TColor(const TColor &color) : TNamed(color)
 {
-   ((TColor&)color).Copy(*this);
+   color.TColor::Copy(*this);
 }
 
 TColor &TColor::operator=(const TColor &color)
 {
-   ((TColor &)color).Copy(*this);
+   if (this != &color)
+      color.TColor::Copy(*this);
    return *this;
 }
 

--- a/core/base/src/TStyle.cxx
+++ b/core/base/src/TStyle.cxx
@@ -487,12 +487,13 @@ TStyle::~TStyle()
 
 TStyle::TStyle(const TStyle &style) : TNamed(style), TAttLine(style), TAttFill(style), TAttMarker(style), TAttText(style)
 {
-   style.Copy(*this);
+   style.TStyle::Copy(*this);
 }
 
 TStyle& TStyle::operator=(const TStyle& style)
 {
-   style.Copy(*this);
+   if (this != &style)
+      style.TStyle::Copy(*this);
    return *this;
 }
 

--- a/graf2d/gpad/src/TPaveClass.cxx
+++ b/graf2d/gpad/src/TPaveClass.cxx
@@ -61,7 +61,7 @@ TPaveClass::~TPaveClass()
 
 TPaveClass::TPaveClass(const TPaveClass &PaveClass) : TPaveLabel(PaveClass)
 {
-   ((TPaveClass&)PaveClass).Copy(*this);
+   PaveClass.TPaveClass::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/inc/TPaveLabel.h
+++ b/graf2d/graf/inc/TPaveLabel.h
@@ -26,13 +26,7 @@ public:
    TPaveLabel();
    TPaveLabel(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, const char *label, Option_t *option="br");
    TPaveLabel(const TPaveLabel &pavelabel);
-   TPaveLabel& operator=(const TPaveLabel &pavelabel)
-   {
-     if (this != &pavelabel) {
-       ((TPaveLabel&)pavelabel).Copy(*this);
-     }
-     return *this;
-   }
+   TPaveLabel& operator=(const TPaveLabel &pavelabel);
    virtual ~TPaveLabel();
 
    void                Copy(TObject &pavelabel) const override;

--- a/graf2d/graf/src/TArc.cxx
+++ b/graf2d/graf/src/TArc.cxx
@@ -55,7 +55,7 @@ TArc::TArc(Double_t x1, Double_t y1,Double_t r1,Double_t phimin,Double_t phimax)
 
 TArc::TArc(const TArc &arc) : TEllipse(arc)
 {
-   ((TArc&)arc).Copy(*this);
+   arc.TArc::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TArrow.cxx
+++ b/graf2d/graf/src/TArrow.cxx
@@ -99,7 +99,7 @@ TArrow::TArrow(const TArrow &arrow) : TLine(), TAttFill()
 {
    fAngle     = fgDefaultAngle;
    fArrowSize = 0.;
-   arrow.Copy(*this);
+   arrow.TArrow::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TCrown.cxx
+++ b/graf2d/graf/src/TCrown.cxx
@@ -82,8 +82,7 @@ TCrown::TCrown(Double_t x1, Double_t y1,Double_t radin, Double_t radout,Double_t
 
 TCrown::TCrown(const TCrown &crown) : TEllipse(crown)
 {
-
-   ((TCrown&)crown).Copy(*this);
+   crown.TCrown::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,7 +97,6 @@ TCrown::~TCrown()
 
 void TCrown::Copy(TObject &crown) const
 {
-
    TEllipse::Copy(crown);
 }
 
@@ -156,7 +154,6 @@ Int_t TCrown::DistancetoPrimitive(Int_t px, Int_t py)
 
 TCrown *TCrown::DrawCrown(Double_t x1, Double_t y1,Double_t radin,Double_t radout,Double_t phimin,Double_t phimax,Option_t *option)
 {
-
    TCrown *newcrown = new TCrown(x1, y1, radin, radout, phimin, phimax);
    TAttLine::Copy(*newcrown);
    TAttFill::Copy(*newcrown);

--- a/graf2d/graf/src/TEllipse.cxx
+++ b/graf2d/graf/src/TEllipse.cxx
@@ -101,7 +101,7 @@ TEllipse::TEllipse(const TEllipse &ellipse) : TObject(ellipse), TAttLine(ellipse
    fPhimax = 360;
    fTheta  = 0;
 
-   ((TEllipse&)ellipse).Copy(*this);
+   ellipse.TEllipse::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TFrame.cxx
+++ b/graf2d/graf/src/TFrame.cxx
@@ -43,7 +43,7 @@ TFrame::TFrame(Double_t x1, Double_t y1,Double_t x2, Double_t  y2)
 
 TFrame::TFrame(const TFrame &frame) : TWbox(frame)
 {
-   ((TFrame&)frame).Copy(*this);
+   frame.TFrame::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -475,7 +475,7 @@ TLatex& TLatex::operator=(const TLatex& lt)
 void TLatex::Copy(TObject &obj) const
 {
    TText::Copy(obj);
-   TAttLine::Copy(((TAttLine&)obj));
+   TAttLine::Copy((TLatex &)obj);
    ((TLatex&)obj).fFactorSize  = fFactorSize;
    ((TLatex&)obj).fFactorPos   = fFactorPos;
    ((TLatex&)obj).fLimitFactorSize  = fLimitFactorSize;

--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -437,7 +437,7 @@ TLatex::~TLatex()
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor.
 
-TLatex::TLatex(const TLatex &text) : TText(text), TAttLine(text)
+TLatex::TLatex(const TLatex &latex) : TText(latex), TAttLine(latex)
 {
    fFactorSize  = 1.5;
    fFactorPos   = 0.6;
@@ -446,7 +446,7 @@ TLatex::TLatex(const TLatex &text) : TText(text), TAttLine(text)
    fOriginSize  = 0.04;
    fItalic      = kFALSE;
    fLimitFactorSize = 3;
-   ((TLatex&)text).Copy(*this);
+   latex.TLatex::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -474,6 +474,8 @@ TLatex& TLatex::operator=(const TLatex& lt)
 
 void TLatex::Copy(TObject &obj) const
 {
+   TText::Copy(obj);
+   TAttLine::Copy(((TAttLine&)obj));
    ((TLatex&)obj).fFactorSize  = fFactorSize;
    ((TLatex&)obj).fFactorPos   = fFactorPos;
    ((TLatex&)obj).fLimitFactorSize  = fLimitFactorSize;
@@ -482,8 +484,6 @@ void TLatex::Copy(TObject &obj) const
    ((TLatex&)obj).fTabSize     = fTabSize;
    ((TLatex&)obj).fOriginSize  = fOriginSize;
    ((TLatex&)obj).fItalic      = fItalic;
-   TText::Copy(obj);
-   TAttLine::Copy(((TAttLine&)obj));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -278,13 +278,7 @@ TLegend::TLegend( Double_t w, Double_t h, const char *header, Option_t *option)
 TLegend::TLegend(const TLegend &legend) : TPave(legend), TAttText(legend),
                                            fPrimitives(nullptr)
 {
-  if (legend.fPrimitives) {
-      fPrimitives = new TList();
-      TIter next(legend.fPrimitives);
-      while (auto entry = (TLegendEntry *) next())
-         fPrimitives->Add(new TLegendEntry(*entry));
-   }
-   legend.Copy(*this);
+   legend.TLegend::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -292,24 +286,8 @@ TLegend::TLegend(const TLegend &legend) : TPave(legend), TAttText(legend),
 
 TLegend& TLegend::operator=(const TLegend &lg)
 {
-   if(this!=&lg) {
-      TPave::operator=(lg);
-      TAttText::operator=(lg);
-      if (fPrimitives) {
-         fPrimitives->Delete();
-         delete fPrimitives;
-         fPrimitives = nullptr;
-      }
-      if (lg.fPrimitives) {
-         fPrimitives = new TList();
-         TIter next(lg.fPrimitives);
-         while (auto entry = (TLegendEntry *) next())
-            fPrimitives->Add(new TLegendEntry(*entry));
-      }
-      fEntrySeparation = lg.fEntrySeparation;
-      fMargin = lg.fMargin;
-      fNColumns = lg.fNColumns;
-   }
+   if(this != &lg)
+      lg.TLegend::Copy(*this);
    return *this;
 }
 
@@ -373,9 +351,8 @@ TLegendEntry *TLegend::AddEntry(const char *name, const char *label, Option_t *o
    if (!obj) {
       TList *lop = gPad->GetListOfPrimitives();
       if (lop) {
-         TObject *o=0;
          TIter next(lop);
-         while( (o=next()) ) {
+         while(auto o = next()) {
             if ( o->InheritsFrom(TMultiGraph::Class() ) ) {
                TList * grlist = ((TMultiGraph *)o)->GetListOfGraphs();
                obj = grlist->FindObject(name);
@@ -405,13 +382,26 @@ void TLegend::Clear( Option_t *)
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy this legend into "obj".
 
-void TLegend::Copy( TObject &obj ) const
+void TLegend::Copy(TObject &obj) const
 {
-   TPave::Copy(obj);
-   TAttText::Copy((TLegend&)obj);
-   ((TLegend&)obj).fEntrySeparation = fEntrySeparation;
-   ((TLegend&)obj).fMargin = fMargin;
-   ((TLegend&)obj).fNColumns = fNColumns;
+   auto &tgt = static_cast<TLegend &> (obj);
+   TPave::Copy(tgt);
+   TAttText::Copy(tgt);
+   tgt.fEntrySeparation = fEntrySeparation;
+   tgt.fMargin = fMargin;
+   tgt.fNColumns = fNColumns;
+
+   if (tgt.fPrimitives) {
+      tgt.fPrimitives->Delete();
+      delete tgt.fPrimitives;
+      tgt.fPrimitives = nullptr;
+   }
+   if (fPrimitives) {
+      tgt.fPrimitives = new TList();
+      TIter next(fPrimitives);
+      while (auto entry = (TLegendEntry *) next())
+         tgt.fPrimitives->Add(new TLegendEntry(*entry));
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TLegendEntry.cxx
+++ b/graf2d/graf/src/TLegendEntry.cxx
@@ -9,7 +9,7 @@
  * For the list of contributors see $ROOTSYS/README/CREDITS.             *
  *************************************************************************/
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "TLegendEntry.h"
 #include "TVirtualPad.h"
@@ -29,7 +29,7 @@ Storage class for one entry of a TLegend.
 
 TLegendEntry::TLegendEntry(): TAttText(), TAttLine(), TAttFill(), TAttMarker()
 {
-   fObject = 0;
+   fObject = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,7 +51,7 @@ TLegendEntry::TLegendEntry(): TAttText(), TAttLine(), TAttFill(), TAttMarker()
 TLegendEntry::TLegendEntry(const TObject* obj, const char* label, Option_t* option )
              :TAttText(0,0,0,0,0), TAttLine(1,1,1), TAttFill(0,0), TAttMarker(1,21,1)
 {
-   fObject = 0;
+   fObject = nullptr;
    if ( !label && obj ) fLabel = obj->GetTitle();
    else                 fLabel = label;
    fOption = option;
@@ -61,9 +61,9 @@ TLegendEntry::TLegendEntry(const TObject* obj, const char* label, Option_t* opti
 ////////////////////////////////////////////////////////////////////////////////
 /// TLegendEntry copy constructor
 
-TLegendEntry::TLegendEntry( const TLegendEntry &entry ) : TObject(entry), TAttText(entry), TAttLine(entry), TAttFill(entry), TAttMarker(entry)
+TLegendEntry::TLegendEntry(const TLegendEntry &entry) : TObject(entry), TAttText(entry), TAttLine(entry), TAttFill(entry), TAttMarker(entry)
 {
-   ((TLegendEntry&)entry).Copy(*this);
+   entry.TLegendEntry::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -71,7 +71,7 @@ TLegendEntry::TLegendEntry( const TLegendEntry &entry ) : TObject(entry), TAttTe
 
 TLegendEntry::~TLegendEntry()
 {
-   fObject = 0;
+   fObject = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -146,10 +146,9 @@ void TLegendEntry::SetObject(TObject* obj )
 ////////////////////////////////////////////////////////////////////////////////
 /// (re)set the obj pointed to by this entry
 
-void TLegendEntry::SetObject( const char* objectName)
+void TLegendEntry::SetObject(const char* objectName)
 {
-   TObject* obj = 0;
-   TList* padprimitives = gPad->GetListOfPrimitives();
-   if (padprimitives) obj = padprimitives->FindObject( objectName );
-   if (obj) SetObject( obj );
+   TList *padprimitives = gPad ? gPad->GetListOfPrimitives() : nullptr;
+   TObject *obj = padprimitives ? padprimitives->FindObject(objectName) : nullptr;
+   if (obj) SetObject(obj);
 }

--- a/graf2d/graf/src/TMarker.cxx
+++ b/graf2d/graf/src/TMarker.cxx
@@ -83,7 +83,7 @@ TMarker::TMarker(const TMarker &marker) : TObject(marker), TAttMarker(marker), T
 {
    fX = 0;
    fY = 0;
-   ((TMarker&)marker).Copy(*this);
+   marker.TMarker::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -92,9 +92,9 @@ TMarker::TMarker(const TMarker &marker) : TObject(marker), TAttMarker(marker), T
 void TMarker::Copy(TObject &obj) const
 {
    TObject::Copy(obj);
-   TAttMarker::Copy(((TMarker&)obj));
-   ((TMarker&)obj).fX = fX;
-   ((TMarker&)obj).fY = fY;
+   TAttMarker::Copy(((TMarker &)obj));
+   ((TMarker &)obj).fX = fX;
+   ((TMarker &)obj).fY = fY;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPaveLabel.cxx
+++ b/graf2d/graf/src/TPaveLabel.cxx
@@ -47,18 +47,28 @@ TPaveLabel::TPaveLabel(Double_t x1, Double_t y1,Double_t x2, Double_t  y2, const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Pavelabel default destructor.
+/// TPaveLabel default destructor.
 
 TPaveLabel::~TPaveLabel()
 {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Pavelabel copy constructor.
+/// TPaveLabel copy constructor.
 
 TPaveLabel::TPaveLabel(const TPaveLabel &pavelabel) : TPave(pavelabel), TAttText(pavelabel)
 {
-   ((TPaveLabel&)pavelabel).Copy(*this);
+   pavelabel.TPaveLabel::Copy(*this);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// TPaveLabel assign operator
+
+TPaveLabel& TPaveLabel::operator=(const TPaveLabel &pavelabel)
+{
+   if (this != &pavelabel)
+      pavelabel.TPaveLabel::Copy(*this);
+   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +78,7 @@ void TPaveLabel::Copy(TObject &obj) const
 {
    TPave::Copy(obj);
    TAttText::Copy(((TPaveLabel&)obj));
-   ((TPaveLabel&)obj).fLabel      = fLabel;
+   ((TPaveLabel &)obj).fLabel = fLabel;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,8 +87,8 @@ void TPaveLabel::Copy(TObject &obj) const
 void TPaveLabel::Draw(Option_t *option)
 {
    Option_t *opt;
-   if (option && strlen(option)) opt = option;
-   else                          opt = GetOption();
+   if (option && *option) opt = option;
+   else                   opt = GetOption();
 
    AppendPad(opt);
 }

--- a/graf2d/graf/src/TPolyLine.cxx
+++ b/graf2d/graf/src/TPolyLine.cxx
@@ -125,9 +125,8 @@ TPolyLine::TPolyLine(Int_t n, Double_t *x, Double_t *y, Option_t *option)
 
 TPolyLine& TPolyLine::operator=(const TPolyLine& pl)
 {
-   if(this!=&pl) {
-      pl.Copy(*this);
-   }
+   if(this != &pl)
+      pl.TPolyLine::Copy(*this);
    return *this;
 }
 
@@ -149,7 +148,7 @@ TPolyLine::TPolyLine(const TPolyLine &polyline) : TObject(polyline), TAttLine(po
    fX = nullptr;
    fY = nullptr;
    fLastPoint = -1;
-   ((TPolyLine&)polyline).Copy(*this);
+   polyline.TPolyLine::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -166,7 +165,10 @@ void TPolyLine::Copy(TObject &obj) const
    if (fN > 0) {
       ((TPolyLine&)obj).fX = new Double_t[fN];
       ((TPolyLine&)obj).fY = new Double_t[fN];
-      for (Int_t i=0; i<fN;i++)  {((TPolyLine&)obj).fX[i] = fX[i]; ((TPolyLine&)obj).fY[i] = fY[i];}
+      for (Int_t i = 0; i < fN; i++) {
+         ((TPolyLine &)obj).fX[i] = fX[i];
+         ((TPolyLine &)obj).fY[i] = fY[i];
+      }
    } else {
       ((TPolyLine&)obj).fX = nullptr;
       ((TPolyLine&)obj).fY = nullptr;

--- a/graf3d/g3d/src/TAxis3D.cxx
+++ b/graf3d/g3d/src/TAxis3D.cxx
@@ -130,7 +130,7 @@ TAxis3D::TAxis3D(Option_t *) : TNamed(TAxis3D::fgRulerName,"ruler")
 
 TAxis3D::TAxis3D(const TAxis3D &axis) : TNamed(axis)
 {
-   axis.Copy(*this);
+   axis.TAxis3D::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/g3d/src/TXTRU.cxx
+++ b/graf3d/g3d/src/TXTRU.cxx
@@ -130,7 +130,7 @@ TXTRU::TXTRU(const char *name, const char *title, const char *material,
 
 TXTRU::TXTRU(const TXTRU &xtru) : TShape(xtru)
 {
-   xtru.Copy(*this);
+   xtru.TXTRU::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -167,7 +167,7 @@ TXTRU& TXTRU::operator=(const TXTRU &rhs)
 {
    // protect against self-assignment
    if (this != &rhs)
-      rhs.Copy(*this);
+      rhs.TXTRU::Copy(*this);
 
    return *this;
 }

--- a/hist/histpainter/src/TPaletteAxis.cxx
+++ b/hist/histpainter/src/TPaletteAxis.cxx
@@ -152,7 +152,7 @@ TPaletteAxis::~TPaletteAxis()
 
 TPaletteAxis::TPaletteAxis(const TPaletteAxis &palette) : TPave(palette)
 {
-   ((TPaletteAxis&)palette).Copy(*this);
+   palette.TPaletteAxis::Copy(*this);
 }
 
 
@@ -161,7 +161,8 @@ TPaletteAxis::TPaletteAxis(const TPaletteAxis &palette) : TPave(palette)
 
 TPaletteAxis& TPaletteAxis::operator=(const TPaletteAxis &orig)
 {
-   orig.Copy( *this );
+   if (this != &orig)
+      orig.TPaletteAxis::Copy(*this);
    return *this;
 }
 


### PR DESCRIPTION
This is virtual method and can be overriden in derived classes.
Therefore when such method used in copy constructor or assignment
operator, one have to explicitly specify class which used.

Fix bug in `TLatex::Copy()`

Provide proper implementation of `TLegend::Copy()`