### PR TITLE
Respect the user-provided number of entries to be displayed

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1318,10 +1318,11 @@ private:
    using Display_t = ROOT::RDF::RDisplay;
    const std::shared_ptr<Display_t> fDisplayerHelper;
    const std::shared_ptr<PrevNodeType> fPrevNode;
+   int fEntriesToProcess;
 
 public:
-   DisplayHelper(const std::shared_ptr<Display_t> &d, const std::shared_ptr<PrevNodeType> &prevNode)
-      : fDisplayerHelper(d), fPrevNode(prevNode)
+   DisplayHelper(int nRows, const std::shared_ptr<Display_t> &d, const std::shared_ptr<PrevNodeType> &prevNode)
+      : fDisplayerHelper(d), fPrevNode(prevNode), fEntriesToProcess(nRows)
    {
    }
    DisplayHelper(DisplayHelper &&) = default;
@@ -1331,8 +1332,17 @@ public:
    template <typename... Columns>
    void Exec(unsigned int, Columns &... columns)
    {
+      if (fEntriesToProcess == 0)
+         return;
+
       fDisplayerHelper->AddRow(columns...);
-      if (!fDisplayerHelper->HasNext()) {
+      --fEntriesToProcess;
+
+      if (fEntriesToProcess == 0) {
+         // No more entries to process. Send a one-time signal that this node
+         // of the graph is done. It is important that the 'StopProcessing'
+         // method is only called once from this helper, otherwise it would seem
+         // like more than one operation has completed its work.
          fPrevNode->StopProcessing();
       }
    }

--- a/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/InterfaceUtils.hxx
@@ -230,15 +230,19 @@ BuildAction(const ColumnNames_t &bl, const std::shared_ptr<double> &stdDeviation
    return std::make_unique<Action_t>(Helper_t(stdDeviationV, nSlots), bl, prevNode, colRegister);
 }
 
+using displayHelperArgs_t = std::pair<int, std::shared_ptr<ROOT::RDF::RDisplay>>;
+
 // Display action
 template <typename... ColTypes, typename PrevNodeType>
-std::unique_ptr<RActionBase> BuildAction(const ColumnNames_t &bl, const std::shared_ptr<RDisplay> &d,
-                                         const unsigned int, std::shared_ptr<PrevNodeType> prevNode,
-                                         ActionTags::Display, const RDFInternal::RColumnRegister &colRegister)
+std::unique_ptr<RActionBase>
+BuildAction(const ColumnNames_t &bl, const std::shared_ptr<displayHelperArgs_t> &helperArgs, const unsigned int,
+            std::shared_ptr<PrevNodeType> prevNode, ActionTags::Display,
+            const RDFInternal::RColumnRegister &colRegister)
 {
    using Helper_t = DisplayHelper<PrevNodeType>;
    using Action_t = RAction<Helper_t, PrevNodeType, TTraits::TypeList<ColTypes...>>;
-   return std::make_unique<Action_t>(Helper_t(d, prevNode), bl, prevNode, colRegister);
+   return std::make_unique<Action_t>(Helper_t(helperArgs->first, helperArgs->second, prevNode), bl, prevNode,
+                                     colRegister);
 }
 
 struct SnapshotHelperArgs {

--- a/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RDisplay.hxx
@@ -87,8 +87,6 @@ private:
    size_t fNextRow = 1;       ///< Next row to be filled.
    size_t fCurrentColumn = 0; ///< Column that is being filled.
 
-   size_t fEntries; ///< Number of events to process for each column (i.e. number of rows).
-
    size_t fNMaxCollectionElements = 10; // threshold on number of elements in collections to be Print()
 
    ////////////////////////////////////////////////////////////////////////////
@@ -223,13 +221,7 @@ private:
             AddToRow(fRepresentations[i]);
          }
       }
-      // This row has been parsed
-      fEntries--;
    }
-
-   ////////////////////////////////////////////////////////////////////////////
-   /// If the number of required rows has been parsed, returns false.
-   bool HasNext() { return fEntries > 0; }
 
    void EnsureCurrentColumnWidth(size_t w);
 
@@ -238,9 +230,8 @@ public:
    /// Creates an RDisplay to print the event values
    /// \param[in] columnNames Columns to print
    /// \param[in] types The type of each column
-   /// \param[in] entries How many events per column (row) must be processed.
    /// \param[in] nMaxCollectionElements Number of maximum elements in collection.
-   RDisplay(const VecStr_t &columnNames, const VecStr_t &types, int entries, size_t nMaxCollectionElements);
+   RDisplay(const VecStr_t &columnNames, const VecStr_t &types, size_t nMaxCollectionElements);
 
    ////////////////////////////////////////////////////////////////////////////
    /// Prints the representation to the standard output

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2643,17 +2643,16 @@ public:
    /// d2->Print();
    /// ~~~
    template <typename... ColumnTypes>
-   RResultPtr<RDisplay>
-   Display(const ColumnNames_t &columnList, int nRows = 5, size_t nMaxCollectionElements = 10)
+   RResultPtr<RDisplay> Display(const ColumnNames_t &columnList, int nRows = 5, size_t nMaxCollectionElements = 10)
    {
       CheckIMTDisabled("Display");
       auto newCols = columnList;
       newCols.insert(newCols.begin(), "rdfentry_"); // Artificially insert first column
-      auto displayer = std::make_shared<RDFInternal::RDisplay>(newCols, GetColumnTypeNamesList(newCols), nRows,
-                                                               nMaxCollectionElements);
+      auto displayer = std::make_shared<RDisplay>(newCols, GetColumnTypeNamesList(newCols), nMaxCollectionElements);
+      using displayHelperArgs_t = std::pair<int, std::shared_ptr<RDisplay>>;
       // Need to add ULong64_t type corresponding to the first column rdfentry_
-      return CreateAction<RDFInternal::ActionTags::Display, ULong64_t, ColumnTypes...>(std::move(newCols), displayer,
-                                                                                       displayer, fProxiedPtr);
+      return CreateAction<RDFInternal::ActionTags::Display, ULong64_t, ColumnTypes...>(
+         std::move(newCols), displayer, std::make_shared<displayHelperArgs_t>(nRows, displayer), fProxiedPtr);
    }
 
    ////////////////////////////////////////////////////////////////////////////
@@ -2667,16 +2666,16 @@ public:
    /// See the previous overloads for further details.
    ///
    /// Invoked when no types are specified to Display
-   RResultPtr<RDisplay>
-   Display(const ColumnNames_t &columnList, int nRows = 5, size_t nMaxCollectionElements = 10)
+   RResultPtr<RDisplay> Display(const ColumnNames_t &columnList, int nRows = 5, size_t nMaxCollectionElements = 10)
    {
       CheckIMTDisabled("Display");
       auto newCols = columnList;
       newCols.insert(newCols.begin(), "rdfentry_"); // Artificially insert first column
-      auto displayer = std::make_shared<RDFInternal::RDisplay>(newCols, GetColumnTypeNamesList(newCols), nRows,
-                                                               nMaxCollectionElements);
+      auto displayer = std::make_shared<RDisplay>(newCols, GetColumnTypeNamesList(newCols), nMaxCollectionElements);
+      using displayHelperArgs_t = std::pair<int, std::shared_ptr<RDisplay>>;
       return CreateAction<RDFInternal::ActionTags::Display, RDFDetail::RInferredType>(
-         std::move(newCols), displayer, displayer, fProxiedPtr, columnList.size() + 1);
+         std::move(newCols), displayer, std::make_shared<displayHelperArgs_t>(nRows, displayer), fProxiedPtr,
+         columnList.size() + 1);
    }
 
    ////////////////////////////////////////////////////////////////////////////

--- a/tree/dataframe/src/RDFDisplay.cxx
+++ b/tree/dataframe/src/RDFDisplay.cxx
@@ -175,9 +175,9 @@ void RDisplay::MovePosition()
    }
 }
 
-RDisplay::RDisplay(const VecStr_t &columnNames, const VecStr_t &types, int entries, size_t nMaxCollectionElements)
+RDisplay::RDisplay(const VecStr_t &columnNames, const VecStr_t &types, size_t nMaxCollectionElements)
    : fTypes(types), fWidths(columnNames.size(), 0), fRepresentations(columnNames.size()),
-     fCollectionsRepresentations(columnNames.size()), fNColumns(columnNames.size()), fEntries(entries),
+     fCollectionsRepresentations(columnNames.size()), fNColumns(columnNames.size()),
      fNMaxCollectionElements(nMaxCollectionElements)
 {
    // Add the first row with the names of the columns


### PR DESCRIPTION
Fixes #11390

Improves the workflow of `DisplayHelper::Exec` as follows:
1. We always check whether there are entries to be displayed with `RDisplay::HasNext`. If so, add one row to the display object
2. If no more entries should be displayed, signal this node has finished its job. Make sure the call to `StopProcessing` is done only once with a boolean flag, to avoid early stop of the execution due to more stop signals than the children who actually have finished their job.



