### PR TITLE
[DF] Rename MakeColumnReaders => GetColumnReaders

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -96,7 +96,7 @@ public:
    {
       RDFInternal::RColumnReadersInfo info{RActionBase::GetColumnNames(), RActionBase::GetColRegister(),
                                            fIsDefine.data(), *fLoopManager};
-      fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
+      fValues[slot] = RDFInternal::GetColumnReaders(slot, r, ColumnTypes_t{}, info);
       fHelper.InitTask(r, slot);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -111,7 +111,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
       RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), *fLoopManager};
-      fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
+      fValues[slot] = RDFInternal::GetColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
       fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -119,7 +119,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
       RDFInternal::RColumnReadersInfo info{fColumnNames, fColRegister, fIsDefine.data(), *fLoopManager};
-      fValues[slot] = RDFInternal::MakeColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
+      fValues[slot] = RDFInternal::GetColumnReaders(slot, r, ColumnTypes_t{}, info, fVariation);
       fLastCheckedEntry[slot * RDFInternal::CacheLineStep<Long64_t>()] = -1;
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -210,7 +210,7 @@ public:
    void InitSlot(TTreeReader *r, unsigned int slot) final
    {
       RColumnReadersInfo info{fInputColumns, fColumnRegister, fIsDefine.data(), *fLoopManager};
-      fValues[slot] = MakeColumnReaders(slot, r, ColumnTypes_t{}, info);
+      fValues[slot] = GetColumnReaders(slot, r, ColumnTypes_t{}, info);
       fLastCheckedEntry[slot * CacheLineStep<Long64_t>()] = -1;
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -107,7 +107,7 @@ public:
 
       // get readers for each systematic variation
       for (const auto &variation : GetVariations())
-         fInputValues[slot].emplace_back(MakeColumnReaders(slot, r, ColumnTypes_t{}, info, variation));
+         fInputValues[slot].emplace_back(GetColumnReaders(slot, r, ColumnTypes_t{}, info, variation));
 
       std::for_each(fHelpers.begin(), fHelpers.end(), [=](Helper &h) { h.InitTask(r, slot); });
    }


### PR DESCRIPTION
With the latest refactorings, MakeColumnReaders does not actually
create the column readers but simply gets them from RLoopManager or RColumnRegister.