### PR TITLE
Add Rint as a dependency of rootcling

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -85,7 +85,7 @@ set_source_files_properties(src/rootcling.cxx PROPERTIES
   VISIBILITY_INLINES_HIDDEN "ON"
 )
 
-ROOT_EXECUTABLE(rootcling src/rootcling.cxx LIBRARIES RIO Cling Core)
+ROOT_EXECUTABLE(rootcling src/rootcling.cxx LIBRARIES RIO Cling Core Rint)
 
 # rootcling includes the ROOT complex header which would build the complex
 # dictionary with modules. To make sure that rootcling_stage1 builds this


### PR DESCRIPTION
`TCling.cxx`’s `RegisterCxxModules` loads explicitly several modules including `Core`, `Rint` and `RIO`.

When executing rootcling (for example for G__Net.cxx) *before* `G__Rint.cxx` was created and thus before `lib/Rint.pcm` was properly created, a default `lib/Rint.pcm` is auto-generated and registered as one of the dependencies.  Later the real `lib/Rint.pcm` is created is creation date is later than other `pcm` than depends-on/uses it’s creation time.  For example:

```
$ ls -lart lib/Net.pcm lib/MultiProc.pcm  lib/Imt.pcm lib/MathCore.pcm lib/Rint.pcm
-rw-r--r-- 1 pcanal pcanal  1158548 Nov 10 20:26 lib/Net.pcm
-rw-r--r-- 1 pcanal pcanal  1278392 Nov 10 20:27 lib/MultiProc.pcm
-rw-r--r-- 1 pcanal pcanal  2032752 Nov 10 20:27 lib/Imt.pcm
-rw-r--r-- 1 pcanal pcanal 12911448 Nov 10 20:27 lib/MathCore.pcm
-rw-r--r-- 1 pcanal pcanal   444724 Nov 10 20:35 lib/Rint.pcm
```

then later uses of those `pcm` leads to the (mis-worded) error message:

```
<<< cling interactive line includer >>>: fatal error: module file '/home/neel/Desktop/Root/build/lib/Rint.pcm' is out of date and needs to be rebuilt: could not read module signature
<<< cling interactive line includer >>>: note: imported by module 'MathCore' in '/home/neel/Desktop/Root/build/lib/MathCore.pcm'
Error: Module 'MathCore.pcm' failed to load.
Error: Error loading the default rootcling header files.
make[2]: *** [math/mathmore/CMakeFiles/G__MathMore.dir/build.make:130: math/mathmore/G__MathMore.cxx] Error 1
```

See the related circumstances in https://root-forum.cern.ch/t/wsl-build-from-source-error-rint-pcm-is-out-of-date-cannot-read-module-signature/47564/39

The stack trace that was triggers the auto-generation of `Rint.pcm`

    at /home/pcanal/root_working/code/master/interpreter/llvm/src/tools/clang/lib/Sema/SemaModule.cpp:325
    at /home/pcanal/root_working/code/master/interpreter/cling/lib/Interpreter/Interpreter.cpp:908
    at /home/pcanal/root_working/code/master/interpreter/cling/lib/Interpreter/Interpreter.cpp:872
    at /home/pcanal/root_working/code/master/core/metacling/src/TCling.cxx:1590

This PR fixes #11686

