### PR TITLE
[DF] Move type-safety checks out of column readers

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -51,8 +51,7 @@ class RDefinesWithReaders {
 public:
    RDefinesWithReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
    RDefineBase &GetDefine() const { return *fDefine; }
-   std::shared_ptr<RDefineReader>
-   GetReader(unsigned int slot, const std::string &variationName, const std::type_info &);
+   std::shared_ptr<RDefineReader> GetReader(unsigned int slot, const std::string &variationName);
 };
 
 class RVariationsWithReaders {
@@ -65,6 +64,8 @@ public:
    RVariationBase &GetVariation() const { return *fVariation; }
    std::shared_ptr<RVariationReader> GetReader(unsigned int slot, const std::string &colName,
                                                const std::string &variationName, const std::type_info &tid);
+   std::shared_ptr<RVariationReader>
+   GetReader(unsigned int slot, const std::string &colName, const std::string &variationName);
 };
 
 /**

--- a/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefineReader.hxx
@@ -13,7 +13,6 @@
 
 #include "RColumnReaderBase.hxx"
 #include "RDefineBase.hxx"
-#include "Utils.hxx" // CheckReaderTypeMatches
 #include <Rtypes.h>  // Long64_t, R__CLING_PTRCHECK
 
 #include <limits>
@@ -43,10 +42,9 @@ class R__CLING_PTRCHECK(off) RDefineReader final : public ROOT::Detail::RDF::RCo
    }
 
 public:
-   RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define, const std::type_info &tid)
+   RDefineReader(unsigned int slot, RDFDetail::RDefineBase &define)
       : fDefine(define), fCustomValuePtr(define.GetValuePtr(slot)), fSlot(slot)
    {
-      CheckReaderTypeMatches(define.GetTypeId(), tid, define.GetName(), "RDefineReader");
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariationReader.hxx
@@ -40,10 +40,9 @@ class R__CLING_PTRCHECK(off) RVariationReader final : public ROOT::Detail::RDF::
 
 public:
    RVariationReader(unsigned int slot, const std::string &colName, const std::string &variationName,
-                    RVariationBase &variation, const std::type_info &tid)
+                    RVariationBase &variation)
       : fVariation(&variation), fValuePtr(variation.GetValuePtr(slot, colName, variationName)), fSlot(slot)
    {
-      CheckReaderTypeMatches(variation.GetTypeId(), tid, colName, "RVariationReader");
    }
 };
 

--- a/tree/dataframe/inc/ROOT/RDF/Utils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/Utils.hxx
@@ -222,7 +222,7 @@ constexpr std::size_t CacheLineStep() {
 }
 
 void CheckReaderTypeMatches(const std::type_info &colType, const std::type_info &requestedType,
-                            const std::string &colName, const std::string &where);
+                            const std::string &colName);
 
 // TODO in C++17 this could be a lambda within FillHelper::Exec
 template <typename T>

--- a/tree/dataframe/src/RDFUtils.cxx
+++ b/tree/dataframe/src/RDFUtils.cxx
@@ -384,7 +384,7 @@ unsigned int GetColumnWidth(const std::vector<std::string>& names, const unsigne
 }
 
 void CheckReaderTypeMatches(const std::type_info &colType, const std::type_info &requestedType,
-                            const std::string &colName, const std::string &where)
+                            const std::string &colName)
 {
    // Here we compare names and not typeinfos since they may come from two different contexts: a compiled
    // and a jitted one.
@@ -397,7 +397,7 @@ void CheckReaderTypeMatches(const std::type_info &colType, const std::type_info 
    if (diffTypes && !inheritedType()) {
       const auto tName = TypeID2TypeName(requestedType);
       const auto colTypeName = TypeID2TypeName(colType);
-      std::string errMsg = where + ": type mismatch: column \"" + colName + "\" is being used as ";
+      std::string errMsg = "RDataFrame: type mismatch: column \"" + colName + "\" is being used as ";
       if (tName.empty()) {
          errMsg += requestedType.name();
          errMsg += " (extracted from type info)";


### PR DESCRIPTION
It simplifies some interfaces and removes one extra responsibility from the column readers.