### PR TITLE
Make IsAboveMaxEdm() return true if Edm is NaN

### DIFF
--- a/math/minuit2/inc/Minuit2/FunctionMinimum.h
+++ b/math/minuit2/inc/Minuit2/FunctionMinimum.h
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <memory>
+#include <cmath>
 
 #ifdef G__DICTIONARY
 typedef ROOT::Minuit2::MinimumState MinimumState;
@@ -100,7 +101,7 @@ public:
    bool HasMadePosDefCovar() const { return State().Error().IsMadePosDef(); }
    bool HesseFailed() const { return State().Error().HesseFailed(); }
    bool HasCovariance() const { return State().Error().IsAvailable(); }
-   bool IsAboveMaxEdm() const { return fPtr->fAboveMaxEdm; }
+   bool IsAboveMaxEdm() const { return fPtr->fAboveMaxEdm || std::isnan(Edm()); }
    bool HasReachedCallLimit() const { return fPtr->fReachedCallLimit; }
 
    void SetErrorDef(double up)


### PR DESCRIPTION
Minuit2's MnHesse sometimes returns success, but the matrix contains only NaN values (this should be fixed, but that is a bigger issue not addressed here).

In this case, IsAboveMaxEdm() returns false, since NaN < threshold is false, irregardless of the threshold. This leads to Minuit2 wrongly reporting that the minimum is "valid".

This fix makes sure that IsAboveMaxEdm() returns true if the Edm value is NaN and the fit is reported as **invalid**, which is not perfect but better than the current confusing behavior.

## Checklist:

- [x] tested changes locally
