### PR TITLE
[RF] Support weighted datasets in RooKeysPdf

### DIFF
--- a/roofit/roofit/src/RooKeysPdf.cxx
+++ b/roofit/roofit/src/RooKeysPdf.cxx
@@ -224,13 +224,13 @@ void RooKeysPdf::LoadDataSet( RooDataSet& data) {
 
   double meanv=x1/x0;
   double sigmav=std::sqrt(x2/x0-meanv*meanv);
-  double h=std::pow(double(4)/double(3),0.2)*std::pow(_nEvents,-0.2)*_rho;
+  double h=std::pow(double(4)/double(3),0.2)*std::pow(_sumWgt,-0.2)*_rho;
   double hmin=h*sigmav*std::sqrt(2.)/10;
-  double norm=h*std::sqrt(sigmav)/(2.0*std::sqrt(3.0));
+  double norm=h*std::sqrt(sigmav * _sumWgt)/(2.0*std::sqrt(3.0));
 
   _weights=new double[_nEvents];
   for(Int_t j=0;j<_nEvents;++j) {
-    _weights[j]=norm/std::sqrt(g(_dataPts[j],h*sigmav));
+    _weights[j] = norm / std::sqrt(_dataWgts[j] * g(_dataPts[j],h*sigmav));
     if (_weights[j]<hmin) _weights[j]=hmin;
   }
 
@@ -403,5 +403,5 @@ double RooKeysPdf::g(double x,double sigmav) const {
   }
 
   static const double sqrt2pi(std::sqrt(2*TMath::Pi()));
-  return y/(sigmav*sqrt2pi*_nEvents);
+  return y/(sigmav*sqrt2pi);
 }

--- a/roofit/roofit/test/CMakeLists.txt
+++ b/roofit/roofit/test/CMakeLists.txt
@@ -11,6 +11,7 @@ ROOT_ADD_GTEST(testRooPoisson testRooPoisson.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooBernstein testRooBernstein.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooCrystalBall testRooCrystalBall.cxx LIBRARIES Gpad RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooJohnson testRooJohnson.cxx LIBRARIES Gpad RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooKeysPdf testRooKeysPdf.cxx LIBRARIES Gpad RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooParamHistFunc testRooParamHistFunc.cxx LIBRARIES Gpad RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooExponential testRooExponential.cxx
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/exponentialPdf.root

--- a/roofit/roofit/test/testRooKeysPdf.cxx
+++ b/roofit/roofit/test/testRooKeysPdf.cxx
@@ -1,0 +1,56 @@
+// Tests for the RooKeysPdf and friends
+// Authors: Jonas Rembser, CERN  07/2022
+
+#include <RooRealVar.h>
+#include <RooKeysPdf.h>
+#include <RooNDKeysPdf.h>
+
+#include "gtest/gtest.h"
+
+// Test the support of RooKeysPdf and RooNDKeysPdf for weighted datasets.
+TEST(RooKeysPdf, WeightedDataset)
+{
+   // We create data with 100 events at x = 5 and 400 events at x = 15. One
+   // version will have 500 unweighted entries, the other will have only 2
+   // entries with the weights 100 and 400 to represent the same data. The
+   // resulting RooKeysPdfs should be identical for both datasets. Checking
+   // this validates that dataset weights are correctly dealt with.
+
+   RooRealVar x("x", "x", 0, 20);
+   RooRealVar weight("weight", "weight", 0, 2000);
+
+   const std::size_t nEvents0 = 100;
+   const std::size_t nEvents1 = 400;
+
+   RooDataSet data1{"data1", "data1", x};
+   RooDataSet data2{"data2", "data2", {x, weight}, "weight"};
+
+   x.setVal(5);
+   for (std::size_t i = 0; i < nEvents0; ++i) {
+      data1.add(x, 1.0);
+   }
+   data2.add(x, double(nEvents0));
+   x.setVal(15);
+   for (std::size_t i = 0; i < nEvents1; ++i) {
+      data1.add(x, 1.0);
+   }
+   data2.add(x, double(nEvents1));
+
+   // Creating RooKeysPdf and RooNDKeysPdf with adaptive kernel and no
+   // mirroring for both weighted and unweighted datasets.
+   RooKeysPdf kest1("kest1", "kest1", x, data1, RooKeysPdf::NoMirror);
+   RooKeysPdf kest2("kest2", "kest2", x, data2, RooKeysPdf::NoMirror);
+   RooNDKeysPdf kestND1("kestND1", "kestND1", x, data1, "a");
+   RooNDKeysPdf kestND2("kestND2", "kestND2", x, data2, "a");
+
+   RooArgSet normSet{x};
+
+   // Check if values for the unweighted and weighted datasets are the same
+   double xVal = x.getMin();
+   while (xVal < x.getMax()) {
+      EXPECT_FLOAT_EQ(kest1.getVal(normSet), kest2.getVal(normSet));
+      EXPECT_FLOAT_EQ(kestND1.getVal(normSet), kestND2.getVal(normSet));
+      x.setVal(xVal);
+      xVal += 0.1;
+   }
+}


### PR DESCRIPTION
So far, a `RooKeysPdf` produced wrong kernel estimations for weighted
datasets, as sometimes the number of entries was used in place of the
sum of weights. This is fixed now. Also, the normalization by the sum of
weights is moved from the private `RooKeysPdf::g()` function that is
called for each event to the global normalization constant.

A new unit test that checks if weighted datasets are correctly handled
by both the RooKeysPdf and the RooNDKeysPdf is also implemented.