### PR TITLE
Add a couple of missing "ROOT::" namespaces

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -1120,7 +1120,7 @@ public:
    {
       const auto definedColumns = fColRegister.GetNames();
       auto *tree = fLoopManager->GetTree();
-      const auto treeBranchNames = tree != nullptr ? Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
+      const auto treeBranchNames = tree != nullptr ? ROOT::Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
       // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;
@@ -1264,7 +1264,7 @@ public:
       const auto definedColumns = fColRegister.GetNames();
       auto *tree = fLoopManager->GetTree();
       const auto treeBranchNames =
-         tree != nullptr ? Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
+         tree != nullptr ? ROOT::Internal::TreeUtils::GetTopLevelBranchNames(*tree) : ColumnNames_t{};
       const auto dsColumns = fDataSource ? fDataSource->GetColumnNames() : ColumnNames_t{};
       // Ignore R_rdf_sizeof_* columns coming from datasources: we don't want to Snapshot those
       ColumnNames_t dsColumnsWithoutSizeColumns;


### PR DESCRIPTION
This fixes the following compilation errors on Windows:
```
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1123,64): error C2039: 'TreeUtils': is not a member of 'ROOT::RDF::Internal' [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RSqliteDS.hxx(27): message : see declaration of 'ROOT::RDF::Internal' [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1120): message : while compiling class template member function 'ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::RDF::RInterface<Proxied,DataSource>::RLoopManager,void>> ROOT::RDF::RInterface<ROOT::RDF::RInterface<Proxied,DataSource>::RLoopManager,void>::Snapshot(std::string_view,std::string_view,std::string_view,const ROOT::RDF::RSnapshotOptions &)' [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\test\datasource_sqlite.cxx(41): message : see reference to function template instantiation 'ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::RDF::RInterface<Proxied,DataSource>::RLoopManager,void>> ROOT::RDF::RInterface<ROOT::RDF::RInterface<Proxied,DataSource>::RLoopManager,void>::Snapshot(std::string_view,std::string_view,std::string_view,const ROOT::RDF::RSnapshotOptions &)' being compiled [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDataFrame.hxx(41): message : see reference to class template instantiation 'ROOT::RDF::RInterface<ROOT::RDF::RInterface<Proxied,DataSource>::RLoopManager,void>' being compiled [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1123,64): error C3083: 'TreeUtils': the symbol to the left of a '::' must be a type [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1123,75): error C2039: 'GetTopLevelBranchNames': is not a member of 'ROOT::RDF::Internal' [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RSqliteDS.hxx(27): message : see declaration of 'ROOT::RDF::Internal' [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1123,1): error C3861: 'GetTopLevelBranchNames': identifier not found [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1123,18): error C2737: 'treeBranchNames': const object must be initialized [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1130,1): error C3536: 'treeBranchNames': cannot be used before it is initialized [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
C:\Users\bellenot\git\master\tree\dataframe\inc\ROOT/RDF/RInterface.hxx(1132,1): error C2661: 'std::vector<std::string,std::allocator<std::string>>::insert': no overloaded function takes 1 arguments [C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj]
Done Building Project "C:\Users\bellenot\build\x86\release\tree\dataframe\test\datasource_sqlite.vcxproj" (default targets) -- FAILED.
```
