### PR TITLE
Re-enable support for profiling/debugging interpreted/JITted code

### DIFF
--- a/interpreter/cling/include/cling/Utils/Utils.h
+++ b/interpreter/cling/include/cling/Utils/Utils.h
@@ -1,0 +1,38 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author: Guilherme Amadio <amadio@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include <cstdlib>
+#include <cstring>
+
+#ifndef CLING_UTILS_UTILS_H
+#define CLING_UTILS_UTILS_H
+
+#if defined(_MSC_VER) && !defined(strcasecmp)
+#define strcasecmp _stricmp
+#endif
+
+namespace cling {
+  namespace utils {
+    /** Convert @p value to boolean */
+    static inline bool ConvertEnvValueToBool(const char* value) {
+      const char* true_strs[] = {"1", "true", "on", "yes"};
+
+      if (!value)
+        return false;
+
+      for (auto str : true_strs)
+        if (strcasecmp(value, str) == 0)
+          return true;
+
+      return false;
+    }
+  } // namespace utils
+} // namespace cling
+
+#endif // CLING_UTILS_UTILS_H

--- a/interpreter/cling/lib/Interpreter/CIFactory.cpp
+++ b/interpreter/cling/lib/Interpreter/CIFactory.cpp
@@ -15,6 +15,7 @@
 #include "cling/Utils/Output.h"
 #include "cling/Utils/Paths.h"
 #include "cling/Utils/Platform.h"
+#include "cling/Utils/Utils.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/Builtins.h"
@@ -50,6 +51,7 @@
 #include "llvm/Target/TargetOptions.h"
 
 #include <cstdio>
+#include <cstdlib>
 #include <ctime>
 #include <limits>
 #include <memory>
@@ -1243,6 +1245,12 @@ namespace {
     std::vector<const char*> argvCompile(argv, argv+1);
     argvCompile.reserve(argc+32);
 
+    bool debuggingEnabled =
+        cling::utils::ConvertEnvValueToBool(std::getenv("CLING_DEBUG"));
+
+    bool profilingEnabled =
+        cling::utils::ConvertEnvValueToBool(std::getenv("CLING_PROFILE"));
+
 #if __APPLE__ && __arm64__
     argvCompile.push_back("--target=arm64-apple-darwin20.3.0");
 #endif
@@ -1322,6 +1330,16 @@ namespace {
     // target.
     if(COpts.CUDAHost)
       argvCompile.push_back("--cuda-host-only");
+
+#ifdef __linux__
+    // Keep frame pointer to make JIT stack unwinding reliable for profiling
+    if (profilingEnabled)
+      argvCompile.push_back("-fno-omit-frame-pointer");
+#endif
+
+    // Disable optimizations and keep frame pointer when debugging
+    if (debuggingEnabled)
+      argvCompile.push_back("-O0 -fno-omit-frame-pointer");
 
     // argv[0] already inserted, get the rest
     argvCompile.insert(argvCompile.end(), argv+1, argv + argc);
@@ -1662,7 +1680,10 @@ namespace {
     // adjusted per transaction in IncrementalParser::codeGenTransaction().
     CGOpts.setInlining(CodeGenOptions::NormalInlining);
 
-    // CGOpts.setDebugInfo(clang::CodeGenOptions::FullDebugInfo);
+    // Add debugging info when debugging or profiling
+    if (debuggingEnabled || profilingEnabled)
+      CGOpts.setDebugInfo(codegenoptions::FullDebugInfo);
+
     // CGOpts.EmitDeclMetadata = 1; // For unloading, for later
     // aliasing the complete ctor to the base ctor causes the JIT to crash
     CGOpts.CXXCtorDtorAliases = 0;

--- a/interpreter/cling/lib/Interpreter/CMakeLists.txt
+++ b/interpreter/cling/lib/Interpreter/CMakeLists.txt
@@ -87,6 +87,7 @@ add_cling_library(clingInterpreter OBJECT
   InvocationOptions.cpp
   LookupHelper.cpp
   NullDerefProtectionTransformer.cpp
+  PerfJITEventListener.cpp
   RequiredSymbols.cpp
   Transaction.cpp
   TransactionUnloader.cpp

--- a/interpreter/cling/lib/Interpreter/PerfJITEventListener.cpp
+++ b/interpreter/cling/lib/Interpreter/PerfJITEventListener.cpp
@@ -1,0 +1,129 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author: Guilherme Amadio <amadio@cern.ch>
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+//
+// This file implements a JITEventListener object that tells perf about JITted
+// symbols using perf map files (/tmp/perf-%d.map, where %d = pid of process).
+//
+// Documentation for this perf jit interface is available at:
+// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/jit-interface.txt
+//
+//------------------------------------------------------------------------------
+
+#ifdef __linux__
+
+#include "llvm/ExecutionEngine/JITEventListener.h"
+#include "llvm/Object/ObjectFile.h"
+#include "llvm/Object/SymbolSize.h"
+#include "llvm/Support/ManagedStatic.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+
+#include <unistd.h>
+
+using namespace llvm;
+using namespace llvm::object;
+
+namespace {
+
+  class PerfJITEventListener : public JITEventListener {
+  public:
+    PerfJITEventListener();
+    ~PerfJITEventListener() {
+      if (m_Perfmap)
+        fclose(m_Perfmap);
+    }
+
+    void notifyObjectLoaded(ObjectKey K, const ObjectFile& Obj,
+                            const RuntimeDyld::LoadedObjectInfo& L) override;
+    void notifyFreeingObject(ObjectKey K) override;
+
+  private:
+    std::mutex m_Mutex;
+    FILE* m_Perfmap;
+  };
+
+  PerfJITEventListener::PerfJITEventListener() {
+    char filename[64];
+    snprintf(filename, 64, "/tmp/perf-%d.map", getpid());
+    m_Perfmap = fopen(filename, "a");
+  }
+
+  void PerfJITEventListener::notifyObjectLoaded(
+      ObjectKey K, const ObjectFile& Obj,
+      const RuntimeDyld::LoadedObjectInfo& L) {
+
+    if (!m_Perfmap)
+      return;
+
+    OwningBinary<ObjectFile> DebugObjOwner = L.getObjectForDebug(Obj);
+    const ObjectFile& DebugObj = *DebugObjOwner.getBinary();
+
+    // For each symbol, we want to check its address and size
+    // if it's a function and write the information to the perf
+    // map file, otherwise we just ignore the symbol and any
+    // related errors. This implementation is adapted from LLVM:
+    // llvm/src/lib/ExecutionEngine/PerfJITEvents/PerfJITEventListener.cpp
+
+    for (const std::pair<SymbolRef, uint64_t>& P :
+         computeSymbolSizes(DebugObj)) {
+      SymbolRef Sym = P.first;
+
+      Expected<SymbolRef::Type> SymTypeOrErr = Sym.getType();
+      if (!SymTypeOrErr) {
+        consumeError(SymTypeOrErr.takeError());
+        continue;
+      }
+
+      SymbolRef::Type SymType = *SymTypeOrErr;
+      if (SymType != SymbolRef::ST_Function)
+        continue;
+
+      Expected<StringRef> Name = Sym.getName();
+      if (!Name) {
+        consumeError(Name.takeError());
+        continue;
+      }
+
+      Expected<uint64_t> AddrOrErr = Sym.getAddress();
+      if (!AddrOrErr) {
+        consumeError(AddrOrErr.takeError());
+        continue;
+      }
+
+      uint64_t address = *AddrOrErr;
+      uint64_t size = P.second;
+
+      if (size == 0)
+        continue;
+
+      std::lock_guard<std::mutex> lock(m_Mutex);
+      fprintf(m_Perfmap, "%" PRIx64 " %" PRIx64 " %s\n", address, size,
+              Name->data());
+    }
+
+    fflush(m_Perfmap);
+  }
+
+  void PerfJITEventListener::notifyFreeingObject(ObjectKey K) {
+    // nothing to be done
+  }
+
+  llvm::ManagedStatic<PerfJITEventListener> PerfListener;
+
+} // end anonymous namespace
+
+namespace cling {
+
+  JITEventListener* createPerfJITEventListener() { return &*PerfListener; }
+
+} // namespace cling
+
+#endif


### PR DESCRIPTION
This feature, originally added in commit 22b1606f, was reverted to make the LLVM upgrade to version 13 easier. This commit adds back all functionality as it was just before the LLVM upgrade.

Edit: Unfortunately, still doesn't work with embedded debugging info:
```
epsftws build $ env CLING_DEBUG=1 EXTRA_CLING_ARGS='-gdwarf-5 -gembed-source' gdb -- bin/root.exe
GNU gdb (Gentoo 12.1 vanilla) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://bugs.gentoo.org/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from bin/root.exe...
(gdb) break f
Function "f" not defined.
Make breakpoint pending on future shared library load? (y or [n]) y
Breakpoint 1 (f) pending.
(gdb) run
Starting program: /srv/root/build/bin/root.exe 
warning: File "/srv/root/build/lib/libCore.so-gdb.py" auto-loading has been declined by your `auto-load safe-path' set to "$debugdir:$datadir/auto-load".
To enable execution of this file add
	add-auto-load-safe-path /srv/root/build/lib/libCore.so-gdb.py
line to your configuration file "/home/amadio/.config/gdb/gdbinit".
To completely disable this security protection add
	set auto-load safe-path /
line to your configuration file "/home/amadio/.config/gdb/gdbinit".
For more information about this security protection see the
"Auto-loading safe path" section in the GDB manual.  E.g., run from the shell:
	info "(gdb)Auto-loading safe path"
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib64/libthread_db.so.1".
[Detaching after vfork from child process 798483]
[Detaching after vfork from child process 800084]
[Detaching after vfork from child process 800087]
   ------------------------------------------------------------------
  | Welcome to ROOT 6.27/01                        https://root.cern |
  | (c) 1995-2022, The ROOT Team; conception: R. Brun, F. Rademakers |
  | Built for linuxx8664gcc on Dec 13 2022, 14:33:20                 |
  | From heads/cling-profile-debug@v6-25-02-3189-gf5fced388b         |
  | With c++ (Gentoo 12.2.1_p20221203 p3) 12.2.1 20221203            |
  | Try '.help'/'.?', '.demo', '.license', '.credits', '.quit'/'.q'  |
   ------------------------------------------------------------------

[Detaching after vfork from child process 800350]
root [0] double f(double x) { return x*x; }
root [1] double y = f(3.0);
Failure value returned from cantFail wrapped call
inconsistent use of embedded source
UNREACHABLE executed at /srv/root/src/root/interpreter/llvm/src/include/llvm/Support/Error.h:782!

Program received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
44	      return INTERNAL_SYSCALL_ERROR_P (ret) ? INTERNAL_SYSCALL_ERRNO (ret) : 0;
(gdb) 

```
I will try with dwarf-5 for everything, let's see if that helps. At least GDB didn't crash this time.