### PR TITLE
[RF] Fix wrong order of iterating over curves in `RooPlot::residHist() `

### DIFF
--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -60,9 +60,6 @@ public:
   RooPlot* emptyClone(const char* name) ;
 
   // implement the TH1 interface
-  virtual Stat_t GetBinContent(Int_t) const;
-  virtual Stat_t GetBinContent(Int_t, Int_t) const;
-  virtual Stat_t GetBinContent(Int_t, Int_t, Int_t) const;
   void Draw(Option_t *options= nullptr) override;
 
   // forwarding of relevant TH1 interface

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -1112,11 +1112,12 @@ double RooPlot::chiSquare(const char* curvename, const char* histname, int nFitP
 /// Otherwise, the curve is evaluated at the bin centres, which is not accurate for strongly curved distributions.
 RooHist* RooPlot::residHist(const char* histname, const char* curvename, bool normalize, bool useAverage) const
 {
-  // Find curve objects (there might be multiple in the case of multi-range fits)
+  // Find all curve objects with the name "curvename" or the name of the last
+  // plotted curve (there might be multiple in the case of multi-range fits).
   std::vector<RooCurve *> curves;
 
-  for(auto const& item : _items) {
-    TObject &obj = *item.first;
+  for(auto it = _items.rbegin(); it != _items.rend(); ++it) {
+    TObject &obj = *it->first;
     if(obj.IsA() == RooCurve::Class()) {
       // If no curvename was passed, we take by default the last curve and all
       // other curves that have the same name
@@ -1140,7 +1141,27 @@ RooHist* RooPlot::residHist(const char* histname, const char* curvename, bool no
   }
 
   auto residHist = hist->createEmptyResidHist(*curves.front(), normalize);
+
+  // We consider all curves with the same name as long as the ranges don't
+  // overlap, to create also the full residual plot in multi-range fits.
+  std::vector<std::pair<double, double>> coveredRanges;
   for(RooCurve * curve : curves) {
+    const double xmin = curve->GetPointX(0);
+    const double xmax = curve->GetPointX(curve->GetN() - 1);
+
+    for(auto const& prevRange : coveredRanges) {
+      const double pxmin = prevRange.first;
+      const double pxmax = prevRange.second;
+      // If either xmin or xmax is within any previous range, the ranges
+      // overloap and it makes to sense to also consider this curve for the
+      // residuals (i.e., they can't come from a multi-range fit).
+      if((pxmax > xmin && pxmin <= xmin) || (pxmax > xmax && pxmin <= xmax)) {
+        continue;
+      }
+    }
+
+    coveredRanges.emplace_back(xmin, xmax);
+
     hist->fillResidHist(*residHist, *curve, normalize, useAverage);
   }
   residHist->GetHistogram()->GetXaxis()->SetRangeUser(_hist->GetXaxis()->GetXmin(), _hist->GetXaxis()->GetXmax());

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -372,36 +372,6 @@ void RooPlot::updateNormVars(const RooArgSet &vars)
 
 
 ////////////////////////////////////////////////////////////////////////////////
-/// A plot object is a frame without any bin contents of its own so this
-/// method always returns zero.
-
-Stat_t RooPlot::GetBinContent(Int_t /*i*/) const {
-  return 0;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// A plot object is a frame without any bin contents of its own so this
-/// method always returns zero.
-
-Stat_t RooPlot::GetBinContent(Int_t, Int_t) const
-{
-  return 0;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// A plot object is a frame without any bin contents of its own so this
-/// method always returns zero.
-
-Stat_t RooPlot::GetBinContent(Int_t, Int_t, Int_t) const
-{
-  return 0;
-}
-
-
-
-////////////////////////////////////////////////////////////////////////////////
 /// Add a generic object to this plot. The specified options will be
 /// used to Draw() this object later. The caller transfers ownership
 /// of the object with this call, and the object will be deleted


### PR DESCRIPTION
The iteration over the plotted `_items` should be in reverse order to
consider the last-plotted curve for the residual histogram.

Also, this commit imporves the support for multi-range residuals by
making sure that multiple curves with the same name are only considered
if the curves are not overlapping.

This commit is a fixup to commit https://github.com/root-project/root/commit/b4bf80c63a8097c2e1fde274bec5d5380e043080.

The PR also includes another commit that removed the dummy member function `RooPlot::GetBinContent()`.

