### PR TITLE
[rbrowser] Fix handling of RNTuple and sub-directories

### DIFF
--- a/gui/browsable/src/RNTupleBrowseProvider.cxx
+++ b/gui/browsable/src/RNTupleBrowseProvider.cxx
@@ -131,6 +131,13 @@ public:
 
    const TClass *GetClass() const { return TClass::GetClass<ROOT::Experimental::RNTuple>(); }
 
+   std::unique_ptr<RItem> CreateItem() const override
+   {
+      auto item = std::make_unique<RItem>(GetName(), -1, "sap-icon://table-chart");
+      item->SetTitle(GetTitle());
+      return item;
+   }
+
    //EActionKind GetDefaultAction() const override;
 
    //bool IsCapable(EActionKind) const override;

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -42,8 +42,8 @@ Iterator over keys in TDirectory
 class TDirectoryLevelIter : public RLevelIter {
    TDirectory *fDir{nullptr};         ///<! current directory handle
    std::unique_ptr<TIterator> fIter;  ///<! created iterator
-   Bool_t fKeysIter{kTRUE};           ///<! iterating over keys list (default)
-   Bool_t fOnlyLastCycle{kFALSE};     ///<! show only last cycle in list of keys
+   bool fKeysIter{true};              ///<! iterating over keys list (default)
+   bool fOnlyLastCycle{false};        ///<! show only last cycle in list of keys
    TKey *fKey{nullptr};               ///<! currently selected key
    TObject *fObj{nullptr};            ///<! currently selected object
    std::string fCurrentName;          ///<! current key name
@@ -86,6 +86,17 @@ class TDirectoryLevelIter : public RLevelIter {
          }
       }
       if (!fKeysIter) {
+         // exclude object with duplicated name as keys
+         while (fObj) {
+            if (!fDir->GetListOfKeys()->FindObject(fObj->GetName()))
+               break;
+            fObj = fIter->Next();
+         }
+         if (!fObj) {
+            fIter.reset();
+            return false;
+         }
+
          fCurrentName = fObj->GetName();
          return true;
       }
@@ -132,9 +143,9 @@ public:
          std::string svalue = value;
          if (svalue != undef) {
             if (svalue == "yes")
-               fOnlyLastCycle = kTRUE;
+               fOnlyLastCycle = true;
             else if (svalue == "no")
-               fOnlyLastCycle = kFALSE;
+               fOnlyLastCycle = false;
             else
                R__LOG_ERROR(ROOT::Experimental::BrowsableLog()) << "WebGui.LastCycle must be yes or no";
          }

--- a/gui/browsable/src/TDirectoryElement.cxx
+++ b/gui/browsable/src/TDirectoryElement.cxx
@@ -177,11 +177,15 @@ public:
          return elem ? elem->CreateItem() : nullptr;
       }
 
-      return GetElement()->CreateItem();
+      auto item = GetDirElement(false)->CreateItem();
+      item->SetName(fCurrentName);
+      return item;
    }
 
+   std::shared_ptr<RElement> GetDirElement(bool read_dir);
+
    /** Returns full information for current element */
-   std::shared_ptr<RElement> GetElement() override;
+   std::shared_ptr<RElement> GetElement() override { return GetDirElement(true); }
 };
 
 // ===============================================================================================================
@@ -516,7 +520,7 @@ public:
 /////////////////////////////////////////////////////////////////////////////////
 /// Return element for current TKey object in TDirectory
 
-std::shared_ptr<RElement> TDirectoryLevelIter::GetElement()
+std::shared_ptr<RElement> TDirectoryLevelIter::GetDirElement(bool read_dir)
 {
    if (!fKeysIter && fObj)
       return std::make_shared<TObjectElement>(fObj);
@@ -525,7 +529,7 @@ std::shared_ptr<RElement> TDirectoryLevelIter::GetElement()
       return RProvider::BrowseNTuple(fKey->GetName(), fDir->GetFile()->GetName());
 
    std::string key_class = fKey->GetClassName();
-   if (key_class.find("TDirectory") == 0) {
+   if (read_dir && (key_class.find("TDirectory") == 0)) {
       auto subdir = fDir->GetDirectory(fKey->GetName());
       if (subdir) return std::make_shared<TDirectoryElement>("", subdir);
    }

--- a/gui/browserv7/src/RBrowserTCanvasWidget.cxx
+++ b/gui/browserv7/src/RBrowserTCanvasWidget.cxx
@@ -172,20 +172,25 @@ public:
 
       std::string drawopt = opt;
 
+      TVirtualPad *pad = fCanvas.get();
+      if (gPad && (gPad->GetCanvas() == fCanvas.get()))
+         pad = gPad;
+
       if (drawopt.compare(0,8,"<append>") == 0) {
          drawopt.erase(0,8);
       } else {
-         fCanvas->GetListOfPrimitives()->Clear();
+         pad->GetListOfPrimitives()->Clear();
          fObjects.clear();
-         fCanvas->Range(0,0,1,1);  // set default range
+         pad->Range(0,0,1,1);  // set default range
       }
 
       if (drawopt == "<dflt>")
          drawopt = Browsable::RProvider::GetClassDrawOption(obj->GetClass());
 
-      if (Browsable::RProvider::Draw6(fCanvas.get(), obj, drawopt)) {
+      if (Browsable::RProvider::Draw6(pad, obj, drawopt)) {
          fObjects.emplace_back(std::move(obj));
-         fCanvas->ForceUpdate();
+         pad->Modified();
+         fCanvas->Update();
          return true;
       }
 

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -120,7 +120,7 @@ protected:
 
    void CheckPadModified(TPad *pad);
 
-   void CheckCanvasModified();
+   void CheckCanvasModified(bool force_modified = false);
 
    Bool_t AddToSendQueue(unsigned connid, const std::string &msg);
 

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1453,11 +1453,13 @@ void TWebCanvas::CheckPadModified(TPad *pad)
 /// Check if any pad on the canvas was modified
 /// If yes, increment version of correspondent pad
 
-void TWebCanvas::CheckCanvasModified()
+void TWebCanvas::CheckCanvasModified(bool force_modified)
 {
    // clear temporary flags
-   for (auto &entry : fPadsStatus)
-      entry.second._detected = entry.second._modified = false;
+   for (auto &entry : fPadsStatus) {
+      entry.second._detected = false;
+      entry.second._modified = force_modified;
+   }
 
    // scan sub-pads
    CheckPadModified(Canvas());
@@ -1517,7 +1519,7 @@ Bool_t TWebCanvas::PerformUpdate()
 
 void TWebCanvas::ForceUpdate()
 {
-   fCanvVersion++;
+   CheckCanvasModified(true);
 
    CheckDataToSend();
 }

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -1406,7 +1406,39 @@ Bool_t TWebCanvas::ProcessData(unsigned connid, const std::string &arg)
          pad->Clear();
          pad->Modified();
          PerformUpdate();
+      } else {
+         printf("Not found pad with id %s\n", snapid.c_str());
       }
+   } else if (arg.compare(0, 7, "DIVIDE:") == 0) {
+      auto arr = TBufferJSON::FromJSON<std::vector<std::string>>(arg.substr(7));
+      if (arr && arr->size() == 2) {
+         TPad *pad = dynamic_cast<TPad *>(FindPrimitive(arr->at(0)));
+         int nn = 0, n1 = 0, n2 = 0;
+
+         std::string divide = arr->at(1);
+         auto p = divide.find('x');
+         if (p == std::string::npos)
+            p = divide.find('X');
+
+         if (p != std::string::npos) {
+            n1 = std::stoi(divide.substr(0,p));
+            n2 = std::stoi(divide.substr(p+1));
+         } else {
+            nn = std::stoi(divide);
+         }
+
+         if (pad && ((nn > 1) || (n1*n2 > 1))) {
+            pad->Clear();
+            pad->Modified();
+            if (nn > 1)
+               pad->DivideSquare(nn);
+            else
+               pad->Divide(n1, n2);
+            pad->cd(1);
+            PerformUpdate();
+         }
+      }
+
    } else if (arg.compare(0, 8, "DRAWOPT:") == 0) {
       auto arr = TBufferJSON::FromJSON<std::vector<std::string>>(arg.substr(8));
       if (arr && arr->size() == 2) {

--- a/js/build/jsroot.js
+++ b/js/build/jsroot.js
@@ -11,7 +11,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '25/11/2022';
+let version_date = '28/11/2022';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -55554,7 +55554,7 @@ class TPadPainter extends ObjectPainter {
      * @return {Object} pad painter for active pad */
    findActivePad() {
       let active_pp;
-      painter.forEachPainterInPad(pp => {
+      this.forEachPainterInPad(pp => {
          if (pp.is_active_pad && !active_pp)
             active_pp = pp;
       }, 'pads');

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '25/11/2022';
+let version_date = '28/11/2022';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}

--- a/js/modules/gpad/TPadPainter.mjs
+++ b/js/modules/gpad/TPadPainter.mjs
@@ -1764,7 +1764,7 @@ class TPadPainter extends ObjectPainter {
      * @return {Object} pad painter for active pad */
    findActivePad() {
       let active_pp;
-      painter.forEachPainterInPad(pp => {
+      this.forEachPainterInPad(pp => {
          if (pp.is_active_pad && !active_pp)
             active_pp = pp;
       }, 'pads');

--- a/ui5/browser/controller/Browser.controller.js
+++ b/ui5/browser/controller/Browser.controller.js
@@ -177,7 +177,7 @@ sap.ui.define(['sap/ui/core/mvc/Controller',
          // copy extra attributes from element to node in the browser
          // later can be done automatically
          this.model.addNodeAttributes = function(node, elem) {
-            node.icon = elem.icon;
+            node.icon = elem.icon || 'sap-icon://document';
             node.fsize = elem.fsize;
             node.mtime = elem.mtime;
             node.ftype = elem.ftype;

--- a/ui5/canv/view/Canvas.view.xml
+++ b/ui5/canv/view/Canvas.view.xml
@@ -40,6 +40,7 @@
                   <Menu itemSelected="onEditMenuAction">
                      <items>
                         <MenuItem text="Style" enabled="false"/>
+                        <MenuItem text="Divide" enabled="{/isRoot6}"/>
                         <MenuItem text="Clear pad" startsSection="true"/>
                         <MenuItem text="Clear canvas"/>
                      </items>


### PR DESCRIPTION
Fix introduced recently bug which broke handling of subdirectories and RNTuple

Provide "Divide" method for TCanvas, use in `RBrowser` active pad for drawing. 
It is convenient method to display many objects at the same time.