### PR TITLE
[webgui] improve RBrowser, fix other problems

### DIFF
--- a/geom/CMakeLists.txt
+++ b/geom/CMakeLists.txt
@@ -22,7 +22,7 @@ if(vecgeom)
   add_subdirectory(vecgeom)
 endif()
 
-if(webgui)
+if(webgui AND root7)
   add_subdirectory(webviewer)
 endif()
 

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -293,9 +293,10 @@ public:
       TObject *tobj = (TObject *) obj_class->DynamicCast(TObject::Class(), obj);
 
       if (tobj) {
-         bool owned_by_dir = (fDir->FindObject(tobj) == tobj) || (fKeyClass == "TGeoManager");
+         if (fDir->FindObject(tobj))
+            fDir->Remove(tobj);
 
-         return std::make_unique<TObjectHolder>(tobj, !owned_by_dir);
+         return std::make_unique<TObjectHolder>(tobj, fKeyClass != "TGeoManager"s);
       }
 
       return std::make_unique<RAnyObjectHolder>(obj_class, obj, true);

--- a/gui/browsable/src/TObjectElement.cxx
+++ b/gui/browsable/src/TObjectElement.cxx
@@ -20,6 +20,7 @@
 #include "TList.h"
 #include "TColor.h"
 #include "TDirectory.h"
+#include "TFile.h"
 #include "TBufferJSON.h"
 
 #include <sstream>
@@ -194,7 +195,9 @@ public:
       TObject *obj = *fIter;
       if (!obj) return nullptr;
 
-      auto item = std::make_unique<TObjectItem>(obj->GetName(), obj->IsFolder() ? -1 : 0);
+      bool is_folder = obj->IsFolder();
+
+      auto item = std::make_unique<TObjectItem>(obj->GetName(), is_folder ? -1 : 0);
 
       item->SetClassName(obj->ClassName());
 
@@ -205,6 +208,11 @@ public:
       if (obj->IsA() == TColor::Class()) {
          if (item->GetName().empty())
             item->SetName("Color"s + std::to_string(static_cast<TColor *>(obj)->GetNumber()));
+      }
+
+      if (is_folder && obj->InheritsFrom(TFile::Class())) {
+         auto f = dynamic_cast<TFile *>(obj);
+         if (f) item->SetSize(f->GetSize());
       }
 
       return item;

--- a/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebDisplayArgs.hxx
@@ -111,8 +111,9 @@ public:
    /// returns true if browser supports headless mode
    bool IsSupportHeadless() const
    {
-      return (GetBrowserKind() == kNative) || (GetBrowserKind() == kChrome) || (GetBrowserKind() == kEdge)
-               || (GetBrowserKind() == kFirefox) || (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5) || (GetBrowserKind() == kQt6);
+      return (GetBrowserKind() == kNative) || (GetBrowserKind() == kDefault) ||
+             (GetBrowserKind() == kChrome) || (GetBrowserKind() == kEdge) || (GetBrowserKind() == kFirefox) ||
+             (GetBrowserKind() == kCEF) || (GetBrowserKind() == kQt5) || (GetBrowserKind() == kQt6);
    }
 
    /// set window url

--- a/js/modules/webwindow.mjs
+++ b/js/modules/webwindow.mjs
@@ -722,7 +722,7 @@ async function connectWebWindow(arg) {
       handle.key = d.get('key');
       handle.token = d.get('token');
 
-      if (typeof sessionStorage !== undefined) {
+      if (typeof sessionStorage !== 'undefined') {
          let new_key = sessionStorage.getItem('RWebWindow_Key');
          sessionStorage.removeItem('RWebWindow_Key');
          if (new_key) {

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -1074,19 +1074,17 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
       },
 
       /** @summary Submit node search query to server, ignore in offline case */
-      changeItemsFilter: function(query, from_handler) {
+      changeItemsFilter(query, from_handler) {
 
-         if (!from_handler) {
-            // do not submit immediately, but after very short timeout
+         if (from_handler) {
+            delete this.search_handler;
+            this.model.setItemsFilter(query);
+         } else {
+            // do not submit immediately, but after short timeout
             // if user types very fast - only last selection will be shown
             if (this.search_handler) clearTimeout(this.search_handler);
-            this.search_handler = setTimeout(this.changeItemsFilter.bind(this, query, true), 1000);
-            return;
+            this.search_handler = setTimeout(() => this.changeItemsFilter(query, true), 1000);
          }
-
-         delete this.search_handler;
-
-         this.model.changeItemsFilter(query);
       },
 
       /** @summary process initial message, now it is list of existing canvases */

--- a/ui5/browser/model/BrowserModel.js
+++ b/ui5/browser/model/BrowserModel.js
@@ -1,21 +1,22 @@
 sap.ui.define([
-    "sap/ui/model/json/JSONModel",
-    "rootui5/browser/model/BrowserListBinding"
+    'sap/ui/model/json/JSONModel',
+    'rootui5/browser/model/BrowserListBinding'
 ], function(JSONModel, BrowserListBinding) {
-   "use strict";
 
-    let hRootModel = JSONModel.extend("rootui5.browser.model.BrowserModel", {
+   'use strict';
+
+    let hRootModel = JSONModel.extend('rootui5.browser.model.BrowserModel', {
 
         constructor: function() {
             JSONModel.apply(this);
-            this.setProperty("/", {
+            this.setProperty('/', {
                 nodes: {}, // nodes shown in the TreeTable, should be flat list
                 length: 0  // total number of elements
             });
 
             // this is true hierarchy, created on the client side and used for creation of flat list
             this.h = {
-               name: "__Holder__",
+               name: '__Holder__',
                expanded: true
             };
 
@@ -23,9 +24,9 @@ sap.ui.define([
 
             this.loadDataCounter = 0; // counter of number of nodes
 
-            this.sortMethod = "name"; // "name", "size"
+            this.sortMethod = 'name'; // 'name', 'size'
             this.reverseOrder = false;
-            this.itemsFilter = "";
+            this.itemsFilter = '';
             this.showHidden = false;
             this.appendToCanvas = false;
             this.onlyLastCycle = 0; // 0 - not changed, -1 off , +1 on
@@ -33,41 +34,42 @@ sap.ui.define([
             this.threshold = 100; // default threshold to prefetch items
         },
 
-        assignTreeTable: function(t) {
+        /** @summary Assign tree table control */
+        assignTreeTable(t) {
            this.treeTable = t;
         },
 
         /** @summary Set sort method */
-        setSortMethod: function(arg) { this.sortMethod = arg; },
+        setSortMethod(arg) { this.sortMethod = arg; },
 
         /** @summary Get sort method */
-        getSortMethod: function() { return this.sortMethod; },
+        getSortMethod() { return this.sortMethod; },
 
         /** @summary Set show hidden flag */
-        setShowHidden: function(flag) { this.showHidden = flag; },
+        setShowHidden(flag) { this.showHidden = flag; },
 
         /** @summary Is show hidden flag set */
-        isShowHidden: function() { return this.showHidden; },
+        isShowHidden() { return this.showHidden; },
 
         /** @summary Set show hidden flag */
-        setAppendToCanvas: function(flag) { this.appendToCanvas = flag; },
+        setAppendToCanvas(flag) { this.appendToCanvas = flag; },
 
         /** @summary Is show hidden flag set */
-        isAppendToCanvas: function() { return this.appendToCanvas; },
+        isAppendToCanvas() { return this.appendToCanvas; },
 
-        getOnlyLastCycle: function() { return this.onlyLastCycle; },
+        getOnlyLastCycle() { return this.onlyLastCycle; },
 
-        setOnlyLastCycle: function(v) { this.onlyLastCycle = v; },
+        setOnlyLastCycle(v) { this.onlyLastCycle = v; },
 
         /** @summary Set reverse order */
-        setReverseOrder: function(on) { this.reverseOrder = on; },
+        setReverseOrder(on) { this.reverseOrder = on; },
 
         /** @summary Is reverse order */
-        isReverseOrder: function() { return this.reverseOrder; },
+        isReverseOrder() { return this.reverseOrder; },
 
         /** @summary Set full model
           * @desc Method can be used when complete hierarchy is ready and can be used directly */
-        setFullModel: function(topnode) {
+        setFullModel(topnode) {
            this.fullModel = true;
            if (topnode.length) {
               this.h.nchilds = topnode.length;
@@ -92,7 +94,7 @@ sap.ui.define([
         },
 
         /** @summary Clear full model */
-        clearFullModel: function() {
+        clearFullModel() {
            if (!this.fullModel) return;
 
            delete this.h.childs;
@@ -104,40 +106,42 @@ sap.ui.define([
               this.oBinding.checkUpdate(true);
         },
 
-        setNoData: function(on) {
+        /** @summary Set nodata flag */
+        setNoData(on) {
            this.noData = on;
            if (this.oBinding)
               this.oBinding.checkUpdate(true);
         },
 
-        bindTree: function(sPath, oContext, aFilters, mParameters, aSorters) {
+        /** @summary Create list binding */
+        bindTree(sPath, oContext, aFilters, mParameters, aSorters) {
            this.oBinding = new BrowserListBinding(this, sPath, oContext, aFilters, mParameters, aSorters);
            return this.oBinding;
         },
 
-        getLength: function() {
-           if (this.noData) return 0;
-           return this.getProperty("/length");
+        /** @summary Return length property */
+        getLength() {
+           return this.noData ? 0 : this.getProperty('/length');
         },
 
         /** @summary Code index as string */
-        codeIndex: function(indx) {
-           return this.useIndexSuffix ? "###" + indx + "$$$" : "";
+        codeIndex(indx) {
+           return this.useIndexSuffix ? '###' + indx + '$$$' : '';
         },
 
         /** @summary Extract index from string */
-        extractIndex: function(name) {
-           if (!name || typeof name != "string") return "";
-           let p1 = name.lastIndexOf("###"), p2 = name.lastIndexOf("$$$");
+        extractIndex(name) {
+           if (!name || typeof name != 'string') return '';
+           let p1 = name.lastIndexOf('###'), p2 = name.lastIndexOf('$$$');
            if ((p1 < 0) || (p2 < 0) || (p1 >= p2) || (p2 != name.length - 3)) return name;
 
-           let indx = parseInt(name.substr(p1+3, p2-p1-3));
+           let indx = parseInt(name.slice(p1+3, p2));
            if (isNaN(indx) || (indx < 0)) return name;
-           return { n: name.substr(0, p1), i: indx };
+           return { n: name.slice(0, p1), i: indx };
         },
 
         /** @summary Get node by path which is array of strings, optionally includes indicies */
-        getNodeByPath: function(path) {
+        getNodeByPath(path) {
            let curr = this.h;
            if (!path || (path.length == 0)) return curr;
 
@@ -146,7 +150,7 @@ sap.ui.define([
            while (names.length > 0) {
               let name = this.extractIndex(names.shift()), find = false, indx = -1;
 
-              if (typeof name != "string") {
+              if (typeof name != 'string') {
                  indx = name.i;
                  name = name.n;
               }
@@ -173,10 +177,10 @@ sap.ui.define([
 
         /** @summary expand node by given path
           * @desc When path not exists - try to send request */
-        expandNodeByPath: function(path) {
-           if (!path || (typeof path !== "string") || (path == "/")) return -1;
+        expandNodeByPath(path) {
+           if (!path || (typeof path !== 'string') || (path == '/')) return -1;
 
-           let names = path.split("/"), curr = this.h, currpath = [];
+           let names = path.split('/'), curr = this.h, currpath = [];
 
            while (names.length > 0) {
               let name = names.shift(), find = false;
@@ -189,7 +193,7 @@ sap.ui.define([
                     curr.expanded = true;
                     this.reset_nodes = true;
                     this._expanding_path = path;
-                    this.submitRequest(false, curr, currpath, "expanding");
+                    this.submitRequest(false, curr, currpath, 'expanding');
                     break;
                  }
                  return -1;
@@ -213,16 +217,17 @@ sap.ui.define([
            return this.scanShifts(curr);
         },
 
-        sendFirstRequest: function(websocket) {
+        /** @summary Assign web socket and submit first request */
+        sendFirstRequest(websocket) {
            this._websocket = websocket;
            // submit top-level request already when construct model
            this.submitRequest(false, this.h);
         },
 
         /** @summary Reload main model
-          * One can force to submit new request while settings were changed
+          * @desc One can force to submit new request while settings were changed
           * One also can force to reload items on the server side if they can be potentially changed */
-        reloadMainModel: function(force_request, force_reload, path) {
+        reloadMainModel(force_request, force_reload, path) {
            if (this.mainModel && !force_request && !force_reload) {
               this.h.nchilds = this.mainModel.length;
               this.h.childs = this.mainModel;
@@ -234,17 +239,19 @@ sap.ui.define([
               if (this.oBinding)
                  this.oBinding.checkUpdate(true);
            } else if (!this.fullModel) {
+              if (force_request)
+                 this.processExpandedList([], 'cleanup');
+
               // send request, content will be reassigned
               this.submitRequest(force_reload, this.h, path);
            }
-
         },
 
         /** @summary submit next request to the server
           * @param {Array} path - path as array of strings
           * @desc directly use web socket, later can be dedicated channel */
-        submitRequest: function(force_reload, elem, path, first, number) {
-           if (first === "expanding") {
+        submitRequest(force_reload, elem, path, first, number) {
+           if (first === 'expanding') {
               first = 0;
            } else {
               delete this._expanding_path;
@@ -259,27 +266,28 @@ sap.ui.define([
               path: path || [],
               first: first || 0,
               number: number || this.threshold || 100,
-              sort: this.sortMethod || "",
+              sort: this.sortMethod || '',
               reverse: this.reverseOrder || false,
               hidden: this.showHidden ? true : false,
               lastcycle: this.onlyLastCycle,
               reload: force_reload ? true : false,  // rescan items by server even when path was not changed
-              regex: this.itemsFilter ? "^(" + this.itemsFilter + ".*)$" : "",
+              regex: this.itemsFilter ? `^(${this.itemsFilter}.*)$` : ''
            };
-           this._websocket.send("BRREQ:" + JSON.stringify(request));
+           this._websocket.send('BRREQ:' + JSON.stringify(request));
         },
 
-        // process reply from server
-        // In the future reply will be received via websocket channel
-        processResponse: function(reply) {
+        /** @summary process reply from server
+          * @desc In the future reply will be received via websocket channel */
+        processResponse(reply) {
 
            this.loadDataCounter--;
 
            let elem = this.getNodeByPath(reply.path);
 
-           if (!elem) { console.error('DID NOT FOUND ' + reply.path); return; }
+           if (!elem)
+              return console.error(`did not found ${reply.path}`);
 
-           if (!elem._requested) console.error('ELEMENT WAS NOT REQUESTED!!!!', reply.path);
+           if (!elem._requested) console.error(`element ${reply.path} was not requested!!!!`);
            delete elem._requested;
 
            let smart_merge = false;
@@ -327,20 +335,21 @@ sap.ui.define([
 
         },
 
-        getNodeByIndex: function(indx) {
-           let nodes = this.getProperty("/nodes");
+        /** @summary Return node by index */
+        getNodeByIndex(indx) {
+           let nodes = this.getProperty('/nodes');
            return nodes ? nodes[indx] : null;
         },
 
-        // return element of hierarchical structure by TreeTable index
-        getElementByIndex: function(indx) {
+        /** @summary return element of hierarchical structure by TreeTable index */
+        getElementByIndex(indx) {
            let node = this.getNodeByIndex(indx);
            return node ? node._elem : null;
         },
 
-        // function used to calculate all ids shifts and total number of elements
-        // if element specified - returns index of that element
-        scanShifts: function(for_elem) {
+        /** @summary function used to calculate all ids shifts and total number of elements
+          * @desc if element specified - returns index of that element */
+        scanShifts(for_elem) {
 
            let id = 0, full = this.fullModel, res = -1;
 
@@ -382,25 +391,25 @@ sap.ui.define([
 
            scan(-1, this.h);
 
-           this.setProperty("/length", id);
+           this.setProperty('/length', id);
 
            return for_elem ? res : id;
         },
 
-        // main  method to create flat list of nodes - only whose which are specified in selection
-        // following arguments:
-        //    args.begin     - first visisble element from flat list
-        //    args.end       - first not-visisble element
-        //    args.threshold - extra elements (before/after) which probably should be prefetched
-        // returns holder object with all existing nodes
-        buildFlatNodes: function(args) {
+        /** @summary main  method to create flat list of nodes - only whose which are specified in selection
+          * @desc following arguments:
+          *    args.begin     - first visisble element from flat list
+          *    args.end       - first not-visisble element
+          *    args.threshold - extra elements (before/after) which probably should be prefetched
+          * @return holder object with all existing nodes */
+        buildFlatNodes(args) {
 
            if (this.noData) return null;
 
            let id = 0,            // current id, at the same time number of items
                threshold = args.threshold || this.threshold || 100,
                threshold2 = Math.round(threshold/2),
-               nodes = this.reset_nodes ? {} : this.getProperty("/nodes");
+               nodes = this.reset_nodes ? {} : this.getProperty('/nodes');
 
            // main method to scan through all existing sub-folders
            let scan = (lvl, elem, path) => {
@@ -414,9 +423,9 @@ sap.ui.define([
                     _elem: elem,
                     isLeaf: !elem.nchilds,
                     // these are required by list binding, should be eliminated in the future
-                    type: elem.nchilds ? "folder" : "file",
+                    type: elem.nchilds ? 'folder' : 'file',
                     level: lvl,
-                    context: this.getContext("/nodes/" + id),
+                    context: this.getContext('/nodes/' + id),
                     nodeState: {
                        expanded: !!elem.expanded,
                        selected: !!elem.selected,
@@ -429,7 +438,9 @@ sap.ui.define([
 
               if (lvl >= 0) id++;
 
-              if (!elem.expanded) return;
+              if (!elem.expanded && !this.processExpandedList(path, 'test')) return;
+
+              elem.expanded = true;
 
               if (elem.childs === undefined) {
                  // add new request - can we check if only special part of childs is required?
@@ -464,7 +475,7 @@ sap.ui.define([
 
 
               let subpath = path.slice(), // make copy to avoid changes in argument
-                  subindx = subpath.push("") - 1;
+                  subindx = subpath.push('') - 1;
               for (let k = 0; k < elem.childs.length; ++k) {
                  subpath[subindx] = elem.childs[k].name + this.codeIndex((elem.first || 0) + k);
                  scan(lvl+1, elem.childs[k], subpath);
@@ -498,28 +509,58 @@ sap.ui.define([
            // start scan from very top
            scan(-1, this.h, []);
 
-           if (this.getProperty("/length") != id) {
-              // console.error('LENGTH MISMATCH', this.getProperty("/length"), id);
-              this.setProperty("/length", id); // update length property
+           if (this.getProperty('/length') != id) {
+              // console.error('LENGTH MISMATCH', this.getProperty('/length'), id);
+              this.setProperty('/length', id); // update length property
            }
 
            if (this.reset_nodes) {
-              this.setProperty("/nodes", nodes);
+              this.setProperty('/nodes', nodes);
               delete this.reset_nodes;
            }
 
            return nodes;
         },
 
-        // toggle expand state of specified node
-        toggleNode: function(index, do_expand) {
+        processExpandedList(path, action) {
+           if (action == 'cleanup') {
+               delete this._last_expands;
+               return true;
+            }
+
+           const exact = (action != 'remove'), len = path.length;
+           const match = test => {
+              if ((len > test.length) || (exact && (len != test.length)))
+                 return false;
+              for (let k = 0; k < len; ++k)
+                 if (test[k] != path[k])
+                    return false;
+              return true;
+           };
+           if (!this._last_expands)
+              this._last_expands = [];
+           for (let n = 0; n < this._last_expands.length; ++n)
+              if (match(this._last_expands[n])) {
+                 if (action == 'remove')
+                    this._last_expands.splice(n--, 1);
+                 else
+                     return true;
+              }
+           if (action == 'add')
+              this._last_expands.push(path);
+           return false;
+        },
+
+        /** @summary toggle expand state of specified node */
+        toggleNode(index, do_expand) {
 
            let node = this.getNodeByIndex(index),
-               elem = node ? node._elem : null;
+               elem = this.getElementByIndex(index);
 
            if (!node || !elem) return;
 
            if (elem.expanded && (do_expand === false)) {
+              this.processExpandedList(node.path, 'remove');
               delete elem.expanded;
               if (!this.fullModel)
                  delete elem.childs; // TODO: for the future keep childs but make request if expand once again
@@ -531,6 +572,7 @@ sap.ui.define([
               return true;
 
            } else if ((elem.nchilds || !elem.index) && (do_expand === true)) {
+              this.processExpandedList(node.path, 'add');
 
               elem.expanded = true;
               // structure is changing but not immediately
@@ -544,9 +586,10 @@ sap.ui.define([
            }
         },
 
-        changeItemsFilter: function(newValue) {
+        /** @summary Change items filter */
+        setItemsFilter(newValue) {
            if (newValue === undefined)
-              newValue = this.getProperty("/itemsFilter") || "";
+              newValue = this.getProperty('/itemsFilter') || '';
 
            // ignore same value
            if (newValue === this.itemsFilter)

--- a/ui5/canv/controller/Canvas.controller.js
+++ b/ui5/canv/controller/Canvas.controller.js
@@ -243,7 +243,7 @@ sap.ui.define([
                p.sendWebsocket("INTERRUPT");
                break;
             case "Reload":
-               if (typeof p._websocket?.askReload)
+               if (typeof p._websocket?.askReload == 'function')
                   p._websocket.askReload();
                break;
             case "Quit ROOT":


### PR DESCRIPTION
1. When filter expression entered, reopen folders again. Means if `TFile` keys were shown, they will be shown again. 
2. When object like `TH1` or `TTree` read from `TFile`, it will be removed from managed objects and owned by `RBrowser`. This allows to correctly work with different histograms version at the time.
3. Show `TFile` size 
4. Fix two LGTM warnings
5. Add `root7` as dependency for `RGeomViewer`
