### PR TITLE
[backport-v626] Avoid using deprecated std::iterator in several classes

### DIFF
--- a/core/base/v7/inc/ROOT/RIndexIter.hxx
+++ b/core/base/v7/inc/ROOT/RIndexIter.hxx
@@ -32,13 +32,20 @@ namespace Internal {
 
 template <class REFERENCE,
           class POINTER = typename std::add_pointer<typename std::remove_reference<REFERENCE>::type>::type>
-class RIndexIter: public std::iterator<std::random_access_iterator_tag, REFERENCE, POINTER> {
+class RIndexIter {
    size_t fIndex;
 
 protected:
    static constexpr size_t fgEndIndex = (size_t)-1;
 
 public:
+   using iterator_category = std::random_access_iterator_tag;
+   using value_type = REFERENCE;
+   using difference_type = POINTER;
+   using pointer = POINTER;
+   using const_pointer = const POINTER;
+   using reference = REFERENCE &;
+
    RIndexIter(size_t idx): fIndex(idx) {}
 
    /// Get the current index value.

--- a/core/base/v7/inc/ROOT/RIndexIter.hxx
+++ b/core/base/v7/inc/ROOT/RIndexIter.hxx
@@ -40,11 +40,10 @@ protected:
 
 public:
    using iterator_category = std::random_access_iterator_tag;
-   using value_type = REFERENCE;
-   using difference_type = POINTER;
+   using value_type = typename std::remove_reference<REFERENCE>::type;
+   using difference_type = std::ptrdiff_t;
    using pointer = POINTER;
-   using const_pointer = const POINTER;
-   using reference = REFERENCE &;
+   using reference = REFERENCE;
 
    RIndexIter(size_t idx): fIndex(idx) {}
 

--- a/core/cont/inc/ROOT/TSeq.hxx
+++ b/core/cont/inc/ROOT/TSeq.hxx
@@ -83,11 +83,18 @@ namespace ROOT {
          checkIntegralType();
       }
 
-      class iterator: public std::iterator<std::random_access_iterator_tag, T, difference_type> {
+      class iterator {
       private:
          T fCounter;
          T fStep;
       public:
+         using iterator_category = std::random_access_iterator_tag;
+         using value_type = T;
+         using difference_type = typename std::make_signed<T>::type;
+         using pointer = T *;
+         using const_pointer = const T *;
+         using reference = T &;
+
          iterator(T start, T step): fCounter(start), fStep(step) {}
          T operator*() const {
             return fCounter;

--- a/core/cont/inc/TBtree.h
+++ b/core/cont/inc/TBtree.h
@@ -331,10 +331,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TBtreeIter : public TIterator,
-                   public std::iterator<std::bidirectional_iterator_tag,
-                                        TObject*, std::ptrdiff_t,
-                                        const TObject**, const TObject*&> {
+class TBtreeIter : public TIterator {
 
 private:
    const TBtree  *fTree;      //btree being iterated
@@ -345,6 +342,13 @@ private:
    TBtreeIter() : fTree(0), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TBtreeIter(const TBtree *t, Bool_t dir = kIterForward);
    TBtreeIter(const TBtreeIter &iter);
    ~TBtreeIter() { }
@@ -360,7 +364,6 @@ public:
 
    ClassDef(TBtreeIter,0)  //B-tree iterator
 };
-
 
 //----- TBtree inlines ---------------------------------------------------------
 

--- a/core/cont/inc/TList.h
+++ b/core/cont/inc/TList.h
@@ -28,12 +28,6 @@
 #include <iterator>
 #include <memory>
 
-#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
-// Prevent -Weffc++ from complaining about the inheritance
-// TListIter from std::iterator.
-#pragma GCC system_header
-#endif
-
 const Bool_t kSortAscending  = kTRUE;
 const Bool_t kSortDescending = !kSortAscending;
 

--- a/core/cont/inc/TList.h
+++ b/core/cont/inc/TList.h
@@ -194,10 +194,7 @@ public:
 // Iterator of linked list.                                             //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-class TListIter : public TIterator,
-                  public std::iterator<std::bidirectional_iterator_tag,
-                                       TObject*, std::ptrdiff_t,
-                                       const TObject**, const TObject*&> {
+class TListIter : public TIterator {
 
 protected:
    using TObjLinkPtr_t = std::shared_ptr<TObjLink>;
@@ -212,6 +209,13 @@ protected:
                  fStarted(kFALSE) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TListIter(const TList *l, Bool_t dir = kIterForward);
    TListIter(const TListIter &iter);
    ~TListIter() { }

--- a/core/cont/inc/TMap.h
+++ b/core/cont/inc/TMap.h
@@ -141,10 +141,7 @@ typedef TPair   TAssoc;     // for backward compatibility
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TMapIter : public TIterator,
-                 public std::iterator<std::bidirectional_iterator_tag,
-                                      TObject*, std::ptrdiff_t,
-                                      const TObject**, const TObject*&> {
+class TMapIter : public TIterator {
 
 private:
    const TMap       *fMap;         //map being iterated
@@ -154,6 +151,13 @@ private:
    TMapIter() : fMap(nullptr), fCursor(nullptr), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TMapIter(const TMap *map, Bool_t dir = kIterForward);
    TMapIter(const TMapIter &iter);
    ~TMapIter();

--- a/core/cont/inc/TObjArray.h
+++ b/core/cont/inc/TObjArray.h
@@ -120,10 +120,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TObjArrayIter : public TIterator,
-                      public std::iterator<std::bidirectional_iterator_tag, // TODO: ideally it should be a  randomaccess_iterator_tag
-                                           TObject*, std::ptrdiff_t,
-                                           const TObject**, const TObject*&> {
+class TObjArrayIter : public TIterator {
 
 private:
    const TObjArray  *fArray;     //array being iterated
@@ -134,6 +131,13 @@ private:
    TObjArrayIter() : fArray(0), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag; // TODO: ideally it should be a randomaccess_iterator_tag
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TObjArrayIter(const TObjArray *arr, Bool_t dir = kIterForward);
    TObjArrayIter(const TObjArrayIter &iter);
    ~TObjArrayIter() { }

--- a/core/cont/inc/TObjArray.h
+++ b/core/cont/inc/TObjArray.h
@@ -26,12 +26,6 @@
 
 #include <iterator>
 
-#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
-// Prevent -Weffc++ from complaining about the inheritance
-// TObjArrayIter from std::iterator.
-#pragma GCC system_header
-#endif
-
 class TObjArrayIter;
 
 class TObjArray : public TSeqCollection {

--- a/core/cont/inc/TOrdCollection.h
+++ b/core/cont/inc/TOrdCollection.h
@@ -93,10 +93,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TOrdCollectionIter : public TIterator,
-                           public std::iterator<std::bidirectional_iterator_tag,
-                                                TObject*, std::ptrdiff_t,
-                                                const TObject**, const TObject*&> {
+class TOrdCollectionIter : public TIterator {
 
 private:
    const TOrdCollection  *fCol;       //collection being iterated
@@ -107,6 +104,13 @@ private:
    TOrdCollectionIter() : fCol(nullptr), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TOrdCollectionIter(const TOrdCollection *col, Bool_t dir = kIterForward);
    TOrdCollectionIter(const TOrdCollectionIter &iter);
    ~TOrdCollectionIter() { }
@@ -122,7 +126,6 @@ public:
 
    ClassDef(TOrdCollectionIter,0)  //Ordered collection iterator
 };
-
 
 //---- inlines -----------------------------------------------------------------
 

--- a/core/cont/inc/TRefArray.h
+++ b/core/cont/inc/TRefArray.h
@@ -27,12 +27,6 @@
 
 #include <iterator>
 
-#if (__GNUC__ >= 3) && !defined(__INTEL_COMPILER)
-// Prevent -Weffc++ from complaining about the inheritance
-// TRefArrayIter from std::iterator.
-#pragma GCC system_header
-#endif
-
 class TSystem;
 class TRefArrayIter;
 

--- a/core/cont/inc/TRefArray.h
+++ b/core/cont/inc/TRefArray.h
@@ -119,10 +119,7 @@ public:
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
 
-class TRefArrayIter : public TIterator,
-                      public std::iterator<std::bidirectional_iterator_tag, // TODO: ideally it should be a  randomaccess_iterator_tag
-                                           TObject*, std::ptrdiff_t,
-                                           const TObject**, const TObject*&> {
+class TRefArrayIter : public TIterator {
 
 private:
    const TRefArray  *fArray;      //array being iterated
@@ -133,6 +130,13 @@ private:
    TRefArrayIter() : fArray(0), fCurCursor(0), fCursor(0), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag; // TODO: ideally it should be a randomaccess_iterator_tag
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TRefArrayIter(const TRefArray *arr, Bool_t dir = kIterForward);
    TRefArrayIter(const TRefArrayIter &iter);
    ~TRefArrayIter() { }

--- a/core/meta/src/TViewPubFunctions.h
+++ b/core/meta/src/TViewPubFunctions.h
@@ -93,11 +93,7 @@ public:
 // Iterator of view of linked list.      `1234                               //
 //                                                                      //
 //////////////////////////////////////////////////////////////////////////
-class TViewPubFunctionsIter : public TIterator,
-                              public std::iterator<std::bidirectional_iterator_tag,
-                                                   TObject*, std::ptrdiff_t,
-                                                    const TObject**, const TObject*&>
-{
+class TViewPubFunctionsIter : public TIterator {
 protected:
    const TList *fView;   //View we are iterating over.
    TIter        fClassIter;    //iterator over the classes
@@ -108,6 +104,13 @@ protected:
    TViewPubFunctionsIter() : fView(0), fClassIter((TCollection *)0), fFuncIter((TCollection *)0), fStarted(kFALSE), fDirection(kIterForward) { }
 
 public:
+   using iterator_category = std::bidirectional_iterator_tag;
+   using value_type = TObject *;
+   using difference_type = std::ptrdiff_t;
+   using pointer = TObject **;
+   using const_pointer = const TObject **;
+   using reference = const TObject *&;
+
    TViewPubFunctionsIter(const TViewPubFunctions *l, Bool_t dir = kIterForward);
    TViewPubFunctionsIter(const TViewPubFunctionsIter &iter);
    ~TViewPubFunctionsIter() { }

--- a/hist/histv7/inc/ROOT/RAxis.hxx
+++ b/hist/histv7/inc/ROOT/RAxis.hxx
@@ -123,11 +123,16 @@ public:
     Random const_iterator through bins. Represents the bin index, not a bin
     content: the axis has no notion of any content.
     */
-   class const_iterator: public std::iterator<std::random_access_iterator_tag, int /*value*/, int /*distance*/,
-                                              const int * /*pointer*/, const int & /*ref*/> {
+   class const_iterator {
       int fCursor = 0; ///< Current iteration position
 
    public:
+      using iterator_category = std::random_access_iterator_tag;
+      using value_type = int;
+      using difference_type = int;
+      using pointer = const int *;
+      using reference = const int &;
+
       const_iterator() = default;
 
       /// Initialize a const_iterator with its position

--- a/tmva/tmva/inc/TMVA/RTensor.hxx
+++ b/tmva/tmva/inc/TMVA/RTensor.hxx
@@ -260,12 +260,16 @@ public:
    RTensor<Value_t, Container_t> Slice(const Slice_t &slice); 
 
    // Iterator class
-   class Iterator : public std::iterator<std::random_access_iterator_tag, Value_t> {
+   class Iterator {
    private:
       RTensor<Value_t, Container_t>& fTensor;
       Index_t::value_type fGlobalIndex;
    public:
-      using difference_type = typename std::iterator<std::random_access_iterator_tag, Value_t>::difference_type;
+      using iterator_category = std::random_access_iterator_tag;
+      using value_type = Value_t;
+      using difference_type = std::ptrdiff_t;
+      using pointer = Value_t *;
+      using reference = Value_t &;
 
       Iterator(RTensor<Value_t, Container_t>& x, typename Index_t::value_type idx) : fTensor(x), fGlobalIndex(idx) {}
       Iterator& operator++() { fGlobalIndex++; return *this; }

--- a/tree/treeplayer/inc/ROOT/TTreeReaderFast.hxx
+++ b/tree/treeplayer/inc/ROOT/TTreeReaderFast.hxx
@@ -42,9 +42,8 @@ public:
    // TTreeReaderFast.
    //
    // NOTE that an increment may invalidate previous copies of the iterator.
-   class Iterator_t:
-      public std::iterator<std::input_iterator_tag, const Long64_t, Long64_t> {
-   private:
+   class Iterator_t {
+
       Int_t   *fIdx{nullptr}; ///< Current offset inside this cluster.
       Int_t    fCount{0};     ///< Number of entries inside this cluster.
       Long64_t fEntry{-1};    ///< Entry number of the tree referenced by this iterator; -1 is invalid.
@@ -54,6 +53,13 @@ public:
       bool IsValid() const { return fEntry >= 0; }
 
    public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = const Long64_t;
+      using difference_type = Long_t;
+      using pointer = const Long64_t *;
+      using const_pointer = const Long64_t *;
+      using reference = const Long64_t &;
+
       /// Default-initialize the iterator as "past the end".
       Iterator_t() {}
 

--- a/tree/treeplayer/inc/TTreeReader.h
+++ b/tree/treeplayer/inc/TTreeReader.h
@@ -53,8 +53,7 @@ public:
    /// It does not really represent a data element; it simply
    /// returns the entry number (or -1 once the end of the tree
    /// is reached).
-   class Iterator_t:
-      public std::iterator<std::input_iterator_tag, const Long64_t, Long64_t> {
+   class Iterator_t {
    private:
       Long64_t fEntry; ///< Entry number of the tree referenced by this iterator; -1 is invalid.
       TTreeReader* fReader; ///< The reader we select the entries on.
@@ -63,6 +62,13 @@ public:
       bool IsValid() const { return fEntry >= 0; }
 
    public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = const Long64_t;
+      using difference_type = Long64_t;
+      using pointer = const Long64_t *;
+      using const_pointer = const Long64_t *;
+      using reference = const Long64_t &;
+
       /// Default-initialize the iterator as "past the end".
       Iterator_t(): fEntry(-1), fReader(nullptr) {}
 


### PR DESCRIPTION
Cherry-picked commits that are updating the deprecated std::iterator in several classes.

Spotted here: https://root-forum.cern.ch/t/deprecated-iterator-in-ttreereader-h-and-tseq-hxx/51344/2.