### PR TITLE
[RF] Added interface changes for TestStatatistics classes

### DIFF
--- a/roofit/roofitcore/CMakeLists.txt
+++ b/roofit/roofitcore/CMakeLists.txt
@@ -499,7 +499,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(RooFitCore
 )
 
 if (roofit_multiprocess)
-  target_link_libraries(RooFitCore PRIVATE RooFitMultiProcess)
+  target_link_libraries(RooFitCore PUBLIC RooFitMultiProcess)
   set(RooFitCore_MultiProcess_TestStatistics_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/res")
   target_include_directories(RooFitCore PRIVATE ${RooFitCore_MultiProcess_TestStatistics_INCLUDE_DIR})
 endif()

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -185,6 +185,9 @@ public:
       int doWarn = 1;
       int doSumW2 = -1;
       int doAsymptotic = -1;
+      int nWorkers = 1;
+      int parallel_gradient = 0;
+      int parallel_likelihood = 0;
       const RooArgSet* minosSet = nullptr;
       std::string minType;
       std::string minAlg = "minuit";

--- a/roofit/roofitcore/inc/RooFit/TestStatistics/RooRealL.h
+++ b/roofit/roofitcore/inc/RooFit/TestStatistics/RooRealL.h
@@ -41,6 +41,8 @@ public:
    inline double getCarry() const { return eval_carry; }
    inline double defaultErrorLevel() const override { return 0.5; }
 
+   std::shared_ptr<RooAbsL> getRooAbsL() { return likelihood_; };
+
 protected:
    double evaluate() const override;
 

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -201,6 +201,8 @@ RooCmdArg EventRange(Int_t nStart, Int_t nStop) ;
 RooCmdArg Extended(bool flag=true) ;
 RooCmdArg DataError(Int_t) ;
 RooCmdArg NumCPU(Int_t nCPU, Int_t interleave=0) ;
+RooCmdArg Parallelize(Int_t nWorkers, bool parallel_gradient, bool parallel_likelihood) ;
+RooCmdArg NewStyle(bool flag=false) ;
 
 RooCmdArg BatchMode(std::string const& batchMode="cpu");
 // The const char * overload is necessary, otherwise the compiler will cast a

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -20,147 +20,168 @@
 #include <RooFit/TestStatistics/RooAbsL.h>
 #include <RooFit/TestStatistics/LikelihoodWrapper.h>
 #include <RooFit/TestStatistics/LikelihoodGradientWrapper.h>
+#include <RooFit/MultiProcess/Config.h>
 
 #include <Fit/Fitter.h>
+#include <Math/MinimizerOptions.h>
 #include <TStopwatch.h>
 #include <TMatrixDSymfwd.h>
 
 #include <fstream>
-#include <memory>  // shared_ptr, unique_ptr
+#include <memory> // shared_ptr, unique_ptr
 #include <string>
 #include <utility>
 #include <vector>
 
-class RooAbsMinimizerFcn ;
-class RooAbsReal ;
-class RooFitResult ;
-class RooArgList ;
-class RooRealVar ;
-class RooArgSet ;
-class RooPlot ;
-class RooDataSet ;
+class RooAbsMinimizerFcn;
+class RooAbsReal;
+class RooFitResult;
+class RooArgList;
+class RooRealVar;
+class RooArgSet;
+class RooPlot;
+class RooDataSet;
 
 class RooMinimizer : public TObject {
 public:
-  enum class FcnMode { classic, gradient, generic_wrapper };
+   enum class FcnMode { classic, gradient, generic_wrapper };
 
-  explicit RooMinimizer(RooAbsReal &function, FcnMode fcnMode = FcnMode::classic);
-  explicit RooMinimizer(std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood,
-                        RooFit::TestStatistics::LikelihoodMode likelihoodMode =
-                           RooFit::TestStatistics::LikelihoodMode::serial,
-                        RooFit::TestStatistics::LikelihoodGradientMode likelihoodGradientMode =
-                           RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   /// Config argument to RooMinimizer ctor
+   struct Config {
+      double recoverFromNaN = 10.; // RooAbsMinimizerFcn config
+      int optConst = 0;            // RooAbsMinimizerFcn config
+      int printEvalErrors = 10;    // RooAbsMinimizerFcn config
+      int doEEWall = 1;            // RooAbsMinimizerFcn config
+      int offsetting = -1;         // RooAbsMinimizerFcn config
+      const char *logf = nullptr;  // RooAbsMinimizerFcn config
+      int nWorkers =
+         RooFit::MultiProcess::Config::getDefaultNWorkers(); // RooAbsMinimizerFcn config that can only be set in ctor
+      int parallel_gradient = 0;          // // RooAbsMinimizerFcn config that can only be set in ctor
+      int parallel_likelihood = 0;        // // RooAbsMinimizerFcn config that can only be set in ctor
+      int verbose = 0;                    // local config
+      bool profile;                       // local config
+      std::string minimizerType = "";     // local config
+      FcnMode fcnMode = FcnMode::classic; // local config
+   };
 
-  ~RooMinimizer() override;
+   explicit RooMinimizer(RooAbsReal &function, FcnMode fcnMode = FcnMode::classic);
+   explicit RooMinimizer(RooAbsReal &function, Config &cfg);
+   explicit RooMinimizer(std::shared_ptr<RooFit::TestStatistics::RooAbsL> likelihood, Config &cfg);
 
-  enum Strategy { Speed=0, Balance=1, Robustness=2 } ;
-  enum PrintLevel { None=-1, Reduced=0, Normal=1, ExtraForProblem=2, Maximum=3 } ;
-  void setStrategy(int strat) ;
-  void setErrorLevel(double level) ;
-  void setEps(double eps) ;
-  void optimizeConst(int flag) ;
-  void setEvalErrorWall(bool flag) ;
-  void setRecoverFromNaNStrength(double strength) ;
-  void setOffsetting(bool flag) ;
-  void setMaxIterations(int n) ;
-  void setMaxFunctionCalls(int n) ;
+   ~RooMinimizer() override;
+   RooMinimizer(const RooMinimizer &min);
 
-  int migrad() ;
-  int hesse() ;
-  int minos() ;
-  int minos(const RooArgSet& minosParamList) ;
-  int seek() ;
-  int simplex() ;
-  int improve() ;
+   enum Strategy { Speed = 0, Balance = 1, Robustness = 2 };
+   enum PrintLevel { None = -1, Reduced = 0, Normal = 1, ExtraForProblem = 2, Maximum = 3 };
 
-  int minimize(const char* type, const char* alg=nullptr) ;
+   // Setters on _theFitter
+   static void setStrategy(int strat);
+   static void setErrorLevel(double level);
+   static void setEps(double eps);
+   static void setMaxIterations(int n);
+   static void setMaxFunctionCalls(int n);
+   static void setPrintLevel(int newLevel);
 
-  RooFitResult* save(const char* name=nullptr, const char* title=nullptr) ;
-  RooPlot* contour(RooRealVar& var1, RooRealVar& var2,
-         double n1=1.0, double n2=2.0, double n3=0.0,
-         double n4=0.0, double n5=0.0, double n6=0.0, unsigned int npoints = 50) ;
+   // Setters on _fcn
+   void optimizeConst(int flag);
+   void setEvalErrorWall(bool flag);
+   void setRecoverFromNaNStrength(double strength);
+   void setOffsetting(bool flag);
+   void setPrintEvalErrors(int numEvalErrors);
+   void setVerbose(bool flag = true);
+   bool setLogFile(const char *logf = nullptr);
 
-  int setPrintLevel(int newLevel) ;
-  void setPrintEvalErrors(int numEvalErrors) ;
-  void setVerbose(bool flag=true) ;
-  void setProfile(bool flag=true) { _profile = flag ; }
-  bool setLogFile(const char* logf=nullptr) ;
+   int migrad();
+   int hesse();
+   int minos();
+   int minos(const RooArgSet &minosParamList);
+   int seek();
+   int simplex();
+   int improve();
 
-  /// Enable or disable the logging of function evaluations to a RooDataSet.
-  /// \see RooMinimizer::getLogDataSet().
-  /// param[in] flag Boolean flag to disable or enable the functionality.
-  void setLoggingToDataSet(bool flag=true) { _loggingToDataSet = flag ; }
+   int minimize(const char *type, const char *alg = nullptr);
 
-  /// If logging of function evaluations to a RooDataSet is enabled, returns a
-  /// pointer to a dataset with one row per evaluation of the RooAbsReal passed
-  /// to the minimizer. As columns, there are all floating parameters and the
-  /// values they had for that evaluation.
-  /// \see RooMinimizer::setLoggingToDataSet(bool).
-  RooDataSet * getLogDataSet() const { return _logDataSet.get(); }
+   RooFitResult *save(const char *name = nullptr, const char *title = nullptr);
+   RooPlot *contour(RooRealVar &var1, RooRealVar &var2, double n1 = 1.0, double n2 = 2.0, double n3 = 0.0,
+                    double n4 = 0.0, double n5 = 0.0, double n6 = 0.0, unsigned int npoints = 50);
 
-  int getPrintLevel() const { return _printLevel; }
+   void setProfile(bool flag = true) { _cfg.profile = flag; }
+   /// Enable or disable the logging of function evaluations to a RooDataSet.
+   /// \see RooMinimizer::getLogDataSet().
+   /// param[in] flag Boolean flag to disable or enable the functionality.
+   void setLoggingToDataSet(bool flag = true) { _loggingToDataSet = flag; }
 
-  void setMinimizerType(std::string const& type) ;
-  std::string const& minimizerType() const { return _minimizerType; }
+   /// If logging of function evaluations to a RooDataSet is enabled, returns a
+   /// pointer to a dataset with one row per evaluation of the RooAbsReal passed
+   /// to the minimizer. As columns, there are all floating parameters and the
+   /// values they had for that evaluation.
+   /// \see RooMinimizer::setLoggingToDataSet(bool).
+   RooDataSet *getLogDataSet() const { return _logDataSet.get(); }
 
-  static void cleanup() ;
-  static RooFitResult* lastMinuitFit() ;
-  static RooFitResult* lastMinuitFit(const RooArgList& varList) ;
+   static int getPrintLevel();
 
-  void saveStatus(const char* label, int status) { _statusHistory.push_back(std::pair<std::string,int>(label,status)) ; }
+   void setMinimizerType(std::string const &type);
+   std::string const &minimizerType() const { return _cfg.minimizerType; }
 
-  int evalCounter() const ;
-  void zeroEvalCount() ;
+   static void cleanup();
+   static RooFitResult *lastMinuitFit();
+   static RooFitResult *lastMinuitFit(const RooArgList &varList);
 
-  ROOT::Fit::Fitter* fitter() ;
-  const ROOT::Fit::Fitter* fitter() const ;
+   void saveStatus(const char *label, int status)
+   {
+      _statusHistory.push_back(std::pair<std::string, int>(label, status));
+   }
 
-  ROOT::Math::IMultiGenFunction* getMultiGenFcn() const;
+   int evalCounter() const;
+   void zeroEvalCount();
 
-  int getNPar() const ;
+   ROOT::Fit::Fitter *fitter();
+   const ROOT::Fit::Fitter *fitter() const;
 
-  void applyCovarianceMatrix(TMatrixDSym const& V) ;
+   ROOT::Math::IMultiGenFunction *getMultiGenFcn() const;
+
+   int getNPar() const;
+
+   void applyCovarianceMatrix(TMatrixDSym const &V);
 
 private:
+   friend class RooAbsMinimizerFcn;
 
-  friend class RooAbsMinimizerFcn;
+   void profileStart();
+   void profileStop();
 
-  void profileStart() ;
-  void profileStop() ;
+   std::ofstream *logfile();
+   double &maxFCN();
 
-  std::ofstream* logfile() ;
-  double& maxFCN() ;
+   bool fitFcn() const;
 
-  bool fitFcn() const;
+   // constructor helper functions
+   void initOldStyle(RooAbsReal &function);
+   void initNewStyle(std::shared_ptr<RooFit::TestStatistics::RooAbsL> &function);
+   void initMinimizerFirstPart();
+   void initMinimizerFcnDependentPart(double defaultErrorLevel);
+   void execSetters(); // Executes setters that set _fcn config as per given _cfg configuration
 
-  // constructor helper functions
-  void initMinimizerFirstPart();
-  void initMinimizerFcnDependentPart(double defaultErrorLevel);
+   int _status = -99;
+   bool _profileStart = false;
+   bool _loggingToDataSet = false;
 
-  int _printLevel = 1;
-  int _status = -99;
-  bool _profile = false;
-  bool _loggingToDataSet = false;
-  bool _verbose = false;
-  bool _profileStart = false;
+   TStopwatch _timer;
+   TStopwatch _cumulTimer;
 
-  TStopwatch _timer;
-  TStopwatch _cumulTimer;
+   std::unique_ptr<TMatrixDSym> _extV;
 
-  std::unique_ptr<TMatrixDSym> _extV;
+   RooAbsMinimizerFcn *_fcn;
 
-  RooAbsMinimizerFcn *_fcn;
+   static std::unique_ptr<ROOT::Fit::Fitter> _theFitter;
 
-  std::string _minimizerType;
-  FcnMode _fcnMode;
+   std::vector<std::pair<std::string, int>> _statusHistory;
 
-  static std::unique_ptr<ROOT::Fit::Fitter> _theFitter ;
+   std::unique_ptr<RooDataSet> _logDataSet;
 
-  std::vector<std::pair<std::string,int> > _statusHistory ;
+   RooMinimizer::Config _cfg; // local config object
 
-  std::unique_ptr<RooDataSet> _logDataSet;
-
-  ClassDefOverride(RooMinimizer,0) // RooFit interface to ROOT::Fit::Fitter
-} ;
+   ClassDefOverride(RooMinimizer, 0) // RooFit interface to ROOT::Fit::Fitter
+};
 
 #endif

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -177,6 +177,8 @@ namespace RooFit {
   RooCmdArg Extended(bool flag) { return RooCmdArg("Extended",flag,0,0,0,0,0,0,0) ; }
   RooCmdArg DataError(Int_t etype) { return RooCmdArg("DataError",(Int_t)etype,0,0,0,0,0,0,0) ; }
   RooCmdArg NumCPU(Int_t nCPU, Int_t interleave)   { return RooCmdArg("NumCPU",nCPU,interleave,0,0,0,0,0,0) ; }
+  RooCmdArg NewStyle(bool flag) { return RooCmdArg("NewStyle",flag,0,0,0,0,0,0) ; }
+  RooCmdArg Parallelize(Int_t nWorkers, bool parallel_gradient, bool parallel_likelihood) { return RooCmdArg("Parallelize",nWorkers,parallel_gradient,parallel_likelihood,0,0,0,0,0) ; }
   RooCmdArg BatchMode(std::string const& batchMode) {
       std::string lower = batchMode;
       std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c){ return std::tolower(c); });

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -51,6 +51,7 @@ ROOT_ADD_GTEST(testRooSTLRefCountList testRooSTLRefCountList.cxx LIBRARIES RooFi
 ROOT_ADD_GTEST(testLikelihoodSerial TestStatistics/testLikelihoodSerial.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsL TestStatistics/testRooAbsL.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooRealL TestStatistics/RooRealL.cpp LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testInterface TestStatistics/testInterface.cpp LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFit)
 ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFit)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)

--- a/roofit/roofitcore/test/TestStatistics/testInterface.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testInterface.cpp
@@ -1,0 +1,107 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *   IP, Inti Pelupessy, Netherlands eScience Center, i.pelupessy@esciencecenter.nl
+ *   VC, Vince Croft, DIANA / NYU, vincent.croft@cern.ch
+ *
+ * Copyright (c) 2021, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include <RooFit/TestStatistics/RooRealL.h>
+#include <RooFit/TestStatistics/RooUnbinnedL.h>
+
+#include <RooArgSet.h>
+#include <RooRandom.h>
+#include <RooWorkspace.h>
+#include <RooAbsPdf.h>
+#include <RooDataSet.h>
+#include <RooMinimizer.h>
+#include <RooFitResult.h>
+#include <RooProdPdf.h>
+#include <RooAddition.h>
+#include <RooConstraintSum.h>
+#include <RooPolynomial.h>
+#include <RooDataHist.h>
+#include <RooRealSumPdf.h>
+#include <RooNLLVar.h>
+#include <RooRealVar.h>
+
+#include <algorithm> // count_if
+
+#include "gtest/gtest.h"
+
+class Interface : public ::testing::TestWithParam<std::tuple<std::size_t>> {};
+
+// Verifies that RooAbsPdf::createNLL() can create a valid RooAbsL wrapped in RooRealL
+TEST(Interface, createNLLRooAbsL)
+{
+   using namespace RooFit;
+
+   // Real-life test: calculate a NLL using event-based parallelization. This
+   // should replicate RooRealMPFE results.
+   RooRandom::randomGenerator()->SetSeed(42);
+   RooWorkspace w;
+   w.factory("Gaussian::g(x[-5,5],mu[0,-3,3],sigma[1])");
+   auto x = w.var("x");
+   RooAbsPdf *pdf = w.pdf("g");
+   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+   RooAbsReal *nll = pdf->createNLL(*data, RooFit::NewStyle(true));
+
+   RooFit::TestStatistics::RooRealL *nll_real = dynamic_cast<RooFit::TestStatistics::RooRealL *>(nll);
+
+   // Check if dynamic cast succesful
+   EXPECT_TRUE(nll_real != nullptr);
+
+   std::shared_ptr<RooFit::TestStatistics::RooAbsL> nll_absL = nll_real->getRooAbsL();
+}
+
+// Verifies that RooAbsPdf::fitTo() can create a valid RooAbsL wrapped in RooRealL and fit
+TEST(Interface, fitTo)
+{
+   using namespace RooFit;
+   ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2");
+
+   // Real-life test: calculate a NLL using event-based parallelization. This
+   // should replicate RooRealMPFE results.
+   RooRandom::randomGenerator()->SetSeed(42);
+   RooWorkspace w;
+   w.factory("Gaussian::g(x[-5,5],mu[0,-3,3],sigma[1])");
+   auto x = w.var("x");
+   RooAbsPdf *pdf = w.pdf("g");
+   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+
+   pdf->fitTo(*data, Parallelize(4, true, true));
+}
+
+// Verifies that RooAbsPdf::createNLL() can create a valid RooAbsL wrapped in RooRealL
+TEST(Interface, RooMinimizer)
+{
+   using namespace RooFit;
+   ROOT::Math::MinimizerOptions::SetDefaultMinimizer("Minuit2");
+
+   // Real-life test: calculate a NLL using event-based parallelization. This
+   // should replicate RooRealMPFE results.
+   RooRandom::randomGenerator()->SetSeed(42);
+   RooWorkspace w;
+   w.factory("Gaussian::g(x[-5,5],mu[0,-3,3],sigma[1])");
+   auto x = w.var("x");
+   RooAbsPdf *pdf = w.pdf("g");
+   std::unique_ptr<RooDataSet> data{pdf->generate(RooArgSet(*x), 10000)};
+
+   // RooAbsReal* nll_1 = pdf->createNLL(*data, RooFit::NewStyle(true));
+   // RooMinimizer m_1(*nll_1);
+   // m_1.minimize("Minuit2");
+
+   RooMinimizer::Config cfg;
+   cfg.parallel_gradient = true;
+   cfg.parallel_likelihood = true;
+   cfg.nWorkers = 4;
+   RooAbsReal *nll_2 = pdf->createNLL(*data, RooFit::NewStyle(true));
+   RooMinimizer m_2(*nll_2, cfg);
+   m_2.minimize("Minuit2");
+}

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cpp
@@ -101,8 +101,10 @@ TEST_P(LikelihoodGradientJob, Gaussian1D)
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooMinimizer m1(likelihood, RooFit::TestStatistics::LikelihoodMode::serial,
-                   RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooMinimizer::Config cfg;
+   cfg.parallel_likelihood = false;
+   cfg.parallel_gradient = true;
+   RooMinimizer m1(likelihood, cfg);
 
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
@@ -148,8 +150,10 @@ TEST(LikelihoodGradientJob, RepeatMigrad)
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooMinimizer m1(likelihood, RooFit::TestStatistics::LikelihoodMode::serial,
-                   RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooMinimizer::Config cfg;
+   cfg.parallel_likelihood = false;
+   cfg.parallel_gradient = true;
+   RooMinimizer m1(likelihood, cfg);
 
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
@@ -223,8 +227,10 @@ TEST_P(LikelihoodGradientJob, GaussianND)
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooMinimizer m1(likelihood, RooFit::TestStatistics::LikelihoodMode::serial,
-                   RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooMinimizer::Config cfg;
+   cfg.parallel_likelihood = false;
+   cfg.parallel_gradient = true;
+   RooMinimizer m1(likelihood, cfg);
 
    m1.setStrategy(0);
    m1.setPrintLevel(-1);
@@ -392,8 +398,10 @@ TEST_F(LikelihoodSimBinnedConstrainedTest, ConstrainedAndOffset)
       pdf, data, RooFit::TestStatistics::ConstrainedParameters(RooArgSet(*w.var("alpha_bkg_obs_A"))),
       RooFit::TestStatistics::GlobalObservables(RooArgSet(*w.var("alpha_bkg_obs_B"))));
 
-   RooMinimizer m1(likelihood, RooFit::TestStatistics::LikelihoodMode::serial,
-                   RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooMinimizer::Config cfg;
+   cfg.parallel_likelihood = false;
+   cfg.parallel_gradient = true;
+   RooMinimizer m1(likelihood, cfg);
    m1.setOffsetting(true);
 
    m1.setStrategy(0);
@@ -475,8 +483,10 @@ TEST_P(LikelihoodGradientJob, Gaussian1DAlsoWithLikelihoodJob)
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
    auto likelihood = std::make_shared<RooFit::TestStatistics::RooUnbinnedL>(pdf, data);
-   RooMinimizer m1(likelihood, RooFit::TestStatistics::LikelihoodMode::multiprocess,
-                   RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+   RooMinimizer::Config cfg;
+   cfg.parallel_likelihood = true;
+   cfg.parallel_gradient = true;
+   RooMinimizer m1(likelihood, cfg);
 
    m1.setStrategy(0);
    m1.setPrintLevel(-1);

--- a/roofit/roofitcore/test/TestStatistics/testPlot.cpp
+++ b/roofit/roofitcore/test/TestStatistics/testPlot.cpp
@@ -72,8 +72,10 @@ public:
       // Creating a minimizer and explicitly setting type of parallelization
       std::size_t nWorkers = 1;
       RooFit::MultiProcess::Config::setDefaultNWorkers(nWorkers);
-      RooMinimizer m(likelihood, RooFit::TestStatistics::LikelihoodMode::serial,
-                     RooFit::TestStatistics::LikelihoodGradientMode::multiprocess);
+      RooMinimizer::Config cfg;
+      cfg.parallel_likelihood = false;
+      cfg.parallel_gradient = true;
+      RooMinimizer m(likelihood, cfg);
 
       // Minimize
       m.migrad();


### PR DESCRIPTION
# This Pull request:

Adds new interface features to `RooAbsPdf::fitTo()` and `RooMinimizer::Minimize()` to use new (parallel) teststatistics based classes. 

## Changes or fixes:

- Adds new Parallelize() and NewStyle() named arguments to RooAbsPdf::fitTo() to respectively determine parallelisation configuration and whether to use new style likelihoods.
- Adds a configuration struct to the RooMinimizer that is the single source of truth on RooMinimizer config parameters, including the new parallelisation parameters. This struct can be given to the RooMinimizer constructor, whereas previously all configuration was done after the creation of the constructor through setters on the RooMinimizer, these setters also maintain their original functionality. Note that the parallelisation parameters can *only* be given in the RooMinimizer constructor.
- Adds tests to test the aforementioned new functionality
- Also, since I made a lot of changes to the file, this PR also includes an entire reformat of the RooMinimizer.cxx and RooMinimizer.h with clang-format.

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

