### PR TITLE
[RF] Fix `RooFit::Link()` pythonization and pythonize RooSimultaneous constructor

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
@@ -205,7 +205,7 @@ def Link(*args, **kwargs):
     if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], dict):
         args = list(args)
         args[0] = _dict_to_std_map(args[0], {"std::string": "RooAbsData*"})
-        return RooFit._Import(args[0])
+        return RooFit._Link(args[0])
 
     return RooFit._Link(*args, **kwargs)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
@@ -11,7 +11,7 @@
 ################################################################################
 
 
-from ._utils import _kwargs_to_roocmdargs, cpp_signature
+from ._utils import _kwargs_to_roocmdargs, cpp_signature, _dict_to_std_map
 
 
 class RooSimultaneous(object):
@@ -26,6 +26,19 @@ class RooSimultaneous(object):
     simPdf.plotOn(frame, Slice=(sample, "control"), ProjWData=(sampleSet, combData))
     \endcode
     """
+
+    @cpp_signature(
+        "RooSimultaneous(const char *name, const char *title,"
+        "                std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;"
+    )
+    def __init__(self, *args):
+        r"""The RooSimultaneous constructor that takes a map of category names
+        to PDFs is accepting a Python dictionary in Python.
+        """
+        if len(args) >= 3 and isinstance(args[2], dict):
+            args = list(args)
+            args[2] = _dict_to_std_map(args[2], {"std::string": "RooAbsPdf*"})
+        self._init(*args)
 
     @cpp_signature(
         "RooPlot *RooSimultaneous::plotOn(RooPlot* frame,"

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -156,6 +156,7 @@ if(roofit)
 
     # Other pythonizations that fail on Windows for unknown reasons
     ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_roosimultaneous roofit/roosimultaneous.py)
   endif()
 
   # NumPy compatibility

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -149,11 +149,13 @@ if(roofit)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabsreal_ploton roofit/rooabsreal_ploton.py)
 
   ROOT_ADD_PYUNITTEST(pyroot_roofit_roolinkedlist roofit/roolinkedlist.py)
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
 
   if(NOT MSVC OR win_broken_tests)
     # Test pythonizations for the RooFitHS3 package, which is not built on Windows.
     ROOT_ADD_PYUNITTEST(pyroot_roofit_roojsonfactorywstool roofit/roojsonfactorywstool.py)
+
+    # Other pythonizations that fail on Windows for unknown reasons
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
   endif()
 
   # NumPy compatibility

--- a/bindings/pyroot/pythonizations/test/roofit/rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooglobalfunc.py
@@ -26,7 +26,26 @@ class TestRooGlobalFunc(unittest.TestCase):
         self.assertEqual(code(ROOT.kRed), code("r"))
 
         # Check that postfix operations applied to ROOT color codes work
-        self.assertEqual(code(ROOT.kRed+1), code("kRed+1"))
+        self.assertEqual(code(ROOT.kRed + 1), code("kRed+1"))
+
+    def test_roodataset_link(self):
+        """Test that the RooFit.Link() command argument works as expected in
+        the RooDataSet constructor.
+        Inspired by the reproducer code in GitHub issue #11469.
+        """
+        x = ROOT.RooRealVar("x", "", 0, 1)
+        g = ROOT.RooGaussian("g", "", x, ROOT.RooFit.RooConst(0.5), ROOT.RooFit.RooConst(0.2))
+
+        n_events = 1000
+
+        data = g.generate({x}, NumEvents=n_events)
+
+        sample = ROOT.RooCategory("cat", "cat")
+        sample.defineType("cat_0")
+
+        data_2 = ROOT.RooDataSet("data_2", "data_2", {x}, Index=sample, Link={"cat_0": data})
+
+        self.assertEqual(data_2.numEntries(), n_events)
 
 
 if __name__ == "__main__":

--- a/bindings/pyroot/pythonizations/test/roofit/roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roosimultaneous.py
@@ -1,0 +1,33 @@
+import unittest
+import ROOT
+
+
+class RooSimultaneous_test(unittest.TestCase):
+    """
+    Test for the pythonizations of RooSimultaneous.
+    """
+
+    # Tests
+    def test_construction_from_dict(self):
+
+        x = ROOT.RooRealVar("x", "x", -10, 10)
+
+        # Define model for each sample
+        model = ROOT.RooGaussian("model", "model", x, ROOT.RooFit.RooConst(1.0), ROOT.RooFit.RooConst(1.0))
+        model_ctl = ROOT.RooGaussian("model_ctl", "model_ctl", x, ROOT.RooFit.RooConst(-1.0), ROOT.RooFit.RooConst(1.0))
+
+        # Define category to distinguish physics and control samples events
+        sample = ROOT.RooCategory("sample", "sample")
+        sample.defineType("physics")
+        sample.defineType("control")
+
+        # Construct the RooSimultaneous
+        sim_pdf = ROOT.RooSimultaneous("simPdf", "simultaneous pdf", {"physics": model, "control": model_ctl}, sample)
+
+        # Verify that the PDF ends up with the right PDFs in the right categories
+        self.assertEqual(sim_pdf.getPdf("physics").GetName(), "model")
+        self.assertEqual(sim_pdf.getPdf("control").GetName(), "model_ctl")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tutorials/roofit/rf102_dataimport.py
+++ b/tutorials/roofit/rf102_dataimport.py
@@ -56,8 +56,7 @@ dh = ROOT.RooDataHist("dh", "dh", [x], Import=hh)
 
 # Plot and fit a RooDataHist
 # ---------------------------------------------------
-# Make plot of binned dataset showing Poisson error bars (ROOT.RooFit
-# default)
+# Make plot of binned dataset showing Poisson error bars (RooFit default)
 frame = x.frame(Title="Imported ROOT.TH1 with Poisson error bars")
 dh.plotOn(frame)
 
@@ -102,7 +101,7 @@ y = ROOT.RooRealVar("y", "y", -10, 10)
 # and RRV y defines a range [-10,10] this means that the ROOT.RooDataSet
 # below will have less entries than the ROOT.TTree 'tree'
 
-ds = ROOT.RooDataSet("ds", "ds", {x, y}, ROOT.RooFit.Import(tree))
+ds = ROOT.RooDataSet("ds", "ds", {x, y}, Import=tree)
 
 # Use ascii import/export for datasets
 # ------------------------------------------------------------------------------------

--- a/tutorials/roofit/rf309_ndimplot.py
+++ b/tutorials/roofit/rf309_ndimplot.py
@@ -38,7 +38,7 @@ data = model.generate({x, y}, 10000)
 hh_data = data.createHistogram("x,y", x, Binning=20, YVar=dict(var=y, Binning=20))
 
 # Create and fill ROOT 2D histogram (50x50 bins) with sampling of pdf
-# hh_pdf = model.createHistogram("hh_model",x, ROOT.RooFit.Binning(50), ROOT.RooFit.YVar(y, ROOT.RooFit.Binning(50)))
+# hh_pdf = model.createHistogram("hh_model", x, Binning=50, YVar=dict(var=y, Binning=50))
 hh_pdf = model.createHistogram("x,y", 50, 50)
 hh_pdf.SetLineColor(ROOT.kBlue)
 
@@ -57,7 +57,7 @@ data3 = model3.generate({x, y, z}, 10000)
 # -------------------------------------------------------------
 
 # Create and fill ROOT 2D histogram (8x8x8 bins) with contents of dataset
-# hh_data3 = data3.createHistogram("hh_data3", x, ROOT.RooFit.Binning(8), ROOT.RooFit.YVar(y, ROOT.RooFit.Binning(8)), ROOT.RooFit.ZVar(z, ROOT.RooFit.Binning(8)))
+# hh_data3 = data3.createHistogram("hh_data3", x, Binning=8, YVar=(var=y, Binning=8), ZVar=(var=z, Binning=8))
 hh_data3 = data3.createHistogram(
     "hh_data3",
     x,

--- a/tutorials/roofit/rf401_importttreethx.py
+++ b/tutorials/roofit/rf401_importttreethx.py
@@ -117,14 +117,6 @@ dsC = ds2.reduce({x, y}, "z>5")
 
 # Create a dataset that imports contents of all the above datasets mapped
 # by index category c
-dsABC = ROOT.RooDataSet(
-    "dsABC",
-    "dsABC",
-    {x, y},
-    ROOT.RooFit.Import("SampleA", dsA),
-    ROOT.RooFit.Import("SampleB", dsB),
-    Index=c,
-    Import=("SampleC", dsC),
-)
+dsABC = ROOT.RooDataSet("dsABC", "dsABC", {x, y}, Index=c, Import={"SampleA": dsA, "SampleB": dsB, "SampleC": dsC})
 
 dsABC.Print()

--- a/tutorials/roofit/rf501_simultaneouspdf.C
+++ b/tutorials/roofit/rf501_simultaneouspdf.C
@@ -84,18 +84,16 @@ void rf501_simultaneouspdf()
    // C o n s t r u c t   a   s i m u l t a n e o u s   p d f   i n   ( x , s a m p l e )
    // -----------------------------------------------------------------------------------
 
-   // Construct a simultaneous pdf using category sample as index
-   RooSimultaneous simPdf("simPdf", "simultaneous pdf", sample);
-
-   // Associate model with the physics state and model_ctl with the control state
-   simPdf.addPdf(model, "physics");
-   simPdf.addPdf(model_ctl, "control");
+   // Construct a simultaneous pdf using category sample as index:
+   // associate model with the physics state and model_ctl with the control state
+   RooSimultaneous simPdf("simPdf", "simultaneous pdf", {{"physics", &model}, {"control", &model_ctl}}, sample);
 
    // P e r f o r m   a   s i m u l t a n e o u s   f i t
    // ---------------------------------------------------
 
    // Perform simultaneous fit of model to data and model_ctl to data_ctl
-   simPdf.fitTo(combData);
+   std::unique_ptr<RooFitResult> fitResult{simPdf.fitTo(combData, PrintLevel(-1), Save())};
+   fitResult->Print();
 
    // P l o t   m o d e l   s l i c e s   o n   d a t a    s l i c e s
    // ----------------------------------------------------------------

--- a/tutorials/roofit/rf509_wsinteractive.py
+++ b/tutorials/roofit/rf509_wsinteractive.py
@@ -92,7 +92,7 @@ d.plotOn(frame)
 #
 # using namespace w
 # model.plotOn(frame)
-# model.plotOn(frame, ROOT.RooFit.Components(bkg), ROOT.RooFit.LineStyle(ROOT.kDashed))
+# model.plotOn(frame, Components=bkg, LineStyle="--")
 
 # correct syntax
 bkg = w["bkg"]

--- a/tutorials/roofit/rf802_mcstudy_addons.py
+++ b/tutorials/roofit/rf802_mcstudy_addons.py
@@ -31,7 +31,7 @@ gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
 
 # Create study manager for binned likelihood fits of a Gaussian pdf in 10
 # bins
-mcs = ROOT.RooMCStudy(gauss, {x}, ROOT.RooFit.Silence(), ROOT.RooFit.Binned())
+mcs = ROOT.RooMCStudy(gauss, {x}, Silence=True, Binned=True)
 
 # Add chi^2 calculator module to mcs
 chi2mod = ROOT.RooChi2MCSModule()
@@ -45,8 +45,8 @@ nBins = 100
 
 # Fill histograms with distributions chi2 and prob(chi2,ndf) that
 # are calculated by ROOT.RooChiMCSModule
-hist_chi2 = mcs.fitParDataSet().createHistogram("chi2", ROOT.RooFit.AutoBinning(nBins))
-hist_prob = mcs.fitParDataSet().createHistogram("prob", ROOT.RooFit.AutoBinning(nBins))
+hist_chi2 = mcs.fitParDataSet().createHistogram("chi2", AutoBinning=nBins)
+hist_prob = mcs.fitParDataSet().createHistogram("prob", AutoBinning=nBins)
 
 # Create manager with separate fit model
 # ----------------------------------------------------------------------------
@@ -58,7 +58,7 @@ gauss2 = ROOT.RooGaussian("gauss2", "gaussian PDF2", x, mean2, sigma)
 # Create study manager with separate generation and fit model. ROOT.This configuration
 # is set up to generate bad fits as the fit and generator model have different means
 # and the mean parameter is not floating in the fit
-mcs2 = ROOT.RooMCStudy(gauss2, {x}, ROOT.RooFit.FitModel(gauss), ROOT.RooFit.Silence(), ROOT.RooFit.Binned())
+mcs2 = ROOT.RooMCStudy(gauss2, {x}, FitModel=gauss, Silence=True, Binned=True)
 
 # Add chi^2 calculator module to mcs
 chi2mod2 = ROOT.RooChi2MCSModule()
@@ -77,8 +77,8 @@ pullMeanFrame = mcs2.plotPull(mean)
 
 # Fill histograms with distributions chi2 and prob(chi2,ndf) that
 # are calculated by ROOT.RooChiMCSModule
-hist2_chi2 = mcs2.fitParDataSet().createHistogram("chi2", ROOT.RooFit.AutoBinning(nBins))
-hist2_prob = mcs2.fitParDataSet().createHistogram("prob", ROOT.RooFit.AutoBinning(nBins))
+hist2_chi2 = mcs2.fitParDataSet().createHistogram("chi2", AutoBinning=nBins)
+hist2_prob = mcs2.fitParDataSet().createHistogram("prob", AutoBinning=nBins)
 hist2_chi2.SetLineColor(ROOT.kRed)
 hist2_prob.SetLineColor(ROOT.kRed)
 

--- a/tutorials/roofit/rf803_mcstudy_addons2.py
+++ b/tutorials/roofit/rf803_mcstudy_addons2.py
@@ -42,15 +42,10 @@ model = ROOT.RooAddPdf("model", "model", [sig, bkg], [nsig, nbkg])
 # Create manager
 # ---------------------------
 
-# Configure manager to perform binned extended likelihood fits (Binned(), ROOT.RooFit.Extended()) on data generated
-# with a Poisson fluctuation on Nobs (Extended())
+# Configure manager to perform binned extended likelihood fits (Binned=True, Extended=True) on data generated
+# with a Poisson fluctuation on Nobs (Extended=True)
 mcs = ROOT.RooMCStudy(
-    model,
-    {mjjj},
-    ROOT.RooFit.Binned(),
-    ROOT.RooFit.Silence(),
-    ROOT.RooFit.Extended(ROOT.kTRUE),
-    ROOT.RooFit.FitOptions(ROOT.RooFit.Extended(ROOT.kTRUE), ROOT.RooFit.PrintEvalErrors(-1)),
+    model, {mjjj}, Binned=True, Silence=True, Extended=True, FitOptions={"Extended": True, "PrintEvalErrors": -1}
 )
 
 # Customize manager

--- a/tutorials/roofit/rf804_mcstudy_constr.py
+++ b/tutorials/roofit/rf804_mcstudy_constr.py
@@ -42,14 +42,7 @@ sumc = ROOT.RooProdPdf("sumc", "sum with constraint", [sum, fconstraint])
 # ---------------------------------------------------
 
 # Perform toy study with internal constraint on f
-mcs = ROOT.RooMCStudy(
-    sumc,
-    {x},
-    ROOT.RooFit.Constrain({f}),
-    ROOT.RooFit.Silence(),
-    ROOT.RooFit.Binned(),
-    ROOT.RooFit.FitOptions(ROOT.RooFit.PrintLevel(-1)),
-)
+mcs = ROOT.RooMCStudy(sumc, {x}, Constrain={f}, Silence=True, Binned=True, FitOptions={"PrintLevel": -1})
 
 # Run 500 toys of 2000 events.
 # Before each toy is generated, value for the f is sampled from the constraint pdf and
@@ -57,14 +50,14 @@ mcs = ROOT.RooMCStudy(
 mcs.generateAndFit(500, 2000)
 
 # Make plot of distribution of generated value of f parameter
-h_f_gen = mcs.fitParDataSet().createHistogram("f_gen", ROOT.RooFit.AutoBinning(40))
+h_f_gen = mcs.fitParDataSet().createHistogram("f_gen", AutoBinning=40)
 
 # Make plot of distribution of fitted value of f parameter
-frame1 = mcs.plotParam(f, ROOT.RooFit.Bins(40))
+frame1 = mcs.plotParam(f, Bins=40)
 frame1.SetTitle("Distribution of fitted f values")
 
 # Make plot of pull distribution on f
-frame2 = mcs.plotPull(f, ROOT.RooFit.Bins(40), ROOT.RooFit.FitGauss())
+frame2 = mcs.plotPull(f, Bins=40, FitGauss=True)
 frame1.SetTitle("Distribution of f pull values")
 
 c = ROOT.TCanvas("rf804_mcstudy_constr", "rf804_mcstudy_constr", 1200, 400)

--- a/tutorials/roofit/rf902_numgenconfig.py
+++ b/tutorials/roofit/rf902_numgenconfig.py
@@ -52,5 +52,5 @@ model.specialGeneratorConfig().getConfigSection("RooFoamGenerator").setRealValue
 
 # Generate 10Kevt using ROOT.RooFoamGenerator (FOAM verbosity increased
 # with above chatLevel adjustment for illustration purposes)
-data_foam = model.generate({x}, 10000, ROOT.RooFit.Verbose())
+data_foam = model.generate({x}, 10000, Verbose=True)
 data_foam.Print()


### PR DESCRIPTION
Obviously the `Link` pythonization should call the original `_Link`
function.

Also, the constructor that takes a map of categories to PDFs should be able to
accept a Python dictionary directly.

The RooFit Python tutorials are covering this constructor, acting as a
unit test.

Closes https://github.com/root-project/root/issues/11496.