### PR TITLE
[PyROOT][11344] Remove sterile setting of EXTRA_CLING_ARGS by cppyy

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+++ b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 __all__ = [
     'load_cpp_backend',           # load libcppyy_backend
-    'set_cling_compile_options',  # set EXTRA_CLING_ARGS envar
     'ensure_precompiled_header'   # build precompiled header as necessary
 ]
 
@@ -57,8 +56,6 @@ def _load_helper(bkname):
 
 _precompiled_header_ensured = False
 def load_cpp_backend():
-    set_cling_compile_options()
-
     if not _precompiled_header_ensured:
      # the precompiled header of standard and system headers is not part of the
      # distribution as there are too many varieties; create it now if needed
@@ -82,20 +79,6 @@ def load_cpp_backend():
         raise RuntimeError("could not load cppyy_backend library")
 
     return c
-
-
-def set_cling_compile_options(add_defaults = False):
- # extra optimization flags for Cling
-    if not 'EXTRA_CLING_ARGS' in os.environ:
-        CURRENT_ARGS = ''
-        add_defaults = True
-    else:
-        CURRENT_ARGS = os.environ['EXTRA_CLING_ARGS']
-
-    if add_defaults:
-        CURRENT_ARGS += ' -O2'
-        os.putenv('EXTRA_CLING_ARGS', CURRENT_ARGS)
-        os.environ['EXTRA_CLING_ARGS'] = CURRENT_ARGS
 
 
 def _disable_pch():

--- a/bindings/pyroot/cppyy/patches/remove_o2_cppyy.patch
+++ b/bindings/pyroot/cppyy/patches/remove_o2_cppyy.patch
@@ -1,0 +1,42 @@
+diff --git a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+index 4cce950c31..d1c91c7357 100644
+--- a/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
++++ b/bindings/pyroot/cppyy/cppyy-backend/cling/python/cppyy_backend/loader.py
+@@ -4,7 +4,6 @@ from __future__ import print_function
+ 
+ __all__ = [
+     'load_cpp_backend',           # load libcppyy_backend
+-    'set_cling_compile_options',  # set EXTRA_CLING_ARGS envar
+     'ensure_precompiled_header'   # build precompiled header as necessary
+ ]
+ 
+@@ -57,8 +56,6 @@ def _load_helper(bkname):
+ 
+ _precompiled_header_ensured = False
+ def load_cpp_backend():
+-    set_cling_compile_options()
+-
+     if not _precompiled_header_ensured:
+      # the precompiled header of standard and system headers is not part of the
+      # distribution as there are too many varieties; create it now if needed
+@@ -84,20 +81,6 @@ def load_cpp_backend():
+     return c
+ 
+ 
+-def set_cling_compile_options(add_defaults = False):
+- # extra optimization flags for Cling
+-    if not 'EXTRA_CLING_ARGS' in os.environ:
+-        CURRENT_ARGS = ''
+-        add_defaults = True
+-    else:
+-        CURRENT_ARGS = os.environ['EXTRA_CLING_ARGS']
+-
+-    if add_defaults:
+-        CURRENT_ARGS += ' -O2'
+-        os.putenv('EXTRA_CLING_ARGS', CURRENT_ARGS)
+-        os.environ['EXTRA_CLING_ARGS'] = CURRENT_ARGS
+-
+-
+ def _disable_pch():
+     os.putenv('CLING_STANDARD_PCH', 'none')
+ 


### PR DESCRIPTION
Fixes #11344 .

Mostly quoting @eguiraud in #11344 :

import ROOT (via cppyy) causes the setting of the environment variable EXTRA_CLING_ARGS to -O2 -- but too late (after interpreter initialization), so that the setting actually has no effect: cling will still use its default of -O1, but checking EXTRA_CLING_ARGS will give users the wrong impression.

Since there is no reason to set the environment variable in the first place, it has no effect anyway, and it can be confusing for users trying to figure out what options cling is running with, this PR removes the behavior from PyROOT.
