### PR TITLE
[RF] Make RooRealIntegral conform with the client-server interface

### DIFF
--- a/roofit/roofit/inc/RooNonCPEigenDecay.h
+++ b/roofit/roofit/inc/RooNonCPEigenDecay.h
@@ -108,7 +108,7 @@ protected:
   RooCategoryProxy _tag;
   RooCategoryProxy _rhoQ;
   RooRealProxy     _correctQ;
-  RooRealProxy     _wQ;
+  RooRealProxy     _wQ; ///< dummy mischarge (must be set to zero!)
   double         _genB0Frac;
   double         _genRhoPlusFrac;
 

--- a/roofit/roofit/src/RooNonCPEigenDecay.cxx
+++ b/roofit/roofit/src/RooNonCPEigenDecay.cxx
@@ -147,13 +147,11 @@ RooNonCPEigenDecay::RooNonCPEigenDecay( const char *name, const char *title,
   _tag      ( "tag",      "CP state",           this, tag      ),
   _rhoQ     ( "rhoQ",     "Charge of the rho",  this, rhoQ     ),
   _correctQ ( "correctQ", "correction of rhoQ", this, correctQ ),
+  _wQ      ( "wQ", "mischarge", this, *(new RooRealVar( "wQ", "wQ", 0 )), true, false, true ),
   _genB0Frac     ( 0 ),
   _genRhoPlusFrac( 0 ),
   _type     ( type )
 {
-  // dummy mischarge (must be set to zero!)
-  _wQ = RooRealProxy( "wQ", "mischarge", this, *(new RooRealVar( "wQ", "wQ", 0 )) );
-
   switch(type) {
   case SingleSided:
     _basisExp = declareBasis( "exp(-@0/@1)",            RooArgList( tau     ) );

--- a/roofit/roofitcore/inc/RooArgProxy.h
+++ b/roofit/roofitcore/inc/RooArgProxy.h
@@ -36,6 +36,13 @@ public:
   RooArgProxy(const char* name, RooAbsArg* owner, const RooArgProxy& other) ;
   ~RooArgProxy() override ;
 
+  // Delete copy/move construction and assignment, because it will always
+  // result in invalid proxies.
+  RooArgProxy(RooArgProxy const& other) = delete;
+  RooArgProxy(RooArgProxy && other) = delete;
+  RooArgProxy& operator=(RooArgProxy const& other) = delete;
+  RooArgProxy& operator=(RooArgProxy && other) = delete;
+
   /// Return pointer to contained argument
   inline RooAbsArg* absArg() const {
     return _arg ;

--- a/roofit/roofitcore/inc/RooArgProxy.h
+++ b/roofit/roofitcore/inc/RooArgProxy.h
@@ -61,6 +61,8 @@ public:
 
 protected:
 
+  friend class RooRealIntegral;
+
   bool changePointer(const RooAbsCollection& newServerSet, bool nameChange=false, bool factoryInitMode=false) override ;
 
   virtual void changeDataSet(const RooArgSet* newNormSet) ;

--- a/roofit/roofitcore/inc/RooArgProxy.h
+++ b/roofit/roofitcore/inc/RooArgProxy.h
@@ -50,19 +50,6 @@ public:
   /// Returns the owner of this proxy.
   RooAbsArg* owner() const { return _owner; }
 
-protected:
-
-  friend class RooSimultaneous ;
-  RooAbsArg* _owner ;       ///< Pointer to owner of proxy
-  RooAbsArg* _arg ;         ///< Pointer to content of proxy
-
-  bool _valueServer ;     ///< If true contents is value server of owner
-  bool _shapeServer ;     ///< If true contents is shape server of owner
-  bool _isFund ;          ///< If true proxy contains an lvalue
-  bool _ownArg ;          ///< If true proxy owns contents
-
-  friend class RooAbsArg ;
-
   /// Returns true of contents is value server of owner
   inline bool isValueServer() const {
     return _valueServer ;
@@ -71,9 +58,20 @@ protected:
   inline bool isShapeServer() const {
     return _shapeServer ;
   }
+
+protected:
+
   bool changePointer(const RooAbsCollection& newServerSet, bool nameChange=false, bool factoryInitMode=false) override ;
 
   virtual void changeDataSet(const RooArgSet* newNormSet) ;
+
+  RooAbsArg* _owner = nullptr;  ///< Pointer to owner of proxy
+  RooAbsArg* _arg = nullptr;    ///< Pointer to content of proxy
+
+  bool _valueServer = false;    ///< If true contents is value server of owner
+  bool _shapeServer = false;    ///< If true contents is shape server of owner
+  bool _isFund = true;          ///< If true proxy contains an lvalue
+  bool _ownArg = false;         ///< If true proxy owns contents
 
   ClassDefOverride(RooArgProxy,1) // Abstract proxy for RooAbsArg objects
 };

--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -55,7 +55,7 @@ public:
 
   RooArgSet intVars() const { RooArgSet tmp(_sumList) ; tmp.add(_intList) ; tmp.add(_anaList) ; tmp.add(_facList) ; return tmp ; }
   const char* intRange() { return _rangeName ? _rangeName->GetName() : 0 ; }
-  const RooAbsReal& integrand() const { return _function.arg() ; }
+  const RooAbsReal& integrand() const { return *_function; }
 
   void setCacheNumeric(bool flag) {
     // If true, value of this integral is cached if it is (partially numeric)
@@ -73,7 +73,7 @@ public:
 
   std::list<double>* plotSamplingHint(RooAbsRealLValue& obs, double xlo, double xhi) const override {
     // Forward plot sampling hint of integrand
-    return _function.arg().plotSamplingHint(obs,xlo,xhi) ;
+    return _function->plotSamplingHint(obs,xlo,xhi) ;
   }
 
   RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override ;
@@ -83,8 +83,8 @@ public:
 
 protected:
 
-  mutable bool _valid;
-  bool _respectCompSelect;
+  mutable bool _valid = false;
+  bool _respectCompSelect = true;
 
   const RooArgSet& parameters() const ;
 
@@ -116,27 +116,27 @@ protected:
 
   mutable RooArgSet   _facListOwned ;  ///< Owned components in _facList
   RooRealProxy       _function ;     ///<Function being integration
-  RooArgSet*      _funcNormSet ;     ///< Optional normalization set passed to function
+  RooArgSet*      _funcNormSet = nullptr;     ///< Optional normalization set passed to function
 
   mutable RooArgSet       _saveInt ; ///<! do not persist
   mutable RooArgSet       _saveSum ; ///<! do not persist
 
-  RooNumIntConfig* _iconfig ;
+  RooNumIntConfig* _iconfig = nullptr;
 
   mutable RooListProxy _sumCat ; ///<! do not persist
 
-  Int_t _mode ;
-  IntOperMode _intOperMode ;   ///< integration operation mode
+  Int_t _mode = 0;
+  IntOperMode _intOperMode = Hybrid;   ///< integration operation mode
 
-  mutable bool _restartNumIntEngine ; ///<! do not persist
-  mutable RooAbsIntegrator* _numIntEngine ;  ///<! do not persist
-  mutable RooAbsFunc *_numIntegrand;         ///<! do not persist
+  mutable bool _restartNumIntEngine = false; ///<! do not persist
+  mutable std::unique_ptr<RooAbsIntegrator> _numIntEngine;  ///<! do not persist
+  mutable std::unique_ptr<RooAbsFunc> _numIntegrand;        ///<! do not persist
 
-  TNamed* _rangeName ;
+  TNamed* _rangeName = nullptr;
 
-  mutable RooArgSet* _params ; ///<! cache for set of parameters
+  mutable std::unique_ptr<RooArgSet> _params; ///<! cache for set of parameters
 
-  bool _cacheNum ;           ///< Cache integral if numeric
+  bool _cacheNum = false;           ///< Cache integral if numeric
   static Int_t _cacheAllNDim ; ///<! Cache all integrals with given numeric dimension
 
   ClassDefOverride(RooRealIntegral,3) // Real-valued function representing an integral over a RooAbsReal object

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -102,8 +102,7 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   _anaList("!anaList","Variables to be integrated analytically",this,false,false),
   _jacList("!jacList","Jacobian product term",this,false,false),
   _facList("!facList","Variables independent of function",this,false,true),
-  _function("!func","Function to be integrated",this,
-       const_cast<RooAbsReal&>(function),false,false),
+  _function("!func","Function to be integrated",this,false,false),
   _iconfig((RooNumIntConfig*)config),
   _sumCat("!sumCat","SuperCategory for summation",this,false,false),
   _mode(0),
@@ -406,7 +405,7 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
   RooArgSet anIntDepList ;
 
   RooArgSet *anaSet = new RooArgSet( _anaList, Form("UniqueCloneOf_%s",_anaList.GetName()));
-  _mode = ((RooAbsReal&)_function.arg()).getAnalyticalIntegralWN(anIntOKDepList,*anaSet,_funcNormSet,RooNameReg::str(_rangeName)) ;
+  _mode = function.getAnalyticalIntegralWN(anIntOKDepList,*anaSet,_funcNormSet,RooNameReg::str(_rangeName)) ;
   _anaList.removeAll() ;
   _anaList.add(*anaSet);
   delete anaSet;
@@ -539,9 +538,13 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
     // Purely analytical integration
     _intOperMode = Analytic ;
   } else {
-    // No integration performed
+    // No integration performed, where the function is a direct value server
     _intOperMode = PassThrough ;
+    _function._valueServer = true;
   }
+  // We are only setting the function proxy now that it's clear if it's a value
+  // server or not.
+  _function.setArg(const_cast<RooAbsReal&>(function));
 
   // Determine auto-dirty status
   autoSelectDirtyMode() ;
@@ -884,6 +887,10 @@ double RooRealIntegral::evaluate() const
 
   case PassThrough:
     {
+      // In pass through mode, the RooRealIntegral should have registered the
+      // function as a value server, because we directly depend on its value.
+      assert(_function.isValueServer());
+
       //setDirtyInhibit(true) ;
       retVal= _function.arg().getVal(_funcNormSet) ;
       //setDirtyInhibit(false) ;


### PR DESCRIPTION
In pass through mode, the RooRealIntegral should have registered the
function as a value server, because we directly depend on its value.

It's important to do this correctly, because the new BatchMode uses the
value server interface to analyze the computation graph.

Furthermore, it is now ensured that in pass-through mode, no servers are
registered other than the actual function and the additional factorized
observables.

There are also some other commits to ensure no invalid proxies are created
via copy/move assignment and construction.

Final commit in this PR does some code modernization of the RooRealIntegral.