### PR TITLE
[asan] Only preload ASan runtime for CMD

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -1610,7 +1610,7 @@ function(ROOT_ADD_TEST test)
              _command MATCHES roottest/root/rint/driveTabCom.py))
        OR (_command MATCHES roottest/python/cmdLineUtils AND
            NOT _command MATCHES MakeNameCyclesRootmvInput))
-      list(APPEND ARG_ENVIRONMENT ${ld_preload}=${ASAN_EXTRA_LD_PRELOAD})
+      set(_command ${_command} -DCMD_ENV=${ld_preload}=${ASAN_EXTRA_LD_PRELOAD})
     endif()
   endif()
 

--- a/cmake/modules/RootTestDriver.cmake
+++ b/cmake/modules/RootTestDriver.cmake
@@ -118,6 +118,11 @@ endif()
 
 if(CMD)
   #---Execute the actual test ------------------------------------------------------------------------
+  if(CMD_ENV)
+    # Only support exactly one variable
+    set(_cmd ${CMAKE_COMMAND} -E env ${CMD_ENV} ${_cmd})
+  endif()
+
   if(IN)
     set(_input INPUT_FILE ${IN})
   endif()


### PR DESCRIPTION
Some Python tests define `PRE_` and `POST_CMD`; they should not get the ASan runtime preloaded. Invent a new `CMD_ENV` that supports exactly one environment variable that is applied to `CMD`. This fixes another 16 test failures.