### PR TITLE
[DF] Avoid useless calls to TTree::GetBranch

### DIFF
--- a/tree/dataframe/src/RLoopManager.cxx
+++ b/tree/dataframe/src/RLoopManager.cxx
@@ -126,7 +126,7 @@ static void ExploreBranch(TTree &t, std::set<std::string> &bNamesReg, ColumnName
          InsertBranchName(bNamesReg, bNames, std::string(branchDirectlyFromTree->GetFullName()), friendName,
                           allowDuplicates);
 
-      if (t.GetBranch(subBranchName.c_str()))
+      if (bNamesReg.find(subBranchName) == bNamesReg.end() && t.GetBranch(subBranchName.c_str()))
          InsertBranchName(bNamesReg, bNames, subBranchName, friendName, allowDuplicates);
    }
 }


### PR DESCRIPTION
If subBranchName is already in bNamesReg, then we don't need to try to reinsert it.
This patch shaves off ~10% from the runtime of an exploration of a large test TTree.