### PR TITLE
[tree/RDF] Move GTLBN from RDF to TreeInternalUtils

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -69,8 +69,6 @@ using namespace ROOT::Detail::RDF;
 using namespace ROOT::RDF;
 namespace TTraits = ROOT::TypeTraits;
 
-ColumnNames_t GetTopLevelBranchNames(TTree &t);
-
 std::string DemangleTypeIdName(const std::type_info &typeInfo);
 
 ColumnNames_t

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1120,7 +1120,7 @@ public:
    {
       const auto definedColumns = fColRegister.GetNames();
       auto *tree = fLoopManager->GetTree();
-      const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
+      const auto treeBranchNames = tree != nullptr ? Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
       // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;
@@ -1264,7 +1264,8 @@ public:
    {
       const auto definedColumns = fColRegister.GetNames();
       auto *tree = fLoopManager->GetTree();
-      const auto treeBranchNames = tree != nullptr ? RDFInternal::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
+      const auto treeBranchNames =
+         tree != nullptr ? Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
       // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;

--- a/tree/tree/inc/ROOT/InternalTreeUtils.hxx
+++ b/tree/tree/inc/ROOT/InternalTreeUtils.hxx
@@ -69,6 +69,7 @@ struct RFriendInfo {
                   const std::string &alias = "");
 };
 
+std::vector<std::string> GetTopLevelBranchNames(TTree &t);
 std::vector<std::string> GetFileNamesFromTree(const TTree &tree);
 RFriendInfo GetFriendInfo(const TTree &tree);
 std::vector<std::string> GetTreeFullPaths(const TTree &tree);

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -18,11 +18,10 @@
 #include <vector>
 #include <stdexcept> // std::runtime_error
 #include <string>
-#include <set>
 
 // Recursively get the top level branches from the specified tree and all of its attached friends.
-static void GetTopLevelBranchNamesImpl(TTree &t, std::set<std::string> &bNamesReg, std::vector<std::string> &bNames,
-                                       std::set<TTree *> &analysedTrees, const std::string friendName = "")
+static void GetTopLevelBranchNamesImpl(TTree &t, std::unordered_set<std::string> &bNamesReg, std::vector<std::string> &bNames,
+                                       std::unordered_set<TTree *> &analysedTrees, const std::string friendName = "")
 {
    if (!analysedTrees.insert(&t).second) {
       return;
@@ -37,7 +36,6 @@ static void GetTopLevelBranchNamesImpl(TTree &t, std::set<std::string> &bNamesRe
          } else if (!friendName.empty()) {
             // If this is a friend and the branch name has already been inserted, it might be because the friend
             // has a branch with the same name as a branch in the main tree. Let's add it as <friendname>.<branchname>.
-            // If used for a Snapshot, this name will become <friendname>_<branchname> (with an underscore).
             const auto longName = friendName + "." + name;
             if (bNamesReg.insert(longName).second)
                bNames.emplace_back(longName);
@@ -121,9 +119,9 @@ void RFriendInfo::AddFriend(const std::vector<std::pair<std::string, std::string
 /// Get all the top-level branches names, including the ones of the friend trees
 std::vector<std::string> GetTopLevelBranchNames(TTree &t)
 {
-   std::set<std::string> bNamesSet;
+   std::unordered_set<std::string> bNamesSet;
    std::vector<std::string> bNames;
-   std::set<TTree *> analysedTrees;
+   std::unordered_set<TTree *> analysedTrees;
    GetTopLevelBranchNamesImpl(t, bNamesSet, bNames, analysedTrees);
    return bNames;
 }


### PR DESCRIPTION
# This Pull request:

Moves GetTopLevelBranchNames from the RDF Internals namespace to the Internal TreeUtils namespace, as it does not rely on RDF and creates unnecessary dependencies.

## Changes or fixes:
- Move GetTopLevelBranch names and its implementation from `/tree/dataframe` to `/tree/tree`.

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes N/A
