### PR TITLE
[RF][PyROOT] Skip out-of-range events in `RooDataSet.from_numpy()` and other fixes

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_roofit/_roodataset.py
@@ -56,7 +56,7 @@ class RooDataSet(object):
         return self._plotOnXY(*args, **kwargs)
 
     @staticmethod
-    def from_numpy(data, variables, name=None, title=None, weight_name=None, clip_to_limits=True):
+    def from_numpy(data, variables, name=None, title=None, weight_name=None):
         """Create a RooDataSet from a dictionary of numpy arrays.
         Args:
             data (dict): Dictionary with strings as keys and numpy arrays as
@@ -71,12 +71,6 @@ class RooDataSet(object):
                          empty string.
             weight_name (str): Key of the array in `data` that will be used for
                                the dataset weights.
-            clip_to_limits (bool): When entries are added to a RooDataSet, the
-                                   standard RooFit behavior is to clip the
-                                   values to the limits specified by the
-                                   binning of the RooFit variables. To save
-                                   computational cost, you can disable this
-                                   clipping if not necessary in your workflow.
 
         Returns:
             RooDataSet
@@ -93,15 +87,43 @@ class RooDataSet(object):
         else:
             dataset = ROOT.RooDataSet(name, title, variables, weight_name)
 
+        def log_warning(s):
+            """Log a string to the RooFit message log for the WARNING level on
+            the DataHandling topic.
+            """
+            log = ROOT.RooMsgService.instance().log(dataset, ROOT.RooFit.WARNING, ROOT.RooFit.DataHandling)
+            b = bytes(s, "utf-8")
+            log.write(b, len(b))
+            log.write("\n", 1)
+
+        range_mask = np.ones_like(list(data.values())[0], dtype=bool)
+
+        def in_range(arr, variable):
+
+            # For categories, we need to check whether the elements of the
+            # array are in the set of category state indices
+            if variable.isCategory():
+                return np.isin(arr, [state.second for state in variable])
+
+            return (arr >= variable.getMin()) & (arr <= variable.getMax())
+
+        # Get a mask that filters out all entries that are outside the variable definition range
+        range_mask = np.logical_and.reduce([in_range(data[v.GetName()], v) for v in variables])
+        # If all entries are in the range, we don't need a mask
+        if range_mask.all():
+            range_mask = None
+
+        def select_range_and_change_type(arr, dtype):
+            if range_mask is not None:
+                arr = arr[range_mask]
+            arr = arr if arr.dtype == dtype else np.array(arr, dtype=dtype)
+            return arr
+
         for real in dataset.store().realStoreList():
             vec = real.data()
             arg = real.bufArg()
-            arr = data[arg.GetName()]
+            arr = select_range_and_change_type(data[arg.GetName()], np.float64)
 
-            if clip_to_limits:
-                arr = np.clip(arr, a_min=arg.getMin(), a_max=arg.getMax())
-
-            arr = arr if arr.dtype == np.float64 else np.array(arr, dtype=np.float64)
             vec.resize(len(arr))
 
             beg = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
@@ -111,8 +133,8 @@ class RooDataSet(object):
 
         for cat in dataset.store().catStoreList():
             vec = cat.data()
-            arr = data[cat.bufArg().GetName()]
-            arr = arr if arr.dtype == np.int32 else np.array(arr, dtype=np.int32)
+            arg = cat.bufArg()
+            arr = select_range_and_change_type(data[arg.GetName()], np.int32)
             vec.resize(len(arr))
 
             beg = arr.ctypes.data_as(ctypes.POINTER(ctypes.c_int))
@@ -131,6 +153,10 @@ class RooDataSet(object):
 
         for cat in dataset.store().catStoreList():
             assert n_entries == cat.size()
+
+        if range_mask is not None:
+            n_out_of_range = len(range_mask) - range_mask.sum()
+            log_warning("RooDataSet.from_numpy({0}) Ignored {1} out-of-range events".format(name, n_out_of_range))
 
         return dataset
 
@@ -174,7 +200,7 @@ class RooDataSet(object):
         return data
 
     @staticmethod
-    def from_pandas(df, variables, name=None, title=None, weight_name=None, clip_to_limits=True):
+    def from_pandas(df, variables, name=None, title=None, weight_name=None):
         """Create a RooDataSet from a pandas DataFrame.
         Args:
             df (pandas.DataFrame): Pandas DataFrame to import.
@@ -188,12 +214,6 @@ class RooDataSet(object):
                          empty string.
             weight_name (str): Key of the array in `data` that will be used for
                                the dataset weights.
-            clip_to_limits (bool): When entries are added to a RooDataSet, the
-                                   standard RooFit behavior is to clip the
-                                   values to the limits specified by the
-                                   binning of the RooFit variables. To save
-                                   computational cost, you can disable this
-                                   clipping if not necessary in your workflow.
 
         Returns:
             RooDataSet
@@ -203,9 +223,7 @@ class RooDataSet(object):
         data = {}
         for column in df:
             data[column] = df[column].values
-        return ROOT.RooDataSet.from_numpy(
-            data, variables=variables, name=name, title=title, weight_name=weight_name, clip_to_limits=clip_to_limits
-        )
+        return ROOT.RooDataSet.from_numpy(data, variables=variables, name=name, title=title, weight_name=weight_name)
 
     def to_pandas(self):
         """Export a RooDataSet to a pandas DataFrame.

--- a/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset_numpy.py
@@ -49,9 +49,17 @@ class TestRooDataSetNumpy(unittest.TestCase):
         w = data.addColumn(wFunc)
         wdata = ROOT.RooDataSet(data.GetName(), data.GetTitle(), data, data.get(), "", w.GetName())
 
-        print(wdata.to_numpy())
-
         self.assertEqual(set(wdata.to_numpy().keys()), {"x", "cat", "w"})
+
+    def _check_value_equality(self, data, np_data):
+        vars_in_data = data.get()
+        x_in_data = vars_in_data["x"]
+        cat_in_data = vars_in_data["cat"]
+
+        for i in range(data.numEntries()):
+            data.get(i)
+            np.testing.assert_almost_equal(np_data["x"][i], x_in_data.getVal(), decimal=10)
+            self.assertEqual(np_data["cat"][i], cat_in_data.getIndex())
 
     def test_to_numpy_and_from_numpy(self):
         """Test exporting to numpy and then importing back a non-weighted dataset."""
@@ -71,6 +79,9 @@ class TestRooDataSetNumpy(unittest.TestCase):
             self.assertEqual(len(np_data[key]), len(np_data_2[key]))
             self.assertEqual(np_data[key][0], np_data_2[key][0])
             self.assertEqual(np_data[key][-1], np_data_2[key][-1])
+
+        self._check_value_equality(data, np_data)
+        self._check_value_equality(data, np_data_2)
 
     def test_to_numpy_and_from_numpy_weighted(self):
         """Test exporting to numpy and then importing back a weighted dataset."""
@@ -100,6 +111,37 @@ class TestRooDataSetNumpy(unittest.TestCase):
             self.assertEqual(len(np_data[key]), len(np_data_2[key]))
             self.assertEqual(np_data[key][0], np_data_2[key][0])
             self.assertEqual(np_data[key][-1], np_data_2[key][-1])
+
+        self._check_value_equality(data, np_data)
+        self._check_value_equality(data, np_data_2)
+
+    def test_ignoring_out_of_range(self):
+        """Test that rows with out-of-range values are skipped, both for
+        real-valued columns and categories.
+        """
+
+        n_events = 100
+        # Dataset with "x" randomly distributed between -3 and 3, and "cat"
+        # being either -1, 0, or +1.
+        data = {
+            "x": np.random.rand(n_events) * 6.0 - 3.0,
+            "cat": np.random.randint(3, size=n_events) - 1,
+        }
+
+        # The RooFit variable "x" is only defined from -1 to 2, and the
+        # category doesn't have the 0-state.
+        x = ROOT.RooRealVar("x", "x", 0.0, -2.0, 2.0)
+        cat = ROOT.RooCategory("cat", "cat")
+        cat.defineType("minus", -1)
+        cat.defineType("plus", +1)
+
+        in_x_range = (data["x"] <= x.getMax()) & (data["x"] >= x.getMin())
+        in_cat_range = (data["cat"] == -1) | (data["cat"] == +1)
+        n_in_range = np.sum(in_x_range & in_cat_range)
+
+        dataset_numpy = ROOT.RooDataSet.from_numpy(data, {x, cat}, name="dataSetNumpy")
+
+        self.assertEqual(dataset_numpy.numEntries(), n_in_range)
 
 
 if __name__ == "__main__":

--- a/roofit/roofitcore/src/RooAbsCategory.cxx
+++ b/roofit/roofitcore/src/RooAbsCategory.cxx
@@ -562,17 +562,10 @@ void RooAbsCategory::copyCache(const RooAbsArg *source, bool /*valueOnly*/, bool
    auto other = static_cast<const RooAbsCategory*>(source);
    assert(dynamic_cast<const RooAbsCategory*>(source));
 
-   value_type tmp = other->_treeReadBuffer ? *other->_treeReadBuffer : other->_currentIndex;
-   // Lookup cat state from other-index because label is missing
-   if (hasIndex(tmp)) {
-     _currentIndex = tmp;
-     if (setValDirty) {
-       setValueDirty();
-     }
-   } else {
-     coutE(DataHandling) << "RooAbsCategory::copyCache(" << GetName() << ") ERROR: index of source arg "
-         << source->GetName() << " is invalid (" << other->_currentIndex
-         << "), value not updated" << endl;
+   _currentIndex = other->_treeReadBuffer ? *other->_treeReadBuffer : other->_currentIndex;
+
+   if (setValDirty) {
+     setValueDirty();
    }
 }
 

--- a/roofit/roofitcore/src/RooTreeDataStore.cxx
+++ b/roofit/roofitcore/src/RooTreeDataStore.cxx
@@ -426,8 +426,15 @@ void RooTreeDataStore::loadValues(const TTree *t, const RooFormulaVar* select, c
         numInvalid++ ;
         allOK=false ;
         if (numInvalid < 5) {
-          coutI(DataHandling) << "RooTreeDataStore::loadValues(" << GetName() << ") Skipping event #" << i << " because " << destArg->GetName()
-              << " cannot accommodate the value " << static_cast<RooAbsReal*>(sourceArg)->getVal() << std::endl;
+          auto& log = coutI(DataHandling);
+          log << "RooTreeDataStore::loadValues(" << GetName() << ") Skipping event #" << i << " because " << destArg->GetName()
+              << " cannot accommodate the value ";
+          if(sourceArg->isCategory()) {
+            log << static_cast<RooAbsCategory*>(sourceArg)->getCurrentIndex();
+          } else {
+            log << static_cast<RooAbsReal*>(sourceArg)->getVal();
+          }
+          log << std::endl;
         } else if (numInvalid == 5) {
           coutI(DataHandling) << "RooTreeDataStore::loadValues(" << GetName() << ") Skipping ..." << std::endl;
         }


### PR DESCRIPTION
The recently-introduced `RooDataSet.from_numpy()` function was clipping
out-of-range events to the variable boundaries instead of clipping them.

This behavior was misleading and confusing to the users, because the
import of a TTree just skips out out-of-range events.

This commit implements the skipping for `RooDataSet.from_numpy()` as
well, logging also the same warnings when that happens.

A unit test that checks the skipping works correctly for categories and
real-valued variables is also implemented.

Closes https://github.com/root-project/root/issues/10447.

Some other things are also fixed by the two first commits, see more detail in the commit descriptions.

