### PR TITLE
Fix physical volume names in GDML, which must be globally unique

### DIFF
--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -712,6 +712,7 @@ void TGDMLWrite::ExtractVolumes(TGeoNode* node)
          physvolname = fNameList->fLst[TString::Format("%p", geoNode)];
          childN = CreatePhysVolN(physvolname, geoNode->GetNumber(), nodevolname.Data(),
                                  posname.Data(), rotname.Data(), scaleN);
+         fGdmlE->AddChild(volumeN, childN);
       }
       nCnt++;
    }


### PR DESCRIPTION
# This Pull request:
- Ensure proper NCN names for surfaces (No '/' and '#' characters) for surfaces
- Make GDML refs to physical volumes unique. Unique physical volume names are mandatory for GDML to properly address surfaces, where local uniqueness is insufficient.
- Change the references of surfaces to physical volumes accordingly.

## Changes or fixes:
Creation of proper GDML files understood by Geant4

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

