### PR TITLE
[DF] Avoid using the same variable for 2 branches in in-memory tree

### DIFF
--- a/tree/dataframe/test/dataframe_interface.cxx
+++ b/tree/dataframe/test/dataframe_interface.cxx
@@ -868,8 +868,8 @@ TEST(RDataFrameUtils, RegexWithFriendsInJittedFilters)
    t.Branch("x", &x);
    t.Fill();
    TTree fr("fr", "fr");
-   x = -42;
-   fr.Branch("x", &x);
+   int frx = -42;
+   fr.Branch("x", &frx);
    fr.Fill();
    t.AddFriend(&fr);
    ROOT::RDataFrame df(t);


### PR DESCRIPTION
When reading in-memory trees that have just been filled in the same scope, TTreeReaderValue re-uses, as storage for the values being read, the variable that was used to fill the tree.

When the same variable is used to fill more than one branch, this means that the addresses of the values of these branches will be the same when reading them back. This breaks the fundamental assumption in RDataFrame that TTreeReaderValues for different columns will store their values at different addresses.

The test happens to work at the moment, but it will break once we switch to bulk I/O because of a different call order inside RDF.