### PR TITLE
Introduce `TVirtualPad::TContext` class

### DIFF
--- a/core/base/inc/TVirtualPad.h
+++ b/core/base/inc/TVirtualPad.h
@@ -56,6 +56,20 @@ protected:
    void  *GetSender() override { return this; }  //used to set gTQSender
 
 public:
+
+   /** small helper class to store/restore gPad context in TPad methods */
+   class TContext {
+       Bool_t fInteractive{kFALSE};
+       TVirtualPad *fSaved{nullptr};
+   public:
+       TContext(Bool_t _interactive = kFALSE);
+       TContext(TVirtualPad *set_gpad, Bool_t _interactive = kFALSE);
+       ~TContext();
+       auto IsInteractive() const { return fInteractive; }
+       auto GetSaved() const { return fSaved; }
+   };
+
+
    TVirtualPad();
    TVirtualPad(const char *name, const char *title, Double_t xlow,
                Double_t ylow, Double_t xup, Double_t yup,

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -292,34 +292,32 @@ void TObject::DrawClass() const
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// Draw a clone of this object in the current selected pad for instance with:
-/// `gROOT->SetSelectedPad(gPad)`.
+/// Draw a clone of this object in the current selected pad with:
+/// `gROOT->SetSelectedPad(c1)`.
+/// If pad was not selected - `gPad` will be used.
 
 TObject *TObject::DrawClone(Option_t *option) const
 {
-   TVirtualPad *pad    = gROOT->GetSelectedPad();
-   TVirtualPad *padsav = gPad;
-   if (pad) pad->cd();
+   TVirtualPad::TContext ctxt(true);
+   auto pad = gROOT->GetSelectedPad();
+   if (pad)
+      pad->cd();
 
    TObject *newobj = Clone();
    if (!newobj)
-      return nullptr; // intentionally not restore gPad
+      return nullptr;
+
+   if (!option || !*option)
+      option = GetDrawOption();
+
    if (pad) {
-      if (option && *option)
-         pad->GetListOfPrimitives()->Add(newobj, option);
-      else
-         pad->GetListOfPrimitives()->Add(newobj, GetDrawOption());
+      pad->GetListOfPrimitives()->Add(newobj, option);
       pad->Modified(kTRUE);
       pad->Update();
-      if (padsav) padsav->cd();
-      return newobj;
-   }
-   if (option && *option)
+   } else {
       newobj->Draw(option);
-   else
-      newobj->Draw(GetDrawOption());
+   }
 
-   if (padsav) padsav->cd();
    return newobj;
 }
 

--- a/core/base/src/TObject.cxx
+++ b/core/base/src/TObject.cxx
@@ -77,7 +77,7 @@ bool DeleteChangesMemoryImpl()
 {
    static constexpr UInt_t kGoldenUUID = 0x00000021;
    static constexpr UInt_t kGoldenbits = 0x03000000;
- 
+
    TObject *o = new TObject;
    o->SetUniqueID(kGoldenUUID);
    UInt_t *o_fuid = &(o->fUniqueID);
@@ -302,7 +302,8 @@ TObject *TObject::DrawClone(Option_t *option) const
    if (pad) pad->cd();
 
    TObject *newobj = Clone();
-   if (!newobj) return nullptr;
+   if (!newobj)
+      return nullptr; // intentionally not restore gPad
    if (pad) {
       if (option && *option)
          pad->GetListOfPrimitives()->Add(newobj, option);
@@ -317,8 +318,8 @@ TObject *TObject::DrawClone(Option_t *option) const
       newobj->Draw(option);
    else
       newobj->Draw(GetDrawOption());
-   if (padsav) padsav->cd();
 
+   if (padsav) padsav->cd();
    return newobj;
 }
 

--- a/core/base/src/TVirtualPad.cxx
+++ b/core/base/src/TVirtualPad.cxx
@@ -21,6 +21,51 @@ TVirtualPad is an abstract base class for the Pad and Canvas classes.
 
 Int_t (*gThreadXAR)(const char *xact, Int_t nb, void **ar, Int_t *iret) = nullptr;
 
+
+/** \class TVirtualPad::TContext
+\ingroup Base
+
+Small helper class to preserve gPad, which will be restored when TContext object is destroyed
+*/
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor which just store gPad
+/// @param _interactive defines how gPad will be restored: with cd() call (kTRUE) or just by assign gPad back
+
+TVirtualPad::TContext::TContext(Bool_t _interactive)
+{
+   fInteractive = _interactive;
+   fSaved = gPad;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Constructor which stores gPad and set it to new value
+/// @param _interactive defines how gPad will be restored: with cd() call (kTRUE) or just by assign gPad back
+
+TVirtualPad::TContext::TContext(TVirtualPad *set_gpad, Bool_t _interactive)
+{
+   fInteractive = _interactive;
+   fSaved = gPad;
+   if (fInteractive && set_gpad)
+      set_gpad->cd();
+   else
+      gPad = set_gpad;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Destructor
+/// Restores previous value of gPad
+
+TVirtualPad::TContext::~TContext()
+{
+   if (!fInteractive || !fSaved)
+      gPad = fSaved;
+   else
+      fSaved->cd();
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 /// Return the current pad for the current thread.
 

--- a/core/meta/src/TClass.cxx
+++ b/core/meta/src/TClass.cxx
@@ -2488,11 +2488,11 @@ void TClass::Draw(Option_t *option)
 {
    if (!HasInterpreterInfo()) return;
 
-   TVirtualPad *padsav = gPad;
+   TVirtualPad::TContext ctxt(kTRUE);
 
    // Should we create a new canvas?
-   TString opt=option;
-   if (!padsav || !opt.Contains("same")) {
+   TString opt = option;
+   if (!ctxt.GetSaved() || !opt.Contains("same")) {
       TVirtualPad *padclass = (TVirtualPad*)(gROOT->GetListOfCanvases())->FindObject("R__class");
       if (!padclass) {
          gROOT->ProcessLine("new TCanvas(\"R__class\",\"class\",20,20,1000,750);");
@@ -2501,9 +2501,8 @@ void TClass::Draw(Option_t *option)
       }
    }
 
-   if (gPad) gPad->DrawClassObject(this,option);
-
-   if (padsav) padsav->cd();
+   if (gPad)
+      gPad->DrawClassObject(this,option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -170,6 +170,8 @@ public:
           else
              save_gpad->cd();
        }
+
+       TVirtualPad *GetSaved() const { return save_gpad; }
    };
 
    // TPad status bits

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -149,6 +149,29 @@ private:
    void              LineNotFree(Int_t x1, Int_t x2, Int_t y1, Int_t y2);
 
 public:
+
+   /** small helper class to store/restore gPad context in TPad methods */
+   class TContext {
+       Bool_t interactive{kFALSE};
+       TVirtualPad *save_gpad{nullptr};
+   public:
+       TContext(Bool_t _interactive = kFALSE) : interactive(_interactive), save_gpad(gPad) {}
+       TContext(TVirtualPad *set_gpad, Bool_t _interactive = kFALSE) : interactive(_interactive), save_gpad(gPad)
+       {
+          if (_interactive && set_gpad)
+             set_gpad->cd();
+          else
+             gPad = set_gpad;
+       }
+       ~TContext()
+       {
+          if (!interactive || !save_gpad)
+             gPad = save_gpad;
+          else
+             save_gpad->cd();
+       }
+   };
+
    // TPad status bits
    enum {
       kFraming      = BIT(6),  ///< Frame is requested

--- a/graf2d/gpad/inc/TPad.h
+++ b/graf2d/gpad/inc/TPad.h
@@ -149,31 +149,6 @@ private:
    void              LineNotFree(Int_t x1, Int_t x2, Int_t y1, Int_t y2);
 
 public:
-
-   /** small helper class to store/restore gPad context in TPad methods */
-   class TContext {
-       Bool_t interactive{kFALSE};
-       TVirtualPad *save_gpad{nullptr};
-   public:
-       TContext(Bool_t _interactive = kFALSE) : interactive(_interactive), save_gpad(gPad) {}
-       TContext(TVirtualPad *set_gpad, Bool_t _interactive = kFALSE) : interactive(_interactive), save_gpad(gPad)
-       {
-          if (_interactive && set_gpad)
-             set_gpad->cd();
-          else
-             gPad = set_gpad;
-       }
-       ~TContext()
-       {
-          if (!interactive || !save_gpad)
-             gPad = save_gpad;
-          else
-             save_gpad->cd();
-       }
-
-       TVirtualPad *GetSaved() const { return save_gpad; }
-   };
-
    // TPad status bits
    enum {
       kFraming      = BIT(6),  ///< Frame is requested

--- a/graf2d/gpad/src/TButton.cxx
+++ b/graf2d/gpad/src/TButton.cxx
@@ -268,7 +268,7 @@ void TButton::Range(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
 
 void TButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   TPad *padsav = (TPad*)gPad;
+   TVirtualPad::TContext ctxt(kTRUE);
    char quote = '"';
    if (gROOT->ClassSaved(TButton::Class())) {
       out<<"   ";
@@ -315,17 +315,17 @@ void TButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    out<<"   button->Draw();"<<std::endl;
 
    TIter next(GetListOfPrimitives());
-   TObject *obj = next();  //do not save first primitive
+   next();  //do not save first primitive
 
    Int_t nprim = 0;
-   while ((obj = next())) {
+   while (auto obj = next()) {
       if (!nprim) out<<"   button->cd();"<<std::endl;
       nprim++;
       obj->SavePrimitive(out, (Option_t *)next.GetOption());
    }
 
-   if (nprim) out<<"   "<<padsav->GetName()<<"->cd();"<<std::endl;
-   padsav->cd();
+   if (nprim && ctxt.GetSaved())
+      out<<"   "<<ctxt.GetSaved()->GetName()<<"->cd();"<<std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TGroupButton.cxx
+++ b/graf2d/gpad/src/TGroupButton.cxx
@@ -221,7 +221,7 @@ void TGroupButton::ExecuteEvent(Int_t event, Int_t px, Int_t py)
 
 void TGroupButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
 {
-   TPad *padsav = (TPad*)gPad;
+   TVirtualPad::TContext ctxt(kTRUE);
    char quote = '"';
    if (gROOT->ClassSaved(TGroupButton::Class())) {
       out<<"   ";
@@ -251,11 +251,11 @@ void TGroupButton::SavePrimitive(std::ostream &out, Option_t * /*= ""*/)
    out<<"   button->cd();"<<std::endl;
 
    TIter next(GetListOfPrimitives());
-   TObject *obj = next();  //do not save first primitive
+   next();  //do not save first primitive
 
-   while ((obj = next()))
-         obj->SavePrimitive(out, (Option_t *)next.GetOption());
+   while (auto obj = next())
+      obj->SavePrimitive(out, (Option_t *)next.GetOption());
 
-   out<<"   "<<padsav->GetName()<<"->cd();"<<std::endl;
-   padsav->cd();
+   if (ctxt.GetSaved())
+      out<<"   "<<ctxt.GetSaved()->GetName()<<"->cd();"<<std::endl;
 }

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -394,7 +394,8 @@ TPad::~TPad()
 
    // Required since we overload TObject::Hash.
    ROOT::CallRecursiveRemoveIfNeeded(*this);
-   if (this == gPad) gPad=nullptr;
+   if (this == gPad)
+      gPad = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -452,7 +453,8 @@ void TPad::AddExec(const char *name, const char *command)
 
 void TPad::AutoExec()
 {
-   if (GetCrosshair()) DrawCrosshair();
+   if (GetCrosshair())
+      DrawCrosshair();
 
    if (!fExecs)
       return;
@@ -556,12 +558,10 @@ TLegend *TPad::BuildLegend(Double_t x1, Double_t y1, Double_t x2, Double_t y2,
       opt = "";
    }
    if (leg) {
-      TVirtualPad *gpadsave = gPad;
-      cd();
+      TContext ctxt(this, kTRUE);
       leg->Draw();
-      gpadsave->cd();
    } else {
-      Info("BuildLegend(void)","No object to build a TLegend.");
+      Info("BuildLegend", "No object(s) to build a TLegend.");
    }
    return leg;
 }
@@ -4943,8 +4943,7 @@ void TPad::Print(const char *filename, Option_t *option)
          GetCanvas()->SetBatch(kTRUE);
       }
 
-      auto padsav = gPad;
-      cd();
+      TContext ctxt(this, kTRUE);
 
       if (!gVirtualPS) {
          // Plugin Postscript/SVG driver
@@ -4971,10 +4970,6 @@ void TPad::Print(const char *filename, Option_t *option)
 
       delete gVirtualPS;
       gVirtualPS = nullptr;
-      if (padsav)
-         padsav->cd();
-      else
-         gPad = nullptr;
 
       return;
    }
@@ -4989,8 +4984,7 @@ void TPad::Print(const char *filename, Option_t *option)
          GetCanvas()->SetBatch(kTRUE);
       }
 
-      auto padsav = gPad;
-      cd();
+      TContext ctxt(this, kTRUE);
 
       if (!gVirtualPS) {
          // Plugin Postscript/SVG driver
@@ -5025,10 +5019,6 @@ void TPad::Print(const char *filename, Option_t *option)
 
       delete gVirtualPS;
       gVirtualPS = nullptr;
-      if (padsav)
-         padsav->cd();
-      else
-         gPad = nullptr;
 
       return;
    }
@@ -5066,8 +5056,8 @@ void TPad::Print(const char *filename, Option_t *option)
    if (strstr(opt,"Landscape")) pstype = 112;
    if (strstr(opt,"eps"))       pstype = 113;
    if (strstr(opt,"Preview"))   pstype = 113;
-   auto padsav = gPad;
-   cd();
+
+   TContext ctxt(this, kTRUE);
    TVirtualPS *psave = gVirtualPS;
 
    if (!gVirtualPS || mustOpen) {
@@ -5150,11 +5140,6 @@ void TPad::Print(const char *filename, Option_t *option)
                           psname.Data()).Data());
       gSystem->Rename("pdf_temp.pdf", psname.Data());
    }
-
-   if (padsav)
-      padsav->cd();
-   else
-      gPad = nullptr;
 
 }
 
@@ -6191,10 +6176,11 @@ void TPad::ShowGuidelines(TObject *object, const Int_t event, const char mode, c
    if (mode != 'i') resize = true;
 
    TPad *is_pad = dynamic_cast<TPad *>( object );
-   TVirtualPad *padSave = nullptr;
-   padSave = gPad;
-   if (is_pad)
-     if (is_pad->GetMother()) is_pad->GetMother()->cd();
+
+   TContext ctxt(kTRUE);
+
+   if (is_pad && is_pad->GetMother())
+      is_pad->GetMother()->cd();
 
    static TPad *tmpGuideLinePad = nullptr;
 
@@ -6453,7 +6439,6 @@ void TPad::ShowGuidelines(TObject *object, const Int_t event, const char mode, c
    }
 
    gPad->Modified(kTRUE);
-   padSave->cd();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3932,38 +3932,29 @@ void TPad::PaintFillAreaHatches(Int_t nn, Double_t *xx, Double_t *yy, Int_t Fill
    static Double_t ang1[10] = {  0., 10., 20., 30., 45.,5., 60., 70., 80., 89.99};
    static Double_t ang2[10] = {180.,170.,160.,150.,135.,5.,120.,110.,100., 89.99};
 
-   Int_t fasi  = FillStyle%1000;
-   Int_t idSPA = (Int_t)(fasi/100);
-   Int_t iAng2 = (Int_t)((fasi-100*idSPA)/10);
-   Int_t iAng1 = fasi%10;
-   Double_t dy = 0.003*(Double_t)(idSPA)*gStyle->GetHatchesSpacing();
-   Int_t lw = gStyle->GetHatchesLineWidth();
-   Short_t lws = 0;
-   Int_t   lss = 0;
-   Int_t   lcs = 0;
+   Int_t fasi  = FillStyle % 1000;
+   Int_t idSPA = fasi / 100;
+   Int_t iAng2 = (fasi - 100 * idSPA) / 10;
+   Int_t iAng1 = fasi % 10;
+   Double_t dy = 0.003 * idSPA * gStyle->GetHatchesSpacing();
+   Short_t lws = 0, lws2 = 0, lw = gStyle->GetHatchesLineWidth();
+   Int_t   lss = 0, lss2 = 0, lcs = 0, lcs2 = 0;
 
-   // Save the current line attributes
+   // Save the current line attributes and change to draw hatches
    if (!gPad->IsBatch() && GetPainter()) {
       lws = GetPainter()->GetLineWidth();
       lss = GetPainter()->GetLineStyle();
       lcs = GetPainter()->GetLineColor();
-   } else {
-      if (gVirtualPS) {
-         lws = gVirtualPS->GetLineWidth();
-         lss = gVirtualPS->GetLineStyle();
-         lcs = gVirtualPS->GetLineColor();
-      }
-   }
-
-   // Change the current line attributes to draw the hatches
-   if (!gPad->IsBatch() && GetPainter()) {
       GetPainter()->SetLineStyle(1);
-      GetPainter()->SetLineWidth(Short_t(lw));
+      GetPainter()->SetLineWidth(lw);
       GetPainter()->SetLineColor(GetPainter()->GetFillColor());
    }
    if (gVirtualPS) {
+      lws2 = gVirtualPS->GetLineWidth();
+      lss2 = gVirtualPS->GetLineStyle();
+      lcs2 = gVirtualPS->GetLineColor();
       gVirtualPS->SetLineStyle(1);
-      gVirtualPS->SetLineWidth(Short_t(lw));
+      gVirtualPS->SetLineWidth(lw);
       gVirtualPS->SetLineColor(gVirtualPS->GetFillColor());
    }
 
@@ -3978,9 +3969,9 @@ void TPad::PaintFillAreaHatches(Int_t nn, Double_t *xx, Double_t *yy, Int_t Fill
       GetPainter()->SetLineColor(lcs);
    }
    if (gVirtualPS) {
-      gVirtualPS->SetLineStyle(lss);
-      gVirtualPS->SetLineWidth(lws);
-      gVirtualPS->SetLineColor(lcs);
+      gVirtualPS->SetLineStyle(lss2);
+      gVirtualPS->SetLineWidth(lws2);
+      gVirtualPS->SetLineColor(lcs2);
    }
 }
 
@@ -4143,8 +4134,7 @@ L50:
 
 void TPad::PaintLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
 {
-   Double_t x[2], y[2];
-   x[0] = x1;   x[1] = x2;   y[0] = y1;   y[1] = y2;
+   Double_t x[2] = {x1, x2}, y[2] = {y1, y2};
 
    //If line is totally clipped, return
    if (TestBit(TGraph::kClipFrame)) {
@@ -4156,9 +4146,8 @@ void TPad::PaintLine(Double_t x1, Double_t y1, Double_t x2, Double_t y2)
    if (!gPad->IsBatch() && GetPainter())
       GetPainter()->DrawLine(x[0], y[0], x[1], y[1]);
 
-   if (gVirtualPS) {
+   if (gVirtualPS)
       gVirtualPS->DrawPS(2, x, y);
-   }
 
    Modified();
 }

--- a/graf2d/graf/src/TLegend.cxx
+++ b/graf2d/graf/src/TLegend.cxx
@@ -559,9 +559,9 @@ void TLegend::Paint( Option_t* option )
 {
    // The legend need to be placed automatically in some empty space
    if (fX1 == fX2 && fY1 == fY2) {
-      if (gPad->PlaceBox(this, fX1, fY1, fX1, fY1)) {
-         fY2 = fY2+fY1;
-         fX2 = fX2+fX1;
+      if (gPad && gPad->PlaceBox(this, fX1, fY1, fX1, fY1)) {
+         fY2 = fY2 + fY1;
+         fX2 = fX2 + fX1;
       } else {
          Warning("Paint", "Legend too large to be automatically placed; a default position is used");
          fX1 = 0.5;

--- a/gui/webgui6/src/TWebCanvas.cxx
+++ b/gui/webgui6/src/TWebCanvas.cxx
@@ -56,23 +56,6 @@ Provides painting of main ROOT6 classes in web browsers
 
 */
 
-class PadContext {
-   TVirtualPad *savedPad{nullptr};
-public:
-   PadContext(TVirtualPad *setPad = nullptr)
-   {
-      savedPad = gPad;
-      if (gPad != setPad)
-         gPad = setPad;
-   }
-   ~PadContext()
-   {
-      if (gPad != savedPad)
-         gPad = savedPad;
-   }
-};
-
-
 using namespace std::string_literals;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -372,14 +355,14 @@ void TWebCanvas::CreatePadSnapshot(TPadWebSnapshot &paddata, TPad *pad, Long64_t
       if (obj->InheritsFrom(THStack::Class())) {
          // workaround for THStack, create extra components before sending to client
          auto hs = static_cast<THStack *>(obj);
-         PadContext ctxt(pad);
+         TVirtualPad::TContext ctxt(pad, kFALSE);
          hs->BuildPrimitives(iter.GetOption());
          has_histo = true;
       } else if (obj->InheritsFrom(TMultiGraph::Class())) {
          // workaround for TMultiGraph
          if (opt.Contains("A")) {
             auto mg = static_cast<TMultiGraph *>(obj);
-            PadContext ctxt;
+            TVirtualPad::TContext ctxt(kFALSE);
             mg->GetHistogram(); // force creation of histogram without any drawings
             has_histo = true;
          }
@@ -1750,7 +1733,7 @@ TPad *TWebCanvas::ProcessObjectOptions(TWebObjectOptions &item, TPad *pad, int i
       if (obj && obj->InheritsFrom(TPave::Class())) {
          TPave *pave = static_cast<TPave *>(obj);
          if ((item.fopt.size() >= 4) && objpad) {
-            PadContext ctxt(objpad);
+            TVirtualPad::TContext ctxt(objpad, kFALSE);
 
             // first time need to overcome init problem
             pave->ConvertNDCtoPad();

--- a/hist/histpainter/src/THistPainter.cxx
+++ b/hist/histpainter/src/THistPainter.cxx
@@ -6781,13 +6781,11 @@ void THistPainter::PaintFrame()
 
 void THistPainter::PaintFunction(Option_t *)
 {
-
-   TObjOptLink *lnk = (TObjOptLink*)fFunctions->FirstLink();
-   TObject *obj;
+   auto lnk = fFunctions->FirstLink();
 
    while (lnk) {
-      obj = lnk->GetObject();
-      TVirtualPad *padsave = gPad;
+      auto obj = lnk->GetObject();
+      TVirtualPad::TContext ctxt(true);
       if (obj->InheritsFrom(TF2::Class())) {
          if (!obj->TestBit(TF2::kNotDraw)) {
             if (Hoption.Lego || Hoption.Surf || Hoption.Error >= 100) {
@@ -6811,8 +6809,7 @@ void THistPainter::PaintFunction(Option_t *)
          if (!gPad->PadInHighlightMode() || (gPad->PadInHighlightMode() && obj == gPad->GetSelected()))
             obj->Paint(lnk->GetOption());
       }
-      lnk = (TObjOptLink*)lnk->Next();
-      padsave->cd();
+      lnk = lnk->Next();
    }
 }
 
@@ -10707,7 +10704,7 @@ void THistPainter::ShowProjectionX(Int_t /*px*/, Int_t py)
    pyold2 = py2;
 
    // Create or set the new canvas proj x
-   TVirtualPad *padsav = gPad;
+   TVirtualPad::TContext ctxt(true);
    TVirtualPad *c = (TVirtualPad*)gROOT->GetListOfCanvases()->FindObject(TString::Format("c_%zx_projection_%d",
                                                                               (size_t)fH, fShowProjection).Data());
    if (c) {
@@ -10719,8 +10716,8 @@ void THistPainter::ShowProjectionX(Int_t /*px*/, Int_t py)
       return;
    }
    c->cd();
-   c->SetLogy(padsav->GetLogz());
-   c->SetLogx(padsav->GetLogx());
+   c->SetLogy(ctxt.GetSaved()->GetLogz());
+   c->SetLogx(ctxt.GetSaved()->GetLogx());
 
    // Draw slice corresponding to mouse position
    TString prjName = TString::Format("slice_px_of_%s",fH->GetName());
@@ -10756,7 +10753,6 @@ void THistPainter::ShowProjectionX(Int_t /*px*/, Int_t py)
       hp->SetYTitle("Number of Entries");
       hp->Draw();
       c->Update();
-      padsav->cd();
    }
 }
 
@@ -10790,7 +10786,8 @@ void THistPainter::ShowProjectionY(Int_t px, Int_t /*py*/)
    pxold2 = px2;
 
    // Create or set the new canvas proj y
-   TVirtualPad *padsav = gPad;
+   TVirtualPad::TContext ctxt(true);
+
    TVirtualPad *c = (TVirtualPad*)gROOT->GetListOfCanvases()->FindObject(TString::Format("c_%zx_projection_%d",
                                                                               (size_t)fH, fShowProjection).Data());
    if (c) {
@@ -10802,8 +10799,8 @@ void THistPainter::ShowProjectionY(Int_t px, Int_t /*py*/)
       return;
    }
    c->cd();
-   c->SetLogy(padsav->GetLogz());
-   c->SetLogx(padsav->GetLogy());
+   c->SetLogy(ctxt.GetSaved()->GetLogz());
+   c->SetLogx(ctxt.GetSaved()->GetLogy());
 
    // Draw slice corresponding to mouse position
    TString prjName = TString::Format("slice_py_of_%s",fH->GetName());
@@ -10839,7 +10836,6 @@ void THistPainter::ShowProjectionY(Int_t px, Int_t /*py*/)
       hp->SetYTitle("Number of Entries");
       hp->Draw();
       c->Update();
-      padsav->cd();
    }
 }
 
@@ -10894,13 +10890,14 @@ void THistPainter::ShowProjection3(Int_t px, Int_t py)
    if (pymin==pymax) return;
    Double_t cx    = (pxmax-pxmin)/(uxmax-uxmin);
    Double_t cy    = (pymax-pymin)/(uymax-uymin);
-   TVirtualPad *padsav = gPad;
    TVirtualPad *c = (TVirtualPad*)gROOT->GetListOfCanvases()->FindObject(TString::Format("c_%zx_projection_%d",
                                                                               (size_t)fH, fShowProjection).Data());
    if (!c) {
       fShowProjection = 0;
       return;
    }
+
+   TVirtualPad::TContext ctxt(true);
 
    switch ((Int_t)fShowProjection%100) {
       case 1:
@@ -11668,5 +11665,4 @@ void THistPainter::ShowProjection3(Int_t px, Int_t py)
          break;
    }
    c->Update();
-   padsav->cd();
 }

--- a/net/httpsniff/src/TRootSnifferFull.cxx
+++ b/net/httpsniff/src/TRootSnifferFull.cxx
@@ -398,7 +398,7 @@ Bool_t TRootSnifferFull::ProduceImage(Int_t kind, const std::string &path, const
       }
 
       Bool_t isbatch = gROOT->IsBatch();
-      TVirtualPad *save_gPad = gPad;
+      TVirtualPad::TContext ctxt(false);
 
       if (!isbatch)
          gROOT->SetBatch(kTRUE);
@@ -410,7 +410,6 @@ Bool_t TRootSnifferFull::ProduceImage(Int_t kind, const std::string &path, const
 
       if (!isbatch)
          gROOT->SetBatch(kFALSE);
-      gPad = save_gPad;
 
    } else {
       delete img;


### PR DESCRIPTION
Class to preserve `gPad` from the position where TContext is created.

Supports two modes - interactive and fast. In interactive mode `pad->cd()` call is used. 
In the fast modes `gPad = saved_value` uses which should not invoke any graphics update.

Use this class mainly in `TPad.cxx` and `TCanvas.cxx`, but also in several other sources