### PR TITLE
[PyROOT] Show std::vector contents at the prompt instead of default repr

### DIFF
--- a/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_stl_vector.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/_pythonization/_stl_vector.py
@@ -38,3 +38,6 @@ def pythonize_stl_vector(klass, name):
     if value_type == 'char':
         klass._original_data = klass.data
         klass.data = _data_vec_char
+
+    # Pretty printing at the Python prompt
+    klass.__repr__ = lambda self: "{}{}".format(self.__class__.__name__, self)


### PR DESCRIPTION
From this 
```python
>>> df = ROOT.RDataFrame("Events", "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
>>> df.GetColumnNames()
<cppyy.gbl.std.vector<string> object at 0x55c82c6e17a0>
```
To this
```python
>>> df = ROOT.RDataFrame("Events", "root://eospublic.cern.ch//eos/opendata/cms/derived-data/AOD2NanoAODOutreachTool/Run2012BC_DoubleMuParked_Muons.root")
>>> df.GetColumnNames()
{ "Muon_charge", "Muon_eta", "Muon_mass", "Muon_phi", "Muon_pt", "nMuon" }
```