### PR TITLE
[skip-ci] Fix an issue with `root-config --has-whatever` (#10922)

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -842,7 +842,8 @@ else()
         "${libdir}" "-lCore" "-lRint" "${incdir}" "" "" "${ROOT_ARCHITECTURE}" "${ROOTBUILD}")
 endif()
 
-#---Get the value of CMAKE_CXX_FLAGS provided by the user in the command line
+#---Get the values of ROOT_ALL_OPTIONS and CMAKE_CXX_FLAGS provided by the user in the command line
+set(all_features ${ROOT_ALL_OPTIONS})
 set(usercflags ${CMAKE_CXX_FLAGS-CACHED})
 file(REMOVE ${CMAKE_BINARY_DIR}/installtree/root-config)
 configure_file(${CMAKE_SOURCE_DIR}/config/root-config.in ${CMAKE_BINARY_DIR}/installtree/root-config @ONLY NEWLINE_STYLE UNIX)
@@ -868,7 +869,6 @@ if(WIN32)
 endif()
 
 #--Local root-configure
-set(all_features ${ROOT_ALL_OPTIONS})
 set(prefix $ROOTSYS)
 set(bindir $ROOTSYS/bin)
 set(libdir $ROOTSYS/lib)


### PR DESCRIPTION
* Fix an issue with `root-config --has-whatever`

Fix an issue with `root-config --has-whatever` as described on the forum: https://root-forum.cern.ch/t/tpythia8-h-file-not-found/50682
The `all_features` list in the `root-config` script was empty when installing it (but was OK in the build directory)

* [skip-ci] Fix the comment
