### PR TITLE
[RF] Enable vectorized first order interpolation for weight evaluation

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -106,7 +106,7 @@ public:
                const std::map<const RooAbsArg*, std::pair<double, double> >& ranges,
                std::function<double(int)> getBinScale = [](int){ return 1.0; } );
 
-  void weights(double* output, RooSpan<double const> xVals, bool correctForBinSize);
+  void weights(double* output, RooSpan<double const> xVals, int intOrder, bool correctForBinSize, bool cdfBoundaries);
   /// Return weight of i-th bin. \see getIndex()
   double weight(std::size_t i) const { return _wgt[i]; }
   double weightFast(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);
@@ -280,6 +280,7 @@ protected:
   mutable double _cache_sum{0.};          ///<! Cache for sum of entries ;
 
 private:
+  void interpolateLinear(double* output, RooSpan<const double> xVals, bool correctForBinSize, bool cdfBoundaries);
   double weightInterpolated(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);
 
   void _adjustBinning(RooRealVar &theirVar, const TAxis &axis, RooRealVar *ourVar, Int_t *offset);

--- a/roofit/roofitcore/inc/RooHistPdf.h
+++ b/roofit/roofitcore/inc/RooHistPdf.h
@@ -104,7 +104,6 @@ public:
 
   void computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const&) const override;
 
-
 protected:
 
   bool areIdentical(const RooDataHist& dh1, const RooDataHist& dh2) ;

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -196,9 +196,9 @@ double RooHistFunc::evaluate() const
 
 
 void RooHistFunc::computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const {
-  if (_depList.size() == 1 && _intOrder == 0) {
+  if (_depList.size() == 1 && _intOrder < 2) {
     auto xVals = dataMap.at(_depList[0]);
-    _dataHist->weights(output, xVals, false);
+    _dataHist->weights(output, xVals, _intOrder, false, _cdfBoundaries);
     return;
   }
   

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -191,13 +191,13 @@ RooHistPdf::~RooHistPdf()
 void RooHistPdf::computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const {
 
   // For interpolation and histograms of higher dimension, use base function
-  if(_pdfObsList.size() > 1 || _intOrder > 0) {
+  if(_pdfObsList.size() > 1 || _intOrder > 1) {
       RooAbsReal::computeBatch(nullptr, output, nEvents, dataMap);
       return;
   }
 
   auto xVals = dataMap.at(_pdfObsList[0]);
-  _dataHist->weights(output, xVals, true);
+  _dataHist->weights(output, xVals, _intOrder, true, _cdfBoundaries);
 }
 
 


### PR DESCRIPTION
With the function `RooDataHist::interpolateLinear` it is now possible to use
`RooDataHist::weights()` (implemented in https://github.com/root-project/root/pull/11171) to evaluate weights for one
dimensional histograms with up to first order interpolation.

`RooDataHist::interpolateLinear` finds the coefficients of a straight line
between two neighboring bin centers by solving a system of two linear
equations. With the coefficients of the straight line, the interpolated weight
for an event between two bin centers can be calculated.

If an event in a bin is to the left of the bin center coordinates, the
corresponding weight is found by interpolating between the current bin and the
neighboring bin to the left. If the event is to the right of the bin center,
the weight is found by inteperpolating between the current bin center and the
one to the right. For the first and last bin, the interpolation is performed
either by mirroring the histogram outside its boundaries, or by applying cdf
boundaries.

`RooDataHist::weights()` has been updated so that it calls
`RooDataHist::interpolateLinear()` when the interpolation order is one.
Furthermore, `RooDataHist::computeBatch()` and `RooHistFunc::computeBatch()`
have been updated so that they call `RooDatahist::weights()` in the cases
where the histogram is one dimensional and the interpolation order is zero or
one.

- [x] tested changes locally
- [x] updated the docs (if necessary)

