### PR TITLE
[DO NOT MERGE][PyROOT] Fix setting of value_type in std::vector

### DIFF
--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.cxx
@@ -46,6 +46,8 @@ PyObject* CPyCppyy::PyStrings::gSecond           = nullptr;
 PyObject* CPyCppyy::PyStrings::gSize             = nullptr;
 PyObject* CPyCppyy::PyStrings::gTemplate         = nullptr;
 PyObject* CPyCppyy::PyStrings::gVectorAt         = nullptr;
+PyObject* CPyCppyy::PyStrings::gValueType        = nullptr;
+PyObject* CPyCppyy::PyStrings::gValueSize        = nullptr;
 
 PyObject* CPyCppyy::PyStrings::gCppReal          = nullptr;
 PyObject* CPyCppyy::PyStrings::gCppImag          = nullptr;
@@ -110,6 +112,8 @@ bool CPyCppyy::CreatePyStrings() {
     CPPYY_INITIALIZE_STRING(gSize,           size);
     CPPYY_INITIALIZE_STRING(gTemplate,       Template);
     CPPYY_INITIALIZE_STRING(gVectorAt,       _vector__at);
+    CPPYY_INITIALIZE_STRING(gValueType,      value_type);
+    CPPYY_INITIALIZE_STRING(gValueSize,      value_size);
 
     CPPYY_INITIALIZE_STRING(gCppReal,        __cpp_real);
     CPPYY_INITIALIZE_STRING(gCppImag,        __cpp_imag);
@@ -170,6 +174,8 @@ PyObject* CPyCppyy::DestroyPyStrings() {
     Py_DECREF(PyStrings::gSize);        PyStrings::gSize        = nullptr;
     Py_DECREF(PyStrings::gTemplate);    PyStrings::gTemplate    = nullptr;
     Py_DECREF(PyStrings::gVectorAt);    PyStrings::gVectorAt    = nullptr;
+    Py_DECREF(PyStrings::gValueType);   PyStrings::gValueType   = nullptr;
+    Py_DECREF(PyStrings::gValueSize);   PyStrings::gValueSize   = nullptr;
 
     Py_DECREF(PyStrings::gCppReal);     PyStrings::gCppReal     = nullptr;
     Py_DECREF(PyStrings::gCppImag);     PyStrings::gCppImag     = nullptr;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/PyStrings.h
@@ -49,6 +49,8 @@ namespace PyStrings {
     extern PyObject* gSize;
     extern PyObject* gTemplate;
     extern PyObject* gVectorAt;
+    extern PyObject* gValueType;
+    extern PyObject* gValueSize;
 
     extern PyObject* gCppReal;
     extern PyObject* gCppImag;

--- a/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
+++ b/bindings/pyroot/cppyy/CPyCppyy/src/Pythonize.cxx
@@ -1149,15 +1149,17 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
 
         // helpers for iteration
             const std::string& vtype = Cppyy::ResolveName(name+"::value_type");
-            size_t typesz = Cppyy::SizeOf(vtype);
+            if (vtype.rfind("value_type") == std::string::npos) {    // actually resolved?
+                PyObject* pyvalue_type = CPyCppyy_PyText_FromString(vtype.c_str());
+                PyObject_SetAttr(pyclass, PyStrings::gValueType, pyvalue_type);
+                Py_DECREF(pyvalue_type);
+            }
+
+            size_t typesz = Cppyy::SizeOf(name+"::value_type");
             if (typesz) {
                 PyObject* pyvalue_size = PyLong_FromSsize_t(typesz);
-                PyObject_SetAttrString(pyclass, "value_size", pyvalue_size);
+                PyObject_SetAttr(pyclass, PyStrings::gValueSize, pyvalue_size);
                 Py_DECREF(pyvalue_size);
-
-                PyObject* pyvalue_type = CPyCppyy_PyText_FromString(vtype.c_str());
-                PyObject_SetAttrString(pyclass, "value_type", pyvalue_type);
-                Py_DECREF(pyvalue_type);
             }
         }
     }

--- a/bindings/pyroot/pythonizations/test/stl_vector.py
+++ b/bindings/pyroot/pythonizations/test/stl_vector.py
@@ -24,9 +24,10 @@ class STL_vector(unittest.TestCase):
     def test_vec_const_char_p(self):
         '''
         Test that creating a std::vector<const char*> does not raise any
-        exception (#11581).
+        exception and that it has the right value_type (#11581).
         '''
-        ROOT.std.vector['const char*']()
+        v = ROOT.std.vector['const char*']()
+        self.assertEqual(v.value_type, 'const char*')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a follow up of what was investigated for https://github.com/root-project/root/issues/11581. In that ticket, it was detected that for certain types, for example `const char*`, the attribute `value_type` was not set for std::vector classes.

This PR aligns with upstream cppyy in terms of setting the `value_type` and `value_size` attributes of a std::vector class.