### PR TITLE
[cling] meta cmd .x should not crash if no file is given

### DIFF
--- a/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
+++ b/interpreter/cling/lib/MetaProcessor/MetaParser.cpp
@@ -279,6 +279,11 @@ namespace cling {
       int forward = 0;
       std::string args;
       llvm::StringRef file(getCurTok().getBufStart());
+
+      if (file.empty()) {
+        return false; // FIXME: Issue proper diagnostics
+      }
+
       while (!lookAhead(forward).is(tok::eof))
 	++forward;
 


### PR DESCRIPTION
## Changes or fixes:

On Ubuntu 22.04 , execute standalone cling binary. In cmd prompt execute .x meta command without giving a filename, cling crashes.

The proposed solution is to directly reject the .x command without giving clear diagnostics. This is not user friendly but this is currently how `MetaParser.cpp` handles all parsing/input error. At least it prevents crashing.

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)


