### PR TITLE
[ntuple] Improve definition of `RNTupleLocator`s

### DIFF
--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -135,8 +135,8 @@ The type can take one of the following values
 
 | Type | Meaning         |
 |------|-----------------|
-| 0x01 | 64bit object ID |
-| 0x02 | URI string      |
+| 0x01 | URI string      |
+| 0x02 | 64bit object ID |
 
 For object ID locators, specifies the 64bit object ID.
 For URI locators, the locator contains the ASCII characters of the URI following the size and the type.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -117,7 +117,7 @@ In this case, the locator should be interpreted like a frame, i.e. size indicate
 _Offset_:
 For on-disk / in-file locators, the 64bit byte offset of the referenced byte range counted from the start of the file.
 
-For non-disk locators, i.e. `T` == 1, the format is more accurately described as
+For non-disk locators, i.e. `T` == 1, the locator format is as follows
 
 ```
  0                   1                   2                   3
@@ -142,7 +142,7 @@ The range 0x03 - 0x7f is currently unused. Additional types can be registered in
 For URI locators, the locator contains the ASCII characters of the URI following the size and the type.
 Each locator type follows a given format for the payload (see Section "Well-known payload formats" below).
 
-_Reserved_ is an 8bit field that can be used by concrete storage backends to store additional information about the locator.
+_Reserved_ is an 8bit field that can be used by the storage backend corresponding to the type in order to store additional information about the locator.
 
 An envelope link consists of a 32bit unsigned integer that specifies the uncompressed size of the envelope
 followed by a locator.

--- a/tree/ntuple/v7/doc/specifications.md
+++ b/tree/ntuple/v7/doc/specifications.md
@@ -133,10 +133,10 @@ In this case, the last 8 bits of the size should be interpreted as a locator typ
 To determine the locator type, the absolute value of the 8bit integer should be taken.
 The type can take one of the following values
 
-| Type | Meaning         |
-|------|-----------------|
-| 0x01 | URI string      |
-| 0x02 | 64bit object ID |
+| Type | Meaning                |
+|------|------------------------|
+| 0x01 | URI string             |
+| 0x02 | DAOS (64bit object ID) |
 
 For object ID locators, specifies the 64bit object ID.
 For URI locators, the locator contains the ASCII characters of the URI following the size and the type.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -143,7 +143,7 @@ struct RNTupleLocator {
       return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage;
    }
    template <typename T>
-   const T &Get() const
+   const T &GetPosition() const
    {
       return std::get<T>(fPosition);
    }

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -117,7 +117,7 @@ struct RNTupleLocator {
    /// Values for the _Type_ field in non-disk locators; see `doc/specifications.md` for details
    enum ELocatorType : std::uint8_t {
       kTypeFile = 0x00,
-      kTypeURI = 0x02,
+      kTypeURI = 0x01,
    };
 
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -140,7 +140,7 @@ struct RNTupleLocator {
    std::uint8_t fReserved = 0;
 
    bool operator==(const RNTupleLocator &other) const {
-      return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage;
+      return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage && fType == other.fType;
    }
    template <typename T>
    const T &GetPosition() const

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -127,6 +127,8 @@ struct RNTupleLocator {
    /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
    /// if the payload structure is identical.
    ELocatorType fType = kTypeFile;
+   /// Reserved for use by concrete storage backends
+   std::uint8_t fReserved = 0;
 
    bool operator==(const RNTupleLocator &other) const {
       return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage;

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -109,6 +109,14 @@ public:
    ClusterSize_t::ValueType GetIndex() const { return fIndex; }
 };
 
+/// RNTupleLocator payload that is common for object stores using 64bit location information.
+/// This might not contain the full location of the content. In particular, for page locators this information may be
+/// used in conjunction with the cluster and column ID.
+struct RNTupleLocatorObject64 {
+   std::uint64_t fLocation = 0;
+   bool operator==(const RNTupleLocatorObject64 &other) const { return fLocation == other.fLocation; }
+};
+
 /// Generic information about the physical location of data. Values depend on the concrete storage type.  E.g.,
 /// for a local file `fPosition` might be a 64bit file offset. Referenced objects on storage can be compressed
 /// and therefore we need to store their actual size.
@@ -118,11 +126,12 @@ struct RNTupleLocator {
    enum ELocatorType : std::uint8_t {
       kTypeFile = 0x00,
       kTypeURI = 0x01,
+      kTypeDAOS = 0x02,
    };
 
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
-   std::variant<std::uint64_t, std::string> fPosition;
+   std::variant<std::uint64_t, std::string, RNTupleLocatorObject64> fPosition;
    std::uint32_t fBytesOnStorage = 0;
    /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
    /// if the payload structure is identical.

--- a/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RNTupleUtil.hxx
@@ -114,15 +114,23 @@ public:
 /// and therefore we need to store their actual size.
 /// TODO(jblomer): consider moving this to `RNTupleDescriptor`
 struct RNTupleLocator {
+   /// Values for the _Type_ field in non-disk locators; see `doc/specifications.md` for details
+   enum ELocatorType : std::uint8_t {
+      kTypeFile = 0x00,
+      kTypeURI = 0x02,
+   };
+
    /// Simple on-disk locators consisting of a 64-bit offset use variant type `uint64_t`; extended locators have
    /// `fPosition.index()` > 0
    std::variant<std::uint64_t, std::string> fPosition;
    std::uint32_t fBytesOnStorage = 0;
+   /// For non-disk locators, the value for the _Type_ field. This makes it possible to have different type values even
+   /// if the payload structure is identical.
+   ELocatorType fType = kTypeFile;
 
    bool operator==(const RNTupleLocator &other) const {
       return fPosition == other.fPosition && fBytesOnStorage == other.fBytesOnStorage;
    }
-   bool IsSimple() const { return fPosition.index() == 0; }
    template <typename T>
    const T &Get() const
    {

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -32,11 +32,11 @@ using RResult = ROOT::Experimental::RResult<T>;
 
 
 namespace {
+using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
 
 std::uint32_t SerializeFieldV1(
    const ROOT::Experimental::RFieldDescriptor &fieldDesc, ROOT::Experimental::DescriptorId_t physParentId, void *buffer)
 {
-   using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
 
    auto base = reinterpret_cast<unsigned char *>(buffer);
    auto pos = base;
@@ -97,7 +97,6 @@ RResult<std::uint32_t> DeserializeFieldV1(
    std::uint32_t bufSize,
    ROOT::Experimental::RFieldDescriptorBuilder &fieldDesc)
 {
-   using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
    using ENTupleStructure = ROOT::Experimental::ENTupleStructure;
 
    auto base = reinterpret_cast<const unsigned char *>(buffer);
@@ -169,7 +168,6 @@ std::uint32_t SerializeColumnListV1(
    ROOT::Experimental::Internal::RNTupleSerializer::RContext &context,
    void *buffer)
 {
-   using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
    using RColumnElementBase = ROOT::Experimental::Detail::RColumnElementBase;
 
    auto base = reinterpret_cast<unsigned char *>(buffer);
@@ -216,7 +214,6 @@ RResult<std::uint32_t> DeserializeColumnV1(
    std::uint32_t bufSize,
    ROOT::Experimental::RColumnDescriptorBuilder &columnDesc)
 {
-   using RNTupleSerializer = ROOT::Experimental::Internal::RNTupleSerializer;
    using EColumnType = ROOT::Experimental::EColumnType;
 
    auto base = reinterpret_cast<const unsigned char *>(buffer);

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -789,7 +789,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeLocator(
    }
    std::int32_t head = sizeof(std::int32_t) + size;
    head |= locator.fReserved << 16;
-   head |= static_cast<int>(locator.fType) << 24;
+   head |= static_cast<int>(locator.fType & 0x7F) << 24;
    head = -head;
    size += RNTupleSerializer::SerializeInt32(head, buffer);
    return size;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -280,8 +280,7 @@ std::uint32_t SerializeLocatorPayloadObject64(const ROOT::Experimental::RNTupleL
    return sizeof(std::uint32_t) + sizeof(std::uint64_t);
 }
 
-void DeserializeLocatorPayloadObject64(const unsigned char *buffer, std::uint32_t /*payloadSize*/,
-                                       ROOT::Experimental::RNTupleLocator &locator)
+void DeserializeLocatorPayloadObject64(const unsigned char *buffer, ROOT::Experimental::RNTupleLocator &locator)
 {
    auto &data = locator.fPosition.emplace<ROOT::Experimental::RNTupleLocatorObject64>();
    RNTupleSerializer::DeserializeUInt32(buffer, locator.fBytesOnStorage);
@@ -816,7 +815,7 @@ RResult<std::uint32_t> ROOT::Experimental::Internal::RNTupleSerializer::Deserial
       locator.fReserved = static_cast<std::uint32_t>(head >> 16) & 0xFF;
       switch (type) {
       case RNTupleLocator::kTypeURI: DeserializeLocatorPayloadURI(bytes, payloadSize, locator); break;
-      case RNTupleLocator::kTypeDAOS: DeserializeLocatorPayloadObject64(bytes, payloadSize, locator); break;
+      case RNTupleLocator::kTypeDAOS: DeserializeLocatorPayloadObject64(bytes, locator); break;
       default: return R__FAIL("unsupported locator type: " + std::to_string(type));
       }
       bytes += payloadSize;

--- a/tree/ntuple/v7/src/RNTupleSerialize.cxx
+++ b/tree/ntuple/v7/src/RNTupleSerialize.cxx
@@ -253,7 +253,7 @@ RResult<std::uint32_t> DeserializeColumnV1(
 
 std::uint32_t SerializeLocatorPayloadURI(const ROOT::Experimental::RNTupleLocator &locator, unsigned char *buffer)
 {
-   const auto &uri = locator.Get<std::string>();
+   const auto &uri = locator.GetPosition<std::string>();
    if (uri.length() >= (1 << 16))
       throw ROOT::Experimental::RException(R__FAIL("locator too large"));
    if (buffer)
@@ -272,7 +272,7 @@ void DeserializeLocatorPayloadURI(const unsigned char *buffer, std::uint32_t pay
 
 std::uint32_t SerializeLocatorPayloadObject64(const ROOT::Experimental::RNTupleLocator &locator, unsigned char *buffer)
 {
-   const auto &data = locator.Get<ROOT::Experimental::RNTupleLocatorObject64>();
+   const auto &data = locator.GetPosition<ROOT::Experimental::RNTupleLocatorObject64>();
    if (buffer) {
       RNTupleSerializer::SerializeUInt32(locator.fBytesOnStorage, buffer);
       RNTupleSerializer::SerializeUInt64(data.fLocation, buffer + sizeof(std::uint32_t));
@@ -776,7 +776,7 @@ std::uint32_t ROOT::Experimental::Internal::RNTupleSerializer::SerializeLocator(
       if (static_cast<std::int32_t>(locator.fBytesOnStorage) < 0)
          throw RException(R__FAIL("locator too large"));
       size += SerializeUInt32(locator.fBytesOnStorage, buffer);
-      size += SerializeUInt64(locator.Get<std::uint64_t>(),
+      size += SerializeUInt64(locator.GetPosition<std::uint64_t>(),
                               buffer ? reinterpret_cast<unsigned char *>(buffer) + size : nullptr);
       return size;
    }

--- a/tree/ntuple/v7/src/RPageStorageDaos.cxx
+++ b/tree/ntuple/v7/src/RPageStorageDaos.cxx
@@ -468,7 +468,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceDao
       buffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLength());
       zipBuffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLocator().fBytesOnStorage);
       fDaosContainer->ReadSingleAkey(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, oidPageList,
-                                     kDistributionKeyDefault, cgDesc.GetPageListLocator().Get<std::uint64_t>(),
+                                     kDistributionKeyDefault, cgDesc.GetPageListLocator().GetPosition<std::uint64_t>(),
                                      kCidMetadata);
       fDecompressor->Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
                            buffer.get());
@@ -505,8 +505,8 @@ void ROOT::Experimental::Detail::RPageSourceDaos::LoadSealedPage(DescriptorId_t 
    sealedPage.fSize = bytesOnStorage;
    sealedPage.fNElements = pageInfo.fNElements;
    if (sealedPage.fBuffer) {
-      RDaosKey daosKey =
-         GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId, pageInfo.fLocator.Get<std::uint64_t>());
+      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId,
+                                                             pageInfo.fLocator.GetPosition<std::uint64_t>());
       fDaosContainer->ReadSingleAkey(const_cast<void *>(sealedPage.fBuffer), bytesOnStorage, daosKey.fOid,
                                      daosKey.fDkey, daosKey.fAkey);
    }
@@ -530,8 +530,8 @@ ROOT::Experimental::Detail::RPageSourceDaos::PopulatePageFromCluster(ColumnHandl
 
    if (fOptions.GetClusterCache() == RNTupleReadOptions::EClusterCache::kOff) {
       directReadBuffer = std::make_unique<unsigned char[]>(bytesOnStorage);
-      RDaosKey daosKey =
-         GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId, pageInfo.fLocator.Get<std::uint64_t>());
+      RDaosKey daosKey = GetPageDaosKey<kDefaultDaosMapping>(fNTupleIndex, clusterId, columnId,
+                                                             pageInfo.fLocator.GetPosition<std::uint64_t>());
       fDaosContainer->ReadSingleAkey(directReadBuffer.get(), bytesOnStorage, daosKey.fOid, daosKey.fDkey,
                                      daosKey.fAkey);
       fCounters->fNPageLoaded.Inc();
@@ -674,7 +674,7 @@ ROOT::Experimental::Detail::RPageSourceDaos::LoadClusters(std::span<RCluster::RK
             for (const auto &pageInfo : pageRange.fPageInfos) {
                const auto &pageLocator = pageInfo.fLocator;
                onDiskClusterPages.push_back(RDaosSealedPageLocator(clusterId, columnId, columnPageCount,
-                                                                   pageLocator.Get<std::uint64_t>(),
+                                                                   pageLocator.GetPosition<std::uint64_t>(),
                                                                    pageLocator.fBytesOnStorage, clusterBufSz));
                ++columnPageCount;
                clusterBufSz += pageLocator.fBytesOnStorage;

--- a/tree/ntuple/v7/src/RPageStorageFile.cxx
+++ b/tree/ntuple/v7/src/RPageStorageFile.cxx
@@ -276,7 +276,7 @@ ROOT::Experimental::RNTupleDescriptor ROOT::Experimental::Detail::RPageSourceFil
       auto buffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLength());
       auto zipBuffer = std::make_unique<unsigned char[]>(cgDesc.GetPageListLocator().fBytesOnStorage);
       fReader.ReadBuffer(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage,
-                         cgDesc.GetPageListLocator().Get<std::uint64_t>());
+                         cgDesc.GetPageListLocator().GetPosition<std::uint64_t>());
       fDecompressor->Unzip(zipBuffer.get(), cgDesc.GetPageListLocator().fBytesOnStorage, cgDesc.GetPageListLength(),
                            buffer.get());
 
@@ -308,7 +308,7 @@ void ROOT::Experimental::Detail::RPageSourceFile::LoadSealedPage(
    sealedPage.fNElements = pageInfo.fNElements;
    if (sealedPage.fBuffer)
       fReader.ReadBuffer(const_cast<void *>(sealedPage.fBuffer), bytesOnStorage,
-                         pageInfo.fLocator.Get<std::uint64_t>());
+                         pageInfo.fLocator.GetPosition<std::uint64_t>());
 }
 
 ROOT::Experimental::Detail::RPage
@@ -329,7 +329,7 @@ ROOT::Experimental::Detail::RPageSourceFile::PopulatePageFromCluster(ColumnHandl
 
    if (fOptions.GetClusterCache() == RNTupleReadOptions::EClusterCache::kOff) {
       directReadBuffer = std::make_unique<unsigned char[]>(bytesOnStorage);
-      fReader.ReadBuffer(directReadBuffer.get(), bytesOnStorage, pageInfo.fLocator.Get<std::uint64_t>());
+      fReader.ReadBuffer(directReadBuffer.get(), bytesOnStorage, pageInfo.fLocator.GetPosition<std::uint64_t>());
       fCounters->fNPageLoaded.Inc();
       fCounters->fNRead.Inc();
       fCounters->fSzReadPayload.Add(bytesOnStorage);
@@ -457,7 +457,8 @@ ROOT::Experimental::Detail::RPageSourceFile::PrepareSingleCluster(
          for (const auto &pageInfo : pageRange.fPageInfos) {
             const auto &pageLocator = pageInfo.fLocator;
             activeSize += pageLocator.fBytesOnStorage;
-            onDiskPages.push_back({columnId, pageNo, pageLocator.Get<std::uint64_t>(), pageLocator.fBytesOnStorage, 0});
+            onDiskPages.push_back(
+               {columnId, pageNo, pageLocator.GetPosition<std::uint64_t>(), pageLocator.fBytesOnStorage, 0});
             ++pageNo;
          }
       }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -297,7 +297,7 @@ TEST(RNTuple, SerializeLocator)
       EXPECT_THAT(err.what(), testing::HasSubstr("too short"));
    }
    EXPECT_EQ(12u, RNTupleSerializer::DeserializeLocator(buffer, 12, locator).Unwrap());
-   EXPECT_EQ(1u, locator.Get<std::uint64_t>());
+   EXPECT_EQ(1u, locator.GetPosition<std::uint64_t>());
    EXPECT_EQ(2u, locator.fBytesOnStorage);
 
    locator.fPosition.emplace<std::string>("X");
@@ -316,13 +316,13 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(5u, RNTupleSerializer::DeserializeLocator(buffer, 5, locator).Unwrap());
    EXPECT_EQ(0u, locator.fBytesOnStorage);
    EXPECT_EQ(RNTupleLocator::kTypeURI, locator.fType);
-   EXPECT_EQ("X", locator.Get<std::string>());
+   EXPECT_EQ("X", locator.GetPosition<std::string>());
 
    locator.fPosition.emplace<std::string>("abcdefghijkl");
    EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer));
    locator.fPosition = 0U;
    EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
-   EXPECT_EQ("abcdefghijkl", locator.Get<std::string>());
+   EXPECT_EQ("abcdefghijkl", locator.GetPosition<std::string>());
 
    locator.fType = RNTupleLocator::kTypeDAOS;
    locator.fPosition.emplace<RNTupleLocatorObject64>(RNTupleLocatorObject64{1337U});
@@ -334,7 +334,7 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(locator.fType, RNTupleLocator::kTypeDAOS);
    EXPECT_EQ(locator.fBytesOnStorage, 420420U);
    EXPECT_EQ(locator.fReserved, 0x5a);
-   EXPECT_EQ(1337U, locator.Get<RNTupleLocatorObject64>().fLocation);
+   EXPECT_EQ(1337U, locator.GetPosition<RNTupleLocatorObject64>().fLocation);
 
    std::int32_t *head = reinterpret_cast<std::int32_t *>(buffer);
    *head = (0x3 << 24) | *head;
@@ -426,8 +426,8 @@ TEST(RNTuple, SerializeClusterGroup)
    EXPECT_EQ(24u, RNTupleSerializer::DeserializeClusterGroup(buffer, 24, reco).Unwrap());
    EXPECT_EQ(group.fNClusters, reco.fNClusters);
    EXPECT_EQ(group.fPageListEnvelopeLink.fUnzippedSize, reco.fPageListEnvelopeLink.fUnzippedSize);
-   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.Get<std::uint64_t>(),
-             reco.fPageListEnvelopeLink.fLocator.Get<std::uint64_t>());
+   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>(),
+             reco.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>());
    EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.fBytesOnStorage, reco.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
 
    // Test frame evolution
@@ -441,8 +441,8 @@ TEST(RNTuple, SerializeClusterGroup)
    EXPECT_EQ(26u, RNTupleSerializer::DeserializeClusterGroup(buffer, 26, reco).Unwrap());
    EXPECT_EQ(group.fNClusters, reco.fNClusters);
    EXPECT_EQ(group.fPageListEnvelopeLink.fUnzippedSize, reco.fPageListEnvelopeLink.fUnzippedSize);
-   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.Get<std::uint64_t>(),
-             reco.fPageListEnvelopeLink.fLocator.Get<std::uint64_t>());
+   EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>(),
+             reco.fPageListEnvelopeLink.fLocator.GetPosition<std::uint64_t>());
    EXPECT_EQ(group.fPageListEnvelopeLink.fLocator.fBytesOnStorage, reco.fPageListEnvelopeLink.fLocator.fBytesOnStorage);
    std::uint16_t remainder;
    RNTupleSerializer::DeserializeUInt16(buffer + 24, remainder);
@@ -585,7 +585,7 @@ TEST(RNTuple, SerializeFooter)
    const auto &clusterGroupDesc = desc.GetClusterGroupDescriptor(0);
    EXPECT_EQ(1u, clusterGroupDesc.GetNClusters());
    EXPECT_EQ(137u, clusterGroupDesc.GetPageListLength());
-   EXPECT_EQ(1337u, clusterGroupDesc.GetPageListLocator().Get<std::uint64_t>());
+   EXPECT_EQ(1337u, clusterGroupDesc.GetPageListLocator().GetPosition<std::uint64_t>());
    EXPECT_EQ(42u, clusterGroupDesc.GetPageListLocator().fBytesOnStorage);
 
    std::vector<RClusterDescriptorBuilder> clusters = RClusterGroupDescriptorBuilder::GetClusterSummaries(desc, 0);
@@ -608,5 +608,5 @@ TEST(RNTuple, SerializeFooter)
    pageRange = clusterDesc.GetPageRange(0).Clone();
    EXPECT_EQ(1u, pageRange.fPageInfos.size());
    EXPECT_EQ(100u, pageRange.fPageInfos[0].fNElements);
-   EXPECT_EQ(7000u, pageRange.fPageInfos[0].fLocator.Get<std::uint64_t>());
+   EXPECT_EQ(7000u, pageRange.fPageInfos[0].fLocator.GetPosition<std::uint64_t>());
 }

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -301,10 +301,12 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(2u, locator.fBytesOnStorage);
 
    locator.fPosition.emplace<std::string>("X");
+   locator.fType = RNTupleLocator::kTypeURI;
    EXPECT_EQ(5u, RNTupleSerializer::SerializeLocator(locator, nullptr));
    EXPECT_EQ(5u, RNTupleSerializer::SerializeLocator(locator, buffer));
    locator.fPosition = 42U;
    locator.fBytesOnStorage = 42;
+   locator.fType = RNTupleLocator::kTypeFile;
    try {
       RNTupleSerializer::DeserializeLocator(buffer, 4, locator).Unwrap();
       FAIL() << "too short locator buffer should throw";
@@ -313,6 +315,7 @@ TEST(RNTuple, SerializeLocator)
    }
    EXPECT_EQ(5u, RNTupleSerializer::DeserializeLocator(buffer, 5, locator).Unwrap());
    EXPECT_EQ(0u, locator.fBytesOnStorage);
+   EXPECT_EQ(RNTupleLocator::kTypeURI, locator.fType);
    EXPECT_EQ("X", locator.Get<std::string>());
 
    locator.fPosition.emplace<std::string>("abcdefghijkl");

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -282,8 +282,7 @@ TEST(RNTuple, SerializeLocator)
       EXPECT_THAT(err.what(), testing::HasSubstr("too large"));
    }
 
-   locator.fPosition = 0U;
-   locator.fBytesOnStorage = 0;
+   locator = RNTupleLocator{};
    try {
       RNTupleSerializer::DeserializeLocator(buffer, 3, locator).Unwrap();
       FAIL() << "too short locator buffer should throw";
@@ -299,14 +298,13 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(12u, RNTupleSerializer::DeserializeLocator(buffer, 12, locator).Unwrap());
    EXPECT_EQ(1u, locator.GetPosition<std::uint64_t>());
    EXPECT_EQ(2u, locator.fBytesOnStorage);
+   EXPECT_EQ(RNTupleLocator::kTypeFile, locator.fType);
 
    locator.fPosition.emplace<std::string>("X");
    locator.fType = RNTupleLocator::kTypeURI;
    EXPECT_EQ(5u, RNTupleSerializer::SerializeLocator(locator, nullptr));
    EXPECT_EQ(5u, RNTupleSerializer::SerializeLocator(locator, buffer));
-   locator.fPosition = 42U;
-   locator.fBytesOnStorage = 42;
-   locator.fType = RNTupleLocator::kTypeFile;
+   locator = RNTupleLocator{};
    try {
       RNTupleSerializer::DeserializeLocator(buffer, 4, locator).Unwrap();
       FAIL() << "too short locator buffer should throw";
@@ -320,7 +318,7 @@ TEST(RNTuple, SerializeLocator)
 
    locator.fPosition.emplace<std::string>("abcdefghijkl");
    EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer));
-   locator.fPosition = 0U;
+   locator = RNTupleLocator{};
    EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
    EXPECT_EQ("abcdefghijkl", locator.GetPosition<std::string>());
 

--- a/tree/ntuple/v7/test/ntuple_serialize.cxx
+++ b/tree/ntuple/v7/test/ntuple_serialize.cxx
@@ -324,6 +324,18 @@ TEST(RNTuple, SerializeLocator)
    EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
    EXPECT_EQ("abcdefghijkl", locator.Get<std::string>());
 
+   locator.fType = RNTupleLocator::kTypeDAOS;
+   locator.fPosition.emplace<RNTupleLocatorObject64>(RNTupleLocatorObject64{1337U});
+   locator.fBytesOnStorage = 420420U;
+   locator.fReserved = 0x5a;
+   EXPECT_EQ(16u, RNTupleSerializer::SerializeLocator(locator, buffer));
+   locator = RNTupleLocator{};
+   EXPECT_EQ(16u, RNTupleSerializer::DeserializeLocator(buffer, 16, locator).Unwrap());
+   EXPECT_EQ(locator.fType, RNTupleLocator::kTypeDAOS);
+   EXPECT_EQ(locator.fBytesOnStorage, 420420U);
+   EXPECT_EQ(locator.fReserved, 0x5a);
+   EXPECT_EQ(1337U, locator.Get<RNTupleLocatorObject64>().fLocation);
+
    std::int32_t *head = reinterpret_cast<std::int32_t *>(buffer);
    *head = (0x3 << 24) | *head;
    try {

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -344,7 +344,7 @@ TEST(RPageSinkBuf, Basics)
    for (std::size_t i = 0; i < num_columns; i++) {
       const auto &columnPages = cluster0.GetPageRange(i);
       for (const auto &page: columnPages.fPageInfos) {
-         pagePositions.push_back(std::make_pair(i, page.fLocator.fPosition));
+         pagePositions.push_back(std::make_pair(i, page.fLocator.Get<std::uint64_t>()));
       }
    }
 

--- a/tree/ntuple/v7/test/ntuple_storage.cxx
+++ b/tree/ntuple/v7/test/ntuple_storage.cxx
@@ -344,7 +344,7 @@ TEST(RPageSinkBuf, Basics)
    for (std::size_t i = 0; i < num_columns; i++) {
       const auto &columnPages = cluster0.GetPageRange(i);
       for (const auto &page: columnPages.fPageInfos) {
-         pagePositions.push_back(std::make_pair(i, page.fLocator.Get<std::uint64_t>()));
+         pagePositions.push_back(std::make_pair(i, page.fLocator.GetPosition<std::uint64_t>()));
       }
    }
 

--- a/tree/ntuple/v7/test/ntuple_test.hxx
+++ b/tree/ntuple/v7/test/ntuple_test.hxx
@@ -68,6 +68,7 @@ using RFieldDescriptor = ROOT::Experimental::RFieldDescriptor;
 using RFieldMerger = ROOT::Experimental::RFieldMerger;
 using RFieldValue = ROOT::Experimental::Detail::RFieldValue;
 using RNTupleLocator = ROOT::Experimental::RNTupleLocator;
+using RNTupleLocatorObject64 = ROOT::Experimental::RNTupleLocatorObject64;
 using RMiniFileReader = ROOT::Experimental::Internal::RMiniFileReader;
 using RNTuple = ROOT::Experimental::RNTuple;
 using RNTupleAtomicCounter = ROOT::Experimental::Detail::RNTupleAtomicCounter;


### PR DESCRIPTION
This pull request improves the internal in-memory layout of `RNTupleLocator`, its serialization/deserialization, and introduces some changes to the binary specification (see list of individual changes below).

## Changes or fixes:
- **FIX** discrepancy between non-disk locators specification and implementation: [specifications.md, Section "Locators and Envelope Links"](https://github.com/root-project/root/blob/master/tree/ntuple/v7/doc/specifications.md#locators-and-envelope-links) stated that on non-disk locators, the 24LSb of _Size_ specify the size of the locator (and not only the size of the payload).  However, _Size_ stored only the size of the payload.
- Use a `std::variant<...>` to represent type-specific information stored in the locator.
- Separate serialization of non-simple locators (i.e. those having the `T` bit set to 1).  Serialization for those types is provided by `{Serialize,Deserialize}LocatorPayloadXxx()`.
- For non-disk locators (i.e., those with `T == 1`), add a _Reserved_ 8bit field that can be used by concrete backends to store 8bits of additional information per locator.
To accommodate that, _Size_ has been reduced to 16 bits, i.e. the maximum size of a locator is now 64kB, which is still enough.
- Explicitly store the locator type in a dedicated member in the `RNTupleLocator` structure. This makes it possible to have different type values even if the payload structure is identical, i.e. use the same alternative in the `fPosition` variant.
**NOTE:** given the reorder of members, `sizeof(RNTupleLocator)` is preserved before and after the changes in this branch, at least in x86_64 and libstdc++.
- Reassign the first representable value for the _Type_ (0x01) for URI string locators.  This makes the entire contiguous range [0x02, 0x7f] assignable for concrete backends.
**NOTE:** given that URI locators were so far unused in produced files, the change should not break existing ntuples.
- Provide a new locator payload format: `RNTupleLocatorObject64`.  This structure groups common data for object stores using 64bit location information.
In some cases, for locators referencing pages, this might not contain the full location of the content. In particular, concrete backends may use this information in conjunction with the cluster and column ID.
- Assign the _Type_ `0x02` for DAOS (layout of payload is given by `RNTupleLocatorObject64`).
- Update `specifications.md` accordingly.

Follow-up PRs: use `kTypeDAOS` locators in RPageStorageDaos.

## Checklist:
- [X] tested changes locally
- [X] updated the docs (if necessary)

This PR fixes #11758.