### PR TITLE
[RF] Refactor `testLikelihoodGradientJob.cxx`

### DIFF
--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -23,7 +23,7 @@ ROOT_ADD_GTEST(testRooAbsPdf testRooAbsPdf.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooAbsCollection testRooAbsCollection.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooDataSet testRooDataSet.cxx LIBRARIES Tree RooFitCore)
 ROOT_ADD_GTEST(testRooFormula testRooFormula.cxx LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testRooProdPdf testRooProdPdf.cxx LIBRARIES RooFitCore RooFit)
+ROOT_ADD_GTEST(testRooProdPdf testRooProdPdf.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testProxiesAndCategories testProxiesAndCategories.cxx
   LIBRARIES RooFitCore
   COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/testProxiesAndCategories_1.root
@@ -55,7 +55,7 @@ ROOT_ADD_GTEST(testLikelihoodSerial TestStatistics/testLikelihoodSerial.cxx LIBR
 ROOT_ADD_GTEST(testRooAbsL TestStatistics/testRooAbsL.cxx LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testRooRealL TestStatistics/RooRealL.cpp LIBRARIES RooFitCore RooFit)
 ROOT_ADD_GTEST(testInterface TestStatistics/testInterface.cpp LIBRARIES RooFitCore)
-ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFit)
+ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
 if (roofit_multiprocess)

--- a/roofit/roofitcore/test/testGlobalObservables.cxx
+++ b/roofit/roofitcore/test/testGlobalObservables.cxx
@@ -1,20 +1,14 @@
 // Tests for global observables
 // Authors: Jonas Rembser, CERN  08/2021
 
-#include "RooRealVar.h"
-#include "RooMsgService.h"
-#include "RooGaussian.h"
-#include "RooPolynomial.h"
-#include "RooAddPdf.h"
-#include "RooDataSet.h"
-#include "RooProdPdf.h"
-#include "RooFitResult.h"
-#include "RooConstVar.h"
-#include "RooPoisson.h"
-#include "RooProduct.h"
-#include "RooWorkspace.h"
+#include <RooAbsPdf.h>
+#include <RooDataSet.h>
+#include <RooFitResult.h>
+#include <RooMsgService.h>
+#include <RooRealVar.h>
+#include <RooWorkspace.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <memory>
 #include <functional>
@@ -27,8 +21,9 @@ namespace {
 bool isNotIdentical(RooFitResult const &res1, RooFitResult const &res2)
 {
    std::size_t n = res1.floatParsFinal().size();
-   if (n != res2.floatParsFinal().size())
+   if (n != res2.floatParsFinal().size()) {
       return true;
+   }
    for (std::size_t i = 0; i < n; ++i) {
       if (static_cast<RooAbsRealLValue &>(res1.floatParsFinal()[i]).getVal() !=
           static_cast<RooAbsRealLValue &>(res2.floatParsFinal()[i]).getVal())
@@ -49,52 +44,38 @@ public:
       // silence log output
       RooMsgService::instance().setGlobalKillBelow(RooFit::WARNING);
 
-      // observables
-      RooRealVar x("x", "x", 0.0, 0.0, 20.0);
-
-      // global observables, always constant in fits
-      RooRealVar gm("gm", "gm", 11.0, 0.0, 20.0);
-      RooRealVar gs("gs", "gs", 1.0, 0.1, 10.0);
-      gm.setConstant(true);
-      gs.setConstant(true);
-
-      // constrained parameters
-      RooRealVar f("f", "f", 0.5, 0.0, 1.0);
-
-      // other parameters
-      RooRealVar m("m", "m", 10.0, 0.0, 20.0);
-      RooRealVar s("s", "s", 2.0, 0.1, 10.0);
-
       // We use the global observable also in the model for the event
       // observables. It's unusual, but let's better do this to also cover the
       // corner case where the global observable is not only part of the
       // constraint term.
-      RooProduct sigma{"sigma", "sigma", {s, gs}};
+      _ws.factory("Product::sigma({s[2.0, 0.1, 10.0], gs[1.0, 0.1, 10.0]})");
 
-      // build the unconstrained model
-      RooGaussian model("model", "model", x, m, sigma);
+      _ws.factory("Gaussian::model(x[0.0, 0.0, 20.0], m[10.0, 0.0, 20.0], sigma)");
 
       // the constraint pdfs, they are RooPoisson so we can't have tests that accidentally
       // pass because of the symmetry of normalizing over x or mu
-      RooPoisson mconstraint("mconstraint", "mconstraint", gm, m);
-      RooPoisson sconstraint("sconstraint", "sconstraint", gs, s);
+      _ws.factory("Poisson::mconstraint(gm[11.0, 0.0, 20.0], m)");
+      _ws.factory("Poisson::sconstraint(gs, s)");
+
+      // global observables, always constant in fits
+      RooRealVar &gm = *_ws.var("gm");
+      RooRealVar &gs = *_ws.var("gs");
+      gm.setConstant(true);
+      gs.setConstant(true);
 
       // the model multiplied with the constraint term
-      RooProdPdf modelc("modelc", "modelc", RooArgSet(model, mconstraint, sconstraint));
+      _ws.factory("ProdPdf::modelc(model, mconstraint, sconstraint)");
 
       // generate small dataset for use in fitting below, also cloned versions
       // with one or two global observables attached
-      _data.reset(model.generate(x, 50));
+      _data.reset(_ws.pdf("model")->generate(*_ws.var("x"), 50));
 
-      _dataWithMeanSigmaGlobs.reset(
-         static_cast<RooDataSet *>(_data->Clone((std::string(_data->GetName()) + "_gm_gs").c_str())));
+      _dataWithMeanSigmaGlobs.reset(static_cast<RooDataSet *>(_data->Clone()));
+      _dataWithMeanSigmaGlobs->SetName((std::string(_data->GetName()) + "_gm_gs").c_str());
       _dataWithMeanSigmaGlobs->setGlobalObservables({gm, gs});
 
       _dataWithMeanGlob.reset(static_cast<RooDataSet *>(_data->Clone((std::string(_data->GetName()) + "_gm").c_str())));
       _dataWithMeanGlob->setGlobalObservables(gm);
-
-      _workspace = std::make_unique<RooWorkspace>("workspace", "workspace");
-      _workspace->import(modelc);
    }
 
    // reset the parameter values to initial values before fits
@@ -103,13 +84,13 @@ public:
       std::vector<std::string> names{"x", "m", "s", "gm", "gs"};
       std::vector<double> values{0.0, 10.0, 2.0, 11.0, 1.0};
       for (std::size_t i = 0; i < names.size(); ++i) {
-         auto *var = _workspace->var(names[i]);
+         auto *var = _ws.var(names[i]);
          var->setVal(values[i]);
          var->setError(0.0);
       }
    }
 
-   RooWorkspace &ws() { return *_workspace; }
+   RooWorkspace &ws() { return _ws; }
    RooDataSet &data() { return *_data; }
    RooDataSet &dataWithMeanSigmaGlobs() { return *_dataWithMeanSigmaGlobs; }
    RooDataSet &dataWithMeanGlob() { return *_dataWithMeanGlob; }
@@ -128,14 +109,13 @@ public:
 
    void TearDown() override
    {
-      _workspace.reset();
       _data.reset();
       _dataWithMeanSigmaGlobs.reset();
       _data.reset();
    }
 
 private:
-   std::unique_ptr<RooWorkspace> _workspace;
+   RooWorkspace _ws;
    std::unique_ptr<RooDataSet> _data;
    std::unique_ptr<RooDataSet> _dataWithMeanSigmaGlobs;
    std::unique_ptr<RooDataSet> _dataWithMeanGlob;

--- a/roofit/roofitcore/test/testRooAbsPdf.cxx
+++ b/roofit/roofitcore/test/testRooAbsPdf.cxx
@@ -28,41 +28,39 @@
 
 #include <memory>
 
-
 // ROOT-10668: Asympt. correct errors don't work when title and name differ
 TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
 {
-  auto& msg = RooMsgService::instance();
-  msg.setGlobalKillBelow(RooFit::WARNING);
+   auto &msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(RooFit::WARNING);
 
-  RooRealVar x("x", "xxx", 0, 0, 10);
-  RooRealVar a("a", "aaa", 2, 0, 10);
-  // Cannot play with RooAbsPdf, since abstract.
-  RooGenericPdf pdf("pdf", "std::pow(x,a)", RooArgSet(x, a));
-  RooFormulaVar formula("w", "(x-5)*(x-5)*1.2", RooArgSet(x));
+   RooRealVar x("x", "xxx", 0, 0, 10);
+   RooRealVar a("a", "aaa", 2, 0, 10);
+   // Cannot play with RooAbsPdf, since abstract.
+   RooGenericPdf pdf("pdf", "std::pow(x,a)", RooArgSet(x, a));
+   RooFormulaVar formula("w", "(x-5)*(x-5)*1.2", RooArgSet(x));
 
-  std::unique_ptr<RooDataSet> data(pdf.generate(x, 5000));
-  data->addColumn(formula);
-  RooRealVar w("w", "weight", 1, 0, 20);
-  RooDataSet weightedData("weightedData", "weightedData",
-      RooArgSet(x, w), RooFit::Import(*data), RooFit::WeightVar(w));
+   std::unique_ptr<RooDataSet> data(pdf.generate(x, 5000));
+   data->addColumn(formula);
+   RooRealVar w("w", "weight", 1, 0, 20);
+   RooDataSet weightedData("weightedData", "weightedData", RooArgSet(x, w), RooFit::Import(*data),
+                           RooFit::WeightVar(w));
 
-  ASSERT_TRUE(weightedData.isWeighted());
-  weightedData.get(0);
-  ASSERT_NE(weightedData.weight(), 1);
+   ASSERT_TRUE(weightedData.isWeighted());
+   weightedData.get(0);
+   ASSERT_NE(weightedData.weight(), 1);
 
-  a = 1.2;
-  auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true), RooFit::PrintLevel(-1));
-  a = 1.2;
-  auto result2 = pdf.fitTo(weightedData, RooFit::Save(), RooFit::SumW2Error(false), RooFit::PrintLevel(-1));
+   a = 1.2;
+   auto result = pdf.fitTo(weightedData, RooFit::Save(), RooFit::AsymptoticError(true), RooFit::PrintLevel(-1));
+   a = 1.2;
+   auto result2 = pdf.fitTo(weightedData, RooFit::Save(), RooFit::SumW2Error(false), RooFit::PrintLevel(-1));
 
-  // Set relative tolerance for errors to large value to only check for values
-  EXPECT_TRUE(result->isIdenticalNoCov(*result2, 1e-6, 10.0)) << "Fit results should be very similar.";
-  // Set non-verbose because we expect the comparison to fail
-  EXPECT_FALSE(result->isIdenticalNoCov(*result2, 1e-6, 1e-3, false))
+   // Set relative tolerance for errors to large value to only check for values
+   EXPECT_TRUE(result->isIdenticalNoCov(*result2, 1e-6, 10.0)) << "Fit results should be very similar.";
+   // Set non-verbose because we expect the comparison to fail
+   EXPECT_FALSE(result->isIdenticalNoCov(*result2, 1e-6, 1e-3, false))
       << "Asymptotically correct errors should be significantly larger.";
 }
-
 
 // Test a conditional fit with batch mode
 //
@@ -79,136 +77,124 @@ TEST(RooAbsPdf, AsymptoticallyCorrectErrors)
 // will inform that a batched evaluation function is missing.
 TEST(RooAbsPdf, ConditionalFitBatchMode)
 {
-  using namespace RooFit;
-  constexpr bool verbose = false;
+   using namespace RooFit;
+   constexpr bool verbose = false;
 
-  if(!verbose) {
-    auto& msg = RooMsgService::instance();
-    msg.getStream(1).removeTopic(RooFit::Minimization);
-    msg.getStream(1).removeTopic(RooFit::Fitting);
-  }
+   if (!verbose) {
+      auto &msg = RooMsgService::instance();
+      msg.getStream(1).removeTopic(RooFit::Minimization);
+      msg.getStream(1).removeTopic(RooFit::Fitting);
+   }
 
-  auto makeFakeDataXY = []() {
-    RooRealVar x("x", "x", 0, 10);
-    RooRealVar y("y", "y", 1.0, 5);
-    RooArgSet coord(x, y);
+   auto makeFakeDataXY = []() {
+      RooRealVar x("x", "x", 0, 10);
+      RooRealVar y("y", "y", 1.0, 5);
+      RooArgSet coord(x, y);
 
-    auto d = std::make_unique<RooDataSet>("d", "d", RooArgSet(x, y));
+      auto d = std::make_unique<RooDataSet>("d", "d", RooArgSet(x, y));
 
-    for (int i = 0; i < 10000; i++) {
-      double tmpy = gRandom->Gaus(3, 2);
-      double tmpx = gRandom->Poisson(tmpy);
-      if (fabs(tmpy) > 1 && fabs(tmpy) < 5 && fabs(tmpx) < 10) {
-        x = tmpx;
-        y = tmpy;
-        d->add(coord);
+      for (int i = 0; i < 10000; i++) {
+         double tmpy = gRandom->Gaus(3, 2);
+         double tmpx = gRandom->Poisson(tmpy);
+         if (fabs(tmpy) > 1 && fabs(tmpy) < 5 && fabs(tmpx) < 10) {
+            x = tmpx;
+            y = tmpy;
+            d->add(coord);
+         }
       }
-    }
 
-    return d;
-  };
+      return d;
+   };
 
-  auto data = makeFakeDataXY();
+   auto data = makeFakeDataXY();
 
-  RooRealVar x("x", "x", 0, 10);
-  RooRealVar y("y", "y", 1.0, 5);
+   RooRealVar x("x", "x", 0, 10);
+   RooRealVar y("y", "y", 1.0, 5);
 
-  RooRealVar factor("factor", "factor", 1.0, 0.0, 10.0);
+   RooRealVar factor("factor", "factor", 1.0, 0.0, 10.0);
 
-  std::vector<RooProduct> means{{"mean", "mean", {factor, y}},
-                                {"mean", "mean", {factor}}};
-  std::vector<bool> expectFastEvaluationsWarnings{true, false};
+   std::vector<RooProduct> means{{"mean", "mean", {factor, y}}, {"mean", "mean", {factor}}};
+   std::vector<bool> expectFastEvaluationsWarnings{true, false};
 
-  int iMean = 0;
-  for(auto& mean : means) {
+   int iMean = 0;
+   for (auto &mean : means) {
 
-    RooPoisson model("model", "model", x, mean);
+      RooPoisson model("model", "model", x, mean);
 
-    std::vector<std::unique_ptr<RooFitResult>> fitResults;
+      std::vector<std::unique_ptr<RooFitResult>> fitResults;
 
-    RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::FastEvaluations);
+      RooHelpers::HijackMessageStream hijack(RooFit::INFO, RooFit::FastEvaluations);
 
-    for(bool batchMode : {false, true}) {
-      factor.setVal(1.0);
-      factor.setError(0.0);
-      fitResults.emplace_back(
-        model.fitTo(
-              *data,
-              ConditionalObservables(y),
-              Save(),
-              PrintLevel(-1),
-              BatchMode(batchMode)
-         ));
-      if (verbose) fitResults.back()->Print();
-    }
+      for (bool batchMode : {false, true}) {
+         factor.setVal(1.0);
+         factor.setError(0.0);
+         fitResults.emplace_back(
+            model.fitTo(*data, ConditionalObservables(y), Save(), PrintLevel(-1), BatchMode(batchMode)));
+         if (verbose)
+            fitResults.back()->Print();
+      }
 
-    EXPECT_TRUE(fitResults[1]->isIdentical(*fitResults[0]));
-    EXPECT_EQ(hijack.str().find("does not implement the faster batch") != std::string::npos, expectFastEvaluationsWarnings[iMean])
-        << "Stream contents: " << hijack.str();
-    ++iMean;
-  }
+      EXPECT_TRUE(fitResults[1]->isIdentical(*fitResults[0]));
+      EXPECT_EQ(hijack.str().find("does not implement the faster batch") != std::string::npos,
+                expectFastEvaluationsWarnings[iMean])
+         << "Stream contents: " << hijack.str();
+      ++iMean;
+   }
 }
 
 // ROOT-9530: RooFit side-band fit inconsistent with fit to full range
 TEST(RooAbsPdf, MultiRangeFit)
 {
-  using namespace RooFit;
-  auto& msg = RooMsgService::instance();
-  msg.setGlobalKillBelow(RooFit::WARNING);
+   using namespace RooFit;
+   auto &msg = RooMsgService::instance();
+   msg.setGlobalKillBelow(RooFit::WARNING);
 
-  RooRealVar x("x","x",-10,10);
+   RooRealVar x("x", "x", -10, 10);
 
-  double cut = -5;
-  x.setRange("full", -10, 10);
-  x.setRange("low", -10, cut);
-  x.setRange("high", cut, 10);
+   double cut = -5;
+   x.setRange("full", -10, 10);
+   x.setRange("low", -10, cut);
+   x.setRange("high", cut, 10);
 
-  RooRealVar mean("mean", "mean",-1, -10, 10);
-  RooRealVar width("width", "width", 3., 0.1, 10);
-  RooGaussian modelSimple("model_simple","model_simple",x,mean,width);
+   RooRealVar mean("mean", "mean", -1, -10, 10);
+   RooRealVar width("width", "width", 3., 0.1, 10);
+   RooGaussian modelSimple("model_simple", "model_simple", x, mean, width);
 
-  std::size_t nEvents = 100;
+   std::size_t nEvents = 100;
 
-  // model for extended fit
-  RooRealVar nsig("nsig","nsig",nEvents,0.,2000) ;
-  RooAddPdf  modelExtended("model_extended","model_simple+a",RooArgList(modelSimple),RooArgList(nsig)) ;
+   // model for extended fit
+   RooRealVar nsig("nsig", "nsig", nEvents, 0., 2000);
+   RooAddPdf modelExtended("model_extended", "model_simple+a", RooArgList(modelSimple), RooArgList(nsig));
 
-  auto resetValues = [&](){
-    mean.setVal(-1);
-    width.setVal(3);
-    nsig.setVal(nEvents);
-    mean.setError(0.0);
-    width.setError(0.0);
-    nsig.setError(0.0);
-  };
+   auto resetValues = [&]() {
+      mean.setVal(-1);
+      width.setVal(3);
+      nsig.setVal(nEvents);
+      mean.setError(0.0);
+      width.setError(0.0);
+      nsig.setError(0.0);
+   };
 
-  // loop over non-extended and extended fit
-  for (auto* model : {static_cast<RooAbsPdf*>(&modelSimple),
-                      static_cast<RooAbsPdf*>(&modelExtended)}) {
+   // loop over non-extended and extended fit
+   for (auto *model : {static_cast<RooAbsPdf *>(&modelSimple), static_cast<RooAbsPdf *>(&modelExtended)}) {
 
-    std::unique_ptr<RooDataSet> dataSet{model->generate(x, nEvents)};
-    std::unique_ptr<RooDataHist> dataHist{dataSet->binnedClone()};
+      std::unique_ptr<RooDataSet> dataSet{model->generate(x, nEvents)};
+      std::unique_ptr<RooDataHist> dataHist{dataSet->binnedClone()};
 
-    // loop over binned fit and unbinned fit
-    for (auto* data : {static_cast<RooAbsData*>(dataSet.get()),
-                       static_cast<RooAbsData*>(dataHist.get())}) {
-      // full range
-      resetValues();
-      std::unique_ptr<RooFitResult> fitResultFull{
-        model->fitTo(*data, Range("full"), Save(), PrintLevel(-1))
-      };
+      // loop over binned fit and unbinned fit
+      for (auto *data : {static_cast<RooAbsData *>(dataSet.get()), static_cast<RooAbsData *>(dataHist.get())}) {
+         // full range
+         resetValues();
+         std::unique_ptr<RooFitResult> fitResultFull{model->fitTo(*data, Range("full"), Save(), PrintLevel(-1))};
 
-      // part (side band fit, but the union of the side bands is the full range)
-      resetValues();
-      std::unique_ptr<RooFitResult> fitResultPart{
-        model->fitTo(*data, Range("low,high"), Save(), PrintLevel(-1))
-      };
+         // part (side band fit, but the union of the side bands is the full range)
+         resetValues();
+         std::unique_ptr<RooFitResult> fitResultPart{model->fitTo(*data, Range("low,high"), Save(), PrintLevel(-1))};
 
-      EXPECT_TRUE(fitResultPart->isIdentical(*fitResultFull))
-          << "Results of fitting " << model->GetName() << " to a "
-          << data->ClassName() <<  " should be very similar.";
-    }
-  }
+         EXPECT_TRUE(fitResultPart->isIdentical(*fitResultFull))
+            << "Results of fitting " << model->GetName() << " to a " << data->ClassName() << " should be very similar.";
+      }
+   }
 }
 
 // ROOT-9530: RooFit side-band fit inconsistent with fit to full range (2D case)
@@ -279,8 +265,8 @@ TEST(RooAbsPdf, MultiRangeFit2D)
       resetValues();
       std::unique_ptr<RooFitResult> fitResultPart{model.fitTo(*data, Range("SB1,SB2,SIG"), Save(), PrintLevel(-1))};
 
-      EXPECT_TRUE(fitResultPart->isIdentical(*fitResultFull)) << "Results of fitting " << model.GetName() << " to a "
-                                                              << data->ClassName() << " should be very similar.";
+      EXPECT_TRUE(fitResultPart->isIdentical(*fitResultFull))
+         << "Results of fitting " << model.GetName() << " to a " << data->ClassName() << " should be very similar.";
    }
 }
 
@@ -338,7 +324,7 @@ TEST(RooAbsPdf, NormSetChange)
 
    RooRealVar x("x", "x", 0, -10, 10);
    RooGaussian gauss("gauss", "gauss", x, RooConst(0), RooConst(2));
-   RooAddition add("add", "add",  {gauss});
+   RooAddition add("add", "add", {gauss});
 
    double v1 = add.getVal();
    double v2 = add.getVal(x);


### PR DESCRIPTION
Get rid of the remaining memory leaks, avoid code duplication for simultaneous binned fit test, etc.

There is also an additional commit that continues the campaign of making the `roofitcore` tests depend less on `roofit`.