### PR TITLE
[proof] use proper string type to store object name in TProofDraw

### DIFF
--- a/proof/proofplayer/src/TProofDraw.cxx
+++ b/proof/proofplayer/src/TProofDraw.cxx
@@ -779,15 +779,15 @@ void TProofDrawHist::SlaveBegin(TTree *tree)
       fTreeDrawArgsParser.Parse(fInitialExp, fSelection, fOption);
       fDimension = fTreeDrawArgsParser.GetDimension();
       TString exp = fTreeDrawArgsParser.GetExp();
-      const char *objname = fTreeDrawArgsParser.GetObjectName();
-      if (objname && strlen(objname) > 0 && strcmp(objname, "htemp")) {
-         TH1 *hist = dynamic_cast<TH1*> (fInput->FindObject(objname));
+      TString objname = fTreeDrawArgsParser.GetObjectName();
+      if (objname.Length() > 0 && strcmp(objname.Data(), "htemp")) {
+         TH1 *hist = dynamic_cast<TH1*> (fInput->FindObject(objname.Data()));
          if (hist) {
             fHistogram = (TH1 *) hist->Clone();
             PDB(kDraw,1) Info("SlaveBegin","original histogram found");
          } else {
             PDB(kDraw,1) Info("SlaveBegin", "original object '%s' not found"
-                                          " or it is not a histogram", objname);
+                                          " or it is not a histogram", objname.Data());
          }
       }
 


### PR DESCRIPTION
Fixing compiler warning:
```
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx: In member function ‘virtual void TProofDrawHist::SlaveBegin(TTree*)’:
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:783:51: error: dangling pointer to an unnamed temporary may be used [-Werror=dangling-pointer=]
  783 |       if (objname && strlen(objname) > 0 && strcmp(objname, "htemp")) {
      |                                             ~~~~~~^~~~~~~~~~~~~~~~~~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:789:30: error: dangling pointer to an unnamed temporary may be used [-Werror=dangling-pointer=]
  789 |             PDB(kDraw,1) Info("SlaveBegin", "original object '%s' not found"
      |                          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  790 |                                           " or it is not a histogram", objname);
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:784:60: error: dangling pointer to an unnamed temporary may be used [-Werror=dangling-pointer=]
  784 |          TH1 *hist = dynamic_cast<TH1*> (fInput->FindObject(objname));
      |                                          ~~~~~~~~~~~~~~~~~~^~~~~~~~~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:783:38: error: dangling pointer to an unnamed temporary may be used [-Werror=dangling-pointer=]
  783 |       if (objname && strlen(objname) > 0 && strcmp(objname, "htemp")) {
      |                      ~~~~~~~~~~~~~~~~^~~
/home/linev/git/root6/proof/proofplayer/src/TProofDraw.cxx:782:62: note: unnamed temporary defined here
  782 |       const char *objname = fTreeDrawArgsParser.GetObjectName();
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

