### PR TITLE
[DF] Remove unnecessary weak ptr from ReportHelper

### DIFF
--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -2435,7 +2435,7 @@ public:
       using Helper_t = RDFInternal::ReportHelper<Proxied>;
       using Action_t = RDFInternal::RAction<Helper_t, Proxied>;
 
-      auto action = std::make_unique<Action_t>(Helper_t(rep, fProxiedPtr, returnEmptyReport), ColumnNames_t({}),
+      auto action = std::make_unique<Action_t>(Helper_t(rep, fProxiedPtr.get(), returnEmptyReport), ColumnNames_t({}),
                                                fProxiedPtr, RDFInternal::RColumnRegister(fColRegister));
 
       return MakeResultPtr(rep, *fLoopManager, std::move(action));


### PR DESCRIPTION
The weak pointer was used to track whether the node that Report was hanging from went out of scope, but since a while the ownership model of nodes in the computation graph (child owns parent) guarantees that as long as the ReportHelper (and the corresponding action node) is around, the node it hangs from will be around as well.
We can use a simple raw pointer instead.