### PR TITLE
Fix #11383 (deadlock at initialization)

### DIFF
--- a/core/base/src/TErrorDefaultHandler.cxx
+++ b/core/base/src/TErrorDefaultHandler.cxx
@@ -102,7 +102,7 @@ void DefaultErrorHandler(Int_t level, Bool_t abort_bool, const char *location, c
 {
    if (gErrorIgnoreLevel == kUnset) {
       // This can also print error messages, so we need to do it outside the lock
-      auto cstrlevel = gEnv->GetValue("Root.ErrorIgnoreLevel", "Print");
+      auto cstrlevel = gEnv ? gEnv->GetValue("Root.ErrorIgnoreLevel", "Print") : 0;
 
       std::lock_guard<std::mutex> guard(*GetErrorMutex());
 

--- a/core/base/src/TErrorDefaultHandler.cxx
+++ b/core/base/src/TErrorDefaultHandler.cxx
@@ -101,12 +101,14 @@ again:
 void DefaultErrorHandler(Int_t level, Bool_t abort_bool, const char *location, const char *msg)
 {
    if (gErrorIgnoreLevel == kUnset) {
+      // This can also print error messages, so we need to do it outside the lock
+      auto cstrlevel = gEnv->GetValue("Root.ErrorIgnoreLevel", "Print");
+
       std::lock_guard<std::mutex> guard(*GetErrorMutex());
 
       gErrorIgnoreLevel = 0;
       if (gEnv) {
          std::string slevel;
-         auto cstrlevel = gEnv->GetValue("Root.ErrorIgnoreLevel", "Print");
          while (cstrlevel && *cstrlevel) {
             slevel.push_back(tolower(*cstrlevel));
             cstrlevel++;

--- a/core/base/src/TErrorDefaultHandler.cxx
+++ b/core/base/src/TErrorDefaultHandler.cxx
@@ -101,12 +101,12 @@ again:
 void DefaultErrorHandler(Int_t level, Bool_t abort_bool, const char *location, const char *msg)
 {
    if (gErrorIgnoreLevel == kUnset) {
-      // This can also print error messages, so we need to do it outside the lock
-      auto cstrlevel = gEnv ? gEnv->GetValue("Root.ErrorIgnoreLevel", "Print") : 0;
-
-      std::lock_guard<std::mutex> guard(*GetErrorMutex());
-
       if (gEnv) {
+         // This can also print error messages, so we need to do it outside the lock
+         auto cstrlevel = gEnv->GetValue("Root.ErrorIgnoreLevel", "Print");
+
+         std::lock_guard<std::mutex> guard(*GetErrorMutex());
+
          gErrorIgnoreLevel = 0;
          std::string slevel;
          while (cstrlevel && *cstrlevel) {

--- a/core/base/src/TErrorDefaultHandler.cxx
+++ b/core/base/src/TErrorDefaultHandler.cxx
@@ -106,8 +106,8 @@ void DefaultErrorHandler(Int_t level, Bool_t abort_bool, const char *location, c
 
       std::lock_guard<std::mutex> guard(*GetErrorMutex());
 
-      gErrorIgnoreLevel = 0;
       if (gEnv) {
+         gErrorIgnoreLevel = 0;
          std::string slevel;
          while (cstrlevel && *cstrlevel) {
             slevel.push_back(tolower(*cstrlevel));


### PR DESCRIPTION
Previously if a message (for example warning of duplicate dictionary) happened during intialization, it would trigger the initialization of gROOT and could trigger a nested Warning. for example due to the duplicate rootmap file entry and would cause a dead lock (recursiverly taking the non recursive lock GetErrorMutex().

