### PR TITLE
Fix typos in tutorials

### DIFF
--- a/tutorials/eve/histobrowser.C
+++ b/tutorials/eve/histobrowser.C
@@ -1,6 +1,6 @@
 /// \file
 /// \ingroup tutorial_eve
-/// Demonstates how to use EVE as a histogram browser.
+/// Demonstrates how to use EVE as a histogram browser.
 ///
 /// \image html eve_histobrowser.png
 /// \macro_code

--- a/tutorials/fft/FFT.C
+++ b/tutorials/fft/FFT.C
@@ -191,7 +191,7 @@ void FFT()
    c1_5->cd();
    TH1 *hr = 0;
    hr = TH1::TransformHisto(fft_own, hr, "RE");
-   hr->SetTitle("Real part of the 3rd (array) tranfsorm");
+   hr->SetTitle("Real part of the 3rd (array) transform");
    hr->Draw();
    hr->SetStats(kFALSE);
    hr->GetXaxis()->SetLabelSize(0.05);

--- a/tutorials/fit/fitLinear.C
+++ b/tutorials/fit/fitLinear.C
@@ -37,7 +37,7 @@ void fitLinear()
    gre3->Draw("a*");
    //Fit the graph with the predefined "pol3" function
    gre3->Fit("pol3");
-   //Access the fit resuts
+   //Access the fit results
    TF1 *f3 = gre3->GetFunction("pol3");
    f3->SetLineWidth(1);
 

--- a/tutorials/fit/langaus.C
+++ b/tutorials/fit/langaus.C
@@ -137,7 +137,7 @@ TF1 *langaufit(TH1F *his, double *fitrange, double *startvalues, double *parlimi
 
 int langaupro(double *params, double &maxx, double &FWHM) {
 
-   // Seaches for the location (x value) at the maximum of the
+   // Searches for the location (x value) at the maximum of the
    // Landau-Gaussian convolute and its full width at half-maximum.
    //
    // The search is probably not very efficient, but it's a first try.

--- a/tutorials/fit/vectorizedFit.C
+++ b/tutorials/fit/vectorizedFit.C
@@ -1,6 +1,7 @@
 /// \file
 /// \ingroup tutorial_fit
-/// \notebook                                                                                                                              /// Tutorial for creating a Vectorized TF1 function using a formunla expression and
+/// \notebook
+/// Tutorial for creating a Vectorized TF1 function using a formula expression and
 /// use it for fitting an histogram
 ///
 /// To create a vectorized function (if ROOT has been compiled with support for vectorization)
@@ -47,7 +48,7 @@ void vectorizedFit() {
 
    std::cout << "Doing Vectorized Gaussian Fit " << std::endl;
    auto f2 = new TF1("f2","gaus",-3,3,"VEC");
-   // alternativly you can also use the TF1::SetVectorized function
+   // alternatively you can also use the TF1::SetVectorized function
    //f2->SetVectorized(true); 
    w.Start();
    h1->Fit(f2);
@@ -61,7 +62,7 @@ void vectorizedFit() {
    ((TF1 *)h1->GetListOfFunctions()->At(1))->SetLineColor(kBlue);
    //c1->cd(1)->BuildLegend();
 
-   /// Do a polynomail fit now
+   /// Do a polynomial fit now
    c1->cd(2);
    auto f3 = new TF1("f3","[A]*x^2+[B]*x+[C]",0,10);
    f3->SetParameters(0.5,3,2);


### PR DESCRIPTION
Fix improper display of vectorizedFit documentation/tutorial.
The header was badly formatted (everything on one line) which resulted in only part it being displayed.
This can be seen here (https://root.cern/doc/master/vectorizedFit_8C.html) where only `use it for fitting an histogram` is displayed instead of the complete sentence: `tutorial for creating a Vectorized TF1 function using a formula expression and use it for fitting an histogram`

Also, fixed some typos.

