### PR TITLE
[ntuple] C-style array RField support

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -580,10 +580,11 @@ They are stored as two fields:
   - Child field of type `T`, which must by a type with RNTuple I/O support.
     The name of the child field is `_0`.
 
-#### std::array<T, N>
+#### std::array<T, N> and array type of the form T[N]
 
 Fixed-sized arrays are stored as single repetitive fields of type `T`.
 The array size `N` is stored in the field meta-data.
+Multi-dimensional arrays of the form `T[N][M]...` are currently not supported.
 
 #### std::variant<T1, T2, ..., Tn>
 

--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -1533,6 +1533,14 @@ public:
    }
 };
 
+template <typename ItemT, std::size_t N>
+class RField<ItemT[N]> : public RField<std::array<ItemT, N>> {
+public:
+   explicit RField(std::string_view name) : RField<std::array<ItemT, N>>(name) {}
+   RField(RField &&other) = default;
+   RField &operator=(RField &&other) = default;
+   ~RField() override = default;
+};
 
 template <typename... ItemTs>
 class RField<std::variant<ItemTs...>> : public RVariantField {

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -35,6 +35,7 @@
 
 #include <algorithm>
 #include <cctype> // for isspace
+#include <charconv>
 #include <cstdint>
 #include <cstdlib> // for malloc, free
 #include <cstring> // for memset
@@ -115,6 +116,31 @@ std::vector<std::string> TokenizeTypeList(std::string templateType) {
    return result;
 }
 
+/// Parse a type name of the form `T[n][m]...` and return the base type `T` and a vector that contains,
+/// in order, the declared size for each dimension, e.g. for `unsigned char[1][2][3]` it returns the tuple
+/// `{"unsigned char", {1, 2, 3}}`.
+///
+/// If `typeName` is not an array type, it returns a tuple `{T, {}}`. On error, it returns a default-constructed tuple.
+std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typeName)
+{
+   std::vector<size_t> sizeVec;
+
+   size_t posRBrace;
+   while ((posRBrace = typeName.find_last_of("]")) != std::string_view::npos) {
+      auto posLBrace = typeName.find_last_of("[", posRBrace);
+      if (posLBrace == std::string_view::npos)
+         return {};
+
+      size_t size;
+      if (std::from_chars(std::begin(typeName) + posLBrace + 1, std::begin(typeName) + posRBrace, size).ec !=
+          std::errc{})
+         return {};
+      sizeVec.insert(sizeVec.begin(), size);
+      typeName.remove_suffix(typeName.size() - posLBrace);
+   }
+   return std::make_tuple(std::string{typeName}, sizeVec);
+}
+
 std::string GetNormalizedType(const std::string &typeName) {
    std::string normalizedType(
       TClassEdit::ResolveTypedef(TClassEdit::CleanType(typeName.c_str(),
@@ -172,6 +198,14 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
       return R__FAIL("no type name specified for Field " + fieldName);
 
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> result;
+
+   if (auto [arrayBaseType, arraySize] = ParseArrayType(typeName); !arraySize.empty()) {
+      // TODO(jalopezg): support multi-dimensional row-major (C order) arrays in RArrayField
+      if (arraySize.size() > 1)
+         return R__FAIL("multi-dimensional array type not supported " + normalizedType);
+      auto itemField = Create(GetNormalizedType(arrayBaseType), arrayBaseType);
+      return {std::make_unique<RArrayField>(fieldName, itemField.Unwrap(), arraySize[0])};
+   }
 
    if (normalizedType == "ROOT::Experimental::ClusterSize_t") {
       result = std::make_unique<RField<ClusterSize_t>>(fieldName);

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -118,15 +118,16 @@ std::vector<std::string> TokenizeTypeList(std::string templateType) {
 
 /// Parse a type name of the form `T[n][m]...` and return the base type `T` and a vector that contains,
 /// in order, the declared size for each dimension, e.g. for `unsigned char[1][2][3]` it returns the tuple
-/// `{"unsigned char", {1, 2, 3}}`.
+/// `{"unsigned char", {1, 2, 3}}`. Extra whitespace in `typeName` should be removed before calling this function.
 ///
 /// If `typeName` is not an array type, it returns a tuple `{T, {}}`. On error, it returns a default-constructed tuple.
 std::tuple<std::string, std::vector<size_t>> ParseArrayType(std::string_view typeName)
 {
    std::vector<size_t> sizeVec;
 
-   size_t posRBrace;
-   while ((posRBrace = typeName.find_last_of("]")) != std::string_view::npos) {
+   /// Only parse outer array definition, i.e. the right `]` should be at the end of the type name
+   while (typeName.back() == ']') {
+      auto posRBrace = typeName.size() - 1;
       auto posLBrace = typeName.find_last_of("[", posRBrace);
       if (posLBrace == std::string_view::npos)
          return {};

--- a/tree/ntuple/v7/src/RField.cxx
+++ b/tree/ntuple/v7/src/RField.cxx
@@ -200,7 +200,7 @@ ROOT::Experimental::Detail::RFieldBase::Create(const std::string &fieldName, con
 
    std::unique_ptr<ROOT::Experimental::Detail::RFieldBase> result;
 
-   if (auto [arrayBaseType, arraySize] = ParseArrayType(typeName); !arraySize.empty()) {
+   if (auto [arrayBaseType, arraySize] = ParseArrayType(normalizedType); !arraySize.empty()) {
       // TODO(jalopezg): support multi-dimensional row-major (C order) arrays in RArrayField
       if (arraySize.size() > 1)
          return R__FAIL("multi-dimensional array type not supported " + normalizedType);

--- a/tree/ntuple/v7/test/CustomStruct.hxx
+++ b/tree/ntuple/v7/test/CustomStruct.hxx
@@ -35,6 +35,11 @@ struct DerivedC : public DerivedA, public DerivedA2 {
    DerivedA2 c_a2;
 };
 
+struct StructWithArrays {
+   unsigned char c[4];
+   float f[2];
+};
+
 struct EmptyBase {
 };
 struct alignas(std::uint64_t) TestEBO : public EmptyBase {

--- a/tree/ntuple/v7/test/CustomStructLinkDef.h
+++ b/tree/ntuple/v7/test/CustomStructLinkDef.h
@@ -9,6 +9,7 @@
 #pragma link C++ class DerivedA2+;
 #pragma link C++ class DerivedB+;
 #pragma link C++ class DerivedC+;
+#pragma link C++ class StructWithArrays + ;
 #pragma link C++ class TestEBO+;
 
 #pragma link C++ class IAuxSetOption+;

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -43,7 +43,7 @@ TEST(RNTuple, ArrayField)
    auto field = RFieldBase::Create("test", "int32_t[10]").Unwrap();
    EXPECT_EQ((10 * sizeof(int32_t)), field->GetValueSize());
    EXPECT_EQ(alignof(int32_t[10]), field->GetAlignment());
-   auto otherField = RFieldBase::Create("test", "std::vector<float[3]>[10]").Unwrap();
+   auto otherField = RFieldBase::Create("test", "std::vector<float[3]   > [10 ]  ").Unwrap();
    EXPECT_EQ((10 * sizeof(std::vector<float[3]>)), otherField->GetValueSize());
 
    // Malformed type names

--- a/tree/ntuple/v7/test/ntuple_types.cxx
+++ b/tree/ntuple/v7/test/ntuple_types.cxx
@@ -43,6 +43,13 @@ TEST(RNTuple, ArrayField)
    auto field = RFieldBase::Create("test", "int32_t[10]").Unwrap();
    EXPECT_EQ((10 * sizeof(int32_t)), field->GetValueSize());
    EXPECT_EQ(alignof(int32_t[10]), field->GetAlignment());
+   auto otherField = RFieldBase::Create("test", "std::vector<float[3]>[10]").Unwrap();
+   EXPECT_EQ((10 * sizeof(std::vector<float[3]>)), otherField->GetValueSize());
+
+   // Malformed type names
+   EXPECT_THROW(RFieldBase::Create("test", "unsigned int[]").Unwrap(), ROOT::Experimental::RException);
+   EXPECT_THROW(RFieldBase::Create("test", "unsigned int [[2").Unwrap(), ROOT::Experimental::RException);
+   EXPECT_THROW(RFieldBase::Create("test", "unsigned[2] int[10]").Unwrap(), ROOT::Experimental::RException);
 
    // Multi-dimensional arrays are not currently supported
    EXPECT_THROW(RFieldBase::Create("test", "int32_t[10][11]").Unwrap(), ROOT::Experimental::RException);


### PR DESCRIPTION
This pull request introduces RField support for C style arrays.  In particular, it provides a `RField<T[N]>` template specialization and allows for parsing of types of the form `T[n][m]...` in `RFieldBase::Create()`

Actual RField implementation is provided by RArrayField, which currently does not support multi-dimensional arrays, although it should be trivial to extend it (if need be in a future PR) to support row-major (C order) multi-dimension arrays.

Additionally, prior to this PR, class members whose type was an array of the form `T[n]` were stored as a scalar.  This is considered a bug (see #11732 for all the details).
The implementation provided here also fixes issue #11732.
 
## Changes or fixes:
- Add `RField<ItemT[N]>` template specialization that matches single-dimension arrays.
- Update `RFieldBase::Create()` to parse types of the form `T[n][m]...`.  As of this PR, it returns `R__FAIL()` for multi-dimensional arrays, though it should be trivial to add support for row-major multi-dimension arrays. 
- RClassField: for class members whose type is a C style array, complete the type name with the size for each dimension, e.g. `int[4][2]`
- Add array unit tests

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #11732.