### PR TITLE
[RF] Make sure value servers of integrals are next direct value servers

### DIFF
--- a/roofit/roofitcore/inc/RooProjectedPdf.h
+++ b/roofit/roofitcore/inc/RooProjectedPdf.h
@@ -32,9 +32,7 @@ public:
   double analyticalIntegralWN(Int_t code, const RooArgSet* normSet, const char* rangeName=nullptr) const override ;
   bool forceAnalyticalInt(const RooAbsArg& dep) const override ;
 
-  Int_t getGenerator(const RooArgSet& directVars, RooArgSet &generateVars, bool staticInitOK=true) const override;
   void initGenerator(Int_t /*code*/) override {} ; // optional pre-generation initialization
-  void generateEvent(Int_t code) override;
 
   bool selfNormalized() const override { return true ; }
 
@@ -52,9 +50,8 @@ protected:
 
   class CacheElem : public RooAbsCacheElement {
   public:
-    ~CacheElem() override { delete _projection ; } ;
     // Payload
-    RooAbsReal* _projection ;
+    std::unique_ptr<RooAbsReal> _projection;
     // Cache management functions
     RooArgList containedArgs(Action) override ;
     void printCompactTreeHook(std::ostream&, const char *, Int_t, Int_t) override ;

--- a/roofit/roofitcore/src/RooAbsCollection.cxx
+++ b/roofit/roofitcore/src/RooAbsCollection.cxx
@@ -1567,8 +1567,7 @@ void RooAbsCollection::sort(bool reverse) {
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Sort collection topologically: the servers of any RooAbsArg will be before
-/// that RooAbsArg in the collection. Will throw an exception if servers
-/// are missing in the collection.
+/// that RooAbsArg in the collection.
 
 void RooAbsCollection::sortTopologically() {
    std::unordered_set<TNamed const *> seenArgs;
@@ -1579,16 +1578,12 @@ void RooAbsCollection::sortTopologically() {
          if (seenArgs.find(server->namePtr()) == seenArgs.end()) {
             auto found = std::find_if(_list.begin(), _list.end(),
                                       [server](RooAbsArg *elem) { return elem->namePtr() == server->namePtr(); });
-            if (found == _list.end()) {
-               std::stringstream ss;
-               ss << "RooAbsArg \"" << arg->GetName() << "\" depends on \"" << server->GetName()
-                  << "\", but this arg is missing in the collection!";
-               throw std::runtime_error(ss.str());
+            if (found != _list.end()) {
+               _list.erase(found);
+               _list.insert(_list.begin() + iArg, server);
+               movedArg = true;
+               break;
             }
-            _list.erase(found);
-            _list.insert(_list.begin() + iArg, server);
-            movedArg = true;
-            break;
          }
       }
       if (movedArg) {

--- a/roofit/roofitcore/src/RooProjectedPdf.cxx
+++ b/roofit/roofitcore/src/RooProjectedPdf.cxx
@@ -35,10 +35,7 @@ is therefore identical to that of <pre>f->createProjection(RooArgSet(x,y))</pre>
 #include "RooRealVar.h"
 #include "RooNameReg.h"
 
-using namespace std;
-
- ClassImp(RooProjectedPdf);
-   ;
+ClassImp(RooProjectedPdf);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,9 +60,9 @@ RooProjectedPdf::RooProjectedPdf() : _cacheMgr(this,10)
    intobs.add(intObs) ;
 
    // Add all other dependens of projected p.d.f. directly
-   RooArgSet* tmpdeps = _intpdf.getParameters(intObs) ;
-   deps.add(*tmpdeps) ;
-   delete tmpdeps ;
+   RooArgSet tmpdeps;
+   _intpdf.getParameters(&intObs, tmpdeps);
+   deps.add(tmpdeps) ;
  }
 
 
@@ -91,9 +88,7 @@ double RooProjectedPdf::evaluate() const
 {
   // Calculate current unnormalized value of object
   int code ;
-  const RooAbsReal* proj = getProjection(&intobs, _normSet, 0, code);
-
-  return proj->getVal() ;
+  return getProjection(&intobs, _normSet, 0, code)->getVal() ;
 }
 
 
@@ -109,28 +104,27 @@ const RooAbsReal* RooProjectedPdf::getProjection(const RooArgSet* iset, const Ro
 
   // Check if this configuration was created before
   Int_t sterileIdx(-1) ;
-  CacheElem* cache = (CacheElem*) _cacheMgr.getObj(iset,nset,&sterileIdx,RooNameReg::ptr(rangeName)) ;
-  if (cache) {
+  if (auto cache = static_cast<CacheElem*>(_cacheMgr.getObj(iset,nset,&sterileIdx,RooNameReg::ptr(rangeName)))) {
     code = _cacheMgr.lastIndex() ;
-    return static_cast<const RooAbsReal*>(cache->_projection);
+    return static_cast<const RooAbsReal*>(cache->_projection.get());
   }
 
-  RooArgSet* nset2 =  intpdf.arg().getObservables(*nset) ;
+  RooArgSet nset2;
+  intpdf.arg().getObservables(nset, nset2);
 
   if (iset) {
-    nset2->add(*iset) ;
+    nset2.add(*iset) ;
   }
-  RooAbsReal* proj = intpdf.arg().createIntegral(iset?*iset:RooArgSet(),nset2,0,rangeName) ;
-  delete nset2 ;
 
-  cache = new CacheElem ;
-  cache->_projection = proj ;
+  auto cache = new CacheElem ;
+  cache->_projection = std::unique_ptr<RooAbsReal>{intpdf.arg().createIntegral(iset?*iset:RooArgSet(),&nset2,0,rangeName)};
 
-  code = _cacheMgr.setObj(iset,nset,(RooAbsCacheElement*)cache,RooNameReg::ptr(rangeName)) ;
+  code = _cacheMgr.setObj(iset, nset, cache, RooNameReg::ptr(rangeName)) ;
 
-  coutI(Integration) << "RooProjectedPdf::getProjection(" << GetName() << ") creating new projection " << proj->GetName() << " with code " << code << endl ;
+  coutI(Integration) << "RooProjectedPdf::getProjection(" << GetName() << ") creating new projection "
+                     << cache->_projection->GetName() << " with code " << code << std::endl;
 
-  return proj ;
+  return cache->_projection.get();
 }
 
 
@@ -183,16 +177,15 @@ Int_t RooProjectedPdf::getAnalyticalIntegralWN(RooArgSet& allVars, RooArgSet& an
 
 double RooProjectedPdf::analyticalIntegralWN(Int_t code, const RooArgSet* /*normSet*/, const char* rangeName) const
 {
-  CacheElem *cache = (CacheElem*) _cacheMgr.getObjByIndex(code-1) ;
-
-  if (cache) {
+  if (auto cache = static_cast<CacheElem*>(_cacheMgr.getObjByIndex(code-1))) {
     return cache->_projection->getVal() ;
   } else {
 
-    std::unique_ptr<RooArgSet> vars{getParameters(RooArgSet())} ;
-    vars->add(intobs) ;
-    RooArgSet iset = _cacheMgr.selectFromSet1(*vars, code-1) ;
-    RooArgSet nset = _cacheMgr.selectFromSet2(*vars, code-1) ;
+    RooArgSet vars;
+    getParameters(nullptr, vars);
+    vars.add(intobs) ;
+    RooArgSet iset = _cacheMgr.selectFromSet1(vars, code-1) ;
+    RooArgSet nset = _cacheMgr.selectFromSet2(vars, code-1) ;
 
     int code2 = -1 ;
 
@@ -200,26 +193,6 @@ double RooProjectedPdf::analyticalIntegralWN(Int_t code, const RooArgSet* /*norm
   }
 
 }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// No internal generator is implemented
-
-Int_t RooProjectedPdf::getGenerator(const RooArgSet& /*directVars*/, RooArgSet& /*generateVars*/, bool /*staticInitOK*/) const
- {
-   return 0 ;
- }
-
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// No internal generator is implemented
-
-void RooProjectedPdf::generateEvent(Int_t /*code*/)
- {
-   return;
- }
 
 
 
@@ -232,8 +205,7 @@ bool RooProjectedPdf::redirectServersHook(const RooAbsCollection& newServerList,
                                           bool nameChange, bool isRecursive)
 {
   // Redetermine explicit list of dependents if intPdf is being replaced
-  RooAbsArg* newPdf = newServerList.find(intpdf.arg().GetName()) ;
-  if (newPdf) {
+  if (RooAbsArg* newPdf = newServerList.find(intpdf.arg().GetName())) {
 
     // Determine if set of dependens of new p.d.f is different from old p.d.f.
     RooArgSet olddeps(deps) ;
@@ -263,8 +235,7 @@ bool RooProjectedPdf::redirectServersHook(const RooAbsCollection& newServerList,
 
 RooArgList RooProjectedPdf::CacheElem::containedArgs(Action)
 {
-  RooArgList ret(*_projection) ;
-  return ret ;
+  return *_projection;
 }
 
 
@@ -273,14 +244,9 @@ RooArgList RooProjectedPdf::CacheElem::containedArgs(Action)
 /// Customized printing of arguments of a RooRealIntegral to more intuitively reflect the contents of the
 /// integration operation
 
-void RooProjectedPdf::printMetaArgs(ostream& os) const
+void RooProjectedPdf::printMetaArgs(std::ostream& os) const
 {
-  os << "Int " << intpdf.arg().GetName() ;
-
-  os << " d" ;
-  os << intobs ;
-  os << " " ;
-
+  os << "Int " << intpdf.arg().GetName() << " d"  << intobs << " ";
 }
 
 
@@ -289,10 +255,10 @@ void RooProjectedPdf::printMetaArgs(ostream& os) const
 ////////////////////////////////////////////////////////////////////////////////
 /// Print contents of cache when printing self as part of object tree
 
-void RooProjectedPdf::CacheElem::printCompactTreeHook(ostream& os, const char* indent, Int_t curElem, Int_t maxElem)
+void RooProjectedPdf::CacheElem::printCompactTreeHook(std::ostream& os, const char* indent, Int_t curElem, Int_t maxElem)
 {
   if (curElem==0) {
-    os << indent << "RooProjectedPdf begin projection cache" << endl ;
+    os << indent << "RooProjectedPdf begin projection cache" << std::endl ;
   }
 
   TString indent2(indent) ;
@@ -301,8 +267,6 @@ void RooProjectedPdf::CacheElem::printCompactTreeHook(ostream& os, const char* i
   _projection->printCompactTree(os,indent2) ;
 
   if(curElem==maxElem) {
-    os << indent << "RooProjectedPdf end projection cache" << endl ;
+    os << indent << "RooProjectedPdf end projection cache" << std::endl ;
   }
 }
-
-

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -41,6 +41,11 @@ ROOT_ADD_GTEST(testRooRealVar testRooRealVar.cxx LIBRARIES RooFitCore
     LIBRARIES RooFitCore
     COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_1.root ${CMAKE_CURRENT_SOURCE_DIR}/testRooAbsReal_2.root)
 if(NOT MSVC OR win_broken_tests)
+  # Dsiabled on Windows because it causes the following error:
+  # unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
+  # According to the internet, this has to do with gtest, so it's not a RooFit problem
+  ROOT_ADD_GTEST(testRooRealIntegral testRooRealIntegral.cxx LIBRARIES RooFitCore RooFit)
+
   ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore RooFit)
 endif()
 ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)

--- a/roofit/roofitcore/test/testRooRealIntegral.cxx
+++ b/roofit/roofitcore/test/testRooRealIntegral.cxx
@@ -1,0 +1,135 @@
+// Tests for RooRealIntegral
+// Authors: Jonas Rembser, CERN 10/2022
+
+#include <RooConstVar.h>
+#include <RooGaussian.h>
+#include <RooGenericPdf.h>
+#include <RooProduct.h>
+#include <RooProjectedPdf.h>
+#include <RooRealVar.h>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+// Verify that the value servers of a RooRealIntegral are the direct
+// mathematical value servers of the integral, and not the leaves in the
+// computation graphs. For the Batch mode, it is important for the evaluation
+// of the computation graph that no direct value servers are skipped. See also
+// GitHub issue #11578.
+TEST(RooRealIntegral, ClientServerInterface1)
+{
+   using namespace RooFit;
+
+   RooRealVar x{"x", "", 0, 1};
+
+   RooRealVar mu{"mu", "", -0.005, -5, 5};
+
+   // This is the key in this test: the mathematically direct value server of
+   // the integral is the derived "muMod", and not the leaf of the computation
+   // graph "mu"
+   RooProduct muMod{"mu_mod", "", {mu, RooConst(10)}};
+
+   RooGaussian gauss{"gauss", "", x, muMod, RooConst(2.0)};
+   RooGenericPdf pdf{"gaussWrapped", "gauss", gauss};
+
+   std::unique_ptr<RooAbsReal> integ1{gauss.createIntegral(x, *pdf.getIntegratorConfig(), nullptr)};
+   std::unique_ptr<RooAbsReal> integ2{pdf.createIntegral(x, *pdf.getIntegratorConfig(), nullptr)};
+
+   RooArgList servers1{integ1->servers().begin(), integ1->servers().end()};
+   RooArgList servers2{integ2->servers().begin(), integ2->servers().end()};
+
+   // Sort alphabetically in case the two integrals didn't add the servers in
+   // the same order:
+   servers1.sort();
+   servers2.sort();
+
+   // Check that the server structure of the Gaussian integral looks as
+   // expected, which should be, if you use Print("v"):
+   //
+   //     (-S) RooRealVar::x ""
+   //     (--) RooGenericPdf::pdf "gauss"
+   //     (V-) RooProduct::mu_mod ""
+   //     (V-) RooConstVar::2 "2"
+   //
+   // What is important is that the indirect value server "mu" doesn't appear
+   // among the servers, and the direct value server "mu_mod" does.
+
+   EXPECT_EQ(servers1.size(), 4);
+
+   // Respect the alphabetical order here
+   EXPECT_EQ(std::string(servers1[0].GetName()), "2");
+   EXPECT_EQ(std::string(servers1[1].GetName()), "gauss");
+   EXPECT_EQ(std::string(servers1[2].GetName()), "mu_mod");
+   EXPECT_EQ(std::string(servers1[3].GetName()), "x");
+
+   EXPECT_TRUE(servers1[0].isValueServer(*integ1));
+   EXPECT_FALSE(servers1[1].isValueServer(*integ1));
+   EXPECT_TRUE(servers1[2].isValueServer(*integ1));
+   EXPECT_FALSE(servers1[3].isValueServer(*integ1));
+
+   EXPECT_FALSE(servers1[0].isShapeServer(*integ1));
+   EXPECT_FALSE(servers1[1].isShapeServer(*integ1));
+   EXPECT_FALSE(servers1[2].isShapeServer(*integ1));
+   EXPECT_TRUE(servers1[3].isShapeServer(*integ1));
+
+   // The Gaussian PDF wrapped in a RooGenericPdf should have exactly the same
+   // server structure, so let's check that:
+
+   EXPECT_EQ(servers2.size(), servers1.size());
+
+   for (std::size_t i = 0; i < servers1.size(); ++i) {
+      RooAbsArg const &s1 = servers1[i];
+      RooAbsArg const &s2 = servers2[i];
+
+      // The 2nd server is the integrated function, which doesn't have the same
+      // name (it's "gaussWrapped" for the second integral instead of "gauss")
+      if (i != 1) {
+         EXPECT_EQ(std::string(s1.GetName()), s2.GetName());
+      }
+
+      EXPECT_EQ(s1.isValueServer(*integ1), s2.isValueServer(*integ2));
+      EXPECT_EQ(s1.isShapeServer(*integ1), s2.isShapeServer(*integ2));
+   }
+}
+
+/// Here we are integrating a function that has shape servers to verify that
+/// they are correctly propagated as shape servers to the integral.
+TEST(RooRealIntegral, IntegrateFuncWithShapeServers)
+{
+   using namespace RooFit;
+
+   RooRealVar x("x", "", 0, 1);
+
+   RooRealVar mu("mu", "", -0.005, -5, 5);
+   RooProduct muMod("mu_mod", "", RooArgSet(mu, RooConst(10)));
+   RooRealVar sigma("sigma", "", 1, 0.5, 2);
+
+   RooGaussian gauss("gauss", "", x, muMod, sigma);
+   RooGenericPdf pdf("pdf", "gauss", gauss);
+
+   // Project over sigma, meaning sigma should now become a shape server
+   RooProjectedPdf gaussProj("gaussProj", "", gauss, sigma);
+
+   EXPECT_TRUE(x.isValueServer(gaussProj));
+   EXPECT_FALSE(x.isShapeServer(gaussProj));
+   EXPECT_TRUE(muMod.isValueServer(gaussProj));
+   EXPECT_FALSE(muMod.isShapeServer(gaussProj));
+   EXPECT_FALSE(sigma.isValueServer(gaussProj));
+   EXPECT_TRUE(sigma.isShapeServer(gaussProj));
+
+   // Integrating also over x, so both x and sigma should now be shape servers of the integral
+   std::unique_ptr<RooAbsReal> integ1{gaussProj.createIntegral(x, *pdf.getIntegratorConfig(), nullptr)};
+
+   EXPECT_FALSE(x.isValueServer(*integ1)); // x is now not a value server anymore
+   EXPECT_TRUE(x.isShapeServer(*integ1));
+   EXPECT_TRUE(muMod.isValueServer(*integ1));
+   EXPECT_FALSE(muMod.isShapeServer(*integ1));
+   EXPECT_FALSE(sigma.isValueServer(*integ1));
+   EXPECT_TRUE(sigma.isShapeServer(*integ1)); // sigma should still be shape server!
+
+   // Also check that that the number of servers is right (should be 3 for x,
+   // mu, and sigma, and 1 more for the underlying PDF)
+   EXPECT_EQ(gaussProj.servers().size(), 4);
+   EXPECT_EQ(integ1->servers().size(), 4);
+}


### PR DESCRIPTION
Integrals of derived PDFs have their client-server interface messed up,
and it's inconsistent with non-derived PDFs. Here is a reproducer:

```C++
void repro() {
    using namespace RooFit;
    RooRealVar x("x", "", 0, 1);

    RooRealVar par("par", "", -0.005, -5, 5);
    RooProduct parMod("par_mod", "", RooArgSet(par, RooConst(10)));

    RooGaussian gauss("gauss", "", x, parMod, RooConst(2.0));
    RooGenericPdf pdf("pdf", "gauss", gauss);

    std::unique_ptr<RooAbsReal> integ1{gauss.createIntegral(x, *pdf.getIntegratorConfig(), nullptr)};
    integ1->Print("v");

    std::cout << std::endl;

    std::unique_ptr<RooAbsReal> integ2{pdf.createIntegral(x, *pdf.getIntegratorConfig(), nullptr)};
    integ2->Print("v");
}
```

The integral of the Gaussian has the correct value (`V`) servers (the parameters of the Gaussian):
```
    (0x7ffc9b9bf798,-S) RooRealVar::x ""
    (0x7ffc9b9bf240,--) RooGaussian::gauss ""
    (0x7ffc9b9bff68,V-) RooProduct::par_mod ""
    (0x55ac531cd470,V-) RooConstVar::2 "2"
```

The integral of the `RooGenericPdf` should have the same value servers,
but it doesn't. Instead, it uses the leaves of the computation graph:
```
    (0x7ffc9b9bf798,-S) RooRealVar::x ""
    (0x7ffc9b9bec88,--) RooRealSumPdf::pdf ""
    (0x7ffc9b9bfb80,V-) RooRealVar::par ""
    (0x55ac51984c50,V-) RooConstVar::10 "10"
    (0x55ac531cd470,V-) RooConstVar::2 "2"
```

That means, the direct value server `par_mod` is **skipped** now,
misrepresenting the client-server relationship.

The new BatchMode makes strong use of the value-server interface for the
`RooFitDriver`, so it's very sensitive to `RooRealIntegrals` getting it
wrong.

That's why this commit suggests to change the logic in `RooRealIntegral`
to always add the next direct value servers that don't depend on the
integration variable, and not the leaves.

A unit test that verifies that the value servers of the integral are the
mathematically direct value servers and not the computation graph leaves
is also implemented.

Closes https://github.com/root-project/root/issues/11578.

The PR also fixes the same problem for the RooProjectedPdf, which is essentially a integral wrapper but it also got the server-client interface wrong. Now, it simply takes over the shape and value servers from the underlying integral, which is now implemented correctly.