### PR TITLE
Fix long long error in findBuiltinType

### DIFF
--- a/interpreter/cling/lib/Interpreter/LookupHelper.cpp
+++ b/interpreter/cling/lib/Interpreter/LookupHelper.cpp
@@ -347,8 +347,8 @@ namespace cling {
       return Context.LongTy;
     }
     if (typeName.equals("long long")) {
-      if (isunsigned) return Context.LongLongTy;
-      return Context.UnsignedLongLongTy;
+      if (isunsigned) return Context.UnsignedLongLongTy;
+      return Context.LongLongTy;
     }
     if (!issigned && !isunsigned) {
       if (typeName.equals("bool")) return Context.BoolTy;


### PR DESCRIPTION
The signed and unsigned logic was reversed for long long and unsigned long long. This PR fixes that.

