### PR TITLE
[ntuple] Store and use type traits in RField

### DIFF
--- a/tree/ntuple/v7/doc/architecture.md
+++ b/tree/ntuple/v7/doc/architecture.md
@@ -1,0 +1,28 @@
+RNTuple Code Architecture
+=========================
+
+> This document is meant for ROOT developers. It provides background information on the RNTuple code design and behavior.
+
+> This document is currently a stub.
+
+
+Semantics of reading a non-trivial objects
+==========================================
+
+Reading an object with RNTuple should be seen as _overwriting_ its persistent data members.
+Given a properly constructed and valid object, the object must ensure that it stays valid when overwriting its persistent data members.
+However, the object should not rely on its transient state to remain unchanged during reading:
+it may be destructed and constructed again when it is read as part of a collection (see below).
+
+An object that is being read from disk may have been constructed by `RField::GenerateValue()`.
+In this case, RNTuple owns the object and it will be destructed by `RField::DestroyValue()`.
+
+When reading collections of type `T` (`std::vector<T>`, `ROOT::RVec<T>`, ...), RNTuple uses `RField::GenerateValue()` to construct elements of the inner type `T`.
+As the size of a collection changes from event to event, this has the following effect on its elements
+  - If the collection shrinks, cut-off elements are destructed
+  - If the collection grows, new elements are constructed before reading them
+  - If the array buffer of the collection is reallocated (may happen for both shrinking and growing depending on the collection), all elements are destructed first in the old buffer
+  and the new number of elements is constructed in the new buffer
+
+So unless the collection buffer needs to be reallocated, RNTuple tries to avoid unnecessary destruction/construction but instead overwrites existing objects.
+Note that RNTuple currently does not copy or move existing objects when the collection buffer is reallocated.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -417,10 +417,12 @@ protected:
                 const std::array<std::size_t, N> &offsets, std::string_view typeName = "")
       : ROOT::Experimental::Detail::RFieldBase(fieldName, typeName, ENTupleStructure::kRecord, false /* isSimple */)
    {
+      fTraits = kTraitTrivialType;
       for (unsigned i = 0; i < N; ++i) {
          fOffsets.push_back(offsets[i]);
          fMaxAlignment = std::max(fMaxAlignment, itemFields[i]->GetAlignment());
          fSize += GetItemPadding(fSize, itemFields[i]->GetAlignment()) + itemFields[i]->GetValueSize();
+         fTraits &= itemFields[i]->GetTraits();
          Attach(std::move(itemFields[i]));
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -108,7 +108,7 @@ protected:
    /// The columns are connected either to a sink or to a source (not to both); they are owned by the field.
    std::vector<std::unique_ptr<RColumn>> fColumns;
    /// Properties of the type that allow for optimizations of collections of that type
-   int fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   int fTraits = 0;
 
    /// Creates the backing columns corresponsing to the field type for writing
    virtual void GenerateColumnsImpl() = 0;
@@ -790,7 +790,10 @@ protected:
 public:
    static std::string TypeName() { return "ROOT::Experimental::ClusterSize_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -847,7 +850,10 @@ protected:
 public:
    static std::string TypeName() { return "bool"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -895,7 +901,10 @@ protected:
 public:
    static std::string TypeName() { return "float"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -944,7 +953,10 @@ protected:
 public:
    static std::string TypeName() { return "double"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -992,7 +1004,10 @@ protected:
 public:
    static std::string TypeName() { return "char"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1040,7 +1055,10 @@ protected:
 public:
    static std::string TypeName() { return "std::int8_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1088,7 +1106,10 @@ protected:
 public:
    static std::string TypeName() { return "std::uint8_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1136,7 +1157,10 @@ protected:
 public:
    static std::string TypeName() { return "std::int16_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1184,7 +1208,10 @@ protected:
 public:
    static std::string TypeName() { return "std::uint16_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1232,7 +1259,10 @@ protected:
 public:
    static std::string TypeName() { return "std::int32_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1280,7 +1310,10 @@ protected:
 public:
    static std::string TypeName() { return "std::uint32_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1328,7 +1361,10 @@ protected:
 public:
    static std::string TypeName() { return "std::uint64_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1376,7 +1412,10 @@ protected:
 public:
    static std::string TypeName() { return "std::int64_t"; }
    explicit RField(std::string_view name)
-     : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */) {}
+      : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
+   {
+      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+   }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
    ~RField() override = default;
@@ -1433,7 +1472,6 @@ public:
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, false /* isSimple */), fIndex(0),
         fElemIndex(&fIndex)
    {
-      fTraits = 0;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -74,9 +74,12 @@ class RFieldBase {
 
 public:
    /// No constructor needs to be called, i.e. any bit pattern in the allocated memory represents a valid type
+   /// A trivially constructible field has a no-op GenerateValue() implementation
    static constexpr int kTraitTriviallyConstructible = 0x01;
-   /// The type is cleaned up just by freeing its memory
+   /// The type is cleaned up just by freeing its memory. I.e. DestroyValue() is a no-op.
    static constexpr int kTraitTriviallyDestructible = 0x02;
+   /// Shorthand combining all other shortcut traits
+   static constexpr int kTraitTrivialType = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
 
 private:
    /// The field name relative to its parent field
@@ -792,7 +795,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -852,7 +855,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -903,7 +906,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -955,7 +958,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1006,7 +1009,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1057,7 +1060,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1108,7 +1111,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1159,7 +1162,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1210,7 +1213,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1261,7 +1264,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1312,7 +1315,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1363,7 +1366,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;
@@ -1414,7 +1417,7 @@ public:
    explicit RField(std::string_view name)
       : Detail::RFieldBase(name, TypeName(), ENTupleStructure::kLeaf, true /* isSimple */)
    {
-      fTraits = kTraitTriviallyConstructible | kTraitTriviallyDestructible;
+      fTraits = kTraitTrivialType;
    }
    RField(RField&& other) = default;
    RField& operator =(RField&& other) = default;

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1905,7 +1905,6 @@ ROOT::Experimental::RPairField::RPairField(std::string_view fieldName,
    : ROOT::Experimental::RRecordField(fieldName, std::move(itemFields), offsets,
                                       "std::pair<" + GetTypeList(itemFields) + ">")
 {
-   fTraits = itemFields[0]->GetTraits() & itemFields[1]->GetTraits();
 }
 
 ROOT::Experimental::RPairField::RPairField(std::string_view fieldName,
@@ -1913,7 +1912,6 @@ ROOT::Experimental::RPairField::RPairField(std::string_view fieldName,
    : ROOT::Experimental::RRecordField(fieldName, std::move(itemFields), {},
                                       "std::pair<" + GetTypeList(itemFields) + ">")
 {
-   fTraits = itemFields[0]->GetTraits() & itemFields[1]->GetTraits();
    // ISO C++ does not guarantee any specific layout for `std::pair`; query TClass for the member offsets
    fClass = TClass::GetClass(GetType().c_str());
    if (!fClass)

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -835,7 +835,7 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
       // Skip members explicitly marked as transient by user comment
       if (!dataMember->IsPersistent()) {
          // TODO(jblomer): we could do better
-         fTraits = 0;
+         fTraits &= ~(kTraitTriviallyConstructible | kTraitTriviallyDestructible);
          continue;
       }
       auto subField = Detail::RFieldBase::Create(dataMember->GetName(), dataMember->GetFullTypeName()).Unwrap();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1108,6 +1108,7 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
    : ROOT::Experimental::Detail::RFieldBase(fieldName, typeName, ENTupleStructure::kRecord, false /* isSimple */),
      fOffsets(offsets)
 {
+   fTraits = kTraitTrivialType;
    for (auto &item : itemFields) {
       fMaxAlignment = std::max(fMaxAlignment, item->GetAlignment());
       fSize += GetItemPadding(fSize, item->GetAlignment()) + item->GetValueSize();

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -833,8 +833,9 @@ ROOT::Experimental::RClassField::RClassField(std::string_view fieldName, std::st
       Attach(std::move(subField),
 	     RSubFieldInfo{kDataMember, static_cast<std::size_t>(dataMember->GetOffset())});
    }
-   for (const auto &f : fSubFields)
-      fTraits &= f->GetTraits();
+   // TODO(jblomer) ask TClass about traits
+   // for (const auto &f : fSubFields)
+   //   fTraits &= f->GetTraits();
 }
 
 void ROOT::Experimental::RClassField::Attach(std::unique_ptr<Detail::RFieldBase> child, RSubFieldInfo info)
@@ -1224,7 +1225,6 @@ ROOT::Experimental::RVectorField::RVectorField(
       fieldName, "std::vector<" + itemField->GetType() + ">", ENTupleStructure::kCollection, false /* isSimple */)
    , fItemSize(itemField->GetValueSize()), fNWritten(0)
 {
-   fTraits = 0;
    Attach(std::move(itemField));
 }
 
@@ -1342,7 +1342,6 @@ ROOT::Experimental::RRVecField::RRVecField(std::string_view fieldName, std::uniq
                                             ENTupleStructure::kCollection, false /* isSimple */),
      fItemSize(itemField->GetValueSize()), fNWritten(0)
 {
-   fTraits = 0;
    Attach(std::move(itemField));
    fValueSize = EvalValueSize(); // requires fSubFields to be populated
 }
@@ -1572,7 +1571,6 @@ ROOT::Experimental::RField<std::vector<bool>>::RField(std::string_view name)
    : ROOT::Experimental::Detail::RFieldBase(name, "std::vector<bool>", ENTupleStructure::kCollection,
                                             false /* isSimple */)
 {
-   fTraits = 0;
    Attach(std::make_unique<RField<bool>>("_0"));
 }
 
@@ -2018,7 +2016,6 @@ ROOT::Experimental::RCollectionField::RCollectionField(
    : RFieldBase(name, "", ENTupleStructure::kCollection, true /* isSimple */)
    , fCollectionNTuple(collectionNTuple)
 {
-   fTraits = 0;
    for (unsigned i = 0; i < collectionModel->GetFieldZero()->fSubFields.size(); ++i) {
       auto& subField = collectionModel->GetFieldZero()->fSubFields[i];
       Attach(std::move(subField));

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1271,6 +1271,7 @@ void ROOT::Experimental::RVectorField::ReadGlobalImpl(NTupleSize_t globalIndex, 
    if (fSubFields[0]->GetTraits() & kTraitTrivialType) {
       typedValue->resize(nItems * fItemSize);
    } else {
+      // See "semantics of reading non-trivial objects" in RNTuple's architecture.md
       const auto oldNItems = typedValue->size() / fItemSize;
       const bool canRealloc = oldNItems < nItems;
       bool allDeallocated = false;
@@ -1407,6 +1408,8 @@ void ROOT::Experimental::RRVecField::ReadGlobalImpl(NTupleSize_t globalIndex, De
    char *begin = reinterpret_cast<char *>(*beginPtr); // for pointer arithmetics
    const std::size_t oldSize = *sizePtr;
 
+   // See "semantics of reading non-trivial objects" in RNTuple's architecture.md for details
+   // on the element construction/destrution.
    const bool needsConstruct = !(fSubFields[0]->GetTraits() & kTraitTriviallyConstructible);
    const bool needsDestruct = !(fSubFields[0]->GetTraits() & kTraitTriviallyDestructible);
 

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1121,11 +1121,13 @@ ROOT::Experimental::RRecordField::RRecordField(std::string_view fieldName,
                                                std::vector<std::unique_ptr<Detail::RFieldBase>> &&itemFields)
    : ROOT::Experimental::Detail::RFieldBase(fieldName, "", ENTupleStructure::kRecord, false /* isSimple */)
 {
+   fTraits = kTraitTrivialType;
    for (auto &item : itemFields) {
       fSize += GetItemPadding(fSize, item->GetAlignment());
       fOffsets.push_back(fSize);
       fMaxAlignment = std::max(fMaxAlignment, item->GetAlignment());
       fSize += item->GetValueSize();
+      fTraits &= item->GetTraits();
       Attach(std::move(item));
    }
    // Trailing padding: although this is implementation-dependent, most add enough padding to comply with the

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -1769,6 +1769,7 @@ ROOT::Experimental::RVariantField::RVariantField(
    : ROOT::Experimental::Detail::RFieldBase(fieldName,
       "std::variant<" + GetTypeList(itemFields) + ">", ENTupleStructure::kVariant, false /* isSimple */)
 {
+   fTraits = kTraitTriviallyDestructible & ~kTraitTriviallyConstructible;
    auto nFields = itemFields.size();
    R__ASSERT(nFields > 0);
    fNWritten.resize(nFields, 0);

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -115,7 +115,8 @@ struct VariantTraitsBase {
    std::variant<int, float> a;
 };
 
-struct VariantTraits : VariantTraitsBase {};
+struct VariantTraits : VariantTraitsBase {
+};
 
 struct StringTraits : VariantTraitsBase {
    std::string s;

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -2,6 +2,7 @@
 #define ROOT7_RNTuple_Test_CustomStruct
 
 #include <string>
+#include <variant>
 #include <vector>
 
 /**
@@ -95,6 +96,37 @@ template <typename T>
 struct StructUsingCollectionProxy {
    using ValueType = T;
    std::vector<T> v; //! do not accidentally store via RClassField
+};
+
+/// Classes to exercise field traits
+struct TrivialTraitsBase {
+   int a;
+};
+
+struct TrivialTraits : TrivialTraitsBase {
+   float b;
+};
+
+struct TransientTraits : TrivialTraitsBase {
+   float b; //! transient member
+};
+
+struct VariantTraitsBase {
+   std::variant<int, float> a;
+};
+
+struct VariantTraits : VariantTraitsBase {};
+
+struct StringTraits : VariantTraitsBase {
+   std::string s;
+};
+
+struct ConstructorTraits : TrivialTraitsBase {
+   ConstructorTraits() {}
+};
+
+struct DestructorTraits : TrivialTraitsBase {
+   ~DestructorTraits() {}
 };
 
 #endif

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -26,4 +26,13 @@
 #pragma link C++ class StructUsingCollectionProxy<StructUsingCollectionProxy<float>> + ;
 #pragma link C++ class StructUsingCollectionProxy<int> + ;
 
+#pragma link C++ class TrivialTraitsBase + ;
+#pragma link C++ class TrivialTraits + ;
+#pragma link C++ class TransientTraits + ;
+#pragma link C++ class VariantTraitsBase + ;
+#pragma link C++ class VariantTraits + ;
+#pragma link C++ class StringTraits + ;
+#pragma link C++ class ConstructorTraits + ;
+#pragma link C++ class DestructorTraits + ;
+
 #endif

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -552,4 +552,10 @@ TEST(RNTuple, Traits)
    EXPECT_EQ(0, f3.GetTraits());
    auto f4 = RField<std::variant<float, int>>("f");
    EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, f4.GetTraits());
+   auto f5 = RField<std::tuple<float, std::string>>("f");
+   EXPECT_EQ(0, f5.GetTraits());
+   auto f6 = RField<std::tuple<float, int>>("f");
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, f6.GetTraits());
+   auto f7 = RField<std::tuple<float, std::variant<int, float>>>("f");
+   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, f7.GetTraits());
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -533,3 +533,8 @@ TEST(RNTuple, Enums)
    EXPECT_EQ(42, viewKlass(0).a);
    EXPECT_EQ(137, viewKlass(0).b);
 }
+
+TEST(RNTuple, Traits)
+{
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<float>("f").GetTraits());
+}

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -558,4 +558,15 @@ TEST(RNTuple, Traits)
    EXPECT_EQ(RFieldBase::kTraitTrivialType, f6.GetTraits());
    auto f7 = RField<std::tuple<float, std::variant<int, float>>>("f");
    EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, f7.GetTraits());
+   auto f8 = RField<std::array<float, 3>>("f");
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, f8.GetTraits());
+   auto f9 = RField<std::array<std::string, 3>>("f");
+   EXPECT_EQ(0, f9.GetTraits());
+
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<TrivialTraits>("f").GetTraits());
+   EXPECT_EQ(0, RField<TransientTraits>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, RField<VariantTraits>("f").GetTraits());
+   EXPECT_EQ(0, RField<StringTraits>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, RField<ConstructorTraits>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTriviallyConstructible, RField<DestructorTraits>("f").GetTraits());
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -537,4 +537,19 @@ TEST(RNTuple, Enums)
 TEST(RNTuple, Traits)
 {
    EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<float>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<bool>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<int>("f").GetTraits());
+   EXPECT_EQ(0, RField<std::string>("f").GetTraits());
+   EXPECT_EQ(0, RField<std::vector<float>>("f").GetTraits());
+   EXPECT_EQ(0, RField<std::vector<bool>>("f").GetTraits());
+   EXPECT_EQ(0, RField<ROOT::RVec<float>>("f").GetTraits());
+   EXPECT_EQ(0, RField<ROOT::RVec<bool>>("f").GetTraits());
+   auto f1 = RField<std::pair<float, std::string>>("f");
+   EXPECT_EQ(0, f1.GetTraits());
+   auto f2 = RField<std::pair<float, int>>("f");
+   EXPECT_EQ(RFieldBase::kTraitTrivialType, f2.GetTraits());
+   auto f3 = RField<std::variant<float, std::string>>("f");
+   EXPECT_EQ(0, f3.GetTraits());
+   auto f4 = RField<std::variant<float, int>>("f");
+   EXPECT_EQ(RFieldBase::kTraitTriviallyDestructible, f4.GetTraits());
 }

--- a/tree/ntuple/v7/test/rfield_vector.cxx
+++ b/tree/ntuple/v7/test/rfield_vector.cxx
@@ -302,25 +302,25 @@ TEST(RNTuple, ComplexVector)
       EXPECT_EQ(0, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(10u, rdV->size());
       ntuple->LoadEntry(2);
-      EXPECT_EQ(10000, ComplexStruct::GetNCallConstructor());
-      EXPECT_EQ(0, ComplexStruct::GetNCallDestructor());
+      EXPECT_EQ(10010, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(10, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(10000u, rdV->size());
       ntuple->LoadEntry(3);
-      EXPECT_EQ(10000, ComplexStruct::GetNCallConstructor());
-      EXPECT_EQ(9900, ComplexStruct::GetNCallDestructor());
+      EXPECT_EQ(10010, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(9910, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(100u, rdV->size());
       ntuple->LoadEntry(4);
-      EXPECT_EQ(10100, ComplexStruct::GetNCallConstructor());
-      EXPECT_EQ(9900, ComplexStruct::GetNCallDestructor());
+      EXPECT_EQ(10210, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(10010, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(200u, rdV->size());
       ntuple->LoadEntry(5);
-      EXPECT_EQ(10100, ComplexStruct::GetNCallConstructor());
-      EXPECT_EQ(10100, ComplexStruct::GetNCallDestructor());
+      EXPECT_EQ(10210, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(10210, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(0u, rdV->size());
       ntuple->LoadEntry(6);
-      EXPECT_EQ(10101, ComplexStruct::GetNCallConstructor());
-      EXPECT_EQ(10100, ComplexStruct::GetNCallDestructor());
+      EXPECT_EQ(10211, ComplexStruct::GetNCallConstructor());
+      EXPECT_EQ(10210, ComplexStruct::GetNCallDestructor());
       EXPECT_EQ(1u, rdV->size());
    }
-   EXPECT_EQ(10101u, ComplexStruct::GetNCallDestructor());
+   EXPECT_EQ(10211u, ComplexStruct::GetNCallDestructor());
 }


### PR DESCRIPTION
Introduces the "trivially constructible" and "trivially destructible" traits for the types wrapped by an RField. Maintaining these traits allows for optimizations when reading collections: for collections of simple types (e.g., `int`s, `float`s), we don't need to call the element constructors and destructors when the collection changes size from event to event.

For the vector-heavy ATLAS OpenData benchmark, this results in a 5-10% performance improvement both with RDF and with RNTuple views (hot disk cache, zstd compressed input).

Fixes #10520