### PR TITLE
[IO] Avoid nullptr dereference in I/O of std::pair

### DIFF
--- a/core/meta/inc/TClass.h
+++ b/core/meta/inc/TClass.h
@@ -33,6 +33,7 @@ class TObjArray;
 // #include <set>
 #endif
 
+#include <cstddef>
 #include <map>
 #include <string>
 #include <unordered_set>
@@ -631,8 +632,8 @@ struct TClassGetClassHelper {
 template <typename F, typename S>
 struct TClassGetClassHelper<std::pair<F, S> > {
    static TClass *GetClass(Bool_t load, Bool_t silent) {
-      std::pair<F, S> *p = nullptr;
-      size_t hint_offset = ((char*)&(p->second)) - (char*)p;
+      using pair_t = std::pair<F,S>;
+      size_t hint_offset = offsetof(pair_t, second);
       return TClass::GetClass(typeid(std::pair<F, S>), load, silent, hint_offset, sizeof(std::pair<F,S>));
    }
 };


### PR DESCRIPTION
Given
```cpp
// tree_with_pair.cpp
void tree_with_pair() {
   TTree t("t", "t");
   auto x = std::make_pair(42, 84);
   //t.Branch("topbranch", &x, "a/I:b/I")
   t.Branch("topbranch", &x);
   t.Fill();
   t.Scan();
}
```

, without this patch the output is:

```
Error in <HandleInterpreterException>: Trying to dereference null pointer or trying to call routine taking non-null arguments
Execution of your code was aborted.
In module 'Core':
/home/blue/ROOT/dev/cmake-build-foo/include/TClass.h:635:38: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
      size_t hint_offset = ((char*)&(p->second)) - (char*)p;
                                     ^
```

with this patch:

```
Processing tree_with_pair.cpp...
************************************
*    Row   * topbranch * topbranch *
************************************
*        0 *        42 *        84 *
************************************
```

This fixes #11215 .