### PR TITLE
[DF] Let RunGraphs log what code is being jitted

### DIFF
--- a/tree/dataframe/src/RDFHelpers.cxx
+++ b/tree/dataframe/src/RDFHelpers.cxx
@@ -52,10 +52,18 @@ void ROOT::RDF::RunGraphs(std::vector<RResultHandle> handles)
    TStopwatch sw;
    sw.Start();
    {
-      // silence logs from RLoopManager::Jit: RunGraphs does its own logging
-      auto silenceRDFLogs = ROOT::Experimental::RLogScopedVerbosity(ROOT::Detail::RDF::RDFLogChannel(),
-                                                                    ROOT::Experimental::ELogLevel::kError);
-      uniqueLoops[0].fLoopManager->Jit();
+      const auto effectiveVerbosity =
+         ROOT::Experimental::Internal::GetChannelOrManager(ROOT::Detail::RDF::RDFLogChannel())
+            .GetEffectiveVerbosity(ROOT::Experimental::RLogManager::Get());
+      if (effectiveVerbosity >= ROOT::Experimental::ELogLevel::kDebug + 10) {
+         // a very high verbosity was requested, let's not silence anything
+         uniqueLoops[0].fLoopManager->Jit();
+      } else {
+         // silence logs from RLoopManager::Jit: RunGraphs does its own logging
+         auto silenceRDFLogs = ROOT::Experimental::RLogScopedVerbosity(ROOT::Detail::RDF::RDFLogChannel(),
+                                                                       ROOT::Experimental::ELogLevel::kError);
+         uniqueLoops[0].fLoopManager->Jit();
+      }
    }
    sw.Stop();
    R__LOG_INFO(ROOT::Detail::RDF::RDFLogChannel())


### PR DESCRIPTION
RunGraphs makes a summary log entry for the jitting time of all computation graphs that are being run concurrently. Generally this is ok, but in the case users specifically requested a log level of kDebug+10 or higher this would accidentally silence the logging of what code is being jitted.
With this patch, if log level is kDebug+10 or higher, RunGraphs avoids silencing inner logs.