### PR TITLE
[cppyy] Do not set batch mode, let ROOT handle that:

### DIFF
--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
@@ -272,10 +272,6 @@ public:
                "#include <utility>";
         gInterpreter->ProcessLine(code);
 
-    // make sure we run in batch mode as far as ROOT graphics is concerned
-        if (!getenv("ROOTSYS"))
-            gROOT->SetBatch(kTRUE);
-
     // create helpers for comparing thingies
         gInterpreter->Declare(
             "namespace __cppyy_internal { template<class C1, class C2>"

--- a/bindings/pyroot/cppyy/patches/0001-cppyy-Do-not-set-batch-mode-let-ROOT-handle-that.patch
+++ b/bindings/pyroot/cppyy/patches/0001-cppyy-Do-not-set-batch-mode-let-ROOT-handle-that.patch
@@ -1,0 +1,27 @@
+From 9ea70187c715fa29daddba28be7b5bb0d991eb28 Mon Sep 17 00:00:00 2001
+From: Axel Naumann <Axel.Naumann@cern.ch>
+Date: Thu, 8 Dec 2022 14:48:18 +0100
+Subject: [PATCH] [cppyy] Do not set batch mode, let ROOT handle that.
+
+---
+ .../cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx     | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+index 70cff54dcd..eaef4605da 100644
+--- a/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
++++ b/bindings/pyroot/cppyy/cppyy-backend/clingwrapper/src/clingwrapper.cxx
+@@ -272,10 +272,6 @@ public:
+                "#include <utility>";
+         gInterpreter->ProcessLine(code);
+ 
+-    // make sure we run in batch mode as far as ROOT graphics is concerned
+-        if (!getenv("ROOTSYS"))
+-            gROOT->SetBatch(kTRUE);
+-
+     // create helpers for comparing thingies
+         gInterpreter->Declare(
+             "namespace __cppyy_internal { template<class C1, class C2>"
+-- 
+2.37.2
+

--- a/bindings/pyroot/pythonizations/python/ROOT/__init__.py
+++ b/bindings/pyroot/pythonizations/python/ROOT/__init__.py
@@ -23,9 +23,6 @@ environ['CPPYY_NO_ROOT_FILTER'] = '1'
 from . import _asan
 
 import cppyy
-if not 'ROOTSYS' in environ:
-    # Revert setting made by cppyy
-    cppyy.gbl.gROOT.SetBatch(False)
 
 # import libROOTPythonizations with Python version number
 import sys, importlib


### PR DESCRIPTION
With `ROOTSYS` unset and no `DISPLAY` variable, this setup causes a spurious warning about an unset `DISPLAY`. `TROOT()` calls `SetBatch(true)`, then cppyy "agrees", and `ROOT/__init__.py` tries to revert that. Just let everyone keep their hands off `SetBatch()` (as is done in newer cppyy anyway).

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

