### PR TITLE
[skip-ci] add missing includes

### DIFF
--- a/documentation/doxygen/MakeRCanvasJS.C
+++ b/documentation/doxygen/MakeRCanvasJS.C
@@ -1,6 +1,10 @@
 /// Generates the json file output of the macro MacroName
 
 #include "ROOT/RCanvas.hxx"
+#include "TString.h"
+#include "TSystem.h"
+#include "TROOT.h"
+#include <fstream>
 
 void MakeRCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
 {

--- a/documentation/doxygen/MakeTCanvasJS.C
+++ b/documentation/doxygen/MakeTCanvasJS.C
@@ -1,5 +1,12 @@
 /// Generates the root file output of the macro MacroName
 
+#include "TString.h"
+#include "TCanvas.h"
+#include "TSystem.h"
+#include "TROOT.h"
+#include "TBufferJSON.h"
+#include <fstream>
+
 void MakeTCanvasJS(const char *MacroName, const char *IN, const char *OutDir, bool cp, bool py)
 {
 


### PR DESCRIPTION
Now the .C scripts used to build the reference guide are compiled using AClic to build the doc faster.
Some includes were missing.

