### PR TITLE
[RF] Add missing `override` keywords in `test`

### DIFF
--- a/test/Aclock.h
+++ b/test/Aclock.h
@@ -30,9 +30,9 @@ protected:
 
 public:
    TPolygon(Int_t n, Float_t *x, Float_t *y);
-   virtual ~TPolygon() { fPad->GetListOfPrimitives()->Remove(this); }
+   ~TPolygon() override { fPad->GetListOfPrimitives()->Remove(this); }
 
-   virtual void Paint(Option_t *option="");
+   void Paint(Option_t *option="") override;
 
    TPad  *GetPad() { return fPad; }
 };
@@ -43,7 +43,7 @@ class ClockPoints : public TPoints {
 
 public:
    ClockPoints(Coord_t x=0, Coord_t y=0) : TPoints(x,y) { }
-   ~ClockPoints() { }
+   ~ClockPoints() override { }
 
    void SetXY(Coord_t x, Coord_t y) { SetX(x); SetY(y); }
 
@@ -80,7 +80,7 @@ protected:
 
 public:
    ClockHand(Int_t n, Float_t *x, Float_t *y);
-   virtual ~ClockHand() { }
+   ~ClockHand() override { }
 
    UInt_t GetTime()    { fgTime->Set(); return fgTime->GetTime(); }
    UInt_t GetHour()    { return  GetTime()/10000; }
@@ -103,9 +103,9 @@ private:
 public:
    MinuteHand(Int_t n=3, Float_t *x=fgMinuteHandX, Float_t *y=fgMinuteHandY)
       : ClockHand(n,x,y) { }
-   ~MinuteHand() { }
+   ~MinuteHand() override { }
 
-   Float_t GetHandAngle() { return 6.*(GetMinute()+ GetSecond()/60.); }
+   Float_t GetHandAngle() override { return 6.*(GetMinute()+ GetSecond()/60.); }
 };
 
 
@@ -119,9 +119,9 @@ private:
 public:
    HourHand(Int_t n=3, Float_t *x=fgHourHandX, Float_t *y=fgHourHandY)
       : ClockHand(n,x,y) { }
-   ~HourHand() { }
+   ~HourHand() override { }
 
-   Float_t GetHandAngle() { return 30.*(GetHour()%12 + GetMinute()/60.); }
+   Float_t GetHandAngle() override { return 30.*(GetHour()%12 + GetMinute()/60.); }
 };
 
 
@@ -133,14 +133,14 @@ private:
    static Float_t fgSecondHandY[];
 
 protected:
-   UInt_t GetTimeValue() { return GetSecond(); }   // used to update every second
+   UInt_t GetTimeValue() override { return GetSecond(); }   // used to update every second
 
 public:
    SecondHand(Int_t n=4, Float_t *x=fgSecondHandX, Float_t *y=fgSecondHandY)
       : ClockHand(n,x,y) { }
-   ~SecondHand() { }
+   ~SecondHand() override { }
 
-   Float_t GetHandAngle() { return  6.*GetSecond(); }
+   Float_t GetHandAngle() override { return  6.*GetSecond(); }
 };
 
 
@@ -155,13 +155,13 @@ private:
 
 public:
    Aclock(Int_t csize=100);
-   virtual ~Aclock();
+   ~Aclock() override;
 
-   virtual Bool_t Notify();
-   void   Paint(Option_t *option);
+   Bool_t Notify() override;
+   void   Paint(Option_t *option) override;
    void   Animate();
 
-   ClassDef(Aclock,0)  // analog clock = xclock
+   ClassDefOverride(Aclock,0)  // analog clock = xclock
 };
 
 #endif   // ACLOCK

--- a/test/Event.h
+++ b/test/Event.h
@@ -49,11 +49,11 @@ public:
    Track() : fTriggerBits(64) { fNsp = 0; fPointValue = 0; }
    Track(const Track& orig);
    Track(Float_t random);
-   virtual ~Track() {Clear(); delete [] fPointValue; fPointValue = nullptr; }
+   ~Track() override {Clear(); delete [] fPointValue; fPointValue = nullptr; }
    Track &operator=(const Track &orig);
 
    void          Set(Float_t random);
-   void          Clear(Option_t *option="");
+   void          Clear(Option_t *option="") override;
    Float_t       GetPx() const { return fPx; }
    Float_t       GetPy() const { return fPy; }
    Float_t       GetPz() const { return fPz; }
@@ -78,7 +78,7 @@ public:
    Int_t         GetN() const { return fNsp; }
    Double32_t    GetPointValue(Int_t i=0) const { return (i<fNsp)?fPointValue[i]:0; }
 
-   ClassDef(Track,2)  //A track segment
+   ClassDefOverride(Track,2)  //A track segment
 };
 
 class EventHeader {
@@ -131,9 +131,9 @@ private:
 
 public:
    Event();
-   virtual ~Event();
+   ~Event() override;
    void          Build(Int_t ev, Int_t arg5=600, Float_t ptmin=1);
-   void          Clear(Option_t *option ="");
+   void          Clear(Option_t *option ="") override;
    Bool_t        IsValid() const { return fIsValid; }
    static void   Reset(Option_t *option ="");
    void          ResetHistogramPointer() {fH=0;}
@@ -167,7 +167,7 @@ public:
    Double32_t    GetMatrix(UChar_t x, UChar_t y) { return (x<4&&y<4)?fMatrix[x][y]:0; }
    TBits&        GetTriggerBits() { return fTriggerBits; }
 
-   ClassDef(Event,1)  //Event structure
+   ClassDefOverride(Event,1)  //Event structure
 };
 
 

--- a/test/EventMT.h
+++ b/test/EventMT.h
@@ -52,10 +52,10 @@ public:
    Track() { fPointValue = 0; }
    Track(const Track& orig);
    Track(Float_t random);
-   virtual ~Track() {Clear();}
+   ~Track() override {Clear();}
    Track &operator=(const Track &orig);
 
-   void          Clear(Option_t *option="");
+   void          Clear(Option_t *option="") override;
    Float_t       GetPx() const { return fPx; }
    Float_t       GetPy() const { return fPy; }
    Float_t       GetPz() const { return fPz; }
@@ -80,7 +80,7 @@ public:
    Int_t         GetN() const { return fNsp; }
    Double32_t    GetPointValue(Int_t i=0) const { return (i<fNsp)?fPointValue[i]:0; }
 
-   ClassDef(Track,2)  //A track segment
+   ClassDefOverride(Track,2)  //A track segment
 };
 
 class EventHeader {
@@ -98,7 +98,7 @@ public:
    Int_t  GetRun() const { return fRun; }
    Int_t  GetDate() const { return fDate; }
 
-   ClassDef(EventHeader,1)  //Event Header
+   ClassDefOverride(EventHeader,1)  //Event Header
 };
 
 
@@ -127,9 +127,9 @@ private:
 
 public:
    Event();
-   virtual ~Event();
+   ~Event() override;
    void          Build(Int_t ev, Int_t arg5=600, Float_t ptmin=1);
-   void          Clear(Option_t *option ="");
+   void          Clear(Option_t *option ="") override;
    Bool_t        IsValid() const { return fIsValid; }
    void          ResetHistogramPointer() {fH=0;}
    void          SetNseg(Int_t n) { fNseg = n; }
@@ -162,7 +162,7 @@ public:
    Double32_t    GetMatrix(UChar_t x, UChar_t y) { return (x<4&&y<4)?fMatrix[x][y]:0; }
    TBits&        GetTriggerBits() { return fTriggerBits; }
 
-   ClassDef(Event,1)  //Event structure
+   ClassDefOverride(Event,1)  //Event structure
 };
 
 
@@ -196,7 +196,7 @@ public:
 
    void Hfill(Event *event);
 
-   ClassDef(HistogramManager,1)  //Manages all histograms
+   ClassDefOverride(HistogramManager,1)  //Manages all histograms
 };
 
 #endif

--- a/test/Hello.h
+++ b/test/Hello.h
@@ -28,7 +28,7 @@ class TChar : public TText {
 
 public:
    TChar(char ch='\0',Coord_t x=0, Coord_t y=0);
-   virtual ~TChar() { }
+   ~TChar() override { }
 
    char GetChar() {
       return GetTitle()[0];
@@ -47,19 +47,19 @@ private:
 
 public:
    Hello(const char *text = "Hello, World!");
-   virtual ~Hello();
+   ~Hello() override;
 
-   Bool_t  Notify();
-   void    ExecuteEvent(Int_t event, Int_t px, Int_t py);
-   Int_t   DistancetoPrimitive(Int_t, Int_t) { return 0; }
+   Bool_t  Notify() override;
+   void    ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
+   Int_t   DistancetoPrimitive(Int_t, Int_t) override { return 0; }
 
    Float_t GetWidth();
-   void    Paint(Option_t* option="");
-   void    Print(Option_t * = "") const;
-   void    ls(Option_t * = "") const;
+   void    Paint(Option_t* option="") override;
+   void    Print(Option_t * = "") const override;
+   void    ls(Option_t * = "") const override;
    TList  *GetList() { return fList; }
 
-   ClassDef(Hello,0)   // animated text with cool wave effect
+   ClassDefOverride(Hello,0)   // animated text with cool wave effect
 };
 
 #endif

--- a/test/ProofBench/EventTree_NoProc.h
+++ b/test/ProofBench/EventTree_NoProc.h
@@ -82,7 +82,7 @@ public :
    virtual void    SlaveTerminate();
    virtual void    Terminate();
 
-   ClassDef(EventTree_NoProc,0);
+   ClassDefOverride(EventTree_NoProc,0);
 };
 
 #endif

--- a/test/ProofBench/EventTree_Proc.h
+++ b/test/ProofBench/EventTree_Proc.h
@@ -82,7 +82,7 @@ public :
    virtual void    SlaveTerminate();
    virtual void    Terminate();
 
-   ClassDef(EventTree_Proc,0);
+   ClassDefOverride(EventTree_Proc,0);
 };
 
 #endif

--- a/test/ProofBench/EventTree_ProcOpt.h
+++ b/test/ProofBench/EventTree_ProcOpt.h
@@ -82,7 +82,7 @@ public :
    virtual void    SlaveTerminate();
    virtual void    Terminate();
 
-   ClassDef(EventTree_ProcOpt,0);
+   ClassDefOverride(EventTree_ProcOpt,0);
 };
 
 #endif

--- a/test/RootIDE/TGRootIDE.h
+++ b/test/RootIDE/TGRootIDE.h
@@ -61,7 +61,7 @@ public:
    TGDocument(const char *fname = "", const char *title = "", Int_t tabid = 0,
              TGTab *tab = 0, TGTabElement *tabel = 0, TGTextEdit *edit = 0,
              TObjArray *doclist = 0);
-   virtual ~TGDocument() { }
+   ~TGDocument() override { }
 
    Bool_t         Open(const char *filename);
    Bool_t         Close();
@@ -76,7 +76,7 @@ public:
    void           DataChanged();
    void           DataDropped(char *fname);
 
-   ClassDef(TGDocument,0)  // Simple class describing document used in TGRootIDE
+   ClassDefOverride(TGDocument,0)  // Simple class describing document used in TGRootIDE
 };
 
 class TGRootIDE : public TGMainFrame {
@@ -136,12 +136,12 @@ public:
                 UInt_t w = 900, UInt_t h = 600);
    TGRootIDE(TMacro *macro, const TGWindow *p = 0, UInt_t w = 0,
                 UInt_t h = 0);
-   virtual ~TGRootIDE();
+   ~TGRootIDE() override;
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
-   virtual Bool_t HandleKey(Event_t *event);
-   virtual Bool_t HandleTimer(TTimer *t);
-   virtual void   CloseWindow();
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   Bool_t HandleKey(Event_t *event) override;
+   Bool_t HandleTimer(TTimer *t) override;
+   void   CloseWindow() override;
 
    void           ClearText();
    Bool_t         LoadBuffer(const char *buf) { return fTextEdit->LoadBuffer(buf); }
@@ -182,7 +182,7 @@ public:
    void           MouseOver(char *);
    void           MouseDown(char *);
 
-   ClassDef(TGRootIDE,0)  // Simple IDE using TGTextEdit and TGHtml widgets
+   ClassDefOverride(TGRootIDE,0)  // Simple IDE using TGTextEdit and TGHtml widgets
 };
 
 #endif

--- a/test/RootShower/GButtonFrame.h
+++ b/test/RootShower/GButtonFrame.h
@@ -42,7 +42,7 @@ public:
    // Constructor & destructor
    GButtonFrame(const TGWindow* p, TGWindow* buttonHandler, Int_t nextEventId,
                 Int_t showTrackId, Int_t interruptSimId);
-   virtual ~GButtonFrame();
+   ~GButtonFrame() override;
 
    void SetState(EState state);
 };

--- a/test/RootShower/GTitleFrame.h
+++ b/test/RootShower/GTitleFrame.h
@@ -48,7 +48,7 @@ public:
    GTitleFrame(const TGWindow *p, const char *mainText, const char *subText,
                UInt_t w, UInt_t h, UInt_t options = kHorizontalFrame | kRaisedFrame);
    void ChangeRightLogo(Int_t frame);
-   virtual ~GTitleFrame();
+   ~GTitleFrame() override;
 };
 
 #endif // GTITLEFRAME_H

--- a/test/RootShower/MyDetector.h
+++ b/test/RootShower/MyDetector.h
@@ -44,7 +44,7 @@ private:
 
 public:
     MyDetector();
-    virtual ~MyDetector();
+    ~MyDetector() override;
     void        Init();
     Double_t    GetI(Int_t idx) { return fI[idx]; }
     Double_t    GetPreconst(Int_t idx) { return fPreconst[idx]; }
@@ -75,7 +75,7 @@ public:
     void        AddELoss(Double_t val) { fTotalELoss += val; }
     void        ClearELoss() { fTotalELoss = 0.0; }
 
-    ClassDef(MyDetector,1)   // Detector structure
+    ClassDefOverride(MyDetector,1)   // Detector structure
 };
 
 #endif // MYDETECTOR_H

--- a/test/RootShower/MyEvent.h
+++ b/test/RootShower/MyEvent.h
@@ -53,7 +53,7 @@ public:
    Int_t       GetPrimary() const { return fPrimary; }
    Double_t    GetEnergy() const { return fEnergy; }
 
-   ClassDef(EventHeader,1)  //Event Header
+   ClassDefOverride(EventHeader,1)  //Event Header
 };
 
 class MyEvent : public TObject {
@@ -77,8 +77,8 @@ private:
 
 public :
    MyEvent();
-   virtual ~MyEvent();
-   void            Clear(Option_t *option ="");
+   ~MyEvent() override;
+   void            Clear(Option_t *option ="") override;
    void            Reset(Option_t *option ="");
    void            Init(Int_t id, Int_t first_particle, Double_t E_0, Double_t B_0);
    void            SetB(Double_t newB) { fB = newB; }
@@ -116,7 +116,7 @@ public :
    Int_t           ParticleColor(Int_t);
    void            ScatterAngle(Int_t);
 
-   ClassDef(MyEvent,1)  //Event structure
+   ClassDefOverride(MyEvent,1)  //Event structure
 };
 
 #endif // MYEVENT_H

--- a/test/RootShower/MyParticle.h
+++ b/test/RootShower/MyParticle.h
@@ -46,7 +46,7 @@ private:
 
 public :
    MyParticle();
-   ~MyParticle();
+   ~MyParticle() override;
    MyParticle(Int_t, Int_t, Int_t, Int_t, const TVector3 &, const TVector3 &, Double_t, Double_t, Double_t);
    MyParticle(Int_t, Int_t, Int_t, Int_t, const TVector3 &, const TVector3 &);
    TPolyLine3D  *AddTrack(const TVector3 &, Int_t);
@@ -64,9 +64,9 @@ public :
    Double_t      GetTimeOfDecay() { return fTimeOfDecay; }
    Int_t         GetNChildren() { return fNChildren; }
    Int_t         GetNTracks() { return fNtrack+1; }
-   Char_t       *GetObjectInfo(Int_t px, Int_t py) const;
+   Char_t       *GetObjectInfo(Int_t px, Int_t py) const override;
    TPolyLine3D  *GetTrack(Int_t at) const {return (TPolyLine3D*)fTracks->At(at);}
-   const Char_t *GetName() const;
+   const Char_t *GetName() const override;
 
    void          SetId(Int_t id) { fId = id; }
    void          SetNChildren(Int_t nb) { fNChildren = nb; }
@@ -89,11 +89,11 @@ public :
 
    void          HighLight(); // *MENU*
 
-   virtual void  Delete(Option_t *) { }
-   virtual void  SetLineAttributes() { }
-   virtual void  SetDrawOption(Option_t *) { }
+   void  Delete(Option_t *) override { }
+   void  SetLineAttributes() override { }
+   void  SetDrawOption(Option_t *) override { }
 
-   ClassDef(MyParticle,1)  //Event structure
+   ClassDefOverride(MyParticle,1)  //Event structure
 };
 
 #endif // MYPARTICLE_H

--- a/test/RootShower/RSAbout.h
+++ b/test/RootShower/RSAbout.h
@@ -48,10 +48,10 @@ private:
 public:
     RootShowerAbout(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h,
                    UInt_t options = kMainFrame | kVerticalFrame);
-    virtual ~RootShowerAbout();
+    ~RootShowerAbout() override;
 
-    virtual void CloseWindow();
-    virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+    void CloseWindow() override;
+    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 #endif // ROOTSHOWERABOUT_H

--- a/test/RootShower/RSMsgBox.h
+++ b/test/RootShower/RSMsgBox.h
@@ -49,10 +49,10 @@ private:
 public:
     RootShowerMsgBox(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h,
                     UInt_t options = kMainFrame | kVerticalFrame);
-    virtual ~RootShowerMsgBox();
+    ~RootShowerMsgBox() override;
 
-    virtual void CloseWindow();
-    virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+    void CloseWindow() override;
+    Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 #endif // ROOTSHOWERMSGBOX_H

--- a/test/RootShower/RootShower.h
+++ b/test/RootShower/RootShower.h
@@ -157,7 +157,7 @@ public:
 
    // Constructors & destructor
    RootShower(const TGWindow *p, UInt_t w, UInt_t h);
-   virtual ~RootShower();
+   ~RootShower() override;
 
    void                SetOk(Bool_t ok=true) { fOk = ok; }
    void                Modified(Bool_t modified=true) { fModified = modified; }
@@ -172,13 +172,13 @@ public:
    virtual void        ShowInfos();
    virtual void        HighLight(TGListTreeItem *item);
    virtual void        OnShowSelected(TGListTreeItem *item);
-   virtual void        Layout();
-   virtual void        CloseWindow();
-   virtual Bool_t      HandleConfigureNotify(Event_t *event);
-   virtual Bool_t      HandleKey(Event_t *event);
-   virtual Bool_t      ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
-   virtual Bool_t      HandleTimer(TTimer *);
-   virtual Int_t       DistancetoPrimitive(Int_t px, Int_t py);
+   void        Layout() override;
+   void        CloseWindow() override;
+   Bool_t      HandleConfigureNotify(Event_t *event) override;
+   Bool_t      HandleKey(Event_t *event) override;
+   Bool_t      ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
+   Bool_t      HandleTimer(TTimer *) override;
+   Int_t       DistancetoPrimitive(Int_t px, Int_t py) override;
    void                Clicked(TGListTreeItem *item, Int_t x, Int_t y);
    void                UpdateDisplay() { fCA->Modified(); fCA->Update(); }
 };

--- a/test/RootShower/SettingsDlg.h
+++ b/test/RootShower/SettingsDlg.h
@@ -43,11 +43,11 @@ private:
 public:
     SettingsDialog(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h,
                          UInt_t options = kVerticalFrame);
-    virtual ~SettingsDialog();
+    ~SettingsDialog() override;
 
     // slots
-    virtual void     CloseWindow();
-    virtual Bool_t   ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+    void     CloseWindow() override;
+    Bool_t   ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 #endif

--- a/test/TBench.h
+++ b/test/TBench.h
@@ -81,9 +81,9 @@ public:
 
   TObjHit();
   TObjHit(int time);
-  virtual ~TObjHit(){;}
+  ~TObjHit() override{;}
 
-  ClassDef(TObjHit,1) // the hit class
+  ClassDefOverride(TObjHit,1) // the hit class
 };
 
 //-------------------------------------------------------------
@@ -232,7 +232,7 @@ public:
   Int_t MakeTree(int mode, int nevents, int compression, int split, float &cx);
   Int_t ReadTree();
 
-  ClassDef(TSTLhitHashSet,1) // STL vector of THit
+  ClassDefOverride(TSTLhitHashSet,1) // STL vector of THit
 };
 //-------------------------------------------------------------
 class TSTLhitHashMultiSet {
@@ -250,7 +250,7 @@ public:
   Int_t MakeTree(int mode, int nevents, int compression, int split, float &cx);
   Int_t ReadTree();
 
-  ClassDef(TSTLhitHashMultiSet,1) // STL vector of THit
+  ClassDefOverride(TSTLhitHashMultiSet,1) // STL vector of THit
 };
 #endif
 //-------------------------------------------------------------

--- a/test/TFormulaTests.cxx
+++ b/test/TFormulaTests.cxx
@@ -42,7 +42,7 @@ protected:
   
 public:
                TFormulaTests(TString name, TString formula): TFormula(name,formula){}
-   virtual     ~TFormulaTests(){}
+       ~TFormulaTests() override{}
    Bool_t      ParserNew();
    Bool_t      GetVarVal();
    Bool_t      GetParVal();

--- a/test/Tetris.h
+++ b/test/Tetris.h
@@ -41,7 +41,7 @@ private:
 
 public:
    TetrisBox(Int_t x=0, Int_t y=0, UInt_t type=0, TPad *pad=(TPad*)TVirtualPad::Pad());
-   virtual ~TetrisBox() { }
+   ~TetrisBox() override { }
 
    Int_t   GetX()                  { return fX; }
    Int_t   GetY()                  { return fY; }
@@ -61,8 +61,8 @@ public:
    virtual void MoveLeft()         { SetX(GetX()-1); }
 
    void    Erase();
-   void    Paint(Option_t *option="");
-   void    ExecuteEvent(Int_t, Int_t, Int_t)  { return; }  // disable any actions on it
+   void    Paint(Option_t *option="") override;
+   void    ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
 };
 
 
@@ -154,11 +154,11 @@ private:
    Bool_t IsLineEmpty(int line);
    void   GluePiece(TetrisPiece *piece);
 
-   void   Clear(Option_t *option = "");
+   void   Clear(Option_t *option = "") override;
    void   Hide();
    void   Show();
-   void   Print(const char *option = "") const;
-   void   Print(const char *, Option_t *) { }  // removes "hiding" warning
+   void   Print(const char *option = "") const override;
+   void   Print(const char *, Option_t *) override { }  // removes "hiding" warning
    Bool_t IsEmptyLine(int line);
    Bool_t IsFullLine(Int_t line);
 
@@ -166,16 +166,16 @@ private:
 
 public:
    TetrisBoard(Float_t xlow, Float_t ylow, Float_t xup, Float_t yup);
-   virtual ~TetrisBoard() { }
+   ~TetrisBoard() override { }
 
    Int_t  GetHeight()                     { return fHeight; }
    Int_t  GetWidth()                      { return fWidth; }
    Bool_t IsEmpty(Int_t x, Int_t y)       { return !Board(x,y); }
    void   SetDropped(Bool_t flag=kTRUE)   { fIsDropped=flag; }
 
-   virtual void PaintModified();
+   void PaintModified() override;
    void   PieceDropped(TetrisPiece *piece, Int_t height);
-   void   ExecuteEvent(Int_t, Int_t, Int_t)  { return; }  // disable any actions on it
+   void   ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
 };
 
 
@@ -195,18 +195,18 @@ protected:
 
 public:
    CurrentPiece(UInt_t type, TetrisBoard* board);
-   ~CurrentPiece() { }
+   ~CurrentPiece() override { }
 
    Bool_t  MoveLeft(Int_t steps = 1);
    Bool_t  MoveRight(Int_t steps = 1);
-   Bool_t  RotateLeft();
-   Bool_t  RotateRight();
+   Bool_t  RotateLeft() override;
+   Bool_t  RotateRight() override;
    Bool_t  DropDown();
    Bool_t  OneLineDown();
-   Bool_t  Notify();
+   Bool_t  Notify() override;
    void    SetSpeed();
-   void    Paint(Option_t *option="");
-   void    ExecuteEvent(Int_t, Int_t, Int_t)  { return; }  // disable any actions on it
+   void    Paint(Option_t *option="") override;
+   void    ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
 };
 
 
@@ -222,14 +222,14 @@ private:
 
 public:
    NextPiecePad(Float_t xlow, Float_t ylow, Float_t xup, Float_t yup);
-   ~NextPiecePad() { }
+   ~NextPiecePad() override { }
 
    void   NewPiece() { fPiece->SetRandomType(); fPiece->Show(); Modified(kTRUE); }
    void   Hide()     { fPiece->Hide(); Modified(kTRUE); }
    void   Show()     { fPiece->Show(); Modified(kTRUE); }
 
    TetrisPiece  *GetPiece() { return fPiece; }
-   void ExecuteEvent(Int_t, Int_t, Int_t)  { return; }  // disable any actions on it
+   void ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
 };
 
 
@@ -242,9 +242,9 @@ class QuitButton : public TButton {
 
 public:
    QuitButton(Float_t xlow, Float_t ylow, Float_t xup, Float_t yup);
-   ~QuitButton() { }
+   ~QuitButton() override { }
 
-   void ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 };
 
 
@@ -259,7 +259,7 @@ private:
 
 public:
    PauseButton(Float_t xlow, Float_t ylow, Float_t xup, Float_t yup);
-   ~PauseButton() { }
+   ~PauseButton() override { }
 
    void SetPressed(Bool_t state) {
       fPressed = state;
@@ -269,7 +269,7 @@ public:
    }
 
    Bool_t   IsPressed()               { return fPressed; }
-   void     ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void     ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 };
 
 
@@ -284,7 +284,7 @@ private:
 
 public:
    NewGameButton(Float_t xlow, Float_t ylow, Float_t xup, Float_t yup);
-   ~NewGameButton() { }
+   ~NewGameButton() override { }
 
    void SetPressed(Bool_t state) {
       fPressed = state;
@@ -294,7 +294,7 @@ public:
    }
 
    Bool_t   IsPressed()               { return fPressed; }
-   void ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   void ExecuteEvent(Int_t event, Int_t px, Int_t py) override;
 };
 
 
@@ -308,15 +308,15 @@ protected:
 
 public:
    InfoPad(const char *title="",Float_t xlow=0, Float_t ylow=0, Float_t xup=0, Float_t yup=0);
-   virtual ~InfoPad() { }
+   ~InfoPad() override { }
 
    UInt_t  GetValue()                  { return fValue; }
    void    SetValue(Int_t value)       { fValue = value; Modified(kTRUE); }
    void    Reset(Option_t * = "")      { SetValue(0); }
    virtual void AddValue(Int_t addValue=1) { fValue = fValue+addValue; Modified(kTRUE); }
 
-   virtual void PaintModified();
-   void ExecuteEvent(Int_t, Int_t, Int_t)  { return; }  // disable any actions on it
+   void PaintModified() override;
+   void ExecuteEvent(Int_t, Int_t, Int_t) override  { return; }  // disable any actions on it
 };
 
 
@@ -329,9 +329,9 @@ class KeyHandler : public TGFrame {
 
 public:
    KeyHandler();
-   ~KeyHandler();
+   ~KeyHandler() override;
 
-   Bool_t HandleKey(Event_t *event);    // handler of the key events
+   Bool_t HandleKey(Event_t *event) override;    // handler of the key events
 };
 
 
@@ -342,9 +342,9 @@ class UpdateLevelTimer : public TTimer {
 
 public:
    UpdateLevelTimer(ULong_t time);
-   ~UpdateLevelTimer() { }
+   ~UpdateLevelTimer() override { }
 
-   Bool_t Notify();
+   Bool_t Notify() override;
 };
 
 
@@ -389,7 +389,7 @@ protected:
 
 public:
    Tetris();
-   virtual ~Tetris() { delete fKeyHandler; }
+   ~Tetris() override { delete fKeyHandler; }
 
    Int_t  GetLevel()           { return fLevel->GetValue(); }
    Int_t  GetLinesRemoved()    { return fLinesRemoved->GetValue(); }
@@ -407,7 +407,7 @@ public:
    void   NewGame();
    void   StopGame();
 
-   ClassDef(Tetris,0)  // ROOT implementation of the Tetris game
+   ClassDefOverride(Tetris,0)  // ROOT implementation of the Tetris game
 };
 
 #endif   // TETRIS_H

--- a/test/fit/GaussFunction.h
+++ b/test/fit/GaussFunction.h
@@ -18,21 +18,21 @@ public:
       fLogAmp = std::log(_amp);
    }
 
-   unsigned int NDim() const { return 1; }
+   unsigned int NDim() const override { return 1; }
 
-   unsigned int NPar() const { return kNPar; }
+   unsigned int NPar() const override { return kNPar; }
 
    inline double amp()   const { return fParams[0]; }
    inline double logamp()   const { return fLogAmp; }
    inline double mean()  const { return fParams[1]; }
    inline double sigma() const { return fParams[2]; }
 
-   const double * Parameters() const { return fParams; }
+   const double * Parameters() const override { return fParams; }
 
-   void SetParameters(const double * p) { std::copy(p,p+kNPar,fParams); /* fLogAmp = std::log( p[0] ); */ }
+   void SetParameters(const double * p) override { std::copy(p,p+kNPar,fParams); /* fLogAmp = std::log( p[0] ); */ }
 
 
-   ROOT::Math::IMultiGenFunction * Clone() const { return new GaussFunction(amp(), mean(), sigma() ); }
+   ROOT::Math::IMultiGenFunction * Clone() const override { return new GaussFunction(amp(), mean(), sigma() ); }
 
 
    // implementing this is much faster
@@ -43,7 +43,7 @@ public:
 
    using  ROOT::Math::IParamMultiGradFunction::operator();
 
-   void ParameterGradient(const double *x, const double * p, double * g) const {
+   void ParameterGradient(const double *x, const double * p, double * g) const override {
       double a = p[0];
       double m = p[1];
       double s = p[2];
@@ -57,7 +57,7 @@ public:
 private:
 
 
-   double DoEvalPar(const double * x, const double * p) const {
+   double DoEvalPar(const double * x, const double * p) const override {
       double a = p[0];
       double m = p[1];
       double s = p[2];
@@ -72,7 +72,7 @@ private:
       return dGdx;
    }
 
-   double DoParameterDerivative(const double *x, const double * p, unsigned int ipar) const {
+   double DoParameterDerivative(const double *x, const double * p, unsigned int ipar) const override {
       double grad[3];
       ParameterGradient(x, p, &grad[0] );
       return grad[ipar];

--- a/test/fit/WrapperRooPdf.h
+++ b/test/fit/WrapperRooPdf.h
@@ -78,7 +78,7 @@ public:
    }
 
 
-   ~WrapperRooPdf() {
+   ~WrapperRooPdf() override {
       // need to delete observables and parameter list
       if (fX) delete fX;
       if (fParams) delete fParams;
@@ -92,18 +92,18 @@ public:
 #else
      ROOT::Math::IMultiGenFunction
 #endif
-     * Clone() const {
+     * Clone() const override {
       // copy the pdf function pointer
       return new WrapperRooPdf(fPdf, *fX, fNorm);
    }
 
-   unsigned int NPar() const {
+   unsigned int NPar() const override {
       return fParams->getSize();
    }
-   unsigned int NDim() const {
+   unsigned int NDim() const override {
       return fX->getSize();
    }
-   const double * Parameters() const {
+   const double * Parameters() const override {
       if (fParamValues.size() != NPar() )
          fParamValues.resize(NPar() );
 
@@ -119,7 +119,7 @@ public:
       return &fParamValues.front();
    }
 
-   std::string ParameterName(unsigned int i) const {
+   std::string ParameterName(unsigned int i) const override {
       // iterate on parameters and set values
       TIter itr = fParams->createIterator() ;
       RooRealVar* var = nullptr;
@@ -137,7 +137,7 @@ public:
       set parameters. Order of parameter is the one defined by the RooPdf and must be checked by user
     */
 
-   void SetParameters(const double * p) {
+   void SetParameters(const double * p) override {
       DoSetParameters(p);
    }
 
@@ -162,7 +162,7 @@ public:
 
 private:
 
-   double DoEvalPar(const double * x, const double * p) const {
+   double DoEvalPar(const double * x, const double * p) const override {
 
       // should maybe be optimized ???
       DoSetParameters(p);

--- a/test/guitest.cxx
+++ b/test/guitest.cxx
@@ -239,10 +239,10 @@ private:
 
 public:
    TestMainFrame(const TGWindow *p, UInt_t w, UInt_t h);
-   virtual ~TestMainFrame();
+   ~TestMainFrame() override;
 
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t);
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
 };
 
 
@@ -271,10 +271,10 @@ private:
 public:
    TestDialog(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h,
                UInt_t options = kVerticalFrame);
-   virtual ~TestDialog();
+   ~TestDialog() override;
 
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -296,10 +296,10 @@ private:
 public:
    TestMsgBox(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h,
               UInt_t options = kVerticalFrame);
-   virtual ~TestMsgBox();
+   ~TestMsgBox() override;
 
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -316,10 +316,10 @@ private:
 
 public:
    TestSliders(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h);
-   virtual ~TestSliders();
+   ~TestSliders() override;
 
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -332,11 +332,11 @@ private:
 
 public:
    TestShutter(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h);
-   ~TestShutter();
+   ~TestShutter() override;
 
    void AddShutterItem(const char *name, shutterData_t data[]);
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -349,8 +349,8 @@ protected:
 
 public:
    TestDirList(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h);
-   virtual ~TestDirList();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   ~TestDirList() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -369,9 +369,9 @@ protected:
 
 public:
    TestFileList(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h);
-   virtual ~TestFileList();
+   ~TestFileList() override;
 
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -387,10 +387,10 @@ private:
 
 public:
    TestProgress(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h);
-   virtual ~TestProgress();
+   ~TestProgress() override;
 
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -418,11 +418,11 @@ private:
 
 public:
    EntryTestDlg(const TGWindow *p, const TGWindow *main);
-   virtual ~EntryTestDlg();
-   virtual void CloseWindow();
+   ~EntryTestDlg() override;
+   void CloseWindow() override;
 
    void SetLimits();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t);
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
 };
 
 
@@ -436,7 +436,7 @@ private:
 
 public:
    Editor(const TGWindow *main, UInt_t w, UInt_t h);
-   virtual ~Editor();
+   ~Editor() override;
 
    void   LoadBuffer(const char *buffer);
    void   LoadFile(const char *file);
@@ -445,8 +445,8 @@ public:
 
    void   SetTitle();
    void   Popup();
-   void   CloseWindow();
-   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   void   CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 };
 
 
@@ -457,10 +457,10 @@ private:
 
 public:
    TileFrame(const TGWindow *p);
-   virtual ~TileFrame() { }
+   ~TileFrame() override { }
 
    void SetCanvas(TGCanvas *canvas) { fCanvas = canvas; }
-   Bool_t HandleButton(Event_t *event);
+   Bool_t HandleButton(Event_t *event) override;
 };
 
 TileFrame::TileFrame(const TGWindow *p) :

--- a/test/guiviewer.h
+++ b/test/guiviewer.h
@@ -22,10 +22,10 @@ private:
 
 public:
    Viewer(const TGWindow *win);
-   virtual ~Viewer();
+   ~Viewer() override;
    void DoButton();
    void DoSlider();
    void SetRange(Float_t xmin, Float_t ymin, Float_t xmax, Float_t ymax,
                  Bool_t move_slider = kTRUE);
-   ClassDef(Viewer,0) //GUI example
+   ClassDefOverride(Viewer,0) //GUI example
 };

--- a/test/histviewer/canvsave.h
+++ b/test/histviewer/canvsave.h
@@ -29,11 +29,11 @@ private:
 public:
    CanvSave(const TGWindow *p, const TGWindow *main, UInt_t w, UInt_t h,
             UInt_t options = kMainFrame | kVerticalFrame);
-   virtual ~CanvSave();
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   ~CanvSave() override;
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
 
-   ClassDef(CanvSave,0)
+   ClassDefOverride(CanvSave,0)
 };
 
 #endif

--- a/test/histviewer/histaction.h
+++ b/test/histviewer/histaction.h
@@ -106,9 +106,9 @@ private:
 
 public:
    HistAction(const TGWindow *p, UInt_t w, UInt_t h);
-   virtual ~HistAction();
-   virtual void CloseWindow();
-   virtual Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2);
+   ~HistAction() override;
+   void CloseWindow() override;
+   Bool_t ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t parm2) override;
    Int_t getNextTrueIndex(); //returns -1 in case of no index found
    void resetIter() {cursorIter = -1;}
    void resetFlags() { for (int i = 0; i < kMaxHist; i++) flags[i] = kFALSE; }
@@ -121,7 +121,7 @@ public:
    void clearScan();
    void paintHist();//draws a histo in case of user defined display layout
 
-   ClassDef(HistAction,0)
+   ClassDefOverride(HistAction,0)
 };
 
 #endif

--- a/test/periodic/NdbAngularDist.h
+++ b/test/periodic/NdbAngularDist.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbAngularDist()
       : NdbMF(4, "Angular distributions for emitted particles") {}
-   ~NdbAngularDist() {}
+   ~NdbAngularDist() override {}
 
-   ClassDef(NdbAngularDist,1)
+   ClassDefOverride(NdbAngularDist,1)
 
 }; // NdbMfAngularDist
 

--- a/test/periodic/NdbDCAngularDist.h
+++ b/test/periodic/NdbDCAngularDist.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbDCAngularDist()
       : NdbMF(34, "Data covariances for angular distributions") {}
-   ~NdbDCAngularDist() {}
+   ~NdbDCAngularDist() override {}
 
-   ClassDef(NdbDCAngularDist,1)
+   ClassDefOverride(NdbDCAngularDist,1)
 
 }; // NdbDCAngularDist
 

--- a/test/periodic/NdbDCEnergyDist.h
+++ b/test/periodic/NdbDCEnergyDist.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbDCEnergyDist()
       : NdbMF(35, "Data covariances for energy distributions") {}
-   ~NdbDCEnergyDist() {}
+   ~NdbDCEnergyDist() override {}
 
-   ClassDef(NdbDCEnergyDist,1)
+   ClassDefOverride(NdbDCEnergyDist,1)
 
 }; // NdbDCEnergyDist
 

--- a/test/periodic/NdbDCNuBar.h
+++ b/test/periodic/NdbDCNuBar.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbDCNuBar()
       : NdbMF(31, "Data covariances for nu(bar)") {}
-   ~NdbDCNuBar() {}
+   ~NdbDCNuBar() override {}
 
-   ClassDef(NdbDCNuBar,1)
+   ClassDefOverride(NdbDCNuBar,1)
 
 }; // NdbDCNuBar
 

--- a/test/periodic/NdbDCRadioXS.h
+++ b/test/periodic/NdbDCRadioXS.h
@@ -12,9 +12,9 @@ public:
    NdbDCRadioXS()
       : NdbMF(40, "Data covariances for radionuclide production "
          "cross sections") {}
-   ~NdbDCRadioXS() {}
+   ~NdbDCRadioXS() override {}
 
-   ClassDef(NdbDCRadioXS,1)
+   ClassDefOverride(NdbDCRadioXS,1)
 
 }; // NdbDCRadioXS
 

--- a/test/periodic/NdbDCRadioYield.h
+++ b/test/periodic/NdbDCRadioYield.h
@@ -12,9 +12,9 @@ public:
    NdbDCRadioYield()
       : NdbMF(39, "Data covariances for radionuclide "
          "production yields") {}
-   ~NdbDCRadioYield() {}
+   ~NdbDCRadioYield() override {}
 
-   ClassDef(NdbDCRadioYield,1)
+   ClassDefOverride(NdbDCRadioYield,1)
 
 }; // NdbDCRadioYield
 

--- a/test/periodic/NdbDCReactionXS.h
+++ b/test/periodic/NdbDCReactionXS.h
@@ -12,9 +12,9 @@ public:
    NdbDCReactionXS()
       : NdbMF(33, "Data covariances for reaction cross section") {}
 
-   ~NdbDCReactionXS() {}
+   ~NdbDCReactionXS() override {}
 
-   ClassDef(NdbDCReactionXS,1)
+   ClassDefOverride(NdbDCReactionXS,1)
 
 }; // NdbDCReactionXS
 

--- a/test/periodic/NdbDCResParam.h
+++ b/test/periodic/NdbDCResParam.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbDCResParam()
       : NdbMF(32, "Data covariances for resonance parameters") {}
-   ~NdbDCResParam() {}
+   ~NdbDCResParam() override {}
 
-   ClassDef(NdbDCResParam,1)
+   ClassDefOverride(NdbDCResParam,1)
 
 }; // NdbDCResParam
 

--- a/test/periodic/NdbDataCovariances.h
+++ b/test/periodic/NdbDataCovariances.h
@@ -13,9 +13,9 @@ public:
       : NdbMF(30, "Data covariances obtained from parameter "
          "covariances and sensitivities") {}
 
-   ~NdbDataCovariances() {}
+   ~NdbDataCovariances() override {}
 
-   ClassDef(NdbDataCovariances,1)
+   ClassDefOverride(NdbDataCovariances,1)
 
 }; // NdbDataCovariances
 

--- a/test/periodic/NdbEndfIO.h
+++ b/test/periodic/NdbEndfIO.h
@@ -51,7 +51,7 @@ protected:
 
 public:
    NdbEndfIO()   { f=NULL; }
-   virtual ~NdbEndfIO()
+   ~NdbEndfIO() override
       { if (f) fclose(f); }
 
    NdbEndfIO( const char *filename, Int_t mode);
@@ -132,7 +132,7 @@ protected:
    Float_t      SubReadReal(Int_t start, Int_t length);
 
 
-   ClassDef(NdbEndfIO,1)
+   ClassDefOverride(NdbEndfIO,1)
 
 }; // NdbEndfIO
 

--- a/test/periodic/NdbEnergyAngleDist.h
+++ b/test/periodic/NdbEnergyAngleDist.h
@@ -12,9 +12,9 @@ public:
    NdbEnergyAngleDist()
       : NdbMF(6, "Energy-angle distributions for emitted particles") {}
 
-   ~NdbEnergyAngleDist() {}
+   ~NdbEnergyAngleDist() override {}
 
-   ClassDef(NdbEnergyAngleDist,1)
+   ClassDefOverride(NdbEnergyAngleDist,1)
 
 }; // NdbEnergyAngleDist
 

--- a/test/periodic/NdbEnergyDist.h
+++ b/test/periodic/NdbEnergyDist.h
@@ -12,9 +12,9 @@ public:
    NdbEnergyDist()
       : NdbMF(5, "Energy distributions for emitted particles") {}
 
-   ~NdbEnergyDist() {}
+   ~NdbEnergyDist() override {}
 
-   ClassDef(NdbEnergyDist,1)
+   ClassDefOverride(NdbEnergyDist,1)
 
 }; // NdbEnergyDist
 

--- a/test/periodic/NdbFissionYield.h
+++ b/test/periodic/NdbFissionYield.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbFissionYield()
       : NdbMF(8, "Radioactivity and fission-product yield data") {}
-   ~NdbFissionYield() {}
+   ~NdbFissionYield() override {}
 
-   ClassDef(NdbFissionYield,1)
+   ClassDefOverride(NdbFissionYield,1)
 
 }; // NdbFissionYield
 

--- a/test/periodic/NdbFormFactors.h
+++ b/test/periodic/NdbFormFactors.h
@@ -12,9 +12,9 @@ public:
    NdbFormFactors()
       : NdbMF(27, "Atomic form factors or scattering functions "
          "for photo-atomic interactions") {}
-   ~NdbFormFactors() {}
+   ~NdbFormFactors() override {}
 
-   ClassDef(NdbFormFactors,1)
+   ClassDefOverride(NdbFormFactors,1)
 
 }; // NdbFormFactors
 

--- a/test/periodic/NdbGeneralInfo.h
+++ b/test/periodic/NdbGeneralInfo.h
@@ -12,9 +12,9 @@ public:
    NdbGeneralInfo()
       : NdbMF(1, "General Information") {}
 
-   ~NdbGeneralInfo() {}
+   ~NdbGeneralInfo() override {}
 
-   ClassDef(NdbGeneralInfo,1)
+   ClassDefOverride(NdbGeneralInfo,1)
 
 }; // NdbGeneralInfo
 

--- a/test/periodic/NdbMF.h
+++ b/test/periodic/NdbMF.h
@@ -24,10 +24,10 @@ public:
       iMF = aMF;
    }
 
-   ~NdbMF() {}
+   ~NdbMF() override {}
 
    // Virtual functions
-   virtual Int_t Compare(const TObject *o) const
+   Int_t Compare(const TObject *o) const override
       { return ((iMF==((NdbMF*)o)->iMF)? 0 :
             (iMF > ((NdbMF*)o)->iMF)? 1 : -1 ); }
 
@@ -50,7 +50,7 @@ public:
    // Move File pointer to beggining of MF section in ENDF file
    void   LocateType() {}
 
-   ClassDef(NdbMF,1)
+   ClassDefOverride(NdbMF,1)
 
 }; // NdbMF
 

--- a/test/periodic/NdbMT.h
+++ b/test/periodic/NdbMT.h
@@ -25,10 +25,10 @@ public:
    NdbMT( Int_t aMT, const char *desc)
    : sDescription(desc) { iMT = aMT; }
 
-   ~NdbMT() {}
+   ~NdbMT() override {}
 
    // Virtual functions
-   virtual Int_t Compare(const TObject *o) const
+   Int_t Compare(const TObject *o) const override
    { return ((iMT == ((NdbMT*)o)->iMT)? 0 :
              (iMT > ((NdbMT*)o)->iMT)? 1 : -1 ); }
 
@@ -51,7 +51,7 @@ public:
    virtual void ReadENDFSectionHeader() {}
    virtual void ReadENDFSection() {}
 
-   ClassDef(NdbMT,1)
+   ClassDefOverride(NdbMT,1)
 
 }; // NdbMT
 

--- a/test/periodic/NdbMTDir.h
+++ b/test/periodic/NdbMTDir.h
@@ -60,7 +60,7 @@ public:
       ENDATE   = NULL;
    }
 
-   ~NdbMTDir();
+   ~NdbMTDir() override;
 
    // --- Input/Output routines ---
    Bool_t      LoadENDF(const char *filename);
@@ -81,7 +81,7 @@ public:
    inline   char*   MasterEntryDate()   { return ENDATE; }
    inline   TString   GetInfo()      { return INFO; }
 
-   ClassDef(NdbMTDir,1)
+   ClassDefOverride(NdbMTDir,1)
 }; // NdbMTDir
 
 #endif

--- a/test/periodic/NdbMTReacDesc.h
+++ b/test/periodic/NdbMTReacDesc.h
@@ -27,7 +27,7 @@ public:
       comment = NULL;
    }
    NdbMTReacDesc(const char *filename);
-   ~NdbMTReacDesc();
+   ~NdbMTReacDesc() override;
 
    void   Init(const char *filename);
 
@@ -40,7 +40,7 @@ public:
    char*   GetDescription(Int_t MT);
    char*   GetComment(Int_t MT);
 
-   ClassDef(NdbMTReacDesc,1)
+   ClassDefOverride(NdbMTReacDesc,1)
 
 }; // NdbMTReacDesc
 

--- a/test/periodic/NdbMTReactionXS.h
+++ b/test/periodic/NdbMTReactionXS.h
@@ -46,7 +46,7 @@ public:
       NR = -1;
       minxs = maxxs = 0.0;
    }
-   ~NdbMTReactionXS() {}
+   ~NdbMTReactionXS() override {}
 
    // --- Access functions ---
    inline Float_t   Energy(int i)      { return ene[i]; }
@@ -71,7 +71,7 @@ public:
    inline Float_t   MinXS()         const   { return minxs; }
    inline Float_t   MaxXS()         const   { return maxxs; }
 
-   ClassDef(NdbMTReactionXS,1)
+   ClassDefOverride(NdbMTReactionXS,1)
 
 }; // NdbMTReactionXS
 

--- a/test/periodic/NdbMaterial.h
+++ b/test/periodic/NdbMaterial.h
@@ -77,10 +77,10 @@ public:
       eBoilingPoint   = elem.eBoilingPoint;
    }
 
-   ~NdbMaterial() {}
+   ~NdbMaterial() override {}
 
    // --- Virtual functions ---
-   Int_t Compare(const TObject *o) const
+   Int_t Compare(const TObject *o) const override
       { return ((eId==((NdbMaterial*)o)->eId)? 0 :
             (eId > ((NdbMaterial*)o)->eId)? 1 : -1 ); }
 
@@ -99,7 +99,7 @@ public:
    inline Float_t MeltingPoint()   const { return eMeltingPoint; }
    inline Float_t BoilingPoint()   const { return eBoilingPoint; }
 
-   ClassDef(NdbMaterial,1)
+   ClassDefOverride(NdbMaterial,1)
 
 }; // NdbMaterial
 

--- a/test/periodic/NdbParticle.h
+++ b/test/periodic/NdbParticle.h
@@ -53,7 +53,7 @@ public:
       pId = anId;
    }
 
-   ~NdbParticle() {}
+   ~NdbParticle() override {}
 
    // --- Access Functions ---
    inline TString Name()      const { return pName; }
@@ -63,7 +63,7 @@ public:
    inline Float_t HalfLife()   const { return pHalfLife; }
    inline Int_t   Charge()      const { return pCharge; }
 
-   ClassDef(NdbParticle,1)
+   ClassDefOverride(NdbParticle,1)
 
 }; // NdbParticle
 

--- a/test/periodic/NdbParticleList.h
+++ b/test/periodic/NdbParticleList.h
@@ -15,7 +15,7 @@ protected:
 
 public:
    NdbParticleList() : mult(), part() { }
-   ~NdbParticleList() {}
+   ~NdbParticleList() override {}
 
    // --- Access Functions ---
    Int_t   TotalCharge();      // Total charge
@@ -25,7 +25,7 @@ public:
 
    void   Add(NdbParticle *p, Int_t n=1);
 
-   ClassDef(NdbParticleList,1)
+   ClassDefOverride(NdbParticleList,1)
 
 }; // NdbParticleList
 

--- a/test/periodic/NdbPhotonAngleDist.h
+++ b/test/periodic/NdbPhotonAngleDist.h
@@ -12,9 +12,9 @@ public:
    NdbPhotonAngleDist()
       : NdbMF(14, "Angular distributions for photon production") {}
 
-   ~NdbPhotonAngleDist() {}
+   ~NdbPhotonAngleDist() override {}
 
-   ClassDef(NdbPhotonAngleDist,1)
+   ClassDefOverride(NdbPhotonAngleDist,1)
 }; // NdbPhotonAngleDist
 
 #endif

--- a/test/periodic/NdbPhotonEnergyDist.h
+++ b/test/periodic/NdbPhotonEnergyDist.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbPhotonEnergyDist()
       : NdbMF(15, "Energy distributions for photon production") {}
-   ~NdbPhotonEnergyDist() {}
+   ~NdbPhotonEnergyDist() override {}
 
-   ClassDef(NdbPhotonEnergyDist,1)
+   ClassDefOverride(NdbPhotonEnergyDist,1)
 }; // NdbPhotonEnergyDist
 
 #endif

--- a/test/periodic/NdbPhotonInteractionXS.h
+++ b/test/periodic/NdbPhotonInteractionXS.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbPhotonInteractionXS()
       : NdbMF(23, "Photo-atomic interaction cross sections") {}
-   ~NdbPhotonInteractionXS() {}
+   ~NdbPhotonInteractionXS() override {}
 
-   ClassDef(NdbPhotonInteractionXS,1)
+   ClassDefOverride(NdbPhotonInteractionXS,1)
 }; // NdbPhotonInteractionXS
 
 #endif

--- a/test/periodic/NdbPhotonMult.h
+++ b/test/periodic/NdbPhotonMult.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbPhotonMult()
       : NdbMF(12, "Multiplicities for photon production") {}
-   ~NdbPhotonMult() {}
+   ~NdbPhotonMult() override {}
 
-   ClassDef(NdbPhotonMult,1)
+   ClassDefOverride(NdbPhotonMult,1)
 }; // NdbPhotonMult
 
 #endif

--- a/test/periodic/NdbPhotonProdXS.h
+++ b/test/periodic/NdbPhotonProdXS.h
@@ -12,9 +12,9 @@ public:
    NdbPhotonProdXS()
       : NdbMF(13, "Cross sections for photon production") {}
 
-   ~NdbPhotonProdXS() {}
+   ~NdbPhotonProdXS() override {}
 
-   ClassDef(NdbPhotonProdXS,1)
+   ClassDefOverride(NdbPhotonProdXS,1)
 }; // NdbPhotonProdXS
 
 #endif

--- a/test/periodic/NdbRadioMult.h
+++ b/test/periodic/NdbRadioMult.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbRadioMult()
       : NdbMF(9, "Multiplicities for radioactive nuclide production") {}
-   ~NdbRadioMult() {}
+   ~NdbRadioMult() override {}
 
-   ClassDef(NdbRadioMult,1)
+   ClassDefOverride(NdbRadioMult,1)
 }; // NdbRadioMult
 
 #endif

--- a/test/periodic/NdbRadioXS.h
+++ b/test/periodic/NdbRadioXS.h
@@ -12,9 +12,9 @@ public:
    NdbRadioXS()
       : NdbMF(10, "Cross section for radioactive nuclide production") {}
 
-   ~NdbRadioXS() {}
+   ~NdbRadioXS() override {}
 
-   ClassDef(NdbRadioXS,1)
+   ClassDefOverride(NdbRadioXS,1)
 }; // NdbRadioXS
 
 #endif

--- a/test/periodic/NdbReaction.h
+++ b/test/periodic/NdbReaction.h
@@ -17,9 +17,9 @@ public:
    NdbReaction()
       : NdbMF(3, "Reaction cross sections"),
         reac() { }
-   ~NdbReaction() {}
+   ~NdbReaction() override {}
 
-   ClassDef(NdbReaction,1)
+   ClassDefOverride(NdbReaction,1)
 }; // NdbReaction
 
 #endif

--- a/test/periodic/NdbResParam.h
+++ b/test/periodic/NdbResParam.h
@@ -11,9 +11,9 @@ protected:
 public:
    NdbResParam()
       : NdbMF(2, "Resonance prameter data") {}
-   ~NdbResParam() {}
+   ~NdbResParam() override {}
 
-   ClassDef(NdbResParam,1)
+   ClassDefOverride(NdbResParam,1)
 }; // NdbResParam
 
 #endif

--- a/test/periodic/NdbThermalNeutron.h
+++ b/test/periodic/NdbThermalNeutron.h
@@ -12,9 +12,9 @@ public:
    NdbThermalNeutron()
       : NdbMF(7, "Thermal neutron scattering law data") {}
 
-   ~NdbThermalNeutron() {}
+   ~NdbThermalNeutron() override {}
 
-   ClassDef(NdbThermalNeutron,1)
+   ClassDefOverride(NdbThermalNeutron,1)
 }; // NdbThermalNeutron
 
 #endif

--- a/test/periodic/XSElementDlg.h
+++ b/test/periodic/XSElementDlg.h
@@ -39,14 +39,14 @@ private:
 public:
    XSElementDlg(const TGWindow *p, const TGWindow *main,
          UInt_t *retZ, UInt_t w=600, UInt_t h=350);
-   ~XSElementDlg();
+   ~XSElementDlg() override;
 
-   virtual void   CloseWindow();
+   void   CloseWindow() override;
    virtual Bool_t   ProcessButton(Longptr_t param);
-   virtual Bool_t   ProcessMessage(Longptr_t msg,
-            Longptr_t param1, Longptr_t param2);
+   Bool_t   ProcessMessage(Longptr_t msg,
+            Longptr_t param1, Longptr_t param2) override;
 
-   //ClassDef(XSElementDlg,1)
+   //ClassDefOverride(XSElementDlg,1)
 }; // XSElementDlg
 
 #endif

--- a/test/periodic/XSElementList.h
+++ b/test/periodic/XSElementList.h
@@ -22,19 +22,19 @@ protected:
 
 public:
    XSElementList(TGWindow *p, Int_t sortby = XSEL_SORTBY_NAME);
-   ~XSElementList();
+   ~XSElementList() override;
 
    void     SelectZ(UInt_t Z);
    UInt_t   CurrentZ();
 
 protected:
    Int_t  Compare(int i, int j) const;
-   Int_t  Compare(const TObject *o) const { return TObject::Compare(o); }
+   Int_t  Compare(const TObject *o) const override { return TObject::Compare(o); }
    UInt_t GetZ( TGTextLBEntry *entry );
    void   Sort(int *index);
    Int_t  ElementString(Int_t idx, char *buf);
 
-   //ClassDef(XSElementList,1)
+   //ClassDefOverride(XSElementList,1)
 }; // XSElementList
 
 #endif

--- a/test/periodic/XSElements.h
+++ b/test/periodic/XSElements.h
@@ -36,7 +36,7 @@ protected:
 
 public:
    XSElement();
-   ~XSElement();
+   ~XSElement() override;
 
    inline char*    Name()      const { return name; }
    inline char*   Mnemonic()   const { return symbol; }
@@ -54,10 +54,10 @@ public:
    inline Bool_t  IsStable(int i)   const { return isotope_stable[i]; }
 
    void   Read(FILE *f);
-   Int_t   Read(const char *name) { return TObject::Read(name); }
+   Int_t   Read(const char *name) override { return TObject::Read(name); }
 protected:
    char*   ReadLine(FILE *f);
-   //ClassDef(XSElement,1)
+   //ClassDefOverride(XSElement,1)
 }; // XSElement
 
 /* =================== XSElements ===================== */
@@ -69,7 +69,7 @@ protected:
 
 public:
    XSElements( const char *filename );
-   ~XSElements();
+   ~XSElements() override;
 
    inline UInt_t   GetSize()   const   { return NElements; }
 
@@ -85,7 +85,7 @@ public:
    // Search for element either by name or mnemonic
    UInt_t      Find(const char *str);
 
-   //ClassDef(XSElements,1)
+   //ClassDefOverride(XSElements,1)
 }; // XSElements
 
 #endif

--- a/test/periodic/XSGraph.h
+++ b/test/periodic/XSGraph.h
@@ -34,11 +34,11 @@ public:
    }
 
    XSGraph( NdbMTReactionXS *reac );
-   ~XSGraph();
+   ~XSGraph() override;
 
    inline TGraph*   GetGraph()   { return graph; }
 
-   //ClassDef(XSGraph,1)
+   //ClassDefOverride(XSGraph,1)
 }; // XSGraph
 
 #endif

--- a/test/periodic/XSGui.h
+++ b/test/periodic/XSGui.h
@@ -90,14 +90,14 @@ private:
 
 public:
    XSGui(const TGWindow *p, UInt_t w, UInt_t h);
-   virtual ~XSGui();
+   ~XSGui() override;
 
-   virtual void   CloseWindow();
-   virtual Bool_t   ProcessMessage(Longptr_t msg, Longptr_t param, Longptr_t);
+   void   CloseWindow() override;
+   Bool_t   ProcessMessage(Longptr_t msg, Longptr_t param, Longptr_t) override;
 
       Bool_t   ProcessMenuMessage( Longptr_t param );
 
-   //ClassDef(XSGui,1)
+   //ClassDefOverride(XSGui,1)
 }; // XSGui
 
 #endif

--- a/test/periodic/XSPeriodicTable.h
+++ b/test/periodic/XSPeriodicTable.h
@@ -25,17 +25,17 @@ private:
 
 public:
    XSTblElement( const TGWindow *p, Int_t z, UInt_t color);
-   ~XSTblElement();
-   virtual void      Layout();
-   virtual TGDimension   GetDefaultSize() const
+   ~XSTblElement() override;
+   void      Layout() override;
+   TGDimension   GetDefaultSize() const override
       { return TGDimension(20,20); }
 
-   virtual void   SetState(EButtonState state, Bool_t emit = kFALSE);
+   void   SetState(EButtonState state, Bool_t emit = kFALSE) override;
 
    Int_t      GetZ()   const { return Z; }
-   virtual void   ChangeBackground( ULong_t color );
+   void   ChangeBackground( ULong_t color ) override;
 
-   //ClassDef(XSTblElement,1)
+   //ClassDefOverride(XSTblElement,1)
 }; // XSTblElement
 
 //////////////////////////////////////////////////////////////
@@ -53,14 +53,14 @@ private:
 public:
    XSPeriodicTable(const TGWindow *msgWnd, const TGWindow* p,
          UInt_t w, UInt_t h);
-   virtual      ~XSPeriodicTable();
+        ~XSPeriodicTable() override;
 
    virtual   void      SelectZ( ULong_t Z );
-   virtual void      Layout();
-   virtual   TGDimension   GetDefaultSize() const
+   void      Layout() override;
+     TGDimension   GetDefaultSize() const override
             { return TGDimension(width,height); }
 
-   //ClassDef(XSPeriodicTable,1)
+   //ClassDefOverride(XSPeriodicTable,1)
 }; // XSPeriodicTable
 
 #endif

--- a/test/periodic/XSReactionDlg.h
+++ b/test/periodic/XSReactionDlg.h
@@ -135,7 +135,7 @@ protected:
 public:
    XSReactionDlg(const TGWindow *p,
            const TGWindow *main, UInt_t initZ, UInt_t w, UInt_t h);
-   ~XSReactionDlg();
+   ~XSReactionDlg() override;
 
 protected:
       void   InitColorCombo(TGComboBox *cb);
@@ -155,12 +155,12 @@ protected:
       void   UpdateGraph(NdbMTReactionXS *xs);
       Bool_t   ExecCommand();
 
-   virtual void   CloseWindow();
+   void   CloseWindow() override;
       Bool_t   ProcessButton(Longptr_t param1, Longptr_t param2);
       Bool_t   ProcessCombo(Longptr_t param1, Longptr_t param2);
-   virtual Bool_t   ProcessMessage(Longptr_t msg, Longptr_t param1, Longptr_t param2);
+   Bool_t   ProcessMessage(Longptr_t msg, Longptr_t param1, Longptr_t param2) override;
 
-   //ClassDef(XSReactionDlg,1)
+   //ClassDefOverride(XSReactionDlg,1)
 }; // XSReactionDlg
 
 #endif

--- a/test/periodic/XSStepButton.h
+++ b/test/periodic/XSStepButton.h
@@ -32,18 +32,18 @@ protected:
 
 public:
    XSStepButton( const TGWindow *p, Int_t id );
-   ~XSStepButton();
+   ~XSStepButton() override;
 
    virtual void   Associate(const TGWindow *w) { fMsgWindow = w; }
 
-   virtual Bool_t   ProcessMessage(Longptr_t msg,
-            Longptr_t param1, Longptr_t param2);
+   Bool_t   ProcessMessage(Longptr_t msg,
+            Longptr_t param1, Longptr_t param2) override;
 
-   virtual TGDimension   GetDefaultSize() const
+   TGDimension   GetDefaultSize() const override
          { return TGDimension(width,height); }
 
 
-   //ClassDef(XSStepButton,1)
+   //ClassDefOverride(XSStepButton,1)
 }; // XSStepButton
 
 #endif

--- a/test/rhtml/rhtml.h
+++ b/test/rhtml/rhtml.h
@@ -57,10 +57,10 @@ protected:
 public:
    TGHtmlBrowserTest(const char *filename = 0, const TGWindow *p = 0,
                  UInt_t w = 900, UInt_t h = 600);
-   virtual ~TGHtmlBrowserTest() { ; }
+   ~TGHtmlBrowserTest() override { ; }
 
-   virtual void      CloseWindow();
-   virtual Bool_t    ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t);
+   void      CloseWindow() override;
+   Bool_t    ProcessMessage(Longptr_t msg, Longptr_t parm1, Longptr_t) override;
    void              Selected(const char *txt);
    void              URLChanged();
    void              Back();
@@ -70,7 +70,7 @@ public:
    void              MouseOver(char *);
    void              MouseDown(char *);
 
-   ClassDef(TGHtmlBrowserTest, 0) // very simple html browser
+   ClassDefOverride(TGHtmlBrowserTest, 0) // very simple html browser
 };
 
 #endif

--- a/test/stressHistFactory_tests.cxx
+++ b/test/stressHistFactory_tests.cxx
@@ -48,7 +48,7 @@ public:
      fOldDirectory = gSystem->pwd();
   }
 
-  ~PdfComparison()
+  ~PdfComparison() override
   {
      // delete temporary directory if in not verbose mode
      if (_verb == 0) {
@@ -59,7 +59,7 @@ public:
      }
   }
 
-  Bool_t isTestAvailable()
+  Bool_t isTestAvailable() override
   {
      bool ret = true;
      ret &= CreateTestDirectory();
@@ -71,7 +71,7 @@ public:
      return ret;
   }
 
-  Bool_t testCode()
+  Bool_t testCode() override
   {
     // print information where the temporary test/log files are placed
     if(_verb > 0)

--- a/test/stressLinear.cxx
+++ b/test/stressLinear.cxx
@@ -431,7 +431,7 @@ void mstress_allocation(Int_t msize)
 
 class FillMatrix : public TElementPosActionD {
    Int_t no_elems,no_cols;
-   void Operation(Double_t &element) const
+   void Operation(Double_t &element) const override
       { element = 4*TMath::Pi()/no_elems * (fI*no_cols+fJ); }
 public:
    FillMatrix() {}
@@ -605,7 +605,7 @@ void mstress_matrix_fill(Int_t rsize,Int_t csize)
 typedef  Double_t (*dfunc)(Double_t);
 class ApplyFunction : public TElementActionD {
    dfunc fFunc;
-   void Operation(Double_t &element) const { element = fFunc(Double_t(element)); }
+   void Operation(Double_t &element) const override { element = fFunc(Double_t(element)); }
 public:
    ApplyFunction(dfunc func) : fFunc(func) { }
 };
@@ -921,7 +921,7 @@ void mstress_transposition(Int_t msize)
 //           Test special matrix creation
 //
 class MakeHilbert : public TElementPosActionD {
-  void Operation(Double_t &element) const { element = 1./(fI+fJ+1); }
+  void Operation(Double_t &element) const override { element = 1./(fI+fJ+1); }
 public:
   MakeHilbert() { }
 };
@@ -929,7 +929,7 @@ public:
 #if !defined (__CINT__) || defined (__MAKECINT__)
 class TestUnit : public TElementPosActionD {
   mutable Int_t fIsUnit;
-  void Operation(Double_t &element) const
+  void Operation(Double_t &element) const override
       { if (fIsUnit)
           fIsUnit = ((fI==fJ) ? (element == 1.0) : (element == 0)); }
 public:
@@ -1077,7 +1077,7 @@ void mstress_special_creation(Int_t dim)
 //           Test matrix promises
 //
 class hilbert_matrix_promise : public TMatrixDLazy {
-  void FillIn(TMatrixD &m) const { m = THilbertMatrixD(m.GetRowLwb(),m.GetRowUpb(),
+  void FillIn(TMatrixD &m) const override { m = THilbertMatrixD(m.GetRowLwb(),m.GetRowUpb(),
                                                    m.GetColLwb(),m.GetColUpb()); }
 
 public:
@@ -3252,14 +3252,14 @@ void vstress_allocation(Int_t msize)
 //                Test uniform element operations
 //
 class SinAction : public TElementActionD {
-  void Operation(Double_t &element) const { element = TMath::Sin(element); }
+  void Operation(Double_t &element) const override { element = TMath::Sin(element); }
   public:
     SinAction() { }
 };
 
 class CosAction : public TElementPosActionD {
   Double_t factor;
-  void Operation(Double_t &element) const { element = TMath::Cos(factor*fI); }
+  void Operation(Double_t &element) const override { element = TMath::Cos(factor*fI); }
   public:
     CosAction(Int_t no_elems): factor(2*TMath::Pi()/no_elems) { }
 };
@@ -3882,7 +3882,7 @@ Bool_t test_svd_expansion(const TMatrixD &A)
 class MakeMatrix : public TMatrixDLazy {
   const Double_t *array;
         Int_t     no_elems;
-  void FillIn(TMatrixD& m) const {
+  void FillIn(TMatrixD& m) const override {
     R__ASSERT( m.GetNrows() * m.GetNcols() == no_elems );
     const Double_t *ap = array;
           Double_t *mp = m.GetMatrixArray();

--- a/test/stressMathCore.cxx
+++ b/test/stressMathCore.cxx
@@ -201,10 +201,10 @@ public:
    }
 
 
-   unsigned int NPar() const { return NPAR; }
-   const double * Parameters() const { return fParams; }
-   ROOT::Math::IGenFunction * Clone() const { return new StatFunction(fPdf,fCdf,fQuant); }
-   void SetParameters(const double * p) { std::copy(p,p+NPAR,fParams); }
+   unsigned int NPar() const override { return NPAR; }
+   const double * Parameters() const override { return fParams; }
+   ROOT::Math::IGenFunction * Clone() const override { return new StatFunction(fPdf,fCdf,fQuant); }
+   void SetParameters(const double * p) override { std::copy(p,p+NPAR,fParams); }
    void SetParameters(double p0) { *fParams = p0; }
    void SetParameters(double p0, double p1) { *fParams = p0; *(fParams+1) = p1; }
    void SetParameters(double p0, double p1, double p2) { *fParams = p0; *(fParams+1) = p1; *(fParams+2) = p2; }
@@ -230,7 +230,7 @@ public:
 private:
 
 
-   double DoEvalPar(double x, const double * ) const {
+   double DoEvalPar(double x, const double * ) const override {
       // implement explicitly using cached parameter values
       return Evaluator<Func,NPAR>::F(fPdf,x, fParams);
    }

--- a/test/stressMathMore.cxx
+++ b/test/stressMathMore.cxx
@@ -120,7 +120,7 @@ struct Func {
 };
 struct Func3 : public Func {
    Func3(FreeFunc3 f) : fFunc(f) {};
-   double operator() (double x, double a, double b) const {
+   double operator() (double x, double a, double b) const override {
       return fFunc(x,a,b);
    }
    FreeFunc3 fFunc;
@@ -128,7 +128,7 @@ struct Func3 : public Func {
 
 struct Func4 : public Func {
    Func4(FreeFunc4 f) : fFunc(f) {};
-   double operator() (double x, double a, double b) const {
+   double operator() (double x, double a, double b) const override {
       return fFunc(x,a,b,0.);
    }
    FreeFunc4 fFunc;
@@ -162,11 +162,11 @@ public:
 
 
 
-   unsigned int NPar() const { return NPAR; }
-   const double * Parameters() const { return fParams; }
-   ROOT::Math::IGenFunction * Clone() const { return new StatFunction(*fPdf,*fCdf,*fQuant); }
+   unsigned int NPar() const override { return NPAR; }
+   const double * Parameters() const override { return fParams; }
+   ROOT::Math::IGenFunction * Clone() const override { return new StatFunction(*fPdf,*fCdf,*fQuant); }
 
-   void SetParameters(const double * p) { std::copy(p,p+NPAR,fParams); }
+   void SetParameters(const double * p) override { std::copy(p,p+NPAR,fParams); }
 
    void SetParameters(double p0, double p1) { *fParams = p0; *(fParams+1) = p1; }
 
@@ -208,7 +208,7 @@ public:
 
 private:
 
-   double DoEvalPar(double x, const double * ) const {
+   double DoEvalPar(double x, const double * ) const override {
       // use esplicity cached param values
       return (*fPdf)(x, *fParams, *(fParams+1));
    }

--- a/test/stressTMVA.cxx
+++ b/test/stressTMVA.cxx
@@ -449,7 +449,7 @@ class utDataSetInfo : public UnitTesting::UnitTest
 {
 public:
    utDataSetInfo();
-   void run();
+   void run() override;
 
 private:
    void testConstructor();
@@ -657,7 +657,7 @@ class utDataSet : public UnitTesting::UnitTest
 {
 public:
    utDataSet();
-   void run();
+   void run() override;
 
 private:
    void testMethods();
@@ -835,7 +835,7 @@ class utEvent : public UnitTesting::UnitTest
 {
 public:
    utEvent();
-   void run();
+   void run() override;
 
 private:
    // the test calls in different blocks
@@ -1208,9 +1208,9 @@ namespace UnitTesting
   {
   public:
     utReader(const char* theOption="");
-    virtual ~utReader();
+    ~utReader() override;
 
-    virtual void run();
+    void run() override;
 
   protected:
 
@@ -1322,9 +1322,9 @@ namespace UnitTesting
   {
   public:
     utReaderMT(const char* theOption="");
-    virtual ~utReaderMT();
+    ~utReaderMT() override;
 
-    virtual void run();
+    void run() override;
 
   protected:
 
@@ -1445,8 +1445,8 @@ namespace UnitTesting
    {
    public:
       utFactory(const char* theOption="");
-      virtual ~utFactory();
-      virtual void run();
+      ~utFactory() override;
+      void run() override;
 
    protected:
       virtual TTree* create_Tree(const char* opt="");
@@ -1729,7 +1729,7 @@ class utVariableInfo : public UnitTesting::UnitTest
 {
  public:
   utVariableInfo();
-  void run();
+  void run() override;
 
  private:
   // the test calls in different blocks
@@ -1929,9 +1929,9 @@ namespace UnitTesting
     MethodUnitTestWithROCLimits(const TMVA::Types::EMVA& theMethod, const TString& methodTitle, const TString& theOption,
                                 double lowLimit = 0., double upLimit = 1.,
                                 const std::string & name="", const std::string & filename="", std::ostream* osptr = &std::cout);
-    virtual ~MethodUnitTestWithROCLimits();
+    ~MethodUnitTestWithROCLimits() override;
 
-    virtual void run();
+    void run() override;
 
   protected:
     TTree*          theTree;
@@ -2367,9 +2367,9 @@ namespace UnitTesting
     RegressionUnitTestWithDeviation(const TMVA::Types::EMVA& theMethod, const TString& methodTitle, const TString& theOption,
                                     double lowFullLimit = 0., double upFullLimit = 10., double low90PercentLimit = 0., double up90PercentLimit = 0.,
                                     const std::string & name="", const std::string & filename="", std::ostream* osptr = &std::cout);
-    virtual ~RegressionUnitTestWithDeviation();
+    ~RegressionUnitTestWithDeviation() override;
 
-    virtual void run();
+    void run() override;
 
   protected:
     TTree*          theTree;
@@ -2618,9 +2618,9 @@ namespace UnitTesting
                                     const TMVA::Types::EMVA& theMethod, const TString& methodTitle, const TString& theOption,
                                     double lowLimit = 0., double upLimit = 1.,
                                     const std::string & name="", const std::string & filename="", std::ostream* osptr = &std::cout);
-      virtual ~MethodUnitTestWithComplexData();
+      ~MethodUnitTestWithComplexData() override;
 
-      virtual void run();
+      void run() override;
 
    protected:
       TTree*  theTree;
@@ -2859,7 +2859,7 @@ Unit test for TMVA::IPythonInteractive located in TMVA/MethodBase.h
 class utIPythonInteractive : public UnitTesting::UnitTest{
 public:
   utIPythonInteractive();
-  void run();
+  void run() override;
 private:
   void testInit();
   void testMethods();

--- a/test/tcollbm.cxx
+++ b/test/tcollbm.cxx
@@ -98,9 +98,9 @@ public:
   Double_t DoTest();         // Tests multiplexsor
 
   void        CleanUp()    { fColl->Delete(); }
-  void        Dump() const { fColl->Dump(); }
+  void        Dump() const override { fColl->Dump(); }
 
-  virtual const char* GetName() const
+  const char* GetName() const override
   { return fColl->ClassName(); }
 
   Tester() :
@@ -111,7 +111,7 @@ public:
       if(!strcmp(GetName(),"TObjArray"))    fWhat = Array;
       if(!strcmp(GetName(),"TBtree"))       fWhat = BTree;
   }
-  virtual ~Tester() { if(fColl) delete fColl; }
+  ~Tester() override { if(fColl) delete fColl; }
 };
 
 void Tester::Fill() {

--- a/test/tcollex.cxx
+++ b/test/tcollex.cxx
@@ -28,7 +28,7 @@ private:
 
 public:
    TObjNum(int i = 0) : num(i) { }
-   ~TObjNum() { Printf("~TObjNum = %d", num); }
+   ~TObjNum() override { Printf("~TObjNum = %d", num); }
    void    SetNum(int i) { num = i; }
    int     GetNum() { return num; }
    void    Print(Option_t *) const override { Printf("TObjNum = %d", num); }

--- a/test/vlazy.cxx
+++ b/test/vlazy.cxx
@@ -20,7 +20,7 @@ class do_downsample : public TElementPosActionF {
 private:
    const TMatrix &fOrigMatrix;
    const int row_lwb, col_lwb;
-   void Operation(Real_t &element) const
+   void Operation(Real_t &element) const override
        { element = fOrigMatrix((fI-row_lwb)*2+row_lwb,(fJ-col_lwb)*2+col_lwb); }
 public:
    do_downsample(const TMatrix &orig_matrix)
@@ -33,7 +33,7 @@ public:
 class downsample_matrix : public TMatrixFLazy {
 private:
    const TMatrix &fOrigMatrix;
-   void FillIn(TMatrixF &m) const;
+   void FillIn(TMatrixF &m) const override;
 public:
   downsample_matrix(const TMatrix &orig_matrix);
 };

--- a/test/vmatrix.cxx
+++ b/test/vmatrix.cxx
@@ -234,7 +234,7 @@ void stress_allocation()
 
 class FillMatrix : public TElementPosActionD {
    Int_t no_elems,no_cols;
-   void Operation(Double_t &element) const
+   void Operation(Double_t &element) const override
       { element = 4*TMath::Pi()/no_elems * (fI*no_cols+fJ); }
 public:
    FillMatrix() {}
@@ -383,7 +383,7 @@ void stress_matrix_fill(Int_t rsize,Int_t csize)
 typedef  double (*dfunc)(double);
 class ApplyFunction : public TElementActionD {
    dfunc fFunc;
-   void Operation(Double_t &element) const { element = fFunc(double(element)); }
+   void Operation(Double_t &element) const override { element = fFunc(double(element)); }
 public:
    ApplyFunction(dfunc func) : fFunc(func) { }
 };
@@ -699,7 +699,7 @@ void stress_transposition(Int_t msize)
 //           Test special matrix creation
 //
 class MakeHilbert : public TElementPosActionD {
-  void Operation(Double_t &element) const { element = 1./(fI+fJ+1); }
+  void Operation(Double_t &element) const override { element = 1./(fI+fJ+1); }
 public:
   MakeHilbert() { }
 };
@@ -707,7 +707,7 @@ public:
 #ifndef __CINT__
 class TestUnit : public TElementPosActionD {
   mutable Int_t fIsUnit;
-  void Operation(Double_t &element) const
+  void Operation(Double_t &element) const override
       { if (fIsUnit)
           fIsUnit = ((fI==fJ) ? (element == 1.0) : (element == 0)); }
 public:
@@ -854,7 +854,7 @@ void stress_special_creation(Int_t dim)
 //           Test matrix promises
 //
 class hilbert_matrix_promise : public TMatrixDLazy {
-  void FillIn(TMatrixD &m) const { m = THilbertMatrixD(m.GetRowLwb(),m.GetRowUpb(),
+  void FillIn(TMatrixD &m) const override { m = THilbertMatrixD(m.GetRowLwb(),m.GetRowUpb(),
                                                    m.GetColLwb(),m.GetColUpb()); }
 
 public:

--- a/test/vvector.cxx
+++ b/test/vvector.cxx
@@ -180,14 +180,14 @@ void stress_allocation()
 //                Test uniform element operations
 //
 class SinAction : public TElementActionD {
-  void Operation(Double_t &element) const { element = TMath::Sin(element); }
+  void Operation(Double_t &element) const override { element = TMath::Sin(element); }
   public:
     SinAction() { }
 };
 
 class CosAction : public TElementPosActionD {
   Double_t factor;
-  void Operation(Double_t &element) const { element = TMath::Cos(factor*fI); }
+  void Operation(Double_t &element) const override { element = TMath::Cos(factor*fI); }
   public:
     CosAction() { }
     CosAction(Int_t no_elems): factor(2*TMath::Pi()/no_elems) { }


### PR DESCRIPTION
This commit contains automatic changes done by `clang-tidy`.

This commit was generated more or less automatically with this Python
script that uses `clang-tidy`:

```Python
import os
import glob
import subprocess
import tqdm

"""
For clang-tidy to work, you have to copy the compile_commands.json from the
build directory back into the repo directory (just like in
.ci/copy_headers.sh).
"""

def get_sources(directory, extensions):

    files = []

    for ext in extensions:
        files += glob.glob(
            os.path.join(directory, "**/*" + ext), recursive=True
        )

    return files

"""
Recursively find extensions in directory, to figure out whic hextensions
should be globbed for.
   find . -type f -name '*.*' | sed 's|.*\.||' | sort -u
"""
extensions = [".h", ".hpp", ".hxx", ".cpp", ".cc", ".cxx"]

"""
Some extensions are recognized as C and not as C++ files by clang-tidy. We
need to rename them, and this dict specifies how file extensions should be
replaced.
"""
rename_dict = {".h": ".hpp"}

files = get_sources("test", extensions)

cflags = (
    subprocess.check_output(["root-config", "--cflags"]).strip().decode("utf-8")
)

for file in tqdm.tqdm(files):

    file_renamed = file
    for ext, ext_renamed in rename_dict.items():
        if file.endswith(ext):
            file_renamed = file.replace(ext, ext_renamed)

    if file_renamed != file:
        os.rename(file, file_renamed)

    cmd = [
        "clang-tidy",
        "-checks=modernize-use-override",
        "--fix",
        file_renamed,
        "--",
    ] + cflags.split(" ")
    subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

    if file_renamed != file:
        os.rename(file_renamed, file)

"""
Finally, replace the ClassDef with the ClassDefOverride macros.
  find test -type f -print | xargs sed -i 's/ClassDef(/ClassDefOverride(/'
...and change back the ClassDefOverride of non-overriding base classes.
"""
```