### PR TITLE
[DF] Re-add a useful transitive include

### DIFF
--- a/tree/dataframe/inc/ROOT/RDFHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDFHelpers.hxx
@@ -16,6 +16,7 @@
 #include <ROOT/RDF/GraphUtils.hxx>
 #include <ROOT/RDF/RActionBase.hxx>
 #include <ROOT/RDF/RResultMap.hxx>
+#include <ROOT/RResultHandle.hxx> // users of RunGraphs might rely on this transitive include
 #include <ROOT/TypeTraits.hxx>
 
 #include <fstream>
@@ -64,7 +65,6 @@ auto PassAsVec(F &&f) -> PassAsVecHelper<std::make_index_sequence<N>, T, F>
 } // namespace Internal
 
 namespace RDF {
-class RResultHandle;
 namespace RDFInternal = ROOT::Internal::RDF;
 
 // clag-format off


### PR DESCRIPTION
RDFHelpers.hxx provides ROOT::RDF::RunGraphs(std::vector<RResultHandle>).
In order for the handy implicit conversion from RResultPtr<T> to
RResultHandle to be available for client code that include
RDFHelpers.hxx, it is not enough that this header forward-declares
RResultHandle, but it needs to transitively provide the whole type
declaration.

In practice, before 8bbd543f3d56, this worked fine:

```
...
RunGraphs({resultptr1, resultptr2});
```

while after that commit it would require an extra `#include
<ROOT/RResultHandle.hxx>`. This patch restores the previous situation.