### PR TITLE
[RF] Consider all curves for `RooPlot::pullHist` in multi-range fits

### DIFF
--- a/roofit/roofitcore/inc/RooHist.h
+++ b/roofit/roofitcore/inc/RooHist.h
@@ -78,13 +78,17 @@ public:
   RooHist* makePullHist(const RooCurve& curve, bool useAverage=false) const
     {return makeResidHist(curve,true,useAverage); }
 
-
   bool isIdentical(const RooHist& other, double tol=1e-6, bool verbose=true) const ;
 
 
 protected:
   void initialize();
   Int_t roundBin(double y);
+
+  friend class RooPlot;
+
+  void fillResidHist(RooHist & residHist, const RooCurve& curve,bool normalize=false, bool useAverage=false) const;
+  std::unique_ptr<RooHist> createEmptyResidHist(const RooCurve& curve, bool normalize=false) const;
 
 private:
   double _nominalBinWidth ; ///< Average bin width

--- a/roofit/roofitcore/src/RooHist.cxx
+++ b/roofit/roofitcore/src/RooHist.cxx
@@ -736,17 +736,10 @@ void RooHist::printClassName(ostream& os) const
 }
 
 
-
-////////////////////////////////////////////////////////////////////////////////
-/// Create and return RooHist containing  residuals w.r.t to given curve.
-/// If normalize is true, the residuals are normalized by the histogram
-/// errors creating a RooHist with pull values
-
-RooHist* RooHist::makeResidHist(const RooCurve& curve, bool normalize, bool useAverage) const
+std::unique_ptr<RooHist> RooHist::createEmptyResidHist(const RooCurve& curve, bool normalize) const
 {
-
   // Copy all non-content properties from hist1
-  RooHist* hist = new RooHist(_nominalBinWidth) ;
+  auto hist = std::make_unique<RooHist>(_nominalBinWidth) ;
   if (normalize) {
     hist->SetName(Form("pull_%s_%s",GetName(),curve.GetName())) ;
     hist->SetTitle(Form("Pull of %s and %s",GetTitle(),curve.GetTitle())) ;
@@ -755,6 +748,12 @@ RooHist* RooHist::makeResidHist(const RooCurve& curve, bool normalize, bool useA
     hist->SetTitle(Form("Residual of %s and %s",GetTitle(),curve.GetTitle())) ;
   }
 
+  return hist;
+}
+
+
+void RooHist::fillResidHist(RooHist & residHist, const RooCurve& curve,bool normalize, bool useAverage) const
+{
   // Determine range of curve
   double xstart,xstop,y ;
   curve.GetPoint(0,xstart,y) ;
@@ -786,7 +785,7 @@ RooHist* RooHist::makeResidHist(const RooCurve& curve, bool normalize, bool useA
     if (normalize) {
         double norm = (yy>0?dyl:dyh);
    if (norm==0.) {
-     coutW(Plotting) << "RooHist::makeResisHist(" << GetName() << ") WARNING: point " << i << " has zero error, setting residual to zero" << endl ;
+     coutW(Plotting) << "RooHist::makeResisHist(" << GetName() << ") WARNING: point " << i << " has zero error, setting residual to zero" << std::endl;
      yy=0 ;
      dyh=0 ;
      dyl=0 ;
@@ -796,7 +795,19 @@ RooHist* RooHist::makeResidHist(const RooCurve& curve, bool normalize, bool useA
      dyl /= norm;
    }
     }
-    hist->addBinWithError(x,yy,dyl,dyh);
+    residHist.addBinWithError(x,yy,dyl,dyh);
   }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Create and return RooHist containing  residuals w.r.t to given curve.
+/// If normalize is true, the residuals are normalized by the histogram
+/// errors creating a RooHist with pull values
+
+RooHist* RooHist::makeResidHist(const RooCurve& curve, bool normalize, bool useAverage) const
+{
+  RooHist* hist = createEmptyResidHist(curve, normalize).release();
+  fillResidHist(*hist, curve, normalize, useAverage);
   return hist ;
 }


### PR DESCRIPTION
When plotting a pdf in 2 separate ranges, 2 RooCurve objects are created with the same name . When using pullHist or whatever function of RooPlot accessing the RooCurve by its name, only the last of the two curve can be retrieved. Since RooPlot has no way to access its list of containing objects, apart than given the name, only the RooCurve with the upper range will be used.

Code to reproduce the problem:

```Python
import ROOT as r

ws = r.RooWorkspace("workspace")
x = ws.factory("x[-10, 10]")
x.setRange("lo", -10, -5)
x.setRange("hi", 5, 10)
pdf = ws.factory("Gaussian::pdf(x, m1[0], s1[3])")
ds = pdf.generate(r.RooArgSet(x), 1000)

fr = x.frame()
ds.plotOn(fr)
pdf.plotOn(fr, r.RooFit.Range("lo,hi"))
pull = fr.pullHist()

c = r.TCanvas()
fr2 = x.frame()
fr2.addPlotable(pull, "P")
fr2.Draw()
```

This commit suggests to fix the issue by also considering the ranges of all the other curves that have the same name as the first curve that was found.

Closes #9741.