### PR TITLE
Reduce usage of locks by TPluginHandler

### DIFF
--- a/core/base/inc/TPluginManager.h
+++ b/core/base/inc/TPluginManager.h
@@ -236,7 +236,7 @@ private:
    void   LoadHandlerMacros(const char *path);
 
 public:
-   TPluginManager() : fHandlers(nullptr), fBasesLoaded(nullptr), fReadingDirs(kFALSE) { }
+   TPluginManager();
    ~TPluginManager();
 
    void   LoadHandlersFromEnv(TEnv *env);

--- a/core/metacling/src/TClingCallFunc.cxx
+++ b/core/metacling/src/TClingCallFunc.cxx
@@ -1675,14 +1675,17 @@ void *TClingCallFunc::InterfaceMethod()
       const Decl *decl = GetFunctionOrShadowDecl();
 
       R__LOCKGUARD_CLING(gInterpreterMutex);
-      map<const Decl *, void *>::iterator I = gWrapperStore.find(decl);
-      if (I != gWrapperStore.end()) {
-         fWrapper = (tcling_callfunc_Wrapper_t) I->second;
-      } else {
-         fWrapper = make_wrapper();
+      // check if another thread already did it
+      if (!fWrapper) {
+         map<const Decl *, void *>::iterator I = gWrapperStore.find(decl);
+         if (I != gWrapperStore.end()) {
+            fWrapper = (tcling_callfunc_Wrapper_t)I->second;
+         } else {
+            fWrapper = make_wrapper();
+         }
       }
    }
-   return (void *)fWrapper;
+   return (void *)fWrapper.load();
 }
 
 bool TClingCallFunc::IsValid() const
@@ -1704,11 +1707,14 @@ TInterpreter::CallFuncIFacePtr_t TClingCallFunc::IFacePtr()
       const Decl *decl = GetFunctionOrShadowDecl();
 
       R__LOCKGUARD_CLING(gInterpreterMutex);
-      map<const Decl *, void *>::iterator I = gWrapperStore.find(decl);
-      if (I != gWrapperStore.end()) {
-         fWrapper = (tcling_callfunc_Wrapper_t) I->second;
-      } else {
-         fWrapper = make_wrapper();
+      // check if another thread already did it
+      if (!fWrapper) {
+         map<const Decl *, void *>::iterator I = gWrapperStore.find(decl);
+         if (I != gWrapperStore.end()) {
+            fWrapper = (tcling_callfunc_Wrapper_t)I->second;
+         } else {
+            fWrapper = make_wrapper();
+         }
       }
    }
    return TInterpreter::CallFuncIFacePtr_t(fWrapper);

--- a/core/metacling/src/TClingCallFunc.h
+++ b/core/metacling/src/TClingCallFunc.h
@@ -69,7 +69,7 @@ private:
    /// Number of required arguments
    size_t fMinRequiredArguments = -1;
    /// Pointer to compiled wrapper, we do *not* own.
-   tcling_callfunc_Wrapper_t fWrapper;
+   std::atomic<tcling_callfunc_Wrapper_t> fWrapper;
    /// Stored function arguments, we own.
    mutable llvm::SmallVector<cling::Value, 8> fArgVals;
 
@@ -151,7 +151,7 @@ public:
    }
 
    TClingCallFunc(const TClingCallFunc &rhs)
-      : fInterp(rhs.fInterp), fWrapper(rhs.fWrapper), fArgVals(rhs.fArgVals)
+      : fInterp(rhs.fInterp), fWrapper(rhs.fWrapper.load()), fArgVals(rhs.fArgVals)
    {
       fMethod = std::unique_ptr<TClingMethodInfo>(new TClingMethodInfo(*rhs.fMethod));
    }


### PR DESCRIPTION
When running RDF/TTreeProcessorMT with large numbers of threads and files with files on xrootd significant lock contention is still present through ```TPluginHandler::LoadPlugin()``` and ```TPluginHandler::ExecPlugin()``` which are called from ```TFile::Open()```.  This PR minimizes the use of locks, which are now only needed the first time a given TPluginHandler is called for various initialization steps.

This change now completely eliminates the use of the global write lock during RDF event loops also for files read from xrootd and finishes addressing https://github.com/root-project/root/issues/7710

For a simple test case:

Create the files:
```cpp
#include "TFile.h"
#include "TTree.h"
#include "TString.h"
#include <thread>

void testwrite() {

  const unsigned int nfiles = 4000;
  const unsigned int nentries = 1000*1000;

  float outval = 1.;

  for (unsigned int ifile = 0; ifile < nfiles; ++ifile) {
    TFile *fout = TFile::Open(TString::Format("test_%i.root", ifile), "RECREATE");
    TTree *tree = new TTree("tree", "");
    tree->Branch("outval", &outval);
    for (unsigned int ientry = 0; ientry < nentries; ++ientry) {
      tree->Fill();
    }
    tree->Write();
    fout->Close();
  }

}
```

run the event loop:
```python
import ROOT
ROOT.ROOT.EnableImplicitMT()


chain = ROOT.TChain("tree")
chain.Add("root://eoscms.cern.ch//store/cmst3/group/wmass/bendavid/iotestinput/test_*.root")

d = ROOT.ROOT.RDataFrame(chain)
res = d.Sum("outval")

resval = res.GetValue()
print(resval)
```

Testing with 256 threads:

before:
```
        Percent of CPU this job got: 1077%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:51.82
```

after:
```
        Percent of CPU this job got: 5626%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:54.89
```
(in fact there is still some possible lock contention/parameter tuning within the xrootd client itself which could improve things further)