### PR TITLE
[RF] New `RooAbsArg::removeStringAttribute(const char* key)` method

### DIFF
--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -362,6 +362,7 @@ public:
   }
 
   void setStringAttribute(const Text_t* key, const Text_t* value) ;
+  void removeStringAttribute(const Text_t* key) ;
   const Text_t* getStringAttribute(const Text_t* key) const ;
   inline const std::map<std::string,std::string>& stringAttributes() const {
     // Returns std::map<string,string> with all string attributes defined

--- a/roofit/roofitcore/src/NormalizationHelpers.cxx
+++ b/roofit/roofitcore/src/NormalizationHelpers.cxx
@@ -317,7 +317,7 @@ void foldIntegrals(RooAbsArg const &topNode, RooArgSet &replacedArgs)
 
          pdf->setAttribute((std::string("ORIGNAME:") + normalizedPdf->GetName()).c_str(), false);
 
-         normalizedPdf->setStringAttribute("_replaced_arg", nullptr);
+         normalizedPdf->removeStringAttribute("_replaced_arg");
       }
    }
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -312,8 +312,16 @@ void RooAbsArg::setStringAttribute(const Text_t* key, const Text_t* value)
   if (value) {
     _stringAttrib[key] = value ;
   } else {
-    _stringAttrib.erase(key) ;
+    removeStringAttribute(key);
   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Delete a string attribute with a given key.
+
+void RooAbsArg::removeStringAttribute(const Text_t* key)
+{
+  _stringAttrib.erase(key) ;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1055,7 +1055,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
   }
 
   // Clear possible range attributes from previous fits.
-  setStringAttribute("fitrange", nullptr);
+  removeStringAttribute("fitrange");
 
   if (pc.hasProcessed("Range")) {
     double rangeLo = pc.getDouble("rangeLo") ;
@@ -1740,7 +1740,7 @@ RooAbsReal* RooAbsPdf::createChi2(RooDataHist& data, const RooCmdArg& arg1,  con
   string baseName = Form("chi2_%s_%s",GetName(),data.GetName()) ;
 
   // Clear possible range attributes from previous fits.
-  setStringAttribute("fitrange", nullptr);
+  removeStringAttribute("fitrange");
 
   if (!rangeName || strchr(rangeName,',')==0) {
     // Simple case: default range, or single restricted range
@@ -2704,7 +2704,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
     coutI(Plotting) << "RooAbsPdf::plotOn(" << GetName() << ") p.d.f was fitted in a subrange and no explicit "
           << (plotRange?"Range()":"") << ((plotRange&&normRange2)?" and ":"")
           << (normRange2?"NormRange()":"") << " was specified. Plotting / normalising in fit range. To override, do one of the following"
-          << "\n\t- Clear the automatic fit range attribute: <pdf>.setStringAttribute(\"fitrange\", nullptr);"
+          << "\n\t- Clear the automatic fit range attribute: <pdf>.removeStringAttribute(\"fitrange\");"
           << "\n\t- Explicitly specify the plotting range: Range(\"<rangeName>\")."
           << "\n\t- Explicitly specify where to compute the normalisation: NormRange(\"<rangeName>\")."
           << "\n\tThe default (full) range can be denoted with Range(\"\") / NormRange(\"\")."<< endl ;

--- a/roofit/roofitcore/src/RooCustomizer.cxx
+++ b/roofit/roofitcore/src/RooCustomizer.cxx
@@ -481,7 +481,7 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
 
    // Create a new clone
    RooAbsArg* clone = (RooAbsArg*) node->Clone(newName.Data()) ;
-   clone->setStringAttribute("factory_tag",0) ;
+   clone->removeStringAttribute("factory_tag") ;
    clone->SetTitle(newTitle) ;
 
    // Affix attribute with old name to clone to support name changing server redirect
@@ -572,7 +572,7 @@ RooAbsArg* RooCustomizer::doBuild(const char* masterCatState, bool verbose)
 
     // Affix attribute with old name to clone to support name changing server redirect
     RooAbsArg* clone = (RooAbsArg*) branch->Clone(newName.Data()) ;
-    clone->setStringAttribute("factory_tag",0) ;
+    clone->removeStringAttribute("factory_tag") ;
     TString nameAttrib("ORIGNAME:") ;
     nameAttrib.Append(branch->GetName()) ;
     clone->setAttribute(nameAttrib) ;

--- a/tutorials/roofit/rf212_plottingInRanges_blinding.C
+++ b/tutorials/roofit/rf212_plottingInRanges_blinding.C
@@ -54,7 +54,7 @@ void rf212_plottingInRanges_blinding()
   // be automatically taken as the NormRange() for plotting. We want to avoid
   // this, because the point of this tutorial is to show what can go wrong when
   // the NormRange() is not specified.
-  expo.setStringAttribute("fitrange", nullptr);
+  expo.removeStringAttribute("fitrange");
 
 
   // Here we will plot the results

--- a/tutorials/roofit/rf212_plottingInRanges_blinding.py
+++ b/tutorials/roofit/rf212_plottingInRanges_blinding.py
@@ -42,9 +42,7 @@ expo.fitTo(blindedData, Range="left,right")
 # automatically taken as the NormRange() for plotting. We want to avoid this,
 # because the point of this tutorial is to show what can go wrong when the
 # NormRange() is not specified.
-# TODO: this should work in PyROOT directly.
-ROOT.gInterpreter.Declare('void resetFitrange(RooAbsArg& arg) { arg.setStringAttribute("fitrange", nullptr); } ')
-ROOT.resetFitrange(expo);
+expo.removeStringAttribute("fitrange");
 
 
 # Here we will plot the results


### PR DESCRIPTION
So far, one had to remove string attributes of a RooAbsArg with the
`RooAbsArg::removeStringAttribute(const char* key, const char* value)`
method, passing `nullptr` as a value. Passing a `nullptr` to a function
that takes a `const char*` is not supported in PyROOT, as explained in
GitHub issue #10954. Therefore, a new function is added to RooAbsArg to
remove a string attribute without having to use `nullptr`.

This new function called `removeStringAttribute()` is now used in all
the ROOT code to remove string attributes from RooAbsArgs, and also
mentioned in the warnings that tell the user that they might want to
remove the `fitrange` attribute.

The verb `remove` was chosen instead of `delete`, `clear`, or `erase`,
because there was already a `RooAbsArg::removeServer()` method.