### PR TITLE
Force storing of StreamerInfo for nested non-split but memberwise streamed collection.

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3181,6 +3181,24 @@ void TStreamerInfo::ForceWriteInfo(TFile* file, Bool_t force)
    ) {
       return;
    }
+
+   auto recurseIntoContent = [file, force](TClass *contentClass)
+   {
+      TVirtualStreamerInfo* si = 0;
+      if (contentClass->Property() & kIsAbstract) {
+         // If the class of the element is abstract, register the
+         // TStreamerInfo only if it has already been built.
+         // Otherwise call cl->GetStreamerInfo() would generate an
+         // incorrect StreamerInfo.
+         si = contentClass->GetCurrentStreamerInfo();
+      } else {
+         si = contentClass->GetStreamerInfo();
+      }
+      if (si) {
+         si->ForceWriteInfo(file, force);
+      }
+   };
+
    // We do not want to write streamer info to the file
    // for std::string.
    static TClassRef string_classref("string");
@@ -3197,6 +3215,9 @@ void TStreamerInfo::ForceWriteInfo(TFile* file, Bool_t force)
          return;
       }
    } else if (fClass->GetCollectionProxy()) { // We are an STL collection.
+      TClass *valueClass = fClass->GetCollectionProxy()->GetValueClass();
+      if (valueClass)
+         recurseIntoContent(valueClass);
       return;
    }
    // Mark ourselves for output, and block
@@ -3211,22 +3232,10 @@ void TStreamerInfo::ForceWriteInfo(TFile* file, Bool_t force)
    for (; element; element = (TStreamerElement*) next()) {
       if (element->IsTransient()) continue;
       TClass* cl = element->GetClassPointer();
-      if (cl) {
-         TVirtualStreamerInfo* si = 0;
-         if (cl->Property() & kIsAbstract) {
-            // If the class of the element is abstract, register the
-            // TStreamerInfo only if it has already been built.
-            // Otherwise call cl->GetStreamerInfo() would generate an
-            // incorrect StreamerInfo.
-            si = cl->GetCurrentStreamerInfo();
-         } else {
-            si = cl->GetStreamerInfo();
-         }
-         if (si) {
-            si->ForceWriteInfo(file, force);
-         }
-      }
+      if (cl)
+         recurseIntoContent(cl);
    }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fix #11436

Corresponding roottest PR: https://github.com/root-project/roottest/pull/906