### PR TITLE
[PyROOT][11581] Fix std::vector pythonization

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_stl_vector.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_stl_vector.py
@@ -34,6 +34,7 @@ def pythonize_stl_vector(klass, name):
     add_array_interface_property(klass, name)
 
     # Inject custom vector<char>::data()
-    if klass.value_type == 'char':
+    value_type = getattr(klass, 'value_type', None)
+    if value_type == 'char':
         klass._original_data = klass.data
         klass.data = _data_vec_char

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -21,5 +21,13 @@ class STL_vector(unittest.TestCase):
         for elem in v:
             self.assertEqual(elem, elems.pop(0))
 
+    def test_vec_const_char_p(self):
+        '''
+        Test that creating a std::vector<const char*> does not raise any
+        exception (#11581).
+        '''
+        ROOT.std.vector['const char*']()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #11581 

`std::vector<const char*>` does not provide a `value_type` attribute. This PR makes the pythonization of `std::vector<char>` resilient to the absence of such attribute.