### PR TITLE
[cling-cpt] Added skip-cleanup flags for check-requirements and create-dev-env [skip-ci]

### DIFF
--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -1975,7 +1975,6 @@ if args['with_llvm_tar']:
     tar_required = True
 
 if args['check_requirements']:
-    args['skip_cleanup'] = True
     llvm_binary_name = ""
     box_draw('Check availability of required softwares')
     if DIST == 'Ubuntu':

--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -1975,6 +1975,7 @@ if args['with_llvm_tar']:
     tar_required = True
 
 if args['check_requirements']:
+    args['skip_cleanup'] = True
     llvm_binary_name = ""
     box_draw('Check availability of required softwares')
     if DIST == 'Ubuntu':
@@ -2449,7 +2450,7 @@ if args['create_dev_env']:
     fetch_llvm(llvm_revision)
     fetch_clang(llvm_revision)
     fetch_cling('master')
-
+    args['skip_cleanup'] = True
     set_version()
     if OS == 'Windows':
         get_win_dep()


### PR DESCRIPTION
# This Pull request: Set skip-cleanup flags to true for check-requirements and create-dev-env

## Changes or fixes: Set the skip-cleanup value to true for the create-dev-env option and check-requirements option


## Checklist:

- [X] tested changes locally
- [NA] updated the docs (if necessary)

This PR fixes issue in meta-issue list #406 (https://github.com/root-project/cling/issues/406)

