### PR TITLE
Use `nullptr` instead of 0 and NULL in math classes headers

### DIFF
--- a/math/fftw/inc/TFFTComplex.h
+++ b/math/fftw/inc/TFFTComplex.h
@@ -51,7 +51,7 @@ public:
    Double_t   GetPointReal(const Int_t* /*ipoint*/, Bool_t /*fromInput=kFALSE*/) const override{return 0;}
    void       GetPointComplex(Int_t ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
    void       GetPointComplex(const Int_t *ipoint, Double_t &re, Double_t &im, Bool_t fromInput=kFALSE) const override;
-   Double_t*  GetPointsReal(Bool_t /*fromInput=kFALSE*/) const override {return 0;};
+   Double_t*  GetPointsReal(Bool_t /*fromInput=kFALSE*/) const override {return nullptr;};
    void       GetPointsComplex(Double_t *re, Double_t *im, Bool_t fromInput = kFALSE) const override ;
    void       GetPointsComplex(Double_t *data, Bool_t fromInput = kFALSE) const override ;
 

--- a/math/foam/inc/TFoamSampler.h
+++ b/math/foam/inc/TFoamSampler.h
@@ -102,7 +102,7 @@ public:
       divided by the bin width)
       By default do not do random sample, just return the function values
     */
-   bool SampleBin(double prob, double & value, double *error = 0) override;
+   bool SampleBin(double prob, double & value, double *error = nullptr) override;
 
 
 

--- a/math/fumili/inc/TFumiliMinimizer.h
+++ b/math/fumili/inc/TFumiliMinimizer.h
@@ -108,7 +108,7 @@ public:
    const double *  X() const override { return &fParams.front(); }
 
    /// return pointer to gradient values at the minimum
-   const double *  MinGradient() const override { return 0; } // not available
+   const double *  MinGradient() const override { return nullptr; } // not available
 
    /// number of function calls to reach the minimum
    unsigned int NCalls() const override { return 0; }

--- a/math/mathcore/inc/Fit/FcnAdapter.h
+++ b/math/mathcore/inc/Fit/FcnAdapter.h
@@ -49,7 +49,7 @@ private:
       double fval = 0;
       int dim = fDim;
       // call with flag 4
-      fFCN(dim, 0, fval, const_cast<double *>(x), 4);
+      fFCN(dim, nullptr, fval, const_cast<double *>(x), 4);
       return fval;
    }
 
@@ -57,7 +57,6 @@ private:
 
    unsigned int fDim;
    void (*fFCN)(int&, double*, double&, double*, int);
-
 
 };
 

--- a/math/mathcore/inc/Fit/FitConfig.h
+++ b/math/mathcore/inc/Fit/FitConfig.h
@@ -111,7 +111,7 @@ public:
       // set the parameters values from the function
       unsigned int npar = func.NPar();
       const double *begin = func.Parameters();
-      if (begin == 0) {
+      if (!begin) {
          fSettings = std::vector<ParameterSettings>(npar);
          return;
       }
@@ -137,12 +137,12 @@ public:
    /**
       set the parameter settings from number of parameters and a vector of values and optionally step values. If there are not existing or number of parameters does not match existing one, create a new parameter setting list.
    */
-   void SetParamsSettings(unsigned int npar, const double * params, const double * vstep = 0);
+   void SetParamsSettings(unsigned int npar, const double * params, const double * vstep = nullptr);
 
    /*
      Set the parameter settings from a vector of parameter settings
    */
-   void SetParamsSettings (const std::vector<ROOT::Fit::ParameterSettings>& pars ) {
+   void SetParamsSettings (const std::vector<ROOT::Fit::ParameterSettings>& pars) {
       fSettings = pars;
    }
 
@@ -178,7 +178,7 @@ public:
    /**
       set minimizer type
    */
-   void SetMinimizer(const char * type, const char * algo = 0) {
+   void SetMinimizer(const char *type, const char *algo = nullptr) {
       if (type) fMinimizerOpts.SetMinimizerType(type);
       if (algo) fMinimizerOpts.SetMinimizerAlgorithm(algo);
    }
@@ -248,7 +248,7 @@ public:
    /**
       static function to control default minimizer type and algorithm
    */
-   static void SetDefaultMinimizer(const char * type, const char * algo = 0);
+   static void SetDefaultMinimizer(const char *type, const char *algo = nullptr);
 
 
 

--- a/math/mathcore/inc/Fit/FitResult.h
+++ b/math/mathcore/inc/Fit/FitResult.h
@@ -76,7 +76,7 @@ public:
       Run also Minos if requested from the configuration
     */
    void FillResult(const std::shared_ptr<ROOT::Math::Minimizer> & min, const FitConfig & fconfig,  const std::shared_ptr<IModelFunction> & f,
-              bool isValid, unsigned int sizeOfData = 0, bool binFit = true, const ROOT::Math::IMultiGenFunction * chi2func = 0, unsigned int ncalls = 0);
+              bool isValid, unsigned int sizeOfData = 0, bool binFit = true, const ROOT::Math::IMultiGenFunction *chi2func = nullptr, unsigned int ncalls = 0);
 
 
    /**
@@ -159,7 +159,7 @@ public:
    /// parameter errors (return st::vector)
    const std::vector<double> & Errors() const { return fErrors; }
    /// parameter errors (return const pointer)
-   const double * GetErrors() const { return (fErrors.empty()) ? 0 : &fErrors.front(); }
+   const double * GetErrors() const { return fErrors.empty() ? nullptr : &fErrors.front(); }
 
    /// parameter values (return std::vector)
    const std::vector<double> & Parameters() const { return fParams; }

--- a/math/mathcore/inc/Fit/FitUtil.h
+++ b/math/mathcore/inc/Fit/FitUtil.h
@@ -130,7 +130,7 @@ namespace FitUtil {
   public:
      IntegralEvaluator(const ParamFunc &func, const double *p, bool useIntegral = true,
                        ROOT::Math::IntegrationOneDim::Type igType = ROOT::Math::IntegrationOneDim::kDEFAULT)
-        : fDim(0), fParams(0), fFunc(0), fIg1Dim(0), fIgNDim(0), fFunc1Dim(0), fFuncNDim(0)
+        : fDim(0), fParams(nullptr), fFunc(nullptr), fIg1Dim(nullptr), fIgNDim(nullptr), fFunc1Dim(nullptr), fFuncNDim(nullptr)
      {
         if (useIntegral) {
            SetFunction(func, p, igType);
@@ -147,7 +147,7 @@ namespace FitUtil {
         // copy the function object to be able to modify the parameters
         // fFunc = dynamic_cast<ROOT::Math::IParamMultiFunction *>( func.Clone() );
         fFunc = &func;
-        assert(fFunc != 0);
+        assert(fFunc != nullptr);
         // set parameters in function
         // fFunc->SetParameters(p);
         if (fDim == 1) {
@@ -335,7 +335,7 @@ namespace FitUtil {
       is used
   */
   double EvaluateChi2Residual(const IModelFunction &func, const BinData &data, const double *p, unsigned int ipoint,
-                              double *g = 0, bool hasGrad = false);
+                              double *g = nullptr, bool hasGrad = false);
 
   /**
       evaluate the pdf contribution to the LogL given a model function and the BinPoint data.
@@ -344,7 +344,7 @@ namespace FitUtil {
       is used
   */
   double
-  EvaluatePdf(const IModelFunction &func, const UnBinData &data, const double *p, unsigned int ipoint, double *g = 0, bool hasGrad = false);
+  EvaluatePdf(const IModelFunction &func, const UnBinData &data, const double *p, unsigned int ipoint, double *g = nullptr, bool hasGrad = false);
 
 #ifdef R__HAS_VECCORE
    template <class NotCompileIfScalarBackend = std::enable_if<!(std::is_same<double, ROOT::Double_v>::value)>>
@@ -365,7 +365,7 @@ namespace FitUtil {
        If the function provides parameter derivatives they are used otherwise a simple derivative calculation
        is used
    */
-   double EvaluatePoissonBinPdf(const IModelFunction & func, const BinData & data, const double * x, unsigned int ipoint, double * g = 0, bool hasGrad = false);
+   double EvaluatePoissonBinPdf(const IModelFunction & func, const BinData & data, const double * x, unsigned int ipoint, double * g = nullptr, bool hasGrad = false);
 
    unsigned setAutomaticChunking(unsigned nEvents);
 
@@ -1429,7 +1429,7 @@ namespace FitUtil {
       {
          FitUtil::EvaluateChi2Gradient(func, data, p, g, nPoints, executionPolicy, nChunks);
       }
-      static double EvalChi2Residual(const IModelFunctionTempl<double> &func, const BinData & data, const double * p, unsigned int i, double *g = 0, bool hasGrad=false)
+      static double EvalChi2Residual(const IModelFunctionTempl<double> &func, const BinData & data, const double * p, unsigned int i, double *g = nullptr, bool hasGrad=false)
       {
          return FitUtil::EvaluateChi2Residual(func, data, p, i, g, hasGrad);
       }

--- a/math/mathcore/inc/Fit/Fitter.h
+++ b/math/mathcore/inc/Fit/Fitter.h
@@ -282,20 +282,20 @@ public:
       Note that passing a params != 0 will set the parameter settings to the new value AND also the
       step sizes to some pre-defined value (stepsize = 0.3 * abs(parameter_value) )
     */
-   bool FitFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Fit using a FitMethodFunction interface. Same as method above, but now extra information
        can be taken from the function class
    */
-   bool FitFCN(const ROOT::Math::FitMethodFunction & fcn, const double * params = 0);
+   bool FitFCN(const ROOT::Math::FitMethodFunction & fcn, const double *params = nullptr);
 
    /**
       Set the FCN function represented by a multi-dimensional function interface
       (ROOT::Math::IMultiGenFunction) and optionally the initial parameters
       See also note above for the initial parameters for FitFCN
     */
-   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
       Set the FCN function represented by a multi-dimensional function interface
@@ -304,14 +304,14 @@ public:
       With this interface we pass in addition a ModelFunction that will be attached to the FitResult and
       used to compute confidence interval of the fit
    */
-   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const IModelFunction & func, const double *params = 0,
+   bool SetFCN(const ROOT::Math::IMultiGenFunction &fcn, const IModelFunction & func, const double *params = nullptr,
                unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Set the objective function (FCN)  using a FitMethodFunction interface.
        Same as method above, but now extra information can be taken from the function class
    */
-   bool SetFCN(const ROOT::Math::FitMethodFunction & fcn, const double * params = 0);
+   bool SetFCN(const ROOT::Math::FitMethodFunction & fcn, const double *params = nullptr);
 
    /**
       Fit using the given FCN function representing a multi-dimensional gradient function
@@ -319,20 +319,20 @@ public:
       gradient information provided by the function.
       For the options same consideration as in the previous method
     */
-   bool FitFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Fit using a FitMethodGradFunction interface. Same as method above, but now extra information
        can be taken from the function class
    */
-   bool FitFCN(const ROOT::Math::FitMethodGradFunction & fcn, const double * params = 0);
+   bool FitFCN(const ROOT::Math::FitMethodGradFunction & fcn, const double *params = nullptr);
 
    /**
       Set the FCN function represented by a multi-dimensional gradient function interface
       (ROOT::Math::IMultiGradFunction) and optionally the initial parameters
       See also note above for the initial parameters for FitFCN
     */
-   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
       Set the FCN function represented by a multi-dimensional gradient function interface
@@ -341,14 +341,14 @@ public:
       With this interface we pass in addition a ModelFunction that will be attached to the FitResult and
       used to compute confidence interval of the fit
    */
-   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const IModelFunction &func, const double *params = 0,
+   bool SetFCN(const ROOT::Math::IMultiGradFunction &fcn, const IModelFunction &func, const double *params = nullptr,
                unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
        Set the objective function (FCN)  using a FitMethodGradFunction interface.
        Same as method above, but now extra information can be taken from the function class
    */
-   bool SetFCN(const ROOT::Math::FitMethodGradFunction & fcn, const double * params = 0);
+   bool SetFCN(const ROOT::Math::FitMethodGradFunction & fcn, const double *params = nullptr);
 
 
    /**
@@ -357,14 +357,14 @@ public:
       For the options same consideration as in the previous method
     */
    typedef  void (* MinuitFCN_t )(int &npar, double *gin, double &f, double *u, int flag);
-   bool FitFCN( MinuitFCN_t fcn, int npar = 0, const double * params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool FitFCN( MinuitFCN_t fcn, int npar = 0, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
       set objective function using user provided FCN with Minuit-like interface
       If npar = 0 it is assumed that the parameters are specified in the parameter settings created before
       For the options same consideration as in the previous method
     */
-   bool SetFCN( MinuitFCN_t fcn, int npar = 0, const double * params = 0, unsigned int dataSize = 0, bool chi2fit = false);
+   bool SetFCN( MinuitFCN_t fcn, int npar = 0, const double *params = nullptr, unsigned int dataSize = 0, bool chi2fit = false);
 
    /**
       Perform a fit with the previously set FCN function. Require SetFCN before

--- a/math/mathcore/inc/Math/BasicMinimizer.h
+++ b/math/mathcore/inc/Math/BasicMinimizer.h
@@ -166,7 +166,7 @@ protected:
 
    bool CheckObjFunction() const;
 
-   MinimTransformFunction * CreateTransformation(std::vector<double> & startValues, const ROOT::Math::IMultiGradFunction * func = 0);
+   MinimTransformFunction * CreateTransformation(std::vector<double> & startValues, const ROOT::Math::IMultiGradFunction * func = nullptr);
 
    void SetFinalValues(const double * x, const MinimTransformFunction * func = nullptr);
 

--- a/math/mathcore/inc/Math/DistSampler.h
+++ b/math/mathcore/inc/Math/DistSampler.h
@@ -59,7 +59,7 @@ class DistSampler {
 public:
 
    /// default constructor
-   DistSampler() : fOwnFunc(false), fRange(0), fFunc(0) {}
+   DistSampler() : fOwnFunc(false), fRange(nullptr), fFunc(nullptr) {}
 
 
    /// virtual destructor
@@ -129,7 +129,7 @@ public:
       To be implemented by the derived classes who needs it
       Returns zero by default
     */
-   virtual TRandom * GetRandom() { return 0; }
+   virtual TRandom * GetRandom() { return nullptr; }
 
    /// Set the range in a given dimension.
    void SetRange(double xmin, double xmax, int icoord = 0);
@@ -209,7 +209,7 @@ public:
       By default do not do random sample, just return the function values
       Typically Poisson statistics will be used
     */
-   virtual bool SampleBin(double prob, double & value, double * error = 0) {
+   virtual bool SampleBin(double prob, double & value, double * error = nullptr) {
       value = prob;
       if (error) *error = 0;
       return true;
@@ -220,7 +220,7 @@ public:
       will be equal to the total number of events to be generated
       For sampling the bins independently, SampleBin should be used
     */
-   virtual bool SampleBins(unsigned int n, const double * prob, double * values, double * errors  = 0)  {
+   virtual bool SampleBins(unsigned int n, const double * prob, double * values, double * errors  = nullptr)  {
       std::copy(prob,prob+n, values); // default impl returns prob values (Asimov data)
       if (errors) std::fill(errors,errors+n,0);
       return true;

--- a/math/mathcore/inc/Math/FitMethodFunction.h
+++ b/math/mathcore/inc/Math/FitMethodFunction.h
@@ -66,7 +66,7 @@ public:
       likelihood functions.
       Estimating eventually also the gradient of the data element if the passed pointer  is not null
     */
-   virtual double DataElement(const double *x, unsigned int i, double *g = 0) const = 0;
+   virtual double DataElement(const double *x, unsigned int i, double *g = nullptr) const = 0;
 
 
    /**

--- a/math/mathcore/inc/Math/GenAlgoOptions.h
+++ b/math/mathcore/inc/Math/GenAlgoOptions.h
@@ -143,7 +143,7 @@ private:
       typename M::const_iterator pos;
       pos = opts.find(name);
       if (pos == opts.end()) {
-         return 0;
+         return nullptr;
       }
       return  &((*pos).second);
    }

--- a/math/mathcore/inc/Math/Integrator.h
+++ b/math/mathcore/inc/Math/Integrator.h
@@ -121,7 +121,7 @@ public:
     */
     explicit
     IntegratorOneDim(IntegrationOneDim::Type type = IntegrationOneDim::kDEFAULT, double absTol = -1, double relTol = -1, unsigned int size = 0, unsigned int rule = 0) :
-       fIntegrator(0), fFunc(0)
+       fIntegrator(nullptr), fFunc(nullptr)
    {
       fIntegrator = CreateIntegrator(type, absTol, relTol, size, rule);
    }
@@ -140,7 +140,7 @@ public:
     */
    explicit
    IntegratorOneDim(const IGenFunction &f, IntegrationOneDim::Type type = IntegrationOneDim::kDEFAULT, double absTol = -1, double relTol = -1, unsigned int size = 0, int rule = 0) :
-      fIntegrator(0), fFunc(0)
+      fIntegrator(nullptr), fFunc(nullptr)
    {
       fIntegrator = CreateIntegrator(type, absTol, relTol, size, rule);
       SetFunction(f,true);
@@ -163,7 +163,7 @@ public:
    template<class Function>
    explicit
    IntegratorOneDim(Function & f, IntegrationOneDim::Type type = IntegrationOneDim::kDEFAULT, double absTol = -1, double relTol = -1, unsigned int size = 0, int rule = 0) :
-      fIntegrator(0), fFunc(0)
+      fIntegrator(nullptr), fFunc(nullptr)
    {
       fIntegrator = CreateIntegrator(type, absTol, relTol, size, rule);
       SetFunction(f);
@@ -178,7 +178,7 @@ public:
    // disable copy constructor and assignment operator
 
 private:
-   IntegratorOneDim(const IntegratorOneDim &) : fIntegrator(0), fFunc(0) {}
+   IntegratorOneDim(const IntegratorOneDim &) : fIntegrator(nullptr), fFunc(nullptr) {}
    IntegratorOneDim & operator=(const IntegratorOneDim &) { return *this; }
 
 public:
@@ -353,7 +353,7 @@ public:
    */
 
    double Integral(double a, double b) {
-      return fIntegrator == 0 ? 0 : fIntegrator->Integral(a,b);
+      return !fIntegrator ? 0 : fIntegrator->Integral(a,b);
    }
 
 
@@ -362,7 +362,7 @@ public:
    */
 
    double Integral( ) {
-      return fIntegrator == 0 ? 0 : fIntegrator->Integral();
+      return !fIntegrator ? 0 : fIntegrator->Integral();
    }
 
    /**
@@ -370,7 +370,7 @@ public:
       @param a lower value of the integration interval
    */
    double IntegralUp(double a ) {
-      return fIntegrator == 0 ? 0 : fIntegrator->IntegralUp(a);
+      return !fIntegrator ? 0 : fIntegrator->IntegralUp(a);
    }
 
    /**
@@ -378,7 +378,7 @@ public:
       @param b upper value of the integration interval
    */
    double IntegralLow( double b ) {
-      return fIntegrator == 0 ? 0 : fIntegrator->IntegralLow(b);
+      return !fIntegrator ? 0 : fIntegrator->IntegralLow(b);
    }
    /**
        define operator() for IntegralLow
@@ -394,7 +394,7 @@ public:
 
    */
    double Integral( const std::vector<double> & pts) {
-      return fIntegrator == 0 ? 0 : fIntegrator->Integral(pts);
+      return !fIntegrator ? 0 : fIntegrator->Integral(pts);
    }
 
    /**
@@ -402,29 +402,29 @@ public:
 
    */
    double IntegralCauchy(double a, double b, double c) {
-      return fIntegrator == 0 ? 0 : fIntegrator->IntegralCauchy(a,b,c);
+      return !fIntegrator ? 0 : fIntegrator->IntegralCauchy(a,b,c);
    }
 
    /**
       return  the Result of the last Integral calculation
    */
-   double Result() const { return fIntegrator == 0 ? 0 : fIntegrator->Result(); }
+   double Result() const { return !fIntegrator ? 0 : fIntegrator->Result(); }
 
    /**
       return the estimate of the absolute Error of the last Integral calculation
    */
-   double Error() const { return fIntegrator == 0 ? 0 : fIntegrator->Error(); }
+   double Error() const { return !fIntegrator ? 0 : fIntegrator->Error(); }
 
    /**
       return the Error Status of the last Integral calculation
    */
-   int Status() const { return fIntegrator == 0 ? -1 : fIntegrator->Status(); }
+   int Status() const { return !fIntegrator ? -1 : fIntegrator->Status(); }
 
    /**
       return number of function evaluations in calculating the integral
       (if integrator do not implement this function returns -1)
    */
-   int NEval() const { return fIntegrator == 0 ? -1 : fIntegrator->NEval(); }
+   int NEval() const { return !fIntegrator ? -1 : fIntegrator->NEval(); }
 
 
    // setter for control Parameters  (getters are not needed so far )

--- a/math/mathcore/inc/Math/IntegratorMultiDim.h
+++ b/math/mathcore/inc/Math/IntegratorMultiDim.h
@@ -66,7 +66,7 @@ public:
     */
    explicit
    IntegratorMultiDim(IntegrationMultiDim::Type type = IntegrationMultiDim::kDEFAULT, double absTol = -1, double relTol = -1, unsigned int ncall = 0) :
-      fIntegrator(0)
+      fIntegrator(nullptr)
    {
        fIntegrator = CreateIntegrator(type, absTol, relTol, ncall);
    }
@@ -81,7 +81,7 @@ public:
     */
    explicit
    IntegratorMultiDim(const IMultiGenFunction &f, IntegrationMultiDim::Type type = IntegrationMultiDim::kDEFAULT, double absTol = -1, double relTol = -1, unsigned int ncall = 0) :
-      fIntegrator(0)
+      fIntegrator(nullptr)
    {
       fIntegrator = CreateIntegrator(type, absTol, relTol, ncall);
       SetFunction(f);
@@ -114,7 +114,7 @@ public:
    // disable copy constructor and assignment operator
 
 private:
-   IntegratorMultiDim(const IntegratorMultiDim &) : fIntegrator(0), fFunc(nullptr) {}
+   IntegratorMultiDim(const IntegratorMultiDim &) : fIntegrator(nullptr), fFunc(nullptr) {}
    IntegratorMultiDim & operator=(const IntegratorMultiDim &) { return *this; }
 
 public:
@@ -124,7 +124,7 @@ public:
       evaluate the integral with the previously given function between xmin[] and xmax[]
    */
    double Integral(const double* xmin, const double * xmax) {
-      return fIntegrator == 0 ? 0 : fIntegrator->Integral(xmin,xmax);
+      return !fIntegrator ? 0 : fIntegrator->Integral(xmin,xmax);
    }
 
    /// evaluate the integral passing a new function
@@ -157,13 +157,13 @@ public:
    }
 
    /// return result of last integration
-   double Result() const { return fIntegrator == 0 ? 0 : fIntegrator->Result(); }
+   double Result() const { return !fIntegrator ? 0 : fIntegrator->Result(); }
 
    /// return integration error
-   double Error() const { return fIntegrator == 0 ? 0 : fIntegrator->Error(); }
+   double Error() const { return !fIntegrator ? 0 : fIntegrator->Error(); }
 
    ///  return the Error Status of the last Integral calculation
-   int Status() const { return fIntegrator == 0 ? -1 : fIntegrator->Status(); }
+   int Status() const { return !fIntegrator ? -1 : fIntegrator->Status(); }
 
    // return number of function evaluations in calculating the integral
    //unsigned int NEval() const { return fNEval; }
@@ -178,13 +178,13 @@ public:
    void SetOptions(const ROOT::Math::IntegratorMultiDimOptions & opt) { if (fIntegrator) fIntegrator->SetOptions(opt); }
 
    /// retrieve the options
-   ROOT::Math::IntegratorMultiDimOptions Options() const { return (fIntegrator) ? fIntegrator->Options() : IntegratorMultiDimOptions(); }
+   ROOT::Math::IntegratorMultiDimOptions Options() const { return fIntegrator ? fIntegrator->Options() : IntegratorMultiDimOptions(); }
 
    /// return a pointer to integrator object
    VirtualIntegratorMultiDim * GetIntegrator() { return fIntegrator; }
 
    /// return name of integrator
-   std::string Name() const { return (fIntegrator) ? Options().Integrator() : std::string(""); }
+   std::string Name() const { return fIntegrator ? Options().Integrator() : std::string(""); }
 
    /// static function to get the enumeration from a string
    static IntegrationMultiDim::Type GetType(const char * name);

--- a/math/mathcore/inc/Math/IntegratorOptions.h
+++ b/math/mathcore/inc/Math/IntegratorOptions.h
@@ -117,7 +117,7 @@ public:
 
    /// constructor using the default options
    /// can pass a pointer to extra options (N.B. pointer will be managed by the class)
-   IntegratorOneDimOptions(IOptions * extraOpts = 0);
+   IntegratorOneDimOptions(IOptions * extraOpts = nullptr);
 
    ~IntegratorOneDimOptions() override {}
 
@@ -176,7 +176,7 @@ public:
    static ROOT::Math::IOptions * FindDefault(const char * name);
 
    /// print only the specified default options
-   static void PrintDefault(const char * name = 0, std::ostream & os = std::cout);
+   static void PrintDefault(const char * name = nullptr, std::ostream & os = std::cout);
 
 
 private:
@@ -198,7 +198,7 @@ public:
 
    /// constructor using the default options
    /// can pass a pointer to extra options (N.B. pointer will be managed by the class)
-   IntegratorMultiDimOptions(IOptions * extraOpts = 0);
+   IntegratorMultiDimOptions(IOptions * extraOpts = nullptr);
 
    ~IntegratorMultiDimOptions() override {}
 
@@ -255,7 +255,7 @@ public:
    static ROOT::Math::IOptions * FindDefault(const char * name);
 
    /// print only the specified default options
-   static void PrintDefault(const char * name = 0, std::ostream & os = std::cout);
+   static void PrintDefault(const char *name = nullptr, std::ostream & os = std::cout);
 
 
 private:

--- a/math/mathcore/inc/Math/MinimTransformFunction.h
+++ b/math/mathcore/inc/Math/MinimTransformFunction.h
@@ -69,7 +69,7 @@ public:
 
    /// clone:  not supported (since unique_ptr used in the fVariables)
    IMultiGenFunction * Clone() const override {
-      return 0;
+      return nullptr;
    }
 
 

--- a/math/mathcore/inc/Math/Minimizer.h
+++ b/math/mathcore/inc/Math/Minimizer.h
@@ -251,7 +251,7 @@ public:
    virtual double Edm() const { return -1; }
 
    /// return pointer to gradient values at the minimum
-   virtual const double *  MinGradient() const { return NULL; }
+   virtual const double *  MinGradient() const { return nullptr; }
 
    /// number of function calls to reach the minimum
    virtual unsigned int NCalls() const { return 0; }
@@ -272,7 +272,7 @@ public:
    virtual bool ProvidesError() const { return false; }
 
    /// return errors at the minimum
-   virtual const double * Errors() const { return NULL; }
+   virtual const double * Errors() const { return nullptr; }
 
    /** return covariance matrices element for variables ivar,jvar
        if the variable is fixed the return value is zero

--- a/math/mathcore/inc/Math/MinimizerOptions.h
+++ b/math/mathcore/inc/Math/MinimizerOptions.h
@@ -72,7 +72,7 @@ public:
    /// - GSLSimAn Simulated annealing minimizer from GSL (see ROOT::Math::GSLSimAnMinimizer). It is a stochastic minimization algorithm using only function values and not the gradient.
    /// - Genetic Genetic minimization algorithms (see TMVA::Genetic)
    ///
-   static void SetDefaultMinimizer(const char * type, const char * algo = 0);
+   static void SetDefaultMinimizer(const char *type, const char *algo = nullptr);
 
    /// Set the default level for computing the parameter errors.
    /// For example for 1-sigma parameter errors
@@ -80,7 +80,7 @@ public:
    ///  - up = 0.5 for a negative log-likelihood function
    ///
    /// The value will be used also by Minos when computing the confidence interval
-   static void SetDefaultErrorDef( double up);
+   static void SetDefaultErrorDef(double up);
 
    /// Set the Minimization tolerance.
    /// The Default value for Minuit and Minuit2 is 0.01
@@ -151,7 +151,7 @@ public:
    static ROOT::Math::IOptions * FindDefault(const char * name);
 
    /// Print all the default options including the extra one specific for a given minimizer name.
-   /// If no minimizer name is given, all the extra default options, which have been set and configured will be printed 
+   /// If no minimizer name is given, all the extra default options, which have been set and configured will be printed
    static void PrintDefault(const char * name = nullptr, std::ostream & os = std::cout);
 
 public:

--- a/math/mathcore/inc/Math/MultiDimParamFunctionAdapter.h
+++ b/math/mathcore/inc/Math/MultiDimParamFunctionAdapter.h
@@ -72,7 +72,7 @@ namespace ROOT {
             BaseFunc(),
             IParamMultiFunction(),
             fOwn(rhs.fOwn),
-            fFunc(0)
+            fFunc(nullptr)
          {
             if (fOwn)
                fFunc = dynamic_cast<IParamFunction *>((rhs.fFunc)->Clone());
@@ -83,7 +83,7 @@ namespace ROOT {
          */
          ~MultiDimParamFunctionAdapter() override
          {
-            if (fOwn && fFunc != 0) delete fFunc;
+            if (fOwn && fFunc) delete fFunc;
          }
 
 
@@ -214,7 +214,7 @@ namespace ROOT {
          */
          ~MultiDimParamGradFunctionAdapter() override
          {
-            if (fOwn && fFunc != 0) delete fFunc;
+            if (fOwn && fFunc) delete fFunc;
          }
 
 

--- a/math/mathcore/inc/Math/OneDimFunctionAdapter.h
+++ b/math/mathcore/inc/Math/OneDimFunctionAdapter.h
@@ -28,14 +28,14 @@ namespace Math {
 template<class MultiFuncType>
 struct EvaluatorOneDim {
    // evaluate function (in general case no param)
-   static double F (MultiFuncType f, const double * x, const double *  = 0 ) {
+   static double F (MultiFuncType f, const double * x, const double *  = nullptr ) {
       return f( x );
    }
 };
 // specialized for param functions
 template<>
 struct EvaluatorOneDim< const ROOT::Math::IParamMultiFunction &> {
-   static double F ( const ROOT::Math::IParamMultiFunction &  f, const double * x, const double * p = 0 ) {
+   static double F ( const ROOT::Math::IParamMultiFunction &  f, const double * x, const double * p = nullptr ) {
       return f( x, p );
    }
 };
@@ -62,7 +62,7 @@ public:
       Constructor from the function object , pointer to an external array of x values
       and coordinate we want to adapt
    */
-   OneDimMultiFunctionAdapter (MultiFuncType f, const double * x, unsigned int icoord =0, const double * p = 0 ) :
+   OneDimMultiFunctionAdapter (MultiFuncType f, const double * x, unsigned int icoord = 0, const double * p = nullptr ) :
       fFunc(f),
       fX( const_cast<double *>(x) ), // wee need to modify x but then we restore it as before
       fParams(p),
@@ -70,7 +70,7 @@ public:
       fDim(0),
       fOwn(false)
    {
-      assert(fX != 0);
+      assert(fX != nullptr);
    }
    /**
       Constructor from the function object , dimension of the function and
@@ -78,9 +78,9 @@ public:
       The coordinate cached vector is created inside and eventually the values must be passed
       later with the SetX which will copy them
    */
-   OneDimMultiFunctionAdapter (MultiFuncType f, unsigned int dim = 1, unsigned int icoord =0, const double * p = 0 ) :
+   OneDimMultiFunctionAdapter (MultiFuncType f, unsigned int dim = 1, unsigned int icoord = 0, const double *p = nullptr) :
       fFunc(f),
-      fX(0 ),
+      fX(nullptr),
       fParams(p),
       fCoord(icoord),
       fDim(dim),
@@ -224,8 +224,8 @@ public:
       fParams(p),
       fIpar(ipar)
    {
-      assert(fX != 0);
-      assert(fParams != 0);
+      assert(fX != nullptr);
+      assert(fParams != nullptr);
    }
 
    /**
@@ -267,8 +267,6 @@ private:
    unsigned int fIpar;
 
 };
-
-
 
 
 } // end namespace Math

--- a/math/mathcore/inc/Math/ParamFunctor.h
+++ b/math/mathcore/inc/Math/ParamFunctor.h
@@ -282,7 +282,7 @@ public:
    /**
       Default constructor
    */
-   ParamFunctorTempl ()  : fImpl(0) {}
+   ParamFunctorTempl ()  : fImpl(nullptr) {}
 
 
    /**
@@ -329,11 +329,11 @@ public:
       Copy constructor
    */
    ParamFunctorTempl(const ParamFunctorTempl & rhs) :
-      fImpl(0)
+      fImpl(nullptr)
    {
 //       if (rhs.fImpl.get() != 0)
 //          fImpl = std::unique_ptr<Impl>( (rhs.fImpl)->Clone() );
-      if (rhs.fImpl != 0)  fImpl = rhs.fImpl->Clone();
+      if (rhs.fImpl)  fImpl = rhs.fImpl->Clone();
    }
 
    /**
@@ -348,8 +348,8 @@ public:
 
       if(this != &rhs) {
          if (fImpl) delete fImpl;
-         fImpl = 0;
-         if (rhs.fImpl != 0)
+         fImpl = nullptr;
+         if (rhs.fImpl)
             fImpl = rhs.fImpl->Clone();
       }
       return *this;
@@ -367,7 +367,7 @@ public:
    }
 
 
-   bool Empty() const { return fImpl == 0; }
+   bool Empty() const { return !fImpl; }
 
 
    void SetFunction(Impl * f) {

--- a/math/mathcore/inc/Math/RandomFunctions.h
+++ b/math/mathcore/inc/Math/RandomFunctions.h
@@ -72,7 +72,7 @@ namespace Math {
    public:
 
       /// class constructor
-      RandomFunctionsImpl() : fBaseEngine(0) {}
+      RandomFunctionsImpl() : fBaseEngine(nullptr) {}
 
       void SetEngine(void *r) {
          fBaseEngine = static_cast<TRandomEngine*>(r);

--- a/math/mathcore/inc/Math/TDataPointN.icc
+++ b/math/mathcore/inc/Math/TDataPointN.icc
@@ -28,7 +28,7 @@ namespace Math
 //______________________________________________________________________________
 template<typename _val_type>
 TDataPointN<_val_type>::TDataPointN():
-   m_vCoordinates(0),
+   m_vCoordinates(nullptr),
    m_fWeight(1)
 {
    m_vCoordinates = new _val_type[kDimension];

--- a/math/mathcore/inc/Math/WrappedParamFunction.h
+++ b/math/mathcore/inc/Math/WrappedParamFunction.h
@@ -46,12 +46,12 @@ public:
       Constructor a wrapped function from a pointer to a callable object, the function dimension and number of parameters
       which are set to zero by default
    */
-   WrappedParamFunction (FuncPtr  func, unsigned int dim = 1, unsigned int npar = 0, double * par = 0) :
+   WrappedParamFunction (FuncPtr  func, unsigned int dim = 1, unsigned int npar = 0, double * par = nullptr) :
       fFunc(func),
       fDim(dim),
       fParams(std::vector<double>(npar) )
    {
-      if (par != 0) std::copy(par,par+npar,fParams.begin() );
+      if (par) std::copy(par, par+npar, fParams.begin());
    }
 
 //    /**

--- a/math/mathcore/inc/TKDTree.h
+++ b/math/mathcore/inc/TKDTree.h
@@ -58,7 +58,7 @@ public:
    Value   KOrdStat(Index ntotal, Value *a, Index k, Index *index) const;
 
 
-   void    MakeBoundaries(Value *range = 0x0);
+   void    MakeBoundaries(Value *range = nullptr);
    void    MakeBoundariesExact();
    void    SetData(Index npoints, Index ndim, UInt_t bsize, Value **data);
    Int_t   SetData(Index idim, Value *data);

--- a/math/mathcore/inc/TMath.h
+++ b/math/mathcore/inc/TMath.h
@@ -454,7 +454,7 @@ struct Limits {
 
    //Sample quantiles
    void      Quantiles(Int_t n, Int_t nprob, Double_t *x, Double_t *quantiles, Double_t *prob,
-                       Bool_t isSorted=kTRUE, Int_t *index = 0, Int_t type=7);
+                       Bool_t isSorted=kTRUE, Int_t *index = nullptr, Int_t type=7);
 
    // IsInside
    template <typename T> Bool_t IsInside(T xp, T yp, Int_t np, T *x, T *y);

--- a/math/mathmore/inc/Math/Derivator.h
+++ b/math/mathmore/inc/Math/Derivator.h
@@ -82,7 +82,7 @@ public:
        @param p :  pointer to the object carrying the function state
                     (for example the function object itself)
     */
-   explicit Derivator(const GSLFuncPointer &f, void * p = 0);
+   explicit Derivator(const GSLFuncPointer &f, void * p = nullptr);
 
    /// destructor
    virtual ~Derivator();
@@ -123,7 +123,7 @@ public:
        @param p :  pointer to the object carrying the function state
                     (for example the function object itself)
    */
-   void SetFunction( const GSLFuncPointer &f, void * p = 0);
+   void SetFunction( const GSLFuncPointer &f, void * p = nullptr);
 
 
 

--- a/math/mathmore/inc/Math/GSLIntegrator.h
+++ b/math/mathmore/inc/Math/GSLIntegrator.h
@@ -172,7 +172,7 @@ namespace Math {
       /**
          Set function from a GSL pointer function type
        */
-      void SetFunction( GSLFuncPointer f, void * p = 0);
+      void SetFunction( GSLFuncPointer f, void * p = nullptr);
 
       // methods using IGenFunction
 

--- a/math/mathmore/inc/Math/GSLMCIntegrator.h
+++ b/math/mathmore/inc/Math/GSLMCIntegrator.h
@@ -140,7 +140,7 @@ public:
 
       typedef double ( * GSLMonteFuncPointer ) ( double *, size_t, void *);
 
-      void SetFunction( GSLMonteFuncPointer f, unsigned int dim, void * p = 0 );
+      void SetFunction( GSLMonteFuncPointer f, unsigned int dim, void * p = nullptr );
 
       // methods using GSLMonteFuncPointer
 
@@ -153,7 +153,7 @@ public:
        @param p pointer to parameter array
        */
 
-      double Integral(const GSLMonteFuncPointer & f, unsigned int dim, double* a, double* b, void * p = 0);
+      double Integral(const GSLMonteFuncPointer & f, unsigned int dim, double* a, double* b, void * p = nullptr);
 
 
       /**

--- a/math/mathmore/inc/Math/GSLMinimizer.h
+++ b/math/mathmore/inc/Math/GSLMinimizer.h
@@ -138,9 +138,7 @@ public:
    bool ProvidesError() const override { return false; }
 
    /// return errors at the minimum
-   const double * Errors() const override {
-      return 0;
-   }
+   const double * Errors() const override { return nullptr; }
 
    /** return covariance matrices elements
        if the variable is fixed the matrix is zero

--- a/math/mathmore/inc/Math/GSLMultiRootFinder.h
+++ b/math/mathmore/inc/Math/GSLMultiRootFinder.h
@@ -44,8 +44,8 @@ namespace Math {
 
    class GSLMultiRootBaseSolver;
 
-   /** @defgroup MultiRoot  Multidimensional ROOT finding 
-       Classes for finding the roots of a multi-dimensional system. 
+   /** @defgroup MultiRoot  Multidimensional ROOT finding
+       Classes for finding the roots of a multi-dimensional system.
        @ingroup NumAlgo
    */
 
@@ -133,7 +133,7 @@ namespace Math {
       after having remived the GSL prefix (gsl_multiroot_fsolver).
       Default algorithm  is "hybrids" (without derivative).
     */
-    GSLMultiRootFinder(const char * name = 0);
+    GSLMultiRootFinder(const char * name = nullptr);
 
     /// destructor
     virtual ~GSLMultiRootFinder();

--- a/math/mathmore/inc/Math/GSLNLSMinimizer.h
+++ b/math/mathmore/inc/Math/GSLNLSMinimizer.h
@@ -117,7 +117,7 @@ public:
    bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   const double * Errors() const override { return (fErrors.size() > 0) ? &fErrors.front() : 0; }
+   const double * Errors() const override { return (fErrors.size() > 0) ? &fErrors.front() : nullptr; }
 //  {
 //       static std::vector<double> err;
 //       err.resize(fDim);

--- a/math/mathmore/inc/Math/GSLSimAnnealing.h
+++ b/math/mathmore/inc/Math/GSLSimAnnealing.h
@@ -68,18 +68,18 @@ protected:
       derived classes might need to re-define completely the class
     */
    GSLSimAnFunc() :
-      fFunc(0)
+      fFunc(nullptr)
    {}
 
 public:
 
 
-   /// virtual distructor (no operations)
+   /// virtual destructor (no operations)
    virtual ~GSLSimAnFunc() { } //
 
 
    /**
-      fast copy method called by GSL simuated annealing internally
+      fast copy method called by GSL simulated annealing internally
       copy only the things which have been changed
       must be re-implemented by derived classes if needed
    */

--- a/math/matrix/inc/TDecompBK.h
+++ b/math/matrix/inc/TDecompBK.h
@@ -40,7 +40,7 @@ public :
    TDecompBK(Int_t row_lwb,Int_t row_upb);
    TDecompBK(const TMatrixDSym &m,Double_t tol = 0.0);
    TDecompBK(const TDecompBK &another);
-   ~TDecompBK() override {if (fIpiv) delete [] fIpiv; fIpiv = 0; }
+   ~TDecompBK() override {if (fIpiv) delete [] fIpiv; fIpiv = nullptr; }
 
          Int_t     GetNrows  () const override { return fU.GetNrows(); }
          Int_t     GetNcols  () const override { return fU.GetNcols(); }

--- a/math/matrix/inc/TDecompLU.h
+++ b/math/matrix/inc/TDecompLU.h
@@ -44,7 +44,7 @@ public :
    TDecompLU(Int_t row_lwb,Int_t row_upb);
    TDecompLU(const TMatrixD &m,Double_t tol = 0.0,Int_t implicit = 1);
    TDecompLU(const TDecompLU &another);
-   ~TDecompLU() override {if (fIndex) delete [] fIndex; fIndex = 0; }
+   ~TDecompLU() override {if (fIndex) delete [] fIndex; fIndex = nullptr; }
 
            const TMatrixD  GetMatrix ();
          Int_t     GetNrows  () const override { return fLU.GetNrows(); }
@@ -63,7 +63,7 @@ public :
    Bool_t   TransSolve (      TMatrixDColumn &b) override;
    void     Det        (Double_t &d1,Double_t &d2) override;
 
-   static  Bool_t   InvertLU  (TMatrixD &a,Double_t tol,Double_t *det=0);
+   static  Bool_t   InvertLU  (TMatrixD &a,Double_t tol,Double_t *det = nullptr);
    Bool_t           Invert    (TMatrixD &inv);
    TMatrixD         Invert    (Bool_t &status);
    TMatrixD         Invert    () { Bool_t status; return Invert(status); }

--- a/math/matrix/inc/TMatrixT.h
+++ b/math/matrix/inc/TMatrixT.h
@@ -58,7 +58,7 @@ public:
    enum EMatrixCreatorsOp1 { kZero,kUnit,kTransposed,kInverted,kAtA };
    enum EMatrixCreatorsOp2 { kMult,kTransposeMult,kInvMult,kMultTranspose,kPlus,kMinus };
 
-   TMatrixT(): fDataStack(), fElements(0) { }
+   TMatrixT(): fDataStack(), fElements(nullptr) { }
    TMatrixT(Int_t nrows,Int_t ncols);
    TMatrixT(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    TMatrixT(Int_t nrows,Int_t ncols,const Element *data,Option_t *option="");
@@ -66,7 +66,7 @@ public:
    TMatrixT(const TMatrixT      <Element> &another);
    TMatrixT(const TMatrixTSym   <Element> &another);
    TMatrixT(const TMatrixTSparse<Element> &another);
-   template <class Element2> TMatrixT(const TMatrixT<Element2> &another): fElements(0)
+   template <class Element2> TMatrixT(const TMatrixT<Element2> &another): fElements(nullptr)
    {
       R__ASSERT(another.IsValid());
       Allocate(another.GetNrows(),another.GetNcols(),another.GetRowLwb(),another.GetColLwb());
@@ -109,17 +109,22 @@ public:
 
    const Element *GetMatrixArray  () const override;
          Element *GetMatrixArray  () override;
-   const Int_t   *GetRowIndexArray() const override { return 0; }
-         Int_t   *GetRowIndexArray() override       { return 0; }
-   const Int_t   *GetColIndexArray() const override { return 0; }
-         Int_t   *GetColIndexArray() override       { return 0; }
+   const Int_t   *GetRowIndexArray() const override { return nullptr; }
+         Int_t   *GetRowIndexArray() override       { return nullptr; }
+   const Int_t   *GetColIndexArray() const override { return nullptr; }
+         Int_t   *GetColIndexArray() override       { return nullptr; }
 
          TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) override { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
          TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) override { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
 
-   void Clear(Option_t * /*option*/ ="") override { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
-                                                   else fElements = 0;
-                                                   this->fNelems = 0; }
+   void Clear(Option_t * /*option*/ ="") override
+   {
+      if (this->fIsOwner)
+         Delete_m(this->fNelems, fElements);
+      else
+         fElements = nullptr;
+      this->fNelems = 0;
+   }
 
            TMatrixT    <Element> &Use     (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Element *data);
    const   TMatrixT    <Element> &Use     (Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,const Element *data) const
@@ -144,8 +149,8 @@ public:
    Double_t Determinant  () const override;
    void     Determinant  (Double_t &d1,Double_t &d2) const override;
 
-           TMatrixT<Element> &Invert      (Double_t *det=0);
-           TMatrixT<Element> &InvertFast  (Double_t *det=0);
+           TMatrixT<Element> &Invert      (Double_t *det = nullptr);
+           TMatrixT<Element> &InvertFast  (Double_t *det = nullptr);
            TMatrixT<Element> &Transpose   (const TMatrixT<Element> &source);
    inline  TMatrixT<Element> &T           () { return this->Transpose(*this); }
            TMatrixT<Element> &Rank1Update (const TVectorT<Element> &v,Element alpha=1.0);

--- a/math/matrix/inc/TMatrixTSparse.h
+++ b/math/matrix/inc/TMatrixTSparse.h
@@ -70,7 +70,7 @@ public:
    enum EMatrixCreatorsOp1 { kZero,kUnit,kTransposed,kAtA };
    enum EMatrixCreatorsOp2 { kMult,kMultTranspose,kPlus,kMinus };
 
-   TMatrixTSparse() { fElements = 0; fRowIndex = 0; fColIndex = 0; }
+   TMatrixTSparse() { fElements = nullptr; fRowIndex = nullptr; fColIndex = nullptr; }
    TMatrixTSparse(Int_t nrows,Int_t ncols);
    TMatrixTSparse(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    TMatrixTSparse(Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb,Int_t nr_nonzeros,
@@ -115,9 +115,9 @@ public:
                                                                                                 m.GetColUpb(),m.GetNoElements()); }
 
    void Clear(Option_t * /*option*/ ="") override { if (this->fIsOwner) {
-                                                      if (fElements) { delete [] fElements; fElements = 0; }
-                                                      if (fRowIndex) { delete [] fRowIndex; fRowIndex = 0; }
-                                                      if (fColIndex) { delete [] fColIndex; fColIndex = 0; }
+                                                      if (fElements) { delete [] fElements; fElements = nullptr; }
+                                                      if (fRowIndex) { delete [] fRowIndex; fRowIndex = nullptr; }
+                                                      if (fColIndex) { delete [] fColIndex; fColIndex = nullptr; }
                                                    }
                                                    this->fNelems    = 0;
                                                    this->fNrowIndex = 0;

--- a/math/matrix/inc/TMatrixTSym.h
+++ b/math/matrix/inc/TMatrixTSym.h
@@ -51,7 +51,7 @@ public:
    enum EMatrixCreatorsOp1 { kZero,kUnit,kTransposed,kInverted,kAtA };
    enum EMatrixCreatorsOp2 { kPlus,kMinus };
 
-   TMatrixTSym() { fElements = 0; }
+   TMatrixTSym() { fElements = nullptr; }
    explicit TMatrixTSym(Int_t nrows);
    TMatrixTSym(Int_t row_lwb,Int_t row_upb);
    TMatrixTSym(Int_t nrows,const Element *data,Option_t *option="");
@@ -81,16 +81,16 @@ public:
 
    const Element *GetMatrixArray  () const override;
          Element *GetMatrixArray  () override;
-   const Int_t   *GetRowIndexArray() const override { return 0; }
-         Int_t   *GetRowIndexArray() override       { return 0; }
-   const Int_t   *GetColIndexArray() const override { return 0; }
-         Int_t   *GetColIndexArray() override       { return 0; }
+   const Int_t   *GetRowIndexArray() const override { return nullptr; }
+         Int_t   *GetRowIndexArray() override       { return nullptr; }
+   const Int_t   *GetColIndexArray() const override { return nullptr; }
+         Int_t   *GetColIndexArray() override       { return nullptr; }
 
          TMatrixTBase<Element> &SetRowIndexArray(Int_t * /*data*/) override { MayNotUse("SetRowIndexArray(Int_t *)"); return *this; }
          TMatrixTBase<Element> &SetColIndexArray(Int_t * /*data*/) override { MayNotUse("SetColIndexArray(Int_t *)"); return *this; }
 
    void   Clear      (Option_t * /*option*/ ="") override { if (this->fIsOwner) Delete_m(this->fNelems,fElements);
-                                                           else fElements = 0;
+                                                           else fElements = nullptr;
                                                            this->fNelems = 0; }
    Bool_t IsSymmetric() const override { return kTRUE; }
 
@@ -121,8 +121,8 @@ public:
    Double_t      Determinant   () const override;
    void          Determinant   (Double_t &d1,Double_t &d2) const override;
 
-           TMatrixTSym<Element>  &Invert        (Double_t *det=0);
-           TMatrixTSym<Element>  &InvertFast    (Double_t *det=0);
+           TMatrixTSym<Element>  &Invert        (Double_t *det=nullptr);
+           TMatrixTSym<Element>  &InvertFast    (Double_t *det=nullptr);
            TMatrixTSym<Element>  &Transpose     (const TMatrixTSym<Element> &source);
    inline  TMatrixTSym<Element>  &T             () { return this->Transpose(*this); }
            TMatrixTSym<Element>  &Rank1Update   (const TVectorT   <Element> &v,Element alpha=1.0);
@@ -216,7 +216,7 @@ template <class Element> inline Element TMatrixTSym<Element>::operator()(Int_t r
    }
    if (acoln >= this->fNcols || acoln < 0) {
       Error("operator()","Request column(%d) outside matrix range of %d - %d",coln,this->fColLwb,this->fColLwb+this->fNcols);
-      return TMatrixTBase<Element>::NaNValue();      
+      return TMatrixTBase<Element>::NaNValue();
    }
    return (fElements[arown*this->fNcols+acoln]);
 }

--- a/math/matrix/inc/TMatrixTUtils.h
+++ b/math/matrix/inc/TMatrixTUtils.h
@@ -120,7 +120,7 @@ protected:
    const Element               *fPtr;     //  pointer to the a[row,0]
 
 public:
-   TMatrixTRow_const() { fMatrix = 0; fRowInd = 0; fInc = 0; fPtr = 0; }
+   TMatrixTRow_const() { fMatrix = nullptr; fRowInd = 0; fInc = 0; fPtr = nullptr; }
    TMatrixTRow_const(const TMatrixT   <Element> &matrix,Int_t row);
    TMatrixTRow_const(const TMatrixTSym<Element> &matrix,Int_t row);
   TMatrixTRow_const(const TMatrixTRow_const<Element>& trc):
@@ -220,7 +220,7 @@ protected:
    const Element               *fPtr;     //  pointer to the a[0,col] column
 
 public:
-   TMatrixTColumn_const() { fMatrix = 0; fColInd = 0; fInc = 0; fPtr = 0; }
+   TMatrixTColumn_const() { fMatrix = nullptr; fColInd = 0; fInc = 0; fPtr = nullptr; }
    TMatrixTColumn_const(const TMatrixT   <Element> &matrix,Int_t col);
    TMatrixTColumn_const(const TMatrixTSym<Element> &matrix,Int_t col);
    TMatrixTColumn_const(const TMatrixTColumn_const<Element>& trc):
@@ -322,7 +322,7 @@ protected:
    const Element               *fPtr;     //  pointer to the a[0,0]
 
 public:
-   TMatrixTDiag_const() { fMatrix = 0; fInc = 0; fNdiag = 0; fPtr = 0; }
+   TMatrixTDiag_const() { fMatrix = nullptr; fInc = 0; fNdiag = 0; fPtr = nullptr; }
    TMatrixTDiag_const(const TMatrixT   <Element> &matrix);
    TMatrixTDiag_const(const TMatrixTSym<Element> &matrix);
    TMatrixTDiag_const(const TMatrixTDiag_const<Element>& trc):
@@ -411,7 +411,7 @@ protected:
    const Element               *fPtr;     //  pointer to the a[0,0]
 
 public:
-   TMatrixTFlat_const() { fMatrix = 0; fNelems = 0; fPtr = 0; }
+   TMatrixTFlat_const() { fMatrix = nullptr; fNelems = 0; fPtr = nullptr; }
    TMatrixTFlat_const(const TMatrixT   <Element> &matrix);
    TMatrixTFlat_const(const TMatrixTSym<Element> &matrix);
    TMatrixTFlat_const(const TMatrixTFlat_const<Element>& trc):
@@ -499,7 +499,7 @@ protected:
          Int_t                  fNcolsSub;  //
 
 public:
-   TMatrixTSub_const() { fRowOff = fColOff = fNrowsSub = fNcolsSub = 0; fMatrix = 0; }
+   TMatrixTSub_const() { fRowOff = fColOff = fNrowsSub = fNcolsSub = 0; fMatrix = nullptr; }
    TMatrixTSub_const(const TMatrixT   <Element> &matrix,Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    TMatrixTSub_const(const TMatrixTSym<Element> &matrix,Int_t row_lwb,Int_t row_upb,Int_t col_lwb,Int_t col_upb);
    virtual ~TMatrixTSub_const() { }
@@ -592,7 +592,7 @@ protected:
    const Element               *fDataPtr; // data pointer
 
 public:
-   TMatrixTSparseRow_const() { fMatrix = 0; fRowInd = 0; fNindex = 0; fColPtr = 0; fDataPtr = 0; }
+   TMatrixTSparseRow_const() { fMatrix = nullptr; fRowInd = 0; fNindex = 0; fColPtr = nullptr; fDataPtr = nullptr; }
    TMatrixTSparseRow_const(const TMatrixTSparse<Element> &matrix,Int_t row);
    TMatrixTSparseRow_const(const TMatrixTSparseRow_const<Element>& trc):
      fMatrix(trc.fMatrix), fRowInd(trc.fRowInd), fNindex(trc.fNindex), fColPtr(trc.fColPtr), fDataPtr(trc.fDataPtr) { }
@@ -656,7 +656,7 @@ protected:
    const Element               *fDataPtr; //  data pointer
 
 public:
-   TMatrixTSparseDiag_const() { fMatrix = 0; fNdiag = 0; fDataPtr = 0; }
+   TMatrixTSparseDiag_const() { fMatrix = nullptr; fNdiag = 0; fDataPtr = nullptr; }
    TMatrixTSparseDiag_const(const TMatrixTSparse<Element> &matrix);
    TMatrixTSparseDiag_const(const TMatrixTSparseDiag_const<Element>& trc):
      fMatrix(trc.fMatrix), fNdiag(trc.fNdiag), fDataPtr(trc.fDataPtr) { }

--- a/math/matrix/inc/TVectorT.h
+++ b/math/matrix/inc/TVectorT.h
@@ -27,15 +27,15 @@
 template<class Element> class TVectorT : public TObject {
 
 protected:
-   Int_t    fNrows{0};                // number of rows
-   Int_t    fRowLwb{0};               // lower bound of the row index
-   Element *fElements{nullptr};             //[fNrows] elements themselves
+   Int_t    fNrows{0};             // number of rows
+   Int_t    fRowLwb{0};            // lower bound of the row index
+   Element *fElements{nullptr};    //[fNrows] elements themselves
 
-   enum {kSizeMax = 5};             // size data container on stack, see New_m(),Delete_m()
-   enum {kWorkMax = 100};           // size of work array's in several routines
+   enum {kSizeMax = 5};            // size data container on stack, see New_m(),Delete_m()
+   enum {kWorkMax = 100};          // size of work array's in several routines
 
    Element  fDataStack[kSizeMax];  //! data container
-   Bool_t   fIsOwner{kTRUE};              //!default kTRUE, when Use array kFALSE
+   Bool_t   fIsOwner{kTRUE};       //!default kTRUE, when Use array kFALSE
 
    Element* New_m   (Int_t size);
    void     Delete_m(Int_t size,Element*&);
@@ -50,7 +50,7 @@ protected:
 
 public:
 
-   TVectorT() : fNrows(0), fRowLwb(0), fElements(0), fDataStack (), fIsOwner(kTRUE) { }
+   TVectorT() : fNrows(0), fRowLwb(0), fElements(nullptr), fDataStack (), fIsOwner(kTRUE) { }
    explicit TVectorT(Int_t n);
    TVectorT(Int_t lwb,Int_t upb);
    TVectorT(Int_t n,const Element *elements);
@@ -171,11 +171,16 @@ public:
 
    void Add(const TVectorT<Element> &v);
    void Add(const TVectorT<Element> &v1, const TVectorT<Element> &v2);
-   void Clear(Option_t * /*option*/ ="") override { if (fIsOwner) Delete_m(fNrows,fElements);
-                                           else fElements = 0;
-                                           fNrows = 0; }
-   void Draw (Option_t *option="") override; // *MENU*
-   void Print(Option_t *option="") const override;  // *MENU*
+   void Clear(Option_t * /*option*/ = "") override
+   {
+      if (fIsOwner)
+         Delete_m(fNrows, fElements);
+      else
+         fElements = nullptr;
+      fNrows = 0;
+   }
+   void Draw(Option_t *option = "") override;       // *MENU*
+   void Print(Option_t *option = "") const override;  // *MENU*
 
    ClassDefOverride(TVectorT,4)  // Template of Vector class
 };

--- a/math/minuit/inc/TLinearFitter.h
+++ b/math/minuit/inc/TLinearFitter.h
@@ -194,7 +194,7 @@ private:
    TBits        fFitsample;      //indices of points, used in the robust fit
 
    Bool_t       *fFixedParams;   //[fNfixed] array of fixed/released params
-   
+
 
    void  AddToDesign(Double_t *x, Double_t y, Double_t e);
    void  ComputeTValues();
@@ -222,7 +222,7 @@ public:
    virtual void       Add(TLinearFitter *tlf);
    virtual void       AddPoint(Double_t *x, Double_t y, Double_t e=1);
    virtual void       AddTempMatrices();
-   virtual void       AssignData(Int_t npoints, Int_t xncols, Double_t *x, Double_t *y, Double_t *e=0);
+   virtual void       AssignData(Int_t npoints, Int_t xncols, Double_t *x, Double_t *y, Double_t *e=nullptr);
 
    void       Clear(Option_t *option="") override;
    virtual void       ClearPoints();
@@ -271,7 +271,7 @@ public:
 
    Int_t     GetStats(Double_t& /*amin*/, Double_t& /*edm*/, Double_t& /*errdef*/, Int_t& /*nvpar*/, Int_t& /*nparx*/) const override {return 0;}
    Double_t  GetSumLog(Int_t /*i*/) override {return 0;}
-   void      SetFitMethod(const char * /*name*/) override {;}
+   void      SetFitMethod(const char * /*name*/) override {}
    Int_t     SetParameter(Int_t /*ipar*/,const char * /*parname*/,Double_t /*value*/,Double_t /*verr*/,Double_t /*vlow*/, Double_t /*vhigh*/) override {return 0;}
 
    ClassDefOverride(TLinearFitter, 2) //fit a set of data points with a linear combination of functions

--- a/math/minuit/inc/TLinearMinimizer.h
+++ b/math/minuit/inc/TLinearMinimizer.h
@@ -87,7 +87,7 @@ public:
    const double *  X() const override { return &fParams.front(); }
 
    /// return pointer to gradient values at the minimum
-   const double *  MinGradient() const override { return 0; } // not available in Minuit2
+   const double *  MinGradient() const override { return nullptr; } // not available in Minuit2
 
    /// number of function calls to reach the minimum
    unsigned int NCalls() const override { return 0; }
@@ -104,7 +104,7 @@ public:
    bool ProvidesError() const override { return true; }
 
    /// return errors at the minimum
-   const double * Errors() const override { return  (fErrors.empty()) ? 0 : &fErrors.front(); }
+   const double * Errors() const override { return  fErrors.empty() ? nullptr : &fErrors.front(); }
 
    /** return covariance matrices elements
        if the variable is fixed the matrix is zero

--- a/math/minuit/inc/TMinuitMinimizer.h
+++ b/math/minuit/inc/TMinuitMinimizer.h
@@ -43,7 +43,7 @@ namespace ROOT {
 
 
 /**
-   TMinuitMinimizer class: 
+   TMinuitMinimizer class:
    ROOT::Math::Minimizer implementation based on TMinuit
 
    @ingroup TMinuit
@@ -138,7 +138,7 @@ public:
    const double *  X() const override { return &fParams.front(); }
 
    /// return pointer to gradient values at the minimum
-   const double *  MinGradient() const override { return 0; } // not available in Minuit2
+   const double *  MinGradient() const override { return nullptr; } // not available in Minuit2
 
    /// number of function calls to reach the minimum
    unsigned int NCalls() const override;
@@ -238,7 +238,7 @@ public:
    void SuppressMinuitWarnings(bool nowarn=true);
 
    /// set debug mode. Return true if setting was successfull
-   bool SetDebug(bool on = true); 
+   bool SetDebug(bool on = true);
 
 protected:
 

--- a/math/minuit2/inc/Minuit2/LASymMatrix.h
+++ b/math/minuit2/inc/Minuit2/LASymMatrix.h
@@ -45,7 +45,7 @@ int Invert(LASymMatrix &);
 class LASymMatrix {
 
 private:
-   LASymMatrix() : fSize(0), fNRow(0), fData(0) {}
+   LASymMatrix() : fSize(0), fNRow(0), fData(nullptr) {}
 
 public:
    typedef sym Type;
@@ -111,7 +111,7 @@ public:
 
    template <class A, class T>
    LASymMatrix(const ABObj<sym, ABSum<ABObj<sym, LASymMatrix, T>, ABObj<sym, A, T>>, T> &sum)
-      : fSize(0), fNRow(0), fData(0)
+      : fSize(0), fNRow(0), fData(nullptr)
    {
       //     std::cout<<"template<class A, class T> LASymMatrix(const ABObj<sym, ABSum<ABObj<sym, LASymMatrix, T>,
       //     ABObj<sym, A, T> >,T>& sum)"<<std::endl;
@@ -126,7 +126,7 @@ public:
    }
 
    template <class A, class T>
-   LASymMatrix(const ABObj<sym, ABObj<sym, A, T>, T> &something) : fSize(0), fNRow(0), fData(0)
+   LASymMatrix(const ABObj<sym, ABObj<sym, A, T>, T> &something) : fSize(0), fNRow(0), fData(nullptr)
    {
       //     std::cout<<"template<class A, class T> LASymMatrix(const ABObj<sym, ABObj<sym, A, T>, T>&
       //     something)"<<std::endl;
@@ -168,7 +168,7 @@ public:
    template <class A, class T>
    LASymMatrix(
       const ABObj<sym, ABSum<ABObj<sym, VectorOuterProduct<ABObj<vec, LAVector, T>, T>, T>, ABObj<sym, A, T>>, T> &sum)
-      : fSize(0), fNRow(0), fData(0)
+      : fSize(0), fNRow(0), fData(nullptr)
    {
       //     std::cout<<"template<class A, class T> LASymMatrix(const ABObj<sym, ABSum<ABObj<sym,
       //     VectorOuterProduct<ABObj<vec, LAVector, T>, T>, T> ABObj<sym, A, T> >,T>& sum)"<<std::endl;
@@ -285,7 +285,7 @@ public:
    LASymMatrix &operator=(const ABObj<sym, LASymMatrix, T> &v)
    {
       // std::cout<<"template<class T> LASymMatrix& operator=(ABObj<sym, LASymMatrix, T>& v)"<<std::endl;
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          fSize = v.Obj().size();
          fNRow = v.Obj().Nrow();
          fData = (double *)StackAllocatorHolder::Get().Allocate(sizeof(double) * fSize);

--- a/math/minuit2/inc/Minuit2/LAVector.h
+++ b/math/minuit2/inc/Minuit2/LAVector.h
@@ -32,12 +32,10 @@ int Mndspmv(const char *, unsigned int, double, const double *, const double *, 
 class LAVector {
 
 private:
-   LAVector() : fSize(0), fData(0) {}
+   LAVector() : fSize(0), fData(nullptr) {}
 
 public:
    typedef vec Type;
-
-   //   LAVector() : fSize(0), fData(0) {}
 
    LAVector(unsigned int n) : fSize(n), fData((double *)StackAllocatorHolder::Get().Allocate(sizeof(double) * n))
    {
@@ -95,7 +93,7 @@ public:
    }
 
    template <class A, class T>
-   LAVector(const ABObj<vec, ABSum<ABObj<vec, LAVector, T>, ABObj<vec, A, T>>, T> &sum) : fSize(0), fData(0)
+   LAVector(const ABObj<vec, ABSum<ABObj<vec, LAVector, T>, ABObj<vec, A, T>>, T> &sum) : fSize(0), fData(nullptr)
    {
       //     std::cout<<"template<class A, class T> LAVector(const ABObj<ABSum<ABObj<LAVector, T>, ABObj<A, T> >,T>&
       //     sum)"<<std::endl;
@@ -235,7 +233,7 @@ public:
    LAVector &operator=(const ABObj<vec, LAVector, T> &v)
    {
       //     std::cout<<"template<class T> LAVector& operator=(ABObj<LAVector, T>& v)"<<std::endl;
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          fSize = v.Obj().size();
          fData = (double *)StackAllocatorHolder::Get().Allocate(sizeof(double) * fSize);
       } else {
@@ -251,7 +249,7 @@ public:
    {
       //     std::cout<<"template<class A, class T> LAVector& operator=(const ABObj<ABObj<A, T>, T>&
       //     something)"<<std::endl;
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          (*this) = something.Obj();
       } else {
          LAVector tmp(something.Obj());
@@ -265,7 +263,7 @@ public:
    template <class A, class B, class T>
    LAVector &operator=(const ABObj<vec, ABSum<ABObj<vec, A, T>, ABObj<vec, B, T>>, T> &sum)
    {
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          (*this) = sum.Obj().A();
          (*this) += sum.Obj().B();
       } else {
@@ -281,7 +279,7 @@ public:
    template <class A, class T>
    LAVector &operator=(const ABObj<vec, ABSum<ABObj<vec, LAVector, T>, ABObj<vec, A, T>>, T> &sum)
    {
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          (*this) = sum.Obj().B();
          (*this) += sum.Obj().A();
       } else {
@@ -298,7 +296,7 @@ public:
    template <class T>
    LAVector &operator=(const ABObj<vec, ABProd<ABObj<sym, LASymMatrix, T>, ABObj<vec, LAVector, T>>, T> &prod)
    {
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          fSize = prod.Obj().B().Obj().size();
          fData = (double *)StackAllocatorHolder::Get().Allocate(sizeof(double) * fSize);
          Mndspmv("U", fSize, double(prod.f() * prod.Obj().A().f() * prod.Obj().B().f()), prod.Obj().A().Obj().Data(),
@@ -320,7 +318,7 @@ public:
              ABSum<ABObj<vec, ABProd<ABObj<sym, LASymMatrix, T>, ABObj<vec, LAVector, T>>, T>, ABObj<vec, LAVector, T>>,
              T> &prod)
    {
-      if (fSize == 0 && fData == 0) {
+      if (fSize == 0 && !fData) {
          (*this) = prod.Obj().B();
          (*this) += prod.Obj().A();
       } else {

--- a/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
+++ b/math/minuit2/inc/Minuit2/Minuit2Minimizer.h
@@ -156,7 +156,7 @@ public:
    const double *X() const override { return &fValues.front(); }
 
    /// return pointer to gradient values at the minimum
-   const double *MinGradient() const override { return 0; } // not available in Minuit2
+   const double *MinGradient() const override { return nullptr; } // not available in Minuit2
 
    /// number of function calls to reach the minimum
    unsigned int NCalls() const override { return fState.NFcn(); }

--- a/math/minuit2/inc/Minuit2/MnTraceObject.h
+++ b/math/minuit2/inc/Minuit2/MnTraceObject.h
@@ -20,7 +20,7 @@ class MnUserParameterState;
 class MnTraceObject {
 
 public:
-   MnTraceObject(int parNumber = -1) : fUserState(0), fParNumber(parNumber) {}
+   MnTraceObject(int parNumber = -1) : fUserState(nullptr), fParNumber(parNumber) {}
 
    virtual ~MnTraceObject() {}
 

--- a/math/minuit2/inc/Minuit2/StackAllocator.h
+++ b/math/minuit2/inc/Minuit2/StackAllocator.h
@@ -49,7 +49,7 @@ public:
    //   enum {default_size = 1048576};
    enum { default_size = 524288 };
 
-   StackAllocator() : fStack(0)
+   StackAllocator() : fStack(nullptr)
    {
 #ifdef _MN_NO_THREAD_SAVE_
       // std::cout<<"StackAllocator Allocate "<<default_size<<std::endl;

--- a/math/mlp/inc/TMLPAnalyzer.h
+++ b/math/mlp/inc/TMLPAnalyzer.h
@@ -38,9 +38,9 @@ protected:
 
 public:
    TMLPAnalyzer(TMultiLayerPerceptron& net):
-      fNetwork(&net), fAnalysisTree(0), fIOTree(0) {}
+      fNetwork(&net), fAnalysisTree(nullptr), fIOTree(nullptr) {}
    TMLPAnalyzer(TMultiLayerPerceptron* net):
-      fNetwork(net), fAnalysisTree(0), fIOTree(0) {}
+      fNetwork(net), fAnalysisTree(nullptr), fIOTree(nullptr) {}
    ~TMLPAnalyzer() override;
    void DrawNetwork(Int_t neuron, const char* signal, const char* bg);
    void DrawDInput(Int_t i);

--- a/math/mlp/inc/TMultiLayerPerceptron.h
+++ b/math/mlp/inc/TMultiLayerPerceptron.h
@@ -31,13 +31,13 @@ class TMultiLayerPerceptron : public TObject {
                           kRibierePolak, kFletcherReeves, kBFGS };
    enum EDataSet { kTraining, kTest };
    TMultiLayerPerceptron();
-   TMultiLayerPerceptron(const char* layout, TTree* data = 0,
+   TMultiLayerPerceptron(const char* layout, TTree* data = nullptr,
                          const char* training = "Entry$%2==0",
                          const char* test = "",
                          TNeuron::ENeuronType type = TNeuron::kSigmoid,
                          const char* extF = "", const char* extD  = "");
    TMultiLayerPerceptron(const char* layout,
-                         const char* weight, TTree* data = 0,
+                         const char* weight, TTree* data = nullptr,
                          const char* training = "Entry$%2==0",
                          const char* test = "",
                          TNeuron::ENeuronType type = TNeuron::kSigmoid,

--- a/math/physics/inc/TRobustEstimator.h
+++ b/math/physics/inc/TRobustEstimator.h
@@ -75,7 +75,7 @@ public:
 
    TRobustEstimator();
    TRobustEstimator(Int_t nvectors, Int_t nvariables, Int_t hh=0);
-   ~TRobustEstimator() override{;}
+   ~TRobustEstimator() override {}
 
    void    AddColumn(Double_t *col);         //adds a column to the data matrix
    void    AddRow(Double_t *row);            //adds a row to the data matrix
@@ -86,8 +86,8 @@ public:
    Int_t   GetBDPoint();                     //returns the breakdown point of the algorithm
 
    /// returns a reference to the data matrix
-   const TMatrixD & GetData() { return fData; } 
-   
+   const TMatrixD & GetData() { return fData; }
+
    void    GetCovariance(TMatrixDSym &matr); //returns robust covariance matrix estimate
    const   TMatrixDSym* GetCovariance() const{return &fCovariance;}
    void    GetCorrelation(TMatrixDSym &matr); //returns robust correlation matrix estimate

--- a/math/physics/inc/TRotation.h
+++ b/math/physics/inc/TRotation.h
@@ -32,7 +32,7 @@ private:
    //    const TRotation & fRR;
    int fII;
 };
-   // Helper class for implemention of C-style subscripting r[i][j]
+   // Helper class for implementation of C-style subscripting r[i][j]
 
    TRotation();
    // Default constructor. Gives a unit matrix.
@@ -41,7 +41,7 @@ private:
    TRotation(const TQuaternion &);
    // Copy constructor.
 
-   ~TRotation() override {;};
+   ~TRotation() override {}
 
    inline Double_t XX() const;
    inline Double_t XY() const;

--- a/math/unuran/inc/TUnuran.h
+++ b/math/unuran/inc/TUnuran.h
@@ -83,7 +83,7 @@ public:
    /**
       Constructor with a generator instance and given level of log output
    */
-   TUnuran (TRandom * r = 0, unsigned int log = 0);
+   TUnuran (TRandom * r = nullptr, unsigned int log = 0);
 
 
    /**

--- a/math/unuran/inc/TUnuranContDist.h
+++ b/math/unuran/inc/TUnuranContDist.h
@@ -59,7 +59,7 @@ public:
       set them in order to speed up the algorithm. For example in case of the Cdf, if the user has not set it, a numerical
       integration algorithm is used to estimate the Cdf from the Pdf.
    */
-   explicit TUnuranContDist (TF1 * pdf = 0, TF1 * deriv = 0, bool isLogPdf = false );
+   explicit TUnuranContDist (TF1 * pdf = nullptr, TF1 * deriv = nullptr, bool isLogPdf = false );
    /**
       Constructor as above but with the possibility to pass also the Cdf.
        In case an algorithm requiring only the Cdf (no Pdf), one can use this constructor passing nullptr for Pdf and derivative of
@@ -69,7 +69,7 @@ public:
    /**
       Constructor as before but from a generic function object interface for one-dim functions
    */
-   explicit TUnuranContDist (const ROOT::Math::IGenFunction & pdf, const ROOT::Math::IGenFunction * dpdf = 0, bool isLogPdf = false, bool copyFunc = false);
+   explicit TUnuranContDist (const ROOT::Math::IGenFunction & pdf, const ROOT::Math::IGenFunction * dpdf = nullptr, bool isLogPdf = false, bool copyFunc = false);
    /**
       Constructor as before from pointers to generic function object interface for one-dim functions
       which can be use for all algorithms including those requiring only the Cdf
@@ -145,7 +145,7 @@ public:
    /**
       check if a cdf function is provided for the distribution
     */
-   bool HasCdf() const { return fCdf != 0; }
+   bool HasCdf() const { return fCdf != nullptr; }
 
    /**
       check if distribution has a pre-computed mode

--- a/math/unuran/inc/TUnuranDiscrDist.h
+++ b/math/unuran/inc/TUnuranDiscrDist.h
@@ -68,8 +68,8 @@ public:
    template<class Iterator>
    TUnuranDiscrDist (Iterator * begin, Iterator * end) :
       fPVec(begin,end),
-      fPmf(0),
-      fCdf(0),
+      fPmf(nullptr),
+      fCdf(nullptr),
       fXmin(1),
       fXmax(-1),
       fMode(0),
@@ -171,7 +171,7 @@ public:
    /**
       flag to control if distribution provides also a Cdf
     */
-   bool HasCdf() const { return fCdf != 0; }
+   bool HasCdf() const { return fCdf != nullptr; }
 
 
    /**

--- a/math/unuran/inc/TUnuranEmpDist.h
+++ b/math/unuran/inc/TUnuranEmpDist.h
@@ -55,7 +55,7 @@ public:
       Constructor from a TH1 objects.
       If the histogram has a buffer by default the unbinned data are used
    */
-   TUnuranEmpDist (const TH1 * h1 = 0, bool useBuffer = true );
+   TUnuranEmpDist (const TH1 * h1 = nullptr, bool useBuffer = true );
 
    /**
       Constructor from a set of data using an iterator to specify begin/end of the data

--- a/math/unuran/inc/TUnuranMultiContDist.h
+++ b/math/unuran/inc/TUnuranMultiContDist.h
@@ -56,7 +56,7 @@ public:
       If a value of dim 0 is passed , the dimension of the function is taken from TF1::GetNdim().
       This works only for 2D and 3D (for TF2 and TF3 objects).
    */
-   TUnuranMultiContDist (TF1 * func = 0, unsigned int dim = 0, bool isLogPdf = false);
+   TUnuranMultiContDist (TF1 * func = nullptr, unsigned int dim = 0, bool isLogPdf = false);
 
 
    /**
@@ -101,7 +101,7 @@ public:
       specify un infinite domain in that coordinate
    */
    void SetDomain(const double *xmin, const double *xmax)  {
-      if (xmin == 0 || xmax == 0) return;
+      if (!xmin || !xmax) return;
       fXmin = std::vector<double>(xmin,xmin+NDim());
       fXmax = std::vector<double>(xmax,xmax+NDim());
    }
@@ -117,14 +117,14 @@ public:
       get the distribution lower domain values. Return a null pointer if domain is not defined
    */
    const double * GetLowerDomain() const {
-      if (fXmin.size() == 0 || (  fXmin.size() != fXmax.size() )  ) return 0;
+      if (fXmin.size() == 0 || (  fXmin.size() != fXmax.size() )  ) return nullptr;
       return &fXmin[0];
    }
    /**
       get the distribution upper domain values. Return a null pointer if domain is not defined
    */
    const double * GetUpperDomain() const {
-      if (fXmax.size() == 0 || (  fXmin.size() != fXmax.size() )  ) return 0;
+      if (fXmax.size() == 0 || (  fXmin.size() != fXmax.size() )  ) return nullptr;
       return &fXmax[0];
    }
 
@@ -133,8 +133,8 @@ public:
       get the mode (vector of coordinate positions of the maxima of the distribution)
       If a mode has not defined return a NULL pointer
    */
-   const double * GetMode( ) const {
-      if (fMode.size() == 0  ) return 0;
+   const double * GetMode() const {
+      if (fMode.size() == 0) return nullptr;
       return &fMode.front();
    }
 
@@ -142,12 +142,12 @@ public:
    /**
       flag to control if given function represent the log of a pdf
    */
-   bool IsLogPdf() const {  return fIsLogPdf; }
+   bool IsLogPdf() const { return fIsLogPdf; }
 
    /**
       evaluate the probability density function, used by UnuRan
    */
-   double Pdf ( const double * x) const;
+   double Pdf (const double * x) const;
 
    /**
        evaluate the gradient vector of  the Pdf. Used by UnuRan

--- a/math/unuran/inc/TUnuranSampler.h
+++ b/math/unuran/inc/TUnuranSampler.h
@@ -164,7 +164,7 @@ public:
       divided by the bin width)
       By default do not do random sample, just return the function values
     */
-   bool SampleBin(double prob, double & value, double *error = 0) override;
+   bool SampleBin(double prob, double & value, double *error = nullptr) override;
 
 
 


### PR DESCRIPTION
Allows to use `-Wzero-as-null-pointer-constant` compiler flag for derived objects