### PR TITLE
[RF] Veto `.py` tutorial tests of RooStats and HistFactory if ROOT is built without `roofit`

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -132,9 +132,9 @@ if(NOT ROOT_spectrum_FOUND)
 endif()
 
 if(NOT ROOT_roofit_FOUND)
-  set(roofit_veto  fit/RoofitDemo.C
-                   roofit/*.C roostats/*.C histfactory/*.C
-                   roofit/*.py)
+  set(roofit_veto roofit/*.C roofit/*.py
+                  roostats/*.C roostats/*.py
+                  histfactory/*.C histfactory/*.py)
 else()
   if(MSVC AND NOT win_broken_tests)
     set(roofit_veto roofit/rf401_importttreethx.py roofit/rf708_bphysics.py roofit/rf501_simultaneouspdf.py)


### PR DESCRIPTION
Veto also tutorial tests of RooStats and HistFactory if ROOT was built without RooFit.

Also removes the `fit/RooFitdemo.C` tutorial from the veto list, as this tutorial doesn't exist anymore.

Partially closes #11605.