### PR TITLE
Fix the classic double "the the" typos in the ROOT documentation

### DIFF
--- a/README/README.CXXMODULES.md
+++ b/README/README.CXXMODULES.md
@@ -218,7 +218,7 @@ implementation searches in the database if this is a known entity.
 Line #1 does not require a definition and the forward declaration consumed at
 startup is sufficient. Parsing of `Foo.h` is not required. This comes at a cost
 of having some non-trivial patches in clang to merge default function arguments
-and default template arguments. The design of the the ROOTMAP infrastructure
+and default template arguments. The design of the ROOTMAP infrastructure
 requires the default arguments to be attached to more than one declaration which
 is not allowed by standard C++. The behavior of line #1 is equivalent to:
 ```cpp

--- a/README/ReleaseNotes/v626/index.md
+++ b/README/ReleaseNotes/v626/index.md
@@ -672,7 +672,7 @@ canvas->Print(".tex", "Standalone");
 
 - Add missing documentation to TH1 functions.
 
-- Restructure the the math reference guide.
+- Restructure the math reference guide.
 
 - Make the web gui documentation visible in the reference guide
 

--- a/README/cfortran.doc
+++ b/README/cfortran.doc
@@ -1530,7 +1530,7 @@ Some loaders, including at least one for the CRAY, turn off the
 'automagically set aside storage' capability for Fortran common blocks,
 if any C object declares that common block.
 Therefore, C code should define, i.e. set aside storage,
-for the the common block as shown above.
+for the common block as shown above.
 
 e.g.
 C Fortran

--- a/bindings/pyroot_legacy/src/TPyBufferFactory.cxx
+++ b/bindings/pyroot_legacy/src/TPyBufferFactory.cxx
@@ -64,7 +64,7 @@ namespace {
 // implement get, str, and length functions
    Py_ssize_t buffer_length( PyObject* self )
    {
-   // Retrieve the (type-strided) size of the the buffer; may be a guess.
+   // Retrieve the (type-strided) size of the buffer; may be a guess.
 #if PY_VERSION_HEX < 0x03000000
       Py_ssize_t nlen = ((PyBufferTop_t*)self)->fSize;
       Py_ssize_t item = ((PyBufferTop_t*)self)->fItemSize;

--- a/build/rmkdepend/imakemdep.h
+++ b/build/rmkdepend/imakemdep.h
@@ -679,7 +679,7 @@ char *cpp_argv[ARGUMENTS] = {
 /*
  * Step 7:  predefs
  *     If your compiler and/or preprocessor define any specific symbols, add
- *     them to the the following table.  The definition of struct symtab is
+ *     them to the following table. The definition of struct symtab is
  *     in util/makedepend/def.h.
  */
 struct symtab   predefs[] = {

--- a/config/root-help.el.in
+++ b/config/root-help.el.in
@@ -193,7 +193,7 @@
 ;;      created.  The point is left in the current window. 
 ;;
 ;;    root-send-buffer-to-root
-;;      Sends the the current buffer to an interactive ROOT session.  
+;;      Sends the current buffer to an interactive ROOT session.  
 ;;      If no session exists, then one will be created.  The point is
 ;;      left in the current window.  If the buffer has an associated
 ;;      file, and it has been modified since the last save, then the
@@ -1272,7 +1272,7 @@ that will be inserted into the session on startup."
 
 ;;____________________________________________________________________
 (defun root-send-buffer-to-root () 
-  "Sends the the current buffer to an interactive ROOT session.  
+  "Sends the current buffer to an interactive ROOT session.  
 
 If no session exists, then one will be created.  The point is
 left in the current window.  If the buffer has an associated

--- a/config/rootauthrc.in
+++ b/config/rootauthrc.in
@@ -3,7 +3,7 @@
 #
 #  NB: this file contains system defaults read only in the case the 
 #      $HOME/.rootauthrc is non-existing or non-readable. Its content 
-#      can be included in the the private $HOME/.rootauthrc using the 
+#      can be included in the private $HOME/.rootauthrc using the 
 #      include directive (see below). The location of the private file
 #      can be changed by setting the environment variable ROOTAUTHRC
 #      to the appropriate absolute file pathname.

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1979,7 +1979,7 @@ Int_t TColor::GetColorBright(Int_t n)
    if (n < ncolors) color = (TColor*)colors->At(n);
    if (!color) return -1;
 
-   //Get the rgb of the the new bright color corresponding to color n
+   //Get the rgb of the new bright color corresponding to color n
    Float_t r,g,b;
    HLStoRGB(color->GetHue(), 1.2f*color->GetLight(), color->GetSaturation(), r, g, b);
 
@@ -2011,7 +2011,7 @@ Int_t TColor::GetColorDark(Int_t n)
    if (n < ncolors) color = (TColor*)colors->At(n);
    if (!color) return -1;
 
-   //Get the rgb of the the new dark color corresponding to color n
+   //Get the rgb of the new dark color corresponding to color n
    Float_t r,g,b;
    HLStoRGB(color->GetHue(), 0.7f*color->GetLight(), color->GetSaturation(), r, g, b);
 

--- a/core/base/src/root-argparse.py
+++ b/core/base/src/root-argparse.py
@@ -22,5 +22,5 @@ An extensive Users Guide is available from that site (see below).
 	parser.add_argument('--web=<browser>', help='Display graphics in specified web browser')
 	parser.add_argument('[dir]', help='if dir is a valid directory cd to it before executing')
 	parser.add_argument('[data1.root...dataN.root]', help='Open the given ROOT files; remote protocols (such as http://) are supported')
-	parser.add_argument('[file1.C...fileN.C]', help='Execute the the ROOT macro file1.C ... fileN.C.\nCompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
+	parser.add_argument('[file1.C...fileN.C]', help='Execute the ROOT macro file1.C ... fileN.C.\nCompilation flags as well as macro arguments can be passed, see format in https://root.cern/manual/root_macros_and_shared_libraries/')
 	return parser

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2588,7 +2588,7 @@ char *TClass::EscapeChars(const char *text) const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return a pointer the the real class of the object.
+/// Return a pointer to the real class of the object.
 /// This is equivalent to object->IsA() when the class has a ClassDef.
 /// It is REQUIRED that object is coming from a proper pointer to the
 /// class represented by 'this'.

--- a/core/winnt/inc/Win32Constants.h
+++ b/core/winnt/inc/Win32Constants.h
@@ -52,7 +52,7 @@ enum ROOT_Graphics_Msg {
 
 enum    L_ROOT_OpenGL
      {
-       GL_MAKECURRENT   // Make the the OpenGL  rendering context the current one
+       GL_MAKECURRENT   // Make the OpenGL rendering context the current one
      };
 
 /*     Emulation of X11 control ROOT routines

--- a/documentation/doxygen/filter.cxx
+++ b/documentation/doxygen/filter.cxx
@@ -10,7 +10,7 @@
 /// The two tags where used the THtml version to generate images from ROOT code.
 /// The generated picture is inlined exactly at the place where the macro is
 /// defined. The Macro can be defined in two way:
-///  - by direct in-lining of the the C++ code
+///  - by direct in-lining of the C++ code
 ///  - by a reference to a C++ file
 /// The tag `Begin_Macro` can have the parameter `(source)`. The directive becomes:
 /// `Begin_Macro(source)`. This parameter allows to show the macro's code in addition.

--- a/documentation/minuit2/Minuit2.md
+++ b/documentation/minuit2/Minuit2.md
@@ -1506,8 +1506,8 @@ MnGlobalCorrelationCoeff data member.
 ### MnUserParameterState::isValid() and\
 MnUserParameterState::hasCovariance() ###
 
-isValid() returns true if the the state is valid, false if not.
-hasCovariance returns true if the the state has a valid covariance,
+isValid() returns `true` if the state is valid, false if not.
+hasCovariance returns `true` if the state has a valid covariance,
 false otherwise.
 
 ### MnUserParameterState::fval(), MnUserParameterState::edm(),\
@@ -1528,7 +1528,7 @@ defined in the file MnPrint.h.
 
 ### operator$<<$(std::ostream&, const FunctionMinimum&) ###
 
-Prints out the the values of the FunctionMinimum, internal parameters
+Prints out the values of the FunctionMinimum, internal parameters
 and external parameters (MnUserParameterState), the function value, the
 expected distance to the minimum and the number of function calls.
 

--- a/documentation/users-guide/FittingHistograms.md
+++ b/documentation/users-guide/FittingHistograms.md
@@ -45,7 +45,7 @@ the histogram represents counts
 	weights different than 1.
 
     -   "`P`" Use Pearson chi-square method, using expected errors instead of the observed one given by `TH1::GetBinError` (default case).
-         The expected error is instead estimated from the the square-root of the bin function value.
+         The expected error is instead estimated from the square-root of the bin function value.
 
 	-   "`Q`" Quiet mode (minimum printing)
 

--- a/graf2d/asimage/src/libAfterImage/asimagexml.c
+++ b/graf2d/asimage/src/libAfterImage/asimagexml.c
@@ -130,7 +130,7 @@ static char* cdata_str = XML_CDATA_STR;
  * Also, variables of the form $image.width and $image.height are
  * supported.  $image.width is the width of the image with refid "image",
  * and $image.height is the height of the same image.  The special
- * $xroot.width and $xroot.height values are defined by the the X root
+ * $xroot.width and $xroot.height values are defined by the X root
  * window, if there is one.  This allows images to be scaled to the
  * desktop size: <scale width="$xroot.width" height="$xroot.height">.
  *

--- a/graf2d/graf/src/TPie.cxx
+++ b/graf2d/graf/src/TPie.cxx
@@ -786,7 +786,7 @@ TLegend* TPie::MakeLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2, co
 ///  - "R"   Print the labels along the central "R"adius of slices.
 ///  - "T"   Print the label in a direction "T"angent to circle that describes
 ///          the TPie.
-///  - "SC"  Paint the the labels with the "S"ame "C"olor as the slices.
+///  - "SC"  Paint the labels with the "S"ame "C"olor as the slices.
 ///  - "3D"  Draw the pie-chart with a pseudo 3D effect.
 ///  - "NOL" No OutLine: Don't draw the slices' outlines, any property over the
 ///          slices' line is ignored.

--- a/graf2d/win32gdk/gdk/src/glib/gmain.c
+++ b/graf2d/win32gdk/gdk/src/glib/gmain.c
@@ -2274,7 +2274,7 @@ g_main_context_pending (GMainContext *context)
  * for a source to become ready, then dispatching the highest priority
  * events sources that are ready. Note that even when @may_block is %TRUE,
  * it is still possible for g_main_context_iteration() to return
- * %FALSE, since the the wait may be interrupted for other
+ * %FALSE, since the wait may be interrupted for other
  * reasons than an event source becoming ready.
  * 
  * Return value: %TRUE if events were dispatched.

--- a/graf2d/x11/src/TGX11.cxx
+++ b/graf2d/x11/src/TGX11.cxx
@@ -1108,7 +1108,7 @@ Int_t TGX11::OpenDisplay(void *disp)
    GetColor(0).fDefined = kTRUE; // default background
    GetColor(0).fPixel = fWhitePixel;
 
-   // Inquire the the XServer Vendor
+   // Inquire the XServer Vendor
    char vendor[132];
    strlcpy(vendor, XServerVendor((Display*)fDisplay),132);
 

--- a/graf3d/gl/src/TGLCamera.cxx
+++ b/graf3d/gl/src/TGLCamera.cxx
@@ -158,7 +158,7 @@ void TGLCamera::UpdateCache() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the the current camera frustum. If asBox == kFALSE return
+/// Return the current camera frustum. If asBox == kFALSE return
 /// a true frustum (truncated square based pyramid). If asBox == kTRUE
 /// return a true box, using the far clipping plane intersection projected
 /// back to the near plane.

--- a/gui/ged/src/TGedEditor.cxx
+++ b/gui/ged/src/TGedEditor.cxx
@@ -38,7 +38,7 @@ different class is selected, a new object editor is loaded in the
 editor frame. The old one is cached in memory for potential reuse.
 
 Any created canvas will be shown with the editor if you have a
-.rootrc file in your working directory containing the the line:
+.rootrc file in your working directory containing the line:
 Canvas.ShowEditor:      true
 
 An created object can be set as selected in a macro by:

--- a/gui/gui/src/TGDoubleSlider.cxx
+++ b/gui/gui/src/TGDoubleSlider.cxx
@@ -211,13 +211,13 @@ void TGDoubleSlider::ChangeCursor(Event_t *event)
    // constrain to the slider width
    if (xy > hw/2-7 && xy < hw/2+7 && fMove != 3) {
       // if the mouse pointer is in the top resizing zone,
-      // and we are not already moving the the bottom side,
+      // and we are not already moving the bottom side,
       // set the cursor shape as TopSide
       if ((yx <= (relMax - relMin) / 4 + relMin) &&
           (yx >= relMin) && (fMove != 2))
          gVirtualX->SetCursor(fId, minCur);
       // if the mouse pointer is in the bottom resizing zone,
-      // and we are not already moving the the top side,
+      // and we are not already moving the top side,
       // set the cursor shape as BottomSide
       else if ((yx >= (relMax - relMin) / 4 * 3 + relMin) &&
                (yx <= relMax) && (fMove != 1))

--- a/gui/guihtml/src/TGHtmlImage.cxx
+++ b/gui/guihtml/src/TGHtmlImage.cxx
@@ -362,7 +362,7 @@ const char *TGHtml::GetPctWidth(TGHtmlElement *p, char *opt, char *ret)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// This routine searchs for an image beneath the coordinates x,y
-/// and returns the token number of the the image, or -1 if no
+/// and returns the token number of the image, or -1 if no
 /// image found.
 
 int TGHtml::GetImageAt(int x, int y)

--- a/hist/hist/src/TF1.cxx
+++ b/hist/hist/src/TF1.cxx
@@ -2700,7 +2700,7 @@ Double_t TF1::IntegralOneDim(Double_t a, Double_t b,  Double_t epsrel, Double_t 
 /// When the poassed pointer to the covariance matrix is null, a covariance matrix from the last fit is retrieved
 /// from a global fitter instance when it exists. Note that the global fitter instance
 /// esists only when ROOT is not running with multi-threading enabled (ROOT::IsImplicitMTEnabled() == True).
-/// When the ovariance matrix from the last fit cannot be retrieved, an error message is printed and a a zero value is
+/// When the ovariance matrix from the last fit cannot be retrieved, an error message is printed and a zero value is
 /// returned.
 ///
 ///
@@ -2750,7 +2750,7 @@ Double_t TF1::IntegralError(Double_t a, Double_t b, const Double_t *params, cons
 /// When the poassed pointer to the covariance matrix is null, a covariance matrix from the last fit is retrieved
 /// from a global fitter instance when it exists. Note that the global fitter instance
 /// esists only when ROOT is not running with multi-threading enabled (ROOT::IsImplicitMTEnabled() == True).
-/// When the ovariance matrix from the last fit cannot be retrieved, an error message is printed and a a zero value is
+/// When the ovariance matrix from the last fit cannot be retrieved, an error message is printed and a zero value is
 /// returned.
 ///
 ///

--- a/hist/hist/src/TPrincipal.cxx
+++ b/hist/hist/src/TPrincipal.cxx
@@ -45,7 +45,7 @@ particle at say 8 fixed planes, the trajectory is described by an
 \f]
 in 8-dimensional pattern space.
 
-One proceeds by generating a a representative tracks sample and
+One proceeds by generating a representative tracks sample and
 building up the covariance matrix \f$\mathsf{C}\f$. Its eigenvectors and
 eigenvalues are computed by standard methods, and thus a new basis is
 obtained for the original 8-dimensional space the expansion of the

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -4170,7 +4170,7 @@ void TGraphPainter::PaintGraphSimple(TGraph *theGraph, Option_t *option)
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Paint a polyline with hatches on one side showing an exclusion zone. x and y
-/// are the the vectors holding the polyline and n the number of points in the
+/// are the vectors holding the polyline and n the number of points in the
 /// polyline and `w` the width of the hatches. `w` can be negative.
 /// This method is not meant to be used directly. It is called automatically
 /// according to the line style convention.

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -2012,7 +2012,7 @@ The height of the mesh is proportional to the cell content.
 | "SURF2"  | Draw a surface plot using colors to show the cell contents.|
 | "SURF3"  | Same as `SURF` with an additional filled contour plot on top.|
 | "SURF4"  | Draw a surface using the Gouraud shading technique.|
-| "SURF5"  | Used with one of the options CYL, PSR and CYL this option allows to draw a a filled contour plot.|
+| "SURF5"  | Used with one of the options CYL, PSR and CYL this option allows to draw a filled contour plot.|
 | "SURF6"  | This option should not be used directly. It is used internally when the CONT is used with option the option SAME on a 3D plot.|
 | "SURF7"  | Same as `SURF2` with an additional line contour plot on top.|
 
@@ -2723,7 +2723,7 @@ is a collection of `TH1` (or derived) objects. For painting only the
 By default, histograms are shown stacked:
 
 1. The first histogram is paint.
-2. The the sum of the first and second, etc...
+2. The sum of the first and second, etc...
 
 If the option `NOSTACK` is specified, the histograms are all paint in
 the same pad as if the option `SAME` had been specified. This allows to

--- a/io/doc/TFile/streamerinfo.md
+++ b/io/doc/TFile/streamerinfo.md
@@ -50,7 +50,7 @@ of class TStreamerInfo.
                       | In the StreamerInfo record, the objects in the list are
                       |   TStreamerInfo objects.  There will be one TStreamerInfo
                       |   object for every class used in data records other than
-                      |   core records and the the StreamerInfo record itself.
+                      |   core records and the StreamerInfo record itself.
 -------
 </pre></div>
 

--- a/io/io/inc/ROOT/TBufferMerger.hxx
+++ b/io/io/inc/ROOT/TBufferMerger.hxx
@@ -106,7 +106,7 @@ public:
       fMerger.SetNotrees(notrees);
    }
 
-   /** Returns whether the the file has been marked as not containing any TTree objects
+   /** Returns whether the file has been marked as not containing any TTree objects
     * and thus that steps that are specific to TTree can be skipped */
    Bool_t GetNotrees() const
    {

--- a/io/io/src/TMapFile.cxx
+++ b/io/io/src/TMapFile.cxx
@@ -506,7 +506,7 @@ zombie:
 ////////////////////////////////////////////////////////////////////////////////
 /// Private copy ctor.
 ///
-/// Used by the the ctor to create a new version
+/// Used by the ctor to create a new version
 /// of TMapFile in the memory mapped heap. It's main purpose is to
 /// correctly create the string data members.
 

--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -1343,7 +1343,7 @@ namespace {
       Int_t oldv = oldClass->GetStreamerInfo()->GetClassVersion();
 
       if (newClass->GetStreamerInfos() && oldv < newClass->GetStreamerInfos()->GetSize() && newClass->GetStreamerInfos()->At(oldv) && strcmp(newClass->GetStreamerInfos()->At(oldv)->GetName(), oldClass->GetName()) != 0) {
-         // The new class has already a TStreamerInfo for the the same version as
+         // The new class has already a TStreamerInfo for the same version as
          // the old class and this was not the result of an import.  So we do not
          // have a match
          return kFALSE;

--- a/math/doc/v520/index.html
+++ b/math/doc/v520/index.html
@@ -90,7 +90,7 @@ In addition we use now the ROOT convention for all enumeration names defining th
 
 <p>
 <h4>MathCore Function interfaces</h4>
-Mathcore provides as well interfaces for the evaluation of mathematical and parametric functions to be used in the the numerical methods. This release contains the following changes:
+Mathcore provides as well interfaces for the evaluation of mathematical and parametric functions to be used in the numerical methods. This release contains the following changes:
 <ul>
 <li>The <tt>ROOT::Math::IParamFunction</tt>, <tt>ROOT::Math::IParamMultiFunction</tt> interfaces (used mainly for fitting) require now a pointer to the parameters (type <tt>const double *</tt>), when evaluating the function. The derived classes must implement now the const
 method <tt>DoEvalPar</tt> (and not <tt>DoEval</tt> as before). In addition the method

--- a/math/genvector/inc/Math/GenVector/RotationX.h
+++ b/math/genvector/inc/Math/GenVector/RotationX.h
@@ -35,7 +35,7 @@ namespace Math {
 //__________________________________________________________________________________________
    /**
       Rotation class representing a 3D rotation about the X axis by the angle of rotation.
-      For efficiency reason, in addition to the the angle, the sine and cosine of the angle are held
+      For efficiency reason, in addition to the angle, the sine and cosine of the angle are held
 
       @ingroup GenVector
 

--- a/math/genvector/inc/Math/GenVector/RotationY.h
+++ b/math/genvector/inc/Math/GenVector/RotationY.h
@@ -35,7 +35,7 @@ namespace Math {
 //__________________________________________________________________________________________
    /**
       Rotation class representing a 3D rotation about the Y axis by the angle of rotation.
-      For efficiency reason, in addition to the the angle, the sine and cosine of the angle are held
+      For efficiency reason, in addition to the angle, the sine and cosine of the angle are held
 
       @ingroup GenVector
 

--- a/math/genvector/inc/Math/GenVector/RotationZ.h
+++ b/math/genvector/inc/Math/GenVector/RotationZ.h
@@ -35,7 +35,7 @@ namespace Math {
 //__________________________________________________________________________________________
    /**
       Rotation class representing a 3D rotation about the Z axis by the angle of rotation.
-      For efficiency reason, in addition to the the angle, the sine and cosine of the angle are held
+      For efficiency reason, in addition to the angle, the sine and cosine of the angle are held
 
       @ingroup GenVector
 

--- a/math/mathcore/inc/Math/MinimizerOptions.h
+++ b/math/mathcore/inc/Math/MinimizerOptions.h
@@ -43,7 +43,7 @@ public:
 
    // static methods for setting and retrieving the default options
 
-   /// Set the the default Minimizer type and corresponding algorithms.
+   /// Set the default Minimizer type and corresponding algorithms.
    /// Here is the list of the available minimizers and their corresponding algorithms.
    /// For some minimizers (e.g. Fumili) there are no specific algorithms available, then there is no need to specify it.
    ///

--- a/math/mathcore/src/TMath.cxx
+++ b/math/mathcore/src/TMath.cxx
@@ -890,7 +890,7 @@ Double_t TMath::KolmogorovTest(Int_t na, const Double_t *a, Int_t nb, const Doub
 /// Translated and adapted by Miha D. Puc
 ///
 /// To calculate the Faddeeva function with relative error less than 10^(-r).
-/// r can be set by the the user subject to the constraints 2 <= r <= 5.
+/// r can be set by the user subject to the constraints 2 <= r <= 5.
 ///
 ///  - [1] J. Humlicek, JQSRT, 21, 437 (1982).
 ///  - [2] [R.J. Wells "Rapid Approximation to the Voigt/Faddeeva Function and its Derivatives" JQSRT 62 (1999), pp 29-48.](http://www-atm.physics.ox.ac.uk/user/wells/voigt.html)

--- a/math/mathcore/src/TRandom.cxx
+++ b/math/mathcore/src/TRandom.cxx
@@ -34,7 +34,7 @@ the ROOT generator, *gRandom*.
 <a href="https://arxiv.org/abs/1705.03123">paper </a>. It generates random numbers with 52 bit precision (double
 precision) and it has an higher luxury level than the original Ranlux generator (`p = 2048` instead of `p=794`).
 - ::TRandomMixMax: Generator based on the family of the MIXMAX matrix generators (see the
-<a href="https://mixmax.hepforge.org">MIXMAX HEPFORGE Web page</a> and the the documentation of the class
+<a href="https://mixmax.hepforge.org">MIXMAX HEPFORGE Web page</a> and the documentation of the class
 ROOT::Math::MixMaxEngine for more information), that are base on the Asanov dynamical C systems. This generator has a
 state of N=240 64 bit integers, proof random properties, it provides 61 random bits and it has a very large period
 (\f$10^{4839}\f$). Furthermore, it provides the capability to be seeded with the guarantee that, for each given

--- a/math/smatrix/doc/SMatrixClass.md
+++ b/math/smatrix/doc/SMatrixClass.md
@@ -131,7 +131,7 @@ x = m.apply(7);                        // returns again the (row=2,col=1) elemen
 
 There are methods to place and/or retrieve ROOT::Math::SVector objects as rows or columns
 in (from) a matrix. In addition one can put (get) a sub-matrix as another
-ROOT::Math::SMatrix object in a matrix. If the size of the the sub-vector or sub-matrix are
+ROOT::Math::SMatrix object in a matrix. If the size of the sub-vector or sub-matrix are
 larger than the matrix size a static assert ( a compilation error) is produced. The non-const
 
 ~~~ {.cpp}

--- a/math/smatrix/inc/Math/MatrixInversion.icc
+++ b/math/smatrix/inc/Math/MatrixInversion.icc
@@ -308,7 +308,7 @@ void Inverter<idim,N>::InvertBunchKaufman(MatRepSym<T,idim> & rhs, int &ifail) {
       }
    } // end of main loop over columns
 
-   if (j == nrow) // the the last pivot is 1x1
+   if (j == nrow) // the last pivot is 1x1
    {
       mjj = rhs.Array() + j*(j-1)/2 + j-1;
       if (*mjj == 0)

--- a/net/alien/src/TAlienJDL.cxx
+++ b/net/alien/src/TAlienJDL.cxx
@@ -369,7 +369,7 @@ void TAlienJDL::AddToMerge(const char *filenameToMerge, const char *jdlToSubmit,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Adds a package name the the package section.
+/// Adds a package name the package section.
 
 void TAlienJDL::AddToMerge(const char *merge, const char *description)
 {

--- a/proof/proof/src/TProof.cxx
+++ b/proof/proof/src/TProof.cxx
@@ -7604,7 +7604,7 @@ void TProof::ClearData(UInt_t what, const char *dsname)
                }
             }
          }
-         // Clean up the the received map
+         // Clean up the received map
          if (fcmap) fcmap->SetOwner(kTRUE);
          SafeDelete(fcmap);
       }

--- a/proof/proof/src/TProofOutputFile.cxx
+++ b/proof/proof/src/TProofOutputFile.cxx
@@ -190,7 +190,7 @@ void TProofOutputFile::Init(const char *path, const char *dsname)
       }
       // Save the raw directory
       fRawDir = dirPath;
-      // Make sure the the path exists
+      // Make sure the path exists
       if (AssertDir(dirPath) != 0)
          Error("Init", "problems asserting path '%s'", dirPath.Data());
       // Take into account local server settings

--- a/roofit/doc/v520/index.html
+++ b/roofit/doc/v520/index.html
@@ -283,7 +283,7 @@
       was printed for the first 10 occurrences of such conditions. <br><br>
 
       Now, each p.d.f component that generates an error
-      in its evaluation logs the error into a separate facility during fitting and the the RooFit minuit interface
+      in its evaluation logs the error into a separate facility during fitting and the RooFit minuit interface
       polls this error logging facility for problems. This allows much more detailed and accurate warning messages
       during the minimization phase. The level of verbosity of this new error facility can be controlled with
       a new 

--- a/roofit/roofitcore/inc/RooLinkedListIter.h
+++ b/roofit/roofitcore/inc/RooLinkedListIter.h
@@ -88,7 +88,7 @@ class RooFIterForLinkedList final : public GenericRooFIter
 ///
 /// With an iterator that counts, only inserting before or at the iterator position will create problems.
 /// deal with reallocations while iterating. Therefore, this iterator will also check that the last element
-/// it was pointing to is the the current element when it is invoked again. This ensures that
+/// it was pointing to is the current element when it is invoked again. This ensures that
 /// inserting or removing before this iterator does not happen, which was possible with
 /// the linked list iterators of RooFit.
 /// When NDEBUG is defined, these checks will disappear.

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -918,7 +918,7 @@ const RooAbsReal *RooAbsReal::createPlotProjection(const RooArgSet &dependentVar
   }
   RooAbsReal *theClone= (RooAbsReal*)cloneSet->find(GetName());
 
-  // The remaining entries in our list of leaf nodes are the the external
+  // The remaining entries in our list of leaf nodes are the external
   // dependents (x) and parameters (p) of the projection. Patch them back
   // into the theClone. This orphans the nodes they replace, but the orphans
   // are still in the cloneList and so will be cleaned up eventually.

--- a/roofit/roofitcore/src/RooConvIntegrandBinding.cxx
+++ b/roofit/roofitcore/src/RooConvIntegrandBinding.cxx
@@ -19,7 +19,7 @@
 \class RooConvIntegrandBinding
 \ingroup Roofitcore
 
-Implementation of RooAbsFunc that represent the the integrand
+Implementation of RooAbsFunc that represent the integrand
 of a generic (numeric) convolution A (x) B so that it can be
 passed to a numeric integrator. This is a utility class for
 RooNumConvPdf

--- a/roofit/roofitcore/src/RooCurve.cxx
+++ b/roofit/roofitcore/src/RooCurve.cxx
@@ -633,7 +633,7 @@ double RooCurve::average(double xFirst, double xLast) const
     const_cast<RooCurve&>(*this).GetPoint(ifirst,xFirstPt,yFirstPt) ;
   }
 
-  // If last point closest to yLast is at yLast or beyond yLast the the previous point
+  // If last point closest to yLast is at yLast or beyond yLast the previous point
   // as the last midway point
   if ((xLastPt-xLast)>tolerance) {
     ilast-- ;

--- a/roofit/roofitcore/src/RooDataWeightedAverage.cxx
+++ b/roofit/roofitcore/src/RooDataWeightedAverage.cxx
@@ -91,7 +91,7 @@ RooDataWeightedAverage::~RooDataWeightedAverage()
 ////////////////////////////////////////////////////////////////////////////////
 /// Return global normalization term by which raw (combined) test statistic should
 /// be defined to obtain final test statistic. For a data weighted avarage this
-/// the the sum of all weights
+/// the sum of all weights
 
 double RooDataWeightedAverage::globalNormalization() const
 {

--- a/roofit/roofitcore/src/RooEffProd.cxx
+++ b/roofit/roofitcore/src/RooEffProd.cxx
@@ -28,8 +28,8 @@
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Constructor of a a production of p.d.f inPdf with efficiency
-/// function inEff.
+/// Constructs the product of the PDF `inPdf` with the efficiency function
+/// `inEff`.
 
 RooEffProd::RooEffProd(const char *name, const char *title,
                              RooAbsPdf& inPdf, RooAbsReal& inEff) :

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -618,7 +618,7 @@ double RooTreeDataStore::weightError(RooAbsData::ErrorType etype) const
 
    } else if (_wgtVar) {
 
-    // We have a a weight variable, use that info
+    // We have a weight variable, use that info
     if (_wgtVar->hasAsymError()) {
       return ( _wgtVar->getAsymErrorHi() - _wgtVar->getAsymErrorLo() ) / 2 ;
     } else {
@@ -680,7 +680,7 @@ void RooTreeDataStore::weightError(double& lo, double& hi, RooAbsData::ErrorType
 
   } else if (_wgtVar) {
 
-    // We have a a weight variable, use that info
+    // We have a weight variable, use that info
     if (_wgtVar->hasAsymError()) {
       hi = _wgtVar->getAsymErrorHi() ;
       lo = _wgtVar->getAsymErrorLo() ;

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -437,7 +437,7 @@ double RooVectorDataStore::weightError(RooAbsData::ErrorType etype) const
 
    } else if (_wgtVar) {
 
-    // We have a a weight variable, use that info
+    // We have a weight variable, use that info
     if (_wgtVar->hasAsymError()) {
       return ( _wgtVar->getAsymErrorHi() - _wgtVar->getAsymErrorLo() ) / 2 ;
     } else if (_wgtVar->hasError(false)) {
@@ -503,7 +503,7 @@ void RooVectorDataStore::weightError(double& lo, double& hi, RooAbsData::ErrorTy
 
   } else if (_wgtVar) {
 
-    // We have a a weight variable, use that info
+    // We have a weight variable, use that info
     if (_wgtVar->hasAsymError()) {
       hi = _wgtVar->getAsymErrorHi() ;
       lo = _wgtVar->getAsymErrorLo() ;

--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -145,7 +145,7 @@ void RooWorkspace::setClassFileExportDir(const char* dir)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// If flag is true, source code of classes not the the ROOT distribution
+/// If flag is true, source code of classes not the ROOT distribution
 /// is automatically imported if on object of such a class is imported
 /// in the workspace
 

--- a/roofit/roostats/inc/RooStats/CombinedCalculator.h
+++ b/roofit/roostats/inc/RooStats/CombinedCalculator.h
@@ -109,7 +109,7 @@ in a common way for several concrete calculators.
       /// Get the Confidence level for the test
       double ConfidenceLevel()  const override {return 1.-fSize;}
 
-      /// Set the DataSet, add to the the workspace if not already there
+      /// Set the DataSet, add to the workspace if not already there
       void SetData(RooAbsData & data) override {
          fData = &data;
       }

--- a/roofit/roostats/inc/RooStats/DebuggingSampler.h
+++ b/roofit/roostats/inc/RooStats/DebuggingSampler.h
@@ -75,7 +75,7 @@ namespace RooStats {
       void Initialize(RooAbsArg& /* testStatistic */, RooArgSet& /* paramsOfInterest */, RooArgSet& /* nuisanceParameters */ ) override {
       }
 
-      /// Set the Pdf, add to the the workspace if not already there
+      /// Set the Pdf, add to the workspace if not already there
       void SetPdf(RooAbsPdf&) override {}
 
       /// specify the parameters of interest in the interval

--- a/roofit/roostats/inc/RooStats/HypoTestCalculator.h
+++ b/roofit/roostats/inc/RooStats/HypoTestCalculator.h
@@ -66,7 +66,7 @@ problem in a common way for several concrete calculators.
       /// main interface to get a HypoTestResult, pure virtual
       virtual HypoTestResult* GetHypoTest() const = 0;
 
-      /// Set a common model for both the null and alternate, add to the the workspace if not already there
+      /// Set a common model for both the null and alternate, add to the workspace if not already there
       virtual void SetCommonModel(const ModelConfig& model) {
          SetNullModel(model);
          SetAlternateModel(model);

--- a/roofit/roostats/inc/RooStats/IntervalCalculator.h
+++ b/roofit/roostats/inc/RooStats/IntervalCalculator.h
@@ -67,7 +67,7 @@ problem in a common way for several concrete calculators.
       /// Get the Confidence level for the test
       virtual double ConfidenceLevel()  const = 0;
 
-      /// Set the DataSet ( add to the the workspace if not already there ?)
+      /// Set the DataSet ( add to the workspace if not already there ?)
       virtual void SetData(RooAbsData&) = 0;
 
       /// Set the Model

--- a/roofit/roostats/inc/RooStats/ModelConfig.h
+++ b/roofit/roostats/inc/RooStats/ModelConfig.h
@@ -71,19 +71,19 @@ public:
      SetWS(*ws);
    }
 
-   /// Set the proto DataSet, add to the the workspace if not already there
+   /// Set the proto DataSet, add to the workspace if not already there
    virtual void SetProtoData(RooAbsData & data) {
       ImportDataInWS(data);
       SetProtoData( data.GetName() );
    }
 
-   /// Set the Pdf, add to the the workspace if not already there
+   /// Set the Pdf, add to the workspace if not already there
    virtual void SetPdf(const RooAbsPdf& pdf) {
       ImportPdfInWS(pdf);
       SetPdf( pdf.GetName() );
    }
 
-   /// Set the Prior Pdf, add to the the workspace if not already there
+   /// Set the Prior Pdf, add to the workspace if not already there
    virtual void SetPriorPdf(const RooAbsPdf& pdf) {
       ImportPdfInWS(pdf);
       SetPriorPdf( pdf.GetName() );

--- a/roofit/roostats/inc/RooStats/NeymanConstruction.h
+++ b/roofit/roostats/inc/RooStats/NeymanConstruction.h
@@ -77,7 +77,7 @@ namespace RooStats {
       /// Set the DataSet
       void SetData(RooAbsData& data) override { fData = data; }
 
-      /// Set the Pdf, add to the the workspace if not already there
+      /// Set the Pdf, add to the workspace if not already there
       virtual void SetPdf(RooAbsPdf& /*pdf*/) {
         std::cout << "DEPRECATED, use ModelConfig"<<std::endl;
       }

--- a/roofit/roostats/inc/RooStats/TestStatSampler.h
+++ b/roofit/roostats/inc/RooStats/TestStatSampler.h
@@ -56,7 +56,7 @@ used for coverage studies, the Neyman Construction, etc.
       /// Common Initialization
       virtual void Initialize(RooAbsArg& testStatistic, RooArgSet& paramsOfInterest, RooArgSet& nuisanceParameters) = 0;
 
-      /// Set the Pdf, add to the the workspace if not already there
+      /// Set the Pdf, add to the workspace if not already there
       virtual void SetPdf(RooAbsPdf&) = 0;
 
       /// How to randomize the prior. Set to nullptr to deactivate randomization.

--- a/roofit/roostats/inc/RooStats/ToyMCSampler.h
+++ b/roofit/roostats/inc/RooStats/ToyMCSampler.h
@@ -146,7 +146,7 @@ class ToyMCSampler: public TestStatSampler {
       }
 
 
-      /// Set the Pdf, add to the the workspace if not already there
+      /// Set the Pdf, add to the workspace if not already there
       void SetParametersForTestStat(const RooArgSet& nullpoi) override {
          fParametersForTestStat.reset( nullpoi.snapshot() );
       }

--- a/roofit/roostats/src/HybridCalculatorOriginal.cxx
+++ b/roofit/roostats/src/HybridCalculatorOriginal.cxx
@@ -455,7 +455,7 @@ void HybridCalculatorOriginal::RunToys(std::vector<double>& bVals, std::vector<d
          }
       }
 
-      // test first the S+B hypothesis and the the B-only hypothesis
+      // test first the S+B hypothesis and the B-only hypothesis
       for (int hypoTested=0; hypoTested<=1; hypoTested++) {
    RooAbsData* dataToTest = sbData;
    bool dataIsEmpty = sbIsEmpty;

--- a/roofit/roostats/src/SPlot.cxx
+++ b/roofit/roostats/src/SPlot.cxx
@@ -56,7 +56,7 @@
   and a list which parameters of the pdf are yields. The SPlot will calculate SWeights, and
   include these as columns in the RooDataSet. The dataset will have two additional columns
   for every yield with name "`<varname>`":
-  - `L_<varname>` is the the likelihood for each event, *i.e.*, the pdf evaluated for the given value of the variable "varname".
+  - `L_<varname>` is the likelihood for each event, *i.e.*, the pdf evaluated for the given value of the variable "varname".
   - `<varname>_sw` is the value of the sWeight for the variable "varname" for each event.
 
   In SPlot::SPlot(), one can choose whether columns should be added to an existing dataset or whether a copy of the dataset
@@ -394,7 +394,7 @@ Int_t SPlot::GetNumSWeightVars() const
 /// Method which adds the sWeights to the dataset.
 ///
 /// The SPlot will contain two new variables for each yield parameter:
-/// - `L_<varname>` is the the likelihood for each event, i.e., the pdf evaluated for the a given value of the variable "varname".
+/// - `L_<varname>` is the likelihood for each event, i.e., the pdf evaluated for the a given value of the variable "varname".
 /// - `<varname>_sw` is the value of the sWeight for the variable "varname" for each event.
 ///
 /// Find Parameters in the PDF to be considered fixed when calculating the SWeights

--- a/test/stressProof.cxx
+++ b/test/stressProof.cxx
@@ -4009,7 +4009,7 @@ Int_t PT_POFDataset(void *, RunTimes &tt)
    // Clean-up any existing dataset with that name
    if (gProof->ExistsDataSet(dsname)) gProof->RemoveDataSet(dsname);
 
-   // Ask for registration of the dataset (the default is the the TFileCollection is return
+   // Ask for registration of the dataset (the default is the TFileCollection is return
    // without registration; the name of the TFileCollection is the name of the dataset
    gProof->SetParameter("SimpleNtuple.root", dsname);
 

--- a/tmva/tmva/inc/TMVA/DNN/CNN/MaxPoolLayer.h
+++ b/tmva/tmva/inc/TMVA/DNN/CNN/MaxPoolLayer.h
@@ -48,7 +48,7 @@ namespace CNN {
     a CNN. It inherits all of the properties of the convolutional layer
     TConvLayer, but it overrides the propagation methods. In a sense, max pooling
     can be seen as non-linear convolution: a filter slides over the input and produces
-    one element as a function of the the elements within the receptive field.
+    one element as a function of the elements within the receptive field.
     In addition to that, it contains a matrix of winning units.
 
     The height and width of the weights and biases is set to 0, since this

--- a/tmva/tmva/src/Classification.cxx
+++ b/tmva/tmva/src/Classification.cxx
@@ -938,7 +938,7 @@ void TMVA::Experimental::Classification::TestMethod(Types::EMVA method, TString 
 
 //_______________________________________________________________________
 /**
- * return the the vector of TMVA::Experimental::ClassificationResult objects.
+ * Return the vector of TMVA::Experimental::ClassificationResult objects.
  * \return vector of results.
  */
 std::vector<TMVA::Experimental::ClassificationResult> &TMVA::Experimental::Classification::GetResults()

--- a/tmva/tmva/src/CvSplit.cxx
+++ b/tmva/tmva/src/CvSplit.cxx
@@ -234,7 +234,7 @@ UInt_t TMVA::CvSplitKFoldsExpr::GetSpectatorIndexForName(DataSetInfo &dsi, TStri
 /// \param[in] splitExpr Expression used to split data into folds. If `""` a
 ///                      random assignment will be done. Otherwise the
 ///                      expression is fed into a TFormula and evaluated per
-///                      event. The resulting value is the the fold assignment.
+///                      event. The resulting value is the fold assignment.
 /// \param[in] seed Used only when using random splitting (i.e. when
 ///                 `splitExpr` is `""`). Seed is used to initialise the random
 ///                 number generator when assigning events to folds.

--- a/tmva/tmva/src/DNN/Architectures/Cpu/DataLoader.cxx
+++ b/tmva/tmva/src/DNN/Architectures/Cpu/DataLoader.cxx
@@ -10,7 +10,7 @@
  *************************************************************************/
 
 //////////////////////////////////////////////////////////////////
-// Implementation for the DataLoader for the the multi-threaded //
+// Implementation for the DataLoader for the multi-threaded //
 // CPU implementation of DNNs.                                  //
 //////////////////////////////////////////////////////////////////
 

--- a/tmva/tmva/src/DataSetFactory.cxx
+++ b/tmva/tmva/src/DataSetFactory.cxx
@@ -129,7 +129,7 @@ TMVA::DataSet* TMVA::DataSetFactory::CreateDataSet( TMVA::DataSetInfo& dsi,
    if (ds->GetNEvents() > 1 && fComputeCorrelations ) {
       CalcMinMax(ds,dsi);
 
-      // from the the final dataset build the correlation matrix
+      // from the final dataset build the correlation matrix
       for (UInt_t cl = 0; cl< dsi.GetNClasses(); cl++) {
          const TString className = dsi.GetClassInfo(cl)->GetName();
          dsi.SetCorrelationMatrix( className, CalcCorrelationMatrix( ds, cl ) );

--- a/tmva/tmva/src/DecisionTree.cxx
+++ b/tmva/tmva/src/DecisionTree.cxx
@@ -1975,7 +1975,7 @@ Double_t TMVA::DecisionTree::TrainNodeFast( const EventConstList & eventSample,
             //  part of the "allowed" variables in case of Randomized Trees)
             if (useVarInFisher[ivar] && useVariable[ivar]) {
                mapVarInFisher[nFisherVars++]=ivar;
-               // now exclud the the variables used in the Fisher cuts, and don't 
+               // now exclud the variables used in the Fisher cuts, and don't 
                // use them anymore in the individual variable scan
                if (fUseExclusiveVars) useVariable[ivar] = kFALSE;
             }

--- a/tmva/tmva/src/MethodBDT.cxx
+++ b/tmva/tmva/src/MethodBDT.cxx
@@ -270,7 +270,7 @@ TMVA::MethodBDT::MethodBDT( DataSetInfo& theData,
    fRegressionLossFunctionBDTG = nullptr;
    // constructor for calculating BDT-MVA using previously generated decision trees
    // the result of the previous training (the decision trees) are read in via the
-   // weight file. Make sure the the variables correspond to the ones used in
+   // weight file. Make sure the variables correspond to the ones used in
    // creating the "weight"-file
 }
 
@@ -1712,7 +1712,7 @@ Double_t TMVA::MethodBDT::TestTreeQuality( DecisionTree *dt )
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Apply the boosting algorithm (the algorithm is selecte via the the "option" given
+/// Apply the boosting algorithm (the algorithm is selecte via the "option" given
 /// in the constructor. The return value is the boosting weight.
 
 Double_t TMVA::MethodBDT::Boost( std::vector<const TMVA::Event*>& eventSample, DecisionTree *dt, UInt_t cls )

--- a/tmva/tmva/src/Types.cxx
+++ b/tmva/tmva/src/Types.cxx
@@ -65,7 +65,7 @@ TMVA::Types::~Types()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// the the single instance of "Types" if existing already, or create it  (Singleton)
+/// The single instance of "Types" if existing already, or create it  (Singleton)
 
 TMVA::Types& TMVA::Types::Instance()
 {

--- a/tmva/tmva/test/DNN/TestDataLoader.h
+++ b/tmva/tmva/test/DNN/TestDataLoader.h
@@ -63,7 +63,7 @@ auto testSum()
 }
 
 /** Test the data loader by loading identical input and output data, running it
- *  through an identity neural network and computing the the mean squared error,
+ *  through an identity neural network and computing the mean squared error,
  *  should obviously be zero. */
 //______________________________________________________________________________
 template <typename Architecture_t>

--- a/tmva/tmva/test/DNN/TestTensorDataLoader.h
+++ b/tmva/tmva/test/DNN/TestTensorDataLoader.h
@@ -71,7 +71,7 @@ auto testSum()
 }
 
 /** Test the data loader by loading identical input and output data, running it
- *  through an identity neural network and computing the the mean squared error,
+ *  through an identity neural network and computing the mean squared error,
  *  should obviously be zero. */
 //______________________________________________________________________________
 template <typename Architecture_t>

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationSplitting.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationSplitting.cxx
@@ -111,7 +111,7 @@ fold_id_vec_t getCurrentFoldExternal(id_vec_t ids, UInt_t numFolds, UInt_t iFold
       std::cout << std::endl;
    }
 
-   // Combine folds into a a training and test set
+   // Combine folds into a training and test set
    fold_id_vec_t combined_vec;
    for (size_t i = 0; i < 2; ++i) {
       combined_vec.push_back(std::shared_ptr<id_vec_t>(new id_vec_t()));

--- a/tree/tree/inc/TFriendElement.h
+++ b/tree/tree/inc/TFriendElement.h
@@ -17,7 +17,7 @@
 // TFriendElement                                                       //
 //                                                                      //
 // A TFriendElement TF describes a TTree object TF in a file.           //
-// When a TFriendElement TF is added to the the list of friends of an   //
+// When a TFriendElement TF is added to the list of friends of an   //
 // existing TTree T, any variable from TF can be referenced in a query  //
 // to T.                                                                //
 //                                                                      //

--- a/tree/tree/src/InternalTreeUtils.cxx
+++ b/tree/tree/src/InternalTreeUtils.cxx
@@ -198,7 +198,7 @@ std::vector<std::string> GetFileNamesFromTree(const TTree &tree)
 /// - A pair with the name and alias of the chain (if present, both might be
 ///   empty strings).
 /// - A vector with all the paths to the files contained in the chain.
-/// - A vector with all the the names of the trees making up the chain,
+/// - A vector with all the names of the trees making up the chain,
 ///   associated with the file names of the previous vector.
 RFriendInfo GetFriendInfo(const TTree &tree)
 {

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -4335,7 +4335,7 @@ void TBranchElement::ReadLeavesCollection(TBuffer& b)
          break;
    }
    //------------------------------------------------------------------------
-   // We have split this stuff, so we need to create the the pointers
+   // We have split this stuff, so we need to create the pointers
    /////////////////////////////////////////////////////////////////////////////
 
    if( proxy->HasPointers() && fSplitLevel > TTree::kSplitCollectionOfPointers )

--- a/tree/tree/src/TFriendElement.cxx
+++ b/tree/tree/src/TFriendElement.cxx
@@ -13,7 +13,7 @@
 \ingroup tree
 
 A TFriendElement TF describes a TTree object TF in a file.
-When a TFriendElement TF is added to the the list of friends of an
+When a TFriendElement TF is added to the list of friends of an
 existing TTree T, any variable from TF can be referenced in a query
 to T.
 

--- a/tree/tree/src/TTree.cxx
+++ b/tree/tree/src/TTree.cxx
@@ -1267,7 +1267,7 @@ bool CheckReshuffling(TTree &mainTree, TTree &friendTree)
 /// see other AddFriend functions
 ///
 /// A TFriendElement TF describes a TTree object TF in a file.
-/// When a TFriendElement TF is added to the the list of friends of an
+/// When a TFriendElement TF is added to the list of friends of an
 /// existing TTree T, any variable from TF can be referenced in a query
 /// to T.
 ///

--- a/tree/treeplayer/src/TFormLeafInfo.cxx
+++ b/tree/treeplayer/src/TFormLeafInfo.cxx
@@ -30,7 +30,7 @@ The following method are available from the TFormLeafInfo interface:
 
  -  AddOffset(Int_t offset, TStreamerElement* element)
  -  GetCounterValue(TLeaf* leaf) : return the size of the array pointed to.
- -  GetObjectAddress(TLeafElement* leaf) : Returns the the location of the object pointed to.
+ -  GetObjectAddress(TLeafElement* leaf) : Returns the location of the object pointed to.
  -  GetMultiplicity() : Returns info on the variability of the number of elements
  -  GetNdata(TLeaf* leaf) : Returns the number of elements
  -  GetNdata() : Used by GetNdata(TLeaf* leaf)
@@ -178,7 +178,7 @@ TClass* TFormLeafInfo::GetClass() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Returns the the location of the object pointed to.
+/// Returns the location of the object pointed to.
 /// Modify instance if the object is part of an array.
 
 char* TFormLeafInfo::GetObjectAddress(TLeafElement* leaf, Int_t& instance)
@@ -1166,7 +1166,7 @@ TFormLeafInfoClones &TFormLeafInfoClones::operator=(const TFormLeafInfoClones &o
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the current size of the the TClonesArray
+/// Return the current size of the TClonesArray
 
 Int_t TFormLeafInfoClones::GetCounterValue(TLeaf* leaf)
 {
@@ -1180,7 +1180,7 @@ Int_t TFormLeafInfoClones::GetCounterValue(TLeaf* leaf)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the current size of the the TClonesArray
+/// Return the current size of the TClonesArray
 
 Int_t TFormLeafInfoClones::ReadCounterValue(char* where)
 {
@@ -1364,7 +1364,7 @@ TFormLeafInfoCollectionObject &TFormLeafInfoCollectionObject::operator=(const TF
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the current size of the the TClonesArray
+/// Return the current size of the TClonesArray
 
 Int_t TFormLeafInfoCollectionObject::GetCounterValue(TLeaf* /* leaf */)
 {
@@ -1607,7 +1607,7 @@ Bool_t TFormLeafInfoCollection::HasCounter() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the current size of the the TClonesArray
+/// Return the current size of the TClonesArray
 
 Int_t TFormLeafInfoCollection::GetCounterValue(TLeaf* leaf)
 {
@@ -1635,7 +1635,7 @@ Int_t TFormLeafInfoCollection::ReadCounterValue(char* where)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Return the current size of the the TClonesArray
+/// Return the current size of the TClonesArray
 
 Int_t TFormLeafInfoCollection::GetCounterValue(TLeaf* leaf, Int_t instance)
 {

--- a/tree/treeplayer/src/TTreeFormula.cxx
+++ b/tree/treeplayer/src/TTreeFormula.cxx
@@ -80,7 +80,7 @@ The following method are available from the TFormLeafInfo interface:
 
  -  AddOffset(Int_t offset, TStreamerElement* element)
  -  GetCounterValue(TLeaf* leaf) : return the size of the array pointed to.
- -  GetObjectAddress(TLeafElement* leaf) : Returns the the location of the object pointed to.
+ -  GetObjectAddress(TLeafElement* leaf) : Returns the location of the object pointed to.
  -  GetMultiplicity() : Returns info on the variability of the number of elements
  -  GetNdata(TLeaf* leaf) : Returns the number of elements
  -  GetNdata() : Used by GetNdata(TLeaf* leaf)

--- a/tutorials/fit/fitEllipseTGraphDLSF.cxx
+++ b/tutorials/fit/fitEllipseTGraphDLSF.cxx
@@ -41,7 +41,7 @@
 //   F(x, y) = 0
 //   B^2 - 4 * A * C < 0
 //
-// input parameter is a a pointer to a "TGraph" with at least 6 points
+// input parameter is a pointer to a "TGraph" with at least 6 points
 //
 // returns a "TVectorD" ("empty" in case any problems encountered):
 // ellipse[0] = "X0"

--- a/tutorials/fit/fitLinear.C
+++ b/tutorials/fit/fitLinear.C
@@ -67,7 +67,7 @@ void fitLinear()
    gre4->SetMarkerColor(kRed);
    gre4->SetLineColor(kRed);
    //If you don't want to define the function, you can just pass the string
-   //with the the formula:
+   //with the formula:
    gre4->Fit("1 ++ exp(-x)");
    //Access the fit results:
    TF1 *f4 = gre4->GetFunction("1 ++ exp(-x)");

--- a/tutorials/io/mergeSelective.C
+++ b/tutorials/io/mergeSelective.C
@@ -62,7 +62,7 @@ void mergeSelective(Int_t nfiles=5)
    fm->OutputFile("exclusive.root");
    fm->AddObjectNames("hprof folder");
    for (i=0; i<nfiles; i++) fm->AddFile(Form("tomerge%03d.root",i));
-   // Must add new merging flag on top of the the default ones
+   // Must add new merging flag on top of the default ones
    Int_t default_mode = TFileMerger::kAll | TFileMerger::kIncremental;
    Int_t mode = default_mode | TFileMerger::kOnlyListed;
    fm->PartialMerge(mode);
@@ -74,7 +74,7 @@ void mergeSelective(Int_t nfiles=5)
    fm->OutputFile("skipped.root");
    fm->AddObjectNames("hprof folder");
    for (i=0; i<nfiles; i++) fm->AddFile(Form("tomerge%03d.root",i));
-   // Must add new merging flag on top of the the default ones
+   // Must add new merging flag on top of the default ones
    mode = default_mode | TFileMerger::kSkipListed;
    fm->PartialMerge(mode);
    delete fm;

--- a/tutorials/proof/runProof.C
+++ b/tutorials/proof/runProof.C
@@ -1112,7 +1112,7 @@ void runProof(const char *what = "simple",
       nevt = (nevt < 0) ? 1000000 : nevt;
       Printf("\nrunProof: running \"dataset\" with nevt= %lld\n", nevt);
 
-      // Ask for registration of the dataset (the default is the the TFileCollection is return
+      // Ask for registration of the dataset (the default is the TFileCollection is return
       // without registration; the name of the TFileCollection is the name of the dataset
       proof->SetParameter("SimpleNtuple.root","testNtuple");
 

--- a/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.C
+++ b/tutorials/roofit/rf204b_extendedLikelihood_rangedFit.C
@@ -102,7 +102,7 @@ void rf204b_extendedLikelihood_rangedFit()
 
 
  // It can be instructive to fit the above model to either the LEFT or RIGHT range. `N` should approximately converge to the expected number
- // of events in the full range. One may try to leave out `"FULL"` in the constructor, o the the interpretation of `N` changes.
+ // of events in the full range. One may try to leave out `"FULL"` in the constructor, or the interpretation of `N` changes.
  extmodel.fitTo(*data, Range("LEFT"), PrintLevel(-1));
  N.Print();
 

--- a/tutorials/tmva/TMVACrossValidation.C
+++ b/tutorials/tmva/TMVACrossValidation.C
@@ -150,7 +150,7 @@ int TMVACrossValidation(bool useRandomSplitting = false)
 
    // The CV mechanism of TMVA splits up the training set into several folds.
    // The test set is currently left unused. The `nTest_ClassName=1` assigns
-   // one event to the the test set for each class and puts the rest in the
+   // one event to the test set for each class and puts the rest in the
    // training set. A value of 0 is a special value and would split the
    // datasets 50 / 50.
    dataloader->PrepareTrainingAndTestTree("", "",

--- a/tutorials/unfold/testUnfold2.C
+++ b/tutorials/unfold/testUnfold2.C
@@ -285,7 +285,7 @@ int testUnfold2()
   // extract unfolding results into histograms
 
   // set up a bin map, excluding underflow and overflow bins
-  // the binMap relates the the output of the unfolding to the final
+  // the binMap relates the output of the unfolding to the final
   // histogram bins
   Int_t *binMap=new Int_t[nGen+2];
   for(Int_t i=1;i<=nGen;i++) binMap[i]=i;


### PR DESCRIPTION
Also fixes the related ` a a ` typos.
