### PR TITLE
libAfterImage: Properly set len parameter for GifAddExtensionBlock and iterate extensions

### DIFF
--- a/graf2d/asimage/src/libAfterImage/ungif.c
+++ b/graf2d/asimage/src/libAfterImage/ungif.c
@@ -188,6 +188,7 @@ get_gif_saved_images( GifFileType *gif, int subimage, SavedImage **ret, int *ret
     GifByteType *ExtData;
 #if (GIFLIB_MAJOR>=5)
     int ExtCode;
+    size_t Len;
 #endif
     SavedImage temp_save;
 	int curr_image = 0, ret_count = *ret_images ;
@@ -229,9 +230,10 @@ get_gif_saved_images( GifFileType *gif, int subimage, SavedImage **ret, int *ret
 				{
             		/* Create an extension block with our data */
 #if (GIFLIB_MAJOR>=5)
-            		if ((status = GifAddExtensionBlock(&temp_save.ExtensionBlockCount, &temp_save.ExtensionBlocks,
-                            ExtCode, sizeof(ExtData), ExtData)) == GIF_OK)
-                    status = DGifGetExtension(gif,&ExtCode,&ExtData);
+                  Len = EGifGCBToExtension(gif, ExtData);
+                  if ((status = GifAddExtensionBlock(&temp_save.ExtensionBlockCount, &temp_save.ExtensionBlocks,
+                                                     ExtCode, Len, ExtData)) == GIF_OK)
+                     status = DGifGetExtensionNext(gif, &ExtData);
 #else
             		if ((status = AddExtensionBlock(&temp_save, ExtData[0], (char*)&(ExtData[1]))) == GIF_OK)
 				    	status = DGifGetExtensionNext(gif, &ExtData);


### PR DESCRIPTION
# This Pull request:

Is a resubmit of #10999 with additional needed changes (as discussed in that original PR)

## Changes or fixes:

Fixes: #10990

## Checklist:

- [x] tested changes locally

This PR fixes #10990

