### PR TITLE
[tmva] Fix a TMVA tutorial  when Keras is not installed

### DIFF
--- a/tutorials/tmva/TMVA_RNN_Classification.py
+++ b/tutorials/tmva/TMVA_RNN_Classification.py
@@ -151,7 +151,7 @@ useTMVA_BDT = False
 
 tf_spec = importlib.util.find_spec("tensorflow")
 if tf_spec is None:
-    useKerasCNN = False
+    useKeras = False
     ROOT.Warning("TMVA_RNN_Classificaton","Skip using Keras since tensorflow is not installed")
 
 


### PR DESCRIPTION

This PR should fix TMVA_RNN_Classification.py tutorial failures seen in many CI node in the nightly builds

