### PR TITLE
[webgui] use default web browser, let reload RWebWindow

### DIFF
--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -41,7 +41,7 @@ public:
       kQt5,      ///< Qt5 QWebEngine libraries - Chromium code packed in qt5
       kQt6,      ///< Qt6 QWebEngine libraries - Chromium code packed in qt6
       kLocal,    ///< either CEF or Qt5 - both runs on local display without real http server
-      kStandard, ///< default system web browser, can not be used in batch mode
+      kDefault,  ///< default system web browser, can not be used in batch mode
       kServer,   ///< indicates that ROOT runs as server and just printouts window URL, browser should be started by the user
       kEmbedded, ///< window will be embedded into other, no extra browser need to be started
       kOff,      ///< disable web display, do not start any browser
@@ -99,7 +99,7 @@ public:
    bool IsInteractiveBrowser() const
    {
       return !IsHeadless() && ((GetBrowserKind() == kNative) || (GetBrowserKind() == kChrome) || (GetBrowserKind() == kEdge)
-                          || (GetBrowserKind() == kFirefox) || (GetBrowserKind() == kStandard) || (GetBrowserKind() == kCustom));
+                          || (GetBrowserKind() == kFirefox) || (GetBrowserKind() == kDefault) || (GetBrowserKind() == kCustom));
    }
 
    /// returns true if local display like CEF or Qt5 QWebEngine should be used

--- a/gui/webdisplay/inc/ROOT/RWebWindow.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindow.hxx
@@ -70,7 +70,7 @@ private:
       unsigned fConnId{0};                 ///<! connection id (unique inside the window)
       bool fHeadlessMode{false};           ///<! indicate if connection represent batch job
       std::string fKey;                    ///<! key value supplied to the window (when exists)
-      bool fKeyUsed{false};                ///<! key value used to verify connection
+      int fKeyUsed{0};                     ///<! key value used to verify connection
       std::unique_ptr<RWebDisplayHandle> fDisplayHandle;  ///<! handle assigned with started web display (when exists)
       std::shared_ptr<THttpCallArg> fHold; ///<! request used to hold headless browser
       timestamp_t fSendStamp;              ///<! last server operation, always used from window thread
@@ -96,6 +96,18 @@ private:
       ~WebConn();
 
       void ResetStamps() { fSendStamp = fRecvStamp = std::chrono::system_clock::now(); }
+
+      void ResetData()
+      {
+         fActive = false;
+         fWSId = 0;
+         fReady = 0;
+         fDoingSend = false;
+         fSendCredits = 0;
+         fClientCredits = 0;
+         while (!fQueue.empty())
+            fQueue.pop();
+      }
    };
 
    enum EQueueEntryKind { kind_None, kind_Connect, kind_Data, kind_Disconnect };
@@ -179,6 +191,8 @@ private:
    void CheckDataToSend(bool only_once = false);
 
    bool HasKey(const std::string &key) const;
+
+   std::string GenerateKey() const;
 
    void CheckPendingConnections();
 

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -208,8 +208,10 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
 
    if (kind == "local")
       SetBrowserKind(kLocal);
-   else if (kind.empty() || (kind == "native"))
+   else if (kind == "native")
       SetBrowserKind(kNative);
+   else if (kind.empty() || (kind == "dflt") || (kind == "default") || (kind == "browser"))
+      SetBrowserKind(kDefault);
    else if (kind == "firefox")
       SetBrowserKind(kFirefox);
    else if ((kind == "chrome") || (kind == "chromium"))
@@ -226,8 +228,6 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
       SetBrowserKind(kQt6);
    else if ((kind == "embed") || (kind == "embedded"))
       SetBrowserKind(kEmbedded);
-   else if ((kind == "dflt") || (kind == "default") || (kind == "browser"))
-      SetBrowserKind(kDefault);
    else if (kind == "server")
       SetBrowserKind(kServer);
    else if (kind == "off")

--- a/gui/webdisplay/src/RWebDisplayArgs.cxx
+++ b/gui/webdisplay/src/RWebDisplayArgs.cxx
@@ -227,7 +227,7 @@ RWebDisplayArgs &RWebDisplayArgs::SetBrowserKind(const std::string &_kind)
    else if ((kind == "embed") || (kind == "embedded"))
       SetBrowserKind(kEmbedded);
    else if ((kind == "dflt") || (kind == "default") || (kind == "browser"))
-      SetBrowserKind(kStandard);
+      SetBrowserKind(kDefault);
    else if (kind == "server")
       SetBrowserKind(kServer);
    else if (kind == "off")
@@ -252,7 +252,7 @@ std::string RWebDisplayArgs::GetBrowserName() const
       case kQt5: return "qt5";
       case kQt6: return "qt6";
       case kLocal: return "local";
-      case kStandard: return "default";
+      case kDefault: return "default";
       case kServer: return "server";
       case kEmbedded: return "embed";
       case kOff: return "off";

--- a/gui/webdisplay/src/RWebDisplayHandle.cxx
+++ b/gui/webdisplay/src/RWebDisplayHandle.cxx
@@ -590,24 +590,27 @@ std::unique_ptr<RWebDisplayHandle> RWebDisplayHandle::Display(const RWebDisplayA
       return handle;
    }
 
+   bool handleAsNative = (args.GetBrowserKind() == RWebDisplayArgs::kNative) ||
+                         (args.IsHeadless() && (args.GetBrowserKind() == RWebDisplayArgs::kDefault));
+
 #ifdef _MSC_VER
-   if ((args.GetBrowserKind() == RWebDisplayArgs::kNative) || (args.GetBrowserKind() == RWebDisplayArgs::kEdge)) {
+   if (handleAsNative || (args.GetBrowserKind() == RWebDisplayArgs::kEdge)) {
       if (try_creator(FindCreator("edge", "ChromeCreator")))
          return handle;
    }
 #endif
 
-   if ((args.GetBrowserKind() == RWebDisplayArgs::kNative) || (args.GetBrowserKind() == RWebDisplayArgs::kChrome)) {
+   if (handleAsNative || (args.GetBrowserKind() == RWebDisplayArgs::kChrome)) {
       if (try_creator(FindCreator("chrome", "ChromeCreator")))
          return handle;
    }
 
-   if ((args.GetBrowserKind() == RWebDisplayArgs::kNative) || (args.GetBrowserKind() == RWebDisplayArgs::kFirefox)) {
+   if (handleAsNative || (args.GetBrowserKind() == RWebDisplayArgs::kFirefox)) {
       if (try_creator(FindCreator("firefox", "FirefoxCreator")))
          return handle;
    }
 
-   if ((args.GetBrowserKind() == RWebDisplayArgs::kChrome) || (args.GetBrowserKind() == RWebDisplayArgs::kFirefox)) {
+   if (handleAsNative || (args.GetBrowserKind() == RWebDisplayArgs::kChrome) || (args.GetBrowserKind() == RWebDisplayArgs::kFirefox) || (args.GetBrowserKind() == RWebDisplayArgs::kEdge)) {
       // R__LOG_ERROR(WebGUILog()) << "Neither Chrome nor Firefox browser cannot be started to provide display";
       return handle;
    }

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -21,10 +21,10 @@
 #include "THttpServer.h"
 
 #include "TSystem.h"
-#include "TRandom3.h"
 #include "TString.h"
 #include "TApplication.h"
 #include "TTimer.h"
+#include "TRandom.h"
 #include "TROOT.h"
 #include "TEnv.h"
 #include "TExec.h"
@@ -546,15 +546,8 @@ unsigned RWebWindowsManager::ShowWindow(RWebWindow &win, const RWebDisplayArgs &
       return 0;
    }
 
-   std::string key;
-   int ntry = 100000;
-   TRandom3 rnd;
-   rnd.SetSeed();
-
-   do {
-      key = std::to_string(rnd.Integer(0x100000));
-   } while ((--ntry > 0) && win.HasKey(key));
-   if (ntry == 0) {
+   std::string key = win.GenerateKey();
+   if (key.empty()) {
       R__LOG_ERROR(WebGUILog()) << "Fail to create unique key for the window";
       return 0;
    }

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '19/11/2021' */
-let version_date = '13/10/2022';
+let version_date = '17/10/2022';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -99637,6 +99637,12 @@ class WebWindowHandle {
                if (msg == 'CLOSE') {
                   this.close(true); // force closing of socket
                   this.invokeReceiver(true, 'onWebsocketClosed');
+               } else if (msg.indexOf('NEW_KEY=') == 0) {
+                  let newkey = msg.slice(8);
+                  this.close(true);
+                  if (typeof sessionStorage !== 'undefined')
+                     sessionStorage.setItem('RWebWindow_Key', newkey);
+                  location.reload(true);
                }
             } else if (msg == '$$binary$$') {
                this.next_binary = chid;
@@ -99674,6 +99680,33 @@ class WebWindowHandle {
       }; // retry_open
 
       retry_open(true); // call for the first time
+   }
+
+   /** @summary Send newkey request to application
+     * @desc If server creates newkey and response - webpage will be reaload
+     * After key generation done, connection will not be working any longer
+     * WARNING - only call when you know that you are doing
+     * @private */
+   askReload() {
+      this.send('GENERATE_KEY', 0);
+   }
+
+   /** @summary Instal Ctrl-R handler to realod web window
+     * @desc Instead of default window reload invokes {@link askReload} method
+     * WARNING - only call when you know that you are doing
+     * @private */
+   addReloadKeyHandler() {
+
+      if (this.kind == 'file') return;
+
+      window.addEventListener( 'keydown', evnt => {
+         if (((evnt.key == 'R') || (evnt.key == 'r')) && evnt.ctrlKey) {
+            evnt.stopPropagation();
+            evnt.preventDefault();
+            console.log('Prevent Ctrl-R propogation - ask reload web window!');
+            this.askReload();
+          }
+      });
    }
 
 } // class WebWindowHandle

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '19/11/2021' */
-let version_date = '13/10/2022';
+let version_date = '17/10/2022';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -562,7 +562,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       /* =============== Settings menu =============== */
       /* ============================================= */
 
-      onSettingPress: function () {
+      onSettingsPress: function () {
          this._oSettingsModel.setProperty("/AppendToCanvas", this.model.isAppendToCanvas());
          this._oSettingsModel.setProperty("/OnlyLastCycle", (this.model.getOnlyLastCycle() > 0));
          this._oSettingsModel.setProperty("/ShowHiddenFiles", this.model.isShowHidden());
@@ -1064,6 +1064,11 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          setTimeout(() => { if (window) window.close(); }, 2000);
       },
 
+      /** @summary Start reload sequence with server */
+      onReloadPress: function() {
+         this.websocket?.askReload();
+      },
+
       onSearch: function(oEvt) {
          this.changeItemsFilter(oEvt.getSource().getValue());
       },
@@ -1154,7 +1159,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
             href: this.websocket.getHRef(url),
             user_args: { nobrowser: true }
          }).then(handle => XMLView.create({
-            viewName: "rootui5.eve7.view.GeomViewer",
+            viewName: "rootui5.geom.view.GeomViewer",
             viewData: { conn_handle: handle, embeded: true, jsroot: this.jsroot }
          })).then(oView => item.addContent(oView));
 

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -161,6 +161,10 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          // if true, most operations are performed locally without involving server
          this.standalone = (this.websocket.kind == 'file');
 
+         // add reload handler
+         if (!this.standalone && this.websocket.addReloadKeyHandler)
+            this.websocket.addReloadKeyHandler();
+
          // create model only for browser - no need for anybody else
          this.model = new BrowserModel();
 

--- a/ui5/browser/view/Browser.view.xml
+++ b/ui5/browser/view/Browser.view.xml
@@ -13,8 +13,9 @@
         <Image height="35px" src="rootui5sys/browser/logo.png"/>
         <Text text="ROOT 7" wrapping="false" />
         <ToolbarSpacer/>
-        <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingPress"/>
-        <Button icon="sap-icon://log" type="Transparent" tooltip="Logoff" press="onQuitRootPress"/>
+        <Button icon="sap-icon://settings" type="Transparent" tooltip="Settings" press="onSettingsPress"/>
+        <Button icon="sap-icon://refresh" type="Transparent" tooltip="Reload RBrowser" press="onReloadPress"/>
+        <Button icon="sap-icon://log" type="Transparent" tooltip="Quit ROOT session" press="onQuitRootPress"/>
       </tnt:ToolHeader>
 
       <ScrollContainer height="calc(100% - 40px)">

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -345,18 +345,18 @@ sap.ui.define([
 
          let can_elem = this.getView().byId("MainPanel");
 
-         return XMLView.create({
-            viewName: viewName,
-            viewData: { handle: panel_handle, masterPanel: this },
-            layoutData: oLd,
-            height: (panel_name == "Panel") ? "100%" : undefined
-         }).then(oView => {
-            // workaround, while CanvasPanel.onBeforeRendering called too late
-            can_elem.getController().preserveCanvasContent();
-            split.insertContentArea(oView, 0);
-            return true;
-         });
-
+         import('./jsrootsys/modules/core.mjs')
+           .then(jsroot => XMLView.create({
+               viewName: viewName,
+               viewData: { handle: panel_handle, masterPanel: this, jsroot },
+               layoutData: oLd,
+               height: (panel_name == "Panel") ? "100%" : undefined
+           })).then(oView => {
+               // workaround, while CanvasPanel.onBeforeRendering called too late
+               can_elem.getController().preserveCanvasContent();
+               split.insertContentArea(oView, 0);
+               return true;
+           });
       },
 
       // TODO: sync with showPanelInLeftArea, it is more or less same

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -29,6 +29,7 @@
                         </MenuItem>
                         <MenuItem text="Save as ..." icon="sap-icon://save" enabled="false"/>
                         <MenuItem text="Interrupt" startsSection="true" icon="sap-icon://stop" enabled="{/Standalone}" tooltip="Interrupts current event loop"/>
+                        <MenuItem text="Reload" icon="sap-icon://refresh" enabled="{/Standalone}" visible="{/Standalone}" tooltip="Fully reload canvas"/>
                         <MenuItem text="Quit ROOT" icon="sap-icon://log" enabled="{/Standalone}" tooltip="Quit ROOT session"/>
 
                      </items>

--- a/ui5/fitpanel/controller/FitPanel.controller.js
+++ b/ui5/fitpanel/controller/FitPanel.controller.js
@@ -14,12 +14,12 @@ sap.ui.define([
 
          // WORKAROUND, need to be FIXED IN THE FUTURE
          if (window && window.location && window.location.hostname && window.location.hostname.indexOf("github.io")>=0)
-            JSROOT.loadScript('../rootui5/fitpanel/style/style.css');
+            this.jsroot.loadScript('../rootui5/fitpanel/style/style.css');
          else
-            JSROOT.loadScript('rootui5sys/fitpanel/style/style.css');
+            this.jsroot.loadScript('rootui5sys/fitpanel/style/style.css');
 
          // need dummy ranges to initialize RangeSliders,
-         var data = {
+         let data = {
                fDim: 1,
                fMinRangeX: -1,
                fMaxRangeX: 1,
@@ -63,7 +63,7 @@ sap.ui.define([
       onWebsocketMsg: function(handle, msg) {
 
          if(msg.startsWith("MODEL:")) {
-            var data = JSROOT.parse(msg.substr(6));
+            let data = this.jsroot.parse(msg.substr(6));
 
             if(data) {
                this.getView().setModel(new JSONModel(data));
@@ -74,7 +74,7 @@ sap.ui.define([
             }
          } else if (msg.startsWith("PARS:")) {
 
-            this.data().fFuncPars = JSROOT.parse(msg.substr(5));
+            this.data().fFuncPars = this.jsroot.parse(msg.substr(5));
 
             this.refresh();
          }
@@ -114,18 +114,18 @@ sap.ui.define([
 
          this.getView().byId("MethodMin").getBinding("items").filter(new Filter("lib", FilterOperator.EQ, data.fLibrary));
 
-         var best = 0, selected = null;
+         let best = 0, selected = null;
 
          // first find selected item
-         for (var k=0;k<data.fMethodMinAll.length;++k) {
+         for (let k = 0; k < data.fMethodMinAll.length; ++k) {
             if (data.fMethodMinAll[k].id == data.fSelectMethodMin) {
                selected = data.fMethodMinAll[k];
                break;
             }
          }
 
-         for (var k=0;k<data.fMethodMinAll.length;++k) {
-            var item = data.fMethodMinAll[k];
+         for (let k=0;k<data.fMethodMinAll.length;++k) {
+            let item = data.fMethodMinAll[k];
             if (item.lib != data.fLibrary) continue;
             if (item.id === data.fSelectMethodMin) return;
             if (!best) best = item.id;
@@ -145,9 +145,9 @@ sap.ui.define([
       },
 
       onContourPar1Change: function() {
-         var data = this.data();
+         let data = this.data();
          if (data.fContourPar1Id == data.fContourPar2Id) {
-            var par2 = parseInt(data.fContourPar2Id);
+            let par2 = parseInt(data.fContourPar2Id);
             if (par2 > 0) par2--; else par2 = 1;
             data.fContourPar2Id = par2.toString();
             this.refresh();
@@ -155,9 +155,9 @@ sap.ui.define([
       },
 
       onContourPar2Change: function() {
-         var data = this.data();
+         let data = this.data();
          if (data.fContourPar1Id == data.fContourPar2Id) {
-            var par1 = parseInt(data.fContourPar1Id);
+            let par1 = parseInt(data.fContourPar1Id);
             if (par1 > 0) par1--; else par1 = 1;
             data.fContourPar1Id = par1.toString();
             this.refresh();
@@ -165,7 +165,7 @@ sap.ui.define([
       },
 
       pressApplyPars: function() {
-         var json = JSROOT.toJSON(this.data().fFuncPars);
+         let json = this.jsroot.toJSON(this.data().fFuncPars);
 
          if (this.websocket)
             this.websocket.send("SETPARS:" + json);

--- a/ui5/geom/controller/GeomViewer.controller.js
+++ b/ui5/geom/controller/GeomViewer.controller.js
@@ -88,6 +88,9 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          // if true, most operations are performed locally without involving server
          this.standalone = this.websocket.kind == "file";
 
+         if (!this.standalone && !this._embeded && this.websocket.addReloadKeyHandler)
+            this.websocket.addReloadKeyHandler();
+
          this.cfg = { standalone: this.websocket.kind == "file" };
          this.cfg_model = new JSONModel(this.cfg);
          this.getView().setModel(this.cfg_model);

--- a/ui5/geom/controller/GeomViewer.controller.js
+++ b/ui5/geom/controller/GeomViewer.controller.js
@@ -87,6 +87,9 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          // if true, most operations are performed locally without involving server
          this.standalone = this.websocket.kind == "file";
 
+         if (!this.standalone && !this._embeded && this.websocket.addReloadKeyHandler)
+            this.websocket.addReloadKeyHandler();
+
          this.cfg = { standalone: this.websocket.kind == "file" };
          this.cfg_model = new JSONModel(this.cfg);
          this.getView().setModel(this.cfg_model);

--- a/ui5/geom/index.html
+++ b/ui5/geom/index.html
@@ -55,7 +55,7 @@
      }).then(handle => {
          sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
              XMLView.create({
-                viewName: "rootui5.eve7.view.GeomViewer",
+                viewName: "rootui5.geom.view.GeomViewer",
                 viewData: { conn_handle: handle, jsroot: { parse, decodeUrl, toJSON, source_dir } }
              }).then(oView => oView.placeAt("GeomDiv"));
           });

--- a/ui5/geom/lib/GeomDrawing.js
+++ b/ui5/geom/lib/GeomDrawing.js
@@ -1,10 +1,10 @@
 sap.ui.define(['sap/ui/core/Control',
-               "sap/ui/core/ResizeHandler"
+               'sap/ui/core/ResizeHandler'
 ],function(CoreControl, ResizeHandler) {
 
    "use strict";
 
-   var GeomDrawing = CoreControl.extend("rootui5.eve7.lib.GeomDrawing", {
+   let GeomDrawing = CoreControl.extend("rootui5.geom.lib.GeomDrawing", {
 
       metadata : {
          properties : {           // setter and getter are created behind the scenes, incl. data binding and type validation

--- a/ui5/geom/view/GeomViewer.view.xml
+++ b/ui5/geom/view/GeomViewer.view.xml
@@ -1,8 +1,8 @@
 <mvc:View height="100%" width="100%" class="sapUiSizeCompact"
-   controllerName="rootui5.eve7.controller.GeomViewer"
+   controllerName="rootui5.geom.controller.GeomViewer"
    xmlns="sap.m"
    xmlns:mvc="sap.ui.core.mvc"
-   xmlns:eve7="rootui5.eve7.lib"
+   xmlns:geom="rootui5.geom.lib"
    xmlns:core="sap.ui.core"
    xmlns:l="sap.ui.layout"
    xmlns:t="sap.ui.table">
@@ -246,7 +246,7 @@
          <Page id="geomDraw" title="GL drawing" showNavButton="false"
             showFooter="false" showSubHeader="false" showHeader="true" class="sapUiStdPage">
             <content>
-               <eve7:GeomDrawing id="geomDrawing" color="white"/>
+               <geom:GeomDrawing id="geomDrawing" color="white"/>
             </content>
          </Page>
          <Page id="geomInfo" title="Node information"
@@ -262,7 +262,7 @@
                      <Text text="Shape name: {/shape_name}"/>
                      <Text text="Type: {/shape_type}"/>
                    </VBox>
-                   <eve7:GeomDrawing id="nodeDrawing" color="white"/>
+                   <geom:GeomDrawing id="nodeDrawing" color="white"/>
                </l:Splitter>
             </content>
          </Page>

--- a/ui5/panel/Controller.js
+++ b/ui5/panel/Controller.js
@@ -20,6 +20,9 @@ sap.ui.define([
             this.websocket.send("PANEL_READY"); // confirm panel creation, only then GUI can send commands
          }
 
+         // assign several core methods which are used like: parse, toJSON, source_dir
+         this.jsroot = data?.jsroot;
+
          // TODO: use more specific API between Canvas and Panel
          this.masterPanel = data?.masterPanel;
 

--- a/ui5/panel/Controller.js
+++ b/ui5/panel/Controller.js
@@ -26,6 +26,11 @@ sap.ui.define([
          // TODO: use more specific API between Canvas and Panel
          this.masterPanel = data?.masterPanel;
 
+         // let correctly reload Panel
+         if (!this.masterPanel && this.websocket)
+            this.websocket.addReloadKeyHandler();
+
+
          if (typeof this.onPanelInit == "function")
             this.onPanelInit();
       },

--- a/ui5/panel/panel.html
+++ b/ui5/panel/panel.html
@@ -27,7 +27,7 @@
    <script type='module'>
 
       import { connectWebWindow } from './jsrootsys/modules/webwindow.mjs';
-      import { source_dir } from './jsrootsys/modules/core.mjs';
+      import * as jsroot from './jsrootsys/modules/core.mjs';
 
       connectWebWindow({
          first_recv: "SHOWPANEL:",
@@ -43,11 +43,11 @@
             let p = viewName.indexOf(".");
             if ((p > 1) && (p < viewName.length - 1)) {
                let tgtpath = "/currentdir/";
-               let pp = source_dir.indexOf("/jsrootsys/");
-               if (pp > 0) tgtpath = source_dir.slice(0, pp) + tgtpath;
+               let pp = jsroot.source_dir.indexOf("/jsrootsys/");
+               if (pp > 0) tgtpath = jsroot.source_dir.slice(0, pp) + tgtpath;
                let _paths = {};
                _paths[viewName.slice(0,p)] = tgtpath;
-               console.log('Register module path', viewName.slice(0,p), ' as ', tgtpath);
+               console.log(`Register module path ${viewName.slice(0,p)} as ${tgtpath}`);
                sap.ui.loader.config({ paths: _paths });
             }
          }
@@ -55,8 +55,8 @@
          sap.ui.require(["sap/ui/core/mvc/XMLView"], XMLView => {
             XMLView.create({
                id: "TopPanelId",
-               viewName: viewName,
-               viewData: { handle: handle }
+               viewName,
+               viewData: { handle, jsroot }
             }).then(oView => oView.placeAt("PanelDiv"));
 
          });

--- a/ui5/tree/controller/TreeViewer.controller.js
+++ b/ui5/tree/controller/TreeViewer.controller.js
@@ -31,6 +31,9 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          // if true, most operations are performed locally without involving server
          this.standalone = this.websocket.kind == 'file';
 
+         if (!this.standalone && !this._embeded && this.websocket.addReloadKeyHandler)
+            this.websocket.addReloadKeyHandler();
+
          this.cfg = {
             fTreeName: '',
             fExprX: '', fExprY: '', fExprZ: '', fExprCut: '', fOption: '',


### PR DESCRIPTION
1. Use default system web browser by default for interactive session
2. Provide way to reload RWebWindow content with key generation
3. Provide `Ctrl-R` handler in RBrowser, RGeomViewer, RWebCanvas, RFitPanel
4. Fix problem in `RGeomViewer` - removing last refs from eve7  
5. Fix problem with `RFitPanel` - still was using global JSROOT handle which is removed in `v7` 