### PR TITLE
[RF] Correct RooPoisson integral if integrated from a > 0 to infinity

### DIFF
--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -87,8 +87,11 @@ double RooPoisson::analyticalIntegral(Int_t code, const char* rangeName) const
 {
   R__ASSERT(code == 1 || code == 2) ;
 
-  if(_protectNegative && mean<0)
-    return exp(-2*mean); // make it fall quickly
+  const double mu = mean; // evaluating the proxy once for less overhead
+
+  if(_protectNegative && mu < 0.0) {
+    return std::exp(-2.0 * mu); // make it fall quickly
+  }
 
   if (code == 1) {
     // Implement integral over x as summation. Add special handling in case
@@ -99,8 +102,11 @@ double RooPoisson::analyticalIntegral(Int_t code, const char* rangeName) const
     if (xmax < 0. || xmax < xmin) {
       return 0.;
     }
-    if ((!x.hasMax() || RooNumber::isInfinite(xmax)) && xmin <= 0.0) {
-      //Integrating the full Poisson distribution here
+    const double delta = 100.0 * std::sqrt(mu);
+    // If the limits are more than many standard deviations away from the mean,
+    // we might as well return the integral of the full Poisson distribution to
+    // save computing time.
+    if (xmin < std::max(mu - delta, 0.0) && xmax > mu + delta) {
       return 1.;
     }
 
@@ -111,16 +117,16 @@ double RooPoisson::analyticalIntegral(Int_t code, const char* rangeName) const
 
     // Sum from 0 to just before the bin outside of the range.
     if (ixmin == 0) {
-      return ROOT::Math::poisson_cdf(ixmax - 1, mean);
+      return ROOT::Math::poisson_cdf(ixmax - 1, mu);
     }
     else {
       // If necessary, subtract from 0 to the beginning of the range
-      if (ixmin <= mean) {
-        return ROOT::Math::poisson_cdf(ixmax - 1, mean) - ROOT::Math::poisson_cdf(ixmin - 1, mean);
+      if (ixmin <= mu) {
+        return ROOT::Math::poisson_cdf(ixmax - 1, mu) - ROOT::Math::poisson_cdf(ixmin - 1, mu);
       }
       else {
         //Avoid catastrophic cancellation in the high tails:
-        return ROOT::Math::poisson_cdf_c(ixmin - 1, mean) - ROOT::Math::poisson_cdf_c(ixmax - 1, mean);
+        return ROOT::Math::poisson_cdf_c(ixmin - 1, mu) - ROOT::Math::poisson_cdf_c(ixmax - 1, mu);
       }
 
     }
@@ -128,18 +134,15 @@ double RooPoisson::analyticalIntegral(Int_t code, const char* rangeName) const
   } else if(code == 2) {
 
     // the integral with respect to the mean is the integral of a gamma distribution
-    double mean_min = mean.min(rangeName);
-    double mean_max = mean.max(rangeName);
 
-    double ix;
-    if(_noRounding) ix = x + 1;
-    else ix = Int_t(TMath::Floor(x)) + 1.0; // negative ix does not need protection (gamma returns 0.0)
+    // negative ix does not need protection (gamma returns 0.0)
+    const double ix = _noRounding ? x + 1 : int(TMath::Floor(x)) + 1.0;
 
-    return ROOT::Math::gamma_cdf(mean_max, ix, 1.0) - ROOT::Math::gamma_cdf(mean_min, ix, 1.0);
+    using ROOT::Math::gamma_cdf;
+    return gamma_cdf(mean.max(rangeName), ix, 1.0) - gamma_cdf(mean.min(rangeName), ix, 1.0);
   }
 
-  return 0;
-
+  return 0.0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofit/src/RooPoisson.cxx
+++ b/roofit/roofit/src/RooPoisson.cxx
@@ -99,7 +99,7 @@ double RooPoisson::analyticalIntegral(Int_t code, const char* rangeName) const
     if (xmax < 0. || xmax < xmin) {
       return 0.;
     }
-    if (!x.hasMax() || RooNumber::isInfinite(xmax)) {
+    if ((!x.hasMax() || RooNumber::isInfinite(xmax)) && xmin <= 0.0) {
       //Integrating the full Poisson distribution here
       return 1.;
     }

--- a/roofit/roofit/test/testRooPoisson.cxx
+++ b/roofit/roofit/test/testRooPoisson.cxx
@@ -1,5 +1,6 @@
 // Tests for the RooPoisson
 // Authors: Stephan Hageboeck, CERN  01/2019
+//          Jonas Rembser, CERN  11/2022
 
 #include "RooRealVar.h"
 #include "RooPoisson.h"
@@ -131,4 +132,45 @@ TEST(RooPoisson, AnalyticalIntegral)
         - ROOT::Math::poisson_cdf_c(max, lambdaVal));
     }
   }
+}
+
+namespace {
+
+double getPoissonIntegral(double a, double b, double muVal)
+{
+   using namespace RooFit;
+
+   RooRealVar x{"x", "x", a, b};
+   RooRealVar mu{"mu", "mu", muVal};
+   RooPoisson poisson{"poisson", "poisson", x, mu};
+
+   return std::unique_ptr<RooAbsReal>{poisson.createIntegral(x)}->getVal();
+}
+
+} // namespace
+
+// Covers GitHub issue #10868 about the wrong integral for RooPoisson if
+// integrated from a > 0 to infinity.
+TEST(RooPoisson, IntegralFromMinGreaterZero)
+{
+   const double mu = 100;
+   const double inf = std::numeric_limits<double>::max();
+
+   // 1. Should be 1 because the probability to have x greater than 100000 is
+   // basically zero.
+   const double intVal1 = getPoissonIntegral(0, 100000, mu);
+   EXPECT_FLOAT_EQ(intVal1, 1.0);
+
+   // 2. Should be around 0.5, as the range of x is from the mean of the
+   // Poisson to basically infinity.
+   const double intVal2 = getPoissonIntegral(100, 100000, mu);
+   EXPECT_FLOAT_EQ(intVal2, 1.0 - ROOT::Math::poisson_cdf(100 - 1, mu));
+
+   // 3. Should be the same as the first integral
+   const double intVal3 = getPoissonIntegral(0, inf, mu);
+   EXPECT_FLOAT_EQ(intVal3, intVal1);
+
+   // 4. Should be the same as the second integral but it isn't!
+   const double intVal4 = getPoissonIntegral(100, inf, mu);
+   EXPECT_FLOAT_EQ(intVal4, intVal2);
 }


### PR DESCRIPTION
In the RooPoisson integration code, it is hardcoded to return 1.0 if the upper boundary is infinite. But this should only be done if the lower boundary is not greater than zero.

Closes #10868.