### PR TITLE
[RF] Fix tutorial for `RooStats::SPlot`

### DIFF
--- a/tutorials/roostats/rs301_splot.C
+++ b/tutorials/roostats/rs301_splot.C
@@ -34,11 +34,14 @@
 #include "RooProdPdf.h"
 #include "RooAddition.h"
 #include "RooProduct.h"
-#include "TCanvas.h"
 #include "RooAbsPdf.h"
 #include "RooFitResult.h"
 #include "RooWorkspace.h"
 #include "RooConstVar.h"
+
+#include "TCanvas.h"
+#include "TLegend.h"
+
 #include <iomanip>
 
 // use this order for safety on library loading
@@ -46,16 +49,16 @@ using namespace RooFit;
 using namespace RooStats;
 
 // see below for implementation
-void AddModel(RooWorkspace *);
-void AddData(RooWorkspace *);
-void DoSPlot(RooWorkspace *);
-void MakePlots(RooWorkspace *);
+void AddModel(RooWorkspace &);
+void AddData(RooWorkspace &);
+void DoSPlot(RooWorkspace &);
+void MakePlots(RooWorkspace &);
 
 void rs301_splot()
 {
 
-   // Create a new workspace to manage the project.
-   RooWorkspace *wspace = new RooWorkspace("myWS");
+   // Create a workspace to manage the project.
+   RooWorkspace wspace{"myWS"};
 
    // add the signal and background models to the workspace.
    // Inside this function you will find a description of our model.
@@ -74,13 +77,10 @@ void rs301_splot()
    // Make some plots showing the discriminating variable and
    // the control variable after unfolding.
    MakePlots(wspace);
-
-   // cleanup
-   delete wspace;
 }
 
 //____________________________________
-void AddModel(RooWorkspace *ws)
+void AddModel(RooWorkspace &ws)
 {
 
    // Make models for signal (Higgs) and background (Z+jets and QCD)
@@ -144,8 +144,8 @@ void AddModel(RooWorkspace *ws)
 
    // These variables represent the number of Z or QCD events
    // They will be fitted.
-   RooRealVar zYield("zYield", "fitted yield for Z", 50, 0., 1000);
-   RooRealVar qcdYield("qcdYield", "fitted yield for QCD", 100, 0., 1000);
+   RooRealVar zYield("zYield", "fitted yield for Z", 500, 0., 5000);
+   RooRealVar qcdYield("qcdYield", "fitted yield for QCD", 1000, 0., 10000);
 
    // now make the combined models
    std::cout << "make full model" << std::endl;
@@ -157,42 +157,39 @@ void AddModel(RooWorkspace *ws)
 
    std::cout << "import model" << std::endl;
 
-   ws->import(model);
-   ws->import(massModel, RecycleConflictNodes());
+   ws.import(model);
+   ws.import(massModel, RecycleConflictNodes());
 }
 
 //____________________________________
-void AddData(RooWorkspace *ws)
+void AddData(RooWorkspace &ws)
 {
    // Add a toy dataset
 
-   // how many events do we want?
-   Int_t nEvents = 1000;
-
    // get what we need out of the workspace to make toy data
-   RooAbsPdf *model = ws->pdf("model");
-   RooRealVar *invMass = ws->var("invMass");
-   RooRealVar *isolation = ws->var("isolation");
+   RooAbsPdf *model = ws.pdf("model");
+   RooRealVar *invMass = ws.var("invMass");
+   RooRealVar *isolation = ws.var("isolation");
 
    // make the toy data
    std::cout << "make data set and import to workspace" << std::endl;
-   RooDataSet *data = model->generate(RooArgSet(*invMass, *isolation), nEvents);
+   RooDataSet *data = model->generate(RooArgSet(*invMass, *isolation));
 
    // import data into workspace
-   ws->import(*data, Rename("data"));
+   ws.import(*data, Rename("data"));
 }
 
 //____________________________________
-void DoSPlot(RooWorkspace *ws)
+void DoSPlot(RooWorkspace &ws)
 {
    std::cout << "Calculate sWeights" << std::endl;
 
    // get what we need out of the workspace to do the fit
-   RooAbsPdf *model = ws->pdf("model");
-   RooAbsPdf *massModel = ws->pdf("massModel");
-   RooRealVar *zYield = ws->var("zYield");
-   RooRealVar *qcdYield = ws->var("qcdYield");
-   RooDataSet& data = static_cast<RooDataSet&>(*ws->data("data"));
+   RooAbsPdf *model = ws.pdf("model");
+   RooAbsPdf *massModel = ws.pdf("massModel");
+   RooRealVar *zYield = ws.var("zYield");
+   RooRealVar *qcdYield = ws.var("qcdYield");
+   RooDataSet& data = static_cast<RooDataSet&>(*ws.data("data"));
 
    // The sPlot technique requires that we fix the parameters
    // of the model that are not yields after doing the fit.
@@ -201,8 +198,8 @@ void DoSPlot(RooWorkspace *ws)
    // by the RooStats::SPlot constructor (or more precisely the AddSWeight
    // method).
    //
-   // RooRealVar* sigmaZ = ws->var("sigmaZ");
-   // RooRealVar* qcdMassDecayConst = ws->var("qcdMassDecayConst");
+   // RooRealVar* sigmaZ = ws.var("sigmaZ");
+   // RooRealVar* qcdMassDecayConst = ws.var("qcdMassDecayConst");
    // sigmaZ->setConstant();
    // qcdMassDecayConst->setConstant();
 
@@ -242,12 +239,12 @@ void DoSPlot(RooWorkspace *ws)
 
    // import this new dataset with sWeights
    std::cout << "import new dataset with sWeights" << std::endl;
-   ws->import(data, Rename("dataWithSWeights"));
+   ws.import(data, Rename("dataWithSWeights"));
 
    RooMsgService::instance().setGlobalKillBelow(RooFit::INFO);
 }
 
-void MakePlots(RooWorkspace *ws)
+void MakePlots(RooWorkspace &ws)
 {
 
    // Here we make plots of the discriminating variable (invMass) after the fit
@@ -259,15 +256,20 @@ void MakePlots(RooWorkspace *ws)
    cdata->Divide(1, 3);
 
    // get what we need out of the workspace
-   RooAbsPdf *model = ws->pdf("model");
-   RooAbsPdf *zModel = ws->pdf("zModel");
-   RooAbsPdf *qcdModel = ws->pdf("qcdModel");
+   RooAbsPdf *model = ws.pdf("model");
+   RooAbsPdf *zModel = ws.pdf("zModel");
+   RooAbsPdf *qcdModel = ws.pdf("qcdModel");
 
-   RooRealVar *isolation = ws->var("isolation");
-   RooRealVar *invMass = ws->var("invMass");
+   RooRealVar *isolation = ws.var("isolation");
+   RooRealVar *invMass = ws.var("invMass");
 
    // note, we get the dataset with sWeights
-   RooDataSet *data = (RooDataSet *)ws->data("dataWithSWeights");
+   auto& data = static_cast<RooDataSet&>(*ws.data("dataWithSWeights"));
+
+   // create weighted data sets
+   RooDataSet dataw_z{data.GetName(), data.GetTitle(), &data, *data.get(), nullptr, "zYield_sw"};
+   RooDataSet dataw_qcd{data.GetName(), data.GetTitle(), &data, *data.get(), nullptr, "qcdYield_sw"};
+
 
    // this shouldn't be necessary, need to fix something with workspace
    // do this to set parameters back to their fitted values.
@@ -276,8 +278,8 @@ void MakePlots(RooWorkspace *ws)
    // plot invMass for data with full model and individual components overlaid
    //  TCanvas* cdata = new TCanvas();
    cdata->cd(1);
-   RooPlot *frame = invMass->frame();
-   data->plotOn(frame);
+   RooPlot *frame = invMass->frame(Title("Fit of model to discriminating variable"));
+   data.plotOn(frame);
    model->plotOn(frame, Name("FullModel"));
    model->plotOn(frame, Components(*zModel), LineStyle(kDashed), LineColor(kRed), Name("ZModel"));
    model->plotOn(frame, Components(*qcdModel), LineStyle(kDashed), LineColor(kGreen), Name("QCDModel"));
@@ -289,7 +291,6 @@ void MakePlots(RooWorkspace *ws)
    leg.SetBorderSize(0);
    leg.SetFillStyle(0);
 
-   frame->SetTitle("Fit of model to discriminating variable");
    frame->Draw();
    leg.DrawClone();
 
@@ -304,14 +305,11 @@ void MakePlots(RooWorkspace *ws)
    // yield + "_sw".
    cdata->cd(2);
 
-   // create weighted data set
-   RooDataSet *dataw_z = new RooDataSet(data->GetName(), data->GetTitle(), data, *data->get(), 0, "zYield_sw");
-
-   RooPlot *frame2 = isolation->frame();
+   RooPlot *frame2 = isolation->frame(Title("Isolation distribution with s weights to project out Z"));
    // Since the data are weighted, we use SumW2 to compute the errors.
-   dataw_z->plotOn(frame2, DataError(RooAbsData::SumW2));
+   dataw_z.plotOn(frame2, DataError(RooAbsData::SumW2));
+   zModel->plotOn(frame2, LineStyle(kDashed), LineColor(kRed));
 
-   frame2->SetTitle("Isolation distribution with s weights to project out Z");
    frame2->Draw();
 
    // Plot isolation for QCD component.
@@ -319,11 +317,10 @@ void MakePlots(RooWorkspace *ws)
    // The SPlot class adds a new variable that has the name of the corresponding
    // yield + "_sw".
    cdata->cd(3);
-   RooDataSet *dataw_qcd = new RooDataSet(data->GetName(), data->GetTitle(), data, *data->get(), 0, "qcdYield_sw");
-   RooPlot *frame3 = isolation->frame();
-   dataw_qcd->plotOn(frame3, DataError(RooAbsData::SumW2));
+   RooPlot *frame3 = isolation->frame(Title("Isolation distribution with s weights to project out QCD"));
+   dataw_qcd.plotOn(frame3, DataError(RooAbsData::SumW2));
+   qcdModel->plotOn(frame3, LineStyle(kDashed), LineColor(kGreen));
 
-   frame3->SetTitle("Isolation distribution with s weights to project out QCD");
    frame3->Draw();
 
    //  cdata->SaveAs("SPlot.gif");


### PR DESCRIPTION
The tutorial is actually using the SPlots class wrong. It is calculating
sWeights for the isolation based on the invariant mass and the isolation
itself. That’s wrong. For sPlots, the control variable should not be in
the set of discriminating variables for the likelihood fit! See
https://arxiv.org/pdf/physics/0402083.pdf.

That means when using the SPlot class, you should exclude the isolation
variable from the dataset that you pass.

Big thanks to Dongliang for reporting this on the ROOT Forum!

https://root-forum.cern.ch/t/strange-results-in-rs301-splot-c

A second commit applies some other improvements to the tutorial:

* Code modernization

* Don't define number of events in toy data redundantly

* Add also plots of isolation models