### PR TITLE
[tmva][sofie] Move parser definition for operators in implementation

### DIFF
--- a/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
+++ b/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
@@ -23,100 +23,10 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
-namespace INTERNAL{
-
-std::unique_ptr<ROperator> make_ROperator_Transpose(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Relu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Tanh(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_LeakyRelu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Selu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Sigmoid(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Gemm(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Conv(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_RNN(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_LSTM(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_BatchNormalization(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Pool(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_GemmFromMatMulandAdd(const onnx::NodeProto& nodeproto1,const onnx::NodeProto& nodeproto2, const onnx::GraphProto& graphproto , std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_FuseConvTransposeAdd(const onnx::NodeProto& convnode, const onnx::NodeProto& addnode, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_FuseConvAdd(const onnx::NodeProto& convnode, const onnx::NodeProto& addnode, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Reshape(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Slice(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_GRU(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-template<EBasicUnaryOperator Op>
-std::unique_ptr<ROperator> make_ROperator_BasicUnary(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-template <EBasicBinaryOperator Op1>
-std::unique_ptr<ROperator> make_ROperator_BasicBinary(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Identity(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Softmax(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Max(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Concat(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Cast(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-template <EReduceOpMode Op1>
-std::unique_ptr<ROperator> make_ROperator_Reduce(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Shape(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_ConvTranspose(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-
-using factoryMethodMap = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(const onnx::NodeProto&, const onnx::GraphProto&, std::unordered_map<std::string, ETensorType>&)>;
-const factoryMethodMap mapOptypeOperator = {
-   {"Gemm", &make_ROperator_Gemm},
-   {"Transpose", &make_ROperator_Transpose},
-   {"Relu", &make_ROperator_Relu},
-   {"Tanh", &make_ROperator_Tanh},
-   {"LeakyRelu", &make_ROperator_LeakyRelu},
-   {"Conv", &make_ROperator_Conv},
-   {"RNN", &make_ROperator_RNN},
-   {"Selu", &make_ROperator_Selu},
-   {"Sigmoid", &make_ROperator_Sigmoid},
-   {"LSTM", &make_ROperator_LSTM},
-   {"GRU", &make_ROperator_GRU},
-   {"BatchNormalization", &make_ROperator_BatchNormalization},
-   {"AveragePool", &make_ROperator_Pool},
-   {"GlobalAveragePool", &make_ROperator_Pool},
-   {"MaxPool", &make_ROperator_Pool},
-   {"Sqrt", &make_ROperator_BasicUnary<EBasicUnaryOperator::kSqrt>},
-   {"Reciprocal", &make_ROperator_BasicUnary<EBasicUnaryOperator::kReciprocal>},
-   {"Neg", &make_ROperator_BasicUnary<EBasicUnaryOperator::kNeg>},
-   {"Exp", &make_ROperator_BasicUnary<EBasicUnaryOperator::kExp>},
-   {"Add", &make_ROperator_BasicBinary<Add>},
-   {"Sub", &make_ROperator_BasicBinary<Sub>},
-   {"Mul", &make_ROperator_BasicBinary<Mul>},
-   {"Div", &make_ROperator_BasicBinary<Div>},
-   {"Pow", &make_ROperator_BasicBinary<Pow>},
-   {"ReduceMean", &make_ROperator_Reduce<ReduceMean>},
-   {"ReduceSumsquare", &make_ROperator_Reduce<ReduceSumsquare>},
-   {"ReduceProd", &make_ROperator_Reduce<ReduceProd>},
-   {"Reshape", &make_ROperator_Reshape},
-   {"Flatten", &make_ROperator_Reshape},
-   {"Slice", &make_ROperator_Slice},
-   {"Squeeze", &make_ROperator_Reshape},
-   {"Unsqueeze", &make_ROperator_Reshape},
-   {"Flatten", &make_ROperator_Reshape},
-   {"Identity", &make_ROperator_Identity},
-   {"Softmax", &make_ROperator_Softmax},
-   {"Concat", &make_ROperator_Concat},
-   {"Cast", &make_ROperator_Cast},
-   {"Max", &make_ROperator_Max},
-   {"Shape", &make_ROperator_Shape},
-   {"ConvTranspose", &make_ROperator_ConvTranspose}
-};
-
-using factoryMethodMap1 = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(const onnx::NodeProto&,const onnx::NodeProto&, const onnx::GraphProto&, std::unordered_map<std::string, ETensorType>&)>;
-const factoryMethodMap1 mapOptypeOperator1 = {
-    {"MatMul", &make_ROperator_GemmFromMatMulandAdd},
-    {"Conv", &make_ROperator_FuseConvAdd},
-    {"ConvTranspose", &make_ROperator_FuseConvTransposeAdd}
-};
-std::unique_ptr<ROperator> make_ROperator(size_t idx, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-}//INTERNAL
-
-
-
 class RModelParser_ONNX{
 public:
    RModel Parse(std::string filename, bool verbose = false);
 };
-
 
 
 }//SOFIE

--- a/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
+++ b/tmva/sofie_parsers/src/RModelParser_ONNX.cxx
@@ -13,6 +13,95 @@ namespace SOFIE{
 
 namespace INTERNAL{
 
+
+std::unique_ptr<ROperator> make_ROperator_Transpose(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Relu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Tanh(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_LeakyRelu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Selu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Sigmoid(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Gemm(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Conv(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_RNN(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_LSTM(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_BatchNormalization(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Pool(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_GemmFromMatMulandAdd(const onnx::NodeProto& nodeproto1,const onnx::NodeProto& nodeproto2, const onnx::GraphProto& graphproto , std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_FuseConvTransposeAdd(const onnx::NodeProto& convnode, const onnx::NodeProto& addnode, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_FuseConvAdd(const onnx::NodeProto& convnode, const onnx::NodeProto& addnode, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Reshape(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Slice(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_GRU(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+template<EBasicUnaryOperator Op>
+std::unique_ptr<ROperator> make_ROperator_BasicUnary(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+template <EBasicBinaryOperator Op1>
+std::unique_ptr<ROperator> make_ROperator_BasicBinary(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Identity(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Softmax(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Max(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Concat(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Cast(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+template <EReduceOpMode Op1>
+std::unique_ptr<ROperator> make_ROperator_Reduce(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_Shape(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+std::unique_ptr<ROperator> make_ROperator_ConvTranspose(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
+
+using factoryMethodMap = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(const onnx::NodeProto&, const onnx::GraphProto&, std::unordered_map<std::string, ETensorType>&)>;
+const factoryMethodMap mapOptypeOperator = {
+   {"Gemm", &make_ROperator_Gemm},
+   {"Transpose", &make_ROperator_Transpose},
+   {"Relu", &make_ROperator_Relu},
+   {"Tanh", &make_ROperator_Tanh},
+   {"LeakyRelu", &make_ROperator_LeakyRelu},
+   {"Conv", &make_ROperator_Conv},
+   {"RNN", &make_ROperator_RNN},
+   {"Selu", &make_ROperator_Selu},
+   {"Sigmoid", &make_ROperator_Sigmoid},
+   {"LSTM", &make_ROperator_LSTM},
+   {"GRU", &make_ROperator_GRU},
+   {"BatchNormalization", &make_ROperator_BatchNormalization},
+   {"AveragePool", &make_ROperator_Pool},
+   {"GlobalAveragePool", &make_ROperator_Pool},
+   {"MaxPool", &make_ROperator_Pool},
+   {"Sqrt", &make_ROperator_BasicUnary<EBasicUnaryOperator::kSqrt>},
+   {"Reciprocal", &make_ROperator_BasicUnary<EBasicUnaryOperator::kReciprocal>},
+   {"Neg", &make_ROperator_BasicUnary<EBasicUnaryOperator::kNeg>},
+   {"Exp", &make_ROperator_BasicUnary<EBasicUnaryOperator::kExp>},
+   {"Add", &make_ROperator_BasicBinary<Add>},
+   {"Sub", &make_ROperator_BasicBinary<Sub>},
+   {"Mul", &make_ROperator_BasicBinary<Mul>},
+   {"Div", &make_ROperator_BasicBinary<Div>},
+   {"Pow", &make_ROperator_BasicBinary<Pow>},
+   {"ReduceMean", &make_ROperator_Reduce<ReduceMean>},
+   {"ReduceSumsquare", &make_ROperator_Reduce<ReduceSumsquare>},
+   {"ReduceProd", &make_ROperator_Reduce<ReduceProd>},
+   {"Reshape", &make_ROperator_Reshape},
+   {"Flatten", &make_ROperator_Reshape},
+   {"Slice", &make_ROperator_Slice},
+   {"Squeeze", &make_ROperator_Reshape},
+   {"Unsqueeze", &make_ROperator_Reshape},
+   {"Flatten", &make_ROperator_Reshape},
+   {"Identity", &make_ROperator_Identity},
+   {"Softmax", &make_ROperator_Softmax},
+   {"Concat", &make_ROperator_Concat},
+   {"Cast", &make_ROperator_Cast},
+   {"Max", &make_ROperator_Max},
+   {"Shape", &make_ROperator_Shape},
+   {"ConvTranspose", &make_ROperator_ConvTranspose}
+};
+
+using factoryMethodMap1 = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(const onnx::NodeProto&,const onnx::NodeProto&, const onnx::GraphProto&, std::unordered_map<std::string, ETensorType>&)>;
+const factoryMethodMap1 mapOptypeOperator1 = {
+    {"MatMul", &make_ROperator_GemmFromMatMulandAdd},
+    {"Conv", &make_ROperator_FuseConvAdd},
+    {"ConvTranspose", &make_ROperator_FuseConvTransposeAdd}
+};
+
+std::unique_ptr<ROperator> make_ROperator(size_t idx, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
+
+
+
+
 std::unique_ptr<ROperator> make_ROperator(size_t i, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type, const std::vector<int> & nodes){
    int idx = (nodes.size() > i) ? nodes[i] : (int) i;
    const auto& nodeproto = graphproto.node(idx);
@@ -1482,8 +1571,8 @@ std::unique_ptr<ROperator> make_ROperator_Shape(const onnx::NodeProto& nodeproto
    auto input_name =  nodeproto.input(0);
    auto it = tensor_type.find(input_name);
 
-   if (it == tensor_type.end()){ 
-      throw std::runtime_error("TMVA::SOFIE ONNX Parser Shape op has input tensor" + input_name + " but its type is not yet registered"); 
+   if (it == tensor_type.end()){
+      throw std::runtime_error("TMVA::SOFIE ONNX Parser Shape op has input tensor" + input_name + " but its type is not yet registered");
    }
 
    std::unique_ptr<ROperator> op;
@@ -1500,7 +1589,7 @@ std::unique_ptr<ROperator> make_ROperator_Shape(const onnx::NodeProto& nodeproto
    }
 
    op.reset(new ROperator_Shape(attr_start, attr_end, nodeproto.input(0), nodeproto.output(0)));
-   
+
    ETensorType output_type = ETensorType::INT64;
    auto it2 = tensor_type.find(nodeproto.output(0));
    if (it2 == tensor_type.end()){


### PR DESCRIPTION
Move definition of free function defining the parser operator functions in the implementation, since these are only for internal use

This should fix some of the issues seen when using PCH


