### PR TITLE
[pyroot][tmva] Fix importing RTensor pythonization when RTensor is not available

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_facade.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_facade.py
@@ -8,6 +8,7 @@ import libcppyy as cppyy_backend
 from cppyy import gbl as gbl_namespace
 from cppyy import cppdef, include
 from libROOTPythonizations import gROOT, CreateBufferFromAddress
+from cppyy.gbl import gSystem
 
 from ._application import PyROOTApplication
 _numba_pyversion = (2, 7, 5)
@@ -354,11 +355,13 @@ class ROOTFacade(types.ModuleType):
         #this line is needed to import the pythonizations in _tmva directory
         from ._pythonization import _tmva
         ns = self._fallback_getattr('TMVA')
-        try:
-            from libROOTPythonizations import AsRTensor
-            ns.Experimental.AsRTensor = AsRTensor
-        except:
-            raise Exception('Failed to pythonize the namespace TMVA')
+        hasRDF = gSystem.GetFromPipe("root-config --has-dataframe") == "yes"
+        if hasRDF:
+            try:
+                from libROOTPythonizations import AsRTensor
+                ns.Experimental.AsRTensor = AsRTensor
+            except:
+                raise Exception('Failed to pythonize the namespace TMVA')
         del type(self).TMVA
         return ns
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_tmva/__init__.py
@@ -18,8 +18,14 @@ from .. import pythonization
 from ._factory import Factory
 from ._dataloader import DataLoader
 from ._crossvalidation import CrossValidation
+
 from ._rbdt import Compute, pythonize_rbdt
-from ._rtensor import get_array_interface, add_array_interface_property, RTensorGetitem, pythonize_rtensor
+hasRDF = gSystem.GetFromPipe("root-config --has-dataframe") == "yes"
+if hasRDF:
+    from ._rtensor import get_array_interface, add_array_interface_property, RTensorGetitem, pythonize_rtensor
+
+#this should be available only when xgboost is there ?
+# We probably don't need a protection here since the code is run only when there is xgboost
 from ._tree_inference import SaveXGBoost, pythonize_tree_inference
 
 


### PR DESCRIPTION
This should fix the failure observed when RDF is not built that one needs to not include the RTensor pythonizations


