### PR TITLE
Minuit2: Explained delgam warning messages in info

### DIFF
--- a/math/minuit2/src/DavidonErrorUpdator.cxx
+++ b/math/minuit2/src/DavidonErrorUpdator.cxx
@@ -28,6 +28,7 @@ DavidonErrorUpdator::Update(const MinimumState &s0, const MinimumParameters &p1,
    // update of the covarianze matrix (Davidon formula, see Tutorial, par. 4.8 pag 26)
    // in case of delgam > gvg (PHI > 1) use rank one formula
    // see  par 4.10 pag 30
+   // ( Tutorial: https://seal.web.cern.ch/seal/documents/minuit/mntutorial.pdf )
 
    MnPrint print("DavidonErrorUpdator");
 
@@ -41,12 +42,39 @@ DavidonErrorUpdator::Update(const MinimumState &s0, const MinimumParameters &p1,
    print.Debug("\ndx", dx, "\ndg", dg, "\ndelgam", delgam, "gvg", gvg);
 
    if (delgam == 0) {
-      print.Warn("delgam = 0 : cannot update - return same matrix");
+      print.Warn("delgam = 0 : cannot update - return same matrix (details in info log)");
+      print.Info("Explanation:\n"
+                 "   The distance from the minimum cannot be estimated, since at two\n"
+                 "   different points s0 and p1, the function gradient projected onto\n"
+                 "   the difference of s0 and p1 is zero, where:\n"
+                 " * s0: ", s0.Vec(), "\n"
+                 " * p1: ", p1.Vec(), "\n"
+                 " * gradient at s0: ", s0.Gradient().Vec(), "\n"
+                 " * gradient at p1: ", g1.Vec(), "\n"
+                 "   To understand whether this hints to an issue in the minimized function,\n"
+                 "   the minimized function can be plotted along points between s0 and p1 to\n"
+                 "   look for unexpected behavior.");
       return s0.Error();
    }
 
    if (delgam < 0) {
-      print.Warn("delgam < 0 : first derivatives increasing along search line");
+      print.Warn("delgam < 0 : first derivatives increasing along search line (details in info log)");
+      print.Info("Explanation:\n"
+                 "   The distance from the minimum cannot be estimated, since the minimized\n"
+                 "   function seems not to be strictly convex in the space probed by the fit.\n"
+                 "   That is expected if the starting parameters are e.g. close to a local maximum\n"
+                 "   of the minimized function. If this function is expected to be fully convex\n"
+                 "   in the probed range or Minuit is already close to the function minimum, this\n"
+                 "   may hint to numerical or analytical issues with the minimized function.\n"
+                 "   This was found by projecting the difference of gradients at two points, s0 and p1,\n"
+                 "   onto the direction given by the difference of s0 and p1, where:\n"
+                 " * s0: ", s0.Vec(), "\n"
+                 " * p1: ", p1.Vec(), "\n"
+                 " * gradient at s0: ", s0.Gradient().Vec(), "\n"
+                 " * gradient at p1: ", g1.Vec(), "\n"
+                 "   To understand whether this hints to an issue in the minimized function,\n"
+                 "   the minimized function can be plotted along points between s0 and p1 to\n"
+                 "   look for unexpected behavior.");
    }
 
    if (gvg <= 0) {


### PR DESCRIPTION
This Pull Request adds more speaking information to users to make warnings of the type
`delgam < 0 : first derivatives increasing along search line`
useful.

Note that I do not have too much knowledge on the details of Minuit2, and the information messages of course reflect my state of knowledge. If someone else with more in-depth knowledge on Minuit2 could check that this is valid, that would of course be very valuable!

The motivation for this PR is that these warnings can hint to significant issues in the minimized function, however as a user, it is difficult to understand the problem or what to look for if one does not know how Minuit exactly works. Also they so far miss information needed to actually use these warnings to find problems with the minimized function. This commit adds explanatory text printed in loglevel `Info`, and a short discovery note in the old warnings.

To demonstrate why this warning + info with the new `s0` and `p1` information is useful, this is an example where I encountered them in the wild and used its newly printed `s0` and `p1` information to plot the function between `s0` and `p1`, pointing to an issue in the likelihood function I use:

![image](https://user-images.githubusercontent.com/31772910/199365936-6994973a-8946-4083-b1b9-da2f4f69cc6f.png)

This commit also adds a link to the "Tutorial" that is referenced for documentation, since otherwise it is very non-trivial for inexperienced people to find it just based on its mention in a comment.
