### PR TITLE
[tree] Fix integer overflow in TEntryList

### DIFF
--- a/tree/tree/inc/TEntryList.h
+++ b/tree/tree/inc/TEntryList.h
@@ -70,8 +70,8 @@ class TEntryList: public TNamed
    void                EnterRange(Long64_t start, Long64_t end, TTree *tree = nullptr, UInt_t step = 1U);
    virtual TEntryList *GetCurrentList() const { return fCurrent; };
    virtual TEntryList *GetEntryList(const char *treename, const char *filename, Option_t *opt="");
-   virtual Long64_t    GetEntry(Int_t index);
-   virtual Long64_t    GetEntryAndTree(Int_t index, Int_t &treenum);
+   virtual Long64_t    GetEntry(Long64_t index);
+   virtual Long64_t    GetEntryAndTree(Long64_t index, Int_t &treenum);
    virtual Long64_t    GetEntriesToProcess() const {return fEntriesToProcess;}
    virtual TList      *GetLists() const { return fLists; }
    virtual TDirectory *GetDirectory() const { return fDirectory; }

--- a/tree/tree/inc/TEntryListFromFile.h
+++ b/tree/tree/inc/TEntryListFromFile.h
@@ -67,8 +67,8 @@ public:
    virtual TEntryList *GetCurrentList() const { return fCurrent; };
    virtual TEntryList *GetEntryList(const char * /*treename*/, const char * /*filename*/, Option_t * /*opt=""*/) {return 0;};
 
-   virtual Long64_t    GetEntry(Int_t index);
-   virtual Long64_t    GetEntryAndTree(Int_t index, Int_t &treenum);
+   virtual Long64_t    GetEntry(Long64_t index);
+   virtual Long64_t    GetEntryAndTree(Long64_t index, Int_t &treenum);
    virtual Long64_t    GetEntries();
    virtual Long64_t    GetEntriesFast() const { return fN; };
 

--- a/tree/tree/src/TEntryList.cxx
+++ b/tree/tree/src/TEntryList.cxx
@@ -752,7 +752,7 @@ Bool_t TEntryList::Remove(Long64_t entry, TTree *tree)
 /// Return the number of the entry \#index of this TEntryList in the TTree or TChain
 /// See also Next().
 
-Long64_t TEntryList::GetEntry(Int_t index)
+Long64_t TEntryList::GetEntry(Long64_t index)
 {
 
    if ((index>=fN) || (index<0)) {
@@ -828,7 +828,7 @@ Long64_t TEntryList::GetEntry(Int_t index)
 /// Return the index of "index"-th non-zero entry in the TTree or TChain
 /// and the # of the corresponding tree in the chain
 
-Long64_t TEntryList::GetEntryAndTree(Int_t index, Int_t &treenum)
+Long64_t TEntryList::GetEntryAndTree(Long64_t index, Int_t &treenum)
 {
 //If shift is true, then when the requested entry is found in an entry list,
 //for which there is no corresponding tree in the chain, this list is not

--- a/tree/tree/src/TEntryListFromFile.cxx
+++ b/tree/tree/src/TEntryListFromFile.cxx
@@ -87,7 +87,7 @@ TEntryListFromFile::~TEntryListFromFile()
 /// Returns entry \#index
 /// See also Next() for a faster alternative
 
-Long64_t TEntryListFromFile::GetEntry(Int_t index)
+Long64_t TEntryListFromFile::GetEntry(Long64_t index)
 {
    if (index<0) return -1;
 
@@ -152,7 +152,7 @@ Long64_t TEntryListFromFile::GetEntry(Int_t index)
 /// Return the entry corresponding to the index parameter and the
 /// number of the tree, where this entry is
 
-Long64_t TEntryListFromFile::GetEntryAndTree(Int_t index, Int_t &treenum)
+Long64_t TEntryListFromFile::GetEntryAndTree(Long64_t index, Int_t &treenum)
 {
    Long64_t result = GetEntry(index);
    treenum = fTreeNumber;


### PR DESCRIPTION
Change signature of methods in TEntryList and derived class that expect
an entry index. Usually this is stored as Long64_t, but in `GetEntry`
and `GetEntryAndTree` methods this was passed as `Int_t` leading to
integer overflows.

Fixes https://github.com/root-project/root/issues/11026


With respect to the reproducer in the linked issue, this PR outputs the following
```
$: ./repro.o
std::numeric_limits<int>::max(): 2147483647
Total entries in chain: 2168958436
Total entries in entrylist: 2168958436
Giving input entry 2147483647
Got input index: 2147483647
Got tree index 100 and entry index 47
Giving input entry 2147483648
Got input index: 2147483648
Got tree index 100 and entry index 48
Got input index: 2147483648
With entryAfterList=2147483648 got loadResult=48
What is the entry status? not kEntryBeyondEnd
```