### PR TITLE
[RF] Correctly forward integrator config in RooImproperIntegrator1D

### DIFF
--- a/roofit/roofitcore/inc/RooImproperIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooImproperIntegrator1D.h
@@ -30,7 +30,6 @@ public:
   RooImproperIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config);
   RooImproperIntegrator1D(const RooAbsFunc& function, double xmin, double xmax, const RooNumIntConfig& config);
   RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
-  ~RooImproperIntegrator1D() override;
 
   bool checkLimits() const override;
   using RooAbsIntegrator::setLimits ;
@@ -57,10 +56,12 @@ protected:
   mutable double _xmin, _xmax; ///< Value of limits
   bool _useIntegrandLimits;    ///< Use limits in function binding?
 
-  RooAbsFunc*      _origFunc ;  ///< Original function binding
-  RooInvTransform *_function;   ///< Binding with inverse of function
+  RooAbsFunc*      _origFunc = nullptr;  ///< Original function binding
+  std::unique_ptr<RooInvTransform> _function;   ///< Binding with inverse of function
   RooNumIntConfig  _config ;    ///< Configuration object
-  mutable RooIntegrator1D *_integrator1,*_integrator2,*_integrator3; ///< Piece integrators
+  mutable std::unique_ptr<RooIntegrator1D> _integrator1; ///< Piece integrator 1
+  mutable std::unique_ptr<RooIntegrator1D> _integrator2; ///< Piece integrator 2
+  mutable std::unique_ptr<RooIntegrator1D> _integrator3; ///< Piece integrator 3
 
   ClassDefOverride(RooImproperIntegrator1D,0) // 1-dimensional improper integration engine
 };

--- a/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
@@ -37,11 +37,7 @@ and the outer two pieces, if required are calculated using a 1/x transform
 #include "TClass.h"
 
 
-
-using namespace std;
-
 ClassImp(RooImproperIntegrator1D);
-;
 
 // Register this class with RooNumIntConfig
 
@@ -60,8 +56,7 @@ void RooImproperIntegrator1D::registerIntegrator(RooNumIntFactory& fact)
 /// Default constructor
 
 RooImproperIntegrator1D::RooImproperIntegrator1D() :
-  _case(ClosedBothEnds), _xmin(-10), _xmax(10), _useIntegrandLimits(true),
-  _origFunc(0), _function(0), _integrator1(0), _integrator2(0), _integrator3(0)
+  _case(ClosedBothEnds), _xmin(-10), _xmax(10), _useIntegrandLimits(true)
 {
 }
 
@@ -73,11 +68,7 @@ RooImproperIntegrator1D::RooImproperIntegrator1D() :
 RooImproperIntegrator1D::RooImproperIntegrator1D(const RooAbsFunc& function) :
   RooAbsIntegrator(function),
   _useIntegrandLimits(true),
-  _origFunc((RooAbsFunc*)&function),
-  _function(0),
-  _integrator1(0),
-  _integrator2(0),
-  _integrator3(0)
+  _origFunc((RooAbsFunc*)&function)
 {
   initialize(&function) ;
 }
@@ -92,11 +83,7 @@ RooImproperIntegrator1D::RooImproperIntegrator1D(const RooAbsFunc& function, con
   RooAbsIntegrator(function),
   _useIntegrandLimits(true),
   _origFunc((RooAbsFunc*)&function),
-  _function(0),
-  _config(config),
-  _integrator1(0),
-  _integrator2(0),
-  _integrator3(0)
+  _config(config)
 {
   initialize(&function) ;
 }
@@ -112,11 +99,7 @@ RooImproperIntegrator1D::RooImproperIntegrator1D(const RooAbsFunc& function, dou
   _xmax(xmax),
   _useIntegrandLimits(false),
   _origFunc((RooAbsFunc*)&function),
-  _function(0),
-  _config(config),
-  _integrator1(0),
-  _integrator2(0),
-  _integrator3(0)
+  _config(config)
 {
   initialize(&function) ;
 }
@@ -139,34 +122,27 @@ RooAbsIntegrator* RooImproperIntegrator1D::clone(const RooAbsFunc& function, con
 void RooImproperIntegrator1D::initialize(const RooAbsFunc* function)
 {
   if(!isValid()) {
-    oocoutE(nullptr,Integration) << "RooImproperIntegrator: cannot integrate invalid function" << endl;
+    oocoutE(nullptr,Integration) << "RooImproperIntegrator: cannot integrate invalid function" << std::endl;
     return;
   }
   // Create a new function object that uses the change of vars: x -> 1/x
   if (function) {
-    _function= new RooInvTransform(*function);
+    _function= std::make_unique<RooInvTransform>(*function);
   } else {
     function = _origFunc ;
-    if (_integrator1) {
-      delete _integrator1 ;
-      _integrator1 = 0 ;
-    }
-    if (_integrator2) {
-      delete _integrator2 ;
-      _integrator2 = 0 ;
-    }
-    if (_integrator3) {
-      delete _integrator3 ;
-      _integrator3 = 0 ;
-    }
+    _integrator1.reset();
+    _integrator2.reset();
+    _integrator3.reset();
   }
 
   // Helper function to create a new configuration that is just like the one
   // associated to this integrator, but with a different summation rule.
-  auto makeNewConfig = [&](RooIntegrator1D::SummationRule rule) {
+  auto makeIntegrator1D = [&](RooAbsFunc const& func,
+                              double xmin, double xmax,
+                              RooIntegrator1D::SummationRule rule) {
       RooNumIntConfig newConfig{_config}; // copy default configuration
       newConfig.getConfigSection("RooIntegrator1D").setCatIndex("sumRule", rule);
-      return newConfig;
+      return std::make_unique<RooIntegrator1D>(func, xmin, xmax, newConfig);
   };
 
   // partition the integration range into subranges that can each be
@@ -174,50 +150,38 @@ void RooImproperIntegrator1D::initialize(const RooAbsFunc* function)
   switch(_case= limitsCase()) {
   case ClosedBothEnds:
     // both limits are finite: use the plain trapezoid integrator
-    _integrator1= new RooIntegrator1D(*function,_xmin,_xmax,_config);
+    _integrator1 = std::make_unique<RooIntegrator1D>(*function,_xmin,_xmax,_config);
     break;
   case OpenBothEnds:
     // both limits are infinite: integrate over (-1,+1) using
     // the plain trapezoid integrator...
-    _integrator1= new RooIntegrator1D(*function,-1,+1,makeNewConfig(RooIntegrator1D::Trapezoid));
+    _integrator1 = makeIntegrator1D(*function,-1,+1,RooIntegrator1D::Trapezoid);
     // ...and integrate the infinite tails using the midpoint integrator
-    _integrator2= new RooIntegrator1D(*_function,-1,0,makeNewConfig(RooIntegrator1D::Midpoint));
-    _integrator3= new RooIntegrator1D(*_function,0,+1,makeNewConfig(RooIntegrator1D::Midpoint));
+    _integrator2 = makeIntegrator1D(*_function,-1,0,RooIntegrator1D::Midpoint);
+    _integrator3 = makeIntegrator1D(*_function,0,+1,RooIntegrator1D::Midpoint);
     break;
   case OpenBelowSpansZero:
     // xmax >= 0 so integrate from (-inf,-1) and (-1,xmax)
-    _integrator1= new RooIntegrator1D(*_function,-1,0,makeNewConfig(RooIntegrator1D::Midpoint));
-    _integrator2= new RooIntegrator1D(*function,-1,_xmax,makeNewConfig(RooIntegrator1D::Trapezoid));
+    _integrator1 = makeIntegrator1D(*_function,-1,0,RooIntegrator1D::Midpoint);
+    _integrator2 = makeIntegrator1D(*function,-1,_xmax,RooIntegrator1D::Trapezoid);
     break;
   case OpenBelow:
     // xmax < 0 so integrate from (-inf,xmax)
-    _integrator1= new RooIntegrator1D(*_function,1/_xmax,0,makeNewConfig(RooIntegrator1D::Midpoint));
+    _integrator1 = makeIntegrator1D(*_function,1/_xmax,0,RooIntegrator1D::Midpoint);
     break;
   case OpenAboveSpansZero:
     // xmin <= 0 so integrate from (xmin,+1) and (+1,+inf)
-    _integrator1= new RooIntegrator1D(*_function,0,+1,makeNewConfig(RooIntegrator1D::Midpoint));
-    _integrator2= new RooIntegrator1D(*function,_xmin,+1,makeNewConfig(RooIntegrator1D::Trapezoid));
+    _integrator1 = makeIntegrator1D(*_function,0,+1,RooIntegrator1D::Midpoint);
+    _integrator2 = makeIntegrator1D(*function,_xmin,+1,RooIntegrator1D::Trapezoid);
     break;
   case OpenAbove:
     // xmin > 0 so integrate from (xmin,+inf)
-    _integrator1= new RooIntegrator1D(*_function,0,1/_xmin,makeNewConfig(RooIntegrator1D::Midpoint));
+    _integrator1 = makeIntegrator1D(*_function,0,1/_xmin,RooIntegrator1D::Midpoint);
     break;
   case Invalid:
   default:
     _valid= false;
   }
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooImproperIntegrator1D::~RooImproperIntegrator1D()
-{
-  if(0 != _integrator1) delete _integrator1;
-  if(0 != _integrator2) delete _integrator2;
-  if(0 != _integrator3) delete _integrator3;
-  if(0 != _function) delete _function;
 }
 
 
@@ -229,7 +193,7 @@ RooImproperIntegrator1D::~RooImproperIntegrator1D()
 bool RooImproperIntegrator1D::setLimits(double *xmin, double *xmax)
 {
   if(_useIntegrandLimits) {
-    oocoutE(nullptr,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << endl;
+    oocoutE(nullptr,Integration) << "RooIntegrator1D::setLimits: cannot override integrand's limits" << std::endl;
     return false;
   }
 
@@ -337,8 +301,8 @@ RooImproperIntegrator1D::LimitsCase RooImproperIntegrator1D::limitsCase() const
 double RooImproperIntegrator1D::integral(const double* yvec)
 {
   double result(0);
-  if(0 != _integrator1) result+= _integrator1->integral(yvec);
-  if(0 != _integrator2) result+= _integrator2->integral(yvec);
-  if(0 != _integrator3) result+= _integrator3->integral(yvec);
+  if(_integrator1) result+= _integrator1->integral(yvec);
+  if(_integrator2) result+= _integrator2->integral(yvec);
+  if(_integrator3) result+= _integrator3->integral(yvec);
   return result;
 }

--- a/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooImproperIntegrator1D.cxx
@@ -161,6 +161,14 @@ void RooImproperIntegrator1D::initialize(const RooAbsFunc* function)
     }
   }
 
+  // Helper function to create a new configuration that is just like the one
+  // associated to this integrator, but with a different summation rule.
+  auto makeNewConfig = [&](RooIntegrator1D::SummationRule rule) {
+      RooNumIntConfig newConfig{_config}; // copy default configuration
+      newConfig.getConfigSection("RooIntegrator1D").setCatIndex("sumRule", rule);
+      return newConfig;
+  };
+
   // partition the integration range into subranges that can each be
   // handled by RooIntegrator1D
   switch(_case= limitsCase()) {
@@ -171,28 +179,28 @@ void RooImproperIntegrator1D::initialize(const RooAbsFunc* function)
   case OpenBothEnds:
     // both limits are infinite: integrate over (-1,+1) using
     // the plain trapezoid integrator...
-    _integrator1= new RooIntegrator1D(*function,-1,+1,RooIntegrator1D::Trapezoid);
+    _integrator1= new RooIntegrator1D(*function,-1,+1,makeNewConfig(RooIntegrator1D::Trapezoid));
     // ...and integrate the infinite tails using the midpoint integrator
-    _integrator2= new RooIntegrator1D(*_function,-1,0,RooIntegrator1D::Midpoint);
-    _integrator3= new RooIntegrator1D(*_function,0,+1,RooIntegrator1D::Midpoint);
+    _integrator2= new RooIntegrator1D(*_function,-1,0,makeNewConfig(RooIntegrator1D::Midpoint));
+    _integrator3= new RooIntegrator1D(*_function,0,+1,makeNewConfig(RooIntegrator1D::Midpoint));
     break;
   case OpenBelowSpansZero:
     // xmax >= 0 so integrate from (-inf,-1) and (-1,xmax)
-    _integrator1= new RooIntegrator1D(*_function,-1,0,RooIntegrator1D::Midpoint);
-    _integrator2= new RooIntegrator1D(*function,-1,_xmax,RooIntegrator1D::Trapezoid);
+    _integrator1= new RooIntegrator1D(*_function,-1,0,makeNewConfig(RooIntegrator1D::Midpoint));
+    _integrator2= new RooIntegrator1D(*function,-1,_xmax,makeNewConfig(RooIntegrator1D::Trapezoid));
     break;
   case OpenBelow:
     // xmax < 0 so integrate from (-inf,xmax)
-    _integrator1= new RooIntegrator1D(*_function,1/_xmax,0,RooIntegrator1D::Midpoint);
+    _integrator1= new RooIntegrator1D(*_function,1/_xmax,0,makeNewConfig(RooIntegrator1D::Midpoint));
     break;
   case OpenAboveSpansZero:
     // xmin <= 0 so integrate from (xmin,+1) and (+1,+inf)
-    _integrator1= new RooIntegrator1D(*_function,0,+1,RooIntegrator1D::Midpoint);
-    _integrator2= new RooIntegrator1D(*function,_xmin,+1,RooIntegrator1D::Trapezoid);
+    _integrator1= new RooIntegrator1D(*_function,0,+1,makeNewConfig(RooIntegrator1D::Midpoint));
+    _integrator2= new RooIntegrator1D(*function,_xmin,+1,makeNewConfig(RooIntegrator1D::Trapezoid));
     break;
   case OpenAbove:
     // xmin > 0 so integrate from (xmin,+inf)
-    _integrator1= new RooIntegrator1D(*_function,0,1/_xmin,RooIntegrator1D::Midpoint);
+    _integrator1= new RooIntegrator1D(*_function,0,1/_xmin,makeNewConfig(RooIntegrator1D::Midpoint));
     break;
   case Invalid:
   default:


### PR DESCRIPTION
If you print a default numeric integrator config object, it will tell
you for the RooImproperIntegrator1D:

```
*** RooImproperIntegrator1D ***
Capabilities: [1-D] [OpenEnded]
Configuration:
(Depends on 'RooIntegrator1D')
```

However, in almost all of the code branches, it does not use the
`RooIntegrator1D` of the given numeric integrator configuration, but
falls back to the default by not forwarding the configuration to the
created `RooIntegrator1D`.

This commit fixes that, copying the correct integrator config to create
a new configuration object with the required summation rule for the
`RooIntegrator1D`.

Closes https://github.com/root-project/root/issues/11067.

