### PR TITLE
thisroot.sh: refactor with shellcheck; thisroot.fish: `dirname` -> `path dirname` to reduce deps

### DIFF
--- a/config/thisroot.fish
+++ b/config/thisroot.fish
@@ -29,7 +29,7 @@ end
 
 set SOURCE (status -f)
 # normalize path
-set thisroot (dirname $SOURCE)
+set thisroot (path dirname $SOURCE)
 set -xg ROOTSYS (set oldpwd $PWD; cd $thisroot/.. > /dev/null;pwd;cd $oldpwd; set -e oldpwd)
 
 if not set -q MANPATH

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -3,7 +3,7 @@
 # Conveniently an alias like this can be defined in .bashrc or .zshrc:
 #   alias thisroot=". bin/thisroot.sh"
 #
-# This script if for the bash like shells, see thisroot.csh for csh like shells.
+# This script is for the bash like shells, see thisroot.csh for csh like shells.
 #
 # Author: Fons Rademakers, 18/8/2006
 

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -16,7 +16,7 @@ drop_from_path()
 {
    # Assert that we got enough arguments
    if test $# -ne 2 ; then
-      echo "drop_from_path: needs 2 arguments"
+      echo "drop_from_path: needs 2 arguments" >&2
       return 1
    fi
 
@@ -213,12 +213,16 @@ if [ -z "${SOURCE}" ]; then
       ROOTSYS="$PWD"; export ROOTSYS
    elif [ -f ./thisroot.sh ]; then
       ROOTSYS=$(cd .. > /dev/null && pwd); export ROOTSYS
+      if [ -z "$ROOTSYS" ]; then
+         echo "ERROR: \"cd ..\" or \"pwd\" failed" >&2
+         return 1
+      fi
    else
       if [ "$SHELLNAME" = "bash" ] ; then
-         echo ERROR: please turn on extdebug using "shopt -s extdebug"
-         echo or "cd where/root/is" before calling ". bin/thisroot.sh"
+         echo "ERROR: please turn on extdebug using \"shopt -s extdebug\"" >&2
+         echo "or \"cd where/root/is\" before calling \". bin/thisroot.sh\"" >&2
       else
-         echo ERROR: must "cd where/root/is" before calling ". bin/thisroot.sh" for this version of "$SHELLNAME"!
+         echo "ERROR: must \"cd where/root/is\" before calling \". bin/thisroot.sh\" for this version of \"$SHELLNAME\"!" >&2
       fi
       ROOTSYS=; export ROOTSYS
       return 1
@@ -227,6 +231,10 @@ else
    # get param to "."
    thisroot="$(dirname "${SOURCE}")"
    ROOTSYS=$(cd "${thisroot}/.." > /dev/null && pwd); export ROOTSYS
+   if [ -z "$ROOTSYS" ]; then
+      echo "ERROR: \"cd ${thisroot}/..\" or \"pwd\" failed" >&2
+      return 1
+   fi
 fi
 
 

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -7,6 +7,11 @@
 #
 # Author: Fons Rademakers, 18/8/2006
 
+# shellcheck disable=SC2123,SC3043
+# Whole-file directives
+# Disable SC2123 to not warn PATH modification
+# Disable SC3043 to not warn for the local keyword
+
 drop_from_path()
 {
    # Assert that we got enough arguments
@@ -15,66 +20,66 @@ drop_from_path()
       return 1
    fi
 
-   local p=$1
-   local drop=$2
+   local p="$1" 2>/dev/null
+   local drop="$2" 2>/dev/null
 
-   newpath=`echo $p | sed -e "s;:${drop}:;:;g" \
+   newpath="$(echo "$p" | sed -e "s;:${drop}:;:;g" \
                           -e "s;:${drop}\$;;g"   \
                           -e "s;^${drop}:;;g"   \
-                          -e "s;^${drop}\$;;g"`
+                          -e "s;^${drop}\$;;g")"
 }
 
 clean_environment()
 {
 
-   if [ -n "${old_rootsys}" ] ; then
-      if [ -n "${PATH}" ]; then
+   if [ -n "${old_rootsys-}" ] ; then
+      if [ -n "${PATH-}" ]; then
          drop_from_path "$PATH" "${old_rootsys}/bin"
          PATH=$newpath
       fi
-      if [ -n "${LD_LIBRARY_PATH}" ]; then
+      if [ -n "${LD_LIBRARY_PATH-}" ]; then
          drop_from_path "$LD_LIBRARY_PATH" "${old_rootsys}/lib"
          LD_LIBRARY_PATH=$newpath
       fi
-      if [ -n "${DYLD_LIBRARY_PATH}" ]; then
+      if [ -n "${DYLD_LIBRARY_PATH-}" ]; then
          drop_from_path "$DYLD_LIBRARY_PATH" "${old_rootsys}/lib"
          DYLD_LIBRARY_PATH=$newpath
       fi
-      if [ -n "${SHLIB_PATH}" ]; then
+      if [ -n "${SHLIB_PATH-}" ]; then
          drop_from_path "$SHLIB_PATH" "${old_rootsys}/lib"
          SHLIB_PATH=$newpath
       fi
-      if [ -n "${LIBPATH}" ]; then
+      if [ -n "${LIBPATH-}" ]; then
          drop_from_path "$LIBPATH" "${old_rootsys}/lib"
          LIBPATH=$newpath
       fi
-      if [ -n "${PYTHONPATH}" ]; then
+      if [ -n "${PYTHONPATH-}" ]; then
          drop_from_path "$PYTHONPATH" "${old_rootsys}/lib"
          PYTHONPATH=$newpath
       fi
-      if [ -n "${MANPATH}" ]; then
+      if [ -n "${MANPATH-}" ]; then
          drop_from_path "$MANPATH" "${old_rootsys}/man"
          MANPATH=$newpath
       fi
-      if [ -n "${CMAKE_PREFIX_PATH}" ]; then
+      if [ -n "${CMAKE_PREFIX_PATH-}" ]; then
          drop_from_path "$CMAKE_PREFIX_PATH" "${old_rootsys}"
          CMAKE_PREFIX_PATH=$newpath
       fi
-      if [ -n "${JUPYTER_PATH}" ]; then
+      if [ -n "${JUPYTER_PATH-}" ]; then
          drop_from_path "$JUPYTER_PATH" "${old_rootsys}/etc/notebook"
          JUPYTER_PATH=$newpath
       fi
-      if [ -n "${JUPYTER_CONFIG_DIR}" ]; then
+      if [ -n "${JUPYTER_CONFIG_DIR-}" ]; then
          drop_from_path "$JUPYTER_CONFIG_DIR" "${old_rootsys}/etc/notebook"
          JUPYTER_CONFIG_DIR=$newpath
       fi
    fi
-   if [ -z "${MANPATH}" ]; then
+   if [ -z "${MANPATH-}" ]; then
       # Grab the default man path before setting the path to avoid duplicates
       if command -v manpath >/dev/null; then
-         default_manpath=`manpath`
+         default_manpath="$(manpath)"
       elif command -v man >/dev/null; then
-         default_manpath=`man -w 2> /dev/null`
+         default_manpath="$(man -w 2> /dev/null)"
       else
          default_manpath=""
       fi
@@ -83,13 +88,13 @@ clean_environment()
 
 set_environment()
 {
-   if [ -z "${PATH}" ]; then
+   if [ -z "${PATH-}" ]; then
       PATH=@bindir@; export PATH
    else
       PATH=@bindir@:$PATH; export PATH
    fi
 
-   if [ -z "${LD_LIBRARY_PATH}" ]; then
+   if [ -z "${LD_LIBRARY_PATH-}" ]; then
       LD_LIBRARY_PATH=@libdir@
       export LD_LIBRARY_PATH       # Linux, ELF HP-UX
    else
@@ -97,7 +102,7 @@ set_environment()
       export LD_LIBRARY_PATH
    fi
 
-   if [ -z "${DYLD_LIBRARY_PATH}" ]; then
+   if [ -z "${DYLD_LIBRARY_PATH-}" ]; then
       DYLD_LIBRARY_PATH=@libdir@
       export DYLD_LIBRARY_PATH       # Linux, ELF HP-UX
    else
@@ -105,7 +110,7 @@ set_environment()
       export DYLD_LIBRARY_PATH
    fi
 
-   if [ -z "${SHLIB_PATH}" ]; then
+   if [ -z "${SHLIB_PATH-}" ]; then
       SHLIB_PATH=@libdir@
       export SHLIB_PATH       # Linux, ELF HP-UX
    else
@@ -113,7 +118,7 @@ set_environment()
       export SHLIB_PATH
    fi
 
-   if [ -z "${LIBPATH}" ]; then
+   if [ -z "${LIBPATH-}" ]; then
       LIBPATH=@libdir@
       export LIBPATH       # Linux, ELF HP-UX
    else
@@ -121,7 +126,7 @@ set_environment()
       export LIBPATH
    fi
 
-   if [ -z "${PYTHONPATH}" ]; then
+   if [ -z "${PYTHONPATH-}" ]; then
       PYTHONPATH=@libdir@
       export PYTHONPATH       # Linux, ELF HP-UX
    else
@@ -129,25 +134,25 @@ set_environment()
       export PYTHONPATH
    fi
 
-   if [ -z "${MANPATH}" ]; then
+   if [ -z "${MANPATH-}" ]; then
       MANPATH=@mandir@:${default_manpath}; export MANPATH
    else
       MANPATH=@mandir@:$MANPATH; export MANPATH
    fi
 
-   if [ -z "${CMAKE_PREFIX_PATH}" ]; then
+   if [ -z "${CMAKE_PREFIX_PATH-}" ]; then
       CMAKE_PREFIX_PATH=$ROOTSYS; export CMAKE_PREFIX_PATH       # Linux, ELF HP-UX
    else
       CMAKE_PREFIX_PATH=$ROOTSYS:$CMAKE_PREFIX_PATH; export CMAKE_PREFIX_PATH
    fi
 
-   if [ -z "${JUPYTER_PATH}" ]; then
+   if [ -z "${JUPYTER_PATH-}" ]; then
       JUPYTER_PATH=$ROOTSYS/etc/notebook; export JUPYTER_PATH       # Linux, ELF HP-UX
    else
       JUPYTER_PATH=$ROOTSYS/etc/notebook:$JUPYTER_PATH; export JUPYTER_PATH
    fi
 
-   if [ -z "${JUPYTER_CONFIG_DIR}" ]; then
+   if [ -z "${JUPYTER_CONFIG_DIR-}" ]; then
       JUPYTER_CONFIG_DIR=$ROOTSYS/etc/notebook; export JUPYTER_CONFIG_DIR # Linux, ELF HP-UX
    else
       JUPYTER_CONFIG_DIR=$ROOTSYS/etc/notebook:$JUPYTER_CONFIG_DIR; export JUPYTER_CONFIG_DIR
@@ -155,6 +160,7 @@ set_environment()
 }
 
 getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
+    # shellcheck disable=SC3043 # assume that local is available
    local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
    # Determine the shell executable filename.
    if [ -r "/proc/$$/cmdline" ]; then
@@ -163,9 +169,13 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
       trueExe=$(ps -p $$ -o comm=) || return 1
    fi
    # Strip a leading "-", as added e.g. by macOS for login shells.
-   [ "${trueExe#-}" = "$trueExe" ] || trueExe=${trueExe#-}
+   if [ "${trueExe#-}" != "$trueExe" ]; then
+      trueExe=${trueExe#-}
+   fi
    # Determine full executable path.
-   [ "${trueExe#/}" != "$trueExe" ] || trueExe=$([ -n "$ZSH_VERSION" ] && which -p "$trueExe" || which "$trueExe")
+   if [ "${trueExe#/}" = "$trueExe" ]; then
+      trueExe=$(if [ -n "${ZSH_VERSION-}" ]; then which -p "$trueExe"; else which "$trueExe"; fi)
+   fi
    # If the executable is a symlink, resolve it to its *ultimate*
    # target.
    while nextTarget=$(readlink "$trueExe"); do trueExe=$nextTarget; done
@@ -176,18 +186,21 @@ getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
 ### main ###
 
 
-if [ -n "${ROOTSYS}" ] ; then
+if [ -n "${ROOTSYS-}" ] ; then
    old_rootsys=${ROOTSYS}
 fi
 
 
 SHELLNAME=$(getTrueShellExeName)
 if [ "$SHELLNAME" = "bash" ]; then
+   # shellcheck disable=SC3028,SC3054 # Bash-only syntax
    SOURCE=${BASH_ARGV[0]}
-elif [ "x${SHELLNAME}" = "x" ]; then # in case getTrueShellExeName does not work, fall back to default
+elif [ -z "${SHELLNAME}" ]; then # in case getTrueShellExeName does not work, fall back to default
    echo "WARNING: shell name was not found. Assuming 'bash'."
+   # shellcheck disable=SC3028,SC3054 # Bash-only syntax
    SOURCE=${BASH_ARGV[0]}
 elif [ "$SHELLNAME" = "zsh" ]; then
+   # shellcheck disable=all
    SOURCE=${(%):-%N}
 else # dash or ksh
    x=$(lsof -p $$ -Fn0 2>/dev/null | tail -1); # Paul Brannan https://stackoverflow.com/a/42815001/7471760
@@ -195,11 +208,11 @@ else # dash or ksh
 fi
 
 
-if [ "x${SOURCE}" = "x" ]; then
+if [ -z "${SOURCE}" ]; then
    if [ -f bin/thisroot.sh ]; then
       ROOTSYS="$PWD"; export ROOTSYS
    elif [ -f ./thisroot.sh ]; then
-      ROOTSYS=$(cd ..  > /dev/null; pwd); export ROOTSYS
+      ROOTSYS=$(cd .. > /dev/null && pwd); export ROOTSYS
    else
       if [ "$SHELLNAME" = "bash" ] ; then
          echo ERROR: please turn on extdebug using "shopt -s extdebug"
@@ -212,8 +225,8 @@ if [ "x${SOURCE}" = "x" ]; then
    fi
 else
    # get param to "."
-   thisroot=$(dirname ${SOURCE})
-   ROOTSYS=$(cd ${thisroot}/.. > /dev/null;pwd); export ROOTSYS
+   thisroot="$(dirname "${SOURCE}")"
+   ROOTSYS=$(cd "${thisroot}/.." > /dev/null && pwd); export ROOTSYS
 fi
 
 
@@ -224,8 +237,8 @@ set_environment
 # Prevent Cppyy from checking the PCH (and avoid warning)
 export CLING_STANDARD_PCH=none
 
-if [ "x`root-config --arch | grep -v win32gcc | grep -i win32`" != "x" ]; then
-   ROOTSYS="`cygpath -w $ROOTSYS`"
+if (root-config --arch | grep -v win32gcc | grep -q -i win32); then
+   ROOTSYS="$(cygpath -w "$ROOTSYS")"
 fi
 
 unset old_rootsys

--- a/config/thisroot.sh
+++ b/config/thisroot.sh
@@ -155,22 +155,22 @@ set_environment()
 }
 
 getTrueShellExeName() { # mklement0 https://stackoverflow.com/a/23011530/7471760
-  local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
-  # Determine the shell executable filename.
-  if [ -r "/proc/$$/cmdline" ]; then
-    trueExe=$(cut -d '' -f1 /proc/$$/cmdline) || return 1
-  else
-    trueExe=$(ps -p $$ -o comm=) || return 1
-  fi
-  # Strip a leading "-", as added e.g. by macOS for login shells.
-  [ "${trueExe#-}" = "$trueExe" ] || trueExe=${trueExe#-}
-  # Determine full executable path.
-  [ "${trueExe#/}" != "$trueExe" ] || trueExe=$([ -n "$ZSH_VERSION" ] && which -p "$trueExe" || which "$trueExe")
-  # If the executable is a symlink, resolve it to its *ultimate*
-  # target.
-  while nextTarget=$(readlink "$trueExe"); do trueExe=$nextTarget; done
-  # Output the executable name only.
-  printf '%s' "$(basename "$trueExe")"
+   local trueExe nextTarget 2>/dev/null # ignore error in shells without `local`
+   # Determine the shell executable filename.
+   if [ -r "/proc/$$/cmdline" ]; then
+      trueExe=$(cut -d '' -f1 /proc/$$/cmdline) || return 1
+   else
+      trueExe=$(ps -p $$ -o comm=) || return 1
+   fi
+   # Strip a leading "-", as added e.g. by macOS for login shells.
+   [ "${trueExe#-}" = "$trueExe" ] || trueExe=${trueExe#-}
+   # Determine full executable path.
+   [ "${trueExe#/}" != "$trueExe" ] || trueExe=$([ -n "$ZSH_VERSION" ] && which -p "$trueExe" || which "$trueExe")
+   # If the executable is a symlink, resolve it to its *ultimate*
+   # target.
+   while nextTarget=$(readlink "$trueExe"); do trueExe=$nextTarget; done
+   # Output the executable name only.
+   printf '%s' "$(basename "$trueExe")"
 }
 
 ### main ###


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
*   `thisroot.sh`:
    *   Pass `shellcheck`
        ```sh
        shellcheck -s sh config/thisroot.sh
        shellcheck -s dash config/thisroot.sh
        shellcheck -s ksh config/thisroot.sh
        shellcheck -s bash config/thisroot.sh
        ```
        Notable fixes:
        *   <code>&DiacriticalGrave;my-command&DiacriticalGrave;</code> -> `$(my-command)`
             (SC2006, &DiacriticalGrave;&DiacriticalGrave; is a legacy Bourn shell syntax with several issues)
        *   `[ "x$foo" = "x" ]` -> `[ -z "${foo-}" ]` and `[ "x$foo" != "x" ]` -> `[ -n "${foo-}"]`
        *   `cond && run-true || run-false` -> `if cond; then run-true; else run false; fi`
            (SC2015: run-false may be triggered when run-true fails)
        *   [ "$foo" == "$bar" ] -> [ "$foo" = "$bar" ] (SC3014, POSIX-conformance)

    *   Fix unbound variables
        *   Whenever a variable `$foo` is possibly not set, call it like `${foo-}`
        *   Now it can be sourced with `set -u`.

    *   Unify indentation: use three spaces everywhere.

*   `thisroot.fish`:
    *   `dirname` -> `path dirname` so that Fish users don't have to call the `dirname` executable.
## Checklist:

- [X] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

