### PR TITLE
Fix datasource_arrow.cxx test

### DIFF
--- a/tree/dataframe/test/datasource_arrow.cxx
+++ b/tree/dataframe/test/datasource_arrow.cxx
@@ -11,6 +11,7 @@
 #include <arrow/memory_pool.h>
 #include <arrow/record_batch.h>
 #include <arrow/table.h>
+#include <arrow/testing/builder.h>
 #include <arrow/testing/gtest_util.h>
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Explicitly include `arrow/testing/builder.h` to make sure ArrayFromVector is available. Probably it was being included implicitly before.
