### PR TITLE
[VecOps] Fix compilation errors in case of RVec of move-only types

### DIFF
--- a/math/vecops/test/vecops_rvec.cxx
+++ b/math/vecops/test/vecops_rvec.cxx
@@ -128,6 +128,21 @@ TEST(VecOps, MoveCtor)
    EXPECT_EQ(v2.size(), 3u);
 }
 
+// regression test: this used to fail to compile
+TEST(VecOps, MoveOnlyValue)
+{
+   struct MoveOnly {
+      MoveOnly() = default;
+      MoveOnly(const MoveOnly &) = delete;
+      MoveOnly &operator=(const MoveOnly &) = delete;
+      MoveOnly(MoveOnly &&) = default;
+      MoveOnly &operator=(MoveOnly &&) = default;
+   };
+   ROOT::RVec<MoveOnly> v(10);
+   v.resize(20);
+   v[19] = MoveOnly();
+}
+
 TEST(VecOps, Conversion)
 {
    RVec<float> fvec{1.0f, 2.0f, 3.0f};


### PR DESCRIPTION
Before this commit, calling `RVec<T> v(n)` where `T` is a move-only type would fail to compile because, internally, the operation was implemented in terms of a std::uninitalized_fill of the first `n` elements in the buffer, and std::uninitalized_fill needs the type to be copy-assignable.

With this patch we use (a backport of) C++17's
std::uninitialized_value_construct instead for that case, which is works for move-only types as well.