### PR TITLE
[skip-ci] redefine the legacy alias

### DIFF
--- a/documentation/doxygen/Doxyfile
+++ b/documentation/doxygen/Doxyfile
@@ -261,7 +261,8 @@ TAB_SIZE               = 3
 # with the commands \{ and \} for these it is advised to use the version @{ and
 # @} or use a double escape (\\{ and \\})
 
-ALIASES                = "legacy{1}=\htmlonly<div class=\"legacybox\"><h2>Legacy Code</h2> \1 is a legacy interface: it is not recommended to use it in new code. There will be no bug fixes nor new developments.</div>\endhtmlonly"
+ALIASES += "legacy{1}=\htmlonly<div class=\"legacybox\"><h2>Legacy Code</h2> \1 is a legacy interface: there will be no bug fixes nor new developments. Therefore it is not recommended to use it in new long-term production code. But, depending on the context, using \1 might still be a valid solution.</div>\endhtmlonly"
+ALIASES += "legacy{2}=\htmlonly<div class=\"legacybox\"><h2>Legacy Code</h2> \1 is a legacy interface: there will be no bug fixes nor new developments. Therefore it is not recommended to use it in new long-term production code. But, depending on the context, using \1 might still be a valid solution. \2</div>\endhtmlonly"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/hist/spectrum/src/TSpectrum.cxx
+++ b/hist/spectrum/src/TSpectrum.cxx
@@ -14,7 +14,7 @@
     \brief Advanced Spectra Processing
     \author Miroslav Morhac
 
- \legacy{TSpectrum}
+ \legacy{TSpectrum, For modeling a spectrum fitting  and estimating the background one can use RooFit while for deconvolution and unfolding one can use TUnfold.}
 
  This class contains advanced spectra processing functions for:
 


### PR DESCRIPTION
There are a lot of questions about TSpectrum being dis-recommended in the ROOT forum, and what alternatives there are.

For example https://root-forum.cern.ch/t/which-package-or-class-supersede-the-tspectrum-for-searching-peaks/51459 

This PR makes the formulation more detailed. The `legacy` alias has been redefined. It has now 2 parameters. The 2nd one is free text (without comma) allowing to precise, for instance, possible replacements of the class. 

