### PR TITLE
[RF] Remove logging-related pdf members or make them transient

### DIFF
--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -199,7 +199,6 @@ public:
   virtual double getNorm(const RooArgSet* set=nullptr) const ;
 
   virtual void resetErrorCounters(Int_t resetValue=10) ;
-  void setTraceCounter(Int_t value, bool allNodes=false) ;
 
   double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
@@ -316,7 +315,6 @@ protected:
 
   virtual bool syncNormalization(const RooArgSet* dset, bool adjustProxies=true) const ;
 
-  mutable double _rawValue = 0;
   mutable RooAbsReal* _norm = nullptr; //! Normalization integral (owned by _normMgr)
   mutable RooArgSet const* _normSet = nullptr; //! Normalization set with for above integral
 
@@ -333,8 +331,6 @@ protected:
                                    bool nameChange, bool isRecursiveStep) override;
 
   mutable Int_t _errorCount = 0; ///< Number of errors remaining to print
-  mutable Int_t _traceCount = 0; ///< Number of traces remaining to print
-  mutable Int_t _negCount = 0;   ///< Number of negative probabilities remaining to print
 
   bool _selectComp = false; ///< Component selection flag for RooAbsPdf::plotCompOn
 
@@ -350,7 +346,7 @@ private:
   friend class RooChi2Var;
   bool interpretExtendedCmdArg(int extendedCmdArg) const;
 
-  ClassDefOverride(RooAbsPdf,5) // Abstract PDF with normalization support
+  ClassDefOverride(RooAbsPdf,6) // Abstract PDF with normalization support
 };
 
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -313,7 +313,6 @@ RooAbsPdf::RooAbsPdf(const char *name, const char *title) :
   RooAbsReal(name,title), _normMgr(this,10), _selectComp(true)
 {
   resetErrorCounters() ;
-  setTraceCounter(0) ;
 }
 
 
@@ -326,7 +325,6 @@ RooAbsPdf::RooAbsPdf(const char *name, const char *title,
   RooAbsReal(name,title,plotMin,plotMax), _normMgr(this,10), _selectComp(true)
 {
   resetErrorCounters() ;
-  setTraceCounter(0) ;
 }
 
 
@@ -339,7 +337,6 @@ RooAbsPdf::RooAbsPdf(const RooAbsPdf& other, const char* name) :
   _normMgr(other._normMgr,this), _selectComp(other._selectComp), _normRange(other._normRange)
 {
   resetErrorCounters() ;
-  setTraceCounter(other._traceCount) ;
 
   if (other._specGeneratorConfig) {
     _specGeneratorConfig = std::make_unique<RooNumGenConfig>(*other._specGeneratorConfig);
@@ -664,31 +661,7 @@ bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) con
 void RooAbsPdf::resetErrorCounters(Int_t resetValue)
 {
   _errorCount = resetValue ;
-  _negCount   = resetValue ;
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Reset trace counter to given value, limiting the
-/// number of future trace messages for this pdf to 'value'
-
-void RooAbsPdf::setTraceCounter(Int_t value, bool allNodes)
-{
-  if (!allNodes) {
-    _traceCount = value ;
-    return ;
-  } else {
-    RooArgList branchList ;
-    branchNodeServerList(&branchList) ;
-    for(auto * pdf : dynamic_range_cast<RooAbsPdf*>(branchList)) {
-      if (pdf) pdf->setTraceCounter(value,false) ;
-    }
-  }
-
-}
-
-
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The RooAbsPdf version number is incremented, going with the removal of
some unused data members:

* `_rawValue`
* `_traceCount`
* `_negCount`

Furthermore, the `_errorCount` member is now made transient, because it
is only related to logging, counting the logged errors to avoid printing
errors them repeatedly.