### PR TITLE
[webgui] let use unix sockets, introduce `rootssh.sh` script

### DIFF
--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -854,6 +854,7 @@ configure_file(${CMAKE_SOURCE_DIR}/config/setxrd.sh ${CMAKE_RUNTIME_OUTPUT_DIREC
 configure_file(${CMAKE_SOURCE_DIR}/config/proofserv.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/proofserv @ONLY NEWLINE_STYLE UNIX)
 configure_file(${CMAKE_SOURCE_DIR}/config/roots.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/roots @ONLY NEWLINE_STYLE UNIX)
 configure_file(${CMAKE_SOURCE_DIR}/config/root-help.el.in root-help.el @ONLY NEWLINE_STYLE UNIX)
+configure_file(${CMAKE_SOURCE_DIR}/config/rootssh.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootssh.sh @ONLY NEWLINE_STYLE UNIX)
 if(xproofd AND xrootd AND ssl AND XROOTD_NOMAIN)
   configure_file(${CMAKE_SOURCE_DIR}/config/xproofd.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/xproofd @ONLY NEWLINE_STYLE UNIX)
 endif()
@@ -901,6 +902,7 @@ install(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/thisroot.sh
 install(FILES ${CMAKE_BINARY_DIR}/installtree/root-config
               ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/roots
               ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/proofserv
+              ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/rootssh.sh
               PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
                           GROUP_EXECUTE GROUP_READ
                           WORLD_EXECUTE WORLD_READ

--- a/config/rootssh.sh
+++ b/config/rootssh.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Invoke ssh and automatically configures port forwarding for remote ROOT session
+# To start, just call:
+#
+#    [localhost] rootssh.sh  user@remotehost
+#
+# And then in the ssh shell do:
+#
+#    [user@remotehost] source path/to/bin/thisroot.sh
+#    [user@remotehost] root --web=server  -e "new TBrowser"
+#
+# ROOT automatically recognizes that it runs in special session (because of ROOT_LISTENERSOCKET var)
+# and provides to this socket information to configure port forwarding and to start web windows automatically
+
+if [[ "$1" == "--as-listener--" ]] ; then
+
+   listener_socket=$2
+
+   sshfile=$3
+
+   probe="probing"
+   localport=7777
+   while [[ "x$probe" != "x" ]] ; do
+      localport=$((7000 + $RANDOM%1000))
+      probe=$(netcat -zv localhost $localport 2>/dev/null)
+   done
+
+   echo "Start listening for socket $listener_socket with ssh file $sshfile, will use $localport"
+
+   flag=1
+
+   while [ $flag -ne 0 ] ; do
+
+      line="$(netcat -l -U $listener_socket)"
+
+      if [[ "${line:0:5}" == "http:" ]] ; then
+         remoteport=${line:5}
+         echo "Want to map remote port $localport:localhost:$remoteport"
+         ssh -S $sshfile -O forward -R $localport:localhost:$remoteport _dummy_arg_ "exit"
+      elif [[ "${line:0:4}" == "win:" ]] ; then
+         winurl=${line:4}
+         echo "Want to show window http://localhost:$localport/$winurl"
+         xdg-open "http://localhost:$localport/$winurl"
+      elif [[ "$line" == "stop" ]] ; then
+         flag=0
+      else
+         echo "Command not recognized $line - stop"
+         flag=0
+      fi
+   done
+
+   echo "Stop listener"
+
+   exit 0
+fi
+
+
+listener_file="$(mktemp /tmp/root.XXXXXXXXX)"
+remote_file="$(mktemp /tmp/root.XXXXXXXXX)"
+ssh_file="$(mktemp ~/.ssh/root.XXXXXXXXX)"
+
+rm -f $ssh_file $listener_file $remote_file
+
+# start listener process
+
+$0 --as-listener-- $listener_file $ssh_file &
+
+listener_id=$!
+
+cmd="ROOT_LISTENERSOCKET=$remote_file"
+cmd+=" $"
+cmd+="SHELL; rm -f $remote_file"
+
+echo "remote socket is $remote_file"
+
+# start ssh
+
+ssh -t -M -S $ssh_file -R $remote_file:$listener_file $1 "$cmd"
+
+echo "stop" | netcat -U $listener_file -q 1
+
+echo "Kill listener process $listener_id"
+kill -9 $listener_id > /dev/null 2>&1
+
+echo "Remove temporary files"
+rm -f $ssh_file $listener_file $remote_file

--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2778,11 +2778,15 @@ void TROOT::SetWebDisplay(const char *webdisplay)
       fIsWebDisplayBatch = kFALSE;
       fWebDisplay = "server";
       if (wd[6] == ':') {
-         auto port = TString(wd+7).Atoi();
-         if (port > 0)
-            gEnv->SetValue("WebGui.HttpPort", port);
-         else
-            Error("SetWebDisplay","Wrong port parameter %s for server", wd+7);
+         if ((wd[7] >= '0') && (wd[7] <= '9')) {
+            auto port = TString(wd+7).Atoi();
+            if (port > 0)
+               gEnv->SetValue("WebGui.HttpPort", port);
+            else
+               Error("SetWebDisplay", "Wrong port parameter %s for server", wd+7);
+         } else if (wd[7]) {
+            gEnv->SetValue("WebGui.UnixSocket", wd+7);
+         }
       }
    } else {
       fIsWebDisplay = kTRUE;

--- a/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
+++ b/gui/webdisplay/inc/ROOT/RWebWindowsManager.hxx
@@ -72,6 +72,8 @@ private:
 
    void AssignWindowThreadId(RWebWindow &win);
 
+   bool InformListener(const std::string &msg);
+
 public:
    RWebWindowsManager();
 

--- a/gui/webdisplay/src/RWebWindowsManager.cxx
+++ b/gui/webdisplay/src/RWebWindowsManager.cxx
@@ -156,8 +156,8 @@ void RWebWindowsManager::AssignWindowThreadId(RWebWindow &win)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-/// If LC_ROOT_LISTENER_SOCKET variable is configured,
-/// message will be send to that unix socket
+/// If ROOT_LISTENER_SOCKET variable is configured,
+/// message will be sent to that unix socket
 
 bool RWebWindowsManager::InformListener(const std::string &msg)
 {
@@ -172,15 +172,17 @@ bool RWebWindowsManager::InformListener(const std::string &msg)
       return false;
 
    TSocket s(fname);
-   if (!s.IsValid())
+   if (!s.IsValid()) {
+      R__LOG_ERROR(WebGUILog()) << "Problem with open listener socket " << fname << ", check ROOT_LISTENER_SOCKET environment variable";
       return false;
+   }
 
    int res = s.SendRaw(msg.c_str(), msg.length());
 
    s.Close();
 
    if (res > 0) {
-      // workaround to let listener configure port forwarding
+      // workaround to let handle socket by system outside ROOT process
       gSystem->ProcessEvents();
       gSystem->Sleep(10);
    }
@@ -224,7 +226,7 @@ bool RWebWindowsManager::InformListener(const std::string &msg)
 ///      WebGui.UnixSocketMode: 0700
 ///
 /// Typically one used unix sockets together with server mode like `root --web=server:/tmp/root.socket` and
-/// then redirect it via ssh tunel to client node
+/// then redirect it via ssh tunnel (e.g. using `rootssh`) to client node
 ///
 /// All incoming requests processed in THttpServer in timer handler with 10 ms timeout.
 /// One may decrease value to improve latency or increase value to minimize CPU load

--- a/net/http/CMakeLists.txt
+++ b/net/http/CMakeLists.txt
@@ -62,7 +62,11 @@ if(FASTCGI_FOUND)
   target_include_directories(RHTTP PRIVATE ${FASTCGI_INCLUDE_DIR})
 endif()
 
-target_compile_definitions(RHTTP PUBLIC -DUSE_WEBSOCKET)
+target_compile_definitions(RHTTP PRIVATE -DUSE_WEBSOCKET)
+
+if(NOT MSVC)
+   target_compile_definitions(RHTTP PRIVATE -DUSE_X_DOM_SOCKET)
+endif()
 
 if(ssl)
   if(OPENSSL_VERSION)
@@ -70,7 +74,6 @@ if(ssl)
      list(GET lst 0 ssl_major)
      list(GET lst 1 ssl_minor)
    endif()
-
 
   if((${ssl_major} EQUAL "1") AND (${ssl_minor} EQUAL "1"))
     MESSAGE(STATUS "Use SSL API VERSION 1.1 for civetweb")

--- a/net/http/civetweb/civetweb.c
+++ b/net/http/civetweb/civetweb.c
@@ -3293,7 +3293,7 @@ sockaddr_to_string(char *buf, size_t len, const union usa *usa)
 		NI_NUMERICHOST);
 		*/
 		strncpy(buf, UNIX_DOMAIN_SOCKET_SERVER_NAME, len);
-		buf[len] = 0;
+		buf[len-1] = 0;
 	}
 #endif
 }

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -525,9 +525,13 @@ Bool_t TCivetweb::Create(const char *args)
 
       // first extract port number
       sport = "";
-      while ((*args != 0) && (*args != '?') && (*args != '/'))
+
+      bool is_socket = *args == 'x';
+
+      while ((*args != 0) && (*args != '?') && (is_socket || (*args != '/')))
          sport.Append(*args++);
-      if (IsSecured() && (sport.Index("s")==kNPOS)) sport.Append("s");
+      if (IsSecured() && (sport.Index("s") == kNPOS) && !is_socket)
+         sport.Append("s");
 
       // than search for extra parameters
       while ((*args != 0) && (*args != '?'))

--- a/net/http/src/TCivetweb.cxx
+++ b/net/http/src/TCivetweb.cxx
@@ -21,6 +21,7 @@
 #include "THttpServer.h"
 #include "THttpWSEngine.h"
 #include "TUrl.h"
+#include "TSystem.h"
 
 //////////////////////////////////////////////////////////////////////////
 /// TCivetwebWSEngine
@@ -480,7 +481,8 @@ Int_t TCivetweb::ProcessLog(const char *message)
 /// @param args string with civetweb server configuration
 ///
 /// As main argument, http port should be specified like "8090".
-/// Or one can provide combination of ipaddress and portnumber like 127.0.0.1:8090
+/// Or one can provide combination of ipaddress and portnumber like "127.0.0.1:8090"
+/// Or one can specify unix socket name like "x/tmp/root.socket"
 /// Extra parameters like in URL string could be specified after '?' mark:
 ///
 ///     thrds=N               - there N is number of threads used by the civetweb (default is 10)
@@ -495,6 +497,7 @@ Int_t TCivetweb::ProcessLog(const char *message)
 ///     debug                 - enable debug mode, server always returns html page with request info
 ///     log=filename          - configure civetweb log file
 ///     max_age=value         - configures "Cache-Control: max_age=value" http header for all file-related requests, default 3600
+///     socket_mode=value     - configures unix socket mode, default is 0700
 ///     nocache               - try to fully disable cache control for file requests
 ///     winsymlinks=no        - do not resolve symbolic links on file system (Windows only), default true
 ///     dirlisting=no         - enable/disable directory listing for browsing filesystem (default no)
@@ -518,7 +521,8 @@ Bool_t TCivetweb::Create(const char *args)
            log_file,
            ssl_cert,
            max_age;
-   Bool_t use_ws = kTRUE;
+   Int_t socket_mode = 0700;
+   bool use_ws = kTRUE, is_socket = false;
 
    // extract arguments
    if (args && *args) {
@@ -526,7 +530,7 @@ Bool_t TCivetweb::Create(const char *args)
       // first extract port number
       sport = "";
 
-      bool is_socket = *args == 'x';
+      is_socket = *args == 'x';
 
       while ((*args != 0) && (*args != '?') && (is_socket || (*args != '/')))
          sport.Append(*args++);
@@ -586,6 +590,10 @@ Bool_t TCivetweb::Create(const char *args)
             const char *dls = url.GetValueFromOptions("dirlisting");
             if (dls && (!strcmp(dls,"no") || !strcmp(dls,"yes")))
                dir_listening = dls;
+
+            const char *smode = url.GetValueFromOptions("socket_mode");
+            if (smode)
+               socket_mode = std::stoi(smode, nullptr, *smode=='0' ? 8 : 10);
 
             if (url.HasOption("loopback") && (sport.Index(":") == kNPOS))
                sport = TString("127.0.0.1:") + sport;
@@ -659,6 +667,10 @@ Bool_t TCivetweb::Create(const char *args)
 
    options[op++] = nullptr;
 
+   // try to remove socket file - if any
+   if (is_socket && !sport.Contains(","))
+      gSystem->Unlink(sport.Data()+1);
+
    // Start the web server.
    fCtx = mg_start(&fCallbacks, this, options);
 
@@ -670,6 +682,10 @@ Bool_t TCivetweb::Create(const char *args)
    if (use_ws)
       mg_set_websocket_handler(fCtx, "**root.websocket$", websocket_connect_handler,
                                websocket_ready_handler, websocket_data_handler, websocket_close_handler, nullptr);
+
+   // try to remove socket file - if any
+   if (is_socket && !sport.Contains(","))
+      gSystem->Chmod(sport.Data()+1, socket_mode);
 
    return kTRUE;
 }

--- a/net/http/src/THttpServer.cxx
+++ b/net/http/src/THttpServer.cxx
@@ -383,14 +383,22 @@ Bool_t THttpServer::CreateEngine(const char *engine)
    if (!arg)
       return kFALSE;
 
-   TString clname;
+   TString clname, sarg;
    if (arg != engine)
       clname.Append(engine, arg - engine);
+   arg++; // skip first :
 
    THttpEngine *eng = nullptr;
 
    if ((clname.Length() == 0) || (clname == "http") || (clname == "civetweb")) {
       eng = new TCivetweb(kFALSE);
+#ifndef R__WIN32
+   } else if (clname == "socket") {
+      eng = new TCivetweb(kFALSE);
+      sarg = "x"; // civetweb require x before socket name
+      sarg.Append(arg);
+      arg = sarg.Data();
+#endif
    } else if (clname == "https") {
       eng = new TCivetweb(kTRUE);
    } else if (clname == "fastcgi") {
@@ -410,7 +418,7 @@ Bool_t THttpServer::CreateEngine(const char *engine)
 
    eng->SetServer(this);
 
-   if (!eng->Create(arg + 1)) {
+   if (!eng->Create(arg)) {
       delete eng;
       return kFALSE;
    }


### PR DESCRIPTION
1. Support unix sockets in `THttpServer`, fix civetweb warning
2. Let configure unix socket for webgui widgets
3. Introduce `rootssh.sh` script which use such ferature

In `rootssh.sh` special tunnel is created which forward requests from local http port to remote unix socket.
In remote session root will automatically use socket which specified as `ROOT_WEBGUI_SOCKET` environment variable.
This socket file by default get `0700` mode - means only user can accuse it. 

This solves most of security issues with using of ROOT webgui on public nodes!

`rootssh.sh`  also creates listener which get informed when new window is started on remote session
and automatically popup web browser using `xdg-open $url` command

Typical session should look like:
```
[localhost] rootssh.sh user@remotehost
[remotehost] root --web=server -e "new Browser"
```



