### PR TITLE
[math][fit] Fix Fitter class for temporary FitData (issue #11154)

### DIFF
--- a/math/mathcore/inc/Fit/BinData.h
+++ b/math/mathcore/inc/Fit/BinData.h
@@ -114,16 +114,16 @@ public :
 
 
    /**
-      Preallocate a data set with given size ,  dimension and error type.
-      If the data set already exists newPoints are appended to the existing dataset.
-      (i.e if the data exists Initialize is equivalent to a resize( NPoints() + maxpoints).
-      Initialize and Append are equivalent.
+      Preallocate a data set with given size, dimension and error type.
+      If the data set already exists, `newPoints` are appended to the existing data set.
+      (i.e., if the data exists Initialize() is equivalent to a `resize( NPoints() + maxpoints)`).
+      Initialize() and Append() are equivalent.
    */
    void Initialize( unsigned int newPoints, unsigned int dim = 1, ErrorType err = kValueError ){
       Append(newPoints,dim,err);
    }
 
-   /// Equivalent to Initialize
+   /// Equivalent to Initialize()
    void Append( unsigned int newPoints, unsigned int dim = 1, ErrorType err = kValueError );
 
 
@@ -241,7 +241,7 @@ public :
         the inverse of the errors.
       - If the data contains errors in coordinates and value (e.g from TGraphErrors) returns a
         pointer to the corresponding value error (NOT the inverse).
-      - If the data contains asymmetric errors return a ponter to the average error (NOT the inverse):
+      - If the data contains asymmetric errors return a pointer to the average error (NOT the inverse):
         0.5(eu + el).
       - If the data does not contain errors return a nullptr.
    */
@@ -257,7 +257,7 @@ public :
    }
 
    /// Return the error on the given point.
-   /// Safer method returing in any case the error and not the inverse as in the
+   /// Safer method returning in any case the error and not the inverse as in the
    /// function above.
    double Error( unsigned int ipoint ) const
    {

--- a/math/mathcore/inc/Fit/BinData.h
+++ b/math/mathcore/inc/Fit/BinData.h
@@ -109,20 +109,24 @@ public :
    */
    BinData(const BinData & rhs);
 
+   /// assignment operator
    BinData & operator= ( const BinData & rhs );
 
 
    /**
-      preallocate a data set with given size ,  dimension and error type (to get the full point size)
-      If the data set already exists and it is having the compatible point size space for the new points
-      is created in the data sets, while if not compatible the old data are erased and new space of
-      new size is allocated.
-      (i.e if exists initialize is equivalent to a resize( NPoints() + maxpoints)
+      Preallocate a data set with given size ,  dimension and error type.
+      If the data set already exists newPoints are appended to the existing dataset.
+      (i.e if the data exists Initialize is equivalent to a resize( NPoints() + maxpoints).
+      Initialize and Append are equivalent.
    */
+   void Initialize( unsigned int newPoints, unsigned int dim = 1, ErrorType err = kValueError ){
+      Append(newPoints,dim,err);
+   }
 
+   /// Equivalent to Initialize
    void Append( unsigned int newPoints, unsigned int dim = 1, ErrorType err = kValueError );
 
-   void Initialize( unsigned int newPoints, unsigned int dim = 1, ErrorType err = kValueError );
+
 
    /**
       flag to control if data provides error on the coordinates
@@ -231,9 +235,15 @@ public :
    }
 
    /**
-      return error on the value for the given fit point
-      Safe (but slower) method returning correctly the error on the value
-      in case of asymm errors return the average 0.5(eu + el)
+      Return a pointer to the error (or the inverse error) on the value for a given point
+      depending on the type of data.
+      - If the data contains only value error (e.g. from histograms) returns a pointer to
+        the inverse of the errors.
+      - If the data contains errors in coordinates and value (e.g from TGraphErrors) returns a
+        pointer to the corresponding value error (NOT the inverse).
+      - If the data contains asymmetric errors return a ponter to the average error (NOT the inverse):
+        0.5(eu + el).
+      - If the data does not contain errors return a nullptr.
    */
 
    const double * ErrorPtr(unsigned int ipoint) const{
@@ -243,10 +253,12 @@ public :
 
       if ( fErrorType == kNoError )
          return nullptr;
-      // assert( fErrorType == kCoordError );
       return &fDataErrorPtr[ ipoint ];
    }
 
+   /// Return the error on the given point.
+   /// Safer method returing in any case the error and not the inverse as in the
+   /// function above.
    double Error( unsigned int ipoint ) const
    {
       assert( ipoint < fMaxPoints );

--- a/math/mathcore/inc/Fit/Chi2FCN.h
+++ b/math/mathcore/inc/Fit/Chi2FCN.h
@@ -68,11 +68,10 @@ public:
    { }
 
    /**
-      Same Constructor from data set (binned ) and model function but now managed by the user
-      we clone the function but not the data
+      Same Constructor from data set (binned ) and model function cloning the function and the data
    */
    Chi2FCN ( const BinData & data, const IModelFunction & func, const ::ROOT::EExecutionPolicy &executionPolicy = ::ROOT::EExecutionPolicy::kSequential) :
-      BaseFCN(std::shared_ptr<BinData>(const_cast<BinData*>(&data), DummyDeleter<BinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
+      BaseFCN(std::make_shared<BinData>(data), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fNEffPoints(0),
       fGrad ( std::vector<double> ( func.NPar() ) ),
       fExecutionPolicy(executionPolicy)

--- a/math/mathcore/inc/Fit/FitData.h
+++ b/math/mathcore/inc/Fit/FitData.h
@@ -35,17 +35,6 @@ namespace ROOT {
 
    namespace Fit {
 
-      //class used for making shared_ptr of data classes managed by the user
-      // (i.e. when we don't want to delete the contained object)
-      template <class T>
-      struct DummyDeleter {
-         // a deleter not deleting the contained object
-         // used to avoid shared_ptr deleting the contained objects if managed externally
-         void operator()(T * /* p */)
-         {
-            //printf("ROOT::Fit::DummyDeleter called - do not delete object %x \n", p);
-         }
-      };
 
       /**
        * Base class for all the fit data types:

--- a/math/mathcore/inc/Fit/FitData.h
+++ b/math/mathcore/inc/Fit/FitData.h
@@ -35,7 +35,8 @@ namespace ROOT {
 
    namespace Fit {
 
-      //class used for making shared_ptr of data classes managed by the user (i.e. when we don;t want to delete the contained object)
+      //class used for making shared_ptr of data classes managed by the user
+      // (i.e. when we don't want to delete the contained object)
       template <class T>
       struct DummyDeleter {
          // a deleter not deleting the contained object

--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -61,21 +61,12 @@ public:
    */
    FitResult (const FitConfig & fconfig);
 
-
-   /**
-      Copy constructor.
-   */
-   FitResult(const FitResult & rhs);
-
-   /**
-      Assignment operator
-   */
-   FitResult & operator = (const FitResult & rhs);
+   // default copy constructor and assignment can be used
 
    /**
       Destructor
    */
-   virtual ~FitResult ();
+   virtual ~FitResult () {}
 
 
 public:

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -520,20 +520,16 @@ protected:
    // get function calls from the FCN
    int GetNCallsFromFCN();
 
-   /// Set data for the fit using a shared ptr
+   /// Set the input data for the fit using a shared ptr (No Copying)
    template <class Data>
    void SetData(const std::shared_ptr<Data> & data) {
       fData = std::static_pointer_cast<Data>(data);
    }
 
-   /// Set the input binned data for the fit copying them
-   void SetData(const BinData & data) {
-      auto dataClone = std::make_shared<BinData>(data);
-      SetData(dataClone);
-   }
-   /// Set the input un-binned data for the fit copying them
-   void SetData(const UnBinData & data) {
-      auto dataClone = std::make_shared<UnBinData>(data);
+   /// Set the input data for the fit (Copying the given data object)
+   template <class Data>
+   void SetData(const Data & data) {
+      auto dataClone = std::make_shared<Data>(data);
       SetData(dataClone);
    }
 

--- a/math/mathcore/inc/Fit/LogLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/LogLikelihoodFCN.h
@@ -67,7 +67,7 @@ public:
       Constructor from unbin data set and model function (pdf) for object managed by users
    */
    LogLikelihoodFCN (const UnBinData & data, const IModelFunction & func, int weight = 0, bool extended = false, const ::ROOT::EExecutionPolicy &executionPolicy = ::ROOT::EExecutionPolicy::kSequential) :
-      BaseFCN(std::shared_ptr<UnBinData>(const_cast<UnBinData*>(&data), DummyDeleter<UnBinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
+      BaseFCN(std::make_shared<UnBinData>(data), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fIsExtended(extended),
       fWeight(weight),
       fNEffPoints(0),

--- a/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
+++ b/math/mathcore/inc/Fit/PoissonLikelihoodFCN.h
@@ -71,7 +71,7 @@ public:
       Constructor from unbin data set and model function (pdf) managed by the users
    */
    PoissonLikelihoodFCN (const BinData & data, const IModelFunction & func, int weight = 0, bool extended = true, const ::ROOT::EExecutionPolicy &executionPolicy = ::ROOT::EExecutionPolicy::kSequential ) :
-      BaseFCN(std::shared_ptr<BinData>(const_cast<BinData*>(&data), DummyDeleter<BinData>()), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
+      BaseFCN(std::make_shared<BinData>(data), std::shared_ptr<IModelFunction>(dynamic_cast<IModelFunction*>(func.Clone() ) ) ),
       fIsExtended(extended),
       fWeight(weight),
       fNEffPoints(0),

--- a/math/mathcore/inc/Fit/SparseData.h
+++ b/math/mathcore/inc/Fit/SparseData.h
@@ -15,6 +15,7 @@
 
 #include "Fit/BinData.h"
 #include <vector>
+#include <memory>
 
 namespace ROOT {
 
@@ -23,23 +24,37 @@ namespace ROOT {
       // This is a proxy to a std::list<Box>
       class ProxyListBox;
 
+      /**
+         SparseData class representing the data of a THNSparse histogram
+         The data needs to be converted to a BinData class before fitting using
+         the GetBinData functions.
+
+         @ingroup FitData
+      */
+
       class SparseData : public FitData  {
       public:
-         //Constructor with a vector
+         /// Constructor with a vector
          SparseData(std::vector<double>& min, std::vector<double>& max);
 
-         //Constructor with a dimension and two arrays
+         /// Constructor with a dimension and two arrays
          SparseData(const unsigned int dim, double min[], double max[]);
 
-         //Destructor
+         /// Copy constructor
+         SparseData(const SparseData & rhs);
+
+         /// Destructor
          ~SparseData() override;
 
-         //Returns the number of points stored
+         /// Assignment operator
+         SparseData & operator=(const SparseData & rhs);
+
+         /// Returns the number of points stored
          unsigned int NPoints() const;
-         //Returns the dimension of the object (bins)
+         /// Returns the dimension of the object (bins)
          unsigned int NDim() const;
 
-         // Adds a new bin specified by the vectors
+         /// Adds a new bin specified by the vectors
          void Add(std::vector<double>& min, std::vector<double>& max,
                   const double content, const double error = 1.0);
 
@@ -47,18 +62,18 @@ namespace ROOT {
                        std::vector<double>& min, std::vector<double>&max,
                        double& content, double& error);
 
-         // Debug method to print the list of bins stored
+         /// Debug method to print the list of bins stored
          void PrintList() const;
 
-         // Transforms the data into a ROOT::Fit::BinData structure
+         /// Transforms the data into a ROOT::Fit::BinData structure
          void GetBinData(BinData&) const;
-         // Same as before, but with integral format
+         /// Same as before, but returning a BInData with integral format (containing bin edges)
          void GetBinDataIntegral(BinData&) const;
-         // Same as before, but including zero content bins
+         /// Same as before, but including zero content bins
          void GetBinDataNoZeros(BinData&) const;
 
       private :
-         ProxyListBox *fList;
+         std::unique_ptr<ProxyListBox> fList;
       };
 
    } // end namespace Fit

--- a/math/mathcore/inc/Fit/SparseData.h
+++ b/math/mathcore/inc/Fit/SparseData.h
@@ -67,7 +67,7 @@ namespace ROOT {
 
          /// Transforms the data into a ROOT::Fit::BinData structure
          void GetBinData(BinData&) const;
-         /// Same as before, but returning a BInData with integral format (containing bin edges)
+         /// Same as before, but returning a BinData with integral format (containing bin edges)
          void GetBinDataIntegral(BinData&) const;
          /// Same as before, but including zero content bins
          void GetBinDataNoZeros(BinData&) const;

--- a/math/mathcore/inc/Fit/UnBinData.h
+++ b/math/mathcore/inc/Fit/UnBinData.h
@@ -41,7 +41,7 @@ namespace ROOT {
   the data are inserted one by one using the Add method.
   It is mandatory to set the size before using the Add method.
 
-  @ingroup  FitData
+  @ingroup FitData
 */
 class UnBinData : public FitData {
 

--- a/math/mathcore/inc/Fit/UnBinData.h
+++ b/math/mathcore/inc/Fit/UnBinData.h
@@ -25,19 +25,23 @@ namespace ROOT {
 
 //___________________________________________________________________________________
 /**
-   Class describing the unbinned data sets (just x coordinates values) of any dimensions
+   Class describing the un-binned data sets (just x coordinates values) of any dimensions
 
-              There is the option to construct UnBindata copying the data in (using the DataVector class)
-              or using pointer to external data (DataWrapper) class.
-              In general is found to be more efficient to copy the data.
-              In case of really large data sets for limiting memory consumption then the other option can be used
-              Specialized constructor exists for using external data up to 3 dimensions.
+  There is the option to construct UnBindata copying the data inside
+  (in the base FitData class) or using a pointer to external data, depending on which
+  constructor of the UnBinData class is used.
+  It is recommended to copy the input data inside, since this will be more efficient and
+  less error prone, since the input provided data will have to be kept alive for all the time the
+  Fit classes will be used.
+  In case of really large data sets for limiting memory consumption then the other option can be used
+  with special care.
+  Specialized constructor exists for using external data up to 3 dimensions.
 
-              When the data are copying in the number of points can be set later (or re-set) using Initialize and
-              the data are inserted one by one using the Add method.
-              It is mandatory to set the size before using the Add method.
+  When the data are copying in the number of points can be set later (or re-set) using Initialize and
+  the data are inserted one by one using the Add method.
+  It is mandatory to set the size before using the Add method.
 
-             @ingroup  FitData
+  @ingroup  FitData
 */
 class UnBinData : public FitData {
 
@@ -173,11 +177,10 @@ public :
   {
   }
 
-private:
-  /// copy constructor (private)
-  UnBinData(const UnBinData &) : FitData() { assert(false); }
-  /// assignment operator  (private)
-  UnBinData & operator= (const UnBinData &) { assert(false); return *this; }
+  /// copy constructor
+  UnBinData(const UnBinData &);
+  /// assignment operator
+  UnBinData & operator= (const UnBinData &);
 
 public:
   /**
@@ -185,14 +188,6 @@ public:
   */
   ~UnBinData() override {
   }
-
-  /**
-    preallocate a data set given size and dimension of the coordinates
-    if a vector already exists with correct dimension (point size) extend the existing one
-    to a total size of maxpoints (equivalent to a Resize)
-  */
-  //void Initialize(unsigned int maxpoints, unsigned int dim = 1, bool isWeighted = false);
-
 
   /**
     add one dim coordinate data (unweighted)

--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -235,7 +235,7 @@ namespace ROOT {
 
       if ( fpTmpBinEdgeVector )
       {
-        assert( Opt().fIntegral );
+        assert(HasBinEdges());
 
         delete[] fpTmpBinEdgeVector;
         fpTmpBinEdgeVector= nullptr;
@@ -304,7 +304,7 @@ namespace ROOT {
 
       fpTmpCoordErrorVector= new double[ fDim ];
 
-      if ( Opt().fIntegral )
+      if ( HasBinEdges() )
         fpTmpBinEdgeVector = new double[ fDim ];
 
       return *this;
@@ -608,7 +608,7 @@ namespace ROOT {
 
     /**
        add the bin width data, a pointer to an array with the bin upper edge information.
-       This is needed when fitting with integral options
+       This is needed when fitting with integral or Bin volume normalization options
        The information is added for the previously inserted point.
        BinData::Add  must be called before
     */

--- a/math/mathcore/src/BinData.cxx
+++ b/math/mathcore/src/BinData.cxx
@@ -340,12 +340,6 @@ namespace ROOT {
       InitializeErrors( );
     }
 
-    void BinData::Initialize( unsigned int newPoints, unsigned int dim, ErrorType err )
-    {
-      Append( newPoints, dim, err );
-    }
-
-
 
     /**
       apply a Log transformation of the data values

--- a/math/mathcore/src/FitData.cxx
+++ b/math/mathcore/src/FitData.cxx
@@ -220,8 +220,9 @@ namespace ROOT {
          fWrapped = rhs.fWrapped;
          fOptions = rhs.fOptions;
          fRange = rhs.fRange;
-         fDim = rhs.fDim;
          fMaxPoints = rhs.fMaxPoints;
+         fNPoints = rhs.fNPoints;
+         fDim = rhs.fDim;
 
          if (fWrapped) {
             fCoords.clear();

--- a/math/mathcore/src/FitResult.cxx
+++ b/math/mathcore/src/FitResult.cxx
@@ -217,61 +217,6 @@ void FitResult::FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, c
 
 }
 
-FitResult::~FitResult() {
-   // destructor. FitResult manages the fit Function pointer
-   //if (fFitFunc) delete fFitFunc;
-}
-
-FitResult::FitResult(const FitResult &rhs) :
-   fFitFunc(0)
-{
-   // Implementation of copy constructor
-   (*this) = rhs;
-}
-
-FitResult & FitResult::operator = (const FitResult &rhs) {
-   // Implementation of assignment operator.
-   if (this == &rhs) return *this;  // time saving self-test
-
-   // Manages the fitted function
-   // if (fFitFunc) delete fFitFunc;
-   // fFitFunc = 0;
-   // if (rhs.fFitFunc != 0 ) {
-   //    fFitFunc = dynamic_cast<IModelFunction *>( (rhs.fFitFunc)->Clone() );
-   //    assert(fFitFunc != 0);
-   // }
-
-   // copy all other data members
-   fValid = rhs.fValid;
-   fNormalized = rhs.fNormalized;
-   fNFree = rhs.fNFree;
-   fNdf = rhs.fNdf;
-   fNCalls = rhs.fNCalls;
-   fCovStatus = rhs.fCovStatus;
-   fStatus = rhs.fStatus;
-   fVal = rhs.fVal;
-   fEdm = rhs.fEdm;
-   fChi2 = rhs.fChi2;
-   fMinimizer = rhs.fMinimizer;
-   fObjFunc = rhs.fObjFunc;
-   fFitFunc = rhs.fFitFunc;
-
-   fFixedParams = rhs.fFixedParams;
-   fBoundParams = rhs.fBoundParams;
-   fParamBounds = rhs.fParamBounds;
-   fParams = rhs.fParams;
-   fErrors = rhs.fErrors;
-   fCovMatrix = rhs.fCovMatrix;
-   fGlobalCC = rhs.fGlobalCC;
-   fMinosErrors = rhs.fMinosErrors;
-
-   fMinimType = rhs.fMinimType;
-   fParNames = rhs.fParNames;
-
-   return *this;
-
-}
-
 bool FitResult::Update(const std::shared_ptr<ROOT::Math::Minimizer> & min, const ROOT::Fit::FitConfig & fconfig, bool isValid, unsigned int ncalls) {
    // update fit result with new status from minimizer
    // ncalls if it is not zero is used instead of value from minimizer

--- a/math/mathcore/src/Fitter.cxx
+++ b/math/mathcore/src/Fitter.cxx
@@ -821,7 +821,6 @@ bool Fitter::DoMinimization(const ROOT::Math::IMultiGenFunction * chi2func) {
    fResult->fObjFunc = fObjFunction;
    fResult->fFitData = fData;
 
-
 #ifdef DEBUG
       std::cout << "ROOT::Fit::Fitter::DoMinimization : ncalls = " << fResult->fNCalls << " type of objfunc " << fFitFitResType << "  typeid: " << typeid(*fObjFunction).name() << " use gradient " << fUseGradient << std::endl;
 #endif

--- a/math/mathcore/src/SparseData.cxx
+++ b/math/mathcore/src/SparseData.cxx
@@ -220,7 +220,7 @@ namespace ROOT {
       SparseData & SparseData::operator=(const SparseData & rhs)
       {
          FitData::operator=( rhs );
-         fList.reset(new ProxyListBox(*rhs.fList));
+         fList = std::make_unique<ProxyListBox>(*rhs.fList);
          return *this;
       }
 

--- a/math/mathcore/src/SparseData.cxx
+++ b/math/mathcore/src/SparseData.cxx
@@ -22,7 +22,6 @@
 #include <cmath>
 #include <limits>
 
-// #include "TMath.h"
 #include "Fit/BinData.h"
 #include "Fit/SparseData.h"
 
@@ -56,7 +55,7 @@ namespace ROOT {
          const vector<double>& GetMax() const { return fMax; }
          // Get the value of the Box
          double GetVal() const { return fVal; }
-         // Get the rror of the Box
+         // Get the error of the Box
          double GetError() const { return fError; }
 
          // Add an amount to the content of the Box
@@ -193,28 +192,39 @@ namespace ROOT {
 
       SparseData::SparseData(vector<double>& min, vector<double>& max)
       {
-         // Creates a SparseData convering the range defined by min
+         // Creates a SparseData covering the range defined by min
          // and max. For this it will create an empty Box for that
          // range.
          Box originalBox(min, max);
-         fList = new ProxyListBox();
+         fList = std::make_unique<ProxyListBox>();
          fList->PushBack(originalBox);
       }
 
       SparseData::SparseData(const unsigned int dim, double min[], double max[])
       {
-         // Creates a SparseData convering the range defined by min
+         // Creates a SparseData covering the range defined by min
          // and max. For this it will create an empty Box for that
          // range.
          vector<double> minv(min,min+dim);
          vector<double> maxv(max,max+dim);
          Box originalBox(minv, maxv);
-         fList = new ProxyListBox();
+         fList = std::make_unique<ProxyListBox>();
          fList->PushBack(originalBox);
       }
 
-      SparseData::~SparseData()
-      { delete fList; }
+      SparseData::SparseData(const SparseData & rhs) :
+         FitData(rhs)
+      {
+         fList = std::make_unique<ProxyListBox>(*rhs.fList);
+      }
+      SparseData & SparseData::operator=(const SparseData & rhs)
+      {
+         FitData::operator=( rhs );
+         fList.reset(new ProxyListBox(*rhs.fList));
+         return *this;
+      }
+
+      SparseData::~SparseData() {}
 
       unsigned int SparseData::NPoints() const
       {

--- a/math/mathcore/src/UnBinData.cxx
+++ b/math/mathcore/src/UnBinData.cxx
@@ -20,53 +20,19 @@ namespace ROOT {
 
    namespace Fit {
 
-/*
-void UnBinData::Initialize(unsigned int maxpoints, unsigned int dim, bool isWeighted ) {
-   //   preallocate a data set given size and dimension
-   unsigned int pointSize = (isWeighted) ? dim+1 : dim;
-   if ( (dim != fDim || pointSize != fPointSize) && fDataVector) {
-//       MATH_INFO_MSGVAL("BinData::Initialize"," Reset amd re-initialize with a new fit point size of ",
-//                        dim);
-      delete fDataVector;
-      fDataVector = 0;
-   }
-   fDim = dim;
-   fPointSize = pointSize;
-   unsigned int n = fPointSize*maxpoints;
-   if ( n > MaxSize() ) {
-      MATH_ERROR_MSGVAL("UnBinData::Initialize","Invalid data size", n );
-      return;
-   }
-   if (fDataVector)
-      (fDataVector->Data()).resize( fDataVector->Size() + n );
-   else
-      fDataVector = new DataVector( n);
-}
+/// copy constructor
+UnBinData::UnBinData(const UnBinData & rhs) :
+   FitData(rhs),
+   fWeighted(rhs.fWeighted)
+{}
 
-void UnBinData::Resize(unsigned int npoints) {
-   // resize vector to new points
-   if (fDim == 0) return;
-   if ( npoints > MaxSize() ) {
-      MATH_ERROR_MSGVAL("BinData::Resize"," Invalid data size  ", npoints );
-      return;
-   }
-   if (fDataVector != 0)  {
-      int nextraPoints = npoints -  fDataVector->Size()/fPointSize;
-      if  (nextraPoints < 0) {
-         // delete extra points
-         (fDataVector->Data()).resize( npoints * fPointSize);
-      }
-      else if (nextraPoints > 0) {
-         // add extra points
-         Initialize(nextraPoints, fDim, IsWeighted()  );
-      }
-      else // nextraPoints == 0
-         return;
-   }
-   else // no DataVector create it
-      fDataVector = new DataVector( npoints*fPointSize);
+///assignment operator
+UnBinData & UnBinData::operator= ( const UnBinData & rhs )
+{
+   FitData::operator=( rhs );
+   fWeighted = rhs.fWeighted;
+   return *this;
 }
-*/
 
 
    } // end namespace Fit


### PR DESCRIPTION
# This Pull request:

This PR implements the correct copy constructors for the FitData classes and, when the user provides to teh Fitter, a reference to a Fit data classes, the data are copied. 
An interface using a `shared_ptr` to the data exists to avoid copying. 


This PR fixes #11154

