### PR TITLE
[DF] Warn and run, do not just warn in RunGraphs

### DIFF
--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -25,7 +25,7 @@ using ROOT::RDF::RResultHandle;
 void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
 {
    if (handles.empty()) {
-      Warning("RunGraphs", "Got an empty list of handles");
+      Warning("RunGraphs", "Got an empty list of handles, now quitting.");
       return;
    }
 
@@ -38,7 +38,6 @@ void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
    if (nNotRun < handles.size()) {
       Warning("RunGraphs", "Got %lu handles from which %lu link to results which are already ready.", handles.size(),
               handles.size() - nNotRun);
-      return;
    }
    if (nNotRun == 0)
       return;

--- a/tree/dataframe/test/dataframe_helpers.cxx
+++ b/tree/dataframe/test/dataframe_helpers.cxx
@@ -662,7 +662,7 @@ TEST(RunGraphs, EmptyListOfHandles)
    ROOT::EnableImplicitMT();
 #endif // R__USE_IMT
 
-   ROOT_EXPECT_WARNING(ROOT::RDF::RunGraphs({}), "RunGraphs", "Got an empty list of handles");
+   ROOT_EXPECT_WARNING(ROOT::RDF::RunGraphs({}), "RunGraphs", "Got an empty list of handles, now quitting.");
 }
 
 TEST(RunGraphs, AlreadyRun)


### PR DESCRIPTION
RunGraphs kindly warns the user if some of the results that were passed to it correspond to results that are already "ready" (i.e. for which the event loop has already run), since that is typically not the intended usage.

At that point it should not quit though: it should run the event loop for the results that still need running.

This patch fixes that.

@vepadulano afaict the distributed version does not check this at all?