### PR TITLE
Use __cplusplus to test the existence of std::span

### DIFF
--- a/core/foundation/inc/ROOT/RSpan.hxx
+++ b/core/foundation/inc/ROOT/RSpan.hxx
@@ -16,7 +16,7 @@
 
 #include "RConfigure.h"
 
-#ifdef R__HAS_STD_SPAN
+#if defined(R__HAS_STD_SPAN) || __cplusplus >= 202002L
 
 #include <span>
 

--- a/core/foundation/inc/ROOT/RSpan.hxx
+++ b/core/foundation/inc/ROOT/RSpan.hxx
@@ -16,13 +16,7 @@
 
 #include "RConfigure.h"
 
-#if defined(_MSVC_LANG)
-# define R__MSVC_LANG _MSVC_LANG
-#else
-# define R__MSVC_LANG 0
-#endif
-
-#if defined(R__HAS_STD_SPAN) || R__MSVC_LANG >= 202002L || __cplusplus >= 202002L
+#if defined(R__HAS_STD_SPAN) || _MSVC_LANG >= 202002L || __cplusplus >= 202002L
 
 #include <span>
 

--- a/core/foundation/inc/ROOT/RSpan.hxx
+++ b/core/foundation/inc/ROOT/RSpan.hxx
@@ -16,7 +16,13 @@
 
 #include "RConfigure.h"
 
-#if defined(R__HAS_STD_SPAN) || __cplusplus >= 202002L
+#if defined(_MSVC_LANG)
+# define R__MSVC_LANG _MSVC_LANG
+#else
+# define R__MSVC_LANG 0
+#endif
+
+#if defined(R__HAS_STD_SPAN) || R__MSVC_LANG >= 202002L || __cplusplus >= 202002L
 
 #include <span>
 


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

When the external application (depending on ROOT) uses C++20, adding this C++ feature test can reduce the possibility of compilation failure.

## Checklist:

- [x] tested changes locally
