### PR TITLE
Provide plugin for RTreeViewer

### DIFF
--- a/config/rootrc.in
+++ b/config/rootrc.in
@@ -211,6 +211,8 @@ Gui.TooltipForegroundColor:  black
 Gui.MimeTypeFile:            $(HOME)/.root.mimes
 # If above does not exists defaults to this:
 #Gui.MimeTypeFile:            @etcdir@/root.mimes
+# Type of tree viewer: TTreeViewer or RTreeViewer
+TreeViewer.Name:             TTreeViewer
 # Type of Browser: TRootBrowser or TRootBrowserLite
 Browser.Name:                @root_browser_class@
 # Browser Options (plugins)

--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -410,6 +410,7 @@ void TApplication::GetOptions(Int_t *argc, char **argv)
          } else if (gSystem->Load("libROOTWebDisplay") >= 0) {
             gROOT->SetWebDisplay(argw.Data());
             gEnv->SetValue("Gui.Factory", "web");
+            gEnv->SetValue("TreeViewer.Name", "RTreeViewer");
          } else {
             Error("GetOptions", "--web option not supported, ROOT should be built with at least c++14 enabled");
          }

--- a/etc/plugins/TVirtualTreeViewer/P010_TTreeViewer.C
+++ b/etc/plugins/TVirtualTreeViewer/P010_TTreeViewer.C
@@ -1,5 +1,5 @@
 void P010_TTreeViewer()
 {
-   gPluginMgr->AddHandler("TVirtualTreeViewer", "*", "TTreeViewer",
+   gPluginMgr->AddHandler("TVirtualTreeViewer", "TTreeViewer", "TTreeViewer",
       "TreeViewer", "TTreeViewer(const TTree*)");
 }

--- a/etc/plugins/TVirtualTreeViewer/P020_RTreeViewer.C
+++ b/etc/plugins/TVirtualTreeViewer/P020_RTreeViewer.C
@@ -1,0 +1,5 @@
+void P020_RTreeViewer()
+{
+   gPluginMgr->AddHandler("TVirtualTreeViewer", "RTreeViewer", "ROOT::Experimental::RTreeViewer",
+      "TreeViewer", "NewViewer(TTree*)");
+}

--- a/proof/proof/src/TDSet.cxx
+++ b/proof/proof/src/TDSet.cxx
@@ -1534,11 +1534,10 @@ void TDSet::StartViewer()
    }
    fProofChain = new TProofChain(this, kTRUE);
 
-   TPluginHandler *h;
-   if ((h = gROOT->GetPluginManager()->FindHandler("TVirtualTreeViewer"))) {
-      if (h->LoadPlugin() == -1)
-         return;
-      h->ExecPlugin(1,fProofChain);
+   const char *hname = gEnv->GetValue("TreeViewer.Name", "TTreeViewer");
+   if (auto h = gROOT->GetPluginManager()->FindHandler("TVirtualTreeViewer", hname)) {
+      if (h->LoadPlugin() != -1)
+         h->ExecPlugin(1,fProofChain);
    }
 }
 

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -27,6 +27,7 @@ extra libraries (Histogram, display, etc).
 #include "TApplication.h"
 #include "TSystem.h"
 #include "TFile.h"
+#include "TEnv.h"
 #include "TEventList.h"
 #include "TEntryList.h"
 #include "TBranchObject.h"
@@ -2948,23 +2949,29 @@ void TTreePlayer::SetEstimate(Long64_t n)
 
 void TTreePlayer::StartViewer(Int_t ww, Int_t wh)
 {
+   // unused variables
+   (void) ww;
+   (void) wh;
+
    if (!gApplication)
       TApplication::CreateApplication();
    // make sure that the Gpad and GUI libs are loaded
    TApplication::NeedGraphicsLibs();
    if (gApplication)
       gApplication->InitializeGraphics();
+
+   TString hname = gEnv->GetValue("TreeViewer.Name", "TTreeViewer");
+
    if (gROOT->IsBatch()) {
-      Warning("StartViewer", "The tree viewer cannot run in batch mode");
-      return;
+      if ((hname != "RTreeViewer") || (gROOT->GetWebDisplay() != "server")) {
+         Warning("StartViewer", "The tree viewer cannot run in batch mode");
+         return;
+      }
    }
 
-   if (ww || wh) { }   // use unused variables
-   TPluginHandler *h;
-   if ((h = gROOT->GetPluginManager()->FindHandler("TVirtualTreeViewer"))) {
-      if (h->LoadPlugin() == -1)
-         return;
-      h->ExecPlugin(1,fTree);
+   if (auto h = gROOT->GetPluginManager()->FindHandler("TVirtualTreeViewer", hname.Data())) {
+      if (h->LoadPlugin() != -1)
+         h->ExecPlugin(1, fTree);
    }
 }
 

--- a/tree/webviewer/inc/ROOT/RTreeViewer.hxx
+++ b/tree/webviewer/inc/ROOT/RTreeViewer.hxx
@@ -79,6 +79,8 @@ public:
 
    void Update();
 
+   static RTreeViewer *NewViewer(TTree *);
+
 private:
 
    TTree *fTree{nullptr};                  ///<! TTree to show

--- a/tree/webviewer/src/RTreeViewer.cxx
+++ b/tree/webviewer/src/RTreeViewer.cxx
@@ -429,3 +429,16 @@ void RTreeViewer::SendProgress(bool completed)
    fWebWindow->Send(0, "PROGRESS:"s + progress);
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////
+/// Create new viewer
+/// Method used for plugin
+
+RTreeViewer *RTreeViewer::NewViewer(TTree *t)
+{
+   auto viewer = new RTreeViewer(t);
+
+   viewer->Show();
+
+   return viewer;
+}
+


### PR DESCRIPTION
There is fictional `TVirtualTreeViewer` class and `RTreeViewer` plugin is activated when web display is configured.

Allows to use web-based canvas and tree viewer together like in `tutorials/tree/tree0.C` example
