### PR TITLE
[RF] Fix wrong fit and improve rf212_plottingInRanges_blinding tutorial

### DIFF
--- a/tutorials/roofit/rf212_plottingInRanges_blinding.C
+++ b/tutorials/roofit/rf212_plottingInRanges_blinding.C
@@ -32,7 +32,7 @@ void rf212_plottingInRanges_blinding()
   // Make a fit model
   RooRealVar x("x", "The observable", 1, 30);
   RooRealVar tau("tau", "The exponent", -0.1337, -10., -0.1);
-  RooExponential exp("exp", "A falling exponential function", x, tau);
+  RooExponential expo("expo", "A falling exponential function", x, tau);
 
   // Define the sidebands (e.g. background regions)
   x.setRange("full", 1, 30);
@@ -40,13 +40,21 @@ void rf212_plottingInRanges_blinding()
   x.setRange("right", 20, 30);
 
   // Generate toy data, and cut out the blinded region.
-  RooDataSet* data = exp.generate(x, 1000);
-  auto blindedData = data->reduce(CutRange("left,right"));
+  std::unique_ptr<RooDataSet> data{expo.generate(x, 1000)};
+  std::unique_ptr<RooAbsData> blindedData{data->reduce(CutRange("left,right"))};
 
   // Kick tau a bit, and run an unbinned fit where the blinded data are missing.
   // ----------------------------------------------------------------------------------------------------------
+  // The fit should be done only in the unblinded regions, otherwise it would
+  // try to make the model adapt to the empty bins in the blinded region.
   tau.setVal(-2.);
-  exp.fitTo(*blindedData);
+  expo.fitTo(*blindedData, Range("left,right"));
+
+  // Clear the "fitrange" attribute of the PDF. Otherwise, the fitrange would
+  // be automatically taken as the NormRange() for plotting. We want to avoid
+  // this, because the point of this tutorial is to show what can go wrong when
+  // the NormRange() is not specified.
+  expo.setStringAttribute("fitrange", nullptr);
 
 
   // Here we will plot the results
@@ -55,10 +63,10 @@ void rf212_plottingInRanges_blinding()
 
 
   // Wrong:
+  // ----------------------------------------------------------------------------------------------------------
   // Plotting each slice on its own normalises the PDF over its plotting range. For the full curve, that means
   // that the blinded region where data is missing is included in the normalisation calculation. The PDF therefore
   // comes out too low, and doesn't match up with the slices in the side bands, which are normalised to "their" data.
-  // ----------------------------------------------------------------------------------------------------------
 
   std::cout << "Now plotting with unique normalisation for each slice." << std::endl;
   canvas->cd(1);
@@ -66,18 +74,18 @@ void rf212_plottingInRanges_blinding()
 
   // Plot only the blinded data, and then plot the PDF over the full range as well as both sidebands
   blindedData->plotOn(plotFrame);
-  exp.plotOn(plotFrame, LineColor(kRed),   Range("full"));
-  exp.plotOn(plotFrame, LineColor(kBlue),  Range("left"));
-  exp.plotOn(plotFrame, LineColor(kGreen), Range("right"));
+  expo.plotOn(plotFrame, LineColor(kRed),   Range("full"));
+  expo.plotOn(plotFrame, LineColor(kBlue),  Range("left"));
+  expo.plotOn(plotFrame, LineColor(kGreen), Range("right"));
 
   plotFrame->Draw();
 
   // Right:
+  // ----------------------------------------------------------------------------------------------------------
   // Make the same plot, but normalise each piece with respect to the regions "left" AND "right". This requires setting
   // a "NormRange", which tells RooFit over which range the PDF has to be integrated to normalise.
-  // This is means that the normalisation of the blue and green curves is slightly different from the left plot,
+  // This means that the normalisation of the blue and green curves is slightly different from the left plot,
   // because they get a common scale factor.
-  // ----------------------------------------------------------------------------------------------------------
 
   std::cout << "\n\nNow plotting with correct norm ranges:" << std::endl;
   canvas->cd(2);
@@ -85,9 +93,9 @@ void rf212_plottingInRanges_blinding()
 
   // Plot only the blinded data, and then plot the PDF over the full range as well as both sidebands
   blindedData->plotOn(plotFrameWithNormRange);
-  exp.plotOn(plotFrameWithNormRange, LineColor(kBlue),  Range("left"),  RooFit::NormRange("left,right"));
-  exp.plotOn(plotFrameWithNormRange, LineColor(kGreen), Range("right"), RooFit::NormRange("left,right"));
-  exp.plotOn(plotFrameWithNormRange, LineColor(kRed),   Range("full"),  RooFit::NormRange("left,right"), LineStyle(10));
+  expo.plotOn(plotFrameWithNormRange, LineColor(kBlue),  Range("left"),  RooFit::NormRange("left,right"));
+  expo.plotOn(plotFrameWithNormRange, LineColor(kGreen), Range("right"), RooFit::NormRange("left,right"));
+  expo.plotOn(plotFrameWithNormRange, LineColor(kRed),   Range("full"),  RooFit::NormRange("left,right"), LineStyle(10));
 
   plotFrameWithNormRange->Draw();
 

--- a/tutorials/roofit/rf212_plottingInRanges_blinding.py
+++ b/tutorials/roofit/rf212_plottingInRanges_blinding.py
@@ -20,7 +20,7 @@ import ROOT
 # Make a fit model
 x = ROOT.RooRealVar("x", "The observable", 1, 30)
 tau = ROOT.RooRealVar("tau", "The exponent", -0.1337, -10.0, -0.1)
-exp = ROOT.RooExponential("exp", "A falling exponential function", x, tau)
+expo = ROOT.RooExponential("expo", "A falling exponential function", x, tau)
 
 # Define the sidebands (e.g. background regions)
 x.setRange("full", 1, 30)
@@ -28,13 +28,23 @@ x.setRange("left", 1, 10)
 x.setRange("right", 20, 30)
 
 # Generate toy data, and cut out the blinded region.
-data = exp.generate(x, 1000)
+data = expo.generate(x, 1000)
 blindedData = data.reduce(CutRange="left,right")
 
 # Kick tau a bit, and run an unbinned fit where the blinded data are missing.
 # ----------------------------------------------------------------------------------------------------------
+# The fit should be done only in the unblinded regions, otherwise it would try
+# to make the model adapt to the empty bins in the blinded region.
 tau.setVal(-2.0)
-exp.fitTo(blindedData)
+expo.fitTo(blindedData, Range="left,right")
+
+# Clear the "fitrange" attribute of the PDF. Otherwise, the fitrange would be
+# automatically taken as the NormRange() for plotting. We want to avoid this,
+# because the point of this tutorial is to show what can go wrong when the
+# NormRange() is not specified.
+# TODO: this should work in PyROOT directly.
+ROOT.gInterpreter.Declare('void resetFitrange(RooAbsArg& arg) { arg.setStringAttribute("fitrange", nullptr); } ')
+ROOT.resetFitrange(expo);
 
 
 # Here we will plot the results
@@ -43,10 +53,10 @@ canvas.Divide(2, 1)
 
 
 # Wrong:
+# ----------------------------------------------------------------------------------------------------------
 # Plotting each slice on its own normalises the PDF over its plotting range. For the full curve, that means
 # that the blinded region where data is missing is included in the normalisation calculation. The PDF therefore
 # comes out too low, and doesn't match up with the slices in the side bands, which are normalised to "their" data.
-# ----------------------------------------------------------------------------------------------------------
 
 print("Now plotting with unique normalisation for each slice.\n")
 canvas.cd(1)
@@ -54,18 +64,18 @@ plotFrame = x.frame(Title="Wrong: Each slice normalised over its plotting range"
 
 # Plot only the blinded data, and then plot the PDF over the full range as well as both sidebands
 blindedData.plotOn(plotFrame)
-exp.plotOn(plotFrame, LineColor="r", Range="full")
-exp.plotOn(plotFrame, LineColor="b", Range="left")
-exp.plotOn(plotFrame, LineColor="g", Range="right")
+expo.plotOn(plotFrame, LineColor="r", Range="full")
+expo.plotOn(plotFrame, LineColor="b", Range="left")
+expo.plotOn(plotFrame, LineColor="g", Range="right")
 
 plotFrame.Draw()
 
 # Right:
+# ----------------------------------------------------------------------------------------------------------
 # Make the same plot, but normalise each piece with respect to the regions "left" AND "right". This requires setting
 # a "NormRange", which tells RooFit over which range the PDF has to be integrated to normalise.
-# This is means that the normalisation of the blue and green curves is slightly different from the left plot,
+# This means that the normalisation of the blue and green curves is slightly different from the left plot,
 # because they get a common scale factor.
-# ----------------------------------------------------------------------------------------------------------
 
 print("\n\nNow plotting with correct norm ranges:\n")
 canvas.cd(2)
@@ -73,9 +83,9 @@ plotFrameWithNormRange = x.frame(Title="Right: All slices have common normalisat
 
 # Plot only the blinded data, and then plot the PDF over the full range as well as both sidebands
 blindedData.plotOn(plotFrameWithNormRange)
-exp.plotOn(plotFrameWithNormRange, LineColor="b", Range="left", NormRange="left,right")
-exp.plotOn(plotFrameWithNormRange, LineColor="g", Range="right", NormRange="left,right")
-exp.plotOn(plotFrameWithNormRange, LineColor="r", Range="full", NormRange="left,right", LineStyle=10)
+expo.plotOn(plotFrameWithNormRange, LineColor="b", Range="left", NormRange="left,right")
+expo.plotOn(plotFrameWithNormRange, LineColor="g", Range="right", NormRange="left,right")
+expo.plotOn(plotFrameWithNormRange, LineColor="r", Range="full", NormRange="left,right", LineStyle=10)
 
 plotFrameWithNormRange.Draw()
 


### PR DESCRIPTION
Sone changes are made to both the Python and C++ version of the
`rf212_plottingInRanges_blinding` tutorial:

  * move around the `-----` that denote section headers to fix the
    notebook formatting
  * rename `exp` to `expo` to avoid an ambiguity error because of
    `std::expr` in C++ tutorial notebook
  * use `std::unique_ptr` to avoid leaking of datasets

In particular, the call to `fitTo` includes now the
`Range("left,right")` command argument. Otherthise, the fit would also
try to make the model adapt to the empty bins in the blinded region,
giving a wrong fit result (it can be easily seen that the fit was wrong
before by increasing the number of events in the toy dataset to 100k).

To avoid that the plotting takes the (now correct) fit range as
`NormRange()` and we can't show what happens if the normalization range
is not set, the `fitrange` string attribute is reset after fitting.
