### PR TITLE
[core] fix typo in TClingCallFunc::exec

### DIFF
--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1537,7 +1537,7 @@ void TClingCallFunc::exec(void *address, void *ret)
             vp_ary.push_back(&vh_ary.back());
          } else {
             ::Error("TClingCallFunc::exec(void*)",
-                    "Invalid type '%s'", BT->getTypeClassName());
+                    "Invalid type '%s'", QT->getTypeClassName());
             QT->dump();
             return;
          }


### PR DESCRIPTION
Fixes the following error when building:
```
/home/vpadulan/programs/rootproject/rootsrc/core/metacling/src/TClingCallFunc.cxx: In member function ‘void TClingCallFunc::exec(void*, void*)’:
/home/vpadulan/programs/rootproject/rootsrc/core/metacling/src/TClingCallFunc.cxx:1539:20: error: ‘this’ pointer is null [-Werror=nonnull]
 1539 |             ::Error("TClingCallFunc::exec(void*)",
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1540 |                     "Invalid type '%s'", BT->getTypeClassName());
```

Co-authored-by: Vassil Vassilev <v.g.vassilev@gmail.com>

