### PR TITLE
[PyROOT][RDF] Fixes for Define and Filter pythonizations

### DIFF
--- a/bindings/pyroot/pythonizations/test/rdf_define_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_define_pyz.py
@@ -70,6 +70,43 @@ class PyDefine(unittest.TestCase):
         arr = np.sqrt(arr*arr + arr*arr )
         flag = np.array_equal(rdf.AsNumpy()["mag"], arr)
         self.assertTrue(flag)
+
+    def test_cpp_functor(self):
+        """
+        Test that a C++ functor can be passed as a callable argument of a
+        Define operation.
+        """
+
+        ROOT.gInterpreter.Declare("""
+        struct MyFunctor
+        {
+            ULong64_t operator()(ULong64_t l) { return l*l; };
+        };
+        """)
+        f = ROOT.MyFunctor()
+
+        rdf = ROOT.RDataFrame(5)
+        rdf2 = rdf.Define("x", f, ["rdfentry_"])
+
+        for x,y in zip(rdf2.Take['ULong64_t']("rdfentry_"), rdf2.Take['ULong64_t']("x")):
+           self.assertEqual(x*x, y)
+
+    def test_std_function(self):
+        """
+        Test that an std::function can be passed as a callable argument of a
+        Define operation.
+        """
+
+        ROOT.gInterpreter.Declare("""
+        std::function<ULong64_t(ULong64_t)> myfun = [](ULong64_t l) { return l*l; };
+        """)
+
+        rdf = ROOT.RDataFrame(5)
+        rdf2 = rdf.Define("x", ROOT.myfun, ["rdfentry_"])
+
+        for x,y in zip(rdf2.Take['ULong64_t']("rdfentry_"), rdf2.Take['ULong64_t']("x")):
+           self.assertEqual(x*x, y)
+
     
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
+++ b/bindings/pyroot/pythonizations/test/rdf_filter_pyz.py
@@ -86,6 +86,41 @@ class PyFilter(unittest.TestCase):
             return x > y
         fil1 = rdf.Filter(x_greater_than_y, "x is greater than 2")
         self.assertTrue(np.array_equal(fil1.AsNumpy()["x"], np.array([3, 4])))
+
+    def test_cpp_functor(self):
+        """
+        Test that a C++ functor can be passed as a callable argument of a
+        Filter operation.
+        """
+
+        ROOT.gInterpreter.Declare("""
+        struct MyFunctor
+        {
+            bool operator()(ULong64_t l) { return l == 0; };
+        };
+        """)
+        f = ROOT.MyFunctor()
+
+        rdf = ROOT.RDataFrame(5)
+        c = rdf.Filter(f, ["rdfentry_"]).Count().GetValue()
+
+        self.assertEqual(c, 1)
+
+    def test_std_function(self):
+        """
+        Test that an std::function can be passed as a callable argument of a
+        Filter operation.
+        """
+
+        ROOT.gInterpreter.Declare("""
+        std::function<bool(ULong64_t)> myfun = [](ULong64_t l) { return l == 0; };
+        """)
+
+        rdf = ROOT.RDataFrame(5)
+        c = rdf.Filter(ROOT.myfun, ["rdfentry_"]).Count().GetValue()
+
+        self.assertEqual(c, 1)
+
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Introduces a couple of fixes for Define and Filter pythonizations, namely:
- Fixes #10092 so that Python lists can be passed in `Filter` operations to specify column names.
- Restores support for C++ functors and `std::function`s passed as callable arguments of `Define` and `Filter`.

and adds the corresponding tests.