### PR TITLE
[NFC][DF] Remove a comment that does not apply anymore.

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RColumnReaderBase.hxx
@@ -29,7 +29,7 @@ class R__CLING_PTRCHECK(off) RColumnReaderBase {
 public:
    virtual ~RColumnReaderBase() = default;
 
-   /// Return the column value for the given entry. Called at most once per entry.
+   /// Return the column value for the given entry.
    /// \tparam T The column type
    /// \param entry The entry number
    template <typename T>


### PR DESCRIPTION
Column readers are now shared among all nodes in the computation graph, so `Get` can be called several times for the same column.