### PR TITLE
Fix various problems in GDML writing with Geant4 units

### DIFF
--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -58,35 +58,31 @@ public:
    TGDMLWrite();
    virtual ~TGDMLWrite();
 
-   static void StartGDMLWriting(TGeoManager * geomanager, const char* filename, TString option) {
-      //static function -
-      //options:
-      //  g - set by default - geant4 compatibility
-      //  f,n - if none of this two is set then naming convention is
-      //        with incremental suffix, if "f" then suffix is pointer
-      //        if "n" then there is no suffix, but uniqness of names
-      //        is not secured.
+   static void StartGDMLWriting(TGeoManager *geomanager, const char *filename, TString option)
+   {
+      // static function -
+      // options:
+      //   g - set by default - geant4 compatibility
+      //   f,n - if none of this two is set then naming convention is
+      //         with incremental suffix, if "f" then suffix is pointer
+      //         if "n" then there is no suffix, but uniqness of names
+      //         is not secured.
       TGDMLWrite *writer = new TGDMLWrite;
       writer->SetFltPrecision(TGeoManager::GetExportPrecision());
       writer->WriteGDMLfile(geomanager, filename, option);
       delete writer;
    }
-   //wrapper of all main methods for extraction
-   void WriteGDMLfile(TGeoManager * geomanager, const char* filename = "test.gdml", TString option = "");
+   // wrapper of all main methods for extraction
+   void WriteGDMLfile(TGeoManager *geomanager, const char *filename = "test.gdml", TString option = "");
    // Wrapper to only selectively write one branch of the volume hierarchy to file
-   void WriteGDMLfile(TGeoManager * geomanager, TGeoNode* top_node, const char* filename = "test.gdml", TString option = "");
+   void
+   WriteGDMLfile(TGeoManager *geomanager, TGeoNode *top_node, const char *filename = "test.gdml", TString option = "");
 
-   enum ENamingType {
-      kelegantButSlow = 0,
-      kwithoutSufixNotUniq = 1,
-      kfastButUglySufix = 2
-   };
+   enum ENamingType { kelegantButSlow = 0, kwithoutSufixNotUniq = 1, kfastButUglySufix = 2 };
    // Ignore dummy material instance, which causes trouble reading GDML in Geant4
    void SetIgnoreDummyMaterial(bool value);
    void SetNamingSpeed(ENamingType naming);
-   void SetG4Compatibility(Bool_t G4Compatible) {
-      fgG4Compatibility = G4Compatible;
-   };
+   void SetG4Compatibility(Bool_t G4Compatible) { fgG4Compatibility = G4Compatible; };
    UInt_t GetFltPrecision() const { return fFltPrecision; }
    void SetFltPrecision(UInt_t prec) { fFltPrecision = prec; }
 
@@ -97,142 +93,144 @@ private:
       Double_t z;
    };
 
-   typedef  std::set<const TGeoOpticalSurface*> SurfaceList;
-   typedef  std::set<const TGeoVolume*> VolList;
-   typedef  std::set<const TGeoNode*>   NodeList;
-   typedef  std::map<TString, Bool_t>   NameList;
-   typedef  std::map<TString, TString>  NameListS;
-   typedef  std::map<TString, Int_t>    NameListI;
-   typedef  std::map<TString, Float_t>  NameListF;
+   typedef std::set<const TGeoOpticalSurface *> SurfaceList;
+   typedef std::set<const TGeoVolume *> VolList;
+   typedef std::set<const TGeoNode *> NodeList;
+   typedef std::map<TString, Bool_t> NameList;
+   typedef std::map<TString, TString> NameListS;
+   typedef std::map<TString, Int_t> NameListI;
+   typedef std::map<TString, Float_t> NameListF;
    struct StructLst {
       NameList fLst;
-   };     //to store pointers
+   }; // to store pointers
    struct NameLst {
-      NameListS fLst;        //to map pointers with names
-      NameListI fLstIter;    //to store all the iterators for repeating names
+      NameListS fLst;     // to map pointers with names
+      NameListI fLstIter; // to store all the iterators for repeating names
    };
 
-   //General lists
-   StructLst *fIsotopeList;   //list of isotopes
-   StructLst *fElementList;   //list of elements
-   StructLst *fAccPatt;       //list of accepted patterns for division
-   StructLst *fRejShape;      //list of rejected shapes
-   SurfaceList fSurfaceList;  //list of optical surfaces
-   VolList     fVolumeList;   //list of volumes
-   NodeList    fNodeList;     //list of placed volumes
+   // General lists
+   StructLst *fIsotopeList;  // list of isotopes
+   StructLst *fElementList;  // list of elements
+   StructLst *fAccPatt;      // list of accepted patterns for division
+   StructLst *fRejShape;     // list of rejected shapes
+   SurfaceList fSurfaceList; // list of optical surfaces
+   VolList fVolumeList;      // list of volumes
+   NodeList fNodeList;       // list of placed volumes
 
-   NameLst *fNameList; //list of names (pointer mapped)
+   NameLst *fNameList; // list of names (pointer mapped)
 
-   //Data members
-   static TGDMLWrite *fgGDMLWrite;                         //pointer to gdml writer
-   Int_t  fgNamingSpeed;                                   //input option for volume and solid naming
-   Int_t  fIgnoreDummyMaterial;                            //Flag to ignore TGeo's dummy material
-   Bool_t fgG4Compatibility;                               //input option for Geant4 compatibility
-   XMLDocPointer_t  fGdmlFile;                             //pointer storing xml file
-   TString fDefault_lunit;                                 //Default unit of length (depends on ROOT unit system)
-   TString fTopVolumeName;                                 //name of top volume
-   TGeoVolume *fTopVolume = nullptr;                       //top volume of the tree being written
-   TXMLEngine *fGdmlE;                                     //xml engine pointer
+   // Data members
+   static TGDMLWrite *fgGDMLWrite;   // pointer to gdml writer
+   Int_t fgNamingSpeed;              // input option for volume and solid naming
+   Int_t fIgnoreDummyMaterial;       // Flag to ignore TGeo's dummy material
+   Bool_t fgG4Compatibility;         // input option for Geant4 compatibility
+   XMLDocPointer_t fGdmlFile;        // pointer storing xml file
+   TString fDefault_lunit;           // Default unit of length (depends on ROOT unit system)
+   TString fTopVolumeName;           // name of top volume
+   TGeoVolume *fTopVolume = nullptr; // top volume of the tree being written
+   TXMLEngine *fGdmlE;               // xml engine pointer
 
-   XMLNodePointer_t fDefineNode;                           //main <define> node...
-   XMLNodePointer_t fMaterialsNode;                        //main <materials> node...
-   XMLNodePointer_t fSolidsNode;                           //main <solids> node...
-   XMLNodePointer_t fStructureNode;                        //main <structure> node...
-   Int_t        fVolCnt;                                   //count of volumes
-   Int_t        fPhysVolCnt;                               //count of physical volumes
-   UInt_t       fActNameErr;                               //count of name errors
-   UInt_t       fSolCnt;                                   //count of name solids
-   UInt_t       fFltPrecision;                             //! floating point precision when writing
+   XMLNodePointer_t fDefineNode;    // main <define> node...
+   XMLNodePointer_t fMaterialsNode; // main <materials> node...
+   XMLNodePointer_t fSolidsNode;    // main <solids> node...
+   XMLNodePointer_t fStructureNode; // main <structure> node...
+   Int_t fVolCnt;                   // count of volumes
+   Int_t fPhysVolCnt;               // count of physical volumes
+   UInt_t fActNameErr;              // count of name errors
+   UInt_t fSolCnt;                  // count of name solids
+   UInt_t fFltPrecision;            //! floating point precision when writing
 
-   static const UInt_t fgkProcBit    = BIT(14);    //14th bit is set when solid is processed
-   static const UInt_t fgkProcBitVol = BIT(19);    //19th bit is set when volume is processed
-   static const UInt_t fgkMaxNameErr = 5;          //maximum number of errors for naming
+   static const UInt_t fgkProcBit = BIT(14);    // 14th bit is set when solid is processed
+   static const UInt_t fgkProcBitVol = BIT(19); // 19th bit is set when volume is processed
+   static const UInt_t fgkMaxNameErr = 5;       // maximum number of errors for naming
 
-   //I. Methods processing the gGeoManager geometry object structure
-   //1. Main methods to extract everything from ROOT gGeoManager
-   XMLNodePointer_t ExtractMaterials(TList* materialsLst); //result <materials>...
-   TString          ExtractSolid(TGeoShape* volShape);     //adds <shape> to <solids>
-   void             ExtractVolumes(TGeoNode* topNode);    //result <volume> node...  + corresp. shape
-   void             ExtractMatrices(TObjArray *matrices);  //adds <matrix> to <define>
-   void             ExtractConstants(TGeoManager *geom);   //adds <constant> to <define>
-   void             ExtractOpticalSurfaces(TObjArray *surfaces); //adds <opticalsurface> to <solids>
-   void             ExtractSkinSurfaces(TObjArray *surfaces);    //adds <skinsurface> to <structure>
-   void             ExtractBorderSurfaces(TObjArray *surfaces);  //adds <bordersurface> to <structure>
+   // I. Methods processing the gGeoManager geometry object structure
+   // 1. Main methods to extract everything from ROOT gGeoManager
+   XMLNodePointer_t ExtractMaterials(TList *materialsLst); // result <materials>...
+   TString ExtractSolid(TGeoShape *volShape);              // adds <shape> to <solids>
+   void ExtractVolumes(TGeoNode *topNode);                 // result <volume> node...  + corresp. shape
+   void ExtractMatrices(TObjArray *matrices);              // adds <matrix> to <define>
+   void ExtractConstants(TGeoManager *geom);               // adds <constant> to <define>
+   void ExtractOpticalSurfaces(TObjArray *surfaces);       // adds <opticalsurface> to <solids>
+   void ExtractSkinSurfaces(TObjArray *surfaces);          // adds <skinsurface> to <structure>
+   void ExtractBorderSurfaces(TObjArray *surfaces);        // adds <bordersurface> to <structure>
 
    // Combined implementation to extract GDML information from the geometry tree
-   void WriteGDMLfile(TGeoManager * geomanager, TGeoNode* top_node, TList* materialsLst, const char* filename, TString option);
+   void WriteGDMLfile(TGeoManager *geomanager, TGeoNode *top_node, TList *materialsLst, const char *filename,
+                      TString option);
 
-   //1.1 Materials sub methods - creating Nodes
-   XMLNodePointer_t CreateAtomN(Double_t atom, const char * unit = "g/mole");
-   XMLNodePointer_t CreateDN(Double_t density, const char * unit = "g/cm3");
-   XMLNodePointer_t CreateFractionN(Double_t percentage, const char * refName);
+   // 1.1 Materials sub methods - creating Nodes
+   XMLNodePointer_t CreateAtomN(Double_t atom, const char *unit = "g/mole");
+   XMLNodePointer_t CreateDN(Double_t density, const char *unit = "g/cm3");
+   XMLNodePointer_t CreateFractionN(Double_t percentage, const char *refName);
    XMLNodePointer_t CreatePropertyN(TNamed const &property);
 
-   XMLNodePointer_t CreateIsotopN(TGeoIsotope * isotope, const char * name);
-   XMLNodePointer_t CreateElementN(TGeoElement * element, XMLNodePointer_t materials, const char * name);
-   XMLNodePointer_t CreateMixtureN(TGeoMixture * mixture, XMLNodePointer_t materials, TString mname);
-   XMLNodePointer_t CreateMaterialN(TGeoMaterial * material, TString mname);
+   XMLNodePointer_t CreateIsotopN(TGeoIsotope *isotope, const char *name);
+   XMLNodePointer_t CreateElementN(TGeoElement *element, XMLNodePointer_t materials, const char *name);
+   XMLNodePointer_t CreateMixtureN(TGeoMixture *mixture, XMLNodePointer_t materials, TString mname);
+   XMLNodePointer_t CreateMaterialN(TGeoMaterial *material, TString mname);
 
-
-   //1.2 Solids sub methods
+   // 1.2 Solids sub methods
    XMLNodePointer_t ChooseObject(TGeoShape *geoShape);
    XMLNodePointer_t CreateZplaneN(Double_t z, Double_t rmin, Double_t rmax);
 
-   XMLNodePointer_t CreateBoxN(TGeoBBox * geoShape);
-   XMLNodePointer_t CreateParaboloidN(TGeoParaboloid * geoShape);
-   XMLNodePointer_t CreateSphereN(TGeoSphere * geoShape);
-   XMLNodePointer_t CreateArb8N(TGeoArb8 * geoShape);
-   XMLNodePointer_t CreateConeN(TGeoConeSeg * geoShape);
-   XMLNodePointer_t CreateConeN(TGeoCone * geoShape);
-   XMLNodePointer_t CreateParaN(TGeoPara * geoShape);
-   XMLNodePointer_t CreateTrapN(TGeoTrap * geoShape);
-   XMLNodePointer_t CreateTwistedTrapN(TGeoGtra * geoShape);
-   XMLNodePointer_t CreateTrdN(TGeoTrd1 * geoShape);
-   XMLNodePointer_t CreateTrdN(TGeoTrd2 * geoShape);
-   XMLNodePointer_t CreateTubeN(TGeoTubeSeg * geoShape);
-   XMLNodePointer_t CreateCutTubeN(TGeoCtub * geoShape);
-   XMLNodePointer_t CreateTubeN(TGeoTube * geoShape);
-   XMLNodePointer_t CreatePolyconeN(TGeoPcon * geoShape);
-   XMLNodePointer_t CreateTorusN(TGeoTorus * geoShape);
-   XMLNodePointer_t CreatePolyhedraN(TGeoPgon * geoShape);
-   XMLNodePointer_t CreateEltubeN(TGeoEltu * geoShape);
-   XMLNodePointer_t CreateHypeN(TGeoHype * geoShape);
-   XMLNodePointer_t CreateXtrusionN(TGeoXtru * geoShape);
-   XMLNodePointer_t CreateEllipsoidN(TGeoCompositeShape * geoShape, TString elName);
-   XMLNodePointer_t CreateElConeN(TGeoScaledShape * geoShape);
-   XMLNodePointer_t CreateTessellatedN(TGeoTessellated * geoShape);
-   XMLNodePointer_t CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf);
-   XMLNodePointer_t CreateSkinSurfaceN(TGeoSkinSurface * geoSurf);
-   XMLNodePointer_t CreateBorderSurfaceN(TGeoBorderSurface * geoSurf);
+   XMLNodePointer_t CreateBoxN(TGeoBBox *geoShape);
+   XMLNodePointer_t CreateParaboloidN(TGeoParaboloid *geoShape);
+   XMLNodePointer_t CreateSphereN(TGeoSphere *geoShape);
+   XMLNodePointer_t CreateArb8N(TGeoArb8 *geoShape);
+   XMLNodePointer_t CreateConeN(TGeoConeSeg *geoShape);
+   XMLNodePointer_t CreateConeN(TGeoCone *geoShape);
+   XMLNodePointer_t CreateParaN(TGeoPara *geoShape);
+   XMLNodePointer_t CreateTrapN(TGeoTrap *geoShape);
+   XMLNodePointer_t CreateTwistedTrapN(TGeoGtra *geoShape);
+   XMLNodePointer_t CreateTrdN(TGeoTrd1 *geoShape);
+   XMLNodePointer_t CreateTrdN(TGeoTrd2 *geoShape);
+   XMLNodePointer_t CreateTubeN(TGeoTubeSeg *geoShape);
+   XMLNodePointer_t CreateCutTubeN(TGeoCtub *geoShape);
+   XMLNodePointer_t CreateTubeN(TGeoTube *geoShape);
+   XMLNodePointer_t CreatePolyconeN(TGeoPcon *geoShape);
+   XMLNodePointer_t CreateTorusN(TGeoTorus *geoShape);
+   XMLNodePointer_t CreatePolyhedraN(TGeoPgon *geoShape);
+   XMLNodePointer_t CreateEltubeN(TGeoEltu *geoShape);
+   XMLNodePointer_t CreateHypeN(TGeoHype *geoShape);
+   XMLNodePointer_t CreateXtrusionN(TGeoXtru *geoShape);
+   XMLNodePointer_t CreateEllipsoidN(TGeoCompositeShape *geoShape, TString elName);
+   XMLNodePointer_t CreateElConeN(TGeoScaledShape *geoShape);
+   XMLNodePointer_t CreateTessellatedN(TGeoTessellated *geoShape);
+   XMLNodePointer_t CreateOpticalSurfaceN(TGeoOpticalSurface *geoSurf);
+   XMLNodePointer_t CreateSkinSurfaceN(TGeoSkinSurface *geoSurf);
+   XMLNodePointer_t CreateBorderSurfaceN(TGeoBorderSurface *geoSurf);
 
    XMLNodePointer_t CreateCommonBoolN(TGeoCompositeShape *geoShape);
 
-   //1.3 Volume sub methods
-   XMLNodePointer_t CreatePhysVolN(const char * name, Int_t copyno, const char * volref, const char * posref, const char * rotref, XMLNodePointer_t scaleN);
-   XMLNodePointer_t CreateDivisionN(Double_t offset, Double_t width, Int_t number, const char * axis, const char * unit, const char * volref);
+   // 1.3 Volume sub methods
+   XMLNodePointer_t CreatePhysVolN(const char *name, Int_t copyno, const char *volref, const char *posref,
+                                   const char *rotref, XMLNodePointer_t scaleN);
+   XMLNodePointer_t CreateDivisionN(Double_t offset, Double_t width, Int_t number, const char *axis, const char *unit,
+                                    const char *volref);
 
-   XMLNodePointer_t CreateSetupN(const char * topVolName , const char * name = "default", const char * version = "1.0");
-   XMLNodePointer_t StartVolumeN(const char * name, const char * solid, const char * material);
-   XMLNodePointer_t StartAssemblyN(const char * name);
+   XMLNodePointer_t CreateSetupN(const char *topVolName, const char *name = "default", const char *version = "1.0");
+   XMLNodePointer_t StartVolumeN(const char *name, const char *solid, const char *material);
+   XMLNodePointer_t StartAssemblyN(const char *name);
 
-
-   //II. Utility methods
-   Xyz GetXYZangles(const Double_t * rotationMatrix);
-   //nodes to create position, rotation and similar types first-position/rotation...
-   XMLNodePointer_t CreatePositionN(const char * name, Xyz position, const char * type, const char * unit);
-   XMLNodePointer_t CreateRotationN(const char * name, Xyz rotation, const char * type = "rotation", const char * unit = "deg");
+   // II. Utility methods
+   Xyz GetXYZangles(const Double_t *rotationMatrix);
+   // nodes to create position, rotation and similar types first-position/rotation...
+   XMLNodePointer_t CreatePositionN(const char *name, Xyz position, const char *type, const char *unit);
+   XMLNodePointer_t
+   CreateRotationN(const char *name, Xyz rotation, const char *type = "rotation", const char *unit = "deg");
    XMLNodePointer_t CreateMatrixN(TGDMLMatrix const *matrix);
    XMLNodePointer_t CreateConstantN(const char *name, Double_t value);
-   TGeoCompositeShape* CreateFakeCtub(TGeoCtub * geoShape);  //create fake cut tube as intersection
+   TGeoCompositeShape *CreateFakeCtub(TGeoCtub *geoShape); // create fake cut tube as intersection
 
-   //check name (2nd parameter) whether it is in the list (1st parameter)
+   // check name (2nd parameter) whether it is in the list (1st parameter)
    Bool_t IsInList(NameList list, TString name2check);
    TString GenName(TString oldname);
    TString GenName(TString oldname, TString objPointer);
    Bool_t CanProcess(TObject *pointer);
-   TString GetPattAxis(Int_t divAxis, const char * pattName, TString& unit);
+   TString GetPattAxis(Int_t divAxis, const char *pattName, TString &unit);
    Bool_t IsNullParam(Double_t parValue, TString parName, TString objName);
-   void UnsetTemporaryBits(TGeoManager * geoMng);
+   void UnsetTemporaryBits(TGeoManager *geoMng);
 
    ////////////////////////////////////////////////////////////////////////////////
    //
@@ -241,13 +239,17 @@ private:
    ////////////////////////////////////////////////////////////////////////////////
 public:
    // Backwards compatibility (to be removed in the future): Wrapper to only selectively write one branch
-   void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* top_vol, const char* filename = "test.gdml", TString option = "");
-private:
-   // Backwards compatibility (to be removed in the future): Combined implementation to extract GDML information from the geometry tree
-   void WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* top_vol, TList* materialsLst, const char* filename, TString option);
-   void ExtractVolumes(TGeoVolume* topVolume);    //result <volume> node...  + corresp. shape
+   void
+   WriteGDMLfile(TGeoManager *geomanager, TGeoVolume *top_vol, const char *filename = "test.gdml", TString option = "");
 
-   ClassDef(TGDMLWrite, 0)    //imports GDML using DOM and binds it to ROOT
+private:
+   // Backwards compatibility (to be removed in the future): Combined implementation to extract GDML information from
+   // the geometry tree
+   void WriteGDMLfile(TGeoManager *geomanager, TGeoVolume *top_vol, TList *materialsLst, const char *filename,
+                      TString option);
+   void ExtractVolumes(TGeoVolume *topVolume); // result <volume> node...  + corresp. shape
+
+   ClassDef(TGDMLWrite, 0) // imports GDML using DOM and binds it to ROOT
 };
 
 #endif /* ROOT_TGDMLWRITE */

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -81,6 +81,8 @@ public:
       kwithoutSufixNotUniq = 1,
       kfastButUglySufix = 2
    };
+   // Ignore dummy material instance, which causes trouble reading GDML in Geant4
+   void SetIgnoreDummyMaterial(bool value);
    void SetNamingSpeed(ENamingType naming);
    void SetG4Compatibility(Bool_t G4Compatible) {
       fgG4Compatibility = G4Compatible;
@@ -122,6 +124,7 @@ private:
    //Data members
    static TGDMLWrite *fgGDMLWrite;                         //pointer to gdml writer
    Int_t  fgNamingSpeed;                                   //input option for volume and solid naming
+   Int_t  fIgnoreDummyMaterial;                            //Flag to ignore TGeo's dummy material
    Bool_t fgG4Compatibility;                               //input option for Geant4 compatibility
    XMLDocPointer_t  fGdmlFile;                             //pointer storing xml file
    TString fDefault_lunit;                                 //Default unit of length (depends on ROOT unit system)

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -87,6 +87,8 @@ public:
    void SetG4Compatibility(Bool_t G4Compatible) {
       fgG4Compatibility = G4Compatible;
    };
+   UInt_t GetFltPrecision() const { return fFltPrecision; }
+   void SetFltPrecision(UInt_t prec) { fFltPrecision = prec; }
 
 private:
    struct Xyz {
@@ -217,7 +219,7 @@ private:
    //II. Utility methods
    Xyz GetXYZangles(const Double_t * rotationMatrix);
    //nodes to create position, rotation and similar types first-position/rotation...
-   XMLNodePointer_t CreatePositionN(const char * name, Xyz position, const char * type = "position", const char * unit = "cm");
+   XMLNodePointer_t CreatePositionN(const char * name, Xyz position, const char * type, const char * unit);
    XMLNodePointer_t CreateRotationN(const char * name, Xyz rotation, const char * type = "rotation", const char * unit = "deg");
    XMLNodePointer_t CreateMatrixN(TGDMLMatrix const *matrix);
    XMLNodePointer_t CreateConstantN(const char *name, Double_t value);
@@ -231,8 +233,6 @@ private:
    TString GetPattAxis(Int_t divAxis, const char * pattName, TString& unit);
    Bool_t IsNullParam(Double_t parValue, TString parName, TString objName);
    void UnsetTemporaryBits(TGeoManager * geoMng);
-   UInt_t GetFltPrecision() const { return fFltPrecision; }
-   void SetFltPrecision(UInt_t prec) { fFltPrecision = prec; }
 
    ////////////////////////////////////////////////////////////////////////////////
    //

--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -594,15 +594,20 @@ XMLNodePointer_t TGDMLParse::MatrixProcess(TXMLEngine *gdml, XMLNodePointer_t no
          continue;
       valueList.push_back(Value(matrixValue.c_str()));
    }
-
-   TGDMLMatrix *matrix = new TGDMLMatrix(name, valueList.size() / coldim, coldim);
-   matrix->SetMatrixAsString(values.c_str());
-   for (size_t i = 0; i < valueList.size(); ++i)
-      matrix->Set(i / coldim, i % coldim, valueList[i]);
-
-   gGeoManager->AddGDMLMatrix(matrix);
-   fmatrices[name.Data()] = matrix;
-
+   // Const Properties in GDML are matrices with size 1 not constants
+   // This gives some ambiguity, but what can one do?
+   if ( coldim == 1 && valueList.size() == 1 )    {
+      gGeoManager->AddProperty(name, valueList[0]);
+   }
+   else  {
+     TGDMLMatrix *matrix = new TGDMLMatrix(name, valueList.size() / coldim, coldim);
+     matrix->SetMatrixAsString(values.c_str());
+     for (size_t i = 0; i < valueList.size(); ++i)
+       matrix->Set(i / coldim, i % coldim, valueList[i]);
+     
+     gGeoManager->AddGDMLMatrix(matrix);
+     fmatrices[name.Data()] = matrix;
+   }
    return node;
 }
 

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -527,12 +527,14 @@ XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList* materialsLst)
    //go through materials  - iterator and object declaration
    TIter next(materialsLst);
    TGeoMaterial *lmaterial;
+   TGeoMedium   *dummy_med = TGeoVolume::DummyMedium();
+   TGeoMaterial *dummy_mat = dummy_med ? dummy_med->GetMaterial() : nullptr;
 
    while ((lmaterial = (TGeoMaterial *)next())) {
       //generate uniq name
       TString mname = lmaterial->GetName();
-      if ( fIgnoreDummyMaterial && mname == "dummy" )   {
-        Info("ExtractMaterials", "Skip dummy material!");
+      if ( fIgnoreDummyMaterial && dummy_mat && dummy_mat->GetName() == mname )   {
+        Info("ExtractMaterials", "Skip dummy material: %s", dummy_mat->GetName());
         continue;
       }
       TString lname = GenName(mname, TString::Format("%p", lmaterial));

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -170,59 +170,46 @@ TGDMLWrite *TGDMLWrite::fgGDMLWrite = nullptr;
 
 namespace {
 
-  // Helper to replace string patterns
-  std::string str_replace(const std::string& str, const std::string& pattern, const std::string& replacement)   {
-    std::string res = str;
-    for(size_t id=res.find(pattern); id != std::string::npos; id = res.find(pattern) )
+// Helper to replace string patterns
+std::string str_replace(const std::string &str, const std::string &pattern, const std::string &replacement)
+{
+   std::string res = str;
+   for (size_t id = res.find(pattern); id != std::string::npos; id = res.find(pattern))
       res.replace(id, pattern.length(), replacement);
-    return res;
-  }
-  
-  // Create a NCN compliant name (no '/' and no '#')  
-  std::string make_NCName(const std::string& in)   {
-    std::string res = str_replace(in, "/", "_");
-    res = str_replace(res, "#", "_");
-    return res;
-  }
-
-  // Materials extractor from a volume tree
-  struct MaterialExtractor  {
-    std::set<TGeoMaterial*> materials;
-    void operator() (const TGeoVolume* v)   {
-      materials.insert(v->GetMaterial());
-      for(Int_t i=0; i<v->GetNdaughters(); ++i)
-        (*this)(v->GetNode(i)->GetVolume());
-    }
-  };
+   return res;
 }
+
+// Create a NCN compliant name (no '/' and no '#')
+std::string make_NCName(const std::string &in)
+{
+   std::string res = str_replace(in, "/", "_");
+   res = str_replace(res, "#", "_");
+   return res;
+}
+
+// Materials extractor from a volume tree
+struct MaterialExtractor {
+   std::set<TGeoMaterial *> materials;
+   void operator()(const TGeoVolume *v)
+   {
+      materials.insert(v->GetMaterial());
+      for (Int_t i = 0; i < v->GetNdaughters(); ++i)
+         (*this)(v->GetNode(i)->GetVolume());
+   }
+};
+} // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Default constructor.
 
 TGDMLWrite::TGDMLWrite()
-   : TObject(),
-     fIsotopeList(0),
-     fElementList(0),
-     fAccPatt(0),
-     fRejShape(0),
-     fNameList(0),
-     fgNamingSpeed(0),
-     fIgnoreDummyMaterial(0),
-     fgG4Compatibility(0),
-     fGdmlFile(0),
-     fTopVolumeName(0),
-     fGdmlE(0),
-     fDefineNode(0),
-     fMaterialsNode(0),
-     fSolidsNode(0),
-     fStructureNode(0),
-     fVolCnt(0),
-     fPhysVolCnt(0),
-     fActNameErr(0),
-     fSolCnt(0),
-     fFltPrecision(17)   // %.17g
+   : TObject(), fIsotopeList(0), fElementList(0), fAccPatt(0), fRejShape(0), fNameList(0), fgNamingSpeed(0),
+     fIgnoreDummyMaterial(0), fgG4Compatibility(0), fGdmlFile(0), fTopVolumeName(0), fGdmlE(0), fDefineNode(0),
+     fMaterialsNode(0), fSolidsNode(0), fStructureNode(0), fVolCnt(0), fPhysVolCnt(0), fActNameErr(0), fSolCnt(0),
+     fFltPrecision(17) // %.17g
 {
-   if (fgGDMLWrite) delete fgGDMLWrite;
+   if (fgGDMLWrite)
+      delete fgGDMLWrite;
    fgGDMLWrite = this;
 }
 
@@ -251,48 +238,49 @@ void TGDMLWrite::SetNamingSpeed(ENamingType naming)
 ////////////////////////////////////////////////////////////////////////////////
 /// Ignore dummy material instance, which causes trouble reading GDML in Geant4
 
-void TGDMLWrite::SetIgnoreDummyMaterial(bool value)    {
-  fIgnoreDummyMaterial = (value ? 1 : 0);
+void TGDMLWrite::SetIgnoreDummyMaterial(bool value)
+{
+   fIgnoreDummyMaterial = (value ? 1 : 0);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-//wrapper of all main methods for extraction
-void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager, const char* filename, TString option)
+// wrapper of all main methods for extraction
+void TGDMLWrite::WriteGDMLfile(TGeoManager *geomanager, const char *filename, TString option)
 {
-  TList* materials = geomanager->GetListOfMaterials();
-  TGeoNode* node = geomanager->GetTopNode();
-  if ( !node )   {
-    Info("WriteGDMLfile", "Top volume does not exist!");
-    return;
-  }
-  fTopVolume = node->GetVolume();
-  fTopVolumeName = fTopVolume->GetName();
-  WriteGDMLfile(geomanager, node, materials, filename, option);
+   TList *materials = geomanager->GetListOfMaterials();
+   TGeoNode *node = geomanager->GetTopNode();
+   if (!node) {
+      Info("WriteGDMLfile", "Top volume does not exist!");
+      return;
+   }
+   fTopVolume = node->GetVolume();
+   fTopVolumeName = fTopVolume->GetName();
+   WriteGDMLfile(geomanager, node, materials, filename, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Wrapper to only selectively write one branch of the volume hierarchy to file
-void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager, TGeoNode* node, const char* filename, TString option)
+void TGDMLWrite::WriteGDMLfile(TGeoManager *geomanager, TGeoNode *node, const char *filename, TString option)
 {
-  TGeoVolume* volume = node->GetVolume();
-  TList materials, volumes, nodes;
-  MaterialExtractor extract;
-  if ( !volume )   {
-    Info("WriteGDMLfile", "Invalid Volume reference to extract GDML information!");
-    return;
-  }
-  extract(volume);
-  for(TGeoMaterial* m : extract.materials)
-    materials.Add(m);
-  fTopVolumeName = volume->GetName();
-  fTopVolume = volume;
-  fSurfaceList.clear();
-  fVolumeList.clear();
-  fNodeList.clear();
-  WriteGDMLfile(geomanager, node, &materials, filename, option);
-  materials.Clear("nodelete");
-  volumes.Clear("nodelete");
-  nodes.Clear("nodelete");
+   TGeoVolume *volume = node->GetVolume();
+   TList materials, volumes, nodes;
+   MaterialExtractor extract;
+   if (!volume) {
+      Info("WriteGDMLfile", "Invalid Volume reference to extract GDML information!");
+      return;
+   }
+   extract(volume);
+   for (TGeoMaterial *m : extract.materials)
+      materials.Add(m);
+   fTopVolumeName = volume->GetName();
+   fTopVolume = volume;
+   fSurfaceList.clear();
+   fVolumeList.clear();
+   fNodeList.clear();
+   WriteGDMLfile(geomanager, node, &materials, filename, option);
+   materials.Clear("nodelete");
+   volumes.Clear("nodelete");
+   nodes.Clear("nodelete");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -300,13 +288,10 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager, TGeoNode* node, const c
 /// Creates blank GDML file and fills it with gGeoManager structure converted
 /// to GDML structure of xml nodes
 
-void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
-                               TGeoNode* node,
-                               TList* materialsLst,
-                               const char* filename,
+void TGDMLWrite::WriteGDMLfile(TGeoManager *geomanager, TGeoNode *node, TList *materialsLst, const char *filename,
                                TString option)
 {
-   //option processing
+   // option processing
    option.ToLower();
    if (option.Contains("g")) {
       SetG4Compatibility(kTRUE);
@@ -326,53 +311,49 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    }
    auto def_units = gGeoManager->GetDefaultUnits();
    switch (def_units) {
-      case TGeoManager::kG4Units:
-         fDefault_lunit = "mm";
-         break;
-      case TGeoManager::kRootUnits:
-         fDefault_lunit = "cm";
-         break;
-      default: // G4 units
-         fDefault_lunit = "mm";
-         break;
+   case TGeoManager::kG4Units: fDefault_lunit = "mm"; break;
+   case TGeoManager::kRootUnits: fDefault_lunit = "cm"; break;
+   default: // G4 units
+      fDefault_lunit = "mm";
+      break;
    }
 
-   //local variables
+   // local variables
    Int_t outputLayout = 1;
-   const char * krootNodeName = "gdml";
-   const char * knsRefGeneral = "http://www.w3.org/2001/XMLSchema-instance";
-   const char * knsNameGeneral = "xsi";
-   const char * knsRefGdml = "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd";
-   const char * knsNameGdml = "xsi:noNamespaceSchemaLocation";
+   const char *krootNodeName = "gdml";
+   const char *knsRefGeneral = "http://www.w3.org/2001/XMLSchema-instance";
+   const char *knsNameGeneral = "xsi";
+   const char *knsRefGdml = "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd";
+   const char *knsNameGdml = "xsi:noNamespaceSchemaLocation";
 
    // First create engine
    fGdmlE = new TXMLEngine;
    fGdmlE->SetSkipComments(kTRUE);
 
-   //create blank GDML file
+   // create blank GDML file
    fGdmlFile = fGdmlE->NewDoc();
 
-   //create root node and add it to blank GDML file
+   // create root node and add it to blank GDML file
    XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, nullptr);
    fGdmlE->DocSetRootElement(fGdmlFile, rootNode);
 
-   //add namespaces to root node
+   // add namespaces to root node
    fGdmlE->NewNS(rootNode, knsRefGeneral, knsNameGeneral);
    fGdmlE->NewAttr(rootNode, nullptr, knsNameGdml, knsRefGdml);
 
-   //initialize general lists and <define>, <solids>, <structure> nodes
-   fIsotopeList  = new StructLst;
-   fElementList  = new StructLst;
+   // initialize general lists and <define>, <solids>, <structure> nodes
+   fIsotopeList = new StructLst;
+   fElementList = new StructLst;
 
-   fNameList     = new NameLst;
+   fNameList = new NameLst;
 
    fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", nullptr);
    fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", nullptr);
    fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", nullptr);
    //========================
 
-   //initialize list of accepted patterns for divisions (in ExtractVolumes)
-   fAccPatt   = new StructLst;
+   // initialize list of accepted patterns for divisions (in ExtractVolumes)
+   fAccPatt = new StructLst;
    fAccPatt->fLst["TGeoPatternX"] = kTRUE;
    fAccPatt->fLst["TGeoPatternY"] = kTRUE;
    fAccPatt->fLst["TGeoPatternZ"] = kTRUE;
@@ -380,22 +361,22 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    fAccPatt->fLst["TGeoPatternCylPhi"] = kTRUE;
    //========================
 
-   //initialize list of rejected shapes for divisions (in ExtractVolumes)
-   fRejShape     = new StructLst;
-   //this shapes are rejected because, it is not possible to divide trd2
-   //in Y axis and while only trd2 object is imported from GDML
-   //it causes a problem when TGeoTrd1 is divided in Y axis
+   // initialize list of rejected shapes for divisions (in ExtractVolumes)
+   fRejShape = new StructLst;
+   // this shapes are rejected because, it is not possible to divide trd2
+   // in Y axis and while only trd2 object is imported from GDML
+   // it causes a problem when TGeoTrd1 is divided in Y axis
    fRejShape->fLst["TGeoTrd1"] = kTRUE;
    fRejShape->fLst["TGeoTrd2"] = kTRUE;
    //=========================
 
-   //Initialize global counters
+   // Initialize global counters
    fActNameErr = 0;
    fVolCnt = 0;
    fPhysVolCnt = 0;
    fSolCnt = 0;
 
-   //calling main extraction functions (with measuring time)
+   // calling main extraction functions (with measuring time)
    time_t startT, endT;
    startT = time(nullptr);
    ExtractMatrices(geomanager->GetListOfGDMLMatrices());
@@ -412,10 +393,10 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    ExtractOpticalSurfaces(geomanager->GetListOfOpticalSurfaces());
    endT = time(nullptr);
    //<gdml>
-   fGdmlE->AddChild(rootNode, fDefineNode);                 //  <define>...</define>
-   fGdmlE->AddChild(rootNode, fMaterialsNode);              //  <materials>...</materials>
-   fGdmlE->AddChild(rootNode, fSolidsNode);                 //  <solids>...</solids>
-   fGdmlE->AddChild(rootNode, fStructureNode);              //  <structure>...</structure>
+   fGdmlE->AddChild(rootNode, fDefineNode);                         //  <define>...</define>
+   fGdmlE->AddChild(rootNode, fMaterialsNode);                      //  <materials>...</materials>
+   fGdmlE->AddChild(rootNode, fSolidsNode);                         //  <solids>...</solids>
+   fGdmlE->AddChild(rootNode, fStructureNode);                      //  <structure>...</structure>
    fGdmlE->AddChild(rootNode, CreateSetupN(fTopVolumeName.Data())); //  <setup>...</setup>
    //</gdml>
    Double_t tdiffI = difftime(endT, startT);
@@ -423,12 +404,12 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    Info("WriteGDMLfile", "Exporting time: %s", tdiffS.Data());
    //=========================
 
-   //Saving document
+   // Saving document
    fGdmlE->SaveDoc(fGdmlFile, filename, outputLayout);
    Info("WriteGDMLfile", "File %s saved", filename);
-   //cleaning
+   // cleaning
    fGdmlE->FreeDoc(fGdmlFile);
-   //unset processing bits:
+   // unset processing bits:
    UnsetTemporaryBits(geomanager);
    delete fGdmlE;
 }
@@ -436,15 +417,16 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
 ////////////////////////////////////////////////////////////////////////////////
 /// Method exporting GDML matrices
 
-void TGDMLWrite::ExtractMatrices(TObjArray* matrixList)
+void TGDMLWrite::ExtractMatrices(TObjArray *matrixList)
 {
-   if (!matrixList->GetEntriesFast()) return;
+   if (!matrixList->GetEntriesFast())
+      return;
    XMLNodePointer_t matrixN;
    TIter next(matrixList);
    TGDMLMatrix *matrix;
-   while ((matrix = (TGDMLMatrix*)next())) {
-     matrixN = CreateMatrixN(matrix);
-     fGdmlE->AddChild(fDefineNode, matrixN);
+   while ((matrix = (TGDMLMatrix *)next())) {
+      matrixN = CreateMatrixN(matrix);
+      fGdmlE->AddChild(fDefineNode, matrixN);
    }
 }
 
@@ -453,7 +435,8 @@ void TGDMLWrite::ExtractMatrices(TObjArray* matrixList)
 
 void TGDMLWrite::ExtractConstants(TGeoManager *geom)
 {
-   if (!geom->GetNproperties()) return;
+   if (!geom->GetNproperties())
+      return;
    XMLNodePointer_t constantN;
    TString property;
    Double_t value;
@@ -469,12 +452,14 @@ void TGDMLWrite::ExtractConstants(TGeoManager *geom)
 
 void TGDMLWrite::ExtractOpticalSurfaces(TObjArray *surfaces)
 {
-   if (!surfaces->GetEntriesFast()) return;
+   if (!surfaces->GetEntriesFast())
+      return;
    XMLNodePointer_t surfaceN;
    TIter next(surfaces);
    TGeoOpticalSurface *surf;
-   while ((surf = (TGeoOpticalSurface*)next())) {
-      if ( fSurfaceList.find(surf) == fSurfaceList.end() ) continue;
+   while ((surf = (TGeoOpticalSurface *)next())) {
+      if (fSurfaceList.find(surf) == fSurfaceList.end())
+         continue;
       surfaceN = CreateOpticalSurfaceN(surf);
       fGdmlE->AddChild(fSolidsNode, surfaceN);
       // Info("ExtractSkinSurfaces", "Extracted optical surface: %s",surf->GetName());
@@ -486,12 +471,14 @@ void TGDMLWrite::ExtractOpticalSurfaces(TObjArray *surfaces)
 
 void TGDMLWrite::ExtractSkinSurfaces(TObjArray *surfaces)
 {
-   if (!surfaces->GetEntriesFast()) return;
+   if (!surfaces->GetEntriesFast())
+      return;
    XMLNodePointer_t surfaceN;
    TIter next(surfaces);
    TGeoSkinSurface *surf;
-   while ((surf = (TGeoSkinSurface*)next())) {
-      if ( fVolumeList.find(surf->GetVolume()) == fVolumeList.end() ) continue;
+   while ((surf = (TGeoSkinSurface *)next())) {
+      if (fVolumeList.find(surf->GetVolume()) == fVolumeList.end())
+         continue;
       surfaceN = CreateSkinSurfaceN(surf);
       fGdmlE->AddChild(fStructureNode, surfaceN);
       fSurfaceList.insert(surf->GetSurface());
@@ -504,25 +491,28 @@ void TGDMLWrite::ExtractSkinSurfaces(TObjArray *surfaces)
 
 void TGDMLWrite::ExtractBorderSurfaces(TObjArray *surfaces)
 {
-   if (!surfaces->GetEntriesFast()) return;
+   if (!surfaces->GetEntriesFast())
+      return;
    XMLNodePointer_t surfaceN;
    TIter next(surfaces);
    TGeoBorderSurface *surf;
-   while ((surf = (TGeoBorderSurface*)next())) {
+   while ((surf = (TGeoBorderSurface *)next())) {
       auto ia = fNodeList.find(surf->GetNode1());
       auto ib = fNodeList.find(surf->GetNode2());
-      if ( ia == fNodeList.end() && ib == fNodeList.end() )  {
-        continue;
-      }
-      else if ( ia == fNodeList.end() && ib != fNodeList.end() )  {
-        Warning("ExtractBorderSurfaces", "Inconsistent border surface extraction %s: Node %s"
-             " is not part of GDML!",surf->GetName(), surf->GetNode1()->GetName());
-        continue;
-      }
-      else if ( ia != fNodeList.end() && ib == fNodeList.end() )  {
-        Warning("ExtractBorderSurfaces", "Inconsistent border surface extraction %s: Node %s"
-             " is not part of GDML!",surf->GetName(), surf->GetNode2()->GetName());
-        continue;
+      if (ia == fNodeList.end() && ib == fNodeList.end()) {
+         continue;
+      } else if (ia == fNodeList.end() && ib != fNodeList.end()) {
+         Warning("ExtractBorderSurfaces",
+                 "Inconsistent border surface extraction %s: Node %s"
+                 " is not part of GDML!",
+                 surf->GetName(), surf->GetNode1()->GetName());
+         continue;
+      } else if (ia != fNodeList.end() && ib == fNodeList.end()) {
+         Warning("ExtractBorderSurfaces",
+                 "Inconsistent border surface extraction %s: Node %s"
+                 " is not part of GDML!",
+                 surf->GetName(), surf->GetNode2()->GetName());
+         continue;
       }
       surfaceN = CreateBorderSurfaceN(surf);
       fGdmlE->AddChild(fStructureNode, surfaceN);
@@ -534,30 +524,30 @@ void TGDMLWrite::ExtractBorderSurfaces(TObjArray *surfaces)
 ////////////////////////////////////////////////////////////////////////////////
 /// Method exporting materials
 
-XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList* materialsLst)
+XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList *materialsLst)
 {
    Info("ExtractMaterials", "Extracting materials");
-   //crate main <materials> node
+   // crate main <materials> node
    XMLNodePointer_t materialsN = fGdmlE->NewChild(nullptr, nullptr, "materials", nullptr);
    Int_t matcnt = 0;
 
-   //go through materials  - iterator and object declaration
+   // go through materials  - iterator and object declaration
    TIter next(materialsLst);
    TGeoMaterial *lmaterial;
-   TGeoMedium   *dummy_med = TGeoVolume::DummyMedium();
+   TGeoMedium *dummy_med = TGeoVolume::DummyMedium();
    TGeoMaterial *dummy_mat = dummy_med ? dummy_med->GetMaterial() : nullptr;
-   std::string   dummy_nam = dummy_mat ? dummy_mat->GetName() : "dummy";
+   std::string dummy_nam = dummy_mat ? dummy_mat->GetName() : "dummy";
    while ((lmaterial = (TGeoMaterial *)next())) {
-      //generate uniq name
+      // generate uniq name
       std::string mname = lmaterial->GetName();
-      if ( fIgnoreDummyMaterial && dummy_mat && dummy_nam == mname )   {
-        Info("ExtractMaterials", "Skip dummy material: %s", dummy_mat->GetName());
-        continue;
+      if (fIgnoreDummyMaterial && dummy_mat && dummy_nam == mname) {
+         Info("ExtractMaterials", "Skip dummy material: %s", dummy_mat->GetName());
+         continue;
       }
       TString lname = GenName(mname.c_str(), TString::Format("%p", lmaterial));
 
       if (lmaterial->IsMixture()) {
-         TGeoMixture  *lmixture = (TGeoMixture *)lmaterial;
+         TGeoMixture *lmixture = (TGeoMixture *)lmaterial;
          XMLNodePointer_t mixtureN = CreateMixtureN(lmixture, materialsN, lname);
          fGdmlE->AddChild(materialsN, mixtureN);
       } else {
@@ -573,13 +563,14 @@ XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList* materialsLst)
 ////////////////////////////////////////////////////////////////////////////////
 /// Method creating solid to xml file and returning its name
 
-TString TGDMLWrite::ExtractSolid(TGeoShape* volShape)
+TString TGDMLWrite::ExtractSolid(TGeoShape *volShape)
 {
    XMLNodePointer_t solidN;
    TString solname = "";
-   solidN = ChooseObject(volShape);  //volume->GetShape()
+   solidN = ChooseObject(volShape); // volume->GetShape()
    fGdmlE->AddChild(fSolidsNode, solidN);
-   if (solidN != nullptr) fSolCnt++;
+   if (solidN != nullptr)
+      fSolCnt++;
    solname = fNameList->fLst[TString::Format("%p", volShape)];
    if (solname.Contains("missing_")) {
       solname = "-1";
@@ -587,106 +578,104 @@ TString TGDMLWrite::ExtractSolid(TGeoShape* volShape)
    return solname;
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Method extracting geometry structure recursively
 
-void TGDMLWrite::ExtractVolumes(TGeoNode* node)
+void TGDMLWrite::ExtractVolumes(TGeoNode *node)
 {
    XMLNodePointer_t volumeN, childN;
-   TGeoVolume * volume = node->GetVolume();
+   TGeoVolume *volume = node->GetVolume();
    TString volname, matname, solname, pattClsName, nodeVolNameBak;
    TGeoPatternFinder *pattFinder = 0;
    Bool_t isPattern = kFALSE;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   
+
    fNodeList.insert(node);
    fVolumeList.insert(volume);
-   //create the name for volume/assembly
+   // create the name for volume/assembly
    if (volume == fTopVolume) {
-      //not needed a special function for generating name
+      // not needed a special function for generating name
       volname = volume->GetName();
       fTopVolumeName = volname;
-      //register name to the pointer
+      // register name to the pointer
       fNameList->fLst[TString::Format("%p", volume)] = volname;
    } else {
       volname = GenName(volume->GetName(), TString::Format("%p", volume));
    }
-   
-   //start to create main volume/assembly node
+
+   // start to create main volume/assembly node
    if (volume->IsAssembly()) {
       volumeN = StartAssemblyN(volname);
    } else {
-      //get reference material and add solid to <solids> + get name
+      // get reference material and add solid to <solids> + get name
       matname = fNameList->fLst[TString::Format("%p", volume->GetMaterial())];
       solname = ExtractSolid(volume->GetShape());
-      //If solid is not supported or corrupted
+      // If solid is not supported or corrupted
       if (solname == "-1") {
          Info("ExtractVolumes", "ERROR! %s volume was not added, because solid is either not supported or corrupted",
               volname.Data());
-         //set volume as missing volume
+         // set volume as missing volume
          fNameList->fLst[TString::Format("%p", volume)] = "missing_" + volname;
          return;
       }
       volumeN = StartVolumeN(volname, solname, matname);
 
-      //divisionvol can't be in assembly
+      // divisionvol can't be in assembly
       pattFinder = volume->GetFinder();
-      //if found pattern
+      // if found pattern
       if (pattFinder) {
          pattClsName = TString::Format("%s", pattFinder->ClassName());
          TString shapeCls = TString::Format("%s", volume->GetShape()->ClassName());
-         //if pattern in accepted pattern list and not in shape rejected list
-         if ((fAccPatt->fLst[pattClsName] == kTRUE) &&
-             (fRejShape->fLst[shapeCls] != kTRUE)) {
+         // if pattern in accepted pattern list and not in shape rejected list
+         if ((fAccPatt->fLst[pattClsName] == kTRUE) && (fRejShape->fLst[shapeCls] != kTRUE)) {
             isPattern = kTRUE;
          }
       }
    }
-   //get all nodes in volume
+   // get all nodes in volume
    TObjArray *nodeLst = volume->GetNodes();
    TIter next(nodeLst);
    TGeoNode *geoNode;
    TString physvolname;
    Int_t nCnt = 0;
-   //loop through all nodes
-   while ((geoNode = (TGeoNode *) next())) {
-      //get volume of current node and if not processed then process it
-      TGeoVolume * subvol = geoNode->GetVolume();
+   // loop through all nodes
+   while ((geoNode = (TGeoNode *)next())) {
+      // get volume of current node and if not processed then process it
+      TGeoVolume *subvol = geoNode->GetVolume();
       fNodeList.insert(geoNode);
       if (subvol->TestAttBit(fgkProcBitVol) == kFALSE) {
          subvol->SetAttBit(fgkProcBitVol);
          ExtractVolumes(geoNode);
       }
 
-      //volume of this node has to exist because it was processed recursively
+      // volume of this node has to exist because it was processed recursively
       TString nodevolname = fNameList->fLst[TString::Format("%p", geoNode->GetVolume())];
       if (nodevolname.Contains("missing_")) {
          continue;
       }
-      if (nCnt == 0) { //save name of the first node for divisionvol
+      if (nCnt == 0) { // save name of the first node for divisionvol
          nodeVolNameBak = nodevolname;
       }
 
       if (isPattern == kFALSE) {
-         //create name for node
+         // create name for node
          TString nodename, posname, rotname;
          nodename = GenName(geoNode->GetName(), TString::Format("%p", geoNode));
          nodename = nodename + "in" + volname;
 
-         //create name for position and clear rotation
+         // create name for position and clear rotation
          posname = nodename + "pos";
          rotname = "";
 
-         //position
-         const Double_t * pos = geoNode->GetMatrix()->GetTranslation();
+         // position
+         const Double_t *pos = geoNode->GetMatrix()->GetTranslation();
          Xyz nodPos;
          nodPos.x = pos[0];
          nodPos.y = pos[1];
          nodPos.z = pos[2];
          childN = CreatePositionN(posname.Data(), nodPos, "position", fDefault_lunit);
-         fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
-         //Deal with reflection
+         fGdmlE->AddChild(fDefineNode, childN); // adding node to <define> node
+         // Deal with reflection
          XMLNodePointer_t scaleN = nullptr;
          Double_t lx, ly, lz;
          Double_t xangle = 0;
@@ -694,14 +683,14 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
          lx = geoNode->GetMatrix()->GetRotationMatrix()[0];
          ly = geoNode->GetMatrix()->GetRotationMatrix()[4];
          lz = geoNode->GetMatrix()->GetRotationMatrix()[8];
-         if (geoNode->GetMatrix()->IsReflection()
-             && TMath::Abs(lx) == 1 &&  TMath::Abs(ly) == 1 && TMath::Abs(lz) == 1) {
+         if (geoNode->GetMatrix()->IsReflection() && TMath::Abs(lx) == 1 && TMath::Abs(ly) == 1 &&
+             TMath::Abs(lz) == 1) {
             scaleN = fGdmlE->NewChild(nullptr, nullptr, "scale", nullptr);
             fGdmlE->NewAttr(scaleN, nullptr, "name", (nodename + "scl").Data());
             fGdmlE->NewAttr(scaleN, nullptr, "x", TString::Format(fltPrecision.Data(), lx));
             fGdmlE->NewAttr(scaleN, nullptr, "y", TString::Format(fltPrecision.Data(), ly));
             fGdmlE->NewAttr(scaleN, nullptr, "z", TString::Format(fltPrecision.Data(), lz));
-            //experimentally found out, that rotation should be updated like this
+            // experimentally found out, that rotation should be updated like this
             if (lx == -1) {
                zangle = 180;
             }
@@ -710,27 +699,27 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
             }
          }
 
-         //rotation
+         // rotation
          TGDMLWrite::Xyz lxyz = GetXYZangles(geoNode->GetMatrix()->GetRotationMatrix());
          lxyz.x -= xangle;
          lxyz.z -= zangle;
          if ((lxyz.x != 0.0) || (lxyz.y != 0.0) || (lxyz.z != 0.0)) {
             rotname = nodename + "rot";
             childN = CreateRotationN(rotname.Data(), lxyz);
-            fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
+            fGdmlE->AddChild(fDefineNode, childN); // adding node to <define> node
          }
 
-         //create physvol for main volume/assembly node
+         // create physvol for main volume/assembly node
          physvolname = fNameList->fLst[TString::Format("%p", geoNode)];
-         childN = CreatePhysVolN(physvolname, geoNode->GetNumber(),
-                                 nodevolname.Data(), posname.Data(), rotname.Data(), scaleN);
+         childN = CreatePhysVolN(physvolname, geoNode->GetNumber(), nodevolname.Data(), posname.Data(), rotname.Data(),
+                                 scaleN);
          fGdmlE->AddChild(volumeN, childN);
       }
       nCnt++;
    }
-   //create only one divisionvol node
+   // create only one divisionvol node
    if (isPattern && pattFinder) {
-      //retrieve attributes of division
+      // retrieve attributes of division
       Int_t ndiv, divaxis;
       Double_t offset, width, xlo, xhi;
       TString axis, unit;
@@ -741,25 +730,24 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
       divaxis = pattFinder->GetDivAxis();
       volume->GetShape()->GetAxisRange(divaxis, xlo, xhi);
 
-      //compute relative start (not positional)
+      // compute relative start (not positional)
       offset = pattFinder->GetStart() - xlo;
       axis = GetPattAxis(divaxis, pattClsName, unit);
 
-      //create division node
+      // create division node
       childN = CreateDivisionN(offset, width, ndiv, axis.Data(), unit.Data(), nodeVolNameBak.Data());
       fGdmlE->AddChild(volumeN, childN);
    }
 
    fVolCnt++;
-   //add volume/assembly node into the <structure> node
+   // add volume/assembly node into the <structure> node
    fGdmlE->AddChild(fStructureNode, volumeN);
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "atom" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
+XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char *unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t atomN = fGdmlE->NewChild(nullptr, nullptr, "atom", nullptr);
@@ -771,7 +759,7 @@ XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "D" density node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
+XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char *unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t densN = fGdmlE->NewChild(nullptr, nullptr, "D", nullptr);
@@ -783,7 +771,7 @@ XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "fraction" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char * refName)
+XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char *refName)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t fractN = fGdmlE->NewChild(nullptr, nullptr, "fraction", nullptr);
@@ -797,16 +785,16 @@ XMLNodePointer_t TGDMLWrite::CreateFractionN(Double_t percentage, const char * r
 
 XMLNodePointer_t TGDMLWrite::CreatePropertyN(TNamed const &property)
 {
-  XMLNodePointer_t propertyN = fGdmlE->NewChild(nullptr, nullptr, "property", nullptr);
-  fGdmlE->NewAttr(propertyN, nullptr, "name", property.GetName());
-  fGdmlE->NewAttr(propertyN, nullptr, "ref", property.GetTitle());
-  return propertyN;
+   XMLNodePointer_t propertyN = fGdmlE->NewChild(nullptr, nullptr, "property", nullptr);
+   fGdmlE->NewAttr(propertyN, nullptr, "name", property.GetName());
+   fGdmlE->NewAttr(propertyN, nullptr, "ref", property.GetTitle());
+   return propertyN;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "isotope" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope * isotope, const char * name)
+XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope *isotope, const char *name)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "isotope", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
@@ -818,20 +806,20 @@ XMLNodePointer_t TGDMLWrite::CreateIsotopN(TGeoIsotope * isotope, const char * n
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "element" node for GDML
-///element node and attribute
+/// element node and attribute
 
-XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointer_t materials, const char * name)
+XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement *element, XMLNodePointer_t materials, const char *name)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "element", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
-   //local associative arrays for saving isotopes and their weight
-   //inside element
+   // local associative arrays for saving isotopes and their weight
+   // inside element
    NameListF wPercentage;
    NameListI wCounter;
 
    if (element->HasIsotopes()) {
       Int_t nOfIso = element->GetNisotopes();
-      //go through isotopes
+      // go through isotopes
       for (Int_t idx = 0; idx < nOfIso; idx++) {
          TGeoIsotope *myIsotope = element->GetIsotope(idx);
          if (!myIsotope) {
@@ -839,33 +827,33 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
             return mainN;
          }
 
-         //Get name of the Isotope (
+         // Get name of the Isotope (
          TString lname = myIsotope->GetName();
          //_iso suffix is added to avoid problems with same names
-         //for material, element and isotopes
+         // for material, element and isotopes
          lname = TString::Format("%s_iso", lname.Data());
 
-         //cumulates abundance, in case 2 isotopes with same names
-         //within one element
+         // cumulates abundance, in case 2 isotopes with same names
+         // within one element
          wPercentage[lname] += element->GetRelativeAbundance(idx);
          wCounter[lname]++;
 
-         //check whether isotope name is not in list of isotopes
+         // check whether isotope name is not in list of isotopes
          if (IsInList(fIsotopeList->fLst, lname)) {
             continue;
          }
-         //add isotope to list of isotopes and to main <materials> node
+         // add isotope to list of isotopes and to main <materials> node
          fIsotopeList->fLst[lname] = kTRUE;
          XMLNodePointer_t isoNode = CreateIsotopN(myIsotope, lname);
          fGdmlE->AddChild(materials, isoNode);
       }
-      //loop through asoc array of isotopes
+      // loop through asoc array of isotopes
       for (NameListI::iterator itr = wCounter.begin(); itr != wCounter.end(); ++itr) {
          if (itr->second > 1) {
             Info("CreateMixtureN", "WARNING! 2 equal isotopes in one element. Check: %s isotope of %s element",
                  itr->first.Data(), name);
          }
-         //add fraction child to element with reference to isotope
+         // add fraction child to element with reference to isotope
          fGdmlE->AddChild(mainN, CreateFractionN(wPercentage[itr->first], itr->first.Data()));
       }
    } else {
@@ -877,7 +865,7 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
       }
       Int_t valN = element->N();
       fGdmlE->NewAttr(mainN, nullptr, "N", TString::Format("%i", valN));
-      
+
       fGdmlE->AddChild(mainN, CreateAtomN(element->A()));
    }
    return mainN;
@@ -886,7 +874,7 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "material" node for GDML with references to other sub elements
 
-XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointer_t materials, TString mname)
+XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture *mixture, XMLNodePointer_t materials, TString mname)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", mname);
@@ -896,58 +884,58 @@ XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointe
    if (properties.GetSize()) {
       TIter next(&properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
    // Write CONST properties
    TList const &const_properties = mixture->GetConstProperties();
    if (const_properties.GetSize()) {
       TIter next(&const_properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
 
    fGdmlE->AddChild(mainN, CreateDN(mixture->GetDensity()));
-   //local associative arrays for saving elements and their weight
-   //inside mixture
+   // local associative arrays for saving elements and their weight
+   // inside mixture
    NameListF wPercentage;
    NameListI wCounter;
 
    Int_t nOfElm = mixture->GetNelements();
-   //go through elements
+   // go through elements
    for (Int_t idx = 0; idx < nOfElm; idx++) {
       TGeoElement *myElement = mixture->GetElement(idx);
 
-      //Get name of the element
-      //NOTE: that for element - GetTitle() returns the "name" tag
-      //and GetName() returns "formula" tag (see createElementN)
+      // Get name of the element
+      // NOTE: that for element - GetTitle() returns the "name" tag
+      // and GetName() returns "formula" tag (see createElementN)
       TString lname = myElement->GetTitle();
       //_elm suffix is added to avoid problems with same names
-      //for material and element
+      // for material and element
       lname = TString::Format("%s_elm", lname.Data());
 
-      //cumulates percentage, in case 2 elements with same names within one mixture
+      // cumulates percentage, in case 2 elements with same names within one mixture
       wPercentage[lname] += mixture->GetWmixt()[idx];
       wCounter[lname]++;
 
-      //check whether element name is not in list of elements already created
+      // check whether element name is not in list of elements already created
       if (IsInList(fElementList->fLst, lname)) {
          continue;
       }
 
-      //add element to list of elements and to main <materials> node
+      // add element to list of elements and to main <materials> node
       fElementList->fLst[lname] = kTRUE;
       XMLNodePointer_t elmNode = CreateElementN(myElement, materials, lname);
       fGdmlE->AddChild(materials, elmNode);
    }
-   //loop through asoc array
+   // loop through asoc array
    for (NameListI::iterator itr = wCounter.begin(); itr != wCounter.end(); ++itr) {
       if (itr->second > 1) {
          Info("CreateMixtureN", "WARNING! 2 equal elements in one material. Check: %s element of %s material",
               itr->first.Data(), mname.Data());
       }
-      //add fraction child to material with reference to element
+      // add fraction child to material with reference to element
       fGdmlE->AddChild(mainN, CreateFractionN(wPercentage[itr->first], itr->first.Data()));
    }
 
@@ -957,12 +945,12 @@ XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointe
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "material" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mname)
+XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial *material, TString mname)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", mname);
    Double_t valZ = material->GetZ();
-   //Z can't be zero in Geant4 so this is workaround for vacuum
+   // Z can't be zero in Geant4 so this is workaround for vacuum
    TString tmpname = mname;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    tmpname.ToLower();
@@ -971,7 +959,9 @@ XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mn
          valZ = 1;
       } else {
          if (fgG4Compatibility == kTRUE) {
-            Info("CreateMaterialN", "WARNING! value of Z in %s material can't be < 1 in Geant4, that is why it was changed to 1, please check it manually! ",
+            Info("CreateMaterialN",
+                 "WARNING! value of Z in %s material can't be < 1 in Geant4, that is why it was changed to 1, please "
+                 "check it manually! ",
                  mname.Data());
             valZ = 1;
          } else {
@@ -979,23 +969,23 @@ XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mn
          }
       }
    }
-   fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format(fltPrecision.Data(), valZ)); //material->GetZ()));
+   fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format(fltPrecision.Data(), valZ)); // material->GetZ()));
 
    // Create properties if any: Properties according to the GDML schema MUST come first!
    TList const &properties = material->GetProperties();
    if (properties.GetSize()) {
       TIter next(&properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
    // Write CONST properties
    TList const &const_properties = material->GetConstProperties();
    if (const_properties.GetSize()) {
       TIter next(&const_properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
    // Now add the other children
    fGdmlE->AddChild(mainN, CreateDN(material->GetDensity()));
@@ -1006,14 +996,13 @@ XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mn
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "box" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateBoxN(TGeoBBox * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateBoxN(TGeoBBox *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "box", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
-   if (IsNullParam(geoShape->GetDX(), "DX", lname) ||
-       IsNullParam(geoShape->GetDY(), "DY", lname) ||
+   if (IsNullParam(geoShape->GetDX(), "DX", lname) || IsNullParam(geoShape->GetDY(), "DY", lname) ||
        IsNullParam(geoShape->GetDZ(), "DZ", lname)) {
       return nullptr;
    }
@@ -1027,14 +1016,13 @@ XMLNodePointer_t TGDMLWrite::CreateBoxN(TGeoBBox * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "paraboloid" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateParaboloidN(TGeoParaboloid * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateParaboloidN(TGeoParaboloid *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "paraboloid", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
-   if (IsNullParam(geoShape->GetRhi(), "Rhi", lname) ||
-       IsNullParam(geoShape->GetDz(), "Dz", lname)) {
+   if (IsNullParam(geoShape->GetRhi(), "Rhi", lname) || IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return nullptr;
    }
    fGdmlE->NewAttr(mainN, nullptr, "rlo", TString::Format(fltPrecision.Data(), geoShape->GetRlo()));
@@ -1048,7 +1036,7 @@ XMLNodePointer_t TGDMLWrite::CreateParaboloidN(TGeoParaboloid * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "sphere" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "sphere", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1061,9 +1049,11 @@ XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
    fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
    fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi",
+                   TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
    fGdmlE->NewAttr(mainN, nullptr, "starttheta", TString::Format(fltPrecision.Data(), geoShape->GetTheta1()));
-   fGdmlE->NewAttr(mainN, nullptr, "deltatheta", TString::Format(fltPrecision.Data(), geoShape->GetTheta2() - geoShape->GetTheta1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltatheta",
+                   TString::Format(fltPrecision.Data(), geoShape->GetTheta2() - geoShape->GetTheta1()));
 
    fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
    fGdmlE->NewAttr(mainN, nullptr, "lunit", fDefault_lunit);
@@ -1073,7 +1063,7 @@ XMLNodePointer_t TGDMLWrite::CreateSphereN(TGeoSphere * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "arb8" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateArb8N(TGeoArb8 * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateArb8N(TGeoArb8 *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "arb8", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1108,7 +1098,7 @@ XMLNodePointer_t TGDMLWrite::CreateArb8N(TGeoArb8 * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "cone" node for GDML from TGeoConeSeg object
 
-XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "cone", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1124,7 +1114,8 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "rmax1", TString::Format(fltPrecision.Data(), geoShape->GetRmax1()));
    fGdmlE->NewAttr(mainN, nullptr, "rmax2", TString::Format(fltPrecision.Data(), geoShape->GetRmax2()));
    fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi",
+                   TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
 
    fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
    fGdmlE->NewAttr(mainN, nullptr, "lunit", fDefault_lunit);
@@ -1134,7 +1125,7 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoConeSeg * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "cone" node for GDML from TGeoCone object
 
-XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoCone * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoCone *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "cone", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1160,7 +1151,7 @@ XMLNodePointer_t TGDMLWrite::CreateConeN(TGeoCone * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "para" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateParaN(TGeoPara * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateParaN(TGeoPara *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "para", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1181,21 +1172,21 @@ XMLNodePointer_t TGDMLWrite::CreateParaN(TGeoPara * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "trap" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateTrapN(TGeoTrap * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTrapN(TGeoTrap *geoShape)
 {
    XMLNodePointer_t mainN;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
-   //if one base equals 0 create Arb8 instead of trap
+   // if one base equals 0 create Arb8 instead of trap
    if ((geoShape->GetBl1() == 0 || geoShape->GetTl1() == 0 || geoShape->GetH1() == 0) ||
        (geoShape->GetBl2() == 0 || geoShape->GetTl2() == 0 || geoShape->GetH2() == 0)) {
       mainN = CreateArb8N(geoShape);
       return mainN;
    }
 
-   //if is twisted then create arb8
+   // if is twisted then create arb8
    if (geoShape->IsTwisted()) {
-      mainN = CreateArb8N((TGeoArb8 *) geoShape);
+      mainN = CreateArb8N((TGeoArb8 *)geoShape);
       return mainN;
    }
 
@@ -1227,27 +1218,27 @@ XMLNodePointer_t TGDMLWrite::CreateTrapN(TGeoTrap * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "twistedtrap" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra *geoShape)
 {
    XMLNodePointer_t mainN;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
-   //if one base equals 0 create Arb8 instead of twisted trap
+   // if one base equals 0 create Arb8 instead of twisted trap
    if ((geoShape->GetBl1() == 0 && geoShape->GetTl1() == 0 && geoShape->GetH1() == 0) ||
        (geoShape->GetBl2() == 0 && geoShape->GetTl2() == 0 && geoShape->GetH2() == 0)) {
-      mainN = CreateArb8N((TGeoArb8 *) geoShape);
+      mainN = CreateArb8N((TGeoArb8 *)geoShape);
       return mainN;
    }
 
-   //if is twisted then create arb8
+   // if is twisted then create arb8
    if (geoShape->IsTwisted()) {
-      mainN = CreateArb8N((TGeoArb8 *) geoShape);
+      mainN = CreateArb8N((TGeoArb8 *)geoShape);
       return mainN;
    }
 
-   //if parameter twistAngle (PhiTwist) equals zero create trap node
+   // if parameter twistAngle (PhiTwist) equals zero create trap node
    if (geoShape->GetTwistAngle() == 0) {
-      mainN = CreateTrapN((TGeoTrap *) geoShape);
+      mainN = CreateTrapN((TGeoTrap *)geoShape);
       return mainN;
    }
 
@@ -1270,13 +1261,14 @@ XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
 
    fGdmlE->NewAttr(mainN, nullptr, "Alph", TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()));
 
-   //check if alpha1 equals to alpha2 (converting to string - to avoid problems with floats)
-   if (TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()) != TString::Format(fltPrecision.Data(), geoShape->GetAlpha2())) {
+   // check if alpha1 equals to alpha2 (converting to string - to avoid problems with floats)
+   if (TString::Format(fltPrecision.Data(), geoShape->GetAlpha1()) !=
+       TString::Format(fltPrecision.Data(), geoShape->GetAlpha2())) {
       Info("CreateTwistedTrapN",
            "ERROR! Object %s is not exported correctly because parameter Alpha2 is not declared in GDML schema",
            lname.Data());
    }
-   //fGdmlE->NewAttr(mainN,0, "alpha2", TString::Format(fltPrecision.Data(), geoShape->GetAlpha2()));
+   // fGdmlE->NewAttr(mainN,0, "alpha2", TString::Format(fltPrecision.Data(), geoShape->GetAlpha2()));
    fGdmlE->NewAttr(mainN, nullptr, "PhiTwist", TString::Format(fltPrecision.Data(), geoShape->GetTwistAngle()));
 
    fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
@@ -1287,7 +1279,7 @@ XMLNodePointer_t TGDMLWrite::CreateTwistedTrapN(TGeoGtra * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "trd" node for GDML from object TGeoTrd1
 
-XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd1 * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd1 *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "trd", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1310,7 +1302,7 @@ XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd1 * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "trd" node for GDML from object TGeoTrd2
 
-XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd2 * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd2 *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "trd", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1333,22 +1325,22 @@ XMLNodePointer_t TGDMLWrite::CreateTrdN(TGeoTrd2 * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "tube" node for GDML  from  object TGeoTubeSeg
 
-XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTubeSeg * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTubeSeg *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "tube", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
-   if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
-       IsNullParam(geoShape->GetDz(), "Dz", lname)) {
+   if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) || IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return nullptr;
    }
 
    fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
    fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
-   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(),  2 * geoShape->GetDz()));
+   fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
    fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi",
+                   TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
 
    fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
    fGdmlE->NewAttr(mainN, nullptr, "lunit", fDefault_lunit);
@@ -1358,7 +1350,7 @@ XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTubeSeg * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "cutTube" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub *geoShape)
 {
    XMLNodePointer_t mainN;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1366,16 +1358,15 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
    mainN = fGdmlE->NewChild(nullptr, nullptr, "cutTube", nullptr);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
-   if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
-       IsNullParam(geoShape->GetDz(), "Dz", lname)) {
+   if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) || IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return nullptr;
    }
-   //This is not needed, because cutTube is already supported by Geant4 9.5
+   // This is not needed, because cutTube is already supported by Geant4 9.5
    if (fgG4Compatibility == kTRUE && kFALSE) {
-      TGeoShape * fakeCtub = CreateFakeCtub(geoShape);
+      TGeoShape *fakeCtub = CreateFakeCtub(geoShape);
       mainN = ChooseObject(fakeCtub);
 
-      //register name for cuttube shape (so it will be found during volume export)
+      // register name for cuttube shape (so it will be found during volume export)
       lname = fNameList->fLst[TString::Format("%p", fakeCtub)];
       fNameList->fLst[TString::Format("%p", geoShape)] = lname;
       Info("CreateCutTubeN", "WARNING! %s - CutTube was replaced by intersection of TGeoTubSeg and two TGeoBBoxes",
@@ -1386,7 +1377,8 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
    fGdmlE->NewAttr(mainN, nullptr, "z", TString::Format(fltPrecision.Data(), 2 * geoShape->GetDz()));
    fGdmlE->NewAttr(mainN, nullptr, "startphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi1()));
-   fGdmlE->NewAttr(mainN, nullptr, "deltaphi", TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
+   fGdmlE->NewAttr(mainN, nullptr, "deltaphi",
+                   TString::Format(fltPrecision.Data(), geoShape->GetPhi2() - geoShape->GetPhi1()));
    fGdmlE->NewAttr(mainN, nullptr, "lowX", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[0]));
    fGdmlE->NewAttr(mainN, nullptr, "lowY", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[1]));
    fGdmlE->NewAttr(mainN, nullptr, "lowZ", TString::Format(fltPrecision.Data(), geoShape->GetNlow()[2]));
@@ -1403,14 +1395,13 @@ XMLNodePointer_t TGDMLWrite::CreateCutTubeN(TGeoCtub * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "tube" node for GDML from  object TGeoTube
 
-XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTube * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTubeN(TGeoTube *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "tube", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
-   if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) ||
-       IsNullParam(geoShape->GetDz(), "Dz", lname)) {
+   if (IsNullParam(geoShape->GetRmax(), "Rmax", lname) || IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return nullptr;
    }
 
@@ -1443,7 +1434,7 @@ XMLNodePointer_t TGDMLWrite::CreateZplaneN(Double_t z, Double_t rmin, Double_t r
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "polycone" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreatePolyconeN(TGeoPcon * geoShape)
+XMLNodePointer_t TGDMLWrite::CreatePolyconeN(TGeoPcon *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "polycone", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1457,35 +1448,40 @@ XMLNodePointer_t TGDMLWrite::CreatePolyconeN(TGeoPcon * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "lunit", fDefault_lunit);
    Int_t nZPlns = geoShape->GetNz();
    for (Int_t it = 0; it < nZPlns; it++) {
-      //add zplane child node
+      // add zplane child node
       fGdmlE->AddChild(mainN, CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmin(it), geoShape->GetRmax(it)));
-      //compare actual plane and next plane
+      // compare actual plane and next plane
       if ((it < nZPlns - 1) && (geoShape->GetZ(it) == geoShape->GetZ(it + 1))) {
-         //rmin of actual is greater then rmax of next one
-         //        |   |rmax next
-         //  __ ...|   |...  __   < rmin actual
-         // |  |            |  |
+         // rmin of actual is greater then rmax of next one
+         //         |   |rmax next
+         //   __ ...|   |...  __   < rmin actual
+         //  |  |            |  |
          if (geoShape->GetRmin(it) > geoShape->GetRmax(it + 1)) {
-            //adding plane from rmax next to rmin actual at the same z position
+            // adding plane from rmax next to rmin actual at the same z position
             if (fgG4Compatibility == kTRUE) {
-               fGdmlE->AddChild(mainN, CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmax(it + 1), geoShape->GetRmin(it)));
-               Info("CreatePolyconeN", "WARNING! One plane was added to %s solid to be compatible with Geant4", lname.Data());
+               fGdmlE->AddChild(mainN,
+                                CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmax(it + 1), geoShape->GetRmin(it)));
+               Info("CreatePolyconeN", "WARNING! One plane was added to %s solid to be compatible with Geant4",
+                    lname.Data());
             } else {
-               Info("CreatePolyconeN", "WARNING! Solid %s definition seems not contiguous may cause problems in Geant4", lname.Data());
+               Info("CreatePolyconeN", "WARNING! Solid %s definition seems not contiguous may cause problems in Geant4",
+                    lname.Data());
             }
-
          }
-         //rmin of next is greater then rmax of actual
-         //  |  |         |  |
-         //  |  |...___...|  |  rmin next
-         //        |   |     > rmax act
+         // rmin of next is greater then rmax of actual
+         //   |  |         |  |
+         //   |  |...___...|  |  rmin next
+         //         |   |     > rmax act
          if (geoShape->GetRmin(it + 1) > geoShape->GetRmax(it)) {
-            //adding plane from rmax act to rmin next at the same z position
+            // adding plane from rmax act to rmin next at the same z position
             if (fgG4Compatibility == kTRUE) {
-               fGdmlE->AddChild(mainN, CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmax(it), geoShape->GetRmin(it + 1)));
-               Info("CreatePolyconeN", "WARNING! One plane was added to %s solid to be compatible with Geant4", lname.Data());
+               fGdmlE->AddChild(mainN,
+                                CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmax(it), geoShape->GetRmin(it + 1)));
+               Info("CreatePolyconeN", "WARNING! One plane was added to %s solid to be compatible with Geant4",
+                    lname.Data());
             } else {
-               Info("CreatePolyconeN", "WARNING! Solid %s definition seems not contiguous may cause problems in Geant4", lname.Data());
+               Info("CreatePolyconeN", "WARNING! Solid %s definition seems not contiguous may cause problems in Geant4",
+                    lname.Data());
             }
          }
       }
@@ -1496,7 +1492,7 @@ XMLNodePointer_t TGDMLWrite::CreatePolyconeN(TGeoPcon * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "torus" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateTorusN(TGeoTorus * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTorusN(TGeoTorus *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "torus", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1521,7 +1517,7 @@ XMLNodePointer_t TGDMLWrite::CreateTorusN(TGeoTorus * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "polyhedra" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreatePolyhedraN(TGeoPgon * geoShape)
+XMLNodePointer_t TGDMLWrite::CreatePolyhedraN(TGeoPgon *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "polyhedra", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1534,7 +1530,7 @@ XMLNodePointer_t TGDMLWrite::CreatePolyhedraN(TGeoPgon * geoShape)
    fGdmlE->NewAttr(mainN, nullptr, "aunit", "deg");
    fGdmlE->NewAttr(mainN, nullptr, "lunit", fDefault_lunit);
    for (Int_t it = 0; it < geoShape->GetNz(); it++) {
-      //add zplane child node
+      // add zplane child node
       fGdmlE->AddChild(mainN, CreateZplaneN(geoShape->GetZ(it), geoShape->GetRmin(it), geoShape->GetRmax(it)));
    }
    return mainN;
@@ -1543,14 +1539,13 @@ XMLNodePointer_t TGDMLWrite::CreatePolyhedraN(TGeoPgon * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "eltube" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateEltubeN(TGeoEltu * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateEltubeN(TGeoEltu *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "eltube", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    TString lname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
    fGdmlE->NewAttr(mainN, nullptr, "name", lname);
-   if (IsNullParam(geoShape->GetA(), "A", lname) ||
-       IsNullParam(geoShape->GetB(), "B", lname) ||
+   if (IsNullParam(geoShape->GetA(), "A", lname) || IsNullParam(geoShape->GetB(), "B", lname) ||
        IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return nullptr;
    }
@@ -1567,7 +1562,7 @@ XMLNodePointer_t TGDMLWrite::CreateEltubeN(TGeoEltu * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "hype" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "hype", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1576,7 +1571,6 @@ XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype * geoShape)
    if (IsNullParam(geoShape->GetDz(), "Dz", lname)) {
       return nullptr;
    }
-
 
    fGdmlE->NewAttr(mainN, nullptr, "rmin", TString::Format(fltPrecision.Data(), geoShape->GetRmin()));
    fGdmlE->NewAttr(mainN, nullptr, "rmax", TString::Format(fltPrecision.Data(), geoShape->GetRmax()));
@@ -1593,7 +1587,7 @@ XMLNodePointer_t TGDMLWrite::CreateHypeN(TGeoHype * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "xtru" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "xtru", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1602,7 +1596,7 @@ XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
 
    fGdmlE->NewAttr(mainN, nullptr, "lunit", fDefault_lunit);
    XMLNodePointer_t childN;
-   Int_t vertNum =  geoShape->GetNvert();
+   Int_t vertNum = geoShape->GetNvert();
    Int_t secNum = geoShape->GetNz();
    if (vertNum < 3 || secNum < 2) {
       Info("CreateXtrusionN", "ERROR! TGeoXtru %s has only %i vertices and %i sections. It was not exported",
@@ -1611,14 +1605,14 @@ XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
       return mainN;
    }
    for (Int_t it = 0; it < vertNum; it++) {
-      //add twoDimVertex child node
+      // add twoDimVertex child node
       childN = fGdmlE->NewChild(nullptr, nullptr, "twoDimVertex", nullptr);
       fGdmlE->NewAttr(childN, nullptr, "x", TString::Format(fltPrecision.Data(), geoShape->GetX(it)));
       fGdmlE->NewAttr(childN, nullptr, "y", TString::Format(fltPrecision.Data(), geoShape->GetY(it)));
       fGdmlE->AddChild(mainN, childN);
    }
    for (Int_t it = 0; it < secNum; it++) {
-      //add section child node
+      // add section child node
       childN = fGdmlE->NewChild(nullptr, nullptr, "section", nullptr);
       fGdmlE->NewAttr(childN, nullptr, "zOrder", TString::Format("%i", it));
       fGdmlE->NewAttr(childN, nullptr, "zPosition", TString::Format(fltPrecision.Data(), geoShape->GetZ(it)));
@@ -1636,18 +1630,17 @@ XMLNodePointer_t TGDMLWrite::CreateXtrusionN(TGeoXtru * geoShape)
 /// so when intersection of scaled sphere and TGeoBBox is found,
 /// it is considered as an ellipsoid
 
-XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape * geoShape, TString elName)
+XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape *geoShape, TString elName)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "ellipsoid", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   TGeoScaledShape *leftS = (TGeoScaledShape *)geoShape->GetBoolNode()->GetLeftShape(); //ScaledShape
-   TGeoBBox *rightS = (TGeoBBox *)geoShape->GetBoolNode()->GetRightShape(); //BBox
-
+   TGeoScaledShape *leftS = (TGeoScaledShape *)geoShape->GetBoolNode()->GetLeftShape(); // ScaledShape
+   TGeoBBox *rightS = (TGeoBBox *)geoShape->GetBoolNode()->GetRightShape();             // BBox
 
    fGdmlE->NewAttr(mainN, nullptr, "name", elName.Data());
    Double_t sx = leftS->GetScale()->GetScale()[0];
    Double_t sy = leftS->GetScale()->GetScale()[1];
-   Double_t radius = ((TGeoSphere *) leftS->GetShape())->GetRmax();
+   Double_t radius = ((TGeoSphere *)leftS->GetShape())->GetRmax();
 
    Double_t ax, by, cz;
    cz = radius;
@@ -1658,7 +1651,6 @@ XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape * geoShape, TSt
    Double_t zorig = rightS->GetOrigin()[2];
    Double_t zcut2 = dz + zorig;
    Double_t zcut1 = 2 * zorig - zcut2;
-
 
    fGdmlE->NewAttr(mainN, nullptr, "ax", TString::Format(fltPrecision.Data(), ax));
    fGdmlE->NewAttr(mainN, nullptr, "by", TString::Format(fltPrecision.Data(), by));
@@ -1675,14 +1667,14 @@ XMLNodePointer_t TGDMLWrite::CreateEllipsoidN(TGeoCompositeShape * geoShape, TSt
 /// this is a special case, because elliptical cone is not defined in ROOT
 /// so when scaled cone is found, it is considered as a elliptical cone
 
-XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape *geoShape)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "elcone", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    fGdmlE->NewAttr(mainN, nullptr, "name", GenName(geoShape->GetName(), TString::Format("%p", geoShape)));
-   Double_t zcut = ((TGeoCone *) geoShape->GetShape())->GetDz();
-   Double_t rx1 = ((TGeoCone *) geoShape->GetShape())->GetRmax1();
-   Double_t rx2 = ((TGeoCone *) geoShape->GetShape())->GetRmax2();
+   Double_t zcut = ((TGeoCone *)geoShape->GetShape())->GetDz();
+   Double_t rx1 = ((TGeoCone *)geoShape->GetShape())->GetRmax1();
+   Double_t rx2 = ((TGeoCone *)geoShape->GetShape())->GetRmax2();
    Double_t zmax = zcut * ((rx1 + rx2) / (rx1 - rx2));
    Double_t z = zcut + zmax;
 
@@ -1702,7 +1694,7 @@ XMLNodePointer_t TGDMLWrite::CreateElConeN(TGeoScaledShape * geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "tessellated" (tessellated shape) node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateTessellatedN(TGeoTessellated * geoShape)
+XMLNodePointer_t TGDMLWrite::CreateTessellatedN(TGeoTessellated *geoShape)
 {
    // add all vertices to the define section
    TString genname = GenName(geoShape->GetName(), TString::Format("%p", geoShape));
@@ -1714,7 +1706,7 @@ XMLNodePointer_t TGDMLWrite::CreateTessellatedN(TGeoTessellated * geoShape)
       nodPos.y = vertex[1];
       nodPos.z = vertex[2];
       auto childN = CreatePositionN(posName.Data(), nodPos, "position", fDefault_lunit);
-      fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
+      fGdmlE->AddChild(fDefineNode, childN); // adding node to <define> node
    }
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "tessellated", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", genname.Data());
@@ -1722,7 +1714,7 @@ XMLNodePointer_t TGDMLWrite::CreateTessellatedN(TGeoTessellated * geoShape)
 
    XMLNodePointer_t childN;
    for (Int_t it = 0; it < geoShape->GetNfacets(); it++) {
-      //add section child node
+      // add section child node
       auto facet = geoShape->GetFacet(it);
       bool triangular = facet.GetNvert() == 3;
       TString ntype = (triangular) ? "triangular" : "quadrangular";
@@ -1748,30 +1740,23 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
    TString lboolType;
    TGeoBoolNode::EGeoBoolType boolType = geoShape->GetBoolNode()->GetBooleanOperator();
    switch (boolType) {
-      case TGeoBoolNode::kGeoUnion:
-         lboolType = "union";
-         break;
-      case TGeoBoolNode::kGeoSubtraction:
-         lboolType = "subtraction";
-         break;
-      case TGeoBoolNode::kGeoIntersection:
-         lboolType = "intersection";
-         break;
+   case TGeoBoolNode::kGeoUnion: lboolType = "union"; break;
+   case TGeoBoolNode::kGeoSubtraction: lboolType = "subtraction"; break;
+   case TGeoBoolNode::kGeoIntersection: lboolType = "intersection"; break;
    }
 
    TGDMLWrite::Xyz lrot = GetXYZangles(geoShape->GetBoolNode()->GetLeftMatrix()->Inverse().GetRotationMatrix());
-   const Double_t  *ltr = geoShape->GetBoolNode()->GetLeftMatrix()->GetTranslation();
+   const Double_t *ltr = geoShape->GetBoolNode()->GetLeftMatrix()->GetTranslation();
    TGDMLWrite::Xyz rrot = GetXYZangles(geoShape->GetBoolNode()->GetRightMatrix()->Inverse().GetRotationMatrix());
-   const Double_t  *rtr = geoShape->GetBoolNode()->GetRightMatrix()->GetTranslation();
+   const Double_t *rtr = geoShape->GetBoolNode()->GetRightMatrix()->GetTranslation();
 
-   //specific case!
-   //Ellipsoid tag preparing
-   //if left == TGeoScaledShape AND right  == TGeoBBox
-   //   AND if TGeoScaledShape->GetShape == TGeoSphere
+   // specific case!
+   // Ellipsoid tag preparing
+   // if left == TGeoScaledShape AND right  == TGeoBBox
+   //    AND if TGeoScaledShape->GetShape == TGeoSphere
    TGeoShape *leftS = geoShape->GetBoolNode()->GetLeftShape();
    TGeoShape *rightS = geoShape->GetBoolNode()->GetRightShape();
-   if (strcmp(leftS->ClassName(), "TGeoScaledShape") == 0 &&
-       strcmp(rightS->ClassName(), "TGeoBBox") == 0) {
+   if (strcmp(leftS->ClassName(), "TGeoScaledShape") == 0 && strcmp(rightS->ClassName(), "TGeoBBox") == 0) {
       if (strcmp(((TGeoScaledShape *)leftS)->GetShape()->ClassName(), "TGeoSphere") == 0) {
          if (lboolType == "intersection") {
             mainN = CreateEllipsoidN(geoShape, nodeName);
@@ -1781,7 +1766,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
    }
 
    Xyz translL, translR;
-   //translation
+   // translation
    translL.x = ltr[0];
    translL.y = ltr[1];
    translL.z = ltr[2];
@@ -1789,15 +1774,15 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
    translR.y = rtr[1];
    translR.z = rtr[2];
 
-   //left and right nodes are created here also their names are created
+   // left and right nodes are created here also their names are created
    ndL = ChooseObject(geoShape->GetBoolNode()->GetLeftShape());
    ndR = ChooseObject(geoShape->GetBoolNode()->GetRightShape());
 
-   //retrieve left and right node names by their pointer to make reference
+   // retrieve left and right node names by their pointer to make reference
    TString lname = fNameList->fLst[TString::Format("%p", geoShape->GetBoolNode()->GetLeftShape())];
    TString rname = fNameList->fLst[TString::Format("%p", geoShape->GetBoolNode()->GetRightShape())];
 
-   //left and right nodes appended to main structure of nodes (if they are not already there)
+   // left and right nodes appended to main structure of nodes (if they are not already there)
    if (ndL != nullptr) {
       fGdmlE->AddChild(fSolidsNode, ndL);
       fSolCnt++;
@@ -1817,7 +1802,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
       }
    }
 
-   //create union node and its child nodes (or intersection or subtraction)
+   // create union node and its child nodes (or intersection or subtraction)
    /* <union name="...">
     *   <first ref="left name" />
     *   <second ref="right name" />
@@ -1826,7 +1811,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
     *   <position .../>
     *   <rotation .../>
     * </union>
-   */
+    */
    mainN = fGdmlE->NewChild(nullptr, nullptr, lboolType.Data(), nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", nodeName);
 
@@ -1842,7 +1827,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
 
    //<firstposition> (left)
    if ((translL.x != 0.0) || (translL.y != 0.0) || (translL.z != 0.0)) {
-     childN = CreatePositionN((nodeName + lname + "pos").Data(), translL, "firstposition", fDefault_lunit);
+      childN = CreatePositionN((nodeName + lname + "pos").Data(), translL, "firstposition", fDefault_lunit);
       fGdmlE->AddChild(mainN, childN);
    }
    //<firstrotation> (left)
@@ -1867,7 +1852,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "opticalsurface" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf)
+XMLNodePointer_t TGDMLWrite::CreateOpticalSurfaceN(TGeoOpticalSurface *geoSurf)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "opticalsurface", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1883,8 +1868,8 @@ XMLNodePointer_t TGDMLWrite::CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf)
    if (properties.GetSize()) {
       TIter next(&properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
    return mainN;
 }
@@ -1892,7 +1877,7 @@ XMLNodePointer_t TGDMLWrite::CreateOpticalSurfaceN(TGeoOpticalSurface * geoSurf)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "skinsurface" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateSkinSurfaceN(TGeoSkinSurface * geoSurf)
+XMLNodePointer_t TGDMLWrite::CreateSkinSurfaceN(TGeoSkinSurface *geoSurf)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "skinsurface", nullptr);
    std::string name = make_NCName(geoSurf->GetName());
@@ -1902,7 +1887,7 @@ XMLNodePointer_t TGDMLWrite::CreateSkinSurfaceN(TGeoSkinSurface * geoSurf)
    fGdmlE->NewAttr(mainN, nullptr, "surfaceproperty", prop.c_str());
    // Cretate the logical volume reference node
    XMLNodePointer_t childN = fGdmlE->NewChild(nullptr, nullptr, "volumeref", nullptr);
-   const TString& volname = fNameList->fLst[TString::Format("%p", geoSurf->GetVolume())];
+   const TString &volname = fNameList->fLst[TString::Format("%p", geoSurf->GetVolume())];
    fGdmlE->NewAttr(childN, nullptr, "ref", volname.Data());
    fGdmlE->AddChild(mainN, childN);
    return mainN;
@@ -1911,7 +1896,7 @@ XMLNodePointer_t TGDMLWrite::CreateSkinSurfaceN(TGeoSkinSurface * geoSurf)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "bordersurface" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateBorderSurfaceN(TGeoBorderSurface * geoSurf)
+XMLNodePointer_t TGDMLWrite::CreateBorderSurfaceN(TGeoBorderSurface *geoSurf)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "bordersurface", nullptr);
    std::string name = make_NCName(geoSurf->GetName());
@@ -1936,7 +1921,7 @@ XMLNodePointer_t TGDMLWrite::CreateBorderSurfaceN(TGeoBorderSurface * geoSurf)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "position" kind of node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreatePositionN(const char * name, Xyz position, const char * type, const char * unit)
+XMLNodePointer_t TGDMLWrite::CreatePositionN(const char *name, Xyz position, const char *type, const char *unit)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, type, nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1951,7 +1936,7 @@ XMLNodePointer_t TGDMLWrite::CreatePositionN(const char * name, Xyz position, co
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "rotation" kind of node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateRotationN(const char * name, Xyz rotation, const char * type, const char * unit)
+XMLNodePointer_t TGDMLWrite::CreateRotationN(const char *name, Xyz rotation, const char *type, const char *unit)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, type, nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
@@ -1974,12 +1959,14 @@ XMLNodePointer_t TGDMLWrite::CreateMatrixN(TGDMLMatrix const *matrix)
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "matrix", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", matrix->GetName());
    fGdmlE->NewAttr(mainN, nullptr, "coldim", TString::Format("%zu", cols));
-   for(size_t i=0; i<rows; ++i)  {
-     for(size_t j=0; j<cols; ++j)  {
-       vals << matrix->Get(i,j);
-       if ( j < cols-1 ) vals << ' ';
-     }
-     if ( i < rows-1 ) vals << '\n';
+   for (size_t i = 0; i < rows; ++i) {
+      for (size_t j = 0; j < cols; ++j) {
+         vals << matrix->Get(i, j);
+         if (j < cols - 1)
+            vals << ' ';
+      }
+      if (i < rows - 1)
+         vals << '\n';
    }
    fGdmlE->NewAttr(mainN, nullptr, "values", vals.str().c_str());
    return mainN;
@@ -2001,7 +1988,7 @@ XMLNodePointer_t TGDMLWrite::CreateConstantN(const char *name, Double_t value)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "setup" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateSetupN(const char * topVolName, const char * name, const char * version)
+XMLNodePointer_t TGDMLWrite::CreateSetupN(const char *topVolName, const char *name, const char *version)
 {
    XMLNodePointer_t setupN = fGdmlE->NewChild(nullptr, nullptr, "setup", nullptr);
    fGdmlE->NewAttr(setupN, nullptr, "name", name);
@@ -2014,7 +2001,7 @@ XMLNodePointer_t TGDMLWrite::CreateSetupN(const char * topVolName, const char * 
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "volume" node for GDML
 
-XMLNodePointer_t TGDMLWrite::StartVolumeN(const char * name, const char * solid, const char * material)
+XMLNodePointer_t TGDMLWrite::StartVolumeN(const char *name, const char *solid, const char *material)
 {
    XMLNodePointer_t childN;
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "volume", nullptr);
@@ -2034,7 +2021,7 @@ XMLNodePointer_t TGDMLWrite::StartVolumeN(const char * name, const char * solid,
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "assembly" node for GDML
 
-XMLNodePointer_t TGDMLWrite::StartAssemblyN(const char * name)
+XMLNodePointer_t TGDMLWrite::StartAssemblyN(const char *name)
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "assembly", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
@@ -2045,13 +2032,14 @@ XMLNodePointer_t TGDMLWrite::StartAssemblyN(const char * name)
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "physvol" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, const char * volref, const char * posref, const char * rotref, XMLNodePointer_t scaleN)
+XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, const char *volref, const char *posref,
+                                            const char *rotref, XMLNodePointer_t scaleN)
 {
    fPhysVolCnt++;
    XMLNodePointer_t childN;
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "physvol", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
-   fGdmlE->NewAttr(mainN, nullptr, "copynumber", TString::Format("%d",copyno));
+   fGdmlE->NewAttr(mainN, nullptr, "copynumber", TString::Format("%d", copyno));
 
    childN = fGdmlE->NewChild(nullptr, nullptr, "volumeref", nullptr);
    fGdmlE->NewAttr(childN, nullptr, "ref", volref);
@@ -2061,7 +2049,7 @@ XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, cons
    fGdmlE->NewAttr(childN, nullptr, "ref", posref);
    fGdmlE->AddChild(mainN, childN);
 
-   //if is not empty string add this node
+   // if is not empty string add this node
    if (strcmp(rotref, "") != 0) {
       childN = fGdmlE->NewChild(nullptr, nullptr, "rotationref", nullptr);
       fGdmlE->NewAttr(childN, nullptr, "ref", rotref);
@@ -2077,21 +2065,22 @@ XMLNodePointer_t TGDMLWrite::CreatePhysVolN(const char *name, Int_t copyno, cons
 ////////////////////////////////////////////////////////////////////////////////
 /// Creates "divisionvol" node for GDML
 
-XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, Int_t number, const char * axis, const char * unit, const char * volref)
+XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, Int_t number, const char *axis,
+                                             const char *unit, const char *volref)
 {
    XMLNodePointer_t childN = 0;
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "divisionvol", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "axis", axis);
    fGdmlE->NewAttr(mainN, nullptr, "number", TString::Format("%i", number));
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
-   if (fgG4Compatibility  == kTRUE) {
-      //if eg. full length is 20 and width * number = 20,0001 problem in geant4
-      //unit is either in cm or degrees nothing else
+   if (fgG4Compatibility == kTRUE) {
+      // if eg. full length is 20 and width * number = 20,0001 problem in geant4
+      // unit is either in cm or degrees nothing else
       width = (floor(width * 1E4)) * 1E-4;
       if ((offset >= 0.) && (strcmp(axis, "kPhi") == 0)) {
-         Int_t offsetI = (Int_t) offset;
+         Int_t offsetI = (Int_t)offset;
          Double_t decimals = offset - offsetI;
-         //put to range from 0 to 360 add decimals and then put to range 0 -> -360
+         // put to range from 0 to 360 add decimals and then put to range 0 -> -360
          offset = (offsetI % 360) + decimals - 360;
       }
    }
@@ -2105,7 +2094,6 @@ XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, In
    }
    fGdmlE->AddChild(mainN, childN);
 
-
    return mainN;
 }
 
@@ -2114,81 +2102,81 @@ XMLNodePointer_t TGDMLWrite::CreateDivisionN(Double_t offset, Double_t width, In
 
 XMLNodePointer_t TGDMLWrite::ChooseObject(TGeoShape *geoShape)
 {
-   const char * clsname = geoShape->ClassName();
+   const char *clsname = geoShape->ClassName();
    XMLNodePointer_t solidN;
 
    if (CanProcess((TObject *)geoShape) == kFALSE) {
       return nullptr;
    }
 
-   //process different shapes
+   // process different shapes
    if (strcmp(clsname, "TGeoBBox") == 0) {
-      solidN = CreateBoxN((TGeoBBox*) geoShape);
+      solidN = CreateBoxN((TGeoBBox *)geoShape);
    } else if (strcmp(clsname, "TGeoParaboloid") == 0) {
-      solidN = CreateParaboloidN((TGeoParaboloid*) geoShape);
+      solidN = CreateParaboloidN((TGeoParaboloid *)geoShape);
    } else if (strcmp(clsname, "TGeoSphere") == 0) {
-      solidN = CreateSphereN((TGeoSphere*) geoShape);
+      solidN = CreateSphereN((TGeoSphere *)geoShape);
    } else if (strcmp(clsname, "TGeoArb8") == 0) {
-      solidN = CreateArb8N((TGeoArb8*) geoShape);
+      solidN = CreateArb8N((TGeoArb8 *)geoShape);
    } else if (strcmp(clsname, "TGeoConeSeg") == 0) {
-      solidN = CreateConeN((TGeoConeSeg*) geoShape);
+      solidN = CreateConeN((TGeoConeSeg *)geoShape);
    } else if (strcmp(clsname, "TGeoCone") == 0) {
-      solidN = CreateConeN((TGeoCone*) geoShape);
+      solidN = CreateConeN((TGeoCone *)geoShape);
    } else if (strcmp(clsname, "TGeoPara") == 0) {
-      solidN = CreateParaN((TGeoPara*) geoShape);
+      solidN = CreateParaN((TGeoPara *)geoShape);
    } else if (strcmp(clsname, "TGeoTrap") == 0) {
-      solidN = CreateTrapN((TGeoTrap*) geoShape);
+      solidN = CreateTrapN((TGeoTrap *)geoShape);
    } else if (strcmp(clsname, "TGeoGtra") == 0) {
-      solidN = CreateTwistedTrapN((TGeoGtra*) geoShape);
+      solidN = CreateTwistedTrapN((TGeoGtra *)geoShape);
    } else if (strcmp(clsname, "TGeoTrd1") == 0) {
-      solidN = CreateTrdN((TGeoTrd1*) geoShape);
+      solidN = CreateTrdN((TGeoTrd1 *)geoShape);
    } else if (strcmp(clsname, "TGeoTrd2") == 0) {
-      solidN = CreateTrdN((TGeoTrd2*) geoShape);
+      solidN = CreateTrdN((TGeoTrd2 *)geoShape);
    } else if (strcmp(clsname, "TGeoTubeSeg") == 0) {
-      solidN = CreateTubeN((TGeoTubeSeg*) geoShape);
+      solidN = CreateTubeN((TGeoTubeSeg *)geoShape);
    } else if (strcmp(clsname, "TGeoCtub") == 0) {
-      solidN = CreateCutTubeN((TGeoCtub*) geoShape);
+      solidN = CreateCutTubeN((TGeoCtub *)geoShape);
    } else if (strcmp(clsname, "TGeoTube") == 0) {
-      solidN = CreateTubeN((TGeoTube*) geoShape);
+      solidN = CreateTubeN((TGeoTube *)geoShape);
    } else if (strcmp(clsname, "TGeoPcon") == 0) {
-      solidN = CreatePolyconeN((TGeoPcon*) geoShape);
+      solidN = CreatePolyconeN((TGeoPcon *)geoShape);
    } else if (strcmp(clsname, "TGeoTorus") == 0) {
-      solidN = CreateTorusN((TGeoTorus*) geoShape);
+      solidN = CreateTorusN((TGeoTorus *)geoShape);
    } else if (strcmp(clsname, "TGeoPgon") == 0) {
-      solidN = CreatePolyhedraN((TGeoPgon*) geoShape);
+      solidN = CreatePolyhedraN((TGeoPgon *)geoShape);
    } else if (strcmp(clsname, "TGeoEltu") == 0) {
-      solidN = CreateEltubeN((TGeoEltu*) geoShape);
+      solidN = CreateEltubeN((TGeoEltu *)geoShape);
    } else if (strcmp(clsname, "TGeoHype") == 0) {
-      solidN = CreateHypeN((TGeoHype*) geoShape);
+      solidN = CreateHypeN((TGeoHype *)geoShape);
    } else if (strcmp(clsname, "TGeoXtru") == 0) {
-      solidN = CreateXtrusionN((TGeoXtru*) geoShape);
+      solidN = CreateXtrusionN((TGeoXtru *)geoShape);
    } else if (strcmp(clsname, "TGeoTessellated") == 0) {
-      solidN = CreateTessellatedN((TGeoTessellated*) geoShape);
+      solidN = CreateTessellatedN((TGeoTessellated *)geoShape);
    } else if (strcmp(clsname, "TGeoScaledShape") == 0) {
-      TGeoScaledShape * geoscale = (TGeoScaledShape *) geoShape;
+      TGeoScaledShape *geoscale = (TGeoScaledShape *)geoShape;
       TString scaleObjClsName = geoscale->GetShape()->ClassName();
       if (scaleObjClsName == "TGeoCone") {
-         solidN = CreateElConeN((TGeoScaledShape*) geoShape);
+         solidN = CreateElConeN((TGeoScaledShape *)geoShape);
       } else {
-         Info("ChooseObject",
-              "ERROR! TGeoScaledShape object is not possible to process correctly. %s object is processed without scale",
-              scaleObjClsName.Data());
+         Info(
+            "ChooseObject",
+            "ERROR! TGeoScaledShape object is not possible to process correctly. %s object is processed without scale",
+            scaleObjClsName.Data());
          solidN = ChooseObject(geoscale->GetShape());
-         //Name has to be propagated to geoscale level pointer
+         // Name has to be propagated to geoscale level pointer
          fNameList->fLst[TString::Format("%p", geoscale)] =
             fNameList->fLst[TString::Format("%p", geoscale->GetShape())];
       }
    } else if (strcmp(clsname, "TGeoCompositeShape") == 0) {
-      solidN = CreateCommonBoolN((TGeoCompositeShape*) geoShape);
+      solidN = CreateCommonBoolN((TGeoCompositeShape *)geoShape);
    } else if (strcmp(clsname, "TGeoUnion") == 0) {
-      solidN = CreateCommonBoolN((TGeoCompositeShape*) geoShape);
+      solidN = CreateCommonBoolN((TGeoCompositeShape *)geoShape);
    } else if (strcmp(clsname, "TGeoIntersection") == 0) {
-      solidN = CreateCommonBoolN((TGeoCompositeShape*) geoShape);
+      solidN = CreateCommonBoolN((TGeoCompositeShape *)geoShape);
    } else if (strcmp(clsname, "TGeoSubtraction") == 0) {
-      solidN = CreateCommonBoolN((TGeoCompositeShape*) geoShape);
+      solidN = CreateCommonBoolN((TGeoCompositeShape *)geoShape);
    } else {
-      Info("ChooseObject", "ERROR! %s Solid CANNOT be processed, solid is NOT supported",
-           clsname);
+      Info("ChooseObject", "ERROR! %s Solid CANNOT be processed, solid is NOT supported", clsname);
       solidN = nullptr;
    }
    if (solidN == nullptr) {
@@ -2196,7 +2184,8 @@ XMLNodePointer_t TGDMLWrite::ChooseObject(TGeoShape *geoShape)
          TString missingName = geoShape->GetName();
          GenName("missing_" + missingName, TString::Format("%p", geoShape));
       } else {
-         fNameList->fLst[TString::Format("%p", geoShape)] = "missing_" + fNameList->fLst[TString::Format("%p", geoShape)];
+         fNameList->fLst[TString::Format("%p", geoShape)] =
+            "missing_" + fNameList->fLst[TString::Format("%p", geoShape)];
       }
    }
 
@@ -2206,7 +2195,7 @@ XMLNodePointer_t TGDMLWrite::ChooseObject(TGeoShape *geoShape)
 ////////////////////////////////////////////////////////////////////////////////
 /// Retrieves X Y Z angles from rotation matrix
 
-TGDMLWrite::Xyz TGDMLWrite::GetXYZangles(const Double_t * rotationMatrix)
+TGDMLWrite::Xyz TGDMLWrite::GetXYZangles(const Double_t *rotationMatrix)
 {
    TGDMLWrite::Xyz lxyz;
    Double_t a, b, c;
@@ -2232,7 +2221,7 @@ TGDMLWrite::Xyz TGDMLWrite::GetXYZangles(const Double_t * rotationMatrix)
 /// Method creating cutTube as an intersection of tube and two boxes
 /// - not used anymore because cutube is supported in Geant4 9.5
 
-TGeoCompositeShape* TGDMLWrite::CreateFakeCtub(TGeoCtub* geoShape)
+TGeoCompositeShape *TGDMLWrite::CreateFakeCtub(TGeoCtub *geoShape)
 {
    Double_t rmin = geoShape->GetRmin();
    Double_t rmax = geoShape->GetRmax();
@@ -2247,8 +2236,7 @@ TGeoCompositeShape* TGDMLWrite::CreateFakeCtub(TGeoCtub* geoShape)
    Double_t z2 = geoShape->GetNhigh()[2];
    TString xname = geoShape->GetName();
 
-
-   Double_t h0 = 2.*((TGeoBBox*)geoShape)->GetDZ();
+   Double_t h0 = 2. * ((TGeoBBox *)geoShape)->GetDZ();
    Double_t h1 = 2 * z;
    Double_t h2 = 2 * z;
    Double_t boxdx = 1E8 * (2 * rmax) + (2 * z);
@@ -2257,31 +2245,29 @@ TGeoCompositeShape* TGDMLWrite::CreateFakeCtub(TGeoCtub* geoShape)
    TGeoBBox *B1 = new TGeoBBox((xname + "B1").Data(), boxdx, boxdx, h1);
    TGeoBBox *B2 = new TGeoBBox((xname + "B2").Data(), boxdx, boxdx, h2);
 
-
-   //first box position parameters
+   // first box position parameters
    Double_t phi1 = 360 - TMath::ATan2(x1, y1) * TMath::RadToDeg();
    Double_t theta1 = 360 - TMath::ATan2(sqrt(x1 * x1 + y1 * y1), z1) * TMath::RadToDeg();
 
-   Double_t phi11 = TMath::ATan2(y1, x1) * TMath::RadToDeg() ;
-   Double_t theta11 = TMath::ATan2(z1, sqrt(x1 * x1 + y1 * y1)) * TMath::RadToDeg() ;
+   Double_t phi11 = TMath::ATan2(y1, x1) * TMath::RadToDeg();
+   Double_t theta11 = TMath::ATan2(z1, sqrt(x1 * x1 + y1 * y1)) * TMath::RadToDeg();
 
-   Double_t xpos1 = h1 * TMath::Cos((theta11) * TMath::DegToRad()) * TMath::Cos((phi11) * TMath::DegToRad()) * (-1);
-   Double_t ypos1 = h1 * TMath::Cos((theta11) * TMath::DegToRad()) * TMath::Sin((phi11) * TMath::DegToRad()) * (-1);
-   Double_t zpos1 = h1 * TMath::Sin((theta11) * TMath::DegToRad()) * (-1);
+   Double_t xpos1 = h1 * TMath::Cos((theta11)*TMath::DegToRad()) * TMath::Cos((phi11)*TMath::DegToRad()) * (-1);
+   Double_t ypos1 = h1 * TMath::Cos((theta11)*TMath::DegToRad()) * TMath::Sin((phi11)*TMath::DegToRad()) * (-1);
+   Double_t zpos1 = h1 * TMath::Sin((theta11)*TMath::DegToRad()) * (-1);
 
-   //second box position parameters
+   // second box position parameters
    Double_t phi2 = 360 - TMath::ATan2(x2, y2) * TMath::RadToDeg();
    Double_t theta2 = 360 - TMath::ATan2(sqrt(x2 * x2 + y2 * y2), z2) * TMath::RadToDeg();
 
-   Double_t phi21 = TMath::ATan2(y2, x2) * TMath::RadToDeg() ;
-   Double_t theta21 = TMath::ATan2(z2, sqrt(x2 * x2 + y2 * y2)) * TMath::RadToDeg() ;
+   Double_t phi21 = TMath::ATan2(y2, x2) * TMath::RadToDeg();
+   Double_t theta21 = TMath::ATan2(z2, sqrt(x2 * x2 + y2 * y2)) * TMath::RadToDeg();
 
-   Double_t xpos2 = h2 * TMath::Cos((theta21) * TMath::DegToRad()) * TMath::Cos((phi21) * TMath::DegToRad()) * (-1);
-   Double_t ypos2 = h2 * TMath::Cos((theta21) * TMath::DegToRad()) * TMath::Sin((phi21) * TMath::DegToRad()) * (-1);
-   Double_t zpos2 = h2 * TMath::Sin((theta21) * TMath::DegToRad()) * (-1);
+   Double_t xpos2 = h2 * TMath::Cos((theta21)*TMath::DegToRad()) * TMath::Cos((phi21)*TMath::DegToRad()) * (-1);
+   Double_t ypos2 = h2 * TMath::Cos((theta21)*TMath::DegToRad()) * TMath::Sin((phi21)*TMath::DegToRad()) * (-1);
+   Double_t zpos2 = h2 * TMath::Sin((theta21)*TMath::DegToRad()) * (-1);
 
-
-   //positioning
+   // positioning
    TGeoTranslation *t0 = new TGeoTranslation(0, 0, 0);
    TGeoTranslation *t1 = new TGeoTranslation(0 + xpos1, 0 + ypos1, 0 + (zpos1 - z));
    TGeoTranslation *t2 = new TGeoTranslation(0 + xpos2, 0 + ypos2, 0 + (zpos2 + z));
@@ -2292,9 +2278,9 @@ TGeoCompositeShape* TGDMLWrite::CreateFakeCtub(TGeoCtub* geoShape)
    r1->SetAngles(phi1, theta1, 0);
    r2->SetAngles(phi2, theta2, 0);
 
-   TGeoMatrix* m0 = new TGeoCombiTrans(*t0, *r0);
-   TGeoMatrix* m1 = new TGeoCombiTrans(*t1, *r1);
-   TGeoMatrix* m2 = new TGeoCombiTrans(*t2, *r2);
+   TGeoMatrix *m0 = new TGeoCombiTrans(*t0, *r0);
+   TGeoMatrix *m1 = new TGeoCombiTrans(*t1, *r1);
+   TGeoMatrix *m2 = new TGeoCombiTrans(*t2, *r2);
 
    TGeoCompositeShape *CS1 = new TGeoCompositeShape((xname + "CS1").Data(), new TGeoIntersection(T, B1, m0, m1));
    TGeoCompositeShape *cs = new TGeoCompositeShape((xname + "CS").Data(), new TGeoIntersection(CS1, B2, m0, m2));
@@ -2317,8 +2303,8 @@ Bool_t TGDMLWrite::IsInList(NameList list, TString name2check)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-///NCNAME basic restrictions
-///Replace "$" character with empty character etc.
+/// NCNAME basic restrictions
+/// Replace "$" character with empty character etc.
 
 TString TGDMLWrite::GenName(TString oldname)
 {
@@ -2339,7 +2325,7 @@ TString TGDMLWrite::GenName(TString oldname)
    newname = newname.ReplaceAll("[", "");
    newname = newname.ReplaceAll("]", "");
    newname = newname.ReplaceAll("_refl", "");
-   //workaround if first letter is digit than replace it to "O" (ou character)
+   // workaround if first letter is digit than replace it to "O" (ou character)
    TString fstLet = newname(0, 1);
    if (fstLet.IsDigit()) {
       newname = "O" + newname(1, newname.Length());
@@ -2355,40 +2341,37 @@ TString TGDMLWrite::GenName(TString oldname, TString objPointer)
    TString newname = GenName(oldname);
    if (newname != oldname) {
       if (fgkMaxNameErr > fActNameErr) {
-         Info("GenName",
-              "WARNING! Name of the object was changed because it failed to comply with NCNAME xml datatype restrictions.");
+         Info("GenName", "WARNING! Name of the object was changed because it failed to comply with NCNAME xml datatype "
+                         "restrictions.");
       } else if ((fgkMaxNameErr == fActNameErr)) {
-         Info("GenName",
-              "WARNING! Probably more names are going to be changed to comply with NCNAME xml datatype restriction, but it will not be displayed on the screen.");
+         Info("GenName", "WARNING! Probably more names are going to be changed to comply with NCNAME xml datatype "
+                         "restriction, but it will not be displayed on the screen.");
       }
       fActNameErr++;
    }
    TString nameIter;
    Int_t iter = 0;
    switch (fgNamingSpeed) {
-      case kfastButUglySufix:
-         newname = newname + "0x" + objPointer;
-         break;
-      case kelegantButSlow:
-         //0 means not in the list
-         iter = fNameList->fLstIter[newname];
-         if (iter == 0) {
-            nameIter = "";
-         } else {
-            nameIter = TString::Format("0x%i", iter);
-         }
-         fNameList->fLstIter[newname]++;
-         newname = newname + nameIter;
-         break;
-      case kwithoutSufixNotUniq:
-         //no change
-         break;
+   case kfastButUglySufix: newname = newname + "0x" + objPointer; break;
+   case kelegantButSlow:
+      // 0 means not in the list
+      iter = fNameList->fLstIter[newname];
+      if (iter == 0) {
+         nameIter = "";
+      } else {
+         nameIter = TString::Format("0x%i", iter);
+      }
+      fNameList->fLstIter[newname]++;
+      newname = newname + nameIter;
+      break;
+   case kwithoutSufixNotUniq:
+      // no change
+      break;
    }
-   //store the name (mapped to pointer)
+   // store the name (mapped to pointer)
    fNameList->fLst[objPointer] = newname;
    return newname;
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Method which tests whether solids can be processed
@@ -2404,34 +2387,32 @@ Bool_t TGDMLWrite::CanProcess(TObject *pointer)
 ////////////////////////////////////////////////////////////////////////////////
 /// Method that retrieves axis and unit along which object is divided
 
-TString TGDMLWrite::GetPattAxis(Int_t divAxis, const char * pattName, TString& unit)
+TString TGDMLWrite::GetPattAxis(Int_t divAxis, const char *pattName, TString &unit)
 {
    TString resaxis;
    unit = fDefault_lunit;
    switch (divAxis) {
-      case 1:
-         if (strcmp(pattName, "TGeoPatternX") == 0) {
-            return "kXAxis";
-         } else if (strcmp(pattName, "TGeoPatternCylR") == 0) {
-            return "kRho";
-         }
-         break;
-      case 2:
-         if (strcmp(pattName, "TGeoPatternY") == 0) {
-            return "kYAxis";
-         } else if (strcmp(pattName, "TGeoPatternCylPhi") == 0) {
-            unit = "deg";
-            return "kPhi";
-         }
-         break;
-      case 3:
-         if (strcmp(pattName, "TGeoPatternZ") == 0) {
-            return "kZAxis";
-         }
-         break;
-      default:
-         return "kUndefined";
-         break;
+   case 1:
+      if (strcmp(pattName, "TGeoPatternX") == 0) {
+         return "kXAxis";
+      } else if (strcmp(pattName, "TGeoPatternCylR") == 0) {
+         return "kRho";
+      }
+      break;
+   case 2:
+      if (strcmp(pattName, "TGeoPatternY") == 0) {
+         return "kYAxis";
+      } else if (strcmp(pattName, "TGeoPatternCylPhi") == 0) {
+         unit = "deg";
+         return "kPhi";
+      }
+      break;
+   case 3:
+      if (strcmp(pattName, "TGeoPatternZ") == 0) {
+         return "kZAxis";
+      }
+      break;
+   default: return "kUndefined"; break;
    }
    return "kUndefined";
 }
@@ -2443,9 +2424,7 @@ Bool_t TGDMLWrite::IsNullParam(Double_t parValue, TString parName, TString objNa
 {
    if (parValue == 0.) {
       Info("IsNullParam", "ERROR! %s is NULL due to %s = %.12g, Volume based on this shape will be skipped",
-           objName.Data(),
-           parName.Data(),
-           parValue);
+           objName.Data(), parName.Data(), parValue);
       return kTRUE;
    }
    return kFALSE;
@@ -2455,7 +2434,7 @@ Bool_t TGDMLWrite::IsNullParam(Double_t parValue, TString parName, TString objNa
 /// Unsetting bits that were changed in gGeoManager during export so that export
 /// can be run more times with the same instance of gGeoManager.
 
-void TGDMLWrite::UnsetTemporaryBits(TGeoManager * geoMng)
+void TGDMLWrite::UnsetTemporaryBits(TGeoManager *geoMng)
 {
    TIter next(geoMng->GetListOfVolumes());
    TGeoVolume *vol;
@@ -2463,9 +2442,7 @@ void TGDMLWrite::UnsetTemporaryBits(TGeoManager * geoMng)
       ((TObject *)vol->GetShape())->SetBit(fgkProcBit, kFALSE);
       vol->SetAttBit(fgkProcBitVol, kFALSE);
    }
-
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -2475,41 +2452,37 @@ void TGDMLWrite::UnsetTemporaryBits(TGeoManager * geoMng)
 
 ////////////////////////////////////////////////////////////////////////////////
 // Backwards compatibility (to be removed in the future): Wrapper to only selectively write one branch
-void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager, TGeoVolume* volume, const char* filename, TString option)
+void TGDMLWrite::WriteGDMLfile(TGeoManager *geomanager, TGeoVolume *volume, const char *filename, TString option)
 {
-  TList materials, volumes, nodes;
-  MaterialExtractor extract;
-  if ( !volume )   {
-    Info("WriteGDMLfile", "Invalid Volume reference to extract GDML information!");
-    return;
-  }
-  extract(volume);
-  for(TGeoMaterial* m : extract.materials)
-    materials.Add(m);
-  fTopVolumeName = volume->GetName();
-  fTopVolume = volume;
-  fSurfaceList.clear();
-  fVolumeList.clear();
-  fNodeList.clear();
-  WriteGDMLfile(geomanager, volume, &materials, filename, option);
-  materials.Clear("nodelete");
-  volumes.Clear("nodelete");
-  nodes.Clear("nodelete");
+   TList materials, volumes, nodes;
+   MaterialExtractor extract;
+   if (!volume) {
+      Info("WriteGDMLfile", "Invalid Volume reference to extract GDML information!");
+      return;
+   }
+   extract(volume);
+   for (TGeoMaterial *m : extract.materials)
+      materials.Add(m);
+   fTopVolumeName = volume->GetName();
+   fTopVolume = volume;
+   fSurfaceList.clear();
+   fVolumeList.clear();
+   fNodeList.clear();
+   WriteGDMLfile(geomanager, volume, &materials, filename, option);
+   materials.Clear("nodelete");
+   volumes.Clear("nodelete");
+   nodes.Clear("nodelete");
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Wrapper of all exporting methods
 /// Creates blank GDML file and fills it with gGeoManager structure converted
 /// to GDML structure of xml nodes
 
-void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
-                               TGeoVolume* volume,
-                               TList* materialsLst,
-                               const char* filename,
+void TGDMLWrite::WriteGDMLfile(TGeoManager *geomanager, TGeoVolume *volume, TList *materialsLst, const char *filename,
                                TString option)
 {
-   //option processing
+   // option processing
    option.ToLower();
    if (option.Contains("g")) {
       SetG4Compatibility(kTRUE);
@@ -2528,42 +2501,42 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
       Info("WriteGDMLfile", "Potentially slow with incremental suffix naming convention set");
    }
 
-   //local variables
+   // local variables
    Int_t outputLayout = 1;
-   const char * krootNodeName = "gdml";
-   const char * knsRefGeneral = "http://www.w3.org/2001/XMLSchema-instance";
-   const char * knsNameGeneral = "xsi";
-   const char * knsRefGdml = "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd";
-   const char * knsNameGdml = "xsi:noNamespaceSchemaLocation";
+   const char *krootNodeName = "gdml";
+   const char *knsRefGeneral = "http://www.w3.org/2001/XMLSchema-instance";
+   const char *knsNameGeneral = "xsi";
+   const char *knsRefGdml = "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd";
+   const char *knsNameGdml = "xsi:noNamespaceSchemaLocation";
 
    // First create engine
    fGdmlE = new TXMLEngine;
    fGdmlE->SetSkipComments(kTRUE);
 
-   //create blank GDML file
+   // create blank GDML file
    fGdmlFile = fGdmlE->NewDoc();
 
-   //create root node and add it to blank GDML file
+   // create root node and add it to blank GDML file
    XMLNodePointer_t rootNode = fGdmlE->NewChild(nullptr, nullptr, krootNodeName, nullptr);
    fGdmlE->DocSetRootElement(fGdmlFile, rootNode);
 
-   //add namespaces to root node
+   // add namespaces to root node
    fGdmlE->NewNS(rootNode, knsRefGeneral, knsNameGeneral);
    fGdmlE->NewAttr(rootNode, nullptr, knsNameGdml, knsRefGdml);
 
-   //initialize general lists and <define>, <solids>, <structure> nodes
-   fIsotopeList  = new StructLst;
-   fElementList  = new StructLst;
+   // initialize general lists and <define>, <solids>, <structure> nodes
+   fIsotopeList = new StructLst;
+   fElementList = new StructLst;
 
-   fNameList     = new NameLst;
+   fNameList = new NameLst;
 
    fDefineNode = fGdmlE->NewChild(nullptr, nullptr, "define", nullptr);
    fSolidsNode = fGdmlE->NewChild(nullptr, nullptr, "solids", nullptr);
    fStructureNode = fGdmlE->NewChild(nullptr, nullptr, "structure", nullptr);
    //========================
 
-   //initialize list of accepted patterns for divisions (in ExtractVolumes)
-   fAccPatt   = new StructLst;
+   // initialize list of accepted patterns for divisions (in ExtractVolumes)
+   fAccPatt = new StructLst;
    fAccPatt->fLst["TGeoPatternX"] = kTRUE;
    fAccPatt->fLst["TGeoPatternY"] = kTRUE;
    fAccPatt->fLst["TGeoPatternZ"] = kTRUE;
@@ -2571,22 +2544,22 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    fAccPatt->fLst["TGeoPatternCylPhi"] = kTRUE;
    //========================
 
-   //initialize list of rejected shapes for divisions (in ExtractVolumes)
-   fRejShape     = new StructLst;
-   //this shapes are rejected because, it is not possible to divide trd2
-   //in Y axis and while only trd2 object is imported from GDML
-   //it causes a problem when TGeoTrd1 is divided in Y axis
+   // initialize list of rejected shapes for divisions (in ExtractVolumes)
+   fRejShape = new StructLst;
+   // this shapes are rejected because, it is not possible to divide trd2
+   // in Y axis and while only trd2 object is imported from GDML
+   // it causes a problem when TGeoTrd1 is divided in Y axis
    fRejShape->fLst["TGeoTrd1"] = kTRUE;
    fRejShape->fLst["TGeoTrd2"] = kTRUE;
    //=========================
 
-   //Initialize global counters
+   // Initialize global counters
    fActNameErr = 0;
    fVolCnt = 0;
    fPhysVolCnt = 0;
    fSolCnt = 0;
 
-   //calling main extraction functions (with measuring time)
+   // calling main extraction functions (with measuring time)
    time_t startT, endT;
    startT = time(nullptr);
    ExtractMatrices(geomanager->GetListOfGDMLMatrices());
@@ -2603,10 +2576,10 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    ExtractOpticalSurfaces(geomanager->GetListOfOpticalSurfaces());
    endT = time(nullptr);
    //<gdml>
-   fGdmlE->AddChild(rootNode, fDefineNode);                 //  <define>...</define>
-   fGdmlE->AddChild(rootNode, fMaterialsNode);              //  <materials>...</materials>
-   fGdmlE->AddChild(rootNode, fSolidsNode);                 //  <solids>...</solids>
-   fGdmlE->AddChild(rootNode, fStructureNode);              //  <structure>...</structure>
+   fGdmlE->AddChild(rootNode, fDefineNode);                         //  <define>...</define>
+   fGdmlE->AddChild(rootNode, fMaterialsNode);                      //  <materials>...</materials>
+   fGdmlE->AddChild(rootNode, fSolidsNode);                         //  <solids>...</solids>
+   fGdmlE->AddChild(rootNode, fStructureNode);                      //  <structure>...</structure>
    fGdmlE->AddChild(rootNode, CreateSetupN(fTopVolumeName.Data())); //  <setup>...</setup>
    //</gdml>
    Double_t tdiffI = difftime(endT, startT);
@@ -2614,23 +2587,20 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
    Info("WriteGDMLfile", "Exporting time: %s", tdiffS.Data());
    //=========================
 
-   //Saving document
+   // Saving document
    fGdmlE->SaveDoc(fGdmlFile, filename, outputLayout);
    Info("WriteGDMLfile", "File %s saved", filename);
-   //cleaning
+   // cleaning
    fGdmlE->FreeDoc(fGdmlFile);
-   //unset processing bits:
+   // unset processing bits:
    UnsetTemporaryBits(geomanager);
    delete fGdmlE;
 }
 
-
-
-
 ////////////////////////////////////////////////////////////////////////////////
 /// Method extracting geometry structure recursively
 
-void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
+void TGDMLWrite::ExtractVolumes(TGeoVolume *volume)
 {
    XMLNodePointer_t volumeN, childN;
    TString volname, matname, solname, pattClsName, nodeVolNameBak;
@@ -2638,90 +2608,89 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
    Bool_t isPattern = kFALSE;
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
 
-   //create the name for volume/assembly
+   // create the name for volume/assembly
    if (volume == fTopVolume) {
-      //not needed a special function for generating name
+      // not needed a special function for generating name
       volname = volume->GetName();
       fTopVolumeName = volname;
-      //register name to the pointer
+      // register name to the pointer
       fNameList->fLst[TString::Format("%p", volume)] = volname;
    } else {
       volname = GenName(volume->GetName(), TString::Format("%p", volume));
    }
 
-   //start to create main volume/assembly node
+   // start to create main volume/assembly node
    if (volume->IsAssembly()) {
       volumeN = StartAssemblyN(volname);
    } else {
-      //get reference material and add solid to <solids> + get name
+      // get reference material and add solid to <solids> + get name
       matname = fNameList->fLst[TString::Format("%p", volume->GetMaterial())];
       solname = ExtractSolid(volume->GetShape());
-      //If solid is not supported or corrupted
+      // If solid is not supported or corrupted
       if (solname == "-1") {
          Info("ExtractVolumes", "ERROR! %s volume was not added, because solid is either not supported or corrupted",
               volname.Data());
-         //set volume as missing volume
+         // set volume as missing volume
          fNameList->fLst[TString::Format("%p", volume)] = "missing_" + volname;
          return;
       }
       volumeN = StartVolumeN(volname, solname, matname);
 
-      //divisionvol can't be in assembly
+      // divisionvol can't be in assembly
       pattFinder = volume->GetFinder();
-      //if found pattern
+      // if found pattern
       if (pattFinder) {
          pattClsName = TString::Format("%s", pattFinder->ClassName());
          TString shapeCls = TString::Format("%s", volume->GetShape()->ClassName());
-         //if pattern in accepted pattern list and not in shape rejected list
-         if ((fAccPatt->fLst[pattClsName] == kTRUE) &&
-             (fRejShape->fLst[shapeCls] != kTRUE)) {
+         // if pattern in accepted pattern list and not in shape rejected list
+         if ((fAccPatt->fLst[pattClsName] == kTRUE) && (fRejShape->fLst[shapeCls] != kTRUE)) {
             isPattern = kTRUE;
          }
       }
    }
-   //get all nodes in volume
+   // get all nodes in volume
    TObjArray *nodeLst = volume->GetNodes();
    TIter next(nodeLst);
    TString physvolname;
    TGeoNode *geoNode;
    Int_t nCnt = 0;
-   //loop through all nodes
-   while ((geoNode = (TGeoNode *) next())) {
-      //get volume of current node and if not processed then process it
-      TGeoVolume * subvol = geoNode->GetVolume();
+   // loop through all nodes
+   while ((geoNode = (TGeoNode *)next())) {
+      // get volume of current node and if not processed then process it
+      TGeoVolume *subvol = geoNode->GetVolume();
       if (subvol->TestAttBit(fgkProcBitVol) == kFALSE) {
          subvol->SetAttBit(fgkProcBitVol);
          ExtractVolumes(subvol);
       }
 
-      //volume of this node has to exist because it was processed recursively
+      // volume of this node has to exist because it was processed recursively
       TString nodevolname = fNameList->fLst[TString::Format("%p", geoNode->GetVolume())];
       if (nodevolname.Contains("missing_")) {
          continue;
       }
-      if (nCnt == 0) { //save name of the first node for divisionvol
+      if (nCnt == 0) { // save name of the first node for divisionvol
          nodeVolNameBak = nodevolname;
       }
 
       if (isPattern == kFALSE) {
-         //create name for node
+         // create name for node
          TString nodename, posname, rotname;
          nodename = GenName(geoNode->GetName(), TString::Format("%p", geoNode));
          nodename = nodename + "in" + volname;
 
-         //create name for position and clear rotation
+         // create name for position and clear rotation
          posname = nodename + "pos";
          rotname = "";
 
-         //position
-         const Double_t * pos = geoNode->GetMatrix()->GetTranslation();
+         // position
+         const Double_t *pos = geoNode->GetMatrix()->GetTranslation();
          Xyz nodPos;
          nodPos.x = pos[0];
          nodPos.y = pos[1];
          nodPos.z = pos[2];
          childN = CreatePositionN(posname.Data(), nodPos, "position", fDefault_lunit);
-         fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
-         //Deal with reflection
+         fGdmlE->AddChild(fDefineNode, childN); // adding node to <define> node
+         // Deal with reflection
          XMLNodePointer_t scaleN = nullptr;
          Double_t lx, ly, lz;
          Double_t xangle = 0;
@@ -2729,14 +2698,14 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
          lx = geoNode->GetMatrix()->GetRotationMatrix()[0];
          ly = geoNode->GetMatrix()->GetRotationMatrix()[4];
          lz = geoNode->GetMatrix()->GetRotationMatrix()[8];
-         if (geoNode->GetMatrix()->IsReflection()
-             && TMath::Abs(lx) == 1 &&  TMath::Abs(ly) == 1 && TMath::Abs(lz) == 1) {
+         if (geoNode->GetMatrix()->IsReflection() && TMath::Abs(lx) == 1 && TMath::Abs(ly) == 1 &&
+             TMath::Abs(lz) == 1) {
             scaleN = fGdmlE->NewChild(nullptr, nullptr, "scale", nullptr);
             fGdmlE->NewAttr(scaleN, nullptr, "name", (nodename + "scl").Data());
             fGdmlE->NewAttr(scaleN, nullptr, "x", TString::Format(fltPrecision.Data(), lx));
             fGdmlE->NewAttr(scaleN, nullptr, "y", TString::Format(fltPrecision.Data(), ly));
             fGdmlE->NewAttr(scaleN, nullptr, "z", TString::Format(fltPrecision.Data(), lz));
-            //experimentally found out, that rotation should be updated like this
+            // experimentally found out, that rotation should be updated like this
             if (lx == -1) {
                zangle = 180;
             }
@@ -2745,27 +2714,27 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
             }
          }
 
-         //rotation
+         // rotation
          TGDMLWrite::Xyz lxyz = GetXYZangles(geoNode->GetMatrix()->GetRotationMatrix());
          lxyz.x -= xangle;
          lxyz.z -= zangle;
          if ((lxyz.x != 0.0) || (lxyz.y != 0.0) || (lxyz.z != 0.0)) {
             rotname = nodename + "rot";
             childN = CreateRotationN(rotname.Data(), lxyz);
-            fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
+            fGdmlE->AddChild(fDefineNode, childN); // adding node to <define> node
          }
 
-         //create physvol for main volume/assembly node
+         // create physvol for main volume/assembly node
          physvolname = fNameList->fLst[TString::Format("%p", geoNode)];
-         childN = CreatePhysVolN(physvolname, geoNode->GetNumber(),
-                                 nodevolname.Data(), posname.Data(), rotname.Data(), scaleN);
+         childN = CreatePhysVolN(physvolname, geoNode->GetNumber(), nodevolname.Data(), posname.Data(), rotname.Data(),
+                                 scaleN);
          fGdmlE->AddChild(volumeN, childN);
       }
       nCnt++;
    }
-   //create only one divisionvol node
+   // create only one divisionvol node
    if (isPattern && pattFinder) {
-      //retrieve attributes of division
+      // retrieve attributes of division
       Int_t ndiv, divaxis;
       Double_t offset, width, xlo, xhi;
       TString axis, unit;
@@ -2776,16 +2745,16 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
       divaxis = pattFinder->GetDivAxis();
       volume->GetShape()->GetAxisRange(divaxis, xlo, xhi);
 
-      //compute relative start (not positional)
+      // compute relative start (not positional)
       offset = pattFinder->GetStart() - xlo;
       axis = GetPattAxis(divaxis, pattClsName, unit);
 
-      //create division node
+      // create division node
       childN = CreateDivisionN(offset, width, ndiv, axis.Data(), unit.Data(), nodeVolNameBak.Data());
       fGdmlE->AddChild(volumeN, childN);
    }
 
    fVolCnt++;
-   //add volume/assembly node into the <structure> node
+   // add volume/assembly node into the <structure> node
    fGdmlE->AddChild(fStructureNode, volumeN);
 }


### PR DESCRIPTION
# This Pull request:
- Allow users to specify the floating point precision of the GDML attributes and elements
- Fix position units: take the chosen default length units rather than default argument 
  from member function which was "cm"
- Eject material property refs as first child elements as required from the GDML schema
- Add the atomic number N to the `<atom>` attributes.
- Ensure proper NCN names for surfaces (No '/' and '#' characters) for surfaces
- Eject **const properties** as matrices in GDML with one element rather than constants.
- Make physical volume names unique as required by the GDML schema.
  This is also mandatory to properly define surfaces.
- Exclude the "dummy" material from being written to the GDML file.
  The dummy material is internally used by TGeo, but not understood by Geant4.
  Requires the new option `TGDMLWrite::SetIgnoreDummyMaterial(true)` to be set by the user.
- Reading the produced GDML files back with Geant4 was tested.

Backwards compatibility should be preserved 100 %

## Changes or fixes:


## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

