### PR TITLE
Remove outdated RTTI flags

### DIFF
--- a/core/dictgen/CMakeLists.txt
+++ b/core/dictgen/CMakeLists.txt
@@ -51,13 +51,6 @@ set_target_properties(Dictgen PROPERTIES
   VISIBILITY_INLINES_HIDDEN "ON"
 )
 
-CHECK_CXX_COMPILER_FLAG("-fno-rtti" CXX_HAS_fno_rtti)
-if(CXX_HAS_fno_rtti)
-    set_source_files_properties(src/rootcling_impl.cxx   PROPERTIES COMPILE_FLAGS "-fno-rtti")
-    set_source_files_properties(src/LinkdefReader.cxx    PROPERTIES COMPILE_FLAGS "-fno-rtti")
-    set_source_files_properties(src/TModuleGenerator.cxx PROPERTIES COMPILE_FLAGS "-fno-rtti")
-endif()
-
 #---CreateRootClingCommandLineOptions------------------------------------------------------------------
 generateHeader(Dictgen
   ${CMAKE_SOURCE_DIR}/core/dictgen/src/rootcling-argparse.py

--- a/core/metacling/src/CMakeLists.txt
+++ b/core/metacling/src/CMakeLists.txt
@@ -7,17 +7,6 @@
 # TInterpreter implementation for cling. Only in libCling; needs to resolve
 # symbols from libCore.
 
-
-if(MSVC)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -GR-)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingDiagnostics.cxx COMPILE_FLAGS -GR-)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingRdictModuleFileExtension.cxx COMPILE_FLAGS -GR-)
-else()
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingCallbacks.cxx COMPILE_FLAGS -fno-rtti)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingDiagnostics.cxx COMPILE_FLAGS -fno-rtti)
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/TClingRdictModuleFileExtension.cxx COMPILE_FLAGS -fno-rtti)
-endif()
-
 ROOT_OBJECT_LIBRARY(MetaCling
   rootclingTCling.cxx
   TCling.cxx

--- a/core/rootcling_stage1/CMakeLists.txt
+++ b/core/rootcling_stage1/CMakeLists.txt
@@ -11,9 +11,6 @@
 if(WIN32)
   set_source_files_properties(src/rootcling_stage1.cxx PROPERTIES COMPILE_FLAGS "-D_WIN32 -DNOMINMAX")
 else()
-  if(CXX_HAS_fno_rtti)
-    set_source_files_properties(src/rootcling_stage1.cxx PROPERTIES COMPILE_FLAGS "-fno-rtti")
-  endif()
 endif()
 
 if(NOT builtin_clang)

--- a/interpreter/cling/CMakeLists.txt
+++ b/interpreter/cling/CMakeLists.txt
@@ -292,7 +292,6 @@ endif ()
 
 # The package needs to be compiler without RTTI information
 if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -GR-")
   if(NOT DEFINED ROOT_BINARY_DIR)
     # Add the /std:c++XX flag for Visual Studio if not building as part of ROOT
     if(MSVC_VERSION GREATER_EQUAL 1920)
@@ -303,8 +302,6 @@ if(MSVC)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std:c++14")
     endif()
   endif()
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
Since commit 0a5b6c60e0, we build LLVM with RTTI enabled. It doesn't make sense anymore to build some of our source files without RTTI just because they are pulling in LLVM headers.