### PR TITLE
[RF] Re-implement multi-range fits

### DIFF
--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -99,7 +99,7 @@ protected:
 
 
   mutable RooObjCacheManager _projCacheMgr ;  ///<! Manager of cache with coefficient projections and transformations
-  AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
+  AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr) const ;
   void updateCoefficients(AddCacheElem& cache, const RooArgSet* nset) const ;
 
   typedef RooArgList* pRooArgList ;

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -105,7 +105,7 @@ protected:
 
 
   mutable RooObjCacheManager _projCacheMgr ;  //! Manager of cache with coefficient projections and transformations
-  AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr, const char* rangeName=nullptr) const ;
+  AddCacheElem* getProjCache(const RooArgSet* nset, const RooArgSet* iset=nullptr) const ;
   void updateCoefficients(AddCacheElem& cache, const RooArgSet* nset, bool syncCoefValues=true) const ;
 
 

--- a/roofit/roofitcore/inc/RooBinSamplingPdf.h
+++ b/roofit/roofitcore/inc/RooBinSamplingPdf.h
@@ -62,7 +62,7 @@ public:
   }
 
   /// Forwards to the PDF's implementation.
-  bool selfNormalized() const override { return _pdf->selfNormalized(); }
+  bool selfNormalized() const override { return true; }
 
   /// Forwards to the PDF's implementation.
   RooAbsReal* createIntegral(const RooArgSet& iset,

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -132,10 +132,9 @@ private:
 
 std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const char* rangeName);
 
-bool checkIfRangesOverlap(RooAbsPdf const& pdf,
+bool checkIfRangesOverlap(RooArgSet const& observables,
                           RooAbsData const& data,
-                          std::vector<std::string> const& rangeNames,
-                          bool splitRange);
+                          std::vector<std::string> const& rangeNames);
 
 std::string getColonSeparatedNameString(RooArgSet const& argSet);
 RooArgSet selectFromArgSet(RooArgSet const&, std::string const& names);

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -34,7 +34,7 @@ public:
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
-                std::string const &rangeName, bool doOffset);
+                bool doOffset);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 
@@ -68,7 +68,6 @@ private:
    std::string _prefix;
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;
-   std::unique_ptr<RooTemplateProxy<RooAbsReal>> _fractionInRange;
    mutable std::vector<double> _binw;                  ///<!
    mutable std::vector<double> _logProbasBuffer;       ///<!
    mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision

--- a/roofit/roofitcore/src/RooAbsData.cxx
+++ b/roofit/roofitcore/src/RooAbsData.cxx
@@ -498,13 +498,9 @@ RooAbsData* RooAbsData::reduce(const RooCmdArg& arg1,const RooCmdArg& arg2,const
     RooFormulaVar cutVarTmp(cutSpec,cutSpec,*get()) ;
     ret =  reduceEng(varSubset,&cutVarTmp,cutRange,nStart,nStop) ;
 
-  } else if (cutVar) {
-
-    ret = reduceEng(varSubset,cutVar,cutRange,nStart,nStop) ;
-
   } else {
 
-    ret = reduceEng(varSubset,0,cutRange,nStart,nStop) ;
+    ret = reduceEng(varSubset,cutVar,cutRange,nStart,nStop) ;
 
   }
 

--- a/roofit/roofitcore/src/RooAddGenContext.cxx
+++ b/roofit/roofitcore/src/RooAddGenContext.cxx
@@ -150,7 +150,7 @@ void RooAddGenContext::initGenerator(const RooArgSet &theEvent)
     _pcache = amod->getProjCache(_vars.get()) ;
   } else {
     RooAddPdf* apdf = (RooAddPdf*) _pdf ;
-    _pcache = apdf->getProjCache(_vars.get(),nullptr,"FULL_RANGE_ADDGENCONTEXT") ;
+    _pcache = apdf->getProjCache(_vars.get(),nullptr) ;
   }
 
   // Forward initGenerator call to all components

--- a/roofit/roofitcore/src/RooAddHelpers.cxx
+++ b/roofit/roofitcore/src/RooAddHelpers.cxx
@@ -206,6 +206,26 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
    }
 }
 
+void AddCacheElem::print() const
+{
+   auto printVector = [](auto const &vec, const char *name) {
+      std::cout << "+++ " << name << ":" << std::endl;
+      for (auto const &arg : vec) {
+         std::cout << "    ";
+         if (arg)
+            arg->Print();
+         else
+            std::cout << "nullptr" << std::endl;
+      }
+   };
+
+   printVector(_suppNormList, "_suppNormList");
+   printVector(_projList, "_projList");
+   printVector(_suppProjList, "_suppProjList");
+   printVector(_refRangeProjList, "_refRangeProjList");
+   printVector(_rangeProjList, "_rangeProjList");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// List all RooAbsArg derived contents in this cache element
 

--- a/roofit/roofitcore/src/RooAddHelpers.cxx
+++ b/roofit/roofitcore/src/RooAddHelpers.cxx
@@ -16,15 +16,20 @@
 #include <RooRealConstant.h>
 #include <RooRealIntegral.h>
 #include <RooRealVar.h>
+#include <RooRatio.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Create a RooAddPdf cache element for a given normalization set and
 /// projection configuration.
 
 AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList,
-                           const RooArgSet *nset, const RooArgSet *iset, const char *rangeName, bool projectCoefs,
-                           RooArgSet const &refCoefNorm, TNamed const *refCoefRangeName, int verboseEval)
+                           const RooArgSet *nset, const RooArgSet *iset, bool projectCoefs,
+                           RooArgSet const &refCoefNormSet, std::string const &refCoefNormRange, int verboseEval)
 {
+   // We put the normRange into a std::string to not have to deal with
+   // nullptr vs. "" ambiguities
+   const std::string normRange = addPdf.normRange() ? addPdf.normRange() : "";
+
    _suppNormList.reserve(pdfList.size());
 
    // *** PART 1 : Create supplemental normalization list ***
@@ -36,10 +41,14 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
       fullDepList.remove(*iset, true, true);
    }
 
+   bool hasPdfWithCustomRange = false;
+
    // Fill with dummy unit RRVs for now
    for (std::size_t i = 0; i < pdfList.size(); ++i) {
       auto pdf = static_cast<const RooAbsPdf *>(pdfList.at(i));
       auto coef = static_cast<const RooAbsReal *>(coefList.at(i));
+
+      hasPdfWithCustomRange |= pdf->normRange() != nullptr;
 
       // Start with full list of dependents
       RooArgSet supNSet(fullDepList);
@@ -63,6 +72,17 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
                                      << " making supplemental normalization set " << supNSet << " for pdf component "
                                      << pdf->GetName() << std::endl;
       }
+
+      if (!normRange.empty()) {
+         auto snormTerm = std::unique_ptr<RooAbsReal>(pdf->createIntegral(*nset, *nset, normRange.c_str()));
+         if (snorm) {
+            auto oldSnorm = std::move(snorm);
+            snorm = std::make_unique<RooProduct>("snorm", "snorm", *oldSnorm.get(), *snormTerm.get());
+            snorm->addOwnedComponents(std::move(snormTerm), std::move(oldSnorm));
+         } else {
+            snorm = std::move(snormTerm);
+         }
+      }
       _suppNormList.emplace_back(std::move(snorm));
    }
 
@@ -74,12 +94,8 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
 
    // *** PART 2 : Create projection coefficients ***
 
-   //   cout << " this = " << this << " (" << GetName() << ")" << std::endl ;
-   //   cout << "projectCoefs = " << (_projectCoefs?"T":"F") << std::endl ;
-   //   cout << "_normRange.Length() = " << _normRange.Length() << std::endl ;
-
    // If no projections required stop here
-   if (!projectCoefs && !rangeName) {
+   if (!projectCoefs && !hasPdfWithCustomRange) {
       //     cout << " no projection required" << std::endl ;
       return;
    }
@@ -94,36 +110,26 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
                                << ")::getPC nset = " << (nset ? *nset : RooArgSet()) << " nset2 = " << nset2
                                << std::endl;
 
-   if (nset2.empty() && !refCoefNorm.empty()) {
+   if (nset2.empty() && !refCoefNormSet.empty()) {
       // cout << "WVE: evaluating RooAddPdf without normalization, but have reference normalization for coefficient
       // definition" << std::endl ;
 
-      nset2.add(refCoefNorm);
-      if (refCoefRangeName) {
-         rangeName = RooNameReg::str(refCoefRangeName);
-      }
+      nset2.add(refCoefNormSet);
    }
 
-   // Check if requested transformation is not identity
-   if (!nset2.equals(refCoefNorm) || refCoefRangeName != 0 || rangeName != 0 || addPdf.normRange()) {
-
-      oocxcoutD(&addPdf, Caching) << "ALEX:     " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
-                                  << ") projecting coefficients from " << nset2 << (rangeName ? ":" : "")
-                                  << (rangeName ? rangeName : "") << " to "
-                                  << ((!refCoefNorm.empty()) ? refCoefNorm : nset2) << (refCoefRangeName ? ":" : "")
-                                  << (refCoefRangeName ? RooNameReg::str(refCoefRangeName) : "") << std::endl;
+   if (!nset2.equals(refCoefNormSet) || !refCoefNormRange.empty() || !normRange.empty() || hasPdfWithCustomRange) {
 
       // Recalculate projection integrals of PDFs
       for (auto *pdf : static_range_cast<const RooAbsPdf *>(pdfList)) {
 
          // Calculate projection integral
          std::unique_ptr<RooAbsReal> pdfProj;
-         if (!nset2.equals(refCoefNorm)) {
-            pdfProj = std::unique_ptr<RooAbsReal>{pdf->createIntegral(nset2, refCoefNorm, addPdf.normRange())};
+         if (!refCoefNormSet.empty() && !nset2.equals(refCoefNormSet)) {
+            pdfProj = std::unique_ptr<RooAbsReal>{pdf->createIntegral(nset2, refCoefNormSet, normRange.c_str())};
             pdfProj->setOperMode(addPdf.operMode());
             oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "(" << addPdf.GetName() << ")::getPC nset2(" << nset2
-                                        << ")!=_refCoefNorm(" << refCoefNorm << ") --> pdfProj = " << pdfProj->GetName()
-                                        << std::endl;
+                                        << ")!=_refCoefNormSet(" << refCoefNormSet
+                                        << ") --> pdfProj = " << pdfProj->GetName() << std::endl;
             oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
                                         << ") PP = " << pdfProj->GetName() << std::endl;
          }
@@ -131,13 +137,13 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
          _projList.emplace_back(std::move(pdfProj));
 
          // Calculation optional supplemental normalization term
-         RooArgSet supNormSet(refCoefNorm);
+         RooArgSet supNormSet(refCoefNormSet);
          auto deps = std::unique_ptr<RooArgSet>{pdf->getParameters(RooArgSet())};
          supNormSet.remove(*deps, true, true);
 
          std::unique_ptr<RooAbsReal> snorm;
          auto name = std::string(addPdf.GetName()) + "_" + pdf->GetName() + "_ProjSupNorm";
-         if (!supNormSet.empty() && !nset2.equals(refCoefNorm)) {
+         if (!supNormSet.empty() && !nset2.equals(refCoefNormSet)) {
             snorm = std::make_unique<RooRealIntegral>(name.c_str(), "Projection Supplemental normalization integral",
                                                       RooRealConstant::value(1.0), supNormSet);
             oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
@@ -145,62 +151,17 @@ AddCacheElem::AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, R
          }
          _suppProjList.emplace_back(std::move(snorm));
 
-         // Calculate reference range adjusted projection integral
-         std::unique_ptr<RooAbsReal> rangeProj1;
-
-         //    cout << "ALEX >>>> RooAddPdf(" << GetName() << ")::getPC refCoefRangeName WVE = "
-         //       <<(refCoefRangeName?":":"") << (refCoefRangeName?RooNameReg::str(refCoefRangeName):"")
-         //       <<" refCoefRangeName AK = "  << (refCoefRangeName?refCoefRangeName->GetName():"")
-         //       << " && _refCoefNorm" << _refCoefNorm << " with size = _refCoefNorm.size() " << _refCoefNorm.size() <<
-         //       std::endl ;
-
-         // Check if refCoefRangeName is identical to default range for all observables,
-         // If so, substitute by unit integral
-
-         // ----------
-         RooArgSet tmpObs;
-         pdf->getObservables(&refCoefNorm, tmpObs);
-         bool allIdent = true;
-         for (auto *rvarg : dynamic_range_cast<RooRealVar *>(tmpObs)) {
-            if (rvarg) {
-               if (rvarg->getMin(RooNameReg::str(refCoefRangeName)) != rvarg->getMin() ||
-                   rvarg->getMax(RooNameReg::str(refCoefRangeName)) != rvarg->getMax()) {
-                  allIdent = false;
-               }
-            }
-         }
-         // -------------
-
-         if (refCoefRangeName && !refCoefNorm.empty() && !allIdent) {
-
-            RooArgSet tmp;
-            pdf->getObservables(&refCoefNorm, tmp);
-            rangeProj1 = std::unique_ptr<RooAbsReal>{pdf->createIntegral(tmp, tmp, RooNameReg::str(refCoefRangeName))};
-
-            // rangeProj1->setOperMode(operMode()) ;
-            oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
-                                        << ") R1 = " << rangeProj1->GetName() << std::endl;
-         }
-         _refRangeProjList.emplace_back(std::move(rangeProj1));
-
          // Calculate range adjusted projection integral
          std::unique_ptr<RooAbsReal> rangeProj2;
-         oocxcoutD(&addPdf, Caching) << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
-                                     << ") rangename = " << (rangeName ? rangeName : "<null>")
-                                     << " nset = " << (nset ? *nset : RooArgSet()) << std::endl;
-         if (rangeName && !refCoefNorm.empty()) {
-
-            rangeProj2 = std::unique_ptr<RooAbsReal>{pdf->createIntegral(refCoefNorm, refCoefNorm, rangeName)};
-            // rangeProj2->setOperMode(operMode()) ;
-
-         } else if (addPdf.normRange()) {
-
+         if (normRange != refCoefNormRange) {
             RooArgSet tmp;
-            pdf->getObservables(&refCoefNorm, tmp);
-            rangeProj2 = std::unique_ptr<RooAbsReal>{pdf->createIntegral(tmp, tmp, addPdf.normRange())};
-            oocxcoutD(&addPdf, Caching) << " " << addPdf.ClassName() << "::syncCoefProjList(" << addPdf.GetName()
-                                        << ") R2 = " << rangeProj2->GetName() << std::endl;
+            pdf->getObservables(refCoefNormSet.empty() ? nset : &refCoefNormSet, tmp);
+            auto int1 = std::unique_ptr<RooAbsReal>{pdf->createIntegral(tmp, tmp, normRange.c_str())};
+            auto int2 = std::unique_ptr<RooAbsReal>{pdf->createIntegral(tmp, tmp, refCoefNormRange.c_str())};
+            rangeProj2 = std::make_unique<RooRatio>("rangeProj", "rangeProj", *int1, *int2);
+            rangeProj2->addOwnedComponents(std::move(int1), std::move(int2));
          }
+
          _rangeProjList.emplace_back(std::move(rangeProj2));
       }
    }
@@ -222,7 +183,6 @@ void AddCacheElem::print() const
    printVector(_suppNormList, "_suppNormList");
    printVector(_projList, "_projList");
    printVector(_suppProjList, "_suppProjList");
-   printVector(_refRangeProjList, "_refRangeProjList");
    printVector(_rangeProjList, "_rangeProjList");
 }
 
@@ -238,10 +198,6 @@ RooArgList AddCacheElem::containedArgs(Action)
          allNodes.add(*arg);
    }
    for (auto const &arg : _suppProjList) {
-      if (arg)
-         allNodes.add(*arg);
-   }
-   for (auto const &arg : _refRangeProjList) {
       if (arg)
          allNodes.add(*arg);
    }
@@ -264,7 +220,7 @@ RooArgList AddCacheElem::containedArgs(Action)
 
 void RooAddHelpers::updateCoefficients(RooAbsPdf const &addPdf, std::vector<double> &coefCache,
                                        RooArgList const &pdfList, bool haveLastCoef, AddCacheElem &cache,
-                                       const RooArgSet *nset, bool projectCoefs, RooArgSet const &refCoefNorm,
+                                       const RooArgSet *nset, bool projectCoefs, RooArgSet const &refCoefNormSet,
                                        bool allExtendable, int &coefErrCount)
 {
    // Straight coefficients
@@ -275,7 +231,7 @@ void RooAddHelpers::updateCoefficients(RooAbsPdf const &addPdf, std::vector<doub
       std::size_t i = 0;
       for (auto arg : pdfList) {
          auto pdf = static_cast<RooAbsPdf *>(arg);
-         coefCache[i] = pdf->expectedEvents(!refCoefNorm.empty() ? &refCoefNorm : nset);
+         coefCache[i] = pdf->expectedEvents(!refCoefNormSet.empty() ? &refCoefNormSet : nset);
          coefSum += coefCache[i];
          i++;
       }

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -21,8 +21,8 @@ class RooArgSet;
 class AddCacheElem : public RooAbsCacheElement {
 public:
    AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList, const RooArgSet *nset,
-                const RooArgSet *iset, const char *rangeName, bool projectCoefs, RooArgSet const &refCoefNorm,
-                TNamed const *refCoefRangeName, int verboseEval);
+                const RooArgSet *iset, bool projectCoefs, RooArgSet const &refCoefNormSet,
+                std::string const &refCoefNormRange, int verboseEval);
 
    RooArgList containedArgs(Action) override;
 
@@ -37,35 +37,27 @@ public:
       return _suppProjList[idx] ? _suppProjList[idx]->getVal() : 1.0;
    }
 
-   inline double rangeProjScaleFactor(std::size_t idx) const { return rangeProjVal(idx) / refRangeProjVal(idx); }
-
-   void print() const;
-
-private:
-   inline double refRangeProjVal(std::size_t idx) const
-   {
-      return _refRangeProjList[idx] ? _refRangeProjList[idx]->getVal() : 1.0;
-   }
-
-   inline double rangeProjVal(std::size_t idx) const
+   inline double rangeProjScaleFactor(std::size_t idx) const
    {
       return _rangeProjList[idx] ? _rangeProjList[idx]->getVal() : 1.0;
    }
 
+   void print() const;
+
+private:
    using OwningArgVector = std::vector<std::unique_ptr<RooAbsReal>>;
 
    OwningArgVector _suppNormList; ///< Supplemental normalization list
    OwningArgVector _projList;     ///< Projection integrals to be multiplied with coefficients
    OwningArgVector _suppProjList; ///< Projection integrals to multiply with coefficients for supplemental normalization
-   OwningArgVector _refRangeProjList; ///< Range integrals to be multiplied with coefficients (reference range)
-   OwningArgVector _rangeProjList;    ///< Range integrals to be multiplied with coefficients (target range)
+   OwningArgVector _rangeProjList; ///< Range integrals to be multiplied with coefficients (reference to target range)
 };
 
 class RooAddHelpers {
 public:
    static void updateCoefficients(RooAbsPdf const &addPdf, std::vector<double> &coefCache, RooArgList const &pdfList,
                                   bool haveLastCoef, AddCacheElem &cache, const RooArgSet *nset, bool projectCoefs,
-                                  RooArgSet const &refCoefNorm, bool allExtendable, int &coefErrCount);
+                                  RooArgSet const &refCoefNormSet, bool allExtendable, int &coefErrCount);
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -39,6 +39,8 @@ public:
 
    inline double rangeProjScaleFactor(std::size_t idx) const { return rangeProjVal(idx) / refRangeProjVal(idx); }
 
+   void print() const;
+
 private:
    inline double refRangeProjVal(std::size_t idx) const
    {

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -311,19 +311,21 @@ Int_t RooAddModel::basisCode(const char* name) const
 /// integrals to calculated transformed fraction coefficients when a frozen reference frame is provided
 /// and projection integrals for similar transformations when a frozen reference range is provided.
 
-AddCacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* iset, const char* rangeName) const
+AddCacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* iset) const
 {
   // Check if cache already exists
-  auto cache = static_cast<AddCacheElem*>(_projCacheMgr.getObj(nset,iset,0,rangeName));
+  auto cache = static_cast<AddCacheElem*>(_projCacheMgr.getObj(nset,iset,0,normRange()));
   if (cache) {
     return cache ;
   }
 
   //Create new cache
-  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset, rangeName,
-                        _projectCoefs, _refCoefNorm, _refCoefRangeName, _verboseEval};
+  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset,
+                           _projectCoefs, _refCoefNorm,
+                           _refCoefRangeName ? RooNameReg::str(_refCoefRangeName) : "",
+                           _verboseEval};
 
-  _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(rangeName)) ;
+  _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(normRange())) ;
 
   return cache;
 }

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -356,19 +356,21 @@ void RooAddPdf::fixCoefRange(const char* rangeName)
 /// - Projection integrals to calculate transformed fraction coefficients when a frozen reference frame is provided
 /// - Projection integrals for similar transformations when a frozen reference range is provided.
 
-AddCacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* iset, const char* rangeName) const
+AddCacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* iset) const
 {
   // Check if cache already exists
-  auto cache = static_cast<AddCacheElem*>(_projCacheMgr.getObj(nset,iset,0,rangeName));
+  auto cache = static_cast<AddCacheElem*>(_projCacheMgr.getObj(nset,iset,0,normRange()));
   if (cache) {
     return cache ;
   }
 
   //Create new cache
-  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset, rangeName,
-                        _projectCoefs, _refCoefNorm, _refCoefRangeName, _verboseEval};
+  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset,
+                           _projectCoefs, _refCoefNorm,
+                           _refCoefRangeName ? RooNameReg::str(_refCoefRangeName) : "",
+                           _verboseEval};
 
-  _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(rangeName)) ;
+  _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(normRange())) ;
 
   return cache;
 }
@@ -476,7 +478,7 @@ double RooAddPdf::getValV(const RooArgSet* normSet) const
     _value = 0.0;
 
     for (unsigned int i=0; i < _pdfList.size(); ++i) {
-      const auto& pdf = static_cast<RooAbsPdf&>(_pdfList[i]);
+      auto& pdf = static_cast<RooAbsPdf&>(_pdfList[i]);
       double snormVal = 1.;
       snormVal = cache->suppNormVal(i);
 
@@ -658,7 +660,7 @@ double RooAddPdf::analyticalIntegralWN(Int_t code, const RooArgSet* normSet, con
     normSet = &_refCoefNorm ;
   }
 
-  AddCacheElem* cache = getProjCache(normSet,intSet,0) ; // WVE rangename here?
+  AddCacheElem* cache = getProjCache(normSet,intSet);
   updateCoefficients(*cache,normSet);
 
   // Calculate the current value of this object

--- a/roofit/roofitcore/src/RooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/src/RooBinSamplingPdf.cxx
@@ -294,7 +294,7 @@ std::unique_ptr<ROOT::Math::IntegratorOneDim>& RooBinSamplingPdf::integrator() c
 /// Binding used by the integrator to evaluate the PDF.
 double RooBinSamplingPdf::operator()(double x) const {
   _observable->setVal(x);
-  return _pdf->getVal();
+  return _pdf;
 }
 
 

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -181,41 +181,13 @@ std::pair<double, double> getRangeOrBinningInterval(RooAbsArg const* arg, const 
 
 
 /// Check if there is any overlap when a list of ranges is applied to a set of observables.
-/// \param[in] pdf the PDF
+/// \param[in] observables The observables to check for overlap
 /// \param[in] data RooAbsCollection with the observables to check for overlap.
 /// \param[in] rangeNames The names of the ranges.
-/// \param[in] splitRange If `true`, each component of a RooSimultaneous will
-///                       be checked individually for overlaps, with the range
-///                       names in that component suffixed by `_<cat_label>`.
-///                       See the `SplitRange()` command argument of
-///                       RooAbsPdf::fitTo()` to understand where this is used.
-bool checkIfRangesOverlap(RooAbsPdf const& pdf,
+bool checkIfRangesOverlap(RooArgSet const& observables,
                           RooAbsData const& data,
-                          std::vector<std::string> const& rangeNames,
-                          bool splitRange)
+                          std::vector<std::string> const& rangeNames)
 {
-  // If the PDF is a RooSimultaneous and the `splitRange` option is set, we
-  // have to check each component PDF with a different set of rangeNames, each
-  // suffixed by the category name.
-  if(splitRange && dynamic_cast<RooSimultaneous const*>(&pdf)) {
-    auto const& simPdf = static_cast<RooSimultaneous const&>(pdf);
-    bool hasOverlap = false;
-    std::vector<std::string> rangeNamesSplit;
-    for (const auto& catState : simPdf.indexCat()) {
-      const std::string& catName = catState.first;
-      for(std::string const& rangeName : rangeNames) {
-        rangeNamesSplit.emplace_back(rangeName + "_" + catName);
-      }
-      hasOverlap |= checkIfRangesOverlap(*simPdf.getPdf(catName.c_str()), data, rangeNamesSplit, false);
-
-      rangeNamesSplit.clear();
-    }
-
-    return hasOverlap;
-  }
-
-  auto observables = *pdf.getObservables(data);
-
   auto getLimits = [&](RooAbsRealLValue const& rlv, const char* rangeName) {
 
     // RooDataHistCase

--- a/roofit/roofitcore/src/RooNormalizedPdf.h
+++ b/roofit/roofitcore/src/RooNormalizedPdf.h
@@ -21,7 +21,7 @@ public:
    RooNormalizedPdf(RooAbsPdf &pdf, RooArgSet const &normSet)
       : _pdf("numerator", "numerator", this, pdf),
         _normIntegral("denominator", "denominator", this,
-                      *pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), nullptr), true, false, true),
+                      *pdf.createIntegral(normSet, *pdf.getIntegratorConfig(), pdf.normRange()), true, false, true),
         _normSet{normSet}
    {
       auto name = std::string(pdf.GetName()) + "_over_" + _normIntegral->GetName();
@@ -59,7 +59,7 @@ public:
    }
 
 protected:
-   void computeBatch(cudaStream_t *, double *output, size_t size, RooFit::Detail::DataMap const&) const override;
+   void computeBatch(cudaStream_t *, double *output, size_t size, RooFit::Detail::DataMap const &) const override;
    double evaluate() const override
    {
       // Evaluate() should not be called in the BatchMode, but we still need it

--- a/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
+++ b/roofit/roofitcore/test/testRooBinSamplingPdf.cxx
@@ -95,7 +95,6 @@ TEST(RooBinSamplingPdf, CheckConsistentNormalization)
    // An integral over the normalization set normalized by an integral over the
    // normalization set should be unity by definition.
    std::unique_ptr<RooAbsReal> int1{binSamplingPdf.createIntegral(normSet, &normSet)};
-   std::cout << int1->getVal() << std::endl;
    EXPECT_FLOAT_EQ(int1->getVal(), 1.0);
 
    // Evaluating the pdf with a given normalization set should not unexpectedly
@@ -103,7 +102,5 @@ TEST(RooBinSamplingPdf, CheckConsistentNormalization)
    std::unique_ptr<RooAbsReal> int2{binSamplingPdf.createIntegral(normSet)};
    binSamplingPdf.getVal(normSet);
    std::unique_ptr<RooAbsReal> int3{binSamplingPdf.createIntegral(normSet)};
-   std::cout << int2->getVal() << std::endl;
-   std::cout << int3->getVal() << std::endl;
    EXPECT_FLOAT_EQ(int2->getVal(), int3->getVal());
 }

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -1,6 +1,7 @@
 // Tests for the RooSimultaneous
 // Authors: Jonas Rembser, CERN  06/2021
 
+#include <RooAddition.h>
 #include <RooAddPdf.h>
 #include <RooConstVar.h>
 #include <RooCategory.h>
@@ -140,7 +141,7 @@ TEST(RooSimultaneous, MultiRangeFitWithSplitRange)
    int nEventsInCat = 11000;
 
    RooWorkspace wsCat1{"wsCat1"};
-   wsCat1.factory("Gaussian::pdf_cat1(x_cat1[0,10],muCat1[4,0,10],sigma_cat1[1.0,0.1,10.0])");
+   wsCat1.factory("Gaussian::pdf_cat1(x_cat1[0,10],mu_cat1[4,0,10],sigma_cat1[1.0,0.1,10.0])");
    RooAbsPdf &pdfCat1 = *wsCat1.pdf("pdf_cat1");
    RooRealVar &xCat1 = *wsCat1.var("x_cat1");
    xCat1.setRange("SideBandLo_cat1", 0, 2);
@@ -148,12 +149,12 @@ TEST(RooSimultaneous, MultiRangeFitWithSplitRange)
    std::unique_ptr<RooDataSet> dsCat1{pdfCat1.generate(xCat1, nEventsInCat)};
 
    RooWorkspace wsCat2{"wsCat2"};
-   wsCat2.factory("Gaussian::pdf_cat2(x_cat2[0,10],muCat2[6,0,10],sigma_cat2[1.0,0.1,10.0])");
+   wsCat2.factory("Gaussian::pdf_cat2(x_cat2[0,10],mu_cat2[6,0,10],sigma_cat2[1.0,0.1,10.0])");
    RooAbsPdf &pdfCat2 = *wsCat2.pdf("pdf_cat2");
    RooRealVar &xCat2 = *wsCat2.var("x_cat2");
    xCat2.setRange("SideBandLo_cat2", 0, 4);
    xCat2.setRange("SideBandHi_cat2", 8, 10);
-   std::unique_ptr<RooDataSet> dsCat2{pdfCat1.generate(xCat2, nEventsInCat)};
+   std::unique_ptr<RooDataSet> dsCat2{pdfCat2.generate(xCat2, nEventsInCat)};
 
    RooCategory indexCat{"cat", "cat"};
    indexCat.defineType("cat1");
@@ -167,33 +168,24 @@ TEST(RooSimultaneous, MultiRangeFitWithSplitRange)
 
    RooDataSet combData{"combData", "", {xCat1, xCat2}, Index(indexCat), Import(dsmap)};
 
-   std::unique_ptr<RooAbsReal> nll1{pdfCat1.createNLL(*dsCat1, Range("SideBandLo_cat1,SideBandHi_cat1"))};
-   std::unique_ptr<RooAbsReal> nll2{pdfCat2.createNLL(*dsCat2, Range("SideBandLo_cat2,SideBandHi_cat2"))};
+   const char *cutRange1 = "SideBandLo_cat1,SideBandHi_cat1";
+   const char *cutRange2 = "SideBandLo_cat2,SideBandHi_cat2";
    std::unique_ptr<RooAbsReal> nllSim{simPdf.createNLL(combData, Range("SideBandLo,SideBandHi"), SplitRange())};
 
-   // For now, we can't cross check the likelihood value and the unit test
-   // only checks whether the simultaneous likelihood can be created with the
-   // SplitRange() argument without the range overlap checks failing. Once the
-   // issue with multi-range simultaneous likelihood values is fixed, the rest
-   // of the test can be commented out:
-
-   //const double nll1Val = nll1->getVal();
-   //const double nll2Val = nll2->getVal();
    // In simultaneous PDFs, the probability is normalized over the categories,
    // so we have to do that as well when computing the reference value. Since
    // we do a ranged fit, we have to consider the ranges when calculating the
    // number of events in data.
-   //double nCat1InRange = std::unique_ptr<RooAbsData>
-   //{
-      //dsCat1->reduce(CutRange("SideBandLo_cat1,SideBandHi_cat1"))
-      //} -> sumEntries();
-   //double nCat2InRange = std::unique_ptr<RooAbsData>
-   //{
-      //dsCat2->reduce(CutRange("SideBandLo_cat2,SideBandHi_cat2"))
-      //} -> sumEntries();
-   //const double nllSimRefVal = (nCat1InRange + nCat2InRange) * std::log(2) + nll1Val + nll2Val;
+   double n1 = std::unique_ptr<RooAbsData>(dsCat1->reduce(CutRange(cutRange1)))->sumEntries();
+   double n2 = std::unique_ptr<RooAbsData>(dsCat2->reduce(CutRange(cutRange2)))->sumEntries();
+   const double normTerm = (n1 + n2) * std::log(2);
 
-   //const double nllSimVal = nllSim->getVal();
+   std::unique_ptr<RooAbsReal> nll1{pdfCat1.createNLL(*dsCat1, Range(cutRange1))};
+   std::unique_ptr<RooAbsReal> nll2{pdfCat2.createNLL(*dsCat2, Range(cutRange2))};
+   RooAddition nllSimRef{"nllSimRef", "nllSimRef", {*nll1, *nll2, RooConst(normTerm)}};
 
-   //EXPECT_FLOAT_EQ(nllSimVal, nllSimRefVal);
+   const double nllSimRefVal = nllSimRef.getVal();
+   const double nllSimVal = nllSim->getVal();
+
+   EXPECT_FLOAT_EQ(nllSimVal, nllSimRefVal);
 }

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -18,6 +18,8 @@
 
 #include <memory>
 
+const bool batchMode = true;
+
 TEST(RooNLLVar, IntegrateBins) {
   RooRandom::randomGenerator()->SetSeed(1337ul);
 
@@ -48,7 +50,7 @@ TEST(RooNLLVar, IntegrateBins) {
 
   a.setVal(3.);
   std::unique_ptr<RooFitResult> fit2( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(true),
+      RooFit::BatchMode(batchMode),
       RooFit::IntegrateBins(1.E-3)) );
   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
@@ -107,14 +109,14 @@ TEST(RooNLLVar, IntegrateBins_SubRange) {
   std::unique_ptr<RooFitResult> fit1( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
       RooFit::Optimize(0),
       RooFit::Range("range"),
-      RooFit::BatchMode(true))  );
+      RooFit::BatchMode(batchMode))  );
   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
 
   a.setVal(3.);
   std::unique_ptr<RooFitResult> fit2( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
       RooFit::Optimize(0),
       RooFit::Range("range"),
-      RooFit::BatchMode(true),
+      RooFit::BatchMode(batchMode),
       RooFit::IntegrateBins(1.E-3)) );
   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
@@ -179,7 +181,7 @@ TEST(RooNLLVar, IntegrateBins_CustomBinning) {
   a.setVal(3.);
   std::unique_ptr<RooFitResult> fit2( pdf.fitTo(data, RooFit::Save(), RooFit::PrintLevel(-1),
       RooFit::Optimize(0),
-      RooFit::BatchMode(true),
+      RooFit::BatchMode(batchMode),
       RooFit::IntegrateBins(1.E-3)) );
   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 
@@ -226,14 +228,14 @@ TEST(RooNLLVar, IntegrateBins_RooDataHist) {
 
   a.setVal(3.);
   std::unique_ptr<RooFitResult> fit1( pdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(true),
+      RooFit::BatchMode(batchMode),
       RooFit::IntegrateBins(-1.) // Disable forcefully
       ) );
   pdf.plotOn(frame.get(), RooFit::LineColor(kRed), RooFit::Name("standard"));
 
   a.setVal(3.);
   std::unique_ptr<RooFitResult> fit2( pdf.fitTo(*data, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(true),
+      RooFit::BatchMode(batchMode),
       RooFit::IntegrateBins(0.) // Auto-enable for all RooDataHists.
       ) );
   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
@@ -283,7 +285,7 @@ TEST(RooChi2Var, IntegrateBins) {
 
   a.setVal(3.);
   std::unique_ptr<RooFitResult> fit2( pdf.chi2FitTo(*dataH, RooFit::Save(), RooFit::PrintLevel(-1),
-      RooFit::BatchMode(true),
+      RooFit::BatchMode(batchMode),
       RooFit::IntegrateBins(1.E-3)) );
   pdf.plotOn(frame.get(), RooFit::LineColor(kBlue), RooFit::Name("highRes"));
 


### PR DESCRIPTION
Multi-range fits in RooFit are more complicated than they should be.

In principle, all that is required is to change the normalization range of the PDF to the union of the ranges.

There is a RooAbdPdf interface to suggest that this could be done easily like this:
```C++
pdf.setNormRange("range1,range2")
```

But this doesn't work well for RooAddPdfs, which is probably why it was chosen to implement mulit-range fits as a sum of separate RooNLLVars. But in this case, the PDFs are normalized separately, and extra terms need to be introduced to correct for that. This resulted in lots of complicated code, and still there are issues like #11447, i.e. is still doesn't work for simultaneous fits.

That's why I decided to fix the `setNormRange()` for RooAddPdfs, and then starting from that re-implement multi-ranged fits in both the new BatchMode and the old RooFit based on that. 

Closes #11447.