### PR TITLE
GDML: Fix material properties

### DIFF
--- a/geom/gdml/src/TGDMLParse.cxx
+++ b/geom/gdml/src/TGDMLParse.cxx
@@ -595,14 +595,20 @@ XMLNodePointer_t TGDMLParse::MatrixProcess(TXMLEngine *gdml, XMLNodePointer_t no
       valueList.push_back(Value(matrixValue.c_str()));
    }
 
-   TGDMLMatrix *matrix = new TGDMLMatrix(name, valueList.size() / coldim, coldim);
-   matrix->SetMatrixAsString(values.c_str());
-   for (size_t i = 0; i < valueList.size(); ++i)
-      matrix->Set(i / coldim, i % coldim, valueList[i]);
+   // Const Properties in GDML are matrices with size 1 not constants
+   // This gives some ambiguity, but what can one do?
+   if ( coldim == 1 && valueList.size() == 1 )    {
+      gGeoManager->AddProperty(name, valueList[0]);
+   }
+   else  {
+      TGDMLMatrix *matrix = new TGDMLMatrix(name, valueList.size() / coldim, coldim);
+      matrix->SetMatrixAsString(values.c_str());
+      for (size_t i = 0; i < valueList.size(); ++i)
+         matrix->Set(i / coldim, i % coldim, valueList[i]);
 
-   gGeoManager->AddGDMLMatrix(matrix);
-   fmatrices[name.Data()] = matrix;
-
+      gGeoManager->AddGDMLMatrix(matrix);
+      fmatrices[name.Data()] = matrix;
+   }
    return node;
 }
 

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -728,7 +728,6 @@ XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t atomN = fGdmlE->NewChild(nullptr, nullptr, "atom", nullptr);
-   if ( gGeoManager->GetDefaultUnits() != TGeoManager::kRootUnits ) atom /= 1e19; // Correct for G4 unit system
    fGdmlE->NewAttr(atomN, nullptr, "unit", unit);
    fGdmlE->NewAttr(atomN, nullptr, "value", TString::Format(fltPrecision.Data(), atom));
    return atomN;
@@ -741,7 +740,6 @@ XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t densN = fGdmlE->NewChild(nullptr, nullptr, "D", nullptr);
-   if ( gGeoManager->GetDefaultUnits() != TGeoManager::kRootUnits ) density /= 1e16; // Correct for G4 unit system
    fGdmlE->NewAttr(densN, nullptr, "unit", unit);
    fGdmlE->NewAttr(densN, nullptr, "value", TString::Format(fltPrecision.Data(), density));
    return densN;

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -728,6 +728,7 @@ XMLNodePointer_t TGDMLWrite::CreateAtomN(Double_t atom, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t atomN = fGdmlE->NewChild(nullptr, nullptr, "atom", nullptr);
+   if ( gGeoManager->GetDefaultUnits() != TGeoManager::kRootUnits ) atom /= 1e19; // Correct for G4 unit system
    fGdmlE->NewAttr(atomN, nullptr, "unit", unit);
    fGdmlE->NewAttr(atomN, nullptr, "value", TString::Format(fltPrecision.Data(), atom));
    return atomN;
@@ -740,6 +741,7 @@ XMLNodePointer_t TGDMLWrite::CreateDN(Double_t density, const char * unit)
 {
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    XMLNodePointer_t densN = fGdmlE->NewChild(nullptr, nullptr, "D", nullptr);
+   if ( gGeoManager->GetDefaultUnits() != TGeoManager::kRootUnits ) density /= 1e16; // Correct for G4 unit system
    fGdmlE->NewAttr(densN, nullptr, "unit", unit);
    fGdmlE->NewAttr(densN, nullptr, "value", TString::Format(fltPrecision.Data(), density));
    return densN;

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -1944,10 +1944,11 @@ XMLNodePointer_t TGDMLWrite::CreateMatrixN(TGDMLMatrix const *matrix)
 
 XMLNodePointer_t TGDMLWrite::CreateConstantN(const char *name, Double_t value)
 {
-   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "constant", nullptr);
+   XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "matrix", nullptr);
    const TString fltPrecision = TString::Format("%%.%dg", fFltPrecision);
    fGdmlE->NewAttr(mainN, nullptr, "name", name);
-   fGdmlE->NewAttr(mainN, nullptr, "value", TString::Format(fltPrecision.Data(), value));
+   fGdmlE->NewAttr(mainN, nullptr, "coldim", "1");
+   fGdmlE->NewAttr(mainN, nullptr, "values", TString::Format(fltPrecision.Data(), value));
    return mainN;
 }
 

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -842,6 +842,8 @@ XMLNodePointer_t TGDMLWrite::CreateElementN(TGeoElement * element, XMLNodePointe
       if (valZ >= 1) {
          fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format("%i", valZ));
       }
+      Int_t valN = element->N();
+      fGdmlE->NewAttr(mainN, nullptr, "N", TString::Format("%i", valN));
       fGdmlE->AddChild(mainN, CreateAtomN(element->A()));
    }
    return mainN;
@@ -854,6 +856,24 @@ XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointe
 {
    XMLNodePointer_t mainN = fGdmlE->NewChild(nullptr, nullptr, "material", nullptr);
    fGdmlE->NewAttr(mainN, nullptr, "name", mname);
+
+   // Write properties
+   TList const &properties = mixture->GetProperties();
+   if (properties.GetSize()) {
+      TIter next(&properties);
+      TNamed *property;
+      while ((property = (TNamed*)next()))
+        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+   }
+   // Write CONST properties
+   TList const &const_properties = mixture->GetConstProperties();
+   if (const_properties.GetSize()) {
+      TIter next(&const_properties);
+      TNamed *property;
+      while ((property = (TNamed*)next()))
+        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+   }
+
    fGdmlE->AddChild(mainN, CreateDN(mixture->GetDensity()));
    //local associative arrays for saving elements and their weight
    //inside mixture
@@ -897,23 +917,6 @@ XMLNodePointer_t TGDMLWrite::CreateMixtureN(TGeoMixture * mixture, XMLNodePointe
       fGdmlE->AddChild(mainN, CreateFractionN(wPercentage[itr->first], itr->first.Data()));
    }
 
-   // Write properties
-   TList const &properties = mixture->GetProperties();
-   if (properties.GetSize()) {
-      TIter next(&properties);
-      TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
-   }
-   // Write CONST properties
-   TList const &const_properties = mixture->GetConstProperties();
-   if (const_properties.GetSize()) {
-      TIter next(&const_properties);
-      TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
-   }
-
    return mainN;
 }
 
@@ -943,24 +946,27 @@ XMLNodePointer_t TGDMLWrite::CreateMaterialN(TGeoMaterial * material, TString mn
       }
    }
    fGdmlE->NewAttr(mainN, nullptr, "Z", TString::Format(fltPrecision.Data(), valZ)); //material->GetZ()));
-   fGdmlE->AddChild(mainN, CreateDN(material->GetDensity()));
-   fGdmlE->AddChild(mainN, CreateAtomN(material->GetA()));
-   // Create properties if any
+
+   // Create properties if any: Properties according to the GDML schema MUST come first!
    TList const &properties = material->GetProperties();
    if (properties.GetSize()) {
       TIter next(&properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
    // Write CONST properties
    TList const &const_properties = material->GetConstProperties();
    if (const_properties.GetSize()) {
       TIter next(&const_properties);
       TNamed *property;
-      while ((property = (TNamed*)next()))
-        fGdmlE->AddChild(mainN, CreatePropertyN(*property));
+      while ((property = (TNamed *)next()))
+         fGdmlE->AddChild(mainN, CreatePropertyN(*property));
    }
+
+   // Now add the other children
+   fGdmlE->AddChild(mainN, CreateDN(material->GetDensity()));
+   fGdmlE->AddChild(mainN, CreateAtomN(material->GetA()));
    return mainN;
 }
 


### PR DESCRIPTION
# This Pull request:
- Eject material property refs as first child elements as required from the GDML schema
- Add the atomic number N to the `<atom>` attributes.
- Eject **const properties** as matrices in GDML with one element rather than constants.
- Consequently, when reading a 1x1 matrix, it will be declared as `const property` to the TGeoManager.

## Changes or fixes:
Creation of GDML files understood by Geant4

## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

