### PR TITLE
[RF] Make NLL creation in new BatchMode feature complete

### DIFF
--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -150,6 +150,8 @@ std::unique_ptr<T> cloneTreeWithSameParameters(T const& arg, RooArgSet const* ob
   return clone;
 }
 
+std::string getRangeNameForSimComponent(std::string const& rangeName, bool splitRange, std::string const& catName);
+
 }
 
 #endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/inc/RooHelpers.h
+++ b/roofit/roofitcore/inc/RooHelpers.h
@@ -152,6 +152,13 @@ std::unique_ptr<T> cloneTreeWithSameParameters(T const& arg, RooArgSet const* ob
 
 std::string getRangeNameForSimComponent(std::string const& rangeName, bool splitRange, std::string const& catName);
 
+struct BinnedLOutput {
+    RooAbsPdf * binnedPdf = nullptr;
+    bool isBinnedL = false;
+};
+
+BinnedLOutput getBinnedL(RooAbsPdf &pdf);
+
 }
 
 #endif /* ROOFIT_ROOFITCORE_INC_ROOHELPERS_H_ */

--- a/roofit/roofitcore/res/RooFit/BatchModeDataHelpers.h
+++ b/roofit/roofitcore/res/RooFit/BatchModeDataHelpers.h
@@ -31,7 +31,7 @@ namespace RooFit {
 namespace BatchModeDataHelpers {
 
 std::map<RooFit::Detail::DataKey, RooSpan<const double>>
-getDataSpans(RooAbsData const &data, std::string_view rangeName, RooAbsCategory const *indexCat,
+getDataSpans(RooAbsData const &data, std::string_view rangeName, std::string const &prefix,
              std::stack<std::vector<double>> &buffers, bool skipZeroWeights);
 
 } // namespace BatchModeDataHelpers

--- a/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
+++ b/roofit/roofitcore/res/RooFit/BatchModeHelpers.h
@@ -35,7 +35,7 @@ namespace BatchModeHelpers {
 std::unique_ptr<RooAbsReal>
 createNLL(std::unique_ptr<RooAbsPdf> &&pdf, RooAbsData &data, std::unique_ptr<RooAbsReal> &&constraints,
           std::string const &rangeName, RooArgSet const &projDeps, bool isExtended, double integrateOverBinsPrecision,
-          RooFit::BatchModeOption batchMode, bool doOffset, bool takeGlobalObservablesFromData);
+          RooFit::BatchModeOption batchMode, bool doOffset, bool splitRange, bool takeGlobalObservablesFromData);
 
 void logArchitectureInfo(RooFit::BatchModeOption batchMode);
 

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -59,6 +59,8 @@ public:
    double getVal();
    RooAbsReal &topNode() const;
 
+   void print(std::ostream &os) const;
+
 private:
    ///////////////////////////
    // Private member functions

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -92,6 +92,8 @@ private:
 
    // RAII structures to reset state of computation graph after driver destruction
    std::stack<RooHelpers::ChangeOperModeRAII> _changeOperModeRAIIs;
+
+   std::vector<std::unique_ptr<RooAbsData>> _splittedDataSets;
 };
 
 } // end namespace Experimental

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -49,9 +49,9 @@ public:
    RooFitDriver(const RooAbsReal &absReal, RooArgSet const &normSet,
                 RooFit::BatchModeOption batchMode = RooFit::BatchModeOption::Cpu);
 
-   void setData(RooAbsData const &data, std::string_view rangeName = "",
-                RooAbsCategory const *indexCatForSplitting = nullptr, bool skipZeroWeights = false,
-                bool takeGlobalObservablesFromData = true);
+   void setData(RooAbsData const &data, std::string const &rangeName = "",
+                RooAbsCategory const *indexCatForSplitting = nullptr, bool splitRange = false,
+                bool skipZeroWeights = false, bool takeGlobalObservablesFromData = true);
    void setData(DataSpansMap const &dataSpans);
 
    ~RooFitDriver();

--- a/roofit/roofitcore/res/RooFitDriver.h
+++ b/roofit/roofitcore/res/RooFitDriver.h
@@ -30,6 +30,7 @@ class RooAbsData;
 namespace RooFit {
 class NormalizationIntegralUnfolder;
 }
+class RooSimultaneous;
 
 namespace ROOT {
 namespace Experimental {
@@ -49,9 +50,8 @@ public:
    RooFitDriver(const RooAbsReal &absReal, RooArgSet const &normSet,
                 RooFit::BatchModeOption batchMode = RooFit::BatchModeOption::Cpu);
 
-   void setData(RooAbsData const &data, std::string const &rangeName = "",
-                RooAbsCategory const *indexCatForSplitting = nullptr, bool splitRange = false,
-                bool skipZeroWeights = false, bool takeGlobalObservablesFromData = true);
+   void setData(RooAbsData const &data, std::string const &rangeName = "", RooSimultaneous const *simPdf = nullptr,
+                bool splitRange = false, bool skipZeroWeights = false, bool takeGlobalObservablesFromData = true);
    void setData(DataSpansMap const &dataSpans);
 
    ~RooFitDriver();

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -34,7 +34,7 @@ public:
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
-                bool doOffset, int simCount = 1);
+                bool doOffset, int simCount = 1, bool binnedL = false);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -56,6 +56,7 @@ public:
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();
+   double getFinalValAfterOffsetting(ROOT::Math::KahanSum<double> &&result) const;
 
    RooTemplateProxy<RooAbsPdf> _pdf;
    RooArgSet _observables;

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -47,14 +47,14 @@ public:
    void computeBatch(cudaStream_t *, double *output, size_t nOut, RooFit::Detail::DataMap const &) const override;
    inline bool isReducerNode() const override { return true; }
 
-   RooArgSet prefixObservableAndWeightNames(std::string const &prefix);
+   RooArgSet prefixArgNames(std::string const &prefix);
 
    void applyWeightSquared(bool flag) override;
 
    std::unique_ptr<RooArgSet> fillNormSetForServer(RooArgSet const &normSet, RooAbsArg const &server) const override;
 
 private:
-   double evaluate() const override;
+   double evaluate() const override { return _value; }
    void resetWeightVarNames();
 
    RooTemplateProxy<RooAbsPdf> _pdf;

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -34,7 +34,7 @@ public:
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
-                bool doOffset);
+                bool doOffset, int simCount = 1);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 
@@ -65,6 +65,7 @@ private:
    bool _weightSquared = false;
    bool _binnedL = false;
    bool _doOffset = false;
+   int _simCount = 0;
    std::string _prefix;
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;

--- a/roofit/roofitcore/src/BatchModeDataHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeDataHelpers.cxx
@@ -12,63 +12,12 @@
 
 #include <RooFit/BatchModeDataHelpers.h>
 
-#include <RooAbsCategory.h>
 #include <RooAbsData.h>
 #include <RooNLLVarNew.h>
 
 #include <ROOT/StringUtils.hxx>
 
 #include <numeric>
-
-namespace {
-
-void splitByCategory(std::map<RooFit::Detail::DataKey, RooSpan<const double>> &dataSpans,
-                     RooAbsCategory const &category, std::stack<std::vector<double>> &buffers)
-{
-   std::stack<std::vector<double>> oldBuffers;
-   std::swap(buffers, oldBuffers);
-
-   auto catVals = dataSpans.at(category.namePtr());
-
-   std::map<RooFit::Detail::DataKey, RooSpan<const double>> dataMapSplit;
-
-   for (auto const &dataMapItem : dataSpans) {
-
-      auto const &varNamePtr = dataMapItem.first;
-      auto const &xVals = dataMapItem.second;
-
-      if (varNamePtr == category.namePtr())
-         continue;
-
-      std::map<RooAbsCategory::value_type, std::vector<double>> valuesMap;
-
-      if (xVals.size() == 1) {
-         // If the span is of size one, we will replicate it for each category
-         // component instead of splitting is up by category value.
-         for (auto const &catItem : category) {
-            valuesMap[catItem.second].push_back(xVals[0]);
-         }
-      } else {
-         for (std::size_t i = 0; i < xVals.size(); ++i) {
-            valuesMap[catVals[i]].push_back(xVals[i]);
-         }
-      }
-
-      for (auto const &item : valuesMap) {
-         RooAbsCategory::value_type index = item.first;
-         auto variableName = std::string("_") + category.lookupName(index) + "_" + varNamePtr->GetName();
-         auto variableNamePtr = RooNameReg::instance().constPtr(variableName.c_str());
-
-         buffers.emplace(std::move(item.second));
-         auto const &values = buffers.top();
-         dataMapSplit[variableNamePtr] = RooSpan<const double>(values.data(), values.size());
-      }
-   }
-
-   dataSpans = std::move(dataMapSplit);
-}
-
-} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Extract all content from a RooFit datasets as a map of spans.
@@ -81,11 +30,8 @@ void splitByCategory(std::map<RooFit::Detail::DataKey, RooSpan<const double>> &d
 /// \param[in] data The input dataset.
 /// \param[in] rangeName Select only entries from the data in a given range
 ///            (empty string for no range).
-/// \param[in] indexCat If not `nullptr`, each span is spit up by this category,
-///            with the new names prefixed by the category component name
-///            surrounded by underscores. For example, if you have a category
-///            with `signal` and `control` samples, the span for a variable `x`
-///            will be split in two spans `_signal_x` and `_control_x`.
+/// \param[in] prefix A string prefix to use for all key names for the data
+///            map.
 /// \param[in] buffers Pass here an empty stack of `double` vectors, which will
 ///            be used as memory for the data if the memory in the dataset
 ///            object can't be used directly (e.g. because you used the range
@@ -96,23 +42,30 @@ void splitByCategory(std::map<RooFit::Detail::DataKey, RooSpan<const double>> &d
 ///            original dataset anymore!
 std::map<RooFit::Detail::DataKey, RooSpan<const double>>
 RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_view rangeName,
-                                           RooAbsCategory const *indexCat, std::stack<std::vector<double>> &buffers,
+                                           std::string const &prefix, std::stack<std::vector<double>> &buffers,
                                            bool skipZeroWeights)
 {
    std::map<RooFit::Detail::DataKey, RooSpan<const double>> dataSpans; // output variable
+
+   auto &nameReg = RooNameReg::instance();
+
+   auto insert = [&](const char *key, RooSpan<const double> span) {
+      const TNamed *namePtr = nameReg.constPtr((prefix + key).c_str());
+      dataSpans[namePtr] = span;
+   };
+
+   auto retrieve = [&](const char *key) {
+      const TNamed *namePtr = nameReg.constPtr((prefix + key).c_str());
+      return dataSpans.at(namePtr);
+   };
 
    std::size_t nEvents = static_cast<size_t>(data.numEntries());
 
    // We also want to support empty datasets: in this case the
    // RooFitDriver::Dataset is not filled with anything.
-   if (nEvents == 0)
+   if (nEvents == 0) {
       return dataSpans;
-
-   if (!buffers.empty()) {
-      throw std::invalid_argument("The buffers container must be empty when passed to getDataSpans()!");
    }
-
-   auto &nameReg = RooNameReg::instance();
 
    auto weight = data.getWeightBatch(0, nEvents, /*sumW2=*/false);
    auto weightSumW2 = data.getWeightBatch(0, nEvents, /*sumW2=*/true);
@@ -154,15 +107,14 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_v
          weightSumW2 = RooSpan<const double>(bufferSumW2.data(), nNonZeroWeight);
       }
       using namespace ROOT::Experimental;
-      dataSpans[nameReg.constPtr(RooNLLVarNew::weightVarName)] = weight;
-      dataSpans[nameReg.constPtr(RooNLLVarNew::weightVarNameSumW2)] = weightSumW2;
+      insert(RooNLLVarNew::weightVarName, weight);
+      insert(RooNLLVarNew::weightVarNameSumW2, weightSumW2);
    }
 
    // Get the real-valued batches and cast the also to double branches to put in
    // the data map
    for (auto const &item : data.getBatches(0, nEvents)) {
 
-      const TNamed *namePtr = nameReg.constPtr(item.first->GetName());
       RooSpan<const double> span{item.second};
 
       buffers.emplace();
@@ -174,14 +126,13 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_v
             buffer.push_back(span[i]);
          }
       }
-      dataSpans[namePtr] = RooSpan<const double>(buffer.data(), buffer.size());
+      insert(item.first->GetName(), {buffer.data(), buffer.size()});
    }
 
    // Get the category batches and cast the also to double branches to put in
    // the data map
    for (auto const &item : data.getCategoryBatches(0, nEvents)) {
 
-      const TNamed *namePtr = nameReg.constPtr(item.first->GetName());
       RooSpan<const RooAbsCategory::value_type> intSpan{item.second};
 
       buffers.emplace();
@@ -193,7 +144,7 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_v
             buffer.push_back(static_cast<double>(intSpan[i]));
          }
       }
-      dataSpans[namePtr] = RooSpan<const double>(buffer.data(), buffer.size());
+      insert(item.first->GetName(), {buffer.data(), buffer.size()});
    }
 
    nEvents = nNonZeroWeight;
@@ -206,9 +157,9 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_v
          std::vector<bool> isInSubRange(nEvents, true);
          for (auto *observable : dynamic_range_cast<RooAbsRealLValue *>(*data.get())) {
             // If the observables is not real-valued, it will not be considered for the range selection
-            if (!observable)
-               continue;
-            observable->inRange({dataSpans.at(observable->namePtr()).data(), nEvents}, range, isInSubRange);
+            if (observable) {
+               observable->inRange({retrieve(observable->GetName()).data(), nEvents}, range, isInSubRange);
+            }
          }
          for (std::size_t i = 0; i < isInSubRange.size(); ++i) {
             isInRange[i] = isInRange[i] || isInSubRange[i];
@@ -235,10 +186,6 @@ RooFit::BatchModeDataHelpers::getDataSpans(RooAbsData const &data, std::string_v
          }
          dataSpans[item.first] = RooSpan<const double>{buffer, nEvents};
       }
-   }
-
-   if (indexCat) {
-      splitByCategory(dataSpans, *indexCat, buffers);
    }
 
    return dataSpans;

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -116,6 +116,12 @@ public:
       const_cast<RooAbsReal &>(_driver->topNode()).applyWeightSquared(flag);
    }
 
+   void printMultiline(std::ostream &os, Int_t /*contents*/, bool /*verbose*/ = false,
+                       TString /*indent*/ = "") const override
+   {
+      _driver->print(os);
+   }
+
 protected:
    double evaluate() const override { return _driver ? _driver->getVal() : 0.0; }
 

--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -44,7 +44,8 @@ std::unique_ptr<RooAbsArg> createSimultaneousNLL(RooSimultaneous const &simPdf, 
          if (!rangeName.empty()) {
             pdf->setNormRange(RooHelpers::getRangeNameForSimComponent(rangeName, splitRange, catName).c_str());
          }
-         auto nll = std::make_unique<RooNLLVarNew>(name.c_str(), name.c_str(), *pdf, observables, isExtended, doOffset);
+         auto nll = std::make_unique<RooNLLVarNew>(name.c_str(), name.c_str(), *pdf, observables, isExtended, doOffset,
+                                                   simPdf.indexCat().size());
          // Rename the observables and weights
          newObservables.add(nll->prefixObservableAndWeightNames(std::string("_") + catName + "_"));
          nllTerms.addOwned(std::move(nll));

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1156,6 +1156,7 @@ RooAbsReal* RooAbsPdf::createNLL(RooAbsData& data, const RooLinkedList& cmdList)
                                                pc.getDouble("IntegrateBins"),
                                                batchMode,
                                                doOffset,
+                                               static_cast<bool>(splitRange),
                                                takeGlobalObservablesFromData).release();
   }
 

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -492,25 +492,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
       // *** START HERE
       // WVE HACK determine if we have a RooRealSumPdf and then treat it like a binned likelihood
-      RooAbsPdf* binnedPdf = 0 ;
-      bool binnedL = false ;
-      if (pdf->getAttribute("BinnedLikelihood") && pdf->IsA()->InheritsFrom(RooRealSumPdf::Class())) {
-        // Simplest case: top-level of component is a RRSP
-        binnedPdf = pdf ;
-        binnedL = true ;
-      } else if (pdf->IsA()->InheritsFrom(RooProdPdf::Class())) {
-        // Default case: top-level pdf is a product of RRSP and other pdfs
-        for (auto const* component : static_cast<RooProdPdf*>(pdf)->pdfList()) {
-          if (component->getAttribute("BinnedLikelihood") && component->IsA()->InheritsFrom(RooRealSumPdf::Class())) {
-            binnedPdf = (RooAbsPdf*) component ;
-            binnedL = true ;
-          }
-          if (component->getAttribute("MAIN_MEASUREMENT")) {
-            // not really a binned pdf, but this prevents a (potentially) long list of subsidiary measurements to be passed to the slave calculator
-            binnedPdf = (RooAbsPdf*) component ;
-          }
-        }
-      }
+      auto binnedInfo = RooHelpers::getBinnedL(*pdf);
       // WVE END HACK
       // Below here directly pass binnedPdf instead of PROD(binnedPdf,constraints) as constraints are evaluated elsewhere anyway
       // and omitting them reduces model complexity and associated handling/cloning times
@@ -519,7 +501,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       cfg.interleave = _mpinterl;
       cfg.verbose = _verbose;
       cfg.splitCutRange = _splitRange;
-      cfg.binnedL = binnedL;
+      cfg.binnedL = binnedInfo.isBinnedL;
       cfg.takeGlobalObservablesFromData = _takeGlobalObservablesFromData;
       // This configuration parameter is stored in the RooAbsOptTestStatistic.
       // It would have been cleaner to move the member variable into RooAbsTestStatistic,
@@ -529,7 +511,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       }
       cfg.rangeName = RooHelpers::getRangeNameForSimComponent(rangeName, _splitRange, catName);
       cfg.nCPU = _nCPU;
-      _gofArray[n] = create(catName.c_str(),catName.c_str(),(binnedPdf?*binnedPdf:*pdf),*dset,*projDeps,cfg);
+      _gofArray[n] = create(catName.c_str(),catName.c_str(),(binnedInfo.binnedPdf?*binnedInfo.binnedPdf:*pdf),*dset,*projDeps,cfg);
       _gofArray[n]->setSimCount(_nGof);
       // *** END HERE
 
@@ -548,7 +530,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
       // Servers may have been redirected between instantiation and (deferred) initialization
 
-      RooArgSet *actualParams = binnedPdf ? binnedPdf->getParameters(dset) : pdf->getParameters(dset);
+      RooArgSet *actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
       RooArgSet* selTargetParams = (RooArgSet*) _paramSet.selectCommon(*actualParams);
 
       _gofArray[n]->recursiveRedirectServers(*selTargetParams);

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -48,6 +48,7 @@ combined in the main thread.
 #include "RooProdPdf.h"
 #include "RooRealSumPdf.h"
 #include "RooAbsCategoryLValue.h"
+#include "RooHelpers.h"
 
 #include "ROOT/StringUtils.hxx"
 
@@ -526,15 +527,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       if(auto thisAsRooAbsOptTestStatistic = dynamic_cast<RooAbsOptTestStatistic const*>(this)) {
         cfg.integrateOverBinsPrecision = thisAsRooAbsOptTestStatistic->_integrateBinsPrecision;
       }
-      if (_splitRange && !rangeName.empty()) {
-        auto tokens = ROOT::Split(rangeName, ",");
-        for(std::string const& token : tokens) {
-          cfg.rangeName += token + "_" + catName + ",";
-        }
-        cfg.rangeName.pop_back(); // to remove the last comma
-      } else {
-        cfg.rangeName = rangeName;
-      }
+      cfg.rangeName = RooHelpers::getRangeNameForSimComponent(rangeName, _splitRange, catName);
       cfg.nCPU = _nCPU;
       _gofArray[n] = create(catName.c_str(),catName.c_str(),(binnedPdf?*binnedPdf:*pdf),*dset,*projDeps,cfg);
       _gofArray[n]->setSimCount(_nGof);

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -532,11 +532,10 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
           cfg.rangeName += token + "_" + catName + ",";
         }
         cfg.rangeName.pop_back(); // to remove the last comma
-        cfg.nCPU = _nCPU*(_mpinterl?-1:1);
       } else {
         cfg.rangeName = rangeName;
-        cfg.nCPU = _nCPU;
       }
+      cfg.nCPU = _nCPU;
       _gofArray[n] = create(catName.c_str(),catName.c_str(),(binnedPdf?*binnedPdf:*pdf),*dset,*projDeps,cfg);
       _gofArray[n]->setSimCount(_nGof);
       // *** END HERE

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -796,5 +796,61 @@ RooAbsReal &RooFitDriver::topNode() const
    return static_cast<RooAbsReal &>(_integralUnfolder->arg());
 }
 
+void RooFitDriver::print(std::ostream &os) const
+{
+   std::cout << "--- RooFit BatchMode evaluation ---\n";
+
+   std::vector<int> widths{9, 37, 20, 9, 10, 20};
+
+   auto printElement = [&](int iCol, auto const &t) {
+      const char separator = ' ';
+      os << separator << std::left << std::setw(widths[iCol]) << std::setfill(separator) << t;
+      os << "|";
+   };
+
+   auto printHorizontalRow = [&]() {
+      int n = 0;
+      for (int w : widths) {
+         n += w + 2;
+      }
+      for (int i = 0; i < n; i++) {
+         os << '-';
+      }
+      os << "|\n";
+   };
+
+   printHorizontalRow();
+
+   os << "|";
+   printElement(0, "Index");
+   printElement(1, "Name");
+   printElement(2, "Class");
+   printElement(3, "Size");
+   printElement(4, "From Data");
+   printElement(5, "1st value");
+   std::cout << "\n";
+
+   printHorizontalRow();
+
+   for (std::size_t iNode = 0; iNode < _nodes.size(); ++iNode) {
+      auto &nodeInfo = _nodes[iNode];
+      RooAbsArg *node = nodeInfo.absArg;
+
+      auto span = _dataMapCPU.at(node);
+
+      os << "|";
+      printElement(0, iNode);
+      printElement(1, node->GetName());
+      printElement(2, node->ClassName());
+      printElement(3, nodeInfo.outputSize);
+      printElement(4, nodeInfo.fromDataset);
+      printElement(5, span[0]);
+
+      std::cout << "\n";
+   }
+
+   printHorizontalRow();
+}
+
 } // namespace Experimental
 } // namespace ROOT

--- a/roofit/roofitcore/src/RooFitDriver.cxx
+++ b/roofit/roofitcore/src/RooFitDriver.cxx
@@ -34,6 +34,7 @@ RooAbsPdf::fitTo() is called and gets destroyed when the fitting ends.
 #include <RooRealVar.h>
 #include <RooArgList.h>
 #include <RooBatchCompute.h>
+#include <RooHelpers.h>
 #include <RooMsgService.h>
 #include <RooBatchCompute/Initialisation.h>
 #include <RooFit/BatchModeDataHelpers.h>
@@ -193,8 +194,8 @@ RooFitDriver::RooFitDriver(const RooAbsReal &absReal, RooArgSet const &normSet, 
    }
 }
 
-void RooFitDriver::setData(RooAbsData const &data, std::string_view rangeName,
-                           RooAbsCategory const *indexCatForSplitting, bool skipZeroWeights,
+void RooFitDriver::setData(RooAbsData const &data, std::string const &rangeName,
+                           RooAbsCategory const *indexCatForSplitting, bool splitRange, bool skipZeroWeights,
                            bool takeGlobalObservablesFromData)
 {
    std::vector<std::pair<std::string, RooAbsData const *>> datas;
@@ -217,8 +218,9 @@ void RooFitDriver::setData(RooAbsData const &data, std::string_view rangeName,
    std::stack<std::vector<double>>{}.swap(_vectorBuffers);
 
    for (auto const &toAdd : datas) {
-      DataSpansMap spans = RooFit::BatchModeDataHelpers::getDataSpans(*toAdd.second, rangeName, toAdd.first,
-                                                                      _vectorBuffers, skipZeroWeights);
+      DataSpansMap spans = RooFit::BatchModeDataHelpers::getDataSpans(
+         *toAdd.second, RooHelpers::getRangeNameForSimComponent(rangeName, splitRange, toAdd.second->GetName()),
+         toAdd.first, _vectorBuffers, skipZeroWeights);
       for (auto const &item : spans) {
          dataSpans.insert(item);
       }

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -24,6 +24,8 @@
 #include <RooDataHist.h>
 #include <RooDataSet.h>
 #include <RooSimultaneous.h>
+#include <RooProdPdf.h>
+#include <RooRealSumPdf.h>
 
 #include <ROOT/StringUtils.hxx>
 #include <TClass.h>
@@ -294,6 +296,26 @@ std::string getRangeNameForSimComponent(std::string const& rangeName, bool split
    }
 
    return rangeName;
+}
+
+BinnedLOutput getBinnedL(RooAbsPdf &pdf)
+{
+   if (pdf.getAttribute("BinnedLikelihood") && pdf.IsA()->InheritsFrom(RooRealSumPdf::Class())) {
+      // Simplest case: top-level of component is a RooRealSumPdf
+      return {&pdf, true};
+   } else if (pdf.IsA()->InheritsFrom(RooProdPdf::Class())) {
+      // Default case: top-level pdf is a product of RooRealSumPdf and other pdfs
+      for (RooAbsArg *component : static_cast<RooProdPdf &>(pdf).pdfList()) {
+         if (component->getAttribute("BinnedLikelihood") && component->IsA()->InheritsFrom(RooRealSumPdf::Class())) {
+            return {static_cast<RooAbsPdf *>(component), true};
+         }
+         if (component->getAttribute("MAIN_MEASUREMENT")) {
+           // not really a binned pdf, but this prevents a (potentially) long list of subsidiary measurements to be passed to the slave calculator
+           return {static_cast<RooAbsPdf *>(component), false};
+         }
+      }
+   }
+   return {nullptr, false};
 }
 
 }

--- a/roofit/roofitcore/src/RooHelpers.cxx
+++ b/roofit/roofitcore/src/RooHelpers.cxx
@@ -281,4 +281,19 @@ RooArgSet selectFromArgSet(RooArgSet const& argSet, std::string const& names) {
 }
 
 
+std::string getRangeNameForSimComponent(std::string const& rangeName, bool splitRange, std::string const& catName)
+{
+   if (splitRange && !rangeName.empty()) {
+      std::string out;
+      auto tokens = ROOT::Split(rangeName, ",");
+      for(std::string const& token : tokens) {
+         out += token + "_" + catName + ",";
+      }
+      out.pop_back(); // to remove the last comma
+      return out;
+   }
+
+   return rangeName;
+}
+
 }

--- a/roofit/roofitcore/test/testRooSimultaneous.cxx
+++ b/roofit/roofitcore/test/testRooSimultaneous.cxx
@@ -168,7 +168,9 @@ TEST(RooSimultaneous, MultiRangeFitWithSplitRange)
 
    const char *cutRange1 = "SideBandLo_cat1,SideBandHi_cat1";
    const char *cutRange2 = "SideBandLo_cat2,SideBandHi_cat2";
-   std::unique_ptr<RooAbsReal> nllSim{simPdf.createNLL(combData, Range("SideBandLo,SideBandHi"), SplitRange())};
+   using RealPtr = std::unique_ptr<RooAbsReal>;
+   RealPtr nllSim{simPdf.createNLL(combData, Range("SideBandLo,SideBandHi"), SplitRange(), BatchMode("off"))};
+   RealPtr nllSimBatch{simPdf.createNLL(combData, Range("SideBandLo,SideBandHi"), SplitRange(), BatchMode("cpu"))};
 
    // In simultaneous PDFs, the probability is normalized over the categories,
    // so we have to do that as well when computing the reference value. Since
@@ -184,6 +186,8 @@ TEST(RooSimultaneous, MultiRangeFitWithSplitRange)
 
    const double nllSimRefVal = nllSimRef.getVal();
    const double nllSimVal = nllSim->getVal();
+   const double nllSimBatchVal = nllSimBatch->getVal();
 
    EXPECT_FLOAT_EQ(nllSimVal, nllSimRefVal);
+   EXPECT_FLOAT_EQ(nllSimBatchVal, nllSimVal) << "BatchMode and old RooFit don't agree!";
 }

--- a/roofit/roofitcore/test/testTestStatistics.cxx
+++ b/roofit/roofitcore/test/testTestStatistics.cxx
@@ -308,8 +308,10 @@ TEST(RooNLLVar, CopyRangedNLL)
 
    std::unique_ptr<RooDataSet> ds{model.generate(x, 20)};
 
-   std::unique_ptr<RooNLLVar> nll{static_cast<RooNLLVar *>(model.createNLL(*ds))};
-   std::unique_ptr<RooNLLVar> nllrange{static_cast<RooNLLVar *>(model.createNLL(*ds, RooFit::Range("fitrange")))};
+   // This bug is related to the implementation details of the old test statistics, so BatchMode is forced to be off
+   using namespace RooFit;
+   std::unique_ptr<RooNLLVar> nll{static_cast<RooNLLVar *>(model.createNLL(*ds, BatchMode("off")))};
+   std::unique_ptr<RooNLLVar> nllrange{static_cast<RooNLLVar *>(model.createNLL(*ds, Range("fitrange"), BatchMode("off")))};
 
    auto nllClone = std::make_unique<RooNLLVar>(*nll);
    auto nllrangeClone = std::make_unique<RooNLLVar>(*nllrange);


### PR DESCRIPTION
This PR applies many fixes to the new RooFit BatchMode to make sure that the NLL is created correctly, respecting all the command arguments of `RooAbsPdf::fitTo()` that were so far not considered.

More detail in the individual commit descriptions.