### PR TITLE
[rmkdepend] Use snprintf against warning (GCC 12.2):

### DIFF
--- a/build/rmkdepend/def.h
+++ b/build/rmkdepend/def.h
@@ -32,6 +32,9 @@ in this Software without prior written authorization from the X Consortium.
 #define _POSIX_SOURCE
 #endif
 #endif
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE
+#endif
 #include <stdio.h>
 #ifndef X_NOT_STDC_ENV
 #include <string.h>

--- a/build/rmkdepend/include.c
+++ b/build/rmkdepend/include.c
@@ -303,7 +303,7 @@ struct inclist *inc_path(char *file, char *include, boolean dot) {
             warning1("\t%s/%s too long\n", *pp, include);
             continue;
          }
-         sprintf(path, "%s/%s", *pp, include);
+         snprintf(path, BUFSIZ, "%s/%s", *pp, include);
          remove_dotdot(path);
 #ifdef _WIN32
          if (stat(path, &st) == 0 && (st.st_mode & S_IFREG)) {


### PR DESCRIPTION
```
build/rmkdepend/include.c:306:28: warning: ‘%s’ directive writing up to 8190 bytes into a region of size between 1 and 8191 [-Wformat-overflow=]
  306 |          sprintf(path, "%s/%s", *pp, include);
      |                            ^~
```

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

