### PR TITLE
[RF] Fix copy-paste error in `RooDataSet::binnedClone`

### DIFF
--- a/roofit/roofitcore/src/RooDataSet.cxx
+++ b/roofit/roofitcore/src/RooDataSet.cxx
@@ -939,7 +939,7 @@ RooDataHist* RooDataSet::binnedClone(const char* newName, const char* newTitle) 
   if (newTitle) {
     title = newTitle ;
   } else {
-    name = std::string(GetTitle()) + "_binned" ;
+    title = std::string(GetTitle()) + "_binned" ;
   }
 
   return new RooDataHist(name,title,*get(),*this) ;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Due to a copy-paste error, `RooDataSet::binnedClone` was overwriting the name of the clone if no title was provided. This PR fixes that

Since this is my first PR in ROOT, I have a couple of questions:
- since this was a small change I did not open an issue in the repo, should I do that regardless?
- do I need to write a test?

