### PR TITLE
Use different filename in loopdir.C and loopdir11.C to avoid race condition

### DIFF
--- a/tutorials/io/loopdir11.C
+++ b/tutorials/io/loopdir11.C
@@ -12,14 +12,14 @@
 void loopdir11() {
    TFile *f1 = TFile::Open("hsimple.root");
    TCanvas c1;
-   c1.Print("hsimple.ps[");
+   c1.Print("hsimple11.ps[");
    for(auto k : *f1->GetListOfKeys()) {
       TKey *key = static_cast<TKey*>(k);
       TClass *cl = gROOT->GetClass(key->GetClassName());
       if (!cl->InheritsFrom("TH1")) continue;
       TH1 *h = key->ReadObject<TH1>();
       h->Draw();
-      c1.Print("hsimple.ps");
+      c1.Print("hsimple11.ps");
    }
-   c1.Print("hsimple.ps]");
+   c1.Print("hsimple11.ps]");
 }


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

~~~~
          Start  672: tutorial-io-loopdir
 690/1156 Test  #666: tutorial-io-double32 ................................................   Passed    2.42 sec
          Start  673: tutorial-io-loopdir11
 691/1156 Test  #673: tutorial-io-loopdir11 ...............................................   Passed    0.76 sec
          Start  674: tutorial-io-mergeSelective
 692/1156 Test  #672: tutorial-io-loopdir .................................................***Failed  Error regular expression found in output. Regex=[Error in <]  1.23 sec
Processing /builddir/build/BUILD/root-6.26.10/tutorials/io/loopdir.C...
Info in <TCanvas::Print>: ps file hsimple.ps has been created
Info in <TCanvas::Print>: Current canvas added to ps file hsimple.ps
Info in <TCanvas::Print>: Current canvas added to ps file hsimple.ps
Info in <TCanvas::Print>: Current canvas added to ps file hsimple.ps
Info in <TCanvas::Print>: ps file hsimple.ps has been closed
Error in <TPostScript::Text>: Cannot open temporary file: hsimple.ps_tmp_2089748
~~~~

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
