### PR TITLE
RConcurrentHashColl: remove unused (internal) function

### DIFF
--- a/core/thread/inc/ROOT/RConcurrentHashColl.hxx
+++ b/core/thread/inc/ROOT/RConcurrentHashColl.hxx
@@ -47,9 +47,6 @@ public:
    bool Find(const HashValue &hash) const;
 
    /// If the hash is there, return false. Otherwise, insert the hash and return true;
-   bool Insert(char *buf, int len) const;
-
-   /// If the hash is there, return false. Otherwise, insert the hash and return true;
    bool Insert(const HashValue &hash) const;
 
    /// Return the hash object corresponding to the buffer.

--- a/core/thread/src/RConcurrentHashColl.cxx
+++ b/core/thread/src/RConcurrentHashColl.cxx
@@ -46,23 +46,6 @@ RConcurrentHashColl::HashValue RConcurrentHashColl::Hash(char *buffer, int len)
 }
 
 /// If the buffer is there, return false. Otherwise, insert the hash and return true
-bool RConcurrentHashColl::Insert(char *buffer, int len) const
-{
-   HashValue hash(buffer, len);
-
-   {
-      ROOT::TRWSpinLockReadGuard rg(*fRWLock);
-      if (fHashSet->fSet.end() != fHashSet->fSet.find(hash))
-         return false;
-   }
-   {
-      ROOT::TRWSpinLockWriteGuard wg(*fRWLock);
-      fHashSet->fSet.insert(hash);
-      return true;
-   }
-}
-
-/// If the buffer is there, return false. Otherwise, insert the hash and return true
 bool RConcurrentHashColl::Insert(const HashValue &hash) const
 {
    ROOT::TRWSpinLockWriteGuard wg(*fRWLock);


### PR DESCRIPTION
As reported by Chris Jones:

> https://github.com/root-project/root/blob/6a1389a16625718f2750ba90156d3f8f9d5dfe8a/core/thread/src/RConcurrentHashColl.cxx#L53-L62
> There is a race condition between line 57 and 58. Between releasing the read lock and taking the write lock, another thread could have inserted the same hash.

And indeed, the unconditional return of `true` within the write lock means that in the case of the race condition then the result is incorrect.

(a) the only consequence of the race is a small performance loss and the return value of the function is incorrect (true instead of false)

(b) but the function does not seem to be called anywhere.

The consequence of (a) should be if (b) is incorrect that a StreamerInfo is being re-read when it does not need to, so 'only'  a performance decrease when opening files.

Also Matti noticed that the 2nd forms was always taking the write lock and that is because:

The proper use of that function is to do the check externally (via a call to Find) and then call the Insert if need be.  The call to std::set::insert does a check internally to reject double inserts and return the status via the iterator.  So that 2nd function is already doing (indirectly) the check Dan recommended.  So the fix is to either fix the return value of the first function or have it call the 2nd function or .... just removing it.



 