### PR TITLE
DistRDF profiling

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/Backends/Utils.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/Utils.py
@@ -9,6 +9,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
+from __future__ import annotations
 
 import logging
 import os
@@ -19,9 +20,9 @@ import ROOT
 from ROOT._pythonization._rdataframe import AsNumpyResult
 
 from DistRDF.PythonMergeables import SnapshotResult
+from DistRDF.Profiling.Base import ProfilingData
 
 logger = logging.getLogger(__name__)
-
 
 def extend_include_path(include_path):
     """
@@ -198,6 +199,7 @@ def merge_values(mergeable_out, mergeable_in):
 
 @merge_values.register(AsNumpyResult)
 @merge_values.register(SnapshotResult)
+@merge_values.register(ProfilingData)
 def _(mergeable_out, mergeable_in):
     """
     Mergeables coming from `Snapshot` or `AsNumpy` operations have their own

--- a/bindings/experimental/distrdf/python/DistRDF/Backends/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Backends/__init__.py
@@ -9,6 +9,7 @@
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
+from __future__ import annotations
 
 import pkgutil
 import types

--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -193,7 +193,9 @@ class HeadNode(Node, ABC):
                 ComputationGraphGenerator.trigger_computation_graph, self._generate_graph_dict())
         
         if self._activate_profiling:
-            mapper = self._visualization.Decorator(profilable_mapper)
+
+            mapper = self._visualization.decorate(profilable_mapper)
+
         else:
             mapper = distrdf_mapper
 
@@ -528,6 +530,6 @@ class TreeHeadNode(HeadNode):
                                f"but {entries_in_trees.processed_entries} were processed.")
 
         if self._activate_profiling:
-            self._visualization.Client_task(values.prof_data)
+            self._visualization.produce_visualization(values.prof_data)
 
         return values.mergeables

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations 
+
 from abc import ABC, abstractmethod
 from typing import Callable
 
@@ -18,10 +20,16 @@ class Visualization:
     Base class that represents visualizations for profiling data
     """
 
-    @property
-    def Decorator(self) -> Callable:
-        return lambda func: func
+    @abstractmethod
+    def decorate(self, mapper:Callable) -> Callable:
+        """
+        Decorate mapper function to include collection and post-processing of profiling data
+        """
+        raise NotImplementedError
 
-    @property
-    def Client_task(self) -> Callable:
-        return lambda task_result: None
+    @abstractmethod
+    def produce_visualization(self, data:ProfilingData) -> Callable:
+        """
+        Using post-processed data from the distributed workers, produce the visualization on the client side 
+        """
+        raise NotImplementedError

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Base.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from typing import Callable
+
+class ProfilingData(ABC):
+    """
+    Base class for the collection of any type of profiling data
+    """
+
+    @abstractmethod
+    def Merge(self, other:"ProfilingData"):
+        """
+        Profiled data must provide a method to merge two instances of the same type.
+        """
+        raise NotImplementedError
+
+class Visualization():
+    """
+    Base class that represents visualizations for profiling data
+    """
+
+    @property
+    def Decorator(self) -> Callable:
+        return lambda func: func
+
+    @property
+    def Client_task(self) -> Callable:
+        return lambda task_result: None

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Base.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Base.py
@@ -13,7 +13,7 @@ class ProfilingData(ABC):
         """
         raise NotImplementedError
 
-class Visualization():
+class Visualization:
     """
     Base class that represents visualizations for profiling data
     """

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/ErrorHandling.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/ErrorHandling.py
@@ -1,0 +1,15 @@
+import os
+
+class ProfilingError(Exception):
+    """Exception raised when profiling utils (e.g. perf, stackcollapse, etc.) return errors"""
+    pass
+
+def check_and_raise_errors(stderr:str, command:str) -> None:
+
+    if len(stderr)>0:
+        
+        # Comunicate which node is raising the error
+        node_name = os.uname()[1]
+
+        raise ProfilingError(f"{command} returned an error in node {node_name}:\n{stderr}")
+        

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/ErrorHandling.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/ErrorHandling.py
@@ -1,3 +1,5 @@
+from __future__ import annotations 
+
 import os
 
 class ProfilingError(Exception):

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Flamegraph.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Flamegraph.py
@@ -1,0 +1,97 @@
+from functools import partial
+import os
+from typing import Callable, Optional
+
+from subprocess import run
+
+from DistRDF.Profiling.ErrorHandling import check_and_raise_errors
+from DistRDF.Profiling.Perf import collect_perf_data
+from DistRDF.Profiling.Base import ProfilingData, Visualization
+
+def Decorator(func:Callable, data_dir:str, perf_options:Optional[dict]):
+    """
+    Decorator for the distributed mapper function.
+    It includes collection of profiling data and postprocessing to build flamegraphs
+    """
+
+    def inner(*args, **kwargs):
+
+        # Start collecting data
+        with collect_perf_data(data_dir, perf_options):
+            result = func(*args, **kwargs)
+
+        # Postprocessing
+        result.prof_data = fold_perf_data(data_dir)
+        return result
+    
+    return inner
+
+class FlameGraphData(ProfilingData):
+    """
+    Handles and merges flamegraph data
+    """
+
+    def __init__(self, data:str) -> None:
+
+        perf_table = [f.rsplit(" ",1) for f in data.splitlines()]
+        self.table = dict(perf_table)
+
+    def Merge(self, other:"FlameGraphData")->None:
+        
+        for key, value in other.table.items():
+            self.table[key] = int(self.table.get(key, 0)) + int(value)
+
+def fold_perf_data(data_dir:str)->"FlameGraphData":
+    """
+    Folds profiling data to pass it through
+    """
+
+    file = os.path.join(data_dir,f"proc-{os.getpid()}.perf.data")
+
+    #Folding
+    scripted = run(["perf", "script", "--no-demangle","-i",file], capture_output=True, text=True)
+    check_and_raise_errors(scripted.stderr, "perf script")
+    folded = run(["stackcollapse-perf.pl","--all"], input=scripted.stdout, capture_output=True, text=True)
+    check_and_raise_errors(folded.stderr, "stackcollapse-perf.pl")
+
+    return FlameGraphData(folded.stdout)
+
+def restore_jit_annotation(callstack:str) -> str:
+    return callstack.replace("[j]","_[j]")
+
+def make_flamegraph(prof_data:FlameGraphData, filename) -> None:
+    """
+    Produce a flamegraph given some folded flamegraph data
+    """
+
+    #build total flamegraph
+    folded = ""
+    for callstack, counts in prof_data.table.items():
+        folded += f"{callstack} {counts}\n"
+
+    filtered = run(["c++filt","-p"], input=folded, capture_output=True, text=True)
+    check_and_raise_errors(filtered.stderr, "c++filt")
+    filtered = restore_jit_annotation(filtered.stdout)
+
+    with open(filename,"w") as file:
+        run(["flamegraph.pl","--colors","java"], input=filtered, stdout=file, text=True)
+
+class FlameGraph(Visualization):
+
+    def __init__(
+        self, 
+        data_dir:str = "DistRDF_Data", 
+        perf_options:Optional[dict] = None,
+        filename:str = "flamegraph.svg"
+    ) -> None:
+
+        self._dc = partial(Decorator, data_dir = data_dir, perf_options = perf_options)
+        self._ct = partial(make_flamegraph, filename = filename)
+
+    @property
+    def Decorator(self):
+        return self._dc
+    
+    @property
+    def Client_task(self):
+        return self._ct

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Perf.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Perf.py
@@ -1,0 +1,60 @@
+from functools import reduce
+from typing import Optional
+import os
+
+from subprocess import Popen, DEVNULL, PIPE
+
+from DistRDF.Profiling.ErrorHandling import check_and_raise_errors
+
+PERF_DEFAULTS = {
+    "-e":"cycles:u",
+    "-m":"16K",
+    "--max-size":"50M",
+    "-F":"99",
+}
+
+def remove_logs(stderr:str)->str:
+    
+    err_lines = stderr.splitlines()
+    msg = "perf record:"
+    return "\n".join([line for line in err_lines if not msg in line])
+
+class collect_perf_data:
+    """
+    Context manager to collect profiling data in the mapper.
+    Data is saved in proc-pid.perf.data
+    """
+
+    def __init__(self, data_dir:str, perf_options:Optional[dict]):
+
+        #get current process id
+        pid = os.getpid()
+
+        #build perf options
+        os.makedirs(data_dir, exist_ok=True)
+        data_name = os.path.join(data_dir,f"proc-{pid}.perf.data")
+
+        customizable_options = PERF_DEFAULTS.copy()
+        customizable_options.update(perf_options or {})
+        
+        self.perf_opts = ["-p",str(pid),"--call-graph=fp","-o",data_name] + list(sum(customizable_options.items(), ()))
+
+
+    def __enter__(self):
+        
+        #spaw process hosting perf
+        self.perf_proc = Popen(["perf","record"]+self.perf_opts, stdout=DEVNULL, stderr=PIPE)
+
+    def __exit__(self, *exc):
+
+        #terminate perf sampling
+        self.perf_proc.terminate()
+
+        #ensure perf has dumped data by waiting for its subprocess to end
+        #this is necessary since terminate is a non-blocking operation
+        self.perf_proc.wait()
+
+        # Catch possible perf errors
+        _, err = self.perf_proc.communicate()
+        err = remove_logs(err.decode("utf-8"))
+        check_and_raise_errors(err,"perf record")

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Perf.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Perf.py
@@ -1,4 +1,3 @@
-from functools import reduce
 from typing import Optional
 import os
 

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/Perf.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/Perf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations 
+
 from typing import Optional
 import os
 
@@ -18,7 +20,7 @@ def remove_logs(stderr:str)->str:
     msg = "perf record:"
     return "\n".join([line for line in err_lines if not msg in line])
 
-class collect_perf_data:
+class CollectPerfData:
     """
     Context manager to collect profiling data in the mapper.
     Data is saved in proc-pid.perf.data

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/__init__.py
@@ -1,0 +1,68 @@
+#  @author Giulio Crognaletti
+#  @author Vincenzo Eduardo Padulano
+#  @author Enric Tejedor
+#  @date 2022-08
+
+################################################################################
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+# Inform cling to activate dumping of profiling information for jitted code.
+# It is crucial that this instruction is executed before importing ROOT in the distributed workers.
+from __future__ import annotations
+
+from os import environ
+environ["CLING_PROFILE"]="1"
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from ..DataFrame import RDataFrame
+
+from .Flamegraph import FlameGraph
+
+SUPPORTED_VISUALIZATIONS = {
+    "flamegraph": FlameGraph
+}
+
+class ClingProfile():
+    """
+    Context manager to enable profiling of DistRDF applications.
+
+    All DistRDF code executed within the ClingProfile context will collect performance metric data in the workers and
+    merge them together in a single visualization (e.g. a flamegraph).
+    """
+
+    def __init__(self, rdf:RDataFrame, visualization:str="flamegraph", **options) -> None:
+        
+        vclass = SUPPORTED_VISUALIZATIONS.get(visualization, None)
+
+        if not vclass:
+            raise ValueError("Visualization {visualization} is not supported.")
+        
+        self.visualization = vclass(**options)
+        self.rdf = rdf
+
+    def __enter__(self):
+        
+        self.rdf._headnode._visualization = self.visualization
+        self.rdf._headnode._activate_profiling = True
+
+    def __exit__(self, *exc):
+        
+        self.rdf._headnode._activate_profiling = False
+        self.rdf._headnode._visualization = None
+
+def profilable_mapper(*args, **kwargs):
+    """DistRDF mapper function wrapper"""
+
+    # This wrapper is used to trick pickle, and avoid import of the dependencies of distrdf_mapper, which include ROOT.
+    # By doing so, this submodule gets imported first, so the CLING_PROFILE=1 environment variable is set before cling
+    # gets initialized, hence effectively enabling the profiling feature.
+
+    # Import of DistRDF mapper is done only here
+    from DistRDF.Backends.Base import distrdf_mapper
+    return distrdf_mapper(*args, **kwargs)

--- a/bindings/experimental/distrdf/python/DistRDF/Profiling/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/Profiling/__init__.py
@@ -15,6 +15,14 @@
 # It is crucial that this instruction is executed before importing ROOT in the distributed workers.
 from __future__ import annotations
 
+# TODO: Each time the module DistRDF is imported, the CLING_PROFILE=1 variable is set
+# modyfing the environment in both the client and the workers.
+# This affects only the workers when the profling option is enabled, since in all other
+# cases Cling is already initialized. However the environment is modified every time, and
+# this can potentially give rise to unexpected side effects.
+# The issue can be solved by adding the option to programmatically enable/disable 
+# Cling's profiling feature after its initialization, moving this step inside the 
+# data collection context manager for all Visualizations
 from os import environ
 environ["CLING_PROFILE"]="1"
 

--- a/bindings/experimental/distrdf/python/DistRDF/__init__.py
+++ b/bindings/experimental/distrdf/python/DistRDF/__init__.py
@@ -9,15 +9,19 @@
 # For the licensing terms see $ROOTSYS/LICENSE.                                #
 # For the list of contributors see $ROOTSYS/README/CREDITS.                    #
 ################################################################################
+from __future__ import annotations
 
 import logging
 import sys
 import types
 
 import concurrent.futures
+from typing import TYPE_CHECKING
 
 from DistRDF.Backends import build_backends_submodules
-from DistRDF.Proxy import ActionProxy, VariationsProxy
+
+if TYPE_CHECKING:
+    from DistRDF.Proxy import ActionProxy, VariationsProxy
 
 logger = logging.getLogger(__name__)
 
@@ -151,5 +155,8 @@ def create_distributed_module(parentmodule):
 
     # Set non-optimized default mode
     distributed.optimized = False
+
+    from .Profiling import ClingProfile
+    distributed.ClingProfile = ClingProfile
 
     return distributed

--- a/interpreter/cling/tools/packaging/cpt.py
+++ b/interpreter/cling/tools/packaging/cpt.py
@@ -1802,7 +1802,6 @@ def make_dmg():
 ###############################################################################
 
 parser = argparse.ArgumentParser(description='Cling Packaging Tool')
-parser.add_argument('-build', "help")
 parser.add_argument('-c', '--check-requirements', help='Check if packages required by the script are installed',
                     action='store_true')
 parser.add_argument('--current-dev',


### PR DESCRIPTION
The pr includes the implementation of a profiling mechanism for DistRDF.
When the feature is activated, profiling data is collected in each distributed node and merged to produce a visualization (i.e. flamegraph) on the client side.

Activation of the feature is done using the ClingProfile ctx manager, accessed from ROOT.RDF.Experimental.Distributed module.
Usage example (dimuon analysis):

```python
RDataFrame = ROOT.RDF.Experimental.Distributed.Dask.RDataFrame
ClingProfile = ROOT.RDF.Experimental.Distributed.ClingProfile
...
df = RDataFrame("Events", files, npartitions=npartitions, daskclient=client)
with ClingProfile(df, filename="flamegraph.svg"):
    df = df.Filter("nMuon == 2", "Events with exactly two muons")
    ...
    h.GetValue()
```


