### PR TITLE
Update minimum dask version found with cmake

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -2169,10 +2169,10 @@ if(test_distrdf_dask)
   message(STATUS "Looking for Dask")
 
   if(fail-on-missing)
-    find_package(Dask 2020.12 REQUIRED)
+    find_package(Dask 2022.02 REQUIRED)
   else()
 
-    find_package(Dask 2020.12)
+    find_package(Dask 2022.02)
     if(NOT Dask_FOUND)
       message(STATUS "Switching OFF 'test_distrdf_dask' option")
       set(test_distrdf_dask OFF CACHE BOOL "Disabled because Dask not found" FORCE)


### PR DESCRIPTION
The minimum dask version in requirements.txt was updated to 2022.02 by https://github.com/root-project/root/pull/11371. Also update it when looking for a dask installation in the cmake configuration.
