### PR TITLE
Fix memory leaks and assign operators in core classes

### DIFF
--- a/core/base/inc/TSystemDirectory.h
+++ b/core/base/inc/TSystemDirectory.h
@@ -32,15 +32,15 @@ class TList;
 class TSystemDirectory : public TSystemFile {
 
 protected:
-   TOrdCollection *fDirsInBrowser;
-   TOrdCollection *fFilesInBrowser;
+   TOrdCollection *fDirsInBrowser{nullptr};
+   TOrdCollection *fFilesInBrowser{nullptr};
 
    Bool_t             IsItDirectory(const char *name) const;
    TSystemDirectory  *FindDirObj(const char *name);
    TSystemFile       *FindFileObj(const char *name, const char *dir);
 
-   TSystemDirectory(const TSystemDirectory&);
-   TSystemDirectory& operator=(const TSystemDirectory&);
+   TSystemDirectory(const TSystemDirectory&) = delete;
+   TSystemDirectory& operator=(const TSystemDirectory&) = delete;
 
 public:
    TSystemDirectory();

--- a/core/base/inc/TSystemFile.h
+++ b/core/base/inc/TSystemFile.h
@@ -40,7 +40,7 @@ public:
    virtual void     Move(const char *to);          // *MENU*
    virtual void     Edit();                        // *MENU*
 
-   virtual Bool_t   IsDirectory(const char *dir = 0) const;
+   virtual Bool_t   IsDirectory(const char *dir = nullptr) const;
    virtual void     SetIconName(const char *name) { fIconName = name; }
    const char      *GetIconName() const override { return fIconName.Data(); }
 

--- a/core/base/inc/TTimeStamp.h
+++ b/core/base/inc/TTimeStamp.h
@@ -12,33 +12,6 @@
 #ifndef ROOT_TTimeStamp
 #define ROOT_TTimeStamp
 
-//////////////////////////////////////////////////////////////////////////
-//
-// The TTimeStamp encapsulates seconds and ns since EPOCH
-//
-// This extends (and isolates) struct timespec
-//    struct timespec
-//       {
-//          time_t   tv_sec;   /* seconds */
-//          long     tv_nsec;  /* nanoseconds */
-//       }
-//    time_t seconds is relative to Jan 1, 1970 00:00:00 UTC
-//
-// No accounting of leap seconds is made.
-//
-// Due to ROOT/CINT limitations TTimeStamp does not explicitly
-// hold a timespec struct; attempting to do so means the Streamer
-// must be hand written.  Instead we have chosen to simply contain
-// similar fields within the private area of this class.
-//
-// NOTE: the use of time_t (and its default implementation as a 32 int)
-//       implies overflow conditions occurs somewhere around
-//       Jan 18, 19:14:07, 2038.
-//       If this experiment is still going when it becomes significant
-//       someone will have to deal with it.
-//
-//////////////////////////////////////////////////////////////////////////
-
 #include "Rtypes.h"
 
 #include <ctime>
@@ -56,6 +29,7 @@ typedef struct tm       tm_t;
 
 class TVirtualMutex;
 class TTimeStamp;
+
 std::ostream &operator<<(std::ostream &os,  const TTimeStamp &ts);
 TBuffer &operator<<(TBuffer &buf, const TTimeStamp &ts);
 TBuffer &operator>>(TBuffer &buf, TTimeStamp &ts);
@@ -105,7 +79,7 @@ public:
    TTimeStamp(UInt_t date, UInt_t time, UInt_t nsec,
               Bool_t isUTC = kTRUE, Int_t secOffset = 0);
 
-   // compatability with time() and DOS date
+   // compatibility with time() and DOS date
    TTimeStamp(UInt_t tloc, Bool_t isUTC = kTRUE, Int_t secOffset = 0,
               Bool_t dosDate = kFALSE);
 
@@ -123,7 +97,7 @@ public:
    void Set(Int_t date,   Int_t time, Int_t nsec,
             Bool_t isUTC, Int_t secOffset);
 
-   // compatability with time() and DOS date
+   // compatibility with time() and DOS date
    void Set(UInt_t tloc, Bool_t isUTC, Int_t secOffset, Bool_t dosDate);
 
    // direct setters
@@ -148,11 +122,11 @@ public:
 
    void         Copy(TTimeStamp &ts) const;
    UInt_t       GetDate(Bool_t inUTC = kTRUE, Int_t secOffset = 0,
-                        UInt_t *year = 0, UInt_t *month = 0,
-                        UInt_t *day = 0) const;
+                        UInt_t *year = nullptr, UInt_t *month = nullptr,
+                        UInt_t *day = nullptr) const;
    UInt_t       GetTime(Bool_t inUTC = kTRUE, Int_t secOffset = 0,
-                        UInt_t *hour = 0, UInt_t *min = 0,
-                        UInt_t *sec = 0) const;
+                        UInt_t *hour = nullptr, UInt_t *min = nullptr,
+                        UInt_t *sec = nullptr) const;
    Int_t        GetDayOfYear(Bool_t inUTC = kTRUE, Int_t secOffset = 0) const;
    Int_t        GetDayOfWeek(Bool_t inUTC = kTRUE, Int_t secOffset = 0) const;
    Int_t        GetMonth(Bool_t inUTC = kTRUE, Int_t secOffset = 0) const;

--- a/core/base/src/TSystemDirectory.cxx
+++ b/core/base/src/TSystemDirectory.cxx
@@ -29,8 +29,6 @@ ClassImp(TSystemDirectory);
 
 TSystemDirectory::TSystemDirectory()
 {
-   fDirsInBrowser  = nullptr;
-   fFilesInBrowser = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -39,31 +37,6 @@ TSystemDirectory::TSystemDirectory()
 TSystemDirectory::TSystemDirectory(const char *dirname, const char *path) :
    TSystemFile(dirname, path)
 {
-   fDirsInBrowser  = nullptr;
-   fFilesInBrowser = nullptr;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Copy constructor
-
-TSystemDirectory::TSystemDirectory(const TSystemDirectory& sd) :
-  TSystemFile(sd),
-  fDirsInBrowser(sd.fDirsInBrowser),
-  fFilesInBrowser(sd.fFilesInBrowser)
-{
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// Assignment operator
-
-TSystemDirectory& TSystemDirectory::operator=(const TSystemDirectory& sd)
-{
-   if(this!=&sd) {
-      TSystemFile::operator=(sd);
-      fDirsInBrowser=sd.fDirsInBrowser;
-      fFilesInBrowser=sd.fFilesInBrowser;
-   }
-   return *this;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -201,7 +174,7 @@ void TSystemDirectory::Browse(TBrowser *b)
 
 TSystemDirectory *TSystemDirectory::FindDirObj(const char *name)
 {
-   int size = fDirsInBrowser->GetSize();
+   int size = fDirsInBrowser ? fDirsInBrowser->GetSize() : 0;
    for (int i = 0; i < size; i++) {
       TSystemDirectory *obj = (TSystemDirectory *) fDirsInBrowser->At(i);
       if (!strcmp(name, obj->GetTitle()))
@@ -216,7 +189,7 @@ TSystemDirectory *TSystemDirectory::FindDirObj(const char *name)
 
 TSystemFile *TSystemDirectory::FindFileObj(const char *name, const char *dir)
 {
-   int size = fFilesInBrowser->GetSize();
+   int size = fFilesInBrowser ? fFilesInBrowser->GetSize() : 0;
    for (int i = 0; i < size; i++) {
       TSystemFile *obj = (TSystemFile *) fFilesInBrowser->At(i);
       if (!strcmp(name, obj->GetName()) && !strcmp(dir, obj->GetTitle()))

--- a/core/base/src/TTask.cxx
+++ b/core/base/src/TTask.cxx
@@ -120,19 +120,20 @@ TTask::TTask(const char* name, const char *title)
 
 TTask& TTask::operator=(const TTask& tt)
 {
-   if(this!=&tt) {
+   if (this != &tt) {
       TNamed::operator=(tt);
-      fTasks->Delete();
+      if (fTasks)
+         fTasks->Delete();
+      else
+         fTasks = new TList;
       TIter next(tt.fTasks);
-      TTask *task;
-      while ((task = (TTask*)next())) {
+      while (auto task = (TTask *)next())
          fTasks->Add(new TTask(*task));
-      }
-      fOption=tt.fOption;
-      fBreakin=tt.fBreakin;
-      fBreakout=tt.fBreakout;
-      fHasExecuted=tt.fHasExecuted;
-      fActive=tt.fActive;
+      fOption = tt.fOption;
+      fBreakin = tt.fBreakin;
+      fBreakout = tt.fBreakout;
+      fHasExecuted = tt.fHasExecuted;
+      fActive = tt.fActive;
    }
    return *this;
 }
@@ -144,10 +145,8 @@ TTask::TTask(const TTask &other) : TNamed(other)
 {
    fTasks = new TList();
    TIter next(other.fTasks);
-   TTask *task;
-   while ((task = (TTask*)next())) {
+   while (auto task = (TTask *)next())
       fTasks->Add(new TTask(*task));
-   }
    fOption = other.fOption;
    fBreakin = other.fBreakin;
    fBreakout = other.fBreakout;
@@ -169,8 +168,10 @@ TTask::~TTask()
 ////////////////////////////////////////////////////////////////////////////////
 /// Add TTask to this.
 
-void  TTask::Add(TTask *task) 
+void  TTask::Add(TTask *task)
 {
+   if (!fTasks)
+      fTasks = new TList;
    fTasks->Add(task);
 }
 
@@ -202,7 +203,8 @@ void TTask::Abort()
 
 void TTask::Browse(TBrowser *b)
 {
-   fTasks->Browse(b);
+   if (fTasks)
+      fTasks->Browse(b);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -217,10 +219,8 @@ void TTask::CleanTasks()
    fHasExecuted = kFALSE;
    Clear();
    TIter next(fTasks);
-   TTask *task;
-   while((task=(TTask*)next())) {
+   while (auto task = (TTask *)next())
       task->CleanTasks();
-   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -307,8 +307,7 @@ void TTask::ExecuteTask(Option_t *option)
 void TTask::ExecuteTasks(Option_t *option)
 {
    TIter next(fTasks);
-   TTask *task;
-   while((task=(TTask*)next())) {
+   while(auto task = (TTask *)next()) {
       if (fgBreakPoint) return;
       if (!task->IsActive()) continue;
       if (task->fHasExecuted) {
@@ -355,9 +354,8 @@ void TTask::ls(Option_t *option) const
 
    TRegexp re(opt, kTRUE);
 
-   TObject *obj;
    TIter nextobj(fTasks);
-   while ((obj = (TObject *) nextobj())) {
+   while (auto obj = (TObject *) nextobj()) {
       TString s = obj->GetName();
       if (s.Index(re) == kNPOS) continue;
       obj->ls(option);

--- a/core/cont/inc/TRefTable.h
+++ b/core/cont/inc/TRefTable.h
@@ -66,6 +66,10 @@ public:
    TRefTable();
    TRefTable(TObject *owner, Int_t size);
    virtual ~TRefTable();
+
+   TRefTable(const TRefTable&) = delete;
+   TRefTable &operator=(const TRefTable&) = delete;
+
    virtual Int_t      Add(Int_t uid, TProcessID* context = nullptr);
    void               Clear(Option_t * /*option*/ ="") override;
    virtual Int_t      Expand(Int_t pid, Int_t newsize);

--- a/core/cont/src/TExMap.cxx
+++ b/core/cont/src/TExMap.cxx
@@ -67,6 +67,7 @@ TExMap& TExMap::operator=(const TExMap &map)
       TObject::operator=(map);
       fSize  = map.fSize;
       fTally = map.fTally;
+      delete [] fTable;
       fTable = new Assoc_t [fSize];
       memcpy(fTable, map.fTable, fSize*sizeof(Assoc_t));
    }
@@ -78,7 +79,7 @@ TExMap& TExMap::operator=(const TExMap &map)
 
 TExMap::~TExMap()
 {
-   delete [] fTable; fTable = 0;
+   delete [] fTable; fTable = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/cont/src/TObjectTable.cxx
+++ b/core/cont/src/TObjectTable.cxx
@@ -88,7 +88,7 @@ via the command gObjectTable->Print()
 #include "TError.h"
 
 
-TObjectTable *gObjectTable;
+TObjectTable *gObjectTable = nullptr;
 
 
 ClassImp(TObjectTable);

--- a/core/cont/src/TRefArray.cxx
+++ b/core/cont/src/TRefArray.cxx
@@ -130,6 +130,7 @@ TRefArray::TRefArray(Int_t s, TProcessID *pid)
 
    fPID  = pid ? pid : TProcessID::GetSessionProcessID();
    fUIDs = nullptr;
+   fSize = 0;
    Init(s, 0);
 }
 
@@ -147,6 +148,7 @@ TRefArray::TRefArray(Int_t s, Int_t lowerBound, TProcessID *pid)
 
    fPID  = pid ? pid : TProcessID::GetSessionProcessID();
    fUIDs = nullptr;
+   fSize = 0;
    Init(s, lowerBound);
 }
 
@@ -157,6 +159,7 @@ TRefArray::TRefArray(const TRefArray &a) : TSeqCollection()
 {
    fPID  = a.fPID;
    fUIDs = nullptr;
+   fSize = 0;
    Init(a.fSize, a.fLowerBound);
 
    for (Int_t i = 0; i < fSize; i++)
@@ -175,9 +178,7 @@ TRefArray& TRefArray::operator=(const TRefArray &a)
       // Copy this by hand because the assignment operator
       // of TCollection is private
       fName   = a.fName;
-      fSize   = a.fSize;
       fSorted = a.fSorted;
-
       fPID = a.fPID;
       Init(a.fSize, a.fLowerBound);
 
@@ -682,19 +683,20 @@ Int_t TRefArray::IndexOf(const TObject *obj) const
 
 void TRefArray::Init(Int_t s, Int_t lowerBound)
 {
-   if (fUIDs && fSize != s) {
-      delete [] fUIDs;
-      fUIDs = nullptr;
+   if (s != fSize) {
+      if (fUIDs) {
+         delete [] fUIDs;
+         fUIDs = nullptr;
+      }
+      fSize = s;
+
+      if (fSize) {
+         fUIDs = new UInt_t[fSize];
+         for (Int_t i=0;i<s;i++)
+            fUIDs[i] = 0;
+      }
    }
 
-   fSize = s;
-
-   if (fSize) {
-      fUIDs = new UInt_t[fSize];
-      for (Int_t i=0;i<s;i++) fUIDs[i] = 0;
-   } else {
-      fUIDs = nullptr;
-   }
    fLowerBound = lowerBound;
    fLast = -1;
    Changed();


### PR DESCRIPTION
1. In `TExMap` assign operator
2. In `TRefArray::Init()` method via assign operator
3. Mark `TSystemDirectory` and `TRefTable` copy constr/assign methods as deleted, default implementation makes only problem
4. Fix `TTask` assign operator
5. Initialize `gObjectTable` to `nullptr`