### PR TITLE
Revert "Revert "[cxxmodules] Allow submodules to contain headers which may be missing.""

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -84,7 +84,7 @@ module "std" [system] {
     header "csignal"
   }
   module "cstdalign" {
-    requires !cplusplus17
+    requires !cplusplus17, !header_existence
     export *
     header "cstdalign"
   }
@@ -309,6 +309,7 @@ module "std" [system] {
     header "string"
   }
   module "string_view" {
+    requires !header_existence
     export *
     textual header "string_view"
   }
@@ -365,10 +366,12 @@ module "std" [system] {
     header "vector"
   }
   module "codecvt" {
+    requires !header_existence
     export *
     header "codecvt"
   }
   module "cuchar" {
+    requires !header_existence
     export *
     header "cuchar"
   }

--- a/interpreter/cling/include/cling/std_msvc.modulemap
+++ b/interpreter/cling/include/cling/std_msvc.modulemap
@@ -20,7 +20,7 @@ module "std" [system] {
     header "atomic"
   }
   module "bit" {
-    requires cplusplus20
+    requires cplusplus20, !header_existence
     export *
     header "bit"
   }
@@ -53,7 +53,7 @@ module "std" [system] {
     header "cfloat"
   }
   module "charconv" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     header "charconv"
   }
@@ -86,7 +86,7 @@ module "std" [system] {
     header "codecvt"
   }
   module "compare" {
-    requires cplusplus20
+    requires cplusplus20, !header_existence
     export *
     header "compare"
   }
@@ -95,7 +95,7 @@ module "std" [system] {
     header "complex"
   }
   module "concepts" {
-    requires cplusplus20
+    requires cplusplus20, !header_existence
     export *
     header "concepts"
   }
@@ -172,12 +172,12 @@ module "std" [system] {
     header "exception"
   }
   module "execution" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     header "execution"
   }
   module "filesystem" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     header "filesystem"
   }
@@ -250,7 +250,7 @@ module "std" [system] {
     header "memory"
   }
   module "memory_resource" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     header "memory_resource"
   }
@@ -263,7 +263,7 @@ module "std" [system] {
     header "new"
   }
   module "numbers" {
-    requires cplusplus20
+    requires cplusplus20, !header_existence
     export *
     header "numbers"
   }
@@ -272,7 +272,7 @@ module "std" [system] {
     header "numeric"
   }
   module "optional" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     header "optional"
   }
@@ -289,7 +289,7 @@ module "std" [system] {
     header "random"
   }
   module "ranges" {
-    requires cplusplus20
+    requires cplusplus20, !header_existence
     export *
     header "ranges"
   }
@@ -338,7 +338,7 @@ module "std" [system] {
     header "string"
   }
   module "string_view" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     textual header "string_view"
   }
@@ -391,7 +391,7 @@ module "std" [system] {
     header "valarray"
   }
   module "variant" {
-    requires cplusplus17
+    requires cplusplus17, !header_existence
     export *
     header "variant"
   }
@@ -484,10 +484,12 @@ module "std" [system] {
     header "xstring"
   }
   module "xthreads.h" {
+    requires !header_existence
     export *
     textual header "xthreads.h"
   }
   module "xtimec.h" {
+    requires !header_existence
     export *
     textual header "xtimec.h"
   }

--- a/interpreter/llvm/src/tools/clang/lib/Basic/Module.cpp
+++ b/interpreter/llvm/src/tools/clang/lib/Basic/Module.cpp
@@ -104,7 +104,7 @@ static bool isPlatformEnvironment(const TargetInfo &Target, StringRef Feature) {
 /// Determine whether a translation unit built using the current
 /// language options has the given feature.
 static bool hasFeature(StringRef Feature, const LangOptions &LangOpts,
-                       const TargetInfo &Target) {
+                       const TargetInfo &Target, bool HasMissingHeaders) {
   bool HasFeature = llvm::StringSwitch<bool>(Feature)
                         .Case("altivec", LangOpts.AltiVec)
                         .Case("blocks", LangOpts.Blocks)
@@ -121,6 +121,7 @@ static bool hasFeature(StringRef Feature, const LangOptions &LangOpts,
                         .Case("objc", LangOpts.ObjC)
                         .Case("objc_arc", LangOpts.ObjCAutoRefCount)
                         .Case("opencl", LangOpts.OpenCL)
+                        .Case("header_existence", !HasMissingHeaders)
                         .Case("tls", Target.isTLSSupported())
                         .Case("zvector", LangOpts.ZVector)
                         .Default(Target.hasFeature(Feature) ||
@@ -144,14 +145,16 @@ bool Module::isAvailable(const LangOptions &LangOpts, const TargetInfo &Target,
       ShadowingModule = Current->ShadowingModule;
       return false;
     }
+    bool HasMissingHeaders = !Current->MissingHeaders.empty();
     for (unsigned I = 0, N = Current->Requirements.size(); I != N; ++I) {
-      if (hasFeature(Current->Requirements[I].first, LangOpts, Target) !=
-              Current->Requirements[I].second) {
+      if (hasFeature(Current->Requirements[I].first, LangOpts, Target,
+                     HasMissingHeaders) !=
+          Current->Requirements[I].second) {
         Req = Current->Requirements[I];
         return false;
       }
     }
-    if (!Current->MissingHeaders.empty()) {
+    if (HasMissingHeaders) {
       MissingHeader = Current->MissingHeaders.front();
       return false;
     }
@@ -279,7 +282,8 @@ void Module::addRequirement(StringRef Feature, bool RequiredState,
   Requirements.push_back(Requirement(Feature, RequiredState));
 
   // If this feature is currently available, we're done.
-  if (hasFeature(Feature, LangOpts, Target) == RequiredState)
+  if (hasFeature(Feature, LangOpts, Target, !MissingHeaders.empty()) ==
+      RequiredState)
     return;
 
   markUnavailable(/*MissingRequirement*/true);


### PR DESCRIPTION
ROOT 6.24 only requires C++11 and we want to continue supporting the likes of GCC 4.8.5 (on CentOS 7) and GCC 5.4.0 (on Ubuntu 16.04).

This reverts commit 44a0c8dcc3e47b3bc7d9677f940384d63074fd97.