### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -14,7 +14,7 @@ jobs:
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
       BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch base_ref HEAD
       run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
     - name: install clang-format

--- a/.github/workflows/issues-nudge.yml
+++ b/.github/workflows/issues-nudge.yml
@@ -9,8 +9,8 @@ jobs:
     if: ${{ github.repository == 'root-project/root' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - run: npm install octokit


### PR DESCRIPTION
The previous versions use Node.js 12, which is deprecated for GitHub Actions.