### PR TITLE
Improve `TGraph::SaveSprimitive()`

### DIFF
--- a/graf2d/gpad/src/TPad.cxx
+++ b/graf2d/gpad/src/TPad.cxx
@@ -3425,7 +3425,7 @@ void TPad::Paint(Option_t * /*option*/)
       PaintBorder(GetFillColor(), kTRUE);
       PaintDate();
 
-      TObjOptLink *lnk = (TObjOptLink*)GetListOfPrimitives()->FirstLink();
+      auto lnk = GetListOfPrimitives()->FirstLink();
 
       while (lnk) {
          TObject *obj = lnk->GetObject();
@@ -3442,7 +3442,7 @@ void TPad::Paint(Option_t * /*option*/)
          }
 
          obj->Paint(lnk->GetOption());
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
    }
 
@@ -3636,14 +3636,12 @@ void TPad::PaintModified()
          Modified(kFALSE);
       }
       TList *pList = GetListOfPrimitives();
-      TObjOptLink *lnk = nullptr;
-      if (pList) lnk = (TObjOptLink*)pList->FirstLink();
-      TObject *obj;
+      auto lnk = pList ? pList->FirstLink() : nullptr;
       while (lnk) {
-         obj = lnk->GetObject();
+         auto obj = lnk->GetObject();
          if (obj->InheritsFrom(TPad::Class()))
             ((TPad*)obj)->PaintModified();
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
       return;
    }
@@ -3670,8 +3668,7 @@ void TPad::PaintModified()
       PaintDate();
 
       TList *pList = GetListOfPrimitives();
-      TObjOptLink *lnk = nullptr;
-      if (pList) lnk = (TObjOptLink*)pList->FirstLink();
+      auto lnk = pList ? pList->FirstLink() : nullptr;
 
       while (lnk) {
          TObject *obj = lnk->GetObject();
@@ -3693,7 +3690,7 @@ void TPad::PaintModified()
 
             obj->Paint(lnk->GetOption());
          }
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
    }
 

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -64,6 +64,8 @@ protected:
    Double_t         **ShrinkAndCopy(Int_t size, Int_t iend);
    virtual Bool_t     DoMerge(const TGraph * g);
 
+   void               SaveHistogramAndFunctions(std::ostream &out, const char *varname, Int_t &frameNumber, Option_t *option);
+
 public:
    // TGraph status bits
    enum EStatusBits {

--- a/hist/hist/inc/TGraph.h
+++ b/hist/hist/inc/TGraph.h
@@ -64,6 +64,7 @@ protected:
    Double_t         **ShrinkAndCopy(Int_t size, Int_t iend);
    virtual Bool_t     DoMerge(const TGraph * g);
 
+   TString            SaveArray(std::ostream &out, const char *suffix, Int_t frameNumber, Double_t *arr);
    void               SaveHistogramAndFunctions(std::ostream &out, const char *varname, Int_t &frameNumber, Option_t *option);
 
 public:

--- a/hist/hist/src/TGraph.cxx
+++ b/hist/hist/src/TGraph.cxx
@@ -2152,10 +2152,15 @@ TString TGraph::SaveArray(std::ostream &out, const char *suffix, Int_t frameNumb
       name = "Graph";
    TString arrname = TString::Format("%s_%s%d", name, suffix, frameNumber);
 
-   out << "   Double_t " << arrname << "[" << fNpoints << "] = {" << std::endl;
-   for (Int_t i = 0; i < fNpoints-1; i++)
-      out << "   " << arr[i] << "," << std::endl;
-   out << "   " << arr[fNpoints-1] << "};" << std::endl;
+   out << "   Double_t " << arrname << "[" << fNpoints << "] = { ";
+   for (Int_t i = 0; i < fNpoints-1; i++) {
+      out << arr[i] << ",";
+      if (i && (i % 16 == 0))
+         out << std::endl << "   ";
+      else
+         out << " ";
+   }
+   out << arr[fNpoints-1] << " };" << std::endl;
 
    return arrname;
 }

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1293,6 +1293,11 @@ void TGraphAsymmErrors::Scale(Double_t c1, Option_t *option)
 
 void TGraphAsymmErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, Double_t eyh)
 {
+   if (!gPad) {
+      Error("SetPointError", "Cannot be used without gPad, requires last mouse position");
+      return;
+   }
+
    Int_t px = gPad->GetEventX();
    Int_t py = gPad->GetEventY();
 
@@ -1322,7 +1327,7 @@ void TGraphAsymmErrors::SetPointError(Int_t i, Double_t exl, Double_t exh, Doubl
 {
    if (i < 0) return;
    if (i >= fNpoints) {
-   // re-allocate the object
+      // re-allocate the object
       TGraphAsymmErrors::SetPoint(i,0,0);
    }
    fEXlow[i]  = exl;
@@ -1339,7 +1344,7 @@ void TGraphAsymmErrors::SetPointEXlow(Int_t i, Double_t exl)
 {
    if (i < 0) return;
    if (i >= fNpoints) {
-   // re-allocate the object
+      // re-allocate the object
       TGraphAsymmErrors::SetPoint(i,0,0);
    }
    fEXlow[i]  = exl;
@@ -1353,7 +1358,7 @@ void TGraphAsymmErrors::SetPointEXhigh(Int_t i, Double_t exh)
 {
    if (i < 0) return;
    if (i >= fNpoints) {
-   // re-allocate the object
+      // re-allocate the object
       TGraphAsymmErrors::SetPoint(i,0,0);
    }
    fEXhigh[i]  = exh;

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1241,12 +1241,12 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
    frameNumber++;
 
    Int_t i;
-   TString fXName   = TString(GetName()) + Form("_fx%d",frameNumber);
-   TString fYName   = TString(GetName()) + Form("_fy%d",frameNumber);
-   TString fElXName = TString(GetName()) + Form("_felx%d",frameNumber);
-   TString fElYName = TString(GetName()) + Form("_fely%d",frameNumber);
-   TString fEhXName = TString(GetName()) + Form("_fehx%d",frameNumber);
-   TString fEhYName = TString(GetName()) + Form("_fehy%d",frameNumber);
+   auto fXName   = TString::Format("%s_fx%d", GetName(), frameNumber);
+   auto fYName   = TString::Format("%s_fy%d", GetName(), frameNumber);
+   auto fElXName = TString::Format("%s_felx%d", GetName(), frameNumber);
+   auto fElYName = TString::Format("%s_fely%d", GetName(), frameNumber);
+   auto fEhXName = TString::Format("%s_fehx%d", GetName(), frameNumber);
+   auto fEhYName = TString::Format("%s_fehy%d", GetName(), frameNumber);
    out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
    out << "   " << fX[fNpoints-1] << "};" << std::endl;
@@ -1266,8 +1266,10 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
    for (i = 0; i < fNpoints-1; i++) out << "   " << fEYhigh[i] << "," << std::endl;
    out << "   " << fEYhigh[fNpoints-1] << "};" << std::endl;
 
-   if (gROOT->ClassSaved(TGraphAsymmErrors::Class())) out<<"   ";
-   else out << "   TGraphAsymmErrors *";
+   if (gROOT->ClassSaved(TGraphAsymmErrors::Class()))
+      out<<"   ";
+   else
+      out << "   TGraphAsymmErrors *";
    out << "grae = new TGraphAsymmErrors("<< fNpoints << ","
                                     << fXName   << ","  << fYName  << ","
                                     << fElXName  << ","  << fEhXName << ","
@@ -1281,40 +1283,7 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
    SaveLineAttributes(out, "grae", 1, 1, 1);
    SaveMarkerAttributes(out, "grae", 1, 1, 1);
 
-   if (fHistogram) {
-      TString hname = fHistogram->GetName();
-      hname += frameNumber;
-      fHistogram->SetName(Form("Graph_%s",hname.Data()));
-      fHistogram->SavePrimitive(out,"nodraw");
-      out<<"   grae->SetHistogram("<<fHistogram->GetName()<<");"<<std::endl;
-      out<<"   "<<std::endl;
-   }
-
-   // save list of functions
-   TIter next(fFunctions);
-   TObject *obj;
-   while ((obj = next())) {
-      obj->SavePrimitive(out, Form("nodraw #%d\n",++frameNumber));
-      if (obj->InheritsFrom("TPaveStats")) {
-         out << "   grae->GetListOfFunctions()->Add(ptstats);" << std::endl;
-         out << "   ptstats->SetParent(grae->GetListOfFunctions());" << std::endl;
-      } else {
-         TString objname;
-         objname.Form("%s%d",obj->GetName(),frameNumber);
-         if (obj->InheritsFrom("TF1")) {
-            out << "   " << objname << "->SetParent(grae);\n";
-         }
-         out << "   grae->GetListOfFunctions()->Add("
-             << objname << ");" << std::endl;
-      }
-   }
-
-   const char *l = strstr(option,"multigraph");
-   if (l) {
-      out<<"   multigraph->Add(grae,"<<quote<<l+10<<quote<<");"<<std::endl;
-   } else {
-      out<<"   grae->Draw("<<quote<<option<<quote<<");"<<std::endl;
-   }
+   SaveHistogramAndFunctions(out, "grae", frameNumber, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphAsymmErrors.cxx
+++ b/hist/hist/src/TGraphAsymmErrors.cxx
@@ -1235,36 +1235,16 @@ void TGraphAsymmErrors::Print(Option_t *) const
 
 void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    out << "   " << std::endl;
    static Int_t frameNumber = 3000;
    frameNumber++;
 
-   Int_t i;
-   auto fXName   = TString::Format("%s_fx%d", GetName(), frameNumber);
-   auto fYName   = TString::Format("%s_fy%d", GetName(), frameNumber);
-   auto fElXName = TString::Format("%s_felx%d", GetName(), frameNumber);
-   auto fElYName = TString::Format("%s_fely%d", GetName(), frameNumber);
-   auto fEhXName = TString::Format("%s_fehx%d", GetName(), frameNumber);
-   auto fEhYName = TString::Format("%s_fehy%d", GetName(), frameNumber);
-   out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-   out << "   " << fX[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-   out << "   " << fY[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fElXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEXlow[i] << "," << std::endl;
-   out << "   " << fEXlow[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fElYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEYlow[i] << "," << std::endl;
-   out << "   " << fEYlow[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEhXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEXhigh[i] << "," << std::endl;
-   out << "   " << fEXhigh[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEhYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEYhigh[i] << "," << std::endl;
-   out << "   " << fEYhigh[fNpoints-1] << "};" << std::endl;
+   auto fXName   = SaveArray(out, "fx", frameNumber, fX);
+   auto fYName   = SaveArray(out, "fy", frameNumber, fY);
+   auto fElXName = SaveArray(out, "felx", frameNumber, fEXlow);
+   auto fElYName = SaveArray(out, "fely", frameNumber, fEYlow);
+   auto fEhXName = SaveArray(out, "fehx", frameNumber, fEXhigh);
+   auto fEhYName = SaveArray(out, "fehy", frameNumber, fEYhigh);
 
    if (gROOT->ClassSaved(TGraphAsymmErrors::Class()))
       out<<"   ";
@@ -1275,13 +1255,6 @@ void TGraphAsymmErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""
                                     << fElXName  << ","  << fEhXName << ","
                                     << fElYName  << ","  << fEhYName << ");"
                                     << std::endl;
-
-   out << "   grae->SetName(" << quote << GetName() << quote << ");" << std::endl;
-   out << "   grae->SetTitle(" << quote << GetTitle() << quote << ");" << std::endl;
-
-   SaveFillAttributes(out, "grae", 0, 1001);
-   SaveLineAttributes(out, "grae", 1, 1, 1);
-   SaveMarkerAttributes(out, "grae", 1, 1, 1);
 
    SaveHistogramAndFunctions(out, "grae", frameNumber, option);
 }

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -148,25 +148,25 @@ TGraphBentErrors::TGraphBentErrors(Int_t n,
   : TGraph(n,x,y)
 {
    if (!CtorAllocate()) return;
-   n = sizeof(Double_t)*fNpoints;
+   auto memsz = sizeof(Double_t)*fNpoints;
 
-      if (exl) memcpy(fEXlow, exl, n);
-      else     memset(fEXlow, 0, n);
-      if (exh) memcpy(fEXhigh, exh, n);
-      else     memset(fEXhigh, 0, n);
-      if (eyl) memcpy(fEYlow, eyl, n);
-      else     memset(fEYlow, 0, n);
-      if (eyh) memcpy(fEYhigh, eyh, n);
-      else     memset(fEYhigh, 0, n);
+   if (exl) memcpy(fEXlow, exl, memsz);
+       else memset(fEXlow, 0, memsz);
+   if (exh) memcpy(fEXhigh, exh, memsz);
+       else memset(fEXhigh, 0, memsz);
+   if (eyl) memcpy(fEYlow, eyl, memsz);
+       else memset(fEYlow, 0, memsz);
+   if (eyh) memcpy(fEYhigh, eyh, memsz);
+       else memset(fEYhigh, 0, memsz);
 
-      if (exld) memcpy(fEXlowd, exld, n);
-      else      memset(fEXlowd, 0, n);
-      if (exhd) memcpy(fEXhighd, exhd, n);
-      else      memset(fEXhighd, 0, n);
-      if (eyld) memcpy(fEYlowd,  eyld, n);
-      else      memset(fEYlowd, 0, n);
-      if (eyhd) memcpy(fEYhighd, eyhd, n);
-      else      memset(fEYhighd, 0, n);
+   if (exld) memcpy(fEXlowd, exld, memsz);
+        else memset(fEXlowd, 0, memsz);
+   if (exhd) memcpy(fEXhighd, exhd, memsz);
+        else memset(fEXhighd, 0, memsz);
+   if (eyld) memcpy(fEYlowd,  eyld, memsz);
+        else memset(fEYlowd, 0, memsz);
+   if (eyhd) memcpy(fEYhighd, eyhd, memsz);
+        else memset(fEYhighd, 0, memsz);
 }
 
 
@@ -204,25 +204,24 @@ void TGraphBentErrors::Apply(TF1 *f)
 
    if (fHistogram) {
       delete fHistogram;
-      fHistogram = 0;
+      fHistogram = nullptr;
    }
-   for (Int_t i=0;i<GetN();i++) {
-      GetPoint(i,x,y);
-      exl=GetErrorXlow(i);
-      exh=GetErrorXhigh(i);
-      eyl=GetErrorYlow(i);
-      eyh=GetErrorYhigh(i);
+   for (Int_t i = 0; i < GetN(); i++) {
+      GetPoint(i, x, y);
+      exl = GetErrorXlow(i);
+      exh = GetErrorXhigh(i);
+      eyl = GetErrorYlow(i);
+      eyh = GetErrorYhigh(i);
 
-      fxy = f->Eval(x,y);
-      SetPoint(i,x,fxy);
+      fxy = f->Eval(x, y);
+      SetPoint(i, x, fxy);
 
       // in the case of the functions like y-> -1*y the roles of the
       // upper and lower error bars is reversed
-      if (f->Eval(x,y-eyl)<f->Eval(x,y+eyh)) {
+      if (f->Eval(x,y-eyl) < f->Eval(x,y+eyh)) {
          eyl_new = TMath::Abs(fxy - f->Eval(x,y-eyl));
          eyh_new = TMath::Abs(f->Eval(x,y+eyh) - fxy);
-      }
-      else {
+      } else {
          eyh_new = TMath::Abs(fxy - f->Eval(x,y-eyl));
          eyl_new = TMath::Abs(f->Eval(x,y+eyh) - fxy);
       }
@@ -335,11 +334,11 @@ Bool_t TGraphBentErrors::CopyPoints(Double_t **arrays,
 ////////////////////////////////////////////////////////////////////////////////
 /// Should be called from ctors after `fNpoints` has been set.
 
-Bool_t TGraphBentErrors::CtorAllocate(void)
+Bool_t TGraphBentErrors::CtorAllocate()
 {
    if (!fNpoints) {
-      fEXlow = fEYlow = fEXhigh = fEYhigh = 0;
-      fEXlowd = fEYlowd = fEXhighd = fEYhighd = 0;
+      fEXlow = fEYlow = fEXhigh = fEYhigh = nullptr;
+      fEXlowd = fEYlowd = fEXhighd = fEYhighd = nullptr;
       return kFALSE;
    }
    fEXlow = new Double_t[fMaxSize];
@@ -360,20 +359,20 @@ Bool_t TGraphBentErrors::DoMerge(const TGraph *g)
 {
    if (g->GetN() == 0) return kFALSE;
 
-   Double_t * exl = g->GetEXlow();
-   Double_t * exh = g->GetEXhigh();
-   Double_t * eyl = g->GetEYlow();
-   Double_t * eyh = g->GetEYhigh();
+   Double_t *exl = g->GetEXlow();
+   Double_t *exh = g->GetEXhigh();
+   Double_t *eyl = g->GetEYlow();
+   Double_t *eyh = g->GetEYhigh();
 
-   Double_t * exld = g->GetEXlowd();
-   Double_t * exhd = g->GetEXhighd();
-   Double_t * eyld = g->GetEYlowd();
-   Double_t * eyhd = g->GetEYhighd();
+   Double_t *exld = g->GetEXlowd();
+   Double_t *exhd = g->GetEXhighd();
+   Double_t *eyld = g->GetEYlowd();
+   Double_t *eyhd = g->GetEYhighd();
 
-   if (exl == 0 || exh == 0 || eyl == 0 || eyh == 0 ||
-       exld == 0 || exhd == 0 || eyld == 0 || eyhd == 0) {
+   if (!exl || !exh || !eyl || !eyh ||
+       !exld || !exhd || !eyld || !eyhd) {
       if (g->IsA() != TGraph::Class() )
-         Warning("DoMerge","Merging a %s is not compatible with a TGraphBentErrors - errors will be ignored",g->IsA()->GetName());
+         Warning("DoMerge", "Merging a %s is not compatible with a TGraphBentErrors - errors will be ignored", g->IsA()->GetName());
       return TGraph::DoMerge(g);
    }
    for (Int_t i = 0 ; i < g->GetN(); i++) {
@@ -382,7 +381,7 @@ Bool_t TGraphBentErrors::DoMerge(const TGraph *g)
       Double_t y = g->GetY()[i];
       SetPoint(ipoint, x, y);
       SetPointError(ipoint, exl[i],  exh[i],  eyl[i],  eyh[i],
-                            exld[i], exhd[i], eyld[i], eyhd[i] );
+                            exld[i], exhd[i], eyld[i], eyhd[i]);
    }
 
    return kTRUE;
@@ -395,7 +394,7 @@ Double_t TGraphBentErrors::GetErrorX(Int_t i) const
 {
    if (i < 0 || i >= fNpoints) return -1;
    if (!fEXlow && !fEXhigh) return -1;
-   Double_t elow=0, ehigh=0;
+   Double_t elow = 0, ehigh = 0;
    if (fEXlow)  elow  = fEXlow[i];
    if (fEXhigh) ehigh = fEXhigh[i];
    return TMath::Sqrt(0.5*(elow*elow + ehigh*ehigh));
@@ -579,14 +578,18 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
 void TGraphBentErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, Double_t eyh,
                                      Double_t exld, Double_t exhd, Double_t eyld, Double_t eyhd)
 {
+   if (!gPad) {
+      Error("SetPointError", "Cannot be used without gPad, requires last mouse position");
+      return;
+   }
+
    Int_t px = gPad->GetEventX();
    Int_t py = gPad->GetEventY();
 
    //localize point to be deleted
    Int_t ipoint = -2;
-   Int_t i;
    // start with a small window (in case the mouse is very close to one point)
-   for (i=0;i<fNpoints;i++) {
+   for (Int_t i = 0; i < fNpoints; i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
       if (dpx*dpx+dpy*dpy < 25) {ipoint = i; break;}
@@ -601,6 +604,7 @@ void TGraphBentErrors::SetPointError(Double_t exl, Double_t exh, Double_t eyl, D
    fEXhighd[ipoint] = exhd;
    fEYlowd[ipoint]  = eyld;
    fEYhighd[ipoint] = eyhd;
+
    gPad->Modified();
 }
 
@@ -613,7 +617,7 @@ void TGraphBentErrors::SetPointError(Int_t i, Double_t exl, Double_t exh, Double
 {
    if (i < 0) return;
    if (i >= fNpoints) {
-   // re-allocate the object
+      // re-allocate the object
       TGraphBentErrors::SetPoint(i,0,0);
    }
    fEXlow[i]   = exl;

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -548,16 +548,16 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
    frameNumber++;
 
    Int_t i;
-   TString fXName    = TString(GetName()) + Form("_fx%d",frameNumber);
-   TString fYName    = TString(GetName()) + Form("_fy%d",frameNumber);
-   TString fElXName  = TString(GetName()) + Form("_felx%d",frameNumber);
-   TString fElYName  = TString(GetName()) + Form("_fely%d",frameNumber);
-   TString fEhXName  = TString(GetName()) + Form("_fehx%d",frameNumber);
-   TString fEhYName  = TString(GetName()) + Form("_fehy%d",frameNumber);
-   TString fEldXName = TString(GetName()) + Form("_feldx%d",frameNumber);
-   TString fEldYName = TString(GetName()) + Form("_feldy%d",frameNumber);
-   TString fEhdXName = TString(GetName()) + Form("_fehdx%d",frameNumber);
-   TString fEhdYName = TString(GetName()) + Form("_fehdy%d",frameNumber);
+   auto fXName    = TString::Format("%s_fx%d", GetName(), frameNumber);
+   auto fYName    = TString::Format("%s_fy%d", GetName(), frameNumber);
+   auto fElXName  = TString::Format("%s_felx%d", GetName(), frameNumber);
+   auto fElYName  = TString::Format("%s_fely%d", GetName(), frameNumber);
+   auto fEhXName  = TString::Format("%s_fehx%d", GetName(), frameNumber);
+   auto fEhYName  = TString::Format("%s_fehy%d", GetName(), frameNumber);
+   auto fEldXName = TString::Format("%s_feldx%d", GetName(), frameNumber);
+   auto fEldYName = TString::Format("%s_feldy%d", GetName(), frameNumber);
+   auto fEhdXName = TString::Format("%s_fehdx%d", GetName(), frameNumber);
+   auto fEhdYName = TString::Format("%s_fehdy%d", GetName(), frameNumber);
    out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
    out << "   " << fX[fNpoints-1] << "};" << std::endl;
@@ -589,8 +589,10 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
    for (i = 0; i < fNpoints-1; i++) out << "   " << fEYhighd[i] << "," << std::endl;
    out << "   " << fEYhighd[fNpoints-1] << "};" << std::endl;
 
-   if (gROOT->ClassSaved(TGraphBentErrors::Class())) out << "   ";
-   else out << "   TGraphBentErrors *";
+   if (gROOT->ClassSaved(TGraphBentErrors::Class()))
+      out << "   ";
+   else
+      out << "   TGraphBentErrors *";
    out << "grbe = new TGraphBentErrors("<< fNpoints << ","
                                     << fXName     << ","  << fYName  << ","
                                     << fElXName   << ","  << fEhXName << ","
@@ -606,40 +608,7 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
    SaveLineAttributes(out,"grbe",1,1,1);
    SaveMarkerAttributes(out,"grbe",1,1,1);
 
-   if (fHistogram) {
-      TString hname = fHistogram->GetName();
-      hname += frameNumber;
-      fHistogram->SetName(Form("Graph_%s",hname.Data()));
-      fHistogram->SavePrimitive(out,"nodraw");
-      out<<"   grbe->SetHistogram("<<fHistogram->GetName()<<");"<<std::endl;
-      out<<"   "<<std::endl;
-   }
-
-   // save list of functions
-   TIter next(fFunctions);
-   TObject *obj;
-   while ((obj = next())) {
-      obj->SavePrimitive(out, Form("nodraw #%d\n",++frameNumber));
-      if (obj->InheritsFrom("TPaveStats")) {
-         out << "   grbe->GetListOfFunctions()->Add(ptstats);" << std::endl;
-         out << "   ptstats->SetParent(grbe->GetListOfFunctions());" << std::endl;
-      } else {
-         TString objname;
-         objname.Form("%s%d",obj->GetName(),frameNumber);
-         if (obj->InheritsFrom("TF1")) {
-            out << "   " << objname << "->SetParent(grbe);\n";
-         }
-         out << "   grbe->GetListOfFunctions()->Add("
-             << objname << ");" << std::endl;
-      }
-   }
-
-   const char *l = strstr(option,"multigraph");
-   if (l) {
-      out<<"   multigraph->Add(grbe,"<<quote<<l+10<<quote<<");"<<std::endl;
-   } else {
-      out<<"   grbe->Draw("<<quote<<option<<quote<<");"<<std::endl;
-   }
+   SaveHistogramAndFunctions(out, "grbe", frameNumber, option);
 }
 
 

--- a/hist/hist/src/TGraphBentErrors.cxx
+++ b/hist/hist/src/TGraphBentErrors.cxx
@@ -542,52 +542,20 @@ void TGraphBentErrors::Scale(Double_t c1, Option_t *option)
 
 void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    out << "   " << std::endl;
    static Int_t frameNumber = 2000;
    frameNumber++;
 
-   Int_t i;
-   auto fXName    = TString::Format("%s_fx%d", GetName(), frameNumber);
-   auto fYName    = TString::Format("%s_fy%d", GetName(), frameNumber);
-   auto fElXName  = TString::Format("%s_felx%d", GetName(), frameNumber);
-   auto fElYName  = TString::Format("%s_fely%d", GetName(), frameNumber);
-   auto fEhXName  = TString::Format("%s_fehx%d", GetName(), frameNumber);
-   auto fEhYName  = TString::Format("%s_fehy%d", GetName(), frameNumber);
-   auto fEldXName = TString::Format("%s_feldx%d", GetName(), frameNumber);
-   auto fEldYName = TString::Format("%s_feldy%d", GetName(), frameNumber);
-   auto fEhdXName = TString::Format("%s_fehdx%d", GetName(), frameNumber);
-   auto fEhdYName = TString::Format("%s_fehdy%d", GetName(), frameNumber);
-   out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-   out << "   " << fX[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-   out << "   " << fY[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fElXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEXlow[i] << "," << std::endl;
-   out << "   " << fEXlow[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fElYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEYlow[i] << "," << std::endl;
-   out << "   " << fEYlow[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEhXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEXhigh[i] << "," << std::endl;
-   out << "   " << fEXhigh[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEhYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEYhigh[i] << "," << std::endl;
-   out << "   " << fEYhigh[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEldXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEXlowd[i] << "," << std::endl;
-   out << "   " << fEXlowd[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEldYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEYlowd[i] << "," << std::endl;
-   out << "   " << fEYlowd[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEhdXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEXhighd[i] << "," << std::endl;
-   out << "   " << fEXhighd[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEhdYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEYhighd[i] << "," << std::endl;
-   out << "   " << fEYhighd[fNpoints-1] << "};" << std::endl;
+   auto fXName   = SaveArray(out, "fx", frameNumber, fX);
+   auto fYName   = SaveArray(out, "fy", frameNumber, fY);
+   auto fElXName = SaveArray(out, "felx", frameNumber, fEXlow);
+   auto fElYName = SaveArray(out, "fely", frameNumber, fEYlow);
+   auto fEhXName = SaveArray(out, "fehx", frameNumber, fEXhigh);
+   auto fEhYName = SaveArray(out, "fehy", frameNumber, fEYhigh);
+   auto fEldXName = SaveArray(out, "feldx", frameNumber, fEXlowd);
+   auto fEldYName = SaveArray(out, "feldy", frameNumber, fEYlowd);
+   auto fEhdXName = SaveArray(out, "fehdx", frameNumber, fEXhighd);
+   auto fEhdYName = SaveArray(out, "fehdy", frameNumber, fEYhighd);
 
    if (gROOT->ClassSaved(TGraphBentErrors::Class()))
       out << "   ";
@@ -600,13 +568,6 @@ void TGraphBentErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*
                                     << fEldXName  << ","  << fEhdXName << ","
                                     << fEldYName  << ","  << fEhdYName << ");"
                                     << std::endl;
-
-   out << "   grbe->SetName(" << quote << GetName() << quote << ");" << std::endl;
-   out << "   grbe->SetTitle(" << quote << GetTitle() << quote << ");" << std::endl;
-
-   SaveFillAttributes(out,"grbe",0,1001);
-   SaveLineAttributes(out,"grbe",1,1,1);
-   SaveMarkerAttributes(out,"grbe",1,1,1);
 
    SaveHistogramAndFunctions(out, "grbe", frameNumber, option);
 }

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -760,6 +760,11 @@ void TGraphErrors::Scale(Double_t c1, Option_t *option)
 
 void TGraphErrors::SetPointError(Double_t ex, Double_t ey)
 {
+   if (!gPad) {
+      Error("SetPointError", "Cannot be used without gPad, requires last mouse position");
+      return;
+   }
+
    Int_t px = gPad->GetEventX();
    Int_t py = gPad->GetEventY();
 

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -719,10 +719,10 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    frameNumber++;
 
    Int_t i;
-   TString fXName  = TString(GetName()) + Form("_fx%d",frameNumber);
-   TString fYName  = TString(GetName()) + Form("_fy%d",frameNumber);
-   TString fEXName = TString(GetName()) + Form("_fex%d",frameNumber);
-   TString fEYName = TString(GetName()) + Form("_fey%d",frameNumber);
+   auto fXName  = TString::Format("%s_fx%d", GetName(), frameNumber);
+   auto fYName  = TString::Format("%s_fy%d", GetName(), frameNumber);
+   auto fEXName = TString::Format("%s_fex%d", GetName(), frameNumber);
+   auto fEYName = TString::Format("%s_fey%d", GetName(), frameNumber);
    out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
    for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
    out << "   " << fX[fNpoints-1] << "};" << std::endl;
@@ -736,8 +736,10 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    for (i = 0; i < fNpoints-1; i++) out << "   " << fEY[i] << "," << std::endl;
    out << "   " << fEY[fNpoints-1] << "};" << std::endl;
 
-   if (gROOT->ClassSaved(TGraphErrors::Class())) out << "   ";
-   else out << "   TGraphErrors *";
+   if (gROOT->ClassSaved(TGraphErrors::Class()))
+      out << "   ";
+   else
+      out << "   TGraphErrors *";
    out << "gre = new TGraphErrors(" << fNpoints << ","
                                     << fXName   << ","  << fYName  << ","
                                     << fEXName  << ","  << fEYName << ");"
@@ -750,40 +752,7 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    SaveLineAttributes(out, "gre", 1, 1, 1);
    SaveMarkerAttributes(out, "gre", 1, 1, 1);
 
-   if (fHistogram) {
-      TString hname = fHistogram->GetName();
-      hname += frameNumber;
-      fHistogram->SetName(Form("Graph_%s", hname.Data()));
-      fHistogram->SavePrimitive(out, "nodraw");
-      out << "   gre->SetHistogram(" << fHistogram->GetName() << ");" << std::endl;
-      out << "   " << std::endl;
-   }
-
-   // save list of functions
-   TIter next(fFunctions);
-   TObject *obj;
-   while ((obj = next())) {
-      obj->SavePrimitive(out, Form("nodraw #%d\n",++frameNumber));
-      if (obj->InheritsFrom("TPaveStats")) {
-         out << "   gre->GetListOfFunctions()->Add(ptstats);" << std::endl;
-         out << "   ptstats->SetParent(gre->GetListOfFunctions());" << std::endl;
-      } else {
-         TString objname;
-         objname.Form("%s%d",obj->GetName(),frameNumber);
-         if (obj->InheritsFrom("TF1")) {
-            out << "   " << objname << "->SetParent(gre);\n";
-         }
-         out << "   gre->GetListOfFunctions()->Add("
-             << objname << ");" << std::endl;
-      }
-   }
-
-   const char *l = strstr(option, "multigraph");
-   if (l) {
-      out << "   multigraph->Add(gre," << quote << l + 10 << quote << ");" << std::endl;
-   } else {
-      out << "   gre->Draw(" << quote << option << quote << ");" << std::endl;
-   }
+   SaveHistogramAndFunctions(out, "gre", frameNumber, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphErrors.cxx
+++ b/hist/hist/src/TGraphErrors.cxx
@@ -713,28 +713,14 @@ void TGraphErrors::Print(Option_t *) const
 
 void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
-   char quote = '"';
    out << "   " << std::endl;
    static Int_t frameNumber = 1000;
    frameNumber++;
 
-   Int_t i;
-   auto fXName  = TString::Format("%s_fx%d", GetName(), frameNumber);
-   auto fYName  = TString::Format("%s_fy%d", GetName(), frameNumber);
-   auto fEXName = TString::Format("%s_fex%d", GetName(), frameNumber);
-   auto fEYName = TString::Format("%s_fey%d", GetName(), frameNumber);
-   out << "   Double_t " << fXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fX[i] << "," << std::endl;
-   out << "   " << fX[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fY[i] << "," << std::endl;
-   out << "   " << fY[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEXName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEX[i] << "," << std::endl;
-   out << "   " << fEX[fNpoints-1] << "};" << std::endl;
-   out << "   Double_t " << fEYName << "[" << fNpoints << "] = {" << std::endl;
-   for (i = 0; i < fNpoints-1; i++) out << "   " << fEY[i] << "," << std::endl;
-   out << "   " << fEY[fNpoints-1] << "};" << std::endl;
+   auto fXName  = SaveArray(out, "fx", frameNumber, fX);
+   auto fYName  = SaveArray(out, "fy", frameNumber, fY);
+   auto fEXName = SaveArray(out, "fex", frameNumber, fEX);
+   auto fEYName = SaveArray(out, "fey", frameNumber, fEY);
 
    if (gROOT->ClassSaved(TGraphErrors::Class()))
       out << "   ";
@@ -744,13 +730,6 @@ void TGraphErrors::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
                                     << fXName   << ","  << fYName  << ","
                                     << fEXName  << ","  << fEYName << ");"
                                     << std::endl;
-
-   out << "   gre->SetName(" << quote << GetName() << quote << ");" << std::endl;
-   out << "   gre->SetTitle(" << quote << GetTitle() << quote << ");" << std::endl;
-
-   SaveFillAttributes(out, "gre", 0, 1001);
-   SaveLineAttributes(out, "gre", 1, 1, 1);
-   SaveMarkerAttributes(out, "gre", 1, 1, 1);
 
    SaveHistogramAndFunctions(out, "gre", frameNumber, option);
 }

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -1761,14 +1761,18 @@ void TGraphMultiErrors::Scale(Double_t c1, Option_t *option)
 void TGraphMultiErrors::SetPointError(Double_t exL, Double_t exH, Double_t eyL1, Double_t eyH1, Double_t eyL2,
                                       Double_t eyH2, Double_t eyL3, Double_t eyH3)
 {
+   if (!gPad) {
+      Error("SetPointError", "Cannot be used without gPad, requires last mouse position");
+      return;
+   }
+
    Int_t px = gPad->GetEventX();
    Int_t py = gPad->GetEventY();
 
    // localize point to be deleted
    Int_t ipoint = -2;
-   Int_t i;
    // start with a small window (in case the mouse is very close to one point)
-   for (i = 0; i < fNpoints; i++) {
+   for (Int_t i = 0; i < fNpoints; i++) {
       Int_t dpx = px - gPad->XtoAbsPixel(gPad->XtoPad(fX[i]));
       Int_t dpy = py - gPad->YtoAbsPixel(gPad->YtoPad(fY[i]));
 

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -1698,6 +1698,8 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
 {
    char quote = '"';
    out << "   " << std::endl;
+   static Int_t frameNumber = 5000;
+   frameNumber++;
 
    if (gROOT->ClassSaved(TGraphMultiErrors::Class()))
       out << "   ";
@@ -1726,34 +1728,7 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
              << std::endl;
    }
 
-   static Int_t frameNumber = 0;
-   if (fHistogram) {
-      frameNumber++;
-      TString hname = fHistogram->GetName();
-      hname += frameNumber;
-      fHistogram->SetName(Form("Graph_%s", hname.Data()));
-      fHistogram->SavePrimitive(out, "nodraw");
-      out << "   tgme->SetHistogram(" << fHistogram->GetName() << ");" << std::endl;
-      out << "   " << std::endl;
-   }
-
-   // save list of functions
-   TIter next(fFunctions);
-   TObject *obj;
-   while ((obj = next())) {
-      obj->SavePrimitive(out, "nodraw");
-      if (obj->InheritsFrom("TPaveStats")) {
-         out << "   tgme->GetListOfFunctions()->Add(ptstats);" << std::endl;
-         out << "   ptstats->SetParent(tgme->GetListOfFunctions());" << std::endl;
-      } else
-         out << "   tgme->GetListOfFunctions()->Add(" << obj->GetName() << ");" << std::endl;
-   }
-
-   const char *l = strstr(option, "multigraph");
-   if (l)
-      out << "   multigraph->Add(tgme, " << quote << l + 10 << quote << ");" << std::endl;
-   else
-      out << "   tgme->Draw(" << quote << option << quote << ");" << std::endl;
+   SaveHistogramAndFunctions(out, "tgme", frameNumber, option);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/TGraphMultiErrors.cxx
+++ b/hist/hist/src/TGraphMultiErrors.cxx
@@ -1696,7 +1696,6 @@ void TGraphMultiErrors::Print(Option_t *) const
 
 void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
 {
-   char quote = '"';
    out << "   " << std::endl;
    static Int_t frameNumber = 5000;
    frameNumber++;
@@ -1707,16 +1706,10 @@ void TGraphMultiErrors::SavePrimitive(std::ostream &out, Option_t *option)
       out << "   TGraphMultiErrors* ";
 
    out << "tgme = new TGraphMultiErrors(" << fNpoints << ", " << fNYErrors << ");" << std::endl;
-   out << "   tgme->SetName(" << quote << GetName() << quote << ");" << std::endl;
-   out << "   tgme->SetTitle(" << quote << GetTitle() << quote << ");" << std::endl;
-
-   SaveFillAttributes(out, "tgme", 0, 1001);
-   SaveLineAttributes(out, "tgme", 1, 1, 1);
-   SaveMarkerAttributes(out, "tgme", 1, 1, 1);
 
    for (Int_t j = 0; j < fNYErrors; j++) {
-      fAttFill[j].SaveFillAttributes(out, Form("tgme->GetAttFill(%d)", j), 0, 1001);
-      fAttLine[j].SaveLineAttributes(out, Form("tgme->GetAttLine(%d)", j), 1, 1, 1);
+      fAttFill[j].SaveFillAttributes(out, TString::Format("tgme->GetAttFill(%d)", j).Data(), 0, 1001);
+      fAttLine[j].SaveLineAttributes(out, TString::Format("tgme->GetAttLine(%d)", j).Data(), 1, 1, 1);
    }
 
    for (Int_t i = 0; i < fNpoints; i++) {

--- a/hist/hist/src/TH1.cxx
+++ b/hist/hist/src/TH1.cxx
@@ -7335,11 +7335,10 @@ void TH1::SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *opti
    }
 
    // save list of functions
-   TObjOptLink *lnk = (TObjOptLink*)fFunctions->FirstLink();
-   TObject *obj;
+   auto lnk = fFunctions->FirstLink();
    static Int_t funcNumber = 0;
    while (lnk) {
-      obj = lnk->GetObject();
+      auto obj = lnk->GetObject();
       obj->SavePrimitive(out, TString::Format("nodraw #%d\n",++funcNumber).Data());
       if (obj->InheritsFrom(TF1::Class())) {
          TString fname;
@@ -7358,7 +7357,7 @@ void TH1::SavePrimitiveHelp(std::ostream &out, const char *hname, Option_t *opti
             <<obj->GetName()
             <<","<<quote<<lnk->GetOption()<<quote<<");"<<std::endl;
       }
-      lnk = (TObjOptLink*)lnk->Next();
+      lnk = lnk->Next();
    }
 
    // save attributes

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -1042,29 +1042,27 @@ void THStack::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    if (fHistogram) {
       frameNumber++;
       TString hname = fHistogram->GetName();
-      hname += "_stack_";
-      hname += frameNumber;
-      fHistogram->SetName(hname.Data());
+      fHistogram->SetName(TString::Format("%s_stack_%d", hname.Data(), frameNumber).Data());
       fHistogram->SavePrimitive(out,"nodraw");
       out<<"   "<<GetName()<<"->SetHistogram("<<fHistogram->GetName()<<");"<<std::endl;
       out<<"   "<<std::endl;
+      fHistogram->SetName(hname.Data()); // restore histogram name
    }
 
    if (fHists) {
       auto lnk = fHists->FirstLink();
       Int_t hcount = 0;
       while (lnk) {
-         TH1 *h = (TH1*)lnk->GetObject();
+         auto h = (TH1 *) lnk->GetObject();
          TString hname = h->GetName();
-         hname += TString::Format("_stack_%d",++hcount);
-         h->SetName(hname.Data());
+         h->SetName(TString::Format("%s_stack_%d", hname.Data(), ++hcount).Data());
          h->SavePrimitive(out,"nodraw");
          out<<"   "<<GetName()<<"->Add("<<h->GetName()<<","<<quote<<lnk->GetOption()<<quote<<");"<<std::endl;
          lnk = lnk->Next();
+         h->SetName(hname.Data()); // restore histogram name
       }
    }
-   out<<"   "<<GetName()<<"->Draw("
-      <<quote<<option<<quote<<");"<<std::endl;
+   out<<"   "<<GetName()<<"->Draw("<<quote<<option<<quote<<");"<<std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/hist/hist/src/THStack.cxx
+++ b/hist/hist/src/THStack.cxx
@@ -724,7 +724,6 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
       if (l3) memcpy(l3,"   ",3);
       TString ws = option;
       if (ws.IsWhitespace()) strncpy(option,"\0",1);
-      TObjOptLink *lnk = (TObjOptLink*)fHists->FirstLink();
       TH1* hAti;
       TH1* hsAti;
       Int_t nhists = fHists->GetSize();
@@ -742,7 +741,6 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
             if (l2) hsAti->SetLineColor(ic);
             if (l3) hsAti->SetMarkerColor(ic);
          }
-         lnk = (TObjOptLink*)lnk->Next();
       }
    }
 
@@ -777,15 +775,13 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
          if (((nx*ny)-nx) >= npads) ny--;
          padsav->Divide(nx,ny);
 
-         TH1 *h;
          Int_t i = 0;
-         TObjOptLink *lnk = (TObjOptLink*)fHists->FirstLink();
+         auto lnk = fHists->FirstLink();
          while (lnk) {
             i++;
             padsav->cd(i);
-            h = (TH1*)lnk->GetObject();
-            h->Draw(lnk->GetOption());
-            lnk = (TObjOptLink*)lnk->Next();
+            lnk->GetObject()->Draw(lnk->GetOption());
+            lnk = lnk->Next();
          }
          padsav->cd();
       }
@@ -898,15 +894,12 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
    }
 
    // Copy the axis labels if needed.
-   TH1 *hfirst;
-   TObjOptLink *lnk = (TObjOptLink*)fHists->FirstLink();
-   hfirst = (TH1*)lnk->GetObject();
+   TH1 *hfirst = (TH1*)fHists->First();
    THashList* labels = hfirst->GetXaxis()->GetLabels();
    if (labels) {
       TIter iL(labels);
-      TObjString* lb;
       Int_t ilab = 1;
-      while ((lb=(TObjString*)iL())) {
+      while (auto lb=(TObjString*)iL()) {
          fHistogram->GetXaxis()->SetBinLabel(ilab,lb->String().Data());
          ilab++;
       }
@@ -928,9 +921,8 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
    strlcpy(noption,loption.Data(),32);
    Int_t nhists = fHists->GetSize();
    if (nostack || candle || violin) {
-      lnk = (TObjOptLink*)fHists->FirstLink();
-      TH1* hAti;
-      Double_t bo=0.03;
+      auto lnk = fHists->FirstLink();
+      Double_t bo = 0.03;
       Double_t bw = (1.-(2*bo))/nhists;
       for (Int_t i=0;i<nhists;i++) {
          if (strstr(lnk->GetOption(),"same")) {
@@ -943,7 +935,7 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
             else if (candle && (indivOpt.Contains("candle") || indivOpt.Contains("violin"))) loption.Form("%ssame",lnk->GetOption());
             else          loption.Form("%ssame%s",noption,lnk->GetOption());
          }
-         hAti = (TH1F*)(fHists->At(i));
+         TH1* hAti = (TH1*) fHists->At(i);
          if (nostackb) {
             hAti->SetBarWidth(bw);
             hAti->SetBarOffset(bo);
@@ -958,11 +950,10 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
          }
          if (paint)
             hAti->Paint(loption.Data());
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
    } else {
-      lnk = (TObjOptLink*)fHists->LastLink();
-      TH1 *h1;
+      auto lnk = fHists->LastLink();
       Int_t h1col, h1fill;
       for (Int_t i=0;i<nhists;i++) {
          if (strstr(lnk->GetOption(),"same")) {
@@ -970,7 +961,7 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
          } else {
             loption.Form("%ssame%s",noption,lnk->GetOption());
          }
-         h1 = (TH1*)fStack->At(nhists-i-1);
+         TH1 *h1 = (TH1*) fStack->At(nhists-i-1);
          if ((i > 0) && lclear && paint) {
             // Erase before drawing the histogram
             h1col  = h1->GetFillColor();
@@ -978,7 +969,7 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
             h1->SetFillColor(10);
             h1->SetFillStyle(1001);
             h1->Paint(loption.Data());
-            static TClassRef clTFrame = TClass::GetClass("TFrame",kFALSE);
+            static TClassRef clTFrame = TClass::GetClass("TFrame", kFALSE);
             TAttFill *frameFill = (TAttFill*)clTFrame->DynamicCast(TAttFill::Class(),gPad->GetFrame());
             if (frameFill) {
                h1->SetFillColor(frameFill->GetFillColor());
@@ -990,7 +981,7 @@ void THStack::BuildAndPaint(Option_t *choptin, Bool_t paint)
          }
          if (paint)
             h1->Paint(loption.Data());
-         lnk = (TObjOptLink*)lnk->Prev();
+         lnk = lnk->Prev();
       }
    }
 
@@ -1060,7 +1051,7 @@ void THStack::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    }
 
    if (fHists) {
-      TObjOptLink *lnk = (TObjOptLink*)fHists->FirstLink();
+      auto lnk = fHists->FirstLink();
       Int_t hcount = 0;
       while (lnk) {
          TH1 *h = (TH1*)lnk->GetObject();
@@ -1069,7 +1060,7 @@ void THStack::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
          h->SetName(hname.Data());
          h->SavePrimitive(out,"nodraw");
          out<<"   "<<GetName()<<"->Add("<<h->GetName()<<","<<quote<<lnk->GetOption()<<quote<<");"<<std::endl;
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
    }
    out<<"   "<<GetName()<<"->Draw("

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -441,14 +441,13 @@ void TMultiGraph::Add(TMultiGraph *multigraph, Option_t *chopt)
 
    if (!fGraphs) fGraphs = new TList();
 
-   TObjOptLink *lnk = (TObjOptLink*)graphlist->FirstLink();
-   TObject *obj = nullptr;
+   auto lnk = graphlist->FirstLink();
 
    while (lnk) {
-      obj = lnk->GetObject();
+      auto obj = lnk->GetObject();
       if (!strlen(chopt)) fGraphs->Add(obj,lnk->GetOption());
       else                fGraphs->Add(obj,chopt);
-      lnk = (TObjOptLink*)lnk->Next();
+      lnk = lnk->Next();
    }
 }
 
@@ -1144,31 +1143,30 @@ void TMultiGraph::Paint(Option_t *choptin)
       if (l1) memcpy(l1,"   ",3);
       if (l2) memcpy(l2,"   ",3);
       if (l3) memcpy(l3,"   ",3);
-      TObjOptLink *lnk = (TObjOptLink*)fGraphs->FirstLink();
-      TGraph* gAti;
+      auto lnk = fGraphs->FirstLink();
       Int_t ngraphs = fGraphs->GetSize();
       Int_t ic;
       gPad->IncrementPaletteColor(ngraphs, opt1);
       for (Int_t i=0;i<ngraphs;i++) {
          ic = gPad->NextPaletteColor();
-         gAti = (TGraph*)(fGraphs->At(i));
+         auto gAti = (TGraph*)(fGraphs->At(i));
          if (l1) gAti->SetFillColor(ic);
          if (l2) gAti->SetLineColor(ic);
          if (l3) gAti->SetMarkerColor(ic);
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
    }
 
    TString chopt = option;
 
-   char *l = (char*)strstr(chopt.Data(),"3D");
+   auto l = strstr(chopt.Data(), "3D");
    if (l) {
-      l = (char*)strstr(chopt.Data(),"L");
+      l = strstr(chopt.Data(),"L");
       if (l) PaintPolyLine3D(chopt.Data());
       return;
    }
 
-   l = (char*)strstr(chopt.Data(),"PADS");
+   l = strstr(chopt.Data(),"PADS");
    if (l) {
       chopt.ReplaceAll("PADS","");
       PaintPads(chopt.Data());
@@ -1182,11 +1180,9 @@ void TMultiGraph::Paint(Option_t *choptin)
       return;
    }
 
-   TGraph *g;
-
-   l = (char*)strstr(chopt.Data(),"A");
+   l = strstr(chopt.Data(),"A");
    if (l) {
-      *l = ' ';
+      *((char *)l) = ' ';
       TIter   next(fGraphs);
       Int_t npt = 100;
       Double_t maximum, minimum, rwxmin, rwxmax, rwymin, rwymax, uxmin, uxmax, dx, dy;
@@ -1201,13 +1197,16 @@ void TMultiGraph::Paint(Option_t *choptin)
 
       if (fHistogram) {
          //cleanup in case of a previous unzoom and in case one of the TGraph has changed
-         TObjOptLink *lnk = (TObjOptLink*)fGraphs->FirstLink();
+         auto lnk = fGraphs->FirstLink();
          Int_t ngraphs = fGraphs->GetSize();
          Bool_t reset_hist = kFALSE;
          for (Int_t i=0;i<ngraphs;i++) {
             TGraph* gAti = (TGraph*)(fGraphs->At(i));
-            if(gAti->TestBit(TGraph::kResetHisto)) {reset_hist = kTRUE; break;}
-            lnk = (TObjOptLink*)lnk->Next();
+            if(gAti->TestBit(TGraph::kResetHisto)) {
+               reset_hist = kTRUE;
+               break;
+            }
+            lnk = lnk->Next();
          }
          if (fHistogram->GetMinimum() >= fHistogram->GetMaximum() || reset_hist) {
             firstx = fHistogram->GetXaxis()->GetFirst();
@@ -1230,7 +1229,7 @@ void TMultiGraph::Paint(Option_t *choptin)
          uxmax   = gPad->PadtoX(rwxmax);
       } else {
          Bool_t initialrangeset = kFALSE;
-         while ((g = (TGraph*) next())) {
+         while (auto g = (TGraph*) next()) {
             if (g->GetN() <= 0) continue;
             if (initialrangeset) {
                Double_t rx1,ry1,rx2,ry2;
@@ -1312,18 +1311,19 @@ void TMultiGraph::Paint(Option_t *choptin)
          if (!timeformat.empty()) fHistogram->GetXaxis()->SetTimeFormat(timeformat.c_str());
       }
       TString chopth = "0";
-      if ((char*)strstr(chopt.Data(),"X+")) chopth.Append("X+");
-      if ((char*)strstr(chopt.Data(),"Y+")) chopth.Append("Y+");
-      if ((char*)strstr(chopt.Data(),"I"))  chopth.Append("A");
+      if (strstr(chopt.Data(),"X+")) chopth.Append("X+");
+      if (strstr(chopt.Data(),"Y+")) chopth.Append("Y+");
+      if (strstr(chopt.Data(),"I"))  chopth.Append("A");
       fHistogram->Paint(chopth.Data());
    }
 
    TGraph *gfit = nullptr;
    if (fGraphs) {
-      TObjOptLink *lnk = (TObjOptLink*)fGraphs->FirstLink();
-      TObject *obj = 0;
+      auto lnk = fGraphs->FirstLink();
 
       chopt.ReplaceAll("A","");
+
+      TObject *obj = nullptr;
 
       while (lnk) {
 
@@ -1341,19 +1341,19 @@ void TMultiGraph::Paint(Option_t *choptin)
             }
          }
 
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
 
       gfit = (TGraph*)obj; // pick one TGraph in the list to paint the fit parameters.
    }
 
-   TObject *f;
    TF1 *fit = nullptr;
    if (fFunctions) {
       TIter   next(fFunctions);
-      while ((f = (TObject*) next())) {
+      while (auto f = next()) {
          if (f->InheritsFrom(TF1::Class())) {
-            if (f->TestBit(TF1::kNotDraw) == 0) f->Paint("lsame");
+            if (f->TestBit(TF1::kNotDraw) == 0)
+               f->Paint("lsame");
             fit = (TF1*)f;
          } else  {
             f->Paint();
@@ -1361,7 +1361,8 @@ void TMultiGraph::Paint(Option_t *choptin)
       }
    }
 
-   if (gfit && fit) gfit->PaintStats(fit);
+   if (gfit && fit)
+      gfit->PaintStats(fit);
 }
 
 
@@ -1598,13 +1599,12 @@ void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
    out<<"   multigraph->SetTitle("<<quote<<GetTitle()<<quote<<");"<<std::endl;
 
    if (fGraphs) {
-      TObjOptLink *lnk = (TObjOptLink*)fGraphs->FirstLink();
-      TObject *g;
+      auto lnk = fGraphs->FirstLink();
 
       while (lnk) {
-         g = lnk->GetObject();
+         auto g = lnk->GetObject();
          g->SavePrimitive(out, TString::Format("multigraph%s",lnk->GetOption()).Data());
-         lnk = (TObjOptLink*)lnk->Next();
+         lnk = lnk->Next();
       }
    }
    const char *l = strstr(option,"th2poly");

--- a/hist/hist/src/TMultiGraph.cxx
+++ b/hist/hist/src/TMultiGraph.cxx
@@ -1062,12 +1062,12 @@ TH1F *TMultiGraph::GetHistogram()
       rwymax = rwymax + dy;
    }
    fHistogram = new TH1F(GetName(),GetTitle(),npt,rwxmin,rwxmax);
-   if (!fHistogram) return 0;
+   if (!fHistogram) return nullptr;
    fHistogram->SetMinimum(rwymin);
    fHistogram->SetBit(TH1::kNoStats);
    fHistogram->SetMaximum(rwymax);
    fHistogram->GetYaxis()->SetLimits(rwymin,rwymax);
-   fHistogram->SetDirectory(0);
+   fHistogram->SetDirectory(nullptr);
    return fHistogram;
 }
 
@@ -1589,24 +1589,19 @@ void TMultiGraph::SavePrimitive(std::ostream &out, Option_t *option /*= ""*/)
 {
    char quote = '"';
    out<<"   "<<std::endl;
-   if (gROOT->ClassSaved(TMultiGraph::Class())) {
+   if (gROOT->ClassSaved(TMultiGraph::Class())) 
       out<<"   ";
-   } else {
+   else 
       out<<"   TMultiGraph *";
-   }
    out<<"multigraph = new TMultiGraph();"<<std::endl;
    out<<"   multigraph->SetName("<<quote<<GetName()<<quote<<");"<<std::endl;
    out<<"   multigraph->SetTitle("<<quote<<GetTitle()<<quote<<");"<<std::endl;
 
-   if (fGraphs) {
-      auto lnk = fGraphs->FirstLink();
+   TIter iter(fGraphs);
 
-      while (lnk) {
-         auto g = lnk->GetObject();
-         g->SavePrimitive(out, TString::Format("multigraph%s",lnk->GetOption()).Data());
-         lnk = lnk->Next();
-      }
-   }
+   while (auto g = iter())
+      g->SavePrimitive(out, TString::Format("multigraph%s", iter.GetOption()).Data());
+
    const char *l = strstr(option,"th2poly");
    if (l) {
       out<<"   "<<l+7<<"->AddBin(multigraph);"<<std::endl;

--- a/hist/histpainter/src/TGraphPainter.cxx
+++ b/hist/histpainter/src/TGraphPainter.cxx
@@ -4142,7 +4142,6 @@ void TGraphPainter::PaintGraphReverse(TGraph *theGraph, Option_t *option)
 
 void TGraphPainter::PaintGraphSimple(TGraph *theGraph, Option_t *option)
 {
-
    if (strstr(option,"H") || strstr(option,"h")) {
       PaintGrapHist(theGraph, theGraph->GetN(), theGraph->GetX(), theGraph->GetY(), option);
    } else {
@@ -4155,21 +4154,18 @@ void TGraphPainter::PaintGraphSimple(TGraph *theGraph, Option_t *option)
    // the fit function).
    TList *functions = theGraph->GetListOfFunctions();
    if (!functions) return;
-   TObjOptLink *lnk = (TObjOptLink*)functions->FirstLink();
-   TObject *obj;
+   auto lnk = functions->FirstLink();
 
    while (lnk) {
-      obj = lnk->GetObject();
-      TVirtualPad *padsave = gPad;
+      auto obj = lnk->GetObject();
+      TVirtualPad::TContext ctxt(true);
       if (obj->InheritsFrom(TF1::Class())) {
          if (obj->TestBit(TF1::kNotDraw) == 0) obj->Paint("lsame");
       } else  {
          obj->Paint(lnk->GetOption());
       }
-      lnk = (TObjOptLink*)lnk->Next();
-      padsave->cd();
+      lnk = lnk->Next();
    }
-   return;
 }
 
 


### PR DESCRIPTION
In all sub-classes same part to store histogram, list of functions and basic attributes was duplicated. Now all this 
functionality collected in protected `TGraph::SaveHistogramAndFunctions` method. 

Also provide `TGraph::SaveArray` method to optimize storage of TGraph arrays in macro - there are quite of them in `TGraphBentErrors` class. Use more compact form for arrays - 16 values in the line.

Made `THStack::SavePrimitve()` re-entrant. Histograms names were changed when stored - now names set back.

Check for `gPad` in several interactive methods like `TGraph::InsertPoint()` to avoid crash when called from macro.

Exclude unnecessary casting to `TObjOptLink` - base `TObjLink` has all required virtual methods already.