### PR TITLE
[RF] Avoid code duplication in RooAddModel cache generation

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -288,6 +288,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
     src/RooAcceptReject.cxx
     src/RooAdaptiveIntegratorND.cxx
     src/RooAddGenContext.cxx
+    src/RooAddHelpers.cxx
     src/RooAddition.cxx
     src/RooAddModel.cxx
     src/RooAddPdf.cxx

--- a/roofit/roofitcore/inc/RooAddGenContext.h
+++ b/roofit/roofitcore/inc/RooAddGenContext.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <vector>
 
+class AddCacheElem;
 class RooDataSet;
 
 class RooAddGenContext : public RooAbsGenContext {
@@ -61,7 +62,7 @@ protected:
   Int_t  _nComp ;                   ///<  Number of PDF components
   std::vector<double> _coefThresh ;           ///<[_nComp] Array of coefficient thresholds
   bool _isModel ;                 ///< Are we generating from a RooAddPdf or a RooAddModel
-  RooAddPdf::CacheElem* _pcache = nullptr;   ///<! RooAddPdf cache element
+  AddCacheElem* _pcache = nullptr;   ///<! RooAddPdf cache element
 
   ClassDefOverride(RooAddGenContext,0) // Specialized context for generating a dataset from a RooAddPdf
 };

--- a/roofit/roofitcore/inc/RooAddGenContext.h
+++ b/roofit/roofitcore/inc/RooAddGenContext.h
@@ -61,7 +61,6 @@ protected:
   Int_t  _nComp ;                   ///<  Number of PDF components
   std::vector<double> _coefThresh ;           ///<[_nComp] Array of coefficient thresholds
   bool _isModel ;                 ///< Are we generating from a RooAddPdf or a RooAddModel
-  RooAddModel::CacheElem* _mcache = nullptr; ///<! RooAddModel cache element
   RooAddPdf::CacheElem* _pcache = nullptr;   ///<! RooAddPdf cache element
 
   ClassDefOverride(RooAddGenContext,0) // Specialized context for generating a dataset from a RooAddPdf

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -16,13 +16,14 @@
 #ifndef ROO_ADD_MODEL
 #define ROO_ADD_MODEL
 
-#include "RooAddPdf.h"
 #include "RooResolutionModel.h"
 #include "RooListProxy.h"
 #include "RooSetProxy.h"
 #include "RooAICRegistry.h"
 #include "RooNormSetCache.h"
 #include "RooObjCacheManager.h"
+
+class AddCacheElem;
 
 class RooAddModel : public RooResolutionModel {
 public:
@@ -99,8 +100,8 @@ protected:
 
 
   mutable RooObjCacheManager _projCacheMgr ;  ///<! Manager of cache with coefficient projections and transformations
-  RooAddPdf::CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
-  void updateCoefficients(RooAddPdf::CacheElem& cache, const RooArgSet* nset) const ;
+  AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
+  void updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const ;
 
   typedef RooArgList* pRooArgList ;
   void getCompIntList(const RooArgSet* nset, const RooArgSet* iset, pRooArgList& compIntList, Int_t& code, const char* isetRangeName) const ;

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -16,6 +16,7 @@
 #ifndef ROO_ADD_MODEL
 #define ROO_ADD_MODEL
 
+#include "RooAddPdf.h"
 #include "RooResolutionModel.h"
 #include "RooListProxy.h"
 #include "RooSetProxy.h"
@@ -97,23 +98,9 @@ protected:
   mutable double* _coefCache ; ///<! Transiet cache with transformed values of coefficients
 
 
-  class CacheElem : public RooAbsCacheElement {
-  public:
-    ~CacheElem() override {} ;
-
-    RooArgList _suppNormList ;     ///< Supplemental normalization list
-
-    RooArgList _projList ;         ///< Projection integrals to be multiplied with coefficients
-    RooArgList _suppProjList ;     ///< Projection integrals to be multiplied with coefficients for supplemental normalization terms
-    RooArgList _refRangeProjList ; ///< Range integrals to be multiplied with coefficients (reference range)
-    RooArgList _rangeProjList ;    ///< Range integrals to be multiplied with coefficients (target range)
-
-    RooArgList containedArgs(Action) override ;
-
-  } ;
   mutable RooObjCacheManager _projCacheMgr ;  ///<! Manager of cache with coefficient projections and transformations
-  CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
-  void updateCoefficients(CacheElem& cache, const RooArgSet* nset) const ;
+  RooAddPdf::CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
+  void updateCoefficients(RooAddPdf::CacheElem& cache, const RooArgSet* nset) const ;
 
   typedef RooArgList* pRooArgList ;
   void getCompIntList(const RooArgSet* nset, const RooArgSet* iset, pRooArgList& compIntList, Int_t& code, const char* isetRangeName) const ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -29,6 +29,8 @@
 #include <list>
 #include <utility>
 
+class AddCacheElem;
+
 class RooAddPdf : public RooAbsPdf {
 public:
 
@@ -102,26 +104,9 @@ protected:
   std::vector<double> _coefCache; ///<! Transient cache with transformed values of coefficients
 
 
-  class CacheElem : public RooAbsCacheElement {
-  public:
-    CacheElem(RooAbsPdf const& addPdf, RooArgList const& pdfList, RooArgList const& coefList,
-              const RooArgSet* nset, const RooArgSet* iset, const char* rangeName,
-              bool projectCoefs, RooArgSet const& refCoefNorm, TNamed const* refCoefRangeName);
-
-    RooArgList _suppNormList ; ///< Supplemental normalization list
-    bool    _needSupNorm ;     ///< Does the above list contain any non-unit entries?
-
-    RooArgList _projList ;     ///< Projection integrals to be multiplied with coefficients
-    RooArgList _suppProjList ; ///< Projection integrals to be multiplied with coefficients for supplemental normalization terms
-    RooArgList _refRangeProjList ; ///< Range integrals to be multiplied with coefficients (reference range)
-    RooArgList _rangeProjList ;    ///< Range integrals to be multiplied with coefficients (target range)
-
-    RooArgList containedArgs(Action) override ;
-
-  } ;
   mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations
-  CacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
-  void updateCoefficients(CacheElem& cache, const RooArgSet* nset) const ;
+  AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
+  void updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const ;
 
 
   friend class RooAddGenContext ;
@@ -158,7 +143,7 @@ protected:
   }
 
 private:
-  std::pair<const RooArgSet*, CacheElem*> getNormAndCache(const RooArgSet* nset) const;
+  std::pair<const RooArgSet*, AddCacheElem*> getNormAndCache(const RooArgSet* nset) const;
   mutable RooFit::UniqueId<RooArgSet>::Value_t _idOfLastUsedNormSet = RooFit::UniqueId<RooArgSet>::nullval; ///<!
   mutable std::unique_ptr<const RooArgSet> _copyOfLastNormSet = nullptr; ///<!
 

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -104,7 +104,9 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    ~CacheElem() override {} ;
+    CacheElem(RooAbsPdf const& addPdf, RooArgList const& pdfList, RooArgList const& coefList,
+              const RooArgSet* nset, const RooArgSet* iset, const char* rangeName,
+              bool projectCoefs, RooArgSet const& refCoefNorm, TNamed const* refCoefRangeName);
 
     RooArgList _suppNormList ; ///< Supplemental normalization list
     bool    _needSupNorm ;     ///< Does the above list contain any non-unit entries?
@@ -123,6 +125,7 @@ protected:
 
 
   friend class RooAddGenContext ;
+  friend class RooAddModel ;
   RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
                                const RooArgSet* auxProto=nullptr, bool verbose= false) const override;
 

--- a/roofit/roofitcore/src/RooAddGenContext.cxx
+++ b/roofit/roofitcore/src/RooAddGenContext.cxx
@@ -147,7 +147,7 @@ void RooAddGenContext::initGenerator(const RooArgSet &theEvent)
 
   if (_isModel) {
     RooAddModel* amod = (RooAddModel*) _pdf ;
-    _mcache = amod->getProjCache(_vars.get()) ;
+    _pcache = amod->getProjCache(_vars.get()) ;
   } else {
     RooAddPdf* apdf = (RooAddPdf*) _pdf ;
     _pcache = apdf->getProjCache(_vars.get(),nullptr,"FULL_RANGE_ADDGENCONTEXT") ;
@@ -205,7 +205,7 @@ void RooAddGenContext::updateThresholds()
     }
   };
 
-  _isModel ? updateThresholdsImpl(static_cast<RooAddModel*>(_pdf), _mcache)
+  _isModel ? updateThresholdsImpl(static_cast<RooAddModel*>(_pdf), _pcache)
            : updateThresholdsImpl(static_cast<RooAddPdf*>(_pdf), _pcache);
 }
 

--- a/roofit/roofitcore/src/RooAddHelpers.cxx
+++ b/roofit/roofitcore/src/RooAddHelpers.cxx
@@ -1,0 +1,241 @@
+/*
+ * Project: RooFit
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooAddHelpers.h"
+
+#include <RooAbsPdf.h>
+#include <RooArgSet.h>
+#include <RooRealConstant.h>
+#include <RooRealIntegral.h>
+#include <RooRealVar.h>
+
+AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList,
+                           const RooArgSet *nset, const RooArgSet *iset, const char *rangeName, bool projectCoefs,
+                           RooArgSet const &refCoefNorm, TNamed const *refCoefRangeName, int verboseEval)
+{
+   // *** PART 1 : Create supplemental normalization list ***
+
+   // Retrieve the combined set of dependents of this PDF ;
+   RooArgSet fullDepList;
+   addPdf.getObservables(nset, fullDepList);
+   if (iset) {
+      fullDepList.remove(*iset, true, true);
+   }
+
+   // Fill with dummy unit RRVs for now
+   for (std::size_t i = 0; i < pdfList.size(); ++i) {
+      auto pdf = static_cast<const RooAbsPdf *>(pdfList.at(i));
+      auto coef = static_cast<const RooAbsReal *>(coefList.at(i));
+
+      // Start with full list of dependents
+      RooArgSet supNSet(fullDepList);
+
+      // Remove PDF dependents
+      if (auto pdfDeps = std::unique_ptr<RooArgSet>{pdf->getObservables(nset)}) {
+         supNSet.remove(*pdfDeps, true, true);
+      }
+
+      // Remove coef dependents
+      if (auto coefDeps = std::unique_ptr<RooArgSet>{coef ? coef->getObservables(nset) : nullptr}) {
+         supNSet.remove(*coefDeps, true, true);
+      }
+
+      std::unique_ptr<RooAbsReal> snorm;
+      auto name = std::string(addPdf.GetName()) + "_" + pdf->GetName() + "_SupNorm";
+      _needSupNorm = false;
+      if (!supNSet.empty()) {
+         snorm = std::make_unique<RooRealIntegral>(name.c_str(), "Supplemental normalization integral",
+                                                   RooRealConstant::value(1.0), supNSet);
+         oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << " " << addPdf.GetName()
+                                     << " making supplemental normalization set " << supNSet << " for pdf component "
+                                     << pdf->GetName() << std::endl;
+         _needSupNorm = true;
+      } else {
+         snorm = std::make_unique<RooRealVar>(name.c_str(), "Unit Supplemental normalization integral", 1.0);
+      }
+      _suppNormList.addOwned(std::move(snorm));
+   }
+
+   if (verboseEval > 1) {
+      oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "::syncSuppNormList(" << addPdf.GetName()
+                                  << ") synching supplemental normalization list for norm"
+                                  << (nset ? *nset : RooArgSet()) << std::endl;
+      if oodologD (&addPdf, Caching) {
+         _suppNormList.Print("v");
+      }
+   }
+
+   // *** PART 2 : Create projection coefficients ***
+
+   //   cout << " this = " << this << " (" << GetName() << ")" << std::endl ;
+   //   cout << "projectCoefs = " << (_projectCoefs?"T":"F") << std::endl ;
+   //   cout << "_normRange.Length() = " << _normRange.Length() << std::endl ;
+
+   // If no projections required stop here
+   if (!projectCoefs && !rangeName) {
+      //     cout << " no projection required" << std::endl ;
+      return;
+   }
+
+   //   cout << "calculating projection" << std::endl ;
+
+   // Reduce iset/nset to actual dependents of this PDF
+   RooArgSet nset2;
+   if (nset)
+      addPdf.getObservables(nset, nset2);
+   oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "(" << addPdf.GetName()
+                               << ")::getPC nset = " << (nset ? *nset : RooArgSet()) << " nset2 = " << nset2
+                               << std::endl;
+
+   if (nset2.empty() && !refCoefNorm.empty()) {
+      // cout << "WVE: evaluating RooAddPdf without normalization, but have reference normalization for coefficient
+      // definition" << std::endl ;
+
+      nset2.add(refCoefNorm);
+      if (refCoefRangeName) {
+         rangeName = RooNameReg::str(refCoefRangeName);
+      }
+   }
+
+   // Check if requested transformation is not identity
+   if (!nset2.equals(refCoefNorm) || refCoefRangeName != 0 || rangeName != 0 || addPdf.normRange()) {
+
+      oocxcoutD(&addPdf, Caching) << "ALEX:     " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
+                                  << ") projecting coefficients from " << nset2 << (rangeName ? ":" : "")
+                                  << (rangeName ? rangeName : "") << " to "
+                                  << ((!refCoefNorm.empty()) ? refCoefNorm : nset2) << (refCoefRangeName ? ":" : "")
+                                  << (refCoefRangeName ? RooNameReg::str(refCoefRangeName) : "") << std::endl;
+
+      // Recalculate projection integrals of PDFs
+      for (auto *thePdf : static_range_cast<const RooAbsPdf *>(pdfList)) {
+
+         // Calculate projection integral
+         std::unique_ptr<RooAbsReal> pdfProj;
+         if (!nset2.equals(refCoefNorm)) {
+            pdfProj = std::unique_ptr<RooAbsReal>{thePdf->createIntegral(nset2, refCoefNorm, addPdf.normRange())};
+            pdfProj->setOperMode(addPdf.operMode());
+            oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "(" << addPdf.GetName() << ")::getPC nset2(" << nset2
+                                        << ")!=_refCoefNorm(" << refCoefNorm << ") --> pdfProj = " << pdfProj->GetName()
+                                        << std::endl;
+         } else {
+            auto name = std::string(addPdf.GetName()) + "_" + thePdf->GetName() + "_ProjectNorm";
+            pdfProj = std::make_unique<RooRealVar>(name.c_str(), "Unit Projection normalization integral", 1.0);
+            oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "(" << addPdf.GetName() << ")::getPC nset2(" << nset2
+                                        << ")==_refCoefNorm(" << refCoefNorm << ") --> pdfProj = " << pdfProj->GetName()
+                                        << std::endl;
+         }
+
+         oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
+                                     << ") PP = " << pdfProj->GetName() << std::endl;
+         _projList.addOwned(std::move(pdfProj));
+
+         // Calculation optional supplemental normalization term
+         RooArgSet supNormSet(refCoefNorm);
+         auto deps = std::unique_ptr<RooArgSet>{thePdf->getParameters(RooArgSet())};
+         supNormSet.remove(*deps, true, true);
+
+         std::unique_ptr<RooAbsReal> snorm;
+         auto name = std::string(addPdf.GetName()) + "_" + thePdf->GetName() + "_ProjSupNorm";
+         if (!supNormSet.empty() && !nset2.equals(refCoefNorm)) {
+            snorm = std::make_unique<RooRealIntegral>(name.c_str(), "Projection Supplemental normalization integral",
+                                                      RooRealConstant::value(1.0), supNormSet);
+         } else {
+            snorm =
+               std::make_unique<RooRealVar>(name.c_str(), "Unit Projection Supplemental normalization integral", 1.0);
+         }
+         oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
+                                     << ") SN = " << snorm->GetName() << std::endl;
+         _suppProjList.addOwned(std::move(snorm));
+
+         // Calculate reference range adjusted projection integral
+         std::unique_ptr<RooAbsReal> rangeProj1;
+
+         //    cout << "ALEX >>>> RooAddPdf(" << GetName() << ")::getPC refCoefRangeName WVE = "
+         //       <<(refCoefRangeName?":":"") << (refCoefRangeName?RooNameReg::str(refCoefRangeName):"")
+         //       <<" refCoefRangeName AK = "  << (refCoefRangeName?refCoefRangeName->GetName():"")
+         //       << " && _refCoefNorm" << _refCoefNorm << " with size = _refCoefNorm.size() " << _refCoefNorm.size() <<
+         //       std::endl ;
+
+         // Check if refCoefRangeName is identical to default range for all observables,
+         // If so, substitute by unit integral
+
+         // ----------
+         RooArgSet tmpObs;
+         thePdf->getObservables(&refCoefNorm, tmpObs);
+         bool allIdent = true;
+         for (auto *rvarg : dynamic_range_cast<RooRealVar *>(tmpObs)) {
+            if (rvarg) {
+               if (rvarg->getMin(RooNameReg::str(refCoefRangeName)) != rvarg->getMin() ||
+                   rvarg->getMax(RooNameReg::str(refCoefRangeName)) != rvarg->getMax()) {
+                  allIdent = false;
+               }
+            }
+         }
+         // -------------
+
+         if (refCoefRangeName && !refCoefNorm.empty() && !allIdent) {
+
+            RooArgSet tmp;
+            thePdf->getObservables(&refCoefNorm, tmp);
+            rangeProj1 =
+               std::unique_ptr<RooAbsReal>{thePdf->createIntegral(tmp, tmp, RooNameReg::str(refCoefRangeName))};
+
+            // rangeProj1->setOperMode(operMode()) ;
+
+         } else {
+
+            auto theName = std::string(addPdf.GetName()) + "_" + thePdf->GetName() + "_RangeNorm1";
+            rangeProj1 = std::make_unique<RooRealVar>(theName.c_str(), "Unit range normalization integral", 1.0);
+         }
+         oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
+                                     << ") R1 = " << rangeProj1->GetName() << std::endl;
+         _refRangeProjList.addOwned(std::move(rangeProj1));
+
+         // Calculate range adjusted projection integral
+         std::unique_ptr<RooAbsReal> rangeProj2;
+         oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
+                                     << ") rangename = " << (rangeName ? rangeName : "<null>")
+                                     << " nset = " << (nset ? *nset : RooArgSet()) << std::endl;
+         if (rangeName && !refCoefNorm.empty()) {
+
+            rangeProj2 = std::unique_ptr<RooAbsReal>{thePdf->createIntegral(refCoefNorm, refCoefNorm, rangeName)};
+            // rangeProj2->setOperMode(operMode()) ;
+
+         } else if (addPdf.normRange()) {
+
+            RooArgSet tmp;
+            thePdf->getObservables(&refCoefNorm, tmp);
+            rangeProj2 = std::unique_ptr<RooAbsReal>{thePdf->createIntegral(tmp, tmp, addPdf.normRange())};
+
+         } else {
+
+            auto theName = std::string(addPdf.GetName()) + "_" + thePdf->GetName() + "_RangeNorm2";
+            rangeProj2 = std::make_unique<RooRealVar>(theName.c_str(), "Unit range normalization integral", 1.0);
+         }
+         oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
+                                     << ") R2 = " << rangeProj2->GetName() << std::endl;
+         _rangeProjList.addOwned(std::move(rangeProj2));
+      }
+   }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// List all RooAbsArg derived contents in this cache element
+
+RooArgList AddCacheElem::containedArgs(Action)
+{
+   RooArgList allNodes;
+   allNodes.add(_projList);
+   allNodes.add(_suppProjList);
+   allNodes.add(_refRangeProjList);
+   allNodes.add(_rangeProjList);
+
+   return allNodes;
+}

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -1,0 +1,37 @@
+/*
+ * Project: RooFit
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef RooFit_RooFitCore_RooAddHelpers_h
+#define RooFit_RooFitCore_RooAddHelpers_h
+
+#include <RooAbsCacheElement.h>
+#include <RooArgList.h>
+
+class RooAbsPdf;
+class RooArgSet;
+
+class AddCacheElem : public RooAbsCacheElement {
+public:
+   AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList, const RooArgSet *nset,
+                const RooArgSet *iset, const char *rangeName, bool projectCoefs, RooArgSet const &refCoefNorm,
+                TNamed const *refCoefRangeName, int verboseEval);
+
+   RooArgList containedArgs(Action) override;
+
+   RooArgList _suppNormList; ///< Supplemental normalization list
+   bool _needSupNorm;        ///< Does the above list contain any non-unit entries?
+
+   RooArgList _projList;         ///< Projection integrals to be multiplied with coefficients
+   RooArgList _suppProjList;     ///< Projection integrals to multiply with coefficients for supplemental normalization
+   RooArgList _refRangeProjList; ///< Range integrals to be multiplied with coefficients (reference range)
+   RooArgList _rangeProjList;    ///< Range integrals to be multiplied with coefficients (target range)
+};
+
+#endif

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -43,6 +43,7 @@
 
 #include "RooAddModel.h"
 
+#include "RooAddHelpers.h"
 #include "RooMsgService.h"
 #include "RooDataSet.h"
 #include "RooRealProxy.h"
@@ -332,17 +333,17 @@ Int_t RooAddModel::basisCode(const char* name) const
 /// integrals to calculated transformed fraction coefficients when a frozen reference frame is provided
 /// and projection integrals for similar transformations when a frozen reference range is provided.
 
-RooAddPdf::CacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* iset, const char* rangeName) const
+AddCacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* iset, const char* rangeName) const
 {
   // Check if cache already exists
-  RooAddPdf::CacheElem* cache = (RooAddPdf::CacheElem*) _projCacheMgr.getObj(nset,iset,0,rangeName) ;
+  auto cache = static_cast<AddCacheElem*>(_projCacheMgr.getObj(nset,iset,0,rangeName));
   if (cache) {
     return cache ;
   }
 
   //Create new cache
-  cache = new RooAddPdf::CacheElem{*this, _pdfList, _coefList, nset, iset, rangeName,
-                        _projectCoefs, _refCoefNorm, _refCoefRangeName};
+  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset, rangeName,
+                        _projectCoefs, _refCoefNorm, _refCoefRangeName, _verboseEval};
 
   _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(rangeName)) ;
 
@@ -356,7 +357,7 @@ RooAddPdf::CacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const Roo
 /// multiply these the various range and dimensional corrections needed in the
 /// current use context
 
-void RooAddModel::updateCoefficients(RooAddPdf::CacheElem& cache, const RooArgSet* nset) const
+void RooAddModel::updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const
 {
   // cxcoutD(ChangeTracking) << "RooAddModel::updateCoefficients(" << GetName() << ") update coefficients" << endl ;
 
@@ -465,7 +466,7 @@ void RooAddModel::updateCoefficients(RooAddPdf::CacheElem& cache, const RooArgSe
 double RooAddModel::evaluate() const
 {
   const RooArgSet* nset = _normSet ;
-  RooAddPdf::CacheElem* cache = getProjCache(nset) ;
+  AddCacheElem* cache = getProjCache(nset) ;
 
   updateCoefficients(*cache,nset) ;
 
@@ -619,7 +620,7 @@ double RooAddModel::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
 
   // Calculate the current value
   const RooArgSet* nset = _normSet ;
-  RooAddPdf::CacheElem* pcache = getProjCache(nset) ;
+  AddCacheElem* pcache = getProjCache(nset) ;
 
   updateCoefficients(*pcache,nset) ;
 


### PR DESCRIPTION
The `RooAddModel::CacheElem` was exactly the same as for the RooAddPdf.
Hence, the RooAddPdf was refactored a bit such that the code to generate
the CacheElem could be reused in the RooAddModel.