### PR TITLE
[Geom] Fix behaviour of locking default units

### DIFF
--- a/geom/geom/src/TGeoManager.cxx
+++ b/geom/geom/src/TGeoManager.cxx
@@ -301,7 +301,7 @@ Int_t  TGeoManager::fgNumThreads      = 0;
 UInt_t TGeoManager::fgExportPrecision = 17;
 TGeoManager::EDefaultUnits TGeoManager::fgDefaultUnits = TGeoManager::kRootUnits;
 TGeoManager::ThreadsMap_t *TGeoManager::fgThreadId = 0;
-static Bool_t gGeometryLocked = kTRUE;
+static Bool_t gGeometryLocked = kFALSE;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
@@ -4034,6 +4034,7 @@ TGeoManager::EDefaultUnits TGeoManager::GetDefaultUnits()
 void TGeoManager::SetDefaultUnits(EDefaultUnits new_value)
 {
    if ( fgDefaultUnits == new_value )   {
+      gGeometryLocked = true;
       return;
    }
    else if ( gGeometryLocked )    {


### PR DESCRIPTION
The default was to lock the units by default, but this forced the user to unlocking via LockDefaultUnits(false) even if no geometry was created, otherwise a Fatal was issued. The patch allows changing the units once in the beginning and locks them automatically upon the definition of any element/material

# This Pull request:
Fixes an unintended behavior

## Changes or fixes:
The static flag `gGeometryLocked` is now set to false by default, and changed to true upon the first invocation of SetDefaultUnits, which all element/material constructors call. As a result, any subsequent attempt to change the units must be made by manual unlocking via `LockDefautUnits(false)`, or it will issue a fatal error.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

