### PR TITLE
Avoid leaking TBaskets in Bulk I/O operations

### DIFF
--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1619,6 +1619,12 @@ Int_t TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *
       }
    }
 
+   if (fCurrentBasket == nullptr) {
+      R__ASSERT(fExtraBasket == nullptr && "fExtraBasket should have been set to nullptr by GetFreshBasket");
+      fExtraBasket = basket;
+      basket->DisownBuffer();
+   }
+
    return N;
 }
 
@@ -1897,7 +1903,7 @@ TBasket *TBranch::GetFreshCluster(TBuffer* user_buffer)
       if (fExtraBasket) {
          newbasket = fExtraBasket;
          fExtraBasket = nullptr;
-      } else { 
+      } else {
          newbasket = fTree->CreateBasket(this);
       }
       if (user_buffer)

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -464,6 +464,8 @@ TBranch::~TBranch()
    delete [] fBasketBytes;
    fBasketBytes = 0;
 
+   if (fExtraBasket && !fBaskets.Remove(fExtraBasket))
+      delete fExtraBasket;
    fBaskets.Delete();
    fNBaskets = 0;
    fCurrentBasket = 0;


### PR DESCRIPTION
* TBranch::GetEntriesSerialized: actually reuse baskets inside of simply leaking them
  This applies fixes that were introduce to GetBulkEntries in 61c9927 and 60ad148
* Prevent leak of ready-to-reuse basket.

This fixes https://github.com/root-project/root/issues/11853

