### PR TITLE
Remove default argument for creating GDML positions. 

### DIFF
--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -214,7 +214,7 @@ private:
    //II. Utility methods
    Xyz GetXYZangles(const Double_t * rotationMatrix);
    //nodes to create position, rotation and similar types first-position/rotation...
-   XMLNodePointer_t CreatePositionN(const char * name, Xyz position, const char * type = "position", const char * unit = "cm");
+   XMLNodePointer_t CreatePositionN(const char * name, Xyz position, const char * type, const char * unit);
    XMLNodePointer_t CreateRotationN(const char * name, Xyz rotation, const char * type = "rotation", const char * unit = "deg");
    XMLNodePointer_t CreateMatrixN(TGDMLMatrix const *matrix);
    XMLNodePointer_t CreateConstantN(const char *name, Double_t value);

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -651,7 +651,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
          nodPos.x = pos[0];
          nodPos.y = pos[1];
          nodPos.z = pos[2];
-         childN = CreatePositionN(posname.Data(), nodPos);
+         childN = CreatePositionN(posname.Data(), nodPos, "position", fDefault_lunit);
          fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
          //Deal with reflection
          XMLNodePointer_t scaleN = nullptr;
@@ -1675,7 +1675,7 @@ XMLNodePointer_t TGDMLWrite::CreateTessellatedN(TGeoTessellated * geoShape)
       nodPos.x = vertex[0];
       nodPos.y = vertex[1];
       nodPos.z = vertex[2];
-      auto childN = CreatePositionN(posName.Data(), nodPos);
+      auto childN = CreatePositionN(posName.Data(), nodPos, "position", fDefault_lunit);
       fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
    }
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "tessellated", nullptr);
@@ -1804,7 +1804,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
 
    //<firstposition> (left)
    if ((translL.x != 0.0) || (translL.y != 0.0) || (translL.z != 0.0)) {
-      childN = CreatePositionN((nodeName + lname + "pos").Data(), translL, "firstposition");
+      childN = CreatePositionN((nodeName + lname + "pos").Data(), translL, "firstposition", fDefault_lunit);
       fGdmlE->AddChild(mainN, childN);
    }
    //<firstrotation> (left)
@@ -1814,7 +1814,7 @@ XMLNodePointer_t TGDMLWrite::CreateCommonBoolN(TGeoCompositeShape *geoShape)
    }
    //<position> (right)
    if ((translR.x != 0.0) || (translR.y != 0.0) || (translR.z != 0.0)) {
-      childN = CreatePositionN((nodeName + rname + "pos").Data(), translR, "position");
+      childN = CreatePositionN((nodeName + rname + "pos").Data(), translR, "position", fDefault_lunit);
       fGdmlE->AddChild(mainN, childN);
    }
    //<rotation> (right)
@@ -2665,7 +2665,7 @@ void TGDMLWrite::ExtractVolumes(TGeoVolume* volume)
          nodPos.x = pos[0];
          nodPos.y = pos[1];
          nodPos.z = pos[2];
-         childN = CreatePositionN(posname.Data(), nodPos);
+         childN = CreatePositionN(posname.Data(), nodPos, "position", fDefault_lunit);
          fGdmlE->AddChild(fDefineNode, childN); //adding node to <define> node
          //Deal with reflection
          XMLNodePointer_t scaleN = nullptr;


### PR DESCRIPTION

# This Pull request:
- Remove default argument for creating GDML positions. The default arguments always define lengths in "cm",
  which is wrong for Geant4 units (mm). Instead the digested units string fDefault_lunit is used, which 
  has the correct value depending on the chosen system of units.

## Changes or fixes:
Creating correct GDML files understood by Geant4.

## Checklist:

- [ x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

