### PR TITLE
[DF] Fix potential use-after-delete in sample callbacks 

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -612,7 +612,6 @@ void CallBuildAction(std::shared_ptr<PrevNodeType> *prevNodeOnHeap, const char *
 
    auto actionPtr = BuildAction<ColTypes...>(cols, std::move(*helperArgOnHeap), nSlots, std::move(prevNodePtr),
                                              ActionTag{}, *colRegister);
-   loopManager.AddSampleCallback(actionPtr->GetSampleCallback());
    jittedActionOnHeap->SetAction(std::move(actionPtr));
 
    doDeletes();

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -42,10 +42,15 @@ public:
       : RDefineBase(name, type, RDFInternal::RColumnRegister{nullptr}, lm, /*columnNames*/ {}),
         fExpression(std::move(expression)), fLastResults(lm.GetNSlots() * RDFInternal::CacheLineStep<RetType_t>())
    {
+      fLoopManager->Register(this);
+      auto callUpdate = [this](unsigned int slot, const ROOT::RDF::RSampleInfo &id) { this->Update(slot, id); };
+      fLoopManager->AddSampleCallback(this, std::move(callUpdate));
    }
 
    RDefinePerSample(const RDefinePerSample &) = delete;
    RDefinePerSample &operator=(const RDefinePerSample &) = delete;
+
+   ~RDefinePerSample() { fLoopManager->Deregister(this); }
 
    /// Return the (type-erased) address of the Define'd value for the given processing slot.
    void *GetValuePtr(unsigned int slot) final

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -662,11 +662,6 @@ public:
       auto newColumn =
          std::make_shared<RDFDetail::RDefinePerSample<F>>(name, retTypeName, std::move(expression), *fLoopManager);
 
-      auto updateDefinePerSample = [newColumn](unsigned int slot, const ROOT::RDF::RSampleInfo &id) {
-         newColumn->Update(slot, id);
-      };
-      fLoopManager->AddSampleCallback(std::move(updateDefinePerSample));
-
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddDefine(std::move(newColumn));
       RInterface<Proxied> newInterface(fProxiedPtr, *fLoopManager, std::move(newCols), fDataSource);
@@ -721,10 +716,6 @@ public:
       auto upcastNodeOnHeap = RDFInternal::MakeSharedOnHeap(RDFInternal::UpcastNode(fProxiedPtr));
       auto jittedDefine =
          RDFInternal::BookDefinePerSampleJit(name, expression, *fLoopManager, fColRegister, upcastNodeOnHeap);
-      auto updateDefinePerSample = [jittedDefine](unsigned int slot, const ROOT::RDF::RSampleInfo &id) {
-         jittedDefine->Update(slot, id);
-      };
-      fLoopManager->AddSampleCallback(std::move(updateDefinePerSample));
 
       RDFInternal::RColumnRegister newCols(fColRegister);
       newCols.AddDefine(std::move(jittedDefine));
@@ -3190,7 +3181,6 @@ private:
 
       auto action = RDFInternal::BuildAction<ColTypes...>(validColumnNames, helperArg, nSlots, fProxiedPtr, ActionTag{},
                                                           fColRegister);
-      fLoopManager->AddSampleCallback(action->GetSampleCallback());
       return MakeResultPtr(r, *fLoopManager, std::move(action));
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -23,6 +23,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 // forward declarations
@@ -133,8 +134,9 @@ class RLoopManager : public RNodeBase {
    std::vector<RDFInternal::RCallback> fCallbacks;         ///< Registered callbacks
    /// Registered callbacks to invoke just once before running the loop
    std::vector<RDFInternal::ROneTimeCallback> fCallbacksOnce;
-   /// Registered callbacks to call at the beginning of each "data block"
-   std::vector<ROOT::RDF::SampleCallback_t> fSampleCallbacks;
+   /// Registered callbacks to call at the beginning of each "data block".
+   /// The key is the pointer of the corresponding node in the computation graph (a RDefinePerSample or a RAction).
+   std::unordered_map<void *, ROOT::RDF::SampleCallback_t> fSampleCallbacks;
    RDFInternal::RNewSampleNotifier fNewSampleNotifier;
    std::vector<ROOT::RDF::RSampleInfo> fSampleInfos;
    unsigned int fNRuns{0}; ///< Number of event loops run
@@ -227,7 +229,7 @@ public:
 
    const ColumnNames_t &GetBranchNames();
 
-   void AddSampleCallback(ROOT::RDF::SampleCallback_t &&callback);
+   void AddSampleCallback(void *nodePtr, ROOT::RDF::SampleCallback_t &&callback);
 };
 
 } // ns RDF


### PR DESCRIPTION
Before this commit, if an action with a sample callback (currently
only Snapshot) or a DefinePerSample went out of scope, we did not
deregister the corresponding callbacks from the RLoopManager, which
would try to run them anyway during the following event loop.
As callbacks typically perform a call on the original action or
define objects, this could cause a use-after-delete.

With this patch, we now associate each callback to the address of
the corresponding node of the computation graph and remove callbacks
when the nodes go out of scope.

This fixes https://github.com/root-project/root/issues/11222.