### PR TITLE
[cling-cpt] Added new dependent arguments [skip-ci]

### DIFF
--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -1970,6 +1970,12 @@ elif args['with_binary_llvm'] is False and args['with_llvm_url']:
     LLVM_GIT_URL = args['with_llvm_url']
 else:
     LLVM_GIT_URL = "http://root.cern.ch/git/llvm.git"
+    
+if args['with_binary_llvm'] and args['with_llvm_tar']:
+    raise Exception("Cannot specify flags --with-binary-llvm and --with-llvm-tar together")
+
+if args['with_llvm_tar'] and args['with_llvm_url']:
+    raise Exception("Cannot specify flags --with-llvm-tar and --with-llvm-url together")
 
 if args['with_llvm_tar']:
     tar_required = True


### PR DESCRIPTION


# This Pull request: Added new dependent arguments to the argument parser

## Changes or fixes: Cannot call llvm tar and binary at the same time and cannot call llvm tar and llvm url at the same time.


## Checklist:

- [X] tested changes locally
- [NA] updated the docs (if necessary)

This PR fixes issue mentioned in #406 (https://github.com/root-project/cling/issues/406)

