### PR TITLE
[ntuple,daos] Add missing attribute to IOD structure mock definition

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
+++ b/tree/ntuple/v7/inc/ROOT/libdaos_mock/daos.h
@@ -196,11 +196,12 @@ typedef enum {
 } daos_iod_type_t;
 
 typedef struct {
-	daos_key_t		iod_name;
-	daos_iod_type_t		iod_type;
-	daos_size_t		iod_size;
-	unsigned int		iod_nr;
-	daos_recx_t		*iod_recxs;
+   daos_key_t iod_name;
+   daos_iod_type_t iod_type;
+   daos_size_t iod_size;
+   uint64_t iod_flags;
+   unsigned int iod_nr;
+   daos_recx_t *iod_recxs;
 } daos_iod_t;
 
 typedef struct {


### PR DESCRIPTION
This pull request adds the attribute `uint64_t iod_flags`, introduced in DAOS v2.0, to the definition of `daos_iod_t` in our mock implementation of libdaos for development. See: https://docs.daos.io/v2.0/doxygen/html/structdaos__iod__t.html.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

