### PR TITLE
[RF] Fixes for using MultiProcess LikelihoodJob

### DIFF
--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -21,7 +21,10 @@
 RooMinimizer is a wrapper class around ROOT::Fit:Fitter that
 provides a seamless interface between the minimizer functionality
 and the native RooFit interface.
-The Minimizer is MINUIT or MINUIT2 depending on configuration.
+By default the Minimizer is MINUIT for classic mode and MINUIT2
+for parallelized mode (activated with the `RooFit::NewStyle(true)`
+parameter or by passing a RooRealL function as the minimization
+target).
 RooMinimizer can minimize any RooAbsReal function with respect to
 its parameters. Usual choices for minimization are RooNLLVar
 and RooChi2Var

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodJob.cxx
@@ -275,7 +275,10 @@ void LikelihoodJob::evaluate_task(std::size_t task)
 void LikelihoodJob::enableOffsetting(bool flag)
 {
    LikelihoodWrapper::enableOffsetting(flag);
-   updateWorkersOffsetting();
+   if (RooFit::MultiProcess::JobManager::is_instantiated()) {
+      printf("WARNING: when calling MinuitFcnGrad::setOffsetting after the run has already been started the MinuitFcnGrad::likelihood_in_gradient object (a LikelihoodSerial) on the workers can no longer be updated! This function (LikelihoodJob::enableOffsetting) can in principle be used outside of MinuitFcnGrad, but be aware of this limitation. To do a minimization with a different offsetting setting, please delete all RooFit::MultiProcess based objects so that the forked processes are killed and then set up a new RooMinimizer.\n");
+      updateWorkersOffsetting();
+   }
 }
 
 #define PROCESS_VAL(p) \

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -270,6 +270,7 @@ bool MinuitFcnGrad::Synchronize(std::vector<ROOT::Fit::ParameterSettings> &param
    }
    gradient->synchronizeParameterSettings(parameters);
 
+   likelihood->synchronizeWithMinimizer(_context->fitter()->Config().MinimizerOptions());
    if (likelihood != likelihood_in_gradient) {
       likelihood_in_gradient->synchronizeWithMinimizer(_context->fitter()->Config().MinimizerOptions());
    }

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.cxx
@@ -56,7 +56,7 @@ MinuitFcnGrad::MinuitFcnGrad(const std::shared_ptr<RooFit::TestStatistics::RooAb
    calculation_is_clean = std::make_shared<WrapperCalculationCleanFlags>();
 
    likelihood = LikelihoodWrapper::create(likelihoodMode, _likelihood, calculation_is_clean);
-   if (likelihoodGradientMode == LikelihoodGradientMode::multiprocess) {
+   if (likelihoodMode == LikelihoodMode::multiprocess && likelihoodGradientMode == LikelihoodGradientMode::multiprocess) {
       likelihood_in_gradient = LikelihoodWrapper::create(LikelihoodMode::serial, _likelihood, calculation_is_clean);
    } else {
       likelihood_in_gradient = likelihood;

--- a/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
+++ b/roofit/roofitcore/src/TestStatistics/MinuitFcnGrad.h
@@ -47,6 +47,9 @@ public:
    inline void setOptimizeConstOnFunction(RooAbsArg::ConstOpCode opcode, bool doAlsoTrackingOpt) override
    {
       likelihood->constOptimizeTestStatistic(opcode, doAlsoTrackingOpt);
+      if (likelihood != likelihood_in_gradient) {
+         likelihood_in_gradient->constOptimizeTestStatistic(opcode, doAlsoTrackingOpt);
+      }
    }
 
    bool fit(ROOT::Fit::Fitter &fitter) const override { return fitter.FitFCN(*this); };
@@ -69,7 +72,13 @@ public:
 
    inline std::string getFunctionTitle() const override { return likelihood->GetTitle(); }
 
-   inline void setOffsetting(bool flag) override { likelihood->enableOffsetting(flag); }
+   inline void setOffsetting(bool flag) override
+   {
+      likelihood->enableOffsetting(flag);
+      if (likelihood != likelihood_in_gradient) {
+         likelihood_in_gradient->enableOffsetting(flag);
+      }
+   }
 
 private:
    /// This override should not be used in this class, so it throws.


### PR DESCRIPTION
# This Pull request:

Note that this PR includes the commit of #11716.

## Changes or fixes:

Apart from the stuff in #11716, this PR fixes the additions previously made in #10966. The implementation there had some bugs, most importantly:

1. Creation went wrong when using MultiProcess-mode for the gradient, but serial mode for the likelihood. This led to larger differences from full-serial mode than expected. We can now tighten expectations in tests again due to this fix.
2. Double-MultiProcess-mode (both gradient and likelihood) did not work when using offsetting, because setOffsetting would not propagate to worker processes correctly for all involved objects. This is now fixed as well.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)