### PR TITLE
[DF] Fix jitted expressions with sub-branches of aliases

### DIFF
--- a/tree/dataframe/test/CMakeLists.txt
+++ b/tree/dataframe/test/CMakeLists.txt
@@ -14,7 +14,7 @@ ROOT_ADD_GTEST(dataframe_callbacks dataframe_callbacks.cxx LIBRARIES ROOTDataFra
 ROOT_ADD_GTEST(dataframe_histomodels dataframe_histomodels.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_interface dataframe_interface.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_nodes dataframe_nodes.cxx LIBRARIES ROOTDataFrame)
-ROOT_ADD_GTEST(dataframe_regression dataframe_regression.cxx LIBRARIES Physics ROOTDataFrame)
+ROOT_ADD_GTEST(dataframe_regression dataframe_regression.cxx LIBRARIES Physics ROOTDataFrame GenVector)
 ROOT_ADD_GTEST(dataframe_utils dataframe_utils.cxx LIBRARIES ROOTDataFrame)
 ROOT_ADD_GTEST(dataframe_report dataframe_report.cxx LIBRARIES ROOTDataFrame)
 


### PR DESCRIPTION
Given a string expression such as "alias.subbranch" (where
`subbranch` is _not_ also the name of a valid data member of
the type of the "alias" top-level branch), we used to transform
the expression to `[](T &var0) { return var0.subbranch; }`,
which does not compile.

Now aliases in jitted expressions are resolved in a first step
and only then we try to match the expression against known branch
names, fixing the problem.

This PR fixes https://github.com/root-project/root/issues/11207 (and adds a test).

- [x] add a less weird test, e.g. based on `std::vector<XYZVector>`, for which we should have dictionaries
