### PR TITLE
[PyROOT] Enclose tuple unpacking in return statement with parenthesis

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_pyz.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_rdf_pyz.py
@@ -250,7 +250,7 @@ def _convert_to_vector(args):
         raise TypeError(
             f"The list of columns of a Filter operation can only contain strings. Please check: {args[0]}")
 
-    return v, *args[1:]
+    return (v, *args[1:])
 
 def _handle_cpp_callables(func, original_template, *args):
     """


### PR DESCRIPTION
As returning an unpacked tuple without parenthesis is only supported since Python 3.8

This patch fixes the following:
```
python3.7 -m py_compile _rdf_pyz.py
  File "_rdf_pyz.py", line 253
    return v, *args[1:]
              ^
SyntaxError: invalid syntax
```
