### PR TITLE
Fix expected return code for two tutorials

### DIFF
--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -440,7 +440,7 @@ if(mpi)
 endif()
 
 #---Special return code------------------------------------------------
-set(returncode_1 fit/fit2a.C fit/graph2dfit.C
+set(returncode_1 fit/fit2a.C
                  graphics/arrow.C
                  graphics/crown.C graphics/diamond.C
                  graphics/earth.C graphics/ellipse.C
@@ -452,7 +452,6 @@ set(returncode_1 fit/fit2a.C fit/graph2dfit.C
                  graphs/exclusiongraph.C
                  graphs/graphstruct.C
                  hist/ContourList.C
-                 hist/hstack.C
                  hist/hbars.C
                  hist/th2polyBoxes.C
                  hist/statsEditing.C


### PR DESCRIPTION
Commit e97f74d67e changed the tutorials `fit/graph2dfit.C` and `hist/hstack.C` to not return a pointer to `TCanvas`. Remove the special case and expect the test to exit code 0.