### PR TITLE
Update hadd docs

### DIFF
--- a/build/misc/argparse2help.py
+++ b/build/misc/argparse2help.py
@@ -20,6 +20,8 @@ def write_header(parser, fileName):
 	file.write("#define ROOT_{}\n".format(splitPath[len(splitPath)-1].partition(".")[0]))
 	file.write("constexpr static const char kCommandLineOptionsHelp[] = R\"RAW(\n")
 	file.write(parser.format_usage() + "\n")
+	if parser.description is not None:
+		file.write(parser.description + "\n\n")
 	file.write("OPTIONS:\n")
 	for arg in listArgs:
 		options = ""
@@ -35,6 +37,8 @@ def write_header(parser, fileName):
 			file.write("  {}{}{}\n".format(options, spaces, help))
 		else:
 			file.write("  {}\n".format(options))
+	if parser.epilog is not None:
+		file.write("\n" + parser.epilog + "\n")
 	file.write(")RAW\";\n")
 	file.write("#endif\n")
 	file.close()

--- a/main/src/hadd-argparse.py
+++ b/main/src/hadd-argparse.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 
 def get_argparse():
 	DESCRIPTION = """This program will add histograms from a list of root files and write them to a target root file.\n

--- a/main/src/hadd-argparse.py
+++ b/main/src/hadd-argparse.py
@@ -3,16 +3,22 @@ import textwrap
 
 
 def get_argparse():
-    DESCRIPTION = """This program will add histograms from a list of root files and write them to a target root file.\n
-The target file is newly created and must not exist, or if -f (\"force\") is given, must not be one of the source files.\n
-"""
-    EPILOGUE = """
-If Target and source files have different compression settings a slower method is used.
-For options that takes a size as argument, a decimal number of bytes is expected.
-If the number ends with a ``k'', ``m'', ``g'', etc., the number is multiplied by 1000 (1K), 1000000 (1MB), 1000000000 (1G), etc.
-If this prefix is followed by i, the number is multiplied by the traditional 1024 (1KiB), 1048576 (1MiB), 1073741824 (1GiB), etc.
-The prefix can be optionally followed by B whose casing is ignored, eg. 1k, 1K, 1Kb and 1KB are the same.
-"""
+    DESCRIPTION = textwrap.fill(
+        "This program will add histograms, trees and other objects from a list "
+        "of ROOT files and write them to a target ROOT file. The target file is "
+        "newly created and must not exist, or if -f (\"force\") is given, must "
+        "not be one of the source files.")
+
+    EPILOGUE = textwrap.fill(
+        "If TARGET and SOURCES have different compression settings a slower "
+        "method is used. For options that takes a size as argument, a decimal "
+        "number of bytes is expected. If the number ends with a ``k'', ``m'', "
+        "``g'', etc., the number is multiplied by 1000 (1K), 1000000 (1MB), "
+        "1000000000 (1G), etc. If this prefix is followed by i, the number is "
+        "multiplied by the traditional 1024 (1KiB), 1048576 (1MiB), 1073741824 "
+        "(1GiB), etc. The prefix can be optionally followed by B whose casing "
+        "is ignored, eg. 1k, 1K, 1Kb and 1KB are the same. ")
+
     parser = argparse.ArgumentParser(add_help=False, prog='hadd',
                                      description=DESCRIPTION, epilog=EPILOGUE)
     parser.add_argument("-a", help="Append to the output")

--- a/main/src/hadd-argparse.py
+++ b/main/src/hadd-argparse.py
@@ -1,4 +1,5 @@
 import argparse
+import textwrap
 
 def get_argparse():
 	DESCRIPTION = """This program will add histograms from a list of root files and write them to a target root file.\n
@@ -17,21 +18,31 @@ The prefix can be optionally followed by B whose casing is ignored, eg. 1k, 1K, 
 	parser.add_argument("-k", help="Skip corrupt or non-existent files, do not exit")
 	parser.add_argument("-T", help="Do not merge Trees")
 	parser.add_argument("-O", help="Re-optimize basket size when merging TTree")
-	parser.add_argument("-v", help="Explicitly set the verbosity level: 0 request no output, 99 is the default")
+	parser.add_argument("-v", help=textwrap.fill(
+		"Explicitly set the verbosity level: 0 request no output, 99 is the default"))
 	parser.add_argument("-j", help="Parallelize the execution in multiple processes")
-	parser.add_argument("-dbg", help="Parallelize the execution in multiple processes in debug mode (Does not delete partial files stored inside working directory)")
-	parser.add_argument("-d", help="Carry out the partial multiprocess execution in the specified directory")
-	parser.add_argument("-n", help="Open at most 'maxopenedfiles' at once (use 0 to request to use the system maximum)")
-	parser.add_argument("-cachesize", help="Resize the prefetching cache use to speed up I/O operations(use 0 to disable)")
-	parser.add_argument("-experimental-io-features", help="Used with an argument provided, enables the corresponding experimental feature for output trees")
-	parser.add_argument("-f", help="Gives the ability to specify the compression level of the target file(by default 4) ")
-	parser.add_argument("-fk", help="""Sets the target file to contain the baskets with the same compression
-as the input files (unless -O is specified). Compresses the meta data
-using the compression level specified in the first input or the
-compression setting after fk (for example 206 when using -fk206)""")
+	parser.add_argument("-dbg", help=textwrap.fill(
+		"Parallelize the execution in multiple processes in debug mode "
+		"(Does not delete partial files stored inside working directory)"))
+	parser.add_argument("-d", help=textwrap.fill(
+		"Carry out the partial multiprocess execution in the specified directory"))
+	parser.add_argument("-n", help=textwrap.fill(
+		"Open at most 'maxopenedfiles' at once (use 0 to request to use the system maximum)"))
+	parser.add_argument("-cachesize", help=textwrap.fill(
+		"Resize the prefetching cache use to speed up I/O operations(use 0 to disable)"))
+	parser.add_argument("-experimental-io-features", help=textwrap.fill(
+		"Used with an argument provided, enables the corresponding experimental feature for output trees"))
+	parser.add_argument("-f", help=textwrap.fill(
+		"Gives the ability to specify the compression level of the target file (by default 4) "))
+	parser.add_argument("-fk", help=textwrap.fill(
+		"Sets the target file to contain the baskets with the same compression "
+		"as the input files (unless -O is specified). Compresses the meta data "
+		"using the compression level specified in the first input or the "
+		"compression setting after fk (for example 206 when using -fk206)"))
 	parser.add_argument("-ff", help="The compression level use is the one specified in the first input")
 	parser.add_argument("-f0", help="Do not compress the target file")
-	parser.add_argument("-f6", help="Use compression level 6. (See TFile::SetCompressionSettings for the support range of value.)")
+	parser.add_argument("-f6", help=textwrap.fill(
+		"Use compression level 6. (See TFile::SetCompressionSettings for the support range of value.)"))
 	parser.add_argument("TARGET", help="Target file")
 	parser.add_argument("SOURCES", help="Source files")
 	return parser

--- a/main/src/hadd-argparse.py
+++ b/main/src/hadd-argparse.py
@@ -1,48 +1,49 @@
 import argparse
 import textwrap
 
+
 def get_argparse():
-	DESCRIPTION = """This program will add histograms from a list of root files and write them to a target root file.\n
+    DESCRIPTION = """This program will add histograms from a list of root files and write them to a target root file.\n
 The target file is newly created and must not exist, or if -f (\"force\") is given, must not be one of the source files.\n
 """
-	EPILOGUE = """
+    EPILOGUE = """
 If Target and source files have different compression settings a slower method is used.
 For options that takes a size as argument, a decimal number of bytes is expected.
 If the number ends with a ``k'', ``m'', ``g'', etc., the number is multiplied by 1000 (1K), 1000000 (1MB), 1000000000 (1G), etc.
 If this prefix is followed by i, the number is multiplied by the traditional 1024 (1KiB), 1048576 (1MiB), 1073741824 (1GiB), etc.
 The prefix can be optionally followed by B whose casing is ignored, eg. 1k, 1K, 1Kb and 1KB are the same.
 """
-	parser = argparse.ArgumentParser(add_help=False, prog='hadd',
-	description = DESCRIPTION, epilog = EPILOGUE)
-	parser.add_argument("-a", help="Append to the output")
-	parser.add_argument("-k", help="Skip corrupt or non-existent files, do not exit")
-	parser.add_argument("-T", help="Do not merge Trees")
-	parser.add_argument("-O", help="Re-optimize basket size when merging TTree")
-	parser.add_argument("-v", help=textwrap.fill(
-		"Explicitly set the verbosity level: 0 request no output, 99 is the default"))
-	parser.add_argument("-j", help="Parallelize the execution in multiple processes")
-	parser.add_argument("-dbg", help=textwrap.fill(
-		"Parallelize the execution in multiple processes in debug mode "
-		"(Does not delete partial files stored inside working directory)"))
-	parser.add_argument("-d", help=textwrap.fill(
-		"Carry out the partial multiprocess execution in the specified directory"))
-	parser.add_argument("-n", help=textwrap.fill(
-		"Open at most 'maxopenedfiles' at once (use 0 to request to use the system maximum)"))
-	parser.add_argument("-cachesize", help=textwrap.fill(
-		"Resize the prefetching cache use to speed up I/O operations(use 0 to disable)"))
-	parser.add_argument("-experimental-io-features", help=textwrap.fill(
-		"Used with an argument provided, enables the corresponding experimental feature for output trees"))
-	parser.add_argument("-f", help=textwrap.fill(
-		"Gives the ability to specify the compression level of the target file (by default 4) "))
-	parser.add_argument("-fk", help=textwrap.fill(
-		"Sets the target file to contain the baskets with the same compression "
-		"as the input files (unless -O is specified). Compresses the meta data "
-		"using the compression level specified in the first input or the "
-		"compression setting after fk (for example 206 when using -fk206)"))
-	parser.add_argument("-ff", help="The compression level use is the one specified in the first input")
-	parser.add_argument("-f0", help="Do not compress the target file")
-	parser.add_argument("-f6", help=textwrap.fill(
-		"Use compression level 6. (See TFile::SetCompressionSettings for the support range of value.)"))
-	parser.add_argument("TARGET", help="Target file")
-	parser.add_argument("SOURCES", help="Source files")
-	return parser
+    parser = argparse.ArgumentParser(add_help=False, prog='hadd',
+                                     description=DESCRIPTION, epilog=EPILOGUE)
+    parser.add_argument("-a", help="Append to the output")
+    parser.add_argument("-k", help="Skip corrupt or non-existent files, do not exit")
+    parser.add_argument("-T", help="Do not merge Trees")
+    parser.add_argument("-O", help="Re-optimize basket size when merging TTree")
+    parser.add_argument("-v", help=textwrap.fill(
+        "Explicitly set the verbosity level: 0 request no output, 99 is the default"))
+    parser.add_argument("-j", help="Parallelize the execution in multiple processes")
+    parser.add_argument("-dbg", help=textwrap.fill(
+        "Parallelize the execution in multiple processes in debug mode "
+        "(Does not delete partial files stored inside working directory)"))
+    parser.add_argument("-d", help=textwrap.fill(
+        "Carry out the partial multiprocess execution in the specified directory"))
+    parser.add_argument("-n", help=textwrap.fill(
+        "Open at most 'maxopenedfiles' at once (use 0 to request to use the system maximum)"))
+    parser.add_argument("-cachesize", help=textwrap.fill(
+        "Resize the prefetching cache use to speed up I/O operations(use 0 to disable)"))
+    parser.add_argument("-experimental-io-features", help=textwrap.fill(
+        "Used with an argument provided, enables the corresponding experimental feature for output trees"))
+    parser.add_argument("-f", help=textwrap.fill(
+        "Gives the ability to specify the compression level of the target file (by default 4) "))
+    parser.add_argument("-fk", help=textwrap.fill(
+        "Sets the target file to contain the baskets with the same compression "
+        "as the input files (unless -O is specified). Compresses the meta data "
+        "using the compression level specified in the first input or the "
+        "compression setting after fk (for example 206 when using -fk206)"))
+    parser.add_argument("-ff", help="The compression level use is the one specified in the first input")
+    parser.add_argument("-f0", help="Do not compress the target file")
+    parser.add_argument("-f6", help=textwrap.fill(
+        "Use compression level 6 (see TFile::SetCompressionSettings for the supported range of values)"))
+    parser.add_argument("TARGET", help="Target file")
+    parser.add_argument("SOURCES", help="Source files")
+    return parser


### PR DESCRIPTION
Related to #11245 . The `-O` option of hadd can be used to force the recompression of the whole target tree (including branches and baskets) to the compression algorithm set with `-f` option. This is not clear in the current `hadd` help message.
The first commit updates the help for the `-O` option, most probably this can be further improved so suggestions are welcome!

Other commits are style changes to the message for a clearer output and code.

After this PR:
```
$: hadd -h
usage: hadd [-a A] [-k K] [-T T] [-O O] [-v V] [-j J] [-dbg DBG] [-d D] [-n N]
            [-cachesize CACHESIZE]
            [-experimental-io-features EXPERIMENTAL_IO_FEATURES] [-f F]
            [-fk FK] [-ff FF] [-f0 F0] [-f6 F6]
            TARGET SOURCES

OPTIONS:
  -a                                   Append to the output
  -k                                   Skip corrupt or non-existent files, do not exit
  -T                                   Do not merge TTree objects
  -O                                   If hadd is used to merge TTree objects, compress the whole target tree
                                       (including its branches and baskets) with the desired compression
                                       algorithm. This can be set for example through the '-f' option
  -v                                   Explicitly set the verbosity level: 0 request no output, 99 is the
                                       default
  -j                                   Parallelize the execution in multiple processes
  -dbg                                 Parallelize the execution in multiple processes in debug mode (Does
                                       not delete partial files stored inside working directory)
  -d                                   Carry out the partial multiprocess execution in the specified
                                       directory
  -n                                   Open at most 'maxopenedfiles' at once (use 0 to request to use the
                                       system maximum)
  -cachesize                           Resize the prefetching cache use to speed up I/O operations (use 0 to
                                       disable)
  -experimental-io-features            Used with an argument provided, enables the corresponding experimental
                                       feature for output trees
  -f                                   Gives the ability to specify the compression level of the target file
                                       (by default 4)
  -fk                                  Sets the target file to contain the baskets with the same compression
                                       as the input files (unless -O is specified). Compresses the meta data
                                       using the compression level specified in the first input or the
                                       compression setting after fk (for example 206 when using -fk206)
  -ff                                  The compression level use is the one specified in the first input
  -f0                                  Do not compress the target file
  -f6                                  Use compression level 6 (See TFile::SetCompressionSettings for the
                                       supported range of values)
  TARGET                               Target file
  SOURCES                              Source files
```