### PR TITLE
DTD files are not in XML format and should not claim to be

### DIFF
--- a/tutorials/xml/person.dtd
+++ b/tutorials/xml/person.dtd
@@ -1,6 +1,3 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-
-
 <!ELEMENT PersonList (Person)+ >
 <!ELEMENT Person (FirstName,LastName,Gender,DateOfBirth,Address) >
 <!ATTLIST Person


### PR DESCRIPTION
The bogus XML designation causes the file to fail XML diagnostic tests.

Test description:
Check that XML files included in the RPM payload are well-formed.

======================================== Test Output ========================================

xml:
----

Result: VERIFY
1) /usr/share/doc/root/tutorials/xml/person.dtd is not a well-formed XML file in root-tutorial on noarch

Waiver Authorization: Anyone

Details:
Extra content at the end of the document

Suggested Remedy:
Correct the reported errors in the XML document
