### PR TITLE
VDT Usage Fix, master branch (2022.12.06.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -605,6 +605,9 @@ if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_INSTALL_PREFIX)
     cmake/modules/RootMacros.cmake
     cmake/modules/RootTestDriver.cmake
     DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
+  install(FILES
+    "cmake/modules/FindVdt.cmake"
+    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}/modules")
 endif()
 
 #---Add configuration files for kernel and jupyter----------------------------------------------

--- a/cmake/modules/RootConfiguration.cmake
+++ b/cmake/modules/RootConfiguration.cmake
@@ -756,6 +756,10 @@ set(ROOT_BINARY_DIR_SETUP "
 # Deprecated value, please don't use it and use ROOT_BINDIR instead.
 set(ROOT_BINARY_DIR ${ROOT_BINDIR})
 ")
+set(ROOT_CMAKE_DIR_SETUP "
+# ROOT configured for use from the build tree - absolute paths are used.
+set(ROOT_CMAKE_DIR ${CMAKE_SOURCE_DIR}/cmake)
+")
 
 get_property(exported_targets GLOBAL PROPERTY ROOT_EXPORTED_TARGETS)
 export(TARGETS ${exported_targets} NAMESPACE ROOT:: FILE ${PROJECT_BINARY_DIR}/ROOTConfig-targets.cmake)
@@ -794,6 +798,10 @@ get_filename_component(ROOT_BINDIR \"\${_ROOT_BINDIR}\" REALPATH)
 set(ROOT_BINARY_DIR_SETUP "
 # Deprecated value, please don't use it and use ROOT_BINDIR instead.
 get_filename_component(ROOT_BINARY_DIR \"\${ROOT_BINDIR}\" REALPATH)
+")
+set(ROOT_CMAKE_DIR_SETUP "
+## ROOT configured for the install with relative paths, so use these
+get_filename_component(ROOT_CMAKE_DIR \"\${_thisdir}\" REALPATH)
 ")
 
 # used by ROOTConfig.cmake from the build directory

--- a/cmake/modules/SearchInstalledSoftware.cmake
+++ b/cmake/modules/SearchInstalledSoftware.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2021, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -1678,6 +1678,12 @@ if(vdt OR builtin_vdt)
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT extra-headers)
     set(vdt ON CACHE BOOL "Enabled because builtin_vdt enabled (${vdt_description})" FORCE)
     set_property(GLOBAL APPEND PROPERTY ROOT_BUILTIN_TARGETS VDT)
+    add_library(VDT::VDT STATIC IMPORTED GLOBAL)
+    set_target_properties(VDT::VDT
+      PROPERTIES
+        IMPORTED_LOCATION "${VDT_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${VDT_INCLUDE_DIRS}"
+    )
   endif()
 endif()
 

--- a/cmake/scripts/ROOTConfig.cmake.in
+++ b/cmake/scripts/ROOTConfig.cmake.in
@@ -61,6 +61,7 @@ get_filename_component(_thisdir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 @ROOT_LIBRARY_DIR_SETUP@
 @ROOT_BINDIR_SETUP@
 @ROOT_BINARY_DIR_SETUP@
+@ROOT_CMAKE_DIR_SETUP@
 
 # Python version used to build ROOT
 set(ROOT_PYTHON_VERSION @PYTHON_VERSION_STRING_Development_Main@)
@@ -85,6 +86,10 @@ foreach(_opt ${_root_enabled_options})
 endforeach()
 
 #----------------------------------------------------------------------------
+# Make any modules bundled with ROOT visible to CMake
+list(APPEND CMAKE_MODULE_PATH "${ROOT_CMAKE_DIR}/modules")
+
+#----------------------------------------------------------------------------
 # Find external packages which were used in ROOT
 include(CMakeFindDependencyMacro)
 if (NOT ROOT_builtin_nlohmannjson_FOUND)
@@ -96,6 +101,9 @@ endif()
 if(ROOT_minuit2_omp_FOUND)
   find_dependency(OpenMP)
   find_dependency(Threads)
+endif()
+if(ROOT_vdt_FOUND AND NOT TARGET VDT::VDT)
+  find_dependency(Vdt)
 endif()
 
 #----------------------------------------------------------------------------

--- a/math/vecops/CMakeLists.txt
+++ b/math/vecops/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -7,10 +7,6 @@
 ############################################################################
 # CMakeLists.txt file for building ROOT math/vecops package
 ############################################################################
-
-if(builtin_vdt)
-  link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-endif()
 
 ROOT_STANDARD_LIBRARY_PACKAGE(ROOTVecOps
   HEADERS
@@ -24,13 +20,10 @@ ROOT_STANDARD_LIBRARY_PACKAGE(ROOTVecOps
 )
 
 if(builtin_vdt OR vdt)
-   target_include_directories(ROOTVecOps PRIVATE ${VDT_INCLUDE_DIRS} INTERFACE $<BUILD_INTERFACE:${VDT_INCLUDE_DIRS}>)
+  target_link_libraries(ROOTVecOps PUBLIC VDT::VDT)
 endif()
-
 if(builtin_vdt)
-  target_link_libraries(ROOTVecOps PRIVATE ${VDT_LIBRARIES})
-elseif(vdt)
-  target_link_libraries(ROOTVecOps PUBLIC ${VDT_LIBRARIES})
+  add_dependencies(ROOTVecOps VDT)
 endif()
 
 if(MSVC)

--- a/roofit/batchcompute/CMakeLists.txt
+++ b/roofit/batchcompute/CMakeLists.txt
@@ -8,7 +8,10 @@ ROOT_LINKER_LIBRARY(RooBatchCompute
 )
 
 if(vdt OR builtin_vdt)
-  target_include_directories(RooBatchCompute PRIVATE ${VDT_INCLUDE_DIRS} INTERFACE $<BUILD_INTERFACE:${VDT_INCLUDE_DIRS}>)
+  target_link_libraries(RooBatchCompute PUBLIC VDT::VDT)
+endif()
+if(builtin_vdt)
+  add_dependencies(RooBatchCompute VDT)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 1995-2019, Rene Brun and Fons Rademakers.
+# Copyright (C) 1995-2022, Rene Brun and Fons Rademakers.
 # All rights reserved.
 #
 # For the licensing terms see $ROOTSYS/LICENSE.
@@ -433,6 +433,7 @@ if (NOT cxxmodules)
     ROOT_ADD_TEST(test-periodic-build
       COMMAND ${CMAKE_CTEST_COMMAND} ${build_generator_args}
         --build-and-test ${CMAKE_CURRENT_SOURCE_DIR}/periodic periodic-build
+        --build-options -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
     )
   else()
     ROOT_ADD_TEST(test-periodic-build
@@ -440,6 +441,7 @@ if (NOT cxxmodules)
         env CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
         ${CMAKE_CTEST_COMMAND} --build-generator ${CMAKE_GENERATOR}
         --build-and-test ${CMAKE_CURRENT_SOURCE_DIR}/periodic periodic-build
+        --build-options -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
     )
   endif()
 endif()

--- a/tmva/tmva/CMakeLists.txt
+++ b/tmva/tmva/CMakeLists.txt
@@ -435,7 +435,10 @@ if(MSVC)
 endif()
 
 if(vdt OR builtin_vdt)
-  target_include_directories(TMVA PRIVATE ${VDT_INCLUDE_DIRS})
+  target_link_libraries(TMVA PRIVATE VDT::VDT)
+endif()
+if(builtin_vdt)
+  add_dependencies(TMVA VDT)
 endif()
 
 if(tmva-cpu)


### PR DESCRIPTION
# This Pull request:

Simplified/fixed how VDT would be used. Did this by making `ROOTVecOps`, `RooBatchCompute` and `TMVA` link against `VDT::VDT` in all circumstances (as long as VDT is being used). Regardless of whether VDT is used as a "builtin" or as an "external". At the same time made `ROOTVecOps` and `RooBatchCompute` depend on `VDT::VDT` publicly, as they actually do.

## Changes or fixes:

  - Made sure that an imported `VDT::VDT` library would be set up when `builtin_vdt` is being used.
  - Simplified how `ROOTVecOps`, `RooBatchCompute` and `TMVA` would just (publicly) link against `VDT::VDT` if either `vdt` or `builtin_vdt` is `TRUE`. Instead of the spaghetti of options that it had before.
  - Made sure that all of those targets would explicitly depend on the `VDT` target if `builtin_vdt` is set to `TRUE`.
  - Made sure that VDT would be searched for when calling `find_package(ROOT)` in client code.

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes #11797.