### PR TITLE
Allow users to ignore material 'dummy', which is not understood by Geant4

### DIFF
--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -82,6 +82,8 @@ public:
       kfastButUglySufix = 2
    };
    void SetNamingSpeed(ENamingType naming);
+   // Ignore dummy material instance, which causes trouble reading GDML in Geant4
+   void SetIgnoreDummyMaterial(bool value);
    void SetG4Compatibility(Bool_t G4Compatible) {
       fgG4Compatibility = G4Compatible;
    };
@@ -122,6 +124,7 @@ private:
    //Data members
    static TGDMLWrite *fgGDMLWrite;                         //pointer to gdml writer
    Int_t  fgNamingSpeed;                                   //input option for volume and solid naming
+   Int_t fIgnoreDummyMaterial;                             //Flag to ignore TGeo's dummy material
    Bool_t fgG4Compatibility;                               //input option for Geant4 compatibility
    XMLDocPointer_t  fGdmlFile;                             //pointer storing xml file
    TString fDefault_lunit;                                 //Default unit of length (depends on ROOT unit system)

--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -124,7 +124,7 @@ private:
    //Data members
    static TGDMLWrite *fgGDMLWrite;                         //pointer to gdml writer
    Int_t  fgNamingSpeed;                                   //input option for volume and solid naming
-   Int_t fIgnoreDummyMaterial;                             //Flag to ignore TGeo's dummy material
+   Int_t fIgnoreDummyMaterial;                             // Flag to ignore TGeo's dummy material
    Bool_t fgG4Compatibility;                               //input option for Geant4 compatibility
    XMLDocPointer_t  fGdmlFile;                             //pointer storing xml file
    TString fDefault_lunit;                                 //Default unit of length (depends on ROOT unit system)

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -532,7 +532,7 @@ XMLNodePointer_t TGDMLWrite::ExtractMaterials(TList* materialsLst)
    std::string dummy_nam = dummy_mat ? dummy_mat->GetName() : "dummy";
 
    while ((lmaterial = (TGeoMaterial *)next())) {
-      //check for dummy material: if requested, ignore it
+      // check for dummy material: if requested, ignore it
       std::string mname = lmaterial->GetName();
       if (fIgnoreDummyMaterial && dummy_mat && dummy_nam == mname) {
          Info("ExtractMaterials", "Skip dummy material: %s", dummy_nam.c_str());


### PR DESCRIPTION

# This Pull request:
TGeo uses internally a material "dummy", which is not a valid material, but gets ejected into the GDML.
This material is not understood by Geant4 and inhibits produced GDML files being loaded to Geant4.
A user switch `TGDMLWrite::SetIgnoreDummyMaterial(true)` allows to inhibit to eject this material into the GDML.

## Changes or fixes:
Badly produced GDML files.

## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

