### PR TITLE
[mathcore] Delete obscure conditions in class for adaptive quadrature integration in multi-dimensions (AdaptiveIntegratorMultiDim)

### DIFF
--- a/math/mathcore/src/AdaptiveIntegratorMultiDim.cxx
+++ b/math/mathcore/src/AdaptiveIntegratorMultiDim.cxx
@@ -320,10 +320,6 @@ L160: //to divide or not
    relerr = abserr;
    if (aresult != 0)  relerr = abserr/aresult;
 
-
-   if (relerr < 1e-1 && aresult < 1e-20) fStatus = 0;
-   if (relerr < 1e-3 && aresult < 1e-10) fStatus = 0;
-   if (relerr < 1e-5 && aresult < 1e-5)  fStatus = 0;
    if (isbrgs+irgnst > iwk) fStatus = 2;
    if (ifncls+2*irlcls > maxpts) {
       if (sum1==0 && sum2==0 && sum3==0 && sum4==0 && sum5==0){


### PR DESCRIPTION
# This Pull request:
Make changes in the class AdaptiveIntegratorMultiDim.
## Changes or fixes:
Delete obscure conditions on evaluating integration status. The mentioned conditions are absent in the original RadMul algorithm. The problem with these conditions is in that they compare some arbitrary hard-coded constants with the absolute value of the integrated function. This lead to incorrect integration of some complicated function. Moreover, if one multiply integrand by some arbitrary factor and then divide the integral by it, then time and accuracy integration will change, but it shouldn't be so.    For example, if integrated function return result of order 10^-38, then sometimes integration gives nonsense result with very low number of integrated function calls. The parameter RelAccuracy is not accounted for by the algorithm in this case (return result with some lower accuracy).   But if the return value of integrated function multiply by 10^38 and then multiply the result of integration by 10^-38 then the integration gives the correct result with appropriate number of integrand calls. The parameter RelAccuracy then does work in this case. All this is because of mentioned hard-coded constants.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)
