### PR TITLE
Fix computation of the radiation length and nuclear interaction lengt…

### DIFF
--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -488,24 +488,17 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
    }
    TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
    // compute radlen systematically with G3 formula for a valid material
-   if ( typ == TGeoManager::kRootUnits && radlen>=0 ) {
+   if ( radlen>=0 ) {
       //taken grom Geant3 routine GSMATE
-      constexpr Double_t alr2av = 1.39621E-03*TGeoUnit::cm2;
+      constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
                    (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
-      fRadLen *= TGeoUnit::cm;
-   }
-   else if ( typ == TGeoManager::kG4Units && radlen>=0 ) {
-      //taken grom Geant3 routine GSMATE
-      constexpr Double_t alr2av = 1.39621E-03*TGeant4Unit::cm2;
-      constexpr Double_t al183  = 5.20948;
-      fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
-                   (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
-      fRadLen *= TGeant4Unit::cm;
+      // fRadLen is in TGeo units. Apply conversion factor in requested length-units
+      fRadLen *= (typ == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    }
    // Compute interaction length using the same formula as in GEANT4
-   if ( typ == TGeoManager::kRootUnits && intlen>=0 ) {
+   if ( intlen>=0 ) {
       constexpr Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
       Double_t nilinv = 0.0;
       TGeoElement *elem = GetElement();
@@ -516,20 +509,9 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
       Double_t nbAtomsPerVolume = TGeoUnit::Avogadro*fDensity/elem->A();
       nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
       nilinv *= TGeoUnit::amu/lambda0;
-      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (TGeoUnit::cm/nilinv);
-   }
-   else if ( typ == TGeoManager::kG4Units && intlen>=0 ) {
-      constexpr Double_t lambda0 = 35.*TGeant4Unit::g/TGeant4Unit::cm2;  // [g/cm^2]
-      Double_t nilinv = 0.0;
-      TGeoElement *elem = GetElement();
-      if (!elem) {
-         Fatal("SetRadLen", "Element not found for material %s", GetName());
-         return;
-      }
-      Double_t nbAtomsPerVolume = TGeant4Unit::Avogadro*fDensity/elem->A();
-      nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
-      nilinv *= TGeant4Unit::amu/lambda0;
-      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (TGeant4Unit::cm/nilinv);
+      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (1.0/nilinv);
+      // fIntLen is in TGeo units. Apply conversion factor in requested length-units
+      fIntLen *= (typ == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    }
 }
 
@@ -800,15 +782,10 @@ TGeoMixture::~TGeoMixture()
 
 void TGeoMixture::AverageProperties()
 {
-   TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
-   const Double_t cm   = (typ==TGeoManager::kRootUnits) ? TGeoUnit::cm   : TGeant4Unit::cm;
-   const Double_t cm2  = (typ==TGeoManager::kRootUnits) ? TGeoUnit::cm2  : TGeant4Unit::cm2;
-   const Double_t amu  = (typ==TGeoManager::kRootUnits) ? TGeoUnit::amu  : TGeant4Unit::amu; // [MeV/c^2]
-   const Double_t gram = (typ==TGeoManager::kRootUnits) ? TGeoUnit::gram : TGeant4Unit::gram;
-   const Double_t na   = (typ==TGeoManager::kRootUnits) ? TGeoUnit::Avogadro : TGeant4Unit::Avogadro;
-   const Double_t alr2av  = 1.39621E-03 * cm2;
-   const Double_t al183   = 5.20948;
-   const Double_t lambda0 = 35.*gram/cm2;  // [g/cm^2]
+   constexpr const Double_t na      = TGeoUnit::Avogadro;
+   constexpr const Double_t alr2av  = 1.39621E-03;
+   constexpr const Double_t al183   = 5.20948;
+   constexpr const Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
    Double_t radinv = 0.0;
    Double_t nilinv = 0.0;
    Double_t nbAtomsPerVolume;
@@ -827,10 +804,15 @@ void TGeoMixture::AverageProperties()
       radinv += xinv*fWeights[j];
    }
    radinv *= alr2av*fDensity;
-   if (radinv > 0) fRadLen = cm/radinv;
+   fRadLen = (radinv <= 0) ? TGeoShape::Big() : 1.0 / radinv;
+   // fRadLen is in TGeo units. Apply conversion factor in requested length-units
+   fRadLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
+   
    // Compute interaction length
-   nilinv *= amu/lambda0;
-   fIntLen = (nilinv<=0) ? TGeoShape::Big() : (cm/nilinv);
+   nilinv *= TGeoUnit::amu/lambda0;
+   fIntLen = (nilinv<=0) ? TGeoShape::Big() : 1.0/nilinv;
+   // fIntLen is in TGeo units. Apply conversion factor in requested length-units
+   fIntLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1312,12 +1294,14 @@ void TGeoMixture::ComputeDerivedQuantities()
 void TGeoMixture::ComputeRadiationLength()
 {
    // Formula taken from G4Material.cxx L556
-   const Double_t cm = (TGeoManager::GetDefaultUnits()==TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    Double_t radinv = 0.0 ;
    for (Int_t i=0;i<fNelements;++i) {
-     radinv += fVecNbOfAtomsPerVolume[i]*((TGeoElement*)fElements->At(i))->GetfRadTsai();
+     //                                                                    GetfRadTsai is in units of cm2
+     radinv += fVecNbOfAtomsPerVolume[i]*((TGeoElement*)fElements->At(i))->GetfRadTsai() / TGeoUnit::cm2;
    }
-   fRadLen = (radinv <= 0.0 ? DBL_MAX : cm/radinv);
+   fRadLen = (radinv <= 0.0 ? DBL_MAX : 1.0/radinv);
+   // fRadLen is in TGeo units. Apply conversion factor in requested length-units
+   fRadLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1325,11 +1309,7 @@ void TGeoMixture::ComputeRadiationLength()
 void TGeoMixture::ComputeNuclearInterLength()
 {
    // Formula taken from G4Material.cxx L567
-   TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
-   const Double_t g   = (typ==TGeoManager::kRootUnits) ? TGeoUnit::g   : TGeant4Unit::g;
-   const Double_t cm  = (typ==TGeoManager::kRootUnits) ? TGeoUnit::cm  : TGeant4Unit::cm;
-   const Double_t amu = (typ==TGeoManager::kRootUnits) ? TGeoUnit::amu : TGeant4Unit::amu;
-   const Double_t lambda0  = 35*g/(cm*cm);
+   constexpr Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
    const Double_t twothird = 2.0/3.0;
    Double_t NILinv = 0.0;
    for (Int_t i=0; i<fNelements; ++i) {
@@ -1341,6 +1321,8 @@ void TGeoMixture::ComputeNuclearInterLength()
          NILinv += fVecNbOfAtomsPerVolume[i]*TMath::Exp(twothird*TMath::Log(A));
       }
    }
-   NILinv *= amu/lambda0;
-   fIntLen = (NILinv <= 0.0 ? DBL_MAX : cm/NILinv);
+   NILinv *= TGeoUnit::amu/lambda0;
+   fIntLen = (NILinv <= 0.0 ? DBL_MAX : 1.0/NILinv);
+   // fIntLen is in TGeo units. Apply conversion factor in requested length-units
+   fIntLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }

--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -488,7 +488,7 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
    }
    TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
    // compute radlen systematically with G3 formula for a valid material
-   if ( radlen>=0 ) {
+   if (radlen >= 0) {
       //taken grom Geant3 routine GSMATE
       constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
@@ -498,8 +498,8 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
       fRadLen *= (typ == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    }
    // Compute interaction length using the same formula as in GEANT4
-   if ( intlen>=0 ) {
-      constexpr Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
+   if (intlen >= 0) {
+      constexpr Double_t lambda0 = 35. * TGeoUnit::g / TGeoUnit::cm2; // [g/cm^2]
       Double_t nilinv = 0.0;
       TGeoElement *elem = GetElement();
       if (!elem) {
@@ -508,8 +508,8 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
       }
       Double_t nbAtomsPerVolume = TGeoUnit::Avogadro*fDensity/elem->A();
       nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
-      nilinv *= TGeoUnit::amu/lambda0;
-      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (1.0/nilinv);
+      nilinv *= TGeoUnit::amu / lambda0;
+      fIntLen = (nilinv <= 0) ? TGeoShape::Big() : (1.0 / nilinv);
       // fIntLen is in TGeo units. Apply conversion factor in requested length-units
       fIntLen *= (typ == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    }
@@ -782,10 +782,10 @@ TGeoMixture::~TGeoMixture()
 
 void TGeoMixture::AverageProperties()
 {
-   constexpr const Double_t na      = TGeoUnit::Avogadro;
-   constexpr const Double_t alr2av  = 1.39621E-03;
-   constexpr const Double_t al183   = 5.20948;
-   constexpr const Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
+   constexpr const Double_t na = TGeoUnit::Avogadro;
+   constexpr const Double_t alr2av = 1.39621E-03;
+   constexpr const Double_t al183 = 5.20948;
+   constexpr const Double_t lambda0 = 35. * TGeoUnit::g / TGeoUnit::cm2; // [g/cm^2]
    Double_t radinv = 0.0;
    Double_t nilinv = 0.0;
    Double_t nbAtomsPerVolume;
@@ -807,10 +807,10 @@ void TGeoMixture::AverageProperties()
    fRadLen = (radinv <= 0) ? TGeoShape::Big() : 1.0 / radinv;
    // fRadLen is in TGeo units. Apply conversion factor in requested length-units
    fRadLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
-   
+
    // Compute interaction length
-   nilinv *= TGeoUnit::amu/lambda0;
-   fIntLen = (nilinv<=0) ? TGeoShape::Big() : 1.0/nilinv;
+   nilinv *= TGeoUnit::amu / lambda0;
+   fIntLen = (nilinv <= 0) ? TGeoShape::Big() : 1.0 / nilinv;
    // fIntLen is in TGeo units. Apply conversion factor in requested length-units
    fIntLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }
@@ -1296,10 +1296,10 @@ void TGeoMixture::ComputeRadiationLength()
    // Formula taken from G4Material.cxx L556
    Double_t radinv = 0.0 ;
    for (Int_t i=0;i<fNelements;++i) {
-     //                                                                    GetfRadTsai is in units of cm2
-     radinv += fVecNbOfAtomsPerVolume[i]*((TGeoElement*)fElements->At(i))->GetfRadTsai() / TGeoUnit::cm2;
+      //                                                                      GetfRadTsai is in units of cm2
+      radinv += fVecNbOfAtomsPerVolume[i] * ((TGeoElement *)fElements->At(i))->GetfRadTsai() / TGeoUnit::cm2;
    }
-   fRadLen = (radinv <= 0.0 ? DBL_MAX : 1.0/radinv);
+   fRadLen = (radinv <= 0.0 ? DBL_MAX : 1.0 / radinv);
    // fRadLen is in TGeo units. Apply conversion factor in requested length-units
    fRadLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }
@@ -1309,20 +1309,20 @@ void TGeoMixture::ComputeRadiationLength()
 void TGeoMixture::ComputeNuclearInterLength()
 {
    // Formula taken from G4Material.cxx L567
-   constexpr Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
+   constexpr Double_t lambda0 = 35. * TGeoUnit::g / TGeoUnit::cm2; // [g/cm^2]
    const Double_t twothird = 2.0/3.0;
    Double_t NILinv = 0.0;
    for (Int_t i=0; i<fNelements; ++i) {
-      Int_t Z = static_cast<Int_t>(((TGeoElement*)fElements->At(i))->Z()+0.5);
+      Int_t Z = static_cast<Int_t>(((TGeoElement *)fElements->At(i))->Z() + 0.5);
       Double_t A = ((TGeoElement*)fElements->At(i))->Neff();
       if(1 == Z) {
-         NILinv += fVecNbOfAtomsPerVolume[i]*A;
+         NILinv += fVecNbOfAtomsPerVolume[i] * A;
       } else {
-         NILinv += fVecNbOfAtomsPerVolume[i]*TMath::Exp(twothird*TMath::Log(A));
+         NILinv += fVecNbOfAtomsPerVolume[i] * TMath::Exp(twothird * TMath::Log(A));
       }
    }
-   NILinv *= TGeoUnit::amu/lambda0;
-   fIntLen = (NILinv <= 0.0 ? DBL_MAX : 1.0/NILinv);
+   NILinv *= TGeoUnit::amu / lambda0;
+   fIntLen = (NILinv <= 0.0 ? DBL_MAX : 1.0 / NILinv);
    // fIntLen is in TGeo units. Apply conversion factor in requested length-units
    fIntLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }


### PR DESCRIPTION
…h when ROOT uses G4 units

# This Pull request:
The PR fixes the computation of the radiation length and nuclear interaction length
  which are computed wrongly when ROOT uses in G4 units.

## Changes or fixes:
All in TGeoMaterial.cpp
  The fix is based on an initial pull request from Ivana:
  https://github.com/root-project/root/pull/9401  
  which did miss the necessary changes for mixtures.

  Output from constructing Iron from:
```
99.5 %   Element: FE      Z=26   N=56.000000   A=55.845000 [g/mole]
 0.5 %   Element: C      Z=6   N=12.000000   A=12.010700 [g/mole]
```
  - ROOT units:
```
    $> root.exe material_test.C\(\"ROOT\"\)
Material Iron    A=55.845 Z=26 rho=7.874 radlen=1.75666 intlen=0.0271712 index=0
TGeoMaterial   Iron
		 Density:  		7.874 [g/cm^3]
		 Radiation   Length: 	1.75666 [cm] 
		 Interaction Length: 	16.9589 [cm] 
```
  - Geant4 units:
```
    $> root.exe material_test.C\(\"G4\"\)
Material Iron    A=55.845 Z=26 rho=7.874 radlen=17.5666 intlen=0.271712 index=3
TGeoMaterial   Iron
		 Density:  		7.874 [g/cm^3]
		 Radiation   Length: 	17.5666 [mm] 
		 Interaction Length: 	169.589 [mm] 
```
PDG (https://pdg.lbl.gov/2020/AtomicNuclearProperties/HTML/iron_Fe.html):
```
Specific gravity 	        7.874 	g cm-3
Nuclear interaction length 	132.1 	g cm-2 	16.77 	cm
Radiation length 	        13.84 	g cm-2 	1.757 	cm
```

## Checklist:

- [X ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

