### PR TITLE
[RF] Speed up `RooAbsRealLValue::setBin` by removing `inRange` check

### DIFF
--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -67,8 +67,6 @@ public:
   virtual void randomize(const RooAbsBinning& binning) ;
 
 
-  virtual void setBinFast(Int_t ibin, const RooAbsBinning& binning) ;
-
   // Get fit range limits
 
   /// Retrive binning configuration with given name or default binning.

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -457,10 +457,8 @@ void RooAbsRealLValue::setBin(Int_t ibin, const char* rangeName)
   }
 
   // Set value to center of requested bin
-  setVal(getBinning(rangeName).binCenter(ibin)) ;
+  setValFast(getBinning(rangeName).binCenter(ibin)) ;
 }
-
-
 
 
 
@@ -470,10 +468,8 @@ void RooAbsRealLValue::setBin(Int_t ibin, const char* rangeName)
 void RooAbsRealLValue::setBin(Int_t ibin, const RooAbsBinning& binning)
 {
   // Set value to center of requested bin
-  setVal(binning.binCenter(ibin)) ;
+  setValFast(binning.binCenter(ibin)) ;
 }
-
-
 
 
 
@@ -485,20 +481,6 @@ void RooAbsRealLValue::randomize(const RooAbsBinning& binning)
 {
   double range= binning.highBound() - binning.lowBound() ;
   setVal(binning.lowBound() + RooRandom::uniform()*range);
-}
-
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Set value to center of bin 'ibin' of binning 'rangeName' (or of
-/// default binning if no range is specified)
-
-void RooAbsRealLValue::setBinFast(Int_t ibin, const RooAbsBinning& binning)
-{
-  // Set value to center of requested bin
-  setValFast(binning.binCenter(ibin)) ;
 }
 
 


### PR DESCRIPTION
Replaced `RooAbsVar::setVal` with `RooRealVar::setValFast`, which does 
not call `RooAbsRealLValue::inRange`, in `RooAbsRealLValue::setBin`.
It is possible to make this change because `setBin` gets passed a bin center, 
and thus the bin is already in range by construction. This led to a big 
improvement in speed for `setBin`.

