### PR TITLE
Adjust `TApplication::InitializeGraphics()` for web case

### DIFF
--- a/core/base/inc/TApplication.h
+++ b/core/base/inc/TApplication.h
@@ -100,7 +100,7 @@ public:
                 void *options = nullptr, Int_t numOptions = 0);
    virtual ~TApplication();
 
-   void            InitializeGraphics();
+   void            InitializeGraphics(Bool_t only_web = kFALSE);
    virtual void    GetOptions(Int_t *argc, char **argv);
    TSignalHandler *GetSignalHandler() const { return fSigHandler; }
    virtual void    SetEchoMode(Bool_t mode);

--- a/core/base/inc/TROOT.h
+++ b/core/base/inc/TROOT.h
@@ -315,7 +315,7 @@ public:
    void              SaveContext();
    void              SetApplication(TApplication *app) { fApplication = app; }
    void              SetBatch(Bool_t batch = kTRUE) { fIsWebDisplayBatch = fBatch = batch; }
-   void              SetWebDisplay(const char *webdisplay);
+   void              SetWebDisplay(const char *webdisplay = "");
    void              SetCutClassName(const char *name = "TCutG");
    void              SetDefCanvasName(const char *name = "c1") { fDefCanvasName = name; }
    void              SetEditHistograms(Bool_t flag = kTRUE) { fEditHistograms = flag; }

--- a/core/base/src/TColor.cxx
+++ b/core/base/src/TColor.cxx
@@ -1496,7 +1496,7 @@ ULong_t TColor::GetPixel() const
    if (gVirtualX && !gROOT->IsBatch()) {
       if (gApplication) {
          TApplication::NeedGraphicsLibs();
-         gApplication->InitializeGraphics();
+         gApplication->InitializeGraphics(gROOT->IsWebDisplay());
       }
       return gVirtualX->GetPixel(fNumber);
    }

--- a/core/gui/inc/TBrowser.h
+++ b/core/gui/inc/TBrowser.h
@@ -37,16 +37,16 @@ class TBrowserTimer;
 class TBrowser : public TNamed {
 
 private:
-   TObject       *fLastSelectedObject; //!The last TObject selected by user
+   TObject       *fLastSelectedObject{nullptr}; //!The last TObject selected by user
 
    TBrowser(const TBrowser&) = delete;             // TBrowser can not be copied since we do not know the type of the TBrowserImp (and it can not be 'Cloned')
    TBrowser& operator=(const TBrowser&) = delete;  // TBrowser can not be copied since we do not know the type of the TBrowserImp (and it can not be 'Cloned')
 
 protected:
-   TBrowserImp   *fImp;                //!Window system specific browser implementation
-   TBrowserTimer *fTimer;              //!Browser's timer
-   TContextMenu  *fContextMenu;        //!Context menu pointer
-   Bool_t         fNeedRefresh;        //True if the browser needs refresh
+   TBrowserImp   *fImp{nullptr};                //!Window system specific browser implementation
+   TBrowserTimer *fTimer{nullptr};              //!Browser's timer
+   TContextMenu  *fContextMenu{nullptr};        //!Context menu pointer
+   Bool_t         fNeedRefresh{kFALSE};         //True if the browser needs refresh
 
    Bool_t         InitGraphics();
 

--- a/core/gui/src/TBrowser.cxx
+++ b/core/gui/src/TBrowser.cxx
@@ -112,13 +112,15 @@ Bool_t TBrowser::InitGraphics()
       TApplication::CreateApplication();
    // make sure that the Gpad and GUI libs are loaded
    TApplication::NeedGraphicsLibs();
+
+   TString hname = gEnv->GetValue("Browser.Name", "TRootBrowserLite");
+
+   Bool_t isweb = gROOT->IsWebDisplay() || (hname == "ROOT::Experimental::RWebBrowserImp");
+
    if (gApplication)
-      gApplication->InitializeGraphics();
+      gApplication->InitializeGraphics(isweb);
 
-   if (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch())
-      return kTRUE;
-
-   if (!gROOT->IsBatch())
+   if (!gROOT->IsBatch() || (isweb && !gROOT->IsWebDisplayBatch()))
       return kTRUE;
 
    Warning("TBrowser", "The ROOT browser cannot run in batch mode");
@@ -131,10 +133,8 @@ Bool_t TBrowser::InitGraphics()
 /// (depending on Rint.Canvas.UseScreenFactor to be true or false, default
 /// is true).
 
-TBrowser::TBrowser(const char *name, const char *title, TBrowserImp *extimp,
-                   Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(extimp), fTimer(nullptr),
-     fContextMenu(nullptr), fNeedRefresh(kFALSE)
+TBrowser::TBrowser(const char *name, const char *title, TBrowserImp *extimp, Option_t *opt)
+   : TNamed(name, title), fImp(extimp)
 {
    if (!InitGraphics())
       return;
@@ -144,7 +144,8 @@ TBrowser::TBrowser(const char *name, const char *title, TBrowserImp *extimp,
       Float_t cx = gStyle->GetScreenFactor();
       UInt_t w = UInt_t(cx*800);
       UInt_t h = UInt_t(cx*500);
-      if (!fImp) fImp = gGuiFactory->CreateBrowserImp(this, title, w, h, opt);
+      if (!fImp)
+         fImp = gGuiFactory->CreateBrowserImp(this, title, w, h, opt);
       Create();
    }
 }
@@ -154,12 +155,12 @@ TBrowser::TBrowser(const char *name, const char *title, TBrowserImp *extimp,
 
 TBrowser::TBrowser(const char *name, const char *title, UInt_t width,
                    UInt_t height, TBrowserImp *extimp, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(extimp), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title), fImp(extimp)
 {
    if (!InitGraphics())
       return;
-   if (!fImp) fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
    Create();
 }
 
@@ -168,12 +169,12 @@ TBrowser::TBrowser(const char *name, const char *title, UInt_t width,
 
 TBrowser::TBrowser(const char *name, const char *title, Int_t x, Int_t y,
                    UInt_t width, UInt_t height, TBrowserImp *extimp, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(extimp), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title), fImp(extimp)
 {
    if (!InitGraphics())
       return;
-   fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
    Create();
 }
 
@@ -181,8 +182,7 @@ TBrowser::TBrowser(const char *name, const char *title, Int_t x, Int_t y,
 /// Create a new browser with a name, title, width and height for TObject *obj.
 
 TBrowser::TBrowser(const char *name, TObject *obj, const char *title, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(nullptr), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title)
 {
    if (!InitGraphics())
       return;
@@ -190,7 +190,8 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title, Option_t *
    UInt_t w = UInt_t(cx*800);
    UInt_t h = UInt_t(cx*500);
 
-   if (!fImp) fImp = gGuiFactory->CreateBrowserImp(this, title, w, h, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, w, h, opt);
    Create(obj);
 }
 
@@ -199,12 +200,12 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title, Option_t *
 
 TBrowser::TBrowser(const char *name, TObject *obj, const char *title,
                    UInt_t width, UInt_t height, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(nullptr), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title)
 {
    if (!InitGraphics())
       return;
-   fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
    Create(obj);
 }
 
@@ -214,12 +215,12 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title,
 TBrowser::TBrowser(const char *name, TObject *obj, const char *title,
                    Int_t x, Int_t y,
                    UInt_t width, UInt_t height, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(nullptr), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title)
 {
    if (!InitGraphics())
       return;
-   fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
    Create(obj);
 }
 
@@ -228,8 +229,7 @@ TBrowser::TBrowser(const char *name, TObject *obj, const char *title,
 
 TBrowser::TBrowser(const char *name, void *obj, TClass *cl,
                    const char *objname, const char *title, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(nullptr), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title)
 {
    if (!InitGraphics())
       return;
@@ -237,7 +237,8 @@ TBrowser::TBrowser(const char *name, void *obj, TClass *cl,
    UInt_t w = UInt_t(cx*800);
    UInt_t h = UInt_t(cx*500);
 
-   fImp = gGuiFactory->CreateBrowserImp(this, title, w, h, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, w, h, opt);
 
    Create(new TBrowserObject(obj,cl,objname));
 }
@@ -248,12 +249,12 @@ TBrowser::TBrowser(const char *name, void *obj, TClass *cl,
 TBrowser::TBrowser(const char *name, void *obj, TClass *cl,
                    const char *objname, const char *title,
                    UInt_t width, UInt_t height, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(nullptr), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title)
 {
    if (!InitGraphics())
       return;
-   fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, width, height, opt);
    Create(new TBrowserObject(obj,cl,objname));
 }
 
@@ -264,12 +265,12 @@ TBrowser::TBrowser(const char *name,void *obj,  TClass *cl,
                    const char *objname, const char *title,
                    Int_t x, Int_t y,
                    UInt_t width, UInt_t height, Option_t *opt)
-   : TNamed(name, title), fLastSelectedObject(nullptr), fImp(nullptr), fTimer(nullptr), fContextMenu(nullptr),
-     fNeedRefresh(kFALSE)
+   : TNamed(name, title)
 {
    if (!InitGraphics())
       return;
-   fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
+   if (!fImp)
+      fImp = gGuiFactory->CreateBrowserImp(this, title, x, y, width, height, opt);
    Create(new TBrowserObject(obj,cl,objname));
 }
 

--- a/core/gui/src/TGuiFactory.cxx
+++ b/core/gui/src/TGuiFactory.cxx
@@ -91,8 +91,15 @@ TCanvasImp *TGuiFactory::CreateCanvasImp(TCanvas *c, const char *title, Int_t x,
 
 TBrowserImp *TGuiFactory::CreateBrowserImp(TBrowser *b, const char *title, UInt_t width, UInt_t height, Option_t *opt)
 {
-   if (gROOT->IsWebDisplay()) {
-      auto ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp", "ROOT::Experimental::RWebBrowserImp");
+   const char *browserName = nullptr;
+
+   if (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch())
+      browserName = "ROOT::Experimental::RWebBrowserImp";
+   else if (!gROOT->IsBatch())
+      browserName = gEnv->GetValue("Browser.Name", "");
+
+   if (browserName && *browserName) {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp", browserName);
 
       if (ph && ph->LoadPlugin() != -1) {
          TBrowserImp *imp = (TBrowserImp *)ph->ExecPlugin(5, b, title, width, height, opt);
@@ -108,8 +115,15 @@ TBrowserImp *TGuiFactory::CreateBrowserImp(TBrowser *b, const char *title, UInt_
 
 TBrowserImp *TGuiFactory::CreateBrowserImp(TBrowser *b, const char *title, Int_t x, Int_t y, UInt_t width, UInt_t height, Option_t *opt)
 {
-   if (gROOT->IsWebDisplay()) {
-      auto ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp", "ROOT::Experimental::RWebBrowserImp");
+   const char *browserName = nullptr;
+
+   if (gROOT->IsWebDisplay() && !gROOT->IsWebDisplayBatch())
+      browserName = "ROOT::Experimental::RWebBrowserImp";
+   else if (!gROOT->IsBatch())
+      browserName = gEnv->GetValue("Browser.Name", "");
+
+   if (browserName && *browserName) {
+      auto ph = gROOT->GetPluginManager()->FindHandler("TBrowserImp", browserName);
 
       if (ph && ph->LoadPlugin() != -1) {
          TBrowserImp *imp = (TBrowserImp *)ph->ExecPlugin(7, b, title, x, y, width, height, opt);

--- a/graf2d/gpad/src/TCanvas.cxx
+++ b/graf2d/gpad/src/TCanvas.cxx
@@ -321,19 +321,20 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t form)
    } else {                  //normal mode with a screen window
       Float_t cx = gStyle->GetScreenFactor();
       if (form < 1 || form > 5) form = 1;
+      auto factory = gROOT->IsWebDisplay() ? gBatchGuiFactory : gGuiFactory;
       if (form == 1) {
          UInt_t uh = UInt_t(cx*gStyle->GetCanvasDefH());
          UInt_t uw = UInt_t(cx*gStyle->GetCanvasDefW());
          Int_t  ux = Int_t(cx*gStyle->GetCanvasDefX());
          Int_t  uy = Int_t(cx*gStyle->GetCanvasDefY());
-         fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, ux, uy, uw, uh);
+         fCanvasImp = factory->CreateCanvasImp(this, name, ux, uy, uw, uh);
       }
       fCw = 500;
       fCh = 500;
-      if (form == 2) fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, 20, 20, UInt_t(cx*500), UInt_t(cx*500));
-      if (form == 3) fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, 30, 30, UInt_t(cx*500), UInt_t(cx*500));
-      if (form == 4) fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, 40, 40, UInt_t(cx*500), UInt_t(cx*500));
-      if (form == 5) fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, 50, 50, UInt_t(cx*500), UInt_t(cx*500));
+      if (form == 2) fCanvasImp = factory->CreateCanvasImp(this, name, 20, 20, UInt_t(cx*500), UInt_t(cx*500));
+      if (form == 3) fCanvasImp = factory->CreateCanvasImp(this, name, 30, 30, UInt_t(cx*500), UInt_t(cx*500));
+      if (form == 4) fCanvasImp = factory->CreateCanvasImp(this, name, 40, 40, UInt_t(cx*500), UInt_t(cx*500));
+      if (form == 5) fCanvasImp = factory->CreateCanvasImp(this, name, 50, 50, UInt_t(cx*500), UInt_t(cx*500));
       if (!fCanvasImp) return;
 
       if (!gROOT->IsBatch() && fCanvasID == -1)
@@ -418,7 +419,8 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t ww, Int_t w
       fBatch        = kTRUE;
    } else {
       Float_t cx = gStyle->GetScreenFactor();
-      fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, UInt_t(cx*ww), UInt_t(cx*wh));
+      auto factory = gROOT->IsWebDisplay() ? gBatchGuiFactory : gGuiFactory;
+      fCanvasImp = factory->CreateCanvasImp(this, name, UInt_t(cx*ww), UInt_t(cx*wh));
       if (!fCanvasImp) return;
 
       if (!gROOT->IsBatch() && fCanvasID == -1)
@@ -504,7 +506,8 @@ void TCanvas::Constructor(const char *name, const char *title, Int_t wtopx,
       fBatch        = kTRUE;
    } else {                   //normal mode with a screen window
       Float_t cx = gStyle->GetScreenFactor();
-      fCanvasImp = gGuiFactory->CreateCanvasImp(this, name, Int_t(cx*wtopx), Int_t(cx*wtopy), UInt_t(cx*ww), UInt_t(cx*wh));
+      auto factory = gROOT->IsWebDisplay() ? gBatchGuiFactory : gGuiFactory;
+      fCanvasImp = factory->CreateCanvasImp(this, name, Int_t(cx*wtopx), Int_t(cx*wtopy), UInt_t(cx*ww), UInt_t(cx*wh));
       if (!fCanvasImp) return;
 
       if (!gROOT->IsBatch() && fCanvasID == -1)
@@ -538,7 +541,7 @@ void TCanvas::Init()
    // TApplication::NeedGraphicsLibs() has been called by a
    // library static initializer.
    if (gApplication)
-      gApplication->InitializeGraphics();
+      gApplication->InitializeGraphics(gROOT->IsWebDisplay());
 
    // Get some default from .rootrc. Used in fCanvasImp->InitWindow().
    fHighLightColor     = gEnv->GetValue("Canvas.HighLightColor", kRed);
@@ -841,8 +844,8 @@ void TCanvas::CopyPixmaps()
 /// This function is useful when a canvas object has been saved in a Root file.
 /// One can then do:
 /// ~~~ {.cpp}
-///     Root > Tfile f("file.root");
-///     Root > canvas.Draw();
+///     Root > TFile::Open("file.root");
+///     Root > canvas->Draw();
 /// ~~~
 
 void TCanvas::Draw(Option_t *)
@@ -851,7 +854,7 @@ void TCanvas::Draw(Option_t *)
    // TApplication::NeedGraphicsLibs() has been called by a
    // library static initializer.
    if (gApplication)
-      gApplication->InitializeGraphics();
+      gApplication->InitializeGraphics(gROOT->IsWebDisplay());
 
    fDrawn = kTRUE;
 
@@ -876,7 +879,8 @@ void TCanvas::Draw(Option_t *)
       fBatch = kTRUE;
 
    } else {                   //normal mode with a screen window
-      fCanvasImp = gGuiFactory->CreateCanvasImp(this, GetName(), fWindowTopX, fWindowTopY,
+      auto factory = gROOT->IsWebDisplay() ? gBatchGuiFactory : gGuiFactory;
+      fCanvasImp = factory->CreateCanvasImp(this, GetName(), fWindowTopX, fWindowTopY,
                                                 fWindowWidth, fWindowHeight);
       if (!fCanvasImp) return;
       fCanvasImp->ShowMenuBar(TestBit(kMenuBar));
@@ -921,7 +925,8 @@ TObject *TCanvas::DrawClonePad()
       return newCanvas;
    }
    if (fCanvasID == -1) {
-      fCanvasImp = gGuiFactory->CreateCanvasImp(this, GetName(), fWindowTopX, fWindowTopY,
+      auto factory = gROOT->IsWebDisplay() ? gBatchGuiFactory : gGuiFactory;
+      fCanvasImp = factory->CreateCanvasImp(this, GetName(), fWindowTopX, fWindowTopY,
                                              fWindowWidth, fWindowHeight);
       if (!fCanvasImp) return nullptr;
       fCanvasImp->ShowMenuBar(TestBit(kMenuBar));

--- a/tree/treeplayer/src/TTreePlayer.cxx
+++ b/tree/treeplayer/src/TTreePlayer.cxx
@@ -2956,11 +2956,12 @@ void TTreePlayer::StartViewer(Int_t ww, Int_t wh)
    if (!gApplication)
       TApplication::CreateApplication();
    // make sure that the Gpad and GUI libs are loaded
-   TApplication::NeedGraphicsLibs();
-   if (gApplication)
-      gApplication->InitializeGraphics();
 
    TString hname = gEnv->GetValue("TreeViewer.Name", "TTreeViewer");
+
+   TApplication::NeedGraphicsLibs();
+   if (gApplication)
+      gApplication->InitializeGraphics(hname == "RTreeViewer");
 
    if (gROOT->IsBatch()) {
       if ((hname != "RTreeViewer") || gROOT->IsWebDisplayBatch()) {


### PR DESCRIPTION
If respective widget (TBrowser, TCanvas, TTreeViewer) want to start web-based implementation,
only minimal graphics initialization is necessary.

Let possibility to really initialize graphics when web display is disabled and normal widget is started.

In TCanvas use batch gui factory to create web-based TWebCanvas. It is done for the case when normal graphics (with its gui factory) was loaded, but then web display was enabled.

