### PR TITLE
[RF] Add back dependency of testHistFactory on RooFitCommon

### DIFF
--- a/roofit/histfactory/test/CMakeLists.txt
+++ b/roofit/histfactory/test/CMakeLists.txt
@@ -7,7 +7,7 @@
 # @author Stephan Hageboeck CERN, 2019
 
 ROOT_ADD_GTEST(testHistFactory testHistFactory.cxx
-  LIBRARIES RooFitCore RooFit RooStats HistFactory
+  LIBRARIES RooFitCommon RooFitCore RooFit RooStats HistFactory
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/ref_6.16_example_UsingC_channel1_meas_model.root ${CMAKE_CURRENT_SOURCE_DIR}/ref_6.16_example_UsingC_combined_meas_model.root)
 
 ROOT_ADD_GTEST(testParamHistFunc testParamHistFunc.cxx LIBRARIES RooFitCore HistFactory)


### PR DESCRIPTION
The last commit that touched `roofit/histfactory/test/CMakeLists.txt` was accidentally removing the dependency on RooFitCommon, which needs to be there to avoid linker errors on Windows.