### PR TITLE
[tmvagui] Fix snprintf warning:

### DIFF
--- a/tmva/tmvagui/src/rulevisCorr.cxx
+++ b/tmva/tmvagui/src/rulevisCorr.cxx
@@ -169,16 +169,16 @@ void TMVA::rulevisCorr( TDirectory *rfdir, TDirectory *vardir, TDirectory *corrd
 
          // create new canvas
          if ((c[countCanvas]==NULL) || (countPad>noPad)) {
-            char cn[20];
-            snprintf( cn, 20, "rulecorr%d_", countCanvas+1 );
-            TString cname(cn);
+            TString cname("rulecorr");
+            cname += countCanvas + 1;
+            cname += "_";
             cname += rfdir->GetName();
             c[countCanvas] = new TCanvas( cname, maintitle,
                                           countCanvas*50+200, countCanvas*20, width, height ); 
             // style
             c[countCanvas]->Divide(xPad,yPad);
             countPad = 1;
-         }       
+         }
          // save canvas to file
          TPad *cPad = (TPad *)(c[countCanvas]->GetPad(countPad));
          c[countCanvas]->cd(countPad);

--- a/tmva/tmvagui/src/rulevisHists.cxx
+++ b/tmva/tmvagui/src/rulevisHists.cxx
@@ -150,16 +150,16 @@ void TMVA::rulevisHists( TDirectory *rfdir, TDirectory *vardir, TDirectory *corr
       if (hname.Contains("__S")){ // found a new signal plot
          // create new canvas
          if ((c[countCanvas]==NULL) || (countPad>noPad)) {
-            char cn[20];
-            snprintf( cn, 20, "rulehist%d_", countCanvas+1 );
-            TString cname(cn);
+            TString cname("rulehist");
+            cname += countCanvas + 1;
+            cname += "_";
             cname += rfdir->GetName();
             c[countCanvas] = new TCanvas( cname, maintitle,
                                           countCanvas*50+200, countCanvas*20, width, height ); 
             // style
             c[countCanvas]->Divide(xPad,yPad);
             countPad = 1;
-         }       
+         }
 
          // save canvas to file
          TPad *cPad = (TPad *)(c[countCanvas]->GetPad(countPad));


### PR DESCRIPTION
```
rulevisCorr.cxx:173:43: error: ‘snprintf’ output may be truncated before the last format character [-Werror=format-truncation=]
  173 |             snprintf( cn, 20, "rulecorr%d_", countCanvas+1 );
      |                                           ^
rulevisCorr.cxx:173:21: note: ‘snprintf’ output between 11 and 21 bytes into a destination of size 20
  173 |             snprintf( cn, 20, "rulecorr%d_", countCanvas+1 );
      |             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

