### PR TITLE
[RF] Necessary changes to RooFit plotting and BatchMode to plot likelihoods that use BatchMode

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreallvalue.py
@@ -53,4 +53,10 @@ class RooAbsRealLValue(object):
         """
         # Redefinition of `RooAbsRealLValue.frame` for keyword arguments.
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
-        return self._frame(*args, **kwargs)
+        frame = self._frame(*args, **kwargs)
+
+        # Add a Python reference to the plot variable to the RooPlot because
+        # the plot variable needs to survive at least as long as the plot.
+        frame._plotVar = self
+
+        return frame

--- a/bindings/pyroot/pythonizations/test/roofit/roodatahist_ploton.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodatahist_ploton.py
@@ -31,7 +31,7 @@ class RooDataHistPlotOn(unittest.TestCase):
 
         dh = ROOT.RooDataHist("dh", "binned version of d", ROOT.RooArgSet(x, y), d)
 
-        yframe = ROOT.RooPlot("yplot", "Operations on binned datasets", y, 0, 40, 10)
+        yframe = y.frame(Bins=10)
 
         return dh, yframe
 

--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -137,7 +137,7 @@ public:
   }
 
   // data member get/set methods
-  inline RooAbsRealLValue *getPlotVar() const { return _plotVarClone; }
+  inline RooAbsRealLValue *getPlotVar() const { return _plotVar; }
   ///Return the number of events in the fit range
   inline double getFitRangeNEvt() const { return _normNumEvts; }
   double getFitRangeNEvt(double xlo, double xhi) const ;
@@ -235,7 +235,7 @@ protected:
   TH1* _hist = nullptr;      ///< Histogram that we uses as basis for drawing the content
   Items _items;  ///< A list of the items we contain.
   double _padFactor;       ///< Scale our y-axis to _padFactor of our maximum contents.
-  RooAbsRealLValue *_plotVarClone = nullptr; ///< A clone of the variable we are plotting.
+  RooAbsRealLValue *_plotVar = nullptr; ///< The variable we are plotting.
   RooArgSet *_plotVarSet = nullptr; ///< A list owning the cloned tree nodes of the plotVarClone
   RooArgSet *_normVars = nullptr; ///< Variables that PDF plots should be normalized over
 

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -219,10 +219,13 @@ public:
 
    double defaultErrorLevel() const override { return _driver->topNode().defaultErrorLevel(); }
 
-   bool getParameters(const RooArgSet * /*observables*/, RooArgSet &outputSet,
+   bool getParameters(const RooArgSet * observables, RooArgSet &outputSet,
                       bool /*stripDisconnected=true*/) const override
    {
       outputSet.add(_parameters);
+      if(observables) {
+         outputSet.remove(*observables);
+      }
       return false;
    }
 
@@ -240,7 +243,7 @@ private:
    RooFitDriver *_driver = nullptr;
    RooRealProxy _topNode;
    RooArgSet _parameters;
-   bool _ownsDriver;
+   bool _ownsDriver = false;
 };
 
 } // namespace

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -4326,7 +4326,7 @@ public:
   RooDataSet* data = model.generate(x,1000) ;
 
   // Construct unbinned likelihood
-  std::unique_ptr<RooAbsReal> nll{model.createNLL(*data)};
+  std::unique_ptr<RooAbsReal> nll{model.createNLL(*data, BatchMode(_batchMode))};
 
 
   // I n t e r a c t i v e   m i n i m i z a t i o n ,   e r r o r   a n a l y s i s
@@ -4628,7 +4628,7 @@ public:
   // ---------------------------------------------------
 
   // Construct unbinned likelihood
-  std::unique_ptr<RooAbsReal> nll{model.createNLL(*data)};
+  std::unique_ptr<RooAbsReal> nll{model.createNLL(*data, BatchMode(_batchMode))};
   nll->SetName("nll");
 
   // Minimize likelihood w.r.t all parameters before making plots
@@ -4753,7 +4753,7 @@ public:
   // ------------------------------------------------------------------
 
   // Construct likelihood function of model and data
-  std::unique_ptr<RooAbsReal> nll{argus.createNLL(*data)};
+  std::unique_ptr<RooAbsReal> nll{argus.createNLL(*data, BatchMode(_batchMode))};
   nll->SetName("nll");
 
   // Plot likelihood in m0 in range that includes problematic values
@@ -5547,7 +5547,7 @@ public:
   RooPlot* frame3 = alpha.frame(Bins(100),Range(0.5,0.9)) ;
 
   // Make 2D pdf of histogram
-  std::unique_ptr<RooAbsReal> nll{lmorph.createNLL(*data)};
+  std::unique_ptr<RooAbsReal> nll{lmorph.createNLL(*data, BatchMode(_batchMode))};
   nll->SetName("nll");
   nll->plotOn(frame3,ShiftToZero()) ;
 


### PR DESCRIPTION
* Avoid coning of plot variable twice then plotting a `RooAbsReal`, as the new BatchMode doesn't like model cloning
* Some minor fixes in `BatchModeHelpers`
* Improving the interface of `RooAbsReal::createPlotProjection`
* Use also the different BatchMode backends in the `createNLL` calls in `stressRooFit`, extending text coverage also to (profile) likelihood scans with the new BatchMode

The likelihood scans in the tutorials are up to 10 times faster now when using the new BatchMode compared to RooFit legacy.

More detail can be found in the commit descriptions.
