### PR TITLE
[tmva][sofie] Some improvements in TMVA SOFIE tests

### DIFF
--- a/tmva/pymva/test/generateKerasModels.py
+++ b/tmva/pymva/test/generateKerasModels.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 import numpy as np
 import tensorflow as tf

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -220,6 +220,9 @@ namespace SOFIE{
          fUseSession = false;
       if (static_cast<std::underlying_type_t<Options>>(Options::kNoWeightFile) & options)
          fUseWeightFile = false;
+      if (fUseWeightFile && !fUseSession) {
+         throw std::runtime_error("TMVA-SOFIE: RModel::Generate: cannot use a separate weight file without generating a Session class");
+      }
       fGC.clear();
       Initialize(batchSize);
       fGC += ("//Code generated automatically by TMVA for Inference of Model file [" + fFileName + "] at [" + fParseTime.substr(0, fParseTime.length()-1) +"] \n");
@@ -311,12 +314,15 @@ namespace SOFIE{
             fGC += fOperators[id]->GenerateSessionMembersCode(opName);
          }
          fGC += "\n";
-         fGC += "Session(std::string filename =\"\") {\n";
          // here add initialization and reading of weight tensors
          if (fUseWeightFile) {
+            fGC += "Session(std::string filename =\"\") {\n";
             fGC += "   if (filename.empty()) filename = \"" + fName + ".dat\";\n";
             ReadInitializedTensorsFromFile();
             //fUseWeightFile = fUseWeightFile;
+         } else {
+            // no need to pass weight file since it is not used
+            fGC += "Session() {\n";
          }
          // add here initialization code
          for (size_t id = 0; id < fOperators.size() ; id++){

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -16,34 +16,29 @@ if (NOT ONNX_MODELS_DIR)
   set(ONNX_MODELS_DIR input_models)
 endif()
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "${SOFIE_PARSERS_DIR}/onnx_proto3")
-set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
+#protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "${SOFIE_PARSERS_DIR}/onnx_proto3")
+#set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
 
 add_executable(emitFromONNX
    EmitFromONNX.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
-   ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
-   ${PROTO_SRCS}
 )
 target_include_directories(emitFromONNX PRIVATE
    ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
    ${SOFIE_PARSERS_DIR}/inc
    ${CMAKE_SOURCE_DIR}/tmva/inc
-   ${Protobuf_INCLUDE_DIRS}
    ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
    ${CMAKE_SOURCE_DIR}/core/foundation/inc
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 
-target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie)
+target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie ROOTTMVASofieParser)
 set_target_properties(emitFromONNX PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 ## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromONNX PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from onnx files
 add_custom_target(SofieCompileModels_ONNX)
-add_dependencies(SofieCompileModels_ONNX emitFromONNX onepcm)
+add_dependencies(SofieCompileModels_ONNX emitFromONNX)
 
 # Finding .onnx files to be compiled and creating the appropriate command
 file(GLOB ONNX_FILES "${ONNX_MODELS_DIR}/*.onnx")
@@ -72,28 +67,23 @@ add_dependencies(TestCustomModelsFromONNX SofieCompileModels_ONNX)
 #For testing serialisation of RModel object
 add_executable(emitFromROOT
    EmitFromRoot.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
-   ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
-   ${PROTO_SRCS}
 )
 target_include_directories(emitFromROOT PRIVATE
    ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
    ${SOFIE_PARSERS_DIR}/inc
    ${CMAKE_SOURCE_DIR}/tmva/inc
-   ${Protobuf_INCLUDE_DIRS}
-   ${CMAKE_CURRENT_BINARY_DIR}   # this is for the protobuf headerfile
+   ${CMAKE_CURRENT_BINARY_DIR}
    ${CMAKE_SOURCE_DIR}/core/foundation/inc
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
-target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie)
+target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie ROOTTMVASofieParser)
 set_target_properties(emitFromROOT PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 ## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromROOT PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from root files
 add_custom_target(SofieCompileModels_ROOT)
-add_dependencies(SofieCompileModels_ROOT emitFromROOT onepcm)
+add_dependencies(SofieCompileModels_ROOT emitFromROOT)
 
 # Finding .onnx files to be parsed and creating the appropriate command
 file(GLOB ONNX_FILES "${ONNX_MODELS_DIR}/*.onnx")

--- a/tmva/sofie/test/EmitFromRoot.cxx
+++ b/tmva/sofie/test/EmitFromRoot.cxx
@@ -29,8 +29,18 @@ int main(int argc, char *argv[]){
    RModel *modelPtr;
    fileRead.GetObject("model",modelPtr);
    fileRead.Close();
-   // in this case we don't write session class and weight file
-   modelPtr->Generate(Options::kNoSession | Options::kNoWeightFile);
+   if (outname.find("Linear_") != std::string::npos) {
+      // use Session and weight file for linear model with large weights
+      modelPtr->Generate(); 
+   }
+   else if (outname.find("LinearWith") != std::string::npos){
+      // in this case we don't write session class but not weight file
+      modelPtr->Generate(Options::kNoWeightFile);
+   }
+   else {
+      // in this case we don't write session class and not weight file
+      modelPtr->Generate(Options::kNoSession | Options::kNoWeightFile);
+   }
    modelPtr->OutputGenerated(outname+"_FromROOT.hxx");
    return 0;
 }

--- a/tmva/sofie/test/TestCustomModelsFromROOT.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromROOT.cxx
@@ -95,7 +95,8 @@ TEST(ROOT, Linear16)
    // Preparing the standard all-ones input
    std::vector<float> input(1600);
    std::fill_n(input.data(), input.size(), 1.0f);
-   std::vector<float> output = TMVA_SOFIE_Linear_16::infer(input.data());
+   TMVA_SOFIE_Linear_16::Session s("Linear_16_FromROOT.dat");
+   std::vector<float> output = s.infer(input.data());
 
    // Testing the actual and expected output sizes
    EXPECT_EQ(output.size(), sizeof(Linear_16_ExpectedOutput::all_ones) / sizeof(float));
@@ -116,7 +117,8 @@ TEST(ROOT, Linear32)
    // Preparing the standard all-ones input
    std::vector<float> input(3200);
    std::fill_n(input.data(), input.size(), 1.0f);
-   std::vector<float> output = TMVA_SOFIE_Linear_32::infer(input.data());
+   TMVA_SOFIE_Linear_32::Session s("Linear_32_FromROOT.dat");
+   std::vector<float> output = s.infer(input.data());
 
    // Testing the actual and expected output sizes
    EXPECT_EQ(output.size(), sizeof(Linear_32_ExpectedOutput::all_ones) / sizeof(float));
@@ -137,7 +139,8 @@ TEST(ROOT, Linear64)
    // Preparing the standard all-ones input
    std::vector<float> input(6400);
    std::fill_n(input.data(), input.size(), 1.0f);
-   std::vector<float> output = TMVA_SOFIE_Linear_64::infer(input.data());
+   TMVA_SOFIE_Linear_64::Session s("Linear_64_FromROOT.dat");
+   std::vector<float> output = s.infer(input.data());
 
    // Testing the actual and expected output values
    EXPECT_EQ(output.size(), sizeof(Linear_64_ExpectedOutput::all_ones) / sizeof(float));
@@ -158,7 +161,8 @@ TEST(ROOT, LinearWithSelu)
    // Preparing the standard all-ones input
    std::vector<float> input(48);
    std::fill_n(input.data(), input.size(), 1.0f);
-   std::vector<float> output = TMVA_SOFIE_LinearWithSelu::infer(input.data());
+   TMVA_SOFIE_LinearWithSelu::Session s; // we don;t use weight file
+   std::vector<float> output = s.infer(input.data());
 
    // Checking output size
    EXPECT_EQ(output.size(), sizeof(LinearWithSelu_ExpectedOutput::all_ones) / sizeof(float));
@@ -179,7 +183,9 @@ TEST(ROOT, LinearWithSigmoid)
    // Preparing the standard all-ones input
    std::vector<float> input(48);
    std::fill_n(input.data(), input.size(), 1.0f);
-   std::vector<float> output = TMVA_SOFIE_LinearWithSigmoid::infer(input.data());
+   TMVA_SOFIE_LinearWithSigmoid::Session s;  // we don't use weight file in this case
+   std::vector<float> output = s.infer(input.data());
+  
 
    // Checking output size
    EXPECT_EQ(output.size(), sizeof(LinearWithSigmoid_ExpectedOutput::all_ones) / sizeof(float));

--- a/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
+++ b/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
@@ -13,12 +13,6 @@
 #include <ctime>
 #include <unordered_map>
 
-//forward declaration
-namespace onnx{
-   class NodeProto;
-   class GraphProto;
-}
-
 namespace TMVA{
 namespace Experimental{
 namespace SOFIE{


### PR DESCRIPTION
-Fix the correct dependency of sofie tests. No ned to depend on protobuf
- Use weight file for Linear tests from ROOT
- Test also the case where the weight file is not present but the session is enabled
- Produce a runtime error when a weight file is enabled but the Session is disabled

