### PR TITLE
[RF] Improve constraint parameter management

### DIFF
--- a/roofit/roofitcore/src/RooAbsPdf.cxx
+++ b/roofit/roofitcore/src/RooAbsPdf.cxx
@@ -994,6 +994,12 @@ RooFit::OwningPtr<RooAbsReal> RooAbsPdf::createNLL(RooAbsData& data, const RooLi
   pc.defineMutex("GlobalObservables","GlobalObservablesTag") ;
   pc.defineInt("ModularL", "ModularL", 0, 0);
 
+  if(pc.getSet("cPars") && pc.getSet("extCons")) {
+    std::string errMsg = "Specifying Constrain() when GlobalObservables() is passed is dangerous!";
+    coutE(InputArguments) << errMsg << std::endl;
+    throw std::invalid_argument(errMsg);
+  }
+
   // New style likelihoods define parallelization through Parallelize(...) on fitTo or attributes on RooMinimizer::Config.
   pc.defineMutex("ModularL", "NumCPU");
 

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodGradientJob.cxx
@@ -385,8 +385,7 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
    RooAbsData *data = w.data("data");
 
    // do a minimization, but now using GradMinimizer and its MP version
-   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_obs_A")),
-                                                  GlobalObservables(*w.var("alpha_bkg_obs_B")), Offset(true))};
+   std::unique_ptr<RooAbsReal> nll{pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_A")), Offset(true))};
 
    // parameters
    std::size_t NWorkers = 2;
@@ -417,8 +416,8 @@ TEST_P(SimBinnedConstrainedTest, ConstrainedAndOffset)
 
    RooFit::MultiProcess::Config::setDefaultNWorkers(NWorkers);
 
-   std::unique_ptr<RooAbsReal> likelihoodAbsReal{pdf->createNLL(
-      *data, Constrain(*w.var("alpha_bkg_obs_A")), GlobalObservables(*w.var("alpha_bkg_obs_B")), ModularL(true))};
+   std::unique_ptr<RooAbsReal> likelihoodAbsReal{
+      pdf->createNLL(*data, Constrain(*w.var("alpha_bkg_A")), ModularL(true))};
 
    RooMinimizer::Config cfg1;
    cfg1.parallelize = -1;

--- a/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
+++ b/roofit/roofitcore/test/TestStatistics/testLikelihoodJob.cxx
@@ -417,18 +417,14 @@ TEST_F(LikelihoodJobSimBinnedConstrainedTest, BasicParameters)
 TEST_F(LikelihoodJobSimBinnedConstrainedTest, ConstrainedAndOffset)
 {
    // a variation to test some additional parameters (ConstrainedParameters and offsetting)
-   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
-                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
-                                                    RooFit::Offset(true))};
+   nll = std::unique_ptr<RooAbsReal>{
+      pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_A")), RooFit::Offset(true))};
 
    // --------
 
    auto nll0 = nll->getVal();
 
-   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}
-                   .ConstrainedParameters(*w.var("alpha_bkg_obs_A"))
-                   .GlobalObservables(*w.var("alpha_bkg_obs_B"))
-                   .build();
+   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}.ConstrainedParameters(*w.var("alpha_bkg_A")).build();
    auto nll_ts =
       LikelihoodWrapper::create(RooFit::TestStatistics::LikelihoodMode::multiprocess, likelihood, clean_flags);
    nll_ts->enableOffsetting(true);
@@ -478,18 +474,15 @@ class LikelihoodJobSplitStrategies : public LikelihoodJobSimBinnedConstrainedTes
 TEST_P(LikelihoodJobSplitStrategies, SimBinnedConstrainedAndOffset)
 {
    // based on ConstrainedAndOffset, this test tests different parallelization strategies
-   nll = std::unique_ptr<RooAbsReal>{pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_obs_A")),
-                                                    RooFit::GlobalObservables(*w.var("alpha_bkg_obs_B")),
-                                                    RooFit::Offset(true))};
+   nll = std::unique_ptr<RooAbsReal>{
+      pdf->createNLL(*data, RooFit::Constrain(*w.var("alpha_bkg_A")), RooFit::Offset(true), RooFit::BatchMode(true))};
 
    // --------
 
    auto nll0 = nll->getVal();
+   nll->Print("v");
 
-   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}
-                   .ConstrainedParameters(*w.var("alpha_bkg_obs_A"))
-                   .GlobalObservables(*w.var("alpha_bkg_obs_B"))
-                   .build();
+   likelihood = RooFit::TestStatistics::NLLFactory{*pdf, *data}.ConstrainedParameters(*w.var("alpha_bkg_A")).build();
 
    RooFit::MultiProcess::Config::LikelihoodJob::defaultNEventTasks = std::get<0>(GetParam());
    RooFit::MultiProcess::Config::LikelihoodJob::defaultNComponentTasks = std::get<1>(GetParam());

--- a/roofit/roostats/src/AsymptoticCalculator.cxx
+++ b/roofit/roostats/src/AsymptoticCalculator.cxx
@@ -302,7 +302,7 @@ double AsymptoticCalculator::EvaluateNLL(RooStats::ModelConfig const& modelConfi
 
     // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
     auto& config = GetGlobalRooStatsConfig();
-    std::unique_ptr<RooAbsReal> nll{modelConfig.createNLL(data, RooFit::Constrain(*allParams), RooFit::Offset(config.useLikelihoodOffset))};
+    std::unique_ptr<RooAbsReal> nll{modelConfig.createNLL(data, RooFit::Offset(config.useLikelihoodOffset))};
 
     std::unique_ptr<RooArgSet> attachedSet{nll->getVariables()};
 
@@ -1270,7 +1270,6 @@ RooAbsData * AsymptoticCalculator::MakeAsimovData(RooAbsData & realData, const M
       args.push_back(RooFit::Strategy(ROOT::Math::MinimizerOptions::DefaultStrategy()));
       args.push_back(RooFit::PrintLevel(minimPrintLevel-1));
       args.push_back(RooFit::Hesse(false));
-      args.push_back(RooFit::Constrain(constrainParams));
       args.push_back(RooFit::GlobalObservables(globalObs));
       args.push_back(RooFit::ConditionalObservables(conditionalObs));
       args.push_back(RooFit::Offset(GetGlobalRooStatsConfig().useLikelihoodOffset));

--- a/roofit/roostats/src/BayesianCalculator.cxx
+++ b/roofit/roostats/src/BayesianCalculator.cxx
@@ -800,7 +800,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
    //constrainedParams->Print("V");
 
    // use RooFit::Constrain() to be sure constraints terms are taken into account
-   fLogLike = std::unique_ptr<RooAbsReal>{fPdf->createNLL(*fData, RooFit::Constrain(*constrainedParams), RooFit::ConditionalObservables(fConditionalObs), RooFit::GlobalObservables(fGlobalObs) )};
+   fLogLike = std::unique_ptr<RooAbsReal>{fPdf->createNLL(*fData, RooFit::ConditionalObservables(fConditionalObs), RooFit::GlobalObservables(fGlobalObs) )};
 
 
 
@@ -893,7 +893,7 @@ RooAbsReal* BayesianCalculator::GetPosteriorFunction() const
       std::unique_ptr<RooArgSet> constrParams{fPdf->getParameters(*fData)};
       // remove the constant parameters
       RemoveConstantParameters(&*constrParams);
-      fLogLike = std::unique_ptr<RooAbsReal>{pdfAndPrior->createNLL(*fData, RooFit::Constrain(*constrParams),RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) )};
+      fLogLike = std::unique_ptr<RooAbsReal>{pdfAndPrior->createNLL(*fData, RooFit::ConditionalObservables(fConditionalObs),RooFit::GlobalObservables(fGlobalObs) )};
 
       TString likeName = TString("likelihood_times_prior_") + TString(pdfAndPrior->GetName());
       TString formula;

--- a/roofit/roostats/src/FrequentistCalculator.cxx
+++ b/roofit/roostats/src/FrequentistCalculator.cxx
@@ -94,7 +94,7 @@ int FrequentistCalculator::PreNullHook(RooArgSet *parameterPoint, double obsTest
       if (fNullModel->GetGlobalObservables()) globalObs.add(*fNullModel->GetGlobalObservables());
 
       auto& config = GetGlobalRooStatsConfig();
-      std::unique_ptr<RooAbsReal> nll{fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
+      std::unique_ptr<RooAbsReal> nll{fNullModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false),
                                                         RooFit::GlobalObservables(globalObs),
                                                         RooFit::ConditionalObservables(conditionalObs),
                                                         RooFit::Offset(config.useLikelihoodOffset))};
@@ -200,7 +200,7 @@ int FrequentistCalculator::PreAltHook(RooArgSet *parameterPoint, double obsTestS
       if (fAltModel->GetGlobalObservables()) globalObs.add(*fAltModel->GetGlobalObservables());
 
       const auto& config = GetGlobalRooStatsConfig();
-      std::unique_ptr<RooAbsReal> nll{fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false), RooFit::Constrain(*allParams),
+      std::unique_ptr<RooAbsReal> nll{fAltModel->GetPdf()->createNLL(*const_cast<RooAbsData*>(fData), RooFit::CloneData(false),
                                                        RooFit::GlobalObservables(globalObs),
                                                        RooFit::ConditionalObservables(conditionalObs),
                                                        RooFit::Offset(config.useLikelihoodOffset))};

--- a/roofit/roostats/src/MCMCCalculator.cxx
+++ b/roofit/roostats/src/MCMCCalculator.cxx
@@ -170,8 +170,7 @@ MCMCInterval* MCMCCalculator::GetInterval() const
       prodPdf = new RooProdPdf(prodName,prodName,RooArgList(*fPdf,*fPriorPdf) );
    }
 
-   std::unique_ptr<RooArgSet> constrainedParams{prodPdf->getParameters(*fData)};
-   std::unique_ptr<RooAbsReal> nll{prodPdf->createNLL(*fData, Constrain(*constrainedParams),ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs))};
+   std::unique_ptr<RooAbsReal> nll{prodPdf->createNLL(*fData, ConditionalObservables(fConditionalObs),GlobalObservables(fGlobalObs))};
 
    std::unique_ptr<RooArgSet> params{nll->getParameters(*fData)};
    RemoveConstantParameters(&*params);

--- a/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodCalculator.cxx
@@ -133,7 +133,7 @@ RooFit::OwningPtr<RooAbsReal>  ProfileLikelihoodCalculator::DoGlobalFit() const 
    RemoveConstantParameters(&*constrainedParams);
 
    const auto& config = GetGlobalRooStatsConfig();
-   auto nll = pdf->createNLL(*data, CloneData(true), Constrain(*constrainedParams),ConditionalObservables(fConditionalObs), GlobalObservables(fGlobalObs),
+   auto nll = pdf->createNLL(*data, CloneData(true), ConditionalObservables(fConditionalObs), GlobalObservables(fGlobalObs),
        RooFit::Offset(config.useLikelihoodOffset) );
 
    // check if global fit has been already done

--- a/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
+++ b/roofit/roostats/src/ProfileLikelihoodTestStat.cxx
@@ -88,7 +88,7 @@ double RooStats::ProfileLikelihoodTestStat::EvaluateProfileLikelihood(int type, 
           RooStats::RemoveConstantParameters(&*allParams);
 
           // need to call constrain for RooSimultaneous until stripDisconnected problem fixed
-          fNll = std::unique_ptr<RooAbsReal>{fPdf->createNLL(data, RooFit::CloneData(false),RooFit::Constrain(*allParams),
+          fNll = std::unique_ptr<RooAbsReal>{fPdf->createNLL(data, RooFit::CloneData(false),
                                  RooFit::GlobalObservables(fGlobalObs), RooFit::ConditionalObservables(fConditionalObs), RooFit::Offset(fLOffset))};
 
           if (fPrintLevel > 0 && fLOffset) cout << "ProfileLikelihoodTestStat::Evaluate - Use Offset in creating NLL " << endl ;

--- a/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
+++ b/roofit/roostats/src/SimpleLikelihoodRatioTestStat.cxx
@@ -52,7 +52,7 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    if (!fNllNull) {
       std::unique_ptr<RooArgSet> allParams{fNullPdf->getParameters(data)};
       using namespace RooFit;
-      fNllNull = std::unique_ptr<RooAbsReal>{fNullPdf->createNLL(data, CloneData(false), Constrain(*allParams), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
+      fNllNull = std::unique_ptr<RooAbsReal>{fNullPdf->createNLL(data, CloneData(false), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
       created = true ;
    }
    if (reuse && !created) {
@@ -77,7 +77,7 @@ double RooStats::SimpleLikelihoodRatioTestStat::Evaluate(RooAbsData& data, RooAr
    if (!fNllAlt) {
       std::unique_ptr<RooArgSet> allParams{fAltPdf->getParameters(data)};
       using namespace RooFit;
-      fNllAlt = std::unique_ptr<RooAbsReal>{fAltPdf->createNLL(data, CloneData(false), Constrain(*allParams), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
+      fNllAlt = std::unique_ptr<RooAbsReal>{fAltPdf->createNLL(data, CloneData(false), GlobalObservables(fGlobalObs), ConditionalObservables(fConditionalObs))};
       created = true ;
    }
    if (reuse && !created) {

--- a/roofit/roostats/src/ToyMCImportanceSampler.cxx
+++ b/roofit/roostats/src/ToyMCImportanceSampler.cxx
@@ -358,7 +358,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       allVars->assign(*fNullSnapshots[i]);
       if( !fNullNLLs[i] ) {
          std::unique_ptr<RooArgSet> allParams{fNullDensities[i]->getParameters(*data)};
-         fNullNLLs[i] = std::unique_ptr<RooAbsReal>{fNullDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
+         fNullNLLs[i] = std::unique_ptr<RooAbsReal>{fNullDensities[i]->createNLL(*data, RooFit::CloneData(false),
                                                      RooFit::ConditionalObservables(fConditionalObs))};
       }else{
          fNullNLLs[i]->setData( *data, false );
@@ -383,7 +383,7 @@ RooAbsData* ToyMCImportanceSampler::GenerateToyData(
       }
       if( !fImpNLLs[i] ) {
          std::unique_ptr<RooArgSet> allParams{fImportanceDensities[i]->getParameters(*data)};
-         fImpNLLs[i] = std::unique_ptr<RooAbsReal>{fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false), RooFit::Constrain(*allParams),
+         fImpNLLs[i] = std::unique_ptr<RooAbsReal>{fImportanceDensities[i]->createNLL(*data, RooFit::CloneData(false),
                                                           RooFit::ConditionalObservables(fConditionalObs))};
       }else{
          fImpNLLs[i]->setData( *data, false );


### PR DESCRIPTION
The `Constrain()` and `GlobalObservables()` arguments were wrong in a
unit test in `testLikelihoodGradientJob`: a global observable was added
as a constrained parameter, which doesn't make sense.

`Constrain()` should contain the constrained parameters, and
`GlobalObservables()` the global observables.
