### PR TITLE
Bump minimum Dask version to 2022.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ metakernel>=0.20.0
 
 # Distributed RDataFrame
 pyspark>=2.4 # Spark backend
-dask>=2020.12 # Dask backend
-distributed>=2020.12 # Dask backend
+dask>=2022.02.0 # Dask backend
+distributed>=2022.02.0 # Dask backend
 dask-jobqueue>=0.7.3 # Dask backend


### PR DESCRIPTION
To fix the timeouts seen in our CI runs of the distributed RDataFrame with Dask suite. In particular, the Dask version used was 2021.10.0. Version 2021.11.2 fixes a couple of deadlock bugs which were most probably responsible for the timeouts (see https://distributed.dask.org/en/stable/changelog.html#v2021-11-2).

We bump the minimum Dask version to 2022.02.0 (
https://distributed.dask.org/en/stable/changelog.html#v2022-02-0) because it is the last version with support for Python 3.7 (the current minimum Python version for distributed RDataFrame).

The test suite was run with Dask 2021.10.0 on both Ubuntu and Fedora, showing the timeout. Version 2021.11.2 doesn't timeout.
