### PR TITLE
Fix computation of the radiation length and nuclear interaction lengt…

### DIFF
--- a/geom/geom/src/TGeoMaterial.cxx
+++ b/geom/geom/src/TGeoMaterial.cxx
@@ -466,25 +466,18 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
    }
    TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
    // compute radlen systematically with G3 formula for a valid material
-   if ( typ == TGeoManager::kRootUnits && radlen>=0 ) {
+   if (radlen >= 0) {
       //taken grom Geant3 routine GSMATE
-      constexpr Double_t alr2av = 1.39621E-03*TGeoUnit::cm2;
+      constexpr Double_t alr2av = 1.39621E-03;
       constexpr Double_t al183  = 5.20948;
       fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
                    (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
-      fRadLen *= TGeoUnit::cm;
-   }
-   else if ( typ == TGeoManager::kG4Units && radlen>=0 ) {
-      //taken grom Geant3 routine GSMATE
-      constexpr Double_t alr2av = 1.39621E-03*TGeant4Unit::cm2;
-      constexpr Double_t al183  = 5.20948;
-      fRadLen = fA/(alr2av*fDensity*fZ*(fZ +TGeoMaterial::ScreenFactor(fZ))*
-                   (al183-TMath::Log(fZ)/3-TGeoMaterial::Coulomb(fZ)));
-      fRadLen *= TGeant4Unit::cm;
+      // fRadLen is in TGeo units. Apply conversion factor in requested length-units
+      fRadLen *= (typ == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    }
    // Compute interaction length using the same formula as in GEANT4
-   if ( typ == TGeoManager::kRootUnits && intlen>=0 ) {
-      constexpr Double_t lambda0 = 35.*TGeoUnit::g/TGeoUnit::cm2;  // [g/cm^2]
+   if (intlen >= 0) {
+      constexpr Double_t lambda0 = 35. * TGeoUnit::g / TGeoUnit::cm2; // [g/cm^2]
       Double_t nilinv = 0.0;
       TGeoElement *elem = GetElement();
       if (!elem) {
@@ -493,21 +486,10 @@ void TGeoMaterial::SetRadLen(Double_t radlen, Double_t intlen)
       }
       Double_t nbAtomsPerVolume = TGeoUnit::Avogadro*fDensity/elem->A();
       nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
-      nilinv *= TGeoUnit::amu/lambda0;
-      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (TGeoUnit::cm/nilinv);
-   }
-   else if ( typ == TGeoManager::kG4Units && intlen>=0 ) {
-      constexpr Double_t lambda0 = 35.*TGeant4Unit::g/TGeant4Unit::cm2;  // [g/cm^2]
-      Double_t nilinv = 0.0;
-      TGeoElement *elem = GetElement();
-      if (!elem) {
-         Fatal("SetRadLen", "Element not found for material %s", GetName());
-         return;
-      }
-      Double_t nbAtomsPerVolume = TGeant4Unit::Avogadro*fDensity/elem->A();
-      nilinv += nbAtomsPerVolume*TMath::Power(elem->Neff(), 0.6666667);
-      nilinv *= TGeant4Unit::amu/lambda0;
-      fIntLen = (nilinv<=0) ? TGeoShape::Big() : (TGeant4Unit::cm/nilinv);
+      nilinv *= TGeoUnit::amu / lambda0;
+      fIntLen = (nilinv <= 0) ? TGeoShape::Big() : (1.0 / nilinv);
+      // fIntLen is in TGeo units. Apply conversion factor in requested length-units
+      fIntLen *= (typ == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    }
 }
 
@@ -778,15 +760,10 @@ TGeoMixture::~TGeoMixture()
 
 void TGeoMixture::AverageProperties()
 {
-   TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
-   const Double_t cm   = (typ==TGeoManager::kRootUnits) ? TGeoUnit::cm   : TGeant4Unit::cm;
-   const Double_t cm2  = (typ==TGeoManager::kRootUnits) ? TGeoUnit::cm2  : TGeant4Unit::cm2;
-   const Double_t amu  = (typ==TGeoManager::kRootUnits) ? TGeoUnit::amu  : TGeant4Unit::amu; // [MeV/c^2]
-   const Double_t gram = (typ==TGeoManager::kRootUnits) ? TGeoUnit::gram : TGeant4Unit::gram;
-   const Double_t na   = (typ==TGeoManager::kRootUnits) ? TGeoUnit::Avogadro : TGeant4Unit::Avogadro;
-   const Double_t alr2av  = 1.39621E-03 * cm2;
-   const Double_t al183   = 5.20948;
-   const Double_t lambda0 = 35.*gram/cm2;  // [g/cm^2]
+   constexpr const Double_t na = TGeoUnit::Avogadro;
+   constexpr const Double_t alr2av = 1.39621E-03;
+   constexpr const Double_t al183 = 5.20948;
+   constexpr const Double_t lambda0 = 35. * TGeoUnit::g / TGeoUnit::cm2; // [g/cm^2]
    Double_t radinv = 0.0;
    Double_t nilinv = 0.0;
    Double_t nbAtomsPerVolume;
@@ -805,10 +782,15 @@ void TGeoMixture::AverageProperties()
       radinv += xinv*fWeights[j];
    }
    radinv *= alr2av*fDensity;
-   if (radinv > 0) fRadLen = cm/radinv;
+   fRadLen = (radinv <= 0) ? TGeoShape::Big() : 1.0 / radinv;
+   // fRadLen is in TGeo units. Apply conversion factor in requested length-units
+   fRadLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
+
    // Compute interaction length
-   nilinv *= amu/lambda0;
-   fIntLen = (nilinv<=0) ? TGeoShape::Big() : (cm/nilinv);
+   nilinv *= TGeoUnit::amu / lambda0;
+   fIntLen = (nilinv <= 0) ? TGeoShape::Big() : 1.0 / nilinv;
+   // fIntLen is in TGeo units. Apply conversion factor in requested length-units
+   fIntLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1290,12 +1272,14 @@ void TGeoMixture::ComputeDerivedQuantities()
 void TGeoMixture::ComputeRadiationLength()
 {
    // Formula taken from G4Material.cxx L556
-   const Double_t cm = (TGeoManager::GetDefaultUnits()==TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
    Double_t radinv = 0.0 ;
    for (Int_t i=0;i<fNelements;++i) {
-     radinv += fVecNbOfAtomsPerVolume[i]*((TGeoElement*)fElements->At(i))->GetfRadTsai();
+      //                                                                      GetfRadTsai is in units of cm2
+      radinv += fVecNbOfAtomsPerVolume[i] * ((TGeoElement *)fElements->At(i))->GetfRadTsai() / TGeoUnit::cm2;
    }
-   fRadLen = (radinv <= 0.0 ? DBL_MAX : cm/radinv);
+   fRadLen = (radinv <= 0.0 ? DBL_MAX : 1.0 / radinv);
+   // fRadLen is in TGeo units. Apply conversion factor in requested length-units
+   fRadLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1303,22 +1287,20 @@ void TGeoMixture::ComputeRadiationLength()
 void TGeoMixture::ComputeNuclearInterLength()
 {
    // Formula taken from G4Material.cxx L567
-   TGeoManager::EDefaultUnits typ = TGeoManager::GetDefaultUnits();
-   const Double_t g   = (typ==TGeoManager::kRootUnits) ? TGeoUnit::g   : TGeant4Unit::g;
-   const Double_t cm  = (typ==TGeoManager::kRootUnits) ? TGeoUnit::cm  : TGeant4Unit::cm;
-   const Double_t amu = (typ==TGeoManager::kRootUnits) ? TGeoUnit::amu : TGeant4Unit::amu;
-   const Double_t lambda0  = 35*g/(cm*cm);
+   constexpr Double_t lambda0 = 35. * TGeoUnit::g / TGeoUnit::cm2; // [g/cm^2]
    const Double_t twothird = 2.0/3.0;
    Double_t NILinv = 0.0;
    for (Int_t i=0; i<fNelements; ++i) {
-      Int_t Z = static_cast<Int_t>(((TGeoElement*)fElements->At(i))->Z()+0.5);
+      Int_t Z = static_cast<Int_t>(((TGeoElement *)fElements->At(i))->Z() + 0.5);
       Double_t A = ((TGeoElement*)fElements->At(i))->Neff();
       if(1 == Z) {
-         NILinv += fVecNbOfAtomsPerVolume[i]*A;
+         NILinv += fVecNbOfAtomsPerVolume[i] * A;
       } else {
-         NILinv += fVecNbOfAtomsPerVolume[i]*TMath::Exp(twothird*TMath::Log(A));
+         NILinv += fVecNbOfAtomsPerVolume[i] * TMath::Exp(twothird * TMath::Log(A));
       }
    }
-   NILinv *= amu/lambda0;
-   fIntLen = (NILinv <= 0.0 ? DBL_MAX : cm/NILinv);
+   NILinv *= TGeoUnit::amu / lambda0;
+   fIntLen = (NILinv <= 0.0 ? DBL_MAX : 1.0 / NILinv);
+   // fIntLen is in TGeo units. Apply conversion factor in requested length-units
+   fIntLen *= (TGeoManager::GetDefaultUnits() == TGeoManager::kRootUnits) ? TGeoUnit::cm : TGeant4Unit::cm;
 }


### PR DESCRIPTION
…… (#11060)

* Fix computation of the radiation length and nuclear interaction length when ROOT uses G4 units

* Fix computation of the radiation length and nuclear interaction length when ROOT uses G4 units

(cherry picked from commit 103bb7e4d930b4921debceec6ad7d418bacae4fc)

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #11080

