### PR TITLE
Tweaks for AddressSanitizer

### DIFF
--- a/bindings/pyroot/pythonizations/CMakeLists.txt
+++ b/bindings/pyroot/pythonizations/CMakeLists.txt
@@ -30,6 +30,7 @@ list(APPEND PYROOT_EXTRA_HEADERS
 
 set(py2_py3_sources
   ROOT/_application.py
+  ROOT/_asan.py
   ROOT/_facade.py
   ROOT/__init__.py
   ROOT/_numbadeclare.py

--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -19,6 +19,9 @@ environ['CPPYY_API_PATH'] = 'none'
 # Prevent cppyy from filtering ROOT libraries
 environ['CPPYY_NO_ROOT_FILTER'] = '1'
 
+# Do setup specific to AddressSanitizer environments
+from . import _asan
+
 import cppyy
 if not 'ROOTSYS' in environ:
     # Revert setting made by cppyy

--- a/bindings/pyroot/pythonizations/python/ROOT/_asan.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_asan.py
@@ -1,0 +1,23 @@
+# Author: Jonas Hahnfeld CERN  10/2022
+
+################################################################################
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.                      #
+# All rights reserved.                                                         #
+#                                                                              #
+# For the licensing terms see $ROOTSYS/LICENSE.                                #
+# For the list of contributors see $ROOTSYS/README/CREDITS.                    #
+################################################################################
+
+import os
+
+# Filter out ASan related libraries that need to be preloaded into the
+# Python process, but must not be propagated into instrumented executables
+# such as root or rootcling.
+if 'LD_PRELOAD' in os.environ:
+    new_preload = []
+    for lib in os.environ['LD_PRELOAD'].split(':'):
+        if 'libROOTSanitizerConfig' in lib or 'libclang_rt.asan-' in lib:
+            continue
+        new_preload.append(lib)
+    os.environ['LD_PRELOAD'] = ':'.join(new_preload)
+

--- a/bindings/pyroot/pythonizations/test/import_load_libs.py
+++ b/bindings/pyroot/pythonizations/test/import_load_libs.py
@@ -67,6 +67,9 @@ class ImportLoadLibs(unittest.TestCase):
             'libnss_.*',
             'ld.*',
             'libffi',
+            # AddressSanitizer runtime and ROOT configuration
+            'libclang_rt.asan-.*',
+            'libROOTSanitizerConfig',
             ]
 
     # Verbose mode of the test


### PR DESCRIPTION
Address a number of AddressSanitizer failures with Python tests, due to the way we need to preload the ASan runtime and our configuration.

If I count correctly (there were a number of failures introduced last night, so I don't have a proper baseline), this fixes 7 tests:
 * `pyunittests-pyroot-import-load-libs`
 * `tutorial-roofit-rf104_classfactory-py`
 * `roottest-python-JupyROOT-simpleCppMagic_notebook`
 * `roottest-python-JupyROOT-thread_local_notebook`
 * `roottest-python-JupyROOT-ROOT_kernel_notebook`
 * `roottest-python-basic-basic`
 * `roottest-python-regression-regression`

Moreover, `tutorial-rcanvas-df104-py` will show a proper AdressSanitizer failure.