### PR TITLE
[RF] add RooDataHist::get_wgt

### DIFF
--- a/roofit/roofitcore/inc/RooDataHist.h
+++ b/roofit/roofitcore/inc/RooDataHist.h
@@ -101,13 +101,13 @@ public:
 
   void weights(double* output, RooSpan<double const> xVals, int intOrder, bool correctForBinSize, bool cdfBoundaries);
   /// Return weight of i-th bin. \see getIndex()
-  double weight(std::size_t i) const { return _wgt[i]; }
+  double weight(std::size_t i) const { return get_wgt(i); }
   double weightFast(const RooArgSet& bin, int intOrder, bool correctForBinSize, bool cdfBoundaries);
   double weight(const RooArgSet& bin, Int_t intOrder=1, bool correctForBinSize=false, bool cdfBoundaries=false, bool oneSafe=false);
   /// Return squared weight sum of i-th bin. \see getIndex(). If sumw2 is not
   /// being tracked, assume that all previous fill operations had a
   /// weight of 1, i.e., return the bare weight of the bin.
-  double weightSquared(std::size_t i) const { return _sumw2 ? _sumw2[i] : _wgt[i]; }
+  double weightSquared(std::size_t i) const { return _sumw2 ? _sumw2[i] : get_wgt(i); }
   /// Return bin volume of i-th bin. \see getIndex()
   double binVolume(std::size_t i) const { return _binv[i]; }
   double binVolume(const RooArgSet& bin) const;
@@ -177,7 +177,7 @@ public:
   /// \deprecated Use the safer weight(std::size_t) const.
   double weight() const override
   R__SUGGEST_ALTERNATIVE("Use the safer weight(std::size_t) const.")
-  { return  _wgt[_curIndex]; }
+  { return get_wgt(_curIndex); }
   /// Return squared weight of last bin that was requested with get().
   /// \deprecated Use the safer weightSquared(std::size_t) const.
   double weightSquared() const override
@@ -230,6 +230,9 @@ protected:
   void importTH1(const RooArgList& vars, const TH1& histo, double initWgt, bool doDensityCorrection) ;
   void importTH1Set(const RooArgList& vars, RooCategory& indexCat, std::map<std::string,TH1*> hmap, double initWgt, bool doDensityCorrection) ;
   void importDHistSet(const RooArgList& vars, RooCategory& indexCat, std::map<std::string,RooDataHist*> dmap, double initWgt) ;
+
+  // get_wgt is necessary because it is overridden in RooFitExtensions' RooExpandedDataHist
+  virtual double get_wgt(std::size_t idx) const { return _wgt[idx]; }
 
   Int_t _arrSize{0}; // Size of member arrays.
   std::vector<Int_t> _idxMult ; // Multiplier jump table for index calculation

--- a/roofit/roofitcore/src/RooDataHist.cxx
+++ b/roofit/roofitcore/src/RooDataHist.cxx
@@ -1130,7 +1130,7 @@ void RooDataHist::interpolateQuadratic(double* output, RooSpan<const double> xVa
   std::vector<double> weightsExt(nBins+3);
   // Fill weights for bins that are inside histogram boundaries
   for (std::size_t binIdx = 0; binIdx < nBins; ++binIdx) {
-    weightsExt[binIdx+2] = correctForBinSize ? _wgt[binIdx] / _binv[binIdx] : _wgt[binIdx];
+    weightsExt[binIdx+2] = correctForBinSize ? get_wgt(binIdx) / _binv[binIdx] : get_wgt(binIdx);
   }
 
   if (cdfBoundaries) {
@@ -1237,7 +1237,7 @@ void RooDataHist::interpolateLinear(double* output, RooSpan<const double> xVals,
   std::vector<double> weightsExt(nBins+2);
   // Fill weights for bins that are inside histogram boundaries
   for (std::size_t binIdx = 0; binIdx < nBins; ++binIdx) {
-    weightsExt[binIdx+1] = correctForBinSize ? _wgt[binIdx] / _binv[binIdx] : _wgt[binIdx];
+    weightsExt[binIdx+1] = correctForBinSize ? get_wgt(binIdx) / _binv[binIdx] : get_wgt(binIdx);
   }
 
   // Fill weights for bins that are outside histogram boundaries
@@ -1307,7 +1307,7 @@ void RooDataHist::weights(double* output, RooSpan<double const> xVals, int intOr
 
     for (std::size_t i=0; i < nEvents; ++i) {
       auto binIdx = binIndices[i];
-      output[i] = correctForBinSize ? _wgt[binIdx] / _binv[binIdx] : _wgt[binIdx];
+      output[i] = correctForBinSize ? get_wgt(binIdx) / _binv[binIdx] : get_wgt(binIdx);
     }
   }
   else if (intOrder == 1) {
@@ -1354,7 +1354,7 @@ double RooDataHist::weightFast(const RooArgSet& bin, Int_t intOrder, bool correc
   // Handle no-interpolation case
   if (intOrder==0) {
     const auto idx = calcTreeIndex(bin, true);
-    return correctForBinSize ? _wgt[idx] / _binv[idx] : _wgt[idx];
+    return correctForBinSize ? get_wgt(idx) / _binv[idx] : get_wgt(idx);
   }
 
   // Handle all interpolation cases
@@ -1389,7 +1389,7 @@ double RooDataHist::weight(const RooArgSet& bin, Int_t intOrder, bool correctFor
   // Handle no-interpolation case
   if (intOrder==0) {
     const auto idx = calcTreeIndex(bin, false);
-    return correctForBinSize ? _wgt[idx] / _binv[idx] : _wgt[idx];
+    return correctForBinSize ? get_wgt(idx) / _binv[idx] : get_wgt(idx);
   }
 
   // Handle all interpolation cases
@@ -1602,7 +1602,7 @@ double RooDataHist::interpolateDim(int iDim, double xval, size_t centralIdx, int
       ibin = i ;
       xarr[i-fbinLo] = binning.binCenter(ibin) ;
       auto idx = offsetIdx + idxMult * ibin;
-      yarr[i - fbinLo] = _wgt[idx];
+      yarr[i - fbinLo] = get_wgt(idx);
       if (correctForBinSize) yarr[i-fbinLo] /=  _binv[idx] ;
     } else if (i>=fbinM) {
       // Overflow: mirror
@@ -1613,7 +1613,7 @@ double RooDataHist::interpolateDim(int iDim, double xval, size_t centralIdx, int
       } else {
         auto idx = offsetIdx + idxMult * ibin;
         xarr[i-fbinLo] = 2*binning.highBound()-binning.binCenter(ibin) ;
-        yarr[i - fbinLo] = _wgt[idx];
+        yarr[i - fbinLo] = get_wgt(idx);
         if (correctForBinSize)
           yarr[i - fbinLo] /= _binv[idx];
       }
@@ -1626,7 +1626,7 @@ double RooDataHist::interpolateDim(int iDim, double xval, size_t centralIdx, int
       } else {
         auto idx = offsetIdx + idxMult * ibin;
         xarr[i-fbinLo] = 2*binning.lowBound()-binning.binCenter(ibin) ;
-        yarr[i - fbinLo] = _wgt[idx];
+        yarr[i - fbinLo] = get_wgt(idx);
         if (correctForBinSize)
           yarr[i - fbinLo] /= _binv[idx];
       }
@@ -1807,7 +1807,7 @@ double RooDataHist::sum(bool correctForBinSize, bool inverseBinCor) const
   ROOT::Math::KahanSum<double> kahanSum;
   for (Int_t i=0; i < _arrSize; i++) {
     const double theBinVolume = correctForBinSize ? (inverseBinCor ? 1/_binv[i] : _binv[i]) : 1.0 ;
-    kahanSum += _wgt[i] * theBinVolume;
+    kahanSum += get_wgt(i) * theBinVolume;
   }
 
   // Store result in cache
@@ -1882,7 +1882,7 @@ double RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet, bool
 
     if (!skip) {
       const double theBinVolume = correctForBinSize ? (inverseBinCor ? 1/(*pbinv)[ibin] : (*pbinv)[ibin] ) : 1.0 ;
-      total += _wgt[ibin] * theBinVolume;
+      total += get_wgt(ibin) * theBinVolume;
     }
   }
 
@@ -1992,7 +1992,7 @@ double RooDataHist::sum(const RooArgSet& sumSet, const RooArgSet& sliceSet,
     const double corrPartial = binVolumeSumSetInRange / binVolumeSumSetFull;
     if (0. == corrPartial) continue;
     const double corr = correctForBinSize ? (inverseBinCor ? binVolumeSumSetFull / _binv[ibin] : binVolumeSumSetFull ) : 1.0;
-    total += getBinScale(ibin)*(_wgt[ibin] * corr * corrPartial);
+    total += getBinScale(ibin)*(get_wgt(ibin) * corr * corrPartial);
   }
 
   _vars.assign(varSave);


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:
Commit 23d861273f56c28a6bad45028115f80228816b6f removed `get_wgt`, but this is used in RooFitExtensions, which in turn is used for Higgs combination fits. This commit adds `get_wgt` back in. It also adds it in places where it was missing before; some new additions since `get_wgt` was added (about 6 years ago) did not use `get_wgt`, but rather directly accessed the `_wgt` array, which again breaks the usecase within RooFitExtensions (`RooExpandedDataHist`).

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)