### PR TITLE
Tweak fitting for TGraph to no assume points are in ascending order

### DIFF
--- a/hist/hist/src/HFitInterface.cxx
+++ b/hist/hist/src/HFitInterface.cxx
@@ -17,10 +17,10 @@
 #include "Fit/FitResult.h"
 #include "Math/IParamFunction.h"
 
-#include <vector>
-
 #include <cassert>
 #include <cmath>
+#include <utility>
+#include <vector>
 
 #include "TH1.h"
 #include "THnBase.h"
@@ -28,9 +28,6 @@
 #include "TGraph2D.h"
 #include "TGraph.h"
 #include "TGraphErrors.h"
-// #include "TGraphErrors.h"
-// #include "TGraphBentErrors.h"
-// #include "TGraphAsymmErrors.h"
 #include "TMultiGraph.h"
 #include "TList.h"
 #include "TError.h"
@@ -596,9 +593,20 @@ void DoFillData ( BinData  & dv,  const TGraph * gr,  BinData::ErrorType type, T
    }
 #endif
 
-   double x[1];
-   for ( int i = 0; i < nPoints; ++i) {
+   // Unlike histograms, graphs may have array of points created in
+   // non-ascending order along the X axis. This breaks fitting algorithm. We
+   // create a "remap" for the TGraph point indexes that provides ascending
+   // order of X values for the BinData
+   std::vector<std::pair<double, int>> indexRemap;
+   for (int i = 0; i < nPoints; ++i) {
+      indexRemap.emplace_back(gx[i], i);
+   }
+   std::sort(indexRemap.begin(), indexRemap.end());
 
+   double x[1];
+   for (int j = 0; j < nPoints; ++j) {
+
+      int i = indexRemap[j].second;
       x[0] = gx[i];
 
 
@@ -978,7 +986,6 @@ bool GetConfidenceIntervals(const TH1 * h1, const ROOT::Fit::FitResult  & result
    }
    return true;
 }
-
 
 } // end namespace Fit
 


### PR DESCRIPTION
Unlike histograms, `TGraph` points are not necessarily stored in memory in ascending "X" coordinate pattern. Generaly speaking, when adding points to the `TGraph`, they are not sorted with respect to their X values. I noticed that this breaks the fitting algorithm. 

In my particular case, the `TGraph` was filled "backwards" - starting with points with larger X values and adding points in decreasing X. Graph plots just fine and visually looks just the same the same as if it was filled in ascending X manner. However, a simple `"gaus"` fit did not converge and ended up having a negative normalization constant (`Constant` fitting parameter).

# This Pull request:
Modifies the way the `BinData` object is populated with `TGraph` points. Instead of adding `TGraph`'s points to the `BinData` in the same pattern they are aligned in the memory, we add points to the `BinData` in strictly ascending order of their X values, starting with lowest.

## Changes or fixes:
An `indexRemap` vector is created prior to populating the `BinData` object for a `TGraph`. This vector governs a new iteration strategy for the `TGraph` points allowing for the adding of the graph points to the `BinData` starting with points with lowest X coordinate values and in ongoing ascending order.

## Checklist:

- [ yes ] tested changes locally
- [ not needed ] updated the docs (if necessary)

