### PR TITLE
[RF] Do initial pass in RooFitDriver::getValHeterogeneous() on GPU

### DIFF
--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -63,8 +63,6 @@ private:
    // Private member functions
 
    double getValHeterogeneous();
-   std::chrono::microseconds simulateFit(std::chrono::microseconds h2dTime, std::chrono::microseconds d2hTime,
-                                         std::chrono::microseconds diffThreshold);
    void markGPUNodes();
    void assignToGPU(NodeInfo &info);
    void computeCPUNode(const RooAbsArg *node, NodeInfo &info);

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -4716,6 +4716,9 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
   ourServers.reserve(servers().size());
 
   for (auto server : servers()) {
+    auto serverValues = dataMap.at(server);
+    if(serverValues.empty()) continue;
+
     // maybe we are still missing inhibit dirty here
     auto oldOperMode = server->operMode();
     // See note at the bottom of this function to learn why we can only set
@@ -4723,7 +4726,7 @@ void RooAbsReal::computeBatch(cudaStream_t*, double* output, size_t nEvents, Roo
     // clients.
     server->setOperMode(RooAbsArg::AClean);
     ourServers.push_back({server,
-        dataMap.at(server),
+        serverValues,
         server->isCategory() ? static_cast<RooAbsCategory const*>(server)->getCurrentIndex() : static_cast<RooAbsReal const*>(server)->_value,
         oldOperMode});
     // Prevent the server from evaluating; just return cached result, which we will side load:


### PR DESCRIPTION
So far, the first pass to measure the timing was done on the CPU and the
second on the GPU. This is not practical when only doing one evaluation
for development purposes. Hence the order is now reversed.
