### PR TITLE
[skip-ci] wrong variable was tested in Makefile

### DIFF
--- a/documentation/doxygen/Makefile
+++ b/documentation/doxygen/Makefile
@@ -2,7 +2,7 @@
 .PHONY: filter folders mathjax js images doxygen replaceCollaborationDiagrams
 
 OS=$(shell uname)
-ifeq ($(UNAME), Darwin)
+ifeq ($(OS), Darwin)
    export DOXYGEN_LDD := otool -L
    NJOB ?= $(shell sysctl -n hw.ncpu)
 else


### PR DESCRIPTION
For some reason, `UNAME` was tested instead of `OS`

