### PR TITLE
Fix ROOT-7462 with libstdc++ >= 10 [v6.26]

### DIFF
--- a/interpreter/llvm/src/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Sema/SemaExpr.cpp
@@ -2439,6 +2439,13 @@ ExprResult Sema::BuildQualifiedDeclarationNameExpr(
                                      NameInfo, /*TemplateArgs=*/nullptr);
 
   if (R.empty()) {
+    // Don't diagnose problems with invalid record decl, the secondary no_member
+    // diagnostic during template instantiation is likely bogus, e.g. if a class
+    // is invalid because it's derived from an invalid base class, then missing
+    // members were likely supposed to be inherited.
+    if (const auto *CD = dyn_cast<CXXRecordDecl>(DC))
+      if (CD->isInvalidDecl())
+        return ExprError();
     Diag(NameInfo.getLoc(), diag::err_no_member)
       << NameInfo.getName() << DC << SS.getRange();
     return ExprError();


### PR DESCRIPTION
The test autoloads an `Outer` class that has `Inner<int>` as a member. Because we suspend autoloading, the `Inner<int>` specialization may not be complete at all times, which triggers a `static_assert` in newer versions of libstdc++.

Backport of D86765, commit bf890dcb0f; original commit message:
```
[clang] Don't emit "no member" diagnostic if the lookup fails on an invalid record decl.

The "no member" diagnostic is likely bogus.
```

(cherry picked from commit 06fd8e9e798919fdc29d8d6ec65d13d55ea30aa7, backport of PR https://github.com/root-project/root/pull/11551)