### PR TITLE
[ntuple] RField: add support for (per field) post-read callback functions

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -157,11 +157,8 @@ protected:
 private:
    void InvokeReadCallbacks(RFieldValue &value)
    {
-      if (R__likely(fReadCallbacks.empty()))
-         return;
-      for (const auto &func : fReadCallbacks) {
+      for (const auto &func : fReadCallbacks)
          func(value);
-      }
    }
 
 public:
@@ -261,7 +258,8 @@ public:
          fPrincipalColumn->Read(globalIndex, &value->fMappedElement);
       else
          ReadGlobalImpl(globalIndex, value);
-      InvokeReadCallbacks(*value);
+      if (R__unlikely(!fReadCallbacks.empty()))
+         InvokeReadCallbacks(*value);
    }
 
    void Read(const RClusterIndex &clusterIndex, RFieldValue *value) {
@@ -272,7 +270,8 @@ public:
          fPrincipalColumn->Read(clusterIndex, &value->fMappedElement);
       else
          ReadInClusterImpl(clusterIndex, value);
-      InvokeReadCallbacks(*value);
+      if (R__unlikely(!fReadCallbacks.empty()))
+         InvokeReadCallbacks(*value);
    }
 
    /// Ensure that all received items are written from page buffers to the storage.

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <functional>
 #include <iostream>
 #include <iterator>
 #include <memory>
@@ -71,7 +72,7 @@ The field knows based on its type and the field name the type(s) and name(s) of 
 // clang-format on
 class RFieldBase {
    friend class ROOT::Experimental::RCollectionField; // to move the fields from the collection model
-   using ReadCallback_t = void (*)(RFieldValue &);
+   using ReadCallback_t = std::function<void(RFieldValue &)>;
 
 public:
    /// No constructor needs to be called, i.e. any bit pattern in the allocated memory represents a valid type
@@ -147,7 +148,7 @@ private:
    {
       if (R__likely(fReadCallbacks.empty()))
          return;
-      for (const auto func : fReadCallbacks) {
+      for (const auto &func : fReadCallbacks) {
          func(value);
       }
    }

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -76,7 +76,7 @@ The field knows based on its type and the field name the type(s) and name(s) of 
 // clang-format on
 class RFieldBase {
    friend class ROOT::Experimental::RCollectionField; // to move the fields from the collection model
-   friend class ROOT::Experimental::Internal::RFieldCallbackInjector;
+   friend class ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
    using ReadCallback_t = std::function<void(RFieldValue &)>;
 
 public:

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -239,7 +239,7 @@ public:
       } else {
          ReadGlobalImpl(globalIndex, value);
       }
-      if (fReadCallback)
+      if (R__unlikely(fReadCallback))
          fReadCallback(*value);
    }
 
@@ -252,7 +252,7 @@ public:
       } else {
          ReadInClusterImpl(clusterIndex, value);
       }
-      if (fReadCallback)
+      if (R__unlikely(fReadCallback))
          fReadCallback(*value);
    }
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -288,6 +288,7 @@ public:
    /// Returns an index that can be used to remove the callback.
    size_t AddReadCallback(ReadCallback_t func);
    void RemoveReadCallback(size_t idx);
+   bool HasReadCallbacks() const { return !fReadCallbacks.empty(); }
 
    DescriptorId_t GetOnDiskId() const { return fOnDiskId; }
    void SetOnDiskId(DescriptorId_t id) { fOnDiskId = id; }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleView.hxx
@@ -165,6 +165,8 @@ public:
       : fField(pageSource->GetSharedDescriptorGuard()->GetFieldDescriptor(fieldId).GetFieldName()),
         fValue(fField.GenerateValue())
    {
+      if ((fField.GetTraits() & Detail::RFieldBase::kTraitMappable) && fField.HasReadCallbacks())
+         throw RException(R__FAIL("view disallowed on field with mappable type and read callback"));
       fField.SetOnDiskId(fieldId);
       fField.ConnectPageSource(*pageSource);
       for (auto &f : fField) {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -404,6 +404,18 @@ ROOT::Experimental::EColumnType ROOT::Experimental::Detail::RFieldBase::EnsureCo
    return columnDesc.GetModel().GetType();
 }
 
+size_t ROOT::Experimental::Detail::RFieldBase::AddReadCallback(ReadCallback_t func)
+{
+   fReadCallbacks.push_back(func);
+   fIsSimple = false;
+   return fReadCallbacks.size() - 1;
+}
+
+void ROOT::Experimental::Detail::RFieldBase::RemoveReadCallback(size_t idx)
+{
+   fReadCallbacks.erase(fReadCallbacks.begin() + idx);
+   fIsSimple = (fTraits & kTraitMappable) && fReadCallbacks.empty();
+}
 
 void ROOT::Experimental::Detail::RFieldBase::ConnectPageSink(RPageSink &pageSink)
 {

--- a/tree/ntuple/v7/test/ntuple_basics.cxx
+++ b/tree/ntuple/v7/test/ntuple_basics.cxx
@@ -658,16 +658,17 @@ TEST(RNTuple, ReadCallback)
 
    auto model = RNTupleModel::Create();
    auto field = std::make_unique<RField<std::int32_t>>("field");
-   field->SetReadCallback([](RFieldValue &value) {
+   field->AddReadCallback([](RFieldValue &value) {
       static std::int32_t expected = 0;
       EXPECT_EQ(*value.Get<std::int32_t>(), expected++);
       gNCallReadCallback++;
    });
+   field->AddReadCallback([](RFieldValue &) { gNCallReadCallback++; });
    model->AddField(std::move(field));
 
    auto ntuple = RNTupleReader::Open(std::move(model), "f", fileGuard.GetPath());
    EXPECT_EQ(2U, ntuple->GetNEntries());
    ntuple->LoadEntry(0);
    ntuple->LoadEntry(1);
-   EXPECT_EQ(2U, gNCallReadCallback);
+   EXPECT_EQ(4U, gNCallReadCallback);
 }

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -588,9 +588,9 @@ TEST(RNTuple, Enums)
 
 TEST(RNTuple, Traits)
 {
-   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<float>("f").GetTraits());
-   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<bool>("f").GetTraits());
-   EXPECT_EQ(RFieldBase::kTraitTrivialType, RField<int>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTrivialType | RFieldBase::kTraitMappable, RField<float>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTrivialType | RFieldBase::kTraitMappable, RField<bool>("f").GetTraits());
+   EXPECT_EQ(RFieldBase::kTraitTrivialType | RFieldBase::kTraitMappable, RField<int>("f").GetTraits());
    EXPECT_EQ(0, RField<std::string>("f").GetTraits());
    EXPECT_EQ(0, RField<std::vector<float>>("f").GetTraits());
    EXPECT_EQ(0, RField<std::vector<bool>>("f").GetTraits());


### PR DESCRIPTION
As per a conversation with @jblomer on 16/11/2022, and ROOT I/O meeting on 25/11/2022 (and probably also related to https://github.com/root-project/root/pull/11628#discussion_r1023123773), this pull request adds support for per field post-read callback functions to be invoked after reading a value object.
Such callbacks can be used to inspect/modify the value object after reading, e.g. to initialize transient members.

The conclusion of a previous discussion is that we should not allow views on fields with a mappable type and that have a read callback.
The signature of a read callback function is
```c++
void callback_func(RFieldValue &);
```

## Changes of fixes:
- Fields with a mappable type need to be distinguished from "simple" fields (i.e. those that have no additional actions after reading).  Thus, the `kTraitMappable` trait is introduced in this PR; it is set for fields of fundamental types that can be directly mapped via `RField<T>::Map()`. These fields also map as-is to a single column.
The `fIsSimple` member now takes a different meaning: a field is simple if it is both mappable (i.e. kTraitMappable) and has no post-read callback.
- Read callbacks are managed via the _protected_ member functions `RFieldBase::{Add,Remove}ReadCallback()`.
- `RFieldBase::Read()` calls the read callbacks as appropriate.  The fast path still only calls `fPrincipalColumn->Read()`.
Callbacks should be relatively rare; thus, the branch is marked as `R__unlikely()`, as it provides a small performance increase for non-mappable types that have no read callback.
- As discussed, views are disallowed on fields with a mappable type and a read callback.

## Experimental measurements
The overhead of the changes in this PR was measured in a synthetic test case.  The schema is comprised of 4 fields of fundamental data types + 2 fields referring to user-defined `struct`s (containing 4 and 8 members of fundamental data types, respectively).  The test program reads all fields across 10000k entries.  The file lies in a tmpfs.

The overhead has been measured to be:
- No callbacks: **~0.5%** w.r.t. the state of RNTuple before this patch set.
- 1 _nop_ callback function for one of the `struct` fields: **~2.7%** w.r.t. the base time.
- 2 _nop_ callback functions, one for each of the `struct` fields: **~3.4%** w.r.t. the base time.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #11730.