### PR TITLE
fix display of items in TBrowser that have a checkbox on MAC

### DIFF
--- a/gui/gui/src/TGListTree.cxx
+++ b/gui/gui/src/TGListTree.cxx
@@ -1507,9 +1507,6 @@ void TGListTree::DrawItem(Handle_t id, TGListTreeItem *item, Int_t x, Int_t y,
          height = pic1->GetHeight();
          ypic1 = y;
       } else {
-#ifdef R__HAS_COCOA
-         if (!pic2)//DO NOT MODIFY ytext, it WAS ADJUSTED already!
-#endif
          ytext = y;
          ypic1 = y + (Int_t)((height - pic1->GetHeight()) >> 1);
       }


### PR DESCRIPTION
This fixes a display issue on TBrowser on the mac (compiled to coca) where items in the list that had checkboxes against them have their text erroneously displayed that the top of the list rather than next to the item.

Please can we backport this fix as well into the patch releases. Thanks!