### PR TITLE
Use `nullptr` in graf classes

### DIFF
--- a/graf2d/asimage/inc/TASImage.h
+++ b/graf2d/asimage/inc/TASImage.h
@@ -128,13 +128,13 @@ public:
              Int_t x = 0, Int_t y = 0, UInt_t width = 0, UInt_t height = 0) override;
    void  Merge(const TImage *im, const char *op = "alphablend", Int_t x = 0, Int_t y = 0) override;
    void  Append(const TImage *im, const char * option = "+", const char *color = "#00000000") override;
-   void  Gradient(UInt_t angle = 0, const char *colors = "#FFFFFF #000000", const char *offsets = 0,
+   void  Gradient(UInt_t angle = 0, const char *colors = "#FFFFFF #000000", const char *offsets = nullptr,
                   Int_t x = 0, Int_t y = 0, UInt_t width = 0, UInt_t height = 0) override;
    void  Bevel(Int_t x = 0, Int_t y = 0, UInt_t width = 0, UInt_t height = 0, const char *hi = "#ffdddddd",
                const char *lo = "#ff555555", UShort_t thick = 1, Bool_t pressed = kFALSE) override;
    void  DrawText(Int_t  x = 0, Int_t y = 0, const char *text = "", Int_t size = 12,
-                  const char *color = 0, const char *font = "fixed", EText3DType type = TImage::kPlain,
-                  const char *fore_file = 0, Float_t angle = 0) override;
+                  const char *color = nullptr, const char *font = "fixed", EText3DType type = TImage::kPlain,
+                  const char *fore_file = nullptr, Float_t angle = 0) override;
    void DrawText(TText *text, Int_t x = 0, Int_t y = 0) override;
 
    // Vector graphics
@@ -144,7 +144,7 @@ public:
    void  DrawDashLine(UInt_t x1, UInt_t y1, UInt_t x2, UInt_t y2, UInt_t nDash, const char *pDash, const char *col = "#000000", UInt_t thick = 1) override;
    void  DrawBox(Int_t x1, Int_t y1, Int_t x2, Int_t y2, const char *col = "#000000", UInt_t thick = 1, Int_t mode = 0) override;
    void  DrawRectangle(UInt_t x, UInt_t y, UInt_t w, UInt_t h, const char *col = "#000000", UInt_t thick = 1) override;
-   void  FillRectangle(const char *col = 0, Int_t x = 0, Int_t y = 0, UInt_t width = 0, UInt_t height = 0) override;
+   void  FillRectangle(const char *col = nullptr, Int_t x = 0, Int_t y = 0, UInt_t width = 0, UInt_t height = 0) override;
    void  DrawPolyLine(UInt_t nn, TPoint *xy, const char *col = "#000000", UInt_t thick = 1, TImage::ECoordMode mode = kCoordModeOrigin) override;
    void  PutPixel(Int_t x, Int_t y, const char *col = "#000000") override;
    void  PolyPoint(UInt_t npt, TPoint *ppt, const char *col = "#000000", TImage::ECoordMode mode = kCoordModeOrigin) override;

--- a/graf2d/fitsio/inc/TFITS.h
+++ b/graf2d/fitsio/inc/TFITS.h
@@ -115,7 +115,7 @@ public:
 
    //Image readers
    TH1               *ReadAsHistogram();
-   TImage            *ReadAsImage(Int_t layer = 0, TImagePalette *pal = 0);
+   TImage            *ReadAsImage(Int_t layer = 0, TImagePalette *pal = nullptr);
    TMatrixD          *ReadAsMatrix(Int_t layer = 0, Option_t *opt="");
    TVectorD          *GetArrayRow(UInt_t row);
    TVectorD          *GetArrayColumn(UInt_t col);

--- a/graf2d/gpad/inc/TRatioPlot.h
+++ b/graf2d/gpad/inc/TRatioPlot.h
@@ -90,9 +90,9 @@ protected:
 
    Float_t fSplitFraction = 0.3; ///< Stores the fraction at which the upper and lower pads meet
 
-   TGraph *fRatioGraph = 0; ///< Stores the lower plot's graph
-   TGraphErrors *fConfidenceInterval1 = 0; ///< Stores the graph for the 1 sigma band
-   TGraphErrors *fConfidenceInterval2 = 0; ///< Stores the graph for the 2 sigma band
+   TGraph *fRatioGraph = nullptr; ///< Stores the lower plot's graph
+   TGraphErrors *fConfidenceInterval1 = nullptr; ///< Stores the graph for the 1 sigma band
+   TGraphErrors *fConfidenceInterval2 = nullptr; ///< Stores the graph for the 2 sigma band
    Color_t fCi1Color = kYellow; ///< Stores the color for the 1 sigma band
    Color_t fCi2Color = kGreen; ///< Stores the color for the 2 sigma band
 

--- a/graf2d/graf/inc/TAttImage.h
+++ b/graf2d/graf/inc/TAttImage.h
@@ -100,7 +100,7 @@ public:
                      { fImageQuality = lquality;} // *SUBMENU*
    virtual void     SetPalette(const TImagePalette *palette);
    virtual void     StartPaletteEditor(); // *MENU*
-   virtual void     EditorClosed() { fPaletteEditor = 0; }
+   virtual void     EditorClosed() { fPaletteEditor = nullptr; }
    Bool_t           IsPaletteEnabled() const { return fPaletteEnabled; }
 
    ClassDef(TAttImage,1)  //Image attributes

--- a/graf2d/graf/inc/TCurlyLine.h
+++ b/graf2d/graf/inc/TCurlyLine.h
@@ -37,7 +37,7 @@ public:
    TCurlyLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
               Double_t wl = .02,
               Double_t amp = .01);
-   virtual ~TCurlyLine(){;}
+   virtual ~TCurlyLine(){}
    virtual void Build();
    Int_t        DistancetoPrimitive(Int_t px, Int_t py) override;
    void         ExecuteEvent(Int_t event, Int_t px, Int_t py) override;

--- a/graf2d/graf/inc/TImage.h
+++ b/graf2d/graf/inc/TImage.h
@@ -113,9 +113,9 @@ public:
    // Input / output
    virtual void ReadImage(const char * /*file*/, EImageFileTypes /*type*/ = TImage::kUnknown) {}
    virtual void WriteImage(const char * /*file*/, EImageFileTypes /*type*/ = TImage::kUnknown)  {}
-   virtual void SetImage(const Double_t * /*imageData*/, UInt_t /*width*/, UInt_t /*height*/, TImagePalette * /*palette*/ = 0) {}
-   virtual void SetImage(const TArrayD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = 0) {}
-   virtual void SetImage(const TVectorD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = 0) {}
+   virtual void SetImage(const Double_t * /*imageData*/, UInt_t /*width*/, UInt_t /*height*/, TImagePalette * /*palette*/ = nullptr) {}
+   virtual void SetImage(const TArrayD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = nullptr) {}
+   virtual void SetImage(const TVectorD & /*imageData*/, UInt_t /*width*/, TImagePalette * /*palette*/ = nullptr) {}
    virtual void SetImage(Pixmap_t /*pxm*/, Pixmap_t /*mask*/ = 0) {}
 
    // Create an image from the given pad. (See TASImage::FromPad)
@@ -158,14 +158,14 @@ public:
    virtual void Blur(Double_t /*horizontal*/ = 3, Double_t /*vertical*/ = 3) { }
 
    // Reduces colordepth of an image. (See TASImage::Vectorize)
-   virtual Double_t *Vectorize(UInt_t /*max_colors*/ = 256, UInt_t /*dither*/ = 4, Int_t /*opaque_threshold*/ = 0) { return 0; }
+   virtual Double_t *Vectorize(UInt_t /*max_colors*/ = 256, UInt_t /*dither*/ = 4, Int_t /*opaque_threshold*/ = 0) { return nullptr; }
 
    // (See TASImage::HSV)
    virtual void HSV(UInt_t /*hue*/ = 0, UInt_t /*radius*/ = 360, Int_t /*H*/ = 0, Int_t /*S*/ = 0, Int_t /*V*/ = 0,
                     Int_t /*x*/ = 0, Int_t /*y*/ = 0, UInt_t /*width*/ = 0, UInt_t /*height*/ = 0) {}
 
    // Render multipoint gradient inside a rectangle. (See TASImage::Gradient)
-   virtual void Gradient(UInt_t /*angle*/ = 0, const char * /*colors*/ = "#FFFFFF #000000", const char * /*offsets*/ = 0,
+   virtual void Gradient(UInt_t /*angle*/ = 0, const char * /*colors*/ = "#FFFFFF #000000", const char * /*offsets*/ = nullptr,
                          Int_t /*x*/ = 0, Int_t /*y*/ = 0, UInt_t /*width*/ = 0, UInt_t /*height*/ = 0) {}
 
    // Merge two images. (See TASImage::Merge)
@@ -189,7 +189,7 @@ public:
                          const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1, Int_t /*mode*/ = 0) {}
    virtual void DrawRectangle(UInt_t /*x*/, UInt_t /*y*/, UInt_t /*w*/, UInt_t /*h*/,
                               const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1) {}
-   virtual void FillRectangle(const char * /*col*/ = 0, Int_t /*x*/ = 0, Int_t /*y*/ = 0,
+   virtual void FillRectangle(const char * /*col*/ = nullptr, Int_t /*x*/ = 0, Int_t /*y*/ = 0,
                               UInt_t /*width*/ = 0, UInt_t /*height*/ = 0) {}
    virtual void DrawPolyLine(UInt_t /*nn*/, TPoint * /*xy*/, const char * /*col*/ = "#000000",
                              UInt_t /*thick*/ = 1, TImage::ECoordMode /*mode*/ = kCoordModeOrigin) {}
@@ -198,24 +198,24 @@ public:
                           TImage::ECoordMode /*mode*/ = kCoordModeOrigin) {}
    virtual void DrawSegments(UInt_t /*nseg*/, Segment_t * /*seg*/, const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1) {}
    virtual void DrawText(Int_t /*x*/ = 0, Int_t /*y*/ = 0, const char * /*text*/ = "", Int_t /*size*/ = 12,
-                         const char * /*color*/ = 0, const char * /*font*/ = "fixed",
-                         EText3DType /*type*/ = TImage::kPlain, const char * /*fore_file*/ = 0, Float_t /*angle*/ = 0) { }
+                         const char * /*color*/ = nullptr, const char * /*font*/ = "fixed",
+                         EText3DType /*type*/ = TImage::kPlain, const char * /*fore_file*/ = nullptr, Float_t /*angle*/ = 0) { }
    virtual void DrawText(TText * /*text*/, Int_t /*x*/ = 0, Int_t /*y*/ = 0) { }
    virtual void FillPolygon(UInt_t /*npt*/, TPoint * /*ppt*/, const char * /*col*/ = "#000000",
-                           const char * /*stipple*/ = 0, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
+                           const char * /*stipple*/ = nullptr, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
    virtual void FillPolygon(UInt_t /*npt*/, TPoint * /*ppt*/, TImage * /*tile*/) {}
    virtual void CropPolygon(UInt_t /*npt*/, TPoint * /*ppt*/) {}
    virtual void DrawFillArea(UInt_t /*npt*/, TPoint * /*ppt*/, const char * /*col*/ = "#000000",
-                           const char * /*stipple*/ = 0, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
+                           const char * /*stipple*/ = nullptr, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
    virtual void DrawFillArea(UInt_t /*npt*/, TPoint * /*ppt*/, TImage * /*tile*/) {}
    virtual void FillSpans(UInt_t /*npt*/, TPoint * /*ppt*/, UInt_t * /*widths*/,  const char * /*col*/ = "#000000",
-                         const char * /*stipple*/ = 0, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
+                         const char * /*stipple*/ = nullptr, UInt_t /*w*/ = 16, UInt_t /*h*/ = 16) {}
    virtual void FillSpans(UInt_t /*npt*/, TPoint * /*ppt*/, UInt_t * /*widths*/, TImage * /*tile*/) {}
    virtual void CropSpans(UInt_t /*npt*/, TPoint * /*ppt*/, UInt_t * /*widths*/) {}
    virtual void CopyArea(TImage * /*dst*/, Int_t /*xsrc*/, Int_t /*ysrc*/, UInt_t /*w*/, UInt_t /*h*/,
                          Int_t /*xdst*/ = 0, Int_t /*ydst*/ = 0, Int_t /*gfunc*/ = 3, EColorChan /*chan*/ = kAllChan) {}
    virtual void DrawCellArray(Int_t /*x1*/, Int_t /*y1*/, Int_t /*x2*/, Int_t /*y2*/, Int_t /*nx*/, Int_t /*ny*/, UInt_t * /*ic*/) {}
-   virtual void FloodFill(Int_t /*x*/, Int_t /*y*/, const char * /*col*/, const char * /*min_col*/, const char * /*max_col*/ = 0) {}
+   virtual void FloodFill(Int_t /*x*/, Int_t /*y*/, const char * /*col*/, const char * /*min_col*/, const char * /*max_col*/ = nullptr) {}
    virtual void DrawCubeBezier(Int_t /*x1*/, Int_t /*y1*/, Int_t /*x2*/, Int_t /*y2*/, Int_t /*x3*/, Int_t /*y3*/, const char * /*col*/ = "#000000", UInt_t /*thick*/ = 1) {}
    virtual void DrawStraightEllips(Int_t /*x*/, Int_t /*y*/, Int_t /*rx*/, Int_t /*ry*/, const char * /*col*/ = "#000000", Int_t /*thick*/ = 1) {}
    virtual void DrawCircle(Int_t /*x*/, Int_t /*y*/, Int_t /*r*/, const char * /*col*/ = "#000000", Int_t /*thick*/ = 1) {}
@@ -228,16 +228,16 @@ public:
    virtual UInt_t GetWidth() const { return 0; }
    virtual UInt_t GetHeight() const { return 0; }
    virtual Bool_t IsValid() const { return kTRUE; }
-   virtual TImage *GetScaledImage() const { return 0; }
+   virtual TImage *GetScaledImage() const { return nullptr; }
 
-   virtual TArrayL  *GetPixels(Int_t /*x*/= 0, Int_t /*y*/= 0, UInt_t /*w*/ = 0, UInt_t /*h*/ = 0) { return 0; }
-   virtual TArrayD  *GetArray(UInt_t /*w*/ = 0, UInt_t /*h*/ = 0, TImagePalette * = gWebImagePalette) { return 0; }
+   virtual TArrayL  *GetPixels(Int_t /*x*/= 0, Int_t /*y*/= 0, UInt_t /*w*/ = 0, UInt_t /*h*/ = 0) { return nullptr; }
+   virtual TArrayD  *GetArray(UInt_t /*w*/ = 0, UInt_t /*h*/ = 0, TImagePalette * = gWebImagePalette) { return nullptr; }
    virtual Pixmap_t  GetPixmap() { return 0; }
    virtual Pixmap_t  GetMask() { return 0; }
-   virtual UInt_t   *GetArgbArray() { return 0; }
-   virtual UInt_t   *GetRgbaArray() { return 0; }
-   virtual Double_t *GetVecArray() { return 0; }
-   virtual UInt_t   *GetScanline(UInt_t /*y*/) { return 0; }
+   virtual UInt_t   *GetArgbArray() { return nullptr; }
+   virtual UInt_t   *GetRgbaArray() { return nullptr; }
+   virtual Double_t *GetVecArray() { return nullptr; }
+   virtual UInt_t   *GetScanline(UInt_t /*y*/) { return nullptr; }
    virtual void      GetImageBuffer(char ** /*buffer*/, int* /*size*/, EImageFileTypes /*type*/ = TImage::kPng) {}
    virtual Bool_t    SetImageBuffer(char ** /*buffer*/, EImageFileTypes /*type*/ = TImage::kPng) { return kFALSE; }
    virtual void      PaintImage(Drawable_t /*wid*/, Int_t /*x*/, Int_t /*y*/, Int_t /*xsrc*/ = 0, Int_t /*ysrc*/ = 0, UInt_t /*wsrc*/ = 0, UInt_t /*hsrc*/ = 0, Option_t * /*opt*/ = "") { }
@@ -249,8 +249,8 @@ public:
    static TImage *Open(const char *file, EImageFileTypes type = kUnknown);
    static TImage *Open(char **data);
    static TImage *Open(const char *name, const Double_t *imageData, UInt_t width, UInt_t height, TImagePalette *palette);
-   static TImage *Open(const char *name, const TArrayD &imageData, UInt_t width, TImagePalette *palette = 0);
-   static TImage *Open(const char *name, const TVectorD &imageData, UInt_t width, TImagePalette *palette = 0);
+   static TImage *Open(const char *name, const TArrayD &imageData, UInt_t width, TImagePalette *palette = nullptr);
+   static TImage *Open(const char *name, const TVectorD &imageData, UInt_t width, TImagePalette *palette = nullptr);
 
    TImage    &operator+=(const TImage &i) { Append(&i, "+"); return *this; }
    TImage    &operator/=(const TImage &i) { Append(&i, "/"); return *this; }

--- a/graf2d/graf/inc/TPie.h
+++ b/graf2d/graf/inc/TPie.h
@@ -48,8 +48,8 @@ protected:
 public:
    TPie();
    TPie(const char *,const char *, Int_t);
-   TPie(const char *,const char *, Int_t, Double_t *,Int_t *cols=0, const char *lbls[]=0);
-   TPie(const char *,const char *, Int_t, Float_t *,Int_t *cols=0, const char *lbls[]=0);
+   TPie(const char *,const char *, Int_t, Double_t *, Int_t *cols = nullptr, const char *lbls[] = nullptr);
+   TPie(const char *,const char *, Int_t, Float_t *, Int_t *cols = nullptr, const char *lbls[] = nullptr);
    TPie(const TH1 *h);
    TPie(const TPie&);
    ~TPie();

--- a/graf2d/gviz/inc/TGraphNode.h
+++ b/graf2d/gviz/inc/TGraphNode.h
@@ -46,7 +46,7 @@ public:
    virtual Int_t  DistancetoPrimitive(Int_t px, Int_t py);
    virtual void   ExecuteEvent(Int_t event, Int_t px, Int_t py);
    void           SetGVNode(GVizAgnode_t *gvn) {fGVNode = gvn;}
-   virtual void   SetTextAngle(Float_t) {;}
+   virtual void   SetTextAngle(Float_t) {}
    GVizAgnode_t  *GetGVNode() {return fGVNode;}
    void           Layout();
    virtual void   Paint(Option_t *option="");

--- a/hist/histpainter/inc/TGraph2DPainter.h
+++ b/hist/histpainter/inc/TGraph2DPainter.h
@@ -65,7 +65,7 @@ protected:
    TGraph2D *fGraph2D;            ///<! Pointer to the TGraph2D in fDelaunay
 
    void FindTriangles();
-   void PaintLevels(Int_t *v, Double_t *x, Double_t *y, Int_t nblev=0, Double_t *glev=0);
+   void PaintLevels(Int_t *v, Double_t *x, Double_t *y, Int_t nblev = 0, Double_t *glev = nullptr);
    void PaintPolyMarker0(Int_t n, Double_t *x, Double_t *y);
 
    void PaintTriangles_old(Option_t *option);

--- a/hist/histpainter/inc/THistPainter.h
+++ b/hist/histpainter/inc/THistPainter.h
@@ -140,7 +140,7 @@ public:
    static  Int_t      ProjectSinusoidal2xy(Double_t l, Double_t b, Double_t &Al, Double_t &Ab);
    static  Int_t      ProjectParabolic2xy(Double_t l, Double_t b, Double_t &Al, Double_t &Ab);
    virtual void       RecalculateRange();
-   void       RecursiveRemove(TObject *) override {;}
+   void       RecursiveRemove(TObject *) override {}
    void       SetHighlight() override;
    void       SetHistogram(TH1 *h) override;
    void       SetStack(TList *stack) override {fStack = stack;}


### PR DESCRIPTION
Allows to use `-Wzero-as-null-pointer-constant` compiler flag in derived projects