### PR TITLE
[tree] Reduce string allocations in TBranch*::GetFullName.

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1959,11 +1959,19 @@ TString TBranch::GetFullName() const
    if (!mother || mother==this) {
       return fName;
    }
-   TString motherName(mother->GetName());
-   if (motherName.Length() && (motherName[motherName.Length()-1] == '.')) {
+
+   const auto motherName = mother->GetName();
+   const auto len = strlen(motherName);
+   if (len > 0 && (motherName[len-1] == '.')) {
       return fName;
    }
-   return motherName + "." + fName;
+
+   // Reserve the final size to avoid allocations
+   TString result{static_cast<Ssiz_t>(len + 1 + fName.Length())};
+   result  = motherName;
+   result += ".";
+   result += fName;
+   return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/tree/src/TBranchElement.cxx
+++ b/tree/tree/src/TBranchElement.cxx
@@ -2845,11 +2845,8 @@ TString TBranchElement::GetFullName() const
       // The parent's name is already included in the name for split TClonesArray and STL collections
       return fName;
    }
-   TString motherName(mother->GetName());
-   if (motherName.Length() && (motherName[motherName.Length()-1] == '.')) {
-      return fName;
-   }
-   return motherName + "." + fName;
+
+   return TBranch::GetFullName();
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When called repeatedly via TTree::GetBranch, the string allocations in
GetFullName have a notable runtime cost.
Here, the allocation is reduced to a single one in every branch.

See here for a performance analysis where repeated invocations produced significant overhead.
![image](https://user-images.githubusercontent.com/16205615/186901068-80db73be-e32a-47e5-8986-4dfe8d5e8dae.png)

This seems to matter most if the branches have mothers, because in this case, the string composition kicks in.

@pcanal
- Do you know if there's a test that covers this case?
- Do you agree that this brings down TString allocations?