### PR TITLE
[RF] Enable vectorized second order interpolation for weight evaluation

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -280,6 +280,8 @@ protected:
   mutable double _cache_sum{0.};          ///<! Cache for sum of entries ;
 
 private:
+
+  void interpolateQuadratic(double* output, RooSpan<const double> xVals, bool correctForBinSize, bool cdfBoundaries);
   void interpolateLinear(double* output, RooSpan<const double> xVals, bool correctForBinSize, bool cdfBoundaries);
   double weightInterpolated(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);
 

--- a/roofit/roofitcore/src/RooHistFunc.cxx
+++ b/roofit/roofitcore/src/RooHistFunc.cxx
@@ -196,7 +196,7 @@ double RooHistFunc::evaluate() const
 
 
 void RooHistFunc::computeBatch(cudaStream_t*, double* output, size_t size, RooFit::Detail::DataMap const& dataMap) const {
-  if (_depList.size() == 1 && _intOrder < 2) {
+  if (_depList.size() == 1) {
     auto xVals = dataMap.at(_depList[0]);
     _dataHist->weights(output, xVals, _intOrder, false, _cdfBoundaries);
     return;

--- a/roofit/roofitcore/src/RooHistPdf.cxx
+++ b/roofit/roofitcore/src/RooHistPdf.cxx
@@ -191,7 +191,7 @@ RooHistPdf::~RooHistPdf()
 void RooHistPdf::computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const {
 
   // For interpolation and histograms of higher dimension, use base function
-  if(_pdfObsList.size() > 1 || _intOrder > 1) {
+  if(_pdfObsList.size() > 1) {
       RooAbsReal::computeBatch(nullptr, output, nEvents, dataMap);
       return;
   }

--- a/roofit/roofitcore/test/testRooDataHist.cxx
+++ b/roofit/roofitcore/test/testRooDataHist.cxx
@@ -673,87 +673,117 @@ TEST(RooDataHist, CombinedRooDataHistBinning)
 
 
 
-TEST(RooDataHist, VectorizedWeightsZeroInterpolation)
+class WeightsTest : public testing::TestWithParam<std::tuple<int, bool, bool, bool>> {
+   void SetUp() override
+   {
+      _interpolationOrder = std::get<0>(GetParam());
+      _correctForBinSize = std::get<1>(GetParam());
+      _cdfBoundaries = std::get<2>(GetParam());
+      _isUniform = std::get<3>(GetParam());
+   }
+
+   void TearDown() override {}
+
+protected:
+   int _interpolationOrder = 0;
+   bool _correctForBinSize = false;
+   bool _cdfBoundaries = false;
+   bool _isUniform = false;
+};
+
+TEST_P(WeightsTest, VectorizedWeights)
 {
+  // Change local message level to suppress unnecessary info
+  RooHelpers::LocalChangeMsgLevel chmsglvl1{RooFit::WARNING, 0u, RooFit::DataHandling, true};
+  RooHelpers::LocalChangeMsgLevel chmsglvl2{RooFit::WARNING, 0u, RooFit::Fitting, true};
+
   const double xMin = -1;
   const double xMax = 1;
   const std::size_t nBins = 100;
-  std::vector<double> boundaries(nBins + 1);
-  for(std::size_t i = 0; i < boundaries.size(); ++i) {
-      boundaries[i] = ((xMax - xMin) / nBins) * i + xMin;
+
+  TH1D h1;
+  if (_isUniform) {
+    h1 = TH1D("h1", "h1", nBins, xMin, xMax);
   }
-  TH1D h1{"h1", "h1", nBins, boundaries.data()};
-  
+  else {
+    std::vector<double> boundaries(nBins + 1);
+    for(std::size_t i = 0; i < boundaries.size(); ++i) {
+      boundaries[i] = ((xMax - xMin) / nBins) * i + xMin;
+    }
+    h1 = TH1D("h1", "h1", nBins, boundaries.data());
+  }
+
   h1.FillRandom("gaus");
 
   RooRealVar x("x", "x", 0, xMin, xMax);
   RooDataHist dh{"dh", "dh", x, &h1};
-  RooHistPdf histPdf{"histPdf", "histPdf", x, dh};
+
+  std::unique_ptr<RooAbsReal> absReal;
+  if (_correctForBinSize) {
+    auto histPdf = std::make_unique<RooHistPdf>("histPdf", "histPdf", x, dh, _interpolationOrder);
+    histPdf->setCdfBoundaries(_cdfBoundaries);
+    absReal = std::move(histPdf);
+  } else {
+    auto histFunc = std::make_unique<RooHistFunc>("histPdf", "histPdf", x, dh, _interpolationOrder);
+    histFunc->setCdfBoundaries(_cdfBoundaries);
+    absReal = std::move(histFunc);
+  }
 
   // Fill 10 000 random x values
   std::size_t nVals = 10000;
   std::vector<double> xVals(nVals);
   RooDataSet data{"data", "data", x};
 
-  for(std::size_t i = 0; i < nVals; ++i) {
-      xVals[i] = xMin + RooRandom::uniform() * (xMax - xMin);
-      x.setVal(xVals[i]);
-      data.add(x);
+  for (std::size_t i = 0; i < nVals; ++i) {
+    xVals[i] = xMin + RooRandom::uniform() * (xMax - xMin);
+    x.setVal(xVals[i]);
+    data.add(x);
   }
 
   std::vector<double> weightsGetVal(nVals);
-  for(std::size_t i = 0; i < nVals; ++i) {
+  for (std::size_t i = 0; i < nVals; ++i) {
     x.setVal(xVals[i]);
-    weightsGetVal[i] = histPdf.getVal(x);
+    weightsGetVal[i] = absReal->getVal(x);
   }
   x.setVal(0.0);
 
-  auto weightsGetValues = histPdf.getValues(data);
+  auto weightsGetValues = absReal->getValues(data);
 
-  for(std::size_t i = 0; i < nVals; ++i) {
+  for (std::size_t i = 0; i < nVals; ++i) {
     EXPECT_NEAR(weightsGetVal[i], weightsGetValues[i], 1e-6);
   }
 }
 
-
-TEST(RooDataHist, VectorizedFirstOrderInterpolation)
-{
-  const double xMin = -1;
-  const double xMax = 1;
-  const std::size_t nBins = 100;
-  std::vector<double> boundaries(nBins + 1);
-  for(std::size_t i = 0; i < boundaries.size(); ++i) {
-      boundaries[i] = ((xMax - xMin) / nBins) * i + xMin;
-  }
-  TH1D h1{"h1", "h1", nBins, boundaries.data()};
-  
-  h1.FillRandom("gaus");
-
-  RooRealVar x("x", "x", 0, xMin, xMax);
-  RooDataHist dh{"dh", "dh", x, &h1};
-  RooHistPdf histPdf{"histPdf", "histPdf", x, dh, 1};
-
-  // Fill 10 000 random x values
-  std::size_t nVals = 10000;
-  std::vector<double> xVals(nVals);
-  RooDataSet data{"data", "data", x};
-
-  for(std::size_t i = 0; i < nVals; ++i) {
-      xVals[i] = xMin + RooRandom::uniform() * (xMax - xMin);
-      x.setVal(xVals[i]);
-      data.add(x);
-  }
-
-  std::vector<double> weightsGetVal(nVals);
-  for(std::size_t i = 0; i < nVals; ++i) {
-    x.setVal(xVals[i]);
-    weightsGetVal[i] = histPdf.getVal(x);
-  }
-  x.setVal(0.0);
-
-  auto weightsGetValues = histPdf.getValues(data);
-
-  for(std::size_t i = 0; i < nVals; ++i) {
-    EXPECT_NEAR(weightsGetVal[i], weightsGetValues[i], 1e-6);
-  }
-}
+INSTANTIATE_TEST_SUITE_P(RooDataHist, WeightsTest,
+                         testing::Values(WeightsTest::ParamType{0, false, false, false},
+                                         WeightsTest::ParamType{1, false, false, false},
+                                         WeightsTest::ParamType{2, false, false, false},
+                                         WeightsTest::ParamType{0, false, true, false},
+                                         WeightsTest::ParamType{1, false, true, false},
+                                         WeightsTest::ParamType{2, false, true, false},
+                                         WeightsTest::ParamType{0, true, false, false},
+                                         WeightsTest::ParamType{1, true, false, false},
+                                         WeightsTest::ParamType{2, true, false, false},
+                                         WeightsTest::ParamType{0, true, true, false},
+                                         WeightsTest::ParamType{1, true, true, false},
+                                         WeightsTest::ParamType{2, true, true, false},
+                                         WeightsTest::ParamType{0, false, false, true},
+                                         WeightsTest::ParamType{1, false, false, true},
+                                         WeightsTest::ParamType{2, false, false, true},
+                                         WeightsTest::ParamType{0, false, true, true},
+                                         WeightsTest::ParamType{1, false, true, true},
+                                         WeightsTest::ParamType{2, false, true, true},
+                                         WeightsTest::ParamType{0, true, false, true},
+                                         WeightsTest::ParamType{1, true, false, true},
+                                         WeightsTest::ParamType{2, true, false, true},
+                                         WeightsTest::ParamType{0, true, true, true},
+                                         WeightsTest::ParamType{1, true, true, true},
+                                         WeightsTest::ParamType{2, true, true, true}),
+                         [](testing::TestParamInfo<WeightsTest::ParamType> const &paramInfo) {
+                            std::stringstream ss;
+                            ss << (std::get<1>(paramInfo.param) ? "RooHistFunc" : "RooHistPdf");
+                            ss << "IntOrder" << std::get<0>(paramInfo.param);
+                            ss << (std::get<2>(paramInfo.param) ? "CDF" : "");
+                            ss << (std::get<3>(paramInfo.param) ? "UniformBins" : "");
+                            return ss.str();
+                         });


### PR DESCRIPTION
With the function `RooDataHist::interpolateQuadratic()` it is now possible to
use `RooDataHist::weights()` (implemented in #11171) to evaluate weights for
one dimensional histograms with up to second order interpolation.

The structure of `RooDataHist::interpolateQuadratic()` is similar to that of
`RooDataHist::interpolateLinear()`, which was implemented in #11211
It finds the coefficients of a second order polynomial between three
neighboring bin centers by solving a system of three quadratic equations. With
the coefficients of the quadratic function, the interpolated weight for an event
between two bin centers can be calculated.

If an event in a bin is to the left of the bin center coordinates, the
corresponding weight is found by interpolating between the current bin and the
two neighboring bins to the left. If the event is to the right of the bin center,
the weight is found by interpolating between the current bin center, one bin to
the the left and one bin to the right. For the first two bins and the last bin,
the interpolation is performed either by mirroring the histogram outside its
boundaries or by applying cdf boundaries.

`RooDataHist::weights()` has been updated so that it calls
`RooDataHist::interpolateQuadratic()` when the interpolation order is two.
Furthermore, `RooDataHist::computeBatch()` and `RooHistFunc::computeBatch()`
have been updated so that they always call RooDatahist::weights() in the case
where the histogram is one dimensional. Since the old interpolation
implementation `RooDataHist::interpolateDim()` only supported up to second
order interpolation, it has been completely replaced by
`RooDataHist::interpolateLinear()` and `RooDataHist::interpolateQuadratic()`
in these `computeBatch()` functions in the case of one dimensional histograms.

# This Pull request:

## Changes or fixes:


## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

