### PR TITLE
[RF] Use VectorDataStore by default in all RooDataSet constructors

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
@@ -134,7 +134,7 @@ class RooDataSet(object):
 
         return dataset
 
-    def to_numpy(self, copy=True, compute_derived_weight=False):
+    def to_numpy(self, copy=True):
         """Export a RooDataSet to a dictinary of numpy arrays.
 
         Args:
@@ -143,12 +143,6 @@ class RooDataSet(object):
                          own the same memory. If the dataset uses a
                          RooTreeDataStore, there will always be a copy and the
                          copy argument is ignored.
-            compute_derived_weight (bool): Sometimes, the weight variable is
-                not stored in the dataset, but it is a derived variable like a
-                RooFormulaVar. If the compute_derived_weight is True, the
-                weights will be computed in this case and also stored in the
-                output. Switched off by default because the computation is
-                relatively expensive.
 
         Returns:
             dict: A dictionary with the variable or weight names as keys and
@@ -176,21 +170,6 @@ class RooDataSet(object):
                 + self.store().__class__.__name__
                 + " is not supported."
             )
-
-        # Special case where the weight is a derived variable (e.g. a RooFormulaVar).
-        # We don't want to miss putting the weight in the output arrays, so we
-        # are forced to iterate over the dataset to compute the weight.
-        if compute_derived_weight:
-            # Check if self.weightVar() is not a nullptr by using implicit
-            # conversion from `nullptr` to Bool.
-            if self.weightVar():
-                wgt_var_name = self.weightVar().GetName()
-                if not wgt_var_name in data:
-                    weight_array = np.zeros(self.numEntries(), dtype=np.float64)
-                    for i in range(self.numEntries()):
-                        self.get(i)
-                        weight_array[i] = self.weight()
-                    data[wgt_var_name] = weight_array
 
         return data
 
@@ -228,16 +207,10 @@ class RooDataSet(object):
             data, variables=variables, name=name, title=title, weight_name=weight_name, clip_to_limits=clip_to_limits
         )
 
-    def to_pandas(self, compute_derived_weight=False):
+    def to_pandas(self):
         """Export a RooDataSet to a pandas DataFrame.
 
         Args:
-            compute_derived_weight (bool): Sometimes, the weight variable is
-                not stored in the dataset, but it is a derived variable like a
-                RooFormulaVar. If the compute_derived_weight is True, the
-                weights will be computed in this case and also stored in the
-                output. Switched off by default because the computation is
-                relatively expensive.
 
         Note:
             Pandas copies the data from the numpy arrays when creating a

--- a/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
@@ -49,8 +49,9 @@ class TestRooDataSetNumpy(unittest.TestCase):
         w = data.addColumn(wFunc)
         wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
 
-        self.assertEqual(set(wdata.to_numpy().keys()), {"x", "cat"})
-        self.assertEqual(set(wdata.to_numpy(compute_derived_weight=True).keys()), {"x", "cat", "w"})
+        print(wdata.to_numpy())
+
+        self.assertEqual(set(wdata.to_numpy().keys()), {"x", "cat", "w"})
 
     def test_to_numpy_and_from_numpy(self):
         """Test exporting to numpy and then importing back a non-weighted dataset."""
@@ -86,7 +87,7 @@ class TestRooDataSetNumpy(unittest.TestCase):
         # Instruct dataset wdata to use w as event weight and not observable
         wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
 
-        np_data = wdata.to_numpy(compute_derived_weight=True)
+        np_data = wdata.to_numpy()
 
         wdata_2 = ROOT.RooDataSet.from_numpy(np_data, (x, cat, wvar), name="wdata_2", title="wdata_2", weight_name="w")
 

--- a/roofit/roofitcore/inc/RooAbsData.h
+++ b/roofit/roofitcore/inc/RooAbsData.h
@@ -79,8 +79,8 @@ public:
   RooAbsData* reduce(const RooArgSet& varSubset, const char* cut=nullptr) ;
   RooAbsData* reduce(const RooArgSet& varSubset, const RooFormulaVar& cutVar) ;
 
-  RooAbsDataStore* store() { return _dstore ; }
-  const RooAbsDataStore* store() const { return _dstore ; }
+  RooAbsDataStore* store() { return _dstore.get(); }
+  const RooAbsDataStore* store() const { return _dstore.get(); }
   const TTree* tree() const ;
   TTree *GetClonedTree() const;
 
@@ -362,7 +362,7 @@ protected:
   RooArgSet _vars;         ///< Dimensions of this data set
   RooArgSet _cachedVars ;  ///<! External variables cached with this data set
 
-  RooAbsDataStore* _dstore = nullptr; ///< Data storage implementation
+  std::unique_ptr<RooAbsDataStore> _dstore; ///< Data storage implementation
 
   std::map<std::string,RooAbsData*> _ownedComponents ; ///< Owned external components
 
@@ -375,7 +375,7 @@ private:
 
   const RooFit::UniqueId<RooAbsData> _uniqueId; ///<!
 
-   ClassDefOverride(RooAbsData, 6) // Abstract data collection
+   ClassDefOverride(RooAbsData, 7) // Abstract data collection
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAbsDataStore.h
+++ b/roofit/roofitcore/inc/RooAbsDataStore.h
@@ -51,7 +51,7 @@ public:
   virtual RooAbsDataStore* clone(const char* newname=nullptr) const = 0 ;
   virtual RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const = 0 ;
 
-  virtual RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+  virtual std::unique_ptr<RooAbsDataStore> reduce(RooStringView name, RooStringView title,
                                   const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                                   std::size_t nStart, std::size_t nStop) = 0 ;
 

--- a/roofit/roofitcore/inc/RooCompositeDataStore.h
+++ b/roofit/roofitcore/inc/RooCompositeDataStore.h
@@ -42,7 +42,7 @@ public:
   RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooCompositeDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooCompositeDataStore(*this,vars,newname) ; }
 
-  RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+  std::unique_ptr<RooAbsDataStore> reduce(RooStringView name, RooStringView title,
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 

--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -289,6 +289,8 @@ private:
   void registerWeightArraysToDataStore() const;
   VarInfo const& getVarInfo();
 
+  static std::unique_ptr<RooAbsDataStore> makeDefaultDataStore(const char* name, const char* title, RooArgSet const& vars);
+
   VarInfo _varInfo; ///<!
   std::vector<double> _interpolationBuffer; ///<! Buffer to contain values used for weight interpolation
 

--- a/roofit/roofitcore/inc/RooTreeDataStore.h
+++ b/roofit/roofitcore/inc/RooTreeDataStore.h
@@ -43,7 +43,7 @@ public:
   RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooTreeDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooTreeDataStore(*this,vars,newname) ; }
 
-  RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+  std::unique_ptr<RooAbsDataStore> reduce(RooStringView name, RooStringView title,
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 

--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -49,7 +49,7 @@ public:
   RooAbsDataStore* clone(const char* newname=nullptr) const override { return new RooVectorDataStore(*this,newname) ; }
   RooAbsDataStore* clone(const RooArgSet& vars, const char* newname=nullptr) const override { return new RooVectorDataStore(*this,vars,newname) ; }
 
-  RooAbsDataStore* reduce(RooStringView name, RooStringView title,
+  std::unique_ptr<RooAbsDataStore> reduce(RooStringView name, RooStringView title,
                           const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                           std::size_t nStart, std::size_t nStop) override;
 

--- a/roofit/roofitcore/src/RooCompositeDataStore.cxx
+++ b/roofit/roofitcore/src/RooCompositeDataStore.cxx
@@ -119,7 +119,7 @@ RooCompositeDataStore::~RooCompositeDataStore()
 }
 
 
-RooAbsDataStore* RooCompositeDataStore::reduce(
+std::unique_ptr<RooAbsDataStore> RooCompositeDataStore::reduce(
         RooStringView name, RooStringView title, const RooArgSet& vars, const RooFormulaVar* cutVar,
         const char* cutRange, std::size_t nStart, std::size_t nStop)
 {
@@ -130,11 +130,11 @@ RooAbsDataStore* RooCompositeDataStore::reduce(
   }
 
   // create an empty RooCompositeDataStore
-  auto * out = new RooCompositeDataStore{name, title, varsNoIndex, *_indexCat, std::map<std::string,RooAbsDataStore*>{}};
+  auto out = std::make_unique<RooCompositeDataStore>(name, title, varsNoIndex, *_indexCat, std::map<std::string,RooAbsDataStore*>{});
 
   // fill it with reduced versions of components
   for (const auto& item : _dataMap) {
-    out->_dataMap[item.first] = item.second->reduce(name, title, varsNoIndex, cutVar, cutRange, nStart, nStop);
+    out->_dataMap[item.first] = item.second->reduce(name, title, varsNoIndex, cutVar, cutRange, nStart, nStop).release();
   }
 
   // indiceate component ownership and return

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -88,6 +88,13 @@ RooDataHist::RooDataHist()
 }
 
 
+std::unique_ptr<RooAbsDataStore> RooDataHist::makeDefaultDataStore(const char* name, const char* title, RooArgSet const& vars)
+{
+  return RooAbsData::defaultStorageType == RooAbsData::Tree
+      ? static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooTreeDataStore>(name, title, vars))
+      : static_cast<std::unique_ptr<RooAbsDataStore>>(std::make_unique<RooVectorDataStore>(name, title, vars));
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Constructor of an empty data hist from a RooArgSet defining the dimensions
@@ -109,8 +116,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgSe
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
-  _dstore = (defaultStorageType==Tree) ? ((RooAbsDataStore*) new RooTreeDataStore(name,title,_vars)) :
-                                         ((RooAbsDataStore*) new RooVectorDataStore(name,title,_vars)) ;
+  _dstore = makeDefaultDataStore(name, title, _vars);
 
   initialize(binningName) ;
 
@@ -146,8 +152,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgSe
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
-  _dstore = (defaultStorageType==Tree) ? ((RooAbsDataStore*) new RooTreeDataStore(name,title,_vars)) :
-                                         ((RooAbsDataStore*) new RooVectorDataStore(name,title,_vars)) ;
+  _dstore = makeDefaultDataStore(name, title, _vars);
 
   initialize() ;
   registerWeightArraysToDataStore();
@@ -173,8 +178,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgLi
   RooAbsData(name,title,RooArgSet(vars,&indexCat))
 {
   // Initialize datastore
-  _dstore = (defaultStorageType==Tree) ? ((RooAbsDataStore*) new RooTreeDataStore(name,title,_vars)) :
-                                         ((RooAbsDataStore*) new RooVectorDataStore(name,title,_vars)) ;
+  _dstore = makeDefaultDataStore(name, title, _vars);
 
   importTH1Set(vars, indexCat, histMap, wgt, false) ;
 
@@ -198,8 +202,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgLi
   RooAbsData(name,title,RooArgSet(vars,&indexCat))
 {
   // Initialize datastore
-  _dstore = (defaultStorageType==Tree) ? ((RooAbsDataStore*) new RooTreeDataStore(name,title,_vars)) :
-                                         ((RooAbsDataStore*) new RooVectorDataStore(name,title,_vars)) ;
+  _dstore = makeDefaultDataStore(name, title, _vars);
 
   importDHistSet(vars, indexCat, dhistMap, wgt) ;
 
@@ -219,8 +222,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgLi
   RooAbsData(name,title,vars)
 {
   // Initialize datastore
-  _dstore = (defaultStorageType==Tree) ? ((RooAbsDataStore*) new RooTreeDataStore(name,title,_vars)) :
-                                         ((RooAbsDataStore*) new RooVectorDataStore(name,title,_vars)) ;
+  _dstore = makeDefaultDataStore(name, title, _vars);
 
   // Check consistency in number of dimensions
   if (vars.getSize() != hist->GetDimension()) {
@@ -279,8 +281,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, const RooArgLi
   RooAbsData(name,title,RooArgSet(vars,(RooAbsArg*)RooCmdConfig::decodeObjOnTheFly("RooDataHist::RooDataHist", "IndexCat",0,0,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8)))
 {
   // Initialize datastore
-  _dstore = (defaultStorageType==Tree) ? ((RooAbsDataStore*) new RooTreeDataStore(name,title,_vars)) :
-                                         ((RooAbsDataStore*) new RooVectorDataStore(name,title,_vars)) ;
+  _dstore = makeDefaultDataStore(name, title, _vars);
 
   // Define configuration for this method
   RooCmdConfig pc(Form("RooDataHist::ctor(%s)",GetName())) ;
@@ -928,7 +929,7 @@ RooDataHist::RooDataHist(RooStringView name, RooStringView title, RooDataHist* h
   RooAbsData(name,title,varSubset)
 {
   // Initialize datastore
-  _dstore = new RooTreeDataStore(name,title,*h->_dstore,_vars,cutVar,cutRange,nStart,nStop) ;
+  _dstore = std::make_unique<RooTreeDataStore>(name,title,*h->_dstore,_vars,cutVar,cutRange,nStart,nStop) ;
 
   initialize(0,false) ;
 
@@ -2400,7 +2401,7 @@ void RooDataHist::Streamer(TBuffer &R__b) {
       // --- End of RooTreeData-v1 streamer
 
       // Construct RooTreeDataStore from X_tree and complete initialization of new-style RooAbsData
-      _dstore = new RooTreeDataStore(X_tree,_vars) ;
+      _dstore = std::make_unique<RooTreeDataStore>(X_tree,_vars);
       _dstore->SetName(GetName()) ;
       _dstore->SetTitle(GetTitle()) ;
       _dstore->checkInit() ;

--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -794,7 +794,7 @@ RooDataSet::RooDataSet(RooStringView name, RooStringView title, RooDataSet *dset
              std::size_t nStart, std::size_t nStop) :
   RooAbsData(name,title,vars)
 {
-  _dstore = dset->_dstore->reduce(name, title, _vars, cutVar, cutRange, nStart, nStop);
+  _dstore = dset->_dstore->reduce(name, title, _vars, cutVar, cutRange, nStart, nStop).release();
 
    _cachedVars.add(_dstore->cachedVars());
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -177,7 +177,7 @@ RooTreeDataStore::RooTreeDataStore(RooStringView name, RooStringView title, RooA
 }
 
 
-RooAbsDataStore* RooTreeDataStore::reduce(RooStringView name, RooStringView title,
+std::unique_ptr<RooAbsDataStore> RooTreeDataStore::reduce(RooStringView name, RooStringView title,
                         const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                         std::size_t nStart, std::size_t nStop) {
   RooArgSet tmp(vars) ;
@@ -185,7 +185,7 @@ RooAbsDataStore* RooTreeDataStore::reduce(RooStringView name, RooStringView titl
     tmp.add(*_wgtVar) ;
   }
   const char* wgtVarName = _wgtVar ? _wgtVar->GetName() : nullptr;
-  return new RooTreeDataStore(name, title, *this, tmp, cutVar, cutRange, nStart, nStop, wgtVarName);
+  return std::make_unique<RooTreeDataStore>(name, title, *this, tmp, cutVar, cutRange, nStart, nStop, wgtVarName);
 }
 
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -245,7 +245,7 @@ RooVectorDataStore::RooVectorDataStore(const RooVectorDataStore& other, const Ro
 }
 
 
-RooAbsDataStore* RooVectorDataStore::reduce(RooStringView name, RooStringView title,
+std::unique_ptr<RooAbsDataStore> RooVectorDataStore::reduce(RooStringView name, RooStringView title,
                         const RooArgSet& vars, const RooFormulaVar* cutVar, const char* cutRange,
                         std::size_t nStart, std::size_t nStop) {
   RooArgSet tmp(vars) ;
@@ -253,7 +253,7 @@ RooAbsDataStore* RooVectorDataStore::reduce(RooStringView name, RooStringView ti
     tmp.add(*_wgtVar) ;
   }
   const char* wgtVarName = _wgtVar ? _wgtVar->GetName() : nullptr;
-  return new RooVectorDataStore(name, title, *this, tmp, cutVar, cutRange, nStart, nStop, wgtVarName);
+  return std::make_unique<RooVectorDataStore>(name, title, *this, tmp, cutVar, cutRange, nStart, nStop, wgtVarName);
 }
 
 

--- a/test/stressRooFit_tests.h
+++ b/test/stressRooFit_tests.h
@@ -3004,7 +3004,6 @@ public:
 
   // Instruct dataset d in interpret w as event weight rather than as observable
   RooDataSet dataw(data->GetName(),data->GetTitle(),data.get(),*data->get(),nullptr,w->GetName()) ;
-  dataw.convertToVectorStore();
   //data->setWeightVar(*w) ;
 
 


### PR DESCRIPTION
There still was a constructor of `RooDataSet` that was hardcoded to use
the TreeDataStore. This needs to be changed, because the
RooVectorDataStore is more performant and compatible with the new
BatchMode.

This PR also includes some other commits that improve the memory management in the dataset classes with `std::unique_ptr`.