### PR TITLE
Implement the "I" option for multigraphs

### DIFF
--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1314,6 +1314,7 @@ void TMultiGraph::Paint(Option_t *choptin)
       TString chopth = "0";
       if ((char*)strstr(chopt.Data(),"X+")) chopth.Append("X+");
       if ((char*)strstr(chopt.Data(),"Y+")) chopth.Append("Y+");
+      if ((char*)strstr(chopt.Data(),"I"))  chopth.Append("A");
       fHistogram->Paint(chopth.Data());
    }
 


### PR DESCRIPTION
The "I" option (axis are Invisible) was implemented for graphs but was not for TMultigraphs.

