### PR TITLE
create dummy images in advance for doxygen not to complain

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -62,6 +62,8 @@ doxygen: filter pyzdoc
 	$(call MkDir,$(DOXYGEN_NOTEBOOK_PATH))
 	./makehtmlfooter.sh > htmlfooter.html
 	./makeinput.sh
+	$(call MkDir,$(DOXYGEN_IMAGE_PATH))
+	bash ./touch_images.sh $(DOXYGEN_SOURCE_DIRECTORY) $(DOXYGEN_IMAGE_PATH)
 	doxygen
 	gzip $(DOXYGEN_IMAGE_PATH)/ROOT.tag
 	gzip $(DOXYGEN_IMAGE_PATH)/ROOT.qch

--- a/documentation/doxygen/touch_images.sh
+++ b/documentation/doxygen/touch_images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+FILES=$(grep -r macro_image $1 -l | sed 's!.*/!!' | sort -u | sed 's/$/.png/' | sed 's/^/_/')
+echo "Touching images..."
+for myfile in $FILES; do
+    for i in {1..25} # 25 is the max number of pictures created by a macro, for double32.C
+    do
+        touch $2/pict$i$myfile &
+    done
+    wait
+done


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

Currently, building the documentation issues 3700 warnings, see https://lcgapp-services.cern.ch/root-jenkins/view/ROOT/job/root-makedoc-master/lastBuild/parsed_console/

With the current hack, we would go down to just 2700.

By the way, it would be nice to fine-tune the parser: see https://github.com/root-project/jenkins-pipelines/issues/10

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

See related discussion https://github.com/doxygen/doxygen/issues/9044

