### PR TITLE
Adjust core gui classes

### DIFF
--- a/core/gui/inc/TApplicationImp.h
+++ b/core/gui/inc/TApplicationImp.h
@@ -33,25 +33,21 @@ protected:
 
 public:
    TApplicationImp(): fApplicationName() { }
-   TApplicationImp(const char *appClassName, int *argc, char **argv);
-   virtual ~TApplicationImp();
+   TApplicationImp(const char *appClassName, int *argc, char **argv) : fApplicationName(appClassName) { (void) argc; (void) argv; }
+   virtual ~TApplicationImp() {}
 
    virtual const char *ApplicationName() const { return fApplicationName.Data(); }
-   virtual void        Show() { }
-   virtual void        Hide() { }
-   virtual void        Iconify() { }
+   virtual void        Show() {}
+   virtual void        Hide() {}
+   virtual void        Iconify() {}
    virtual Bool_t      IsCmdThread() { return kTRUE; } // by default (for UNIX) ROOT is a single thread application
-   virtual void        Init() { }
-   virtual void        Open() { }
-   virtual void        Raise() { }
-   virtual void        Lower() { }
-   virtual Int_t       ExecCommand(TGWin32Command *code, Bool_t synch);
+   virtual void        Init() {}
+   virtual void        Open() {}
+   virtual void        Raise() {}
+   virtual void        Lower() {}
+   virtual Int_t       ExecCommand(TGWin32Command *code, Bool_t synch) { (void) code; (void) synch; return 0; }
 
    ClassDef(TApplicationImp,0)  //ABC describing application protocol
 };
-
-inline TApplicationImp::TApplicationImp(const char *appClassName, int *, char **)
-  : fApplicationName(appClassName) { }
-inline Int_t TApplicationImp::ExecCommand(TGWin32Command *, Bool_t) { return 0; }
 
 #endif

--- a/core/gui/inc/TCanvasImp.h
+++ b/core/gui/inc/TCanvasImp.h
@@ -31,15 +31,18 @@ class TCanvasImp {
 friend class TCanvas;
 
 protected:
-   TCanvas  *fCanvas;   //TCanvas associated with this implementation
+   TCanvas  *fCanvas{nullptr};   //TCanvas associated with this implementation
 
-   TCanvasImp(const TCanvasImp& ci)
-     : fCanvas(ci.fCanvas) { }
-   TCanvasImp& operator=(const TCanvasImp& ci)
-     {if(this!=&ci) fCanvas=ci.fCanvas; return *this;}
+   TCanvasImp(const TCanvasImp &ci) : fCanvas(ci.fCanvas) {}
+   TCanvasImp &operator=(const TCanvasImp &ci)
+   {
+      if (this != &ci)
+         fCanvas = ci.fCanvas;
+      return *this;
+   }
 
-   virtual void   Lock();
-   virtual void   Unlock() { }
+   virtual void   Lock() {}
+   virtual void   Unlock() {}
    virtual Bool_t IsLocked() { return kFALSE; }
 
    virtual Bool_t IsWeb() const { return kFALSE; }
@@ -47,31 +50,36 @@ protected:
    virtual TVirtualPadPainter *CreatePadPainter() { return nullptr; }
 
 public:
-   TCanvasImp(TCanvas *c=0) : fCanvas(c) { }
-   TCanvasImp(TCanvas *c, const char *name, UInt_t width, UInt_t height);
-   TCanvasImp(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height);
-   virtual ~TCanvasImp() { }
+   TCanvasImp(TCanvas *c = nullptr) : fCanvas(c) {}
+   TCanvasImp(TCanvas *c, const char *name, UInt_t width, UInt_t height) : fCanvas(c) { (void) name; (void) width; (void) height; }
+   TCanvasImp(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height) : fCanvas(c) {(void) name; (void) x; (void) y; (void) width; (void) height;}
+   virtual ~TCanvasImp() {}
 
    TCanvas       *Canvas() const { return fCanvas; }
-   virtual void   Close() { }
-   virtual void   ForceUpdate() { }
-   virtual UInt_t GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h);
-   virtual void   Iconify() { }
+   virtual void   Close() {}
+   virtual void   ForceUpdate() {}
+   virtual UInt_t GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h)
+   {
+      x = y = 0;
+      w = h = 0;
+      return 0;
+   }
+   virtual void Iconify() {}
    virtual Int_t  InitWindow() { return 0; }
-   virtual void   SetStatusText(const char *text = nullptr, Int_t partidx = 0);
-   virtual void   SetWindowPosition(Int_t x, Int_t y);
-   virtual void   SetWindowSize(UInt_t w, UInt_t h);
-   virtual void   SetWindowTitle(const char *newTitle);
-   virtual void   SetCanvasSize(UInt_t w, UInt_t h);
-   virtual void   Show() { }
-   virtual void   ShowMenuBar(Bool_t show = kTRUE);
-   virtual void   ShowStatusBar(Bool_t show = kTRUE);
-   virtual void   RaiseWindow();
-   virtual void   ReallyDelete();
+   virtual void   SetStatusText(const char *text = nullptr, Int_t partidx = 0) { (void) text; (void) partidx; }
+   virtual void   SetWindowPosition(Int_t x, Int_t y) { (void) x; (void) y; }
+   virtual void   SetWindowSize(UInt_t width, UInt_t height) { (void) width; (void) height; }
+   virtual void   SetWindowTitle(const char *newTitle) { (void) newTitle; }
+   virtual void   SetCanvasSize(UInt_t w, UInt_t h) { (void) w; (void) h; }
+   virtual void   Show() {}
+   virtual void   ShowMenuBar(Bool_t show = kTRUE) { (void) show; }
+   virtual void   ShowStatusBar(Bool_t show = kTRUE) { (void) show; }
+   virtual void   RaiseWindow() {}
+   virtual void   ReallyDelete() {}
 
-   virtual void   ShowEditor(Bool_t show = kTRUE);
-   virtual void   ShowToolBar(Bool_t show = kTRUE);
-   virtual void   ShowToolTips(Bool_t show = kTRUE);
+   virtual void   ShowEditor(Bool_t show = kTRUE) { (void) show; }
+   virtual void   ShowToolBar(Bool_t show = kTRUE) { (void) show; }
+   virtual void   ShowToolTips(Bool_t show = kTRUE) { (void) show; }
 
    virtual Bool_t HasEditor() const { return kFALSE; }
    virtual Bool_t HasMenuBar() const { return kFALSE; }
@@ -81,23 +89,5 @@ public:
 
    ClassDef(TCanvasImp,0)  //ABC describing main window protocol
 };
-
-inline TCanvasImp::TCanvasImp(TCanvas *c, const char *, UInt_t, UInt_t) : fCanvas(c) { }
-inline TCanvasImp::TCanvasImp(TCanvas *c, const char *, Int_t, Int_t, UInt_t, UInt_t) : fCanvas(c) { }
-inline UInt_t TCanvasImp::GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h)
-               { x = y = 0; w = h = 0; return 0;}
-inline void TCanvasImp::SetStatusText(const char *, Int_t) { }
-inline void TCanvasImp::SetWindowPosition(Int_t, Int_t) { }
-inline void TCanvasImp::SetWindowSize(UInt_t, UInt_t) { }
-inline void TCanvasImp::SetWindowTitle(const char *) { }
-inline void TCanvasImp::SetCanvasSize(UInt_t, UInt_t) { }
-inline void TCanvasImp::ShowMenuBar(Bool_t) { }
-inline void TCanvasImp::ShowStatusBar(Bool_t) { }
-inline void TCanvasImp::RaiseWindow() { }
-inline void TCanvasImp::ReallyDelete() { }
-
-inline void TCanvasImp::ShowEditor(Bool_t) { }
-inline void TCanvasImp::ShowToolBar(Bool_t) { }
-inline void TCanvasImp::ShowToolTips(Bool_t) { }
 
 #endif

--- a/core/gui/inc/TContextMenuImp.h
+++ b/core/gui/inc/TContextMenuImp.h
@@ -33,29 +33,27 @@ class TFunction;
 class TContextMenuImp {
 
 protected:
-   TContextMenu *fContextMenu; //TContextMenu associated with this implementation
+   TContextMenu *fContextMenu{nullptr}; //TContextMenu associated with this implementation
 
-   TContextMenuImp(const TContextMenuImp& cmi)
-     : fContextMenu(cmi.fContextMenu) { }
-   TContextMenuImp& operator=(const TContextMenuImp& cmi)
-     {if(this!=&cmi) fContextMenu=cmi.fContextMenu;
-     return *this;}
+   TContextMenuImp(const TContextMenuImp &cmi) : fContextMenu(cmi.fContextMenu) {}
+   TContextMenuImp &operator=(const TContextMenuImp &cmi)
+   {
+      if (this != &cmi)
+         fContextMenu = cmi.fContextMenu;
+      return *this;
+   }
 
 public:
-   TContextMenuImp(TContextMenu *c=nullptr) : fContextMenu(c) { }
-   virtual ~TContextMenuImp();
+   TContextMenuImp(TContextMenu *c = nullptr) : fContextMenu(c) {}
+   virtual ~TContextMenuImp() {}
 
    virtual TContextMenu *GetContextMenu() const { return fContextMenu; }
 
-   virtual void Dialog(TObject *object, TFunction *function);
-   virtual void Dialog(TObject *object, TMethod *method);
-   virtual void DisplayPopup(Int_t x, Int_t y);
+   virtual void Dialog(TObject *object, TFunction *function) { (void) object; (void) function; }
+   virtual void Dialog(TObject *object, TMethod *method) { (void) object; (void) method; }
+   virtual void DisplayPopup(Int_t x, Int_t y) { (void) x; (void) y; }
 
    ClassDef(TContextMenuImp,0) //Context sensitive popup menu implementation
 };
-
-inline void TContextMenuImp::Dialog(TObject *, TFunction *) { }
-inline void TContextMenuImp::Dialog(TObject *, TMethod *) { }
-inline void TContextMenuImp::DisplayPopup(Int_t, Int_t) { }
 
 #endif

--- a/core/gui/src/TApplicationImp.cxx
+++ b/core/gui/src/TApplicationImp.cxx
@@ -18,4 +18,3 @@ ABC describing GUI independent application implementation protocol.
 #include "TApplicationImp.h"
 
 ClassImp(TApplicationImp);
-TApplicationImp::~TApplicationImp() {}

--- a/core/gui/src/TCanvasImp.cxx
+++ b/core/gui/src/TCanvasImp.cxx
@@ -19,4 +19,3 @@ and a drawing area).
 #include "TCanvasImp.h"
 
 ClassImp(TCanvasImp);
-void TCanvasImp::Lock() {}

--- a/core/gui/src/TContextMenuImp.cxx
+++ b/core/gui/src/TContextMenuImp.cxx
@@ -18,4 +18,3 @@ This class provides an interface to GUI independent context sensitive popup menu
 #include "TContextMenuImp.h"
 
 ClassImp(TContextMenuImp);
-TContextMenuImp::~TContextMenuImp() {}


### PR DESCRIPTION
Do not split methods declaration and implementation because of compiler warnings

Use `(void) arg` instead.
