### PR TITLE
Move call to set the export precision to the lowest level of WriteGDML

### DIFF
--- a/geom/gdml/inc/TGDMLWrite.h
+++ b/geom/gdml/inc/TGDMLWrite.h
@@ -67,7 +67,6 @@ public:
       //        if "n" then there is no suffix, but uniqness of names
       //        is not secured.
       TGDMLWrite *writer = new TGDMLWrite;
-      writer->SetFltPrecision(TGeoManager::GetExportPrecision());
       writer->WriteGDMLfile(geomanager, filename, option);
       delete writer;
    }

--- a/geom/gdml/src/TGDMLWrite.cxx
+++ b/geom/gdml/src/TGDMLWrite.cxx
@@ -299,6 +299,9 @@ void TGDMLWrite::WriteGDMLfile(TGeoManager * geomanager,
       SetNamingSpeed(kelegantButSlow);
       Info("WriteGDMLfile", "Potentially slow with incremental suffix naming convention set");
    }
+
+   SetFltPrecision(TGeoManager::GetExportPrecision());
+
    auto def_units = gGeoManager->GetDefaultUnits();
    switch (def_units) {
       case TGeoManager::kG4Units:


### PR DESCRIPTION
# This Pull request:
Move call to set the export precision to the lowest level of WriteGDML.

## Changes or fixes:
At the lower level interface setting the precision was impossible,

## Checklist:

- [ ] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 

