### PR TITLE
gcc12's regex header file relies on a std::vector<int> instance, export it

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -273,6 +273,7 @@ module "std" [system] {
   }
   module "regex" {
     export *
+    export vector
     header "regex"
   }
   module "scoped_allocator" {


### PR DESCRIPTION
The C++ modules marks the std::vector<int> instantiation as not visible because it came from the `regex` header file which we did not explicitly include.

root-project/root@a785402 introduces checks if certain declaration is visible in dictionary generation time which was intending to semantically improve the coherence by what the user "allowed" (or requested) rootcling to see vs what it can see globally. While this model works well it seems to not work for template instantiations as they won't be re-instantiated with visible modifier.

This patch works around the current issue seen with libstdc++ 12 but a better solution would be to implement a finer grained control over the implicit template instatiations when generating a dictionary.

Fixes root-project/root#11329
