### PR TITLE
[PyROOT] Fixes for Numba.Declare

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
@@ -61,9 +61,11 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
                         'UL': 'unsigned long',
                         'B': 'bool'
                         }
-                if t[4:] in typemap: # first 3 characters are "RVec"
-                    return typemap[t[4:]]
-                raise Exception(
+                rvec_start = t.find('RVec') # discard a possible const modifier before "RVec"
+                try:
+                    return typemap[t[rvec_start+4:]] # alias type characters come after "RVec"
+                except KeyError:
+                    raise Exception(
                         'Unrecognized type {}. Valid shorthand aliases of RVec are {}'
                         .format(t, list('RVec' + i for i in typemap.keys())))
             g = re.match('(.*)<(.*)>', t).groups(0)
@@ -137,6 +139,25 @@ def _NumbaDeclareDecorator(input_types, return_type = None, name=None):
             nb_return_type = None
         return nb_return_type, nb_input_types
 
+    def add_rvec_input_type_ref(input_types_ref, const_mod, rvect):
+        '''
+        Construct the type of an RVec input parameter for its use in the C++
+        wrapper function signature.
+        '''
+        tref = '{}ROOT::{}&'.format(const_mod, rvect)
+        input_types_ref.append(tref)
+
+    def add_rvec_func_ptr_input_type(func_ptr_input_types, const_mod, rvect):
+        '''
+        Construct the type of an RVec input parameter for its use in the cast
+        of the function pointer of the jitted Python wrapper.
+        '''
+        innert = get_inner_type(rvect)
+        if innert == 'bool':
+            # Special treatment for bool: In numpy, bools have 1 byte
+            innert = 'char'
+
+        func_ptr_input_types += ['{}{}*, int'.format(const_mod, innert)]
 
     def inner(func, input_types=input_types, return_type=return_type, name=name):
         '''
@@ -265,22 +286,25 @@ def pywrapper({SIGNATURE}):
 
         # Build C++ wrapper for jitting with cling
 
-        # Define input signature
-        input_types_ref = ['ROOT::{}&'.format(t) if 'RVec' in t else t for t in input_types]
-        input_signature = ', '.join('{} x_{}'.format(t, i) for i, t in enumerate(input_types_ref))
-
-        # Define function pointer types
+        # Define:
+        # - Input signature
+        # - Function pointer types
+        input_types_ref = []
         func_ptr_input_types = []
         for t in input_types:
-            if 'RVec' in t:
-                innert = get_inner_type(t)
-                if innert == 'bool':
-                    # Special treatment for bool: In numpy, bools have 1 byte
-                    func_ptr_input_types += ['char*, int']
-                else:
-                    func_ptr_input_types += ['{}*, int'.format(innert)]
+            m = re.match('\s*(const\s+)?(RVec[\w<>\s]+)', t)
+            if m:
+                const_mod = '' if m.group(1) is None else 'const '
+                rvect = m.group(2)
+
+                add_rvec_input_type_ref(input_types_ref, const_mod, rvect)
+                add_rvec_func_ptr_input_type(func_ptr_input_types, const_mod, rvect)
             else:
-                func_ptr_input_types += [t]
+                input_types_ref.append(t)
+                func_ptr_input_types.append(t)
+
+        input_signature = ', '.join('{} x_{}'.format(t, i) for i, t in enumerate(input_types_ref))
+
         if 'RVec' in return_type:
             # See C++ wrapper code for the reason using these types
             innert = get_inner_type(return_type)

--- a/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_numbadeclare.py
@@ -292,7 +292,7 @@ def pywrapper({SIGNATURE}):
         input_types_ref = []
         func_ptr_input_types = []
         for t in input_types:
-            m = re.match('\s*(const\s+)?(RVec[\w<>\s]+)', t)
+            m = re.match('\s*(const\s+)?(RVec\w+|RVec<[\w\s]+>)', t)
             if m:
                 const_mod = '' if m.group(1) is None else 'const '
                 rvect = m.group(2)

--- a/bindings/pyroot/pythonizations/test/numbadeclare.py
+++ b/bindings/pyroot/pythonizations/test/numbadeclare.py
@@ -128,6 +128,23 @@ class NumbaDeclareSimple(unittest.TestCase):
         self.assertEqual(mean_x.GetValue(), 1.5)
         self.assertEqual(mean_y.GetValue(), 3.0)
 
+    @unittest.skipIf(skip, skip_reason)
+    def test_rdataframe_temporary(self):
+        """
+        Test passing a temporary from an RDataFrame operation
+        """
+        @ROOT.Numba.Declare(["const RVecF"], "RVecF")
+        def pass_temporary(v):
+            return v*np.array([2.]).astype(np.float32)
+
+        df = ROOT.RDataFrame(1)\
+                 .Define("v", "ROOT::RVecF{0.f,2.f}")\
+                 .Define("v2", "Numba::pass_temporary(v[v > 0])")
+
+        rvecf = df.Take['RVecF']('v2').GetValue()[0]
+
+        self.assertTrue(np.array_equal(rvecf, np.array([4.])))
+
     # Test wrappings
     @unittest.skipIf(skip, skip_reason)
     def test_wrapper_in_void(self):
@@ -555,6 +572,32 @@ class NumbaDeclareArray(unittest.TestCase):
             x2 = ROOT.Numba.g2fb(ROOT.VecOps.RVec('float')(vf), ROOT.VecOps.RVec('bool')(vb))
             self.assertEqual(x1[0], bool(x2[0]))
             self.assertEqual(x1[1], bool(x2[1]))
+
+    @unittest.skipIf(skip, skip_reason)
+    def test_const_modifier(self):
+        """
+        Test const modifier in input argument type
+        """
+        @ROOT.Numba.Declare(["const ROOT::VecOps::RVec<float>"], "RVecF")
+        def const_mod(v):
+            return v*np.array([1.,2.]).astype(np.float32)
+
+        rvecf = ROOT.Numba.const_mod(ROOT.RVecF([1.,2.]))
+
+        self.assertTrue(np.array_equal(rvecf, np.array([1.,4.])))
+
+    @unittest.skipIf(skip, skip_reason)
+    def test_reference(self):
+        """
+        Test passing a reference as input argument
+        """
+        @ROOT.Numba.Declare(["RVec<float>&"], "RVecF")
+        def pass_reference(v):
+            return v*np.array([1.,2.]).astype(np.float32)
+
+        rvecf = ROOT.Numba.pass_reference(ROOT.RVecF([1.,2.]))
+
+        self.assertTrue(np.array_equal(rvecf, np.array([1.,4.])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #11294 .

In particular:
- Properly parses const modifier in type of input argument
- Fixes wrong addition of extra ampersand when passing a reference
- Allows passing temporaries as arguments from RDataFrame