### PR TITLE
Fix race condition when loading dictionary shared libraries

### DIFF
--- a/core/meta/src/TGenericClassInfo.cxx
+++ b/core/meta/src/TGenericClassInfo.cxx
@@ -195,7 +195,10 @@ namespace Internal {
 
    void TGenericClassInfo::Init(Int_t pragmabits)
    {
-      // Initilization routine.
+      // Initialization routine.
+
+      // Writing to TClassTable requires that we hold this lock.
+      R__WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
       //TVirtualStreamerInfo::Class_Version MUST be the same as TStreamerInfo::Class_Version
       if (fVersion==-2) fVersion = TVirtualStreamerInfo::Class_Version();


### PR DESCRIPTION
Earlier, ATLAS was seeing a nasty race condition involving ROOT dictionary
information (see ATR-25049).

The ROOT internal class TClassTable records information about all classes
that could potentially be created. This is effectively a singleton,
but TClassTable itself does no locking. Rather, it depends on callers
already having acquired the root internal mutex. When a shared library
is loaded that contains dictionary information, TClassTable gets calls
to register information for classes defined in that file. However,
the ROOT lock is not acquired in that case. So a shared library load
could race with TClass::GetClass and result in corruption of TClassTable.

This change modifies TGenericClassInfo::Init so that we will take the lock
when a shared library is loaded.

(ATLAS is currently working around this by hacking shared library loading
in order to acquire the lock, but this hack is not possible with newer
versions of glibc, so this will eventually become a blocker for
moving to centos9.)
