### PR TITLE
Fix a compilation error on Win64

### DIFF
--- a/tree/readspeed/src/ReadSpeed.cxx
+++ b/tree/readspeed/src/ReadSpeed.cxx
@@ -331,7 +331,7 @@ Result ReadSpeed::EvalThroughputMT(const Data &d, unsigned nThreads)
 
    TStopwatch sw;
    sw.Start();
-   const auto totalByteData = pool.MapReduce(processFile, ROOT::TSeqUL{(unsigned long)d.fFileNames.size()}, SumBytes);
+   const auto totalByteData = pool.MapReduce(processFile, ROOT::TSeqUL(d.fFileNames.size()), SumBytes);
    sw.Stop();
 
    return {sw.RealTime(),

--- a/tree/readspeed/src/ReadSpeed.cxx
+++ b/tree/readspeed/src/ReadSpeed.cxx
@@ -331,7 +331,7 @@ Result ReadSpeed::EvalThroughputMT(const Data &d, unsigned nThreads)
 
    TStopwatch sw;
    sw.Start();
-   const auto totalByteData = pool.MapReduce(processFile, ROOT::TSeqUL{d.fFileNames.size()}, SumBytes);
+   const auto totalByteData = pool.MapReduce(processFile, ROOT::TSeqUL{(unsigned long)d.fFileNames.size()}, SumBytes);
    sw.Stop();
 
    return {sw.RealTime(),


### PR DESCRIPTION
Fix the following compilation error on Win64:
```
ReadSpeed.cxx(334,89): error C2398: Element '1': conversion from 'unsigned __int64' to 'T' requires a narrowing conversion
```
