### PR TITLE
[ntuple,daos] Page concatenation for buffered page-groups

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -48,13 +48,13 @@ struct RDaosEventQueue {
    /// \brief Sets event barrier for a given parent event and waits for the completion of all children launched before
    /// the barrier (must have at least one child).
    /// \return 0 on success; a DAOS error code otherwise (< 0).
-   int WaitOnParentBarrier(daos_event_t *ev_ptr);
+   static int WaitOnParentBarrier(daos_event_t *ev_ptr);
    /// \brief Reserve event in queue, optionally tied to a parent event.
    /// \return 0 on success; a DAOS error code otherwise (< 0).
-   int InitializeEvent(daos_event_t *ev_ptr, daos_event_t *parent_ptr = nullptr);
+   int InitializeEvent(daos_event_t *ev_ptr, daos_event_t *parent_ptr = nullptr) const;
    /// \brief Release event data from queue.
    /// \return 0 on success; a DAOS error code otherwise (< 0).
-   int FinalizeEvent(daos_event_t *ev_ptr);
+   static int FinalizeEvent(daos_event_t *ev_ptr);
 };
 
 class RDaosContainer;
@@ -120,7 +120,7 @@ public:
    struct FetchUpdateArgs {
       FetchUpdateArgs() = default;
       FetchUpdateArgs(const FetchUpdateArgs &) = delete;
-      FetchUpdateArgs(FetchUpdateArgs &&fua);
+      FetchUpdateArgs(FetchUpdateArgs &&fua) noexcept;
       FetchUpdateArgs(DistributionKey_t d, std::span<RAkeyRequest> rs, bool is_async = false);
       FetchUpdateArgs &operator=(const FetchUpdateArgs &) = delete;
       daos_event_t *GetEventPointer();
@@ -194,7 +194,7 @@ public:
          for (unsigned i = 0; i < fDataRequests.size(); i++)
             fIndices.emplace(fDataRequests[i].fAkey, i);
       };
-      RWOperation(ROidDkeyPair &k) : fOid(k.oid), fDistributionKey(k.dkey){};
+      explicit RWOperation(ROidDkeyPair &k) : fOid(k.oid), fDistributionKey(k.dkey){};
       daos_obj_id_t fOid{};
       DistributionKey_t fDistributionKey{};
       std::vector<RDaosObject::RAkeyRequest> fDataRequests{};

--- a/tree/ntuple/v7/inc/ROOT/RDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RDaos.hxx
@@ -108,6 +108,7 @@ public:
       static constexpr std::size_t kOCNameMaxLength = 64;
    };
 
+   /// \brief Contains an attribute key and the associated IOVs for a single scatter-gather I/O request.
    struct RAkeyRequest {
       AttributeKey_t fAkey{};
       std::vector<d_iov_t> fIovs{};
@@ -127,9 +128,9 @@ public:
 
       /// \brief A `daos_key_t` is a type alias of `d_iov_t`. This type stores a pointer and a length.
       /// In order for `fDistributionKey` to point to memory that we own, `fDkey` holds the distribution key.
-      /// `fRequests` is a sequential container assumed to remain valid throughout the fetch/update operation, holding a
-      /// list of attribute keys and their associated IOVs.
       DistributionKey_t fDkey{};
+      /// \brief `fRequests` is a sequential container assumed to remain valid throughout the fetch/update operation,
+      /// holding a list of `RAkeyRequest`-typed elements.
       std::span<RAkeyRequest> fRequests{};
 
       /// \brief The distribution key, as used by the `daos_obj_{fetch,update}` functions.
@@ -185,7 +186,8 @@ public:
       };
    };
 
-   /// \brief Describes a read/write operation on multiple objects; see the `ReadV`/`WriteV` functions.
+   /// \brief Describes a read/write operation on multiple attribute keys under the same object ID and distribution key,
+   /// see the `ReadV`/`WriteV` functions.
    struct RWOperation {
       RWOperation() = default;
       RWOperation(daos_obj_id_t o, DistributionKey_t d, std::vector<RDaosObject::RAkeyRequest> &&rs)

--- a/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleOptions.hxx
@@ -47,6 +47,7 @@ All page sink classes need to support the common options.
 */
 // clang-format on
 class RNTupleWriteOptions {
+protected:
    int fCompression{RCompressionSetting::EDefaults::kUseAnalysis};
    ENTupleContainerFormat fContainerFormat{ENTupleContainerFormat::kTFile};
    /// Approximation of the target compressed cluster size
@@ -95,7 +96,11 @@ public:
 */
 // clang-format on
 class RNTupleWriteOptionsDaos : public RNTupleWriteOptions {
-  std::string fObjectClass{"SX"};
+   std::string fObjectClass{"SX"};
+   /// The maximum cage size is set to the equivalent of 16 uncompressed pages - 1MiB by default. Empirically, such a
+   /// cage size yields acceptable results in throughput and page granularity for most use cases. A `fMaxCageSize` of 0
+   /// disables the caging mechanism.
+   uint32_t fMaxCageSize = 16 * RNTupleWriteOptions::fApproxUnzippedPageSize;
 
 public:
    ~RNTupleWriteOptionsDaos() override = default;
@@ -107,6 +112,12 @@ public:
    /// `OC_xxx` constant defined in `daos_obj_class.h` may be used here without
    /// the OC_ prefix.
    void SetObjectClass(const std::string &val) { fObjectClass = val; }
+
+   uint32_t GetMaxCageSize() const { return fMaxCageSize; }
+   /// Set the upper bound for page concatenation into cages, in bytes. It is assumed
+   /// that cage size will be no smaller than the approximate uncompressed page size.
+   /// To disable page concatenation, set this value to 0.
+   void SetMaxCageSize(uint32_t cageSz) { fMaxCageSize = cageSz; }
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -31,6 +31,14 @@
 
 namespace ROOT {
 namespace Experimental {
+
+namespace Internal {
+enum EDaosLocatorFlags {
+   // Indicates that the referenced page is "caged", i.e. it is stored in a larger blob that contains multiple pages.
+   kCagedPage = 0x01,
+};
+}
+
 namespace Detail {
 
 class RCluster;
@@ -152,6 +160,7 @@ private:
 
    RDaosNTupleAnchor fNTupleAnchor;
    ntuple_index_t fNTupleIndex{0};
+   uint32_t fCageSizeLimit{};
 
 protected:
    void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -34,10 +34,10 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
-#include <iostream>
 #include <limits>
 #include <utility>
 #include <regex>
+#include <cassert>
 
 namespace {
 using AttributeKey_t = ROOT::Experimental::Detail::RDaosContainer::AttributeKey_t;

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -340,7 +340,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPage
             GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fPhysicalColumnId, cageIdx);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [it, ret] = writeRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
-         it->second.insert(daosKey.fAkey, pageIov);
+         it->second.Insert(daosKey.fAkey, pageIov);
 
          RNTupleLocator locator;
          locator.fPosition = EncodeDaosPagePosition(cageIdx, szCurrentCage);
@@ -765,7 +765,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
          RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId, cageIndex);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [itReq, ret] = readRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
-         itReq->second.insert(daosKey.fAkey, iov);
+         itReq->second.Insert(daosKey.fAkey, iov);
 
          cageBuffer += cageSz;
       }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -104,6 +104,18 @@ RDaosURI ParseDaosURI(std::string_view uri)
    return {m[1], m[2]};
 }
 
+std::pair<uint32_t, uint32_t> DecodeDaosPagePosition(ROOT::Experimental::RNTupleLocatorObject64 &address)
+{
+   auto position = static_cast<uint32_t>(address.fLocation & 0xFFFFFFFF);
+   auto offset = static_cast<uint32_t>(address.fLocation >> 32);
+   return {position, offset};
+}
+
+ROOT::Experimental::RNTupleLocatorObject64 EncodeDaosPagePosition(uint64_t position, uint64_t offset = 0)
+{
+   uint64_t address = (position & 0xFFFFFFFF) | (offset << 32);
+   return ROOT::Experimental::RNTupleLocatorObject64{address};
+}
 } // namespace
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -273,8 +273,9 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageImpl(DescriptorId_t p
    }
 
    RNTupleLocator result;
-   result.fPosition = offsetData;
+   result.fPosition = RNTupleLocatorObject64{offsetData};
    result.fBytesOnStorage = sealedPage.fSize;
+   result.fType = RNTupleLocator::kTypeDAOS;
    fCounters->fNPageCommitted.Inc();
    fCounters->fSzWritePayload.Add(sealedPage.fSize);
    fNBytesCurrentCluster += sealedPage.fSize;
@@ -310,8 +311,9 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPage
          it->second.insert(daosKey.fAkey, pageIov);
 
          RNTupleLocator locator;
-         locator.fPosition = offsetData;
+         locator.fPosition = RNTupleLocatorObject64{offsetData};
          locator.fBytesOnStorage = s.fSize;
+         locator.fType = RNTupleLocator::kTypeDAOS;
          locators.push_back(locator);
 
          szPayload += s.fSize;
@@ -351,8 +353,9 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterGroupImpl(unsigned char 
       daos_obj_id_t{kOidLowPageList, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)}, kDistributionKeyDefault,
       offsetData, kCidMetadata);
    RNTupleLocator result;
-   result.fPosition = offsetData;
+   result.fPosition = RNTupleLocatorObject64{offsetData};
    result.fBytesOnStorage = szPageListZip;
+   result.fType = RNTupleLocator::kTypeDAOS;
    fCounters->fSzWritePayload.Add(szPageListZip);
    return result;
 }


### PR DESCRIPTION
This pull request adds support for the concatenation of RNTuple pages into 'cages' that are then written to, and read from, DAOS containers as a single value of the key-value object store under the same attribute key, thus the smallest addressable unit. Pages from the same page-group are concatenated in the order they are handled on the DAOS side through vector I/O from the sealed pages' buffers. The name 'cage' is a portmanteau of "concatenated pages" and suggests the fact that pages caged together must be read together in DAOS.

This change emancipates the DAOS backend from the original, on-disk ntuple page size. The option to concatenate sealed and buffered pages avoids unnecessary throughput constraints caused by the original page size (e.g., the on-disk default, 64KiB, generally leads to lower performance than pages an order of magnitude larger, e.g. 1MiB), particularly if the pattern of data analysis is based on reading back entire page-group ranges at once. On the other hand, this change ties the reader to the new, concatenated sizes; in DAOS key-value stores, it is impossible to read only a part of the value. It is important that the cage size limit be set adequately for the use-case during writing to DAOS.

## Changes or fixes:

- `RNTupleWriteOptions` provides a way to `SetMaxCageSize()` (default: caging enabled with 1 MiB cages), the maximum size a concatenation of pages from the same page-group can achieve.
- `RPageSinkDaos::CommitSealedPageVImpl()` maps pages from the same page-group to the same attribute key, thus concatenating them on the DAOS-side (i.e. relies on scatter-gathered I/O) until the cage limit is reached. The cage sizes can vary due to page compression and the length of page-groups, thus it is calculated and stored to be referenced when reading back.
- `RWOperation` is generalized to allow many IOVs associated with one attribute key in a request, enabling the non-contiguous buffers of sealed pages to be aggregated into a cage under the same position ID in the object store. 
- `RNTupleLocator`: leverages the changes introduced by PR #11828; all DAOS locators use the type `kDaos` and payload format `RNTupleLocatorObject64`. To locate pages within a cage, the 64-bit payload encodes the cage index in the LS half and the offset in the MS half. If caging is disabled, the offset remains zero, and each 'cage' is trivially the sealed page.
- Currently, there are no plans to enable support for page-wise reading without cluster caching if the desired page is caged, as that use-case is not performant and thus not recommended. Caged pages in DAOS should be accessed with the page buffering read option turned on. By disallowing the reading of a single caged page when the wrapping cage size is unknown, the cage sizes - or upper bounds for them - do not need to be passed to `RPageSourceDaos`; they are trivially devised in `RPageSourceDaos::LoadClusters()` by accessing all page locators in a buffered page-group. 
- `RPageSourceDaos::LoadClusters()` and `RPageSourceDaos::PopulatePageFromCluster()` extract the cage position and offset-in-cage from each sealed page's `RNTupleLocator::fPosition`. The former function has been changed to coalesce the page locators by cage index and perform a single read operation per cage.

## Checklist:

- [x] tested changes locally + HPE `delphi` cluster
- [x] updated the docs

