### PR TITLE
[RF] Avoid manual memory management in the rs101 tutorial

### DIFF
--- a/tutorials/roostats/rs101_limitexample.py
+++ b/tutorials/roostats/rs101_limitexample.py
@@ -54,7 +54,7 @@ data = ROOT.RooDataSet("exampleData", "exampleData", {obs})
 data.add(obs)
 
 # not necessary
-modelWithConstraints.fitTo(data, Constrain=constrainedParams)
+modelWithConstraints.fitTo(data, Constrain=constrainedParams, PrintLevel=-1)
 
 # Now let's make some confidence intervals for s, our parameter of interest
 modelConfig = ROOT.RooStats.ModelConfig(wspace)
@@ -72,7 +72,7 @@ wspace.writeToFile("rs101_ws.root")
 # First, let's use a Calculator based on the Profile Likelihood Ratio
 plc = ROOT.RooStats.ProfileLikelihoodCalculator(data, modelConfig)
 plc.SetTestSize(0.05)
-lrinterval = plc.GetInterval()  # that was easy.
+lrinterval = plc.GetInterval()
 
 # Let's make a plot
 dataCanvas = ROOT.TCanvas("dataCanvas")
@@ -90,9 +90,9 @@ fc.FluctuateNumDataEntries(False)  # number counting analysis: dataset always ha
 fc.SetNBins(100)  # number of points to test per parameter
 fc.SetTestSize(0.05)
 # fc.SaveBeltToFile(True) # optional
-fcint = fc.GetInterval()  # that was easy
+fcint = fc.GetInterval()
 
-fit = modelWithConstraints.fitTo(data, Save=True)
+fit = modelWithConstraints.fitTo(data, Save=True, PrintLevel=-1)
 
 # Third, use a Calculator based on Markov Chain monte carlo
 # Before configuring the calculator, let's make a ProposalFunction
@@ -102,7 +102,7 @@ ph.SetVariables(fit.floatParsFinal())
 ph.SetCovMatrix(fit.covarianceMatrix())
 ph.SetUpdateProposalParameters(True)
 ph.SetCacheSize(100)
-pdfProp = ph.GetProposalFunction()  # that was easy
+pdfProp = ph.GetProposalFunction()
 
 mc = ROOT.RooStats.MCMCCalculator(data, modelConfig)
 mc.SetNumIters(20000)  # steps to propose in the chain
@@ -110,7 +110,7 @@ mc.SetTestSize(0.05)  # 95% CL
 mc.SetNumBurnInSteps(40)  # ignore first N steps in chain as "burn in"
 mc.SetProposalFunction(pdfProp)
 mc.SetLeftSideTailFraction(0.5)  # find a "central" interval
-mcInt = mc.GetInterval()  # that was easy
+mcInt = mc.GetInterval()
 
 # Get Lower and Upper limits from Profile Calculator
 print("Profile lower limit on s = ", lrinterval.LowerLimit(s))

--- a/tutorials/roostats/rs_numberCountingCombination.C
+++ b/tutorials/roostats/rs_numberCountingCombination.C
@@ -132,7 +132,7 @@ void rs_numberCountingCombination_expected()
    // We need to specify what are our parameters of interest
    RooArgSet *paramsOfInterest = nullParams; // they are the same as before in this case
    plc.SetParameters(*paramsOfInterest);
-   LikelihoodInterval *lrint = (LikelihoodInterval *)plc.GetInterval(); // that was easy.
+   LikelihoodInterval *lrint = (LikelihoodInterval *)plc.GetInterval();
    lrint->SetConfidenceLevel(0.95);
 
    // Step 9, make a plot of the likelihood ratio and the interval obtained
@@ -294,7 +294,7 @@ void rs_numberCountingCombination_observed()
    // We need to specify what are our parameters of interest
    RooArgSet *paramsOfInterest = nullParams; // they are the same as before in this case
    plc.SetParameters(*paramsOfInterest);
-   LikelihoodInterval *lrint = (LikelihoodInterval *)plc.GetInterval(); // that was easy.
+   LikelihoodInterval *lrint = (LikelihoodInterval *)plc.GetInterval();
    lrint->SetConfidenceLevel(0.95);
 
    // Step 9c. Get upper and lower limits
@@ -383,7 +383,7 @@ void rs_numberCountingCombination_observedWithTau()
    // We need to specify what are our parameters of interest
    RooArgSet *paramsOfInterest = nullParams; // they are the same as before in this case
    plc.SetParameters(*paramsOfInterest);
-   LikelihoodInterval *lrint = (LikelihoodInterval *)plc.GetInterval(); // that was easy.
+   LikelihoodInterval *lrint = (LikelihoodInterval *)plc.GetInterval();
    lrint->SetConfidenceLevel(0.95);
 
    // Step 9c. Get upper and lower limits


### PR DESCRIPTION
This is done because the manual memory management in the `rs101_limitexample` tutorial deleted the object in the wrong way.

For example, it deleted the workspace first, and then the `lrinterval` object that pointed to the PDF stored in the workspace. This caused crashes in configurations that are sentitive to the resulting dangling pointers, like in the new BatchMode.