### PR TITLE
[ntuple,daos] Support multiple ntuples per container

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -119,22 +119,7 @@ struct RDaosContainerNTupleLocator {
                                    RNTupleDescriptorBuilder &builder);
 
    static std::pair<RDaosContainerNTupleLocator, RNTupleDescriptorBuilder>
-   LocateNTuple(RDaosContainer &cont, const std::string &ntupleName, RNTupleDecompressor &decompressor)
-   {
-      auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName), RNTupleDescriptorBuilder());
-
-      auto &loc = result.first;
-      auto &builder = result.second;
-
-      if (int err = loc.InitNTupleDescriptorBuilder(cont, decompressor, builder); !err) {
-         if (ntupleName.empty() || ntupleName != builder.GetDescriptor().GetName()) {
-            // Hash already taken by a differently-named ntuple.
-            throw ROOT::Experimental::RException(
-               R__FAIL("LocateNTuple: ntuple name '" + ntupleName + "' unavailable in this container."));
-         }
-      }
-      return result;
-   }
+   LocateNTuple(RDaosContainer &cont, const std::string &ntupleName, RNTupleDecompressor &decompressor);
 };
 
 // clang-format off

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -28,6 +28,8 @@
 #include <memory>
 #include <string>
 
+using ntuple_index_t = std::uint32_t;
+
 namespace ROOT {
 
 namespace Experimental {
@@ -108,6 +110,7 @@ private:
    std::uint64_t fNBytesCurrentCluster{0};
 
    RDaosNTupleAnchor fNTupleAnchor;
+   ntuple_index_t fNTupleIndex{0};
 
 protected:
    void CreateImpl(const RNTupleModel &model, unsigned char *serializedHeader, std::uint32_t length) final;
@@ -162,6 +165,8 @@ private:
       /// The first element number of the page's column in the given cluster
       std::uint64_t fColumnOffset = 0;
    };
+
+   ntuple_index_t fNTupleIndex{0};
 
    /// Populated pages might be shared; the memory buffer is managed by the RPageAllocatorDaos
    std::unique_ptr<RPageAllocatorDaos> fPageAllocator;

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -102,7 +102,8 @@ struct RDaosContainerNTupleLocator {
    RDaosContainerNTupleLocator() = default;
    explicit RDaosContainerNTupleLocator(const std::string &ntupleName) : fName(ntupleName), fIndex(Hash(ntupleName)){};
 
-   ntuple_index_t GetIndex() const { return fIndex; };
+   bool IsValid() { return fAnchor.has_value() && fAnchor->fNBytesHeader; }
+   [[nodiscard]] ntuple_index_t GetIndex() const { return fIndex; };
    static ntuple_index_t Hash(const std::string &ntupleName)
    {
       // Convert string to numeric representation via `std::hash`.
@@ -110,8 +111,7 @@ struct RDaosContainerNTupleLocator {
       // Fold `std::size_t` bits into 32-bit using `boost::hash_combine()` algorithm and magic number.
       auto seed = static_cast<uint32_t>(h >> 32);
       seed ^= static_cast<uint32_t>(h & 0xffffffff) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-      ntuple_index_t hash = static_cast<ntuple_index_t>(seed);
-
+      auto hash = static_cast<ntuple_index_t>(seed);
       return (hash == kReservedIndex) ? kReservedIndex + 1 : hash;
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RPageStorageDaos.hxx
@@ -27,39 +27,9 @@
 #include <cstdio>
 #include <memory>
 #include <string>
-
-using ntuple_index_t = std::uint32_t;
-namespace ROOT::Experimental::Detail {
-struct RDaosNTupleAnchor;
-}
-
-struct RDaosContainerNTupleLocator {
-   std::string fName{};
-   std::uint32_t fHashedName{};
-   ntuple_index_t fIndex{};
-   std::unique_ptr<ROOT::Experimental::Detail::RDaosNTupleAnchor> fAnchor;
-   ROOT::Experimental::RNTupleDescriptorBuilder fDescBuilder{};
-   static const ntuple_index_t kReservedHash = 0;
-
-   RDaosContainerNTupleLocator() = default;
-   explicit RDaosContainerNTupleLocator(const std::string &ntupleName) : fName(ntupleName), fHashedName(Hash(ntupleName))
-   {
-      fIndex = fHashedName;
-      fAnchor = std::make_unique<ROOT::Experimental::Detail::RDaosNTupleAnchor>();
-   };
-
-   ntuple_index_t GetIndex() const { return fIndex; };
-   static ntuple_index_t Hash(const std::string &ntupleName)
-   {
-      // Use `std::hash` implementation followed by XOR to fit in `ntuple_index_t` (i.e., 32-bit)
-      std::size_t h = std::hash<std::string>{}(ntupleName);
-      ntuple_index_t hash = (h & 0xffffffff) ^ ((h >> 32));
-      return (hash == kReservedHash) ? kReservedHash + 1 : hash;
-   }
-};
+#include <optional>
 
 namespace ROOT {
-
 namespace Experimental {
 namespace Detail {
 
@@ -69,6 +39,8 @@ class RPageAllocatorHeap;
 class RPagePool;
 class RDaosPool;
 class RDaosContainer;
+
+using ntuple_index_t = std::uint32_t;
 
 // clang-format off
 /**
@@ -107,6 +79,58 @@ struct RDaosNTupleAnchor {
    RResult<std::uint32_t> Deserialize(const void *buffer, std::uint32_t bufSize);
 
    static std::uint32_t GetSize();
+};
+
+// clang-format off
+/**
+\class ROOT::Experimental::Detail::RDaosContainerNTupleLocator
+\ingroup NTuple
+\brief Helper structure concentrating the functionality required to locate an ntuple within a DAOS container.
+It includes a hashing function that converts the RNTuple's name into a 32-bit identifier; this value is used to index
+the subspace for the ntuple among all objects in the container. A zero-value hash value is reserved for storing any
+future metadata related to container-wide management; a zero-index ntuple is thus disallowed and remapped to "1".
+Once the index is computed, `InitNTupleDescriptorBuilder()` can be called to return a partially-filled builder with
+the ntuple's anchor, header and footer, lacking only pagelists. Upon that call, a copy of the anchor is stored in `fAnchor`.
+*/
+// clang-format on
+struct RDaosContainerNTupleLocator {
+   std::string fName{};
+   ntuple_index_t fIndex{};
+   std::optional<ROOT::Experimental::Detail::RDaosNTupleAnchor> fAnchor;
+   static const ntuple_index_t kReservedIndex = 0;
+
+   RDaosContainerNTupleLocator() = default;
+   explicit RDaosContainerNTupleLocator(const std::string &ntupleName) : fName(ntupleName), fIndex(Hash(ntupleName)){};
+
+   ntuple_index_t GetIndex() const { return fIndex; };
+   static ntuple_index_t Hash(const std::string &ntupleName)
+   {
+      // Use `std::hash` implementation followed by XOR to fit in `ntuple_index_t` (i.e., 32-bit)
+      std::size_t h = std::hash<std::string>{}(ntupleName);
+      ntuple_index_t hash = (h & 0xffffffff) ^ ((h >> 32));
+      return (hash == kReservedIndex) ? kReservedIndex + 1 : hash;
+   }
+
+   int InitNTupleDescriptorBuilder(RDaosContainer &cont, RNTupleDecompressor &decompressor,
+                                   RNTupleDescriptorBuilder &builder);
+
+   static std::pair<RDaosContainerNTupleLocator, RNTupleDescriptorBuilder>
+   LocateNTuple(RDaosContainer &cont, const std::string &ntupleName, RNTupleDecompressor &decompressor)
+   {
+      auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName), RNTupleDescriptorBuilder());
+
+      auto &loc = result.first;
+      auto &builder = result.second;
+
+      if (int err = loc.InitNTupleDescriptorBuilder(cont, decompressor, builder); !err) {
+         if (ntupleName.empty() || ntupleName != builder.GetDescriptor().GetName()) {
+            // Hash already taken by a differently-named ntuple.
+            throw ROOT::Experimental::RException(
+               R__FAIL("LocateNTuple: ntuple name '" + ntupleName + "' unavailable in this container."));
+         }
+      }
+      return result;
+   }
 };
 
 // clang-format off
@@ -160,7 +184,6 @@ public:
    void ReleasePage(RPage &page) final;
 };
 
-
 // clang-format off
 /**
 \class ROOT::Experimental::Detail::RPageAllocatorDaos
@@ -171,9 +194,8 @@ public:
 class RPageAllocatorDaos {
 public:
    static RPage NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements);
-   static void DeletePage(const RPage& page);
+   static void DeletePage(const RPage &page);
 };
-
 
 // clang-format off
 /**
@@ -230,8 +252,7 @@ public:
    RPage PopulatePage(ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex) final;
    void ReleasePage(RPage &page) final;
 
-   void LoadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex,
-                       RSealedPage &sealedPage) final;
+   void LoadSealedPage(DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage) final;
 
    std::vector<std::unique_ptr<RCluster>> LoadClusters(std::span<RCluster::RKey> clusterKeys) final;
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -187,6 +187,26 @@ int ROOT::Experimental::Detail::RDaosContainerNTupleLocator::InitNTupleDescripto
    return 0;
 }
 
+std::pair<ROOT::Experimental::Detail::RDaosContainerNTupleLocator, ROOT::Experimental::RNTupleDescriptorBuilder>
+ROOT::Experimental::Detail::RDaosContainerNTupleLocator::LocateNTuple(RDaosContainer &cont,
+                                                                      const std::string &ntupleName,
+                                                                      RNTupleDecompressor &decompressor)
+{
+   auto result = std::make_pair(RDaosContainerNTupleLocator(ntupleName), RNTupleDescriptorBuilder());
+
+   auto &loc = result.first;
+   auto &builder = result.second;
+
+   if (int err = loc.InitNTupleDescriptorBuilder(cont, decompressor, builder); !err) {
+      if (ntupleName.empty() || ntupleName != builder.GetDescriptor().GetName()) {
+         // Hash already taken by a differently-named ntuple.
+         throw ROOT::Experimental::RException(
+            R__FAIL("LocateNTuple: ntuple name '" + ntupleName + "' unavailable in this container."));
+      }
+   }
+   return result;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos(std::string_view ntupleName, std::string_view uri,

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -62,23 +62,34 @@ static constexpr AttributeKey_t kAttributeKeyAnchor = 0x4243544b5344422a;
 static constexpr AttributeKey_t kAttributeKeyHeader = 0x4243544b5344422b;
 static constexpr AttributeKey_t kAttributeKeyFooter = 0x4243544b5344422c;
 
-/// \brief Pre-defined object IDs for metadata (holds anchor/header/footer) and clusters' pagelists.
-static constexpr daos_obj_id_t kOidMetadata{std::uint64_t(-1), 0};
-static constexpr daos_obj_id_t kOidPageList{std::uint64_t(-2), 0};
+/// \brief The zeroth attribute key in the container metadata object is reserved to hold global metadata for the
+/// container, such as the number of ntuples. Names of existing ntuples are stored under their hashes in the following
+/// attributes.
+static constexpr AttributeKey_t kAttributeKeyContainerSummary = 0;
+
+/// \brief Pre-defined object ID for container metadata (holds global count and indexing of present ntuples in
+/// container)
+static constexpr daos_obj_id_t kOidContainer{static_cast<decltype(daos_obj_id_t::lo)>(-1), 0};
+
+/// \brief Pre-defined 64 LSb of the OIDs for ntuple metadata (holds anchor/header/footer) and clusters' pagelists.
+static constexpr decltype(daos_obj_id_t::lo) kOidLowMetadata = -1;
+static constexpr decltype(daos_obj_id_t::lo) kOidLowPageList = -2;
 
 static constexpr daos_oclass_id_t kCidMetadata = OC_SX;
 
 static constexpr EDaosMapping kDefaultDaosMapping = kOidPerCluster;
 
 template <EDaosMapping mapping>
-RDaosKey GetPageDaosKey(long unsigned clusterId, long unsigned columnId, long unsigned pageCount)
+RDaosKey GetPageDaosKey(ntuple_index_t ntplId, long unsigned clusterId, long unsigned columnId, long unsigned pageCount)
 {
    if constexpr (mapping == kOidPerCluster) {
-      return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(clusterId), 0},
+      return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(clusterId),
+                                    static_cast<decltype(daos_obj_id_t::hi)>(ntplId)},
                       static_cast<DistributionKey_t>(columnId), static_cast<AttributeKey_t>(pageCount)};
    } else if constexpr (mapping == kOidPerPage) {
-      return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(pageCount), 0}, kDistributionKeyDefault,
-                      kAttributeKeyDefault};
+      return RDaosKey{daos_obj_id_t{static_cast<decltype(daos_obj_id_t::lo)>(pageCount),
+                                    static_cast<decltype(daos_obj_id_t::hi)>(ntplId)},
+                      kDistributionKeyDefault, kAttributeKeyDefault};
    }
 }
 
@@ -102,11 +113,9 @@ RDaosURI ParseDaosURI(std::string_view uri)
 }
 } // namespace
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
-std::uint32_t
-ROOT::Experimental::Detail::RDaosNTupleAnchor::Serialize(void *buffer) const
+std::uint32_t ROOT::Experimental::Detail::RDaosNTupleAnchor::Serialize(void *buffer) const
 {
    using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
    if (buffer != nullptr) {
@@ -140,29 +149,23 @@ ROOT::Experimental::Detail::RDaosNTupleAnchor::Deserialize(const void *buffer, s
    return result.Unwrap() + 20;
 }
 
-std::uint32_t
-ROOT::Experimental::Detail::RDaosNTupleAnchor::GetSize()
+std::uint32_t ROOT::Experimental::Detail::RDaosNTupleAnchor::GetSize()
 {
-   return RDaosNTupleAnchor().Serialize(nullptr)
-      + ROOT::Experimental::Detail::RDaosObject::ObjClassId::kOCNameMaxLength;
+   return RDaosNTupleAnchor().Serialize(nullptr) +
+          ROOT::Experimental::Detail::RDaosObject::ObjClassId::kOCNameMaxLength;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
 ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos(std::string_view ntupleName, std::string_view uri,
-   const RNTupleWriteOptions &options)
-   : RPageSink(ntupleName, options)
-   , fPageAllocator(std::make_unique<RPageAllocatorHeap>())
-   , fURI(uri)
+                                                         const RNTupleWriteOptions &options)
+   : RPageSink(ntupleName, options), fPageAllocator(std::make_unique<RPageAllocatorHeap>()), fURI(uri)
 {
-   R__LOG_WARNING(NTupleLog()) << "The DAOS backend is experimental and still under development. " <<
-      "Do not store real data with this version of RNTuple!";
+   R__LOG_WARNING(NTupleLog()) << "The DAOS backend is experimental and still under development. "
+                               << "Do not store real data with this version of RNTuple!";
    fCompressor = std::make_unique<RNTupleCompressor>();
    EnableDefaultMetrics("RPageSinkDaos");
 }
-
 
 ROOT::Experimental::Detail::RPageSinkDaos::~RPageSinkDaos() = default;
 
@@ -185,7 +188,6 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CreateImpl(const RNTupleModel & 
                                        RNTupleCompressor::MakeMemCopyWriter(zipBuffer.get()));
    WriteNTupleHeader(zipBuffer.get(), szZipHeader, length);
 }
-
 
 ROOT::Experimental::RNTupleLocator
 ROOT::Experimental::Detail::RPageSinkDaos::CommitPageImpl(ColumnHandle_t columnHandle, const RPage &page)
@@ -210,7 +212,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageImpl(DescriptorId_t c
 
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallWrite, fCounters->fTimeCpuWrite);
-      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(clusterId, columnId, offsetData);
+      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId, offsetData);
       fDaosContainer->WriteSingleAkey(sealedPage.fBuffer, sealedPage.fSize, daosKey.fOid, daosKey.fDkey, daosKey.fAkey);
    }
 
@@ -245,7 +247,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPage
          d_iov_set(&pageIov, const_cast<void *>(s.fBuffer), s.fSize);
          auto offsetData = fPageId.fetch_add(1);
 
-         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(clusterId, range.fColumnId, offsetData);
+         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, range.fColumnId, offsetData);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [it, ret] = writeRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
          it->second.insert(daosKey.fAkey, pageIov);
@@ -273,7 +275,7 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitSealedPageVImpl(std::span<RPage
 }
 
 std::uint64_t
-ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
+   ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterImpl(ROOT::Experimental::NTupleSize_t /* nEntries */)
 {
    return std::exchange(fNBytesCurrentCluster, 0);
 }
@@ -287,8 +289,10 @@ ROOT::Experimental::Detail::RPageSinkDaos::CommitClusterGroupImpl(unsigned char 
                                          RNTupleCompressor::MakeMemCopyWriter(bufPageListZip.get()));
 
    auto offsetData = fClusterGroupId.fetch_add(1);
-   fDaosContainer->WriteSingleAkey(bufPageListZip.get(), szPageListZip, kOidPageList, kDistributionKeyDefault,
-                                   offsetData, kCidMetadata);
+   fDaosContainer->WriteSingleAkey(
+      bufPageListZip.get(), szPageListZip,
+      daos_obj_id_t{kOidLowPageList, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)}, kDistributionKeyDefault,
+      offsetData, kCidMetadata);
    RNTupleLocator result;
    result.fPosition = offsetData;
    result.fBytesOnStorage = szPageListZip;
@@ -305,30 +309,32 @@ void ROOT::Experimental::Detail::RPageSinkDaos::CommitDatasetImpl(unsigned char 
    WriteNTupleAnchor();
 }
 
-void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleHeader(
-		const void *data, size_t nbytes, size_t lenHeader)
+void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleHeader(const void *data, size_t nbytes, size_t lenHeader)
 {
-   fDaosContainer->WriteSingleAkey(data, nbytes, kOidMetadata, kDistributionKeyDefault, kAttributeKeyHeader,
-                                   kCidMetadata);
+   fDaosContainer->WriteSingleAkey(
+      data, nbytes, daos_obj_id_t{kOidLowMetadata, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)},
+      kDistributionKeyDefault, kAttributeKeyHeader, kCidMetadata);
    fNTupleAnchor.fLenHeader = lenHeader;
    fNTupleAnchor.fNBytesHeader = nbytes;
 }
 
-void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleFooter(
-		const void *data, size_t nbytes, size_t lenFooter)
+void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleFooter(const void *data, size_t nbytes, size_t lenFooter)
 {
-   fDaosContainer->WriteSingleAkey(data, nbytes, kOidMetadata, kDistributionKeyDefault, kAttributeKeyFooter,
-                                   kCidMetadata);
+   fDaosContainer->WriteSingleAkey(
+      data, nbytes, daos_obj_id_t{kOidLowMetadata, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)},
+      kDistributionKeyDefault, kAttributeKeyFooter, kCidMetadata);
    fNTupleAnchor.fLenFooter = lenFooter;
    fNTupleAnchor.fNBytesFooter = nbytes;
 }
 
-void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleAnchor() {
+void ROOT::Experimental::Detail::RPageSinkDaos::WriteNTupleAnchor()
+{
    const auto ntplSize = RDaosNTupleAnchor::GetSize();
    auto buffer = std::make_unique<unsigned char[]>(ntplSize);
    fNTupleAnchor.Serialize(buffer.get());
-   fDaosContainer->WriteSingleAkey(buffer.get(), ntplSize, kOidMetadata, kDistributionKeyDefault, kAttributeKeyAnchor,
-                                   kCidMetadata);
+   fDaosContainer->WriteSingleAkey(
+      buffer.get(), ntplSize, daos_obj_id_t{kOidLowMetadata, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)},
+      kDistributionKeyDefault, kAttributeKeyAnchor, kCidMetadata);
 }
 
 ROOT::Experimental::Detail::RPage
@@ -345,25 +351,23 @@ void ROOT::Experimental::Detail::RPageSinkDaos::ReleasePage(RPage &page)
    fPageAllocator->DeletePage(page);
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
-
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageAllocatorDaos::NewPage(
-   ColumnId_t columnId, void *mem, std::size_t elementSize, std::size_t nElements)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageAllocatorDaos::NewPage(ColumnId_t columnId, void *mem, std::size_t elementSize,
+                                                        std::size_t nElements)
 {
    RPage newPage(columnId, mem, elementSize, nElements);
    newPage.GrowUnchecked(nElements);
    return newPage;
 }
 
-void ROOT::Experimental::Detail::RPageAllocatorDaos::DeletePage(const RPage& page)
+void ROOT::Experimental::Detail::RPageAllocatorDaos::DeletePage(const RPage &page)
 {
    if (page.IsNull())
       return;
    delete[] reinterpret_cast<unsigned char *>(page.GetBuffer());
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -381,9 +385,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::RPageSourceDaos(std::string_view nt
    fDaosContainer = std::make_unique<RDaosContainer>(pool, args.fContainerLabel);
 }
 
-
 ROOT::Experimental::Detail::RPageSourceDaos::~RPageSourceDaos() = default;
-
 
 ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDaos::AttachImpl()
 {
@@ -391,7 +393,11 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    RDaosNTupleAnchor ntpl;
    const auto ntplSize = RDaosNTupleAnchor::GetSize();
    auto buffer = std::make_unique<unsigned char[]>(ntplSize);
-   fDaosContainer->ReadSingleAkey(buffer.get(), ntplSize, kOidMetadata, kDistributionKeyDefault, kAttributeKeyAnchor,
+
+   daos_obj_id_t oidMetadata{kOidLowMetadata, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)};
+   daos_obj_id_t oidPageList{kOidLowPageList, static_cast<decltype(daos_obj_id_t::hi)>(fNTupleIndex)};
+
+   fDaosContainer->ReadSingleAkey(buffer.get(), ntplSize, oidMetadata, kDistributionKeyDefault, kAttributeKeyAnchor,
                                   kCidMetadata);
    ntpl.Deserialize(buffer.get(), ntplSize).Unwrap();
 
@@ -403,7 +409,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    descBuilder.SetOnDiskHeaderSize(ntpl.fNBytesHeader);
    buffer = std::make_unique<unsigned char[]>(ntpl.fLenHeader);
    auto zipBuffer = std::make_unique<unsigned char[]>(ntpl.fNBytesHeader);
-   fDaosContainer->ReadSingleAkey(zipBuffer.get(), ntpl.fNBytesHeader, kOidMetadata, kDistributionKeyDefault,
+   fDaosContainer->ReadSingleAkey(zipBuffer.get(), ntpl.fNBytesHeader, oidMetadata, kDistributionKeyDefault,
                                   kAttributeKeyHeader, kCidMetadata);
    fDecompressor->Unzip(zipBuffer.get(), ntpl.fNBytesHeader, ntpl.fLenHeader, buffer.get());
    Internal::RNTupleSerializer::DeserializeHeaderV1(buffer.get(), ntpl.fLenHeader, descBuilder);
@@ -411,7 +417,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    descBuilder.AddToOnDiskFooterSize(ntpl.fNBytesFooter);
    buffer = std::make_unique<unsigned char[]>(ntpl.fLenFooter);
    zipBuffer = std::make_unique<unsigned char[]>(ntpl.fNBytesFooter);
-   fDaosContainer->ReadSingleAkey(zipBuffer.get(), ntpl.fNBytesFooter, kOidMetadata, kDistributionKeyDefault,
+   fDaosContainer->ReadSingleAkey(zipBuffer.get(), ntpl.fNBytesFooter, oidMetadata, kDistributionKeyDefault,
                                   kAttributeKeyFooter, kCidMetadata);
    fDecompressor->Unzip(zipBuffer.get(), ntpl.fNBytesFooter, ntpl.fLenFooter, buffer.get());
    Internal::RNTupleSerializer::DeserializeFooterV1(buffer.get(), ntpl.fLenFooter, descBuilder);
@@ -421,7 +427,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    for (const auto &cgDesc : ntplDesc.GetClusterGroupIterable()) {
       buffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLength());
       zipBuffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLocator().fBytesOnStorage);
-      fDaosContainer->ReadSingleAkey(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, kOidPageList,
+      fDaosContainer->ReadSingleAkey(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, oidPageList,
                                      kDistributionKeyDefault, cgDesc.GetPageListLocator().fPosition, kCidMetadata);
       fDecompressor->Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
                            buffer.get());
@@ -436,15 +442,14 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
    return ntplDesc;
 }
 
-
 std::string ROOT::Experimental::Detail::RPageSourceDaos::GetObjectClass() const
 {
    return fDaosContainer->GetDefaultObjectClass().ToString();
 }
 
-
-void ROOT::Experimental::Detail::RPageSourceDaos::LoadSealedPage(
-   DescriptorId_t columnId, const RClusterIndex &clusterIndex, RSealedPage &sealedPage)
+void ROOT::Experimental::Detail::RPageSourceDaos::LoadSealedPage(DescriptorId_t columnId,
+                                                                 const RClusterIndex &clusterIndex,
+                                                                 RSealedPage &sealedPage)
 {
    const auto clusterId = clusterIndex.GetClusterId();
 
@@ -459,7 +464,8 @@ void ROOT::Experimental::Detail::RPageSourceDaos::LoadSealedPage(
    sealedPage.fSize = bytesOnStorage;
    sealedPage.fNElements = pageInfo.fNElements;
    if (sealedPage.fBuffer) {
-      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(clusterId, columnId, pageInfo.fLocator.fPosition);
+      RDaosKey daosKey =
+         GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId, pageInfo.fLocator.fPosition);
       fDaosContainer->ReadSingleAkey(const_cast<void *>(sealedPage.fBuffer), bytesOnStorage, daosKey.fOid,
                                      daosKey.fDkey, daosKey.fAkey);
    }
@@ -479,11 +485,12 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
    const auto bytesOnStorage = pageInfo.fLocator.fBytesOnStorage;
 
    const void *sealedPageBuffer = nullptr; // points either to directReadBuffer or to a read-only page in the cluster
-   std::unique_ptr<unsigned char []> directReadBuffer; // only used if cluster pool is turned off
+   std::unique_ptr<unsigned char[]> directReadBuffer; // only used if cluster pool is turned off
 
    if (fOptions.GetClusterCache() == RNTupleReadOptions::EClusterCache::kOff) {
       directReadBuffer = std::make_unique<unsigned char[]>(bytesOnStorage);
-      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(clusterId, columnId, pageInfo.fLocator.fPosition);
+      RDaosKey daosKey =
+         GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId, pageInfo.fLocator.fPosition);
       fDaosContainer->ReadSingleAkey(directReadBuffer.get(), bytesOnStorage, daosKey.fOid, daosKey.fDkey,
                                      daosKey.fAkey);
       fCounters->fNPageLoaded.Inc();
@@ -505,7 +512,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
       sealedPageBuffer = onDiskPage->GetAddress();
    }
 
-   std::unique_ptr<unsigned char []> pageBuffer;
+   std::unique_ptr<unsigned char[]> pageBuffer;
    {
       RNTupleAtomicTimer timer(fCounters->fTimeWallUnzip, fCounters->fTimeCpuUnzip);
       pageBuffer = UnsealPage({sealedPageBuffer, bytesOnStorage, pageInfo.fNElements}, *element);
@@ -515,18 +522,15 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
    auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), elementSize, pageInfo.fNElements);
    newPage.SetWindow(clusterInfo.fColumnOffset + pageInfo.fFirstInPage,
                      RPage::RClusterInfo(clusterId, clusterInfo.fColumnOffset));
-   fPagePool->RegisterPage(newPage,
-      RPageDeleter([](const RPage &page, void * /*userData*/)
-      {
-         RPageAllocatorDaos::DeletePage(page);
-      }, nullptr));
+   fPagePool->RegisterPage(
+      newPage,
+      RPageDeleter([](const RPage &page, void * /*userData*/) { RPageAllocatorDaos::DeletePage(page); }, nullptr));
    fCounters->fNPagePopulated.Inc();
    return newPage;
 }
 
-
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(
-   ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnHandle, NTupleSize_t globalIndex)
 {
    const auto columnId = columnHandle.fId;
    auto cachedPage = fPagePool->GetPage(columnId, globalIndex);
@@ -549,9 +553,9 @@ ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceDaos::P
    return PopulatePageFromCluster(columnHandle, clusterInfo, idxInCluster);
 }
 
-
-ROOT::Experimental::Detail::RPage ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(
-   ColumnHandle_t columnHandle, const RClusterIndex &clusterIndex)
+ROOT::Experimental::Detail::RPage
+ROOT::Experimental::Detail::RPageSourceDaos::PopulatePage(ColumnHandle_t columnHandle,
+                                                          const RClusterIndex &clusterIndex)
 {
    const auto clusterId = clusterIndex.GetClusterId();
    const auto idxInCluster = clusterIndex.GetIndex();
@@ -652,7 +656,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
          d_iov_t iov;
          d_iov_set(&iov, clusterBuffers[i] + s.fBufPos, s.fSize);
 
-         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(s.fClusterId, s.fColumnId, s.fObjectId);
+         RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, s.fClusterId, s.fColumnId, s.fObjectId);
          auto odPair = RDaosContainer::ROidDkeyPair{daosKey.fOid, daosKey.fDkey};
          auto [it, ret] = readRequests.emplace(odPair, RDaosContainer::RWOperation(odPair));
          it->second.insert(daosKey.fAkey, iov);
@@ -706,30 +710,26 @@ void ROOT::Experimental::Detail::RPageSourceDaos::UnzipClusterImpl(RCluster *clu
          auto onDiskPage = cluster->GetOnDiskPage(key);
          R__ASSERT(onDiskPage && (onDiskPage->GetSize() == pi.fLocator.fBytesOnStorage));
 
-         auto taskFunc =
-            [this, columnId, clusterId, firstInPage, onDiskPage,
-             element = allElements.back().get(),
-             nElements = pi.fNElements,
-             indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex
-            ] () {
-               auto pageBuffer = UnsealPage({onDiskPage->GetAddress(), onDiskPage->GetSize(), nElements}, *element);
-               fCounters->fSzUnzip.Add(element->GetSize() * nElements);
+         auto taskFunc = [this, columnId, clusterId, firstInPage, onDiskPage, element = allElements.back().get(),
+                          nElements = pi.fNElements,
+                          indexOffset = clusterDescriptor.GetColumnRange(columnId).fFirstElementIndex]() {
+            auto pageBuffer = UnsealPage({onDiskPage->GetAddress(), onDiskPage->GetSize(), nElements}, *element);
+            fCounters->fSzUnzip.Add(element->GetSize() * nElements);
 
-               auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), element->GetSize(), nElements);
-               newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
-               fPagePool->PreloadPage(newPage,
-                  RPageDeleter([](const RPage &page, void * /*userData*/)
-                  {
-                     RPageAllocatorDaos::DeletePage(page);
-                  }, nullptr));
-            };
+            auto newPage = fPageAllocator->NewPage(columnId, pageBuffer.release(), element->GetSize(), nElements);
+            newPage.SetWindow(indexOffset + firstInPage, RPage::RClusterInfo(clusterId, indexOffset));
+            fPagePool->PreloadPage(
+               newPage,
+               RPageDeleter([](const RPage &page, void * /*userData*/) { RPageAllocatorDaos::DeletePage(page); },
+                            nullptr));
+         };
 
          fTaskScheduler->AddTask(taskFunc);
 
          firstInPage += pi.fNElements;
          pageNo++;
       } // for all pages in column
-   } // for all columns in cluster
+   }    // for all columns in cluster
 
    fCounters->fNPagePopulated.Add(cluster->GetNOnDiskPages());
 

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -422,7 +422,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::RPageSourceDaos(std::string_view nt
 
    auto [locator, descBuilder] = RDaosContainerNTupleLocator::LocateNTuple(*fDaosContainer, fNTupleName, *fDecompressor);
 
-   if (!locator.fAnchor.has_value() || !locator.fAnchor->fNBytesHeader)
+   if (!locator.IsValid())
       throw ROOT::Experimental::RException(
          R__FAIL("Requested ntuple '" + fNTupleName + "' is not present in DAOS container."));
 

--- a/tree/ntuple/v7/test/ntuple_storage_daos.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage_daos.cxx
@@ -7,7 +7,8 @@ TEST(RPageStorageDaos, Basics)
 {
    ROOT::TestSupport::CheckDiagsRAII diags;
    diags.optionalDiag(kWarning, "in int daos_init()", "This RNTuple build uses libdaos_mock. Use only for testing!");
-   diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos", "The DAOS backend is experimental and still under development.", false);
+   diags.requiredDiag(kWarning, "ROOT::Experimental::Detail::RPageSinkDaos::RPageSinkDaos",
+                      "The DAOS backend is experimental and still under development.", false);
    diags.requiredDiag(kWarning, "[ROOT.NTuple]", "Pre-release format version: RC 1", false);
 
    std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-1");
@@ -17,7 +18,7 @@ TEST(RPageStorageDaos, Basics)
 
    {
       RNTupleWriteOptions options;
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", daosUri, options);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple-1", daosUri, options);
       ntuple->Fill();
       ntuple->CommitCluster();
       *wrPt = 24.0;
@@ -26,7 +27,7 @@ TEST(RPageStorageDaos, Basics)
       ntuple->Fill();
    }
 
-   auto ntuple = RNTupleReader::Open("f", daosUri);
+   auto ntuple = RNTupleReader::Open("ntuple-1", daosUri);
    EXPECT_EQ(3U, ntuple->GetNEntries());
    auto rdPt = ntuple->GetModel()->GetDefaultEntry()->Get<float>("pt");
 
@@ -49,13 +50,13 @@ TEST(RPageStorageDaos, Extended)
    double chksumWrite = 0.0;
    {
       RNTupleWriteOptions options;
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", daosUri, options);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple-2", daosUri, options);
       constexpr unsigned int nEvents = 32000;
       for (unsigned int i = 0; i < nEvents; ++i) {
          auto nVec = 1 + floor(rnd.Rndm() * 1000.);
          wrVector->resize(nVec);
          for (unsigned int n = 0; n < nVec; ++n) {
-            auto val = 1 + rnd.Rndm()*1000. - 500.;
+            auto val = 1 + rnd.Rndm() * 1000. - 500.;
             (*wrVector)[n] = val;
             chksumWrite += val;
          }
@@ -67,7 +68,7 @@ TEST(RPageStorageDaos, Extended)
 
    RNTupleReadOptions options;
    options.SetClusterBunchSize(5);
-   auto ntuple = RNTupleReader::Open("f", daosUri, options);
+   auto ntuple = RNTupleReader::Open("ntuple-2", daosUri, options);
    auto rdVector = ntuple->GetModel()->GetDefaultEntry()->Get<std::vector<double>>("vector");
 
    double chksumRead = 0.0;
@@ -89,9 +90,9 @@ TEST(RPageStorageDaos, Options)
       RNTupleWriteOptionsDaos options;
       options.SetObjectClass("UNKNOWN");
       try {
-         auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", daosUri, options);
+         auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple-3", daosUri, options);
          FAIL() << "unknown object class should throw";
-      } catch (const RException& err) {
+      } catch (const RException &err) {
          EXPECT_THAT(err.what(), testing::HasSubstr("UNKNOWN"));
       }
    }
@@ -102,16 +103,68 @@ TEST(RPageStorageDaos, Options)
 
       RNTupleWriteOptionsDaos options;
       options.SetObjectClass("RP_XSF");
-      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple", daosUri, options);
+      auto ntuple = RNTupleWriter::Recreate(std::move(model), "ntuple-3", daosUri, options);
       ntuple->Fill();
       ntuple->CommitCluster();
    }
 
    auto readOptions = RNTupleReadOptions();
    readOptions.SetClusterBunchSize(3);
-   ROOT::Experimental::Detail::RPageSourceDaos source("ntuple", daosUri, readOptions);
+   ROOT::Experimental::Detail::RPageSourceDaos source("ntuple-3", daosUri, readOptions);
    source.Attach();
    EXPECT_STREQ("RP_XSF", source.GetObjectClass().c_str());
    EXPECT_EQ(3U, source.GetReadOptions().GetClusterBunchSize());
    EXPECT_EQ(1U, source.GetNEntries());
+}
+
+TEST(RPageStorageDaos, MultipleNTuplesPerContainer)
+{
+   std::string daosUri("daos://" R__DAOS_TEST_POOL "/container-test-4");
+
+   RNTupleWriteOptions options;
+
+   {
+      auto modelA = RNTupleModel::Create();
+      auto wrPt = modelA->MakeField<float>("pt", 34.0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(modelA), "ntupleA", daosUri, options);
+      ntuple->Fill();
+      *wrPt = 160.0;
+      ntuple->Fill();
+   }
+   {
+      auto modelB = RNTupleModel::Create();
+      auto wrPt = modelB->MakeField<float>("pt", 81.0);
+      auto ntuple = RNTupleWriter::Recreate(std::move(modelB), "ntupleB", daosUri, options);
+      ntuple->Fill();
+      *wrPt = 96.0;
+      ntuple->Fill();
+      *wrPt = 54.0;
+      ntuple->Fill();
+   }
+   {
+      auto ntupleA = RNTupleReader::Open("ntupleA", daosUri);
+      auto ntupleB = RNTupleReader::Open("ntupleB", daosUri);
+      EXPECT_EQ(2U, ntupleA->GetNEntries());
+      EXPECT_EQ(3U, ntupleB->GetNEntries());
+
+      {
+         auto rdPt = ntupleA->GetModel()->GetDefaultEntry()->Get<float>("pt");
+         ntupleA->LoadEntry(0);
+         EXPECT_EQ(34.0, *rdPt);
+         ntupleA->LoadEntry(1);
+         EXPECT_EQ(160.0, *rdPt);
+      }
+      {
+         auto rdPt = ntupleB->GetModel()->GetDefaultEntry()->Get<float>("pt");
+         ntupleB->LoadEntry(0);
+         EXPECT_EQ(81.0, *rdPt);
+         ntupleB->LoadEntry(1);
+         EXPECT_EQ(96.0, *rdPt);
+         ntupleB->LoadEntry(2);
+         EXPECT_EQ(54.0, *rdPt);
+      }
+   }
+
+   // Nonexistent ntuple
+   EXPECT_THROW(RNTupleReader::Open("ntupleC", daosUri), ROOT::Experimental::RException);
 }


### PR DESCRIPTION
This pull request introduces ntuple management at the DAOS container level, extending support for more than one ntuple to populate a container.

## Changes or fixes:
- Support for up to 2\^32 - 1 ntuples in a DAOS container, by assigning an index to a previously-unused portion of the DAOS Object ID address space. The index thus induces a subspace dedicated for all objects belonging to a given ntuple. The zeroth space (index `0`) is reserved for any container-wide metadata objects that may need to be stored in the future.
- `ROOT::Experimental::Detail::RDaosContainerNTupleLocator` is a structure that concentrates the functionality for locating and retrieving stored metadata from an ntuple by its name.
- The structure hashes the name into a well-distributed 32-bit index. Collisions are expressly forbidden to simplify implementation; a different ntuple name must be provided to the sink upon creation if an ntuple stored in the container with another name happens to have the same hash (index).
- The sink (in `RPageSinkDaos` ctor) uses the locator to assign an index for a new ntuple, which may fail if the name's resulting hash collides with some other ntuple present unless the name matches. Overwriting ("recreating") an existing ntuple is allowed in this context.
- The source (in `RPageSourceDaos::AttachImpl()`) locates the ntuple by the name to validate that it is indeed present in storage (otherwise, an exception is thrown). The objects that are read for this validation are reused as part of the ntuple metadata deserialization procedure when attaching. 
- Unit test coverage is provided for the following cases: write and read from different ntuples in a container; and attempt to open an ntuple that was not stored there.

## Checklist:

- [x] tested changes locally + cluster on single client with libdaos 2.2.0
- [x] updated the docs (if necessary)

This PR fixes #10958

