### PR TITLE
[DF] Simplify column reader ownership model

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ColumnReaderUtils.hxx
@@ -41,16 +41,15 @@ using namespace ROOT::TypeTraits;
 namespace RDFDetail = ROOT::Detail::RDF;
 
 template <typename T>
-std::shared_ptr<RDFDetail::RColumnReaderBase>
-GetColumnReader(unsigned int slot, std::shared_ptr<RColumnReaderBase> defineOrVariationReader, RLoopManager &lm,
-                TTreeReader *r, const std::string &colName)
+RDFDetail::RColumnReaderBase *GetColumnReader(unsigned int slot, RColumnReaderBase *defineOrVariationReader,
+                                              RLoopManager &lm, TTreeReader *r, const std::string &colName)
 {
    if (defineOrVariationReader != nullptr)
       return defineOrVariationReader;
 
    // Check if we already inserted a reader for this column in the dataset column readers (RDataSource or Tree/TChain
    // readers)
-   auto datasetColReader = lm.GetDatasetColumnReader(slot, colName, typeid(T));
+   auto *datasetColReader = lm.GetDatasetColumnReader(slot, colName, typeid(T));
    if (datasetColReader != nullptr)
       return datasetColReader;
 
@@ -74,7 +73,7 @@ struct RColumnReadersInfo {
 
 /// Create a group of column readers, one per type in the parameter pack.
 template <typename... ColTypes>
-std::array<std::shared_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)>
+std::array<RDFDetail::RColumnReaderBase *, sizeof...(ColTypes)>
 GetColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, const RColumnReadersInfo &colInfo,
                  const std::string &variationName = "nominal")
 {
@@ -84,14 +83,14 @@ GetColumnReaders(unsigned int slot, TTreeReader *r, TypeList<ColTypes...>, const
    auto &colRegister = colInfo.fColRegister;
 
    int i = -1;
-   std::array<std::shared_ptr<RDFDetail::RColumnReaderBase>, sizeof...(ColTypes)> ret{
-      {{(++i, GetColumnReader<ColTypes>(slot, colRegister.GetReader(slot, colNames[i], variationName, typeid(ColTypes)),
-                                        lm, r, colNames[i]))}...}};
+   std::array<RDFDetail::RColumnReaderBase *, sizeof...(ColTypes)> ret{
+      (++i, GetColumnReader<ColTypes>(slot, colRegister.GetReader(slot, colNames[i], variationName, typeid(ColTypes)),
+                                      lm, r, colNames[i]))...};
    return ret;
 }
 
 // Shortcut overload for the case of no columns
-inline std::array<std::shared_ptr<RDFDetail::RColumnReaderBase>, 0>
+inline std::array<RDFDetail::RColumnReaderBase *, 0>
 GetColumnReaders(unsigned int, TTreeReader *, TypeList<>, const RColumnReadersInfo &, const std::string & = "nominal")
 {
    return {};

--- a/tree/dataframe/inc/ROOT/RDF/RAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RAction.hxx
@@ -58,7 +58,7 @@ class R__CLING_PTRCHECK(off) RAction : public RActionBase {
    const std::shared_ptr<PrevNode> fPrevNodePtr;
    PrevNode &fPrevNode;
    /// Column readers per slot and per input column
-   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<RColumnReaderBase *, ColumnTypes_t::list_size>> fValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;
@@ -118,8 +118,7 @@ public:
    /// Clean-up operations to be performed at the end of a task.
    void FinalizeSlot(unsigned int slot) final
    {
-      for (auto &v : fValues[slot])
-         v.reset();
+      fValues[slot].fill(nullptr);
       fHelper.CallFinalizeTask(slot);
    }
 

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -46,24 +46,23 @@ class RDefinesWithReaders {
 
    std::shared_ptr<RDefineBase> fDefine; // cannot be null
    // Column readers per variation (in the map) per slot (in the vector).
-   std::vector<std::unordered_map<std::string, std::shared_ptr<RDefineReader>>> fReadersPerVariation;
+   std::vector<std::unordered_map<std::string, std::unique_ptr<RDefineReader>>> fReadersPerVariation;
 
 public:
    RDefinesWithReaders(std::shared_ptr<RDefineBase> define, unsigned int nSlots);
    RDefineBase &GetDefine() const { return *fDefine; }
-   std::shared_ptr<RDefineReader> GetReader(unsigned int slot, const std::string &variationName);
+   RDefineReader *GetReader(unsigned int slot, const std::string &variationName);
 };
 
 class RVariationsWithReaders {
    std::shared_ptr<RVariationBase> fVariation; // cannot be null
    // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
-   std::vector<std::unordered_map<std::string, std::shared_ptr<RVariationReader>>> fReadersPerVariation;
+   std::vector<std::unordered_map<std::string, std::unique_ptr<RVariationReader>>> fReadersPerVariation;
 
 public:
    RVariationsWithReaders(std::shared_ptr<RVariationBase> variation, unsigned int nSlots);
    RVariationBase &GetVariation() const { return *fVariation; }
-   std::shared_ptr<RVariationReader>
-   GetReader(unsigned int slot, const std::string &colName, const std::string &variationName);
+   RVariationReader *GetReader(unsigned int slot, const std::string &colName, const std::string &variationName);
 };
 
 /**
@@ -112,12 +111,7 @@ public:
    RColumnRegister(RColumnRegister &&) = default;
    RColumnRegister &operator=(const RColumnRegister &) = default;
 
-   explicit RColumnRegister(std::shared_ptr<RDFDetail::RLoopManager> lm)
-      : fLoopManager(lm), fDefines(std::make_shared<DefinesMap_t>()),
-        fAliases(std::make_shared<std::unordered_map<std::string, std::string>>()),
-        fVariations(std::make_shared<VariationsMap_t>()), fColumnNames(std::make_shared<ColumnNames_t>())
-   {
-   }
+   explicit RColumnRegister(std::shared_ptr<RDFDetail::RLoopManager> lm);
    ~RColumnRegister();
 
    ////////////////////////////////////////////////////////////////////////////
@@ -148,8 +142,8 @@ public:
 
    ROOT::RDF::RVariationsDescription BuildVariationsDescription() const;
 
-   std::shared_ptr<RDFDetail::RColumnReaderBase> GetReader(unsigned int slot, const std::string &colName,
-                                                           const std::string &variationName, const std::type_info &tid);
+   RDFDetail::RColumnReaderBase *GetReader(unsigned int slot, const std::string &colName,
+                                           const std::string &variationName, const std::type_info &tid);
 };
 
 } // Namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnRegister.hxx
@@ -44,7 +44,9 @@ class RVariationReader;
 class RDefinesWithReaders {
    using RDefineBase = RDFDetail::RDefineBase;
 
-   std::shared_ptr<RDefineBase> fDefine; // cannot be null
+   // this is a shared_ptr only because we have to track its lifetime with a weak_ptr that we pass to jitted code
+   // (see BookDefineJit). it is never null.
+   std::shared_ptr<RDefineBase> fDefine;
    // Column readers per variation (in the map) per slot (in the vector).
    std::vector<std::unordered_map<std::string, std::unique_ptr<RDefineReader>>> fReadersPerVariation;
 
@@ -55,7 +57,9 @@ public:
 };
 
 class RVariationsWithReaders {
-   std::shared_ptr<RVariationBase> fVariation; // cannot be null
+   // this is a shared_ptr only because we have to track its lifetime with a weak_ptr that we pass to jitted code
+   // (see BookVariationJit). it is never null.
+   std::shared_ptr<RVariationBase> fVariation;
    // Column readers for this RVariation for a given variation (map key) and a given slot (vector element).
    std::vector<std::unordered_map<std::string, std::unique_ptr<RVariationReader>>> fReadersPerVariation;
 

--- a/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDefine.hxx
@@ -64,7 +64,7 @@ class R__CLING_PTRCHECK(off) RDefine final : public RDefineBase {
    ValuesPerSlot_t fLastResults;
 
    /// Column readers per slot and per input column
-   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<RColumnReaderBase *, ColumnTypes_t::list_size>> fValues;
 
    /// Define objects corresponding to systematic variations other than nominal for this defined column.
    /// The map key is the full variation name, e.g. "pt:up".
@@ -138,8 +138,7 @@ public:
    /// Clean-up operations to be performed at the end of a task.
    void FinalizeSlot(unsigned int slot) final
    {
-      for (auto &v : fValues[slot])
-         v.reset();
+      fValues[slot].fill(nullptr);
 
       for (auto &e : fVariedDefines)
          e.second->FinalizeSlot(slot);

--- a/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RFilter.hxx
@@ -65,7 +65,7 @@ class R__CLING_PTRCHECK(off) RFilter final : public RFilterBase {
 
    FilterF fFilter;
    /// Column readers per slot and per input column
-   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<RColumnReaderBase *, ColumnTypes_t::list_size>> fValues;
    const std::shared_ptr<PrevNode_t> fPrevNodePtr;
    PrevNode_t &fPrevNode;
 
@@ -161,11 +161,7 @@ public:
    }
 
    /// Clean-up operations to be performed at the end of a task.
-   void FinalizeSlot(unsigned int slot) final
-   {
-      for (auto &v : fValues[slot])
-         v.reset();
-   }
+   void FinalizeSlot(unsigned int slot) final { fValues[slot].fill(nullptr); }
 
    std::shared_ptr<RDFGraphDrawing::GraphNode>
    GetGraph(std::unordered_map<void *, std::shared_ptr<RDFGraphDrawing::GraphNode>> &visitedMap)

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -142,7 +142,7 @@ class RLoopManager : public RNodeBase {
    unsigned int fNRuns{0}; ///< Number of event loops run
 
    /// Readers for TTree/RDataSource columns (one per slot), shared by all nodes in the computation graph.
-   std::vector<std::unordered_map<std::string, std::shared_ptr<RColumnReaderBase>>> fDatasetColumnReaders;
+   std::vector<std::unordered_map<std::string, std::unique_ptr<RColumnReaderBase>>> fDatasetColumnReaders;
 
    /// Cache of the tree/chain branch names. Never access directy, always use GetBranchNames().
    ColumnNames_t fValidBranchNames;
@@ -206,11 +206,9 @@ public:
    bool HasDataSourceColumnReaders(const std::string &col, const std::type_info &ti) const;
    void AddDataSourceColumnReaders(const std::string &col, std::vector<std::unique_ptr<RColumnReaderBase>> &&readers,
                                    const std::type_info &ti);
-   std::shared_ptr<RColumnReaderBase> AddTreeColumnReader(unsigned int slot, const std::string &col,
-                                                          std::unique_ptr<RColumnReaderBase> &&reader,
-                                                          const std::type_info &ti);
-   std::shared_ptr<RColumnReaderBase>
-   GetDatasetColumnReader(unsigned int slot, const std::string &col, const std::type_info &ti) const;
+   RColumnReaderBase *AddTreeColumnReader(unsigned int slot, const std::string &col,
+                                          std::unique_ptr<RColumnReaderBase> &&reader, const std::type_info &ti);
+   RColumnReaderBase *GetDatasetColumnReader(unsigned int slot, const std::string &col, const std::type_info &ti) const;
 
    /// End of recursive chain of calls, does nothing
    void AddFilterName(std::vector<std::string> &) {}

--- a/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariation.hxx
@@ -158,7 +158,7 @@ class R__CLING_PTRCHECK(off) RVariation final : public RVariationBase {
    std::vector<Result_t> fLastResults;
 
    /// Column readers per slot and per input column
-   std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>> fValues;
+   std::vector<std::array<RColumnReaderBase *, ColumnTypes_t::list_size>> fValues;
 
    template <typename... ColTypes, std::size_t... S>
    void UpdateHelper(unsigned int slot, Long64_t entry, TypeList<ColTypes...>, std::index_sequence<S...>)
@@ -230,11 +230,7 @@ public:
    const std::type_info &GetTypeId() const { return typeid(VariedCol_t); }
 
    /// Clean-up operations to be performed at the end of a task.
-   void FinalizeSlot(unsigned int slot) final
-   {
-      for (auto &v : fValues[slot])
-         v.reset();
-   }
+   void FinalizeSlot(unsigned int slot) final { fValues[slot].fill(nullptr); }
 };
 
 } // namespace RDF

--- a/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RVariedAction.hxx
@@ -47,7 +47,7 @@ class R__CLING_PTRCHECK(off) RVariedAction final : public RActionBase {
    std::vector<std::shared_ptr<PrevNodeType>> fPrevNodes;
 
    /// Column readers per slot (outer dimension), per variation and per input column (inner dimension, std::array).
-   std::vector<std::vector<std::array<std::shared_ptr<RColumnReaderBase>, ColumnTypes_t::list_size>>> fInputValues;
+   std::vector<std::vector<std::array<RColumnReaderBase *, ColumnTypes_t::list_size>>> fInputValues;
 
    /// The nth flag signals whether the nth input column is a custom column or not.
    std::array<bool, ColumnTypes_t::list_size> fIsDefine;


### PR DESCRIPTION
Rather than sharing ownerhsip of column readers between different
components of the computation graph, now:
- RLoopManager has unique ownership of TTree/datasource readers
- RColumnRegister has unique ownership of define/variation readers
- everything else uses non-owning raw pointers