### PR TITLE
[TMVA][SOFIE] Fix copying shape tensor for reshape layer in SOFIE Keras parser

### DIFF
--- a/tmva/pymva/src/RModelParser_Keras.cxx
+++ b/tmva/pymva/src/RModelParser_Keras.cxx
@@ -128,9 +128,9 @@ void AddKerasLayer(RModel& rmodel, PyObject* fLayer){
       std::string fLayerName = PyStringAsString(PyDict_GetItemString(fAttributes,"_name"));
       PyObject* fPTargetShape = PyDict_GetItemString(fAttributes,"target_shape");
       std::vector<size_t>fTargetShape = GetDataFromTuple(fPTargetShape);
-      std::shared_ptr<void> fData(malloc(fTargetShape.size() * sizeof(float)), free);
-      std::memcpy(fData.get(),(float*)fTargetShape.data(), fTargetShape.size() * sizeof(float));
-      rmodel.AddInitializedTensor(fLayerName+"ReshapeAxes",ETensorType::FLOAT,{fTargetShape.size()},fData);
+      std::shared_ptr<void> fData(malloc(fTargetShape.size() * sizeof(int64_t)), free);
+      std::copy(fTargetShape.begin(),fTargetShape.end(),(int64_t*)fData.get());
+      rmodel.AddInitializedTensor(fLayerName+"ReshapeAxes",ETensorType::INT64,{fTargetShape.size()},fData);
    }
 
    //For layers without additional activation attribute

--- a/tmva/pymva/test/EmitFromKeras.cxx
+++ b/tmva/pymva/test/EmitFromKeras.cxx
@@ -45,6 +45,7 @@ int main(){
    RModel modelConv2D_Same = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelConv2D_Same.h5");
    modelConv2D_Same.Generate();
    modelConv2D_Same.OutputGenerated("KerasConv2D_Same.hxx");
+ 
    //Emitting header file for Keras model with Reshape layer
    RModel modelReshape = TMVA::Experimental::SOFIE::PyKeras::Parse("KerasModelReshape.h5");
    modelReshape.Generate();

--- a/tmva/pymva/test/TestRModelParserKeras.C
+++ b/tmva/pymva/test/TestRModelParserKeras.C
@@ -237,7 +237,10 @@ TEST(RModelParser_Keras, CONV_SAME)
 TEST(RModelParser_Keras, RESHAPE)
 {
     constexpr float TOLERANCE = DEFAULT_TOLERANCE;
-    float inputReshape[]={1,1,1,1};
+    float inputReshape[]={1,1,1,1,
+                          1,1,1,1,
+                          1,1,1,1,
+                          1,1,1,1};
     TMVA_SOFIE_KerasModelReshape::Session s("KerasReshapeModel.dat");
     std::vector<float> outputReshape = s.infer(inputReshape);
 
@@ -256,7 +259,7 @@ TEST(RModelParser_Keras, RESHAPE)
     PyRun_String("from tensorflow.keras.models import load_model",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("import numpy",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("model=load_model('KerasModelReshape.h5')",Py_single_input,fGlobalNS,fLocalNS);
-    PyRun_String("input=numpy.ones((1,4))",Py_single_input,fGlobalNS,fLocalNS);
+    PyRun_String("input=numpy.ones((1,4,4,1))",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("output=model(input).numpy()",Py_single_input,fGlobalNS,fLocalNS);
     PyRun_String("outputSize=output.size",Py_single_input,fGlobalNS,fLocalNS);
     std::size_t pOutputReshapeSize=(std::size_t)PyLong_AsLong(PyDict_GetItemString(fLocalNS,"outputSize"));

--- a/tmva/pymva/test/generateKerasModels.py
+++ b/tmva/pymva/test/generateKerasModels.py
@@ -78,12 +78,12 @@ def generateConv2DModel_SamePadding():
     
 def generateReshapeModel():
     model = Sequential()
-    model.add(Dense(3, input_shape=(4,)))
-    model.add(Reshape((3, 1)))
+    model.add(Conv2D(8, kernel_size=3, activation="relu", input_shape=(4,4,1), padding="same"))
+    model.add(Reshape((32,4)))
 
     randomGenerator=np.random.RandomState(0)
-    x_train=randomGenerator.rand(1,4)
-    y_train=randomGenerator.rand(1,3,1)
+    x_train=randomGenerator.rand(1,4,4,1)
+    y_train=randomGenerator.rand(1,32,4)
 
     model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
     model.fit(x_train, y_train, epochs=10, batch_size=2)

--- a/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Transpose.hxx
@@ -114,7 +114,7 @@ public:
       for (int k =0; k < dim; k++){
          // find value in fAtrrPerm corresponding to k
          int l = std::find(fAttrPerm.begin(), fAttrPerm.end(), k) - fAttrPerm.begin();
-         assert(l > 0 && l < dim);
+         assert(l >= 0 && l < dim);
          out << "( " << i_out[l] << " )";
          if (k < dim-1) {
             out << " * " << inStrides[k];


### PR DESCRIPTION
This PR fixes the way in which the shape tensor is extracted and then copied & added as an Initialized tensor in the RModel for the Reshape layer in SOFIE Keras parser.