### PR TITLE
[cmake] Protect against empty `COMPILE_DEFINITIONS` in rootcint command

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -628,7 +628,10 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
       # and list exclusion for generator expressions is too complex.
       set(module_incs $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:${ARG_MODULE},INCLUDE_DIRECTORIES>>)
       set(module_sysincs $<REMOVE_DUPLICATES:$<TARGET_PROPERTY:${ARG_MODULE},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>>)
-      set(module_defs $<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>)
+      # The COMPILE_DEFINITIONS list might contain empty elements. These are
+      # removed with the FILTER generator expression, excluding elements that
+      # match the ^$ regexp (only matches empty strings).
+      set(module_defs "$<FILTER:$<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>,EXCLUDE,^$>")
     endif()
   endif()
 


### PR DESCRIPTION
In the `rootcint` command defined in `RootMacros.cmake`, the
`COMPILE_DEFINITIONS` from the target are forwarded as compiler flags.

The `COMPILE_DEFINITIONS` are stored in the `module_defs` variable with
a generator expression:

```
set(module_defs $<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>)
```

Then, the definitions are added to the rootcint command with this
expression:

```
"$<$<BOOL:${module_defs}>:-D$<JOIN:${module_defs},;-D>>"
```

This code was almost copied exactly from the CMake documentation
example:

https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html

In particular, the `BOOL` check makes sure that the if the target
property is empty, we will not get a bare `-D` with nothing after it,
corrupting the rootcint command.

However, there is no protection against the case where the
`COMPILE_DEFINITIONS` target property is not empty, but its elements are
empty strings! This happened to me in my recent build.

Instead of trying to figure out where the empty strings are added to the
`COMPILE_DEFINITIONS`, it is better to also protect against empty target
property elements in the CMake generator expressions, which is
implemented in this commit.