### PR TITLE
Remove usage of Range in empty source distributed mode

### DIFF
--- a/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
+++ b/bindings/experimental/distrdf/python/DistRDF/HeadNode.py
@@ -311,7 +311,9 @@ class EmptySourceHeadNode(HeadNode):
             """
             Builds an RDataFrame instance for a distributed mapper.
             """
-            return TaskObjects(ROOT.RDataFrame(nentries).Range(current_range.start, current_range.end), None)
+            rdf = ROOT.RDataFrame(nentries)
+            ROOT.Internal.RDF.ChangeEmptyEntryRange(ROOT.RDF.AsRNode(rdf), (current_range.start, current_range.end))
+            return TaskObjects(rdf, None)
 
         return build_rdf_from_range
 

--- a/bindings/experimental/distrdf/test/test_headnode.py
+++ b/bindings/experimental/distrdf/test/test_headnode.py
@@ -168,9 +168,8 @@ class NumEntriesTest(unittest.TestCase):
     """'get_num_entries' returns the number of entries in the input dataset"""
 
     def fill_tree(self, size):
-        """Stores an RDataFrame object of a given size in 'data.root'."""
-        tdf = ROOT.ROOT.RDataFrame(size)
-        tdf.Define("b1", "(double) tdfentry_").Snapshot("tree", "data.root")
+        """Writes a TTree with one column of type 'double' with the given size to 'data.root'."""
+        ROOT.RDataFrame(size).Define("b1", "static_cast<double>(rdfentry_)").Snapshot("tree", "data.root")
 
     def test_num_entries_two_args_case(self):
         """

--- a/bindings/experimental/distrdf/test/test_proxy.py
+++ b/bindings/experimental/distrdf/test/test_proxy.py
@@ -100,8 +100,8 @@ class AttrReadTest(unittest.TestCase):
         proxy = Proxy.TransformationProxy(node)
 
         transformations = {
-            "Define": ["x", "tdfentry_"],
-            "Filter": ["tdfentry_ > 0"],
+            "Define": ["x", "1"],
+            "Filter": ["x > 0"],
         }
 
         for transformation, args in transformations.items():

--- a/tree/dataframe/CMakeLists.txt
+++ b/tree/dataframe/CMakeLists.txt
@@ -108,6 +108,7 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTDataFrame
     src/RDFHelpers.cxx
     src/RFilterBase.cxx
     src/RInterfaceBase.cxx
+    src/RInterface.cxx
     src/RJittedAction.cxx
     src/RJittedDefine.cxx
     src/RJittedFilter.cxx

--- a/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RInterface.hxx
@@ -86,6 +86,15 @@ template <typename Proxied, typename DataSource>
 class RInterface;
 
 using RNode = RInterface<::ROOT::Detail::RDF::RNodeBase, void>;
+} // namespace RDF
+
+namespace Internal {
+namespace RDF {
+void ChangeEmptyEntryRange(const ROOT::RDF::RNode &node, std::pair<ULong64_t, ULong64_t> &&newRange);
+} // namespace RDF
+} // namespace Internal
+
+namespace RDF {
 
 // clang-format off
 /**
@@ -112,6 +121,7 @@ class RInterface : public RInterfaceBase {
    friend class RInterface;
 
    friend void RDFInternal::TriggerRun(RNode &node);
+   friend void RDFInternal::ChangeEmptyEntryRange(const RNode &node, std::pair<ULong64_t, ULong64_t> &&newRange);
 
    std::shared_ptr<Proxied> fProxiedPtr; ///< Smart pointer to the graph node encapsulated by this RInterface.
 

--- a/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
+++ b/tree/dataframe/inc/ROOT/RDF/RLoopManager.hxx
@@ -132,7 +132,8 @@ class RLoopManager : public RNodeBase {
 
    std::vector<std::unique_ptr<TTree>> fFriends; ///< Friends of the fTree. Only used if we constructed fTree ourselves.
    const ColumnNames_t fDefaultColumns;
-   const ULong64_t fNEmptyEntries{0};
+   /// Range of entries created when no data source is specified.
+   std::pair<ULong64_t, ULong64_t> fEmptyEntryRange{};
    const unsigned int fNSlots{1};
    bool fMustRunNamedFilters{true};
    const ELoopType fLoopType; ///< The kind of event loop that is going to be run (e.g. on ROOT files, on no files)
@@ -186,7 +187,7 @@ public:
    const ColumnNames_t &GetDefaultColumnNames() const;
    TTree *GetTree() const;
    ::TDirectory *GetDirectory() const;
-   ULong64_t GetNEmptyEntries() const { return fNEmptyEntries; }
+   ULong64_t GetNEmptyEntries() const { return fEmptyEntryRange.second - fEmptyEntryRange.first; }
    RDataSource *GetDataSource() const { return fDataSource.get(); }
    void Register(RDFInternal::RActionBase *actionPtr);
    void Deregister(RDFInternal::RActionBase *actionPtr);
@@ -234,6 +235,8 @@ public:
    const ColumnNames_t &GetBranchNames();
 
    void AddSampleCallback(void *nodePtr, ROOT::RDF::SampleCallback_t &&callback);
+
+   void SetEmptyEntryRange(std::pair<ULong64_t, ULong64_t> &&newRange);
 };
 
 } // ns RDF

--- a/tree/dataframe/src/RInterface.cxx
+++ b/tree/dataframe/src/RInterface.cxx
@@ -1,0 +1,18 @@
+// Author: Vincenzo Eduardo Padulano, Axel Naumann, Enrico Guiraud CERN 02/2023
+
+/*************************************************************************
+ * Copyright (C) 1995-2023, Rene Brun and Fons Rademakers.               *
+ * All rights reserved.                                                  *
+ *                                                                       *
+ * For the licensing terms see $ROOTSYS/LICENSE.                         *
+ * For the list of contributors see $ROOTSYS/README/CREDITS.             *
+ *************************************************************************/
+
+#include "ROOT/RDF/RInterface.hxx"
+
+void ROOT::Internal::RDF::ChangeEmptyEntryRange(const ROOT::RDF::RNode &node,
+                                                std::pair<ULong64_t, ULong64_t> &&newRange)
+{
+   R__ASSERT(newRange.second >= newRange.first && "end is less than begin in the passed entry range!");
+   node.GetLoopManager()->SetEmptyEntryRange(std::move(newRange));
+}


### PR DESCRIPTION
UPDATE:
The RDataFrame created in each task can now be modified with the correct entry range of the task via an internal function. The internal representation in case of an RDataFrame with no data source has been modified to store a pair of integers indicating the range, instead of only one integer. This is only for internal purposes, the public API is unchanged


See https://github.com/root-project/roottest/pull/923 for test changes