### PR TITLE
Improvements on resource restrictions for distributed tests

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -687,6 +687,9 @@ if(ROOT_pyroot_FOUND)
       list(APPEND ROOT_environ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES)
     endif()
   endif()
+  # These lists keep track of distrdf tutorials, so we can add specific properties later
+  file(GLOB distrdf_spark_tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} dataframe/*spark*)
+  file(GLOB distrdf_dask_tutorials RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} dataframe/*dask*)
 
   find_python_module(xgboost QUIET)
   if(NOT PY_XGBOOST_FOUND OR NOT dataframe)
@@ -808,5 +811,18 @@ if(ROOT_pyroot_FOUND)
       # However, even this poor indication of MT behaviour is a good hint for cmake to reduce congestion.
       set_tests_properties(${tutorial_name} PROPERTIES RESOURCE_LOCK multithreaded PROCESSORS 4)
     endif()
+
+    if(${t} IN_LIST distrdf_spark_tutorials)
+      # Create a resource lock for the creation of a Spark cluster. This is also used in roottest.
+      # Also signal 4 processors to cmake to give the tutorial some room (it uses 2 cores).
+      set_tests_properties(${tutorial_name} PROPERTIES RESOURCE_LOCK spark_resource_lock PROCESSORS 4)
+    endif()
+
+    if(${t} IN_LIST distrdf_dask_tutorials)
+      # Create a resource lock for the creation of a Dask cluster. This is also used in roottest.
+      # Also signal 4 processors to cmake to give the tutorial some room (it uses 2 cores).
+      set_tests_properties(${tutorial_name} PROPERTIES RESOURCE_LOCK dask_resource_lock PROCESSORS 4)
+    endif()
+
   endforeach()
 endif()

--- a/tutorials/dataframe/distrdf001_spark_connection.py
+++ b/tutorials/dataframe/distrdf001_spark_connection.py
@@ -27,8 +27,8 @@ RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
 #
 #     1. spark.app.name: The name of the Spark application
 #     2. spark.master: The Spark endpoint responsible for running the
-#         application. With the syntax "local[4]" we signal Spark we want to run
-#         locally on the same machine with 4 cores, each running a separate
+#         application. With the syntax "local[2]" we signal Spark we want to run
+#         locally on the same machine with 2 cores, each running a separate
 #         process. The default behaviour of a Spark application would run
 #         locally on the same machine with as many concurrent processes as
 #         available cores, that could be also written as "local[*]".
@@ -49,7 +49,8 @@ RDataFrame = ROOT.RDF.Experimental.Distributed.Spark.RDataFrame
 # Create a SparkConf object with all the desired Spark configuration parameters
 sparkconf = pyspark.SparkConf().setAll(
     {"spark.app.name": "distrdf001_spark_connection",
-     "spark.master": "local[4]", }.items())
+     "spark.master": "local[2]",
+     "spark.driver.memory": "4g"}.items())
 # Create a SparkContext with the configuration stored in `sparkconf`
 sparkcontext = pyspark.SparkContext(conf=sparkconf)
 

--- a/tutorials/dataframe/distrdf002_dask_connection.py
+++ b/tutorials/dataframe/distrdf002_dask_connection.py
@@ -73,10 +73,10 @@ def create_connection():
     ```
 
     In this tutorial, a cluster object is created for the local machine, using
-    multiprocessing (processes=True) on 4 workers (n_workers=4) each using only
-    1 core (threads_per_worker=1).
+    multiprocessing (processes=True) on 2 workers (n_workers=2) each using only
+    1 core (threads_per_worker=1) and 2GiB of RAM (memory_limit="2GiB").
     """
-    cluster = LocalCluster(n_workers=4, threads_per_worker=1, processes=True)
+    cluster = LocalCluster(n_workers=2, threads_per_worker=1, processes=True, memory_limit="2GiB")
     client = Client(cluster)
     return client
 


### PR DESCRIPTION
The distributed RDataFrame tutorials/tests have to create cluster objects, which take up resources on the machine. This is another step towards a clearer resource usage for both tutorials and tests. Whenever a cluster object is created, it now uses RESOURCE_LOCK test property to signal that no other cluster object should be created while the previous one is still running.

This PR addresses the tutorials in the root repository, a sibling PR will address the tests in roottest