### PR TITLE
Use Canvas.UseScreenFactor on high resolution screens

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -298,7 +298,7 @@ void TApplication::InitializeGraphics()
       UInt_t w, h;
       if (gVirtualX) {
          gVirtualX->GetGeometry(-1, x, y, w, h);
-         if (h > 0 && h < 1000) gStyle->SetScreenFactor(0.0011*h);
+         if (h > 0) gStyle->SetScreenFactor(0.001*h);
       }
    }
 }

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -299,7 +299,7 @@ void TApplication::InitializeGraphics()
       if (gVirtualX) {
          gVirtualX->GetGeometry(-1, x, y, w, h);
          if (h > 0)
-            gStyle->SetScreenFactor(0.001*h);
+            gStyle->SetScreenFactor(0.001 * h);
       }
    }
 }

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -298,7 +298,8 @@ void TApplication::InitializeGraphics()
       UInt_t w, h;
       if (gVirtualX) {
          gVirtualX->GetGeometry(-1, x, y, w, h);
-         if (h > 0) gStyle->SetScreenFactor(0.001*h);
+         if (h > 0)
+            gStyle->SetScreenFactor(0.001*h);
       }
    }
 }

--- a/gui/gui/src/TGApplication.cxx
+++ b/gui/gui/src/TGApplication.cxx
@@ -108,7 +108,7 @@ TGApplication::TGApplication(const char *appClassName,
       UInt_t w, h;
       if (gVirtualX) {
          gVirtualX->GetGeometry(-1, x, y, w, h);
-         if (h > 0 && h < 1000) gStyle->SetScreenFactor(0.0011*h);
+         if (h > 0) gStyle->SetScreenFactor(0.001*h);
       }
    }
 

--- a/gui/gui/src/TGApplication.cxx
+++ b/gui/gui/src/TGApplication.cxx
@@ -109,7 +109,7 @@ TGApplication::TGApplication(const char *appClassName,
       if (gVirtualX) {
          gVirtualX->GetGeometry(-1, x, y, w, h);
          if (h > 0)
-            gStyle->SetScreenFactor(0.001*h);
+            gStyle->SetScreenFactor(0.001 * h);
       }
    }
 

--- a/gui/gui/src/TGApplication.cxx
+++ b/gui/gui/src/TGApplication.cxx
@@ -108,7 +108,8 @@ TGApplication::TGApplication(const char *appClassName,
       UInt_t w, h;
       if (gVirtualX) {
          gVirtualX->GetGeometry(-1, x, y, w, h);
-         if (h > 0) gStyle->SetScreenFactor(0.001*h);
+         if (h > 0)
+            gStyle->SetScreenFactor(0.001*h);
       }
    }
 


### PR DESCRIPTION
Allow to use the `Canvas.UseScreenFactor` entry in `system.rootrc` to automatically resize the `TCanvas` and `TBrowser` on high resolution displays