### PR TITLE
core/clib: Remove K&R function definitions

### DIFF
--- a/core/clib/src/Demangle.c
+++ b/core/clib/src/Demangle.c
@@ -57,9 +57,7 @@ enum demangling_styles current_demangling_style = gnu_demangling;
 
 static char cplus_markers[] = { CPLUS_MARKER, '.', '$', '\0' };
 
-void
-set_cplus_marker_for_demangling (ch)
-int ch;
+void set_cplus_marker_for_demangling(int ch)
 {
    cplus_markers[0] = ch;
 }
@@ -284,9 +282,7 @@ string_prepends (string *, string *);
  Trying to consume something that isn't a count results in
  no consumption of input and a return of 0. */
 
-static int
-consume_count (type)
-const char **type;
+static int consume_count(const char **type)
 {
    int count = 0;
 
@@ -299,11 +295,7 @@ const char **type;
    return (count);
 }
 
-int
-cplus_demangle_opname (opname, result, options)
-char *opname;
-char *result;
-int options;
+int cplus_demangle_opname(char *opname, char *result, int options)
 {
    int len, i, len1, ret;
    string type;
@@ -428,10 +420,7 @@ int options;
  If OPTIONS & DMGL_ANSI == 1, return the ANSI name;
  if OPTIONS & DMGL_ANSI == 0, return the old GNU name.  */
 
-char *
-cplus_mangle_opname (opname, options)
-char *opname;
-int options;
+char *cplus_mangle_opname(char *opname, int options)
 {
    int i;
    int len;
@@ -450,10 +439,7 @@ int options;
 /* check to see whether MANGLED can match TEXT in the first TEXT_LEN
  characters. */
 
-int cplus_match (mangled, text, text_len)
-const char *mangled;
-char *text;
-int text_len;
+int cplus_match(const char *mangled, char *text, int text_len)
 {
    if (strncmp (mangled, text, text_len) != 0) {
       return(0); /* cannot match either */
@@ -490,10 +476,7 @@ int text_len;
  the compilation system, are presumed to have already been stripped from
  MANGLED.  */
 
-char *
-cplus_demangle (mangled, options)
-const char *mangled;
-int options;
+char *cplus_demangle(const char *mangled, int options)
 {
    string decl;
    int success = 0;
@@ -543,11 +526,7 @@ int options;
    return (demangled);
 }
 
-static char *
-mop_up (work, declp, success)
-struct work_stuff *work;
-string *declp;
-int success;
+static char *mop_up(struct work_stuff *work, string *declp, int success)
 {
    char *demangled = NULL;
 
@@ -605,11 +584,7 @@ int success;
  argument list.
  */
 
-static int
-demangle_signature (work, mangled, declp)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
+static int demangle_signature(struct work_stuff *work, const char **mangled, string *declp)
 {
    int success = 1;
    int func_done = 0;
@@ -816,12 +791,7 @@ string *declp;
 
 #endif
 
-static int
-demangle_template (work, mangled, tname, trawname)
-struct work_stuff *work;
-const char **mangled;
-string *tname;
-string *trawname;
+static int demangle_template(struct work_stuff *work, const char **mangled, string *tname, string *trawname)
 {
    int i;
    int is_pointer;
@@ -1048,12 +1018,7 @@ string *trawname;
    return (success);
 }
 
-static int
-arm_pt (work, mangled, n, anchor, args)
-struct work_stuff *work;
-const char *mangled;
-int n;
-const char **anchor, **args;
+static int arm_pt(struct work_stuff *work, const char *mangled, int n, const char **anchor, const char **args)
 {
    /* ARM template? */
    if (ARM_DEMANGLING && (*anchor = strstr(mangled, "__pt__")))
@@ -1070,12 +1035,7 @@ const char **anchor, **args;
    return 0;
 }
 
-static void
-demangle_arm_pt (work, mangled, n, declp)
-struct work_stuff *work;
-const char **mangled;
-int n;
-string *declp;
+static void demangle_arm_pt(struct work_stuff *work, const char **mangled, int n, string *declp)
 {
    const char *p;
    const char *args;
@@ -1106,11 +1066,7 @@ string *declp;
    *mangled += n;
 }
 
-static int
-demangle_class_name (work, mangled, declp)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
+static int demangle_class_name(struct work_stuff *work, const char **mangled, string *declp)
 {
    int n;
    int success = 0;
@@ -1160,11 +1116,7 @@ string *declp;
 
  */
 
-static int
-demangle_class (work, mangled, declp)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
+static int demangle_class(struct work_stuff *work, const char **mangled, string *declp)
 {
    int success = 0;
    string class_name;
@@ -1224,11 +1176,7 @@ string *declp;
  Returns 1 on success, 0 otherwise.
  */
 
-static int
-demangle_prefix (work, mangled, declp)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
+static int demangle_prefix(struct work_stuff *work, const char **mangled, string *declp)
 {
    int success = 1;
    const char *scan;
@@ -1408,11 +1356,7 @@ string *declp;
  __thunk_4__$_7ostream (virtual function thunk)
  */
 
-static int
-gnu_special (work, mangled, declp)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
+static int gnu_special(struct work_stuff *work, const char **mangled, string *declp)
 {
    int n;
    int success = 1;
@@ -1649,13 +1593,7 @@ arm_special (struct work_stuff *work, const char **mangled, string *declp)
 
  */
 
-static int
-demangle_qualified (work, mangled, result, isfuncname, append)
-struct work_stuff *work;
-const char **mangled;
-string *result;
-int isfuncname;
-int append;
+static int demangle_qualified(struct work_stuff *work, const char **mangled, string *result, int isfuncname, int append)
 {
    int qualifiers = 0;
    int namelength = 0;
@@ -1799,10 +1737,7 @@ int append;
  Return 0 if no conversion is performed, 1 if a string is converted.
  */
 
-static int
-get_count (type, count)
-const char **type;
-int *count;
+static int get_count(const char **type, int *count)
 {
    const char *p;
    int n;
@@ -1838,11 +1773,7 @@ int *count;
 
 /* result will be initialised here; it will be freed on failure */
 
-static int
-do_type (work, mangled, result)
-struct work_stuff *work;
-const char **mangled;
-string *result;
+static int do_type(struct work_stuff *work, const char **mangled, string *result)
 {
    int n;
    int done;
@@ -2070,11 +2001,7 @@ string *result;
 
  */
 
-static int
-demangle_fund_type (work, mangled, result)
-struct work_stuff *work;
-const char **mangled;
-string *result;
+static int demangle_fund_type(struct work_stuff *work, const char **mangled, string *result)
 {
    int done = 0;
    int success = 1;
@@ -2217,11 +2144,7 @@ string *result;
 
 /* `result' will be initialized in do_type; it will be freed on failure */
 
-static int
-do_arg (work, mangled, result)
-struct work_stuff *work;
-const char **mangled;
-string *result;
+static int do_arg(struct work_stuff *work, const char **mangled, string *result)
 {
    const char *start = *mangled;
 
@@ -2236,11 +2159,7 @@ string *result;
    }
 }
 
-static void
-remember_type (work, start, len)
-struct work_stuff *work;
-const char *start;
-int len;
+static void remember_type(struct work_stuff *work, const char *start, int len)
 {
    char *tem;
 
@@ -2268,9 +2187,7 @@ int len;
 
 /* Forget the remembered types, but not the type vector itself. */
 
-static void
-forget_types (work)
-struct work_stuff *work;
+static void forget_types(struct work_stuff *work)
 {
    int i;
 
@@ -2327,11 +2244,7 @@ struct work_stuff *work;
 
  */
 
-static int
-demangle_args (work, mangled, declp)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
+static int demangle_args(struct work_stuff *work, const char **mangled, string *declp)
 {
    string arg;
    int need_comma = 0;
@@ -2455,12 +2368,7 @@ string *declp;
    return (1);
 }
 
-static void
-demangle_function_name (work, mangled, declp, scan)
-struct work_stuff *work;
-const char **mangled;
-string *declp;
-const char *scan;
+static void demangle_function_name(struct work_stuff *work, const char **mangled, string *declp, const char *scan)
 {
    int i;
    int len;
@@ -2607,10 +2515,7 @@ const char *scan;
 
 /* a mini string-handling package */
 
-static void
-string_need (s, n)
-string *s;
-int n;
+static void string_need(string *s, int n)
 {
    int tem;
 
@@ -2634,9 +2539,7 @@ int n;
    }
 }
 
-static void
-string_delete (s)
-string *s;
+static void string_delete(string *s)
 {
    if (s->b != NULL)
    {
@@ -2645,16 +2548,12 @@ string *s;
    }
 }
 
-static void
-string_init (s)
-string *s;
+static void string_init(string *s)
 {
    s->b = s->p = s->e = NULL;
 }
 
-static void
-string_clear (s)
-string *s;
+static void string_clear(string *s)
 {
    s->p = s->b;
 }
@@ -2670,10 +2569,7 @@ string *s;
 
 #endif
 
-static void
-string_append (p, s)
-string *p;
-const char *s;
+static void string_append(string *p, const char *s)
 {
    int n;
    if (s == NULL || *s == '\0')
@@ -2684,9 +2580,7 @@ const char *s;
    p->p += n;
 }
 
-static void
-string_appends (p, s)
-string *p, *s;
+static void string_appends(string *p, string *s)
 {
    int n;
 
@@ -2699,11 +2593,7 @@ string *p, *s;
    }
 }
 
-static void
-string_appendn (p, s, n)
-string *p;
-const char *s;
-int n;
+static void string_appendn(string *p, const char *s, int n)
 {
    if (n != 0)
    {
@@ -2713,10 +2603,7 @@ int n;
    }
 }
 
-static void
-string_prepend (p, s)
-string *p;
-const char *s;
+static void string_prepend(string *p, const char *s)
 {
    if (s != NULL && *s != '\0')
    {
@@ -2724,9 +2611,7 @@ const char *s;
    }
 }
 
-static void
-string_prepends (p, s)
-string *p, *s;
+static void string_prepends(string *p, string *s)
 {
    if (s->b != s->p)
    {
@@ -2734,11 +2619,7 @@ string *p, *s;
    }
 }
 
-static void
-string_prependn (p, s, n)
-string *p;
-const char *s;
-int n;
+static void string_prependn(string *p, const char *s, int n)
 {
    char *q;
 
@@ -2761,9 +2642,7 @@ int n;
 
 #ifdef MAIN
 
-static void
-demangle_it (mangled_name)
-char *mangled_name;
+static void demangle_it(chat *mangled_name)
 {
    char *result;
 
@@ -2784,10 +2663,7 @@ char *mangled_name;
 static char *program_name;
 extern char *program_version;
 
-static void
-usage (stream, status)
-FILE *stream;
-int status;
+static void usage(FILE *stream, int status)
 {
    fprintf (stream, "\
             Usage: %s [-_] [-n] [-s {gnu,lucid,arm}] [--strip-underscores]\n\
@@ -2814,10 +2690,7 @@ static struct option long_options[] = {
    {0, no_argument, 0, 0}
 };
 
-int
-main (argc, argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
    char *result;
    int c;

--- a/core/clib/src/attach.c
+++ b/core/clib/src/attach.c
@@ -85,14 +85,11 @@ Boston, MA 02111-1307, USA.  */
    On failure returns NULL. */
 
 PTR
-mmalloc_attach (fd, baseaddr, minsize)
 #ifndef WIN32
-  int fd;
+mmalloc_attach (int fd, PTR baseaddr, int minsize)
 #else
-  HANDLE fd;
+mmalloc_attach (HANDLE fd, PTR baseaddr, int minsize)
 #endif
-  PTR baseaddr;
-  int minsize;
 {
   struct mdesc mtemp;
   struct mdesc *mdp;
@@ -236,11 +233,10 @@ mmalloc_attach (fd, baseaddr, minsize)
    unsuccessful for some reason. */
 
 static struct mdesc *
-reuse (cfd)
 #ifndef WIN32
-  int cfd;
+reuse(int cfd)
 #else
-  HANDLE cfd;
+reuse(HANDLE cfd)
 #endif
 {
   struct mdesc *mtemp = (struct mdesc*) malloc(sizeof(struct mdesc));

--- a/core/clib/src/detach.c
+++ b/core/clib/src/detach.c
@@ -41,9 +41,7 @@ Boston, MA 02111-1307, USA.  */
    region we are about to unmap, so we first make a local copy of it on the
    stack and use the copy. */
 
-PTR
-mmalloc_detach (md)
-     PTR md;
+PTR mmalloc_detach(PTR md)
 {
    struct mdesc mtemp;
 

--- a/core/clib/src/keys.c
+++ b/core/clib/src/keys.c
@@ -41,11 +41,7 @@ Boston, MA 02111-1307, USA.  */
 
 #include "mmprivate.h"
 
-int
-mmalloc_setkey (md, keynum, key)
-  PTR md;
-  int keynum;
-  PTR key;
+int mmalloc_setkey(PTR md, int keynum, PTR key)
 {
   struct mdesc *mdp = (struct mdesc *) md;
   int result = 0;
@@ -68,10 +64,7 @@ mmalloc_setkey (md, keynum, key)
   return (result);
 }
 
-PTR
-mmalloc_getkey (md, keynum)
-  PTR md;
-  int keynum;
+PTR mmalloc_getkey(PTR md, int keynum)
 {
   struct mdesc *mdp = (struct mdesc *) md;
   PTR keyval = NULL;

--- a/core/clib/src/mcalloc.c
+++ b/core/clib/src/mcalloc.c
@@ -26,11 +26,7 @@ Boston, MA 02111-1307, USA.  */
 /* Allocate an array of NMEMB elements each SIZE bytes long.
    The entire array is initialized to zeros.  */
 
-PTR
-mcalloc (md, nmemb, size)
-  PTR md;
-  register size_t nmemb;
-  register size_t size;
+PTR mcalloc(PTR md, register size_t nmemb, register size_t size)
 {
    register PTR result;
 

--- a/core/clib/src/mfree.c
+++ b/core/clib/src/mfree.c
@@ -31,10 +31,7 @@ Boston, MA 02111-1307, USA.
 /* Return memory to the heap.
    Like `mfree' but don't call a mfree_hook if there is one.  */
 
-void
-__mmalloc_free (mdp, ptr)
-  struct mdesc *mdp;
-  PTR ptr;
+void __mmalloc_free(struct mdesc *mdp, PTR ptr)
 {
    int type;
    size_t block, blocks;
@@ -206,10 +203,7 @@ __mmalloc_free (mdp, ptr)
 
 /* Return memory to the heap.  */
 
-void
-mfree (md, ptr)
-  PTR md;
-  PTR ptr;
+void mfree(PTR md, PTR ptr)
 {
    struct mdesc *mdp;
    register struct alignlist *l;

--- a/core/clib/src/mmalloc.c
+++ b/core/clib/src/mmalloc.c
@@ -39,10 +39,7 @@ static PTR align PARAMS ((struct mdesc *, size_t));
 
 /* Aligned allocation.  */
 
-static PTR
-align (mdp, size)
-  struct mdesc *mdp;
-  size_t size;
+static PTR align(struct mdesc *mdp, size_t size)
 {
   PTR result;
   unsigned long int adj;
@@ -60,9 +57,7 @@ align (mdp, size)
 
 /* Set everything up and remember that we have.  */
 
-static int
-initialize (mdp)
-  struct mdesc *mdp;
+static int initialize(struct mdesc *mdp)
 {
   mdp -> heapsize = HEAP / BLOCKSIZE;
   mdp -> heapinfo = (mmalloc_info *)
@@ -83,10 +78,7 @@ initialize (mdp)
 /* Get neatly aligned memory, initializing or
    growing the heap info table as necessary. */
 
-static PTR
-morecore (mdp, size)
-  struct mdesc *mdp;
-  size_t size;
+static PTR morecore(struct mdesc *mdp, size_t size)
 {
    PTR result;
    mmalloc_info *newinfo, *oldinfo;
@@ -130,10 +122,7 @@ morecore (mdp, size)
 
 /* Allocate memory from the heap.  */
 
-PTR
-mmalloc (md, size)
-  PTR md;
-  size_t size;
+PTR mmalloc(PTR md, size_t size)
 {
    struct mdesc *mdp;
    PTR result;

--- a/core/clib/src/mmapsup.c
+++ b/core/clib/src/mmapsup.c
@@ -60,10 +60,7 @@ static size_t pagesize;
     amount to either add to or subtract from the existing region.  Works
     like sbrk(), but using mmap(). */
 
-PTR
-__mmalloc_mmap_morecore (mdp, size)
-  struct mdesc *mdp;
-  int size;
+PTR __mmalloc_mmap_morecore(struct mdesc *mdp, int size)
 {
   PTR result = NULL;
   off_t foffset;        /* File offset at which new mapping will start */
@@ -200,9 +197,7 @@ __mmalloc_mmap_morecore (mdp, size)
   return (result);
 }
 
-PTR
-__mmalloc_remap_core (mdp)
-  struct mdesc *mdp;
+PTR __mmalloc_remap_core(struct mdesc *mdp)
 {
   caddr_t base;
   int rdonly = 0;
@@ -283,9 +278,7 @@ __mmalloc_remap_core (mdp)
   return ((PTR) base);
 }
 
-int
-mmalloc_update_mapping(md)
-  PTR md;
+int mmalloc_update_mapping(PTR md)
 {
   /*
    * In case of a read-only mapping, we need to call this routine to

--- a/core/clib/src/mmcheck.c
+++ b/core/clib/src/mmcheck.c
@@ -61,10 +61,7 @@ typedef PTR (*mmrealloc_fun_t) PARAMS ((PTR, PTR, size_t));
 /* Check the magicword and magicbyte, and if either is corrupted then
    call the emergency abort function specified for the heap in use. */
 
-static void
-checkhdr (mdp, hdr)
-  struct mdesc *mdp;
-  const struct hdr *hdr;
+static void checkhdr(struct mdesc *mdp, const struct hdr *hdr)
 {
   if (hdr -> magic != MAGICWORD ||
       ((char *) &hdr[1])[hdr -> size] != MAGICBYTE)
@@ -73,10 +70,7 @@ checkhdr (mdp, hdr)
     }
 }
 
-static void
-mfree_check (md, ptr)
-  PTR md;
-  PTR ptr;
+static void mfree_check(PTR md, PTR ptr)
 {
   struct hdr *hdr = ((struct hdr *) ptr) - 1;
   struct mdesc *mdp;
@@ -89,10 +83,7 @@ mfree_check (md, ptr)
   mdp -> mfree_hook = (mmfree_fun_t) mfree_check;
 }
 
-static PTR
-mmalloc_check (md, size)
-  PTR md;
-  size_t size;
+static PTR mmalloc_check(PTR md, size_t size)
 {
   struct hdr *hdr;
   struct mdesc *mdp;
@@ -113,11 +104,7 @@ mmalloc_check (md, size)
   return ((PTR) hdr);
 }
 
-static PTR
-mrealloc_check (md, ptr, size)
-  PTR md;
-  PTR ptr;
-  size_t size;
+static PTR mrealloc_check(PTR md, PTR ptr, size_t size)
 {
   struct hdr *hdr = ((struct hdr *) ptr) - 1;
   struct mdesc *mdp;
@@ -165,10 +152,7 @@ mrealloc_check (md, ptr, size)
 
    Returns non-zero if checking is successfully enabled, zero otherwise. */
 
-int
-mmcheck (md, func)
-  PTR md;
-  void (*func) PARAMS ((void));
+int mmcheck(PTR md, void(*func) PARAMS((void)))
 {
   struct mdesc *mdp;
   int rtnval;

--- a/core/clib/src/mmemalign.c
+++ b/core/clib/src/mmemalign.c
@@ -21,11 +21,7 @@ Boston, MA 02111-1307, USA.  */
 
 #include "mmprivate.h"
 
-PTR
-mmemalign (md, alignment, size)
-  PTR md;
-  size_t alignment;
-  size_t size;
+PTR mmemalign(PTR md, size_t alignment, size_t size)
 {
    PTR result;
    unsigned long int adj;

--- a/core/clib/src/mmstats.c
+++ b/core/clib/src/mmstats.c
@@ -31,9 +31,7 @@ Boston, MA 02111-1307, USA.
    None of the internal mmalloc structures should be externally visible
    outside the library. */
 
-struct mmstats_t
-mmstats (md)
-  PTR md;
+struct mmstats_t mmstats(PTR md)
 {
   struct mmstats_t result;
   struct mdesc *mdp;

--- a/core/clib/src/mrealloc.c
+++ b/core/clib/src/mrealloc.c
@@ -34,11 +34,7 @@ Boston, MA 02111-1307, USA.
    new region.  This module has incestuous knowledge of the
    internals of both mfree and mmalloc. */
 
-PTR
-mrealloc (md, ptr, size)
-  PTR md;
-  PTR ptr;
-  size_t size;
+PTR mrealloc(PTR md, PTR ptr, size_t size)
 {
    struct mdesc *mdp;
    PTR result;

--- a/core/clib/src/mvalloc.c
+++ b/core/clib/src/mvalloc.c
@@ -41,10 +41,7 @@ Boston, MA 02111-1307, USA.  */
 
 static size_t pagesize;
 
-PTR
-mvalloc (md, size)
-  PTR md;
-  size_t size;
+PTR mvalloc(PTR md, size_t size)
 {
   if (pagesize == 0)
     {


### PR DESCRIPTION
Soon-to-be-released Clang 15 complains:
```
a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
```