### PR TITLE
Try to completely remove identifiers that are namespace in the GMI

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -1135,11 +1135,11 @@ static GlobalModuleIndex *loadGlobalModuleIndex(cling::Interpreter &interp)
                if (TagDecl *TD = llvm::dyn_cast<TagDecl>(ND)) {
                   if (TD->isCompleteDefinition())
                      Register(TD);
-               } else if (NamespaceDecl *NSD = llvm::dyn_cast<NamespaceDecl>(ND)) {
-                  Register(NSD, /*AddSingleEntry=*/ false);
                }
                else if (TypedefNameDecl *TND = dyn_cast<TypedefNameDecl>(ND))
                   Register(TND);
+               else if (isa<FunctionDecl>(ND) && !isa<CXXMethodDecl>(ND))
+                  Register(ND);
                // FIXME: Add the rest...
                return true; // continue decending
             }


### PR DESCRIPTION
This patch is to verify if we really need to store identifiers that
are namespace in GlobalModuleIndex, which greatly increase the maximum
memory pressure. Send this to trigger ROOT's CI so we can have a full
test, and will be closed if the direction is wrong.

**No need for code review or merge**

Signed-off-by: Jun Zhang <jun@junz.org>

