### PR TITLE
Revert "Avoid dupe "llvm.ident" operands."

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -5553,9 +5553,6 @@ void CodeGenFunction::EmitDeclMetadata() {
 void CodeGenModule::EmitVersionIdentMetadata() {
   llvm::NamedMDNode *IdentMetadata =
     TheModule.getOrInsertNamedMetadata("llvm.ident");
-  if (IdentMetadata->getNumOperands() > 0)
-    return;
-
   std::string Version = getClangFullVersion();
   llvm::LLVMContext &Ctx = TheModule.getContext();
 


### PR DESCRIPTION
This patch was developed as part of an llvm upgrade in 2015. This patch is not needed anymore considering that the LLVM JIT has advanced significantly.
