### PR TITLE
[IO] Honor READ_WITHOUT_GLOBALREGISTRATION in TNetXNGFile (v6.26)

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -372,25 +372,25 @@ TFile::TFile(const char *fname1, Option_t *option, const char *ftitle, Int_t com
       }
    }
 
+   if (fOption.Contains("_WITHOUT_GLOBALREGISTRATION")) {
+      fOption = fOption.ReplaceAll("_WITHOUT_GLOBALREGISTRATION", "");
+      fGlobalRegistration = false;
+      if (fList) {
+         fList->UseRWLock(false);
+      }
+   }
+
    if (fOption == "NET")
       return;
 
    if (fOption == "WEB") {
-      fOption   = "READ";
+      fOption = "READ";
       fWritable = kFALSE;
       return;
    }
 
    if (fOption == "NEW")
       fOption = "CREATE";
-
-   if (fOption == "READ_WITHOUT_GLOBALREGISTRATION") {
-      fOption = "READ";
-      fGlobalRegistration = false;
-      if (fList) {
-         fList->UseRWLock(false);
-      }
-   }
 
    Bool_t create   = (fOption == "CREATE") ? kTRUE : kFALSE;
    Bool_t recreate = (fOption == "RECREATE") ? kTRUE : kFALSE;

--- a/net/davix/src/TDavixFile.cxx
+++ b/net/davix/src/TDavixFile.cxx
@@ -655,8 +655,9 @@ Int_t TDavixFileInternal::DavixStat(const char *url, struct stat *st)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TDavixFile::TDavixFile(const char *url, Option_t *opt, const char *ftitle, Int_t compress) : TFile(url, "WEB"),
-   d_ptr(new TDavixFileInternal(fUrl, opt))
+TDavixFile::TDavixFile(const char *url, Option_t *opt, const char *ftitle, Int_t compress)
+   : TFile(url, strstr(opt, "_WITHOUT_GLOBALREGISTRATION") != nullptr ? "WEB_WITHOUT_GLOBALREGISTRATION" : "WEB"),
+     d_ptr(new TDavixFileInternal(fUrl, opt))
 {
    (void) ftitle;
    (void) compress;

--- a/net/net/src/TNetFile.cxx
+++ b/net/net/src/TNetFile.cxx
@@ -76,9 +76,10 @@ ClassImp(TNetSystem);
 /// for a description of the options and other arguments see Create().
 /// Normally a TNetFile is created via TFile::Open().
 
-TNetFile::TNetFile(const char *url, Option_t *option, const char *ftitle,
-                   Int_t compress, Int_t netopt)
-   : TFile(url, "NET", ftitle, compress), fEndpointUrl(url)
+TNetFile::TNetFile(const char *url, Option_t *option, const char *ftitle, Int_t compress, Int_t netopt)
+   : TFile(url, strstr(option, "_WITHOUT_GLOBALREGISTRATION") != nullptr ? "NET_WITHOUT_GLOBALREGISTRATION" : "NET",
+           ftitle, compress),
+     fEndpointUrl(url)
 {
    fSocket = 0;
    Create(url, option, netopt);

--- a/net/net/src/TWebFile.cxx
+++ b/net/net/src/TWebFile.cxx
@@ -143,7 +143,9 @@ ClassImp(TWebFile);
 /// to see if the file is accessible. The preferred interface to this
 /// constructor is via TFile::Open().
 
-TWebFile::TWebFile(const char *url, Option_t *opt) : TFile(url, "WEB"), fSocket(0)
+TWebFile::TWebFile(const char *url, Option_t *opt)
+   : TFile(url, strstr(opt, "_WITHOUT_GLOBALREGISTRATION") != nullptr ? "WEB_WITHOUT_GLOBALREGISTRATION" : "WEB"),
+     fSocket(0)
 {
    TString option = opt;
    fNoProxy = kFALSE;

--- a/net/netxng/src/TNetXNGFile.cxx
+++ b/net/netxng/src/TNetXNGFile.cxx
@@ -131,14 +131,11 @@ TNetXNGFile::TNetXNGFile(const char *url,
                          Bool_t      parallelopen) :
 	TNetXNGFile(url,0,mode,title,compress,netopt,parallelopen){}
 
-TNetXNGFile::TNetXNGFile(const char *url,
-		         const char *lurl,
-                         Option_t   *mode,
-                         const char *title,
-                         Int_t       compress,
-                         Int_t       /*netopt*/,
-                         Bool_t      parallelopen) :
-   TFile((lurl ? lurl : url), "NET", title, compress)
+TNetXNGFile::TNetXNGFile(const char *url, const char *lurl, Option_t *mode, const char *title, Int_t compress,
+                         Int_t /*netopt*/, Bool_t parallelopen)
+   : TFile((lurl ? lurl : url),
+           strstr(mode, "_WITHOUT_GLOBALREGISTRATION") != nullptr ? "NET_WITHOUT_GLOBALREGISTRATION" : "NET", title,
+           compress)
 {
    using namespace XrdCl;
 


### PR DESCRIPTION
...as well as in TNetFile, TDavixFile and TWebFile.

This fixes #10742.