### PR TITLE
Replace `sprintnf` calls with `snprintf` in multiple packages

### DIFF
--- a/graf2d/graf/src/TCandle.cxx
+++ b/graf2d/graf/src/TCandle.cxx
@@ -139,7 +139,7 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, Long64_t 
    fNHistoPoints  = 0;
    fAxisMin       = 0.;
    fAxisMax       = 0.;
-   sprintf(fOptionStr," ");
+   snprintf(fOptionStr, sizeof(fOptionStr), " ");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -173,7 +173,7 @@ TCandle::TCandle(const Double_t candlePos, const Double_t candleWidth, TH1D *pro
    fNHistoPoints  = 0;
    fAxisMin       = 0.;
    fAxisMax       = 0.;
-   sprintf(fOptionStr," ");
+   snprintf(fOptionStr, sizeof(fOptionStr), " ");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/gui/gui/src/TGFont.cxx
+++ b/gui/gui/src/TGFont.cxx
@@ -1367,7 +1367,7 @@ void TGTextLayout::ToPostscript(TString *result) const
             // Postscript as part of this sequence.
 
                // coverity[secure_coding]
-               sprintf(buf + used, "\\%03o", c);
+               snprintf(buf + used, MAXUSE + 10 - used, "\\%03o", c);
                used += 4;
             } else {
                buf[used++] = c;

--- a/gui/guihtml/src/TGHtmlDraw.cxx
+++ b/gui/guihtml/src/TGHtmlDraw.cxx
@@ -378,7 +378,8 @@ void TGHtml::BlockDraw(TGHtmlBlock *pBlock, Drawable_t drawable,
       // We are dealing with a single TGHtmlElement which contains something
       // other than plain text.
       int cnt, w;
-      char zBuf[30];
+      constexpr std::size_t zBufSize = 30;
+      char zBuf[zBufSize];
       TGHtmlLi *li;
       TGHtmlImageMarkup *image;
       switch (src->fType) {
@@ -389,7 +390,7 @@ void TGHtml::BlockDraw(TGHtmlBlock *pBlock, Drawable_t drawable,
             switch (li->fLtype) {
                case LI_TYPE_Enum_1:
                   // coverity[secure_coding]: zBuf is large enough for an int
-                  sprintf(zBuf, "%d.", li->fCnt);
+                  snprintf(zBuf, zBufSize, "%d.", li->fCnt);
                   break;
                case LI_TYPE_Enum_A:
                   GetLetterIndex(zBuf, li->fCnt, 1);

--- a/io/xml/src/TBufferXML.cxx
+++ b/io/xml/src/TBufferXML.cxx
@@ -418,13 +418,14 @@ void TBufferXML::XmlWriteBlock(XMLNodePointer_t node)
    }
 
    TString res;
-   char sbuf[500];
+   constexpr std::size_t sbufSize = 500;
+   char sbuf[sbufSize];
    int block = 0;
    char *tgt = sbuf;
    int srcCnt = 0;
 
    while (srcCnt++ < srcSize) {
-      tgt += sprintf(tgt, " %02x", (unsigned char)*src);
+      tgt += snprintf(tgt, sbufSize - (tgt - sbuf), " %02x", (unsigned char)*src);
       src++;
       if (block++ == 100) {
          res += sbuf;

--- a/io/xml/src/TXMLEngine.cxx
+++ b/io/xml/src/TXMLEngine.cxx
@@ -612,7 +612,7 @@ XMLAttrPointer_t TXMLEngine::NewAttr(XMLNodePointer_t xmlnode, XMLNsPointer_t, c
 XMLAttrPointer_t TXMLEngine::NewIntAttr(XMLNodePointer_t xmlnode, const char *name, Int_t value)
 {
    char sbuf[30];
-   sprintf(sbuf, "%d", value);
+   snprintf(sbuf, 30, "%d", value);
    return NewAttr(xmlnode, 0, name, sbuf);
 }
 

--- a/io/xml/src/TXMLFile.cxx
+++ b/io/xml/src/TXMLFile.cxx
@@ -770,7 +770,9 @@ void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement 
 
    XMLNodePointer_t node = fXML->NewChild(infonode, nullptr, cl->GetName());
 
-   char sbuf[100], namebuf[100];
+   constexpr std::size_t bufferSize = 100;
+   char sbuf[bufferSize];
+   char namebuf[bufferSize];
 
    fXML->NewAttr(node, nullptr, "name", elem->GetName());
    if (strlen(elem->GetTitle()) > 0)
@@ -789,16 +791,16 @@ void TXMLFile::StoreStreamerElement(XMLNodePointer_t infonode, TStreamerElement 
       fXML->NewIntAttr(node, "numdim", elem->GetArrayDim());
 
       for (int ndim = 0; ndim < elem->GetArrayDim(); ndim++) {
-         sprintf(namebuf, "dim%d", ndim);
+         snprintf(namebuf, bufferSize, "dim%d", ndim);
          fXML->NewIntAttr(node, namebuf, elem->GetMaxIndex(ndim));
       }
    }
 
    if (cl == TStreamerBase::Class()) {
       TStreamerBase *base = (TStreamerBase *)elem;
-      sprintf(sbuf, "%d", base->GetBaseVersion());
+      snprintf(sbuf, bufferSize, "%d", base->GetBaseVersion());
       fXML->NewAttr(node, nullptr, "baseversion", sbuf);
-      sprintf(sbuf, "%d", base->GetBaseCheckSum());
+      snprintf(sbuf, bufferSize, "%d", base->GetBaseCheckSum());
       fXML->NewAttr(node, nullptr, "basechecksum", sbuf);
    } else if (cl == TStreamerBasicPointer::Class()) {
       TStreamerBasicPointer *bptr = (TStreamerBasicPointer *)elem;
@@ -869,7 +871,7 @@ void TXMLFile::ReadStreamerElement(XMLNodePointer_t node, TStreamerInfo *info)
       int numdim = fXML->GetIntAttr(node, "numdim");
       elem->SetArrayDim(numdim);
       for (int ndim = 0; ndim < numdim; ndim++) {
-         sprintf(namebuf, "dim%d", ndim);
+         snprintf(namebuf, 100, "dim%d", ndim);
          int maxi = fXML->GetIntAttr(node, namebuf);
          elem->SetMaxIndex(ndim, maxi);
       }

--- a/math/minuit/src/TMinuit.cxx
+++ b/math/minuit/src/TMinuit.cxx
@@ -1493,7 +1493,7 @@ void TMinuit::mncont(Int_t ike1, Int_t ike2, Int_t nptu, Double_t *xptu, Double_
          fXpt[i-1] = xptu[i-2];
          fYpt[i-1] = yptu[i-2];
       }
-      sprintf(fChpt,"%s"," ABCD");
+      snprintf(fChpt, fMaxcpt+1, "%s", " ABCD");
       mnplot(fXpt, fYpt, fChpt, nall, fNpagwd, fNpagln);
    }
 

--- a/test/guitest.cxx
+++ b/test/guitest.cxx
@@ -943,7 +943,7 @@ TestDialog::TestDialog(const TGWindow *p, const TGWindow *main, UInt_t w,
    for (i = 0; i < 20; i++) {
       char tmp[20];
 
-      sprintf(tmp, "Entry %i", i+1);
+      snprintf(tmp, 20, "Entry %i", i+1);
       fCombo->AddEntry(tmp, i+1);
    }
 
@@ -1010,7 +1010,7 @@ TestDialog::TestDialog(const TGWindow *p, const TGWindow *main, UInt_t w,
    for (i=0; i < 20; ++i) {
       char tmp[20];
 
-      sprintf(tmp, "Entry %i", i);
+      snprintf(tmp, 20, "Entry %i", i);
       fListBox->AddEntry(tmp, i);
    }
    fFirstEntry = 0;
@@ -1031,7 +1031,7 @@ TestDialog::TestDialog(const TGWindow *p, const TGWindow *main, UInt_t w,
    char buff[100];
    int j;
    for (j = 0; j < 4; j++) {
-      sprintf(buff, "Module %i", j+1);
+      snprintf(buff, 100, "Module %i", j+1);
       fF6->AddFrame(new TGLabel(fF6, new TGHotString(buff)));
 
       TGTextBuffer *tbuf = new TGTextBuffer(10);
@@ -1146,7 +1146,8 @@ Bool_t TestDialog::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t)
 {
    // Process messages coming from widgets associated with the dialog.
 
-   char tmp[20];
+   constexpr std::size_t bufferSize = 20;
+   char tmp[bufferSize];
    static int newtab = 0;
 
    switch (GET_MSG(msg)) {
@@ -1170,7 +1171,7 @@ Bool_t TestDialog::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t)
                      break;
                   case 90:  // add one entry in list box
                      fLastEntry++;
-                     sprintf(tmp, "Entry %i", fLastEntry);
+                     snprintf(tmp, bufferSize, "Entry %i", fLastEntry);
                      fListBox->AddEntry(tmp, fLastEntry);
                      fListBox->MapSubwindows();
                      fListBox->Layout();
@@ -1211,7 +1212,7 @@ Bool_t TestDialog::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t)
                      }
                      break;
                   case 103:  // add tabs
-                     sprintf(tmp, "New Tab %d", ++newtab);
+                     snprintf(tmp, bufferSize, "New Tab %d", ++newtab);
                      fTab->AddTab(tmp);
                      fTab->MapSubwindows();
                      fTab->Layout();
@@ -1579,7 +1580,8 @@ Bool_t TestSliders::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
 {
    // Process slider messages.
 
-   char buf[10];
+   constexpr std::size_t bufferSize = 10;
+   char buf[bufferSize];
 
    switch (GET_MSG(msg)) {
       case kC_TEXTENTRY:
@@ -1607,7 +1609,7 @@ Bool_t TestSliders::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
       case kC_HSLIDER:
          switch (GET_SUBMSG(msg)) {
             case kSL_POS:
-               sprintf(buf, "%zd", (size_t)parm2);
+               snprintf(buf, bufferSize, "%zd", (size_t)parm2);
                switch (parm1) {
                   case HSId1:
                      fTbh1->Clear();
@@ -1632,7 +1634,7 @@ Bool_t TestSliders::ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t par
                      fClient->NeedRedraw(fTeh2);
                      break;
                   case VSId2:
-                     sprintf(buf, "%f", fVslider2->GetMinPosition());
+                     snprintf(buf, bufferSize, "%f", fVslider2->GetMinPosition());
                      fTbv2->Clear();
                      fTbv2->AddText(0, buf);
                      fTev2->SetCursorPosition(fTev2->GetCursorPosition());
@@ -2352,9 +2354,9 @@ void Editor::SetTitle()
 
    char title[256];
    if (untitled)
-      sprintf(title, "ROOT Editor - Untitled");
+      snprintf(title, 256, "ROOT Editor - Untitled");
    else
-      sprintf(title, "ROOT Editor - %s", txt->GetFileName());
+      snprintf(title, 256, "ROOT Editor - %s", txt->GetFileName());
 
    SetWindowName(title);
    SetIconName(title);

--- a/test/stressGraphics.cxx
+++ b/test/stressGraphics.cxx
@@ -171,9 +171,12 @@ Bool_t    gOptionK;
 TH2F     *gH2;
 TFile    *gHsimple;
 TFile    *gCernstaff;
-char      gCfile[16];
-char      outfile[16];
-char      gLine[80];
+constexpr std::size_t gCfileSize = 16;
+constexpr std::size_t outfileSize = 16;
+constexpr std::size_t gLineSize = 80;
+char      gCfile[gCfileSize];
+char      outfile[outfileSize];
+char      gLine[gLineSize];
 
 
 #ifndef __CLING__
@@ -455,9 +458,9 @@ Int_t StatusPrint(TString &filename, Int_t id, const TString &title,
 {
    if (!gOptionR) {
       if (id>0) {
-         sprintf(gLine,"Test %2d: %s",id,title.Data());
+         snprintf(gLine, gLineSize, "Test %2d: %s",id,title.Data());
       } else {
-         sprintf(gLine,"       %s",title.Data());
+         snprintf(gLine, gLineSize, "       %s",title.Data());
       }
 
       const Int_t nch = strlen(gLine);
@@ -559,7 +562,7 @@ TCanvas *StartTest(Int_t w, Int_t h)
 void TestReport1(TCanvas *C, const TString &title, Int_t IPS)
 {
    gErrorIgnoreLevel = 9999;
-   sprintf(outfile,"sg1_%2.2d.ps",gTestNum);
+   snprintf(outfile, outfileSize, "sg1_%2.2d.ps",gTestNum);
 
    TPostScript *ps1 = new TPostScript(outfile, 111);
    C->Draw();
@@ -575,7 +578,7 @@ void TestReport1(TCanvas *C, const TString &title, Int_t IPS)
                                             gPS1ErrNb[gTestNum-1]);
    }
 
-   sprintf(outfile,"sg%2.2d.pdf",gTestNum);
+   snprintf(outfile, outfileSize, "sg%2.2d.pdf",gTestNum);
    C->cd(0);
    TPDF *pdf = new TPDF(outfile,111);
    C->Draw();
@@ -585,7 +588,7 @@ void TestReport1(TCanvas *C, const TString &title, Int_t IPS)
                                            gPDFRefNb[gTestNum-1],
                                            gPDFErrNb[gTestNum-1]);
 
-   sprintf(outfile,"sg%2.2d.gif",gTestNum);
+   snprintf(outfile, outfileSize, "sg%2.2d.gif",gTestNum);
    C->cd(0);
    C->SaveAs(outfile);
    TString giffile = outfile;
@@ -593,7 +596,7 @@ void TestReport1(TCanvas *C, const TString &title, Int_t IPS)
                                            gGIFRefNb[gTestNum-1],
                                            gGIFErrNb[gTestNum-1]);
 
-   sprintf(outfile,"sg%2.2d.jpg",gTestNum);
+   snprintf(outfile, outfileSize, "sg%2.2d.jpg",gTestNum);
    C->cd(0);
    C->SaveAs(outfile);
    TString jpgfile = outfile;
@@ -601,7 +604,7 @@ void TestReport1(TCanvas *C, const TString &title, Int_t IPS)
                                            gJPGRefNb[gTestNum-1],
                                            gJPGErrNb[gTestNum-1]);
 
-   sprintf(outfile,"sg%2.2d.png",gTestNum);
+   snprintf(outfile, outfileSize, "sg%2.2d.png",gTestNum);
    C->cd(0);
    C->SaveAs(outfile);
    TString pngfile = outfile;
@@ -622,7 +625,7 @@ void DoCcode(TCanvas *C)
 {
    gErrorIgnoreLevel = 9999;
 
-   sprintf(gCfile,"sg%2.2d.C",gTestNum);
+   snprintf(gCfile, gCfileSize, "sg%2.2d.C",gTestNum);
 
    if (C) {
       C->SaveAs(gCfile);
@@ -643,10 +646,10 @@ void DoCcode(TCanvas *C)
 
 void TestReport2(Int_t IPS)
 {
-   sprintf(outfile,"sg2_%2.2d.ps",gTestNum);
+   snprintf(outfile, outfileSize, "sg2_%2.2d.ps",gTestNum);
 
    gErrorIgnoreLevel = 9999;
-   sprintf(gCfile,".x sg%2.2d.C",gTestNum);
+   snprintf(gCfile, gCfileSize, ".x sg%2.2d.C",gTestNum);
    gROOT->ProcessLine(gCfile);
    gPad->SaveAs(outfile);
    gErrorIgnoreLevel = 0;
@@ -663,7 +666,7 @@ void TestReport2(Int_t IPS)
                                                     gPS2ErrNb[gTestNum-1]);
    }
 
-   sprintf(gCfile,"sg%2.2d.C",gTestNum);
+   snprintf(gCfile, gCfileSize, "sg%2.2d.C",gTestNum);
 #ifndef ClingWorkAroundDeletedSourceFile
    if (!gOptionK && !i) gSystem->Unlink(gCfile);
 #endif
@@ -1584,21 +1587,22 @@ void tgaxis5()
          a.SetTimeOffset(offset[i], opt);
          const char* offsettimeformat = a.GetTimeFormat();
 
-         char buf[256];
+         constexpr std::size_t bufSize = 256;
+         char buf[bufSize];
          if (offset[i] < t[i]) {
-            sprintf(buf, "#splitline{%s, %s}{offset: %ld, option %s}",
+            snprintf(buf, bufSize, "#splitline{%s, %s}{offset: %ld, option %s}",
                     stime(t+i).Data(), stime(t+i, true).Data(), (long) offset[i], opt);
          } else {
             int h = t[i] / 3600;
             int m = (t[i] - 3600 * h) / 60 ;
             int s = (t[i] - h * 3600 - m * 60);
-            sprintf(buf, "#splitline{%d h %d m %d s}{offset: %s, option %s}",
+            snprintf(buf, bufSize, "#splitline{%d h %d m %d s}{offset: %s, option %s}",
                     h, m, s, stime(offset + i, gmt).Data(), opt);
          }
          tex1.DrawLatex(.01, .75, buf);
          tex2.DrawLatex(.01, .50, offsettimeformat);
          time_t t_ = t[i] + offset[i];
-         sprintf(buf, "Expecting:    #color[2]{%s}", stime(&t_, gmt, false).Data());
+         snprintf(buf, bufSize, "Expecting:    #color[2]{%s}", stime(&t_, gmt, false).Data());
          tex3.DrawLatex(.01, .24, buf);
          if(i > 0) l.DrawLine(0, 0.95, 1, 0.95);
       }

--- a/test/stressRooFit.cxx
+++ b/test/stressRooFit.cxx
@@ -40,7 +40,7 @@ void StatusPrint(Int_t id,const TString &title,Int_t status)
 {
   const Int_t kMAX = 65;
   Char_t number[4];
-  sprintf(number,"%2d",id);
+  snprintf(number, 4, "%2d", id);
   TString header = TString("Test ")+number+" : "+title;
   const Int_t nch = header.Length();
   for (Int_t i = nch; i < kMAX; i++) header += '.';


### PR DESCRIPTION
This is to suppress the warnings we see now in the nightlies on the
macbeta nodes:

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=macbeta,SPEC=cxx17,V=master/lastBuild/parsed_console/

After this PR, there will only be a final PR necessacy to fix these
warnings in TMVA.