### PR TITLE
[DF] Move warning about lazy Snapshot to appropriate helpers

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1526,15 +1526,15 @@ void ValidateSnapshotOutput(const RSnapshotOptions &opts, const std::string &tre
 /// Helper object for a single-thread Snapshot action
 template <typename... ColTypes>
 class R__CLING_PTRCHECK(off) SnapshotHelper : public RActionImpl<SnapshotHelper<ColTypes...>> {
-   const std::string fFileName;
-   const std::string fDirName;
-   const std::string fTreeName;
-   const RSnapshotOptions fOptions;
+   std::string fFileName;
+   std::string fDirName;
+   std::string fTreeName;
+   RSnapshotOptions fOptions;
    std::unique_ptr<TFile> fOutputFile;
    std::unique_ptr<TTree> fOutputTree; // must be a ptr because TTrees are not copy/move constructible
    bool fBranchAddressesNeedReset{true};
-   const ColumnNames_t fInputBranchNames; // This contains the resolved aliases
-   const ColumnNames_t fOutputBranchNames;
+   ColumnNames_t fInputBranchNames; // This contains the resolved aliases
+   ColumnNames_t fOutputBranchNames;
    TTree *fInputTree = nullptr; // Current input tree. Set at initialization time (`InitTask`)
    // TODO we might be able to unify fBranches, fBranchAddresses and fOutputBranches
    std::vector<TBranch *> fBranches; // Addresses of branches in output, non-null only for the ones holding C arrays
@@ -1652,17 +1652,17 @@ public:
 /// Helper object for a multi-thread Snapshot action
 template <typename... ColTypes>
 class R__CLING_PTRCHECK(off) SnapshotHelperMT : public RActionImpl<SnapshotHelperMT<ColTypes...>> {
-   const unsigned int fNSlots;
+   unsigned int fNSlots;
    std::unique_ptr<ROOT::TBufferMerger> fMerger; // must use a ptr because TBufferMerger is not movable
    std::vector<std::shared_ptr<ROOT::TBufferMergerFile>> fOutputFiles;
    std::vector<std::unique_ptr<TTree>> fOutputTrees;
    std::vector<int> fBranchAddressesNeedReset; // vector<bool> does not allow concurrent writing of different elements
-   const std::string fFileName;           // name of the output file name
-   const std::string fDirName;            // name of TFile subdirectory in which output must be written (possibly empty)
-   const std::string fTreeName;           // name of output tree
-   const RSnapshotOptions fOptions;       // struct holding options to pass down to TFile and TTree in this action
-   const ColumnNames_t fInputBranchNames; // This contains the resolved aliases
-   const ColumnNames_t fOutputBranchNames;
+   std::string fFileName;           // name of the output file name
+   std::string fDirName;            // name of TFile subdirectory in which output must be written (possibly empty)
+   std::string fTreeName;           // name of output tree
+   RSnapshotOptions fOptions;       // struct holding options to pass down to TFile and TTree in this action
+   ColumnNames_t fInputBranchNames; // This contains the resolved aliases
+   ColumnNames_t fOutputBranchNames;
    std::vector<TTree *> fInputTrees; // Current input trees. Set at initialization time (`InitTask`)
    // Addresses of branches in output per slot, non-null only for the ones holding C arrays
    std::vector<std::vector<TBranch *>> fBranches;

--- a/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/ActionHelpers.hxx
@@ -1556,6 +1556,11 @@ public:
 
    SnapshotHelper(const SnapshotHelper &) = delete;
    SnapshotHelper(SnapshotHelper &&) = default;
+   ~SnapshotHelper()
+   {
+      if (!fTreeName.empty() /*not moved from*/ && !fOutputFile /* did not run */ && fOptions.fLazy)
+         Warning("Snapshot", "A lazy Snapshot action was booked but never triggered.");
+   }
 
    void InitTask(TTreeReader *r, unsigned int /* slot */)
    {
@@ -1687,6 +1692,12 @@ public:
    }
    SnapshotHelperMT(const SnapshotHelperMT &) = delete;
    SnapshotHelperMT(SnapshotHelperMT &&) = default;
+   ~SnapshotHelperMT()
+   {
+      if (!fTreeName.empty() /*not moved from*/ && fOptions.fLazy &&
+          std::all_of(fOutputFiles.begin(), fOutputFiles.end(), [](const auto &f) { return !f; }) /* never run */)
+         Warning("Snapshot", "A lazy Snapshot action was booked but never triggered.");
+   }
 
    void InitTask(TTreeReader *r, unsigned int slot)
    {

--- a/tree/dataframe/inc/ROOT/RResultPtr.hxx
+++ b/tree/dataframe/inc/ROOT/RResultPtr.hxx
@@ -41,21 +41,6 @@ class RInterface;
 namespace Internal {
 namespace RDF {
 class GraphCreatorHelper;
-
-// no-op overload
-template <typename T>
-inline void WarnOnLazySnapshotNotTriggered(const ROOT::RDF::RResultPtr<T> &)
-{
-}
-
-template <typename DS>
-void WarnOnLazySnapshotNotTriggered(
-   const ROOT::RDF::RResultPtr<ROOT::RDF::RInterface<ROOT::Detail::RDF::RLoopManager, DS>> &r)
-{
-   if (!r.IsReady()) {
-      Warning("Snapshot", "A lazy Snapshot action was booked but never triggered.");
-   }
-}
 }
 } // namespace Internal
 
@@ -192,12 +177,6 @@ public:
    RResultPtr &operator=(const RResultPtr &) = default;
    RResultPtr &operator=(RResultPtr &&) = default;
    explicit operator bool() const { return bool(fObjPtr); }
-   ~RResultPtr()
-   {
-      if (fObjPtr.use_count() == 1) {
-         ROOT::Internal::RDF::WarnOnLazySnapshotNotTriggered(*this);
-      }
-   }
 
    /// Convert a RResultPtr<T2> to a RResultPtr<T>.
    ///


### PR DESCRIPTION
It's not the responsibility of RResultPtr to check for unused lazy Snapshots.
