### PR TITLE
[core] Replace `sprintnf` calls with `snprintf` in ROOT core

### DIFF
--- a/core/base/src/TTimeStamp.cxx
+++ b/core/base/src/TTimeStamp.cxx
@@ -271,9 +271,10 @@ Double_t TTimeStamp::AsLAST(Double_t Longitude, Double_t UT1Offset) const
 const Char_t *TTimeStamp::AsString(Option_t *option) const
 {
    const Int_t nbuffers = 8;     // # of buffers
+   constexpr std::size_t bufferSize = 64;
 
-   static Char_t formatted[nbuffers][64];  // strftime fields substituted
-   static Char_t formatted2[nbuffers][64]; // nanosec field substituted
+   static Char_t formatted[nbuffers][bufferSize];  // strftime fields substituted
+   static Char_t formatted2[nbuffers][bufferSize]; // nanosec field substituted
 
    static Int_t ibuffer = nbuffers;
 
@@ -286,7 +287,7 @@ const Char_t *TTimeStamp::AsString(Option_t *option) const
 
    if (opt.Contains("2")) {
       // return string formatted as integer {sec,nsec}
-      sprintf(formatted[ibuffer], "{%d,%d}", fSec, fNanoSec);
+      snprintf(formatted[ibuffer], bufferSize, "{%d,%d}", fSec, fNanoSec);
       return formatted[ibuffer];
    }
 
@@ -332,7 +333,7 @@ const Char_t *TTimeStamp::AsString(Option_t *option) const
    // hack in the nsec part
    Char_t *ptr = strrchr(formatted[ibuffer], '#');
    if (ptr) *ptr = '%';    // substitute % for #
-   sprintf(formatted2[ibuffer], formatted[ibuffer], fNanoSec);
+   snprintf(formatted2[ibuffer], bufferSize, formatted[ibuffer], fNanoSec);
 
    return formatted2[ibuffer];
 }

--- a/core/base/src/TUri.cxx
+++ b/core/base/src/TUri.cxx
@@ -824,7 +824,7 @@ const TString TUri::PctEncode(const TString &source)
          // reserved character -> encode to 2 digit hex
          // preceded by '%'
          char buffer[4];
-         sprintf(buffer, "%%%02X", source[i]);
+         snprintf(buffer, 4, "%%%02X", source[i]);
          sink = sink + buffer;
       }
    }

--- a/core/base/src/TUrl.cxx
+++ b/core/base/src/TUrl.cxx
@@ -195,8 +195,9 @@ tryfile:
       // allow url of form: "proto://"
    } else {
       if (defaultIsFile) {
-         char *newu = new char [strlen("file:") + strlen(u0) + 1];
-         sprintf(newu, "file:%s", u0);
+         const std::size_t bufferSize = strlen("file:") + strlen(u0) + 1;
+         char *newu = new char [bufferSize];
+         snprintf(newu, bufferSize, "file:%s", u0);
          delete [] u0;
          u0 = newu;
          goto tryfile;
@@ -446,7 +447,7 @@ const char *TUrl::GetUrl(Bool_t withDeflt) const
 
       if (!deflt || withDeflt) {
          char p[10];
-         sprintf(p, "%d", fPort);
+         snprintf(p, 10, "%d", fPort);
          fUrl = fUrl + fHost + ":" + p + "/" + fFile;
       } else
          fUrl = fUrl + fHost + "/" + fFile;

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -983,8 +983,9 @@ again:
       goto again;
    }
    if (level >= kSysError && level < kFatal) {
-      char *buf1 = new char[buf_size + strlen(gSystem->GetError()) + 5];
-      sprintf(buf1, "%s (%s)", buf, gSystem->GetError());
+      const std::size_t bufferSize = buf_size + strlen(gSystem->GetError()) + 5;
+      char *buf1 = new char[bufferSize];
+      snprintf(buf1, bufferSize, "%s (%s)", buf, gSystem->GetError());
       bp = buf1;
       delete [] buf;
    } else
@@ -1015,11 +1016,13 @@ void TThread::DoError(int level, const char *location, const char *fmt,
    char *loc = 0;
 
    if (location) {
-      loc = new char[strlen(location) + strlen(GetName()) + 32];
-      sprintf(loc, "%s %s:0x%lx", location, GetName(), fId);
+      const std::size_t bufferSize = strlen(location) + strlen(GetName()) + 32;
+      loc = new char[bufferSize];
+      snprintf(loc, bufferSize, "%s %s:0x%lx", location, GetName(), fId);
    } else {
-      loc = new char[strlen(GetName()) + 32];
-      sprintf(loc, "%s:0x%lx", GetName(), fId);
+      const std::size_t bufferSize = strlen(GetName()) + 32;
+      loc = new char[bufferSize];
+      snprintf(loc, bufferSize, "%s:0x%lx", GetName(), fId);
    }
 
    ErrorHandler(level, loc, fmt, va);


### PR DESCRIPTION
This is to suppress the warnings we see now in the nightlies on the
macbeta nodes:

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=macbeta,SPEC=cxx17,V=master/lastBuild/parsed_console/