### PR TITLE
[TMVA] Replace `sprintnf` calls with `snprintf` in TMVA

### DIFF
--- a/tmva/tmvagui/src/BDT.cxx
+++ b/tmva/tmvagui/src/BDT.cxx
@@ -187,9 +187,9 @@ void TMVA::StatDialogBDT::DrawNode( TMVA::DecisionTreeNode *n,
    t->SetFillColor(fColorOffset+Int_t(pur*100));
 
    char buffer[25];
-   sprintf( buffer, "N=%f", n->GetNEvents() );
+   snprintf( buffer, 25, "N=%f", n->GetNEvents() );
    if (n->GetNEvents()>0) t->AddText(buffer);
-   sprintf( buffer, "S/(S+B)=%4.3f", n->GetPurity() );
+   snprintf( buffer, 25, "S/(S+B)=%4.3f", n->GetPurity() );
    t->AddText(buffer);
 
    if (n->GetNodeType() == 0){
@@ -242,7 +242,7 @@ TMVA::DecisionTree* TMVA::StatDialogBDT::ReadTree( TString* &vars, Int_t itree )
 
       char buffer[20];
       char line[256];
-      sprintf(buffer,"Tree %d",itree);
+      snprintf(buffer, 20, "Tree %d",itree);
 
       while (!dummy.Contains(buffer)) {
          fin.getline(line,256);

--- a/tmva/tmvagui/src/BDTControlPlots.cxx
+++ b/tmva/tmvagui/src/BDTControlPlots.cxx
@@ -46,9 +46,11 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
 
    Int_t width  = 900;
    Int_t height = 600;
-   char cn[100], cn2[100];
+   constexpr std::size_t bufferSize = 100;
+   char cn[bufferSize];
+   char cn2[bufferSize];
    const TString titName = bdtdir->GetName();
-   sprintf( cn, "cv_%s", titName.Data() );
+   snprintf( cn, bufferSize, "cv_%s", titName.Data() );
    TCanvas *c = new TCanvas( cn,  Form( "%s Control Plots", titName.Data() ),
                              width, height ); 
    c->Divide(3,2);
@@ -97,7 +99,7 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
    
    TCanvas *c2 = NULL;
    if (BoostMonitorIsDone){
-      sprintf( cn2, "cv2_%s", titName.Data() );
+      snprintf( cn2, bufferSize, "cv2_%s", titName.Data() );
       c2 = new TCanvas( cn2,  Form( "%s BoostWeights", titName.Data() ),
                         1200, 1200 ); 
       c2->Divide(5,5);
@@ -139,7 +141,7 @@ void TMVA::bdtcontrolplots(TString dataset, TDirectory *bdtdir ) {
 
    TCanvas *c3 = NULL;
    if (BoostMonitorIsDone){
-      sprintf( cn2, "cv3_%s", titName.Data() );
+      snprintf( cn2, bufferSize, "cv3_%s", titName.Data() );
       c3 = new TCanvas( cn2,  Form( "%s Variables", titName.Data() ),
                         1200, 1200 ); 
       c3->Divide(5,5);

--- a/tmva/tmvagui/src/BDT_Reg.cxx
+++ b/tmva/tmvagui/src/BDT_Reg.cxx
@@ -186,7 +186,7 @@ void TMVA::StatDialogBDTReg::DrawNode( TMVA::DecisionTreeNode *n,
    char buffer[25];
    //   sprintf( buffer, "N=%f", n->GetNEvents() );
    //   t->AddText(buffer);
-   sprintf( buffer, "R=%4.1f +- %4.1f", n->GetResponse(),n->GetRMS() );
+   snprintf( buffer, 25, "R=%4.1f +- %4.1f", n->GetResponse(),n->GetRMS() );
    t->AddText(buffer);
 
    if (n->GetNodeType() == 0){
@@ -242,7 +242,7 @@ TMVA::DecisionTree* TMVA::StatDialogBDTReg::ReadTree( TString* &vars, Int_t itre
       
       char buffer[20];
       char line[256];
-      sprintf(buffer,"Tree %d",itree);
+      snprintf(buffer, 20, "Tree %d",itree);
 
       while (!dummy.Contains(buffer)) {
          fin.getline(line,256);

--- a/tmva/tmvagui/src/BoostControlPlots.cxx
+++ b/tmva/tmvagui/src/BoostControlPlots.cxx
@@ -43,7 +43,7 @@ void TMVA::boostcontrolplots(TString dataset, TDirectory *boostdir ) {
    Int_t height = 900;
    char cn[100];
    const TString titName = boostdir->GetName();
-   sprintf( cn, "cv_%s", titName.Data() );
+   snprintf( cn, 100, "cv_%s", titName.Data() );
    TCanvas *c = new TCanvas( cn,  Form( "%s Control Plots", titName.Data() ),
                              width, height ); 
    c->Divide(2,4);

--- a/tmva/tmvagui/src/likelihoodrefs.cxx
+++ b/tmva/tmvagui/src/likelihoodrefs.cxx
@@ -44,7 +44,7 @@ void TMVA::likelihoodrefs(TString dataset, TDirectory *lhdir ) {
 
             if (newCanvas) {
                char cn[20];
-               sprintf( cn, "cv%d_%s", ic+1, titName.Data() );
+               snprintf( cn, 20, "cv%d_%s", ic+1, titName.Data() );
                ++ic;
                TString n = hname;
                c[ic] = new TCanvas( cn, Form( "%s reference for variable: %s", 

--- a/tmva/tmvagui/src/probas.cxx
+++ b/tmva/tmvagui/src/probas.cxx
@@ -54,7 +54,8 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
    }
    TIter next(&methods);
    TKey *key, *hkey;
-   char fname[200];
+   constexpr std::size_t fnameSize = 200;
+   char fname[fnameSize];
    TH1* sig(0);
    TH1* bgd(0);
    
@@ -139,7 +140,7 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
                      // create new canvas
                      cout << "--- Book canvas no: " << countCanvas << endl;
                      char cn[20];
-                     sprintf( cn, "canvas%d", countCanvas+1 );
+                     snprintf( cn, 20, "canvas%d", countCanvas+1 );
                      c = new TCanvas( cn, Form("TMVA Output Fit Variables %s",methodTitle.Data()), 
                                       countCanvas*50+200, countCanvas*20, width, width*0.78 ); 
             
@@ -209,7 +210,7 @@ void TMVA::probas(TString dataset, TString fin , Bool_t useTMVAStyle  )
                      // save canvas to file
                      c->Update();
                      TMVAGlob::plot_logo();
-                     sprintf( fname, "%s/plots/mva_pdf_%s_c%i",dataset.Data(), methodTitle.Data(), countCanvas+1 );
+                     snprintf( fname, fnameSize, "%s/plots/mva_pdf_%s_c%i",dataset.Data(), methodTitle.Data(), countCanvas+1 );
                      if (Save_Images) TMVAGlob::imgconv( c, fname );
                      countCanvas++;
                   }

--- a/tmva/tmvagui/src/rulevisCorr.cxx
+++ b/tmva/tmvagui/src/rulevisCorr.cxx
@@ -170,7 +170,7 @@ void TMVA::rulevisCorr( TDirectory *rfdir, TDirectory *vardir, TDirectory *corrd
          // create new canvas
          if ((c[countCanvas]==NULL) || (countPad>noPad)) {
             char cn[20];
-            sprintf( cn, "rulecorr%d_", countCanvas+1 );
+            snprintf( cn, 20, "rulecorr%d_", countCanvas+1 );
             TString cname(cn);
             cname += rfdir->GetName();
             c[countCanvas] = new TCanvas( cname, maintitle,

--- a/tmva/tmvagui/src/rulevisHists.cxx
+++ b/tmva/tmvagui/src/rulevisHists.cxx
@@ -151,7 +151,7 @@ void TMVA::rulevisHists( TDirectory *rfdir, TDirectory *vardir, TDirectory *corr
          // create new canvas
          if ((c[countCanvas]==NULL) || (countPad>noPad)) {
             char cn[20];
-            sprintf( cn, "rulehist%d_", countCanvas+1 );
+            snprintf( cn, 20, "rulehist%d_", countCanvas+1 );
             TString cname(cn);
             cname += rfdir->GetName();
             c[countCanvas] = new TCanvas( cname, maintitle,


### PR DESCRIPTION
This is to suppress the warnings we see now in the nightlies on the
macbeta nodes:

https://lcgapp-services.cern.ch/root-jenkins/view/ROOT%20Nightly/job/root-nightly-master/LABEL=macbeta,SPEC=cxx17,V=master/lastBuild/parsed_console/