### PR TITLE
Improve TFile::DrawMap

### DIFF
--- a/io/io/src/TFile.cxx
+++ b/io/io/src/TFile.cxx
@@ -1062,7 +1062,16 @@ void TFile::Draw(Option_t *option)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Draw map of objects in this file.
+/// Draw map of objects in this file. The map drawing is handled by TFileDrawMap.
+/// Once the map is drawn, turn on the TCanvas option "View->Event Statusbar". Then, when
+/// moving the mouse in the canvas, the "Event Status" panels shows the object corresponding
+/// to the mouse position.
+///
+/// Example:
+/// ~~~{.cpp}
+///   auto f = new TFile("myfile.root");
+///   f->DrawMap();
+/// ~~~
 
 void TFile::DrawMap(const char *keys, Option_t *option)
 {
@@ -1480,7 +1489,7 @@ void TFile::MakeFree(Long64_t first, Long64_t last)
 ///     20010404/150443  At:407678    N=86        FreeSegments
 ///     20010404/150443  At:407764    N=1         END
 ///
-/// If the parameter opt contains "forComp", the Date/Time is ommitted
+/// If the parameter opt contains "forComp", the Date/Time is omitted
 /// and the decompressed size is also printed.
 ///
 ///    Record_Adress Logical_Record_Length  Key_Length Object_Record_Length ClassName  CompressionFactor
@@ -4077,7 +4086,7 @@ TFile *TFile::Open(const char *url, Option_t *options, const char *ftitle,
          // Remove from the options field
          sto.Insert(0, "TIMEOUT=");
          opts.ReplaceAll(sto, "");
-         // Asynchrounous open
+         // Asynchronous open
          TFileOpenHandle *fh = TFile::AsyncOpen(expandedUrl, opts, ftitle, compress, netopt);
          // Check the result in steps of 1 millisec
          TFile::EAsyncOpenStatus aos = TFile::kAOSNotAsync;

--- a/tree/treeplayer/src/TFileDrawMap.cxx
+++ b/tree/treeplayer/src/TFileDrawMap.cxx
@@ -50,7 +50,7 @@ objects to be shown. For example, to view only the keys with
 names starting with "abc", set the argument keys to "abc*".
 The default is to view all the objects.
 The argument options can also be used (only one option currently)
-When the option "same" is given, the new picture is suprimposed.
+When the option "same" is given, the new picture is superimposed.
 The option "same" is useful, eg:
 to draw all keys with names = "abc" in a first pass
 then all keys with names = "uv*" in a second pass, etc.
@@ -497,7 +497,7 @@ void TFileDrawMap::Paint(Option_t *)
          fFrame->SetMinimum(0);
          fFrame->GetYaxis()->SetLimits(0,fYsize+1);
       }
-      fFrame->Paint("a");
+      fFrame->Paint();
    }
 
    //draw keys
@@ -577,7 +577,10 @@ void TFileDrawMap::PaintDir(TDirectory *dir, const char *keys)
          while ((leaf = (TLeaf*)nextb())) {
             TBranch *branch = leaf->GetBranch();
             color = branch->GetFillColor();
-            if (color == 0) color = 1;
+            if (color == 0) {
+               gPad->IncrementPaletteColor(1, "pfc");
+               color = gPad->NextPaletteColor();
+            }
             box.SetFillColor(color);
             Int_t nbaskets = branch->GetMaxBaskets();
             for (Int_t i=0;i<nbaskets;i++) {


### PR DESCRIPTION
As described [here](https://github.com/root-project/root/issues/11723), `TFile::DrawMap` produced a weird plot, mostly black. With this PR the plot is improved.
```
   auto f = new TFile("hsimple.root");
   f->DrawMap();
```
Gives:
<img width="650" alt="Screenshot 2022-11-17 at 16 13 04" src="https://user-images.githubusercontent.com/4697738/202487187-9c83c2ab-578a-4550-9c7b-feea0ddbb543.png">

### Changes:
- Use the current color map to paint the various branches of trees,
- Paint the axis label and titles,
- Improve the help,
- fix typos