### PR TITLE
[webgui] let configure default browser to used with web widgets

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -807,7 +807,9 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    TStyle::BuildStyles();
    SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
 
-   const char *webdisplay = gEnv->GetValue("WebGui.Display", "");
+   const char *webdisplay = gSystem->Getenv("ROOT_WEBDISPLAY");
+   if (!webdisplay || !*webdisplay)
+      webdisplay = gEnv->GetValue("WebGui.Display", "");
    if (webdisplay && *webdisplay)
       SetWebDisplay(webdisplay);
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -807,6 +807,10 @@ TROOT::TROOT(const char *name, const char *title, VoidFuncPtr_t *initfunc)
    TStyle::BuildStyles();
    SetStyle(gEnv->GetValue("Canvas.Style", "Modern"));
 
+   const char *webdisplay = gEnv->GetValue("WebGui.Display", "");
+   if (webdisplay && *webdisplay)
+      SetWebDisplay(webdisplay);
+
    // Setup default (batch) graphics and GUI environment
    gBatchGuiFactory = new TGuiFactory;
    gGuiFactory      = gBatchGuiFactory;

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -40,7 +40,7 @@ public:
       kQt5,      ///< Qt5 QWebEngine libraries - Chromium code packed in qt5
       kQt6,      ///< Qt6 QWebEngine libraries - Chromium code packed in qt6
       kLocal,    ///< either CEF or Qt5 - both runs on local display without real http server
-      kStandard, ///< standard system web browser, not recognized by ROOT, without batch mode
+      kStandard, ///< standard system web browser, do not support in batch mode
       kEmbedded, ///< window will be embedded into other, no extra browser need to be started
       kOff,      ///< disable web display, do not start any browser
       kCustom    ///< custom web browser, execution string should be provided

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -40,7 +40,7 @@ public:
       kQt5,      ///< Qt5 QWebEngine libraries - Chromium code packed in qt5
       kQt6,      ///< Qt6 QWebEngine libraries - Chromium code packed in qt6
       kLocal,    ///< either CEF or Qt5 - both runs on local display without real http server
-      kStandard, ///< standard system web browser, do not support in batch mode
+      kStandard, ///< default system web browser, can not be used in batch mode
       kEmbedded, ///< window will be embedded into other, no extra browser need to be started
       kOff,      ///< disable web display, do not start any browser
       kCustom    ///< custom web browser, execution string should be provided

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -36,7 +36,8 @@ Holds different arguments for starting browser with RWebDisplayHandle::Display()
 */
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Default constructor - browser kind configured from gROOT->GetWebDisplay()
+/// Default constructor.
+/// Browser kind configured from gROOT->GetWebDisplay()
 
 RWebDisplayArgs::RWebDisplayArgs()
 {
@@ -44,8 +45,9 @@ RWebDisplayArgs::RWebDisplayArgs()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Constructor - browser kind specified as std::string
-/// See SetBrowserKind() method for description of allowed parameters
+/// Constructor.
+/// Browser kind specified as std::string.
+/// See \ref SetBrowserKind method for description of allowed parameters
 
 RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
 {
@@ -53,7 +55,8 @@ RWebDisplayArgs::RWebDisplayArgs(const std::string &browser)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Constructor - browser kind specified as const char *
+/// Constructor.
+/// Browser kind specified as `const char *`.
 /// See \ref SetBrowserKind method for description of allowed parameters
 
 RWebDisplayArgs::RWebDisplayArgs(const char *browser)
@@ -62,7 +65,8 @@ RWebDisplayArgs::RWebDisplayArgs(const char *browser)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Constructor - specify window width and height
+/// Constructor.
+/// Let specify window width and height
 
 RWebDisplayArgs::RWebDisplayArgs(int width, int height, int x, int y, const std::string &browser)
 {
@@ -72,7 +76,8 @@ RWebDisplayArgs::RWebDisplayArgs(int width, int height, int x, int y, const std:
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Constructor - specify master window and channel (if reserved already)
+/// Constructor.
+/// Let specify master window and channel (if reserved already)
 
 RWebDisplayArgs::RWebDisplayArgs(std::shared_ptr<RWebWindow> master, int channel)
 {
@@ -80,8 +85,8 @@ RWebDisplayArgs::RWebDisplayArgs(std::shared_ptr<RWebWindow> master, int channel
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Destructor
-/// must be defined in source code to correctly call RWebWindow destructor
+/// Destructor.
+/// Must be defined in source code to correctly call RWebWindow destructor
 
 RWebDisplayArgs::~RWebDisplayArgs() = default;
 
@@ -134,7 +139,7 @@ bool RWebDisplayArgs::SetPosAsStr(const std::string &str)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Set browser kind as string argument
+/// Set browser kind as string argument.
 ///
 /// Recognized values:
 ///
@@ -240,7 +245,7 @@ std::string RWebDisplayArgs::GetBrowserName() const
       case kQt5: return "qt5";
       case kQt6: return "qt6";
       case kLocal: return "local";
-      case kStandard: return "default";
+      case kStandard: return "standard";
       case kEmbedded: return "embed";
       case kOff: return "off";
       case kCustom:
@@ -262,7 +267,7 @@ void RWebDisplayArgs::SetMasterWindow(std::shared_ptr<RWebWindow> master, int ch
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Append string to url options
+/// Append string to url options.
 /// Add "&" as separator if any options already exists
 
 void RWebDisplayArgs::AppendUrlOpt(const std::string &opt)
@@ -276,7 +281,7 @@ void RWebDisplayArgs::AppendUrlOpt(const std::string &opt)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Returns full url, which is combined from URL and extra URL options
+/// Returns full url, which is combined from URL and extra URL options.
 /// Takes into account "#" symbol in url - options are inserted before that symbol
 
 std::string RWebDisplayArgs::GetFullUrl() const
@@ -297,7 +302,7 @@ std::string RWebDisplayArgs::GetFullUrl() const
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// Configure custom web browser
+/// Configure custom web browser.
 /// Either just name of browser which can be used like "opera"
 /// or full execution string which must includes $url like "/usr/bin/opera $url"
 
@@ -308,7 +313,7 @@ void RWebDisplayArgs::SetCustomExec(const std::string &exec)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// returns custom executable to start web browser
+/// Returns custom executable to start web browser
 
 std::string RWebDisplayArgs::GetCustomExec() const
 {
@@ -324,9 +329,11 @@ std::string RWebDisplayArgs::GetCustomExec() const
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-/// returns string which can be used as argument in RWebWindow::Show() method
-/// to display web window in provided QWidget
+/// Returns string which can be used as argument in RWebWindow::Show() method
+/// to display web window in provided QWidget.
+///
 /// After RWebWindow is displayed created QWebEngineView can be found with the command:
+///
 ///     auto view = qparent->findChild<QWebEngineView*>("RootWebView");
 
 std::string RWebDisplayArgs::GetQt5EmbedQualifier(const void *qparent, const std::string &urlopt)

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -222,7 +222,7 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
       SetBrowserKind(kQt6);
    else if ((kind == "embed") || (kind == "embedded"))
       SetBrowserKind(kEmbedded);
-   else if ((kind == "std") || (kind == "standard") || (kind == "browser"))
+   else if ((kind == "dflt") || (kind == "default") || (kind == "browser"))
       SetBrowserKind(kStandard);
    else if (kind == "off")
       SetBrowserKind(kOff);
@@ -245,7 +245,7 @@ std::string RWebDisplayArgs::GetBrowserName() const
       case kQt5: return "qt5";
       case kQt6: return "qt6";
       case kLocal: return "local";
-      case kStandard: return "standard";
+      case kStandard: return "default";
       case kEmbedded: return "embed";
       case kOff: return "off";
       case kCustom:

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -135,17 +135,19 @@ bool RWebDisplayArgs::SetPosAsStr(const std::string &str)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 /// Set browser kind as string argument
+///
 /// Recognized values:
-///   chrome - use Google Chrome web browser, supports headless mode from v60, default
-///  firefox - use Mozilla Firefox browser, supports headless mode from v57
-///   native - (or empty string) either chrome or firefox, only these browsers support batch (headless) mode
-///  browser - default system web-browser, no batch mode
-///   safari - Safari browser on Mac
-///      cef - Chromium Embeded Framework, local display, local communication
-///      qt5 - Qt5 QWebEngine, local display, local communication
-///      qt6 - Qt6 QWebEngineCore, local display, local communication
-///    local - either cef or qt5 or qt6
-/// `<prog>` - any program name which will be started instead of default browser, like /usr/bin/opera
+///
+///      chrome - use Google Chrome web browser, supports headless mode from v60, default
+///     firefox - use Mozilla Firefox browser, supports headless mode from v57
+///      native - (or empty string) either chrome or firefox, only these browsers support batch (headless) mode
+///     browser - default system web-browser, no batch mode
+///      safari - Safari browser on Mac
+///         cef - Chromium Embeded Framework, local display, local communication
+///         qt5 - Qt5 QWebEngine, local display, local communication
+///         qt6 - Qt6 QWebEngineCore, local display, local communication
+///       local - either cef or qt5 or qt6
+///    `<prog>` - any program name which will be started instead of default browser, like /usr/bin/opera
 
 RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
 {
@@ -215,6 +217,8 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
       SetBrowserKind(kQt6);
    else if ((kind == "embed") || (kind == "embedded"))
       SetBrowserKind(kEmbedded);
+   else if ((kind == "std") || (kind == "standard") || (kind == "browser"))
+      SetBrowserKind(kStandard);
    else if (kind == "off")
       SetBrowserKind(kOff);
    else if (!SetSizeAsStr(kind))

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -494,6 +494,7 @@ std::string RWebWindowsManager::GetUrl(const RWebWindow &win, bool remote)
 ///
 /// Following parameters can be configured in rootrc file:
 ///
+///      WebGui.Display: kind of display like chrome or firefox or browser, can be overwritten by --web=value command line argument
 ///      WebGui.Chrome: full path to Google Chrome executable
 ///      WebGui.ChromeBatch: command to start chrome in batch, used for image production, like "$prog --headless --disable-gpu $geometry $url"
 ///      WebGui.ChromeHeadless: command to start chrome in headless mode, like "fork: --headless --disable-gpu $geometry $url"


### PR DESCRIPTION
When specified `root --web=default` or `root --web=browser`, default web browser will be used to open web widgets

web display can be configured with `WebGui.Display` rootrc parameter or `ROOT_WEBDISPLAY` environment variable.

Improve webgui documentation   