### PR TITLE
[webgui] introduce `WebGui.OnetimeKey` rootrc parameter

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -41,6 +41,7 @@ public:
       kQt6,      ///< Qt6 QWebEngine libraries - Chromium code packed in qt6
       kLocal,    ///< either CEF or Qt5 - both runs on local display without real http server
       kStandard, ///< default system web browser, can not be used in batch mode
+      kServer,   ///< indicates that ROOT runs as server and just printouts window URL, browser should be started by the user
       kEmbedded, ///< window will be embedded into other, no extra browser need to be started
       kOff,      ///< disable web display, do not start any browser
       kCustom    ///< custom web browser, execution string should be provided

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -94,6 +94,12 @@ public:
 
    void SetMasterWindow(std::shared_ptr<RWebWindow> master, int channel = -1);
 
+   /// returns true if interactive browser window supposed to be started
+   bool IsInteractiveBrowser() const
+   {
+      return !IsHeadless() && ((GetBrowserKind() == kNative) || (GetBrowserKind() == kChrome) || (GetBrowserKind() == kFirefox) || (GetBrowserKind() == kStandard) || (GetBrowserKind() == kCustom));
+   }
+
    /// returns true if local display like CEF or Qt5 QWebEngine should be used
    bool IsLocalDisplay() const
    {

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -70,6 +70,7 @@ private:
       unsigned fConnId{0};                 ///<! connection id (unique inside the window)
       bool fHeadlessMode{false};           ///<! indicate if connection represent batch job
       std::string fKey;                    ///<! key value supplied to the window (when exists)
+      bool fKeyUsed{false};                ///<! key value used to verify connection
       std::unique_ptr<RWebDisplayHandle> fDisplayHandle;  ///<! handle assigned with started web display (when exists)
       std::shared_ptr<THttpCallArg> fHold; ///<! request used to hold headless browser
       timestamp_t fSendStamp;              ///<! last server operation, always used from window thread
@@ -162,6 +163,8 @@ private:
    std::shared_ptr<WebConn> FindConnection(unsigned wsid) { return FindOrCreateConnection(wsid, false, nullptr); }
 
    std::shared_ptr<WebConn> RemoveConnection(unsigned wsid);
+
+   std::shared_ptr<WebConn> _FindConnWithKey(const std::string &key) const;
 
    std::string _MakeSendHeader(std::shared_ptr<WebConn> &conn, bool txt, const std::string &data, int chid);
 

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -131,7 +131,7 @@ bool RWebDisplayArgs::SetPosAsStr(const std::string &str)
       return false;
    }
 
-   if ((x<0) || (y<0))
+   if ((x < 0) || (y < 0))
       return false;
 
    SetPos(x, y);
@@ -224,6 +224,8 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
       SetBrowserKind(kEmbedded);
    else if ((kind == "dflt") || (kind == "default") || (kind == "browser"))
       SetBrowserKind(kStandard);
+   else if (kind == "server")
+      SetBrowserKind(kServer);
    else if (kind == "off")
       SetBrowserKind(kOff);
    else if (!SetSizeAsStr(kind))
@@ -246,6 +248,7 @@ std::string RWebDisplayArgs::GetBrowserName() const
       case kQt6: return "qt6";
       case kLocal: return "local";
       case kStandard: return "default";
+      case kServer: return "server";
       case kEmbedded: return "embed";
       case kOff: return "off";
       case kCustom:

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -25,6 +25,7 @@
 #include "TBase64.h"
 
 #include <fstream>
+#include <iostream>
 #include <memory>
 #include <regex>
 
@@ -212,6 +213,11 @@ RWebDisplayHandle::BrowserCreator::Display(const RWebDisplayArgs &args)
    std::string url = args.GetFullUrl();
    if (url.empty())
       return nullptr;
+
+   if(args.GetBrowserKind() == RWebDisplayArgs::kServer) {
+      std::cout << "New web window: " << url << std::endl;
+      return std::make_unique<RWebBrowserHandle>(url, "", "");
+   }
 
    std::string exec;
    if (args.IsBatchMode())


### PR DESCRIPTION
If specified, enforce unique key every time client connect to
web window. Once key used, it is not possible to use it again for reconnect.
If one wants to connect to window again, one should
call RWebWindow::Show() method again.

Now parameter is off, but once tested - will be enabled by default.
This should significantly increase security for web applications.

Fix problem with random seed for key generation  

Add warning when browser on remote node is started - by checking DISPLAY variable 
