### PR TITLE
Avoid using deperecated `RooCatType` in RooStats tutorials

### DIFF
--- a/roofit/roofitcore/inc/RooThresholdCategory.h
+++ b/roofit/roofitcore/inc/RooThresholdCategory.h
@@ -21,8 +21,6 @@
 #include <vector>
 #include <utility>
 
-#include "RooFitLegacy/RooCatTypeLegacy.h"
-
 class RooThresholdCategory : public RooAbsCategory {
 
 public:

--- a/tutorials/roostats/ModelInspector.C
+++ b/tutorials/roostats/ModelInspector.C
@@ -72,8 +72,10 @@ enum ETestCommandIdentifiers {
    HSId1
 };
 
+using namespace std;
 using namespace RooFit;
 using namespace RooStats;
+
 class ModelInspectorGUI : public TGMainFrame {
 
 private:
@@ -117,9 +119,8 @@ public:
    void DoFit();
    void DoExit();
    void HandleButtons();
-
-   ClassDef(ModelInspectorGUI, 0)
 };
+
 
 //______________________________________________________________________________
 ModelInspectorGUI::ModelInspectorGUI(RooWorkspace *w, ModelConfig *mc, RooAbsData *data)
@@ -273,9 +274,9 @@ void ModelInspectorGUI::DoText(const char * /*text*/)
    Int_t id = te->WidgetId();
 
    switch (id) {
-   case HId1: fHslider1->SetPosition(atof(fTbh1->GetString()), fHslider1->GetMaxPosition()); break;
+   case HId1: fHslider1->SetPosition(atof(fTbh1->GetString()), static_cast<double>(fHslider1->GetMaxPosition())); break;
    case HId2: fHslider1->SetPointerPosition(atof(fTbh2->GetString())); break;
-   case HId3: fHslider1->SetPosition(fHslider1->GetMinPosition(), atof(fTbh1->GetString())); break;
+   case HId3: fHslider1->SetPosition(static_cast<double>(fHslider1->GetMinPosition()), atof(fTbh1->GetString())); break;
    default: break;
    }
    DoSlider();
@@ -373,15 +374,15 @@ void ModelInspectorGUI::DoSlider()
       ////////////////////////////////////////////////////////////////////////////
       RooCategory *channelCat = (RooCategory *)(&simPdf->indexCat());
       //    TIterator* iter = simPdf->indexCat().typeIterator() ;
-      TIterator *iter = channelCat->typeIterator();
-      RooCatType *tt = NULL;
       Int_t frameIndex = 0;
-      while ((tt = (RooCatType *)iter->Next())) {
+      for (auto const& tt : *channelCat) {
+         auto const& catName = tt.first;
+
          ++frameIndex;
          fCanvas->GetCanvas()->cd(frameIndex);
 
          // pre loop
-         RooAbsPdf *pdftmp = simPdf->getPdf(tt->GetName());
+         RooAbsPdf *pdftmp = simPdf->getPdf(catName.c_str());
          RooArgSet *obstmp = pdftmp->getObservables(*fMC->GetObservables());
          RooRealVar *obs = ((RooRealVar *)obstmp->first());
 
@@ -394,7 +395,7 @@ void ModelInspectorGUI::DoSlider()
          RooFit::MsgLevel msglevel = RooMsgService::instance().globalKillBelow();
          RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
          fData->plotOn(fPlot, MarkerSize(1),
-                       Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName())),
+                       Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str())),
                        DataError(RooAbsData::None));
          RooMsgService::instance().setGlobalKillBelow(msglevel);
 
@@ -448,7 +449,7 @@ void ModelInspectorGUI::DoSlider()
             msglevel = RooMsgService::instance().globalKillBelow();
             RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
             fData->plotOn(fPlot, MarkerSize(1),
-                          Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName())),
+                          Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str())),
                           DataError(RooAbsData::None));
             RooMsgService::instance().setGlobalKillBelow(msglevel);
          }
@@ -484,7 +485,6 @@ void ModelInspectorGUI::DoExit()
 void ModelInspector(const char *infile = "", const char *workspaceName = "combined",
                     const char *modelConfigName = "ModelConfig", const char *dataName = "obsData")
 {
-
    // -------------------------------------------------------
    // First part is just to access a user-defined file
    // or create the standard example file if it doesn't exist

--- a/tutorials/roostats/OneSidedFrequentistUpperLimitWithBands.C
+++ b/tutorials/roostats/OneSidedFrequentistUpperLimitWithBands.C
@@ -369,23 +369,18 @@ void OneSidedFrequentistUpperLimitWithBands(const char *infile = "", const char 
       } else {
 
          // try fix for sim pdf
-         TIterator *iter = simPdf->indexCat().typeIterator();
-         RooCatType *tt = NULL;
-         while ((tt = (RooCatType *)iter->Next())) {
+         for (auto const& tt : simPdf->indexCat()) {
+            auto const& catName = tt.first;
 
             // Get pdf associated with state from simpdf
-            RooAbsPdf *pdftmp = simPdf->getPdf(tt->GetName());
+            RooAbsPdf *pdftmp = simPdf->getPdf(catName.c_str());
 
             // Generate only global variables defined by the pdf associated with this state
-            RooArgSet *globtmp = pdftmp->getObservables(*mc->GetGlobalObservables());
-            RooDataSet *tmp = pdftmp->generate(*globtmp, 1);
+            std::unique_ptr<RooArgSet> globtmp{pdftmp->getObservables(*mc->GetGlobalObservables())};
+            std::unique_ptr<RooDataSet> tmp{pdftmp->generate(*globtmp, 1)};
 
             // Transfer values to output placeholder
-            *globtmp = *tmp->get(0);
-
-            // Cleanup
-            delete globtmp;
-            delete tmp;
+            globtmp->assign(*tmp->get(0));
          }
       }
 

--- a/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
+++ b/tutorials/roostats/StandardHistFactoryPlotsWithCategories.C
@@ -153,21 +153,19 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
 
    if (doFit) {
       RooCategory *channelCat = (RooCategory *)(&simPdf->indexCat());
-      TIterator *iter = channelCat->typeIterator();
-      RooCatType *tt = NULL;
-      tt = (RooCatType *)iter->Next();
-      RooAbsPdf *pdftmp = ((RooSimultaneous *)mc->GetPdf())->getPdf(tt->GetName());
+      auto const& catName = channelCat->begin()->first;
+      RooAbsPdf *pdftmp = ((RooSimultaneous *)mc->GetPdf())->getPdf(catName.c_str());
       RooArgSet *obstmp = pdftmp->getObservables(*mc->GetObservables());
       obs = ((RooRealVar *)obstmp->first());
       RooPlot *frame = obs->frame();
-      cout << Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName()) << endl;
-      cout << tt->GetName() << " " << channelCat->getLabel() << endl;
+      cout << Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str()) << endl;
+      cout << catName << " " << channelCat->getLabel() << endl;
       data->plotOn(frame, MarkerSize(1),
-                   Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName())),
+                   Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str())),
                    DataError(RooAbsData::None));
 
       Double_t normCount =
-         data->sumEntries(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName()));
+         data->sumEntries(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str()));
 
       pdftmp->plotOn(frame, LineWidth(2.), Normalization(normCount, RooAbsReal::NumEvent));
       frame->Draw();
@@ -196,14 +194,17 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
 
    } else {
       RooCategory *channelCat = (RooCategory *)(&simPdf->indexCat());
-      //    TIterator* iter = simPdf->indexCat().typeIterator() ;
-      TIterator *iter = channelCat->typeIterator();
-      RooCatType *tt = NULL;
-      while (nPlots < nPlotsMax && (tt = (RooCatType *)iter->Next())) {
+      for (auto const& tt : *channelCat) {
 
-         cout << "on type " << tt->GetName() << " " << endl;
+         if (nPlots == nPlotsMax) {
+            break;
+         }
+
+         auto const& catName = tt.first;
+
+         cout << "on type " << catName << " " << endl;
          // Get pdf associated with state from simpdf
-         RooAbsPdf *pdftmp = simPdf->getPdf(tt->GetName());
+         RooAbsPdf *pdftmp = simPdf->getPdf(catName.c_str());
 
          // Generate observables defined by the pdf associated with this state
          RooArgSet *obstmp = pdftmp->getObservables(*mc->GetObservables());
@@ -219,14 +220,14 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
             frame->SetName(Form("frame%d", nPlots));
             frame->SetYTitle(var->GetName());
 
-            cout << Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName()) << endl;
-            cout << tt->GetName() << " " << channelCat->getLabel() << endl;
+            cout << Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str()) << endl;
+            cout << catName << " " << channelCat->getLabel() << endl;
             data->plotOn(frame, MarkerSize(1),
-                         Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName())),
+                         Cut(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str())),
                          DataError(RooAbsData::None));
 
             Double_t normCount =
-               data->sumEntries(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), tt->GetName()));
+               data->sumEntries(Form("%s==%s::%s", channelCat->GetName(), channelCat->GetName(), catName.c_str()));
 
             if (strcmp(var->GetName(), "Lumi") == 0) {
                cout << "working on lumi" << endl;
@@ -238,8 +239,8 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
             // w->allVars().Print("v");
             // mc->GetNuisanceParameters()->Print("v");
             // pdftmp->plotOn(frame,LineWidth(2.));
-            // mc->GetPdf()->plotOn(frame,LineWidth(2.),Slice(*channelCat,tt->GetName()),ProjWData(*data));
-            // pdftmp->plotOn(frame,LineWidth(2.),Slice(*channelCat,tt->GetName()),ProjWData(*data));
+            // mc->GetPdf()->plotOn(frame,LineWidth(2.),Slice(*channelCat,catName.c_str()),ProjWData(*data));
+            // pdftmp->plotOn(frame,LineWidth(2.),Slice(*channelCat,catName.c_str()),ProjWData(*data));
             normCount = pdftmp->expectedEvents(*obs);
             pdftmp->plotOn(frame, LineWidth(2.), Normalization(normCount, RooAbsReal::NumEvent));
 
@@ -251,8 +252,8 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
                var->setVal(nSigmaToVary);
             }
             // pdftmp->plotOn(frame,LineColor(kRed),LineStyle(kDashed),LineWidth(2));
-            // mc->GetPdf()->plotOn(frame,LineColor(kRed),LineStyle(kDashed),LineWidth(2.),Slice(*channelCat,tt->GetName()),ProjWData(*data));
-            // pdftmp->plotOn(frame,LineColor(kRed),LineStyle(kDashed),LineWidth(2.),Slice(*channelCat,tt->GetName()),ProjWData(*data));
+            // mc->GetPdf()->plotOn(frame,LineColor(kRed),LineStyle(kDashed),LineWidth(2.),Slice(*channelCat,catName.c_str()),ProjWData(*data));
+            // pdftmp->plotOn(frame,LineColor(kRed),LineStyle(kDashed),LineWidth(2.),Slice(*channelCat,catName.c_str()),ProjWData(*data));
             normCount = pdftmp->expectedEvents(*obs);
             pdftmp->plotOn(frame, LineWidth(2.), LineColor(kRed), LineStyle(kDashed),
                            Normalization(normCount, RooAbsReal::NumEvent));
@@ -265,8 +266,8 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
                var->setVal(-nSigmaToVary);
             }
             // pdftmp->plotOn(frame,LineColor(kGreen),LineStyle(kDashed),LineWidth(2));
-            // mc->GetPdf()->plotOn(frame,LineColor(kGreen),LineStyle(kDashed),LineWidth(2),Slice(*channelCat,tt->GetName()),ProjWData(*data));
-            // pdftmp->plotOn(frame,LineColor(kGreen),LineStyle(kDashed),LineWidth(2),Slice(*channelCat,tt->GetName()),ProjWData(*data));
+            // mc->GetPdf()->plotOn(frame,LineColor(kGreen),LineStyle(kDashed),LineWidth(2),Slice(*channelCat,catName.c_str()),ProjWData(*data));
+            // pdftmp->plotOn(frame,LineColor(kGreen),LineStyle(kDashed),LineWidth(2),Slice(*channelCat,catName.c_str()),ProjWData(*data));
             normCount = pdftmp->expectedEvents(*obs);
             pdftmp->plotOn(frame, LineWidth(2.), LineColor(kGreen), LineStyle(kDashed),
                            Normalization(normCount, RooAbsReal::NumEvent));
@@ -286,7 +287,7 @@ void StandardHistFactoryPlotsWithCategories(const char *infile = "", const char 
             ++nPlots;
 
             frame->Draw();
-            c2->SaveAs(Form("%s_%s_%s.pdf", tt->GetName(), obs->GetName(), var->GetName()));
+            c2->SaveAs(Form("%s_%s_%s.pdf", catName.c_str(), obs->GetName(), var->GetName()));
             delete c2;
          }
       }


### PR DESCRIPTION
With the rewrite of the RooCategory classes, the `RooCatType` was
deprecated (moved into RooFitLegacy) and should also not be used anymore
in tutorial code.