### PR TITLE
[Cling] improve cmd history support

### DIFF
--- a/core/textinput/src/textinput/TextInput.cpp
+++ b/core/textinput/src/textinput/TextInput.cpp
@@ -338,6 +338,16 @@ namespace textinput {
                   [](Display *D) { return D->NotifyWindowChange(); });
   }
 
+  void TextInput::SetHistoryMaxDepth(size_t maxDepth) const
+  {
+     fContext->GetHistory()->SetMaxDepth(maxDepth);
+  }
+
+  void TextInput::SetHistoryPruneLength(size_t pruneLength) const
+  {
+     fContext->GetHistory()->SetPruneLength(pruneLength);
+  }
+
   void
   TextInput::AddHistoryLine(const char* line) {
     if (!line) return;

--- a/core/textinput/src/textinput/TextInput.h
+++ b/core/textinput/src/textinput/TextInput.h
@@ -84,6 +84,8 @@ namespace textinput {
     void ReleaseInputOutput() const;
 
     // History interface
+    void SetHistoryMaxDepth(size_t maxDepth) const;
+    void SetHistoryPruneLength(size_t pruneLength) const;
     bool IsAutoHistAddEnabled() const { return fAutoHistAdd; }
     void EnableAutoHistAdd(bool enable = true) { fAutoHistAdd = enable; }
     void AddHistoryLine(const char* line);

--- a/interpreter/cling/lib/UserInterface/UserInterface.cpp
+++ b/interpreter/cling/lib/UserInterface/UserInterface.cpp
@@ -13,9 +13,10 @@
 #include "cling/MetaProcessor/MetaProcessor.h"
 #include "cling/Utils/Output.h"
 #include "textinput/Callbacks.h"
-#include "textinput/TextInput.h"
+#include "textinput/History.h"
 #include "textinput/StreamReader.h"
 #include "textinput/TerminalDisplay.h"
+#include "textinput/TextInput.h"
 
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -94,6 +95,17 @@ namespace cling {
     TextInputHolder TI(histfilePath);
 
     TI->SetCompletion(Completion.get());
+
+    if (const char* HistSizeEnvvar = std::getenv("CLING_HISTSIZE")) {
+      const size_t HistSize = std::strtoull(HistSizeEnvvar, nullptr, 0);
+
+      // std::strtoull() returns 0 if the parsing fails.
+      // zero HistSize will disable history logging to file.
+      // refer to textinput::History::AppendToFile()
+      TI->SetHistoryMaxDepth(HistSize);
+      TI->SetHistoryPruneLength(
+          static_cast<size_t>(textinput::History::kPruneLengthDefault));
+    }
 
     bool Done = false;
     std::string Line;

--- a/interpreter/cling/test/Driver/CommandHistory.C
+++ b/interpreter/cling/test/Driver/CommandHistory.C
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// clang-format off
+// RUN: %rm /tmp/__testing_cling_history
+// RUN: cat %s | env --unset=CLING_NOHISTORY CLING_HISTSIZE=8 CLING_HISTFILE="/tmp/__testing_cling_history" %cling - 2>&1
+// RUN: diff /tmp/__testing_cling_history "%S/Inputs/cling_history"
+// REQUIRES: not_system-windows
+
+#include <iostream>
+
+int i = 8;
+
+template<class T>
+struct type_a {
+	const T t;
+	double d;
+
+/*
+		comment
+ * */
+
+	static const int i = 37;
+};
+
+// another comment
+
+using std::cout;
+
+std::cout << "test\n";
+

--- a/interpreter/cling/test/Driver/Inputs/cling_history
+++ b/interpreter/cling/test/Driver/Inputs/cling_history
@@ -1,0 +1,8 @@
+/*
+comment
+ * */
+static const int i = 37;
+};
+// another comment
+using std::cout;
+std::cout << "test\n";


### PR DESCRIPTION
## Changes or fixes:

1. Environment variable `CLING_HISTFILE` to specify history file path.
2. Environment variable `CLING_HISTSIZE` to specify history size. The original behavior is to not set the history size explicitly.
    That is equivalent to unlimited history size according to `textinput::History::AppendToFile()`  (history file will never be pruned so it grows indefinitely). This is probably not most users expect. @Axel-Naumann, @vgvassilev do you think it makes sense to set default cling history size to something like 500 ?   (That changes current behavior.)

## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

