### PR TITLE
[cmake] Update XRootD to v5.5.1

### DIFF
--- a/builtins/xrootd/CMakeLists.txt
+++ b/builtins/xrootd/CMakeLists.txt
@@ -8,8 +8,8 @@ include(ExternalProject)
 
 find_package(OpenSSL REQUIRED)
 
-set(XROOTD_VERSION "5.5.0")
-set(XROOTD_VERSIONNUM 500050000 CACHE INTERNAL "" FORCE)
+set(XROOTD_VERSION "5.5.1")
+set(XROOTD_VERSIONNUM 500050001 CACHE INTERNAL "" FORCE)
 set(lcgpackages http://lcgpackages.web.cern.ch/lcgpackages/tarFiles/sources)
 set(XROOTD_SRC_URI ${lcgpackages}/xrootd-${XROOTD_VERSION}.tar.gz)
 set(XROOTD_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/XROOTD-prefix)
@@ -34,7 +34,7 @@ endif()
 ExternalProject_Add(
     XROOTD
     URL ${XROOTD_SRC_URI}
-    URL_HASH SHA256=e01d83997e428580aadefd4b18cc6246e97a1941dfceff3726ffd0c40921de34
+    URL_HASH SHA256=3556d5afcae20ed9a12c89229d515492f6c6f94f829a3d537f5880fcd2fa77e4
     INSTALL_DIR ${XROOTD_PREFIX}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                -DCMAKE_PREFIX_PATH:STRING=${OPENSSL_PREFIX}


### PR DESCRIPTION
# This Pull request:

* Update XRootD builtin from v5.5.0 to v5.5.1
   - c.f. https://github.com/xrootd/xrootd/releases/tag/v5.5.1
* Follow up to PR #11328
* Requires https://sft.its.cern.ch/jira/browse/SPI-2231

## Changes or fixes:

* Update XRootD builtin from v5.5.0 to v5.5.1


## Checklist:

- [x] tested changes locally

I didn't build ROOT from source (though c.f. https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/75 for a source build with effectively this change)

- [N/A] updated the docs (if necessary)
