### PR TITLE
The line color for "COL POL" can be changed

### DIFF
--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -5892,6 +5892,7 @@ void THistPainter::PaintColorLevels(Option_t*)
          } else  {
             TCrown crown(0,0,ylow,yup,xlow*TMath::RadToDeg(),xup*TMath::RadToDeg());
             crown.SetFillColor(gStyle->GetColorPalette(theColor));
+            crown.SetLineColor(fH->GetLineColor());
             crown.Paint();
          }
       }


### PR DESCRIPTION
When a histogram is drawn with the option COL POL, the line color of the polar boxes cannot be changed.
This was pointed out by: https://root-forum.cern.ch/t/removing-bin-borders-when-using-pol-draw-option/52098/3
