### PR TITLE
[RF] Ensure that using variable clones also works to specify integrals

### DIFF
--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -118,7 +118,7 @@ protected:
 
   mutable RooArgSet   _facListOwned ;  ///< Owned components in _facList
   RooRealProxy       _function ;     ///<Function being integration
-  RooArgSet*      _funcNormSet = nullptr;     ///< Optional normalization set passed to function
+  std::unique_ptr<RooArgSet> _funcNormSet; ///< Optional normalization set passed to function
 
   mutable RooArgSet       _saveInt ; ///<! do not persist
   mutable RooArgSet       _saveSum ; ///<! do not persist
@@ -141,7 +141,7 @@ protected:
   bool _cacheNum = false;           ///< Cache integral if numeric
   static Int_t _cacheAllNDim ; ///<! Cache all integrals with given numeric dimension
 
-  ClassDefOverride(RooRealIntegral,3) // Real-valued function representing an integral over a RooAbsReal object
+  ClassDefOverride(RooRealIntegral,4) // Real-valued function representing an integral over a RooAbsReal object
 };
 
 #endif

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -104,7 +104,7 @@ enum class MarkedState { Dependent, Independent, AlreadyAdded };
 bool unmarkDepValueClients(RooAbsArg const &dep, RooArgSet const &args, std::vector<MarkedState> &marked)
 {
    assert(args.size() == marked.size());
-   auto index = args.index(&dep);
+   auto index = args.index(dep.GetName());
    if (index >= 0) {
       marked[index] = MarkedState::Dependent;
       for (RooAbsArg *client : dep.valueClients()) {
@@ -141,7 +141,7 @@ getValueAndShapeServers(RooAbsReal const &function, RooArgSet const &depList, co
    // add it to the server list.
    for (RooAbsArg *dep : depList) {
       if (unmarkDepValueClients(*dep, allArgs, marked)) {
-         addObservableToServers(function, *dep, serversToAdd, rangeName);
+         addObservableToServers(function, *allArgs.find(*dep), serversToAdd, rangeName);
       }
    }
 
@@ -150,7 +150,7 @@ getValueAndShapeServers(RooAbsReal const &function, RooArgSet const &depList, co
    for (std::size_t i = 0; i < allArgs.size(); ++i) {
       if(marked[i] == MarkedState::Dependent) {
          for(RooAbsArg* server : allArgs[i]->servers()) {
-            int index = allArgs.index(server);
+            int index = allArgs.index(server->GetName());
             if(index >= 0 && marked[index] == MarkedState::Independent) {
                addParameterToServers(function, *server, serversToAdd, !allValueArgs.find(*server));
                marked[index] = MarkedState::AlreadyAdded;
@@ -301,8 +301,6 @@ RooRealIntegral::RooRealIntegral(const char *name, const char *title,
         _funcNormSet->addClone(*nArg) ;
       }
     }
-  } else {
-    _funcNormSet = 0 ;
   }
 
   //_funcNormSet = funcNormSet ? (RooArgSet*)funcNormSet->snapshot(false) : 0 ;


### PR DESCRIPTION
Recently, in commit https://github.com/root-project/root/commit/47c250898f3d3a1bb1718c73b84014a70809ffdf, the algorithm to figure out the value
and shape servers of integrals was rewritten. However, the new
implementation analyzed the computation graph by pointer, which caused a
wrong list of servers if one passed clones of the integration variables
to the integral constructor.

This commit fixes that, and also implements a unit test for this case.

Closes https://github.com/root-project/root/issues/11637, as the issue was caused by the integration variable
wrongly being registered as a value server of the integral. This made
the reproducer code in the issue thread very slow, because the integral
was reevaluated for each event.
