### PR TITLE
[RF] Explicitly forbid integration of a `RooAbsRealLValue`

### DIFF
--- a/roofit/roofitcore/inc/RooAbsRealLValue.h
+++ b/roofit/roofitcore/inc/RooAbsRealLValue.h
@@ -153,6 +153,8 @@ public:
   static TH1* createHistogram(const char *name, RooArgList &vars, const char *tAxisLabel, double* xlo, double* xhi, Int_t* nBins) ;
   static TH1* createHistogram(const char *name, RooArgList &vars, const char *tAxisLabel, const RooAbsBinning** bins) ;
 
+  RooAbsReal* createIntegral(const RooArgSet& iset, const RooArgSet* nset=nullptr, const RooNumIntConfig* cfg=nullptr, const char* rangeName=nullptr) const override;
+
 protected:
 
   virtual void setValFast(double value) { setVal(value) ; }

--- a/roofit/roofitcore/src/RooAbsRealLValue.cxx
+++ b/roofit/roofitcore/src/RooAbsRealLValue.cxx
@@ -1030,3 +1030,14 @@ bool RooAbsRealLValue::isJacobianOK(const RooArgSet&) const
   // always returns true (i.e. jacobian is constant)
   return true ;
 }
+
+
+RooAbsReal* RooAbsRealLValue::createIntegral(const RooArgSet&, const RooArgSet*, const RooNumIntConfig*, const char*) const
+{
+  std::stringstream errStream;
+  errStream << "Attempting to integrate the " << ClassName() << " \"" << GetName()
+            << "\", but integrating a RooAbsRealLValue is not allowed!";
+  const std::string errString = errStream.str();
+  coutE(InputArguments) << errString << std::endl;
+  throw std::runtime_error(errString);
+}

--- a/roofit/roofitcore/test/testRooWrapperPdf.cxx
+++ b/roofit/roofitcore/test/testRooWrapperPdf.cxx
@@ -22,9 +22,10 @@ TEST(RooWrapperPdf, Basics)
   RooRealVar a0("a0", "a0", 0.1, 0.1, 10.);
   RooRealVar a1("a1", "a1", -0.01, -2.1, 0.);
   RooRealVar a2("a2", "a2", 0.01, 0.01, 5.);
+  RooProduct xId("xId", "x", RooArgList(x));
   RooProduct xSq("xSq", "x^2", RooArgList(x, x));
   RooConstVar one("one", "one", 1.);
-  RooRealSumFunc pol("pol", "pol", RooArgList(one, x, xSq), RooArgList(a0, a1, a2));
+  RooRealSumFunc pol("pol", "pol", RooArgList(one, xId, xSq), RooArgList(a0, a1, a2));
 
   RooWrapperPdf polPdf("polPdf", "polynomial PDF", pol);
 
@@ -52,15 +53,16 @@ TEST(RooWrapperPdf, GenerateAndFit) {
   RooRealVar a0("a0", "a0", 0.1);
   RooRealVar a1("a1", "a1", -0.01);
   RooRealVar a2("a2", "a2", 0.01, 0.001, 5.);
+  RooProduct xId("xId", "x", RooArgList(x));
   RooProduct xSq("xSq", "x^2", RooArgList(x, x));
   RooConstVar one("one", "one", 1.);
-  RooRealSumFunc pol("pol", "pol", RooArgList(one, x, xSq), RooArgList(a0, a1, a2));
+  RooRealSumFunc pol("pol", "pol", RooArgList(one, xId, xSq), RooArgList(a0, a1, a2));
 
   RooWrapperPdf polPdf("polPdf", "polynomial PDF", pol);
 
   auto data = polPdf.generate(x, 50000);
   a2.setVal(0.02);
-  auto result = polPdf.fitTo(*data, RooFit::Save());
+  auto result = polPdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1));
 
   EXPECT_EQ(result->status(), 0) << "Fit converged.";
   EXPECT_LT(fabs(a2.getVal()-0.01), a2.getError());


### PR DESCRIPTION
Integrating a RooAbsRealLValue like a RooRealVar doesn't work in RooFit,
which one can check with this code:

```C++
RooRealVar x{"x", "x", 2.0, -5.0, 5.0};
std::unique_ptr<RooAbsReal> xint{x.createIntegral(x)};
xint->Print();
```

The integral of x from -5 to 5 should be zero, but the integral object
only returns the current value of the variable.

Some users expect the integral to work, and give the same result as
this, which correctly prints out zero:

```C++
RooRealVar x{"x", "x", 2.0, -5.0, 5.0};
RooProduct xId{"xId", "xId", RooArgList{x}};
std::unique_ptr<RooAbsReal> xint{xId.createIntegral(x)};
xint->Print();
```

This is assumed in two RooFit unit tests:

  * [testRooWrapperPdf](https://github.com/root-project/root/blob/master/roofit/roofitcore/test/testRooWrapperPdf.cxx#L27)
  * [testNestedPDFs](https://github.com/guitargeek/roottest/blob/master/root/roofitstats/vectorisedPDFs/testNestedPDFs.cxx#L45) in roottest

Both tests **work only by chance** because the stored x value is the
same as its integral! As soon as the x value or limits would change, the
results don't make sense anymore.

As the integration of RooAbsRealLValues never worked correctly and was
not used anywhere outside artificial unit tests, this commit suggests so
prohibit the integration of RooAbsRealLValues by throwing an exception
if `RooAbsRealLValue::createIntegral()` is called.

Related to https://github.com/root-project/roottest/pull/894.