### PR TITLE
[ntuple] Importer for TTrees 

### DIFF
--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -53,9 +53,17 @@ public:
 
 private:
    struct RImportFeature {
+      RImportFeature() = default;
+      RImportFeature(const RImportFeature &other) = delete;
+      RImportFeature(RImportFeature &&other) = default;
+      RImportFeature &operator=(const RImportFeature &other) = delete;
+      RImportFeature &operator=(RImportFeature &&other) = default;
+      std::string fBranchName;
       std::string fLeafName;
       std::string fFieldName;
       std::string fTypeName;
+      std::unique_ptr<unsigned char[]> fTreeBuffer;
+      void *fFieldDataPtr = nullptr;
    };
 
    RNTupleImporter() = default;
@@ -72,6 +80,7 @@ private:
    bool fIsQuiet = false;
    std::unique_ptr<RProgressCallback> fProgressCallback;
    std::vector<RImportFeature> fImportFeatures;
+   std::vector<std::size_t> fFeatureCStringIndexes;
    std::unique_ptr<RNTupleModel> fModel;
 
    RResult<void> PrepareSchema();

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -50,6 +50,7 @@ class RNTupleImporter {
 public:
    class RProgressCallback {
    public:
+      virtual ~RProgressCallback() = default;
       void operator()(std::uint64_t nbytesWritten, std::uint64_t neventsWritten)
       {
          Call(nbytesWritten, neventsWritten);

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -83,10 +83,9 @@ Most RNTuple fields have a type identical to the corresponding TTree input branc
 Current limitations of the importer:
   - Adding projected fields where necessary is pending the implementation of the core functionality in RNTuple
   - Importing collection proxies is untested
-  - No support for importing split objects and nested split collections
   - No support for trees containing TObject (or derived classes) or TClonesArray collections
   - Due to RNTuple currently storing data fully split, "don't split" markers are ignored
-  - Some types are not (yet) available in RNTuple, such as Double32_t or std::map
+  - Some types are not (yet) available in RNTuple, such as pointers, Double32_t or std::map
 */
 // clang-format on
 class RNTupleImporter {

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -55,7 +55,7 @@ importer->Import().ThrowOnError();
 ~~~
 
 The output file is created if it does not exist, otherwise the ntuple is added to the existing file.
-Note that input file and output file can be identical if the nutple is stored under a different name than the tree
+Note that input file and output file can be identical if the ntuple is stored under a different name than the tree
 (use `SetNTupleName()`).
 
 By default, the RNTuple is compressed with zstd, independent of the input compression. The compression settings

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -84,6 +84,7 @@ Current limitations of the importer:
   - Adding projected fields where necessary is pending the implementation of the core functionality in RNTuple
   - Importing collection proxies is untested
   - No support for importing split objects and nested split collections
+  - No support for trees containing TObject (or derived classes) or TClonesArray collections
   - Due to RNTuple currently storing data fully split, "don't split" markers are ignored
   - Some types are not (yet) available in RNTuple, such as Double32_t or std::map
 */

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -82,7 +82,7 @@ private:
       RImportField(const RImportField &other) = delete;
       RImportField(RImportField &&other)
          : fField(other.fField), fFieldBuffer(other.fFieldBuffer), fOwnsFieldBuffer(other.fOwnsFieldBuffer),
-           fIsInUntypedCollection(other.fIsInUntypedCollection)
+           fIsInUntypedCollection(other.fIsInUntypedCollection), fIsClass(other.fIsClass)
       {
          other.fOwnsFieldBuffer = false;
       }
@@ -93,6 +93,7 @@ private:
          fFieldBuffer = other.fFieldBuffer;
          fOwnsFieldBuffer = other.fOwnsFieldBuffer;
          fIsInUntypedCollection = other.fIsInUntypedCollection;
+         fIsClass = other.fIsClass;
          other.fOwnsFieldBuffer = false;
          return *this;
       }
@@ -101,6 +102,7 @@ private:
       void *fFieldBuffer = nullptr;
       bool fOwnsFieldBuffer = false;
       bool fIsInUntypedCollection = false;
+      bool fIsClass = false;
    };
 
    struct RImportLeafCountCollection {

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -83,6 +83,8 @@ Most RNTuple fields have a type identical to the corresponding TTree input branc
 Current limitations of the importer:
   - Adding projected fields where necessary is pending the implementation of the core functionality in RNTuple
   - Importing collection proxies is untested
+  - No support for importing split objects and nested split collections
+  - Due to RNTuple currently storing data fully split, "don't split" markers are ignored
   - Some types are not (yet) available in RNTuple, such as Double32_t or std::map
 */
 // clang-format on

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -66,7 +66,7 @@ private:
    };
 
    struct RImportField {
-      explicit RImportField(Detail::RFieldBase *f) : fField(f) {}
+      RImportField() = default;
       ~RImportField()
       {
          if (fOwnsFieldBuffer)

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -205,7 +205,7 @@ private:
    std::unique_ptr<TFile> fDestFile;
    RNTupleWriteOptions fWriteOptions;
 
-   /// No standard output, conversly if set to false, schema information and progress is printed
+   /// No standard output, conversely if set to false, schema information and progress is printed
    bool fIsQuiet = false;
    std::unique_ptr<RProgressCallback> fProgressCallback;
 

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -79,6 +79,11 @@ Most RNTuple fields have a type identical to the corresponding TTree input branc
       ROOT::RVec<float> jet_pt (projected from _collection0.jet_pt)
       ROOT::RVec<float> jet_eta (projected from _collection0.jet_eta)
     These projections are meta-data only operations and don't involve duplicating the data.
+
+Current limitations of the importer:
+  - Adding projected fields where necessary is pending the implementation of the core functionality in RNTuple
+  - Importing collection proxies is untested
+  - Some types are not (yet) available in RNTuple, such as Double32_t or std::map
 */
 // clang-format on
 class RNTupleImporter {

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -146,7 +146,7 @@ private:
       /// The field is kept during schema preparation and transferred to the fModel before the writing starts
       Detail::RFieldBase *fField = nullptr;
       void *fFieldBuffer = nullptr; ///< Usually points to the corresponding RImportBranch::fBranchBuffer but not always
-      bool fOwnsFieldBuffer = false;       ///< Whether or now fFieldBuffer needs to be freed on destruction
+      bool fOwnsFieldBuffer = false;       ///< Whether or not `fFieldBuffer` needs to be freed on destruction
       bool fIsInUntypedCollection = false; ///< Sub-fields of untyped collections (leaf count arrays in the input)
       bool fIsClass = false; ///< Field imported from a branch with stramer info (e.g., STL, user-defined class)
    };

--- a/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
+++ b/tree/ntupleutil/v7/inc/ROOT/RNTupleImporter.hxx
@@ -153,7 +153,8 @@ private:
       {
       }
       virtual ~RImportTransformation() = default;
-      virtual RResult<void> Transform(std::int64_t entry, const RImportBranch &branch, RImportField &field) = 0;
+      virtual RResult<void> Transform(const RImportBranch &branch, RImportField &field) = 0;
+      virtual void ResetEntry() = 0; // called at the end of an entry
    };
 
    /// Leaf count arrays require special treatment. They are translated into RNTuple untyped collections.
@@ -181,18 +182,19 @@ private:
    struct RCStringTransformation : public RImportTransformation {
       RCStringTransformation(std::size_t b, std::size_t f) : RImportTransformation(b, f) {}
       virtual ~RCStringTransformation() = default;
-      RResult<void> Transform(std::int64_t entry, const RImportBranch &branch, RImportField &field) final;
+      RResult<void> Transform(const RImportBranch &branch, RImportField &field) final;
+      void ResetEntry() final {}
    };
 
    /// When writing the elements of a leaf count array, moves the data from the input array one-by-one
    /// to the memory locations of the fields of the corresponding untyped collection.
    /// TODO(jblomer): write arrays as a whole to RNTuple
    struct RLeafArrayTransformation : public RImportTransformation {
-      std::int64_t fEntry = -1;
       std::int64_t fNum = 0;
       RLeafArrayTransformation(std::size_t b, std::size_t f) : RImportTransformation(b, f) {}
       virtual ~RLeafArrayTransformation() = default;
-      RResult<void> Transform(std::int64_t entry, const RImportBranch &branch, RImportField &field) final;
+      RResult<void> Transform(const RImportBranch &branch, RImportField &field) final;
+      void ResetEntry() final { fNum = 0; }
    };
 
    RNTupleImporter() = default;

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -186,22 +186,17 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
 
          RImportField f;
          f.fIsClass = isClass;
-         std::unique_ptr<Detail::RFieldBase> field;
+         auto fieldOrError = Detail::RFieldBase::Create(fieldName, fieldType);
+         if (!fieldOrError)
+            return R__FORWARD_ERROR(fieldOrError);
+         auto field = fieldOrError.Unwrap();
          if (isCString) {
             branchBufferSize = l->GetMaximum();
-            auto result = Detail::RFieldBase::Create(fieldName, fieldType);
-            if (!result)
-               return R__FORWARD_ERROR(result);
-            field = result.Unwrap();
             f.fFieldBuffer = field->GenerateValue().GetRawPtr();
             f.fOwnsFieldBuffer = true;
             fImportTransformations.emplace_back(
                std::make_unique<RCStringTransformation>(fImportBranches.size(), fImportFields.size()));
          } else {
-            auto result = Detail::RFieldBase::Create(fieldName, fieldType);
-            if (!result)
-               return R__FORWARD_ERROR(result);
-            field = result.Unwrap();
             if (isClass) {
                // For classes, the branch buffer contains a pointer to object, which gets instantiated by TTree upon
                // calling SetBranchAddress()

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -41,6 +41,7 @@ private:
    std::uint64_t fNbytesLast = 0;
 
 public:
+   virtual ~RDefaultProgressCallback() {}
    void Call(std::uint64_t nbytesWritten, std::uint64_t neventsWritten) final
    {
       if (nbytesWritten < (fNbytesLast + 50 * 1000 * 1000))

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -71,8 +71,8 @@ ROOT::Experimental::RNTupleImporter::RCStringTransformation::Transform(const RIm
 }
 
 ROOT::Experimental::RResult<void>
-ROOT::Experimental::RNTupleImporter::RLeafArrayTransformation::Transform(
-   const RImportBranch &branch, RImportField &field)
+ROOT::Experimental::RNTupleImporter::RLeafArrayTransformation::Transform(const RImportBranch &branch,
+                                                                         RImportField &field)
 {
    auto valueSize = field.fField->GetValueSize();
    memcpy(field.fFieldBuffer, branch.fBranchBuffer.get() + (fNum * valueSize), valueSize);

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -41,17 +41,18 @@ namespace {
 
 class RDefaultProgressCallback : public ROOT::Experimental::RNTupleImporter::RProgressCallback {
 private:
-   std::uint64_t fNbytesLast = 0;
+   static constexpr std::uint64_t gUpdateFrequencyBytes = 50 * 1000 * 1000; // report every 50MB
+   std::uint64_t fNbytesNext = gUpdateFrequencyBytes;
 
 public:
    virtual ~RDefaultProgressCallback() {}
    void Call(std::uint64_t nbytesWritten, std::uint64_t neventsWritten) final
    {
       // Report if more than 50MB (compressed) where written since the last status update
-      if (nbytesWritten < (fNbytesLast + 50 * 1000 * 1000))
+      if (nbytesWritten < fNbytesNext)
          return;
       std::cout << "Wrote " << nbytesWritten / 1000 / 1000 << "MB, " << neventsWritten << " entries" << std::endl;
-      fNbytesLast = nbytesWritten;
+      fNbytesNext += gUpdateFrequencyBytes;
    }
 
    void Finish(std::uint64_t nbytesWritten, std::uint64_t neventsWritten) final

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -241,7 +241,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
       if (isClass) {
          auto klass = TClass::GetClass(firstLeaf->GetTypeName());
          if (!klass)
-            return R__FAIL("unable to load class" + std::string(firstLeaf->GetTypeName()));
+            return R__FAIL("unable to load class " + std::string(firstLeaf->GetTypeName()));
          auto ptrBuf = reinterpret_cast<void **>(ib.fBranchBuffer.get());
          fSourceTree->SetBranchAddress(b->GetName(), ptrBuf, klass, EDataType::kOther_t, true /* isptr*/);
       } else {

--- a/tree/ntupleutil/v7/src/RNTupleImporter.cxx
+++ b/tree/ntupleutil/v7/src/RNTupleImporter.cxx
@@ -130,7 +130,7 @@ ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::PrepareSc
 ROOT::Experimental::RResult<void> ROOT::Experimental::RNTupleImporter::Import()
 {
    if (fDestFile->FindKey(fNTupleName.c_str()) != nullptr)
-      return R__FAIL("Key " + fNTupleName + " already exists in file " + fDestFileName);
+      return R__FAIL("Key '" + fNTupleName + "' already exists in file " + fDestFileName);
 
    PrepareSchema();
 

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -6,4 +6,4 @@
 
 # @author Jakob Blomer CERN
 
-ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil)
+ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTDataFrame ROOTNTupleUtil)

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -19,4 +19,4 @@ if(MSVC)
                                      ${CMAKE_CURRENT_BINARY_DIR}/libCustomStructUtil.dll)
 endif()
 
-ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil)
+ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil CustomStructUtil)

--- a/tree/ntupleutil/v7/test/CMakeLists.txt
+++ b/tree/ntupleutil/v7/test/CMakeLists.txt
@@ -6,4 +6,17 @@
 
 # @author Jakob Blomer CERN
 
-ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTDataFrame ROOTNTupleUtil)
+ROOT_STANDARD_LIBRARY_PACKAGE(CustomStructUtil
+                              NO_INSTALL_HEADERS
+                              HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/CustomStructUtil.hxx
+                              SOURCES CustomStructUtil.cxx
+                              LINKDEF CustomStructUtilLinkDef.h
+                              DEPENDENCIES RIO)
+configure_file(CustomStructUtil.hxx . COPYONLY)
+if(MSVC)
+  add_custom_command(TARGET CustomStructUtil POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libCustomStructUtil.dll
+                                     ${CMAKE_CURRENT_BINARY_DIR}/libCustomStructUtil.dll)
+endif()
+
+ROOT_ADD_GTEST(ntuple_importer ntuple_importer.cxx LIBRARIES ROOTNTupleUtil)

--- a/tree/ntupleutil/v7/test/CustomStructUtil.cxx
+++ b/tree/ntupleutil/v7/test/CustomStructUtil.cxx
@@ -1,0 +1,1 @@
+#include "CustomStructUtil.hxx"

--- a/tree/ntupleutil/v7/test/CustomStructUtil.hxx
+++ b/tree/ntupleutil/v7/test/CustomStructUtil.hxx
@@ -1,0 +1,16 @@
+#ifndef ROOT7_RNTupleUtil_Test_CustomStructUtil
+#define ROOT7_RNTupleUtil_Test_CustomStructUtil
+
+#include <string>
+#include <vector>
+
+/**
+ * Used to test importing of classes with dictionary
+ */
+struct CustomStructUtil {
+   float a = 0.0;
+   std::vector<float> v1;
+   std::string s;
+};
+
+#endif

--- a/tree/ntupleutil/v7/test/CustomStructUtil.hxx
+++ b/tree/ntupleutil/v7/test/CustomStructUtil.hxx
@@ -4,10 +4,12 @@
 #include <string>
 #include <vector>
 
-/**
- * Used to test importing of classes with dictionary
- */
-struct CustomStructUtil {
+
+struct Base {
+   int base;
+};
+
+struct CustomStructUtil : Base {
    float a = 0.0;
    std::vector<float> v1;
    std::vector<std::vector<float>> nnlo;

--- a/tree/ntupleutil/v7/test/CustomStructUtil.hxx
+++ b/tree/ntupleutil/v7/test/CustomStructUtil.hxx
@@ -5,15 +5,90 @@
 #include <vector>
 
 
-struct Base {
+struct BaseUtil {
    int base;
 };
 
-struct CustomStructUtil : Base {
+struct CustomStructUtil : BaseUtil {
    float a = 0.0;
    std::vector<float> v1;
    std::vector<std::vector<float>> nnlo;
    std::string s;
+};
+
+struct HitUtil : BaseUtil {
+   float x;
+   float y;
+
+   bool operator==(const HitUtil &other) const
+   {
+      return base == other.base && x == other.x && y == other.y;
+   }
+};
+
+struct TrackUtil : BaseUtil {
+   float E;
+   std::vector<HitUtil> hits;
+
+   bool operator==(const TrackUtil &other) const
+   {
+      return base == other.base && E == other.E && hits == other.hits;
+   }
+};
+
+struct ComplexStructUtil : BaseUtil {
+   float pt;
+   std::vector<TrackUtil> tracks;
+
+   void Init1() {
+      tracks.clear();
+      base = 1;
+      pt = 2.0;
+      HitUtil hit;
+      hit.base = 3;
+      hit.x = 4.0;
+      hit.y = 5.0;
+      TrackUtil track;
+      track.base = 6;
+      track.E = 7.0;
+      track.hits.emplace_back(hit);
+      tracks.emplace_back(track);
+   }
+
+   void Init2() {
+      tracks.clear();
+      base = 100;
+      pt = 101.0;
+   }
+
+   void Init3() {
+      tracks.clear();
+      base = 1000;
+      pt = 1001.0;
+      HitUtil hit1;
+      hit1.base = 1002;
+      hit1.x = 1003.0;
+      hit1.y = 1004.0;
+      HitUtil hit2;
+      hit2.base = 1005;
+      hit2.x = 1006.0;
+      hit2.y = 1007.0;
+      TrackUtil track1;
+      track1.base = 1008;
+      track1.E = 1009.0;
+      tracks.emplace_back(track1);
+      TrackUtil track2;
+      track2.base = 1010;
+      track2.E = 1011.0;
+      track2.hits.emplace_back(hit1);
+      track2.hits.emplace_back(hit2);
+      tracks.emplace_back(track2);
+   }
+
+   bool operator==(const ComplexStructUtil &other) const
+   {
+      return base == other.base && pt == other.pt && tracks == other.tracks;
+   }
 };
 
 #endif

--- a/tree/ntupleutil/v7/test/CustomStructUtil.hxx
+++ b/tree/ntupleutil/v7/test/CustomStructUtil.hxx
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-
 struct BaseUtil {
    int base;
 };
@@ -20,27 +19,22 @@ struct HitUtil : BaseUtil {
    float x;
    float y;
 
-   bool operator==(const HitUtil &other) const
-   {
-      return base == other.base && x == other.x && y == other.y;
-   }
+   bool operator==(const HitUtil &other) const { return base == other.base && x == other.x && y == other.y; }
 };
 
 struct TrackUtil : BaseUtil {
    float E;
    std::vector<HitUtil> hits;
 
-   bool operator==(const TrackUtil &other) const
-   {
-      return base == other.base && E == other.E && hits == other.hits;
-   }
+   bool operator==(const TrackUtil &other) const { return base == other.base && E == other.E && hits == other.hits; }
 };
 
 struct ComplexStructUtil : BaseUtil {
    float pt;
    std::vector<TrackUtil> tracks;
 
-   void Init1() {
+   void Init1()
+   {
       tracks.clear();
       base = 1;
       pt = 2.0;
@@ -55,13 +49,15 @@ struct ComplexStructUtil : BaseUtil {
       tracks.emplace_back(track);
    }
 
-   void Init2() {
+   void Init2()
+   {
       tracks.clear();
       base = 100;
       pt = 101.0;
    }
 
-   void Init3() {
+   void Init3()
+   {
       tracks.clear();
       base = 1000;
       pt = 1001.0;

--- a/tree/ntupleutil/v7/test/CustomStructUtil.hxx
+++ b/tree/ntupleutil/v7/test/CustomStructUtil.hxx
@@ -10,6 +10,7 @@
 struct CustomStructUtil {
    float a = 0.0;
    std::vector<float> v1;
+   std::vector<std::vector<float>> nnlo;
    std::string s;
 };
 

--- a/tree/ntupleutil/v7/test/CustomStructUtilLinkDef.h
+++ b/tree/ntupleutil/v7/test/CustomStructUtilLinkDef.h
@@ -4,6 +4,10 @@
 #pragma link off all classes;
 #pragma link off all functions;
 
+#pragma link C++ class BaseUtil + ;
 #pragma link C++ class CustomStructUtil + ;
+#pragma link C++ class HitUtil + ;
+#pragma link C++ class TrackUtil + ;
+#pragma link C++ class ComplexStructUtil + ;
 
 #endif

--- a/tree/ntupleutil/v7/test/CustomStructUtilLinkDef.h
+++ b/tree/ntupleutil/v7/test/CustomStructUtilLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class CustomStructUtil + ;
+
+#endif

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -44,4 +44,61 @@ TEST(RNTupleImporter, Empty)
    importer->Import();
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(0U, reader->GetNEntries());
+   EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
+}
+
+TEST(RNTupleImporter, SimpleBranches)
+{
+   FileRaii fileGuard("test_ntuple_importer_simple_branches.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      bool myBool = true;
+      Char_t myInt8 = -8;
+      UChar_t myUInt8 = 8;
+      Short_t myInt16 = -16;
+      UShort_t myUInt16 = 16;
+      Int_t myInt32 = -32;
+      UInt_t myUInt32 = 32;
+      Long64_t myInt64 = -64;
+      ULong64_t myUInt64 = 64;
+      Float_t myFloat = 32.0;
+      Double_t myDouble = 64.0;
+      // TODO(jblomer): Float16_t, Double32_t
+      // const char *myString = "ROOT RNTuple";
+      tree->Branch("myBool", &myBool);
+      tree->Branch("myInt8", &myInt8);
+      tree->Branch("myUInt8", &myUInt8);
+      tree->Branch("myInt16", &myInt16);
+      tree->Branch("myUInt16", &myUInt16);
+      tree->Branch("myInt32", &myInt32);
+      tree->Branch("myUInt32", &myUInt32);
+      tree->Branch("myInt64", &myInt64);
+      tree->Branch("myUInt64", &myUInt64);
+      tree->Branch("myFloat", &myFloat);
+      tree->Branch("myDouble", &myDouble);
+      // tree->Branch("myString", const_cast<char *>(myString), "myString/C");
+      tree->Fill();
+      tree->Write();
+   }
+
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   importer->SetIsQuiet(true);
+   importer->SetNTupleName("ntuple");
+   importer->Import();
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   reader->LoadEntry(0);
+   EXPECT_TRUE(*reader->GetModel()->Get<bool>("myBool"));
+   EXPECT_EQ(-8, *reader->GetModel()->Get<char>("myInt8"));
+   EXPECT_EQ(8U, *reader->GetModel()->Get<std::uint8_t>("myUInt8"));
+   EXPECT_EQ(-16, *reader->GetModel()->Get<std::int16_t>("myInt16"));
+   EXPECT_EQ(16U, *reader->GetModel()->Get<std::uint16_t>("myUInt16"));
+   EXPECT_EQ(-32, *reader->GetModel()->Get<std::int32_t>("myInt32"));
+   EXPECT_EQ(32U, *reader->GetModel()->Get<std::uint32_t>("myUInt32"));
+   EXPECT_EQ(-64, *reader->GetModel()->Get<std::int64_t>("myInt64"));
+   EXPECT_EQ(64U, *reader->GetModel()->Get<std::uint64_t>("myUInt64"));
+   EXPECT_FLOAT_EQ(32.0, *reader->GetModel()->Get<float>("myFloat"));
+   EXPECT_FLOAT_EQ(64.0, *reader->GetModel()->Get<double>("myDouble"));
+   // EXPECT_STREQ("RNTuple", reader->GetModel()->Get<std::string>("myString")->c_str());
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -345,12 +345,12 @@ TEST(RNTupleImporter, CustomClass)
    {
       std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
       auto tree = std::make_unique<TTree>("tree", "");
-      CustomStructUtil *klass = nullptr;
-      tree->Branch("klass", &klass);
-      klass->a = 1.0;
-      klass->v1.emplace_back(2.0);
-      klass->v1.emplace_back(3.0);
-      klass->s = "ROOT";
+      CustomStructUtil *object = nullptr;
+      tree->Branch("object", &object);
+      object->a = 1.0;
+      object->v1.emplace_back(2.0);
+      object->v1.emplace_back(3.0);
+      object->s = "ROOT";
       tree->Fill();
       tree->Write();
    }
@@ -363,10 +363,10 @@ TEST(RNTupleImporter, CustomClass)
    auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
    EXPECT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
-   auto klass = reader->GetModel()->Get<CustomStructUtil>("klass");
-   EXPECT_FLOAT_EQ(1.0, klass->a);
-   EXPECT_EQ(2U, klass->v1.size());
-   EXPECT_FLOAT_EQ(2.0, klass->v1[0]);
-   EXPECT_FLOAT_EQ(3.0, klass->v1[1]);
-   EXPECT_EQ(std::string("ROOT"), klass->s);
+   auto object = reader->GetModel()->Get<CustomStructUtil>("object");
+   EXPECT_FLOAT_EQ(1.0, object->a);
+   EXPECT_EQ(2U, object->v1.size());
+   EXPECT_FLOAT_EQ(2.0, object->v1[0]);
+   EXPECT_FLOAT_EQ(3.0, object->v1[1]);
+   EXPECT_EQ(std::string("ROOT"), object->s);
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -300,20 +300,26 @@ TEST(RNTupleImporter, LeafCountArray)
    auto viewJetEta = viewJets.GetView<float>("jet_eta");
    auto viewMuons = reader->GetViewCollection("_collection1");
    auto viewMuonPt = viewMuons.GetView<float>("muon_pt");
+
+   // Entry 0: 1 jet, 1 muon
    EXPECT_EQ(1, viewJets(0));
    EXPECT_FLOAT_EQ(1.0, viewJetPt(0));
    EXPECT_FLOAT_EQ(2.0, viewJetEta(0));
+   EXPECT_EQ(1, viewMuons(0));
+   EXPECT_FLOAT_EQ(10.0, viewMuonPt(0));
+
+   // Entry 1: 0 jets, 1 muon
    EXPECT_EQ(0, viewJets(1));
+   EXPECT_EQ(1, viewMuons(1));
+   EXPECT_FLOAT_EQ(11.0, viewMuonPt(1));
+
+   // Entry 2: 2 jets, 1 muon
    EXPECT_EQ(2, viewJets(2));
    EXPECT_FLOAT_EQ(3.0, viewJetPt(1));
    EXPECT_FLOAT_EQ(4.0, viewJetEta(1));
    EXPECT_FLOAT_EQ(5.0, viewJetPt(2));
    EXPECT_FLOAT_EQ(6.0, viewJetEta(2));
-   EXPECT_EQ(1, viewMuons(0));
-   EXPECT_EQ(1, viewMuons(1));
    EXPECT_EQ(1, viewMuons(2));
-   EXPECT_FLOAT_EQ(10.0, viewMuonPt(0));
-   EXPECT_FLOAT_EQ(11.0, viewMuonPt(1));
    EXPECT_FLOAT_EQ(12.0, viewMuonPt(2));
 }
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -146,4 +146,17 @@ TEST(RNTupleImporter, Leaflist)
       tree->Fill();
       tree->Write();
    }
+
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   importer->SetIsQuiet(true);
+   importer->SetNTupleName("ntuple");
+   importer->Import();
+
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   EXPECT_EQ(1U, reader->GetNEntries());
+   // Field "branch" is an anonymous record, we cannot go through the default model here
+   auto viewA = reader->GetView<std::int32_t>("branch.a");
+   auto viewB = reader->GetView<std::int32_t>("branch.b");
+   EXPECT_EQ(1, viewA(0));
+   EXPECT_EQ(2, viewB(0));
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -173,6 +173,12 @@ TEST(RNTupleImporter, FixedSizeArray)
       tree->Branch("a", a, "a[1]/I");
       tree->Branch("b", b, "b[2]/I");
       tree->Branch("c", c, "c[4]/C");
+      struct {
+         Int_t a = 1;
+         Int_t b[2] = {2, 3};
+         Int_t c = 4;
+      } leafList;
+      tree->Branch("branch", &leafList, "a/I:b[2]/I:c/I");
       tree->Fill();
       tree->Write();
    }
@@ -196,4 +202,12 @@ TEST(RNTupleImporter, FixedSizeArray)
    EXPECT_EQ('O', viewC(0)[1]);
    EXPECT_EQ('O', viewC(0)[2]);
    EXPECT_EQ('T', viewC(0)[3]);
+   auto viewBranchA = reader->GetView<std::int32_t>("branch.a");
+   auto viewBranchB = reader->GetView<std::array<std::int32_t, 2>>("branch.b");
+   auto viewBranchC = reader->GetView<std::int32_t>("branch.c");
+   EXPECT_EQ(1, viewBranchA(0));
+   EXPECT_EQ(2U, viewBranchB(0).size());
+   EXPECT_EQ(2, viewBranchB(0)[0]);
+   EXPECT_EQ(3, viewBranchB(0)[1]);
+   EXPECT_EQ(4, viewBranchC(0));
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -131,3 +131,19 @@ TEST(RNTupleImporter, CString)
    reader->LoadEntry(2);
    EXPECT_EQ(std::string("ROOT RNTuple"), *reader->GetModel()->Get<std::string>("myString"));
 }
+
+TEST(RNTupleImporter, Leaflist)
+{
+   FileRaii fileGuard("test_ntuple_importer_leaflist.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      struct {
+         Int_t a = 1;
+         Int_t b = 2;
+      } leafList;
+      tree->Branch("branch", &leafList, "a/I:b/I");
+      tree->Fill();
+      tree->Write();
+   }
+}

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -243,29 +243,36 @@ TEST(RNTupleImporter, LeafCountArray)
    {
       std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
       auto tree = std::make_unique<TTree>("tree", "");
+      Int_t nmuons = 1;
       Int_t begin = 1;
       Int_t njets;
       float jet_pt[2];
       Int_t middle = 2;
       float jet_eta[2];
       Int_t end = 3;
+      float muon_pt[1];
+      tree->Branch("nmuons", &nmuons);
       tree->Branch("begin", &begin);
       tree->Branch("njets", &njets);
       tree->Branch("jet_pt", jet_pt, "jet_pt[njets]");
       tree->Branch("middle", &middle);
       tree->Branch("jet_eta", jet_eta, "jet_eta[njets]");
       tree->Branch("end", &end);
+      tree->Branch("muon_pt", muon_pt, "muon_pt[nmuons]");
       njets = 1;
       jet_pt[0] = 1.0;
       jet_eta[0] = 2.0;
+      muon_pt[0] = 10.0;
       tree->Fill();
       njets = 0;
+      muon_pt[0] = 11.0;
       tree->Fill();
       njets = 2;
       jet_pt[0] = 3.0;
       jet_eta[0] = 4.0;
       jet_pt[1] = 5.0;
       jet_eta[1] = 6.0;
+      muon_pt[0] = 12.0;
       tree->Fill();
       tree->Write();
    }
@@ -286,6 +293,8 @@ TEST(RNTupleImporter, LeafCountArray)
    auto viewJets = reader->GetViewCollection("_collection0");
    auto viewJetPt = viewJets.GetView<float>("jet_pt");
    auto viewJetEta = viewJets.GetView<float>("jet_eta");
+   auto viewMuons = reader->GetViewCollection("_collection1");
+   auto viewMuonPt = viewMuons.GetView<float>("muon_pt");
    EXPECT_EQ(1, viewJets(0));
    EXPECT_FLOAT_EQ(1.0, viewJetPt(0));
    EXPECT_FLOAT_EQ(2.0, viewJetEta(0));
@@ -295,6 +304,12 @@ TEST(RNTupleImporter, LeafCountArray)
    EXPECT_FLOAT_EQ(4.0, viewJetEta(1));
    EXPECT_FLOAT_EQ(5.0, viewJetPt(2));
    EXPECT_FLOAT_EQ(6.0, viewJetEta(2));
+   EXPECT_EQ(1, viewMuons(0));
+   EXPECT_EQ(1, viewMuons(1));
+   EXPECT_EQ(1, viewMuons(2));
+   EXPECT_FLOAT_EQ(10.0, viewMuonPt(0));
+   EXPECT_FLOAT_EQ(11.0, viewMuonPt(1));
+   EXPECT_FLOAT_EQ(12.0, viewMuonPt(2));
 }
 
 TEST(RNTupleImporter, STL)

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -1,10 +1,47 @@
 #include "gtest/gtest.h"
 
+#include <ROOT/RNTuple.hxx>
 #include <ROOT/RNTupleImporter.hxx>
 
-TEST(RNTupleImporter, Basics)
+#include <TFile.h>
+#include <TTree.h>
+
+#include <cstdio>
+#include <string>
+
+using ROOT::Experimental::RNTupleImporter;
+using ROOT::Experimental::RNTupleReader;
+
+/**
+ * An RAII wrapper around an open temporary file on disk. It cleans up the guarded file when the wrapper object
+ * goes out of scope.
+ */
+class FileRaii {
+private:
+   std::string fPath;
+
+public:
+   explicit FileRaii(const std::string &path) : fPath(path) {}
+   FileRaii(const FileRaii &) = delete;
+   FileRaii &operator=(const FileRaii &) = delete;
+   ~FileRaii() { std::remove(fPath.c_str()); }
+   std::string GetPath() const { return fPath; }
+};
+
+TEST(RNTupleImporter, Empty)
 {
-   auto importer =
-      ROOT::Experimental::RNTupleImporter::Create("/data/B2HHH~zstd.root", "DecayTree", "test.root").Unwrap();
+   FileRaii fileGuard("test_ntuple_importer_empty.root");
+   {
+      std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
+      auto tree = std::make_unique<TTree>("tree", "");
+      tree->Write();
+   }
+
+   auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();
+   importer->SetIsQuiet(true);
+   EXPECT_THROW(importer->Import(), ROOT::Experimental::RException);
+   importer->SetNTupleName("ntuple");
    importer->Import();
+   auto reader = RNTupleReader::Open("ntuple", fileGuard.GetPath());
+   EXPECT_EQ(0U, reader->GetNEntries());
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -4,5 +4,7 @@
 
 TEST(RNTupleImporter, Basics)
 {
-   auto importer = ROOT::Experimental::RNTupleImporter::Create("", "", "");
+   auto importer =
+      ROOT::Experimental::RNTupleImporter::Create("/data/B2HHH~zstd.root", "DecayTree", "test.root").Unwrap();
+   importer->Import();
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -375,6 +375,9 @@ TEST(RNTupleImporter, CustomClass)
       object->a = 1.0;
       object->v1.emplace_back(2.0);
       object->v1.emplace_back(3.0);
+      object->nnlo.push_back(std::vector<float>{42.0, 43.0});
+      object->nnlo.push_back(std::vector<float>());
+      object->nnlo.push_back(std::vector<float>{137.0});
       object->s = "ROOT";
       tree->Fill();
       tree->Write();
@@ -394,4 +397,11 @@ TEST(RNTupleImporter, CustomClass)
    EXPECT_FLOAT_EQ(2.0, object->v1[0]);
    EXPECT_FLOAT_EQ(3.0, object->v1[1]);
    EXPECT_EQ(std::string("ROOT"), object->s);
+   EXPECT_EQ(3U, object->nnlo.size());
+   EXPECT_EQ(2U, object->nnlo[0].size());
+   EXPECT_FLOAT_EQ(42.0, object->nnlo[0][0]);
+   EXPECT_FLOAT_EQ(43.0, object->nnlo[0][1]);
+   EXPECT_EQ(0U, object->nnlo[1].size());
+   EXPECT_EQ(1U, object->nnlo[2].size());
+   EXPECT_FLOAT_EQ(137.0, object->nnlo[2][0]);
 }

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -372,6 +372,7 @@ TEST(RNTupleImporter, CustomClass)
       auto tree = std::make_unique<TTree>("tree", "");
       CustomStructUtil *object = nullptr;
       tree->Branch("object", &object);
+      object->base = 13;
       object->a = 1.0;
       object->v1.emplace_back(2.0);
       object->v1.emplace_back(3.0);
@@ -392,6 +393,7 @@ TEST(RNTupleImporter, CustomClass)
    EXPECT_EQ(1U, reader->GetNEntries());
    reader->LoadEntry(0);
    auto object = reader->GetModel()->Get<CustomStructUtil>("object");
+   EXPECT_EQ(13, object->base);
    EXPECT_FLOAT_EQ(1.0, object->a);
    EXPECT_EQ(2U, object->v1.size());
    EXPECT_FLOAT_EQ(2.0, object->v1[0]);

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -8,6 +8,9 @@
 
 #include <cstdio>
 #include <string>
+#include <tuple>
+#include <vector>
+#include <utility>
 
 #include "CustomStructUtil.hxx"
 
@@ -330,7 +333,11 @@ TEST(RNTupleImporter, STL)
       std::unique_ptr<TFile> file(TFile::Open(fileGuard.GetPath().c_str(), "RECREATE"));
       auto tree = std::make_unique<TTree>("tree", "");
       auto vec = new std::vector<float>{1.0, 2.0};
+      auto pair = new std::pair<float, float>{3.0, 4.0};
+      auto tuple = new std::tuple<int, float, bool>{5, 6.0, true};
       tree->Branch("vec", &vec);
+      tree->Branch("pair", &pair);
+      tree->Branch("tuple", &tuple);
       tree->Fill();
       tree->Write();
       delete vec;
@@ -348,6 +355,13 @@ TEST(RNTupleImporter, STL)
    EXPECT_EQ(2U, vec->size());
    EXPECT_FLOAT_EQ(1.0, vec->at(0));
    EXPECT_FLOAT_EQ(2.0, vec->at(1));
+   auto pair = reader->GetModel()->Get<std::pair<float, float>>("pair");
+   EXPECT_FLOAT_EQ(3.0, pair->first);
+   EXPECT_FLOAT_EQ(4.0, pair->second);
+   auto tuple = reader->GetModel()->Get<std::tuple<int, float, bool>>("tuple");
+   EXPECT_EQ(5, std::get<0>(*tuple));
+   EXPECT_FLOAT_EQ(6.0, std::get<1>(*tuple));
+   EXPECT_TRUE(std::get<2>(*tuple));
 }
 
 TEST(RNTupleImporter, CustomClass)

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -20,13 +20,18 @@ using ROOT::Experimental::RNTupleReader;
  */
 class FileRaii {
 private:
+   static constexpr bool kDebug = false; // if true, don't delete the file on destruction
    std::string fPath;
 
 public:
    explicit FileRaii(const std::string &path) : fPath(path) {}
    FileRaii(const FileRaii &) = delete;
    FileRaii &operator=(const FileRaii &) = delete;
-   ~FileRaii() { std::remove(fPath.c_str()); }
+   ~FileRaii()
+   {
+      if (!kDebug)
+         std::remove(fPath.c_str());
+   }
    std::string GetPath() const { return fPath; }
 };
 

--- a/tree/ntupleutil/v7/test/ntuple_importer.cxx
+++ b/tree/ntupleutil/v7/test/ntuple_importer.cxx
@@ -341,6 +341,8 @@ TEST(RNTupleImporter, STL)
       tree->Fill();
       tree->Write();
       delete vec;
+      delete pair;
+      delete tuple;
    }
 
    auto importer = RNTupleImporter::Create(fileGuard.GetPath(), "tree", fileGuard.GetPath()).Unwrap();

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -1,0 +1,59 @@
+/// \file
+/// \ingroup tutorial_ntuple
+/// \notebook
+/// Example of converting data stored in a TTree into an RNTuple
+///
+/// \macro_image
+/// \macro_code
+///
+/// \date December 2022
+/// \author The ROOT Team
+
+// NOTE: The RNTuple classes are experimental at this point.
+// Functionality, interface, and data format is still subject to changes.
+// Do not use for real data!
+
+// Until C++ runtime modules are universally used, we explicitly load the ntuple library.  Otherwise
+// triggering autoloading from the use of templated types would require an exhaustive enumeration
+// of "all" template instances in the LinkDef file.
+R__LOAD_LIBRARY(ROOTNTupleUtil)
+
+#include <ROOT/RNTuple.hxx>
+#include <ROOT/RNTupleImporter.hxx>
+
+#include <TFile.h>
+#include <TROOT.h>
+
+// Import classes from experimental namespace for the time being
+using RNTuple = ROOT::Experimental::RNTuple;
+using RNTupleImporter = ROOT::Experimental::RNTupleImporter;
+using RNTupleReader = ROOT::Experimental::RNTupleReader;
+
+// Where to store the ntuple of this example
+constexpr char const *kTreeFileName = "http://root.cern.ch/files/HiggsTauTauReduced/GluGluToHToTauTau.root";
+constexpr char const *kTreeName = "Events";
+constexpr char const *kNTupleFileName = "ntpl008_import.root";
+
+void ntpl008_import()
+{
+    // Use multiple threads to compress RNTuple data
+    ROOT::EnableImplicitMT();
+
+    // RNTupleImporter::Create() returns a wrapper for an RNTupleImporter. If the creation fails,
+    // the result will contain an exception. Calling Unwrap() returns the actual RNTupleImporter
+    // class or throws the exception in case of errors.
+    auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName).Unwrap();
+
+    // Using `ThrowOnError()` makes sure that the macro abort if the import fails.
+    importer->Import().ThrowOnError();
+
+    // Inspect the schema of the written RNTuple
+    auto file = std::unique_ptr<TFile>(TFile::Open(kNTupleFileName));
+    if (!file || file->IsZombie()) {
+        std::cerr << "cannot open " << kNTupleFileName << std::endl;
+        return;
+    }
+    auto ntpl = file->Get<RNTuple>("Events");
+    auto reader = RNTupleReader::Open(ntpl);
+    reader->PrintInfo();
+}

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -29,7 +29,7 @@ using RNTuple = ROOT::Experimental::RNTuple;
 using RNTupleImporter = ROOT::Experimental::RNTupleImporter;
 using RNTupleReader = ROOT::Experimental::RNTupleReader;
 
-// Where to store the ntuple of this example
+// Input and output
 constexpr char const *kTreeFileName = "http://root.cern.ch/files/HiggsTauTauReduced/GluGluToHToTauTau.root";
 constexpr char const *kTreeName = "Events";
 constexpr char const *kNTupleFileName = "ntpl008_import.root";

--- a/tutorials/v7/ntuple/ntpl008_import.C
+++ b/tutorials/v7/ntuple/ntpl008_import.C
@@ -36,24 +36,24 @@ constexpr char const *kNTupleFileName = "ntpl008_import.root";
 
 void ntpl008_import()
 {
-    // Use multiple threads to compress RNTuple data
-    ROOT::EnableImplicitMT();
+   // Use multiple threads to compress RNTuple data
+   ROOT::EnableImplicitMT();
 
-    // RNTupleImporter::Create() returns a wrapper for an RNTupleImporter. If the creation fails,
-    // the result will contain an exception. Calling Unwrap() returns the actual RNTupleImporter
-    // class or throws the exception in case of errors.
-    auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName).Unwrap();
+   // RNTupleImporter::Create() returns a wrapper for an RNTupleImporter. If the creation fails,
+   // the result will contain an exception. Calling Unwrap() returns the actual RNTupleImporter
+   // class or throws the exception in case of errors.
+   auto importer = RNTupleImporter::Create(kTreeFileName, kTreeName, kNTupleFileName).Unwrap();
 
-    // Using `ThrowOnError()` makes sure that the macro abort if the import fails.
-    importer->Import().ThrowOnError();
+   // Using `ThrowOnError()` makes sure that the macro abort if the import fails.
+   importer->Import().ThrowOnError();
 
-    // Inspect the schema of the written RNTuple
-    auto file = std::unique_ptr<TFile>(TFile::Open(kNTupleFileName));
-    if (!file || file->IsZombie()) {
-        std::cerr << "cannot open " << kNTupleFileName << std::endl;
-        return;
-    }
-    auto ntpl = file->Get<RNTuple>("Events");
-    auto reader = RNTupleReader::Open(ntpl);
-    reader->PrintInfo();
+   // Inspect the schema of the written RNTuple
+   auto file = std::unique_ptr<TFile>(TFile::Open(kNTupleFileName));
+   if (!file || file->IsZombie()) {
+      std::cerr << "cannot open " << kNTupleFileName << std::endl;
+      return;
+   }
+   auto ntpl = file->Get<RNTuple>("Events");
+   auto reader = RNTupleReader::Open(ntpl);
+   reader->PrintInfo();
 }


### PR DESCRIPTION
Implements the class `RNTupleImporter` from the ntuple utility package. The class reads a ROOT tree and writes the data out as RNTuple. Most branch types map directly to RNTuple field types, with some exceptions:

- C strings are converted to `std::string`
- C fixed-size arrays are converted to `std::array`
- Leaf lists are converted to untyped records
- Count leaf arrays are converted to untyped collections with generic names (`_collection0`, `_collection1`, etc.). In a follow up PR, RNTuple should receive functionality for "stored projections". That will allow storing virtual fields whose data comes from physical columns. In this way, the data from the untyped collections can be presented with their original TTree names (e.g., `njets`, `jet_pt`, etc.).

At this point, the importer can process all the RNTuple benchmark files (LHCb ntuples, H1, ATLAS OpenData, CMS nanoAOD).

The work is partially based on a [GSoC project](https://hepsoftwarefoundation.org/gsoc/blogs/2022/blog_ROOT_ZifengLuo.html).

Todo for this PR:

- [x] Improve code comments
- [x] Add tutorial

In a follow-up PR, importing for leaf count arrays should be improved with vector writes. Use of bulk I/O in general should speed up the import.