### PR TITLE
[cmake] Correct typo in REFLEX_GENERATE_DICTIONARY. 

### DIFF
--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -182,7 +182,7 @@ function(REFLEX_GENERATE_DICTIONARY dictionary)
     # The COMPILE_DEFINITIONS list might contain empty elements. These are
     # removed with the FILTER generator expression, excluding elements that
     # match the ^$ regexp (only matches empty strings).
-    LIST(APPEND definitions "$<FILTER:$<TARGET_PROPERTY:${ARG_MODULE},COMPILE_DEFINITIONS>,EXCLUDE,^$>")
+    LIST(APPEND definitions "$<FILTER:$<TARGET_PROPERTY:${dictionary},COMPILE_DEFINITIONS>,EXCLUDE,^$>")
   ENDIF()
 
   add_custom_command(


### PR DESCRIPTION
This corrects the content of https://github.com/root-project/root/commit/6efc1684a62d37ccfa582cbbe3605995201ea7cb [cmake] Protect against empty COMPILE_DEFINITIONS in genreflex command

