### PR TITLE
[RF] More fixes and unit tests related to the RooAddPdf normalization

### DIFF
--- a/roofit/roofitcore/inc/RooAddModel.h
+++ b/roofit/roofitcore/inc/RooAddModel.h
@@ -94,7 +94,6 @@ protected:
   mutable RooSetProxy _refCoefNorm ;   ///<! Reference observable set for coefficient interpretation
   mutable TNamed* _refCoefRangeName = nullptr;  ///<! Reference range name for coefficient interpretation
 
-  bool _projectCoefs = false;  ///< If true coefficients need to be projected for use in evaluate()
   mutable std::vector<double> _coefCache; ///<! Transiet cache with transformed values of coefficients
 
 
@@ -128,7 +127,7 @@ protected:
 
 private:
 
-  ClassDefOverride(RooAddModel,2) // Resolution model representing a sum of resolution models
+  ClassDefOverride(RooAddModel,3) // Resolution model representing a sum of resolution models
 };
 
 #endif

--- a/roofit/roofitcore/inc/RooAddPdf.h
+++ b/roofit/roofitcore/inc/RooAddPdf.h
@@ -100,7 +100,6 @@ protected:
   mutable RooSetProxy _refCoefNorm ;   ///< Reference observable set for coefficient interpretation
   mutable TNamed* _refCoefRangeName = nullptr ;  ///< Reference range name for coefficient interpreation
 
-  bool _projectCoefs = false;     ///< If true coefficients need to be projected for use in evaluate()
   mutable std::vector<double> _coefCache; ///<! Transient cache with transformed values of coefficients
 
 
@@ -144,7 +143,7 @@ private:
 
   void finalizeConstruction();
 
-  ClassDefOverride(RooAddPdf,4) // PDF representing a sum of PDFs
+  ClassDefOverride(RooAddPdf,5) // PDF representing a sum of PDFs
 };
 
 #endif

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -3386,6 +3386,20 @@ RooAbsPdf::GenSpec::GenSpec(RooAbsGenContext* context, const RooArgSet& whatVars
 }
 
 
+namespace {
+
+void sterilizeClientCaches(RooAbsArg & arg) {
+  for(auto const& client : arg.clients()) {
+    for(int iCache = 0; iCache < client->numCaches(); ++iCache) {
+      if(auto cacheMgr = dynamic_cast<RooObjCacheManager*>(client->getCache(iCache))) {
+        cacheMgr->sterilize();
+      }
+    }
+  }
+}
+
+} // namespace
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -3396,6 +3410,9 @@ void RooAbsPdf::setNormRange(const char* rangeName)
   } else {
     _normRange.Clear() ;
   }
+
+  // the stuff that the clients have cached may depend on the normalization range
+  sterilizeClientCaches(*this);
 
   if (_norm) {
     _normMgr.sterilize() ;
@@ -3413,6 +3430,9 @@ void RooAbsPdf::setNormRangeOverride(const char* rangeName)
   } else {
     _normRangeOverride.Clear() ;
   }
+
+  // the stuff that the clients have cached may depend on the normalization range
+  sterilizeClientCaches(*this);
 
   if (_norm) {
     _normMgr.sterilize() ;

--- a/roofit/roofitcore/src/RooAddHelpers.h
+++ b/roofit/roofitcore/src/RooAddHelpers.h
@@ -21,8 +21,8 @@ class RooArgSet;
 class AddCacheElem : public RooAbsCacheElement {
 public:
    AddCacheElem(RooAbsPdf const &addPdf, RooArgList const &pdfList, RooArgList const &coefList, const RooArgSet *nset,
-                const RooArgSet *iset, bool projectCoefs, RooArgSet const &refCoefNormSet,
-                std::string const &refCoefNormRange, int verboseEval);
+                const RooArgSet *iset, RooArgSet const &refCoefNormSet, std::string const &refCoefNormRange,
+                int verboseEval);
 
    RooArgList containedArgs(Action) override;
 
@@ -56,7 +56,7 @@ private:
 class RooAddHelpers {
 public:
    static void updateCoefficients(RooAbsPdf const &addPdf, std::vector<double> &coefCache, RooArgList const &pdfList,
-                                  bool haveLastCoef, AddCacheElem &cache, const RooArgSet *nset, bool projectCoefs,
+                                  bool haveLastCoef, AddCacheElem &cache, const RooArgSet *nset,
                                   RooArgSet const &refCoefNormSet, bool allExtendable, int &coefErrCount);
 };
 

--- a/roofit/roofitcore/src/RooAddModel.cxx
+++ b/roofit/roofitcore/src/RooAddModel.cxx
@@ -81,7 +81,6 @@ RooAddModel::RooAddModel(const char *name, const char *title, const RooArgList& 
   RooResolutionModel(name,title,(static_cast<RooResolutionModel*>(inPdfList.at(0)))->convVar()),
   _refCoefNorm("!refCoefNorm","Reference coefficient normalization set",this,false,false),
   _refCoefRangeName(0),
-  _projectCoefs(false),
   _projCacheMgr(this,10),
   _intCacheMgr(this,10),
   _codeReg(10),
@@ -162,7 +161,6 @@ RooAddModel::RooAddModel(const RooAddModel& other, const char* name) :
   RooResolutionModel(other,name),
   _refCoefNorm("!refCoefNorm",this,other._refCoefNorm),
   _refCoefRangeName((TNamed*)other._refCoefRangeName),
-  _projectCoefs(other._projectCoefs),
   _projCacheMgr(other._projCacheMgr,this),
   _intCacheMgr(other._intCacheMgr,this),
   _codeReg(other._codeReg),
@@ -189,10 +187,8 @@ RooAddModel::RooAddModel(const RooAddModel& other, const char* name) :
 void RooAddModel::fixCoefNormalization(const RooArgSet& refCoefNorm)
 {
   if (refCoefNorm.empty()) {
-    _projectCoefs = false ;
     return ;
   }
-  _projectCoefs = true ;
 
   _refCoefNorm.removeAll() ;
   _refCoefNorm.add(refCoefNorm) ;
@@ -216,7 +212,6 @@ void RooAddModel::fixCoefNormalization(const RooArgSet& refCoefNorm)
 void RooAddModel::fixCoefRange(const char* rangeName)
 {
   _refCoefRangeName = (TNamed*)RooNameReg::ptr(rangeName) ;
-  if (_refCoefRangeName) _projectCoefs = true ;
 }
 
 
@@ -320,8 +315,7 @@ AddCacheElem* RooAddModel::getProjCache(const RooArgSet* nset, const RooArgSet* 
   }
 
   //Create new cache
-  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset,
-                           _projectCoefs, _refCoefNorm,
+  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset, _refCoefNorm,
                            _refCoefRangeName ? RooNameReg::str(_refCoefRangeName) : "",
                            _verboseEval};
 
@@ -343,7 +337,7 @@ void RooAddModel::updateCoefficients(AddCacheElem& cache, const RooArgSet* nset)
   for(std::size_t i = 0; i < _coefList.size(); ++i) {
     _coefCache[i] = static_cast<RooAbsReal const&>(_coefList[i]).getVal(nset);
   }
-  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset, _projectCoefs,
+  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset,
                                     _refCoefNorm, _allExtendable, _coefErrCount);
 }
 

--- a/roofit/roofitcore/src/RooAddPdf.cxx
+++ b/roofit/roofitcore/src/RooAddPdf.cxx
@@ -281,7 +281,6 @@ RooAddPdf::RooAddPdf(const RooAddPdf& other, const char* name) :
   RooAbsPdf(other,name),
   _refCoefNorm("!refCoefNorm",this,other._refCoefNorm),
   _refCoefRangeName((TNamed*)other._refCoefRangeName),
-  _projectCoefs(other._projectCoefs),
   _projCacheMgr(other._projCacheMgr,this),
   _codeReg(other._codeReg),
   _pdfList("!pdfs",this,other._pdfList),
@@ -309,10 +308,8 @@ RooAddPdf::RooAddPdf(const RooAddPdf& other, const char* name) :
 void RooAddPdf::fixCoefNormalization(const RooArgSet& refCoefNorm)
 {
   if (refCoefNorm.empty()) {
-    _projectCoefs = false ;
     return ;
   }
-  _projectCoefs = true ;
 
   _refCoefNorm.removeAll() ;
   _refCoefNorm.add(refCoefNorm) ;
@@ -340,7 +337,6 @@ void RooAddPdf::fixCoefRange(const char* rangeName)
     _projCacheMgr.reset() ;
   }
   _refCoefRangeName = newNamePtr;
-  if (_refCoefRangeName) _projectCoefs = true ;
 }
 
 
@@ -365,10 +361,12 @@ AddCacheElem* RooAddPdf::getProjCache(const RooArgSet* nset, const RooArgSet* is
   }
 
   //Create new cache
-  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset,
-                           _projectCoefs, _refCoefNorm,
+  cache = new AddCacheElem{*this, _pdfList, _coefList, nset, iset, _refCoefNorm,
                            _refCoefRangeName ? RooNameReg::str(_refCoefRangeName) : "",
                            _verboseEval};
+  //std::cout << std::endl;
+  //cache->print();
+  //std::cout << std::endl;
 
   _projCacheMgr.setObj(nset,iset,cache,RooNameReg::ptr(normRange())) ;
 
@@ -398,7 +396,7 @@ void RooAddPdf::updateCoefficients(AddCacheElem& cache, const RooArgSet* nset, b
       _coefCache[i] = static_cast<RooAbsReal const&>(_coefList[i]).getVal(nset);
     }
   }
-  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset, _projectCoefs,
+  RooAddHelpers::updateCoefficients(*this, _coefCache, _pdfList, _haveLastCoef, cache, nset,
                                     _refCoefNorm, _allExtendable, _coefErrCount);
 }
 


### PR DESCRIPTION
The commit implements a few new unit tests and also fixes one bug related to the normalization of a RooAddPdf when the custom normalization set of its components is reset.

There is also some code improvement by removing a redundant data member of the `RooAddPdf` and `RooAddModel` classes.


More details in the commit descriptions.

