### PR TITLE
[RF] Ensure using variable clones also works for integrals - part 2

### DIFF
--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -18,7 +18,7 @@ ROOT_ADD_GTEST(testRooDataHist testRooDataHist.cxx LIBRARIES RooFitCore
                    ${CMAKE_CURRENT_SOURCE_DIR}/dataHistv6_ref.root)
 ROOT_ADD_GTEST(testRooBinSamplingPdf testRooBinSamplingPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooWrapperPdf testRooWrapperPdf.cxx LIBRARIES Gpad RooFitCore)
-ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testGenericPdf testGenericPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
@@ -44,19 +44,19 @@ if(NOT MSVC OR win_broken_tests)
   # Dsiabled on Windows because it causes the following error:
   # unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
   # According to the internet, this has to do with gtest, so it's not a RooFit problem
-  ROOT_ADD_GTEST(testRooRealIntegral testRooRealIntegral.cxx LIBRARIES RooFitCore RooFit)
+  ROOT_ADD_GTEST(testRooRealIntegral testRooRealIntegral.cxx LIBRARIES RooFitCore)
 
   ROOT_ADD_GTEST(testTestStatistics testTestStatistics.cxx LIBRARIES RooFitCore RooFit)
 endif()
 ROOT_ADD_GTEST(testNaNPacker testNaNPacker.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooSimultaneous testRooSimultaneous.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooSTLRefCountList testRooSTLRefCountList.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testLikelihoodSerial TestStatistics/testLikelihoodSerial.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsL TestStatistics/testRooAbsL.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooRealL TestStatistics/RooRealL.cpp LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testInterface TestStatistics/testInterface.cpp LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFit)
-ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFit)
+ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
 if (roofit_multiprocess)
   ROOT_ADD_GTEST(testTestStatisticsPlot TestStatistics/testPlot.cpp LIBRARIES RooFitMultiProcess RooFitCore RooFit

--- a/roofit/roofitcore/test/testGenericPdf.cxx
+++ b/roofit/roofitcore/test/testGenericPdf.cxx
@@ -2,7 +2,6 @@
 // Authors: Stephan Hageboeck, CERN  05/2019
 //          Jonas Rembser, CERN 06/2022
 
-#include <RooExponential.h>
 #include <RooRealVar.h>
 #include <RooGenericPdf.h>
 #include <RooWorkspace.h>
@@ -58,10 +57,11 @@ TEST(GenericPdf, CrashWhenRenamingArguments) {
 
 // ROOT-5101: Identity PDF affects normalization
 TEST(GenericPdf, IdentidyPdfNormalization) {
-  RooRealVar x{"x", "x", 0.0, 100.0};
-  RooRealVar s{"s", "s", -0.5, -10.0,  0.0};
+  RooWorkspace ws;
+  ws.factory("Exponential::exp(x[0.0, 100.0], s[-0.5, -10.0,  0.0])");
 
-  RooExponential exp{"exp", "exp", x, s};
+  RooRealVar& x = *ws.var("x");
+  RooAbsPdf& exp = *ws.pdf("exp");
 
   // This RooGenericPdf should behave exactly the same as the exponential, only
   // that the integration will be done numerically.

--- a/roofit/roofitcore/test/testRooPolyFunc.cxx
+++ b/roofit/roofitcore/test/testRooPolyFunc.cxx
@@ -1,19 +1,18 @@
 // Author: Rahul Balasubramanian, CERN  12/2021
 
-#include "RooPolyFunc.h"
+#include <RooFormulaVar.h>
+#include <RooPolyFunc.h>
+#include <RooRealVar.h>
+#include <RooWorkspace.h>
+#include <RooWrapperPdf.h>
 
-#include "RooPolynomial.h"
-#include "RooRealVar.h"
-#include "RooFormulaVar.h"
-#include "RooWrapperPdf.h"
+#include <gtest/gtest.h>
 
 #include <initializer_list>
 #include <iostream>
 #include <memory>
 #include <numeric>
 #include <string>
-
-#include "gtest/gtest.h"
 
 namespace {
 
@@ -46,14 +45,14 @@ using Doubles = std::initializer_list<double>;
 
 TEST(RooPolyFunc, WrappedPdfClosure)
 {
-   RooRealVar x("x", "x", 0., -10., 10.);
+   RooWorkspace ws;
+   ws.factory("Polynomial::pdf(x[0., -10., 10.], {c0[1.], c1[1.], c2[1.]}, 0)");
+
+   RooRealVar& x = *ws.var("x");
+   RooAbsPdf& pdf = *ws.pdf("pdf");
+
    auto polyfunc = makePolyFunc1D(x);
    RooWrapperPdf wrapperpdf("wrappdf", "wrappdf", *polyfunc);
-
-   RooRealVar c0("c0", "c0", 1.);
-   RooRealVar c1("c1", "c1", 1.);
-   RooRealVar c2("c2", "c2", 1.);
-   RooPolynomial pdf("pdf", "pdf", x, RooArgList(c0, c1, c2), /*lowestOrder=*/0.0);
 
    RooArgSet normSet{x};
    for (double theX : Doubles{-10., -5., -1., -0.5, 0., 0.5, 1., 5., 10.}) {


### PR DESCRIPTION
This is a direct fixup to commit https://github.com/root-project/root/commit/faa42a17e3614efbd97a91194243157b77e74fde. That commit tried to make
it possible to use also variable clones as integration variables, but it
failed to cover the case where the integration variable is only an
indirect server of the integrated function. This was because
`valueClients()` used for the graph traversal was still called on the
clone, not the variable in the actual computation graph of the
integrated function.

This commit fixes this by passing the correct variable to
`unmarkDepValueClients` to begin with.

A unit test for this case is also implemented.

As such, this PR is part of the series of PRs that redesigned the
RooRealIntegral client-server interface:

* https://github.com/root-project/root/pull/11597
* https://github.com/root-project/root/pull/11619
* https://github.com/root-project/root/pull/11662

A second commit in this PR makes less tests in RooFitCore depend on RooFit,
using the RooWorkspace factory. This reduces the time of increamental builds
where one changes the RooFit library, because the RooFitCore tests don't need
to be rebuilt.