### PR TITLE
[DF] Fix the broken RDatasetSpec test

### DIFF
--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -64,8 +64,6 @@ protected:
 };
 #endif
 
-// TODO: This test throws "unknown file: error: SEH exception with code 0xc0000005 thrown in the test body" on windows
-#if !defined(_MSC_VER) || defined(R__ENABLE_BROKEN_WIN_TESTS)
 // ensure that the chains are created as expected, no ranges, neither friends are passed
 TEST_P(RDatasetSpecTest, SimpleChainsCreation)
 {
@@ -88,7 +86,7 @@ TEST_P(RDatasetSpecTest, SimpleChainsCreation)
 
    // third constructor: many trees, many files; trees and files passed in a vector of pairs; here 1 specTestFile
    // advanced note: when using this constructor, the internal TChain will always have no name
-   const auto dfRDSc31 = *(RDataFrame(RDatasetSpec({{"tree"s}, {"specTestFile0.root"s}})).Take<ULong64_t>("z"));
+   const auto dfRDSc31 = *(RDataFrame(RDatasetSpec({{"tree"s, "specTestFile0.root"s}})).Take<ULong64_t>("z"));
    EXPECT_VEC_EQ(dfRDSc31, {100u, 101u, 102u, 103u, 104u});
 
    // third constructor: many trees and files
@@ -99,7 +97,6 @@ TEST_P(RDatasetSpecTest, SimpleChainsCreation)
    std::sort(dfRDSc3N.begin(), dfRDSc3N.end());
    EXPECT_VEC_EQ(dfRDSc3N, {100u, 101u, 102u, 103u, 104u});
 }
-#endif
 
 // ensure that ranges are properly handled, even if the ranges are invalid
 // let: start = desired start, end = desired end, last = actually last entry


### PR DESCRIPTION
`RDatasetSpec({{"tree"s}, {"specTestFile0.root"s}})` was calling the first ctor on unix systems and was failing on windows. Neither behaviour was desired.

The modified `RDatasetSpec({{"tree"s, "specTestFile0.root"s}})` always invokes the third ctor as requested.