### PR TITLE
[webcanvas] TExec support, sub-pads update

### DIFF
--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -58,20 +58,20 @@ protected:
       WebConn(unsigned id) : fConnId(id) {}
    };
 
-   struct PadModified {
+   struct PadStatus {
       Long64_t fVersion{0};    ///<! last pad version
       bool _detected{false};   ///<! if pad was detected during last scan
       bool _modified{false};   ///<! if pad was modified during last scan
+      bool _has_specials{false}; ///<! are there any special objects with painting
    };
 
    std::vector<WebConn> fWebConn;  ///<! connections
 
-   std::map<TPad*, PadModified> fPadModified; ///<! map of pads in canvas and their modified flags
+   std::map<TPad*, PadStatus> fPadsStatus; ///<! map of pads in canvas and their status flags
 
    std::shared_ptr<ROOT::Experimental::RWebWindow> fWindow; ///!< configured display
 
    Bool_t fReadOnly{true};         ///<! in read-only mode canvas cannot be changed from client side
-   Bool_t fHasSpecials{false};     ///<! has special objects which may require pad ranges
    Long64_t fCanvVersion{1};       ///<! actual canvas version, changed with every new Modified() call
    UInt_t fClientBits{0};          ///<! latest status bits from client like editor visible or not
    TList fPrimitivesLists;         ///<! list of lists of primitives, temporary collected during painting
@@ -124,7 +124,7 @@ protected:
 
    virtual Bool_t ProcessData(unsigned connid, const std::string &arg);
 
-   virtual Bool_t DecodePadOptions(const std::string &);
+   virtual Bool_t DecodePadOptions(const std::string &, bool process_execs = false);
 
    virtual Bool_t CanCreateObject(const std::string &) { return !IsReadOnly() && fCanCreateObjects; }
 
@@ -132,7 +132,7 @@ protected:
 
    TObject *FindPrimitive(const std::string &id, int idcnt = 1, TPad *pad = nullptr, TObjLink **padlnk = nullptr, TPad **objpad = nullptr);
 
-   Bool_t ProcessTExec(TList *primitves);
+   void ProcessPadExecs(TPad *pad);
 
 public:
    TWebCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Bool_t readonly = kTRUE);

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <queue>
 #include <functional>
+#include <map>
 
 class TPad;
 class TPadWebSnapshot;
@@ -57,7 +58,15 @@ protected:
       WebConn(unsigned id) : fConnId(id) {}
    };
 
+   struct PadModified {
+      Long64_t fVersion{0};    ///<! last pad version
+      bool _detected{false};   ///<! if pad was detected during last scan
+      bool _modified{false};   ///<! if pad was modified during last scan
+   };
+
    std::vector<WebConn> fWebConn;  ///<! connections
+
+   std::map<TPad*, PadModified> fPadModified; ///<! map of pads in canvas and their modified flags
 
    std::shared_ptr<ROOT::Experimental::RWebWindow> fWindow; ///!< configured display
 
@@ -95,7 +104,9 @@ protected:
    void CreateObjectSnapshot(TPadWebSnapshot &master, TPad *pad, TObject *obj, const char *opt, TWebPS *masterps = nullptr);
    void CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t version, PadPaintingReady_t func);
 
-   Bool_t CheckPadModified(TPad *pad, Int_t inc_version = 1);
+   void CheckPadModified(TPad *pad);
+
+   void CheckCanvasModified();
 
    Bool_t AddToSendQueue(unsigned connid, const std::string &msg);
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -53,10 +53,17 @@ protected:
 
    struct WebConn {
       unsigned fConnId{0};             ///<! connection id
+      Long64_t fCheckedVersion{0};     ///<! canvas version checked before sending
       Long64_t fSendVersion{0};        ///<! canvas version send to the client
       Long64_t fDrawVersion{0};        ///<! canvas version drawn (confirmed) by client
+      UInt_t fLastSendHash{0};         ///<! hash of last send draw message, avoid looping
       std::queue<std::string> fSend;   ///<! send queue, processed after sending draw data
       WebConn(unsigned id) : fConnId(id) {}
+      void reset()
+      {
+         fCheckedVersion = fSendVersion = fDrawVersion = 0;
+         fLastSendHash = 0;
+      }
    };
 
    struct PadStatus {

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -29,6 +29,7 @@ class TPad;
 class TPadWebSnapshot;
 class TWebPS;
 class TObjLink;
+class TExec;
 
 class TWebCanvas : public TCanvasImp {
 
@@ -132,7 +133,7 @@ protected:
 
    TObject *FindPrimitive(const std::string &id, int idcnt = 1, TPad *pad = nullptr, TObjLink **padlnk = nullptr, TPad **objpad = nullptr);
 
-   void ProcessPadExecs(TPad *pad);
+   void ProcessExecs(TPad *pad, TExec *extra = nullptr);
 
 public:
    TWebCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height, Bool_t readonly = kTRUE);

--- a/gui/webgui6/inc/TWebPadOptions.h
+++ b/gui/webgui6/inc/TWebPadOptions.h
@@ -34,6 +34,7 @@ class TWebPadOptions {
 public:
    std::string snapid;                        ///< id of pad
    bool active{false};                        ///< if pad selected as active
+   int cw{0}, ch{0};                          ///< canvas width and height in pixels
    int logx{0}, logy{0}, logz{0};             ///< pad log properties
    int gridx{0}, gridy{0};                    ///< pad grid properties
    int tickx{0}, ticky{0};                    ///< pad ticks properties

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -89,14 +89,11 @@ public:
 
 class TCanvasWebSnapshot : public TPadWebSnapshot {
 protected:
-   Long64_t fVersion{0};           ///< actual canvas version
    std::string fScripts;           ///< custom scripts to load
    bool fHighlightConnect{false};  ///< does HighlightConnect has connection
 public:
    TCanvasWebSnapshot() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
-   TCanvasWebSnapshot(bool readonly, Long64_t v) : TPadWebSnapshot(readonly), fVersion(v) {}
-
-   Long64_t GetVersion() const { return fVersion; }
+   TCanvasWebSnapshot(bool readonly) : TPadWebSnapshot(readonly) {}
 
    void SetScripts(const std::string &src) { fScripts = src; }
    const std::string &GetScripts() const { return fScripts; }
@@ -104,7 +101,7 @@ public:
    void SetHighlightConnect(bool on = true) { fHighlightConnect = on; }
    bool GetHighlightConnect() const { return fHighlightConnect; }
 
-   ClassDef(TCanvasWebSnapshot, 2) // Canvas painting snapshot, used for JSROOT
+   ClassDef(TCanvasWebSnapshot, 3) // Canvas painting snapshot, used for JSROOT
 };
 
 

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -60,6 +60,7 @@ class TPadWebSnapshot : public TWebSnapshot {
 protected:
    bool fActive{false};                                    ///< true when pad is active
    bool fReadOnly{true};                                   ///< when canvas or pad are in readonly mode
+   bool fWithoutPrimitives{false};                         ///< true when primitives not send while there are no modifications
    std::vector<std::unique_ptr<TWebSnapshot>> fPrimitives; ///< list of all primitives, drawn in the pad
 
 public:
@@ -71,6 +72,8 @@ public:
 
    void SetActive(bool on = true) { fActive = on; }
 
+   void SetWithoutPrimitives(bool on = true) { fWithoutPrimitives = on; }
+
    bool IsReadOnly() const { return fReadOnly; }
 
    TWebSnapshot &NewPrimitive(TObject *obj = nullptr, const std::string &opt = "");
@@ -79,7 +82,7 @@ public:
 
    TWebSnapshot &NewSpecials();
 
-   ClassDef(TPadWebSnapshot, 1) // Pad painting snapshot, used for JSROOT
+   ClassDef(TPadWebSnapshot, 2) // Pad painting snapshot, used for JSROOT
 };
 
 // =================================================================================

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -843,17 +843,29 @@ Bool_t TWebCanvas::DecodePadOptions(const std::string &msg, bool process_execs)
 
       // pad->SetPad(r.mleft, r.mbottom, 1-r.mright, 1-r.mtop);
 
-      change_pad_member("fXlowNDC", r.xlow);
-      change_pad_member("fYlowNDC", r.ylow);
-      change_pad_member("fXUpNDC", r.xup);
-      change_pad_member("fYUpNDC", r.yup);
-      change_pad_member("fWNDC", r.xup - r.xlow);
-      change_pad_member("fHNDC", r.yup - r.ylow);
-
       change_pad_member("fAbsXlowNDC", r.xlow);
       change_pad_member("fAbsYlowNDC", r.ylow);
       change_pad_member("fAbsWNDC", r.xup - r.xlow);
       change_pad_member("fAbsHNDC", r.yup - r.ylow);
+
+      if (pad == Canvas()) {
+         change_pad_member("fXlowNDC", r.xlow);
+         change_pad_member("fYlowNDC", r.ylow);
+         change_pad_member("fXUpNDC", r.xup);
+         change_pad_member("fYUpNDC", r.yup);
+         change_pad_member("fWNDC", r.xup - r.xlow);
+         change_pad_member("fHNDC", r.yup - r.ylow);
+      } else {
+         auto mother = pad->GetMother();
+         if (mother->GetAbsWNDC() > 0. && mother->GetAbsHNDC() > 0.) {
+            change_pad_member("fXlowNDC", (r.xlow - mother->GetAbsXlowNDC()) / mother->GetAbsWNDC());
+            change_pad_member("fYlowNDC", (r.ylow - mother->GetAbsYlowNDC()) / mother->GetAbsHNDC());
+            change_pad_member("fXUpNDC", (r.xup - mother->GetAbsXlowNDC()) / mother->GetAbsWNDC() );
+            change_pad_member("fYUpNDC", (r.yup - mother->GetAbsYlowNDC()) / mother->GetAbsHNDC());
+            change_pad_member("fWNDC", (r.xup - r.xlow) / mother->GetAbsWNDC());
+            change_pad_member("fHNDC", (r.yup - r.ylow) / mother->GetAbsHNDC() );
+         }
+      }
 
       // copy of code from TPad::ResizePad()
 

--- a/js/modules/base/BasePainter.mjs
+++ b/js/modules/base/BasePainter.mjs
@@ -47,7 +47,7 @@ function getElementRect(elem, sizearg) {
 /** @summary Calculate absolute position of provided element in canvas
   * @private */
 function getAbsPosInCanvas(sel, pos) {
-   while (!sel.empty() && !sel.classed('root_canvas') && pos) {
+   while (pos && !sel.empty() && !sel.classed('root_canvas')) {
       let cl = sel.attr('class');
       if (cl && ((cl.indexOf('root_frame') >= 0) || (cl.indexOf('__root_pad_') >= 0))) {
          pos.x += sel.property('draw_x') || 0;

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '19/11/2021' */
-let version_date = '15/11/2022';
+let version_date = '17/11/2022';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gpad/RPadPainter.mjs
+++ b/js/modules/gpad/RPadPainter.mjs
@@ -227,28 +227,28 @@ class RPadPainter extends RObjectPainter {
    /** @summary Generate pad events, normally handled by GED
      * @desc in pad painter, while pad may be drawn without canvas
      * @private */
-   producePadEvent(_what, _padpainter, _painter, _position, _place) {
-      if ((_what == 'select') && isFunc(this.selectActivePad))
-         this.selectActivePad(_padpainter, _painter, _position);
+   producePadEvent(what, padpainter, painter, position, place) {
+      if ((what == 'select') && isFunc(this.selectActivePad))
+         this.selectActivePad(padpainter, painter, position);
 
       if (this.pad_events_receiver)
-         this.pad_events_receiver({ what: _what, padpainter:  _padpainter, painter: _painter, position: _position, place: _place });
+         this.pad_events_receiver({ what, padpainter, painter, position, place });
    }
 
    /** @summary method redirect call to pad events receiver */
-   selectObjectPainter(_painter, pos, _place) {
+   selectObjectPainter(painter, pos, place) {
 
       let istoppad = (this.iscan || !this.has_canvas),
           canp = istoppad ? this : this.getCanvPainter();
 
-      if (_painter === undefined) _painter = this;
+      if (painter === undefined) painter = this;
 
       if (pos && !istoppad)
          pos = getAbsPosInCanvas(this.svg_this_pad(), pos);
 
       selectActivePad({ pp: this, active: true });
 
-      canp.producePadEvent('select', this, _painter, pos, _place);
+      canp.producePadEvent('select', this, painter, pos, place);
    }
 
    /** @summary Create SVG element for the canvas */

--- a/js/modules/gpad/TCanvasPainter.mjs
+++ b/js/modules/gpad/TCanvasPainter.mjs
@@ -306,14 +306,15 @@ class TCanvasPainter extends TPadPainter {
          this.closeWebsocket(true);
       } else if (msg.slice(0,6) == 'SNAP6:') {
          // This is snapshot, produced with ROOT6
-
-         let snap = parse(msg.slice(6));
+         let p1 = msg.indexOf(':', 6),
+             version = msg.slice(6, p1),
+             snap = parse(msg.slice(p1+1));
 
          this.syncDraw(true).then(() => this.redrawPadSnap(snap)).then(() => {
             this.completeCanvasSnapDrawing();
             let ranges = this.getWebPadOptions(); // all data, including subpads
             if (ranges) ranges = ':' + ranges;
-            handle.send('READY6:' + snap.fVersion + ranges); // send ready message back when drawing completed
+            handle.send('READY6:' + version + ranges); // send ready message back when drawing completed
             this.confirmDraw();
          });
       } else if (msg.slice(0,5) == 'MENU:') {
@@ -550,7 +551,7 @@ class TCanvasPainter extends TPadPainter {
 
       if (this._last_highlight_msg != msg) {
          this._last_highlight_msg = msg;
-         this.sendWebsocket('HIGHLIGHT:' + msg);
+         this.sendWebsocket(`HIGHLIGHT:${msg}`);
       }
    }
 

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -288,7 +288,8 @@ const TooltipHandler = {
 
    /** @summary central function which let show selected hints for the object */
    processFrameTooltipEvent(pnt, evnt) {
-      if (pnt && pnt.handler) {
+
+      if (pnt?.handler) {
          // special use of interactive handler in the frame painter
          let rect = this.draw_g ? this.draw_g.select('.main_layer') : null;
          if (!rect || rect.empty()) {
@@ -316,7 +317,10 @@ const TooltipHandler = {
       // collect tooltips from pad painter - it has list of all drawn objects
       if (pp) hints = pp.processPadTooltipEvent(pnt);
 
-      if (pnt && pnt.touch) textheight = 15;
+      if (pp?._deliver_webcanvas_events && pp?.is_active_pad && pnt && isFunc(pp?.deliverWebCanvasEvent))
+         pp.deliverWebCanvasEvent('move', frame_rect.x + pnt.x, frame_rect.y + pnt.y, hints);
+
+      if (pnt?.touch) textheight = 15;
 
       for (let n = 0; n < hints.length; ++n) {
          let hint = hints[n];
@@ -326,7 +330,8 @@ const TooltipHandler = {
             hint.painter.provideUserTooltip(hint.user_info);
 
          if (!hint.lines || (hint.lines.length === 0)) {
-            hints[n] = null; continue;
+            hints[n] = null;
+            continue;
          }
 
          // check if fully duplicated hint already exists
@@ -383,7 +388,6 @@ const TooltipHandler = {
       }
 
       this.showObjectStatus(name, title, info, coordinates);
-
 
       // end of closing tooltips
       if (!pnt || disable_tootlips || (hints.length === 0) || (maxlen === 0) || (show_only_best && !best_hint)) {

--- a/tutorials/hist/exec1.C
+++ b/tutorials/hist/exec1.C
@@ -4,15 +4,14 @@
 /// Example of macro called when a pad is redrawn
 /// one must create a TExec object in the following way
 /// ~~~{.cpp}
-/// TExec ex("ex",".x exec1.C");
-/// ex.Draw();
+///    gPad->AddExec("ex1", ".x exec1.C");
 /// ~~~
 /// this macro prints the bin number and the bin content when one clicks
 /// on the histogram contour of any histogram in a pad
 ///
 /// \macro_code
 ///
-/// \author Rene Brun
+/// \authors Rene Brun, Sergey Linev
 
 
 void exec1()
@@ -22,17 +21,16 @@ void exec1()
       return;
    }
 
-   int event = gPad->GetEvent();
-   if (event != 11) return;
+   Int_t event = gPad->GetEvent();
    int px = gPad->GetEventX();
    TObject *select = gPad->GetSelected();
-   if (!select) return;
-   if (select->InheritsFrom(TH1::Class())) {
+
+   if (select && select->InheritsFrom(TH1::Class())) {
       TH1 *h = (TH1*)select;
       Float_t xx = gPad->AbsPixeltoX(px);
       Float_t x  = gPad->PadtoX(xx);
       Int_t binx = h->GetXaxis()->FindBin(x);
-      printf("event=%d, hist:%s, bin=%d, content=%f\n",event,h->GetName(),binx,h->GetBinContent(binx));
+      printf("event=%d, hist:%s, bin=%d, content=%f\n", event, h->GetName(), binx, h->GetBinContent(binx));
    }
 }
 

--- a/tutorials/hist/exec2.C
+++ b/tutorials/hist/exec2.C
@@ -5,9 +5,9 @@
 ///
 /// Example:
 /// ~~~{.cpp}
-/// Root > TFile f("hsimple.root");
-/// Root > hpxpy.Draw();
-/// Root > c1.AddExec("ex2",".x exec2.C");
+///   TFile::Open("hsimple.root");
+///   hpxpy->Draw("colz");
+///   gPad->AddExec("ex2", ".x exec2.C");
 /// ~~~
 /// When moving the mouse in the canvas, a second canvas shows the
 /// projection along X of the bin corresponding to the Y position
@@ -19,52 +19,58 @@
 ///
 /// \macro_code
 ///
-/// \author Rene Brun
+/// \authors Rene Brun, Sergey Linev
 
 void exec2()
 {
-
    if (!gPad) {
       Error("exec2", "gPad is null, you are not supposed to run this macro");
       return;
    }
 
-
-   TObject *select = gPad->GetSelected();
-   if(!select) return;
-   if (!select->InheritsFrom(TH2::Class())) {gPad->SetUniqueID(0); return;}
-   gPad->GetCanvas()->FeedbackMode(kTRUE);
-
-   //erase old position and draw a line at current position
-   int pyold = gPad->GetUniqueID();
    int px = gPad->GetEventX();
    int py = gPad->GetEventY();
    float uxmin = gPad->GetUxmin();
    float uxmax = gPad->GetUxmax();
    int pxmin = gPad->XtoAbsPixel(uxmin);
    int pxmax = gPad->XtoAbsPixel(uxmax);
-   if(pyold) gVirtualX->DrawLine(pxmin,pyold,pxmax,pyold);
-   gVirtualX->DrawLine(pxmin,py,pxmax,py);
+   TObject *select = gPad->GetSelected();
+   TCanvas *c2 = (TCanvas*)gROOT->GetListOfCanvases()->FindObject("c2");
+
+   gPad->GetCanvas()->FeedbackMode(kTRUE);
+
+   int pyold = gPad->GetUniqueID(); // misuse of pad unique for last draw position
+
+   if (pyold && c2) {
+      // erase line at old position
+      gVirtualX->DrawLine(pxmin, pyold, pxmax, pyold);
+      gPad->SetUniqueID(0);
+   }
+
+   TH2 *h = dynamic_cast<TH2 *>(select);
+   if(!h) return;
+
+   //erase old position and draw a line at current position
+   gVirtualX->DrawLine(pxmin, py, pxmax, py);
    gPad->SetUniqueID(py);
+
    Float_t upy = gPad->AbsPixeltoY(py);
    Float_t y = gPad->PadtoY(upy);
 
    //create or set the new canvas c2
-   TVirtualPad *padsav = gPad;
-   TCanvas *c2 = (TCanvas*)gROOT->GetListOfCanvases()->FindObject("c2");
+   auto padsav = gPad;
    if(c2) delete c2->GetPrimitive("Projection");
-   else   c2 = new TCanvas("c2");
+     else c2 = new TCanvas("c2","Projection Canvas",710,10,700,500);
+   c2->SetGrid();
    c2->cd();
 
    //draw slice corresponding to mouse position
-   TH2 *h = (TH2*)select;
    Int_t biny = h->GetYaxis()->FindBin(y);
    TH1D *hp = h->ProjectionX("",biny,biny);
-   char title[80];
-   sprintf(title,"Projection of biny=%d",biny);
    hp->SetName("Projection");
-   hp->SetTitle(title);
+   hp->SetTitle(TString::Format("Projection of biny=%d",biny));
    hp->Fit("gaus","ql");
    c2->Update();
+
    padsav->cd();
 }


### PR DESCRIPTION
1. Process active pad `TExec` when pad click/mouse move event is produced. JSROOT client deliver such events only when execs are configured.  Good example is `hist/DynamicSlice.C` tutorial
2. Process `TExec` from histogram list of functions. Here execs processed when client confirms drawing and returns applied ranges. Working example is `hist/htproj.C` tutorial
3. Analyze modification of sub-pads, only data for modified pads send to the client. Improve performance when canvas with many sub-pads, but only few of them are modified. Good example is `hist/tprofile2polyRealistic.C` tutorial, which currently working very slow. 
4. Optimize server/client communication. If canvas marked modified without real change of data, no extra message will be send to client. Also allows break self-triggered Modify/Update loops with `TExec` 
5. Adjust several `TExec` tutorials.