### PR TITLE
Allow also only one parameter in `TF1::SetParameters()`

### DIFF
--- a/hist/hist/inc/TF1.h
+++ b/hist/hist/inc/TF1.h
@@ -651,9 +651,9 @@ public:
       (fFormula) ? fFormula->SetParameters(params) : fParams->SetParameters(params);
       Update();
    }
-   virtual void     SetParameters(Double_t p0, Double_t p1, Double_t p2 = 0, Double_t p3 = 0, Double_t p4 = 0,
-                                  Double_t p5 = 0, Double_t p6 = 0, Double_t p7 = 0, Double_t p8 = 0,
-                                  Double_t p9 = 0, Double_t p10 = 0)
+   virtual void     SetParameters(double p0, double p1 = 0.0, double p2 = 0.0, double p3 = 0.0, double p4 = 0.0,
+                                  double p5 = 0.0, double p6 = 0.0, double p7 = 0.0, double p8 = 0.0,
+                                  double p9 = 0.0, double p10 = 0.0)
    {
       if (fFormula) fFormula->SetParameters(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
       else          fParams->SetParameters(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);


### PR DESCRIPTION
People know that they can use `TF1::SetParameters()` to set the
parameter values of a TF1. For example, when you have two parameters:
```C++
TF1 myexpo("myexp", "[coef] * std::exp(-[rate] * x)", 0, 10);
myexpo.SetParameters(1.0, 0.5);
```

When people get rid of all parameters except for one, they therefore
automatically assume that this will work:

```C++
TF1 myexpo("myexp", "std::exp(-[rate] * x)", 0, 10);
myexpo.SetParameters(0.5);
```

However, it doesn't work because `SetParameters` requires at least two
arguments. This commit suggests to fix that and generalize the function
to take only one parameter as well.

This reduces the surprises people have when interacting with a TF1 and
therefore improves the user experience for first-time ROOT users.
