### PR TITLE
[RF] Use of proxy norm sets in RooRealIntegral and RooGenProdProj

### DIFF
--- a/roofit/roofitcore/inc/RooRealIntegral.h
+++ b/roofit/roofitcore/inc/RooRealIntegral.h
@@ -109,6 +109,13 @@ protected:
   bool redirectServersHook(const RooAbsCollection& newServerList,
                  bool mustReplaceAll, bool nameChange, bool isRecursive) override ;
 
+  // Internal function to get the normalization set for the integrated
+  // function. By default, we will take the normalization set from the function
+  // proxy, but _funcNormSet will be used if it is set.
+  inline RooArgSet const* funcNormSet() const {
+    return _funcNormSet ? _funcNormSet.get() : _function.nset();
+  }
+
   // Function pointer and integrands list
   mutable RooSetProxy _sumList ; ///< Set of discrete observable over which is summed numerically
   mutable RooSetProxy _intList ; ///< Set of continuous observables over which is integrated numerically

--- a/roofit/roofitcore/src/RooGenProdProj.cxx
+++ b/roofit/roofitcore/src/RooGenProdProj.cxx
@@ -256,11 +256,13 @@ RooAbsReal* RooGenProdProj::makeIntegral(const char* name, const RooArgSet& comp
 
 double RooGenProdProj::evaluate() const
 {
-  double nom = ((RooAbsReal*)_intList.at(0))->getVal() ;
+  RooArgSet const* nset = _intList.nset();
+
+  double nom = static_cast<RooAbsReal*>(_intList.at(0))->getVal(nset);
 
   if (!_haveD) return nom ;
 
-  double den = ((RooAbsReal*)_intList.at(1))->getVal() ;
+  double den = static_cast<RooAbsReal*>(_intList.at(1))->getVal(nset);
 
   //cout << "RooGenProdProj::eval(" << GetName() << ") nom = " << nom << " den = " << den << endl ;
 

--- a/roofit/roofitcore/src/RooRealIntegral.cxx
+++ b/roofit/roofitcore/src/RooRealIntegral.cxx
@@ -695,10 +695,10 @@ bool RooRealIntegral::initNumIntegrator() const
   // Bind the appropriate analytic integral (specified by _mode) of our RooRealVar object to
   // those of its arguments that will be integrated out numerically.
   if(_mode != 0) {
-    _numIntegrand = std::make_unique<RooRealAnalytic>(*_function,_intList,_mode,_funcNormSet.get(),_rangeName);
+    _numIntegrand = std::make_unique<RooRealAnalytic>(*_function,_intList,_mode,funcNormSet(),_rangeName);
   }
   else {
-    _numIntegrand = std::make_unique<RooRealBinding>(*_function,_intList,_funcNormSet.get(),false,_rangeName);
+    _numIntegrand = std::make_unique<RooRealBinding>(*_function,_intList,funcNormSet(),false,_rangeName);
   }
   if(0 == _numIntegrand || !_numIntegrand->isValid()) {
     coutE(Integration) << ClassName() << "::" << GetName() << ": failed to create valid integrand." << std::endl;
@@ -918,7 +918,7 @@ double RooRealIntegral::evaluate() const
       assert(servers().size() == _facList.size() + 1);
 
       //setDirtyInhibit(true) ;
-      retVal= _function->getVal(_funcNormSet.get()) ;
+      retVal= _function->getVal(funcNormSet());
       //setDirtyInhibit(false) ;
       break ;
     }


### PR DESCRIPTION
In the RooRealIntegral and RooGenProdProj classes, the normalization sets were so far not forwarded to the servers, which resulted in undefined normalization sets for integrated PDFs as reported in #11476.

A unit test that covers #11476 and the related JIRA issue ROOT-9436 is also implemented.

Closes #11476.