### PR TITLE
[RF] Fix various memory leaks in RooFit from opened TFile objects

### DIFF
--- a/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
+++ b/roofit/histfactory/src/MakeModelAndMeasurementsFast.cxx
@@ -198,11 +198,12 @@ RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::Hist
       meas_chan.GetChannels().clear();
       meas_chan.GetChannels().push_back( channel );
       cxcoutIHF << "Opening File to hold channel: " << ChannelFileName << std::endl;
-      TFile* chanFile = TFile::Open( ChannelFileName.c_str(), "UPDATE" );
-      cxcoutIHF << "About to write channel measurement to file" << std::endl;
-      meas_chan.writeToFile( chanFile );
-      cxcoutPHF << "Successfully wrote channel to file" << std::endl;
-      chanFile->Close();
+      {
+        std::unique_ptr<TFile> chanFile{TFile::Open( ChannelFileName.c_str(), "UPDATE" )};
+        cxcoutIHF << "About to write channel measurement to file" << std::endl;
+        meas_chan.writeToFile( chanFile.get() );
+        cxcoutPHF << "Successfully wrote channel to file" << std::endl;
+      }
 
       // Get the Paramater of Interest as a RooRealVar
       RooRealVar* poi = dynamic_cast<RooRealVar*>( ws_single->var(measurement.GetPOI()));
@@ -246,13 +247,14 @@ RooWorkspace* RooStats::HistFactory::MakeModelAndMeasurementFast( RooStats::Hist
     cxcoutPHF << "Writing combined workspace to file: " << CombinedFileName << std::endl;
     ws->writeToFile( CombinedFileName.c_str() );
     cxcoutPHF << "Writing combined measurement to file: " << CombinedFileName << std::endl;
-    TFile* combFile = TFile::Open( CombinedFileName.c_str(), "UPDATE" );
-    if( combFile == nullptr ) {
-      cxcoutEHF << "Error: Failed to open file " << CombinedFileName << std::endl;
-      throw hf_exc();
+    {
+      std::unique_ptr<TFile> combFile{TFile::Open( CombinedFileName.c_str(), "UPDATE" )};
+      if( combFile == nullptr ) {
+        cxcoutEHF << "Error: Failed to open file " << CombinedFileName << std::endl;
+        throw hf_exc();
+      }
+      measurement.writeToFile( combFile.get() );
     }
-    measurement.writeToFile( combFile );
-    combFile->Close();
 
     // Fit the combined model
     if(! measurement.GetExportOnly()){

--- a/roofit/roofit/src/Roo2DKeysPdf.cxx
+++ b/roofit/roofit/src/Roo2DKeysPdf.cxx
@@ -522,10 +522,9 @@ void Roo2DKeysPdf::writeToFile(char * outputFile, const char * name) const
 
 void Roo2DKeysPdf::writeHistToFile(char * outputFile, const char * histName) const
 {
-  TFile * file = 0;
   cout << "Roo2DKeysPdf::writeHistToFile This member function is temporarily disabled" <<endl;
   //make sure that any existing file is not over written
-  file = new TFile(outputFile, "UPDATE");
+  std::unique_ptr<TFile> file{TFile::Open(outputFile, "UPDATE")};
   if (!file)
   {
     cout << "Roo2DKeysPdf::writeHistToFile unable to open file "<< outputFile <<endl;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -488,7 +488,7 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
       } else if (fname && strlen(fname)) {
 
         // Case 5a --- Import TTree from file with cutspec
-        TFile *f = TFile::Open(fname) ;
+        std::unique_ptr<TFile> f{TFile::Open(fname)};
         if (!f) {
           coutE(InputArguments) << "RooDataSet::ctor(" << GetName() << ") ERROR file '" << fname << "' cannot be opened or does not exist" << endl ;
           throw string(Form("RooDataSet::ctor(%s) ERROR file %s cannot be opened or does not exist",GetName(),fname)) ;
@@ -546,7 +546,7 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, const RooArgSet&
         }
       } else if (fname && strlen(fname)) {
         // Case 5b --- Import TTree from file with cutvar
-        TFile *f = TFile::Open(fname) ;
+        std::unique_ptr<TFile> f{TFile::Open(fname)};
         if (!f) {
           coutE(InputArguments) << "RooDataSet::ctor(" << GetName() << ") ERROR file '" << fname << "' cannot be opened or does not exist" << endl ;
           throw string(Form("RooDataSet::ctor(%s) ERROR file %s cannot be opened or does not exist",GetName(),fname)) ;

--- a/roofit/roofitcore/src/RooStudyManager.cxx
+++ b/roofit/roofitcore/src/RooStudyManager.cxx
@@ -69,7 +69,7 @@ RooStudyManager::RooStudyManager(RooWorkspace& w, RooAbsStudy& study)
 RooStudyManager::RooStudyManager(const char* studyPackFileName)
 {
   string pwd = gDirectory->GetName() ;
-  TFile *f = new TFile(studyPackFileName) ;
+  std::unique_ptr<TFile> f{TFile::Open(studyPackFileName, "READ")};
   _pkg = dynamic_cast<RooStudyPackage*>(f->Get("studypack")) ;
   gDirectory->cd(Form("%s:",pwd.c_str())) ;
 }

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -281,7 +281,7 @@ bool RooWorkspace::import(const char* fileSpec,
   const std::string& objname = tokens[2];
 
   // Check that file can be opened
-  TFile* f = TFile::Open(filename.c_str()) ;
+  std::unique_ptr<TFile> f{TFile::Open(filename.c_str())};
   if (f==0) {
     coutE(InputArguments) << "RooWorkspace(" << GetName() << ") ERROR opening file " << filename << endl ;
     return false;
@@ -299,13 +299,11 @@ bool RooWorkspace::import(const char* fileSpec,
   RooAbsArg* warg = w->arg(objname.c_str()) ;
   if (warg) {
     bool ret = import(*warg,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9) ;
-    delete f ;
     return ret ;
   }
   RooAbsData* wdata = w->data(objname.c_str()) ;
   if (wdata) {
     bool ret = import(*wdata,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9) ;
-    delete f ;
     return ret ;
   }
 

--- a/roofit/roostats/src/HLFactory.cxx
+++ b/roofit/roostats/src/HLFactory.cxx
@@ -600,7 +600,7 @@ int HLFactory::fParseLine(TString& line){
         TString ws_name("");
         TString rootfile_name (static_cast<TObjString*>(descr_array->At(0))->GetString());
 
-        TFile* ifile=TFile::Open(rootfile_name);
+        std::unique_ptr<TFile> ifile{TFile::Open(rootfile_name)};
         if (ifile==0)
             return 1;
 
@@ -615,7 +615,6 @@ int HLFactory::fParseLine(TString& line){
           TObject* the_obj=ifile->Get(obj_name);
           fWs->import(*the_obj,o_name);
           }
-        delete ifile;
         return 0;
         } // end of import block
 

--- a/roofit/roostats/src/HypoTestInverter.cxx
+++ b/roofit/roostats/src/HypoTestInverter.cxx
@@ -1171,7 +1171,7 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
    RooArgSet saveParams;
    allParams->snapshot(saveParams);
 
-   TFile * fileOut = TFile::Open(outputfile,"RECREATE");
+   std::unique_ptr<TFile> fileOut{TFile::Open(outputfile,"RECREATE")};
    if (!fileOut) {
       oocoutE(nullptr,InputArguments) << "HypoTestInverter - RebuildDistributions - Error opening file " << outputfile
                                           << " - the resulting limits will not be stored" << std::endl;
@@ -1320,9 +1320,6 @@ SamplingDistribution * HypoTestInverter::RebuildDistributions(bool isUpper, int 
       }
    }
 
-   if (fileOut) {
-      fileOut->Close();
-   }
    else {
       // delete all the histograms
       delete hL;

--- a/roofit/roostats/src/HypoTestInverterResult.cxx
+++ b/roofit/roostats/src/HypoTestInverterResult.cxx
@@ -676,9 +676,10 @@ double HypoTestInverterResult::GetGraphX(const TGraph & graph, double y0, bool l
 
    TString fname = "graph_upper.root";
    if (lowSearch) fname = "graph_lower.root";
-   auto file = TFile::Open(fname,"RECREATE");
-   graph.Write("graph");
-   file->Close();
+   {
+      std::unique_ptr<TFile> file{TFile::Open(fname,"RECREATE")};
+      graph.Write("graph");
+   }
 #endif
 
    // look in case if a new intersection exists


### PR DESCRIPTION
In quite a few places in RooFit, TFile objects were manually allocated
but not deleted afterwards.