### PR TITLE
[RF] Make no distinction in VectorDataStore between `get` and getNative

### DIFF
--- a/roofit/roofitcore/inc/RooVectorDataStore.h
+++ b/roofit/roofitcore/inc/RooVectorDataStore.h
@@ -106,8 +106,6 @@ public:
   using RooAbsDataStore::get;
   const RooArgSet* get(Int_t index) const override;
 
-  virtual const RooArgSet* getNative(Int_t index) const;
-
   using RooAbsDataStore::weight ;
   /// Return the weight of the last-retrieved data point.
   double weight() const override
@@ -288,6 +286,7 @@ public:
     inline void load(std::size_t idx) const {
       assert(idx < _vec.size());
       *_buf = *(_vec.begin() + idx) ;
+      *_nativeBuf = *_buf ;
     }
 
     RooSpan<const double> getRange(std::size_t first, std::size_t last) const {
@@ -295,10 +294,6 @@ public:
       auto end = std::min(_vec.cbegin() + last,  _vec.cend());
 
       return RooSpan<const double>(beg, end);
-    }
-
-    inline void loadToNative(std::size_t idx) const {
-      *_nativeBuf = *(_vec.begin() + idx) ;
     }
 
     std::size_t size() const { return _vec.size() ; }
@@ -435,17 +430,6 @@ public:
       }
     }
 
-    inline void loadToNative(Int_t idx) const {
-      RealVector::loadToNative(idx) ;
-      if (_vecE) {
-        *_nativeBufE = (*_vecE)[idx] ;
-      }
-      if (_vecEL) {
-        *_nativeBufEL = (*_vecEL)[idx] ;
-        *_nativeBufEH = (*_vecEH)[idx] ;
-      }
-    }
-
     void fill() {
       RealVector::fill() ;
       if (_vecE) _vecE->push_back(*_bufE) ;
@@ -476,11 +460,20 @@ public:
       }
     }
 
-    inline void get(Int_t idx) const {
+    inline void load(Int_t idx) const {
       RealVector::load(idx) ;
-      if (_vecE) *_bufE = (*_vecE)[idx];
-      if (_vecEL) *_bufEL = (*_vecEL)[idx] ;
-      if (_vecEH) *_bufEH = (*_vecEH)[idx] ;
+      if (_vecE) {
+        *_bufE = (*_vecE)[idx];
+        *_nativeBufE = (*_vecE)[idx] ;
+      }
+      if (_vecEL) {
+        *_bufEL = (*_vecEL)[idx] ;
+        *_nativeBufEL = (*_vecEL)[idx] ;
+      }
+      if (_vecEH) {
+        *_bufEH = (*_vecEH)[idx] ;
+        *_nativeBufEH = (*_vecEH)[idx] ;
+      }
     }
 
     void resize(Int_t siz) {
@@ -595,6 +588,7 @@ public:
 
     inline void load(std::size_t idx) const {
       *_buf = _vec[idx];
+      *_nativeBuf = *_buf;
     }
 
     RooSpan<const RooAbsCategory::value_type> getRange(std::size_t first, std::size_t last) const {
@@ -604,10 +598,6 @@ public:
       return RooSpan<const RooAbsCategory::value_type>(beg, end);
     }
 
-
-    inline void loadToNative(std::size_t idx) const {
-      *_nativeBuf = _vec[idx];
-    }
 
     std::size_t size() const { return _vec.size() ; }
 

--- a/roofit/roofitcore/src/RooVectorDataStore.cxx
+++ b/roofit/roofitcore/src/RooVectorDataStore.cxx
@@ -358,7 +358,7 @@ const RooArgSet* RooVectorDataStore::get(Int_t index) const
   }
 
   for (const auto fullRealP : _realfStoreList) {
-    fullRealP->get(index);
+    fullRealP->load(index);
   }
 
   for (const auto catP : _catStoreList) {
@@ -377,43 +377,6 @@ const RooArgSet* RooVectorDataStore::get(Int_t index) const
 
   if (_cache) {
     _cache->get(index) ;
-  }
-
-  return &_vars;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// Load the n-th data point (n='index') into the variables of this dataset,
-/// and return a pointer to the RooArgSet that holds them.
-const RooArgSet* RooVectorDataStore::getNative(Int_t index) const
-{
-  if (index < 0 || static_cast<std::size_t>(index) >= size()) return 0;
-
-  for (const auto realV : _realStoreList) {
-    realV->loadToNative(index) ;
-  }
-
-  for (const auto fullRealP : _realfStoreList) {
-    fullRealP->loadToNative(index);
-  }
-
-  for (const auto catP : _catStoreList) {
-    catP->loadToNative(index);
-  }
-
-  if (_doDirtyProp) {
-    // Raise all dirty flags
-    for (auto var : _vars) {
-      var->setValueDirty() ; // This triggers recalculation of all clients
-    }
-  }
-
-  // Update current weight cache
-  _currentWeightIndex = index;
-
-  if (_cache) {
-    _cache->getNative(index) ;
   }
 
   return &_vars;
@@ -687,7 +650,7 @@ RooAbsArg* RooVectorDataStore::addColumn(RooAbsArg& newVar, bool /*adjustRange*/
   }
 
   for (std::size_t i=0; i < numEvt; i++) {
-    getNative(i) ;
+    get(i) ;
 
     newVarClone->syncCache(&_vars) ;
     valHolder->copyCache(newVarClone) ;
@@ -902,7 +865,7 @@ void RooVectorDataStore::cacheArgs(const RooAbsArg* owner, RooArgSet& newVarSet,
   const std::size_t numEvt = size();
   newCache->reserve(numEvt);
   for (std::size_t i=0; i < numEvt; i++) {
-    getNative(i) ;
+    get(i) ;
     if (weight()!=0 || !skipZeroWeights) {
       for (unsigned int j = 0; j < cloneSet.size(); ++j) {
         auto& cloneArg = cloneSet[j];

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -42,7 +42,7 @@ ROOT_ADD_GTEST(testRooRealVar testRooRealVar.cxx LIBRARIES RooFitCore
     LIBRARIES RooFitCore
     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_1.root ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_2.root)
 if(NOT MSVC OR win_broken_tests)
-  ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore)
+  ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore RooFit)
 endif()
 ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore RooFit)


### PR DESCRIPTION
The `RooVectorDataStore` had two different buffers to store the row data in: the so-called "attached buffers" and the "native buffers".

The problem is that when external buffers are attached, the call to `RooVectorDataStore::get()` is not loading the native buffers anymore, which is breaking some code that assumes this, like `RooVectorDataStore::loadValues`, which is used in `RooDataSet::reduce`. This breaks the reduction of datasets with externally attached buffers, which breaks the copy constructor of the `RooNLLVar`.

This commit suggests to always load both the native and attached buffers if `RooVectorDataStore::get()` is called. This has almost no performance overhead and is much safeter.

Since this change fixes the copy constructor of the `RooNLLVar`, which is used when plotting the NLL, this commit fixes this JIRA ticket: https://sft.its.cern.ch/jira/browse/ROOT-9752

A unit test that covers the problem reported in the JIRA ticket is also added.