### PR TITLE
[hist] Fix computation of statistics in TH2::Fill(nameX, nameY)

### DIFF
--- a/hist/hist/src/TH2.cxx
+++ b/hist/hist/src/TH2.cxx
@@ -482,7 +482,7 @@ Int_t TH2::Fill(const char *namex, const char *namey, Double_t w)
       fTsumwx2 += z * x * x;
       fTsumwy += z * y;
       fTsumwy2 += z * y * y;
-      fTsumwx2 += z * x * x;
+      fTsumwxy += z * x * y;
    }
    return bin;
 }
@@ -523,6 +523,7 @@ Int_t TH2::Fill(const char *namex, Double_t y, Double_t w)
    fTsumw2  += z*z;
    fTsumwy  += z*y;
    fTsumwy2 += z*y*y;
+   // skip statistics along x axis, for only one axis no need to use bit mask from GetAxisLabelStatus
    if (!fXaxis.CanExtend() || !fXaxis.IsAlphanumeric()) {
       Double_t x = fXaxis.GetBinCenter(binx);
       fTsumwx += z * x;
@@ -569,6 +570,7 @@ Int_t TH2::Fill(Double_t x, const char *namey, Double_t w)
    fTsumw2  += z*z;
    fTsumwx  += z*x;
    fTsumwx2 += z*x*x;
+   // skip statistics along y axis
    if (!fYaxis.CanExtend() || !fYaxis.IsAlphanumeric()) {
       Double_t y = fYaxis.GetBinCenter(biny);
       fTsumwy += z * y;

--- a/hist/hist/src/TH3.cxx
+++ b/hist/hist/src/TH3.cxx
@@ -593,22 +593,24 @@ Int_t TH3::Fill(Double_t x, const char *namey, const char *namez, Double_t w)
    if (biny == 0 || biny > fYaxis.GetNbins()) return -1;
    if (binz == 0 || binz > fZaxis.GetNbins()) return -1;
 
-   // skip computation of the statistics along axis that have labels (can be extended and are aphanumeric)
-   UInt_t labelBitMask = GetAxisLabelStatus();
-   Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
-   Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
    Double_t v = w;
    fTsumw += v;
    fTsumw2 += v * v;
    fTsumwx += v * x;
    fTsumwx2 += v * x * x;
-   fTsumwy += v * y;
-   fTsumwy2 += v * y * y;
-   fTsumwxy += v * x * y;
-   fTsumwz += v * z;
-   fTsumwz2 += v * z * z;
-   fTsumwxz += v * x * z;
-   fTsumwyz += v * y * z;
+   // skip computation of the statistics along axis that have labels (can be extended and are aphanumeric)
+   UInt_t labelBitMask = GetAxisLabelStatus();
+   if (labelBitMask != (TH1::kYaxis | TH1::kZaxis)) {
+      Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
+      Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
+      fTsumwy += v * y;
+      fTsumwy2 += v * y * y;
+      fTsumwxy += v * x * y;
+      fTsumwz += v * z;
+      fTsumwz2 += v * z * z;
+      fTsumwxz += v * x * z;
+      fTsumwyz += v * y * z;
+   }
    return bin;
 }
 
@@ -647,20 +649,22 @@ Int_t TH3::Fill(const char * namex, Double_t y, Double_t z, Double_t w)
       if (!GetStatOverflowsBehaviour())
          return -1;
    }
-   UInt_t labelBitMask = GetAxisLabelStatus();
-   Double_t x = (labelBitMask & TH1::kXaxis) ? 0 : fXaxis.GetBinCenter(binx);
    Double_t v = w;
    fTsumw += v;
    fTsumw2 += v * v;
-   fTsumwx += v * x;
-   fTsumwx2 += v * x * x;
    fTsumwy += v * y;
    fTsumwy2 += v * y * y;
-   fTsumwxy += v * x * y;
    fTsumwz += v * z;
    fTsumwz2 += v * z * z;
-   fTsumwxz += v * x * z;
    fTsumwyz += v * y * z;
+   // skip computation for x axis : for only one axis no need to use bit mask
+   if (!fXaxis.CanExtend() || !fXaxis.IsAlphanumeric()) {
+      Double_t x = fXaxis.GetBinCenter(binx);
+      fTsumwx += v * x;
+      fTsumwx2 += v * x * x;
+      fTsumwxy += v * x * y;
+      fTsumwxz += v * x * z;
+   }
    return bin;
 }
 
@@ -692,20 +696,23 @@ Int_t TH3::Fill(Double_t x, const char *namey, Double_t z, Double_t w)
    if (binz == 0 || binz > fZaxis.GetNbins()) {
       if (!GetStatOverflowsBehaviour()) return -1;
    }
-   UInt_t labelBitMask = GetAxisLabelStatus();
-   Double_t y = (labelBitMask & TH1::kYaxis) ? 0 : fYaxis.GetBinCenter(biny);
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;
    fTsumwx  += v*x;
    fTsumwx2 += v*x*x;
-   fTsumwy  += v*y;
-   fTsumwy2 += v*y*y;
-   fTsumwxy += v*x*y;
    fTsumwz  += v*z;
    fTsumwz2 += v*z*z;
    fTsumwxz += v*x*z;
-   fTsumwyz += v*y*z;
+   // skip computation for y axis : for only one axis no need to use bit mask
+   if (!fYaxis.CanExtend() || !fYaxis.IsAlphanumeric()) {
+      Double_t y = fYaxis.GetBinCenter(biny);
+      fTsumwy  += v*y;
+      fTsumwy2 += v*y*y;
+      fTsumwxy += v*x*y;
+      fTsumwyz += v*y*z;
+   }
+
    return bin;
 }
 
@@ -738,8 +745,7 @@ Int_t TH3::Fill(Double_t x, Double_t y, const char *namez, Double_t w)
       if (!GetStatOverflowsBehaviour()) return -1;
    }
    if (binz == 0 || binz > fZaxis.GetNbins()) return -1;
-   UInt_t labelBitMask = GetAxisLabelStatus();
-   Double_t z = (labelBitMask & TH1::kZaxis) ? 0 : fZaxis.GetBinCenter(binz);
+
    Double_t v = w;
    fTsumw   += v;
    fTsumw2  += v*v;
@@ -748,10 +754,15 @@ Int_t TH3::Fill(Double_t x, Double_t y, const char *namez, Double_t w)
    fTsumwy  += v*y;
    fTsumwy2 += v*y*y;
    fTsumwxy += v*x*y;
-   fTsumwz  += v*z;
-   fTsumwz2 += v*z*z;
-   fTsumwxz += v*x*z;
-   fTsumwyz += v*y*z;
+
+   // skip computation for z axis : for only one axis no need to use bit mask
+   if (!fZaxis.CanExtend() || !fZaxis.IsAlphanumeric()) {
+      Double_t z = fZaxis.GetBinCenter(binz);
+      fTsumwz  += v*z;
+      fTsumwz2 += v*z*z;
+      fTsumwxz += v*x*z;
+      fTsumwyz += v*y*z;
+   }
    return bin;
 }
 


### PR DESCRIPTION
The Sum in x and y was not updated when the X and Y axis are not extendable or are not alphanumerics. 

This PR fixes ROOT #11746

