### PR TITLE
[core][skip-ci] Clarify documentation of `TClass::CopyCollectionProxy()`

### DIFF
--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2464,7 +2464,8 @@ TObject *TClass::Clone(const char *new_name) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Copy the argument.
+/// Replaces the collection proxy for this class. The provided object is cloned
+/// and the copy is then owned by `TClass`.
 
 void TClass::CopyCollectionProxy(const TVirtualCollectionProxy &orig)
 {


### PR DESCRIPTION
This pull request updates the description of `TClass:CopyCollectionProxy()`, which was (sort of) misleading.  Probably the name of the member function is not descriptive either, but that's a different topic.

## Checklist:
- [X] updated the docs (if necessary)