### PR TITLE
[tmva][sofie] Exclude SOFIE test when blas is not found

### DIFF
--- a/tmva/sofie/test/CMakeLists.txt
+++ b/tmva/sofie/test/CMakeLists.txt
@@ -49,6 +49,7 @@ foreach(onnx_file ${ONNX_FILES})
 endforeach()
 
 # Creating a Google Test
+if (tmva-cpu)  # we need BLAS for compiling the models
 ROOT_ADD_GTEST(TestCustomModelsFromONNX TestCustomModelsFromONNX.cxx
   LIBRARIES
     ROOTTMVASofie
@@ -59,7 +60,7 @@ ROOT_ADD_GTEST(TestCustomModelsFromONNX TestCustomModelsFromONNX.cxx
 )
 
 add_dependencies(TestCustomModelsFromONNX SofieCompileModels_ONNX)
-
+endif()
 
 #For testing serialisation of RModel object
 add_executable(emitFromROOT
@@ -98,6 +99,7 @@ foreach(onnx_file ${ONNX_FILES})
 endforeach()
 
 # Creating a Google Test for Serialisation of RModel
+if (tmva-cpu)
 ROOT_ADD_GTEST(TestCustomModelsFromROOT TestCustomModelsFromROOT.cxx
   LIBRARIES
     ROOTTMVASofie
@@ -107,6 +109,7 @@ ROOT_ADD_GTEST(TestCustomModelsFromROOT TestCustomModelsFromROOT.cxx
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 add_dependencies(TestCustomModelsFromROOT SofieCompileModels_ROOT)
+endif()
 
 # gtest
 # Look for needed python modules
@@ -119,6 +122,7 @@ if(PY_TORCH_FOUND)
   configure_file(LinearModelGenerator.py  LinearModelGenerator.py COPYONLY)
   configure_file(RecurrentModelGenerator.py  RecurrentModelGenerator.py COPYONLY)
 
+if (tmva-cpu)
   ROOT_ADD_GTEST(TestSofieModels TestSofieModels.cxx
     LIBRARIES
       ROOTTMVASofie
@@ -128,4 +132,5 @@ if(PY_TORCH_FOUND)
     INCLUDE_DIRS
       ${CMAKE_CURRENT_BINARY_DIR}
   )
+ endif()
 endif()


### PR DESCRIPTION
This Pull request exclude running of SOFIE tests when Blas is not found (this is when `tmva-cpu=Off`)

