### PR TITLE
[tmva] Fix maximum value for indexing the NumFolds parameter

### DIFF
--- a/tmva/tmva/src/CvSplit.cxx
+++ b/tmva/tmva/src/CvSplit.cxx
@@ -137,7 +137,7 @@ void TMVA::CvSplit::RecombineKFoldDataSet(DataSetInfo &dsi, Types::ETreeType tt)
 ///
 
 TMVA::CvSplitKFoldsExpr::CvSplitKFoldsExpr(DataSetInfo &dsi, TString expr)
-   : fDsi(dsi), fIdxFormulaParNumFolds(std::numeric_limits<UInt_t>::max()), fSplitFormula("", expr),
+   : fDsi(dsi), fIdxFormulaParNumFolds(std::numeric_limits<Int_t>::max()), fSplitFormula("", expr),
      fParValues(fSplitFormula.GetNpar())
 {
    if (!fSplitFormula.IsValid()) {

--- a/tmva/tmva/test/crossvalidation/TestCrossValidationSplitting.cxx
+++ b/tmva/tmva/test/crossvalidation/TestCrossValidationSplitting.cxx
@@ -313,6 +313,45 @@ TEST(CrossValidationSplitting, TrainingSetSplitOnSpectator)
    testFold(d, ids, split, 1);
 }
 
+TEST(CrossValidationSplitting, TrainingSetSplitOnSpectator2)
+{
+   TMVA::Tools::Instance();
+
+   const UInt_t NUM_FOLDS = 2;
+   const UInt_t nPointsSig = 11;
+   const UInt_t nPointsBkg = 10;
+
+   // Create DataSet
+   TMVA::MsgLogger::InhibitOutput();
+   data_t data_class0 = TMVA::createData(nPointsSig, 0);
+   data_t data_class1 = TMVA::createData(nPointsBkg, 100);
+
+   id_vec_t ids;
+   ids.insert(ids.end(), std::get<0>(data_class0).begin(), std::get<0>(data_class0).end());
+   ids.insert(ids.end(), std::get<0>(data_class1).begin(), std::get<0>(data_class1).end());
+
+   TMVA::DataLoader *d = new TMVA::DataLoader("dataset");
+
+   d->AddSignalTree(std::get<1>(data_class0));
+   d->AddBackgroundTree(std::get<1>(data_class1));
+
+   d->AddVariable("x", 'D');
+   d->AddSpectator("id", "id", "");
+   d->PrepareTrainingAndTestTree(
+      "", Form("SplitMode=Block:nTrain_Signal=%i:nTrain_Background=%i:!V", nPointsSig, nPointsBkg));
+
+   d->GetDataSetInfo().GetDataSet(); // Force creation of dataset.
+   TMVA::MsgLogger::EnableOutput();
+
+   // test split expression without passing the number of folds
+   TMVA::CvSplitKFolds split{NUM_FOLDS, "int([id])%2", kFALSE, 0};
+   d->MakeKFoldDataSet(split);
+
+   // Actual test
+   testFold(d, ids, split, 0);
+   testFold(d, ids, split, 1);
+}
+
 TEST(CrossValidationSplitting, TrainingSetSplitRandomStratified)
 {
    TMVA::Tools::Instance();


### PR DESCRIPTION
The maximum unsigned int value was used for an integer resulting in a negative integer value and this was causing a bug when accessing the numfold parameter in the CvSplit expression formula.
The bug is present when the parameter "NumFold" is not used in the SPlit expression.
See https://root-forum.cern.ch/t/tmva-crossvalidation-crashes-on-destructor-pyroot/51195



