### PR TITLE
Add missing includes in RooSimPdfBuilder.cxx

### DIFF
--- a/roofit/roofitcore/src/RooSimPdfBuilder.cxx
+++ b/roofit/roofitcore/src/RooSimPdfBuilder.cxx
@@ -416,6 +416,7 @@
 
 #include <cstring>
 #include "strtok.h"
+#include "strlcpy.h"
 
 #ifndef _WIN32
 #include <strings.h>
@@ -428,6 +429,7 @@
 #include "RooFormulaVar.h"
 #include "RooAbsCategory.h"
 #include "RooCategory.h"
+#include "RooCatType.h"
 #include "RooStringVar.h"
 #include "RooMappedCategory.h"
 #include "RooRealIntegral.h"


### PR DESCRIPTION
Appears with `-Ddev=on` builds