### PR TITLE
[RF] Always clone constraint term in `createNLL`

### DIFF
--- a/roofit/roofitcore/src/BatchModeHelpers.cxx
+++ b/roofit/roofitcore/src/BatchModeHelpers.cxx
@@ -157,6 +157,15 @@ std::unique_ptr<RooAbsReal> RooFit::BatchModeHelpers::createNLL(std::unique_ptr<
                                                                 RooFit::BatchModeOption batchMode, bool doOffset,
                                                                 bool splitRange, bool takeGlobalObservablesFromData)
 {
+   if (constraints) {
+      // Redirect the global observables to the ones from the dataset if applicable.
+      constraints->setData(data, false);
+
+      // The computation graph for the constraints is very small, no need to do
+      // the tracking of clean and dirty nodes here.
+      constraints->setOperMode(RooAbsArg::ADirty);
+   }
+
    RooArgSet observables;
    pdf->getObservables(data.get(), observables);
    observables.remove(projDeps, true, true);

--- a/roofit/roofitcore/src/ConstraintHelpers.cxx
+++ b/roofit/roofitcore/src/ConstraintHelpers.cxx
@@ -167,17 +167,8 @@ std::unique_ptr<RooAbsReal> createConstraintTerm(std::string const &name, RooAbs
          takeGlobalObservablesFromData = false;
       }
 
-      auto constraintTerm = std::make_unique<RooConstraintSum>(name.c_str(), "nllCons", allConstraints,
-                                                               glObs ? *glObs : cPars, takeGlobalObservablesFromData);
-
-      // Redirect the global observables to the ones from the dataset if applicable.
-      constraintTerm->setData(data, false);
-
-      // The computation graph for the constraints is very small, no need to do
-      // the tracking of clean and dirty nodes here.
-      constraintTerm->setOperMode(RooAbsArg::ADirty);
-
-      return constraintTerm;
+      return std::make_unique<RooConstraintSum>(name.c_str(), "nllCons", allConstraints, glObs ? *glObs : cPars,
+                                                takeGlobalObservablesFromData);
    }
 
    // no constraints


### PR DESCRIPTION
Even though cloning the constraint term is technically only required when the computation graph is changed because global observables are taken from data, it is safer to clone the constraint model in general to reset the normalization integral caches and avoid ASAN build failures (the PDF of the main measurement is cloned too anyway, so not much overhead).

This can be reconsidered after the caching of normalization sets by pointer is changed to a more memory-safe solution.