### PR TITLE
[core] Fix typo in `CompressionSettings()` declaration

### DIFF
--- a/core/zip/inc/Compression.h
+++ b/core/zip/inc/Compression.h
@@ -121,7 +121,7 @@ enum ECompressionAlgorithm {
    kUndefinedCompressionAlgorithm = RCompressionSetting::EAlgorithm::kUndefined
 };
 
-int CompressionSettings(RCompressionSetting::EAlgorithm algorithm, int compressionLevel);
+int CompressionSettings(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel);
 /// Deprecated name, do *not* use:
 int CompressionSettings(ROOT::ECompressionAlgorithm algorithm, int compressionLevel);
 } // namespace ROOT

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -67,7 +67,7 @@ public:
 
    int GetCompression() const { return fCompression; }
    void SetCompression(int val) { fCompression = val; }
-   void SetCompression(RCompressionSetting::EAlgorithm algorithm, int compressionLevel) {
+   void SetCompression(RCompressionSetting::EAlgorithm::EValues algorithm, int compressionLevel) {
       fCompression = CompressionSettings(algorithm, compressionLevel);
    }
 


### PR DESCRIPTION
Fix typo in `CompressionSettings()` function declaration to match definition in `Compression.cxx`.  Many thanks for reporting @mnowakgit!

This typo caused the following to fail:
```
root [0] auto c = ROOT::RCompressionSetting::EAlgorithm::kZSTD;
root [1] CompressionSettings(c, 5);
input_line_10:2:3: error: no matching function for call to 'CompressionSettings'
 (CompressionSettings(((*(enum ROOT::RCompressionSetting::EAlgorithm::EValues*)0x7f02285f4010)), 5))
  ^~~~~~~~~~~~~~~~~~~
/home/jalopezg/_build/include/Compression.h:124:5: note: candidate function not viable: no known conversion from 'enum ROOT::RCompressionSetting::EAlgorithm::EValues' to 'RCompressionSetting::EAlgorithm' for 1st argument
int CompressionSettings(RCompressionSetting::EAlgorithm algorithm, int compressionLevel);
    ^
/home/jalopezg/_build/include/Compression.h:126:5: note: candidate function not viable: no known conversion from 'enum ROOT::RCompressionSetting::EAlgorithm::EValues' to 'ROOT::ECompressionAlgorithm' for 1st argument
int CompressionSettings(ROOT::ECompressionAlgorithm algorithm, int compressionLevel);
    ^
```

## Checklist:
- [X] tested changes locally
- [ ] updated the docs (if necessary) 