### PR TITLE
[tmva] Backport in 6.26 to fix Keras and PyTorch tutorials 

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -285,7 +285,7 @@ else()
   if (NOT tmva-sofie)
     list(APPEND tmva_veto tmva/TMVA_SOFIE_ONNX.C)
   endif()
-  
+
 endif()
 
 if (NOT ROOT_pythia6_FOUND)
@@ -499,6 +499,10 @@ set (tmva-tmva101_Training-depends tutorial-tmva-tmva100_DataPreparation-py)
 set (tmva-tmva102_Testing-depends tutorial-tmva-tmva101_Training-py)
 set (tmva-pytorch-ApplicationClassificationPyTorch-depends tutorial-tmva-pytorch-ClassificationPyTorch-py)
 set (tmva-pytorch-ApplicationRegressionPyTorch-depends tutorial-tmva-pytorch-RegressionPyTorch-py)
+if (PY_KERAS_FOUND)
+set (tmva-keras-ApplicationRegressionKeras-depends tutorial-tmva-keras-RegressionKeras-py)
+set (tmva-keras-ApplicationClassificationKeras-depends tutorial-tmva-keras-ClassificationKeras-py)
+endif()
 
 #--List long-running tutorials to label them as "longtest"
 set (long_running
@@ -671,6 +675,10 @@ if(ROOT_pyroot_FOUND)
   if(NOT PY_KERAS_FOUND)
     file(GLOB tmva_veto_py RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tmva/keras/*.py)
     list(APPEND pyveto ${tmva_veto_py})
+  else()
+    #disable keras Regression tutorials, they are too slow because of the regression evaluation for each event
+   list(APPEND pyveto tmva/keras/RegressionKeras.py)
+   list(APPEND pyveto tmva/keras/ApplicationRegressionKeras.py)
   endif()
 
   find_python_module(torch QUIET)

--- a/tutorials/tmva/TMVA_SOFIE_ONNX.C
+++ b/tutorials/tmva/TMVA_SOFIE_ONNX.C
@@ -10,14 +10,18 @@
 
 using namespace TMVA::Experimental;
 
-void TMVA_SOFIE_ONNX(){
+void TMVA_SOFIE_ONNX(std::string inputFile = ""){
+   if (inputFile.empty() )
+      inputFile = std::string(gROOT->GetTutorialsDir()) + "/tmva/Linear_16.onnx";
+
     //Creating parser object to parse ONNX files
-    SOFIE::RModelParser_ONNX Parser;
-    SOFIE::RModel model = Parser.Parse("../../tmva/sofie/test/input_models/Linear_16.onnx");
+    SOFIE::RModelParser_ONNX parser;
+    SOFIE::RModel model = parser.Parse(inputFile);
 
     //Generating inference code
     model.Generate();
-    model.OutputGenerated("Linear_16.hxx");
+    // write the code in a file (by default Linear_16.hxx and Linear_16.dat
+    model.OutputGenerated();
 
     //Printing required input tensors
     model.PrintRequiredInputTensors();

--- a/tutorials/tmva/keras/ClassificationKeras.py
+++ b/tutorials/tmva/keras/ClassificationKeras.py
@@ -52,17 +52,17 @@ model.add(Dense(2, activation='softmax'))
 
 # Set loss and optimizer
 model.compile(loss='categorical_crossentropy',
-              optimizer=SGD(lr=0.01), metrics=['accuracy', ])
+              optimizer=SGD(learning_rate=0.01), metrics=['accuracy', ])
 
 # Store model to file
-model.save('model.h5')
+model.save('modelClassification.h5')
 model.summary()
 
 # Book methods
 factory.BookMethod(dataloader, TMVA.Types.kFisher, 'Fisher',
                    '!H:!V:Fisher:VarTransform=D,G')
 factory.BookMethod(dataloader, TMVA.Types.kPyKeras, 'PyKeras',
-                   'H:!V:VarTransform=D,G:FilenameModel=model.h5:NumEpochs=20:BatchSize=32')
+                   'H:!V:VarTransform=D,G:FilenameModel=modelClassification.h5:FilenameTrainedModel=trainedModelClassification.h5:NumEpochs=20:BatchSize=32')
 
 # Run training, test and evaluation
 factory.TrainAllMethods()

--- a/tutorials/tmva/keras/GenerateModel.py
+++ b/tutorials/tmva/keras/GenerateModel.py
@@ -10,11 +10,11 @@
 ## \date 2017
 ## \author TMVA Team
 
-from keras.models import Sequential
-from keras.layers.core import Dense, Activation
-from keras.regularizers import l2
-from keras.optimizers import SGD
-from keras.utils import plot_model
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Dense, Activation
+from tensorflow.keras.regularizers import l2
+from tensorflow.keras.optimizers import SGD
+from tensorflow.keras.utils import plot_model
 
 # Setup the model here
 num_input_nodes = 4
@@ -27,12 +27,12 @@ model = Sequential()
 
 # Hidden layer 1
 # NOTE: Number of input nodes need to be defined in this layer
-model.add(Dense(nodes_hidden_layer, activation='relu', W_regularizer=l2(l2_val), input_dim=num_input_nodes))
+model.add(Dense(nodes_hidden_layer, activation='relu', kernel_regularizer=l2(l2_val), input_dim=num_input_nodes))
 
 # Hidden layer 2 to num_hidden_layers
 # NOTE: Here, you can do what you want
 for k in range(num_hidden_layers-1):
-    model.add(Dense(nodes_hidden_layer, activation='relu', W_regularizer=l2(l2_val)))
+    model.add(Dense(nodes_hidden_layer, activation='relu', kernel_regularizer=l2(l2_val)))
 
 # Ouput layer
 # NOTE: Use following output types for the different tasks
@@ -45,7 +45,7 @@ model.add(Dense(num_output_nodes, activation='softmax'))
 # NOTE: Use following settings for the different tasks
 # Any classification: 'categorical_crossentropy' is recommended loss function
 # Regression: 'mean_squared_error' is recommended loss function
-model.compile(loss='categorical_crossentropy', optimizer=SGD(lr=0.01), metrics=['accuracy',])
+model.compile(loss='categorical_crossentropy', optimizer=SGD(learning_rate=0.01), metrics=['accuracy',])
 
 # Save model
 model.save('model.h5')

--- a/tutorials/tmva/keras/MulticlassKeras.py
+++ b/tutorials/tmva/keras/MulticlassKeras.py
@@ -57,17 +57,17 @@ model.add(Dense(32, activation='relu', input_dim=4))
 model.add(Dense(4, activation='softmax'))
 
 # Set loss and optimizer
-model.compile(loss='categorical_crossentropy', optimizer=SGD(lr=0.01), metrics=['accuracy',])
+model.compile(loss='categorical_crossentropy', optimizer=SGD(learning_rate=0.01), metrics=['accuracy',])
 
 # Store model to file
-model.save('model.h5')
+model.save('modelMultiClass.h5')
 model.summary()
 
 # Book methods
 factory.BookMethod(dataloader, TMVA.Types.kFisher, 'Fisher',
         '!H:!V:Fisher:VarTransform=D,G')
-factory.BookMethod(dataloader, TMVA.Types.kPyKeras, "PyKeras",
-        'H:!V:VarTransform=D,G:FilenameModel=model.h5:NumEpochs=20:BatchSize=32')
+factory.BookMethod(dataloader, TMVA.Types.kPyKeras, 'PyKeras',
+                   'H:!V:VarTransform=D,G:FilenameModel=modelMultiClass.h5:FilenameTrainedModel=trainedModelMultiClass.h5:NumEpochs=20:BatchSize=32')
 
 # Run TMVA
 factory.TrainAllMethods()

--- a/tutorials/tmva/keras/RegressionKeras.py
+++ b/tutorials/tmva/keras/RegressionKeras.py
@@ -52,15 +52,15 @@ model.add(Dense(64, activation='tanh', input_dim=2))
 model.add(Dense(1, activation='linear'))
 
 # Set loss and optimizer
-model.compile(loss='mean_squared_error', optimizer=SGD(lr=0.01))
+model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.01))
 
 # Store model to file
-model.save('model.h5')
+model.save('modelRegression.h5')
 model.summary()
 
 # Book methods
 factory.BookMethod(dataloader, TMVA.Types.kPyKeras, 'PyKeras',
-        'H:!V:VarTransform=D,G:FilenameModel=model.h5:NumEpochs=20:BatchSize=32')
+        'H:!V:VarTransform=D,G:FilenameModel=modelRegression.h5:FilenameTrainedModel=trainedModelRegression.h5:NumEpochs=20:BatchSize=32')
 factory.BookMethod(dataloader, TMVA.Types.kBDT, 'BDTG',
         '!H:!V:VarTransform=D,G:NTrees=1000:BoostType=Grad:Shrinkage=0.1:UseBaggedBoost:BaggedSampleFraction=0.5:nCuts=20:MaxDepth=4')
 

--- a/tutorials/tmva/pytorch/ClassificationPyTorch.py
+++ b/tutorials/tmva/pytorch/ClassificationPyTorch.py
@@ -117,7 +117,7 @@ def train(model, train_loader, val_loader, num_epochs, batch_size, optimizer, cr
 def predict(model, test_X, batch_size=32):
     # Set to eval mode
     model.eval()
-   
+
     test_dataset = torch.utils.data.TensorDataset(torch.Tensor(test_X))
     test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
 
@@ -128,7 +128,7 @@ def predict(model, test_X, batch_size=32):
             outputs = model(X)
             predictions.append(outputs)
         preds = torch.cat(predictions)
-   
+
     return preds.numpy()
 
 
@@ -138,7 +138,7 @@ load_model_custom_objects = {"optimizer": optimizer, "criterion": loss, "train_f
 # Store model to file
 # Convert the model to torchscript before saving
 m = torch.jit.script(model)
-torch.jit.save(m, "model.pt")
+torch.jit.save(m, "modelClassification.pt")
 print(m)
 
 
@@ -146,7 +146,7 @@ print(m)
 factory.BookMethod(dataloader, TMVA.Types.kFisher, 'Fisher',
                    '!H:!V:Fisher:VarTransform=D,G')
 factory.BookMethod(dataloader, TMVA.Types.kPyTorch, 'PyTorch',
-                   'H:!V:VarTransform=D,G:FilenameModel=model.pt:NumEpochs=20:BatchSize=32')
+                   'H:!V:VarTransform=D,G:FilenameModel=modelClassification.pt:FilenameTrainedModel=trainedModelClassification.pt:NumEpochs=20:BatchSize=32')
 
 
 # Run training, test and evaluation

--- a/tutorials/tmva/pytorch/MulticlassPyTorch.py
+++ b/tutorials/tmva/pytorch/MulticlassPyTorch.py
@@ -124,7 +124,7 @@ def train(model, train_loader, val_loader, num_epochs, batch_size, optimizer, cr
 def predict(model, test_X, batch_size=32):
     # Set to eval mode
     model.eval()
-   
+
     test_dataset = torch.utils.data.TensorDataset(torch.Tensor(test_X))
     test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
 
@@ -135,7 +135,7 @@ def predict(model, test_X, batch_size=32):
             outputs = model(X)
             predictions.append(outputs)
         preds = torch.cat(predictions)
-   
+
     return preds.numpy()
 
 
@@ -145,7 +145,7 @@ load_model_custom_objects = {"optimizer": optimizer, "criterion": loss, "train_f
 # Store model to file
 # Convert the model to torchscript before saving
 m = torch.jit.script(model)
-torch.jit.save(m, "model.pt")
+torch.jit.save(m, "modelMultiClass.pt")
 print(m)
 
 
@@ -153,7 +153,7 @@ print(m)
 factory.BookMethod(dataloader, TMVA.Types.kFisher, 'Fisher',
         '!H:!V:Fisher:VarTransform=D,G')
 factory.BookMethod(dataloader, TMVA.Types.kPyTorch, "PyTorch",
-        'H:!V:VarTransform=D,G:FilenameModel=model.pt:NumEpochs=20:BatchSize=32')
+        'H:!V:VarTransform=D,G:FilenameModel=modelMultiClass.pt:FilenameTrainedModel=trainedModelMultiClass.pt:NumEpochs=20:BatchSize=32')
 
 
 # Run TMVA

--- a/tutorials/tmva/pytorch/RegressionPyTorch.py
+++ b/tutorials/tmva/pytorch/RegressionPyTorch.py
@@ -117,7 +117,7 @@ def train(model, train_loader, val_loader, num_epochs, batch_size, optimizer, cr
 def predict(model, test_X, batch_size=32):
     # Set to eval mode
     model.eval()
-   
+
     test_dataset = torch.utils.data.TensorDataset(torch.Tensor(test_X))
     test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
 
@@ -128,7 +128,7 @@ def predict(model, test_X, batch_size=32):
             outputs = model(X)
             predictions.append(outputs)
         preds = torch.cat(predictions)
-   
+
     return preds.numpy()
 
 
@@ -138,13 +138,13 @@ load_model_custom_objects = {"optimizer": optimizer, "criterion": loss, "train_f
 # Store model to file
 # Convert the model to torchscript before saving
 m = torch.jit.script(model)
-torch.jit.save(m, "model.pt")
+torch.jit.save(m, "modelRegression.pt")
 print(m)
 
 
 # Book methods
 factory.BookMethod(dataloader, TMVA.Types.kPyTorch, 'PyTorch',
-        'H:!V:VarTransform=D,G:FilenameModel=model.pt:NumEpochs=20:BatchSize=32')
+        'H:!V:VarTransform=D,G:FilenameModel=modelRegression.pt:FilenameTrainedModel=trainedModelRegression.pt:NumEpochs=20:BatchSize=32')
 factory.BookMethod(dataloader, TMVA.Types.kBDT, 'BDTG',
         '!H:!V:VarTransform=D,G:NTrees=1000:BoostType=Grad:Shrinkage=0.1:UseBaggedBoost:BaggedSampleFraction=0.5:nCuts=20:MaxDepth=4')
 


### PR DESCRIPTION
* [cmake] Fix dependency of some TMVA_SOFIE tutorials

* [tmva] Set unique model file names for tutorials

The tutorials were using the same model file name and this was causing a problem when running the tutorials in parallel as in the CI builds.

Fix also some deprectations happening when using now the  new Keras  version based on tensorflow.keras Fix dependency also for Python Keras tutorials

Disable also Regression Keras tutorials in CI builds since they are too slow for the regression evaluation on single events




## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

