### PR TITLE
Remove dependency from dask_jobqueue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ metakernel>=0.20.0
 pyspark>=2.4 # Spark backend
 dask>=2022.02.0 # Dask backend
 distributed>=2022.02.0 # Dask backend
-dask-jobqueue>=0.7.3 # Dask backend


### PR DESCRIPTION
It was there to test whether the user wants to connect to a batch system with Dask and consequently get the number of cores requested. Now this is done lazily, and if the module is not found it means that there is no connection to a batch system involved. Thus we can just get the number of cores through the more generic Client API.
