### PR TITLE
[RF] Vectorize `RooAbsBinning` interface for bin index lookups

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -175,6 +175,11 @@ The `RooAbsMinimizerFcn` class and its implementation `RooMinimizerFcn` were rem
 These classes are implementation details of the RooMinimizer and should not be used in your code.
 In the unlikely case that this causes any problem for you, please open a GitHub issue requesting to extend the RooMinimizer by the needed functionality.
 
+### Vectorize `RooAbsBinning` interface for bin index lookups
+
+The `RooAbsBinning` interface for bin index lookups was changed to enable vectorized implementations.
+Instead of having the override `RooAbsBinning::binNumber()`, the binning implementations now have to override the `RooAbsBinning::binNumbers()` function to evaluate the bin indices of multiple values in one function call.
+
 ## 2D Graphics Libraries
 
 - Implement the option "File": The current file name is painted on the bottom right of each plot

--- a/roofit/roofitcore/inc/RooAbsBinning.h
+++ b/roofit/roofitcore/inc/RooAbsBinning.h
@@ -39,7 +39,6 @@ public:
   }
   virtual Int_t numBoundaries() const = 0 ;
   virtual Int_t binNumber(double x) const = 0 ;
-  virtual Int_t rawBinNumber(double x) const { return binNumber(x) ; }
   virtual double binCenter(Int_t bin) const = 0 ;
   virtual double binWidth(Int_t bin) const = 0 ;
   virtual double binLow(Int_t bin) const = 0 ;

--- a/roofit/roofitcore/inc/RooBinning.h
+++ b/roofit/roofitcore/inc/RooBinning.h
@@ -38,7 +38,7 @@ public:
   Int_t numBoundaries() const override {
     return _nbins+1;
   }
-  Int_t binNumber(double x) const override;
+  void binNumbers(double const * x, int * bins, std::size_t n, int coef) const override;
   Int_t rawBinNumber(double x) const;
   virtual double nearestBoundary(double x) const;
 

--- a/roofit/roofitcore/inc/RooBinning.h
+++ b/roofit/roofitcore/inc/RooBinning.h
@@ -39,7 +39,7 @@ public:
     return _nbins+1;
   }
   Int_t binNumber(double x) const override;
-  Int_t rawBinNumber(double x) const override;
+  Int_t rawBinNumber(double x) const;
   virtual double nearestBoundary(double x) const;
 
   void setRange(double xlo, double xhi) override;
@@ -69,8 +69,6 @@ public:
   void addBoundaryPair(double boundary, double mirrorPoint = 0);
   void addUniform(Int_t nBins, double xlo, double xhi);
   bool removeBoundary(double boundary);
-
-  bool hasBoundary(double boundary);
 
 protected:
 

--- a/roofit/roofitcore/inc/RooLinTransBinning.h
+++ b/roofit/roofitcore/inc/RooLinTransBinning.h
@@ -29,7 +29,7 @@ public:
   ~RooLinTransBinning() override ;
 
   Int_t numBoundaries() const override { return _input->numBoundaries() ; }
-  Int_t binNumber(double x) const override { return _input->binNumber(invTrans(x)) ; }
+  void binNumbers(double const * x, int * bins, std::size_t n, int coef) const override;
   double binCenter(Int_t bin) const override { return trans(_input->binCenter(binTrans(bin))) ; }
   double binWidth(Int_t bin) const override { return _slope*_input->binWidth(binTrans(bin)) ; }
   double binLow(Int_t bin) const override { if (_slope>0) return trans(_input->binLow(binTrans(bin))) ; else return trans(_input->binHigh(binTrans(bin))) ; }

--- a/roofit/roofitcore/inc/RooParamBinning.h
+++ b/roofit/roofitcore/inc/RooParamBinning.h
@@ -33,7 +33,7 @@ public:
   void setRange(double xlo, double xhi) override ;
 
   Int_t numBoundaries() const override { return _nbins + 1 ; }
-  Int_t binNumber(double x) const override  ;
+  void binNumbers(double const * x, int * bins, std::size_t n, int coef) const override;
 
   double lowBound() const override { return xlo()->getVal() ; }
   double highBound() const override { return xhi()->getVal() ; }

--- a/roofit/roofitcore/inc/RooRangeBinning.h
+++ b/roofit/roofitcore/inc/RooRangeBinning.h
@@ -28,7 +28,7 @@ public:
   ~RooRangeBinning() override ;
 
   Int_t numBoundaries() const override { return 2 ; }
-  Int_t binNumber(double) const override { return 0 ; }
+  void binNumbers(double const * /*x*/, int * /*bins*/, std::size_t /*n*/, int /*coef*/) const override {}
   double binCenter(Int_t) const override { return (_range[0] + _range[1]) / 2 ; }
   double binWidth(Int_t) const override { return (_range[1] - _range[0]) ; }
   double binLow(Int_t) const override { return _range[0] ; }

--- a/roofit/roofitcore/inc/RooUniformBinning.h
+++ b/roofit/roofitcore/inc/RooUniformBinning.h
@@ -31,7 +31,7 @@ public:
   void setRange(double xlo, double xhi) override ;
 
   Int_t numBoundaries() const override { return _nbins + 1 ; }
-  Int_t binNumber(double x) const override  ;
+  void binNumbers(double const * x, int * bins, std::size_t n, int coef) const override;
   bool isUniform() const override { return true ; }
 
   double lowBound() const override { return _xlo ; }

--- a/roofit/roofitcore/src/RooAbsBinning.cxx
+++ b/roofit/roofitcore/src/RooAbsBinning.cxx
@@ -34,24 +34,6 @@ This class defines the interface to retrieve bin boundaries, ranges etc.
 using namespace std;
 
 ClassImp(RooAbsBinning);
-;
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Constructor
-
-RooAbsBinning::RooAbsBinning(const char* name) : TNamed(name,name)
-{
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-
-RooAbsBinning::~RooAbsBinning()
-{
-}
 
 
 

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -158,14 +158,6 @@ bool RooBinning::removeBoundary(double boundary)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Check if boundary exists at given value
-
-bool RooBinning::hasBoundary(double boundary)
-{
-  return std::binary_search(_boundaries.begin(), _boundaries.end(), boundary);
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// Add array of nbins uniformly sized bins in range [xlo,xhi]
 
 void RooBinning::addUniform(Int_t nbins, double xlo, double xhi)
@@ -176,6 +168,18 @@ void RooBinning::addUniform(Int_t nbins, double xlo, double xhi)
    (double(i) / double(nbins)) * xhi);
 }
 
+namespace {
+
+inline int rawBinNumberImpl(double x, std::vector<double> const& boundaries) {
+  auto it = std::lower_bound(boundaries.begin(), boundaries.end(), x);
+  // always return valid bin number
+  while (boundaries.begin() != it &&
+     (boundaries.end() == it || boundaries.end() == it + 1 || x < *it)) --it;
+  return it - boundaries.begin();
+}
+
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Return sequential bin number that contains value x where bin
 /// zero is the first bin with an upper boundary above the lower bound
@@ -183,7 +187,7 @@ void RooBinning::addUniform(Int_t nbins, double xlo, double xhi)
 
 Int_t RooBinning::binNumber(double x) const
 {
-  return std::max(0, std::min(_nbins, rawBinNumber(x) - _blo));
+  return std::max(0, std::min(_nbins, rawBinNumberImpl(x, _boundaries) - _blo));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -193,13 +197,9 @@ Int_t RooBinning::binNumber(double x) const
 
 Int_t RooBinning::rawBinNumber(double x) const
 {
-  std::vector<double>::const_iterator it = std::lower_bound(
-      _boundaries.begin(), _boundaries.end(), x);
-  // always return valid bin number
-  while (_boundaries.begin() != it &&
-     (_boundaries.end() == it || _boundaries.end() == it + 1 || x < *it)) --it;
-  return it - _boundaries.begin();
+  return rawBinNumberImpl(x, _boundaries);
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the value of the nearest boundary to x
@@ -254,7 +254,7 @@ void RooBinning::updateBinCount()
       _nbins = -1;
       return;
   }
-  _blo = rawBinNumber(_xlo);
+  _blo = rawBinNumberImpl(_xlo, _boundaries);
   std::vector<double>::const_iterator it = std::lower_bound(
       _boundaries.begin(), _boundaries.end(), _xhi);
   if (_boundaries.begin() != it && (_boundaries.end() == it || _xhi < *it)) --it;

--- a/roofit/roofitcore/src/RooBinning.cxx
+++ b/roofit/roofitcore/src/RooBinning.cxx
@@ -185,9 +185,11 @@ inline int rawBinNumberImpl(double x, std::vector<double> const& boundaries) {
 /// zero is the first bin with an upper boundary above the lower bound
 /// of the range
 
-Int_t RooBinning::binNumber(double x) const
+void RooBinning::binNumbers(double const * x, int * bins, std::size_t n, int coef) const
 {
-  return std::max(0, std::min(_nbins, rawBinNumberImpl(x, _boundaries) - _blo));
+  for(std::size_t i = 0; i < n; ++i) {
+    bins[i] += coef * (std::max(0, std::min(_nbins, rawBinNumberImpl(x[i], _boundaries) - _blo)));
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooLinTransBinning.cxx
+++ b/roofit/roofitcore/src/RooLinTransBinning.cxx
@@ -26,6 +26,8 @@ way that RooLinearVar does
 
 #include "RooLinTransBinning.h"
 
+#include <stdexcept>
+
 using namespace std;
 
 ClassImp(RooLinTransBinning);
@@ -113,3 +115,15 @@ void RooLinTransBinning::updateInput(const RooAbsBinning& input, double slope, d
   _offset = offset ;
 }
 
+
+void RooLinTransBinning::binNumbers(double const * x, int * bins, std::size_t n, int coef) const
+{
+  // We are not allowed to modify the input array, so we can't apply the
+  // transformation in-place and then call _input->binNumbers() without
+  // allocating additional memory. That's why we fall back to binNumber() for
+  // now. The RooLinTransBinning is only ever used in the RooLinearVar, so if
+  // this ever becomes a bottleneck this could be optimized.
+  for(std::size_t i = 0; i < n; ++i) {
+    bins[i] += coef * _input->binNumber(invTrans(x[i]));
+  }
+}

--- a/roofit/roofitcore/src/RooParamBinning.cxx
+++ b/roofit/roofitcore/src/RooParamBinning.cxx
@@ -192,12 +192,15 @@ void RooParamBinning::setRange(double newxlo, double newxhi)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the fit bin index for the current value
 
-Int_t RooParamBinning::binNumber(double x) const
+void RooParamBinning::binNumbers(double const * x, int * bins, std::size_t n, int coef) const
 {
-  if (x >= xhi()->getVal()) return _nbins-1 ;
-  if (x < xlo()->getVal()) return 0 ;
+  const double xloVal = xlo()->getVal();
+  const double xhiVal = xhi()->getVal();
+  const double oneOverW = 1./averageBinWidth();
 
-  return Int_t((x - xlo()->getVal())/averageBinWidth()) ;
+  for(std::size_t i = 0; i < n; ++i) {
+    bins[i] += coef * (x[i] >= xhiVal ? _nbins - 1 : std::max(0, int((x[i] - xloVal)*oneOverW)));
+  }
 }
 
 

--- a/roofit/roofitcore/src/RooUniformBinning.cxx
+++ b/roofit/roofitcore/src/RooUniformBinning.cxx
@@ -114,12 +114,13 @@ void RooUniformBinning::setRange(double xlo, double xhi)
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the index of the bin that encloses 'x'
 
-Int_t RooUniformBinning::binNumber(double x) const
+void RooUniformBinning::binNumbers(double const * x, int * bins, std::size_t n, int coef) const
 {
-  Int_t bin = Int_t((x - _xlo)/_binw) ;
-  if (bin<0) return 0 ;
-  if (bin>_nbins-1) return _nbins-1 ;
-  return bin ;
+  const double oneOverW = 1./_binw;
+
+  for(std::size_t i = 0; i < n; ++i) {
+    bins[i] += coef * (x[i] >= _xhi ? _nbins - 1 : std::max(0, int((x[i] - _xlo)*oneOverW)));
+  }
 }
 
 


### PR DESCRIPTION
The `RooAbsBinning` interface for bin index lookups was changed to
enable vectorized implementations. Instead of having the override
`RooAbsBinning::binNumber()`, the binning implementations now have to
override the `RooAbsBinning::binNumbers()` function to evaluate the bin
indices of multiple values in one function call.

The interface of `RooAbsBinning::binNumbers()` is designed to facilitate
the accregation of bin indices over multiple dimensions, and it uses a
`double` ouput vector such that the caller can reuse the output buffer
for other computations.

The former `RooAbsBinning::binNumber()` method is now implement in terms
of the vectorized version, such that we automatically get wide test
coverage. It was verified that this doesn't come with a performance
overhead.

This will greatly facilitate the vectorization of the RooHistPdf and
RooHistFunc later.

A second commit in this PR applies some other improvements to the `RooBinning` class.

