### PR TITLE
[RF] Disable copy assignment for RooAbsArg and derived types

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -123,6 +123,20 @@ hfCfg.binnedFitOptimization = false;
 RooStats::HistFactory::MakeModelAndMeasurementFast(measurement, hfCfg);
 ```
 
+### Disable copy assignment for RooAbsArg and derived types
+
+Copy assignment for RooAbsArgs was implemented in an unexpected and
+inconsistent way. While one would expect that the copy assignment is copying
+the object, it said in the documentation of `RooAbsArg::operator=` that it will
+"assign all boolean and string properties of the original bject. Transient
+properties and client-server links are not assigned." This contradicted with
+the implementation, where the server links were actually copied too.
+Furthermore, in `RooAbsRealLValue`, the assigment operator was overloaded by a
+function that only assigns the value of another `RooAbsReal`.
+
+With all these inconsistencies, it was deemed safer to disable copy assignment
+of RooAbsArgs from now on.
+
 ### Removal of deprecated HistFactory functionality
 
 #### Removal of HistoToWorkspaceFactory (non-Fast version)

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -78,7 +78,7 @@ public:
   ~RooAbsArg() override;
   RooAbsArg(const char *name, const char *title);
   RooAbsArg(const RooAbsArg& other, const char* name=nullptr) ;
-  RooAbsArg& operator=(const RooAbsArg& other);
+  RooAbsArg& operator=(const RooAbsArg& other) = delete;
   virtual TObject* clone(const char* newname=nullptr) const = 0 ;
   TObject* Clone(const char* newname = 0) const override {
     return clone(newname && newname[0] != '\0' ? newname : nullptr);

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -69,7 +69,6 @@ public:
   RooAbsReal(const char *name, const char *title, double minVal, double maxVal,
         const char *unit= "") ;
   RooAbsReal(const RooAbsReal& other, const char* name=nullptr);
-  RooAbsReal& operator=(const RooAbsReal& other);
   ~RooAbsReal() override;
 
 

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -34,7 +34,6 @@ public:
   inline RooAbsRealLValue() { }
   RooAbsRealLValue(const char *name, const char *title, const char *unit= "") ;
   RooAbsRealLValue(const RooAbsRealLValue& other, const char* name=nullptr);
-  RooAbsRealLValue& operator=(const RooAbsRealLValue&) = default;
   ~RooAbsRealLValue() override;
 
   // Parameter value and error accessors
@@ -45,7 +44,6 @@ public:
   virtual void setVal(double value, const char* /*rangeName*/) {
     return setVal(value) ;
   }
-  virtual RooAbsArg& operator=(const RooAbsReal& other) ;
   virtual RooAbsArg& operator=(double newValue);
 
   // Implementation of RooAbsLValue

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -48,7 +48,6 @@ public:
   RooRealVar(const char *name, const char *title, double value,
       double minValue, double maxValue, const char *unit= "") ;
   RooRealVar(const RooRealVar& other, const char* name=nullptr);
-  RooRealVar& operator=(const RooRealVar& other);
   TObject* clone(const char* newname) const override { return new RooRealVar(*this,newname); }
   ~RooRealVar() override;
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -170,37 +170,6 @@ RooAbsArg::RooAbsArg(const RooAbsArg &other, const char *name)
 
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// Assign all boolean and string properties of the original
-/// object. Transient properties and client-server links are not assigned.
-RooAbsArg& RooAbsArg::operator=(const RooAbsArg& other) {
-  TNamed::operator=(other);
-  RooPrintable::operator=(other);
-  _boolAttrib = other._boolAttrib;
-  _stringAttrib = other._stringAttrib;
-  _deleteWatch = other._deleteWatch;
-  _operMode = other._operMode;
-  _fast = other._fast;
-  _ownedComponents = nullptr;
-  _prohibitServerRedirect = other._prohibitServerRedirect;
-  _namePtr = other._namePtr;
-  _isConstant = other._isConstant;
-  _localNoInhibitDirty = other._localNoInhibitDirty;
-  _myws = nullptr;
-
-  bool valueProp, shapeProp;
-  for (const auto server : other._serverList) {
-    valueProp = server->_clientListValue.containsByNamePtr(&other);
-    shapeProp = server->_clientListShape.containsByNamePtr(&other);
-    addServer(*server,valueProp,shapeProp) ;
-  }
-
-  setValueDirty();
-  setShapeDirty();
-
-  return *this;
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor.

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -180,32 +180,6 @@ RooAbsReal::RooAbsReal(const RooAbsReal& other, const char* name) :
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Assign values, name and configs from another RooAbsReal.
-RooAbsReal& RooAbsReal::operator=(const RooAbsReal& other) {
-  RooAbsArg::operator=(other);
-
-  _plotMin = other._plotMin;
-  _plotMax = other._plotMax;
-  _plotBins = other._plotBins;
-  _value = other._value;
-  _unit = other._unit;
-  _label = other._label;
-  _forceNumInt = other._forceNumInt;
-  _selectComp = other._selectComp;
-  _lastNSet = other._lastNSet;
-
-  if (other._specIntegratorConfig) {
-    _specIntegratorConfig = new RooNumIntConfig(*other._specIntegratorConfig);
-  } else {
-    _specIntegratorConfig = nullptr;
-  }
-
-  return *this;
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Destructor
 
 RooAbsReal::~RooAbsReal()

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -185,16 +185,6 @@ RooAbsArg& RooAbsRealLValue::operator=(double newValue)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Assignment operator from other RooAbsReal
-
-RooAbsArg& RooAbsRealLValue::operator=(const RooAbsReal& arg)
-{
-  return operator=(arg.getVal()) ;
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Create a new RooPlot on the heap with a drawing frame initialized for this
 /// object, but no plot contents. Use x.frame() as the first argument to a
 /// y.plotOn(...) method, for example. The caller is responsible for deleting

--- a/roofit/roofitcore/src/RooRealVar.cxx
+++ b/roofit/roofitcore/src/RooRealVar.cxx
@@ -194,33 +194,6 @@ RooRealVar::RooRealVar(const RooRealVar& other, const char* name) :
 
 }
 
-/// Assign the values of another RooRealVar to this instance.
-RooRealVar& RooRealVar::operator=(const RooRealVar& other) {
-  RooAbsRealLValue::operator=(other);
-
-  _error = other._error;
-  _asymErrLo = other._asymErrLo;
-  _asymErrHi = other._asymErrHi;
-
-  _binning.reset();
-  if (other._binning) {
-    _binning.reset(other._binning->clone());
-    _binning->insertHook(*this) ;
-  }
-
-  _altNonSharedBinning.clear();
-  for (const auto& item : other._altNonSharedBinning) {
-    RooAbsBinning* abc = item.second->clone();
-    _altNonSharedBinning[item.first].reset(abc);
-    abc->insertHook(*this);
-  }
-
-  _sharedProp = other.sharedProp();
-
-  return *this;
-}
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Destructor


### PR DESCRIPTION
Copy assignment for RooAbsArgs was implemented in an unexpected and
inconsistent way. While one would expect that the copy assignment is
copying the object, it said in the documentation of
`RooAbsArg::operator=` that it will "assign all boolean and string
properties of the original bject. Transient properties and client-server
links are not assigned." This contradicted with the implementation,
where the server links were actually copied too. Indeed it is
questionable that adding also the servers of the `other` RooAbsArg makes
sense when the proxies are not changed.

There was also a memory leak of the `_ownedComponents`, because
`_ownedComponents` got reset to `nullptr` without deleting the
pointed-to owned collection.

Furthermore, in `RooAbsRealLValue`, the assigment operator was
overloaded by a function that only assigns the value of another
`RooAbsReal`.

With all these inconsistencies, it was deemed safer to disable copy
assignment of RooAbsArgs from now on.