### PR TITLE
Provide cling globals list in special RBrowser widget

### DIFF
--- a/gui/browserv7/inc/ROOT/RBrowser.hxx
+++ b/gui/browserv7/inc/ROOT/RBrowser.hxx
@@ -31,11 +31,12 @@ protected:
    std::string fTitle;  ///<! title
    unsigned fConnId{0}; ///<! default connection id
 
-   bool fUseRCanvas{false};             ///<!  which canvas should be used
-   bool fCatchWindowShow{true};         ///<! if arbitrary RWebWindow::Show calls should be catched by browser
+   bool fUseRCanvas{false};              ///<!  which canvas should be used
+   bool fCatchWindowShow{true};          ///<! if arbitrary RWebWindow::Show calls should be catched by browser
    std::string fActiveWidgetName;        ///<! name of active widget
    std::vector<std::shared_ptr<RBrowserWidget>> fWidgets; ///<!  all browser widgets
    int fWidgetCnt{0};                                     ///<! counter for created widgets
+   std::string fPromptFileOutput;        ///<! file name for prompt output
 
    std::shared_ptr<RWebWindow> fWebWindow;   ///<! web window to browser
 
@@ -43,7 +44,7 @@ protected:
 
    std::shared_ptr<RBrowserWidget> AddWidget(const std::string &kind);
    std::shared_ptr<RBrowserWidget> AddCatchedWidget(const std::string &url, const std::string &kind);
-   std::shared_ptr<RBrowserWidget> FindWidget(const std::string &name) const;
+   std::shared_ptr<RBrowserWidget> FindWidget(const std::string &name, const std::string &kind = "") const;
    std::shared_ptr<RBrowserWidget> GetActiveWidget() const { return FindWidget(fActiveWidgetName); }
 
    void CloseTab(const std::string &name);

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -329,7 +329,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
 
          let item = new TabContainerItem(name, {
             icon: "sap-icon://hint",
-            name: "Info Viewer",
+            name: "Globals",
             key: name,
             additionalText: "{/title}",
             tooltip: tooltip || ''
@@ -437,12 +437,17 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
                name = line.slice(0, p).trim();
 
             if (!name) return;
+            if (name == '<command')
+               name = '<command line>';
 
             p = line.indexOf('(address: NA)');
 
             if (p < 0) return;
 
-            let info = line.slice(p + 15),
+            if (name.indexOf('ROOT_cli') == 0)
+               name = 'ROOT_cli';
+
+            let info = line.slice(p + 14),
                 item = cache[name];
 
             if (!item) {
@@ -453,6 +458,14 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          });
 
          items.sub.sort((a,b) => a.name > b.name);
+
+         // single elements not create hierarchy
+         items.sub.forEach(item => {
+            if (item.sub.length == 1) {
+               item.info = item.sub[0].info;
+               delete item.sub;
+            }
+         });
 
          tab.getModel().setProperty("/items", items);
       },

--- a/ui5/browser/view/tabsmenu.fragment.xml
+++ b/ui5/browser/view/tabsmenu.fragment.xml
@@ -1,9 +1,10 @@
 <core:FragmentDefinition xmlns="sap.m" xmlns:core="sap.ui.core">
   <ActionSheet title="Tabs selection" showCancelButton="true" placement="Left">
-    <Button text="Root 6 canvas"   icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
-    <Button text="Root 7 canvas"   icon="sap-icon://column-chart-dual-axis" press="handleNewTab" />
-    <Button text="Geometry viewer" icon="sap-icon://overview-chart"         press="handleNewTab" />
-    <Button text="Code editor"     icon="sap-icon://write-new-document"     press="handleNewTab"  />
-    <Button text="Image viewer"    icon="sap-icon://background"             press="handleNewTab" />
+    <Button text="Root 6 canvas"   icon="sap-icon://column-chart-dual-axis" press="handleNewTab"/>
+    <Button text="Root 7 canvas"   icon="sap-icon://column-chart-dual-axis" press="handleNewTab"/>
+    <Button text="Geometry viewer" icon="sap-icon://overview-chart"         press="handleNewTab"/>
+    <Button text="Code editor"     icon="sap-icon://write-new-document"     press="handleNewTab"/>
+    <Button text="Image viewer"    icon="sap-icon://background"             press="handleNewTab"/>
+    <Button text="Cling info"      icon="sap-icon://hint"                   press="handleNewTab"/>
   </ActionSheet>
 </core:FragmentDefinition>


### PR DESCRIPTION

![Screenshot_cling](https://user-images.githubusercontent.com/4936580/199507709-0d15f971-6f64-4fe1-8cd8-24c4ed5d23ba.png)
Parse and provide output of `.g` command

Automatically create such widget when `.g` typed in `RBrowser` command prompt

Use `TreeTable` element for more structured output

Using idea of @ferdymercury from #11295,  