### PR TITLE
Replace fwd decl of json with wrapper type

### DIFF
--- a/graf3d/eve7/inc/ROOT/REveBox.hxx
+++ b/graf3d/eve7/inc/ROOT/REveBox.hxx
@@ -44,7 +44,7 @@ public:
    // For TAttBBox:
    virtual void ComputeBBox() override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void BuildRenderData() override;
    // Projectable:
    virtual TClass* ProjectedClass(const REveProjection* p) const override;
@@ -76,7 +76,7 @@ public:
    virtual ~REveBoxProjected();
 
    void BuildRenderData() override;
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    // For TAttBBox:
    void ComputeBBox() override;

--- a/graf3d/eve7/inc/ROOT/REveBoxSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveBoxSet.hxx
@@ -100,7 +100,7 @@ public:
    void  SetBoxSkip(Int_t bs) { fBoxSkip = bs; }
 
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void  BuildRenderData() override;
 };
 

--- a/graf3d/eve7/inc/ROOT/REveCalo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCalo.hxx
@@ -145,8 +145,8 @@ public:
 
    Bool_t  CellInEtaPhiRng (REveCaloData::CellData_t&) const;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
-   virtual void WriteCoreJsonSelection(nlohmann::json &j,  REveCaloData::vCellId_t) = 0;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
+   virtual void WriteCoreJsonSelection(Internal::REveJsonWrapper &j,  REveCaloData::vCellId_t) = 0;
 };
 
 /**************************************************************************/
@@ -177,8 +177,8 @@ public:
    virtual ~REveCalo3D() {}
    void ComputeBBox() override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
-   void WriteCoreJsonSelection(nlohmann::json &j,  REveCaloData::vCellId_t) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
+   void WriteCoreJsonSelection(Internal::REveJsonWrapper &j,  REveCaloData::vCellId_t) override;
    void BuildRenderData() override;
 
    void    SetFrameWidth(Float_t w) { fFrameWidth = w; }
@@ -249,8 +249,8 @@ public:
 
    Float_t GetValToHeight() const override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
-   void WriteCoreJsonSelection(nlohmann::json &j,  REveCaloData::vCellId_t) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
+   void WriteCoreJsonSelection(Internal::REveJsonWrapper &j,  REveCaloData::vCellId_t) override;
    void BuildRenderData() override;
 
    void NewBinPicked(Int_t bin, Int_t slice, Int_t selectionId, Bool_t multi);

--- a/graf3d/eve7/inc/ROOT/REveCaloData.hxx
+++ b/graf3d/eve7/inc/ROOT/REveCaloData.hxx
@@ -223,12 +223,12 @@ public:
    void     SetSelector(REveCaloDataSelector* iSelector) { fSelector.reset(iSelector); }
    REveCaloDataSelector* GetSelector() { return fSelector.get(); }
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    static  Float_t EtaToTheta(Float_t eta);
 
    bool RequiresExtraSelectionData() const override { return true; };
-   void FillExtraSelectionData(nlohmann::json&, const std::set<int>&) const override;
+   void FillExtraSelectionData(Internal::REveJsonWrapper&, const std::set<int>&) const override;
 
    using REveElement::GetHighlightTooltip;
    std::string GetHighlightTooltip(const std::set<int>& secondary_idcs) const override;

--- a/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataCollection.hxx
@@ -81,7 +81,7 @@ private:
 public:
    REveDataItemList(const std::string& n = "Items", const std::string& t = "");
    virtual ~REveDataItemList() {}
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
 
    virtual void ItemChanged(REveDataItem *item);
    virtual void ItemChanged(Int_t idx);
@@ -151,8 +151,8 @@ public:
    void *GetDataPtr(Int_t i) const { return  fItemList->fItems[i]->GetDataPtr(); }
    const REveDataItem* GetDataItem(Int_t i) const { return  fItemList->fItems[i]; }
 
-   void  StreamPublicMethods(nlohmann::json &cj) const;
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   void  StreamPublicMethods(Internal::REveJsonWrapper &cj) const;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
 
    void SetMainColor(Color_t) override;
 

--- a/graf3d/eve7/inc/ROOT/REveDataTable.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDataTable.hxx
@@ -33,7 +33,7 @@ public:
    const REveDataCollection *GetCollection() const { return fCollection; }
 
    void PrintTable();
-   virtual Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset);
+   virtual Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset);
 
    void AddNewColumn(const std::string& expr, const std::string& title, int prec = 2);
 };

--- a/graf3d/eve7/inc/ROOT/REveDigitSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveDigitSet.hxx
@@ -183,9 +183,9 @@ public:
 
    
    bool    RequiresExtraSelectionData() const override { return true; };
-   void    FillExtraSelectionData(nlohmann::json& j, const std::set<int>& secondary_idcs) const override;
+   void    FillExtraSelectionData(Internal::REveJsonWrapper& j, const std::set<int>& secondary_idcs) const override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 };
 
 } // namespace Experimental

--- a/graf3d/eve7/inc/ROOT/REveElement.hxx
+++ b/graf3d/eve7/inc/ROOT/REveElement.hxx
@@ -21,21 +21,6 @@
 
 class TGeoMatrix;
 
-namespace nlohmann {
-template<typename T, typename SFINAE>
-struct adl_serializer;
-
-template <template <typename U, typename V, typename... Args> class ObjectType,
-          template <typename U, typename... Args> class ArrayType, class StringType, class BooleanType,
-          class NumberIntegerType, class NumberUnsignedType, class NumberFloatType,
-          template <typename U> class AllocatorType, template <typename T, typename SFINAE = void> class JSONSerializer,
-          class BinaryType>
-class basic_json;
-
-using json = basic_json<std::map, std::vector, std::string, bool, std::int64_t, std::uint64_t, double, std::allocator,
-                        adl_serializer, std::vector<std::uint8_t>>;
-} // namespace nlohmann
-
 namespace ROOT {
 namespace Experimental {
 
@@ -44,6 +29,10 @@ class REveScene;
 class REveCompound;
 class REveTrans;
 class REveRenderData;
+
+namespace Internal {
+struct REveJsonWrapper;
+}
 
 //==============================================================================
 // REveElement
@@ -264,7 +253,7 @@ public:
    virtual void SetTransMatrix(Double_t *carr);
    virtual void SetTransMatrix(const TGeoMatrix &mat);
 
-   virtual Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset);
+   virtual Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset);
    virtual void  BuildRenderData();
 
    void* GetUserData() const   { return fUserData; }
@@ -328,7 +317,7 @@ public:
    void   CSCApplyMainTransparencyToMatchingChildren() { fCSCBits |= kCSCBApplyMainTransparencyToMatchingChildren; }
 
    virtual bool RequiresExtraSelectionData() const { return false; }
-   virtual void FillExtraSelectionData(nlohmann::json&, const std::set<int>&) const {}
+   virtual void FillExtraSelectionData(Internal::REveJsonWrapper&, const std::set<int>&) const {}
 
    // Change-stamping and change bits
    //---------------------------------

--- a/graf3d/eve7/inc/ROOT/REveEllipsoid.hxx
+++ b/graf3d/eve7/inc/ROOT/REveEllipsoid.hxx
@@ -48,7 +48,7 @@ public:
    void SetBaseVectors(REveVector& v0, REveVector& v1, REveVector& v3);
    void SetPhiStep(float ps);
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    TClass *ProjectedClass(const REveProjection *p) const override;
 };
@@ -78,7 +78,7 @@ public:
 
    void BuildRenderData() override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    virtual void OutlineProjected();
    virtual void SetProjection(REveProjectionManager *mng, REveProjectable *model) override;

--- a/graf3d/eve7/inc/ROOT/REveGeoShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveGeoShape.hxx
@@ -53,7 +53,7 @@ public:
    REveGeoShape(const std::string &name = "REveGeoShape", const std::string &title = "");
    virtual ~REveGeoShape();
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void BuildRenderData() override;
 
    Int_t GetNSegments() const { return fNSegments; }

--- a/graf3d/eve7/inc/ROOT/REveJetCone.hxx
+++ b/graf3d/eve7/inc/ROOT/REveJetCone.hxx
@@ -49,7 +49,7 @@ public:
    REveJetCone(const Text_t *n = "REveJetCone", const Text_t *t = "");
    virtual ~REveJetCone() {}
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void BuildRenderData() override;
 
    void ComputeBBox() override;

--- a/graf3d/eve7/inc/ROOT/REveLine.hxx
+++ b/graf3d/eve7/inc/ROOT/REveLine.hxx
@@ -67,7 +67,7 @@ public:
 
    TClass *ProjectedClass(const REveProjection *p) const override;
 
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
    void BuildRenderData() override;
 
    static Bool_t GetDefaultSmooth();

--- a/graf3d/eve7/inc/ROOT/REvePointSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REvePointSet.hxx
@@ -76,7 +76,7 @@ public:
 
    TClass* ProjectedClass(const REveProjection *p) const override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void  BuildRenderData()override;
 
    void ComputeBBox() override;

--- a/graf3d/eve7/inc/ROOT/REvePolygonSetProjected.hxx
+++ b/graf3d/eve7/inc/ROOT/REvePolygonSetProjected.hxx
@@ -90,7 +90,7 @@ public:
    virtual void DumpPolys() const;
    void DumpBuffer3D();
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void BuildRenderData() override;
 };
 

--- a/graf3d/eve7/inc/ROOT/REveScene.hxx
+++ b/graf3d/eve7/inc/ROOT/REveScene.hxx
@@ -102,7 +102,7 @@ public:
    void ProcessChanges();
 
    void StreamElements();
-   void StreamJsonRecurse(REveElement *el, nlohmann::json &jobj);
+   void StreamJsonRecurse(REveElement *el, Internal::REveJsonWrapper &jobj);
 
    // void   Repaint(Bool_t dropLogicals=kFALSE);
    // void   RetransHierarchically();

--- a/graf3d/eve7/inc/ROOT/REveSceneInfo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSceneInfo.hxx
@@ -39,7 +39,7 @@ public:
    REveSceneInfo(REveViewer *viewer, REveScene *scene);
    virtual ~REveSceneInfo() {}
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    REveViewer *GetViewer() const { return fViewer; }
    REveScene *GetScene() const { return fScene; }

--- a/graf3d/eve7/inc/ROOT/REveSelection.hxx
+++ b/graf3d/eve7/inc/ROOT/REveSelection.hxx
@@ -175,7 +175,7 @@ public:
 
    // ----------------------------------------------------------------
 
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
 
 };
 

--- a/graf3d/eve7/inc/ROOT/REveShape.hxx
+++ b/graf3d/eve7/inc/ROOT/REveShape.hxx
@@ -49,7 +49,7 @@ public:
    REveShape(const std::string &n = "REveShape", const std::string &t = "");
    virtual ~REveShape();
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    // Rendering parameters.
    void SetMainColor(Color_t color) override;

--- a/graf3d/eve7/inc/ROOT/REveStraightLineSet.hxx
+++ b/graf3d/eve7/inc/ROOT/REveStraightLineSet.hxx
@@ -115,7 +115,7 @@ public:
 
    TClass* ProjectedClass(const REveProjection* p) const override;
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
    void  BuildRenderData() override;
 
    void ComputeBBox() override;

--- a/graf3d/eve7/inc/ROOT/REveTableInfo.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTableInfo.hxx
@@ -98,7 +98,7 @@ public:
 
    void AddDelegate(Delegate_t d) { fDelegates.push_back(d); }
 
-   Int_t WriteCoreJson(nlohmann::json &j, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset) override;
 
    // read
    REveTableHandle::Entries_t &RefTableEntries(std::string cname);

--- a/graf3d/eve7/inc/ROOT/REveTrack.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrack.hxx
@@ -130,7 +130,7 @@ public:
 
    TClass *ProjectedClass(const REveProjection *p) const override;
 
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
    void BuildRenderData() override;
 };
 

--- a/graf3d/eve7/inc/ROOT/REveTrackProjected.hxx
+++ b/graf3d/eve7/inc/ROOT/REveTrackProjected.hxx
@@ -53,7 +53,7 @@ public:
 
    void SecSelected(REveTrack *) override; // marked as signal in REveTrack
 
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
    void BuildRenderData() override;
 };
 

--- a/graf3d/eve7/inc/ROOT/REveViewer.hxx
+++ b/graf3d/eve7/inc/ROOT/REveViewer.hxx
@@ -49,7 +49,7 @@ public:
 
    void RemoveElementLocal(REveElement *el) override;
    void RemoveElementsLocal() override;
-   Int_t WriteCoreJson(nlohmann::json &cj, Int_t rnr_offset) override;
+   Int_t WriteCoreJson(Internal::REveJsonWrapper &cj, Int_t rnr_offset) override;
 };
 
 

--- a/graf3d/eve7/src/REveBox.cxx
+++ b/graf3d/eve7/src/REveBox.cxx
@@ -15,6 +15,7 @@
 
 #include "TClass.h"
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -99,7 +100,7 @@ void REveBox::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveBox::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveBox::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 
@@ -276,7 +277,7 @@ void REveBoxProjected::BuildRenderData()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveBoxProjected::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveBoxProjected::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveShape::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveBoxSet.cxx
+++ b/graf3d/eve7/src/REveBoxSet.cxx
@@ -17,6 +17,7 @@
 #include "TRandom.h"
 #include <cassert>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace::ROOT::Experimental;
@@ -333,7 +334,7 @@ void REveBoxSet::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveBoxSet::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveBoxSet::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveDigitSet::WriteCoreJson(j, rnr_offset);
    j["boxType"] = int(fBoxType);

--- a/graf3d/eve7/src/REveCalo.cxx
+++ b/graf3d/eve7/src/REveCalo.cxx
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -424,7 +425,7 @@ void REveCaloViz::SetupHeight(Float_t value, Int_t /*slice*/, Float_t& outH) con
 ///////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveCaloViz::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveCaloViz::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    // The slice colors need to be streamed becuse at EveElement contruction time, streamed caloData
    // is not available. Maybe this is not necessary if EveElements have EveManager globaly available
@@ -656,7 +657,7 @@ void REveCalo3D::BuildRenderData()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveCalo3D::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveCalo3D::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    return REveCaloViz::WriteCoreJson(j, rnr_offset);
 }
@@ -664,7 +665,7 @@ Int_t REveCalo3D::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation for selection.
 
-void REveCalo3D::WriteCoreJsonSelection(nlohmann::json &j, REveCaloData::vCellId_t cells)
+void REveCalo3D::WriteCoreJsonSelection(Internal::REveJsonWrapper &j, REveCaloData::vCellId_t cells)
 {
    // selection
    auto sarr = nlohmann::json::array();
@@ -686,7 +687,7 @@ void REveCalo3D::WriteCoreJsonSelection(nlohmann::json &j, REveCaloData::vCellId
    rec["caloVizId"] = GetElementId();
    rec["cells"] = sarr;
 
-   j.push_back(rec);
+   j.json.push_back(rec);
 }
 
 
@@ -1017,7 +1018,7 @@ void REveCalo2D::ComputeBBox()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveCalo2D::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveCalo2D::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveCaloViz::WriteCoreJson(j, rnr_offset);
    j["isRPhi"] = IsRPhi();
@@ -1027,7 +1028,7 @@ Int_t REveCalo2D::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation for selection.
 
-void REveCalo2D::WriteCoreJsonSelection(nlohmann::json &j, REveCaloData::vCellId_t cells)
+void REveCalo2D::WriteCoreJsonSelection(Internal::REveJsonWrapper &j, REveCaloData::vCellId_t cells)
 {
    static const REveException eh("REveCalo2D::WriteCoreJsonSelection ");
    auto sarr = nlohmann::json::array();
@@ -1161,7 +1162,7 @@ void REveCalo2D::WriteCoreJsonSelection(nlohmann::json &j, REveCaloData::vCellId
    nlohmann::json rec = {};
    rec["caloVizId"] = GetElementId();
    rec["cells"] = sarr;
-   j.push_back(rec);
+   j.json.push_back(rec);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf3d/eve7/src/REveCaloData.cxx
+++ b/graf3d/eve7/src/REveCaloData.cxx
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <set>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -256,7 +257,7 @@ void REveCaloData::DataChanged()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Int_t REveCaloData::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveCaloData::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 
@@ -274,7 +275,7 @@ Int_t REveCaloData::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
 }
 ////////////////////////////////////////////////////////////////////////////////
 
-void  REveCaloData::FillExtraSelectionData(nlohmann::json& j, const std::set<int>& secondary_idcs) const
+void  REveCaloData::FillExtraSelectionData(Internal::REveJsonWrapper& j, const std::set<int>& secondary_idcs) const
 {
    vCellId_t cells;
 

--- a/graf3d/eve7/src/REveDataCollection.cxx
+++ b/graf3d/eve7/src/REveDataCollection.cxx
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <regex>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -106,7 +107,7 @@ void REveDataItemList::FillImpliedSelectedSet(Set_t &impSelSet, const std::set<i
 //______________________________________________________________________________
 
 
-Int_t REveDataItemList::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveDataItemList::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
    j["items"] =  nlohmann::json::array();
@@ -353,7 +354,7 @@ void REveDataCollection::ApplyFilter()
 
 //______________________________________________________________________________
 
-void  REveDataCollection::StreamPublicMethods(nlohmann::json &j) const
+void  REveDataCollection::StreamPublicMethods(Internal::REveJsonWrapper &j) const
 {
    struct PubMethods
    {
@@ -462,7 +463,7 @@ Bool_t REveDataCollection::SetRnrState(Bool_t iRnrSelf)
 
 //______________________________________________________________________________
 
-Int_t REveDataCollection::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveDataCollection::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
    j["fFilterExpr"] = fFilterExpr.Data();

--- a/graf3d/eve7/src/REveDataTable.cxx
+++ b/graf3d/eve7/src/REveDataTable.cxx
@@ -18,6 +18,7 @@
 
 #include <sstream>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -53,7 +54,7 @@ void REveDataTable::PrintTable()
    }
 }
 
-Int_t REveDataTable::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveDataTable::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    int ret = REveElement::WriteCoreJson(j, rnr_offset);
    Int_t Nit = fCollection->GetNItems();

--- a/graf3d/eve7/src/REveDigitSet.cxx
+++ b/graf3d/eve7/src/REveDigitSet.cxx
@@ -16,6 +16,7 @@
 
 #include "TRefArray.h"
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace::ROOT::Experimental;
@@ -527,7 +528,7 @@ void REveDigitSet::NewShapePicked(int shapeIdx, Int_t selectionId, bool multi)
 
 ////////////////////////////////////////////////////////////////////////////////
 // called from REveSelection to stream specific selection data
-void REveDigitSet::FillExtraSelectionData(nlohmann::json &j, const std::set<int> &secondary_idcs) const
+void REveDigitSet::FillExtraSelectionData(Internal::REveJsonWrapper &j, const std::set<int> &secondary_idcs) const
 {
    j["shape_idcs"] = nlohmann::json::array();
    for (auto &i : secondary_idcs) {
@@ -540,7 +541,7 @@ void REveDigitSet::FillExtraSelectionData(nlohmann::json &j, const std::set<int>
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveDigitSet::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveDigitSet::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveElement.cxx
+++ b/graf3d/eve7/src/REveElement.cxx
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <algorithm>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -1459,7 +1460,7 @@ const std::string& REveElement::ToString(Bool_t b)
 /// written.
 /// Returns number of bytes written into binary render data.
 
-Int_t REveElement::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveElement::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    j["_typename"]  = IsA()->GetName();
    j["fName"]      = fName;

--- a/graf3d/eve7/src/REveEllipsoid.cxx
+++ b/graf3d/eve7/src/REveEllipsoid.cxx
@@ -19,6 +19,7 @@
 
 #include <cassert>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -92,7 +93,7 @@ TClass* REveEllipsoid::ProjectedClass(const REveProjection*) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveEllipsoid::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveEllipsoid::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveStraightLineSet::WriteCoreJson(j, rnr_offset);
 
@@ -293,7 +294,7 @@ void REveEllipsoidProjected::UpdateProjection()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveEllipsoidProjected::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveEllipsoidProjected::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveStraightLineSet::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveGeoShape.cxx
+++ b/graf3d/eve7/src/REveGeoShape.cxx
@@ -134,7 +134,7 @@ TGeoShape* REveGeoShape::MakePolyShape()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveGeoShape::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveGeoShape::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    return REveShape::WriteCoreJson(j, rnr_offset);
 }

--- a/graf3d/eve7/src/REveJetCone.cxx
+++ b/graf3d/eve7/src/REveJetCone.cxx
@@ -19,6 +19,7 @@
 
 #include <cassert>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -77,7 +78,7 @@ void  REveJetCone::SetNDiv(Int_t n)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveJetCone::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveJetCone::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveJsonWrapper.hxx
+++ b/graf3d/eve7/src/REveJsonWrapper.hxx
@@ -1,0 +1,37 @@
+// @(#)root/eve7:$Id$
+// Author: Jonas Hahnfeld, 2022
+
+/*************************************************************************
+ * Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#ifndef ROOT7_REveJsonWrapper_hxx
+#define ROOT7_REveJsonWrapper_hxx
+
+#include <nlohmann/json.hpp>
+
+namespace ROOT {
+namespace Experimental {
+namespace Internal {
+
+struct REveJsonWrapper {
+  nlohmann::json &json;
+
+  REveJsonWrapper(nlohmann::json &j) : json(j) {}
+
+  operator nlohmann::json &() { return json; }
+
+  // Convenience function to access properties of the wrapped object.
+  template <typename Key>
+  nlohmann::json::reference operator[](const Key &key) { return json.operator[](key); }
+};
+
+}
+}
+}
+
+#endif

--- a/graf3d/eve7/src/REveLine.cxx
+++ b/graf3d/eve7/src/REveLine.cxx
@@ -15,6 +15,7 @@
 
 #include "TClass.h"
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -280,7 +281,7 @@ TClass* REveLine::ProjectedClass(const REveProjection*) const
 
 //------------------------------------------------------------------------------
 
-Int_t REveLine::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveLine::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REvePointSet::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveManager.cxx
+++ b/graf3d/eve7/src/REveManager.cxx
@@ -45,6 +45,7 @@
 #include <iostream>
 #include <regex>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;

--- a/graf3d/eve7/src/REvePointSet.cxx
+++ b/graf3d/eve7/src/REvePointSet.cxx
@@ -19,6 +19,7 @@
 #include "TArrayI.h"
 #include "TClass.h"
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -206,7 +207,7 @@ TClass* REvePointSet::ProjectedClass(const REveProjection*) const
 }
 
 
-Int_t REvePointSet::WriteCoreJson(nlohmann::json& j, Int_t rnr_offset)
+Int_t REvePointSet::WriteCoreJson(Internal::REveJsonWrapper& j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REvePolygonSetProjected.cxx
+++ b/graf3d/eve7/src/REvePolygonSetProjected.cxx
@@ -20,6 +20,7 @@
 
 #include <cassert>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -68,7 +69,7 @@ REvePolygonSetProjected::~REvePolygonSetProjected()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REvePolygonSetProjected::WriteCoreJson(nlohmann::json& j, Int_t rnr_offset)
+Int_t REvePolygonSetProjected::WriteCoreJson(Internal::REveJsonWrapper& j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveSceneInfo.cxx
+++ b/graf3d/eve7/src/REveSceneInfo.cxx
@@ -12,6 +12,7 @@
 #include <ROOT/REveSceneInfo.hxx>
 #include <ROOT/REveScene.hxx>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -37,7 +38,7 @@ REveSceneInfo::REveSceneInfo(REveViewer* viewer, REveScene* scene) :
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveSceneInfo::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveSceneInfo::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveSelection.cxx
+++ b/graf3d/eve7/src/REveSelection.cxx
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <regex>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -693,7 +694,7 @@ int REveSelection::RemoveImpliedSelectedReferencesTo(REveElement *el)
 ////////////////////////////////////////////////////////////////////////////////
 /// Write core json. If rnr_offset negative, render data will not be written
 
-Int_t REveSelection::WriteCoreJson(nlohmann::json &j, Int_t /* rnr_offset */)
+Int_t REveSelection::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t /* rnr_offset */)
 {
    REveElement::WriteCoreJson(j, -1);
 
@@ -707,6 +708,7 @@ Int_t REveSelection::WriteCoreJson(nlohmann::json &j, Int_t /* rnr_offset */)
       nlohmann::json rec = {}, imp = nlohmann::json::array(), sec = nlohmann::json::array();
 
       rec["primary"] = i.first->GetElementId();
+      Internal::REveJsonWrapper extra(rec["extra"]);
 
       // XXX if not empty / f_is_sec is false ???
       for (auto &sec_id : i.second.f_sec_idcs)
@@ -715,14 +717,14 @@ Int_t REveSelection::WriteCoreJson(nlohmann::json &j, Int_t /* rnr_offset */)
       // XXX if not empty ???
       for (auto &imp_el : i.second.f_implied) {
          imp.push_back(imp_el->GetElementId());
-         imp_el->FillExtraSelectionData(rec["extra"], sec);
+         imp_el->FillExtraSelectionData(extra, sec);
 
       }
       rec["implied"]  = imp;
 
 
       if (i.first->RequiresExtraSelectionData()) {
-         i.first->FillExtraSelectionData(rec["extra"], sec);
+         i.first->FillExtraSelectionData(extra, sec);
       }
 
       rec["sec_idcs"] = sec;

--- a/graf3d/eve7/src/REveShape.cxx
+++ b/graf3d/eve7/src/REveShape.cxx
@@ -11,6 +11,7 @@
 
 #include <ROOT/REveShape.hxx>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -54,7 +55,7 @@ REveShape::~REveShape()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveShape::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveShape::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveStraightLineSet.cxx
+++ b/graf3d/eve7/src/REveStraightLineSet.cxx
@@ -15,6 +15,7 @@
 
 #include "TClass.h"
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -156,7 +157,7 @@ void REveStraightLineSet::WriteVizParams(std::ostream& out, const TString& var)
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveStraightLineSet::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveStraightLineSet::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveElement::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveTableInfo.cxx
+++ b/graf3d/eve7/src/REveTableInfo.cxx
@@ -21,6 +21,7 @@
 
 #include <sstream>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -167,7 +168,7 @@ REveTableHandle::Entries_t &REveTableViewInfo::RefTableEntries(std::string cname
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveTableViewInfo::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveTableViewInfo::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    auto ret = REveElement::WriteCoreJson(j, rnr_offset);
    j["fDisplayedCollection"] = fDisplayedCollection;

--- a/graf3d/eve7/src/REveTrack.cxx
+++ b/graf3d/eve7/src/REveTrack.cxx
@@ -523,7 +523,7 @@ void REveTrack::PrintPathMarks()
 ////////////////////////////////////////////////////////////////////////////////
 /// Fill core part of JSON representation.
 
-Int_t REveTrack::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveTrack::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    // TODO: missing streaming of fitting points
    return REveLine::WriteCoreJson(j, rnr_offset);

--- a/graf3d/eve7/src/REveTrackProjected.cxx
+++ b/graf3d/eve7/src/REveTrackProjected.cxx
@@ -15,6 +15,7 @@
 #include <ROOT/REveTrans.hxx>
 #include <ROOT/REveRenderData.hxx>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -313,7 +314,7 @@ void REveTrackListProjected::SetDepth(Float_t d, REveElement *el)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates client representation.
 
-Int_t REveTrackProjected::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+Int_t REveTrackProjected::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    Int_t ret = REveTrack::WriteCoreJson(j, rnr_offset);
 

--- a/graf3d/eve7/src/REveViewer.cxx
+++ b/graf3d/eve7/src/REveViewer.cxx
@@ -17,6 +17,7 @@
 #include <ROOT/REveManager.hxx>
 #include <ROOT/REveSelection.hxx>
 
+#include "REveJsonWrapper.hxx"
 #include <nlohmann/json.hpp>
 
 using namespace ROOT::Experimental;
@@ -104,7 +105,7 @@ List of Viewers providing common operations on REveViewer collections.
 ////////////////////////////////////////////////////////////////////////////////
 /// Stream Camera Info.
 /// Virtual from REveElement.
-int REveViewer::WriteCoreJson(nlohmann::json &j, Int_t rnr_offset)
+int REveViewer::WriteCoreJson(Internal::REveJsonWrapper &j, Int_t rnr_offset)
 {
    std::string ct;
    switch (fCameraType)


### PR DESCRIPTION
Since https://github.com/nlohmann/json/pull/3590, the `basic_json` class and the `json` `using`-declaration are located in a "versioned, ABI-tagged inline namespace". This makes it impossible to forward declare the type in `REveElement.hxx`.
Instead introduce a new struct `REveJsonWrapper` that just wraps a `json` object (after including the full `nlohmann/json.hpp`). As the `struct` is under our control, we can easily forward declare the type and use it for method arguments.

Fixes #11130