### PR TITLE
[skip-ci][DF] Fix typos and grammar mistakes in df002 tutorials

### DIFF
--- a/tutorials/dataframe/df002_dataModel.C
+++ b/tutorials/dataframe/df002_dataModel.C
@@ -4,7 +4,7 @@
 /// Show how to work with non-flat data models, e.g. vectors of tracks.
 ///
 /// This tutorial shows the possibility to use data models which are more
-/// complex than flat ntuples with RDataFrame
+/// complex than flat ntuples with RDataFrame.
 ///
 /// \macro_code
 /// \macro_image
@@ -59,9 +59,9 @@ int df002_dataModel()
    // allows us to interact with the data contained in the tree.
    ROOT::RDataFrame d(treeName, fileName, {"tracks"});
 
-   // ## Operating on branches which are collection of objects
+   // ## Operating on branches which are collections of objects
    // Here we deal with the simplest of the cuts: we decide to accept the event
-   // only if the number of tracks is greater than 5.
+   // only if the number of tracks is greater than 8.
    auto n_cut = [](const FourVectorRVec &tracks) { return tracks.size() > 8; };
    auto nentries = d.Filter(n_cut, {"tracks"}).Count();
 

--- a/tutorials/dataframe/df002_dataModel.py
+++ b/tutorials/dataframe/df002_dataModel.py
@@ -4,7 +4,7 @@
 ## Show how to work with non-flat data models, e.g. vectors of tracks.
 ##
 ## This tutorial shows the possibility to use data models which are more
-## complex than flat ntuples with RDataFrame
+## complex than flat ntuples with RDataFrame.
 ##
 ## \macro_code
 ## \macro_image
@@ -61,7 +61,7 @@ ROOT.fill_tree(fileName, treeName)
 # allows us to interact with the data contained in the tree.
 d = ROOT.RDataFrame(treeName, fileName)
 
-# Operating on branches which are collection of objects
+# Operating on branches which are collections of objects
 # Here we deal with the simplest of the cuts: we decide to accept the event
 # only if the number of tracks is greater than 8.
 n_cut = 'tracks.size() > 8'


### PR DESCRIPTION
# This Pull request: df002 tutorial

## Changes or fixes:

Typos and grammar mistakes are now fixed.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

