### PR TITLE
[VecOps] Add missing #include <limits> to RVec.hxx

### DIFF
--- a/math/vecops/inc/ROOT/RVec.hxx
+++ b/math/vecops/inc/ROOT/RVec.hxx
@@ -38,6 +38,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits> // for numeric_limits
 #include <new>
 #include <numeric> // for inner_product
 #include <sstream>


### PR DESCRIPTION
The file uses `std::numeric_limits`, defined in `<limits>` . That header is transitively included in most configurations, but for example not when building with a recent libstdc++ (with less transitive includes) and configuring with cxx14 and without VDT.