### PR TITLE
[jsroot] update to version 7.2.0 with few extra fixes

### DIFF
--- a/js/changes.md
+++ b/js/changes.md
@@ -1,8 +1,27 @@
 # JSROOT changelog
 
 ## Changes in dev
+1. Force MathJax rendering when `\` symbol is found (#243)
+2. Fix - use alfa channel for TColor when intended
+
+
+## Changes in 7.2.0
 1. Use TAxis attributes in lego plots - ticks/labels/title colors, sizes, offsets
 2. Correctly resize stats box when number of lines changes
+3. Support JSROOT usage with yarn and webpack
+4. Provide `FileProxy` class to let read ROOT files from arbitrary place
+5. Let 'hook' save file functionality to use alternative method to store image files
+6. Implement 'tabs' layout for objects display (#238)
+7. Upgrade d3.js to version 7.6.1
+8. Fix - adjust pad margins when moving palette and frame
+
+
+## Changes in 7.1.1
+1. Fix - let modify node visibility bits via context menu
+2. Fix - menu position adjusting
+3. Fix - tree_draw.js example, export treeDraw function from main.mjs
+4. Fix - TH3 scatter plot with large number of bins converted to box2
+5. Fix - create geo css entries also when expand object in hierarchy (#240)
 
 
 ## Changes in 7.1.0

--- a/js/modules/base/BasePainter.mjs
+++ b/js/modules/base/BasePainter.mjs
@@ -489,7 +489,7 @@ class BasePainter {
       this.divid = null;
       delete this._selected_main;
 
-      if (this._hpainter && typeof this._hpainter.removePainter === 'function')
+      if (typeof this._hpainter?.removePainter === 'function')
          this._hpainter.removePainter(this);
 
       delete this._hitemname;

--- a/js/modules/base/TAttFillHandler.mjs
+++ b/js/modules/base/TAttFillHandler.mjs
@@ -126,7 +126,8 @@ class TAttFillHandler {
          return true;
       }
 
-      if (this.pattern == 1000) this.pattern = 1001;
+      if (this.pattern == 1000)
+         this.pattern = 1001;
 
       if (this.pattern < 1001) {
          this.pattern_url = 'none';
@@ -159,13 +160,13 @@ class TAttFillHandler {
 
       if (!svg || svg.empty() || (this.pattern < 3000) || (this.color == "none")) return false;
 
-      let id = "pat_" + this.pattern + "_" + indx,
+      let id = `pat_${this.pattern}_${indx}`,
          defs = svg.select('.canvas_defs');
 
       if (defs.empty())
          defs = svg.insert("svg:defs", ":first-child").attr("class", "canvas_defs");
 
-      this.pattern_url = "url(#" + id + ")";
+      this.pattern_url = `url(#${id})`;
       this.antialias = false;
 
       if (!defs.select("." + id).empty())
@@ -320,9 +321,9 @@ class TAttFillHandler {
 
       const sample = new TAttFillHandler({ svg, pattern: this.pattern, color: this.color, color_as_svg: true });
 
-     svg.append("path")
-        .attr("d", `M0,0h${width}v${height}h${-width}z`)
-        .call(sample.func);
+      svg.append("path")
+         .attr("d", `M0,0h${width}v${height}h${-width}z`)
+         .call(sample.func);
    }
 
    /** @summary Save fill attributes to style
@@ -335,8 +336,6 @@ class TAttFillHandler {
       if (name_pattern)
          gStyle[name_pattern] = this.pattern;
    }
-
-
 
 } // class TAttFillHandler
 

--- a/js/modules/base/TAttLineHandler.mjs
+++ b/js/modules/base/TAttLineHandler.mjs
@@ -141,6 +141,7 @@ class TAttLineHandler {
          .call(this.func);
    }
 
+   /** @summary Save attributes values to gStyle */
    saveToStyle(name_color, name_width, name_style) {
       if (name_color) {
          let indx = (this.color_index !== undefined) ? this.color_index : findColor(this.color);
@@ -148,9 +149,9 @@ class TAttLineHandler {
             gStyle[name_color] = indx;
       }
       if (name_width)
-        gStyle[name_width] = this.width;
+         gStyle[name_width] = this.width;
       if (name_style)
-        gStyle[name_style] = this.style;
+         gStyle[name_style] = this.style;
    }
 
 } // class TAttLineHandler

--- a/js/modules/base/TAttMarkerHandler.mjs
+++ b/js/modules/base/TAttMarkerHandler.mjs
@@ -130,8 +130,8 @@ class TAttMarkerHandler {
 
       this.optimized = false;
 
-      let marker_kind = root_markers[this.style] ?? 104;
-      let shape = marker_kind % 100;
+      let marker_kind = root_markers[this.style] ?? 104,
+          shape = marker_kind % 100;
 
       this.fill = (marker_kind >= 100);
 

--- a/js/modules/base/latex.mjs
+++ b/js/modules/base/latex.mjs
@@ -1,4 +1,4 @@
-import { loadScript, settings, isNodeJs } from '../core.mjs';
+import { loadScript, settings, isNodeJs, source_dir } from '../core.mjs';
 import { getElementRect, _loadJSDOM } from './BasePainter.mjs';
 import { FontHandler } from './FontHandler.mjs';
 
@@ -844,7 +844,7 @@ function parseLatex(node, arg, label, curr) {
   * @private */
 function produceLatex(painter, node, arg) {
 
-   let pos = { lvl: 0, g: node, x: 0, y: 0, dx: 0, dy: -0.1, fsize: arg.font_size, font: arg.font, parent: null, painter: painter };
+   let pos = { lvl: 0, g: node, x: 0, y: 0, dx: 0, dy: -0.1, fsize: arg.font_size, font: arg.font, parent: null, painter };
 
    return parseLatex(node, arg, arg.text, pos);
 }
@@ -895,7 +895,7 @@ function loadMathjax() {
          },
          svg: svg_config,
          startup: {
-            ready: function() {
+            ready() {
                MathJax.startup.defaultReady();
                let arr = _mj_loading;
                _mj_loading = undefined;
@@ -904,7 +904,7 @@ function loadMathjax() {
          }
       };
 
-      return loadScript('../../mathjax/3.2.0/es5/tex-svg.js')
+      return loadScript(source_dir + '../mathjax/3.2.0/es5/tex-svg.js')
                .catch(() => loadScript('https://cdn.jsdelivr.net/npm/mathjax@3.2.0/es5/tex-svg.js'))
                .then(() => promise);
    }
@@ -927,15 +927,15 @@ function loadMathjax() {
           },
           startup: {
              typeset: false,
-             ready: function() {
-                   MathJax.startup.registerConstructor('jsdomAdaptor', () => {
-                      return new MathJax._.adaptors.HTMLAdaptor.HTMLAdaptor(new MathJax.config.config.JSDOM().window);
-                   });
-                   MathJax.startup.useAdaptor('jsdomAdaptor', true);
-                   MathJax.startup.defaultReady();
-                   let arr = _mj_loading;
-                   _mj_loading = undefined;
-                   arr.forEach(func => func(MathJax));
+             ready() {
+                MathJax.startup.registerConstructor('jsdomAdaptor', () => {
+                   return new MathJax._.adaptors.HTMLAdaptor.HTMLAdaptor(new MathJax.config.config.JSDOM().window);
+                });
+                MathJax.startup.useAdaptor('jsdomAdaptor', true);
+                MathJax.startup.defaultReady();
+                let arr = _mj_loading;
+                _mj_loading = undefined;
+                arr.forEach(func => func(MathJax));
              }
           }
       });
@@ -1274,19 +1274,25 @@ function applyAttributesToMathJax(painter, mj_node, svg, arg, font_size, svg_fac
    if (arg.valign === null) arg.valign = (font_size - mh) / 2;
 
    let sign = { x: 1, y: 1 }, nx = "x", ny = "y";
-   if (arg.rotate == 180) { sign.x = sign.y = -1; } else
-      if ((arg.rotate == 270) || (arg.rotate == 90)) {
-         sign.x = (arg.rotate == 270) ? -1 : 1;
-         sign.y = -sign.x;
-         nx = "y"; ny = "x"; // replace names to which align applied
-      }
+   if (arg.rotate == 180) {
+      sign.x = sign.y = -1;
+   } else if ((arg.rotate == 270) || (arg.rotate == 90)) {
+      sign.x = (arg.rotate == 270) ? -1 : 1;
+      sign.y = -sign.x;
+      nx = "y"; ny = "x"; // replace names to which align applied
+   }
 
-   if (arg.align[0] == 'middle') arg[nx] += sign.x * (arg.width - mw) / 2; else
-      if (arg.align[0] == 'end') arg[nx] += sign.x * (arg.width - mw);
+   if (arg.align[0] == 'middle')
+      arg[nx] += sign.x * (arg.width - mw) / 2;
+   else if (arg.align[0] == 'end')
+      arg[nx] += sign.x * (arg.width - mw);
 
-   if (arg.align[1] == 'middle') arg[ny] += sign.y * (arg.height - mh) / 2; else
-      if (arg.align[1] == 'bottom') arg[ny] += sign.y * (arg.height - mh); else
-         if (arg.align[1] == 'bottom-base') arg[ny] += sign.y * (arg.height - mh - arg.valign);
+   if (arg.align[1] == 'middle')
+      arg[ny] += sign.y * (arg.height - mh) / 2;
+   else if (arg.align[1] == 'bottom')
+      arg[ny] += sign.y * (arg.height - mh);
+   else if (arg.align[1] == 'bottom-base')
+      arg[ny] += sign.y * (arg.height - mh - arg.valign);
 
    let trans = `translate(${arg.x},${arg.y})`;
    if (arg.rotate) trans += ` rotate(${arg.rotate})`;
@@ -1306,7 +1312,7 @@ function produceMathjax(painter, mj_node, arg) {
               // when adding element to new node, it will be removed from original parent
               let svg = elem.querySelector('svg');
 
-              mj_node.append(function() { return svg; });
+              mj_node.append(() => svg);
 
               repairMathJaxSvgSize(painter, mj_node, svg, arg);
 

--- a/js/modules/draw.mjs
+++ b/js/modules/draw.mjs
@@ -106,8 +106,8 @@ const drawFuncs = { lst: [
    { name: "TNtuple", sameas: "TTree" },
    { name: "TNtupleD", sameas: "TTree" },
    { name: "TBranchFunc", icon: "img_leaf_method", draw: () => import('./draw/TTree.mjs').then(h => h.drawTree), opt: ";dump", noinspect: true },
-   { name: /^TBranch/, icon: "img_branch", draw: () => import('./draw/TTree.mjs').then(h => h.drawTree), dflt: "expand", opt: ";dump", ctrl: "dump", shift: "inspect", ignore_online: true },
-   { name: /^TLeaf/, icon: "img_leaf", noexpand: true, draw: () => import('./draw/TTree.mjs').then(h => h.drawTree), opt: ";dump", ctrl: "dump", ignore_online: true },
+   { name: /^TBranch/, icon: "img_branch", draw: () => import('./draw/TTree.mjs').then(h => h.drawTree), dflt: "expand", opt: ";dump", ctrl: "dump", shift: "inspect", ignore_online: true, always_draw: true },
+   { name: /^TLeaf/, icon: "img_leaf", noexpand: true, draw: () => import('./draw/TTree.mjs').then(h => h.drawTree), opt: ";dump", ctrl: "dump", ignore_online: true, always_draw: true },
    { name: "TList", icon: "img_list", draw: () => import('./gui/HierarchyPainter.mjs').then(h => h.drawList), get_expand: () => import('./gui/HierarchyPainter.mjs').then(h => h.listHierarchy), dflt: "expand" },
    { name: "THashList", sameas: "TList" },
    { name: "TObjArray", sameas: "TList" },
@@ -294,6 +294,7 @@ function setDefaultDrawOpt(classname, opt) {
   * let obj = await file.readObject("hpxpy;1");
   * await draw("drawing", obj, "colz;logx;gridx;gridy"); */
 function draw(dom, obj, opt) {
+
    if (!obj || (typeof obj !== 'object'))
       return Promise.reject(Error('not an object in draw call'));
 
@@ -325,7 +326,7 @@ function draw(dom, obj, opt) {
 
          let main_painter = getElementMainPainter(dom);
 
-         if (main_painter && (typeof main_painter.performDrop === 'function'))
+         if (typeof main_painter?.performDrop === 'function')
             return main_painter.performDrop(obj, "", null, opt);
       }
 

--- a/js/modules/draw/TArrowPainter.mjs
+++ b/js/modules/draw/TArrowPainter.mjs
@@ -8,6 +8,7 @@ import { addMoveHandler } from '../gui/utils.mjs';
   * @private */
 class TArrowPainter extends ObjectPainter {
 
+   /** @summary Create line segment with rotation */
    rotate(angle, x0, y0) {
       let dx = this.wsize * Math.cos(angle), dy = this.wsize * Math.sin(angle), res = "";
       if ((x0 !== undefined) && (y0 !== undefined)) {
@@ -20,6 +21,7 @@ class TArrowPainter extends ObjectPainter {
       return res;
    }
 
+   /** @summary Create SVG path for the arrow */
    createPath() {
       let angle = Math.atan2(this.y2 - this.y1, this.x2 - this.x1),
           dlen = this.wsize * Math.cos(this.angle2),
@@ -47,19 +49,27 @@ class TArrowPainter extends ObjectPainter {
               path;
    }
 
+   /** @summary Start interactive moving */
    moveStart(x,y) {
-      let fullsize = Math.sqrt(Math.pow(this.x1-this.x2,2) + Math.pow(this.y1-this.y2,2)),
-          sz1 = Math.sqrt(Math.pow(x-this.x1,2) + Math.pow(y-this.y1,2))/fullsize,
-          sz2 = Math.sqrt(Math.pow(x-this.x2,2) + Math.pow(y-this.y2,2))/fullsize;
-      if (sz1>0.9) this.side = 1; else if (sz2>0.9) this.side = -1; else this.side = 0;
+      let fullsize = Math.sqrt((this.x1-this.x2)**2 + (this.y1-this.y2)**2),
+          sz1 = Math.sqrt((x-this.x1)**2 + (y-this.y1)**2)/fullsize,
+          sz2 = Math.sqrt((x-this.x2)**2 + (y-this.y2)**2)/fullsize;
+      if (sz1 > 0.9)
+         this.side = 1;
+      else if (sz2 > 0.9)
+         this.side = -1;
+      else
+         this.side = 0;
    }
 
+   /** @summary Continue interactive moving */
    moveDrag(dx,dy) {
       if (this.side != 1) { this.x1 += dx; this.y1 += dy; }
       if (this.side != -1) { this.x2 += dx; this.y2 += dy; }
       this.draw_g.select('path').attr("d", this.createPath());
    }
 
+   /** @summary Finish interactive moving */
    moveEnd(not_changed) {
       if (not_changed) return;
       let arrow = this.getObject(), exec = "";
@@ -72,6 +82,7 @@ class TArrowPainter extends ObjectPainter {
       this.submitCanvExec(exec + "Notify();;");
    }
 
+   /** @summary Redraw arrow */
    redraw() {
       let arrow = this.getObject(), kLineNDC = BIT(14),
           oo = arrow.fOption, rect = this.getPadPainter().getPadRect();
@@ -122,6 +133,7 @@ class TArrowPainter extends ObjectPainter {
       return this;
    }
 
+   /** @summary Draw TArrow object */
    static draw(dom, obj, opt) {
       let painter = new TArrowPainter(dom, obj,opt);
       return ensureTCanvas(painter, false).then(() => painter.redraw());

--- a/js/modules/draw/TF2.mjs
+++ b/js/modules/draw/TF2.mjs
@@ -5,6 +5,8 @@ import { getElementMainPainter } from '../base/ObjectPainter.mjs';
 import { DrawOptions } from '../base/BasePainter.mjs';
 
 
+/** @summary Create histogram for TF2 drawing
+  * @private */
 function createTF2Histogram(func, hist = undefined) {
    let nsave = func.fSave.length, use_middle = true;
    if ((nsave > 6) && (nsave !== (func.fSave[nsave-2]+1)*(func.fSave[nsave-1]+1) + 6)) nsave = 0;

--- a/js/modules/draw/TGraphPolarPainter.mjs
+++ b/js/modules/draw/TGraphPolarPainter.mjs
@@ -348,7 +348,7 @@ class TGraphPolarPainter extends ObjectPainter {
       let graph = this.getObject(),
           main = this.getMainPainter();
 
-      if (!graph || !main || !main.$polargram) return;
+      if (!graph || !main?.$polargram) return;
 
       if (this.options.mark) this.createAttMarker({ attr: graph });
       if (this.options.err || this.options.line || this.options.curve) this.createAttLine({ attr: graph });
@@ -448,7 +448,7 @@ class TGraphPolarPainter extends ObjectPainter {
 
       for (let n = 0; n < graph.fNpoints; ++n) {
          let pos = main.translate(graph.fX[n], graph.fY[n]),
-             dist2 = (pos.x-pnt.x)*(pos.x-pnt.x) + (pos.y-pnt.y)*(pos.y-pnt.y);
+             dist2 = (pos.x-pnt.x)**2 + (pos.y-pnt.y)**2;
          if (dist2 < best_dist2) { best_dist2 = dist2; bestindx = n; bestpos = pos; }
       }
 

--- a/js/modules/draw/TRatioPlotPainter.mjs
+++ b/js/modules/draw/TRatioPlotPainter.mjs
@@ -14,14 +14,12 @@ class TRatioPlotPainter extends ObjectPainter {
 
    /** @summary Set grids range */
    setGridsRange(xmin, xmax) {
-      let ratio = this.getObject(),
-          pp = this.getPadPainter();
+      let ratio = this.getObject();
       if (xmin === xmax) {
-         let low_p = pp.findPainterFor(ratio.fLowerPad, "lower_pad", "TPad"),
-             low_fp = low_p ? low_p.getFramePainter() : null;
-         if (!low_fp || !low_fp.x_handle) return;
-         xmin = low_fp.x_handle.full_min;
-         xmax = low_fp.x_handle.full_max;
+         let x_handle = this.getPadPainter()?.findPainterFor(ratio.fLowerPad, "lower_pad", "TPad")?.getFramePainter()?.x_handle;
+         if (!x_handle) return;
+         xmin = x_handle.full_min;
+         xmax = x_handle.full_max;
       }
 
       ratio.fGridlines.forEach(line => {
@@ -39,11 +37,11 @@ class TRatioPlotPainter extends ObjectPainter {
       if (top_p) top_p.disablePadDrawing();
 
       let up_p = pp.findPainterFor(ratio.fUpperPad, "upper_pad", "TPad"),
-          up_main = up_p ? up_p.getMainPainter() : null,
-          up_fp = up_p ? up_p.getFramePainter() : null,
+          up_main = up_p?.getMainPainter(),
+          up_fp = up_p?.getFramePainter(),
           low_p = pp.findPainterFor(ratio.fLowerPad, "lower_pad", "TPad"),
-          low_main = low_p ? low_p.getMainPainter() : null,
-          low_fp = low_p ? low_p.getFramePainter() : null,
+          low_main = low_p?.getMainPainter(),
+          low_fp = low_p?.getFramePainter(),
           lbl_size = 20, promise_up = Promise.resolve(true);
 
       if (up_p && up_main && up_fp && low_fp && !up_p._ratio_configured) {
@@ -99,7 +97,7 @@ class TRatioPlotPainter extends ObjectPainter {
          low_p.getRootPad().fTicky = 1;
 
          low_p.forEachPainterInPad(objp => {
-            if (typeof objp.testEditable == 'function')
+            if (typeof objp?.testEditable == 'function')
                objp.testEditable(false);
          });
 

--- a/js/modules/draw/TSplinePainter.mjs
+++ b/js/modules/draw/TSplinePainter.mjs
@@ -76,7 +76,7 @@ class TSplinePainter extends ObjectPainter {
       let xmin = 0, xmax = 1, ymin = 0, ymax = 1,
           spline = this.getObject();
 
-      if (spline && spline.fPoly) {
+      if (spline?.fPoly) {
 
          xmin = xmax = spline.fPoly[0].fX;
          ymin = ymax = spline.fPoly[0].fY;
@@ -112,7 +112,7 @@ class TSplinePainter extends ObjectPainter {
       let cleanup = false,
           spline = this.getObject(),
           main = this.getFramePainter(),
-          funcs = main ? main.getGrFuncs(this.options.second_x, this.options.second_y) : null,
+          funcs = main?.getGrFuncs(this.options.second_x, this.options.second_y),
           xx, yy, knot = null, indx = 0;
 
       if ((pnt === null) || !spline || !funcs) {
@@ -160,7 +160,7 @@ class TSplinePainter extends ObjectPainter {
 
       res.changed = gbin.property("current_xx") !== xx;
       res.menu = res.exact;
-      res.menu_dist = Math.sqrt((res.x-pnt.x)*(res.x-pnt.x) + (res.y-pnt.y)*(res.y-pnt.y));
+      res.menu_dist = Math.sqrt((res.x-pnt.x)**2 + (res.y-pnt.y)**2);
 
       if (res.changed)
          gbin.attr("cx", Math.round(res.x))
@@ -176,7 +176,7 @@ class TSplinePainter extends ObjectPainter {
          res.lines.push("B = " + floatToString(knot.fB, gStyle.fStatFormat));
          res.lines.push("C = " + floatToString(knot.fC, gStyle.fStatFormat));
          res.lines.push("D = " + floatToString(knot.fD, gStyle.fStatFormat));
-         if ((knot.fE!==undefined) && (knot.fF!==undefined)) {
+         if ((knot.fE !== undefined) && (knot.fF !== undefined)) {
             res.lines.push("E = " + floatToString(knot.fE, gStyle.fStatFormat));
             res.lines.push("F = " + floatToString(knot.fF, gStyle.fStatFormat));
          }
@@ -191,7 +191,7 @@ class TSplinePainter extends ObjectPainter {
 
       let spline = this.getObject(),
           pmain = this.getFramePainter(),
-          funcs = pmain ? pmain.getGrFuncs(this.options.second_x, this.options.second_y) : null,
+          funcs = pmain?.getGrFuncs(this.options.second_x, this.options.second_y),
           w = pmain.getFrameWidth(),
           h = pmain.getFrameHeight();
 
@@ -226,7 +226,7 @@ class TSplinePainter extends ObjectPainter {
          }
 
          let h0 = h;  // use maximal frame height for filling
-         if ((pmain.hmin!==undefined) && (pmain.hmin >= 0)) {
+         if ((pmain.hmin !== undefined) && (pmain.hmin >= 0)) {
             h0 = Math.round(funcs.gry(0));
             if ((h0 > h) || (h0 < 0)) h0 = h;
          }

--- a/js/modules/draw/TWebPaintingPainter.mjs
+++ b/js/modules/draw/TWebPaintingPainter.mjs
@@ -17,7 +17,7 @@ class TWebPaintingPainter extends ObjectPainter {
 
       const obj = this.getObject(), func = this.getAxisToSvgFunc();
 
-      if (!obj || !obj.fOper || !func) return;
+      if (!obj?.fOper || !func) return;
 
       let indx = 0, attr = {}, lastpath = null, lastkind = "none", d = "",
           oper, npoints, n, arr = obj.fOper.split(";");

--- a/js/modules/draw/draw3d.mjs
+++ b/js/modules/draw/draw3d.mjs
@@ -4,10 +4,12 @@ import { createLineSegments, PointsCreator, create3DLineMaterial } from '../base
 import { drawDummy3DGeom } from '../geom/TGeoPainter.mjs';
 
 
+/** @summary Prepare frame painter for 3D drawing
+  * @private */
 function before3DDraw(painter, obj) {
    let fp = painter.getFramePainter();
 
-   if (!fp || !fp.mode3d || !obj)
+   if (!fp?.mode3d || !obj)
       return null;
 
    if (fp.toplevel)
@@ -16,7 +18,7 @@ function before3DDraw(painter, obj) {
    let geop = painter.getMainPainter();
    if(!geop)
       return drawDummy3DGeom(painter);
-   else if (typeof geop.drawExtras == 'function')
+   if (typeof geop.drawExtras == 'function')
       return geop.drawExtras(obj);
 
    return null;
@@ -33,12 +35,12 @@ function drawPolyMarker3D() {
    if (!fp || (typeof fp !== 'object') || !fp.grx || !fp.gry || !fp.grz)
       return fp;
 
-   let step = 1, sizelimit = 50000, numselect = 0;
+   let step = 1, sizelimit = 50000, numselect = 0, fP = poly.fP;
 
-   for (let i = 0; i < poly.fP.length; i += 3) {
-      if ((poly.fP[i] < fp.scale_xmin) || (poly.fP[i] > fp.scale_xmax) ||
-          (poly.fP[i+1] < fp.scale_ymin) || (poly.fP[i+1] > fp.scale_ymax) ||
-          (poly.fP[i+2] < fp.scale_zmin) || (poly.fP[i+2] > fp.scale_zmax)) continue;
+   for (let i = 0; i < fP.length; i += 3) {
+      if ((fP[i] < fp.scale_xmin) || (fP[i] > fp.scale_xmax) ||
+          (fP[i+1] < fp.scale_ymin) || (fP[i+1] > fp.scale_ymax) ||
+          (fP[i+2] < fp.scale_zmin) || (fP[i+2] > fp.scale_zmax)) continue;
       ++numselect;
    }
 
@@ -52,11 +54,11 @@ function drawPolyMarker3D() {
        index = new Int32Array(size),
        select = 0, icnt = 0;
 
-   for (let i = 0; i < poly.fP.length; i += 3) {
+   for (let i = 0; i < fP.length; i += 3) {
 
-      if ((poly.fP[i] < fp.scale_xmin) || (poly.fP[i] > fp.scale_xmax) ||
-          (poly.fP[i+1] < fp.scale_ymin) || (poly.fP[i+1] > fp.scale_ymax) ||
-          (poly.fP[i+2] < fp.scale_zmin) || (poly.fP[i+2] > fp.scale_zmax)) continue;
+      if ((fP[i] < fp.scale_xmin) || (fP[i] > fp.scale_xmax) ||
+          (fP[i+1] < fp.scale_ymin) || (fP[i+1] > fp.scale_ymax) ||
+          (fP[i+2] < fp.scale_zmin) || (fP[i+2] > fp.scale_zmax)) continue;
 
       if (step > 1) {
          select = (select+1) % step;
@@ -65,7 +67,7 @@ function drawPolyMarker3D() {
 
       index[icnt++] = i;
 
-      pnts.addPoint(fp.grx(poly.fP[i]), fp.gry(poly.fP[i+1]), fp.grz(poly.fP[i+2]));
+      pnts.addPoint(fp.grx(fP[i]), fp.gry(fP[i+1]), fp.grz(fP[i+2]));
    }
 
    return pnts.createPoints({ color: this.getColor(poly.fMarkerColor), style: poly.fMarkerStyle }).then(mesh => {

--- a/js/modules/draw/v7more.mjs
+++ b/js/modules/draw/v7more.mjs
@@ -29,12 +29,12 @@ function drawText() {
   * @private */
 function drawLine() {
 
-    let line         = this.getObject(),
-        pp           = this.getPadPainter(),
-        onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
-        clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
-        p1           = pp.getCoordinate(line.fP1, onframe),
-        p2           = pp.getCoordinate(line.fP2, onframe);
+    let line     = this.getObject(),
+        pp       = this.getPadPainter(),
+        onframe  = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
+        clipping = onframe ? this.v7EvalAttr("clipping", false) : false,
+        p1       = pp.getCoordinate(line.fP1, onframe),
+        p2       = pp.getCoordinate(line.fP2, onframe);
 
     this.createG(clipping ? "main_layer" : (onframe ? "upper_layer" : false));
 
@@ -50,12 +50,12 @@ function drawLine() {
   * @private */
 function drawBox() {
 
-   let box          = this.getObject(),
-       pp           = this.getPadPainter(),
-       onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
-       clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
-       p1           = pp.getCoordinate(box.fP1, onframe),
-       p2           = pp.getCoordinate(box.fP2, onframe);
+   let box      = this.getObject(),
+       pp       = this.getPadPainter(),
+       onframe  = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
+       clipping = onframe ? this.v7EvalAttr("clipping", false) : false,
+       p1       = pp.getCoordinate(box.fP1, onframe),
+       p2       = pp.getCoordinate(box.fP2, onframe);
 
    this.createG(clipping ? "main_layer" : (onframe ? "upper_layer" : false));
 
@@ -73,11 +73,11 @@ function drawBox() {
 /** @summary draw RMarker object
   * @private */
 function drawMarker() {
-    let marker       = this.getObject(),
-        pp           = this.getPadPainter(),
-        onframe      = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
-        clipping     = onframe ? this.v7EvalAttr("clipping", false) : false,
-        p            = pp.getCoordinate(marker.fP, onframe);
+    let marker   = this.getObject(),
+        pp       = this.getPadPainter(),
+        onframe  = this.v7EvalAttr("onFrame", false) ? pp.getFramePainter() : null,
+        clipping = onframe ? this.v7EvalAttr("clipping", false) : false,
+        p        = pp.getCoordinate(marker.fP, onframe);
 
     this.createG(clipping ? "main_layer" : (onframe ? "upper_layer" : false));
 

--- a/js/modules/geom/csg.mjs
+++ b/js/modules/geom/csg.mjs
@@ -63,7 +63,7 @@ class Vertex {
    }
 
    normalize() {
-      let length = Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
+      let length = Math.sqrt( this.x**2 + this.y**2 + this.z**2 );
 
       this.x /= length;
       this.y /= length;
@@ -80,9 +80,9 @@ class Vertex {
       let dx = (this.x - vertex.x),
           dy = (this.y - vertex.y),
           dz = (this.z - vertex.z),
-          len2 = this.x*this.x + this.y*this.y + this.z*this.z;
+          len2 = this.x**2 + this.y**2 + this.z**2;
 
-      return (dx*dx + dy*dy + dz*dz) / (len2>0 ? len2 : 1e-10);
+      return (dx**2 + dy**2 + dz**2) / (len2>0 ? len2 : 1e-10);
    }
 
 /*
@@ -108,9 +108,9 @@ class Vertex {
 */
 
    interpolate( a, t ) {
-      let t1 = 1-t;
+      let t1 = 1 - t;
       return new Vertex(this.x*t1 + a.x*t, this.y*t1 + a.y*t, this.z*t1 + a.z*t,
-                                 this.nx*t1 + a.nx*t, this.ny*t1 + a.ny*t, this.nz*t1 + a.nz*t);
+                        this.nx*t1 + a.nx*t, this.ny*t1 + a.ny*t, this.nz*t1 + a.nz*t);
    }
 
    applyMatrix4(m) {
@@ -502,7 +502,7 @@ class Geometry {
          for (let i=0;i<polygons.length;++i) {
             let polygon = polygons[i];
             if (transfer_matrix) {
-               for (let n=0;n<polygon.vertices.length;++n)
+               for (let n = 0; n < polygon.vertices.length; ++n)
                   polygon.vertices[n].applyMatrix4(transfer_matrix);
             }
 
@@ -577,7 +577,7 @@ class Geometry {
 
    union( other_tree ) {
       let a = this.tree.clone(),
-         b = other_tree.tree.clone();
+          b = other_tree.tree.clone();
 
       a.clipTo( b );
       b.clipTo( a );
@@ -592,7 +592,7 @@ class Geometry {
 
    intersect( other_tree ) {
       let a = this.tree.clone(),
-         b = other_tree.tree.clone();
+          b = other_tree.tree.clone();
 
       a.invert();
       b.clipTo( a );
@@ -623,7 +623,7 @@ class Geometry {
          arr[p.id].push(p);
       }
 
-      for(n=0; n<arr.length; ++n) {
+      for(n = 0; n < arr.length; ++n) {
          parts = arr[n];
          if (parts===undefined) continue;
 
@@ -636,7 +636,7 @@ class Geometry {
 
             for (i1 = 0; i1<len-1; ++i1) {
                p1 = parts[i1];
-               if (!p1 || !p1.parent) continue;
+               if (!p1?.parent) continue;
                for (i2 = i1+1; i2 < len; ++i2) {
                   p2 = parts[i2];
                   if (p2 && (p1.parent === p2.parent) && (p1.nsign === p2.nsign)) {
@@ -658,7 +658,7 @@ class Geometry {
       if (nreduce>0) {
          polygons.splice(0, polygons.length);
 
-         for(n=0;n<arr.length;++n) {
+         for(n = 0; n < arr.length; ++n) {
             parts = arr[n];
             if (parts !== undefined)
                for (i1=0,len=parts.length; i1<len;++i1)

--- a/js/modules/geom/geobase.mjs
+++ b/js/modules/geom/geobase.mjs
@@ -28,18 +28,18 @@ const kindGeo = 0,    // TGeoNode / TGeoShape
 /** @summary TGeo-related bits
   * @private */
 const geoBITS = {
-   kVisOverride     : JSROOT_BIT(0),           // volume's vis. attributes are overwritten
-   kVisNone         : JSROOT_BIT(1),           // the volume/node is invisible, as well as daughters
-   kVisThis         : JSROOT_BIT(2),           // this volume/node is visible
-   kVisDaughters    : JSROOT_BIT(3),           // all leaves are visible
-   kVisOneLevel     : JSROOT_BIT(4),           // first level daughters are visible (not used)
-   kVisStreamed     : JSROOT_BIT(5),           // true if attributes have been streamed
-   kVisTouched      : JSROOT_BIT(6),           // true if attributes are changed after closing geom
-   kVisOnScreen     : JSROOT_BIT(7),           // true if volume is visible on screen
-   kVisContainers   : JSROOT_BIT(12),          // all containers visible
-   kVisOnly         : JSROOT_BIT(13),          // just this visible
-   kVisBranch       : JSROOT_BIT(14),          // only a given branch visible
-   kVisRaytrace     : JSROOT_BIT(15)           // raytracing flag
+   kVisOverride   : JSROOT_BIT(0),  // volume's vis. attributes are overwritten
+   kVisNone       : JSROOT_BIT(1),  // the volume/node is invisible, as well as daughters
+   kVisThis       : JSROOT_BIT(2),  // this volume/node is visible
+   kVisDaughters  : JSROOT_BIT(3),  // all leaves are visible
+   kVisOneLevel   : JSROOT_BIT(4),  // first level daughters are visible (not used)
+   kVisStreamed   : JSROOT_BIT(5),  // true if attributes have been streamed
+   kVisTouched    : JSROOT_BIT(6),  // true if attributes are changed after closing geom
+   kVisOnScreen   : JSROOT_BIT(7),  // true if volume is visible on screen
+   kVisContainers : JSROOT_BIT(12), // all containers visible
+   kVisOnly       : JSROOT_BIT(13), // just this visible
+   kVisBranch     : JSROOT_BIT(14), // only a given branch visible
+   kVisRaytrace   : JSROOT_BIT(15)  // raytracing flag
 };
 
 /** @summary Test fGeoAtt bits
@@ -66,7 +66,7 @@ function toggleGeoBit(volume, f) {
 /** @summary Implementation of TGeoVolume::InvisibleAll
   * @private */
 function setInvisibleAll(volume, flag) {
-   if (flag===undefined) flag = true;
+   if (flag === undefined) flag = true;
 
    setGeoBit(volume, geoBITS.kVisThis, !flag);
    // setGeoBit(this, geoBITS.kVisDaughters, !flag);
@@ -97,7 +97,7 @@ function geoWarn(msg) {
  * @private */
 function getNodeKind(obj) {
    if ((obj === undefined) || (obj === null) || (typeof obj !== 'object')) return -1;
-   return ('fShape' in obj) && ('fTrans' in obj) ? 1 : 0;
+   return ('fShape' in obj) && ('fTrans' in obj) ? kindEve : kindGeo;
 }
 
 /** @summary Returns number of shapes
@@ -111,11 +111,10 @@ function countNumShapes(shape) {
 
 
 /** @summary Returns geo object name
-  * @desc Can appens some special suffixes
+  * @desc Can appends some special suffixes
   * @private */
 function getObjectName(obj) {
-   if (!obj || !obj.fName) return "";
-   return obj.fName + (obj.$geo_suffix ? obj.$geo_suffix : "");
+   return obj?.fName ? (obj.fName + (obj.$geo_suffix || "")) : "";
 }
 
 /** @summary Check duplicates
@@ -129,7 +128,7 @@ function checkDuplicates(parent, chlds) {
    let names = [], cnts = [];
    for (let k = 0; k < chlds.length; ++k) {
       let chld = chlds[k];
-      if (!chld || !chld.fName) continue;
+      if (!chld?.fName) continue;
       if (!chld.$geo_suffix) {
          let indx = names.indexOf(chld.fName);
          if (indx>=0) {
@@ -154,9 +153,9 @@ function produceNormal(x1,y1,z1, x2,y2,z2, x3,y3,z3) {
        cb = new Vector3(),
        ab = new Vector3();
 
-   cb.subVectors( pC, pB );
-   ab.subVectors( pA, pB );
-   cb.cross(ab );
+   cb.subVectors(pC, pB);
+   ab.subVectors(pA, pB);
+   cb.cross(ab);
 
    return cb;
 }
@@ -295,13 +294,13 @@ class GeometryCreator {
          this.ab = new Vector3();
       }
 
-      this.pA.fromArray( this.pos, this.indx - 9 );
-      this.pB.fromArray( this.pos, this.indx - 6 );
-      this.pC.fromArray( this.pos, this.indx - 3 );
+      this.pA.fromArray(this.pos, this.indx - 9);
+      this.pB.fromArray(this.pos, this.indx - 6);
+      this.pC.fromArray(this.pos, this.indx - 3);
 
-      this.cb.subVectors( this.pC, this.pB );
-      this.ab.subVectors( this.pA, this.pB );
-      this.cb.cross( this.ab );
+      this.cb.subVectors(this.pC, this.pB);
+      this.ab.subVectors(this.pA, this.pB);
+      this.cb.cross(this.ab);
 
       this.setNormal(this.cb.x, this.cb.y, this.cb.z);
    }
@@ -325,7 +324,7 @@ class GeometryCreator {
    /** @summary Set normal
      * @desc special shortcut, when same normals can be applied for 1-2 point and 3-4 point */
    setNormal_12_34(nx12,ny12,nz12, nx34,ny34,nz34, reduce) {
-      if (reduce===undefined) reduce = 0;
+      if (reduce === undefined) reduce = 0;
 
       let indx = this.indx - ((reduce>0) ? 9 : 18), norm = this.norm;
 
@@ -359,11 +358,11 @@ class GeometryCreator {
    /** @summary Create geometry */
    create() {
       if (this.nfaces !== this.indx/9)
-         console.error('Mismatch with created ' + this.nfaces + ' and filled ' + this.indx/9 + ' number of faces');
+         console.error(`Mismatch with created ${this.nfaces} and filled ${this.indx/9} number of faces`);
 
       let geometry = new BufferGeometry();
-      geometry.setAttribute( 'position', new BufferAttribute( this.pos, 3 ) );
-      geometry.setAttribute( 'normal', new BufferAttribute( this.norm, 3 ) );
+      geometry.setAttribute('position', new BufferAttribute(this.pos, 3));
+      geometry.setAttribute('normal', new BufferAttribute(this.norm, 3));
       return geometry;
    }
 }
@@ -397,7 +396,7 @@ class PolygonsCreator{
 
    /** @summary Add face with 3 vertices */
    addFace3(x1,y1,z1, x2,y2,z2, x3,y3,z3) {
-      this.addFace4(x1,y1,z1,x2,y2,z2,x3,y3,z3,x3,y3,z3,2);
+      this.addFace4(x1,y1,z1, x2,y2,z2, x3,y3,z3, x3,y3,z3, 2);
    }
 
    /** @summary Add face with 4 vertices
@@ -407,10 +406,10 @@ class PolygonsCreator{
    addFace4(x1,y1,z1, x2,y2,z2, x3,y3,z3, x4,y4,z4, reduce) {
       if (reduce === undefined) reduce = 0;
 
-      this.v1 = new CsgVertex( x1, y1, z1, 0, 0, 0 );
-      this.v2 = (reduce===1) ? null : new CsgVertex( x2, y2, z2, 0, 0, 0 );
-      this.v3 = new CsgVertex( x3, y3, z3, 0, 0, 0 );
-      this.v4 = (reduce===2) ? null : new CsgVertex( x4, y4, z4, 0, 0, 0 );
+      this.v1 = new CsgVertex(x1,y1,z1, 0,0,0);
+      this.v2 = (reduce===1) ? null : new CsgVertex(x2,y2,z2, 0,0,0);
+      this.v3 = new CsgVertex(x3,y3,z3, 0,0,0);
+      this.v4 = (reduce===2) ? null : new CsgVertex(x4,y4,z4, 0,0,0);
 
       this.reduce = reduce;
 
@@ -503,9 +502,9 @@ class PolygonsCreator{
          this.pC.set( this.v4.x, this.v4.y, this.v4.z);
       }
 
-      this.cb.subVectors( this.pC, this.pB );
-      this.ab.subVectors( this.pA, this.pB );
-      this.cb.cross( this.ab );
+      this.cb.subVectors(this.pC, this.pB);
+      this.ab.subVectors(this.pA, this.pB);
+      this.cb.cross(this.ab);
 
       this.setNormal(this.cb.x, this.cb.y, this.cb.z);
    }
@@ -541,9 +540,8 @@ function createCubeBuffer(shape, faces_limit) {
 
    if (faces_limit < 0) return 12;
 
-   let dx = shape.fDX, dy = shape.fDY, dz = shape.fDZ;
-
-   let creator = faces_limit ? new PolygonsCreator : new GeometryCreator(12);
+   let dx = shape.fDX, dy = shape.fDY, dz = shape.fDZ,
+       creator = faces_limit ? new PolygonsCreator : new GeometryCreator(12);
 
    creator.addFace4(dx,dy,dz, dx,-dy,dz, dx,-dy,-dz, dx,dy,-dz); creator.setNormal(1,0,0);
 
@@ -564,9 +562,8 @@ function createCubeBuffer(shape, faces_limit) {
   * @private */
 function create8edgesBuffer( v, faces_limit ) {
 
-   let indicies = [ 4,7,6,5,  0,3,7,4,  4,5,1,0,  6,2,1,5,  7,3,2,6,  1,2,3,0 ];
-
-   let creator = (faces_limit > 0) ? new PolygonsCreator : new GeometryCreator(12);
+   let indicies = [4,7,6,5, 0,3,7,4, 4,5,1,0, 6,2,1,5, 7,3,2,6, 1,2,3,0],
+        creator = (faces_limit > 0) ? new PolygonsCreator : new GeometryCreator(12);
 
    for (let n = 0; n < indicies.length; n += 4) {
       let i1 = indicies[n]*3,
@@ -592,17 +589,15 @@ function createParaBuffer( shape, faces_limit ) {
 
    if (faces_limit < 0) return 12;
 
-   let txy = shape.fTxy, txz = shape.fTxz, tyz = shape.fTyz;
-
-   let v = [
-       -shape.fZ*txz-txy*shape.fY-shape.fX, -shape.fY-shape.fZ*tyz,  -shape.fZ,
-       -shape.fZ*txz+txy*shape.fY-shape.fX,  shape.fY-shape.fZ*tyz,  -shape.fZ,
-       -shape.fZ*txz+txy*shape.fY+shape.fX,  shape.fY-shape.fZ*tyz,  -shape.fZ,
-       -shape.fZ*txz-txy*shape.fY+shape.fX, -shape.fY-shape.fZ*tyz,  -shape.fZ,
-        shape.fZ*txz-txy*shape.fY-shape.fX, -shape.fY+shape.fZ*tyz,   shape.fZ,
-        shape.fZ*txz+txy*shape.fY-shape.fX,  shape.fY+shape.fZ*tyz,   shape.fZ,
-        shape.fZ*txz+txy*shape.fY+shape.fX,  shape.fY+shape.fZ*tyz,   shape.fZ,
-        shape.fZ*txz-txy*shape.fY+shape.fX, -shape.fY+shape.fZ*tyz,   shape.fZ ];
+   let txy = shape.fTxy, txz = shape.fTxz, tyz = shape.fTyz, v = [
+       -shape.fZ*txz-txy*shape.fY-shape.fX, -shape.fY-shape.fZ*tyz, -shape.fZ,
+       -shape.fZ*txz+txy*shape.fY-shape.fX,  shape.fY-shape.fZ*tyz, -shape.fZ,
+       -shape.fZ*txz+txy*shape.fY+shape.fX,  shape.fY-shape.fZ*tyz, -shape.fZ,
+       -shape.fZ*txz-txy*shape.fY+shape.fX, -shape.fY-shape.fZ*tyz, -shape.fZ,
+        shape.fZ*txz-txy*shape.fY-shape.fX, -shape.fY+shape.fZ*tyz,  shape.fZ,
+        shape.fZ*txz+txy*shape.fY-shape.fX,  shape.fY+shape.fZ*tyz,  shape.fZ,
+        shape.fZ*txz+txy*shape.fY+shape.fX,  shape.fY+shape.fZ*tyz,  shape.fZ,
+        shape.fZ*txz-txy*shape.fY+shape.fX, -shape.fY+shape.fZ*tyz,  shape.fZ ];
 
    return create8edgesBuffer(v, faces_limit );
 }
@@ -621,15 +616,15 @@ function createTrapezoidBuffer( shape, faces_limit ) {
    }
 
    let v = [
-         -shape.fDx1,  y1, -shape.fDZ,
-          shape.fDx1,  y1, -shape.fDZ,
-          shape.fDx1, -y1, -shape.fDZ,
-         -shape.fDx1, -y1, -shape.fDZ,
-         -shape.fDx2,  y2,  shape.fDZ,
-          shape.fDx2,  y2,  shape.fDZ,
-          shape.fDx2, -y2,  shape.fDZ,
-         -shape.fDx2, -y2,  shape.fDZ
-      ];
+      -shape.fDx1,  y1, -shape.fDZ,
+       shape.fDx1,  y1, -shape.fDZ,
+       shape.fDx1, -y1, -shape.fDZ,
+      -shape.fDx1, -y1, -shape.fDZ,
+      -shape.fDx2,  y2,  shape.fDZ,
+       shape.fDx2,  y2,  shape.fDZ,
+       shape.fDx2, -y2,  shape.fDZ,
+      -shape.fDx2, -y2,  shape.fDZ
+   ];
 
    return create8edgesBuffer(v, faces_limit );
 }
@@ -642,22 +637,22 @@ function createArb8Buffer( shape, faces_limit ) {
    if (faces_limit < 0) return 12;
 
    let vertices = [
-         shape.fXY[0][0], shape.fXY[0][1], -shape.fDZ,
-         shape.fXY[1][0], shape.fXY[1][1], -shape.fDZ,
-         shape.fXY[2][0], shape.fXY[2][1], -shape.fDZ,
-         shape.fXY[3][0], shape.fXY[3][1], -shape.fDZ,
-         shape.fXY[4][0], shape.fXY[4][1],  shape.fDZ,
-         shape.fXY[5][0], shape.fXY[5][1],  shape.fDZ,
-         shape.fXY[6][0], shape.fXY[6][1],  shape.fDZ,
-         shape.fXY[7][0], shape.fXY[7][1],  shape.fDZ
-      ];
+      shape.fXY[0][0], shape.fXY[0][1], -shape.fDZ,
+      shape.fXY[1][0], shape.fXY[1][1], -shape.fDZ,
+      shape.fXY[2][0], shape.fXY[2][1], -shape.fDZ,
+      shape.fXY[3][0], shape.fXY[3][1], -shape.fDZ,
+      shape.fXY[4][0], shape.fXY[4][1],  shape.fDZ,
+      shape.fXY[5][0], shape.fXY[5][1],  shape.fDZ,
+      shape.fXY[6][0], shape.fXY[6][1],  shape.fDZ,
+      shape.fXY[7][0], shape.fXY[7][1],  shape.fDZ
+   ];
    const indicies = [
-         4,7,6,   6,5,4,   3,7,4,   4,0,3,
-         5,1,0,   0,4,5,   6,2,1,   1,5,6,
-         7,3,2,   2,6,7,   1,2,3,   3,0,1 ];
+         4,7,6,  6,5,4,  3,7,4,  4,0,3,
+         5,1,0,  0,4,5,  6,2,1,  1,5,6,
+         7,3,2,  2,6,7,  1,2,3,  3,0,1 ];
 
    // detect same vertices on both Z-layers
-   for (let side=0;side<vertices.length;side += vertices.length/2)
+   for (let side = 0; side < vertices.length; side += vertices.length/2)
       for (let n1 = side; n1 < side + vertices.length/2 - 3 ; n1+=3)
          for (let n2 = n1+3; n2 < side + vertices.length/2 ; n2+=3)
             if ((vertices[n1] === vertices[n2]) &&
@@ -698,8 +693,11 @@ function createArb8Buffer( shape, faces_limit ) {
 
       if ((i1 >= 0) && (i4 >= 0) && faces_limit) {
          // try to identify two faces with same normal - very useful if one can create face4
-         if (n===0) norm = new Vector3(0,0,1); else
-         if (n===30) norm = new Vector3(0,0,-1); else {
+         if (n === 0)
+            norm = new Vector3(0,0,1);
+         else if (n === 30)
+            norm = new Vector3(0,0,-1);
+         else {
             let norm1 = produceNormal(vertices[i1], vertices[i1+1], vertices[i1+2],
                                       vertices[i2], vertices[i2+1], vertices[i2+2],
                                       vertices[i3], vertices[i3+1], vertices[i3+2]);
@@ -723,13 +721,13 @@ function createArb8Buffer( shape, faces_limit ) {
                           vertices[i5], vertices[i5+1], vertices[i5+2]);
          creator.setNormal(norm.x, norm.y, norm.z);
       }  else {
-         if (i1>=0) {
+         if (i1 >= 0) {
             creator.addFace3(vertices[i1], vertices[i1+1], vertices[i1+2],
                              vertices[i2], vertices[i2+1], vertices[i2+2],
                              vertices[i3], vertices[i3+1], vertices[i3+2]);
             creator.calcNormal();
          }
-         if (i4>=0) {
+         if (i4 >= 0) {
             creator.addFace3(vertices[i4], vertices[i4+1], vertices[i4+2],
                              vertices[i5], vertices[i5+1], vertices[i5+2],
                              vertices[i6], vertices[i6+1], vertices[i6+2]);
@@ -831,7 +829,7 @@ function createSphereBuffer( shape, faces_limit ) {
       if (Math.abs(_sint[side]) >= epsilon) {
          let ss = _sint[side], cc = _cost[side],
              d1 = (side===0) ? 0 : 1, d2 = 1 - d1;
-         for (let n=0;n<widthSegments;++n) {
+         for (let n = 0; n < widthSegments; ++n) {
             creator.addFace4(
                   radius[1] * ss * _cosp[n+d1], radius[1] * ss * _sinp[n+d1], radius[1] * cc,
                   radius[0] * ss * _cosp[n+d1], radius[0] * ss * _sinp[n+d1], radius[0] * cc,
@@ -953,7 +951,7 @@ function createTubeBuffer( shape, faces_limit) {
    }
 
    // create upper/bottom part
-   for (let side = 0; side<2; ++side) {
+   for (let side = 0; side < 2; ++side) {
       if (outerR[side] <= 0) continue;
 
       let d1 = side, d2 = 1- side,
@@ -1031,7 +1029,7 @@ function createEltuBuffer( shape , faces_limit ) {
       nx1 = nx2; ny1 = ny2;
       nx2 = x[seg+1] * shape.fRmax / shape.fRmin;
       ny2 = y[seg+1] * shape.fRmin / shape.fRmax;
-      let dist = Math.sqrt(nx2*nx2 + ny2*ny2);
+      let dist = Math.sqrt(nx2**2 + ny2**2);
       nx2 = nx2 / dist; ny2 = ny2/dist;
 
       creator.setNormal_12_34(nx1,ny1,0,nx2,ny2,0);
@@ -1124,12 +1122,12 @@ function createTorusBuffer( shape, faces_limit ) {
    }
 
    if (shape.fDphi !== 360)
-      for (let t=0;t<=tubularSegments;t+=tubularSegments) {
+      for (let t = 0; t <= tubularSegments; t += tubularSegments) {
          let tube1 = shape.fRmax, tube2 = shape.fRmin,
              d1 = (t > 0) ? 0 : 1, d2 = 1 - d1,
              skip = (shape.fRmin) > 0 ?  0 : 1,
              nsign = (t > 0) ? 1 : -1;
-         for (let n=0;n<radialSegments;++n) {
+         for (let n = 0; n < radialSegments; ++n) {
             creator.addFace4((radius + tube1 * _cosr[n+d1]) * _cost[t], (radius + tube1 * _cosr[n+d1]) * _sint[t], tube1*_sinr[n+d1],
                              (radius + tube2 * _cosr[n+d1]) * _cost[t], (radius + tube2 * _cosr[n+d1]) * _sint[t], tube2*_sinr[n+d1],
                              (radius + tube2 * _cosr[n+d2]) * _cost[t], (radius + tube2 * _cosr[n+d2]) * _sint[t], tube2*_sinr[n+d2],
@@ -1247,7 +1245,7 @@ function createPolygonBuffer( shape, faces_limit ) {
           z1 = shape.fZ[0], r1 = factor*shape[rside][0],
           d1 = 1 - side, d2 = side;
 
-      for (let layer=0; layer < shape.fNz; ++layer) {
+      for (let layer = 0; layer < shape.fNz; ++layer) {
 
          if (usage[layer*2+side] === 0) continue;
 
@@ -1275,7 +1273,7 @@ function createPolygonBuffer( shape, faces_limit ) {
    }
 
    // add top/bottom
-   for (let layer=0; layer < shape.fNz; layer += (shape.fNz-1)) {
+   for (let layer = 0; layer < shape.fNz; layer += (shape.fNz-1)) {
 
       let rmin = factor*shape.fRmin[layer], rmax = factor*shape.fRmax[layer];
 
@@ -1287,7 +1285,7 @@ function createPolygonBuffer( shape, faces_limit ) {
 
       if (!hasrmin && !cut_faces) creator.startPolygon(layer>0);
 
-      for (let seg=0;seg < radiusSegments;++seg) {
+      for (let seg = 0; seg < radiusSegments; ++seg) {
          creator.addFace4(rmin * _cos[seg+d1], rmin * _sin[seg+d1], layerz,
                           rmax * _cos[seg+d1], rmax * _sin[seg+d1], layerz,
                           rmax * _cos[seg+d2], rmax * _sin[seg+d2], layerz,
@@ -1330,10 +1328,9 @@ function createXtruBuffer( shape, faces_limit ) {
    for (let vert = 0; vert < shape.fNvert; ++vert)
       pnts.push(new Vector2(shape.fX[vert], shape.fY[vert]));
 
-   // console.log('triangulate Xtru ' + shape.fShapeId);
    let faces = ShapeUtils.triangulateShape(pnts , []);
    if (faces.length < pnts.length-2) {
-      geoWarn('Problem with XTRU shape ' +shape.fName + ' with ' + pnts.length + ' vertices');
+      geoWarn(`Problem with XTRU shape ${shape.fName} with ${pnts.length} vertices`);
       faces = [];
    } else {
       nfaces += faces.length * 2;
@@ -1417,9 +1414,8 @@ function createParaboloidBuffer( shape, faces_limit ) {
       _sin[seg] = Math.sin(seg/radiusSegments*2*Math.PI);
    }
 
-   let creator = faces_limit ? new PolygonsCreator : new GeometryCreator(numfaces);
-
-   let lastz = zmin, lastr = 0, lastnxy = 0, lastnz = -1;
+   let creator = faces_limit ? new PolygonsCreator : new GeometryCreator(numfaces),
+       lastz = zmin, lastr = 0, lastnxy = 0, lastnz = -1;
 
    for (let layer = 0; layer <= heightSegments + 1; ++layer) {
 
@@ -1434,8 +1430,8 @@ function createParaboloidBuffer( shape, faces_limit ) {
          case heightSegments: layerz = zmax; radius = rmax; break;
          case heightSegments + 1: layerz = zmax; radius = 0; break;
          default: {
-            let tt = Math.tan(ttmin + (ttmax-ttmin) * layer / heightSegments);
-            let delta = tt*tt - 4*shape.fA*shape.fB; // should be always positive (a*b<0)
+            let tt = Math.tan(ttmin + (ttmax-ttmin) * layer / heightSegments),
+                delta = tt**2 - 4*shape.fA*shape.fB; // should be always positive (a*b<0)
             radius = 0.5*(tt+Math.sqrt(delta))/shape.fA;
             if (radius < 1e-6) radius = 0;
             layerz = radius*tt;
@@ -1511,8 +1507,8 @@ function createHypeBuffer( shape, faces_limit ) {
       for (let layer = 0; layer < heightSegments; ++layer) {
          let z1 = -shape.fDz + layer/heightSegments*2*shape.fDz,
              z2 = -shape.fDz + (layer+1)/heightSegments*2*shape.fDz,
-             r1 = Math.sqrt(r0*r0+tsq*z1*z1),
-             r2 = Math.sqrt(r0*r0+tsq*z2*z2);
+             r1 = Math.sqrt(r0**2 + tsq*z1**2),
+             r2 = Math.sqrt(r0**2 + tsq*z2**2);
 
          for (let seg = 0; seg < radiusSegments; ++seg) {
             creator.addFace4(r1 * _cos[seg+d1], r1 * _sin[seg+d1], z1,
@@ -1527,8 +1523,8 @@ function createHypeBuffer( shape, faces_limit ) {
    // add caps
    for (let layer = 0; layer < 2; ++layer) {
       let z = (layer === 0) ? shape.fDz : -shape.fDz,
-          r1 = Math.sqrt(shape.fRmax*shape.fRmax + shape.fToutsq*z*z),
-          r2 = (shape.fRmin > 0) ? Math.sqrt(shape.fRmin*shape.fRmin + shape.fTinsq*z*z) : 0,
+          r1 = Math.sqrt(shape.fRmax**2 + shape.fToutsq*z**2),
+          r2 = (shape.fRmin > 0) ? Math.sqrt(shape.fRmin**2 + shape.fTinsq*z**2) : 0,
           skip = (shape.fRmin > 0) ? 0 : 1,
           d1 = 1 - layer, d2 = 1 - d1;
       for (let seg = 0; seg < radiusSegments; ++seg) {
@@ -1779,7 +1775,7 @@ function geomBoundingBox(geom) {
   * @desc Just big-enough triangle to make BSP calculations
   * @private */
 function createHalfSpace(shape, geom) {
-   if (!shape || !shape.fN || !shape.fP) return null;
+   if (!shape?.fN || !shape?.fP) return null;
 
    let vertex = new Vector3(shape.fP[0], shape.fP[1], shape.fP[2]),
        normal = new Vector3(shape.fN[0], shape.fN[1], shape.fN[2]);
@@ -1802,13 +1798,13 @@ function createHalfSpace(shape, geom) {
                                       v0.x,v0.y,v0.z, v1.x,v1.y,v1.z, v3.x,v3.y,v3.z,
                                       v1.x,v1.y,v1.z, v2.x,v2.y,v2.z, v3.x,v3.y,v3.z,
                                       v2.x,v2.y,v2.z, v0.x,v0.y,v0.z, v3.x,v3.y,v3.z ]);
-   geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
+   geometry.setAttribute('position', new BufferAttribute(positions, 3));
    geometry.computeVertexNormals();
 
    geometry.lookAt(normal);
    geometry.computeVertexNormals();
 
-   for(let k=0;k<positions.length;k+=3) {
+   for(let k = 0; k < positions.length; k += 3) {
       positions[k] = positions[k] + vertex.x;
       positions[k+1] = positions[k+1] + vertex.y;
       positions[k+2] = positions[k+2] + vertex.z;
@@ -1952,14 +1948,14 @@ function projectGeometry(geom, matrix, projection, position, flippedMesh) {
 }
 
 /** @summary Creates geometry model for the provided shape
- * @desc
- *  - if limit === 0 (or undefined) returns BufferGeometry
- *  - if limit < 0 just returns estimated number of faces
- *  - if limit > 0 return list of CsgPolygons (used only for composite shapes)
- * @param {Object} shape - instance of TGeoShape object
- * @param {Number} limit - defines return value, see details
- * @private */
-function createGeometry( shape, limit ) {
+  * @param {Object} shape - instance of TGeoShape object
+  * @param {Number} limit - defines return value, see details
+  * @desc
+  *  - if limit === 0 (or undefined) returns BufferGeometry
+  *  - if limit < 0 just returns estimated number of faces
+  *  - if limit > 0 return list of CsgPolygons (used only for composite shapes)
+  * @private */
+function createGeometry(shape, limit) {
    if (limit === undefined) limit = 0;
 
    try {
@@ -2332,9 +2328,8 @@ class ClonedNodes {
 
       // than fill children lists
       for (let n = 0; n < this.origin.length; ++n) {
-         let obj = this.origin[n], clone = this.nodes[n];
-
-         let chlds = null, shape = null;
+         let obj = this.origin[n], clone = this.nodes[n],
+             chlds = null, shape = null;
 
          if (kind === kindEve) {
             shape = obj.fShape;
@@ -3308,8 +3303,8 @@ function createFlippedMesh(shape, material) {
          }
 
          shape.geomZ = new BufferGeometry();
-         shape.geomZ.setAttribute( 'position', new BufferAttribute( newpos, 3 ) );
-         shape.geomZ.setAttribute( 'normal', new BufferAttribute( newnorm, 3 ) );
+         shape.geomZ.setAttribute('position', new BufferAttribute(newpos, 3));
+         shape.geomZ.setAttribute('normal', new BufferAttribute(newnorm, 3));
          // normals are calculated with normal geometry and correctly scaled
          // geom.computeVertexNormals();
 
@@ -3349,7 +3344,7 @@ function getBoundingBox(node, box3, local_coordinates) {
    let v1 = new Vector3(),
        geometry = node.geometry;
 
-   if ( geometry.isGeometry ) {
+   if (geometry.isGeometry) {
       let vertices = geometry.vertices;
       for (let i = 0, l = vertices.length; i < l; i ++ ) {
          v1.copy( vertices[ i ] );
@@ -3398,7 +3393,7 @@ function produceRenderOrder(toplevel, origin, method, clones) {
    function setdefaults(top) {
       if (!top) return;
       top.traverse(obj => {
-         obj.renderOrder = 0;
+         obj.renderOrder = obj.defaultOrder || 0;
          if (obj.material) obj.material.depthWrite = true; // by default depthWriting enabled
       });
    }
@@ -3450,7 +3445,8 @@ function produceRenderOrder(toplevel, origin, method, clones) {
             mesh.$jsroot_box3 = box3 = getBoundingBox(mesh);
 
          if (method === 'size') {
-            mesh.$jsroot_distance = box3.getSize(new Vector3());
+            let sz = box3.getSize(new Vector3());
+            mesh.$jsroot_distance = sz.x*sz.y*sz.z;
             continue;
          }
 
@@ -3536,7 +3532,7 @@ function produceRenderOrder(toplevel, origin, method, clones) {
          }
 
       for (let i = 0; i < resort.length; ++i) {
-         resort[i].renderOrder = maxorder - (i+1) / (resort.length+1) * (maxorder-minorder);
+         resort[i].renderOrder = Math.round( maxorder - (i+1) / (resort.length+1) * (maxorder-minorder));
          delete resort[i].$jsroot_index;
          delete resort[i].$jsroot_distance;
       }

--- a/js/modules/gpad/RCanvasPainter.mjs
+++ b/js/modules/gpad/RCanvasPainter.mjs
@@ -263,21 +263,21 @@ class RCanvasPainter extends RPadPainter {
                conn.setReceiver({
                   cpainter: this,
 
-                  onWebsocketOpened: function() {
+                  onWebsocketOpened() {
                   },
 
-                  onWebsocketMsg: function(panel_handle, msg) {
+                  onWebsocketMsg(panel_handle, msg) {
                      let panel_name = (msg.indexOf("SHOWPANEL:")==0) ? msg.slice(10) : "";
                      this.cpainter.showUI5Panel(panel_name, panel_handle)
                                   .then(res => handle.send(reply + (res ? "true" : "false")));
                   },
 
-                  onWebsocketClosed: function() {
+                  onWebsocketClosed() {
                      // if connection failed,
                      handle.send(reply + "false");
                   },
 
-                  onWebsocketError: function() {
+                  onWebsocketError() {
                      // if connection failed,
                      handle.send(reply + "false");
                   }
@@ -409,7 +409,7 @@ class RCanvasPainter extends RPadPainter {
       delete this._submreq[reply.reqid];
 
       // remove blocking reference for that kind
-      if (req._painter && req._kind && req._painter._requests)
+      if (req._kind && req._painter?._requests)
          if (req._painter._requests[req._kind] === req)
             delete req._painter._requests[req._kind];
 
@@ -454,7 +454,7 @@ class RCanvasPainter extends RPadPainter {
             console.log('TPave is moved inside RCanvas - that to do?');
             break;
          default:
-            if ((kind.slice(0,5) == "exec:") && painter && painter.snapid) {
+            if ((kind.slice(0,5) == "exec:") && painter?.snapid) {
                this.submitExec(painter, kind.slice(5), subelem);
             } else {
                console.log("UNPROCESSED CHANGES", kind);
@@ -480,28 +480,25 @@ class RCanvasPainter extends RPadPainter {
       if (this.brlayout)
          return this.brlayout.hasStatus();
       let hp = getHPainter();
-      if (hp)
-         return hp.hasStatusLine();
-      return false;
+      return hp ? hp.hasStatusLine() : false;
    }
 
    /** @summary Show/toggle event status bar
      * @private */
    activateStatusBar(state) {
       if (this.testUI5()) return;
-      if (this.brlayout) {
+      if (this.brlayout)
          this.brlayout.createStatusLine(23, state);
-      } else {
-         let hp = getHPainter();
-         if (hp) hp.createStatusLine(23, state);
-      }
+      else
+         getHPainter()?.createStatusLine(23, state);
+
       this.processChanges("sbits", this);
    }
 
    /** @summary Returns true if GED is present on the canvas */
    hasGed() {
       if (this.testUI5()) return false;
-      return this.brlayout ? this.brlayout.hasContent() : false;
+      return this.brlayout?.hasContent() ?? false;
    }
 
    /** @summary Function used to de-activate GED
@@ -516,8 +513,7 @@ class RCanvasPainter extends RPadPainter {
          this.ged_view.destroy();
          delete this.ged_view;
       }
-      if (this.brlayout)
-         this.brlayout.deleteContent();
+      this.brlayout?.deleteContent();
 
       this.processChanges("sbits", this);
    }
@@ -530,12 +526,10 @@ class RCanvasPainter extends RPadPainter {
          return Promise.resolve(false);
 
       if (this.brlayout.hasContent()) {
-         if ((mode === "toggle") || (mode === false)) {
+         if ((mode === "toggle") || (mode === false))
             this.removeGed();
-         } else {
-            let pp = objpainter ? objpainter.getPadPainter() : null;
-            if (pp) pp.selectObjectPainter(objpainter);
-         }
+         else
+            objpainter?.getPadPainter()?.selectObjectPainter(objpainter);
 
          return Promise.resolve(true);
       }
@@ -582,8 +576,7 @@ class RCanvasPainter extends RPadPainter {
                   // TODO: should be moved into Ged controller - it must be able to detect canvas painter itself
                   this.registerForPadEvents(oGed.getController().padEventsReceiver.bind(oGed.getController()));
 
-                  let pp = objpainter ? objpainter.getPadPainter() : null;
-                  if (pp) pp.selectObjectPainter(objpainter);
+                  objpainter?.getPadPainter()?.selectObjectPainter(objpainter);
 
                   this.processChanges("sbits", this);
 

--- a/js/modules/gpad/RFramePainter.mjs
+++ b/js/modules/gpad/RFramePainter.mjs
@@ -313,8 +313,8 @@ class RFramePainter extends RObjectPainter {
       }
 
       let xaxis = this.xaxis, yaxis = this.yaxis;
-      if (!xaxis || xaxis._typename != "TAxis") xaxis = create("TAxis");
-      if (!yaxis || yaxis._typename != "TAxis") yaxis = create("TAxis");
+      if (xaxis?._typename != "TAxis") xaxis = create("TAxis");
+      if (yaxis?._typename != "TAxis") yaxis = create("TAxis");
 
       this.x_handle = new TAxisPainter(this.getDom(), xaxis, true);
       this.x_handle.setPadName(this.getPadName());
@@ -425,7 +425,7 @@ class RFramePainter extends RObjectPainter {
           draw_vertical = this.swap_xy ? this.x_handle : this.y_handle,
           pp = this.getPadPainter(), pr;
 
-      if (pp && pp._fast_drawing) {
+      if (pp?._fast_drawing) {
          pr = Promise.resolve(true); // do nothing
       } else if (this.v6axes) {
 
@@ -545,12 +545,12 @@ class RFramePainter extends RObjectPainter {
          scale_ymax: use_y2 ? this.scale_y2max : this.scale_ymax,
          swap_xy: this.swap_xy,
          fp: this,
-         revertAxis: function(name, v) {
+         revertAxis(name, v) {
             if ((name == "x") && this.use_x2) name = "x2";
             if ((name == "y") && this.use_y2) name = "y2";
             return this.fp.revertAxis(name, v);
          },
-         axisAsText: function(name, v) {
+         axisAsText(name, v) {
             if ((name == "x") && this.use_x2) name = "x2";
             if ((name == "y") && this.use_y2) name = "y2";
             return this.fp.axisAsText(name, v);
@@ -667,7 +667,7 @@ class RFramePainter extends RObjectPainter {
       delete this._dblclick_handler;
 
       let pp = this.getPadPainter();
-      if (pp && (pp.frame_painter_ref === this))
+      if (pp?.frame_painter_ref === this)
          delete pp.frame_painter_ref;
 
       super.cleanup();
@@ -965,7 +965,7 @@ class RFramePainter extends RObjectPainter {
           };
 
       let checkZooming = (painter, force) => {
-         if (!force && (typeof painter.canZoomInside != 'function')) return;
+         if (!force && (typeof painter?.canZoomInside != 'function')) return;
 
          is_any_check = true;
 
@@ -988,8 +988,8 @@ class RFramePainter extends RObjectPainter {
          checkZooming(null, true);
 
       if (unzoom_v) {
-         if (this["zoom_" + name + "min"] !== this["zoom_" + name + "max"]) changed = true;
-         this["zoom_" + name + "min"] = this["zoom_" + name + "max"] = 0;
+         if (this[`zoom_${name}min`] !== this[`zoom_${name}max`]) changed = true;
+         this[`zoom_${name}min`] = this[`zoom_${name}max`] = 0;
          req.values[indx*2] = req.values[indx*2+1] = -1;
       }
 

--- a/js/modules/gpad/TAxisPainter.mjs
+++ b/js/modules/gpad/TAxisPainter.mjs
@@ -213,10 +213,10 @@ const AxisPainterMethods = {
          for (let k = 1; k < arr.length; ++k) {
             let diff = (arr[k] - arr[k-1]);
             sum1 += diff;
-            sum2 += diff*diff;
+            sum2 += diff**2;
          }
          let mean = sum1/(arr.length-1),
-             dev = sum2/(arr.length-1) - mean*mean;
+             dev = sum2/(arr.length-1) - mean**2;
 
          if (dev <= 0) return true;
          if (Math.abs(mean) < 1e-100) return false;
@@ -466,7 +466,7 @@ class TAxisPainter extends ObjectPainter {
       else
          this.gr = this.func;
 
-      let is_gaxis = (axis && axis._typename === 'TGaxis');
+      let is_gaxis = (axis?._typename === 'TGaxis');
 
       delete this.format;// remove formatting func
 

--- a/js/modules/gpad/TCanvasPainter.mjs
+++ b/js/modules/gpad/TCanvasPainter.mjs
@@ -187,8 +187,7 @@ class TCanvasPainter extends TPadPainter {
 
          promise.then(painter => { this.proj_painter = painter; });
       } else {
-         let hp = this.proj_painter.getMainPainter();
-         if (hp) hp.updateObject(hist, hopt);
+         this.proj_painter.getMainPainter()?.updateObject(hist, hopt);
          this.proj_painter.redrawPad();
       }
    }
@@ -370,29 +369,24 @@ class TCanvasPainter extends TPadPainter {
          return false;
       if (this.brlayout)
          return this.brlayout.hasStatus();
-      let hp = getHPainter();
-      if (hp)
-         return hp.hasStatusLine();
-      return false;
+      return getHPainter()?.hasStatusLine() ?? false;
    }
 
    /** @summary Show/toggle event status bar
      * @private */
    activateStatusBar(state) {
       if (this.testUI5()) return;
-      if (this.brlayout) {
+      if (this.brlayout)
          this.brlayout.createStatusLine(23, state);
-      } else {
-         let hp = getHPainter();
-         if (hp) hp.createStatusLine(23, state);
-      }
+      else
+         getHPainter()?.createStatusLine(23, state);
       this.processChanges("sbits", this);
    }
 
    /** @summary Returns true if GED is present on the canvas */
    hasGed() {
       if (this.testUI5()) return false;
-      return this.brlayout ? this.brlayout.hasContent() : false;
+      return this.brlayout?.hasContent() ?? false;
    }
 
    /** @summary Function used to de-activate GED
@@ -407,8 +401,7 @@ class TCanvasPainter extends TPadPainter {
          this.ged_view.destroy();
          delete this.ged_view;
       }
-      if (this.brlayout)
-         this.brlayout.deleteContent();
+      this.brlayout?.deleteContent();
 
       this.processChanges("sbits", this);
    }
@@ -421,12 +414,10 @@ class TCanvasPainter extends TPadPainter {
          return Promise.resolve(false);
 
       if (this.brlayout.hasContent()) {
-         if ((mode === "toggle") || (mode === false)) {
+         if ((mode === "toggle") || (mode === false))
             this.removeGed();
-         } else {
-            let pp = objpainter ? objpainter.getPadPainter() : null;
-            if (pp) pp.selectObjectPainter(objpainter);
-         }
+         else
+            objpainter?.getPadPainter()?.selectObjectPainter(objpainter);
 
          return Promise.resolve(true);
       }
@@ -473,8 +464,7 @@ class TCanvasPainter extends TPadPainter {
                   // TODO: should be moved into Ged controller - it must be able to detect canvas painter itself
                   this.registerForPadEvents(oGed.getController().padEventsReceiver.bind(oGed.getController()));
 
-                  let pp = objpainter ? objpainter.getPadPainter() : null;
-                  if (pp) pp.selectObjectPainter(objpainter);
+                  objpainter?.getPadPainter()?.selectObjectPainter(objpainter);
 
                   this.processChanges("sbits", this);
 
@@ -575,7 +565,7 @@ class TCanvasPainter extends TPadPainter {
             }
             break;
          default:
-            if ((kind.slice(0,5) == "exec:") && painter && painter.snapid) {
+            if ((kind.slice(0,5) == "exec:") && painter?.snapid) {
                console.log('Call exec', painter.snapid);
 
                msg = "PRIMIT6:" + toJSON({
@@ -610,7 +600,7 @@ class TCanvasPainter extends TPadPainter {
          this.forEachPainterInPad(pp => pp.drawActiveBorder(null, pp === pad_painter), "pads");
       }
 
-      if (obj_painter && (obj_painter.snapid!==undefined) && arg) {
+      if ((obj_painter?.snapid !== undefined) && arg) {
          ischanged = true;
          arg.objid = obj_painter.snapid.toString();
       }

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -13,7 +13,7 @@ function setPainterTooltipEnabled(painter, on) {
    if (!painter) return;
 
    let fp = painter.getFramePainter();
-   if (fp && typeof fp.setTooltipEnabled == 'function') {
+   if (typeof fp?.setTooltipEnabled == 'function') {
       fp.setTooltipEnabled(on);
       fp.processFrameTooltipEvent(null);
    }
@@ -28,7 +28,7 @@ function addDragHandler(_painter, arg) {
    if (!settings.MoveResize || isBatchMode()) return;
 
    let painter = _painter, drag_rect = null, pp = painter.getPadPainter();
-   if (pp && pp._fast_drawing) return;
+   if (pp?._fast_drawing) return;
 
    function makeResizeElements(group, handler) {
       function addElement(cursor, d) {
@@ -172,8 +172,7 @@ function addDragHandler(_painter, arg) {
                let rrr = resize_se.node().getBoundingClientRect();
                painter.showContextMenu('main', { clientX: rrr.left, clientY: rrr.top });
             } else if (arg.canselect && (spent <= 600)) {
-               let pp = painter.getPadPainter();
-               if (pp) pp.selectObjectPainter(painter);
+               painter.getPadPainter()?.selectObjectPainter(painter);
             }
          }
       });
@@ -362,7 +361,7 @@ const TooltipHandler = {
 
          if (!pnt || (hints[k].x === undefined) || (hints[k].y === undefined)) continue;
 
-         let dist2 = (pnt.x - hints[k].x) * (pnt.x - hints[k].x) + (pnt.y - hints[k].y) * (pnt.y - hints[k].y);
+         let dist2 = (pnt.x - hints[k].x) ** 2 + (pnt.y - hints[k].y) ** 2;
          if (dist2 < best_dist2) { best_dist2 = dist2; best_hint = hints[k]; }
       }
 
@@ -615,7 +614,7 @@ const FrameInteractive = {
               .property('handlers_set', 0);
 
       let pp = this.getPadPainter(),
-          handlers_set = (pp && pp._fast_drawing) ? 0 : 1;
+          handlers_set = pp?._fast_drawing ? 0 : 1;
 
       if (main_svg.property('handlers_set') != handlers_set) {
          let close_handler = handlers_set ? this.processFrameTooltipEvent.bind(this, null) : null,
@@ -652,7 +651,7 @@ const FrameInteractive = {
 
       let pp = this.getPadPainter(),
           svg = this.getFrameSvg();
-      if ((pp && pp._fast_drawing) || svg.empty())
+      if (pp?._fast_drawing || svg.empty())
          return Promise.resolve(this);
 
       if (for_second_axes) {
@@ -731,24 +730,14 @@ const FrameInteractive = {
 
    /** @summary Handle key press */
    processKeyPress(evnt) {
-      let main = this.selectDom();
-      if (!settings.HandleKeys || main.empty() || (this.enabledKeys === false)) return;
+      const allowed = ["PageUp", "PageDown", "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown", "PrintScreen", "*"];
 
-      let key = "";
-      switch (evnt.keyCode) {
-         case 33: key = "PageUp"; break;
-         case 34: key = "PageDown"; break;
-         case 37: key = "ArrowLeft"; break;
-         case 38: key = "ArrowUp"; break;
-         case 39: key = "ArrowRight"; break;
-         case 40: key = "ArrowDown"; break;
-         case 42: key = "PrintScreen"; break;
-         case 106: key = "*"; break;
-         default: return false;
-      }
+      let main = this.selectDom(),
+          key = evnt.key,
+          pp = this.getPadPainter();
 
-      let pp = this.getPadPainter();
-      if (getActivePad() !== pp) return;
+      if (!settings.HandleKeys || main.empty() || (this.enabledKeys === false) ||
+          (getActivePad() !== pp) || (allowed.indexOf(key) < 0)) return false;
 
       if (evnt.shiftKey) key = "Shift " + key;
       if (evnt.altKey) key = "Alt " + key;
@@ -770,14 +759,14 @@ const FrameInteractive = {
       if (zoom.dleft || zoom.dright) {
          if (!settings.Zooming) return false;
          // in 3dmode with orbit control ignore simple arrows
-         if (this.mode3d && (key.indexOf("Ctrl")!==0)) return false;
+         if (this.mode3d && (key.indexOf("Ctrl") !== 0)) return false;
          this.analyzeMouseWheelEvent(null, zoom, 0.5);
          this.zoom(zoom.name, zoom.min, zoom.max);
          if (zoom.changed) this.zoomChangedInteractive(zoom.name, true);
          evnt.stopPropagation();
          evnt.preventDefault();
       } else {
-         let func = pp && pp.findPadButton ? pp.findPadButton(key) : "";
+         let func = pp?.findPadButton(key);
          if (func) {
             pp.clickPadButton(func);
             evnt.stopPropagation();
@@ -800,7 +789,7 @@ const FrameInteractive = {
 
       // collect tooltips from pad painter - it has list of all drawn objects
       let hints = pp.processPadTooltipEvent(pnt), exact = null, res;
-      for (let k = 0; (k <hints.length) && !exact; ++k)
+      for (let k = 0; (k < hints.length) && !exact; ++k)
          if (hints[k] && hints[k].exact)
             exact = hints[k];
 
@@ -995,13 +984,11 @@ const FrameInteractive = {
             this.processFrameClick(pnt);
             break;
          case 2: {
-            let pp = this.getPadPainter();
-            if (pp) pp.selectObjectPainter(this, null, "xaxis");
+            this.getPadPainter()?.selectObjectPainter(this, null, "xaxis");
             break;
          }
          case 3: {
-            let pp = this.getPadPainter();
-            if (pp) pp.selectObjectPainter(this, null, "yaxis");
+            this.getPadPainter()?.selectObjectPainter(this, null, "yaxis");
             break;
          }
       }
@@ -1250,10 +1237,10 @@ const FrameInteractive = {
       if (this.self_drawaxes) return true;
 
       let pad_painter = this.getPadPainter();
-      if (pad_painter && pad_painter.painters)
+      if (pad_painter?.painters)
          for (let k = 0; k < pad_painter.painters.length; ++k) {
             let subpainter = pad_painter.painters[k];
-            if (subpainter && (subpainter.wheel_zoomy !== undefined))
+            if (subpainter?.wheel_zoomy !== undefined)
                return subpainter.wheel_zoomy;
          }
 
@@ -1327,7 +1314,7 @@ const FrameInteractive = {
             else if (ms.length === 2)
                pnt = { x: ms[0], y: ms[1], touch: false };
 
-            if ((pnt !== null) && (pp !== null)) {
+            if (pnt && pp) {
                pnt.painters = true; // assign painter for every tooltip
                let hints = pp.processPadTooltipEvent(pnt), bestdist = 1000;
                for (let n = 0; n < hints.length; ++n)
@@ -1345,7 +1332,7 @@ const FrameInteractive = {
          } else if ((kind == "x") || (kind == "y") || (kind == "z")) {
             exec_painter = this.getMainPainter(true); // histogram painter delivers items for axis menu
 
-            if (this.v7_frame && exec_painter && typeof exec_painter.v7EvalAttr === 'function')
+            if (this.v7_frame && typeof exec_painter?.v7EvalAttr === 'function')
                exec_painter = null;
          }
       } else if (kind == 'painter' && obj) {
@@ -1870,12 +1857,12 @@ class TFramePainter extends ObjectPainter {
          scale_ymax: use_y2 ? this.scale_y2max : this.scale_ymax,
          swap_xy: this.swap_xy,
          fp: this,
-         revertAxis: function(name, v) {
+         revertAxis(name, v) {
             if ((name == "x") && this.use_x2) name = "x2";
             if ((name == "y") && this.use_y2) name = "y2";
             return this.fp.revertAxis(name, v);
          },
-         axisAsText: function(name, v) {
+         axisAsText(name, v) {
             if ((name == "x") && this.use_x2) name = "x2";
             if ((name == "y") && this.use_y2) name = "y2";
             return this.fp.axisAsText(name, v);
@@ -1927,13 +1914,13 @@ class TFramePainter extends ObjectPainter {
       layer.selectAll(".ygrid").remove();
 
       let pp = this.getPadPainter(),
-          pad = pp ? pp.getRootPad(true) : null,
+          pad = pp?.getRootPad(true),
           h = this.getFrameHeight(),
           w = this.getFrameWidth(),
           grid_style = gStyle.fGridStyle;
 
       // add a grid on x axis, if the option is set
-      if (pad && pad.fGridx && this.x_handle) {
+      if (pad?.fGridx && this.x_handle) {
          let gridx = "";
          for (let n = 0; n < this.x_handle.ticks.length; ++n)
             if (this.swap_xy)
@@ -1944,7 +1931,7 @@ class TFramePainter extends ObjectPainter {
          let colid = (gStyle.fGridColor > 0) ? gStyle.fGridColor : (this.getAxis("x") ? this.getAxis("x").fAxisColor : 1),
              grid_color = this.getColor(colid) || "black";
 
-         if (gridx.length > 0)
+         if (gridx)
            layer.append("svg:path")
                 .attr("class", "xgrid")
                 .attr("d", gridx)
@@ -1954,7 +1941,7 @@ class TFramePainter extends ObjectPainter {
       }
 
       // add a grid on y axis, if the option is set
-      if (pad && pad.fGridy && this.y_handle) {
+      if (pad?.fGridy && this.y_handle) {
          let gridy = "";
          for (let n = 0; n < this.y_handle.ticks.length; ++n)
             if (this.swap_xy)
@@ -1965,7 +1952,7 @@ class TFramePainter extends ObjectPainter {
          let colid = (gStyle.fGridColor > 0) ? gStyle.fGridColor : (this.getAxis("y") ? this.getAxis("y").fAxisColor : 1),
              grid_color = this.getColor(colid) || "black";
 
-         if (gridy.length > 0)
+         if (gridy)
            layer.append("svg:path")
                 .attr("class", "ygrid")
                 .attr("d", gridy)
@@ -2019,10 +2006,8 @@ class TFramePainter extends ObjectPainter {
       let draw_horiz = this.swap_xy ? this.y_handle : this.x_handle,
           draw_vertical = this.swap_xy ? this.x_handle : this.y_handle;
 
-      if (!disable_x_draw || !disable_y_draw) {
-         let pp = this.getPadPainter();
-         if (pp && pp._fast_drawing) disable_x_draw = disable_y_draw = true;
-      }
+      if ((!disable_x_draw || !disable_y_draw) && pp._fast_drawing)
+         disable_x_draw = disable_y_draw = true;
 
       let pr = Promise.resolve(true);
 
@@ -2031,14 +2016,14 @@ class TFramePainter extends ObjectPainter {
          let can_adjust_frame = !shrink_forbidden && settings.CanAdjustFrame;
 
          let pr1 = draw_horiz.drawAxis(layer, w, h,
-                                   draw_horiz.invert_side ? undefined : `translate(0,${h})`,
-                                   pad && pad.fTickx ? -h : 0, disable_x_draw,
-                                   undefined, false);
+                                       draw_horiz.invert_side ? undefined : `translate(0,${h})`,
+                                       pad?.fTickx ? -h : 0, disable_x_draw,
+                                       undefined, false);
 
          let pr2 = draw_vertical.drawAxis(layer, w, h,
-                                      draw_vertical.invert_side ? `translate(${w})` : undefined,
-                                      pad && pad.fTicky ? w : 0, disable_y_draw,
-                                      draw_vertical.invert_side ? 0 : this._frame_x, can_adjust_frame);
+                                          draw_vertical.invert_side ? `translate(${w})` : undefined,
+                                          pad?.fTicky ? w : 0, disable_y_draw,
+                                          draw_vertical.invert_side ? 0 : this._frame_x, can_adjust_frame);
 
          pr = Promise.all([pr1,pr2]).then(() => {
 
@@ -2093,23 +2078,21 @@ class TFramePainter extends ObjectPainter {
       let draw_horiz = this.swap_xy ? this.y2_handle : this.x2_handle,
           draw_vertical = this.swap_xy ? this.x2_handle : this.y2_handle;
 
-      if (draw_horiz || draw_vertical) {
-         let pp = this.getPadPainter();
-         if (pp && pp._fast_drawing) draw_horiz = draw_vertical = null;
-      }
+      if ((draw_horiz || draw_vertical) && pp._fast_drawing)
+         draw_horiz = draw_vertical = null;
 
       let pr1, pr2;
 
       if (draw_horiz)
          pr1 = draw_horiz.drawAxis(layer, w, h,
                                    draw_horiz.invert_side ? undefined : `translate(0,${h})`,
-                                   pad && pad.fTickx ? -h : 0, false,
+                                   pad?.fTickx ? -h : 0, false,
                                    undefined, false);
 
       if (draw_vertical)
          pr2 = draw_vertical.drawAxis(layer, w, h,
                                       draw_vertical.invert_side ? `translate(${w})` : undefined,
-                                      pad && pad.fTicky ? w : 0, false,
+                                      pad?.fTicky ? w : 0, false,
                                       draw_vertical.invert_side ? 0 : this._frame_x, false);
 
        return Promise.all([pr1, pr2]);
@@ -2120,7 +2103,7 @@ class TFramePainter extends ObjectPainter {
      * @private */
    updateAttributes(force) {
       let pp = this.getPadPainter(),
-          pad = pp ? pp.getRootPad(true) : null,
+          pad = pp?.getRootPad(true),
           tframe = this.getObject();
 
       if ((this.fX1NDC === undefined) || (force && !this.modified_NDC)) {
@@ -2147,11 +2130,11 @@ class TFramePainter extends ObjectPainter {
             this.createAttFill({ pattern: 1001, color: 0 });
 
          // force white color for the canvas frame
-         if (!tframe && this.fillatt.empty() && pp && pp.iscan)
+         if (!tframe && this.fillatt.empty() && pp?.iscan)
             this.fillatt.setSolidColor('white');
       }
 
-      if (!tframe && pad && (pad.fFrameLineColor !== undefined))
+      if (!tframe && (pad?.fFrameLineColor !== undefined))
          this.createAttLine({ color: pad.fFrameLineColor, width: pad.fFrameLineWidth, style: pad.fFrameLineStyle });
       else
          this.createAttLine({ attr: tframe, color: 'black' });
@@ -2162,8 +2145,7 @@ class TFramePainter extends ObjectPainter {
      * @private */
    sizeChanged() {
 
-      let pp = this.getPadPainter(),
-          pad = pp ? pp.getRootPad(true) : null;
+      let pad = this.getPadPainter()?.getRootPad(true);
 
       if (pad) {
          pad.fLeftMargin = this.fX1NDC;
@@ -2288,7 +2270,7 @@ class TFramePainter extends ObjectPainter {
       delete this.enabledKeys;
 
       let pp = this.getPadPainter();
-      if (pp && (pp.frame_painter_ref === this))
+      if (pp?.frame_painter_ref === this)
          delete pp.frame_painter_ref;
 
       super.cleanup();
@@ -2386,7 +2368,7 @@ class TFramePainter extends ObjectPainter {
      * @param {number} value - 0 (linear), 1 (log) or 2 (log2) */
    changeAxisLog(axis, value) {
       let pp = this.getPadPainter(),
-          pad = pp ? pp.getRootPad(true) : null;
+          pad = pp?.getRootPad(true);
       if (!pad) return;
 
       pp._interactively_changed = true;
@@ -2420,7 +2402,7 @@ class TFramePainter extends ObjectPainter {
    fillContextMenu(menu, kind, obj) {
       let main = this.getMainPainter(true),
           pp = this.getPadPainter(),
-          pad = pp ? pp.getRootPad(true) : null;
+          pad = pp?.getRootPad(true);
 
       if ((kind == "x") || (kind == "y") || (kind == "z") || (kind == "x2") || (kind == "y2")) {
          let faxis = obj || this[kind+'axis'];
@@ -2438,14 +2420,13 @@ class TFramePainter extends ObjectPainter {
          menu.addchk(faxis.TestBit(EAxisBits.kNoExponent), "No exponent",
                () => { faxis.InvertBit(EAxisBits.kNoExponent); this.redrawPad(); });
 
-         if ((kind === "z") && main && main.options && main.options.Zscale)
-            if (typeof main.fillPaletteMenu == 'function')
-               main.fillPaletteMenu(menu);
+         if ((kind === "z") && main?.options?.Zscale && (typeof main?.fillPaletteMenu == 'function'))
+            main.fillPaletteMenu(menu);
 
          if (faxis) {
             let handle = this[kind+"_handle"];
 
-            if (handle && (handle.kind == "labels") && (faxis.fNbins > 20))
+            if ((handle?.kind == "labels") && (faxis.fNbins > 20))
                menu.add("Find label", () => menu.input("Label id").then(id => {
                   if (!id) return;
                   for (let bin = 0; bin < faxis.fNbins; ++bin) {
@@ -2644,15 +2625,12 @@ class TFramePainter extends ObjectPainter {
          }
 
          // than try to unzoom all overlapped objects
-         if (!changed) {
-            let pp = this.getPadPainter();
-            if (pp && pp.painters)
-               pp.painters.forEach(painter => {
-                  if (painter && (typeof painter.unzoomUserRange == 'function'))
-                     if (painter.unzoomUserRange(unzoom_x, unzoom_y, unzoom_z))
-                        changed = true;
+         if (!changed)
+            this.getPadPainter()?.painters?.forEach(painter => {
+               if (typeof painter?.unzoomUserRange == 'function')
+                  if (painter.unzoomUserRange(unzoom_x, unzoom_y, unzoom_z))
+                     changed = true;
             });
-         }
       }
 
       return changed ? this.interactiveRedraw("pad", "zoom").then(() => true) : Promise.resolve(false);

--- a/js/modules/gui.mjs
+++ b/js/modules/gui.mjs
@@ -36,6 +36,12 @@ function readStyleFromURL(url) {
    get_bool("usestamp", "UseStamp");
    get_bool("dark", "DarkMode");
 
+   let mr = d.get("maxranges");
+   if (mr) {
+      mr = parseInt(mr);
+      if (Number.isInteger(mr)) settings.MaxRanges = mr;
+   }
+
    if (d.has('wrong_http_response'))
       settings.HandleWrongHttpResponse = true;
 

--- a/js/modules/hist/RH1Painter.mjs
+++ b/js/modules/hist/RH1Painter.mjs
@@ -12,11 +12,12 @@ class RH1Painter extends RH1Painter2D {
 
       let main = this.getFramePainter(), // who makes axis drawing
           is_main = this.isMainPainter(), // is main histogram
-          zmult = 1 + 2*gStyle.fHistTopMargin;
+          zmult = 1 + 2*gStyle.fHistTopMargin,
+          pr = Promise.resolve(this);
 
       if (reason == "resize")  {
          if (is_main && main.resize3D()) main.render3D();
-         return Promise.resolve(this);
+         return pr;
       }
 
       this.deleteAttr();
@@ -25,16 +26,17 @@ class RH1Painter extends RH1Painter2D {
 
       if (is_main) {
          assignFrame3DMethods(main);
-         main.create3DScene(this.options.Render3D);
-         main.setAxesRanges(this.getAxis("x"), this.xmin, this.xmax, null, this.ymin, this.ymax, null, 0, 0);
-         main.set3DOptions(this.options);
-         main.drawXYZ(main.toplevel, RAxisPainter, { use_y_for_z: true, zmult, zoom: settings.Zooming, ndim: 1, draw: true, v7: true });
+         pr = main.create3DScene(this.options.Render3D).then(() => {
+            main.setAxesRanges(this.getAxis("x"), this.xmin, this.xmax, null, this.ymin, this.ymax, null, 0, 0);
+            main.set3DOptions(this.options);
+            main.drawXYZ(main.toplevel, RAxisPainter, { use_y_for_z: true, zmult, zoom: settings.Zooming, ndim: 1, draw: true, v7: true });
+         });
       }
 
       if (!main.mode3d)
-         return Promise.resolve(this);
+         return pr;
 
-      return this.drawingBins(reason).then(() => {
+      return pr.then(() => this.drawingBins(reason)).then(() => {
 
          // called when bins received from server, must be reentrant
          let main = this.getFramePainter();

--- a/js/modules/hist/RH3Painter.mjs
+++ b/js/modules/hist/RH3Painter.mjs
@@ -94,9 +94,9 @@ class RH3Painter extends RHistPainter {
                   stat_sumx1 += xx * cont;
                   stat_sumy1 += yy * cont;
                   stat_sumz1 += zz * cont;
-                  stat_sumx2 += xx * xx * cont;
-                  stat_sumy2 += yy * yy * cont;
-                  stat_sumz2 += zz * zz * cont;
+                  stat_sumx2 += xx**2 * cont;
+                  stat_sumy2 += yy**2 * cont;
+                  stat_sumz2 += zz**2 * cont;
                }
             }
          }
@@ -116,9 +116,9 @@ class RH3Painter extends RHistPainter {
          res.meanx = stat_sumx1 / stat_sum0;
          res.meany = stat_sumy1 / stat_sum0;
          res.meanz = stat_sumz1 / stat_sum0;
-         res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx * res.meanx));
-         res.rmsy = Math.sqrt(Math.abs(stat_sumy2 / stat_sum0 - res.meany * res.meany));
-         res.rmsz = Math.sqrt(Math.abs(stat_sumz2 / stat_sum0 - res.meanz * res.meanz));
+         res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx**2));
+         res.rmsy = Math.sqrt(Math.abs(stat_sumy2 / stat_sum0 - res.meany**2));
+         res.rmsz = Math.sqrt(Math.abs(stat_sumz2 / stat_sum0 - res.meanz**2));
       }
 
       res.integral = stat_sum0;
@@ -623,14 +623,12 @@ class RH3Painter extends RHistPainter {
       }
 
       assignFrame3DMethods(main);
-      main.create3DScene(this.options.Render3D);
-      main.setAxesRanges(this.getAxis("x"), this.xmin, this.xmax, this.getAxis("y"), this.ymin, this.ymax, this.getAxis("z"), this.zmin, this.zmax);
-      main.set3DOptions(this.options);
-      main.drawXYZ(main.toplevel, RAxisPainter, { zoom: settings.Zooming, ndim: 3, draw: true, v7: true });
-
-      return this.drawingBins(reason)
-            .then(() => this.draw3D()) // called when bins received from server, must be reentrant
-            .then(() => {
+      return main.create3DScene(this.options.Render3D).then(() => {
+         main.setAxesRanges(this.getAxis("x"), this.xmin, this.xmax, this.getAxis("y"), this.ymin, this.ymax, this.getAxis("z"), this.zmin, this.zmax);
+         main.set3DOptions(this.options);
+         main.drawXYZ(main.toplevel, RAxisPainter, { zoom: settings.Zooming, ndim: 3, draw: true, v7: true });
+         return this.drawingBins(reason);
+      }).then(() => this.draw3D()).then(() => {
          main.render3D();
          main.addKeysHandler();
          return this;

--- a/js/modules/hist/RPavePainter.mjs
+++ b/js/modules/hist/RPavePainter.mjs
@@ -304,7 +304,7 @@ class RHistStatsPainter extends RPavePainter {
    /** @summary fill statistic */
    fillStatistic() {
       let pp = this.getPadPainter();
-      if (pp && pp._fast_drawing) return false;
+      if (pp?._fast_drawing) return false;
 
       let obj = this.getObject();
       if (obj.fLines !== undefined) {
@@ -315,7 +315,7 @@ class RHistStatsPainter extends RPavePainter {
 
       if (this.v7OfflineMode()) {
          let main = this.getMainPainter();
-         if (!main || (typeof main.fillStatistic !== 'function')) return false;
+         if (typeof main?.fillStatistic !== 'function') return false;
          // we take statistic from main painter
          return main.fillStatistic(this, gStyle.fOptStat, gStyle.fOptFit);
       }
@@ -443,7 +443,7 @@ class RHistStatsPainter extends RPavePainter {
                   align: (n == 0) ? "start" : "end", x: margin_x, y: posy,
                   width: width-2*margin_x, height: stepy, text: parts[n], draw_g: text_g,
                   _expected_width: width-2*margin_x, _args: args,
-                  post_process: function(painter) {
+                  post_process(painter) {
                     if (this._args[0].ready && this._args[1].ready)
                        painter.scaleTextDrawing(1.05*(this._args[0].result_width && this._args[1].result_width)/this.__expected_width, this.draw_g);
                   }

--- a/js/modules/hist/TF1Painter.mjs
+++ b/js/modules/hist/TF1Painter.mjs
@@ -251,7 +251,7 @@ class TF1Painter extends ObjectPainter {
 
       res.changed = gbin.property("current_bin") !== best;
       res.menu = res.exact;
-      res.menu_dist = Math.sqrt((bin.grx-pnt.x)*(bin.grx-pnt.x) + (bin.gry-pnt.y)*(bin.gry-pnt.y));
+      res.menu_dist = Math.sqrt((bin.grx-pnt.x)**2 + (bin.gry-pnt.y)**2);
 
       if (res.changed)
          gbin.attr("cx", bin.grx)
@@ -262,7 +262,7 @@ class TF1Painter extends ObjectPainter {
       if (name.length > 0) res.lines.push(name);
 
       let pmain = this.getFramePainter(),
-          funcs = pmain ? pmain.getGrFuncs(this.second_x, this.second_y) : null;
+          funcs = pmain?.getGrFuncs(this.second_x, this.second_y);
       if (funcs)
          res.lines.push("x = " + funcs.axisAsText("x",bin.x) + " y = " + funcs.axisAsText("y",bin.y));
 

--- a/js/modules/hist/TGraphTimePainter.mjs
+++ b/js/modules/hist/TGraphTimePainter.mjs
@@ -42,7 +42,7 @@ class TGraphTimePainter extends ObjectPainter {
          this._doing_primitives = true;
       }
 
-      let lst = this.getObject().fSteps.arr[this.step];
+      let lst = this.getObject()?.fSteps.arr[this.step];
 
       if (!lst || (indx >= lst.arr.length)) {
          delete this._doing_primitives;

--- a/js/modules/hist/TH1Painter.mjs
+++ b/js/modules/hist/TH1Painter.mjs
@@ -31,23 +31,25 @@ class TH1Painter extends TH1Painter2D {
 
          if (is_main) {
             assignFrame3DMethods(main);
-            main.create3DScene(this.options.Render3D, this.options.x3dscale, this.options.y3dscale);
-            main.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
-            main.set3DOptions(this.options);
-            main.drawXYZ(main.toplevel, TAxisPainter, { use_y_for_z: true, zmult, zoom: settings.Zooming, ndim: 1, draw: this.options.Axis !== -1 });
+            pr = main.create3DScene(this.options.Render3D, this.options.x3dscale, this.options.y3dscale).then(() => {
+               main.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, 0, 0);
+               main.set3DOptions(this.options);
+               main.drawXYZ(main.toplevel, TAxisPainter, { use_y_for_z: true, zmult, zoom: settings.Zooming, ndim: 1, draw: this.options.Axis !== -1 });
+            });
          }
 
-         if (main.mode3d) {
-            drawBinsLego(this);
-            main.render3D();
-            this.updateStatWebCanvas();
-            main.addKeysHandler();
-         }
+         if (main.mode3d)
+            pr = pr.then(() => {
+               drawBinsLego(this);
+               main.render3D();
+               this.updateStatWebCanvas();
+               main.addKeysHandler();
+            });
       }
 
       if (is_main)
-         pr = this.drawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14)))
-                  .then(() => this.drawHistTitle());
+         pr = pr.then(() => this.drawColorPalette(this.options.Zscale && ((this.options.Lego===12) || (this.options.Lego===14))))
+                .then(() => this.drawHistTitle());
 
       return pr.then(() => this);
    }

--- a/js/modules/hist/TH2Painter.mjs
+++ b/js/modules/hist/TH2Painter.mjs
@@ -232,35 +232,37 @@ class TH2Painter extends TH2Painter2D {
 
          if (is_main) {
             assignFrame3DMethods(main);
-            main.create3DScene(this.options.Render3D, this.options.x3dscale, this.options.y3dscale);
-            main.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, this.zmin, this.zmax);
-            main.set3DOptions(this.options);
-            main.drawXYZ(main.toplevel, TAxisPainter, { zmult, zoom: settings.Zooming, ndim: 2, draw: this.options.Axis !== -1 });
+            pr = main.create3DScene(this.options.Render3D, this.options.x3dscale, this.options.y3dscale).then(() => {
+               main.setAxesRanges(histo.fXaxis, this.xmin, this.xmax, histo.fYaxis, this.ymin, this.ymax, histo.fZaxis, this.zmin, this.zmax);
+               main.set3DOptions(this.options);
+               main.drawXYZ(main.toplevel, TAxisPainter, { zmult, zoom: settings.Zooming, ndim: 2, draw: this.options.Axis !== -1 });
+            });
          }
 
-         if (main.mode3d) {
-            if (this.draw_content) {
-               if (this.isTH2Poly())
-                  drawTH2PolyLego(this);
-               else if (this.options.Contour)
-                  drawBinsContour3D(this, true);
-               else if (this.options.Surf)
-                  drawBinsSurf3D(this);
-               else if (this.options.Error)
-                  drawBinsError3D(this);
-               else
-                  drawBinsLego(this);
-            }
-            main.render3D();
-            this.updateStatWebCanvas();
-            main.addKeysHandler();
-         }
+         if (main.mode3d)
+            pr = pr.then(() => {
+               if (this.draw_content) {
+                  if (this.isTH2Poly())
+                     drawTH2PolyLego(this);
+                  else if (this.options.Contour)
+                     drawBinsContour3D(this, true);
+                  else if (this.options.Surf)
+                     drawBinsSurf3D(this);
+                  else if (this.options.Error)
+                     drawBinsError3D(this);
+                  else
+                     drawBinsLego(this);
+               }
+               main.render3D();
+               this.updateStatWebCanvas();
+               main.addKeysHandler();
+            });
       }
 
       //  (re)draw palette by resize while canvas may change dimension
       if (is_main)
-         pr = this.drawColorPalette(this.options.Zscale && ((this.options.Lego == 12) || (this.options.Lego == 14) ||
-                                     (this.options.Surf == 11) || (this.options.Surf == 12))).then(() => this.drawHistTitle());
+         pr = pr.then(() => this.drawColorPalette(this.options.Zscale && ((this.options.Lego == 12) || (this.options.Lego == 14) ||
+                                     (this.options.Surf == 11) || (this.options.Surf == 12)))).then(() => this.drawHistTitle());
 
       return pr.then(() => this);
    }

--- a/js/modules/hist/THStackPainter.mjs
+++ b/js/modules/hist/THStackPainter.mjs
@@ -27,8 +27,7 @@ class THStackPainter extends ObjectPainter {
 
    /** @summary Cleanup THStack painter */
    cleanup() {
-      let pp = this.getPadPainter();
-      if (pp) pp.cleanPrimitives(objp => { return (objp === this.firstpainter) || (this.painters.indexOf(objp) >= 0); });
+      this.getPadPainter()?.cleanPrimitives(objp => { return (objp === this.firstpainter) || (this.painters.indexOf(objp) >= 0); });
       delete this.firstpainter;
       delete this.painters;
       super.cleanup();
@@ -165,7 +164,7 @@ class THStackPainter extends ObjectPainter {
 
       if (this.options._pfc || this.options._plc || this.options._pmc) {
          let mp = this.getMainPainter();
-         if (mp && mp.createAutoColor) {
+         if (typeof mp?.createAutoColor == 'function') {
             let icolor = mp.createAutoColor(nhists);
             if (this.options._pfc) hist.fFillColor = icolor;
             if (this.options._plc) hist.fLineColor = icolor;
@@ -325,8 +324,7 @@ class THStackPainter extends ObjectPainter {
           nhists = (hlst && hlst.arr) ? hlst.arr.length : 0;
 
       if (nhists !== this.painters.length) {
-         let pp = this.getPadPainter();
-         if (pp) pp.cleanPrimitives(objp => { return this.painters.indexOf(objp) >= 0; });
+         this.getPadPainter()?.cleanPrimitives(objp => { return this.painters.indexOf(objp) >= 0; });
          this.painters = [];
          this.did_update = true;
       } else {
@@ -366,8 +364,8 @@ class THStackPainter extends ObjectPainter {
 
          if (painter.options.pads) {
             pad_painter = painter.getPadPainter();
-            if (pad_painter.doingDraw() && pad_painter.pad && pad_painter.pad.fPrimitives &&
-                pad_painter.pad.fPrimitives.arr.length > 1 && (pad_painter.pad.fPrimitives.arr.indexOf(stack)==0)) {
+            if (pad_painter.doingDraw() && pad_painter.pad?.fPrimitives &&
+                pad_painter.pad.fPrimitives.arr.length > 1 && (pad_painter.pad.fPrimitives.arr.indexOf(stack) == 0)) {
                skip_drawing = true;
                console.log('special case with THStack with is already rendered - do nothing');
                return;

--- a/js/modules/hist2d/RH1Painter.mjs
+++ b/js/modules/hist2d/RH1Painter.mjs
@@ -109,7 +109,7 @@ class RH1Painter extends RHistPainter {
           stat_sumw = 0, stat_sumwx = 0, stat_sumwx2 = 0, stat_sumwy = 0, stat_sumwy2 = 0,
           i, xx = 0, w = 0, xmax = null, wmax = null,
           fp = this.getFramePainter(),
-          res = { name: "histo", meanx: 0, meany: 0, rmsx: 0, rmsy: 0, integral: 0, entries: this.stat_entries, xmax:0, wmax:0 };
+          res = { name: "histo", meanx: 0, meany: 0, rmsx: 0, rmsy: 0, integral: 0, entries: this.stat_entries, xmax: 0, wmax: 0 };
 
       for (i = left; i < right; ++i) {
          xx = xaxis.GetBinCoord(i+0.5);
@@ -122,7 +122,7 @@ class RH1Painter extends RHistPainter {
 
          stat_sumw += w;
          stat_sumwx += w * xx;
-         stat_sumwx2 += w * xx * xx;
+         stat_sumwx2 += w * xx**2;
       }
 
       // when no range selection done, use original statistic from histogram
@@ -137,8 +137,8 @@ class RH1Painter extends RHistPainter {
       if (stat_sumw > 0) {
          res.meanx = stat_sumwx / stat_sumw;
          res.meany = stat_sumwy / stat_sumw;
-         res.rmsx = Math.sqrt(Math.abs(stat_sumwx2 / stat_sumw - res.meanx * res.meanx));
-         res.rmsy = Math.sqrt(Math.abs(stat_sumwy2 / stat_sumw - res.meany * res.meany));
+         res.rmsx = Math.sqrt(Math.abs(stat_sumwx2 / stat_sumw - res.meanx**2));
+         res.rmsy = Math.sqrt(Math.abs(stat_sumwy2 / stat_sumw - res.meany**2));
       }
 
       if (xmax !== null) {
@@ -832,7 +832,7 @@ class RH1Painter extends RHistPainter {
 
          res.menu = res.exact; // one could show context menu
          // distance to middle point, use to decide which menu to activate
-         res.menu_dist = Math.sqrt((midx-pnt_x)*(midx-pnt_x) + (midy-pnt_y)*(midy-pnt_y));
+         res.menu_dist = Math.sqrt((midx-pnt_x)**2 + (midy-pnt_y)**2);
 
       } else {
          let radius = this.lineatt.width + 3;
@@ -848,7 +848,7 @@ class RH1Painter extends RHistPainter {
          res.exact = (Math.abs(midx - pnt.x) <= radius) && (Math.abs(midy - pnt.y) <= radius);
 
          res.menu = res.exact; // show menu only when mouse pointer exactly over the histogram
-         res.menu_dist = Math.sqrt((midx-pnt.x)*(midx-pnt.x) + (midy-pnt.y)*(midy-pnt.y));
+         res.menu_dist = Math.sqrt((midx-pnt.x)**2 + (midy-pnt.y)**2);
 
          res.changed = ttrect.property("current_bin") !== findbin;
 

--- a/js/modules/hist2d/RH2Painter.mjs
+++ b/js/modules/hist2d/RH2Painter.mjs
@@ -274,16 +274,16 @@ class RH2Painter extends RHistPainter {
             stat_sum0 += zz;
             stat_sumx1 += xx * zz;
             stat_sumy1 += yy * zz;
-            stat_sumx2 += xx * xx * zz;
-            stat_sumy2 += yy * yy * zz;
+            stat_sumx2 += xx**2 * zz;
+            stat_sumy2 += yy**2 * zz;
          }
       }
 
       if (stat_sum0 > 0) {
          res.meanx = stat_sumx1 / stat_sum0;
          res.meany = stat_sumy1 / stat_sum0;
-         res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx * res.meanx));
-         res.rmsy = Math.sqrt(Math.abs(stat_sumy2 / stat_sum0 - res.meany * res.meany));
+         res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx**2));
+         res.rmsy = Math.sqrt(Math.abs(stat_sumy2 / stat_sum0 - res.meany**2));
       }
 
       if (res.wmax === null) res.wmax = 0;
@@ -324,7 +324,7 @@ class RH2Painter extends RHistPainter {
       }
 
       if (print_integral > 0)
-         stat.addText("Integral = " + stat.format(data.matrix[4],"entries"));
+         stat.addText("Integral = " + stat.format(data.matrix[4], "entries"));
 
       if (print_skew > 0) {
          stat.addText("Skewness x = <undef>");
@@ -737,7 +737,7 @@ class RH2Painter extends RHistPainter {
          bin._sumx = bin._sumy = bin._suml = 0;
 
       function addPoint(x1,y1,x2,y2) {
-         let len = Math.sqrt((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2));
+         let len = Math.sqrt((x1-x2)**2 + (y1-y2)**2);
          bin._sumx += (x1+x2)*len/2;
          bin._sumy += (y1+y2)*len/2;
          bin._suml += len;
@@ -895,7 +895,7 @@ class RH2Painter extends RHistPainter {
                      cmd += "M"+Math.round(x1)+","+Math.round(y1) + makeLine(dx,dy);;
 
                      if (Math.abs(dx) > 5 || Math.abs(dy) > 5) {
-                        anr = Math.sqrt(2/(dx*dx + dy*dy));
+                        anr = Math.sqrt(2/(dx**2 + dy**2));
                         si  = Math.round(anr*(dx + dy));
                         co  = Math.round(anr*(dx - dy));
                         if (si || co)
@@ -1428,7 +1428,7 @@ class RH2Painter extends RHistPainter {
          const realx = pmain.revertAxis("x", pnt.x),
                realy = pmain.revertAxis("y", pnt.y);
 
-         if ((realx!==undefined) && (realy!==undefined)) {
+         if ((realx !== undefined) && (realy !== undefined)) {
             const len = histo.fBins.arr.length;
 
             for (let i = 0; (i < len) && (foundindx < 0); ++ i) {

--- a/js/modules/hist2d/RHistPainter.mjs
+++ b/js/modules/hist2d/RHistPainter.mjs
@@ -221,7 +221,7 @@ class RHistPainter extends RObjectPainter {
    /** @summary Clear 3d drawings - if any */
    clear3DScene() {
       let fp = this.getFramePainter();
-      if (fp && typeof fp.create3DScene === 'function')
+      if (typeof fp?.create3DScene === 'function')
          fp.create3DScene(-1);
       this.mode3d = false;
    }
@@ -605,11 +605,11 @@ class RHistPainter extends RObjectPainter {
    changeValuesRange(menu, arg) {
       let pmain = this.getFramePainter();
       if (!pmain) return;
-      let prefix = pmain.isAxisZoomed(arg) ? "zoom_" + arg : arg;
-      let curr = "[" + pmain[prefix+'min'] + "," + pmain[prefix+'max'] + "]";
+      let prefix = pmain.isAxisZoomed(arg) ? "zoom_" + arg : arg,
+          curr = "[" + pmain[prefix+'min'] + "," + pmain[prefix+'max'] + "]";
       menu.input("Enter values range for axis " + arg + " like [0,100] or empty string to unzoom", curr).then(res => {
          res = res ? JSON.parse(res) : [];
-         if (!res || (typeof res != "object") || (res.length!=2) || !Number.isFinite(res[0]) || !Number.isFinite(res[1]))
+         if (!res || (typeof res != "object") || (res.length != 2) || !Number.isFinite(res[0]) || !Number.isFinite(res[1]))
             pmain.unzoom(arg);
          else
             pmain.zoom(arg, res[0], res[1]);
@@ -648,7 +648,7 @@ class RHistPainter extends RObjectPainter {
             if (!fp.enable_highlight && main.highlightBin3D && main.mode3d) main.highlightBin3D(null);
          });
 
-         if (fp && fp.render3D) {
+         if (typeof fp?.render3D == 'function') {
             menu.addchk(main.options.FrontBox, 'Front box', () => {
                main.options.FrontBox = !main.options.FrontBox;
                fp.render3D();
@@ -665,12 +665,13 @@ class RHistPainter extends RObjectPainter {
                this.redrawPad();
             });
 
-            if ((this.options.Lego==12) || (this.options.Lego==14)) {
-               if (this.fillPaletteMenu) this.fillPaletteMenu(menu);
+            if ((this.options.Lego == 12) || (this.options.Lego == 14)) {
+               if (this.fillPaletteMenu)
+                  this.fillPaletteMenu(menu);
             }
          }
 
-         if (main.control && typeof main.control.reset === 'function')
+         if (typeof main.control?.reset === 'function')
             menu.add('Reset camera', () => main.control.reset());
       }
 
@@ -684,10 +685,8 @@ class RHistPainter extends RObjectPainter {
 
    /** @summary Update palette drawing */
    updatePaletteDraw() {
-      if (this.isMainPainter()) {
-         let pp = this.getPadPainter().findPainterFor(undefined, undefined, "ROOT::Experimental::RPaletteDrawable");
-         if (pp) pp.drawPalette();
-      }
+      if (this.isMainPainter())
+         this.getPadPainter().findPainterFor(undefined, undefined, "ROOT::Experimental::RPaletteDrawable")?.drawPalette();
    }
 
    /** @summary Fill menu entries for palette */

--- a/js/modules/hist2d/TH1Painter.mjs
+++ b/js/modules/hist2d/TH1Painter.mjs
@@ -177,7 +177,7 @@ class TH1Painter extends THistPainter {
 
          stat_sumw += w;
          stat_sumwx += w * xx;
-         stat_sumwx2 += w * xx * xx;
+         stat_sumwx2 += w * xx**2;
       }
 
       // when no range selection done, use original statistic from histogram
@@ -192,11 +192,11 @@ class TH1Painter extends THistPainter {
       if (stat_sumw > 0) {
          res.meanx = stat_sumwx / stat_sumw;
          res.meany = stat_sumwy / stat_sumw;
-         res.rmsx = Math.sqrt(Math.abs(stat_sumwx2 / stat_sumw - res.meanx * res.meanx));
-         res.rmsy = Math.sqrt(Math.abs(stat_sumwy2 / stat_sumw - res.meany * res.meany));
+         res.rmsx = Math.sqrt(Math.abs(stat_sumwx2 / stat_sumw - res.meanx**2));
+         res.rmsy = Math.sqrt(Math.abs(stat_sumwy2 / stat_sumw - res.meany**2));
       }
 
-      if (xmax!==null) {
+      if (xmax !== null) {
          res.xmax = xmax;
          res.wmax = wmax;
       }
@@ -550,7 +550,7 @@ class TH1Painter extends THistPainter {
             if (show_text) {
                let cont = text_profile ? histo.fBinEntries[bin+1] : bincont;
 
-               if (cont!==0) {
+               if (cont !== 0) {
                   let lbl = (cont === Math.round(cont)) ? cont.toString() : floatToString(cont, gStyle.fPaintTextFormat);
 
                   if (text_angle)
@@ -618,7 +618,7 @@ class TH1Painter extends THistPainter {
             bestimin = bestimax = i;
             prevx = startx = currx = grx;
             prevy = curry_min = curry_max = curry = gry;
-            res = "M"+currx+","+curry;
+            res = `M${currx},${curry}`;
          } else if (use_minmax) {
             if ((grx === currx) && !lastbin) {
                if (gry < curry_min) bestimax = i; else
@@ -661,7 +661,7 @@ class TH1Painter extends THistPainter {
                }
 
                if (lastbin && (prevx !== grx))
-                  res += "h"+(grx-prevx);
+                  res += "h" + (grx-prevx);
 
                bestimin = bestimax = i;
                curry_min = curry_max = curry = gry;
@@ -748,7 +748,7 @@ class TH1Painter extends THistPainter {
           cont = histo.getBinContent(bin+1),
           xlbl = this.getAxisBinTip("x", histo.fXaxis, bin);
 
-      if (name.length > 0) tips.push(name);
+      if (name) tips.push(name);
 
       if (this.options.Error || this.options.Mark) {
          tips.push("x = " + xlbl);
@@ -779,10 +779,10 @@ class TH1Painter extends THistPainter {
       }
 
       const pmain = this.getFramePainter(),
-           funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
-           histo = this.getHisto(),
-           left = this.getSelectIndex("x", "left", -1),
-           right = this.getSelectIndex("x", "right", 2);
+            funcs = pmain.getGrFuncs(this.options.second_x, this.options.second_y),
+            histo = this.getHisto(),
+            left = this.getSelectIndex("x", "left", -1),
+            right = this.getSelectIndex("x", "right", 2);
       let width = pmain.getFrameWidth(),
           height = pmain.getFrameHeight(),
           findbin = null, show_rect,
@@ -860,7 +860,7 @@ class TH1Painter extends THistPainter {
 
          gapx = 0;
 
-         gry1 = Math.round(funcs.gry(((this.options.BaseLine!==false) && (this.options.BaseLine > funcs.scale_ymin)) ? this.options.BaseLine : funcs.scale_ymin));
+         gry1 = Math.round(funcs.gry(((this.options.BaseLine !== false) && (this.options.BaseLine > funcs.scale_ymin)) ? this.options.BaseLine : funcs.scale_ymin));
 
          if (gry1 > gry2) { let d = gry1; gry1 = gry2; gry2 = d; }
 
@@ -968,7 +968,7 @@ class TH1Painter extends THistPainter {
 
          res.menu = res.exact; // one could show context menu when histogram is selected
          // distance to middle point, use to decide which menu to activate
-         res.menu_dist = Math.sqrt((midx-pnt_x)*(midx-pnt_x) + (midy-pnt_y)*(midy-pnt_y));
+         res.menu_dist = Math.sqrt((midx-pnt_x)**2 + (midy-pnt_y)**2);
 
       } else {
          let radius = this.lineatt.width + 3;
@@ -984,7 +984,7 @@ class TH1Painter extends THistPainter {
          res.exact = (Math.abs(midx - pnt.x) <= radius) && (Math.abs(midy - pnt.y) <= radius);
 
          res.menu = res.exact; // show menu only when mouse pointer exactly over the histogram
-         res.menu_dist = Math.sqrt((midx-pnt.x)*(midx-pnt.x) + (midy-pnt.y)*(midy-pnt.y));
+         res.menu_dist = Math.sqrt((midx-pnt.x)**2 + (midy-pnt.y)**2);
 
          res.changed = ttrect.property("current_bin") !== findbin;
 

--- a/js/modules/hist2d/TH2Painter.mjs
+++ b/js/modules/hist2d/TH2Painter.mjs
@@ -73,7 +73,7 @@ class TH2Painter extends THistPainter {
 
       if (canp && !canp._readonly && (this.snapid !== undefined)) {
          // this is when projection should be created on the server side
-         let exec = "EXECANDSEND:D" + this.is_projection + "PROJ:" + this.snapid + ":";
+         let exec = `EXECANDSEND:D${this.is_projection}PROJ:${this.snapid}:`;
          if (this.is_projection == "X")
             exec += `ProjectionX("_projx",${jj1+1},${jj2},"")`;
          else
@@ -101,7 +101,8 @@ class TH2Painter extends THistPainter {
       if (this.is_projection == "X") {
          for (let i = 0; i < this.nbinsx; ++i) {
             let sum = 0;
-            for (let j = jj1; j < jj2; ++j) sum += histo.getBinContent(i+1,j+1);
+            for (let j = jj1; j < jj2; ++j)
+               sum += histo.getBinContent(i+1,j+1);
             this.proj_hist.setBinContent(i+1, sum);
          }
          this.proj_hist.fTitle = "X projection " + (jj1+1 == jj2 ? `bin ${jj2}` : `bins [${jj1+1} .. ${jj2}]`);
@@ -110,7 +111,8 @@ class TH2Painter extends THistPainter {
       } else {
          for (let j = 0; j < this.nbinsy; ++j) {
             let sum = 0;
-            for (let i = ii1; i < ii2; ++i) sum += histo.getBinContent(i+1,j+1);
+            for (let i = ii1; i < ii2; ++i)
+               sum += histo.getBinContent(i+1,j+1);
             this.proj_hist.setBinContent(j+1, sum);
          }
          this.proj_hist.fTitle = "Y projection " + (ii1+1 == ii2 ? `bin ${ii2}` : `bins [${ii1+1} .. ${ii2}]`);
@@ -383,7 +385,7 @@ class TH2Painter extends THistPainter {
 
             if (cond && !cond(xx,yy)) continue;
 
-            if ((res.wmax===null) || (zz>res.wmax)) { res.wmax = zz; res.xmax = xx; res.ymax = yy; }
+            if ((res.wmax === null) || (zz > res.wmax)) { res.wmax = zz; res.xmax = xx; res.ymax = yy; }
 
             stat_sum0 += zz;
             stat_sumx1 += xx * zz;
@@ -416,13 +418,13 @@ class TH2Painter extends THistPainter {
 
                if (cond && !cond(xx,yy)) continue;
 
-               if ((res.wmax===null) || (zz>res.wmax)) { res.wmax = zz; res.xmax = xx; res.ymax = yy; }
+               if ((res.wmax === null) || (zz > res.wmax)) { res.wmax = zz; res.xmax = xx; res.ymax = yy; }
 
                stat_sum0 += zz;
                stat_sumx1 += xx * zz;
                stat_sumy1 += yy * zz;
-               stat_sumx2 += xx * xx * zz;
-               stat_sumy2 += yy * yy * zz;
+               stat_sumx2 += xx**2 * zz;
+               stat_sumy2 += yy**2 * zz;
                // stat_sumxy += xx * yy * zz;
             }
          }
@@ -440,8 +442,8 @@ class TH2Painter extends THistPainter {
       if (stat_sum0 > 0) {
          res.meanx = stat_sumx1 / stat_sum0;
          res.meany = stat_sumy1 / stat_sum0;
-         res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx * res.meanx));
-         res.rmsy = Math.sqrt(Math.abs(stat_sumy2 / stat_sum0 - res.meany * res.meany));
+         res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx**2));
+         res.rmsy = Math.sqrt(Math.abs(stat_sumy2 / stat_sum0 - res.meany**2));
       }
 
       if (res.wmax===null) res.wmax = 0;
@@ -1006,7 +1008,7 @@ class TH2Painter extends THistPainter {
          bin._sumx = bin._sumy = bin._suml = 0;
 
       const addPoint = (x1,y1,x2,y2) => {
-         const len = Math.sqrt((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2));
+         const len = Math.sqrt((x1-x2)**2 + (y1-y2)**2);
          bin._sumx += (x1+x2)*len/2;
          bin._sumy += (y1+y2)*len/2;
          bin._suml += len;
@@ -1275,7 +1277,7 @@ class TH2Painter extends THistPainter {
                      cmd += "M"+Math.round(x1)+","+Math.round(y1) + makeLine(dx,dy);
 
                      if (Math.abs(dx) > 5 || Math.abs(dy) > 5) {
-                        anr = Math.sqrt(9/(dx*dx + dy*dy));
+                        anr = Math.sqrt(9/(dx**2 + dy**2));
                         si  = Math.round(anr*(dx + dy));
                         co  = Math.round(anr*(dx - dy));
                         if (si || co)
@@ -1321,8 +1323,9 @@ class TH2Painter extends THistPainter {
       if (pad && pad.fLogz && (absmax > 0)) {
          uselogz = true;
          let logmax = Math.log(absmax);
-         if (absmin>0) logmin = Math.log(absmin); else
-         if ((main.minposbin>=1) && (main.minposbin<100))
+         if (absmin > 0)
+            logmin = Math.log(absmin);
+         else if ((main.minposbin>=1) && (main.minposbin<100))
             logmin = Math.log(0.7);
          else
             logmin = (main.minposbin > 0) ? Math.log(0.7*main.minposbin) : logmax - 10;
@@ -1810,26 +1813,26 @@ class TH2Painter extends THistPainter {
              .style("stroke", this.getColor(histo.fFillColor));
 
       let hline_color = (isOption(kHistoZeroIndicator) && (histo.fFillStyle != 0)) ? this.fillatt.color : this.lineatt.color;
-      if ((hists.length > 0) && (!this.fillatt.empty() || (hline_color != 'none')))
+      if (hists && (!this.fillatt.empty() || (hline_color != 'none')))
          this.draw_g.append("svg:path")
              .attr("d", hists)
              .style("stroke", (hline_color != 'none') ? hline_color : null)
-             .style("pointer-events",isBatchMode() ? null : "visibleFill")
+             .style("pointer-events", isBatchMode() ? null : "visibleFill")
              .call(this.fillatt.func);
 
-      if (bars.length > 0)
+      if (bars)
          this.draw_g.append("svg:path")
              .attr("d", bars)
              .call(this.lineatt.func)
              .call(this.fillatt.func);
 
-      if (lines.length > 0)
+      if (lines)
          this.draw_g.append("svg:path")
              .attr("d", lines)
              .call(this.lineatt.func)
              .style('fill','none');
 
-      if (dashed_lines.length > 0) {
+      if (dashed_lines) {
          let dashed = new TAttLineHandler({ attr: histo, style: 2 });
          this.draw_g.append("svg:path")
              .attr("d", dashed_lines)
@@ -1837,12 +1840,12 @@ class TH2Painter extends THistPainter {
              .style('fill','none');
       }
 
-      if (cmarkers.length > 0)
+      if (cmarkers)
          this.draw_g.append("svg:path")
              .attr("d", cmarkers)
              .call(attrcmarkers.func);
 
-      if (markers.length > 0)
+      if (markers)
          this.draw_g.append("svg:path")
              .attr("d", markers)
              .call(this.markeratt.func);
@@ -2066,15 +2069,15 @@ class TH2Painter extends THistPainter {
       let pnts = [];
 
       for (let n = 0; n < nbins; n++) {
-         let angle = (0.5 - n/nbins)*Math.PI*2,
-             cx = Math.round((0.9*rect.width/2 - 2*circle_size) * Math.cos(angle)),
-             cy = Math.round((0.9*rect.height/2 - 2*circle_size) * Math.sin(angle)),
-             x = Math.round(0.9*rect.width/2 * Math.cos(angle)),
-             y = Math.round(0.9*rect.height/2 * Math.sin(angle)),
-             rotate = Math.round(angle/Math.PI*180), align = 12,
+         let a = (0.5 - n/nbins)*Math.PI*2,
+             cx = Math.round((0.9*rect.width/2 - 2*circle_size) * Math.cos(a)),
+             cy = Math.round((0.9*rect.height/2 - 2*circle_size) * Math.sin(a)),
+             x = Math.round(0.9*rect.width/2 * Math.cos(a)),
+             y = Math.round(0.9*rect.height/2 * Math.sin(a)),
+             rotate = Math.round(a/Math.PI*180), align = 12,
              color = palette ? palette.calcColor(n, nbins) : 'black';
 
-         pnts.push({x: cx, y: cy, a: angle, color: color }); // remember points coordinates
+         pnts.push({ x: cx, y: cy, a, color }); // remember points coordinates
 
          if ((rotate < -90) || (rotate > 90)) { rotate += 180; align = 32; }
 
@@ -2085,7 +2088,7 @@ class TH2Painter extends THistPainter {
                     .style('stroke', color)
                     .style('fill','none');
 
-         this.drawText({ align, rotate, text: getBinLabel(n), x, y });
+         this.drawText({ align, rotate, x, y, text: getBinLabel(n)});
       }
 
       let max_width = circle_size/2, max_value = 0, min_value = 0;
@@ -2328,10 +2331,10 @@ class TH2Painter extends THistPainter {
          let gr = bin.fPoly, numgraphs = 1;
          if (gr._typename === 'TMultiGraph') { numgraphs = bin.fPoly.fGraphs.arr.length; gr = null; }
 
-         for (let ngr=0;ngr<numgraphs;++ngr) {
-            if (!gr || (ngr>0)) gr = bin.fPoly.fGraphs.arr[ngr];
+         for (let ngr = 0; ngr < numgraphs; ++ngr) {
+            if (!gr || (ngr > 0)) gr = bin.fPoly.fGraphs.arr[ngr];
 
-            for (let n=0;n<gr.fNpoints;++n) {
+            for (let n = 0; n < gr.fNpoints; ++n) {
                ++numpoints;
                realx += gr.fX[n];
                realy += gr.fY[n];
@@ -2377,7 +2380,7 @@ class TH2Painter extends THistPainter {
          const realx = funcs.revertAxis("x", pnt.x),
                realy = funcs.revertAxis("y", pnt.y);
 
-         if ((realx!==undefined) && (realy!==undefined)) {
+         if ((realx !== undefined) && (realy !== undefined)) {
             const len = histo.fBins.arr.length;
 
             for (let i = 0; (i < len) && (foundindx < 0); ++i) {
@@ -2393,8 +2396,8 @@ class TH2Painter extends THistPainter {
                let gr = bin.fPoly, numgraphs = 1;
                if (gr._typename === 'TMultiGraph') { numgraphs = bin.fPoly.fGraphs.arr.length; gr = null; }
 
-               for (let ngr=0;ngr<numgraphs;++ngr) {
-                  if (!gr || (ngr>0)) gr = bin.fPoly.fGraphs.arr[ngr];
+               for (let ngr = 0; ngr < numgraphs; ++ngr) {
+                  if (!gr || (ngr > 0)) gr = bin.fPoly.fGraphs.arr[ngr];
                   if (gr.IsInside(realx,realy)) {
                      foundindx = i;
                      break;

--- a/js/modules/hist2d/TMultiGraphPainter.mjs
+++ b/js/modules/hist2d/TMultiGraphPainter.mjs
@@ -47,18 +47,14 @@ class TMultiGraphPainter extends ObjectPainter {
          if (this.firstpainter.updateObject(histo)) isany = true;
       }
 
-      for (let i = 0; i < graphs.arr.length; ++i) {
-         if (i<this.painters.length)
-            if (this.painters[i].updateObject(graphs.arr[i])) isany = true;
-      }
+      for (let i = 0; i < graphs.arr.length; ++i)
+         if ((i < this.painters.length) && this.painters[i].updateObject(graphs.arr[i]))
+            isany = true;
 
-      if (obj.fFunctions)
-         for (let i = 0; i < obj.fFunctions.arr.length; ++i) {
-            let func = obj.fFunctions.arr[i];
-            if (!func || !func._typename || !func.fName) continue;
-            let funcpainter = pp ? pp.findPainterFor(null, func.fName, func._typename) : null;
-            if (funcpainter) funcpainter.updateObject(func);
-         }
+      obj.fFunctions?.arr?.forEach(func => {
+         if (func?._typename && func?.fName)
+            pp?.findPainterFor(null, func.fName, func._typename)?.updateObject(func);
+      });
 
       return isany;
    }
@@ -237,7 +233,7 @@ class TMultiGraphPainter extends ObjectPainter {
       // if there is auto colors assignment, try to provide it
       if (this._pfc || this._plc || this._pmc) {
          let mp = this.getMainPainter();
-         if (mp && mp.createAutoColor) {
+         if (typeof mp?.createAutoColor == 'function') {
             let icolor = mp.createAutoColor(graphs.arr.length);
             if (this._pfc) graphs.arr[indx].fFillColor = icolor;
             if (this._plc) graphs.arr[indx].fLineColor = icolor;
@@ -271,7 +267,7 @@ class TMultiGraphPainter extends ObjectPainter {
       if (d.check("A") || !painter.getMainPainter()) {
           let mgraph = painter.getObject(),
               pp = painter.getPadPainter(),
-              histo = painter.scanGraphsRange(mgraph.fGraphs, mgraph.fHistogram, pp ? pp.getRootPad(true) : null);
+              histo = painter.scanGraphsRange(mgraph.fGraphs, mgraph.fHistogram, pp?.getRootPad(true));
 
          promise = painter.drawAxisHist(histo, hopt).then(fp => {
             painter.firstpainter = fp;

--- a/js/modules/io.mjs
+++ b/js/modules/io.mjs
@@ -58,22 +58,22 @@ const CustomStreamers = {
    },
 
    TNamed: [ {
-      basename: clTObject, base: 1, func: (buf, obj) => {
+      basename: clTObject, base: 1, func(buf, obj) {
          if (!obj._typename) obj._typename = clTNamed;
          buf.classStreamer(obj, clTObject);
       }
      },
-     { name: 'fName', func: (buf, obj) => { obj.fName = buf.readTString(); } },
-     { name: 'fTitle', func: (buf, obj) => { obj.fTitle = buf.readTString(); } }
+     { name: 'fName', func(buf, obj) { obj.fName = buf.readTString(); } },
+     { name: 'fTitle', func(buf, obj) { obj.fTitle = buf.readTString(); } }
    ],
 
    TObjString: [ {
-      basename: clTObject, base: 1, func: (buf, obj) => {
+      basename: clTObject, base: 1, func(buf, obj) {
          if (!obj._typename) obj._typename = clTObjString;
          buf.classStreamer(obj, clTObject);
       }
      },
-     { name: 'fString', func: (buf, obj) => { obj.fString = buf.readTString(); } }
+     { name: 'fString', func(buf, obj) { obj.fString = buf.readTString(); } }
    ],
 
    TClonesArray(buf, list) {
@@ -312,7 +312,7 @@ const CustomStreamers = {
          buf.classStreamer(elem, "TStreamerSTL");
    },
 
-   TList: function(buf, obj) {
+   TList(buf, obj) {
       // stream all objects in the list from the I/O buffer
       if (!obj._typename) obj._typename = this.typename;
       obj.$kind = clTList; // all derived classes will be marked as well
@@ -363,7 +363,7 @@ const CustomStreamers = {
 
    TTree: {
       name: '$file',
-      func: (buf, obj) => { obj.$kind = "TTree"; obj.$file = buf.fFile; }
+      func(buf, obj) { obj.$kind = "TTree"; obj.$file = buf.fFile; }
    },
 
    RooRealVar(buf, obj) {
@@ -409,24 +409,24 @@ const CustomStreamers = {
 
    TImagePalette: [
       {
-         basename: clTObject, base: 1, func: (buf, obj) => {
+         basename: clTObject, base: 1, func(buf, obj) {
             if (!obj._typename) obj._typename = 'TImagePalette';
             buf.classStreamer(obj, clTObject);
          }
       },
-      { name: 'fNumPoints', func: (buf, obj) => { obj.fNumPoints = buf.ntou4(); } },
-      { name: 'fPoints', func: (buf, obj) => { obj.fPoints = buf.readFastArray(obj.fNumPoints, kDouble); } },
-      { name: 'fColorRed', func: (buf, obj) => { obj.fColorRed = buf.readFastArray(obj.fNumPoints, kUShort); } },
-      { name: 'fColorGreen', func: (buf, obj) => { obj.fColorGreen = buf.readFastArray(obj.fNumPoints, kUShort); } },
-      { name: 'fColorBlue', func: (buf, obj) => { obj.fColorBlue = buf.readFastArray(obj.fNumPoints, kUShort); } },
-      { name: 'fColorAlpha', func: (buf, obj) => { obj.fColorAlpha = buf.readFastArray(obj.fNumPoints, kUShort); } }
+      { name: 'fNumPoints', func(buf, obj) { obj.fNumPoints = buf.ntou4(); } },
+      { name: 'fPoints', func(buf, obj) { obj.fPoints = buf.readFastArray(obj.fNumPoints, kDouble); } },
+      { name: 'fColorRed', func(buf, obj) { obj.fColorRed = buf.readFastArray(obj.fNumPoints, kUShort); } },
+      { name: 'fColorGreen', func(buf, obj) { obj.fColorGreen = buf.readFastArray(obj.fNumPoints, kUShort); } },
+      { name: 'fColorBlue', func(buf, obj) { obj.fColorBlue = buf.readFastArray(obj.fNumPoints, kUShort); } },
+      { name: 'fColorAlpha', func(buf, obj) { obj.fColorAlpha = buf.readFastArray(obj.fNumPoints, kUShort); } }
    ],
 
    TAttImage: [
-      { name: 'fImageQuality', func: (buf, obj) => { obj.fImageQuality = buf.ntoi4(); } },
-      { name: 'fImageCompression', func: (buf, obj) => { obj.fImageCompression = buf.ntou4(); } },
-      { name: 'fConstRatio', func: (buf, obj) => { obj.fConstRatio = (buf.ntou1() != 0); } },
-      { name: 'fPalette', func: (buf, obj) => { obj.fPalette = buf.classStreamer({}, "TImagePalette"); } }
+      { name: 'fImageQuality', func(buf, obj) { obj.fImageQuality = buf.ntoi4(); } },
+      { name: 'fImageCompression', func(buf, obj) { obj.fImageCompression = buf.ntou4(); } },
+      { name: 'fConstRatio', func(buf, obj) { obj.fConstRatio = (buf.ntou1() != 0); } },
+      { name: 'fPalette', func(buf, obj) { obj.fPalette = buf.classStreamer({}, "TImagePalette"); } }
    ],
 
    TASImage(buf, obj) {
@@ -1301,7 +1301,7 @@ function addClassMethods(clname, streamer) {
             streamer.push({
                name: key,
                method: methods[key],
-               func: function(buf, obj) { obj[this.name] = this.method; }
+               func(buf, obj) { obj[this.name] = this.method; }
             });
 
    return streamer;
@@ -2571,9 +2571,8 @@ class TBuffer {
          return obj;
       }
 
-      const ver = this.readVersion();
-
-      const streamer = this.fFile.getStreamer(classname, ver);
+      const ver = this.readVersion(),
+            streamer = this.fFile.getStreamer(classname, ver);
 
       if (streamer !== null) {
 
@@ -2661,12 +2660,10 @@ class TDirectory {
       if ((this.fSeekKeys <= 0) || (this.fNbytesKeys <= 0))
          return Promise.resolve(this);
 
-      let file = this.fFile;
-
-      return file.readBuffer([this.fSeekKeys, this.fNbytesKeys]).then(blob => {
+      return this.fFile.readBuffer([this.fSeekKeys, this.fNbytesKeys]).then(blob => {
          // Read keys of the top directory
 
-         const buf = new TBuffer(blob, 0, file);
+         const buf = new TBuffer(blob, 0, this.fFile);
 
          buf.readTKey();
          const nkeys = buf.ntoi4();
@@ -2674,7 +2671,7 @@ class TDirectory {
          for (let i = 0; i < nkeys; ++i)
             this.fKeys.push(buf.readTKey());
 
-         file.fDirectories.push(this);
+         this.fFile.fDirectories.push(this);
 
          return this;
       });
@@ -2701,7 +2698,7 @@ class TFile {
       this.fUseStampPar = settings.UseStamp ? "stamp=" + (new Date).getTime() : false;
       this.fFileContent = null; // this can be full or partial content of the file (if ranges are not supported or if 1K header read from file)
       // stored as TBuffer instance
-      this.fMaxRanges = 200; // maximal number of file ranges requested at once
+      this.fMaxRanges = settings.MaxRanges || 200; // maximal number of file ranges requested at once
       this.fDirectories = [];
       this.fKeys = [];
       this.fSeekInfo = 0;
@@ -2798,32 +2795,34 @@ class TFile {
             ranges += (n > first ? "," : "=") + (place[n] + "-" + (place[n] + place[n + 1] - 1));
             totalsz += place[n + 1]; // accumulated total size
          }
-         if (last - first > 2) totalsz += (last - first) * 60; // for multi-range ~100 bytes/per request
+         if (last - first > 2)
+            totalsz += (last - first) * 60; // for multi-range ~100 bytes/per request
 
-         let xhr = createHttpRequest(fullurl, "buf", read_callback);
+         return createHttpRequest(fullurl, "buf", read_callback, undefined, true).then(xhr => {
 
-         if (file.fAcceptRanges) {
-            xhr.setRequestHeader("Range", ranges);
-            xhr.expected_size = Math.max(Math.round(1.1 * totalsz), totalsz + 200); // 200 if offset for the potential gzip
-         }
-
-         if (progress_callback && (typeof xhr.addEventListener === 'function')) {
-            let sum1 = 0, sum2 = 0, sum_total = 0;
-            for (let n = 1; n < place.length; n += 2) {
-               sum_total += place[n];
-               if (n < first) sum1 += place[n];
-               if (n < last) sum2 += place[n];
+            if (file.fAcceptRanges) {
+               xhr.setRequestHeader("Range", ranges);
+               xhr.expected_size = Math.max(Math.round(1.1 * totalsz), totalsz + 200); // 200 if offset for the potential gzip
             }
-            if (!sum_total) sum_total = 1;
 
-            let progress_offest = sum1 / sum_total, progress_this = (sum2 - sum1) / sum_total;
-            xhr.addEventListener("progress", function(oEvent) {
-               if (oEvent.lengthComputable)
-                  progress_callback(progress_offest + progress_this * oEvent.loaded / oEvent.total);
-            });
-         }
+            if (progress_callback && (typeof xhr.addEventListener === 'function')) {
+               let sum1 = 0, sum2 = 0, sum_total = 0;
+               for (let n = 1; n < place.length; n += 2) {
+                  sum_total += place[n];
+                  if (n < first) sum1 += place[n];
+                  if (n < last) sum2 += place[n];
+               }
+               if (!sum_total) sum_total = 1;
 
-         xhr.send(null);
+               let progress_offest = sum1 / sum_total, progress_this = (sum2 - sum1) / sum_total;
+               xhr.addEventListener("progress", function(oEvent) {
+                  if (oEvent.lengthComputable)
+                     progress_callback(progress_offest + progress_this * oEvent.loaded / oEvent.total);
+               });
+            }
+
+            xhr.send(null);
+         });
       }
 
       read_callback = function(res) {
@@ -2985,9 +2984,7 @@ class TFile {
          send_new_request(true);
       }
 
-      send_new_request(true);
-
-      return promise;
+      return send_new_request(true).then(() => promise);
    }
 
    /** @summary Returns file name */
@@ -3415,7 +3412,7 @@ class TFile {
 
          if (elem.basename == clTObject) {
             tgt.push({
-               func: function(buf, obj) {
+               func(buf, obj) {
                   buf.ntoi2(); // read version, why it here??
                   obj.fUniqueID = buf.ntou4();
                   obj.fBits = buf.ntou4();
@@ -3727,12 +3724,89 @@ class TNodejsFile extends TFile {
 
 } // class TNodejsFile
 
+/**
+  * @summary Proxy to read file contenxt
+  *
+  * @desc Should implement followinf methods
+  *        openFile() - return Promise with true when file can be open normally
+  *        getFileName() - returns string with file name
+  *        getFileSize() - returns size of file
+  *        readBuffer(pos, len) - return promise with DataView for requested position and length
+  * @private
+  */
+
+class FileProxy {
+
+   openFile() { return Promise.resolve(false); }
+
+   getFileName() { return ""; }
+
+   getFileSize() { return 0; }
+
+   readBuffer(/*pos, sz*/) { return Promise.resolve(null); }
+
+} // class FileProxy
+
+/**
+  * @summary File to use file context via FileProxy
+  *
+  * @hideconstructor
+  * @desc Use {@link openFile} to create instance of the class, providing FileProxy as argument
+  * @private
+  */
+
+class TProxyFile extends TFile {
+
+   constructor(proxy) {
+      super(null);
+      this.fUseStampPar = false;
+      this.proxy = proxy;
+   }
+
+   /** @summary Open file
+     * @returns {Promise} after file keys are read */
+   _open() {
+      return this.proxy.openFile().then(res => {
+         if (!res) return false;
+         this.fEND = this.proxy.getFileSize();
+         this.fFullURL = this.fURL = this.fFileName = this.proxy.getFileName();
+         if (typeof this.fFileName == 'string') {
+            let p = this.fFileName.lastIndexOf("/");
+            if ((p > 0) && (p < this.fFileName.length - 4))
+               this.fFileName = this.fFileName.slice(p+1);
+         }
+         return this.readKeys();
+      });
+   }
+
+   /** @summary Read buffer from FileProxy
+     * @returns {Promise} with requested blocks */
+   readBuffer(place, filename /*, progress_callback */) {
+      if (filename)
+         return Promise.reject(Error(`Cannot access other file ${filename}`));
+
+      if (!this.proxy)
+         return Promise.reject(Error(`File is not opened ${this.fFileName}`));
+
+      if (place.length == 2)
+         return this.proxy.readBuffer(place[0], place[1]);
+
+      let arr = [];
+      for (let k = 0; k < place.length; k+=2)
+         arr.push(this.proxy.readBuffer(place[k], place[k+1]));
+      return Promise.all(arr);
+   }
+
+} // class TProxyFile
+
+
 /** @summary Open ROOT file for reading
   * @desc Generic method to open ROOT file for reading
   * Following kind of arguments can be provided:
   *  - string with file URL (see example). In node.js environment local file like "file://hsimple.root" can be specified
   *  - [File]{@link https://developer.mozilla.org/en-US/docs/Web/API/File} instance which let read local files from browser
   *  - [ArrayBuffer]{@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer} instance with complete file content
+  *  - [FileProxy]{@link FileProxy} let access arbitrary files via tiny proxy API
   * @param {string|object} arg - argument for file open like url, see details
   * @returns {object} - Promise with {@link TFile} instance when file is opened
   * @example
@@ -3750,6 +3824,9 @@ function openFile(arg) {
       else if (arg.indexOf("http") !== 0)
          file = new TNodejsFile(arg);
    }
+
+   if (!file && (typeof arg === 'object') && (arg instanceof FileProxy))
+      file = new TProxyFile(arg);
 
    if (!file && (typeof arg === 'object') && (arg instanceof ArrayBuffer)) {
       file = new TFile("localfile.root");
@@ -3777,6 +3854,6 @@ export {
    kBase, kOffsetL, kOffsetP, kObject, kAny, kObjectp, kObjectP, kTString,
    kAnyP, kStreamer, kStreamLoop, kSTLp, kSTL,
    R__unzip, addUserStreamer, createStreamerElement, createMemberStreamer,
-   openFile, reconstructObject,
+   openFile, reconstructObject, FileProxy,
    TBuffer /*, TDirectory, TFile, TLocalFile, TNodejsFile */
 };

--- a/js/modules/main.mjs
+++ b/js/modules/main.mjs
@@ -15,14 +15,16 @@ export * from './hist/TH2Painter.mjs';
 
 export * from './hist/TH3Painter.mjs';
 
-export { loadOpenui5, registerForResize } from './gui/utils.mjs';
+export { loadOpenui5, registerForResize, setSaveFile } from './gui/utils.mjs';
 
 export { draw, redraw, makeSVG, addDrawFunc, setDefaultDrawOpt } from './draw.mjs';
 
-export { openFile } from './io.mjs';
+export { openFile, FileProxy } from './io.mjs';
 
 export * from './gui/display.mjs';
 
 export { HierarchyPainter, getHPainter } from './gui/HierarchyPainter.mjs';
 
 export { readStyleFromURL, buildGUI } from './gui.mjs';
+
+export { TSelector, treeDraw } from './tree.mjs';

--- a/js/modules/tree.mjs
+++ b/js/modules/tree.mjs
@@ -383,7 +383,7 @@ function findBranch(tree, name) {
   * @private */
 function getNumBranches(tree) {
    function count(obj) {
-      if (!obj || !obj.fBranches) return 0;
+      if (!obj?.fBranches) return 0;
       let nchld = 0;
       obj.fBranches.arr.forEach(sub => nchld += count(sub));
       return obj.fBranches.arr.length + nchld;
@@ -810,7 +810,7 @@ class TDrawSelector extends TSelector {
       let expr = this.parseParameters(tree, args, args.expr), cut = "";
 
       // parse option for histogram creation
-      this.hist_title = "drawing '" + expr + "' from " + tree.fName;
+      this.hist_title = `drawing '${expr}' from ${tree.fName}`;
 
       let pos = 0;
       if (args.cut) {
@@ -1237,8 +1237,10 @@ class TDrawSelector extends TSelector {
    ProcessArraysFunc(/*entry*/) {
 
       if (this.arr_limit || this.graph) {
-         let var0 = this.vars[0], len = this.tgtarr.br0.length,
-            var1 = this.vars[1], var2 = this.vars[2];
+         let var0 = this.vars[0],
+             var1 = this.vars[1],
+             var2 = this.vars[2],
+             len = this.tgtarr.br0.length;
          if ((var0.buf.length === 0) && (len >= this.arr_limit) && !this.graph) {
             // special use case - first array large enough to create histogram directly base on it
             var0.buf = this.tgtarr.br0;
@@ -1459,7 +1461,7 @@ function makeMethodsList(typename) {
    let res = {
       names: [],
       values: [],
-      Create: function() {
+      Create() {
          let obj = {};
          for (let n = 0; n < this.names.length; ++n)
             obj[this.names[n]] = this.values[n];
@@ -1467,7 +1469,8 @@ function makeMethodsList(typename) {
       }
    }
 
-   res.names.push("_typename"); res.values.push(typename);
+   res.names.push("_typename");
+   res.values.push(typename);
    for (let key in methods) {
       res.names.push(key);
       res.values.push(methods[key]);
@@ -1588,14 +1591,14 @@ function treeProcess(tree, selector, args) {
          staged_prev: 0, // entry limit of previous I/O request
          staged_now: 0, // entry limit of current I/O request
          progress_showtm: 0, // last time when progress was showed
-         GetBasketEntry: function(k) {
+         GetBasketEntry(k) {
             if (!this.branch || (k > this.branch.fMaxBaskets)) return 0;
             let res = (k < this.branch.fMaxBaskets) ? this.branch.fBasketEntry[k] : 0;
             if (res) return res;
             let bskt = (k > 0) ? this.branch.fBaskets.arr[k - 1] : null;
             return bskt ? (this.branch.fBasketEntry[k - 1] + bskt.fNevBuf) : 0;
          },
-         GetTarget: function(tgtobj) {
+         GetTarget(tgtobj) {
             // returns target object which should be used for the branch reading
             if (!this.tgt) return tgtobj;
             for (let k = 0; k < this.tgt.length; ++k) {
@@ -1605,7 +1608,7 @@ function treeProcess(tree, selector, args) {
             }
             return tgtobj;
          },
-         GetEntry: function(entry) {
+         GetEntry(entry) {
             // This should be equivalent to TBranch::GetEntry() method
             let shift = entry - this.first_entry, off;
             if (!this.branch.TestBit(kDoNotUseBufferMap))
@@ -1669,18 +1672,17 @@ function treeProcess(tree, selector, args) {
 
             if (!item_cnt2) { console.error('Cannot add counter branch2', BranchCount2.fName); return null; }
          }
-      } else
-         if (nb_leaves === 1 && leaf && leaf.fLeafCount) {
-            let br_cnt = findBranch(handle.tree, leaf.fLeafCount.fName);
+      } else if (nb_leaves === 1 && leaf && leaf.fLeafCount) {
+         let br_cnt = findBranch(handle.tree, leaf.fLeafCount.fName);
 
-            if (br_cnt) {
-               item_cnt = findInHandle(br_cnt);
+         if (br_cnt) {
+            item_cnt = findInHandle(br_cnt);
 
-               if (!item_cnt) item_cnt = AddBranchForReading(br_cnt, target_object, "$counter" + namecnt++, true);
+            if (!item_cnt) item_cnt = AddBranchForReading(br_cnt, target_object, "$counter" + namecnt++, true);
 
-               if (!item_cnt) { console.error('Cannot add counter branch', br_cnt.fName); return null; }
-            }
+            if (!item_cnt) { console.error('Cannot add counter branch', br_cnt.fName); return null; }
          }
+      }
 
       function ScanBranches(lst, master_target, chld_kind) {
          if (!lst || !lst.arr.length) return true;
@@ -1737,129 +1739,128 @@ function treeProcess(tree, selector, args) {
             name: target_name,
             typename: branch.fClassName,
             virtual: leaf.fVirtual,
-            func: function(buf, obj) {
+            func(buf, obj) {
                let clname = this.typename;
                if (this.virtual) clname = buf.readFastString(buf.ntou1() + 1);
                obj[this.name] = buf.classStreamer({}, clname);
             }
          };
-      } else
 
-         if ((branch.fType === kClonesNode) || (branch.fType === kSTLNode)) {
+      } else if ((branch.fType === kClonesNode) || (branch.fType === kSTLNode)) {
 
-            elem = createStreamerElement(target_name, kInt);
+         elem = createStreamerElement(target_name, kInt);
 
-            if (!read_mode || ((typeof read_mode === "string") && (read_mode[0] === ".")) || (read_mode === 1)) {
-               handle.process_arrays = false;
+         if (!read_mode || ((typeof read_mode === "string") && (read_mode[0] === ".")) || (read_mode === 1)) {
+            handle.process_arrays = false;
 
-               member = {
-                  name: target_name,
-                  conttype: branch.fClonesName || "TObject",
-                  reallocate: args.reallocate_objects,
-                  func: function(buf, obj) {
-                     let size = buf.ntoi4(), n = 0, arr = obj[this.name];
-                     if (!arr || this.reallocate) {
-                        arr = obj[this.name] = new Array(size);
-                     } else {
-                        n = arr.length;
-                        arr.length = size; // reallocate array
-                     }
-
-                     while (n < size) arr[n++] = this.methods.Create(); // create new objects
+            member = {
+               name: target_name,
+               conttype: branch.fClonesName || "TObject",
+               reallocate: args.reallocate_objects,
+               func(buf, obj) {
+                  let size = buf.ntoi4(), n = 0, arr = obj[this.name];
+                  if (!arr || this.reallocate) {
+                     arr = obj[this.name] = new Array(size);
+                  } else {
+                     n = arr.length;
+                     arr.length = size; // reallocate array
                   }
-               };
 
-               if ((typeof read_mode === "string") && (read_mode[0] === ".")) {
-                  member.conttype = detectBranchMemberClass(branch.fBranches, branch.fName + read_mode);
-                  if (!member.conttype) {
-                     console.error(`Cannot select object ${read_mode} in the branch ${branch.fName}`);
-                     return null;
-                  }
+                  while (n < size) arr[n++] = this.methods.Create(); // create new objects
                }
+            };
 
-               member.methods = makeMethodsList(member.conttype);
-
-               child_scan = (branch.fType === kClonesNode) ? kClonesMemberNode : kSTLMemberNode;
-            }
-         } else
-
-            if ((object_class = getBranchObjectClass(branch, handle.tree))) {
-
-               if (read_mode === true) {
-                  console.warn(`Object branch ${object_class} can not have data to be read directly`);
+            if ((typeof read_mode === "string") && (read_mode[0] === ".")) {
+               member.conttype = detectBranchMemberClass(branch.fBranches, branch.fName + read_mode);
+               if (!member.conttype) {
+                  console.error(`Cannot select object ${read_mode} in the branch ${branch.fName}`);
                   return null;
                }
-
-               handle.process_arrays = false;
-
-               let newtgt = new Array(target_object ? (target_object.length + 1) : 1);
-               for (let l = 0; l < newtgt.length - 1; ++l)
-                  newtgt[l] = target_object[l];
-               newtgt[newtgt.length - 1] = { name: target_name, lst: makeMethodsList(object_class) };
-
-               if (!ScanBranches(branch.fBranches, newtgt, 0)) return null;
-
-               return item; // this kind of branch does not have baskets and not need to be read
-
-            } else if (is_brelem && (nb_leaves === 1) && (leaf.fName === branch.fName) && (branch.fID == -1)) {
-
-               elem = createStreamerElement(target_name, branch.fClassName);
-
-               if (elem.fType === kAny) {
-
-                  let streamer = handle.file.getStreamer(branch.fClassName, { val: branch.fClassVersion, checksum: branch.fCheckSum });
-                  if (!streamer) { elem = null; console.warn('not found streamer!'); } else
-                     member = {
-                        name: target_name,
-                        typename: branch.fClassName,
-                        streamer: streamer,
-                        func: function(buf, obj) {
-                           let res = { _typename: this.typename };
-                           for (let n = 0; n < this.streamer.length; ++n)
-                              this.streamer[n].func(buf, res);
-                           obj[this.name] = res;
-                        }
-                     };
-               }
-
-               // elem.fType = kAnyP;
-
-               // only STL containers here
-               // if (!elem.fSTLtype) elem = null;
-            } else if (is_brelem && (nb_leaves <= 1)) {
-
-               elem = findBrachStreamerElement(branch, handle.file);
-
-               // this is basic type - can try to solve problem differently
-               if (!elem && branch.fStreamerType && (branch.fStreamerType < 20))
-                  elem = createStreamerElement(target_name, branch.fStreamerType);
-
-            } else if (nb_leaves === 1) {
-               // no special constrains for the leaf names
-
-               elem = createLeafElem(leaf, target_name);
-
-            } else if ((branch._typename === "TBranch") && (nb_leaves > 1)) {
-               // branch with many elementary leaves
-
-               let arr = new Array(nb_leaves), isok = true;
-               for (let l = 0; l < nb_leaves; ++l) {
-                  arr[l] = createMemberStreamer(createLeafElem(branch.fLeaves.arr[l]), handle.file);
-                  if (!arr[l]) isok = false;
-               }
-
-               if (isok)
-                  member = {
-                     name: target_name,
-                     leaves: arr,
-                     func: function(buf, obj) {
-                        let tgt = obj[this.name], l = 0;
-                        if (!tgt) obj[this.name] = tgt = {};
-                        while (l < this.leaves.length)
-                           this.leaves[l++].func(buf, tgt);
-                     }
-                  };
             }
+
+            member.methods = makeMethodsList(member.conttype);
+
+            child_scan = (branch.fType === kClonesNode) ? kClonesMemberNode : kSTLMemberNode;
+         }
+
+      } else if ((object_class = getBranchObjectClass(branch, handle.tree))) {
+
+         if (read_mode === true) {
+            console.warn(`Object branch ${object_class} can not have data to be read directly`);
+            return null;
+         }
+
+         handle.process_arrays = false;
+
+         let newtgt = new Array(target_object ? (target_object.length + 1) : 1);
+         for (let l = 0; l < newtgt.length - 1; ++l)
+            newtgt[l] = target_object[l];
+         newtgt[newtgt.length - 1] = { name: target_name, lst: makeMethodsList(object_class) };
+
+         if (!ScanBranches(branch.fBranches, newtgt, 0)) return null;
+
+         return item; // this kind of branch does not have baskets and not need to be read
+
+      } else if (is_brelem && (nb_leaves === 1) && (leaf.fName === branch.fName) && (branch.fID == -1)) {
+
+         elem = createStreamerElement(target_name, branch.fClassName);
+
+         if (elem.fType === kAny) {
+
+            let streamer = handle.file.getStreamer(branch.fClassName, { val: branch.fClassVersion, checksum: branch.fCheckSum });
+            if (!streamer) { elem = null; console.warn('not found streamer!'); } else
+               member = {
+                  name: target_name,
+                  typename: branch.fClassName,
+                  streamer: streamer,
+                  func(buf, obj) {
+                     let res = { _typename: this.typename };
+                     for (let n = 0; n < this.streamer.length; ++n)
+                        this.streamer[n].func(buf, res);
+                     obj[this.name] = res;
+                  }
+               };
+         }
+
+         // elem.fType = kAnyP;
+
+         // only STL containers here
+         // if (!elem.fSTLtype) elem = null;
+
+      } else if (is_brelem && (nb_leaves <= 1)) {
+
+         elem = findBrachStreamerElement(branch, handle.file);
+
+         // this is basic type - can try to solve problem differently
+         if (!elem && branch.fStreamerType && (branch.fStreamerType < 20))
+            elem = createStreamerElement(target_name, branch.fStreamerType);
+
+      } else if (nb_leaves === 1) {
+         // no special constrains for the leaf names
+
+         elem = createLeafElem(leaf, target_name);
+
+      } else if ((branch._typename === "TBranch") && (nb_leaves > 1)) {
+         // branch with many elementary leaves
+
+         let leaves = new Array(nb_leaves), isok = true;
+         for (let l = 0; l < nb_leaves; ++l) {
+            leaves[l] = createMemberStreamer(createLeafElem(branch.fLeaves.arr[l]), handle.file);
+            if (!leaves[l]) isok = false;
+         }
+
+         if (isok)
+            member = {
+               name: target_name,
+               leaves,
+               func(buf, obj) {
+                  let tgt = obj[this.name], l = 0;
+                  if (!tgt) obj[this.name] = tgt = {};
+                  while (l < this.leaves.length)
+                     this.leaves[l++].func(buf, tgt);
+               }
+            };
+      }
 
       if (!elem && !member) {
          console.warn('Not supported branch kind', branch.fName, branch._typename);
@@ -1935,7 +1936,6 @@ function treeProcess(tree, selector, args) {
 
          // case when target is sub-object and need to be created before
 
-
          if (member.objs_branch_func) {
             // STL branch provides special function for the reading
             member.func = member.objs_branch_func;
@@ -1961,104 +1961,100 @@ function treeProcess(tree, selector, args) {
                obj[this.name] = this.readarr(buf, obj[this.stl_size]);
             };
 
-         } else
-            if (((elem.fType === kOffsetP + kDouble32) || (elem.fType === kOffsetP + kFloat16)) && branch.fBranchCount2) {
-               // special handling for variable arrays of compressed floats in branch - not tested
+         } else if (((elem.fType === kOffsetP + kDouble32) || (elem.fType === kOffsetP + kFloat16)) && branch.fBranchCount2) {
+            // special handling for variable arrays of compressed floats in branch - not tested
 
-               member.stl_size = item_cnt.name;
+            member.stl_size = item_cnt.name;
+            member.arr_size = item_cnt2.name;
+            member.func = function(buf, obj) {
+               let sz0 = obj[this.stl_size], sz1 = obj[this.arr_size], arr = new Array(sz0);
+               for (let n = 0; n < sz0; ++n)
+                  arr[n] = (buf.ntou1() === 1) ? this.readarr(buf, sz1[n]) : [];
+               obj[this.name] = arr;
+            };
+
+         } else if (((elem.fType > 0) && (elem.fType < kOffsetL)) || (elem.fType === kTString) ||
+                    (((elem.fType > kOffsetP) && (elem.fType < kOffsetP + kOffsetL)) && branch.fBranchCount2)) {
+            // special handling of simple arrays
+            member = {
+               name: target_name,
+               stl_size: item_cnt.name,
+               type: elem.fType,
+               func(buf, obj) {
+                  obj[this.name] = buf.readFastArray(obj[this.stl_size], this.type);
+               }
+            };
+
+            if (branch.fBranchCount2) {
+               member.type -= kOffsetP;
                member.arr_size = item_cnt2.name;
                member.func = function(buf, obj) {
                   let sz0 = obj[this.stl_size], sz1 = obj[this.arr_size], arr = new Array(sz0);
                   for (let n = 0; n < sz0; ++n)
-                     arr[n] = (buf.ntou1() === 1) ? this.readarr(buf, sz1[n]) : [];
+                     arr[n] = (buf.ntou1() === 1) ? buf.readFastArray(sz1[n], this.type) : [];
                   obj[this.name] = arr;
                };
+            }
 
-            } else
-               // special handling of simple arrays
-               if (((elem.fType > 0) && (elem.fType < kOffsetL)) || (elem.fType === kTString) ||
-                  (((elem.fType > kOffsetP) && (elem.fType < kOffsetP + kOffsetL)) && branch.fBranchCount2)) {
+         } else if ((elem.fType > kOffsetP) && (elem.fType < kOffsetP + kOffsetL) && member.cntname) {
 
-                  member = {
-                     name: target_name,
-                     stl_size: item_cnt.name,
-                     type: elem.fType,
-                     func: function(buf, obj) {
-                        obj[this.name] = buf.readFastArray(obj[this.stl_size], this.type);
-                     }
-                  };
+            member.cntname = item_cnt.name;
 
-                  if (branch.fBranchCount2) {
-                     member.type -= kOffsetP;
-                     member.arr_size = item_cnt2.name;
-                     member.func = function(buf, obj) {
-                        let sz0 = obj[this.stl_size], sz1 = obj[this.arr_size], arr = new Array(sz0);
-                        for (let n = 0; n < sz0; ++n)
-                           arr[n] = (buf.ntou1() === 1) ? buf.readFastArray(sz1[n], this.type) : [];
-                        obj[this.name] = arr;
-                     };
+         } else if (elem.fType == kStreamer) {
+            // with streamers one need to extend existing array
+
+            if (item_cnt2)
+               throw new Error('Second branch counter not supported yet with kStreamer');
+
+            // function provided by normal I/O
+            member.func = member.branch_func;
+            member.stl_size = item_cnt.name;
+
+         } else if ((elem.fType === kStreamLoop) || (elem.fType === kOffsetL + kStreamLoop)) {
+            if (item_cnt2) {
+               // special solution for kStreamLoop
+               member.stl_size = item_cnt.name;
+               member.cntname = item_cnt2.name;
+               member.func = member.branch_func; // this is special function, provided by base I/O
+            } else {
+               member.cntname = item_cnt.name;
+            }
+         } else {
+
+            member.name = "$stl_member";
+
+            let loop_size_name;
+
+            if (item_cnt2) {
+               if (member.cntname) {
+                  loop_size_name = item_cnt2.name;
+                  member.cntname = "$loop_size";
+               } else {
+                  throw new Error('Second branch counter not used - very BAD');
+               }
+            }
+
+            let stlmember = {
+               name: target_name,
+               stl_size: item_cnt.name,
+               loop_size: loop_size_name,
+               member0: member,
+               func(buf, obj) {
+                  let cnt = obj[this.stl_size], arr = new Array(cnt);
+                  for (let n = 0; n < cnt; ++n) {
+                     if (this.loop_size) obj.$loop_size = obj[this.loop_size][n];
+                     this.member0.func(buf, obj);
+                     arr[n] = obj.$stl_member;
                   }
+                  delete obj.$stl_member;
+                  delete obj.$loop_size;
+                  obj[this.name] = arr;
+               }
+            };
 
-               } else
-                  if ((elem.fType > kOffsetP) && (elem.fType < kOffsetP + kOffsetL) && member.cntname) {
-
-                     member.cntname = item_cnt.name;
-                  } else
-                     if (elem.fType == kStreamer) {
-                        // with streamers one need to extend existing array
-
-                        if (item_cnt2)
-                           throw new Error('Second branch counter not supported yet with kStreamer');
-
-                        // function provided by normal I/O
-                        member.func = member.branch_func;
-                        member.stl_size = item_cnt.name;
-                     } else
-                        if ((elem.fType === kStreamLoop) || (elem.fType === kOffsetL + kStreamLoop)) {
-                           if (item_cnt2) {
-                              // special solution for kStreamLoop
-                              member.stl_size = item_cnt.name;
-                              member.cntname = item_cnt2.name;
-                              member.func = member.branch_func; // this is special function, provided by base I/O
-                           } else {
-                              member.cntname = item_cnt.name;
-                           }
-                        } else {
-
-                           member.name = "$stl_member";
-
-                           let loop_size_name;
-
-                           if (item_cnt2) {
-                              if (member.cntname) {
-                                 loop_size_name = item_cnt2.name;
-                                 member.cntname = "$loop_size";
-                              } else {
-                                 throw new Error('Second branch counter not used - very BAD');
-                              }
-                           }
-
-                           let stlmember = {
-                              name: target_name,
-                              stl_size: item_cnt.name,
-                              loop_size: loop_size_name,
-                              member0: member,
-                              func: function(buf, obj) {
-                                 let cnt = obj[this.stl_size], arr = new Array(cnt);
-                                 for (let n = 0; n < cnt; ++n) {
-                                    if (this.loop_size) obj.$loop_size = obj[this.loop_size][n];
-                                    this.member0.func(buf, obj);
-                                    arr[n] = obj.$stl_member;
-                                 }
-                                 delete obj.$stl_member;
-                                 delete obj.$loop_size;
-                                 obj[this.name] = arr;
-                              }
-                           };
-
-                           member = stlmember;
-                        }
-      }
+            member = stlmember;
+         }
+      } // if (item_cnt)
 
       // set name used to store result
       member.name = target_name;
@@ -2191,7 +2187,7 @@ function treeProcess(tree, selector, args) {
             places.push(branch.fBasketSeek[bitems[n].basket], branch.fBasketBytes[bitems[n].basket]);
          }
 
-         return places.length > 0 ? { places: places, filename: filename } : null;
+         return places.length > 0 ? { places, filename } : null;
       }
 
       function ReadProgress(value) {
@@ -2378,7 +2374,8 @@ function treeProcess(tree, selector, args) {
 
       handle.progress_showtm = new Date().getTime();
 
-      if (totalsz > 0) return ReadBaskets(bitems).then(ProcessBaskets);
+      if (totalsz > 0)
+         return ReadBaskets(bitems).then(ProcessBaskets);
 
       if (is_direct) return ProcessBaskets([]); // directly process baskets
 
@@ -2559,13 +2556,13 @@ function treeIOTest(tree, args) {
    let branches = [], names = [], nchilds = [];
 
    function collectBranches(obj, prntname = "") {
-      if (!obj || !obj.fBranches) return 0;
+      if (!obj?.fBranches) return 0;
 
       let cnt = 0;
 
       for (let n = 0; n < obj.fBranches.arr.length; ++n) {
          let br = obj.fBranches.arr[n],
-            name = (prntname ? prntname + "/" : "") + br.fName;
+             name = (prntname ? prntname + "/" : "") + br.fName;
          branches.push(br);
          names.push(name);
          nchilds.push(0);
@@ -2666,17 +2663,17 @@ function treeHierarchy(node, obj) {
       branch.$tree = tree; // keep tree pointer, later do it more smart
 
       let subitem = {
-            _name : ClearName(branch.fName),
-            _kind : "ROOT." + branch._typename,
-            _title : branch.fTitle,
-            _obj : branch
+            _name: ClearName(branch.fName),
+            _kind: "ROOT." + branch._typename,
+            _title: branch.fTitle,
+            _obj: branch
       };
 
       if (!node._childs) node._childs = [];
 
       node._childs.push(subitem);
 
-      if (branch._typename==='TBranchElement')
+      if (branch._typename === 'TBranchElement')
          subitem._title += " from " + branch.fClassName + ";" + branch.fClassVersion;
 
       if (nb_branches > 0) {
@@ -2696,7 +2693,7 @@ function treeHierarchy(node, obj) {
                     _kind: "ROOT.TLeafElement",
                     _icon: "img_leaf",
                     _obj: bobj.fLeaves.arr[0],
-                    _more : false
+                    _more: false
                  });
               }
 
@@ -2716,7 +2713,7 @@ function treeHierarchy(node, obj) {
                         _title: "function " + key + " of class " + object_class,
                         _kind: "ROOT.TBranchFunc", // fictional class, only for drawing
                         _obj: { _typename: "TBranchFunc", branch: bobj, func: key },
-                        _more : false
+                        _more: false
                      });
 
                }

--- a/js/scripts/JSRoot.core.js
+++ b/js/scripts/JSRoot.core.js
@@ -225,8 +225,8 @@ exports.define = function(req, factoryFunc) {
 exports.decodeUrl = function(url) {
    let res = {
       opts: {},
-      has: function(opt) { return this.opts[opt] !== undefined; },
-      get: function(opt,dflt) { let v = this.opts[opt]; return v!==undefined ? v : dflt; }
+      has(opt) { return this.opts[opt] !== undefined; },
+      get(opt,dflt) { let v = this.opts[opt]; return v !== undefined ? v : dflt; }
    };
 
    if (!url || (typeof url !== 'string')) {


### PR DESCRIPTION
## Changes in dev
1. Force MathJax rendering when `\` symbol is found (243)
2. Fix - use alfa channel for TColor when intended


## Changes in 7.2.0
1. Use TAxis attributes in lego plots - ticks/labels/title colors, sizes, offsets
2. Correctly resize stats box when number of lines changes
3. Support JSROOT usage with yarn and webpack
4. Provide `FileProxy` class to let read ROOT files from arbitrary place
5. Let 'hook' save file functionality to use alternative method to store image files
6. Implement 'tabs' layout for objects display (238)
7. Upgrade d3.js to version 7.6.1
8. Fix - adjust pad margins when moving palette and frame


## Changes in 7.1.1
1. Fix - let modify node visibility bits via context menu
2. Fix - menu position adjusting
3. Fix - tree_draw.js example, export treeDraw function from main.mjs
4. Fix - TH3 scatter plot with large number of bins converted to box2
5. Fix - create geo css entries also when expand object in hierarchy (240)
