### PR TITLE
[cmake] Protect against empty COMPILE_DEFINITIONS in genreflex command

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -179,7 +179,10 @@ function(REFLEX_GENERATE_DICTIONARY dictionary)
 
   IF(TARGET ${dictionary})
     LIST(APPEND include_dirs $<TARGET_PROPERTY:${dictionary},INCLUDE_DIRECTORIES>)
-    LIST(APPEND definitions $<TARGET_PROPERTY:${dictionary},COMPILE_DEFINITIONS>)
+    # The COMPILE_DEFINITIONS list might contain empty elements. These are
+    # removed with the FILTER generator expression, excluding elements that
+    # match the ^$ regexp (only matches empty strings).
+    LIST(APPEND definitions "$<FILTER:$<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>,EXCLUDE,^$>")
   ENDIF()
 
   add_custom_command(


### PR DESCRIPTION
This applies the change made to ROOT_GENERATE_DICTIONARY in the main branch commit 08ab7e0306 to GENREFLEX_GENERATE_DICTIONARY.

This commit in conjunction with 08ab7e0306 fixes #11312.

See commit 08ab7e0306 and issue #11312 for more details on the issue and solution.

