### PR TITLE
Provide json_fwd.hpp for nlohmann 3.9.1 [6.26]

### DIFF
--- a/builtins/nlohmann/CMakeLists.txt
+++ b/builtins/nlohmann/CMakeLists.txt
@@ -17,10 +17,16 @@ add_custom_command(
      COMMENT "Copying nlohmann/json.hpp header to ${CMAKE_BINARY_DIR}/include"
      DEPENDS ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json.hpp)
 
-add_custom_target(builtin_nlohmann_json_incl DEPENDS ${CMAKE_BINARY_DIR}/include/nlohmann/json.hpp)
+add_custom_command(
+     OUTPUT ${CMAKE_BINARY_DIR}/include/nlohmann/json_fwd.hpp
+     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json_fwd.hpp ${CMAKE_BINARY_DIR}/include/nlohmann/json_fwd.hpp
+     COMMENT "Copying nlohmann/json_fwd.hpp header to ${CMAKE_BINARY_DIR}/include"
+     DEPENDS ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json_fwd.hpp)
+
+add_custom_target(builtin_nlohmann_json_incl DEPENDS ${CMAKE_BINARY_DIR}/include/nlohmann/json.hpp ${CMAKE_BINARY_DIR}/include/nlohmann/json_fwd.hpp)
 
 set_property(GLOBAL APPEND PROPERTY ROOT_HEADER_TARGETS builtin_nlohmann_json_incl)
 
-install(FILES ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nlohmann/)
+install(FILES ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json.hpp ${CMAKE_SOURCE_DIR}/builtins/nlohmann/json_fwd.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nlohmann/)
 
 

--- a/builtins/nlohmann/json_fwd.hpp
+++ b/builtins/nlohmann/json_fwd.hpp
@@ -1,0 +1,78 @@
+#ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
+
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+namespace nlohmann
+{
+/*!
+@brief default JSONSerializer template argument
+
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
+
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer,
+         class BinaryType = std::vector<std::uint8_t>>
+class basic_json;
+
+/*!
+@brief JSON Pointer
+
+A JSON pointer defines a string syntax for identifying a specific value
+within a JSON document. It can be used with functions `at` and
+`operator[]`. Furthermore, JSON pointers are the base for JSON patches.
+
+@sa [RFC 6901](https://tools.ietf.org/html/rfc6901)
+
+@since version 2.0.0
+*/
+template<typename BasicJsonType>
+class json_pointer;
+
+/*!
+@brief default JSON class
+
+This type is the default specialization of the @ref basic_json class which
+uses the standard template types.
+
+@since version 1.0.0
+*/
+using json = basic_json<>;
+
+template<class Key, class T, class IgnoredLess, class Allocator>
+struct ordered_map;
+
+/*!
+@brief ordered JSON class
+
+This type preserves the insertion order of object keys.
+
+@since version 3.9.0
+*/
+using ordered_json = basic_json<nlohmann::ordered_map>;
+
+}  // namespace nlohmann
+
+#endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_


### PR DESCRIPTION
For systems with old `nlohmann/json.hpp` ROOT fails to build while it can find not matching `json_fwd.hpp`.

Master branch uses newer nlohmann/hson.hpp, therefore one cannot backport changes directly
