### PR TITLE
[RF] Keep track of the original number of events per bin in `RooHist` for `RooHist::getFitRangeNEvt()`

### DIFF
--- a/roofit/roofitcore/inc/RooHist.h
+++ b/roofit/roofitcore/inc/RooHist.h
@@ -28,7 +28,7 @@ class TH1;
 
 class RooHist : public TGraphAsymmErrors, public RooPlotable {
 public:
-  RooHist() ;
+  RooHist() {}
   RooHist(double nominalBinWidth, double nSigma= 1, double xErrorFrac=1.0, double scaleFactor=1.0);
   RooHist(const TH1 &data, double nominalBinWidth= 0, double nSigma= 1, RooAbsData::ErrorType=RooAbsData::Poisson,
      double xErrorFrac=1.0, bool correctForBinWidth=true, double scaleFactor=1.);
@@ -94,10 +94,10 @@ private:
 
   void addPoint(Axis_t binCenter, double y, double yscale, double exlow, double exhigh, double eylow, double eyhigh);
 
-  double _nominalBinWidth ; ///< Average bin width
-  double _nSigma ;          ///< Number of 'sigmas' error bars represent
-  double _entries ;         ///< Number of entries in histogram
-  double _rawEntries;       ///< Number of entries in source dataset
+  double _nominalBinWidth = 1.0; ///< Average bin width
+  double _nSigma = 1.0;          ///< Number of 'sigmas' error bars represent
+  double _entries = 0.0;         ///< Number of entries in histogram
+  double _rawEntries = 0.0;      ///< Number of entries in source dataset
 
   std::vector<double> _originalWeights; ///< The original bin weights that were passed to the `RooHist::addBin` functions before scaling and bin width correction
 

--- a/roofit/roofitcore/inc/RooHist.h
+++ b/roofit/roofitcore/inc/RooHist.h
@@ -91,12 +91,17 @@ protected:
   std::unique_ptr<RooHist> createEmptyResidHist(const RooCurve& curve, bool normalize=false) const;
 
 private:
+
+  void addPoint(Axis_t binCenter, double y, double yscale, double exlow, double exhigh, double eylow, double eyhigh);
+
   double _nominalBinWidth ; ///< Average bin width
   double _nSigma ;          ///< Number of 'sigmas' error bars represent
   double _entries ;         ///< Number of entries in histogram
   double _rawEntries;       ///< Number of entries in source dataset
 
-  ClassDefOverride(RooHist,1) // 1-dimensional histogram with error bars
+  std::vector<double> _originalWeights; ///< The original bin weights that were passed to the `RooHist::addBin` functions before scaling and bin width correction
+
+  ClassDefOverride(RooHist,2) // 1-dimensional histogram with error bars
 };
 
 #endif

--- a/roofit/roofitcore/test/CMakeLists.txt
+++ b/roofit/roofitcore/test/CMakeLists.txt
@@ -58,6 +58,7 @@ ROOT_ADD_GTEST(testInterface TestStatistics/testInterface.cpp LIBRARIES RooFitCo
 ROOT_ADD_GTEST(testGlobalObservables testGlobalObservables.cxx LIBRARIES RooFitCore)
 ROOT_ADD_GTEST(testRooPolyFunc testRooPolyFunc.cxx LIBRARIES Gpad RooFitCore)
 ROOT_ADD_GTEST(testSumW2Error testSumW2Error.cxx LIBRARIES Gpad RooFitCore)
+ROOT_ADD_GTEST(testRooHist testRooHist.cxx LIBRARIES RooFitCore)
 if (roofit_multiprocess)
   ROOT_ADD_GTEST(testTestStatisticsPlot TestStatistics/testPlot.cpp LIBRARIES RooFitMultiProcess RooFitCore RooFit
                    COPY_TO_BUILDDIR ${CMAKE_CURRENT_SOURCE_DIR}/TestStatistics/TestStatistics_ref.root)

--- a/roofit/roofitcore/test/testRooHist.cxx
+++ b/roofit/roofitcore/test/testRooHist.cxx
@@ -1,0 +1,50 @@
+// Tests for the RooHist
+// Authors: Jonas Rembser, CERN 12/2022
+
+#include <RooDataHist.h>
+#include <RooHist.h>
+#include <RooHistPdf.h>
+#include <RooPlot.h>
+#include <RooRealVar.h>
+
+#include <TH1D.h>
+
+#include <gtest/gtest.h>
+
+/// Check that the values returned by `RooHist::getFitRangeNEvt(double xmin,
+/// double xmax)` are correct also for non-uniform binning. Covers ROOT-9649.
+TEST(RooHist, GetFitRangeNEvtWithSubrange)
+{
+   using namespace RooFit;
+
+   std::vector<double> binEdges{130, 140.761, 152.413, 165.03, 178.691, 193.483, 209.5, 226.842, 245.62, 265.952};
+
+   std::size_t nBins = binEdges.size() - 1.0;
+   const double xmin = binEdges.front();
+   const double xmax = binEdges.back();
+
+   std::vector<double> binCenters(nBins);
+
+   for (std::size_t i = 0; i < binCenters.size(); i++) {
+      binCenters[i] = (binEdges[i] + binEdges[i + 1]) / 2.;
+   }
+
+   std::vector<double> weights{1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000};
+
+   TH1D hist{"name", "name", int(nBins), binEdges.data()};
+   hist.FillN(nBins, binCenters.data(), weights.data());
+
+   RooRealVar x("x", "x", xmin, xmax);
+
+   RooDataHist rooDataHist("rooDataHist", "", RooArgSet(x), &hist);
+
+   std::unique_ptr<RooPlot> frame{x.frame()};
+   rooDataHist.plotOn(frame.get());
+
+   RooHist &rooHist = *frame->getHist();
+
+   const double nEvents = rooDataHist.sumEntries();
+
+   EXPECT_FLOAT_EQ(rooHist.getFitRangeNEvt(), nEvents);
+   EXPECT_FLOAT_EQ(rooHist.getFitRangeNEvt(x.getMin(), x.getMax()), nEvents);
+}


### PR DESCRIPTION
In the non-uniform binning case, the `RooHist` that you get from
plotting a RooDataHist doesn't contain the number of events, but the
number of events normalized by the bin width.

This means that `RooHist::getFitRangeNEvt()` was returning wrong
results. To fix this, a new data member is added to the `RooHist`, which
tracks the original number of events in each bin before the scaling.

A unit test that covers this is also implemented.

Closes JIRA ticket ROOT-9649:
https://sft.its.cern.ch/jira/browse/ROOT-9649

A second commit in this PR also does some code modernization of the `RooHist`.