### PR TITLE
[DF] Use generic lambda instead of template helper function

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -495,8 +495,16 @@ public:
       // array of bools keeping track of which inputs are containers
       constexpr std::array<bool, sizeof...(Xs)> isContainer{IsDataContainer<Xs>::value...};
 
+      auto findIdxTrue = [](const auto &arr) {
+         for (size_t i = 0; i < arr.size(); ++i) {
+            if (arr[i])
+               return i;
+         }
+         return arr.size();
+      };
+
       // index of the first container input
-      constexpr std::size_t colidx = FindIdxTrue(isContainer);
+      constexpr std::size_t colidx = findIdxTrue(isContainer);
       // if this happens, there is a bug in the implementation
       static_assert(colidx < sizeof...(Xs), "Error: index of collection-type argument not found.");
 

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -224,17 +224,6 @@ constexpr std::size_t CacheLineStep() {
 void CheckReaderTypeMatches(const std::type_info &colType, const std::type_info &requestedType,
                             const std::string &colName, const std::string &where);
 
-// TODO in C++17 this could be a lambda within FillHelper::Exec
-template <typename T>
-constexpr std::size_t FindIdxTrue(const T &arr)
-{
-   for (size_t i = 0; i < arr.size(); ++i) {
-      if (arr[i])
-         return i;
-   }
-   return arr.size();
-}
-
 // return type has to be decltype(auto) to preserve perfect forwarding
 template <std::size_t N, typename... Ts>
 decltype(auto) GetNthElement(Ts &&...args)


### PR DESCRIPTION
Lambdas are implicitly marked constexpr whenever possible already
in C++14.