### PR TITLE
[RF] Convert RooStats tutorials to Python 

### DIFF
--- a/tutorials/roostats/FourBinInstructional.py
+++ b/tutorials/roostats/FourBinInstructional.py
@@ -236,7 +236,7 @@ if doFeldmanCousins:  # takes 7 minutes
 bc = ROOT.RooStats.BayesianCalculator(data, modelConfig)
 bc.SetConfidenceLevel(0.95)
 bInt = ROOT.RooStats.SimpleInterval()
-if doBayesian and wspace.set("poi").getSize() == 1:
+if doBayesian and len(wspace.set("poi")) == 1:
     bInt = bc.GetInterval()
 else:
     print("Bayesian Calc. only supports on parameter of interest")
@@ -278,7 +278,7 @@ elif doBayesian or doMCMC:
 lrplot = ROOT.RooStats.LikelihoodIntervalPlot(plInt)
 lrplot.Draw()
 
-if doBayesian and wspace.set("poi").getSize() == 1:
+if doBayesian and len(wspace.set("poi")) == 1:
     c1.cd(2)
     # the plot takes a long time and print lots of error
     # using a scan it is better
@@ -287,7 +287,7 @@ if doBayesian and wspace.set("poi").getSize() == 1:
     bplot.Draw()
 
 if doMCMC:
-    if doBayesian and wspace.set("poi").getSize() == 1:
+    if doBayesian and len(wspace.set("poi")) == 1:
         c1.cd(3)
     else:
         c1.cd(2)
@@ -301,7 +301,7 @@ print(
 )
 # Profile Likelihood interval on s = [12.1902, 88.6871]
 
-if doBayesian and wspace.set("poi").getSize() == 1:
+if doBayesian and len(wspace.set("poi")) == 1:
     print("Bayesian interval on s = [{}, {}]".format(bInt.LowerLimit(), bInt.UpperLimit()))
 
 if doFeldmanCousins:
@@ -319,9 +319,11 @@ t.Print()
 
 c1.SaveAs("FourBinInstructional.png")
 
-# TODO: The MCMCCalculator has to be destructed first. Otherwise, we can get
+# TODO: The calculators have to be destructed first. Otherwise, we can get
 # segmentation faults depending on the destruction order, which is random in
 # Python. Probably the issue is that some object has a non-owning pointer to
 # another object, which it uses in its destructor. This should be fixed either
 # in the design of RooStats in C++, or with phythonizations.
+del plc
+del bc
 del mc

--- a/tutorials/roostats/FourBinInstructional.py
+++ b/tutorials/roostats/FourBinInstructional.py
@@ -1,0 +1,327 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook
+## This example is a generalization of the on/off problem.
+##
+##  This example is a generalization of the on/off problem.
+## It's a common setup for SUSY searches.  Imagine that one has two
+## variables "x" and "y" (eg. missing ET and SumET), see figure.
+## The signal region has high values of both of these variables (top right).
+## One can see low values of "x" or "y" acting as side-bands.  If we
+## just used "y" as a sideband, we would have the on/off problem.
+##  - In the signal region we observe non events and expect s+b events.
+##  - In the region with low values of "y" (bottom right)
+##    we observe noff events and expect tau*b events.
+## Note the significance of tau.  In the background only case:
+##
+## ~~~{.cpp}
+##    tau ~ <expectation off> / <expectation on>
+## ~~~
+##
+## If tau is known, this model is sufficient, but often tau is not known exactly.
+## So one can use low values of "x" as an additional constraint for tau.
+## Note that this technique critically depends on the notion that the
+## joint distribution for "x" and "y" can be factorized.
+## Generally, these regions have many events, so it the ratio can be
+## measured very precisely there.  So we extend the model to describe the
+## left two boxes... denoted with "bar".
+##   - In the upper left we observe nonbar events and expect bbar events
+##   - In the bottom left we observe noffbar events and expect tau bbar events
+## Note again we have:
+##
+## ~~~{.cpp}
+##    tau ~ <expectation off bar> / <expectation on bar>
+## ~~~
+##
+## One can further expand the model to account for the systematic associated
+## to assuming the distribution of "x" and "y" factorizes (eg. that
+## tau is the same for off/on and offbar/onbar). This can be done in several
+## ways, but here we introduce an additional parameter rho, which so that
+## one set of models will use tau and the other tau*rho. The choice is arbitrary,
+## but it has consequences on the numerical stability of the algorithms.
+## The "bar" measurements typically have more events (& smaller relative errors).
+## If we choose
+##
+## ~~~{.cpp}
+## <expectation noffbar> = tau * rho * <expectation noonbar>
+## ~~~
+##
+## the product tau*rho will be known very precisely (~1/sqrt(bbar)) and the contour
+## in those parameters will be narrow and have a non-trivial tau~1/rho shape.
+## However, if we choose to put rho on the non/noff measurements (where the
+## product will have an error `~1/sqrt(b))`, the contours will be more amenable
+## to numerical techniques.  Thus, here we choose to define:
+##
+## ~~~{.cpp}
+##    tau := <expectation off bar> / (<expectation on bar>)
+##    rho := <expectation off> / (<expectation on> * tau)
+##
+## ^ y
+## |
+## |---------------------------+
+## |               |           |
+## |     nonbar    |    non    |
+## |      bbar     |    s+b    |
+## |               |           |
+## |---------------+-----------|
+## |               |           |
+## |    noffbar    |    noff   |
+## |    tau bbar   | tau b rho |
+## |               |           |
+## +-----------------------------> x
+## ~~~
+##
+## Left in this way, the problem is under-constrained.  However, one may
+## have some auxiliary measurement (usually based on Monte Carlo) to
+## constrain rho.  Let us call this auxiliary measurement that gives
+## the nominal value of rho "rhonom".  Thus, there is a 'constraint' term in
+## the full model: P(rhonom | rho).  In this case, we consider a Gaussian
+## constraint with standard deviation sigma.
+##
+## In the example, the initial values of the parameters are:
+##
+## ~~~{.cpp}
+##   - s    = 40
+##   - b    = 100
+##   - tau  = 5
+##   - bbar = 1000
+##   - rho  = 1
+##   (sigma for rho = 20%)
+## ~~~
+##
+## and in the toy dataset:
+##
+## ~~~{.cpp}
+##    - non = 139
+##    - noff = 528
+##    - nonbar = 993
+##    - noffbar = 4906
+##    - rhonom = 1.27824
+## ~~~
+##
+## Note, the covariance matrix of the parameters has large off-diagonal terms.
+## Clearly s,b are anti-correlated.  Similarly, since noffbar >> nonbar, one would
+## expect bbar,tau to be anti-correlated.
+##
+## This can be seen below.
+##
+## ~~~{.cpp}
+##             GLOBAL      b    bbar   rho      s     tau
+##         b  0.96820   1.000  0.191 -0.942 -0.762 -0.209
+##      bbar  0.91191   0.191  1.000  0.000 -0.146 -0.912
+##       rho  0.96348  -0.942  0.000  1.000  0.718 -0.000
+##         s  0.76250  -0.762 -0.146  0.718  1.000  0.160
+##       tau  0.92084  -0.209 -0.912 -0.000  0.160  1.000
+## ~~~
+##
+## Similarly, since tau*rho appears as a product, we expect rho,tau
+## to be anti-correlated. When the error on rho is significantly
+## larger than 1/sqrt(bbar), tau is essentially known and the
+## correlation is minimal (tau mainly cares about bbar, and rho about b,s).
+## In the alternate parametrization (bbar* tau * rho) the correlation coefficient
+## for rho,tau is large (and negative).
+##
+## The code below uses best-practices for RooFit & RooStats as of June 2010.
+##
+## It proceeds as follows:
+##  - create a workspace to hold the model
+##  - use workspace factory to quickly create the terms of the model
+##  - use workspace factory to define total model (a prod pdf)
+##  - create a RooStats ModelConfig to specify observables, parameters of interest
+##  - add to the ModelConfig a prior on the parameters for Bayesian techniques
+##    note, the pdf it is factorized for parameters of interest & nuisance params
+##  - visualize the model
+##  - write the workspace to a file
+##  - use several of RooStats IntervalCalculators & compare results
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Kyle Cranmer and Tanja Rommerskirchen (C++ version)
+
+import ROOT
+
+doBayesian = False
+doFeldmanCousins = False
+doMCMC = False
+
+# let's time this challenging example
+t = ROOT.TStopwatch()
+t.Start()
+
+# set RooFit random seed for reproducible results
+ROOT.RooRandom.randomGenerator().SetSeed(4357)
+
+# make model
+wspace = ROOT.RooWorkspace("wspace")
+wspace.factory("Poisson::on(non[0,1000], sum::splusb(s[40,0,100],b[100,0,300]))")
+wspace.factory("Poisson::off(noff[0,5000], prod::taub(b,tau[5,3,7],rho[1,0,2]))")
+wspace.factory("Poisson::onbar(nonbar[0,10000], bbar[1000,500,2000])")
+wspace.factory("Poisson::offbar(noffbar[0,1000000], prod::lambdaoffbar(bbar, tau))")
+wspace.factory("Gaussian::mcCons(rhonom[1.,0,2], rho, sigma[.2])")
+wspace.factory("PROD::model(on,off,onbar,offbar,mcCons)")
+wspace.defineSet("obs", "non,noff,nonbar,noffbar,rhonom")
+
+wspace.factory("Uniform::prior_poi({s})")
+wspace.factory("Uniform::prior_nuis({b,bbar,tau, rho})")
+wspace.factory("PROD::prior(prior_poi,prior_nuis)")
+
+# ----------------------------------
+# Control some interesting variations
+# define parameers of interest
+# for 1-d plots
+wspace.defineSet("poi", "s")
+wspace.defineSet("nuis", "b,tau,rho,bbar")
+
+# for 2-d plots to inspect correlations:
+# wspace.defineSet("poi","s,rho")
+
+# test simpler cases where parameters are known.
+# wspace["tau"].setConstant()
+# wspace["rho"].setConstant()
+# wspace["b"].setConstant()
+# wspace["bbar"].setConstant()
+
+# inspect workspace
+# wspace.Print()
+
+# ----------------------------------------------------------
+# Generate toy data
+# generate toy data assuming current value of the parameters
+# import into workspace.
+# add Verbose() to see how it's being generated
+data = wspace["model"].generate(wspace.set("obs"), 1)
+# data.Print("v")
+wspace.Import(data)
+
+# ----------------------------------
+# Now the statistical tests
+# model config
+modelConfig = ROOT.RooStats.ModelConfig("FourBins")
+modelConfig.SetWorkspace(wspace)
+modelConfig.SetPdf(wspace["model"])
+modelConfig.SetPriorPdf(wspace["prior"])
+modelConfig.SetParametersOfInterest(wspace.set("poi"))
+modelConfig.SetNuisanceParameters(wspace.set("nuis"))
+wspace.Import(modelConfig)
+wspace.writeToFile("FourBin.root")
+
+# -------------------------------------------------
+# If you want to see the covariance matrix uncomment
+# wspace["model"].fitTo(data)
+
+# use ProfileLikelihood
+plc = ROOT.RooStats.ProfileLikelihoodCalculator(data, modelConfig)
+plc.SetConfidenceLevel(0.95)
+plInt = plc.GetInterval()
+msglevel = ROOT.RooMsgService.instance().globalKillBelow()
+ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.FATAL)
+plInt.LowerLimit(wspace["s"])  # get ugly print out of the way. Fix.
+ROOT.RooMsgService.instance().setGlobalKillBelow(msglevel)
+
+# use FeldmaCousins (takes ~20 min)
+fc = ROOT.RooStats.FeldmanCousins(data, modelConfig)
+fc.SetConfidenceLevel(0.95)
+# number counting: dataset always has 1 entry with N events observed
+fc.FluctuateNumDataEntries(False)
+fc.UseAdaptiveSampling(True)
+fc.SetNBins(40)
+fcInt = ROOT.RooStats.PointSetInterval()
+if doFeldmanCousins:  # takes 7 minutes
+    fcInt = fc.GetInterval()
+
+# use BayesianCalculator (only 1-d parameter of interest, slow for this problem)
+bc = ROOT.RooStats.BayesianCalculator(data, modelConfig)
+bc.SetConfidenceLevel(0.95)
+bInt = ROOT.RooStats.SimpleInterval()
+if doBayesian and wspace.set("poi").getSize() == 1:
+    bInt = bc.GetInterval()
+else:
+    print("Bayesian Calc. only supports on parameter of interest")
+
+# use MCMCCalculator  (takes about 1 min)
+# Want an efficient proposal function, so derive it from covariance
+# matrix of fit
+fit = wspace["model"].fitTo(data, Save=True)
+ph = ROOT.RooStats.ProposalHelper()
+ph.SetVariables(fit.floatParsFinal())
+ph.SetCovMatrix(fit.covarianceMatrix())
+ph.SetUpdateProposalParameters(ROOT.kTRUE)  # auto-create mean vars and add mappings
+ph.SetCacheSize(100)
+pf = ph.GetProposalFunction()
+
+mc = ROOT.RooStats.MCMCCalculator(data, modelConfig)
+mc.SetConfidenceLevel(0.95)
+mc.SetProposalFunction(pf)
+mc.SetNumBurnInSteps(500)  # first N steps to be ignored as burn-in
+mc.SetNumIters(50000)
+mc.SetLeftSideTailFraction(0.5)  # make a central interval
+mcInt = ROOT.RooStats.MCMCInterval()
+if doMCMC:
+    mcInt = mc.GetInterval()
+
+# ----------------------------------
+# Make some plots
+c1 = ROOT.gROOT.Get("c1")
+if not c1:
+    c1 = ROOT.TCanvas("c1")
+
+if doBayesian and doMCMC:
+    c1.Divide(3)
+    c1.cd(1)
+elif doBayesian or doMCMC:
+    c1.Divide(2)
+    c1.cd(1)
+
+lrplot = ROOT.RooStats.LikelihoodIntervalPlot(plInt)
+lrplot.Draw()
+
+if doBayesian and wspace.set("poi").getSize() == 1:
+    c1.cd(2)
+    # the plot takes a long time and print lots of error
+    # using a scan it is better
+    bc.SetScanOfPosterior(20)
+    bplot = bc.GetPosteriorPlot()
+    bplot.Draw()
+
+if doMCMC:
+    if doBayesian and wspace.set("poi").getSize() == 1:
+        c1.cd(3)
+    else:
+        c1.cd(2)
+    mcPlot = ROOT.RooStats.MCMCIntervalPlot(mcInt)
+    mcPlot.Draw()
+
+# ----------------------------------
+# querry intervals
+print(
+    "Profile Likelihood interval on s = [{}, {}]".format(plInt.LowerLimit(wspace["s"]), plInt.UpperLimit(wspace["s"]))
+)
+# Profile Likelihood interval on s = [12.1902, 88.6871]
+
+if doBayesian and wspace.set("poi").getSize() == 1:
+    print("Bayesian interval on s = [{}, {}]".format(bInt.LowerLimit(), bInt.UpperLimit()))
+
+if doFeldmanCousins:
+    print(
+        "Feldman Cousins interval on s = [{}, {}]".format(fcInt.LowerLimit(wspace["s"]), fcInt.UpperLimit(wspace["s"]))
+    )
+    # Feldman Cousins interval on s = [18.75 +/- 2.45, 83.75 +/- 2.45]
+
+if doMCMC:
+    print("MCMC interval on s = [{}, {}]".format(mcInt.LowerLimit(wspace["s"]), mcInt.UpperLimit(wspace["s"])))
+    # MCMC interval on s = [15.7628, 84.7266]
+
+t.Stop()
+t.Print()
+
+c1.SaveAs("FourBinInstructional.png")
+
+# TODO: The MCMCCalculator has to be destructed first. Otherwise, we can get
+# segmentation faults depending on the destruction order, which is random in
+# Python. Probably the issue is that some object has a non-owning pointer to
+# another object, which it uses in its destructor. This should be fixed either
+# in the design of RooStats in C++, or with phythonizations.
+del mc

--- a/tutorials/roostats/MultivariateGaussianTest.C
+++ b/tutorials/roostats/MultivariateGaussianTest.C
@@ -161,8 +161,8 @@ void MultivariateGaussianTest(Int_t dim = 4, Int_t nPOI = 2)
       Double_t ll = mcInt->LowerLimit(*p0);
       Double_t ul = mcInt->UpperLimit(*p0);
       cout << "MCMC interval on p0: [" << ll << ", " << ul << "]" << endl;
-      ll = mcInt->LowerLimit(*p0);
-      ul = mcInt->UpperLimit(*p0);
+      ll = mcInt->LowerLimit(*p1);
+      ul = mcInt->UpperLimit(*p1);
       cout << "MCMC interval on p1: [" << ll << ", " << ul << "]" << endl;
 
       // MCMC interval on p0: [-0.2, 0.6]

--- a/tutorials/roostats/MultivariateGaussianTest.py
+++ b/tutorials/roostats/MultivariateGaussianTest.py
@@ -115,11 +115,11 @@ mcPlot.Draw()
 plPlot = ROOT.RooStats.LikelihoodIntervalPlot(plInt)
 plPlot.Draw("same")
 
-if poiList.getSize() == 1:
+if len(poiList) == 1:
     p = poiList.at(0)
     print("MCMC interval: [{}, {}]".format(mcInt.LowerLimit(p), mcInt.UpperLimit(p)))
 
-if poiList.getSize() == 2:
+if len(poiList) == 2:
     p0 = poiList.at(0)
     p1 = poiList.at(1)
     scatter = ROOT.TCanvas()

--- a/tutorials/roostats/MultivariateGaussianTest.py
+++ b/tutorials/roostats/MultivariateGaussianTest.py
@@ -1,0 +1,146 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook
+## Comparison of MCMC and PLC in a multi-variate gaussian problem
+##
+## This tutorial produces an N-dimensional multivariate Gaussian
+## with a non-trivial covariance matrix.  By default N=4 (called "dim").
+##
+## A subset of these are considered parameters of interest.
+## This problem is tractable analytically.
+##
+## We use this mainly as a test of Markov Chain Monte Carlo
+## and we compare the result to the profile likelihood ratio.
+##
+## We use the proposal helper to create a customized
+## proposal function for this problem.
+##
+## For N=4 and 2 parameters of interest it takes about 10-20 seconds
+## and the acceptance rate is 37%
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Kevin Belasco and Kyle Cranmer (C++ version)
+
+import ROOT
+
+dim = 4
+nPOI = 2
+
+# let's time this challenging example
+t = ROOT.TStopwatch()
+t.Start()
+
+xVec = []
+muVec = []
+poi = set()
+
+# make the observable and means
+for i in range(dim):
+    name = "x{}".format(i)
+    x = ROOT.RooRealVar(name, name, 0, -3, 3)
+    xVec.append(x)
+
+    mu_name = "mu_x{}".format(i)
+    mu_x = ROOT.RooRealVar(mu_name, mu_name, 0, -2, 2)
+    muVec.append(mu_x)
+
+# put them into the list of parameters of interest
+for i in range(nPOI):
+    poi.add(muVec[i])
+
+# make a covariance matrix that is all 1's
+cov = ROOT.TMatrixDSym(dim)
+for i in range(dim):
+    for j in range(dim):
+        if i == j:
+            cov[i, j] = 3.0
+        else:
+            cov[i, j] = 1.0
+
+# now make the multivariate Gaussian
+mvg = ROOT.RooMultiVarGaussian("mvg", "mvg", xVec, muVec, cov)
+
+# --------------------
+# make a toy dataset
+data = mvg.generate(xVec, 100)
+
+# now create the model config for this problem
+w = ROOT.RooWorkspace("MVG")
+modelConfig = ROOT.RooStats.ModelConfig(w)
+modelConfig.SetPdf(mvg)
+modelConfig.SetParametersOfInterest(poi)
+
+# -------------------------------------------------------
+# Setup calculators
+
+# MCMC
+# we want to setup an efficient proposal function
+# using the covariance matrix from a fit to the data
+fit = mvg.fitTo(data, Save=True)
+ph = ROOT.RooStats.ProposalHelper()
+ph.SetVariables(fit.floatParsFinal())
+ph.SetCovMatrix(fit.covarianceMatrix())
+ph.SetUpdateProposalParameters(True)
+ph.SetCacheSize(100)
+pdfProp = ph.GetProposalFunction()
+
+# now create the calculator
+mc = ROOT.RooStats.MCMCCalculator(data, modelConfig)
+mc.SetConfidenceLevel(0.95)
+mc.SetNumBurnInSteps(100)
+mc.SetNumIters(10000)
+mc.SetNumBins(50)
+mc.SetProposalFunction(pdfProp)
+
+mcInt = mc.GetInterval()
+poiList = mcInt.GetAxes()
+
+# now setup the profile likelihood calculator
+plc = ROOT.RooStats.ProfileLikelihoodCalculator(data, modelConfig)
+plc.SetConfidenceLevel(0.95)
+plInt = plc.GetInterval()
+
+# make some plots
+mcPlot = ROOT.RooStats.MCMCIntervalPlot(mcInt)
+
+c1 = ROOT.TCanvas()
+mcPlot.SetLineColor(ROOT.kGreen)
+mcPlot.SetLineWidth(2)
+mcPlot.Draw()
+
+plPlot = ROOT.RooStats.LikelihoodIntervalPlot(plInt)
+plPlot.Draw("same")
+
+if poiList.getSize() == 1:
+    p = poiList.at(0)
+    print("MCMC interval: [{}, {}]".format(mcInt.LowerLimit(p), mcInt.UpperLimit(p)))
+
+if poiList.getSize() == 2:
+    p0 = poiList.at(0)
+    p1 = poiList.at(1)
+    scatter = ROOT.TCanvas()
+    print("MCMC interval on p0: [{}, {}]".format(mcInt.LowerLimit(p0), mcInt.UpperLimit(p0)))
+    print("MCMC interval on p1: [{}, {}]".format(mcInt.LowerLimit(p1), mcInt.UpperLimit(p1)))
+
+    # MCMC interval on p0: [-0.2, 0.6]
+    # MCMC interval on p1: [-0.2, 0.6]
+
+    mcPlot.DrawChainScatter(p0, p1)
+    scatter.Update()
+    scatter.SaveAs("MultivariateGaussianTest_scatter.png")
+
+t.Stop()
+t.Print()
+
+c1.SaveAs("MultivariateGaussianTest_plot.png")
+
+# TODO: The MCMCCalculator has to be destructed first. Otherwise, we can get
+# segmentation faults depending on the destruction order, which is random in
+# Python. Probably the issue is that some object has a non-owning pointer to
+# another object, which it uses in its destructor. This should be fixed either
+# in the design of RooStats in C++, or with phythonizations.
+del mc

--- a/tutorials/roostats/Zbi_Zgamma.C
+++ b/tutorials/roostats/Zbi_Zgamma.C
@@ -25,7 +25,7 @@ void Zbi_Zgamma()
    // Make model for prototype on/off problem
    // Pois(x | s+b) * Pois(y | tau b )
    // for Z_Gamma, use uniform prior on b.
-   RooWorkspace *w1 = new RooWorkspace("w", true);
+   RooWorkspace *w1 = new RooWorkspace("w");
    w1->factory("Poisson::px(x[150,0,500],sum::splusb(s[0,0,100],b[100,0,300]))");
    w1->factory("Poisson::py(y[100,0,500],prod::taub(tau[1.],b))");
    w1->factory("Uniform::prior_b(b)");

--- a/tutorials/roostats/Zbi_Zgamma.py
+++ b/tutorials/roostats/Zbi_Zgamma.py
@@ -8,7 +8,7 @@
 ## \macro_code
 ##
 ## \date July 2022
-## \authors Artem Busorgin, Kyle Cranmer & Wouter Verkerke (C++ version)
+## \authors Artem Busorgin, Kyle Cranmer and Wouter Verkerke (C++ version)
 
 import ROOT
 

--- a/tutorials/roostats/Zbi_Zgamma.py
+++ b/tutorials/roostats/Zbi_Zgamma.py
@@ -15,7 +15,7 @@ import ROOT
 # Make model for prototype on/off problem
 # Pois(x | s+b) * Pois(y | tau b )
 # for Z_Gamma, use uniform prior on b.
-w1 = ROOT.RooWorkspace("w", True)
+w1 = ROOT.RooWorkspace("w")
 w1.factory("Poisson::px(x[150,0,500],sum::splusb(s[0,0,100],b[100,0,300]))")
 w1.factory("Poisson::py(y[100,0,500],prod::taub(tau[1.],b))")
 w1.factory("Uniform::prior_b(b)")

--- a/tutorials/roostats/Zbi_Zgamma.py
+++ b/tutorials/roostats/Zbi_Zgamma.py
@@ -1,0 +1,52 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook -js
+## Demonstrate Z_Bi = Z_Gamma
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Kyle Cranmer & Wouter Verkerke (C++ version)
+
+import ROOT
+
+# Make model for prototype on/off problem
+# Pois(x | s+b) * Pois(y | tau b )
+# for Z_Gamma, use uniform prior on b.
+w1 = ROOT.RooWorkspace("w", True)
+w1.factory("Poisson::px(x[150,0,500],sum::splusb(s[0,0,100],b[100,0,300]))")
+w1.factory("Poisson::py(y[100,0,500],prod::taub(tau[1.],b))")
+w1.factory("Uniform::prior_b(b)")
+
+# construct the Bayesian-averaged model (eg. a projection pdf)
+# p'(x|s) = \int db p(x|s+b) * [ p(y|b) * prior(b) ]
+w1.factory("PROJ::averagedModel(PROD::foo(px|b,py,prior_b),b)")
+
+c = ROOT.TCanvas()
+
+# plot it, blue is averaged model, red is b known exactly
+frame = w1["x"].frame()
+w1["averagedModel"].plotOn(frame)
+w1["px"].plotOn(frame, LineColor=ROOT.kRed)
+frame.Draw()
+
+# compare analytic calculation of Z_Bi
+# with the numerical RooFit implementation of Z_Gamma
+# for an example with x = 150, y = 100
+
+# numeric RooFit Z_Gamma
+w1["y"].setVal(100)
+w1["x"].setVal(150)
+cdf = w1["averagedModel"].createCdf(w1["x"])
+cdf.getVal()  # get ugly print messages out of the way
+
+print("Hybrid p-value = ", cdf.getVal())
+print("Z_Gamma Significance  = ", ROOT.RooStats.PValueToSignificance(1 - cdf.getVal()))
+
+# analytic Z_Bi
+Z_Bi = ROOT.RooStats.NumberCountingUtils.BinomialWithTauObsZ(150, 100, 1)
+print("Z_Bi significance estimation: ", Z_Bi)
+
+c.SaveAs("Zbi_Zgamma.png")

--- a/tutorials/roostats/rs601_HLFactoryexample.py
+++ b/tutorials/roostats/rs601_HLFactoryexample.py
@@ -1,0 +1,49 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook -js
+## High Level Factory: creation of a simple model
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Danilo Piparo (C++ version)
+
+import ROOT
+
+# --- Build the datacard and dump to file---
+card_name = "HLFavtoryexample.rs"
+with open(card_name, "w") as f:
+    f.write("// The simplest card\n\n")
+    f.write("gauss = Gaussian(mes[5.20,5.30],mean[5.28,5.2,5.3],width[0.0027,0.001,1]);\n")
+    f.write("argus = ArgusBG(mes,5.291,argpar[-20,-100,-1]);\n")
+    f.write("sum = SUM(nsig[200,0,10000]*gauss,nbkg[800,0,10000]*argus);\n\n")
+
+hlf = ROOT.RooStats.HLFactory("HLFavtoryexample", card_name, False)
+
+# --- Take elements out of the internal workspace ---
+w = hlf.GetWs()
+
+mes = w.arg("mes")
+sum = w.pdf("sum")
+argus = w.pdf("argus")
+
+# --- Generate a toyMC sample from composite PDF ---
+data = sum.generate(mes, 2000)
+
+# --- Perform extended ML fit of composite PDF to toy data ---
+sum.fitTo(data)
+
+# --- Plot toy data and composite PDF overlaid ---
+mesframe = mes.frame()
+data.plotOn(mesframe)
+sum.plotOn(mesframe)
+sum.plotOn(mesframe, Components=argus, LineStyle=ROOT.kDashed)
+
+ROOT.gROOT.SetStyle("Plain")
+
+c = ROOT.TCanvas()
+mesframe.Draw()
+
+c.SaveAs("rs601_HLFactoryexample.png")

--- a/tutorials/roostats/rs601_HLFactoryexample.py
+++ b/tutorials/roostats/rs601_HLFactoryexample.py
@@ -26,20 +26,20 @@ hlf = ROOT.RooStats.HLFactory("HLFavtoryexample", card_name, False)
 w = hlf.GetWs()
 
 mes = w.arg("mes")
-sum = w["sum"]
+sumpdf = w["sum"]
 argus = w["argus"]
 
 # --- Generate a toyMC sample from composite PDF ---
-data = sum.generate(mes, 2000)
+data = sumpdf.generate(mes, 2000)
 
 # --- Perform extended ML fit of composite PDF to toy data ---
-sum.fitTo(data)
+sumpdf.fitTo(data)
 
 # --- Plot toy data and composite PDF overlaid ---
 mesframe = mes.frame()
 data.plotOn(mesframe)
-sum.plotOn(mesframe)
-sum.plotOn(mesframe, Components=argus, LineStyle=ROOT.kDashed)
+sumpdf.plotOn(mesframe)
+sumpdf.plotOn(mesframe, Components=argus, LineStyle="--")
 
 ROOT.gROOT.SetStyle("Plain")
 

--- a/tutorials/roostats/rs601_HLFactoryexample.py
+++ b/tutorials/roostats/rs601_HLFactoryexample.py
@@ -26,8 +26,8 @@ hlf = ROOT.RooStats.HLFactory("HLFavtoryexample", card_name, False)
 w = hlf.GetWs()
 
 mes = w.arg("mes")
-sum = w.pdf("sum")
-argus = w.pdf("argus")
+sum = w["sum"]
+argus = w["argus"]
 
 # --- Generate a toyMC sample from composite PDF ---
 data = sum.generate(mes, 2000)

--- a/tutorials/roostats/rs701_BayesianCalculator.C
+++ b/tutorials/roostats/rs701_BayesianCalculator.C
@@ -25,7 +25,7 @@ using namespace RooStats;
 void rs701_BayesianCalculator(bool useBkg = true, double confLevel = 0.90)
 {
 
-   RooWorkspace *w = new RooWorkspace("w", true);
+   RooWorkspace *w = new RooWorkspace("w");
    w->factory("SUM::pdf(s[0.001,15]*Uniform(x[0,1]),b[1,0,2]*Uniform(x))");
    w->factory("Gaussian::prior_b(b,1,1)");
    w->factory("PROD::model(pdf,prior_b)");

--- a/tutorials/roostats/rs701_BayesianCalculator.py
+++ b/tutorials/roostats/rs701_BayesianCalculator.py
@@ -1,0 +1,87 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook
+## Bayesian calculator: basic exmple
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date July 2022
+## \authors Artem Busorgin, Gregory Schott (C++ version)
+
+import ROOT
+
+useBkg = True
+confLevel = 0.90
+
+w = ROOT.RooWorkspace("w", True)
+w.factory("SUM::pdf(s[0.001,15]*Uniform(x[0,1]),b[1,0,2]*Uniform(x))")
+w.factory("Gaussian::prior_b(b,1,1)")
+w.factory("PROD::model(pdf,prior_b)")
+model = w["model"]  # pdf*priorNuisance
+nuisanceParameters = ROOT.RooArgSet(w["b"])
+
+POI = w["s"]
+priorPOI = w.factory("Uniform::priorPOI(s)")
+priorPOI2 = w.factory("GenericPdf::priorPOI2('1/sqrt(@0)',s)")
+
+w.factory("n[3]")  # observed number of events
+# create a data set with n observed events
+data = ROOT.RooDataSet("data", "", {w["x"], w["n"]}, "n")
+data.add({w["x"]}, w["n"].getVal())
+
+# to suppress messages when pdf goes to zero
+ROOT.RooMsgService.instance().setGlobalKillBelow(ROOT.RooFit.FATAL)
+
+nuisPar = 0
+if useBkg:
+    nuisPar = nuisanceParameters
+else:
+    w["b"].setVal(0)
+
+size = 1.0 - confLevel
+print("\nBayesian Result using a Flat prior ")
+bcalc = ROOT.RooStats.BayesianCalculator(data, model, {POI}, priorPOI, nuisPar)
+bcalc.SetTestSize(size)
+interval = bcalc.GetInterval()
+cl = bcalc.ConfidenceLevel()
+print(
+    "{}% CL central interval: [ {} - {} ] or {}% CL limits\n".format(
+        cl, interval.LowerLimit(), interval.UpperLimit(), cl + (1.0 - cl) / 2
+    )
+)
+plot = bcalc.GetPosteriorPlot()
+c1 = ROOT.TCanvas("c1", "Bayesian Calculator Result")
+c1.Divide(1, 2)
+c1.cd(1)
+plot.Draw()
+c1.Update()
+
+print("\nBayesian Result using a 1/sqrt(s) prior  ")
+bcalc2 = ROOT.RooStats.BayesianCalculator(data, model, {POI}, priorPOI2, nuisPar)
+bcalc2.SetTestSize(size)
+interval2 = bcalc2.GetInterval()
+cl = bcalc2.ConfidenceLevel()
+print(
+    "{}% CL central interval: [ {} - {} ] or {}% CL limits\n".format(
+        cl, interval2.LowerLimit(), interval2.UpperLimit(), cl + (1.0 - cl) / 2
+    )
+)
+plot2 = bcalc2.GetPosteriorPlot()
+c1.cd(2)
+plot2.Draw()
+ROOT.gPad.SetLogy()
+c1.Update()
+
+# observe one event while expecting one background event -> the 95% CL upper limit on s is 4.10
+# observe one event while expecting zero background event -> the 95% CL upper limit on s is 4.74
+
+c1.SaveAs("rs701_BayesianCalculator.png")
+
+# TODO: The BayesianCalculator has to be destructed first. Otherwise, we can get
+# segmentation faults depending on the destruction order, which is random in
+# Python. Probably the issue is that some object has a non-owning pointer to
+# another object, which it uses in its destructor. This should be fixed either
+# in the design of RooStats in C++, or with phythonizations.
+del bcalc, bcalc2

--- a/tutorials/roostats/rs701_BayesianCalculator.py
+++ b/tutorials/roostats/rs701_BayesianCalculator.py
@@ -15,11 +15,10 @@ import ROOT
 useBkg = True
 confLevel = 0.90
 
-w = ROOT.RooWorkspace("w", True)
+w = ROOT.RooWorkspace("w")
 w.factory("SUM::pdf(s[0.001,15]*Uniform(x[0,1]),b[1,0,2]*Uniform(x))")
 w.factory("Gaussian::prior_b(b,1,1)")
-w.factory("PROD::model(pdf,prior_b)")
-model = w["model"]  # pdf*priorNuisance
+model = w.factory("PROD::model(pdf,prior_b)") # pdf*priorNuisance
 nuisanceParameters = ROOT.RooArgSet(w["b"])
 
 POI = w["s"]

--- a/tutorials/roostats/rs_bernsteinCorrection.C
+++ b/tutorials/roostats/rs_bernsteinCorrection.C
@@ -99,8 +99,7 @@ void rs_bernsteinCorrection()
    RooPlot *frame = x.frame();
    data->plotOn(frame);
    // plot the best fit nominal model in blue
-   TString minimType = ROOT::Math::MinimizerOptions::DefaultMinimizerType();
-   nominal.fitTo(*data, PrintLevel(0), Minimizer(minimType));
+    nominal.fitTo(*data, PrintLevel(0));
    nominal.plotOn(frame);
 
    // plot the best fit corrected model in red
@@ -109,7 +108,7 @@ void rs_bernsteinCorrection()
       return;
 
    // fit corrected model
-   corrected->fitTo(*data, PrintLevel(0), Minimizer(minimType));
+   corrected->fitTo(*data, PrintLevel(0));
    corrected->plotOn(frame, LineColor(kRed));
 
    // plot the correction term (* norm constant) in dashed green

--- a/tutorials/roostats/rs_bernsteinCorrection.py
+++ b/tutorials/roostats/rs_bernsteinCorrection.py
@@ -77,7 +77,7 @@ nominal.fitTo(data, PrintLevel=0, Minimizer=minimType)
 nominal.plotOn(frame)
 
 # plot the best fit corrected model in red
-corrected = wks.pdf("corrected")
+corrected = wks["corrected"]
 if not corrected:
     sys.exit()
 
@@ -87,7 +87,7 @@ corrected.plotOn(frame, LineColor=ROOT.kRed)
 
 # plot the correction term (* norm constant) in dashed green
 # should make norm constant just be 1, not depend on binning of data
-poly = wks.pdf("poly")
+poly = wks["poly"]
 if poly:
     poly.plotOn(frame, LineColor=ROOT.kGreen, LineStyle=ROOT.kDashed)
 

--- a/tutorials/roostats/rs_bernsteinCorrection.py
+++ b/tutorials/roostats/rs_bernsteinCorrection.py
@@ -72,8 +72,7 @@ print("Correction based on Bernstein Poly of degree ", degree)
 frame = x.frame()
 data.plotOn(frame)
 # plot the best fit nominal model in blue
-minimType = ROOT.Math.MinimizerOptions.DefaultMinimizerType()
-nominal.fitTo(data, PrintLevel=0, Minimizer=minimType)
+nominal.fitTo(data, PrintLevel=0)
 nominal.plotOn(frame)
 
 # plot the best fit corrected model in red
@@ -82,14 +81,14 @@ if not corrected:
     sys.exit()
 
 # fit corrected model
-corrected.fitTo(data, PrintLevel=0, Minimizer=minimType)
-corrected.plotOn(frame, LineColor=ROOT.kRed)
+corrected.fitTo(data, PrintLevel=0)
+corrected.plotOn(frame, LineColor="r")
 
 # plot the correction term (* norm constant) in dashed green
 # should make norm constant just be 1, not depend on binning of data
 poly = wks["poly"]
 if poly:
-    poly.plotOn(frame, LineColor=ROOT.kGreen, LineStyle=ROOT.kDashed)
+    poly.plotOn(frame, LineColor="g", LineStyle="--")
 
 # this is a switch to check the sampling distribution
 # of -2 log LR for two comparisons:

--- a/tutorials/roostats/rs_bernsteinCorrection.py
+++ b/tutorials/roostats/rs_bernsteinCorrection.py
@@ -1,0 +1,126 @@
+## \file
+## \ingroup tutorial_roostats
+## \notebook -js
+## Example of the BernsteinCorrection utility in RooStats.
+##
+## The idea is that one has a distribution coming either from data or Monte Carlo
+## (called "reality" in the macro) and a nominal model that is not sufficiently
+## flexible to take into account the real distribution.  One wants to take into
+## account the systematic associated with this imperfect modeling by augmenting
+## the nominal model with some correction term (in this case a polynomial).
+## The BernsteinCorrection utility will import into your workspace a corrected model
+## given by nominal(x) * poly_N(x), where poly_N is an n-th order polynomial in
+## the Bernstein basis.  The degree N of the polynomial is chosen by specifying the tolerance
+## one has in adding an extra term to the polynomial.
+## The Bernstein basis is nice because it only has positive-definite terms
+## and works well with PDFs.
+## Finally, the macro makes a plot of:
+##  - the data (drawn from 'reality'),
+##  - the best fit of the nominal model (blue)
+##  - and the best fit corrected model.
+##
+## \macro_image
+## \macro_output
+## \macro_code
+##
+## \date June 2022
+## \authors Artem Busorgin, Kyle Cranmer (C++ version)
+
+import sys
+import ROOT
+
+# set range of observable
+lowRange = -1
+highRange = 5
+
+# make a RooRealVar for the observable
+x = ROOT.RooRealVar("x", "x", lowRange, highRange)
+
+# true model
+narrow = ROOT.RooGaussian("narrow", "", x, ROOT.RooFit.RooConst(0.0), ROOT.RooFit.RooConst(0.8))
+wide = ROOT.RooGaussian("wide", "", x, ROOT.RooFit.RooConst(0.0), ROOT.RooFit.RooConst(2.0))
+reality = ROOT.RooAddPdf("reality", "", [narrow, wide], ROOT.RooFit.RooConst(0.8))
+
+data = reality.generate(x, 1000)
+
+# nominal model
+sigma = ROOT.RooRealVar("sigma", "", 1.0, 0, 10)
+nominal = ROOT.RooGaussian("nominal", "", x, ROOT.RooFit.RooConst(0.0), sigma)
+
+wks = ROOT.RooWorkspace("myWorksspace")
+
+wks.Import(data, Rename="data")
+wks.Import(nominal)
+
+if ROOT.TClass.GetClass("ROOT::Minuit2::Minuit2Minimizer"):
+    # use Minuit2 if ROOT was built with support for it:
+    ROOT.Math.MinimizerOptions.SetDefaultMinimizer("Minuit2")
+
+# The tolerance sets the probability to add an unnecessary term.
+# lower tolerance will add fewer terms, while higher tolerance
+# will add more terms and provide a more flexible function.
+tolerance = 0.05
+bernsteinCorrection = ROOT.RooStats.BernsteinCorrection(tolerance)
+degree = bernsteinCorrection.ImportCorrectedPdf(wks, "nominal", "x", "data")
+
+if degree < 0:
+    ROOT.Error("rs_bernsteinCorrection", "Bernstein correction failed !")
+    sys.exit()
+
+print("Correction based on Bernstein Poly of degree ", degree)
+
+frame = x.frame()
+data.plotOn(frame)
+# plot the best fit nominal model in blue
+minimType = ROOT.Math.MinimizerOptions.DefaultMinimizerType()
+nominal.fitTo(data, PrintLevel=0, Minimizer=minimType)
+nominal.plotOn(frame)
+
+# plot the best fit corrected model in red
+corrected = wks.pdf("corrected")
+if not corrected:
+    sys.exit()
+
+# fit corrected model
+corrected.fitTo(data, PrintLevel=0, Minimizer=minimType)
+corrected.plotOn(frame, LineColor=ROOT.kRed)
+
+# plot the correction term (* norm constant) in dashed green
+# should make norm constant just be 1, not depend on binning of data
+poly = wks.pdf("poly")
+if poly:
+    poly.plotOn(frame, LineColor=ROOT.kGreen, LineStyle=ROOT.kDashed)
+
+# this is a switch to check the sampling distribution
+# of -2 log LR for two comparisons:
+# the first is for n-1 vs. n degree polynomial corrections
+# the second is for n vs. n+1 degree polynomial corrections
+# Here we choose n to be the one chosen by the tolerance
+# criterion above, eg. n = "degree" in the code.
+# Setting this to true is takes about 10 min.
+checkSamplingDist = True
+numToyMC = 20  # increase this value for sensible results
+
+c1 = ROOT.TCanvas()
+if checkSamplingDist:
+    c1.Divide(1, 2)
+    c1.cd(1)
+
+frame.Draw()
+ROOT.gPad.Update()
+
+if checkSamplingDist:
+    # check sampling dist
+    ROOT.Math.MinimizerOptions.SetDefaultPrintLevel(-1)
+    samplingDist = ROOT.TH1F("samplingDist", "", 20, 0, 10)
+    samplingDistExtra = ROOT.TH1F("samplingDistExtra", "", 20, 0, 10)
+    bernsteinCorrection.CreateQSamplingDist(
+        wks, "nominal", "x", "data", samplingDist, samplingDistExtra, degree, numToyMC
+    )
+
+    c1.cd(2)
+    samplingDistExtra.SetLineColor(ROOT.kRed)
+    samplingDistExtra.Draw()
+    samplingDist.Draw("same")
+
+c1.SaveAs("rs_bernsteinCorrection.png")


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
These new tutorial translations are added:
  * tutorials/roostats/FourBinInstructional.py
  * tutorials/roostats/MultivariateGaussianTest.py
  * tutorials/roostats/Zbi_Zgamma.py
  * tutorials/roostats/rs601_HLFactoryexample.py
  * tutorials/roostats/rs701_BayesianCalculator.py
  * tutorials/roostats/rs_bernsteinCorrection.py

## Checklist:

- [x] tested changes locally
- [x] Formatted with black --line-length=120 <tutorial file>.py

This PR is a partial fix for #8758
