### PR TITLE
[tmva][pymva] Fix and improve Python tutorials and enable  tf.keras by default

### DIFF
--- a/tmva/pymva/inc/TMVA/MethodPyKeras.h
+++ b/tmva/pymva/inc/TMVA/MethodPyKeras.h
@@ -86,7 +86,7 @@ namespace TMVA {
       UInt_t fNumEpochs {0}; // Number of training epochs
       Int_t fNumThreads {0}; // Number of CPU threads (if 0 uses default values)
       Int_t fVerbose; // Keras verbosity during training
-      Bool_t fUseTFKeras { kFALSE};   // use Keras from Tensorflow (-1, default, 0 false, 1, true)
+      Bool_t fUseTFKeras { true};   // use Keras from Tensorflow default is true
       Bool_t fContinueTraining; // Load weights from previous training
       Bool_t fSaveBestOnly; // Store only weights with smallest validation loss
       Int_t fTriesEarlyStopping; // Stop training if validation loss is not decreasing for several epochs

--- a/tmva/pymva/src/MethodPyKeras.cxx
+++ b/tmva/pymva/src/MethodPyKeras.cxx
@@ -82,6 +82,7 @@ void MethodPyKeras::DeclareOptions() {
    DeclareOptionRef(fNumThreads, "NumThreads", "Number of CPU threads (only for Tensorflow backend)");
    DeclareOptionRef(fGpuOptions, "GpuOptions", "GPU options for tensorflow, such as allow_growth");
    DeclareOptionRef(fUseTFKeras, "tf.keras", "Use tensorflow from Keras");
+   DeclareOptionRef(fUseTFKeras, "tfkeras", "Use tensorflow from Keras");
    DeclareOptionRef(fVerbose, "Verbose", "Keras verbosity during training");
    DeclareOptionRef(fContinueTraining, "ContinueTraining", "Load weights from previous training");
    DeclareOptionRef(fSaveBestOnly, "SaveBestOnly", "Store only weights with smallest validation loss");

--- a/tutorials/tmva/TMVA_CNN_Classification.py
+++ b/tutorials/tmva/TMVA_CNN_Classification.py
@@ -33,8 +33,6 @@ import os
 import importlib
 
 TMVA.Tools.Instance()
-TMVA.PyMethodBase.PyInitialize()
-
 
 def MakeImagesTree(n, nh, nw):
     # image size (nh x nw)
@@ -122,6 +120,8 @@ if (not hasCPU and not hasGPU) :
 if ROOT.gSystem.GetFromPipe("root-config --has-tmva-pymva") != "yes":
     useKerasCNN = False
     usePyTorchCNN = False
+else:
+    TMVA.PyMethodBase.PyInitialize()
 
 tf_spec = importlib.util.find_spec("tensorflow")
 if tf_spec is None:
@@ -138,10 +138,6 @@ if not useTMVACNN:
         "TMVA_CNN_Classificaton",
         "TMVA is not build with GPU or CPU multi-thread support. Cannot use TMVA Deep Learning for CNN",
     )
-
-#there is an issue using TF and PyTorch - so use only one of the two
-if (usePyTorchCNN):
-   useKerasCNN = False
 
 writeOutputFile = True
 


### PR DESCRIPTION
- Protect usage of pymva when it is available
- Enable tf.keras by default in MethodPyKeras since this is now the standard for Keras. Call also the option `tfkeras`
 in addition to `tf.keras` since this form will not work as cmd arg in Python.

