### PR TITLE
[DF] Preserve ordering of snapshotted columns

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -780,6 +780,8 @@ std::pair<std::vector<std::string>, std::vector<std::string>>
 AddSizeBranches(const std::vector<std::string> &branches, TTree *tree, std::vector<std::string> &&colsWithoutAliases,
                 std::vector<std::string> &&colsWithAliases);
 
+void RemoveDuplicates(ColumnNames_t &columnNames);
+
 } // namespace RDF
 } // namespace Internal
 

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1132,10 +1132,9 @@ public:
       columnNames.insert(columnNames.end(), treeBranchNames.begin(), treeBranchNames.end());
       columnNames.insert(columnNames.end(), dsColumnsWithoutSizeColumns.begin(), dsColumnsWithoutSizeColumns.end());
 
-      // De-duplicate column names. Currently the only way this can happen is if a column coming from a tree or
-      // data-source is Redefine'd.
-      std::set<std::string> uniqueCols(columnNames.begin(), columnNames.end());
-      columnNames.assign(uniqueCols.begin(), uniqueCols.end());
+      // The only way we can get duplicate entries is if a column coming from a tree or data-source is Redefine'd.
+      // RemoveDuplicates should preserve ordering of the columns: it might be meaningful.
+      RDFInternal::RemoveDuplicates(columnNames);
 
       const auto selectedColumns = RDFInternal::ConvertRegexToColumns(columnNames, columnNameRegexp, "Snapshot");
       return Snapshot(treename, filename, selectedColumns, options);

--- a/tree/dataframe/src/RDFInterfaceUtils.cxx
+++ b/tree/dataframe/src/RDFInterfaceUtils.cxx
@@ -1031,6 +1031,15 @@ AddSizeBranches(const std::vector<std::string> &branches, TTree *tree, std::vect
    return {std::move(colsWithoutAliases), std::move(colsWithAliases)};
 }
 
+void RemoveDuplicates(ColumnNames_t &columnNames)
+{
+   std::set<std::string> uniqueCols;
+   columnNames.erase(
+      std::remove_if(columnNames.begin(), columnNames.end(),
+                     [&uniqueCols](const std::string &colName) { return !uniqueCols.insert(colName).second; }),
+      columnNames.end());
+}
+
 } // namespace RDF
 } // namespace Internal
 } // namespace ROOT


### PR DESCRIPTION
Before this patch (and since a2156969b4), Snapshot was enforcing
alphabetical ordering of the output branches. The ordering
specified as argument, however, could carry meaning: it might
make sense to have branches carrying related physics information
close together in the TTree so that they appear close to each
other e.g. in TTree::Print or in TBrowser.

With this patch we keep the original column ordering (the one
explicitly specified by the user or the one coming from TTree)
when creating output branches.

One exception are branches from the input TTree that are
Redefine'd in case of auto-generated lists of output columns:
Define'd and Redefine'd columns appear before TTree branches,
which might move the position of branches that have been
Redefine'd with respect to others that have not.