### PR TITLE
[webgui] fixing tutorials run in ctest

### DIFF
--- a/core/base/src/TROOT.cxx
+++ b/core/base/src/TROOT.cxx
@@ -2753,15 +2753,16 @@ void TROOT::SetMacroPath(const char *newpath)
 /// The input parameter `webdisplay` defines where web graphics is rendered.
 /// `webdisplay` parameter may contain:
 ///
+///  - "firefox": select Mozilla Firefox browser for interactive web display
+///  - "chrome": select Google Chrome browser for interactive web display
+///  - "edge": select Microsoft Edge browser for interactive web display
 ///  - "off": turns off the web display and comes back to normal graphics in
 ///    interactive mode.
-///  - "batch": turns the web display in batch mode. It can be prepended with
-///    another string which is considered as the new current web display.
-///  - "nobatch": turns the web display in interactive mode. It can be
-///    prepended with another string which is considered as the new current web display.
-///
-/// If the option "off" is not set, this method turns the normal graphics to
-/// "Batch" to avoid the loading of local graphics libraries.
+///  - "batch": turns the web display in batch mode. TCanvas images will be produced with web graphics.
+///    One could append browser kind like "batch:firefox"
+///  - "batch7": turns the web display only of ROOT7 classes in batch mode, TCanvas will be handled with old graphics.
+///  - "server:port": turns the web display into server mode as specified port. Web widgets will not be displayed,
+///    only text message with window URL will be printed on standard output
 
 void TROOT::SetWebDisplay(const char *webdisplay)
 {
@@ -2773,9 +2774,27 @@ void TROOT::SetWebDisplay(const char *webdisplay)
       fIsWebDisplay = kFALSE;
       fIsWebDisplayBatch = kFALSE;
       fWebDisplay = "";
-   } else if (!strncmp(wd, "server", 6)) {
+      return;
+   }
+
+   // handle batch combinations
+   if (!strncmp(wd, "batch7", 6)) {
+      fIsWebDisplay = kFALSE;
+      fIsWebDisplayBatch = kTRUE;
+      wd += 6;
+      wd = (*wd == ':') ? wd+1 : "";
+   } else if (!strncmp(wd, "batch", 5)) {
+      fIsWebDisplay = kTRUE;
+      fIsWebDisplayBatch = kTRUE;
+      wd += 5;
+      wd = (*wd == ':') ? wd+1 : "";
+   } else {
       fIsWebDisplay = kTRUE;
       fIsWebDisplayBatch = kFALSE;
+   }
+
+   // handle server mode
+   if (!strncmp(wd, "server", 6)) {
       fWebDisplay = "server";
       if (wd[6] == ':') {
          if ((wd[7] >= '0') && (wd[7] <= '9')) {
@@ -2788,17 +2807,9 @@ void TROOT::SetWebDisplay(const char *webdisplay)
             gEnv->SetValue("WebGui.UnixSocket", wd+7);
          }
       }
+   } else if (!strcmp(wd, "on")) {
+      fWebDisplay = "";
    } else {
-      fIsWebDisplay = kTRUE;
-      if (!strncmp(wd, "batch", 5)) {
-         fIsWebDisplayBatch = kTRUE;
-         wd += 5;
-      } else if (!strncmp(wd, "nobatch", 7)) {
-         fIsWebDisplayBatch = kFALSE;
-         wd += 7;
-      } else {
-         fIsWebDisplayBatch = kFALSE;
-      }
       fWebDisplay = wd;
    }
 }

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -304,7 +304,7 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t form)
       Warning("Constructor","Deleting canvas with same name: %s",name);
       delete old;
    }
-   if (gROOT->IsBatch() && (!gROOT->IsWebDisplay() || gROOT->IsWebDisplayBatch())) {   //We are in Batch mode
+   if (gROOT->IsBatch()) {   //We are in Batch mode
       fWindowTopX = fWindowTopY = 0;
       if (form == 1) {
          fWindowWidth  = gStyle->GetCanvasDefW();

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -764,9 +764,11 @@ void TWebCanvas::ShowWebWindow(const ROOT::Experimental::RWebDisplayArgs &args)
 
 void TWebCanvas::Show()
 {
-   ROOT::Experimental::RWebDisplayArgs args;
-   args.SetWidgetKind("TCanvas");
-   ShowWebWindow(args);
+   if (!Canvas()->IsBatch()) {
+      ROOT::Experimental::RWebDisplayArgs args;
+      args.SetWidgetKind("TCanvas");
+      ShowWebWindow(args);
+   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1536,6 +1538,9 @@ UInt_t TWebCanvas::GetWindowGeometry(Int_t &x, Int_t &y, UInt_t &w, UInt_t &h)
 
 Bool_t TWebCanvas::PerformUpdate()
 {
+   if (Canvas()->IsBatch())
+      return kFALSE;
+
    CheckCanvasModified();
 
    CheckDataToSend();
@@ -1551,6 +1556,9 @@ Bool_t TWebCanvas::PerformUpdate()
 
 void TWebCanvas::ForceUpdate()
 {
+   if (Canvas()->IsBatch())
+      return;
+
    CheckCanvasModified(true);
 
    CheckDataToSend();

--- a/tutorials/.rootlogon.py
+++ b/tutorials/.rootlogon.py
@@ -1,4 +1,4 @@
 """rootlogon module for the Python tutorials. Disables the graphics."""
 import ROOT
 ROOT.gROOT.SetBatch(True)
-ROOT.gROOT.SetWebDisplay("batch")
+ROOT.gROOT.SetWebDisplay("batch7")

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -44,9 +44,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_CURRENT_BIN
 #   tutorials directory which is copied to the build area.
 #-------------------------------------------------------------------
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootlogon.C "{
-  // Needed by ACLiC to use the current dicrectory for scratch area
+  // Needed by ACLiC to use the current directory for scratch area
   gSystem->SetBuildDir(\".\", kTRUE);
-  gROOT->SetWebDisplay(\"batch\");
+  gROOT->SetWebDisplay(\"batch7\");
 }")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootalias.C "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rootlogoff.C "{}")


### PR DESCRIPTION
1. Let enable only web batch mode, which will be used by ROOT7 widgets
2. For all normal widgets as TCanvas `gROOT->IsBatch()` should be used 
3. When run tutorials, do `gROOT->SetWebDisplay("batch7")`

Should fix problems with many macros