### PR TITLE
[RF] Improve RooVoigtian documentation

### DIFF
--- a/roofit/roofit/inc/RooVoigtian.h
+++ b/roofit/roofit/inc/RooVoigtian.h
@@ -16,27 +16,25 @@
 #ifndef ROO_VOIGTIAN
 #define ROO_VOIGTIAN
 
-#include "RooAbsPdf.h"
-#include "RooRealProxy.h"
-
-class RooRealVar;
+#include <RooAbsPdf.h>
+#include <RooRealProxy.h>
 
 class RooVoigtian : public RooAbsPdf {
 public:
-  RooVoigtian() {} ;
+  RooVoigtian() {}
   RooVoigtian(const char *name, const char *title,
          RooAbsReal& _x, RooAbsReal& _mean,
               RooAbsReal& _width, RooAbsReal& _sigma,
               bool doFast = false);
   RooVoigtian(const RooVoigtian& other, const char* name=nullptr) ;
   TObject* clone(const char* newname) const override { return new RooVoigtian(*this,newname); }
-  inline ~RooVoigtian() override { }
 
-// These methods allow the user to select the fast evaluation
-// of the complex error function using look-up tables
-// (default is the "slow" CERNlib algorithm)
-
+  /// Enable the fast evaluation of the complex error function using look-up
+  /// tables (default is the "slow" CERNlib algorithm).
   inline void selectFastAlgorithm()    { _doFast = true;  }
+
+  /// Disable the fast evaluation of the complex error function using look-up
+  /// tables (default is the "slow" CERNlib algorithm).
   inline void selectDefaultAlgorithm() { _doFast = false; }
 
 protected:
@@ -52,7 +50,7 @@ protected:
 
 private:
 
-  bool _doFast;
+  bool _doFast = false;
   ClassDefOverride(RooVoigtian,2) // Voigtian PDF (Gauss (x) BreitWigner)
 };
 

--- a/roofit/roofit/src/RooVoigtian.cxx
+++ b/roofit/roofit/src/RooVoigtian.cxx
@@ -23,20 +23,34 @@ function (the default CERNlib C335 algorithm, and a faster, look-up-table
 based method). By default, RooVoigtian employs the default (CERNlib)
 algorithm. Select the faster algorithm either in the constructor, or with
 the selectFastAlgorithm() method.
+
+\Note The "width" parameter that determines the Breit-Wigner shape
+      represents the **full width at half maximum (FWHM)** of the
+      Breit-Wigner (often referred to as \f$\Gamma\f$ or \f$2\gamma\f$).
 **/
 
-#include "RooVoigtian.h"
-#include "RooRealVar.h"
-#include "RooMath.h"
-#include "RooBatchCompute.h"
+#include <RooVoigtian.h>
+
+#include <RooMath.h>
+#include <RooBatchCompute.h>
 
 #include <cmath>
 #include <complex>
-using namespace std;
 
 ClassImp(RooVoigtian);
 
 ////////////////////////////////////////////////////////////////////////////////
+/// Construct a RooVoigtian PDF, which represents the convolution of a
+/// Breit-Wigner with a Gaussian.
+/// \param name Name that identifies the PDF in computations.
+/// \param title Title for plotting.
+/// \param _x The observable for the PDF.
+/// \param _mean The mean of the distribution.
+/// \param _width The **full width at half maximum (FWHM)** of the Breit-Wigner
+///               (often referred to as \f$\Gamma\f$ or \f$2\gamma\f$).
+/// \param _sigma The width of the Gaussian distribution.
+/// \param doFast Use the faster look-up-table-based method for the evaluation
+///               of the complex error function.
 
 RooVoigtian::RooVoigtian(const char *name, const char *title,
           RooAbsReal& _x, RooAbsReal& _mean,
@@ -79,7 +93,7 @@ double RooVoigtian::evaluate() const
   if (s==0.) return (1./(arg*arg+0.25*w*w));
 
   // Gauss for zero width
-  if (w==0.) return exp(coef*arg*arg);
+  if (w==0.) return std::exp(coef*arg*arg);
 
   // actual Voigtian for non-trivial width and sigma
   double c = 1./(sqrt(2.)*s);


### PR DESCRIPTION
The RooVoigtian uses the FWHM (Full width half maximum) as the width of the Breit-Wigner part, which is the usual definition from HEP text books because it corresponds to the decay width.

However, other sources define the Breit-Wigner profile with the HWHM (half width half maximum), for example the Wikipedia article: https://en.wikipedia.org/wiki/Cauchy_distribution

This can easily lead to mistakes if people use the RooVoigtian with the HWHM.

With this commit, it is explicitly stated in the docs that the RooVoigtian takes the FWHM, both in the constructor and the overall class documentation.

Furthermore, some other small improvements are made to the docs of the RooVoigtian, like converting some of the function documentations to doxygen.

Closes #11757.