### PR TITLE
[RF] New `RooPlot::createInternalPlotVarClone()` function for RooUnitTest

### DIFF
--- a/roofit/roofitcore/inc/RooPlot.h
+++ b/roofit/roofitcore/inc/RooPlot.h
@@ -204,6 +204,8 @@ public:
 
   static void fillItemsFromTList(Items & items, TList const& tlist);
 
+  void createInternalPlotVarClone();
+
 protected:
 
   RooPlot(const RooPlot& other) = delete; // cannot be copied

--- a/roofit/roofitcore/src/RooMCStudy.cxx
+++ b/roofit/roofitcore/src/RooMCStudy.cxx
@@ -1007,7 +1007,12 @@ RooPlot* RooMCStudy::plotError(const RooRealVar& param, const RooCmdArg& arg1, c
 
   std::unique_ptr<RooErrorVar> evar{param.errorVar()};
   std::unique_ptr<RooRealVar> evar_rrv{static_cast<RooRealVar*>(evar->createFundamental())};
-  return plotParam(*evar_rrv,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8);
+  RooPlot* frame = plotParam(*evar_rrv,arg1,arg2,arg3,arg4,arg5,arg6,arg7,arg8) ;
+
+  // To make sure the frame has no dangling pointer to evar_rrv.
+  frame->createInternalPlotVarClone();
+
+  return frame ;
 }
 
 namespace {
@@ -1132,6 +1137,9 @@ RooPlot* RooMCStudy::plotPull(const RooRealVar& param, const RooCmdArg& arg1, co
     if (fitGauss) {
       fitGaussToPulls(*frame, *_fitParData);
     }
+
+    // To make sure the frame has no dangling pointer to pvar.
+    frame->createInternalPlotVarClone();
   }
   return frame;
 }

--- a/roofit/roofitcore/src/RooPlot.cxx
+++ b/roofit/roofitcore/src/RooPlot.cxx
@@ -1440,3 +1440,17 @@ void RooPlot::fillItemsFromTList(RooPlot::Items & items, TList const& tlist) {
     items.emplace_back(obj, obj->GetOption());
   }
 }
+
+/// Replaces the pointer to the plot variable with a pointer to a clone of the
+/// plot variable that is owned by this RooPlot. The RooPlot references the
+/// plotted variable by non-owning pointer by default since ROOT 6.28, which
+/// resulted in a big speedup when plotting complicated pdfs that are expensive
+/// to clone. However, going back to an owned clone is useful in rare cases.
+/// For example in the RooUnitTest, where the registered plots need to live
+/// longer than the scope of the unit test.
+void RooPlot::createInternalPlotVarClone() {
+  // If the plot variable is already cloned, we don't need to do anything.
+  if(_plotVarSet) return;
+  _plotVarSet = static_cast<RooArgSet*>(RooArgSet(*_plotVar).snapshot());
+  _plotVar = static_cast<RooAbsRealLValue*>(_plotVarSet->find(_plotVar->GetName()));
+}

--- a/roofit/roofitcore/src/RooUnitTest.cxx
+++ b/roofit/roofitcore/src/RooUnitTest.cxx
@@ -28,7 +28,7 @@ Object          | function
 ----------------|------------
    RooPlot      | regPlot()
    RooFitResult | regResult()
-   double     | regValue()
+   double       | regValue()
    RooTable     | regTable()
    TH1/2/3      | regTH()
    RooWorkspace | regWS()
@@ -79,7 +79,13 @@ void RooUnitTest::regPlot(RooPlot* frame, const char* refName)
   if (_refFile) {
     string refNameStr(refName) ;
     frame->SetName(refName) ;
-    _regPlots.push_back(make_pair(frame,refNameStr)) ;
+    // Since ROOT 6.28, the RooPlot doesn't clone the plot variable by default
+    // anymore. This is a problem for registering the RooPlots, because they
+    // need to survive without dangling pointers even after the RooUnitTest is
+    // done. For that reason, we ask the RooPlot to create an internal plot
+    // variable clone for itself.
+    frame->createInternalPlotVarClone();
+    _regPlots.emplace_back(frame,refNameStr);
   } else {
     delete frame ;
   }


### PR DESCRIPTION
This is a followup to commit 8679898a. In that commit, the RooPlot was changed to not create an internal clone of the plot variables anymore.

However, in rare cases like for the RooUnitTest, it is necessary that the RooPlot owns the plot plot variables to avoid dangling pointers when the RooPlot lives longer than the original plot variables.

To support these cases, a new member function
`RooPlot::createInternalPlotVarClone()` is introduced. It can be used to convert the RooPlot to a plot that owns a clone of the plot variable at any point in time of the RooPlot lifetime.