### PR TITLE
v6-26: Avoid TPad::fFrame double delete when read from file

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -2878,6 +2878,10 @@ TFrame *TPad::GetFrame()
       fFrame->SetLineWidth(GetFrameLineWidth());
       fFrame->SetBorderSize(GetFrameBorderSize());
       fFrame->SetBorderMode(GetFrameBorderMode());
+   } else {
+      // Preexisting and now assigned to fFrame, let's make sure it is not
+      // deleted twice (the bit might have been set in TPad::Streamer)
+      fFrame->ResetBit(kCanDelete);
    }
    return fFrame;
 }


### PR DESCRIPTION
This fixes #11747

As seen in https://github.com/cms-sw/cmssw/issues/40091 the code in `TPad::Close`:
```
   if (fPrimitives)
      fPrimitives->Clear();
   if (fView) {
      if (!ROOT::Detail::HasBeenDeleted(fView)) delete fView;
      fView = nullptr;
   }
   if (fFrame) {
      if (!ROOT::Detail::HasBeenDeleted(fFrame)) delete fFrame;
      fFrame = nullptr;
   }
```
is failing in the case of reading a pad from a file in at least some circumstances.

`TPad::Streamer` explicit set the bit `kCanDelete` on all objects in the list of primitives, thus including the view and the frame which have their `kCanDelete` bit explicitly reset elsewhere (in the code run during the initial creation of the frame and view).

This means that avoiding the a double deletion (the first is now during the `fPrimitives->Clear()`) relies on the heuristic of `HasBeenDeleted` to work properly, at least in the case seen in cmssw above) it does not and lead to crash.

Backport of https://github.com/root-project/root/pull/11763