### PR TITLE
[ntuple] Fix mismatch class vs struct for test

### DIFF
--- a/tree/ntuple/v7/inc/ROOT/RField.hxx
+++ b/tree/ntuple/v7/inc/ROOT/RField.hxx
@@ -54,7 +54,7 @@ class REntry;
 class RNTupleModel;
 
 namespace Internal {
-class RFieldCallbackInjector;
+struct RFieldCallbackInjector;
 } // namespace Internal
 
 namespace Detail {
@@ -76,7 +76,7 @@ The field knows based on its type and the field name the type(s) and name(s) of 
 // clang-format on
 class RFieldBase {
    friend class ROOT::Experimental::RCollectionField; // to move the fields from the collection model
-   friend class ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
+   friend struct ROOT::Experimental::Internal::RFieldCallbackInjector; // used for unit tests
    using ReadCallback_t = std::function<void(RFieldValue &)>;
 
 public:


### PR DESCRIPTION
clang-14 complains:
```
warning: 'RFieldCallbackInjector' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
```