### PR TITLE
[wegui] use web-based `TPad::Print()`  method when web output is enabled

### DIFF
--- a/bindings/jupyroot/python/JupyROOT/helpers/utils.py
+++ b/bindings/jupyroot/python/JupyROOT/helpers/utils.py
@@ -34,7 +34,6 @@ from JupyROOT.helpers import handlers
 
 # We want iPython to take over the graphics
 ROOT.gROOT.SetBatch()
-ROOT.gROOT.SetWebDisplay("jupyter")
 
 cppMIME = 'text/x-c++src'
 

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4857,9 +4857,6 @@ void TPad::Print(const char *filename, Option_t *option)
       psname.Prepend(gEnv->GetValue("Canvas.PrintDirectory","."));
    }
 
-   if (!GetCanvas()->IsBatch() && GetPainter())
-      GetPainter()->SelectDrawable(GetCanvasID());
-
    // Save pad/canvas in alternative formats
    TImage::EImageFileTypes gtype = TImage::kUnknown;
    if (strstr(opt, "gif+")) {
@@ -4884,6 +4881,16 @@ void TPad::Print(const char *filename, Option_t *option)
       gtype = TImage::kBmp;
       image = kTRUE;
    }
+
+   if (GetCanvas()->IsWeb() && GetPainter() &&
+       (strstr(opt,"svg") || strstr(opt,"pdf") || (gtype == TImage::kJpeg) || (gtype == TImage::kPng))) {
+      GetPainter()->SaveImage(this, psname.Data(), gtype);
+      return;
+   }
+
+   if (!GetCanvas()->IsBatch() && GetPainter())
+      GetPainter()->SelectDrawable(GetCanvasID());
+
 
    if (!gROOT->IsBatch() && image) {
       if ((gtype == TImage::kGif) && !ContainsTImage(fPrimitives)) {

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -4817,6 +4817,9 @@ static Bool_t ContainsTImage(TList *li)
 
 void TPad::Print(const char *filename, Option_t *option)
 {
+   if (!GetCanvas())
+      return;
+
    TString psname, fs1 = filename;
 
    // "[" and "]" are special characters for ExpandPathName. When they are at the end
@@ -4853,7 +4856,8 @@ void TPad::Print(const char *filename, Option_t *option)
       psname.Prepend("/");
       psname.Prepend(gEnv->GetValue("Canvas.PrintDirectory","."));
    }
-   if (!gPad->IsBatch() && fCanvas && GetPainter())
+
+   if (!GetCanvas()->IsBatch() && GetPainter())
       GetPainter()->SelectDrawable(GetCanvasID());
 
    // Save pad/canvas in alternative formats
@@ -4881,7 +4885,6 @@ void TPad::Print(const char *filename, Option_t *option)
       image = kTRUE;
    }
 
-   if (!GetCanvas()) return;
    if (!gROOT->IsBatch() && image) {
       if ((gtype == TImage::kGif) && !ContainsTImage(fPrimitives)) {
          Int_t wid = (this == GetCanvas()) ? GetCanvas()->GetCanvasID() : GetPixmapID();

--- a/graf2d/gpadv7/src/RCanvas.cxx
+++ b/graf2d/gpadv7/src/RCanvas.cxx
@@ -111,10 +111,11 @@ std::shared_ptr<ROOT::Experimental::RCanvas> ROOT::Experimental::RCanvas::Create
 
 void ROOT::Experimental::RCanvas::Show(const std::string &where)
 {
-   fShown = true;
+   // Do not display canvas in batch mode
+   if (gROOT->IsWebDisplayBatch())
+      return;
 
-   // workaround - in jupyter do not create any painters yet
-   if (gROOT->GetWebDisplay() == "jupyter") return;
+   fShown = true;
 
    if (fPainter) {
       bool isany = (fPainter->NumDisplays() > 0);

--- a/gui/webgui6/inc/TWebCanvas.h
+++ b/gui/webgui6/inc/TWebCanvas.h
@@ -170,7 +170,6 @@ public:
    void ShowToolBar(Bool_t show = kTRUE) override { ShowCmd("ToolBar", show); }
    void ShowToolTips(Bool_t show = kTRUE) override { ShowCmd("ToolTips", show); }
 
-
    // web-canvas specific methods
 
    void ActivateInEditor(TPad *pad, TObject *obj);
@@ -224,10 +223,11 @@ public:
    void SetAsyncMode(Bool_t on = kTRUE) { fAsyncMode = on; }
    Bool_t IsAsyncMode() const { return fAsyncMode; }
 
+   static TString CreatePadJSON(TPad *pad, Int_t json_compression = 0);
    static TString CreateCanvasJSON(TCanvas *c, Int_t json_compression = 0);
    static Int_t StoreCanvasJSON(TCanvas *c, const char *filename, const char *option = "");
 
-   static bool ProduceImage(TCanvas *c, const char *filename, Int_t width = 0, Int_t height = 0);
+   static bool ProduceImage(TPad *pad, const char *filename, Int_t width = 0, Int_t height = 0);
 
    static TCanvasImp *NewCanvas(TCanvas *c, const char *name, Int_t x, Int_t y, UInt_t width, UInt_t height);
 

--- a/gui/webgui6/inc/TWebSnapshot.h
+++ b/gui/webgui6/inc/TWebSnapshot.h
@@ -60,14 +60,16 @@ class TPadWebSnapshot : public TWebSnapshot {
 protected:
    bool fActive{false};                                    ///< true when pad is active
    bool fReadOnly{true};                                   ///< when canvas or pad are in readonly mode
+   bool fSetObjectIds{true};                               ///<! set objects ids
    bool fWithoutPrimitives{false};                         ///< true when primitives not send while there are no modifications
    std::vector<std::unique_ptr<TWebSnapshot>> fPrimitives; ///< list of all primitives, drawn in the pad
 
 public:
-   TPadWebSnapshot(bool readonly = true)
+   TPadWebSnapshot(bool readonly = true, bool setids = true)
    {
       SetKind(kSubPad);
       fReadOnly = readonly;
+      fSetObjectIds = setids;
    }
 
    void SetActive(bool on = true) { fActive = on; }
@@ -75,6 +77,8 @@ public:
    void SetWithoutPrimitives(bool on = true) { fWithoutPrimitives = on; }
 
    bool IsReadOnly() const { return fReadOnly; }
+
+   bool IsSetObjectIds() const { return fSetObjectIds; }
 
    TWebSnapshot &NewPrimitive(TObject *obj = nullptr, const std::string &opt = "");
 
@@ -92,8 +96,7 @@ protected:
    std::string fScripts;           ///< custom scripts to load
    bool fHighlightConnect{false};  ///< does HighlightConnect has connection
 public:
-   TCanvasWebSnapshot() {} // NOLINT: not allowed to use = default because of TObject::kIsOnHeap detection, see ROOT-10300
-   TCanvasWebSnapshot(bool readonly) : TPadWebSnapshot(readonly) {}
+   TCanvasWebSnapshot(bool readonly = true, bool setids = true) : TPadWebSnapshot(readonly, setids) {}
 
    void SetScripts(const std::string &src) { fScripts = src; }
    const std::string &GetScripts() const { return fScripts; }

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -329,8 +329,10 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
    // send primitives if version 0 or actual pad version grater than already send version
    bool process_primitives = (version == 0) || (pad_status.fVersion > version);
 
-   paddata.SetActive(pad == gPad);
-   paddata.SetObjectIDAsPtr(pad);
+   if (paddata.IsSetObjectIds()) {
+      paddata.SetActive(pad == gPad);
+      paddata.SetObjectIDAsPtr(pad);
+   }
    paddata.SetSnapshot(TWebSnapshot::kSubPad, pad); // add ref to the pad
    paddata.SetWithoutPrimitives(!process_primitives);
 
@@ -1620,7 +1622,7 @@ TString TWebCanvas::CreateCanvasJSON(TCanvas *c, Int_t json_compression)
    {
       auto imp = std::make_unique<TWebCanvas>(c, c->GetName(), 0, 0, 1000, 500);
 
-      TCanvasWebSnapshot holder(true); // always readonly
+      TCanvasWebSnapshot holder(true, false); // readonly, no ids
 
       imp->CreatePadSnapshot(holder, c, 0, [&res, json_compression](TPadWebSnapshot *snap) {
          res = TBufferJSON::ToJSON(snap, json_compression);
@@ -1644,7 +1646,7 @@ Int_t TWebCanvas::StoreCanvasJSON(TCanvas *c, const char *filename, const char *
    {
       auto imp = std::make_unique<TWebCanvas>(c, c->GetName(), 0, 0, 1000, 500);
 
-      TCanvasWebSnapshot holder(true); // always readonly
+      TCanvasWebSnapshot holder(true, false); // readonly, no ids
 
       imp->CreatePadSnapshot(holder, c, 0, [&res, filename, option](TPadWebSnapshot *snap) {
          res = TBufferJSON::ExportToFile(filename, snap, option);

--- a/gui/webgui6/src/TWebPadPainter.cxx
+++ b/gui/webgui6/src/TWebPadPainter.cxx
@@ -11,9 +11,8 @@
 #include "TWebPadPainter.h"
 #include "TError.h"
 #include "TImage.h"
-#include "TVirtualPad.h"
+#include "TPad.h"
 #include "TWebCanvas.h"
-#include "TBufferJSON.h"
 
 
 /** \class TWebPadPainter
@@ -294,7 +293,8 @@ void TWebPadPainter::DrawTextNDC(Double_t  u , Double_t v, const wchar_t * /*tex
 
 void TWebPadPainter::SaveImage(TVirtualPad *pad, const char *fileName, Int_t gtype) const
 {
-   if ((gtype == TImage::kPng) || (gtype == TImage::kJpeg))
-      TWebCanvas::ProduceImage(pad->GetCanvas(), fileName);
+   (void) gtype;
+   // if ((gtype == TImage::kPng) || (gtype == TImage::kJpeg))
+   TWebCanvas::ProduceImage(dynamic_cast<TPad *>(pad), fileName);
 }
 

--- a/gui/webgui6/src/TWebSnapshot.cxx
+++ b/gui/webgui6/src/TWebSnapshot.cxx
@@ -56,7 +56,8 @@ TWebSnapshot &TPadWebSnapshot::NewPrimitive(TObject *obj, const std::string &opt
 {
    fPrimitives.emplace_back(std::make_unique<TWebSnapshot>());
    if (obj) {
-      fPrimitives.back()->SetObjectIDAsPtr(obj);
+      if (IsSetObjectIds())
+         fPrimitives.back()->SetObjectIDAsPtr(obj);
       fPrimitives.back()->SetOption(opt);
    }
    return *(fPrimitives.back());
@@ -67,7 +68,7 @@ TWebSnapshot &TPadWebSnapshot::NewPrimitive(TObject *obj, const std::string &opt
 
 TPadWebSnapshot &TPadWebSnapshot::NewSubPad()
 {
-   auto res = new TPadWebSnapshot(IsReadOnly());
+   auto res = new TPadWebSnapshot(IsReadOnly(), IsSetObjectIds());
    fPrimitives.emplace_back(res);
    return *res;
 }

--- a/js/changes.md
+++ b/js/changes.md
@@ -12,6 +12,7 @@
 9. Provide `settings.PreferSavedPoints` to exclude function evaluation when there are saved points
 10. Improve TWebCanvas support
 11. Correctly handle axis zooming on lego plots
+12. Fix hist stats calculation with negative bins
 
 
 ## Changes in 7.2.1

--- a/js/modules/core.mjs
+++ b/js/modules/core.mjs
@@ -5,7 +5,7 @@ let version_id = 'dev';
 
 /** @summary version date
   * @desc Release date in format day/month/year like '14/04/2022' */
-let version_date = '29/11/2022';
+let version_date = '9/12/2022';
 
 /** @summary version id and date
   * @desc Produced by concatenation of {@link version_id} and {@link version_date}
@@ -975,7 +975,8 @@ const clTObject = 'TObject', clTNamed = 'TNamed',
       clTAttLine = 'TAttLine', clTAttFill = 'TAttFill', clTAttMarker = 'TAttMarker', clTAttText = 'TAttText',
       clTHStack = 'THStack', clTGraph = 'TGraph', clTMultiGraph = 'TMultiGraph', clTCutG = 'TCutG',
       clTGraphPolargram = 'TGraphPolargram', clTGraphTime = 'TGraphTime',
-      clTPave = 'TPave', clTPaveText = 'TPaveText', clTPaveStats = 'TPaveStats', clTLegend = 'TLegend', clTPaletteAxis = 'TPaletteAxis',
+      clTPave = 'TPave', clTPaveText = 'TPaveText', clTPaveStats = 'TPaveStats',
+      clTLegend = 'TLegend', clTLegendEntry = 'TLegendEntry', clTPaletteAxis = 'TPaletteAxis',
       clTText = 'TText', clTLatex = 'TLatex', clTMathText = 'TMathText',
       clTColor = 'TColor', clTLine = 'TLine', clTBox = 'TBox', clTPolyLine = 'TPolyLine',
       clTPolyLine3D = 'TPolyLine3D', clTPolyMarker3D = 'TPolyMarker3D',
@@ -1066,7 +1067,11 @@ function create(typename, target) {
          extend(obj, { fColumnSeparation: 0, fEntrySeparation: 0.1, fMargin: 0.25, fNColumns: 1, fPrimitives: create(clTList),
                        fBorderSize: gStyle.fLegendBorderSize, fTextFont: gStyle.fLegendFont, fTextSize: gStyle.fLegendTextSize, fFillColor: gStyle.fLegendFillColor });
          break;
-      case 'TLegendEntry':
+      case clTPaletteAxis:
+         create(clTPave, obj);
+         extend(obj, { fAxis: create(clTGaxis), fH: null, fName: clTPave });
+         break;
+      case clTLegendEntry:
          create(clTObject, obj);
          create(clTAttText, obj);
          create(clTAttLine, obj);
@@ -1720,7 +1725,7 @@ export { version_id, version_date, version, source_dir, isNodeJs, isBatchMode, s
          browser, internals, constants, settings, gStyle, atob_func, btoa_func,
          clTObject, clTNamed, clTString, clTObjString, clTList, clTHashList, clTMap, clTObjArray, clTClonesArray,
          clTAttLine, clTAttFill, clTAttMarker, clTAttText,
-         clTPave, clTPaveText, clTPaveStats, clTLegend, clTPaletteAxis, clTText, clTLatex, clTMathText, clTMultiGraph,
+         clTPave, clTPaveText, clTPaveStats, clTLegend, clTLegendEntry, clTPaletteAxis, clTText, clTLatex, clTMathText, clTMultiGraph,
          clTColor, clTLine, clTBox, clTPolyLine, clTPad, clTCanvas, clTAttCanvas, clTGaxis,
          clTAxis, clTStyle, clTH1, clTH2, clTH3, clTF1, clTF2, clTProfile, clTProfile2D,
          clTGraph, clTGraphPolargram, clTGraphTime, clTCutG, clTPolyLine3D, clTPolyMarker3D, clTGeoVolume, clTGeoNode, clTGeoNodeMatrix, kNoZoom,

--- a/js/modules/draw/TASImagePainter.mjs
+++ b/js/modules/draw/TASImagePainter.mjs
@@ -239,13 +239,9 @@ class TASImagePainter extends ObjectPainter {
          return null;
 
       if (!this.draw_palette) {
-         let pal = create(clTPave);
-
-         Object.assign(pal, { _typename: clTPaletteAxis, fName: clTPave, fH: null, fAxis: create(clTGaxis),
-                               fX1NDC: 0.91, fX2NDC: 0.95, fY1NDC: 0.1, fY2NDC: 0.9, fInit: 1 });
-
+         let pal = create(clTPaletteAxis);
+         Object.assign(pal, { fX1NDC: 0.91, fX2NDC: 0.95, fY1NDC: 0.1, fY2NDC: 0.9, fInit: 1 });
          pal.fAxis.fChopt = '+';
-
          this.draw_palette = pal;
          this.fPalette = true; // to emulate behaviour of hist painter
       }

--- a/js/modules/draw/draw3d.mjs
+++ b/js/modules/draw/draw3d.mjs
@@ -12,7 +12,7 @@ function before3DDraw(painter, obj) {
    if (!fp?.mode3d || !obj)
       return null;
 
-   if (fp.toplevel)
+   if (fp?.toplevel)
       return fp;
 
    let geop = painter.getMainPainter();
@@ -37,9 +37,7 @@ async function drawPolyMarker3D() {
 
    this.$fp = fp;
 
-   this.plain_redraw = drawPolyMarker3Dplain;
-
-   return this.plain_redraw();
+   return drawPolyMarker3Dplain.bind(this)();
 }
 
 /** @summary Direct draw function for TPolyLine3D object

--- a/js/modules/draw/more.mjs
+++ b/js/modules/draw/more.mjs
@@ -50,8 +50,13 @@ async function drawText() {
 
    if (text.fTextAngle) arg.rotate = -text.fTextAngle;
 
-   if (text._typename == clTLatex) { arg.latex = 1; fact = 0.9; } else
-   if (text._typename == clTMathText) { arg.latex = 2; fact = 0.8; }
+   if (text._typename == clTLatex) {
+      arg.latex = 1;
+      fact = 0.9;
+   } else if (text._typename == clTMathText) {
+      arg.latex = 2;
+      fact = 0.8;
+   }
 
    this.startTextDrawing(text.fTextFont, Math.round((textsize > 1) ? textsize : textsize*Math.min(w,h)*fact));
 
@@ -127,7 +132,8 @@ function drawPolyLine() {
    if (polyline._typename != clTPolyLine)
       fillatt.setSolidColor('none');
 
-   if (!fillatt.empty()) cmd += 'Z';
+   if (!fillatt.empty())
+      cmd += 'Z';
 
    this.draw_g
        .append('svg:path')

--- a/js/modules/geom/TGeoPainter.mjs
+++ b/js/modules/geom/TGeoPainter.mjs
@@ -2365,7 +2365,7 @@ class TGeoPainter extends ObjectPainter {
       // Light - add default point light, adjust later
       let light = new PointLight(0xefefef, 1);
       light.position.set(10, 10, 10);
-      this._camera.add( light );
+      this._camera.add(light);
 
       this._scene.add(this._camera);
    }
@@ -2378,8 +2378,8 @@ class TGeoPainter extends ObjectPainter {
       if (this._webgl && (this.ctrl.ssao.enabled || this.ctrl.outline)) {
 
          if (this.ctrl.outline && isFunc(this.createOutline)) {
-            this._effectComposer = new EffectComposer( this._renderer );
-            this._effectComposer.addPass(new RenderPass( this._scene, this._camera));
+            this._effectComposer = new EffectComposer(this._renderer);
+            this._effectComposer.addPass(new RenderPass(this._scene, this._camera));
             this.createOutline(this._scene_width, this._scene_height);
          } else if (this.ctrl.ssao.enabled) {
             this.createSSAO();
@@ -2427,7 +2427,8 @@ class TGeoPainter extends ObjectPainter {
             this._renderer.domElement.style.width = '100%';
             this._renderer.domElement.style.height = '100%';
             let main = this.selectDom();
-            if (main.style('position') == 'static') main.style('position','relative');
+            if (main.style('position') == 'static')
+               main.style('position', 'relative');
          }
 
          this._animating = false;
@@ -2511,11 +2512,7 @@ class TGeoPainter extends ObjectPainter {
          // if detect of coordinates fails - ignore
          if (!Number.isFinite(box.min.x)) return 1000;
 
-         let sizex = box.max.x - box.min.x,
-             sizey = box.max.y - box.min.y,
-             sizez = box.max.z - box.min.z;
-
-         this._overall_size = 2 * Math.max(sizex, sizey, sizez);
+         this._overall_size = 2 * Math.max(box.max.x - box.min.x, box.max.y - box.min.y, box.max.z - box.min.z);
       }
 
       return this._overall_size;
@@ -2548,10 +2545,7 @@ class TGeoPainter extends ObjectPainter {
 
       let pos1 = new Vector3().add(this._camera0pos).sub(this._lookat),
           pos2 = new Vector3().add(this._camera.position).sub(this._lookat),
-          len1 = pos1.length(), len2 = pos2.length(),
-          zoom = this.ctrl.zoom * len2 / len1 * 100;
-
-      if (zoom < 1) zoom = 1; else if (zoom>10000) zoom = 10000;
+          zoom = Math.min(10000, Math.max(1, this.ctrl.zoom * pos2.length() / pos1.length() * 100));
 
       pos1.normalize();
       pos2.normalize();
@@ -2566,8 +2560,9 @@ class TGeoPainter extends ObjectPainter {
 
       if (roty < 0) roty += 360;
       if (rotz < 0) rotz += 360;
+      prec = prec || 0;
 
-      return 'roty' + roty.toFixed(prec || 0) + ',rotz' + rotz.toFixed(prec || 0) + ',zoom' + zoom.toFixed(prec || 0);
+      return `roty${roty.toFixed(prec)},rotz${rotz.toFixed(prec)},zoom${zoom.toFixed(prec)}`;
    }
 
    /** @summary Calculates current zoom factor */
@@ -2709,11 +2704,8 @@ class TGeoPainter extends ObjectPainter {
 
       let stack = this._clones.findStackByName(itemname);
 
-      if (!stack) return;
-
-      let info = this._clones.resolveStack(stack, true);
-
-      this.focusCamera( info, false );
+      if (stack)
+         this.focusCamera(this._clones.resolveStack(stack, true), false);
    }
 
    /** @summary focus camera on speicifed position */
@@ -2730,7 +2722,7 @@ class TGeoPainter extends ObjectPainter {
       } else {
          let center = new Vector3().setFromMatrixPosition(focus.matrix),
              node = focus.node,
-             halfDelta = new Vector3( node.fDX, node.fDY, node.fDZ ).multiplyScalar(0.5);
+             halfDelta = new Vector3(node.fDX, node.fDY, node.fDZ).multiplyScalar(0.5);
          box.min = center.clone().sub(halfDelta);
          box.max = center.clone().add(halfDelta);
       }
@@ -2773,20 +2765,20 @@ class TGeoPainter extends ObjectPainter {
 
       // Interpolate //
 
-      let animate = () => {
+      const animate = () => {
          if (this._animating === undefined) return;
 
          if (this._animating) {
-            requestAnimationFrame( animate );
+            requestAnimationFrame(animate);
          } else {
             if (!this._geom_viewer)
                this.startDrawGeometry();
          }
-         let smoothFactor = -Math.cos( ( 2.0 * Math.PI * step ) / frames ) + 1.0;
-         this._camera.position.add( posIncrement.clone().multiplyScalar( smoothFactor ) );
-         oldTarget.add( targetIncrement.clone().multiplyScalar( smoothFactor ) );
+         let smoothFactor = -Math.cos((2.0*Math.PI*step)/frames) + 1.0;
+         this._camera.position.add(posIncrement.clone().multiplyScalar(smoothFactor));
+         oldTarget.add(targetIncrement.clone().multiplyScalar(smoothFactor));
          this._lookat = oldTarget;
-         this._camera.lookAt( this._lookat );
+         this._camera.lookAt(this._lookat);
          this._camera.updateProjectionMatrix();
 
          let tm1 = new Date().getTime();
@@ -2819,7 +2811,8 @@ class TGeoPainter extends ObjectPainter {
 
          let current = new Date();
 
-         if ( this.ctrl.rotate ) requestAnimationFrame( animate );
+         if (this.ctrl.rotate)
+            requestAnimationFrame(animate);
 
          if (this._controls) {
             this._controls.autoRotate = this.ctrl.rotate;
@@ -2841,13 +2834,13 @@ class TGeoPainter extends ObjectPainter {
             let boxHelper = new BoxHelper(this._toplevel);
             this._scene.add( boxHelper );
          }
-         this._scene.add( new AxesHelper( 2 * this._overall_size ) );
-         this._scene.add( new GridHelper( Math.ceil( this._overall_size), Math.ceil( this._overall_size ) / 50 ) );
+         this._scene.add(new AxesHelper(2 * this._overall_size));
+         this._scene.add(new GridHelper(Math.ceil(this._overall_size), Math.ceil(this._overall_size)/50));
          this.helpText("<font face='verdana' size='1' color='red'><center>Transform Controls<br>" +
                "'T' translate | 'R' rotate | 'S' scale<br>" +
                "'+' increase size | '-' decrease size<br>" +
                "'W' toggle wireframe/solid display<br>"+
-         "keep 'Ctrl' down to snap to grid</center></font>");
+               "keep 'Ctrl' down to snap to grid</center></font>");
       }
    }
 
@@ -2883,14 +2876,14 @@ class TGeoPainter extends ObjectPainter {
           numvis = this._clones.scanVisible(arg),
           tm2 = new Date().getTime();
 
-      res.push('Total visible nodes: ' + numvis, 'Total shapes: ' + nshapes);
+      res.push(`Total visible nodes: ${numvis}`, `Total shapes: ${nshapes}`);
 
       for (let lvl = 0; lvl < arg.cnt.length; ++lvl) {
          if (arg.cnt[lvl] !== undefined)
-            res.push('  lvl' + lvl + ': ' + arg.cnt[lvl]);
+            res.push(`  lvl${lvl}: ${arg.cnt[lvl]}`);
       }
 
-      res.push('Time to scan: ' + makeTime(tm2-tm1), '', 'Check timing for matrix calculations ...');
+      res.push(`Time to scan: ${makeTime(tm2-tm1)}`, '', 'Check timing for matrix calculations ...');
 
       let elem = this.selectDom().style('overflow', 'auto');
 
@@ -2906,7 +2899,7 @@ class TGeoPainter extends ObjectPainter {
             numvis = this._clones.scanVisible(arg);
             tm2 = new Date().getTime();
 
-            let last_str = 'Time to scan with matrix: ' + makeTime(tm2-tm1);
+            let last_str = `Time to scan with matrix: ${makeTime(tm2-tm1)}`;
             if (isBatchMode())
                res.push(last_str);
             else
@@ -2924,7 +2917,7 @@ class TGeoPainter extends ObjectPainter {
      * @return {Promise} handling of drop operation */
    async performDrop(obj, itemname, hitem, opt) {
 
-      if (obj && (obj.$kind === 'TTree')) {
+      if (obj?.$kind === 'TTree') {
          // drop tree means function call which must extract tracks from provided tree
 
          let funcname = 'extract_geo_tracks';
@@ -2944,7 +2937,6 @@ class TGeoPainter extends ObjectPainter {
             // FIXME: probably tracks should be remembered?
             return this.drawExtras(tracks, '', false).then(()=> {
                this.updateClipping(true);
-
                return this.render3D(100);
             });
          });
@@ -2996,7 +2988,7 @@ class TGeoPainter extends ObjectPainter {
       return true;
    }
 
-   /** @summary manipulate visisbility of extra objects, used for HierarhcyPainter
+   /** @summary manipulate visisbility of extra objects, used for HierarchyPainter
      * @private */
    extraObjectVisible(hpainter, hitem, toggle) {
       if (!this._extraObjects) return;
@@ -3356,7 +3348,7 @@ class TGeoPainter extends ObjectPainter {
                // return proxy object with several methods, typically used in ROOT geom scripts
                return {
                    found: currnode,
-                   fVolume: currnode ? currnode.node.fVolume : null,
+                   fVolume: currnode?.node?.fVolume,
                    InvisibleAll(flag) {
                       setInvisibleAll(this.fVolume, flag);
                    },
@@ -3367,8 +3359,8 @@ class TGeoPainter extends ObjectPainter {
                       console.log(`Select volume for drawing ${this.fVolume.fName} ${result.prefix}`);
                    },
                    SetTransparency(lvl) {
-                     if (this.fVolume && this.fVolume.fMedium && this.fVolume.fMedium.fMaterial)
-                        this.fVolume.fMedium.fMaterial.fFillStyle = 3000+lvl;
+                     if (this.fVolume?.fMedium?.fMaterial)
+                        this.fVolume.fMedium.fMaterial.fFillStyle = 3000 + lvl;
                    },
                    SetLineColor(col) {
                       if (this.fVolume) this.fVolume.fLineColor = col;
@@ -3452,27 +3444,16 @@ class TGeoPainter extends ObjectPainter {
          this.ctrl.use_worker = 0;
          this._geom_viewer = true; // indicate that working with geom viewer
       } else if (this._main_painter) {
-
          this._clones_owner = false;
-
          this._clones = this._main_painter._clones;
-
          console.log(`Reuse clones ${this._clones.nodes.length} from main painter`);
-
       } else if (!draw_obj) {
-
          this._clones_owner = false;
-
          this._clones = null;
-
       } else {
-
          this._start_drawing_time = new Date().getTime();
-
          this._clones_owner = true;
-
          this._clones = new ClonedNodes(draw_obj);
-
          let lvl = this.ctrl.vislevel, maxnodes = this.ctrl.maxnodes;
          if (this.geo_manager) {
             if (!lvl && this.geo_manager.fVisLevel)
@@ -3480,7 +3461,6 @@ class TGeoPainter extends ObjectPainter {
             if (!maxnodes)
                maxnodes = this.geo_manager.fMaxVisNodes;
          }
-
          this._clones.setVisLevel(lvl);
          this._clones.setMaxVisNodes(maxnodes);
 
@@ -3532,7 +3512,8 @@ class TGeoPainter extends ObjectPainter {
 
          } else {
             // activate worker
-            if (this.ctrl.use_worker > 0) this.startWorker();
+            if (this.ctrl.use_worker > 0)
+               this.startWorker();
 
             assign3DHandler(this);
 
@@ -3582,7 +3563,7 @@ class TGeoPainter extends ObjectPainter {
          if (!info) {
             info = document.createElement('p');
             info.setAttribute('class', 'geo_info');
-            info.setAttribute('style',  'position: absolute; text-align: center; vertical-align: middle; top: 45%; left: 40%; color: red; font-size: 150%;');
+            info.setAttribute('style', 'position: absolute; text-align: center; vertical-align: middle; top: 45%; left: 40%; color: red; font-size: 150%;');
             main.append(info);
          }
          info.innerHTML = `${msg}, ${spent.toFixed(1)}s`;
@@ -3602,7 +3583,6 @@ class TGeoPainter extends ObjectPainter {
       while(true) {
 
          let res = this.nextDrawAction();
-
          if (!res) break;
 
          now = new Date().getTime();
@@ -3802,9 +3782,7 @@ class TGeoPainter extends ObjectPainter {
       if (!this._worker) return false;
 
       this._worker_jobs++;
-
       job.tm0 = new Date().getTime();
-
       this._worker.postMessage(job);
    }
 
@@ -4121,7 +4099,6 @@ class TGeoPainter extends ObjectPainter {
       if (!this.ctrl.highlight)
          this.highlightMesh(null);
    }
-
 
    /** @summary Assign clipping attributes to the meshes - supported only for webgl */
    updateClipping(without_render, force_traverse) {
@@ -4515,7 +4492,7 @@ class TGeoPainter extends ObjectPainter {
       let obj = child.parent;
       while (obj && !(obj instanceof TransformControls) )
          obj = obj.parent;
-      return (obj && (obj instanceof TransformControls));
+      return obj && (obj instanceof TransformControls);
    }
 
    /** @summary either change mesh wireframe or return current value
@@ -4589,9 +4566,7 @@ class TGeoPainter extends ObjectPainter {
       if (!main) return;
 
       let sz = main.getSizeFor3d(main.access3dKind());
-
       main.apply3dSize(sz);
-
       return this.performResize(sz.width, sz.height);
    }
 
@@ -4833,10 +4808,8 @@ function provideMenu(menu, item, hpainter) {
    if (iseve) {
       menu.addchk(obj.fRnrSelf, 'Visible', 'self', ToggleEveVisibility);
       let res = ScanEveVisible(obj, undefined, true);
-
       if (res.hidden + res.visible > 0)
          menu.addchk((res.hidden == 0), 'Daughters', res.hidden !== 0 ? 'true' : 'false', ToggleEveVisibility);
-
    } else {
       menu.addchk(testGeoBit(vol, geoBITS.kVisNone), 'Invisible',
             geoBITS.kVisNone, ToggleMenuBit);
@@ -4949,8 +4922,7 @@ function createItem(node, obj, name) {
       if (subnodes) {
          sub._more = true;
          sub._expand = expandGeoObject;
-      } else
-      if (shape && (shape._typename === clTGeoCompositeShape) && shape.fNode) {
+      } else if (shape && (shape._typename === clTGeoCompositeShape) && shape.fNode) {
          sub._more = true;
          sub._shape = shape;
          sub._expand = function(node /*, obj */) {
@@ -4960,7 +4932,8 @@ function createItem(node, obj, name) {
          };
       }
 
-      if (!sub._title && (obj._typename != clTGeoVolume)) sub._title = obj._typename;
+      if (!sub._title && (obj._typename != clTGeoVolume))
+         sub._title = obj._typename;
 
       if (shape) {
          if (sub._title == '')
@@ -5004,7 +4977,7 @@ async function drawDummy3DGeom(painter) {
    let extra = painter.getObject(),
        min = [-1, -1, -1], max = [1, 1, 1];
 
-   if (extra.fP && extra.fP.length)
+   if (extra.fP?.length)
       for(let k = 0; k < extra.fP.length; k += 3)
          for (let i = 0; i < 3; ++i) {
             min[i] = Math.min(min[i], extra.fP[k+i]);
@@ -5028,7 +5001,7 @@ async function drawDummy3DGeom(painter) {
 
    let opt = '', pp = painter.getPadPainter();
 
-   if (pp?.pad?.fFillColor && pp?.pad?.fFillStyle > 1000)
+   if (pp?.pad?.fFillColor && (pp?.pad?.fFillStyle > 1000))
       opt = 'bkgr_' +  pp.pad.fFillColor;
 
    return TGeoPainter.draw(painter.getDom(), obj, opt)

--- a/js/modules/geom/geobase.mjs
+++ b/js/modules/geom/geobase.mjs
@@ -3474,7 +3474,7 @@ function getBoundingBox(node, box3, local_coordinates) {
    let v1 = new Vector3(), attribute = node.geometry.attributes?.position;
 
    if ( attribute !== undefined )
-      for (let i = 0, l = attribute.count; i < l; i ++ ) {
+      for (let i = 0, l = attribute.count; i < l; i++) {
          // v1.fromAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
          v1.fromBufferAttribute( attribute, i );
          if (!local_coordinates) v1.applyMatrix4( node.matrixWorld );

--- a/js/modules/gpad/RFramePainter.mjs
+++ b/js/modules/gpad/RFramePainter.mjs
@@ -697,7 +697,7 @@ class RFramePainter extends RObjectPainter {
 
       if (rotate) {
          trans = `rotate(-90,${lm},${tm}) translate(${lm-h},${tm})`;
-         let d = w; w = h; h = d;
+         [w, h] = [h, w];
       } else {
          trans = `translate(${lm},${tm})`;
       }

--- a/js/modules/gpad/TCanvasPainter.mjs
+++ b/js/modules/gpad/TCanvasPainter.mjs
@@ -619,11 +619,11 @@ class TCanvasPainter extends TPadPainter {
 
    /** @summary Select active pad on the canvas */
    selectActivePad(pad_painter, obj_painter, click_pos) {
-      if ((this.snapid === undefined) || !pad_painter) return; // only interactive canvas
+      if (!this.snapid || !pad_painter) return; // only interactive canvas
 
       let arg = null, ischanged = false;
 
-      if ((pad_painter.snapid !== undefined) && this._websocket)
+      if (pad_painter.snapid && this._websocket)
          arg = { _typename: 'TWebPadClick', padid: pad_painter.snapid.toString(), objid: '', x: -1, y: -1, dbl: false };
 
       if (!pad_painter.is_active_pad) {

--- a/js/modules/gpad/TFramePainter.mjs
+++ b/js/modules/gpad/TFramePainter.mjs
@@ -2337,7 +2337,7 @@ class TFramePainter extends ObjectPainter {
 
       if (rotate) {
          trans = `rotate(-90,${lm},${tm}) translate(${lm-h},${tm})`;
-         let d = w; w = h; h = d;
+         [w, h] = [h, w];
       } else {
          trans = `translate(${lm},${tm})`;
       }

--- a/js/modules/hist/RH3Painter.mjs
+++ b/js/modules/hist/RH3Painter.mjs
@@ -102,17 +102,7 @@ class RH3Painter extends RHistPainter {
          }
       }
 
-      if ((histo.fTsumw > 0) && !fp.isAxisZoomed('x') && !fp.isAxisZoomed('y') && !fp.isAxisZoomed('z')) {
-         stat_sum0  = histo.fTsumw;
-         stat_sumx1 = histo.fTsumwx;
-         stat_sumx2 = histo.fTsumwx2;
-         stat_sumy1 = histo.fTsumwy;
-         stat_sumy2 = histo.fTsumwy2;
-         stat_sumz1 = histo.fTsumwz;
-         stat_sumz2 = histo.fTsumwz2;
-      }
-
-      if (stat_sum0 > 0) {
+      if (Math.abs(stat_sum0) > 1e-300) {
          res.meanx = stat_sumx1 / stat_sum0;
          res.meany = stat_sumy1 / stat_sum0;
          res.meanz = stat_sumz1 / stat_sum0;
@@ -123,7 +113,8 @@ class RH3Painter extends RHistPainter {
 
       res.integral = stat_sum0;
 
-      if (histo.fEntries > 1) res.entries = histo.fEntries;
+      if (histo.fEntries > 1)
+         res.entries = histo.fEntries;
 
       return res;
    }

--- a/js/modules/hist/TH2Painter.mjs
+++ b/js/modules/hist/TH2Painter.mjs
@@ -23,7 +23,7 @@ function drawTH2PolyLego(painter) {
 
    let cntr = painter.getContour(true), palette = painter.getHistPalette();
 
-   for (i = 0; i < len; ++ i) {
+   for (i = 0; i < len; ++i) {
       bin = histo.fBins.arr[i];
       if (bin.fContent < axis_zmin) continue;
 

--- a/js/modules/hist/TH3Painter.mjs
+++ b/js/modules/hist/TH3Painter.mjs
@@ -35,8 +35,10 @@ class TH3Painter extends THistPainter {
          for (let j = 0; j < this.nbinsy; ++j)
             for (let k = 0; k < this.nbinsz; ++k) {
                let bin_content = histo.getBinContent(i+1, j+1, k+1);
-               if (bin_content < this.gminbin) this.gminbin = bin_content; else
-               if (bin_content > this.gmaxbin) this.gmaxbin = bin_content;
+               if (bin_content < this.gminbin)
+                  this.gminbin = bin_content;
+               else if (bin_content > this.gmaxbin)
+                  this.gmaxbin = bin_content;
             }
 
       this.draw_content = this.gmaxbin > 0;
@@ -55,7 +57,8 @@ class TH3Painter extends THistPainter {
           k2 = this.getSelectIndex('z', 'right'),
           fp = this.getFramePainter(),
           res = { name: histo.fName, entries: 0, integral: 0, meanx: 0, meany: 0, meanz: 0, rmsx: 0, rmsy: 0, rmsz: 0 },
-          xi, yi, zi, xx, xside, yy, yside, zz, zside, cont;
+          xi, yi, zi, xx, xside, yy, yside, zz, zside, cont,
+          has_counted_stat = (Math.abs(histo.fTsumw) > 1e-300) && !fp.isAxisZoomed('x') && !fp.isAxisZoomed('y') && !fp.isAxisZoomed('z');
 
       for (xi = 0; xi < this.nbinsx+2; ++xi) {
 
@@ -75,7 +78,7 @@ class TH3Painter extends THistPainter {
                cont = histo.getBinContent(xi, yi, zi);
                res.entries += cont;
 
-               if ((xside == 1) && (yside == 1) && (zside == 1)) {
+               if (!has_counted_stat && (xside == 1) && (yside == 1) && (zside == 1)) {
                   stat_sum0 += cont;
                   stat_sumx1 += xx * cont;
                   stat_sumy1 += yy * cont;
@@ -88,7 +91,7 @@ class TH3Painter extends THistPainter {
          }
       }
 
-      if ((histo.fTsumw > 0) && !fp.isAxisZoomed('x') && !fp.isAxisZoomed('y') && !fp.isAxisZoomed('z')) {
+      if (has_counted_stat) {
          stat_sum0  = histo.fTsumw;
          stat_sumx1 = histo.fTsumwx;
          stat_sumx2 = histo.fTsumwx2;
@@ -98,7 +101,7 @@ class TH3Painter extends THistPainter {
          stat_sumz2 = histo.fTsumwz2;
       }
 
-      if (stat_sum0 > 0) {
+      if (Math.abs(stat_sum0) > 1e-300) {
          res.meanx = stat_sumx1 / stat_sum0;
          res.meany = stat_sumy1 / stat_sum0;
          res.meanz = stat_sumz1 / stat_sum0;
@@ -109,7 +112,8 @@ class TH3Painter extends THistPainter {
 
       res.integral = stat_sum0;
 
-      if (histo.fEntries > 1) res.entries = histo.fEntries;
+      if (histo.fEntries > 1)
+         res.entries = histo.fEntries;
 
       return res;
    }
@@ -118,7 +122,8 @@ class TH3Painter extends THistPainter {
    fillStatistic(stat, dostat, dofit) {
 
       // no need to refill statistic if histogram is dummy
-      if (this.isIgnoreStatsFill()) return false;
+      if (this.isIgnoreStatsFill())
+         return false;
 
       let data = this.countStat(),
           print_name = dostat % 10,

--- a/js/modules/hist/TPavePainter.mjs
+++ b/js/modules/hist/TPavePainter.mjs
@@ -1,5 +1,5 @@
 import { gStyle, browser, settings, clone, create, isBatchMode, isObject, isFunc, isStr,
-         clTPave, clTPaveText, clTPaveStats, clTLegend, clTPaletteAxis,
+         clTPave, clTPaveText, clTPaveStats, clTLegend, clTLegendEntry, clTPaletteAxis,
          clTText, clTLatex, clTLine, clTBox } from '../core.mjs';
 import { select as d3_select, rgb as d3_rgb, pointer as d3_pointer } from '../d3.mjs';
 import { Prob } from '../base/math.mjs';
@@ -1243,16 +1243,20 @@ async function produceLegend(dom, opt) {
 
       if (!obj) continue;
 
-      let entry = create('TLegendEntry');
+      let entry = create(clTLegendEntry);
       entry.fObject = obj;
       entry.fLabel = (opt == 'all') ? obj.fName : painter.getItemName();
       entry.fOption = '';
       if (!entry.fLabel) continue;
 
-      if (painter.lineatt?.used) entry.fOption += 'l';
-      if (painter.fillatt?.used) entry.fOption += 'f';
-      if (painter.markeratt?.used) entry.fOption += 'm';
-      if (!entry.fOption) entry.fOption = 'l';
+      if (painter.lineatt?.used)
+         entry.fOption += 'l';
+      if (painter.fillatt?.used)
+         entry.fOption += 'f';
+      if (painter.markeratt?.used)
+         entry.fOption += 'm';
+      if (!entry.fOption)
+         entry.fOption = 'l';
 
       leg.fPrimitives.Add(entry);
    }

--- a/js/modules/hist/hist3d.mjs
+++ b/js/modules/hist/hist3d.mjs
@@ -1112,7 +1112,8 @@ function drawBinsLego(painter, is_v7 = false) {
          binz1 = painter.options.BaseLine;
       else
          binz1 = painter.options.Zero ? axis_zmin : 0;
-      if (binz2 < binz1) { let d = binz1; binz1 = binz2; binz2 = d; }
+      if (binz2 < binz1)
+         [binz1, binz2] = [binz2, binz1];
 
       if ((binz1 >= zmax) || (binz2 < zmin)) return false;
 

--- a/js/modules/hist2d/RH1Painter.mjs
+++ b/js/modules/hist2d/RH1Painter.mjs
@@ -125,16 +125,9 @@ class RH1Painter extends RHistPainter {
          stat_sumwx2 += w * xx**2;
       }
 
-      // when no range selection done, use original statistic from histogram
-      if (!fp.isAxisZoomed('x') && histo.fTsumw) {
-         stat_sumw = histo.fTsumw;
-         stat_sumwx = histo.fTsumwx;
-         stat_sumwx2 = histo.fTsumwx2;
-      }
-
       res.integral = stat_sumw;
 
-      if (stat_sumw > 0) {
+      if (Math.abs(stat_sumw) > 1e-300) {
          res.meanx = stat_sumwx / stat_sumw;
          res.meany = stat_sumwy / stat_sumw;
          res.rmsx = Math.sqrt(Math.abs(stat_sumwx2 / stat_sumw - res.meanx**2));
@@ -711,9 +704,10 @@ class RH1Painter extends RHistPainter {
          grx2 = grx1 + Math.round(this.options.BarWidth*w);
       }
 
-      if (grx1 > grx2) { let d = grx1; grx1 = grx2; grx2 = d; }
+      if (grx1 > grx2)
+         [grx1, grx2] = [grx2, grx1];
 
-      midx = Math.round((grx1+grx2)/2);
+      midx = Math.round((grx1 + grx2)/2);
 
       midy = gry1 = gry2 = GetBinGrY(findbin);
 
@@ -724,10 +718,11 @@ class RH1Painter extends RHistPainter {
 
          gry1 = Math.round(funcs.gry(((this.options.BaseLine!==false) && (this.options.BaseLine > funcs.scale_ymin)) ? this.options.BaseLine : funcs.scale_ymin));
 
-         if (gry1 > gry2) { let d = gry1; gry1 = gry2; gry2 = d; }
+         if (gry1 > gry2)
+            [gry1, gry2] = [gry2, gry1];
 
          if (!pnt.touch && (pnt.nproc === 1))
-            if ((pnt_y<gry1) || (pnt_y>gry2)) findbin = null;
+            if ((pnt_y < gry1) || (pnt_y > gry2)) findbin = null;
 
       } else if (this.options.Error || this.options.Mark) {
 
@@ -771,9 +766,9 @@ class RH1Painter extends RHistPainter {
             gry2 = height;
 
             if (!this.fillatt.empty()) {
-               gry2 = Math.round(funcs.gry(0));
-               if (gry2 < 0) gry2 = 0; else if (gry2 > height) gry2 = height;
-               if (gry2 < gry1) { let d = gry1; gry1 = gry2; gry2 = d; }
+               gry2 = Math.min(height, Math.max(0, Math.round(funcs.gry(0))));
+               if (gry2 < gry1)
+                  [gry1, gry2] = [gry2, gry1];
             }
 
             // for mouse events pointer should be between y1 and y2

--- a/js/modules/hist2d/RH2Painter.mjs
+++ b/js/modules/hist2d/RH2Painter.mjs
@@ -279,7 +279,7 @@ class RH2Painter extends RHistPainter {
          }
       }
 
-      if (stat_sum0 > 0) {
+      if (Math.abs(stat_sum0) > 1e-300) {
          res.meanx = stat_sumx1 / stat_sum0;
          res.meany = stat_sumy1 / stat_sum0;
          res.rmsx = Math.sqrt(Math.abs(stat_sumx2 / stat_sum0 - res.meanx**2));

--- a/js/modules/hist2d/THistPainter.mjs
+++ b/js/modules/hist2d/THistPainter.mjs
@@ -1020,7 +1020,7 @@ class THistPainter extends ObjectPainter {
             histo.fBinEntries = obj.fBinEntries;
          } else if (this.isTH1K()) {
             histo.fNIn = obj.fNIn;
-            histo.fReady = false;
+            histo.fReady = 0;
          } else if (this.isTH2Poly()) {
             histo.fBins = obj.fBins;
          }


### PR DESCRIPTION
For "png", "jpg", "pdf" and "svg" headless web browser will be used inside `TPad::Print()` method.
Fix small issue and improve `TPad::Print()`
Update JSROOT