### PR TITLE
[RF] Remove error in `RooWorkspace::getSnapshot()` if no snapshot found

### DIFF
--- a/roofit/roofitcore/src/RooWorkspace.cxx
+++ b/roofit/roofitcore/src/RooWorkspace.cxx
@@ -1191,13 +1191,7 @@ bool RooWorkspace::loadSnapshot(const char* name)
 
 const RooArgSet* RooWorkspace::getSnapshot(const char* name) const
 {
-  RooArgSet* snap = (RooArgSet*) _snapshots.find(name) ;
-  if (!snap) {
-    coutE(ObjectHandling) << "RooWorkspace::loadSnapshot(" << GetName() << ") no snapshot with name " << name << " is available" << endl ;
-    return nullptr;
-  }
-
-  return snap ;
+  return static_cast<RooArgSet*>(_snapshots.find(name));
 }
 
 


### PR DESCRIPTION
In this forum post, the point was made that
`RooWorkspace::getSnapshot()` should not print an error if a snapshot
with the passed name is not found.

https://root-forum.cern.ch/t/roofit-check-if-snapshot-exist-without-showing-objecthandling-error

Just like in the other `RooWorkspace` access functions, like `arg()`,
`pdf()`, or `function()`, users expect to use `getSnapshot()` also to
query if a snapshot exists and check if the returned value is `nullptr`.
So there should be no error printed in `getSnapshot()` itself. If it is
actually an error for th caller that no snapshot has been found, an
error or exception should be raised by the caller.

A second commit in this PR applies some general code modernization to `RooWorkspace.cxx`.

