### PR TITLE
Update TColor enum since rainbow is one word

### DIFF
--- a/core/base/inc/TColor.h
+++ b/core/base/inc/TColor.h
@@ -125,6 +125,7 @@ public:
                        kStarryNight=102,     kSunset=103,      kTemperatureMap=104,
                        kThermometer=105,     kValentine=106,   kVisibleSpectrum=107,
                        kWaterMelon=108,      kCool=109,        kCopper=110,
-                       kGistEarth=111,       kViridis=112,     kCividis=113};
+                       kGistEarth=111,       kViridis=112,     kCividis=113,
+                       kRainbow=kRainBow,    kDarkRainbow=kDarkRainBow};
 #endif
 


### PR DESCRIPTION
Hello ROOTers! This is a proposal to allow `kRainBow` or `kRainbow`. I think I have accidentally called `kRainbow` a thousand times. But it is a justified accident, since rainbow is one word.

C/C++ enums allow multiple keys to have the same value, so this proposal would not impact existing use of `kRainBow`.