### PR TITLE
[RF] Implement consideration of category range in simultaneous fits

### DIFF
--- a/roofit/roofitcore/inc/RooAbsTestStatistic.h
+++ b/roofit/roofitcore/inc/RooAbsTestStatistic.h
@@ -32,7 +32,6 @@ class RooSimultaneous ;
 class RooRealMPFE ;
 
 class RooAbsTestStatistic ;
-typedef RooAbsTestStatistic* pRooAbsTestStatistic ;
 typedef RooAbsData* pRooAbsData ;
 typedef RooRealMPFE* pRooRealMPFE ;
 
@@ -146,9 +145,7 @@ protected:
   Int_t       _extSet = 0;        ///<! Number of designated set to calculated extended term
 
   // Simultaneous mode data
-  Int_t          _nGof = 0    ;   ///< Number of sub-contexts
-  pRooAbsTestStatistic* _gofArray = nullptr;   ///<! Array of sub-contexts representing part of the combined test statistic
-  std::vector<RooFit::MPSplit> _gofSplitMode ; ///<! GOF MP Split mode specified by component (when Auto is active)
+  std::vector<std::unique_ptr<RooAbsTestStatistic>> _gofArray; ///<! Array of sub-contexts representing part of the combined test statistic
 
   // Parallel mode data
   Int_t          _nCPU = 1;            ///<  Number of processors to use in parallel calculation mode
@@ -160,7 +157,7 @@ protected:
   mutable ROOT::Math::KahanSum<double> _offset = 0.0; ///<! Offset as KahanSum to avoid loss of precision
   mutable double _evalCarry = 0.0;                  ///<! carry of Kahan sum in evaluatePartition
 
-  ClassDefOverride(RooAbsTestStatistic,3) // Abstract base class for real-valued test statistics
+  ClassDefOverride(RooAbsTestStatistic,4) // Abstract base class for real-valued test statistics
 
 };
 

--- a/roofit/roofitcore/res/RooNLLVarNew.h
+++ b/roofit/roofitcore/res/RooNLLVarNew.h
@@ -34,7 +34,7 @@ public:
 
    RooNLLVarNew(){};
    RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables, bool isExtended,
-                bool doOffset, int simCount = 1, bool binnedL = false);
+                bool doOffset, bool binnedL = false);
    RooNLLVarNew(const RooNLLVarNew &other, const char *name = nullptr);
    TObject *clone(const char *newname) const override { return new RooNLLVarNew(*this, newname); }
 
@@ -55,6 +55,8 @@ public:
 
    void enableOffsetting(bool) override;
 
+   void setSimCount(int simCount) { _simCount = simCount; }
+
 private:
    double evaluate() const override { return _value; }
    void resetWeightVarNames();
@@ -68,7 +70,7 @@ private:
    bool _weightSquared = false;
    bool _binnedL = false;
    bool _doOffset = false;
-   int _simCount = 0;
+   int _simCount = 1;
    std::string _prefix;
    RooTemplateProxy<RooAbsReal> _weightVar;
    RooTemplateProxy<RooAbsReal> _weightSquaredVar;

--- a/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsOptTestStatistic.cxx
@@ -301,7 +301,7 @@ void RooAbsOptTestStatistic::initSlave(RooAbsReal& real, RooAbsData& indata, con
              std::stringstream errMsg;
              errMsg << "The observable \"" << realObs->GetName() << "\" doesn't define the requested range \""
                     << token << "\". Replacing it with the default range." << std::endl;
-             coutW(Fitting) << errMsg.str() << std::endl;
+             coutI(Fitting) << errMsg.str() << std::endl;
           }
         }
       }

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -582,13 +582,10 @@ bool RooAbsTestStatistic::setData(RooAbsData& indata, bool cloneData)
         _gofArray[i]->setDataSlave(indata, cloneData);
       }
     } else {
-      const RooAbsCategoryLValue& indexCat = static_cast<RooSimultaneous*>(_func)->indexCat();
-      std::unique_ptr<TList> dlist{indata.split(indexCat, true)};
+      std::unique_ptr<TList> dlist{indata.split(*static_cast<RooSimultaneous*>(_func), processEmptyDataSets())};
       if (!dlist) {
-        coutF(DataHandling) << "Tried to split '" << indata.GetName() << "' into categories of '" << indexCat.GetName()
-            << "', but splitting failed. Input data:" << std::endl;
-        indata.Print("V");
-        throw std::runtime_error("Error when setting up test statistic: dataset couldn't be split into categories.");
+        coutE(Fitting) << "RooAbsTestStatistic::initSimMode(" << GetName() << ") ERROR: index category of simultaneous pdf is missing in dataset, aborting" << endl;
+        throw std::runtime_error("RooAbsTestStatistic::initSimMode() ERROR, index category of simultaneous pdf is missing in dataset, aborting");
       }
 
       for (int i = 0; i < _nGof; ++i) {

--- a/roofit/roofitcore/src/RooAbsTestStatistic.cxx
+++ b/roofit/roofitcore/src/RooAbsTestStatistic.cxx
@@ -126,7 +126,6 @@ RooAbsTestStatistic::RooAbsTestStatistic(const RooAbsTestStatistic& other, const
   // Determine if RooAbsReal is a RooSimultaneous
   _gofOpMode{(other._nCPU>1 || other._nCPU==-1) ? MPMaster : (dynamic_cast<RooSimultaneous*>(_func) ? SimMaster : Slave)},
   _nEvents{_data->numEntries()},
-  _gofSplitMode(other._gofSplitMode),
   _nCPU(other._nCPU != -1 ? other._nCPU : 1),
   _mpinterl(other._mpinterl),
   _doOffset(other._doOffset),
@@ -150,13 +149,7 @@ RooAbsTestStatistic::~RooAbsTestStatistic()
     delete[] _mpfeArray ;
   }
 
-  if (SimMaster == _gofOpMode && _init) {
-    for (Int_t i = 0; i < _nGof; ++i) delete _gofArray[i];
-    delete[] _gofArray ;
-  }
-
   delete _projDeps ;
-
 }
 
 
@@ -180,18 +173,20 @@ double RooAbsTestStatistic::evaluate() const
     double ret = 0.;
 
     if (_mpinterl == RooFit::BulkPartition || _mpinterl == RooFit::Interleave ) {
-      ret = combinedValue((RooAbsReal**)_gofArray,_nGof);
+      ret = combinedValue(reinterpret_cast<RooAbsReal**>(const_cast<std::unique_ptr<RooAbsTestStatistic>*>(_gofArray.data())),_gofArray.size());
     } else {
       double sum = 0., carry = 0.;
-      for (Int_t i = 0 ; i < _nGof; ++i) {
-   if (i % _numSets == _setNum || (_mpinterl==RooFit::Hybrid && _gofSplitMode[i] != RooFit::SimComponents )) {
-     double y = _gofArray[i]->getValV();
-     carry += _gofArray[i]->getCarry();
-     y -= carry;
-     const double t = sum + y;
-     carry = (t - sum) - y;
-     sum = t;
-   }
+      int i = 0;
+      for (auto& gof : _gofArray) {
+        if (i % _numSets == _setNum || (_mpinterl==RooFit::Hybrid && gof->_mpinterl != RooFit::SimComponents )) {
+          double y = gof->getValV();
+          carry += gof->getCarry();
+          y -= carry;
+          const double t = sum + y;
+          carry = (t - sum) - y;
+          sum = t;
+        }
+        ++i;
       }
       ret = sum ;
       _evalCarry = carry;
@@ -300,12 +295,10 @@ bool RooAbsTestStatistic::initialize()
 
 bool RooAbsTestStatistic::redirectServersHook(const RooAbsCollection& newServerList, bool mustReplaceAll, bool nameChange, bool isRecursive)
 {
-  if (SimMaster == _gofOpMode && _gofArray) {
+  if (SimMaster == _gofOpMode) {
     // Forward to slaves
-    for (Int_t i = 0; i < _nGof; ++i) {
-      if (_gofArray[i]) {
-   _gofArray[i]->recursiveRedirectServers(newServerList,mustReplaceAll,nameChange);
-      }
+    for(auto& gof : _gofArray) {
+      gof->recursiveRedirectServers(newServerList,mustReplaceAll,nameChange);
     }
   } else if (MPMaster == _gofOpMode&& _mpfeArray) {
     // Forward to slaves
@@ -330,12 +323,10 @@ void RooAbsTestStatistic::printCompactTreeHook(ostream& os, const char* indent)
   if (SimMaster == _gofOpMode) {
     // Forward to slaves
     os << indent << "RooAbsTestStatistic begin GOF contents" << endl ;
-    for (Int_t i = 0; i < _nGof; ++i) {
-      if (_gofArray[i]) {
-   TString indent2(indent);
-   indent2 += Form("[%d] ",i);
-   _gofArray[i]->printCompactTreeHook(os,indent2);
-      }
+    for (std::size_t i = 0; i < _gofArray.size(); ++i) {
+      TString indent2(indent);
+      indent2 += "[" + std::to_string(i) + "] ";
+      _gofArray[i]->printCompactTreeHook(os,indent2);
     }
     os << indent << "RooAbsTestStatistic end GOF contents" << endl;
   } else if (MPMaster == _gofOpMode) {
@@ -354,12 +345,14 @@ void RooAbsTestStatistic::constOptimizeTestStatistic(ConstOpCode opcode, bool do
   initialize();
   if (SimMaster == _gofOpMode) {
     // Forward to slaves
-    for (Int_t i = 0; i < _nGof; ++i) {
+    int i = 0;
+    for (auto& gof : _gofArray) {
       // In SimComponents Splitting strategy only constOptimize the terms that are actually used
-      RooFit::MPSplit effSplit = (_mpinterl!=RooFit::Hybrid) ? _mpinterl : _gofSplitMode[i];
+      RooFit::MPSplit effSplit = (_mpinterl!=RooFit::Hybrid) ? _mpinterl : gof->_mpinterl;
       if ( (i % _numSets == _setNum) || (effSplit != RooFit::SimComponents) ) {
-   if (_gofArray[i]) _gofArray[i]->constOptimizeTestStatistic(opcode,doAlsoTrackingOpt);
+        gof->constOptimizeTestStatistic(opcode,doAlsoTrackingOpt);
       }
+      ++i;
     }
   } else if (MPMaster == _gofOpMode) {
     for (Int_t i = 0; i < _nCPU; ++i) {
@@ -381,8 +374,8 @@ void RooAbsTestStatistic::setMPSet(Int_t inSetNum, Int_t inNumSets)
   if (SimMaster == _gofOpMode) {
     // Forward to slaves
     initialize();
-    for (Int_t i = 0; i < _nGof; ++i) {
-      if (_gofArray[i]) _gofArray[i]->setMPSet(inSetNum,inNumSets);
+    for(auto& gof : _gofArray) {
+      gof->setMPSet(inSetNum,inNumSets);
     }
   }
 }
@@ -449,30 +442,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
 
   RooAbsCategoryLValue& simCat = const_cast<RooAbsCategoryLValue&>(simpdf->indexCat());
 
-  TString simCatName(simCat.GetName());
-  TList* dsetList = const_cast<RooAbsData*>(data)->split(*simpdf,processEmptyDataSets());
-  if (!dsetList) {
-    coutE(Fitting) << "RooAbsTestStatistic::initSimMode(" << GetName() << ") ERROR: index category of simultaneous pdf is missing in dataset, aborting" << endl;
-    throw std::runtime_error("RooAbsTestStatistic::initSimMode() ERROR, index category of simultaneous pdf is missing in dataset, aborting");
-  }
-
-  // Count number of used states
-  Int_t n = 0;
-  _nGof = 0;
-
-  for (const auto& catState : simCat) {
-    // Retrieve the PDF for this simCat state
-    RooAbsPdf* pdf = simpdf->getPdf(catState.first.c_str());
-    RooAbsData* dset = (RooAbsData*) dsetList->FindObject(catState.first.c_str());
-
-    if (pdf && dset && (0. != dset->sumEntries() || processEmptyDataSets())) {
-      ++_nGof;
-    }
-  }
-
-  // Allocate arrays
-  _gofArray = new pRooAbsTestStatistic[_nGof];
-  _gofSplitMode.resize(_nGof);
+  std::unique_ptr<TList> dsetList{const_cast<RooAbsData*>(data)->split(*simpdf,processEmptyDataSets())};
 
   // Create array of regular fit contexts, containing subset of data and single fitCat PDF
   for (const auto& catState : simCat) {
@@ -482,7 +452,7 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
     RooAbsData* dset = (RooAbsData*) dsetList->FindObject(catName.c_str());
 
     if (pdf && dset && (0. != dset->sumEntries() || processEmptyDataSets())) {
-      ccoutI(Fitting) << "RooAbsTestStatistic::initSimMode: creating slave calculator #" << n << " for state " << catName
+      ccoutI(Fitting) << "RooAbsTestStatistic::initSimMode: creating slave calculator #" << _gofArray.size() << " for state " << catName
           << " (" << dset->numEntries() << " dataset entries)" << endl;
 
 
@@ -507,21 +477,12 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       }
       cfg.rangeName = RooHelpers::getRangeNameForSimComponent(rangeName, _splitRange, catName);
       cfg.nCPU = _nCPU;
-      _gofArray[n] = create(catName.c_str(),catName.c_str(),(binnedInfo.binnedPdf?*binnedInfo.binnedPdf:*pdf),*dset,*projDeps,cfg);
-      _gofArray[n]->setSimCount(_nGof);
+      _gofArray.emplace_back(create(catName.c_str(),catName.c_str(),(binnedInfo.binnedPdf?*binnedInfo.binnedPdf:*pdf),*dset,*projDeps,cfg));
       // *** END HERE
 
       // Fill per-component split mode with Bulk Partition for now so that Auto will map to bulk-splitting of all components
       if (_mpinterl==RooFit::Hybrid) {
-        if (dset->numEntries()<10) {
-          //cout << "RAT::initSim("<< GetName() << ") MP mode is auto, setting split mode for component "<< n << " to SimComponents"<< endl ;
-          _gofSplitMode[n] = RooFit::SimComponents;
-          _gofArray[n]->_mpinterl = RooFit::SimComponents;
-        } else {
-          //cout << "RAT::initSim("<< GetName() << ") MP mode is auto, setting split mode for component "<< n << " to BulkPartition"<< endl ;
-          _gofSplitMode[n] = RooFit::BulkPartition;
-          _gofArray[n]->_mpinterl = RooFit::BulkPartition;
-        }
+        _gofArray.back()->_mpinterl = dset->numEntries()<10 ? RooFit::SimComponents : RooFit::BulkPartition;
       }
 
       // Servers may have been redirected between instantiation and (deferred) initialization
@@ -529,13 +490,10 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       RooArgSet *actualParams = binnedInfo.binnedPdf ? binnedInfo.binnedPdf->getParameters(dset) : pdf->getParameters(dset);
       RooArgSet* selTargetParams = (RooArgSet*) _paramSet.selectCommon(*actualParams);
 
-      _gofArray[n]->recursiveRedirectServers(*selTargetParams);
+      _gofArray.back()->recursiveRedirectServers(*selTargetParams);
 
       delete selTargetParams;
       delete actualParams;
-
-      ++n;
-
     } else {
       if ((!dset || (0. != dset->sumEntries() && !processEmptyDataSets())) && pdf) {
         if (_verbose) {
@@ -545,10 +503,12 @@ void RooAbsTestStatistic::initSimMode(RooSimultaneous* simpdf, RooAbsData* data,
       }
     }
   }
-  coutI(Fitting) << "RooAbsTestStatistic::initSimMode: created " << n << " slave calculators." << endl;
+  for(auto& gof : _gofArray) {
+    gof->setSimCount(_gofArray.size());
+  }
+  coutI(Fitting) << "RooAbsTestStatistic::initSimMode: created " << _gofArray.size() << " slave calculators." << endl;
 
   dsetList->Delete(); // delete the content.
-  delete dsetList;
 }
 
 
@@ -572,14 +532,14 @@ bool RooAbsTestStatistic::setData(RooAbsData& indata, bool cloneData)
   case SimMaster:
     // Forward to slaves
     if (indata.canSplitFast()) {
-      for (int i = 0; i < _nGof; ++i) {
-        RooAbsData* compData = indata.getSimData(_gofArray[i]->GetName());
-        _gofArray[i]->setDataSlave(*compData, cloneData);
+      for(auto& gof : _gofArray) {
+        RooAbsData* compData = indata.getSimData(gof->GetName());
+        gof->setDataSlave(*compData, cloneData);
       }
     } else if (0 == indata.numEntries()) {
       // For an unsplit empty dataset, simply assign empty dataset to each component
-      for (int i = 0; i < _nGof; ++i) {
-        _gofArray[i]->setDataSlave(indata, cloneData);
+      for(auto& gof : _gofArray) {
+        gof->setDataSlave(indata, cloneData);
       }
     } else {
       std::unique_ptr<TList> dlist{indata.split(*static_cast<RooSimultaneous*>(_func), processEmptyDataSets())};
@@ -588,11 +548,11 @@ bool RooAbsTestStatistic::setData(RooAbsData& indata, bool cloneData)
         throw std::runtime_error("RooAbsTestStatistic::initSimMode() ERROR, index category of simultaneous pdf is missing in dataset, aborting");
       }
 
-      for (int i = 0; i < _nGof; ++i) {
-        if (auto compData = static_cast<RooAbsData*>(dlist->FindObject(_gofArray[i]->GetName()))) {
-          _gofArray[i]->setDataSlave(*compData,false,true);
+      for(auto& gof : _gofArray) {
+        if (auto compData = static_cast<RooAbsData*>(dlist->FindObject(gof->GetName()))) {
+          gof->setDataSlave(*compData,false,true);
         } else {
-          coutE(DataHandling) << "RooAbsTestStatistic::setData(" << GetName() << ") ERROR: Cannot find component data for state " << _gofArray[i]->GetName() << endl;
+          coutE(DataHandling) << "RooAbsTestStatistic::setData(" << GetName() << ") ERROR: Cannot find component data for state " << gof->GetName() << endl;
         }
       }
     }
@@ -627,8 +587,8 @@ void RooAbsTestStatistic::enableOffsetting(bool flag)
     break ;
   case SimMaster:
     _doOffset = flag;
-    for (Int_t i = 0; i < _nGof; ++i) {
-      _gofArray[i]->enableOffsetting(flag);
+    for(auto& gof : _gofArray) {
+      gof->enableOffsetting(flag);
     }
     break ;
   case MPMaster:

--- a/roofit/roofitcore/src/RooNLLVar.cxx
+++ b/roofit/roofitcore/src/RooNLLVar.cxx
@@ -208,8 +208,8 @@ void RooNLLVar::applyWeightSquared(bool flag)
     for (int i=0 ; i<_nCPU ; i++)
       _mpfeArray[i]->applyNLLWeightSquared(flag);
   } else if ( _gofOpMode==SimMaster) {
-    for (int i=0 ; i<_nGof ; i++)
-      static_cast<RooNLLVar*>(_gofArray[i])->applyWeightSquared(flag);
+    for(auto& gof : _gofArray)
+      static_cast<RooNLLVar&>(*gof).applyWeightSquared(flag);
   }
 }
 

--- a/roofit/roofitcore/src/RooNLLVarNew.cxx
+++ b/roofit/roofitcore/src/RooNLLVarNew.cxx
@@ -72,9 +72,9 @@ RooArgSet getObs(RooAbsArg const &arg, RooArgSet const &observables)
 \param isExtended Set to true if this is an extended fit
 **/
 RooNLLVarNew::RooNLLVarNew(const char *name, const char *title, RooAbsPdf &pdf, RooArgSet const &observables,
-                           bool isExtended, bool doOffset, int simCount, bool binnedL)
+                           bool isExtended, bool doOffset, bool binnedL)
    : RooAbsReal(name, title), _pdf{"pdf", "pdf", this, pdf}, _observables{getObs(pdf, observables)},
-     _isExtended{isExtended}, _binnedL{binnedL}, _simCount{simCount},
+     _isExtended{isExtended}, _binnedL{binnedL},
      _weightVar{"weightVar", "weightVar", this, *new RooRealVar(weightVarName, weightVarName, 1.0), true, false, true},
      _weightSquaredVar{weightVarNameSumW2,
                        weightVarNameSumW2,
@@ -275,7 +275,8 @@ RooNLLVarNew::fillNormSetForServer(RooArgSet const & /*normSet*/, RooAbsArg cons
    return nullptr;
 }
 
-void RooNLLVarNew::enableOffsetting(bool flag) {
+void RooNLLVarNew::enableOffsetting(bool flag)
+{
    _doOffset = flag;
    _offset = {};
 }


### PR DESCRIPTION
It is possible to set ranges for a `RooCategory`, suggesting that this
is a possible way to select only a subset of channels in a simultaneous
fit. However, this was not working so far, and this commit implements
that.

This commit implements that feature for both the old test statistic
classes and the new BatchMode.

As now it also makes sense to fit to a range that is not defined for the
observables but for the categories only, the message that is printed
when your observables don't define the range is demoted from a warning
to an info message.

The debug message that was printed when channels are not selected also
got removed, because it had some overhead from `sumEntries`, the
debugging prints are rarely used, and the message is not true anymore
because chanels might also be skipped now becauese the are not selected
in the category range.

Also, a new unit test is implemented that verifies the `RooFit::Range()`
command argument for fitTo can be used to select specific components
from a RooSimultaneous.

Closes issue https://github.com/root-project/root/issues/8231.

Two additional commits in this PR make some improvements to the `RooAbsTestStatistic` code, as described in the commit descriptions.