### PR TITLE
[RF] Multiple RooAddPdf improvements that also speed up the evaluation in BatchMode

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -545,6 +545,7 @@ protected:
 
   friend class RooRealSumPdf ;
   friend class RooRealSumFunc;
+  friend class RooAddHelpers ;
   friend class RooAddPdf ;
   friend class RooAddModel ;
   void selectComp(bool flag) {

--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -33,7 +33,6 @@ public:
   RooAddModel(const RooAddModel& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooAddModel(*this,newname) ; }
   RooResolutionModel* convolution(RooFormulaVar* basis, RooAbsArg* owner) const override ;
-  ~RooAddModel() override ;
 
   double evaluate() const override ;
   bool checkObservables(const RooArgSet* nset) const override ;
@@ -93,10 +92,10 @@ protected:
   void selectNormalizationRange(const char* rangeName=nullptr, bool force=false) override ;
 
   mutable RooSetProxy _refCoefNorm ;   ///<! Reference observable set for coefficient interpretation
-  mutable TNamed* _refCoefRangeName ;  ///<! Reference range name for coefficient interpretation
+  mutable TNamed* _refCoefRangeName = nullptr;  ///<! Reference range name for coefficient interpretation
 
-  bool _projectCoefs ;         ///< If true coefficients need to be projected for use in evaluate()
-  mutable double* _coefCache ; ///<! Transiet cache with transformed values of coefficients
+  bool _projectCoefs = false;  ///< If true coefficients need to be projected for use in evaluate()
+  mutable std::vector<double> _coefCache; ///<! Transiet cache with transformed values of coefficients
 
 
   mutable RooObjCacheManager _projCacheMgr ;  ///<! Manager of cache with coefficient projections and transformations
@@ -114,14 +113,14 @@ protected:
 
   mutable RooObjCacheManager _intCacheMgr ; ///<! Manager of cache with integrals
 
-  mutable RooAICRegistry _codeReg ;  ///<! Registry of component analytical integration codes
+  mutable RooAICRegistry _codeReg = 10; ///<! Registry of component analytical integration codes
 
   RooListProxy _pdfList ;   ///<  List of component PDFs
   RooListProxy _coefList ;  ///<  List of coefficients
   mutable RooArgList* _snormList{nullptr};  ///<!  List of supplemental normalization factors
 
-  bool _haveLastCoef ;    ///<  Flag indicating if last PDFs coefficient was supplied in the ctor
-  bool _allExtendable ;   ///<  Flag indicating if all PDF components are extendable
+  bool _haveLastCoef = false;    ///<  Flag indicating if last PDFs coefficient was supplied in the ctor
+  bool _allExtendable = false;   ///<  Flag indicating if all PDF components are extendable
 
   mutable Int_t _coefErrCount ; ///<! Coefficient error counter
 

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -106,7 +106,7 @@ protected:
 
   mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations
   AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
-  void updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const ;
+  void updateCoefficients(AddCacheElem& cache, const RooArgSet* nset, bool syncCoefValues=true) const ;
 
 
   friend class RooAddGenContext ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -101,7 +101,7 @@ protected:
   mutable TNamed* _refCoefRangeName = nullptr ;  ///< Reference range name for coefficient interpreation
 
   bool _projectCoefs = false;     ///< If true coefficients need to be projected for use in evaluate()
-  std::vector<double> _coefCache; ///<! Transient cache with transformed values of coefficients
+  mutable std::vector<double> _coefCache; ///<! Transient cache with transformed values of coefficients
 
 
   mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -34,4 +34,12 @@ public:
    RooArgList _rangeProjList;    ///< Range integrals to be multiplied with coefficients (target range)
 };
 
+class RooAddHelpers {
+public:
+   static void updateCoefficients(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList,
+                                  AddCacheElem &cache, const RooArgSet *nset, bool projectCoefs,
+                                  RooArgSet const &refCoefNorm, bool allExtendable, std::vector<double> &coefCache,
+                                  int &coefErrCount);
+};
+
 #endif

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -61,10 +61,9 @@ private:
 
 class RooAddHelpers {
 public:
-   static void updateCoefficients(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList,
-                                  AddCacheElem &cache, const RooArgSet *nset, bool projectCoefs,
-                                  RooArgSet const &refCoefNorm, bool allExtendable, std::vector<double> &coefCache,
-                                  int &coefErrCount);
+   static void updateCoefficients(RooAbsPdf const &addPdf, std::vector<double> &coefCache, RooArgList const &pdfList,
+                                  bool haveLastCoef, AddCacheElem &cache, const RooArgSet *nset, bool projectCoefs,
+                                  RooArgSet const &refCoefNorm, bool allExtendable, int &coefErrCount);
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -13,6 +13,7 @@
 
 #include <RooAbsCacheElement.h>
 #include <RooArgList.h>
+#include <RooAbsReal.h>
 
 class RooAbsPdf;
 class RooArgSet;
@@ -25,13 +26,37 @@ public:
 
    RooArgList containedArgs(Action) override;
 
-   RooArgList _suppNormList; ///< Supplemental normalization list
-   bool _needSupNorm;        ///< Does the above list contain any non-unit entries?
+   inline double suppNormVal(std::size_t idx) const { return _suppNormList[idx] ? _suppNormList[idx]->getVal() : 1.0; }
 
-   RooArgList _projList;         ///< Projection integrals to be multiplied with coefficients
-   RooArgList _suppProjList;     ///< Projection integrals to multiply with coefficients for supplemental normalization
-   RooArgList _refRangeProjList; ///< Range integrals to be multiplied with coefficients (reference range)
-   RooArgList _rangeProjList;    ///< Range integrals to be multiplied with coefficients (target range)
+   inline bool doProjection() const { return !_projList.empty(); }
+
+   inline double projVal(std::size_t idx) const { return _projList[idx] ? _projList[idx]->getVal() : 1.0; }
+
+   inline double projSuppNormVal(std::size_t idx) const
+   {
+      return _suppProjList[idx] ? _suppProjList[idx]->getVal() : 1.0;
+   }
+
+   inline double rangeProjScaleFactor(std::size_t idx) const { return rangeProjVal(idx) / refRangeProjVal(idx); }
+
+private:
+   inline double refRangeProjVal(std::size_t idx) const
+   {
+      return _refRangeProjList[idx] ? _refRangeProjList[idx]->getVal() : 1.0;
+   }
+
+   inline double rangeProjVal(std::size_t idx) const
+   {
+      return _rangeProjList[idx] ? _rangeProjList[idx]->getVal() : 1.0;
+   }
+
+   using OwningArgVector = std::vector<std::unique_ptr<RooAbsReal>>;
+
+   OwningArgVector _suppNormList; ///< Supplemental normalization list
+   OwningArgVector _projList;     ///< Projection integrals to be multiplied with coefficients
+   OwningArgVector _suppProjList; ///< Projection integrals to multiply with coefficients for supplemental normalization
+   OwningArgVector _refRangeProjList; ///< Range integrals to be multiplied with coefficients (reference range)
+   OwningArgVector _rangeProjList;    ///< Range integrals to be multiplied with coefficients (target range)
 };
 
 class RooAddHelpers {

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -64,7 +64,6 @@ RooAddModel::RooAddModel() :
   _projCacheMgr(this,10),
   _intCacheMgr(this,10)
 {
-  _coefCache.resize(10);
   _coefErrCount = _errorCount ;
 }
 
@@ -149,7 +148,6 @@ RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& 
       _haveLastCoef = true;
    }
 
-   _coefCache.resize(_pdfList.getSize());
    _coefErrCount = _errorCount;
 
    if (ownPdfList) {
@@ -173,7 +171,6 @@ RooAddModel::RooAddModel(const RooAddModel& other, const char* name) :
   _haveLastCoef(other._haveLastCoef),
   _allExtendable(other._allExtendable)
 {
-  _coefCache.resize(_pdfList.getSize());
   _coefErrCount = _errorCount ;
 }
 
@@ -340,8 +337,12 @@ AddCacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* 
 
 void RooAddModel::updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const
 {
-  RooAddHelpers::updateCoefficients(*this, _pdfList, _coefList, cache, nset, _projectCoefs,
-                                    _refCoefNorm, _allExtendable, _coefCache, _coefErrCount);
+  _coefCache.resize(_pdfList.getSize());
+  for(std::size_t i = 0; i < _coefList.size(); ++i) {
+    _coefCache[i] = static_cast<RooAbsReal const&>(_coefList[i]).getVal(nset);
+  }
+  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset, _projectCoefs,
+                                    _refCoefNorm, _allExtendable, _coefErrCount);
 }
 
 

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -364,7 +364,7 @@ double RooAddModel::evaluate() const
     auto pdf = static_cast<RooAbsPdf*>(obj);
 
     if (_coefCache[i]!=0.) {
-      snormVal = nset ? ((RooAbsReal*)cache->_suppNormList.at(i))->getVal() : 1.0 ;
+      snormVal = nset ? cache->suppNormVal(i) : 1.0 ;
       double pdfVal = pdf->getVal(nset) ;
       // double pdfNorm = pdf->getNorm(nset) ;
       if (pdf->isSelectedComp()) {
@@ -516,7 +516,7 @@ double RooAddModel::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, c
   for (const auto obj : *compIntList) {
     auto pdfInt = static_cast<const RooAbsReal*>(obj);
     if (_coefCache[i]!=0.) {
-      snormVal = nset ? ((RooAbsReal*)pcache->_suppNormList.at(i))->getVal() : 1.0 ;
+      snormVal = nset ? pcache->suppNormVal(i) : 1.0 ;
       double intVal = pdfInt->getVal(nset) ;
       value += intVal*_coefCache[i]/snormVal ;
       cxcoutD(Eval) << "RooAddModel::evaluate(" << GetName() << ")  value += ["


### PR DESCRIPTION
This PR applies several improvements to the RooAddPdf class:

1. Avoid code duplication of `updateCoefficients()` with RooAddModel
2. Reduce footprint of cache object by using `std::vector` and avoid creating dummy RooRealVars
3. Avoid redundant computation of raw coefficient values in BatchMode, which fixes performance problems in important fits like the ATLAS Higgs combination

More details can be found in the commit descriptions.

