### PR TITLE
[Geom] GDML parser warns about entities missing a unit definition.

### DIFF
--- a/geom/gdml/inc/TGDMLParse.h
+++ b/geom/gdml/inc/TGDMLParse.h
@@ -99,6 +99,7 @@ public:
    TGeoVolume* fWorld; //top volume of geometry
    int fVolID;   //volume ID, incremented as assigned.
    int fFILENO; //Holds which level of file the parser is at
+   int fNunitless{0};           // Number of entities defined unitless
    TXMLEngine* fFileEngine[20]; //array of dom object pointers
    const char* fStartFile; //name of originating file
    const char* fCurrentFile; //current file name being parsed


### PR DESCRIPTION
In case TGeoManager is set to work with default ROOT units [cm,deg] and the GDML parser reads entities missing explicit units, it issues now a warning. This is due to the fact that the default unit in this case will not match the unit types defined in the GDML schema [mm,rad]. An automatic fix cannot be done because it would introduce backward incompatibilities. This closes #11781

# This Pull request:
Produces warnings for GDML files with entities missing explicit unit declaration

## Changes or fixes:
The number of entities missing declaration of units is reported. The warning proposes the alternative fix of using Geant4 units supported by TGeo. 

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR addresses #11781 

