### PR TITLE
Redirect TFile::Open() calls to XRootD protocol if possible

### DIFF
--- a/README/ReleaseNotes/v628/index.md
+++ b/README/ReleaseNotes/v628/index.md
@@ -87,6 +87,17 @@ can be set to enable debugging and/or profiling.
 
 ## I/O Libraries
 
+### Faster reading from EOS
+
+A new cross-protocol redirection has been added to allow files on EOS mounts to be opened
+by `TFile::Open` via XRootD protocol rather than via FUSE when that is possible. The
+redirection uses the `eos.url.xroot` extended file attribute that is present on files in EOS.
+The attribute can be viewed with `getfattr -n eos.url.xroot [file]` on the command line.
+When the URL passed into `TFile::Open` is a for a file on an EOS mount, the extended
+attribute is used to attempt the redirection to XRootD protocol. If the redirection fails,
+the file is opened using the plain file path as before. This feature is controlled by the
+pre-existing configuration option `TFile.CrossProtocolRedirects` and is enabled by default.
+It can be disabled by setting `TFile.CrossProtocolRedirects` to `0` in `rootrc`.
 
 ## TTree Libraries
 


### PR DESCRIPTION
In a meeting in IT I saw that ~200PB/year are being read from the `eoshome` instance via fuse, and I thought that maybe ROOT at least could try to do something smart and just redirect fuse traffic to XRootD if possible. The patch in this pull request does just that. When I talked to Axel about making this work, we wanted the redirection to not happen when using `file://file.root`, but it created some inconsistencies when using `TFile::Open` vs using `TChain` so the final implementation always attempts to redirect.

Below is a demo session of ROOT opening a file on EOS with (a former version of) the patch:
```sh
$ pwd
/eos/home-a/amadio
$ ls *.root
Run2012BC_DoubleMuParked_Muons.root
$ root.exe
   ------------------------------------------------------------------
  | Welcome to ROOT 6.27/01                        https://root.cern |
  | (c) 1995-2022, The ROOT Team; conception: R. Brun, F. Rademakers |
  | Built for linuxx8664gcc on Oct 28 2022, 09:49:15                 |
  | From heads/redirect-xrootd@v6-09-01-24773-gd85df4c5e9            |
  | With c++ (GCC) 8.5.0 20210514 (Red Hat 8.5.0-15)                 |
  | Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'  |
   ------------------------------------------------------------------

root [0] auto f1 = TFile::Open("file://Run2012BC_DoubleMuParked_Muons.root");
root [1] auto f2 = TFile::Open("Run2012BC_DoubleMuParked_Muons.root");
root [2] f1->GetName()
(const char *) "Run2012BC_DoubleMuParked_Muons.root"
root [3] f2->GetName()
(const char *) "root://eoshome-a.cern.ch//eos/user/a/amadio/Run2012BC_DoubleMuParked_Muons.root"
root [4] .q
$
```
and with a slightly modified `df102_NanoAODDimuonAnalysis` tutorial to avoid `TChain`:
```diff
void df102_NanoAODDimuonAnalysis(const char* filename)
 {
    // Enable multi-threading
    ROOT::EnableImplicitMT();
 
-   // std::cout << "Using filename: " << filename << std::endl;
+   auto f = TFile::Open(filename);
+   auto t = f->Get<TTree>("Events");
 
-   ROOT::RDataFrame df("Events", filename);
+   ROOT::RDataFrame df(*t);
```

I got the following:

```sh
$ time ./dimuon file://Run2012BC_DoubleMuParked_Muons.root 
Info in <TCanvas::Print>: pdf file dimuon_spectrum.pdf has been created
Events with exactly two muons: pass=31104343   all=61540413   -- eff=50.54 % cumulative eff=50.54 %
Muons with opposite charge: pass=24067843   all=31104343   -- eff=77.38 % cumulative eff=39.11 %
13.34
$ time ./dimuon Run2012BC_DoubleMuParked_Muons.root 
Info in <TCanvas::Print>: pdf file dimuon_spectrum.pdf has been created
Events with exactly two muons: pass=31104343   all=61540413   -- eff=50.54 % cumulative eff=50.54 %
Muons with opposite charge: pass=24067843   all=31104343   -- eff=77.38 % cumulative eff=39.11 %
8.81
$
```

**Note:** With the final version of the patch, instead of using `file://`, which now does not disable the redirection anymore, one should add `TFile.CrossProtocolRedirects: no` to their `rootrc` configuration file in order to disable this feature (I checked that it works).
