### PR TITLE
[RF] New mechanism to create RooHistPdf/Func that own the RooDataHist

### DIFF
--- a/roofit/roofit/src/RooLagrangianMorphFunc.cxx
+++ b/roofit/roofit/src/RooLagrangianMorphFunc.cxx
@@ -798,12 +798,9 @@ void collectHistograms(const char *name, TDirectory *file, std::map<std::string,
          RooArgSet vars;
          vars.add(var);
 
-         // TODO: to fix the memory leak of this RooDataHist here, the best
-         // solution will be to follow up with a way for having the RooHistFunc
-         // own the underlying RooDataHist.
-         RooDataHist *dh = new RooDataHist(histname, histname, vars, hist.get());
+         auto dh = std::make_unique<RooDataHist>(histname, histname, vars, hist.get());
          // add it to the list
-         auto hf = std::make_unique<RooHistFunc>(funcname, funcname, var, *dh);
+         auto hf = std::make_unique<RooHistFunc>(funcname, funcname, var, std::move(dh));
          int idx = physics.getSize();
          list_hf[sample] = idx;
          physics.addOwned(std::move(hf));

--- a/roofit/roofitcore/inc/RooHistFunc.h
+++ b/roofit/roofitcore/inc/RooHistFunc.h
@@ -21,17 +21,22 @@
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
 #include "RooTrace.h"
+#include "RooDataHist.h"
+
 #include <list>
 
 class RooRealVar;
 class RooAbsReal;
-class RooDataHist ;
 
 class RooHistFunc : public RooAbsReal {
 public:
-  RooHistFunc() ;
+  RooHistFunc() {}
   RooHistFunc(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistFunc(const char *name, const char *title, const RooArgList& funcObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
+  RooHistFunc(const char *name, const char *title, const RooArgSet& vars,
+             std::unique_ptr<RooDataHist> dhist, int intOrder=0);
+  RooHistFunc(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs,
+             std::unique_ptr<RooDataHist> dhist, int intOrder=0);
   RooHistFunc(const RooHistFunc& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooHistFunc(*this,newname); }
   ~RooHistFunc() override ;
@@ -99,14 +104,15 @@ protected:
 
   void ioStreamerPass2() override ;
 
-  RooArgSet         _histObsList ;   ///< List of observables defining dimensions of histogram
-  RooSetProxy       _depList ;       ///< List of observables mapped onto histogram observables
-  RooDataHist*      _dataHist ;      ///< Unowned pointer to underlying histogram
-  mutable RooAICRegistry _codeReg ;  ///<! Auxiliary class keeping tracking of analytical integration code
-  Int_t             _intOrder ;      ///< Interpolation order
-  bool            _cdfBoundaries ; ///< Use boundary conditions for CDFs.
-  mutable double  _totVolume ;     ///<! Total volume of space (product of ranges of observables)
-  bool            _unitNorm  ;     ///<! Assume contents is unit normalized (for use as pdf cache)
+  RooArgSet _histObsList;                      ///< List of observables defining dimensions of histogram
+  RooSetProxy _depList;                        ///< List of observables mapped onto histogram observables
+  RooDataHist* _dataHist = nullptr;            ///< Unowned pointer to underlying histogram
+  std::unique_ptr<RooDataHist> _ownedDataHist; ///<! Owned pointer to underlying histogram
+  mutable RooAICRegistry _codeReg;             ///<! Auxiliary class keeping tracking of analytical integration code
+  Int_t _intOrder = 0;                         ///< Interpolation order
+  bool _cdfBoundaries = false;                 ///< Use boundary conditions for CDFs.
+  mutable double _totVolume = 0.0;             ///<! Total volume of space (product of ranges of observables)
+  bool _unitNorm = false;                      ///<! Assume contents is unit normalized (for use as pdf cache)
 
   ClassDefOverride(RooHistFunc,2) // Histogram based function
 };

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -20,17 +20,22 @@
 #include "RooRealProxy.h"
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
+#include "RooDataHist.h"
+
 #include <list>
 
 class RooRealVar;
 class RooAbsReal;
-class RooDataHist ;
 
 class RooHistPdf : public RooAbsPdf {
 public:
-  RooHistPdf() ;
+  RooHistPdf() {}
   RooHistPdf(const char *name, const char *title, const RooArgSet& vars, const RooDataHist& dhist, Int_t intOrder=0);
   RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs, const RooDataHist& dhist, Int_t intOrder=0);
+  RooHistPdf(const char *name, const char *title, const RooArgSet& vars,
+             std::unique_ptr<RooDataHist> dhist, int intOrder=0);
+  RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs,
+             std::unique_ptr<RooDataHist> dhist, int intOrder=0);
   RooHistPdf(const RooHistPdf& other, const char* name=nullptr);
   TObject* clone(const char* newname) const override { return new RooHistPdf(*this,newname); }
   ~RooHistPdf() override ;
@@ -109,14 +114,15 @@ protected:
   friend class RooAbsCachedPdf ;
   double totVolume() const ;
 
-  RooArgSet         _histObsList ;   ///< List of observables defining dimensions of histogram
-  RooSetProxy       _pdfObsList ;    ///< List of observables mapped onto histogram observables
-  RooDataHist*      _dataHist ;      ///< Unowned pointer to underlying histogram
-  mutable RooAICRegistry _codeReg ;  ///<! Auxiliary class keeping tracking of analytical integration code
-  Int_t             _intOrder ;      ///< Interpolation order
-  bool            _cdfBoundaries ; ///< Use boundary conditions for CDFs.
-  mutable double  _totVolume ;     ///<! Total volume of space (product of ranges of observables)
-  bool            _unitNorm  ;     ///< Assume contents is unit normalized (for use as pdf cache)
+  RooArgSet _histObsList;                      ///< List of observables defining dimensions of histogram
+  RooSetProxy _pdfObsList;                     ///< List of observables mapped onto histogram observables
+  RooDataHist* _dataHist = nullptr;            ///< Unowned pointer to underlying histogram
+  std::unique_ptr<RooDataHist> _ownedDataHist; ///<! Owned pointer to underlying histogram
+  mutable RooAICRegistry _codeReg ;            ///<! Auxiliary class keeping tracking of analytical integration code
+  Int_t _intOrder = 0;                         ///< Interpolation order
+  bool _cdfBoundaries = false;                 ///< Use boundary conditions for CDFs.
+  mutable double _totVolume = 0.0;             ///<! Total volume of space (product of ranges of observables)
+  bool _unitNorm  = false;                     ///< Assume contents is unit normalized (for use as pdf cache)
 
   ClassDefOverride(RooHistPdf,4) // Histogram based PDF
 };

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -41,22 +41,6 @@ discrete dimensions and may have negative values.
 using namespace std;
 
 ClassImp(RooHistFunc);
-;
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-
-RooHistFunc::RooHistFunc() :
-  _dataHist(0),
-  _intOrder(0),
-  _cdfBoundaries(false),
-  _totVolume(0),
-  _unitNorm(false)
-{
-  TRACE_CREATE
-}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -73,9 +57,7 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgSet& v
   _dataHist((RooDataHist*)&dhist),
   _codeReg(10),
   _intOrder(intOrder),
-  _cdfBoundaries(false),
-  _totVolume(0),
-  _unitNorm(false)
+  _cdfBoundaries(false)
 {
   _histObsList.addClone(vars) ;
   _depList.add(vars) ;
@@ -115,9 +97,7 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgList& 
   _dataHist((RooDataHist*)&dhist),
   _codeReg(10),
   _intOrder(intOrder),
-  _cdfBoundaries(false),
-  _totVolume(0),
-  _unitNorm(false)
+  _cdfBoundaries(false)
 {
   _histObsList.addClone(histObs) ;
   _depList.add(funcObs) ;
@@ -141,6 +121,21 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgList& 
   TRACE_CREATE
 }
 
+
+RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgSet& vars,
+           std::unique_ptr<RooDataHist> dhist, int intOrder)
+  : RooHistFunc{name, title, vars, *dhist, intOrder}
+{
+  _ownedDataHist = std::move(dhist);
+}
+
+
+RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs,
+           std::unique_ptr<RooDataHist> dhist, int intOrder)
+  : RooHistFunc{name, title, pdfObs, histObs, *dhist, intOrder}
+{
+  _ownedDataHist = std::move(dhist);
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -38,7 +38,6 @@ discrete dimensions and may have negative values.
 
 #include <stdexcept>
 
-using namespace std;
 
 ClassImp(RooHistFunc);
 
@@ -64,16 +63,16 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgSet& v
 
   // Verify that vars and dhist.get() have identical contents
   const RooArgSet* dvars = dhist.get() ;
-  if (vars.getSize()!=dvars->getSize()) {
+  if (vars.size()!=dvars->size()) {
     coutE(InputArguments) << "RooHistFunc::ctor(" << GetName()
-           << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
+           << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
     throw std::invalid_argument("RooHistFunc: ERROR variable list and RooDataHist must contain the same variables.");
   }
 
   for (const auto arg : vars) {
     if (!dvars->find(arg->GetName())) {
       coutE(InputArguments) << "RooHistFunc::ctor(" << GetName()
-             << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
+             << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
       throw std::invalid_argument("RooHistFunc: ERROR variable list and RooDataHist must contain the same variables.");
     }
   }
@@ -104,16 +103,16 @@ RooHistFunc::RooHistFunc(const char *name, const char *title, const RooArgList& 
 
   // Verify that vars and dhist.get() have identical contents
   const RooArgSet* dvars = dhist.get() ;
-  if (histObs.getSize()!=dvars->getSize()) {
+  if (histObs.size()!=dvars->size()) {
     coutE(InputArguments) << "RooHistFunc::ctor(" << GetName()
-           << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
+           << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
     throw std::invalid_argument("RooHistFunc: ERROR variable list and RooDataHist must contain the same variables.");
   }
 
   for (const auto arg : histObs) {
     if (!dvars->find(arg->GetName())) {
       coutE(InputArguments) << "RooHistFunc::ctor(" << GetName()
-             << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
+             << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
       throw std::invalid_argument("RooHistFunc: ERROR variable list and RooDataHist must contain the same variables.");
     }
   }
@@ -176,7 +175,7 @@ RooHistFunc::~RooHistFunc()
 double RooHistFunc::evaluate() const
 {
   // Transfer values from
-  if (_depList.getSize()>0) {
+  if (!_depList.empty()) {
     for (auto i = 0u; i < _histObsList.size(); ++i) {
       const auto harg = _histObsList[i];
       const auto parg = _depList[i];
@@ -234,7 +233,7 @@ void RooHistFunc::computeBatch(cudaStream_t*, double* output, size_t size, RooFi
 Int_t RooHistFunc::getMaxVal(const RooArgSet& vars) const
 {
   RooAbsCollection* common = _depList.selectCommon(vars) ;
-  if (common->getSize()==_depList.getSize()) {
+  if (common->size()==_depList.size()) {
     delete common ;
     return 1;
   }
@@ -313,7 +312,7 @@ double RooHistFunc::analyticalIntegral(Int_t code, const char* rangeName) const
 /// as the recursive division strategy of RooCurve cannot deal efficiently
 /// with the vertical lines that occur in a non-interpolated histogram
 
-list<double>* RooHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const
+std::list<double>* RooHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const
 {
   // No hints are required when interpolation is used
   if (_intOrder>1) {
@@ -322,11 +321,11 @@ list<double>* RooHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double xlo, d
 
 
   // Find histogram observable corresponding to pdf observable
-  RooAbsArg* hobs(0) ;
+  RooAbsArg* hobs = nullptr;
   for (auto i = 0u; i < _histObsList.size(); ++i) {
     const auto harg = _histObsList[i];
     const auto parg = _depList[i];
-    if (string(parg->GetName())==obs.GetName()) {
+    if (std::string(parg->GetName())==obs.GetName()) {
       hobs=harg ;
     }
   }
@@ -344,7 +343,7 @@ list<double>* RooHistFunc::plotSamplingHint(RooAbsRealLValue& obs, double xlo, d
   const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
   double* boundaries = binning->array() ;
 
-  list<double>* hint = new list<double> ;
+  auto hint = new std::list<double> ;
 
   // Widen range slighty
   xlo = xlo - 0.01*(xhi-xlo) ;
@@ -382,23 +381,23 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
   for (auto i = 0u; i < _histObsList.size(); ++i) {
     const auto harg = _histObsList[i];
     const auto parg = _depList[i];
-    if (string(parg->GetName())==obs.GetName()) {
+    if (std::string(parg->GetName())==obs.GetName()) {
       hobs=harg ;
     }
   }
 
-  // cout << "RooHistFunc::bb(" << GetName() << ") histObs = " << _histObsList << endl ;
-  // cout << "RooHistFunc::bb(" << GetName() << ") pdfObs = " << _depList << endl ;
+  // cout << "RooHistFunc::bb(" << GetName() << ") histObs = " << _histObsList << std::endl ;
+  // cout << "RooHistFunc::bb(" << GetName() << ") pdfObs = " << _depList << std::endl ;
 
-  RooAbsRealLValue* transform(0) ;
+  RooAbsRealLValue* transform = nullptr;
   if (!hobs) {
 
     // Considering alternate: input observable is histogram observable and pdf observable is transformation in terms of it
-    RooAbsArg* pobs(0) ;
+    RooAbsArg* pobs = nullptr;
     for (auto i = 0u; i < _histObsList.size(); ++i) {
       const auto harg = _histObsList[i];
       const auto parg = _depList[i];
-      if (string(harg->GetName())==obs.GetName()) {
+      if (std::string(harg->GetName())==obs.GetName()) {
         pobs=parg ;
         hobs=harg ;
       }
@@ -406,7 +405,7 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
 
     // Not found, or check that matching pdf observable is an l-value dependent on histogram observable fails
     if (!hobs || !(pobs->dependsOn(obs) && dynamic_cast<RooAbsRealLValue*>(pobs))) {
-      cout << "RooHistFunc::binBoundaries(" << GetName() << ") obs = " << obs.GetName() << " hobs is not found, returning null" << endl ;
+      std::cout << "RooHistFunc::binBoundaries(" << GetName() << ") obs = " << obs.GetName() << " hobs is not found, returning null" << std::endl ;
       return 0 ;
     }
 
@@ -416,19 +415,19 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
   }
 
 
-  // cout << "hobs = " << hobs->GetName() << endl ;
-  // cout << "transform = " << (transform?transform->GetName():"<none>") << endl ;
+  // cout << "hobs = " << hobs->GetName() << std::endl ;
+  // cout << "transform = " << (transform?transform->GetName():"<none>") << std::endl ;
 
   // Check that observable is in dataset, if not no hint is generated
   RooAbsArg* xtmp = _dataHist->get()->find(hobs->GetName()) ;
   if (!xtmp) {
-    cout << "RooHistFunc::binBoundaries(" << GetName() << ") hobs = " << hobs->GetName() << " is not found in dataset?" << endl ;
+    std::cout << "RooHistFunc::binBoundaries(" << GetName() << ") hobs = " << hobs->GetName() << " is not found in dataset?" << std::endl ;
     _dataHist->get()->Print("v") ;
     return 0 ;
   }
   RooAbsLValue* lvarg = dynamic_cast<RooAbsLValue*>(_dataHist->get()->find(hobs->GetName())) ;
   if (!lvarg) {
-    cout << "RooHistFunc::binBoundaries(" << GetName() << ") hobs = " << hobs->GetName() << " but is not an LV, returning null" << endl ;
+    std::cout << "RooHistFunc::binBoundaries(" << GetName() << ") hobs = " << hobs->GetName() << " but is not an LV, returning null" << std::endl ;
     return 0 ;
   }
 
@@ -436,7 +435,7 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
   const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
   double* boundaries = binning->array() ;
 
-  list<double>* hint = new list<double> ;
+  auto hint = new std::list<double> ;
 
   double delta = (xhi-xlo)*1e-8 ;
 
@@ -448,7 +447,7 @@ std::list<double>* RooHistFunc::binBoundaries(RooAbsRealLValue& obs, double xlo,
       double boundary = boundaries[i] ;
       if (transform) {
    transform->setVal(boundary) ;
-   //cout << "transform bound " << boundary << " using " << transform->GetName() << " result " << obs.getVal() << endl ;
+   //cout << "transform bound " << boundary << " using " << transform->GetName() << " result " << obs.getVal() << std::endl ;
    hint->push_back(obs.getVal()) ;
       } else {
    hint->push_back(boundary) ;
@@ -485,25 +484,25 @@ bool RooHistFunc::importWorkspaceHook(RooWorkspace& ws)
       } else {
 
         // not identical, clone rename and import
-        TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
-        bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
+        auto uniqueName = std::string(_dataHist->GetName()) + "_" + GetName();
+        bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.c_str()),RooFit::Embedded()) ;
         if (flag) {
-          coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
+          coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
           return true ;
         }
-        _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
+        _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.c_str()) ;
       }
 
     } else {
 
       // Exists and is NOT of correct type: clone rename and import
-      TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
-      bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
+      auto uniqueName = std::string(_dataHist->GetName()) + "_" + GetName();
+      bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.c_str()),RooFit::Embedded()) ;
       if (flag) {
-        coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
+        coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
         return true ;
       }
-      _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
+      _dataHist = static_cast<RooDataHist*>(ws.embeddedData(uniqueName.c_str()));
 
     }
     return false ;

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -44,18 +44,6 @@ using namespace std;
 ClassImp(RooHistPdf);
 
 
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-/// coverity[UNINIT_CTOR]
-
-RooHistPdf::RooHistPdf() : _dataHist(0), _totVolume(0), _unitNorm(false)
-{
-
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor from a RooDataHist. RooDataHist dimensions
 /// can be either real or discrete. See RooDataHist::RooDataHist for details on the binning.
@@ -69,9 +57,7 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgSet& var
   _dataHist((RooDataHist*)&dhist),
   _codeReg(10),
   _intOrder(intOrder),
-  _cdfBoundaries(false),
-  _totVolume(0),
-  _unitNorm(false)
+  _cdfBoundaries(false)
 {
   _histObsList.addClone(vars) ;
   _pdfObsList.add(vars) ;
@@ -121,9 +107,7 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList& pd
   _dataHist((RooDataHist*)&dhist),
   _codeReg(10),
   _intOrder(intOrder),
-  _cdfBoundaries(false),
-  _totVolume(0),
-  _unitNorm(false)
+  _cdfBoundaries(false)
 {
   _histObsList.addClone(histObs) ;
   _pdfObsList.add(pdfObs) ;
@@ -161,6 +145,19 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList& pd
   }
 }
 
+
+RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgSet& vars,
+           std::unique_ptr<RooDataHist> dhist, int intOrder)
+  : RooHistPdf{name, title, vars, *dhist, intOrder}
+{
+  _ownedDataHist = std::move(dhist);
+}
+RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList& pdfObs, const RooArgList& histObs,
+           std::unique_ptr<RooDataHist> dhist, int intOrder)
+  : RooHistPdf{name, title, pdfObs, histObs, *dhist, intOrder}
+{
+  _ownedDataHist = std::move(dhist);
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -39,7 +39,6 @@ discrete dimensions.
 #include "TError.h"
 #include "TBuffer.h"
 
-using namespace std;
 
 ClassImp(RooHistPdf);
 
@@ -64,15 +63,15 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgSet& var
 
   // Verify that vars and dhist.get() have identical contents
   const RooArgSet* dvars = dhist.get() ;
-  if (vars.getSize()!=dvars->getSize()) {
+  if (vars.size()!=dvars->size()) {
     coutE(InputArguments) << "RooHistPdf::ctor(" << GetName()
-           << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
+           << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
     assert(0) ;
   }
   for (const auto arg : vars) {
     if (!dvars->find(arg->GetName())) {
       coutE(InputArguments) << "RooHistPdf::ctor(" << GetName()
-             << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
+             << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
       assert(0) ;
     }
   }
@@ -114,22 +113,22 @@ RooHistPdf::RooHistPdf(const char *name, const char *title, const RooArgList& pd
 
   // Verify that vars and dhist.get() have identical contents
   const RooArgSet* dvars = dhist.get() ;
-  if (histObs.getSize()!=dvars->getSize()) {
+  if (histObs.size()!=dvars->size()) {
     coutE(InputArguments) << "RooHistPdf::ctor(" << GetName()
-           << ") ERROR histogram variable list and RooDataHist must contain the same variables." << endl ;
-    throw(string("RooHistPdf::ctor() ERROR: histogram variable list and RooDataHist must contain the same variables")) ;
+           << ") ERROR histogram variable list and RooDataHist must contain the same variables." << std::endl ;
+    throw(std::string("RooHistPdf::ctor() ERROR: histogram variable list and RooDataHist must contain the same variables")) ;
   }
 
   for (const auto arg : histObs) {
     if (!dvars->find(arg->GetName())) {
       coutE(InputArguments) << "RooHistPdf::ctor(" << GetName()
-             << ") ERROR variable list and RooDataHist must contain the same variables." << endl ;
-      throw(string("RooHistPdf::ctor() ERROR: histogram variable list and RooDataHist must contain the same variables")) ;
+             << ") ERROR variable list and RooDataHist must contain the same variables." << std::endl ;
+      throw(std::string("RooHistPdf::ctor() ERROR: histogram variable list and RooDataHist must contain the same variables")) ;
     }
     if (!arg->isFundamental()) {
       coutE(InputArguments) << "RooHistPdf::ctor(" << GetName()
-             << ") ERROR all elements of histogram observables set must be of type RooRealVar or RooCategory." << endl ;
-      throw(string("RooHistPdf::ctor() ERROR all elements of histogram observables set must be of type RooRealVar or RooCategory.")) ;
+             << ") ERROR all elements of histogram observables set must be of type RooRealVar or RooCategory." << std::endl ;
+      throw(std::string("RooHistPdf::ctor() ERROR all elements of histogram observables set must be of type RooRealVar or RooCategory.")) ;
     }
   }
 
@@ -312,7 +311,7 @@ double RooHistPdf::analyticalIntegral(Int_t code,
                                         RooDataHist& dataHist,
                                         bool histFuncMode) {
   // Simplest scenario, full-range integration over all dependents
-  if (((2 << histObsList.getSize()) - 1) == code) {
+  if (((2 << histObsList.size()) - 1) == code) {
     return dataHist.sum(histFuncMode);
   }
 
@@ -373,7 +372,7 @@ double RooHistPdf::analyticalIntegral(Int_t code, const char* rangeName) const
 /// as the recursive division strategy of RooCurve cannot deal efficiently
 /// with the vertical lines that occur in a non-interpolated histogram
 
-list<double>* RooHistPdf::plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const
+std::list<double>* RooHistPdf::plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const
 {
   // No hints are required when interpolation is used
   if (_intOrder>0) {
@@ -385,18 +384,18 @@ list<double>* RooHistPdf::plotSamplingHint(RooAbsRealLValue& obs, double xlo, do
   for (unsigned int i=0; i < _pdfObsList.size(); ++i) {
     RooAbsArg* histObs = _histObsList[i];
     RooAbsArg* pdfObs = _pdfObsList[i];
-    if (TString(obs.GetName())==pdfObs->GetName()) {
+    if (std::string(obs.GetName())==pdfObs->GetName()) {
       dhObs = _dataHist->get()->find(histObs->GetName()) ;
       break;
     }
   }
 
   if (!dhObs) {
-    return 0 ;
+    return nullptr;
   }
   RooAbsLValue* lval = dynamic_cast<RooAbsLValue*>(dhObs) ;
   if (!lval) {
-    return 0 ;
+    return nullptr;
   }
 
   // Retrieve position of all bin boundaries
@@ -404,7 +403,7 @@ list<double>* RooHistPdf::plotSamplingHint(RooAbsRealLValue& obs, double xlo, do
   const RooAbsBinning* binning = lval->getBinningPtr(0) ;
   double* boundaries = binning->array() ;
 
-  list<double>* hint = new list<double> ;
+  auto hint = new std::list<double> ;
 
   // Widen range slighty
   xlo = xlo - 0.01*(xhi-xlo) ;
@@ -435,7 +434,7 @@ std::list<double>* RooHistPdf::binBoundaries(RooAbsRealLValue& obs, double xlo, 
 {
   // No hints are required when interpolation is used
   if (_intOrder>0) {
-    return 0 ;
+    return nullptr;
   }
 
   // Check that observable is in dataset, if not no hint is generated
@@ -448,7 +447,7 @@ std::list<double>* RooHistPdf::binBoundaries(RooAbsRealLValue& obs, double xlo, 
   const RooAbsBinning* binning = lvarg->getBinningPtr(0) ;
   double* boundaries = binning->array() ;
 
-  list<double>* hint = new list<double> ;
+  auto hint = new std::list<double> ;
 
   // Construct array with pairs of points positioned epsilon to the left and
   // right of the bin boundaries
@@ -469,12 +468,10 @@ std::list<double>* RooHistPdf::binBoundaries(RooAbsRealLValue& obs, double xlo, 
 
 Int_t RooHistPdf::getMaxVal(const RooArgSet& vars) const
 {
-  RooAbsCollection* common = _pdfObsList.selectCommon(vars) ;
-  if (common->getSize()==_pdfObsList.getSize()) {
-    delete common ;
+  std::unique_ptr<RooAbsCollection> common{_pdfObsList.selectCommon(vars)};
+  if (common->size()==_pdfObsList.size()) {
     return 1;
   }
-  delete common ;
   return 0 ;
 }
 
@@ -519,19 +516,15 @@ bool RooHistPdf::areIdentical(const RooDataHist& dh1, const RooDataHist& dh2)
 
 bool RooHistPdf::importWorkspaceHook(RooWorkspace& ws)
 {
-  std::list<RooAbsData*> allData = ws.allData() ;
-  std::list<RooAbsData*>::const_iterator iter ;
-  for (iter = allData.begin() ; iter != allData.end() ; ++iter) {
+  for(auto const& data : ws.allData()) {
     // If your dataset is already in this workspace nothing needs to be done
-    if (*iter == _dataHist) {
+    if (data == _dataHist) {
       return false ;
     }
   }
 
   // Check if dataset with given name already exists
-  RooAbsData* wsdata = ws.embeddedData(_dataHist->GetName()) ;
-
-  if (wsdata) {
+  if (RooAbsData* wsdata = ws.embeddedData(_dataHist->GetName())) {
 
     // Yes it exists - now check if it is identical to our internal histogram
     if (wsdata->InheritsFrom(RooDataHist::Class())) {
@@ -544,25 +537,25 @@ bool RooHistPdf::importWorkspaceHook(RooWorkspace& ws)
       } else {
 
    // not identical, clone rename and import
-   TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
-   bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
+   auto uniqueName = std::string(_dataHist->GetName()) + "_" + GetName();
+   bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.c_str()),RooFit::Embedded()) ;
    if (flag) {
-     coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
+     coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
      return true ;
    }
-   _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
+   _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.c_str()) ;
       }
 
     } else {
 
       // Exists and is NOT of correct type: clone rename and import
-      TString uniqueName = Form("%s_%s",_dataHist->GetName(),GetName()) ;
-      bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.Data()),RooFit::Embedded()) ;
+      auto uniqueName = std::string(_dataHist->GetName()) + "_" + GetName();
+      bool flag = ws.import(*_dataHist,RooFit::Rename(uniqueName.c_str()),RooFit::Embedded()) ;
       if (flag) {
-   coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << endl ;
+   coutE(ObjectHandling) << " RooHistPdf::importWorkspaceHook(" << GetName() << ") unable to import clone of underlying RooDataHist with unique name " << uniqueName << ", abort" << std::endl ;
    return true ;
       }
-      _dataHist = (RooDataHist*) ws.embeddedData(uniqueName.Data()) ;
+      _dataHist = static_cast<RooDataHist*>(ws.embeddedData(uniqueName.c_str()));
 
     }
     return false ;


### PR DESCRIPTION
It happens often that you want to create a RooDataHist just to serve a
RooHistPdf or a RooHistFunc. In this case, it is convenient for the
HistPdf/HistFunc to take ownership of the RooDataHist.

The cleanest way to implement this is probably via additional
constructors that take the RooDataHist via `std::unique_ptr`, such that
the ownership is always clear. A new transient member of
HistPdf/HistFunc is then taking over the ownership.

With this change, it is easy to fix one of the remaining memory leaks in
the RooLagrangianMorphFunc.

I second commit in this PR applies also some general code modernization to RooHistPdf and RooHistFunc.