### PR TITLE
[Doxygen,skipci] `modifyClassWebpage.sh`: remove trailing whitespace after library name

### DIFF
--- a/documentation/doxygen/libs.C
+++ b/documentation/doxygen/libs.C
@@ -16,9 +16,5 @@ void libs(TString classname)
    if (!libname)
       return;
 
-   // Print the library name in a external file
-   TString mainlib = libname;
-   mainlib.ReplaceAll(" ","");
-   mainlib.ReplaceAll(".so","");
    printf("mainlib=%s", libname);
 }

--- a/documentation/doxygen/modifyClassWebpage.sh
+++ b/documentation/doxygen/modifyClassWebpage.sh
@@ -24,7 +24,7 @@ if [ -z "${libname}" ]; then
 fi
 
 libname=${libname#mainlib=}
-libname=${libname%.so}
+libname=${libname%.*}
 
 # Picture name containing the "coll graph"
 PICNAME="$HTMLPATH/${libname}__coll__graph.svg"


### PR DESCRIPTION
This pull request fixes a remaining issue after merging #5913 and #10930 (see below).

## Changes or fixes:
- Remove the `.so` suffix and any trailing whitespace in the output generated by `libs.C`.  This should fix the following errors found in the log:
```
Error: file /home/sftnight/build/workspace/root-makedoc-master/rootspi/rdoc/master_TMP/html/libRMVA.so __coll__graph.svg not found.
```
- Remove dead code in `libs.C`.

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary)