### PR TITLE
[v626][RF] Backports of RooFit PRs to `v6-26-00-patches`: Part 22

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_rooglobalfunc.py
@@ -205,7 +205,7 @@ def Link(*args, **kwargs):
     if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], dict):
         args = list(args)
         args[0] = _dict_to_std_map(args[0], {"std::string": "RooAbsData*"})
-        return RooFit._Import(args[0])
+        return RooFit._Link(args[0])
 
     return RooFit._Link(*args, **kwargs)
 

--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roosimultaneous.py
@@ -11,7 +11,7 @@
 ################################################################################
 
 
-from ._utils import _kwargs_to_roocmdargs, cpp_signature
+from ._utils import _kwargs_to_roocmdargs, cpp_signature, _dict_to_std_map
 
 
 class RooSimultaneous(object):
@@ -26,6 +26,19 @@ class RooSimultaneous(object):
     simPdf.plotOn(frame, Slice=(sample, "control"), ProjWData=(sampleSet, combData))
     \endcode
     """
+
+    @cpp_signature(
+        "RooSimultaneous(const char *name, const char *title,"
+        "                std::map<std::string,RooAbsPdf*> pdfMap, RooAbsCategoryLValue& inIndexCat) ;"
+    )
+    def __init__(self, *args):
+        r"""The RooSimultaneous constructor that takes a map of category names
+        to PDFs is accepting a Python dictionary in Python.
+        """
+        if len(args) >= 3 and isinstance(args[2], dict):
+            args = list(args)
+            args[2] = _dict_to_std_map(args[2], {"std::string": "RooAbsPdf*"})
+        self._init(*args)
 
     @cpp_signature(
         "RooPlot *RooSimultaneous::plotOn(RooPlot* frame,"

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -147,6 +147,7 @@ if(roofit)
 
     # Other pythonizations that fail on Windows for unknown reasons
     ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_roosimultaneous roofit/roosimultaneous.py)
 
     # NumPy compatibility
     ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py PYTHON_DEPS numpy)

--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -140,11 +140,13 @@ if(roofit)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabsreal_ploton roofit/rooabsreal_ploton.py)
 
   ROOT_ADD_PYUNITTEST(pyroot_roofit_roolinkedlist roofit/roolinkedlist.py)
-  ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
 
   if(NOT MSVC OR win_broken_tests)
     # Test pythonizations for the RooFitHS3 package, which is not built on Windows.
     ROOT_ADD_PYUNITTEST(pyroot_roofit_roojsonfactorywstool roofit/roojsonfactorywstool.py)
+
+    # Other pythonizations that fail on Windows for unknown reasons
+    ROOT_ADD_PYUNITTEST(pyroot_roofit_rooglobalfunc roofit/rooglobalfunc.py)
 
     # NumPy compatibility
     ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset_numpy roofit/roodataset_numpy.py PYTHON_DEPS numpy)

--- a/bindings/pyroot/pythonizations/test/roofit/rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooglobalfunc.py
@@ -26,7 +26,26 @@ class TestRooGlobalFunc(unittest.TestCase):
         self.assertEqual(code(ROOT.kRed), code("r"))
 
         # Check that postfix operations applied to ROOT color codes work
-        self.assertEqual(code(ROOT.kRed+1), code("kRed+1"))
+        self.assertEqual(code(ROOT.kRed + 1), code("kRed+1"))
+
+    def test_roodataset_link(self):
+        """Test that the RooFit.Link() command argument works as expected in
+        the RooDataSet constructor.
+        Inspired by the reproducer code in GitHub issue #11469.
+        """
+        x = ROOT.RooRealVar("x", "", 0, 1)
+        g = ROOT.RooGaussian("g", "", x, ROOT.RooFit.RooConst(0.5), ROOT.RooFit.RooConst(0.2))
+
+        n_events = 1000
+
+        data = g.generate({x}, NumEvents=n_events)
+
+        sample = ROOT.RooCategory("cat", "cat")
+        sample.defineType("cat_0")
+
+        data_2 = ROOT.RooDataSet("data_2", "data_2", {x}, Index=sample, Link={"cat_0": data})
+
+        self.assertEqual(data_2.numEntries(), n_events)
 
 
 if __name__ == "__main__":

--- a/bindings/pyroot/pythonizations/test/roofit/roosimultaneous.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roosimultaneous.py
@@ -1,0 +1,33 @@
+import unittest
+import ROOT
+
+
+class RooSimultaneous_test(unittest.TestCase):
+    """
+    Test for the pythonizations of RooSimultaneous.
+    """
+
+    # Tests
+    def test_construction_from_dict(self):
+
+        x = ROOT.RooRealVar("x", "x", -10, 10)
+
+        # Define model for each sample
+        model = ROOT.RooGaussian("model", "model", x, ROOT.RooFit.RooConst(1.0), ROOT.RooFit.RooConst(1.0))
+        model_ctl = ROOT.RooGaussian("model_ctl", "model_ctl", x, ROOT.RooFit.RooConst(-1.0), ROOT.RooFit.RooConst(1.0))
+
+        # Define category to distinguish physics and control samples events
+        sample = ROOT.RooCategory("sample", "sample")
+        sample.defineType("physics")
+        sample.defineType("control")
+
+        # Construct the RooSimultaneous
+        sim_pdf = ROOT.RooSimultaneous("simPdf", "simultaneous pdf", {"physics": model, "control": model_ctl}, sample)
+
+        # Verify that the PDF ends up with the right PDFs in the right categories
+        self.assertEqual(sim_pdf.getPdf("physics").GetName(), "model")
+        self.assertEqual(sim_pdf.getPdf("control").GetName(), "model_ctl")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a backport of all the relevant bugfix RooFit PRs that were recently merged to `master` to `v6-26-00-patches` (in the right order, to not have the commit history diverge too much).

1. https://github.com/root-project/root/pull/11500
    Excluding the last commit that only updates the tutorials