### PR TITLE
Properly use `Copy(TObject &)` methods in `hist` classes

### DIFF
--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -194,8 +194,8 @@ public:
    static  Bool_t   AddDirectoryStatus();
            void     Browse(TBrowser *b) override;
    virtual Bool_t   CanExtendAllAxes() const;
-   virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = 0) const;
-   virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = 0) const;
+   virtual Double_t Chi2Test(const TH1* h2, Option_t *option = "UU", Double_t *res = nullptr) const;
+   virtual Double_t Chi2TestX(const TH1* h2, Double_t &chi2, Int_t &ndf, Int_t &igood,Option_t *option = "UU",  Double_t *res = nullptr) const;
    virtual Double_t Chisquare(TF1 * f1, Option_t *option = "") const;
    virtual void     ClearUnderflowAndOverflow();
    virtual Double_t ComputeIntegral(Bool_t onlyPositive = false);
@@ -219,7 +219,7 @@ public:
    virtual Int_t    Fill(Double_t x, Double_t w);
    virtual Int_t    Fill(const char *name, Double_t w);
    virtual void     FillN(Int_t ntimes, const Double_t *x, const Double_t *w, Int_t stride=1);
-   virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {;}
+   virtual void     FillN(Int_t, const Double_t *, const Double_t *, const Double_t *, Int_t) {}
    virtual void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom * rng = nullptr);
    virtual void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom * rng = nullptr);
    virtual Int_t    FindBin(Double_t x, Double_t y=0, Double_t z=0);
@@ -271,7 +271,7 @@ public:
    virtual EBinErrorOpt  GetBinErrorOption() const { return fBinStatErrOpt; }
    virtual Double_t GetBinLowEdge(Int_t bin) const;
    virtual Double_t GetBinWidth(Int_t bin) const;
-   virtual Double_t GetBinWithContent(Double_t c, Int_t &binx, Int_t firstx=0, Int_t lastx=0,Double_t maxdiff=0) const;
+   virtual Double_t GetBinWithContent(Double_t c, Int_t &binx, Int_t firstx = 0, Int_t lastx = 0,Double_t maxdiff = 0) const;
    virtual void     GetCenter(Double_t *center) const;
    static  Bool_t   GetDefaultSumw2();
    TDirectory      *GetDirectory() const {return fDirectory;}
@@ -302,7 +302,7 @@ public:
 
    TVirtualHistPainter *GetPainter(Option_t *option="");
 
-   virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum=0);
+   virtual Int_t    GetQuantiles(Int_t nprobSum, Double_t *q, const Double_t *probSum = nullptr);
    virtual Double_t GetRandom(TRandom * rng = nullptr) const;
    virtual void     GetStats(Double_t *stats) const;
    virtual Double_t GetStdDev(Int_t axis=1) const;
@@ -315,7 +315,7 @@ public:
            Double_t GetRMSError(Int_t axis=1) const { return GetStdDevError(axis); }
 
    virtual Double_t GetSkewness(Int_t axis=1) const;
-           EStatOverflows GetStatOverflows() const {return fStatOverflows; }; ///< Get the behaviour adopted by the object about the statoverflows. See EStatOverflows for more information.
+           EStatOverflows GetStatOverflows() const { return fStatOverflows; } ///< Get the behaviour adopted by the object about the statoverflows. See EStatOverflows for more information.
            TAxis*   GetXaxis()  { return &fXaxis; }
            TAxis*   GetYaxis()  { return &fYaxis; }
            TAxis*   GetZaxis()  { return &fZaxis; }
@@ -345,7 +345,7 @@ public:
            void     Paint(Option_t *option = "") override;
            void     Print(Option_t *option = "") const override;
    virtual void     PutStats(Double_t *stats);
-   virtual TH1     *Rebin(Int_t ngroup = 2, const char *newname = "", const Double_t *xbins = 0);  // *MENU*
+   virtual TH1     *Rebin(Int_t ngroup = 2, const char *newname = "", const Double_t *xbins = nullptr);  // *MENU*
    virtual TH1     *RebinX(Int_t ngroup = 2, const char *newname = "") { return Rebin(ngroup,newname, (Double_t*) nullptr); }
    virtual void     Rebuild(Option_t *option = "");
            void     RecursiveRemove(TObject *obj) override;
@@ -376,12 +376,12 @@ public:
    virtual void     SetBuffer(Int_t buffersize, Option_t *option="");
    virtual UInt_t   SetCanExtend(UInt_t extendBitMask);
    virtual void     SetContent(const Double_t *content);
-   virtual void     SetContour(Int_t nlevels, const Double_t *levels=0);
+   virtual void     SetContour(Int_t nlevels, const Double_t *levels = nullptr);
    virtual void     SetContourLevel(Int_t level, Double_t value);
    static  void     SetDefaultBufferSize(Int_t buffersize=1000);
    static  void     SetDefaultSumw2(Bool_t sumw2=kTRUE);
    virtual void     SetDirectory(TDirectory *dir);
-   virtual void     SetEntries(Double_t n) {fEntries = n;};
+   virtual void     SetEntries(Double_t n) { fEntries = n; }
    virtual void     SetError(const Double_t *error);
    virtual void     SetHighlight(Bool_t set = kTRUE); // *TOGGLE* *GETTER=IsHighlight
    virtual void     SetLabelColor(Color_t color=1, Option_t *axis="X");
@@ -394,8 +394,8 @@ public:
     *   By default the maximum / minimum value used in drawing is the maximum / minimum value of the histogram
     * plus a margin of 10%. If these functions are called, the values are used without any extra margin.
     */
-   virtual void     SetMaximum(Double_t maximum = -1111) { fMaximum = maximum; }; // *MENU*
-   virtual void     SetMinimum(Double_t minimum = -1111) { fMinimum = minimum; }; // *MENU*
+   virtual void     SetMaximum(Double_t maximum = -1111) { fMaximum = maximum; } // *MENU*
+   virtual void     SetMinimum(Double_t minimum = -1111) { fMinimum = minimum; } // *MENU*
 
            void     SetName(const char *name) override; // *MENU*
            void     SetNameTitle(const char *name, const char *title) override;
@@ -407,7 +407,7 @@ public:
    virtual void     SetTitleFont(Style_t font=62, Option_t *axis="X");
    virtual void     SetTitleOffset(Float_t offset=1, Option_t *axis="X");
    virtual void     SetTitleSize(Float_t size=0.02, Option_t *axis="X");
-           void     SetStatOverflows(EStatOverflows statOverflows) {fStatOverflows = statOverflows;}; ///< See GetStatOverflows for more information.
+           void     SetStatOverflows(EStatOverflows statOverflows) { fStatOverflows = statOverflows; } ///< See GetStatOverflows for more information.
            void     SetTitle(const char *title) override;  // *MENU*
    virtual void     SetXTitle(const char *title) {fXaxis.SetTitle(title);}
    virtual void     SetYTitle(const char *title) {fYaxis.SetTitle(title);}

--- a/hist/hist/inc/TH1.h
+++ b/hist/hist/inc/TH1.h
@@ -122,7 +122,7 @@ public:
 private:
    void    Build();
 
-   TH1(const TH1&);
+   TH1(const TH1&) = delete;
    TH1& operator=(const TH1&) = delete;
 
 protected:

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -61,7 +61,7 @@ protected:
 
 private:
 
-   TH2(const TH2&);
+   TH2(const TH2&) = delete;
    TH2& operator=(const TH2&) = delete;
 
    // make private methods which have a TH1 signature and should not

--- a/hist/hist/inc/TH2.h
+++ b/hist/hist/inc/TH2.h
@@ -81,8 +81,8 @@ public:
            void     FillN(Int_t ntimes, const Double_t *x, const Double_t *y, const Double_t *w, Int_t stride=1) override;
            void     FillRandom(const char *fname, Int_t ntimes=5000, TRandom *rng = nullptr) override;
            void     FillRandom(TH1 *h, Int_t ntimes=5000, TRandom *rng = nullptr) override;
-   virtual void     FitSlicesX(TF1 *f1=0,Int_t firstybin=0, Int_t lastybin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
-   virtual void     FitSlicesY(TF1 *f1=0,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = 0);
+   virtual void     FitSlicesX(TF1 *f1=0,Int_t firstybin=0, Int_t lastybin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = nullptr);
+   virtual void     FitSlicesY(TF1 *f1=0,Int_t firstxbin=0, Int_t lastxbin=-1, Int_t cut=0, Option_t *option="QNR", TObjArray* arr = nullptr);
            Int_t    GetBin(Int_t binx, Int_t biny, Int_t binz = 0) const override;
    virtual Double_t GetBinWithContent2(Double_t c, Int_t &binx, Int_t &biny, Int_t firstxbin=1, Int_t lastxbin=-1,Int_t firstybin=1, Int_t lastybin=-1, Double_t maxdiff=0) const;
    using TH1::GetBinContent;

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -130,25 +130,20 @@ public:
 
 protected:
 
-   virtual TH1D        *DoProject1D(const char* name, const char * title, int imin1, int imax1, int imin2, int imax2,
-                                    const TAxis* projAxis, const TAxis * axis1, const TAxis * axis2, Option_t * option) const;
-   virtual TH1D *DoProject1D(const char *name, const char *title, const TAxis *projAxis, const TAxis *axis1,
-                             const TAxis *axis2, bool computeErrors, bool originalRange, bool useUF, bool useOF) const;
-   virtual TH2D        *DoProject2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
-                        bool computeErrors, bool originalRange,
-                         bool useUF, bool useOF) const;
-   virtual TProfile2D  *DoProjectProfile2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
-                                          bool originalRange, bool useUF, bool useOF) const;
+   virtual TH1D    *DoProject1D(const char* name, const char * title, int imin1, int imax1, int imin2, int imax2,
+                                const TAxis* projAxis, const TAxis * axis1, const TAxis * axis2, Option_t * option) const;
+   virtual TH1D    *DoProject1D(const char *name, const char *title, const TAxis *projAxis, const TAxis *axis1,
+                                const TAxis *axis2, bool computeErrors, bool originalRange, bool useUF, bool useOF) const;
+   virtual TH2D    *DoProject2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
+                                bool computeErrors, bool originalRange, bool useUF, bool useOF) const;
+   virtual TProfile2D *DoProjectProfile2D(const char* name, const char * title, const TAxis* projX, const TAxis* projY,
+                                           bool originalRange, bool useUF, bool useOF) const;
 
    // these functions are need to be used inside TProfile3D::DoProjectProfile2D
-   static TH1D         *DoProject1D(const TH3 & h, const char* name, const char * title, const TAxis* projX,
-                                    bool computeErrors, bool originalRange, bool useUF, bool useOF)  {
-      return h.DoProject1D(name, title, projX, nullptr, nullptr, computeErrors, originalRange, useUF, useOF);
-   }
-   static TH2D         *DoProject2D(const TH3 & h, const char* name, const char * title, const TAxis* projX, const TAxis* projY,
-                                    bool computeErrors, bool originalRange, bool useUF, bool useOF)  {
-      return h.DoProject2D(name, title, projX,projY, computeErrors, originalRange, useUF, useOF);
-   }
+   static TH1D     *DoProject1D(const TH3 & h, const char* name, const char * title, const TAxis* projX,
+                                bool computeErrors, bool originalRange, bool useUF, bool useOF);
+   static TH2D     *DoProject2D(const TH3 & h, const char* name, const char * title, const TAxis* projX, const TAxis* projY,
+                                bool computeErrors, bool originalRange, bool useUF, bool useOF);
 
    ClassDefOverride(TH3,6)  //3-Dim histogram base class
 };

--- a/hist/hist/inc/TH3.h
+++ b/hist/hist/inc/TH3.h
@@ -67,7 +67,7 @@ protected:
 
 private:
 
-   TH3(const TH3&);
+   TH3(const TH3&) = delete;
    TH3& operator=(const TH3&) = delete;
 
    using TH1::Integral;

--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -732,8 +732,8 @@ fPaintHisto(0),
 fWeight(kDefWeight)
 {
    // do not add new created histograms to gDirectory
-   {  
-      // use separate scope for TContext 
+   {
+      // use separate scope for TContext
       TDirectory::TContext ctx(nullptr);
       fTotalHistogram = new TH1D("total","total",nbins,xbins);
       fPassedHistogram = new TH1D("passed","passed",nbins,xbins);
@@ -979,22 +979,22 @@ fWeight(kDefWeight)
 ///      by calling Write().
 
 TEfficiency::TEfficiency(const TEfficiency& rEff):
-TNamed(),
-TAttLine(),
-TAttFill(),
-TAttMarker(),
-fBeta_alpha(rEff.fBeta_alpha),
-fBeta_beta(rEff.fBeta_beta),
-fBeta_bin_params(rEff.fBeta_bin_params),
-fConfLevel(rEff.fConfLevel),
-fDirectory(0),
-fFunctions(0),
-fPaintGraph(0),
-fPaintHisto(0),
-fWeight(rEff.fWeight)
+   TNamed(),
+   TAttLine(),
+   TAttFill(),
+   TAttMarker(),
+   fBeta_alpha(rEff.fBeta_alpha),
+   fBeta_beta(rEff.fBeta_beta),
+   fBeta_bin_params(rEff.fBeta_bin_params),
+   fConfLevel(rEff.fConfLevel),
+   fDirectory(0),
+   fFunctions(0),
+   fPaintGraph(0),
+   fPaintHisto(0),
+   fWeight(rEff.fWeight)
 {
    // copy TObject bits
-   ((TObject&)rEff).Copy(*this);
+   rEff.TObject::Copy(*this);
 
    // do not add cloned histograms to gDirectory
    {

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -124,12 +124,9 @@ public:
             SetBit(BIT(ibit));
 
       // copy the graph attributes
-      auto &fromLine = static_cast<TAttLine &>(from);
-      fromLine.Copy(*this);
-      auto &fromFill = static_cast<TAttFill &>(from);
-      fromFill.Copy(*this);
-      auto &fromMarker = static_cast<TAttMarker &>(from);
-      fromMarker.Copy(*this);
+      from.TAttLine::Copy(*this);
+      from.TAttFill::Copy(*this);
+      from.TAttMarker::Copy(*this);
    }
 };
 } // unnamed namespace
@@ -954,9 +951,8 @@ int TF1::TermCoeffLength(TString &term) {
 
 TF1 &TF1::operator=(const TF1 &rhs)
 {
-   if (this != &rhs) {
-      rhs.Copy(*this);
-   }
+   if (this != &rhs)
+      rhs.TF1::Copy(*this);
    return *this;
 }
 
@@ -985,7 +981,7 @@ TF1::TF1(const TF1 &f1) :
    TNamed(f1), TAttLine(f1), TAttFill(f1), TAttMarker(f1),
    fXmin(0), fXmax(0), fNpar(0), fNdim(0), fType(EFType::kFormula)
 {
-   ((TF1 &)f1).Copy(*this);
+   f1.TF1::Copy(*this);
 }
 
 

--- a/hist/hist/src/TF12.cxx
+++ b/hist/hist/src/TF12.cxx
@@ -86,7 +86,7 @@ TF12::~TF12()
 
 TF12::TF12(const TF12 &f12) : TF1(f12)
 {
-   ((TF12&)f12).Copy(*this);
+   f12.TF12::Copy(*this);
 }
 
 

--- a/hist/hist/src/TF1Convolution.cxx
+++ b/hist/hist/src/TF1Convolution.cxx
@@ -238,7 +238,7 @@ TF1Convolution::TF1Convolution(TString formula1, TString formula2,  Double_t xmi
 
 TF1Convolution::TF1Convolution(const TF1Convolution &conv)
 {
-   conv.Copy((TObject &)*this);
+   conv.TF1Convolution::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -247,7 +247,7 @@ TF1Convolution::TF1Convolution(const TF1Convolution &conv)
 TF1Convolution &TF1Convolution::operator=(const TF1Convolution &rhs)
 {
    if (this != &rhs)
-      rhs.Copy(*this);
+      rhs.TF1Convolution::Copy(*this);
    return *this;
 }
 
@@ -517,9 +517,9 @@ void TF1Convolution::Copy(TObject &obj) const
    ((TF1Convolution &)obj).fParNames = fParNames;
 
    // we need to copy the content of the  unique_ptr's
-   ((TF1Convolution &)obj).fFunction1 = std::unique_ptr<TF1>((TF1 *)new TF1() );
-   ((TF1Convolution &)obj).fFunction2 = std::unique_ptr<TF1>((TF1 *)new TF1() );
-   fFunction1->Copy(*(((TF1Convolution &)obj).fFunction1 ) );
-   fFunction2->Copy(*(((TF1Convolution &)obj).fFunction2 ) );
+   ((TF1Convolution &)obj).fFunction1 = std::make_unique<TF1>();
+   ((TF1Convolution &)obj).fFunction2 = std::make_unique<TF1>();
+   fFunction1->Copy(*(((TF1Convolution &)obj).fFunction1));
+   fFunction2->Copy(*(((TF1Convolution &)obj).fFunction2));
    // fGraphConv is transient anyway, so we don't bother to copy it
 }

--- a/hist/hist/src/TF1NormSum.cxx
+++ b/hist/hist/src/TF1NormSum.cxx
@@ -255,7 +255,7 @@ TF1NormSum::TF1NormSum(const TString &formula, Double_t xmin, Double_t xmax)
 
 TF1NormSum::TF1NormSum(const TF1NormSum &nsum)
 {
-   nsum.Copy((TObject &)*this);
+   nsum.TF1NormSum::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -264,7 +264,7 @@ TF1NormSum::TF1NormSum(const TF1NormSum &nsum)
 TF1NormSum &TF1NormSum::operator=(const TF1NormSum &rhs)
 {
    if (this != &rhs)
-      rhs.Copy(*this);
+      rhs.TF1NormSum::Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TF2.cxx
+++ b/hist/hist/src/TF2.cxx
@@ -184,9 +184,8 @@ TF2::TF2(const char *name, ROOT::Math::ParamFunctor f, Double_t xmin, Double_t x
 
 TF2& TF2::operator=(const TF2 &rhs)
 {
-   if (this != &rhs) {
-      rhs.Copy(*this);
-   }
+   if (this != &rhs)
+      rhs.TF2::Copy(*this);
    return *this;
 }
 
@@ -202,7 +201,7 @@ TF2::~TF2()
 
 TF2::TF2(const TF2 &f2) : TF1()
 {
-   ((TF2&)f2).Copy(*this);
+   f2.TF2::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TF3.cxx
+++ b/hist/hist/src/TF3.cxx
@@ -144,9 +144,8 @@ TF3::TF3(const char *name, ROOT::Math::ParamFunctor f, Double_t xmin, Double_t x
 
 TF3& TF3::operator=(const TF3 &rhs)
 {
-   if (this != &rhs) {
-      rhs.Copy(*this);
-   }
+   if (this != &rhs)
+      rhs.TF3::Copy(*this);
    return *this;
 }
 
@@ -162,7 +161,7 @@ TF3::~TF3()
 
 TF3::TF3(const TF3 &f3) : TF2()
 {
-   ((TF3&)f3).Copy(*this);
+   f3.TF3::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TFormula.cxx
+++ b/hist/hist/src/TFormula.cxx
@@ -576,7 +576,7 @@ TFormula::TFormula(const char *name, const char *formula, int ndim, int npar, bo
 TFormula::TFormula(const TFormula &formula) :
    TNamed(formula.GetName(),formula.GetTitle())
 {
-   formula.Copy(*this);
+   formula.TFormula::Copy(*this);
 
    if (!TestBit(TFormula::kNotGlobal) && gROOT ) {
       R__LOCKGUARD(gROOTMutex);
@@ -597,10 +597,8 @@ TFormula::TFormula(const TFormula &formula) :
 
 TFormula& TFormula::operator=(const TFormula &rhs)
 {
-
-   if (this != &rhs) {
-      rhs.Copy(*this);
-   }
+   if (this != &rhs)
+      rhs.TFormula::Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TFormula_v5.cxx
+++ b/hist/hist/src/TFormula_v5.cxx
@@ -294,7 +294,7 @@ TFormula::TFormula(const TFormula &formula) : TNamed()
    fOperOptimized  = 0;
    fOptimal = (ROOT::v5::TFormulaPrimitive::TFuncG)&TFormula::EvalParOld;
 
-   ((TFormula&)formula).TFormula::Copy(*this);
+   formula.TFormula::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -302,9 +302,8 @@ TFormula::TFormula(const TFormula &formula) : TNamed()
 
 TFormula& TFormula::operator=(const TFormula &rhs)
 {
-   if (this != &rhs) {
-      rhs.Copy(*this);
-   }
+   if (this != &rhs)
+      rhs.TFormula::Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -10145,7 +10145,8 @@ TH1D::~TH1D()
 
 TH1D::TH1D(const TH1D &h1d) : TH1(), TArrayD()
 {
-   h1d.TH1D::Copy(*this);
+   // intentially call virtual method to warn if TProfile is copying
+   h1d.Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10181,8 +10182,9 @@ void TH1D::SetBinsLength(Int_t n)
 
 TH1D& TH1D::operator=(const TH1D &h1d)
 {
+   // intentially call virtual method to warn if TProfile is copying
    if (this != &h1d)
-      h1d.TH1D::Copy(*this);
+      h1d.Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -730,16 +730,6 @@ TH1::TH1(const char *name,const char *title,Int_t nbins,const Double_t *xbins)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Private copy constructor.
-/// One should use the copy constructor of the derived classes (e.g. TH1D, TH1F ...).
-/// The list of functions is not copied. (Use Clone() if needed)
-
-TH1::TH1(const TH1 &h) : TNamed(), TAttLine(), TAttFill(), TAttMarker()
-{
-   h.TH1::Copy(*this);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Static function: cannot be inlined on Windows/NT.
 
 Bool_t TH1::AddDirectoryStatus()

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -736,7 +736,7 @@ TH1::TH1(const char *name,const char *title,Int_t nbins,const Double_t *xbins)
 
 TH1::TH1(const TH1 &h) : TNamed(), TAttLine(), TAttFill(), TAttMarker()
 {
-   ((TH1&)h).Copy(*this);
+   h.TH1::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9407,7 +9407,7 @@ TH1C::~TH1C()
 
 TH1C::TH1C(const TH1C &h1c) : TH1(), TArrayC()
 {
-   ((TH1C&)h1c).Copy(*this);
+   h1c.TH1C::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9462,7 +9462,8 @@ void TH1C::SetBinsLength(Int_t n)
 
 TH1C& TH1C::operator=(const TH1C &h1)
 {
-   if (this != &h1)  ((TH1C&)h1).Copy(*this);
+   if (this != &h1)
+      h1.TH1C::Copy(*this);
    return *this;
 }
 
@@ -9589,7 +9590,7 @@ TH1S::~TH1S()
 
 TH1S::TH1S(const TH1S &h1s) : TH1(), TArrayS()
 {
-   ((TH1S&)h1s).Copy(*this);
+   h1s.TH1S::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9644,7 +9645,8 @@ void TH1S::SetBinsLength(Int_t n)
 
 TH1S& TH1S::operator=(const TH1S &h1)
 {
-   if (this != &h1)  ((TH1S&)h1).Copy(*this);
+   if (this != &h1)
+      h1.TH1S::Copy(*this);
    return *this;
 }
 
@@ -9772,7 +9774,7 @@ TH1I::~TH1I()
 
 TH1I::TH1I(const TH1I &h1i) : TH1(), TArrayI()
 {
-   ((TH1I&)h1i).Copy(*this);
+   h1i.TH1I::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9827,7 +9829,8 @@ void TH1I::SetBinsLength(Int_t n)
 
 TH1I& TH1I::operator=(const TH1I &h1)
 {
-   if (this != &h1)  ((TH1I&)h1).Copy(*this);
+   if (this != &h1)
+      h1.TH1I::Copy(*this);
    return *this;
 }
 
@@ -9963,9 +9966,9 @@ TH1F::TH1F(const TVectorF &v)
 /// Copy Constructor.
 /// The list of functions is not copied. (Use Clone() if needed)
 
-TH1F::TH1F(const TH1F &h) : TH1(), TArrayF()
+TH1F::TH1F(const TH1F &h1f) : TH1(), TArrayF()
 {
-   ((TH1F&)h).Copy(*this);
+   h1f.TH1F::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10006,9 +10009,10 @@ void TH1F::SetBinsLength(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH1F& TH1F::operator=(const TH1F &h1)
+TH1F& TH1F::operator=(const TH1F &h1f)
 {
-   if (this != &h1)  ((TH1F&)h1).Copy(*this);
+   if (this != &h1f)
+      h1f.TH1F::Copy(*this);
    return *this;
 }
 
@@ -10151,7 +10155,7 @@ TH1D::~TH1D()
 
 TH1D::TH1D(const TH1D &h1d) : TH1(), TArrayD()
 {
-   ((TH1D&)h1d).Copy(*this);
+   h1d.TH1D::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -10185,9 +10189,10 @@ void TH1D::SetBinsLength(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH1D& TH1D::operator=(const TH1D &h1)
+TH1D& TH1D::operator=(const TH1D &h1d)
 {
-   if (this != &h1)  ((TH1D&)h1).Copy(*this);
+   if (this != &h1d)
+      h1d.TH1D::Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -218,9 +218,9 @@ TH2::TH2(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins
 /// One should use the copy constructor of the derived classes (e.g. TH2D, TH2F ...).
 /// The list of functions is not copied. (Use Clone() if needed)
 
-TH2::TH2(const TH2 &h) : TH1()
+TH2::TH2(const TH2 &h2) : TH1()
 {
-   ((TH2&)h).Copy(*this);
+   h2.TH2::Copy(*this);
 }
 
 
@@ -2884,7 +2884,7 @@ TH2C::TH2C(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins
 
 TH2C::TH2C(const TH2C &h2c) : TH2(), TArrayC()
 {
-   ((TH2C&)h2c).Copy(*this);
+   h2c.TH2C::Copy(*this);
 }
 
 
@@ -2914,7 +2914,7 @@ void TH2C::AddBinContent(Int_t bin, Double_t w)
 
 void TH2C::Copy(TObject &newth2) const
 {
-   TH2::Copy((TH2C&)newth2);
+   TH2::Copy(newth2);
 }
 
 
@@ -2978,9 +2978,10 @@ void TH2C::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH2C& TH2C::operator=(const TH2C &h1)
+TH2C& TH2C::operator=(const TH2C &h2c)
 {
-   if (this != &h1)  ((TH2C&)h1).Copy(*this);
+   if (this != &h2c)
+      h2c.TH2C::Copy(*this);
    return *this;
 }
 
@@ -3144,7 +3145,7 @@ TH2S::TH2S(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins
 
 TH2S::TH2S(const TH2S &h2s) : TH2(), TArrayS()
 {
-   ((TH2S&)h2s).Copy(*this);
+   h2s.TH2S::Copy(*this);
 }
 
 
@@ -3174,7 +3175,7 @@ void TH2S::AddBinContent(Int_t bin, Double_t w)
 
 void TH2S::Copy(TObject &newth2) const
 {
-   TH2::Copy((TH2S&)newth2);
+   TH2::Copy(newth2);
 }
 
 
@@ -3238,9 +3239,10 @@ void TH2S::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH2S& TH2S::operator=(const TH2S &h1)
+TH2S& TH2S::operator=(const TH2S &h2s)
 {
-   if (this != &h1)  ((TH2S&)h1).Copy(*this);
+   if (this != &h2s)
+      h2s.TH2S::Copy(*this);
    return *this;
 }
 
@@ -3248,9 +3250,9 @@ TH2S& TH2S::operator=(const TH2S &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH2S operator*(Float_t c1, TH2S &h1)
+TH2S operator*(Float_t c1, TH2S &h2s)
 {
-   TH2S hnew = h1;
+   TH2S hnew = h2s;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;
@@ -3404,7 +3406,7 @@ TH2I::TH2I(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins
 
 TH2I::TH2I(const TH2I &h2i) : TH2(), TArrayI()
 {
-   ((TH2I&)h2i).Copy(*this);
+   h2i.TH2I::Copy(*this);
 }
 
 
@@ -3434,7 +3436,7 @@ void TH2I::AddBinContent(Int_t bin, Double_t w)
 
 void TH2I::Copy(TObject &newth2) const
 {
-   TH2::Copy((TH2I&)newth2);
+   TH2::Copy(newth2);
 }
 
 
@@ -3463,9 +3465,10 @@ void TH2I::SetBinsLength(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH2I& TH2I::operator=(const TH2I &h1)
+TH2I& TH2I::operator=(const TH2I &h2i)
 {
-   if (this != &h1)  ((TH2I&)h1).Copy(*this);
+   if (this != &h2i)
+      h2i.TH2I::Copy(*this);
    return *this;
 }
 
@@ -3473,9 +3476,9 @@ TH2I& TH2I::operator=(const TH2I &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH2I operator*(Float_t c1, TH2I &h1)
+TH2I operator*(Float_t c1, TH2I &h2i)
 {
-   TH2I hnew = h1;
+   TH2I hnew = h2i;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;
@@ -3649,7 +3652,7 @@ TH2F::TH2F(const TMatrixFBase &m)
 
 TH2F::TH2F(const TH2F &h2f) : TH2(), TArrayF()
 {
-   ((TH2F&)h2f).Copy(*this);
+   h2f.TH2F::Copy(*this);
 }
 
 
@@ -3658,7 +3661,7 @@ TH2F::TH2F(const TH2F &h2f) : TH2(), TArrayF()
 
 void TH2F::Copy(TObject &newth2) const
 {
-   TH2::Copy((TH2F&)newth2);
+   TH2::Copy(newth2);
 }
 
 
@@ -3722,9 +3725,10 @@ void TH2F::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH2F& TH2F::operator=(const TH2F &h1)
+TH2F& TH2F::operator=(const TH2F &h2f)
 {
-   if (this != &h1)  ((TH2F&)h1).Copy(*this);
+   if (this != &h2f)
+      h2f.TH2F::Copy(*this);
    return *this;
 }
 
@@ -3921,7 +3925,7 @@ TH2D::TH2D(const TMatrixDBase &m)
 
 TH2D::TH2D(const TH2D &h2d) : TH2(), TArrayD()
 {
-   ((TH2D&)h2d).Copy(*this);
+   h2d.TH2D::Copy(*this);
 }
 
 
@@ -3930,7 +3934,7 @@ TH2D::TH2D(const TH2D &h2d) : TH2(), TArrayD()
 
 void TH2D::Copy(TObject &newth2) const
 {
-   TH2::Copy((TH2D&)newth2);
+   TH2::Copy(newth2);
 }
 
 
@@ -3994,9 +3998,10 @@ void TH2D::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH2D& TH2D::operator=(const TH2D &h1)
+TH2D& TH2D::operator=(const TH2D &h2d)
 {
-   if (this != &h1)  ((TH2D&)h1).Copy(*this);
+   if (this != &h2d)
+      h2d.TH2D::Copy(*this);
    return *this;
 }
 
@@ -4005,9 +4010,9 @@ TH2D& TH2D::operator=(const TH2D &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH2D operator*(Float_t c1, TH2D &h1)
+TH2D operator*(Float_t c1, TH2D &h2d)
 {
-   TH2D hnew = h1;
+   TH2D hnew = h2d;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -3914,7 +3914,8 @@ TH2D::TH2D(const TMatrixDBase &m)
 
 TH2D::TH2D(const TH2D &h2d) : TH2(), TArrayD()
 {
-   h2d.TH2D::Copy(*this);
+   // intentially call virtual Copy method to warn if TProfile2D is copied
+   h2d.Copy(*this);
 }
 
 
@@ -3989,8 +3990,9 @@ void TH2D::Streamer(TBuffer &R__b)
 
 TH2D& TH2D::operator=(const TH2D &h2d)
 {
+   // intentially call virtual Copy method to warn if TProfile2D is copied
    if (this != &h2d)
-      h2d.TH2D::Copy(*this);
+      h2d.Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -214,17 +214,6 @@ TH2::TH2(const char *name,const char *title,Int_t nbinsx,const Float_t *xbins
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Private copy constructor.
-/// One should use the copy constructor of the derived classes (e.g. TH2D, TH2F ...).
-/// The list of functions is not copied. (Use Clone() if needed)
-
-TH2::TH2(const TH2 &h2) : TH1()
-{
-   h2.TH2::Copy(*this);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
 
 TH2::~TH2()

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -4428,7 +4428,8 @@ TH3D::TH3D(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 TH3D::TH3D(const TH3D &h3d) : TH3(), TArrayD()
 {
-   h3d.TH3D::Copy(*this);
+   // intentially call virtual Copy method to warn if TProfile3D is copied
+   h3d.Copy(*this);
 }
 
 
@@ -4502,8 +4503,9 @@ void TH3D::Streamer(TBuffer &R__b)
 
 TH3D& TH3D::operator=(const TH3D &h3d)
 {
+   // intentially call virtual Copy method to warn if TProfile3D is copied
    if (this != &h3d)
-      h3d.TH3D::Copy(*this);
+      h3d.Copy(*this);
    return *this;
 }
 

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -3411,6 +3411,23 @@ void TH3::Streamer(TBuffer &R__b)
    }
 }
 
+////////////////////////////////////////////////////////////////////////////////
+/// static methdod performing the projection to 1D histogram
+
+TH1D *TH3::DoProject1D(const TH3 &h, const char *name, const char *title, const TAxis *projX, bool computeErrors,
+                       bool originalRange, bool useUF, bool useOF)
+{
+   return h.DoProject1D(name, title, projX, nullptr, nullptr, computeErrors, originalRange, useUF, useOF);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// static methdod performing the projection to 2D histogram
+
+TH2D *TH3::DoProject2D(const TH3 &h, const char *name, const char *title, const TAxis *projX, const TAxis *projY,
+                       bool computeErrors, bool originalRange, bool useUF, bool useOF)
+{
+   return h.DoProject2D(name, title, projX, projY, computeErrors, originalRange, useUF, useOF);
+}
 
 //______________________________________________________________________________
 //                     TH3C methods

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -192,9 +192,9 @@ TH3::TH3(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 /// One should use the copy constructor of the derived classes (e.g. TH3D, TH3F ...).
 /// The list of functions is not copied. (Use Clone() if needed)
 
-TH3::TH3(const TH3 &h) : TH1(), TAtt3D()
+TH3::TH3(const TH3 &h3) : TH1(), TAtt3D()
 {
-   ((TH3&)h).Copy(*this);
+   h3.TH3::Copy(*this);
 }
 
 
@@ -2359,7 +2359,7 @@ TH2D *TH3::DoProject2D(const char* name, const char * title, const TAxis* projX,
 ///  With SetRange() you can have all bins except underflow/overflow only if you set the axis bit range as
 ///  following after having called SetRange:  axis->SetRange(1, axis->GetNbins());
 ///
-///  NOTE 5: If TH1::AddDirectory is set to false, a new histogram is always created and the ownership of the 
+///  NOTE 5: If TH1::AddDirectory is set to false, a new histogram is always created and the ownership of the
 ///  returned pointer is delegated to the user. Be sure in this case to call `delete` on it after it's no longer needed,
 ///  to avoid memory leaks.
 
@@ -3499,7 +3499,7 @@ TH3C::TH3C(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 TH3C::TH3C(const TH3C &h3c) : TH3(), TArrayC()
 {
-   ((TH3C&)h3c).Copy(*this);
+   h3c.TH3C::Copy(*this);
 }
 
 
@@ -3529,7 +3529,7 @@ void TH3C::AddBinContent(Int_t bin, Double_t w)
 
 void TH3C::Copy(TObject &newth3) const
 {
-   TH3::Copy((TH3C&)newth3);
+   TH3::Copy(newth3);
 }
 
 
@@ -3621,9 +3621,10 @@ void TH3C::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH3C& TH3C::operator=(const TH3C &h1)
+TH3C& TH3C::operator=(const TH3C &h3c)
 {
-   if (this != &h1)  ((TH3C&)h1).Copy(*this);
+   if (this != &h3c)
+      h3c.TH3C::Copy(*this);
    return *this;
 }
 
@@ -3631,9 +3632,9 @@ TH3C& TH3C::operator=(const TH3C &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH3C operator*(Float_t c1, TH3C &h1)
+TH3C operator*(Float_t c1, TH3C &h3c)
 {
-   TH3C hnew = h1;
+   TH3C hnew = h3c;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;
@@ -3764,7 +3765,7 @@ TH3S::TH3S(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 TH3S::TH3S(const TH3S &h3s) : TH3(), TArrayS()
 {
-   ((TH3S&)h3s).Copy(*this);
+   h3s.TH3S::Copy(*this);
 }
 
 
@@ -3794,7 +3795,7 @@ void TH3S::AddBinContent(Int_t bin, Double_t w)
 
 void TH3S::Copy(TObject &newth3) const
 {
-   TH3::Copy((TH3S&)newth3);
+   TH3::Copy(newth3);
 }
 
 
@@ -3857,9 +3858,10 @@ void TH3S::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH3S& TH3S::operator=(const TH3S &h1)
+TH3S& TH3S::operator=(const TH3S &h3s)
 {
-   if (this != &h1)  ((TH3S&)h1).Copy(*this);
+   if (this != &h3s)
+      h3s.TH3S::Copy(*this);
    return *this;
 }
 
@@ -3867,9 +3869,9 @@ TH3S& TH3S::operator=(const TH3S &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH3S operator*(Float_t c1, TH3S &h1)
+TH3S operator*(Float_t c1, TH3S &h3s)
 {
-   TH3S hnew = h1;
+   TH3S hnew = h3s;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;
@@ -4000,7 +4002,7 @@ TH3I::TH3I(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 TH3I::TH3I(const TH3I &h3i) : TH3(), TArrayI()
 {
-   ((TH3I&)h3i).Copy(*this);
+   h3i.TH3I::Copy(*this);
 }
 
 
@@ -4030,7 +4032,7 @@ void TH3I::AddBinContent(Int_t bin, Double_t w)
 
 void TH3I::Copy(TObject &newth3) const
 {
-   TH3::Copy((TH3I&)newth3);
+   TH3::Copy(newth3);
 }
 
 
@@ -4060,9 +4062,10 @@ void TH3I::SetBinsLength(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH3I& TH3I::operator=(const TH3I &h1)
+TH3I& TH3I::operator=(const TH3I &h3i)
 {
-   if (this != &h1)  ((TH3I&)h1).Copy(*this);
+   if (this != &h3i)
+      h3i.TH3I::Copy(*this);
    return *this;
 }
 
@@ -4070,9 +4073,9 @@ TH3I& TH3I::operator=(const TH3I &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH3I operator*(Float_t c1, TH3I &h1)
+TH3I operator*(Float_t c1, TH3I &h3i)
 {
-   TH3I hnew = h1;
+   TH3I hnew = h3i;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;
@@ -4203,7 +4206,7 @@ TH3F::TH3F(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 TH3F::TH3F(const TH3F &h3f) : TH3(), TArrayF()
 {
-   ((TH3F&)h3f).Copy(*this);
+   h3f.TH3F::Copy(*this);
 }
 
 
@@ -4212,7 +4215,7 @@ TH3F::TH3F(const TH3F &h3f) : TH3(), TArrayF()
 
 void TH3F::Copy(TObject &newth3) const
 {
-   TH3::Copy((TH3F&)newth3);
+   TH3::Copy(newth3);
 }
 
 
@@ -4275,9 +4278,10 @@ void TH3F::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH3F& TH3F::operator=(const TH3F &h1)
+TH3F& TH3F::operator=(const TH3F &h3f)
 {
-   if (this != &h1)  ((TH3F&)h1).Copy(*this);
+   if (this != &h3f)
+      h3f.TH3F::Copy(*this);
    return *this;
 }
 
@@ -4285,9 +4289,9 @@ TH3F& TH3F::operator=(const TH3F &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH3F operator*(Float_t c1, TH3F &h1)
+TH3F operator*(Float_t c1, TH3F &h3f)
 {
-   TH3F hnew = h1;
+   TH3F hnew = h3f;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;
@@ -4418,7 +4422,7 @@ TH3D::TH3D(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 TH3D::TH3D(const TH3D &h3d) : TH3(), TArrayD()
 {
-   ((TH3D&)h3d).Copy(*this);
+   h3d.TH3D::Copy(*this);
 }
 
 
@@ -4427,7 +4431,7 @@ TH3D::TH3D(const TH3D &h3d) : TH3(), TArrayD()
 
 void TH3D::Copy(TObject &newth3) const
 {
-   TH3::Copy((TH3D&)newth3);
+   TH3::Copy(newth3);
 }
 
 
@@ -4490,9 +4494,10 @@ void TH3D::Streamer(TBuffer &R__b)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator =
 
-TH3D& TH3D::operator=(const TH3D &h1)
+TH3D& TH3D::operator=(const TH3D &h3d)
 {
-   if (this != &h1)  ((TH3D&)h1).Copy(*this);
+   if (this != &h3d)
+      h3d.TH3D::Copy(*this);
    return *this;
 }
 
@@ -4500,9 +4505,9 @@ TH3D& TH3D::operator=(const TH3D &h1)
 ////////////////////////////////////////////////////////////////////////////////
 /// Operator *
 
-TH3D operator*(Float_t c1, TH3D &h1)
+TH3D operator*(Float_t c1, TH3D &h3d)
 {
-   TH3D hnew = h1;
+   TH3D hnew = h3d;
    hnew.Scale(c1);
    hnew.SetDirectory(nullptr);
    return hnew;

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -188,17 +188,6 @@ TH3::TH3(const char *name,const char *title,Int_t nbinsx,const Double_t *xbins
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Private copy constructor.
-/// One should use the copy constructor of the derived classes (e.g. TH3D, TH3F ...).
-/// The list of functions is not copied. (Use Clone() if needed)
-
-TH3::TH3(const TH3 &h3) : TH1(), TAtt3D()
-{
-   h3.TH3::Copy(*this);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Destructor.
 
 TH3::~TH3()

--- a/hist/hist/src/TPolyMarker.cxx
+++ b/hist/hist/src/TPolyMarker.cxx
@@ -109,7 +109,7 @@ TPolyMarker::TPolyMarker(Int_t n, Double_t *x, Double_t *y, Option_t *option)
 TPolyMarker& TPolyMarker::operator=(const TPolyMarker& pm)
 {
    if(this != &pm)
-      pm.Copy(*this);
+      pm.TPolyMarker::Copy(*this);
 
    return *this;
 }
@@ -132,7 +132,7 @@ TPolyMarker::TPolyMarker(const TPolyMarker &polymarker) : TObject(polymarker), T
    fN = 0;
    fX = fY = nullptr;
    fLastPoint = -1;
-   polymarker.Copy(*this);
+   polymarker.TPolyMarker::Copy(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -141,7 +141,7 @@ TPolyMarker::TPolyMarker(const TPolyMarker &polymarker) : TObject(polymarker), T
 void TPolyMarker::Copy(TObject &obj) const
 {
    TObject::Copy(obj);
-   TAttMarker::Copy(((TPolyMarker&)obj));
+   TAttMarker::Copy((TPolyMarker&)obj);
    ((TPolyMarker&)obj).fN = fN;
    // delete first previous existing fX and fY
    if (((TPolyMarker&)obj).fX) delete [] (((TPolyMarker&)obj).fX);

--- a/hist/hist/src/TProfile.cxx
+++ b/hist/hist/src/TProfile.cxx
@@ -243,12 +243,13 @@ void TProfile::BuildOptions(Double_t ymin, Double_t ymax, Option_t *option)
 
 TProfile::TProfile(const TProfile &profile) : TH1D()
 {
-   ((TProfile&)profile).Copy(*this);
+   profile.TProfile::Copy(*this);
 }
 
 TProfile &TProfile::operator=(const TProfile &profile)
 {
-   ((TProfile &)profile).Copy(*this);
+   if (this != &profile)
+      profile.TProfile::Copy(*this);
    return *this;
 }
 
@@ -419,7 +420,7 @@ Int_t TProfile::BufferFill(Double_t x, Double_t y, Double_t w)
 void TProfile::Copy(TObject &obj) const
 {
    try {
-      TProfile & pobj = dynamic_cast<TProfile&>(obj);
+      TProfile &pobj = dynamic_cast<TProfile&>(obj);
       TH1D::Copy(pobj);
       fBinEntries.Copy(pobj.fBinEntries);
       fBinSumw2.Copy(pobj.fBinSumw2);

--- a/hist/hist/src/TProfile2D.cxx
+++ b/hist/hist/src/TProfile2D.cxx
@@ -203,14 +203,15 @@ void TProfile2D::BuildOptions(Double_t zmin, Double_t zmax, Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor.
 
-TProfile2D::TProfile2D(const TProfile2D &profile) : TH2D()
+TProfile2D::TProfile2D(const TProfile2D &profile2d) : TH2D()
 {
-   ((TProfile2D&)profile).Copy(*this);
+   profile2d.TProfile2D::Copy(*this);
 }
 
-TProfile2D &TProfile2D::operator=(const TProfile2D &profile)
+TProfile2D &TProfile2D::operator=(const TProfile2D &profile2d)
 {
-   ((TProfile2D &)profile).Copy(*this);
+   if (this != &profile2d)
+      profile2d.TProfile2D::Copy(*this);
    return *this;
 }
 
@@ -385,7 +386,7 @@ Int_t TProfile2D::BufferFill(Double_t x, Double_t y, Double_t z, Double_t w)
 void TProfile2D::Copy(TObject &obj) const
 {
    try {
-      TProfile2D & pobj = dynamic_cast<TProfile2D&>(obj);
+      TProfile2D &pobj = dynamic_cast<TProfile2D &>(obj);
 
       TH2D::Copy(pobj);
       fBinEntries.Copy(pobj.fBinEntries);

--- a/hist/hist/src/TProfile3D.cxx
+++ b/hist/hist/src/TProfile3D.cxx
@@ -154,14 +154,15 @@ void TProfile3D::BuildOptions(Double_t tmin, Double_t tmax, Option_t *option)
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy constructor.
 
-TProfile3D::TProfile3D(const TProfile3D &profile) : TH3D()
+TProfile3D::TProfile3D(const TProfile3D &profile3d) : TH3D()
 {
-   ((TProfile3D&)profile).Copy(*this);
+   profile3d.TProfile3D::Copy(*this);
 }
 
-TProfile3D &TProfile3D::operator=(const TProfile3D &profile)
+TProfile3D &TProfile3D::operator=(const TProfile3D &profile3d)
 {
-   ((TProfile3D &)profile).Copy(*this);
+   if (this != &profile3d)
+      profile3d.TProfile3D::Copy(*this);
    return *this;
 }
 
@@ -349,7 +350,7 @@ Int_t TProfile3D::BufferFill(Double_t x, Double_t y, Double_t z, Double_t t, Dou
 void TProfile3D::Copy(TObject &obj) const
 {
    try {
-      TProfile3D & pobj = dynamic_cast<TProfile3D&>(obj);
+      TProfile3D &pobj = dynamic_cast<TProfile3D &>(obj);
 
       TH3D::Copy(pobj);
       fBinEntries.Copy(pobj.fBinEntries);


### PR DESCRIPTION
This is virtual method and can be overriden in derived classes.
Therefore when such method used in copy constructor or assignment
operator, one have to explicitly specify class which used.

Fixes #10919 