### PR TITLE
[skip-ci] Raise exception in TFile constructor when remote path is passed

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tfile.py
@@ -84,6 +84,8 @@ def _TFileConstructor(self, *args):
     # Parameters:
     # self: instance of TFile class
     # *args: arguments passed to the constructor
+    if len(args) > 0 and "://" in args[0]:
+        raise ValueError("Cannot handle path to remote file '{}' in TFile constructor. Use TFile::Open instead.".format(args[0]))
     self._OriginalConstructor(*args)
     if len(args) >= 1:
         if self.IsZombie():


### PR DESCRIPTION
The public TFile constructor cannot be used for files that must be read through remote protocols. This is a common source of confusion for users.

I split the error in two commits, one for the C++ constructor and one for its pythonization. I would like to discuss:
1. The wording of the error message
2. The usage of `std::exception` in the C++ side. This should be a better practice in general, but the rest of TFile uses the `TObject::Error` method for this kind of problems. The downside of that is that it doesn't really stop the execution of the program

With the current status, the errors would look like this
```python
>>> import ROOT
>>> f = ROOT.TFile("https://root.cern/files/tutorials/hsimple.root")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vpadulan/programs/rootproject/rootinstall/tfile-constructor-error-distrdf-release/lib/ROOT/_pythonization/_tfile.py", line 88, in _TFileConstructor
    raise ValueError("Cannot handle path to remote file '{}' in TFile constructor. Use TFile::Open instead.".format(args[0]))
ValueError: Cannot handle path to remote file 'https://root.cern/files/tutorials/hsimple.root' in TFile constructor. Use TFile::Open instead.
```
```
$: root.exe
   ------------------------------------------------------------------
  | Welcome to ROOT 6.27/01                        https://root.cern |
  | (c) 1995-2022, The ROOT Team; conception: R. Brun, F. Rademakers |
  | Built for linuxx8664gcc on Jul 27 2022, 19:14:18                 |
  | From heads/master@v6-25-02-1893-ge1d4a59786                      |
  | With c++ (GCC) 12.1.1 20220507 (Red Hat 12.1.1-1)                |
  | Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'  |
   ------------------------------------------------------------------

root [0] TFile f{"https://root.cern/files/tutorials/hsimple.root"};
Error in <TRint::HandleTermInput()>: std::invalid_argument caught: Cannot handle path to remote file 'https://root.cern/files/tutorials/hsimple.root' in TFile constructor. Use TFile::Open instead
```
```
$: ./test.o
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Cannot handle path to remote file 'https://root.cern/files/tutorials/hsimple.root' in TFile constructor. Use TFile::Open instead.
Aborted (core dumped)
```