### PR TITLE
cling: Improve support for expression in template re-substitution.

### DIFF
--- a/core/clingutils/src/TClingUtils.cxx
+++ b/core/clingutils/src/TClingUtils.cxx
@@ -4741,8 +4741,12 @@ clang::QualType ROOT::TMetaUtils::ReSubstTemplateArg(clang::QualType input, cons
             // so we probably don't really know how to spell it ... we would need to recreate it
             // (See AddDefaultParameters).
             return input;
-         } else {
+         } else if (TST->getArg(index).getKind() == clang::TemplateArgument::Type) {
             return TST->getArg(index).getAsType();
+         } else {
+            // The argument is (likely) a value or expression and there is nothing for us
+            // to change
+            return input;
          }
       }
    }

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -253,6 +253,10 @@ if(ROOT_CLASSIC_BUILD)
   set(classic_veto multicore/mp104_*.C multicore/mp105_*.C)
 endif()
 
+if(NOT gdml)
+  set(gdml_veto geom/gdml/testoptical.C)
+endif()
+
 #---These ones requires a display to run-----------------------------
 set(gui_veto fit/fitpanel_playback.C
              cocoa/*.C
@@ -384,6 +388,7 @@ set(extra_veto
 set(all_veto hsimple.C
              geom/geometry.C
              ${extra_veto}
+             ${gdml_veto}
              ${gui_veto}
              ${minuit2_veto}
              ${roofit_veto}


### PR DESCRIPTION
This addresses the issue described in #11259.  In particular it handles the case where the template parameter
is a value.  i.e. in the inner template of
```
__and_<is_constructible<_Rb_tree_iterator<pair<const unsigned int,string> >,const _Rb_tree_iterator<pair<const unsigned int,string> >&>,is_constructible<bool,const bool&> >
```

