### PR TITLE
[VecOps] Do not enforce const-ness in Map function parameters

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -99,8 +99,8 @@ std::size_t GetVectorsSize(const std::string &id, const RVec<T> &... vs)
    return sizes[0];
 }
 
-template <typename F, typename... T>
-auto MapImpl(F &&f, const RVec<T> &... vs) -> RVec<decltype(f(vs[0]...))>
+template <typename F, typename... RVecs>
+auto MapImpl(F &&f, RVecs &&... vs) -> RVec<decltype(f(vs[0]...))>
 {
    const auto size = GetVectorsSize("Map", vs...);
    RVec<decltype(f(vs[0]...))> ret(size);

--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -1204,6 +1204,28 @@ TEST(VecOps, Map)
    CheckEqual(res, ref);
 }
 
+TEST(VecOps, MapOnNestedVectors)
+{
+   RVec<RVecF> vecOfVecs = {{1.f, 2.f}, {3.f}, {}};
+   RVecI sizes = {2, 1, 0};
+
+   auto size_by_value = [](RVecF v) { return v.size(); };
+   auto result = Map(vecOfVecs, size_by_value);
+   CheckEqual(result, sizes);
+
+   auto size_by_cvalue = [](const RVecF v) { return v.size(); };
+   result = Map(vecOfVecs, size_by_cvalue);
+   CheckEqual(result, sizes);
+
+   auto size_by_ref = [](RVecF &v) { return v.size(); };
+   result = Map(vecOfVecs, size_by_ref);
+   CheckEqual(result, sizes);
+
+   auto size_by_cref = [](const RVecF &v) { return v.size(); };
+   result = Map(vecOfVecs, size_by_cref);
+   CheckEqual(result, sizes);
+}
+
 TEST(VecOps, Construct)
 {
    RVec<float> pts {15.5f, 34.32f, 12.95f};


### PR DESCRIPTION
Before this PR, the lambda passed to VecOps::Map could not
take arguments by non-const reference as the implementation was
adding a const qualifier to the RVec arguments.

We now instead forward RVecs from Map to MapImpl keeping their
cv qualifiers.

A test has been added.