### PR TITLE
[cling] Create non-empty source file

### DIFF
--- a/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.cpp
@@ -290,7 +290,7 @@ namespace cling {
       : m_Interpreter(interp) {
     std::unique_ptr<cling::DeclCollector> consumer;
     consumer.reset(m_Consumer = new cling::DeclCollector());
-    m_CI.reset(CIFactory::createCI("", interp->getOptions(), llvmdir,
+    m_CI.reset(CIFactory::createCI("\n", interp->getOptions(), llvmdir,
                                    std::move(consumer), moduleExtensions));
 
     if (!m_CI) {

--- a/interpreter/cling/lib/Interpreter/IncrementalParser.h
+++ b/interpreter/cling/lib/Interpreter/IncrementalParser.h
@@ -70,8 +70,9 @@ namespace cling {
     // file ID of the memory buffer
     clang::FileID m_VirtualFileID;
 
-    // The next available unique sourcelocation offset.
-    unsigned m_VirtualFileLocOffset = 1; // skip the system sloc 0.
+    // The next available unique sourcelocation offset. Skip the system sloc 0
+    // and any offset that may actually exist in the virtual file.
+    unsigned m_VirtualFileLocOffset = 100;
 
     // CI owns it
     DeclCollector* m_Consumer;

--- a/interpreter/llvm/src/include/llvm/IR/DebugInfoMetadata.h
+++ b/interpreter/llvm/src/include/llvm/IR/DebugInfoMetadata.h
@@ -620,9 +620,7 @@ public:
     return StringRefChecksum;
   }
   Optional<StringRef> getSource() const {
-    if (!Source || !*Source)
-      return None;
-    return Optional<StringRef>((*Source)->getString());
+    return Source ? Optional<StringRef>((*Source)->getString()) : None;
   }
 
   MDString *getRawFilename() const { return getOperandAs<MDString>(0); }


### PR DESCRIPTION
LLVM currently has an issue that a completely empty source file is stored as a `nullptr`, but `DIFile::getSource()` does not correctly deal with this situation. A crash can be observed if just attempting to launch root.exe with `EXTRA_CLING_ARGS="-gdwarf-5 -gembed-source"`.