### PR TITLE
[RF] Use `nullptr` and not `0` literal for default pointer parameters

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/ParamHistFunc.h
@@ -51,8 +51,8 @@ public:
 
   bool forceAnalyticalInt(const RooAbsArg&) const override { return true ; }
 
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=nullptr) const override;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override;
 
   static RooArgList createParamSet(RooWorkspace& w, const std::string&, const RooArgList& Vars);
   static RooArgList createParamSet(RooWorkspace& w, const std::string&, const RooArgList& Vars, double, double);

--- a/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/PiecewiseInterpolation.h
@@ -54,8 +54,8 @@ public:
   //virtual bool forceAnalyticalInt(const RooAbsArg&) const { return true ; }
   bool setBinIntegrator(RooArgSet& allVars) ;
 
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   void setPositiveDefinite(bool flag=true){_positiveDefinite=flag;}
 

--- a/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
@@ -27,7 +27,7 @@ public:
 
   RooBarlowBeestonLL() ;
   RooBarlowBeestonLL(const char *name, const char *title, RooAbsReal& nll /*, const RooArgSet& observables*/);
-  RooBarlowBeestonLL(const RooBarlowBeestonLL& other, const char* name=0) ;
+  RooBarlowBeestonLL(const RooBarlowBeestonLL& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooBarlowBeestonLL(*this,newname); }
   ~RooBarlowBeestonLL() override ;
 

--- a/roofit/roofit/inc/Roo2DKeysPdf.h
+++ b/roofit/roofit/inc/Roo2DKeysPdf.h
@@ -27,7 +27,7 @@ class Roo2DKeysPdf : public RooAbsPdf
 public:
   Roo2DKeysPdf(const char *name, const char *title,
              RooAbsReal& xx, RooAbsReal &yy, RooDataSet& data, TString options = "a", double widthScaleFactor = 1.0);
-  Roo2DKeysPdf(const Roo2DKeysPdf& other, const char* name=0);
+  Roo2DKeysPdf(const Roo2DKeysPdf& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new Roo2DKeysPdf(*this,newname); }
 
   ~Roo2DKeysPdf() override;

--- a/roofit/roofit/inc/RooArgusBG.h
+++ b/roofit/roofit/inc/RooArgusBG.h
@@ -26,12 +26,12 @@ public:
         RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c);
   RooArgusBG(const char *name, const char *title,
         RooAbsReal& _m, RooAbsReal& _m0, RooAbsReal& _c, RooAbsReal& _p);
-  RooArgusBG(const RooArgusBG& other,const char* name=0) ;
+  RooArgusBG(const RooArgusBG& other,const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooArgusBG(*this,newname); }
   inline ~RooArgusBG() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
   RooRealProxy m ;

--- a/roofit/roofit/inc/RooBCPEffDecay.h
+++ b/roofit/roofit/inc/RooBCPEffDecay.h
@@ -35,14 +35,14 @@ public:
        RooAbsReal& effRatio, RooAbsReal& delMistag,
        const RooResolutionModel& model, DecayType type=DoubleSided) ;
 
-  RooBCPEffDecay(const RooBCPEffDecay& other, const char* name=0);
+  RooBCPEffDecay(const RooBCPEffDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooBCPEffDecay(*this,newname) ; }
   ~RooBCPEffDecay() override;
 
   double coefficient(Int_t basisIndex) const override ;
 
-  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void initGenerator(Int_t code) override ;

--- a/roofit/roofit/inc/RooBCPGenDecay.h
+++ b/roofit/roofit/inc/RooBCPGenDecay.h
@@ -36,14 +36,14 @@ public:
                  RooAbsReal& mu,
        const RooResolutionModel& model, DecayType type=DoubleSided) ;
 
-  RooBCPGenDecay(const RooBCPGenDecay& other, const char* name=0);
+  RooBCPGenDecay(const RooBCPGenDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooBCPGenDecay(*this,newname) ; }
   ~RooBCPGenDecay() override;
 
   double coefficient(Int_t basisIndex) const override ;
 
-  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void initGenerator(Int_t code) override ;

--- a/roofit/roofit/inc/RooBDecay.h
+++ b/roofit/roofit/inc/RooBDecay.h
@@ -37,7 +37,7 @@ public:
          RooAbsReal& f3, RooAbsReal& dm,
          const RooResolutionModel& model,
          DecayType type);
-  RooBDecay(const RooBDecay& other, const char* name=0);
+  RooBDecay(const RooBDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override
   {
     return new RooBDecay(*this,newname);
@@ -47,8 +47,8 @@ public:
   double coefficient(Int_t basisIndex) const override;
   RooArgSet* coefVars(Int_t coefIdx) const override ;
 
-  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooBMixDecay.h
+++ b/roofit/roofit/inc/RooBMixDecay.h
@@ -33,14 +33,14 @@ public:
           RooAbsReal& mistag, RooAbsReal& delMistag, const RooResolutionModel& model,
           DecayType type=DoubleSided) ;
 
-  RooBMixDecay(const RooBMixDecay& other, const char* name=0);
+  RooBMixDecay(const RooBMixDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooBMixDecay(*this,newname) ; }
   ~RooBMixDecay() override;
 
   double coefficient(Int_t basisIndex) const override ;
 
-  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const override ;
+  Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void initGenerator(Int_t code) override ;

--- a/roofit/roofit/inc/RooBernstein.h
+++ b/roofit/roofit/inc/RooBernstein.h
@@ -35,9 +35,9 @@ public:
   TObject* clone(const char* newname) const override { return new RooBernstein(*this, newname); }
   inline ~RooBernstein() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
-  void selectNormalizationRange(const char* rangeName=0, bool force=false) override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
+  void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
 
 private:
 

--- a/roofit/roofit/inc/RooBifurGauss.h
+++ b/roofit/roofit/inc/RooBifurGauss.h
@@ -27,12 +27,12 @@ public:
   RooBifurGauss(const char *name, const char *title, RooAbsReal& _x,
       RooAbsReal& _mean, RooAbsReal& _sigmaL, RooAbsReal& _sigmaR);
 
-  RooBifurGauss(const RooBifurGauss& other, const char* name=0) ;
+  RooBifurGauss(const RooBifurGauss& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooBifurGauss(*this,newname); }
   inline ~RooBifurGauss() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 
 protected:

--- a/roofit/roofit/inc/RooBreitWigner.h
+++ b/roofit/roofit/inc/RooBreitWigner.h
@@ -27,12 +27,12 @@ public:
   RooBreitWigner() {} ;
   RooBreitWigner(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _width);
-  RooBreitWigner(const RooBreitWigner& other, const char* name=0) ;
+  RooBreitWigner(const RooBreitWigner& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooBreitWigner(*this,newname); }
   inline ~RooBreitWigner() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofit/inc/RooBukinPdf.h
+++ b/roofit/roofit/inc/RooBukinPdf.h
@@ -35,7 +35,7 @@ public:
          RooAbsReal& _sigp, RooAbsReal& _xi,
               RooAbsReal& _rho1, RooAbsReal& _rho2);
 
-  RooBukinPdf(const RooBukinPdf& other,const char* name=0) ;
+  RooBukinPdf(const RooBukinPdf& other,const char* name=nullptr) ;
 
   TObject* clone(const char* newname) const override { return new RooBukinPdf(*this,newname);   }
   inline ~RooBukinPdf() override { }

--- a/roofit/roofit/inc/RooCBShape.h
+++ b/roofit/roofit/inc/RooCBShape.h
@@ -33,8 +33,8 @@ public:
 
   inline ~RooCBShape() override { }
 
-  Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=0 ) const override;
-  double analyticalIntegral( Int_t code, const char* rangeName=0 ) const override;
+  Int_t getAnalyticalIntegral( RooArgSet& allVars,  RooArgSet& analVars, const char* rangeName=nullptr ) const override;
+  double analyticalIntegral( Int_t code, const char* rangeName=nullptr ) const override;
 
   // Optimized accept/reject generator support
   Int_t getMaxVal(const RooArgSet& vars) const override ;

--- a/roofit/roofit/inc/RooCFunction1Binding.h
+++ b/roofit/roofit/inc/RooCFunction1Binding.h
@@ -90,7 +90,7 @@ class RooCFunction1Map {
 template<class VO, class VI>
 class RooCFunction1Ref : public TObject {
  public:
-  RooCFunction1Ref(VO (*ptr)(VI)=0) : _ptr(ptr) {
+  RooCFunction1Ref(VO (*ptr)(VI)=nullptr) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
   ~RooCFunction1Ref() override {} ;
@@ -178,7 +178,7 @@ void RooCFunction1Ref<VO,VI>::Streamer(TBuffer &R__b)
        // Lookup pointer to C function with given name
        _ptr = fmap().lookupPtr(tmpName.Data()) ;
 
-       if (_ptr==0) {
+       if (_ptr==nullptr) {
     coutW(ObjectHandling) << "ERROR: Objected embeds pointer to function named " << tmpName
                 << " but no such function is registered, object will not be functional" << std::endl ;
        }
@@ -223,7 +223,7 @@ public:
     // Default constructor
   } ;
   RooCFunction1Binding(const char *name, const char *title, VO (*_func)(VI), RooAbsReal& _x);
-  RooCFunction1Binding(const RooCFunction1Binding& other, const char* name=0) ;
+  RooCFunction1Binding(const RooCFunction1Binding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction1Binding(*this,newname); }
   inline ~RooCFunction1Binding() override { }
 
@@ -287,7 +287,7 @@ public:
     // Default constructor
   } ;
   RooCFunction1PdfBinding(const char *name, const char *title, VO (*_func)(VI), RooAbsReal& _x);
-  RooCFunction1PdfBinding(const RooCFunction1PdfBinding& other, const char* name=0) ;
+  RooCFunction1PdfBinding(const RooCFunction1PdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction1PdfBinding(*this,newname); }
   inline ~RooCFunction1PdfBinding() override { }
 

--- a/roofit/roofit/inc/RooCFunction2Binding.h
+++ b/roofit/roofit/inc/RooCFunction2Binding.h
@@ -99,7 +99,7 @@ class RooCFunction2Map {
 template<class VO, class VI1, class VI2>
 class RooCFunction2Ref : public TObject {
  public:
-  RooCFunction2Ref(VO (*ptr)(VI1,VI2)=0) : _ptr(ptr) {
+  RooCFunction2Ref(VO (*ptr)(VI1,VI2)=nullptr) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
   ~RooCFunction2Ref() override {} ;
@@ -194,7 +194,7 @@ void RooCFunction2Ref<VO,VI1,VI2>::Streamer(TBuffer &R__b)
        // Lookup pointer to C function with given name
        _ptr = fmap().lookupPtr(tmpName.Data()) ;
 
-       if (_ptr==0) {
+       if (_ptr==nullptr) {
     coutW(ObjectHandling) << "ERROR: Objected embeds pointer to function named " << tmpName
                 << " but no such function is registered, object will not be functional" << std::endl ;
        }
@@ -233,7 +233,7 @@ public:
     // Default constructor
   } ;
   RooCFunction2Binding(const char *name, const char *title, VO (*_func)(VI1,VI2), RooAbsReal& _x, RooAbsReal& _y);
-  RooCFunction2Binding(const RooCFunction2Binding& other, const char* name=0) ;
+  RooCFunction2Binding(const RooCFunction2Binding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction2Binding(*this,newname); }
   inline ~RooCFunction2Binding() override { }
 
@@ -301,7 +301,7 @@ public:
     // Default constructor
   } ;
   RooCFunction2PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2), RooAbsReal& _x, RooAbsReal& _y);
-  RooCFunction2PdfBinding(const RooCFunction2PdfBinding& other, const char* name=0) ;
+  RooCFunction2PdfBinding(const RooCFunction2PdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction2PdfBinding(*this,newname); }
   inline ~RooCFunction2PdfBinding() override { }
 

--- a/roofit/roofit/inc/RooCFunction3Binding.h
+++ b/roofit/roofit/inc/RooCFunction3Binding.h
@@ -101,7 +101,7 @@ class RooCFunction3Map {
 template<class VO, class VI1, class VI2, class VI3>
 class RooCFunction3Ref : public TObject {
  public:
-  RooCFunction3Ref(VO (*ptr)(VI1,VI2,VI3)=0) : _ptr(ptr) {
+  RooCFunction3Ref(VO (*ptr)(VI1,VI2,VI3)=nullptr) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
   ~RooCFunction3Ref() override {} ;
@@ -198,7 +198,7 @@ void RooCFunction3Ref<VO,VI1,VI2,VI3>::Streamer(TBuffer &R__b)
        // Lookup pointer to C function wih given name
        _ptr = fmap().lookupPtr(tmpName.Data()) ;
 
-       if (_ptr==0) {
+       if (_ptr==nullptr) {
     coutW(ObjectHandling) << "ERROR: Objected embeds pointer to function named " << tmpName
                 << " but no such function is registered, object will not be functional" << std::endl ;
        }
@@ -243,7 +243,7 @@ public:
     // Default constructor
   } ;
   RooCFunction3Binding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z);
-  RooCFunction3Binding(const RooCFunction3Binding& other, const char* name=0) ;
+  RooCFunction3Binding(const RooCFunction3Binding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction3Binding(*this,newname); }
   inline ~RooCFunction3Binding() override { }
 
@@ -314,7 +314,7 @@ public:
     // Default constructor
   } ;
   RooCFunction3PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z);
-  RooCFunction3PdfBinding(const RooCFunction3PdfBinding& other, const char* name=0) ;
+  RooCFunction3PdfBinding(const RooCFunction3PdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction3PdfBinding(*this,newname); }
   inline ~RooCFunction3PdfBinding() override { }
 

--- a/roofit/roofit/inc/RooCFunction4Binding.h
+++ b/roofit/roofit/inc/RooCFunction4Binding.h
@@ -97,7 +97,7 @@ class RooCFunction4Map {
 template<class VO, class VI1, class VI2, class VI3, class VI4>
 class RooCFunction4Ref : public TObject {
  public:
-  RooCFunction4Ref(VO (*ptr)(VI1,VI2,VI3,VI4)=0) : _ptr(ptr) {
+  RooCFunction4Ref(VO (*ptr)(VI1,VI2,VI3,VI4)=nullptr) : _ptr(ptr) {
     // Constructor of persistable function reference
   } ;
   ~RooCFunction4Ref() override {} ;
@@ -191,7 +191,7 @@ void RooCFunction4Ref<VO,VI1,VI2,VI3,VI4>::Streamer(TBuffer &R__b)
        // Lookup pointer to C function wih given name
        _ptr = fmap().lookupPtr(tmpName.Data()) ;
 
-       if (_ptr==0) {
+       if (_ptr==nullptr) {
     coutW(ObjectHandling) << "ERROR: Objected embeds pointer to function named " << tmpName
                 << " but no such function is registered, object will not be functional" << std::endl ;
        }
@@ -230,7 +230,7 @@ public:
     // Default constructor
   } ;
   RooCFunction4Binding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3,VI4), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z, RooAbsReal& _w);
-  RooCFunction4Binding(const RooCFunction4Binding& other, const char* name=0) ;
+  RooCFunction4Binding(const RooCFunction4Binding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction4Binding(*this,newname); }
   inline ~RooCFunction4Binding() override { }
 
@@ -303,7 +303,7 @@ public:
     // Default constructor
   } ;
   RooCFunction4PdfBinding(const char *name, const char *title, VO (*_func)(VI1,VI2,VI3,VI4), RooAbsReal& _x, RooAbsReal& _y, RooAbsReal& _z, RooAbsReal& _w);
-  RooCFunction4PdfBinding(const RooCFunction4PdfBinding& other, const char* name=0) ;
+  RooCFunction4PdfBinding(const RooCFunction4PdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCFunction4PdfBinding(*this,newname); }
   inline ~RooCFunction4PdfBinding() override { }
 

--- a/roofit/roofit/inc/RooChebychev.h
+++ b/roofit/roofit/inc/RooChebychev.h
@@ -33,10 +33,10 @@ public:
   TObject* clone(const char* newname) const override { return new RooChebychev(*this, newname); }
   inline ~RooChebychev() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
-  void selectNormalizationRange(const char* rangeName=0, bool force=false) override ;
+  void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
 
 private:
 

--- a/roofit/roofit/inc/RooChiSquarePdf.h
+++ b/roofit/roofit/inc/RooChiSquarePdf.h
@@ -31,8 +31,8 @@ public:
   inline ~RooChiSquarePdf() override { }
 
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 
 private:

--- a/roofit/roofit/inc/RooDecay.h
+++ b/roofit/roofit/inc/RooDecay.h
@@ -28,7 +28,7 @@ public:
   inline RooDecay() { }
   RooDecay(const char *name, const char *title, RooRealVar& t,
       RooAbsReal& tau, const RooResolutionModel& model, DecayType type) ;
-  RooDecay(const RooDecay& other, const char* name=0);
+  RooDecay(const RooDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooDecay(*this,newname) ; }
   ~RooDecay() override;
 

--- a/roofit/roofit/inc/RooDstD0BG.h
+++ b/roofit/roofit/inc/RooDstD0BG.h
@@ -30,13 +30,13 @@ public:
         RooAbsReal& _dm, RooAbsReal& _dm0, RooAbsReal& _c,
         RooAbsReal& _a, RooAbsReal& _b);
 
-  RooDstD0BG(const RooDstD0BG& other, const char *name=0) ;
+  RooDstD0BG(const RooDstD0BG& other, const char *name=nullptr) ;
   TObject *clone(const char *newname) const override {
     return new RooDstD0BG(*this,newname); }
   inline ~RooDstD0BG() override { };
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofit/inc/RooExponential.h
+++ b/roofit/roofit/inc/RooExponential.h
@@ -27,12 +27,12 @@ public:
   RooExponential() {} ;
   RooExponential(const char *name, const char *title,
        RooAbsReal& _x, RooAbsReal& _c);
-  RooExponential(const RooExponential& other, const char* name=0);
+  RooExponential(const RooExponential& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooExponential(*this,newname); }
   inline ~RooExponential() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
 protected:
   RooRealProxy x;

--- a/roofit/roofit/inc/RooFunctor1DBinding.h
+++ b/roofit/roofit/inc/RooFunctor1DBinding.h
@@ -36,7 +36,7 @@ public:
     // Default constructor
   } ;
   RooFunctor1DBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionOneDim& ftor, RooAbsReal& var);
-  RooFunctor1DBinding(const RooFunctor1DBinding& other, const char* name=0) ;
+  RooFunctor1DBinding(const RooFunctor1DBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooFunctor1DBinding(*this,newname); }
   inline ~RooFunctor1DBinding() override {}
   void printArgs(std::ostream& os) const override ;
@@ -62,7 +62,7 @@ public:
     // Default constructor
   } ;
   RooFunctor1DPdfBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionOneDim& ftor, RooAbsReal& vars);
-  RooFunctor1DPdfBinding(const RooFunctor1DPdfBinding& other, const char* name=0) ;
+  RooFunctor1DPdfBinding(const RooFunctor1DPdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooFunctor1DPdfBinding(*this,newname); }
   inline ~RooFunctor1DPdfBinding() override {}
   void printArgs(std::ostream& os) const override ;

--- a/roofit/roofit/inc/RooFunctorBinding.h
+++ b/roofit/roofit/inc/RooFunctorBinding.h
@@ -34,7 +34,7 @@ public:
     // Default constructor
   } ;
   RooFunctorBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionMultiDim& ftor, const RooArgList& vars);
-  RooFunctorBinding(const RooFunctorBinding& other, const char* name=0) ;
+  RooFunctorBinding(const RooFunctorBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooFunctorBinding(*this,newname); }
   inline ~RooFunctorBinding() override { delete[] x ; }
   void printArgs(std::ostream& os) const override ;
@@ -61,7 +61,7 @@ public:
     // Default constructor
   } ;
   RooFunctorPdfBinding(const char *name, const char *title, const ROOT::Math::IBaseFunctionMultiDim& ftor, const RooArgList& vars);
-  RooFunctorPdfBinding(const RooFunctorPdfBinding& other, const char* name=0) ;
+  RooFunctorPdfBinding(const RooFunctorPdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooFunctorPdfBinding(*this,newname); }
   inline ~RooFunctorPdfBinding() override { delete[] x ; }
   void printArgs(std::ostream& os) const override ;

--- a/roofit/roofit/inc/RooGExpModel.h
+++ b/roofit/roofit/inc/RooGExpModel.h
@@ -63,13 +63,13 @@ public:
 
 
 
-  RooGExpModel(const RooGExpModel& other, const char* name=0);
+  RooGExpModel(const RooGExpModel& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooGExpModel(*this,newname) ; }
   ~RooGExpModel() override;
 
   Int_t basisCode(const char* name) const override ;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooGamma.h
+++ b/roofit/roofit/inc/RooGamma.h
@@ -22,12 +22,12 @@ public:
   RooGamma() {} ;
   RooGamma(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _gamma, RooAbsReal& _beta, RooAbsReal& _mu);
-  RooGamma(const RooGamma& other, const char* name=0) ;
+  RooGamma(const RooGamma& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooGamma(*this,newname); }
   inline ~RooGamma() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooGaussModel.h
+++ b/roofit/roofit/inc/RooGaussModel.h
@@ -44,12 +44,12 @@ public:
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& msSF) ;
   RooGaussModel(const char *name, const char *title, RooAbsRealLValue& x,
       RooAbsReal& mean, RooAbsReal& sigma, RooAbsReal& meanSF, RooAbsReal& sigmaSF) ;
-  RooGaussModel(const RooGaussModel& other, const char* name=0);
+  RooGaussModel(const RooGaussModel& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooGaussModel(*this,newname) ; }
   ~RooGaussModel() override;
 
   Int_t basisCode(const char* name) const override ;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
   double analyticalIntegral(Int_t code, const char* rangeName) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;

--- a/roofit/roofit/inc/RooGaussian.h
+++ b/roofit/roofit/inc/RooGaussian.h
@@ -26,14 +26,14 @@ public:
   RooGaussian() { };
   RooGaussian(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma);
-  RooGaussian(const RooGaussian& other, const char* name=0);
+  RooGaussian(const RooGaussian& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override {
     return new RooGaussian(*this,newname);
   }
   inline ~RooGaussian() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooHistConstraint.h
+++ b/roofit/roofit/inc/RooHistConstraint.h
@@ -20,11 +20,11 @@ class RooHistConstraint : public RooAbsPdf {
 public:
   RooHistConstraint() {} ;
   RooHistConstraint(const char *name, const char *title, const RooArgSet& phfSet, Int_t threshold=1000000);
-  RooHistConstraint(const RooHistConstraint& other, const char* name=0) ;
+  RooHistConstraint(const RooHistConstraint& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooHistConstraint(*this,newname); }
   inline ~RooHistConstraint() override { }
 
-  double getLogVal(const RooArgSet* set=0) const override ;
+  double getLogVal(const RooArgSet* set=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofit/inc/RooIntegralMorph.h
+++ b/roofit/roofit/inc/RooIntegralMorph.h
@@ -33,7 +33,7 @@ public:
          RooAbsReal& _pdf2,
            RooAbsReal& _x,
          RooAbsReal& _alpha, bool cacheAlpha=false);
-  RooIntegralMorph(const RooIntegralMorph& other, const char* name=0) ;
+  RooIntegralMorph(const RooIntegralMorph& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooIntegralMorph(*this,newname); }
   inline ~RooIntegralMorph() override { }
 

--- a/roofit/roofit/inc/RooJohnson.h
+++ b/roofit/roofit/inc/RooJohnson.h
@@ -38,8 +38,8 @@ public:
     return new RooJohnson(*this,newname);
   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooKeysPdf.h
+++ b/roofit/roofit/inc/RooKeysPdf.h
@@ -35,7 +35,7 @@ public:
   RooKeysPdf(const char *name, const char *title,
              RooAbsReal& x, RooRealVar& xdata, RooDataSet& data, Mirror mirror= NoMirror,
         double rho=1);
-  RooKeysPdf(const RooKeysPdf& other, const char* name=0);
+  RooKeysPdf(const RooKeysPdf& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override {return new RooKeysPdf(*this,newname); }
   ~RooKeysPdf() override;
 

--- a/roofit/roofit/inc/RooLandau.h
+++ b/roofit/roofit/inc/RooLandau.h
@@ -25,7 +25,7 @@ class RooLandau : public RooAbsPdf {
 public:
   RooLandau() {} ;
   RooLandau(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, RooAbsReal& _sigma);
-  RooLandau(const RooLandau& other, const char* name=0);
+  RooLandau(const RooLandau& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooLandau(*this,newname); }
   inline ~RooLandau() override { }
 

--- a/roofit/roofit/inc/RooLognormal.h
+++ b/roofit/roofit/inc/RooLognormal.h
@@ -21,12 +21,12 @@ public:
   RooLognormal() {} ;
   RooLognormal(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _m0, RooAbsReal& _k);
-  RooLognormal(const RooLognormal& other, const char* name=0) ;
+  RooLognormal(const RooLognormal& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooLognormal(*this,newname); }
   inline ~RooLognormal() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooMomentMorph.h
+++ b/roofit/roofit/inc/RooMomentMorph.h
@@ -32,7 +32,7 @@ public:
           const RooArgList& pdfList, const RooArgList& mrefList, Setting setting = NonLinearPosFractions);
   RooMomentMorph(const char *name, const char *title, RooAbsReal& _m, const RooArgList& varList,
           const RooArgList& pdfList, const TVectorD& mrefpoints, Setting setting = NonLinearPosFractions );
-  RooMomentMorph(const RooMomentMorph& other, const char* name=0) ;
+  RooMomentMorph(const RooMomentMorph& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooMomentMorph(*this,newname); }
   ~RooMomentMorph() override;
 
@@ -45,7 +45,7 @@ public:
     return true ;
   }
 
-  virtual double getVal(const RooArgSet* set=0) const ;
+  virtual double getVal(const RooArgSet* set=nullptr) const ;
   RooAbsPdf* sumPdf(const RooArgSet* nset) ;
 
 

--- a/roofit/roofit/inc/RooMultiBinomial.h
+++ b/roofit/roofit/inc/RooMultiBinomial.h
@@ -28,7 +28,7 @@ class RooMultiBinomial : public RooAbsReal {
   }
 
   RooMultiBinomial(const char *name, const char *title, const RooArgList& effFuncList, const RooArgList& catList, bool ignoreNonVisible);
-  RooMultiBinomial(const RooMultiBinomial& other, const char* name=0);
+  RooMultiBinomial(const RooMultiBinomial& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooMultiBinomial(*this,newname); }
   ~RooMultiBinomial() override;
 

--- a/roofit/roofit/inc/RooNDKeysPdf.h
+++ b/roofit/roofit/inc/RooNDKeysPdf.h
@@ -82,13 +82,13 @@ public:
                TString options = "ma", double rho = 1.0, double nSigma = 3, bool rotate = true,
                bool sortInput = true);
 
-  RooNDKeysPdf(const RooNDKeysPdf& other, const char* name=0);
+  RooNDKeysPdf(const RooNDKeysPdf& other, const char* name=nullptr);
   ~RooNDKeysPdf() override;
 
   TObject* clone(const char* newname) const override { return new RooNDKeysPdf(*this,newname); }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   inline void fixShape(bool fix) {
     createPdf(false);

--- a/roofit/roofit/inc/RooNonCPEigenDecay.h
+++ b/roofit/roofit/inc/RooNonCPEigenDecay.h
@@ -76,7 +76,7 @@ public:
             const RooResolutionModel& model,
             DecayType       type = DoubleSided );
 
-  RooNonCPEigenDecay(const RooNonCPEigenDecay& other, const char* name=0);
+  RooNonCPEigenDecay(const RooNonCPEigenDecay& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override {
     return new RooNonCPEigenDecay(*this,newname);
   }
@@ -85,8 +85,8 @@ public:
   double coefficient( Int_t basisIndex ) const override;
 
   Int_t getCoefAnalyticalIntegral( Int_t coef, RooArgSet& allVars,
-                    RooArgSet& analVars, const char* rangeName=0 ) const override;
-  double coefAnalyticalIntegral( Int_t coef, Int_t code, const char* rangeName=0 ) const override;
+                    RooArgSet& analVars, const char* rangeName=nullptr ) const override;
+  double coefAnalyticalIntegral( Int_t coef, Int_t code, const char* rangeName=nullptr ) const override;
 
   Int_t getGenerator( const RooArgSet& directVars,
             RooArgSet&       generateVars, bool staticInitOK=true ) const override;

--- a/roofit/roofit/inc/RooNovosibirsk.h
+++ b/roofit/roofit/inc/RooNovosibirsk.h
@@ -33,12 +33,12 @@ public:
        RooAbsReal& _x,     RooAbsReal& _peak,
        RooAbsReal& _width, RooAbsReal& _tail);
 
-  RooNovosibirsk(const RooNovosibirsk& other,const char* name=0) ;
+  RooNovosibirsk(const RooNovosibirsk& other,const char* name=nullptr) ;
 
   TObject* clone(const char* newname) const override { return new RooNovosibirsk(*this,newname);   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   // An empty constructor is usually ok
   inline ~RooNovosibirsk() override { }

--- a/roofit/roofit/inc/RooParamHistFunc.h
+++ b/roofit/roofit/inc/RooParamHistFunc.h
@@ -23,7 +23,7 @@ public:
   RooParamHistFunc(const char *name, const char *title, RooDataHist& dh, bool paramRelative=true);
   RooParamHistFunc(const char *name, const char *title, const RooAbsArg& x, RooDataHist& dh, bool paramRelative=true);
   RooParamHistFunc(const char *name, const char *title, RooDataHist& dh, const RooParamHistFunc& paramSource, bool paramRelative=true) ;
-  RooParamHistFunc(const RooParamHistFunc& other, const char* name=0) ;
+  RooParamHistFunc(const RooParamHistFunc& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooParamHistFunc(*this,newname); }
   inline ~RooParamHistFunc() override { }
 
@@ -33,8 +33,8 @@ public:
 
 
   bool forceAnalyticalInt(const RooAbsArg&) const override { return true ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   double getActual(Int_t ibin) ;
   void setActual(Int_t ibin, double newVal) ;

--- a/roofit/roofit/inc/RooPoisson.h
+++ b/roofit/roofit/inc/RooPoisson.h
@@ -20,12 +20,12 @@ class RooPoisson : public RooAbsPdf {
 public:
   RooPoisson() { _noRounding = false ;   } ;
   RooPoisson(const char *name, const char *title, RooAbsReal& _x, RooAbsReal& _mean, bool noRounding=false);
-  RooPoisson(const RooPoisson& other, const char* name=0) ;
+  RooPoisson(const RooPoisson& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooPoisson(*this,newname); }
   inline ~RooPoisson() override {  }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooPolynomial.h
+++ b/roofit/roofit/inc/RooPolynomial.h
@@ -37,8 +37,8 @@ public:
   TObject* clone(const char* newname) const override { return new RooPolynomial(*this, newname); }
   ~RooPolynomial() override ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofit/inc/RooTFnBinding.h
+++ b/roofit/roofit/inc/RooTFnBinding.h
@@ -18,7 +18,7 @@ public:
    RooTFnBinding() : _func(0) {} ;
   RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list);
   RooTFnBinding(const char *name, const char *title, TF1* func, const RooArgList& list, const RooArgList& plist);
-  RooTFnBinding(const RooTFnBinding& other, const char* name=0) ;
+  RooTFnBinding(const RooTFnBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooTFnBinding(*this,newname); }
   inline ~RooTFnBinding() override { }
 

--- a/roofit/roofit/inc/RooTFnPdfBinding.h
+++ b/roofit/roofit/inc/RooTFnPdfBinding.h
@@ -17,7 +17,7 @@ class RooTFnPdfBinding : public RooAbsPdf {
 public:
   RooTFnPdfBinding() : _func(0) {} ;
   RooTFnPdfBinding(const char *name, const char *title, TF1* func, const RooArgList& list);
-  RooTFnPdfBinding(const RooTFnPdfBinding& other, const char* name=0) ;
+  RooTFnPdfBinding(const RooTFnPdfBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooTFnPdfBinding(*this,newname); }
   inline ~RooTFnPdfBinding() override { }
 

--- a/roofit/roofit/inc/RooUnblindCPAsymVar.h
+++ b/roofit/roofit/inc/RooUnblindCPAsymVar.h
@@ -32,7 +32,7 @@ public:
          const char *blindString, RooAbsReal& cpasym);
   RooUnblindCPAsymVar(const char *name, const char *title,
             const char *blindString, RooAbsReal& cpasym, RooAbsCategory& blindState);
-  RooUnblindCPAsymVar(const RooUnblindCPAsymVar& other, const char* name=0);
+  RooUnblindCPAsymVar(const RooUnblindCPAsymVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooUnblindCPAsymVar(*this,newname); }
   ~RooUnblindCPAsymVar() override;
 

--- a/roofit/roofit/inc/RooUnblindOffset.h
+++ b/roofit/roofit/inc/RooUnblindOffset.h
@@ -29,7 +29,7 @@ public:
   RooUnblindOffset(const char *name, const char *title,
          const char *blindString, double scale, RooAbsReal& blindValue,
          RooAbsCategory& blindState);
-  RooUnblindOffset(const RooUnblindOffset& other, const char* name=0);
+  RooUnblindOffset(const RooUnblindOffset& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooUnblindOffset(*this,newname); }
   ~RooUnblindOffset() override;
 

--- a/roofit/roofit/inc/RooUnblindPrecision.h
+++ b/roofit/roofit/inc/RooUnblindPrecision.h
@@ -32,7 +32,7 @@ public:
   RooUnblindPrecision(const char *name, const char *title,
             const char *blindString, double centralValue, double scale,
             RooAbsReal& blindValue, RooAbsCategory& blindState, bool sin2betaMode=false);
-  RooUnblindPrecision(const RooUnblindPrecision& other, const char* name=0);
+  RooUnblindPrecision(const RooUnblindPrecision& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooUnblindPrecision(*this,newname); }
   ~RooUnblindPrecision() override;
 

--- a/roofit/roofit/inc/RooUnblindUniform.h
+++ b/roofit/roofit/inc/RooUnblindUniform.h
@@ -26,7 +26,7 @@ public:
   RooUnblindUniform() ;
   RooUnblindUniform(const char *name, const char *title,
             const char *blindString, double scale, RooAbsReal& blindValue);
-  RooUnblindUniform(const RooUnblindUniform& other, const char* name=0);
+  RooUnblindUniform(const RooUnblindUniform& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooUnblindUniform(*this,newname); }
   ~RooUnblindUniform() override;
 

--- a/roofit/roofit/inc/RooUniform.h
+++ b/roofit/roofit/inc/RooUniform.h
@@ -25,12 +25,12 @@ class RooUniform : public RooAbsPdf {
 public:
   RooUniform() {} ;
   RooUniform(const char *name, const char *title, const RooArgSet& _x);
-  RooUniform(const RooUniform& other, const char* name=0) ;
+  RooUniform(const RooUniform& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooUniform(*this,newname); }
   inline ~RooUniform() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;

--- a/roofit/roofit/inc/RooVoigtian.h
+++ b/roofit/roofit/inc/RooVoigtian.h
@@ -28,7 +28,7 @@ public:
          RooAbsReal& _x, RooAbsReal& _mean,
               RooAbsReal& _width, RooAbsReal& _sigma,
               bool doFast = false);
-  RooVoigtian(const RooVoigtian& other, const char* name=0) ;
+  RooVoigtian(const RooVoigtian& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooVoigtian(*this,newname); }
   inline ~RooVoigtian() override { }
 

--- a/roofit/roofitZMQ/res/RooFit_ZMQ/ZeroMQSvc.h
+++ b/roofit/roofitZMQ/res/RooFit_ZMQ/ZeroMQSvc.h
@@ -154,7 +154,7 @@ public:
    }
 
    /// receive message with ZMQ, general version
-   // FIXME: what to do with flags=0.... more is a pointer, that might prevent conversion
+   // FIXME: what to do with flags=nullptr.... more is a pointer, that might prevent conversion
    template <class T, typename std::enable_if<!(std::is_same<zmq::message_t, T>::value), T>::type * = nullptr>
    T receive(zmq::socket_t &socket, zmq::recv_flags flags = zmq::recv_flags::none, bool *more = nullptr) const
    {

--- a/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
+++ b/roofit/roofitcore/inc/RooAbsAnaConvPdf.h
@@ -38,7 +38,7 @@ public:
          const RooResolutionModel& model,
          RooRealVar& convVar) ;
 
-  RooAbsAnaConvPdf(const RooAbsAnaConvPdf& other, const char* name=0);
+  RooAbsAnaConvPdf(const RooAbsAnaConvPdf& other, const char* name=nullptr);
   ~RooAbsAnaConvPdf() override;
 
   Int_t declareBasis(const char* expression, const RooArgList& params) ;
@@ -49,17 +49,17 @@ public:
     // Returns normalization integral for coefficient coefIdx for observables nset in range rangeNae
     return getCoefNorm(coefIdx,&nset,rangeName) ;
   }
-  double getCoefNorm(Int_t coefIdx, const RooArgSet* nset=0, const char* rangeName=0) const {
+  double getCoefNorm(Int_t coefIdx, const RooArgSet* nset=nullptr, const char* rangeName=nullptr) const {
        return getCoefNorm(coefIdx,nset,RooNameReg::ptr(rangeName));
   }
 
   // Analytical integration support
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   // Coefficient Analytical integration support
-  virtual Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=0) const ;
+  virtual Int_t getCoefAnalyticalIntegral(Int_t coef, RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const ;
+  virtual double coefAnalyticalIntegral(Int_t coef, Int_t code, const char* rangeName=nullptr) const ;
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
   virtual double coefficient(Int_t basisIndex) const = 0 ;
@@ -69,8 +69,8 @@ public:
 
   void setCacheAndTrackHints(RooArgSet&) override ;
 
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, bool verbose= false) const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                       const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
   virtual bool changeModel(const RooResolutionModel& newModel) ;
 
   /// Retrieve the convolution variable.
@@ -94,7 +94,7 @@ protected:
   RooRealProxy _model ;   ///< Original model
   RooRealProxy _convVar ; ///< Convolution variable
 
-  RooArgSet* parseIntegrationRequest(const RooArgSet& intSet, Int_t& coefCode, RooArgSet* analVars=0) const ;
+  RooArgSet* parseIntegrationRequest(const RooArgSet& intSet, Int_t& coefCode, RooArgSet* analVars=nullptr) const ;
 
   RooListProxy _convSet  ;  ///<  Set of (resModel (x) basisFunc) convolution objects
   RooArgList _basisList ;   ///<!  List of created basis functions

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -77,13 +77,13 @@ public:
   RooAbsArg() ;
   ~RooAbsArg() override;
   RooAbsArg(const char *name, const char *title);
-  RooAbsArg(const RooAbsArg& other, const char* name=0) ;
+  RooAbsArg(const RooAbsArg& other, const char* name=nullptr) ;
   RooAbsArg& operator=(const RooAbsArg& other);
-  virtual TObject* clone(const char* newname=0) const = 0 ;
+  virtual TObject* clone(const char* newname=nullptr) const = 0 ;
   TObject* Clone(const char* newname = 0) const override {
     return clone(newname && newname[0] != '\0' ? newname : nullptr);
   }
-  virtual RooAbsArg* cloneTree(const char* newname=0) const ;
+  virtual RooAbsArg* cloneTree(const char* newname=nullptr) const ;
 
   // Accessors to client-server relation information
 
@@ -98,7 +98,7 @@ public:
   /// @param serverList Test if one of the elements in this list serves values to `this`.
   /// @param ignoreArg Ignore values served by this object.
   /// @return True if values are served.
-  bool dependsOnValue(const RooAbsCollection& serverList, const RooAbsArg* ignoreArg=0) const {
+  bool dependsOnValue(const RooAbsCollection& serverList, const RooAbsArg* ignoreArg=nullptr) const {
     return dependsOn(serverList,ignoreArg,true) ;
   }
   /// Check whether this object depends on values served from the object passed as `server`.
@@ -106,11 +106,11 @@ public:
   /// @param server Test if `server` serves values to `this`.
   /// @param ignoreArg Ignore values served by this object.
   /// @return True if values are served.
-  bool dependsOnValue(const RooAbsArg& server, const RooAbsArg* ignoreArg=0) const {
+  bool dependsOnValue(const RooAbsArg& server, const RooAbsArg* ignoreArg=nullptr) const {
     return dependsOn(server,ignoreArg,true) ;
   }
-  bool dependsOn(const RooAbsCollection& serverList, const RooAbsArg* ignoreArg=0, bool valueOnly=false) const ;
-  bool dependsOn(const RooAbsArg& server, const RooAbsArg* ignoreArg=0, bool valueOnly=false) const ;
+  bool dependsOn(const RooAbsCollection& serverList, const RooAbsArg* ignoreArg=nullptr, bool valueOnly=false) const ;
+  bool dependsOn(const RooAbsArg& server, const RooAbsArg* ignoreArg=nullptr, bool valueOnly=false) const ;
   bool overlaps(const RooAbsArg& testArg, bool valueOnly=false) const ;
   bool hasClients() const { return !_clientList.empty(); }
 
@@ -227,9 +227,9 @@ public:
   inline bool isShapeServer(const char* name) const {
     return _clientListShape.containsSameName(name);
   }
-  void leafNodeServerList(RooAbsCollection* list, const RooAbsArg* arg=0, bool recurseNonDerived=false) const ;
-  void branchNodeServerList(RooAbsCollection* list, const RooAbsArg* arg=0, bool recurseNonDerived=false) const ;
-  void treeNodeServerList(RooAbsCollection* list, const RooAbsArg* arg=0,
+  void leafNodeServerList(RooAbsCollection* list, const RooAbsArg* arg=nullptr, bool recurseNonDerived=false) const ;
+  void branchNodeServerList(RooAbsCollection* list, const RooAbsArg* arg=nullptr, bool recurseNonDerived=false) const ;
+  void treeNodeServerList(RooAbsCollection* list, const RooAbsArg* arg=nullptr,
            bool doBranch=true, bool doLeaf=true,
            bool valueOnly=false, bool recurseNonDerived=false) const ;
 
@@ -245,7 +245,7 @@ public:
   /// Create a fundamental-type object that stores our type of value. The
   /// created object will have a valid value, but not necessarily the same
   /// as our value. The caller is responsible for deleting the returned object.
-  virtual RooAbsArg *createFundamental(const char* newname=0) const = 0;
+  virtual RooAbsArg *createFundamental(const char* newname=nullptr) const = 0;
 
   /// Is this argument an l-value, i.e., can it appear on the left-hand side
   /// of an assignment expression? LValues are also special since they can
@@ -534,9 +534,9 @@ public:
   void graphVizTree(const char* fileName, const char* delimiter="\n", bool useTitle=false, bool useLatex=false) ;
   void graphVizTree(std::ostream& os, const char* delimiter="\n", bool useTitle=false, bool useLatex=false) ;
 
-  void printComponentTree(const char* indent="",const char* namePat=0, Int_t nLevel=999) ;
-  void printCompactTree(const char* indent="",const char* fileName=0, const char* namePat=0, RooAbsArg* client=0) ;
-  void printCompactTree(std::ostream& os, const char* indent="", const char* namePat=0, RooAbsArg* client=0) ;
+  void printComponentTree(const char* indent="",const char* namePat=nullptr, Int_t nLevel=999) ;
+  void printCompactTree(const char* indent="",const char* fileName=nullptr, const char* namePat=nullptr, RooAbsArg* client=nullptr) ;
+  void printCompactTree(std::ostream& os, const char* indent="", const char* namePat=nullptr, RooAbsArg* client=nullptr) ;
   virtual void printCompactTreeHook(std::ostream& os, const char *ind="") ;
 
   // We want to support three cases here:
@@ -679,7 +679,7 @@ private:
   friend class RooVectorDataStore ;
   friend class RooDataSet ;
   friend class RooRealMPFE ;
-  virtual void syncCache(const RooArgSet* nset=0) = 0 ;
+  virtual void syncCache(const RooArgSet* nset=nullptr) = 0 ;
   virtual void copyCache(const RooAbsArg* source, bool valueOnly=false, bool setValDirty=true) = 0 ;
 
   virtual void attachToTree(TTree& t, Int_t bufSize=32000) = 0 ;

--- a/roofit/roofitcore/inc/RooAbsBinning.h
+++ b/roofit/roofitcore/inc/RooAbsBinning.h
@@ -25,12 +25,12 @@ class RooAbsReal ;
 class RooAbsBinning : public TNamed, public RooPrintable {
 public:
 
-  RooAbsBinning(const char* name=0) ;
-  RooAbsBinning(const RooAbsBinning& other, const char* name=0) : TNamed(name,name), RooPrintable(other) {
+  RooAbsBinning(const char* name=nullptr) ;
+  RooAbsBinning(const RooAbsBinning& other, const char* name=nullptr) : TNamed(name,name), RooPrintable(other) {
     // Copy constructor
   }
-  TObject* Clone(const char* newname=0) const override { return clone(newname) ; }
-  virtual RooAbsBinning* clone(const char* name=0) const = 0 ;
+  TObject* Clone(const char* newname=nullptr) const override { return clone(newname) ; }
+  virtual RooAbsBinning* clone(const char* name=nullptr) const = 0 ;
   ~RooAbsBinning() override ;
 
   /// Return number of bins.

--- a/roofit/roofitcore/inc/RooAbsCache.h
+++ b/roofit/roofitcore/inc/RooAbsCache.h
@@ -28,9 +28,9 @@ class RooAbsCache {
 
 public:
 
-  RooAbsCache(RooAbsArg* owner=0) ;
+  RooAbsCache(RooAbsArg* owner=nullptr) ;
 
-  RooAbsCache(const RooAbsCache&, RooAbsArg* owner=0 ) ;
+  RooAbsCache(const RooAbsCache&, RooAbsArg* owner=nullptr ) ;
 
   virtual ~RooAbsCache() ;
 

--- a/roofit/roofitcore/inc/RooAbsCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsCachedPdf.h
@@ -44,8 +44,8 @@ public:
     // Return RooDataHist with cached values
     return getCacheHist(&nset) ;
   }
-  RooAbsPdf* getCachePdf(const RooArgSet* nset=0) const ;
-  RooDataHist* getCacheHist(const RooArgSet* nset=0) const ;
+  RooAbsPdf* getCachePdf(const RooArgSet* nset=nullptr) const ;
+  RooDataHist* getCacheHist(const RooArgSet* nset=nullptr) const ;
 
   void setInterpolationOrder(int order) ;
   Int_t getInterpolationOrder() const {

--- a/roofit/roofitcore/inc/RooAbsCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsCachedReal.h
@@ -26,10 +26,10 @@ public:
 
   RooAbsCachedReal() : _cacheMgr(this,10) {}
   RooAbsCachedReal(const char *name, const char *title, Int_t ipOrder=0);
-  RooAbsCachedReal(const RooAbsCachedReal& other, const char* name=0) ;
+  RooAbsCachedReal(const RooAbsCachedReal& other, const char* name=nullptr) ;
   ~RooAbsCachedReal() override ;
 
-  double getValV(const RooArgSet* set=0) const override ;
+  double getValV(const RooArgSet* set=nullptr) const override ;
   virtual bool selfNormalized() const {
     // Declares function self normalized
     return true ;
@@ -46,8 +46,8 @@ public:
     return true ;
   }
 
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   void disableCache(bool flag) {
     // Switch to disable caching mechanism

--- a/roofit/roofitcore/inc/RooAbsCategory.h
+++ b/roofit/roofitcore/inc/RooAbsCategory.h
@@ -43,7 +43,7 @@ public:
   // Constructors, assignment etc.
   RooAbsCategory();
   RooAbsCategory(const char *name, const char *title);
-  RooAbsCategory(const RooAbsCategory& other, const char* name=0) ;
+  RooAbsCategory(const RooAbsCategory& other, const char* name=nullptr) ;
   ~RooAbsCategory() override;
 
   // Value accessors
@@ -90,7 +90,7 @@ public:
     return true ;
   }
 
-  RooAbsArg *createFundamental(const char* newname=0) const override;
+  RooAbsArg *createFundamental(const char* newname=nullptr) const override;
 
   /// Iterator for category state names. Points to pairs of index and name.
   std::map<std::string, value_type>::const_iterator begin() const {
@@ -130,8 +130,8 @@ public:
   TIterator*
   R__SUGGEST_ALTERNATIVE("This interface is inefficient. Use begin(), end() or range-based for loops.")
   typeIterator() const;
-  /// Return number of types defined (in range named rangeName if rangeName!=0)
-  Int_t numTypes(const char* /*rangeName*/=0) const {
+  /// Return number of types defined (in range named rangeName if rangeName!=nullptr)
+  Int_t numTypes(const char* /*rangeName*/=nullptr) const {
     return stateNames().size();
   }
   /// Retrieve the current index. Use getCurrentIndex() for more clarity.
@@ -206,7 +206,7 @@ protected:
   virtual void recomputeShape() = 0;
 
   friend class RooVectorDataStore ;
-  void syncCache(const RooArgSet* set=0) override ;
+  void syncCache(const RooArgSet* set=nullptr) override ;
   void copyCache(const RooAbsArg* source, bool valueOnly=false, bool setValueDirty=true) override ;
   void setCachedValue(double value, bool notifyClients = true) final;
   void attachToTree(TTree& t, Int_t bufSize=32000) override ;

--- a/roofit/roofitcore/inc/RooAbsCategoryLValue.h
+++ b/roofit/roofitcore/inc/RooAbsCategoryLValue.h
@@ -29,7 +29,7 @@ public:
     // Default constructor
   } ;
   RooAbsCategoryLValue(const char *name, const char *title);
-  RooAbsCategoryLValue(const RooAbsCategoryLValue& other, const char* name=0) ;
+  RooAbsCategoryLValue(const RooAbsCategoryLValue& other, const char* name=nullptr) ;
   ~RooAbsCategoryLValue() override;
 
   // Value modifiers
@@ -76,21 +76,21 @@ public:
   RooAbsArg& operator=(const RooAbsCategory& other) ;
 
   // Binned fit interface
-  void setBin(Int_t ibin, const char* rangeName=0) override ;
+  void setBin(Int_t ibin, const char* rangeName=nullptr) override ;
   /// Get the index of the plot bin for the current value of this category.
   Int_t getBin(const char* /*rangeName*/=nullptr) const override {
     return getCurrentOrdinalNumber();
   }
   Int_t numBins(const char* rangeName=nullptr) const override ;
-  double getBinWidth(Int_t /*i*/, const char* /*rangeName*/=0) const override {
-    // Return volume of i-th bin (according to binning named rangeName if rangeName!=0)
+  double getBinWidth(Int_t /*i*/, const char* /*rangeName*/=nullptr) const override {
+    // Return volume of i-th bin (according to binning named rangeName if rangeName!=nullptr)
     return 1.0 ;
   }
   double volume(const char* rangeName) const override {
     // Return span of range with given name (=number of states included in this range)
     return numTypes(rangeName) ;
   }
-  void randomize(const char* rangeName=0) override;
+  void randomize(const char* rangeName=nullptr) override;
 
   const RooAbsBinning* getBinningPtr(const char* /*rangeName*/) const override { return 0 ; }
   std::list<std::string> getBinningNames() const override { return std::list<std::string>(1, "") ; }

--- a/roofit/roofitcore/inc/RooAbsCollection.h
+++ b/roofit/roofitcore/inc/RooAbsCollection.h
@@ -72,7 +72,7 @@ public:
   RooAbsCollection(const char *name);
   virtual TObject* clone(const char* newname) const = 0 ;
   virtual TObject* create(const char* newname) const = 0 ;
-  TObject* Clone(const char* newname=0) const override {
+  TObject* Clone(const char* newname=nullptr) const override {
     return clone(newname?newname:GetName()) ;
   }
   ~RooAbsCollection() override;
@@ -151,11 +151,11 @@ public:
   }
 
    // Utilities functions when used as configuration object
-   double getRealValue(const char* name, double defVal=0, bool verbose=false) const ;
+   double getRealValue(const char* name, double defVal=0.0, bool verbose=false) const ;
    const char* getCatLabel(const char* name, const char* defVal="", bool verbose=false) const ;
    Int_t getCatIndex(const char* name, Int_t defVal=0, bool verbose=false) const ;
    const char* getStringValue(const char* name, const char* defVal="", bool verbose=false) const ;
-   bool setRealValue(const char* name, double newVal=0, bool verbose=false) ;
+   bool setRealValue(const char* name, double newVal=0.0, bool verbose=false) ;
    bool setCatLabel(const char* name, const char* newVal="", bool verbose=false) ;
    bool setCatIndex(const char* name, Int_t newVal=0, bool verbose=false) ;
    bool setStringValue(const char* name, const char* newVal="", bool verbose=false) ;
@@ -313,7 +313,7 @@ public:
         const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
         const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) const ;
   void printLatex(std::ostream& ofs, Int_t ncol, const char* option="NEYU", Int_t sigDigit=1,
-                  const RooLinkedList& siblingLists=RooLinkedList(), const RooCmdArg* formatCmd=0) const ;
+                  const RooLinkedList& siblingLists=RooLinkedList(), const RooCmdArg* formatCmd=nullptr) const ;
 
   void setName(const char *name) {
     // Set name of collection
@@ -366,13 +366,13 @@ protected:
   // Support for snapshot method
   bool addServerClonesToList(const RooAbsArg& var) ;
 
-  inline TNamed* structureTag() { if (_structureTag==0) makeStructureTag() ; return _structureTag ; }
-  inline TNamed* typedStructureTag() { if (_typedStructureTag==0) makeTypedStructureTag() ; return _typedStructureTag ; }
+  inline TNamed* structureTag() { if (_structureTag==nullptr) makeStructureTag() ; return _structureTag ; }
+  inline TNamed* typedStructureTag() { if (_typedStructureTag==nullptr) makeTypedStructureTag() ; return _typedStructureTag ; }
 
   mutable TNamed* _structureTag{nullptr};      ///<! Structure tag
   mutable TNamed* _typedStructureTag{nullptr}; ///<! Typed structure tag
 
-  inline void clearStructureTags() { _structureTag=0 ; _typedStructureTag = 0 ; }
+  inline void clearStructureTags() { _structureTag=nullptr ; _typedStructureTag = 0 ; }
 
   void makeStructureTag() {}
   void makeTypedStructureTag() {}

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -64,19 +64,19 @@ public:
 
   // Constructors, factory methods etc.
   RooAbsData() ;
-  RooAbsData(RooStringView name, RooStringView title, const RooArgSet& vars, RooAbsDataStore* store=0) ;
+  RooAbsData(RooStringView name, RooStringView title, const RooArgSet& vars, RooAbsDataStore* store=nullptr) ;
   RooAbsData(const RooAbsData& other, const char* newname = 0) ;
 
   RooAbsData& operator=(const RooAbsData& other);
   ~RooAbsData() override ;
-  virtual RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const = 0 ;
+  virtual RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const = 0 ;
 
   // Reduction methods
   RooAbsData* reduce(const RooCmdArg& arg1,const RooCmdArg& arg2=RooCmdArg(),const RooCmdArg& arg3=RooCmdArg(),const RooCmdArg& arg4=RooCmdArg(),
                      const RooCmdArg& arg5=RooCmdArg(),const RooCmdArg& arg6=RooCmdArg(),const RooCmdArg& arg7=RooCmdArg(),const RooCmdArg& arg8=RooCmdArg()) ;
   RooAbsData* reduce(const char* cut) ;
   RooAbsData* reduce(const RooFormulaVar& cutVar) ;
-  RooAbsData* reduce(const RooArgSet& varSubset, const char* cut=0) ;
+  RooAbsData* reduce(const RooArgSet& varSubset, const char* cut=nullptr) ;
   RooAbsData* reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) ;
 
   RooAbsDataStore* store() { return _dstore ; }
@@ -99,7 +99,7 @@ public:
   virtual bool changeObservableName(const char* from, const char* to) ;
 
   // Add one ore more rows of data
-  virtual void add(const RooArgSet& row, double weight=1, double weightError=0) = 0 ; // DERIVED
+  virtual void add(const RooArgSet& row, double weight=1, double weightError=0.0) = 0 ; // DERIVED
   virtual void fill() ;
 
   // Load a given row of data
@@ -152,7 +152,7 @@ public:
   /// Return effective number of entries in dataset inside range or after cuts, i.e., sum certain weights.
   /// \param[in] cutSpec Apply given cut when counting (e.g. `0 < x && x < 5`). Passing `"1"` selects all events.
   /// \param[in] cutRange If the observables have a range with this name, only count events inside this range.
-  virtual double sumEntries(const char* cutSpec, const char* cutRange=0) const = 0 ; // DERIVED
+  virtual double sumEntries(const char* cutSpec, const char* cutRange=nullptr) const = 0 ; // DERIVED
   double sumEntriesW2() const;
   virtual bool isWeighted() const {
     // Do events in dataset have weights?
@@ -165,7 +165,7 @@ public:
   virtual void reset() ;
 
 
-  bool getRange(const RooAbsRealLValue& var, double& lowest, double& highest, double marginFrac=0, bool symMode=false) const ;
+  bool getRange(const RooAbsRealLValue& var, double& lowest, double& highest, double marginFrac=0.0, bool symMode=false) const ;
 
   // Plot the distribution of a real valued arg
   virtual Roo1DTable* table(const RooArgSet& catSet, const char* cuts="", const char* opts="") const ;
@@ -233,7 +233,7 @@ public:
                         const char* cuts="", const char *name="hist") const;
 
   // Fill an existing histogram
-  virtual TH1 *fillHistogram(TH1 *hist, const RooArgList &plotVars, const char *cuts= "", const char* cutRange=0) const;
+  virtual TH1 *fillHistogram(TH1 *hist, const RooArgList &plotVars, const char *cuts= "", const char* cutRange=nullptr) const;
 
   // Printing interface (human readable)
   inline void Print(Option_t *options= 0) const override {
@@ -250,25 +250,25 @@ public:
 
   void setDirtyProp(bool flag) ;
 
-  double moment(const RooRealVar& var, double order, const char* cutSpec=0, const char* cutRange=0) const ;
-  double moment(const RooRealVar& var, double order, double offset, const char* cutSpec=0, const char* cutRange=0) const ;
-  double standMoment(const RooRealVar& var, double order, const char* cutSpec=0, const char* cutRange=0) const ;
+  double moment(const RooRealVar& var, double order, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
+  double moment(const RooRealVar& var, double order, double offset, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
+  double standMoment(const RooRealVar& var, double order, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
 
-  double mean(const RooRealVar& var, const char* cutSpec=0, const char* cutRange=0) const { return moment(var,1,0,cutSpec,cutRange) ; }
-  double sigma(const RooRealVar& var, const char* cutSpec=0, const char* cutRange=0) const { return sqrt(moment(var,2,cutSpec,cutRange)) ; }
-  double skewness(const RooRealVar& var, const char* cutSpec=0, const char* cutRange=0) const { return standMoment(var,3,cutSpec,cutRange) ; }
-  double kurtosis(const RooRealVar& var, const char* cutSpec=0, const char* cutRange=0) const { return standMoment(var,4,cutSpec,cutRange) ; }
+  double mean(const RooRealVar& var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return moment(var,1,0,cutSpec,cutRange) ; }
+  double sigma(const RooRealVar& var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return sqrt(moment(var,2,cutSpec,cutRange)) ; }
+  double skewness(const RooRealVar& var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return standMoment(var,3,cutSpec,cutRange) ; }
+  double kurtosis(const RooRealVar& var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return standMoment(var,4,cutSpec,cutRange) ; }
 
-  double covariance(RooRealVar &x,RooRealVar &y, const char* cutSpec=0, const char* cutRange=0) const { return corrcov(x,y,cutSpec,cutRange,false) ; }
-  double correlation(RooRealVar &x,RooRealVar &y, const char* cutSpec=0, const char* cutRange=0) const { return corrcov(x,y,cutSpec,cutRange,true) ; }
+  double covariance(RooRealVar &x,RooRealVar &y, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcov(x,y,cutSpec,cutRange,false) ; }
+  double correlation(RooRealVar &x,RooRealVar &y, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcov(x,y,cutSpec,cutRange,true) ; }
 
-  TMatrixDSym* covarianceMatrix(const char* cutSpec=0, const char* cutRange=0) const { return covarianceMatrix(*get(),cutSpec,cutRange) ; }
-  TMatrixDSym* correlationMatrix(const char* cutSpec=0, const char* cutRange=0) const { return correlationMatrix(*get(),cutSpec,cutRange) ; }
-  TMatrixDSym* covarianceMatrix(const RooArgList& vars, const char* cutSpec=0, const char* cutRange=0) const { return corrcovMatrix(vars,cutSpec,cutRange,false) ; }
-  TMatrixDSym* correlationMatrix(const RooArgList& vars, const char* cutSpec=0, const char* cutRange=0) const { return corrcovMatrix(vars,cutSpec,cutRange,true) ; }
+  TMatrixDSym* covarianceMatrix(const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return covarianceMatrix(*get(),cutSpec,cutRange) ; }
+  TMatrixDSym* correlationMatrix(const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return correlationMatrix(*get(),cutSpec,cutRange) ; }
+  TMatrixDSym* covarianceMatrix(const RooArgList& vars, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcovMatrix(vars,cutSpec,cutRange,false) ; }
+  TMatrixDSym* correlationMatrix(const RooArgList& vars, const char* cutSpec=nullptr, const char* cutRange=nullptr) const { return corrcovMatrix(vars,cutSpec,cutRange,true) ; }
 
-  RooRealVar* meanVar(const RooRealVar &var, const char* cutSpec=0, const char* cutRange=0) const ;
-  RooRealVar* rmsVar(const RooRealVar &var, const char* cutSpec=0, const char* cutRange=0) const ;
+  RooRealVar* meanVar(const RooRealVar &var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
+  RooRealVar* rmsVar(const RooRealVar &var, const char* cutSpec=nullptr, const char* cutRange=nullptr) const ;
 
   virtual RooPlot* statOn(RooPlot* frame,
                           const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
@@ -280,8 +280,8 @@ public:
            const char *label= "", Int_t sigDigits= 2,
            Option_t *options= "NELU", double xmin=0.15,
            double xmax= 0.65,double ymax=0.85,
-                          const char* cutSpec=0, const char* cutRange=0,
-                          const RooCmdArg* formatCmd=0);
+                          const char* cutSpec=nullptr, const char* cutRange=nullptr,
+                          const RooCmdArg* formatCmd=nullptr);
 
   void RecursiveRemove(TObject *obj) override;
 
@@ -348,12 +348,12 @@ protected:
   // for access into copied dataset:
   friend class RooFit::TestStatistics::RooAbsL;
 
-  virtual void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, bool skipZeroWeights=false) ;
+  virtual void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=nullptr, bool skipZeroWeights=false) ;
   virtual void resetCache() ;
   virtual void setArgStatus(const RooArgSet& set, bool active) ;
   virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) ;
 
-  virtual RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
+  virtual RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
                            std::size_t nStart = 0, std::size_t = std::numeric_limits<std::size_t>::max()) = 0 ;
 
   RooRealVar* dataRealVar(const char* methodname, const RooRealVar& extVar) const ;

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -40,16 +40,16 @@ public:
   RooAbsDataStore() {}
   RooAbsDataStore(RooStringView name, RooStringView title, const RooArgSet& vars)
     : TNamed(name,title), _vars{vars} {}
-  RooAbsDataStore(const RooAbsDataStore& other, const char* newname=0)
+  RooAbsDataStore(const RooAbsDataStore& other, const char* newname=nullptr)
     : RooAbsDataStore(other, other._vars, newname) {}
-  RooAbsDataStore(const RooAbsDataStore& other, const RooArgSet& vars, const char* newname=0)
+  RooAbsDataStore(const RooAbsDataStore& other, const RooArgSet& vars, const char* newname=nullptr)
     : TNamed(other), RooPrintable(other), _vars{vars}, _doDirtyProp{other._doDirtyProp}
   {
     if(newname) SetName(newname);
   }
 
-  virtual RooAbsDataStore* clone(const char* newname=0) const = 0 ;
-  virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const = 0 ;
+  virtual RooAbsDataStore* clone(const char* newname=nullptr) const = 0 ;
+  virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const = 0 ;
 
   virtual RooAbsDataStore* reduce(RooStringView name, RooStringView title,
                                   const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
@@ -126,7 +126,7 @@ public:
 
 
   // Constant term  optimizer interface
-  virtual void cacheArgs(const RooAbsArg* cacheOwner, RooArgSet& varSet, const RooArgSet* nset=0, bool skipZeroWeights=false) = 0 ;
+  virtual void cacheArgs(const RooAbsArg* cacheOwner, RooArgSet& varSet, const RooArgSet* nset=nullptr, bool skipZeroWeights=false) = 0 ;
   virtual const RooAbsArg* cacheOwner() = 0 ;
   virtual void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) = 0 ;
   virtual void setArgStatus(const RooArgSet& set, bool active) = 0 ;
@@ -144,7 +144,7 @@ public:
   virtual const TTree* tree() const { return 0 ; }
   virtual void dump() {}
 
-  virtual void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=0, const char* rangeName=0,
+  virtual void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=nullptr, const char* rangeName=nullptr,
       std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) = 0 ;
 
   virtual void forceCacheUpdate() {} ;

--- a/roofit/roofitcore/inc/RooAbsGenContext.h
+++ b/roofit/roofitcore/inc/RooAbsGenContext.h
@@ -25,7 +25,7 @@ class RooDataSet;
 
 class RooAbsGenContext : public TNamed, public RooPrintable {
 public:
-  RooAbsGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0, const RooArgSet* auxProto=0,
+  RooAbsGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0, const RooArgSet* auxProto=nullptr,
          bool _verbose= false) ;
   ~RooAbsGenContext() override;
 

--- a/roofit/roofitcore/inc/RooAbsHiddenReal.h
+++ b/roofit/roofitcore/inc/RooAbsHiddenReal.h
@@ -30,7 +30,7 @@ public:
   }
   RooAbsHiddenReal(const char *name, const char *title, const char *unit= "") ;
   RooAbsHiddenReal(const char *name, const char *title, RooAbsCategory& blindState, const char *unit= "") ;
-  RooAbsHiddenReal(const RooAbsHiddenReal& other, const char* name=0) ;
+  RooAbsHiddenReal(const RooAbsHiddenReal& other, const char* name=nullptr) ;
   ~RooAbsHiddenReal() override;
 
   // I/O streaming interface (machine readable)
@@ -45,7 +45,7 @@ public:
     return _state.arg().getCurrentIndex()!=0 ;
   }
 
-  double getHiddenVal(const RooArgSet* nset=0) const {
+  double getHiddenVal(const RooArgSet* nset=nullptr) const {
     // Bypass accessor to function value that also works in hidden mode
     return RooAbsReal::getVal(nset) ;
   }
@@ -55,7 +55,7 @@ protected:
   // This is dubious from a C++ point of view, but it blocks the interactive user
   // from accidentally calling getVal() without explicit cast, which is the whole
   // point of this class
-  double getValV(const RooArgSet* nset=0) const override {
+  double getValV(const RooArgSet* nset=nullptr) const override {
     // Forward call to RooAbsReal
     return RooAbsReal::getValV(nset) ;
   }

--- a/roofit/roofitcore/inc/RooAbsIntegrator.h
+++ b/roofit/roofitcore/inc/RooAbsIntegrator.h
@@ -48,8 +48,8 @@ public:
     return true;
   }
 
-  double calculate(const double *yvec=0) ;
-  virtual double integral(const double *yvec=0)=0 ;
+  double calculate(const double *yvec=nullptr) ;
+  virtual double integral(const double *yvec=nullptr)=0 ;
 
   virtual bool canIntegrate1D() const = 0 ;
   virtual bool canIntegrate2D() const = 0 ;

--- a/roofit/roofitcore/inc/RooAbsLValue.h
+++ b/roofit/roofitcore/inc/RooAbsLValue.h
@@ -30,12 +30,12 @@ public:
   RooAbsLValue() ;
   virtual ~RooAbsLValue();
 
-  virtual void setBin(Int_t ibin, const char* rangeName=0) = 0 ;
-  virtual Int_t getBin(const char* rangeName=0) const = 0 ;
-  virtual Int_t numBins(const char* rangeName=0) const = 0 ;
-  virtual double getBinWidth(Int_t i, const char* rangeName=0) const = 0 ;
+  virtual void setBin(Int_t ibin, const char* rangeName=nullptr) = 0 ;
+  virtual Int_t getBin(const char* rangeName=nullptr) const = 0 ;
+  virtual Int_t numBins(const char* rangeName=nullptr) const = 0 ;
+  virtual double getBinWidth(Int_t i, const char* rangeName=nullptr) const = 0 ;
   virtual double volume(const char* rangeName) const = 0 ;
-  virtual void randomize(const char* rangeName=0) = 0 ;
+  virtual void randomize(const char* rangeName=nullptr) = 0 ;
 
   virtual const RooAbsBinning* getBinningPtr(const char* rangeName) const = 0 ;
   virtual std::list<std::string> getBinningNames() const = 0;

--- a/roofit/roofitcore/inc/RooAbsMCStudyModule.h
+++ b/roofit/roofitcore/inc/RooAbsMCStudyModule.h
@@ -77,7 +77,7 @@ protected:
    // which are only functional after module has been attached to a RooMCStudy object
 
    /// Refit model using orignal or specified data sample
-   RooFitResult* refit(RooAbsData* inGenSample=0) {
+   RooFitResult* refit(RooAbsData* inGenSample=nullptr) {
      if (_mcs) return _mcs->refit(inGenSample) ; else return 0 ;
    }
 

--- a/roofit/roofitcore/inc/RooAbsNumGenerator.h
+++ b/roofit/roofitcore/inc/RooAbsNumGenerator.h
@@ -30,9 +30,9 @@ class RooNumGenConfig ;
 class RooAbsNumGenerator : public TNamed, public RooPrintable {
 public:
   RooAbsNumGenerator() : _cloneSet(0), _funcClone(0), _funcMaxVal(0), _verbose(false), _isValid(false), _funcValStore(0), _funcValPtr(0), _cache(0) {} ;
-  RooAbsNumGenerator(const RooAbsReal &func, const RooArgSet &genVars, bool verbose=false, const RooAbsReal* maxFuncVal=0);
+  RooAbsNumGenerator(const RooAbsReal &func, const RooArgSet &genVars, bool verbose=false, const RooAbsReal* maxFuncVal=nullptr);
   virtual RooAbsNumGenerator* clone(const RooAbsReal&, const RooArgSet& genVars, const RooArgSet& condVars,
-                const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=0) const = 0 ;
+                const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=nullptr) const = 0 ;
 
   bool isValid() const {
     // If true, generator is in a valid state

--- a/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsOptTestStatistic.h
@@ -33,7 +33,7 @@ public:
   RooAbsOptTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                          const RooArgSet& projDeps,
                          RooAbsTestStatistic::Configuration const& cfg);
-  RooAbsOptTestStatistic(const RooAbsOptTestStatistic& other, const char* name=0);
+  RooAbsOptTestStatistic(const RooAbsOptTestStatistic& other, const char* name=nullptr);
   ~RooAbsOptTestStatistic() override;
 
   double combinedValue(RooAbsReal** gofArray, Int_t nVal) const override ;

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -45,9 +45,9 @@ public:
 
   // Constructors, assignment etc
   RooAbsPdf() ;
-  RooAbsPdf(const char *name, const char *title=0) ;
+  RooAbsPdf(const char *name, const char *title=nullptr) ;
   RooAbsPdf(const char *name, const char *title, double minVal, double maxVal) ;
-  // RooAbsPdf(const RooAbsPdf& other, const char* name=0);
+  // RooAbsPdf(const RooAbsPdf& other, const char* name=nullptr);
   ~RooAbsPdf() override;
 
   // Toy MC generation
@@ -226,8 +226,8 @@ public:
   RooAbsReal* createScanCdf(const RooArgSet& iset, const RooArgSet& nset, Int_t numScanBins, Int_t intOrder) ;
 
   // Function evaluation support
-  double getValV(const RooArgSet* set=0) const override ;
-  virtual double getLogVal(const RooArgSet* set=0) const ;
+  double getValV(const RooArgSet* set=nullptr) const override ;
+  virtual double getLogVal(const RooArgSet* set=nullptr) const ;
 
   RooSpan<const double> getValues(RooBatchCompute::RunContext& evalData, const RooArgSet* normSet) const override;
   using RooAbsReal::getValues;
@@ -240,12 +240,12 @@ public:
   double getNorm(const RooArgSet& nset) const {
     return getNorm(&nset) ;
   }
-  virtual double getNorm(const RooArgSet* set=0) const ;
+  virtual double getNorm(const RooArgSet* set=nullptr) const ;
 
   virtual void resetErrorCounters(Int_t resetValue=10) ;
   void setTraceCounter(Int_t value, bool allNodes=false) ;
 
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   /// Shows if a PDF is self-normalized, which means that no attempt is made to add a normalization term.
   /// Always returns false, unless a PDF overrides this function.
@@ -297,14 +297,14 @@ public:
 
   const RooAbsReal* getNormIntegral(const RooArgSet& nset) const { return getNormObj(0,&nset,0) ; }
 
-  virtual const RooAbsReal* getNormObj(const RooArgSet* set, const RooArgSet* iset, const TNamed* rangeName=0) const ;
+  virtual const RooAbsReal* getNormObj(const RooArgSet* set, const RooArgSet* iset, const TNamed* rangeName=nullptr) const ;
 
   virtual RooAbsGenContext* binnedGenContext(const RooArgSet &vars, bool verbose= false) const ;
 
-  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                  const RooArgSet* auxProto=0, bool verbose= false) const ;
+  virtual RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                  const RooArgSet* auxProto=nullptr, bool verbose= false) const ;
 
-  virtual RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0,
+  virtual RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=nullptr, const RooArgSet* auxProto=nullptr,
                   bool verbose=false, bool autoBinned=true, const char* binnedTag="") const ;
 
 private:
@@ -316,7 +316,7 @@ private:
   // Implementation version
   virtual RooPlot* paramOn(RooPlot* frame, const RooArgSet& params, bool showConstants=false,
                            const char *label= "", Int_t sigDigits = 2, Option_t *options = "NELU", double xmin=0.65,
-            double xmax= 0.99,double ymax=0.95, const RooCmdArg* formatCmd=0) ;
+            double xmax= 0.99,double ymax=0.95, const RooCmdArg* formatCmd=nullptr) ;
 
   void logBatchComputationErrors(RooSpan<const double>& outputs, std::size_t begin) const;
   bool traceEvalPdf(double value) const;

--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -68,7 +68,7 @@ public:
   RooAbsReal(const char *name, const char *title, const char *unit= "") ;
   RooAbsReal(const char *name, const char *title, double minVal, double maxVal,
         const char *unit= "") ;
-  RooAbsReal(const RooAbsReal& other, const char* name=0);
+  RooAbsReal(const RooAbsReal& other, const char* name=nullptr);
   RooAbsReal& operator=(const RooAbsReal& other);
   ~RooAbsReal() override;
 
@@ -156,16 +156,16 @@ public:
   TString getTitle(bool appendUnit= false) const;
 
   // Lightweight interface adaptors (caller takes ownership)
-  RooAbsFunc *bindVars(const RooArgSet &vars, const RooArgSet* nset=0, bool clipInvalid=false) const;
+  RooAbsFunc *bindVars(const RooArgSet &vars, const RooArgSet* nset=nullptr, bool clipInvalid=false) const;
 
   // Create a fundamental-type object that can hold our value.
-  RooAbsArg *createFundamental(const char* newname=0) const override;
+  RooAbsArg *createFundamental(const char* newname=nullptr) const override;
 
   // Analytical integration support
-  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const ;
-  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const ;
-  virtual double analyticalIntegral(Int_t code, const char* rangeName=0) const ;
+  virtual Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const ;
+  virtual double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const ;
+  virtual Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const ;
+  virtual double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const ;
   virtual bool forceAnalyticalInt(const RooAbsArg& /*dep*/) const {
     // Interface to force RooRealIntegral to offer given observable for internal integration
     // even if this is deemed unsafe. This default implementation returns always false
@@ -214,19 +214,19 @@ public:
     return createIntegral(iset,0,0,rangeName) ;
   }
   /// Create integral over observables in iset in range named rangeName with integrand normalized over observables in nset
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet& nset, const char* rangeName=0) const {
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet& nset, const char* rangeName=nullptr) const {
     return createIntegral(iset,&nset,0,rangeName) ;
   }
   /// Create integral over observables in iset in range named rangeName with integrand normalized over observables in nset while
   /// using specified configuration for any numeric integration.
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet& nset, const RooNumIntConfig& cfg, const char* rangeName=0) const {
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet& nset, const RooNumIntConfig& cfg, const char* rangeName=nullptr) const {
     return createIntegral(iset,&nset,&cfg,rangeName) ;
   }
   /// Create integral over observables in iset in range named rangeName using specified configuration for any numeric integration.
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooNumIntConfig& cfg, const char* rangeName=0) const {
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooNumIntConfig& cfg, const char* rangeName=nullptr) const {
     return createIntegral(iset,0,&cfg,rangeName) ;
   }
-  virtual RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=0, const RooNumIntConfig* cfg=0, const char* rangeName=0) const ;
+  virtual RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const ;
 
 
   void setParameterizeIntegral(const RooArgSet& paramVars) ;
@@ -265,7 +265,7 @@ public:
   void setIntegratorConfig(const RooNumIntConfig& config) ;
 
   virtual void fixAddCoefNormalization(const RooArgSet& addNormSet=RooArgSet(),bool force=true) ;
-  virtual void fixAddCoefRange(const char* rangeName=0,bool force=true) ;
+  virtual void fixAddCoefRange(const char* rangeName=nullptr,bool force=true) ;
 
   virtual void preferredObservableScanOrder(const RooArgSet& obs, RooArgSet& orderedObs) const ;
 
@@ -283,12 +283,12 @@ public:
 
   // Forwarder function for backward compatibility
   virtual RooPlot *plotSliceOn(RooPlot *frame, const RooArgSet& sliceSet, Option_t* drawOptions="L",
-                double scaleFactor=1.0, ScaleType stype=Relative, const RooAbsData* projData=0) const;
+                double scaleFactor=1.0, ScaleType stype=Relative, const RooAbsData* projData=nullptr) const;
 
   // Fill an existing histogram
   TH1 *fillHistogram(TH1 *hist, const RooArgList &plotVars,
            double scaleFactor= 1, const RooArgSet *projectedVars= 0, bool scaling=true,
-           const RooArgSet* condObs=0, bool setError=true) const;
+           const RooArgSet* condObs=nullptr, bool setError=true) const;
 
   // Create 1,2, and 3D histograms from and fill it
   TH1 *createHistogram(const char* varNameList, Int_t xbins=0, Int_t ybins=0, Int_t zbins=0) const ;
@@ -327,8 +327,8 @@ public:
   enum ErrorLoggingMode { PrintErrors, CollectErrors, CountErrors, Ignore } ;
   static ErrorLoggingMode evalErrorLoggingMode() ;
   static void setEvalErrorLoggingMode(ErrorLoggingMode m) ;
-  void logEvalError(const char* message, const char* serverValueString=0) const ;
-  static void logEvalError(const RooAbsReal* originator, const char* origName, const char* message, const char* serverValueString=0) ;
+  void logEvalError(const char* message, const char* serverValueString=nullptr) const ;
+  static void logEvalError(const RooAbsReal* originator, const char* origName, const char* message, const char* serverValueString=nullptr) ;
   static void printEvalErrors(std::ostream&os=std::cout, Int_t maxPerNode=10000000) ;
   static Int_t numEvalErrors() ;
   static Int_t numEvalErrorItems() ;
@@ -375,15 +375,15 @@ public:
 
 protected:
   // Hook for objects with normalization-dependent parameters interpretation
-  virtual void selectNormalization(const RooArgSet* depSet=0, bool force=false) ;
-  virtual void selectNormalizationRange(const char* rangeName=0, bool force=false) ;
+  virtual void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) ;
+  virtual void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) ;
 
   // Helper functions for plotting
   bool plotSanityChecks(RooPlot* frame) const ;
   void makeProjectionSet(const RooAbsArg* plotVar, const RooArgSet* allVars,
           RooArgSet& projectedVars, bool silent) const ;
 
-  TString integralNameSuffix(const RooArgSet& iset, const RooArgSet* nset=0, const char* rangeName=0, bool omitEmpty=false) const ;
+  TString integralNameSuffix(const RooArgSet& iset, const RooArgSet* nset=nullptr, const char* rangeName=nullptr, bool omitEmpty=false) const ;
 
 
   bool isSelectedComp() const ;
@@ -392,7 +392,7 @@ protected:
  public:
   const RooAbsReal* createPlotProjection(const RooArgSet& depVars, const RooArgSet& projVars, RooArgSet*& cloneSet) const ;
   const RooAbsReal *createPlotProjection(const RooArgSet &dependentVars, const RooArgSet *projectedVars,
-                     RooArgSet *&cloneSet, const char* rangeName=0, const RooArgSet* condObs=0) const;
+                     RooArgSet *&cloneSet, const char* rangeName=nullptr, const RooArgSet* condObs=nullptr) const;
   virtual void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const;
 
  protected:
@@ -467,7 +467,7 @@ protected:
  protected:
   // Hooks for RooDataSet interface
   friend class RooVectorDataStore ;
-  void syncCache(const RooArgSet* set=0) override { getVal(set) ; }
+  void syncCache(const RooArgSet* set=nullptr) override { getVal(set) ; }
   void copyCache(const RooAbsArg* source, bool valueOnly=false, bool setValDirty=true) override ;
   void attachToTree(TTree& t, Int_t bufSize=32000) override ;
   void attachToVStore(RooVectorDataStore& vstore) override ;

--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -33,7 +33,7 @@ public:
   // Constructors, assignment etc.
   inline RooAbsRealLValue() { }
   RooAbsRealLValue(const char *name, const char *title, const char *unit= "") ;
-  RooAbsRealLValue(const RooAbsRealLValue& other, const char* name=0);
+  RooAbsRealLValue(const RooAbsRealLValue& other, const char* name=nullptr);
   RooAbsRealLValue& operator=(const RooAbsRealLValue&) = default;
   ~RooAbsRealLValue() override;
 
@@ -49,12 +49,12 @@ public:
   virtual RooAbsArg& operator=(double newValue);
 
   // Implementation of RooAbsLValue
-  void setBin(Int_t ibin, const char* rangeName=0) override ;
-  Int_t getBin(const char* rangeName=0) const override { return getBinning(rangeName).binNumber(getVal()) ; }
-  Int_t numBins(const char* rangeName=0) const override { return getBins(rangeName) ; }
-  double getBinWidth(Int_t i, const char* rangeName=0) const override { return getBinning(rangeName).binWidth(i) ; }
+  void setBin(Int_t ibin, const char* rangeName=nullptr) override ;
+  Int_t getBin(const char* rangeName=nullptr) const override { return getBinning(rangeName).binNumber(getVal()) ; }
+  Int_t numBins(const char* rangeName=nullptr) const override { return getBins(rangeName) ; }
+  double getBinWidth(Int_t i, const char* rangeName=nullptr) const override { return getBinning(rangeName).binWidth(i) ; }
   double volume(const char* rangeName) const override { return getMax(rangeName)-getMin(rangeName) ; }
-  void randomize(const char* rangeName=0) override;
+  void randomize(const char* rangeName=nullptr) override;
 
   const RooAbsBinning* getBinningPtr(const char* rangeName) const override { return &getBinning(rangeName) ; }
   Int_t getBin(const RooAbsBinning* ptr) const override { return ptr->binNumber(getVal()) ; }
@@ -72,21 +72,21 @@ public:
   // Get fit range limits
 
   /// Retrive binning configuration with given name or default binning.
-  virtual const RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) const = 0 ;
+  virtual const RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) const = 0 ;
   /// Retrive binning configuration with given name or default binning.
-  virtual RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) = 0 ;
+  virtual RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) = 0 ;
   /// Check if binning with given name has been defined.
   virtual bool hasBinning(const char* name) const = 0 ;
   bool inRange(const char* name) const override ;
   /// Get number of bins of currently defined range.
   /// \param name Optionally, request number of bins for range with given name.
-  virtual Int_t getBins(const char* name=0) const { return getBinning(name).numBins(); }
+  virtual Int_t getBins(const char* name=nullptr) const { return getBinning(name).numBins(); }
   /// Get minimum of currently defined range.
   /// \param name Optionally, request minimum of range with given name.
-  virtual double getMin(const char* name=0) const { return getBinning(name).lowBound(); }
+  virtual double getMin(const char* name=nullptr) const { return getBinning(name).lowBound(); }
   /// Get maximum of currently defined range.
   /// \param name Optionally, request maximum of range with given name.
-  virtual double getMax(const char* name=0) const { return getBinning(name).highBound(); }
+  virtual double getMax(const char* name=nullptr) const { return getBinning(name).highBound(); }
   /// Get low and high bound of the variable.
   /// \param name Optional range name. If not given, the default range will be used.
   /// \return A pair with [lowerBound, upperBound]
@@ -95,9 +95,9 @@ public:
     return {binning.lowBound(), binning.highBound()};
   }
   /// Check if variable has a lower bound.
-  inline bool hasMin(const char* name=0) const { return !RooNumber::isInfinite(getMin(name)); }
+  inline bool hasMin(const char* name=nullptr) const { return !RooNumber::isInfinite(getMin(name)); }
   /// Check if variable has an upper bound.
-  inline bool hasMax(const char* name=0) const { return !RooNumber::isInfinite(getMax(name)); }
+  inline bool hasMax(const char* name=nullptr) const { return !RooNumber::isInfinite(getMax(name)); }
   /// Check if variable has a binning with given name.
   bool hasRange(const char* name) const override { return hasBinning(name) ; }
 
@@ -108,7 +108,7 @@ public:
   inline bool isLValue() const override { return true; }
 
   // Test a value against our fit range
-  bool inRange(double value, const char* rangeName, double* clippedValue=0) const;
+  bool inRange(double value, const char* rangeName, double* clippedValue=nullptr) const;
   void inRange(std::span<const double> values, std::string const& rangeName, std::vector<bool>& out) const;
   bool isValidReal(double value, bool printError=false) const override ;
 
@@ -145,13 +145,13 @@ public:
   TH1F *createHistogram(const char *name, const char *yAxisLabel, double xlo, double xhi, Int_t nBins) const ;
   TH1F *createHistogram(const char *name, const char *yAxisLabel, const RooAbsBinning& bins) const ;
 
-  TH2F *createHistogram(const char *name, const RooAbsRealLValue &yvar, const char *zAxisLabel=0,
-         double* xlo=0, double* xhi=0, Int_t* nBins=0) const ;
+  TH2F *createHistogram(const char *name, const RooAbsRealLValue &yvar, const char *zAxisLabel=nullptr,
+         double* xlo=nullptr, double* xhi=nullptr, Int_t* nBins=nullptr) const ;
   TH2F *createHistogram(const char *name, const RooAbsRealLValue &yvar, const char *zAxisLabel, const RooAbsBinning** bins) const ;
 
 
   TH3F *createHistogram(const char *name, const RooAbsRealLValue &yvar, const RooAbsRealLValue &zvar,
-         const char *tAxisLabel, double* xlo=0, double* xhi=0, Int_t* nBins=0) const ;
+         const char *tAxisLabel, double* xlo=nullptr, double* xhi=nullptr, Int_t* nBins=nullptr) const ;
   TH3F *createHistogram(const char *name, const RooAbsRealLValue &yvar, const RooAbsRealLValue &zvar, const char* tAxisLabel, const RooAbsBinning** bins) const ;
 
   static TH1* createHistogram(const char *name, RooArgList &vars, const char *tAxisLabel, double* xlo, double* xhi, Int_t* nBins) ;

--- a/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedPdf.h
@@ -23,7 +23,7 @@ public:
 
   RooAbsSelfCachedPdf() {} ;
   RooAbsSelfCachedPdf(const char *name, const char *title, Int_t ipOrder=0);
-  RooAbsSelfCachedPdf(const RooAbsSelfCachedPdf& other, const char* name=0) ;
+  RooAbsSelfCachedPdf(const RooAbsSelfCachedPdf& other, const char* name=nullptr) ;
   ~RooAbsSelfCachedPdf() override ;
 
 protected:

--- a/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
+++ b/roofit/roofitcore/inc/RooAbsSelfCachedReal.h
@@ -23,7 +23,7 @@ public:
 
   RooAbsSelfCachedReal() {} ;
   RooAbsSelfCachedReal(const char *name, const char *title, Int_t ipOrder=0);
-  RooAbsSelfCachedReal(const RooAbsSelfCachedReal& other, const char* name=0) ;
+  RooAbsSelfCachedReal(const RooAbsSelfCachedReal& other, const char* name=nullptr) ;
   ~RooAbsSelfCachedReal() override ;
 
 protected:

--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -58,7 +58,7 @@ public:
   RooAbsTestStatistic() {}
   RooAbsTestStatistic(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                       const RooArgSet& projDeps, Configuration const& cfg);
-  RooAbsTestStatistic(const RooAbsTestStatistic& other, const char* name=0);
+  RooAbsTestStatistic(const RooAbsTestStatistic& other, const char* name=nullptr);
   ~RooAbsTestStatistic() override;
   virtual RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& data,
                                       const RooArgSet& projDeps, Configuration const& cfg) = 0;

--- a/roofit/roofitcore/inc/RooAcceptReject.h
+++ b/roofit/roofitcore/inc/RooAcceptReject.h
@@ -31,9 +31,9 @@ public:
   RooAcceptReject() {
     // coverity[UNINIT_CTOR]
   } ;
-  RooAcceptReject(const RooAbsReal &func, const RooArgSet &genVars, const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=0);
+  RooAcceptReject(const RooAbsReal &func, const RooArgSet &genVars, const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=nullptr);
   RooAbsNumGenerator* clone(const RooAbsReal& func, const RooArgSet& genVars, const RooArgSet& /*condVars*/,
-             const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=0) const override {
+             const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=nullptr) const override {
     return new RooAcceptReject(func,genVars,config,verbose,maxFuncVal) ;
   }
 

--- a/roofit/roofitcore/inc/RooAdaptiveIntegratorND.h
+++ b/roofit/roofitcore/inc/RooAdaptiveIntegratorND.h
@@ -34,7 +34,7 @@ public:
   ~RooAdaptiveIntegratorND() override;
 
   bool checkLimits() const override;
-  double integral(const double *yvec=0) override ;
+  double integral(const double *yvec=nullptr) override ;
 
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double* xmin, double* xmax) override;

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -28,7 +28,7 @@ public:
 
   RooAddModel() ;
   RooAddModel(const char *name, const char *title, const RooArgList& pdfList, const RooArgList& coefList, bool ownPdfList=false) ;
-  RooAddModel(const RooAddModel& other, const char* name=0) ;
+  RooAddModel(const RooAddModel& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooAddModel(*this,newname) ; }
   RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const override ;
   ~RooAddModel() override ;
@@ -42,8 +42,8 @@ public:
     // Force RooRealIntegral to offer all observables for internal integration
     return true ;
   }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   /// Model is self normalized when used as p.d.f
   bool selfNormalized() const override {
@@ -84,11 +84,11 @@ public:
 protected:
 
   friend class RooAddGenContext ;
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, bool verbose= false) const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                       const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
 
-  void selectNormalization(const RooArgSet* depSet=0, bool force=false) override ;
-  void selectNormalizationRange(const char* rangeName=0, bool force=false) override ;
+  void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override ;
+  void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
 
   mutable RooSetProxy _refCoefNorm ;   ///<! Reference observable set for coefficient interpretation
   mutable TNamed* _refCoefRangeName ;  ///<! Reference range name for coefficient interpretation
@@ -112,7 +112,7 @@ protected:
 
   } ;
   mutable RooObjCacheManager _projCacheMgr ;  ///<! Manager of cache with coefficient projections and transformations
-  CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=0, const char* rangeName=0) const ;
+  CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
   void updateCoefficients(CacheElem& cache, const RooArgSet* nset) const ;
 
   typedef RooArgList* pRooArgList ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -33,13 +33,13 @@ class RooAddPdf : public RooAbsPdf {
 public:
 
   RooAddPdf() : _projCacheMgr(this,10) { TRACE_CREATE }
-  RooAddPdf(const char *name, const char *title=0);
+  RooAddPdf(const char *name, const char *title=nullptr);
   RooAddPdf(const char *name, const char *title,
             RooAbsPdf& pdf1, RooAbsPdf& pdf2, RooAbsReal& coef1) ;
   RooAddPdf(const char *name, const char *title, const RooArgList& pdfList) ;
   RooAddPdf(const char *name, const char *title, const RooArgList& pdfList, const RooArgList& coefList, bool recursiveFraction=false) ;
 
-  RooAddPdf(const RooAddPdf& other, const char* name=0) ;
+  RooAddPdf(const RooAddPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooAddPdf(*this,newname) ; }
   ~RooAddPdf() override { TRACE_DESTROY }
 
@@ -49,8 +49,8 @@ public:
   bool forceAnalyticalInt(const RooAbsArg& /*dep*/) const override {
     return true ;
   }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override;
   bool selfNormalized() const override {
     // P.d.f is self normalized
     return true ;
@@ -92,8 +92,8 @@ public:
 
 protected:
 
-  void selectNormalization(const RooArgSet* depSet=0, bool force=false) override;
-  void selectNormalizationRange(const char* rangeName=0, bool force=false) override;
+  void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override;
+  void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override;
 
   mutable RooSetProxy _refCoefNorm ;   ///< Reference observable set for coefficient interpretation
   mutable TNamed* _refCoefRangeName = nullptr ;  ///< Reference range name for coefficient interpreation
@@ -118,13 +118,13 @@ protected:
 
   } ;
   mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations
-  CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=0, const char* rangeName=0) const ;
+  CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
   void updateCoefficients(CacheElem& cache, const RooArgSet* nset) const ;
 
 
   friend class RooAddGenContext ;
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                               const RooArgSet* auxProto=0, bool verbose= false) const override;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                               const RooArgSet* auxProto=nullptr, bool verbose= false) const override;
 
 
   double evaluate() const override {

--- a/roofit/roofitcore/inc/RooAddition.h
+++ b/roofit/roofitcore/inc/RooAddition.h
@@ -45,8 +45,8 @@ public:
       // Force RooRealIntegral to offer all observables for internal integration
       return true ;
   }
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& numVars, const char* rangeName=0) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& numVars, const char* rangeName=nullptr) const override;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   bool setData(RooAbsData& data, bool cloneData=true) override ;
 

--- a/roofit/roofitcore/inc/RooArgSet.h
+++ b/roofit/roofitcore/inc/RooArgSet.h
@@ -161,9 +161,9 @@ public:
     return readFromStream(is, compact, 0, 0, verbose) ;
   }
   bool readFromStream(std::istream& is, bool compact, const char* flagReadAtt, const char* section, bool verbose=false) ;
-  virtual void writeToStream(std::ostream& os, bool compact, const char* section=0) const;
+  virtual void writeToStream(std::ostream& os, bool compact, const char* section=nullptr) const;
   void writeToFile(const char* fileName) const ;
-  bool readFromFile(const char* fileName, const char* flagReadAtt=0, const char* section=0, bool verbose=false) ;
+  bool readFromFile(const char* fileName, const char* flagReadAtt=nullptr, const char* section=nullptr, bool verbose=false) ;
 
 
   /// Check if this exact instance is in this collection.

--- a/roofit/roofitcore/inc/RooBinIntegrator.h
+++ b/roofit/roofitcore/inc/RooBinIntegrator.h
@@ -38,7 +38,7 @@ public:
   ~RooBinIntegrator() override;
 
   bool checkLimits() const override;
-  double integral(const double *yvec=0) override ;
+  double integral(const double *yvec=nullptr) override ;
 
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double* xmin, double* xmax) override;

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -44,12 +44,12 @@ public:
   }
   /// Forwards to the PDF's implementation.
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,
-      const char* rangeName=0) const override {
+      const char* rangeName=nullptr) const override {
     return _pdf->getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName);
   }
   /// Forwards to the PDF's implementation.
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& numVars,
-      const char* rangeName=0) const override {
+      const char* rangeName=nullptr) const override {
     return _pdf->getAnalyticalIntegral(allVars, numVars, rangeName);
   }
   /// Forwards to the PDF's implementation.
@@ -57,7 +57,7 @@ public:
     return _pdf->analyticalIntegralWN(code, normSet, rangeName);
   }
   /// Forwards to the PDF's implementation.
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override {
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override {
     return _pdf->analyticalIntegral(code, rangeName);
   }
 

--- a/roofit/roofitcore/inc/RooBinnedGenContext.h
+++ b/roofit/roofitcore/inc/RooBinnedGenContext.h
@@ -26,10 +26,10 @@ class RooDataHist;
 class RooBinnedGenContext : public RooAbsGenContext {
 public:
   RooBinnedGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-                   const RooArgSet* auxProto=0, bool _verbose= false);
+                   const RooArgSet* auxProto=nullptr, bool _verbose= false);
   ~RooBinnedGenContext() override;
 
-  RooDataSet* generate(double nEvents=0, bool skipInit=false, bool extendedMode=false) override ;
+  RooDataSet* generate(double nEvents=0.0, bool skipInit=false, bool extendedMode=false) override ;
 
   void setProtoDataOrder(Int_t*) override  {}
 

--- a/roofit/roofitcore/inc/RooBinningCategory.h
+++ b/roofit/roofitcore/inc/RooBinningCategory.h
@@ -25,8 +25,8 @@ class RooBinningCategory : public RooAbsCategory {
 public:
   // Constructors etc.
   inline RooBinningCategory() { }
-  RooBinningCategory(const char *name, const char *title, RooAbsRealLValue& inputVar, const char* binningName=0, const char* catTypeName=0);
-  RooBinningCategory(const RooBinningCategory& other, const char *name=0) ;
+  RooBinningCategory(const char *name, const char *title, RooAbsRealLValue& inputVar, const char* binningName=nullptr, const char* catTypeName=nullptr);
+  RooBinningCategory(const RooBinningCategory& other, const char *name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooBinningCategory(*this, newname); }
   ~RooBinningCategory() override;
 
@@ -35,7 +35,7 @@ public:
 
 protected:
 
-  void initialize(const char* catTypeName=0) ;
+  void initialize(const char* catTypeName=nullptr) ;
 
   RooTemplateProxy<RooAbsRealLValue> _inputVar; ///< Input variable that is mapped
   TString _bname ;         ///< Name of the binning specification to be used to perform the mapping

--- a/roofit/roofitcore/inc/RooCacheManager.h
+++ b/roofit/roofitcore/inc/RooCacheManager.h
@@ -37,16 +37,16 @@ public:
 
   RooCacheManager(Int_t maxSize=2) ;
   RooCacheManager(RooAbsArg* owner, Int_t maxSize=2) ;
-  RooCacheManager(const RooCacheManager& other, RooAbsArg* owner=0) ;
+  RooCacheManager(const RooCacheManager& other, RooAbsArg* owner=nullptr) ;
   ~RooCacheManager() override ;
 
   /// Getter function without integration set
-  T* getObj(const RooArgSet* nset, Int_t* sterileIndex=0, const TNamed* isetRangeName=0) {
+  T* getObj(const RooArgSet* nset, Int_t* sterileIndex=nullptr, const TNamed* isetRangeName=nullptr) {
     return getObj(nset,0,sterileIndex,isetRangeName) ;
   }
 
   /// Setter function without integration set
-  Int_t setObj(const RooArgSet* nset, T* obj, const TNamed* isetRangeName=0) {
+  Int_t setObj(const RooArgSet* nset, T* obj, const TNamed* isetRangeName=nullptr) {
     return setObj(nset,0,obj,isetRangeName) ;
   }
 
@@ -55,8 +55,8 @@ public:
     return getObj(nset,iset,sterileIdx,RooNameReg::ptr(isetRangeName)) ;
   }
 
-  T* getObj(const RooArgSet* nset, const RooArgSet* iset, Int_t* sterileIndex=0, const TNamed* isetRangeName=0) ;
-  Int_t setObj(const RooArgSet* nset, const RooArgSet* iset, T* obj, const TNamed* isetRangeName=0) ;
+  T* getObj(const RooArgSet* nset, const RooArgSet* iset, Int_t* sterileIndex=nullptr, const TNamed* isetRangeName=nullptr) ;
+  Int_t setObj(const RooArgSet* nset, const RooArgSet* iset, T* obj, const TNamed* isetRangeName=nullptr) ;
 
   void reset() ;
   virtual void sterilize() ;
@@ -146,7 +146,7 @@ RooCacheManager<T>::RooCacheManager(RooAbsArg* owner, Int_t maxSize) : RooAbsCac
 
   Int_t i ;
   for (i=0 ; i<_maxSize ; i++) {
-    _object[i]=0 ;
+    _object[i]=nullptr ;
   }
 
 }
@@ -192,7 +192,7 @@ void RooCacheManager<T>::reset()
 {
   for (int i=0 ; i<_maxSize ; i++) {
     delete _object[i] ;
-    _object[i]=0 ;
+    _object[i]=nullptr ;
     _nsetCache[i].clear() ;
   }
   _lastIndex = -1 ;
@@ -208,7 +208,7 @@ void RooCacheManager<T>::sterilize()
   Int_t i ;
   for (i=0 ; i<_maxSize ; i++) {
     delete _object[i] ;
-    _object[i]=0 ;
+    _object[i]=nullptr ;
   }
 }
 
@@ -278,7 +278,7 @@ T* RooCacheManager<T>::getObj(const RooArgSet* nset, const RooArgSet* iset, Int_
 {
   // Fast-track for wired mode
   if (_wired) {
-    if(_object[0]==0 && sterileIdx) *sterileIdx=0 ;
+    if(_object[0]==nullptr && sterileIdx) *sterileIdx=0 ;
     return _object[0] ;
   }
 
@@ -286,7 +286,7 @@ T* RooCacheManager<T>::getObj(const RooArgSet* nset, const RooArgSet* iset, Int_
   for (i=0 ; i<_size ; i++) {
     if (_nsetCache[i].contains(nset,iset,isetRangeName)==true) {
       _lastIndex = i ;
-      if(_object[i]==0 && sterileIdx) *sterileIdx=i ;
+      if(_object[i]==nullptr && sterileIdx) *sterileIdx=i ;
       return _object[i] ;
     }
   }
@@ -294,7 +294,7 @@ T* RooCacheManager<T>::getObj(const RooArgSet* nset, const RooArgSet* iset, Int_
   for (i=0 ; i<_size ; i++) {
     if (_nsetCache[i].autoCache(_owner,nset,iset,isetRangeName,false)==false) {
       _lastIndex = i ;
-      if(_object[i]==0 && sterileIdx) *sterileIdx=i ;
+      if(_object[i]==nullptr && sterileIdx) *sterileIdx=i ;
       return _object[i] ;
     }
   }

--- a/roofit/roofitcore/inc/RooCachedPdf.h
+++ b/roofit/roofitcore/inc/RooCachedPdf.h
@@ -22,7 +22,7 @@ public:
   RooCachedPdf() {} ;
   RooCachedPdf(const char *name, const char *title, RooAbsPdf& _pdf, const RooArgSet& cacheObs);
   RooCachedPdf(const char *name, const char *title, RooAbsPdf& _pdf);
-  RooCachedPdf(const RooCachedPdf& other, const char* name=0) ;
+  RooCachedPdf(const RooCachedPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCachedPdf(*this,newname); }
   ~RooCachedPdf() override ;
 

--- a/roofit/roofitcore/inc/RooCachedReal.h
+++ b/roofit/roofitcore/inc/RooCachedReal.h
@@ -24,7 +24,7 @@ public:
   }
   RooCachedReal(const char *name, const char *title, RooAbsReal& _func, const RooArgSet& cacheObs);
   RooCachedReal(const char *name, const char *title, RooAbsReal& _func);
-  RooCachedReal(const RooCachedReal& other, const char* name=0) ;
+  RooCachedReal(const RooCachedReal& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooCachedReal(*this,newname); }
   ~RooCachedReal() override ;
 

--- a/roofit/roofitcore/inc/RooCategory.h
+++ b/roofit/roofitcore/inc/RooCategory.h
@@ -31,7 +31,7 @@ public:
   RooCategory() ;
   RooCategory(const char *name, const char *title);
   RooCategory(const char* name, const char* title, const std::map<std::string, int>& allowedStates);
-  RooCategory(const RooCategory& other, const char* name=0) ;
+  RooCategory(const RooCategory& other, const char* name=nullptr) ;
   RooCategory& operator=(const RooCategory&) = delete;
   ~RooCategory() override;
   TObject* clone(const char* newname) const override { return new RooCategory(*this,newname); }

--- a/roofit/roofitcore/inc/RooChi2Var.h
+++ b/roofit/roofitcore/inc/RooChi2Var.h
@@ -38,7 +38,7 @@ public:
 
   enum FuncMode { Function, Pdf, ExtendedPdf } ;
 
-  RooChi2Var(const RooChi2Var& other, const char* name=0);
+  RooChi2Var(const RooChi2Var& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooChi2Var(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& dhist,

--- a/roofit/roofitcore/inc/RooClassFactory.h
+++ b/roofit/roofitcore/inc/RooClassFactory.h
@@ -36,21 +36,21 @@ public:
   RooClassFactory() ;
   ~RooClassFactory() override ;
 
-  static RooAbsReal* makeFunctionInstance(const char* className, const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
-  static RooAbsReal* makeFunctionInstance(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
+  static RooAbsReal* makeFunctionInstance(const char* className, const char* name, const char* expression, const RooArgList& vars, const char* intExpression=nullptr) ;
+  static RooAbsReal* makeFunctionInstance(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=nullptr) ;
 
-  static RooAbsPdf* makePdfInstance(const char* className, const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
-  static RooAbsPdf* makePdfInstance(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
+  static RooAbsPdf* makePdfInstance(const char* className, const char* name, const char* expression, const RooArgList& vars, const char* intExpression=nullptr) ;
+  static RooAbsPdf* makePdfInstance(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=nullptr) ;
 
-  static bool makeAndCompilePdf(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=0) ;
-  static bool makeAndCompileFunction(const char* name, const char* expression, const RooArgList& args, const char* intExpression=0) ;
+  static bool makeAndCompilePdf(const char* name, const char* expression, const RooArgList& vars, const char* intExpression=nullptr) ;
+  static bool makeAndCompileFunction(const char* name, const char* expression, const RooArgList& args, const char* intExpression=nullptr) ;
 
-  static bool makePdf(const char* name, const char* realArgNames=0, const char* catArgNames=0,
-         const char* expression="1.0", bool hasAnaInt=false, bool hasIntGen=false, const char* intExpression=0) ;
-  static bool makeFunction(const char* name, const char* realArgNames=0, const char* catArgNames=0,
-              const char* expression="1.0", bool hasAnaInt=false, const char* intExpression=0) ;
-  static bool makeClass(const char* className, const char* name, const char* realArgNames=0, const char* catArgNames=0,
-           const char* expression="1.0", bool hasAnaInt=false, bool hasIntGen=false, const char* intExpression=0) ;
+  static bool makePdf(const char* name, const char* realArgNames=nullptr, const char* catArgNames=nullptr,
+         const char* expression="1.0", bool hasAnaInt=false, bool hasIntGen=false, const char* intExpression=nullptr) ;
+  static bool makeFunction(const char* name, const char* realArgNames=nullptr, const char* catArgNames=nullptr,
+              const char* expression="1.0", bool hasAnaInt=false, const char* intExpression=nullptr) ;
+  static bool makeClass(const char* className, const char* name, const char* realArgNames=nullptr, const char* catArgNames=nullptr,
+           const char* expression="1.0", bool hasAnaInt=false, bool hasIntGen=false, const char* intExpression=nullptr) ;
 
   class ClassFacIFace : public RooFactoryWSTool::IFace {
   public:

--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -35,10 +35,10 @@ public:
   /// a name and no payload doesn't make sense anyway.
   RooCmdArg(const char* name,
             Int_t i1, Int_t i2=0,
-            double d1=0, double d2=0,
-            const char* s1=0, const char* s2=0,
-            const TObject* o1=0, const TObject* o2=0, const RooCmdArg* ca=0, const char* s3=0,
-            const RooArgSet* c1=0, const RooArgSet* c2=0) ;
+            double d1=0.0, double d2=0.0,
+            const char* s1=nullptr, const char* s2=nullptr,
+            const TObject* o1=nullptr, const TObject* o2=nullptr, const RooCmdArg* ca=nullptr, const char* s3=nullptr,
+            const RooArgSet* c1=nullptr, const RooArgSet* c2=nullptr) ;
   RooCmdArg(const RooCmdArg& other) ;
   RooCmdArg& operator=(const RooCmdArg& other) ;
   void addArg(const RooCmdArg& arg) ;
@@ -54,7 +54,7 @@ public:
   /// Return list of sub-arguments in this RooCmdArg
   RooLinkedList& subArgs() { return _argList ; }
 
-  TObject* Clone(const char* newName=0) const override {
+  TObject* Clone(const char* newName=nullptr) const override {
     RooCmdArg* newarg = new RooCmdArg(*this) ;
     if (newName) { newarg->SetName(newName) ; }
     return newarg ;

--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -53,10 +53,10 @@ public:
   void defineMutex(const char*) {} // to end the recursion of defineMutex()
 
   bool defineInt(const char* name, const char* argName, Int_t intNum, Int_t defValue=0) ;
-  bool defineDouble(const char* name, const char* argName, Int_t doubleNum, double defValue=0.) ;
+  bool defineDouble(const char* name, const char* argName, Int_t doubleNum, double defValue=0.0) ;
   bool defineString(const char* name, const char* argName, Int_t stringNum, const char* defValue="",bool appendMode=false) ;
-  bool defineObject(const char* name, const char* argName, Int_t setNum, const TObject* obj=0, bool isArray=false) ;
-  bool defineSet(const char* name, const char* argName, Int_t setNum, const RooArgSet* set=0) ;
+  bool defineObject(const char* name, const char* argName, Int_t setNum, const TObject* obj=nullptr, bool isArray=false) ;
+  bool defineSet(const char* name, const char* argName, Int_t setNum, const RooArgSet* set=nullptr) ;
 
   bool process(const RooCmdArg& arg) ;
   template<class... Args_t>
@@ -66,10 +66,10 @@ public:
   bool process(It_t begin, It_t end);
 
   Int_t getInt(const char* name, Int_t defaultValue=0) ;
-  double getDouble(const char* name, double defaultValue=0) ;
+  double getDouble(const char* name, double defaultValue=0.0) ;
   const char* getString(const char* name, const char* defaultValue="",bool convEmptyToNull=false) ;
-  TObject* getObject(const char* name, TObject* obj=0) ;
-  RooArgSet* getSet(const char* name, RooArgSet* set=0) ;
+  TObject* getObject(const char* name, TObject* obj=nullptr) ;
+  RooArgSet* getSet(const char* name, RooArgSet* set=nullptr) ;
   const RooLinkedList& getObjectList(const char* name) ;
 
   bool ok(bool verbose) const ;

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -39,15 +39,15 @@ public:
   RooCompositeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, RooCategory& indexCat, std::map<std::string,RooAbsDataStore*> const& inputData) ;
 
   // Empty ctor
-  RooAbsDataStore* clone(const char* newname=0) const override { return new RooCompositeDataStore(*this,newname) ; }
-  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooCompositeDataStore(*this,vars,newname) ; }
+  RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooCompositeDataStore(*this,newname) ; }
+  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooCompositeDataStore(*this,vars,newname) ; }
 
   RooAbsDataStore* reduce(RooStringView name, RooStringView title,
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 
-  RooCompositeDataStore(const RooCompositeDataStore& other, const char* newname=0) ;
-  RooCompositeDataStore(const RooCompositeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
+  RooCompositeDataStore(const RooCompositeDataStore& other, const char* newname=nullptr) ;
+  RooCompositeDataStore(const RooCompositeDataStore& other, const RooArgSet& vars, const char* newname=nullptr) ;
 
   ~RooCompositeDataStore() override ;
 
@@ -90,7 +90,7 @@ public:
   void resetBuffers() override ;
 
   // Constant term  optimizer interface
-  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, bool skipZeroWeights=false) override ;
+  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=nullptr, bool skipZeroWeights=false) override ;
   const RooAbsArg* cacheOwner() override { return 0 ; }
   void setArgStatus(const RooArgSet& set, bool active) override ;
   void resetCache() override ;
@@ -98,7 +98,7 @@ public:
   void recalculateCache(const RooArgSet* /*proj*/, Int_t /*firstEvent*/, Int_t /*lastEvent*/, Int_t /*stepSize*/, bool /*skipZeroWeights*/) override ;
   bool hasFilledCache() const override ;
 
-  void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=0, const char* rangeName=0,
+  void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=nullptr, const char* rangeName=nullptr,
       std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
 
   void forceCacheUpdate() override ;

--- a/roofit/roofitcore/inc/RooConstVar.h
+++ b/roofit/roofitcore/inc/RooConstVar.h
@@ -28,7 +28,7 @@ public:
   // Constructors, assignment etc
   RooConstVar() { }
   RooConstVar(const char *name, const char *title, double value);
-  RooConstVar(const RooConstVar& other, const char* name=0);
+  RooConstVar(const RooConstVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooConstVar(*this,newname); }
   ~RooConstVar() override = default;
 

--- a/roofit/roofitcore/inc/RooConvCoefVar.h
+++ b/roofit/roofitcore/inc/RooConvCoefVar.h
@@ -31,18 +31,18 @@ public:
   /// Default constructor
   inline RooConvCoefVar() {
   }
-  RooConvCoefVar(const char *name, const char *title, const RooAbsAnaConvPdf& input, Int_t coefIdx, const RooArgSet* varList=0) ;
-  RooConvCoefVar(const RooConvCoefVar& other, const char* name=0);
+  RooConvCoefVar(const char *name, const char *title, const RooAbsAnaConvPdf& input, Int_t coefIdx, const RooArgSet* varList=nullptr) ;
+  RooConvCoefVar(const RooConvCoefVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooConvCoefVar(*this,newname); }
   /// Destructor
   ~RooConvCoefVar() override {
   } ;
 
-  double getValV(const RooArgSet* nset=0) const override ;
+  double getValV(const RooArgSet* nset=nullptr) const override ;
 
   double evaluate() const override ;
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofitcore/inc/RooConvGenContext.h
+++ b/roofit/roofitcore/inc/RooConvGenContext.h
@@ -31,11 +31,11 @@ class RooFFTConvPdf ;
 class RooConvGenContext : public RooAbsGenContext {
 public:
   RooConvGenContext(const RooFFTConvPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-          const RooArgSet* auxProto=0, bool _verbose= false);
+          const RooArgSet* auxProto=nullptr, bool _verbose= false);
   RooConvGenContext(const RooNumConvPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-          const RooArgSet* auxProto=0, bool _verbose= false);
+          const RooArgSet* auxProto=nullptr, bool _verbose= false);
   RooConvGenContext(const RooAbsAnaConvPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-          const RooArgSet* auxProto=0, bool _verbose= false);
+          const RooArgSet* auxProto=nullptr, bool _verbose= false);
 
   void setProtoDataOrder(Int_t* lut) override ;
 

--- a/roofit/roofitcore/inc/RooConvIntegrandBinding.h
+++ b/roofit/roofitcore/inc/RooConvIntegrandBinding.h
@@ -26,7 +26,7 @@ class RooConvIntegrandBinding : public RooAbsFunc {
 public:
   RooConvIntegrandBinding(const RooAbsReal& func, const RooAbsReal& model,
                 RooAbsReal& x, RooAbsReal& xprime,
-                     const RooArgSet* nset=0, bool clipInvalid=false);
+                     const RooArgSet* nset=nullptr, bool clipInvalid=false);
   ~RooConvIntegrandBinding() override;
 
   double operator()(const double xvector[]) const override;

--- a/roofit/roofitcore/inc/RooCurve.h
+++ b/roofit/roofitcore/inc/RooCurve.h
@@ -35,11 +35,11 @@ public:
   enum WingMode { NoWings=0 ,Straight=1, Extended=2 } ;
   RooCurve(const RooAbsReal &func, RooAbsRealLValue &x, double xlo, double xhi, Int_t xbins,
       double scaleFactor= 1, const RooArgSet *normVars= 0, double prec= 1e-3, double resolution= 1e-3,
-      bool shiftToZero=false, WingMode wmode=Extended, Int_t nEvalError=-1, Int_t doEEVal=false, double eeVal=0,
+      bool shiftToZero=false, WingMode wmode=Extended, Int_t nEvalError=-1, Int_t doEEVal=false, double eeVal=0.0,
       bool showProgress=false);
   RooCurve(const char *name, const char *title, const RooAbsFunc &func, double xlo,
       double xhi, UInt_t minPoints, double prec= 1e-3, double resolution= 1e-3,
-      bool shiftToZero=false, WingMode wmode=Extended, Int_t nEvalError=-1, Int_t doEEVal=false, double eeVal=0);
+      bool shiftToZero=false, WingMode wmode=Extended, Int_t nEvalError=-1, Int_t doEEVal=false, double eeVal=0.0);
   ~RooCurve() override;
 
   RooCurve(const char* name, const char* title, const RooCurve& c1, const RooCurve& c2, double scale1=1., double scale2=1.) ;
@@ -80,10 +80,10 @@ protected:
   void initialize();
   void addPoints(const RooAbsFunc &func, double xlo, double xhi,
        Int_t minPoints, double prec, double resolution, WingMode wmode,
-       Int_t numee=0, bool doEEVal=false, double eeVal=0.,std::list<double>* samplingHint=0) ;
+       Int_t numee=0, bool doEEVal=false, double eeVal=0.0,std::list<double>* samplingHint=nullptr) ;
   void addRange(const RooAbsFunc& func, double x1, double x2, double y1,
       double y2, double minDy, double minDx,
-      Int_t numee=0, bool doEEVal=false, double eeVal=0.)  ;
+      Int_t numee=0, bool doEEVal=false, double eeVal=0.0);
 
 
   void shiftCurveToZero(double prevYMax) ;

--- a/roofit/roofitcore/inc/RooCustomizer.h
+++ b/roofit/roofitcore/inc/RooCustomizer.h
@@ -37,7 +37,7 @@ class RooCustomizer : public TNamed, public RooPrintable {
 public:
 
   // Constructors, assignment etc
-  RooCustomizer(const RooAbsArg& pdf, const RooAbsCategoryLValue& masterCat, RooArgSet& splitLeafListOwned, RooArgSet* splitLeafListAll=0) ;
+  RooCustomizer(const RooAbsArg& pdf, const RooAbsCategoryLValue& masterCat, RooArgSet& splitLeafListOwned, RooArgSet* splitLeafListAll=nullptr) ;
   RooCustomizer(const RooAbsArg& pdf, const char* name) ;
   ~RooCustomizer() override ;
 

--- a/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
+++ b/roofit/roofitcore/inc/RooDLLSignificanceMCSModule.h
@@ -23,8 +23,8 @@
 class RooDLLSignificanceMCSModule : public RooAbsMCStudyModule {
 public:
 
-  RooDLLSignificanceMCSModule(const RooRealVar& param, double nullHypoValue=0) ;
-  RooDLLSignificanceMCSModule(const char* parName, double nullHypoValue=0) ;
+  RooDLLSignificanceMCSModule(const RooRealVar& param, double nullHypoValue=0.0) ;
+  RooDLLSignificanceMCSModule(const char* parName, double nullHypoValue=0.0) ;
   RooDLLSignificanceMCSModule(const RooDLLSignificanceMCSModule& other) ;
   ~RooDLLSignificanceMCSModule() override ;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -47,7 +47,7 @@ public:
 
   // Constructors, factory methods etc.
   RooDataHist() ;
-  RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const char* binningName=0) ;
+  RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const char* binningName=nullptr) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsData& data, double initWgt=1.0) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, const TH1* hist, double initWgt=1.0) ;
   RooDataHist(RooStringView name, RooStringView title, const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> histMap, double initWgt=1.0) ;
@@ -64,7 +64,7 @@ public:
   ~RooDataHist() override ;
 
   /// Return empty clone of this RooDataHist.
-  RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet*vars=0, const char* /*wgtVarName*/=0) const override {
+  RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet*vars=nullptr, const char* /*wgtVarName*/=nullptr) const override {
     return new RooDataHist(newName?newName:GetName(),newTitle?newTitle:GetTitle(),vars?*vars:*get()) ;
   }
 
@@ -75,7 +75,7 @@ public:
   void set(const RooArgSet& row, double weight, double wgtErr=-1.) ;
   void set(const RooArgSet& row, double weight, double wgtErrLo, double wgtErrHi) ;
 
-  void add(const RooAbsData& dset, const RooFormulaVar* cutVar=0, double weight=1.0 ) ;
+  void add(const RooAbsData& dset, const RooFormulaVar* cutVar=nullptr, double weight=1.0 ) ;
   void add(const RooAbsData& dset, const char* cut, double weight=1.0 ) ;
 
   /// Get bin centre of current bin.
@@ -84,7 +84,7 @@ public:
   virtual const RooArgSet* get(const RooArgSet& coord) const;
   Int_t numEntries() const override;
   double sumEntries() const override;
-  double sumEntries(const char* cutSpec, const char* cutRange=0) const override;
+  double sumEntries(const char* cutSpec, const char* cutRange=nullptr) const override;
 
   /// Always returns true as all histograms use event weights.
   bool isWeighted() const override { return true; }
@@ -231,16 +231,16 @@ protected:
 
   void setAllWeights(double value) ;
 
-  void initialize(const char* binningName=0,bool fillTree=true) ;
+  void initialize(const char* binningName=nullptr,bool fillTree=true) ;
   RooDataHist(RooStringView name, RooStringView title, RooDataHist* h, const RooArgSet& varSubset,
         const RooFormulaVar* cutVar, const char* cutRange, Int_t nStart, Int_t nStop) ;
-  RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
+  RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
                   std::size_t nStart=0, std::size_t nStop=std::numeric_limits<std::size_t>::max()) override;
   double interpolateDim(int iDim, double xval, size_t centralIdx, int intOrder, bool correctForBinSize, bool cdfBoundaries) ;
   const std::vector<double>& calculatePartialBinVolume(const RooArgSet& dimSet) const ;
   void checkBinBounds() const;
 
-  void adjustBinning(const RooArgList& vars, const TH1& href, Int_t* offset=0) ;
+  void adjustBinning(const RooArgList& vars, const TH1& href, Int_t* offset=nullptr) ;
   void importTH1(const RooArgList& vars, const TH1& histo, double initWgt, bool doDensityCorrection) ;
   void importTH1Set(const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> hmap, double initWgt, bool doDensityCorrection) ;
   void importDHistSet(const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dmap, double initWgt) ;

--- a/roofit/roofitcore/inc/RooDataProjBinding.h
+++ b/roofit/roofitcore/inc/RooDataProjBinding.h
@@ -24,7 +24,7 @@ class Roo1DTable ;
 
 class RooDataProjBinding : public RooRealBinding {
 public:
-  RooDataProjBinding(const RooAbsReal &real, const RooAbsData& data, const RooArgSet &vars, const RooArgSet* normSet=0) ;
+  RooDataProjBinding(const RooAbsReal &real, const RooAbsData& data, const RooArgSet &vars, const RooArgSet* normSet=nullptr) ;
   ~RooDataProjBinding() override ;
 
   double operator()(const double xvector[]) const override;

--- a/roofit/roofitcore/inc/RooDataSet.h
+++ b/roofit/roofitcore/inc/RooDataSet.h
@@ -65,7 +65,7 @@ public:
   RooDataSet() ;
 
   // Empty constructor
-  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
 
   // Universal constructor
   RooDataSet(RooStringView name, RooStringView title, const RooArgSet& vars, const RooCmdArg& arg1, const RooCmdArg& arg2=RooCmdArg(),
@@ -74,29 +74,29 @@ public:
 
     // Constructor for subset of existing dataset
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
-             const char *cuts=0, const char* wgtVarName=0);
+             const char *cuts=nullptr, const char* wgtVarName=nullptr);
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *data, const RooArgSet& vars,
-             const RooFormulaVar& cutVar, const char* wgtVarName=0) ;
+             const RooFormulaVar& cutVar, const char* wgtVarName=nullptr) ;
 
 
   // Constructor importing data from external ROOT Tree
   RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
-             const char *cuts=0, const char* wgtVarName=0);
+             const char *cuts=nullptr, const char* wgtVarName=nullptr);
   RooDataSet(RooStringView name, RooStringView title, TTree *tree, const RooArgSet& vars,
-             const RooFormulaVar& cutVar, const char* wgtVarName=0) ;
+             const RooFormulaVar& cutVar, const char* wgtVarName=nullptr) ;
 
-  RooDataSet(RooDataSet const & other, const char* newname=0) ;
+  RooDataSet(RooDataSet const & other, const char* newname=nullptr) ;
   TObject* Clone(const char* newname = "") const override {
     return new RooDataSet(*this, newname && newname[0] != '\0' ? newname : GetName());
   }
   ~RooDataSet() override ;
 
-  RooAbsData* emptyClone(const char* newName=0, const char* newTitle=0, const RooArgSet* vars=0, const char* wgtVarName=0) const override;
+  RooAbsData* emptyClone(const char* newName=nullptr, const char* newTitle=nullptr, const RooArgSet* vars=nullptr, const char* wgtVarName=nullptr) const override;
 
-  RooDataHist* binnedClone(const char* newName=0, const char* newTitle=0) const ;
+  RooDataHist* binnedClone(const char* newName=nullptr, const char* newTitle=nullptr) const ;
 
   double sumEntries() const override;
-  double sumEntries(const char* cutSpec, const char* cutRange=0) const override;
+  double sumEntries(const char* cutSpec, const char* cutRange=nullptr) const override;
 
   virtual RooPlot* plotOnXY(RooPlot* frame,
              const RooCmdArg& arg1=RooCmdArg::none(), const RooCmdArg& arg2=RooCmdArg::none(),
@@ -109,7 +109,7 @@ public:
   /// The possible options are: (D)ebug, (Q)uiet.
   static RooDataSet *read(const char *filename, const RooArgList &variables,
            const char *opts= "", const char* commonPath="",
-           const char *indexCatName=0) ;
+           const char *indexCatName=nullptr) ;
   bool write(const char* filename) const;
   bool write(std::ostream & ofs) const;
 
@@ -130,14 +130,14 @@ public:
   RooSpan<const double> getWeightBatch(std::size_t first, std::size_t len, bool sumW2) const override;
 
   /// Add one ore more rows of data
-  void add(const RooArgSet& row, double weight=1.0, double weightError=0) override;
+  void add(const RooArgSet& row, double weight=1.0, double weightError=0.0) override;
   virtual void add(const RooArgSet& row, double weight, double weightErrorLo, double weightErrorHi);
 
-  virtual void addFast(const RooArgSet& row, double weight=1.0, double weightError=0);
+  virtual void addFast(const RooArgSet& row, double weight=1.0, double weightError=0.0);
 
   void append(RooDataSet& data) ;
-  bool merge(RooDataSet* data1, RooDataSet* data2=0, RooDataSet* data3=0,
-           RooDataSet* data4=0, RooDataSet* data5=0, RooDataSet* data6=0) ;
+  bool merge(RooDataSet* data1, RooDataSet* data2=nullptr, RooDataSet* data3=nullptr,
+           RooDataSet* data4=nullptr, RooDataSet* data5=nullptr, RooDataSet* data6=nullptr) ;
   bool merge(std::list<RooDataSet*> dsetList) ;
 
   virtual RooAbsArg* addColumn(RooAbsArg& var, bool adjustRange=true) ;
@@ -161,7 +161,7 @@ protected:
   void initialize(const char* wgtVarName) ;
 
   // Cache copy feature is not publicly accessible
-  RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=0,
+  RooAbsData* reduceEng(const RooArgSet& varSubset, const RooFormulaVar* cutVar, const char* cutRange=nullptr,
                         std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
   RooDataSet(RooStringView name, RooStringView title, RooDataSet *ntuple,
              const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,

--- a/roofit/roofitcore/inc/RooDataWeightedAverage.h
+++ b/roofit/roofitcore/inc/RooDataWeightedAverage.h
@@ -30,7 +30,7 @@ public:
   RooDataWeightedAverage(const char *name, const char *title, RooAbsReal& real, RooAbsData& data, const RooArgSet& projDeps,
                          RooAbsTestStatistic::Configuration const& cfg, bool showProgress=false) ;
 
-  RooDataWeightedAverage(const RooDataWeightedAverage& other, const char* name=0);
+  RooDataWeightedAverage(const RooDataWeightedAverage& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooDataWeightedAverage(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& real, RooAbsData& adata,

--- a/roofit/roofitcore/inc/RooEffGenContext.h
+++ b/roofit/roofitcore/inc/RooEffGenContext.h
@@ -25,7 +25,7 @@ public:
   RooEffGenContext(const RooAbsPdf &model,
                    const RooAbsPdf &pdf,const RooAbsReal& eff,
                    const RooArgSet &vars, const RooDataSet *prototype= 0,
-                   const RooArgSet* auxProto=0, bool verbose=false, const RooArgSet* forceDirect=0);
+                   const RooArgSet* auxProto=nullptr, bool verbose=false, const RooArgSet* forceDirect=nullptr);
   ~RooEffGenContext() override;
 
 protected:

--- a/roofit/roofitcore/inc/RooEffProd.h
+++ b/roofit/roofitcore/inc/RooEffProd.h
@@ -21,7 +21,7 @@ class RooEffProd: public RooAbsPdf {
 public:
   // Constructors, assignment etc
   RooEffProd(const char *name, const char *title, RooAbsPdf& pdf, RooAbsReal& efficiency);
-  RooEffProd(const RooEffProd& other, const char* name=0);
+  RooEffProd(const RooEffProd& other, const char* name=nullptr);
 
   TObject* clone(const char* newname) const override { return new RooEffProd(*this,newname); }
 

--- a/roofit/roofitcore/inc/RooEfficiency.h
+++ b/roofit/roofitcore/inc/RooEfficiency.h
@@ -31,12 +31,12 @@ public:
   inline RooEfficiency() {
   }
   RooEfficiency(const char *name, const char *title, const RooAbsReal& effFunc, const RooAbsCategory& cat, const char* sigCatName);
-  RooEfficiency(const RooEfficiency& other, const char* name=0);
+  RooEfficiency(const RooEfficiency& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooEfficiency(*this,newname); }
   ~RooEfficiency() override;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofitcore/inc/RooErrorVar.h
+++ b/roofit/roofitcore/inc/RooErrorVar.h
@@ -32,11 +32,11 @@ public:
   inline RooErrorVar() {
   }
   RooErrorVar(const char *name, const char *title, const RooRealVar& input) ;
-  RooErrorVar(const RooErrorVar& other, const char* name=0);
+  RooErrorVar(const RooErrorVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooErrorVar(*this,newname); }
   ~RooErrorVar() override ;
 
-  double getValV(const RooArgSet* set=0) const override ;
+  double getValV(const RooArgSet* set=nullptr) const override ;
 
   double evaluate() const override {
     // return error of input RooRealVar
@@ -75,16 +75,16 @@ public:
   void setRange(const char* name, double min, double max) ;
 
   void setBins(Int_t nBins);
-  void setBinning(const RooAbsBinning& binning, const char* name=0) ;
-  const RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) const override ;
-  RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) override ;
+  void setBinning(const RooAbsBinning& binning, const char* name=nullptr) ;
+  const RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) const override ;
+  RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) override ;
   bool hasBinning(const char* name) const override ;
   std::list<std::string> getBinningNames() const override ;
 
   // Set infinite fit range limits
-  void removeMin(const char* name=0);
-  void removeMax(const char* name=0);
-  void removeRange(const char* name=0);
+  void removeMin(const char* name=nullptr);
+  void removeMax(const char* name=nullptr);
+  void removeRange(const char* name=nullptr);
 
   using RooAbsRealLValue::operator= ;
   using RooAbsRealLValue::setVal ;
@@ -93,7 +93,7 @@ protected:
 
   RooLinkedList _altBinning ;  ///<! Optional alternative ranges and binnings
 
-  void syncCache(const RooArgSet* set=0) override ;
+  void syncCache(const RooArgSet* set=nullptr) override ;
 
   RooRealProxy _realVar ;   ///< RealVar with the original error
   RooAbsBinning* _binning ; ///<! Pointer to default binning definition

--- a/roofit/roofitcore/inc/RooExtendPdf.h
+++ b/roofit/roofitcore/inc/RooExtendPdf.h
@@ -24,8 +24,8 @@ public:
 
   RooExtendPdf() ;
   RooExtendPdf(const char *name, const char *title, RooAbsPdf& pdf,
-          RooAbsReal& norm, const char* rangeName=0) ;
-  RooExtendPdf(const RooExtendPdf& other, const char* name=0) ;
+          RooAbsReal& norm, const char* rangeName=nullptr) ;
+  RooExtendPdf(const RooExtendPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooExtendPdf(*this,newname) ; }
   ~RooExtendPdf() override ;
 
@@ -33,11 +33,11 @@ public:
 
   bool forceAnalyticalInt(const RooAbsArg& /*dep*/) const override { return true ; }
   /// Forward determination of analytical integration capabilities to input p.d.f
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override {
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override {
     return _pdf->getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName) ;
   }
   /// Forward calculation of analytical integrals to input p.d.f
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override {
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override {
     return _pdf->analyticalIntegralWN(code, normSet, rangeName) ;
   }
 

--- a/roofit/roofitcore/inc/RooExtendedBinding.h
+++ b/roofit/roofitcore/inc/RooExtendedBinding.h
@@ -17,7 +17,7 @@ class RooExtendedBinding : public RooAbsReal {
 public:
   RooExtendedBinding() {} ;
   RooExtendedBinding(const char *name, const char *title, RooAbsPdf& _pdf);
-  RooExtendedBinding(const RooExtendedBinding& other, const char* name=0) ;
+  RooExtendedBinding(const RooExtendedBinding& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooExtendedBinding(*this,newname); }
   inline ~RooExtendedBinding() override { }
 

--- a/roofit/roofitcore/inc/RooExtendedTerm.h
+++ b/roofit/roofitcore/inc/RooExtendedTerm.h
@@ -24,7 +24,7 @@ public:
 
   RooExtendedTerm() ;
   RooExtendedTerm(const char *name, const char *title, const RooAbsReal& n) ;
-  RooExtendedTerm(const RooExtendedTerm& other, const char* name=0) ;
+  RooExtendedTerm(const RooExtendedTerm& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooExtendedTerm(*this,newname) ; }
   ~RooExtendedTerm() override ;
 

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -30,7 +30,7 @@ public:
   } ;
   RooFFTConvPdf(const char *name, const char *title, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder=2);
   RooFFTConvPdf(const char *name, const char *title, RooAbsReal& pdfConvVar, RooRealVar& convVar, RooAbsPdf& pdf1, RooAbsPdf& pdf2, Int_t ipOrder=2);
-  RooFFTConvPdf(const RooFFTConvPdf& other, const char* name=0) ;
+  RooFFTConvPdf(const RooFFTConvPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooFFTConvPdf(*this,newname); }
   ~RooFFTConvPdf() override ;
 
@@ -112,8 +112,8 @@ protected:
   double  _shift1 ;
   double  _shift2 ;
 
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, bool verbose= false) const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                       const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
 
   friend class RooConvGenContext ;
   RooSetProxy  _cacheObs ; ///< Non-convolution observables that are also cached

--- a/roofit/roofitcore/inc/RooFactoryWSTool.h
+++ b/roofit/roofitcore/inc/RooFactoryWSTool.h
@@ -56,7 +56,7 @@ public:
 
   // Create variables
   RooRealVar* createVariable(const char* name, double xmin, double xmax) ;
-  RooCategory* createCategory(const char* name, const char* stateNameList=0) ;
+  RooCategory* createCategory(const char* name, const char* stateNameList=nullptr) ;
 
   // Create functions and p.d.f.s (any RooAbsArg)
   RooAbsArg* createArg(const char* className, const char* objName, const char* varList) ;

--- a/roofit/roofitcore/inc/RooFitLegacy/RooMinuit.h
+++ b/roofit/roofitcore/inc/RooFitLegacy/RooMinuit.h
@@ -63,10 +63,10 @@ public:
   Int_t simplex() ;
   Int_t improve() ;
 
-  RooFitResult* save(const char* name=0, const char* title=0) ;
+  RooFitResult* save(const char* name=nullptr, const char* title=nullptr) ;
   RooPlot* contour(RooRealVar& var1, RooRealVar& var2,
-         double n1=1, double n2=2, double n3=0,
-         double n4=0, double n5=0, double n6=0) ;
+         double n1=1, double n2=2, double n3=0.0,
+         double n4=0.0, double n5=0.0, double n6=0.0) ;
 
   Int_t setPrintLevel(Int_t newLevel) ;
   void setNoWarn() ;
@@ -75,7 +75,7 @@ public:
   void setVerbose(bool flag=true) { _verbose = flag ; }
   void setProfile(bool flag=true) { _profile = flag ; }
   void setMaxEvalMultiplier(Int_t n) { _maxEvalMult = n ; }
-  bool setLogFile(const char* logfile=0) ;
+  bool setLogFile(const char* logfile=nullptr) ;
 
   static void cleanup() ;
 

--- a/roofit/roofitcore/inc/RooFitResult.h
+++ b/roofit/roofitcore/inc/RooFitResult.h
@@ -41,7 +41,7 @@ class RooFitResult : public TNamed, public RooPrintable, public RooDirItem {
 public:
 
   // Constructors, assignment etc.
-  RooFitResult(const char* name=0, const char* title=0) ;
+  RooFitResult(const char* name=nullptr, const char* title=nullptr) ;
   RooFitResult(const RooFitResult& other) ;
   TObject* Clone(const char* newname = 0) const override {
     RooFitResult* r =  new RooFitResult(*this) ;

--- a/roofit/roofitcore/inc/RooFoamGenerator.h
+++ b/roofit/roofitcore/inc/RooFoamGenerator.h
@@ -31,9 +31,9 @@ class RooNumGenFactory ;
 class RooFoamGenerator : public RooAbsNumGenerator {
 public:
   RooFoamGenerator() : _binding(0), _tfoam(0), _xmin(0), _range(0), _vec(0) {} ;
-  RooFoamGenerator(const RooAbsReal &func, const RooArgSet &genVars, const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=0);
+  RooFoamGenerator(const RooAbsReal &func, const RooArgSet &genVars, const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=nullptr);
   RooAbsNumGenerator* clone(const RooAbsReal& func, const RooArgSet& genVars, const RooArgSet& /*condVars*/,
-             const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=0) const override {
+             const RooNumGenConfig& config, bool verbose=false, const RooAbsReal* maxFuncVal=nullptr) const override {
     return new RooFoamGenerator(func,genVars,config,verbose,maxFuncVal) ;
   }
   ~RooFoamGenerator() override;

--- a/roofit/roofitcore/inc/RooFormula.h
+++ b/roofit/roofitcore/inc/RooFormula.h
@@ -35,7 +35,7 @@ public:
   // Constructors etc.
   RooFormula() ;
   RooFormula(const char* name, const char* formula, const RooArgList& varList, bool checkVariables = true);
-  RooFormula(const RooFormula& other, const char* name=0);
+  RooFormula(const RooFormula& other, const char* name=nullptr);
   TObject* Clone(const char* newName = nullptr) const override {return new RooFormula(*this, newName);}
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -57,7 +57,7 @@ public:
 
   bool ok() const { return _tFormula != nullptr; }
   /// Evalute all parameters/observables, and then evaluate formula.
-  double eval(const RooArgSet* nset=0) const;
+  double eval(const RooArgSet* nset=nullptr) const;
   RooSpan<double> evaluateSpan(const RooAbsReal* dataOwner, RooBatchCompute::RunContext& inputData, const RooArgSet* nset = nullptr) const;
   void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const;
 

--- a/roofit/roofitcore/inc/RooFormulaVar.h
+++ b/roofit/roofitcore/inc/RooFormulaVar.h
@@ -33,7 +33,7 @@ public:
   RooFormulaVar() { }
   RooFormulaVar(const char *name, const char *title, const char* formula, const RooArgList& dependents, bool checkVariables = true);
   RooFormulaVar(const char *name, const char *title, const RooArgList& dependents, bool checkVariables = true);
-  RooFormulaVar(const RooFormulaVar& other, const char* name=0);
+  RooFormulaVar(const RooFormulaVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooFormulaVar(*this,newname); }
 
   inline bool ok() const { return getFormula().ok() ; }

--- a/roofit/roofitcore/inc/RooGenContext.h
+++ b/roofit/roofitcore/inc/RooGenContext.h
@@ -30,7 +30,7 @@ class RooAbsNumGenerator ;
 class RooGenContext : public RooAbsGenContext {
 public:
   RooGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-      const RooArgSet* auxProto=0, bool verbose=false, const RooArgSet* forceDirect=0);
+      const RooArgSet* auxProto=nullptr, bool verbose=false, const RooArgSet* forceDirect=nullptr);
   ~RooGenContext() override;
 
   void printMultiline(std::ostream &os, Int_t content, bool verbose=false, TString indent="") const override ;

--- a/roofit/roofitcore/inc/RooGenFitStudy.h
+++ b/roofit/roofitcore/inc/RooGenFitStudy.h
@@ -35,7 +35,7 @@ class RooAbsGenContext ;
 class RooGenFitStudy : public RooAbsStudy {
 public:
 
-  RooGenFitStudy(const char* name=0, const char* title=0) ;
+  RooGenFitStudy(const char* name=nullptr, const char* title=nullptr) ;
   RooGenFitStudy(const RooGenFitStudy& other) ;
   ~RooGenFitStudy() override ;
   RooAbsStudy* clone(const char* newname="") const override { return new RooGenFitStudy(newname?newname:GetName(),GetTitle()) ; }

--- a/roofit/roofitcore/inc/RooGenProdProj.h
+++ b/roofit/roofitcore/inc/RooGenProdProj.h
@@ -28,7 +28,7 @@ public:
 
   RooGenProdProj() ;
   RooGenProdProj(const char *name, const char *title, const RooArgSet& _prodSet, const RooArgSet& _intSet,
-       const RooArgSet& _normSet, const char* isetRangeName, const char* normRangeName=0, bool doFactorize=true) ;
+       const RooArgSet& _normSet, const char* isetRangeName, const char* normRangeName=nullptr, bool doFactorize=true) ;
 
   RooGenProdProj(const RooGenProdProj& other, const char* name = 0);
   TObject* clone(const char* newname) const override { return new RooGenProdProj(*this, newname); }

--- a/roofit/roofitcore/inc/RooGenericPdf.h
+++ b/roofit/roofitcore/inc/RooGenericPdf.h
@@ -28,7 +28,7 @@ public:
   inline RooGenericPdf(){}
   RooGenericPdf(const char *name, const char *title, const char* formula, const RooArgList& dependents);
   RooGenericPdf(const char *name, const char *title, const RooArgList& dependents);
-  RooGenericPdf(const RooGenericPdf& other, const char* name=0);
+  RooGenericPdf(const RooGenericPdf& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooGenericPdf(*this,newname); }
 
   // I/O streaming interface (machine readable)

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -129,7 +129,7 @@ RooCmdArg Cut(const char* cutSpec) ;
 RooCmdArg Cut(const RooFormulaVar& cutVar) ;
 RooCmdArg Binning(const RooAbsBinning& binning) ;
 RooCmdArg Binning(const char* binningName) ;
-RooCmdArg Binning(int nBins, double xlo=0., double xhi=0.) ;
+RooCmdArg Binning(int nBins, double xlo=0.0, double xhi=0.0) ;
 RooCmdArg MarkerStyle(Style_t style) ;
 RooCmdArg MarkerSize(Size_t size) ;
 RooCmdArg MarkerColor(Color_t color) ;
@@ -271,7 +271,7 @@ RooCmdArg SumW2Error(bool flag) ;
 RooCmdArg AsymptoticError(bool flag) ;
 RooCmdArg CloneData(bool flag) ;
 RooCmdArg Integrate(bool flag) ;
-RooCmdArg Minimizer(const char* type, const char* alg=0) ;
+RooCmdArg Minimizer(const char* type, const char* alg=nullptr) ;
 RooCmdArg Offset(bool flag=true) ;
 RooCmdArg RecoverFromUndefinedRegions(double strength);
 /** @} */

--- a/roofit/roofitcore/inc/RooHistError.h
+++ b/roofit/roofitcore/inc/RooHistError.h
@@ -49,7 +49,7 @@ private:
   // -----------------------------------------------------------
   // Define a 1-dim RooAbsFunc of mu that evaluates the sum:
   //
-  //  Q(n|mu) = Sum_{k=0}^{n} P(k|mu)
+  //  Q(n|mu) = Sum_{k=nullptr}^{n} P(k|mu)
   //
   // where P(n|mu) = exp(-mu) mu**n / n! is the Poisson PDF.
   // -----------------------------------------------------------
@@ -73,7 +73,7 @@ private:
   // -----------------------------------------------------------
   // Define a 1-dim RooAbsFunc of a that evaluates the sum:
   //
-  //  Q(n|n+m,a) = Sum_{k=0}^{n} B(k|n+m,a)
+  //  Q(n|n+m,a) = Sum_{k=nullptr}^{n} B(k|n+m,a)
   //
   // where B(n|n+m,a) = (n+m)!/(n!m!) ((1+a)/2)**n ((1-a)/2)**m
   // is the Binomial PDF.
@@ -104,7 +104,7 @@ private:
   // -----------------------------------------------------------
   // Define a 1-dim RooAbsFunc of a that evaluates the sum:
   //
-  //  Q(n|n+m,a) = Sum_{k=0}^{n} B(k|n+m,a)
+  //  Q(n|n+m,a) = Sum_{k=nullptr}^{n} B(k|n+m,a)
   //
   // where B(n|n+m,a) = (n+m)!/(n!m!) ((1+a)/2)**n ((1-a)/2)**m
   // is the Binomial PDF.

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -32,7 +32,7 @@ public:
   RooHistFunc() ;
   RooHistFunc(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistFunc(const char *name, const char *title, const RooArgList& funcObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
-  RooHistFunc(const RooHistFunc& other, const char* name=0);
+  RooHistFunc(const RooHistFunc& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooHistFunc(*this,newname); }
   ~RooHistFunc() override ;
 
@@ -62,8 +62,8 @@ public:
     return _intOrder ;
   }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   /// Set use of special boundary conditions for c.d.f.s
   void setCdfBoundaries(bool flag) {

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -31,7 +31,7 @@ public:
   RooHistPdf() ;
   RooHistPdf(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
-  RooHistPdf(const RooHistPdf& other, const char* name=0);
+  RooHistPdf(const RooHistPdf& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooHistPdf(*this,newname); }
   ~RooHistPdf() override ;
 
@@ -67,8 +67,8 @@ public:
                                      RooDataHist& dataHist,
                                      bool histFuncMode) ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   void setCdfBoundaries(bool flag) {
     // Set use of special boundary conditions for c.d.f.s

--- a/roofit/roofitcore/inc/RooImproperIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooImproperIntegrator1D.h
@@ -35,7 +35,7 @@ public:
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double* xmin, double* xmax) override;
   bool setUseIntegrandLimits(bool flag) override {_useIntegrandLimits = flag ; return true ; }
-  double integral(const double* yvec=0) override ;
+  double integral(const double* yvec=nullptr) override ;
 
   bool canIntegrate1D() const override { return true ; }
   bool canIntegrate2D() const override { return false ; }
@@ -47,7 +47,7 @@ protected:
   friend class RooNumIntFactory ;
   static void registerIntegrator(RooNumIntFactory& fact) ;
 
-  void initialize(const RooAbsFunc* function=0) ;
+  void initialize(const RooAbsFunc* function=nullptr) ;
 
   enum LimitsCase { Invalid, ClosedBothEnds, OpenBothEnds, OpenBelowSpansZero, OpenBelow,
           OpenAboveSpansZero, OpenAbove };

--- a/roofit/roofitcore/inc/RooIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooIntegrator1D.h
@@ -39,7 +39,7 @@ public:
   ~RooIntegrator1D() override;
 
   bool checkLimits() const override;
-  double integral(const double *yvec=0) override ;
+  double integral(const double *yvec=nullptr) override ;
 
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double* xmin, double* xmax) override;

--- a/roofit/roofitcore/inc/RooLinTransBinning.h
+++ b/roofit/roofitcore/inc/RooLinTransBinning.h
@@ -22,10 +22,10 @@
 class RooLinTransBinning : public RooAbsBinning {
 public:
 
-  RooLinTransBinning(const char* name=0) : RooAbsBinning(name) { }
-  RooLinTransBinning(const RooAbsBinning& input, double slope=1.0, double offset=0.0, const char* name=0);
-  RooLinTransBinning(const RooLinTransBinning&, const char* name=0);
-  RooAbsBinning* clone(const char* name=0) const override { return new RooLinTransBinning(*this,name) ; }
+  RooLinTransBinning(const char* name=nullptr) : RooAbsBinning(name) { }
+  RooLinTransBinning(const RooAbsBinning& input, double slope=1.0, double offset=0.0, const char* name=nullptr);
+  RooLinTransBinning(const RooLinTransBinning&, const char* name=nullptr);
+  RooAbsBinning* clone(const char* name=nullptr) const override { return new RooLinTransBinning(*this,name) ; }
   ~RooLinTransBinning() override ;
 
   Int_t numBoundaries() const override { return _input->numBoundaries() ; }
@@ -51,7 +51,7 @@ protected:
 
   inline Int_t binTrans(Int_t bin) const { if (_slope>0) return bin ; else return numBins()-bin-1 ; }
   inline double trans(double x) const { return x*_slope + _offset ; }
-  inline double invTrans(double x) const { if (_slope==0.) return 0 ; return (x-_offset)/_slope ; }
+  inline double invTrans(double x) const { if (_slope==0.0) return 0.0 ; return (x-_offset)/_slope ; }
 
   double _slope{0.};   ///< Slope of transformation
   double _offset{0.};  ///< Offset of transformation

--- a/roofit/roofitcore/inc/RooLinearVar.h
+++ b/roofit/roofitcore/inc/RooLinearVar.h
@@ -32,7 +32,7 @@ public:
   // Constructors, assignment etc.
   RooLinearVar() {} ;
   RooLinearVar(const char *name, const char *title, RooAbsRealLValue& variable, const RooAbsReal& slope, const RooAbsReal& offset, const char *unit= "") ;
-  RooLinearVar(const RooLinearVar& other, const char* name=0);
+  RooLinearVar(const RooLinearVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooLinearVar(*this,newname); }
   ~RooLinearVar() override ;
 
@@ -41,8 +41,8 @@ public:
 
   // Jacobian and limits
   bool hasBinning(const char* name) const override ;
-  const RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) const override ;
-  RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) override  ;
+  const RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) const override ;
+  RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) override  ;
   std::list<std::string> getBinningNames() const override;
 
   double jacobian() const override ;

--- a/roofit/roofitcore/inc/RooLinkedList.h
+++ b/roofit/roofitcore/inc/RooLinkedList.h
@@ -43,7 +43,7 @@ public:
   // Copy constructor
   RooLinkedList(const RooLinkedList& other) ;
 
-  TObject* Clone(const char* =0) const override {
+  TObject* Clone(const char* =nullptr) const override {
     return new RooLinkedList(*this) ;
   }
 
@@ -76,8 +76,8 @@ public:
   RooLinkedListIterImpl rbegin() const;
   RooLinkedListIterImpl rend() const;
 
-  void Clear(Option_t *o=0) override ;
-  void Delete(Option_t *o=0) override ;
+  void Clear(Option_t *o=nullptr) override ;
+  void Delete(Option_t *o=nullptr) override ;
   TObject* find(const char* name) const ;
   RooAbsArg* findArg(const RooAbsArg*) const ;
   TObject* FindObject(const char* name) const override ;
@@ -105,7 +105,7 @@ public:
 
 protected:
 
-  RooLinkedListElem* createElement(TObject* obj, RooLinkedListElem* elem=0) ;
+  RooLinkedListElem* createElement(TObject* obj, RooLinkedListElem* elem=nullptr) ;
   void deleteElement(RooLinkedListElem*) ;
 
 

--- a/roofit/roofitcore/inc/RooLinkedListElem.h
+++ b/roofit/roofitcore/inc/RooLinkedListElem.h
@@ -34,7 +34,7 @@ public:
     _prev(0), _next(0), _arg(0), _refCount(0) {
   }
 
-  void init(TObject* arg, RooLinkedListElem* after=0) {
+  void init(TObject* arg, RooLinkedListElem* after=nullptr) {
    _arg = arg ;
    _refCount = 1 ;
 

--- a/roofit/roofitcore/inc/RooMCIntegrator.h
+++ b/roofit/roofitcore/inc/RooMCIntegrator.h
@@ -35,7 +35,7 @@ public:
   ~RooMCIntegrator() override;
 
   bool checkLimits() const override;
-  double integral(const double* yvec=0) override;
+  double integral(const double* yvec=nullptr) override;
 
   enum Stage { AllStages, ReuseGrid, RefineGrid };
   double vegas(Stage stage, UInt_t calls, UInt_t iterations, double *absError= 0);

--- a/roofit/roofitcore/inc/RooMCStudy.h
+++ b/roofit/roofitcore/inc/RooMCStudy.h
@@ -44,8 +44,8 @@ public:
 
 
   // Run methods
-  bool generateAndFit(Int_t nSamples, Int_t nEvtPerSample=0, bool keepGenData=false, const char* asciiFilePat=0) ;
-  bool generate(Int_t nSamples, Int_t nEvtPerSample=0, bool keepGenData=false, const char* asciiFilePat=0) ;
+  bool generateAndFit(Int_t nSamples, Int_t nEvtPerSample=0, bool keepGenData=false, const char* asciiFilePat=nullptr) ;
+  bool generate(Int_t nSamples, Int_t nEvtPerSample=0, bool keepGenData=false, const char* asciiFilePat=nullptr) ;
   bool fit(Int_t nSamples, const char* asciiFilePat) ;
   bool fit(Int_t nSamples, TList& dataSetList) ;
   bool addFitResult(const RooFitResult& fr) ;
@@ -141,7 +141,7 @@ protected:
   std::list<RooAbsMCStudyModule*> _modList ; ///< List of additional study modules ;
 
   // Utilities for modules ;
-  RooFitResult* refit(RooAbsData* genSample=0) ;
+  RooFitResult* refit(RooAbsData* genSample=nullptr) ;
   void resetFitParams() ;
   void RecursiveRemove(TObject *obj) override;
 

--- a/roofit/roofitcore/inc/RooMappedCategory.h
+++ b/roofit/roofitcore/inc/RooMappedCategory.h
@@ -31,7 +31,7 @@ public:
 
   inline RooMappedCategory() : _defCat(0), _mapcache(0) { }
   RooMappedCategory(const char *name, const char *title, RooAbsCategory& inputCat, const char* defCatName="NotMapped", Int_t defCatIdx=NoCatIdx);
-  RooMappedCategory(const RooMappedCategory& other, const char *name=0) ;
+  RooMappedCategory(const RooMappedCategory& other, const char *name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooMappedCategory(*this,newname); }
   ~RooMappedCategory() override;
 

--- a/roofit/roofitcore/inc/RooMath.h
+++ b/roofit/roofitcore/inc/RooMath.h
@@ -45,7 +45,7 @@ public:
     * following Fourier series based approximation:
     *
     * @f[ w(z) \approx \frac{i}{2\sqrt{\pi}}\left(
-    * \sum^N_{n=0} a_n \tau_m\left(
+    * \sum^N_{n=nullptr} a_n \tau_m\left(
     * \frac{1-e^{i(n\pi+\tau_m z)}}{n\pi + \tau_m z} -
     * \frac{1-e^{i(-n\pi+\tau_m z)}}{n\pi - \tau_m z}
     * \right) - a_0 \frac{1-e^{i \tau_m z}}{z}

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -75,10 +75,10 @@ public:
 
   int minimize(const char* type, const char* alg=nullptr) ;
 
-  RooFitResult* save(const char* name=0, const char* title=0) ;
+  RooFitResult* save(const char* name=nullptr, const char* title=nullptr) ;
   RooPlot* contour(RooRealVar& var1, RooRealVar& var2,
-         double n1=1, double n2=2, double n3=0,
-         double n4=0, double n5=0, double n6=0, unsigned int npoints = 50) ;
+         double n1=1.0, double n2=2.0, double n3=0.0,
+         double n4=0.0, double n5=0.0, double n6=0.0, unsigned int npoints = 50) ;
 
   int setPrintLevel(int newLevel) ;
   void setPrintEvalErrors(int numEvalErrors) ;

--- a/roofit/roofitcore/inc/RooMultiCategory.h
+++ b/roofit/roofitcore/inc/RooMultiCategory.h
@@ -30,7 +30,7 @@ public:
   // Constructors etc.
   inline RooMultiCategory() { setShapeDirty(); }
   RooMultiCategory(const char *name, const char *title, const RooArgSet& inputCatList);
-  RooMultiCategory(const RooMultiCategory& other, const char *name=0) ;
+  RooMultiCategory(const RooMultiCategory& other, const char *name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooMultiCategory(*this,newname); }
   ~RooMultiCategory() override;
 

--- a/roofit/roofitcore/inc/RooMultiVarGaussian.h
+++ b/roofit/roofitcore/inc/RooMultiVarGaussian.h
@@ -38,12 +38,12 @@ public:
   RooMultiVarGaussian(const char *name, const char *title, const RooArgList& xvec,const TMatrixDSym& covMatrix) ;
   void setAnaIntZ(double z) { _z = z ; }
 
-  RooMultiVarGaussian(const RooMultiVarGaussian& other, const char* name=0) ;
+  RooMultiVarGaussian(const RooMultiVarGaussian& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooMultiVarGaussian(*this,newname); }
   inline ~RooMultiVarGaussian() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void initGenerator(Int_t code) override ;

--- a/roofit/roofitcore/inc/RooNLLVar.h
+++ b/roofit/roofitcore/inc/RooNLLVar.h
@@ -45,7 +45,7 @@ public:
             const RooArgSet& projDeps, bool extended = false,
             RooAbsTestStatistic::Configuration const& cfg=RooAbsTestStatistic::Configuration{});
 
-  RooNLLVar(const RooNLLVar& other, const char* name=0);
+  RooNLLVar(const RooNLLVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooNLLVar(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,

--- a/roofit/roofitcore/inc/RooNumCdf.h
+++ b/roofit/roofitcore/inc/RooNumCdf.h
@@ -17,7 +17,7 @@
 class RooNumCdf : public RooNumRunningInt {
 public:
   RooNumCdf(const char *name, const char *title, RooAbsPdf& _pdf, RooRealVar& _x, const char* binningName="cache");
-  RooNumCdf(const RooNumCdf& other, const char* name=0) ;
+  RooNumCdf(const RooNumCdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooNumCdf(*this,newname); }
   ~RooNumCdf() override ;
 

--- a/roofit/roofitcore/inc/RooNumConvPdf.h
+++ b/roofit/roofitcore/inc/RooNumConvPdf.h
@@ -31,7 +31,7 @@ public:
   RooNumConvPdf(const char *name, const char *title,
                 RooRealVar& convVar, RooAbsPdf& pdf, RooAbsPdf& resmodel) ;
 
-  RooNumConvPdf(const RooNumConvPdf& other, const char* name=0) ;
+  RooNumConvPdf(const RooNumConvPdf& other, const char* name=nullptr) ;
 
   TObject* clone(const char* newname) const override { return new RooNumConvPdf(*this,newname) ; }
   ~RooNumConvPdf() override ;
@@ -70,8 +70,8 @@ protected:
   RooRealProxy _origPdf ;         ///< Original input PDF
   RooRealProxy _origModel ;       ///< Original resolution model
 
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                       const RooArgSet* auxProto=0, bool verbose= false) const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                       const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
 
   friend class RooConvGenContext ;
 

--- a/roofit/roofitcore/inc/RooNumConvolution.h
+++ b/roofit/roofitcore/inc/RooNumConvolution.h
@@ -32,9 +32,9 @@ public:
   RooNumConvolution() ;
 
   RooNumConvolution(const char *name, const char *title,
-            RooRealVar& convVar, RooAbsReal& pdf, RooAbsReal& resmodel, const RooNumConvolution* proto=0) ;
+            RooRealVar& convVar, RooAbsReal& pdf, RooAbsReal& resmodel, const RooNumConvolution* proto=nullptr) ;
 
-  RooNumConvolution(const RooNumConvolution& other, const char* name=0) ;
+  RooNumConvolution(const RooNumConvolution& other, const char* name=nullptr) ;
 
   TObject* clone(const char* newname) const override { return new RooNumConvolution(*this,newname) ; }
   ~RooNumConvolution() override ;

--- a/roofit/roofitcore/inc/RooNumGenFactory.h
+++ b/roofit/roofitcore/inc/RooNumGenFactory.h
@@ -37,7 +37,7 @@ public:
   const RooAbsNumGenerator* getProtoSampler(const char* name) ;
 
   RooAbsNumGenerator* createSampler(RooAbsReal& func, const RooArgSet& genVars, const RooArgSet& condVars,
-                const RooNumGenConfig& config, bool verbose=false, RooAbsReal* maxFuncVal=0) ;
+                const RooNumGenConfig& config, bool verbose=false, RooAbsReal* maxFuncVal=nullptr) ;
 
 
 protected:

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -20,7 +20,7 @@
 class RooNumRunningInt : public RooAbsCachedReal {
 public:
   RooNumRunningInt(const char *name, const char *title, RooAbsReal& _func, RooRealVar& _x, const char* binningName="cache");
-  RooNumRunningInt(const RooNumRunningInt& other, const char* name=0) ;
+  RooNumRunningInt(const RooNumRunningInt& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooNumRunningInt(*this,newname); }
   ~RooNumRunningInt() override ;
 

--- a/roofit/roofitcore/inc/RooObjCacheManager.h
+++ b/roofit/roofitcore/inc/RooObjCacheManager.h
@@ -31,8 +31,8 @@ class RooObjCacheManager : public RooCacheManager<RooAbsCacheElement> {
 
 public:
 
-  RooObjCacheManager(RooAbsArg* owner=0, Int_t maxSize=2, bool clearCacheOnServerRedirect=true, bool allowOptimize=false) ;
-  RooObjCacheManager(const RooObjCacheManager& other, RooAbsArg* owner=0) ;
+  RooObjCacheManager(RooAbsArg* owner=nullptr, Int_t maxSize=2, bool clearCacheOnServerRedirect=true, bool allowOptimize=false) ;
+  RooObjCacheManager(const RooObjCacheManager& other, RooAbsArg* owner=nullptr) ;
   ~RooObjCacheManager() override ;
 
   bool redirectServersHook(const RooAbsCollection& /*newServerList*/, bool /*mustReplaceAll*/, bool /*nameChange*/, bool /*isRecursive*/) override ;

--- a/roofit/roofitcore/inc/RooParamBinning.h
+++ b/roofit/roofitcore/inc/RooParamBinning.h
@@ -24,10 +24,10 @@
 class RooParamBinning : public RooAbsBinning {
 public:
 
-  RooParamBinning(const char* name=0) ;
-  RooParamBinning(RooAbsReal& xlo, RooAbsReal& xhi, Int_t nBins, const char* name=0) ;
-  RooParamBinning(const RooParamBinning& other, const char* name=0) ;
-  RooAbsBinning* clone(const char* name=0) const override { return new RooParamBinning(*this,name?name:GetName()) ; }
+  RooParamBinning(const char* name=nullptr) ;
+  RooParamBinning(RooAbsReal& xlo, RooAbsReal& xhi, Int_t nBins, const char* name=nullptr) ;
+  RooParamBinning(const RooParamBinning& other, const char* name=nullptr) ;
+  RooAbsBinning* clone(const char* name=nullptr) const override { return new RooParamBinning(*this,name?name:GetName()) ; }
   ~RooParamBinning() override ;
 
   void setRange(double xlo, double xhi) override ;

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -111,7 +111,7 @@ public:
 
   // container management
   const char* nameOf(Int_t idx) const ;
-  TObject *findObject(const char *name, const TClass* clas=0) const;
+  TObject *findObject(const char *name, const TClass* clas=nullptr) const;
   TObject* getObject(Int_t idx) const ;
   Stat_t numItems() const {return _items.size();}
 
@@ -120,7 +120,7 @@ public:
   void addTH1(TH1 *hist, Option_t* drawOptions= "", bool invisible=false);
   std::unique_ptr<TLegend> BuildLegend() const;
 
-  void remove(const char* name=0, bool deleteToo=true) ;
+  void remove(const char* name=nullptr, bool deleteToo=true) ;
 
   // ascii printing
   void printName(std::ostream& os) const override ;
@@ -149,14 +149,14 @@ public:
   const RooArgSet *getNormVars() const { return _normVars; }
 
   // get attributes of contained objects
-  TAttLine *getAttLine(const char *name=0) const;
-  TAttFill *getAttFill(const char *name=0) const;
-  TAttMarker *getAttMarker(const char *name=0) const;
-  TAttText *getAttText(const char *name=0) const;
+  TAttLine *getAttLine(const char *name=nullptr) const;
+  TAttFill *getAttFill(const char *name=nullptr) const;
+  TAttMarker *getAttMarker(const char *name=nullptr) const;
+  TAttText *getAttText(const char *name=nullptr) const;
 
   // Convenient type-safe accessors
-  RooCurve* getCurve(const char* name=0) const ;
-  RooHist* getHist(const char* name=0) const ;
+  RooCurve* getCurve(const char* name=nullptr) const ;
+  RooHist* getHist(const char* name=nullptr) const ;
 
 
   // rearrange drawing order of contained objects
@@ -173,13 +173,13 @@ public:
   virtual void SetMaximum(double maximum = -1111) ;
   virtual void SetMinimum(double minimum = -1111) ;
 
-  ///Shortcut for RooPlot::chiSquare(const char* pdfname, const char* histname, int nFitParam=0)
+  ///Shortcut for RooPlot::chiSquare(const char* pdfname, const char* histname, int nFitParam=nullptr)
   double chiSquare(int nFitParam=0) const { return chiSquare(0,0,nFitParam) ; }
   double chiSquare(const char* pdfname, const char* histname, int nFitParam=0) const ;
 
-  RooHist* residHist(const char* histname=0, const char* pdfname=0,bool normalize=false, bool useAverage=true) const ;
+  RooHist* residHist(const char* histname=nullptr, const char* pdfname=nullptr,bool normalize=false, bool useAverage=true) const ;
   ///Uses residHist() and sets normalize=true
-  RooHist* pullHist(const char* histname=0, const char* pdfname=0, bool useAverage=true) const
+  RooHist* pullHist(const char* histname=nullptr, const char* pdfname=nullptr, bool useAverage=true) const
     { return residHist(histname,pdfname,true,useAverage); }
 
   void Browse(TBrowser *b) override ;
@@ -214,7 +214,7 @@ protected:
   class DrawOpt {
     public:
 
-    DrawOpt(const char* _rawOpt=0) : invisible(false) { drawOptions[0] = 0 ; initialize(_rawOpt) ; }
+    DrawOpt(const char* _rawOpt=nullptr) : invisible(false) { drawOptions[0] = 0 ; initialize(_rawOpt) ; }
     void initialize(const char* _rawOpt) ;
     const char* rawOpt() const ;
 

--- a/roofit/roofitcore/inc/RooPolyVar.h
+++ b/roofit/roofitcore/inc/RooPolyVar.h
@@ -37,8 +37,8 @@ public:
   TObject* clone(const char* newname) const override { return new RooPolyVar(*this, newname); }
   ~RooPolyVar() override ;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofitcore/inc/RooProdGenContext.h
+++ b/roofit/roofitcore/inc/RooProdGenContext.h
@@ -30,7 +30,7 @@ class RooSuperCategory ;
 class RooProdGenContext : public RooAbsGenContext {
 public:
   RooProdGenContext(const RooProdPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-          const RooArgSet* auxProto=0, bool _verbose= false);
+          const RooArgSet* auxProto=nullptr, bool _verbose= false);
   ~RooProdGenContext() override;
 
   void setProtoDataOrder(Int_t* lut) override ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -35,8 +35,8 @@ public:
 
   RooProdPdf() ;
   RooProdPdf(const char *name, const char *title,
-       RooAbsPdf& pdf1, RooAbsPdf& pdf2, double cutOff=0) ;
-  RooProdPdf(const char* name, const char* title, const RooArgList& pdfList, double cutOff=0) ;
+       RooAbsPdf& pdf1, RooAbsPdf& pdf2, double cutOff=0.0) ;
+  RooProdPdf(const char* name, const char* title, const RooArgList& pdfList, double cutOff=0.0) ;
   RooProdPdf(const char* name, const char* title, const RooArgSet& fullPdfSet, const RooLinkedList& cmdArgList) ;
 
   RooProdPdf(const char* name, const char* title, const RooArgSet& fullPdfSet,
@@ -51,15 +51,15 @@ public:
              const RooCmdArg& arg5=RooCmdArg(), const RooCmdArg& arg6=RooCmdArg(),
              const RooCmdArg& arg7=RooCmdArg(), const RooCmdArg& arg8=RooCmdArg()) ;
 
-  RooProdPdf(const RooProdPdf& other, const char* name=0) ;
+  RooProdPdf(const RooProdPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooProdPdf(*this,newname) ; }
   ~RooProdPdf() override ;
 
   bool checkObservables(const RooArgSet* nset) const override ;
 
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
   bool selfNormalized() const override { return _selfNorm ; }
 
   ExtendMode extendMode() const override ;
@@ -81,7 +81,7 @@ public:
 
   void printMetaArgs(std::ostream& os) const override ;
 
-  void selectNormalizationRange(const char* rangeName=0, bool force=false) override ;
+  void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
   void fixRefRange(const char* rangeName) ;
 
   void setSelfNormalized(bool flag) { _selfNorm = flag ; }
@@ -121,7 +121,7 @@ private:
 
 
 
-  Int_t getPartIntList(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName=0) const ;
+  Int_t getPartIntList(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName=nullptr) const ;
 
   std::vector<RooAbsReal*> processProductTerm(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName,
                      const RooArgSet* term,const RooArgSet& termNSet, const RooArgSet& termISet,
@@ -160,8 +160,8 @@ private:
 
 
   friend class RooProdGenContext ;
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                  const RooArgSet *auxProto=0, bool verbose= false) const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                  const RooArgSet *auxProto=nullptr, bool verbose= false) const override ;
 
 
   mutable RooAICRegistry _genCode ; ///<! Registry of composite direct generator codes

--- a/roofit/roofitcore/inc/RooProduct.h
+++ b/roofit/roofitcore/inc/RooProduct.h
@@ -41,8 +41,8 @@ public:
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars,
                                                    const RooArgSet* normSet,
-                                                   const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override;
+                                                   const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
 
   RooArgList components() { RooArgList tmp(_compRSet) ; tmp.add(_compCSet) ; return tmp ; }
@@ -84,7 +84,7 @@ protected:
 
   const char* makeFPName(const char *pfx,const RooArgSet& terms) const ;
   ProdMap* groupProductTerms(const RooArgSet&) const;
-  Int_t getPartIntList(const RooArgSet* iset, const char *rangeName=0) const;
+  Int_t getPartIntList(const RooArgSet* iset, const char *rangeName=nullptr) const;
 
   ClassDefOverride(RooProduct,3) // Product of RooAbsReal and/or RooAbsCategory terms
 };

--- a/roofit/roofitcore/inc/RooProfileLL.h
+++ b/roofit/roofitcore/inc/RooProfileLL.h
@@ -24,7 +24,7 @@ public:
 
   RooProfileLL() ;
   RooProfileLL(const char *name, const char *title, RooAbsReal& nll, const RooArgSet& observables);
-  RooProfileLL(const RooProfileLL& other, const char* name=0) ;
+  RooProfileLL(const RooProfileLL& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooProfileLL(*this,newname); }
 
   void setAlwaysStartFromMin(bool flag) { _startFromMin = flag ; }

--- a/roofit/roofitcore/inc/RooProjectedPdf.h
+++ b/roofit/roofitcore/inc/RooProjectedPdf.h
@@ -23,13 +23,13 @@ public:
 
   RooProjectedPdf() ;
   RooProjectedPdf(const char *name, const char *title,  RooAbsReal& _intpdf, const RooArgSet& intObs);
-  RooProjectedPdf(const RooProjectedPdf& other, const char* name=0) ;
+  RooProjectedPdf(const RooProjectedPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooProjectedPdf(*this,newname); }
   inline ~RooProjectedPdf() override { }
 
   // Analytical integration support
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;

--- a/roofit/roofitcore/inc/RooProofDriverSelector.h
+++ b/roofit/roofitcore/inc/RooProofDriverSelector.h
@@ -23,7 +23,7 @@ public :
    // List of branches
    TBranch        *b_i;   ///<!
 
-   RooProofDriverSelector(TTree * /*tree*/ =0) { b_i = 0 ; _pkg = 0 ; fChain = 0 ; }
+   RooProofDriverSelector(TTree * /*tree*/ =nullptr) { b_i = 0 ; _pkg = 0 ; fChain = 0 ; }
    ~RooProofDriverSelector() override { }
    Int_t   Version() const override { return 2; }
    void    SlaveBegin(TTree *tree) override;

--- a/roofit/roofitcore/inc/RooRangeBinning.h
+++ b/roofit/roofitcore/inc/RooRangeBinning.h
@@ -21,10 +21,10 @@
 class RooRangeBinning : public RooAbsBinning {
 public:
 
-  RooRangeBinning(const char* name=0) ;
-  RooRangeBinning(double xmin, double xmax, const char* name=0) ;
-  RooRangeBinning(const RooRangeBinning&, const char* name=0) ;
-  RooAbsBinning* clone(const char* name=0) const override { return new RooRangeBinning(*this,name?name:GetName()) ; }
+  RooRangeBinning(const char* name=nullptr) ;
+  RooRangeBinning(double xmin, double xmax, const char* name=nullptr) ;
+  RooRangeBinning(const RooRangeBinning&, const char* name=nullptr) ;
+  RooAbsBinning* clone(const char* name=nullptr) const override { return new RooRangeBinning(*this,name?name:GetName()) ; }
   ~RooRangeBinning() override ;
 
   Int_t numBoundaries() const override { return 2 ; }

--- a/roofit/roofitcore/inc/RooRealAnalytic.h
+++ b/roofit/roofitcore/inc/RooRealAnalytic.h
@@ -20,7 +20,7 @@
 
 class RooRealAnalytic : public RooRealBinding {
 public:
-  inline RooRealAnalytic(const RooAbsReal &func, const RooArgSet &vars, Int_t code, const RooArgSet* normSet=0, const TNamed* rangeName=0) :
+  inline RooRealAnalytic(const RooAbsReal &func, const RooArgSet &vars, Int_t code, const RooArgSet* normSet=nullptr, const TNamed* rangeName=nullptr) :
     RooRealBinding(func,vars,normSet,rangeName), _code(code) { }
   inline ~RooRealAnalytic() override { }
 

--- a/roofit/roofitcore/inc/RooRealBinding.h
+++ b/roofit/roofitcore/inc/RooRealBinding.h
@@ -28,8 +28,8 @@ namespace RooBatchCompute{ struct RunContext; }
 
 class RooRealBinding : public RooAbsFunc {
 public:
-  RooRealBinding(const RooAbsReal& func, const RooArgSet &vars, const RooArgSet* nset=0, bool clipInvalid=false, const TNamed* rangeName=0);
-  RooRealBinding(const RooRealBinding& other, const RooArgSet* nset=0) ;
+  RooRealBinding(const RooAbsReal& func, const RooArgSet &vars, const RooArgSet* nset=nullptr, bool clipInvalid=false, const TNamed* rangeName=nullptr);
+  RooRealBinding(const RooRealBinding& other, const RooArgSet* nset=nullptr) ;
   ~RooRealBinding() override;
 
   double operator()(const double xvector[]) const override;

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -37,12 +37,12 @@ public:
   // Constructors, assignment etc
   RooRealIntegral() ;
   RooRealIntegral(const char *name, const char *title, const RooAbsReal& function, const RooArgSet& depList,
-        const RooArgSet* funcNormSet=0, const RooNumIntConfig* config=0, const char* rangeName=0) ;
-  RooRealIntegral(const RooRealIntegral& other, const char* name=0);
+        const RooArgSet* funcNormSet=nullptr, const RooNumIntConfig* config=nullptr, const char* rangeName=nullptr) ;
+  RooRealIntegral(const RooRealIntegral& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooRealIntegral(*this,newname); }
   ~RooRealIntegral() override;
 
-  double getValV(const RooArgSet* set=0) const override ;
+  double getValV(const RooArgSet* set=nullptr) const override ;
 
   bool isValid() const override { return _valid; }
 
@@ -76,7 +76,7 @@ public:
     return _function.arg().plotSamplingHint(obs,xlo,xhi) ;
   }
 
-  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=0, const RooNumIntConfig* cfg=0, const char* rangeName=0) const override ;
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override ;
 
   void setAllowComponentSelection(bool allow);
   bool getAllowComponentSelection() const;

--- a/roofit/roofitcore/inc/RooRealMPFE.h
+++ b/roofit/roofitcore/inc/RooRealMPFE.h
@@ -31,12 +31,12 @@ class RooRealMPFE : public RooAbsReal {
 public:
   // Constructors, assignment etc
   RooRealMPFE(const char *name, const char *title, RooAbsReal& arg, bool calcInline=false) ;
-  RooRealMPFE(const RooRealMPFE& other, const char* name=0);
+  RooRealMPFE(const RooRealMPFE& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooRealMPFE(*this,newname); }
   ~RooRealMPFE() override;
 
   void calculate() const ;
-  double getValV(const RooArgSet* nset=0) const override ;
+  double getValV(const RooArgSet* nset=nullptr) const override ;
   void standby() ;
 
   void setVerbose(bool clientFlag=true, bool serverFlag=true) ;

--- a/roofit/roofitcore/inc/RooRealSumPdf.h
+++ b/roofit/roofitcore/inc/RooRealSumPdf.h
@@ -29,7 +29,7 @@ public:
   RooRealSumPdf(const char *name, const char *title, const RooArgList& funcList, const RooArgList& coefList, bool extended=false) ;
   RooRealSumPdf(const char *name, const char *title,
          RooAbsReal& func1, RooAbsReal& func2, RooAbsReal& coef1) ;
-  RooRealSumPdf(const RooRealSumPdf& other, const char* name=0) ;
+  RooRealSumPdf(const RooRealSumPdf& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooRealSumPdf(*this,newname) ; }
   ~RooRealSumPdf() override ;
 
@@ -39,8 +39,8 @@ public:
   void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
 
   bool forceAnalyticalInt(const RooAbsArg& arg) const override { return arg.isFundamental() ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   const RooArgList& funcList() const { return _funcList ; }
   const RooArgList& coefList() const { return _coefList ; }

--- a/roofit/roofitcore/inc/RooRealVar.h
+++ b/roofit/roofitcore/inc/RooRealVar.h
@@ -47,13 +47,13 @@ public:
       double maxValue, const char *unit= "");
   RooRealVar(const char *name, const char *title, double value,
       double minValue, double maxValue, const char *unit= "") ;
-  RooRealVar(const RooRealVar& other, const char* name=0);
+  RooRealVar(const RooRealVar& other, const char* name=nullptr);
   RooRealVar& operator=(const RooRealVar& other);
   TObject* clone(const char* newname) const override { return new RooRealVar(*this,newname); }
   ~RooRealVar() override;
 
   // Parameter value and error accessors
-  double getValV(const RooArgSet* nset=0) const override ;
+  double getValV(const RooArgSet* nset=nullptr) const override ;
   RooSpan<const double> getValues(RooBatchCompute::RunContext& inputData, const RooArgSet* = nullptr) const final;
 
   /// Returns how many times the value of this RooRealVar was reset.
@@ -86,22 +86,22 @@ public:
   /// Set parameterised limits of the default range. See setRange(const char*, RooAbsReal&, RooAbsReal&).
   inline void setRange(RooAbsReal& min, RooAbsReal& max) { setRange(0,min,max) ; }
 
-  void setBins(Int_t nBins, const char* name=0);
-  void setBinning(const RooAbsBinning& binning, const char* name=0) ;
+  void setBins(Int_t nBins, const char* name=nullptr);
+  void setBinning(const RooAbsBinning& binning, const char* name=nullptr) ;
 
   // RooAbsRealLValue implementation
   bool hasBinning(const char* name) const override ;
-  const RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) const override ;
-  RooAbsBinning& getBinning(const char* name=0, bool verbose=true, bool createOnTheFly=false) override ;
+  const RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) const override ;
+  RooAbsBinning& getBinning(const char* name=nullptr, bool verbose=true, bool createOnTheFly=false) override ;
   std::list<std::string> getBinningNames() const override ;
 
   // Set infinite fit range limits
   /// Remove lower range limit for binning with given name. Empty name means default range.
-  void removeMin(const char* name=0);
+  void removeMin(const char* name=nullptr);
   /// Remove upper range limit for binning with given name. Empty name means default range.
-  void removeMax(const char* name=0);
+  void removeMax(const char* name=nullptr);
   /// Remove range limits for binning with given name. Empty name means default range.
-  void removeRange(const char* name=0);
+  void removeRange(const char* name=nullptr);
 
   // I/O streaming interface (machine readable)
   bool readFromStream(std::istream& is, bool compact, bool verbose=false) override ;

--- a/roofit/roofitcore/inc/RooResolutionModel.h
+++ b/roofit/roofitcore/inc/RooResolutionModel.h
@@ -29,7 +29,7 @@ public:
   // Constructors, assignment etc
   inline RooResolutionModel() : _basis(0) { }
   RooResolutionModel(const char *name, const char *title, RooAbsRealLValue& x) ;
-  RooResolutionModel(const RooResolutionModel& other, const char* name=0);
+  RooResolutionModel(const RooResolutionModel& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override = 0 ;
   ~RooResolutionModel() override;
 
@@ -37,7 +37,7 @@ public:
                                             const RooDataSet*, const RooArgSet*,
                                             bool) const { return 0; }
 
-  double getValV(const RooArgSet* nset=0) const override ;
+  double getValV(const RooArgSet* nset=nullptr) const override ;
 
   // If used as regular PDF, it also has to be normalized. If this resolution
   // model is used in a convolution, return unnormalized value regardless of
@@ -53,7 +53,7 @@ public:
   virtual Int_t basisCode(const char* name) const = 0 ;
 
   virtual void normLeafServerList(RooArgSet& list) const ;
-  double getNorm(const RooArgSet* nset=0) const override ;
+  double getNorm(const RooArgSet* nset=nullptr) const override ;
 
   inline const RooFormulaVar& basis() const { return _basis?*_basis:*identity() ; }
   bool isConvolved() const { return _basis ? true : false ; }

--- a/roofit/roofitcore/inc/RooSegmentedIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooSegmentedIntegrator1D.h
@@ -32,7 +32,7 @@ public:
   ~RooSegmentedIntegrator1D() override;
 
   bool checkLimits() const override;
-  double integral(const double *yvec=0) override ;
+  double integral(const double *yvec=nullptr) override ;
 
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double *xmin, double *xmax) override;

--- a/roofit/roofitcore/inc/RooSharedProperties.h
+++ b/roofit/roofitcore/inc/RooSharedProperties.h
@@ -35,7 +35,7 @@ public:
   RooSharedProperties(RooSharedProperties &&) = delete;
   RooSharedProperties& operator=(RooSharedProperties &&) = delete;
 
-  void Print(Option_t* opts=0) const override ;
+  void Print(Option_t* opts=nullptr) const override ;
 
   void increaseRefCount() { _refCount++ ; }
   void decreaseRefCount() { if (_refCount>0) _refCount-- ; }

--- a/roofit/roofitcore/inc/RooSimGenContext.h
+++ b/roofit/roofitcore/inc/RooSimGenContext.h
@@ -27,7 +27,7 @@ class RooAbsCategoryLValue ;
 class RooSimGenContext : public RooAbsGenContext {
 public:
   RooSimGenContext(const RooSimultaneous &model, const RooArgSet &vars, const RooDataSet *prototype= 0,
-                   const RooArgSet* auxProto=0, bool _verbose= false);
+                   const RooArgSet* auxProto=nullptr, bool _verbose= false);
   ~RooSimGenContext() override;
   void setProtoDataOrder(Int_t* lut) override ;
 

--- a/roofit/roofitcore/inc/RooSimPdfBuilder.h
+++ b/roofit/roofitcore/inc/RooSimPdfBuilder.h
@@ -38,7 +38,7 @@ public:
   RooArgSet* createProtoBuildConfig() ;
 
   RooSimultaneous* buildPdf(const RooArgSet& buildConfig, const RooArgSet& dependents,
-              const RooArgSet* auxSplitCats=0, bool verbose=false) ;
+              const RooArgSet* auxSplitCats=nullptr, bool verbose=false) ;
 
   RooSimultaneous* buildPdf(const RooArgSet& buildConfig, const RooAbsData* dataSet,
               const RooArgSet& auxSplitCats, bool verbose=false) {
@@ -51,7 +51,7 @@ public:
   }
 
   RooSimultaneous* buildPdf(const RooArgSet& buildConfig, const RooAbsData* dataSet,
-              const RooArgSet* auxSplitCats=0, bool verbose=false) {
+              const RooArgSet* auxSplitCats=nullptr, bool verbose=false) {
     return buildPdf(buildConfig,*dataSet->get(),auxSplitCats,verbose) ;
   }
 

--- a/roofit/roofitcore/inc/RooSimultaneous.h
+++ b/roofit/roofitcore/inc/RooSimultaneous.h
@@ -42,7 +42,7 @@ public:
   RooSimultaneous(const char *name, const char *title, RooAbsCategoryLValue& indexCat) ;
   RooSimultaneous(const char *name, const char *title, std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;
   RooSimultaneous(const char *name, const char *title, const RooArgList& pdfList, RooAbsCategoryLValue& indexCat) ;
-  RooSimultaneous(const RooSimultaneous& other, const char* name=0);
+  RooSimultaneous(const RooSimultaneous& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooSimultaneous(*this,newname) ; }
   ~RooSimultaneous() override ;
 
@@ -55,8 +55,8 @@ public:
   double expectedEvents(const RooArgSet* nset) const override ;
 
   bool forceAnalyticalInt(const RooAbsArg&) const override { return true ; }
-  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=0) const override ;
-  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
+  double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
 
   using RooAbsPdf::plotOn ;
   RooPlot* plotOn(RooPlot* frame,
@@ -71,9 +71,9 @@ public:
 
   // Backward compatibility function
   virtual RooPlot *plotOn(RooPlot *frame, Option_t* drawOptions, double scaleFactor=1.0,
-           ScaleType stype=Relative, const RooAbsData* projData=0, const RooArgSet* projSet=0,
-           double precision=1e-3, bool shiftToZero=false, const RooArgSet* projDataSet=0,
-           double rangeLo=0, double rangeHi=0, RooCurve::WingMode wmode=RooCurve::Extended) const;
+           ScaleType stype=Relative, const RooAbsData* projData=nullptr, const RooArgSet* projSet=nullptr,
+           double precision=1e-3, bool shiftToZero=false, const RooArgSet* projDataSet=nullptr,
+           double rangeLo=0.0, double rangeHi=0.0, RooCurve::WingMode wmode=RooCurve::Extended) const;
 
   RooAbsPdf* getPdf(const char* catName) const ;
   const RooAbsCategoryLValue& indexCat() const { return (RooAbsCategoryLValue&) _indexCat.arg() ; }
@@ -93,8 +93,8 @@ protected:
 
   void initialize(RooAbsCategoryLValue& inIndexCat, std::map<std::string,RooAbsPdf*> pdfMap) ;
 
-  void selectNormalization(const RooArgSet* depSet=0, bool force=false) override ;
-  void selectNormalizationRange(const char* rangeName=0, bool force=false) override ;
+  void selectNormalization(const RooArgSet* depSet=nullptr, bool force=false) override ;
+  void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
   mutable RooSetProxy _plotCoefNormSet ;
   const TNamed* _plotCoefNormRange ;
 
@@ -109,10 +109,10 @@ protected:
 
   friend class RooSimGenContext ;
   friend class RooSimSplitGenContext ;
-  RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=0, const RooArgSet* auxProto=0,
+  RooAbsGenContext* autoGenContext(const RooArgSet &vars, const RooDataSet* prototype=nullptr, const RooArgSet* auxProto=nullptr,
                   bool verbose=false, bool autoBinned=true, const char* binnedTag="") const override ;
-  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=0,
-                                  const RooArgSet* auxProto=0, bool verbose= false) const override ;
+  RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
+                                  const RooArgSet* auxProto=nullptr, bool verbose= false) const override ;
 
   RooCategoryProxy _indexCat ; ///< Index category
   TList    _pdfProxyList ;     ///< List of PDF proxies (named after applicable category state)

--- a/roofit/roofitcore/inc/RooStringVar.h
+++ b/roofit/roofitcore/inc/RooStringVar.h
@@ -25,7 +25,7 @@ public:
   // Constructors, assignment etc.
   RooStringVar() { }
   RooStringVar(const char *name, const char *title, const char* value, Int_t size=1024) ;
-  RooStringVar(const RooStringVar& other, const char* name=0);
+  RooStringVar(const RooStringVar& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooStringVar(*this,newname); }
   ~RooStringVar() override = default;
 
@@ -54,7 +54,7 @@ public:
   void printValue(std::ostream& os) const override { os << _string; }
 
 
-  RooAbsArg *createFundamental(const char* newname=0) const override {
+  RooAbsArg *createFundamental(const char* newname=nullptr) const override {
     return new RooStringVar(newname ? newname : GetName(), GetTitle(), "", 1);
   }
 

--- a/roofit/roofitcore/inc/RooSuperCategory.h
+++ b/roofit/roofitcore/inc/RooSuperCategory.h
@@ -29,7 +29,7 @@ public:
   // Constructors etc.
   RooSuperCategory();
   RooSuperCategory(const char *name, const char *title, const RooArgSet& inputCatList);
-  RooSuperCategory(const RooSuperCategory& other, const char *name=0) ;
+  RooSuperCategory(const RooSuperCategory& other, const char *name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooSuperCategory(*this,newname); }
   ~RooSuperCategory() override { };
 

--- a/roofit/roofitcore/inc/RooTemplateProxy.h
+++ b/roofit/roofitcore/inc/RooTemplateProxy.h
@@ -201,7 +201,7 @@ public:
     }
   }
 
-  TObject* Clone(const char* newName=0) const override { return new RooTemplateProxy<T>(newName,_owner,*this); }
+  TObject* Clone(const char* newName=nullptr) const override { return new RooTemplateProxy<T>(newName,_owner,*this); }
 
 
   /// Return reference to the proxied object.
@@ -303,13 +303,13 @@ public:
   }
 
   /// Query lower limit of range. This requires the payload to be RooAbsRealLValue or derived.
-  double min(const char* rname=0) const  { return lvptr(static_cast<const T*>(nullptr))->getMin(rname) ; }
+  double min(const char* rname=nullptr) const  { return lvptr(static_cast<const T*>(nullptr))->getMin(rname) ; }
   /// Query upper limit of range. This requires the payload to be RooAbsRealLValue or derived.
-  double max(const char* rname=0) const  { return lvptr(static_cast<const T*>(nullptr))->getMax(rname) ; }
+  double max(const char* rname=nullptr) const  { return lvptr(static_cast<const T*>(nullptr))->getMax(rname) ; }
   /// Check if the range has a lower bound. This requires the payload to be RooAbsRealLValue or derived.
-  bool hasMin(const char* rname=0) const { return lvptr(static_cast<const T*>(nullptr))->hasMin(rname) ; }
+  bool hasMin(const char* rname=nullptr) const { return lvptr(static_cast<const T*>(nullptr))->hasMin(rname) ; }
   /// Check if the range has a upper bound. This requires the payload to be RooAbsRealLValue or derived.
-  bool hasMax(const char* rname=0) const { return lvptr(static_cast<const T*>(nullptr))->hasMax(rname) ; }
+  bool hasMax(const char* rname=nullptr) const { return lvptr(static_cast<const T*>(nullptr))->hasMax(rname) ; }
 
   /// @}
 

--- a/roofit/roofitcore/inc/RooThresholdCategory.h
+++ b/roofit/roofitcore/inc/RooThresholdCategory.h
@@ -30,7 +30,7 @@ public:
   RooThresholdCategory() {};
   RooThresholdCategory(const char *name, const char *title, RooAbsReal& inputVar,
       const char* defCatName="Default", Int_t defCatIdx=0);
-  RooThresholdCategory(const RooThresholdCategory& other, const char *name=0) ;
+  RooThresholdCategory(const RooThresholdCategory& other, const char *name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooThresholdCategory(*this, newname); }
 
   // Mapping function

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -36,29 +36,29 @@ class RooTreeDataStore : public RooAbsDataStore {
 public:
 
   RooTreeDataStore() ;
-  RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooTreeDataStore(TTree* t, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
 
   // Empty ctor
-  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
-  RooAbsDataStore* clone(const char* newname=0) const override { return new RooTreeDataStore(*this,newname) ; }
-  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooTreeDataStore(*this,vars,newname) ; }
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
+  RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooTreeDataStore(*this,newname) ; }
+  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooTreeDataStore(*this,vars,newname) ; }
 
   RooAbsDataStore* reduce(RooStringView name, RooStringView title,
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 
   // Constructor from TTree
-  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr=0, const char* wgtVarName=0) ;
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, TTree& t, const char* selExpr=nullptr, const char* wgtVarName=nullptr) ;
 
   // Constructor from DataStore
-  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=0, const char* wgtVarName=0) ;
+  RooTreeDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const RooAbsDataStore& tds, const char* selExpr=nullptr, const char* wgtVarName=nullptr) ;
 
   RooTreeDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
                    const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-                   Int_t nStart, Int_t nStop, const char* wgtVarName=0) ;
+                   Int_t nStart, Int_t nStop, const char* wgtVarName=nullptr) ;
 
-  RooTreeDataStore(const RooTreeDataStore& other, const char* newname=0) ;
-  RooTreeDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
+  RooTreeDataStore(const RooTreeDataStore& other, const char* newname=nullptr) ;
+  RooTreeDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=nullptr) ;
   ~RooTreeDataStore() override ;
 
 
@@ -72,7 +72,7 @@ public:
   double weight() const override ;
   double weightError(RooAbsData::ErrorType etype=RooAbsData::Poisson) const override ;
   void weightError(double& lo, double& hi, RooAbsData::ErrorType etype=RooAbsData::Poisson) const override ;
-  bool isWeighted() const override { return (_wgtVar!=0||_extWgtArray!=0) ; }
+  bool isWeighted() const override { return (_wgtVar!=nullptr||_extWgtArray!=nullptr) ; }
 
   RooAbsData::RealSpans getBatches(std::size_t first, std::size_t len) const override {
     //TODO
@@ -111,20 +111,20 @@ public:
 
   // Forwarded from TTree
   Stat_t GetEntries() const;
-  void Reset(Option_t* option=0);
+  void Reset(Option_t* option=nullptr);
   Int_t Fill();
   Int_t GetEntry(Int_t entry = 0, Int_t getall = 0);
 
   void   Draw(Option_t* option = "") override ;
 
   // Constant term  optimizer interface
-  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, bool skipZeroWeights=false) override ;
+  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=nullptr, bool skipZeroWeights=false) override ;
   const RooAbsArg* cacheOwner() override { return _cacheOwner ; }
   void setArgStatus(const RooArgSet& set, bool active) override ;
   void resetCache() override ;
 
-  void loadValues(const TTree *t, const RooFormulaVar* select=0, const char* rangeName=0, Int_t nStart=0, Int_t nStop=2000000000)  ;
-  void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=0, const char* rangeName=0,
+  void loadValues(const TTree *t, const RooFormulaVar* select=nullptr, const char* rangeName=nullptr, Int_t nStart=0, Int_t nStop=2000000000)  ;
+  void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=nullptr, const char* rangeName=nullptr,
       std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
 
   void checkInit() const override;
@@ -143,8 +143,8 @@ public:
 
   friend class RooVectorDataStore ;
 
-  RooArgSet varsNoWeight(const RooArgSet& allVars, const char* wgtName=0) ;
-  RooRealVar* weightVar(const RooArgSet& allVars, const char* wgtName=0) ;
+  RooArgSet varsNoWeight(const RooArgSet& allVars, const char* wgtName=nullptr) ;
+  RooRealVar* weightVar(const RooArgSet& allVars, const char* wgtName=nullptr) ;
 
   void initialize();
   void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override ;

--- a/roofit/roofitcore/inc/RooTruthModel.h
+++ b/roofit/roofitcore/inc/RooTruthModel.h
@@ -37,21 +37,21 @@ public:
   // Constructors, assignment etc
   inline RooTruthModel() { }
   RooTruthModel(const char *name, const char *title, RooAbsRealLValue& x) ;
-  RooTruthModel(const RooTruthModel& other, const char* name=0);
+  RooTruthModel(const RooTruthModel& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooTruthModel(*this,newname) ; }
   ~RooTruthModel() override;
 
   Int_t basisCode(const char* name) const override ;
 
   RooAbsGenContext* modelGenContext(const RooAbsAnaConvPdf& convPdf, const RooArgSet &vars,
-                                            const RooDataSet *prototype=0, const RooArgSet* auxProto=0,
+                                            const RooDataSet *prototype=nullptr, const RooArgSet* auxProto=nullptr,
                                             bool verbose= false) const override;
 
   Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void generateEvent(Int_t code) override;
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
   double evaluate() const override ;

--- a/roofit/roofitcore/inc/RooUniformBinning.h
+++ b/roofit/roofitcore/inc/RooUniformBinning.h
@@ -22,10 +22,10 @@
 class RooUniformBinning : public RooAbsBinning {
 public:
 
-  RooUniformBinning(const char* name=0) ;
-  RooUniformBinning(double xlo, double xhi, Int_t nBins, const char* name=0) ;
-  RooUniformBinning(const RooUniformBinning& other, const char* name=0) ;
-  RooAbsBinning* clone(const char* name=0) const override { return new RooUniformBinning(*this,name?name:GetName()) ; }
+  RooUniformBinning(const char* name=nullptr) ;
+  RooUniformBinning(double xlo, double xhi, Int_t nBins, const char* name=nullptr) ;
+  RooUniformBinning(const RooUniformBinning& other, const char* name=nullptr) ;
+  RooAbsBinning* clone(const char* name=nullptr) const override { return new RooUniformBinning(*this,name?name:GetName()) ; }
   ~RooUniformBinning() override ;
 
   void setRange(double xlo, double xhi) override ;

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -44,23 +44,23 @@ public:
   RooVectorDataStore() ;
 
   // Empty ctor
-  RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=0) ;
+  RooVectorDataStore(RooStringView name, RooStringView title, const RooArgSet& vars, const char* wgtVarName=nullptr) ;
 
-  RooAbsDataStore* clone(const char* newname=0) const override { return new RooVectorDataStore(*this,newname) ; }
-  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=0) const override { return new RooVectorDataStore(*this,vars,newname) ; }
+  RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooVectorDataStore(*this,newname) ; }
+  RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooVectorDataStore(*this,vars,newname) ; }
 
   RooAbsDataStore* reduce(RooStringView name, RooStringView title,
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 
-  RooVectorDataStore(const RooVectorDataStore& other, const char* newname=0) ;
-  RooVectorDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=0) ;
-  RooVectorDataStore(const RooVectorDataStore& other, const RooArgSet& vars, const char* newname=0) ;
+  RooVectorDataStore(const RooVectorDataStore& other, const char* newname=nullptr) ;
+  RooVectorDataStore(const RooTreeDataStore& other, const RooArgSet& vars, const char* newname=nullptr) ;
+  RooVectorDataStore(const RooVectorDataStore& other, const RooArgSet& vars, const char* newname=nullptr) ;
 
 
   RooVectorDataStore(RooStringView name, RooStringView title, RooAbsDataStore& tds,
                      const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
-                     std::size_t nStart, std::size_t nStop, const char* wgtVarName=0) ;
+                     std::size_t nStart, std::size_t nStop, const char* wgtVarName=nullptr) ;
 
   ~RooVectorDataStore() override ;
 
@@ -163,7 +163,7 @@ public:
 
   // Constant term  optimizer interface
   const RooAbsArg* cacheOwner() override { return _cacheOwner ; }
-  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=0, bool skipZeroWeights=true) override;
+  void cacheArgs(const RooAbsArg* owner, RooArgSet& varSet, const RooArgSet* nset=nullptr, bool skipZeroWeights=true) override;
   void attachCache(const RooAbsArg* newOwner, const RooArgSet& cachedVars) override;
   void resetCache() override;
   void recalculateCache(const RooArgSet* /*proj*/, Int_t firstEvent, Int_t lastEvent, Int_t stepSize, bool skipZeroWeights) override;
@@ -172,7 +172,7 @@ public:
 
   const RooVectorDataStore* cache() const { return _cache ; }
 
-  void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=0, const char* rangeName=0, std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
+  void loadValues(const RooAbsDataStore *tds, const RooFormulaVar* select=nullptr, const char* rangeName=nullptr, std::size_t nStart=0, std::size_t nStop = std::numeric_limits<std::size_t>::max()) override;
 
   void dump() override;
 
@@ -211,7 +211,7 @@ public:
       if (_nset) delete _nset ;
     }
 
-    RealVector(const RealVector& other, RooAbsReal* real=0) :
+    RealVector(const RealVector& other, RooAbsReal* real=nullptr) :
       _vec(other._vec), _nativeReal(real?real:other._nativeReal), _real(real?real:other._real), _buf(other._buf), _nativeBuf(other._nativeBuf), _nset(0) {
       if (other._tracker) {
         _tracker = new RooChangeTracker(Form("track_%s",_nativeReal->GetName()),"tracker",other._tracker->parameters()) ;
@@ -251,12 +251,12 @@ public:
     void setBuffer(RooAbsReal* real, double* newBuf) {
       _real = real ;
       _buf = newBuf ;
-      if (_nativeBuf==0) {
+      if (_nativeBuf==nullptr) {
         _nativeBuf=newBuf ;
       }
     }
 
-    void setNativeBuffer(double* newBuf=0) {
+    void setNativeBuffer(double* newBuf=nullptr) {
       _nativeBuf = newBuf ? newBuf : _buf ;
     }
 
@@ -364,7 +364,7 @@ public:
       if (_vecEH) delete _vecEH ;
     }
 
-    RealFullVector(const RealFullVector& other, RooAbsReal* real=0) : RealVector(other,real),
+    RealFullVector(const RealFullVector& other, RooAbsReal* real=nullptr) : RealVector(other,real),
       _bufE(other._bufE), _bufEL(other._bufEL), _bufEH(other._bufEH),
       _nativeBufE(other._nativeBufE), _nativeBufEL(other._nativeBufEL), _nativeBufEH(other._nativeBufEH) {
       _vecE = (other._vecE) ? new std::vector<double>(*other._vecE) : 0 ;
@@ -372,7 +372,7 @@ public:
       _vecEH = (other._vecEH) ? new std::vector<double>(*other._vecEH) : 0 ;
     }
 
-    RealFullVector(const RealVector& other, RooAbsReal* real=0) : RealVector(other,real),
+    RealFullVector(const RealVector& other, RooAbsReal* real=nullptr) : RealVector(other,real),
       _bufE(0), _bufEL(0), _bufEH(0),
       _nativeBufE(0), _nativeBufEL(0), _nativeBufEH(0) {
       _vecE = 0 ;

--- a/roofit/roofitcore/inc/RooWorkspace.h
+++ b/roofit/roofitcore/inc/RooWorkspace.h
@@ -45,11 +45,11 @@ public:
 
   RooWorkspace() ;
   RooWorkspace(const char* name, bool doCINTExport) ;
-  RooWorkspace(const char* name, const char* title=0) ;
+  RooWorkspace(const char* name, const char* title=nullptr) ;
   RooWorkspace(const RooWorkspace& other) ;
   ~RooWorkspace() override ;
 
-  void exportToCint(const char* namespaceName=0) ;
+  void exportToCint(const char* namespaceName=nullptr) ;
 
   bool importClassCode(const char* pat="*", bool doReplace=false) ;
   bool importClassCode(TClass* theClass, bool doReplace=false) ;
@@ -153,13 +153,13 @@ public:
   void clearStudies() ;
 
   // Print function
-  void Print(Option_t* opts=0) const override ;
+  void Print(Option_t* opts=nullptr) const override ;
 
   static void autoImportClassCode(bool flag) ;
 
   static void addClassDeclImportDir(const char* dir) ;
   static void addClassImplImportDir(const char* dir) ;
-  static void setClassFileExportDir(const char* dir=0) ;
+  static void setClassFileExportDir(const char* dir=nullptr) ;
 
   const TUUID& uuid() const { return _uuid ; }
 
@@ -167,9 +167,9 @@ public:
 
   class CodeRepo : public TObject {
   public:
-    CodeRepo(RooWorkspace* wspace=0) : _wspace(wspace), _compiledOK(true) {} ;
+    CodeRepo(RooWorkspace* wspace=nullptr) : _wspace(wspace), _compiledOK(true) {} ;
 
-    CodeRepo(const CodeRepo& other, RooWorkspace* wspace=0) : TObject(other) ,
+    CodeRepo(const CodeRepo& other, RooWorkspace* wspace=nullptr) : TObject(other) ,
           _wspace(wspace?wspace:other._wspace),
           _c2fmap(other._c2fmap),
           _fmap(other._fmap),

--- a/roofit/roofitcore/inc/RooWrapperPdf.h
+++ b/roofit/roofitcore/inc/RooWrapperPdf.h
@@ -48,17 +48,17 @@ public:
     return _func.arg().forceAnalyticalInt(dep);
   }
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars, const RooArgSet* normSet,
-      const char* rangeName=0) const override {
+      const char* rangeName=nullptr) const override {
     return _func.arg().getAnalyticalIntegralWN(allVars, analVars, normSet, rangeName);
   }
   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& numVars,
-      const char* rangeName=0) const override {
+      const char* rangeName=nullptr) const override {
     return _func.arg().getAnalyticalIntegral(allVars, numVars, rangeName);
   }
   double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName) const override {
     return _func.arg().analyticalIntegralWN(code, normSet, rangeName);
   }
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override {
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override {
     return _func.arg().analyticalIntegral(code, rangeName);
   }
 

--- a/roofit/roofitcore/inc/RooXYChi2Var.h
+++ b/roofit/roofitcore/inc/RooXYChi2Var.h
@@ -36,7 +36,7 @@ public:
   RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& data, bool integrate=false) ;
   RooXYChi2Var(const char *name, const char* title, RooAbsPdf& extPdf, RooDataSet& data, RooRealVar& yvar, bool integrate=false) ;
 
-  RooXYChi2Var(const RooXYChi2Var& other, const char* name=0);
+  RooXYChi2Var(const RooXYChi2Var& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooXYChi2Var(*this,newname); }
 
   RooAbsTestStatistic* create(const char *name, const char *title, RooAbsReal& pdf, RooAbsData& adata,

--- a/roofit/roofitcore/src/RooFitLegacy/RooMultiCatIter.h
+++ b/roofit/roofitcore/src/RooFitLegacy/RooMultiCatIter.h
@@ -29,7 +29,7 @@ typedef RooAbsCategoryLValue* pRooCategory ;
 class RooMultiCatIter : public TIterator {
 public:
   // Constructors, assignment etc.
-  RooMultiCatIter(const RooArgSet& catList, const char* rangeName=0) ;
+  RooMultiCatIter(const RooArgSet& catList, const char* rangeName=nullptr) ;
   RooMultiCatIter(const RooMultiCatIter& other) ;
   ~RooMultiCatIter() override ;
 

--- a/roofit/roofitmore/inc/RooAdaptiveGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/inc/RooAdaptiveGaussKronrodIntegrator1D.h
@@ -33,7 +33,7 @@ public:
   ~RooAdaptiveGaussKronrodIntegrator1D() override;
 
   bool checkLimits() const override;
-  double integral(const double *yvec=0) override ;
+  double integral(const double *yvec=nullptr) override ;
 
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double* xmin, double* xmax) override;

--- a/roofit/roofitmore/inc/RooGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/inc/RooGaussKronrodIntegrator1D.h
@@ -32,7 +32,7 @@ public:
   ~RooGaussKronrodIntegrator1D() override;
 
   bool checkLimits() const override;
-  double integral(const double *yvec=0) override ;
+  double integral(const double *yvec=nullptr) override ;
 
   using RooAbsIntegrator::setLimits ;
   bool setLimits(double* xmin, double* xmax) override;

--- a/roofit/roofitmore/inc/RooHypatia2.h
+++ b/roofit/roofitmore/inc/RooHypatia2.h
@@ -28,14 +28,14 @@ public:
   RooHypatia2(const char *name, const char *title,
          RooAbsReal& x, RooAbsReal& lambda, RooAbsReal& zeta, RooAbsReal& beta,
          RooAbsReal& sigma, RooAbsReal& mu, RooAbsReal& a, RooAbsReal& n, RooAbsReal& a2, RooAbsReal& n2);
-  RooHypatia2(const RooHypatia2& other, const char* name=0);
+  RooHypatia2(const RooHypatia2& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooHypatia2(*this,newname); }
   inline ~RooHypatia2() override { }
 
   /* Analytical integrals need testing.
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override;
 
   */
 

--- a/roofit/roofitmore/inc/RooLegendre.h
+++ b/roofit/roofitmore/inc/RooLegendre.h
@@ -30,8 +30,8 @@ public:
   TObject* clone(const char* newname) const override { return new RooLegendre(*this, newname); }
   inline ~RooLegendre() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getMaxVal( const RooArgSet& vars) const override;
   double maxVal( Int_t code) const override;

--- a/roofit/roofitmore/inc/RooNonCentralChiSquare.h
+++ b/roofit/roofitmore/inc/RooNonCentralChiSquare.h
@@ -24,7 +24,7 @@ public:
                           RooAbsReal& _x,
                           RooAbsReal& _k,
                           RooAbsReal& _lambda);
-   RooNonCentralChiSquare(const RooNonCentralChiSquare& other, const char* name=0) ;
+   RooNonCentralChiSquare(const RooNonCentralChiSquare& other, const char* name=nullptr) ;
    TObject* clone(const char* newname) const override { return new RooNonCentralChiSquare(*this,newname); }
    inline ~RooNonCentralChiSquare() override { }
 
@@ -33,8 +33,8 @@ public:
    void SetForceSum(bool flag);
 
 
-   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-   double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+   Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+   double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
 protected:
 

--- a/roofit/roofitmore/inc/RooSpHarmonic.h
+++ b/roofit/roofitmore/inc/RooSpHarmonic.h
@@ -27,8 +27,8 @@ public:
   TObject* clone(const char* newname) const override { return new RooSpHarmonic(*this, newname); }
   inline ~RooSpHarmonic() override { }
 
-  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=0) const override ;
-  double analyticalIntegral(Int_t code, const char* rangeName=0) const override ;
+  Int_t getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* rangeName=nullptr) const override ;
+  double analyticalIntegral(Int_t code, const char* rangeName=nullptr) const override ;
 
   Int_t getMaxVal( const RooArgSet& vars) const override;
   double maxVal( Int_t code) const override;

--- a/roofit/roostats/inc/RooStats/FrequentistCalculator.h
+++ b/roofit/roostats/inc/RooStats/FrequentistCalculator.h
@@ -29,7 +29,7 @@ namespace RooStats {
                         const RooAbsData &data,
                         const ModelConfig &altModel,
                         const ModelConfig &nullModel,
-                        TestStatSampler* sampler=0
+                        TestStatSampler* sampler=nullptr
       ) :
          HypoTestCalculatorGeneric(data, altModel, nullModel, sampler),
          fConditionalMLEsNull(nullptr),

--- a/roofit/roostats/inc/RooStats/HLFactory.h
+++ b/roofit/roostats/inc/RooStats/HLFactory.h
@@ -32,7 +32,7 @@ namespace RooStats {
 
     /// Constructor
     HLFactory(const char *name,
-              const char *fileName=0,
+              const char *fileName=nullptr,
               bool isVerbose = false);
 
     /// Constructor with external RooWorkspace
@@ -49,8 +49,8 @@ namespace RooStats {
     /// Add channel for the combination
     int AddChannel(const char* label,
                    const char* SigBkgPdfName,
-                   const char* BkgPdfName=0,
-                   const char* datasetName=0);
+                   const char* BkgPdfName=nullptr,
+                   const char* datasetName=nullptr);
 
     /// Dump the Workspace content as configuration file
     /* It needs some workspace object list or something..*/

--- a/roofit/roostats/inc/RooStats/Heaviside.h
+++ b/roofit/roostats/inc/RooStats/Heaviside.h
@@ -21,7 +21,7 @@ namespace RooStats {
       Heaviside(const char *name, const char *title,
             RooAbsReal& _x,
             RooAbsReal& _c);
-      Heaviside(const Heaviside& other, const char* name=0) ;
+      Heaviside(const Heaviside& other, const char* name=nullptr) ;
       TObject* clone(const char* newname) const override { return new Heaviside(*this,newname); }
       inline ~Heaviside() override { }
 

--- a/roofit/roostats/inc/RooStats/HybridCalculator.h
+++ b/roofit/roostats/inc/RooStats/HybridCalculator.h
@@ -26,7 +26,7 @@ namespace RooStats {
                         const RooAbsData &data,
                         const ModelConfig &altModel,
                         const ModelConfig &nullModel,
-                        TestStatSampler* sampler=0
+                        TestStatSampler* sampler=nullptr
       ) :
          HypoTestCalculatorGeneric(data, altModel, nullModel, sampler),
          fPriorNuisanceNull(MakeNuisancePdf(nullModel, "PriorNuisanceNull")),

--- a/roofit/roostats/inc/RooStats/HypoTestCalculatorGeneric.h
+++ b/roofit/roostats/inc/RooStats/HypoTestCalculatorGeneric.h
@@ -38,7 +38,7 @@ namespace RooStats {
                         const RooAbsData &data,
                         const ModelConfig &altModel,
                         const ModelConfig &nullModel,
-                        TestStatSampler* sampler=0
+                        TestStatSampler* sampler=nullptr
       );
 
 

--- a/roofit/roostats/inc/RooStats/HypoTestInverter.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverter.h
@@ -44,7 +44,7 @@ public:
 
    /// constructor from generic hypotest calculator
    HypoTestInverter( HypoTestCalculatorGeneric & hc,
-                     RooRealVar* scannedVariable =0,
+                     RooRealVar* scannedVariable =nullptr,
                      double size = 0.05) ;
 
 
@@ -97,9 +97,9 @@ public:
 
    bool RunOnePoint( double thisX, bool adaptive = false, double clTarget = -1 ) const;
 
-   //bool RunAutoScan( double xMin, double xMax, double target, double epsilon=0.005, unsigned int numAlgorithm=0 );
+   //bool RunAutoScan( double xMin, double xMax, double target, double epsilon=nullptr.005, unsigned int numAlgorithm=nullptr );
 
-   bool RunLimit(double &limit, double &limitErr, double absTol = 0, double relTol = 0, const double *hint=0) const;
+   bool RunLimit(double &limit, double &limitErr, double absTol = 0, double relTol = 0, const double *hint=nullptr) const;
 
    void UseCLs( bool on = true) { fUseCLs = on; if (fResults) fResults->UseCLs(on);   }
 

--- a/roofit/roostats/inc/RooStats/HypoTestInverterResult.h
+++ b/roofit/roostats/inc/RooStats/HypoTestInverterResult.h
@@ -157,7 +157,7 @@ public:
    double GetExpectedUpperLimit(double nsig = 0, const char * opt = "") const ;
 
 
-   double FindInterpolatedLimit(double target, bool lowSearch = false, double xmin=1, double xmax=0);
+   double FindInterpolatedLimit(double target, bool lowSearch = false, double xmin=1, double xmax=0.0);
 
    enum InterpolOption_t { kLinear, kSpline };
 
@@ -169,7 +169,7 @@ public:
 private:
 
 
-   double CalculateEstimatedError(double target, bool lower = true, double xmin = 1, double xmax = 0);
+   double CalculateEstimatedError(double target, bool lower = true, double xmin = 1, double xmax = 0.0);
 
    int FindClosestPointIndex(double target, int mode = 0, double xtarget = 0);
 

--- a/roofit/roostats/inc/RooStats/LikelihoodIntervalPlot.h
+++ b/roofit/roostats/inc/RooStats/LikelihoodIntervalPlot.h
@@ -70,7 +70,7 @@ namespace RooStats {
     /// if option "TF1" is used the objects are drawn using a TF1 scanning the LL function in a
     /// grid of the set points (by default
     /// the TF1 can be costumized by setting maximum and the number of points to scan
-    void Draw(const Option_t *options=0) override;
+    void Draw(const Option_t *options=nullptr) override;
 
   private:
 

--- a/roofit/roostats/inc/RooStats/ModelConfig.h
+++ b/roofit/roostats/inc/RooStats/ModelConfig.h
@@ -271,7 +271,7 @@ public:
 protected:
 
    /// helper function to check that content of a given set is exclusively parameters
-   bool SetHasOnlyParameters(const RooArgSet& set, const char* errorMsgPrefix=0) ;
+   bool SetHasOnlyParameters(const RooArgSet& set, const char* errorMsgPrefix=nullptr) ;
 
    /// helper functions to define a set in the WS
    void DefineSetInWS(const char* name, const RooArgSet& set);

--- a/roofit/roostats/inc/RooStats/NumberCountingUtils.h
+++ b/roofit/roostats/inc/RooStats/NumberCountingUtils.h
@@ -71,7 +71,7 @@ namespace RooStats{
    namespace  NumberCountingUtils {
 
 
-  /// Expected P-value for s=0 in a ratio of Poisson means.
+  /// Expected P-value for s=nullptr in a ratio of Poisson means.
   /// Here the background and its uncertainty are provided directly and
   /// assumed to be from the double Poisson counting setup described in the
   /// BinomialWithTau functions.
@@ -92,14 +92,14 @@ namespace RooStats{
   /// See BinomialExpP
      double BinomialExpP(double sExp, double bExp, double fractionalBUncertainty);
 
-  /// Expected P-value for s=0 in a ratio of Poisson means.
+  /// Expected P-value for s=nullptr in a ratio of Poisson means.
   /// Based on two expectations, a main measurement that might have signal
   /// and an auxiliary measurement for the background that is signal free.
   /// The expected background in the auxiliary measurement is a factor
   /// tau larger than in the main measurement.
      double BinomialWithTauExpP(double sExp, double bExp, double tau);
 
-  /// P-value for s=0 in a ratio of Poisson means.
+  /// P-value for s=nullptr in a ratio of Poisson means.
   /// Here the background and its uncertainty are provided directly and
   /// assumed to be from the double Poisson counting setup.
   /// Normally one would know tau directly, but here it is determined from
@@ -107,7 +107,7 @@ namespace RooStats{
   /// approximation.
      double BinomialObsP(double nObs, double, double fractionalBUncertainty);
 
-  /// P-value for s=0 in a ratio of Poisson means.
+  /// P-value for s=nullptr in a ratio of Poisson means.
   /// Based on two observations, a main measurement that might have signal
   /// and an auxiliary measurement for the background that is signal free.
   /// The expected background in the auxiliary measurement is a factor

--- a/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
+++ b/roofit/roostats/inc/RooStats/RatioOfProfiledLikelihoodsTestStat.h
@@ -37,7 +37,7 @@ namespace RooStats {
       }
 
       RatioOfProfiledLikelihoodsTestStat(RooAbsPdf& nullPdf, RooAbsPdf& altPdf,
-                                         const RooArgSet* altPOI=0) :
+                                         const RooArgSet* altPOI=nullptr) :
          fNullProfile(nullPdf),
          fAltProfile(altPdf),
          fSubtractMLE(true),

--- a/roofit/roostats/inc/RooStats/SamplingDistPlot.h
+++ b/roofit/roostats/inc/RooStats/SamplingDistPlot.h
@@ -54,7 +54,7 @@ namespace RooStats {
     /// set legend
     void SetLegend(TLegend* l){ fLegend = l; }
 
-    void Draw(Option_t *options=0) override;
+    void Draw(Option_t *options=nullptr) override;
 
     /// Applies a predefined style if fApplyStyle is true (default).
     void ApplyDefaultStyle(void);
@@ -129,8 +129,8 @@ namespace RooStats {
 
     void SetSampleWeights(const SamplingDistribution *samplingDist);
 
-    void addObject(TObject *obj, Option_t *drawOptions=0); // for TH1Fs only
-    void addOtherObject(TObject *obj, Option_t *drawOptions=0);
+    void addObject(TObject *obj, Option_t *drawOptions=nullptr); // for TH1Fs only
+    void addOtherObject(TObject *obj, Option_t *drawOptions=nullptr);
     void GetAbsoluteInterval(double &theMin, double &theMax, double &theYMax) const;
 
     ClassDefOverride(SamplingDistPlot,2)  /// Class containing the results of the HybridCalculator


### PR DESCRIPTION
This is not only modernizing the RooFit code, but also improving the
documentation because the default parameter values are also listed in
the doxygen.

By using the `nullptr` instead of the `0` literal for default pointer
parameters in the documentation, the users are also taught to write
better C++.

In some places, this commit also changed from `0` to `0.0` for default
floating point values for the same reasons.