### PR TITLE
[tree] Introduce the RDatasetSpec as internal in v6-26-06

### DIFF
--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -60,6 +60,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RDSColumnReader.hxx
     ROOT/RDF/RColumnReaderBase.hxx
     ROOT/RDF/RCutFlowReport.hxx
+    ROOT/RDF/RDatasetSpec.hxx
     ROOT/RDF/RDisplay.hxx
     ROOT/RDF/RFilterBase.hxx
     ROOT/RDF/RFilter.hxx
@@ -92,6 +93,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RDefineBase.cxx
     src/RCutFlowReport.cxx
     src/RDataFrame.cxx
+    src/RDatasetSpec.cxx
     src/RDFActionHelpers.cxx
     src/RDFColumnRegister.cxx
     src/RDFDisplay.cxx

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -49,6 +49,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/GraphUtils.hxx
     ROOT/RDF/HistoModels.hxx
     ROOT/RDF/InterfaceUtils.hxx
+    ROOT/RDF/InternalUtils.hxx
     ROOT/RDF/RActionBase.hxx
     ROOT/RDF/RAction.hxx
     ROOT/RDF/RColumnRegister.hxx
@@ -100,6 +101,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RDFGraphUtils.cxx
     src/RDFHistoModels.cxx
     src/RDFInterfaceUtils.cxx
+    src/RDFInternalUtils.cxx
     src/RDFUtils.cxx
     src/RDFHelpers.cxx
     src/RFilterBase.cxx

--- a/tree/dataframe/inc/ROOT/RDF/InternalUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InternalUtils.hxx
@@ -1,0 +1,12 @@
+#include "ROOT/RDF/RDatasetSpec.hxx"
+#include "ROOT/RDataFrame.hxx"
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+ROOT::RDataFrame MakeDataFrameFromSpec(const RDatasetSpec &spec);
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT

--- a/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
@@ -1,0 +1,85 @@
+// Author: Vincenzo Eduardo Padulano CERN/UPV, Ivan Kabadzhov CERN  06/2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT_RDF_RDATASETSPEC
+#define ROOT_RDF_RDATASETSPEC
+
+#include <limits>
+#include <string>
+#include <utility> // std::pair
+#include <vector>
+
+#include <ROOT/InternalTreeUtils.hxx> // ROOT::Internal::TreeUtils::RFriendInfo
+#include <RtypesCore.h>               // Long64_t
+
+namespace ROOT {
+
+namespace Detail {
+namespace RDF {
+class RLoopManager;
+} // namespace RDF
+} // namespace Detail
+
+namespace Internal {
+
+namespace RDF {
+
+class RDatasetSpec {
+
+   friend class ROOT::Detail::RDF::RLoopManager;
+
+public:
+   struct REntryRange {
+      Long64_t fBegin{0};
+      Long64_t fEnd{std::numeric_limits<Long64_t>::max()};
+      REntryRange();
+      REntryRange(Long64_t endEntry);
+      REntryRange(Long64_t beginEntry, Long64_t endEntry);
+   };
+
+private:
+   /**
+    * A list of names of trees.
+    * This list should go in lockstep with fFileNameGlobs, only in case this dataset is a TChain where each file
+    * contains its own tree with a different name from the global name of the dataset.
+    * Otherwise, fTreeNames contains 1 treename, that is common for all file globs.
+    */
+   std::vector<std::string> fTreeNames;
+   /**
+    * A list of file names.
+    * They can contain the globbing characters supported by TChain. See TChain::Add for more information.
+    */
+   std::vector<std::string> fFileNameGlobs;
+   REntryRange fEntryRange; ///< Begin (inclusive) and end (exclusive) entry for the dataset processing
+   ROOT::Internal::TreeUtils::RFriendInfo fFriendInfo; ///< List of friends
+
+public:
+   RDatasetSpec(const std::string &treeName, const std::string &fileNameGlob, const REntryRange &entryRange = {});
+
+   RDatasetSpec(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
+                const REntryRange &entryRange = {});
+
+   RDatasetSpec(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
+                const REntryRange &entryRange = {});
+
+   void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "");
+
+   void
+   AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs, const std::string &alias = "");
+
+   void AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
+                  const std::string &alias = "");
+};
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT
+
+#endif // ROOT_RDF_RDATASETSPEC

--- a/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDatasetSpec.hxx
@@ -1,3 +1,4 @@
+/// \cond HIDDEN_SYMBOLS
 // Author: Vincenzo Eduardo Padulano CERN/UPV, Ivan Kabadzhov CERN  06/2022
 
 /*************************************************************************
@@ -83,3 +84,4 @@ public:
 } // namespace ROOT
 
 #endif // ROOT_RDF_RDATASETSPEC
+/// \endcond

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -162,7 +162,9 @@ public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
    RLoopManager(ULong64_t nEmptyEntries);
    RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches);
+   /// \cond HIDDEN_SYMBOLS
    RLoopManager(ROOT::Internal::RDF::RDatasetSpec &&spec);
+   /// \endcond
    RLoopManager(const RLoopManager &) = delete;
    RLoopManager &operator=(const RLoopManager &) = delete;
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -11,11 +11,13 @@
 #ifndef ROOT_RLOOPMANAGER
 #define ROOT_RLOOPMANAGER
 
+#include "ROOT/RDF/RDatasetSpec.hxx"
 #include "ROOT/RDF/RNodeBase.hxx"
 #include "ROOT/RDF/RNewSampleNotifier.hxx"
 #include "ROOT/RDF/RSampleInfo.hxx"
 
 #include <functional>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -115,6 +117,9 @@ class RLoopManager : public RNodeBase {
    /// Shared pointer to the input TTree. It does not delete the pointee if the TTree/TChain was passed directly as an
    /// argument to RDataFrame's ctor (in which case we let users retain ownership).
    std::shared_ptr<TTree> fTree{nullptr};
+   Long64_t fBeginEntry{0};
+   Long64_t fEndEntry{std::numeric_limits<Long64_t>::max()};
+   std::vector<std::unique_ptr<TTree>> fFriends; ///< Friends of the fTree. Only used if we constructed fTree ourselves.
    const ColumnNames_t fDefaultColumns;
    const ULong64_t fNEmptyEntries{0};
    const unsigned int fNSlots{1};
@@ -157,6 +162,7 @@ public:
    RLoopManager(TTree *tree, const ColumnNames_t &defaultBranches);
    RLoopManager(ULong64_t nEmptyEntries);
    RLoopManager(std::unique_ptr<RDataSource> ds, const ColumnNames_t &defaultBranches);
+   RLoopManager(ROOT::Internal::RDF::RDatasetSpec &&spec);
    RLoopManager(const RLoopManager &) = delete;
    RLoopManager &operator=(const RLoopManager &) = delete;
 

--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -17,6 +17,7 @@ ROOT's RDataFrame allows to analyse data stored in TTrees with a high level inte
 #define ROOT_RDATAFRAME
 
 #include "TROOT.h" // To allow ROOT::EnableImplicitMT without including ROOT.h
+#include "ROOT/RDF/RDatasetSpec.hxx"
 #include "ROOT/RDF/RInterface.hxx"
 #include "ROOT/RDF/Utils.hxx"
 #include "ROOT/RStringView.hxx"
@@ -47,6 +48,10 @@ public:
    RDataFrame(TTree &tree, const ColumnNames_t &defaultBranches = {});
    RDataFrame(ULong64_t numEntries);
    RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource>, const ColumnNames_t &defaultBranches = {});
+
+   /// \cond HIDDEN_SYMBOLS
+   RDataFrame(ROOT::Internal::RDF::RDatasetSpec spec);
+   /// \endcond
 };
 
 } // ns ROOT

--- a/tree/dataframe/inc/ROOT/RDataFrame.hxx
+++ b/tree/dataframe/inc/ROOT/RDataFrame.hxx
@@ -32,6 +32,15 @@ class TDirectory;
 class TTree;
 
 namespace ROOT {
+
+class RDataFrame;
+
+namespace Internal {
+namespace RDF {
+ROOT::RDataFrame MakeDataFrameFromSpec(const RDatasetSpec &spec);
+} // namespace RDF
+} // namespace Internal
+
 namespace RDF {
 class RDataSource;
 }
@@ -49,9 +58,10 @@ public:
    RDataFrame(ULong64_t numEntries);
    RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource>, const ColumnNames_t &defaultBranches = {});
 
-   /// \cond HIDDEN_SYMBOLS
+   friend RDataFrame ROOT::Internal::RDF::MakeDataFrameFromSpec(const ROOT::Internal::RDF::RDatasetSpec &spec);
+
+private:
    RDataFrame(ROOT::Internal::RDF::RDatasetSpec spec);
-   /// \endcond
 };
 
 } // ns ROOT

--- a/tree/dataframe/src/RDFInternalUtils.cxx
+++ b/tree/dataframe/src/RDFInternalUtils.cxx
@@ -1,0 +1,14 @@
+#include "ROOT/RDF/InternalUtils.hxx"
+
+namespace ROOT {
+namespace Internal {
+namespace RDF {
+
+ROOT::RDataFrame MakeDataFrameFromSpec(const RDatasetSpec &spec)
+{
+   return ROOT::RDataFrame(std::move(spec));
+}
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT

--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -1397,6 +1397,11 @@ RDataFrame::RDataFrame(std::unique_ptr<ROOT::RDF::RDataSource> ds, const ColumnN
 {
 }
 
+RDataFrame::RDataFrame(ROOT::Internal::RDF::RDatasetSpec spec)
+   : RInterface(std::make_shared<RDFDetail::RLoopManager>(std::move(spec)))
+{
+}
+
 } // namespace ROOT
 
 namespace cling {

--- a/tree/dataframe/src/RDatasetSpec.cxx
+++ b/tree/dataframe/src/RDatasetSpec.cxx
@@ -1,0 +1,132 @@
+// Author: Vincenzo Eduardo Padulano CERN/UPV, Ivan Kabadzhov CERN  06/2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RDF/RDatasetSpec.hxx"
+#include <stdexcept> // std::logic_error
+
+namespace ROOT {
+
+namespace Internal {
+
+namespace RDF {
+
+RDatasetSpec::REntryRange::REntryRange() {}
+
+RDatasetSpec::REntryRange::REntryRange(Long64_t end) : fEnd(end) {}
+
+RDatasetSpec::REntryRange::REntryRange(Long64_t begin, Long64_t end) : fBegin(begin), fEnd(end)
+{
+   if (fBegin > fEnd)
+      throw std::logic_error("The starting entry cannot be larger than the ending entry in the "
+                             "creation of a dataset specification.");
+}
+
+/**
+ * \class ROOT::Internal::RDF::RDatasetSpec
+ * \ingroup dataframe
+ * \brief A dataset specification for RDataFrame.
+ **/
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Construct an RDatasetSpec for one or more samples with the same tree name.
+/// \param[in] treeName Name of the tree
+/// \param[in] fileNameGlob Single file name or glob expression for the files where the tree(s) are stored
+/// \param[in] entryRange The global entry range to be processed, {begin (inclusive), end (exclusive)}
+///
+/// The filename glob supports the same type of expressions as TChain::Add().
+RDatasetSpec::RDatasetSpec(const std::string &treeName, const std::string &fileNameGlob, const REntryRange &entryRange)
+   : fTreeNames({treeName}), fFileNameGlobs({fileNameGlob}), fEntryRange(entryRange)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Construct an RDatasetSpec for one or more samples with the same tree name.
+/// \param[in] treeName Name of the tree
+/// \param[in] fileNameGlobs A vector of file names or glob expressions for the files where the trees are stored
+/// \param[in] entryRange The global entry range to be processed, {begin (inclusive), end (exclusive)}
+///
+/// The filename glob supports the same type of expressions as TChain::Add().
+RDatasetSpec::RDatasetSpec(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
+                           const REntryRange &entryRange)
+   : fTreeNames({treeName}), fFileNameGlobs(fileNameGlobs), fEntryRange(entryRange)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Construct an RDatasetSpec for a chain of several trees (possibly having different names).
+/// \param[in] treeAndFileNameGlobs A vector of pairs of tree names and their corresponding file names/globs
+/// \param[in] entryRange The global entry range to be processed, {begin (inclusive), end (exclusive)}
+///
+/// The filename glob supports the same type of expressions as TChain::Add().
+///
+/// ### Example usage:
+/// ~~~{.py}
+/// spec = ROOT.Internal.RDF.RDatasetSpec([("tree1", "a.root"), ("tree2", "b.root")], (5, 10))
+/// df = ROOT.RDataFrame(spec)
+/// ~~~
+RDatasetSpec::RDatasetSpec(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
+                           const REntryRange &entryRange)
+   : fEntryRange(entryRange)
+{
+   fTreeNames.reserve(treeAndFileNameGlobs.size());
+   fFileNameGlobs.reserve(treeAndFileNameGlobs.size());
+   for (auto &p : treeAndFileNameGlobs) {
+      fTreeNames.emplace_back(p.first);
+      fFileNameGlobs.emplace_back(p.second);
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add a friend tree or chain with the same tree name to the dataset specification.
+/// \param[in] treeName Name of the tree
+/// \param[in] fileNameGlob Single file name or glob expression for the files where the tree(s) are stored
+/// \param[in] alias String to refer to the particular friend
+///
+/// The filename glob supports the same type of expressions as TChain::Add().
+void RDatasetSpec::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias)
+{
+   fFriendInfo.AddFriend(treeName, fileNameGlob, alias);
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add a friend tree or chain with the same tree name to the dataset specification.
+/// \param[in] treeName Name of the tree
+/// \param[in] fileNameGlobs A vector of file names or glob expressions for the files where the trees are stored
+/// \param[in] alias String to refer to the particular friend
+///
+/// The filename glob supports the same type of expressions as TChain::Add().
+void RDatasetSpec::AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
+                             const std::string &alias)
+{
+   fFriendInfo.AddFriend(treeName, fileNameGlobs, alias);
+}
+
+////////////////////////////////////////////////////////////////////////////
+/// \brief Add a friend tree or chain (possibly with different tree names) to the dataset specification.
+/// \param[in] treeAndFileNameGlobs A vector of pairs of tree names and their corresponding file names/globs
+/// \param[in] alias String to refer to the particular friend
+///
+/// The filename glob supports the same type of expressions as TChain::Add().
+///
+/// ### Example usage:
+/// ~~~{.py}
+/// spec = ROOT.Internal.RDF.RDatasetSpec("tree", "file.root")
+/// spec.AddFriend([("tree1", "a.root"), ("tree2", "b.root")], "alias")
+/// df = ROOT.RDataFrame(spec)
+/// ~~~
+void RDatasetSpec::AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
+                             const std::string &alias)
+{
+   fFriendInfo.AddFriend(treeAndFileNameGlobs, alias);
+}
+
+} // namespace RDF
+} // namespace Internal
+} // namespace ROOT

--- a/tree/dataframe/src/RDatasetSpec.cxx
+++ b/tree/dataframe/src/RDatasetSpec.cxx
@@ -1,3 +1,4 @@
+/// \cond HIDDEN_SYMBOLS
 // Author: Vincenzo Eduardo Padulano CERN/UPV, Ivan Kabadzhov CERN  06/2022
 
 /*************************************************************************
@@ -130,3 +131,4 @@ void RDatasetSpec::AddFriend(const std::vector<std::pair<std::string, std::strin
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT
+/// \endcond

--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -38,6 +38,7 @@ if(NOT (MSVC OR (APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES arm64)) OR win_broken_
   ROOT_ADD_GTEST(dataframe_snapshot dataframe_snapshot.cxx LIBRARIES ROOTDataFrame)
 endif()
 
+ROOT_ADD_GTEST(dataframe_datasetspec dataframe_datasetspec.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_display dataframe_display.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_ranges dataframe_ranges.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_leaves dataframe_leaves.cxx LIBRARIES ROOTDataFrame)

--- a/tree/dataframe/test/dataframe_datasetspec.cxx
+++ b/tree/dataframe/test/dataframe_datasetspec.cxx
@@ -1,0 +1,276 @@
+#include <gtest/gtest.h>
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RVec.hxx>
+#include <ROOT/RDFHelpers.hxx>
+#include <TSystem.h>
+
+using namespace ROOT;
+using namespace ROOT::Internal::RDF;
+
+using namespace std::literals; // remove ambiguity of using std::vector<std::string>-s and std::string-s
+
+void EXPECT_VEC_EQ(const std::vector<ULong64_t> &vec1, const std::vector<ULong64_t> &vec2)
+{
+   ASSERT_EQ(vec1.size(), vec2.size());
+   for (auto i = 0u; i < vec1.size(); ++i)
+      EXPECT_EQ(vec1[i], vec2[i]);
+}
+
+// The helper class is also responsible for the creation and the deletion of the root specTestFiles
+class RDatasetSpecTest : public ::testing::TestWithParam<bool> {
+protected:
+   RDatasetSpecTest() {}
+
+   ~RDatasetSpecTest() {}
+
+   static void SetUpTestCase()
+   {
+      auto dfWriter0 = RDataFrame(5).Define("z", [](ULong64_t e) { return e + 100; }, {"rdfentry_"});
+      dfWriter0.Snapshot<ULong64_t>("tree", "specTestFile0.root", {"z"});
+      dfWriter0.Range(0, 2).Snapshot<ULong64_t>("subTree", "specTestFile1.root", {"z"});
+      dfWriter0.Range(2, 4).Snapshot<ULong64_t>("subTree", "specTestFile2.root", {"z"});
+      dfWriter0.Range(4, 5).Snapshot<ULong64_t>("subTree", "specTestFile3.root", {"z"});
+      dfWriter0.Range(0, 2).Snapshot<ULong64_t>("subTreeA", "specTestFile4.root", {"z"});
+      dfWriter0.Range(2, 4).Snapshot<ULong64_t>("subTreeB", "specTestFile5.root", {"z"});
+
+      auto dfWriter1 = RDataFrame(10)
+                          .Define("x", [](ULong64_t e) { return double(e); }, {"rdfentry_"})
+                          .Define("w", [](ULong64_t e) { return e + 1.; }, {"rdfentry_"});
+      dfWriter1.Range(5).Snapshot<double>("subTree0", "specTestFile6.root", {"x"});
+      dfWriter1.Range(5, 10).Snapshot<double>("subTree1", "specTestFile7.root", {"x"});
+      dfWriter1.Range(5).Snapshot<double>("subTree2", "specTestFile8.root", {"w"});
+      dfWriter1.Range(5, 10).Snapshot<double>("subTree3", "specTestFile9.root", {"w"});
+   }
+
+   static void TearDownTestCase()
+   {
+      for (auto i = 0u; i < 10; ++i)
+         gSystem->Unlink(("specTestFile" + std::to_string(i) + ".root").c_str());
+   }
+};
+
+// ensure that the chains are created as expected, no ranges, neither friends are passed
+TEST_P(RDatasetSpecTest, SimpleChainsCreation)
+{
+   // first constructor: 1 tree, 1 file; both passed as string directly
+   // advanced note: internally a TChain is created named the same as the tree provided
+   const auto dfRDSc1 = *(RDataFrame(RDatasetSpec("tree", "specTestFile0.root")).Take<ULong64_t>("z"));
+   EXPECT_VEC_EQ(dfRDSc1, {100u, 101u, 102u, 103u, 104u});
+
+   // second constructor: 1 tree, many files; files passed as a vector; testing with 1 specTestFile
+   // advanced note: internally a TChain is created named the same as the tree provided
+   const auto dfRDSc21 = *(RDataFrame(RDatasetSpec("tree", {"specTestFile0.root"s})).Take<ULong64_t>("z"));
+   EXPECT_VEC_EQ(dfRDSc21, {100u, 101u, 102u, 103u, 104u});
+
+   // second constructor: here with multiple files
+   auto dfRDSc2N =
+      *(RDataFrame(RDatasetSpec("subTree", {"specTestFile1.root"s, "specTestFile2.root"s, "specTestFile3.root"s}))
+           .Take<ULong64_t>("z"));
+   std::sort(dfRDSc2N.begin(), dfRDSc2N.end()); // the order is not necessary preserved by Take in MT
+   EXPECT_VEC_EQ(dfRDSc2N, {100u, 101u, 102u, 103u, 104u});
+
+   // third constructor: many trees, many files; trees and files passed in a vector of pairs; here 1 specTestFile
+   // advanced note: when using this constructor, the internal TChain will always have no name
+   const auto dfRDSc31 = *(RDataFrame(RDatasetSpec({{"tree"s, "specTestFile0.root"s}})).Take<ULong64_t>("z"));
+   EXPECT_VEC_EQ(dfRDSc31, {100u, 101u, 102u, 103u, 104u});
+
+   // third constructor: many trees and files
+   auto dfRDSc3N = *(RDataFrame(RDatasetSpec({{"subTreeA"s, "specTestFile4.root"s},
+                                              {"subTreeB"s, "specTestFile5.root"s},
+                                              {"subTree"s, "specTestFile3.root"s}}))
+                        .Take<ULong64_t>("z"));
+   std::sort(dfRDSc3N.begin(), dfRDSc3N.end());
+   EXPECT_VEC_EQ(dfRDSc3N, {100u, 101u, 102u, 103u, 104u});
+}
+
+// reuse the possible ranges from above
+TEST_P(RDatasetSpecTest, Friends)
+{
+   std::vector<RDatasetSpec::REntryRange> ranges = {{}, {1, 4}, {2, 4}, {100}, {1, 100}, {2, 2}, {7, 7}};
+   std::vector<std::vector<ULong64_t>> expectedRess = {
+      {100, 101, 102, 103, 104}, {101, 102, 103}, {102, 103}, {100, 101, 102, 103, 104}, {101, 102, 103, 104}, {}, {}};
+   std::vector<std::vector<RDatasetSpec>> specs;
+   // all entries across a column of specs should be the same, where each column tests all constructors
+   for (const auto &r : ranges) {
+      specs.push_back({});
+      specs.back().push_back(RDatasetSpec("tree", "specTestFile0.root", r));
+      specs.back().push_back(
+         RDatasetSpec("subTree", {"specTestFile1.root"s, "specTestFile2.root"s, "specTestFile3.root"s}, r));
+      specs.back().push_back(RDatasetSpec({{"subTreeA"s, "specTestFile4.root"s},
+                                           {"subTreeB"s, "specTestFile5.root"s},
+                                           {"subTree"s, "specTestFile3.root"s}},
+                                          r));
+
+      // add all possible friends to every specification
+      // friends cannot take range but can be shorter/longer than the main chain
+      for (auto &sp : specs.back()) {
+         sp.AddFriend("tree", "specTestFile0.root", "friendTree");
+         sp.AddFriend("subTree", "specTestFile1.root", "friendShortTree");
+         sp.AddFriend("subTree", {"specTestFile1.root"s, "specTestFile2.root"s, "specTestFile3.root"s}, "friendChain1");
+         sp.AddFriend("subTree", {"specTestFile1.root"s, "specTestFile2.root"s}, "friendShortChain1");
+         sp.AddFriend({{"subTreeA"s, "specTestFile4.root"s},
+                       {"subTreeB"s, "specTestFile5.root"s},
+                       {"subTree"s, "specTestFile3.root"s}},
+                      "friendChainN");
+         sp.AddFriend({{"subTreeA"s, "specTestFile4.root"s}, {"subTreeB"s, "specTestFile5.root"s}},
+                      "friendShortChainN");
+      }
+   }
+
+   // ensure that the friends did not "corrupt" the main chain
+   for (auto i = 0u; i < ranges.size(); ++i) {
+      for (const auto &s : specs[i]) {
+         auto res = *(RDataFrame(s).Take<ULong64_t>("z"));
+         std::sort(res.begin(), res.end());
+         EXPECT_VEC_EQ(res, expectedRess[i]);
+      }
+   }
+
+   // TODO: error out on shorter friends, as currently silent garbage is produced
+   // this garbage is of no interest to be tested
+   for (auto i = 0u; i < ranges.size(); ++i) {
+      for (const auto &s : specs[i]) {
+         // nested structure so that the event loop is not called multiple times with different actions
+         std::vector<ROOT::RDF::RResultPtr<std::vector<ULong64_t>>> friends;
+         friends.push_back(RDataFrame(s).Take<ULong64_t>("friendTree.z"));
+         // friends.push_back(RDataFrame(s).Take<ULong64_t>("friendShortTree.z"));
+         friends.push_back(RDataFrame(s).Take<ULong64_t>("friendChain1.z"));
+         // friends.push_back(RDataFrame(s).Take<ULong64_t>("friendShortChain1.z"));
+         friends.push_back(RDataFrame(s).Take<ULong64_t>("friendChainN.z"));
+         // friends.push_back(RDataFrame(s).Take<ULong64_t>("friendShortChainN.z"));
+
+         for (auto &fr : friends) {
+            std::sort(fr->begin(), fr->end());
+            EXPECT_VEC_EQ(*fr, expectedRess[i]);
+         }
+      }
+   }
+}
+
+TEST_P(RDatasetSpecTest, Histo1D)
+{
+   RDatasetSpec spec(
+      {{"subTree0"s, "specTestFile6.root"s}, {"subTree1"s, "specTestFile7.root"s}}); // vertical concatenation
+   spec.AddFriend(
+      {{"subTree2"s, "specTestFile8.root"s}, {"subTree3"s, "specTestFile9.root"s}}); // horizontal concatenation
+   ROOT::RDataFrame d(spec);
+
+   auto h1 = d.Histo1D(::TH1D("h1", "h1", 10, 0, 10), "x");
+   auto h2 = d.Histo1D({"h2", "h2", 10, 0, 10}, "x");
+   auto h1w = d.Histo1D(::TH1D("h0w", "h0w", 10, 0, 10), "x", "w");
+   auto h2w = d.Histo1D({"h2w", "h2w", 10, 0, 10}, "x", "w");
+   std::vector<double> edgesd{1, 2, 3, 4, 5, 6, 10};
+   auto h1edgesd = d.Histo1D(::TH1D("h1edgesd", "h1edgesd", (int)edgesd.size() - 1, edgesd.data()), "x");
+   auto h2edgesd = d.Histo1D({"h2edgesd", "h2edgesd", (int)edgesd.size() - 1, edgesd.data()}, "x");
+
+   ROOT::RDF::TH1DModel m0("m0", "m0", 10, 0, 10);
+   ROOT::RDF::TH1DModel m1(::TH1D("m1", "m1", 10, 0, 10));
+
+   auto hm0 = d.Histo1D(m0, "x");
+   auto hm1 = d.Histo1D(m1, "x");
+   auto hm0w = d.Histo1D(m0, "x", "w");
+   auto hm1w = d.Histo1D(m1, "x", "w");
+
+   std::vector<double> ref({0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10.});
+
+   auto CheckBins = [](const TAxis *axis, const std::vector<double> &v) {
+      auto nBins = axis->GetNbins();
+      auto nBinsp1 = nBins + 1;
+      auto nBinsm1 = nBins - 1;
+      EXPECT_EQ(nBinsp1, (int)v.size());
+      for (auto i : ROOT::TSeqI(1, nBinsp1)) {
+         EXPECT_DOUBLE_EQ(axis->GetBinLowEdge(i), (double)v[i - 1]);
+      }
+      EXPECT_DOUBLE_EQ(axis->GetBinUpEdge(nBinsm1), (double)v[nBinsm1]);
+   };
+
+   CheckBins(h1->GetXaxis(), ref);
+   CheckBins(h2->GetXaxis(), ref);
+   CheckBins(hm0->GetXaxis(), ref);
+   CheckBins(hm1->GetXaxis(), ref);
+   CheckBins(h1edgesd->GetXaxis(), edgesd);
+   CheckBins(h2edgesd->GetXaxis(), edgesd);
+}
+
+TEST_P(RDatasetSpecTest, FilterDependingOnVariation)
+{
+   RDatasetSpec spec(
+      {{"subTree0"s, "specTestFile6.root"s}, {"subTree1"s, "specTestFile7.root"s}}); // vertical concatenation
+   spec.AddFriend(
+      {{"subTree2"s, "specTestFile8.root"s}, {"subTree3"s, "specTestFile9.root"s}}); // horizontal concatenation
+   auto df = ROOT::RDataFrame(spec);
+
+   auto sum = df.Vary(
+                   "x",
+                   [](double x) {
+                      return ROOT::RVecD{x - 1., x + 2.};
+                   },
+                   {"x"}, 2)
+                 .Filter([](double x) { return x > 5.; }, {"x"})
+                 .Sum<double>("x");
+   auto fr_sum = df.Vary(
+                      "w",
+                      [](double w) {
+                         return ROOT::RVecD{w - 1., w + 2.};
+                      },
+                      {"w"}, 2)
+                    .Filter([](double w) { return w > 5.; }, {"w"})
+                    .Sum<double>("w");
+   EXPECT_EQ(*sum, 30);
+   EXPECT_EQ(*fr_sum, 40);
+
+   auto sums = ROOT::RDF::Experimental::VariationsFor(sum);
+   auto fr_sums = ROOT::RDF::Experimental::VariationsFor(fr_sum);
+
+   EXPECT_EQ(sums["nominal"], 30);
+   EXPECT_EQ(sums["x:0"], 21);
+   EXPECT_EQ(sums["x:1"], 51);
+   EXPECT_EQ(fr_sums["nominal"], 40);
+   EXPECT_EQ(fr_sums["w:0"], 30);
+   EXPECT_EQ(fr_sums["w:1"], 63);
+}
+
+TEST(RDatasetSpecTest, Describe)
+{
+   auto dfWriter1 = RDataFrame(10)
+                       .Define("x", [](ULong64_t e) { return double(e); }, {"rdfentry_"})
+                       .Define("w", [](ULong64_t e) { return e + 1.; }, {"rdfentry_"});
+   dfWriter1.Range(5).Snapshot<double>("subTree0", "specTestFile12.root", {"x"});
+   dfWriter1.Range(5, 10).Snapshot<double>("subTree1", "specTestFile13.root", {"x"});
+   dfWriter1.Range(5).Snapshot<double>("subTree2", "specTestFile14.root", {"w"});
+   dfWriter1.Range(5, 10).Snapshot<double>("subTree3", "specTestFile15.root", {"w"});
+
+   RDatasetSpec spec(
+      {{"subTree0"s, "specTestFile12.root"s}, {"subTree1"s, "specTestFile13.root"s}}); // vertical concatenation
+   spec.AddFriend(
+      {{"subTree2"s, "specTestFile14.root"s}, {"subTree3"s, "specTestFile15.root"s}}); // horizontal concatenation
+   auto df = ROOT::RDataFrame(spec);
+   auto res0 = df.Sum<double>("x");
+   auto res1 = df.Sum<double>("w");
+
+   static const std::string expectedDescribe("Dataframe from TChain  in files\n"
+                                             "  specTestFile12.root\n"
+                                             "  specTestFile13.root\n"
+                                             "with friend\n"
+                                             "  \n"
+                                             "    subTree2 specTestFile14.root\n"
+                                             "    subTree3 specTestFile15.root\n"
+                                             "\n"
+                                             "Property                Value\n"
+                                             "--------                -----\n"
+                                             "Columns in total            2\n"
+                                             "Columns from defines        0\n"
+                                             "Event loops run             0\n"
+                                             "Processing slots            1\n"
+                                             "\n"
+                                             "Column  Type            Origin\n"
+                                             "------  ----            ------\n"
+                                             "w       Double_t        Dataset\n"
+                                             "x       Double_t        Dataset");
+   EXPECT_EQ(expectedDescribe, df.Describe().AsString());
+   for (auto i = 12u; i < 16; ++i)
+      gSystem->Unlink(("specTestFile" + std::to_string(i) + ".root").c_str());
+}
+
+// instantiate single-thread tests
+INSTANTIATE_TEST_SUITE_P(Seq, RDatasetSpecTest, ::testing::Values(false));

--- a/tree/tree/inc/ROOT/InternalTreeUtils.hxx
+++ b/tree/tree/inc/ROOT/InternalTreeUtils.hxx
@@ -55,6 +55,14 @@ struct RFriendInfo {
       vector with a single empty string.
    */
    std::vector<std::vector<std::string>> fFriendChainSubNames;
+
+   void AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias = "");
+
+   void
+   AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs, const std::string &alias = "");
+
+   void AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
+                  const std::string &alias = "");
 };
 
 std::vector<std::string> GetFileNamesFromTree(const TTree &tree);

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -22,6 +22,61 @@ namespace Internal {
 namespace TreeUtils {
 
 ////////////////////////////////////////////////////////////////////////////////
+/// \brief Add information of a single friend.
+///
+/// \param[in] treeName Name of the tree.
+/// \param[in] fileNameGlob Path to the file. Refer to TChain::Add for globbing rules.
+/// \param[in] alias Alias for this friend.
+void RFriendInfo::AddFriend(const std::string &treeName, const std::string &fileNameGlob, const std::string &alias)
+{
+   fFriendNames.emplace_back(std::make_pair(treeName, alias));
+   fFriendFileNames.emplace_back(std::vector<std::string>{fileNameGlob});
+   fFriendChainSubNames.emplace_back();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Add information of a single friend.
+///
+/// \param[in] treeName Name of the tree.
+/// \param[in] fileNameGlobs Paths to the files. Refer to TChain::Add for globbing rules.
+/// \param[in] alias Alias for this friend.
+void RFriendInfo::AddFriend(const std::string &treeName, const std::vector<std::string> &fileNameGlobs,
+                            const std::string &alias)
+{
+   fFriendNames.emplace_back(std::make_pair(treeName, alias));
+   fFriendFileNames.emplace_back(fileNameGlobs);
+   fFriendChainSubNames.emplace_back(std::vector<std::string>(fileNameGlobs.size(), treeName));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// \brief Add information of a single friend.
+///
+/// \param[in] treeAndFileNameGlobs Pairs of (treename, filename). Refer to TChain::Add for globbing rules.
+/// \param[in] alias Alias for this friend.
+void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string>> &treeAndFileNameGlobs,
+                            const std::string &alias)
+{
+   fFriendNames.emplace_back(std::make_pair("", alias));
+
+   fFriendFileNames.emplace_back();
+   fFriendChainSubNames.emplace_back();
+
+   auto &theseFileNames = fFriendFileNames.back();
+   auto &theseChainSubNames = fFriendChainSubNames.back();
+   auto nPairs = treeAndFileNameGlobs.size();
+   theseFileNames.reserve(nPairs);
+   theseChainSubNames.reserve(nPairs);
+
+   auto fSubNamesIt = std::back_inserter(theseFileNames);
+   auto fNamesIt = std::back_inserter(theseChainSubNames);
+
+   for (const auto &names : treeAndFileNameGlobs) {
+      *fSubNamesIt = names.first;
+      *fNamesIt = names.second;
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 /// \fn std::vector<std::string> GetFileNamesFromTree(const TTree &tree)
 /// \ingroup tree
 /// \brief Get and store the file names associated with the input tree.

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -67,8 +67,8 @@ void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string
    theseFileNames.reserve(nPairs);
    theseChainSubNames.reserve(nPairs);
 
-   auto fSubNamesIt = std::back_inserter(theseFileNames);
-   auto fNamesIt = std::back_inserter(theseChainSubNames);
+   auto fSubNamesIt = std::back_inserter(theseChainSubNames);
+   auto fNamesIt = std::back_inserter(theseFileNames);
 
    for (const auto &names : treeAndFileNameGlobs) {
       *fSubNamesIt = names.first;


### PR DESCRIPTION
As an intermediate step, needed was to add interface to add a friend in RFriendInfo. The current v6-26 RDatasetSpec resides in the internal namespace.

This is needed to allow the fix for friends support in DistRDF.