### PR TITLE
[TSpectrum] avoid recurrent questions on forum concerning legacy

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -262,7 +262,7 @@ TAB_SIZE               = 3
 # @} or use a double escape (\\{ and \\})
 
 ALIASES                = "legacy{1}=\htmlonly<div class=\"legacybox\"><h2>Legacy Code</h2> \1 is a legacy interface: it is not recommended to use it in new code. There will be no bug fixes nor new developments.</div>\endhtmlonly"
-ALIASES               += "unmaintained{1}=\htmlonly<div class=\"legacybox\"><h2>Unmainted Code</h2> \1 is a legacy interface: you can use it, as there is no one-to-one replacement interface planned/known. There will be no bug fixes nor new developments.</div>\endhtmlonly"
+ALIASES               += "unmaintained{1}=\htmlonly<div class=\"legacybox\"><h2>Unmaintained Code</h2> \1 is a legacy interface: you can use it, as there is no one-to-one replacement interface planned/known. There will be no bug fixes nor new developments.</div>\endhtmlonly"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -262,6 +262,7 @@ TAB_SIZE               = 3
 # @} or use a double escape (\\{ and \\})
 
 ALIASES                = "legacy{1}=\htmlonly<div class=\"legacybox\"><h2>Legacy Code</h2> \1 is a legacy interface: it is not recommended to use it in new code. There will be no bug fixes nor new developments.</div>\endhtmlonly"
+ALIASES               += "unmaintained{1}=\htmlonly<div class=\"legacybox\"><h2>Unmainted Code</h2> \1 is a legacy interface: you can use it, as there is no one-to-one replacement interface planned/known. There will be no bug fixes nor new developments.</div>\endhtmlonly"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/hist/spectrum/src/TSpectrum.cxx
+++ b/hist/spectrum/src/TSpectrum.cxx
@@ -14,7 +14,7 @@
     \brief Advanced Spectra Processing
     \author Miroslav Morhac
 
- \legacy{TSpectrum}
+ \unmaintained{TSpectrum}
 
  This class contains advanced spectra processing functions for:
 

--- a/hist/spectrum/src/TSpectrum2.cxx
+++ b/hist/spectrum/src/TSpectrum2.cxx
@@ -6,7 +6,7 @@
     \brief Advanced 2-dimensional spectra processing
     \author Miroslav Morhac
 
-    \legacy{TSpectrum2}
+    \unmaintained{TSpectrum2}
 
  This class contains advanced spectra processing functions.
 

--- a/hist/spectrum/src/TSpectrum2Fit.cxx
+++ b/hist/spectrum/src/TSpectrum2Fit.cxx
@@ -6,7 +6,7 @@
     \brief Advanced 2-dimensional spectra fitting functions
     \author Miroslav Morhac
 
- \legacy{TSpectrum2Fit}
+ \unmaintained{TSpectrum2Fit}
 
 Class for fitting 2D spectra using AWMI (algorithm without matrix
 inversion) and conjugate gradient algorithms for symmetrical

--- a/hist/spectrum/src/TSpectrum2Transform.cxx
+++ b/hist/spectrum/src/TSpectrum2Transform.cxx
@@ -6,7 +6,7 @@
     \brief Advanced 2-dimensional orthogonal transform functions
     \author Miroslav Morhac
 
- \legacy{TSpectrum2Transform}
+ \unmaintained{TSpectrum2Transform}
 
  Class to carry out transforms of 2D spectra, its filtering and
  enhancement. It allows to calculate classic Fourier, Cosine, Sin,

--- a/hist/spectrum/src/TSpectrum3.cxx
+++ b/hist/spectrum/src/TSpectrum3.cxx
@@ -6,7 +6,7 @@
     \brief Advanced 3-dimensional spectra processing functions
     \author Miroslav Morhac
 
- \legacy{TSpectrum3}
+ \unmaintained{TSpectrum3}
 
   This class contains advanced spectra processing functions.
 

--- a/hist/spectrum/src/TSpectrumFit.cxx
+++ b/hist/spectrum/src/TSpectrumFit.cxx
@@ -6,7 +6,7 @@
     \brief Advanced 1-dimensional spectra fitting functions
     \author Miroslav Morhac
 
- \legacy{TSpectrumFit}
+ \unmaintained{TSpectrumFit}
 
  Class for fitting 1D spectra using AWMI (algorithm without matrix
  inversion) and conjugate gradient algorithms for symmetrical

--- a/hist/spectrum/src/TSpectrumTransform.cxx
+++ b/hist/spectrum/src/TSpectrumTransform.cxx
@@ -6,7 +6,7 @@
     \brief Advanced 1-dimensional orthogonal transform functions
     \author Miroslav Morhac
 
- \legacy{TSpectrumTransform}
+ \unmaintained{TSpectrumTransform}
 
 
  Class to carry out transforms of 1D spectra, its filtering and


### PR DESCRIPTION
There are monthly questions about TSpectrum being dis-recommended in the ROOT forum, and what alternatives there are.

For example: https://root-forum.cern.ch/t/which-package-or-class-supersede-the-tspectrum-for-searching-peaks/51459 and links there-in.

Normally, the answer is, there is no one to one development, you can still use it, it's just that it will no longer be maintained.

This PR makes the formulation of the 'warning' less alarming and potentially prevents further duplicate questions in the forum.
