### PR TITLE
[RF] component-based LikelihoodJob mode

### DIFF
--- a/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
@@ -13,6 +13,8 @@
 #ifndef ROOT_ROOFIT_MultiProcess_Config
 #define ROOT_ROOFIT_MultiProcess_Config
 
+#include <cstddef>  // std::size_t
+
 namespace RooFit {
 namespace MultiProcess {
 
@@ -20,6 +22,15 @@ class Config {
 public:
    static void setDefaultNWorkers(unsigned int N_workers);
    static unsigned int getDefaultNWorkers();
+
+   struct LikelihoodJob {
+      // magic values to indicate that the number of tasks will be set automatically
+      constexpr static std::size_t automaticNEventTasks = 0;
+      constexpr static std::size_t automaticNComponentTasks = 0;
+
+      static std::size_t defaultNEventTasks;
+      static std::size_t defaultNComponentTasks;
+   };
 private:
    static unsigned int defaultNWorkers_;
 };

--- a/roofit/multiprocess/src/Config.cxx
+++ b/roofit/multiprocess/src/Config.cxx
@@ -25,8 +25,11 @@ namespace MultiProcess {
  *
  * This class offers user-accessible configuration of the MultiProcess infrastructure.
  * Since the rest of the MultiProcess classes are only accessible at compile time, a
- * separate class is needed to set configuration. Currently, the only configurable
- * part is the number of workers to be deployed.
+ * separate class is needed to set configuration. Currently, the configurable parts
+ * are:
+ * 1. the number of workers to be deployed,
+ * 2. the number of event-tasks in LikelihoodJobs,
+ * 3. and the number of component-tasks in LikelihoodJobs.
  *
  * The default number of workers is set using 'std::thread::hardware_concurrency()'.
  * To change it, use 'Config::setDefaultNWorkers()' to set it to a different value
@@ -34,6 +37,21 @@ namespace MultiProcess {
  * and also cannot be changed after JobManager has been instantiated.
  *
  * Use Config::getDefaultNWorkers() to access the current value.
+ *
+ * Under Config::LikelihoodJob, we find two members for the number of tasks to use to
+ * calculate the range of events and components in parallel, respectively:
+ * defaultNEventTasks and defaultNComponentTasks. Newly created LikelihoodJobs will
+ * then use these values at construction time. Note that (like with the number of
+ * workers) the number cannot be changed for an individual LikelihoodJob after it has
+ * been created.
+ *
+ * Both event- and component-based tasks by default are set to automatic mode using
+ * the automaticNEventTasks and automaticNComponentTasks constants (both under
+ * Config::LikelihoodJob as well). These are currently set to zero, but this could
+ * change. Automatic mode for events means that the number of tasks is set to the
+ * number of workers in the JobManager, with events divided equally over workers. For
+ * components, the automatic mode uses just 1 task for all components. These automatic
+ * modes may change in the future (for instance, we may switch them around).
  */
 
 void Config::setDefaultNWorkers(unsigned int N_workers)
@@ -52,8 +70,10 @@ unsigned int Config::getDefaultNWorkers()
    return defaultNWorkers_;
 }
 
-// initialize static member
+// initialize static members
 unsigned int Config::defaultNWorkers_ = std::thread::hardware_concurrency();
+std::size_t Config::LikelihoodJob::defaultNEventTasks = Config::LikelihoodJob::automaticNEventTasks;
+std::size_t Config::LikelihoodJob::defaultNComponentTasks = Config::LikelihoodJob::automaticNComponentTasks;
 
 } // namespace MultiProcess
 } // namespace RooFit

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
@@ -17,6 +17,7 @@
 #include "RooFit/MultiProcess/Queue.h"
 #include "RooFit/MultiProcess/Job.h"
 #include "RooFit/MultiProcess/types.h"
+#include "RooFit/MultiProcess/Config.h"
 #include "RooFit/TestStatistics/RooAbsL.h"
 #include "RooFit/TestStatistics/RooUnbinnedL.h"
 #include "RooFit/TestStatistics/RooBinnedL.h"
@@ -29,8 +30,10 @@ namespace TestStatistics {
 
 LikelihoodJob::LikelihoodJob(
    std::shared_ptr<RooAbsL> likelihood,
-   std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean /*, RooMinimizer *minimizer*/)
-   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean) /*, minimizer*/)
+   std::shared_ptr<WrapperCalculationCleanFlags> calculation_is_clean)
+   : LikelihoodWrapper(std::move(likelihood), std::move(calculation_is_clean)),
+     n_event_tasks_(MultiProcess::Config::LikelihoodJob::defaultNEventTasks),
+     n_component_tasks_(MultiProcess::Config::LikelihoodJob::defaultNComponentTasks)
 {
    init_vars();
    // determine likelihood type
@@ -105,6 +108,32 @@ void LikelihoodJob::update_state()
    }
 }
 
+/// \warning In automatic mode, this function can start MultiProcess (forks, starts workers, etc)!
+std::size_t LikelihoodJob::getNEventTasks()
+{
+   std::size_t val = n_event_tasks_;
+   if (val == MultiProcess::Config::LikelihoodJob::automaticNEventTasks) {
+      val = get_manager()->process_manager().N_workers();
+   }
+   if (val > likelihood_->getNEvents()) {
+      val = likelihood_->getNEvents();
+   }
+   return val;
+}
+
+
+std::size_t LikelihoodJob::getNComponentTasks()
+{
+   std::size_t val = n_component_tasks_;
+   if (val == MultiProcess::Config::LikelihoodJob::automaticNComponentTasks) {
+      val = 1;
+   }
+   if (val > likelihood_->getNComponents()) {
+      val = likelihood_->getNComponents();
+   }
+   return val;
+}
+
 void LikelihoodJob::updateWorkersParameters()
 {
    if (get_manager()->process_manager().is_master()) {
@@ -155,10 +184,11 @@ void LikelihoodJob::evaluate()
       updateWorkersParameters();
 
       // master fills queue with tasks
-      for (std::size_t ix = 0; ix < get_manager()->process_manager().N_workers(); ++ix) {
+      auto N_tasks = getNEventTasks() * getNComponentTasks();
+      for (std::size_t ix = 0; ix < N_tasks; ++ix) {
          get_manager()->queue().add({id_, state_id_, ix});
       }
-      N_tasks_at_workers_ = get_manager()->process_manager().N_workers();
+      n_tasks_at_workers_ = N_tasks;
 
       // wait for task results back from workers to master
       gather_worker_results();
@@ -186,8 +216,8 @@ bool LikelihoodJob::receive_task_result_on_master(const zmq::message_t &message)
 {
    auto task_result = message.data<task_result_t>();
    results_.emplace_back(task_result->value, task_result->carry);
-   --N_tasks_at_workers_;
-   bool job_completed = (N_tasks_at_workers_ == 0);
+   --n_tasks_at_workers_;
+   bool job_completed = (n_tasks_at_workers_ == 0);
    return job_completed;
 }
 
@@ -197,22 +227,40 @@ void LikelihoodJob::evaluate_task(std::size_t task)
 {
    assert(get_manager()->process_manager().is_worker());
 
-   std::size_t N_events = likelihood_->numDataEntries();
-
-   // used to have multiple modes here, but only kept "bulk" mode; dropped interleaved, single_event and all_events from
-   // old MultiProcess::NLLVar
-   std::size_t first = N_events * task / get_manager()->process_manager().N_workers();
-   std::size_t last = N_events * (task + 1) / get_manager()->process_manager().N_workers();
+   double section_first = 0;
+   double section_last = 1;
+   if (getNEventTasks() > 1) {
+      std::size_t event_task = task % getNEventTasks();
+      std::size_t N_events = likelihood_->numDataEntries();
+      if (event_task > 0) {
+         std::size_t first = N_events * event_task / getNEventTasks();
+         section_first = static_cast<double>(first) / N_events;
+      }
+      if (event_task < getNEventTasks() - 1) {
+         std::size_t last = N_events * (event_task + 1) / getNEventTasks();
+         section_last = static_cast<double>(last) / N_events;
+      }
+   }
 
    switch (likelihood_type_) {
    case LikelihoodType::unbinned:
    case LikelihoodType::binned: {
-      result_ = likelihood_->evaluatePartition(
-         {static_cast<double>(first) / N_events, static_cast<double>(last) / N_events}, 0, 0);
+      result_ = likelihood_->evaluatePartition({section_first, section_last}, 0, 0);
       break;
    }
    case LikelihoodType::sum: {
-      result_ = likelihood_->evaluatePartition( {static_cast<double>(first) / N_events, static_cast<double>(last) / N_events}, 0, likelihood_->getNComponents());
+      std::size_t components_first = 0;
+      std::size_t components_last = likelihood_->getNComponents();
+      if (getNComponentTasks() > 1) {
+         std::size_t component_task = task / getNEventTasks();
+         components_first = likelihood_->getNComponents() * component_task / getNComponentTasks();
+         if (component_task == getNComponentTasks() - 1) {
+            components_last = likelihood_->getNComponents();
+         } else {
+            components_last = likelihood_->getNComponents() * (component_task + 1) / getNComponentTasks();
+         }
+      }
+      result_ = likelihood_->evaluatePartition({section_first, section_last}, components_first, components_last);
       break;
    }
 

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.h
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.h
@@ -70,7 +70,13 @@ private:
    RooArgList save_vars_; // Copy of variables
 
    LikelihoodType likelihood_type_;
-   std::size_t N_tasks_at_workers_ = 0;
+   std::size_t n_tasks_at_workers_ = 0;
+
+   // warning: don't use the following values directly, use the getters instead!
+   std::size_t n_event_tasks_;
+   std::size_t n_component_tasks_;
+   std::size_t getNEventTasks();
+   std::size_t getNComponentTasks();
 };
 
 std::ostream &operator<<(std::ostream &out, const LikelihoodJob::update_state_mode value);

--- a/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooUnbinnedL.cxx
@@ -103,7 +103,7 @@ RooUnbinnedL::evaluatePartition(Section events, std::size_t /*components_begin*/
    }
 
    // include the extended maximum likelihood term, if requested
-   if (extended_ && events.begin(N_events_) == 0) {
+   if (extended_ && events.begin_fraction == 0) {
       if (apply_weight_squared) {
 
          // TODO: the following should also be factored out into free/static functions like RooNLLVar::Compute*


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
**Commit 1 (2932c2af9ce19d346807a39d990d77efd1169e09): bug fix.** When using a fractional event range smaller than an actual (integral) event, rounding to integers would cause the extended term in unbinned likelihoods in `RooUnbinnedL` to be added multiple times.
**Commit 2 (18cb82c9ef0aed0b30f08b62b3161aa3a2bc3a29): new `LikelihoodJob` mode.** `LikelihoodJob` would parallelize over events, just like the old bulk parallelization mode of `RooNLLVar` (through `RooRealMPFE`). Now it can also parallelize over components and the two modes can be mixed as well to parallelize over both, allowing the user to define an optimal splitting for their usecase.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)