### PR TITLE
[TMVA][SOFIE] Fix infer function input tensors order

### DIFF
--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -391,6 +391,9 @@ namespace SOFIE{
             case  ETensorType::DOUBLE :{
                fGC += "double* tensor_" + fInputTensorNames[i] + ",";
                break;
+            }
+            default: {
+               throw std::runtime_error("TMVA-SOFIE: input tensor " + fInputTensorNames[i] + " is of a data type which is not yet supported.");
             }            
          }
       }

--- a/tmva/sofie/src/RModel.cxx
+++ b/tmva/sofie/src/RModel.cxx
@@ -125,7 +125,7 @@ namespace SOFIE{
    }
 
    void RModel::AddInputTensorName(std::string input_name) {
-       fInputTensorNames.push_back(input_name);
+       fInputTensorNames.push_back(UTILITY::Clean_name(input_name));
    }
 
    void RModel::AddOperator(std::unique_ptr<ROperator> op, int order_execution){
@@ -374,18 +374,24 @@ namespace SOFIE{
       }
 
       fGC += "infer(";
-      for (auto& i: fReadyInputTensorInfos){
-         if (i.second.type == ETensorType::FLOAT){
-            fGC += "float* tensor_" + i.first + ",";
-         }
-         else if (i.second.type == ETensorType::INT32 ){
-            fGC += "int32_t* tensor_" + i.first + ",";
-         }
-         else if (i.second.type == ETensorType::INT64){
-            fGC += "int64_t* tensor_" + i.first + ",";
-         }
-         else if(i.second.type == ETensorType::DOUBLE){
-            fGC += "double* tensor_" + i.first + ",";
+      for(size_t i = 0; i<fInputTensorNames.size(); ++i){
+         switch((fReadyInputTensorInfos[fInputTensorNames[i]]).type){
+            case  ETensorType::FLOAT :{
+               fGC += "float* tensor_" + fInputTensorNames[i] + ",";
+               break;
+            }
+            case  ETensorType::INT32 :{
+               fGC += "int32_t* tensor_" + fInputTensorNames[i] + ",";
+               break;
+            } 
+            case  ETensorType::INT64 :{
+               fGC += "int64_t* tensor_" + fInputTensorNames[i] + ",";
+               break;
+            }
+            case  ETensorType::DOUBLE :{
+               fGC += "double* tensor_" + fInputTensorNames[i] + ",";
+               break;
+            }            
          }
       }
       fGC.pop_back(); //remove last ","

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -1727,14 +1727,15 @@ TEST(ONNX, AddBroadcast1) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shape of A is {4, 5}
-   std::vector<float> A({1.0626695,  0.43842875,  1.22476468,  0.79763274,  0.98688211,
+   // The shape of A is {5}
+   std::vector<float> A({-0.78023305, -1.34029483, -3.01482951, 0.53641361,
+                 -1.22594789});
+   // The shape of B is {4, 5}
+   std::vector<float> B({1.0626695,  0.43842875,  1.22476468,  0.79763274,  0.98688211,
                  0.25267614, 0.44874883,  0.31516773,  -0.78771195, 0.64565664,
                  0.50450593, -0.41265227, -0.22474539, -0.22362374, 0.00509674,
                  0.16927211, 1.06756969,  -0.81634773, 0.88467744,  0.78902059});
-   // The shape of B is {5}
-   std::vector<float> B({-0.78023305, -1.34029483, -3.01482951, 0.53641361,
-                 -1.22594789});
+
    TMVA_SOFIE_AddBroadcast1::Session s("AddBroadcast1_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 
@@ -1753,8 +1754,10 @@ TEST(ONNX, AddBroadcast2) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shape of A is {2, 3, 4, 5}
-   std::vector<float> A({
+   // The shape of A is {5}
+   std::vector<float> A({0.60081805, 0.56575772, -0.58408511, -1.50827751, 1.2396254});
+   // The shape of B is {2, 3, 4, 5}
+   std::vector<float> B({
         -1.22516739e+00, -2.50373737e+00, -6.14517347e-01, 4.43165956e-01,
         4.09232228e-03,  1.43520073e+00,  -8.37526920e-01, 1.18762642e+00,
         -1.42122220e+00, 3.77123343e-01,  -6.16450821e-01, 1.96641319e+00,
@@ -1785,8 +1788,7 @@ TEST(ONNX, AddBroadcast2) {
         -1.55637568e+00, 2.14343040e+00,  4.69610352e-01,  9.09135609e-01,
         -6.20603382e-01, -1.04235434e+00, -1.32974691e+00, -1.35968049e-01,
         9.62438348e-01,  1.13413513e+00,  -9.24612219e-01, -2.26132356e+00});
-   // The shape of B is {5}
-   std::vector<float> B({0.60081805, 0.56575772, -0.58408511, -1.50827751, 1.2396254});
+
    TMVA_SOFIE_AddBroadcast2::Session s("AddBroadcast2_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 
@@ -1805,8 +1807,11 @@ TEST(ONNX, AddBroadcast3) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shape of A is {2, 3, 4, 5}
-   std::vector<float> A({
+   // The shape of A is {2, 1, 1, 5}
+   std::vector<float> A({0.13225244, -0.47801406, -1.47034622, 0.87786363, -0.51388502,
+                 0.77012016, 0.99407484,  -0.41014198, 1.76506248, 1.24142803});
+   // The shape of B is {2, 3, 4, 5}
+   std::vector<float> B({
          -0.79900037, 1.26774471,  0.10287351,  -0.00704713, 0.19927171,
         1.77125926,  0.23393901,  -0.75160577, -0.40987021, 0.02957325,
         2.48770369,  2.72426688,  0.16116267,  0.13580884,  -1.34550983,
@@ -1831,9 +1836,7 @@ TEST(ONNX, AddBroadcast3) {
         0.04793575,  -2.04214516, -0.45765407, -1.12307202, 0.90727137,
         0.96272832,  0.54303206,  -0.84973033, 0.28780329,  0.17027854,
         -0.11893711, -1.22414638, -1.62747593, 0.53264501,  0.53483601});
-   // The shape of B is {2, 1, 1, 5}
-   std::vector<float> B({0.13225244, -0.47801406, -1.47034622, 0.87786363, -0.51388502,
-                 0.77012016, 0.99407484,  -0.41014198, 1.76506248, 1.24142803});
+
    TMVA_SOFIE_AddBroadcast3::Session s("AddBroadcast3_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 
@@ -1852,11 +1855,11 @@ TEST(ONNX, AddBroadcast4) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shape of A is {2, 4}
-   std::vector<float> A({0.50898894, -0.27829921, -0.68761628,  0.33186382,  0.57915535,
+   // The shape of A is {2, 1}
+   std::vector<float> A({1.94301397, 0.40606817});
+   // The shape of B is {2, 4}
+   std::vector<float> B({0.50898894, -0.27829921, -0.68761628,  0.33186382,  0.57915535,
         0.406858  ,  1.4203833 ,  0.19857093});
-   // The shape of B is {2, 1}
-   std::vector<float> B({1.94301397, 0.40606817});
    TMVA_SOFIE_AddBroadcast4::Session s("AddBroadcast4_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 
@@ -1875,15 +1878,16 @@ TEST(ONNX, AddBroadcast5) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shape of A is {2, 3, 4}
-   std::vector<float> A({1.69787452,  1.10641673,  2.19755165,  0.06709206,  0.04572308,
+   // The shape of A is {2, 1, 4}
+   std::vector<float> A({-0.45616139, -0.05853134,  1.09564217,  0.95880315,  0.94995322,
+       -0.35864105,  1.08570897,  0.6028053});
+   // The shape of B is {2, 3, 4}
+   std::vector<float> B({1.69787452,  1.10641673,  2.19755165,  0.06709206,  0.04572308,
        -2.14504366, -0.47730702,  0.15205423, -0.25159224, -0.07529807,
         0.5174367 ,  0.08267595,  0.34015625,  0.09460231, -1.16608969,
        -0.23466058, -0.5520268 , -0.13844847,  0.53055759,  0.17068648,
        -0.49491276, -1.4246271 , -0.99973914, -0.2571329});
-   // The shape of B is {2, 1, 4}
-   std::vector<float> B({-0.45616139, -0.05853134,  1.09564217,  0.95880315,  0.94995322,
-       -0.35864105,  1.08570897,  0.6028053});
+
    TMVA_SOFIE_AddBroadcast5::Session s("AddBroadcast5_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 
@@ -1902,8 +1906,12 @@ TEST(ONNX, AddBroadcast6) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shape of A is {2, 2, 3, 2, 2}
-   std::vector<float> A({
+   // The shape of A is {2, 1, 3, 1, 2}
+   std::vector<float> A({1.05498675, -1.64311041,  0.11925147, -1.59755778, -0.01445313,
+       -0.69440541, -0.12011281,  0.00539323, -0.16923531,  2.34533598,
+        1.30268048,  0.45699443});
+   // The shape of B is {2, 2, 3, 2, 2}
+   std::vector<float> B({
        0.03162163,  1.36340443, -0.34736459, -0.71856324,  0.40669968,
        -0.37595741,  0.22234952,  1.69563792,  0.91459166, -0.02081215,
        -1.64894217, -0.01189261,  0.58031339, -0.11880191,  0.70099317,
@@ -1914,10 +1922,7 @@ TEST(ONNX, AddBroadcast6) {
        -1.43818087, -0.14550621, -0.33635512, -0.6185612 , -0.49281407,
        -1.12947258,  1.61818821, -0.05826431, -1.47802183,  0.25637381,
        -0.1547858 ,  2.50788792,  0.30898059});
-   // The shape of B is {2, 1, 3, 1, 2}
-   std::vector<float> B({1.05498675, -1.64311041,  0.11925147, -1.59755778, -0.01445313,
-       -0.69440541, -0.12011281,  0.00539323, -0.16923531,  2.34533598,
-        1.30268048,  0.45699443});
+
    TMVA_SOFIE_AddBroadcast6::Session s("AddBroadcast6_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 
@@ -1936,13 +1941,14 @@ TEST(ONNX, AddBroadcast7) {
    constexpr float TOLERANCE = DEFAULT_TOLERANCE;
 
    // input
-   // The shae of A is {1, 1, 3, 4}
-   std::vector<float> A({1.40519865e+00, -2.87660856e-01,  7.49375999e-02,  1.22074840e+00,
+   // The shape of A is {2, 1, 3, 1}
+   std::vector<float> A({-0.42164834, -0.61767078, -0.68778897, -1.14175916,  0.63204375,
+       -0.60630317});
+   // The shae of B is {1, 1, 3, 4}
+   std::vector<float> B({1.40519865e+00, -2.87660856e-01,  7.49375999e-02,  1.22074840e+00,
        -4.86212681e-01, -6.88210109e-01, -6.77434705e-01,  3.67088873e-01,
         8.05744026e-04, -2.08031088e-01,  9.69779132e-01,  7.58373863e-01});
-   // The shape of B is {2, 1, 3, 1}
-   std::vector<float> B({-0.42164834, -0.61767078, -0.68778897, -1.14175916,  0.63204375,
-       -0.60630317});
+
    TMVA_SOFIE_AddBroadcast7::Session s("AddBroadcast7_FromONNX.dat");
    std::vector<float> output(s.infer(A.data(), B.data()));
 

--- a/tmva/sofie/test/TestCustomModelsFromONNX.cxx
+++ b/tmva/sofie/test/TestCustomModelsFromONNX.cxx
@@ -255,7 +255,7 @@ TEST(ONNX, Sub)
       });
       TMVA_SOFIE_Sub::Session s("Sub_FromONNX.dat");
 
-      std::vector<float> output = s.infer(input2.data(),input1.data());
+      std::vector<float> output = s.infer(input1.data(),input2.data());
 
       // Checking output size
       EXPECT_EQ(output.size(), sizeof(Sub_ExpectedOutput::outputs) / sizeof(float));
@@ -333,7 +333,7 @@ TEST(ONNX, Div)
       });
       TMVA_SOFIE_Div::Session s("Div_FromONNX.dat");
 
-      std::vector<float> output = s.infer(input2.data(),input1.data());
+      std::vector<float> output = s.infer(input1.data(),input2.data());
 
       // Checking output size
       EXPECT_EQ(output.size(), sizeof(Div_ExpectedOutput::outputs) / sizeof(float));
@@ -781,7 +781,7 @@ TEST(ONNX, Pow){
    });
    
    TMVA_SOFIE_Pow::Session s("Pow_FromONNX.dat");
-   std::vector<float> output = s.infer(input2.data(),input1.data());
+   std::vector<float> output = s.infer(input1.data(),input2.data());
    // Checking output size
    EXPECT_EQ(output.size(), sizeof(Pow_ExpectedOutput::outputs) / sizeof(float));
    
@@ -806,7 +806,7 @@ TEST(ONNX, Pow_broadcast){
    });
    
    TMVA_SOFIE_Pow_broadcast::Session s("Pow_broadcast_FromONNX.dat");
-   std::vector<float> output = s.infer(input2.data(),input1.data());
+   std::vector<float> output = s.infer(input1.data(),input2.data());
    // Checking output size
    EXPECT_EQ(output.size(), sizeof(Pow_broadcast_ExpectedOutput::outputs) / sizeof(float));
    


### PR DESCRIPTION
This PR fixes the ordering of input tensors in the generated `infer` function. Previously, the tensors were iterated from an unordered map and thus were not in the order in which they were added. The correct ordering in which they are added is necessary for different layers in other parsers like Keras, and in the inference of GNN. With this PR, the tensors are iterated from a vector, thus the ordering is correct. 