### PR TITLE
[RF] ProcessTimer for logging timings in `RooFit::MultiProcess` and `RooFit::TestStatistics`, and HeatmapAnalyzer for analysing them

### DIFF
--- a/roofit/multiprocess/CMakeLists.txt
+++ b/roofit/multiprocess/CMakeLists.txt
@@ -15,13 +15,14 @@ ROOT_LINKER_LIBRARY(RooFitMultiProcess
         src/Job.cxx
         src/Config.cxx
         src/ProcessTimer.cxx
+        src/HeatmapAnalyzer.cxx
     LIBRARIES
         RooFitCommon
     DEPENDENCIES
         RooFitZMQ
 )
 
-target_link_libraries(RooFitMultiProcess PUBLIC RooFitZMQ)
+target_link_libraries(RooFitMultiProcess PUBLIC Hist RooFitZMQ)
 set(RooFitMultiProcess_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/res")
 target_include_directories(RooFitMultiProcess
         PRIVATE ${RooFitMultiProcess_INCLUDE_DIR}

--- a/roofit/multiprocess/CMakeLists.txt
+++ b/roofit/multiprocess/CMakeLists.txt
@@ -14,6 +14,7 @@ ROOT_LINKER_LIBRARY(RooFitMultiProcess
         src/JobManager.cxx
         src/Job.cxx
         src/Config.cxx
+        src/ProcessTimer.cxx
     LIBRARIES
         RooFitCommon
     DEPENDENCIES
@@ -25,6 +26,14 @@ set(RooFitMultiProcess_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/res")
 target_include_directories(RooFitMultiProcess
         PRIVATE ${RooFitMultiProcess_INCLUDE_DIR}
         INTERFACE $<BUILD_INTERFACE:${RooFitMultiProcess_INCLUDE_DIR}>)
+
+if(builtin_nlohmannjson)
+  target_include_directories(RooFitMultiProcess
+    PRIVATE ${CMAKE_SOURCE_DIR}/builtins
+    INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>/builtins)
+else()
+  target_link_libraries(RooFitMultiProcess PUBLIC nlohmann_json::nlohmann_json)
+endif()
 
 ROOT_ADD_TEST_SUBDIRECTORY(test)
 

--- a/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
@@ -26,8 +26,8 @@ public:
    static void setDefaultNWorkers(unsigned int N_workers);
    static unsigned int getDefaultNWorkers();
 
-   static void setLogTimings(bool logTimings);
-   static bool getLogTimings();
+   static void setTimingAnalysis(bool timingAnalysis);
+   static bool getTimingAnalysis();
 
    struct LikelihoodJob {
       // magic values to indicate that the number of tasks will be set automatically
@@ -49,7 +49,7 @@ public:
    };
 private:
    static unsigned int defaultNWorkers_;
-   static bool logTimings_;
+   static bool timingAnalysis_;
 };
 
 } // namespace MultiProcess

--- a/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/Config.h
@@ -26,6 +26,9 @@ public:
    static void setDefaultNWorkers(unsigned int N_workers);
    static unsigned int getDefaultNWorkers();
 
+   static void setLogTimings(bool logTimings);
+   static bool getLogTimings();
+
    struct LikelihoodJob {
       // magic values to indicate that the number of tasks will be set automatically
       constexpr static std::size_t automaticNEventTasks = 0;
@@ -46,6 +49,7 @@ public:
    };
 private:
    static unsigned int defaultNWorkers_;
+   static bool logTimings_;
 };
 
 } // namespace MultiProcess

--- a/roofit/multiprocess/inc/RooFit/MultiProcess/HeatmapAnalyzer.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/HeatmapAnalyzer.h
@@ -26,29 +26,29 @@ namespace MultiProcess {
 
 class HeatmapAnalyzer {
 public:
-    HeatmapAnalyzer(TString logs_dir);
+   HeatmapAnalyzer(TString logs_dir);
 
-    // main method of this class, produces heatmap
-    TH2I analyze(int analyzed_gradient);
+   // main method of this class, produces heatmap
+   TH2I analyze(int analyzed_gradient);
 
-    // getters to inspect logfiles
-    std::vector<std::string> const getPartitionNames();
-    std::vector<std::string> const getTaskNames();
-    json const getMetadata();
+   // getters to inspect logfiles
+   std::vector<std::string> const getPartitionNames();
+   std::vector<std::string> const getTaskNames();
+   json const getMetadata();
 
 private:
-    // internal helper functions
-    std::string findTaskForDuration(json durations, int start_t, int end_t);
-    void sortTaskNames(std::vector<std::string>& task_names);
+   // internal helper functions
+   std::string findTaskForDuration(json durations, int start_t, int end_t);
+   void sortTaskNames(std::vector<std::string> &task_names);
 
-    TH2I matrix_;
+   TH2I matrix_;
 
-    json gradients_;
-    json metadata_;
-    std::vector<json> durations_;
+   json gradients_;
+   json metadata_;
+   std::vector<json> durations_;
 
-    std::vector<std::string> tasks_names_;
-    std::vector<std::string> eval_partitions_names_;
+   std::vector<std::string> tasks_names_;
+   std::vector<std::string> eval_partitions_names_;
 };
 
 } // namespace MultiProcess

--- a/roofit/multiprocess/inc/RooFit/MultiProcess/HeatmapAnalyzer.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/HeatmapAnalyzer.h
@@ -1,0 +1,57 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   ZW, Zef Wolffs, Nikhef, zefwolffs@gmail.com
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#ifndef ROOT_ROOFIT_MultiProcess_HeatmapAnalyzer
+#define ROOT_ROOFIT_MultiProcess_HeatmapAnalyzer
+
+#include "TString.h"
+#include "TH2I.h"
+
+#include <vector>
+#include <string>
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+namespace RooFit {
+namespace MultiProcess {
+
+class HeatmapAnalyzer {
+public:
+    HeatmapAnalyzer(TString logs_dir);
+
+    // main method of this class, produces heatmap
+    TH2I analyze(int analyzed_gradient);
+
+    // getters to inspect logfiles
+    std::vector<std::string> const getPartitionNames();
+    std::vector<std::string> const getTaskNames();
+    json const getMetadata();
+
+private:
+    // internal helper functions
+    std::string findTaskForDuration(json durations, int start_t, int end_t);
+    void sortTaskNames(std::vector<std::string>& task_names);
+
+    TH2I matrix_;
+
+    json gradients_;
+    json metadata_;
+    std::vector<json> durations_;
+
+    std::vector<std::string> tasks_names_;
+    std::vector<std::string> eval_partitions_names_;
+};
+
+} // namespace MultiProcess
+} // namespace RooFit
+
+#endif // ROOT_ROOFIT_MultiProcess_HeatmapAnalyzer

--- a/roofit/multiprocess/inc/RooFit/MultiProcess/HeatmapAnalyzer.h
+++ b/roofit/multiprocess/inc/RooFit/MultiProcess/HeatmapAnalyzer.h
@@ -16,6 +16,7 @@
 #include "TString.h"
 #include "TH2I.h"
 
+#include <memory>
 #include <vector>
 #include <string>
 #include <nlohmann/json.hpp>
@@ -26,10 +27,10 @@ namespace MultiProcess {
 
 class HeatmapAnalyzer {
 public:
-   HeatmapAnalyzer(TString logs_dir);
+   HeatmapAnalyzer(std::string const& logs_dir);
 
    // main method of this class, produces heatmap
-   TH2I analyze(int analyzed_gradient);
+   std::unique_ptr<TH2I> analyze(int analyzed_gradient);
 
    // getters to inspect logfiles
    std::vector<std::string> const getPartitionNames();

--- a/roofit/multiprocess/res/RooFit/MultiProcess/ProcessTimer.h
+++ b/roofit/multiprocess/res/RooFit/MultiProcess/ProcessTimer.h
@@ -22,8 +22,6 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-using namespace std;
-
 namespace RooFit {
 namespace MultiProcess {
 
@@ -34,19 +32,19 @@ public:
    {
       ProcessTimer::process = proc;
       if (set_begin)
-         ProcessTimer::begin = chrono::steady_clock::now();
+         ProcessTimer::begin = std::chrono::steady_clock::now();
       ProcessTimer::previous_write = ProcessTimer::begin;
    };
 
    static pid_t get_process() { return ProcessTimer::process; };
    static void set_process(pid_t proc) { ProcessTimer::process = proc; };
 
-   static list<chrono::time_point<chrono::steady_clock>> get_durations(string section_name);
+   static std::list<std::chrono::time_point<std::chrono::steady_clock>> get_durations(std::string section_name);
 
-   static void start_timer(string section_name);
-   static void end_timer(string section_name);
+   static void start_timer(std::string section_name);
+   static void end_timer(std::string section_name);
 
-   static void print_durations(string to_print = "all");
+   static void print_durations(std::string to_print = "all");
    static void print_timestamps();
 
    static void write_file();
@@ -57,11 +55,11 @@ public:
 
 private:
    // Map of a list of timepoints, even timepoints are start times, uneven timepoints are end times
-   using duration_map_t = map<string, list<chrono::time_point<chrono::steady_clock>>>;
+   using duration_map_t = std::map<std::string, std::list<std::chrono::time_point<std::chrono::steady_clock>>>;
 
    static duration_map_t durations;
-   static chrono::time_point<chrono::steady_clock> begin;
-   static chrono::time_point<chrono::steady_clock> previous_write;
+   static std::chrono::time_point<std::chrono::steady_clock> begin;
+   static std::chrono::time_point<std::chrono::steady_clock> previous_write;
    static pid_t process;
    static json metadata;
    static int write_interval;

--- a/roofit/multiprocess/res/RooFit/MultiProcess/ProcessTimer.h
+++ b/roofit/multiprocess/res/RooFit/MultiProcess/ProcessTimer.h
@@ -1,3 +1,16 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   ZW, Zef Wolffs, Nikhef, zefwolffs@gmail.com
+ *   PB, Patrick Bos, Netherlands eScience Center, p.bos@esciencecenter.nl
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
 #ifndef ROOT_ROOFIT_MultiProcess_ProcessTimer
 #define ROOT_ROOFIT_MultiProcess_ProcessTimer
 
@@ -6,24 +19,17 @@
 #include <sys/types.h> // pid_t
 #include <map>
 #include <list>
-#include <tuple>
 #include <nlohmann/json.hpp>
+using json = nlohmann::json;
 
 using namespace std;
 
+namespace RooFit {
+namespace MultiProcess {
+
 class ProcessTimer {
-
-   // Map of a list of timepoints, even timepoints are start times, uneven timepoints are end times
-   using duration_map_t = map<string, list<chrono::time_point<chrono::steady_clock>>>;
-   static duration_map_t durations;
-   static chrono::time_point<chrono::steady_clock> begin;
-   static chrono::time_point<chrono::steady_clock> previous_write;
-   static pid_t process;
-   static nlohmann::json metadata;
-   static int write_interval;
-   static int times_written;
-
 public:
+   // setup processtimer, initialize some variables
    static void setup(pid_t proc, bool set_begin = true)
    {
       ProcessTimer::process = proc;
@@ -33,22 +39,36 @@ public:
    };
 
    static pid_t get_process() { return ProcessTimer::process; };
-
    static void set_process(pid_t proc) { ProcessTimer::process = proc; };
 
-   static void start_timer(string section_name);
+   static list<chrono::time_point<chrono::steady_clock>> get_durations(string section_name);
 
+   static void start_timer(string section_name);
    static void end_timer(string section_name);
 
    static void print_durations(string to_print = "all");
-
    static void print_timestamps();
 
    static void write_file();
 
-   static void add_metadata(nlohmann::json data);
+   static void add_metadata(json data);
 
    static void set_write_interval(int write_interval);
+
+private:
+   // Map of a list of timepoints, even timepoints are start times, uneven timepoints are end times
+   using duration_map_t = map<string, list<chrono::time_point<chrono::steady_clock>>>;
+
+   static duration_map_t durations;
+   static chrono::time_point<chrono::steady_clock> begin;
+   static chrono::time_point<chrono::steady_clock> previous_write;
+   static pid_t process;
+   static json metadata;
+   static int write_interval;
+   static int times_written;
 };
+
+} // namespace MultiProcess
+} // namespace RooFit
 
 #endif // ROOT_ROOFIT_MultiProcess_ProcessTimer

--- a/roofit/multiprocess/res/RooFit/MultiProcess/ProcessTimer.h
+++ b/roofit/multiprocess/res/RooFit/MultiProcess/ProcessTimer.h
@@ -1,0 +1,54 @@
+#ifndef ROOT_ROOFIT_MultiProcess_ProcessTimer
+#define ROOT_ROOFIT_MultiProcess_ProcessTimer
+
+#include <chrono>
+#include <string>
+#include <sys/types.h> // pid_t
+#include <map>
+#include <list>
+#include <tuple>
+#include <nlohmann/json.hpp>
+
+using namespace std;
+
+class ProcessTimer {
+
+   // Map of a list of timepoints, even timepoints are start times, uneven timepoints are end times
+   using duration_map_t = map<string, list<chrono::time_point<chrono::steady_clock>>>;
+   static duration_map_t durations;
+   static chrono::time_point<chrono::steady_clock> begin;
+   static chrono::time_point<chrono::steady_clock> previous_write;
+   static pid_t process;
+   static nlohmann::json metadata;
+   static int write_interval;
+   static int times_written;
+
+public:
+   static void setup(pid_t proc, bool set_begin = true)
+   {
+      ProcessTimer::process = proc;
+      if (set_begin)
+         ProcessTimer::begin = chrono::steady_clock::now();
+      ProcessTimer::previous_write = ProcessTimer::begin;
+   };
+
+   static pid_t get_process() { return ProcessTimer::process; };
+
+   static void set_process(pid_t proc) { ProcessTimer::process = proc; };
+
+   static void start_timer(string section_name);
+
+   static void end_timer(string section_name);
+
+   static void print_durations(string to_print = "all");
+
+   static void print_timestamps();
+
+   static void write_file();
+
+   static void add_metadata(nlohmann::json data);
+
+   static void set_write_interval(int write_interval);
+};
+
+#endif // ROOT_ROOFIT_MultiProcess_ProcessTimer

--- a/roofit/multiprocess/src/Config.cxx
+++ b/roofit/multiprocess/src/Config.cxx
@@ -75,18 +75,18 @@ void Config::setDefaultNWorkers(unsigned int N_workers)
    }
 }
 
-void Config::setLogTimings(bool logTimings)
+void Config::setTimingAnalysis(bool timingAnalysis)
 {
    if (JobManager::is_instantiated() && JobManager::instance()->process_manager().is_initialized()) {
-      printf("Warning: Config::setLogTimings cannot set logging of timings, forking has already taken place!\n");
+      printf("Warning: Config::setTimingAnalysis cannot set logging of timings, forking has already taken place!\n");
    } else {
-      logTimings_ = logTimings;
+      timingAnalysis_ = timingAnalysis;
    }
 }
 
-bool Config::getLogTimings()
+bool Config::getTimingAnalysis()
 {
-   return logTimings_;
+   return timingAnalysis_;
 }
 
 unsigned int Config::getDefaultNWorkers()
@@ -147,7 +147,7 @@ unsigned int Config::defaultNWorkers_ = std::thread::hardware_concurrency();
 std::size_t Config::LikelihoodJob::defaultNEventTasks = Config::LikelihoodJob::automaticNEventTasks;
 std::size_t Config::LikelihoodJob::defaultNComponentTasks = Config::LikelihoodJob::automaticNComponentTasks;
 Config::Queue::QueueType Config::Queue::queueType_ = Config::Queue::QueueType::FIFO;
-bool Config::logTimings_ = false;
+bool Config::timingAnalysis_ = false;
 
 } // namespace MultiProcess
 } // namespace RooFit

--- a/roofit/multiprocess/src/Config.cxx
+++ b/roofit/multiprocess/src/Config.cxx
@@ -13,6 +13,7 @@
 #include "RooFit/MultiProcess/Config.h"
 #include "RooFit/MultiProcess/JobManager.h"
 #include "PriorityQueue.h"
+#include "RooFit/MultiProcess/ProcessManager.h"
 
 #include <thread> // std::thread::hardware_concurrency()
 #include <cstdio>
@@ -74,6 +75,20 @@ void Config::setDefaultNWorkers(unsigned int N_workers)
    }
 }
 
+void Config::setLogTimings(bool logTimings)
+{
+   if (JobManager::is_instantiated() && JobManager::instance()->process_manager().is_initialized()) {
+      printf("Warning: Config::setLogTimings cannot set logging of timings, forking has already taken place!\n");
+   } else {
+      logTimings_ = logTimings;
+   }
+}
+
+bool Config::getLogTimings()
+{
+   return logTimings_;
+}
+
 unsigned int Config::getDefaultNWorkers()
 {
    return defaultNWorkers_;
@@ -132,6 +147,7 @@ unsigned int Config::defaultNWorkers_ = std::thread::hardware_concurrency();
 std::size_t Config::LikelihoodJob::defaultNEventTasks = Config::LikelihoodJob::automaticNEventTasks;
 std::size_t Config::LikelihoodJob::defaultNComponentTasks = Config::LikelihoodJob::automaticNComponentTasks;
 Config::Queue::QueueType Config::Queue::queueType_ = Config::Queue::QueueType::FIFO;
+bool Config::logTimings_ = false;
 
 } // namespace MultiProcess
 } // namespace RooFit

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -25,180 +25,187 @@ namespace MultiProcess {
  * \brief Reads and processes logfiles produced by RooFit::MultiProcess::ProcessTimer
  *
  * RooFit::MultiProcess::ProcessTimer records timings of multiple processes simultaneously
- * and allows for these timings to be written out in json format, one for each process. 
+ * and allows for these timings to be written out in json format, one for each process.
  * This class, the HeatmapAnalyzer, can read these json files and produce a heatmap from
  * them with partial derivatives on the y-axis, likelihood evaluations on the x-axis, and
- * time expenditures on the z-axis. This class also contains some convenience functions 
+ * time expenditures on the z-axis. This class also contains some convenience functions
  * for inspecting these log files.
- * 
+ *
  * Note that this class requires the logfiles to contain three specific keys in the json:
  *      - `master:gradient` containing an array of gradient timestamps
  *      - `*eval_task*<task_number>` containing an array of task evaluation timestamps.
  *      - `*eval_partition*` containing an array of partition evaluation timestamps
  */
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// HeatmapAnalyzer Constructor. This method reads the input files in the folder
 /// specified by the user and creates internal attributes used by the other
 /// methods in this class.
-/// \param[in] logs_dir Directory where log files are stored in the format 
-///                     outputted by RooFit::MultiProcess::ProcessTimer. 
+/// \param[in] logs_dir Directory where log files are stored in the format
+///                     outputted by RooFit::MultiProcess::ProcessTimer.
 ///                     There can be other files in this directory as well.
 HeatmapAnalyzer::HeatmapAnalyzer(TString logs_dir)
 {
-    TSystemDirectory dir(logs_dir, logs_dir);
-    TList* duration_files = dir.GetListOfFiles();
+   TSystemDirectory dir(logs_dir, logs_dir);
+   TList *duration_files = dir.GetListOfFiles();
 
-    for(const auto&& file: *duration_files) {
-        if (!TString(file->GetName()).Contains("p_")) continue;
+   for (const auto &&file : *duration_files) {
+      if (!TString(file->GetName()).Contains("p_"))
+         continue;
 
-        std::ifstream f(logs_dir + "/" + TString(file->GetName()));
+      std::ifstream f(logs_dir + "/" + TString(file->GetName()));
 
-        if (TString(file->GetName()).Contains("999"))
-            gradients_ = json::parse(f);
-        else
-            durations_.push_back(json::parse(f));
-    }
+      if (TString(file->GetName()).Contains("999"))
+         gradients_ = json::parse(f);
+      else
+         durations_.push_back(json::parse(f));
+   }
 
-    for (json& durations_json: durations_) {
-        for (auto&& el : durations_json.items()) {
-            if (el.key().find("eval_task") != std::string::npos && 
-                std::find(tasks_names_.begin(), tasks_names_.end(), el.key()) == tasks_names_.end())
-                tasks_names_.push_back(el.key());
-            else if (el.key().find("eval_partition") != std::string::npos && 
-                     std::find(eval_partitions_names_.begin(), eval_partitions_names_.end(), el.key()) == eval_partitions_names_.end())
-                            eval_partitions_names_.push_back(el.key());
-            else if (el.key().find("metadata") != std::string::npos){
-                metadata_ = durations_json[el.key()];
-            }
-        }
-    }
+   for (json &durations_json : durations_) {
+      for (auto &&el : durations_json.items()) {
+         if (el.key().find("eval_task") != std::string::npos &&
+             std::find(tasks_names_.begin(), tasks_names_.end(), el.key()) == tasks_names_.end())
+            tasks_names_.push_back(el.key());
+         else if (el.key().find("eval_partition") != std::string::npos &&
+                  std::find(eval_partitions_names_.begin(), eval_partitions_names_.end(), el.key()) ==
+                     eval_partitions_names_.end())
+            eval_partitions_names_.push_back(el.key());
+         else if (el.key().find("metadata") != std::string::npos) {
+            metadata_ = durations_json[el.key()];
+         }
+      }
+   }
 
-    for (json& durations_json: durations_) {
-        durations_json.erase("metadata");
-    }
+   for (json &durations_json : durations_) {
+      durations_json.erase("metadata");
+   }
 
-    sortTaskNames(tasks_names_);
+   sortTaskNames(tasks_names_);
 
-    duration_files->Delete();
+   duration_files->Delete();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// This method is the main functionality in this class. It does the heavy
 /// lifting of matching duration timestamps to tasks and partition evaluations.
 /// \param[in] analyzed_gradient Gradient to analyze. For example, setting to 1
-///                              analyzes the first gradient (ordered by time) 
+///                              analyzes the first gradient (ordered by time)
 ///                              in the logs.
 TH2I HeatmapAnalyzer::analyze(int analyzed_gradient)
 {
-    int gradient_start_t = gradients_["master:gradient"][analyzed_gradient * 2 - 2];
-    int gradient_end_t = gradients_["master:gradient"][analyzed_gradient * 2 - 1];
+   int gradient_start_t = gradients_["master:gradient"][analyzed_gradient * 2 - 2];
+   int gradient_end_t = gradients_["master:gradient"][analyzed_gradient * 2 - 1];
 
-    TH2I total_matrix("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+   TH2I total_matrix("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
 
-    // loop over all logfiles stored in durations_
-    for (json& durations_json: durations_) {
-        // partial heatmap is the heatmap that will be filled in for the current durations logfile
-        TH2I partial_matrix("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
-        
-        // remove unneccesary components (those that are out of range)
-        for (auto&& el: durations_json.items()) {
-            auto beg_interval = std::upper_bound(durations_json[el.key()].begin(), durations_json[el.key()].end(), gradient_start_t);
-            auto end_interval = std::upper_bound(durations_json[el.key()].begin(), durations_json[el.key()].end(), gradient_end_t);
-            durations_json[el.key()].erase(end_interval, durations_json[el.key()].end());
-            durations_json[el.key()].erase(durations_json[el.key()].begin(), beg_interval);
-        }
+   // loop over all logfiles stored in durations_
+   for (json &durations_json : durations_) {
+      // partial heatmap is the heatmap that will be filled in for the current durations logfile
+      TH2I partial_matrix("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
 
-        // loops over all evaluated partitions in logfile
-        for (std::string& eval_partition_name : eval_partitions_names_) {
-            
-            // for this partition, loops over all durations, i.e. start and end times for partition evaluations, and for each tries
-            // to find the corresponding task
-            for (int idx = 0; idx < durations_json[eval_partition_name].size(); idx += 2) {
-                if (durations_json[eval_partition_name][idx + 1] > gradient_end_t || durations_json[eval_partition_name][idx] < gradient_start_t) continue;
-                std::string task_name = findTaskForDuration(durations_json, durations_json[eval_partition_name][idx], durations_json[eval_partition_name][idx + 1]);
-                
-                if (task_name == "") continue;
+      // remove unneccesary components (those that are out of range)
+      for (auto &&el : durations_json.items()) {
+         auto beg_interval =
+            std::upper_bound(durations_json[el.key()].begin(), durations_json[el.key()].end(), gradient_start_t);
+         auto end_interval =
+            std::upper_bound(durations_json[el.key()].begin(), durations_json[el.key()].end(), gradient_end_t);
+         durations_json[el.key()].erase(end_interval, durations_json[el.key()].end());
+         durations_json[el.key()].erase(durations_json[el.key()].begin(), beg_interval);
+      }
 
-                // add found combination of task, partition evaluation, and duration to partial matrix
-                int tasks_idx = find(tasks_names_.begin(), tasks_names_.end(), task_name) - tasks_names_.begin() + 1;
-                int eval_partitions_idx = find(eval_partitions_names_.begin(), eval_partitions_names_.end(), eval_partition_name) - eval_partitions_names_.begin() + 1;
-                partial_matrix.SetBinContent(eval_partitions_idx, tasks_idx, durations_json[eval_partition_name][idx + 1].get<int>() - durations_json[eval_partition_name][idx].get<int>());
-            }
-        }
-        // add all partial matrices to form one matrix with entire gradient evaluation information
-        total_matrix.Add(&partial_matrix);
-    }
+      // loops over all evaluated partitions in logfile
+      for (std::string &eval_partition_name : eval_partitions_names_) {
 
-    // do not need the legend in case heatmap is plotted
-    total_matrix.SetStats(0);
+         // for this partition, loops over all durations, i.e. start and end times for partition evaluations, and for
+         // each tries to find the corresponding task
+         for (int idx = 0; idx < durations_json[eval_partition_name].size(); idx += 2) {
+            if (durations_json[eval_partition_name][idx + 1] > gradient_end_t ||
+                durations_json[eval_partition_name][idx] < gradient_start_t)
+               continue;
+            std::string task_name = findTaskForDuration(durations_json, durations_json[eval_partition_name][idx],
+                                                        durations_json[eval_partition_name][idx + 1]);
 
-    // set the axes labels on the heatmap matrix
-    TAxis* y = total_matrix.GetYaxis();
-    TAxis* x = total_matrix.GetXaxis();
-    for (std::size_t i = 0; i != tasks_names_.size(); ++i) {
-        y->SetBinLabel(i+1, (metadata_[0][i].get<std::string>()).c_str());
-        y->ChangeLabel(i+1,30,0.01,-1,-1,-1,"");
-    }
-    for (std::size_t i = 0; i != eval_partitions_names_.size(); ++i) {
-        x->SetBinLabel(i+1, (eval_partitions_names_[i]).c_str());
-        x->ChangeLabel(i+1,30,-1,-1,-1,-1,"");
-    }
-    x->LabelsOption("v");
+            if (task_name == "")
+               continue;
 
-    return total_matrix;
+            // add found combination of task, partition evaluation, and duration to partial matrix
+            int tasks_idx = find(tasks_names_.begin(), tasks_names_.end(), task_name) - tasks_names_.begin() + 1;
+            int eval_partitions_idx =
+               find(eval_partitions_names_.begin(), eval_partitions_names_.end(), eval_partition_name) -
+               eval_partitions_names_.begin() + 1;
+            partial_matrix.SetBinContent(eval_partitions_idx, tasks_idx,
+                                         durations_json[eval_partition_name][idx + 1].get<int>() -
+                                            durations_json[eval_partition_name][idx].get<int>());
+         }
+      }
+      // add all partial matrices to form one matrix with entire gradient evaluation information
+      total_matrix.Add(&partial_matrix);
+   }
+
+   // do not need the legend in case heatmap is plotted
+   total_matrix.SetStats(0);
+
+   // set the axes labels on the heatmap matrix
+   TAxis *y = total_matrix.GetYaxis();
+   TAxis *x = total_matrix.GetXaxis();
+   for (std::size_t i = 0; i != tasks_names_.size(); ++i) {
+      y->SetBinLabel(i + 1, (metadata_[0][i].get<std::string>()).c_str());
+      y->ChangeLabel(i + 1, 30, 0.01, -1, -1, -1, "");
+   }
+   for (std::size_t i = 0; i != eval_partitions_names_.size(); ++i) {
+      x->SetBinLabel(i + 1, (eval_partitions_names_[i]).c_str());
+      x->ChangeLabel(i + 1, 30, -1, -1, -1, -1, "");
+   }
+   x->LabelsOption("v");
+
+   return total_matrix;
 }
 
 std::vector<std::string> const HeatmapAnalyzer::getTaskNames()
 {
-    return tasks_names_;
+   return tasks_names_;
 };
 
 std::vector<std::string> const HeatmapAnalyzer::getPartitionNames()
 {
-    return eval_partitions_names_;
+   return eval_partitions_names_;
 };
 
 json const HeatmapAnalyzer::getMetadata()
 {
-    return metadata_;
+   return metadata_;
 };
 
-
-
-std::string HeatmapAnalyzer::findTaskForDuration(json durations, int start_t, int end_t) 
+std::string HeatmapAnalyzer::findTaskForDuration(json durations, int start_t, int end_t)
 {
-    for (auto&& el : durations.items()) {
-        if (el.key().find("eval_partition") != std::string::npos) continue;
+   for (auto &&el : durations.items()) {
+      if (el.key().find("eval_partition") != std::string::npos)
+         continue;
 
-        for (int idx = 0; idx < durations[el.key()].size(); idx += 2) {
-            if (durations[el.key()][idx] <= start_t && durations[el.key()][idx + 1] >= end_t)
-            {
-                return el.key();
-            }
-        }
-    }
-    return "";
+      for (int idx = 0; idx < durations[el.key()].size(); idx += 2) {
+         if (durations[el.key()][idx] <= start_t && durations[el.key()][idx + 1] >= end_t) {
+            return el.key();
+         }
+      }
+   }
+   return "";
 }
 
-void HeatmapAnalyzer::sortTaskNames(std::vector<std::string>& task_names)
+void HeatmapAnalyzer::sortTaskNames(std::vector<std::string> &task_names)
 {
-    char const* digits = "0123456789";
-    std::vector<int> digit_vec;
-    std::vector<std::pair<int, std::string>> pair_vec;
-    for (auto&& el: task_names)
-    {
-        std::size_t const n = el.find_first_of(digits);
-        pair_vec.push_back(std::make_pair(stoi(el.substr(n)), el));
-    }
+   char const *digits = "0123456789";
+   std::vector<int> digit_vec;
+   std::vector<std::pair<int, std::string>> pair_vec;
+   for (auto &&el : task_names) {
+      std::size_t const n = el.find_first_of(digits);
+      pair_vec.push_back(std::make_pair(stoi(el.substr(n)), el));
+   }
 
-    std::sort(pair_vec.begin(), pair_vec.end());
+   std::sort(pair_vec.begin(), pair_vec.end());
 
-    for (int i = 0; i < task_names.size(); i++)
-    {
-        task_names[i] = pair_vec[i].second;
-    }
+   for (int i = 0; i < task_names.size(); i++) {
+      task_names[i] = pair_vec[i].second;
+   }
 }
 
 } // namespace MultiProcess

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -118,7 +118,7 @@ TH2I HeatmapAnalyzer::analyze(int analyzed_gradient)
 
          // for this partition, loops over all durations, i.e. start and end times for partition evaluations, and for
          // each tries to find the corresponding task
-         for (int idx = 0; idx < durations_json[eval_partition_name].size(); idx += 2) {
+         for (size_t idx = 0; idx < durations_json[eval_partition_name].size(); idx += 2) {
             if (durations_json[eval_partition_name][idx + 1] > gradient_end_t ||
                 durations_json[eval_partition_name][idx] < gradient_start_t)
                continue;
@@ -182,7 +182,7 @@ std::string HeatmapAnalyzer::findTaskForDuration(json durations, int start_t, in
       if (el.key().find("eval_partition") != std::string::npos)
          continue;
 
-      for (int idx = 0; idx < durations[el.key()].size(); idx += 2) {
+      for (size_t idx = 0; idx < durations[el.key()].size(); idx += 2) {
          if (durations[el.key()][idx] <= start_t && durations[el.key()][idx + 1] >= end_t) {
             return el.key();
          }
@@ -203,7 +203,7 @@ void HeatmapAnalyzer::sortTaskNames(std::vector<std::string> &task_names)
 
    std::sort(pair_vec.begin(), pair_vec.end());
 
-   for (int i = 0; i < task_names.size(); i++) {
+   for (size_t i = 0; i < task_names.size(); i++) {
       task_names[i] = pair_vec[i].second;
    }
 }

--- a/roofit/multiprocess/src/HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/src/HeatmapAnalyzer.cxx
@@ -1,0 +1,205 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   ZW, Zef Wolffs, Nikhef, zefwolffs@gmail.com
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooFit/MultiProcess/HeatmapAnalyzer.h"
+
+#include "TSystemDirectory.h"
+#include "TList.h"
+
+#include <fstream>
+
+namespace RooFit {
+namespace MultiProcess {
+
+/** \class HeatmapAnalyzer
+ *
+ * \brief Reads and processes logfiles produced by RooFit::MultiProcess::ProcessTimer
+ *
+ * RooFit::MultiProcess::ProcessTimer records timings of multiple processes simultaneously
+ * and allows for these timings to be written out in json format, one for each process. 
+ * This class, the HeatmapAnalyzer, can read these json files and produce a heatmap from
+ * them with partial derivatives on the y-axis, likelihood evaluations on the x-axis, and
+ * time expenditures on the z-axis. This class also contains some convenience functions 
+ * for inspecting these log files.
+ * 
+ * Note that this class requires the logfiles to contain three specific keys in the json:
+ *      - `master:gradient` containing an array of gradient timestamps
+ *      - `*eval_task*<task_number>` containing an array of task evaluation timestamps.
+ *      - `*eval_partition*` containing an array of partition evaluation timestamps
+ */
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// HeatmapAnalyzer Constructor. This method reads the input files in the folder
+/// specified by the user and creates internal attributes used by the other
+/// methods in this class.
+/// \param[in] logs_dir Directory where log files are stored in the format 
+///                     outputted by RooFit::MultiProcess::ProcessTimer. 
+///                     There can be other files in this directory as well.
+HeatmapAnalyzer::HeatmapAnalyzer(TString logs_dir)
+{
+    TSystemDirectory dir(logs_dir, logs_dir);
+    TList* duration_files = dir.GetListOfFiles();
+
+    for(const auto&& file: *duration_files) {
+        if (!TString(file->GetName()).Contains("p_")) continue;
+
+        std::ifstream f(logs_dir + "/" + TString(file->GetName()));
+
+        if (TString(file->GetName()).Contains("999"))
+            gradients_ = json::parse(f);
+        else
+            durations_.push_back(json::parse(f));
+    }
+
+    for (json& durations_json: durations_) {
+        for (auto&& el : durations_json.items()) {
+            if (el.key().find("eval_task") != std::string::npos && 
+                std::find(tasks_names_.begin(), tasks_names_.end(), el.key()) == tasks_names_.end())
+                tasks_names_.push_back(el.key());
+            else if (el.key().find("eval_partition") != std::string::npos && 
+                     std::find(eval_partitions_names_.begin(), eval_partitions_names_.end(), el.key()) == eval_partitions_names_.end())
+                            eval_partitions_names_.push_back(el.key());
+            else if (el.key().find("metadata") != std::string::npos){
+                metadata_ = durations_json[el.key()];
+            }
+        }
+    }
+
+    for (json& durations_json: durations_) {
+        durations_json.erase("metadata");
+    }
+
+    sortTaskNames(tasks_names_);
+
+    duration_files->Delete();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// This method is the main functionality in this class. It does the heavy
+/// lifting of matching duration timestamps to tasks and partition evaluations.
+/// \param[in] analyzed_gradient Gradient to analyze. For example, setting to 1
+///                              analyzes the first gradient (ordered by time) 
+///                              in the logs.
+TH2I HeatmapAnalyzer::analyze(int analyzed_gradient)
+{
+    int gradient_start_t = gradients_["master:gradient"][analyzed_gradient * 2 - 2];
+    int gradient_end_t = gradients_["master:gradient"][analyzed_gradient * 2 - 1];
+
+    TH2I total_matrix("heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+
+    // loop over all logfiles stored in durations_
+    for (json& durations_json: durations_) {
+        // partial heatmap is the heatmap that will be filled in for the current durations logfile
+        TH2I partial_matrix("partial_heatmap", "", eval_partitions_names_.size(), 0, 1, tasks_names_.size(), 0, 1);
+        
+        // remove unneccesary components (those that are out of range)
+        for (auto&& el: durations_json.items()) {
+            auto beg_interval = std::upper_bound(durations_json[el.key()].begin(), durations_json[el.key()].end(), gradient_start_t);
+            auto end_interval = std::upper_bound(durations_json[el.key()].begin(), durations_json[el.key()].end(), gradient_end_t);
+            durations_json[el.key()].erase(end_interval, durations_json[el.key()].end());
+            durations_json[el.key()].erase(durations_json[el.key()].begin(), beg_interval);
+        }
+
+        // loops over all evaluated partitions in logfile
+        for (std::string& eval_partition_name : eval_partitions_names_) {
+            
+            // for this partition, loops over all durations, i.e. start and end times for partition evaluations, and for each tries
+            // to find the corresponding task
+            for (int idx = 0; idx < durations_json[eval_partition_name].size(); idx += 2) {
+                if (durations_json[eval_partition_name][idx + 1] > gradient_end_t || durations_json[eval_partition_name][idx] < gradient_start_t) continue;
+                std::string task_name = findTaskForDuration(durations_json, durations_json[eval_partition_name][idx], durations_json[eval_partition_name][idx + 1]);
+                
+                if (task_name == "") continue;
+
+                // add found combination of task, partition evaluation, and duration to partial matrix
+                int tasks_idx = find(tasks_names_.begin(), tasks_names_.end(), task_name) - tasks_names_.begin() + 1;
+                int eval_partitions_idx = find(eval_partitions_names_.begin(), eval_partitions_names_.end(), eval_partition_name) - eval_partitions_names_.begin() + 1;
+                partial_matrix.SetBinContent(eval_partitions_idx, tasks_idx, durations_json[eval_partition_name][idx + 1].get<int>() - durations_json[eval_partition_name][idx].get<int>());
+            }
+        }
+        // add all partial matrices to form one matrix with entire gradient evaluation information
+        total_matrix.Add(&partial_matrix);
+    }
+
+    // do not need the legend in case heatmap is plotted
+    total_matrix.SetStats(0);
+
+    // set the axes labels on the heatmap matrix
+    TAxis* y = total_matrix.GetYaxis();
+    TAxis* x = total_matrix.GetXaxis();
+    for (std::size_t i = 0; i != tasks_names_.size(); ++i) {
+        y->SetBinLabel(i+1, (metadata_[0][i].get<std::string>()).c_str());
+        y->ChangeLabel(i+1,30,0.01,-1,-1,-1,"");
+    }
+    for (std::size_t i = 0; i != eval_partitions_names_.size(); ++i) {
+        x->SetBinLabel(i+1, (eval_partitions_names_[i]).c_str());
+        x->ChangeLabel(i+1,30,-1,-1,-1,-1,"");
+    }
+    x->LabelsOption("v");
+
+    return total_matrix;
+}
+
+std::vector<std::string> const HeatmapAnalyzer::getTaskNames()
+{
+    return tasks_names_;
+};
+
+std::vector<std::string> const HeatmapAnalyzer::getPartitionNames()
+{
+    return eval_partitions_names_;
+};
+
+json const HeatmapAnalyzer::getMetadata()
+{
+    return metadata_;
+};
+
+
+
+std::string HeatmapAnalyzer::findTaskForDuration(json durations, int start_t, int end_t) 
+{
+    for (auto&& el : durations.items()) {
+        if (el.key().find("eval_partition") != std::string::npos) continue;
+
+        for (int idx = 0; idx < durations[el.key()].size(); idx += 2) {
+            if (durations[el.key()][idx] <= start_t && durations[el.key()][idx + 1] >= end_t)
+            {
+                return el.key();
+            }
+        }
+    }
+    return "";
+}
+
+void HeatmapAnalyzer::sortTaskNames(std::vector<std::string>& task_names)
+{
+    char const* digits = "0123456789";
+    std::vector<int> digit_vec;
+    std::vector<std::pair<int, std::string>> pair_vec;
+    for (auto&& el: task_names)
+    {
+        std::size_t const n = el.find_first_of(digits);
+        pair_vec.push_back(std::make_pair(stoi(el.substr(n)), el));
+    }
+
+    std::sort(pair_vec.begin(), pair_vec.end());
+
+    for (int i = 0; i < task_names.size(); i++)
+    {
+        task_names[i] = pair_vec[i].second;
+    }
+}
+
+} // namespace MultiProcess
+} // namespace RooFit

--- a/roofit/multiprocess/src/ProcessManager.cxx
+++ b/roofit/multiprocess/src/ProcessManager.cxx
@@ -14,7 +14,10 @@
 #include "RooFit/MultiProcess/ProcessManager.h"
 #include "RooFit/MultiProcess/JobManager.h"
 #include "RooFit/MultiProcess/util.h"
+#include "RooFit/MultiProcess/ProcessTimer.h"
+#include "RooFit/MultiProcess/Config.h"
 
+#include <thread>
 #include <cstring>    // for strsignal
 #include <sys/wait.h> // for wait
 #include <iostream>
@@ -109,11 +112,19 @@ void ProcessManager::initialize_processes(bool cpu_pinning)
 {
    // Initialize processes;
    // ... first workers:
+
+   // Setup process timer master and assign pid_t 999
+   if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::setup(999);
+
    worker_pids_.resize(N_workers_);
    pid_t child_pid{};
    for (std::size_t ix = 0; ix < N_workers_; ++ix) {
       child_pid = fork_and_handle_errors();
       if (!child_pid) { // we're on the worker
+         // Setup process timer, do not overwrite begin time, this keeps timing
+         // synced between worker and master processes. The forked process keeps
+         // the master process' begin time
+         if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::setup(ix, false);
          is_worker_ = true;
          worker_id_ = ix;
          break;
@@ -255,6 +266,9 @@ int chill_wait()
 void ProcessManager::shutdown_processes()
 {
    if (is_master()) {
+      if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::write_file();
+      // Give children some time to write to file
+      if (RooFit::MultiProcess::Config::getLogTimings()) std::this_thread::sleep_for(std::chrono::seconds(2));
       // terminate all children
       std::unordered_set<pid_t> children;
       children.insert(queue_pid_);

--- a/roofit/multiprocess/src/ProcessManager.cxx
+++ b/roofit/multiprocess/src/ProcessManager.cxx
@@ -114,7 +114,7 @@ void ProcessManager::initialize_processes(bool cpu_pinning)
    // ... first workers:
 
    // Setup process timer master and assign pid_t 999
-   if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::setup(999);
+   if (RooFit::MultiProcess::Config::getTimingAnalysis()) ProcessTimer::setup(999);
 
    worker_pids_.resize(N_workers_);
    pid_t child_pid{};
@@ -124,7 +124,7 @@ void ProcessManager::initialize_processes(bool cpu_pinning)
          // Setup process timer, do not overwrite begin time, this keeps timing
          // synced between worker and master processes. The forked process keeps
          // the master process' begin time
-         if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::setup(ix, false);
+         if (RooFit::MultiProcess::Config::getTimingAnalysis()) ProcessTimer::setup(ix, false);
          is_worker_ = true;
          worker_id_ = ix;
          break;
@@ -266,9 +266,9 @@ int chill_wait()
 void ProcessManager::shutdown_processes()
 {
    if (is_master()) {
-      if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::write_file();
+      if (RooFit::MultiProcess::Config::getTimingAnalysis()) ProcessTimer::write_file();
       // Give children some time to write to file
-      if (RooFit::MultiProcess::Config::getLogTimings()) std::this_thread::sleep_for(std::chrono::seconds(2));
+      if (RooFit::MultiProcess::Config::getTimingAnalysis()) std::this_thread::sleep_for(std::chrono::seconds(2));
       // terminate all children
       std::unordered_set<pid_t> children;
       children.insert(queue_pid_);

--- a/roofit/multiprocess/src/ProcessTimer.cxx
+++ b/roofit/multiprocess/src/ProcessTimer.cxx
@@ -24,9 +24,9 @@ namespace MultiProcess {
  *
  * \brief Can be used to generate timings of multiple processes simultaneously and output logs
  *
- * This static class records timings of multiple processes simultaneously and allows for these 
+ * This static class records timings of multiple processes simultaneously and allows for these
  * timings to be written out in json format, one file for each process. Multiple overlapping
- * sections can be timed independently on the same process. It also allows for the timings 
+ * sections can be timed independently on the same process. It also allows for the timings
  * to be written out to json logfiles in a specified interval, for example every half hour.
  */
 
@@ -41,8 +41,9 @@ list<chrono::time_point<chrono::steady_clock>> ProcessTimer::get_durations(strin
       else
          return duration_list;
    }
-   throw ::invalid_argument("section name " + to_return + " not found in timer map, so it cannot"
-                          " be retrieved");
+   throw ::invalid_argument("section name " + to_return +
+                            " not found in timer map, so it cannot"
+                            " be retrieved");
 }
 
 void ProcessTimer::start_timer(string section_name)

--- a/roofit/multiprocess/src/ProcessTimer.cxx
+++ b/roofit/multiprocess/src/ProcessTimer.cxx
@@ -17,6 +17,8 @@
 #include <fstream>
 #include <iomanip> // setw
 
+using namespace std;
+
 namespace RooFit {
 namespace MultiProcess {
 
@@ -28,6 +30,8 @@ namespace MultiProcess {
  * timings to be written out in json format, one file for each process. Multiple overlapping
  * sections can be timed independently on the same process. It also allows for the timings
  * to be written out to json logfiles in a specified interval, for example every half hour.
+ * 
+ * Note that this class logs timings in milliseconds.
  */
 
 list<chrono::time_point<chrono::steady_clock>> ProcessTimer::get_durations(string to_return)

--- a/roofit/multiprocess/src/ProcessTimer.cxx
+++ b/roofit/multiprocess/src/ProcessTimer.cxx
@@ -1,0 +1,150 @@
+#include "RooFit/MultiProcess/ProcessTimer.h"
+
+#include <thread>
+#include <iostream>
+#include <thread>
+#include <fstream>
+#include <iomanip> // setw
+
+void ProcessTimer::start_timer(string section_name)
+{
+   auto it = ProcessTimer::durations.find(section_name);
+   if (it == ProcessTimer::durations.end()) {
+      // Key does not exist in map yet, start the first timer of this section
+      ProcessTimer::durations.insert({section_name, {chrono::steady_clock::now()}});
+   } else if (it->second.size() % 2 != 0) {
+      // All even indices contain start times, if size of list is currently even we can not start a new timer
+      throw ::invalid_argument("Section name " + section_name +
+                               " timer has already started, and was not stopped before calling `start_timer`");
+   } else {
+      // Add start time to list
+      it->second.push_back(chrono::steady_clock::now());
+   }
+}
+
+void ProcessTimer::end_timer(string section_name)
+{
+   auto it = ProcessTimer::durations.find(section_name);
+   if (it == ProcessTimer::durations.end()) {
+      // Key does not exist in map yet
+      throw ::invalid_argument("Section name " + section_name + " timer was never started!");
+   } else if (it->second.size() % 2 == 0) {
+      // All odd indices contain end times, if size of list is currently odd we can not start a new timer
+      throw ::invalid_argument("Section name " + section_name +
+                               " timer does exist, but was not started before calling `end_timer`");
+   } else {
+      // Add end time to list
+      it->second.push_back(chrono::steady_clock::now());
+   }
+
+   // Write to file intermittently if interval is reached and write_interval is set
+   if (write_interval && (chrono::duration_cast<chrono::seconds>(chrono::steady_clock::now() - previous_write).count() >
+                          write_interval)) {
+      previous_write = chrono::steady_clock::now();
+      ProcessTimer::write_file();
+      times_written++;
+   }
+}
+
+void ProcessTimer::print_durations(string to_print)
+{
+   cout << "On PID: " << ProcessTimer::process << endl << "====================" << endl << endl;
+   ProcessTimer::duration_map_t::key_type sec_name;
+   ProcessTimer::duration_map_t::mapped_type duration_list;
+   for (auto const &durations_element : ProcessTimer::durations) {
+      std::tie(sec_name, duration_list) = std::move(durations_element);
+      if (to_print != "all" && sec_name != to_print)
+         continue; // continue if only asked for specific section
+
+      int i = 0;
+      long total_duration = 0;
+      cout << "Section name " << sec_name << ":" << endl;
+      for (auto it = duration_list.begin(); it != duration_list.end(); ++it) {
+         long duration = chrono::duration_cast<chrono::milliseconds>(*++it - *it).count();
+         cout << "Duration " << i << ": " << duration << "ms +" << endl;
+         total_duration += duration;
+         i++;
+      }
+      cout << "--------------------" << endl << "Total: " << total_duration << "ms" << endl << endl;
+   }
+}
+
+void ProcessTimer::print_timestamps()
+{
+   cout << "On PID: " << ProcessTimer::process << endl;
+   ProcessTimer::duration_map_t::key_type sec_name;
+   ProcessTimer::duration_map_t::mapped_type duration_list;
+   for (auto const &durations_element : ProcessTimer::durations) {
+      std::tie(sec_name, duration_list) = std::move(durations_element);
+      int i = 0;
+      cout << "Section name " << sec_name << ":" << endl;
+      for (auto it = duration_list.begin(); it != duration_list.end(); ++it) {
+         long duration_since_begin_start =
+            chrono::duration_cast<chrono::milliseconds>(*it - ProcessTimer::begin).count();
+
+         long duration_since_begin_end =
+            chrono::duration_cast<chrono::milliseconds>(*++it - ProcessTimer::begin).count();
+
+         cout << "Duration " << i << ": " << duration_since_begin_start << "ms-->" << duration_since_begin_end << "ms"
+              << endl;
+         i++;
+      }
+   }
+}
+
+void ProcessTimer::write_file()
+{
+   nlohmann::json j;
+   j["metadata"] = metadata;
+   std::ofstream file("p_" + to_string((long)ProcessTimer::get_process()) + ".json." + to_string(times_written),
+                      ios::app);
+   list<long> durations_since_begin;
+
+   ProcessTimer::duration_map_t::key_type sec_name;
+   ProcessTimer::duration_map_t::mapped_type duration_list;
+   for (auto const &durations_element : ProcessTimer::durations) {
+      std::tie(sec_name, duration_list) = std::move(durations_element);
+      durations_since_begin.clear();
+      for (auto const &timestamp : duration_list) {
+         durations_since_begin.push_back(
+            chrono::duration_cast<chrono::microseconds>(timestamp - ProcessTimer::begin).count());
+      }
+      j[sec_name] = durations_since_begin;
+   }
+   file << std::setw(4) << j;
+   file.close();
+}
+
+void ProcessTimer::add_metadata(nlohmann::json data)
+{
+   if (write_interval) {
+      nlohmann::json j, meta;
+      meta.push_back(std::move(data));
+      j["metadata"] = meta;
+      std::ofstream file("p_" + to_string((long)ProcessTimer::get_process()) + ".json", ios::app);
+      file << std::setw(4) << j;
+   } else {
+      metadata.push_back(std::move(data));
+   }
+}
+
+void ProcessTimer::set_write_interval(int write_int)
+{
+   write_interval = write_int;
+   if (write_interval) {
+      nlohmann::json j, meta;
+      meta["write_interval"] = true;
+      j["metadata"] = meta;
+      std::ofstream file("p_" + to_string((long)ProcessTimer::get_process()) + ".json", ios::app);
+      file << std::setw(4) << j;
+   }
+}
+
+// Initialize static members
+ProcessTimer::duration_map_t ProcessTimer::durations;
+chrono::time_point<chrono::steady_clock> ProcessTimer::begin = chrono::steady_clock::now();
+chrono::time_point<chrono::steady_clock> ProcessTimer::previous_write = chrono::steady_clock::now();
+pid_t ProcessTimer::process = 0;
+nlohmann::json ProcessTimer::metadata;
+int ProcessTimer::write_interval = 0;
+int ProcessTimer::times_written = 0;

--- a/roofit/multiprocess/src/worker.cxx
+++ b/roofit/multiprocess/src/worker.cxx
@@ -18,7 +18,10 @@
 #include "RooFit/MultiProcess/Messenger.h"
 #include "RooFit/MultiProcess/Job.h"
 #include "RooFit/MultiProcess/util.h"
+#include "RooFit/MultiProcess/ProcessTimer.h"
+#include "RooFit/MultiProcess/Config.h"
 
+#include <string>
 #include <unistd.h> // getpid, pid_t
 #include <cerrno>   // EINTR
 #include <csignal>  // sigprocmask etc
@@ -107,8 +110,9 @@ void worker_loop()
                         JobManager::instance()->messenger().receive_from_master_on_worker<std::size_t>();
                      JobManager::get_job_object(job_id_for_state)->update_state();
                   }
-
+                  if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::start_timer("worker:eval_task:" + std::to_string(task_id));
                   JobManager::get_job_object(job_id)->evaluate_task(task_id);
+                  if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::end_timer("worker:eval_task:" + std::to_string(task_id));
                   JobManager::get_job_object(job_id)->send_back_task_result_from_worker(task_id);
 
                   break;
@@ -140,6 +144,9 @@ void worker_loop()
          throw;
       }
    }
+
+   if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::write_file();
+   
    // clean up signal management modifications
    sigprocmask(SIG_SETMASK, &JobManager::instance()->messenger().ppoll_sigmask, nullptr);
 

--- a/roofit/multiprocess/src/worker.cxx
+++ b/roofit/multiprocess/src/worker.cxx
@@ -110,9 +110,9 @@ void worker_loop()
                         JobManager::instance()->messenger().receive_from_master_on_worker<std::size_t>();
                      JobManager::get_job_object(job_id_for_state)->update_state();
                   }
-                  if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::start_timer("worker:eval_task:" + std::to_string(task_id));
+                  if (RooFit::MultiProcess::Config::getTimingAnalysis()) ProcessTimer::start_timer("worker:eval_task:" + std::to_string(task_id));
                   JobManager::get_job_object(job_id)->evaluate_task(task_id);
-                  if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::end_timer("worker:eval_task:" + std::to_string(task_id));
+                  if (RooFit::MultiProcess::Config::getTimingAnalysis()) ProcessTimer::end_timer("worker:eval_task:" + std::to_string(task_id));
                   JobManager::get_job_object(job_id)->send_back_task_result_from_worker(task_id);
 
                   break;
@@ -145,7 +145,7 @@ void worker_loop()
       }
    }
 
-   if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::write_file();
+   if (RooFit::MultiProcess::Config::getTimingAnalysis()) ProcessTimer::write_file();
    
    // clean up signal management modifications
    sigprocmask(SIG_SETMASK, &JobManager::instance()->messenger().ppoll_sigmask, nullptr);

--- a/roofit/multiprocess/test/CMakeLists.txt
+++ b/roofit/multiprocess/test/CMakeLists.txt
@@ -12,3 +12,4 @@ ROOT_ADD_GTEST(test_RooFit_MultiProcess_ProcessManager test_ProcessManager.cxx L
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_Messenger test_Messenger.cxx LIBRARIES RooFitMultiProcess)
 
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_Queue test_Queue.cxx LIBRARIES RooFitMultiProcess)
+ROOT_ADD_GTEST(test_RooFit_MultiProcess_ProcessTimer test_ProcessTimer.cxx LIBRARIES RooFitMultiProcess)

--- a/roofit/multiprocess/test/CMakeLists.txt
+++ b/roofit/multiprocess/test/CMakeLists.txt
@@ -13,3 +13,7 @@ ROOT_ADD_GTEST(test_RooFit_MultiProcess_Messenger test_Messenger.cxx LIBRARIES R
 
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_Queue test_Queue.cxx LIBRARIES RooFitMultiProcess)
 ROOT_ADD_GTEST(test_RooFit_MultiProcess_ProcessTimer test_ProcessTimer.cxx LIBRARIES RooFitMultiProcess)
+ROOT_ADD_GTEST(test_RooFit_MultiProcess_HeatmapAnalyzer test_HeatmapAnalyzer.cxx LIBRARIES RooFitMultiProcess
+  COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/test_logs/p_0.json
+  COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/test_logs/p_1.json
+  COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/test_logs/p_999.json)

--- a/roofit/multiprocess/test/test_HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/test/test_HeatmapAnalyzer.cxx
@@ -1,0 +1,29 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   ZW, Zef Wolffs, Nikhef, zefwolffs@gmail.com
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooFit/MultiProcess/HeatmapAnalyzer.h"
+
+#include <iostream>
+
+#include "gtest/gtest.h"
+
+TEST(TestMPHeatmapAnalyzer, Analyze)
+{
+    RooFit::MultiProcess::HeatmapAnalyzer hm_analyzer(".");
+    TH2I hm = hm_analyzer.analyze(2); // analyze second gradient
+
+    // indexing starts from 1 in heatmap because of under/overflow bins
+    GTEST_ASSERT_EQ(hm.GetBinContent(1, 1), 5);
+    GTEST_ASSERT_EQ(hm.GetBinContent(2, 1), 15);
+    GTEST_ASSERT_EQ(hm.GetBinContent(1, 2), 10);
+    GTEST_ASSERT_EQ(hm.GetBinContent(2, 2), 20);
+}

--- a/roofit/multiprocess/test/test_HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/test/test_HeatmapAnalyzer.cxx
@@ -18,12 +18,12 @@
 
 TEST(TestMPHeatmapAnalyzer, Analyze)
 {
-    RooFit::MultiProcess::HeatmapAnalyzer hm_analyzer(".");
-    TH2I hm = hm_analyzer.analyze(2); // analyze second gradient
+   RooFit::MultiProcess::HeatmapAnalyzer hm_analyzer(".");
+   TH2I hm = hm_analyzer.analyze(2); // analyze second gradient
 
-    // indexing starts from 1 in heatmap because of under/overflow bins
-    GTEST_ASSERT_EQ(hm.GetBinContent(1, 1), 5);
-    GTEST_ASSERT_EQ(hm.GetBinContent(2, 1), 15);
-    GTEST_ASSERT_EQ(hm.GetBinContent(1, 2), 10);
-    GTEST_ASSERT_EQ(hm.GetBinContent(2, 2), 20);
+   // indexing starts from 1 in heatmap because of under/overflow bins
+   GTEST_ASSERT_EQ(hm.GetBinContent(1, 1), 5);
+   GTEST_ASSERT_EQ(hm.GetBinContent(2, 1), 15);
+   GTEST_ASSERT_EQ(hm.GetBinContent(1, 2), 10);
+   GTEST_ASSERT_EQ(hm.GetBinContent(2, 2), 20);
 }

--- a/roofit/multiprocess/test/test_HeatmapAnalyzer.cxx
+++ b/roofit/multiprocess/test/test_HeatmapAnalyzer.cxx
@@ -12,18 +12,18 @@
 
 #include "RooFit/MultiProcess/HeatmapAnalyzer.h"
 
-#include <iostream>
-
 #include "gtest/gtest.h"
+
+#include <iostream>
 
 TEST(TestMPHeatmapAnalyzer, Analyze)
 {
    RooFit::MultiProcess::HeatmapAnalyzer hm_analyzer(".");
-   TH2I hm = hm_analyzer.analyze(2); // analyze second gradient
+   std::unique_ptr<TH2I> hm = hm_analyzer.analyze(2); // analyze second gradient
 
    // indexing starts from 1 in heatmap because of under/overflow bins
-   GTEST_ASSERT_EQ(hm.GetBinContent(1, 1), 5);
-   GTEST_ASSERT_EQ(hm.GetBinContent(2, 1), 15);
-   GTEST_ASSERT_EQ(hm.GetBinContent(1, 2), 10);
-   GTEST_ASSERT_EQ(hm.GetBinContent(2, 2), 20);
+   GTEST_ASSERT_EQ(hm->GetBinContent(1, 1), 5);
+   GTEST_ASSERT_EQ(hm->GetBinContent(2, 1), 15);
+   GTEST_ASSERT_EQ(hm->GetBinContent(1, 2), 10);
+   GTEST_ASSERT_EQ(hm->GetBinContent(2, 2), 20);
 }

--- a/roofit/multiprocess/test/test_ProcessTimer.cxx
+++ b/roofit/multiprocess/test/test_ProcessTimer.cxx
@@ -18,6 +18,8 @@
 #include <chrono>
 #include <thread>
 
+using namespace std;
+
 TEST(TestMPProcessTimer, Timings)
 {
    RooFit::MultiProcess::ProcessManager pm(1);

--- a/roofit/multiprocess/test/test_ProcessTimer.cxx
+++ b/roofit/multiprocess/test/test_ProcessTimer.cxx
@@ -20,53 +20,54 @@
 
 TEST(TestMPProcessTimer, Timings)
 {
-    RooFit::MultiProcess::ProcessManager pm(1);
+   RooFit::MultiProcess::ProcessManager pm(1);
 
-    // Setup processtimers on processes
-    if (pm.is_master())
-        RooFit::MultiProcess::ProcessTimer::setup(999);
-    if (!pm.is_master())
-        RooFit::MultiProcess::ProcessTimer::setup(0);
+   // Setup processtimers on processes
+   if (pm.is_master())
+      RooFit::MultiProcess::ProcessTimer::setup(999);
+   if (!pm.is_master())
+      RooFit::MultiProcess::ProcessTimer::setup(0);
 
-    // Do some timed sleeping to emulate timing work being done
-    RooFit::MultiProcess::ProcessTimer::start_timer("all:cumulative");
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    if (pm.is_master()) {
-        // on master
-        RooFit::MultiProcess::ProcessTimer::start_timer("master:wait_500");
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        RooFit::MultiProcess::ProcessTimer::end_timer("master:wait_500");
-    }
-    if (pm.is_worker()) {
-        // on worker
-        RooFit::MultiProcess::ProcessTimer::start_timer("worker:wait_1000");
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        RooFit::MultiProcess::ProcessTimer::end_timer("worker:wait_1000");
-    }
-    RooFit::MultiProcess::ProcessTimer::end_timer("all:cumulative");
+   // Do some timed sleeping to emulate timing work being done
+   RooFit::MultiProcess::ProcessTimer::start_timer("all:cumulative");
+   std::this_thread::sleep_for(std::chrono::milliseconds(200));
+   if (pm.is_master()) {
+      // on master
+      RooFit::MultiProcess::ProcessTimer::start_timer("master:wait_500");
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+      RooFit::MultiProcess::ProcessTimer::end_timer("master:wait_500");
+   }
+   if (pm.is_worker()) {
+      // on worker
+      RooFit::MultiProcess::ProcessTimer::start_timer("worker:wait_1000");
+      std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+      RooFit::MultiProcess::ProcessTimer::end_timer("worker:wait_1000");
+   }
+   RooFit::MultiProcess::ProcessTimer::end_timer("all:cumulative");
 
-    // Check if results make sense
-    if (pm.is_master()) {
-        list<chrono::time_point<chrono::steady_clock>> durations = RooFit::MultiProcess::ProcessTimer::get_durations("all:cumulative");
-        auto it = durations.begin();
-        long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
-        EXPECT_NEAR(duration, 700, 100);
+   // Check if results make sense
+   if (pm.is_master()) {
+      list<chrono::time_point<chrono::steady_clock>> durations =
+         RooFit::MultiProcess::ProcessTimer::get_durations("all:cumulative");
+      auto it = durations.begin();
+      long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+      EXPECT_NEAR(duration, 700, 100);
 
-        durations = RooFit::MultiProcess::ProcessTimer::get_durations("master:wait_500");
-        it = durations.begin();
-        duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
-        EXPECT_NEAR(duration, 500, 100);
-    }
-    if (pm.is_worker()) {
-        list<chrono::time_point<chrono::steady_clock>> durations = RooFit::MultiProcess::ProcessTimer::get_durations("all:cumulative");
-        auto it = durations.begin();
-        long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
-        EXPECT_NEAR(duration, 1200, 100);
+      durations = RooFit::MultiProcess::ProcessTimer::get_durations("master:wait_500");
+      it = durations.begin();
+      duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+      EXPECT_NEAR(duration, 500, 100);
+   }
+   if (pm.is_worker()) {
+      list<chrono::time_point<chrono::steady_clock>> durations =
+         RooFit::MultiProcess::ProcessTimer::get_durations("all:cumulative");
+      auto it = durations.begin();
+      long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+      EXPECT_NEAR(duration, 1200, 100);
 
-        durations = RooFit::MultiProcess::ProcessTimer::get_durations("worker:wait_1000");
-        it = durations.begin();
-        duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
-        EXPECT_NEAR(duration, 1000, 100);
-    }
-
+      durations = RooFit::MultiProcess::ProcessTimer::get_durations("worker:wait_1000");
+      it = durations.begin();
+      duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+      EXPECT_NEAR(duration, 1000, 100);
+   }
 }

--- a/roofit/multiprocess/test/test_ProcessTimer.cxx
+++ b/roofit/multiprocess/test/test_ProcessTimer.cxx
@@ -1,0 +1,72 @@
+/*
+ * Project: RooFit
+ * Authors:
+ *   ZW, Zef Wolffs, Nikhef, zefwolffs@gmail.com
+ *
+ * Copyright (c) 2022, CERN
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted according to the terms
+ * listed in LICENSE (http://roofit.sourceforge.net/license.txt)
+ */
+
+#include "RooFit/MultiProcess/ProcessTimer.h"
+#include "RooFit/MultiProcess/ProcessManager.h" // ... JobManager::process_manager()
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <thread>
+
+TEST(TestMPProcessTimer, Timings)
+{
+    RooFit::MultiProcess::ProcessManager pm(1);
+
+    // Setup processtimers on processes
+    if (pm.is_master())
+        RooFit::MultiProcess::ProcessTimer::setup(999);
+    if (!pm.is_master())
+        RooFit::MultiProcess::ProcessTimer::setup(0);
+
+    // Do some timed sleeping to emulate timing work being done
+    RooFit::MultiProcess::ProcessTimer::start_timer("all:cumulative");
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    if (pm.is_master()) {
+        // on master
+        RooFit::MultiProcess::ProcessTimer::start_timer("master:wait_500");
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        RooFit::MultiProcess::ProcessTimer::end_timer("master:wait_500");
+    }
+    if (pm.is_worker()) {
+        // on worker
+        RooFit::MultiProcess::ProcessTimer::start_timer("worker:wait_1000");
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        RooFit::MultiProcess::ProcessTimer::end_timer("worker:wait_1000");
+    }
+    RooFit::MultiProcess::ProcessTimer::end_timer("all:cumulative");
+
+    // Check if results make sense
+    if (pm.is_master()) {
+        list<chrono::time_point<chrono::steady_clock>> durations = RooFit::MultiProcess::ProcessTimer::get_durations("all:cumulative");
+        auto it = durations.begin();
+        long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+        EXPECT_NEAR(duration, 700, 100);
+
+        durations = RooFit::MultiProcess::ProcessTimer::get_durations("master:wait_500");
+        it = durations.begin();
+        duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+        EXPECT_NEAR(duration, 500, 100);
+    }
+    if (pm.is_worker()) {
+        list<chrono::time_point<chrono::steady_clock>> durations = RooFit::MultiProcess::ProcessTimer::get_durations("all:cumulative");
+        auto it = durations.begin();
+        long duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+        EXPECT_NEAR(duration, 1200, 100);
+
+        durations = RooFit::MultiProcess::ProcessTimer::get_durations("worker:wait_1000");
+        it = durations.begin();
+        duration = chrono::duration_cast<chrono::milliseconds>(*std::next(it) - *it).count();
+        EXPECT_NEAR(duration, 1000, 100);
+    }
+
+}

--- a/roofit/multiprocess/test/test_logs/p_0.json
+++ b/roofit/multiprocess/test/test_logs/p_0.json
@@ -1,0 +1,32 @@
+{
+    "metadata": [
+        [
+            "test_param1",
+            "test_param2"
+        ]
+    ],
+    "worker:eval_partition:test_partition1": [
+        110,
+        190,
+        325,
+        330,
+        530,
+        570
+    ],
+    "worker:eval_partition:test_partition2": [
+        110,
+        190,
+        355,
+        370,
+        530,
+        570
+    ],
+    "worker:eval_task:0": [
+        110,
+        190,
+        320,
+        380,
+        530,
+        570
+    ]
+}

--- a/roofit/multiprocess/test/test_logs/p_1.json
+++ b/roofit/multiprocess/test/test_logs/p_1.json
@@ -1,0 +1,32 @@
+{
+    "metadata": [
+        [
+            "test_param1",
+            "test_param2"
+        ]
+    ],
+    "worker:eval_partition:test_partition1": [
+        110,
+        190,
+        320,
+        330,
+        530,
+        570
+    ],
+    "worker:eval_partition:test_partition2": [
+        110,
+        190,
+        350,
+        370,
+        530,
+        570
+    ],
+    "worker:eval_task:1": [
+        110,
+        190,
+        320,
+        380,
+        530,
+        570
+    ]
+}

--- a/roofit/multiprocess/test/test_logs/p_999.json
+++ b/roofit/multiprocess/test/test_logs/p_999.json
@@ -1,0 +1,16 @@
+{
+    "master:gradient": [
+        100,
+        200,
+        300,
+        400,
+        500,
+        600
+    ],
+    "metadata": [
+        [
+            "test_param1",
+            "test_param2"
+        ]
+    ]
+}

--- a/roofit/roofitcore/inc/RooAbsPdf.h
+++ b/roofit/roofitcore/inc/RooAbsPdf.h
@@ -192,6 +192,7 @@ public:
       int parallelize = 0;
       bool enableParallelGradient = true;
       bool enableParallelDescent = false;
+      bool timingAnalysis = false;
       const RooArgSet* minosSet = nullptr;
       std::string minType;
       std::string minAlg = "minuit";

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -214,8 +214,10 @@ RooCmdArg EventRange(Int_t nStart, Int_t nStop) ;
 RooCmdArg Extended(bool flag=true) ;
 RooCmdArg DataError(Int_t) ;
 RooCmdArg NumCPU(Int_t nCPU, Int_t interleave=0) ;
+
 RooCmdArg Parallelize(int nWorkers) ;
 RooCmdArg ModularL(bool flag=false) ;
+RooCmdArg TimingAnalysis(bool timingAnalysis) ;
 
 RooCmdArg BatchMode(std::string const& batchMode="cpu");
 // The const char * overload is necessary, otherwise the compiler will cast a

--- a/roofit/roofitcore/inc/RooGlobalFunc.h
+++ b/roofit/roofitcore/inc/RooGlobalFunc.h
@@ -214,7 +214,6 @@ RooCmdArg EventRange(Int_t nStart, Int_t nStop) ;
 RooCmdArg Extended(bool flag=true) ;
 RooCmdArg DataError(Int_t) ;
 RooCmdArg NumCPU(Int_t nCPU, Int_t interleave=0) ;
-
 RooCmdArg Parallelize(int nWorkers) ;
 RooCmdArg ModularL(bool flag=false) ;
 RooCmdArg TimingAnalysis(bool timingAnalysis) ;

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -66,7 +66,7 @@ public:
 
       bool verbose = false;               // local config
       bool profile = false;               // local config
-      bool logTimings = false;            // local config
+      bool timingAnalysis = false;            // local config
       std::string minimizerType = "";     // local config
    private:
       int getDefaultWorkers();

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -66,6 +66,7 @@ public:
 
       bool verbose = false;               // local config
       bool profile = false;               // local config
+      bool logTimings = false;            // local config
       std::string minimizerType = "";     // local config
    private:
       int getDefaultWorkers();

--- a/roofit/roofitcore/inc/RooMinimizer.h
+++ b/roofit/roofitcore/inc/RooMinimizer.h
@@ -152,6 +152,8 @@ public:
 private:
    friend class RooAbsMinimizerFcn;
 
+   void addParamsToProcessTimer();
+
    void profileStart();
    void profileStop();
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1614,6 +1614,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   pc.defineInt("parallelize", "Parallelize", 0, 0); // Three parallelize arguments
   pc.defineInt("enableParallelGradient", "ParallelGradientOptions", 0, 0);
   pc.defineInt("enableParallelDescent", "ParallelDescentOptions", 0, 0);
+  pc.defineInt("timingAnalysis", "TimingAnalysis", 0, 0);
   pc.defineString("mintype","Minimizer",0,minimizerDefaults.minType.c_str()) ;
   pc.defineString("minalg","Minimizer",1,minimizerDefaults.minAlg.c_str()) ;
   pc.defineSet("minosSet","Minos",0,minimizerDefaults.minosSet) ;
@@ -1709,7 +1710,7 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   cfg.parallelize = pc.getInt("parallelize");
   cfg.enableParallelGradient = pc.getInt("enableParallelGradient");
   cfg.enableParallelDescent = pc.getInt("enableParallelDescent");
-
+  cfg.timingAnalysis = pc.getInt("timingAnalysis");
   return minimizeNLL(*nll, data, cfg).release();
 }
 

--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -1384,6 +1384,7 @@ std::unique_ptr<RooFitResult> RooAbsPdf::minimizeNLL(RooAbsReal & nll,
   minimizerConfig.enableParallelGradient = cfg.enableParallelGradient;
   minimizerConfig.enableParallelDescent = cfg.enableParallelDescent;
   minimizerConfig.parallelize = cfg.parallelize;
+  minimizerConfig.timingAnalysis = cfg.timingAnalysis;
   RooMinimizer m(nll, minimizerConfig);
 
   m.setMinimizerType(cfg.minType.c_str());
@@ -1576,8 +1577,12 @@ std::unique_ptr<RooFitResult> RooAbsPdf::minimizeNLL(RooAbsReal & nll,
 ///                                                                                                      parallelization. The second argument determines whether to split the task batches
 ///                                                                                                      per event or per likelihood component. And the third argument how many events or
 ///                                                                                                      respectively components to include in each batch.                                                                            
+/// <tr><td> `TimingAnalysis(bool flag)`   <td> **Experimental** log timings. This feature logs timings with NewStyle likelihoods on multiple processes simultaneously
+///                                         and outputs the timings at the end of a run to json log files, which can be analyzed with the 
+///                                         `RooFit::MultiProcess::HeatmapAnalyzer`. Only works with simultaneous likelihoods.
 /// </table>
 ///
+
 RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
 {
   // Select the pdf-specific commands
@@ -1624,6 +1629,13 @@ RooFitResult* RooAbsPdf::fitTo(RooAbsData& data, const RooLinkedList& cmdList)
   pc.process(fitCmdList) ;
   if (!pc.ok(true)) {
     return 0 ;
+  }
+
+  // TimingAnalysis works only for RooSimultaneus.
+  if (pc.getInt("timingAnalysis") && !this->InheritsFrom("RooSimultaneous") ) {
+     coutW(Minimization) << "The timingAnalysis feature was built for minimization with RooSimulteneous "
+                            "and is not implemented for other PDF's. Please create a RooSimultenous to " 
+                            "enable this feature."  << endl;
   }
 
   // Decode command line arguments

--- a/roofit/roofitcore/src/RooGlobalFunc.cxx
+++ b/roofit/roofitcore/src/RooGlobalFunc.cxx
@@ -192,6 +192,7 @@ namespace RooFit {
   RooCmdArg NumCPU(Int_t nCPU, Int_t interleave)   { return RooCmdArg("NumCPU",nCPU,interleave,0,0,0,0,0,0) ; }
   RooCmdArg ModularL(bool flag) { return RooCmdArg("ModularL",flag,0,0,0,0,0,0) ; }
   RooCmdArg Parallelize(Int_t nWorkers) { return RooCmdArg("Parallelize",nWorkers,0,0,0,0,0,0,0) ; }
+  RooCmdArg TimingAnalysis(bool flag) { return RooCmdArg("TimingAnalysis",flag,0,0,0,0,0,0) ; }
   RooCmdArg BatchMode(std::string const& batchMode) {
       std::string lower = batchMode;
       std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c){ return std::tolower(c); });

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -58,6 +58,7 @@ automatic PDF optimization.
 #include "RooFit/TestStatistics/RooRealL.h"
 #ifdef R__HAS_ROOFIT_MULTIPROCESS
 #include "RooFit/MultiProcess/Config.h"
+#include "RooFit/MultiProcess/ProcessTimer.h"
 #endif
 
 #include "TClass.h"
@@ -309,6 +310,8 @@ bool RooMinimizer::fitFcn() const
 /// \param[in] alg  Fit algorithm to use. (Optional)
 int RooMinimizer::minimize(const char *type, const char *alg)
 {
+   if (_cfg.logTimings) addParamsToProcessTimer();
+
    _fcn->Synchronize(_theFitter->Config().ParamsSettings());
 
    setMinimizerType(type);
@@ -740,6 +743,22 @@ RooPlot *RooMinimizer::contour(RooRealVar &var1, RooRealVar &var2, double n1, do
    params->assign(*paramSave);
 
    return frame;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Add parameters in metadata field to process timer
+
+void RooMinimizer::addParamsToProcessTimer()
+{
+  // parameter indices for use in timing heat matrix
+  std::vector<std::string> parameter_names;
+  for (auto && parameter : *_fcn->GetFloatParamList()) {
+    parameter_names.push_back(parameter->GetName());
+    if (_cfg.verbose) {
+      coutI(Minimization) << "parameter name: " << parameter_names.back() << std::endl;
+    }
+  }
+  RooFit::MultiProcess::ProcessTimer::add_metadata(parameter_names);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -118,7 +118,7 @@ RooMinimizer::RooMinimizer(RooAbsReal &function, Config const &cfg) : _cfg(cfg)
          // If _cfg.parallelize is larger than zero set the number of workers to that value. Otherwise do not do anything and let 
          // RooFit::MultiProcess handle the number of workers
          if (_cfg.parallelize > 0) RooFit::MultiProcess::Config::setDefaultNWorkers(_cfg.parallelize);
-
+         RooFit::MultiProcess::Config::setTimingAnalysis(_cfg.timingAnalysis);
          _fcn = std::make_unique<RooFit::TestStatistics::MinuitFcnGrad>(
             nll_real->getRooAbsL(), this, _theFitter->Config().ParamsSettings(),
             RooFit::TestStatistics::LikelihoodMode{

--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -115,11 +115,11 @@ RooMinimizer::RooMinimizer(RooAbsReal &function, Config const &cfg) : _cfg(cfg)
                                   << "also setting parallel gradient calculation mode." << std::endl;
             _cfg.enableParallelGradient = 1;
          }
-
          // If _cfg.parallelize is larger than zero set the number of workers to that value. Otherwise do not do anything and let 
          // RooFit::MultiProcess handle the number of workers
          if (_cfg.parallelize > 0) RooFit::MultiProcess::Config::setDefaultNWorkers(_cfg.parallelize);
          RooFit::MultiProcess::Config::setTimingAnalysis(_cfg.timingAnalysis);
+
          _fcn = std::make_unique<RooFit::TestStatistics::MinuitFcnGrad>(
             nll_real->getRooAbsL(), this, _theFitter->Config().ParamsSettings(),
             RooFit::TestStatistics::LikelihoodMode{
@@ -310,7 +310,7 @@ bool RooMinimizer::fitFcn() const
 /// \param[in] alg  Fit algorithm to use. (Optional)
 int RooMinimizer::minimize(const char *type, const char *alg)
 {
-   if (_cfg.logTimings) 
+   if (_cfg.timingAnalysis) 
 #ifdef R__HAS_ROOFIT_MULTIPROCESS
       addParamsToProcessTimer();
 #else

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -14,7 +14,9 @@
 
 #include "RooFit/MultiProcess/JobManager.h"
 #include "RooFit/MultiProcess/Messenger.h"
+#include "RooFit/MultiProcess/ProcessTimer.h"
 #include "RooFit/MultiProcess/Queue.h"
+#include "RooFit/MultiProcess/Config.h"
 #include "RooMsgService.h"
 #include "RooMinimizer.h"
 
@@ -225,7 +227,9 @@ void LikelihoodGradientJob::fillGradientWithPrevResult(double *grad, double *pre
       }
 
       if (!calculation_is_clean_->gradient) {
+         if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::start_timer("master:gradient");
          calculate_all();
+         if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::end_timer("master:gradient");
       }
 
       // put the results from _grad into *grad

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -227,9 +227,9 @@ void LikelihoodGradientJob::fillGradientWithPrevResult(double *grad, double *pre
       }
 
       if (!calculation_is_clean_->gradient) {
-         if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::start_timer("master:gradient");
+         if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::start_timer("master:gradient");
          calculate_all();
-         if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::end_timer("master:gradient");
+         if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::end_timer("master:gradient");
       }
 
       // put the results from _grad into *grad

--- a/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/src/TestStatistics/LikelihoodGradientJob.cxx
@@ -227,9 +227,9 @@ void LikelihoodGradientJob::fillGradientWithPrevResult(double *grad, double *pre
       }
 
       if (!calculation_is_clean_->gradient) {
-         if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::start_timer("master:gradient");
+         if (RooFit::MultiProcess::Config::getTimingAnalysis()) RooFit::MultiProcess::ProcessTimer::start_timer("master:gradient");
          calculate_all();
-         if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::end_timer("master:gradient");
+         if (RooFit::MultiProcess::Config::getTimingAnalysis()) RooFit::MultiProcess::ProcessTimer::end_timer("master:gradient");
       }
 
       // put the results from _grad into *grad

--- a/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
@@ -13,7 +13,7 @@
 #include <RooFit/TestStatistics/RooSumL.h>
 #include <RooAbsData.h>
 #include <RooFit/TestStatistics/RooSubsidiaryL.h>
-#include <RooFit/multiprocess/ProcessTimer.h>
+#include "RooFit/MultiProcess/ProcessTimer.h"
 #include "RooFit/MultiProcess/Config.h"
 
 #include <algorithm> // min, max
@@ -94,9 +94,9 @@ RooSumL::evaluatePartition(Section events, std::size_t components_begin, std::si
 
    // from RooAbsOptTestStatistic::combinedValue (which is virtual, so could be different for non-RooNLLVar!):
    for (std::size_t ix = components_begin; ix < components_end; ++ix) {
-      if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::start_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
+      if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::start_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
       ret += components_[ix]->evaluatePartition(events, 0, 0);
-      if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::end_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
+      if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::end_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
    }
 
    return ret;

--- a/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
@@ -13,8 +13,10 @@
 #include <RooFit/TestStatistics/RooSumL.h>
 #include <RooAbsData.h>
 #include <RooFit/TestStatistics/RooSubsidiaryL.h>
+#ifdef R__HAS_ROOFIT_MULTIPROCESS
 #include "RooFit/MultiProcess/ProcessTimer.h"
 #include "RooFit/MultiProcess/Config.h"
+#endif
 
 #include <algorithm> // min, max
 
@@ -94,9 +96,13 @@ RooSumL::evaluatePartition(Section events, std::size_t components_begin, std::si
 
    // from RooAbsOptTestStatistic::combinedValue (which is virtual, so could be different for non-RooNLLVar!):
    for (std::size_t ix = components_begin; ix < components_end; ++ix) {
+#ifdef R__HAS_ROOFIT_MULTIPROCESS
       if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::start_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
+#endif
       ret += components_[ix]->evaluatePartition(events, 0, 0);
+#ifdef R__HAS_ROOFIT_MULTIPROCESS
       if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::end_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
+#endif
    }
 
    return ret;

--- a/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
@@ -97,11 +97,11 @@ RooSumL::evaluatePartition(Section events, std::size_t components_begin, std::si
    // from RooAbsOptTestStatistic::combinedValue (which is virtual, so could be different for non-RooNLLVar!):
    for (std::size_t ix = components_begin; ix < components_end; ++ix) {
 #ifdef R__HAS_ROOFIT_MULTIPROCESS
-      if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::start_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
+      if (RooFit::MultiProcess::Config::getTimingAnalysis()) RooFit::MultiProcess::ProcessTimer::start_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
 #endif
       ret += components_[ix]->evaluatePartition(events, 0, 0);
 #ifdef R__HAS_ROOFIT_MULTIPROCESS
-      if (RooFit::MultiProcess::Config::getLogTimings()) RooFit::MultiProcess::ProcessTimer::end_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
+      if (RooFit::MultiProcess::Config::getTimingAnalysis()) RooFit::MultiProcess::ProcessTimer::end_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
 #endif
    }
 

--- a/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
+++ b/roofit/roofitcore/src/TestStatistics/RooSumL.cxx
@@ -13,6 +13,8 @@
 #include <RooFit/TestStatistics/RooSumL.h>
 #include <RooAbsData.h>
 #include <RooFit/TestStatistics/RooSubsidiaryL.h>
+#include <RooFit/multiprocess/ProcessTimer.h>
+#include "RooFit/MultiProcess/Config.h"
 
 #include <algorithm> // min, max
 
@@ -92,7 +94,9 @@ RooSumL::evaluatePartition(Section events, std::size_t components_begin, std::si
 
    // from RooAbsOptTestStatistic::combinedValue (which is virtual, so could be different for non-RooNLLVar!):
    for (std::size_t ix = components_begin; ix < components_end; ++ix) {
+      if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::start_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
       ret += components_[ix]->evaluatePartition(events, 0, 0);
+      if (RooFit::MultiProcess::Config::getLogTimings()) ProcessTimer::end_timer("worker:eval_partition:" + components_[ix]->GetClassName() + ":" + components_[ix]->GetName());
    }
 
    return ret;


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

This MR contains mostly two classes: 
- `RooFit::MultiProcess::ProcessTimer` which keeps a set of potentially overlapping timers per process that can be started and stopped by referring to their identifier string. Timings are written out in json format. Some extra functionality is added to write out at a specified interval.
- `RooFit::MultiProcess::HeatmapAnalyzer` which translates the timings output in log format by the process timer to a heatmap which it can return in the form of a TH2I with the correctly labeled x and y axes. Some extra functionality is available for inspecting the log files and retrieving its metadata.

Tests are included for both classes.

Note that also the interface to enable timing logging is included in the `RooMinimizer::Config` object which can be given to the RooMinimizer and on RooAbsPdf::fitTo. The variable that centrally controls whether timings are logged or not is `RooMinimizer::Config::logTimings_`. 

Also, an initial timing setup is included, with some `ProcessTimer::start_timer` and `ProcessTimer::end_timer` calls throughout the `RooFit::TestStatistics` code.

## Checklist:

- [x] tested changes locally
- [x] updated the docs (if necessary)

This PR fixes # 

