### PR TITLE
[RF] New mechanism to evaluate a `RooProdPdf` for a given normalization set in BatchMode

### DIFF
--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -55,8 +55,6 @@ public:
   TObject* clone(const char* newname) const override { return new RooProdPdf(*this,newname) ; }
   ~RooProdPdf() override ;
 
-  bool checkObservables(const RooArgSet* nset) const override ;
-
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
   Int_t getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& numVars, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
   double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -100,8 +100,6 @@ public:
 private:
 
   double evaluate() const override ;
-  void computeBatch(cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const override;
-  inline bool canComputeBatchWithCuda() const override { return true; }
 
   std::unique_ptr<RooAbsReal> makeCondPdfRatioCorr(RooAbsReal& term, const RooArgSet& termNset, const RooArgSet& termImpSet, const char* normRange, const char* refRange) const ;
 
@@ -159,6 +157,7 @@ private:
   RooAbsReal* specializeIntegral(RooAbsReal& orig, const char* targetRangeName) const ;
   RooAbsReal* specializeRatio(RooFormulaVar& input, const char* targetRangeName) const ;
   double calculate(const RooProdPdf::CacheElem& cache, bool verbose=false) const ;
+  void calculateBatch(const RooProdPdf::CacheElem& cache, cudaStream_t*, double* output, size_t nEvents, RooFit::Detail::DataMap const&) const;
 
 
   friend class RooProdGenContext ;

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -161,6 +161,7 @@ private:
 
 
   friend class RooProdGenContext ;
+  friend class RooFixedProdPdf ;
   RooAbsGenContext* genContext(const RooArgSet &vars, const RooDataSet *prototype=nullptr,
                                   const RooArgSet *auxProto=nullptr, bool verbose= false) const override ;
 

--- a/roofit/roofitcore/inc/RooProdPdf.h
+++ b/roofit/roofitcore/inc/RooProdPdf.h
@@ -149,6 +149,9 @@ private:
     void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) override ;
     void writeToStream(std::ostream& os) const ;
   } ;
+
+  std::unique_ptr<CacheElem> createCacheElem(const RooArgSet* nset, const RooArgSet* iset, const char* isetRangeName=nullptr) const;
+
   mutable RooObjCacheManager _cacheMgr ; //! The cache manager
 
   CacheElem* getCacheElem(RooArgSet const* nset) const ;

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -1697,15 +1697,6 @@ double RooProdPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, co
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Obsolete
-
-bool RooProdPdf::checkObservables(const RooArgSet* /*nset*/) const
-{ return false ; }
-
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// If this product contains exactly one extendable p.d.f return the extension abilities of
 /// that p.d.f, otherwise return CanNotBeExtended
 

--- a/roofit/roofitcore/src/RooProdPdf.cxx
+++ b/roofit/roofitcore/src/RooProdPdf.cxx
@@ -435,17 +435,24 @@ double RooProdPdf::calculate(const RooProdPdf::CacheElem& cache, bool /*verbose*
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Evaluate product of PDFs in batch mode.
-void RooProdPdf::computeBatch(cudaStream_t* stream, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
+void RooProdPdf::calculateBatch(const RooProdPdf::CacheElem& cache, cudaStream_t* stream, double* output, size_t nEvents, RooFit::Detail::DataMap const& dataMap) const
 {
-  RooBatchCompute::VarVector pdfs;
-  pdfs.reserve(_pdfList.size());
-  for (const RooAbsArg* i:_pdfList) {
-    auto span = dataMap.at(i);
-    pdfs.push_back(span);
-  }
-  RooBatchCompute::ArgVector special{ static_cast<double>(pdfs.size()) };
   auto dispatch = stream ? RooBatchCompute::dispatchCUDA : RooBatchCompute::dispatchCPU;
-  dispatch->compute(stream, RooBatchCompute::ProdPdf, output, nEvents, pdfs, special);
+
+  if (cache._isRearranged) {
+    auto numerator = dataMap.at(cache._rearrangedNum.get());
+    auto denominator = dataMap.at(cache._rearrangedDen.get());
+    dispatch->compute(stream, RooBatchCompute::Ratio, output, nEvents, {numerator, denominator});
+  } else {
+    RooBatchCompute::VarVector factors;
+    factors.reserve(cache._partList.size());
+    for (const RooAbsArg *i : cache._partList) {
+       auto span = dataMap.at(i);
+       factors.push_back(span);
+    }
+    RooBatchCompute::ArgVector special{static_cast<double>(factors.size())};
+    dispatch->compute(stream, RooBatchCompute::ProdPdf, output, nEvents, factors, special);
+  }
 }
 
 namespace {


### PR DESCRIPTION
The RooProdPdf is not trivial to deal with in BatchMode, because its
actual servers depend on the normalization set.

One should rather think of the RooProdPdf as something like a caching
PDF, but instead of creating a cached HistPdf for a given normalization
set, it creates an internal computation graph representing the
normalized product for a given normalization set.

This internal computation graph is not expsed via the usual
client-server interface. However, this is strictly required for the new
BatchMode: internal computation graphs are not allowed because the
RooFitDriver would not be able to manage memory copies between host and
device, and also schedeuling.

For this reason, BatchMode support is removed from the RooProdPdf class.
We only keep a `RooProdPdf::calculateBatch` function that can be used to
evaluated a given cache element when all the internal args are contained
in the BatchMode data map.

To correctly evaluate these computation graphs in the batchMode, a new
class is introduced that wraps them with the correct client-server
interface. Instances of this class are then created for each ProdPdf in
the original computation graph, and the ProdPdfs are replaced with these
objects.

This means all the different RooProdPdf cache configurations are now
correctly dealt with in the BatchMode, making the
`RooProdPdf/TestProdPdf.CachingOpt` unit test also pass with the
BatchMode.

