### PR TITLE
[RF] Some RooFit documentation updates

### DIFF
--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -40,6 +40,7 @@ To not break old code, the old RooCatType interfaces are still available. Whenev
 the following replacements should be used:
 - lookupType() \f$ \rightarrow \f$ lookupName() / lookupIndex()
 - typeIterator() \f$ \rightarrow \f$ range-based for loop / begin() / end()
+- isValidIndex(Int_t index) \f$ \rightarrow \f$ hasIndex()
 - isValid(const RooCatType&) \f$ \rightarrow \f$ hasIndex() / hasLabel()
 **/
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1911,7 +1911,7 @@ RooAbsGenContext* RooAbsPdf::autoGenContext(const RooArgSet &vars, const RooData
 /// <tr><th> Type of CmdArg                    <th> Effect on generate
 /// <tr><td> `Name(const char* name)`            <td> Name of the output dataset
 /// <tr><td> `Verbose(bool flag)`              <td> Print informational messages during event generation
-/// <tr><td> `NumEvent(int nevt)`                <td> Generate specified number of events
+/// <tr><td> `NumEvents(int nevt)`               <td> Generate specified number of events
 /// <tr><td> `Extended()`                        <td> If no number of events to be generated is given,
 /// use expected number of events from extended likelihood term.
 /// This evidently only works for extended PDFs.
@@ -2334,11 +2334,11 @@ bool RooAbsPdf::isDirectGenSafe(const RooAbsArg& arg) const
 /// dataset.
 ///
 /// The following named arguments are supported
-/// | Type of CmdArg       | Effect on generation
-/// |-------------------------|-----------------------
+/// | Type of CmdArg            | Effect on generation
+/// |---------------------------|-----------------------
 /// | `Name(const char* name)`  | Name of the output dataset
-/// | `Verbose(bool flag)`    | Print informational messages during event generation
-/// | `NumEvent(int nevt)`      | Generate specified number of events
+/// | `Verbose(bool flag)`      | Print informational messages during event generation
+/// | `NumEvents(int nevt)`     | Generate specified number of events
 /// | `Extended()`              | The actual number of events generated will be sampled from a Poisson distribution with mu=nevt.
 /// This can be *much* faster for peaked PDFs, but the number of events is not exactly what was requested.
 /// | `ExpectedData()`          | Return a binned dataset _without_ statistical fluctuations (also aliased as Asimov())

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -107,11 +107,11 @@ RooArgSet RooChi2Var::_emptySet ;
 ///  - RooAbsData::Expected: Expected Poisson error (\f$ \sqrt{n_\text{expected}} \f$ from the PDF).
 ///  - RooAbsData::SumW2: The observed error from the square root of the sum of weights,
 ///    i.e., symmetric errors calculated with the standard deviation of a Poisson distribution.
-///  - RooAbsData::Poisson: Asymmetric errors from the observed central poisson (68 %) interval.
+///  - RooAbsData::Poisson: Asymmetric errors from the central 68 % interval around a Poisson distribution with mean \f$ n_\text{observed} \f$.
 ///    If for a given bin \f$ n_\text{expected} \f$ is lower than the \f$ n_\text{observed} \f$, the lower uncertainty is taken
-///    (e.g., the difference between the mean and the 16 % quantile of the Poisson distribution with with mean \f$ n_\text{observed} \f$).
+///    (e.g., the difference between the mean and the 16 % quantile).
 ///    If \f$ n_\text{expected} \f$ is higher than \f$ n_\text{observed} \f$, the higher uncertainty is taken
-///    (e.g., the difference between the mean and the 84 % quantile of the Poisson distribution with with mean \f$ n_\text{observed} \f$).
+///    (e.g., the difference between the 84 % quantile and the mean).
 ///  - RooAbsData::Auto (default): RooAbsData::Expected for unweighted data, RooAbsData::SumW2 for weighted data.
 ///  <tr><td>
 ///  `Extended()` <td>  Use expected number of events of an extended p.d.f as normalization

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1784,7 +1784,6 @@ void RooDataHist::set(std::size_t binNumber, double wgt, double wgtErr) {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Set bin content of bin that was last loaded with get(std::size_t).
-/// \deprecated Prefer set(std::size_t, double, double).
 /// \param[in] wgt New bin content.
 /// \param[in] wgtErr Optional error of the bin content.
 void RooDataHist::set(double wgt, double wgtErr) {


### PR DESCRIPTION
* Explain better which functions should be used to get category indices

* Make documentation of RooChi2Var less verbose

* Avoid duplicate deprecation notice in `RooDataHist::set()`: the `RooDataHist::set()` function is marked deprecated in the header file with `R__SUGGEST_ALTERNATIVE`. This already adds a deprecation notice to the doxygen, so it is not necessary to add a `\deprecated` tag manually to the documentation. https://root.cern.ch/doc/v626/classRooDataHist.html#a3053f0f1a21eb39bb2508be61e30d8b9

* Replace `NumEvent()` with the correct `NumEvents()` in the RooAbsPdf documentation

Closes #11418.