### PR TITLE
[RF] Fix nWorker setting in RooMinimizer input config

### DIFF
--- a/roofit/roofitcore/src/RooMinimizer.cxx
+++ b/roofit/roofitcore/src/RooMinimizer.cxx
@@ -113,6 +113,8 @@ RooMinimizer::RooMinimizer(RooAbsReal &function, Config const &cfg) : _cfg(cfg)
             coutI(InputArguments) << "New style likelihood detected and likelihood parallelization requested, "
                                   << "also setting parallel gradient calculation mode." << std::endl;
          }
+         RooFit::MultiProcess::Config::setDefaultNWorkers(_cfg.nWorkers);
+
          _fcn = std::make_unique<RooFit::TestStatistics::MinuitFcnGrad>(
             nll_real->getRooAbsL(), this, _theFitter->Config().ParamsSettings(),
             RooFit::TestStatistics::LikelihoodMode{


### PR DESCRIPTION
# This Pull request:

## Changes or fixes:

nWorkers setting was actually not being set when the RooMinimizer was called with the nWorkers setting enabled in `RooMinimizer::Config`. Now that is fixed by passing the `RooMinimizer::Config::nWorkers` setting to the multiprocessing internal config.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

