### PR TITLE
core: Disable check for already deleted object.

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/cppcompleter.py
@@ -75,6 +75,7 @@ class CppCompleter(object):
     ...     print(suggestion)
     TROOT::IsA
     TROOT::IsBatch
+    TROOT::IsDestructed
     TROOT::IsEqual
     TROOT::IsEscaped
     TROOT::IsExecutingMacro

--- a/bindings/pyroot_legacy/JupyROOT/helpers/cppcompleter.py
+++ b/bindings/pyroot_legacy/JupyROOT/helpers/cppcompleter.py
@@ -87,6 +87,7 @@ class CppCompleter(object):
     ...     print(suggestion)
     TROOT::IsA
     TROOT::IsBatch
+    TROOT::IsDestructed
     TROOT::IsEqual
     TROOT::IsEscaped
     TROOT::IsExecutingMacro

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -56,6 +56,76 @@ Bool_t TObject::fgObjectStat = kTRUE;
 
 ClassImp(TObject);
 
+namespace ROOT {
+namespace Internal {
+
+// Return true if delete changes/poisons/taints the memory.
+//
+// Detect whether operator delete taints the memory. If it does, we can not rely
+// on TestBit(kNotDeleted) to check if the memory has been deleted (but in case,
+// like TClonesArray, where we know the destructor will be called but not operator
+// delete, we can still use it to detect the cases where the destructor was called.
+
+bool DeleteChangesMemoryImpl()
+{
+   static constexpr UInt_t kGoldenUUID = 0x00000021;
+   static constexpr UInt_t kGoldenbits = 0x03000000;
+ 
+   TObject *o = new TObject;
+   o->SetUniqueID(kGoldenUUID);
+   UInt_t *o_fuid = &(o->fUniqueID);
+   UInt_t *o_fbits = &(o->fBits);
+
+   if (*o_fuid != kGoldenUUID) {
+      Error("CheckingDeleteSideEffects",
+            "fUniqueID is not as expected, we got 0x%.8x instead of 0x%.8x",
+            *o_fuid, kGoldenUUID);
+   }
+   if (*o_fbits != kGoldenbits) {
+      Error("CheckingDeleteSideEffects",
+            "fBits is not as expected, we got 0x%.8x instead of 0x%.8x",
+            *o_fbits, kGoldenbits);
+   }
+   if (gDebug >= 9) {
+      unsigned char *oc = reinterpret_cast<unsigned char *>(o); // for address calculations
+      unsigned char references[sizeof(TObject)];
+      memcpy(references, oc, sizeof(TObject));
+
+      // The effective part of this code (the else statement is just that without
+      // any of the debug statement)
+      delete o;
+
+      // Not using the error logger, as there routine is meant to be called
+      // during library initialization/loading.
+      fprintf(stderr,
+              "DEBUG: Checking before and after delete the content of a TObject with uniqueID 0x21\n");
+      for(size_t i = 0; i < sizeof(TObject); i += 4) {
+        fprintf(stderr, "DEBUG: 0x%.8x vs 0x%.8x\n", *(int*)(references +i), *(int*)(oc + i));
+      }
+   } else
+      delete o;  // the 'if' part is that surrounded by the debug code.
+
+   // Intentionally accessing the deleted memory to check whether it has been changed as
+   // a consequence (side effect) of executing operator delete.  If there no change, we
+   // can guess this is always the case and we can rely on the changes to fBits made
+   // by ~TObject to detect use-after-delete error (and print a message rather than
+   // stop the program with a segmentation fault)
+   if ( *o_fbits != 0x01000000 ) {
+      // operator delete tainted the memory, we can not rely on TestBit(kNotDeleted)
+      return true;
+   }
+   return false;
+}
+
+bool DeleteChangesMemory()
+{
+   static const bool value = DeleteChangesMemoryImpl();
+   if (gDebug >= 9)
+      DeleteChangesMemoryImpl(); // To allow for printing the debug info
+   return value;
+}
+
+}} // ROOT::Detail
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Copy this to obj.

--- a/core/base/src/TQConnection.cxx
+++ b/core/base/src/TQConnection.cxx
@@ -284,7 +284,7 @@ CallFunc_t *TQSlot::StartExecuting() {
 
 void TQSlot::EndExecuting() {
    fExecuting--;
-   if (!TestBit(kNotDeleted) && !fExecuting)
+   if (ROOT::Detail::HasBeenDeleted(this) && !fExecuting)
       gCling->CallFunc_Delete(fFunc);
 }
 
@@ -344,7 +344,7 @@ inline void TQSlot::ExecuteMethod(void *object, Longptr_t *paramArr, Int_t npara
    fExecuting++;
    gCling->CallFunc_Exec(fFunc, address);
    fExecuting--;
-   if (!TestBit(kNotDeleted) && !fExecuting)
+   if (ROOT::Detail::HasBeenDeleted(this) && !fExecuting)
       gCling->CallFunc_Delete(fFunc);
 }
 

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -1371,7 +1371,7 @@ TObject *TROOT::FindSpecialObject(const char *name, void *&where)
       }
    }
    if (!temp) return nullptr;
-   if (temp->TestBit(kNotDeleted)) return temp;
+   if (!ROOT::Detail::HasBeenDeleted(temp)) return temp;
    return nullptr;
 }
 

--- a/core/cont/src/TCollection.cxx
+++ b/core/cont/src/TCollection.cxx
@@ -584,7 +584,7 @@ void TCollection::RecursiveRemove(TObject *obj)
    TObject *object;
 
    while ((object = next())) {
-      if (object->TestBit(kNotDeleted)) object->RecursiveRemove(obj);
+      if (!ROOT::Detail::HasBeenDeleted(object)) object->RecursiveRemove(obj);
    }
 }
 

--- a/core/cont/src/THashList.cxx
+++ b/core/cont/src/THashList.cxx
@@ -227,7 +227,7 @@ void THashList::Delete(Option_t *option)
          auto obj = tlk->GetObject();
          // In case somebody else access it.
          tlk->SetObject(nullptr);
-         if (obj && !obj->TestBit(kNotDeleted))
+         if (obj && ROOT::Detail::HasBeenDeleted(obj))
             Error("Delete", "A list is accessing an object (%p) already deleted (list name = %s)",
                   obj, GetName());
          else if (obj && obj->IsOnHeap())
@@ -350,7 +350,7 @@ void THashList::RecursiveRemove(TObject *obj)
    while (lnk.get()) {
       next = lnk->NextSP();
       TObject *ob = lnk->GetObject();
-      if (ob && ob->TestBit(kNotDeleted)) {
+      if (ob && !ROOT::Detail::HasBeenDeleted(ob)) {
          ob->RecursiveRemove(obj);
       }
       lnk = next;

--- a/core/cont/src/TObjArray.cxx
+++ b/core/cont/src/TObjArray.cxx
@@ -675,7 +675,7 @@ void TObjArray::RecursiveRemove(TObject *obj)
    R__COLLECTION_WRITE_LOCKGUARD(ROOT::gCoreMutex);
 
    for (int i = 0; i < fSize; i++) {
-      if (fCont[i] && fCont[i]->TestBit(kNotDeleted) && fCont[i]->IsEqual(obj)) {
+      if (fCont[i] && !ROOT::Detail::HasBeenDeleted(fCont[i]) && fCont[i]->IsEqual(obj)) {
          fCont[i] = nullptr;
          // recalculate array size
          if (i == fLast)
@@ -683,7 +683,7 @@ void TObjArray::RecursiveRemove(TObject *obj)
                fLast--;
             } while (fLast >= 0 && !fCont[fLast]);
          Changed();
-      } else if (fCont[i] && fCont[i]->TestBit(kNotDeleted))
+      } else if (fCont[i] && !ROOT::Detail::HasBeenDeleted(fCont[i]))
          fCont[i]->RecursiveRemove(obj);
    }
 }

--- a/core/cont/src/TObjectTable.cxx
+++ b/core/cont/src/TObjectTable.cxx
@@ -383,7 +383,7 @@ void TObjectTable::UpdateInstCount() const
 
    for (int i = 0; i < fSize; i++)
       if ((op = fTable[i])) {                // attention: no ==
-         if (op->TestBit(TObject::kNotDeleted))
+         if (!ROOT::Detail::HasBeenDeleted(op))
             op->IsA()->AddInstance(op->IsOnHeap());
          else
             Error("UpdateInstCount", "oops 0x%zx\n", (size_t)op);

--- a/core/gui/src/TContextMenu.cxx
+++ b/core/gui/src/TContextMenu.cxx
@@ -126,7 +126,7 @@ void TContextMenu::Action(TClassMenuItem *menuitem)
 
    if (object) {
       // If object deleted, remove from popup and return
-      if (!(object->TestBit(kNotDeleted))) {
+      if (ROOT::Detail::HasBeenDeleted(object)) {
          menuitem->SetType(TClassMenuItem::kPopupSeparator);
          menuitem->SetCall(nullptr, "");
          return;

--- a/etc/valgrind-root.supp
+++ b/etc/valgrind-root.supp
@@ -1013,6 +1013,14 @@
    fun:_ZN11TBufferFile13ReadStdStringERSs
 }
 
+######## ROOT use-after-delete detection attempts
+
+{
+   Checking if delete taints memory
+   Memcheck:Addr4
+   fun:_ZN4ROOT8Internal*DeleteChangesMemory*
+}
+
 ######## ROOT TObject on heap
 
 {

--- a/graf2d/gpad/src/TButton.cxx
+++ b/graf2d/gpad/src/TButton.cxx
@@ -149,7 +149,7 @@ void TButton::Draw(Option_t *option)
 void TButton::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 {
    //check case where pressing a button deletes itself
-   if (!TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(this)) return;
 
    if (IsEditable()) {
       TPad::ExecuteEvent(event,px,py);
@@ -202,7 +202,7 @@ void TButton::ExecuteEvent(Int_t event, Int_t px, Int_t py)
          gROOT->ProcessLine(GetMethod());
       }
       //check case where pressing a button deletes itself
-      if (!TestBit(kNotDeleted)) return;
+      if (ROOT::Detail::HasBeenDeleted(this)) return;
       SetBorderMode(1);
       Modified();
       Update();

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -687,7 +687,7 @@ void TCanvas::Destructor()
       if ((*gThreadXAR)("CDEL", 2, arr, 0)) return;
    }
 
-   if (!TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(this)) return;
 
    SafeDelete(fContextMenu);
    if (!gPad) return;

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -379,7 +379,7 @@ zombie:
 
 TPad::~TPad()
 {
-   if (!TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(this)) return;
    Close();
    CloseToolTip(fTip);
    DeleteToolTip(fTip);
@@ -633,7 +633,7 @@ void TPad::Clear(Option_t *option)
       SafeDelete(fView);
       if (fPrimitives) fPrimitives->Clear(option);
       if (fFrame) {
-         if (fFrame->TestBit(kNotDeleted)) delete fFrame;
+         if (! ROOT::Detail::HasBeenDeleted(fFrame)) delete fFrame;
          fFrame = nullptr;
       }
    }
@@ -973,18 +973,18 @@ Int_t TPad::ClipPolygon(Int_t n, Double_t *x, Double_t *y, Int_t nn, Double_t *x
 
 void TPad::Close(Option_t *)
 {
-   if (!TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(this)) return;
    if (!fMother) return;
-   if (!fMother->TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(fMother)) return;
 
    if (fPrimitives)
       fPrimitives->Clear();
    if (fView) {
-      if (fView->TestBit(kNotDeleted)) delete fView;
+      if (!ROOT::Detail::HasBeenDeleted(fView)) delete fView;
       fView = nullptr;
    }
    if (fFrame) {
-      if (fFrame->TestBit(kNotDeleted)) delete fFrame;
+      if (!ROOT::Detail::HasBeenDeleted(fFrame)) delete fFrame;
       fFrame = nullptr;
    }
 
@@ -1274,7 +1274,7 @@ void TPad::Draw(Option_t *option)
    // pad cannot be in itself and it can only be in one other pad at a time
    if (!fPrimitives) fPrimitives = new TList;
    if (gPad != this) {
-      if (fMother && fMother->TestBit(kNotDeleted))
+      if (fMother && !ROOT::Detail::HasBeenDeleted(fMother))
             if (fMother->GetListOfPrimitives()) fMother->GetListOfPrimitives()->Remove(this);
       TPad *oldMother = fMother;
       fCanvas = gPad->GetCanvas();
@@ -4611,7 +4611,7 @@ TPad *TPad::Pick(Int_t px, Int_t py, TObjLink *&pickobj)
 void TPad::Pop()
 {
    if (!fMother) return;
-   if (!fMother->TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(fMother)) return;
    if (!fPrimitives) fPrimitives = new TList;
    if (this == fMother->GetListOfPrimitives()->Last()) return;
 

--- a/graf2d/gpad/src/TRatioPlot.cxx
+++ b/graf2d/gpad/src/TRatioPlot.cxx
@@ -111,26 +111,31 @@ TRatioPlot::~TRatioPlot()
 
    gROOT->GetListOfCleanups()->Remove(this);
 
-   if (fRatioGraph && fRatioGraph->TestBit(kNotDeleted)) delete fRatioGraph;
-   if (fConfidenceInterval1 && fConfidenceInterval1->TestBit(kNotDeleted)) delete fConfidenceInterval1;
-   if (fConfidenceInterval2 && fConfidenceInterval2->TestBit(kNotDeleted)) delete fConfidenceInterval2;
+   auto safeDelete = [](TObject *obj) {
+      if (obj && !ROOT::Detail::HasBeenDeleted(obj))
+         delete obj;
+   };
+
+   safeDelete(fRatioGraph);
+   safeDelete(fConfidenceInterval1);
+   safeDelete(fConfidenceInterval2);
 
    for (unsigned int i=0;i<fGridlines.size();++i) {
       delete (fGridlines[i]);
    }
 
-   if (fSharedXAxis && fSharedXAxis->TestBit(kNotDeleted)) delete fSharedXAxis;
-   if (fUpperGXaxis && fUpperGXaxis->TestBit(kNotDeleted)) delete fUpperGXaxis;
-   if (fLowerGXaxis && fLowerGXaxis->TestBit(kNotDeleted)) delete fLowerGXaxis;
-   if (fUpperGYaxis && fUpperGYaxis->TestBit(kNotDeleted)) delete fUpperGYaxis;
-   if (fLowerGYaxis && fLowerGYaxis->TestBit(kNotDeleted)) delete fLowerGYaxis;
-   if (fUpperGXaxisMirror && fUpperGXaxisMirror->TestBit(kNotDeleted)) delete fUpperGXaxisMirror;
-   if (fLowerGXaxisMirror && fLowerGXaxisMirror->TestBit(kNotDeleted)) delete fLowerGXaxisMirror;
-   if (fUpperGYaxisMirror && fUpperGYaxisMirror->TestBit(kNotDeleted)) delete fUpperGYaxisMirror;
-   if (fLowerGYaxisMirror && fLowerGYaxisMirror->TestBit(kNotDeleted)) delete fLowerGYaxisMirror;
+   safeDelete(fSharedXAxis);
+   safeDelete(fUpperGXaxis);
+   safeDelete(fLowerGXaxis);
+   safeDelete(fUpperGYaxis);
+   safeDelete(fLowerGYaxis);
+   safeDelete(fUpperGXaxisMirror);
+   safeDelete(fLowerGXaxisMirror);
+   safeDelete(fUpperGYaxisMirror);
+   safeDelete(fLowerGYaxisMirror);
 
-   if (fUpYaxis && fUpYaxis->TestBit(kNotDeleted)) delete fUpYaxis;
-   if (fLowYaxis && fLowYaxis->TestBit(kNotDeleted)) delete fLowYaxis;
+   safeDelete(fUpYaxis);
+   safeDelete(fLowYaxis);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/graf/src/TPaveText.cxx
+++ b/graf2d/graf/src/TPaveText.cxx
@@ -115,7 +115,7 @@ TPaveText::TPaveText(Double_t x1, Double_t y1,Double_t x2, Double_t  y2, Option_
 
 TPaveText::~TPaveText()
 {
-   if (!TestBit(kNotDeleted)) return;
+   if (ROOT::Detail::HasBeenDeleted(this)) return;
    if (fLines) fLines->Delete();
    delete fLines;
    fLines = nullptr;

--- a/graf3d/g3d/src/TGeometry.cxx
+++ b/graf3d/g3d/src/TGeometry.cxx
@@ -346,7 +346,7 @@ TNode *TGeometry::GetNode(const char *name) const
 {
    TNode *node= (TNode*)GetListOfNodes()->First();
    if (!node) return 0;
-   if (node->TestBit(kNotDeleted))  return node->GetNode(name);
+   if (!ROOT::Detail::HasBeenDeleted(node))  return node->GetNode(name);
    return 0;
 }
 

--- a/graf3d/g3d/src/TNode.cxx
+++ b/graf3d/g3d/src/TNode.cxx
@@ -382,7 +382,7 @@ TNode *TNode::GetNode(const char *name) const
    TObjLink *lnk = fNodes->FirstLink();
    while (lnk) {
       node = (TNode *)lnk->GetObject();
-      if (node->TestBit(kNotDeleted)) {
+      if (!ROOT::Detail::HasBeenDeleted(node)) {
          nodefound = node->GetNode(name);
          if (nodefound) return nodefound;
       }

--- a/gui/gui/src/TGFileBrowser.cxx
+++ b/gui/gui/src/TGFileBrowser.cxx
@@ -656,7 +656,7 @@ void TGFileBrowser::Update()
    TGListTreeItem *curr = fListTree->GetSelected(); // GetCurrent() ??
    if (curr) {
       TObject *obj = (TObject *) curr->GetUserData();
-      if (obj && !obj->TestBit(kNotDeleted)) {
+      if (obj && ROOT::Detail::HasBeenDeleted(obj)) {
          // if the item to be deleted has a filter,
          // delete its entry in the map
          if (CheckFiltered(curr))
@@ -665,7 +665,7 @@ void TGFileBrowser::Update()
          curr = 0;
          obj = 0;
       }
-      else if (obj && obj->TestBit(kNotDeleted) &&
+      else if (obj && !ROOT::Detail::HasBeenDeleted(obj) &&
                obj->InheritsFrom("TObjString") && curr->GetParent()) {
          fListTree->GetPathnameFromItem(curr->GetParent(), path);
          if (strlen(path) > 1) {

--- a/gui/gui/src/TGFrame.cxx
+++ b/gui/gui/src/TGFrame.cxx
@@ -1731,7 +1731,7 @@ Bool_t TGMainFrame::HandleClientMessage(Event_t *event)
    if ((event->fFormat == 32) && ((Atom_t)event->fUser[0] == gWM_DELETE_WINDOW) &&
        (event->fHandle != gROOT_MESSAGE)) {
       Emit("CloseWindow()");
-      if (TestBit(kNotDeleted) && !TestBit(kDontCallClose))
+      if (!ROOT::Detail::HasBeenDeleted(this) && !TestBit(kDontCallClose))
          CloseWindow();
    }
    return kTRUE;

--- a/gui/gui/src/TGMdiMainFrame.cxx
+++ b/gui/gui/src/TGMdiMainFrame.cxx
@@ -963,7 +963,7 @@ Int_t TGMdiMainFrame::Close(TGMdiFrame *mdiframe)
    TGMdiDecorFrame *frame = GetDecorFrame(mdiframe);
    Restore(mdiframe);
    mdiframe->Emit("CloseWindow()");
-   if (frame && mdiframe->TestBit(kNotDeleted) && !mdiframe->TestBit(TGMdiFrame::kDontCallClose))
+   if (frame && !ROOT::Detail::HasBeenDeleted(mdiframe) && !mdiframe->TestBit(TGMdiFrame::kDontCallClose))
       return frame->CloseWindow();
    return kTRUE;
 }

--- a/gui/gui/src/TGTextEntry.cxx
+++ b/gui/gui/src/TGTextEntry.cxx
@@ -1229,7 +1229,7 @@ Bool_t TGTextEntry::HandleKey(Event_t* event)
    if ((EKeySym)keysym  == kKey_Enter || (EKeySym)keysym  == kKey_Return) {
 
       ReturnPressed();                                      // emit signal
-      if (!TestBit(kNotDeleted)) return kTRUE;
+      if (ROOT::Detail::HasBeenDeleted(this)) return kTRUE;
       fSelectionOn = kFALSE;
 
    } else if (event->fState & kKeyShiftMask && (EKeySym)keysym  == kKey_Backtab) {

--- a/hist/hist/src/TEfficiency.cxx
+++ b/hist/hist/src/TEfficiency.cxx
@@ -1033,7 +1033,7 @@ TEfficiency::~TEfficiency()
       TObject* obj = 0;
       while ((obj  = fFunctions->First())) {
          while(fFunctions->Remove(obj)) { }
-         if (!obj->TestBit(kNotDeleted)) {
+         if (ROOT::Detail::HasBeenDeleted(obj)) {
             break;
          }
          delete obj;

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -623,7 +623,7 @@ TH1::TH1(): TNamed(), TAttLine(), TAttFill(), TAttMarker()
 
 TH1::~TH1()
 {
-   if (!TestBit(kNotDeleted)) {
+   if (ROOT::Detail::HasBeenDeleted(this)) {
       return;
    }
    delete[] fIntegral;
@@ -644,7 +644,7 @@ TH1::~TH1()
       //and may have been already deleted.
       while ((obj  = fFunctions->First())) {
          while(fFunctions->Remove(obj)) { }
-         if (!obj->TestBit(kNotDeleted)) {
+         if (ROOT::Detail::HasBeenDeleted(obj)) {
             break;
          }
          delete obj;

--- a/net/net/src/TApplicationServer.cxx
+++ b/net/net/src/TApplicationServer.cxx
@@ -896,7 +896,7 @@ Int_t TApplicationServer::SendCanvases()
       while (lnk) {
          TObject *sc = lnk->GetObject();
          lnk = lnk->Next();
-         if ((sc->TestBit(kNotDeleted)) && sc == o)
+         if ((!ROOT::Detail::HasBeenDeleted(sc)) && sc == o)
             sentalready = kTRUE;
       }
       if (!sentalready) {

--- a/tutorials/net/spyserv.C
+++ b/tutorials/net/spyserv.C
@@ -133,7 +133,7 @@ SpyServ::SpyServ()
          TSocket *s;
          if ((s = fMon->Select(20)) != (TSocket*)-1)
             HandleSocket(s);
-         if (!fCanvas->TestBit(TObject::kNotDeleted))
+         if (ROOT::Detail::HasBeenDeleted(fCanvas))
             break;
          if (gROOT->IsInterrupted())
             break;


### PR DESCRIPTION
On some platform operator delete taints the memory, so even right after the deletion the information stored by ~TObject is already erased.  On those platform we no longer rely on the kNotDelete bit hack and rely on the system (which has tainted the memory assumingly for a reason) to detect the use-after-delete problems.

Introduce 2 new functions.

TObject::IsDestructed (used by TClonesArray) that detects that the destructor has been run and is active in all configuration.  This should be used if the code knows that the memory has not been freed/deleted.

ROOT::Detail::HasBeenDeleted(TObject*) with returns true if the platform does not taint the memory and if the kNotDeleted is not set (in all other case, it returns false)

This fixes #11330


