### PR TITLE
THStack histogram line width should be 0

### DIFF
--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -905,7 +905,11 @@ void THStack::Paint(Option_t *choptin)
       }
    }
 
-   if (!lsame) fHistogram->Paint(loption.Data());
+   // Set fHistogram attributes and pain it.
+   if (!lsame) {
+      fHistogram->SetLineWidth(0);
+      fHistogram->Paint(loption.Data());
+   }
 
    if (fHistogram->GetDimension() > 1) SetDrawOption(loption.Data());
    if (loption.Index("lego")>=0) return;


### PR DESCRIPTION
THStack fHistogram line width should be 0 as suggested here: https://root-forum.cern.ch/t/continuing-the-discussion-from-an-unwanted-horizontal-line-is-drawn-at-y-0/50877/17