### PR TITLE
[RF] Hardcode import of hist-samples in JSONFactoriesHistFactory

### DIFF
--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -43,7 +43,7 @@ class TClass;
 
 class RooJSONFactoryWSTool {
 public:
-   std::ostream &log(int level) const;
+   static std::ostream &log(int level);
 
    static std::string name(const RooFit::Detail::JSONNode &n);
 
@@ -102,7 +102,8 @@ public:
    static std::unique_ptr<RooDataHist> readBinnedData(RooWorkspace &ws, const RooFit::Detail::JSONNode &n,
                                                       const std::string &namecomp, RooArgList observables);
 
-   void getObservables(const RooFit::Detail::JSONNode &n, const std::string &obsnamecomp, RooArgSet &out);
+   static void
+   getObservables(RooWorkspace &ws, const RooFit::Detail::JSONNode &n, const std::string &obsnamecomp, RooArgSet &out);
 
    bool importJSON(std::string const &filename);
    bool importYML(std::string const &filename);
@@ -145,7 +146,7 @@ private:
    std::map<std::string, std::unique_ptr<RooAbsData>> loadData(const RooFit::Detail::JSONNode &n);
    std::unique_ptr<RooDataSet> unbinned(RooDataHist const &hist);
    RooRealVar *getWeightVar(const char *name);
-   RooRealVar *createObservable(const std::string &name, const RooJSONFactoryWSTool::Var &var);
+   static RooRealVar *createObservable(RooWorkspace &ws, const std::string &name, const RooJSONFactoryWSTool::Var &var);
 
    class MissingRootnodeError : public std::exception {
    public:

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -23,11 +23,9 @@ class RooArgList;
 class RooAbsData;
 class RooArgSet;
 class RooAbsArg;
-class RooAbsReal;
 class RooAbsPdf;
 class RooDataHist;
 class RooDataSet;
-class RooRealVar;
 class RooRealVar;
 class RooWorkspace;
 
@@ -50,8 +48,8 @@ public:
    template <class T>
    T *request(const std::string &objname, const std::string &requestAuthor);
 
-   RooJSONFactoryWSTool(RooWorkspace &ws) : _workspace{&ws} {}
-   RooWorkspace *workspace() { return _workspace; }
+   RooJSONFactoryWSTool(RooWorkspace &ws) : _workspace{ws} {}
+   RooWorkspace *workspace() { return &_workspace; }
 
    static void error(const char *s) { throw std::runtime_error(s); }
    static void error(const std::string &s) { throw std::runtime_error(s); }
@@ -188,7 +186,7 @@ private:
    void append(RooFit::Detail::JSONNode &n, const std::string &elem);
 
    void exportAttributes(const RooAbsArg *arg, RooFit::Detail::JSONNode &n);
-   void exportVariable(const RooAbsReal *v, RooFit::Detail::JSONNode &n);
+   void exportVariable(const RooAbsArg *v, RooFit::Detail::JSONNode &n);
    void exportVariables(const RooArgSet &allElems, RooFit::Detail::JSONNode &n);
    void exportFunctions(const RooArgSet &allElems, RooFit::Detail::JSONNode &n);
 
@@ -199,6 +197,6 @@ private:
    // member variables
    const RooFit::Detail::JSONNode *_rootnode_input = nullptr;
    RooFit::Detail::JSONNode *_rootnode_output = nullptr;
-   RooWorkspace *_workspace;
+   RooWorkspace &_workspace;
 };
 #endif

--- a/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
+++ b/roofit/hs3/inc/RooFitHS3/RooJSONFactoryWSTool.h
@@ -103,10 +103,6 @@ public:
                                                       const std::string &namecomp, RooArgList observables);
 
    void getObservables(const RooFit::Detail::JSONNode &n, const std::string &obsnamecomp, RooArgSet &out);
-   void setScopeObservables(const RooArgList &args);
-   RooAbsArg *getScopeObject(const std::string &name);
-   void setScopeObject(const std::string &key, RooAbsArg *obj);
-   void clearScope();
 
    bool importJSON(std::string const &filename);
    bool importYML(std::string const &filename);
@@ -141,11 +137,6 @@ private:
 
       Var(int n) : nbins(n), min(0), max(n) {}
       Var(const RooFit::Detail::JSONNode &val);
-   };
-
-   struct Scope {
-      std::vector<RooAbsArg *> observables;
-      std::map<std::string, RooAbsArg *> objects;
    };
 
    RooFit::Detail::JSONNode &orootnode();
@@ -205,7 +196,6 @@ private:
    void exportDependants(const RooAbsArg *source, RooFit::Detail::JSONNode *n);
 
    // member variables
-   mutable Scope _scope;
    const RooFit::Detail::JSONNode *_rootnode_input = nullptr;
    RooFit::Detail::JSONNode *_rootnode_output = nullptr;
    RooWorkspace *_workspace;

--- a/roofit/hs3/src/HistFactoryJSONTool.cxx
+++ b/roofit/hs3/src/HistFactoryJSONTool.cxx
@@ -29,7 +29,6 @@ void exportSample(const RooStats::HistFactory::Sample &sample, JSONNode &s)
                                            "obs_z_" + sample.GetChannelName()};
 
    s.set_map();
-   s["type"] << "hist-sample";
 
    if (sample.GetOverallSysList().size() > 0) {
       auto &overallSys = s["overallSystematics"];

--- a/roofit/hs3/src/JSONFactories_HistFactory.cxx
+++ b/roofit/hs3/src/JSONFactories_HistFactory.cxx
@@ -465,7 +465,7 @@ public:
       std::vector<std::string> coefnames;
       RooArgSet observables;
       if (p.has_child("observables")) {
-         tool->getObservables(p, name, observables);
+         RooJSONFactoryWSTool::getObservables(ws, p, name, observables);
          scope.setObservables(observables);
       }
       for (const auto &comp : p["samples"].children()) {
@@ -474,7 +474,7 @@ public:
          std::string fprefix = RooJSONFactoryWSTool::genPrefix(def, true);
          try {
             if (observables.empty()) {
-               tool->getObservables(comp["data"], fprefix, observables);
+               RooJSONFactoryWSTool::getObservables(ws, comp["data"], fprefix, observables);
                scope.setObservables(observables);
             }
             if (def.has_child("overallSystematics"))

--- a/roofit/hs3/src/JSONFactories_RooFitCore.cxx
+++ b/roofit/hs3/src/JSONFactories_RooFitCore.cxx
@@ -176,7 +176,7 @@ public:
       RooCategory cat(indexname.c_str(), indexname.c_str());
       for (const auto &comp : p["channels"].children()) {
          std::string catname(RooJSONFactoryWSTool::name(comp));
-         tool->log(RooFit::INFO) << "importing category " << catname << std::endl;
+         RooJSONFactoryWSTool::log(RooFit::INFO) << "importing category " << catname << std::endl;
          tool->importFunction(comp, true);
          std::string pdfname(comp.has_val() ? comp.val() : RooJSONFactoryWSTool::name(comp));
          RooAbsPdf *pdf = tool->request<RooAbsPdf>(pdfname, name);
@@ -345,7 +345,7 @@ public:
          RooJSONFactoryWSTool::error("function '" + name + "' is of histogram type, but does not define a 'data' key");
       }
       RooArgSet varlist;
-      tool->getObservables(p["data"], name, varlist);
+      RooJSONFactoryWSTool::getObservables(ws, p["data"], name, varlist);
       RooDataHist *dh = dynamic_cast<RooDataHist *>(ws.embeddedData(name));
       if (!dh) {
          auto dhForImport = RooJSONFactoryWSTool::readBinnedData(ws, p["data"], name, varlist);

--- a/roofit/hs3/src/RooJSONFactoryWSTool.cxx
+++ b/roofit/hs3/src/RooJSONFactoryWSTool.cxx
@@ -1013,10 +1013,6 @@ void RooJSONFactoryWSTool::exportData(RooAbsData *data, JSONNode &n)
 // create several observables
 void RooJSONFactoryWSTool::getObservables(const JSONNode &n, const std::string &obsnamecomp, RooArgSet &out)
 {
-   if (!_scope.observables.empty()) {
-      out.add(_scope.observables.begin(), _scope.observables.end());
-      return;
-   }
    auto vars = readObservables(n, obsnamecomp);
    for (auto v : vars) {
       std::string name(v.first);
@@ -1026,26 +1022,6 @@ void RooJSONFactoryWSTool::getObservables(const JSONNode &n, const std::string &
          out.add(*RooJSONFactoryWSTool::createObservable(name, v.second));
       }
    }
-}
-
-void RooJSONFactoryWSTool::setScopeObservables(const RooArgList &args)
-{
-   for (auto *arg : args) {
-      _scope.observables.push_back(arg);
-   }
-}
-void RooJSONFactoryWSTool::setScopeObject(const std::string &name, RooAbsArg *obj)
-{
-   _scope.objects[name] = obj;
-}
-RooAbsArg *RooJSONFactoryWSTool::getScopeObject(const std::string &name)
-{
-   return _scope.objects[name];
-}
-void RooJSONFactoryWSTool::clearScope()
-{
-   _scope.objects.clear();
-   _scope.observables.clear();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
A `histfactory` PDF type in the JSON always needs to have the
histogram sample specifications in the `samples` field. Therefore, it is
better to code the import of the histogram stacks directly into the
function that imports the full HistFactory PDF.

Like this, we can get around some of the hacks in the HistFactory JSON
IO that make assumptions on how functions are imported from the JSON,
and we have more flexibility to change the top-level structure later.

This means that the "type" field for each sample in the histogram stack
is also not necessary anymore.

This PR also includes some other code improvements that are explained in the commit descriptions.

