### PR TITLE
Use `TString::Format()` instead `Form()` in core classes

### DIFF
--- a/core/base/src/TApplication.cxx
+++ b/core/base/src/TApplication.cxx
@@ -1857,7 +1857,7 @@ TApplication *TApplication::Open(const char *url,
    // If new session on a known machine pass the number as option
    if (nnew > 0) {
       nnew++;
-      nu.SetOptions(Form("%d", nnew));
+      nu.SetOptions(TString::Format("%d", nnew).Data());
    }
 
    // Instantiate the TApplication object to be run

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1923,7 +1923,7 @@ Int_t TColor::GetColor(Int_t r, Int_t g, Int_t b)
    TColor *color = nullptr;
 
    // Look for color by name
-   if ((color = (TColor*) colors->FindObject(Form("#%02x%02x%02x", r, g, b))))
+   if ((color = (TColor*) colors->FindObject(TString::Format("#%02x%02x%02x", r, g, b).Data())))
       // We found the color by name, so we use that right away
       return color->GetNumber();
 
@@ -1957,7 +1957,7 @@ Int_t TColor::GetColor(Int_t r, Int_t g, Int_t b)
    // add it. Note name is of the form "#rrggbb" where rr, etc. are
    // hexadecimal numbers.
    color = new TColor(colors->GetLast()+1, rr, gg, bb,
-                      Form("#%02x%02x%02x", r, g, b));
+                      TString::Format("#%02x%02x%02x", r, g, b).Data());
 
    return color->GetNumber();
 }
@@ -1989,7 +1989,7 @@ Int_t TColor::GetColorBright(Int_t n)
    if (nb < ncolors) colorb = (TColor*)colors->At(nb);
    if (colorb) return nb;
    colorb = new TColor(nb,r,g,b);
-   colorb->SetName(Form("%s_bright",color->GetName()));
+   colorb->SetName(TString::Format("%s_bright",color->GetName()).Data());
    colors->AddAtAndExpand(colorb,nb);
    return nb;
 }
@@ -2021,7 +2021,7 @@ Int_t TColor::GetColorDark(Int_t n)
    if (nd < ncolors) colord = (TColor*)colors->At(nd);
    if (colord) return nd;
    colord = new TColor(nd,r,g,b);
-   colord->SetName(Form("%s_dark",color->GetName()));
+   colord->SetName(TString::Format("%s_dark",color->GetName()).Data());
    colors->AddAtAndExpand(colord,nd);
    return nd;
 }
@@ -2051,7 +2051,7 @@ Int_t TColor::GetColorTransparent(Int_t n, Float_t a)
       TColor *colort = new TColor(gROOT->GetListOfColors()->GetLast()+1,
                                   color->GetRed(), color->GetGreen(), color->GetBlue());
       colort->SetAlpha(a);
-      colort->SetName(Form("%s_transparent",color->GetName()));
+      colort->SetName(TString::Format("%s_transparent",color->GetName()).Data());
       return colort->GetNumber();
    } else {
       ::Error("TColor::GetColorTransparent", "color with index %d not defined", n);

--- a/core/base/src/TEnv.cxx
+++ b/core/base/src/TEnv.cxx
@@ -581,7 +581,7 @@ void TEnv::PrintEnv(EEnvLevel level) const
 
    while ((er = (TEnvRec*) next()))
       if (er->fLevel == level || level == kEnvAll)
-         Printf("%-25s %-30s [%s]", Form("%s:", er->fName.Data()),
+         Printf("%-25s %-30s [%s]", TString::Format("%s:", er->fName.Data()).Data(),
                 er->fValue.Data(), lc[er->fLevel]);
 }
 
@@ -632,7 +632,7 @@ Int_t TEnv::WriteFile(const char *fname, EEnvLevel level)
       TEnvRec *er;
       while ((er = (TEnvRec*) next()))
          if (er->fLevel == level || level == kEnvAll)
-            fprintf(ofp, "%-40s %s\n", Form("%s:", er->fName.Data()),
+            fprintf(ofp, "%-40s %s\n", TString::Format("%s:", er->fName.Data()).Data(),
                     er->fValue.Data());
       fclose(ofp);
       return 0;
@@ -692,7 +692,7 @@ void TEnv::SaveLevel(EEnvLevel level)
    else
       return;
 
-   if ((ofp = fopen(Form("%s.new", rootrcdir.Data()), "w"))) {
+   if ((ofp = fopen(TString::Format("%s.new", rootrcdir.Data()).Data(), "w"))) {
       ifp = fopen(rootrcdir.Data(), "r");
       if (ifp == nullptr) {     // try to create file
          ifp = fopen(rootrcdir.Data(), "w");
@@ -714,15 +714,15 @@ void TEnv::SaveLevel(EEnvLevel level)
                if (er->fLevel == kEnvChange) er->fLevel = level;
                if (er->fLevel == level) {
                   er->fModified = kFALSE;
-                  fprintf(ofp, "%-40s %s\n", Form("%s:", er->fName.Data()),
+                  fprintf(ofp, "%-40s %s\n", TString::Format("%s:", er->fName.Data()).Data(),
                           er->fValue.Data());
                }
             }
          }
          fclose(ifp);
          fclose(ofp);
-         gSystem->Rename(rootrcdir.Data(), Form("%s.bak", rootrcdir.Data()));
-         gSystem->Rename(Form("%s.new", rootrcdir.Data()), rootrcdir.Data());
+         gSystem->Rename(rootrcdir.Data(), TString::Format("%s.bak", rootrcdir.Data()).Data());
+         gSystem->Rename(TString::Format("%s.new", rootrcdir.Data()).Data(), rootrcdir.Data());
          return;
       }
       fclose(ofp);
@@ -775,7 +775,7 @@ void TEnv::SetValue(const char *name, EEnvLevel level)
 
 void TEnv::SetValue(const char *name, Int_t value)
 {
-   SetValue(name, Form("%d", value));
+   SetValue(name, TString::Format("%d", value).Data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -783,7 +783,7 @@ void TEnv::SetValue(const char *name, Int_t value)
 
 void TEnv::SetValue(const char *name, Double_t value)
 {
-   SetValue(name, Form("%g", value));
+   SetValue(name, TString::Format("%g", value).Data());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TMacro.cxx
+++ b/core/base/src/TMacro.cxx
@@ -183,8 +183,7 @@ void TMacro::Browse(TBrowser * /*b*/)
       return;
    }
    if (opt.Contains(".C")) {
-      const char *cmd = Form(".x %s((TMacro*)0x%zx)",opt.Data(),(size_t)this);
-      gROOT->ProcessLine(cmd);
+      gROOT->ProcessLine(TString::Format(".x %s((TMacro*)0x%zx)", opt.Data(), (size_t)this).Data());
       return;
    }
 }

--- a/core/gui/src/TContextMenu.cxx
+++ b/core/gui/src/TContextMenu.cxx
@@ -152,24 +152,26 @@ void TContextMenu::Action(TClassMenuItem *menuitem)
                Execute(object, method, "");
 #else
                // It is a workaround of the "Dead lock under Windows
-               char *cmd = Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"
-                                "(TMethod *)0x%zx,\"\");",
-                                (size_t)this,(size_t)object,(size_t)method);
-               //Printf("%s", cmd);
-               gROOT->ProcessLine(cmd);
+               TString cmd;
+               cmd.Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"
+                        "(TMethod *)0x%zx,\"\");",
+                        (size_t)this,(size_t)object,(size_t)method);
+               //Printf("%s", cmd.Data());
+               gROOT->ProcessLine(cmd.Data());
                //Execute( object, method, (TObjArray *)NULL );
 #endif
             } else {
 #ifndef WIN32
-               Execute(object, method, Form("(TObject*)0x%zx",(size_t)fSelectedObject));
+               Execute(object, method, TString::Format("(TObject*)0x%zx",(size_t)fSelectedObject).Data());
 #else
                // It is a workaround of the "Dead lock under Windows
-               char *cmd = Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"
-                                "(TMethod *)0x%zx,(TObject*)0x%zx);",
-                                (size_t)this,(size_t)object,(size_t)method,
-                                (size_t)fSelectedObject);
-               //Printf("%s", cmd);
-               gROOT->ProcessLine(cmd);
+               TString cmd;
+               cmd.Form("((TContextMenu *)0x%zx)->Execute((TObject *)0x%zx,"
+                        "(TMethod *)0x%zx,(TObject*)0x%zx);",
+                        (size_t)this,(size_t)object,(size_t)method,
+                        (size_t)fSelectedObject);
+               //Printf("%s", cmd.Data());
+               gROOT->ProcessLine(cmd.Data());
                //Execute( object, method, (TObjArray *)NULL );
 #endif
             }
@@ -188,14 +190,14 @@ void TContextMenu::Action(TClassMenuItem *menuitem)
                function->GetNargs() > 1) {
             fContextMenuImp->Dialog(nullptr, function);
          } else {
-            char* cmd;
+            TString cmd;
             if (menuitem->GetSelfObjectPos() < 0) {
-               cmd = Form("%s();", menuitem->GetFunctionName());
+               cmd.Form("%s();", menuitem->GetFunctionName());
             } else {
-              cmd = Form("%s((TObject*)0x%zx);",
+              cmd.Form("%s((TObject*)0x%zx);",
                      menuitem->GetFunctionName(), (size_t)fSelectedObject);
             }
-            gROOT->ProcessLine(cmd);
+            gROOT->ProcessLine(cmd.Data());
          }
       }
    }
@@ -332,10 +334,9 @@ void TContextMenu::Execute(TObject *object, TFunction *method, const char *param
 
       gROOT->SetFromPopUp(kTRUE);
       if (object) {
-         object->Execute((char *) method->GetName(), params);
+         object->Execute(method->GetName(), params);
       } else {
-         char *cmd = Form("%s(%s);", method->GetName(),params);
-         gROOT->ProcessLine(cmd);
+         gROOT->ProcessLine(TString::Format("%s(%s);", method->GetName(),params).Data());
       }
       if (fSelectedCanvas && fSelectedCanvas->GetPadSave())
          fSelectedCanvas->GetPadSave()->Modified();
@@ -383,8 +384,7 @@ void TContextMenu::Execute(TObject *object, TFunction *method, TObjArray *params
             if (!args.IsNull()) args += ",";
             args += s->String();
          }
-         char *cmd = Form("%s(%s);", method->GetName(), args.Data());
-         gROOT->ProcessLine(cmd);
+         gROOT->ProcessLine(TString::Format("%s(%s);", method->GetName(), args.Data()).Data());
       }
       if (fSelectedCanvas && fSelectedCanvas->GetPadSave())
          fSelectedCanvas->GetPadSave()->Modified();

--- a/core/gui/src/TGuiFactory.cxx
+++ b/core/gui/src/TGuiFactory.cxx
@@ -133,10 +133,9 @@ TControlBarImp *TGuiFactory::CreateControlBarImp(TControlBar *c, const char *tit
 
 TInspectorImp *TGuiFactory::CreateInspectorImp(const TObject *obj, UInt_t width, UInt_t height)
 {
-   if (gROOT->IsBatch()) {
+   if (gROOT->IsBatch())
       return new TInspectorImp(obj, width, height);
-   }
 
-   gROOT->ProcessLine(Form("TInspectCanvas::Inspector((TObject*)0x%zx);", (size_t)obj));
+   gROOT->ProcessLine(TString::Format("TInspectCanvas::Inspector((TObject*)0x%zx);", (size_t)obj).Data());
    return nullptr;
 }

--- a/core/thread/src/TThread.cxx
+++ b/core/thread/src/TThread.cxx
@@ -1093,7 +1093,7 @@ void TThread::XAction()
    enum { kPRTF = 0, kCUPD = 5, kCANV = 10, kCDEL = 15,
           kPDCD = 20, kMETH = 25, kERRO = 30 };
    int iact = strstr(acts, fgXAct) - acts;
-   char *cmd = 0;
+   TString cmd;
 
    switch (iact) {
 
@@ -1131,8 +1131,8 @@ void TThread::XAction()
 
             case 2:
                //((TCanvas*)fgXArr[1])->Constructor();
-               cmd = Form("((TCanvas *)0x%zx)->Constructor();",(size_t)fgXArr[1]);
-               gROOT->ProcessLine(cmd);
+               cmd.Form("((TCanvas *)0x%zx)->Constructor();",(size_t)fgXArr[1]);
+               gROOT->ProcessLine(cmd.Data());
                break;
 
             case 5:
@@ -1140,8 +1140,8 @@ void TThread::XAction()
                //                 (char*)fgXArr[2],
                //                 (char*)fgXArr[3],
                //                *((Int_t*)(fgXArr[4])));
-               cmd = Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4]);
-               gROOT->ProcessLine(cmd);
+               cmd.Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4]);
+               gROOT->ProcessLine(cmd.Data());
                break;
             case 6:
                //((TCanvas*)fgXArr[1])->Constructor(
@@ -1149,8 +1149,8 @@ void TThread::XAction()
                //                 (char*)fgXArr[3],
                //                *((Int_t*)(fgXArr[4])),
                //                *((Int_t*)(fgXArr[5])));
-               cmd = Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4],(size_t)fgXArr[5]);
-               gROOT->ProcessLine(cmd);
+               cmd.Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4],(size_t)fgXArr[5]);
+               gROOT->ProcessLine(cmd.Data());
                break;
 
             case 8:
@@ -1161,8 +1161,8 @@ void TThread::XAction()
                //               *((Int_t*)(fgXArr[5])),
                //               *((Int_t*)(fgXArr[6])),
                //               *((Int_t*)(fgXArr[7])));
-               cmd = Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4],(size_t)fgXArr[5],(size_t)fgXArr[6],(size_t)fgXArr[7]);
-               gROOT->ProcessLine(cmd);
+               cmd.Form("((TCanvas *)0x%zx)->Constructor((char*)0x%zx,(char*)0x%zx,*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)),*((Int_t*)(0x%zx)));",(size_t)fgXArr[1],(size_t)fgXArr[2],(size_t)fgXArr[3],(size_t)fgXArr[4],(size_t)fgXArr[5],(size_t)fgXArr[6],(size_t)fgXArr[7]);
+               gROOT->ProcessLine(cmd.Data());
                break;
 
          }
@@ -1170,8 +1170,8 @@ void TThread::XAction()
 
       case kCDEL:
          //((TCanvas*)fgXArr[1])->Destructor();
-         cmd = Form("((TCanvas *)0x%zx)->Destructor();",(size_t)fgXArr[1]);
-         gROOT->ProcessLine(cmd);
+         cmd.Form("((TCanvas *)0x%zx)->Destructor();",(size_t)fgXArr[1]);
+         gROOT->ProcessLine(cmd.Data());
          break;
 
       case kPDCD:


### PR DESCRIPTION
Reduce usage of unsafe `Form()` function, especially in Thread.cxx