### PR TITLE
Revert "Use quotes around PATHs. Should fix #10759"

### DIFF
--- a/config/root-config.in
+++ b/config/root-config.in
@@ -11,43 +11,43 @@ if [ `uname` = "AIX" ]; then
 fi
 
 # work around readlink versions not having -f option
-fullpath1=`$readlink "$0"`
+fullpath1=`$readlink $0`
 if [ "$?" -ne "0" ]; then
-   fullpath1="$0"
+   fullpath1=$0
 else
-   if [ "${fullpath1##/}" = "$fullpath1" ] && [ "${fullpath1##~}" = "$fullpath1" ]; then
+   if [ ${fullpath1##/} = $fullpath1 ] && [ ${fullpath1##~} = $fullpath1 ]; then
       # relative path, prepend directory where executable was found
-      lpath=`dirname "$0"`
-      fullpath1="$lpath/$fullpath1"
+      lpath=`dirname $0`
+      fullpath1=$lpath/$fullpath1
    fi
 fi
-progdir=`dirname "$fullpath1"`
+progdir=`dirname $fullpath1`
 runningdir=`pwd`
-if [ "${progdir##/}" != "$progdir" ] || [ "${progdir##~}" != "$progdir" ]; then
+if [ ${progdir##/} != $progdir ] || [ ${progdir##~} != $progdir ]; then
    # absolute path
-   fullpath="$progdir"
+   fullpath=$progdir
 else
    # relative path
-   if [ "$progdir" != "." ]; then
-      fullpath="$runningdir/$progdir"
+   if [ $progdir != "." ]; then
+      fullpath=$runningdir/$progdir
    else
-      fullpath="$runningdir"
+      fullpath=$runningdir
    fi
 fi
 # work around readlink versions not having -f option
-fullpath1=`$readlink "$fullpath"`
+fullpath1=`$readlink $fullpath`
 if [ "$?" -ne "0" ]; then
-   fullpath1="$fullpath"
+   fullpath1=$fullpath
 fi
-ROOTSYS=`dirname "$fullpath1"`
+ROOTSYS=`dirname $fullpath1`
 
 arch=@architecture@
 platform=@platform@
-bindir="@bindir@"
-libdir="@libdir@"
-incdir="@incdir@"
-etcdir="@etcdir@"
-tutdir="@tutdir@"
+bindir=@bindir@
+libdir=@libdir@
+incdir=@incdir@
+etcdir=@etcdir@
+tutdir=@tutdir@
 all_features="@all_features@"
 features="@features@"
 configargs="@configargs@"
@@ -370,7 +370,7 @@ freebsd* | openbsd* | linux*)
 
    for f in $features ; do
       if test "x$f" = "xrpath" ; then
-         auxlibs="-Wl,-rpath,\"$libdir\" $auxlibs"
+         auxlibs="-Wl,-rpath,$libdir $auxlibs"
       fi
       if test "x$f" = "xlibcxx" ; then
          auxcflags="-stdlib=libc++ $auxcflags"
@@ -389,7 +389,7 @@ macosx*)
    for f in $features ; do
       if test "x$f" = "xrpath" ; then
          if [ \( $macosx_major -eq 10 -a $macosx_minor -ge 5 \) -o $macosx_major -gt 10  ]; then
-            auxlibs="-Wl,-rpath,\"$libdir\" $auxlibs"
+            auxlibs="-Wl,-rpath,$libdir $auxlibs"
          fi
       fi
       if test "x$f" = "xlibcxx" ; then
@@ -505,9 +505,9 @@ while test $# -gt 0; do
          optarg=`cygpath -u $optarg`
       fi
       prefix=$optarg
-      bindir="${prefix}/bin"
-      libdir="${prefix}/lib"
-      incdir="${prefix}/include"
+      bindir=${prefix}/bin
+      libdir=${prefix}/lib
+      incdir=${prefix}/include
       if test $exec_prefix_set = no ; then
          exec_prefix=$optarg
       fi
@@ -550,8 +550,8 @@ while test $# -gt 0; do
       ;;
     --version)
       ### Output the version number.  If RVersion.h can not be found, give up.
-      if test -r "${incdir}/RVersion.h"; then
-         out="$out `sed -n 's,.*ROOT_RELEASE *\"\(.*\)\".*,\1,p' < \"${incdir}/RVersion.h\"`"
+      if test -r ${incdir}/RVersion.h; then
+         out="$out `sed -n 's,.*ROOT_RELEASE *\"\(.*\)\".*,\1,p' < ${incdir}/RVersion.h`"
       else
          echo "cannot read ${incdir}/RVersion.h"
          exit 1
@@ -559,8 +559,8 @@ while test $# -gt 0; do
       ;;
     --git-revision)
       ### Output the git revision number.  If RGitCommit.h can not be found, give up.
-      if test -r "${incdir}/RGitCommit.h"; then
-         out="$out `sed -n 's,.*ROOT_GIT_COMMIT *\"\(.*\)\".*,\1,p' < \"${incdir}/RGitCommit.h\"`"
+      if test -r ${incdir}/RGitCommit.h; then
+         out="$out `sed -n 's,.*ROOT_GIT_COMMIT *\"\(.*\)\".*,\1,p' < ${incdir}/RGitCommit.h`"
       else
          echo "cannot read ${incdir}/RGitCommit.h"
          exit 1
@@ -577,13 +577,13 @@ while test $# -gt 0; do
       ;;
     --cflags)
       ### Output the compiler flags
-      if test "${incdir}" != "/usr/include"; then
+      if test ${incdir} != /usr/include; then
          ### In case we're on a Win32 system, we need to expand the
          ### path to a backslash seperated path
          if test "$platform" = "win32"; then
             includes=-I\'`cygpath -w ${incdir}`\'
          else
-            includes=-I"\"${incdir}\""
+            includes=-I${incdir}
          fi
       fi
       if test "x$noauxcflags" = "xyes" ; then
@@ -626,7 +626,7 @@ while test $# -gt 0; do
          done
       else
          if test "x$noldflags" = "xno" ; then
-            out="$out -L\"${libdir}\""
+            out="$out -L${libdir}"
          fi
       fi
       if test "x$noauxlibs" = "xyes" ; then
@@ -671,7 +671,7 @@ while test $# -gt 0; do
          done
       else
         if test "x$noldflags" = "xno" ; then
-           out="$out -L\"${libdir}\""
+           out="$out -L${libdir}"
         fi
       fi
       if test "x$glibsonly" = "xyes" ; then
@@ -725,7 +725,7 @@ while test $# -gt 0; do
          done
       else
         if test "x$noldflags" = "xno" ; then
-           out="$out -L\"${libdir}\""
+           out="$out -L${libdir}"
         fi
       fi
       if test "x$evelibsonly" = "xyes" ; then
@@ -746,15 +746,15 @@ while test $# -gt 0; do
       ;;
     --bindir)
       ### output the executable directory
-      out="$out \"$bindir\""
+      out="$out $bindir"
       ;;
     --libdir)
       ### output the library directory
-      out="$out \"$libdir\""
+      out="$out $libdir"
       ;;
     --incdir)
       ### output the header directory
-      out="$out \"$incdir\""
+      out="$out $incdir"
       ;;
     --etcdir)
       ### output the etc directory


### PR DESCRIPTION
The quotes are causing issues in some autoconf macros for two packages in the LCG stack

This reverts commit ade40b1ea048ec9fe6f590914a16b16391374c8a.
