### PR TITLE
[cmake] Tell CMake >= 3.24 to use tared timestamps:

### DIFF
--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -19,6 +19,10 @@ macro(find_package)
   endif()
 endmacro()
 
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+  set(DOWNLOAD_EXTRACT_TIMESTAMP_ARG DOWNLOAD_EXTRACT_TIMESTAMP false)
+endif()
+
 #---On MacOSX, try to find frameworks after standard libraries or headers------------
 set(CMAKE_FIND_FRAMEWORK LAST)
 
@@ -178,6 +182,7 @@ if(builtin_freetype)
       FREETYPE
       URL ${CMAKE_SOURCE_DIR}/graf2d/freetype/src/freetype-${freetype_version}.tar.gz
       URL_HASH SHA256=efe71fd4b8246f1b0b1b9bfca13cfff1c9ad85930340c27df469733bbb620938
+      ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
       CONFIGURE_COMMAND ./configure --prefix <INSTALL_DIR> --with-pic
                          --disable-shared --with-png=no --with-bzip2=no
                          --with-harfbuzz=no ${_freetype_brotli} ${_freetype_zlib}
@@ -275,6 +280,7 @@ if(builtin_lzma)
       LZMA
       URL ${CMAKE_SOURCE_DIR}/core/lzma/src/xz-${lzma_version}.tar.gz
       URL_HASH SHA256=b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145
+      ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
       INSTALL_DIR ${CMAKE_BINARY_DIR}
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix <INSTALL_DIR> --libdir <INSTALL_DIR>/lib
                         --with-pic --disable-shared --quiet
@@ -496,6 +502,7 @@ if(builtin_afterimage)
     ExternalProject_Add(
       AFTERIMAGE
       DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/graf2d/asimage/src/libAfterImage AFTERIMAGE
+      ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
       INSTALL_DIR ${CMAKE_BINARY_DIR}
       CONFIGURE_COMMAND ./configure --prefix <INSTALL_DIR>
                         --libdir=<INSTALL_DIR>/lib
@@ -557,6 +564,7 @@ if(mathmore OR builtin_gsl)
       URL ${lcgpackages}/gsl-${gsl_version}.tar.gz
       URL_HASH SHA256=0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d
       SOURCE_DIR GSL-src # prevent "<gsl/...>" vs GSL/ macOS warning
+      ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
       INSTALL_DIR ${CMAKE_BINARY_DIR}
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix <INSTALL_DIR>
                         --libdir=<INSTALL_DIR>/lib
@@ -866,6 +874,7 @@ if(builtin_fftw3)
     FFTW3
     URL ${lcgpackages}/fftw-${FFTW_VERSION}.tar.gz
     URL_HASH SHA256=6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
+    ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
     INSTALL_DIR ${CMAKE_BINARY_DIR}
     CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR>
     BUILD_COMMAND make CFLAGS=-fPIC
@@ -921,6 +930,7 @@ if(fitsio OR builtin_cfitsio)
         # ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio${cfitsio_version_no_dots}.tar.gz
         URL ${lcgpackages}/cfitsio${cfitsio_version_no_dots}.tar.gz
         URL_HASH SHA256=bf6012dbe668ecb22c399c4b7b2814557ee282c74a7d5dc704eb17c30d9fb92e
+        ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
         INSTALL_DIR ${CMAKE_BINARY_DIR}
         CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix <INSTALL_DIR>
         LOG_DOWNLOAD 1 LOG_CONFIGURE 1 LOG_BUILD 1 LOG_INSTALL 1
@@ -1385,6 +1395,7 @@ if(builtin_tbb)
       TBB
       URL ${lcgpackages}/tbb-${tbb_builtin_version}.tar.gz
       URL_HASH SHA256=${tbb_sha256}
+      ${DOWNLOAD_EXTRACT_TIMESTAMP_ARG}
       INSTALL_DIR ${CMAKE_BINARY_DIR}
       PATCH_COMMAND sed -i -e "/clang -v/s@-v@--version@" build/macos.inc
       COMMAND ${tbb_command}


### PR DESCRIPTION
Newer CMake uses extraction timestamps for extracted files, instead of the timestamp as stored in the tar file, see
https://cmake.org/cmake/help/latest/policy/CMP0135.html#policy:CMP0135 This causes (massive) problems with configure/Makefile tar files, where the configure/Makefile dependencies (e.g. autoconf) might be newer than configure/Makefile, causing configure/Makefile to wanting to regenerate themselves because they are supposedly out of date.

For anything with "./configure", force the timestamp as stored in the tar file.

Fixes https://github.com/root-project/root/issues/11743
