### PR TITLE
[RF] Error out for non-extendible PDFs in no-coef RooAddPdf constructor

### DIFF
--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -81,8 +81,6 @@ An (enforced) condition for this assumption is that each \f$ \mathrm{PDF}_i \f$ 
 #include <sstream>
 #include <set>
 
-using namespace std;
-
 ClassImp(RooAddPdf);
 
 
@@ -114,9 +112,8 @@ void RooAddPdf::finalizeConstruction() {
     if(found != seen.end()) {
       std::stringstream errorMsg;
       errorMsg << "RooAddPdf::RooAddPdf(" << GetName()
-               << ") pdf list contains pdfs with duplicate name \"" << pdf->GetName() << "\"."
-               << std::endl;
-      coutE(InputArguments) << errorMsg.str();
+               << ") pdf list contains pdfs with duplicate name \"" << pdf->GetName() << "\".";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
       throw std::invalid_argument(errorMsg.str().c_str());
     }
     seen.insert(elem);
@@ -158,16 +155,16 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
   if (inPdfList.size()>inCoefList.size()+1 || inPdfList.size()<inCoefList.size()) {
     std::stringstream errorMsg;
     errorMsg << "RooAddPdf::RooAddPdf(" << GetName()
-           << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1." << endl ;
-    coutE(InputArguments) << errorMsg.str();
+             << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1.";
+    coutE(InputArguments) << errorMsg.str() << std::endl;
     throw std::invalid_argument(errorMsg.str().c_str());
   }
 
   if (recursiveFractions && inPdfList.size()!=inCoefList.size()+1) {
     std::stringstream errorMsg;
     errorMsg << "RooAddPdf::RooAddPdf(" << GetName()
-           << "): Recursive fractions option can only be used if Npdf=Ncoef+1." << endl;
-    coutE(InputArguments) << errorMsg.str();
+             << "): Recursive fractions option can only be used if Npdf=Ncoef+1.";
+    coutE(InputArguments) << errorMsg.str() << std::endl;
     throw std::invalid_argument(errorMsg.str());
   }
 
@@ -195,20 +192,20 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
     if (inPdfList.at(i) == nullptr) {
       std::stringstream errorMsg;
       errorMsg << "RooAddPdf::RooAddPdf(" << GetName()
-                 << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1" << endl ;
-      coutE(InputArguments) << errorMsg.str();
+                 << ") number of pdfs and coefficients inconsistent, must have Npdf=Ncoef or Npdf=Ncoef+1";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
       throw std::invalid_argument(errorMsg.str());
     }
     if (!coef) {
       std::stringstream errorMsg;
-      errorMsg << "RooAddPdf::RooAddPdf(" << GetName() << ") coefficient " << (coef ? coef->GetName() : "") << " is not of type RooAbsReal, ignored" << endl ;
-      coutE(InputArguments) << errorMsg.str();
+      errorMsg << "RooAddPdf::RooAddPdf(" << GetName() << ") coefficient " << (coef ? coef->GetName() : "") << " is not of type RooAbsReal, ignored";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
       throw std::invalid_argument(errorMsg.str());
     }
     if (!pdf) {
       std::stringstream errorMsg;
-      errorMsg << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << (pdf ? pdf->GetName() : "") << " is not of type RooAbsPdf, ignored" << endl ;
-      coutE(InputArguments) << errorMsg.str();
+      errorMsg << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << (pdf ? pdf->GetName() : "") << " is not of type RooAbsPdf, ignored";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
       throw std::invalid_argument(errorMsg.str());
     }
     _pdfList.add(*pdf) ;
@@ -221,7 +218,7 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
     auto pdf = dynamic_cast<RooAbsPdf*>(inPdfList.at(inCoefList.size()));
 
     if (!pdf) {
-      coutE(InputArguments) << "RooAddPdf::RooAddPdf(" << GetName() << ") last argument " << inPdfList.at(inCoefList.size())->GetName() << " is not of type RooAbsPdf." << endl ;
+      coutE(InputArguments) << "RooAddPdf::RooAddPdf(" << GetName() << ") last argument " << inPdfList.at(inCoefList.size())->GetName() << " is not of type RooAbsPdf." << std::endl;
       throw std::invalid_argument("Last argument for RooAddPdf is not a PDF.");
     }
     _pdfList.add(*pdf) ;
@@ -257,12 +254,18 @@ RooAddPdf::RooAddPdf(const char *name, const char *title, const RooArgList& inPd
     auto pdf = dynamic_cast<const RooAbsPdf*>(pdfArg);
 
     if (!pdf) {
-      coutE(InputArguments) << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << (pdf ? pdf->GetName() : "") << " is not of type RooAbsPdf, ignored" << endl ;
-      continue ;
+      std::stringstream errorMsg;
+      errorMsg << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << (pdf ? pdf->GetName() : "")
+               << " is not of type RooAbsPdf, RooAddPdf constructor call is invalid!";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
+      throw std::invalid_argument(errorMsg.str().c_str());
     }
     if (!pdf->canBeExtended()) {
-      coutE(InputArguments) << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << pdf->GetName() << " is not extendable, ignored" << endl ;
-      continue ;
+      std::stringstream errorMsg;
+      errorMsg << "RooAddPdf::RooAddPdf(" << GetName() << ") pdf " << pdf->GetName()
+               << " is not extendable, RooAddPdf constructor call is invalid!";
+      coutE(InputArguments) << errorMsg.str() << std::endl;
+      throw std::invalid_argument(errorMsg.str().c_str());
     }
     _pdfList.add(*pdf) ;
   }
@@ -607,7 +610,7 @@ Int_t RooAddPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& analVars
     if (subCode[n]==0 && !allAnalVars2->empty()) {
       coutE(InputArguments) << "RooAddPdf::getAnalyticalIntegral(" << GetName() << ") WARNING: component PDF " << pdf->GetName()
              << "   advertises inconsistent set of integrals (e.g. (X,Y) but not X or Y individually."
-             << "   Distributed analytical integration disabled. Please fix PDF" << endl ;
+             << "   Distributed analytical integration disabled. Please fix PDF" << std::endl ;
       allOK = false ;
     }
     n++ ;
@@ -642,14 +645,16 @@ double RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, con
   RooArgSet* intSet ;
   const std::vector<Int_t>& subCode = _codeReg.retrieve(code-1,intSet) ;
   if (subCode.empty()) {
-    coutE(InputArguments) << "RooAddPdf::analyticalIntegral(" << GetName() << "): ERROR unrecognized integration code, " << code << endl ;
-    assert(0) ;
+    std::stringstream errorMsg;
+    errorMsg << "RooAddPdf::analyticalIntegral(" << GetName() << "): ERROR unrecognized integration code, " << code;
+    coutE(InputArguments) << errorMsg.str() << std::endl;
+    throw std::invalid_argument(errorMsg.str().c_str());
   }
 
-  cxcoutD(Caching) << "RooAddPdf::aiWN(" << GetName() << ") calling getProjCache with nset = " << (normSet?*normSet:RooArgSet()) << endl ;
+  cxcoutD(Caching) << "RooAddPdf::aiWN(" << GetName() << ") calling getProjCache with nset = " << (normSet?*normSet:RooArgSet()) << std::endl ;
 
   if ((normSet==0 || normSet->empty()) && !_refCoefNorm.empty()) {
-//     cout << "WVE integration of RooAddPdf without normalization, but have reference set, using ref set for normalization" << endl ;
+//     cout << "WVE integration of RooAddPdf without normalization, but have reference set, using ref set for normalization" << std::endl ;
     normSet = &_refCoefNorm ;
   }
 
@@ -662,7 +667,7 @@ double RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, con
   // Do running sum of coef/pdf pairs, calculate lastCoef.
   double snormVal ;
 
-  //cout << "ROP::aIWN updateCoefCache with rangeName = " << (rangeName?rangeName:"<null>") << endl ;
+  //cout << "ROP::aIWN updateCoefCache with rangeName = " << (rangeName?rangeName:"<null>") << std::endl ;
   for (std::size_t i = 0; i < _pdfList.size(); ++i ) {
     auto pdf = static_cast<const RooAbsPdf*>(_pdfList.at(i));
 
@@ -691,7 +696,7 @@ double RooAddPdf::expectedEvents(const RooArgSet* nset) const
 {
   double expectedTotal{0.0};
 
-  cxcoutD(Caching) << "RooAddPdf::expectedEvents(" << GetName() << ") calling getProjCache with nset = " << (nset?*nset:RooArgSet()) << endl ;
+  cxcoutD(Caching) << "RooAddPdf::expectedEvents(" << GetName() << ") calling getProjCache with nset = " << (nset?*nset:RooArgSet()) << std::endl ;
   AddCacheElem& cache = *getProjCache(nset) ;
   updateCoefficients(cache, nset);
 


### PR DESCRIPTION
There is a constructor of the RooAddPdf that takes no coefficients and
only a list of PDFs. This only makes sense if all of the PDFs are
extendible. Indeed, there are error messages when a PDF is not
extendible, but it would be better to throw an exception because this is
an error that will certainly break your model.

This change is inspired by the following forum post:
https://root-forum.cern.ch/t/roofftconvpdf-not-working-in-product-with-rooaddpdf-even-in-new-root-versions/51442

One user error that resulted in the post was using the no-coefficient constructor with non-extendible PDFs, which would have been prevented by throwing an error as suggested in this PR.