### PR TITLE
[skip-ci][win] Fix thisroot.bat

### DIFF
--- a/config/thisroot.bat
+++ b/config/thisroot.bat
@@ -5,7 +5,7 @@ rem Author: Axel Naumann, 10/07/2007
 
 set OLDPATH=%CD%
 set THIS=%0
-set THIS=%THIS:~0,-12%.
+set THIS=%THIS:~0,-13%.
 cd /D %THIS%\..
 set ROOTSYS=%CD%
 cd /D %OLDPATH%


### PR DESCRIPTION
Fix correct substring length when setting ROOTSYS
