### PR TITLE
[PyROOT] Replace non-existent assertEquals with assertEqual

### DIFF
--- a/bindings/pyroot/pythonizations/test/tarray_getitem.py
+++ b/bindings/pyroot/pythonizations/test/tarray_getitem.py
@@ -34,7 +34,7 @@ class TArrayGetItem(unittest.TestCase):
         for i in range(self.num_elems):
             a[i] = val
 
-        self.assertEquals(list(a), [ val for _ in range(self.num_elems) ])
+        self.assertEqual(list(a), [ val for _ in range(self.num_elems) ])
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tclass_dynamiccast.py
+++ b/bindings/pyroot/pythonizations/test/tclass_dynamiccast.py
@@ -19,11 +19,11 @@ class TClassDynamicCast(unittest.TestCase):
 
         # Upcast: TObject <- TObjString
         o_upcast = tobjstr_class.DynamicCast(tobj_class, o)
-        self.assertEquals(type(o_upcast), TObject)
+        self.assertEqual(type(o_upcast), TObject)
 
         # Downcast: TObject -> TObjString
         o_downcast = tobjstr_class.DynamicCast(tobj_class, o_upcast, False)
-        self.assertEquals(type(o_downcast), TObjString)
+        self.assertEqual(type(o_downcast), TObjString)
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tvector3_getitem.py
+++ b/bindings/pyroot/pythonizations/test/tvector3_getitem.py
@@ -28,7 +28,7 @@ class TVector3GetItem(unittest.TestCase):
     def test_iterable(self):
         v = ROOT.TVector3(1., 2., 3.)
 
-        self.assertEquals(list(v), [1., 2., 3.])
+        self.assertEqual(list(v), [1., 2., 3.])
 
 
 if __name__ == '__main__':

--- a/bindings/pyroot/pythonizations/test/tvectort_getitem.py
+++ b/bindings/pyroot/pythonizations/test/tvectort_getitem.py
@@ -34,7 +34,7 @@ class TVectorTGetItem(unittest.TestCase):
         for i in range(self.num_elems):
             v[i] = val
 
-        self.assertEquals(list(v), [ val for _ in range(self.num_elems) ])
+        self.assertEqual(list(v), [ val for _ in range(self.num_elems) ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The changed tests were failing with errors like the one below:

```
Traceback (most recent call last):
  File "root/bindings/pyroot/pythonizations/test/tclass_dynamiccast.py",
       line 22, in test_dynamiccast
    self.assertEquals(type(o_upcast), TObject)
    ^^^^^^^^^^^^^^^^^
AttributeError: 'TClassDynamicCast' object has no attribute 'assertEquals'.
                Did you mean: 'assertEqual'?
```

These errors were observed with Python 3.12, but I guess they also happen with earlier versions of Python.

