### PR TITLE
[RF] New mechanism to detect if `_normSet` in RooAbsPdf is invalid

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -366,7 +366,7 @@ double RooAbsPdf::getValV(const RooArgSet* nset) const
 
   // Process change in last data set used
   bool nsetChanged(false) ;
-  if (RooFit::getUniqueId(nset) != RooFit::getUniqueId(_normSet) || _norm==0) {
+  if (!isActiveNormSet(nset) || _norm==0) {
     nsetChanged = syncNormalization(nset) ;
   }
 
@@ -537,7 +537,7 @@ const RooAbsReal* RooAbsPdf::getNormObj(const RooArgSet* nset, const RooArgSet* 
 
 bool RooAbsPdf::syncNormalization(const RooArgSet* nset, bool adjustProxies) const
 {
-  _normSet = nset;
+  setActiveNormSet(nset);
 
   // Check if data sets are identical
   CacheElem* cache = (CacheElem*) _normMgr.getObj(nset) ;
@@ -3535,6 +3535,6 @@ bool RooAbsPdf::redirectServersHook(const RooAbsCollection & newServerList, bool
   // Similar to the situation with the normalization integral above: if a
   // server is redirected, the cached normalization set might not point to
   // the right observables anymore. We need to reset it.
-  _normSet = nullptr ;
+  setActiveNormSet(nullptr);
   return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
 }

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -464,7 +464,7 @@ double RooAddPdf::getValV(const RooArgSet* normSet) const
 
   // Process change in last data set used
   bool nsetChanged(false) ;
-  if (RooFit::getUniqueId(nset) != RooFit::getUniqueId(_normSet) || _norm==0) {
+  if (!isActiveNormSet(nset) || _norm==0) {
     nsetChanged = syncNormalization(nset) ;
   }
 


### PR DESCRIPTION
In RooAbsPdf, the following check is done to check if the normalization
set has changed:
```C++
RooFit::getUniqueId(nset) != RooFit::getUniqueId(_normSet)
```

This works, but like the previous pointer comparison it still gives
false results if the `_normSet` was replaced buy another RooArgSet at
the same memory location. The problem can be reproduced with this code:

```C++
using namespace RooFit;

// Create observables
RooRealVar x("x", "x", -5, 5);
RooRealVar y("y", "y", -5, 5);

// Create signal pdf gauss(x)*gauss(y)
RooGaussian gx("gx", "gx", x, RooConst(0), RooConst(1));
RooGaussian gy("gy", "gy", y, RooConst(0), RooConst(1));
RooProdPdf sig("sig", "sig", {gx, gy});

// Create composite pdf
RooAddPdf model("model", "model", RooArgList(sig), RooConst(100.));

// The results of the last two lines depend on the order of execution
// which should not be the case!
std::cout << model.getVal(x) << std::endl;
std::cout << model.getVal({x, y}) << std::endl;
```

The solution would be to replace the `_normSet` member directly with
its unique ID value, but then it could not be used anymore. Hence we
need both.

This commit also adds a new private `RooAbsPdf` member functions to set
the `_normSet` together with the new `_normSetId` member, and one
protected `isActiveNormSet(RooArgSet const*)` function. The latter
function is comparing the input to the current `_normSet`, but shortcuts
to `false` is the ID does not match with the last `_normSet` ID. Like
this, we avoid dereferencing invalid `_normSet` pointers.

This change is mainly done to fix several of the ASAN build failures in
RooFit.