### PR TITLE
Avoid out-of-bounds vector element access

### DIFF
--- a/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.icc
+++ b/tmva/sofie/inc/TMVA/ROperator_ConvTranspose.icc
@@ -268,7 +268,9 @@ std::string ROperator_ConvTranspose<T>::Generate(std::string OpName)
    size_t iw = fDim - 1;
    size_t wstrideDil = fAttrDilations[iw];
    size_t hstride = kWidth;
-   size_t hstrideDil = fAttrKernelShape[iw] * fAttrDilations[ih];
+   size_t hstrideDil = fAttrKernelShape[iw];
+   if (fDim > 1)
+      hstrideDil *= fAttrDilations[ih];
    // stride dilated in the height
    size_t dstride = kHeight * kWidth;
    size_t dstrideDil = fAttrKernelShape[iw];
@@ -349,8 +351,6 @@ std::string ROperator_ConvTranspose<T>::Generate(std::string OpName)
                    << std::endl;
          fAttrPads[0] = (fAttrPads[0] + fAttrPads[1]) / 2;
       }
-      fAttrPads[1] = 0;
-      fAttrStrides[1] = 1;
    }
    if (fDim == 2) {
       if (fAttrPads[0] != fAttrPads[2] || fAttrPads[1] != fAttrPads[3]) {


### PR DESCRIPTION
# This Pull request:

This PR fixes a build failure due to out-of-bounds vector element access in SOFIE.

## Changes or fixes:
~~~~
cd <SRCDIR>/redhat-linux-build/tmva/sofie/test && /usr/bin/cmake -E env ROOTIGNOREPREFIX=1 ./emitFromONNX <SRCDIR>/tmva/sofie/test/input_models/ConvTranspose1d.onnx <SRCDIR>/redhat-linux-build/tmva/sofie/test/ConvTranspose1d
/usr/include/c++/12/bits/stl_vector.h:1123: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = long unsigned int; _Alloc = std::allocator<long unsigned int>; reference = long unsigned int&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Subprocess aborted
gmake[2]: *** [tmva/sofie/test/CMakeFiles/SofieCompileModels_ONNX.dir/build.make:84: SofieCompileModels_ONNX] Error 1
gmake[2]: Leaving directory '<SRCDIR>/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:50024: tmva/sofie/test/CMakeFiles/SofieCompileModels_ONNX.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
~~~~


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

