### PR TITLE
[cmake] Add POLICY CMP0135 and set it to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     " Please see README/INSTALL for more information.")
 endif()
 
-set(policy_new CMP0072 CMP0077)
+set(policy_new CMP0072 CMP0077 CMP0135)
 foreach(policy ${policy_new})
   if(POLICY ${policy})
     cmake_policy(SET ${policy} NEW)


### PR DESCRIPTION
Fixes the following warning with CMake 3.24:
```
CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3071 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```
