### PR TITLE
[RF] Fix RooAddPdf::fixCoefRange cache issue with createIntegral

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -347,7 +347,11 @@ void RooAddPdf::fixCoefNormalization(const RooArgSet& refCoefNorm)
 
 void RooAddPdf::fixCoefRange(const char* rangeName)
 {
-  _refCoefRangeName = (TNamed*)RooNameReg::ptr(rangeName) ;
+  auto* newNamePtr = const_cast<TNamed*>(RooNameReg::ptr(rangeName));
+  if(newNamePtr != _refCoefRangeName) {
+    _projCacheMgr.reset() ;
+  }
+  _refCoefRangeName = newNamePtr;
   if (_refCoefRangeName) _projectCoefs = true ;
 }
 


### PR DESCRIPTION
When the normalization range for coefficient determination of a
RooAddPdf is changed, the AddPdf's projection cache needs to be reset,
just like it is already done in `RooAddPdf::fixCoefNormalization`.
Otherwise, there will be problems in the pdf evaluation and integration
because the projection cache is invalid.

A unit test based on the GitHub issue that reported this problem is also
implemented.

Closes https://github.com/root-project/root/issues/10988.

Furthermore, another potential RooAddPdf problem is fixed, where several instances of RooRecursiveFraction were created with the same name (which could become problematic for example when using the new BatchMode).
