### PR TITLE
Fixes several issues with `core/meta` classes

### DIFF
--- a/core/meta/inc/TEnum.h
+++ b/core/meta/inc/TEnum.h
@@ -53,6 +53,9 @@ public:
 
    TEnum() : TDictionary()  {}
    TEnum(const char *name, DeclId_t declid, TClass *cls);
+   TEnum(const TEnum &);
+   TEnum& operator=(const TEnum &);
+
    virtual ~TEnum();
 
    void                  AddConstant(TEnumConstant *constant);

--- a/core/meta/src/TDataMember.cxx
+++ b/core/meta/src/TDataMember.cxx
@@ -315,6 +315,7 @@ TDataMember& TDataMember::operator=(const TDataMember& dm)
       fSTLCont=dm.fSTLCont;
       fProperty=dm.fProperty;
       fArrayDim = dm.fArrayDim;
+      delete [] fArrayMaxIndex;
       fArrayMaxIndex = dm.fArrayDim ? new Int_t[dm.fArrayDim] : nullptr;
       for(Int_t d = 0; d < fArrayDim; ++d)
          fArrayMaxIndex[d] = dm.fArrayMaxIndex[d];

--- a/core/meta/src/TEnum.cxx
+++ b/core/meta/src/TEnum.cxx
@@ -58,6 +58,49 @@ TEnum::TEnum(const char *name, DeclId_t declid, TClass *cls)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Copy constructor
+
+TEnum::TEnum(const TEnum &src) : TDictionary(src)
+{
+   fClass = src.fClass;
+   fInfo = src.fInfo ? gInterpreter->ClassInfo_Factory(src.fInfo) : nullptr;
+   fQualName = src.fQualName;
+   fUnderlyingType = src.fUnderlyingType;
+
+   Bool_t isowner = src.fConstantList.IsOwner();
+   fConstantList.SetOwner(isowner);
+   TIter next(&src.fConstantList);
+   while (auto c = (TEnumConstant *) next())
+      fConstantList.Add(isowner ? new TEnumConstant(*c) : c);
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Assign operator
+
+TEnum& TEnum::operator=(const TEnum &src)
+{
+   if (this != &src) {
+      if (fInfo)
+         gInterpreter->ClassInfo_Delete(fInfo);
+      fConstantList.Clear();
+
+      TDictionary::operator=(src);
+
+      fInfo = src.fInfo ? gInterpreter->ClassInfo_Factory(src.fInfo) : nullptr;
+      fQualName = src.fQualName;
+      fUnderlyingType = src.fUnderlyingType;
+
+      Bool_t isowner = src.fConstantList.IsOwner();
+      fConstantList.SetOwner(isowner);
+      TIter next(&src.fConstantList);
+      while (auto c = (TEnumConstant *) next())
+         fConstantList.Add(isowner ? new TEnumConstant(*c) : c);
+   }
+   return *this;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
 TEnum::~TEnum()

--- a/core/meta/src/TFunctionTemplate.cxx
+++ b/core/meta/src/TFunctionTemplate.cxx
@@ -57,6 +57,8 @@ TFunctionTemplate& TFunctionTemplate::operator=(const TFunctionTemplate &rhs)
          gCling->FuncTempInfo_Title(fInfo,fTitle);
       } else
          fInfo = nullptr;
+
+      fClass = rhs.fClass;
    }
    return *this;
 }

--- a/core/meta/src/TGlobal.cxx
+++ b/core/meta/src/TGlobal.cxx
@@ -58,6 +58,10 @@ TGlobal &TGlobal::operator=(const TGlobal &rhs)
          fInfo = gCling->DataMemberInfo_FactoryCopy(rhs.fInfo);
          SetName(gCling->DataMemberInfo_Name(fInfo));
          SetTitle(gCling->DataMemberInfo_Title(fInfo));
+      } else {
+         fInfo = nullptr;
+         SetName(rhs.GetName());
+         SetTitle(rhs.GetTitle());
       }
    }
    return *this;

--- a/core/meta/src/TProtoClass.cxx
+++ b/core/meta/src/TProtoClass.cxx
@@ -166,13 +166,14 @@ TProtoClass::~TProtoClass()
 /// if (fPRealData) fPRealData->Delete(opt);
 /// delete fPRealData; fPRealData = 0;
 
-void TProtoClass::Delete(Option_t* opt /*= ""*/) {
+void TProtoClass::Delete(Option_t* opt /*= ""*/)
+{
    if (fBase) fBase->Delete(opt);
    delete fBase; fBase = nullptr;
 
-   for (auto dm: fData) {
+   for (auto dm: fData)
       delete dm;
-   }
+   fData.clear();
 
    if (fEnums) fEnums->Delete(opt);
    delete fEnums; fEnums = nullptr;


### PR DESCRIPTION
1. Fix memory leak in TDataMember assign operator
2. Provide copy constructor and assign operator for TEnum - default will not work or should be deleted
3. Not forget to reset pointer in TGlobal assign operator
4. Make TProtoClass::Delete reentrant

