### PR TITLE
[cling] Make string_view module non-textual:

### DIFF
--- a/interpreter/cling/include/cling/std.modulemap
+++ b/interpreter/cling/include/cling/std.modulemap
@@ -312,7 +312,7 @@ module "std" [system] {
     requires cplusplus17
 
     export *
-    textual header "string_view"
+    header "string_view"
   }
 //  module "string.h" {
 //    export *


### PR DESCRIPTION
this causes issues with C++20 module composability and the need for textual is unclear.

# This Pull request:

## Changes or fixes:


## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

