### PR TITLE
[RF] Remove redundant configuration members of `RooAbsMinimizerFcn`

### DIFF
--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -53,7 +53,7 @@ public:
       int nWorkers = getDefaultWorkers(); // RooAbsMinimizerFcn config that can only be set in ctor
       bool parallelGradient = false;      // RooAbsMinimizerFcn config that can only be set in ctor
       bool parallelLikelihood = false;    // RooAbsMinimizerFcn config that can only be set in ctor
-      int verbose = 0;                    // local config
+      bool verbose = false;               // local config
       bool profile = false;               // local config
       std::string minimizerType = "";     // local config
    private:
@@ -77,11 +77,11 @@ public:
 
    // Setters on _fcn
    void optimizeConst(int flag);
-   void setEvalErrorWall(bool flag);
+   void setEvalErrorWall(bool flag) { _cfg.doEEWall = flag; }
    void setRecoverFromNaNStrength(double strength);
    void setOffsetting(bool flag);
-   void setPrintEvalErrors(int numEvalErrors);
-   void setVerbose(bool flag = true);
+   void setPrintEvalErrors(int numEvalErrors) { _cfg.printEvalErrors = numEvalErrors; }
+   void setVerbose(bool flag = true) { _cfg.verbose = flag; }
    bool setLogFile(const char *logf = nullptr);
 
    int migrad();
@@ -151,7 +151,6 @@ private:
    // constructor helper functions
    void initMinimizerFirstPart();
    void initMinimizerFcnDependentPart(double defaultErrorLevel);
-   void execSetters(); // Executes setters that set _fcn config as per given _cfg configuration
 
    int _status = -99;
    bool _profileStart = false;

--- a/roofit/roofitcore/src/RooAbsMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooAbsMinimizerFcn.h
@@ -23,6 +23,7 @@
 
 #include "RooAbsReal.h"
 #include "RooArgList.h"
+#include "RooMinimizer.h"
 #include "RooRealVar.h"
 
 #include <Fit/Fitter.h>
@@ -31,9 +32,6 @@
 #include <fstream>
 #include <string>
 #include <memory> // unique_ptr
-
-// forward declaration
-class RooMinimizer;
 
 class RooAbsMinimizerFcn {
 
@@ -48,7 +46,7 @@ public:
    /// its parameter_settings vector of RooFit parameter properties, but
    /// Synchronize can be overridden to e.g. also include gradient strategy
    /// synchronization in subclasses.
-   virtual bool Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters, bool optConst);
+   virtual bool Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters);
 
    RooArgList *GetFloatParamList() { return _floatParamList.get(); }
    RooArgList *GetConstParamList() { return _constParamList.get(); }
@@ -56,15 +54,6 @@ public:
    RooArgList *GetInitConstParamList() { return _initConstParamList.get(); }
    Int_t GetNumInvalidNLL() const { return _numBadNLL; }
 
-   // need access from Minimizer:
-   void SetEvalErrorWall(bool flag) { _doEvalErrorWall = flag; }
-   /// Try to recover from invalid function values. When invalid function values are encountered,
-   /// a penalty term is returned to the minimiser to make it back off. This sets the strength of this penalty.
-   /// \note A strength of zero is equivalent to a constant penalty (= the gradient vanishes, ROOT < 6.24).
-   /// Positive values lead to a gradient pointing away from the undefined regions. Use ~10 to force the minimiser
-   /// away from invalid function values.
-   void SetRecoverFromNaNStrength(double strength) { _recoverFromNaNStrength = strength; }
-   void SetPrintEvalErrors(Int_t numEvalErrors) { _printEvalErrors = numEvalErrors; }
    double &GetMaxFCN() { return _maxFCN; }
    Int_t evalCounter() const { return _evalCounter; }
    void zeroEvalCount() { _evalCounter = 0; }
@@ -95,7 +84,6 @@ public:
 
    void setOptimizeConst(Int_t flag);
 
-   bool getOptConst() { return _optConst; }
    std::vector<double> getParameterValues() const;
 
    bool SetPdfParamVal(int index, double value) const;
@@ -105,7 +93,7 @@ public:
    virtual bool fit(ROOT::Fit::Fitter &) const = 0;
    virtual ROOT::Math::IMultiGenFunction *getMultiGenFcn() = 0;
 
-   bool isVerbose() const;
+   RooMinimizer::Config const &cfg() const { return _context->_cfg; }
 
 protected:
    void optimizeConstantTerms(bool constStatChange, bool constValChange);
@@ -129,9 +117,7 @@ protected:
    // Reset the *largest* negative log-likelihood value we have seen so far:
    mutable double _maxFCN = -std::numeric_limits<double>::infinity();
    mutable double _funcOffset{0.};
-   double _recoverFromNaNStrength{10.};
    mutable int _numBadNLL = 0;
-   mutable int _printEvalErrors = 10;
    mutable int _evalCounter{0};
 
    unsigned int _nDim = 0;
@@ -144,7 +130,6 @@ protected:
    std::unique_ptr<RooArgList> _initConstParamList;
 
    std::ofstream *_logfile = nullptr;
-   bool _doEvalErrorWall{true};
 };
 
 #endif

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -160,7 +160,7 @@ void RooMinimizer::initMinimizerFcnDependentPart(double defaultErrorLevel)
    setErrorLevel(defaultErrorLevel);
 
    // Declare our parameters to MINUIT
-   _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+   _fcn->Synchronize(_theFitter->Config().ParamsSettings());
 
    // Now set default verbosity
    if (RooMsgService::instance().silentMode()) {
@@ -170,15 +170,6 @@ void RooMinimizer::initMinimizerFcnDependentPart(double defaultErrorLevel)
    }
 
    // Set user defined and default _fcn config
-   execSetters();
-}
-
-/// Execute all setters on _fcn
-void RooMinimizer::execSetters()
-{
-   setEvalErrorWall(_cfg.doEEWall);
-   setRecoverFromNaNStrength(_cfg.recoverFromNaN);
-   setPrintEvalErrors(_cfg.printEvalErrors);
    setLogFile(_cfg.logf);
 
    // Likelihood holds information on offsetting in old style, so do not set here unless explicitly set by user
@@ -301,7 +292,7 @@ bool RooMinimizer::fitFcn() const
 /// \param[in] alg  Fit algorithm to use. (Optional)
 int RooMinimizer::minimize(const char *type, const char *alg)
 {
-   _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+   _fcn->Synchronize(_theFitter->Config().ParamsSettings());
 
    setMinimizerType(type);
    _theFitter->Config().SetMinimizer(type, alg);
@@ -330,7 +321,7 @@ int RooMinimizer::minimize(const char *type, const char *alg)
 
 int RooMinimizer::migrad()
 {
-   _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+   _fcn->Synchronize(_theFitter->Config().ParamsSettings());
    profileStart();
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
    RooAbsReal::clearEvalErrorLog();
@@ -361,7 +352,7 @@ int RooMinimizer::hesse()
       _status = -1;
    } else {
 
-      _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+      _fcn->Synchronize(_theFitter->Config().ParamsSettings());
       profileStart();
       RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
       RooAbsReal::clearEvalErrorLog();
@@ -393,7 +384,7 @@ int RooMinimizer::minos()
       _status = -1;
    } else {
 
-      _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+      _fcn->Synchronize(_theFitter->Config().ParamsSettings());
       profileStart();
       RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
       RooAbsReal::clearEvalErrorLog();
@@ -425,7 +416,7 @@ int RooMinimizer::minos(const RooArgSet &minosParamList)
       _status = -1;
    } else if (!minosParamList.empty()) {
 
-      _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+      _fcn->Synchronize(_theFitter->Config().ParamsSettings());
       profileStart();
       RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
       RooAbsReal::clearEvalErrorLog();
@@ -469,7 +460,7 @@ int RooMinimizer::minos(const RooArgSet &minosParamList)
 
 int RooMinimizer::seek()
 {
-   _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+   _fcn->Synchronize(_theFitter->Config().ParamsSettings());
    profileStart();
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
    RooAbsReal::clearEvalErrorLog();
@@ -495,7 +486,7 @@ int RooMinimizer::seek()
 
 int RooMinimizer::simplex()
 {
-   _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+   _fcn->Synchronize(_theFitter->Config().ParamsSettings());
    profileStart();
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
    RooAbsReal::clearEvalErrorLog();
@@ -521,7 +512,7 @@ int RooMinimizer::simplex()
 
 int RooMinimizer::improve()
 {
-   _fcn->Synchronize(_theFitter->Config().ParamsSettings(), _fcn->getOptConst());
+   _fcn->Synchronize(_theFitter->Config().ParamsSettings());
    profileStart();
    RooAbsReal::setEvalErrorLoggingMode(RooAbsReal::CollectErrors);
    RooAbsReal::clearEvalErrorLog();
@@ -883,27 +874,17 @@ RooFitResult *RooMinimizer::lastMinuitFit(const RooArgList &varList)
    return res;
 }
 
-void RooMinimizer::setEvalErrorWall(bool flag)
-{
-   _cfg.doEEWall = flag;
-   _fcn->SetEvalErrorWall(_cfg.doEEWall);
-}
-
-/// \copydoc RooMinimizerFcn::SetRecoverFromNaNStrength()
+/// Try to recover from invalid function values. When invalid function values
+/// are encountered, a penalty term is returned to the minimiser to make it
+/// back off. This sets the strength of this penalty. \note A strength of zero
+/// is equivalent to a constant penalty (= the gradient vanishes, ROOT < 6.24).
+/// Positive values lead to a gradient pointing away from the undefined
+/// regions. Use ~10 to force the minimiser away from invalid function values.
 void RooMinimizer::setRecoverFromNaNStrength(double strength)
 {
    _cfg.recoverFromNaN = strength;
-   _fcn->SetRecoverFromNaNStrength(_cfg.recoverFromNaN);
 }
-void RooMinimizer::setPrintEvalErrors(Int_t numEvalErrors)
-{
-   _cfg.printEvalErrors = numEvalErrors;
-   _fcn->SetPrintEvalErrors(_cfg.printEvalErrors);
-}
-void RooMinimizer::setVerbose(bool flag)
-{
-   _cfg.verbose = flag;
-}
+
 bool RooMinimizer::setLogFile(const char *logf)
 {
    _cfg.logf = logf;

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -35,38 +35,35 @@
 
 using namespace std;
 
-
 namespace {
 
 // Helper function that wraps RooAbsArg::getParameters and directly returns the
 // output RooArgSet. To be used in the initializer list of the RooMinimizerFcn
 // constructor.
-RooArgSet getParameters(RooAbsReal const& funct) {
-    RooArgSet out;
-    funct.getParameters(nullptr, out);
-    return out;
+RooArgSet getParameters(RooAbsReal const &funct)
+{
+   RooArgSet out;
+   funct.getParameters(nullptr, out);
+   return out;
 }
 
 } // namespace
 
-
-RooMinimizerFcn::RooMinimizerFcn(RooAbsReal *funct, RooMinimizer* context) : RooAbsMinimizerFcn(getParameters(*funct), context), _funct(funct)
-{}
-
-
-
-RooMinimizerFcn::RooMinimizerFcn(const RooMinimizerFcn& other) : RooAbsMinimizerFcn(other), ROOT::Math::IBaseFunctionMultiDim(other),
-  _funct(other._funct)
-{}
-
-
-RooMinimizerFcn::~RooMinimizerFcn()
-{}
-
-
-ROOT::Math::IBaseFunctionMultiDim* RooMinimizerFcn::Clone() const
+RooMinimizerFcn::RooMinimizerFcn(RooAbsReal *funct, RooMinimizer *context)
+   : RooAbsMinimizerFcn(getParameters(*funct), context), _funct(funct)
 {
-  return new RooMinimizerFcn(*this) ;
+}
+
+RooMinimizerFcn::RooMinimizerFcn(const RooMinimizerFcn &other)
+   : RooAbsMinimizerFcn(other), ROOT::Math::IBaseFunctionMultiDim(other), _funct(other._funct)
+{
+}
+
+RooMinimizerFcn::~RooMinimizerFcn() {}
+
+ROOT::Math::IBaseFunctionMultiDim *RooMinimizerFcn::Clone() const
+{
+   return new RooMinimizerFcn(*this);
 }
 
 void RooMinimizerFcn::setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt)
@@ -75,51 +72,53 @@ void RooMinimizerFcn::setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, 
 }
 
 /// Evaluate function given the parameters in `x`.
-double RooMinimizerFcn::DoEval(const double *x) const {
+double RooMinimizerFcn::DoEval(const double *x) const
+{
 
-  // Set the parameter values for this iteration
-  for (unsigned index = 0; index < _nDim; index++) {
-    if (_logfile) (*_logfile) << x[index] << " " ;
-    SetPdfParamVal(index,x[index]);
-  }
+   // Set the parameter values for this iteration
+   for (unsigned index = 0; index < _nDim; index++) {
+      if (_logfile)
+         (*_logfile) << x[index] << " ";
+      SetPdfParamVal(index, x[index]);
+   }
 
-  // Calculate the function for these parameters
-  RooAbsReal::setHideOffset(false) ;
-  double fvalue = _funct->getVal();
-  RooAbsReal::setHideOffset(true) ;
+   // Calculate the function for these parameters
+   RooAbsReal::setHideOffset(false);
+   double fvalue = _funct->getVal();
+   RooAbsReal::setHideOffset(true);
 
-  if (!std::isfinite(fvalue) || RooAbsReal::numEvalErrors() > 0 || fvalue > 1e30) {
-    printEvalErrors();
-    RooAbsReal::clearEvalErrorLog() ;
-    _numBadNLL++ ;
+   if (!std::isfinite(fvalue) || RooAbsReal::numEvalErrors() > 0 || fvalue > 1e30) {
+      printEvalErrors();
+      RooAbsReal::clearEvalErrorLog();
+      _numBadNLL++;
 
-    if (_doEvalErrorWall) {
-      const double badness = RooNaNPacker::unpackNaN(fvalue);
-      fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + _recoverFromNaNStrength * badness;
-    }
-  } else {
-    if (_evalCounter > 0 && _evalCounter == _numBadNLL) {
-      // This is the first time we get a valid function value; while before, the
-      // function was always invalid. For invalid  cases, we returned values > 0.
-      // Now, we offset valid values such that they are < 0.
-      _funcOffset = -fvalue;
-    }
-    fvalue += _funcOffset;
-    _maxFCN = std::max(fvalue, _maxFCN);
-  }
+      if (_doEvalErrorWall) {
+         const double badness = RooNaNPacker::unpackNaN(fvalue);
+         fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + _recoverFromNaNStrength * badness;
+      }
+   } else {
+      if (_evalCounter > 0 && _evalCounter == _numBadNLL) {
+         // This is the first time we get a valid function value; while before, the
+         // function was always invalid. For invalid  cases, we returned values > 0.
+         // Now, we offset valid values such that they are < 0.
+         _funcOffset = -fvalue;
+      }
+      fvalue += _funcOffset;
+      _maxFCN = std::max(fvalue, _maxFCN);
+   }
 
-  // Optional logging
-  if (_logfile)
-    (*_logfile) << setprecision(15) << fvalue << setprecision(4) << endl;
-  if (isVerbose()) {
-    cout << "\nprevFCN" << (_funct->isOffsetting()?"-offset":"") << " = " << setprecision(10)
-         << fvalue << setprecision(4) << "  " ;
-    cout.flush() ;
-  }
+   // Optional logging
+   if (_logfile)
+      (*_logfile) << setprecision(15) << fvalue << setprecision(4) << endl;
+   if (isVerbose()) {
+      cout << "\nprevFCN" << (_funct->isOffsetting() ? "-offset" : "") << " = " << setprecision(10) << fvalue
+           << setprecision(4) << "  ";
+      cout.flush();
+   }
 
-  finishDoEval();
+   finishDoEval();
 
-  return fvalue;
+   return fvalue;
 }
 
 std::string RooMinimizerFcn::getFunctionName() const

--- a/roofit/roofitcore/src/RooMinimizerFcn.cxx
+++ b/roofit/roofitcore/src/RooMinimizerFcn.cxx
@@ -92,9 +92,9 @@ double RooMinimizerFcn::DoEval(const double *x) const
       RooAbsReal::clearEvalErrorLog();
       _numBadNLL++;
 
-      if (_doEvalErrorWall) {
+      if (cfg().doEEWall) {
          const double badness = RooNaNPacker::unpackNaN(fvalue);
-         fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + _recoverFromNaNStrength * badness;
+         fvalue = (std::isfinite(_maxFCN) ? _maxFCN : 0.) + cfg().recoverFromNaN * badness;
       }
    } else {
       if (_evalCounter > 0 && _evalCounter == _numBadNLL) {
@@ -110,7 +110,7 @@ double RooMinimizerFcn::DoEval(const double *x) const
    // Optional logging
    if (_logfile)
       (*_logfile) << setprecision(15) << fvalue << setprecision(4) << endl;
-   if (isVerbose()) {
+   if (cfg().verbose) {
       cout << "\nprevFCN" << (_funct->isOffsetting() ? "-offset" : "") << " = " << setprecision(10) << fvalue
            << setprecision(4) << "  ";
       cout.flush();

--- a/roofit/roofitcore/src/RooMinimizerFcn.h
+++ b/roofit/roofitcore/src/RooMinimizerFcn.h
@@ -27,7 +27,8 @@
 
 #include "RooAbsMinimizerFcn.h"
 
-template<typename T> class TMatrixTSym;
+template <typename T>
+class TMatrixTSym;
 using TMatrixDSym = TMatrixTSym<double>;
 
 // forward declaration
@@ -49,8 +50,8 @@ public:
    void setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt) override;
 
    void setOffsetting(bool flag) override;
-   bool fit(ROOT::Fit::Fitter& fitter) const override { return fitter.FitFCN(*this); };
-   ROOT::Math::IMultiGenFunction* getMultiGenFcn() override { return this; };
+   bool fit(ROOT::Fit::Fitter &fitter) const override { return fitter.FitFCN(*this); };
+   ROOT::Math::IMultiGenFunction *getMultiGenFcn() override { return this; };
 
 private:
    double DoEval(const double *x) const override;

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -97,9 +97,9 @@ double MinuitFcnGrad::DoEval(const double *x) const
 
    if (!std::isfinite(fvalue) || RooAbsReal::numEvalErrors() > 0 || fvalue > 1e30) {
 
-      if (_printEvalErrors >= 0) {
+      if (cfg().printEvalErrors >= 0) {
 
-         if (_doEvalErrorWall) {
+         if (cfg().doEEWall) {
             oocoutW(nullptr, Eval) << "MinuitFcnGrad: Minimized function has error status." << std::endl
                                    << "Returning maximum FCN so far (" << _maxFCN
                                    << ") to force MIGRAD to back out of this region. Error log follows" << std::endl;
@@ -121,11 +121,11 @@ double MinuitFcnGrad::DoEval(const double *x) const
          }
          ooccoutW(static_cast<RooAbsArg *>(nullptr), Eval) << std::endl;
 
-         RooAbsReal::printEvalErrors(ooccoutW(static_cast<RooAbsArg *>(nullptr), Eval), _printEvalErrors);
+         RooAbsReal::printEvalErrors(ooccoutW(static_cast<RooAbsArg *>(nullptr), Eval), cfg().printEvalErrors);
          ooccoutW(static_cast<RooAbsArg *>(nullptr), Eval) << std::endl;
       }
 
-      if (_doEvalErrorWall) {
+      if (cfg().doEEWall) {
          fvalue = _maxFCN + 1;
       }
 
@@ -136,7 +136,7 @@ double MinuitFcnGrad::DoEval(const double *x) const
    }
 
    // Optional logging
-   if (isVerbose()) {
+   if (cfg().verbose) {
       std::cout << "\nprevFCN" << (likelihood_here->isOffsetting() ? "-offset" : "") << " = " << std::setprecision(10)
                 << fvalue << std::setprecision(4) << "  ";
       std::cout.flush();
@@ -261,9 +261,9 @@ double MinuitFcnGrad::DoDerivative(const double * /*x*/, unsigned int /*icoord*/
    throw std::runtime_error("MinuitFcnGrad::DoDerivative is not implemented, please use Gradient instead.");
 }
 
-bool MinuitFcnGrad::Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters, bool optConst)
+bool MinuitFcnGrad::Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameters)
 {
-   bool returnee = synchronizeParameterSettings(parameters, optConst);
+   bool returnee = synchronizeParameterSettings(parameters, _optConst);
    likelihood->synchronizeParameterSettings(parameters);
    if (likelihood != likelihood_in_gradient) {
       likelihood_in_gradient->synchronizeParameterSettings(parameters);

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
@@ -39,7 +39,7 @@ public:
    inline ROOT::Math::IMultiGradFunction *Clone() const override { return new MinuitFcnGrad(*this); }
 
    /// Overridden from RooAbsMinimizerFcn to include gradient strategy synchronization.
-   bool Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameter_settings, bool optConst) override;
+   bool Synchronize(std::vector<ROOT::Fit::ParameterSettings> &parameter_settings) override;
 
    // used inside Minuit:
    inline bool returnsInMinuit2ParameterSpace() const override { return gradient->usesMinuitInternalValues(); }


### PR DESCRIPTION
In https://github.com/root-project/root/pull/11604, many redundancies in the RooMinimizer design became apparent,
and this PR aims to avoid them. The following changes are made:

* The signature of `RooAbsMinimizerFcn::Synchronize()` is changed to not
  take a `bool optConst` argument anymore. Ths is because the value of
  the argument that was passed by the RooMinimizer instance was always a
  member of the `RooAbsMinimizerFcn` anyway.

* Change type of `RooMinimizer::Config::verbose` to `bool`, because
  `setVerbose()` also takes a `bool` flag.

* Give `RooAbsMinimizerFcn` access to the RooMinimizer configuration
  such that configuration data does not need to be duplicated.

A separate commit in this PR formats the code of the `RooMinimizerFcn`.