### PR TITLE
[tmva][sofie] Fix operator Shape

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
@@ -52,7 +52,7 @@ public:
       size_t length = ConvertShapeToLength(fShape);
       if (fStart < 0) fStart += length;
       if (fEnd < 0) fEnd += length;
-      fOutput_shape = { size_t(fEnd - fStart) };
+      fOutput_shape = { size_t(fEnd - fStart) + 1};
       model.AddIntermediateTensor(fNY, ETensorType::INT64, fOutput_shape);
    }
 


### PR DESCRIPTION
End axis value passed as attribute in Shape is included. So a +1 was missing when computing the output tensor length


This PR should fix the failure observed in the TestCustomModelFromONNX

