### PR TITLE
[RF] Don't forget to call `redirectServersHook()` of the base class 

### DIFF
--- a/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
+++ b/roofit/histfactory/inc/RooStats/HistFactory/RooBarlowBeestonLL.h
@@ -51,10 +51,6 @@ public:
   void initializeBarlowCache();
   bool getParameters(const RooArgSet* depList, RooArgSet& outputSet, bool stripDisconnected=true) const override;
   RooAbsReal& nll() { return const_cast<RooAbsReal&>(_nll.arg()) ; }
-  bool redirectServersHook(const RooAbsCollection& /*newServerList*/,
-                                   bool /*mustReplaceAll*/,
-                                   bool /*nameChange*/,
-                                   bool /*isRecursive*/) override ;
   void setPdf(RooAbsPdf* pdf) { _pdf = pdf; }
   void setDataset(RooAbsData* data) { _data = data; }
 

--- a/roofit/histfactory/src/RooBarlowBeestonLL.cxx
+++ b/roofit/histfactory/src/RooBarlowBeestonLL.cxx
@@ -349,7 +349,7 @@ bool RooStats::HistFactory::RooBarlowBeestonLL::getParameters(const RooArgSet* d
 
   RooArgSet toRemove;
   toRemove.reserve( _statUncertParams.size());
-    
+
   for (auto const& arg : outputSet) {
 
     // If there is a gamma in the name,
@@ -359,9 +359,9 @@ bool RooStats::HistFactory::RooBarlowBeestonLL::getParameters(const RooArgSet* d
       toRemove.add( *arg );
     }
   }
-  
+
   for( auto& arg : toRemove) outputSet.remove( *arg, true );
-  
+
   return errorInBaseCall || false;
 
 }
@@ -704,20 +704,3 @@ void RooStats::HistFactory::RooBarlowBeestonLL::validateAbsMin() const
   }
 }
 */
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-bool RooStats::HistFactory::RooBarlowBeestonLL::redirectServersHook(const RooAbsCollection& /*newServerList*/, bool /*mustReplaceAll*/,
-                bool /*nameChange*/, bool /*isRecursive*/)
-{
-  /*
-  if (_minuit) {
-    delete _minuit ;
-    _minuit = 0 ;
-  }
-  */
-  return false ;
-}
-
-

--- a/roofit/roofitcore/inc/RooAbsArg.h
+++ b/roofit/roofitcore/inc/RooAbsArg.h
@@ -259,23 +259,8 @@ public:
   bool redirectServers(const RooAbsCollection& newServerList, bool mustReplaceAll=false, bool nameChange=false, bool isRecursionStep=false) ;
   bool recursiveRedirectServers(const RooAbsCollection& newServerList, bool mustReplaceAll=false, bool nameChange=false, bool recurseInNewSet=true) ;
 
-  /// Function that is called at the end of redirectServers(). Can be overloaded
-  /// to inject some class-dependent behavior after server redirection, e.g.
-  /// resetting of caches. The return value is meant to be an error flag, so in
-  /// case something goes wrong the function should return `true`.
-  ///
-  /// \see redirectServers() For a detailed explanation of the function parameters.
-  ///
-  // \param[in] newServerList One of the original parameters passed to redirectServers().
-  // \param[in] mustReplaceAll One of the original parameters passed to redirectServers().
-  // \param[in] nameChange  One of the original parameters passed to redirectServers().
-  // \param[in] isRecursiveStep  One of the original parameters passed to redirectServers().
-  virtual bool redirectServersHook(const RooAbsCollection & /*newServerList*/, bool /*mustReplaceAll*/,
-                                   bool /*nameChange*/, bool /*isRecursiveStep*/)
-  {
-    return false;
-  }
-
+  virtual bool redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
+                                   bool nameChange, bool isRecursiveStep);
 
   virtual void serverNameChangeHook(const RooAbsArg* /*oldServer*/, const RooAbsArg* /*newServer*/) { } ;
 

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -351,20 +351,8 @@ protected:
   } ;
   mutable RooObjCacheManager _normMgr ; //! The cache manager
 
-  bool redirectServersHook(const RooAbsCollection&, bool, bool, bool) override {
-    // Hook function intercepting redirectServer calls. Discard current normalization
-    // object if any server is redirected
-
-    // Object is own by _normCacheManager that will delete object as soon as cache
-    // is sterilized by server redirect
-    _norm = nullptr ;
-
-    // Similar to the situation with the normalization integral above: if a
-    // server is redirected, the cached normalization set might not point to
-    // the right observables anymore. We need to reset it.
-    _normSet = nullptr ;
-    return false ;
-  } ;
+  bool redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
+                                   bool nameChange, bool isRecursiveStep) override;
 
 
   mutable Int_t _errorCount ;        ///< Number of errors remaining to print

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -135,12 +135,7 @@ protected:
 
   mutable Int_t _coefErrCount ; ///<! Coefficient error counter
 
-  bool redirectServersHook(const RooAbsCollection&, bool, bool, bool) override {
-    // If a server is redirected, the cached normalization set might not point
-    // to the right observables anymore. We need to reset it.
-    _copyOfLastNormSet.reset();
-    return false;
-  }
+  bool redirectServersHook(const RooAbsCollection&, bool, bool, bool) override;
 
 private:
   std::pair<const RooArgSet*, AddCacheElem*> getNormAndCache(const RooArgSet* nset) const;

--- a/roofit/roofitcore/inc/RooFFTConvPdf.h
+++ b/roofit/roofitcore/inc/RooFFTConvPdf.h
@@ -71,7 +71,6 @@ protected:
   RooSetProxy _params ;  ///< Effective parameters of this p.d.f.
 
   void calcParams() ;
-  bool redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive) override ;
 
   std::vector<double>  scanPdf(RooRealVar& obs, RooAbsPdf& pdf, const RooDataHist& hist, const RooArgSet& slicePos, Int_t& N, Int_t& N2, Int_t& zeroBin, double shift) const ;
 

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1200,6 +1200,27 @@ bool RooAbsArg::recursiveRedirectServers(const RooAbsCollection& newSet, bool mu
 }
 
 
+////////////////////////////////////////////////////////////////////////////////
+/// Function that is called at the end of redirectServers(). Can be overloaded
+/// to inject some class-dependent behavior after server redirection, e.g.
+/// resetting of caches. The return value is meant to be an error flag, so in
+/// case something goes wrong the function should return `true`. If you
+/// overload this function, don't forget to also call the function of the
+/// base class.
+///
+/// \see redirectServers() For a detailed explanation of the function parameters.
+///
+// \param[in] newServerList One of the original parameters passed to redirectServers().
+// \param[in] mustReplaceAll One of the original parameters passed to redirectServers().
+// \param[in] nameChange  One of the original parameters passed to redirectServers().
+// \param[in] isRecursiveStep  One of the original parameters passed to redirectServers().
+bool RooAbsArg::redirectServersHook(const RooAbsCollection & /*newServerList*/, bool /*mustReplaceAll*/,
+                                    bool /*nameChange*/, bool /*isRecursiveStep*/)
+{
+  return false;
+}
+
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Register an RooArgProxy in the proxy list. This function is called by owned

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -477,7 +477,7 @@ bool RooAbsOptTestStatistic::redirectServersHook(const RooAbsCollection& newServ
   RooAbsTestStatistic::redirectServersHook(newServerList,mustReplaceAll,nameChange,isRecursive) ;
   if (operMode()!=Slave) return false ;
   bool ret = _funcClone->recursiveRedirectServers(newServerList,false,nameChange) ;
-  return ret ;
+  return ret || RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -3519,3 +3519,22 @@ void RooAbsPdf::setNormRangeOverride(const char* rangeName)
     _norm = 0 ;
   }
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Hook function intercepting redirectServer calls. Discard current
+/// normalization object if any server is redirected
+
+bool RooAbsPdf::redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
+                                    bool nameChange, bool isRecursiveStep)
+{
+  // Object is own by _normCacheManager that will delete object as soon as cache
+  // is sterilized by server redirect
+  _norm = nullptr ;
+
+  // Similar to the situation with the normalization integral above: if a
+  // server is redirected, the cached normalization set might not point to
+  // the right observables anymore. We need to reset it.
+  _normSet = nullptr ;
+  return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+}

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -309,7 +309,7 @@ bool RooAbsTestStatistic::initialize()
 ////////////////////////////////////////////////////////////////////////////////
 /// Forward server redirect calls to component test statistics
 
-bool RooAbsTestStatistic::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool)
+bool RooAbsTestStatistic::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
   if (SimMaster == _gofOpMode && _gofArray) {
     // Forward to slaves
@@ -327,7 +327,7 @@ bool RooAbsTestStatistic::redirectServersHook(const RooAbsCollection& newServerL
       }
     }
   }
-  return false;
+  return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -814,3 +814,13 @@ void RooAddPdf::printMetaArgs(std::ostream& os) const
 {
   RooRealSumPdf::printMetaArgs(_pdfList, _coefList, os);
 }
+
+
+bool RooAddPdf::redirectServersHook(const RooAbsCollection & newServerList, bool mustReplaceAll,
+                                    bool nameChange, bool isRecursiveStep)
+{
+  // If a server is redirected, the cached normalization set might not point
+  // to the right observables anymore. We need to reset it.
+  _copyOfLastNormSet.reset();
+  return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursiveStep);
+}

--- a/roofit/roofitcore/src/RooDerivative.cxx
+++ b/roofit/roofitcore/src/RooDerivative.cxx
@@ -142,11 +142,11 @@ double RooDerivative::evaluate() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Zap functor and derivator ;
 
-bool RooDerivative::redirectServersHook(const RooAbsCollection& /*newServerList*/, bool /*mustReplaceAll*/, bool /*nameChange*/, bool /*isRecursive*/)
+bool RooDerivative::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
   delete _ftor ;
   delete _rd ;
   _ftor = 0 ;
   _rd = 0 ;
-  return false ;
+  return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }

--- a/roofit/roofitcore/src/RooFFTConvPdf.cxx
+++ b/roofit/roofitcore/src/RooFFTConvPdf.cxx
@@ -876,13 +876,3 @@ void RooFFTConvPdf::calcParams()
   _params.add(params1) ;
   _params.add(params2,true) ;
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-///calcParams() ;
-
-bool RooFFTConvPdf::redirectServersHook(const RooAbsCollection& /*newServerList*/, bool /*mustReplaceAll*/, bool /*nameChange*/, bool /*isRecursive*/)
-{
-  return false ;
-}

--- a/roofit/roofitcore/src/RooFormulaVar.cxx
+++ b/roofit/roofitcore/src/RooFormulaVar.cxx
@@ -172,12 +172,12 @@ RooSpan<double> RooFormulaVar::evaluateSpan(RooBatchCompute::RunContext& inputDa
 ////////////////////////////////////////////////////////////////////////////////
 /// Propagate server change information to embedded RooFormula object
 
-bool RooFormulaVar::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool /*isRecursive*/)
+bool RooFormulaVar::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
-  bool success = getFormula().changeDependents(newServerList,mustReplaceAll,nameChange);
+  bool error = getFormula().changeDependents(newServerList,mustReplaceAll,nameChange);
 
   _formExpr = getFormula().GetTitle();
-  return success;
+  return error || RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooGenericPdf.cxx
+++ b/roofit/roofitcore/src/RooGenericPdf.cxx
@@ -169,13 +169,10 @@ bool RooGenericPdf::isValidReal(double /*value*/, bool /*printError*/) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Propagate server changes to embedded formula object
 
-bool RooGenericPdf::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool /*isRecursive*/)
+bool RooGenericPdf::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
-  if (_formula) {
-     return _formula->changeDependents(newServerList,mustReplaceAll,nameChange);
-  } else {
-    return true ;
-  }
+  bool error = _formula ? _formula->changeDependents(newServerList,mustReplaceAll,nameChange) : true;
+  return error || RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooNumConvolution.cxx
+++ b/roofit/roofitcore/src/RooNumConvolution.cxx
@@ -262,11 +262,11 @@ double RooNumConvolution::evaluate() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Intercept server redirects. Throw away cache, as figuring out redirections on the cache is an unsolvable problem.
 
-bool RooNumConvolution::redirectServersHook(const RooAbsCollection& /*newServerList*/, bool /*mustReplaceAll*/,
-                     bool /*nameChange*/, bool /*isRecursive*/)
+bool RooNumConvolution::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll,
+                     bool nameChange, bool isRecursive)
 {
   _init = false ;
-  return false ;
+  return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -2202,7 +2202,7 @@ void RooProdPdf::printMetaArgs(ostream& os) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Implement support for node removal
 
-bool RooProdPdf::redirectServersHook(const RooAbsCollection& newServerList, bool /*mustReplaceAll*/, bool nameChange, bool /*isRecursive*/)
+bool RooProdPdf::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
   if (nameChange && _pdfList.find("REMOVAL_DUMMY")) {
 
@@ -2234,7 +2234,7 @@ bool RooProdPdf::redirectServersHook(const RooAbsCollection& newServerList, bool
     }
   }
 
-  return false ;
+  return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 void RooProdPdf::CacheElem::writeToStream(std::ostream& os) const {

--- a/roofit/roofitcore/src/RooProfileLL.cxx
+++ b/roofit/roofitcore/src/RooProfileLL.cxx
@@ -278,11 +278,11 @@ void RooProfileLL::validateAbsMin() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-bool RooProfileLL::redirectServersHook(const RooAbsCollection& /*newServerList*/, bool /*mustReplaceAll*/,
-                bool /*nameChange*/, bool /*isRecursive*/)
+bool RooProfileLL::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll,
+                                       bool nameChange, bool isRecursive)
 {
   _minimizer.reset(nullptr);
-  return false ;
+  return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -228,8 +228,8 @@ void RooProjectedPdf::generateEvent(Int_t /*code*/)
 /// Specifically update the set proxy 'deps' which introduces the dependency
 /// on server value dirty flags of ourselves
 
-bool RooProjectedPdf::redirectServersHook(const RooAbsCollection& newServerList, bool /*mustReplaceAll*/,
-                   bool /*nameChange*/, bool /*isRecursive*/)
+bool RooProjectedPdf::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll,
+                                          bool nameChange, bool isRecursive)
 {
   // Redetermine explicit list of dependents if intPdf is being replaced
   RooAbsArg* newPdf = newServerList.find(intpdf.arg().GetName()) ;
@@ -237,24 +237,23 @@ bool RooProjectedPdf::redirectServersHook(const RooAbsCollection& newServerList,
 
     // Determine if set of dependens of new p.d.f is different from old p.d.f.
     RooArgSet olddeps(deps) ;
-    RooArgSet* newdeps = newPdf->getParameters(intobs) ;
-    RooArgSet* common = (RooArgSet*) newdeps->selectCommon(deps) ;
-    newdeps->remove(*common,true,true) ;
-    olddeps.remove(*common,true,true) ;
+    RooArgSet newdeps;
+    newPdf->getParameters(&intobs, newdeps);
+    RooArgSet common;
+    newdeps.selectCommon(deps, common);
+    newdeps.remove(common,true,true) ;
+    olddeps.remove(common,true,true) ;
 
     // If so, adjust composition of deps Listproxy
-    if (newdeps->getSize()>0) {
-      deps.add(*newdeps) ;
+    if (!newdeps.empty()) {
+      deps.add(newdeps) ;
     }
-    if (olddeps.getSize()>0) {
+    if (!olddeps.empty()) {
       deps.remove(olddeps,true,true) ;
     }
-
-    delete common ;
-    delete newdeps ;
   }
 
-  return false ;
+  return RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -1010,8 +1010,8 @@ double RooRealIntegral::integrate() const
 ////////////////////////////////////////////////////////////////////////////////
 /// Intercept server redirects and reconfigure internal object accordingly
 
-bool RooRealIntegral::redirectServersHook(const RooAbsCollection& /*newServerList*/,
-                   bool /*mustReplaceAll*/, bool /*nameChange*/, bool /*isRecursive*/)
+bool RooRealIntegral::redirectServersHook(const RooAbsCollection& newServerList,
+                   bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
   _restartNumIntEngine = true ;
 
@@ -1026,7 +1026,7 @@ bool RooRealIntegral::redirectServersHook(const RooAbsCollection& /*newServerLis
   // Delete parameters cache if we have one
   _params.reset();
 
-  return false ;
+  return RooAbsReal::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/roofit/roofitcore/src/RooResolutionModel.cxx
+++ b/roofit/roofitcore/src/RooResolutionModel.cxx
@@ -255,7 +255,7 @@ double RooResolutionModel::getValV(const RooArgSet* nset) const
 /// Forward redirectServers call to our basis function, which is not connected to either resolution
 /// model or the physics model.
 
-bool RooResolutionModel::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool /*isRecursive*/)
+bool RooResolutionModel::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
   if (!_basis) {
     _norm = 0 ;
@@ -275,7 +275,7 @@ bool RooResolutionModel::redirectServersHook(const RooAbsCollection& newServerLi
 
   _basis->redirectServers(newServerList,mustReplaceAll,nameChange) ;
 
-  return (mustReplaceAll && !newBasis) ;
+  return (mustReplaceAll && !newBasis) || RooAbsPdf::redirectServersHook(newServerList, mustReplaceAll, nameChange, isRecursive);
 }
 
 

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -1,3 +1,88 @@
+#include <Roo1DTable.h>
+#include <RooAbsReal.h>
+#include <RooAddModel.h>
+#include <RooAddPdf.h>
+#include <RooAddition.h>
+#include <RooArgSet.h>
+#include <RooArgusBG.h>
+#include <RooBCPEffDecay.h>
+#include <RooBDecay.h>
+#include <RooBMixDecay.h>
+#include <RooBinning.h>
+#include <RooBinningCategory.h>
+#include <RooCFunction1Binding.h>
+#include <RooCFunction3Binding.h>
+#include <RooCategory.h>
+#include <RooChebychev.h>
+#include <RooChi2MCSModule.h>
+#include <RooConstVar.h>
+#include <RooDLLSignificanceMCSModule.h>
+#include <RooDataHist.h>
+#include <RooDataSet.h>
+#include <RooDecay.h>
+#include <RooEffProd.h>
+#include <RooEfficiency.h>
+#include <RooExponential.h>
+#include <RooExtendPdf.h>
+#include <RooFFTConvPdf.h>
+#include <RooFitResult.h>
+#include <RooFormulaVar.h>
+#include <RooGaussModel.h>
+#include <RooGaussian.h>
+#include <RooGenericPdf.h>
+#include <RooGlobalFunc.h>
+#include <RooHelpers.h>
+#include <RooHist.h>
+#include <RooHistPdf.h>
+#include <RooIntegralMorph.h>
+#include <RooKeysPdf.h>
+#include <RooLandau.h>
+#include <RooMCStudy.h>
+#include <RooMappedCategory.h>
+#include <RooMinimizer.h>
+#include <RooMultiCategory.h>
+#include <RooNDKeysPdf.h>
+#include <RooNumIntConfig.h>
+#include <RooPlot.h>
+#include <RooPolyVar.h>
+#include <RooPolynomial.h>
+#include <RooProdPdf.h>
+#include <RooProduct.h>
+#include <RooProfileLL.h>
+#include <RooRandomizeParamMCSModule.h>
+#include <RooRealConstant.h>
+#include <RooRealSumPdf.h>
+#include <RooRealVar.h>
+#include <RooSimultaneous.h>
+#include <RooSuperCategory.h>
+#include <RooTFnBinding.h>
+#include <RooThresholdCategory.h>
+#include <RooTruthModel.h>
+#include <RooUnitTest.h>
+#include <RooWorkspace.h>
+
+#include <Math/DistFunc.h>
+#include <TCanvas.h>
+#include <TDirectory.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1.h>
+#include <TH1D.h>
+#include <TH2.h>
+#include <TH2D.h>
+#include <TMath.h>
+#include <TPluginManager.h>
+#include <TROOT.h>
+#include <TRandom.h>
+#include <TStyle.h>
+#include <TTree.h>
+
+#include <iomanip>
+
+
+using namespace RooFit ;
+
+
 //////////////////////////////////////////////////////////////////////////
 //
 // 'BASIC FUNCTIONALITY' RooFit tutorial macro #101
@@ -10,20 +95,6 @@
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooFormulaVar.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooUnitTest.h"
-#include "RooHelpers.h"
-
-using namespace RooFit ;
 
 
 // Elementary operations on a gaussian PDF
@@ -103,21 +174,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooDataHist.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "TTree.h"
-#include "TH1D.h"
-#include "TRandom.h"
-using namespace RooFit ;
 
 
 class TestBasic102 : public RooUnitTest
@@ -274,20 +330,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooConstVar.h"
-#include "RooPlot.h"
-#include "RooFitResult.h"
-#include "RooGenericPdf.h"
-
-using namespace RooFit ;
-
 
 class TestBasic103 : public RooUnitTest
 {
@@ -389,22 +431,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "TMath.h"
-#include "TF1.h"
-#include "Math/DistFunc.h"
-#include "RooCFunction1Binding.h"
-#include "RooCFunction3Binding.h"
-#include "RooTFnBinding.h"
-
-using namespace RooFit ;
 
 class TestBasic105 : public RooUnitTest
 {
@@ -486,21 +512,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussModel.h"
-#include "RooDecay.h"
-#include "RooBMixDecay.h"
-#include "RooCategory.h"
-#include "RooBinning.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
 
 
 class TestBasic108 : public RooUnitTest
@@ -620,16 +631,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooHist.h"
-using namespace RooFit ;
 
 class TestBasic109 : public RooUnitTest
 {
@@ -716,15 +717,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooGaussian.h"
-#include "RooAbsReal.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-using namespace RooFit ;
 
 class TestBasic110 : public RooUnitTest
 {
@@ -807,19 +799,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooNumIntConfig.h"
-#include "RooLandau.h"
-#include "RooArgSet.h"
-#include <iomanip>
-using namespace RooFit ;
 
 class TestBasic111 : public RooUnitTest
 {
@@ -909,18 +888,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic201 : public RooUnitTest
@@ -1036,19 +1003,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooExtendPdf.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic202 : public RooUnitTest
 {
@@ -1155,20 +1109,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooAddPdf.h"
-#include "RooFitResult.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
 
 class TestBasic203 : public RooUnitTest
 {
@@ -1242,20 +1182,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooExtendPdf.h"
-#include "RooFitResult.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic204 : public RooUnitTest
@@ -1336,19 +1262,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooAddPdf.h"
-#include "RooChebychev.h"
-#include "RooExponential.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic205 : public RooUnitTest
@@ -1463,23 +1376,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooLandau.h"
-#include "RooFFTConvPdf.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-#include "TPluginManager.h"
-#include "TROOT.h"
-
-using namespace RooFit ;
-
-
 
 class TestBasic208 : public RooUnitTest
 {
@@ -1580,21 +1476,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussModel.h"
-#include "RooAddModel.h"
-#include "RooTruthModel.h"
-#include "RooDecay.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
-
 
 class TestBasic209 : public RooUnitTest
 {
@@ -1673,19 +1554,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolyVar.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
-
 
 class TestBasic301 : public RooUnitTest
 {
@@ -1752,23 +1620,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooFormulaVar.h"
-#include "RooAddition.h"
-#include "RooProduct.h"
-#include "RooPolyVar.h"
-#include "TCanvas.h"
-#include "TH1.h"
-
-using namespace RooFit ;
 
 
 class TestBasic302 : public RooUnitTest
@@ -1867,20 +1718,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolyVar.h"
-#include "RooProdPdf.h"
-#include "RooPlot.h"
-#include "TRandom.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
 
 
 class TestBasic303 : public RooUnitTest
@@ -2002,18 +1839,6 @@ RooDataSet* makeFakeDataXY()
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooProdPdf.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
-
 
 class TestBasic304 : public RooUnitTest
 {
@@ -2085,20 +1910,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolyVar.h"
-#include "RooProdPdf.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
 
 
 class TestBasic305 : public RooUnitTest
@@ -2185,21 +1996,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooGaussModel.h"
-#include "RooDecay.h"
-#include "RooLandau.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH2D.h"
-using namespace RooFit ;
-
 
 
 class TestBasic306 : public RooUnitTest
@@ -2303,22 +2099,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooGaussModel.h"
-#include "RooDecay.h"
-#include "RooLandau.h"
-#include "RooProdPdf.h"
-#include "RooHistPdf.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
 
 class TestBasic307 : public RooUnitTest
 {
@@ -2416,18 +2196,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooGaussian.h"
-#include "RooProdPdf.h"
-#include "RooAbsReal.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
 
 class TestBasic308 : public RooUnitTest
 {
@@ -2524,19 +2292,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussModel.h"
-#include "RooDecay.h"
-#include "RooBMixDecay.h"
-#include "RooCategory.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic310 : public RooUnitTest
 {
@@ -2628,19 +2383,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooProdPdf.h"
-#include "RooAddPdf.h"
-#include "RooPolynomial.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic311 : public RooUnitTest
 {
@@ -2724,20 +2466,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooProdPdf.h"
-#include "RooAddPdf.h"
-#include "RooPolynomial.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooFitResult.h"
-using namespace RooFit ;
 
 
 class TestBasic312 : public RooUnitTest
@@ -2850,18 +2578,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooProdPdf.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic313 : public RooUnitTest
 {
@@ -2944,19 +2660,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooExponential.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooFitResult.h"
-
-using namespace RooFit ;
-
 
 class TestBasic314 : public RooUnitTest
 {
@@ -3034,21 +2737,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooProdPdf.h"
-#include "RooPolyVar.h"
-#include "TH1.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooNumIntConfig.h"
-#include "RooConstVar.h"
-using namespace RooFit ;
 
 
 
@@ -3134,19 +2822,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooAddPdf.h"
-#include "RooProdPdf.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic316 : public RooUnitTest
@@ -3263,19 +2938,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooDataHist.h"
-#include "RooGaussian.h"
-#include "RooCategory.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "TFile.h"
-using namespace RooFit ;
-
 
 class TestBasic402 : public RooUnitTest
 {
@@ -3388,22 +3050,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooDataHist.h"
-#include "RooGaussian.h"
-#include "RooFormulaVar.h"
-#include "RooGenericPdf.h"
-#include "RooPolynomial.h"
-#include "RooMinimizer.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooFitResult.h"
-using namespace RooFit ;
 
 
 class TestBasic403 : public RooUnitTest
@@ -3548,19 +3194,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooPolynomial.h"
-#include "RooCategory.h"
-#include "Roo1DTable.h"
-#include "RooGaussian.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic404 : public RooUnitTest
 {
@@ -3660,22 +3293,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooCategory.h"
-#include "RooThresholdCategory.h"
-#include "RooBinningCategory.h"
-#include "Roo1DTable.h"
-#include "RooArgusBG.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "RooRealConstant.h"
-using namespace RooFit ;
 
 
 class TestBasic405 : public RooUnitTest
@@ -3790,21 +3407,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooPolynomial.h"
-#include "RooCategory.h"
-#include "RooMappedCategory.h"
-#include "RooMultiCategory.h"
-#include "RooSuperCategory.h"
-#include "Roo1DTable.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic406 : public RooUnitTest
 {
@@ -3898,20 +3500,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooSimultaneous.h"
-#include "RooCategory.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic501 : public RooUnitTest
@@ -4049,25 +3637,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooWorkspace.h"
-#include "RooProdPdf.h"
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooGaussModel.h"
-#include "RooAddModel.h"
-#include "RooDecay.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooSimultaneous.h"
-#include "RooCategory.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic599 : public RooUnitTest
@@ -4283,21 +3852,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooProdPdf.h"
-#include "RooAddPdf.h"
-#include "RooMinimizer.h"
-#include "RooFitResult.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
-
 
 class TestBasic601 : public RooUnitTest
 {
@@ -4396,19 +3950,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooMinimizer.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic602 : public RooUnitTest
 {
@@ -4481,21 +4022,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooAddPdf.h"
-#include "RooProdPdf.h"
-#include "RooFitResult.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-using namespace RooFit ;
 
 
 class TestBasic604 : public RooUnitTest
@@ -4581,19 +4107,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooAddPdf.h"
-#include "RooProfileLL.h"
-#include "RooMinimizer.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
 
 class TestBasic605 : public RooUnitTest
@@ -4696,16 +4209,6 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooArgusBG.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
-
 
 class TestBasic606 : public RooUnitTest
 {
@@ -4784,23 +4287,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooAddPdf.h"
-#include "RooChebychev.h"
-#include "RooFitResult.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "TFile.h"
-#include "TStyle.h"
-#include "TH2.h"
-
-using namespace RooFit ;
 
 
 class TestBasic607 : public RooUnitTest
@@ -4893,19 +4379,6 @@ public:
 /////////////////////////////////////////////////////////////////////////
 
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooPolyVar.h"
-#include "RooMinimizer.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "TRandom.h"
-
-using namespace RooFit ;
-
 class TestBasic609 : public RooUnitTest
 {
 public:
@@ -4987,23 +4460,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooFormulaVar.h"
-#include "RooProdPdf.h"
-#include "RooEfficiency.h"
-#include "RooPolynomial.h"
-#include "RooCategory.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic701 : public RooUnitTest
 {
 public:
@@ -5092,24 +4549,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooCategory.h"
-#include "RooEfficiency.h"
-#include "RooPolynomial.h"
-#include "RooProdPdf.h"
-#include "RooFormulaVar.h"
-#include "TCanvas.h"
-#include "TH1.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic702 : public RooUnitTest
 {
 public:
@@ -5210,21 +4650,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooExponential.h"
-#include "RooEffProd.h"
-#include "RooFormulaVar.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic703 : public RooUnitTest
 {
 public:
@@ -5309,24 +4735,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooTruthModel.h"
-#include "RooFormulaVar.h"
-#include "RooRealSumPdf.h"
-#include "RooPolyVar.h"
-#include "RooProduct.h"
-#include "TH1.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic704 : public RooUnitTest
 {
 public:
@@ -5428,21 +4837,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooIntegralMorph.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-#include "TH1.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic705 : public RooUnitTest
 {
 public:
@@ -5576,20 +4971,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooHistPdf.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic706 : public RooUnitTest
 {
 public:
@@ -5665,23 +5047,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooKeysPdf.h"
-#include "RooNDKeysPdf.h"
-#include "RooProdPdf.h"
-#include "TCanvas.h"
-#include "TH1.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-
-// Elementary operations on a gaussian PDF
 class TestBasic707 : public RooUnitTest
 {
 public:
@@ -5785,23 +5151,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooCategory.h"
-#include "RooBMixDecay.h"
-#include "RooBCPEffDecay.h"
-#include "RooBDecay.h"
-#include "RooFormulaVar.h"
-#include "RooTruthModel.h"
-#include "TCanvas.h"
-#include "RooPlot.h"
-using namespace RooFit ;
 
-// Elementary operations on a gaussian PDF
 class TestBasic708 : public RooUnitTest
 {
 public:
@@ -6003,26 +5353,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooMCStudy.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH2.h"
-#include "RooFitResult.h"
-#include "TStyle.h"
-#include "TDirectory.h"
 
-using namespace RooFit ;
-
-
-// Elementary operations on a gaussian PDF
 class TestBasic801 : public RooUnitTest
 {
 public:
@@ -6122,25 +5453,7 @@ public:
 //
 /////////////////////////////////////////////////////////////////////////
 
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooMCStudy.h"
-#include "RooChi2MCSModule.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-#include "TDirectory.h"
 
-using namespace RooFit ;
-
-
-// Elementary operations on a gaussian PDF
 class TestBasic802 : public RooUnitTest
 {
 public:
@@ -6194,7 +5507,6 @@ public:
   // Create alternate pdf with shifted mean
   RooRealVar mean2("mean2","mean of gaussian 2",0.5) ;
   RooGaussian gauss2("gauss2","gaussian PDF2",x,mean2,sigma) ;
-
   // Create study manager with separate generation and fit model. This configuration
   // is set up to generate bad fits as the fit and generator model have different means
   // and the mean parameter is not floating in the fit
@@ -6240,24 +5552,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooChebychev.h"
-#include "RooAddPdf.h"
-#include "RooMCStudy.h"
-#include "RooRandomizeParamMCSModule.h"
-#include "RooDLLSignificanceMCSModule.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-#include "TDirectory.h"
-
-using namespace RooFit ;
 
 
 class TestBasic803 : public RooUnitTest
@@ -6376,22 +5670,6 @@ public:
 // 07/2008 - Wouter Verkerke
 //
 /////////////////////////////////////////////////////////////////////////
-
-#ifndef __CINT__
-#include "RooGlobalFunc.h"
-#endif
-#include "RooRealVar.h"
-#include "RooDataSet.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooAddPdf.h"
-#include "RooProdPdf.h"
-#include "RooMCStudy.h"
-#include "RooPlot.h"
-#include "TCanvas.h"
-#include "TH1.h"
-
-using namespace RooFit ;
 
 
 class TestBasic804 : public RooUnitTest


### PR DESCRIPTION
If one overloads `RooAbsArg::redirectServersHook()`, one also needs to
call the `redirectServersHook()` of the base class. Otherwise, important
things that must be done when redirecting the servers of a `RooAbsReal`
or `RooAbsPdf` for example are not done.

In particular, this fixes some ASAN build test failures where the
`RooAbsPdf::_normSet` member was not reset when redirecting servers
because `RooAbsPdf::redirectServersHook()` was not called.

A second, minor commit in this PR cleans the includes in `stressRooFit_tests.h`.

