### PR TITLE
[ntuple] Support the storage of collections using the `TVirtualCollectionProxy` interface

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -602,6 +602,11 @@ The child fileds are named `_0`, `_1`, ...
 
 ### User-defined classes
 
+User-defined classes might behave either as a record or as a collection of elements of a given type.
+The behavior depends on whether the class has an associated collection proxy.
+
+#### Regular class / struct
+
 User defined C++ classes are supported with the following limitations
   - The class must have a dictionary
   - All persistent members and base classes must be themselves types with RNTuple I/O support
@@ -614,6 +619,16 @@ User classes are stored as a record mother field with no attached columns.
 Direct base classes and persistent members are stored as subfields with their respective types.
 The field name of member subfields is identical to the C++ field name.
 The field name of base class subfields are numbered and preceeded by a colon (`:`), i.e. `:_0`, `:_1`, ...
+
+#### Classes with an associated collection proxy
+
+User classes that specify a collection proxy behave as collections of a given value type.
+Associative collections are not currently supported.
+
+The on-disk representation is similar to a `std::vector<T>` where `T` is the value type; specifically, it is stored as two fields:
+  - Collection mother field of type SplitIndex32 or SplitIndex64
+  - Child field of type `T`, which must by a type with RNTuple I/O support.
+    The name of the child field is `_0`.
 
 ## Limits
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -344,7 +344,7 @@ private:
    /// Chunk size in bytes used in `ReadGlobalImp()`. Items held in the same chunk will be inserted in
    /// a single `TVirtualCollectionProxy::Insert()` call.
    static constexpr const std::size_t kReadChunkSize = 64 * 1024;
-   TVirtualCollectionProxy *fProxy;
+   std::unique_ptr<TVirtualCollectionProxy> fProxy;
    std::size_t fItemSize;
    ClusterSize_t fNWritten;
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -341,6 +341,7 @@ public:
 /// The collection proxy for a given class can be set via `TClass::CopyCollectionProxy()`.
 class RCollectionClassField : public Detail::RFieldBase {
 private:
+   static constexpr const std::uint32_t kReadChunkSize = 128;
    TVirtualCollectionProxy *fProxy;
    std::size_t fItemSize;
    ClusterSize_t fNWritten;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -341,6 +341,8 @@ public:
 /// The collection proxy for a given class can be set via `TClass::CopyCollectionProxy()`.
 class RCollectionClassField : public Detail::RFieldBase {
 private:
+   /// Chunk size in number of items used in `ReadGlobalImp()`. Items in the same chunk will be inserted in
+   /// a single `TVirtualCollectionProxy::Insert()` call.
    static constexpr const std::uint32_t kReadChunkSize = 128;
    TVirtualCollectionProxy *fProxy;
    std::size_t fItemSize;
@@ -617,7 +619,7 @@ public:
    static std::string TypeName() { return ROOT::Internal::GetDemangledTypeName(typeid(T)); }
    RField(std::string_view name) : RCollectionClassField(name, TypeName())
    {
-      static_assert(std::is_class<T>::value, "no I/O support for this basic C++ type");
+      static_assert(std::is_class<T>::value, "collection proxy unsupported for fundamental types");
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -605,13 +605,30 @@ public:
 };
 
 template <typename T, typename = void>
-struct IsCollectionProxy : std::false_type {};
+struct HasCollectionProxyMemberType : std::false_type {
+};
+template <typename T>
+struct HasCollectionProxyMemberType<
+   T, typename std::enable_if<std::is_same<typename T::IsCollectionProxy, std::true_type>::value>::type>
+   : std::true_type {
+};
+
+template <typename T, typename = void>
+struct IsCollectionProxy : HasCollectionProxyMemberType<T> {
+};
 /// Classes behaving as a collection of elements that can be queried via the `TVirtualCollectionProxy` interface
 /// The use of a collection proxy for a particular class can be enabled via:
 /// ```
 /// namespace ROOT::Experimental {
 ///    template <> struct IsCollectionProxy<Classname> : std::true_type {};
 /// }
+/// ```
+/// Alternatively, this can be achieved by adding a member type to the class definition as follows:
+/// ```
+/// class Classname {
+/// public:
+///    using IsCollectionProxy = std::true_type;
+/// };
 /// ```
 template <typename T>
 class RField<T, typename std::enable_if<IsCollectionProxy<T>::value>::type> : public RCollectionClassField {

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -341,9 +341,9 @@ public:
 /// The collection proxy for a given class can be set via `TClass::CopyCollectionProxy()`.
 class RCollectionClassField : public Detail::RFieldBase {
 private:
-   /// Chunk size in number of items used in `ReadGlobalImp()`. Items in the same chunk will be inserted in
+   /// Chunk size in bytes used in `ReadGlobalImp()`. Items held in the same chunk will be inserted in
    /// a single `TVirtualCollectionProxy::Insert()` call.
-   static constexpr const std::uint32_t kReadChunkSize = 128;
+   static constexpr const std::size_t kReadChunkSize = 64 * 1024;
    TVirtualCollectionProxy *fProxy;
    std::size_t fItemSize;
    ClusterSize_t fNWritten;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -602,10 +602,17 @@ public:
    ROOT::Experimental::Detail::RFieldValue GenerateValue(void *where) final { return GenerateValue(where, T()); }
 };
 
-struct TagUseCollectionProxy {};
+template <typename T, typename = void>
+struct IsCollectionProxy : std::false_type {};
 /// Classes behaving as a collection of elements that can be queried via the `TVirtualCollectionProxy` interface
+/// The use of a collection proxy for a particular class can be enabled via:
+/// ```
+/// namespace ROOT::Experimental {
+///    template <> struct IsCollectionProxy<Classname> : std::true_type {};
+/// }
+/// ```
 template <typename T>
-class RField<T, ROOT::Experimental::TagUseCollectionProxy> : public RCollectionClassField {
+class RField<T, typename std::enable_if<IsCollectionProxy<T>::value>::type> : public RCollectionClassField {
 public:
    static std::string TypeName() { return ROOT::Internal::GetDemangledTypeName(typeid(T)); }
    RField(std::string_view name) : RCollectionClassField(name, TypeName())

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -48,6 +48,7 @@ public:
    virtual void VisitArrayField(const RArrayField &field) { VisitField(field); }
    virtual void VisitBoolField(const RField<bool> &field) { VisitField(field); }
    virtual void VisitClassField(const RClassField &field) { VisitField(field); }
+   virtual void VisitCollectionClassField(const RCollectionClassField &field) { VisitField(field); }
    virtual void VisitRecordField(const RRecordField &field) { VisitField(field); }
    virtual void VisitClusterSizeField(const RField<ClusterSize_t> &field) { VisitField(field); }
    virtual void VisitDoubleField(const RField<double> &field) { VisitField(field); }

--- a/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RFieldVisitor.hxx
@@ -210,6 +210,7 @@ public:
    void VisitArrayField(const RArrayField &field) final;
    void VisitClassField(const RClassField &field) final;
    void VisitRecordField(const RRecordField &field) final;
+   void VisitCollectionClassField(const RCollectionClassField &field) final;
    void VisitVectorField(const RVectorField &field) final;
    void VisitVectorBoolField(const RField<std::vector<bool>> &field) final;
    void VisitRVecField(const RRVecField &field) final;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -808,6 +808,10 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
    if (fClass->Property() & kIsDefinedInStd) {
       throw RException(R__FAIL(std::string(className) + " is not supported"));
    }
+   if (fClass->GetCollectionProxy()) {
+      throw RException(
+         R__FAIL(std::string(className) + " has an associated collection proxy; use RCollectionClassField instead"));
+   }
 
    int i = 0;
    for (auto baseClass : ROOT::Detail::TRangeStaticCast<TBaseClass>(*fClass->GetListOfBases())) {
@@ -930,7 +934,7 @@ ROOT::Experimental::RCollectionClassField::RCollectionClassField(std::string_vie
      fNWritten(0)
 {
    if (classp == nullptr)
-      throw RException(R__FAIL("RField: no I/O support for type " + std::string(className)));
+      throw RException(R__FAIL("RField: no I/O support for collection proxy type " + std::string(className)));
 
    fProxy = classp->GetCollectionProxy();
    if (!fProxy)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1005,14 +1005,8 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
    RClusterIndex collectionStart;
    fPrincipalColumn->GetCollectionInfo(globalIndex, &collectionStart, &nItems);
 
-   auto oldNItems = fProxy->Size();
-   if (fProxy->GetProperties() & TVirtualCollectionProxy::kNeedDelete) {
-      for (std::size_t i = 0; i < oldNItems; ++i) {
-         auto itemValue = fSubFields[0]->CaptureValue(fProxy->At(i));
-         fSubFields[0]->DestroyValue(itemValue, true /* dtorOnly */);
-      }
-   }
-   fProxy->Clear();
+   // `TVirtualCollectionProxy::Clear()` is responsible for destroying the items in the collection
+   fProxy->Clear("force");
 
    // Avoid heap fragmentation at the cost of temporarily allocating slightly more memory
    const size_t buffSize = std::max(kReadChunkSize, fItemSize);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1015,10 +1015,13 @@ void ROOT::Experimental::RCollectionClassField::ReadGlobalImpl(NTupleSize_t glob
    fProxy->Clear();
 
    // Avoid heap fragmentation at the cost of temporarily allocating slightly more memory
-   auto buff = std::make_unique<unsigned char[]>(kReadChunkSize * fItemSize);
+   const size_t buffSize = std::max(kReadChunkSize, fItemSize);
+   const std::uint32_t nItemsPerChunk = buffSize / fItemSize;
+   auto buff = std::make_unique<unsigned char[]>(buffSize);
+
    auto nItemsLeft = static_cast<std::uint32_t>(nItems);
    while (nItemsLeft > 0) {
-      auto count = std::min(nItemsLeft, kReadChunkSize);
+      auto count = std::min(nItemsLeft, nItemsPerChunk);
       for (std::size_t i = 0; i < count; ++i) {
          auto itemValue = fSubFields[0]->GenerateValue(buff.get() + (i * fItemSize));
          fSubFields[0]->Read(collectionStart + i, &itemValue);

--- a/tree/ntuple/v7/src/RFieldVisitor.cxx
+++ b/tree/ntuple/v7/src/RFieldVisitor.cxx
@@ -320,6 +320,10 @@ void ROOT::Experimental::RPrintValueVisitor::VisitRecordField(const RRecordField
    fOutput << "}";
 }
 
+void ROOT::Experimental::RPrintValueVisitor::VisitCollectionClassField(const RCollectionClassField &field)
+{
+   PrintCollection(field);
+}
 
 void ROOT::Experimental::RPrintValueVisitor::VisitVectorField(const RVectorField &field)
 {

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -90,4 +90,11 @@ struct StructWithEnums : BaseOfStructWithEnums {
    int b = static_cast<int>(DeclEC::E42);
 };
 
+/// A class that behaves as a collection accessed through the `TVirtualCollectionProxy` interface
+template <typename T>
+struct StructUsingCollectionProxy {
+   using ValueType = T;
+   std::vector<T> v; //! do not accidentally store via RClassField
+};
+
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -20,4 +20,7 @@
 #pragma link C++ class BaseOfStructWithEnums + ;
 #pragma link C++ class StructWithEnums + ;
 
+#pragma link C++ class StructUsingCollectionProxy<char> + ;
+#pragma link C++ class StructUsingCollectionProxy<float> + ;
+
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -24,5 +24,6 @@
 #pragma link C++ class StructUsingCollectionProxy<float> + ;
 #pragma link C++ class StructUsingCollectionProxy<CustomStruct> + ;
 #pragma link C++ class StructUsingCollectionProxy<StructUsingCollectionProxy<float>> + ;
+#pragma link C++ class StructUsingCollectionProxy<int> + ;
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -23,5 +23,6 @@
 #pragma link C++ class StructUsingCollectionProxy<char> + ;
 #pragma link C++ class StructUsingCollectionProxy<float> + ;
 #pragma link C++ class StructUsingCollectionProxy<CustomStruct> + ;
+#pragma link C++ class StructUsingCollectionProxy<StructUsingCollectionProxy<float>> + ;
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -22,5 +22,6 @@
 
 #pragma link C++ class StructUsingCollectionProxy<char> + ;
 #pragma link C++ class StructUsingCollectionProxy<float> + ;
+#pragma link C++ class StructUsingCollectionProxy<CustomStruct> + ;
 
 #endif

--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -84,6 +84,8 @@ struct IsCollectionProxy<StructUsingCollectionProxy<CustomStruct>> : std::true_t
 template <>
 struct IsCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>> : std::true_type {
 };
+
+// Intentionally omit `IsCollectionProxy<StructUsingCollectionProxy<int>>`
 } // namespace ROOT::Experimental
 
 #endif

--- a/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
+++ b/tree/ntuple/v7/test/SimpleCollectionProxy.hxx
@@ -1,0 +1,89 @@
+#ifndef ROOT7_RNTuple_Test_SimpleCollectionProxy
+#define ROOT7_RNTuple_Test_SimpleCollectionProxy
+
+#include "ntuple_test.hxx"
+
+namespace {
+/// Simple collection proxy for `StructUsingCollectionProxy<T>`
+template <typename CollectionT>
+struct SimpleCollectionProxy : public TVirtualCollectionProxy {
+   CollectionT *fObject = nullptr;
+
+   SimpleCollectionProxy()
+      : TVirtualCollectionProxy(TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(CollectionT)).c_str()))
+   {
+   }
+   SimpleCollectionProxy(const SimpleCollectionProxy &) : SimpleCollectionProxy() {}
+
+   TVirtualCollectionProxy *Generate() const override { return new SimpleCollectionProxy<CollectionT>(*this); }
+   Int_t GetCollectionType() const override { return ROOT::kSTLvector; }
+   ULong_t GetIncrement() const override { return sizeof(typename CollectionT::ValueType); }
+   UInt_t Sizeof() const override { return sizeof(CollectionT); }
+   Bool_t HasPointers() const override { return kFALSE; }
+
+   TClass *GetValueClass() const override
+   {
+      if constexpr (std::is_fundamental<typename CollectionT::ValueType>::value)
+         return nullptr;
+      return TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(typename CollectionT::ValueType)).c_str());
+   }
+   EDataType GetType() const override
+   {
+      if constexpr (std::is_same<typename CollectionT::ValueType, char>::value)
+         return EDataType::kChar_t;
+      ;
+      if constexpr (std::is_same<typename CollectionT::ValueType, float>::value)
+         return EDataType::kFloat_t;
+      ;
+      return EDataType::kOther_t;
+   }
+
+   void PushProxy(void *objectstart) override { fObject = static_cast<CollectionT *>(objectstart); }
+   void PopProxy() override { fObject = nullptr; }
+
+   void *At(UInt_t idx) override { return &fObject->v[idx]; }
+   void Clear(const char * /*opt*/ = "") override { fObject->v.clear(); }
+   UInt_t Size() const override { return fObject->v.size(); }
+   void *Allocate(UInt_t /*n*/, Bool_t /*forceDelete*/) override { return nullptr; }
+   void Commit(void *) override {}
+   void Insert(const void *data, void *container, size_t size) override
+   {
+      auto p = static_cast<const typename CollectionT::ValueType *>(data);
+      for (size_t i = 0; i < size; ++i) {
+         static_cast<CollectionT *>(container)->v.push_back(p[i]);
+      }
+   }
+
+   TStreamerInfoActions::TActionSequence *
+   GetConversionReadMemberWiseActions(TClass * /*oldClass*/, Int_t /*version*/) override
+   {
+      return nullptr;
+   }
+   TStreamerInfoActions::TActionSequence *GetReadMemberWiseActions(Int_t /*version*/) override { return nullptr; }
+   TStreamerInfoActions::TActionSequence *GetWriteMemberWiseActions() override { return nullptr; }
+
+   CreateIterators_t GetFunctionCreateIterators(Bool_t /*read*/ = kTRUE) override { return nullptr; }
+   CopyIterator_t GetFunctionCopyIterator(Bool_t /*read*/ = kTRUE) override { return nullptr; }
+   Next_t GetFunctionNext(Bool_t /*read*/ = kTRUE) override { return nullptr; }
+   DeleteIterator_t GetFunctionDeleteIterator(Bool_t /*read*/ = kTRUE) override { return nullptr; }
+   DeleteTwoIterators_t GetFunctionDeleteTwoIterators(Bool_t /*read*/ = kTRUE) override { return nullptr; }
+};
+} // namespace
+
+namespace ROOT::Experimental {
+template <>
+struct IsCollectionProxy<StructUsingCollectionProxy<char>> : std::true_type {
+};
+template <>
+struct IsCollectionProxy<StructUsingCollectionProxy<float>> : std::true_type {
+};
+template <>
+struct IsCollectionProxy<StructUsingCollectionProxy<CustomStruct>> : std::true_type {
+};
+
+template <>
+struct IsCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>> : std::true_type {
+};
+} // namespace ROOT::Experimental
+
+#endif

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -1,4 +1,5 @@
 #include "ntuple_test.hxx"
+#include "SimpleCollectionProxy.hxx"
 #include "TInterpreter.h"
 
 TEST(RNTuple, TypeName) {
@@ -392,85 +393,6 @@ TEST(RNTuple, TClassTemplatedBase)
       EXPECT_EQ((std::vector<int>{static_cast<int>(i + 2),
                                   static_cast<int>(i + 3)}), viewKlass(i));
    }
-}
-
-namespace {
-/// Simple collection proxy for `StructUsingCollectionProxy<T>`
-template <typename CollectionT>
-struct SimpleCollectionProxy : public TVirtualCollectionProxy {
-   CollectionT *fObject = nullptr;
-
-   SimpleCollectionProxy()
-      : TVirtualCollectionProxy(TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(CollectionT)).c_str()))
-   {
-   }
-   SimpleCollectionProxy(const SimpleCollectionProxy &) : SimpleCollectionProxy() {}
-
-   TVirtualCollectionProxy *Generate() const override { return new SimpleCollectionProxy<CollectionT>(*this); }
-   Int_t GetCollectionType() const override { return ROOT::kSTLvector; }
-   ULong_t GetIncrement() const override { return sizeof(typename CollectionT::ValueType); }
-   UInt_t Sizeof() const override { return sizeof(CollectionT); }
-   Bool_t HasPointers() const override { return kFALSE; }
-
-   TClass *GetValueClass() const override
-   {
-      if constexpr (std::is_fundamental<typename CollectionT::ValueType>::value)
-         return nullptr;
-      return TClass::GetClass(ROOT::Internal::GetDemangledTypeName(typeid(typename CollectionT::ValueType)).c_str());
-   }
-   EDataType GetType() const override
-   {
-      if constexpr (std::is_same<typename CollectionT::ValueType, char>::value)
-         return EDataType::kChar_t;
-      ;
-      if constexpr (std::is_same<typename CollectionT::ValueType, float>::value)
-         return EDataType::kFloat_t;
-      ;
-      return EDataType::kOther_t;
-   }
-
-   void PushProxy(void *objectstart) override { fObject = static_cast<CollectionT *>(objectstart); }
-   void PopProxy() override { fObject = nullptr; }
-
-   void *At(UInt_t idx) override { return &fObject->v[idx]; }
-   void Clear(const char * /*opt*/ = "") override { fObject->v.clear(); }
-   UInt_t Size() const override { return fObject->v.size(); }
-   void *Allocate(UInt_t /*n*/, Bool_t /*forceDelete*/) override { return nullptr; }
-   void Commit(void *) override {}
-   void Insert(const void *data, void *container, size_t size) override
-   {
-      auto p = static_cast<const typename CollectionT::ValueType *>(data);
-      for (size_t i = 0; i < size; ++i) {
-         static_cast<CollectionT *>(container)->v.push_back(p[i]);
-      }
-   }
-
-   TStreamerInfoActions::TActionSequence *
-   GetConversionReadMemberWiseActions(TClass * /*oldClass*/, Int_t /*version*/) override
-   {
-      return nullptr;
-   }
-   TStreamerInfoActions::TActionSequence *GetReadMemberWiseActions(Int_t /*version*/) override { return nullptr; }
-   TStreamerInfoActions::TActionSequence *GetWriteMemberWiseActions() override { return nullptr; }
-
-   CreateIterators_t GetFunctionCreateIterators(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-   CopyIterator_t GetFunctionCopyIterator(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-   Next_t GetFunctionNext(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-   DeleteIterator_t GetFunctionDeleteIterator(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-   DeleteTwoIterators_t GetFunctionDeleteTwoIterators(Bool_t /*read*/ = kTRUE) override { return nullptr; }
-};
-} // namespace
-
-namespace ROOT::Experimental {
-   template <>
-   struct IsCollectionProxy<StructUsingCollectionProxy<char>> : std::true_type {};
-   template <>
-   struct IsCollectionProxy<StructUsingCollectionProxy<float>> : std::true_type {};
-   template <>
-   struct IsCollectionProxy<StructUsingCollectionProxy<CustomStruct>> : std::true_type {};
-
-   template <>
-   struct IsCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>> : std::true_type {};
 }
 
 TEST(RNTuple, TVirtualCollectionProxy)

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -402,6 +402,10 @@ TEST(RNTuple, TVirtualCollectionProxy)
    SimpleCollectionProxy<StructUsingCollectionProxy<CustomStruct>> proxyS;
    SimpleCollectionProxy<StructUsingCollectionProxy<StructUsingCollectionProxy<float>>> proxyNested;
 
+   // `RCollectionClassField` instantiated but no collection proxy set (yet)
+   EXPECT_THROW(RField<StructUsingCollectionProxy<float>>("hasTraitButNoCollectionProxySet"),
+                ROOT::Experimental::RException);
+
    auto klassC = TClass::GetClass("StructUsingCollectionProxy<char>");
    klassC->CopyCollectionProxy(proxyC);
    auto klassF = TClass::GetClass("StructUsingCollectionProxy<float>");
@@ -410,6 +414,13 @@ TEST(RNTuple, TVirtualCollectionProxy)
    klassS->CopyCollectionProxy(proxyS);
    auto klassNested = TClass::GetClass("StructUsingCollectionProxy<StructUsingCollectionProxy<float>>");
    klassNested->CopyCollectionProxy(proxyNested);
+
+   // `RClassField` instantiated (due to intentionally missing `IsCollectionProxy<T>` trait) but a collection proxy is
+   // set
+   auto klassI = TClass::GetClass("StructUsingCollectionProxy<int>");
+   klassI->CopyCollectionProxy(SimpleCollectionProxy<StructUsingCollectionProxy<int>>{});
+   EXPECT_THROW(RField<StructUsingCollectionProxy<int>>("noTraitButCollectionProxySet"),
+                ROOT::Experimental::RException);
 
    auto field = RField<StructUsingCollectionProxy<float>>("c");
    EXPECT_EQ(sizeof(StructUsingCollectionProxy<float>), field.GetValueSize());

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -466,17 +466,22 @@ namespace ROOT::Experimental {
    struct IsCollectionProxy<StructUsingCollectionProxy<char>> : std::true_type {};
    template <>
    struct IsCollectionProxy<StructUsingCollectionProxy<float>> : std::true_type {};
+   template <>
+   struct IsCollectionProxy<StructUsingCollectionProxy<CustomStruct>> : std::true_type {};
 }
 
 TEST(RNTuple, TVirtualCollectionProxy)
 {
    SimpleCollectionProxy<StructUsingCollectionProxy<char>> proxyC;
    SimpleCollectionProxy<StructUsingCollectionProxy<float>> proxyF;
+   SimpleCollectionProxy<StructUsingCollectionProxy<CustomStruct>> proxyS;
 
    auto klassC = TClass::GetClass("StructUsingCollectionProxy<char>");
    klassC->CopyCollectionProxy(proxyC);
    auto klassF = TClass::GetClass("StructUsingCollectionProxy<float>");
    klassF->CopyCollectionProxy(proxyF);
+   auto klassS = TClass::GetClass("StructUsingCollectionProxy<CustomStruct>");
+   klassS->CopyCollectionProxy(proxyS);
 
    auto field = RField<StructUsingCollectionProxy<float>>("c");
    EXPECT_EQ(sizeof(StructUsingCollectionProxy<float>), field.GetValueSize());
@@ -486,17 +491,30 @@ TEST(RNTuple, TVirtualCollectionProxy)
       auto model = RNTupleModel::Create();
       model->AddField(RFieldBase::Create("C", "StructUsingCollectionProxy<char>").Unwrap());
       model->AddField(RFieldBase::Create("F", "StructUsingCollectionProxy<float>").Unwrap());
+      model->AddField(RFieldBase::Create("S", "StructUsingCollectionProxy<CustomStruct>").Unwrap());
 
       auto ntuple = RNTupleWriter::Recreate(std::move(model), "f", fileGuard.GetPath());
       auto fieldC = ntuple->GetModel()->GetDefaultEntry()->Get<StructUsingCollectionProxy<char>>("C");
       auto fieldF = ntuple->GetModel()->GetDefaultEntry()->Get<StructUsingCollectionProxy<float>>("F");
+      auto fieldS = ntuple->GetModel()->GetDefaultEntry()->Get<StructUsingCollectionProxy<CustomStruct>>("S");
       for (unsigned i = 0; i < 1000; ++i) {
          if ((i % 100) == 0) {
             fieldC->v.clear();
             fieldF->v.clear();
+            fieldS->v.clear();
          }
          fieldC->v.push_back(42);
          fieldF->v.push_back(static_cast<float>(i % 100));
+
+         std::vector<float> v1;
+         for (unsigned j = 0, nItems = (i % 10); j < nItems; ++j) {
+            v1.push_back(static_cast<float>(j));
+         }
+         fieldS->v.push_back(CustomStruct{
+            /*a=*/static_cast<float>(i % 100),
+            /*v1=*/std::move(v1),
+            /*v2=*/std::vector<std::vector<float>>{{static_cast<float>(i % 100)}, {static_cast<float>((i % 100) + 1)}},
+            /*s=*/"hello" + std::to_string(i % 100)});
          ntuple->Fill();
       }
    }
@@ -506,9 +524,11 @@ TEST(RNTuple, TVirtualCollectionProxy)
       EXPECT_EQ(1000U, ntuple->GetNEntries());
       auto viewC = ntuple->GetView<StructUsingCollectionProxy<char>>("C");
       auto viewF = ntuple->GetView<StructUsingCollectionProxy<float>>("F");
+      auto viewS = ntuple->GetView<StructUsingCollectionProxy<CustomStruct>>("S");
       for (auto i : ntuple->GetEntryRange()) {
          auto &collC = viewC(i);
          auto &collF = viewF(i);
+         auto &collS = viewS(i);
 
          EXPECT_EQ((i % 100) + 1, collC.v.size());
          for (unsigned j = 0; j < collC.v.size(); ++j) {
@@ -517,6 +537,18 @@ TEST(RNTuple, TVirtualCollectionProxy)
          EXPECT_EQ((i % 100) + 1, collF.v.size());
          for (unsigned j = 0; j < collF.v.size(); ++j) {
             EXPECT_EQ(static_cast<float>(j), collF.v[j]);
+         }
+
+         EXPECT_EQ((i % 100) + 1, collS.v.size());
+         for (unsigned j = 0; j < collS.v.size(); ++j) {
+            const auto &item = collS.v[j];
+            EXPECT_EQ(static_cast<float>(j), item.a);
+            for (unsigned k = 0; k < item.v1.size(); ++k) {
+               EXPECT_EQ(static_cast<float>(k), item.v1[k]);
+            }
+            EXPECT_EQ(static_cast<float>(j), item.v2[0][0]);
+            EXPECT_EQ(static_cast<float>(j + 1), item.v2[1][0]);
+            EXPECT_EQ("hello" + std::to_string(j), item.s);
          }
       }
    }


### PR DESCRIPTION
This pull request introduces RField support for user-defined classes that behave as collections of elements.  These classes specify a "collection proxy" that provides access to the elements in the collection.
A legacy collection proxy is provided in the form of an instance of a class derived from `TVirtualCollectionProxy`.  The collection proxy for a class is typically set during initialization, usually using `TClass::CopyCollectionProxy()` or similar.

In this pull request, we introduce support for legacy collection proxies derived from the `TVirtualCollectionProxy` class, although in later stages, RNTuple might provide this functionality through an interface different interface.

At a bare minimum, the user is required to provide an implementation for the following functions in `TVirtualCollectionProxy`:
- `HasPointers()`, `GetProperties()`, `GetValueClass()`, `GetType()`, `Sizeof()`: for general information about the collection and its value type.
- `Sizeof()`, `At()`, `Clear()`, and `Insert()`: for element access
- `PushProxy()`, `PopProxy()`: for selecting the target object.

A usage example can be seen [here](https://github.com/root-project/root/pull/11525/files#diff-81832cd72f5d9af1508fd153abdf63b6406256248f1d1440f966e82e628da141).

## Changes or fixes:
- Added class `RCollectionClassField`, representing a field of a user-defined class that behaves as a collection that is compliant with the `TVirtualCollectionProxy` interface.
Given that the `RField<T>` primary template definition (that used if no specialization matches) uses `RClassField` to store members of a class, we rely on an additional helper type (`IsCollectionProxy<T>`) to annotate that a particular class has an associated collection proxy (see example below).
```c++
// Alternatively, this can be specified via a member type in the user-defined class; see the documentation
template <>
struct IsCollectionProxy<ProxiedCollection> : std::true_type {};

auto model = RNTupleModel::Create();
auto fieldKlass = model->MakeField<MyClass>("fieldKlass"); // Regular class
auto fieldCollection = model->MakeField<ProxiedCollection>("fieldCollection"); // Class with associated collection proxy
```
**This tag is not required when using the type-erased interface** (i.e., `RFieldBase::Create()`), as the use of a collection proxy can be determined at run time via `TClass`.
- `RCollectionClassField::ReadGlobalImpl()`: reduce the number of virtual calls to `TVirtualCollectionProxy::Insert()` by reading and inserting a block of elements at once.  The size of the buffer that holds the elements is set by `RCollectionClassField::kReadChunkSize` (in bytes).
- Provide implementation and tests for `RPrintValueVisitor::VisitCollectionClassField()`
- Add unit tests for collections of fundamental types, compound types, vector of a collection proxy, and nested collection proxies.
- Update `doc/specifications.md`

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #11523.