### PR TITLE
[RF] Replace some manually-allocated C-style arrays with `std::vector`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsGenContext.h
+++ b/roofit/roofitcore/inc/RooAbsGenContext.h
@@ -27,7 +27,6 @@ class RooAbsGenContext : public TNamed, public RooPrintable {
 public:
   RooAbsGenContext(const RooAbsPdf &model, const RooArgSet &vars, const RooDataSet *prototype= 0, const RooArgSet* auxProto=nullptr,
          bool _verbose= false) ;
-  ~RooAbsGenContext() override;
 
   virtual RooDataSet *generate(double nEvents= 0, bool skipInit=false, bool extendedMode=false);
 
@@ -82,7 +81,7 @@ protected:
   RooArgSet _protoVars;         ///< Prototype observables
   Int_t _nextProtoIndex;        ///< Next prototype event to load according to LUT
   RooAbsPdf::ExtendMode _extendMode ;  ///< Extended mode capabilities of p.d.f.
-  Int_t* _protoOrder ;          ///< LUT with traversal order of prototype data
+  std::vector<Int_t> _protoOrder ; ///< LUT with traversal order of prototype data
   TString _normRange ;          ///< Normalization range of pdf
 
   RooDataSet* _genData ;        ///<! Data being generated

--- a/roofit/roofitcore/inc/RooAdaptiveIntegratorND.h
+++ b/roofit/roofitcore/inc/RooAdaptiveIntegratorND.h
@@ -52,8 +52,8 @@ protected:
 
   bool _useIntegrandLimits;  ///< If true limits of function binding are used
 
-  mutable double* _xmin ;    ///< Lower bound in each dimension
-  mutable double* _xmax ;    ///< Upper bound in each dimension
+  mutable std::vector<double> _xmin;    ///< Lower bound in each dimension
+  mutable std::vector<double> _xmax;    ///< Upper bound in each dimension
   double _epsRel ;           ///< Relative precision
   double _epsAbs ;           ///< Absolute precision
   Int_t    _nmax ;             ///< Max number of divisions

--- a/roofit/roofitcore/inc/RooBinIntegrator.h
+++ b/roofit/roofitcore/inc/RooBinIntegrator.h
@@ -58,19 +58,19 @@ protected:
   // Numerical integrator workspace
   mutable std::vector<double> _xmin;      ///<! Lower integration bound
   mutable std::vector<double> _xmax;      ///<! Upper integration bound
-  std::vector<std::vector<double>> _binb;   ///<! list of bin boundaries
-  mutable Int_t _numBins;                   ///<! Size of integration range
+  std::vector<std::vector<double>> _binb; ///<! list of bin boundaries
+  mutable Int_t _numBins = 0;             ///<! Size of integration range
 
-  bool _useIntegrandLimits;  ///< If true limits of function binding are ued
+  bool _useIntegrandLimits = false;       ///< If true limits of function binding are ued
 
   std::unique_ptr<RooBatchCompute::RunContext> _evalData;     ///<! Run context for evaluating a function.
   std::unique_ptr<RooBatchCompute::RunContext> _evalDataOrig; ///<! Run context to save bin centres in between invocations.
 
-  double* xvec(double xx) { _x[0] = xx ; return _x ; }
-  double* xvec(double xx, double yy) { _x[0] = xx ; _x[1] = yy ; return _x ; }
-  double* xvec(double xx, double yy, double zz) { _x[0] = xx ; _x[1] = yy ; _x[2] = zz ; return _x ; }
+  double* xvec(double xx) { _x[0] = xx ; return _x.data(); }
+  double* xvec(double xx, double yy) { _x[0] = xx ; _x[1] = yy ; return _x.data(); }
+  double* xvec(double xx, double yy, double zz) { _x[0] = xx ; _x[1] = yy ; _x[2] = zz ; return _x.data(); }
 
-  double *_x ; ///<! do not persist
+  std::vector<double> _x ; ///<! do not persist
 
   ClassDefOverride(RooBinIntegrator,0) // 1-dimensional numerical integration engine
 };

--- a/roofit/roofitcore/inc/RooGrid.h
+++ b/roofit/roofitcore/inc/RooGrid.h
@@ -19,13 +19,14 @@
 #include "TObject.h"
 #include "RooPrintable.h"
 
+#include <vector>
+
 class RooAbsFunc;
 
 class RooGrid : public TObject, public RooPrintable {
 public:
-  RooGrid() ;
+  RooGrid() {}
   RooGrid(const RooAbsFunc &function);
-  ~RooGrid() override;
 
   // Printing interface
   void printName(std::ostream& os) const override ;
@@ -43,9 +44,6 @@ public:
   inline UInt_t getNBins() const { return _bins; }
   inline UInt_t getNBoxes() const { return _boxes; }
   inline void setNBoxes(UInt_t boxes) { _boxes= boxes; }
-
-  inline double *createPoint() const { return _valid ? new double[_dim] : 0; }
-  inline UInt_t *createIndexVector() const { return _valid ? new UInt_t[_dim] : 0; }
 
   bool initialize(const RooAbsFunc &function);
   void resize(UInt_t bins);
@@ -71,17 +69,19 @@ protected:
 
 protected:
 
-  bool _valid;              ///< Is configuration valid
-  UInt_t _dim,_bins,_boxes;   ///< Number of dimensions, bins and boxes
-  double _vol;              ///< Volume
+  bool _valid = false;         ///< Is configuration valid
+  UInt_t _dim = 0;             ///< Number of dimensions, bins and boxes
+  UInt_t _bins = 0;            ///< Number of bins
+  UInt_t _boxes = 0;           ///<Numbser of boxes
+  double _vol = 0.0;           ///< Volume
 
-  double *_xl;     ///<! Internal workspace
-  double *_xu;     ///<! Internal workspace
-  double *_delx;   ///<! Internal workspace
-  double *_d;      ///<! Internal workspace
-  double *_xi;     ///<! Internal workspace
-  double *_xin;    ///<! Internal workspace
-  double *_weight; ///<! Internal workspace
+  std::vector<double> _xl;     ///<! Internal workspace
+  std::vector<double> _xu;     ///<! Internal workspace
+  std::vector<double> _delx;   ///<! Internal workspace
+  std::vector<double> _d;      ///<! Internal workspace
+  std::vector<double> _xi;     ///<! Internal workspace
+  std::vector<double> _xin;    ///<! Internal workspace
+  std::vector<double> _weight; ///<! Internal workspace
 
   ClassDefOverride(RooGrid,1) // Utility class for RooMCIntegrator holding a multi-dimensional grid
 };

--- a/roofit/roofitcore/inc/RooIntegrator1D.h
+++ b/roofit/roofitcore/inc/RooIntegrator1D.h
@@ -24,7 +24,7 @@ public:
 
   // Constructors, assignment etc
   enum SummationRule { Trapezoid, Midpoint };
-  RooIntegrator1D() ;
+  RooIntegrator1D() {}
 
   RooIntegrator1D(const RooAbsFunc& function, SummationRule rule= Trapezoid,
         Int_t maxSteps= 0, double eps= 0) ;
@@ -36,7 +36,6 @@ public:
         const RooNumIntConfig& config) ;
 
   RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
-  ~RooIntegrator1D() override;
 
   bool checkLimits() const override;
   double integral(const double *yvec=nullptr) override ;
@@ -80,15 +79,15 @@ protected:
   double _range;             ///<! Size of integration range
   double _extrapValue;       ///<! Extrapolated value
   double _extrapError;       ///<! Error on extrapolated value
-  double *_h ;               ///<! Integrator workspace
-  double *_s ;               ///<! Integrator workspace
-  double *_c ;               ///<! Integrator workspace
-  double *_d ;               ///<! Integrator workspace
+  std::vector<double> _h ;   ///<! Integrator workspace
+  std::vector<double> _s ;   ///<! Integrator workspace
+  std::vector<double> _c ;   ///<! Integrator workspace
+  std::vector<double> _d ;   ///<! Integrator workspace
   double _savedResult;       ///<! Integrator workspace
 
-  double* xvec(double& xx) { _x[0] = xx ; return _x ; }
+  double* xvec(double& xx) { _x[0] = xx ; return _x.data(); }
 
-  double *_x ; //! do not persist
+  std::vector<double> _x ; //! do not persist
 
   ClassDefOverride(RooIntegrator1D,0) // 1-dimensional numerical integration engine
 };

--- a/roofit/roofitcore/inc/RooNumRunningInt.h
+++ b/roofit/roofitcore/inc/RooNumRunningInt.h
@@ -15,7 +15,9 @@
 #include "RooAbsCachedReal.h"
 #include "RooRealProxy.h"
 #include "RooAbsReal.h"
+
 #include <string>
+#include <vector>
 
 class RooNumRunningInt : public RooAbsCachedReal {
 public:
@@ -29,15 +31,14 @@ protected:
   class RICacheElem: public FuncCacheElem {
   public:
     RICacheElem(const RooNumRunningInt& ri, const RooArgSet* nset) ;
-    ~RICacheElem() override ;
     RooArgList containedArgs(Action) override ;
     void calculate(bool cdfmode) ;
     void addRange(Int_t ixlo, Int_t ixhi, Int_t nbins) ;
     void addPoint(Int_t ix) ;
 
     RooNumRunningInt* _self ;
-    double* _ax ;
-    double* _ay ;
+    std::vector<double> _ax ;
+    std::vector<double> _ay ;
     RooRealVar* _xx ;
 
   } ;

--- a/roofit/roofitcore/src/BidirMMapPipe.cxx
+++ b/roofit/roofitcore/src/BidirMMapPipe.cxx
@@ -1852,7 +1852,7 @@ childcloses:
     {
         std::cout << std::endl << "[PARENT]: benchmark: round-trip times vs block size" << std::endl;
         for (unsigned i = 0; i <= 24; ++i) {
-            char *s = new char[1 + (1 << i)];
+            std::vector<char> s(1 + (1 << i));
             std::memset(s, 'A', 1 << i);
             s[1 << i] = 0;
             const unsigned n = 1 << 7;
@@ -1883,7 +1883,6 @@ childcloses:
             int retVal = pipe->close();
             if (retVal) {
                 std::cout << "[PARENT]: child exited with code " << retVal << std::endl;
-                delete[] s;
                 return retVal;
             }
             delete pipe;
@@ -1896,7 +1895,6 @@ childcloses:
                 "us speed " << std::setw(9) <<
                 2. * (double(1 << i) / double(1 << 20) / (1e-6 * avg)) <<
                 " MB/s" << std::endl;
-            delete[] s;
         }
         std::cout << "[PARENT]: all children had exit code 0" << std::endl;
     }
@@ -1904,7 +1902,7 @@ childcloses:
     {
         std::cout << std::endl << "[PARENT]: benchmark: raw transfer rate with child as sink" << std::endl;
         for (unsigned i = 0; i <= 24; ++i) {
-            char *s = new char[1 + (1 << i)];
+            std::vector<char> s(1 + (1 << i));
             std::memset(s, 'A', 1 << i);
             s[1 << i] = 0;
             const unsigned n = 1 << 7;
@@ -1943,7 +1941,6 @@ childcloses:
                 "us speed " << std::setw(9) <<
                 (double(1 << i) / double(1 << 20) / (1e-6 * avg)) <<
                 " MB/s" << std::endl;
-            delete[] s;
         }
         std::cout << "[PARENT]: all children had exit code 0" << std::endl;
     }

--- a/roofit/roofitcore/src/RooAbsGenContext.cxx
+++ b/roofit/roofitcore/src/RooAbsGenContext.cxx
@@ -52,7 +52,6 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
   _prototype(prototype),
   _isValid(true),
   _verbose(verbose),
-  _protoOrder(0),
   _genData(0)
 {
   // Check PDF dependents
@@ -95,16 +94,6 @@ RooAbsGenContext::RooAbsGenContext(const RooAbsPdf& model, const RooArgSet &vars
   if (model.normRange()) {
     _normRange = model.normRange() ;
   }
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooAbsGenContext::~RooAbsGenContext()
-{
-  if (_protoOrder) delete[] _protoOrder ;
 }
 
 
@@ -218,7 +207,7 @@ RooDataSet *RooAbsGenContext::generate(double nEvents, bool skipInit, bool exten
     if(0 != _prototype) {
       if(_nextProtoIndex >= _prototype->numEntries()) _nextProtoIndex= 0;
 
-      Int_t actualProtoIdx = _protoOrder ? _protoOrder[_nextProtoIndex] : _nextProtoIndex ;
+      Int_t actualProtoIdx = !_protoOrder.empty() ? _protoOrder[_nextProtoIndex] : _nextProtoIndex ;
 
       const RooArgSet *subEvent= _prototype->get(actualProtoIdx);
       _nextProtoIndex++;
@@ -332,16 +321,10 @@ void RooAbsGenContext::printMultiline(ostream &/*os*/, Int_t /*contents*/, bool 
 
 void RooAbsGenContext::setProtoDataOrder(Int_t* lut)
 {
-  // Delete any previous lookup table
-  if (_protoOrder) {
-    delete[] _protoOrder ;
-    _protoOrder = 0 ;
-  }
-
   // Copy new lookup table if provided and needed
   if (lut && _prototype) {
     Int_t n = _prototype->numEntries() ;
-    _protoOrder = new Int_t[n] ;
+    _protoOrder.resize(n);
     Int_t i ;
     for (i=0 ; i<n ; i++) {
       _protoOrder[i] = lut[i] ;

--- a/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
+++ b/roofit/roofitcore/src/RooAdaptiveIntegratorND.cxx
@@ -67,8 +67,6 @@ void RooAdaptiveIntegratorND::registerIntegrator(RooNumIntFactory& fact)
 
 RooAdaptiveIntegratorND::RooAdaptiveIntegratorND()
 {
-  _xmin = 0 ;
-  _xmax = 0 ;
   _epsRel = 1e-7 ;
   _epsAbs = 1e-7 ;
   _nmax = 10000 ;
@@ -106,8 +104,6 @@ RooAdaptiveIntegratorND::RooAdaptiveIntegratorND(const RooAbsFunc& function, con
   _integrator->SetFunction(*_func) ;
   _useIntegrandLimits=true ;
 
-  _xmin = 0 ;
-  _xmax = 0 ;
   _nError = 0 ;
   _nWarn = 0 ;
   checkLimits() ;
@@ -134,8 +130,6 @@ RooAbsIntegrator* RooAdaptiveIntegratorND::clone(const RooAbsFunc& function, con
 
 RooAdaptiveIntegratorND::~RooAdaptiveIntegratorND()
 {
-  delete[] _xmin ;
-  delete[] _xmax ;
   delete _integrator ;
   delete _func ;
   if (_nError>_nWarn) {
@@ -153,9 +147,9 @@ RooAdaptiveIntegratorND::~RooAdaptiveIntegratorND()
 
 bool RooAdaptiveIntegratorND::checkLimits() const
 {
-  if (!_xmin) {
-    _xmin = new double[_func->NDim()] ;
-    _xmax = new double[_func->NDim()] ;
+  if (_xmin.empty()) {
+    _xmin.resize(_func->NDim());
+    _xmax.resize(_func->NDim());
   }
 
   if (_useIntegrandLimits) {
@@ -196,7 +190,7 @@ bool RooAdaptiveIntegratorND::setLimits(double *xmin, double *xmax)
 
 double RooAdaptiveIntegratorND::integral(const double* /*yvec*/)
 {
-  double ret = _integrator->Integral(_xmin,_xmax) ;
+  double ret = _integrator->Integral(_xmin.data(),_xmax.data());
   if (_integrator->Status()==1) {
     _nError++ ;
     if (_nError<=_nWarn) {

--- a/roofit/roofitcore/src/RooBinIntegrator.cxx
+++ b/roofit/roofitcore/src/RooBinIntegrator.cxx
@@ -80,7 +80,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function) :
   assert(_function && _function->isValid());
 
   // Allocate coordinate buffer size after number of function dimensions
-  _x = new double[_function->getDimension()] ;
+  _x.resize(_function->getDimension());
   _numBins = 100 ;
 
   _xmin.resize(_function->getDimension()) ;
@@ -133,7 +133,7 @@ RooBinIntegrator::RooBinIntegrator(const RooAbsFunc& function, const RooNumIntCo
   assert(_function && _function->isValid());
 
   // Allocate coordinate buffer size after number of function dimensions
-  _x = new double[_function->getDimension()] ;
+  _x.resize(_function->getDimension());
 
   auto realBinding = dynamic_cast<const RooRealBinding*>(_function);
   if (realBinding) {
@@ -187,7 +187,6 @@ RooAbsIntegrator* RooBinIntegrator::clone(const RooAbsFunc& function, const RooN
 
 RooBinIntegrator::~RooBinIntegrator()
 {
-  if(_x) delete[] _x;
 }
 
 

--- a/roofit/roofitcore/src/RooClassFactory.cxx
+++ b/roofit/roofitcore/src/RooClassFactory.cxx
@@ -426,27 +426,25 @@ bool RooClassFactory::makeClass(const char* baseName, const char* className, con
 
   if (realArgNames && *realArgNames) {
     const size_t bufSize = strlen(realArgNames)+1;
-    char* buf = new char[bufSize] ;
-    strlcpy(buf,realArgNames,bufSize) ;
-    char* token = strtok(buf,",") ;
+    std::vector<char> buf(bufSize);
+    strlcpy(buf.data(),realArgNames,bufSize) ;
+    char* token = strtok(buf.data(),",") ;
     while(token) {
       alist.push_back(token) ;
       isCat.push_back(false) ;
       token = strtok(0,",") ;
     }
-    delete[] buf ;
   }
   if (catArgNames && *catArgNames) {
     const size_t bufSize = strlen(catArgNames)+1;
-    char* buf = new char[bufSize] ;
-    strlcpy(buf,catArgNames,bufSize) ;
-    char* token = strtok(buf,",") ;
+    std::vector<char> buf(bufSize);
+    strlcpy(buf.data(),catArgNames,bufSize) ;
+    char* token = strtok(buf.data(),",") ;
     while(token) {
       alist.push_back(token) ;
       isCat.push_back(true) ;
       token = strtok(0,",") ;
     }
-    delete[] buf ;
   }
 
   TString impFileName(className), hdrFileName(className) ;
@@ -626,15 +624,14 @@ bool RooClassFactory::makeClass(const char* baseName, const char* className, con
     // Expected form is observable:expression,observable,observable:expression;[...]
     if (intExpression && *intExpression) {
       const size_t bufSize = strlen(intExpression)+1;
-      char* buf = new char[bufSize] ;
-      strlcpy(buf,intExpression,bufSize) ;
-      char* ptr = strtok(buf,":") ;
+      std::vector<char> buf(bufSize);
+      strlcpy(buf.data(),intExpression,bufSize) ;
+      char* ptr = strtok(buf.data(),":") ;
       while(ptr) {
    intObs.push_back(ptr) ;
    intExpr.push_back(strtok(0,";")) ;
    ptr = strtok(0,":") ;
       }
-      delete[] buf ;
     }
 
     cf << " Int_t " << className << "::getAnalyticalIntegral(RooArgSet& allVars, RooArgSet& analVars, const char* /*rangeName*/) const  " << endl

--- a/roofit/roofitcore/src/RooGrid.cxx
+++ b/roofit/roofitcore/src/RooGrid.cxx
@@ -39,23 +39,13 @@ integration, following the VEGAS algorithm.
 using namespace std;
 
 ClassImp(RooGrid);
-;
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Default constructor
-
-RooGrid::RooGrid() :
-  _valid(false), _dim(0), _bins(0), _boxes(0), _vol(0), _xl(0),  _xu(0),  _delx(0),  _d(0),  _xi(0),  _xin(0),  _weight(0)
-{
-}
 
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor with given function binding
 
 RooGrid::RooGrid(const RooAbsFunc &function)
-  : _valid(true), _xl(0),_xu(0),_delx(0),_xi(0)
+  : _valid(true)
 {
   // check that the input function is valid
   if(!(_valid= function.isValid())) {
@@ -65,36 +55,16 @@ RooGrid::RooGrid(const RooAbsFunc &function)
 
   // allocate workspace memory
   _dim= function.getDimension();
-  _xl= new double[_dim];
-  _xu= new double[_dim];
-  _delx= new double[_dim];
-  _d= new double[_dim*maxBins];
-  _xi= new double[_dim*(maxBins+1)];
-  _xin= new double[maxBins+1];
-  _weight= new double[maxBins];
-  if(!_xl || !_xu || !_delx || !_d || !_xi || !_xin || !_weight) {
-    oocoutE(nullptr,Integration) << ClassName() << ": memory allocation failed" << endl;
-    _valid= false;
-    return;
-  }
+  _xl.resize(_dim);
+  _xu.resize(_dim);
+  _delx.resize(_dim);
+  _d.resize(_dim*maxBins);
+  _xi.resize(_dim*(maxBins+1));
+  _xin.resize(maxBins+1);
+  _weight.resize(maxBins);
 
   // initialize the grid
   _valid= initialize(function);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooGrid::~RooGrid()
-{
-  if(_xl)     delete[] _xl;
-  if(_xu)     delete[] _xu;
-  if(_delx)   delete[] _delx;
-  if(_d)      delete[] _d;
-  if(_xi)     delete[] _xi;
-  if(_xin)    delete[] _xin;
-  if(_weight) delete[] _weight;
 }
 
 

--- a/roofit/roofitcore/src/RooIntegrator1D.cxx
+++ b/roofit/roofitcore/src/RooIntegrator1D.cxx
@@ -70,17 +70,6 @@ void RooIntegrator1D::registerIntegrator(RooNumIntFactory& fact)
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// coverity[UNINIT_CTOR]
-/// Default constructor
-
-RooIntegrator1D::RooIntegrator1D() :
-  _h(0), _s(0), _c(0), _d(0), _x(0)
-{
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Construct integrator on given function binding, using specified summation
 /// rule, maximum number of steps and conversion tolerance. The integration
@@ -204,30 +193,16 @@ bool RooIntegrator1D::initialize()
   }
 
   // Allocate coordinate buffer size after number of function dimensions
-  _x = new double[_function->getDimension()] ;
+  _x.resize(_function->getDimension());
 
 
   // Allocate workspace for numerical integration engine
-  _h= new double[_maxSteps + 2];
-  _s= new double[_maxSteps + 2];
-  _c= new double[_nPoints + 1];
-  _d= new double[_nPoints + 1];
+  _h.resize(_maxSteps + 2);
+  _s.resize(_maxSteps + 2);
+  _c.resize(_nPoints + 1);
+  _d.resize(_nPoints + 1);
 
   return checkLimits();
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooIntegrator1D::~RooIntegrator1D()
-{
-  // Release integrator workspace
-  if(_h) delete[] _h;
-  if(_s) delete[] _s;
-  if(_c) delete[] _c;
-  if(_d) delete[] _d;
-  if(_x) delete[] _x;
 }
 
 

--- a/roofit/roofitcore/src/RooNumRunningInt.cxx
+++ b/roofit/roofitcore/src/RooNumRunningInt.cxx
@@ -103,8 +103,8 @@ RooNumRunningInt::RICacheElem::RICacheElem(const RooNumRunningInt& self, const R
   FuncCacheElem(self,nset), _self(&const_cast<RooNumRunningInt&>(self))
 {
   // Instantiate temp arrays
-  _ax = new double[hist()->numEntries()] ;
-  _ay = new double[hist()->numEntries()] ;
+  _ax.resize(hist()->numEntries());
+  _ay.resize(hist()->numEntries());
 
   // Copy X values from histo
   _xx = (RooRealVar*) hist()->get()->find(self.x.arg().GetName()) ;
@@ -114,17 +114,6 @@ RooNumRunningInt::RICacheElem::RICacheElem(const RooNumRunningInt& self, const R
     _ay[i] = -1 ;
   }
 
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooNumRunningInt::RICacheElem::~RICacheElem()
-{
-  // Delete temp arrays
-  delete[] _ax ;
-  delete[] _ay ;
 }
 
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1074,15 +1074,14 @@ void RooProdPdf::rearrangeProduct(RooProdPdf::CacheElem& cache) const
 
   list<string> rangeComps ;
   {
-    char* buf = new char[strlen(_normRange.Data()) + 1] ;
-    strcpy(buf,_normRange.Data()) ;
+    std::vector<char> buf(strlen(_normRange.Data()) + 1);
+    strcpy(buf.data(),_normRange.Data()) ;
     char* save(0) ;
-    char* token = R__STRTOK_R(buf,",",&save) ;
+    char* token = R__STRTOK_R(buf.data(),",",&save) ;
     while(token) {
       rangeComps.push_back(token) ;
       token = R__STRTOK_R(0,",",&save) ;
     }
-    delete[] buf;
   }
 
 

--- a/roofit/roofitmore/inc/RooAdaptiveGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/inc/RooAdaptiveGaussKronrodIntegrator1D.h
@@ -25,7 +25,7 @@ class RooAdaptiveGaussKronrodIntegrator1D : public RooAbsIntegrator {
 public:
 
   // Constructors, assignment etc
-  RooAdaptiveGaussKronrodIntegrator1D() ;
+  RooAdaptiveGaussKronrodIntegrator1D() {}
   RooAdaptiveGaussKronrodIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooAdaptiveGaussKronrodIntegrator1D(const RooAbsFunc& function, double xmin, double xmax,
                                       const RooNumIntConfig& config) ;
@@ -75,15 +75,15 @@ protected:
 
   double* xvec(double& xx) {
     // Return contents of xx in internal array pointer
-    _x[0] = xx ; return _x ;
+    _x[0] = xx ; return _x.data();
   }
-  double *_x ;                        //! Current coordinate
+  std::vector<double> _x ;                        //! Current coordinate
 
   double _epsAbs ;                   // Absolute precision
   double _epsRel ;                   // Relative precision
   Int_t    _methodKey ;                // GSL method key
   Int_t    _maxSeg ;                   // Maximum number of segments
-  void*    _workspace ;                // GSL workspace
+  void*    _workspace = nullptr;       // GSL workspace
 
   mutable double _xmin;              //! Lower integration bound
   mutable double _xmax;              //! Upper integration bound

--- a/roofit/roofitmore/inc/RooGaussKronrodIntegrator1D.h
+++ b/roofit/roofitmore/inc/RooGaussKronrodIntegrator1D.h
@@ -25,11 +25,10 @@ class RooGaussKronrodIntegrator1D : public RooAbsIntegrator {
 public:
 
   // Constructors, assignment etc
-  RooGaussKronrodIntegrator1D() ;
+  RooGaussKronrodIntegrator1D() {}
   RooGaussKronrodIntegrator1D(const RooAbsFunc& function, const RooNumIntConfig& config) ;
   RooGaussKronrodIntegrator1D(const RooAbsFunc& function, double xmin, double xmax, const RooNumIntConfig& config) ;
   RooAbsIntegrator* clone(const RooAbsFunc& function, const RooNumIntConfig& config) const override ;
-  ~RooGaussKronrodIntegrator1D() override;
 
   bool checkLimits() const override;
   double integral(const double *yvec=nullptr) override ;
@@ -54,8 +53,8 @@ protected:
 
   bool _useIntegrandLimits;  // Use limits in function binding?
 
-  double* xvec(double& xx) { _x[0] = xx ; return _x ; }
-  double *_x ; //! do not persist
+  double* xvec(double& xx) { _x[0] = xx ; return _x.data(); }
+  std::vector<double> _x ; //! do not persist
 
   double _epsAbs ;                   // Absolute precision
   double _epsRel ;                   // Relative precision

--- a/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooAdaptiveGaussKronrodIntegrator1D.cxx
@@ -169,16 +169,6 @@ void RooAdaptiveGaussKronrodIntegrator1D::registerIntegrator(RooNumIntFactory& f
      oocoutI(nullptr,Integration)  << "RooAdaptiveGaussKronrodIntegrator1D has been registered " << std::endl;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// coverity[UNINIT_CTOR]
-/// Default constructor
-
-RooAdaptiveGaussKronrodIntegrator1D::RooAdaptiveGaussKronrodIntegrator1D() : _x(0), _workspace(0)
-{
-}
-
-
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor taking a function binding and a configuration object
@@ -187,8 +177,7 @@ RooAdaptiveGaussKronrodIntegrator1D::RooAdaptiveGaussKronrodIntegrator1D(const R
                             const RooNumIntConfig& config) :
   RooAbsIntegrator(function),
   _epsAbs(config.epsRel()),
-  _epsRel(config.epsAbs()),
-  _workspace(0)
+  _epsRel(config.epsAbs())
 {
   // Use this form of the constructor to integrate over the function's default range.
   const RooArgSet& confSet = config.getConfigSection(ClassName()) ;
@@ -210,7 +199,6 @@ RooAdaptiveGaussKronrodIntegrator1D::RooAdaptiveGaussKronrodIntegrator1D(const R
   RooAbsIntegrator(function),
   _epsAbs(config.epsRel()),
   _epsRel(config.epsAbs()),
-  _workspace(0),
   _xmin(xmin),
   _xmax(xmax)
 {
@@ -241,7 +229,7 @@ RooAbsIntegrator* RooAdaptiveGaussKronrodIntegrator1D::clone(const RooAbsFunc& f
 bool RooAdaptiveGaussKronrodIntegrator1D::initialize()
 {
   // Allocate coordinate buffer size after number of function dimensions
-  _x = new double[_function->getDimension()] ;
+  _x.resize(_function->getDimension());
   _workspace = gsl_integration_workspace_alloc (_maxSeg)  ;
 
   return checkLimits();
@@ -256,9 +244,6 @@ RooAdaptiveGaussKronrodIntegrator1D::~RooAdaptiveGaussKronrodIntegrator1D()
 {
   if (_workspace) {
     gsl_integration_workspace_free ((gsl_integration_workspace*) _workspace) ;
-  }
-  if (_x) {
-    delete[] _x ;
   }
 }
 

--- a/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
+++ b/roofit/roofitmore/src/RooGaussKronrodIntegrator1D.cxx
@@ -108,16 +108,6 @@ void RooGaussKronrodIntegrator1D::registerIntegrator(RooNumIntFactory& fact)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// coverity[UNINIT_CTOR]
-/// Default constructor
-
-RooGaussKronrodIntegrator1D::RooGaussKronrodIntegrator1D() : _x(0)
-{
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Construct integral on 'function' using given configuration object. The integration
 /// range is taken from the definition in the function binding
 
@@ -165,21 +155,9 @@ RooAbsIntegrator* RooGaussKronrodIntegrator1D::clone(const RooAbsFunc& function,
 bool RooGaussKronrodIntegrator1D::initialize()
 {
   // Allocate coordinate buffer size after number of function dimensions
-  _x = new double[_function->getDimension()] ;
+  _x.resize(_function->getDimension());
 
   return checkLimits();
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooGaussKronrodIntegrator1D::~RooGaussKronrodIntegrator1D()
-{
-  if (_x) {
-    delete[] _x ;
-  }
 }
 
 

--- a/roofit/roostats/src/MCMCInterval.cxx
+++ b/roofit/roostats/src/MCMCInterval.cxx
@@ -246,12 +246,11 @@ bool MCMCInterval::IsInInterval(const RooArgSet& point) const
                                     const_cast<RooArgSet*>(&fParameters));
             Long_t bin;
             // kbelasco: consider making x static
-            double* x = new double[fDimension];
+            std::vector<double> x(fDimension);
             for (Int_t i = 0; i < fDimension; i++)
                x[i] = fAxes[i]->getVal();
-            bin = fSparseHist->GetBin(x, false);
+            bin = fSparseHist->GetBin(x.data(), false);
             double weight = fSparseHist->GetBinContent((Long64_t)bin);
-            delete[] x;
             return (weight >= (double)fHistCutoff);
          } else {
             if (fDataHist == nullptr)
@@ -457,20 +456,16 @@ void MCMCInterval::CreateSparseHist()
    if (fSparseHist != nullptr)
       delete fSparseHist;
 
-   double* min = new double[fDimension];
-   double* max = new double[fDimension];
-   Int_t* bins = new Int_t[fDimension];
+   std::vector<double> min(fDimension);
+   std::vector<double> max(fDimension);
+   std::vector<Int_t> bins(fDimension);
    for (Int_t i = 0; i < fDimension; i++) {
       min[i] = fAxes[i]->getMin();
       max[i] = fAxes[i]->getMax();
       bins[i] = fAxes[i]->numBins();
    }
    fSparseHist = new THnSparseF("posterior", "MCMC Posterior Histogram",
-         fDimension, bins, min, max);
-
-   delete[] min;
-   delete[] max;
-   delete[] bins;
+         fDimension, bins.data(), min.data(), max.data());
 
    // kbelasco: it appears we need to call Sumw2() just to get the
    // histogram to keep a running total of the weight so that Getsumw doesn't
@@ -487,14 +482,13 @@ void MCMCInterval::CreateSparseHist()
    // Fill histogram
    Int_t size = fChain->Size();
    const RooArgSet* entry;
-   double* x = new double[fDimension];
+   std::vector<double> x(fDimension);
    for (Int_t i = fNumBurnInSteps; i < size; i++) {
       entry = fChain->Get(i);
       for (Int_t ii = 0; ii < fDimension; ii++)
          x[ii] = entry->getRealValue(fAxes[ii]->GetName());
-      fSparseHist->Fill(x, fChain->Weight());
+      fSparseHist->Fill(x.data(), fChain->Weight());
    }
-   delete[] x;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1484,7 +1478,7 @@ void MCMCInterval::CreateKeysDataHist()
       return;
 
    //RooAbsBinning** savedBinning = new RooAbsBinning*[fDimension];
-   Int_t* savedBins = new Int_t[fDimension];
+   std::vector<Int_t> savedBins(fDimension);
    Int_t i;
    double numBins;
    RooRealVar* var;
@@ -1537,9 +1531,6 @@ void MCMCInterval::CreateKeysDataHist()
          //fAxes[i]->setBins(savedBinning[i]->numBins(), nullptr);
          fAxes[i]->setBins(savedBins[i], nullptr);
    }
-
-   //delete[] savedBinning;
-   delete[] savedBins;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roostats/src/MarkovChain.cxx
+++ b/roofit/roostats/src/MarkovChain.cxx
@@ -243,17 +243,16 @@ THnSparse* MarkovChain::GetAsSparseHist(RooAbsCollection* whichVars) const
    // Fill histogram
    Int_t size = fChain->numEntries();
    const RooArgSet* entry;
-   double* x = new double[dim];
+   std::vector<double> x(dim);
    for ( i = 0; i < size; i++) {
       entry = fChain->get(i);
 
       for (Int_t ii = 0; ii < dim; ii++) {
          //LM:  doing this is probably quite slow
          x[ii] = entry->getRealValue( names[ii]);
-         sparseHist->Fill(x, fChain->weight());
+         sparseHist->Fill(x.data(), fChain->weight());
       }
    }
-   delete[] x;
 
    return sparseHist;
 }


### PR DESCRIPTION
This is part of the effort of making memory management in RooFit more
automatic and safer.