### PR TITLE
rmkdepend: Remove K&R function definitions and add arguments to function pointer types

### DIFF
--- a/build/rmkdepend/cppsetup.c
+++ b/build/rmkdepend/cppsetup.c
@@ -60,11 +60,7 @@ extern char slotab[];
 struct filepointer *currentfile;
 struct inclist  *currentinc;
 
-int
-cppsetup(line, filep, inc)
-register char *line;
-register struct filepointer *filep;
-register struct inclist  *inc;
+int cppsetup(register char *line, register struct filepointer *filep, register struct inclist *inc)
 {
    register char *p, savec;
    static boolean setupdone = FALSE;
@@ -97,8 +93,7 @@ register struct inclist  *inc;
    return(value);
 }
 
-struct symtab **lookup(symbol)
-         char *symbol;
+struct symtab **lookup(char *symbol)
 {
    static struct symtab    *undefined;
    struct symtab   **sp;
@@ -111,16 +106,13 @@ struct symtab **lookup(symbol)
    return (sp);
 }
 
-pperror(tag, x0, x1, x2, x3, x4)
-int tag, x0, x1, x2, x3, x4;
+void pperror(int tag, int x0, int x1, int x2, int x3, int x4)
 {
    warning("\"%s\", line %d: ", currentinc->i_file, currentfile->f_line);
    warning(x0, x1, x2, x3, x4);
 }
 
-
-yyerror(s)
-register char *s;
+void yyerror(register char *s)
 {
    fatalerr("Fatal error: %s\n", s);
 }
@@ -133,11 +125,7 @@ struct _parse_data {
    const char *line;
 };
 
-static const char *
-my_if_errors(ip, cp, expecting)
-IfParser *ip;
-const char *cp;
-const char *expecting;
+static const char *my_if_errors(IfParser *ip, const char *cp, const char *expecting)
 {
    struct _parse_data *pd = (struct _parse_data *) ip->data;
    int lineno = pd->filep->f_line;
@@ -165,11 +153,7 @@ const char *expecting;
 
 #define MAXNAMELEN 256
 
-static struct symtab **
-         lookup_variable(ip, var, len)
-         IfParser *ip;
-const char *var;
-int len;
+static struct symtab **lookup_variable(IfParser *ip, const char *var, int len)
 {
    char tmpbuf[MAXNAMELEN + 1];
    struct _parse_data *pd = (struct _parse_data *) ip->data;
@@ -182,12 +166,7 @@ int len;
    return isdefined(tmpbuf, pd->inc, NULL);
 }
 
-
-static int
-my_eval_defined(ip, var, len)
-IfParser *ip;
-const char *var;
-int len;
+static int my_eval_defined(IfParser *ip, const char *var, int len)
 {
    if (lookup_variable(ip, var, len))
       return 1;
@@ -197,11 +176,7 @@ int len;
 
 #define isvarfirstletter(ccc) (isalpha(ccc) || (ccc) == '_')
 
-static long
-my_eval_variable(ip, var, len)
-IfParser *ip;
-const char *var;
-int len;
+static long my_eval_variable(IfParser *ip, const char *var, int len)
 {
    struct symtab **s;
 
@@ -218,11 +193,7 @@ int len;
    return strtol(var, NULL, 0);
 }
 
-
-int cppsetup(line, filep, inc)
-register char *line;
-register struct filepointer *filep;
-register struct inclist  *inc;
+int cppsetup(register char *line, register struct filepointer *filep, register struct inclist *inc)
 {
    IfParser ip;
    struct _parse_data pd;

--- a/build/rmkdepend/def.h
+++ b/build/rmkdepend/def.h
@@ -137,7 +137,7 @@ char   *base_name(char*);
 char   *rgetline(struct filepointer*);
 struct symtab  **slookup(char*, struct inclist*);
 struct symtab  **isdefined(char*,struct inclist*, struct inclist**);
-struct symtab  **fdefined();
+struct symtab **fdefined(char *, struct inclist *, struct inclist **);
 struct filepointer *getfile(char*);
 struct inclist  *newinclude(char*,char*);
 struct inclist  *inc_path(char*, char*, boolean);

--- a/build/rmkdepend/ifparser.c
+++ b/build/rmkdepend/ifparser.c
@@ -74,12 +74,7 @@
 #define SKIPSPACE(ccc) while (isspace(*ccc)) ccc++
 #define isvarfirstletter(ccc) (isalpha(ccc) || (ccc) == '_')
 
-
-static const char *
-parse_variable(g, cp, varp)
-IfParser *g;
-const char *cp;
-const char **varp;
+static const char *parse_variable(IfParser *g, const char *cp, const char **varp)
 {
    SKIPSPACE(cp);
 
@@ -92,12 +87,7 @@ const char **varp;
    return cp;
 }
 
-
-static const char *
-parse_number(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_number(IfParser *g, const char *cp, long *valp)
 {
    SKIPSPACE(cp);
 
@@ -115,11 +105,7 @@ long *valp;
    return cp;
 }
 
-static const char *
-parse_character(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_character(IfParser *g, const char *cp, long *valp)
 {
    char val;
    if (g) { }   /* use argument */
@@ -174,11 +160,7 @@ long *valp;
    return cp;
 }
 
-static const char *
-parse_value(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_value(IfParser *g, const char *cp, long *valp)
 {
    const char *var;
 
@@ -294,13 +276,7 @@ long *valp;
    return cp;
 }
 
-
-
-static const char *
-parse_product(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_product(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -328,12 +304,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_sum(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_sum(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -354,12 +325,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_shift(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_shift(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -384,12 +350,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_inequality(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_inequality(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -420,12 +381,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_equality(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_equality(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -450,12 +406,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_band(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_band(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -473,12 +424,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_bxor(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_bxor(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -494,12 +440,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_bor(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_bor(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -517,12 +458,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_land(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_land(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -540,12 +476,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_lor(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_lor(IfParser *g, const char *cp, long *valp)
 {
    long rightval;
 
@@ -563,12 +494,7 @@ long *valp;
    return cp;
 }
 
-
-static const char *
-parse_cond(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+static const char *parse_cond(IfParser *g, const char *cp, long *valp)
 {
    long trueval, falseval;
 
@@ -593,11 +519,7 @@ long *valp;
         External Entry Points
  ****************************************************************************/
 
-const char *
-ParseIfExpression(g, cp, valp)
-IfParser *g;
-const char *cp;
-long *valp;
+const char *ParseIfExpression(IfParser *g, const char *cp, long *valp)
 {
    return parse_cond(g, cp, valp);
 }

--- a/build/rmkdepend/ifparser.h
+++ b/build/rmkdepend/ifparser.h
@@ -71,10 +71,9 @@ typedef int Bool;
 
 typedef struct _if_parser {
    struct {    /* functions */
-      char *(*handle_error)(/* struct _if_parser *, const char *,
-     const char * */);
-      long(*eval_variable)(/* struct _if_parser *, const char *, int */);
-      int (*eval_defined)(/* struct _if_parser *, const char *, int */);
+      char *(*handle_error)(struct _if_parser *, const char *, const char *);
+      long (*eval_variable)(struct _if_parser *, const char *, int);
+      int (*eval_defined)(struct _if_parser *, const char *, int);
    } funcs;
    char *data;
 } IfParser;

--- a/build/rmkdepend/include.c
+++ b/build/rmkdepend/include.c
@@ -40,28 +40,21 @@ extern char *notdotdot[ ];
 extern boolean show_where_not;
 extern boolean warn_multiple;
 
-
-boolean
-isdot(p)
-register char *p;
+boolean isdot(register char *p)
 {
    if (p && *p++ == '.' && *p++ == '\0')
       return(TRUE);
    return(FALSE);
 }
 
-boolean
-isdotdot(p)
-register char *p;
+boolean isdotdot(register char *p)
 {
    if (p && *p++ == '.' && *p++ == '.' && *p++ == '\0')
       return(TRUE);
    return(FALSE);
 }
 
-boolean
-issymbolic(dir, component)
-register char *dir, *component;
+boolean issymbolic(register char *dir, register char *component)
 {
 #ifdef S_IFLNK
    struct stat st;
@@ -89,9 +82,7 @@ register char *dir, *component;
  * Any of the 'x/..' sequences within the name can be eliminated.
  * (but only if 'x' is not a symbolic link!!)
  */
-void
-remove_dotdot(path)
-char *path;
+void remove_dotdot(char *path)
 {
    register char *end, *from, *to, **cp;
    char  *components[ MAXFILES ],
@@ -161,8 +152,7 @@ char *path;
 /*
  * Add an include file to the list of those included by 'file'.
  */
-struct inclist *newinclude(newfile, incstring)
-         register char *newfile, *incstring;
+struct inclist *newinclude(register char *newfile, register char *incstring)
 {
    register struct inclist *ip;
 
@@ -182,9 +172,7 @@ struct inclist *newinclude(newfile, incstring)
    return(ip);
 }
 
-void
-included_by(ip, newfile)
-register struct inclist *ip, *newfile;
+void included_by(register struct inclist *ip, register struct inclist *newfile)
 {
    register int i;
 

--- a/build/rmkdepend/main.c
+++ b/build/rmkdepend/main.c
@@ -149,9 +149,7 @@ extern int find_includes(struct filepointer *filep, struct inclist *file,
 extern void recursive_pr_include(struct inclist *head, char *file, char *base, char *dep);
 extern void inc_clean();
 
-int main_orig(argc, argv)
-int argc;
-char **argv;
+int main_orig(int argc, char **argv)
 {
    register char **fp = filelist;
    register char  **tp = targetlist;
@@ -521,8 +519,7 @@ static int elim_cr(char *buf, int sz)
 }
 #endif
 
-struct filepointer *getfile(file)
-         char *file;
+struct filepointer *getfile(char *file)
 {
    register int fd;
    struct filepointer *content;
@@ -553,16 +550,13 @@ struct filepointer *getfile(file)
    return(content);
 }
 
-void
-freefile(fp)
-struct filepointer *fp;
+void freefile(struct filepointer *fp)
 {
    free(fp->f_base);
    free(fp);
 }
 
-char *copy(str)
-register char *str;
+char *copy(register char *str)
 {
    register char *p = (char *)malloc(strlen(str) + 1);
 
@@ -570,8 +564,7 @@ register char *str;
    return(p);
 }
 
-int match(str, list)
-register char *str, **list;
+int match(register char *str, register char **list)
 {
    register int i;
 
@@ -585,8 +578,7 @@ register char *str, **list;
  * Get the next line.  We only return lines beginning with '#' since that
  * is all this program is ever interested in.
  */
-char *rgetline(filep)
-register struct filepointer *filep;
+char *rgetline(register struct filepointer *filep)
 {
    register char *p, /* walking pointer */
    *eof, /* end of file pointer */
@@ -651,8 +643,7 @@ done:
  * Strip the file name down to what we want to see in the Makefile.
  * It will have objprefix and objsuffix around it.
  */
-char *base_name(file)
-register char *file;
+char *base_name(register char *file)
 {
    register char *p;
 
@@ -678,10 +669,7 @@ char *from, *to;
 }
 #endif /* USGISH */
 
-void
-redirect(line, makefile)
-char *line,
-*makefile;
+void redirect(char *line, char *makefile)
 {
    struct stat st;
    FILE *fdin = 0, *fdout = 0;

--- a/build/rmkdepend/parse.c
+++ b/build/rmkdepend/parse.c
@@ -45,12 +45,7 @@ extern void add_include(struct filepointer *filep, struct inclist *file,
                            struct inclist *file_red, char *include,
                            boolean dot, boolean failOK);
 
-
-
-int
-gobble(filep, file, file_red)
-register struct filepointer *filep;
-struct inclist  *file, *file_red;
+int gobble(register struct filepointer *filep, struct inclist *file, struct inclist *file_red)
 {
    register char *line;
    register int type;
@@ -110,11 +105,8 @@ static void inplace_strcpy(char* to, const char* from)
 /*
  * Decide what type of # directive this line is.
  */
-int deftype(line, filep, file_red, file, parse_it)
-register char *line;
-register struct filepointer *filep;
-register struct inclist *file_red, *file;
-int parse_it;
+int deftype(register char *line, register struct filepointer *filep, register struct inclist *file_red,
+            register struct inclist *file, int parse_it)
 {
    register char *p;
    char *directive, savechar;
@@ -251,10 +243,7 @@ int parse_it;
    return(ret);
 }
 
-struct symtab **fdefined(symbol, file, srcfile)
-         register char *symbol;
-struct inclist *file;
-struct inclist **srcfile;
+struct symtab **fdefined(register char *symbol, struct inclist *file, struct inclist **srcfile)
 {
    register struct inclist **ip;
    register struct symtab **val;
@@ -285,10 +274,7 @@ struct inclist **srcfile;
    return(val);
 }
 
-struct symtab **isdefined(symbol, file, srcfile)
-         register char *symbol;
-struct inclist *file;
-struct inclist **srcfile;
+struct symtab **isdefined(register char *symbol, struct inclist *file, struct inclist **srcfile)
 {
    register struct symtab **val;
 
@@ -306,11 +292,7 @@ struct inclist **srcfile;
 /*
  * Return type based on if the #if expression evaluates to 0
  */
-int
-zero_value(exp, filep, file_red)
-register char *exp;
-register struct filepointer *filep;
-register struct inclist *file_red;
+int zero_value(register char *exp, register struct filepointer *filep, register struct inclist *file_red)
 {
    if (cppsetup(exp, filep, file_red))
       return(IFFALSE);
@@ -318,10 +300,7 @@ register struct inclist *file_red;
       return(IF);
 }
 
-void
-define2(name, val, file)
-char *name, *val;
-struct inclist *file;
+void define2(char *name, char *val, struct inclist *file)
 {
    int first, last, below;
    register struct symtab **sp = NULL, **dest;
@@ -394,10 +373,7 @@ struct inclist *file;
    *sp = stab;
 }
 
-void
-define(def, file)
-char *def;
-struct inclist *file;
+void define(char *def, struct inclist *file)
 {
    char *val;
 
@@ -415,9 +391,7 @@ struct inclist *file;
    define2(def, val, file);
 }
 
-struct symtab **slookup(symbol, file)
-         register char *symbol;
-register struct inclist *file;
+struct symtab **slookup(register char *symbol, register struct inclist *file)
 {
    register int first = 0;
    register int last = file->i_ndefs - 1;
@@ -451,9 +425,7 @@ register struct inclist *file;
    return(NULL);
 }
 
-int merge2defines(file1, file2)
-struct inclist *file1;
-struct inclist *file2;
+int merge2defines(struct inclist *file1, struct inclist *file2)
 {
    if ((file1 != NULL) && (file2 != NULL)) {
       int first1 = 0;
@@ -502,10 +474,7 @@ struct inclist *file2;
    return 0;
 }
 
-void
-undefine(symbol, file)
-char *symbol;
-register struct inclist *file;
+void undefine(char *symbol, register struct inclist *file)
 {
    register struct symtab **ptr;
    struct inclist *srcfile;
@@ -516,9 +485,7 @@ register struct inclist *file;
    }
 }
 
-void
-undefine_all(file)
-register struct inclist *file;
+void undefine_all(register struct inclist *file)
 {
    register struct symtab **ptr;
 
@@ -528,12 +495,8 @@ register struct inclist *file;
    file->i_ndefs = 0;
 }
 
-int
-find_includes(filep, file, file_red, recursion, failOK)
-struct filepointer *filep;
-struct inclist  *file, *file_red;
-int   recursion;
-boolean   failOK;
+int find_includes(struct filepointer *filep, struct inclist *file, struct inclist *file_red, int recursion,
+                  boolean failOK)
 {
    register char *line;
    register int type;

--- a/build/rmkdepend/pr.c
+++ b/build/rmkdepend/pr.c
@@ -46,12 +46,8 @@ extern void freefile(struct filepointer *fp);
 extern void ROOT_adddep(char* buf, size_t len);
 extern void ROOT_newFile();
 
-void
-add_include(filep, file, file_red, include, dot, failOK)
-struct filepointer *filep;
-struct inclist *file, *file_red;
-char *include;
-boolean dot, failOK;
+void add_include(struct filepointer *filep, struct inclist *file, struct inclist *file_red, char *include, boolean dot,
+                 boolean failOK)
 {
    register struct inclist *newfile;
    register struct filepointer *content;
@@ -87,10 +83,7 @@ boolean dot, failOK;
    }
 }
 
-void
-pr(ip, file, base, dep)
-register struct inclist  *ip;
-char *file, *base, *dep;
+void pr(register struct inclist *ip, char *file, char *base, char *dep)
 {
    static char *lastfile;
    static int current_len;
@@ -162,11 +155,7 @@ char *file, *base, *dep;
       printf("\n#\t%s", ip->i_list[ i ]->i_incstring);
 }
 
-void
-recursive_pr_include(head, file, base, dep)
-register struct inclist *head;
-register char *file, *base;
-register char  *dep;
+void recursive_pr_include(register struct inclist *head, register char *file, register char *base, register char *dep)
 {
    register int i;
 


### PR DESCRIPTION
Soon-to-be-released Clang 15 complains:
```
a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
```
and
```
passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
```