### PR TITLE
[DF] Fix builds with imt=OFF

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -17,7 +17,6 @@
 #include "ROOT/RDF/RRangeBase.hxx"
 #include "ROOT/RDF/RVariationBase.hxx"
 #include "ROOT/RLogger.hxx"
-#include "ROOT/RSlotStack.hxx"
 #include "RtypesCore.h" // Long64_t
 #include "TStopwatch.h"
 #include "TBranchElement.h"
@@ -33,6 +32,7 @@
 #ifdef R__USE_IMT
 #include "ROOT/TThreadExecutor.hxx"
 #include "ROOT/TTreeProcessorMT.hxx"
+#include "ROOT/RSlotStack.hxx"
 #endif
 
 #include <algorithm>
@@ -423,12 +423,14 @@ RLoopManager::RLoopManager(ROOT::RDF::Experimental::RDatasetSpec &&spec)
    }
 }
 
+#ifdef R__USE_IMT
 struct RSlotRAII {
    ROOT::Internal::RSlotStack &fSlotStack;
    unsigned int fSlot;
    RSlotRAII(ROOT::Internal::RSlotStack &slotStack) : fSlotStack(slotStack), fSlot(slotStack.GetSlot()) {}
    ~RSlotRAII() { fSlotStack.ReturnSlot(fSlot); }
 };
+#endif
 
 /// Run event loop with no source files, in parallel.
 void RLoopManager::RunEmptySourceMT()

--- a/tree/dataframe/test/dataframe_nodes.cxx
+++ b/tree/dataframe/test/dataframe_nodes.cxx
@@ -1,7 +1,6 @@
 #include "ROOT/TestSupport.hxx"
 
 #include <ROOT/RDataFrame.hxx>
-#include <ROOT/RSlotStack.hxx>
 #include <TStatistic.h> // To check reading of columns with types which are mothers of the column type
 #include <TSystem.h>
 
@@ -10,7 +9,8 @@
 
 #include "gtest/gtest.h"
 
-#ifndef NDEBUG
+#if defined(R__USE_IMT) && !defined(NDEBUG)
+#include <ROOT/RSlotStack.hxx>
 
 TEST(RDataFrameNodes, RSlotStackGetOneTooMuch)
 {


### PR DESCRIPTION
A recent commit moved `RSlotStack` to `core/imt`, so now we can only include it if `R__USE_IMT` is defined.