### PR TITLE
MakeProject: workaound deficiency in gcc 11.2 warning

### DIFF
--- a/io/io/src/TStreamerInfo.cxx
+++ b/io/io/src/TStreamerInfo.cxx
@@ -3481,15 +3481,8 @@ static void R__WriteMoveBodyPointersArrays(FILE *file, const TString &protoname,
             if (element->GetArrayDim() == 1) {
                fprintf(file,"   for (Int_t i=0;i<%d;i++) %s[i] = rhs.%s[i];\n",element->GetArrayLength(),ename,ename);
             } else if (element->GetArrayDim() >= 2) {
-               fprintf(file,"   for (Int_t i=0;i<%d;i++) (&(%s",element->GetArrayLength(),ename);
-               for (Int_t d = 0; d < element->GetArrayDim(); ++d) {
-                  fprintf(file,"[0]");
-               }
-               fprintf(file,"))[i] = (&(rhs.%s",ename);
-               for (Int_t d = 0; d < element->GetArrayDim(); ++d) {
-                  fprintf(file,"[0]");
-               }
-               fprintf(file,"))[i];\n");
+               fprintf(file,"   for (Int_t i=0;i<%d;i++) reinterpret_cast<%s *>(%s", element->GetArrayLength(), element->GetTypeName(), ename);
+               fprintf(file,")[i] = reinterpret_cast<%s const *>(rhs.%s)[i];\n", element->GetTypeName(), ename);
             }
          } else if (element->GetType() == TVirtualStreamerInfo::kSTLp) {
             if (!defMod) { fprintf(file,"   %s &modrhs = const_cast<%s &>( rhs );\n",protoname.Data(),protoname.Data()); defMod = kTRUE; };


### PR DESCRIPTION
On Ubuntu 22, gcc 11.2 with get the apparently spurious message:
```
aliceesdProjectSource.cxx: In copy constructor ‘AliESDkink::AliESDkink(const AliESDkink&)’:
aliceesdProjectSource.cxx:992:54: warning: writing 16 bytes into a region of size 8 [-Wstringop-overflow=]
  992 |    for (Int_t i=0;i<4;i++) (&(fTPCdensity[0][0]))[i] = (&(rhs.fTPCdensity[0][0]))[i];
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from aliceesdProjectHeaders.h:20,
                 from aliceesdProjectSource.cxx:3:
AliESDkink.h:36:26: note: destination object ‘AliESDkink::fTPCdensity’ of size 8
   36 |    Float_t               fTPCdensity[2][2];    //tpc cluster density before and after kink
      |                          ^~~~~~~~~~~
                      ^~~~~~~~~~~
```
I.e. complaining about having only 8 bytes when 16 are reserved.

We work around this issue by using:
```
  for (Int_t i=0;i<4;i++) reinterpret_cast<Float_t*>(fTPCdensity)[i] = (&(rhs.fTPCdensity[0][0]))[i];
```