### PR TITLE
[tmva][sofie] Backport some fixes in  tmva sofie for 6.26 

### DIFF
--- a/tmva/pymva/test/CMakeLists.txt
+++ b/tmva/pymva/test/CMakeLists.txt
@@ -11,8 +11,8 @@
 
 project(pymva-tests)
 
-set(Libraries Core MathCore TMVA PyMVA)
-include_directories(${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS})
+set(Libraries Core MathCore TMVA PyMVA ROOTTMVASofie)
+include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS})
 
 # Look for needed python modules
 find_python_module(torch QUIET)
@@ -45,9 +45,6 @@ if(PY_TORCH_FOUND)
    # Test RModelParser_PyTorch
    add_executable(emitFromPyTorch
                   EmitFromPyTorch.cxx
-                  ${CMAKE_SOURCE_DIR}/tmva/pymva/src/RModelParser_PyTorch.cxx
-                  ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
-                  ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
                  )
    target_link_libraries(emitFromPyTorch ${PYTHON_LIBRARIES} ${Libraries})
 if(APPLE)
@@ -79,6 +76,9 @@ endif()
          blas
          ${PYTHON_LIBRARIES}
          INCLUDE_DIRS
+         SYSTEM
+         ${PYTHON_INCLUDE_DIRS_Development_Main}
+         ${NUMPY_INCLUDE_DIRS}
          ${CMAKE_CURRENT_BINARY_DIR}
       )
       add_dependencies(TestRModelParserPyTorch SofieCompileModels_PyTorch)
@@ -107,9 +107,6 @@ if((PY_KERAS_FOUND AND PY_THEANO_FOUND) OR (PY_KERAS_FOUND AND PY_TENSORFLOW_FOU
    # Test RModelParser_Keras
    add_executable(emitFromKeras
                  EmitFromKeras.cxx
-                 ${CMAKE_SOURCE_DIR}/tmva/pymva/src/RModelParser_Keras.cxx
-                 ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
-                 ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
                  )
    target_link_libraries(emitFromKeras ${PYTHON_LIBRARIES} ${Libraries})
 if(APPLE)
@@ -135,6 +132,9 @@ endif()
     blas
     ${PYTHON_LIBRARIES}
     INCLUDE_DIRS
+    SYSTEM
+    ${PYTHON_INCLUDE_DIRS_Development_Main}
+    ${NUMPY_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}
    )
    add_dependencies(TestRModelParserKeras SofieCompileModels_Keras)

--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -16,15 +16,9 @@ if (NOT ONNX_MODELS_DIR)
   set(ONNX_MODELS_DIR input_models)
 endif()
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS "${SOFIE_PARSERS_DIR}/onnx_proto3")
-set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
 
 add_executable(emitFromONNX
    EmitFromONNX.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
-   ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
-   ${PROTO_SRCS}
 )
 target_include_directories(emitFromONNX PRIVATE
    ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
@@ -36,7 +30,7 @@ target_include_directories(emitFromONNX PRIVATE
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
 
-target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie)
+target_link_libraries(emitFromONNX ${Protobuf_LIBRARIES} ROOTTMVASofie ROOTTMVASofieParser)
 set_target_properties(emitFromONNX PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 ## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromONNX PRIVATE -Wno-unused-parameter -Wno-array-bounds)
@@ -60,7 +54,8 @@ endforeach()
 ROOT_ADD_GTEST(TestCustomModelsFromONNX TestCustomModelsFromONNX.cxx
   LIBRARIES
     ROOTTMVASofie
-    blas
+    ${BLAS_LINKER_FLAGS}
+    ${BLAS_LIBRARIES}
   INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}
 )
@@ -71,10 +66,6 @@ add_dependencies(TestCustomModelsFromONNX SofieCompileModels_ONNX)
 #For testing serialisation of RModel object
 add_executable(emitFromROOT
    EmitFromRoot.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/SOFIE_common.cxx
-   ${CMAKE_SOURCE_DIR}/tmva/sofie/src/RModel.cxx
-   ${SOFIE_PARSERS_DIR}/src/RModelParser_ONNX.cxx
-   ${PROTO_SRCS}
 )
 target_include_directories(emitFromROOT PRIVATE
    ${CMAKE_SOURCE_DIR}/tmva/sofie/inc
@@ -85,14 +76,19 @@ target_include_directories(emitFromROOT PRIVATE
    ${CMAKE_SOURCE_DIR}/core/foundation/inc
    ${CMAKE_BINARY_DIR}/ginclude   # this is for RConfigure.h
 )
-target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie)
+target_link_libraries(emitFromROOT ${Protobuf_LIBRARIES} ROOTTMVASofie ROOTTMVASofieParser)
 set_target_properties(emitFromROOT PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 ## silence protobuf warnings seen in version 3.0 and 3.6. Not needed from protobuf version 3.17
 target_compile_options(emitFromROOT PRIVATE -Wno-unused-parameter -Wno-array-bounds)
 
 # Automatic compilation of headers from root files
 add_custom_target(SofieCompileModels_ROOT)
-add_dependencies(SofieCompileModels_ROOT emitFromROOT)
+# onepcm or modules dependency is needed for using ROOT I/O when converting a model in a ROOT file
+if (runtime_cxxmodules)
+  add_dependencies(SofieCompileModels_ROOT emitFromROOT modules_idx)
+else()
+  add_dependencies(SofieCompileModels_ROOT emitFromROOT onepcm)
+endif()
 
 # Finding .onnx files to be parsed and creating the appropriate command
 file(GLOB ONNX_FILES "${ONNX_MODELS_DIR}/*.onnx")
@@ -109,7 +105,8 @@ endforeach()
 ROOT_ADD_GTEST(TestCustomModelsFromROOT TestCustomModelsFromROOT.cxx
   LIBRARIES
     ROOTTMVASofie
-    blas
+    ${BLAS_LINKER_FLAGS}
+    ${BLAS_LIBRARIES}
   INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
+++ b/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx
@@ -22,52 +22,6 @@ namespace TMVA{
 namespace Experimental{
 namespace SOFIE{
 
-namespace INTERNAL{
-
-std::unique_ptr<ROperator> make_ROperator_Transpose(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Relu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Selu(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Sigmoid(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Gemm(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Conv(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_RNN(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_LSTM(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_BatchNormalization(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Pool(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Add(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Reshape(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_Slice(const onnx::NodeProto &nodeproto, const onnx::GraphProto &graphproto, std::unordered_map<std::string, ETensorType> &tensor_type);
-std::unique_ptr<ROperator> make_ROperator_GRU(const onnx::NodeProto& nodeproto, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-
-
-using factoryMethodMap = std::unordered_map<std::string, std::unique_ptr<ROperator> (*)(const onnx::NodeProto&, const onnx::GraphProto&, std::unordered_map<std::string, ETensorType>&)>;
-const factoryMethodMap mapOptypeOperator = {
-   {"Gemm", &make_ROperator_Gemm},
-   {"Transpose", &make_ROperator_Transpose},
-   {"Relu", &make_ROperator_Relu},
-   {"Conv", &make_ROperator_Conv},
-   {"RNN", &make_ROperator_RNN},
-   {"Selu", &make_ROperator_Selu},
-   {"Sigmoid", &make_ROperator_Sigmoid},
-   {"LSTM", &make_ROperator_LSTM},
-   {"GRU", &make_ROperator_GRU},
-   {"BatchNormalization", &make_ROperator_BatchNormalization},
-   {"AveragePool", &make_ROperator_Pool},
-   {"GlobalAveragePool", &make_ROperator_Pool},
-   {"MaxPool", &make_ROperator_Pool},
-   {"Add", &make_ROperator_Add},
-   {"Reshape", &make_ROperator_Reshape},
-   {"Flatten", &make_ROperator_Reshape},
-   {"Slice", &make_ROperator_Slice},
-   {"Squeeze", &make_ROperator_Reshape},
-   {"Unsqueeze", &make_ROperator_Reshape},
-   {"Flatten", &make_ROperator_Reshape}
-};
-
-std::unique_ptr<ROperator> make_ROperator(size_t idx, const onnx::GraphProto& graphproto, std::unordered_map<std::string, ETensorType>& tensor_type);
-}//INTERNAL
-
-
 
 class RModelParser_ONNX{
 public:


### PR DESCRIPTION
This PR backports in 6.26 some fixes from master in the build configuration for SOFIE. 

 - backport fix from #PR 11481 (movie some Sofie parser definition in implementation)
 - backport fix from #PR 11545 (fix some issues with no rt modules)
  - backport fix from the tests #11529 (apply some fixes in the building of SOFIE tests)
