### PR TITLE
[skip-ci][DF] Updated explanation of actions and fixes of grammar mistakes in df001…

### DIFF
--- a/tutorials/dataframe/df001_introduction.C
+++ b/tutorials/dataframe/df001_introduction.C
@@ -48,17 +48,19 @@ int df001_introduction()
 
    // ## Operations on the dataframe
    // We now review some *actions* which can be performed on the data frame.
-   // All actions but ForEach return a TActionResultPtr<T>. The series of
-   // operations on the data frame is not executed until one of those pointers
-   // is accessed. If the Foreach action is invoked, the execution is immediate.
-   // But first of all, let us we define now our cut-flow with two lambda
+   // Actions can be divided into instant actions (e. g. Foreach()) and lazy
+   // actions (e. g. Count()), depending on whether they trigger the event
+   // loop immediately or only when one of the results is accessed for the
+   // first time. Actions that return "something" either return their result
+   // wrapped in a RResultPtr or in a RDataFrame.
+   // But first of all, let us define our cut-flow with two lambda
    // functions. We can use free functions too.
    auto cutb1 = [](double b1) { return b1 < 5.; };
    auto cutb1b2 = [](int b2, double b1) { return b2 % 2 && b1 < 4.; };
 
    // ### `Count` action
    // The `Count` allows to retrieve the number of the entries that passed the
-   // filters. Here we show how the automatic selection of the column kicks
+   // filters. Here, we show how the automatic selection of the column kicks
    // in in case the user specifies none.
    auto entries1 = d.Filter(cutb1) // <- no column name specified here!
                       .Filter(cutb1b2, {"b2", "b1"})
@@ -68,7 +70,7 @@ int df001_introduction()
 
    // Filters can be expressed as strings. The content must be C++ code. The
    // name of the variables must be the name of the branches. The code is
-   // just in time compiled.
+   // just-in-time compiled.
    auto entries2 = d.Filter("b1 < 5.").Count();
    std::cout << *entries2 << " entries passed the string filter" << std::endl;
 
@@ -121,7 +123,7 @@ int df001_introduction()
    // which is well organised, for example allowing to conditionally add filters
    // or again to clearly separate filters and actions without the need of
    // writing the entire pipeline on one line. This can be easily achieved.
-   // We'll show this re-working the `Count` example:
+   // We'll show this by re-working the `Count` example:
    auto cutb1_result = d.Filter(cutb1);
    auto cutb1b2_result = d.Filter(cutb1b2, {"b2", "b1"});
    auto cutb1_cutb1b2_result = cutb1_result.Filter(cutb1b2, {"b2", "b1"});
@@ -137,7 +139,7 @@ int df001_introduction()
    // ## Calculating quantities starting from existing columns
    // Often, operations need to be carried out on quantities calculated starting
    // from the ones present in the columns. We'll create in this example a third
-   // column the values of which are the sum of the *b1* and *b2* ones, entry by
+   // column, the values of which are the sum of the *b1* and *b2* ones, entry by
    // entry. The way in which the new quantity is defined is via a callable.
    // It is important to note two aspects at this point:
    // - The value is created on the fly only if the entry passed the existing
@@ -154,7 +156,7 @@ int df001_introduction()
 
    // Additional columns can be expressed as strings. The content must be C++
    // code. The name of the variables must be the name of the branches. The code
-   // is just in time compiled.
+   // is just-in-time compiled.
    auto entries_sum2 = d.Define("sum2", "b1 + b2").Filter("sum2 > 4.2").Count();
    std::cout << *entries_sum2 << std::endl;
 

--- a/tutorials/dataframe/df001_introduction.py
+++ b/tutorials/dataframe/df001_introduction.py
@@ -33,13 +33,15 @@ d = ROOT.RDataFrame(treeName, fileName)
 
 # Operations on the dataframe
 # We now review some *actions* which can be performed on the data frame.
-# All actions but ForEach return a TActionResultPtr<T>. The series of
-# operations on the data frame is not executed until one of those pointers
-# is accessed.
+# Actions can be divided into instant actions (e. g. Foreach()) and lazy
+# actions (e. g. Count()), depending on whether they trigger the event 
+# loop immediately or only when one of the results is accessed for the 
+# first time. Actions that return "something" either return their result 
+# wrapped in a RResultPtr or in a RDataFrame.
 # But first of all, let us we define now our cut-flow with two strings.
 # Filters can be expressed as strings. The content must be C++ code. The
 # name of the variables must be the name of the branches. The code is
-# just in time compiled.
+# just-in-time compiled.
 cutb1 = 'b1 < 5.'
 cutb1b2 = 'b2 % 2 && b1 < 4.'
 
@@ -97,7 +99,7 @@ print('Events passing both: {}'.format(evts_cutb1_cutb1b2_result.GetValue()))
 # Calculating quantities starting from existing columns
 # Often, operations need to be carried out on quantities calculated starting
 # from the ones present in the columns. We'll create in this example a third
-# column the values of which are the sum of the *b1* and *b2* ones, entry by
+# column, the values of which are the sum of the *b1* and *b2* ones, entry by
 # entry. The way in which the new quantity is defined is via a callable.
 # It is important to note two aspects at this point:
 # - The value is created on the fly only if the entry passed the existing
@@ -111,3 +113,4 @@ entries_sum = d.Define('sum', 'b2 + b1') \
                .Filter('sum > 4.2') \
                .Count()
 print(entries_sum.GetValue())
+


### PR DESCRIPTION
… tutorials

# This Pull request: df001_Introduction tutorial

## Changes or fixes:

The explanation of the actions in the part "Operations on dataframe" using ForEach() and TActionResultPtr<T> does not match with the RDataFrame Reference guide and is hence outdated. Now there is an updated text. Also, a few grammar mistakes are now corrected for.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

