### PR TITLE
Improve ListLibraries

### DIFF
--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -488,7 +488,7 @@ public:
    virtual void            Unload(const char *module);
    virtual UInt_t          LoadAllLibraries();
    virtual void            ListSymbols(const char *module, const char *re = "");
-   virtual void            ListLibraries(const char *regexp = "", Bool_t wildcard = kTRUE);
+   virtual void            ListLibraries(const char *regexp = "");
    virtual const char     *GetLibraries(const char *regexp = "",
                                         const char *option = "",
                                         Bool_t isRegexp = kTRUE);

--- a/core/base/inc/TSystem.h
+++ b/core/base/inc/TSystem.h
@@ -403,7 +403,7 @@ public:
    virtual TString         GetFromPipe(const char *command);
    virtual int             GetPid();
    virtual void            StackTrace();
-   
+
    [[ noreturn ]] virtual void Exit(int code, Bool_t mode = kTRUE);
    [[ noreturn ]] virtual void Abort(int code = 0);
 
@@ -488,7 +488,7 @@ public:
    virtual void            Unload(const char *module);
    virtual UInt_t          LoadAllLibraries();
    virtual void            ListSymbols(const char *module, const char *re = "");
-   virtual void            ListLibraries(const char *regexp = "");
+   virtual void            ListLibraries(const char *regexp = "", Bool_t wildcard = kTRUE);
    virtual const char     *GetLibraries(const char *regexp = "",
                                         const char *option = "",
                                         Bool_t isRegexp = kTRUE);

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2068,43 +2068,31 @@ void TSystem::ListSymbols(const char *, const char *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// List all loaded shared libraries. `regexp` is a wildcard expression,
-/// (see TRegexp::MakeWildcard) if `wildcard` is true (default) otherwise (if it is false)
-/// it is consider as a simple character string and only the libraries containing this
-/// character string  will be listed.
+/// List all loaded shared libraries. `regexp` is a regular expression.
+///
+/// Examples:
+///
+/// The following line lists all the librabries currently loaded:
+/// ~~~ {.cpp}
+///  gSystem->ListLibraries()
+/// ~~~
+///
+/// The following line lists all the librabries currently loaded have "RIO" in their names:
+/// ~~~ {.cpp}
+///  gSystem->ListLibraries(".*RIO.*")
+/// ~~~
 
-void TSystem::ListLibraries(const char *regexp, Bool_t wildcard)
-{
-   TString libs = GetLibraries(regexp,"", wildcard);
-   TRegexp separator("[^ \\t\\s]+");
-   TString s;
-   Ssiz_t start = 0, index = 0, end = 0;
-   int i = 0;
-
-   Printf(" ");
-   Printf("Loaded shared libraries");
-   Printf("=======================");
-
-   while ((start < libs.Length()) && (index != kNPOS)) {
-      index = libs.Index(separator, &end, start);
-      if (index >= 0) {
-         s = libs(index, end);
-         if (s.BeginsWith("-")) {
-            if (s.BeginsWith("-l")) {
-               Printf("%s", s.Data());
-               i++;
-            }
-         } else {
-            Printf("%s", s.Data());
-            i++;
-         }
-      }
-      start += end+1;
+void TSystem::ListLibraries(const char *regexp) {
+   if (!gSystem) return;
+   if (!(regexp && regexp[0])) regexp = ".*";
+   TRegexp pat(regexp, kFALSE);
+   TString libs(gSystem->GetLibraries());
+   TString tok;
+   Ssiz_t from = 0, ext;
+   while (libs.Tokenize(tok, from, " ")) {
+      if ((tok.Index(pat, &ext) != 0) || (ext != tok.Length())) continue;
+      std::cout << tok << "\n";
    }
-
-   Printf("-----------------------");
-   Printf("%d libraries loaded", i);
-   Printf("=======================");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2084,10 +2084,9 @@ void TSystem::ListSymbols(const char *, const char *)
 /// ~~~
 
 void TSystem::ListLibraries(const char *regexp) {
-   if (!gSystem) return;
    if (!(regexp && regexp[0])) regexp = ".*";
    TRegexp pat(regexp, kFALSE);
-   TString libs(gSystem->GetLibraries());
+   TString libs(GetLibraries());
    TString tok;
    Ssiz_t from = 0, ext;
    while (libs.Tokenize(tok, from, " ")) {

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2068,12 +2068,14 @@ void TSystem::ListSymbols(const char *, const char *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// List all loaded shared libraries. Regexp is a wildcard expression,
-/// see TRegexp::MakeWildcard.
+/// List all loaded shared libraries. `regexp` is a wildcard expression,
+/// (see TRegexp::MakeWildcard) if `wildcard` is true (default) otherwise (if it is false)
+/// it is consider as a simple character string and only the libraries containing this
+/// character string  will be listed.
 
-void TSystem::ListLibraries(const char *regexp)
+void TSystem::ListLibraries(const char *regexp, Bool_t wildcard)
 {
-   TString libs = GetLibraries(regexp);
+   TString libs = GetLibraries(regexp,"", wildcard);
    TRegexp separator("[^ \\t\\s]+");
    TString s;
    Ssiz_t start = 0, index = 0, end = 0;

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2068,7 +2068,8 @@ void TSystem::ListSymbols(const char *, const char *)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// List all loaded shared libraries. `regexp` is a regular expression.
+/// List the loaded shared libraries.
+/// `regexp` is a regular expression allowing to filter the list.
 ///
 /// Examples:
 ///
@@ -2077,7 +2078,7 @@ void TSystem::ListSymbols(const char *, const char *)
 ///  gSystem->ListLibraries()
 /// ~~~
 ///
-/// The following line lists all the libraries currently loaded have "RIO" in their names:
+/// The following line lists all the libraries currently loaded having "RIO" in their names:
 /// ~~~ {.cpp}
 ///  gSystem->ListLibraries(".*RIO.*")
 /// ~~~

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -382,7 +382,7 @@ loop_entry:
    }
    // handle every exception
    catch (...) {
-      Warning("Run", "handle uncaugth exception, terminating");
+      Warning("Run", "handle uncaught exception, terminating");
    }
 
 loop_end:
@@ -2072,12 +2072,12 @@ void TSystem::ListSymbols(const char *, const char *)
 ///
 /// Examples:
 ///
-/// The following line lists all the librabries currently loaded:
+/// The following line lists all the libraries currently loaded:
 /// ~~~ {.cpp}
 ///  gSystem->ListLibraries()
 /// ~~~
 ///
-/// The following line lists all the librabries currently loaded have "RIO" in their names:
+/// The following line lists all the libraries currently loaded have "RIO" in their names:
 /// ~~~ {.cpp}
 ///  gSystem->ListLibraries(".*RIO.*")
 /// ~~~

--- a/core/base/src/TSystem.cxx
+++ b/core/base/src/TSystem.cxx
@@ -2084,13 +2084,15 @@ void TSystem::ListSymbols(const char *, const char *)
 /// ~~~
 
 void TSystem::ListLibraries(const char *regexp) {
-   if (!(regexp && regexp[0])) regexp = ".*";
+   if (!(regexp && regexp[0]))
+      regexp = ".*";
    TRegexp pat(regexp, kFALSE);
    TString libs(GetLibraries());
    TString tok;
    Ssiz_t from = 0, ext;
    while (libs.Tokenize(tok, from, " ")) {
-      if ((tok.Index(pat, &ext) != 0) || (ext != tok.Length())) continue;
+      if ((tok.Index(pat, &ext) != 0) || (ext != tok.Length()))
+         continue;
       std::cout << tok << "\n";
    }
 }

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -117,7 +117,7 @@ public:
    int               ClosePipe(FILE *pipe) override;
    int               GetPid() override;
    void              StackTrace() override;
-   
+
    [[ noreturn ]] void Exit (int code, Bool_t mode = kTRUE) override;
    [[ noreturn ]] void Abort (int code = 0) override;
 
@@ -186,7 +186,7 @@ public:
    int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE) override;
    void              Unload(const char *module) override;
    void              ListSymbols(const char *module, const char *re = "") override;
-   void              ListLibraries(const char *regexp = "") override;
+   void              ListLibraries(const char *regexp = "", Bool_t wildcard = kTRUE) override;
 
    //---- RPC --------------------------------------------------
    TInetAddress      GetHostByName(const char *server) override;

--- a/core/unix/inc/TUnixSystem.h
+++ b/core/unix/inc/TUnixSystem.h
@@ -186,7 +186,7 @@ public:
    int               Load(const char *module, const char *entry = "", Bool_t system = kFALSE) override;
    void              Unload(const char *module) override;
    void              ListSymbols(const char *module, const char *re = "") override;
-   void              ListLibraries(const char *regexp = "", Bool_t wildcard = kTRUE) override;
+   void              ListLibraries(const char *regexp = "") override;
 
    //---- RPC --------------------------------------------------
    TInetAddress      GetHostByName(const char *server) override;

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -2792,9 +2792,9 @@ void TUnixSystem::ListSymbols(const char * /*module*/, const char * /*regexp*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// List all loaded shared libraries.
 
-void TUnixSystem::ListLibraries(const char *regexp)
+void TUnixSystem::ListLibraries(const char *regexp, Bool_t wildcard)
 {
-   TSystem::ListLibraries(regexp);
+   TSystem::ListLibraries(regexp, wildcard);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/core/unix/src/TUnixSystem.cxx
+++ b/core/unix/src/TUnixSystem.cxx
@@ -2792,9 +2792,9 @@ void TUnixSystem::ListSymbols(const char * /*module*/, const char * /*regexp*/)
 ////////////////////////////////////////////////////////////////////////////////
 /// List all loaded shared libraries.
 
-void TUnixSystem::ListLibraries(const char *regexp, Bool_t wildcard)
+void TUnixSystem::ListLibraries(const char *regexp)
 {
-   TSystem::ListLibraries(regexp, wildcard);
+   TSystem::ListLibraries(regexp);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As mentioned [here](https://root-forum.cern.ch/t/regex-usage-in-tsystem-listlibraries/52503), it is difficult to list libraries using regular expressions. The `regexp` parameter is in fact a wildcard that does not work when the libraries names contain `/` (see the help of [TRegexp::MakeWildcard](https://root.cern/doc/master/classTRegexp.html#ab2762d059ace7f79a45b76b0f3b1a1b1). An additional optional parameter allows to use the `regexp` parameter as a simple string. Only the libraries containing this character string will be listed.
Example:
```
root [0] gSystem->ListLibraries("Core")
 
Loaded shared libraries
=======================
-----------------------
0 libraries loaded
=======================


root [1] gSystem->ListLibraries("Core",kFALSE)
 
Loaded shared libraries
=======================
/Users/couet/git/couet-root-bin/lib/libCore.so
/Users/couet/git/couet-root-bin/lib/libMathCore.so
-----------------------
2 libraries loaded
=======================
```

