### PR TITLE
[RF] Speed up integral creation for large computation graphs

### DIFF
--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -2229,6 +2229,13 @@ RooAbsArg* RooAbsArg::cloneTree(const char* newname) const
   RooAbsArg* head = clonedNodes.find(*this) ;
   assert(head);
 
+  // We better to release the ownership before removing the "head". Otherwise,
+  // "head" might also be deleted as the clonedNodes collection owns it.
+  // (Actually this does not happen because even an owning collection doesn't
+  // delete the element when removed by pointer lookup, but it's better not to
+  // rely on this unexpected fact).
+  clonedNodes.releaseOwnership();
+
   // Remove the head node from the cloneSet
   // To release it from the set ownership
   clonedNodes.remove(*head) ;


### PR DESCRIPTION
In the `RooRealIntegral` constructor, there was a `O(N^2)` operation on
the computation graph, checking the dependency of the top-level function
on each other node. This is very expensive in the numer of RooAbsArgs N
is large. Instead of calling `dependsOnValue` for each leaf node, which is
very expensive because it's a recursive function, the value server
leaves are all put in a RooArgSet before the leaf iteration to check
quickly if a leaf is also a value server.

This change speeds up the `createNLL` step of large models like the
ATLAS Higgs combination by at least a factor of two or three.

In the same PR, I also bring a little other commit, where the ownership of the `cloneSet` in `cloneTree` is released before removing the top node element, in order to avoid ownership ambiguities.

