### PR TITLE
[Doxygen] fix generation of collaboration diagrams

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -1,7 +1,15 @@
 
 .PHONY: filter folders mathjax js images doxygen replaceCollaborationDiagrams
 
-NJOB ?= $(shell nproc)
+OS=$(shell uname)
+ifeq ($(UNAME), Darwin)
+   export DOXYGEN_LDD := otool -L
+   NJOB ?= $(shell sysctl -n hw.ncpu)
+else
+   export DOXYGEN_LDD := ldd
+   NJOB ?= $(shell nproc)
+endif
+
 PYTHON_EXECUTABLE ?= python3
 export PYTHON_EXECUTABLE
 export PYSPARK_PYTHON := $(PYTHON_EXECUTABLE)

--- a/documentation/doxygen/makeCollaborationDiagrams.sh
+++ b/documentation/doxygen/makeCollaborationDiagrams.sh
@@ -4,7 +4,7 @@
 
 HTMLPATH=$DOXYGEN_OUTPUT_DIRECTORY/html
 DOXYGEN_LDD=${DOXYGEN_LDD:=ldd}
-dotFile=$(mktemp /tmp/libraries_XXXX.dot)
+dotFile=$(mktemp /tmp/libraries.dot.XXXX)
 
 test -d "$HTMLPATH" || { echo "HTMLPATH '$HTMLPATH' not found."; exit 1; }
 test -d "$ROOTSYS"  || { echo "ROOTSYS not set"; exit 1; }

--- a/documentation/doxygen/modifyClassWebpage.sh
+++ b/documentation/doxygen/modifyClassWebpage.sh
@@ -12,7 +12,7 @@ fi
 
 # Find the libraries for the class $1
 libname=$(root -l -b -q "libs.C+g(\"$1\")" | grep 'mainlib=')
-   
+
 # The class was not found. Remove the collaboration graph
 if [ -z "${libname}" ]; then
    echo "WARNING modifyClassWebpage.sh: libs.C could not get library of class $1 from ROOT interpreter. Removing its collaboration diagram."

--- a/documentation/doxygen/modifyClassWebpages.sh
+++ b/documentation/doxygen/modifyClassWebpages.sh
@@ -4,16 +4,7 @@
 
 # Finding the system we are running
 
-export DOXYGEN_LDD="ldd"
-listOfClasses=$(mktemp /tmp/listOfClasses_XXXXXX.txt)
-OS=`uname`
-
-case "$OS" in
-   "Linux") export DOXYGEN_LDD="ldd"
-   ;;
-   "Darwin")export DOXYGEN_LDD="otool -L"
-   ;;
-esac
+listOfClasses=$(mktemp /tmp/listOfClasses.XXXXXX)
 
 case "$1" in
    -j*)

--- a/documentation/doxygen/modifyClassWebpages.sh
+++ b/documentation/doxygen/modifyClassWebpages.sh
@@ -25,4 +25,5 @@ if [ ! -s "${listOfClasses}" ]; then
    exit 0
 fi
 
+root -l -b -q -e ".L libs.C++g"
 xargs -L 1 -P ${NJOB:-1} ./modifyClassWebpage.sh < ${listOfClasses}


### PR DESCRIPTION
This pull request applies a number of fixes after the merge or PR #5913 (see below).

## Changes or fixes:
- Fix issues with documentation generation on macOS.  In particular: 
1. Fix `mktemp` command lines to only use template `X`s at the end.
2. Use `sysctl -n hw.ncpu` instead to get the number of available CPUs on Darwin.
3. Move OS-dependent variable assignments to the `Makefile`
- Ensure `libs.C` is ACLiC'ed before `modifyClassWebpage.sh` runs.  Specifically, `modifyClassWebpages.sh` might spawn many `modifyClassWebpage.sh` processes via `xargs -P`.  In turn, `modifyClassWebpage.sh` depends on `libs.C` which is ACLiC'ed if to generate `libs_C.so` where required.
However, if `libs_C.so` does not exist, multiple processes might race to create it. Thus, ensure that the macro is ACLiC'ed before `modifyClassWebpage.sh` runs.

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary)