### PR TITLE
[RF] Vectorize weight evaluation with ```RooDataHist::weights()```

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -106,6 +106,7 @@ public:
                const std::map<const RooAbsArg*, std::pair<double, double> >& ranges,
                std::function<double(int)> getBinScale = [](int){ return 1.0; } );
 
+  void weights(double* output, RooSpan<double const> xVals, bool correctForBinSize);
   /// Return weight of i-th bin. \see getIndex()
   double weight(std::size_t i) const { return _wgt[i]; }
   double weightFast(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -102,6 +102,8 @@ public:
   std::list<double>* binBoundaries(RooAbsRealLValue& /*obs*/, double /*xlo*/, double /*xhi*/) const override ;
   bool isBinnedDistribution(const RooArgSet&) const override { return _intOrder==0 ; }
 
+  void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
+
 
 protected:
 

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -196,6 +196,12 @@ double RooHistFunc::evaluate() const
 
 
 void RooHistFunc::computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const {
+  if (_depList.size() == 1 && _intOrder == 0) {
+    auto xVals = dataMap.at(_depList[0]);
+    _dataHist->weights(output, xVals, false);
+    return;
+  }
+  
   std::vector<RooSpan<const double>> inputValues;
   for (const auto& obs : _depList) {
     auto realObs = dynamic_cast<const RooAbsReal*>(obs);

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -188,7 +188,17 @@ RooHistPdf::~RooHistPdf()
 }
 
 
+void RooHistPdf::computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const {
 
+  // For interpolation and histograms of higher dimension, use base function
+  if(_pdfObsList.size() > 1 || _intOrder > 0) {
+      RooAbsReal::computeBatch(nullptr, output, nEvents, dataMap);
+      return;
+  }
+
+  auto xVals = dataMap.at(_pdfObsList[0]);
+  _dataHist->weights(output, xVals, true);
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR improves the speed for evaluating weights in `RooHistPdf`
and `RooHistFunc` for one dimensional histograms with no interpolation.
In the future, `RooDataHist::weights()` can be extended to cover
cases with higher dimensions and interpolation.

The function `RooDataHist::weights()` was implemented to enable
vectorized evaluations of bin weights. In `RooHistPdf` it is implemented
using the new function `RooHistPdf::computeBatch()`, which calls
`RooDataHist::weights()` in the case of no interpolation and 1D
histograms, and `RooAbsReal::computeBatch()` otherwise. In
`RooHistFunc::computeBatch`, `RooDataHist::weights()` is called in the
case of no interpolation and 1D histograms and is unchanged in the other cases.

To calculate the weight, bin indices are stored as a vector
using `RooAbsBinning::binNumbers`, which was implemented in #11151.

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)


