### PR TITLE
[TMVA][SOFIE] Fix SOFIE tests

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
+++ b/tmva/sofie/inc/TMVA/ROperator_Shape.hxx
@@ -39,7 +39,6 @@ public:
 
    std::vector<std::vector<size_t>> ShapeInference(std::vector<std::vector<size_t>> input){
       std::vector<std::vector<size_t>>  ret;
-      ret[0].push_back(input.size());
       ret[0].push_back(input[0].size());
       return ret;
    }


### PR DESCRIPTION
# This Pull request:

Fix the following issue in SOFIE:

```
n file included from /usr/include/c++/12.2.0/vector:70,
                 from /home/ahmat/cern/root/tmva/sofie/inc/TMVA/RModel.hxx:6,
                 from /home/ahmat/cern/root/tmva/sofie_parsers/inc/TMVA/RModelParser_ONNX.hxx:4,
                 from /home/ahmat/cern/root/tmva/sofie_parsers/src/ParseShape.cxx:1:
In member function ‘std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {long unsigned int}; _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’,
    inlined from ‘void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’ at /usr/include/c++/12.2.0/bits/stl_vector.h:1294:21,
    inlined from ‘virtual std::vector<std::vector<long unsigned int> > TMVA::Experimental::SOFIE::ROperator_Shape::ShapeInference(std::vector<std::vector<long unsigned int> >)’ at /home/ahmat/cern/root/tmva/sofie/inc/TMVA/ROperator_Shape.hxx:42:23:
/usr/include/c++/12.2.0/bits/vector.tcc:123:28: warning: ‘this’ pointer is null [-Wnonnull]
  123 |           _M_realloc_insert(end(), std::forward<_Args>(__args)...);
      |           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/12.2.0/bits/vector.tcc: In member function ‘virtual std::vector<std::vector<long unsigned int> > TMVA::Experimental::SOFIE::ROperator_Shape::ShapeInference(std::vector<std::vector<long unsigned int> >)’:
/usr/include/c++/12.2.0/bits/vector.tcc:439:7: note: in a call to non-static member function ‘void std::vector<_Tp, _Alloc>::_M_realloc_insert(iterator, _Args&& ...) [with _Args = {long unsigned int}; _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>]’
  439 |       vector<_Tp, _Alloc>::

...

```

Now the tests in tmva/sofie/test/TestCustonModelsFromONNX.cxx can be build with gcc. The others tests still fail.

- [x] tested changes locally
