### PR TITLE
use latest JSROOT in jupyter

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -72,7 +72,7 @@ if (typeof requirejs !== 'undefined') {{
 
     // We are in jupyter notebooks, use require.js which should be configured already
     requirejs.config({{
-       paths: {{ 'JSRootCore' : [ 'scripts/JSRoot.core', 'https://root.cern/js/6.3.4/scripts/JSRoot.core.min', 'https://jsroot.gsi.de/6.3.4/scripts/JSRoot.core.min' ] }}
+       paths: {{ 'JSRootCore' : [ 'build/jsroot', 'https://root.cern/js/7.2.1/build/jsroot', 'https://jsroot.gsi.de/7.2.1/build/jsroot' ] }}
     }})(['JSRootCore'],  function(Core) {{
        display_{jsDivId}(Core);
     }});
@@ -93,9 +93,9 @@ if (typeof requirejs !== 'undefined') {{
     }}
 
     // Try loading a local version of requirejs and fallback to cdn if not possible.
-    script_load_{jsDivId}(base_url + 'static/scripts/JSRoot.core.js', function(){{
+    script_load_{jsDivId}(base_url + 'static/build/jsroot.js', function(){{
         console.error('Fail to load JSROOT locally, please check your jupyter_notebook_config.py file');
-        script_load_{jsDivId}('https://root.cern/js/6.3.4/scripts/JSRoot.core.min.js', function(){{
+        script_load_{jsDivId}('https://root.cern/js/7.2.1/build/jsroot.js', function(){{
             document.getElementById("{jsDivId}").innerHTML = "Failed to load JSROOT";
         }});
     }});


### PR DESCRIPTION
Since JSROOT v7 one should use modules or bundle provided as `build/jsroot.js`.
This bundle can be loaded with `require.js` (as in jupyter notebooks) or just as regular script (as in jupyter lab).

Usage of `JSRootCore.js` is obsolete and should be avoided.

Use JSROOT version 7.2.1 as fallback if local version is not available.

