### PR TITLE
[TMVA][SOFIE] Add support for Reshape layer in Keras parser

### DIFF
--- a/tmva/pymva/test/EmitFromKeras.cxx
+++ b/tmva/pymva/test/EmitFromKeras.cxx
@@ -45,6 +45,10 @@ int main(){
    RModel modelConv2D_Same = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelConv2D_Same.h5");
    modelConv2D_Same.Generate();
    modelConv2D_Same.OutputGenerated("KerasConv2D_Same.hxx");
+   //Emitting header file for Keras model with Reshape layer
+   RModel modelReshape = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelReshape.h5");
+   modelReshape.Generate();
+   modelReshape.OutputGenerated("KerasReshapeModel.hxx");
 
    return 0;
 }

--- a/tmva/pymva/test/TestRModelParserKeras.C
+++ b/tmva/pymva/test/TestRModelParserKeras.C
@@ -233,13 +233,28 @@ TEST(RModelParser_Keras, CONV_SAME)
       EXPECT_LE(std::abs(outputConv2D_Same[i] - pOutputConv2DSame[i]), TOLERANCE);
     }
 }
-    
+
 TEST(RModelParser_Keras, RESHAPE)
 {
     constexpr float TOLERANCE = DEFAULT_TOLERANCE;
     float inputReshape[]={1,1,1,1};
     TMVA_SOFIE_KerasModelReshape::Session s("KerasReshapeModel.dat");
     std::vector<float> outputReshape = s.infer(inputReshape);
+
+    Py_Initialize();
+    PyObject* main = PyImport_AddModule("__main__");
+    PyObject* fGlobalNS = PyModule_GetDict(main);
+    PyObject* fLocalNS = PyDict_New();
+    if (!fGlobalNS) {
+        throw std::runtime_error("Can't init global namespace for Python");
+        }
+    if (!fLocalNS) {
+        throw std::runtime_error("Can't init local namespace for Python");
+        }
+    PyRun_String("import os",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("from tensorflow.keras.models import load_model",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("import numpy",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("model=load_model('KerasModelReshape.h5')",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("input=numpy.ones((1,4))",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("output=model(input).numpy()",Py_single_input,fGlobalNS,fLocalNS);

--- a/tmva/pymva/test/generateKerasModels.py
+++ b/tmva/pymva/test/generateKerasModels.py
@@ -3,7 +3,7 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 
 import numpy as np
 from tensorflow.keras.models import Model,Sequential
-from tensorflow.keras.layers import Input,Dense,Activation,ReLU,BatchNormalization,Conv2D
+from tensorflow.keras.layers import Input,Dense,Activation,ReLU,BatchNormalization,Conv2D,Reshape
 from tensorflow.keras.optimizers import SGD
 
 def generateFunctionalModel():
@@ -75,9 +75,24 @@ def generateConv2DModel_SamePadding():
     model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
     model.fit(x_train, y_train, epochs=10, batch_size=2)
     model.save('KerasModelConv2D_Same.h5')
+    
+def generateReshapeModel():
+    model = Sequential()
+    model.add(Dense(3, input_shape=(4,)))
+    model.add(Reshape((3, 1)))
+
+    randomGenerator=np.random.RandomState(0)
+    x_train=randomGenerator.rand(1,4)
+    y_train=randomGenerator.rand(1,3,1)
+
+    model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
+    model.fit(x_train, y_train, epochs=10, batch_size=2)
+    model.save('KerasModelReshape.h5')
+
 
 generateFunctionalModel()
 generateSequentialModel()
 generateBatchNormModel()
 generateConv2DModel_ValidPadding()
 generateConv2DModel_SamePadding()
+generateReshapeModel()


### PR DESCRIPTION
This PR adds support for parsing the Keras Reshape layer in SOFIE RModel.

## Checklist:
- [x] Parsing function
- [x] Tests
- [x] tested changes locally
- [x] updated the docs (if necessary)

