### PR TITLE
Fix bug in TLatex::Copy method [6.22]

### DIFF
--- a/graf2d/graf/src/TLatex.cxx
+++ b/graf2d/graf/src/TLatex.cxx
@@ -481,7 +481,7 @@ void TLatex::Copy(TObject &obj) const
    ((TLatex&)obj).fPos         = fPos;
    ((TLatex&)obj).fItalic      = fItalic;
    TText::Copy(obj);
-   TAttLine::Copy(((TAttLine&)obj));
+   TAttLine::Copy((TLatex&)obj);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
TAttLine::Copy was using wrong cast for target object.
As a result, line attributes were overwriting some base TObject
members

