### PR TITLE
[doc] fix typos in cppyy documentation.

### DIFF
--- a/bindings/pyroot/cppyy/cppyy/doc/source/lowlevel.rst
+++ b/bindings/pyroot/cppyy/cppyy/doc/source/lowlevel.rst
@@ -237,7 +237,7 @@ C++ has three ways of allocating heap memory (``malloc``, ``new``, and
 Direct use of ``malloc`` and ``new`` should be avoided for C++ classes, as
 these may override ``operator new`` to control their allocation own.
 However these low-level allocators can be necessary for builtin types on
-occassion if the C++ side takes ownership (otherwise, prefer either
+occasion if the C++ side takes ownership (otherwise, prefer either
 ``array`` from the builtin module ``array`` or ``ndarray`` from Numpy).
 
 The low-level module adds the following functions:

--- a/bindings/pyroot/cppyy/cppyy/doc/tutorial/CppyyTutorial.ipynb
+++ b/bindings/pyroot/cppyy/cppyy/doc/tutorial/CppyyTutorial.ipynb
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Namespaces have simularities to modules, so we could have imported the class as well.\n",
+    "Namespaces have similarities to modules, so we could have imported the class as well.\n",
     "\n",
     "Bound C++ classes are first-class Python object. We can instantiate them, use normal Python introspection tools, call `help()`, they raise Python exceptions on failure, manage memory through Python's ref-counting and garbage collection, etc., etc. Furthermore, we can use them in conjunction with other C++ classes."
    ]


### PR DESCRIPTION
Fix typos in cppyy documentation.

