### PR TITLE
[RF][PyROOT] Move RooFit pythonization tests from roottest to main repo

### DIFF
--- a/bindings/pyroot/pythonizations/test/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/test/CMakeLists.txt
@@ -143,6 +143,9 @@ if(roofit)
   # RooDataHist pythonisations
   ROOT_ADD_PYUNITTEST(pyroot_roofit_roodatahist_ploton roofit/roodatahist_ploton.py)
 
+  # RooDataSet pythonisations
+  ROOT_ADD_PYUNITTEST(pyroot_roofit_roodataset roofit/roodataset.py)
+
   # RooWorkspace pythonizations
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooworkspace roofit/rooworkspace.py)
   ROOT_ADD_PYUNITTEST(pyroot_roofit_rooabspdf_fitto roofit/rooabspdf_fitto.py)

--- a/bindings/pyroot/pythonizations/test/roofit/rooabscollection.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooabscollection.py
@@ -142,8 +142,19 @@ class TestRooAbsCollection(unittest.TestCase):
         s2 = ROOT.RooArgSet()
         s3 = ROOT.RooArgSet()
 
-        s2.addClone(s1) # addClone(const RooAbsCollection& list)
-        s3.addClone(x) # addClone(const RooAbsArg& var)
+        s2.addClone(s1)  # addClone(const RooAbsCollection& list)
+        s3.addClone(x)  # addClone(const RooAbsArg& var)
+
+    def test_rooargset_iter(self):
+        """STL sequence iterator injected in RooAbsCollection, inherited by RooArgSet"""
+        # ROOT-10606
+
+        varA = ROOT.RooRealVar("a", "a", 0.0)
+        varB = ROOT.RooRealVar("b", "b", 1.0)
+        varSet = ROOT.RooArgSet(varA, varB)
+        for var in varSet:
+            var.getVal()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bindings/pyroot/pythonizations/test/roofit/roodataset.py
+++ b/bindings/pyroot/pythonizations/test/roofit/roodataset.py
@@ -1,0 +1,24 @@
+import unittest
+
+import ROOT
+
+import numpy as np
+
+
+class TestRooDataSet(unittest.TestCase):
+    def test_createHistogram_decls(self):
+        """RooDataSet::createHistogram overloads obtained with using decls."""
+
+        import ROOT
+
+        x = ROOT.RooRealVar("x", "x", -10, 10)
+        mean = ROOT.RooRealVar("mean", "mean of gaussian", 1, -10, 10)
+        sigma = ROOT.RooRealVar("sigma", "width of gaussian", 1, 0.1, 10)
+        gauss = ROOT.RooGaussian("gauss", "gaussian PDF", x, mean, sigma)
+
+        data = gauss.generate(ROOT.RooArgSet(x), 10000)  # ROOT.RooDataSet
+        h1d = data.createHistogram("myname", x)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bindings/pyroot/pythonizations/test/roofit/rooglobalfunc.py
+++ b/bindings/pyroot/pythonizations/test/roofit/rooglobalfunc.py
@@ -47,6 +47,11 @@ class TestRooGlobalFunc(unittest.TestCase):
 
         self.assertEqual(data_2.numEntries(), n_events)
 
+    def test_minimizer(self):
+        """C++ object returned by RooFit::Minimizer should not be double deleted"""
+        # ROOT-9516
+        minimizer = ROOT.RooFit.Minimizer("Minuit2", "migrad")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is more practical, because most RooFit tests are already here and and different from when these tests were in `roottest`, it's also to exclude them if ROOT is not built with RooFit enabled.

Technically independent of https://github.com/root-project/roottest/pull/909, but they go together.

Closes https://github.com/root-project/root/issues/11605.