### PR TITLE
fix verbose printing of proxies in 6.26

### DIFF
--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1541,12 +1541,12 @@ void RooAbsArg::printMultiline(ostream& os, Int_t /*contents*/, Bool_t /*verbose
       } else {
 	os << " (empty)" << endl ; ;
       }
-    } else {
+    } else if(dynamic_cast<RooAbsCollection*>(proxy)) {
       os << indent << "    " << proxy->name() << " -> " ;
       os << endl ;
       TString moreIndent(indent) ;
       moreIndent.Append("    ") ;
-      ((RooSetProxy*)proxy)->printStream(os,kName,kStandard,moreIndent.Data()) ;
+      dynamic_cast<RooAbsCollection*>(proxy)->printStream(os,kName,kStandard,moreIndent.Data()) ;
     }
   }
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1546,7 +1546,7 @@ void RooAbsArg::printMultiline(ostream& os, Int_t /*contents*/, Bool_t /*verbose
       os << endl ;
       TString moreIndent(indent) ;
       moreIndent.Append("    ") ;
-      static_cast<RooAbsCollection*>(proxy)->printStream(os,kName,kStandard,moreIndent.Data()) ;
+      dynamic_cast<RooAbsCollection*>(proxy)->printStream(os,kName,kStandard,moreIndent.Data()) ;
     }
   }
 }

--- a/roofit/roofitcore/src/RooAbsArg.cxx
+++ b/roofit/roofitcore/src/RooAbsArg.cxx
@@ -1546,7 +1546,7 @@ void RooAbsArg::printMultiline(ostream& os, Int_t /*contents*/, Bool_t /*verbose
       os << endl ;
       TString moreIndent(indent) ;
       moreIndent.Append("    ") ;
-      dynamic_cast<RooAbsCollection*>(proxy)->printStream(os,kName,kStandard,moreIndent.Data()) ;
+      static_cast<RooAbsCollection*>(proxy)->printStream(os,kName,kStandard,moreIndent.Data()) ;
     }
   }
 }


### PR DESCRIPTION
# This Pull request:

Discovered that in 6.26 verbose print of lots of classes doesn't work. e.g. you can do:

```
RooWorkspace ws;
ws.factory("SUM::model(RooExponential::pdf1(obs1[0,5],tau1[-1]))"); 
ws.pdf("model")->Print("v")
```

and it will crash.

## Changes or fixes:
Fixes verbose printout of roofit object that uses RooListProxy (lots of classes do). 

## Checklist:

- [x ] tested changes locally
- [x ] updated the docs (if necessary)

This PR fixes # 

