### PR TITLE
[RF] Always pass RooArgSets to RooCmdArgs by value

### DIFF
--- a/roofit/roofitcore/inc/RooCmdArg.h
+++ b/roofit/roofitcore/inc/RooCmdArg.h
@@ -104,12 +104,6 @@ public:
 
   void Print(const char* = "") const override;
 
-  template<class T>
-  static T const& take(T && obj) {
-    getNextSharedData().emplace_back(new T{std::move(obj)});
-    return static_cast<T const&>(*getNextSharedData().back());
-  }
-
   bool procSubArgs() const { return _procSubArgs; }
   bool prefixSubArgs() const { return _prefixSubArgs; }
 
@@ -127,14 +121,7 @@ private:
   RooLinkedList _argList ; ///< Payload sub-arguments
   bool _prefixSubArgs ;  ///< Prefix sub-arguments with container name?
 
-  using DataCollection = std::vector<std::unique_ptr<TObject>>;
-  std::shared_ptr<DataCollection> _sharedData; ///<!
-
-  // the next RooCmdArg created will take ownership of this data
-  static DataCollection _nextSharedData;
-  static DataCollection &getNextSharedData();
-
-  ClassDefOverride(RooCmdArg,2) // Generic named argument container
+  ClassDefOverride(RooCmdArg,0) // Generic named argument container
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooCmdConfig.h
+++ b/roofit/roofitcore/inc/RooCmdConfig.h
@@ -95,6 +95,10 @@ public:
   static TObject* decodeObjOnTheFly(
           const char* callerID, const char* cmdArgName, Int_t objIdx, TObject* defVal, Args_t && ...args);
 
+  template<class ...Args_t>
+  static RooArgSet* decodeSetOnTheFly(
+          const char* callerID, const char* cmdArgName, Int_t objIdx, RooArgSet* defVal, Args_t && ...args);
+
   static double decodeDoubleOnTheFly(const char* callerID, const char* cmdArgName, int idx, double defVal,
       std::initializer_list<std::reference_wrapper<const RooCmdArg>> args);
 
@@ -223,6 +227,18 @@ TObject* RooCmdConfig::decodeObjOnTheFly(
   pc.defineObject("theObj",cmdArgName,objIdx,defVal) ;
   pc.process(std::forward<Args_t>(args)...);
   return pc.getObject("theObj") ;
+}
+
+
+template<class ...Args_t>
+RooArgSet* RooCmdConfig::decodeSetOnTheFly(
+        const char* callerID, const char* cmdArgName, Int_t objIdx, RooArgSet* defVal, Args_t && ...args)
+{
+  RooCmdConfig pc(callerID) ;
+  pc.allowUndefined() ;
+  pc.defineSet("theObj",cmdArgName,objIdx,defVal) ;
+  pc.process(std::forward<Args_t>(args)...);
+  return pc.getSet("theObj") ;
 }
 
 

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -42,8 +42,6 @@ class RooConstVar ;
 class RooRealVar ;
 class RooAbsCategory ;
 class RooNumIntConfig ;
-class RooArgList ;
-class RooAbsCollection ;
 class TH1 ;
 class TTree ;
 
@@ -83,14 +81,11 @@ enum class BatchModeOption { Off, Cpu, Cuda, Old };
 RooCmdArg DrawOption(const char* opt) ;
 RooCmdArg Normalization(double scaleFactor) ;
 RooCmdArg Slice(const RooArgSet& sliceSet) ;
-RooCmdArg Slice(RooArgSet && sliceSet) ;
 RooCmdArg Slice(RooCategory& cat, const char* label) ;
 RooCmdArg Slice(std::map<RooCategory*, std::string> const&) ;
 RooCmdArg Project(const RooArgSet& projSet) ;
-RooCmdArg Project(RooArgSet && projSet) ;
 RooCmdArg ProjWData(const RooAbsData& projData, bool binData=false) ;
 RooCmdArg ProjWData(const RooArgSet& projSet, const RooAbsData& projData, bool binData=false) ;
-RooCmdArg ProjWData(RooArgSet && projSet, const RooAbsData& projData, bool binData=false) ;
 RooCmdArg Asymmetry(const RooCategory& cat) ;
 RooCmdArg Precision(double prec) ;
 RooCmdArg ShiftToZero() ;
@@ -112,15 +107,15 @@ RooCmdArg MoveToBack()  ;
 RooCmdArg VisualizeError(const RooDataSet& paramData, double Z=1) ;
 RooCmdArg VisualizeError(const RooFitResult& fitres, double Z=1, bool linearMethod=true) ;
 RooCmdArg VisualizeError(const RooFitResult& fitres, const RooArgSet& param, double Z=1, bool linearMethod=true) ;
-RooCmdArg VisualizeError(const RooFitResult& fitres, RooArgSet && param, double Z=1, bool linearMethod=true) ;
 RooCmdArg ShowProgress() ;
 
 // RooAbsPdf::plotOn arguments
 RooCmdArg Normalization(double scaleFactor, Int_t scaleType) ;
 template<class... Args_t>
 RooCmdArg Components(Args_t &&... argsOrArgSet) {
-  return RooCmdArg("SelectCompSet",0,0,0,0,nullptr,nullptr,
-          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}), nullptr);
+  RooCmdArg out{"SelectCompSet",0};
+  out.setSet(0, RooArgSet{std::forward<Args_t>(argsOrArgSet)...});
+  return out;
 }
 RooCmdArg Components(const char* compSpec) ;
 
@@ -165,9 +160,7 @@ RooCmdArg Import(RooDataSet& data) ;
 RooCmdArg Import(TTree& tree) ;
 RooCmdArg ImportFromFile(const char* fname, const char* tname) ;
 RooCmdArg StoreError(const RooArgSet& aset) ;
-RooCmdArg StoreError(RooArgSet && aset) ;
 RooCmdArg StoreAsymError(const RooArgSet& aset) ;
-RooCmdArg StoreAsymError(RooArgSet && aset) ;
 RooCmdArg OwnLinked() ;
 
 /** @} */
@@ -194,11 +187,9 @@ RooCmdArg AutoBinning(Int_t nbins=100, double marginFactor=0.1) ;
 
 // RooAbsReal::fillHistogram arguments
 RooCmdArg IntegratedObservables(const RooArgSet& intObs) ;
-RooCmdArg IntegratedObservables(RooArgSet && intObs) ;
 
 // RooAbsData::reduce arguments
 RooCmdArg SelectVars(const RooArgSet& vars) ;
-RooCmdArg SelectVars(RooArgSet && vars) ;
 RooCmdArg EventRange(Int_t nStart, Int_t nStop) ;
 
 
@@ -230,8 +221,9 @@ RooCmdArg Optimize(Int_t flag=2) ;
 //                          observables or a single RooArgSet containing them.
 template<class... Args_t>
 RooCmdArg ConditionalObservables(Args_t &&... argsOrArgSet) {
-  return RooCmdArg("ProjectedObservables",0,0,0,0,nullptr,nullptr,
-          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}));
+  RooCmdArg out{"ProjectedObservables",0};
+  out.setSet(0, RooArgSet{std::forward<Args_t>(argsOrArgSet)...});
+  return out;
 }
 
 // obsolete, for backward compatibility
@@ -250,21 +242,19 @@ RooCmdArg InitialHesse(bool flag=true) ;
 RooCmdArg Hesse(bool flag=true) ;
 RooCmdArg Minos(bool flag=true) ;
 RooCmdArg Minos(const RooArgSet& minosArgs) ;
-RooCmdArg Minos(RooArgSet && minosArgs) ;
 RooCmdArg SplitRange(bool flag=true) ;
 RooCmdArg SumCoefRange(const char* rangeName) ;
 RooCmdArg Constrain(const RooArgSet& params) ;
-RooCmdArg Constrain(RooArgSet && params) ;
 
 template<class... Args_t>
 RooCmdArg GlobalObservables(Args_t &&... argsOrArgSet) {
-  return RooCmdArg("GlobalObservables",0,0,0,0,nullptr,nullptr,nullptr,nullptr,nullptr,nullptr,
-          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}));
+  RooCmdArg out{"GlobalObservables",0};
+  out.setSet(0, RooArgSet{std::forward<Args_t>(argsOrArgSet)...});
+  return out;
 }
 RooCmdArg GlobalObservablesSource(const char* sourceName);
 RooCmdArg GlobalObservablesTag(const char* tagName) ;
 RooCmdArg ExternalConstraints(const RooArgSet& constraintPdfs) ;
-RooCmdArg ExternalConstraints(RooArgSet && constraintPdfs) ;
 RooCmdArg PrintEvalErrors(Int_t numErrors) ;
 RooCmdArg EvalErrorWall(bool flag) ;
 RooCmdArg SumW2Error(bool flag) ;
@@ -280,7 +270,6 @@ RooCmdArg RecoverFromUndefinedRegions(double strength);
 RooCmdArg Label(const char* str) ;
 RooCmdArg Layout(double xmin, double xmax=0.99, double ymin=0.95) ;
 RooCmdArg Parameters(const RooArgSet& params) ;
-RooCmdArg Parameters(RooArgSet && params) ;
 RooCmdArg ShowConstants(bool flag=true) ;
 
 // RooTreeData::statOn arguments
@@ -288,9 +277,6 @@ RooCmdArg What(const char* str) ;
 
 // RooProdPdf::ctor arguments
 RooCmdArg Conditional(const RooArgSet& pdfSet, const RooArgSet& depSet, bool depsAreCond=false) ;
-RooCmdArg Conditional(RooArgSet && pdfSet, const RooArgSet& depSet, bool depsAreCond=false) ;
-RooCmdArg Conditional(const RooArgSet& pdfSet, RooArgSet && depSet, bool depsAreCond=false) ;
-RooCmdArg Conditional(RooArgSet && pdfSet, RooArgSet && depSet, bool depsAreCond=false) ;
 
 /**
  * \defgroup Generating Arguments for generating data
@@ -321,8 +307,9 @@ RooCmdArg IntrinsicBinning(bool flag=true) ;
 // RooAbsReal::createIntegral arguments
 template<class... Args_t>
 RooCmdArg NormSet(Args_t &&... argsOrArgSet) {
-  return RooCmdArg("NormSet",0,0,0,0,nullptr,nullptr,
-          &RooCmdArg::take(RooArgSet{std::forward<Args_t>(argsOrArgSet)...}), nullptr);
+  RooCmdArg out{"NormSet",0};
+  out.setSet(0, RooArgSet{std::forward<Args_t>(argsOrArgSet)...});
+  return out;
 }
 RooCmdArg NumIntConfig(const RooNumIntConfig& cfg) ;
 
@@ -380,7 +367,6 @@ RooCmdArg Restrict(const char* catName, const char* stateNameList) ;
 
 // RooAbsPdf::createCdf() arguments
 RooCmdArg SupNormSet(const RooArgSet& nset) ;
-RooCmdArg SupNormSet(RooArgSet && nset) ;
 RooCmdArg ScanParameters(Int_t nbins,Int_t intOrder) ;
 RooCmdArg ScanNumCdf() ;
 RooCmdArg ScanAllCdf() ;

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -458,7 +458,7 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
   pc.defineObject("cutVar","CutVar",0,0) ;
   pc.defineInt("evtStart","EventRange",0,0) ;
   pc.defineInt("evtStop","EventRange",1,std::numeric_limits<int>::max()) ;
-  pc.defineObject("varSel","SelectVars",0,0) ;
+  pc.defineSet("varSel","SelectVars",0,0) ;
   pc.defineMutex("CutVar","CutSpec") ;
 
   // Process & check varargs
@@ -473,7 +473,7 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
   RooFormulaVar* cutVar = static_cast<RooFormulaVar*>(pc.getObject("cutVar",0)) ;
   Int_t nStart = pc.getInt("evtStart",0) ;
   Int_t nStop = pc.getInt("evtStop",std::numeric_limits<int>::max()) ;
-  RooArgSet* varSet = static_cast<RooArgSet*>(pc.getObject("varSel")) ;
+  RooArgSet* varSet = pc.getSet("varSel");
   const char* name = pc.getString("name",0,true) ;
   const char* title = pc.getString("title",0,true) ;
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1012,7 +1012,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
   pc.defineInt("verbose","Verbose",0,0) ;
   pc.defineInt("optConst","Optimize",0,0) ;
   pc.defineInt("cloneData","CloneData", 0, 2);
-  pc.defineObject("projDepSet","ProjectedObservables",0,0) ;
+  pc.defineSet("projDepSet","ProjectedObservables",0,0) ;
   pc.defineSet("cPars","Constrain",0,0) ;
   pc.defineSet("glObs","GlobalObservables",0,0) ;
   pc.defineInt("doOffset","OffsetLikelihood",0,0) ;
@@ -1073,7 +1073,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
   }
 
   RooArgSet projDeps ;
-  auto tmp = static_cast<RooArgSet*>(pc.getObject("projDepSet")) ;
+  auto tmp = pc.getSet("projDepSet");
   if (tmp) {
     projDeps.add(*tmp) ;
   }
@@ -1595,7 +1595,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   pc.defineInt("doOffset","OffsetLikelihood",0,0) ;
   pc.defineString("mintype","Minimizer",0,minimizerDefaults.minType.c_str()) ;
   pc.defineString("minalg","Minimizer",1,minimizerDefaults.minAlg.c_str()) ;
-  pc.defineObject("minosSet","Minos",0,minimizerDefaults.minosSet) ;
+  pc.defineSet("minosSet","Minos",0,minimizerDefaults.minosSet) ;
   pc.defineMutex("Range","RangeWithName") ;
 
   // Process and check varargs
@@ -1674,7 +1674,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   cfg.doWarn = pc.getInt("doWarn");
   cfg.doSumW2 = pc.getInt("doSumW2");
   cfg.doAsymptotic = pc.getInt("doAsymptoticError");
-  cfg.minosSet = static_cast<RooArgSet*>(pc.getObject("minosSet"));
+  cfg.minosSet = pc.getSet("minosSet");
   cfg.minType = pc.getString("mintype","");
   cfg.minAlg = pc.getString("minalg","minuit");
 
@@ -2710,7 +2710,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
   RooCmdConfig pc(Form("RooAbsPdf::plotOn(%s)",GetName())) ;
   pc.defineDouble("scaleFactor","Normalization",0,1.0) ;
   pc.defineInt("scaleType","Normalization",0,Relative) ;
-  pc.defineObject("compSet","SelectCompSet",0) ;
+  pc.defineSet("compSet","SelectCompSet",0) ;
   pc.defineString("compSpec","SelectCompSpec",0) ;
   pc.defineObject("asymCat","Asymmetry",0) ;
   pc.defineDouble("rangeLo","Range",0,-999.) ;
@@ -2734,7 +2734,7 @@ RooPlot* RooAbsPdf::plotOn(RooPlot* frame, RooLinkedList& cmdList) const
   double scaleFactor = pc.getDouble("scaleFactor") ;
   const RooAbsCategoryLValue* asymCat = (const RooAbsCategoryLValue*) pc.getObject("asymCat") ;
   const char* compSpec = pc.getString("compSpec") ;
-  const RooArgSet* compSet = (const RooArgSet*) pc.getObject("compSet") ;
+  const RooArgSet* compSet = pc.getSet("compSet");
   bool haveCompSel = ( (compSpec && strlen(compSpec)>0) || compSet) ;
 
   // Suffix for curve name
@@ -3044,7 +3044,7 @@ RooPlot* RooAbsPdf::paramOn(RooPlot* frame, const RooCmdArg& arg1, const RooCmdA
   pc.defineDouble("xmax","Layout",1,0.9) ;
   pc.defineInt("ymaxi","Layout",0,Int_t(0.9*10000)) ;
   pc.defineInt("showc","ShowConstants",0,0) ;
-  pc.defineObject("params","Parameters",0,0) ;
+  pc.defineSet("params","Parameters",0,0) ;
   pc.defineString("formatStr","Format",0,"NELU") ;
   pc.defineInt("sigDigit","Format",0,2) ;
   pc.defineInt("dummy","FormatArgs",0,0) ;
@@ -3067,7 +3067,7 @@ RooPlot* RooAbsPdf::paramOn(RooPlot* frame, const RooCmdArg& arg1, const RooCmdA
   Int_t sigDigit = pc.getInt("sigDigit") ;
 
   // Decode command line arguments
-  RooArgSet* params = static_cast<RooArgSet*>(pc.getObject("params")) ;
+  RooArgSet* params = pc.getSet("params");
   if (!params) {
     std::unique_ptr<RooArgSet> paramsPtr{getParameters(frame->getNormVars())} ;
     if (pc.hasProcessed("FormatArgs")) {
@@ -3290,7 +3290,7 @@ RooAbsReal* RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, c
 {
   // Define configuration for this method
   RooCmdConfig pc(Form("RooAbsReal::createCdf(%s)",GetName())) ;
-  pc.defineObject("supNormSet","SupNormSet",0,0) ;
+  pc.defineSet("supNormSet","SupNormSet",0,0) ;
   pc.defineInt("numScanBins","ScanParameters",0,1000) ;
   pc.defineInt("intOrder","ScanParameters",1,2) ;
   pc.defineInt("doScanNum","ScanNumCdf",0,1) ;
@@ -3305,7 +3305,7 @@ RooAbsReal* RooAbsPdf::createCdf(const RooArgSet& iset, const RooCmdArg& arg1, c
   }
 
   // Extract values from named arguments
-  const RooArgSet* snset = static_cast<const RooArgSet*>(pc.getObject("supNormSet",0)) ;
+  const RooArgSet* snset = pc.getSet("supNormSet",0);
   RooArgSet nset ;
   if (snset) {
     nset.add(*snset) ;

--- a/roofit/roofitcore/src/RooAbsReal.cxx
+++ b/roofit/roofitcore/src/RooAbsReal.cxx
@@ -532,7 +532,7 @@ RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& a
   // Define configuration for this method
   RooCmdConfig pc(Form("RooAbsReal::createIntegral(%s)",GetName())) ;
   pc.defineString("rangeName","RangeWithName",0,"",true) ;
-  pc.defineObject("normSet","NormSet",0,0) ;
+  pc.defineSet("normSet","NormSet",0,0) ;
   pc.defineObject("numIntConfig","NumIntConfig",0,0) ;
 
   // Process & check varargs
@@ -543,7 +543,7 @@ RooAbsReal* RooAbsReal::createIntegral(const RooArgSet& iset, const RooCmdArg& a
 
   // Extract values from named arguments
   const char* rangeName = pc.getString("rangeName",0,true) ;
-  const RooArgSet* nset = static_cast<const RooArgSet*>(pc.getObject("normSet",0)) ;
+  const RooArgSet* nset = pc.getSet("normSet",0);
   const RooNumIntConfig* cfg = static_cast<const RooNumIntConfig*>(pc.getObject("numIntConfig",0)) ;
 
   return createIntegral(iset,nset,cfg,rangeName) ;
@@ -1327,9 +1327,9 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
   pc.defineInt("intBinning","IntrinsicBinning",0,2) ;
   pc.defineInt("extended","Extended",0,2) ;
 
-  pc.defineObject("compSet","SelectCompSet",0) ;
+  pc.defineSet("compSet","SelectCompSet",0);
   pc.defineString("compSpec","SelectCompSpec",0) ;
-  pc.defineObject("projObs","ProjectedObservables",0,0) ;
+  pc.defineSet("projObs","ProjectedObservables",0,0) ;
   pc.defineObject("yvar","YVar",0,0) ;
   pc.defineObject("zvar","ZVar",0,0) ;
   pc.defineMutex("SelectCompSet","SelectCompSpec") ;
@@ -1354,7 +1354,7 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
     vars.add(*zvar) ;
   }
 
-  auto projObs = static_cast<RooArgSet*>(pc.getObject("projObs")) ;
+  auto projObs = pc.getSet("projObs");
   RooArgSet* intObs = 0 ;
 
   bool doScaling = pc.getInt("scaling") ;
@@ -1376,7 +1376,7 @@ TH1* RooAbsReal::createHistogram(const char *name, const RooAbsRealLValue& xvar,
   }
 
   const char* compSpec = pc.getString("compSpec") ;
-  const RooArgSet* compSet = (const RooArgSet*) pc.getObject("compSet") ;
+  const RooArgSet* compSet = pc.getSet("compSet");
   bool haveCompSel = ( (compSpec && strlen(compSpec)>0) || compSet) ;
 
   RooBinning* intBinning(0) ;
@@ -1703,19 +1703,19 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   pc.defineString("sliceCatState","SliceCat",0,"",true) ;
   pc.defineDouble("scaleFactor","Normalization",0,1.0) ;
   pc.defineInt("scaleType","Normalization",0,Relative) ;
-  pc.defineObject("sliceSet","SliceVars",0) ;
+  pc.defineSet("sliceSet","SliceVars",0) ;
   pc.defineObject("sliceCatList","SliceCat",0,0,true) ;
   // This dummy is needed for plotOn to recognize the "SliceCatMany" command.
   // It is not used directly, but the "SliceCat" commands are nested in it.
   // Removing this dummy definition results in "ERROR: unrecognized command: SliceCatMany".
   pc.defineObject("dummy1","SliceCatMany",0) ;
-  pc.defineObject("projSet","Project",0) ;
+  pc.defineSet("projSet","Project",0) ;
   pc.defineObject("asymCat","Asymmetry",0) ;
   pc.defineDouble("precision","Precision",0,1e-3) ;
   pc.defineDouble("evalErrorVal","EvalErrorValue",0,0) ;
   pc.defineInt("doEvalError","EvalErrorValue",0,0) ;
   pc.defineInt("shiftToZero","ShiftToZero",0,0) ;
-  pc.defineObject("projDataSet","ProjData",0) ;
+  pc.defineSet("projDataSet","ProjData",0) ;
   pc.defineObject("projData","ProjData",1) ;
   pc.defineObject("errorFR","VisualizeError",0) ;
   pc.defineDouble("errorZ","VisualizeError",0,1.) ;
@@ -1779,15 +1779,15 @@ RooPlot* RooAbsReal::plotOn(RooPlot* frame, RooLinkedList& argList) const
   o.stype = (ScaleType) pc.getInt("scaleType")  ;
   o.projData = (const RooAbsData*) pc.getObject("projData") ;
   o.binProjData = pc.getInt("binProjData") ;
-  o.projDataSet = (const RooArgSet*) pc.getObject("projDataSet") ;
+  o.projDataSet = pc.getSet("projDataSet");
   o.numCPU = pc.getInt("numCPU") ;
   o.interleave = (RooFit::MPSplit) pc.getInt("interleave") ;
   o.eeval      = pc.getDouble("evalErrorVal") ;
   o.doeeval   = pc.getInt("doEvalError") ;
 
-  const RooArgSet* sliceSetTmp = (const RooArgSet*) pc.getObject("sliceSet") ;
+  const RooArgSet* sliceSetTmp = pc.getSet("sliceSet");
   std::unique_ptr<RooArgSet> sliceSet{sliceSetTmp ? static_cast<RooArgSet*>(sliceSetTmp->Clone()) : nullptr};
-  const RooArgSet* projSet = (const RooArgSet*) pc.getObject("projSet") ;
+  const RooArgSet* projSet = pc.getSet("projSet") ;
   const RooAbsCategoryLValue* asymCat = (const RooAbsCategoryLValue*) pc.getObject("asymCat") ;
 
 
@@ -3878,7 +3878,7 @@ RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCm
 {
   // Define configuration for this method
   RooCmdConfig pc(Form("RooAbsReal::createRunningIntegral(%s)",GetName())) ;
-  pc.defineObject("supNormSet","SupNormSet",0,0) ;
+  pc.defineSet("supNormSet","SupNormSet",0,0) ;
   pc.defineInt("numScanBins","ScanParameters",0,1000) ;
   pc.defineInt("intOrder","ScanParameters",1,2) ;
   pc.defineInt("doScanNum","ScanNum",0,1) ;
@@ -3893,9 +3893,8 @@ RooAbsReal* RooAbsReal::createRunningIntegral(const RooArgSet& iset, const RooCm
   }
 
   // Extract values from named arguments
-  const RooArgSet* snset = static_cast<const RooArgSet*>(pc.getObject("supNormSet",0)) ;
   RooArgSet nset ;
-  if (snset) {
+  if (const RooArgSet* snset = pc.getSet("supNormSet",0)) {
     nset.add(*snset) ;
   }
   Int_t numScanBins = pc.getInt("numScanBins") ;
@@ -4474,7 +4473,7 @@ RooFitResult* RooAbsReal::chi2FitDriver(RooAbsReal& fcn, RooLinkedList& cmdList)
   pc.defineInt("doWarn","Warnings",0,1) ;
   pc.defineString("mintype","Minimizer",0,"") ;
   pc.defineString("minalg","Minimizer",1,"minuit") ;
-  pc.defineObject("minosSet","Minos",0,0) ;
+  pc.defineSet("minosSet","Minos",0,nullptr) ;
 
   // Process and check varargs
   pc.process(cmdList) ;
@@ -4496,7 +4495,7 @@ RooFitResult* RooAbsReal::chi2FitDriver(RooAbsReal& fcn, RooLinkedList& cmdList)
   Int_t minos    = pc.getInt("minos") ;
   Int_t numee    = pc.getInt("numee") ;
   Int_t doWarn   = pc.getInt("doWarn") ;
-  const RooArgSet* minosSet = static_cast<RooArgSet*>(pc.getObject("minosSet")) ;
+  const RooArgSet* minosSet = pc.getSet("minosSet");
 
   RooFitResult *ret = 0 ;
 

--- a/roofit/roofitcore/src/RooChi2Var.cxx
+++ b/roofit/roofitcore/src/RooChi2Var.cxx
@@ -199,8 +199,8 @@ RooChi2Var::RooChi2Var(const char *name, const char* title, RooAbsPdf& pdf, RooD
              const RooCmdArg& arg4,const RooCmdArg& arg5,const RooCmdArg& arg6,
              const RooCmdArg& arg7,const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,pdf,hdata,
-                         *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet,
-                                 arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+                         *RooCmdConfig::decodeSetOnTheFly("RooChi2Var::RooChi2Var","ProjectedObservables",0,&_emptySet,
+                                 arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
                          makeRooAbsTestStatisticCfgForPdf(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooChi2Var::RooChi2Var") ;

--- a/roofit/roofitcore/src/RooCmdArg.cxx
+++ b/roofit/roofitcore/src/RooCmdArg.cxx
@@ -100,9 +100,6 @@ RooCmdArg::RooCmdArg(const char* name, Int_t i1, Int_t i2, double d1, double d2,
   if (ca) {
     _argList.Add(new RooCmdArg(*ca)) ;
   }
-
-  _sharedData.reset(new DataCollection);
-  _sharedData->swap(_nextSharedData);
 }
 
 
@@ -111,8 +108,7 @@ RooCmdArg::RooCmdArg(const char* name, Int_t i1, Int_t i2, double d1, double d2,
 /// Copy constructor
 
 RooCmdArg::RooCmdArg(const RooCmdArg& other) :
-  TNamed(other),
-  _sharedData{other._sharedData}
+  TNamed(other)
 {
   _i[0] = other._i[0] ;
   _i[1] = other._i[1] ;
@@ -145,8 +141,6 @@ RooCmdArg::RooCmdArg(const RooCmdArg& other) :
 RooCmdArg& RooCmdArg::operator=(const RooCmdArg& other)
 {
   if (&other==this) return *this ;
-
-  _sharedData = other._sharedData;
 
   SetName(other.GetName()) ;
   SetTitle(other.GetTitle()) ;
@@ -229,7 +223,3 @@ void RooCmdArg::Print(const char*) const {
       << "\nstrings\t" << _s[0] << " " << _s[1] << " " << _s[2]
       << "\nobjects\t" << _o[0] << " " << _o[1] << std::endl;
 }
-
-RooCmdArg::DataCollection RooCmdArg::_nextSharedData = RooCmdArg::DataCollection{};
-
-RooCmdArg::DataCollection &RooCmdArg::getNextSharedData() { return _nextSharedData; }

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -69,36 +69,43 @@ namespace RooFit {
 
   // RooAbsReal::plotOn arguments
   RooCmdArg DrawOption(const char* opt)            { return RooCmdArg("DrawOption",0,0,0,0,opt,0,0,0) ; }
-  RooCmdArg Slice(const RooArgSet& sliceSet)       { return RooCmdArg("SliceVars",0,0,0,0,0,0,&sliceSet,0) ; }
-  RooCmdArg Slice(RooArgSet && sliceSet)           { return Slice(RooCmdArg::take(std::move(sliceSet))); }
+  RooCmdArg Slice(const RooArgSet& sliceSet) {
+      RooCmdArg out{"SliceVars",0};
+      out.setSet(0, sliceSet);
+      return out;
+  }
   RooCmdArg Slice(RooCategory& cat, const char* label) { return RooCmdArg("SliceCat",0,0,0,0,label,0,&cat,0) ; }
   RooCmdArg Slice(std::map<RooCategory*, std::string> const& arg) {
     return processMap("SliceCatMany", processSliceItem, arg);
   }
 
-  RooCmdArg Project(const RooArgSet& projSet)      { return RooCmdArg("Project",0,0,0,0,0,0,&projSet,0) ; }
-  RooCmdArg Project(RooArgSet && projSet)          { return Project(RooCmdArg::take(std::move(projSet))); }
+  RooCmdArg Project(const RooArgSet& projSet) {
+    RooCmdArg out{"Project",0};
+    out.setSet(0, projSet);
+    return out;
+  }
   RooCmdArg ProjWData(const RooArgSet& projSet,
                       const RooAbsData& projData,
-                      bool binData)              { return RooCmdArg("ProjData",binData,0,0,0,0,0,&projSet,&projData) ; }
-  RooCmdArg ProjWData(RooArgSet && projSet, const RooAbsData& projData, bool binData) {
-    return ProjWData(RooCmdArg::take(std::move(projSet)), projData, binData);
+                      bool binData) {
+    RooCmdArg out{"ProjData",binData,0,0,0,0,0,nullptr,&projData};
+    out.setSet(0, projSet);
+    return out;
   }
   RooCmdArg ProjWData(const RooAbsData& projData,
                       bool binData)              { return RooCmdArg("ProjData",binData,0,0,0,0,0,0,&projData) ; }
   RooCmdArg Asymmetry(const RooCategory& cat)      { return RooCmdArg("Asymmetry",0,0,0,0,0,0,&cat,0) ; }
   RooCmdArg Precision(double prec)               { return RooCmdArg("Precision",0,0,prec,0,0,0,0,0) ; }
-  RooCmdArg ShiftToZero()                          { return RooCmdArg("ShiftToZero",1,0,0,0,0,0,0,0) ; }
+  RooCmdArg ShiftToZero()                          { return RooCmdArg("ShiftToZero",1) ; }
   RooCmdArg Normalization(double scaleFactor)    { return RooCmdArg("Normalization",RooAbsReal::Relative,0,scaleFactor,0,0,0,0,0) ; }
   RooCmdArg Range(const char* rangeName, bool adjustNorm)   { return RooCmdArg("RangeWithName",adjustNorm,0,0,0,rangeName,0,0,0) ; }
   RooCmdArg Range(double lo, double hi, bool adjustNorm){ return RooCmdArg("Range",adjustNorm,0,lo,hi,0,0,0,0) ; }
   RooCmdArg NormRange(const char* rangeNameList)   { return RooCmdArg("NormRange",0,0,0,0,rangeNameList,0,0,0) ; }
   RooCmdArg VLines()                               { return RooCmdArg("VLines",1,0,0,0,0,0,0,0) ; }
-  RooCmdArg LineColor(Color_t color)               { return RooCmdArg("LineColor",color,0,0,0,0,0,0,0) ; }
-  RooCmdArg LineStyle(Style_t style)               { return RooCmdArg("LineStyle",style,0,0,0,0,0,0,0) ; }
-  RooCmdArg LineWidth(Width_t width)               { return RooCmdArg("LineWidth",width,0,0,0,0,0,0,0) ; }
-  RooCmdArg FillColor(Color_t color)               { return RooCmdArg("FillColor",color,0,0,0,0,0,0,0) ; }
-  RooCmdArg FillStyle(Style_t style)               { return RooCmdArg("FillStyle",style,0,0,0,0,0,0,0) ; }
+  RooCmdArg LineColor(Color_t color)               { return RooCmdArg("LineColor",color) ; }
+  RooCmdArg LineStyle(Style_t style)               { return RooCmdArg("LineStyle",style) ; }
+  RooCmdArg LineWidth(Width_t width)               { return RooCmdArg("LineWidth",width) ; }
+  RooCmdArg FillColor(Color_t color)               { return RooCmdArg("FillColor",color) ; }
+  RooCmdArg FillStyle(Style_t style)               { return RooCmdArg("FillStyle",style) ; }
   RooCmdArg ProjectionRange(const char* rangeName) { return RooCmdArg("ProjectionRange",0,0,0,0,rangeName,0,0,0) ; }
   RooCmdArg Name(const char* name)                 { return RooCmdArg("Name",0,0,0,0,name,0,0,0) ; }
   RooCmdArg Invisible(bool inv)                    { return RooCmdArg("Invisible",inv,0,0,0,0,0,0,0) ; }
@@ -108,9 +115,6 @@ namespace RooFit {
   RooCmdArg VisualizeError(const RooFitResult& fitres, double Z, bool EVmethod)  { return RooCmdArg("VisualizeError",EVmethod,0,Z,0,0,0,&fitres,0) ; }
   RooCmdArg VisualizeError(const RooFitResult& fitres, const RooArgSet& param, double Z, bool EVmethod)
                                                                   { return RooCmdArg("VisualizeError",EVmethod,0,Z,0,0,0,&fitres,0,0,0,&param) ; }
-  RooCmdArg VisualizeError(const RooFitResult& fitres, RooArgSet && param, double Z, bool linearMethod) {
-    return VisualizeError(fitres, RooCmdArg::take(std::move(param)), Z, linearMethod);
-  }
   RooCmdArg VisualizeError(const RooDataSet& paramData, double Z) { return RooCmdArg("VisualizeErrorData",0,0,Z,0,0,0,&paramData,0) ; }
   RooCmdArg ShowProgress()                         { return RooCmdArg("ShowProgress",1,0,0,0,0,0,0,0) ; }
 
@@ -158,9 +162,7 @@ namespace RooFit {
   RooCmdArg Import(TTree& tree)                         { return RooCmdArg("ImportTree",0,0,0,0,0,0,reinterpret_cast<TObject*>(&tree),0) ; }
   RooCmdArg ImportFromFile(const char* fname, const char* tname){ return RooCmdArg("ImportFromFile",0,0,0,0,fname,tname,0,0) ; }
   RooCmdArg StoreError(const RooArgSet& aset)           { return RooCmdArg("StoreError",0,0,0,0,0,0,0,0,0,0,&aset) ; }
-  RooCmdArg StoreError(RooArgSet && aset)               { return StoreError(RooCmdArg::take(std::move(aset))); }
   RooCmdArg StoreAsymError(const RooArgSet& aset)       { return RooCmdArg("StoreAsymError",0,0,0,0,0,0,0,0,0,0,&aset) ; }
-  RooCmdArg StoreAsymError(RooArgSet && aset)           { return StoreAsymError(RooCmdArg::take(std::move(aset))); }
   RooCmdArg OwnLinked()                                 { return RooCmdArg("OwnLinked",1,0,0,0,0,0,0,0,0,0,0) ; }
 
   RooCmdArg Import(const std::map<std::string,RooDataSet*>& arg) {
@@ -210,32 +212,36 @@ namespace RooFit {
   RooCmdArg AutoRange(const RooAbsData& data, double marginFactor) { return RooCmdArg("AutoRange",0,0,marginFactor,0,0,0,&data,0) ; }
 
   // RooAbsData::reduce arguments
-  RooCmdArg SelectVars(const RooArgSet& vars)     { return RooCmdArg("SelectVars",0,0,0,0,0,0,&vars,0) ; }
-  RooCmdArg SelectVars(RooArgSet && vars) { return SelectVars(RooCmdArg::take(std::move(vars))); }
+  RooCmdArg SelectVars(const RooArgSet& vars) {
+      RooCmdArg out{"SelectVars",0};
+      out.setSet(0, vars);
+      return out;
+  }
   RooCmdArg EventRange(Int_t nStart, Int_t nStop) { return RooCmdArg("EventRange",nStart,nStop,0,0,0,0,0,0) ; }
 
   // RooAbsPdf::fitTo arguments
   RooCmdArg PrefitDataFraction(double data_ratio)  { return RooCmdArg("Prefit",0,0,data_ratio,0,nullptr,nullptr,nullptr,nullptr) ; }
-  RooCmdArg Optimize(Int_t flag)         { return RooCmdArg("Optimize",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Verbose(bool flag)         { return RooCmdArg("Verbose",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Save(bool flag)            { return RooCmdArg("Save",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Timer(bool flag)           { return RooCmdArg("Timer",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg PrintLevel(Int_t level)      { return RooCmdArg("PrintLevel",level,0,0,0,0,0,0,0) ; }
-  RooCmdArg Warnings(bool flag)        { return RooCmdArg("Warnings",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Strategy(Int_t code)         { return RooCmdArg("Strategy",code,0,0,0,0,0,0,0) ; }
-  RooCmdArg InitialHesse(bool flag)    { return RooCmdArg("InitialHesse",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Hesse(bool flag)           { return RooCmdArg("Hesse",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Minos(bool flag)           { return RooCmdArg("Minos",flag,0,0,0,0,0,0,0) ; }
-  RooCmdArg Minos(const RooArgSet& minosArgs)            { return RooCmdArg("Minos",true,0,0,0,0,0,&minosArgs,0) ; }
-  RooCmdArg Minos(RooArgSet && minosArgs) { return Minos(RooCmdArg::take(std::move(minosArgs))); }
+  RooCmdArg Optimize(Int_t flag)         { return RooCmdArg("Optimize",flag) ; }
+  RooCmdArg Verbose(bool flag)         { return RooCmdArg("Verbose",flag) ; }
+  RooCmdArg Save(bool flag)            { return RooCmdArg("Save",flag) ; }
+  RooCmdArg Timer(bool flag)           { return RooCmdArg("Timer",flag) ; }
+  RooCmdArg PrintLevel(Int_t level)      { return RooCmdArg("PrintLevel",level) ; }
+  RooCmdArg Warnings(bool flag)        { return RooCmdArg("Warnings",flag) ; }
+  RooCmdArg Strategy(Int_t code)         { return RooCmdArg("Strategy",code) ; }
+  RooCmdArg InitialHesse(bool flag)    { return RooCmdArg("InitialHesse",flag) ; }
+  RooCmdArg Hesse(bool flag)           { return RooCmdArg("Hesse",flag) ; }
+  RooCmdArg Minos(bool flag)           { return RooCmdArg("Minos",flag) ; }
+  RooCmdArg Minos(const RooArgSet& minosArgs)            {
+      RooCmdArg out{"Minos",1};
+      out.setSet(0, minosArgs);
+      return out;
+  }
   RooCmdArg SplitRange(bool flag)                      { return RooCmdArg("SplitRange",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg SumCoefRange(const char* rangeName)          { return RooCmdArg("SumCoefRange",0,0,0,0,rangeName,0,0,0) ; }
   RooCmdArg Constrain(const RooArgSet& params)           { return RooCmdArg("Constrain",0,0,0,0,0,0,0,0,0,0,&params) ; }
-  RooCmdArg Constrain(RooArgSet && params) { return Constrain(RooCmdArg::take(std::move(params))); }
   RooCmdArg GlobalObservablesSource(const char* sourceName) { return {"GlobalObservablesSource",0,0,0,0,sourceName,0,0,0}; }
   RooCmdArg GlobalObservablesTag(const char* tagName)    { return RooCmdArg("GlobalObservablesTag",0,0,0,0,tagName,0,0,0) ; }
-  RooCmdArg ExternalConstraints(const RooArgSet& cpdfs)  { return RooCmdArg("ExternalConstraints",0,0,0,0,0,0,&cpdfs,0,0,0,&cpdfs) ; }
-  RooCmdArg ExternalConstraints(RooArgSet && cpdfs)      { return ExternalConstraints(RooCmdArg::take(std::move(cpdfs))); }
+  RooCmdArg ExternalConstraints(const RooArgSet& cpdfs)  { return RooCmdArg("ExternalConstraints",0,0,0,0,0,0,nullptr,nullptr,0,0,&cpdfs) ; }
   RooCmdArg PrintEvalErrors(Int_t numErrors)             { return RooCmdArg("PrintEvalErrors",numErrors,0,0,0,0,0,0,0) ; }
   RooCmdArg EvalErrorWall(bool flag)                   { return RooCmdArg("EvalErrorWall",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg SumW2Error(bool flag)                      { return RooCmdArg("SumW2Error",flag,0,0,0,0,0,0,0) ; }
@@ -252,8 +258,11 @@ namespace RooFit {
   // RooAbsPdf::paramOn arguments
   RooCmdArg Label(const char* str) { return RooCmdArg("Label",0,0,0,0,str,0,0,0) ; }
   RooCmdArg Layout(double xmin, double xmax, double ymin) { return RooCmdArg("Layout",Int_t(ymin*10000),0,xmin,xmax,0,0,0,0) ; }
-  RooCmdArg Parameters(const RooArgSet& params) { return RooCmdArg("Parameters",0,0,0,0,0,0,&params,0) ; }
-  RooCmdArg Parameters(RooArgSet && params) { return Parameters(RooCmdArg::take(std::move(params))) ; }
+  RooCmdArg Parameters(const RooArgSet& params) {
+      RooCmdArg out{"Parameters",0};
+      out.setSet(0, params);
+      return out;
+  }
   RooCmdArg ShowConstants(bool flag) { return RooCmdArg("ShowConstants",flag,0,0,0,0,0,0,0) ; }
 
   // RooTreeData::statOn arguments
@@ -261,15 +270,6 @@ namespace RooFit {
 
   // RooProdPdf::ctor arguments
   RooCmdArg Conditional(const RooArgSet& pdfSet, const RooArgSet& depSet, bool depsAreCond) { return RooCmdArg("Conditional",depsAreCond,0,0,0,0,0,0,0,0,0,&pdfSet,&depSet) ; } ;
-  RooCmdArg Conditional(RooArgSet && pdfSet, const RooArgSet& depSet, bool depsAreCond) {
-    return Conditional(RooCmdArg::take(std::move(pdfSet)), depSet, depsAreCond);
-  }
-  RooCmdArg Conditional(const RooArgSet& pdfSet, RooArgSet && depSet, bool depsAreCond) {
-    return Conditional(pdfSet, RooCmdArg::take(std::move(depSet)), depsAreCond);
-  }
-  RooCmdArg Conditional(RooArgSet && pdfSet, RooArgSet && depSet, bool depsAreCond) {
-    return Conditional(RooCmdArg::take(std::move(pdfSet)), RooCmdArg::take(std::move(depSet)), depsAreCond);
-  }
 
   // RooAbsPdf::generate arguments
   RooCmdArg ProtoData(const RooDataSet& protoData, bool randomizeOrder, bool resample)
@@ -298,7 +298,6 @@ namespace RooFit {
 
   // RooAbsReal::fillHistogram arguments
   RooCmdArg IntegratedObservables(const RooArgSet& intObs) {  return RooCmdArg("IntObs",0,0,0,0,0,0,0,0,0,0,&intObs,0) ; } ;
-  RooCmdArg IntegratedObservables(RooArgSet && intObs) { return IntegratedObservables(RooCmdArg::take(std::move(intObs))); }
 
   // RooAbsReal::createIntegral arguments
   RooCmdArg NumIntConfig(const RooNumIntConfig& cfg) { return RooCmdArg("NumIntConfig",0,0,0,0,0,0,&cfg,0) ; }
@@ -371,8 +370,11 @@ namespace RooFit {
   RooCmdArg Restrict(const char* catName, const char* stateNameList) { return RooCmdArg("Restrict",0,0,0,0,catName,stateNameList,0,0) ; }
 
   // RooAbsPdf::createCdf() arguments
-  RooCmdArg SupNormSet(const RooArgSet& nset) { return RooCmdArg("SupNormSet",0,0,0,0,0,0,&nset,0) ; }
-  RooCmdArg SupNormSet(RooArgSet && nset) { return SupNormSet(RooCmdArg::take(std::move(nset))); }
+  RooCmdArg SupNormSet(const RooArgSet& nset) {
+      RooCmdArg out{"SupNormSet",0};
+      out.setSet(0, nset);
+      return out;
+  }
   RooCmdArg ScanParameters(Int_t nbins,Int_t intOrder) { return RooCmdArg("ScanParameters",nbins,intOrder,0,0,0,0,0,0) ; }
   RooCmdArg ScanNumCdf() { return RooCmdArg("ScanNumCdf",1,0,0,0,0,0,0,0) ; }
   RooCmdArg ScanAllCdf() { return RooCmdArg("ScanAllCdf",1,0,0,0,0,0,0,0) ; }

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -123,7 +123,7 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
   RooCmdConfig pc(Form("RooMCStudy::RooMCStudy(%s)",model.GetName())) ;
 
   pc.defineObject("fitModel","FitModel",0,0) ;
-  pc.defineObject("condObs","ProjectedDependents",0,0) ;
+  pc.defineObject("condObs","ProjectedObservables",0,0) ;
   pc.defineObject("protoData","PrototypeData",0,0) ;
   pc.defineSet("cPars","Constrain",0,0) ;
   pc.defineSet("extCons","ExternalConstraints",0,0) ;

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -123,7 +123,7 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
   RooCmdConfig pc(Form("RooMCStudy::RooMCStudy(%s)",model.GetName())) ;
 
   pc.defineObject("fitModel","FitModel",0,0) ;
-  pc.defineObject("condObs","ProjectedObservables",0,0) ;
+  pc.defineSet("condObs","ProjectedObservables",0,0) ;
   pc.defineObject("protoData","PrototypeData",0,0) ;
   pc.defineSet("cPars","Constrain",0,0) ;
   pc.defineSet("extCons","ExternalConstraints",0,0) ;
@@ -221,8 +221,8 @@ RooMCStudy::RooMCStudy(const RooAbsPdf& model, const RooArgSet& observables,
 
   // Extract conditional observables and prototype data
   _genProtoData = static_cast<RooDataSet*>(pc.getObject("protoData",0)) ;
-  if (pc.getObject("condObs",0)) {
-    _projDeps.add(static_cast<RooArgSet&>(*pc.getObject("condObs",0))) ;
+  if (auto condObs = pc.getSet("condObs",0)) {
+    _projDeps.add(*condObs);
   }
 
   _dependents.add(observables) ;

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -94,9 +94,9 @@ RooNLLVar::RooNLLVar(const char *name, const char* title, RooAbsPdf& pdf, RooAbs
            const RooCmdArg& arg4, const RooCmdArg& arg5,const RooCmdArg& arg6,
            const RooCmdArg& arg7, const RooCmdArg& arg8,const RooCmdArg& arg9) :
   RooAbsOptTestStatistic(name,title,pdf,indata,
-                         *static_cast<const RooArgSet*>(RooCmdConfig::decodeObjOnTheFly(
+                         *RooCmdConfig::decodeSetOnTheFly(
                              "RooNLLVar::RooNLLVar","ProjectedObservables",0,&_emptySet,
-                             arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9)),
+                             arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9),
                          makeRooAbsTestStatisticCfg(arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8,arg9))
 {
   RooCmdConfig pc("RooNLLVar::RooNLLVar") ;

--- a/roofit/roofitcore/src/RooSimultaneous.cxx
+++ b/roofit/roofitcore/src/RooSimultaneous.cxx
@@ -590,9 +590,9 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   // It is not used directly, but the "SliceCat" commands are nested in it.
   // Removing this dummy definition results in "ERROR: unrecognized command: SliceCatMany".
   pc.defineObject("dummy1","SliceCatMany",0) ;
-  pc.defineObject("projSet","Project",0) ;
-  pc.defineObject("sliceSet","SliceVars",0) ;
-  pc.defineObject("projDataSet","ProjData",0) ;
+  pc.defineSet("projSet","Project",0) ;
+  pc.defineSet("sliceSet","SliceVars",0) ;
+  pc.defineSet("projDataSet","ProjData",0) ;
   pc.defineObject("projData","ProjData",1) ;
   pc.defineMutex("Project","SliceVars") ;
   pc.allowUndefined() ; // there may be commands we don't handle here
@@ -604,10 +604,10 @@ RooPlot* RooSimultaneous::plotOn(RooPlot *frame, RooLinkedList& cmdList) const
   }
 
   const RooAbsData* projData = (const RooAbsData*) pc.getObject("projData") ;
-  const RooArgSet* projDataSet = (const RooArgSet*) pc.getObject("projDataSet") ;
-  const RooArgSet* sliceSetTmp = (const RooArgSet*) pc.getObject("sliceSet") ;
+  const RooArgSet* projDataSet = pc.getSet("projDataSet");
+  const RooArgSet* sliceSetTmp = pc.getSet("sliceSet") ;
   std::unique_ptr<RooArgSet> sliceSet( sliceSetTmp ? ((RooArgSet*) sliceSetTmp->Clone()) : nullptr );
-  const RooArgSet* projSet = (const RooArgSet*) pc.getObject("projSet") ;
+  const RooArgSet* projSet = pc.getSet("projSet") ;
   double scaleFactor = pc.getDouble("scaleFactor") ;
   ScaleType stype = (ScaleType) pc.getInt("scaleType") ;
 


### PR DESCRIPTION
As reported in issue https://github.com/root-project/root/issues/11421, the fact that in the RooFit command
arguments, the `RooArgSet`s are often stored by pointer is still a
problem. I attempted before to circumvent the problem by detecting
potential lifetime issues by having a dedicated `RooArgSet&&` overloads
that resulted in RooCmdArgs that owned copied of the RooArgSets.

However, this still didn't work for the case where the Python collection
pythonizations are used in PyROOT, because there the `RooArgSet &&`
overloads are not hit.

I realized now that the `RooCmdArg` class already has the slots to store
RooArgSets by value, which was alredy used by a few RooFit command
arguments. When these `set` slots are used, there are no ownership
issues.

This commit suggests to always use these `set` slots for RooArgSets.
This entailed changing the functions that make use of the command
arguments, migrating from `defineObject` to `defineSet`.

All the hacks to get owned copies of the RooArgSets and `RooArgSet&&`
overloads can now be removed.

Now that the slot indices for the sets was changed in many RooFit
command arguments, there is only the caveat that command arguments are
not backwards compatible anymore. However, this should not be any
problem because `RooCmdArgs` are not supposed to be written to files
anyway. To explicitely disallow this and prevent any silet backwards
compatibility issue, the class version of the RooCmdArg was set to zero
to disable IO.

A first commit in this PR fixes also an other issue where the wrong command argument name was used in the RooMCStudy.

Closes https://github.com/root-project/root/issues/11421.

