### PR TITLE
[Minuit2] make the MnHesse implementation easily replaceable

### DIFF
--- a/math/minuit2/inc/Minuit2/MnHesse.h
+++ b/math/minuit2/inc/Minuit2/MnHesse.h
@@ -14,6 +14,7 @@
 #include "Minuit2/MnStrategy.h"
 
 #include <vector>
+#include <functional>
 
 namespace ROOT {
 
@@ -84,10 +85,12 @@ public:
    MinimumState
    operator()(const MnFcn &, const MinimumState &, const MnUserTransformation &, unsigned int maxcalls = 0) const;
 
-   /// forward interface of MnStrategy
-   unsigned int Ncycles() const { return fStrategy.HessianNCycles(); }
-   double Tolerstp() const { return fStrategy.HessianStepTolerance(); }
-   double TolerG2() const { return fStrategy.HessianG2Tolerance(); }
+   /// the internal interface function in turn calls this calculator, which can be set to something different by
+   /// users
+   static std::function<MinimumState(const MnStrategy &, const MnFcn &, const MinimumState &, const MnUserTransformation &, unsigned int)> calculator;
+   /// default calculator implementation
+   static MinimumState default_calculator(const MnStrategy &strategy, const MnFcn &mfcn, const MinimumState &st,
+                                          const MnUserTransformation &trafo, unsigned int maxcalls);
 
 private:
    MnStrategy fStrategy;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
The actual calculation of the Hessian / covariance matrix done by MnHesse was contained to a single function. Since the only needed internal state was the `MnStrategy` object, it was easy to turn this calculation function into a static member function.

The implementation of the "internal interface" (previously the calculation function) now forwards its call to a static class member `std::function` object. By default, this object is set to be the now-static calculation function. However, this `std::function` object is public, so users can easily replace it with any Hessian calculator function they prefer.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)