### PR TITLE
Guard gInterpreterMutex in TClingClassInfo::IsEnum

### DIFF
--- a/core/metacling/src/TClingClassInfo.cxx
+++ b/core/metacling/src/TClingClassInfo.cxx
@@ -815,6 +815,7 @@ bool TClingClassInfo::IsBase(const char *name) const
 
 bool TClingClassInfo::IsEnum(cling::Interpreter *interp, const char *name)
 {
+   R__LOCKGUARD(gInterpreterMutex);
    // Note: This is a static member function.
    TClingClassInfo info(interp, name);
    if (info.IsValid() && (info.Property() & kIsEnum)) {


### PR DESCRIPTION
Fixes https://github.com/root-project/root/issues/11515

This method leads to contention in some specific scenarios (see linked issue).

Note: I'm opening this PR to see how the CI reacts. I would still like to add some comments to the usage of the lockguard in that method