### PR TITLE
[ACLiC] For macOS, make sure the syslib exists:

### DIFF
--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3392,7 +3392,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        // "Link against the umbrella framework 'System.framework' instead"
        || !strncmp(filename, "/usr/lib/system/libsystem_kernel", 32)
        || !strncmp(filename, "/usr/lib/system/libsystem_platform", 34)
-       || !strncmp(filename, "/usr/lib/system/libsystem_pthread", 34)
+       || !strncmp(filename, "/usr/lib/system/libsystem_pthread", 33)
        // "cannot link directly with dylib/framework, your binary is not an allowed client of
        // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/
        // SDKs/MacOSX.sdk/usr/lib/libAudioToolboxUtility.tbd for architecture x86_64

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3381,42 +3381,17 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
    }
 
 #if defined(R__MACOSX)
-   // Check that this is not a system library
+   // Check that this is not a system library that does not exist on disk.
    auto lenFilename = strlen(filename);
-   if (!strncmp(filename, "/usr/lib/system/", 16)
-       || !strncmp(filename, "/usr/lib/libc++", 15)
-       || !strncmp(filename, "/System/Library/Frameworks/", 27)
-       || !strncmp(filename, "/System/Library/PrivateFrameworks/", 34)
-       || !strncmp(filename, "/System/Library/CoreServices/", 29)
-       || !strcmp(filename, "cl_kernels") // yepp, no directory
-       || strstr(filename, "/usr/lib/libSystem")
-       || strstr(filename, "/usr/lib/libstdc++")
-       || strstr(filename, "/usr/lib/libicucore")
-       || strstr(filename, "/usr/lib/libbsm")
-       || strstr(filename, "/usr/lib/libobjc")
-       || strstr(filename, "/usr/lib/libresolv")
-       || strstr(filename, "/usr/lib/libauto")
-       || strstr(filename, "/usr/lib/libcups")
-       || strstr(filename, "/usr/lib/libDiagnosticMessagesClient")
-       || strstr(filename, "/usr/lib/liblangid")
-       || strstr(filename, "/usr/lib/libCRFSuite")
-       || strstr(filename, "/usr/lib/libpam")
-       || strstr(filename, "/usr/lib/libOpenScriptingUtil")
-       || strstr(filename, "/usr/lib/libextension")
-       || strstr(filename, "/usr/lib/libAudioToolboxUtility")
-       || strstr(filename, "/usr/lib/liboah")
-       || strstr(filename, "/usr/lib/libRosetta")
-       || strstr(filename, "/usr/lib/libCoreEntitlements")
-       || strstr(filename, "/usr/lib/libssl.")
-       || strstr(filename, "/usr/lib/libcrypto.")
-       // These are candidates for suppression, too:
-       //   -lfakelink -lapple_nghttp2 -lnetwork -lsqlite3 -lenergytrace -lCoreEntitlements
-       //   -lMobileGestalt -lcoretls -lcoretls_cfhelpers -lxar.1 -lcompression -larchive.2
-       //   -lxml2.2 -lpcap.A -ldns_services -llzma.5 -lbz2.1.0 -liconv.2 -lcharset.1
-       //   -lCheckFix -lmecabra -lmecab -lgermantok -lThaiTokenizer -lChineseTokenizer
-       //   -lcmph -lutil -lapp_launch_measurement -lxslt.1 -lspindump -late -lexpat.1
-       //   -lAudioStatistics -lSMC -lperfcheck -lmis -lIOReport -lheimdal-asn1
-
+   auto isInMacOSSystemDir = [](const char *fn) {
+      return !strncmp(fn, "/usr/lib/", 9) || !strncmp(fn, "/System/Library/", 16);
+   };
+   if (!strcmp(filename, "cl_kernels") // yepp, no directory
+       // The system lib is likely in macOS's blob.
+       || (isInMacOSSystemDir(filename) && gSystem->AccessPathName(filename))
+       // "Link against the umbrella framework 'System.framework' instead"
+       || !strncmp(filename, "/usr/lib/system/libsystem_kernel", 32)
+       || !strncmp(filename, "/usr/lib/system/libsystem_platform", 34)
        // "cannot link directly with dylib/framework, your binary is not an allowed client of
        // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/
        // SDKs/MacOSX.sdk/usr/lib/libAudioToolboxUtility.tbd for architecture x86_64

--- a/core/metacling/src/TCling.cxx
+++ b/core/metacling/src/TCling.cxx
@@ -3392,6 +3392,7 @@ void TCling::RegisterLoadedSharedLibrary(const char* filename)
        // "Link against the umbrella framework 'System.framework' instead"
        || !strncmp(filename, "/usr/lib/system/libsystem_kernel", 32)
        || !strncmp(filename, "/usr/lib/system/libsystem_platform", 34)
+       || !strncmp(filename, "/usr/lib/system/libsystem_pthread", 34)
        // "cannot link directly with dylib/framework, your binary is not an allowed client of
        // /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/
        // SDKs/MacOSX.sdk/usr/lib/libAudioToolboxUtility.tbd for architecture x86_64


### PR DESCRIPTION
macOS 13 again moves many libraries into the binary blob: these files do not exist anymore on disk, but the linker "knows what to do". Linking against them would fail ("file not found"), so rely on the non-system libraries to pull them in. An exception are /usr/lib/system/libsystem_... which *do* exist on disk but must not be linked against.
