### PR TITLE
[RF] Bring back accidentally removed RooEffProd default constructor

### DIFF
--- a/roofit/roofitcore/inc/RooEffProd.h
+++ b/roofit/roofitcore/inc/RooEffProd.h
@@ -13,13 +13,13 @@
 #define ROO_EFF_PROD
 
 #include "RooAbsPdf.h"
-#include "RooAbsReal.h"
 #include "RooRealProxy.h"
 #include "RooObjCacheManager.h"
 
 class RooEffProd: public RooAbsPdf {
 public:
   // Constructors, assignment etc
+  RooEffProd() {}
   RooEffProd(const char *name, const char *title, RooAbsPdf& pdf, RooAbsReal& efficiency);
   RooEffProd(const RooEffProd& other, const char* name=nullptr);
 

--- a/roofit/roofitcore/src/RooEffProd.cxx
+++ b/roofit/roofitcore/src/RooEffProd.cxx
@@ -23,8 +23,6 @@
 
 #include "RooEffProd.h"
 #include "RooEffGenContext.h"
-#include "RooNameReg.h"
-#include "RooRealVar.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In ROOT 6.26, the default constructor of the RooEffProd was accidentally removed. This commit is bringing it back, and it also needs to be backported to the 6.26 development branch.

Thanks to this forum post for noticing the problem: https://root-forum.cern.ch/t/trouble-with-rooworkspace-since-rooeffprod-default-constructor-is-deleted-in-v6-26/50577

