### PR TITLE
cmake: Replace ever expanding modules_idx_deps cached variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,9 +516,6 @@ endif()
 if(runtime_cxxmodules)
   ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)
   get_property(modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
-  # This custom target allows to add dependencies to the modules.idx file after the
-  # facts.
-  add_custom_target(modules_idx_marker)
   add_custom_command(OUTPUT ${library_output_dir}/modules.idx
                      COMMAND ${CMAKE_COMMAND} -E remove -f modules.idx modules.timestamp
                      COMMAND ${ld_library_path}=${library_output_dir}:$ENV{${ld_library_path}}
@@ -526,7 +523,7 @@ if(runtime_cxxmodules)
                              $<TARGET_FILE:root.exe> -l -q -b
                      WORKING_DIRECTORY ${library_output_dir}
                      DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts
-                             modules_idx_marker ${modules_idx_deps})
+                             ${modules_idx_deps})
   add_custom_target(modules_idx ALL DEPENDS ${library_output_dir}/modules.idx)
   add_dependencies(modules_idx ${modules_idx_deps})
   set_property(TARGET modules_idx PROPERTY modules_idx_file ${library_output_dir}/modules.idx)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,15 +515,21 @@ endif()
 # modules.idx
 if(runtime_cxxmodules)
   ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)
+  get_property(modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
+  # This custom target allows to add dependencies to the modules.idx file after the
+  # facts.
+  add_custom_target(modules_idx_marker)
   add_custom_command(OUTPUT ${library_output_dir}/modules.idx
                      COMMAND ${CMAKE_COMMAND} -E remove -f modules.idx modules.timestamp
                      COMMAND ${ld_library_path}=${library_output_dir}:$ENV{${ld_library_path}}
                              ROOTIGNOREPREFIX=1 ROOT_HIST=0
                              $<TARGET_FILE:root.exe> -l -q -b
                      WORKING_DIRECTORY ${library_output_dir}
-                     DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts ${modules_idx_deps})
+                     DEPENDS $<TARGET_FILE:root.exe> Cling Hist Tree Gpad Graf HistPainter move_artifacts
+                             modules_idx_marker ${modules_idx_deps})
   add_custom_target(modules_idx ALL DEPENDS ${library_output_dir}/modules.idx)
   add_dependencies(modules_idx ${modules_idx_deps})
+  set_property(TARGET modules_idx PROPERTY modules_idx_file ${library_output_dir}/modules.idx)
   set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${library_output_dir}/modules.timestamp")
 endif()
 

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -522,8 +522,14 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endif(ARG_MODULE)
 
   # modules.idx deps
-  list(APPEND modules_idx_deps ${library_target_name})
-  set(modules_idx_deps ${modules_idx_deps} CACHE INTERNAL "modules_idx_deps")
+  if (TARGET modules_idx)
+    add_dependencies(modules_idx_marker ${library_target_name})
+    add_dependencies(modules_idx ${library_target_name})
+  else()
+    get_property(modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
+    list(APPEND modules_idx_deps ${library_target_name})
+    set_property(GLOBAL PROPERTY modules_idx_deps_property "${modules_idx_deps}")
+  endif()
 
   #---Set the library output directory-----------------------
   ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)

--- a/cmake/modules/RootMacros.cmake
+++ b/cmake/modules/RootMacros.cmake
@@ -522,14 +522,9 @@ function(ROOT_GENERATE_DICTIONARY dictionary)
   endif(ARG_MODULE)
 
   # modules.idx deps
-  if (TARGET modules_idx)
-    add_dependencies(modules_idx_marker ${library_target_name})
-    add_dependencies(modules_idx ${library_target_name})
-  else()
-    get_property(modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
-    list(APPEND modules_idx_deps ${library_target_name})
-    set_property(GLOBAL PROPERTY modules_idx_deps_property "${modules_idx_deps}")
-  endif()
+  get_property(local_modules_idx_deps GLOBAL PROPERTY modules_idx_deps_property)
+  list(APPEND local_modules_idx_deps ${library_target_name})
+  set_property(GLOBAL PROPERTY modules_idx_deps_property "${local_modules_idx_deps}")
 
   #---Set the library output directory-----------------------
   ROOT_GET_LIBRARY_OUTPUT_DIR(library_output_dir)


### PR DESCRIPTION
We replace it with a combination of a global property and an additional custom target.
The global property is used to collect the dependencies created before the modules.idx target is created.
The custom target is used as a direct dependency of the custom_command (add_dependencies can not be used on the target of a custom_command).  Then we can use
this custom target to collect the dependencies created after the modules.idx target.

This fixes #10510.

To test:

```
ls -rtl lib/modules.idx lib/libEve.so
rm lib/*Eve*
ninja # or make or cmake --build ; this should update modules.idx
ls -rtl lib/modules.idx lib/libEve.so
```
