### PR TITLE
[tree] Add missing `override` specifiers in tree/dataframe

### DIFF
--- a/tree/dataframe/inc/ROOT/RArrowDS.hxx
+++ b/tree/dataframe/inc/ROOT/RArrowDS.hxx
@@ -36,20 +36,20 @@ private:
 
    std::vector<std::pair<size_t, size_t>> fGetterIndex; // (columnId, visitorId)
    std::vector<std::unique_ptr<ROOT::Internal::RDF::TValueGetter>> fValueGetters; // Visitors to be used to track and get entries. One per column.
-   std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &type) override;
+   std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &type) final;
 
 public:
    RArrowDS(std::shared_ptr<arrow::Table> table, std::vector<std::string> const &columns);
    ~RArrowDS();
-   const std::vector<std::string> &GetColumnNames() const override;
-   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() override;
-   std::string GetTypeName(std::string_view colName) const override;
-   bool HasColumn(std::string_view colName) const override;
-   bool SetEntry(unsigned int slot, ULong64_t entry) override;
-   void InitSlot(unsigned int slot, ULong64_t firstEntry) override;
-   void SetNSlots(unsigned int nSlots) override;
-   void Initialize() override;
-   std::string GetLabel() override;
+   const std::vector<std::string> &GetColumnNames() const final;
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final;
+   std::string GetTypeName(std::string_view colName) const final;
+   bool HasColumn(std::string_view colName) const final;
+   bool SetEntry(unsigned int slot, ULong64_t entry) final;
+   void InitSlot(unsigned int slot, ULong64_t firstEntry) final;
+   void SetNSlots(unsigned int nSlots) final;
+   void Initialize() final;
+   std::string GetLabel() final;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/inc/ROOT/RCsvDS.hxx
+++ b/tree/dataframe/inc/ROOT/RCsvDS.hxx
@@ -66,7 +66,7 @@ private:
    void FillHeaders(const std::string &);
    void FillRecord(const std::string &, Record_t &);
    void GenerateHeaders(size_t);
-   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &);
+   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &) final;
    void ValidateColTypes(std::vector<std::string> &) const;
    void InferColTypes(std::vector<std::string> &);
    void InferType(const std::string &, unsigned int);
@@ -76,7 +76,7 @@ private:
    void FreeRecords();
 
 protected:
-   std::string AsString();
+   std::string AsString() final;
 
 public:
    RCsvDS(std::string_view fileName, bool readHeaders = true, char delimiter = ',', Long64_t linesChunkSize = -1LL,

--- a/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefinePerSample.hxx
@@ -69,7 +69,7 @@ public:
       fLastResults[slot * RDFInternal::CacheLineStep<RetType_t>()] = fExpression(slot, id);
    }
 
-   const std::type_info &GetTypeId() const { return typeid(RetType_t); }
+   const std::type_info &GetTypeId() const final { return typeid(RetType_t); }
 
    void InitSlot(TTreeReader *, unsigned int) final {}
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -153,7 +153,7 @@ public:
       fPrevNode.IncrChildrenCount();
    }
 
-   void AddFilterName(std::vector<std::string> &filters)
+   void AddFilterName(std::vector<std::string> &filters) final
    {
       fPrevNode.AddFilterName(filters);
       auto name = (HasName() ? fName : "Unnamed Filter");
@@ -164,7 +164,7 @@ public:
    void FinalizeSlot(unsigned int slot) final { fValues[slot].fill(nullptr); }
 
    std::shared_ptr<RDFGraphDrawing::GraphNode>
-   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) final
    {
       // Recursively call for the previous node.
       auto prevNode = fPrevNode.GetGraph(visitedMap);

--- a/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilterBase.hxx
@@ -55,7 +55,7 @@ public:
                const std::vector<std::string> &prevVariations, const std::string &variation = "nominal");
    RFilterBase &operator=(const RFilterBase &) = delete;
 
-   virtual ~RFilterBase();
+   ~RFilterBase() override;
 
    virtual void InitSlot(TTreeReader *r, unsigned int slot) = 0;
    bool HasName() const;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedAction.hxx
@@ -58,7 +58,7 @@ public:
    void SetHasRun() final;
 
    std::shared_ptr<GraphDrawing::GraphNode>
-   GetGraph(std::unordered_map<void *, std::shared_ptr<GraphDrawing::GraphNode>> &visitedMap);
+   GetGraph(std::unordered_map<void *, std::shared_ptr<GraphDrawing::GraphNode>> &visitedMap) final;
 
    // Helper for RMergeableValue
    std::unique_ptr<ROOT::Detail::RDF::RMergeableValueBase> GetMergeableValue() const final;

--- a/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedFilter.hxx
@@ -59,7 +59,7 @@ public:
    void AddFilterName(std::vector<std::string> &filters) final;
    void FinalizeSlot(unsigned int slot) final;
    std::shared_ptr<RDFGraphDrawing::GraphNode>
-   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap);
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) final;
    std::shared_ptr<RNodeBase> GetVariedFilter(const std::string &variationName) final;
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RJittedVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RJittedVariation.hxx
@@ -36,7 +36,7 @@ public:
       : RVariationBase(colNames, variationName, variationTags, type, colRegister, lm, inputColNames)
    {
    }
-   ~RJittedVariation();
+   ~RJittedVariation() override;
 
    void SetVariation(std::unique_ptr<RVariationBase> c) { fConcreteVariation = std::move(c); }
 

--- a/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLazyDSImpl.hxx
@@ -53,7 +53,7 @@ class RLazyDS final : public ROOT::RDF::RDataSource {
    std::vector<std::pair<ULong64_t, ULong64_t>> fEntryRanges{};
    unsigned int fNSlots{0};
 
-   Record_t GetColumnReadersImpl(std::string_view colName, const std::type_info &id)
+   Record_t GetColumnReadersImpl(std::string_view colName, const std::type_info &id) final
    {
       auto colNameStr = std::string(colName);
       // This could be optimised and done statically
@@ -114,7 +114,7 @@ class RLazyDS final : public ROOT::RDF::RDataSource {
    }
 
 protected:
-   std::string AsString() { return "lazy data source"; };
+   std::string AsString() final { return "lazy data source"; };
 
 public:
    RLazyDS(std::pair<std::string, RResultPtr<std::vector<ColumnTypes>>>... colsNameVals)
@@ -134,34 +134,34 @@ public:
       }
    }
 
-   const std::vector<std::string> &GetColumnNames() const { return fColNames; }
+   const std::vector<std::string> &GetColumnNames() const final { return fColNames; }
 
-   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges()
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final
    {
       auto entryRanges(std::move(fEntryRanges)); // empty fEntryRanges
       return entryRanges;
    }
 
-   std::string GetTypeName(std::string_view colName) const
+   std::string GetTypeName(std::string_view colName) const final
    {
       const auto key = std::string(colName);
       return fColTypesMap.at(key);
    }
 
-   bool HasColumn(std::string_view colName) const
+   bool HasColumn(std::string_view colName) const final
    {
       const auto key = std::string(colName);
       const auto endIt = fColTypesMap.end();
       return endIt != fColTypesMap.find(key);
    }
 
-   bool SetEntry(unsigned int slot, ULong64_t entry)
+   bool SetEntry(unsigned int slot, ULong64_t entry) final
    {
       SetEntryHelper(slot, entry, std::index_sequence_for<ColumnTypes...>());
       return true;
    }
 
-   void SetNSlots(unsigned int nSlots)
+   void SetNSlots(unsigned int nSlots) final
    {
       fNSlots = nSlots;
       const auto nCols = fColNames.size();
@@ -179,7 +179,7 @@ public:
          delete ptrHolder;
    }
 
-   void Initialize()
+   void Initialize() final
    {
       ColLenghtChecker(std::index_sequence_for<ColumnTypes...>());
       const auto nEntries = GetEntriesNumber();
@@ -200,7 +200,7 @@ public:
       }
    }
 
-   std::string GetLabel() { return "LazyDS"; }
+   std::string GetLabel() final { return "LazyDS"; }
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -211,7 +211,7 @@ public:
    RColumnReaderBase *GetDatasetColumnReader(unsigned int slot, const std::string &col, const std::type_info &ti) const;
 
    /// End of recursive chain of calls, does nothing
-   void AddFilterName(std::vector<std::string> &) {}
+   void AddFilterName(std::vector<std::string> &) final {}
    /// For each booked filter, returns either the name or "Unnamed Filter"
    std::vector<std::string> GetFiltersNames();
 
@@ -223,7 +223,7 @@ public:
    std::vector<RDFInternal::RActionBase *> GetAllActions() const;
 
    std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>
-   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap);
+   GetGraph(std::unordered_map<void *, std::shared_ptr<ROOT::Internal::RDF::GraphDrawing::GraphNode>> &visitedMap) final;
 
    const ColumnNames_t &GetBranchNames();
 

--- a/tree/dataframe/inc/ROOT/RDF/RRange.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRange.hxx
@@ -109,9 +109,9 @@ public:
    }
 
    /// This function must be defined by all nodes, but only the filters will add their name
-   void AddFilterName(std::vector<std::string> &filters) { fPrevNode.AddFilterName(filters); }
+   void AddFilterName(std::vector<std::string> &filters) final { fPrevNode.AddFilterName(filters); }
    std::shared_ptr<RDFGraphDrawing::GraphNode>
-   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)
+   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) final
    {
       // TODO: Ranges node have no information about custom columns, hence it is not possible now
       // if defines have been used before.

--- a/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RRangeBase.hxx
@@ -50,11 +50,9 @@ public:
               const unsigned int nSlots, const std::vector<std::string> &prevVariations);
 
    RRangeBase &operator=(const RRangeBase &) = delete;
-   virtual ~RRangeBase();
+   ~RRangeBase() override;
 
    void InitNode() { ResetCounters(); }
-   virtual std::shared_ptr<RDFGraphDrawing::GraphNode>
-   GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap) = 0;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RTreeColumnReader.hxx
@@ -46,7 +46,7 @@ public:
    // - Thread #2) a task starts and overwrites thread-local TTreeReaderValues
    // - Thread #1) first task deletes TTreeReader
    // See https://github.com/root-project/root/commit/26e8ace6e47de6794ac9ec770c3bbff9b7f2e945
-   ~RTreeColumnReader() { fTreeValue.reset(); }
+   ~RTreeColumnReader() override { fTreeValue.reset(); }
 };
 
 /// RTreeColumnReader specialization for TTree values read via TTreeReaderArrays.
@@ -137,7 +137,7 @@ public:
    }
 
    /// See the other class template specializations for an explanation.
-   ~RTreeColumnReader() { fTreeArray.reset(); }
+   ~RTreeColumnReader() override { fTreeArray.reset(); }
 };
 
 /// RTreeColumnReader specialization for arrays of boolean values read via TTreeReaderArrays.
@@ -178,7 +178,7 @@ public:
    }
 
    /// See the other class template specializations for an explanation.
-   ~RTreeColumnReader() { fTreeArray.reset(); }
+   ~RTreeColumnReader() override { fTreeArray.reset(); }
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -227,7 +227,7 @@ public:
       }
    }
 
-   const std::type_info &GetTypeId() const { return typeid(VariedCol_t); }
+   const std::type_info &GetTypeId() const final { return typeid(VariedCol_t); }
 
    /// Clean-up operations to be performed at the end of a task.
    void FinalizeSlot(unsigned int slot) final { fValues[slot].fill(nullptr); }

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -189,7 +189,7 @@ public:
       return std::make_unique<RDFDetail::RMergeableVariationsBase>(std::move(keys), std::move(values));
    }
 
-   [[noreturn]] std::unique_ptr<RActionBase> MakeVariedAction(std::vector<void *> &&)
+   [[noreturn]] std::unique_ptr<RActionBase> MakeVariedAction(std::vector<void *> &&) final
    {
       throw std::logic_error("Cannot produce a varied action from a varied action.");
    }

--- a/tree/dataframe/inc/ROOT/RDataSource.hxx
+++ b/tree/dataframe/inc/ROOT/RDataSource.hxx
@@ -62,7 +62,7 @@ class TTypedPointerHolder final : public TPointerHolder {
 public:
    TTypedPointerHolder(T *ptr) : TPointerHolder((void *)ptr) {}
 
-   virtual TPointerHolder *GetDeepCopy()
+   TPointerHolder *GetDeepCopy() final
    {
       const auto typedPtr = static_cast<T *>(fPointer);
       return new TTypedPointerHolder(new T(*typedPtr));

--- a/tree/dataframe/inc/ROOT/RRootDS.hxx
+++ b/tree/dataframe/inc/ROOT/RRootDS.hxx
@@ -37,24 +37,24 @@ private:
    std::vector<std::vector<void *>> fBranchAddresses; // first container-> slot, second -> column;
    std::vector<std::unique_ptr<TChain>> fChains;
 
-   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &);
+   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &) final;
 
 protected:
-   std::string AsString() { return "ROOT data source"; };
+   std::string AsString() final { return "ROOT data source"; };
 
 public:
    RRootDS(std::string_view treeName, std::string_view fileNameGlob);
    ~RRootDS();
-   std::string GetTypeName(std::string_view colName) const;
-   const std::vector<std::string> &GetColumnNames() const;
-   bool HasColumn(std::string_view colName) const;
-   void InitSlot(unsigned int slot, ULong64_t firstEntry);
-   void FinalizeSlot(unsigned int slot);
-   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges();
-   bool SetEntry(unsigned int slot, ULong64_t entry);
-   void SetNSlots(unsigned int nSlots);
-   void Initialize();
-   std::string GetLabel();
+   std::string GetTypeName(std::string_view colName) const final;
+   const std::vector<std::string> &GetColumnNames() const final;
+   bool HasColumn(std::string_view colName) const final;
+   void InitSlot(unsigned int slot, ULong64_t firstEntry) final;
+   void FinalizeSlot(unsigned int slot) final;
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final;
+   bool SetEntry(unsigned int slot, ULong64_t entry) final;
+   void SetNSlots(unsigned int nSlots) final;
+   void Initialize() final;
+   std::string GetLabel() final;
 };
 
 } // ns RDF

--- a/tree/dataframe/inc/ROOT/RTrivialDS.hxx
+++ b/tree/dataframe/inc/ROOT/RTrivialDS.hxx
@@ -32,24 +32,24 @@ private:
    std::vector<std::string> fColNames{"col0"};
    std::vector<ULong64_t> fCounter;
    std::vector<ULong64_t *> fCounterAddr;
-   std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &);
+   std::vector<void *> GetColumnReadersImpl(std::string_view name, const std::type_info &) final;
 
 protected:
-   std::string AsString() { return "trivial data source"; };
+   std::string AsString() final { return "trivial data source"; };
 
 public:
    RTrivialDS(ULong64_t size, bool skipEvenEntries = false);
    /// This ctor produces a data-source that returns infinite entries
    RTrivialDS();
    ~RTrivialDS();
-   const std::vector<std::string> &GetColumnNames() const;
-   bool HasColumn(std::string_view colName) const;
-   std::string GetTypeName(std::string_view) const;
-   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges();
-   bool SetEntry(unsigned int slot, ULong64_t entry);
-   void SetNSlots(unsigned int nSlots);
-   void Initialize();
-   std::string GetLabel();
+   const std::vector<std::string> &GetColumnNames() const final;
+   bool HasColumn(std::string_view colName) const final;
+   std::string GetTypeName(std::string_view) const final;
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final;
+   bool SetEntry(unsigned int slot, ULong64_t entry) final;
+   void SetNSlots(unsigned int nSlots) final;
+   void Initialize() final;
+   std::string GetLabel() final;
 };
 
 /// \brief Make a RDF wrapping a RTrivialDS with the specified amount of entries.

--- a/tree/dataframe/src/RNTupleDS.cxx
+++ b/tree/dataframe/src/RNTupleDS.cxx
@@ -128,7 +128,7 @@ public:
       : fField(std::move(f)), fValue(fField->GenerateValue()), fLastEntry(-1)
    {
    }
-   virtual ~RNTupleColumnReader() { fField->DestroyValue(fValue); }
+   ~RNTupleColumnReader() { fField->DestroyValue(fValue); }
 
    /// Column readers are created as prototype and then cloned for every slot
    std::unique_ptr<RNTupleColumnReader> Clone()

--- a/tree/dataframe/test/RNonCopiableColumnDS.hxx
+++ b/tree/dataframe/test/RNonCopiableColumnDS.hxx
@@ -19,7 +19,7 @@ private:
    std::vector<std::string> fColNames{fgColumnName};
    RNonCopiable fNonCopiable;
    RNonCopiable *fCounterAddr = &fNonCopiable;
-   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &)
+   std::vector<void *> GetColumnReadersImpl(std::string_view, const std::type_info &) final
    {
       std::vector<void *> ret{(void *)(&fCounterAddr)};
       return ret;
@@ -29,18 +29,18 @@ public:
    using NonCopiable_t = RNonCopiable;
    constexpr const static auto fgColumnName = "nonCopiable";
    RNonCopiableColumnDS(){};
-   ~RNonCopiableColumnDS(){};
-   const std::vector<std::string> &GetColumnNames() const { return fColNames; };
-   bool HasColumn(std::string_view colName) const { return colName == fColNames[0]; };
-   std::string GetTypeName(std::string_view) const { return "RNonCopiable"; };
-   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges()
+   ~RNonCopiableColumnDS() override {};
+   const std::vector<std::string> &GetColumnNames() const final { return fColNames; };
+   bool HasColumn(std::string_view colName) const final { return colName == fColNames[0]; };
+   std::string GetTypeName(std::string_view) const final { return "RNonCopiable"; };
+   std::vector<std::pair<ULong64_t, ULong64_t>> GetEntryRanges() final
    {
       auto entryRanges(std::move(fEntryRanges)); // empty fEntryRanges
       return entryRanges;
    };
-   bool SetEntry(unsigned int, ULong64_t){ return true;};
-   void SetNSlots(unsigned int){};
-   std::string GetLabel(){
+   bool SetEntry(unsigned int, ULong64_t) final { return true;};
+   void SetNSlots(unsigned int) final {};
+   std::string GetLabel() final {
       return "NonCopiableColumnDS";
    }
 };

--- a/tree/dataframe/test/dataframe_definepersample.cxx
+++ b/tree/dataframe/test/dataframe_definepersample.cxx
@@ -21,7 +21,7 @@ struct DefinePerSample : ::testing::TestWithParam<bool> {
          ROOT::EnableImplicitMT();
    }
 
-   ~DefinePerSample()
+   ~DefinePerSample() override
    {
       if (GetParam())
          ROOT::DisableImplicitMT();

--- a/tree/dataframe/test/dataframe_regression.cxx
+++ b/tree/dataframe/test/dataframe_regression.cxx
@@ -18,7 +18,7 @@ protected:
       if (GetParam())
          ROOT::EnableImplicitMT(NSLOTS);
    }
-   ~RDFRegressionTests()
+   ~RDFRegressionTests() override
    {
       if (GetParam())
          ROOT::DisableImplicitMT();
@@ -252,14 +252,14 @@ TEST_P(RDFRegressionTests, UseAfterDeleteOfSampleCallbacks)
       bool fThisWasDeleted = false;
 
       MyHelper() : fResult(std::make_shared<int>()) {}
-      ~MyHelper() { fThisWasDeleted = true; }
+      ~MyHelper() override { fThisWasDeleted = true; }
       void Initialize() {}
       void InitTask(TTreeReader *, unsigned int) {}
       void Exec(unsigned int) {}
       void Finalize() {}
       std::shared_ptr<Result_t> GetResultPtr() const { return fResult; }
       std::string GetActionName() const { return "MyHelper"; }
-      ROOT::RDF::SampleCallback_t GetSampleCallback()
+      ROOT::RDF::SampleCallback_t GetSampleCallback() final
       {
          // in a well-behaved program, this won't ever even be called as the RResultPtr returned
          // by the Book call below goes immediately out of scope, removing the action from the computation graph

--- a/tree/dataframe/test/dataframe_samplecallback.cxx
+++ b/tree/dataframe/test/dataframe_samplecallback.cxx
@@ -27,7 +27,7 @@ struct RDFSampleCallback : ::testing::TestWithParam<bool> {
          ROOT::EnableImplicitMT();
    }
 
-   ~RDFSampleCallback()
+   ~RDFSampleCallback() override
    {
       if (GetParam())
          ROOT::DisableImplicitMT();


### PR DESCRIPTION
For developers, it is unconvenient that the `override` specifier
that flags member functions as overriding on first sight is not used so
much in `hist`.

I think it is a good time to add the missing `override` specifiers
to more ROOT components now, as I have already done it for `roofit`,
`math`, and `hist`, where it was really a game changer for me because it
made reading und understanding the code easier!

See:
  * https://github.com/root-project/root/pull/10083
  * https://github.com/root-project/root/pull/9808
  * https://github.com/root-project/root/pull/9883

This commit was generated more or less automatically with this Python
script that uses `clang-tidy`:

```Python
import os
import glob
import subprocess
import tqdm

"""
For clang-tidy to work, you have to copy the compile_commands.json from the
build directory back into the repo directory (just like in
.ci/copy_headers.sh).
"""

def get_sources(directory, extensions):

    files = []

    for ext in extensions:
        files += glob.glob(
            os.path.join(directory, "**/*" + ext), recursive=True
        )

    return files

"""
Recursively find extensions in directory, to figure out whic hextensions
should be globbed for.
   find . -type f -name '*.*' | sed 's|.*\.||' | sort -u
"""
extensions = [".h", ".hpp", ".hxx", ".cpp", ".cc", ".cxx"]

"""
Some extensions are recognized as C and not as C++ files by clang-tidy. We
need to rename them, and this dict specifies how file extensions should be
replaced.
"""
rename_dict = {".h": ".hpp"}

files = get_sources("tree", extensions)

cflags = (
    subprocess.check_output(["root-config", "--cflags"]).strip().decode("utf-8")
)

for file in tqdm.tqdm(files):

    file_renamed = file
    for ext, ext_renamed in rename_dict.items():
        if file.endswith(ext):
            file_renamed = file.replace(ext, ext_renamed)

    if file_renamed != file:
        os.rename(file, file_renamed)

    cmd = [
        "clang-tidy",
        "-checks=modernize-use-override",
        "--fix",
        file_renamed,
        "--",
    ] + cflags.split(" ")
    subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

    if file_renamed != file:
        os.rename(file_renamed, file)

"""
Finally, replace the ClassDef with the ClassDefOverride macros.
  find tree -type f -print | xargs sed -i 's/ClassDef(/ClassDefOverride(/'
...and change back the ClassDefOverride of non-overriding base classes.
"""
```