### PR TITLE
[DF] Avoid registration of inner TChain with global lists 

### DIFF
--- a/tree/dataframe/src/RDataFrame.cxx
+++ b/tree/dataframe/src/RDataFrame.cxx
@@ -1356,9 +1356,9 @@ RDataFrame::RDataFrame(std::string_view treeName, std::string_view filenameglob,
 {
    const std::string treeNameInt(treeName);
    const std::string filenameglobInt(filenameglob);
-   auto chain = std::make_shared<TChain>(treeNameInt.c_str());
+   auto chain = std::make_shared<TChain>(treeNameInt.c_str(), "", TChain::kWithoutGlobalRegistration);
    chain->Add(filenameglobInt.c_str());
-   GetProxiedPtr()->SetTree(chain);
+   GetProxiedPtr()->SetTree(std::move(chain));
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -1377,10 +1377,10 @@ RDataFrame::RDataFrame(std::string_view treeName, const std::vector<std::string>
    : RInterface(std::make_shared<RDFDetail::RLoopManager>(nullptr, defaultColumns))
 {
    std::string treeNameInt(treeName);
-   auto chain = std::make_shared<TChain>(treeNameInt.c_str());
+   auto chain = std::make_shared<TChain>(treeNameInt.c_str(), "", TChain::kWithoutGlobalRegistration);
    for (auto &f : fileglobs)
       chain->Add(f.c_str());
-   GetProxiedPtr()->SetTree(chain);
+   GetProxiedPtr()->SetTree(std::move(chain));
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
With this patch we create chains with kWithoutGlobalRegistration in
RDF's constructors -- this is the chain object that RDF uses for
single-thread runs and to look up which branches exist and other
information about the input dataset.

The deregistration of that chain from the global lists can take
some time in certain cases.

This PR depends (and is based) on #11321 .

