### PR TITLE
[physics] Add conversion to ROOT::Math::XYZTVector

### DIFF
--- a/math/genvector/inc/Math/GenVector/LorentzVector.h
+++ b/math/genvector/inc/Math/GenVector/LorentzVector.h
@@ -97,7 +97,11 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
           Construct from a foreign 4D vector type, for example, HepLorentzVector
           Precondition: v must implement methods x(), y(), z(), and t()
        */
-       template<class ForeignLorentzVector>
+       template<class ForeignLorentzVector,
+                typename = decltype(std::declval<ForeignLorentzVector>().x()
+                                    + std::declval<ForeignLorentzVector>().y()
+                                    + std::declval<ForeignLorentzVector>().z()
+                                    + std::declval<ForeignLorentzVector>().t())>
        explicit LorentzVector( const ForeignLorentzVector & v) :
           fCoordinates(PxPyPzE4D<Scalar>( v.x(), v.y(), v.z(), v.t()  ) ) { }
 
@@ -132,7 +136,11 @@ ROOT provides specialisations and aliases to them of the ROOT::Math::LorentzVect
           assignment from any other Lorentz vector  implementing
           x(), y(), z() and t()
        */
-       template<class ForeignLorentzVector>
+       template<class ForeignLorentzVector,
+                typename = decltype(std::declval<ForeignLorentzVector>().x()
+                                    + std::declval<ForeignLorentzVector>().y()
+                                    + std::declval<ForeignLorentzVector>().z()
+                                    + std::declval<ForeignLorentzVector>().t())>
        LorentzVector & operator = ( const ForeignLorentzVector & v) {
           SetXYZT( v.x(), v.y(), v.z(), v.t() );
           return *this;

--- a/math/physics/CMakeLists.txt
+++ b/math/physics/CMakeLists.txt
@@ -34,6 +34,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(Physics
   DEPENDENCIES
     Matrix
     MathCore
+    GenVector
   DICTIONARY_OPTIONS
     -writeEmptyRootPCM
 )

--- a/math/physics/inc/TLorentzVector.h
+++ b/math/physics/inc/TLorentzVector.h
@@ -24,10 +24,9 @@
 #include "TMath.h"
 #include "TVector3.h"
 #include "TRotation.h"
-
+#include "Math/Vector4D.h"
 
 class TLorentzRotation;
-
 
 class TLorentzVector : public TObject {
 
@@ -256,6 +255,10 @@ public:
    TLorentzVector & operator *= (const TLorentzRotation &);
    TLorentzVector & Transform(const TLorentzRotation &);
    // Transformation with HepLorenzRotation.
+
+   operator ROOT::Math::PxPyPzEVector() const {
+      return {Px(), Py(), Pz(), E()};
+   }
 
    void        Print(Option_t *option="") const override;
 

--- a/test/stressVector.cxx
+++ b/test/stressVector.cxx
@@ -66,7 +66,7 @@
 using namespace ROOT::Math;
 
 
-
+bool gTestResultSuccess = true;
 
 class VectorTest {
 
@@ -107,6 +107,7 @@ public:
     std::cout.precision(16);
     std::cout << s1 << "\t" << s2 <<"\t" << s3 << "\n";
     std::cout << "Test " << name << " failed !!\n\n";
+    gTestResultSuccess = false;
     return -1;
   }
 
@@ -653,5 +654,9 @@ int main(int argc,const char *argv[]) {
 
   //tr.dump();
 
+  if (!gTestResultSuccess)
+    return 1;
+
+  return 0;
 }
 

--- a/test/stressVector.cxx
+++ b/test/stressVector.cxx
@@ -542,7 +542,7 @@ int main(int argc,const char *argv[]) {
       s1=a.testDeltaR   (v1, t, t1,      "DeltaR   TLorentzVector      " );
       s2=a.testDeltaR   (v2, t, t2,      "DeltaR   XYZTVector          " );
       s3=a.testDeltaR   (v3, t, t3,      "DeltaR   PtEtaPhiEVector     " );
-      a.check("DeltaR",s1,s2,s3,10);
+      a.check("DeltaR",s1,s2,s3,15);
 
 
       int n1, n2, n3;

--- a/test/stressVector.cxx
+++ b/test/stressVector.cxx
@@ -640,6 +640,19 @@ int main(int argc,const char *argv[]) {
       a.check("BoostX2",s1,s2,s3,10);
 
 
+      // test TLorentzVector => ROOT::Math::PxPyPzEVector conversion.
+      TLorentzVector lv(0.1, 0.2, 0.3, 0.4);
+      ROOT::Math::PxPyPzEVector xyze(lv);
+      auto checkConversion = [](double l, double g, const char* what) {
+        if (l != g) {
+          std::cerr << "ERROR: PxPyPzEVector::" << what << "()\n";
+          gTestResultSuccess = false;
+        }
+      };
+      checkConversion(lv.X(), xyze.X(), "X");
+      checkConversion(lv.Y(), xyze.Y(), "Y");
+      checkConversion(lv.Z(), xyze.Z(), "Z");
+      checkConversion(lv.E(), xyze.E(), "E");
 
       // clean all at the end
       a.clear(v1);


### PR DESCRIPTION
As a wonderful side-effect, this adds support for construction from a TLorentzVector.

See https://root-forum.cern.ch/t/problem-initializing-a-4-vector/50789
