### PR TITLE
TString sanity check nchar not larger than capacity

### DIFF
--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -263,6 +263,10 @@ char *TString::Init(Ssiz_t capacity, Ssiz_t nchar)
       Error("*TString::Init", "Negative length!");
       nchar = 0;
    }
+   if (nchar > capacity) {
+      Error("TString::Init", "capacity is smaller than nchar (%d > %d)", nchar, capacity);
+      nchar = capacity;
+   }
    if (capacity > MaxSize()) {
       Error("TString::Init", "capacity too large (%d, max = %d)", capacity, MaxSize());
       capacity = MaxSize();

--- a/core/base/src/TString.cxx
+++ b/core/base/src/TString.cxx
@@ -1031,7 +1031,7 @@ TString &TString::Replace(Ssiz_t pos, Ssiz_t n1, const char *cs, Ssiz_t n2)
    Ssiz_t capac = Capacity();
    char *p = GetPointer();
 
-   if (capac - len + n1 >= n2) {
+   if (capac >= tot) {
       if (n1 != n2) {
          if (rem) {
             if (n1 > n2) {


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

A potential memleak or sanity-check in TString found by clang-tidy
