### PR TITLE
[RF] Fix remaining RooFit ASAN failures

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooabsreal.py
@@ -113,3 +113,19 @@ class RooAbsReal(object):
         # Redefinition of `RooAbsReal.chi2FitTo` for keyword arguments.
         args, kwargs = _kwargs_to_roocmdargs(*args, **kwargs)
         return self._chi2FitTo(*args, **kwargs)
+
+    def getVal(self, normalizationSet=None):
+        # We do the conversion to RooArgSet now, such that we can keep alive
+        # the normalization set by setting it as an attribute of this
+        # RooAbsReal.
+        if isinstance(normalizationSet, (set, list, tuple)):
+            import ROOT
+
+            normalizationSet = ROOT.RooArgSet(normalizationSet)
+        # With the pythonizations, we have the opportunity to use the Python
+        # reference counting to make sure the last normalization set doesn't
+        # get deleted under our feet (RooFit tries to use it by pointer when
+        # you call getVal() without any normalization set the next time).
+        if normalizationSet:
+            self._getVal_normSet = normalizationSet
+        return self._getVal(normalizationSet) if normalizationSet else self._getVal()

--- a/roofit/roofitcore/inc/RooLinearVar.h
+++ b/roofit/roofitcore/inc/RooLinearVar.h
@@ -62,12 +62,12 @@ protected:
   double evaluate() const override ;
 
   mutable RooLinTransBinning _binning ;
-  RooLinkedList _altBinning ; ///<!
-  RooRealProxy _var ;         ///< Input observable
-  RooRealProxy _slope ;       ///< Slope of transformation
-  RooRealProxy _offset ;      ///< Offset of transformation
+  RooLinkedList _altBinning ;              ///<!
+  RooTemplateProxy<RooAbsRealLValue> _var; ///< Input observable
+  RooRealProxy _slope ;                    ///< Slope of transformation
+  RooRealProxy _offset ;                   ///< Offset of transformation
 
-  ClassDefOverride(RooLinearVar,1) // Lvalue linear transformation function
+  ClassDefOverride(RooLinearVar,2) // Lvalue linear transformation function
 };
 
 #endif

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -452,11 +452,15 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
   // This is necessary because SPlot assumes the yields minimise -Log(likelihood)
   pdf->fitTo(*fSData, RooFit::Extended(true), RooFit::SumW2Error(true), RooFit::PrintLevel(-1), RooFit::PrintEvalErrors(-1), arg5, arg6, arg7, arg8);
 
+  // The list of variables to normalize over when calculating PDF values.
+  RooArgSet vars(*fSData->get() );
+  vars.remove(projDeps, true, true);
+
   // Hold the value of the fitted yields
   std::vector<double> yieldsHolder;
 
   for(Int_t i = 0; i < yieldsTmp.getSize(); i++)
-    yieldsHolder.push_back(static_cast<RooAbsReal*>(yieldsTmp.at(i))->getVal());
+    yieldsHolder.push_back(static_cast<RooAbsReal*>(yieldsTmp.at(i))->getVal(&vars));
 
   const Int_t nspec = yieldsTmp.getSize();
   RooArgList yields = *(RooArgList*)yieldsTmp.snapshot(false);
@@ -465,11 +469,6 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
     coutI(InputArguments) << "Printing Yields" << endl;
     yields.Print();
   }
-
-  // The list of variables to normalize over when calculating PDF values.
-
-  RooArgSet vars(*fSData->get() );
-  vars.remove(projDeps, true, true);
 
 
   // first calculate the pdf values for all species and all events
@@ -484,10 +483,10 @@ void SPlot::AddSWeight( RooAbsPdf* pdf, const RooArgList &yieldsTmp,
     assert(pdf->dependsOn(*yieldinpdf));
 
     if (yieldinpdf) {
-      coutI(InputArguments)<< "yield in pdf: " << yieldinpdf->GetName() << " " << thisyield->getVal() << endl;
+      coutI(InputArguments)<< "yield in pdf: " << yieldinpdf->GetName() << " " << thisyield->getVal(&vars) << endl;
 
       yieldvars.push_back(yieldinpdf) ;
-      yieldvalues.push_back(thisyield->getVal()) ;
+      yieldvalues.push_back(thisyield->getVal(&vars)) ;
     }
   }
 

--- a/roofit/roostats/test/testSPlot.cxx
+++ b/roofit/roostats/test/testSPlot.cxx
@@ -13,7 +13,7 @@
 TEST(SPlot, UseWithRooLinearVar) {
   RooRealVar x("x", "observable", 0, 0, 20);
   RooRealVar m("m", "mean", 5., -10, 10);
-  RooRealVar s("s", "sigma", 2., 0, 10);
+  RooRealVar s("s", "sigma", 2., 0.1, 10);
   RooGaussian gaus("gaus", "gaus", x, m, s);
 
   RooRealVar a("a", "exp", -0.2, -10., 0.);
@@ -26,7 +26,7 @@ TEST(SPlot, UseWithRooLinearVar) {
   RooLinearVar c2("c2", "c2", r2, common, RooFit::RooConst(0.));
   RooAddPdf sum("sum", "sum", RooArgSet(gaus, ex), RooArgSet(c1, c2));
 
-  auto data = sum.generate(x, 1000);
+  std::unique_ptr<RooDataSet> data{sum.generate(x, 1000)};
 
   RooStats::SPlot splot("splot", "splot", *data, &sum, RooArgSet(c1, c2));
   EXPECT_EQ(splot.GetNumSWeightVars(), 2);


### PR DESCRIPTION
* fixes a memory leak in `testSPlot`
* make sure the last normalization set is kept alive in PyROOT even when the last normalization set was implicitly created from a Python collection via the new Pythonizations
* make sure no derived coefficients are evaluated without normalization sets in `SPlot` to fix undefined behavior when calling `getVal()` and `RooAbsReal::getValV()` checks for the last normalization set that might not be alive anymore
* improving the code of the `RooLinearVar` that is used by the `SPlot`

Closes #11221.
