### PR TITLE
Fix compilation with VS 2022 v17.4

### DIFF
--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -813,7 +813,7 @@ namespace {
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
-#if (_MSC_VER >= 1926)
+#if (_MSC_VER >= 1926 && _MSC_VER < 1930)
     // FIXME: Silly workaround for cling not being able to parse the STL
     //        headers anymore after the update of Visual Studio v16.7.0
     //        To be checked/removed after the upgrade of LLVM & Clang

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -813,12 +813,6 @@ namespace {
     PPOpts.addMacroDef("__CLING__GNUC_MINOR__=" ClingStringify(__GNUC_MINOR__));
 #elif defined(_MSC_VER)
     PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
-#if (_MSC_VER >= 1926 && _MSC_VER < 1930)
-    // FIXME: Silly workaround for cling not being able to parse the STL
-    //        headers anymore after the update of Visual Studio v16.7.0
-    //        To be checked/removed after the upgrade of LLVM & Clang
-    PPOpts.addMacroDef("_HAS_CONDITIONAL_EXPLICIT=0");
-#endif
 #endif
 
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html


### PR DESCRIPTION
This PR fixes the issue #10875 _HAS_CONDITIONAL_EXPLICIT=0 won't work with VS 2022 17.4
