### PR TITLE
[skip-ci][Windows] Fix root-config.bat

### DIFF
--- a/config/root-config.bat.in
+++ b/config/root-config.bat.in
@@ -75,7 +75,10 @@ for %%w in (%*) do (
       for %%f in (%features%) do (
          if %%f==!feature! (
             set res=%%f
-            set out=!out! yes
+            if not "!out!"=="" (
+               set out=!out! 
+            )
+            set out=!out!yes
          )
       )
       if !res!=="" (
@@ -86,10 +89,13 @@ for %%w in (%*) do (
          )
          if !known!=="" (
             set out=!out! --has-!feature!: unknown feature^^!
+            set err=1
          ) else (
-            set out=!out! no
+            if not "!out!"=="" (
+               set out=!out! 
+            )
+            set out=!out!no
          )
-         set err=1
       )
    )
    if "!arg!"=="--version" (


### PR DESCRIPTION
Fix the output of `root-config.bat` that makes several TMVA tests failing due to extra spaces
