### PR TITLE
Move RSlotStack from RDF to Imt

### DIFF
--- a/core/imt/CMakeLists.txt
+++ b/core/imt/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 ROOT_LINKER_LIBRARY(Imt
     src/base.cxx
+    src/RSlotStack.cxx
     src/TExecutor.cxx
     src/TTaskGroup.cxx
   DEPENDENCIES
@@ -34,6 +35,7 @@ if(imt)
     ROOT/TFuture.hxx
     ROOT/TTaskGroup.hxx
     ROOT/RTaskArena.hxx
+    ROOT/RSlotStack.hxx
     ROOT/TExecutor.hxx
     ROOT/TThreadExecutor.hxx
     LINKDEF

--- a/core/imt/inc/ROOT/RSlotStack.hxx
+++ b/core/imt/inc/ROOT/RSlotStack.hxx
@@ -17,7 +17,6 @@
 
 namespace ROOT {
 namespace Internal {
-namespace RDF {
 
 /// This is an helper class to allow to pick a slot resorting to a map
 /// indexed by thread ids.
@@ -35,7 +34,7 @@ public:
    void ReturnSlot(unsigned int slotNumber);
    unsigned int GetSlot();
 };
-} // namespace RDF
+
 } // namespace Internal
 } // namespace ROOT
 

--- a/core/imt/src/RSlotStack.cxx
+++ b/core/imt/src/RSlotStack.cxx
@@ -9,18 +9,18 @@
  *************************************************************************/
 
 #include <ROOT/TSeq.hxx>
-#include <ROOT/RDF/RSlotStack.hxx>
+#include <ROOT/RSlotStack.hxx>
 
 #include <cassert>
 #include <mutex> // std::lock_guard
 
-ROOT::Internal::RDF::RSlotStack::RSlotStack(unsigned int size) : fSize(size)
+ROOT::Internal::RSlotStack::RSlotStack(unsigned int size) : fSize(size)
 {
    for (auto i : ROOT::TSeqU(size))
       fStack.push(i);
 }
 
-void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slot)
+void ROOT::Internal::RSlotStack::ReturnSlot(unsigned int slot)
 {
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
    assert(fStack.size() < fSize && "Trying to put back a slot to a full stack!");
@@ -28,7 +28,7 @@ void ROOT::Internal::RDF::RSlotStack::ReturnSlot(unsigned int slot)
    fStack.push(slot);
 }
 
-unsigned int ROOT::Internal::RDF::RSlotStack::GetSlot()
+unsigned int ROOT::Internal::RSlotStack::GetSlot()
 {
    std::lock_guard<ROOT::TSpinMutex> guard(fMutex);
    assert(!fStack.empty() && "Trying to pop a slot from an empty stack!");

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -77,7 +77,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     ROOT/RDF/RRangeBase.hxx
     ROOT/RDF/RRange.hxx
     ROOT/RDF/RResultMap.hxx
-    ROOT/RDF/RSlotStack.hxx
     ROOT/RDF/RTreeColumnReader.hxx
     ROOT/RDF/RVariation.hxx
     ROOT/RDF/RVariationBase.hxx
@@ -113,7 +112,6 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RVariationBase.cxx
     src/RVariationsDescription.cxx
     src/RRootDS.cxx
-    src/RSlotStack.cxx
     src/RTrivialDS.cxx
     src/RDFDescription.cxx
   DICTIONARY_OPTIONS

--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -15,9 +15,9 @@
 #include "ROOT/RDF/RFilterBase.hxx"
 #include "ROOT/RDF/RLoopManager.hxx"
 #include "ROOT/RDF/RRangeBase.hxx"
-#include "ROOT/RDF/RSlotStack.hxx"
 #include "ROOT/RDF/RVariationBase.hxx"
 #include "ROOT/RLogger.hxx"
+#include "ROOT/RSlotStack.hxx"
 #include "RtypesCore.h" // Long64_t
 #include "TStopwatch.h"
 #include "TBranchElement.h"
@@ -424,9 +424,9 @@ RLoopManager::RLoopManager(ROOT::RDF::Experimental::RDatasetSpec &&spec)
 }
 
 struct RSlotRAII {
-   RSlotStack &fSlotStack;
+   ROOT::Internal::RSlotStack &fSlotStack;
    unsigned int fSlot;
-   RSlotRAII(RSlotStack &slotStack) : fSlotStack(slotStack), fSlot(slotStack.GetSlot()) {}
+   RSlotRAII(ROOT::Internal::RSlotStack &slotStack) : fSlotStack(slotStack), fSlot(slotStack.GetSlot()) {}
    ~RSlotRAII() { fSlotStack.ReturnSlot(fSlot); }
 };
 
@@ -434,7 +434,7 @@ struct RSlotRAII {
 void RLoopManager::RunEmptySourceMT()
 {
 #ifdef R__USE_IMT
-   RSlotStack slotStack(fNSlots);
+   ROOT::Internal::RSlotStack slotStack(fNSlots);
    // Working with an empty tree.
    // Evenly partition the entries according to fNSlots. Produce around 2 tasks per slot.
    const auto nEntriesPerSlot = fNEmptyEntries / (fNSlots * 2);
@@ -499,7 +499,7 @@ void RLoopManager::RunTreeProcessorMT()
 #ifdef R__USE_IMT
    if (fEndEntry == fBeginEntry) // empty range => no work needed
       return;
-   RSlotStack slotStack(fNSlots);
+   ROOT::Internal::RSlotStack slotStack(fNSlots);
    const auto &entryList = fTree->GetEntryList() ? *fTree->GetEntryList() : TEntryList();
    auto tp = (fBeginEntry != 0 || fEndEntry != std::numeric_limits<Long64_t>::max())
                 ? std::make_unique<ROOT::TTreeProcessorMT>(*fTree, fNSlots, std::make_pair(fBeginEntry, fEndEntry))
@@ -612,7 +612,7 @@ void RLoopManager::RunDataSourceMT()
 {
 #ifdef R__USE_IMT
    assert(fDataSource != nullptr);
-   RSlotStack slotStack(fNSlots);
+   ROOT::Internal::RSlotStack slotStack(fNSlots);
    ROOT::TThreadExecutor pool;
 
    // Each task works on a subrange of entries

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -1,7 +1,7 @@
 #include "ROOT/TestSupport.hxx"
 
 #include <ROOT/RDataFrame.hxx>
-#include <ROOT/RDF/RSlotStack.hxx>
+#include <ROOT/RSlotStack.hxx>
 #include <TStatistic.h> // To check reading of columns with types which are mothers of the column type
 #include <TSystem.h>
 
@@ -16,7 +16,7 @@ TEST(RDataFrameNodes, RSlotStackGetOneTooMuch)
 {
    auto theTest = []() {
       unsigned int n(2);
-      ROOT::Internal::RDF::RSlotStack s(n);
+      ROOT::Internal::RSlotStack s(n);
 
       std::vector<std::thread> ts;
 
@@ -34,7 +34,7 @@ TEST(RDataFrameNodes, RSlotStackGetOneTooMuch)
 TEST(RDataFrameNodes, RSlotStackPutBackTooMany)
 {
    auto theTest = []() {
-      ROOT::Internal::RDF::RSlotStack s(1);
+      ROOT::Internal::RSlotStack s(1);
       s.ReturnSlot(0);
    };
 


### PR DESCRIPTION
# This Pull request:
Moves the RSlotStack implementation from tree/dataframe/ to core/imt/.

## Changes or fixes:
Makes RSlotStack useable without requiring the whole of RDataFrame as a dependency.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # N/A

