### PR TITLE
Allow multidimensional treatment of Barlow-Beeston

### DIFF
--- a/roofit/histfactory/src/HistFactoryModelUtils.cxx
+++ b/roofit/histfactory/src/HistFactoryModelUtils.cxx
@@ -189,15 +189,17 @@ namespace HistFactory{
       // get num events expected in bin for obsVal
       // double nu = expected * fracAtObsValue;
 
-      // an easier way to get n
-      TH1* histForN = dataForChan->createHistogram("HhstForN",*obs);
-      for(int i=1; i<=histForN->GetNbinsX(); ++i){
-   double n = histForN->GetBinContent(i);
-   if(verbose) std::cout << "n" <<  i << " = " << n  << std::endl;
-   ChannelBinDataMap[ ChannelName ].push_back( n );
+      // multidimensional way to get n
+      // credit goes to P. Hamilton
+      for(int i=0; i<dataForChan->numEntries(); i++)
+      {
+        const RooArgSet* tmpargs=dataForChan->get(i);
+        if(verbose) tmpargs->Print();
+        const double n = dataForChan->weight();
+        if(verbose) std::cout << "n" << i << " = " << n << std::endl;
+        ChannelBinDataMap[ ChannelName ].push_back( n );
       }
-      delete histForN;
-
+      
     } // End Loop Over Categories
 
     dataByCategory->Delete();


### PR DESCRIPTION


# This Pull request:
Enables Barlow-Beeston in multidimensional fits. This patch was extensively tested and used by P. Hamilton et al. in LHCb.

## Changes or fixes:
Loop over all entries, not just the x-axis of a histogram.

## Checklist:

- [x ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

