### PR TITLE
[ntuple,daos] Parallelizable page vector writes

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -113,6 +113,7 @@ protected:
    void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
    RNTupleLocator CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page) final;
    RNTupleLocator CommitSealedPageImpl(DescriptorId_t columnId, const RPageStorage::RSealedPage &sealedPage) final;
+   std::vector<RNTupleLocator> CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges) final;
    std::uint64_t CommitClusterImpl(NTupleSize_t nEntries) final;
    RNTupleLocator CommitClusterGroupImpl(unsigned char *serializedPageList, std::uint32_t length) final;
    void CommitDatasetImpl(unsigned char *serializedFooter, std::uint32_t length) final;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -223,6 +223,50 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageImpl(DescriptorId_t c
    return result;
 }
 
+std::vector<ROOT::Experimental::RNTupleLocator>
+ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges)
+{
+   RDaosContainer::MultiObjectRWOperation_t writeRequests;
+   std::vector<ROOT::Experimental::RNTupleLocator> locators;
+   locators.reserve(ranges.size());
+
+   DescriptorId_t clusterId = fDescriptorBuilder.GetDescriptor().GetNClusters();
+   std::size_t szPayload = 0;
+   unsigned numPages = 0;
+
+   /// Aggregate batch of requests by object ID and distribution key, determined by the ntuple-DAOS mapping
+   for (auto &range : ranges) {
+      for (auto sealedPageIt = range.fFirst; sealedPageIt != range.fLast; ++sealedPageIt) {
+         const RPageStorage::RSealedPage &s = *sealedPageIt;
+         d_iov_t pageIov;
+         d_iov_set(&pageIov, const_cast<void *>(s.fBuffer), s.fSize);
+         auto offsetData = fPageId.fetch_add(1);
+
+         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(clusterId, range.fColumnId, offsetData);
+         auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
+         auto [it, ret] = writeRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
+         it->second.insert(daosKey.fAkey, pageIov);
+
+         RNTupleLocator result;
+         result.fPosition = offsetData;
+         result.fBytesOnStorage = s.fSize;
+         locators.push_back(result);
+
+         szPayload += s.fSize;
+         ++numPages;
+      }
+   }
+   fNBytesCurrentCluster += szPayload;
+
+   RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
+   if (int err = fDaosContainer->WriteV(writeRequests))
+      throw ROOT::Experimental::RException(R__FAIL("WriteV: error" + std::string(d_errstr(err))));
+
+   fCounters->fNPageCommitted.Add(numPages);
+   fCounters->fSzWritePayload.Add(szPayload);
+
+   return locators;
+}
 
 std::uint64_t
 ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)


### PR DESCRIPTION
This Pull request extends `RPageSink::RPageSinkDaos` to implement `RPageSinkDaos::CommitSealedPageVImpl()`, of signature: 
```c++
vector<RNTupleLocator> RPageSinkDaos::CommitSealedPageVImpl(span<RPageStorage::RSealedPageGroup> ranges)
```
, which is virtually declared in the parent class `RPageSink` since PR #10775. 

The implemented method modifies the default behavior for committing page ranges, i.e. calling `::CommitSealedPage` repeatedly for each individual page. 
Instead, it coalesces the buffered page ranges - e.g. all pages in a column or cluster - into a batch of vector writes, enabling I/O parallelization after recent optimizations to the `RDaos` library. 

As with the batched fetching case in `RPageSourceDaos::LoadClusters()`, the page write requests are aggregated by the pair (Object ID, Distribution Key). This pair is part of the `RDaosKey` determined by the mapping strategy set in `kDefaultDaosMapping` from the pages metadata and the `RPageSinkDaos` instance's atomic counter `fPageId` that uniquely identifies pages in the storage sink.

## Changes or fixes:

* Implements `std::vector<RNTupleLocator> RPageSinkDaos::CommitSealedPageVImpl(std::span<RPageStorage::RSealedPageGroup> ranges)`
  * Modifies the default behavior in `RPageSink::CommitSealedPageV()` to coalesce pages before sending out the write request to storage
  * Enables optimized (i.e. batched) vector write requests of multiple pages within a column range by exploiting the refactored `RDaos` interface and the generalized ntuple-object mappings in `RPageStorageDaos`.

## Checklist:

- [x] tested changes locally and on openlab cluster `olsky-03` with DAOS 2.0.x
- [ ] updated the docs (if necessary)

This PR fixes # 

