### PR TITLE
[RF] Don't skip zero-weight events by default in new BatchMode

### DIFF
--- a/roofit/roofitcore/res/RooFit/BatchModeDataHelpers.h
+++ b/roofit/roofitcore/res/RooFit/BatchModeDataHelpers.h
@@ -30,10 +30,9 @@ class TNamed;
 namespace RooFit {
 namespace BatchModeDataHelpers {
 
-std::map<RooFit::Detail::DataKey, RooSpan<const double>> getDataSpans(RooAbsData const &data,
-                                                                      std::string_view rangeName,
-                                                                      RooAbsCategory const *indexCat,
-                                                                      std::stack<std::vector<double>> &buffers);
+std::map<RooFit::Detail::DataKey, RooSpan<const double>>
+getDataSpans(RooAbsData const &data, std::string_view rangeName, RooAbsCategory const *indexCat,
+             std::stack<std::vector<double>> &buffers, bool skipZeroWeights);
 
 } // namespace BatchModeDataHelpers
 } // namespace RooFit

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -50,7 +50,7 @@ public:
                 RooFit::BatchModeOption batchMode = RooFit::BatchModeOption::Cpu);
 
    void setData(RooAbsData const &data, std::string_view rangeName = "",
-                RooAbsCategory const *indexCatForSplitting = nullptr);
+                RooAbsCategory const *indexCatForSplitting = nullptr, bool skipZeroWeights = false);
    void setData(DataSpansMap const &dataSpans);
 
    ~RooFitDriver();

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -186,9 +186,10 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooArgSet const &normSet, 
 }
 
 void RooFitDriver::setData(RooAbsData const &data, std::string_view rangeName,
-                           RooAbsCategory const *indexCatForSplitting)
+                           RooAbsCategory const *indexCatForSplitting, bool skipZeroWeights)
 {
-   setData(RooFit::BatchModeDataHelpers::getDataSpans(data, rangeName, indexCatForSplitting, _vectorBuffers));
+   setData(RooFit::BatchModeDataHelpers::getDataSpans(data, rangeName, indexCatForSplitting, _vectorBuffers,
+                                                      skipZeroWeights));
 }
 
 void RooFitDriver::setData(DataSpansMap const &dataSpans)


### PR DESCRIPTION
The new RooFit batchMode skipped zero-weight events to optimize the
likelihood calculation. However, this should not be done in general,
because it is unexpected to users is the output of batched computations
is not aligned with the original dataset.

This commit also adds a smaller commit with a change to ensure that
norm set args are part of the graph in NormalizationHelpers, also used
in the new BatchMode.

